### PR TITLE
feat(dnd): session notes for active campaigns

### DIFF
--- a/application/src/test/kotlin/web/controller/CampaignControllerTest.kt
+++ b/application/src/test/kotlin/web/controller/CampaignControllerTest.kt
@@ -14,8 +14,10 @@ import org.springframework.security.oauth2.core.OAuth2AccessToken
 import org.springframework.security.oauth2.core.user.OAuth2User
 import org.springframework.ui.Model
 import org.springframework.web.servlet.mvc.support.RedirectAttributes
+import web.service.AddNoteResult
 import web.service.CampaignDetail
 import web.service.CampaignWebService
+import web.service.DeleteNoteResult
 import web.service.EndResult
 import web.service.GuildCampaignInfo
 import web.service.JoinResult
@@ -409,5 +411,88 @@ class CampaignControllerTest {
         val view = controller.setPlayerAlive(guildId, 99L, false, mockUser, mockRa)
 
         assertEquals("redirect:/dnd/campaign", view)
+    }
+
+    // addNote
+
+    @Test
+    fun `addNote redirects with no flash on success`() {
+        every { campaignWebService.addNote(guildId, 1L, "hi") } returns AddNoteResult.ADDED
+
+        val view = controller.addNote(guildId, "hi", mockUser, mockRa)
+
+        assertEquals("redirect:/dnd/campaign/$guildId", view)
+        verify(exactly = 0) { mockRa.addFlashAttribute(any<String>(), any()) }
+    }
+
+    @Test
+    fun `addNote sets error when not a participant`() {
+        every { campaignWebService.addNote(guildId, 1L, "hi") } returns AddNoteResult.NOT_PARTICIPANT
+
+        controller.addNote(guildId, "hi", mockUser, mockRa)
+
+        verify { mockRa.addFlashAttribute("error", "Only the DM and campaign players can add notes.") }
+    }
+
+    @Test
+    fun `addNote sets error on empty body`() {
+        every { campaignWebService.addNote(guildId, 1L, "  ") } returns AddNoteResult.EMPTY_BODY
+
+        controller.addNote(guildId, "  ", mockUser, mockRa)
+
+        verify { mockRa.addFlashAttribute("error", "Note body can't be empty.") }
+    }
+
+    @Test
+    fun `addNote sets error on body too long`() {
+        every { campaignWebService.addNote(guildId, 1L, any()) } returns AddNoteResult.BODY_TOO_LONG
+
+        controller.addNote(guildId, "x".repeat(3000), mockUser, mockRa)
+
+        verify { mockRa.addFlashAttribute("error", "Note is too long (max 2000 characters).") }
+    }
+
+    @Test
+    fun `addNote redirects to list when user id missing`() {
+        every { mockUser.getAttribute<String>("id") } returns null
+
+        val view = controller.addNote(guildId, "hi", mockUser, mockRa)
+
+        assertEquals("redirect:/dnd/campaign", view)
+    }
+
+    // deleteNote
+
+    @Test
+    fun `deleteNote redirects with no flash on success`() {
+        every { campaignWebService.deleteNote(guildId, 1L, 42L) } returns DeleteNoteResult.DELETED
+
+        val view = controller.deleteNote(guildId, 42L, mockUser, mockRa)
+
+        assertEquals("redirect:/dnd/campaign/$guildId", view)
+        verify(exactly = 0) { mockRa.addFlashAttribute(any<String>(), any()) }
+    }
+
+    @Test
+    fun `deleteNote sets error when not allowed`() {
+        every { campaignWebService.deleteNote(guildId, 1L, 42L) } returns DeleteNoteResult.NOT_ALLOWED
+
+        controller.deleteNote(guildId, 42L, mockUser, mockRa)
+
+        verify {
+            mockRa.addFlashAttribute(
+                "error",
+                "You can only delete your own notes (or any note if you're the DM)."
+            )
+        }
+    }
+
+    @Test
+    fun `deleteNote sets error when note not found`() {
+        every { campaignWebService.deleteNote(guildId, 1L, 42L) } returns DeleteNoteResult.NOT_FOUND
+
+        controller.deleteNote(guildId, 42L, mockUser, mockRa)
+
+        verify { mockRa.addFlashAttribute("error", "That note doesn't exist.") }
     }
 }

--- a/application/src/test/kotlin/web/service/CampaignWebServiceTest.kt
+++ b/application/src/test/kotlin/web/service/CampaignWebServiceTest.kt
@@ -3,11 +3,14 @@ package web.service
 import database.dto.CampaignDto
 import database.dto.CampaignPlayerDto
 import database.dto.CampaignPlayerId
