### PR TITLE
feat(web): overhaul intro manager UX and add bot-parity features

### DIFF
--- a/application/src/test/kotlin/web/controller/IntroWebControllerTest.kt
+++ b/application/src/test/kotlin/web/controller/IntroWebControllerTest.kt
@@ -1,9 +1,11 @@
 package web.controller
 
+import database.service.MusicFileService
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.unmockkAll
 import io.mockk.verify
+import jakarta.servlet.http.HttpSession
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
@@ -20,12 +22,14 @@ import web.service.IntroWebService
 class IntroWebControllerTest {
 
     private lateinit var introWebService: IntroWebService
+    private lateinit var musicFileService: MusicFileService
     private lateinit var controller: IntroWebController
 
     private val mockUser = mockk<OAuth2User>(relaxed = true)
     private val mockClient = mockk<OAuth2AuthorizedClient>(relaxed = true)
     private val mockModel = mockk<Model>(relaxed = true)
     private val mockRa = mockk<RedirectAttributes>(relaxed = true)
+    private val mockSession = mockk<HttpSession>(relaxed = true)
 
     private val discordId = "111"
     private val guildId = 222L
@@ -33,7 +37,8 @@ class IntroWebControllerTest {
     @BeforeEach
     fun setup() {
         introWebService = mockk(relaxed = true)
-        controller = IntroWebController(introWebService)
+        musicFileService = mockk(relaxed = true)
+        controller = IntroWebController(introWebService, musicFileService, "test-client-id")
 
         every { mockUser.getAttribute<String>("id") } returns discordId
         every { mockUser.getAttribute<String>("username") } returns "TestUser"
@@ -65,7 +70,7 @@ class IntroWebControllerTest {
     fun `introPage redirects to guilds when discordId is null`() {
         every { mockUser.getAttribute<String>("id") } returns null
 
-        val view = controller.introPage(guildId, mockUser, mockModel, mockRa)
+        val view = controller.introPage(guildId, null, mockUser, mockModel, mockRa)
 
         assertEquals("redirect:/intro/guilds", view)
     }
@@ -74,7 +79,7 @@ class IntroWebControllerTest {
     fun `introPage redirects when guild not found`() {
         every { introWebService.getGuildName(guildId) } returns null
 
-        val view = controller.introPage(guildId, mockUser, mockModel, mockRa)
+        val view = controller.introPage(guildId, null, mockUser, mockModel, mockRa)
 
         assertEquals("redirect:/intro/guilds", view)
         verify { mockRa.addFlashAttribute("error", "Bot is not in that server.") }
@@ -86,7 +91,7 @@ class IntroWebControllerTest {
         every { introWebService.getGuildName(guildId) } returns "Test Guild"
         every { introWebService.getUserIntros(discordId.toLong(), guildId) } returns intros
 
-        val view = controller.introPage(guildId, mockUser, mockModel, mockRa)
+        val view = controller.introPage(guildId, null, mockUser, mockModel, mockRa)
 
         assertEquals("intros", view)
         verify { mockModel.addAttribute("intros", intros) }
@@ -101,7 +106,7 @@ class IntroWebControllerTest {
     fun `setIntro with url adds success flash on success`() {
         every { introWebService.setIntroByUrl(any(), any(), any(), any(), any()) } returns null
 
-        val view = controller.setIntro(guildId, mockUser, "url", "https://example.com", null, 90, null, mockRa)
+        val view = controller.setIntro(guildId, mockUser, "url", "https://example.com", null, 90, null, null, mockRa)
 
         assertEquals("redirect:/intro/$guildId", view)
         verify { mockRa.addFlashAttribute("success", "Intro saved successfully.") }
@@ -111,7 +116,7 @@ class IntroWebControllerTest {
     fun `setIntro with url adds error flash on failure`() {
         every { introWebService.setIntroByUrl(any(), any(), any(), any(), any()) } returns "Invalid URL provided."
 
-        val view = controller.setIntro(guildId, mockUser, "url", "bad-url", null, 90, null, mockRa)
+        val view = controller.setIntro(guildId, mockUser, "url", "bad-url", null, 90, null, null, mockRa)
 
         assertEquals("redirect:/intro/$guildId", view)
         verify { mockRa.addFlashAttribute("error", "Invalid URL provided.") }
@@ -122,7 +127,7 @@ class IntroWebControllerTest {
         val file = mockk<MultipartFile> { every { isEmpty } returns false }
         every { introWebService.setIntroByFile(any(), any(), any(), any(), any()) } returns null
 
-        val view = controller.setIntro(guildId, mockUser, "file", null, file, 90, null, mockRa)
+        val view = controller.setIntro(guildId, mockUser, "file", null, file, 90, null, null, mockRa)
 
         assertEquals("redirect:/intro/$guildId", view)
         verify { mockRa.addFlashAttribute("success", "Intro saved successfully.") }
@@ -130,7 +135,7 @@ class IntroWebControllerTest {
 
     @Test
     fun `setIntro with missing file returns error`() {
-        val view = controller.setIntro(guildId, mockUser, "file", null, null, 90, null, mockRa)
+        val view = controller.setIntro(guildId, mockUser, "file", null, null, 90, null, null, mockRa)
 
         assertEquals("redirect:/intro/$guildId", view)
         verify { mockRa.addFlashAttribute("error", "No file provided.") }
@@ -140,7 +145,7 @@ class IntroWebControllerTest {
     fun `setIntro clamps volume above 100 to 100`() {
         every { introWebService.setIntroByUrl(any(), any(), any(), any(), any()) } returns null
 
-        controller.setIntro(guildId, mockUser, "url", "https://example.com", null, 200, null, mockRa)
+        controller.setIntro(guildId, mockUser, "url", "https://example.com", null, 200, null, null, mockRa)
 
         verify { introWebService.setIntroByUrl(any(), any(), any(), 100, any()) }
     }
@@ -149,7 +154,7 @@ class IntroWebControllerTest {
     fun `setIntro clamps volume below 1 to 1`() {
         every { introWebService.setIntroByUrl(any(), any(), any(), any(), any()) } returns null
 
-        controller.setIntro(guildId, mockUser, "url", "https://example.com", null, 0, null, mockRa)
+        controller.setIntro(guildId, mockUser, "url", "https://example.com", null, 0, null, null, mockRa)
 
         verify { introWebService.setIntroByUrl(any(), any(), any(), 1, any()) }
     }
@@ -160,7 +165,7 @@ class IntroWebControllerTest {
     fun `deleteIntro adds success flash on success`() {
         every { introWebService.deleteIntro(any(), any(), any()) } returns null
 
-        val view = controller.deleteIntro(guildId, "${guildId}_${discordId}_1", mockUser, mockRa)
+        val view = controller.deleteIntro(guildId, "${guildId}_${discordId}_1", mockUser, null, mockSession, mockRa)
 
         assertEquals("redirect:/intro/$guildId", view)
         verify { mockRa.addFlashAttribute("success", "Intro deleted.") }
@@ -170,7 +175,7 @@ class IntroWebControllerTest {
     fun `deleteIntro adds error flash on failure`() {
         every { introWebService.deleteIntro(any(), any(), any()) } returns "Intro not found."
 
-        val view = controller.deleteIntro(guildId, "${guildId}_${discordId}_1", mockUser, mockRa)
+        val view = controller.deleteIntro(guildId, "${guildId}_${discordId}_1", mockUser, null, mockSession, mockRa)
 
         assertEquals("redirect:/intro/$guildId", view)
         verify { mockRa.addFlashAttribute("error", "Intro not found.") }

--- a/application/src/test/kotlin/web/service/IntroWebServiceTest.kt
+++ b/application/src/test/kotlin/web/service/IntroWebServiceTest.kt
@@ -120,7 +120,12 @@ class IntroWebServiceTest {
         every { userService.getUserById(discordId, guildId) } returns user
         every { musicFileService.updateMusicFile(any()) } returns mockk()
         val spyService = spyk(service)
-        every { spyService.getYouTubeVideoTitle(youtubeUrl) } returns "My Video Title"
+        every { spyService.fetchYouTubePreview(youtubeUrl) } returns web.service.YouTubePreview(
+            videoId = "_cPeDB-EQ8U",
+            title = "My Video Title",
+            thumbnailUrl = null,
+            durationSeconds = null
+        )
 
         val result = spyService.getUserIntros(discordId, guildId)
 
@@ -144,7 +149,7 @@ class IntroWebServiceTest {
         }
         every { userService.getUserById(discordId, guildId) } returns user
         val spyService = spyk(service)
-        every { spyService.getYouTubeVideoTitle(youtubeUrl) } returns null
+        every { spyService.fetchYouTubePreview(youtubeUrl) } returns null
 
         val result = spyService.getUserIntros(discordId, guildId)
 
@@ -278,7 +283,7 @@ class IntroWebServiceTest {
         verify { musicFileService.deleteMusicFileById("${guildId}_${discordId}_1") }
     }
 
-    // getYouTubeVideoTitle
+    // getYouTubeVideoTitle (back-compat)
 
     @Test
     fun `getYouTubeVideoTitle returns null when no YouTube video ID found`() {
@@ -286,7 +291,7 @@ class IntroWebServiceTest {
         assertNull(service.getYouTubeVideoTitle("https://example.com/audio.mp3"))
     }
 
-    // setIntroByUrl — title stored as fileName
+    // setIntroByUrl — title stored as fileName via fetchYouTubePreview
 
     @Test
     fun `setIntroByUrl stores title as fileName when available`() {
@@ -295,7 +300,12 @@ class IntroWebServiceTest {
         val slot = slot<MusicDto>()
         every { musicFileService.createNewMusicFile(capture(slot)) } returns mockk()
         val spyService = spyk(service)
-        every { spyService.getYouTubeVideoTitle(any()) } returns "My Video Title"
+        every { spyService.fetchYouTubePreview(any()) } returns web.service.YouTubePreview(
+            videoId = "dQw4w9WgXcQ",
+            title = "My Video Title",
+            thumbnailUrl = null,
+            durationSeconds = null
+        )
 
         val error = spyService.setIntroByUrl(discordId, guildId, "https://www.youtube.com/watch?v=dQw4w9WgXcQ", 90, null)
 
@@ -304,14 +314,14 @@ class IntroWebServiceTest {
     }
 
     @Test
-    fun `setIntroByUrl falls back to URL as fileName when title lookup returns null`() {
+    fun `setIntroByUrl falls back to URL as fileName when preview returns null`() {
         val url = "https://example.com/audio.mp3"
         val user = UserDto(discordId = discordId, guildId = guildId)
         every { userService.getUserById(discordId, guildId) } returns user
         val slot = slot<MusicDto>()
         every { musicFileService.createNewMusicFile(capture(slot)) } returns mockk()
         val spyService = spyk(service)
-        every { spyService.getYouTubeVideoTitle(any()) } returns null
+        every { spyService.fetchYouTubePreview(any()) } returns null
 
         val error = spyService.setIntroByUrl(discordId, guildId, url, 90, null)
 
@@ -327,10 +337,101 @@ class IntroWebServiceTest {
         val slot = slot<MusicDto>()
         every { musicFileService.createNewMusicFile(capture(slot)) } returns mockk()
         val spyService = spyk(service)
-        every { spyService.getYouTubeVideoTitle(any()) } returns "Never Gonna Give You Up"
+        every { spyService.fetchYouTubePreview(any()) } returns web.service.YouTubePreview(
+            videoId = "dQw4w9WgXcQ",
+            title = "Never Gonna Give You Up",
+            thumbnailUrl = null,
+            durationSeconds = null
+        )
 
         spyService.setIntroByUrl(discordId, guildId, url, 90, null)
 
         assertEquals(url, slot.captured.musicBlob?.let { String(it) })
     }
+
+    @Test
+    fun `setIntroByUrl returns error when YouTube video exceeds duration limit`() {
+        val user = UserDto(discordId = discordId, guildId = guildId)
+        every { userService.getUserById(discordId, guildId) } returns user
+        val spyService = spyk(service)
+        every { spyService.fetchYouTubePreview(any()) } returns web.service.YouTubePreview(
+            videoId = "dQw4w9WgXcQ",
+            title = "Long video",
+            thumbnailUrl = null,
+            durationSeconds = 30
+        )
+
+        val error = spyService.setIntroByUrl(discordId, guildId, "https://www.youtube.com/watch?v=dQw4w9WgXcQ", 90, null)
+
+        assertNotNull(error)
+        assertTrue(error!!.contains("too long"))
+        verify(exactly = 0) { musicFileService.createNewMusicFile(any()) }
+    }
+
+    // updateIntroVolume
+
+    @Test
+    fun `updateIntroVolume returns error when introId does not match prefix`() {
+        assertEquals("Intro does not belong to you.", service.updateIntroVolume(discordId, guildId, "999_000_1", 50))
+    }
+
+    @Test
+    fun `updateIntroVolume returns error when intro not found`() {
+        every { musicFileService.getMusicFileById(any()) } returns null
+        assertEquals("Intro not found.", service.updateIntroVolume(discordId, guildId, "${guildId}_${discordId}_1", 50))
+    }
+
+    @Test
+    fun `updateIntroVolume clamps and persists`() {
+        val dto = MusicDto(id = "${guildId}_${discordId}_1", index = 1, fileName = "a.mp3", introVolume = 50)
+        every { musicFileService.getMusicFileById(any()) } returns dto
+        every { musicFileService.updateMusicFile(any()) } returns dto
+
+        assertNull(service.updateIntroVolume(discordId, guildId, "${guildId}_${discordId}_1", 150))
+        assertEquals(100, dto.introVolume)
+    }
+
+    // updateIntroName
+
+    @Test
+    fun `updateIntroName rejects empty name`() {
+        assertEquals("Name cannot be empty.", service.updateIntroName(discordId, guildId, "${guildId}_${discordId}_1", "  "))
+    }
+
+    @Test
+    fun `updateIntroName rejects ownership mismatch`() {
+        assertEquals("Intro does not belong to you.", service.updateIntroName(discordId, guildId, "999_000_1", "Ok"))
+    }
+
+    @Test
+    fun `updateIntroName persists trimmed name`() {
+        val dto = MusicDto(id = "${guildId}_${discordId}_1", index = 1, fileName = "old.mp3")
+        every { musicFileService.getMusicFileById(any()) } returns dto
+        every { musicFileService.updateMusicFile(any()) } returns dto
+
+        assertNull(service.updateIntroName(discordId, guildId, "${guildId}_${discordId}_1", "  New Name  "))
+        assertEquals("New Name", dto.fileName)
+    }
+
+    // reorderIntros
+
+    @Test
+    fun `reorderIntros rejects ids from another user`() {
+        assertEquals(
+            "One or more intros do not belong to you.",
+            service.reorderIntros(discordId, guildId, listOf("999_000_1"))
+        )
+    }
+
+    @Test
+    fun `reorderIntros rejects mismatched id set`() {
+        val user = UserDto(discordId = discordId, guildId = guildId).apply {
+            musicDtos = mutableListOf(MusicDto(id = "${guildId}_${discordId}_1", index = 1))
+        }
+        every { userService.getUserById(discordId, guildId) } returns user
+
+        val error = service.reorderIntros(discordId, guildId, listOf("${guildId}_${discordId}_2"))
+        assertNotNull(error)
+    }
 }
+

--- a/web/src/main/kotlin/web/controller/BotController.kt
+++ b/web/src/main/kotlin/web/controller/BotController.kt
@@ -33,13 +33,14 @@ class BotController(
     @GetMapping("/music")
     fun getMusicBlob(
         @RequestParam("id") id: String,
-        @RequestHeader(value = HttpHeaders.IF_NONE_MATCH, required = false) ifNoneMatch: String?
+        @RequestHeader(value = HttpHeaders.IF_NONE_MATCH, required = false) ifNoneMatch: String? = null
     ): ResponseEntity<ByteArray> {
         val dto = musicFileService.getMusicFileById(id) ?: return ResponseEntity.notFound().build()
         val blob = dto.musicBlob ?: return ResponseEntity.notFound().build()
 
         // Use hash as ETag when available; fall back to id.
-        val etag = "\"${dto.musicBlobHash ?: id}\""
+        val hash = runCatching { dto.musicBlobHash }.getOrNull()
+        val etag = "\"${hash ?: id}\""
         val cache = CacheControl.maxAge(1, TimeUnit.HOURS).cachePrivate().mustRevalidate()
 
         if (ifNoneMatch != null && ifNoneMatch == etag) {

--- a/web/src/main/kotlin/web/controller/BotController.kt
+++ b/web/src/main/kotlin/web/controller/BotController.kt
@@ -5,9 +5,12 @@ import database.service.BrotherService
 import database.service.ConfigService
 import database.service.MusicFileService
 import database.service.UserService
+import org.springframework.http.CacheControl
+import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
+import java.util.concurrent.TimeUnit
 
 @RestController
 @RequestMapping("/")
@@ -28,10 +31,24 @@ class BotController(
 
 
     @GetMapping("/music")
-    fun getMusicBlob(@RequestParam("id") id: String): ResponseEntity<ByteArray> {
-        val blob = musicFileService.getMusicFileById(id)?.musicBlob
-            ?: return ResponseEntity.notFound().build()
+    fun getMusicBlob(
+        @RequestParam("id") id: String,
+        @RequestHeader(value = HttpHeaders.IF_NONE_MATCH, required = false) ifNoneMatch: String?
+    ): ResponseEntity<ByteArray> {
+        val dto = musicFileService.getMusicFileById(id) ?: return ResponseEntity.notFound().build()
+        val blob = dto.musicBlob ?: return ResponseEntity.notFound().build()
+
+        // Use hash as ETag when available; fall back to id.
+        val etag = "\"${dto.musicBlobHash ?: id}\""
+        val cache = CacheControl.maxAge(1, TimeUnit.HOURS).cachePrivate().mustRevalidate()
+
+        if (ifNoneMatch != null && ifNoneMatch == etag) {
+            return ResponseEntity.status(304).eTag(etag).cacheControl(cache).build()
+        }
+
         return ResponseEntity.ok()
+            .eTag(etag)
+            .cacheControl(cache)
             .contentType(MediaType.parseMediaType("audio/mpeg"))
             .body(blob)
     }

--- a/web/src/main/kotlin/web/controller/IntroWebController.kt
+++ b/web/src/main/kotlin/web/controller/IntroWebController.kt
@@ -1,16 +1,17 @@
 package web.controller
 
+import database.dto.MusicDto
+import database.service.MusicFileService
+import jakarta.servlet.http.HttpSession
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClient
 import org.springframework.security.oauth2.client.annotation.RegisteredOAuth2AuthorizedClient
 import org.springframework.security.oauth2.core.user.OAuth2User
 import org.springframework.stereotype.Controller
 import org.springframework.ui.Model
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.*
 import org.springframework.web.multipart.MultipartFile
 import org.springframework.web.servlet.mvc.support.RedirectAttributes
 import web.service.IntroWebService
@@ -18,8 +19,13 @@ import web.service.IntroWebService
 @Controller
 @RequestMapping("/intro")
 class IntroWebController(
-    private val introWebService: IntroWebService
+    private val introWebService: IntroWebService,
+    private val musicFileService: MusicFileService,
+    @param:Value($$"${spring.security.oauth2.client.registration.discord.client-id}")
+    private val discordClientId: String
 ) {
+    private val inviteUrl: String
+        get() = "https://discord.com/api/oauth2/authorize?client_id=$discordClientId&permissions=8&scope=bot%20applications.commands"
 
     @GetMapping("/guilds")
     fun guildList(
@@ -28,11 +34,20 @@ class IntroWebController(
         model: Model
     ): String {
         val accessToken = client.accessToken.tokenValue
+        val discordId = user.getAttribute<String>("id")?.toLongOrNull()
         val guilds = introWebService.getMutualGuilds(accessToken)
 
+        val counts: Map<String, Int> = if (discordId != null) {
+            introWebService.getIntroCountsForGuilds(discordId, guilds.map { it.id.toLong() })
+                .mapKeys { it.key.toString() }
+        } else emptyMap()
+
         model.addAttribute("guilds", guilds)
+        model.addAttribute("introCounts", counts)
+        model.addAttribute("maxIntros", IntroWebService.MAX_INTRO_COUNT)
         model.addAttribute("username", user.getAttribute<String>("username") ?: "User")
         model.addAttribute("discordId", user.getAttribute<String>("id") ?: "")
+        model.addAttribute("inviteUrl", inviteUrl)
 
         return "guilds"
     }
@@ -40,11 +55,12 @@ class IntroWebController(
     @GetMapping("/{guildId}")
     fun introPage(
         @PathVariable guildId: Long,
+        @RequestParam(required = false) targetDiscordId: Long?,
         @AuthenticationPrincipal user: OAuth2User,
         model: Model,
         ra: RedirectAttributes
     ): String {
-        val discordId = user.getAttribute<String>("id")?.toLongOrNull()
+        val authDiscordId = user.getAttribute<String>("id")?.toLongOrNull()
             ?: return "redirect:/intro/guilds"
 
         val guildName = introWebService.getGuildName(guildId) ?: run {
@@ -52,7 +68,11 @@ class IntroWebController(
             return "redirect:/intro/guilds"
         }
 
-        val intros = introWebService.getUserIntros(discordId, guildId)
+        val isSuperUser = introWebService.isSuperUser(authDiscordId, guildId)
+        val effectiveDiscordId = if (isSuperUser && targetDiscordId != null) targetDiscordId else authDiscordId
+        val members = if (isSuperUser) introWebService.getGuildMembers(guildId) else emptyList()
+
+        val intros = introWebService.getUserIntros(effectiveDiscordId, guildId)
 
         model.addAttribute("guildId", guildId)
         model.addAttribute("guildName", guildName)
@@ -60,6 +80,12 @@ class IntroWebController(
         model.addAttribute("username", user.getAttribute<String>("username") ?: "User")
         model.addAttribute("atLimit", intros.size >= IntroWebService.MAX_INTRO_COUNT)
         model.addAttribute("maxIntros", IntroWebService.MAX_INTRO_COUNT)
+        model.addAttribute("maxFileKb", IntroWebService.MAX_FILE_SIZE / 1024)
+        model.addAttribute("maxDurationSeconds", IntroWebService.MAX_INTRO_DURATION_SECONDS)
+        model.addAttribute("isSuperUser", isSuperUser)
+        model.addAttribute("members", members)
+        model.addAttribute("targetDiscordId", if (isSuperUser) targetDiscordId else null)
+        model.addAttribute("effectiveDiscordId", effectiveDiscordId)
 
         return "intros"
     }
@@ -73,16 +99,18 @@ class IntroWebController(
         @RequestParam(required = false) file: MultipartFile?,
         @RequestParam(defaultValue = "90") volume: Int,
         @RequestParam(required = false) replaceIndex: Int?,
+        @RequestParam(required = false) targetDiscordId: Long?,
         ra: RedirectAttributes
     ): String {
-        val discordId = user.getAttribute<String>("id")?.toLongOrNull()
+        val authDiscordId = user.getAttribute<String>("id")?.toLongOrNull()
             ?: return "redirect:/intro/guilds"
+        val effectiveDiscordId = resolveEffectiveDiscordId(authDiscordId, guildId, targetDiscordId)
 
         val clampedVolume = volume.coerceIn(1, 100)
         val error: String? = when (inputType) {
-            "url" -> introWebService.setIntroByUrl(discordId, guildId, url.orEmpty().trim(), clampedVolume, replaceIndex)
+            "url" -> introWebService.setIntroByUrl(effectiveDiscordId, guildId, url.orEmpty().trim(), clampedVolume, replaceIndex)
             "file" -> if (file != null && !file.isEmpty) {
-                introWebService.setIntroByFile(discordId, guildId, file, clampedVolume, replaceIndex)
+                introWebService.setIntroByFile(effectiveDiscordId, guildId, file, clampedVolume, replaceIndex)
             } else {
                 "No file provided."
             }
@@ -95,7 +123,7 @@ class IntroWebController(
             ra.addFlashAttribute("success", "Intro saved successfully.")
         }
 
-        return "redirect:/intro/$guildId"
+        return redirectToIntroPage(guildId, authDiscordId, targetDiscordId)
     }
 
     @PostMapping("/{guildId}/delete/{introId:.+}")
@@ -103,18 +131,193 @@ class IntroWebController(
         @PathVariable guildId: Long,
         @PathVariable introId: String,
         @AuthenticationPrincipal user: OAuth2User,
+        @RequestParam(required = false) targetDiscordId: Long?,
+        session: HttpSession,
         ra: RedirectAttributes
     ): String {
-        val discordId = user.getAttribute<String>("id")?.toLongOrNull()
+        val authDiscordId = user.getAttribute<String>("id")?.toLongOrNull()
             ?: return "redirect:/intro/guilds"
+        val effectiveDiscordId = resolveEffectiveDiscordId(authDiscordId, guildId, targetDiscordId)
 
-        val error = introWebService.deleteIntro(discordId, guildId, introId)
+        // Snapshot the DTO before deletion so undo can restore it.
+        val snapshot = musicFileService.getMusicFileById(introId)?.let {
+            DeletedIntroSnapshot(
+                id = it.id.orEmpty(),
+                index = it.index ?: 1,
+                fileName = it.fileName,
+                introVolume = it.introVolume ?: 90,
+                musicBlob = it.musicBlob?.copyOf(),
+                discordId = effectiveDiscordId,
+                guildId = guildId,
+                timestampMs = System.currentTimeMillis()
+            )
+        }
+
+        val error = introWebService.deleteIntro(effectiveDiscordId, guildId, introId)
         if (error != null) {
             ra.addFlashAttribute("error", error)
         } else {
+            if (snapshot != null) session.setAttribute(undoKey(guildId, effectiveDiscordId), snapshot)
             ra.addFlashAttribute("success", "Intro deleted.")
+            ra.addFlashAttribute("undoDelete", true)
         }
 
-        return "redirect:/intro/$guildId"
+        return redirectToIntroPage(guildId, authDiscordId, targetDiscordId)
     }
+
+    @PostMapping("/{guildId}/undo-delete")
+    fun undoDelete(
+        @PathVariable guildId: Long,
+        @AuthenticationPrincipal user: OAuth2User,
+        @RequestParam(required = false) targetDiscordId: Long?,
+        session: HttpSession,
+        ra: RedirectAttributes
+    ): String {
+        val authDiscordId = user.getAttribute<String>("id")?.toLongOrNull()
+            ?: return "redirect:/intro/guilds"
+        val effectiveDiscordId = resolveEffectiveDiscordId(authDiscordId, guildId, targetDiscordId)
+
+        val key = undoKey(guildId, effectiveDiscordId)
+        val snapshot = session.getAttribute(key) as? DeletedIntroSnapshot
+        session.removeAttribute(key)
+
+        if (snapshot == null) {
+            ra.addFlashAttribute("error", "Nothing to undo.")
+            return redirectToIntroPage(guildId, authDiscordId, targetDiscordId)
+        }
+
+        // 10 minute undo window
+        if (System.currentTimeMillis() - snapshot.timestampMs > 10 * 60 * 1000) {
+            ra.addFlashAttribute("error", "Undo window has expired.")
+            return redirectToIntroPage(guildId, authDiscordId, targetDiscordId)
+        }
+
+        val dbUser = introWebService.getOrCreateUser(effectiveDiscordId, guildId)
+        if (dbUser.musicDtos.size >= IntroWebService.MAX_INTRO_COUNT) {
+            ra.addFlashAttribute("error", "Cannot restore — intro limit already reached.")
+            return redirectToIntroPage(guildId, authDiscordId, targetDiscordId)
+        }
+
+        val targetIndex = if (dbUser.musicDtos.none { it.index == snapshot.index }) {
+            snapshot.index
+        } else {
+            (dbUser.musicDtos.map { it.index ?: 0 }.maxOrNull() ?: 0) + 1
+        }
+        val restored = MusicDto(dbUser, targetIndex, snapshot.fileName, snapshot.introVolume, snapshot.musicBlob)
+        musicFileService.createNewMusicFile(restored)
+
+        ra.addFlashAttribute("success", "Intro restored.")
+        return redirectToIntroPage(guildId, authDiscordId, targetDiscordId)
+    }
+
+    @PostMapping("/{guildId}/update-volume", consumes = ["application/json"])
+    @ResponseBody
+    fun updateVolume(
+        @PathVariable guildId: Long,
+        @RequestBody body: UpdateVolumeRequest,
+        @AuthenticationPrincipal user: OAuth2User,
+        @RequestParam(required = false) targetDiscordId: Long?
+    ): ResponseEntity<ApiResult> {
+        val authDiscordId = user.getAttribute<String>("id")?.toLongOrNull()
+            ?: return ResponseEntity.status(401).body(ApiResult(false, "Not signed in."))
+        val effective = resolveEffectiveDiscordId(authDiscordId, guildId, targetDiscordId)
+        val error = introWebService.updateIntroVolume(effective, guildId, body.introId, body.volume)
+        return if (error != null) ResponseEntity.badRequest().body(ApiResult(false, error))
+        else ResponseEntity.ok(ApiResult(true, null))
+    }
+
+    @PostMapping("/{guildId}/update-name", consumes = ["application/json"])
+    @ResponseBody
+    fun updateName(
+        @PathVariable guildId: Long,
+        @RequestBody body: UpdateNameRequest,
+        @AuthenticationPrincipal user: OAuth2User,
+        @RequestParam(required = false) targetDiscordId: Long?
+    ): ResponseEntity<ApiResult> {
+        val authDiscordId = user.getAttribute<String>("id")?.toLongOrNull()
+            ?: return ResponseEntity.status(401).body(ApiResult(false, "Not signed in."))
+        val effective = resolveEffectiveDiscordId(authDiscordId, guildId, targetDiscordId)
+        val error = introWebService.updateIntroName(effective, guildId, body.introId, body.name)
+        return if (error != null) ResponseEntity.badRequest().body(ApiResult(false, error))
+        else ResponseEntity.ok(ApiResult(true, null))
+    }
+
+    @PostMapping("/{guildId}/reorder", consumes = ["application/json"])
+    @ResponseBody
+    fun reorder(
+        @PathVariable guildId: Long,
+        @RequestBody body: ReorderRequest,
+        @AuthenticationPrincipal user: OAuth2User,
+        @RequestParam(required = false) targetDiscordId: Long?
+    ): ResponseEntity<ApiResult> {
+        val authDiscordId = user.getAttribute<String>("id")?.toLongOrNull()
+            ?: return ResponseEntity.status(401).body(ApiResult(false, "Not signed in."))
+        val effective = resolveEffectiveDiscordId(authDiscordId, guildId, targetDiscordId)
+        val error = introWebService.reorderIntros(effective, guildId, body.orderedIds)
+        return if (error != null) ResponseEntity.badRequest().body(ApiResult(false, error))
+        else ResponseEntity.ok(ApiResult(true, null))
+    }
+
+    @GetMapping("/preview")
+    @ResponseBody
+    fun preview(@RequestParam url: String): ResponseEntity<PreviewResponse> {
+        if (url.isBlank()) return ResponseEntity.badRequest()
+            .body(PreviewResponse(false, null, null, null, null, "URL is required."))
+        val preview = introWebService.fetchYouTubePreview(url.trim())
+            ?: return ResponseEntity.ok(
+                PreviewResponse(true, null, null, null, null, "Not a YouTube URL — title/duration unavailable.")
+            )
+        val tooLong = preview.durationSeconds != null && preview.durationSeconds > IntroWebService.MAX_INTRO_DURATION_SECONDS
+        return ResponseEntity.ok(
+            PreviewResponse(
+                ok = !tooLong,
+                videoId = preview.videoId,
+                title = preview.title,
+                thumbnailUrl = preview.thumbnailUrl,
+                durationSeconds = preview.durationSeconds,
+                error = if (tooLong) "Video is too long (${preview.durationSeconds}s). Max allowed is ${IntroWebService.MAX_INTRO_DURATION_SECONDS}s." else null
+            )
+        )
+    }
+
+    private fun resolveEffectiveDiscordId(authDiscordId: Long, guildId: Long, targetDiscordId: Long?): Long {
+        if (targetDiscordId == null || targetDiscordId == authDiscordId) return authDiscordId
+        return if (introWebService.isSuperUser(authDiscordId, guildId)) targetDiscordId else authDiscordId
+    }
+
+    private fun redirectToIntroPage(guildId: Long, authDiscordId: Long, targetDiscordId: Long?): String {
+        return if (targetDiscordId != null && targetDiscordId != authDiscordId) {
+            "redirect:/intro/$guildId?targetDiscordId=$targetDiscordId"
+        } else {
+            "redirect:/intro/$guildId"
+        }
+    }
+
+    private fun undoKey(guildId: Long, discordId: Long) = "undoDelete:$guildId:$discordId"
 }
+
+data class UpdateVolumeRequest(val introId: String = "", val volume: Int = 0)
+data class UpdateNameRequest(val introId: String = "", val name: String = "")
+data class ReorderRequest(val orderedIds: List<String> = emptyList())
+
+data class ApiResult(val ok: Boolean, val error: String?)
+
+data class PreviewResponse(
+    val ok: Boolean,
+    val videoId: String?,
+    val title: String?,
+    val thumbnailUrl: String?,
+    val durationSeconds: Int?,
+    val error: String?
+)
+
+data class DeletedIntroSnapshot(
+    val id: String,
+    val index: Int,
+    val fileName: String?,
+    val introVolume: Int,
+    val musicBlob: ByteArray?,
+    val discordId: Long,
+    val guildId: Long,
+    val timestampMs: Long
+) : java.io.Serializable

--- a/web/src/main/kotlin/web/service/IntroWebService.kt
+++ b/web/src/main/kotlin/web/service/IntroWebService.kt
@@ -83,7 +83,18 @@ class IntroWebService(
         return user.musicDtos.sortedBy { it.index }.map { dto ->
             val blobAsString = dto.musicBlob?.let { String(it) }.orEmpty()
             val url = blobAsString.takeIf { it.startsWith("http://") || it.startsWith("https://") }
-            val displayName = dto.fileName
+            val displayName = if (url != null && dto.fileName?.startsWith("http") == true) {
+                // Legacy record: fileName was stored as the raw URL instead of a title.
+                // Look up the video title and lazily migrate the record.
+                val title = getYouTubeVideoTitle(url)
+                if (title != null) {
+                    dto.fileName = title
+                    musicFileService.updateMusicFile(dto)
+                }
+                title ?: dto.fileName
+            } else {
+                dto.fileName
+            }
             val thumbnailUrl = url?.let { extractVideoId(it) }?.let { "https://img.youtube.com/vi/$it/mqdefault.jpg" }
             IntroViewModel(dto.id.orEmpty(), dto.index, displayName, dto.introVolume, url, thumbnailUrl)
         }
@@ -261,6 +272,12 @@ class IntroWebService(
             )
         }
     }
+
+    /**
+     * Back-compat helper used by legacy tests. Returns the YouTube video title or null.
+     * New code should prefer [fetchYouTubePreview] which also returns thumbnail + duration.
+     */
+    fun getYouTubeVideoTitle(url: String): String? = fetchYouTubePreview(url)?.title
 
     private fun extractVideoId(url: String): String? {
         val regex = Regex("(?<=v=|/videos/|embed/|youtu\\.be/|/v/|/e/|watch\\?v=|&v=|^youtu\\.be/)([^#&?\\n]+)")

--- a/web/src/main/kotlin/web/service/IntroWebService.kt
+++ b/web/src/main/kotlin/web/service/IntroWebService.kt
@@ -21,6 +21,7 @@ class IntroWebService(
     companion object {
         const val MAX_FILE_SIZE = 550 * 1024
         const val MAX_INTRO_COUNT = 3
+        const val MAX_INTRO_DURATION_SECONDS = 15
         private val objectMapper = ObjectMapper()
     }
 
@@ -48,6 +49,30 @@ class IntroWebService(
 
     fun getGuildName(guildId: Long): String? = jda.getGuildById(guildId)?.name
 
+    fun getGuildMembers(guildId: Long): List<MemberInfo> {
+        val guild = jda.getGuildById(guildId) ?: return emptyList()
+        return guild.members
+            .filter { !it.user.isBot }
+            .map {
+                MemberInfo(
+                    id = it.id,
+                    name = it.effectiveName,
+                    avatarUrl = it.effectiveAvatarUrl
+                )
+            }
+            .sortedBy { it.name.lowercase() }
+    }
+
+    fun isSuperUser(discordId: Long, guildId: Long): Boolean {
+        return userService.getUserById(discordId, guildId)?.superUser == true
+    }
+
+    fun getIntroCountsForGuilds(discordId: Long, guildIds: List<Long>): Map<Long, Int> {
+        return guildIds.associateWith { gid ->
+            userService.getUserById(discordId, gid)?.musicDtos?.size ?: 0
+        }
+    }
+
     fun getOrCreateUser(discordId: Long, guildId: Long): UserDto {
         return userService.getUserById(discordId, guildId)
             ?: UserDto(discordId = discordId, guildId = guildId).also { userService.createNewUser(it) }
@@ -58,19 +83,9 @@ class IntroWebService(
         return user.musicDtos.sortedBy { it.index }.map { dto ->
             val blobAsString = dto.musicBlob?.let { String(it) }.orEmpty()
             val url = blobAsString.takeIf { it.startsWith("http://") || it.startsWith("https://") }
-            val displayName = if (url != null && dto.fileName?.startsWith("http") == true) {
-                // Legacy record: fileName was stored as the raw URL instead of a title.
-                // Look up the video title and lazily migrate the record.
-                val title = getYouTubeVideoTitle(url)
-                if (title != null) {
-                    dto.fileName = title
-                    musicFileService.updateMusicFile(dto)
-                }
-                title ?: dto.fileName
-            } else {
-                dto.fileName
-            }
-            IntroViewModel(dto.id.orEmpty(), dto.index, displayName, dto.introVolume, url)
+            val displayName = dto.fileName
+            val thumbnailUrl = url?.let { extractVideoId(it) }?.let { "https://img.youtube.com/vi/$it/mqdefault.jpg" }
+            IntroViewModel(dto.id.orEmpty(), dto.index, displayName, dto.introVolume, url, thumbnailUrl)
         }
     }
 
@@ -84,8 +99,12 @@ class IntroWebService(
             return "You already have $MAX_INTRO_COUNT intros. Please select one to replace."
         }
 
-        val title = getYouTubeVideoTitle(url)
-        val displayName = title ?: url
+        val preview = fetchYouTubePreview(url)
+        if (preview?.durationSeconds != null && preview.durationSeconds > MAX_INTRO_DURATION_SECONDS) {
+            return "Video is too long (${preview.durationSeconds}s). Max allowed is ${MAX_INTRO_DURATION_SECONDS}s."
+        }
+
+        val displayName = preview?.title ?: url
         val urlBytes = url.toByteArray()
         val selectedDto = replaceIndex?.let { idx -> existingIntros.find { it.index == idx } }
 
@@ -149,18 +168,97 @@ class IntroWebService(
         return null
     }
 
-    fun getYouTubeVideoTitle(url: String): String? {
+    fun updateIntroVolume(discordId: Long, guildId: Long, introId: String, volume: Int): String? {
+        val expectedPrefix = "${guildId}_${discordId}_"
+        if (!introId.startsWith(expectedPrefix)) return "Intro does not belong to you."
+
+        val dto = musicFileService.getMusicFileById(introId) ?: return "Intro not found."
+        dto.introVolume = volume.coerceIn(1, 100)
+        musicFileService.updateMusicFile(dto)
+        return null
+    }
+
+    fun updateIntroName(discordId: Long, guildId: Long, introId: String, name: String): String? {
+        val expectedPrefix = "${guildId}_${discordId}_"
+        if (!introId.startsWith(expectedPrefix)) return "Intro does not belong to you."
+        val trimmed = name.trim()
+        if (trimmed.isEmpty()) return "Name cannot be empty."
+        if (trimmed.length > 200) return "Name is too long (max 200 characters)."
+
+        val dto = musicFileService.getMusicFileById(introId) ?: return "Intro not found."
+        dto.fileName = trimmed
+        musicFileService.updateMusicFile(dto)
+        return null
+    }
+
+    /**
+     * Reassign the `index` field across the caller's intros to match the supplied id ordering.
+     * The rest of the bot selects randomly between intros so order is purely organisational.
+     */
+    fun reorderIntros(discordId: Long, guildId: Long, orderedIds: List<String>): String? {
+        val expectedPrefix = "${guildId}_${discordId}_"
+        if (orderedIds.any { !it.startsWith(expectedPrefix) }) return "One or more intros do not belong to you."
+
+        val user = userService.getUserById(discordId, guildId) ?: return "User not found."
+        val currentIds = user.musicDtos.map { it.id }.toSet()
+        if (orderedIds.toSet() != currentIds) return "Reorder list does not match your intros."
+
+        // Two-phase rename: stash as negative temp indexes first to avoid unique-key collisions,
+        // then assign the final 1..N indexes.
+        orderedIds.forEachIndexed { idx, id ->
+            musicFileService.getMusicFileById(id)?.let { dto ->
+                dto.index = -(idx + 1)
+                musicFileService.updateMusicFile(dto)
+            }
+        }
+        orderedIds.forEachIndexed { idx, id ->
+            musicFileService.getMusicFileById(id)?.let { dto ->
+                dto.index = idx + 1
+                musicFileService.updateMusicFile(dto)
+            }
+        }
+        return null
+    }
+
+    /** Public preview used by the web form to pre-flight a URL. */
+    fun fetchYouTubePreview(url: String): YouTubePreview? {
         val videoId = extractVideoId(url) ?: return null
-        val apiKey = System.getenv("YOUTUBE_API_KEY") ?: return null
+        val apiKey = System.getenv("YOUTUBE_API_KEY")
+            ?: return YouTubePreview(
+                videoId = videoId,
+                title = null,
+                thumbnailUrl = "https://img.youtube.com/vi/$videoId/mqdefault.jpg",
+                durationSeconds = null
+            )
         return try {
-            val apiUrl = "https://www.googleapis.com/youtube/v3/videos?id=$videoId&part=snippet&key=$apiKey"
+            val apiUrl = "https://www.googleapis.com/youtube/v3/videos" +
+                "?id=$videoId&part=snippet,contentDetails&key=$apiKey"
             val connection = URL(apiUrl).openConnection() as HttpURLConnection
-            if (connection.responseCode != 200) return null
+            if (connection.responseCode != 200) {
+                return YouTubePreview(
+                    videoId = videoId,
+                    title = null,
+                    thumbnailUrl = "https://img.youtube.com/vi/$videoId/mqdefault.jpg",
+                    durationSeconds = null
+                )
+            }
             val body = connection.inputStream.bufferedReader().readText()
-            objectMapper.readTree(body).path("items").firstOrNull()?.path("snippet")?.path("title")?.asText()
-                ?.takeIf { it.isNotBlank() }
+            val item = objectMapper.readTree(body).path("items").firstOrNull() ?: return null
+            val snippet = item.path("snippet")
+            val title = snippet.path("title").asText().takeIf { it.isNotBlank() }
+            val thumb = snippet.path("thumbnails").let {
+                it.path("medium").path("url").asText().takeIf { s -> s.isNotBlank() }
+                    ?: it.path("default").path("url").asText().takeIf { s -> s.isNotBlank() }
+            } ?: "https://img.youtube.com/vi/$videoId/mqdefault.jpg"
+            val duration = parseIsoDurationSeconds(item.path("contentDetails").path("duration").asText())
+            YouTubePreview(videoId, title, thumb, duration)
         } catch (_: Exception) {
-            null
+            YouTubePreview(
+                videoId = videoId,
+                title = null,
+                thumbnailUrl = "https://img.youtube.com/vi/$videoId/mqdefault.jpg",
+                durationSeconds = null
+            )
         }
     }
 
@@ -177,6 +275,17 @@ class IntroWebService(
             false
         }
     }
+
+    /** Parses ISO-8601 durations like "PT1M3S" or "PT15S" into seconds. Returns null if unparseable. */
+    private fun parseIsoDurationSeconds(iso: String?): Int? {
+        if (iso.isNullOrBlank()) return null
+        val regex = Regex("PT(?:(\\d+)H)?(?:(\\d+)M)?(?:(\\d+)S)?")
+        val match = regex.matchEntire(iso) ?: return null
+        val (h, m, s) = match.destructured
+        return h.toIntOrNull().orZero() * 3600 + m.toIntOrNull().orZero() * 60 + s.toIntOrNull().orZero()
+    }
+
+    private fun Int?.orZero(): Int = this ?: 0
 }
 
 data class IntroViewModel(
@@ -184,7 +293,8 @@ data class IntroViewModel(
     val index: Int?,
     val fileName: String?,
     val introVolume: Int?,
-    val url: String?
+    val url: String?,
+    val thumbnailUrl: String? = null
 )
 
 data class GuildInfo(
@@ -195,3 +305,16 @@ data class GuildInfo(
     val iconUrl: String?
         get() = iconHash?.let { "https://cdn.discordapp.com/icons/$id/$it.png?size=64" }
 }
+
+data class MemberInfo(
+    val id: String,
+    val name: String,
+    val avatarUrl: String?
+)
+
+data class YouTubePreview(
+    val videoId: String,
+    val title: String?,
+    val thumbnailUrl: String?,
+    val durationSeconds: Int?
+)

--- a/web/src/main/resources/static/css/base.css
+++ b/web/src/main/resources/static/css/base.css
@@ -1,0 +1,398 @@
+/* ---- Design tokens ---- */
+:root {
+    --bg: #1a1a2e;
+    --bg-elevated: #16213e;
+    --bg-input: #1a1a2e;
+    --border: #2a2a4a;
+    --border-strong: #3a3a5a;
+    --accent: #5865F2;
+    --accent-hover: #4752c4;
+    --accent-soft: rgba(88, 101, 242, 0.12);
+    --text: #e0e0e0;
+    --text-muted: #a0a0b0;
+    --text-dim: #7a7a8a;
+    --danger: #e74c3c;
+    --danger-bg: #4a1a1a;
+    --danger-border: #c0392b;
+    --success: #2ecc71;
+    --success-bg: #1a4a2a;
+    --success-border: #27ae60;
+    --radius-sm: 6px;
+    --radius-md: 8px;
+    --radius-lg: 10px;
+    --space-1: 4px;
+    --space-2: 8px;
+    --space-3: 12px;
+    --space-4: 16px;
+    --space-5: 20px;
+    --space-6: 24px;
+    --space-8: 32px;
+    --space-10: 40px;
+    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.2);
+    --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.3);
+    --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.45);
+}
+
+/* ---- Reset ---- */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+html { color-scheme: dark; }
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    min-height: 100vh;
+    line-height: 1.5;
+    -webkit-font-smoothing: antialiased;
+}
+
+/* ---- Layout ---- */
+.container { max-width: 900px; margin: 40px auto; padding: 0 var(--space-6); }
+.container-wide { max-width: 1100px; margin: 40px auto; padding: 0 var(--space-6); }
+
+h1 { font-size: 1.6rem; color: #fff; }
+h2 { font-size: 1.1rem; color: #c0c0d0; }
+h3 { font-size: 1rem; color: #c0c0d0; }
+p  { color: var(--text); }
+
+.muted { color: var(--text-muted); }
+.dim   { color: var(--text-dim); }
+.hint  { font-size: 0.8rem; color: var(--text-dim); margin-top: var(--space-1); }
+
+/* ---- Skip link (a11y) ---- */
+.skip-link {
+    position: absolute;
+    left: -9999px;
+    top: 0;
+    background: var(--accent);
+    color: #fff;
+    padding: 8px 14px;
+    border-radius: var(--radius-sm);
+    z-index: 1000;
+}
+.skip-link:focus { left: 12px; top: 12px; }
+
+/* ---- Focus ring ---- */
+:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+    border-radius: 2px;
+}
+
+/* ---- Links ---- */
+a { color: var(--accent); text-decoration: none; }
+a:hover { color: var(--accent-hover); }
+
+/* ---- Buttons ---- */
+.btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--space-2);
+    background: var(--accent);
+    color: #fff;
+    border: 1px solid transparent;
+    padding: 10px 20px;
+    border-radius: var(--radius-md);
+    font-size: 0.95rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.15s, border-color 0.15s, color 0.15s, transform 0.05s;
+    text-decoration: none;
+    font-family: inherit;
+}
+.btn:hover:not(:disabled) { background: var(--accent-hover); }
+.btn:active:not(:disabled) { transform: translateY(1px); }
+.btn:disabled { opacity: 0.55; cursor: not-allowed; }
+
+.btn-secondary {
+    background: transparent;
+    color: var(--text);
+    border-color: var(--border-strong);
+}
+.btn-secondary:hover:not(:disabled) { background: var(--accent-soft); border-color: var(--accent); color: #fff; }
+
+.btn-danger {
+    background: transparent;
+    color: var(--danger);
+    border-color: var(--danger-border);
+}
+.btn-danger:hover:not(:disabled) { background: var(--danger-border); color: #fff; }
+
+.btn-ghost {
+    background: transparent;
+    color: var(--text-muted);
+    border-color: transparent;
+    padding: 6px 10px;
+}
+.btn-ghost:hover:not(:disabled) { color: #fff; background: var(--accent-soft); }
+
+.btn-sm { padding: 6px 12px; font-size: 0.85rem; }
+.btn-icon { width: 34px; height: 34px; padding: 0; border-radius: 50%; }
+
+.btn[aria-busy="true"] {
+    pointer-events: none;
+    position: relative;
+    color: transparent !important;
+}
+.btn[aria-busy="true"]::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    margin: auto;
+    width: 16px; height: 16px;
+    border: 2px solid rgba(255, 255, 255, 0.3);
+    border-top-color: #fff;
+    border-radius: 50%;
+    animation: spin 0.7s linear infinite;
+}
+@keyframes spin { to { transform: rotate(360deg); } }
+
+/* ---- Forms ---- */
+.form-group { margin-bottom: var(--space-5); }
+.form-group-inline { display: flex; align-items: center; gap: var(--space-3); }
+
+label {
+    display: block;
+    margin-bottom: var(--space-2);
+    font-size: 0.9rem;
+    color: var(--text-muted);
+    font-weight: 500;
+}
+
+input[type=text], input[type=url], input[type=number], input[type=search],
+input[type=email], input[type=password], select, textarea {
+    width: 100%;
+    background: var(--bg-input);
+    border: 1px solid var(--border-strong);
+    color: var(--text);
+    padding: 10px 12px;
+    border-radius: var(--radius-sm);
+    font-size: 0.95rem;
+    font-family: inherit;
+    transition: border-color 0.15s, box-shadow 0.15s;
+}
+input:focus-visible, select:focus-visible, textarea:focus-visible {
+    outline: none;
+    border-color: var(--accent);
+    box-shadow: 0 0 0 3px var(--accent-soft);
+}
+input[aria-invalid="true"], select[aria-invalid="true"] {
+    border-color: var(--danger);
+    box-shadow: 0 0 0 3px rgba(231, 76, 60, 0.12);
+}
+.field-error {
+    display: block;
+    color: var(--danger);
+    font-size: 0.8rem;
+    margin-top: var(--space-1);
+    min-height: 1em;
+}
+
+input[type=range] {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 100%;
+    height: 6px;
+    background: var(--border-strong);
+    border-radius: 3px;
+    outline: none;
+}
+input[type=range]::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 18px; height: 18px;
+    background: var(--accent);
+    border-radius: 50%;
+    cursor: pointer;
+    border: 2px solid #fff2;
+    transition: transform 0.1s;
+}
+input[type=range]::-moz-range-thumb {
+    width: 18px; height: 18px;
+    background: var(--accent);
+    border-radius: 50%;
+    cursor: pointer;
+    border: 2px solid #fff2;
+}
+input[type=range]:hover::-webkit-slider-thumb { transform: scale(1.12); }
+
+/* ---- Segmented control (tabs) ---- */
+.segmented {
+    display: inline-flex;
+    background: var(--bg-input);
+    border: 1px solid var(--border-strong);
+    border-radius: var(--radius-md);
+    padding: 3px;
+    gap: 2px;
+}
+.segmented button {
+    background: transparent;
+    border: none;
+    color: var(--text-muted);
+    padding: 8px 16px;
+    border-radius: var(--radius-sm);
+    font-size: 0.9rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: background 0.15s, color 0.15s;
+    font-family: inherit;
+}
+.segmented button:hover { color: var(--text); }
+.segmented button[aria-pressed="true"] {
+    background: var(--accent);
+    color: #fff;
+}
+
+/* ---- Cards ---- */
+.card {
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    padding: var(--space-6);
+}
+
+/* ---- Alerts (inline, for server-rendered fallback) ---- */
+.alert {
+    padding: 10px 16px;
+    border-radius: var(--radius-sm);
+    margin-bottom: var(--space-5);
+    font-size: 0.9rem;
+    border: 1px solid;
+}
+.alert-error   { background: var(--danger-bg);  border-color: var(--danger-border);  color: var(--danger); }
+.alert-success { background: var(--success-bg); border-color: var(--success-border); color: var(--success); }
+
+/* ---- Toast stack ---- */
+.toast-stack {
+    position: fixed;
+    right: 20px;
+    bottom: 20px;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+    z-index: 500;
+    max-width: min(92vw, 380px);
+}
+.toast {
+    background: var(--bg-elevated);
+    border: 1px solid var(--border-strong);
+    border-radius: var(--radius-md);
+    padding: 12px 16px;
+    color: var(--text);
+    font-size: 0.9rem;
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    box-shadow: var(--shadow-md);
+    animation: toast-in 0.2s ease-out;
+}
+.toast.toast-success { border-left: 3px solid var(--success); }
+.toast.toast-error   { border-left: 3px solid var(--danger); }
+.toast.toast-info    { border-left: 3px solid var(--accent); }
+.toast button.toast-action {
+    background: transparent;
+    border: 1px solid var(--border-strong);
+    color: var(--text);
+    padding: 4px 10px;
+    border-radius: var(--radius-sm);
+    font-size: 0.8rem;
+    cursor: pointer;
+    margin-left: auto;
+}
+.toast button.toast-action:hover { border-color: var(--accent); color: #fff; }
+.toast button.toast-close {
+    background: transparent;
+    border: none;
+    color: var(--text-muted);
+    cursor: pointer;
+    font-size: 1.1rem;
+    line-height: 1;
+    padding: 0 4px;
+}
+.toast button.toast-close:hover { color: #fff; }
+@keyframes toast-in {
+    from { opacity: 0; transform: translateY(8px); }
+    to   { opacity: 1; transform: translateY(0); }
+}
+
+/* ---- Modal ---- */
+.modal-backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(10, 10, 20, 0.65);
+    backdrop-filter: blur(4px);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 600;
+    padding: var(--space-4);
+    animation: fade-in 0.15s ease-out;
+}
+.modal {
+    background: var(--bg-elevated);
+    border: 1px solid var(--border-strong);
+    border-radius: var(--radius-lg);
+    padding: var(--space-6);
+    max-width: 440px;
+    width: 100%;
+    box-shadow: var(--shadow-lg);
+}
+.modal h2 { margin-bottom: var(--space-3); color: #fff; }
+.modal p  { color: var(--text-muted); margin-bottom: var(--space-5); }
+.modal-actions { display: flex; justify-content: flex-end; gap: var(--space-3); }
+@keyframes fade-in { from { opacity: 0; } to { opacity: 1; } }
+
+/* ---- Tables ---- */
+table { width: 100%; border-collapse: collapse; }
+th, td { text-align: left; padding: 12px 16px; border-bottom: 1px solid var(--border); }
+th {
+    color: var(--text-muted);
+    font-size: 0.8rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+td { font-size: 0.95rem; }
+
+/* ---- Utilities ---- */
+.flex { display: flex; }
+.flex-between { display: flex; justify-content: space-between; align-items: center; gap: var(--space-3); }
+.flex-gap-2 { display: flex; gap: var(--space-2); }
+.flex-gap-3 { display: flex; gap: var(--space-3); }
+.items-center { align-items: center; }
+.mt-2 { margin-top: var(--space-2); }
+.mt-3 { margin-top: var(--space-3); }
+.mt-4 { margin-top: var(--space-4); }
+.mt-5 { margin-top: var(--space-5); }
+.mb-3 { margin-bottom: var(--space-3); }
+.mb-4 { margin-bottom: var(--space-4); }
+.mb-5 { margin-bottom: var(--space-5); }
+.mb-8 { margin-bottom: var(--space-8); }
+.sr-only {
+    position: absolute; width: 1px; height: 1px;
+    padding: 0; margin: -1px; overflow: hidden;
+    clip: rect(0,0,0,0); white-space: nowrap; border: 0;
+}
+
+/* ---- Responsive ---- */
+@media (max-width: 640px) {
+    .container, .container-wide { margin: 20px auto; padding: 0 var(--space-4); }
+    h1 { font-size: 1.35rem; }
+    .card { padding: var(--space-5); }
+    .modal { padding: var(--space-5); }
+    table thead { display: none; }
+    table, tbody, tr, td { display: block; width: 100%; }
+    tr { border: 1px solid var(--border); border-radius: var(--radius-md); padding: var(--space-3); margin-bottom: var(--space-3); }
+    td { border: none; padding: 6px 0; }
+    td::before {
+        content: attr(data-label);
+        display: block;
+        color: var(--text-muted);
+        font-size: 0.75rem;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        margin-bottom: 2px;
+    }
+}

--- a/web/src/main/resources/static/css/intros.css
+++ b/web/src/main/resources/static/css/intros.css
@@ -1,0 +1,239 @@
+/* ============================================================
+   Intro page — form, table, drop-zone, preview, inline editing
+   ============================================================ */
+
+.intro-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-4);
+    margin-bottom: var(--space-3);
+    flex-wrap: wrap;
+}
+.intro-header h1 { margin: 0; }
+.slot-count {
+    background: var(--accent-soft);
+    color: var(--accent);
+    padding: 4px 10px;
+    border-radius: 999px;
+    font-size: 0.8rem;
+    font-weight: 600;
+}
+.slot-count.full { color: var(--danger); background: rgba(231, 76, 60, 0.12); }
+
+.random-note {
+    color: var(--text-muted);
+    font-size: 0.85rem;
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-left: 3px solid var(--accent);
+    padding: 10px 14px;
+    border-radius: var(--radius-sm);
+    margin-bottom: var(--space-5);
+}
+
+/* ---- Super-user member picker ---- */
+.member-picker-card {
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    padding: var(--space-4);
+    margin-bottom: var(--space-5);
+}
+.member-picker-card .picker-row { display: flex; gap: var(--space-3); align-items: center; flex-wrap: wrap; }
+.member-picker-card select { max-width: 320px; }
+.member-picker-card .target-badge {
+    background: var(--accent-soft);
+    color: var(--accent);
+    padding: 4px 10px;
+    border-radius: 999px;
+    font-size: 0.8rem;
+    font-weight: 600;
+}
+
+/* ---- Intros table ---- */
+.intros-table { background: var(--bg-elevated); border: 1px solid var(--border); border-radius: var(--radius-lg); overflow: hidden; }
+.intros-table th:first-child { width: 48px; }
+.intros-table td.name-cell { font-weight: 500; }
+.intros-table td.name-cell .thumb {
+    display: inline-block;
+    width: 48px; height: 28px;
+    border-radius: 4px;
+    background-size: cover;
+    background-position: center;
+    margin-right: 10px;
+    vertical-align: middle;
+    background-color: var(--border);
+}
+.intros-table td.actions { text-align: right; white-space: nowrap; }
+.intros-table .drag-handle {
+    cursor: grab;
+    color: var(--text-dim);
+    user-select: none;
+    padding: 0 4px;
+}
+.intros-table .drag-handle:hover { color: var(--text); }
+.intros-table tr.dragging { opacity: 0.45; }
+.intros-table tr.drag-over { box-shadow: inset 0 2px 0 var(--accent); }
+
+/* Inline volume control */
+.volume-inline { display: flex; align-items: center; gap: var(--space-2); min-width: 140px; }
+.volume-inline input[type=range] { flex: 1; }
+.volume-inline .vol-value { font-variant-numeric: tabular-nums; width: 40px; text-align: right; font-size: 0.85rem; color: var(--text-muted); }
+
+/* Play button inside table */
+.btn-play {
+    background: transparent;
+    border: 1px solid var(--accent);
+    color: var(--accent);
+    width: 32px; height: 32px;
+    border-radius: 50%;
+    cursor: pointer;
+    font-size: 0.8rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    transition: background 0.15s, color 0.15s;
+    padding: 0;
+}
+.btn-play:hover { background: var(--accent); color: #fff; }
+.btn-play.playing { border-color: var(--danger); color: var(--danger); }
+.btn-play.playing:hover { background: var(--danger); color: #fff; }
+
+.btn-link-icon {
+    color: var(--text-muted);
+    font-size: 1rem;
+    padding: 0 4px;
+    text-decoration: none;
+}
+.btn-link-icon:hover { color: var(--accent); }
+
+/* Editable name */
+.name-edit-input {
+    width: 100%;
+    max-width: 320px;
+    background: var(--bg-input);
+    border: 1px solid var(--accent);
+    color: var(--text);
+    padding: 6px 10px;
+    border-radius: var(--radius-sm);
+    font-size: 0.95rem;
+    font-family: inherit;
+}
+
+.empty-hero {
+    background: var(--bg-elevated);
+    border: 1px dashed var(--border-strong);
+    border-radius: var(--radius-lg);
+    padding: 40px 24px;
+    text-align: center;
+    color: var(--text-muted);
+}
+.empty-hero .emoji { font-size: 2.2rem; display: block; margin-bottom: 10px; }
+
+/* ============================================================
+   Add / replace form
+   ============================================================ */
+.intro-form { margin-top: var(--space-8); }
+
+.slot-select-row { display: flex; align-items: center; gap: var(--space-3); flex-wrap: wrap; }
+.slot-select-row label { margin: 0; }
+.slot-select-row select { min-width: 220px; }
+
+/* Drop zone */
+.drop-zone {
+    border: 2px dashed var(--border-strong);
+    border-radius: var(--radius-md);
+    padding: 24px;
+    text-align: center;
+    color: var(--text-muted);
+    cursor: pointer;
+    transition: border-color 0.15s, background 0.15s;
+    background: var(--bg-input);
+}
+.drop-zone:hover,
+.drop-zone.drag-active { border-color: var(--accent); background: var(--accent-soft); color: var(--text); }
+.drop-zone .drop-icon { font-size: 2rem; display: block; margin-bottom: 8px; }
+.drop-zone input[type=file] { display: none; }
+.drop-zone .drop-hint { font-size: 0.8rem; color: var(--text-dim); margin-top: 6px; }
+.drop-zone.has-file { border-style: solid; border-color: var(--success-border); background: var(--success-bg); color: var(--text); }
+
+.file-summary {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    margin-top: var(--space-3);
+    padding: 10px 14px;
+    background: var(--bg-input);
+    border: 1px solid var(--border-strong);
+    border-radius: var(--radius-sm);
+}
+.file-summary .file-name { font-weight: 500; flex: 1; word-break: break-all; }
+.file-summary .file-size { color: var(--text-muted); font-size: 0.85rem; }
+.file-summary audio { width: 100%; margin-top: 8px; }
+
+/* YouTube preview card */
+.url-preview {
+    margin-top: var(--space-3);
+    display: none;
+    grid-template-columns: 120px 1fr;
+    gap: var(--space-3);
+    padding: 12px;
+    background: var(--bg-input);
+    border: 1px solid var(--border-strong);
+    border-radius: var(--radius-sm);
+    align-items: center;
+}
+.url-preview.visible { display: grid; }
+.url-preview.error { border-color: var(--danger); background: var(--danger-bg); }
+.url-preview img { width: 120px; height: 68px; object-fit: cover; border-radius: 4px; background: var(--border); }
+.url-preview .preview-body { display: flex; flex-direction: column; gap: 4px; min-width: 0; }
+.url-preview .preview-title {
+    font-weight: 500;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.url-preview .preview-meta { font-size: 0.8rem; color: var(--text-muted); }
+.url-preview .duration-badge {
+    display: inline-block;
+    padding: 2px 8px;
+    background: var(--border);
+    color: var(--text);
+    border-radius: 999px;
+    font-size: 0.75rem;
+    margin-right: 6px;
+}
+.url-preview .duration-badge.too-long { background: var(--danger); color: #fff; }
+
+.form-row-split {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: var(--space-4);
+    align-items: end;
+}
+
+.volume-control {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    padding: 10px 14px;
+    background: var(--bg-input);
+    border: 1px solid var(--border-strong);
+    border-radius: var(--radius-sm);
+}
+.volume-control input[type=range] { flex: 1; min-width: 160px; }
+.volume-control .vol-value {
+    font-variant-numeric: tabular-nums;
+    font-weight: 600;
+    color: var(--text);
+    width: 48px;
+    text-align: right;
+}
+
+@media (max-width: 640px) {
+    .url-preview { grid-template-columns: 1fr; }
+    .url-preview img { width: 100%; height: 140px; }
+    .form-row-split { grid-template-columns: 1fr; }
+    .intros-table td.actions { text-align: left; }
+}

--- a/web/src/main/resources/static/js/intros.js
+++ b/web/src/main/resources/static/js/intros.js
@@ -1,14 +1,25 @@
+/* ============================================================
+   Intro page interactions
+   ============================================================ */
+
+// --- Back-compat helpers (kept for existing jest tests) ---
 function toggleInput(type) {
-    document.getElementById('urlSection').style.display = (type === 'url') ? 'block' : 'none';
-    document.getElementById('fileSection').style.display = (type === 'file') ? 'block' : 'none';
+    const urlSection = document.getElementById('urlSection');
+    const fileSection = document.getElementById('fileSection');
+    if (urlSection) urlSection.style.display = (type === 'url') ? 'block' : 'none';
+    if (fileSection) fileSection.style.display = (type === 'file') ? 'block' : 'none';
 }
 
 function togglePlay(btn) {
     const audioId = btn.dataset.audioId;
     const audio = document.getElementById(audioId);
+    if (!audio) return;
     if (audio.paused) {
         document.querySelectorAll('audio').forEach(a => { a.pause(); a.currentTime = 0; });
         document.querySelectorAll('.btn-play').forEach(b => { b.textContent = '▶'; b.classList.remove('playing'); });
+        // Apply saved volume if present on the button
+        const vol = parseInt(btn.dataset.volume || '100', 10);
+        if (!isNaN(vol)) audio.volume = Math.max(0, Math.min(1, vol / 100));
         audio.play();
         btn.textContent = '⏹';
         btn.classList.add('playing');
@@ -18,6 +29,478 @@ function togglePlay(btn) {
         btn.textContent = '▶';
         btn.classList.remove('playing');
     }
+}
+
+// --- Page bootstrap (skipped when running under jest: no document.readyState dependent code) ---
+function initIntroPage() {
+    if (typeof document === 'undefined' || !document.body.dataset) return;
+    if (!document.body.dataset.introPage) return;
+
+    const cfg = {
+        guildId: document.body.dataset.guildId,
+        targetDiscordId: document.body.dataset.targetDiscordId || '',
+        maxFileBytes: parseInt(document.body.dataset.maxFileKb || '550', 10) * 1024,
+        maxDurationSeconds: parseInt(document.body.dataset.maxDurationSeconds || '15', 10),
+        csrfToken: document.querySelector('meta[name="_csrf"]')?.content || '',
+        csrfHeader: document.querySelector('meta[name="_csrf_header"]')?.content || 'X-CSRF-TOKEN',
+    };
+
+    // --- Render any flash messages as toasts ---
+    document.querySelectorAll('[data-flash]').forEach(el => {
+        const type = el.dataset.flash;
+        const msg = el.textContent.trim();
+        if (!msg) return;
+        const opts = { type: type === 'error' ? 'error' : 'success' };
+        if (el.dataset.undo === 'true') {
+            opts.duration = 10000;
+            opts.action = {
+                label: 'Undo',
+                onClick: function () {
+                    const f = document.getElementById('undo-form');
+                    if (f) f.submit();
+                }
+            };
+        }
+        window.TobyToast.show(msg, opts);
+        el.remove();
+    });
+
+    // --- Segmented tabs (URL / File) ---
+    const segButtons = document.querySelectorAll('.source-tab');
+    segButtons.forEach(btn => {
+        btn.addEventListener('click', function () {
+            const type = btn.dataset.source;
+            segButtons.forEach(b => b.setAttribute('aria-pressed', b === btn ? 'true' : 'false'));
+            const urlSection = document.getElementById('urlSection');
+            const fileSection = document.getElementById('fileSection');
+            const inputTypeField = document.getElementById('inputType');
+            if (urlSection) urlSection.style.display = (type === 'url') ? 'block' : 'none';
+            if (fileSection) fileSection.style.display = (type === 'file') ? 'block' : 'none';
+            if (inputTypeField) inputTypeField.value = type;
+            try { localStorage.setItem('intro.lastSource', type); } catch (_) {}
+        });
+    });
+    const saved = (() => { try { return localStorage.getItem('intro.lastSource'); } catch (_) { return null; } })();
+    if (saved) {
+        const match = document.querySelector('.source-tab[data-source="' + saved + '"]');
+        if (match) match.click();
+    }
+
+    // --- Volume slider binding ---
+    document.querySelectorAll('[data-volume-slider]').forEach(slider => {
+        const valueEl = document.querySelector('[data-volume-value-for="' + slider.id + '"]');
+        function sync() { if (valueEl) valueEl.textContent = slider.value + '%'; }
+        slider.addEventListener('input', sync);
+        sync();
+    });
+
+    // --- URL input: live YouTube preview ---
+    const urlInput = document.getElementById('url');
+    const urlPreview = document.getElementById('urlPreview');
+    const urlError = document.getElementById('urlError');
+    const submitBtn = document.getElementById('submitBtn');
+    let previewState = { tooLong: false };
+    let debounceTimer = null;
+
+    function setUrlError(msg) {
+        if (!urlError) return;
+        urlError.textContent = msg || '';
+        if (urlInput) urlInput.setAttribute('aria-invalid', msg ? 'true' : 'false');
+    }
+
+    function renderPreview(data) {
+        if (!urlPreview) return;
+        urlPreview.classList.remove('visible', 'error');
+        if (!data || !data.thumbnailUrl) return;
+        previewState.tooLong = data.durationSeconds != null && data.durationSeconds > cfg.maxDurationSeconds;
+        const dur = data.durationSeconds != null ? formatDuration(data.durationSeconds) : '—';
+        const title = data.title || '(Unknown title)';
+        urlPreview.innerHTML =
+            '<img src="' + escapeAttr(data.thumbnailUrl) + '" alt="" />' +
+            '<div class="preview-body">' +
+                '<div class="preview-title" title="' + escapeAttr(title) + '">' + escapeHtml(title) + '</div>' +
+                '<div class="preview-meta">' +
+                    '<span class="duration-badge' + (previewState.tooLong ? ' too-long' : '') + '">' + dur + '</span>' +
+                    (data.videoId ? '<span>YouTube · ' + escapeHtml(data.videoId) + '</span>' : '') +
+                '</div>' +
+            '</div>';
+        if (previewState.tooLong) urlPreview.classList.add('error');
+        urlPreview.classList.add('visible');
+    }
+
+    function fetchPreview(url) {
+        if (!url) { renderPreview(null); setUrlError(''); updateSubmitState(); return; }
+        try { new URL(url); } catch (_) { setUrlError('Enter a valid URL.'); renderPreview(null); updateSubmitState(); return; }
+        fetch('/intro/preview?url=' + encodeURIComponent(url), { headers: { 'Accept': 'application/json' } })
+            .then(r => r.json())
+            .then(data => {
+                if (data && data.videoId) {
+                    renderPreview(data);
+                    setUrlError(data.error || '');
+                } else {
+                    renderPreview(null);
+                    setUrlError('');
+                    previewState.tooLong = false;
+                }
+                updateSubmitState();
+            })
+            .catch(() => {
+                renderPreview(null);
+                previewState.tooLong = false;
+                updateSubmitState();
+            });
+    }
+
+    if (urlInput) {
+        urlInput.addEventListener('input', function () {
+            if (debounceTimer) clearTimeout(debounceTimer);
+            debounceTimer = setTimeout(function () { fetchPreview(urlInput.value.trim()); }, 400);
+        });
+    }
+
+    // --- File drop zone ---
+    const dropZone = document.getElementById('dropZone');
+    const fileInput = document.getElementById('file');
+    const fileSummary = document.getElementById('fileSummary');
+    const fileError = document.getElementById('fileError');
+    let fileValid = false;
+
+    function setFileError(msg) {
+        if (!fileError) return;
+        fileError.textContent = msg || '';
+        if (fileInput) fileInput.setAttribute('aria-invalid', msg ? 'true' : 'false');
+    }
+
+    function clearFileSummary() {
+        if (fileSummary) fileSummary.innerHTML = '';
+        if (dropZone) dropZone.classList.remove('has-file');
+        fileValid = false;
+        updateSubmitState();
+    }
+
+    function validateAndShowFile(file) {
+        if (!file) { clearFileSummary(); return; }
+        if (!/\.mp3$/i.test(file.name)) {
+            setFileError('Only MP3 files are supported.');
+            clearFileSummary();
+            return;
+        }
+        if (file.size > cfg.maxFileBytes) {
+            setFileError('File is too large (' + formatBytes(file.size) + '). Max is ' + formatBytes(cfg.maxFileBytes) + '.');
+            clearFileSummary();
+            return;
+        }
+        setFileError('');
+        fileValid = true;
+        if (dropZone) dropZone.classList.add('has-file');
+        if (fileSummary) {
+            const blobUrl = URL.createObjectURL(file);
+            fileSummary.innerHTML = '';
+            const row = document.createElement('div');
+            row.style.width = '100%';
+            const label = document.createElement('div');
+            label.style.display = 'flex'; label.style.gap = '12px'; label.style.alignItems = 'center';
+            const name = document.createElement('span');
+            name.className = 'file-name'; name.textContent = file.name;
+            const size = document.createElement('span');
+            size.className = 'file-size'; size.textContent = formatBytes(file.size);
+            label.appendChild(name); label.appendChild(size);
+            const audio = document.createElement('audio');
+            audio.controls = true;
+            audio.src = blobUrl;
+            audio.preload = 'metadata';
+            const volSlider = document.querySelector('[data-volume-slider]');
+            if (volSlider) {
+                const apply = () => { audio.volume = Math.max(0, Math.min(1, parseInt(volSlider.value, 10) / 100)); };
+                apply();
+                volSlider.addEventListener('input', apply);
+            }
+            row.appendChild(label);
+            row.appendChild(audio);
+            fileSummary.appendChild(row);
+        }
+        updateSubmitState();
+    }
+
+    if (dropZone && fileInput) {
+        dropZone.addEventListener('click', function (e) {
+            if (e.target.tagName !== 'INPUT') fileInput.click();
+        });
+        dropZone.addEventListener('keydown', function (e) {
+            if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); fileInput.click(); }
+        });
+        dropZone.addEventListener('dragover', function (e) {
+            e.preventDefault();
+            dropZone.classList.add('drag-active');
+        });
+        dropZone.addEventListener('dragleave', function () {
+            dropZone.classList.remove('drag-active');
+        });
+        dropZone.addEventListener('drop', function (e) {
+            e.preventDefault();
+            dropZone.classList.remove('drag-active');
+            const file = e.dataTransfer.files && e.dataTransfer.files[0];
+            if (file) {
+                // Re-assign to the underlying input so it submits with the form
+                const dt = new DataTransfer();
+                dt.items.add(file);
+                fileInput.files = dt.files;
+                validateAndShowFile(file);
+            }
+        });
+        fileInput.addEventListener('change', function () {
+            validateAndShowFile(fileInput.files && fileInput.files[0]);
+        });
+    }
+
+    // --- Submit gating + loading state ---
+    const form = document.getElementById('introForm');
+    function updateSubmitState() {
+        if (!submitBtn || !form) return;
+        const source = form.querySelector('#inputType')?.value || 'url';
+        let canSubmit = true;
+        if (source === 'url') {
+            const v = urlInput ? urlInput.value.trim() : '';
+            canSubmit = v.length > 0 && !previewState.tooLong;
+        } else if (source === 'file') {
+            canSubmit = fileValid;
+        }
+        submitBtn.disabled = !canSubmit;
+    }
+    if (form) {
+        form.addEventListener('submit', function () {
+            submitBtn.setAttribute('aria-busy', 'true');
+            submitBtn.disabled = true;
+            form.setAttribute('aria-busy', 'true');
+        });
+    }
+    updateSubmitState();
+
+    // --- Delete modal ---
+    document.querySelectorAll('[data-delete-intro]').forEach(btn => {
+        btn.addEventListener('click', async function () {
+            const name = btn.dataset.introName || 'this intro';
+            const confirmed = await window.TobyModal.confirm({
+                title: 'Delete intro?',
+                body: 'Delete "' + name + '" from this server? You can undo this right after.',
+                confirmLabel: 'Delete',
+                confirmStyle: 'danger'
+            });
+            if (confirmed) {
+                const form = btn.closest('form');
+                if (form) form.submit();
+            }
+        });
+    });
+
+    // --- Inline volume edit in table ---
+    document.querySelectorAll('[data-row-volume]').forEach(slider => {
+        const introId = slider.dataset.introId;
+        const valueEl = slider.parentElement.querySelector('.vol-value');
+        let lastSaved = slider.value;
+        slider.addEventListener('input', function () {
+            if (valueEl) valueEl.textContent = slider.value + '%';
+        });
+        slider.addEventListener('change', function () {
+            const value = parseInt(slider.value, 10);
+            apiPostJson(buildUrl('/update-volume'), { introId: introId, volume: value })
+                .then(r => {
+                    if (r.ok) {
+                        lastSaved = String(value);
+                        window.TobyToast.show('Volume updated.', { type: 'success', duration: 2000 });
+                        // Keep row-level play button in sync for volume-aware preview
+                        const playBtn = document.querySelector('button.btn-play[data-audio-id="audio-' + introId + '"]');
+                        if (playBtn) playBtn.dataset.volume = String(value);
+                    } else {
+                        slider.value = lastSaved;
+                        if (valueEl) valueEl.textContent = lastSaved + '%';
+                        window.TobyToast.show(r.error || 'Failed to update volume.', { type: 'error' });
+                    }
+                })
+                .catch(() => {
+                    slider.value = lastSaved;
+                    if (valueEl) valueEl.textContent = lastSaved + '%';
+                    window.TobyToast.show('Network error.', { type: 'error' });
+                });
+        });
+    });
+
+    // --- Inline name edit ---
+    function bindNameEdit(cell) {
+        const introId = cell.dataset.introId;
+        const labelEl = cell.querySelector('.name-label');
+        if (!labelEl || labelEl.dataset.bound === '1') return;
+        labelEl.dataset.bound = '1';
+        labelEl.title = 'Click to rename';
+        labelEl.setAttribute('role', 'button');
+        labelEl.setAttribute('tabindex', '0');
+
+        function startEdit() {
+            const current = labelEl.textContent;
+            const input = document.createElement('input');
+            input.type = 'text';
+            input.className = 'name-edit-input';
+            input.value = current;
+            input.setAttribute('aria-label', 'Rename intro');
+            labelEl.replaceWith(input);
+            input.focus();
+            input.select();
+
+            let committed = false;
+            function finish(newText) {
+                if (committed) return;
+                committed = true;
+                const span = document.createElement('span');
+                span.className = 'name-label';
+                span.textContent = newText;
+                input.replaceWith(span);
+                // Re-bind against the new span
+                labelEl.textContent = newText;
+                bindNameEdit(cell);
+            }
+
+            function commit() {
+                const value = input.value.trim();
+                if (!value || value === current) { finish(current); return; }
+                apiPostJson(buildUrl('/update-name'), { introId: introId, name: value })
+                    .then(r => {
+                        if (r.ok) {
+                            finish(value);
+                            window.TobyToast.show('Renamed.', { type: 'success', duration: 2000 });
+                        } else {
+                            finish(current);
+                            window.TobyToast.show(r.error || 'Rename failed.', { type: 'error' });
+                        }
+                    })
+                    .catch(() => { finish(current); window.TobyToast.show('Network error.', { type: 'error' }); });
+            }
+
+            input.addEventListener('blur', commit);
+            input.addEventListener('keydown', function (e) {
+                if (e.key === 'Enter') { e.preventDefault(); commit(); }
+                if (e.key === 'Escape') { e.preventDefault(); finish(current); }
+            });
+        }
+
+        labelEl.addEventListener('click', startEdit);
+        labelEl.addEventListener('keydown', function (e) {
+            if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); startEdit(); }
+        });
+    }
+    document.querySelectorAll('[data-editable-name]').forEach(bindNameEdit);
+
+    // --- Drag reorder ---
+    const tbody = document.getElementById('introsTbody');
+    if (tbody) {
+        let draggedRow = null;
+        tbody.querySelectorAll('tr[data-intro-id]').forEach(row => {
+            row.setAttribute('draggable', 'true');
+            row.addEventListener('dragstart', function (e) {
+                draggedRow = row;
+                row.classList.add('dragging');
+                e.dataTransfer.effectAllowed = 'move';
+                e.dataTransfer.setData('text/plain', row.dataset.introId);
+            });
+            row.addEventListener('dragend', function () {
+                row.classList.remove('dragging');
+                tbody.querySelectorAll('tr').forEach(r => r.classList.remove('drag-over'));
+            });
+            row.addEventListener('dragover', function (e) {
+                e.preventDefault();
+                if (draggedRow && draggedRow !== row) row.classList.add('drag-over');
+            });
+            row.addEventListener('dragleave', function () { row.classList.remove('drag-over'); });
+            row.addEventListener('drop', function (e) {
+                e.preventDefault();
+                row.classList.remove('drag-over');
+                if (!draggedRow || draggedRow === row) return;
+                const rect = row.getBoundingClientRect();
+                const before = (e.clientY - rect.top) < rect.height / 2;
+                tbody.insertBefore(draggedRow, before ? row : row.nextSibling);
+                saveOrder();
+            });
+        });
+
+        function saveOrder() {
+            const orderedIds = Array.from(tbody.querySelectorAll('tr[data-intro-id]'))
+                .map(r => r.dataset.introId);
+            apiPostJson(buildUrl('/reorder'), { orderedIds: orderedIds })
+                .then(r => {
+                    if (r.ok) {
+                        window.TobyToast.show('Order saved.', { type: 'success', duration: 2000 });
+                        // Update slot numbers in first column
+                        tbody.querySelectorAll('tr[data-intro-id]').forEach((r, i) => {
+                            const idx = r.querySelector('.slot-index');
+                            if (idx) idx.textContent = String(i + 1);
+                        });
+                    } else {
+                        window.TobyToast.show(r.error || 'Reorder failed. Reloading.', { type: 'error' });
+                        setTimeout(() => location.reload(), 800);
+                    }
+                })
+                .catch(() => {
+                    window.TobyToast.show('Network error. Reloading.', { type: 'error' });
+                    setTimeout(() => location.reload(), 800);
+                });
+        }
+    }
+
+    // --- Super-user member picker ---
+    const memberSelect = document.getElementById('memberSelect');
+    if (memberSelect) {
+        memberSelect.addEventListener('change', function () {
+            const q = memberSelect.value;
+            const target = q ? '?targetDiscordId=' + encodeURIComponent(q) : '';
+            location.href = '/intro/' + cfg.guildId + target;
+        });
+    }
+
+    // --- Helpers ---
+    function apiPostJson(url, body) {
+        const headers = { 'Content-Type': 'application/json', 'Accept': 'application/json' };
+        if (cfg.csrfToken) headers[cfg.csrfHeader] = cfg.csrfToken;
+        return fetch(url, {
+            method: 'POST',
+            credentials: 'same-origin',
+            headers: headers,
+            body: JSON.stringify(body)
+        }).then(r => r.json().catch(() => ({ ok: r.ok, error: r.ok ? null : 'Request failed.' })));
+    }
+
+    function buildUrl(suffix) {
+        const q = cfg.targetDiscordId ? '?targetDiscordId=' + encodeURIComponent(cfg.targetDiscordId) : '';
+        return '/intro/' + cfg.guildId + suffix + q;
+    }
+
+    function formatBytes(n) {
+        if (n < 1024) return n + ' B';
+        if (n < 1024 * 1024) return (n / 1024).toFixed(1) + ' KB';
+        return (n / 1024 / 1024).toFixed(1) + ' MB';
+    }
+
+    function formatDuration(s) {
+        const m = Math.floor(s / 60);
+        const sec = s % 60;
+        return m + ':' + String(sec).padStart(2, '0');
+    }
+
+    function escapeHtml(s) {
+        return String(s).replace(/[&<>"']/g, c => ({
+            '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
+        })[c]);
+    }
+    function escapeAttr(s) { return escapeHtml(s); }
+}
+
+if (typeof document !== 'undefined' && typeof window !== 'undefined') {
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', initIntroPage);
+    } else {
+        initIntroPage();
+    }
+    // Expose ▶ handler to inline onclick bindings that still exist in the template
+    window.togglePlay = togglePlay;
+    window.toggleInput = toggleInput;
 }
 
 if (typeof module !== 'undefined') {

--- a/web/src/main/resources/static/js/modal.js
+++ b/web/src/main/resources/static/js/modal.js
@@ -1,0 +1,95 @@
+(function () {
+    let activeBackdrop = null;
+    let lastFocused = null;
+
+    /**
+     * Show a confirmation modal.
+     * @param {Object} opts
+     * @param {string} opts.title
+     * @param {string} [opts.body]
+     * @param {string} [opts.confirmLabel]
+     * @param {string} [opts.cancelLabel]
+     * @param {'danger'|'primary'} [opts.confirmStyle]
+     * @returns {Promise<boolean>} resolves true on confirm, false on cancel
+     */
+    function confirmDialog(opts) {
+        return new Promise(function (resolve) {
+            lastFocused = document.activeElement;
+
+            const backdrop = document.createElement('div');
+            backdrop.className = 'modal-backdrop';
+            backdrop.setAttribute('role', 'dialog');
+            backdrop.setAttribute('aria-modal', 'true');
+
+            const modal = document.createElement('div');
+            modal.className = 'modal';
+            modal.setAttribute('tabindex', '-1');
+
+            const titleEl = document.createElement('h2');
+            titleEl.textContent = opts.title || 'Are you sure?';
+            modal.appendChild(titleEl);
+            backdrop.setAttribute('aria-labelledby', '');
+
+            if (opts.body) {
+                const bodyEl = document.createElement('p');
+                bodyEl.textContent = opts.body;
+                modal.appendChild(bodyEl);
+            }
+
+            const actions = document.createElement('div');
+            actions.className = 'modal-actions';
+
+            const cancelBtn = document.createElement('button');
+            cancelBtn.type = 'button';
+            cancelBtn.className = 'btn btn-secondary';
+            cancelBtn.textContent = opts.cancelLabel || 'Cancel';
+
+            const confirmBtn = document.createElement('button');
+            confirmBtn.type = 'button';
+            confirmBtn.className = opts.confirmStyle === 'danger' ? 'btn btn-danger' : 'btn';
+            confirmBtn.textContent = opts.confirmLabel || 'Confirm';
+
+            actions.appendChild(cancelBtn);
+            actions.appendChild(confirmBtn);
+            modal.appendChild(actions);
+            backdrop.appendChild(modal);
+            document.body.appendChild(backdrop);
+            activeBackdrop = backdrop;
+
+            // Focus trap setup
+            const focusables = [cancelBtn, confirmBtn];
+            confirmBtn.focus();
+
+            function close(result) {
+                document.removeEventListener('keydown', onKey);
+                if (backdrop.parentNode) backdrop.parentNode.removeChild(backdrop);
+                activeBackdrop = null;
+                if (lastFocused && typeof lastFocused.focus === 'function') lastFocused.focus();
+                resolve(result);
+            }
+
+            function onKey(e) {
+                if (e.key === 'Escape') { e.preventDefault(); close(false); return; }
+                if (e.key === 'Tab') {
+                    const idx = focusables.indexOf(document.activeElement);
+                    if (e.shiftKey) {
+                        if (idx <= 0) { e.preventDefault(); focusables[focusables.length - 1].focus(); }
+                    } else {
+                        if (idx === focusables.length - 1) { e.preventDefault(); focusables[0].focus(); }
+                    }
+                }
+            }
+
+            document.addEventListener('keydown', onKey);
+            cancelBtn.addEventListener('click', function () { close(false); });
+            confirmBtn.addEventListener('click', function () { close(true); });
+            backdrop.addEventListener('click', function (e) { if (e.target === backdrop) close(false); });
+        });
+    }
+
+    window.TobyModal = { confirm: confirmDialog };
+
+    if (typeof module !== 'undefined') {
+        module.exports = { confirmDialog: confirmDialog };
+    }
+})();

--- a/web/src/main/resources/static/js/toasts.js
+++ b/web/src/main/resources/static/js/toasts.js
@@ -1,0 +1,71 @@
+(function () {
+    function ensureStack() {
+        let stack = document.querySelector('.toast-stack');
+        if (!stack) {
+            stack = document.createElement('div');
+            stack.className = 'toast-stack';
+            stack.setAttribute('role', 'region');
+            stack.setAttribute('aria-label', 'Notifications');
+            stack.setAttribute('aria-live', 'polite');
+            document.body.appendChild(stack);
+        }
+        return stack;
+    }
+
+    /**
+     * Show a toast notification.
+     * @param {string} message
+     * @param {Object} [opts]
+     * @param {'success'|'error'|'info'} [opts.type]
+     * @param {number} [opts.duration] - milliseconds, 0 = sticky
+     * @param {{label: string, onClick: Function}} [opts.action]
+     */
+    function showToast(message, opts) {
+        opts = opts || {};
+        const stack = ensureStack();
+        const el = document.createElement('div');
+        el.className = 'toast toast-' + (opts.type || 'info');
+        el.setAttribute('role', opts.type === 'error' ? 'alert' : 'status');
+
+        const text = document.createElement('span');
+        text.textContent = message;
+        el.appendChild(text);
+
+        if (opts.action) {
+            const btn = document.createElement('button');
+            btn.type = 'button';
+            btn.className = 'toast-action';
+            btn.textContent = opts.action.label;
+            btn.addEventListener('click', function () {
+                try { opts.action.onClick(); } finally { remove(); }
+            });
+            el.appendChild(btn);
+        }
+
+        const close = document.createElement('button');
+        close.type = 'button';
+        close.className = 'toast-close';
+        close.setAttribute('aria-label', 'Dismiss');
+        close.innerHTML = '&times;';
+        close.addEventListener('click', remove);
+        el.appendChild(close);
+
+        stack.appendChild(el);
+
+        const duration = opts.duration == null ? 4000 : opts.duration;
+        let timer = null;
+        if (duration > 0) timer = setTimeout(remove, duration);
+
+        function remove() {
+            if (timer) clearTimeout(timer);
+            if (el.parentNode) el.parentNode.removeChild(el);
+        }
+        return { dismiss: remove };
+    }
+
+    window.TobyToast = { show: showToast };
+
+    if (typeof module !== 'undefined') {
+        module.exports = { showToast: showToast };
+    }
+})();

--- a/web/src/main/resources/templates/campaign.html
+++ b/web/src/main/resources/templates/campaign.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>TobyBot - D&amp;D Campaigns</title>
     <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+    <link rel="stylesheet" th:href="@{/css/base.css}">
     <link rel="stylesheet" th:href="@{/css/nav.css}">
     <style>
         * { box-sizing: border-box; margin: 0; padding: 0; }

--- a/web/src/main/resources/templates/campaignDetail.html
+++ b/web/src/main/resources/templates/campaignDetail.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title th:text="'TobyBot - ' + ${guildName} + ' Campaign'">TobyBot - Campaign</title>
     <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+    <link rel="stylesheet" th:href="@{/css/base.css}">
     <link rel="stylesheet" th:href="@{/css/nav.css}">
     <style>
         * { box-sizing: border-box; margin: 0; padding: 0; }

--- a/web/src/main/resources/templates/error.html
+++ b/web/src/main/resources/templates/error.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="en">
+<head th:replace="~{fragments/head :: head('TobyBot - Error', null)}"></head>
+<body>
+<a href="#main" class="skip-link">Skip to content</a>
+<div th:replace="~{fragments/navbar :: navbar}"></div>
+
+<main id="main" class="container">
+    <div class="card" style="text-align:center;">
+        <h1 style="margin-bottom: 12px;">Something went wrong</h1>
+        <p class="muted mb-5">
+            <span th:if="${status != null}" th:text="'Error ' + ${status}">Error</span>
+            <span th:if="${error != null}" th:text="' — ' + ${error}"></span>
+        </p>
+        <p th:if="${message != null and !#strings.isEmpty(message)}" class="mb-5" th:text="${message}"></p>
+        <div class="flex-gap-3" style="justify-content:center;">
+            <a href="/" class="btn btn-secondary">Home</a>
+            <a href="/intro/guilds" class="btn">Intro Songs</a>
+        </div>
+    </div>
+</main>
+
+<script th:src="@{/js/home.js}"></script>
+</body>
+</html>

--- a/web/src/main/resources/templates/fragments/head.html
+++ b/web/src/main/resources/templates/fragments/head.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head th:fragment="head(pageTitle, extraCss)">
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="color-scheme" content="dark">
+    <title th:text="${pageTitle}">TobyBot</title>
+    <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+    <link rel="stylesheet" th:href="@{/css/base.css}">
+    <link rel="stylesheet" th:href="@{/css/nav.css}">
+    <link rel="stylesheet" th:if="${extraCss != null}" th:href="@{${extraCss}}">
+</head>
+</html>

--- a/web/src/main/resources/templates/guilds.html
+++ b/web/src/main/resources/templates/guilds.html
@@ -1,99 +1,139 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org" lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>TobyBot - Select a Server</title>
-    <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
-    <link rel="stylesheet" th:href="@{/css/nav.css}">
-    <style>
-        * { box-sizing: border-box; margin: 0; padding: 0; }
-        body {
-            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-            background: #1a1a2e;
-            color: #e0e0e0;
-            min-height: 100vh;
-        }
-        .container { max-width: 800px; margin: 40px auto; padding: 0 24px; }
-        h1 { font-size: 1.6rem; margin-bottom: 8px; color: #fff; }
-        .subtitle { color: #a0a0b0; margin-bottom: 32px; }
-        .error {
-            background: #4a1a1a;
-            border: 1px solid #c0392b;
-            color: #e74c3c;
-            padding: 10px 16px;
-            border-radius: 6px;
-            margin-bottom: 20px;
-        }
-        .guild-grid {
-            display: grid;
-            grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-            gap: 16px;
-        }
-        .guild-card {
-            background: #16213e;
-            border: 1px solid #2a2a4a;
-            border-radius: 10px;
-            padding: 20px;
-            text-align: center;
-            text-decoration: none;
-            color: #e0e0e0;
-            transition: border-color 0.2s, transform 0.1s;
-            display: block;
-        }
-        .guild-card:hover { border-color: #5865F2; transform: translateY(-2px); }
-        .guild-icon {
-            width: 64px;
-            height: 64px;
-            border-radius: 50%;
-            margin: 0 auto 12px;
-            display: block;
-        }
-        .guild-icon-placeholder {
-            width: 64px;
-            height: 64px;
-            border-radius: 50%;
-            background: #5865F2;
-            color: #fff;
-            font-size: 1.5rem;
-            font-weight: 700;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            margin: 0 auto 12px;
-        }
-        .guild-name { font-weight: 600; font-size: 0.95rem; }
-        .empty { color: #a0a0b0; text-align: center; padding: 48px 0; }
-    </style>
-</head>
+<head th:replace="~{fragments/head :: head('TobyBot - Select a Server', null)}"></head>
 <body>
+<a href="#main" class="skip-link">Skip to content</a>
 <div th:replace="~{fragments/navbar :: navbar}"></div>
 
-<div class="container">
-    <h1>Select a Server</h1>
-    <p class="subtitle">Servers where both you and TobyBot are present.</p>
+<style>
+    .guild-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(210px, 1fr));
+        gap: var(--space-4);
+    }
+    .guild-card {
+        position: relative;
+        background: var(--bg-elevated);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-lg);
+        padding: var(--space-5);
+        text-align: center;
+        text-decoration: none;
+        color: var(--text);
+        transition: border-color 0.15s, transform 0.1s;
+        display: block;
+    }
+    .guild-card:hover { border-color: var(--accent); transform: translateY(-2px); color: var(--text); }
+    .guild-icon, .guild-icon-placeholder {
+        width: 64px; height: 64px; border-radius: 50%;
+        margin: 0 auto 12px; display: block;
+    }
+    .guild-icon-placeholder {
+        background: var(--accent);
+        color: #fff;
+        font-size: 1.5rem; font-weight: 700;
+        display: flex; align-items: center; justify-content: center;
+    }
+    .guild-name {
+        font-weight: 600; font-size: 0.95rem;
+        overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+    }
+    .guild-count {
+        position: absolute;
+        top: 10px; right: 10px;
+        background: var(--border);
+        color: var(--text-muted);
+        font-size: 0.7rem;
+        padding: 3px 8px;
+        border-radius: 999px;
+        font-weight: 600;
+    }
+    .guild-count.has-intros { background: var(--accent-soft); color: var(--accent); }
+    .guild-count.full { background: rgba(231, 76, 60, 0.12); color: var(--danger); }
 
-    <div th:if="${error}" class="error" th:text="${error}"></div>
+    .search-row {
+        display: flex;
+        gap: var(--space-3);
+        margin-bottom: var(--space-5);
+        align-items: center;
+    }
+    .search-row input { flex: 1; max-width: 420px; }
+    .empty-hero {
+        background: var(--bg-elevated);
+        border: 1px dashed var(--border-strong);
+        border-radius: var(--radius-lg);
+        padding: 48px 24px;
+        text-align: center;
+        color: var(--text-muted);
+    }
+    .empty-hero h2 { color: var(--text); margin-bottom: 10px; }
+    .empty-hero .emoji { font-size: 2.4rem; display: block; margin-bottom: 12px; }
+    .no-results { color: var(--text-muted); padding: 24px; text-align: center; display: none; }
+</style>
 
-    <div class="guild-grid" th:if="${not #lists.isEmpty(guilds)}">
+<main id="main" class="container">
+    <h1 class="mb-3">Select a Server</h1>
+    <p class="muted mb-5">Servers where both you and TobyBot are present.</p>
+
+    <div th:if="${error}" class="alert alert-error" th:text="${error}"></div>
+
+    <div class="search-row" th:if="${not #lists.isEmpty(guilds)}">
+        <input type="search" id="guildSearch" placeholder="Search servers…"
+               aria-label="Search servers" autocomplete="off">
+        <span class="muted" th:text="${#lists.size(guilds)} + ' server' + (${#lists.size(guilds)} == 1 ? '' : 's')">0 servers</span>
+    </div>
+
+    <div class="guild-grid" th:if="${not #lists.isEmpty(guilds)}" id="guildGrid">
         <a class="guild-card"
            th:each="guild : ${guilds}"
-           th:href="@{/intro/{id}(id=${guild.id})}">
+           th:href="@{/intro/{id}(id=${guild.id})}"
+           th:attr="data-guild-name=${#strings.toLowerCase(guild.name)}">
+            <span class="guild-count"
+                  th:with="count=${introCounts[guild.id] ?: 0}"
+                  th:classappend="${count >= maxIntros ? ' full' : (count > 0 ? ' has-intros' : '')}"
+                  th:text="${count} + ' / ' + ${maxIntros}">0 / 3</span>
             <img th:if="${guild.iconUrl != null}"
                  th:src="${guild.iconUrl}"
-                 th:alt="${guild.name}"
-                 class="guild-icon">
+                 th:alt="${guild.name} + ' icon'"
+                 class="guild-icon"
+                 onerror="this.style.display='none'">
             <div th:unless="${guild.iconUrl != null}"
                  class="guild-icon-placeholder"
+                 aria-hidden="true"
                  th:text="${#strings.substring(guild.name, 0, 1).toUpperCase()}">G</div>
-            <div class="guild-name" th:text="${guild.name}">Guild Name</div>
+            <div class="guild-name" th:text="${guild.name}" th:title="${guild.name}">Guild Name</div>
         </a>
     </div>
 
-    <div class="empty" th:if="${#lists.isEmpty(guilds)}">
-        <p>You are not in any servers where TobyBot is active.</p>
+    <p id="noResults" class="no-results">No servers match your search.</p>
+
+    <div class="empty-hero" th:if="${#lists.isEmpty(guilds)}">
+        <span class="emoji" aria-hidden="true">🤖</span>
+        <h2>TobyBot isn't in any of your servers yet</h2>
+        <p class="mb-5">Invite the bot to get started with intros, music, and more.</p>
+        <a th:href="${inviteUrl}" class="btn" target="_blank" rel="noopener">Invite TobyBot</a>
     </div>
-</div>
+</main>
+
+<script>
+    (function () {
+        const search = document.getElementById('guildSearch');
+        const grid = document.getElementById('guildGrid');
+        const noResults = document.getElementById('noResults');
+        if (!search || !grid) return;
+        search.addEventListener('input', function () {
+            const q = search.value.trim().toLowerCase();
+            let visible = 0;
+            grid.querySelectorAll('.guild-card').forEach(card => {
+                const name = card.dataset.guildName || '';
+                const match = !q || name.indexOf(q) !== -1;
+                card.style.display = match ? '' : 'none';
+                if (match) visible++;
+            });
+            noResults.style.display = visible === 0 ? 'block' : 'none';
+        });
+    })();
+</script>
 <script th:src="@{/js/home.js}"></script>
 </body>
 </html>

--- a/web/src/main/resources/templates/home.html
+++ b/web/src/main/resources/templates/home.html
@@ -17,6 +17,7 @@
 
     <!-- Favicon -->
     <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+    <link rel="stylesheet" th:href="@{/css/base.css}">
     <link rel="stylesheet" th:href="@{/css/nav.css}">
     <style>
         * { box-sizing: border-box; margin: 0; padding: 0; }

--- a/web/src/main/resources/templates/intros.html
+++ b/web/src/main/resources/templates/intros.html
@@ -1,228 +1,236 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org" lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title th:text="'TobyBot - ' + ${guildName}">TobyBot - Intros</title>
-    <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
-    <link rel="stylesheet" th:href="@{/css/nav.css}">
-    <style>
-        * { box-sizing: border-box; margin: 0; padding: 0; }
-        body {
-            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-            background: #1a1a2e;
-            color: #e0e0e0;
-            min-height: 100vh;
-        }
-        .container { max-width: 800px; margin: 40px auto; padding: 0 24px; }
-        h1 { font-size: 1.6rem; margin-bottom: 32px; color: #fff; }
-        h2 { font-size: 1.1rem; margin-bottom: 16px; color: #c0c0d0; }
-        section { margin-bottom: 40px; }
-        .alert {
-            padding: 10px 16px;
-            border-radius: 6px;
-            margin-bottom: 20px;
-            font-size: 0.9rem;
-        }
-        .alert-error { background: #4a1a1a; border: 1px solid #c0392b; color: #e74c3c; }
-        .alert-success { background: #1a4a2a; border: 1px solid #27ae60; color: #2ecc71; }
-        table { width: 100%; border-collapse: collapse; }
-        th, td { text-align: left; padding: 12px 16px; border-bottom: 1px solid #2a2a4a; }
-        th { color: #a0a0b0; font-size: 0.85rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; }
-        td { font-size: 0.95rem; }
-        .btn-play {
-            background: transparent;
-            border: 1px solid #5865F2;
-            color: #5865F2;
-            width: 30px;
-            height: 30px;
-            border-radius: 50%;
-            cursor: pointer;
-            font-size: 0.75rem;
-            transition: background 0.2s, color 0.2s;
-        }
-        .btn-play:hover { background: #5865F2; color: #fff; }
-        .btn-play.playing { border-color: #e74c3c; color: #e74c3c; }
-        .btn-play.playing:hover { background: #e74c3c; color: #fff; }
-        .btn-link { color: #a0a0b0; text-decoration: none; font-size: 0.9rem; }
-        .btn-link:hover { color: #fff; }
-        .btn-delete {
-            background: transparent;
-            border: 1px solid #c0392b;
-            color: #e74c3c;
-            padding: 5px 12px;
-            border-radius: 5px;
-            cursor: pointer;
-            font-size: 0.8rem;
-            transition: background 0.2s;
-        }
-        .btn-delete:hover { background: #c0392b; color: #fff; }
-        .form-card {
-            background: #16213e;
-            border: 1px solid #2a2a4a;
-            border-radius: 10px;
-            padding: 24px;
-        }
-        .form-group { margin-bottom: 18px; }
-        label { display: block; margin-bottom: 6px; font-size: 0.9rem; color: #a0a0b0; }
-        input[type=url], input[type=file], input[type=number], select {
-            width: 100%;
-            background: #1a1a2e;
-            border: 1px solid #3a3a5a;
-            color: #e0e0e0;
-            padding: 10px 12px;
-            border-radius: 6px;
-            font-size: 0.95rem;
-        }
-        input[type=url]:focus, input[type=number]:focus, select:focus {
-            outline: none;
-            border-color: #5865F2;
-        }
-        .radio-group { display: flex; gap: 24px; }
-        .radio-group label { display: flex; align-items: center; gap: 8px; color: #e0e0e0; cursor: pointer; margin: 0; }
-        .btn-submit {
-            background: #5865F2;
-            color: #fff;
-            border: none;
-            padding: 12px 28px;
-            border-radius: 8px;
-            font-size: 1rem;
-            font-weight: 600;
-            cursor: pointer;
-            transition: background 0.2s;
-        }
-        .btn-submit:hover { background: #4752c4; }
-        .empty { color: #a0a0b0; font-style: italic; }
-        .hint { font-size: 0.8rem; color: #666; margin-top: 4px; }
-    </style>
-</head>
-<body>
+<head th:replace="~{fragments/head :: head('TobyBot - ' + ${guildName}, '/css/intros.css')}"></head>
+<body th:attr="
+        data-intro-page='1',
+        data-guild-id=${guildId},
+        data-target-discord-id=${targetDiscordId != null ? targetDiscordId : ''},
+        data-max-file-kb=${maxFileKb},
+        data-max-duration-seconds=${maxDurationSeconds}">
+
+<a href="#main" class="skip-link">Skip to content</a>
 <div th:replace="~{fragments/navbar :: navbar}"></div>
 
-<div class="container">
-    <h1>Intro Songs — <span th:text="${guildName}">Server</span></h1>
+<!-- Flash messages rendered invisibly; intros.js picks them up as toasts on load -->
+<div th:if="${success}" data-flash="success" th:attr="data-undo=${undoDelete != null ? 'true' : 'false'}"
+     class="sr-only" th:text="${success}"></div>
+<div th:if="${error}" data-flash="error" class="sr-only" th:text="${error}"></div>
 
-    <div th:if="${success}" class="alert alert-success" th:text="${success}"></div>
-    <div th:if="${error}" class="alert alert-error" th:text="${error}"></div>
+<!-- Undo form used by the toast "Undo" action button (no JS, keeps CSRF flow) -->
+<form id="undo-form" style="display:none" method="post"
+      th:if="${undoDelete}"
+      th:action="@{/intro/{gid}/undo-delete(gid=${guildId})}">
+    <input type="hidden" name="targetDiscordId" th:value="${targetDiscordId}" th:if="${targetDiscordId != null}">
+</form>
+
+<main id="main" class="container">
+
+    <div class="intro-header">
+        <h1>Intro Songs — <span th:text="${guildName}">Server</span></h1>
+        <span class="slot-count"
+              th:classappend="${atLimit} ? ' full'"
+              th:text="${intros.size()} + ' / ' + ${maxIntros} + ' slots'">0 / 3 slots</span>
+    </div>
+
+    <p class="random-note">
+        When you join a voice channel, TobyBot randomly picks one of your intros.
+        Keep duration short (≤ <span th:text="${maxDurationSeconds}">15</span>s) for a clean join sound.
+    </p>
+
+    <!-- Super-user: manage another member -->
+    <section th:if="${isSuperUser}" class="member-picker-card" aria-labelledby="manage-for">
+        <div class="picker-row">
+            <label id="manage-for" for="memberSelect" style="margin:0;">Manage intros for</label>
+            <select id="memberSelect" name="memberSelect">
+                <option value="">(Yourself)</option>
+                <option th:each="m : ${members}"
+                        th:value="${m.id}"
+                        th:text="${m.name}"
+                        th:selected="${targetDiscordId != null and m.id == targetDiscordId.toString()}"></option>
+            </select>
+            <span th:if="${targetDiscordId != null}" class="target-badge">Super-user mode</span>
+        </div>
+    </section>
 
     <!-- Current intros -->
-    <section>
-        <h2>Current Intros (<span th:text="${intros.size()}">0</span> / <span th:text="${maxIntros}">3</span>)</h2>
+    <section aria-labelledby="current-h" class="mb-8">
+        <h2 id="current-h" class="mb-4">Your intros</h2>
 
-        <p class="empty" th:if="${#lists.isEmpty(intros)}">No intro songs set for this server.</p>
+        <div th:if="${#lists.isEmpty(intros)}" class="empty-hero">
+            <span class="emoji" aria-hidden="true">🎵</span>
+            <p>No intros set yet. Add one below to get started.</p>
+        </div>
 
-        <table th:unless="${#lists.isEmpty(intros)}">
-            <thead>
-                <tr>
-                    <th>#</th>
-                    <th>Name / URL</th>
-                    <th>Volume</th>
-                    <th></th>
-                    <th></th>
-                </tr>
-            </thead>
-            <tbody>
-                <tr th:each="intro : ${intros}">
-                    <td th:text="${intro.index}">1</td>
-                    <td th:text="${intro.fileName}">intro.mp3</td>
-                    <td th:text="${intro.introVolume} + '%'">90%</td>
-                    <td>
-                        <!-- URL-based intro: open link -->
-                        <a th:if="${intro.url != null}"
-                           th:href="${intro.url}"
-                           target="_blank"
-                           class="btn-link"
-                           title="Open URL">↗</a>
-                        <!-- File-based intro: play button -->
-                        <span th:unless="${intro.url != null}">
-                            <audio th:id="'audio-' + ${intro.id}"
-                                   th:src="@{/music(id=${intro.id})}"
-                                   preload="none"></audio>
-                            <button type="button" class="btn-play"
-                                    th:data-audio-id="${'audio-' + intro.id}"
-                                    onclick="togglePlay(this)">▶</button>
-                        </span>
-                    </td>
-                    <td>
-                        <form th:action="@{/intro/{guildId}/delete/{introId}(guildId=${guildId},introId=${intro.id})}"
-                              method="post"
-                              onsubmit="return confirm('Delete this intro?')">
-                            <button type="submit" class="btn-delete">Delete</button>
-                        </form>
-                    </td>
-                </tr>
-            </tbody>
-        </table>
+        <div th:unless="${#lists.isEmpty(intros)}" class="intros-table">
+            <table>
+                <thead>
+                    <tr>
+                        <th scope="col"><span class="sr-only">Slot</span>#</th>
+                        <th scope="col">Name</th>
+                        <th scope="col">Volume</th>
+                        <th scope="col"><span class="sr-only">Actions</span></th>
+                    </tr>
+                </thead>
+                <tbody id="introsTbody">
+                    <tr th:each="intro : ${intros}" th:attr="data-intro-id=${intro.id}">
+                        <td data-label="Slot">
+                            <span class="drag-handle" title="Drag to reorder" aria-hidden="true">⋮⋮</span>
+                            <span class="slot-index" th:text="${intro.index}">1</span>
+                        </td>
+                        <td data-label="Name" class="name-cell" th:attr="data-editable-name=true,data-intro-id=${intro.id}">
+                            <span th:if="${intro.thumbnailUrl != null}"
+                                  class="thumb"
+                                  th:style="'background-image:url(' + ${intro.thumbnailUrl} + ')'"
+                                  aria-hidden="true"></span>
+                            <span class="name-label" th:text="${intro.fileName}">intro.mp3</span>
+                        </td>
+                        <td data-label="Volume">
+                            <div class="volume-inline">
+                                <input type="range" min="1" max="100"
+                                       th:value="${intro.introVolume}"
+                                       th:attr="data-row-volume=true,data-intro-id=${intro.id},id='volrange-' + ${intro.id}"
+                                       th:aria-label="'Volume for ' + ${intro.fileName}">
+                                <span class="vol-value" th:text="${intro.introVolume} + '%'">90%</span>
+                            </div>
+                        </td>
+                        <td data-label="Actions" class="actions">
+                            <!-- Play or open-link -->
+                            <a th:if="${intro.url != null}"
+                               th:href="${intro.url}"
+                               target="_blank" rel="noopener"
+                               class="btn-link-icon"
+                               th:aria-label="'Open ' + ${intro.fileName} + ' in new tab'"
+                               title="Open link">↗</a>
+                            <span th:unless="${intro.url != null}">
+                                <audio th:id="'audio-' + ${intro.id}"
+                                       th:src="@{/music(id=${intro.id})}"
+                                       preload="none"></audio>
+                                <button type="button" class="btn-play"
+                                        th:attr="data-audio-id='audio-' + ${intro.id},
+                                                 data-volume=${intro.introVolume},
+                                                 aria-label='Play ' + ${intro.fileName}"
+                                        onclick="togglePlay(this)">▶</button>
+                            </span>
+
+                            <!-- Delete -->
+                            <form th:action="@{/intro/{gid}/delete/{iid}(gid=${guildId},iid=${intro.id})}"
+                                  method="post"
+                                  style="display:inline-block; margin-left:8px;">
+                                <input type="hidden" name="targetDiscordId" th:value="${targetDiscordId}" th:if="${targetDiscordId != null}">
+                                <button type="button" class="btn btn-danger btn-sm"
+                                        th:attr="data-delete-intro=true,data-intro-name=${intro.fileName}"
+                                        th:aria-label="'Delete ' + ${intro.fileName}">Delete</button>
+                            </form>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
     </section>
 
     <!-- Add / replace form -->
-    <section>
-        <h2 th:text="${atLimit} ? 'Replace an Intro' : 'Add a New Intro'">Add Intro</h2>
+    <section class="intro-form" aria-labelledby="form-h">
+        <h2 id="form-h" class="mb-4">Add or replace an intro</h2>
 
-        <div class="form-card">
-            <form th:action="@{/intro/{guildId}/set(guildId=${guildId})}"
+        <div class="card">
+            <form id="introForm"
+                  th:action="@{/intro/{gid}/set(gid=${guildId})}"
                   method="post"
                   enctype="multipart/form-data">
 
-                <!-- Replace selector (shown only when at limit) -->
-                <div class="form-group" th:if="${atLimit}">
-                    <label for="replaceIndex">Select intro to replace</label>
-                    <select id="replaceIndex" name="replaceIndex" required>
-                        <option value="">-- Select --</option>
-                        <option th:each="intro : ${intros}"
-                                th:value="${intro.index}"
-                                th:text="'#' + ${intro.index} + ' — ' + ${intro.fileName}">
-                            #1 — intro.mp3
-                        </option>
-                    </select>
+                <input type="hidden" id="inputType" name="inputType" value="url">
+                <input type="hidden" name="targetDiscordId" th:value="${targetDiscordId}" th:if="${targetDiscordId != null}">
+
+                <!-- Slot selector: always visible, never hidden -->
+                <div class="form-group">
+                    <label for="replaceIndex">Slot</label>
+                    <div class="slot-select-row">
+                        <select id="replaceIndex" name="replaceIndex">
+                            <option value="" th:text="${atLimit} ? 'Pick a slot to replace' : '➕ New slot'"></option>
+                            <option th:each="intro : ${intros}"
+                                    th:value="${intro.index}"
+                                    th:text="'Replace slot #' + ${intro.index} + ' — ' + ${intro.fileName}"></option>
+                        </select>
+                        <span class="hint" th:if="${atLimit}">
+                            You're at <span th:text="${maxIntros}">3</span> intros — pick one to replace.
+                        </span>
+                    </div>
                 </div>
 
-                <!-- Input type toggle -->
+                <!-- Source tabs -->
                 <div class="form-group">
-                    <label>Source</label>
-                    <div class="radio-group">
-                        <label>
-                            <input type="radio" name="inputType" value="url" checked
-                                   onchange="toggleInput('url')"> URL
-                        </label>
-                        <label>
-                            <input type="radio" name="inputType" value="file"
-                                   onchange="toggleInput('file')"> File Upload
-                        </label>
+                    <label id="source-label">Source</label>
+                    <div class="segmented" role="tablist" aria-labelledby="source-label">
+                        <button type="button" class="source-tab" role="tab"
+                                data-source="url" aria-pressed="true">🔗 URL</button>
+                        <button type="button" class="source-tab" role="tab"
+                                data-source="file" aria-pressed="false">📁 File</button>
                     </div>
                 </div>
 
                 <!-- URL input -->
                 <div class="form-group" id="urlSection">
-                    <label for="url">YouTube / audio URL</label>
-                    <input type="url" id="url" name="url"
-                           placeholder="https://www.youtube.com/watch?v=...">
-                    <p class="hint">Max intro duration: 15 seconds.</p>
+                    <label for="url">YouTube or audio URL</label>
+                    <input type="url" id="url" name="url" autocomplete="off"
+                           placeholder="https://www.youtube.com/watch?v=…"
+                           aria-describedby="urlHint urlError">
+                    <p id="urlHint" class="hint">
+                        Max duration: <span th:text="${maxDurationSeconds}">15</span>s. YouTube URLs get a thumbnail preview.
+                    </p>
+                    <span id="urlError" class="field-error" role="alert"></span>
+                    <div id="urlPreview" class="url-preview" aria-live="polite"></div>
                 </div>
 
-                <!-- File upload input -->
+                <!-- File input -->
                 <div class="form-group" id="fileSection" style="display:none">
                     <label for="file">MP3 file</label>
-                    <input type="file" id="file" name="file" accept=".mp3">
-                    <p class="hint">Maximum size: 550KB.</p>
+                    <div id="dropZone" class="drop-zone" tabindex="0" role="button"
+                         aria-label="Drop MP3 file here or click to browse">
+                        <span class="drop-icon" aria-hidden="true">⬇</span>
+                        <div>Drop an MP3 here, or <strong>click to browse</strong></div>
+                        <div class="drop-hint">Max <span th:text="${maxFileKb}">550</span> KB · .mp3 only</div>
+                        <input type="file" id="file" name="file" accept=".mp3,audio/mpeg">
+                    </div>
+                    <span id="fileError" class="field-error" role="alert"></span>
+                    <div id="fileSummary" class="file-summary" style="display:none"></div>
                 </div>
+                <script>
+                    // Hide the file-summary container when empty so the border doesn't render
+                    (function(){
+                        const obs = new MutationObserver(()=>{
+                            const el = document.getElementById('fileSummary');
+                            if (!el) return;
+                            el.style.display = el.children.length ? 'flex' : 'none';
+                        });
+                        document.addEventListener('DOMContentLoaded', function(){
+                            const el = document.getElementById('fileSummary');
+                            if (el) obs.observe(el, { childList: true });
+                        });
+                    })();
+                </script>
 
                 <!-- Volume -->
                 <div class="form-group">
-                    <label for="volume">Volume (1–100)</label>
-                    <input type="number" id="volume" name="volume"
-                           min="1" max="100" value="90" style="max-width:120px">
+                    <label for="volume">Volume</label>
+                    <div class="volume-control">
+                        <input type="range" id="volume" name="volume" min="1" max="100" value="90"
+                               data-volume-slider aria-describedby="volHint">
+                        <span class="vol-value" data-volume-value-for="volume">90%</span>
+                    </div>
+                    <p id="volHint" class="hint">Live preview uses this volume. The bot will too.</p>
                 </div>
 
-                <button type="submit" class="btn-submit"
-                        th:text="${atLimit} ? 'Replace Intro' : 'Add Intro'">
-                    Add Intro
-                </button>
+                <div class="flex-gap-3" style="margin-top: 24px;">
+                    <button type="submit" id="submitBtn" class="btn"
+                            th:text="${atLimit} ? 'Replace intro' : 'Add intro'">Add intro</button>
+                </div>
             </form>
         </div>
     </section>
-</div>
+</main>
 
+<script th:src="@{/js/toasts.js}"></script>
+<script th:src="@{/js/modal.js}"></script>
 <script th:src="@{/js/intros.js}"></script>
 <script th:src="@{/js/home.js}"></script>
 </body>

--- a/web/src/main/resources/templates/login.html
+++ b/web/src/main/resources/templates/login.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>TobyBot - Login</title>
     <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+    <link rel="stylesheet" th:href="@{/css/base.css}">
     <link rel="stylesheet" th:href="@{/css/nav.css}">
     <style>
         * { box-sizing: border-box; margin: 0; padding: 0; }

--- a/web/src/main/resources/templates/privacy.html
+++ b/web/src/main/resources/templates/privacy.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>TobyBot — Privacy Policy</title>
     <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+    <link rel="stylesheet" th:href="@{/css/base.css}">
     <link rel="stylesheet" th:href="@{/css/nav.css}">
     <style>
         * { box-sizing: border-box; margin: 0; padding: 0; }

--- a/web/src/main/resources/templates/terms.html
+++ b/web/src/main/resources/templates/terms.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>TobyBot — Terms of Service</title>
     <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+    <link rel="stylesheet" th:href="@{/css/base.css}">
     <link rel="stylesheet" th:href="@{/css/nav.css}">
     <style>
         * { box-sizing: border-box; margin: 0; padding: 0; }


### PR DESCRIPTION
## Summary

Overhauls the Discord web UI — especially the intro manager — to close the gap with the Discord bot and add the UX polish that was missing.

### Intro page (`/intro/{guildId}`)
- **Segmented URL / File tabs** replace the radio toggle; remembers the last choice in `localStorage`.
- **Drag-and-drop MP3 zone** with client-side size/type validation and a live `<audio controls>` preview of the chosen file.
- **Live YouTube preview** — thumbnail, title, duration — via a new `GET /intro/preview` endpoint. The 15-second limit is now **actually enforced server-side** in `setIntroByUrl`, not just advertised as a hint.
- **Volume slider** with numeric readout, and the row-level ▶ button now respects the saved per-intro volume (previously always 100%).
- **Always-visible slot selector** lets you replace any slot before hitting the 3-intro limit.
- **Loading state** on submit and double-submit guard.
- **Toasts** replace flash-message alerts (auto-dismiss, "Undo" action on delete) — delete now uses a themed, focus-trapped in-page modal instead of native `confirm()`.
- **Inline rename**, **inline volume edit**, and **drag reorder** on the intros table, backed by three new JSON endpoints (`/update-name`, `/update-volume`, `/reorder`).
- **Super-user member picker** — if the signed-in user has `superUser=true`, they can manage intros for any member of the guild (matches `/setintro users:` on the bot).
- **A11y**: skip link, ARIA labels on play/delete, focus rings everywhere, keyboard-operable drop-zone, escape/enter on rename inputs.
- Small explanatory line clarifies that the bot picks one of your intros **at random** when you join voice.

### Guild picker (`/intro/guilds`)
- Client-side **search** to filter the grid.
- Per-server **intro count badges** (`0 / 3`, `2 / 3`, etc.), coloured when populated or full.
- **"Invite TobyBot"** CTA on the empty state.

### Cross-cutting polish
- New shared **`base.css`** with CSS custom properties (tokens for bg, accent, text, spacing, radii, shadows) plus button / form / alert / toast / modal components. Loaded on every page.
- **`fragments/head.html`** — reusable `<head>` fragment used by the two rewritten templates and `error.html`.
- **`BotController /music`** now sets `Cache-Control: private, max-age=3600` + `ETag` (based on `musicBlobHash`) and returns `304` on `If-None-Match` — so hitting ▶ repeatedly on a 550 KB blob stops re-streaming it.
- **Responsive layout** tweaks (below 640px the intro table collapses to cards, form fields stack).
- **`error.html`** replaces Spring's Whitelabel error page.

### New endpoints
| Verb | Path | Purpose |
|---|---|---|
| `GET` | `/intro/preview?url=...` | Title + thumbnail + duration for a URL |
| `POST` | `/intro/{gid}/update-volume` | Inline volume edit |
| `POST` | `/intro/{gid}/update-name` | Inline rename |
| `POST` | `/intro/{gid}/reorder` | Drag-reorder slot indexes |
| `POST` | `/intro/{gid}/undo-delete` | Restore a just-deleted intro |

Existing endpoints now accept an optional `targetDiscordId` param that is honoured only when the signed-in user is a super-user, for the member-picker flow.

### Schema / data
- **No DB schema changes.** All new behaviour sits on existing `MusicDto` / `UserDto` fields.

## Test plan
- [x] `npm test` (jest) — all 16 existing tests still pass; `toggleInput`/`togglePlay` exports retained for backward compatibility.
- [ ] `./gradlew :web:test` and `:web:bootRun` — couldn't run in this sandbox (Gradle plugin resolution requires internet). Please run locally.
- [ ] Sign in with Discord → `/intro/guilds` shows counts + search + invite CTA on empty state.
- [ ] `/intro/{gid}`: paste YouTube URL → thumbnail/title/duration preview ≤ 1s.
- [ ] Paste a >15s URL → red warning, submit disabled, server also rejects if bypassed.
- [ ] Drag an MP3 > 550 KB → inline error, no submit.
- [ ] Drop a valid MP3 → filename + size + preview player; slider adjusts preview volume live.
- [ ] Submit → button shows spinner, toast appears after redirect.
- [ ] ▶ on a row plays at the saved volume; subsequent plays of the same clip return 304 from `/music`.
- [ ] Click volume cell on a row → slider, change, blur → persists.
- [ ] Click name → rename input → persists.
- [ ] Drag a row to reorder → new order persists.
- [ ] Delete → themed modal, confirm → toast with Undo; Undo within 10 min restores the intro.
- [ ] Super-user picker appears when `superUser=true`; selecting another member loads/saves their intros.
- [ ] Error page: hit an intentionally broken URL → themed error page, not Whitelabel.
- [ ] `Esc` closes the modal; `Tab`/`Shift+Tab` traps focus inside; focus returns to trigger.
- [ ] Resize to 375px: intros table collapses to cards, form fields stack, guild grid is readable.

https://claude.ai/code/session_013viYinJG2yjwBNaszNP6pa