### PR TITLE
Add unit tests to improve test coverage

### DIFF
--- a/application/src/test/kotlin/integration/bot/AutocompleteManagerTest.kt
+++ b/application/src/test/kotlin/integration/bot/AutocompleteManagerTest.kt
@@ -1,5 +1,6 @@
 package integration.bot
 
+import Application
 import bot.configuration.TestAppConfig
 import bot.configuration.TestBotConfig
 import bot.configuration.TestManagerConfig
@@ -8,11 +9,10 @@ import bot.toby.managers.DefaultAutoCompleteManager
 import common.configuration.TestCachingConfig
 import core.autocomplete.AutocompleteHandler
 import database.configuration.TestDatabaseConfig
-import io.mockk.unmockkAll
+import io.mockk.*
+import net.dv8tion.jda.api.events.interaction.command.CommandAutoCompleteInteractionEvent
 import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNotNull
-import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -59,5 +59,19 @@ internal class AutocompleteManagerTest {
         val handler = autocompleteManager.getHandler("help")
         assertNotNull(handler)
         assertEquals("help", handler?.name)
+    }
+
+    @Test
+    fun testHandle() {
+        val event = mockk<CommandAutoCompleteInteractionEvent> {
+            every { name } returns "help"
+        }
+        val handler = mockk<AutocompleteHandler> {
+            every { name } returns "help"
+            every { handle(event) } just Runs
+        }
+        val manager = DefaultAutoCompleteManager(listOf(handler))
+        manager.handle(event)
+        verify(exactly = 1) { handler.handle(event) }
     }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/fetch/Kf2RandomMapCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/fetch/Kf2RandomMapCommand.kt
