### PR TITLE
feat(dnd): session log event backbone + roll capture (PR A of 4)

### DIFF
--- a/application/src/main/kotlin/CampaignEventListener.kt
+++ b/application/src/main/kotlin/CampaignEventListener.kt
@@ -1,0 +1,46 @@
+import common.events.CampaignEventOccurred
+import common.logging.DiscordLogger
+import database.dto.CampaignEventDto
+import database.service.CampaignEventService
+import database.service.CampaignService
+import org.springframework.context.event.EventListener
+import org.springframework.stereotype.Component
+import java.time.LocalDateTime
+
+/**
+ * Persists every [CampaignEventOccurred] to `dnd_campaign_event` for the guild's
+ * currently active campaign. Events for guilds without an active campaign are
+ * dropped silently — callers like `/roll` fire unconditionally and shouldn't
+ * fail or leak state.
+ *
+ * PR B will add a second listener that broadcasts the persisted event to SSE
+ * subscribers; this listener stays the write path.
+ */
+@Component
+class CampaignEventListener(
+    private val campaignService: CampaignService,
+    private val campaignEventService: CampaignEventService
+) {
+
+    private val logger: DiscordLogger = DiscordLogger.createLogger(this::class.java)
+
+    @EventListener
+    fun onCampaignEvent(event: CampaignEventOccurred) {
+        val campaign = campaignService.getActiveCampaignForGuild(event.guildId) ?: return
+        runCatching {
+            campaignEventService.append(
+                CampaignEventDto(
+                    campaignId = campaign.id,
+                    eventType = event.type.name,
+                    actorDiscordId = event.actorDiscordId,
+                    actorName = event.actorName,
+                    refEventId = event.refEventId,
+                    payload = event.payloadJson,
+                    createdAt = LocalDateTime.now()
+                )
+            )
+        }.onFailure {
+            logger.warn("Failed to persist campaign event ${event.type} for guild ${event.guildId}: ${it.message}")
+        }
+    }
+}

--- a/application/src/test/kotlin/CampaignEventListenerTest.kt
+++ b/application/src/test/kotlin/CampaignEventListenerTest.kt
@@ -1,0 +1,84 @@
+import common.events.CampaignEventOccurred
+import common.events.CampaignEventType
+import database.dto.CampaignDto
+import database.dto.CampaignEventDto
+import database.service.CampaignEventService
+import database.service.CampaignService
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class CampaignEventListenerTest {
+
+    private lateinit var campaignService: CampaignService
+    private lateinit var campaignEventService: CampaignEventService
+    private lateinit var listener: CampaignEventListener
+
+    private val guildId = 100L
+
+    private fun makeCampaign(id: Long = 10L) = CampaignDto(
+        id = id,
+        guildId = guildId,
+        channelId = guildId,
+        dmDiscordId = 1L,
+        name = "Test Campaign"
+    )
+
+    @BeforeEach
+    fun setUp() {
+        campaignService = mockk()
+        campaignEventService = mockk(relaxed = true)
+        listener = CampaignEventListener(campaignService, campaignEventService)
+    }
+
+    @Test
+    fun `persists event when active campaign exists`() {
+        val campaign = makeCampaign()
+        every { campaignService.getActiveCampaignForGuild(guildId) } returns campaign
+        val captured = slot<CampaignEventDto>()
+        every { campaignEventService.append(capture(captured)) } answers { captured.captured }
+
+        val incoming = CampaignEventOccurred(
+            guildId = guildId,
+            type = CampaignEventType.ROLL,
+            actorDiscordId = 42L,
+            actorName = "Dave",
+            payloadJson = """{"sides":20,"count":1,"modifier":0,"total":14,"rawTotal":14}"""
+        )
+        listener.onCampaignEvent(incoming)
+
+        val persisted = captured.captured
+        assertEquals(campaign.id, persisted.campaignId)
+        assertEquals(CampaignEventType.ROLL.name, persisted.eventType)
+        assertEquals(42L, persisted.actorDiscordId)
+        assertEquals("Dave", persisted.actorName)
+        assertEquals(incoming.payloadJson, persisted.payload)
+    }
+
+    @Test
+    fun `silently skips when no active campaign`() {
+        every { campaignService.getActiveCampaignForGuild(guildId) } returns null
+
+        listener.onCampaignEvent(
+            CampaignEventOccurred(guildId, CampaignEventType.ROLL, payloadJson = "{}")
+        )
+
+        verify(exactly = 0) { campaignEventService.append(any()) }
+    }
+
+    @Test
+    fun `swallows persistence failure`() {
+        val campaign = makeCampaign()
+        every { campaignService.getActiveCampaignForGuild(guildId) } returns campaign
+        every { campaignEventService.append(any()) } throws RuntimeException("boom")
+
+        listener.onCampaignEvent(
+            CampaignEventOccurred(guildId, CampaignEventType.ROLL, payloadJson = "{}")
+        )
+        // No exception propagated — listener must not crash the publisher thread.
+    }
+}

--- a/application/src/test/kotlin/web/controller/CampaignControllerTest.kt
+++ b/application/src/test/kotlin/web/controller/CampaignControllerTest.kt
@@ -23,8 +23,10 @@ import web.service.GuildCampaignInfo
 import web.service.JoinResult
 import web.service.KickResult
 import web.service.LeaveResult