+import database.dto.SessionNoteDto
 import database.dto.UserDto
 import database.service.CampaignPlayerService
 import database.service.CampaignService
 import database.service.CharacterSheetService
+import database.service.SessionNoteService
 import database.service.UserService
+import java.time.LocalDateTime
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.unmockkAll
@@ -27,6 +30,7 @@ class CampaignWebServiceTest {
     private lateinit var introWebService: IntroWebService
     private lateinit var userService: UserService
     private lateinit var characterSheetService: CharacterSheetService
+    private lateinit var sessionNoteService: SessionNoteService
     private lateinit var jda: JDA
     private lateinit var service: CampaignWebService
 
@@ -49,6 +53,7 @@ class CampaignWebServiceTest {
         introWebService = mockk(relaxed = true)
         userService = mockk(relaxed = true)
         characterSheetService = mockk(relaxed = true)
+        sessionNoteService = mockk(relaxed = true)
         jda = mockk(relaxed = true)
         service = CampaignWebService(
             campaignService,
@@ -56,6 +61,7 @@ class CampaignWebServiceTest {
             introWebService,
             userService,
             characterSheetService,
+            sessionNoteService,
             jda
         )
     }
@@ -505,5 +511,172 @@ class CampaignWebServiceTest {
         )
         assertFalse(existing.alive)
         verify { campaignPlayerService.updatePlayer(existing) }
+    }
+
+    // addNote
+
+    @Test
+    fun `addNote rejects empty body`() {
+        assertEquals(AddNoteResult.EMPTY_BODY, service.addNote(guildId, dmDiscordId, "   "))
+        verify(exactly = 0) { sessionNoteService.createNote(any()) }
+    }
+
+    @Test
+    fun `addNote rejects body longer than max`() {
+        val body = "x".repeat(CampaignWebService.MAX_NOTE_BODY_LENGTH + 1)
+        assertEquals(AddNoteResult.BODY_TOO_LONG, service.addNote(guildId, dmDiscordId, body))
+        verify(exactly = 0) { sessionNoteService.createNote(any()) }
+    }
+
+    @Test
+    fun `addNote returns NO_ACTIVE_CAMPAIGN when none exists`() {
+        every { campaignService.getActiveCampaignForGuild(guildId) } returns null
+        assertEquals(AddNoteResult.NO_ACTIVE_CAMPAIGN, service.addNote(guildId, dmDiscordId, "hello"))
+    }
+
+    @Test
+    fun `addNote rejects non-participant`() {
+        val campaign = makeCampaign()
+        every { campaignService.getActiveCampaignForGuild(guildId) } returns campaign
+        every { campaignPlayerService.getPlayer(CampaignPlayerId(campaign.id, 99L)) } returns null
+
+        assertEquals(AddNoteResult.NOT_PARTICIPANT, service.addNote(guildId, 99L, "hi"))
+        verify(exactly = 0) { sessionNoteService.createNote(any()) }
+    }
+
+    @Test
+    fun `addNote allows DM and persists trimmed body`() {
+        val campaign = makeCampaign()
+        every { campaignService.getActiveCampaignForGuild(guildId) } returns campaign
+
+        assertEquals(AddNoteResult.ADDED, service.addNote(guildId, dmDiscordId, "  party reached the tavern  "))
+        verify {
+            sessionNoteService.createNote(match {
+                it.campaignId == campaign.id &&
+                    it.authorDiscordId == dmDiscordId &&
+                    it.body == "party reached the tavern"
+            })
+        }
+    }
+
+    @Test
+    fun `addNote allows existing player`() {
+        val campaign = makeCampaign()
+        val playerId = CampaignPlayerId(campaign.id, playerDiscordId)
+        every { campaignService.getActiveCampaignForGuild(guildId) } returns campaign
+        every { campaignPlayerService.getPlayer(playerId) } returns
+            CampaignPlayerDto(id = playerId, guildId = guildId)
+
+        assertEquals(AddNoteResult.ADDED, service.addNote(guildId, playerDiscordId, "loot!"))
+        verify { sessionNoteService.createNote(any()) }
+    }
+
+    // deleteNote
+
+    @Test
+    fun `deleteNote returns NO_ACTIVE_CAMPAIGN when none exists`() {
+        every { campaignService.getActiveCampaignForGuild(guildId) } returns null
+        assertEquals(DeleteNoteResult.NO_ACTIVE_CAMPAIGN, service.deleteNote(guildId, dmDiscordId, 1L))
+    }
+
+    @Test
+    fun `deleteNote returns NOT_FOUND when note missing`() {
+        every { campaignService.getActiveCampaignForGuild(guildId) } returns makeCampaign()
+        every { sessionNoteService.getNoteById(42L) } returns null
+
+        assertEquals(DeleteNoteResult.NOT_FOUND, service.deleteNote(guildId, dmDiscordId, 42L))
+    }
+
+    @Test
+    fun `deleteNote returns NOT_FOUND when note belongs to another campaign`() {
+        val campaign = makeCampaign()
+        every { campaignService.getActiveCampaignForGuild(guildId) } returns campaign
+        every { sessionNoteService.getNoteById(42L) } returns SessionNoteDto(
+            id = 42L,
+            campaignId = campaign.id + 1,
+            authorDiscordId = dmDiscordId,
+            body = "stale"
+        )
+
+        assertEquals(DeleteNoteResult.NOT_FOUND, service.deleteNote(guildId, dmDiscordId, 42L))
+        verify(exactly = 0) { sessionNoteService.deleteNoteById(any()) }
+    }
+
+    @Test
+    fun `deleteNote rejects non-author non-DM`() {
+        val campaign = makeCampaign()
+        every { campaignService.getActiveCampaignForGuild(guildId) } returns campaign
+        every { sessionNoteService.getNoteById(42L) } returns SessionNoteDto(
+            id = 42L,
+            campaignId = campaign.id,
+            authorDiscordId = playerDiscordId,
+            body = "by player"
+        )
+
+        assertEquals(DeleteNoteResult.NOT_ALLOWED, service.deleteNote(guildId, 999L, 42L))
+        verify(exactly = 0) { sessionNoteService.deleteNoteById(any()) }
+    }
+
+    @Test
+    fun `deleteNote allows author`() {
+        val campaign = makeCampaign()
+        every { campaignService.getActiveCampaignForGuild(guildId) } returns campaign
+        every { sessionNoteService.getNoteById(42L) } returns SessionNoteDto(
+            id = 42L,
+            campaignId = campaign.id,
+            authorDiscordId = playerDiscordId,
+            body = "mine"
+        )
+
+        assertEquals(DeleteNoteResult.DELETED, service.deleteNote(guildId, playerDiscordId, 42L))
+        verify { sessionNoteService.deleteNoteById(42L) }
+    }
+
+    @Test
+    fun `deleteNote allows DM to delete any note`() {
+        val campaign = makeCampaign()
+        every { campaignService.getActiveCampaignForGuild(guildId) } returns campaign
+        every { sessionNoteService.getNoteById(42L) } returns SessionNoteDto(
+            id = 42L,
+            campaignId = campaign.id,
+            authorDiscordId = playerDiscordId,
+            body = "player's note"
+        )
+
+        assertEquals(DeleteNoteResult.DELETED, service.deleteNote(guildId, dmDiscordId, 42L))
+        verify { sessionNoteService.deleteNoteById(42L) }
+    }
+
+    // getCampaignDetail notes hydration
+
+    @Test
+    fun `getCampaignDetail hydrates notes with author names and delete permissions`() {
+        val campaign = makeCampaign()
+        every { campaignService.getActiveCampaignForGuild(guildId) } returns campaign
+
+        val dmMember = mockk<Member> { every { effectiveName } returns "DM" }
+        val playerMember = mockk<Member> { every { effectiveName } returns "Player" }
+        val jdaGuild = mockk<Guild> {
+            every { getMemberById(dmDiscordId) } returns dmMember
+            every { getMemberById(playerDiscordId) } returns playerMember
+        }
+        every { jda.getGuildById(guildId) } returns jdaGuild
+        every { campaignPlayerService.getPlayersForCampaign(campaign.id) } returns emptyList()
+
+        val now = LocalDateTime.now()
+        every { sessionNoteService.getNotesForCampaign(campaign.id) } returns listOf(
+            SessionNoteDto(id = 1, campaignId = campaign.id, authorDiscordId = dmDiscordId, body = "dm", createdAt = now),
+            SessionNoteDto(id = 2, campaignId = campaign.id, authorDiscordId = playerDiscordId, body = "pl", createdAt = now)
+        )
+
+        val asDm = service.getCampaignDetail(guildId, dmDiscordId)!!
+        assertEquals(2, asDm.notes.size)
+        assertTrue(asDm.notes.all { it.canDelete }, "DM should be able to delete every note")
+        assertEquals("DM", asDm.notes[0].authorName)
+        assertEquals("Player", asDm.notes[1].authorName)
+
+        val asPlayer = service.getCampaignDetail(guildId, playerDiscordId)!!
+        assertFalse(asPlayer.notes[0].canDelete, "Player can't delete DM's note")
+        assertTrue(asPlayer.notes[1].canDelete, "Player can delete their own note")
     }
 }

