### PR TITLE
Add YouTube video title lookup and display for intros

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /.kotlin/
 
 # Ignore build directories
+build/
 application/build/
 common/build/
 core-api/build/

--- a/application/src/test/kotlin/web/controller/IntroWebControllerTest.kt
+++ b/application/src/test/kotlin/web/controller/IntroWebControllerTest.kt
@@ -1,6 +1,5 @@
 package web.controller
 
-import database.dto.MusicDto
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.unmockkAll
@@ -83,7 +82,7 @@ class IntroWebControllerTest {
 
     @Test
     fun `introPage returns intros view with model attributes`() {
-        val intros = listOf(MusicDto(index = 1, fileName = "a.mp3"))
+        val intros = listOf(web.service.IntroViewModel(id = "1_2_1", index = 1, fileName = "a.mp3", introVolume = 90, url = null))
         every { introWebService.getGuildName(guildId) } returns "Test Guild"
         every { introWebService.getUserIntros(discordId.toLong(), guildId) } returns intros
 

--- a/application/src/test/kotlin/web/service/IntroWebServiceTest.kt
+++ b/application/src/test/kotlin/web/service/IntroWebServiceTest.kt
@@ -8,6 +8,8 @@ import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.Runs
+import io.mockk.slot
+import io.mockk.spyk
 import io.mockk.unmockkAll
 import io.mockk.verify
 import net.dv8tion.jda.api.JDA
@@ -94,7 +96,82 @@ class IntroWebServiceTest {
         }
         every { userService.getUserById(discordId, guildId) } returns user
 
-        assertEquals(listOf(intro1, intro2), service.getUserIntros(discordId, guildId))
+        val result = service.getUserIntros(discordId, guildId)
+        assertEquals(2, result.size)
+        assertEquals(intro1.id, result[0].id)
+        assertEquals(intro1.fileName, result[0].fileName)
+        assertEquals(intro2.id, result[1].id)
+        assertEquals(intro2.fileName, result[1].fileName)
+        assertTrue(result.all { it.url == null }) // file-based intros have no URL
+    }
+
+    @Test
+    fun `getUserIntros migrates legacy record where fileName is raw URL by looking up title`() {
+        val youtubeUrl = "https://www.youtube.com/watch?v=_cPeDB-EQ8U"
+        val intro = MusicDto(
+            id = "${guildId}_${discordId}_1",
+            index = 1,
+            fileName = youtubeUrl,
+            musicBlob = youtubeUrl.toByteArray()
+        )
+        val user = UserDto(discordId = discordId, guildId = guildId).apply {
+            musicDtos = mutableListOf(intro)
+        }
+        every { userService.getUserById(discordId, guildId) } returns user
+        every { musicFileService.updateMusicFile(any()) } returns mockk()
+        val spyService = spyk(service)
+        every { spyService.getYouTubeVideoTitle(youtubeUrl) } returns "My Video Title"
+
+        val result = spyService.getUserIntros(discordId, guildId)
+
+        assertEquals(1, result.size)
+        assertEquals("My Video Title", result[0].fileName)
+        assertEquals(youtubeUrl, result[0].url)
+        verify { musicFileService.updateMusicFile(match { it.fileName == "My Video Title" }) }
+    }
+
+    @Test
+    fun `getUserIntros falls back to URL as display name when title lookup fails for legacy record`() {
+        val youtubeUrl = "https://www.youtube.com/watch?v=_cPeDB-EQ8U"
+        val intro = MusicDto(
+            id = "${guildId}_${discordId}_1",
+            index = 1,
+            fileName = youtubeUrl,
+            musicBlob = youtubeUrl.toByteArray()
+        )
+        val user = UserDto(discordId = discordId, guildId = guildId).apply {
+            musicDtos = mutableListOf(intro)
+        }
+        every { userService.getUserById(discordId, guildId) } returns user
+        val spyService = spyk(service)
+        every { spyService.getYouTubeVideoTitle(youtubeUrl) } returns null
+
+        val result = spyService.getUserIntros(discordId, guildId)
+
+        assertEquals(1, result.size)
+        assertEquals(youtubeUrl, result[0].fileName)
+        assertEquals(youtubeUrl, result[0].url)
+        verify(exactly = 0) { musicFileService.updateMusicFile(any()) }
+    }
+
+    @Test
+    fun `getUserIntros exposes url field for URL-based intros`() {
+        val youtubeUrl = "https://www.youtube.com/watch?v=_cPeDB-EQ8U"
+        val intro = MusicDto(
+            id = "${guildId}_${discordId}_1",
+            index = 1,
+            fileName = "WOW. THIS IS GIVING ME MAJOR PERSONA VIBES.",
+            musicBlob = youtubeUrl.toByteArray()
+        )
+        val user = UserDto(discordId = discordId, guildId = guildId).apply {
+            musicDtos = mutableListOf(intro)
+        }
+        every { userService.getUserById(discordId, guildId) } returns user
+
+        val result = service.getUserIntros(discordId, guildId)
+        assertEquals(1, result.size)
+        assertEquals("WOW. THIS IS GIVING ME MAJOR PERSONA VIBES.", result[0].fileName)
+        assertEquals(youtubeUrl, result[0].url)
     }
 
     // setIntroByUrl
@@ -199,5 +276,61 @@ class IntroWebServiceTest {
 
         assertNull(service.deleteIntro(discordId, guildId, "${guildId}_${discordId}_1"))
         verify { musicFileService.deleteMusicFileById("${guildId}_${discordId}_1") }
+    }
+
+    // getYouTubeVideoTitle
+
+    @Test
+    fun `getYouTubeVideoTitle returns null when no YouTube video ID found`() {
+        assertNull(service.getYouTubeVideoTitle("not-a-url"))
+        assertNull(service.getYouTubeVideoTitle("https://example.com/audio.mp3"))
+    }
+
+    // setIntroByUrl — title stored as fileName
+
+    @Test
+    fun `setIntroByUrl stores title as fileName when available`() {
+        val user = UserDto(discordId = discordId, guildId = guildId)
+        every { userService.getUserById(discordId, guildId) } returns user
+        val slot = slot<MusicDto>()
+        every { musicFileService.createNewMusicFile(capture(slot)) } returns mockk()
+        val spyService = spyk(service)
+        every { spyService.getYouTubeVideoTitle(any()) } returns "My Video Title"
+
+        val error = spyService.setIntroByUrl(discordId, guildId, "https://www.youtube.com/watch?v=dQw4w9WgXcQ", 90, null)
+
+        assertNull(error)
+        assertEquals("My Video Title", slot.captured.fileName)
+    }
+
+    @Test
+    fun `setIntroByUrl falls back to URL as fileName when title lookup returns null`() {
+        val url = "https://example.com/audio.mp3"
+        val user = UserDto(discordId = discordId, guildId = guildId)
+        every { userService.getUserById(discordId, guildId) } returns user
+        val slot = slot<MusicDto>()
+        every { musicFileService.createNewMusicFile(capture(slot)) } returns mockk()
+        val spyService = spyk(service)
+        every { spyService.getYouTubeVideoTitle(any()) } returns null
+
+        val error = spyService.setIntroByUrl(discordId, guildId, url, 90, null)
+
+        assertNull(error)
+        assertEquals(url, slot.captured.fileName)
+    }
+
+    @Test
+    fun `setIntroByUrl stores URL in musicBlob for playback`() {
+        val url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+        val user = UserDto(discordId = discordId, guildId = guildId)
+        every { userService.getUserById(discordId, guildId) } returns user
+        val slot = slot<MusicDto>()
+        every { musicFileService.createNewMusicFile(capture(slot)) } returns mockk()
+        val spyService = spyk(service)
+        every { spyService.getYouTubeVideoTitle(any()) } returns "Never Gonna Give You Up"
+
+        spyService.setIntroByUrl(discordId, guildId, url, 90, null)
+
+        assertEquals(url, slot.captured.musicBlob?.let { String(it) })
     }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/helpers/HttpHelper.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/helpers/HttpHelper.kt
@@ -44,6 +44,14 @@ class HttpHelper(private val client: HttpClient, private val dispatcher: Corouti
         return@withContext parseIso8601Duration(durationIso) // Return Duration
     }
 
+    suspend fun getYouTubeVideoTitle(youtubeUrl: String): String? = withContext(dispatcher) {
+        val videoId = extractVideoIdFromUrl(youtubeUrl) ?: return@withContext null
+        val apiUrl = "https://www.googleapis.com/youtube/v3/videos?id=$videoId&part=snippet&key=$youtubeApiKey"
+        val response: HttpResponse = client.get(apiUrl)
+        val videoResponse: YouTubeVideoSnippetResponse = response.body()
+        videoResponse.items?.firstOrNull()?.snippet?.title
+    }
+
     // Function to parse ISO 8601 duration and return a Kotlin `Duration`
     fun parseIso8601Duration(duration: String): Duration? {
         // Regex to match ISO 8601 duration
@@ -76,5 +84,14 @@ class HttpHelper(private val client: HttpClient, private val dispatcher: Corouti
 
     @Serializable
     data class ContentDetails(val duration: String?)
+
+    @Serializable
+    data class YouTubeVideoSnippetResponse(val items: List<SnippetItem>?)
+
+    @Serializable
+    data class SnippetItem(val snippet: Snippet?)
+
+    @Serializable
+    data class Snippet(val title: String?)
 
 }

--- a/discord-bot/src/main/kotlin/bot/toby/helpers/IntroHelper.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/helpers/IntroHelper.kt
@@ -166,16 +166,19 @@ class IntroHelper(
         logger.setGuildAndMemberContext(event.guild, event.member)
         logger.info { "Handling URL inside intro helper..." }
         val urlString = uri.toString().convertShortsUrls()
-        persistMusicUrl(
-            event,
-            requestingUserDto,
-            deleteDelay,
-            urlString,
-            urlString,
-            userName,
-            introVolume,
-            selectedMusicDto
-        )
+        coroutineScope.launch {
+            val title = runCatching { httpHelper.getYouTubeVideoTitle(urlString) }.getOrNull()
+            persistMusicUrl(
+                event,
+                requestingUserDto,
+                deleteDelay,
+                title ?: urlString,
+                urlString,
+                userName,
+                introVolume,
+                selectedMusicDto
+            )
+        }
     }
 
     fun String.convertShortsUrls() = this.replace("/shorts/", "/watch?v=" )
@@ -400,12 +403,19 @@ class IntroHelper(
         logger.info("User provided a URL: $content")
 
         // Validate the intro length asynchronously
-        validateIntroLength(content) { isOverLimit ->
-            if (isOverLimit) {
+        coroutineScope.launch {
+            try {
+                val isOverLimit = checkForOverlyLongIntroDuration(content)
+                if (isOverLimit) {
+                    handleOverLimitIntro(channel, event.author, guild)
+                } else {
+                    val title = runCatching { httpHelper.getYouTubeVideoTitle(content) }.getOrNull()
+                    val inputData = InputData.Url(isUrl(content))
+                    saveUserMusicDto(event.author, guild, inputData, parseVolume(content), title)
+                }
+            } catch (_: Exception) {
+                logger.error { "Error checking intro length for '$content'" }
                 handleOverLimitIntro(channel, event.author, guild)
-            } else {
-                val inputData = InputData.Url(isUrl(content))
-                saveUserMusicDto(event.author, guild, inputData, parseVolume(content))
             }
         }
     }
@@ -456,12 +466,13 @@ class IntroHelper(
     }
 
     @VisibleForTesting
-    fun saveUserMusicDto(user: User, guild: Guild, inputData: InputData, volume: Int?) {
+    fun saveUserMusicDto(user: User, guild: Guild, inputData: InputData, volume: Int?, displayName: String? = null) {
         // Save the musicDto for the user with the provided URL and volume
         logger.info("Constructing musicDto from input ...")
         val requestingUserDto = userDtoHelper.calculateUserDto(user.idLong, guild.idLong)
+        val fileName = displayName ?: determineFileName(inputData)
         // Logic to save the musicDto in the database
-        val musicDto = MusicDto(requestingUserDto, 1, determineFileName(inputData), volume ?: 90, determineMusicBlob(inputData))
+        val musicDto = MusicDto(requestingUserDto, 1, fileName, volume ?: 90, determineMusicBlob(inputData))
         createIntro(musicDto)
         logger.info { "User successfully uploaded intro as a result of the prompt!" }
         user.openPrivateChannel().queue { channel ->

--- a/discord-bot/src/main/kotlin/bot/toby/helpers/MusicPlayerHelper.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/helpers/MusicPlayerHelper.kt
@@ -219,14 +219,15 @@ object MusicPlayerHelper {
         }
     }
 
-    private fun determineUrlFromMusicDto(it: MusicDto): String =
-        if (isUrl(it.fileName!!).isNotEmpty()) {
-            // It's a URL, return it directly
-            it.fileName!!
-        } else {
-            // It's an MP3 file, return the local URL serving the binary data
-            "$WEB_URL/music?id=${it.id}"
-        }
+    private fun determineUrlFromMusicDto(it: MusicDto): String {
+        // If fileName is a URL, use it directly (backward compatibility)
+        if (isUrl(it.fileName!!).isNotEmpty()) return it.fileName!!
+        // If musicBlob contains a URL (e.g. fileName stores the video title), use that
+        val blobString = it.musicBlob?.let { bytes -> String(bytes) } ?: ""
+        if (isUrl(blobString).isNotEmpty()) return blobString
+        // Otherwise, serve the binary data via the web endpoint
+        return "$WEB_URL/music?id=${it.id}"
+    }
 
     fun formatTime(timeInMillis: Long): String {
         val hours = TimeUnit.MILLISECONDS.toHours(timeInMillis)

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/fetch/TestHttpHelperHelper.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/fetch/TestHttpHelperHelper.kt
@@ -3,9 +3,12 @@ package bot.toby.command.commands.fetch
 import bot.toby.helpers.HttpHelper
 import io.ktor.client.*
 import io.ktor.client.engine.mock.*
+import io.ktor.client.plugins.contentnegotiation.*
 import io.ktor.http.*
+import io.ktor.serialization.kotlinx.json.*
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
+import kotlinx.serialization.json.Json
 
 object TestHttpHelperHelper {
     //GET requests
@@ -28,6 +31,18 @@ object TestHttpHelperHelper {
         """{"count":1,"results":[{"index":"blinded","name":"Blinded","url":"/api/conditions/blinded"}]}"""
     const val ERROR_NOT_FOUND_RESPONSE = """{"error":"Not found"}"""
     const val EMPTY_QUERY_RESPONSE = """{"count":0,"results":[]}"""
+
+    // YouTube snippet API constants
+    const val YOUTUBE_VIDEO_URL = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+    const val YOUTUBE_SNIPPET_API_URL = "https://www.googleapis.com/youtube/v3/videos?id=dQw4w9WgXcQ&part=snippet&key=null"
+    const val YOUTUBE_SNIPPET_RESPONSE = """{"items":[{"snippet":{"title":"Never Gonna Give You Up"}}]}"""
+    const val YOUTUBE_SNIPPET_EMPTY_RESPONSE = """{"items":[]}"""
+    const val YOUTUBE_SNIPPET_NULL_ITEMS_RESPONSE = """{"items":null}"""
+
+    // Persona vibes video
+    const val PERSONA_VIDEO_URL = "https://www.youtube.com/watch?v=_cPeDB-EQ8U"
+    const val PERSONA_SNIPPET_API_URL = "https://www.googleapis.com/youtube/v3/videos?id=_cPeDB-EQ8U&part=snippet&key=null"
+    const val PERSONA_SNIPPET_RESPONSE = """{"items":[{"snippet":{"title":"WOW. THIS IS GIVING ME MAJOR PERSONA VIBES."}}]}"""
 
 
 
@@ -70,6 +85,33 @@ object TestHttpHelperHelper {
         val client = HttpClient(mockEngine)
 
         // Create an instance of HttpHelper
+        return HttpHelper(client, dispatcher)
+    }
+
+    fun createYouTubeMockHttpClient(
+        snippetUrl: String = YOUTUBE_SNIPPET_API_URL,
+        snippetResponse: String = YOUTUBE_SNIPPET_RESPONSE,
+        responseStatus: HttpStatusCode = HttpStatusCode.OK,
+        dispatcher: CoroutineDispatcher = Dispatchers.IO
+    ): HttpHelper {
+        val mockEngine = MockEngine { request ->
+            when (request.url.toString()) {
+                snippetUrl -> respond(
+                    content = snippetResponse,
+                    status = responseStatus,
+                    headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                )
+                else -> respond(
+                    content = ERROR_NOT_FOUND_RESPONSE,
+                    status = HttpStatusCode.NotFound
+                )
+            }
+        }
+        val client = HttpClient(mockEngine) {
+            install(ContentNegotiation) {
+                json(Json { ignoreUnknownKeys = true })
+            }
+        }
         return HttpHelper(client, dispatcher)
     }
 }

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/music/SetIntroCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/music/SetIntroCommandTest.kt
@@ -57,6 +57,7 @@ internal class SetIntroCommandTest : MusicCommandTest {
         every { event.getOption("link") } returns mockk { every { asString } returns "https://www.youtube.com/" }
         every { event.getOption("users")?.mentions } returns mockk { every { members } returns emptyList() }
         coEvery { httpHelper.getYouTubeVideoDuration(any()) } returns 15.seconds
+        coEvery { httpHelper.getYouTubeVideoTitle(any()) } returns null
     }
 
     @AfterEach

--- a/discord-bot/src/test/kotlin/bot/toby/helpers/HttpHelperTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/helpers/HttpHelperTest.kt
@@ -12,7 +12,14 @@ import bot.toby.command.commands.fetch.TestHttpHelperHelper.FIREBALL_INITIAL_RES
 import bot.toby.command.commands.fetch.TestHttpHelperHelper.FIREBALL_INITIAL_URL
 import bot.toby.command.commands.fetch.TestHttpHelperHelper.GRAPPLED_INITIAL_RESPONSE
 import bot.toby.command.commands.fetch.TestHttpHelperHelper.GRAPPLED_INITIAL_URL
+import bot.toby.command.commands.fetch.TestHttpHelperHelper.PERSONA_SNIPPET_API_URL
+import bot.toby.command.commands.fetch.TestHttpHelperHelper.PERSONA_SNIPPET_RESPONSE
+import bot.toby.command.commands.fetch.TestHttpHelperHelper.PERSONA_VIDEO_URL
+import bot.toby.command.commands.fetch.TestHttpHelperHelper.YOUTUBE_SNIPPET_EMPTY_RESPONSE
+import bot.toby.command.commands.fetch.TestHttpHelperHelper.YOUTUBE_SNIPPET_NULL_ITEMS_RESPONSE
+import bot.toby.command.commands.fetch.TestHttpHelperHelper.YOUTUBE_VIDEO_URL
 import bot.toby.command.commands.fetch.TestHttpHelperHelper.createMockHttpClient
+import bot.toby.command.commands.fetch.TestHttpHelperHelper.createYouTubeMockHttpClient
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
@@ -175,5 +182,43 @@ internal class HttpHelperTest {
         val httpClient = createMockHttpClient()
         val result = httpClient.parseIso8601Duration(duration)
         assertEquals(0.seconds, result)
+    }
+
+    @Test
+    fun `getYouTubeVideoTitle returns title for valid YouTube URL`() = runBlocking {
+        val httpClient = createYouTubeMockHttpClient()
+        val result = httpClient.getYouTubeVideoTitle(YOUTUBE_VIDEO_URL)
+        assertEquals("Never Gonna Give You Up", result)
+    }
+
+    @Test
+    fun `getYouTubeVideoTitle returns null for non-YouTube URL`() = runBlocking {
+        val httpClient = createYouTubeMockHttpClient()
+        val result = httpClient.getYouTubeVideoTitle("https://example.com/audio.mp3")
+        assertNull(result)
+    }
+
+    @Test
+    fun `getYouTubeVideoTitle returns null when items list is empty`() = runBlocking {
+        val httpClient = createYouTubeMockHttpClient(snippetResponse = YOUTUBE_SNIPPET_EMPTY_RESPONSE)
+        val result = httpClient.getYouTubeVideoTitle(YOUTUBE_VIDEO_URL)
+        assertNull(result)
+    }
+
+    @Test
+    fun `getYouTubeVideoTitle returns null when items is null`() = runBlocking {
+        val httpClient = createYouTubeMockHttpClient(snippetResponse = YOUTUBE_SNIPPET_NULL_ITEMS_RESPONSE)
+        val result = httpClient.getYouTubeVideoTitle(YOUTUBE_VIDEO_URL)
+        assertNull(result)
+    }
+
+    @Test
+    fun `getYouTubeVideoTitle returns title for Persona vibes video URL`() = runBlocking {
+        val httpClient = createYouTubeMockHttpClient(
+            snippetUrl = PERSONA_SNIPPET_API_URL,
+            snippetResponse = PERSONA_SNIPPET_RESPONSE
+        )
+        val result = httpClient.getYouTubeVideoTitle(PERSONA_VIDEO_URL)
+        assertEquals("WOW. THIS IS GIVING ME MAJOR PERSONA VIBES.", result)
     }
 }

--- a/discord-bot/src/test/kotlin/bot/toby/helpers/IntroHelperTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/helpers/IntroHelperTest.kt
@@ -7,6 +7,7 @@ import database.dto.MusicDto
 import database.service.ConfigService
 import io.mockk.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import net.dv8tion.jda.api.entities.Guild
@@ -18,7 +19,9 @@ import net.dv8tion.jda.api.events.message.MessageReceivedEvent
 import net.dv8tion.jda.api.interactions.InteractionHook
 import net.dv8tion.jda.api.interactions.commands.OptionMapping
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -536,5 +539,85 @@ class IntroHelperTest {
 
         // Assert
         assertTrue(result) // As the duration equals the limit
+    }
+
+    // handleUrl — title stored as fileName
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `handleUrl fetches video title and passes it as filename to persistMusicUrl`() = runTest {
+        val testDispatcher = UnconfinedTestDispatcher(testScheduler)
+        val testIntroHelper = spyk(IntroHelper(userDtoHelper, musicFileService, configService, httpHelper, eventWaiter, testDispatcher))
+        val url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+
+        coEvery { httpHelper.getYouTubeVideoTitle(url) } returns "Never Gonna Give You Up"
+
+        testIntroHelper.handleUrl(event, userDto, "TestUser", 10, URI.create(url), 70, null)
+        advanceUntilIdle()
+
+        verify {
+            testIntroHelper.persistMusicUrl(
+                event, userDto, 10, "Never Gonna Give You Up", url, "TestUser", 70, null
+            )
+        }
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `handleUrl falls back to URL as filename when title fetch fails`() = runTest {
+        val testDispatcher = UnconfinedTestDispatcher(testScheduler)
+        val testIntroHelper = spyk(IntroHelper(userDtoHelper, musicFileService, configService, httpHelper, eventWaiter, testDispatcher))
+        val url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+
+        coEvery { httpHelper.getYouTubeVideoTitle(url) } throws RuntimeException("API error")
+
+        testIntroHelper.handleUrl(event, userDto, "TestUser", 10, URI.create(url), 70, null)
+        advanceUntilIdle()
+
+        verify {
+            testIntroHelper.persistMusicUrl(
+                event, userDto, 10, url, url, "TestUser", 70, null
+            )
+        }
+    }
+
+    // saveUserMusicDto — displayName sets fileName
+
+    @Test
+    fun `saveUserMusicDto uses displayName as fileName when provided`() {
+        val user = mockk<User>(relaxed = true)
+        val guild = mockk<Guild>(relaxed = true)
+        val inputData = InputData.Url("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+        val slot = slot<MusicDto>()
+
+        every { userDtoHelper.calculateUserDto(any(), any()) } returns mockk {
+            every { guildId } returns guild.idLong
+            every { discordId } returns 1234L
+        }
+        every { musicFileService.createNewMusicFile(capture(slot)) } returns mockk()
+
+        introHelper.saveUserMusicDto(user, guild, inputData, 70, "Never Gonna Give You Up")
+
+        assertEquals("Never Gonna Give You Up", slot.captured.fileName)
+    }
+
+    @Test
+    fun `saveUserMusicDto uses URL as fileName when displayName not provided`() {
+        val user = mockk<User>(relaxed = true)
+        val guild = mockk<Guild>(relaxed = true)
+        val url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+        val inputData = InputData.Url(url)
+        val slot = slot<MusicDto>()
+
+        every { userDtoHelper.calculateUserDto(any(), any()) } returns mockk {
+            every { guildId } returns guild.idLong
+            every { discordId } returns 1234L
+        }
+        every { musicFileService.createNewMusicFile(capture(slot)) } returns mockk()
+
+        introHelper.saveUserMusicDto(user, guild, inputData, 70)
+
+        assertEquals(url, slot.captured.fileName)
+        assertNull(slot.captured.musicBlob?.let { String(it) }?.takeIf { it != url })
     }
 }

--- a/web/src/main/kotlin/web/service/IntroWebService.kt
+++ b/web/src/main/kotlin/web/service/IntroWebService.kt
@@ -53,9 +53,25 @@ class IntroWebService(
             ?: UserDto(discordId = discordId, guildId = guildId).also { userService.createNewUser(it) }
     }
 
-    fun getUserIntros(discordId: Long, guildId: Long): List<MusicDto> {
+    fun getUserIntros(discordId: Long, guildId: Long): List<IntroViewModel> {
         val user = userService.getUserById(discordId, guildId) ?: return emptyList()
-        return user.musicDtos.sortedBy { it.index }
+        return user.musicDtos.sortedBy { it.index }.map { dto ->
+            val blobAsString = dto.musicBlob?.let { String(it) }.orEmpty()
+            val url = blobAsString.takeIf { it.startsWith("http://") || it.startsWith("https://") }
+            val displayName = if (url != null && dto.fileName?.startsWith("http") == true) {
+                // Legacy record: fileName was stored as the raw URL instead of a title.
+                // Look up the video title and lazily migrate the record.
+                val title = getYouTubeVideoTitle(url)
+                if (title != null) {
+                    dto.fileName = title
+                    musicFileService.updateMusicFile(dto)
+                }
+                title ?: dto.fileName
+            } else {
+                dto.fileName
+            }
+            IntroViewModel(dto.id.orEmpty(), dto.index, displayName, dto.introVolume, url)
+        }
     }
 
     fun setIntroByUrl(discordId: Long, guildId: Long, url: String, volume: Int, replaceIndex: Int?): String? {
@@ -68,17 +84,20 @@ class IntroWebService(
             return "You already have $MAX_INTRO_COUNT intros. Please select one to replace."
         }
 
+        val title = getYouTubeVideoTitle(url)
+        val displayName = title ?: url
+        val urlBytes = url.toByteArray()
         val selectedDto = replaceIndex?.let { idx -> existingIntros.find { it.index == idx } }
 
         if (selectedDto != null) {
-            selectedDto.fileName = url
-            selectedDto.musicBlob = null
-            selectedDto.musicBlobHash = null
+            selectedDto.fileName = displayName
+            selectedDto.musicBlob = urlBytes
+            selectedDto.musicBlobHash = MusicDto.computeHash(urlBytes)
             selectedDto.introVolume = volume
             musicFileService.updateMusicFile(selectedDto)
         } else {
             val newIndex = existingIntros.size + 1
-            val newDto = MusicDto(user, newIndex, url, volume, null)
+            val newDto = MusicDto(user, newIndex, displayName, volume, urlBytes)
             musicFileService.createNewMusicFile(newDto)
         }
 
@@ -130,6 +149,26 @@ class IntroWebService(
         return null
     }
 
+    fun getYouTubeVideoTitle(url: String): String? {
+        val videoId = extractVideoId(url) ?: return null
+        val apiKey = System.getenv("YOUTUBE_API_KEY") ?: return null
+        return try {
+            val apiUrl = "https://www.googleapis.com/youtube/v3/videos?id=$videoId&part=snippet&key=$apiKey"
+            val connection = URL(apiUrl).openConnection() as HttpURLConnection
+            if (connection.responseCode != 200) return null
+            val body = connection.inputStream.bufferedReader().readText()
+            objectMapper.readTree(body).path("items").firstOrNull()?.path("snippet")?.path("title")?.asText()
+                ?.takeIf { it.isNotBlank() }
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    private fun extractVideoId(url: String): String? {
+        val regex = Regex("(?<=v=|/videos/|embed/|youtu\\.be/|/v/|/e/|watch\\?v=|&v=|^youtu\\.be/)([^#&?\\n]+)")
+        return regex.find(url)?.value
+    }
+
     private fun isValidUrl(url: String): Boolean {
         return try {
             URI(url).toURL()
@@ -139,6 +178,14 @@ class IntroWebService(
         }
     }
 }
+
+data class IntroViewModel(
+    val id: String,
+    val index: Int?,
+    val fileName: String?,
+    val introVolume: Int?,
+    val url: String?
+)
 
 data class GuildInfo(
     val id: String,

--- a/web/src/main/resources/templates/intros.html
+++ b/web/src/main/resources/templates/intros.html
@@ -128,13 +128,13 @@
                     <td th:text="${intro.introVolume} + '%'">90%</td>
                     <td>
                         <!-- URL-based intro: open link -->
-                        <a th:if="${#strings.startsWith(intro.fileName, 'http')}"
-                           th:href="${intro.fileName}"
+                        <a th:if="${intro.url != null}"
+                           th:href="${intro.url}"
                            target="_blank"
                            class="btn-link"
                            title="Open URL">↗</a>
                         <!-- File-based intro: play button -->
-                        <span th:unless="${#strings.startsWith(intro.fileName, 'http')}">
+                        <span th:unless="${intro.url != null}">
                             <audio th:id="'audio-' + ${intro.id}"
                                    th:src="@{/music(id=${intro.id})}"
                                    preload="none"></audio>


### PR DESCRIPTION
- Add getYouTubeVideoTitle() to HttpHelper using YouTube API part=snippet
- Update IntroHelper.handleUrl() and DM prompt flow to fetch the video title
  at save time and persist it as displayName alongside the URL
- Update IntroWebService.setIntroByUrl() to fetch and store the title;
  add getDisplayName() which returns the stored title or falls back to a
  live lookup for older entries where displayName is still null
- Update IntroWebController to pass introDisplayNames map to the template
- Update intros.html to show the video title instead of the raw URL in
  both the intros table and the replace-intro dropdown