### PR TITLE
feat(dnd): more session-log producers + typed renderers (PR C of 4)

### DIFF
--- a/application/src/test/kotlin/web/service/CampaignWebServiceTest.kt
+++ b/application/src/test/kotlin/web/service/CampaignWebServiceTest.kt
@@ -34,6 +34,7 @@ class CampaignWebServiceTest {
     private lateinit var characterSheetService: CharacterSheetService
     private lateinit var sessionNoteService: SessionNoteService
     private lateinit var campaignEventService: CampaignEventService
+    private lateinit var sessionLog: SessionLogPublisher
     private lateinit var jda: JDA
     private lateinit var service: CampaignWebService
 
@@ -58,6 +59,7 @@ class CampaignWebServiceTest {
         characterSheetService = mockk(relaxed = true)
         sessionNoteService = mockk(relaxed = true)
         campaignEventService = mockk(relaxed = true)
+        sessionLog = mockk(relaxed = true)
         jda = mockk(relaxed = true)
         service = CampaignWebService(
             campaignService,
@@ -67,6 +69,7 @@ class CampaignWebServiceTest {
             characterSheetService,
             sessionNoteService,
             campaignEventService,
+            sessionLog,
             jda
         )
     }

--- a/discord-bot/src/main/kotlin/bot/toby/button/buttons/InitiativeClearButton.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/button/buttons/InitiativeClearButton.kt
@@ -1,13 +1,18 @@
 package bot.toby.button.buttons
 
 import bot.toby.helpers.DnDHelper
+import common.events.CampaignEventType
 import core.button.Button
 import core.button.ButtonContext
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
+import web.service.SessionLogPublisher
 
 @Component
-class InitiativeClearButton @Autowired constructor(private val dnDHelper: DnDHelper) : Button {
+class InitiativeClearButton @Autowired constructor(
+    private val dnDHelper: DnDHelper,
+    private val sessionLog: SessionLogPublisher
+) : Button {
     override val name: String
         get() = "init:clear"
     override val description: String
@@ -16,6 +21,14 @@ class InitiativeClearButton @Autowired constructor(private val dnDHelper: DnDHel
     override fun handle(ctx: ButtonContext, requestingUserDto: database.dto.UserDto, deleteDelay: Int) {
         val event = ctx.event
         val hook = ctx.event.hook
-        dnDHelper.clearInitiative(ctx.guild.idLong, hook, event)
+        val guildId = ctx.guild.idLong
+        dnDHelper.clearInitiative(guildId, hook, event)
+
+        sessionLog.publish(
+            guildId = guildId,
+            type = CampaignEventType.INITIATIVE_CLEARED,
+            actorDiscordId = event.user.idLong,
+            actorName = event.member?.effectiveName ?: event.user.effectiveName
+        )
     }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/button/buttons/InitiativeNextButton.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/button/buttons/InitiativeNextButton.kt
@@ -1,13 +1,18 @@
 package bot.toby.button.buttons
 
 import bot.toby.helpers.DnDHelper
+import common.events.CampaignEventType
 import core.button.Button
 import core.button.ButtonContext
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
+import web.service.SessionLogPublisher
 
 @Component
-class InitiativeNextButton @Autowired constructor(private val dndHelper: DnDHelper) : Button {
+class InitiativeNextButton @Autowired constructor(
+    private val dndHelper: DnDHelper,
+    private val sessionLog: SessionLogPublisher
+) : Button {
     override val name: String
         get() = "init:next"
     override val description: String
@@ -16,6 +21,20 @@ class InitiativeNextButton @Autowired constructor(private val dndHelper: DnDHelp
     override fun handle(ctx: ButtonContext, requestingUserDto: database.dto.UserDto, deleteDelay: Int) {
         val event = ctx.event
         val hook = event.hook
-        dndHelper.incrementTurnTable(ctx.guild.idLong, hook, event, deleteDelay)
+        val guildId = ctx.guild.idLong
+        dndHelper.incrementTurnTable(guildId, hook, event, deleteDelay)
+
+        val state = dndHelper.stateFor(guildId)
+        val current = state.sortedEntries.getOrNull(state.initiativeIndex.get())
+        sessionLog.publish(
+            guildId = guildId,
+            type = CampaignEventType.INITIATIVE_NEXT,
+            actorDiscordId = event.user.idLong,
+            actorName = event.member?.effectiveName ?: event.user.effectiveName,
+            payload = mapOf(
+                "currentName" to current?.key,
+                "currentIndex" to state.initiativeIndex.get()
+            )
+        )
     }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/button/buttons/InitiativePreviousButton.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/button/buttons/InitiativePreviousButton.kt
@@ -1,13 +1,18 @@
 package bot.toby.button.buttons
 
 import bot.toby.helpers.DnDHelper
+import common.events.CampaignEventType
 import core.button.Button
 import core.button.ButtonContext
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
+import web.service.SessionLogPublisher
 
 @Component
-class InitiativePreviousButton @Autowired constructor(private val dndHelper: DnDHelper) : Button {
+class InitiativePreviousButton @Autowired constructor(
+    private val dndHelper: DnDHelper,
+    private val sessionLog: SessionLogPublisher
+) : Button {
     override val name: String
         get() = "init:prev"
     override val description: String
@@ -16,6 +21,20 @@ class InitiativePreviousButton @Autowired constructor(private val dndHelper: DnD
     override fun handle(ctx: ButtonContext, requestingUserDto: database.dto.UserDto, deleteDelay: Int) {
         val event = ctx.event
         val hook = event.hook
-        dndHelper.decrementTurnTable(ctx.guild.idLong, hook, event, deleteDelay)
+        val guildId = ctx.guild.idLong
+        dndHelper.decrementTurnTable(guildId, hook, event, deleteDelay)
+
+        val state = dndHelper.stateFor(guildId)
+        val current = state.sortedEntries.getOrNull(state.initiativeIndex.get())
+        sessionLog.publish(
+            guildId = guildId,
+            type = CampaignEventType.INITIATIVE_PREV,
+            actorDiscordId = event.user.idLong,
+            actorName = event.member?.effectiveName ?: event.user.effectiveName,
+            payload = mapOf(
+                "currentName" to current?.key,
+                "currentIndex" to state.initiativeIndex.get()
+            )
+        )
     }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/dnd/CampaignCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/dnd/CampaignCommand.kt
@@ -2,6 +2,7 @@ package bot.toby.command.commands.dnd
 
 import bot.toby.BOT_WEB_URL
 import bot.toby.helpers.UserDtoHelper
+import common.events.CampaignEventType
 import core.command.Command.Companion.invokeDeleteOnMessageResponse
 import core.command.CommandContext
 import database.dto.CampaignDto
@@ -16,13 +17,15 @@ import net.dv8tion.jda.api.interactions.commands.OptionType
 import net.dv8tion.jda.api.interactions.commands.build.OptionData
 import net.dv8tion.jda.api.interactions.commands.build.SubcommandData
 import org.springframework.stereotype.Component
+import web.service.SessionLogPublisher
 import java.awt.Color
 
 @Component
 class CampaignCommand(
     private val campaignService: CampaignService,
     private val campaignPlayerService: CampaignPlayerService,
-    private val userDtoHelper: UserDtoHelper
+    private val userDtoHelper: UserDtoHelper,
+    private val sessionLog: SessionLogPublisher
 ) : DnDCommand {
 
     override val name = "campaign"
@@ -133,6 +136,13 @@ class CampaignCommand(
         )
         campaignPlayerService.addPlayer(player)
 
+        sessionLog.publish(
+            guildId = guild.idLong,
+            type = CampaignEventType.PLAYER_JOINED,
+            actorDiscordId = callerDto.discordId,
+            actorName = ctx.member?.effectiveName
+        )
+
         val characterNote = if (callerDto.dndBeyondCharacterId != null)
             "Character linked (ID: ${callerDto.dndBeyondCharacterId})"
         else
@@ -165,6 +175,14 @@ class CampaignCommand(
         }
 
         campaignPlayerService.removePlayer(playerId)
+
+        sessionLog.publish(
+            guildId = guild.idLong,
+            type = CampaignEventType.PLAYER_LEFT,
+            actorDiscordId = callerDto.discordId,
+            actorName = ctx.member?.effectiveName
+        )
+
         event.hook.sendMessage("You have left the campaign **${campaign.name}**.")
             .queue(invokeDeleteOnMessageResponse(deleteDelay))
     }
@@ -219,6 +237,14 @@ class CampaignCommand(
             return
         }
 
+        // Publish before deactivation so the listener can still resolve the active campaign.
+        sessionLog.publish(
+            guildId = guild.idLong,
+            type = CampaignEventType.CAMPAIGN_ENDED,
+            actorDiscordId = callerDto.discordId,
+            actorName = ctx.member?.effectiveName,
+            payload = mapOf("campaignName" to campaign.name)
+        )
         campaignService.deactivateCampaignForGuild(guild.idLong)
         event.hook.sendMessage("The campaign **${campaign.name}** has ended. Thanks for playing!")
             .queue()

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/dnd/InitiativeCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/dnd/InitiativeCommand.kt
@@ -1,6 +1,7 @@
 package bot.toby.command.commands.dnd
 
 import bot.toby.helpers.DnDHelper
+import common.events.CampaignEventType
 import core.command.Command.Companion.invokeDeleteOnHookResponse
 import core.command.Command.Companion.invokeDeleteOnMessageResponse
 import core.command.CommandContext
@@ -14,9 +15,13 @@ import net.dv8tion.jda.api.interactions.commands.OptionType
 import net.dv8tion.jda.api.interactions.commands.build.OptionData
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
+import web.service.SessionLogPublisher
 
 @Component
-class InitiativeCommand @Autowired constructor(private val dndHelper: DnDHelper) : DnDCommand {
+class InitiativeCommand @Autowired constructor(
+    private val dndHelper: DnDHelper,
+    private val sessionLog: SessionLogPublisher
+) : DnDCommand {
 
     override fun handle(ctx: CommandContext, requestingUserDto: UserDto, deleteDelay: Int) {
         val event = ctx.event
@@ -47,6 +52,16 @@ class InitiativeCommand @Autowired constructor(private val dndHelper: DnDHelper)
 
         if (checkForNonDmMembersInVoiceChannel(deleteDelay, event, guildId)) return
         displayAllValues(guildId, event.hook, deleteDelay)
+
+        val entries = dndHelper.stateFor(guildId).sortedEntries
+            .map { mapOf("name" to it.key, "roll" to it.value) }
+        sessionLog.publish(
+            guildId = guildId,
+            type = CampaignEventType.INITIATIVE_ROLLED,
+            actorDiscordId = event.user.idLong,
+            actorName = event.member?.effectiveName ?: event.user.effectiveName,
+            payload = mapOf("entries" to entries)
+        )
     }
 
     override val name: String = "initiative"

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/dnd/RollCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/dnd/RollCommand.kt
@@ -1,8 +1,6 @@
 package bot.toby.command.commands.dnd
 
 import bot.toby.helpers.DnDHelper
-import com.fasterxml.jackson.databind.ObjectMapper
-import common.events.CampaignEventOccurred
 import common.events.CampaignEventType
 import core.command.Command.Companion.invokeDeleteOnMessageResponse
 import core.command.CommandContext
@@ -18,15 +16,14 @@ import net.dv8tion.jda.api.components.actionrow.ActionRow
 import net.dv8tion.jda.api.components.buttons.Button
 import net.dv8tion.jda.api.requests.restaction.WebhookMessageCreateAction
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Component
+import web.service.SessionLogPublisher
 import java.util.*
 
 @Component
 class RollCommand @Autowired constructor(
     private val dndHelper: DnDHelper,
-    private val applicationEventPublisher: ApplicationEventPublisher,
-    private val objectMapper: ObjectMapper
+    private val sessionLog: SessionLogPublisher
 ) : DnDCommand {
     companion object {
         private const val DICE_NUMBER = "number"
@@ -87,20 +84,17 @@ class RollCommand @Autowired constructor(
         rawTotal: Int
     ) {
         val guild = event.guild ?: return
-        val payload = mapOf(
-            "sides" to diceValue,
-            "count" to diceToRoll,
-            "modifier" to modifier,
-            "rawTotal" to rawTotal,
-            "total" to rawTotal + modifier
-        )
-        applicationEventPublisher.publishEvent(
-            CampaignEventOccurred(
-                guildId = guild.idLong,
-                type = CampaignEventType.ROLL,
-                actorDiscordId = event.user.idLong,
-                actorName = event.member?.effectiveName ?: event.user.effectiveName,
-                payloadJson = objectMapper.writeValueAsString(payload)
+        sessionLog.publish(
+            guildId = guild.idLong,
+            type = CampaignEventType.ROLL,
+            actorDiscordId = event.user.idLong,
+            actorName = event.member?.effectiveName ?: event.user.effectiveName,
+            payload = mapOf(
+                "sides" to diceValue,
+                "count" to diceToRoll,
+                "modifier" to modifier,
+                "rawTotal" to rawTotal,
+                "total" to rawTotal + modifier
             )
         )
     }

--- a/discord-bot/src/test/kotlin/bot/toby/button/buttons/InitiativeClearButtonTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/button/buttons/InitiativeClearButtonTest.kt
@@ -59,7 +59,7 @@ class InitiativeClearButtonTest : ButtonTest {
         every { dndHelper.clearInitiative(any<Long>(), any(), any()) } just Runs
 
         // Invoke the handler
-        InitiativeClearButton(dndHelper).handle(DefaultButtonContext(event), UserDto(6L, 1L), 0)
+        InitiativeClearButton(dndHelper, io.mockk.mockk(relaxed = true)).handle(DefaultButtonContext(event), UserDto(6L, 1L), 0)
 
         // Verify expected interactions
         verify(exactly = 1) { dndHelper.clearInitiative(1L, mockHook, event) }

--- a/discord-bot/src/test/kotlin/bot/toby/button/buttons/InitiativeNextButtonTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/button/buttons/InitiativeNextButtonTest.kt
@@ -6,6 +6,7 @@ import bot.toby.button.ButtonTest.Companion.dndHelper
 import bot.toby.button.ButtonTest.Companion.event
 import bot.toby.button.ButtonTest.Companion.userService
 import bot.toby.button.DefaultButtonContext
+import bot.toby.helpers.InitiativeState
 import database.dto.ConfigDto
 import io.mockk.*
 import net.dv8tion.jda.api.entities.Message
@@ -57,6 +58,7 @@ class InitiativeNextButtonTest : ButtonTest {
         // Mock clearInitiative method to just verify the call
 
         every { dndHelper.incrementTurnTable(any(), any(), any(), any()) } just Runs
+        every { dndHelper.stateFor(any()) } returns InitiativeState()
 
         // Invoke the handler
         InitiativeNextButton(dndHelper, io.mockk.mockk(relaxed = true)).handle(DefaultButtonContext(event), database.dto.UserDto(6L, 1L), 0)

--- a/discord-bot/src/test/kotlin/bot/toby/button/buttons/InitiativeNextButtonTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/button/buttons/InitiativeNextButtonTest.kt
@@ -59,7 +59,7 @@ class InitiativeNextButtonTest : ButtonTest {
         every { dndHelper.incrementTurnTable(any(), any(), any(), any()) } just Runs
 
         // Invoke the handler
-        InitiativeNextButton(dndHelper).handle(DefaultButtonContext(event), database.dto.UserDto(6L, 1L), 0)
+        InitiativeNextButton(dndHelper, io.mockk.mockk(relaxed = true)).handle(DefaultButtonContext(event), database.dto.UserDto(6L, 1L), 0)
 
         // Verify expected interactions
         verify(exactly = 1) { dndHelper.incrementTurnTable(1L, mockHook, event, 0) }

--- a/discord-bot/src/test/kotlin/bot/toby/button/buttons/InitiativePreviousButtonTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/button/buttons/InitiativePreviousButtonTest.kt
@@ -58,7 +58,7 @@ class InitiativePreviousButtonTest : ButtonTest {
         every { dndHelper.decrementTurnTable(any(), any(), any(), any()) } just Runs
 
         // Invoke the handler
-        InitiativePreviousButton(dndHelper).handle(DefaultButtonContext(event), database.dto.UserDto(6L, 1L), 0)
+        InitiativePreviousButton(dndHelper, io.mockk.mockk(relaxed = true)).handle(DefaultButtonContext(event), database.dto.UserDto(6L, 1L), 0)
 
         // Verify expected interactions
         verify(exactly = 1) { dndHelper.decrementTurnTable(1L, mockHook, event, 0) }

--- a/discord-bot/src/test/kotlin/bot/toby/button/buttons/InitiativePreviousButtonTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/button/buttons/InitiativePreviousButtonTest.kt
@@ -6,6 +6,7 @@ import bot.toby.button.ButtonTest.Companion.dndHelper
 import bot.toby.button.ButtonTest.Companion.event
 import bot.toby.button.ButtonTest.Companion.userService
 import bot.toby.button.DefaultButtonContext
+import bot.toby.helpers.InitiativeState
 import database.dto.ConfigDto
 import io.mockk.*
 import net.dv8tion.jda.api.entities.Message
@@ -56,6 +57,7 @@ class InitiativePreviousButtonTest : ButtonTest {
 
 
         every { dndHelper.decrementTurnTable(any(), any(), any(), any()) } just Runs
+        every { dndHelper.stateFor(any()) } returns InitiativeState()
 
         // Invoke the handler
         InitiativePreviousButton(dndHelper, io.mockk.mockk(relaxed = true)).handle(DefaultButtonContext(event), database.dto.UserDto(6L, 1L), 0)

--- a/discord-bot/src/test/kotlin/bot/toby/button/buttons/RollButtonTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/button/buttons/RollButtonTest.kt
@@ -7,9 +7,8 @@ import bot.toby.button.ButtonTest.Companion.mockChannel
 import bot.toby.button.DefaultButtonContext
 import bot.toby.command.commands.dnd.RollCommand
 import bot.toby.managers.DefaultCommandManager
-import com.fasterxml.jackson.databind.ObjectMapper
 import io.mockk.*
-import org.springframework.context.ApplicationEventPublisher
+import web.service.SessionLogPublisher
 import net.dv8tion.jda.api.components.actionrow.ActionRow
 import net.dv8tion.jda.api.entities.Message
 import net.dv8tion.jda.api.entities.MessageEmbed
@@ -29,7 +28,7 @@ class RollButtonTest : ButtonTest {
         super.setup()
 
         // Initialize RollCommand and mock its methods
-        rollCommand = spyk(RollCommand(dndHelper, mockk<ApplicationEventPublisher>(relaxed = true), ObjectMapper()))
+        rollCommand = spyk(RollCommand(dndHelper, mockk<SessionLogPublisher>(relaxed = true)))
         every { rollCommand.handleDiceRoll(any(), any(), any(), any()) } returns mockk<WebhookMessageCreateAction<Message>> {
             every { queue(any()) } just Runs
         }

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/dnd/CampaignCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/dnd/CampaignCommandTest.kt
@@ -25,6 +25,7 @@ internal class CampaignCommandTest : CommandTest {
     private lateinit var campaignService: CampaignService
     private lateinit var campaignPlayerService: CampaignPlayerService
     private lateinit var userDtoHelper: UserDtoHelper
+    private lateinit var sessionLog: web.service.SessionLogPublisher
     private lateinit var command: CampaignCommand
 
     private val guildId = 1L
@@ -45,7 +46,8 @@ internal class CampaignCommandTest : CommandTest {
         campaignService = mockk(relaxed = true)
         campaignPlayerService = mockk(relaxed = true)
         userDtoHelper = mockk(relaxed = true)
-        command = CampaignCommand(campaignService, campaignPlayerService, userDtoHelper)
+        sessionLog = mockk(relaxed = true)
+        command = CampaignCommand(campaignService, campaignPlayerService, userDtoHelper, sessionLog)
 
         every { event.subcommandName } returns "status"
         every { userDtoHelper.calculateUserDto(any(), any(), any()) } returns requestingUserDto

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/dnd/InitiativeCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/dnd/InitiativeCommandTest.kt
@@ -40,7 +40,7 @@ internal class InitiativeCommandTest : CommandTest {
         setUpCommonMocks()
         userDtoHelper = mockk()
         dndHelper = DnDHelper(userDtoHelper)
-        initiativeCommand = InitiativeCommand(dndHelper)
+        initiativeCommand = InitiativeCommand(dndHelper, mockk(relaxed = true))
         channelOption = mockk<OptionMapping>()
         initButtons = dndHelper.initButtons
         every { event.getOption("channel") } returns channelOption

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/dnd/RollCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/dnd/RollCommandTest.kt
@@ -6,11 +6,10 @@ import bot.toby.command.CommandTest.Companion.webhookMessageCreateAction
 import bot.toby.command.DefaultCommandContext
 import bot.toby.helpers.DnDHelper
 import bot.toby.helpers.UserDtoHelper
-import com.fasterxml.jackson.databind.ObjectMapper
-import common.events.CampaignEventOccurred
 import common.events.CampaignEventType
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
 import io.mockk.verify
 import net.dv8tion.jda.api.components.actionrow.ActionRow
 import net.dv8tion.jda.api.interactions.commands.OptionMapping
@@ -18,24 +17,23 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.springframework.context.ApplicationEventPublisher
+import web.service.SessionLogPublisher
 
 class RollCommandTest : CommandTest {
     private lateinit var rollCommand: RollCommand
 
     lateinit var userDtoHelper: UserDtoHelper
     lateinit var dndHelper: DnDHelper
-    lateinit var applicationEventPublisher: ApplicationEventPublisher
-    private val objectMapper = ObjectMapper()
+    lateinit var sessionLog: SessionLogPublisher
 
     @BeforeEach
     fun setUp() {
         setUpCommonMocks()
         userDtoHelper = mockk()
         dndHelper = DnDHelper(userDtoHelper)
-        applicationEventPublisher = mockk(relaxed = true)
+        sessionLog = mockk(relaxed = true)
         every { event.hook.sendMessageEmbeds(any(), *anyVararg()) } returns webhookMessageCreateAction
-        rollCommand = RollCommand(dndHelper, applicationEventPublisher, objectMapper)
+        rollCommand = RollCommand(dndHelper, sessionLog)
     }
 
     fun tearDown() {
@@ -44,7 +42,6 @@ class RollCommandTest : CommandTest {
 
     @Test
     fun testRollCommand() {
-        // Arrange
         val ctx = DefaultCommandContext(event)
         val userDto = mockk<database.dto.UserDto>()
         val deleteDelay = 0
@@ -61,11 +58,8 @@ class RollCommandTest : CommandTest {
         every { modifier.asInt } returns 0
         every { webhookMessageCreateAction.addComponents(any<ActionRow>()) } returns webhookMessageCreateAction
 
-
-        // Act
         rollCommand.handle(ctx, userDto, deleteDelay)
 
-        // Assert
         verify(exactly = 1) { event.deferReply() }
         verify(exactly = 1) { event.hook.sendMessageEmbeds(any(), *anyVararg()) }
         verify(exactly = 1) {
@@ -77,10 +71,8 @@ class RollCommandTest : CommandTest {
     fun testHandleDiceRoll() {
         every { webhookMessageCreateAction.addComponents(any<ActionRow>()) } returns webhookMessageCreateAction
 
-        // Call the handleDiceRoll method
         rollCommand.handleDiceRoll(event, 6, 1, 0)
 
-        // Perform verifications as needed
         verify(exactly = 1) { event.deferReply() }
         verify(exactly = 1) { event.hook.sendMessageEmbeds(any(), *anyVararg()) }
         verify(exactly = 1) {
@@ -95,11 +87,14 @@ class RollCommandTest : CommandTest {
         rollCommand.handleDiceRoll(event, 20, 2, 3)
 
         verify(exactly = 1) {
-            applicationEventPublisher.publishEvent(match<CampaignEventOccurred> {
-                it.type == CampaignEventType.ROLL &&
-                    it.guildId == 1L &&
-                    it.actorDiscordId == 1L
-            })
+            sessionLog.publish(
+                guildId = 1L,
+                type = CampaignEventType.ROLL,
+                actorDiscordId = 1L,
+                actorName = any(),
+                payload = any(),
+                refEventId = null
+            )
         }
     }
 
@@ -110,29 +105,33 @@ class RollCommandTest : CommandTest {
 
         rollCommand.handleDiceRoll(event, 20, 1, 0)
 
-        verify(exactly = 0) { applicationEventPublisher.publishEvent(any<CampaignEventOccurred>()) }
+        verify(exactly = 0) { sessionLog.publish(any(), any(), any(), any(), any(), any()) }
     }
 
     @Test
     fun testRollPayloadShape() {
         every { webhookMessageCreateAction.addComponents(any<ActionRow>()) } returns webhookMessageCreateAction
+        val captured = slot<Map<String, Any?>>()
+        every {
+            sessionLog.publish(
+                guildId = any(),
+                type = CampaignEventType.ROLL,
+                actorDiscordId = any(),
+                actorName = any(),
+                payload = capture(captured),
+                refEventId = any()
+            )
+        } returns Unit
 
         rollCommand.handleDiceRoll(event, 6, 3, 2)
 
-        verify(exactly = 1) {
-            applicationEventPublisher.publishEvent(match<CampaignEventOccurred> { published ->
-                val payload = objectMapper.readValue(
-                    published.payloadJson, Map::class.java
-                ) as Map<String, Any?>
-                assertEquals(6, payload["sides"])
-                assertEquals(3, payload["count"])
-                assertEquals(2, payload["modifier"])
-                val raw = payload["rawTotal"] as Int
-                val total = payload["total"] as Int
-                assertTrue(raw in 3..18)
-                assertEquals(raw + 2, total)
-                true
-            })
-        }
+        val payload = captured.captured
+        assertEquals(6, payload["sides"])
+        assertEquals(3, payload["count"])
+        assertEquals(2, payload["modifier"])
+        val raw = payload["rawTotal"] as Int
+        val total = payload["total"] as Int
+        assertTrue(raw in 3..18)
+        assertEquals(raw + 2, total)
     }
 }

--- a/web/src/main/kotlin/web/service/CampaignWebService.kt
+++ b/web/src/main/kotlin/web/service/CampaignWebService.kt
@@ -2,6 +2,7 @@ package web.service
 
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
+import common.events.CampaignEventType
 import common.helpers.parseDndBeyondCharacterId
 import database.dto.CampaignDto
 import database.dto.CampaignPlayerDto
@@ -91,6 +92,7 @@ class CampaignWebService(
     private val characterSheetService: CharacterSheetService,
     private val sessionNoteService: SessionNoteService,
     private val campaignEventService: CampaignEventService,
+    private val sessionLog: SessionLogPublisher,
     private val jda: JDA
 ) {
 
@@ -121,6 +123,9 @@ class CampaignWebService(
 
     fun getActiveCampaignId(guildId: Long): Long? =
         campaignService.getActiveCampaignForGuild(guildId)?.id
+
+    private fun resolveMemberName(guildId: Long, discordId: Long): String? =
+        jda.getGuildById(guildId)?.getMemberById(discordId)?.effectiveName
 
     fun getCampaignDetail(guildId: Long, requestingDiscordId: Long): CampaignDetail? {
         val campaign = campaignService.getActiveCampaignForGuild(guildId) ?: return null
@@ -226,6 +231,12 @@ class CampaignWebService(
                 alive = true
             )
         )
+        sessionLog.publish(
+            guildId = guildId,
+            type = CampaignEventType.PLAYER_JOINED,
+            actorDiscordId = discordId,
+            actorName = resolveMemberName(guildId, discordId)
+        )
         return JoinResult.JOINED
     }
 
@@ -235,6 +246,12 @@ class CampaignWebService(
         val playerId = CampaignPlayerId(campaign.id, discordId)
         if (campaignPlayerService.getPlayer(playerId) == null) return LeaveResult.NOT_A_PLAYER
         campaignPlayerService.removePlayer(playerId)
+        sessionLog.publish(
+            guildId = guildId,
+            type = CampaignEventType.PLAYER_LEFT,
+            actorDiscordId = discordId,
+            actorName = resolveMemberName(guildId, discordId)
+        )
         return LeaveResult.LEFT
     }
 
@@ -259,6 +276,14 @@ class CampaignWebService(
         val campaign = campaignService.getActiveCampaignForGuild(guildId)
             ?: return EndResult.NO_ACTIVE_CAMPAIGN
         if (campaign.dmDiscordId != requestingDiscordId) return EndResult.NOT_DM
+        // Publish before deactivation so the listener can still resolve the active campaign.
+        sessionLog.publish(
+            guildId = guildId,
+            type = CampaignEventType.CAMPAIGN_ENDED,
+            actorDiscordId = requestingDiscordId,
+            actorName = resolveMemberName(guildId, requestingDiscordId),
+            payload = mapOf("campaignName" to campaign.name)
+        )
         campaignService.deactivateCampaignForGuild(guildId)
         return EndResult.ENDED
     }
@@ -272,6 +297,16 @@ class CampaignWebService(
         val playerId = CampaignPlayerId(campaign.id, targetDiscordId)
         if (campaignPlayerService.getPlayer(playerId) == null) return KickResult.NOT_A_PLAYER
         campaignPlayerService.removePlayer(playerId)
+        sessionLog.publish(
+            guildId = guildId,
+            type = CampaignEventType.PLAYER_KICKED,
+            actorDiscordId = requestingDiscordId,
+            actorName = resolveMemberName(guildId, requestingDiscordId),
+            payload = mapOf(
+                "targetDiscordId" to targetDiscordId,
+                "targetName" to resolveMemberName(guildId, targetDiscordId)
+            )
+        )
         return KickResult.KICKED
     }
 
@@ -287,8 +322,21 @@ class CampaignWebService(
 
         val playerId = CampaignPlayerId(campaign.id, targetDiscordId)
         val player = campaignPlayerService.getPlayer(playerId) ?: return SetAliveResult.NOT_A_PLAYER
+        val previouslyAlive = player.alive
         player.alive = alive
         campaignPlayerService.updatePlayer(player)
+        if (previouslyAlive != alive) {
+            sessionLog.publish(
+                guildId = guildId,
+                type = if (alive) CampaignEventType.PLAYER_REVIVED else CampaignEventType.PLAYER_DIED,
+                actorDiscordId = requestingDiscordId,
+                actorName = resolveMemberName(guildId, requestingDiscordId),
+                payload = mapOf(
+                    "targetDiscordId" to targetDiscordId,
+                    "targetName" to resolveMemberName(guildId, targetDiscordId)
+                )
+            )
+        }
         return SetAliveResult.UPDATED
     }
 

--- a/web/src/main/kotlin/web/service/SessionLogPublisher.kt
+++ b/web/src/main/kotlin/web/service/SessionLogPublisher.kt
@@ -1,0 +1,41 @@
+package web.service
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import common.events.CampaignEventOccurred
+import common.events.CampaignEventType
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Service
+
+/**
+ * Tiny convenience around Spring's [ApplicationEventPublisher] for producing
+ * [CampaignEventOccurred] events from both Discord commands and web actions.
+ * Lives in `web` because it's the only module with an already-autoconfigured
+ * Jackson [ObjectMapper] bean; callers in `discord-bot` reach it through the
+ * existing `discord-bot → web` project dependency.
+ */
+@Service
+class SessionLogPublisher(
+    private val publisher: ApplicationEventPublisher,
+    private val objectMapper: ObjectMapper
+) {
+
+    fun publish(
+        guildId: Long,
+        type: CampaignEventType,
+        actorDiscordId: Long? = null,
+        actorName: String? = null,
+        payload: Map<String, Any?> = emptyMap(),
+        refEventId: Long? = null
+    ) {
+        publisher.publishEvent(
+            CampaignEventOccurred(
+                guildId = guildId,
+                type = type,
+                actorDiscordId = actorDiscordId,
+                actorName = actorName,
+                payloadJson = objectMapper.writeValueAsString(payload),
+                refEventId = refEventId
+            )
+        )
+    }
+}

--- a/web/src/main/resources/static/js/sessionLog.js
+++ b/web/src/main/resources/static/js/sessionLog.js
@@ -17,13 +17,48 @@
         return String(v);
     }
 
-    function renderRollBody(p) {
-        const sides = p.sides;
-        const count = p.count;
-        const modifier = p.modifier || 0;
-        const total = p.total;
-        const modSegment = modifier ? ' + ' + modifier : '';
-        return 'rolled ' + count + 'd' + sides + modSegment + ' = ' + total;
+    function renderBody(event) {
+        const p = event.payload || {};
+        switch (event.type) {
+            case 'ROLL': {
+                const mod = p.modifier ? ' + ' + p.modifier : '';
+                return 'rolled ' + p.count + 'd' + p.sides + mod + ' = ' + p.total;
+            }
+            case 'INITIATIVE_ROLLED': {
+                const entries = Array.isArray(p.entries) ? p.entries : [];
+                if (!entries.length) return 'rolled initiative (empty)';
+                const order = entries.map(function (e) { return e.name + ' ' + e.roll; }).join(', ');
+                return 'rolled initiative — ' + order;
+            }
+            case 'INITIATIVE_NEXT':
+                return p.currentName ? 'next turn: ' + p.currentName : 'advanced initiative';
+            case 'INITIATIVE_PREV':
+                return p.currentName ? 'back to: ' + p.currentName : 'rewound initiative';
+            case 'INITIATIVE_CLEARED':
+                return 'cleared initiative';
+            case 'PLAYER_JOINED':
+                return 'joined the campaign';
+            case 'PLAYER_LEFT':
+                return 'left the campaign';
+            case 'PLAYER_KICKED':
+                return 'kicked ' + (p.targetName || 'player ' + p.targetDiscordId);
+            case 'PLAYER_DIED':
+                return '☠️ marked ' + (p.targetName || 'player') + ' as dead';
+            case 'PLAYER_REVIVED':
+                return 'revived ' + (p.targetName || 'player');
+            case 'CAMPAIGN_ENDED':
+                return p.campaignName
+                    ? 'ended campaign “' + p.campaignName + '”'
+                    : 'ended the campaign';
+            case 'DM_NOTE':
+                return p.body ? p.body : '(empty note)';
+            case 'HIT':
+                return 'marked as HIT' + (p.target ? ' on ' + p.target : '');
+            case 'MISS':
+                return 'marked as MISS' + (p.target ? ' on ' + p.target : '');
+            default:
+                return escapeText(JSON.stringify(p));
+        }
     }
 
     function renderEvent(event) {
@@ -45,12 +80,7 @@
 
         const body = document.createElement('span');
         body.className = 'event-body';
-        const payload = event.payload || {};
-        if (event.type === 'ROLL') {
-            body.textContent = renderRollBody(payload);
-        } else {
-            body.textContent = escapeText(JSON.stringify(payload));
-        }
+        body.textContent = renderBody(event);
 
         const time = document.createElement('span');
         time.className = 'event-time';

--- a/web/src/main/resources/templates/campaignDetail.html
+++ b/web/src/main/resources/templates/campaignDetail.html
@@ -518,6 +518,34 @@
                                    + |&nbsp;=&nbsp;${event.payload['total']}|">
                         rolled 1d20 = 15
                     </span>
+                    <span th:case="'INITIATIVE_ROLLED'"
+                          th:text="${event.payload['entries'] != null and !#lists.isEmpty(event.payload['entries'])
+                                    ? 'rolled initiative — ' + #strings.arrayJoin(
+                                          event.payload['entries'].![name + ' ' + roll].toArray(), ', ')
+                                    : 'rolled initiative (empty)'}">
+                        rolled initiative — Alice 18, Bob 12
+                    </span>
+                    <span th:case="'INITIATIVE_NEXT'"
+                          th:text="${event.payload['currentName'] != null
+                                    ? 'next turn: ' + event.payload['currentName']
+                                    : 'advanced initiative'}">next turn: Alice</span>
+                    <span th:case="'INITIATIVE_PREV'"
+                          th:text="${event.payload['currentName'] != null
+                                    ? 'back to: ' + event.payload['currentName']
+                                    : 'rewound initiative'}">back to: Alice</span>
+                    <span th:case="'INITIATIVE_CLEARED'">cleared initiative</span>
+                    <span th:case="'PLAYER_JOINED'">joined the campaign</span>
+                    <span th:case="'PLAYER_LEFT'">left the campaign</span>
+                    <span th:case="'PLAYER_KICKED'"
+                          th:text="${'kicked ' + (event.payload['targetName'] ?: 'a player')}">kicked someone</span>
+                    <span th:case="'PLAYER_DIED'"
+                          th:text="${'☠️ marked ' + (event.payload['targetName'] ?: 'a player') + ' as dead'}">died</span>
+                    <span th:case="'PLAYER_REVIVED'"
+                          th:text="${'revived ' + (event.payload['targetName'] ?: 'a player')}">revived</span>
+                    <span th:case="'CAMPAIGN_ENDED'"
+                          th:text="${event.payload['campaignName'] != null
+                                    ? 'ended campaign “' + event.payload['campaignName'] + '”'
+                                    : 'ended the campaign'}">ended campaign</span>
                     <span th:case="*" th:text="${event.payload}">raw payload</span>
                 </span>
                 <span class="event-time"


### PR DESCRIPTION
## Summary

Third of four PRs for the session log. Adds every remaining event producer and replaces the JSON fallback in both the client JS and the server template with typed human-readable renderers.

### New helper
`web.service.SessionLogPublisher` bundles `ApplicationEventPublisher` + `ObjectMapper` so 9 producer sites don't each inject both. `RollCommand` (from PR A) is refactored onto it, cutting the per-call serialisation boilerplate.

### Producers
**Discord:**
- `InitiativeCommand` → `INITIATIVE_ROLLED` with `entries: [{name, roll}, …]`
- `InitiativeNextButton` → `INITIATIVE_NEXT` with `currentName`, `currentIndex`
- `InitiativePreviousButton` → `INITIATIVE_PREV`
- `InitiativeClearButton` → `INITIATIVE_CLEARED`
- `CampaignCommand.handleJoin/handleLeave/handleEnd` → `PLAYER_JOINED`, `PLAYER_LEFT`, `CAMPAIGN_ENDED` (end publishes *before* deactivation so the listener can still find the active campaign)

**Web:**
- `CampaignWebService.joinCampaign`/`leaveCampaign`/`kickPlayer`/`setPlayerAlive`/`endCampaign` with actor/target metadata resolved via JDA member lookups. `setPlayerAlive` only publishes when `alive` actually flips.

### Renderers
- `sessionLog.js`: `switch` on `event.type` rendering each kind as a short human sentence ("rolled initiative — Alice 18, Bob 12", "☠️ marked Dave as dead", "ended campaign 'Whispering Tomb'"). Unknown types still fall back to JSON for forward-compat.
- `campaignDetail.html`: matching Thymeleaf switch cases so server-rendered backfill looks identical to what JS produces.

### Tests
- `RollCommandTest`: mocks `SessionLogPublisher` instead of the bare publisher + mapper; verifies type/actor/payload via capture slot.
- Initiative button tests + `InitiativeCommandTest`: pass a relaxed `SessionLogPublisher` mock into the constructor.
- `CampaignCommandTest`, `CampaignWebServiceTest`, `RollButtonTest`: extended constructors with relaxed `sessionLog` mocks. Existing assertions unchanged.

## Test plan

- [ ] `./gradlew build` passes
- [ ] Manual: run `/initiative`, `/campaign join`, `/campaign leave`, `/campaign end` in Discord and watch them appear in the session log live
- [ ] Manual: click Mark dead / Revive / Kick on the web UI — corresponding event appears for everyone viewing
- [ ] Manual: refresh the page → server-rendered events use the same typed strings the JS produces
- [ ] Qodana: unused-enum warnings for the previously-declared `CampaignEventType` values should drop (each is now emitted somewhere)

## What's next

- **PR D** — DM hit/miss annotations on roll entries + narrate form

https://claude.ai/code/session_01DgKBYeiGaxmLg5xaPasU4r