--- a/database/src/main/kotlin/database/dto/SessionNoteDto.kt
+++ b/database/src/main/kotlin/database/dto/SessionNoteDto.kt
@@ -1,0 +1,44 @@
+package database.dto
+
+import jakarta.persistence.*
+import java.io.Serializable
+import java.time.LocalDateTime
+
+@NamedQueries(
+    NamedQuery(
+        name = "SessionNoteDto.getByCampaign",
+        query = "select n from SessionNoteDto n where n.campaignId = :campaignId order by n.createdAt desc"
+    ),
+    NamedQuery(
+        name = "SessionNoteDto.getById",
+        query = "select n from SessionNoteDto n where n.id = :id"
+    ),
+    NamedQuery(
+        name = "SessionNoteDto.deleteById",
+        query = "delete from SessionNoteDto n where n.id = :id"
+    )
+)
+@Entity
+@Table(name = "dnd_campaign_session_note", schema = "public")
+class SessionNoteDto(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    var id: Long = 0,
+
+    @Column(name = "campaign_id", nullable = false)
+    var campaignId: Long = 0,
+
+    @Column(name = "author_discord_id", nullable = false)
+    var authorDiscordId: Long = 0,
+
+    @Column(name = "body", nullable = false, columnDefinition = "TEXT")
+    var body: String = "",
+
+    @Column(name = "created_at", nullable = false)
+    var createdAt: LocalDateTime = LocalDateTime.now()
+) : Serializable {
+
+    override fun toString(): String =
+        "SessionNoteDto(id=$id, campaignId=$campaignId, authorDiscordId=$authorDiscordId, createdAt=$createdAt)"
+}

