### PR TITLE
feat(dnd): DM hit/miss annotations and narrate (PR D of 4)

### DIFF
--- a/application/src/test/kotlin/web/controller/CampaignControllerTest.kt
+++ b/application/src/test/kotlin/web/controller/CampaignControllerTest.kt
@@ -16,6 +16,7 @@ import org.springframework.security.oauth2.core.user.OAuth2User
 import org.springframework.ui.Model
 import org.springframework.web.servlet.mvc.support.RedirectAttributes
 import web.service.AddNoteResult
+import web.service.AnnotateRollResult
 import web.service.CampaignDetail
 import web.service.CampaignEventBroadcaster
 import web.service.CampaignWebService
@@ -25,6 +26,7 @@ import web.service.GuildCampaignInfo
 import web.service.JoinResult
 import web.service.KickResult
 import web.service.LeaveResult
+import web.service.NarrateResult
 import web.service.SessionEventView
 import web.service.SetAliveResult
 import web.service.SetCharacterResult
@@ -570,5 +572,106 @@ class CampaignControllerTest {
 
         assertNotNull(emitter)
         verify(exactly = 0) { campaignEventBroadcaster.subscribe(any()) }
+    }
+
+    // annotateRoll
+
+    @Test
+    fun `annotateRoll redirects on success`() {
+        every {
+            campaignWebService.annotateRoll(guildId, 1L, 42L, "HIT", null)
+        } returns AnnotateRollResult.ANNOTATED
+
+        val view = controller.annotateRoll(guildId, 42L, "HIT", null, mockUser, mockRa)
+
+        assertEquals("redirect:/dnd/campaign/$guildId", view)
+        verify(exactly = 0) { mockRa.addFlashAttribute(any<String>(), any()) }
+    }
+
+    @Test
+    fun `annotateRoll sets error when not DM`() {
+        every {
+            campaignWebService.annotateRoll(guildId, 1L, 42L, "HIT", null)
+        } returns AnnotateRollResult.NOT_DM
+
+        controller.annotateRoll(guildId, 42L, "HIT", null, mockUser, mockRa)
+
+        verify { mockRa.addFlashAttribute("error", "Only the Dungeon Master can annotate rolls.") }
+    }
+
+    @Test
+    fun `annotateRoll sets error when referenced event is not a roll`() {
+        every {
+            campaignWebService.annotateRoll(guildId, 1L, 42L, "HIT", null)
+        } returns AnnotateRollResult.NOT_A_ROLL
+
+        controller.annotateRoll(guildId, 42L, "HIT", null, mockUser, mockRa)
+
+        verify { mockRa.addFlashAttribute("error", "You can only mark Hit/Miss on a roll.") }
+    }
+
+    @Test
+    fun `annotateRoll sets error when kind is invalid`() {
+        every {
+            campaignWebService.annotateRoll(guildId, 1L, 42L, "FOO", null)
+        } returns AnnotateRollResult.INVALID_KIND
+
+        controller.annotateRoll(guildId, 42L, "FOO", null, mockUser, mockRa)
+
+        verify { mockRa.addFlashAttribute("error", "Annotation kind must be HIT or MISS.") }
+    }
+
+    @Test
+    fun `annotateRoll redirects to list when user id missing`() {
+        every { mockUser.getAttribute<String>("id") } returns null
+
+        val view = controller.annotateRoll(guildId, 42L, "HIT", null, mockUser, mockRa)
+
+        assertEquals("redirect:/dnd/campaign", view)
+    }
+
+    // narrate
+
+    @Test
+    fun `narrate redirects on success`() {
+        every {
+            campaignWebService.narrate(guildId, 1L, "beat")
+        } returns NarrateResult.NARRATED
+
+        val view = controller.narrate(guildId, "beat", mockUser, mockRa)
+
+        assertEquals("redirect:/dnd/campaign/$guildId", view)
+        verify(exactly = 0) { mockRa.addFlashAttribute(any<String>(), any()) }
+    }
+
+    @Test
+    fun `narrate sets error when not DM`() {
+        every {
+            campaignWebService.narrate(guildId, 1L, "beat")
+        } returns NarrateResult.NOT_DM
+
+        controller.narrate(guildId, "beat", mockUser, mockRa)
+
+        verify { mockRa.addFlashAttribute("error", "Only the Dungeon Master can narrate.") }
+    }
+
+    @Test
+    fun `narrate sets error on empty body`() {
+        every {
+            campaignWebService.narrate(guildId, 1L, "")
+        } returns NarrateResult.EMPTY_BODY
+
+        controller.narrate(guildId, "", mockUser, mockRa)
+
+        verify { mockRa.addFlashAttribute("error", "Narration can't be empty.") }
+    }
+
+    @Test
+    fun `narrate redirects to list when user id missing`() {
+        every { mockUser.getAttribute<String>("id") } returns null
+
+        val view = controller.narrate(guildId, "beat", mockUser, mockRa)
+
+        assertEquals("redirect:/dnd/campaign", view)
     }
 }

