### PR TITLE
feat(dnd): DM web controls for campaigns

### DIFF
--- a/application/src/test/kotlin/web/controller/CampaignControllerTest.kt
+++ b/application/src/test/kotlin/web/controller/CampaignControllerTest.kt
@@ -16,9 +16,12 @@ import org.springframework.ui.Model
 import org.springframework.web.servlet.mvc.support.RedirectAttributes
 import web.service.CampaignDetail
 import web.service.CampaignWebService
+import web.service.EndResult
 import web.service.GuildCampaignInfo
 import web.service.JoinResult
+import web.service.KickResult
 import web.service.LeaveResult
+import web.service.SetAliveResult
 import web.service.SetCharacterResult
 
 class CampaignControllerTest {
@@ -296,6 +299,114 @@ class CampaignControllerTest {
         every { mockUser.getAttribute<String>("id") } returns null
 
         val view = controller.setLinkedCharacter(guildId, "12345", mockUser, mockRa)
+
+        assertEquals("redirect:/dnd/campaign", view)
+    }
+
+    // endCampaign
+
+    @Test
+    fun `endCampaign redirects with no flash on success`() {
+        every { campaignWebService.endCampaign(guildId, 1L) } returns EndResult.ENDED
+
+        val view = controller.endCampaign(guildId, mockUser, mockRa)
+
+        assertEquals("redirect:/dnd/campaign/$guildId", view)
+        verify(exactly = 0) { mockRa.addFlashAttribute(any<String>(), any()) }
+    }
+
+    @Test
+    fun `endCampaign sets error when no active campaign`() {
+        every { campaignWebService.endCampaign(guildId, 1L) } returns EndResult.NO_ACTIVE_CAMPAIGN
+
+        controller.endCampaign(guildId, mockUser, mockRa)
+
+        verify { mockRa.addFlashAttribute("error", "No active campaign in this server.") }
+    }
+
+    @Test
+    fun `endCampaign sets error when not DM`() {
+        every { campaignWebService.endCampaign(guildId, 1L) } returns EndResult.NOT_DM
+
+        controller.endCampaign(guildId, mockUser, mockRa)
+
+        verify { mockRa.addFlashAttribute("error", "Only the Dungeon Master can end the campaign.") }
+    }
+
+    // kickPlayer
+
+    @Test
+    fun `kickPlayer redirects with no flash on success`() {
+        every { campaignWebService.kickPlayer(guildId, 1L, 99L) } returns KickResult.KICKED
+
+        val view = controller.kickPlayer(guildId, 99L, mockUser, mockRa)
+
+        assertEquals("redirect:/dnd/campaign/$guildId", view)
+        verify(exactly = 0) { mockRa.addFlashAttribute(any<String>(), any()) }
+    }
+
+    @Test
+    fun `kickPlayer sets error when not DM`() {
+        every { campaignWebService.kickPlayer(guildId, 1L, 99L) } returns KickResult.NOT_DM
+
+        controller.kickPlayer(guildId, 99L, mockUser, mockRa)
+
+        verify { mockRa.addFlashAttribute("error", "Only the Dungeon Master can kick players.") }
+    }
+
+    @Test
+    fun `kickPlayer sets error when target is DM`() {
+        every { campaignWebService.kickPlayer(guildId, 1L, 1L) } returns KickResult.CANNOT_KICK_DM
+
+        controller.kickPlayer(guildId, 1L, mockUser, mockRa)
+
+        verify { mockRa.addFlashAttribute("error", "The DM can't be kicked.") }
+    }
+
+    @Test
+    fun `kickPlayer sets error when target is not a player`() {
+        every { campaignWebService.kickPlayer(guildId, 1L, 99L) } returns KickResult.NOT_A_PLAYER
+
+        controller.kickPlayer(guildId, 99L, mockUser, mockRa)
+
+        verify { mockRa.addFlashAttribute("error", "That user isn't in the campaign.") }
+    }
+
+    // setPlayerAlive
+
+    @Test
+    fun `setPlayerAlive redirects with no flash on success`() {
+        every { campaignWebService.setPlayerAlive(guildId, 1L, 99L, false) } returns SetAliveResult.UPDATED
+
+        val view = controller.setPlayerAlive(guildId, 99L, false, mockUser, mockRa)
+
+        assertEquals("redirect:/dnd/campaign/$guildId", view)
+        verify(exactly = 0) { mockRa.addFlashAttribute(any<String>(), any()) }
+    }
+
+    @Test
+    fun `setPlayerAlive sets error when not DM`() {
+        every { campaignWebService.setPlayerAlive(guildId, 1L, 99L, true) } returns SetAliveResult.NOT_DM
+
+        controller.setPlayerAlive(guildId, 99L, true, mockUser, mockRa)
+
+        verify { mockRa.addFlashAttribute("error", "Only the Dungeon Master can change player status.") }
+    }
+
+    @Test
+    fun `setPlayerAlive sets error when target is not a player`() {
+        every { campaignWebService.setPlayerAlive(guildId, 1L, 99L, false) } returns SetAliveResult.NOT_A_PLAYER
+
+        controller.setPlayerAlive(guildId, 99L, false, mockUser, mockRa)
+
+        verify { mockRa.addFlashAttribute("error", "That user isn't in the campaign.") }
+    }
+
+    @Test
+    fun `setPlayerAlive redirects to list when user id missing`() {
+        every { mockUser.getAttribute<String>("id") } returns null
+
+        val view = controller.setPlayerAlive(guildId, 99L, false, mockUser, mockRa)
 
         assertEquals("redirect:/dnd/campaign", view)
     }

--- a/application/src/test/kotlin/web/service/CampaignWebServiceTest.kt
+++ b/application/src/test/kotlin/web/service/CampaignWebServiceTest.kt
@@ -389,4 +389,121 @@ class CampaignWebServiceTest {
         verify { userService.createNewUser(any()) }
         verify { userService.updateUser(match { it.dndBeyondCharacterId == 12345L }) }
     }
+
+    // endCampaign
+
+    @Test
+    fun `endCampaign returns NO_ACTIVE_CAMPAIGN when none exists`() {
+        every { campaignService.getActiveCampaignForGuild(guildId) } returns null
+        assertEquals(EndResult.NO_ACTIVE_CAMPAIGN, service.endCampaign(guildId, dmDiscordId))
+        verify(exactly = 0) { campaignService.deactivateCampaignForGuild(any()) }
+    }
+
+    @Test
+    fun `endCampaign returns NOT_DM when requester is not the DM`() {
+        every { campaignService.getActiveCampaignForGuild(guildId) } returns makeCampaign()
+        assertEquals(EndResult.NOT_DM, service.endCampaign(guildId, playerDiscordId))
+        verify(exactly = 0) { campaignService.deactivateCampaignForGuild(any()) }
+    }
+
+    @Test
+    fun `endCampaign deactivates and returns ENDED for DM`() {
+        every { campaignService.getActiveCampaignForGuild(guildId) } returns makeCampaign()
+        assertEquals(EndResult.ENDED, service.endCampaign(guildId, dmDiscordId))
+        verify { campaignService.deactivateCampaignForGuild(guildId) }
+    }
+
+    // kickPlayer
+
+    @Test
+    fun `kickPlayer returns NO_ACTIVE_CAMPAIGN when none exists`() {
+        every { campaignService.getActiveCampaignForGuild(guildId) } returns null
+        assertEquals(KickResult.NO_ACTIVE_CAMPAIGN, service.kickPlayer(guildId, dmDiscordId, playerDiscordId))
+    }
+
+    @Test
+    fun `kickPlayer returns NOT_DM when requester is not the DM`() {
+        every { campaignService.getActiveCampaignForGuild(guildId) } returns makeCampaign()
+        assertEquals(KickResult.NOT_DM, service.kickPlayer(guildId, playerDiscordId, playerDiscordId))
+        verify(exactly = 0) { campaignPlayerService.removePlayer(any()) }
+    }
+
+    @Test
+    fun `kickPlayer refuses to kick the DM`() {
+        every { campaignService.getActiveCampaignForGuild(guildId) } returns makeCampaign()
+        assertEquals(KickResult.CANNOT_KICK_DM, service.kickPlayer(guildId, dmDiscordId, dmDiscordId))
+        verify(exactly = 0) { campaignPlayerService.removePlayer(any()) }
+    }
+
+    @Test
+    fun `kickPlayer returns NOT_A_PLAYER when target is not in campaign`() {
+        val campaign = makeCampaign()
+        every { campaignService.getActiveCampaignForGuild(guildId) } returns campaign
+        every { campaignPlayerService.getPlayer(CampaignPlayerId(campaign.id, playerDiscordId)) } returns null
+
+        assertEquals(KickResult.NOT_A_PLAYER, service.kickPlayer(guildId, dmDiscordId, playerDiscordId))
+        verify(exactly = 0) { campaignPlayerService.removePlayer(any()) }
+    }
+
+    @Test
+    fun `kickPlayer removes the player and returns KICKED`() {
+        val campaign = makeCampaign()
+        val playerId = CampaignPlayerId(campaign.id, playerDiscordId)
+        every { campaignService.getActiveCampaignForGuild(guildId) } returns campaign
+        every { campaignPlayerService.getPlayer(playerId) } returns
+            CampaignPlayerDto(id = playerId, guildId = guildId)
+
+        assertEquals(KickResult.KICKED, service.kickPlayer(guildId, dmDiscordId, playerDiscordId))
+        verify { campaignPlayerService.removePlayer(playerId) }
+    }
+
+    // setPlayerAlive
+
+    @Test
+    fun `setPlayerAlive returns NO_ACTIVE_CAMPAIGN when none exists`() {
+        every { campaignService.getActiveCampaignForGuild(guildId) } returns null
+        assertEquals(
+            SetAliveResult.NO_ACTIVE_CAMPAIGN,
+            service.setPlayerAlive(guildId, dmDiscordId, playerDiscordId, false)
+        )
+    }
+
+    @Test
+    fun `setPlayerAlive returns NOT_DM when requester is not the DM`() {
+        every { campaignService.getActiveCampaignForGuild(guildId) } returns makeCampaign()
+        assertEquals(
+            SetAliveResult.NOT_DM,
+            service.setPlayerAlive(guildId, playerDiscordId, playerDiscordId, false)
+        )
+        verify(exactly = 0) { campaignPlayerService.updatePlayer(any()) }
+    }
+
+    @Test
+    fun `setPlayerAlive returns NOT_A_PLAYER when target is not in campaign`() {
+        val campaign = makeCampaign()
+        every { campaignService.getActiveCampaignForGuild(guildId) } returns campaign
+        every { campaignPlayerService.getPlayer(CampaignPlayerId(campaign.id, playerDiscordId)) } returns null
+
+        assertEquals(
+            SetAliveResult.NOT_A_PLAYER,
+            service.setPlayerAlive(guildId, dmDiscordId, playerDiscordId, false)
+        )
+        verify(exactly = 0) { campaignPlayerService.updatePlayer(any()) }
+    }
+
+    @Test
+    fun `setPlayerAlive toggles alive and returns UPDATED`() {
+        val campaign = makeCampaign()
+        val playerId = CampaignPlayerId(campaign.id, playerDiscordId)
+        val existing = CampaignPlayerDto(id = playerId, guildId = guildId, alive = true)
+        every { campaignService.getActiveCampaignForGuild(guildId) } returns campaign
+        every { campaignPlayerService.getPlayer(playerId) } returns existing
+
+        assertEquals(
+            SetAliveResult.UPDATED,
+            service.setPlayerAlive(guildId, dmDiscordId, playerDiscordId, false)
+        )
+        assertFalse(existing.alive)
+        verify { campaignPlayerService.updatePlayer(existing) }
+    }
 }