--- a/database/src/main/kotlin/database/persistence/SessionNotePersistence.kt
+++ b/database/src/main/kotlin/database/persistence/SessionNotePersistence.kt
@@ -1,0 +1,10 @@
+package database.persistence
+
+import database.dto.SessionNoteDto
+
+interface SessionNotePersistence {
+    fun createNote(note: SessionNoteDto): SessionNoteDto
+    fun getNoteById(id: Long): SessionNoteDto?
+    fun getNotesForCampaign(campaignId: Long): List<SessionNoteDto>
+    fun deleteNoteById(id: Long)
+}

--- a/database/src/main/kotlin/database/persistence/impl/DefaultSessionNotePersistence.kt
+++ b/database/src/main/kotlin/database/persistence/impl/DefaultSessionNotePersistence.kt
@@ -1,0 +1,40 @@
+package database.persistence.impl
+
+import database.dto.SessionNoteDto
+import database.persistence.SessionNotePersistence
+import jakarta.persistence.EntityManager
+import jakarta.persistence.PersistenceContext
+import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
+
+@Repository
+@Transactional
+class DefaultSessionNotePersistence : SessionNotePersistence {
+
+    @PersistenceContext
+    private lateinit var entityManager: EntityManager
+
+    override fun createNote(note: SessionNoteDto): SessionNoteDto {
+        entityManager.persist(note)
+        entityManager.flush()
+        return note
+    }
+
+    override fun getNoteById(id: Long): SessionNoteDto? {
+        val q = entityManager.createNamedQuery("SessionNoteDto.getById", SessionNoteDto::class.java)
+        q.setParameter("id", id)
+        return runCatching { q.singleResult }.getOrNull()
+    }
+
+    override fun getNotesForCampaign(campaignId: Long): List<SessionNoteDto> {
+        val q = entityManager.createNamedQuery("SessionNoteDto.getByCampaign", SessionNoteDto::class.java)
+        q.setParameter("campaignId", campaignId)
+        return q.resultList
+    }
+
+    override fun deleteNoteById(id: Long) {
+        val q = entityManager.createNamedQuery("SessionNoteDto.deleteById")
+        q.setParameter("id", id)
+        q.executeUpdate()
+    }
+}

--- a/database/src/main/kotlin/database/service/SessionNoteService.kt
+++ b/database/src/main/kotlin/database/service/SessionNoteService.kt
@@ -1,0 +1,10 @@
+package database.service
+
+import database.dto.SessionNoteDto
+
+interface SessionNoteService {
+    fun createNote(note: SessionNoteDto): SessionNoteDto
+    fun getNoteById(id: Long): SessionNoteDto?
+    fun getNotesForCampaign(campaignId: Long): List<SessionNoteDto>
+    fun deleteNoteById(id: Long)
+}

