### PR TITLE
refactor: extract shared helpers and drop duplication

### DIFF
--- a/discord-bot/src/main/kotlin/bot/toby/Constants.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/Constants.kt
@@ -1,0 +1,3 @@
+package bot.toby
+
+const val BOT_WEB_URL = "https://www.toby-bot.co.uk"

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/dnd/CampaignCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/dnd/CampaignCommand.kt
@@ -1,5 +1,6 @@
 package bot.toby.command.commands.dnd
 
+import bot.toby.BOT_WEB_URL
 import bot.toby.helpers.UserDtoHelper
 import core.command.Command.Companion.invokeDeleteOnMessageResponse
 import core.command.CommandContext
@@ -38,10 +39,6 @@ class CampaignCommand(
         SubcommandData("status", "Show the active campaign and its players"),
         SubcommandData("end", "End the active campaign (DM only)")
     )
-
-    companion object {
-        private const val WEB_URL = "https://www.toby-bot.co.uk"
-    }
 
     override fun handle(ctx: CommandContext, requestingUserDto: UserDto, deleteDelay: Int) {
         val event = ctx.event
@@ -101,7 +98,7 @@ class CampaignCommand(
             .addField("Dungeon Master", ctx.member?.effectiveName ?: "Unknown", true)
             .addField("Guild", guild.name, true)
             .addField("Players", "None yet — use `/campaign join` to join!", false)
-            .addField("Web UI", "$WEB_URL/dnd/campaign/${guild.idLong}", false)
+            .addField("Web UI", "$BOT_WEB_URL/dnd/campaign/${guild.idLong}", false)
             .build()
 
         event.hook.sendMessageEmbeds(embed).queue()
@@ -146,7 +143,7 @@ class CampaignCommand(
             .setColor(Color(88, 101, 242))
             .addField("Player", ctx.member?.effectiveName ?: "Unknown", true)
             .addField("Character", characterNote, false)
-            .addField("Web UI", "$WEB_URL/dnd/campaign/${guild.idLong}", false)
+            .addField("Web UI", "$BOT_WEB_URL/dnd/campaign/${guild.idLong}", false)
             .build()
 
         event.hook.sendMessageEmbeds(embed).queue()
@@ -202,7 +199,7 @@ class CampaignCommand(
             .addField("Dungeon Master", dmName, true)
             .addField("Guild", guild.name, true)
             .addField("Players (${players.size})", playerList, false)
-            .addField("Web UI", "$WEB_URL/dnd/campaign/${guild.idLong}", false)
+            .addField("Web UI", "$BOT_WEB_URL/dnd/campaign/${guild.idLong}", false)
             .build()
 
         event.hook.sendMessageEmbeds(embed).queue()

--- a/discord-bot/src/main/kotlin/bot/toby/dto/web/dnd/Condition.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/dto/web/dnd/Condition.kt
@@ -17,11 +17,9 @@ data class Condition(
 
     override fun toEmbed(): MessageEmbed {
         val embedBuilder = EmbedBuilder()
-        if (name != null) {
-            embedBuilder.setTitle(name)
-        }
+        name?.let { embedBuilder.setTitle(it) }
         if (!desc.isNullOrEmpty()) {
-            embedBuilder.setDescription((desc.transformListToString()))
+            embedBuilder.setDescription(desc.transformListToString())
         }
         embedBuilder.setColor(0x42f5a7)
         return embedBuilder.build()

--- a/discord-bot/src/main/kotlin/bot/toby/dto/web/dnd/Feature.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/dto/web/dnd/Feature.kt
@@ -25,16 +25,12 @@ data class Feature(
 
     override fun toEmbed(): MessageEmbed {
         val embedBuilder = EmbedBuilder()
-        if (name != null) {
-            embedBuilder.setTitle(name)
-        }
+        name?.let { embedBuilder.setTitle(it) }
         if (!desc.isNullOrEmpty()) {
             embedBuilder.setDescription(desc.transformListToString())
         }
-        if (classInfo != null) {
-            embedBuilder.addField("Class", classInfo.name, true)
-        }
-        level?.let { embedBuilder.addField("Level", level.toString(), true) }
+        classInfo?.let { embedBuilder.addField("Class", it.name, true) }
+        level?.let { embedBuilder.addField("Level", it.toString(), true) }
         if (prerequisites.isNotEmpty()) {
             embedBuilder.addField("Prerequisites", prerequisites.transformListToString(), false)
         }

--- a/discord-bot/src/main/kotlin/bot/toby/dto/web/dnd/SpellClasses.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/dto/web/dnd/SpellClasses.kt
@@ -56,11 +56,11 @@ data class Spell(
         if (higherLevel.isNotEmpty()) {
             embedBuilder.addField("Higher Level", higherLevel.transformListToString(), false)
         }
-        if (range != null) {
-            val meterValue = if (range == "Touch") "Touch" else buildString {
+        range?.let {
+            val meterValue = if (it == "Touch") "Touch" else buildString {
                 append(
                     transformToMeters(
-                        range.split(" ".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()[0].toInt()
+                        it.split(" ".toRegex()).dropLastWhile { s -> s.isEmpty() }.toTypedArray()[0].toInt()
                     )
                 )
                 append("m")
@@ -89,23 +89,18 @@ data class Spell(
             }
             embedBuilder.addField("Damage Info", damageInfo.toString(), true)
         }
-        val dc = dc
-        if (dc != null) {
-            embedBuilder.addField("DC Type", dc.dcType.name, true)
-            if (dc.dcSuccess != null) {
-                embedBuilder.addField("DC Success", dc.dcSuccess, true)
-            }
+        dc?.let {
+            embedBuilder.addField("DC Type", it.dcType.name, true)
+            it.dcSuccess?.let { success -> embedBuilder.addField("DC Success", success, true) }
         }
-        if (areaOfEffect != null) {
+        areaOfEffect?.let {
             embedBuilder.addField(
                 "Area of Effect",
-                "Type: ${areaOfEffect.type}, Size: ${transformToMeters(areaOfEffect.size)}m",
+                "Type: ${it.type}, Size: ${transformToMeters(it.size)}m",
                 true
             )
         }
-        if (school != null) {
-            embedBuilder.addField("School", school.name, true)
-        }
+        school?.let { embedBuilder.addField("School", it.name, true) }
         val spellClasses = classes
         if (!spellClasses.isNullOrEmpty()) {
             val classesInfo = StringBuilder()
@@ -122,9 +117,7 @@ data class Spell(
             }
             embedBuilder.addField("Subclasses", subclassesInfo.toString(), true)
         }
-        if (url != null) {
-            embedBuilder.setUrl("https://www.dndbeyond.com/" + url.replace("/api/", ""))
-        }
+        url?.let { embedBuilder.setUrl("https://www.dndbeyond.com/" + it.replace("/api/", "")) }
         embedBuilder.setColor(0x42f5a7)
         return embedBuilder.build()
     }

--- a/discord-bot/src/main/kotlin/bot/toby/handler/VoiceEventHandler.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/handler/VoiceEventHandler.kt
@@ -4,6 +4,7 @@ import bot.toby.helpers.IntroHelper
 import bot.toby.helpers.MusicPlayerHelper.playUserIntro
 import bot.toby.helpers.UserDtoHelper
 import bot.toby.helpers.UserDtoHelper.Companion.getRequestingUserDto
+import bot.toby.helpers.nonBots
 import bot.toby.lavaplayer.PlayerManager
 import common.logging.DiscordLogger
 import database.dto.ConfigDto.Configurations.DELETE_DELAY
@@ -49,8 +50,8 @@ class VoiceEventHandler @Autowired constructor(
 
     private fun Guild.connectToMostPopulatedVoiceChannel() {
         val mostPopulatedChannel = this.voiceChannels
-            .filter { channel -> channel.members.any { !it.user.isBot } }
-            .maxByOrNull { channel -> channel.members.count { !it.user.isBot } }
+            .filter { channel -> channel.members.nonBots().isNotEmpty() }
+            .maxByOrNull { channel -> channel.members.nonBots().size }
 
         mostPopulatedChannel?.checkStateAndConnectToVoiceChannel()
             ?: logger.info("No occupied voice channel to join found")
@@ -159,7 +160,7 @@ class VoiceEventHandler @Autowired constructor(
     ) {
         //Ignore the bot joining voice event
         if (event.member.user.idLong != event.jda.selfUser.idLong) {
-            val joinedChannelConnectedMembers = event.channelJoined?.members?.filter { !it.user.isBot } ?: emptyList()
+            val joinedChannelConnectedMembers = event.channelJoined?.members?.nonBots() ?: emptyList()
             if (joinedChannelConnectedMembers.isNotEmpty() && !audioManager.isConnected) {
                 logger.info { "Joining new channel '${event.channelJoined?.name}'." }
                 PlayerManager.instance.getMusicManager(guild).audioPlayer.volume = defaultVolume
@@ -193,13 +194,13 @@ class VoiceEventHandler @Autowired constructor(
         val guild = event.guild
         val audioManager = guild.audioManager
         audioManager.checkAudioManagerToCloseConnectionOnEmptyChannel()
-        event.channelLeft?.let { deleteTemporaryChannelIfEmpty(it.members.none { m -> !m.user.isBot }, it) }
+        event.channelLeft?.let { deleteTemporaryChannelIfEmpty(it.members.nonBots().isEmpty(), it) }
     }
 
     private fun AudioManager.checkAudioManagerToCloseConnectionOnEmptyChannel() {
         val connectedChannel = this.connectedChannel
         if (connectedChannel != null) {
-            if (connectedChannel.members.none { !it.user.isBot }) {
+            if (connectedChannel.members.nonBots().isEmpty()) {
                 this.closeAudioConnection()
                 logger.info("Audio connection closed due to empty channel.")
                 lastConnectedChannel.remove(this.guild.idLong)

--- a/discord-bot/src/main/kotlin/bot/toby/helpers/DnDHelper.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/helpers/DnDHelper.kt
@@ -31,7 +31,7 @@ class DnDHelper(private val userDtoHelper: UserDtoHelper) {
         dm: Member,
         initiativeMap: MutableMap<String, Int>
     ) {
-        val nonDmMembers = memberList.nonBots().filter { it != dm }
+        val nonDmMembers = memberList.filter { it != dm }.nonBots()
         nonDmMembers.forEach { target ->
             val userDto = userDtoHelper.calculateUserDto(target.idLong, target.guild.idLong, target.isOwner)
             rollAndAddToMap(initiativeMap, target.user.effectiveName, userDto.initiativeModifier ?: 0)

--- a/discord-bot/src/main/kotlin/bot/toby/helpers/DnDHelper.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/helpers/DnDHelper.kt
@@ -31,7 +31,7 @@ class DnDHelper(private val userDtoHelper: UserDtoHelper) {
         dm: Member,
         initiativeMap: MutableMap<String, Int>
     ) {
-        val nonDmMembers = memberList.filter { it != dm && !it.user.isBot }
+        val nonDmMembers = memberList.nonBots().filter { it != dm }
         nonDmMembers.forEach { target ->
             val userDto = userDtoHelper.calculateUserDto(target.idLong, target.guild.idLong, target.isOwner)
             rollAndAddToMap(initiativeMap, target.user.effectiveName, userDto.initiativeModifier ?: 0)

--- a/discord-bot/src/main/kotlin/bot/toby/helpers/MemberExtensions.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/helpers/MemberExtensions.kt
@@ -1,0 +1,5 @@
+package bot.toby.helpers
+
+import net.dv8tion.jda.api.entities.Member
+
+fun List<Member>.nonBots(): List<Member> = filter { !it.user.isBot }

--- a/discord-bot/src/main/kotlin/bot/toby/helpers/MusicPlayerHelper.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/helpers/MusicPlayerHelper.kt
@@ -1,5 +1,6 @@
 package bot.toby.helpers
 
+import bot.toby.BOT_WEB_URL
 import bot.toby.command.commands.music.MusicCommand.Companion.sendDeniedStoppableMessage
 import bot.toby.lavaplayer.GuildMusicManager
 import bot.toby.lavaplayer.PlayerManager
@@ -23,7 +24,6 @@ import java.util.concurrent.TimeUnit
 
 object MusicPlayerHelper {
     private val logger: DiscordLogger = DiscordLogger.createLogger(this::class.java)
-    private const val WEB_URL = "https://www.toby-bot.co.uk"
     private const val SECOND_MULTIPLIER = 1000
     val nowPlayingManager = NowPlayingManager()
 
@@ -226,7 +226,7 @@ object MusicPlayerHelper {
         val blobString = it.musicBlob?.let { bytes -> String(bytes) } ?: ""
         if (isUrl(blobString).isNotEmpty()) return blobString
         // Otherwise, serve the binary data via the web endpoint
-        return "$WEB_URL/music?id=${it.id}"
+        return "$BOT_WEB_URL/music?id=${it.id}"
     }
 
     fun formatTime(timeInMillis: Long): String {

--- a/discord-bot/src/main/kotlin/bot/toby/helpers/UserDtoHelper.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/helpers/UserDtoHelper.kt
@@ -1,7 +1,6 @@
 package bot.toby.helpers
 
 import common.logging.DiscordLogger
-import database.dto.MusicDto
 import database.dto.UserDto
 import database.service.UserService
 import net.dv8tion.jda.api.entities.Member
@@ -18,7 +17,7 @@ class UserDtoHelper(private val userService: UserService) {
         logger.info("Processing lookup for user: $discordId, guild: $guildId")
         return userService.getUserById(discordId, guildId) ?: UserDto(discordId, guildId).apply {
             this.superUser = isSuperUser
-            this.musicDtos = emptyList<MusicDto>().toMutableList()
+            this.musicDtos = mutableListOf()
             userService.createNewUser(this)
         }
     }

--- a/discord-bot/src/main/kotlin/bot/toby/managers/DefaultCommandManager.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/managers/DefaultCommandManager.kt
@@ -57,11 +57,11 @@ class DefaultCommandManager @Autowired constructor(
 
     val allSlashCommands: List<CommandData?> get() = slashCommands
     val allCommands: List<Command> get() = commands
-    override val musicCommands: List<Command> get() = commands.filterIsInstance<MusicCommand>().toList()
-    override val dndCommands: List<Command> get() = commands.filterIsInstance<DnDCommand>().toList()
-    override val moderationCommands: List<Command> get() = commands.filterIsInstance<ModerationCommand>().toList()
-    override val miscCommands: List<Command> get() = commands.filterIsInstance<MiscCommand>().toList()
-    override val fetchCommands: List<Command> get() = commands.filterIsInstance<FetchCommand>().toList()
+    override val musicCommands: List<Command> get() = commands.filterIsInstance<MusicCommand>()
+    override val dndCommands: List<Command> get() = commands.filterIsInstance<DnDCommand>()
+    override val moderationCommands: List<Command> get() = commands.filterIsInstance<ModerationCommand>()
+    override val miscCommands: List<Command> get() = commands.filterIsInstance<MiscCommand>()
+    override val fetchCommands: List<Command> get() = commands.filterIsInstance<FetchCommand>()
 
     override fun handle(event: SlashCommandInteractionEvent) {
         val guildId = event.guild?.id ?: return

--- a/web/src/main/kotlin/web/controller/CampaignController.kt
+++ b/web/src/main/kotlin/web/controller/CampaignController.kt
@@ -9,6 +9,8 @@ import org.springframework.ui.Model
 import org.springframework.web.bind.annotation.*
 import org.springframework.web.servlet.mvc.support.RedirectAttributes
 import web.service.CampaignWebService
+import web.util.discordIdOrNull
+import web.util.displayName
 
 @Controller
 @RequestMapping("/dnd")
@@ -26,7 +28,7 @@ class CampaignController(
         val guilds = campaignWebService.getMutualGuildsWithCampaigns(accessToken)
 
         model.addAttribute("guilds", guilds)
-        model.addAttribute("username", user.getAttribute<String>("username") ?: "User")
+        model.addAttribute("username", user.displayName())
 
         return "campaign"
     }
@@ -38,7 +40,7 @@ class CampaignController(
         model: Model,
         ra: RedirectAttributes
     ): String {
-        val discordId = user.getAttribute<String>("id")?.toLongOrNull()
+        val discordId = user.discordIdOrNull()
             ?: return "redirect:/dnd/campaign"
 
         val guildName = campaignWebService.getGuildName(guildId) ?: run {
@@ -54,7 +56,7 @@ class CampaignController(
         model.addAttribute("players", campaignDetail?.players ?: emptyList<Any>())
         model.addAttribute("dmName", campaignDetail?.dmName)
         model.addAttribute("isUserDm", campaignDetail?.isDm(discordId) ?: false)
-        model.addAttribute("username", user.getAttribute<String>("username") ?: "User")
+        model.addAttribute("username", user.displayName())
 
         return "campaignDetail"
     }
@@ -66,7 +68,7 @@ class CampaignController(
         @AuthenticationPrincipal user: OAuth2User,
         ra: RedirectAttributes
     ): String {
-        val discordId = user.getAttribute<String>("id")?.toLongOrNull()
+        val discordId = user.discordIdOrNull()
             ?: return "redirect:/dnd/campaign"
 
         campaignWebService.getGuildName(guildId) ?: run {

--- a/web/src/main/kotlin/web/controller/IntroWebController.kt
+++ b/web/src/main/kotlin/web/controller/IntroWebController.kt
@@ -15,6 +15,9 @@ import org.springframework.web.bind.annotation.*
 import org.springframework.web.multipart.MultipartFile
 import org.springframework.web.servlet.mvc.support.RedirectAttributes
 import web.service.IntroWebService
+import web.util.discordIdOrNull
+import web.util.discordIdString
+import web.util.displayName
 
 @Controller
 @RequestMapping("/intro")
@@ -34,7 +37,7 @@ class IntroWebController(
         model: Model
     ): String {
         val accessToken = client.accessToken.tokenValue
-        val discordId = user.getAttribute<String>("id")?.toLongOrNull()
+        val discordId = user.discordIdOrNull()
         val guilds = introWebService.getMutualGuilds(accessToken)
 
         val counts: Map<String, Int> = if (discordId != null) {
@@ -45,8 +48,8 @@ class IntroWebController(
         model.addAttribute("guilds", guilds)
         model.addAttribute("introCounts", counts)
         model.addAttribute("maxIntros", IntroWebService.MAX_INTRO_COUNT)
-        model.addAttribute("username", user.getAttribute<String>("username") ?: "User")
-        model.addAttribute("discordId", user.getAttribute<String>("id") ?: "")
+        model.addAttribute("username", user.displayName())
+        model.addAttribute("discordId", user.discordIdString())
         model.addAttribute("inviteUrl", inviteUrl)
 
         return "guilds"
@@ -60,7 +63,7 @@ class IntroWebController(
         model: Model,
         ra: RedirectAttributes
     ): String {
-        val authDiscordId = user.getAttribute<String>("id")?.toLongOrNull()
+        val authDiscordId = user.discordIdOrNull()
             ?: return "redirect:/intro/guilds"
 
         val guildName = introWebService.getGuildName(guildId) ?: run {
@@ -77,7 +80,7 @@ class IntroWebController(
         model.addAttribute("guildId", guildId)
         model.addAttribute("guildName", guildName)
         model.addAttribute("intros", intros)
-        model.addAttribute("username", user.getAttribute<String>("username") ?: "User")
+        model.addAttribute("username", user.displayName())
         model.addAttribute("atLimit", intros.size >= IntroWebService.MAX_INTRO_COUNT)
         model.addAttribute("maxIntros", IntroWebService.MAX_INTRO_COUNT)
         model.addAttribute("maxFileKb", IntroWebService.MAX_FILE_SIZE / 1024)
@@ -102,7 +105,7 @@ class IntroWebController(
         @RequestParam(required = false) targetDiscordId: Long?,
         ra: RedirectAttributes
     ): String {
-        val authDiscordId = user.getAttribute<String>("id")?.toLongOrNull()
+        val authDiscordId = user.discordIdOrNull()
             ?: return "redirect:/intro/guilds"
         val effectiveDiscordId = resolveEffectiveDiscordId(authDiscordId, guildId, targetDiscordId)
 
@@ -135,7 +138,7 @@ class IntroWebController(
         session: HttpSession,
         ra: RedirectAttributes
     ): String {
-        val authDiscordId = user.getAttribute<String>("id")?.toLongOrNull()
+        val authDiscordId = user.discordIdOrNull()
             ?: return "redirect:/intro/guilds"
         val effectiveDiscordId = resolveEffectiveDiscordId(authDiscordId, guildId, targetDiscordId)
 
@@ -173,7 +176,7 @@ class IntroWebController(
         session: HttpSession,
         ra: RedirectAttributes
     ): String {
-        val authDiscordId = user.getAttribute<String>("id")?.toLongOrNull()
+        val authDiscordId = user.discordIdOrNull()
             ?: return "redirect:/intro/guilds"
         val effectiveDiscordId = resolveEffectiveDiscordId(authDiscordId, guildId, targetDiscordId)
 
@@ -218,7 +221,7 @@ class IntroWebController(
         @AuthenticationPrincipal user: OAuth2User,
         @RequestParam(required = false) targetDiscordId: Long?
     ): ResponseEntity<ApiResult> {
-        val authDiscordId = user.getAttribute<String>("id")?.toLongOrNull()
+        val authDiscordId = user.discordIdOrNull()
             ?: return ResponseEntity.status(401).body(ApiResult(false, "Not signed in."))
         val effective = resolveEffectiveDiscordId(authDiscordId, guildId, targetDiscordId)
         val error = introWebService.updateIntroVolume(effective, guildId, body.introId, body.volume)
@@ -234,7 +237,7 @@ class IntroWebController(
         @AuthenticationPrincipal user: OAuth2User,
         @RequestParam(required = false) targetDiscordId: Long?
     ): ResponseEntity<ApiResult> {
-        val authDiscordId = user.getAttribute<String>("id")?.toLongOrNull()
+        val authDiscordId = user.discordIdOrNull()
             ?: return ResponseEntity.status(401).body(ApiResult(false, "Not signed in."))
         val effective = resolveEffectiveDiscordId(authDiscordId, guildId, targetDiscordId)
         val error = introWebService.updateIntroName(effective, guildId, body.introId, body.name)
@@ -250,7 +253,7 @@ class IntroWebController(
         @AuthenticationPrincipal user: OAuth2User,
         @RequestParam(required = false) targetDiscordId: Long?
     ): ResponseEntity<ApiResult> {
-        val authDiscordId = user.getAttribute<String>("id")?.toLongOrNull()
+        val authDiscordId = user.discordIdOrNull()
             ?: return ResponseEntity.status(401).body(ApiResult(false, "Not signed in."))
         val effective = resolveEffectiveDiscordId(authDiscordId, guildId, targetDiscordId)
         val error = introWebService.reorderIntros(effective, guildId, body.orderedIds)

--- a/web/src/main/kotlin/web/service/IntroWebService.kt
+++ b/web/src/main/kotlin/web/service/IntroWebService.kt
@@ -170,9 +170,12 @@ class IntroWebService(
         return null
     }
 
+    private fun requireOwnedIntro(discordId: Long, guildId: Long, introId: String): String? =
+        if (introId.startsWith("${guildId}_${discordId}_")) null
+        else "Intro does not belong to you."
+
     fun deleteIntro(discordId: Long, guildId: Long, introId: String): String? {
-        val expectedPrefix = "${guildId}_${discordId}_"
-        if (!introId.startsWith(expectedPrefix)) return "Intro does not belong to you."
+        requireOwnedIntro(discordId, guildId, introId)?.let { return it }
 
         musicFileService.getMusicFileById(introId) ?: return "Intro not found."
         musicFileService.deleteMusicFileById(introId)
@@ -180,8 +183,7 @@ class IntroWebService(
     }
 
     fun updateIntroVolume(discordId: Long, guildId: Long, introId: String, volume: Int): String? {
-        val expectedPrefix = "${guildId}_${discordId}_"
-        if (!introId.startsWith(expectedPrefix)) return "Intro does not belong to you."
+        requireOwnedIntro(discordId, guildId, introId)?.let { return it }
 
         val dto = musicFileService.getMusicFileById(introId) ?: return "Intro not found."
         dto.introVolume = volume.coerceIn(1, 100)
@@ -190,8 +192,7 @@ class IntroWebService(
     }
 
     fun updateIntroName(discordId: Long, guildId: Long, introId: String, name: String): String? {
-        val expectedPrefix = "${guildId}_${discordId}_"
-        if (!introId.startsWith(expectedPrefix)) return "Intro does not belong to you."
+        requireOwnedIntro(discordId, guildId, introId)?.let { return it }
         val trimmed = name.trim()
         if (trimmed.isEmpty()) return "Name cannot be empty."
         if (trimmed.length > 200) return "Name is too long (max 200 characters)."

--- a/web/src/main/kotlin/web/util/OAuth2UserExtensions.kt
+++ b/web/src/main/kotlin/web/util/OAuth2UserExtensions.kt
@@ -1,0 +1,9 @@
+package web.util
+
+import org.springframework.security.oauth2.core.user.OAuth2User
+
+fun OAuth2User?.displayName(): String = this?.getAttribute<String>("username") ?: "User"
+
+fun OAuth2User.discordIdOrNull(): Long? = getAttribute<String>("id")?.toLongOrNull()
+
+fun OAuth2User.discordIdString(): String = getAttribute<String>("id") ?: ""

--- a/web/src/main/resources/static/js/intros.js
+++ b/web/src/main/resources/static/js/intros.js
@@ -303,25 +303,21 @@ function initIntroPage() {
         });
         slider.addEventListener('change', function () {
             const value = parseInt(slider.value, 10);
-            apiPostJson(buildUrl('/update-volume'), { introId: introId, volume: value })
-                .then(r => {
-                    if (r.ok) {
-                        lastSaved = String(value);
-                        window.TobyToast.show('Volume updated.', { type: 'success', duration: 2000 });
-                        // Keep row-level play button in sync for volume-aware preview
-                        const playBtn = document.querySelector('button.btn-play[data-audio-id="audio-' + introId + '"]');
-                        if (playBtn) playBtn.dataset.volume = String(value);
-                    } else {
-                        slider.value = lastSaved;
-                        if (valueEl) valueEl.textContent = lastSaved + '%';
-                        window.TobyToast.show(r.error || 'Failed to update volume.', { type: 'error' });
-                    }
-                })
-                .catch(() => {
+            apiCall(buildUrl('/update-volume'), { introId: introId, volume: value }, {
+                onSuccess: () => {
+                    lastSaved = String(value);
+                    window.TobyToast.show('Volume updated.', { type: 'success', duration: 2000 });
+                    // Keep row-level play button in sync for volume-aware preview
+                    const playBtn = document.querySelector('button.btn-play[data-audio-id="audio-' + introId + '"]');
+                    if (playBtn) playBtn.dataset.volume = String(value);
+                },
+                onError: (r) => {
                     slider.value = lastSaved;
                     if (valueEl) valueEl.textContent = lastSaved + '%';
-                    window.TobyToast.show('Network error.', { type: 'error' });
-                });
+                    const msg = r ? (r.error || 'Failed to update volume.') : 'Network error.';
+                    window.TobyToast.show(msg, { type: 'error' });
+                }
+            });
         });
     });
 
@@ -362,17 +358,17 @@ function initIntroPage() {
             function commit() {
                 const value = input.value.trim();
                 if (!value || value === current) { finish(current); return; }
-                apiPostJson(buildUrl('/update-name'), { introId: introId, name: value })
-                    .then(r => {
-                        if (r.ok) {
-                            finish(value);
-                            window.TobyToast.show('Renamed.', { type: 'success', duration: 2000 });
-                        } else {
-                            finish(current);
-                            window.TobyToast.show(r.error || 'Rename failed.', { type: 'error' });
-                        }
-                    })
-                    .catch(() => { finish(current); window.TobyToast.show('Network error.', { type: 'error' }); });
+                apiCall(buildUrl('/update-name'), { introId: introId, name: value }, {
+                    onSuccess: () => {
+                        finish(value);
+                        window.TobyToast.show('Renamed.', { type: 'success', duration: 2000 });
+                    },
+                    onError: (r) => {
+                        finish(current);
+                        const msg = r ? (r.error || 'Rename failed.') : 'Network error.';
+                        window.TobyToast.show(msg, { type: 'error' });
+                    }
+                });
             }
 
             input.addEventListener('blur', commit);
@@ -424,24 +420,21 @@ function initIntroPage() {
         function saveOrder() {
             const orderedIds = Array.from(tbody.querySelectorAll('tr[data-intro-id]'))
                 .map(r => r.dataset.introId);
-            apiPostJson(buildUrl('/reorder'), { orderedIds: orderedIds })
-                .then(r => {
-                    if (r.ok) {
-                        window.TobyToast.show('Order saved.', { type: 'success', duration: 2000 });
-                        // Update slot numbers in first column
-                        tbody.querySelectorAll('tr[data-intro-id]').forEach((r, i) => {
-                            const idx = r.querySelector('.slot-index');
-                            if (idx) idx.textContent = String(i + 1);
-                        });
-                    } else {
-                        window.TobyToast.show(r.error || 'Reorder failed. Reloading.', { type: 'error' });
-                        setTimeout(() => location.reload(), 800);
-                    }
-                })
-                .catch(() => {
-                    window.TobyToast.show('Network error. Reloading.', { type: 'error' });
+            apiCall(buildUrl('/reorder'), { orderedIds: orderedIds }, {
+                onSuccess: () => {
+                    window.TobyToast.show('Order saved.', { type: 'success', duration: 2000 });
+                    // Update slot numbers in first column
+                    tbody.querySelectorAll('tr[data-intro-id]').forEach((r, i) => {
+                        const idx = r.querySelector('.slot-index');
+                        if (idx) idx.textContent = String(i + 1);
+                    });
+                },
+                onError: (r) => {
+                    const msg = r ? (r.error || 'Reorder failed. Reloading.') : 'Network error. Reloading.';
+                    window.TobyToast.show(msg, { type: 'error' });
                     setTimeout(() => location.reload(), 800);
-                });
+                }
+            });
         }
     }
 
@@ -465,6 +458,14 @@ function initIntroPage() {
             headers: headers,
             body: JSON.stringify(body)
         }).then(r => r.json().catch(() => ({ ok: r.ok, error: r.ok ? null : 'Request failed.' })));
+    }
+
+    // Wraps apiPostJson so callers only supply success/error branches. Network
+    // failures go through onError with r = null so the same handler can cover both.
+    function apiCall(url, body, { onSuccess, onError }) {
+        return apiPostJson(url, body)
+            .then(r => { if (r.ok) onSuccess(r); else onError(r); })
+            .catch(() => onError(null));
     }
 
     function buildUrl(suffix) {


### PR DESCRIPTION
## Summary

Small, mechanical DRY cleanups across `discord-bot` and `web`. No behaviour changes — every change is a one-for-one rewrite of existing code paths.

### discord-bot / core-api
- **`BOT_WEB_URL` constant** (`discord-bot/.../Constants.kt`) — replaces the `"https://www.toby-bot.co.uk"` literal that was duplicated in `MusicPlayerHelper` and `CampaignCommand`.
- **`List<Member>.nonBots()` extension** (`discord-bot/.../helpers/MemberExtensions.kt`) — replaces five `!it.user.isBot` filter/count/none sites in `VoiceEventHandler` and `DnDHelper`.
- **Drop redundant `.toList()`** on five `filterIsInstance<T>()` call sites in `DefaultCommandManager` (already returns `List<T>`).
- **`mutableListOf()`** instead of `emptyList<MusicDto>().toMutableList()` in `UserDtoHelper` (and drop the now-unused `MusicDto` import).
- **`?.let` in DnD DTO `toEmbed()`** for `Feature`, `Condition`, and `SpellClasses` (range/dc/areaOfEffect/school/url) — removes verbose Java-style null guards.

### web
- **`OAuth2User` extensions** (`web/.../util/OAuth2UserExtensions.kt`):
  - `displayName()` → `"User"` fallback
  - `discordIdOrNull()` → parses `id` attr to `Long?`
  - `discordIdString()` → raw `id` attr or `""`
- Migrated 10+ call sites across `IntroWebController` and `CampaignController`.
- **`requireOwnedIntro` helper** in `IntroWebService` — replaces the `"${guildId}_${discordId}_"` prefix check that was duplicated in `deleteIntro` / `updateIntroVolume` / `updateIntroName`.
- **`apiCall` helper in `intros.js`** — consolidates three identical `fetch → toast` blocks (volume, rename, reorder). Preserves the original per-site api-error vs network-error messaging.

## Test plan
- [x] `npm test` (web JS suite) — 16/16 pass
- [ ] CI runs `./gradlew build` on JDK 22 (Gradle build blocked locally — only JDK 21 available in this environment)
- [ ] Bot starts and `DefaultCommandManager` still dispatches commands by category
- [ ] `/campaign` and music commands still render the `toby-bot.co.uk` links
- [ ] Voice event bot-filtering still works (idle disconnect, temporary channel cleanup, intro playback)
- [ ] `/intro/guilds` and `/intro/{guildId}` render with username; delete/rename/volume/reorder endpoints still reject foreign intro IDs with the same error message

https://claude.ai/code/session_01CaChvSYe78ZESuMbg8LScb