### PR TITLE
feat: add OG meta tags, preview image and favicon for link sharing

### DIFF
--- a/web/src/main/resources/static/images/favicon.svg
+++ b/web/src/main/resources/static/images/favicon.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64">
+  <!-- Background -->
+  <rect width="64" height="64" rx="12" fill="#1a1a2e"/>
+
+  <!-- Head -->
+  <rect x="14" y="16" width="36" height="28" rx="6" fill="none" stroke="#5865F2" stroke-width="3"/>
+  <!-- Antenna -->
+  <line x1="32" y1="16" x2="32" y2="8" stroke="#5865F2" stroke-width="2.5"/>
+  <circle cx="32" cy="6" r="3" fill="#5865F2"/>
+  <!-- Eyes -->
+  <circle cx="23" cy="28" r="4" fill="#5865F2"/>
+  <circle cx="41" cy="28" r="4" fill="#5865F2"/>
+  <!-- Mouth -->
+  <rect x="22" y="37" width="20" height="3" rx="1.5" fill="#5865F2" opacity="0.8"/>
+  <!-- Body -->
+  <rect x="20" y="47" width="24" height="12" rx="4" fill="#5865F2" opacity="0.4"/>
+</svg>

--- a/web/src/main/resources/static/images/preview.svg
+++ b/web/src/main/resources/static/images/preview.svg
@@ -1,0 +1,48 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <!-- Background -->
+  <rect width="1200" height="630" fill="#1a1a2e"/>
+
+  <!-- Left accent bar -->
+  <rect x="0" y="0" width="8" height="630" fill="#5865F2"/>
+
+  <!-- Subtle grid pattern -->
+  <defs>
+    <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+      <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#2a2a4a" stroke-width="1"/>
+    </pattern>
+  </defs>
+  <rect width="1200" height="630" fill="url(#grid)" opacity="0.5"/>
+
+  <!-- Glow blob behind icon -->
+  <circle cx="600" cy="240" r="160" fill="#5865F2" opacity="0.08"/>
+
+  <!-- Robot icon (centred, above text) -->
+  <!-- Head -->
+  <rect x="548" y="148" width="104" height="88" rx="16" fill="none" stroke="#5865F2" stroke-width="5"/>
+  <!-- Antenna -->
+  <line x1="600" y1="148" x2="600" y2="124" stroke="#5865F2" stroke-width="4"/>
+  <circle cx="600" cy="118" r="8" fill="#5865F2"/>
+  <!-- Eyes -->
+  <circle cx="576" cy="183" r="10" fill="#5865F2"/>
+  <circle cx="624" cy="183" r="10" fill="#5865F2"/>
+  <!-- Mouth -->
+  <rect x="572" y="210" width="56" height="8" rx="4" fill="#5865F2" opacity="0.7"/>
+  <!-- Body -->
+  <rect x="556" y="244" width="88" height="56" rx="10" fill="none" stroke="#5865F2" stroke-width="4" opacity="0.6"/>
+  <!-- Arms -->
+  <line x1="556" y1="262" x2="524" y2="274" stroke="#5865F2" stroke-width="4" stroke-linecap="round" opacity="0.6"/>
+  <line x1="644" y1="262" x2="676" y2="274" stroke="#5865F2" stroke-width="4" stroke-linecap="round" opacity="0.6"/>
+
+  <!-- TobyBot wordmark -->
+  <text x="600" y="378" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif"
+        font-size="88" font-weight="700" fill="#ffffff" text-anchor="middle" letter-spacing="-2">TobyBot</text>
+
+  <!-- Tagline -->
+  <text x="600" y="434" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif"
+        font-size="30" font-weight="400" fill="#a0a0b0" text-anchor="middle">Your Discord Companion</text>
+
+  <!-- Bottom divider + URL -->
+  <rect x="80" y="520" width="1040" height="1" fill="#2a2a4a"/>
+  <text x="600" y="558" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif"
+        font-size="22" fill="#555570" text-anchor="middle">www.toby-bot.co.uk</text>
+</svg>

--- a/web/src/main/resources/templates/home.html
+++ b/web/src/main/resources/templates/home.html
@@ -4,6 +4,19 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>TobyBot — Your Discord Companion</title>
+
+    <!-- SEO -->
+    <meta name="description" content="Music, moderation, DnD tools, and more — all in one bot for your Discord server.">
+
+    <!-- Open Graph (WhatsApp, Facebook, etc.) -->
+    <meta property="og:type"        content="website">
+    <meta property="og:url"         content="https://www.toby-bot.co.uk/">
+    <meta property="og:title"       content="TobyBot — Your Discord Companion">
+    <meta property="og:description" content="Music, moderation, DnD tools, and more — all in one bot for your Discord server.">
+    <meta property="og:image"       content="https://www.toby-bot.co.uk/images/preview.svg">
+
+    <!-- Favicon -->
+    <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
     <style>
         * { box-sizing: border-box; margin: 0; padding: 0; }
         body {


### PR DESCRIPTION
Adds branded SVG preview banner and favicon, plus Open Graph meta tags to home.html so WhatsApp (and other platforms) show a rich card with title, description and image when the link is shared.