### PR TITLE
feat(dnd): per-guild initiative state + Phase 3 snapshot/restore

### DIFF
--- a/application/src/main/kotlin/CampaignShutdownHook.kt
+++ b/application/src/main/kotlin/CampaignShutdownHook.kt
@@ -39,7 +39,7 @@ class CampaignShutdownHook(
             runCatching {
                 campaign.state = objectMapper.writeValueAsString(snapshot)
                 campaignService.updateCampaign(campaign)
-            }.onFailure { logger.error("Failed to persist state for guild $guildId", it) }
+            }.onFailure { logger.error("Failed to persist state for guild $guildId: ${it.message}") }
         }
     }
 }

--- a/application/src/main/kotlin/CampaignShutdownHook.kt
+++ b/application/src/main/kotlin/CampaignShutdownHook.kt
@@ -1,3 +1,5 @@
+import bot.toby.helpers.DnDHelper
+import com.fasterxml.jackson.databind.ObjectMapper
 import common.logging.DiscordLogger
 import database.service.CampaignService
 import org.springframework.beans.factory.DisposableBean
@@ -6,20 +8,38 @@ import org.springframework.stereotype.Component
 /**
  * Persists in-memory campaign state to the database on application shutdown (#218).
  *
- * In Phase 1 there is no transient in-memory state beyond what is already in the DB,
- * so this hook is a no-op. Phase 3 will populate `CampaignDto.state` with a JSON
- * snapshot of initiative order, roll history, and monster lists so sessions can resume
- * after a restart.
+ * For each guild whose DnDHelper currently holds an active initiative tracker, we
+ * look up the guild's active campaign and write the snapshot as JSON into
+ * [database.dto.CampaignDto.state]. Startup restoration happens in
+ * [CampaignStartupHook].
  */
 @Component
 class CampaignShutdownHook(
-    private val campaignService: CampaignService
+    private val campaignService: CampaignService,
+    private val dndHelper: DnDHelper,
+    private val objectMapper: ObjectMapper
 ) : DisposableBean {
 
     private val logger: DiscordLogger = DiscordLogger.createLogger(this::class.java)
 
     override fun destroy() {
-        logger.info("CampaignShutdownHook: persisting campaign state before shutdown")
-        // Phase 3: iterate active campaigns, serialise in-memory state to CampaignDto.state
+        val snapshots = dndHelper.activeSnapshots()
+        if (snapshots.isEmpty()) {
+            logger.info("CampaignShutdownHook: no in-memory initiative state to persist")
+            return
+        }
+
+        logger.info("CampaignShutdownHook: persisting initiative state for ${snapshots.size} guild(s)")
+        snapshots.forEach { (guildId, snapshot) ->
+            val campaign = campaignService.getActiveCampaignForGuild(guildId)
+            if (campaign == null) {
+                logger.warn("Guild $guildId has initiative state but no active campaign; skipping")
+                return@forEach
+            }
+            runCatching {
+                campaign.state = objectMapper.writeValueAsString(snapshot)
+                campaignService.updateCampaign(campaign)
+            }.onFailure { logger.error("Failed to persist state for guild $guildId", it) }
+        }
     }
 }

--- a/application/src/main/kotlin/CampaignStartupHook.kt
+++ b/application/src/main/kotlin/CampaignStartupHook.kt
@@ -1,0 +1,44 @@
+import bot.toby.helpers.DnDHelper
+import bot.toby.helpers.InitiativeStateSnapshot
+import com.fasterxml.jackson.databind.ObjectMapper
+import common.logging.DiscordLogger
+import database.service.CampaignService
+import org.springframework.boot.context.event.ApplicationReadyEvent
+import org.springframework.context.event.EventListener
+import org.springframework.stereotype.Component
+
+/**
+ * Restores any persisted initiative tracker state into DnDHelper on startup.
+ *
+ * Read pair of [CampaignShutdownHook]: for every active campaign with a non-blank
+ * state column, deserialize the [InitiativeStateSnapshot] and seed DnDHelper so
+ * the /init next, previous, and clear buttons work after a restart.
+ */
+@Component
+class CampaignStartupHook(
+    private val campaignService: CampaignService,
+    private val dndHelper: DnDHelper,
+    private val objectMapper: ObjectMapper
+) {
+
+    private val logger: DiscordLogger = DiscordLogger.createLogger(this::class.java)
+
+    @EventListener(ApplicationReadyEvent::class)
+    fun restoreCampaignState() {
+        val campaigns = campaignService.listActiveCampaigns().filter { !it.state.isNullOrBlank() }
+        if (campaigns.isEmpty()) {
+            logger.info("CampaignStartupHook: no persisted initiative state to restore")
+            return
+        }
+
+        logger.info("CampaignStartupHook: restoring initiative state for ${campaigns.size} campaign(s)")
+        campaigns.forEach { campaign ->
+            runCatching {
+                val snapshot = objectMapper.readValue(campaign.state, InitiativeStateSnapshot::class.java)
+                dndHelper.restore(campaign.guildId, snapshot)
+            }.onFailure {
+                logger.warn("Failed to restore state for guild ${campaign.guildId}: ${it.message}")
+            }
+        }
+    }
+}