--- a/web/src/main/kotlin/web/controller/CampaignController.kt
+++ b/web/src/main/kotlin/web/controller/CampaignController.kt
@@ -9,8 +9,11 @@ import org.springframework.ui.Model
 import org.springframework.web.bind.annotation.*
 import org.springframework.web.servlet.mvc.support.RedirectAttributes
 import web.service.CampaignWebService
+import web.service.EndResult
 import web.service.JoinResult
+import web.service.KickResult
 import web.service.LeaveResult
+import web.service.SetAliveResult
 import web.service.SetCharacterResult
 import web.util.discordIdOrNull
 import web.util.displayName
@@ -138,6 +141,63 @@ class CampaignController(
                 "error",
                 "Could not extract a valid character ID. Paste a D&D Beyond URL or numeric ID."
             )
+        }
+        return "redirect:/dnd/campaign/$guildId"
+    }
+
+    @PostMapping("/campaign/{guildId}/end")
+    fun endCampaign(
+        @PathVariable guildId: Long,
+        @AuthenticationPrincipal user: OAuth2User,
+        ra: RedirectAttributes
+    ): String {
+        val discordId = user.discordIdOrNull()
+            ?: return "redirect:/dnd/campaign"
+
+        when (campaignWebService.endCampaign(guildId, discordId)) {
+            EndResult.ENDED -> {}
+            EndResult.NO_ACTIVE_CAMPAIGN -> ra.addFlashAttribute("error", "No active campaign in this server.")
+            EndResult.NOT_DM -> ra.addFlashAttribute("error", "Only the Dungeon Master can end the campaign.")
+        }
+        return "redirect:/dnd/campaign/$guildId"
+    }
+
+    @PostMapping("/campaign/{guildId}/players/{targetDiscordId}/kick")
+    fun kickPlayer(
+        @PathVariable guildId: Long,
+        @PathVariable targetDiscordId: Long,
+        @AuthenticationPrincipal user: OAuth2User,
+        ra: RedirectAttributes
+    ): String {
+        val discordId = user.discordIdOrNull()
+            ?: return "redirect:/dnd/campaign"
+
+        when (campaignWebService.kickPlayer(guildId, discordId, targetDiscordId)) {
+            KickResult.KICKED -> {}
+            KickResult.NO_ACTIVE_CAMPAIGN -> ra.addFlashAttribute("error", "No active campaign in this server.")
+            KickResult.NOT_DM -> ra.addFlashAttribute("error", "Only the Dungeon Master can kick players.")
+            KickResult.NOT_A_PLAYER -> ra.addFlashAttribute("error", "That user isn't in the campaign.")
+            KickResult.CANNOT_KICK_DM -> ra.addFlashAttribute("error", "The DM can't be kicked.")
+        }
+        return "redirect:/dnd/campaign/$guildId"
+    }
+
+    @PostMapping("/campaign/{guildId}/players/{targetDiscordId}/alive")
+    fun setPlayerAlive(
+        @PathVariable guildId: Long,
+        @PathVariable targetDiscordId: Long,
+        @RequestParam alive: Boolean,
+        @AuthenticationPrincipal user: OAuth2User,
+        ra: RedirectAttributes
+    ): String {
+        val discordId = user.discordIdOrNull()
+            ?: return "redirect:/dnd/campaign"
+
+        when (campaignWebService.setPlayerAlive(guildId, discordId, targetDiscordId, alive)) {
+            SetAliveResult.UPDATED -> {}
+            SetAliveResult.NO_ACTIVE_CAMPAIGN -> ra.addFlashAttribute("error", "No active campaign in this server.")
+            SetAliveResult.NOT_DM -> ra.addFlashAttribute("error", "Only the Dungeon Master can change player status.")
+            SetAliveResult.NOT_A_PLAYER -> ra.addFlashAttribute("error", "That user isn't in the campaign.")
         }
         return "redirect:/dnd/campaign/$guildId"
     }