+import web.service.SessionEventView
 import web.service.SetAliveResult
 import web.service.SetCharacterResult
+import java.time.LocalDateTime
 
 class CampaignControllerTest {
 
@@ -494,5 +496,41 @@ class CampaignControllerTest {
         controller.deleteNote(guildId, 42L, mockUser, mockRa)
 
         verify { mockRa.addFlashAttribute("error", "That note doesn't exist.") }
+    }
+
+    // listEvents
+
+    @Test
+    fun `listEvents returns empty list when user id missing`() {
+        every { mockUser.getAttribute<String>("id") } returns null
+
+        val result = controller.listEvents(guildId, null, 100, mockUser)
+
+        assertEquals(emptyList<SessionEventView>(), result)
+    }
+
+    @Test
+    fun `listEvents delegates to web service`() {
+        val events = listOf(
+            SessionEventView(
+                id = 1L, type = "ROLL", actorDiscordId = 7L, actorName = "Dave",
+                refEventId = null, payload = mapOf("total" to 14),
+                createdAt = LocalDateTime.now()
+            )
+        )
+        every { campaignWebService.listRecentEvents(guildId, null, 100) } returns events
+
+        val result = controller.listEvents(guildId, null, 100, mockUser)
+
+        assertEquals(events, result)
+    }
+
+    @Test
+    fun `listEvents forwards since cursor`() {
+        every { campaignWebService.listRecentEvents(guildId, 42L, 50) } returns emptyList()
+
+        controller.listEvents(guildId, 42L, 50, mockUser)
+
+        verify { campaignWebService.listRecentEvents(guildId, 42L, 50) }
     }
 }

--- a/application/src/test/kotlin/web/service/CampaignWebServiceTest.kt
+++ b/application/src/test/kotlin/web/service/CampaignWebServiceTest.kt
@@ -1,10 +1,12 @@
 package web.service
 
 import database.dto.CampaignDto
+import database.dto.CampaignEventDto
 import database.dto.CampaignPlayerDto
 import database.dto.CampaignPlayerId
 import database.dto.SessionNoteDto
 import database.dto.UserDto
+import database.service.CampaignEventService
 import database.service.CampaignPlayerService
 import database.service.CampaignService
 import database.service.CharacterSheetService