--- a/database/src/main/kotlin/database/dto/CampaignDto.kt
+++ b/database/src/main/kotlin/database/dto/CampaignDto.kt
@@ -13,6 +13,10 @@ import java.io.Serializable
         query = "select c from CampaignDto c where c.id = :id"
     ),
     NamedQuery(
+        name = "CampaignDto.listActive",
+        query = "select c from CampaignDto c where c.active = true"
+    ),
+    NamedQuery(
         name = "CampaignDto.deactivateByGuild",
         query = "update CampaignDto c set c.active = false where c.guildId = :guildId and c.active = true"
     )

--- a/database/src/main/kotlin/database/persistence/CampaignPersistence.kt
+++ b/database/src/main/kotlin/database/persistence/CampaignPersistence.kt
@@ -6,6 +6,7 @@ interface CampaignPersistence {
     fun createCampaign(campaign: CampaignDto): CampaignDto
     fun getCampaignById(id: Long): CampaignDto?
     fun getActiveCampaignForGuild(guildId: Long): CampaignDto?
+    fun listActiveCampaigns(): List<CampaignDto>
     fun updateCampaign(campaign: CampaignDto): CampaignDto
     fun deactivateCampaignForGuild(guildId: Long)
 }

--- a/database/src/main/kotlin/database/persistence/impl/DefaultCampaignPersistence.kt
+++ b/database/src/main/kotlin/database/persistence/impl/DefaultCampaignPersistence.kt
@@ -32,6 +32,9 @@ class DefaultCampaignPersistence : CampaignPersistence {
         return runCatching { q.singleResult }.getOrNull()
     }
 