--- a/application/src/test/kotlin/web/service/CampaignWebServiceTest.kt
+++ b/application/src/test/kotlin/web/service/CampaignWebServiceTest.kt
@@ -767,4 +767,166 @@ class CampaignWebServiceTest {
         assertEquals(1, detail.recentEvents.size)
         assertEquals(9L, detail.recentEvents[0].id)
     }
+
+    // annotateRoll
+
+    @Test
+    fun `annotateRoll rejects unknown kind`() {
+        assertEquals(
+            AnnotateRollResult.INVALID_KIND,
+            service.annotateRoll(guildId, dmDiscordId, 1L, "BOGUS", null)
+        )
+    }
+
+    @Test
+    fun `annotateRoll returns NO_ACTIVE_CAMPAIGN when none exists`() {
+        every { campaignService.getActiveCampaignForGuild(guildId) } returns null
+        assertEquals(
+            AnnotateRollResult.NO_ACTIVE_CAMPAIGN,
+            service.annotateRoll(guildId, dmDiscordId, 1L, "HIT", null)
+        )
+    }
+
+    @Test
+    fun `annotateRoll returns NOT_DM when requester is not the DM`() {
+        every { campaignService.getActiveCampaignForGuild(guildId) } returns makeCampaign()
+        assertEquals(
+            AnnotateRollResult.NOT_DM,
+            service.annotateRoll(guildId, playerDiscordId, 1L, "HIT", null)
+        )
+    }
+
+    @Test
+    fun `annotateRoll returns NOT_FOUND when event id doesn't exist`() {
+        val campaign = makeCampaign()
+        every { campaignService.getActiveCampaignForGuild(guildId) } returns campaign
+        every { campaignEventService.getById(99L) } returns null
+        assertEquals(
+            AnnotateRollResult.NOT_FOUND,
+            service.annotateRoll(guildId, dmDiscordId, 99L, "HIT", null)
+        )
+    }
+
+    @Test
+    fun `annotateRoll returns NOT_FOUND when event belongs to a different campaign`() {
+        val campaign = makeCampaign()
+        every { campaignService.getActiveCampaignForGuild(guildId) } returns campaign
+        every { campaignEventService.getById(99L) } returns CampaignEventDto(
+            id = 99L, campaignId = 999L, eventType = "ROLL", payload = "{}"
+        )
+        assertEquals(
+            AnnotateRollResult.NOT_FOUND,
+            service.annotateRoll(guildId, dmDiscordId, 99L, "HIT", null)
+        )
+    }
+
+    @Test
+    fun `annotateRoll returns NOT_A_ROLL when referenced event isn't a roll`() {
+        val campaign = makeCampaign()
+        every { campaignService.getActiveCampaignForGuild(guildId) } returns campaign
+        every { campaignEventService.getById(99L) } returns CampaignEventDto(
+            id = 99L, campaignId = campaign.id, eventType = "PLAYER_JOINED", payload = "{}"
+        )
+        assertEquals(
+            AnnotateRollResult.NOT_A_ROLL,
+            service.annotateRoll(guildId, dmDiscordId, 99L, "HIT", null)
+        )
+    }
+
+    @Test
+    fun `annotateRoll publishes HIT referencing the roll`() {
+        val campaign = makeCampaign()
+        every { campaignService.getActiveCampaignForGuild(guildId) } returns campaign
+        every { campaignEventService.getById(99L) } returns CampaignEventDto(
+            id = 99L, campaignId = campaign.id, eventType = "ROLL", payload = "{}"
+        )
+
+        assertEquals(
+            AnnotateRollResult.ANNOTATED,
+            service.annotateRoll(guildId, dmDiscordId, 99L, "hit", "goblin")
+        )
+        verify {
+            sessionLog.publish(
+                guildId = guildId,
+                type = common.events.CampaignEventType.HIT,
+                actorDiscordId = dmDiscordId,
+                actorName = any(),
+                payload = match { it["target"] == "goblin" },
+                refEventId = 99L
+            )
+        }
+    }
+
+    @Test
+    fun `annotateRoll publishes MISS without target when target is blank`() {
+        val campaign = makeCampaign()
+        every { campaignService.getActiveCampaignForGuild(guildId) } returns campaign
+        every { campaignEventService.getById(99L) } returns CampaignEventDto(
+            id = 99L, campaignId = campaign.id, eventType = "ROLL", payload = "{}"
+        )
+
+        service.annotateRoll(guildId, dmDiscordId, 99L, "MISS", "  ")
+
+        verify {
+            sessionLog.publish(
+                guildId = guildId,
+                type = common.events.CampaignEventType.MISS,
+                actorDiscordId = dmDiscordId,
+                actorName = any(),
+                payload = match { it.isEmpty() },
+                refEventId = 99L
+            )
+        }
+    }
+
+    // narrate
+
+    @Test
+    fun `narrate rejects empty body`() {
+        assertEquals(NarrateResult.EMPTY_BODY, service.narrate(guildId, dmDiscordId, "   "))
+    }
+
+    @Test
+    fun `narrate rejects body over the length cap`() {
+        val long = "x".repeat(CampaignWebService.MAX_NARRATE_BODY_LENGTH + 1)
+        assertEquals(NarrateResult.BODY_TOO_LONG, service.narrate(guildId, dmDiscordId, long))
+    }
+
+    @Test
+    fun `narrate returns NO_ACTIVE_CAMPAIGN when none exists`() {
+        every { campaignService.getActiveCampaignForGuild(guildId) } returns null
+        assertEquals(
+            NarrateResult.NO_ACTIVE_CAMPAIGN,
+            service.narrate(guildId, dmDiscordId, "Something happens.")
+        )
+    }
+
+    @Test
+    fun `narrate returns NOT_DM when requester is not the DM`() {
+        every { campaignService.getActiveCampaignForGuild(guildId) } returns makeCampaign()
+        assertEquals(
+            NarrateResult.NOT_DM,
+            service.narrate(guildId, playerDiscordId, "Something happens.")
+        )
+    }
+
+    @Test
+    fun `narrate publishes DM_NOTE for DM`() {
+        every { campaignService.getActiveCampaignForGuild(guildId) } returns makeCampaign()
+
+        assertEquals(
+            NarrateResult.NARRATED,
+            service.narrate(guildId, dmDiscordId, "  A dragon lands.  ")
+        )
+        verify {
+            sessionLog.publish(
+                guildId = guildId,
+                type = common.events.CampaignEventType.DM_NOTE,
+                actorDiscordId = dmDiscordId,
+                actorName = any(),
+                payload = match { it["body"] == "A dragon lands." },
+                refEventId = null
+            )
+        }
+    }
 }