@@ -31,6 +33,7 @@ class CampaignWebServiceTest {
     private lateinit var userService: UserService
     private lateinit var characterSheetService: CharacterSheetService
     private lateinit var sessionNoteService: SessionNoteService
+    private lateinit var campaignEventService: CampaignEventService
     private lateinit var jda: JDA
     private lateinit var service: CampaignWebService
 
@@ -54,6 +57,7 @@ class CampaignWebServiceTest {
         userService = mockk(relaxed = true)
         characterSheetService = mockk(relaxed = true)
         sessionNoteService = mockk(relaxed = true)
+        campaignEventService = mockk(relaxed = true)
         jda = mockk(relaxed = true)
         service = CampaignWebService(
             campaignService,
@@ -62,6 +66,7 @@ class CampaignWebServiceTest {
             userService,
             characterSheetService,
             sessionNoteService,
+            campaignEventService,
             jda
         )
     }
@@ -678,5 +683,85 @@ class CampaignWebServiceTest {
         val asPlayer = service.getCampaignDetail(guildId, playerDiscordId)!!
         assertFalse(asPlayer.notes[0].canDelete, "Player can't delete DM's note")
         assertTrue(asPlayer.notes[1].canDelete, "Player can delete their own note")
+    }
+
+    // listRecentEvents + CampaignDetail.recentEvents
+
+    @Test
+    fun `listRecentEvents returns empty when no active campaign`() {
+        every { campaignService.getActiveCampaignForGuild(guildId) } returns null
+        assertTrue(service.listRecentEvents(guildId, null, 50).isEmpty())
+    }
+
+    @Test
+    fun `listRecentEvents delegates to listRecent when no since cursor`() {
+        val campaign = makeCampaign()
+        every { campaignService.getActiveCampaignForGuild(guildId) } returns campaign
+        val now = LocalDateTime.now()
+        every { campaignEventService.listRecent(campaign.id, 50) } returns listOf(
+            CampaignEventDto(
+                id = 1, campaignId = campaign.id, eventType = "ROLL",
+                actorDiscordId = 7L, actorName = "Dave",
+                payload = """{"sides":20,"count":1,"modifier":0,"total":17,"rawTotal":17}""",
+                createdAt = now
+            )
+        )
+
+        val out = service.listRecentEvents(guildId, null, 50)
+
+        assertEquals(1, out.size)
+        assertEquals(1L, out[0].id)
+        assertEquals("ROLL", out[0].type)
+        assertEquals("Dave", out[0].actorName)
+        assertEquals(20, out[0].payload["sides"])
+        assertEquals(17, out[0].payload["total"])
+    }
+
+    @Test
+    fun `listRecentEvents delegates to listSince when cursor provided`() {
+        val campaign = makeCampaign()
+        every { campaignService.getActiveCampaignForGuild(guildId) } returns campaign
+        every { campaignEventService.listSince(campaign.id, 42L, 30) } returns emptyList()
+
+        service.listRecentEvents(guildId, 42L, 30)
+
+        verify { campaignEventService.listSince(campaign.id, 42L, 30) }
+        verify(exactly = 0) { campaignEventService.listRecent(any(), any()) }
+    }
+
+    @Test
+    fun `listRecentEvents tolerates malformed payload json`() {
+        val campaign = makeCampaign()
+        every { campaignService.getActiveCampaignForGuild(guildId) } returns campaign
+        every { campaignEventService.listRecent(campaign.id, any()) } returns listOf(
+            CampaignEventDto(
+                id = 1, campaignId = campaign.id, eventType = "ROLL",
+                payload = "not-valid-json",
+                createdAt = LocalDateTime.now()
+            )
+        )
+
+        val out = service.listRecentEvents(guildId, null, 100)
+        assertEquals(1, out.size)
+        assertTrue(out[0].payload.isEmpty(), "malformed payload falls back to empty map")
+    }
+
+    @Test
+    fun `getCampaignDetail populates recentEvents`() {
+        val campaign = makeCampaign()
+        every { campaignService.getActiveCampaignForGuild(guildId) } returns campaign
+        every { jda.getGuildById(guildId) } returns mockk(relaxed = true)
+        every { campaignPlayerService.getPlayersForCampaign(campaign.id) } returns emptyList()
+        every { sessionNoteService.getNotesForCampaign(campaign.id) } returns emptyList()
+        every { campaignEventService.listRecent(campaign.id, 100) } returns listOf(
+            CampaignEventDto(
+                id = 9, campaignId = campaign.id, eventType = "ROLL",
+                payload = """{"total":12}""", createdAt = LocalDateTime.now()
+            )
+        )
+
+        val detail = service.getCampaignDetail(guildId, dmDiscordId)!!
+        assertEquals(1, detail.recentEvents.size)
+        assertEquals(9L, detail.recentEvents[0].id)
     }
 }

--- a/common/src/main/kotlin/common/events/CampaignEventOccurred.kt
+++ b/common/src/main/kotlin/common/events/CampaignEventOccurred.kt
@@ -1,0 +1,20 @@
+package common.events
+
+/**
+ * Fact emitted via Spring's [org.springframework.context.ApplicationEventPublisher]
+ * whenever a campaign-visible action happens (roll, initiative change, join/leave,
+ * DM annotation…). A single listener in the application module resolves the
+ * active campaign, persists the row, and (in later slices) fans out to SSE subscribers.
+ *
+ * `guildId` is the Discord guild the action happened in; the listener maps this
+ * to the currently active campaign. `payloadJson` is an opaque, type-specific
+ * JSON blob so new event shapes don't need schema migrations.
+ */
+data class CampaignEventOccurred(
+    val guildId: Long,
+    val type: CampaignEventType,
+    val actorDiscordId: Long? = null,
+    val actorName: String? = null,
+    val payloadJson: String = "{}",
+    val refEventId: Long? = null
+)

--- a/common/src/main/kotlin/common/events/CampaignEventType.kt
+++ b/common/src/main/kotlin/common/events/CampaignEventType.kt
@@ -1,0 +1,23 @@
+package common.events
+
+/**
+ * Kinds of event that can appear in a campaign's session log.
+ * The full set is declared up front so that publishers and view renderers
+ * across the session-log PRs (A–D) agree on the vocabulary; PR A only emits ROLL.
+ */
+enum class CampaignEventType {
+    ROLL,
+    INITIATIVE_ROLLED,
+    INITIATIVE_NEXT,
+    INITIATIVE_PREV,
+    INITIATIVE_CLEARED,
+    PLAYER_JOINED,
+    PLAYER_LEFT,
+    PLAYER_KICKED,
+    PLAYER_DIED,
+    PLAYER_REVIVED,
+    CAMPAIGN_ENDED,
+    DM_NOTE,
+    HIT,
+    MISS
+}

--- a/database/src/main/kotlin/database/dto/CampaignEventDto.kt
+++ b/database/src/main/kotlin/database/dto/CampaignEventDto.kt
@@ -1,0 +1,53 @@
+package database.dto
+
+import jakarta.persistence.*
+import java.io.Serializable
+import java.time.LocalDateTime
+
+@NamedQueries(
+    NamedQuery(
+        name = "CampaignEventDto.getByCampaignDesc",
+        query = "select e from CampaignEventDto e where e.campaignId = :campaignId order by e.id desc"
+    ),
+    NamedQuery(
+        name = "CampaignEventDto.getSinceId",
+        query = "select e from CampaignEventDto e where e.campaignId = :campaignId and e.id > :sinceId order by e.id asc"
+    ),
+    NamedQuery(
+        name = "CampaignEventDto.getById",
+        query = "select e from CampaignEventDto e where e.id = :id"
+    )
+)
+@Entity
+@Table(name = "dnd_campaign_event", schema = "public")
+class CampaignEventDto(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    var id: Long = 0,
+
+    @Column(name = "campaign_id", nullable = false)
+    var campaignId: Long = 0,
+
+    @Column(name = "event_type", nullable = false, length = 40)
+    var eventType: String = "",
+
+    @Column(name = "actor_discord_id")
+    var actorDiscordId: Long? = null,
+
+    @Column(name = "actor_name", length = 100)
+    var actorName: String? = null,
+
+    @Column(name = "ref_event_id")
+    var refEventId: Long? = null,
+
+    @Column(name = "payload", nullable = false, columnDefinition = "TEXT")
+    var payload: String = "{}",
+
+    @Column(name = "created_at", nullable = false)
+    var createdAt: LocalDateTime = LocalDateTime.now()
+) : Serializable {
+
+    override fun toString(): String =
+        "CampaignEventDto(id=$id, campaignId=$campaignId, type=$eventType, createdAt=$createdAt)"
+}

--- a/database/src/main/kotlin/database/persistence/CampaignEventPersistence.kt
+++ b/database/src/main/kotlin/database/persistence/CampaignEventPersistence.kt
@@ -1,0 +1,10 @@
+package database.persistence
+
+import database.dto.CampaignEventDto
+
+interface CampaignEventPersistence {
+    fun append(event: CampaignEventDto): CampaignEventDto
+    fun getById(id: Long): CampaignEventDto?
+    fun listRecent(campaignId: Long, limit: Int): List<CampaignEventDto>
+    fun listSince(campaignId: Long, sinceId: Long, limit: Int): List<CampaignEventDto>
+}

--- a/database/src/main/kotlin/database/persistence/impl/DefaultCampaignEventPersistence.kt
+++ b/database/src/main/kotlin/database/persistence/impl/DefaultCampaignEventPersistence.kt
@@ -1,0 +1,43 @@
+package database.persistence.impl
+
+import database.dto.CampaignEventDto
+import database.persistence.CampaignEventPersistence
+import jakarta.persistence.EntityManager
+import jakarta.persistence.PersistenceContext
+import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
+
+@Repository
+@Transactional
+class DefaultCampaignEventPersistence : CampaignEventPersistence {
+
+    @PersistenceContext
+    private lateinit var entityManager: EntityManager
+
+    override fun append(event: CampaignEventDto): CampaignEventDto {
+        entityManager.persist(event)
+        entityManager.flush()
+        return event
+    }
+
+    override fun getById(id: Long): CampaignEventDto? {
+        val q = entityManager.createNamedQuery("CampaignEventDto.getById", CampaignEventDto::class.java)
+        q.setParameter("id", id)
+        return runCatching { q.singleResult }.getOrNull()
+    }
+
+    override fun listRecent(campaignId: Long, limit: Int): List<CampaignEventDto> {
+        val q = entityManager.createNamedQuery("CampaignEventDto.getByCampaignDesc", CampaignEventDto::class.java)
+        q.setParameter("campaignId", campaignId)
+        q.maxResults = limit
+        return q.resultList.reversed()
+    }
+
+    override fun listSince(campaignId: Long, sinceId: Long, limit: Int): List<CampaignEventDto> {
+        val q = entityManager.createNamedQuery("CampaignEventDto.getSinceId", CampaignEventDto::class.java)
+        q.setParameter("campaignId", campaignId)
+        q.setParameter("sinceId", sinceId)
+        q.maxResults = limit
+        return q.resultList
+    }
+}

--- a/database/src/main/kotlin/database/service/CampaignEventService.kt
+++ b/database/src/main/kotlin/database/service/CampaignEventService.kt
@@ -1,0 +1,10 @@
+package database.service
+
+import database.dto.CampaignEventDto
+
+interface CampaignEventService {
+    fun append(event: CampaignEventDto): CampaignEventDto
+    fun getById(id: Long): CampaignEventDto?
+    fun listRecent(campaignId: Long, limit: Int): List<CampaignEventDto>
+    fun listSince(campaignId: Long, sinceId: Long, limit: Int): List<CampaignEventDto>
+}

--- a/database/src/main/kotlin/database/service/impl/DefaultCampaignEventService.kt
+++ b/database/src/main/kotlin/database/service/impl/DefaultCampaignEventService.kt
@@ -1,0 +1,26 @@
+package database.service.impl
+
+import database.dto.CampaignEventDto
+import database.persistence.CampaignEventPersistence
+import database.service.CampaignEventService
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional
+class DefaultCampaignEventService(
+    private val campaignEventPersistence: CampaignEventPersistence
+) : CampaignEventService {
+
+    override fun append(event: CampaignEventDto): CampaignEventDto =
+        campaignEventPersistence.append(event)
+
+    override fun getById(id: Long): CampaignEventDto? =
+        campaignEventPersistence.getById(id)
+
+    override fun listRecent(campaignId: Long, limit: Int): List<CampaignEventDto> =
+        campaignEventPersistence.listRecent(campaignId, limit)
+
+    override fun listSince(campaignId: Long, sinceId: Long, limit: Int): List<CampaignEventDto> =
+        campaignEventPersistence.listSince(campaignId, sinceId, limit)
+}

--- a/database/src/main/resources/db/migration/V5__dnd_campaign_event.sql
+++ b/database/src/main/resources/db/migration/V5__dnd_campaign_event.sql
@@ -1,0 +1,19 @@
+-- Session log / event feed for an active D&D campaign. Append-only; events linked to a
+-- campaign are deleted when the campaign is deleted. ref_event_id lets hit/miss
+-- annotations point at the ROLL event they qualify.
+CREATE TABLE IF NOT EXISTS dnd_campaign_event (
+    id BIGSERIAL PRIMARY KEY,
+    campaign_id BIGINT NOT NULL REFERENCES dnd_campaign(id) ON DELETE CASCADE,
+    event_type VARCHAR(40) NOT NULL,
+    actor_discord_id BIGINT,
+    actor_name VARCHAR(100),
+    ref_event_id BIGINT REFERENCES dnd_campaign_event(id) ON DELETE CASCADE,
+    payload TEXT NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_dnd_campaign_event_campaign_created
+    ON dnd_campaign_event(campaign_id, created_at);
+
+CREATE INDEX IF NOT EXISTS idx_dnd_campaign_event_ref
+    ON dnd_campaign_event(ref_event_id);

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/dnd/RollCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/dnd/RollCommand.kt
@@ -1,6 +1,9 @@
 package bot.toby.command.commands.dnd
 
 import bot.toby.helpers.DnDHelper
+import com.fasterxml.jackson.databind.ObjectMapper
+import common.events.CampaignEventOccurred
+import common.events.CampaignEventType
 import core.command.Command.Companion.invokeDeleteOnMessageResponse
 import core.command.CommandContext
 import database.dto.UserDto
@@ -15,11 +18,16 @@ import net.dv8tion.jda.api.components.actionrow.ActionRow
 import net.dv8tion.jda.api.components.buttons.Button
 import net.dv8tion.jda.api.requests.restaction.WebhookMessageCreateAction
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Component
 import java.util.*
 
 @Component
-class RollCommand @Autowired constructor(private val dndHelper: DnDHelper) : DnDCommand {
+class RollCommand @Autowired constructor(
+    private val dndHelper: DnDHelper,
+    private val applicationEventPublisher: ApplicationEventPublisher,
+    private val objectMapper: ObjectMapper
+) : DnDCommand {
     companion object {
         private const val DICE_NUMBER = "number"
         private const val DICE_TO_ROLL = "amount"
@@ -48,7 +56,11 @@ class RollCommand @Autowired constructor(private val dndHelper: DnDHelper) : DnD
         modifier: Int
     ): WebhookMessageCreateAction<Message> {
         event.deferReply().queue()
-        val sb = buildStringForDiceRoll(diceValue, diceToRoll, modifier)
+        val rollTotal = dndHelper.rollDice(diceValue, diceToRoll)
+        publishRollEvent(event, diceValue, diceToRoll, modifier, rollTotal)
+        val sb = StringBuilder().append(
+            String.format("Your final roll total was '%d' (%d + %d).", rollTotal + modifier, rollTotal, modifier)
+        )
         val embedBuilder = EmbedBuilder()
             .addField(
                 MessageEmbed.Field(
@@ -67,11 +79,30 @@ class RollCommand @Autowired constructor(private val dndHelper: DnDHelper) : DnD
             .addComponents(ActionRow.of(Button.primary("resend_last_request", "Click to Reroll"), rollD20, rollD10, rollD6, rollD4))
     }
 
-    private fun buildStringForDiceRoll(diceValue: Int, diceToRoll: Int, modifier: Int): StringBuilder {
-        val sb = StringBuilder()
-        val rollTotal = dndHelper.rollDice(diceValue, diceToRoll)
-        sb.append(String.format("Your final roll total was '%d' (%d + %d).", rollTotal + modifier, rollTotal, modifier))
-        return sb
+    private fun publishRollEvent(
+        event: IReplyCallback,
+        diceValue: Int,
+        diceToRoll: Int,
+        modifier: Int,
+        rawTotal: Int
+    ) {
+        val guild = event.guild ?: return
+        val payload = mapOf(
+            "sides" to diceValue,
+            "count" to diceToRoll,
+            "modifier" to modifier,
+            "rawTotal" to rawTotal,
+            "total" to rawTotal + modifier
+        )
+        applicationEventPublisher.publishEvent(
+            CampaignEventOccurred(
+                guildId = guild.idLong,
+                type = CampaignEventType.ROLL,
+                actorDiscordId = event.user.idLong,
+                actorName = event.member?.effectiveName ?: event.user.effectiveName,
+                payloadJson = objectMapper.writeValueAsString(payload)
+            )
+        )
     }
 
     override val name: String

--- a/discord-bot/src/test/kotlin/bot/toby/button/buttons/RollButtonTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/button/buttons/RollButtonTest.kt
@@ -7,7 +7,9 @@ import bot.toby.button.ButtonTest.Companion.mockChannel
 import bot.toby.button.DefaultButtonContext
 import bot.toby.command.commands.dnd.RollCommand
 import bot.toby.managers.DefaultCommandManager
+import com.fasterxml.jackson.databind.ObjectMapper
 import io.mockk.*
+import org.springframework.context.ApplicationEventPublisher
 import net.dv8tion.jda.api.components.actionrow.ActionRow
 import net.dv8tion.jda.api.entities.Message
 import net.dv8tion.jda.api.entities.MessageEmbed
@@ -27,7 +29,7 @@ class RollButtonTest : ButtonTest {
         super.setup()
 
         // Initialize RollCommand and mock its methods
-        rollCommand = spyk(RollCommand(dndHelper))
+        rollCommand = spyk(RollCommand(dndHelper, mockk<ApplicationEventPublisher>(relaxed = true), ObjectMapper()))
         every { rollCommand.handleDiceRoll(any(), any(), any(), any()) } returns mockk<WebhookMessageCreateAction<Message>> {
             every { queue(any()) } just Runs
         }

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/dnd/RollCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/dnd/RollCommandTest.kt
@@ -6,27 +6,36 @@ import bot.toby.command.CommandTest.Companion.webhookMessageCreateAction
 import bot.toby.command.DefaultCommandContext
 import bot.toby.helpers.DnDHelper
 import bot.toby.helpers.UserDtoHelper
+import com.fasterxml.jackson.databind.ObjectMapper
+import common.events.CampaignEventOccurred
+import common.events.CampaignEventType
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import net.dv8tion.jda.api.components.actionrow.ActionRow
 import net.dv8tion.jda.api.interactions.commands.OptionMapping
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.springframework.context.ApplicationEventPublisher
 
 class RollCommandTest : CommandTest {
     private lateinit var rollCommand: RollCommand
 
     lateinit var userDtoHelper: UserDtoHelper
     lateinit var dndHelper: DnDHelper
+    lateinit var applicationEventPublisher: ApplicationEventPublisher
+    private val objectMapper = ObjectMapper()
 
     @BeforeEach
     fun setUp() {
         setUpCommonMocks()
         userDtoHelper = mockk()
         dndHelper = DnDHelper(userDtoHelper)
+        applicationEventPublisher = mockk(relaxed = true)
         every { event.hook.sendMessageEmbeds(any(), *anyVararg()) } returns webhookMessageCreateAction
-        rollCommand = RollCommand(dndHelper)
+        rollCommand = RollCommand(dndHelper, applicationEventPublisher, objectMapper)
     }
 
     fun tearDown() {
@@ -76,6 +85,54 @@ class RollCommandTest : CommandTest {
         verify(exactly = 1) { event.hook.sendMessageEmbeds(any(), *anyVararg()) }
         verify(exactly = 1) {
             webhookMessageCreateAction.addComponents(any<ActionRow>())
+        }
+    }
+
+    @Test
+    fun testRollPublishesCampaignEvent() {
+        every { webhookMessageCreateAction.addComponents(any<ActionRow>()) } returns webhookMessageCreateAction
+
+        rollCommand.handleDiceRoll(event, 20, 2, 3)
+
+        verify(exactly = 1) {
+            applicationEventPublisher.publishEvent(match<CampaignEventOccurred> {
+                it.type == CampaignEventType.ROLL &&
+                    it.guildId == 1L &&
+                    it.actorDiscordId == 1L
+            })
+        }
+    }
+
+    @Test
+    fun testRollSkipsPublishWhenNoGuild() {
+        every { webhookMessageCreateAction.addComponents(any<ActionRow>()) } returns webhookMessageCreateAction
+        every { event.guild } returns null
+
+        rollCommand.handleDiceRoll(event, 20, 1, 0)
+
+        verify(exactly = 0) { applicationEventPublisher.publishEvent(any<CampaignEventOccurred>()) }
+    }
+
+    @Test
+    fun testRollPayloadShape() {
+        every { webhookMessageCreateAction.addComponents(any<ActionRow>()) } returns webhookMessageCreateAction
+
+        rollCommand.handleDiceRoll(event, 6, 3, 2)
+
+        verify(exactly = 1) {
+            applicationEventPublisher.publishEvent(match<CampaignEventOccurred> { published ->
+                val payload = objectMapper.readValue(
+                    published.payloadJson, Map::class.java
+                ) as Map<String, Any?>
+                assertEquals(6, payload["sides"])
+                assertEquals(3, payload["count"])
+                assertEquals(2, payload["modifier"])
+                val raw = payload["rawTotal"] as Int
+                val total = payload["total"] as Int
+                assertTrue(raw in 3..18)
+                assertEquals(raw + 2, total)
+                true
+            })
         }
     }
 }

--- a/web/src/main/kotlin/web/controller/CampaignController.kt
+++ b/web/src/main/kotlin/web/controller/CampaignController.kt
@@ -15,6 +15,7 @@ import web.service.EndResult
 import web.service.JoinResult
 import web.service.KickResult
 import web.service.LeaveResult
+import web.service.SessionEventView
 import web.service.SetAliveResult
 import web.service.SetCharacterResult
 import web.util.discordIdOrNull
@@ -67,9 +68,22 @@ class CampaignController(
         model.addAttribute("isUserPlayer", campaignDetail?.isCurrentUserPlayer ?: false)
         model.addAttribute("currentUserCharacterId", campaignDetail?.currentUserCharacterId)
         model.addAttribute("notes", campaignDetail?.notes ?: emptyList<Any>())
+        model.addAttribute("recentEvents", campaignDetail?.recentEvents ?: emptyList<Any>())
         model.addAttribute("username", user.displayName())
 
         return "campaignDetail"
+    }
+
+    @GetMapping("/campaign/{guildId}/events")
+    @ResponseBody
+    fun listEvents(
+        @PathVariable guildId: Long,
+        @RequestParam(name = "since", required = false) since: Long?,
+        @RequestParam(name = "limit", required = false, defaultValue = "100") limit: Int,
+        @AuthenticationPrincipal user: OAuth2User
+    ): List<SessionEventView> {
+        user.discordIdOrNull() ?: return emptyList()
+        return campaignWebService.listRecentEvents(guildId, since, limit)
     }
 
     @PostMapping("/campaign/{guildId}/create")

--- a/web/src/main/kotlin/web/service/CampaignWebService.kt
+++ b/web/src/main/kotlin/web/service/CampaignWebService.kt
@@ -8,6 +8,7 @@ import database.dto.CampaignPlayerDto
 import database.dto.CampaignPlayerId
 import database.dto.SessionNoteDto
 import database.dto.UserDto
+import database.service.CampaignEventService
 import database.service.CampaignPlayerService
 import database.service.CampaignService
 import database.service.CharacterSheetService
@@ -23,7 +24,8 @@ data class CampaignDetail(
     val dmName: String,
     val isCurrentUserPlayer: Boolean = false,
     val currentUserCharacterId: Long? = null,
-    val notes: List<SessionNoteView> = emptyList()
+    val notes: List<SessionNoteView> = emptyList(),
+    val recentEvents: List<SessionEventView> = emptyList()
 ) {
     fun isDm(discordId: Long): Boolean = campaign.dmDiscordId == discordId
 }
@@ -35,6 +37,16 @@ data class SessionNoteView(
     val body: String,
     val createdAt: LocalDateTime,
     val canDelete: Boolean
+)
+
+data class SessionEventView(
+    val id: Long,
+    val type: String,
+    val actorDiscordId: Long?,
+    val actorName: String?,
+    val refEventId: Long?,
+    val payload: Map<String, Any?>,
+    val createdAt: LocalDateTime
 )
 
 data class PlayerInfo(
@@ -78,13 +90,17 @@ class CampaignWebService(
     private val userService: UserService,
     private val characterSheetService: CharacterSheetService,
     private val sessionNoteService: SessionNoteService,
+    private val campaignEventService: CampaignEventService,
     private val jda: JDA
 ) {
 
     private val objectMapper = ObjectMapper()
+    private val payloadTypeRef =
+        object : com.fasterxml.jackson.core.type.TypeReference<Map<String, Any?>>() {}
 
     companion object {
         const val MAX_NOTE_BODY_LENGTH = 2000
+        const val DEFAULT_EVENT_LIMIT = 100
     }
 
     fun getMutualGuildsWithCampaigns(accessToken: String): List<GuildCampaignInfo> {
@@ -143,13 +159,43 @@ class CampaignWebService(
             )
         }
 
+        val recentEvents = campaignEventService
+            .listRecent(campaign.id, DEFAULT_EVENT_LIMIT)
+            .map(::toSessionEventView)
+
         return CampaignDetail(
             campaign = campaign,
             players = players,
             dmName = dmName,
             isCurrentUserPlayer = isCurrentUserPlayer,
             currentUserCharacterId = currentUserCharacterId,
-            notes = notes
+            notes = notes,
+            recentEvents = recentEvents
+        )
+    }
+
+    fun listRecentEvents(guildId: Long, sinceId: Long?, limit: Int): List<SessionEventView> {
+        val campaign = campaignService.getActiveCampaignForGuild(guildId) ?: return emptyList()
+        val bounded = limit.coerceIn(1, DEFAULT_EVENT_LIMIT * 10)
+        val events = if (sinceId != null) {
+            campaignEventService.listSince(campaign.id, sinceId, bounded)
+        } else {
+            campaignEventService.listRecent(campaign.id, bounded)
+        }
+        return events.map(::toSessionEventView)
+    }
+
+    private fun toSessionEventView(dto: database.dto.CampaignEventDto): SessionEventView {
+        val parsed = runCatching { objectMapper.readValue(dto.payload, payloadTypeRef) }
+            .getOrDefault(emptyMap())
+        return SessionEventView(
+            id = dto.id,
+            type = dto.eventType,
+            actorDiscordId = dto.actorDiscordId,
+            actorName = dto.actorName,
+            refEventId = dto.refEventId,
+            payload = parsed,
+            createdAt = dto.createdAt
         )
     }
 

--- a/web/src/main/resources/templates/campaignDetail.html
+++ b/web/src/main/resources/templates/campaignDetail.html
@@ -290,6 +290,40 @@
             color: #a0a0b0;
         }
         .empty-notes { color: #a0a0b0; font-size: 0.9rem; padding: 10px 0; }
+
+        .event-list {
+            display: flex;
+            flex-direction: column;
+            gap: 6px;
+            margin-bottom: 20px;
+        }
+        .event-row {
+            background: #1a2140;
+            border: 1px solid #2a3460;
+            border-radius: 6px;
+            padding: 8px 12px;
+            font-size: 0.85rem;
+            color: #d0d0e0;
+            display: flex;
+            gap: 10px;
+            align-items: baseline;
+        }
+        .event-type {
+            font-size: 0.7rem;
+            font-weight: 700;
+            color: #8892f5;
+            text-transform: uppercase;
+            letter-spacing: 0.04em;
+            min-width: 70px;
+        }
+        .event-actor { color: #e0e0e0; font-weight: 600; }
+        .event-body { flex: 1; color: #b0b0c0; }
+        .event-time {
+            font-size: 0.7rem;
+            color: #6a6a80;
+            font-family: monospace;
+        }
+        .empty-events { color: #a0a0b0; font-size: 0.9rem; padding: 10px 0; }
     </style>
 </head>
 <body>
@@ -466,6 +500,31 @@
                 <button type="submit" class="btn btn-primary">Add note</button>
             </div>
         </form>
+
+        <div class="section-title">Session log</div>
+
+        <div class="event-list" th:if="${not #lists.isEmpty(recentEvents)}">
+            <div class="event-row" th:each="event : ${recentEvents}">
+                <span class="event-type" th:text="${event.type}">ROLL</span>
+                <span class="event-actor" th:text="${event.actorName ?: 'system'}">actor</span>
+                <span th:switch="${event.type}" class="event-body">
+                    <span th:case="'ROLL'"
+                          th:text="|rolled ${event.payload['count']}d${event.payload['sides']}|
+                                   + (${event.payload['modifier']} != null and ${event.payload['modifier']} != 0
+                                        ? ' + ' + ${event.payload['modifier']} : '')
+                                   + |&nbsp;=&nbsp;${event.payload['total']}|">
+                        rolled 1d20 = 15
+                    </span>
+                    <span th:case="*" th:text="${event.payload}">raw payload</span>
+                </span>
+                <span class="event-time"
+                      th:text="${#temporals.format(event.createdAt, 'HH:mm:ss')}">12:00:00</span>
+            </div>
+        </div>
+
+        <div class="empty-events" th:if="${#lists.isEmpty(recentEvents)}">
+            No activity yet. Rolls from Discord will appear here.
+        </div>
 
         <div class="hint">
             Also available in Discord:


### PR DESCRIPTION
## Summary

First of four PRs adding a live-synced session log to `/dnd/campaign/{guildId}`. This slice ships the event backbone and the first producer (`/roll`); the campaign detail page shows a Session log panel with the last 100 rolls, refreshing on page reload. **No real-time updates yet** — PR B adds SSE; PR C adds initiative + roster producers; PR D adds DM hit/miss + narrate.

### Schema
`V5__dnd_campaign_event.sql` — append-only table `dnd_campaign_event` with FK → `dnd_campaign(id) ON DELETE CASCADE`, a `ref_event_id` self-FK reserved for PR D's hit/miss links, and composite `(campaign_id, created_at)` + `(ref_event_id)` indexes.

### Event bus
Plain Spring `ApplicationEventPublisher`; no new infra.

- `common.events.CampaignEventType` — full enum (ROLL, INITIATIVE_ROLLED, INITIATIVE_NEXT, INITIATIVE_PREV, INITIATIVE_CLEARED, PLAYER_JOINED, PLAYER_LEFT, PLAYER_KICKED, PLAYER_DIED, PLAYER_REVIVED, CAMPAIGN_ENDED, DM_NOTE, HIT, MISS) so future PRs don't widen it.
- `common.events.CampaignEventOccurred` — plain data class carrying guildId, type, actor metadata, JSON payload, optional refEventId.
- `application.CampaignEventListener` `@EventListener` resolves the guild's active campaign and persists every event. Silent skip when no active campaign; swallowed failures so publishers don't crash.

### Producer
`RollCommand` now injects `ApplicationEventPublisher` + `ObjectMapper`, and after each `handleDiceRoll` publishes a `ROLL` event whenever the interaction has a guild. Works for both the slash command and the Roll buttons.

### Web read path
- `CampaignWebService.listRecentEvents(guildId, since?, limit)` → `List<SessionEventView>`.
- `CampaignDetail.recentEvents` populated from the last 100 events.
- `GET /dnd/campaign/{guildId}/events?since=&limit=` JSON endpoint (reserved for PR B's backfill; guarded by the existing `/dnd/**` authenticated rule).
- `campaignDetail.html` gains a "Session log" section — ROLL entries render as `Ndk + mod = total`, unknown types fall back to raw payload (will be prettier once PR C ships).

### Tests
- `CampaignEventListenerTest` — persists on active campaign, skips without one, swallows exceptions.
- `RollCommandTest` — publisher invoked with right payload shape, not invoked when guild is null, `total = rawTotal + modifier`.
- `CampaignWebServiceTest` — `listRecentEvents` delegates correctly (since vs no-since), tolerates malformed JSON, `recentEvents` populated on the detail view.
- `CampaignControllerTest` — `/events` endpoint returns empty without auth, delegates to the service with the since cursor.

## Test plan

- [ ] `./gradlew build` passes
- [ ] Flyway applies V5 cleanly against an existing DB
- [ ] Manual: with an active campaign, run `/roll amount:3 number:6 modifier:2` in Discord — confirm a row in `dnd_campaign_event` with `event_type='ROLL'` and the expected payload
- [ ] Manual: refresh `/dnd/campaign/{guildId}` — the roll appears in the Session log section with the roller's name
- [ ] Manual: `/roll` with no active campaign still works and silently skips logging
- [ ] Manual: `GET /dnd/campaign/{guildId}/events` returns JSON matching the page

## What's next

- PR B — SSE live stream (`/events/stream`, `CampaignEventBroadcaster`, `EventSource` client JS)
- PR C — more producers (initiative command/buttons, `/campaign` join/leave/end, web roster actions)
- PR D — DM Hit/Miss annotations on roll entries + narrate form

https://claude.ai/code/session_01DgKBYeiGaxmLg5xaPasU4r