+    override fun listActiveCampaigns(): List<CampaignDto> =
+        entityManager.createNamedQuery("CampaignDto.listActive", CampaignDto::class.java).resultList
+
     override fun updateCampaign(campaign: CampaignDto): CampaignDto {
         entityManager.merge(campaign)
         entityManager.flush()

--- a/database/src/main/kotlin/database/service/CampaignService.kt
+++ b/database/src/main/kotlin/database/service/CampaignService.kt
@@ -6,6 +6,7 @@ interface CampaignService {
     fun createCampaign(campaign: CampaignDto): CampaignDto
     fun getCampaignById(id: Long): CampaignDto?
     fun getActiveCampaignForGuild(guildId: Long): CampaignDto?
+    fun listActiveCampaigns(): List<CampaignDto>
     fun updateCampaign(campaign: CampaignDto): CampaignDto
     fun deactivateCampaignForGuild(guildId: Long)
 }

--- a/database/src/main/kotlin/database/service/impl/DefaultCampaignService.kt
+++ b/database/src/main/kotlin/database/service/impl/DefaultCampaignService.kt
@@ -21,6 +21,9 @@ class DefaultCampaignService(
     override fun getActiveCampaignForGuild(guildId: Long): CampaignDto? =
         campaignPersistence.getActiveCampaignForGuild(guildId)
 
+    override fun listActiveCampaigns(): List<CampaignDto> =
+        campaignPersistence.listActiveCampaigns()
+
     override fun updateCampaign(campaign: CampaignDto): CampaignDto =
         campaignPersistence.updateCampaign(campaign)
 

--- a/discord-bot/src/main/kotlin/bot/toby/button/buttons/InitiativeClearButton.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/button/buttons/InitiativeClearButton.kt
@@ -16,6 +16,6 @@ class InitiativeClearButton @Autowired constructor(private val dnDHelper: DnDHel
     override fun handle(ctx: ButtonContext, requestingUserDto: database.dto.UserDto, deleteDelay: Int) {
         val event = ctx.event
         val hook = ctx.event.hook
-        dnDHelper.clearInitiative(hook, event)
+        dnDHelper.clearInitiative(ctx.guild.idLong, hook, event)
     }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/button/buttons/InitiativeNextButton.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/button/buttons/InitiativeNextButton.kt
@@ -16,6 +16,6 @@ class InitiativeNextButton @Autowired constructor(private val dndHelper: DnDHelp
     override fun handle(ctx: ButtonContext, requestingUserDto: database.dto.UserDto, deleteDelay: Int) {
         val event = ctx.event
         val hook = event.hook
-        dndHelper.incrementTurnTable(hook, event, deleteDelay)
+        dndHelper.incrementTurnTable(ctx.guild.idLong, hook, event, deleteDelay)
     }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/button/buttons/InitiativePreviousButton.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/button/buttons/InitiativePreviousButton.kt
@@ -16,6 +16,6 @@ class InitiativePreviousButton @Autowired constructor(private val dndHelper: DnD
     override fun handle(ctx: ButtonContext, requestingUserDto: database.dto.UserDto, deleteDelay: Int) {
         val event = ctx.event
         val hook = event.hook
-        dndHelper.decrementTurnTable(hook, event, deleteDelay)
+        dndHelper.decrementTurnTable(ctx.guild.idLong, hook, event, deleteDelay)
     }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/dnd/InitiativeCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/dnd/InitiativeCommand.kt
@@ -20,6 +20,12 @@ class InitiativeCommand @Autowired constructor(private val dndHelper: DnDHelper)
     override fun handle(ctx: CommandContext, requestingUserDto: UserDto, deleteDelay: Int) {
         val event = ctx.event
         event.deferReply().queue()
+        val guildId = event.guild?.idLong ?: run {
+            event.hook.sendMessage("Initiative can only be rolled inside a server.")
+                .setEphemeral(true)
+                .queue(invokeDeleteOnHookResponse(deleteDelay))
+            return
+        }
         val member = ctx.member
         val names = event.getOption("names")?.asString
         val dm = event.getOption("dm")?.asMember ?: ctx.member
@@ -31,15 +37,15 @@ class InitiativeCommand @Autowired constructor(private val dndHelper: DnDHelper)
 
         if (invalidArguments(deleteDelay, event, memberList, nameList)) return
 
-        dndHelper.clearInitiative()
+        dndHelper.clearInitiative(guildId)
         if (nameList.isNotEmpty()) {
-            dndHelper.rollInitiativeForString(nameList, initiativeMap)
+            dndHelper.rollInitiativeForString(guildId, nameList, initiativeMap)
         } else {
-            dndHelper.rollInitiativeForMembers(memberList, dm!!, initiativeMap)
+            dndHelper.rollInitiativeForMembers(guildId, memberList, dm!!, initiativeMap)
         }
 
-        if (checkForNonDmMembersInVoiceChannel(deleteDelay, event)) return
-        displayAllValues(event.hook, deleteDelay)
+        if (checkForNonDmMembersInVoiceChannel(deleteDelay, event, guildId)) return
+        displayAllValues(guildId, event.hook, deleteDelay)
     }
 
     override val name: String = "initiative"
@@ -69,8 +75,12 @@ class InitiativeCommand @Autowired constructor(private val dndHelper: DnDHelper)
         return false
     }
 
-    private fun checkForNonDmMembersInVoiceChannel(deleteDelay: Int, event: SlashCommandInteractionEvent): Boolean {
-        if (dndHelper.sortedEntries.isEmpty()) {
+    private fun checkForNonDmMembersInVoiceChannel(
+        deleteDelay: Int,
+        event: SlashCommandInteractionEvent,
+        guildId: Long
+    ): Boolean {
+        if (!dndHelper.stateFor(guildId).isActive()) {
             event.reply("The amount of non DM members in the voice channel you're in, or the one you mentioned, is empty, so no rolls were done.")
                 .setEphemeral(true)
                 .queue(invokeDeleteOnHookResponse(deleteDelay))
@@ -89,9 +99,9 @@ class InitiativeCommand @Autowired constructor(private val dndHelper: DnDHelper)
         return names?.split(",")?.map { it.trim() }?.filter { it.isNotEmpty() } ?: emptyList()
     }
 
-    private fun displayAllValues(hook: InteractionHook?, deleteDelay: Int) {
-        val embedBuilder = dndHelper.initiativeEmbedBuilder
-        dndHelper.sendOrEditInitiativeMessage(hook ?: return, embedBuilder, null, deleteDelay)
+    private fun displayAllValues(guildId: Long, hook: InteractionHook?, deleteDelay: Int) {
+        val embedBuilder = dndHelper.stateFor(guildId).initiativeEmbedBuilder
+        dndHelper.sendOrEditInitiativeMessage(guildId, hook ?: return, embedBuilder, null, deleteDelay)
     }
 
 }

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/dnd/InitiativeCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/dnd/InitiativeCommand.kt
@@ -2,6 +2,7 @@ package bot.toby.command.commands.dnd
 
 import bot.toby.helpers.DnDHelper
 import core.command.Command.Companion.invokeDeleteOnHookResponse
+import core.command.Command.Companion.invokeDeleteOnMessageResponse
 import core.command.CommandContext
 import database.dto.UserDto
 import net.dv8tion.jda.api.entities.GuildVoiceState
@@ -23,7 +24,7 @@ class InitiativeCommand @Autowired constructor(private val dndHelper: DnDHelper)
         val guildId = event.guild?.idLong ?: run {
             event.hook.sendMessage("Initiative can only be rolled inside a server.")
                 .setEphemeral(true)
-                .queue(invokeDeleteOnHookResponse(deleteDelay))
+                .queue(invokeDeleteOnMessageResponse(deleteDelay))
             return
         }
         val member = ctx.member

--- a/discord-bot/src/main/kotlin/bot/toby/helpers/DnDHelper.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/helpers/DnDHelper.kt
@@ -14,18 +14,36 @@ import net.dv8tion.jda.api.interactions.InteractionHook
 import net.dv8tion.jda.api.components.actionrow.ActionRow
 import net.dv8tion.jda.api.components.buttons.Button
 import org.springframework.stereotype.Service
-import java.awt.Color
-import java.util.*
-import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.ConcurrentHashMap
 import kotlin.random.Random
 
 @Service
 class DnDHelper(private val userDtoHelper: UserDtoHelper) {
-    val initiativeIndex = AtomicInteger(0)
-    var sortedEntries = LinkedList<Map.Entry<String, Int>>()
+
     private val logger = DiscordLogger(this::class.java)
+    private val states: ConcurrentHashMap<Long, InitiativeState> = ConcurrentHashMap()
+
+    val initButtons = TableButtons(
+        Button.primary("init:prev", "⬅️"),
+        Button.primary("init:clear", "❌"),
+        Button.primary("init:next", "➡️")
+    )
+
+    /** Returns (creating if absent) the per-guild initiative state. */
+    fun stateFor(guildId: Long): InitiativeState =
+        states.computeIfAbsent(guildId) { InitiativeState() }
+
+    /** Snapshot of every guild that currently has active initiative state. */
+    fun activeSnapshots(): Map<Long, InitiativeStateSnapshot> =
+        states.filterValues { it.isActive() }.mapValues { (_, v) -> v.snapshot() }
+
+    /** Replace (or seed) the state for the given guild from a snapshot. */
+    fun restore(guildId: Long, snapshot: InitiativeStateSnapshot) {
+        stateFor(guildId).restoreFrom(snapshot)
+    }
 
     fun rollInitiativeForMembers(
+        guildId: Long,
         memberList: List<Member>,
         dm: Member,
         initiativeMap: MutableMap<String, Int>
@@ -35,105 +53,71 @@ class DnDHelper(private val userDtoHelper: UserDtoHelper) {
             val userDto = userDtoHelper.calculateUserDto(target.idLong, target.guild.idLong, target.isOwner)
             rollAndAddToMap(initiativeMap, target.user.effectiveName, userDto.initiativeModifier ?: 0)
         }
-        sortMap(initiativeMap)
+        stateFor(guildId).sortMap(initiativeMap)
     }
 
-    fun rollInitiativeForString(nameList: List<String>, initiativeMap: MutableMap<String, Int>) {
+    fun rollInitiativeForString(
+        guildId: Long,
+        nameList: List<String>,
+        initiativeMap: MutableMap<String, Int>
+    ) {
         nameList.forEach { name -> rollAndAddToMap(initiativeMap, name, 0) }
-        sortMap(initiativeMap)
-    }
-
-    private fun sortMap(initiativeMap: Map<String, Int>) {
-        sortedEntries = LinkedList(initiativeMap.entries.sortedByDescending { it.value })
+        stateFor(guildId).sortMap(initiativeMap)
     }
 
     private fun rollAndAddToMap(initiativeMap: MutableMap<String, Int>, name: String, modifier: Int) {
-        val diceRoll = rollDiceWithModifier(20, 1, modifier)
-        initiativeMap[name] = diceRoll
+        initiativeMap[name] = rollDiceWithModifier(20, 1, modifier)
     }
 
-    fun rollDiceWithModifier(diceValue: Int, diceToRoll: Int, modifier: Int): Int {
-        return rollDice(diceValue, diceToRoll) + modifier
+    fun rollDiceWithModifier(diceValue: Int, diceToRoll: Int, modifier: Int): Int =
+        rollDice(diceValue, diceToRoll) + modifier
+
+    fun rollDice(diceValue: Int, diceToRoll: Int): Int =
+        (0 until diceToRoll).sumOf { Random.nextInt(1, diceValue + 1) }
+
+    fun incrementTurnTable(guildId: Long, hook: InteractionHook, event: ButtonInteractionEvent?, deleteDelay: Int) {
+        val state = stateFor(guildId)
+        state.incrementIndex()
+        sendOrEditInitiativeMessage(guildId, hook, state.initiativeEmbedBuilder, event, deleteDelay)
     }
 
-    fun rollDice(diceValue: Int, diceToRoll: Int): Int {
-        return (0 until diceToRoll).sumOf { Random.nextInt(1, diceValue + 1) }
+    fun decrementTurnTable(guildId: Long, hook: InteractionHook, event: ButtonInteractionEvent?, deleteDelay: Int) {
+        val state = stateFor(guildId)
+        state.decrementIndex()
+        sendOrEditInitiativeMessage(guildId, hook, state.initiativeEmbedBuilder, event, deleteDelay)
     }
-
-    fun incrementTurnTable(hook: InteractionHook, event: ButtonInteractionEvent?, deleteDelay: Int) {
-        incrementIndex()
-        sendOrEditInitiativeMessage(hook, initiativeEmbedBuilder, event, deleteDelay)
-    }
-
-    private fun incrementIndex() {
-        initiativeIndex.incrementAndGet()
-        if (initiativeIndex.get() >= sortedEntries.size) {
-            initiativeIndex.set(0)
-        }
-    }
-
-    fun decrementTurnTable(hook: InteractionHook, event: ButtonInteractionEvent?, deleteDelay: Int) {
-        decrementIndex()
-        sendOrEditInitiativeMessage(hook, initiativeEmbedBuilder, event, deleteDelay)
-    }
-
-    private fun decrementIndex() {
-        initiativeIndex.decrementAndGet()
-        if (initiativeIndex.get() < 0) {
-            initiativeIndex.set(sortedEntries.size - 1)
-        }
-    }
-
-    val initButtons = TableButtons(
-        Button.primary("init:prev", "⬅️"),
-        Button.primary("init:clear", "❌"),
-        Button.primary("init:next", "➡️")
-    )
 
     fun sendOrEditInitiativeMessage(
+        guildId: Long,
         hook: InteractionHook,
         embedBuilder: EmbedBuilder,
         event: ButtonInteractionEvent?,
         deleteDelay: Int
     ) {
+        val state = stateFor(guildId)
         val messageEmbed = embedBuilder.build()
         if (event == null) {
             hook.sendMessageEmbeds(messageEmbed)
                 .setComponents(ActionRow.of(initButtons.prev, initButtons.clear, initButtons.next))
                 .queue()
         } else {
-            // if we're here we came via a button press, so edit the embed rather than make a new one
             event.message
                 .editMessageEmbeds(messageEmbed)
                 .setComponents(ActionRow.of(initButtons.prev, initButtons.clear, initButtons.next))
                 .queue()
-            hook.setEphemeral(true).sendMessage("Next turn: ${sortedEntries[initiativeIndex.get()].key}").queue(
-                core.command.Command.invokeDeleteOnMessageResponse(deleteDelay)
-            )
+            hook.setEphemeral(true)
+                .sendMessage("Next turn: ${state.sortedEntries[state.initiativeIndex.get()].key}")
+                .queue(core.command.Command.invokeDeleteOnMessageResponse(deleteDelay))
         }
     }
 
-    val initiativeEmbedBuilder: EmbedBuilder
-        get() {
-            val embedBuilder = EmbedBuilder()
-            embedBuilder.setColor(Color.GREEN)
-            embedBuilder.setTitle("Initiative Order")
-            val description = sortedEntries.withIndex().joinToString("\n") { (index, entry) ->
-                "${index + initiativeIndex.get() % sortedEntries.size}: ${entry.key}: ${entry.value}"
-            }
-            embedBuilder.setDescription(description)
-            return embedBuilder
-        }
-
-    fun clearInitiative() {
-        initiativeIndex.set(0)
-        sortedEntries.clear()
+    fun clearInitiative(guildId: Long) {
+        stateFor(guildId).clear()
     }
 
-    fun clearInitiative(hook: InteractionHook, event: ButtonInteractionEvent) {
+    fun clearInitiative(guildId: Long, hook: InteractionHook, event: ButtonInteractionEvent) {
         event.message.delete().queue()
-        initiativeIndex.set(0)
-        sortedEntries.clear()
+        stateFor(guildId).clear()
         hook.deleteOriginal().queue()
     }
 
@@ -144,7 +128,7 @@ class DnDHelper(private val userDtoHelper: UserDtoHelper) {
         httpHelper: HttpHelper
     ): DnDResponse? {
         val url = "https://www.dnd5eapi.co/api/$typeValue/${query.replaceSpaceWithDash()}"
-        logger.info ("Fetching data from '$url'")
+        logger.info("Fetching data from '$url'")
         val responseData = httpHelper.fetchFromGet(url)
         return when (typeName) {
             SPELL_NAME -> JsonParser.parseJSONToSpell(responseData)
@@ -166,13 +150,8 @@ class DnDHelper(private val userDtoHelper: UserDtoHelper) {
         return JsonParser.parseJsonToQueryResult(queryResponseData)
     }
 
-    private fun String.replaceSpaceWithDash(): String {
-        return this.replace(" ", "-")
-    }
-
-    private fun String.replaceSpaceWithUrlEncode(): String {
-        return this.replace(" ", "%20")
-    }
+    private fun String.replaceSpaceWithDash(): String = this.replace(" ", "-")
+    private fun String.replaceSpaceWithUrlEncode(): String = this.replace(" ", "%20")
 
     data class TableButtons(val prev: Button, val clear: Button, val next: Button)
 }

--- a/discord-bot/src/main/kotlin/bot/toby/helpers/InitiativeState.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/helpers/InitiativeState.kt
@@ -1,0 +1,79 @@
+package bot.toby.helpers
+
+import net.dv8tion.jda.api.EmbedBuilder
+import net.dv8tion.jda.api.components.actionrow.ActionRow
+import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent
+import net.dv8tion.jda.api.interactions.InteractionHook
+import java.awt.Color
+import java.util.LinkedList
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Per-guild initiative tracker state. One instance per active guild; DnDHelper
+ * manages the Map keyed by guildId. Snapshot/restore methods support Phase 3
+ * persistence via CampaignDto.state.
+ */
+class InitiativeState {
+
+    val initiativeIndex: AtomicInteger = AtomicInteger(0)
+    var sortedEntries: LinkedList<Map.Entry<String, Int>> = LinkedList()
+        private set
+
+    fun isActive(): Boolean = sortedEntries.isNotEmpty()
+
+    internal fun sortMap(initiativeMap: Map<String, Int>) {
+        sortedEntries = LinkedList(initiativeMap.entries.sortedByDescending { it.value })
+    }
+
+    fun clear() {
+        initiativeIndex.set(0)
+        sortedEntries.clear()
+    }
+
+    internal fun incrementIndex() {
+        initiativeIndex.incrementAndGet()
+        if (initiativeIndex.get() >= sortedEntries.size) {
+            initiativeIndex.set(0)
+        }
+    }
+
+    internal fun decrementIndex() {
+        initiativeIndex.decrementAndGet()
+        if (initiativeIndex.get() < 0) {
+            initiativeIndex.set(sortedEntries.size - 1)
+        }
+    }
+
+    val initiativeEmbedBuilder: EmbedBuilder
+        get() {
+            val embedBuilder = EmbedBuilder()
+            embedBuilder.setColor(Color.GREEN)
+            embedBuilder.setTitle("Initiative Order")
+            val description = sortedEntries.withIndex().joinToString("\n") { (index, entry) ->
+                "${index + initiativeIndex.get() % sortedEntries.size}: ${entry.key}: ${entry.value}"
+            }
+            embedBuilder.setDescription(description)
+            return embedBuilder
+        }
+
+    fun snapshot(): InitiativeStateSnapshot = InitiativeStateSnapshot(
+        initiativeIndex = initiativeIndex.get(),
+        entries = sortedEntries.map { InitiativeEntry(it.key, it.value) }
+    )
+
+    fun restoreFrom(snapshot: InitiativeStateSnapshot) {
+        initiativeIndex.set(snapshot.initiativeIndex)
+        sortedEntries = LinkedList(snapshot.entries.map { java.util.AbstractMap.SimpleEntry(it.name, it.roll) })
+    }
+}
+
+/** JSON-friendly snapshot of an [InitiativeState], persisted in CampaignDto.state. */
+data class InitiativeStateSnapshot(
+    val initiativeIndex: Int = 0,
+    val entries: List<InitiativeEntry> = emptyList()
+)
+
+data class InitiativeEntry(
+    val name: String = "",
+    val roll: Int = 0
+)

--- a/discord-bot/src/main/kotlin/bot/toby/helpers/InitiativeState.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/helpers/InitiativeState.kt
@@ -1,9 +1,6 @@
 package bot.toby.helpers
 
 import net.dv8tion.jda.api.EmbedBuilder
-import net.dv8tion.jda.api.components.actionrow.ActionRow
-import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent
-import net.dv8tion.jda.api.interactions.InteractionHook
 import java.awt.Color
 import java.util.LinkedList
 import java.util.concurrent.atomic.AtomicInteger

--- a/discord-bot/src/test/kotlin/bot/toby/button/buttons/InitiativeClearButtonTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/button/buttons/InitiativeClearButtonTest.kt
@@ -56,12 +56,12 @@ class InitiativeClearButtonTest : ButtonTest {
 
         // Mock clearInitiative method to just verify the call
 
-        every { dndHelper.clearInitiative(any(), any()) } just Runs
+        every { dndHelper.clearInitiative(any<Long>(), any(), any()) } just Runs
 
         // Invoke the handler
         InitiativeClearButton(dndHelper).handle(DefaultButtonContext(event), UserDto(6L, 1L), 0)
 
         // Verify expected interactions
-        verify(exactly = 1) { dndHelper.clearInitiative(mockHook, event) }
+        verify(exactly = 1) { dndHelper.clearInitiative(1L, mockHook, event) }
     }
 }

--- a/discord-bot/src/test/kotlin/bot/toby/button/buttons/InitiativeNextButtonTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/button/buttons/InitiativeNextButtonTest.kt
@@ -56,12 +56,12 @@ class InitiativeNextButtonTest : ButtonTest {
 
         // Mock clearInitiative method to just verify the call
 
-        every { dndHelper.incrementTurnTable(any(), any(), any()) } just Runs
+        every { dndHelper.incrementTurnTable(any(), any(), any(), any()) } just Runs
 
         // Invoke the handler
         InitiativeNextButton(dndHelper).handle(DefaultButtonContext(event), database.dto.UserDto(6L, 1L), 0)
 
         // Verify expected interactions
-        verify(exactly = 1) { dndHelper.incrementTurnTable(mockHook, event, 0) }
+        verify(exactly = 1) { dndHelper.incrementTurnTable(1L, mockHook, event, 0) }
     }
 }

--- a/discord-bot/src/test/kotlin/bot/toby/button/buttons/InitiativePreviousButtonTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/button/buttons/InitiativePreviousButtonTest.kt
@@ -55,12 +55,12 @@ class InitiativePreviousButtonTest : ButtonTest {
         every { userService.getUserById(any(), any()) } returns mockk(relaxed = true)
 
 
-        every { dndHelper.decrementTurnTable(any(), any(), any()) } just Runs
+        every { dndHelper.decrementTurnTable(any(), any(), any(), any()) } just Runs
 
         // Invoke the handler
         InitiativePreviousButton(dndHelper).handle(DefaultButtonContext(event), database.dto.UserDto(6L, 1L), 0)
 
         // Verify expected interactions
-        verify(exactly = 1) { dndHelper.decrementTurnTable(mockHook, event, 0) }
+        verify(exactly = 1) { dndHelper.decrementTurnTable(1L, mockHook, event, 0) }
     }
 }

--- a/discord-bot/src/test/kotlin/bot/toby/helpers/DnDHelperTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/helpers/DnDHelperTest.kt
@@ -43,6 +43,8 @@ internal class DnDHelperTest {
     lateinit var userDtoHelper: UserDtoHelper
     lateinit var dndHelper: DnDHelper
 
+    private val guildId = 1L
+
     @BeforeEach
     fun setUp() {
         hook = mockk()
@@ -106,7 +108,7 @@ internal class DnDHelperTest {
         every { messageEditAction.queue() } just Runs
         every { message.delete() } returns auditableRestAction
 
-        dndHelper.clearInitiative()
+        dndHelper.clearInitiative(guildId)
 
         every { hook.deleteOriginal() } returns mockk<RestAction<Void>>()
         every { hook.setEphemeral(true) } returns hook
@@ -137,7 +139,7 @@ internal class DnDHelperTest {
     @AfterEach
     fun tearDown() {
         clearAllMocks()
-        dndHelper.clearInitiative()
+        dndHelper.clearInitiative(guildId)
     }
 
     @Test
@@ -154,28 +156,30 @@ internal class DnDHelperTest {
 
     @Test
     fun testIncrementTurnTable() {
-        dndHelper.rollInitiativeForMembers(memberList, member, initiativeMap)
-        dndHelper.sendOrEditInitiativeMessage(hook, dndHelper.initiativeEmbedBuilder, null, 0)
-        dndHelper.incrementTurnTable(hook, event, 0)
+        dndHelper.rollInitiativeForMembers(guildId, memberList, member, initiativeMap)
+        val state = dndHelper.stateFor(guildId)
+        dndHelper.sendOrEditInitiativeMessage(guildId, hook, state.initiativeEmbedBuilder, null, 0)
+        dndHelper.incrementTurnTable(guildId, hook, event, 0)
         verifySetActionRows(webhookMessageCreateAction, messageEditAction)
 
         verify(exactly = 1) { webhookMessageCreateAction.queue(any()) }
         verify(exactly = 1) { hook.sendMessageEmbeds(any<MessageEmbed>()) }
         verify(exactly = 1) { messageEditAction.queue() }
-        Assertions.assertEquals(1, dndHelper.initiativeIndex.get())
+        Assertions.assertEquals(1, state.initiativeIndex.get())
     }
 
     @Test
     fun testDecrementTurnTable() {
-        dndHelper.rollInitiativeForMembers(memberList, member, initiativeMap)
-        dndHelper.sendOrEditInitiativeMessage(hook, dndHelper.initiativeEmbedBuilder, null, 0)
-        dndHelper.decrementTurnTable(hook, event, 0)
+        dndHelper.rollInitiativeForMembers(guildId, memberList, member, initiativeMap)
+        val state = dndHelper.stateFor(guildId)
+        dndHelper.sendOrEditInitiativeMessage(guildId, hook, state.initiativeEmbedBuilder, null, 0)
+        dndHelper.decrementTurnTable(guildId, hook, event, 0)
         verifySetActionRows(webhookMessageCreateAction, messageEditAction)
 
         verify(exactly = 1) { webhookMessageCreateAction.queue(any()) }
         verify(exactly = 1) { hook.sendMessageEmbeds(any<MessageEmbed>()) }
         verify(exactly = 1) { messageEditAction.queue() }
-        Assertions.assertEquals(2, dndHelper.initiativeIndex.get())
+        Assertions.assertEquals(2, state.initiativeIndex.get())
     }
 
     @Test
@@ -190,7 +194,7 @@ internal class DnDHelperTest {
 
     @Test
     fun testGetInitiativeEmbedBuilder() {
-        val embedBuilder = dndHelper.initiativeEmbedBuilder
+        val embedBuilder = dndHelper.stateFor(guildId).initiativeEmbedBuilder
 
         Assertions.assertNotNull(embedBuilder)
         Assertions.assertEquals("Initiative Order", embedBuilder.build().title)
@@ -198,19 +202,20 @@ internal class DnDHelperTest {
 
     @Test
     fun testClearInitiative() {
-        dndHelper.rollInitiativeForMembers(memberList, member, initiativeMap)
-        dndHelper.clearInitiative()
+        dndHelper.rollInitiativeForMembers(guildId, memberList, member, initiativeMap)
+        dndHelper.clearInitiative(guildId)
 
-        Assertions.assertEquals(0, dndHelper.initiativeIndex.get())
-        Assertions.assertEquals(0, dndHelper.sortedEntries.size)
+        val state = dndHelper.stateFor(guildId)
+        Assertions.assertEquals(0, state.initiativeIndex.get())
+        Assertions.assertEquals(0, state.sortedEntries.size)
     }
 
     @Test
     fun testRollInitiativeForMembersWithEmptyList() {
-        dndHelper.clearInitiative()
-        dndHelper.rollInitiativeForMembers(emptyList(), member, initiativeMap)
+        dndHelper.clearInitiative(guildId)
+        dndHelper.rollInitiativeForMembers(guildId, emptyList(), member, initiativeMap)
         Assertions.assertTrue(
-            dndHelper.sortedEntries.isEmpty(),
+            dndHelper.stateFor(guildId).sortedEntries.isEmpty(),
             "Sorted entries should be empty for an empty member list"
         )
     }
@@ -218,7 +223,7 @@ internal class DnDHelperTest {
     @Test
     fun testRollInitiativeForString() {
         val names = listOf("Alice", "Bob", "Charlie")
-        dndHelper.rollInitiativeForString(names, initiativeMap)
+        dndHelper.rollInitiativeForString(guildId, names, initiativeMap)
         Assertions.assertEquals(3, initiativeMap.size, "There should be an entry for each name")
         names.forEach { name ->
             Assertions.assertTrue(initiativeMap.containsKey(name), "Initiative map should contain entry for $name")
@@ -227,9 +232,11 @@ internal class DnDHelperTest {
 
     @Test
     fun testSendOrEditInitiativeMessageForNewMessage() {
-        dndHelper.clearInitiative()
-        dndHelper.rollInitiativeForMembers(memberList, member, initiativeMap)
-        dndHelper.sendOrEditInitiativeMessage(hook, dndHelper.initiativeEmbedBuilder, null, 0)
+        dndHelper.clearInitiative(guildId)
+        dndHelper.rollInitiativeForMembers(guildId, memberList, member, initiativeMap)
+        dndHelper.sendOrEditInitiativeMessage(
+            guildId, hook, dndHelper.stateFor(guildId).initiativeEmbedBuilder, null, 0
+        )
 
         verify(exactly = 1) { hook.sendMessageEmbeds(any<MessageEmbed>()) }
         verify(exactly = 1) { webhookMessageCreateAction.setComponents(any<ActionRow>()) }
@@ -238,15 +245,42 @@ internal class DnDHelperTest {
 
     @Test
     fun testSendOrEditInitiativeMessageForExistingMessage() {
-        dndHelper.clearInitiative()
-        dndHelper.rollInitiativeForMembers(memberList, member, initiativeMap)
-        dndHelper.sendOrEditInitiativeMessage(hook, dndHelper.initiativeEmbedBuilder, event, 0)
+        dndHelper.clearInitiative(guildId)
+        dndHelper.rollInitiativeForMembers(guildId, memberList, member, initiativeMap)
+        dndHelper.sendOrEditInitiativeMessage(
+            guildId, hook, dndHelper.stateFor(guildId).initiativeEmbedBuilder, event, 0
+        )
 
         verify(exactly = 1) { message.editMessageEmbeds(any<MessageEmbed>()) }
         verify(exactly = 1) { messageEditAction.setComponents(any<ActionRow>()) }
         verify(exactly = 1) { messageEditAction.queue() }
         verify(exactly = 1) { hook.setEphemeral(true) }
         verify(exactly = 1) { hook.sendMessage(any<String>()) }
+    }
+
+    @Test
+    fun testActiveSnapshotsRoundTrip() {
+        dndHelper.rollInitiativeForMembers(guildId, memberList, member, initiativeMap)
+        val snapshots = dndHelper.activeSnapshots()
+        Assertions.assertTrue(snapshots.containsKey(guildId))
+
+        dndHelper.clearInitiative(guildId)
+        Assertions.assertTrue(dndHelper.activeSnapshots().isEmpty())
+
+        dndHelper.restore(guildId, snapshots.getValue(guildId))
+        val restored = dndHelper.stateFor(guildId)
+        Assertions.assertTrue(restored.isActive())
+        Assertions.assertEquals(snapshots.getValue(guildId).entries.size, restored.sortedEntries.size)
+    }
+
+    @Test
+    fun testStatesAreIsolatedBetweenGuilds() {
+        val otherGuild = 2L
+        dndHelper.rollInitiativeForMembers(guildId, memberList, member, initiativeMap)
+        dndHelper.clearInitiative(otherGuild)
+        // Roll for guildId must not be affected by clearing otherGuild
+        Assertions.assertTrue(dndHelper.stateFor(guildId).isActive())
+        Assertions.assertFalse(dndHelper.stateFor(otherGuild).isActive())
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)


### PR DESCRIPTION
## Summary

Closes the per-guild initiative bug and ships Phase 3 (issue #218) campaign-state snapshot/restore.

### The bug this fixes
`DnDHelper` is a Spring singleton and previously held a single `initiativeIndex` + `sortedEntries` pair shared across every guild the bot is in. Guild A rolling initiative would silently clobber Guild B's tracker. Multi-guild deployments had no correct initiative behaviour.

### Refactor
- New `InitiativeState` class owns `initiativeIndex`, `sortedEntries`, and helpers (`sortMap`, `incrementIndex`, `decrementIndex`, `clear`, `initiativeEmbedBuilder`, `snapshot`, `restoreFrom`).
- `DnDHelper` now owns a `ConcurrentHashMap<Long, InitiativeState>` keyed by `guildId`, plus stateless concerns (dice, `initButtons`, `doInitialLookup`, `queryNonMatchRetry`).
- Every stateful DnDHelper entry point takes a leading `guildId: Long`.
- Callers updated: `InitiativeCommand` derives `guildId` from the event (and errors out cleanly for DMs), and all three initiative buttons pass `ctx.guild.idLong`.

### Phase 3 serialization
- `CampaignShutdownHook` (was a stub) now iterates `dndHelper.activeSnapshots()`, looks up each guild's active campaign, and persists the JSON snapshot into `CampaignDto.state` via `campaignService.updateCampaign`.
- New `CampaignStartupHook` listens for `ApplicationReadyEvent`, reads every active campaign's `state`, and seeds `DnDHelper` back with the snapshot. Non-blank states only; malformed JSON is logged and skipped.
- `CampaignService.listActiveCampaigns()` (+ persistence + named query `CampaignDto.listActive`) added so the startup hook can enumerate candidates.

### Tests
- `DnDHelperTest`: every state-touching test updated to the new per-guild API. Two new tests cover (a) snapshot/restore round-trip and (b) cross-guild isolation (the behaviour that was previously broken).
- `InitiativeNextButtonTest`, `InitiativePreviousButtonTest`, `InitiativeClearButtonTest`: updated to the new 4-arg signatures, verifying the button resolves `guild.idLong = 1L` correctly.
- `InitiativeCommandTest`: unchanged — it already relied on the common `event.guild` mock, so the new guildId derivation works without edits.

## Test plan

- [ ] `./gradlew build` passes
- [ ] Manual: roll initiative on guild A, roll on guild B, confirm each tracker is independent (previously broken)
- [ ] Manual: restart the bot with an active initiative — confirm the tracker is restored and next/previous still work
- [ ] Manual: end a campaign with state persisted, confirm the state column is no longer read on startup

https://claude.ai/code/session_01DgKBYeiGaxmLg5xaPasU4r