--- a/database/src/main/kotlin/database/service/impl/DefaultSessionNoteService.kt
+++ b/database/src/main/kotlin/database/service/impl/DefaultSessionNoteService.kt
@@ -1,0 +1,26 @@
+package database.service.impl
+
+import database.dto.SessionNoteDto
+import database.persistence.SessionNotePersistence
+import database.service.SessionNoteService
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional
+class DefaultSessionNoteService(
+    private val sessionNotePersistence: SessionNotePersistence
+) : SessionNoteService {
+
+    override fun createNote(note: SessionNoteDto): SessionNoteDto =
+        sessionNotePersistence.createNote(note)
+
+    override fun getNoteById(id: Long): SessionNoteDto? =
+        sessionNotePersistence.getNoteById(id)
+
+    override fun getNotesForCampaign(campaignId: Long): List<SessionNoteDto> =
+        sessionNotePersistence.getNotesForCampaign(campaignId)
+
+    override fun deleteNoteById(id: Long) =
+        sessionNotePersistence.deleteNoteById(id)
+}

--- a/database/src/main/resources/db/migration/V4__dnd_campaign_session_note.sql
+++ b/database/src/main/resources/db/migration/V4__dnd_campaign_session_note.sql
@@ -1,0 +1,12 @@
+-- Session notes attached to an active D&D campaign. Players and the DM can add;
+-- author can delete their own, DM can delete any (enforced in the service layer).
+CREATE TABLE IF NOT EXISTS dnd_campaign_session_note (
+    id BIGSERIAL PRIMARY KEY,
+    campaign_id BIGINT NOT NULL REFERENCES dnd_campaign(id) ON DELETE CASCADE,
+    author_discord_id BIGINT NOT NULL,
+    body TEXT NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_dnd_campaign_session_note_campaign_id
+    ON dnd_campaign_session_note(campaign_id);

--- a/web/src/main/kotlin/web/controller/CampaignController.kt
+++ b/web/src/main/kotlin/web/controller/CampaignController.kt
@@ -8,7 +8,9 @@ import org.springframework.stereotype.Controller
 import org.springframework.ui.Model
 import org.springframework.web.bind.annotation.*
 import org.springframework.web.servlet.mvc.support.RedirectAttributes
+import web.service.AddNoteResult
 import web.service.CampaignWebService
+import web.service.DeleteNoteResult
 import web.service.EndResult
 import web.service.JoinResult
 import web.service.KickResult
@@ -64,6 +66,7 @@ class CampaignController(
         model.addAttribute("isUserDm", campaignDetail?.isDm(discordId) ?: false)
         model.addAttribute("isUserPlayer", campaignDetail?.isCurrentUserPlayer ?: false)
         model.addAttribute("currentUserCharacterId", campaignDetail?.currentUserCharacterId)
+        model.addAttribute("notes", campaignDetail?.notes ?: emptyList<Any>())
         model.addAttribute("username", user.displayName())
 
         return "campaignDetail"
@@ -198,6 +201,54 @@ class CampaignController(
             SetAliveResult.NO_ACTIVE_CAMPAIGN -> ra.addFlashAttribute("error", "No active campaign in this server.")
             SetAliveResult.NOT_DM -> ra.addFlashAttribute("error", "Only the Dungeon Master can change player status.")
             SetAliveResult.NOT_A_PLAYER -> ra.addFlashAttribute("error", "That user isn't in the campaign.")
+        }
+        return "redirect:/dnd/campaign/$guildId"
+    }
+
+    @PostMapping("/campaign/{guildId}/notes")
+    fun addNote(
+        @PathVariable guildId: Long,
+        @RequestParam body: String,
+        @AuthenticationPrincipal user: OAuth2User,
+        ra: RedirectAttributes
+    ): String {
+        val discordId = user.discordIdOrNull()
+            ?: return "redirect:/dnd/campaign"
+
+        when (campaignWebService.addNote(guildId, discordId, body)) {
+            AddNoteResult.ADDED -> {}
+            AddNoteResult.NO_ACTIVE_CAMPAIGN -> ra.addFlashAttribute("error", "No active campaign in this server.")
+            AddNoteResult.NOT_PARTICIPANT -> ra.addFlashAttribute(
+                "error",
+                "Only the DM and campaign players can add notes."
+            )
+            AddNoteResult.EMPTY_BODY -> ra.addFlashAttribute("error", "Note body can't be empty.")
+            AddNoteResult.BODY_TOO_LONG -> ra.addFlashAttribute(
+                "error",
+                "Note is too long (max 2000 characters)."
+            )
+        }
+        return "redirect:/dnd/campaign/$guildId"
+    }
+
+    @PostMapping("/campaign/{guildId}/notes/{noteId}/delete")
+    fun deleteNote(
+        @PathVariable guildId: Long,
+        @PathVariable noteId: Long,
+        @AuthenticationPrincipal user: OAuth2User,
+        ra: RedirectAttributes
+    ): String {
+        val discordId = user.discordIdOrNull()
+            ?: return "redirect:/dnd/campaign"
+
+        when (campaignWebService.deleteNote(guildId, discordId, noteId)) {
+            DeleteNoteResult.DELETED -> {}
+            DeleteNoteResult.NO_ACTIVE_CAMPAIGN -> ra.addFlashAttribute("error", "No active campaign in this server.")
+            DeleteNoteResult.NOT_FOUND -> ra.addFlashAttribute("error", "That note doesn't exist.")
+            DeleteNoteResult.NOT_ALLOWED -> ra.addFlashAttribute(
+                "error",
+                "You can only delete your own notes (or any note if you're the DM)."
+            )
         }
         return "redirect:/dnd/campaign/$guildId"
     }

--- a/web/src/main/kotlin/web/service/CampaignWebService.kt
+++ b/web/src/main/kotlin/web/service/CampaignWebService.kt
@@ -6,23 +6,36 @@ import common.helpers.parseDndBeyondCharacterId
 import database.dto.CampaignDto
 import database.dto.CampaignPlayerDto
 import database.dto.CampaignPlayerId
+import database.dto.SessionNoteDto
 import database.dto.UserDto
 import database.service.CampaignPlayerService
 import database.service.CampaignService
 import database.service.CharacterSheetService
+import database.service.SessionNoteService
 import database.service.UserService
 import net.dv8tion.jda.api.JDA
 import org.springframework.stereotype.Service
+import java.time.LocalDateTime
 
 data class CampaignDetail(
     val campaign: CampaignDto,
     val players: List<PlayerInfo>,
     val dmName: String,
     val isCurrentUserPlayer: Boolean = false,
-    val currentUserCharacterId: Long? = null
+    val currentUserCharacterId: Long? = null,
+    val notes: List<SessionNoteView> = emptyList()
 ) {
     fun isDm(discordId: Long): Boolean = campaign.dmDiscordId == discordId
 }
+
+data class SessionNoteView(
+    val id: Long,
+    val authorDiscordId: Long,
+    val authorName: String,
+    val body: String,
+    val createdAt: LocalDateTime,
+    val canDelete: Boolean
+)
 
 data class PlayerInfo(
     val discordId: Long,
@@ -54,6 +67,8 @@ enum class SetCharacterResult { UPDATED, CLEARED, INVALID }
 enum class EndResult { ENDED, NO_ACTIVE_CAMPAIGN, NOT_DM }
 enum class KickResult { KICKED, NO_ACTIVE_CAMPAIGN, NOT_DM, NOT_A_PLAYER, CANNOT_KICK_DM }
 enum class SetAliveResult { UPDATED, NO_ACTIVE_CAMPAIGN, NOT_DM, NOT_A_PLAYER }
+enum class AddNoteResult { ADDED, NO_ACTIVE_CAMPAIGN, NOT_PARTICIPANT, EMPTY_BODY, BODY_TOO_LONG }
+enum class DeleteNoteResult { DELETED, NO_ACTIVE_CAMPAIGN, NOT_FOUND, NOT_ALLOWED }
 
 @Service
 class CampaignWebService(
@@ -62,10 +77,15 @@ class CampaignWebService(
     private val introWebService: IntroWebService,
     private val userService: UserService,
     private val characterSheetService: CharacterSheetService,
+    private val sessionNoteService: SessionNoteService,
     private val jda: JDA
 ) {
 
     private val objectMapper = ObjectMapper()
+
+    companion object {
+        const val MAX_NOTE_BODY_LENGTH = 2000
+    }
 
     fun getMutualGuildsWithCampaigns(accessToken: String): List<GuildCampaignInfo> {
         val mutualGuilds = introWebService.getMutualGuilds(accessToken)
@@ -108,13 +128,28 @@ class CampaignWebService(
 
         val isCurrentUserPlayer = players.any { it.discordId == requestingDiscordId }
         val currentUserCharacterId = userService.getUserById(requestingDiscordId, guildId)?.dndBeyondCharacterId
+        val isDm = campaign.dmDiscordId == requestingDiscordId
+
+        val notes = sessionNoteService.getNotesForCampaign(campaign.id).map { note ->
+            val authorName = guild?.getMemberById(note.authorDiscordId)?.effectiveName
+                ?: "Unknown (ID: ${note.authorDiscordId})"
+            SessionNoteView(
+                id = note.id,
+                authorDiscordId = note.authorDiscordId,
+                authorName = authorName,
+                body = note.body,
+                createdAt = note.createdAt,
+                canDelete = isDm || note.authorDiscordId == requestingDiscordId
+            )
+        }
 
         return CampaignDetail(
             campaign = campaign,
             players = players,
             dmName = dmName,
             isCurrentUserPlayer = isCurrentUserPlayer,
-            currentUserCharacterId = currentUserCharacterId
+            currentUserCharacterId = currentUserCharacterId,
+            notes = notes
         )
     }
 
@@ -206,6 +241,48 @@ class CampaignWebService(
         player.alive = alive
         campaignPlayerService.updatePlayer(player)
         return SetAliveResult.UPDATED
+    }
+
+    fun addNote(guildId: Long, authorDiscordId: Long, body: String): AddNoteResult {
+        val trimmed = body.trim()
+        if (trimmed.isEmpty()) return AddNoteResult.EMPTY_BODY
+        if (trimmed.length > MAX_NOTE_BODY_LENGTH) return AddNoteResult.BODY_TOO_LONG
+
+        val campaign = campaignService.getActiveCampaignForGuild(guildId)
+            ?: return AddNoteResult.NO_ACTIVE_CAMPAIGN
+
+        if (!isCampaignParticipant(campaign, authorDiscordId)) return AddNoteResult.NOT_PARTICIPANT
+
+        sessionNoteService.createNote(
+            SessionNoteDto(
+                campaignId = campaign.id,
+                authorDiscordId = authorDiscordId,
+                body = trimmed,
+                createdAt = LocalDateTime.now()
+            )
+        )
+        return AddNoteResult.ADDED
+    }
+
+    fun deleteNote(guildId: Long, requestingDiscordId: Long, noteId: Long): DeleteNoteResult {
+        val campaign = campaignService.getActiveCampaignForGuild(guildId)
+            ?: return DeleteNoteResult.NO_ACTIVE_CAMPAIGN
+
+        val note = sessionNoteService.getNoteById(noteId) ?: return DeleteNoteResult.NOT_FOUND
+        if (note.campaignId != campaign.id) return DeleteNoteResult.NOT_FOUND
+
+        val isDm = campaign.dmDiscordId == requestingDiscordId
+        val isAuthor = note.authorDiscordId == requestingDiscordId
+        if (!isDm && !isAuthor) return DeleteNoteResult.NOT_ALLOWED
+
+        sessionNoteService.deleteNoteById(noteId)
+        return DeleteNoteResult.DELETED
+    }
+
+    private fun isCampaignParticipant(campaign: CampaignDto, discordId: Long): Boolean {
+        if (campaign.dmDiscordId == discordId) return true
+        val playerId = CampaignPlayerId(campaign.id, discordId)
+        return campaignPlayerService.getPlayer(playerId) != null
     }
 
     private fun loadCharacterSummary(characterId: Long): CharacterSummary? {

--- a/web/src/main/resources/templates/campaignDetail.html
+++ b/web/src/main/resources/templates/campaignDetail.html
@@ -242,6 +242,54 @@
         .btn-xs:hover { color: #e0e0e0; border-color: #3a4a70; }
         .btn-xs.kick { color: #e74c3c; border-color: rgba(192,57,43,0.4); }
         .btn-xs.kick:hover { background: rgba(192,57,43,0.15); }
+        .notes-list { display: flex; flex-direction: column; gap: 10px; margin-bottom: 16px; }
+        .note-card {
+            background: #1e2d50;
+            border: 1px solid #2a3a60;
+            border-radius: 8px;
+            padding: 12px 16px;
+        }
+        .note-head {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 10px;
+            font-size: 0.8rem;
+            color: #a0a0b0;
+            margin-bottom: 6px;
+        }
+        .note-author { font-weight: 600; color: #e0e0e0; }
+        .note-body {
+            font-size: 0.92rem;
+            color: #e0e0e0;
+            white-space: pre-wrap;
+            word-break: break-word;
+        }
+        .note-form {
+            display: flex;
+            flex-direction: column;
+            gap: 10px;
+        }
+        .note-form textarea {
+            width: 100%;
+            min-height: 78px;
+            padding: 10px 12px;
+            border-radius: 6px;
+            border: 1px solid #2a2a4a;
+            background: #1a1a2e;
+            color: #e0e0e0;
+            font-size: 0.9rem;
+            font-family: inherit;
+            resize: vertical;
+        }
+        .note-form .row {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            font-size: 0.75rem;
+            color: #a0a0b0;
+        }
+        .empty-notes { color: #a0a0b0; font-size: 0.9rem; padding: 10px 0; }
     </style>
 </head>
 <body>
@@ -384,6 +432,40 @@
         <div class="empty-players" th:if="${#lists.isEmpty(players)}">
             No players have joined yet.
         </div>
+
+        <div class="section-title">Session notes</div>
+
+        <div class="notes-list" th:if="${not #lists.isEmpty(notes)}">
+            <div class="note-card" th:each="note : ${notes}">
+                <div class="note-head">
+                    <span>
+                        <span class="note-author" th:text="${note.authorName}">Author</span>
+                        · <span th:text="${#temporals.format(note.createdAt, 'yyyy-MM-dd HH:mm')}">timestamp</span>
+                    </span>
+                    <form th:if="${note.canDelete}"
+                          th:action="@{/dnd/campaign/{id}/notes/{nid}/delete(id=${guildId},nid=${note.id})}"
+                          method="post"
+                          th:onsubmit="|return confirm('Delete this note?');|"
+                          style="margin:0;">
+                        <button type="submit" class="btn-xs kick" title="Delete note">Delete</button>
+                    </form>
+                </div>
+                <div class="note-body" th:text="${note.body}">Note body</div>
+            </div>
+        </div>
+
+        <div class="empty-notes" th:if="${#lists.isEmpty(notes)}">
+            No notes yet.
+        </div>
+
+        <form class="note-form" th:if="${isUserDm or isUserPlayer}"
+              th:action="@{/dnd/campaign/{id}/notes(id=${guildId})}" method="post">
+            <textarea name="body" placeholder="Write a session note…" maxlength="2000" required></textarea>
+            <div class="row">
+                <span>Visible to everyone on this page. Max 2000 characters.</span>
+                <button type="submit" class="btn btn-primary">Add note</button>
+            </div>
+        </form>
 
         <div class="hint">
             Also available in Discord:


### PR DESCRIPTION
## Summary

Adds dated session notes to the campaign detail page so DMs and players can jot down session recap lines without leaving the web UI. Notes live alongside the campaign (not the guild), so they're automatically invisible once the campaign ends — the `ON DELETE CASCADE` on the FK handles cleanup.

### Schema
`V4__dnd_campaign_session_note.sql`: new `dnd_campaign_session_note` table
- `id BIGSERIAL PRIMARY KEY`
- `campaign_id BIGINT NOT NULL REFERENCES dnd_campaign(id) ON DELETE CASCADE`
- `author_discord_id BIGINT NOT NULL`
- `body TEXT NOT NULL`
- `created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP`
- `idx_dnd_campaign_session_note_campaign_id` on `campaign_id`

### Persistence / service layer
- `SessionNoteDto` with three named queries (getByCampaign ordered newest-first, getById, deleteById)
- `SessionNotePersistence` / `DefaultSessionNotePersistence` (@Repository @Transactional)
- `SessionNoteService` / `DefaultSessionNoteService`

### Web layer

**`CampaignWebService`**
- `addNote(guildId, authorDiscordId, body) -> AddNoteResult` — must be DM or a player in the campaign; trims body; returns `EMPTY_BODY` for blank and `BODY_TOO_LONG` past `MAX_NOTE_BODY_LENGTH` (2000).
- `deleteNote(guildId, requestingDiscordId, noteId) -> DeleteNoteResult` — author or DM only.
- `getCampaignDetail(...)` now also hydrates `notes: List<SessionNoteView>` with author display names resolved via JDA and a per-note `canDelete` flag.

**`CampaignController`**
- `POST /dnd/campaign/{guildId}/notes` (form param `body`)
- `POST /dnd/campaign/{guildId}/notes/{noteId}/delete`

Both redirect back to the detail page, with flash errors for every failure branch.

### Template
New "Session notes" section on campaign detail:
- Notes rendered newest-first with author + timestamp.
- Delete button visible only when `canDelete` is true (author or DM).
- Add-note form visible to the DM and campaign players only.

### Tests
- `CampaignWebServiceTest`: 12 new tests covering add/delete branches plus the notes hydration with DM-vs-author delete permissions.
- `CampaignControllerTest`: 8 new tests covering each new endpoint's success and flash-error paths.

## Test plan

- [ ] `./gradlew build` passes
- [ ] Flyway applies V4 cleanly against an existing DB
- [ ] Manual: as a player, add a note — confirm it appears, can be deleted by the author and not by other players
- [ ] Manual: as the DM, delete any player's note — confirm it works
- [ ] Manual: as a non-player guild member viewing the page, the add-note form is hidden and the delete button is hidden
- [ ] Manual: end a campaign — confirm associated notes are removed via the FK cascade

https://claude.ai/code/session_01DgKBYeiGaxmLg5xaPasU4r