--- a/web/src/main/kotlin/web/service/CampaignWebService.kt
+++ b/web/src/main/kotlin/web/service/CampaignWebService.kt
@@ -51,6 +51,9 @@ data class GuildCampaignInfo(
 enum class JoinResult { JOINED, NO_ACTIVE_CAMPAIGN, ALREADY_JOINED, IS_DM }
 enum class LeaveResult { LEFT, NO_ACTIVE_CAMPAIGN, NOT_A_PLAYER }
 enum class SetCharacterResult { UPDATED, CLEARED, INVALID }
+enum class EndResult { ENDED, NO_ACTIVE_CAMPAIGN, NOT_DM }
+enum class KickResult { KICKED, NO_ACTIVE_CAMPAIGN, NOT_DM, NOT_A_PLAYER, CANNOT_KICK_DM }
+enum class SetAliveResult { UPDATED, NO_ACTIVE_CAMPAIGN, NOT_DM, NOT_A_PLAYER }
 
 @Service
 class CampaignWebService(
@@ -166,6 +169,43 @@ class CampaignWebService(
         user.dndBeyondCharacterId = id
         userService.updateUser(user)
         return SetCharacterResult.UPDATED
+    }
+
+    fun endCampaign(guildId: Long, requestingDiscordId: Long): EndResult {
+        val campaign = campaignService.getActiveCampaignForGuild(guildId)
+            ?: return EndResult.NO_ACTIVE_CAMPAIGN
+        if (campaign.dmDiscordId != requestingDiscordId) return EndResult.NOT_DM
+        campaignService.deactivateCampaignForGuild(guildId)
+        return EndResult.ENDED
+    }
+
+    fun kickPlayer(guildId: Long, requestingDiscordId: Long, targetDiscordId: Long): KickResult {
+        val campaign = campaignService.getActiveCampaignForGuild(guildId)
+            ?: return KickResult.NO_ACTIVE_CAMPAIGN
+        if (campaign.dmDiscordId != requestingDiscordId) return KickResult.NOT_DM
+        if (campaign.dmDiscordId == targetDiscordId) return KickResult.CANNOT_KICK_DM
+
+        val playerId = CampaignPlayerId(campaign.id, targetDiscordId)
+        if (campaignPlayerService.getPlayer(playerId) == null) return KickResult.NOT_A_PLAYER
+        campaignPlayerService.removePlayer(playerId)
+        return KickResult.KICKED
+    }
+
+    fun setPlayerAlive(
+        guildId: Long,
+        requestingDiscordId: Long,
+        targetDiscordId: Long,
+        alive: Boolean
+    ): SetAliveResult {
+        val campaign = campaignService.getActiveCampaignForGuild(guildId)
+            ?: return SetAliveResult.NO_ACTIVE_CAMPAIGN
+        if (campaign.dmDiscordId != requestingDiscordId) return SetAliveResult.NOT_DM
+
+        val playerId = CampaignPlayerId(campaign.id, targetDiscordId)
+        val player = campaignPlayerService.getPlayer(playerId) ?: return SetAliveResult.NOT_A_PLAYER
+        player.alive = alive
+        campaignPlayerService.updatePlayer(player)
+        return SetAliveResult.UPDATED
     }
 
     private fun loadCharacterSummary(characterId: Long): CharacterSummary? {

--- a/web/src/main/resources/templates/campaignDetail.html
+++ b/web/src/main/resources/templates/campaignDetail.html
@@ -222,6 +222,26 @@
             font-size: 0.9rem;
         }
         .clear-form { display: inline; }
+        .dm-player-actions {
+            display: flex;
+            gap: 6px;
+            margin-left: 10px;
+        }
+        .dm-player-actions form { display: inline; }
+        .btn-xs {
+            padding: 5px 10px;
+            font-size: 0.75rem;
+            border-radius: 5px;
+            border: 1px solid #2a3a60;
+            background: transparent;
+            color: #a0a0b0;
+            font-family: inherit;
+            font-weight: 500;
+            cursor: pointer;
+        }
+        .btn-xs:hover { color: #e0e0e0; border-color: #3a4a70; }
+        .btn-xs.kick { color: #e74c3c; border-color: rgba(192,57,43,0.4); }
+        .btn-xs.kick:hover { background: rgba(192,57,43,0.15); }
     </style>
 </head>
 <body>
@@ -277,6 +297,11 @@
                 <form th:if="${isUserPlayer}"
                       th:action="@{/dnd/campaign/{id}/leave(id=${guildId})}" method="post">
                     <button type="submit" class="btn btn-secondary">Leave campaign</button>
+                </form>
+                <form th:if="${isUserDm}"
+                      th:action="@{/dnd/campaign/{id}/end(id=${guildId})}" method="post"
+                      onsubmit="return confirm('End this campaign? Players will be removed and the campaign marked inactive.');">
+                    <button type="submit" class="btn btn-danger">End campaign</button>
                 </form>
             </div>
         </div>
@@ -334,6 +359,25 @@
                 </div>
                 <span th:if="${player.alive}" class="player-status alive">Alive</span>
                 <span th:unless="${player.alive}" class="player-status dead">☠️ Dead</span>
+                <div th:if="${isUserDm}" class="dm-player-actions">
+                    <form th:if="${player.alive}"
+                          th:action="@{/dnd/campaign/{id}/players/{pid}/alive(id=${guildId},pid=${player.discordId})}"
+                          method="post">
+                        <input type="hidden" name="alive" value="false">
+                        <button type="submit" class="btn-xs" title="Mark as dead">☠️ Mark dead</button>
+                    </form>
+                    <form th:unless="${player.alive}"
+                          th:action="@{/dnd/campaign/{id}/players/{pid}/alive(id=${guildId},pid=${player.discordId})}"
+                          method="post">
+                        <input type="hidden" name="alive" value="true">
+                        <button type="submit" class="btn-xs" title="Mark as alive">Revive</button>
+                    </form>
+                    <form th:action="@{/dnd/campaign/{id}/players/{pid}/kick(id=${guildId},pid=${player.discordId})}"
+                          method="post"
+                          th:onsubmit="|return confirm('Kick ${player.displayName} from the campaign?');|">
+                        <button type="submit" class="btn-xs kick" title="Kick from campaign">Kick</button>
+                    </form>
+                </div>
             </div>
         </div>
 
@@ -344,7 +388,7 @@
         <div class="hint">
             Also available in Discord:
             <code>/campaign join</code> · <code>/campaign leave</code> · <code>/linkcharacter</code>
-            <span th:if="${isUserDm}"> · End the campaign with <code>/campaign end</code></span>
+            <span th:if="${isUserDm}"> · <code>/campaign end</code></span>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Summary

Adds DM-only controls to the campaign detail page at `/dnd/campaign/{guildId}`, filling the parity gap left after #228. All three actions are gated on `isUserDm` in the template and re-validated at the service layer.

- **End campaign** button on the campaign card — deactivates the campaign via `campaignService.deactivateCampaignForGuild`.
- **Kick** button per player — hard-remove via `campaignPlayerService.removePlayer` (matches `/campaign leave` semantics). DMs are refused.
- **Mark dead / Revive** toggle per player — flips `CampaignPlayerDto.alive` through `campaignPlayerService.updatePlayer`.

New endpoints:
- `POST /dnd/campaign/{guildId}/end`
- `POST /dnd/campaign/{guildId}/players/{targetDiscordId}/kick`
- `POST /dnd/campaign/{guildId}/players/{targetDiscordId}/alive` (form param `alive=true|false`)

Each endpoint redirects back to the detail page and surfaces a flash error for the obvious failure cases (no active campaign, not DM, not a player, can't kick DM).

## Test plan

- [ ] `./gradlew build` passes
- [ ] `CampaignWebServiceTest` — 10 new tests cover end/kick/alive happy paths + rejection branches
- [ ] `CampaignControllerTest` — 10 new tests cover redirects and flash errors for each endpoint
- [ ] Manual: as the DM, click End campaign → confirm dialog → campaign inactive
- [ ] Manual: as the DM, click Mark dead on a player → card shows ☠️ Dead; click Revive → back to Alive
- [ ] Manual: as the DM, click Kick on a player → confirm dialog → player removed from the list
- [ ] Manual: as a non-DM member viewing the detail page, confirm no End / Kick / Mark dead controls render

https://claude.ai/code/session_01DgKBYeiGaxmLg5xaPasU4r