--- a/web/src/main/kotlin/web/controller/CampaignController.kt
+++ b/web/src/main/kotlin/web/controller/CampaignController.kt
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.*
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
 import org.springframework.web.servlet.mvc.support.RedirectAttributes
 import web.service.AddNoteResult
+import web.service.AnnotateRollResult
 import web.service.CampaignEventBroadcaster
 import web.service.CampaignWebService
 import web.service.DeleteNoteResult
@@ -17,6 +18,7 @@ import web.service.EndResult
 import web.service.JoinResult
 import web.service.KickResult
 import web.service.LeaveResult
+import web.service.NarrateResult
 import web.service.SessionEventView
 import web.service.SetAliveResult
 import web.service.SetCharacterResult
@@ -284,6 +286,52 @@ class CampaignController(
             DeleteNoteResult.NOT_ALLOWED -> ra.addFlashAttribute(
                 "error",
                 "You can only delete your own notes (or any note if you're the DM)."
+            )
+        }
+        return "redirect:/dnd/campaign/$guildId"
+    }
+
+    @PostMapping("/campaign/{guildId}/events/{eventId}/annotate")
+    fun annotateRoll(
+        @PathVariable guildId: Long,
+        @PathVariable eventId: Long,
+        @RequestParam kind: String,
+        @RequestParam(name = "target", required = false) target: String?,
+        @AuthenticationPrincipal user: OAuth2User,
+        ra: RedirectAttributes
+    ): String {
+        val discordId = user.discordIdOrNull()
+            ?: return "redirect:/dnd/campaign"
+
+        when (campaignWebService.annotateRoll(guildId, discordId, eventId, kind, target)) {
+            AnnotateRollResult.ANNOTATED -> {}
+            AnnotateRollResult.NO_ACTIVE_CAMPAIGN -> ra.addFlashAttribute("error", "No active campaign in this server.")
+            AnnotateRollResult.NOT_DM -> ra.addFlashAttribute("error", "Only the Dungeon Master can annotate rolls.")
+            AnnotateRollResult.NOT_FOUND -> ra.addFlashAttribute("error", "That roll doesn't exist in this campaign.")
+            AnnotateRollResult.NOT_A_ROLL -> ra.addFlashAttribute("error", "You can only mark Hit/Miss on a roll.")
+            AnnotateRollResult.INVALID_KIND -> ra.addFlashAttribute("error", "Annotation kind must be HIT or MISS.")
+        }
+        return "redirect:/dnd/campaign/$guildId"
+    }
+
+    @PostMapping("/campaign/{guildId}/narrate")
+    fun narrate(
+        @PathVariable guildId: Long,
+        @RequestParam body: String,
+        @AuthenticationPrincipal user: OAuth2User,
+        ra: RedirectAttributes
+    ): String {
+        val discordId = user.discordIdOrNull()
+            ?: return "redirect:/dnd/campaign"
+
+        when (campaignWebService.narrate(guildId, discordId, body)) {
+            NarrateResult.NARRATED -> {}
+            NarrateResult.NO_ACTIVE_CAMPAIGN -> ra.addFlashAttribute("error", "No active campaign in this server.")
+            NarrateResult.NOT_DM -> ra.addFlashAttribute("error", "Only the Dungeon Master can narrate.")
+            NarrateResult.EMPTY_BODY -> ra.addFlashAttribute("error", "Narration can't be empty.")
+            NarrateResult.BODY_TOO_LONG -> ra.addFlashAttribute(
+                "error",
+                "Narration is too long (max ${web.service.CampaignWebService.MAX_NARRATE_BODY_LENGTH} characters)."
             )
         }
         return "redirect:/dnd/campaign/$guildId"

--- a/web/src/main/kotlin/web/service/CampaignWebService.kt
+++ b/web/src/main/kotlin/web/service/CampaignWebService.kt
@@ -82,6 +82,8 @@ enum class KickResult { KICKED, NO_ACTIVE_CAMPAIGN, NOT_DM, NOT_A_PLAYER, CANNOT
 enum class SetAliveResult { UPDATED, NO_ACTIVE_CAMPAIGN, NOT_DM, NOT_A_PLAYER }
 enum class AddNoteResult { ADDED, NO_ACTIVE_CAMPAIGN, NOT_PARTICIPANT, EMPTY_BODY, BODY_TOO_LONG }
 enum class DeleteNoteResult { DELETED, NO_ACTIVE_CAMPAIGN, NOT_FOUND, NOT_ALLOWED }
+enum class AnnotateRollResult { ANNOTATED, NO_ACTIVE_CAMPAIGN, NOT_DM, NOT_FOUND, NOT_A_ROLL, INVALID_KIND }
+enum class NarrateResult { NARRATED, NO_ACTIVE_CAMPAIGN, NOT_DM, EMPTY_BODY, BODY_TOO_LONG }
 
 @Service
 class CampaignWebService(
@@ -102,6 +104,7 @@ class CampaignWebService(
 
     companion object {
         const val MAX_NOTE_BODY_LENGTH = 2000
+        const val MAX_NARRATE_BODY_LENGTH = 1000
         const val DEFAULT_EVENT_LIMIT = 100
     }
 
@@ -380,6 +383,58 @@ class CampaignWebService(
         if (campaign.dmDiscordId == discordId) return true
         val playerId = CampaignPlayerId(campaign.id, discordId)
         return campaignPlayerService.getPlayer(playerId) != null
+    }
+
+    fun annotateRoll(
+        guildId: Long,
+        requestingDiscordId: Long,
+        refEventId: Long,
+        kind: String,
+        target: String?
+    ): AnnotateRollResult {
+        val type = when (kind.uppercase()) {
+            "HIT" -> CampaignEventType.HIT
+            "MISS" -> CampaignEventType.MISS
+            else -> return AnnotateRollResult.INVALID_KIND
+        }
+        val campaign = campaignService.getActiveCampaignForGuild(guildId)
+            ?: return AnnotateRollResult.NO_ACTIVE_CAMPAIGN
+        if (campaign.dmDiscordId != requestingDiscordId) return AnnotateRollResult.NOT_DM
+
+        val referenced = campaignEventService.getById(refEventId)
+            ?: return AnnotateRollResult.NOT_FOUND
+        if (referenced.campaignId != campaign.id) return AnnotateRollResult.NOT_FOUND
+        if (referenced.eventType != CampaignEventType.ROLL.name) return AnnotateRollResult.NOT_A_ROLL
+
+        val trimmedTarget = target?.trim()?.takeIf { it.isNotEmpty() }
+        sessionLog.publish(
+            guildId = guildId,
+            type = type,
+            actorDiscordId = requestingDiscordId,
+            actorName = resolveMemberName(guildId, requestingDiscordId),
+            payload = if (trimmedTarget != null) mapOf("target" to trimmedTarget) else emptyMap(),
+            refEventId = refEventId
+        )
+        return AnnotateRollResult.ANNOTATED
+    }
+
+    fun narrate(guildId: Long, requestingDiscordId: Long, body: String): NarrateResult {
+        val trimmed = body.trim()
+        if (trimmed.isEmpty()) return NarrateResult.EMPTY_BODY
+        if (trimmed.length > MAX_NARRATE_BODY_LENGTH) return NarrateResult.BODY_TOO_LONG
+
+        val campaign = campaignService.getActiveCampaignForGuild(guildId)
+            ?: return NarrateResult.NO_ACTIVE_CAMPAIGN
+        if (campaign.dmDiscordId != requestingDiscordId) return NarrateResult.NOT_DM
+
+        sessionLog.publish(
+            guildId = guildId,
+            type = CampaignEventType.DM_NOTE,
+            actorDiscordId = requestingDiscordId,
+            actorName = resolveMemberName(guildId, requestingDiscordId),
+            payload = mapOf("body" to trimmed)
+        )
+        return NarrateResult.NARRATED
     }
 
     private fun loadCharacterSummary(characterId: Long): CharacterSummary? {

--- a/web/src/main/resources/static/js/sessionLog.js
+++ b/web/src/main/resources/static/js/sessionLog.js
@@ -5,8 +5,43 @@
     const guildId = logEl.dataset.guildId;
     if (!guildId) return;
 
+    const isDm = logEl.dataset.isDm === 'true';
     let lastSeenId = parseInt(logEl.dataset.lastSeenId || '0', 10);
     const emptyEl = document.getElementById('session-log-empty');
+
+    function postAnnotation(eventId, kind) {
+        const form = document.createElement('form');
+        form.method = 'POST';
+        form.action = '/dnd/campaign/' + guildId + '/events/' + eventId + '/annotate';
+        const input = document.createElement('input');
+        input.type = 'hidden';
+        input.name = 'kind';
+        input.value = kind;
+        form.appendChild(input);
+        document.body.appendChild(form);
+        form.submit();
+    }
+
+    function buildDmActions(event) {
+        if (!isDm || event.type !== 'ROLL') return null;
+        const wrap = document.createElement('span');
+        wrap.className = 'event-dm-actions';
+        const hit = document.createElement('button');
+        hit.type = 'button';
+        hit.className = 'btn-xs';
+        hit.title = 'Mark this roll as a hit';
+        hit.textContent = 'Hit';
+        hit.addEventListener('click', function () { postAnnotation(event.id, 'HIT'); });
+        const miss = document.createElement('button');
+        miss.type = 'button';
+        miss.className = 'btn-xs kick';
+        miss.title = 'Mark this roll as a miss';
+        miss.textContent = 'Miss';
+        miss.addEventListener('click', function () { postAnnotation(event.id, 'MISS'); });
+        wrap.appendChild(hit);
+        wrap.appendChild(miss);
+        return wrap;
+    }
 
     function ensureContainer() {
         if (emptyEl) emptyEl.style.display = 'none';
@@ -93,6 +128,8 @@
         row.appendChild(actor);
         row.appendChild(body);
         row.appendChild(time);
+        const dmActions = buildDmActions(event);
+        if (dmActions) row.appendChild(dmActions);
         logEl.appendChild(row);
     }
 

--- a/web/src/main/resources/templates/campaignDetail.html
+++ b/web/src/main/resources/templates/campaignDetail.html
@@ -324,6 +324,27 @@
             font-family: monospace;
         }
         .empty-events { color: #a0a0b0; font-size: 0.9rem; padding: 10px 0; }
+
+        .event-dm-actions {
+            display: inline-flex;
+            gap: 4px;
+            margin-left: 6px;
+        }
+        .event-dm-actions form { margin: 0; }
+        .narrate-form {
+            display: flex;
+            gap: 8px;
+            margin: 14px 0 20px;
+        }
+        .narrate-form input[type=text] {
+            flex: 1;
+            padding: 9px 12px;
+            border-radius: 6px;
+            border: 1px solid #2a2a4a;
+            background: #1a1a2e;
+            color: #e0e0e0;
+            font-size: 0.9rem;
+        }
     </style>
 </head>
 <body>
@@ -505,9 +526,11 @@
 
         <div id="session-log" class="event-list"
              th:attr="data-guild-id=${guildId},
+                      data-is-dm=${isUserDm},
                       data-last-seen-id=${recentEvents != null and not #lists.isEmpty(recentEvents)
                         ? recentEvents[#lists.size(recentEvents) - 1].id : 0}">
-            <div class="event-row" th:each="event : ${recentEvents}">
+            <div class="event-row" th:each="event : ${recentEvents}"
+                 th:attr="data-event-id=${event.id},data-event-type=${event.type}">
                 <span class="event-type" th:text="${event.type}">ROLL</span>
                 <span class="event-actor" th:text="${event.actorName ?: 'system'}">actor</span>
                 <span th:switch="${event.type}" class="event-body">
@@ -546,10 +569,32 @@
                           th:text="${event.payload['campaignName'] != null
                                     ? 'ended campaign “' + event.payload['campaignName'] + '”'
                                     : 'ended the campaign'}">ended campaign</span>
+                    <span th:case="'DM_NOTE'"
+                          th:text="${event.payload['body'] ?: '(empty note)'}">dm note body</span>
+                    <span th:case="'HIT'"
+                          th:text="${event.payload['target'] != null
+                                    ? 'marked HIT on ' + event.payload['target']
+                                    : 'marked HIT'}">marked HIT</span>
+                    <span th:case="'MISS'"
+                          th:text="${event.payload['target'] != null
+                                    ? 'marked MISS on ' + event.payload['target']
+                                    : 'marked MISS'}">marked MISS</span>
                     <span th:case="*" th:text="${event.payload}">raw payload</span>
                 </span>
                 <span class="event-time"
                       th:text="${#temporals.format(event.createdAt, 'HH:mm:ss')}">12:00:00</span>
+                <span th:if="${isUserDm and event.type == 'ROLL'}" class="event-dm-actions">
+                    <form th:action="@{/dnd/campaign/{id}/events/{eid}/annotate(id=${guildId},eid=${event.id})}"
+                          method="post" style="display:inline;">
+                        <input type="hidden" name="kind" value="HIT">
+                        <button type="submit" class="btn-xs" title="Mark this roll as a hit">Hit</button>
+                    </form>
+                    <form th:action="@{/dnd/campaign/{id}/events/{eid}/annotate(id=${guildId},eid=${event.id})}"
+                          method="post" style="display:inline;">
+                        <input type="hidden" name="kind" value="MISS">
+                        <button type="submit" class="btn-xs kick" title="Mark this roll as a miss">Miss</button>
+                    </form>
+                </span>
             </div>
         </div>
 
@@ -557,6 +602,12 @@
              th:style="${#lists.isEmpty(recentEvents) ? '' : 'display:none;'}">
             No activity yet. Rolls from Discord will appear here.
         </div>
+
+        <form th:if="${isUserDm and campaign != null}" class="narrate-form"
+              th:action="@{/dnd/campaign/{id}/narrate(id=${guildId})}" method="post">
+            <input type="text" name="body" placeholder="Narrate a beat…" maxlength="1000" required>
+            <button type="submit" class="btn btn-primary">Narrate</button>
+        </form>
 
         <div class="hint">
             Also available in Discord:


### PR DESCRIPTION
## Summary

Final slice of the session log. Adds two DM-only interactions — **Hit/Miss annotations on roll entries** and a **narrate** form — and wires the last three `CampaignEventType` values (`HIT`, `MISS`, `DM_NOTE`) through both renderers.

### Service
- `CampaignWebService.annotateRoll(guildId, dm, refEventId, kind, target?)` — validates `kind ∈ {HIT, MISS}`, active campaign, requester is the DM, referenced event exists, belongs to *this* campaign, and has `event_type = ROLL`. On success publishes `HIT` or `MISS` with `refEventId` pointing back to the roll.
- `CampaignWebService.narrate(guildId, dm, body)` — validates non-empty body ≤ `MAX_NARRATE_BODY_LENGTH` (1000) and DM role. Publishes `DM_NOTE` with `{body}`.

### Controller
- `POST /dnd/campaign/{guildId}/events/{eventId}/annotate` (form: `kind`, optional `target`)
- `POST /dnd/campaign/{guildId}/narrate` (form: `body`)

Both redirect to the detail page with per-result flash errors.

### Template
- Every ROLL row now carries `data-event-id` / `data-event-type` and, when `isUserDm`, renders inline **Hit / Miss** forms.
- New DM-only **narrate** form under the session log.
- `#session-log` exposes `data-is-dm` so JS knows whether to paint DM controls on freshly-streamed rows.
- `th:switch` gains server-side cases for `HIT`, `MISS`, `DM_NOTE`.

### Client
- `sessionLog.js`: `buildDmActions()` injects Hit/Miss buttons on newly-arrived ROLL rows when `isUserDm`. Buttons POST via a synthesised form, matching the non-JS fallback, so the resulting event flows through SSE to every viewer.

### Tests
- `CampaignWebServiceTest` — 8 `annotateRoll` branches (invalid kind, no active campaign, not DM, not found, wrong campaign, wrong event type, HIT with target, MISS with blank target collapsed to empty payload) + 4 `narrate` branches.
- `CampaignControllerTest` — 5 annotate + 4 narrate cases covering redirects, flash errors, and the missing-auth path.

## Test plan

- [ ] `./gradlew build` passes
- [ ] Manual: in Discord, `/roll`. On the web page as the DM, click Hit → row appears in feed for every viewer, `refEventId` set.
- [ ] Manual: as a non-DM, no Hit/Miss buttons or narrate form visible.
- [ ] Manual: type into narrate → appears in feed as a DM_NOTE with the body.
- [ ] Manual: try to annotate a non-ROLL event id via curl → flash error "You can only mark Hit/Miss on a roll."
- [ ] Qodana: remaining `Unused symbol` count for the event enum drops to 0; the series-wide follow-up is done.

## The whole session log feature

- **PR A (#233)** — event backbone + roll capture
- **PR B (#234)** — live SSE broadcaster + EventSource client
- **PR C (#235)** — initiative + roster producers + typed renderers
- **PR D (this)** — DM Hit/Miss + narrate

https://claude.ai/code/session_01DgKBYeiGaxmLg5xaPasU4r