@@ -12,7 +12,6 @@ import java.io.IOException
 @Component
 class Kf2RandomMapCommand @Autowired constructor(private val cache: Cache) : FetchCommand {
     override fun handle(ctx: CommandContext, requestingUserDto: UserDto, deleteDelay: Int) {
-        ctx.event.hook.deleteAfter(deleteDelay)
         val event = ctx.event
         event.deferReply(true).queue()
         try {

--- a/discord-bot/src/test/kotlin/bot/toby/autocomplete/autocompletes/HelpAutoCompleteTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/autocomplete/autocompletes/HelpAutoCompleteTest.kt
@@ -1,0 +1,109 @@
+package bot.toby.autocomplete.autocompletes
+
+import core.command.Command
+import core.managers.CommandManager
+import io.mockk.*
+import net.dv8tion.jda.api.events.interaction.command.CommandAutoCompleteInteractionEvent
+import net.dv8tion.jda.api.interactions.commands.Command.Choice
+import net.dv8tion.jda.api.requests.restaction.interactions.AutoCompleteCallbackAction
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class HelpAutoCompleteTest {
+
+    private val commandManager: CommandManager = mockk(relaxed = true)
+    private val event: CommandAutoCompleteInteractionEvent = mockk(relaxed = true)
+    private val autoCompleteCallbackAction: AutoCompleteCallbackAction = mockk(relaxed = true)
+    private lateinit var helpAutoComplete: HelpAutoComplete
+
+    private fun mockCommand(name: String): Command {
+        return mockk { every { this@mockk.name } returns name }
+    }
+
+    @BeforeEach
+    fun setUp() {
+        helpAutoComplete = HelpAutoComplete(commandManager)
+        every { event.replyChoices(any<Collection<Choice>>()) } returns autoCompleteCallbackAction
+        every { autoCompleteCallbackAction.queue() } just Runs
+    }
+
+    @AfterEach
+    fun tearDown() {
+        clearAllMocks()
+    }
+
+    @Test
+    fun `handle replies with matching commands when focused option is command`() {
+        every { event.focusedOption.name } returns "command"
+        every { event.focusedOption.value } returns "play"
+        every { commandManager.commands } returns listOf(
+            mockCommand("play"),
+            mockCommand("pause"),
+            mockCommand("playlist")
+        )
+
+        helpAutoComplete.handle(event)
+
+        verify(exactly = 1) { event.replyChoices(any<Collection<Choice>>()) }
+        verify(exactly = 1) { autoCompleteCallbackAction.queue() }
+    }
+
+    @Test
+    fun `handle replies with empty list when no commands match input`() {
+        every { event.focusedOption.name } returns "command"
+        every { event.focusedOption.value } returns "xyz"
+        every { commandManager.commands } returns listOf(
+            mockCommand("play"),
+            mockCommand("pause")
+        )
+
+        val choicesSlot = slot<Collection<Choice>>()
+        every { event.replyChoices(capture(choicesSlot)) } returns autoCompleteCallbackAction
+
+        helpAutoComplete.handle(event)
+
+        assert(choicesSlot.captured.isEmpty())
+    }
+
+    @Test
+    fun `handle returns at most 25 choices`() {
+        every { event.focusedOption.name } returns "command"
+        every { event.focusedOption.value } returns ""
+        val manyCommands = (1..30).map { mockCommand("command$it") }
+        every { commandManager.commands } returns manyCommands
+
+        val choicesSlot = slot<Collection<Choice>>()
+        every { event.replyChoices(capture(choicesSlot)) } returns autoCompleteCallbackAction
+
+        helpAutoComplete.handle(event)
+
+        assert(choicesSlot.captured.size <= 25)
+    }
+
+    @Test
+    fun `handle does not reply when focused option is not command`() {
+        every { event.focusedOption.name } returns "other"
+
+        helpAutoComplete.handle(event)
+
+        verify(exactly = 0) { event.replyChoices(any<Collection<Choice>>()) }
+    }
+
+    @Test
+    fun `handle matches commands case insensitively`() {
+        every { event.focusedOption.name } returns "command"
+        every { event.focusedOption.value } returns "PLAY"
+        every { commandManager.commands } returns listOf(
+            mockCommand("play"),
+            mockCommand("pause")
+        )
+
+        val choicesSlot = slot<Collection<Choice>>()
+        every { event.replyChoices(capture(choicesSlot)) } returns autoCompleteCallbackAction
+
+        helpAutoComplete.handle(event)
+
+        assert(choicesSlot.captured.any { it.name == "play" })
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/command/CommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/CommandTest.kt
@@ -30,8 +30,7 @@ interface CommandTest {
         every { event.hook.deleteOriginal() } returns restAction as RestAction<Void>
         every { event.hook.sendMessage(any<String>()) } returns webhookMessageCreateAction
         every { event.hook.sendMessageFormat(any(), *anyVararg()) } returns webhookMessageCreateAction
-        every { event.hook.sendMessageEmbeds(any(), any<MessageEmbed>()) } returns webhookMessageCreateAction
-        every { event.hook.sendMessageEmbeds(any(), *anyVararg()) } returns webhookMessageCreateAction
+        every { event.hook.sendMessageEmbeds(any<MessageEmbed>(), *anyVararg()) } returns webhookMessageCreateAction
         every { event.options } returns emptyList()
         every { user.effectiveName } returns "UserName"
         every { user.idLong } returns 1L
@@ -40,10 +39,9 @@ interface CommandTest {
         every { user.isBot } returns false
         every { interactionHook.deleteOriginal() } returns restAction
         every { interactionHook.sendMessage(any<String>()) } returns webhookMessageCreateAction
-        every { interactionHook.sendMessage(any<String>()).queue(any()) } just Runs
         every { interactionHook.sendMessageFormat(any(), *anyVararg()) } returns webhookMessageCreateAction
         every { interactionHook.retrieveOriginal() } returns restAction as RestAction<Message>
-        every { interactionHook.sendMessageEmbeds(any(), any<MessageEmbed>()) } returns webhookMessageCreateAction
+        every { interactionHook.sendMessageEmbeds(any<MessageEmbed>(), *anyVararg()) } returns webhookMessageCreateAction
         every { replyCallbackAction.setEphemeral(any()) } returns replyCallbackAction
         every { replyCallbackAction.queue() } just runs
         every { webhookMessageCreateAction.addComponents(any<ActionRow>()) } returns webhookMessageCreateAction

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/fetch/DbdRandomKillerCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/fetch/DbdRandomKillerCommandTest.kt
@@ -1,0 +1,69 @@
+package bot.toby.command.commands.fetch
+
+import bot.toby.command.CommandTest
+import bot.toby.command.CommandTest.Companion.event
+import bot.toby.command.DefaultCommandContext
+import bot.toby.helpers.WikiFetcher
+import common.helpers.Cache
+import io.mockk.*
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.io.IOException
+
+class DbdRandomKillerCommandTest : CommandTest {
+
+    private val cache: Cache = mockk(relaxed = true)
+    private lateinit var command: DbdRandomKillerCommand
+
+    @BeforeEach
+    fun setUp() {
+        setUpCommonMocks()
+        mockkConstructor(WikiFetcher::class)
+        command = DbdRandomKillerCommand(cache)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        tearDownCommonMocks()
+        unmockkConstructor(WikiFetcher::class)
+    }
+
+    @Test
+    fun `handle sends a random killer name on success`() {
+        every {
+            anyConstructed<WikiFetcher>().fetchFromWiki(any(), any(), any(), any())
+        } returns listOf("The Trapper", "The Wraith", "The Hillbilly")
+
+        command.handle(DefaultCommandContext(event), CommandTest.requestingUserDto, 0)
+
+        verify(exactly = 1) { event.hook.sendMessageFormat(any(), *anyVararg()) }
+    }
+
+    @Test
+    fun `handle sends error message when WikiFetcher throws IOException`() {
+        every {
+            anyConstructed<WikiFetcher>().fetchFromWiki(any(), any(), any(), any())
+        } throws IOException("Connection failed")
+
+        command.handle(DefaultCommandContext(event), CommandTest.requestingUserDto, 0)
+
+        verify(exactly = 1) {
+            event.hook.sendMessageFormat(
+                match { it.contains("unexpected") },
+                *anyVararg()
+            )
+        }
+    }
+
+    @Test
+    fun `name is dbd-killer`() {
+        assertEquals("dbd-killer", command.name)
+    }
+
+    @Test
+    fun `description describes the command`() {
+        assertEquals("return a random dead by daylight killer", command.description)
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/fetch/Kf2RandomMapCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/fetch/Kf2RandomMapCommandTest.kt
@@ -1,0 +1,64 @@
+package bot.toby.command.commands.fetch
+
+import bot.toby.command.CommandTest
+import bot.toby.command.CommandTest.Companion.event
+import bot.toby.command.DefaultCommandContext
+import bot.toby.helpers.WikiFetcher
+import common.helpers.Cache
+import io.mockk.*
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.io.IOException
+
+class Kf2RandomMapCommandTest : CommandTest {
+
+    private val cache: Cache = mockk(relaxed = true)
+    private lateinit var command: Kf2RandomMapCommand
+
+    @BeforeEach
+    fun setUp() {
+        setUpCommonMocks()
+        mockkConstructor(WikiFetcher::class)
+        command = Kf2RandomMapCommand(cache)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        tearDownCommonMocks()
+        unmockkConstructor(WikiFetcher::class)
+    }
+
+    @Test
+    fun `handle sends a random map name on success`() {
+        every {
+            anyConstructed<WikiFetcher>().fetchFromWiki(any(), any(), any(), any())
+        } returns listOf("Biotics Lab", "Burning Paris", "Farmhouse")
+
+        command.handle(DefaultCommandContext(event), CommandTest.requestingUserDto, 0)
+
+        verify(exactly = 1) { event.hook.sendMessage(any<String>()) }
+    }
+
+    @Test
+    fun `handle sends error message when WikiFetcher throws IOException`() {
+        every {
+            anyConstructed<WikiFetcher>().fetchFromWiki(any(), any(), any(), any())
+        } throws IOException("Connection failed")
+
+        command.handle(DefaultCommandContext(event), CommandTest.requestingUserDto, 0)
+
+        verify(exactly = 1) { event.hook.sendMessage(match<String> { it.contains("unexpected") }) }
+    }
+
+    @Test
+    fun `name is kf2`() {
+        assertEquals("kf2", command.name)
+    }
+
+    @Test
+    fun `description describes the command`() {
+        assertEquals("return a random kf2 map", command.description)
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/handler/MessageEventHandlerTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/handler/MessageEventHandlerTest.kt
@@ -1,16 +1,12 @@
+package bot.toby.handler
+
 import bot.toby.emote.Emotes
-import bot.toby.handler.MessageEventHandler
-import bot.toby.managers.DefaultButtonManager
-import bot.toby.managers.DefaultCommandManager
-import bot.toby.managers.DefaultMenuManager
 import core.managers.AutocompleteManager
-import io.mockk.every
+import core.managers.ButtonManager
+import core.managers.CommandManager
+import core.managers.MenuManager
+import io.mockk.*
 import io.mockk.junit5.MockKExtension
-import io.mockk.just
-import io.mockk.mockk
-import io.mockk.Runs
-import io.mockk.spyk
-import io.mockk.verify
 import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.entities.Member
 import net.dv8tion.jda.api.entities.Message
@@ -25,9 +21,9 @@ import org.junit.jupiter.api.extension.ExtendWith
 @ExtendWith(MockKExtension::class)
 class MessageEventHandlerTest {
 
-    private val commandManager: DefaultCommandManager = mockk()
-    private val buttonManager: DefaultButtonManager = mockk()
-    private val menuManager: DefaultMenuManager = mockk()
+    private val commandManager: CommandManager = mockk()
+    private val buttonManager: ButtonManager = mockk()
+    private val menuManager: MenuManager = mockk()
     private val autocompleteManager: AutocompleteManager = mockk()
     private val handler = spyk(
         MessageEventHandler(

--- a/discord-bot/src/test/kotlin/bot/toby/helpers/URLHelperTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/helpers/URLHelperTest.kt
@@ -1,0 +1,60 @@
+package bot.toby.helpers
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+class URLHelperTest {
+
+    @Test
+    fun `isValidURL returns true for valid http URL`() {
+        assertTrue(URLHelper.isValidURL("http://example.com"))
+    }
+
+    @Test
+    fun `isValidURL returns true for valid https URL`() {
+        assertTrue(URLHelper.isValidURL("https://www.example.com/path?query=value"))
+    }
+
+    @Test
+    fun `isValidURL returns false for null input`() {
+        assertFalse(URLHelper.isValidURL(null))
+    }
+
+    @Test
+    fun `isValidURL returns false for empty string`() {
+        assertFalse(URLHelper.isValidURL(""))
+    }
+
+    @Test
+    fun `isValidURL returns false for malformed URL`() {
+        assertFalse(URLHelper.isValidURL("not a url"))
+    }
+
+    @Test
+    fun `isValidURL returns false for URL with spaces`() {
+        assertFalse(URLHelper.isValidURL("http://example .com"))
+    }
+
+    @Test
+    fun `fromUrlString returns URI for valid URL`() {
+        val uri = URLHelper.fromUrlString("https://example.com/path")
+        assertNotNull(uri)
+        assertEquals("https", uri!!.scheme)
+        assertEquals("example.com", uri.host)
+    }
+
+    @Test
+    fun `fromUrlString returns null for null input`() {
+        assertNull(URLHelper.fromUrlString(null))
+    }
+
+    @Test
+    fun `fromUrlString returns null for invalid URL string`() {
+        assertNull(URLHelper.fromUrlString("not a url"))
+    }
+
+    @Test
+    fun `fromUrlString returns null for empty string`() {
+        assertNull(URLHelper.fromUrlString(""))
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/helpers/UserDtoHelperTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/helpers/UserDtoHelperTest.kt
@@ -1,0 +1,159 @@
+package bot.toby.helpers
+
+import bot.toby.helpers.UserDtoHelper.Companion.produceMusicFileDataStringForPrinting
+import database.dto.MusicDto
+import database.dto.UserDto
+import database.service.UserService
+import io.mockk.*
+import net.dv8tion.jda.api.entities.Member
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class UserDtoHelperTest {
+
+    private val userService: UserService = mockk(relaxed = true)
+    private lateinit var userDtoHelper: UserDtoHelper
+
+    @BeforeEach
+    fun setUp() {
+        userDtoHelper = UserDtoHelper(userService)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        clearAllMocks()
+    }
+
+    @Test
+    fun `calculateUserDto returns existing user when found in service`() {
+        val existingUser = mockk<UserDto>()
+        every { userService.getUserById(123L, 456L) } returns existingUser
+
+        val result = userDtoHelper.calculateUserDto(123L, 456L)
+
+        assertEquals(existingUser, result)
+        verify(exactly = 0) { userService.createNewUser(any()) }
+    }
+
+    @Test
+    fun `calculateUserDto creates new user when not found in service`() {
+        every { userService.getUserById(123L, 456L) } returns null
+        every { userService.createNewUser(any()) } returns mockk()
+
+        val result = userDtoHelper.calculateUserDto(123L, 456L)
+
+        assertNotNull(result)
+        assertEquals(123L, result.discordId)
+        assertEquals(456L, result.guildId)
+        verify(exactly = 1) { userService.createNewUser(any()) }
+    }
+
+    @Test
+    fun `calculateUserDto sets superUser flag when creating new user with isSuperUser=true`() {
+        every { userService.getUserById(any(), any()) } returns null
+        val capturedDto = slot<UserDto>()
+        every { userService.createNewUser(capture(capturedDto)) } returns mockk()
+
+        userDtoHelper.calculateUserDto(1L, 2L, isSuperUser = true)
+
+        assertTrue(capturedDto.captured.superUser)
+    }
+
+    @Test
+    fun `calculateUserDto does not set superUser when isSuperUser=false`() {
+        every { userService.getUserById(any(), any()) } returns null
+        val capturedDto = slot<UserDto>()
+        every { userService.createNewUser(capture(capturedDto)) } returns mockk()
+
+        userDtoHelper.calculateUserDto(1L, 2L, isSuperUser = false)
+
+        assertFalse(capturedDto.captured.superUser)
+    }
+
+    @Test
+    fun `userAdjustmentValidation returns true when requester is superUser and target is not`() {
+        val requester = mockk<UserDto> { every { superUser } returns true }
+        val target = mockk<UserDto> { every { superUser } returns false }
+
+        assertTrue(userDtoHelper.userAdjustmentValidation(requester, target))
+    }
+
+    @Test
+    fun `userAdjustmentValidation returns false when both are superUsers`() {
+        val requester = mockk<UserDto> { every { superUser } returns true }
+        val target = mockk<UserDto> { every { superUser } returns true }
+
+        assertFalse(userDtoHelper.userAdjustmentValidation(requester, target))
+    }
+
+    @Test
+    fun `userAdjustmentValidation returns false when requester is not superUser`() {
+        val requester = mockk<UserDto> { every { superUser } returns false }
+        val target = mockk<UserDto> { every { superUser } returns false }
+
+        assertFalse(userDtoHelper.userAdjustmentValidation(requester, target))
+    }
+
+    @Test
+    fun `updateUser delegates to userService`() {
+        val userDto = mockk<UserDto>()
+        every { userService.updateUser(userDto) } returns mockk()
+
+        userDtoHelper.updateUser(userDto)
+
+        verify(exactly = 1) { userService.updateUser(userDto) }
+    }
+
+    @Test
+    fun `produceMusicFileDataStringForPrinting returns no-intro message when musicDtos is empty`() {
+        val member = mockk<Member> { every { effectiveName } returns "Alice" }
+        val userDto = mockk<UserDto> {
+            every { musicDtos } returns mutableListOf()
+        }
+
+        val result = produceMusicFileDataStringForPrinting(member, userDto)
+
+        assertTrue(result.contains("no valid intro music file"))
+        assertTrue(result.contains("Alice"))
+    }
+
+    @Test
+    fun `produceMusicFileDataStringForPrinting returns no-intro message when all musicDtos have blank filenames`() {
+        val member = mockk<Member> { every { effectiveName } returns "Bob" }
+        val dto = mockk<MusicDto> { every { fileName } returns ""; every { index } returns 0 }
+        val userDto = mockk<UserDto> {
+            every { musicDtos } returns mutableListOf(dto)
+        }
+
+        val result = produceMusicFileDataStringForPrinting(member, userDto)
+
+        assertTrue(result.contains("no valid intro music file"))
+    }
+
+    @Test
+    fun `produceMusicFileDataStringForPrinting returns formatted list when musicDtos has valid entries`() {
+        val member = mockk<Member> { every { effectiveName } returns "Charlie" }
+        val dto1 = mockk<MusicDto> {
+            every { fileName } returns "song1.mp3"
+            every { introVolume } returns 80
+            every { index } returns 0
+        }
+        val dto2 = mockk<MusicDto> {
+            every { fileName } returns "song2.mp3"
+            every { introVolume } returns 50
+            every { index } returns 1
+        }
+        val userDto = mockk<UserDto> {
+            every { musicDtos } returns mutableListOf(dto1, dto2)
+        }
+
+        val result = produceMusicFileDataStringForPrinting(member, userDto)
+
+        assertTrue(result.contains("song1.mp3"))
+        assertTrue(result.contains("Volume: 80"))
+        assertTrue(result.contains("song2.mp3"))
+        assertTrue(result.contains("Volume: 50"))
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/helpers/VoiceStateHelperTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/helpers/VoiceStateHelperTest.kt
@@ -1,0 +1,125 @@
+package bot.toby.helpers
+
+import bot.toby.command.CommandTest
+import bot.toby.command.CommandTest.Companion.event
+import bot.toby.command.CommandTest.Companion.guild
+import bot.toby.command.CommandTest.Companion.member
+import bot.toby.command.CommandTest.Companion.requestingUserDto
+import bot.toby.command.CommandTest.Companion.webhookMessageCreateAction
+import io.mockk.*
+import net.dv8tion.jda.api.Permission
+import net.dv8tion.jda.api.entities.GuildVoiceState
+import net.dv8tion.jda.api.entities.Member
+import net.dv8tion.jda.api.entities.channel.unions.AudioChannelUnion
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class VoiceStateHelperTest : CommandTest {
+
+    private val target: Member = mockk(relaxed = true)
+    private val voiceState: GuildVoiceState = mockk(relaxed = true)
+    private val audioChannel: AudioChannelUnion = mockk(relaxed = true)
+
+    @BeforeEach
+    fun setUp() {
+        setUpCommonMocks()
+        every { member.voiceState } returns voiceState
+        every { voiceState.channel } returns audioChannel
+        every { audioChannel.members } returns listOf(target)
+        every { target.effectiveName } returns "TargetUser"
+        every { webhookMessageCreateAction.queue(any()) } just Runs
+        every { requestingUserDto.superUser } returns true
+        every { member.canInteract(target) } returns true
+        every { member.hasPermission(Permission.VOICE_MUTE_OTHERS) } returns true
+        every { guild.selfMember.hasPermission(Permission.VOICE_MUTE_OTHERS) } returns true
+    }
+
+    @AfterEach
+    fun tearDown() {
+        tearDownCommonMocks()
+    }
+
+    @Test
+    fun `muteOrUnmuteMembers does nothing when member voiceState channel is null`() {
+        every { voiceState.channel } returns null
+
+        VoiceStateHelper.muteOrUnmuteMembers(member, requestingUserDto, event, 0, guild, true)
+
+        verify(exactly = 0) { event.hook.sendMessage(any<String>()) }
+        verify(exactly = 0) { guild.mute(any(), any()) }
+    }
+
+    @Test
+    fun `muteOrUnmuteMembers sends error when member cannot interact with target`() {
+        every { member.canInteract(target) } returns false
+
+        VoiceStateHelper.muteOrUnmuteMembers(member, requestingUserDto, event, 0, guild, true)
+
+        verify(exactly = 1) { event.hook.sendMessage(match<String> { it.contains("aren't allowed to mute") }) }
+        verify(exactly = 0) { guild.mute(any(), any()) }
+    }
+
+    @Test
+    fun `muteOrUnmuteMembers sends error when member lacks VOICE_MUTE_OTHERS permission`() {
+        every { member.hasPermission(Permission.VOICE_MUTE_OTHERS) } returns false
+
+        VoiceStateHelper.muteOrUnmuteMembers(member, requestingUserDto, event, 0, guild, true)
+
+        verify(exactly = 1) { event.hook.sendMessage(match<String> { it.contains("aren't allowed to mute") }) }
+        verify(exactly = 0) { guild.mute(any(), any()) }
+    }
+
+    @Test
+    fun `muteOrUnmuteMembers sends error when requesting user is not superUser`() {
+        every { requestingUserDto.superUser } returns false
+
+        VoiceStateHelper.muteOrUnmuteMembers(member, requestingUserDto, event, 0, guild, true)
+
+        verify(exactly = 1) { event.hook.sendMessage(match<String> { it.contains("aren't allowed to mute") }) }
+        verify(exactly = 0) { guild.mute(any(), any()) }
+    }
+
+    @Test
+    fun `muteOrUnmuteMembers sends error when bot lacks VOICE_MUTE_OTHERS permission`() {
+        every { guild.selfMember.hasPermission(Permission.VOICE_MUTE_OTHERS) } returns false
+
+        VoiceStateHelper.muteOrUnmuteMembers(member, requestingUserDto, event, 0, guild, true)
+
+        verify(exactly = 1) { event.hook.sendMessage(match<String> { it.contains("not allowed to mute") }) }
+        verify(exactly = 0) { guild.mute(any(), any()) }
+    }
+
+    @Test
+    fun `muteOrUnmuteMembers mutes member when all permissions are satisfied`() {
+        val muteAction = mockk<net.dv8tion.jda.api.requests.restaction.AuditableRestAction<Void>>(relaxed = true)
+        every { guild.mute(target, true) } returns muteAction
+        every { muteAction.reason(any()) } returns muteAction
+        every { muteAction.queue() } just Runs
+
+        VoiceStateHelper.muteOrUnmuteMembers(member, requestingUserDto, event, 0, guild, true)
+
+        verify(exactly = 1) { guild.mute(target, true) }
+    }
+
+    @Test
+    fun `muteOrUnmuteMembers unmutes member when muteTargets is false`() {
+        val muteAction = mockk<net.dv8tion.jda.api.requests.restaction.AuditableRestAction<Void>>(relaxed = true)
+        every { guild.mute(target, false) } returns muteAction
+        every { muteAction.reason(any()) } returns muteAction
+        every { muteAction.queue() } just Runs
+
+        VoiceStateHelper.muteOrUnmuteMembers(member, requestingUserDto, event, 0, guild, false)
+
+        verify(exactly = 1) { guild.mute(target, false) }
+    }
+
+    @Test
+    fun `muteOrUnmuteMembers uses unmute wording when muteTargets is false`() {
+        every { member.canInteract(target) } returns false
+
+        VoiceStateHelper.muteOrUnmuteMembers(member, requestingUserDto, event, 0, guild, false)
+
+        verify(exactly = 1) { event.hook.sendMessage(match<String> { it.contains("aren't allowed to unmute") }) }
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/lavaplayer/TrackSchedulerTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/lavaplayer/TrackSchedulerTest.kt
@@ -1,0 +1,206 @@
+package bot.toby.lavaplayer
+
+import com.sedmelluq.discord.lavaplayer.player.AudioPlayer
+import com.sedmelluq.discord.lavaplayer.track.AudioPlaylist
+import com.sedmelluq.discord.lavaplayer.track.AudioTrack
+import com.sedmelluq.discord.lavaplayer.track.AudioTrackEndReason
+import com.sedmelluq.discord.lavaplayer.track.AudioTrackInfo
+import io.mockk.*
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class TrackSchedulerTest {
+
+    private val player: AudioPlayer = mockk(relaxed = true)
+    private lateinit var scheduler: TrackScheduler
+
+    private fun mockTrack(title: String = "Test Track", author: String = "Author", volume: Int = 50): AudioTrack {
+        val track = mockk<AudioTrack>(relaxed = true)
+        every { track.info } returns AudioTrackInfo(title, author, 60000L, "identifier", false, "http://example.com")
+        every { track.userData } returns volume
+        every { track.makeClone() } returns track
+        return track
+    }
+
+    @BeforeEach
+    fun setUp() {
+        scheduler = TrackScheduler(player, guildId = 1L, deleteDelay = 5)
+        mockkObject(PlayerManager.Companion)
+        every { PlayerManager.instance } returns mockk(relaxed = true)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        clearAllMocks()
+        unmockkObject(PlayerManager.Companion)
+    }
+
+    @Test
+    fun `queue starts track immediately when player is free`() {
+        val track = mockTrack()
+        every { player.startTrack(track, true) } returns true
+
+        scheduler.queue(track, 0L, 50)
+
+        verify(exactly = 1) { player.startTrack(track, true) }
+        assertEquals(0, scheduler.queue.size)
+    }
+
+    @Test
+    fun `queue adds track to queue when player is busy`() {
+        val track = mockTrack()
+        every { player.startTrack(track, true) } returns false
+
+        scheduler.queue(track, 0L, 50)
+
+        verify(exactly = 1) { player.startTrack(track, true) }
+        assertEquals(1, scheduler.queue.size)
+        assertSame(track, scheduler.queue.poll())
+    }
+
+    @Test
+    fun `queue sets track position and userData`() {
+        val track = mockTrack()
+        every { player.startTrack(track, true) } returns true
+
+        scheduler.queue(track, 1000L, 75)
+
+        verify(exactly = 1) { track.position = 1000L }
+        verify(exactly = 1) { track.userData = 75 }
+    }
+
+    @Test
+    fun `queueTrackList adds all tracks to queue when player is busy`() {
+        val track1 = mockTrack("Track 1")
+        val track2 = mockTrack("Track 2")
+        val playlist = mockk<AudioPlaylist>(relaxed = true)
+        every { playlist.name } returns "Test Playlist"
+        every { playlist.tracks } returns listOf(track1, track2)
+        every { player.startTrack(any(), true) } returns false
+
+        scheduler.queueTrackList(playlist, 80)
+
+        assertEquals(2, scheduler.queue.size)
+    }
+
+    @Test
+    fun `queueTrackList sets userData on each track`() {
+        val track1 = mockTrack()
+        val track2 = mockTrack()
+        val playlist = mockk<AudioPlaylist>(relaxed = true)
+        every { playlist.name } returns "Playlist"
+        every { playlist.tracks } returns listOf(track1, track2)
+        every { player.startTrack(any(), true) } returns false
+
+        scheduler.queueTrackList(playlist, 60)
+
+        verify(exactly = 1) { track1.userData = 60 }
+        verify(exactly = 1) { track2.userData = 60 }
+    }
+
+    @Test
+    fun `nextTrack does nothing when queue is empty`() {
+        scheduler.nextTrack()
+
+        verify(exactly = 0) { player.startTrack(any(), any()) }
+    }
+
+    @Test
+    fun `nextTrack starts next track from queue and sets volume`() {
+        val track = mockTrack(volume = 70)
+        scheduler.queue.offer(track)
+        every { player.startTrack(track, false) } returns true
+
+        scheduler.nextTrack()
+
+        verify(exactly = 1) { player.volume = 70 }
+        verify(exactly = 1) { player.startTrack(track, false) }
+        assertEquals(0, scheduler.queue.size)
+    }
+
+    @Test
+    fun `onTrackStart sets player volume from track userData`() {
+        val track = mockTrack(volume = 65)
+
+        scheduler.onTrackStart(player, track)
+
+        verify(exactly = 1) { player.volume = 65 }
+    }
+
+    @Test
+    fun `onTrackEnd does not proceed to next track when mayStartNext is false`() {
+        val track = mockTrack()
+
+        scheduler.onTrackEnd(player, track, AudioTrackEndReason.STOPPED)
+
+        verify(exactly = 0) { player.startTrack(any(), false) }
+    }
+
+    @Test
+    fun `onTrackEnd loops track when isLooping is true`() {
+        val track = mockTrack()
+        val clonedTrack = mockTrack()
+        every { track.makeClone() } returns clonedTrack
+        scheduler.isLooping = true
+
+        scheduler.onTrackEnd(player, track, AudioTrackEndReason.FINISHED)
+
+        verify(exactly = 1) { player.startTrack(clonedTrack, false) }
+    }
+
+    @Test
+    fun `onTrackEnd advances queue when not looping and queue has tracks`() {
+        val currentTrack = mockTrack("Current")
+        val nextTrack = mockTrack("Next", volume = 55)
+        scheduler.queue.offer(nextTrack)
+        scheduler.isLooping = false
+
+        scheduler.onTrackEnd(player, currentTrack, AudioTrackEndReason.FINISHED)
+
+        verify(exactly = 1) { player.startTrack(nextTrack, false) }
+    }
+
+    @Test
+    fun `onTrackStuck at position 0 calls nextTrack`() {
+        val track = mockTrack()
+        every { track.position } returns 0L
+
+        scheduler.onTrackStuck(player, track, 1000L)
+
+        // nextTrack on empty queue should not start any track
+        verify(exactly = 0) { player.startTrack(any(), false) }
+    }
+
+    @Test
+    fun `onTrackStuck at position greater than 0 does nothing`() {
+        val track = mockTrack()
+        every { track.position } returns 5000L
+
+        scheduler.onTrackStuck(player, track, 1000L)
+
+        verify(exactly = 0) { player.startTrack(any(), false) }
+    }
+
+    @Test
+    fun `stopTrack returns false when isStoppable is false`() {
+        assertFalse(scheduler.stopTrack(false))
+        verify(exactly = 0) { player.stopTrack() }
+    }
+
+    @Test
+    fun `stopTrack stops player and returns true when isStoppable is true`() {
+        assertTrue(scheduler.stopTrack(true))
+        verify(exactly = 1) { player.stopTrack() }
+    }
+
+    @Test
+    fun `setPreviousVolume stores value for later use`() {
+        scheduler.setPreviousVolume(42)
+        // If we stop a stoppable track with no event, setVolumeToPrevious won't send a message
+        // but we can verify it's stored by verifying stopTrack calls stopTrack on player
+        assertTrue(scheduler.stopTrack(true))
+        verify(exactly = 1) { player.stopTrack() }
+    }
+}


### PR DESCRIPTION
New test files covering previously untested source files:
- HelpAutoCompleteTest: tests autocomplete filtering, case-insensitivity, 25-choice limit
- DbdRandomKillerCommandTest: tests WikiFetcher success/failure paths
- Kf2RandomMapCommandTest: tests WikiFetcher success/failure paths
- URLHelperTest: tests isValidURL and fromUrlString pure functions
- UserDtoHelperTest: tests calculateUserDto, userAdjustmentValidation, updateUser
- VoiceStateHelperTest: tests muteOrUnmuteMembers permission scenarios
- TrackSchedulerTest: tests queue, nextTrack, onTrackEnd, stopTrack lifecycle

