### PR TITLE
refactor: dedupe D&amp;D Beyond character ID parsing

### DIFF
--- a/common/src/main/kotlin/common/helpers/DndBeyondCharacterId.kt
+++ b/common/src/main/kotlin/common/helpers/DndBeyondCharacterId.kt
@@ -1,0 +1,6 @@
+package common.helpers
+
+private val CHARACTER_ID_REGEX = Regex("(\\d+)")
+
+fun parseDndBeyondCharacterId(input: String): Long? =
+    CHARACTER_ID_REGEX.findAll(input).lastOrNull()?.value?.toLongOrNull()

--- a/common/src/test/kotlin/common/helpers/DndBeyondCharacterIdTest.kt
+++ b/common/src/test/kotlin/common/helpers/DndBeyondCharacterIdTest.kt
@@ -1,0 +1,36 @@
+package common.helpers
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class DndBeyondCharacterIdTest {
+
+    @Test
+    fun `parses the character page URL`() {
+        assertEquals(48690485L, parseDndBeyondCharacterId("https://www.dndbeyond.com/characters/48690485"))
+    }
+
+    @Test
+    fun `parses a bare numeric ID`() {
+        assertEquals(48690485L, parseDndBeyondCharacterId("48690485"))
+    }
+
+    @Test
+    fun `parses the character-service API URL`() {
+        assertEquals(
+            48690485L,
+            parseDndBeyondCharacterId("https://character-service.dndbeyond.com/character/v5/character/48690485")
+        )
+    }
+
+    @Test
+    fun `returns null when input has no digits`() {
+        assertNull(parseDndBeyondCharacterId("not-a-valid-url"))
+    }
+
+    @Test
+    fun `returns the trailing numeric segment when multiple are present`() {
+        assertEquals(99L, parseDndBeyondCharacterId("abc123def/99"))
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/dnd/LinkCharacterCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/dnd/LinkCharacterCommand.kt
@@ -3,6 +3,7 @@ package bot.toby.command.commands.dnd
 import bot.toby.dto.web.dnd.CharacterSheet
 import bot.toby.helpers.UserDtoHelper
 import bot.toby.helpers.charactersheet.CharacterSheetProvider
+import common.helpers.parseDndBeyondCharacterId
 import core.command.Command.Companion.invokeDeleteOnMessageResponse
 import core.command.CommandContext
 import database.dto.UserDto
@@ -39,7 +40,7 @@ class LinkCharacterCommand @Autowired constructor(
         val hook = event.hook
 
         val input = event.getOption(CHARACTER)?.asString ?: ""
-        val characterId = extractCharacterId(input)
+        val characterId = parseDndBeyondCharacterId(input)
 
         if (characterId == null) {
             hook.sendMessage("Could not extract a valid character ID from: `$input`. Please provide a D&D Beyond character URL or numeric ID.")
@@ -75,9 +76,6 @@ class LinkCharacterCommand @Autowired constructor(
             }
         }
     }
-
-    internal fun extractCharacterId(input: String): Long? =
-        Regex("(\\d+)").findAll(input).lastOrNull()?.value?.toLongOrNull()
 
     private fun formatModifier(mod: Int): String = if (mod >= 0) "+$mod" else "$mod"
 }

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/dnd/LinkCharacterCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/dnd/LinkCharacterCommandTest.kt
@@ -16,8 +16,6 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import net.dv8tion.jda.api.interactions.commands.OptionMapping
 import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -132,11 +130,4 @@ class LinkCharacterCommandTest : CommandTest {
         verify { event.hook.sendMessage(any<String>()) }
     }
 
-    @Test
-    fun `extractCharacterId correctly parses various URL formats`() {
-        assertEquals(48690485L, command.extractCharacterId("https://www.dndbeyond.com/characters/48690485"))
-        assertEquals(48690485L, command.extractCharacterId("48690485"))
-        assertEquals(48690485L, command.extractCharacterId("https://character-service.dndbeyond.com/character/v5/character/48690485"))
-        assertNull(command.extractCharacterId("not-a-valid-url"))
-    }
 }

--- a/web/src/main/kotlin/web/service/CampaignWebService.kt
+++ b/web/src/main/kotlin/web/service/CampaignWebService.kt
@@ -2,6 +2,7 @@ package web.service
 
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
+import common.helpers.parseDndBeyondCharacterId
 import database.dto.CampaignDto
 import database.dto.CampaignPlayerDto
 import database.dto.CampaignPlayerId
@@ -161,7 +162,7 @@ class CampaignWebService(
             return SetCharacterResult.CLEARED
         }
 
-        val id = extractCharacterId(trimmed) ?: return SetCharacterResult.INVALID
+        val id = parseDndBeyondCharacterId(trimmed) ?: return SetCharacterResult.INVALID
         user.dndBeyondCharacterId = id
         userService.updateUser(user)
         return SetCharacterResult.UPDATED
@@ -198,11 +199,4 @@ class CampaignWebService(
         val classesString: String?,
         val totalLevel: Int?
     )
-
-    companion object {
-        private val CHARACTER_ID_REGEX = Regex("(\\d+)")
-
-        internal fun extractCharacterId(input: String): Long? =
-            CHARACTER_ID_REGEX.findAll(input).lastOrNull()?.value?.toLongOrNull()
-    }
 }


### PR DESCRIPTION
## Summary

Qodana cleanup pass after #228. The Qodana report cited 2 duplicated code fragments; one was the D&D Beyond character-ID regex copy-pasted between the Discord `/linkcharacter` command and the web `CampaignWebService`. Consolidates both callers onto a single `parseDndBeyondCharacterId` helper in `common/helpers` with its own focused test.

- New: `common/src/main/kotlin/common/helpers/DndBeyondCharacterId.kt`
- New: `common/src/test/kotlin/common/helpers/DndBeyondCharacterIdTest.kt`
- `LinkCharacterCommand`: drops the internal `extractCharacterId` method, uses the shared helper
- `CampaignWebService`: drops the companion-object regex, uses the shared helper
- `LinkCharacterCommandTest`: removes the URL-parsing test (moved to the common test)

## Test plan

- [ ] `./gradlew :common:test` — new `DndBeyondCharacterIdTest` passes locally
- [ ] `./gradlew build` passes in CI
- [ ] Existing `LinkCharacterCommandTest` + `CampaignWebServiceTest` still pass
- [ ] Qodana re-run no longer reports the duplicated-fragment finding for this pair

https://claude.ai/code/session_01DgKBYeiGaxmLg5xaPasU4r