### PR TITLE
feat(dnd): web initiative composer + monster templates + turn table (PR 1 of 2)

### DIFF
--- a/application/src/test/kotlin/web/controller/CampaignControllerTest.kt
+++ b/application/src/test/kotlin/web/controller/CampaignControllerTest.kt
@@ -16,17 +16,23 @@ import org.springframework.security.oauth2.core.user.OAuth2User
 import org.springframework.ui.Model
 import org.springframework.web.servlet.mvc.support.RedirectAttributes
 import web.service.AddNoteResult
+import web.service.AdhocMonster
 import web.service.AnnotateRollResult
 import web.service.CampaignDetail
 import web.service.CampaignEventBroadcaster
 import web.service.CampaignWebService
 import web.service.DeleteNoteResult
+import web.service.DeleteTemplateResult
 import web.service.EndResult
 import web.service.GuildCampaignInfo
+import web.service.InitiativeRollRequest
 import web.service.JoinResult
 import web.service.KickResult
 import web.service.LeaveResult
+import web.service.MonsterTemplateView
 import web.service.NarrateResult
+import web.service.RollInitiativeResult
+import web.service.SaveTemplateResult
 import web.service.SessionEventView
 import web.service.SetAliveResult
 import web.service.SetCharacterResult
@@ -673,5 +679,162 @@ class CampaignControllerTest {
         val view = controller.narrate(guildId, "beat", mockUser, mockRa)
 
         assertEquals("redirect:/dnd/campaign", view)
+    }
+
+    // monster templates
+
+    @Test
+    fun `listMonsterTemplates delegates to service`() {
+        val templates = listOf(MonsterTemplateView(1L, "Goblin", 2, 7, 15))
+        every { campaignWebService.listTemplatesForDm(1L) } returns templates
+
+        val result = controller.listMonsterTemplates(mockUser)
+
+        assertEquals(templates, result)
+    }
+
+    @Test
+    fun `listMonsterTemplates returns empty when user id missing`() {
+        every { mockUser.getAttribute<String>("id") } returns null
+
+        val result = controller.listMonsterTemplates(mockUser)
+
+        assertEquals(emptyList<MonsterTemplateView>(), result)
+    }
+
+    @Test
+    fun `saveMonsterTemplate redirects on success`() {
+        every {
+            campaignWebService.saveTemplate(1L, null, "Goblin", 2, 7, 15)
+        } returns SaveTemplateResult.SAVED
+
+        val view = controller.saveMonsterTemplate(guildId, null, "Goblin", 2, 7, 15, mockUser, mockRa)
+
+        assertEquals("redirect:/dnd/campaign/$guildId", view)
+        verify(exactly = 0) { mockRa.addFlashAttribute(any<String>(), any()) }
+    }
+
+    @Test
+    fun `saveMonsterTemplate sets error when name blank`() {
+        every {
+            campaignWebService.saveTemplate(1L, null, "", 0, null, null)
+        } returns SaveTemplateResult.NAME_BLANK
+
+        controller.saveMonsterTemplate(guildId, null, "", 0, null, null, mockUser, mockRa)
+
+        verify { mockRa.addFlashAttribute("error", "Monster name can't be empty.") }
+    }
+
+    @Test
+    fun `saveMonsterTemplate sets error when not owner`() {
+        every {
+            campaignWebService.saveTemplate(1L, 99L, "X", 0, null, null)
+        } returns SaveTemplateResult.NOT_OWNER
+
+        controller.saveMonsterTemplate(guildId, 99L, "X", 0, null, null, mockUser, mockRa)
+
+        verify { mockRa.addFlashAttribute("error", "You can only edit your own templates.") }
+    }
+
+    @Test
+    fun `deleteMonsterTemplate redirects on success`() {
+        every { campaignWebService.deleteTemplate(1L, 99L) } returns DeleteTemplateResult.DELETED
+
+        val view = controller.deleteMonsterTemplate(guildId, 99L, mockUser, mockRa)
+
+        assertEquals("redirect:/dnd/campaign/$guildId", view)
+    }
+
+    @Test
+    fun `deleteMonsterTemplate sets error when not owner`() {
+        every { campaignWebService.deleteTemplate(1L, 99L) } returns DeleteTemplateResult.NOT_OWNER
+
+        controller.deleteMonsterTemplate(guildId, 99L, mockUser, mockRa)
+
+        verify { mockRa.addFlashAttribute("error", "You can only delete your own templates.") }
+    }
+
+    // rollInitiative
+
+    @Test
+    fun `rollInitiative redirects on success`() {
+        every {
+            campaignWebService.rollInitiative(guildId, 1L, match { it.playerDiscordIds == listOf(7L) })
+        } returns RollInitiativeResult.ROLLED
+
+        val view = controller.rollInitiative(
+            guildId,
+            playerDiscordIds = listOf(7L),
+            templateIds = null,
+            adhocNames = null,
+            adhocMods = null,
+            user = mockUser,
+            ra = mockRa
+        )
+
+        assertEquals("redirect:/dnd/campaign/$guildId", view)
+        verify(exactly = 0) { mockRa.addFlashAttribute(any<String>(), any()) }
+    }
+
+    @Test
+    fun `rollInitiative builds adhoc monsters from parallel arrays`() {
+        every {
+            campaignWebService.rollInitiative(
+                guildId,
+                1L,
+                match<InitiativeRollRequest> { req ->
+                    req.adhocMonsters == listOf(
+                        AdhocMonster("Bugbear", 1),
+                        AdhocMonster("Kobold", 2)
+                    )
+                }
+            )
+        } returns RollInitiativeResult.ROLLED
+
+        controller.rollInitiative(
+            guildId,
+            playerDiscordIds = null,
+            templateIds = null,
+            adhocNames = listOf("Bugbear", "", "Kobold"),
+            adhocMods = listOf(1, 0, 2),
+            user = mockUser,
+            ra = mockRa
+        )
+        // Assertion is implicit in the match{} matcher above.
+    }
+
+    @Test
+    fun `rollInitiative sets error when not DM`() {
+        every {
+            campaignWebService.rollInitiative(guildId, 1L, any())
+        } returns RollInitiativeResult.NOT_DM
+
+        controller.rollInitiative(guildId, listOf(7L), null, null, null, mockUser, mockRa)
+
+        verify { mockRa.addFlashAttribute("error", "Only the Dungeon Master can roll initiative here.") }
+    }
+
+    @Test
+    fun `rollInitiative sets error when roster empty`() {
+        every {
+            campaignWebService.rollInitiative(guildId, 1L, any())
+        } returns RollInitiativeResult.EMPTY_ROSTER
+
+        controller.rollInitiative(guildId, null, null, null, null, mockUser, mockRa)
+
+        verify { mockRa.addFlashAttribute("error", "Pick at least one player or monster before rolling.") }
+    }
+
+    @Test
+    fun `rollInitiative sets error when template missing`() {
+        every {
+            campaignWebService.rollInitiative(guildId, 1L, any())
+        } returns RollInitiativeResult.TEMPLATE_NOT_FOUND
+
+        controller.rollInitiative(guildId, null, listOf(77L), null, null, mockUser, mockRa)
+
+        verify {
+            mockRa.addFlashAttribute("error", "One of the selected monster templates couldn't be found.")
+        }
     }
 }

--- a/application/src/test/kotlin/web/controller/CampaignControllerTest.kt
+++ b/application/src/test/kotlin/web/controller/CampaignControllerTest.kt
@@ -766,6 +766,7 @@ class CampaignControllerTest {
             guildId,
             playerDiscordIds = listOf(7L),
             templateIds = null,
+            templateQtys = null,
             adhocNames = null,
             adhocMods = null,
             user = mockUser,
@@ -795,12 +796,36 @@ class CampaignControllerTest {
             guildId,
             playerDiscordIds = null,
             templateIds = null,
+            templateQtys = null,
             adhocNames = listOf("Bugbear", "", "Kobold"),
             adhocMods = listOf(1, 0, 2),
             user = mockUser,
             ra = mockRa
         )
-        // Assertion is implicit in the match{} matcher above.
+    }
+
+    @Test
+    fun `rollInitiative expands templateId and templateQty into repeated template ids`() {
+        every {
+            campaignWebService.rollInitiative(
+                guildId,
+                1L,
+                match<InitiativeRollRequest> { req ->
+                    req.templateIds == listOf(10L, 10L, 20L)
+                }
+            )
+        } returns RollInitiativeResult.ROLLED
+
+        controller.rollInitiative(
+            guildId,
+            playerDiscordIds = null,
+            templateIds = listOf(10L, 20L, 30L),
+            templateQtys = listOf(2, 1, 0),
+            adhocNames = null,
+            adhocMods = null,
+            user = mockUser,
+            ra = mockRa
+        )
     }
 
     @Test
@@ -809,7 +834,7 @@ class CampaignControllerTest {
             campaignWebService.rollInitiative(guildId, 1L, any())
         } returns RollInitiativeResult.NOT_DM
 
-        controller.rollInitiative(guildId, listOf(7L), null, null, null, mockUser, mockRa)
+        controller.rollInitiative(guildId, listOf(7L), null, null, null, null, mockUser, mockRa)
 
         verify { mockRa.addFlashAttribute("error", "Only the Dungeon Master can roll initiative here.") }
     }
@@ -820,7 +845,7 @@ class CampaignControllerTest {
             campaignWebService.rollInitiative(guildId, 1L, any())
         } returns RollInitiativeResult.EMPTY_ROSTER
 
-        controller.rollInitiative(guildId, null, null, null, null, mockUser, mockRa)
+        controller.rollInitiative(guildId, null, null, null, null, null, mockUser, mockRa)
 
         verify { mockRa.addFlashAttribute("error", "Pick at least one player or monster before rolling.") }
     }
@@ -831,7 +856,7 @@ class CampaignControllerTest {
             campaignWebService.rollInitiative(guildId, 1L, any())
         } returns RollInitiativeResult.TEMPLATE_NOT_FOUND
 
-        controller.rollInitiative(guildId, null, listOf(77L), null, null, mockUser, mockRa)
+        controller.rollInitiative(guildId, null, listOf(77L), listOf(1), null, null, mockUser, mockRa)
 
         verify {
             mockRa.addFlashAttribute("error", "One of the selected monster templates couldn't be found.")

--- a/application/src/test/kotlin/web/service/CampaignWebServiceTest.kt
+++ b/application/src/test/kotlin/web/service/CampaignWebServiceTest.kt
@@ -10,6 +10,7 @@ import database.service.CampaignEventService
 import database.service.CampaignPlayerService
 import database.service.CampaignService
 import database.service.CharacterSheetService
+import database.service.MonsterTemplateService
 import database.service.SessionNoteService
 import database.service.UserService
 import java.time.LocalDateTime
@@ -34,6 +35,8 @@ class CampaignWebServiceTest {
     private lateinit var characterSheetService: CharacterSheetService
     private lateinit var sessionNoteService: SessionNoteService
     private lateinit var campaignEventService: CampaignEventService
+    private lateinit var monsterTemplateService: MonsterTemplateService
+    private lateinit var initiativeStore: InitiativeStore
     private lateinit var sessionLog: SessionLogPublisher
     private lateinit var jda: JDA
     private lateinit var service: CampaignWebService
@@ -59,6 +62,8 @@ class CampaignWebServiceTest {
         characterSheetService = mockk(relaxed = true)
         sessionNoteService = mockk(relaxed = true)
         campaignEventService = mockk(relaxed = true)
+        monsterTemplateService = mockk(relaxed = true)
+        initiativeStore = mockk(relaxed = true)
         sessionLog = mockk(relaxed = true)
         jda = mockk(relaxed = true)
         service = CampaignWebService(
@@ -69,6 +74,8 @@ class CampaignWebServiceTest {
             characterSheetService,
             sessionNoteService,
             campaignEventService,
+            monsterTemplateService,
+            initiativeStore,
             sessionLog,
             jda
         )
@@ -925,6 +932,168 @@ class CampaignWebServiceTest {
                 actorDiscordId = dmDiscordId,
                 actorName = any(),
                 payload = match { it["body"] == "A dragon lands." },
+                refEventId = null
+            )
+        }
+    }
+
+    // saveTemplate / deleteTemplate
+
+    @Test
+    fun `saveTemplate rejects blank name`() {
+        assertEquals(
+            SaveTemplateResult.NAME_BLANK,
+            service.saveTemplate(dmDiscordId, id = null, name = "   ", initiativeModifier = 0, maxHp = null, ac = null)
+        )
+    }
+
+    @Test
+    fun `saveTemplate rejects name past length cap`() {
+        val long = "x".repeat(CampaignWebService.MAX_TEMPLATE_NAME_LENGTH + 1)
+        assertEquals(
+            SaveTemplateResult.NAME_TOO_LONG,
+            service.saveTemplate(dmDiscordId, id = null, name = long, initiativeModifier = 0, maxHp = null, ac = null)
+        )
+    }
+
+    @Test
+    fun `saveTemplate creates when id is null`() {
+        assertEquals(
+            SaveTemplateResult.SAVED,
+            service.saveTemplate(dmDiscordId, id = null, name = "Goblin", initiativeModifier = 2, maxHp = 7, ac = 15)
+        )
+        verify {
+            monsterTemplateService.save(match {
+                it.id == 0L && it.dmDiscordId == dmDiscordId && it.name == "Goblin" &&
+                    it.initiativeModifier == 2 && it.maxHp == 7 && it.ac == 15
+            })
+        }
+    }
+
+    @Test
+    fun `saveTemplate returns NOT_FOUND when id doesn't exist`() {
+        every { monsterTemplateService.getById(99L) } returns null
+        assertEquals(
+            SaveTemplateResult.NOT_FOUND,
+            service.saveTemplate(dmDiscordId, id = 99L, name = "X", initiativeModifier = 0, maxHp = null, ac = null)
+        )
+    }
+
+    @Test
+    fun `saveTemplate returns NOT_OWNER when template belongs to another DM`() {
+        every { monsterTemplateService.getById(99L) } returns MonsterTemplateDto(
+            id = 99L, dmDiscordId = 999L, name = "Stolen"
+        )
+        assertEquals(
+            SaveTemplateResult.NOT_OWNER,
+            service.saveTemplate(dmDiscordId, id = 99L, name = "X", initiativeModifier = 0, maxHp = null, ac = null)
+        )
+    }
+
+    @Test
+    fun `deleteTemplate returns NOT_FOUND when missing`() {
+        every { monsterTemplateService.getById(99L) } returns null
+        assertEquals(DeleteTemplateResult.NOT_FOUND, service.deleteTemplate(dmDiscordId, 99L))
+    }
+
+    @Test
+    fun `deleteTemplate returns NOT_OWNER when template belongs to another DM`() {
+        every { monsterTemplateService.getById(99L) } returns MonsterTemplateDto(
+            id = 99L, dmDiscordId = 999L, name = "Stolen"
+        )
+        assertEquals(DeleteTemplateResult.NOT_OWNER, service.deleteTemplate(dmDiscordId, 99L))
+        verify(exactly = 0) { monsterTemplateService.deleteById(any()) }
+    }
+
+    @Test
+    fun `deleteTemplate removes when caller owns it`() {
+        every { monsterTemplateService.getById(99L) } returns MonsterTemplateDto(
+            id = 99L, dmDiscordId = dmDiscordId, name = "Mine"
+        )
+        assertEquals(DeleteTemplateResult.DELETED, service.deleteTemplate(dmDiscordId, 99L))
+        verify { monsterTemplateService.deleteById(99L) }
+    }
+
+    // rollInitiative
+
+    @Test
+    fun `rollInitiative returns NO_ACTIVE_CAMPAIGN when none exists`() {
+        every { campaignService.getActiveCampaignForGuild(guildId) } returns null
+        assertEquals(
+            RollInitiativeResult.NO_ACTIVE_CAMPAIGN,
+            service.rollInitiative(guildId, dmDiscordId, InitiativeRollRequest(playerDiscordIds = listOf(1L)))
+        )
+    }
+
+    @Test
+    fun `rollInitiative returns NOT_DM when caller is not the DM`() {
+        every { campaignService.getActiveCampaignForGuild(guildId) } returns makeCampaign()
+        assertEquals(
+            RollInitiativeResult.NOT_DM,
+            service.rollInitiative(guildId, playerDiscordId, InitiativeRollRequest(playerDiscordIds = listOf(1L)))
+        )
+    }
+
+    @Test
+    fun `rollInitiative returns EMPTY_ROSTER when nobody is picked`() {
+        every { campaignService.getActiveCampaignForGuild(guildId) } returns makeCampaign()
+        assertEquals(
+            RollInitiativeResult.EMPTY_ROSTER,
+            service.rollInitiative(guildId, dmDiscordId, InitiativeRollRequest())
+        )
+    }
+
+    @Test
+    fun `rollInitiative returns TEMPLATE_NOT_FOUND for missing template`() {
+        every { campaignService.getActiveCampaignForGuild(guildId) } returns makeCampaign()
+        every { monsterTemplateService.getById(77L) } returns null
+        assertEquals(
+            RollInitiativeResult.TEMPLATE_NOT_FOUND,
+            service.rollInitiative(guildId, dmDiscordId, InitiativeRollRequest(templateIds = listOf(77L)))
+        )
+    }
+
+    @Test
+    fun `rollInitiative returns TEMPLATE_NOT_FOUND when template belongs to another DM`() {
+        every { campaignService.getActiveCampaignForGuild(guildId) } returns makeCampaign()
+        every { monsterTemplateService.getById(77L) } returns MonsterTemplateDto(
+            id = 77L, dmDiscordId = 999L, name = "Someone Else's Wolf"
+        )
+        assertEquals(
+            RollInitiativeResult.TEMPLATE_NOT_FOUND,
+            service.rollInitiative(guildId, dmDiscordId, InitiativeRollRequest(templateIds = listOf(77L)))
+        )
+    }
+
+    @Test
+    fun `rollInitiative seeds store and publishes INITIATIVE_ROLLED`() {
+        every { campaignService.getActiveCampaignForGuild(guildId) } returns makeCampaign()
+        every { userService.getUserById(playerDiscordId, guildId) } returns UserDto(playerDiscordId, guildId).apply {
+            initiativeModifier = 3
+        }
+        every { monsterTemplateService.getById(77L) } returns MonsterTemplateDto(
+            id = 77L, dmDiscordId = dmDiscordId, name = "Goblin", initiativeModifier = 2
+        )
+
+        val result = service.rollInitiative(
+            guildId,
+            dmDiscordId,
+            InitiativeRollRequest(
+                playerDiscordIds = listOf(playerDiscordId),
+                templateIds = listOf(77L),
+                adhocMonsters = listOf(AdhocMonster("Bugbear", 1))
+            )
+        )
+
+        assertEquals(RollInitiativeResult.ROLLED, result)
+        verify { initiativeStore.seed(eq(guildId), match { it.size == 3 }) }
+        verify {
+            sessionLog.publish(
+                guildId = guildId,
+                type = common.events.CampaignEventType.INITIATIVE_ROLLED,
+                actorDiscordId = dmDiscordId,
+                actorName = any(),
+                payload = match { (it["entries"] as? List<*>)?.size == 3 },
                 refEventId = null
             )
         }

--- a/application/src/test/kotlin/web/service/CampaignWebServiceTest.kt
+++ b/application/src/test/kotlin/web/service/CampaignWebServiceTest.kt
@@ -1099,4 +1099,60 @@ class CampaignWebServiceTest {
             )
         }
     }
+
+    @Test
+    fun `rollInitiative suffixes duplicate names with hash-index`() {
+        every { campaignService.getActiveCampaignForGuild(guildId) } returns makeCampaign()
+        every { monsterTemplateService.getById(77L) } returns MonsterTemplateDto(
+            id = 77L, dmDiscordId = dmDiscordId, name = "Goblin", initiativeModifier = 2
+        )
+
+        service.rollInitiative(
+            guildId,
+            dmDiscordId,
+            InitiativeRollRequest(
+                templateIds = listOf(77L, 77L),
+                adhocMonsters = listOf(
+                    AdhocMonster("Goblin", 2),
+                    AdhocMonster("Kobold", 1)
+                )
+            )
+        )
+
+        verify {
+            initiativeStore.seed(
+                eq(guildId),
+                match { seeded ->
+                    val names = seeded.map { it.name }.sorted()
+                    names == listOf("Goblin #1", "Goblin #2", "Goblin #3", "Kobold")
+                }
+            )
+        }
+    }
+
+    @Test
+    fun `rollInitiative leaves unique names untouched`() {
+        every { campaignService.getActiveCampaignForGuild(guildId) } returns makeCampaign()
+        every { monsterTemplateService.getById(77L) } returns MonsterTemplateDto(
+            id = 77L, dmDiscordId = dmDiscordId, name = "Goblin", initiativeModifier = 2
+        )
+
+        service.rollInitiative(
+            guildId,
+            dmDiscordId,
+            InitiativeRollRequest(
+                templateIds = listOf(77L),
+                adhocMonsters = listOf(AdhocMonster("Bugbear", 1))
+            )
+        )
+
+        verify {
+            initiativeStore.seed(
+                eq(guildId),
+                match { seeded ->
+                    seeded.map { it.name }.toSet() == setOf("Goblin", "Bugbear")
+                }
+            )
+        }
+    }
 }

--- a/application/src/test/kotlin/web/service/CampaignWebServiceTest.kt
+++ b/application/src/test/kotlin/web/service/CampaignWebServiceTest.kt
@@ -4,6 +4,7 @@ import database.dto.CampaignDto
 import database.dto.CampaignEventDto
 import database.dto.CampaignPlayerDto
 import database.dto.CampaignPlayerId
+import database.dto.MonsterTemplateDto
 import database.dto.SessionNoteDto
 import database.dto.UserDto
 import database.service.CampaignEventService

--- a/database/src/main/kotlin/database/dto/MonsterTemplateDto.kt
+++ b/database/src/main/kotlin/database/dto/MonsterTemplateDto.kt
@@ -1,0 +1,53 @@
+package database.dto
+
+import jakarta.persistence.*
+import java.io.Serializable
+import java.time.LocalDateTime
+
+@NamedQueries(
+    NamedQuery(
+        name = "MonsterTemplateDto.getByDm",
+        query = "select t from MonsterTemplateDto t where t.dmDiscordId = :dmDiscordId order by t.name asc"
+    ),
+    NamedQuery(
+        name = "MonsterTemplateDto.getById",
+        query = "select t from MonsterTemplateDto t where t.id = :id"
+    ),
+    NamedQuery(
+        name = "MonsterTemplateDto.deleteById",
+        query = "delete from MonsterTemplateDto t where t.id = :id"
+    )
+)
+@Entity
+@Table(name = "dnd_monster_template", schema = "public")
+class MonsterTemplateDto(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    var id: Long = 0,
+
+    @Column(name = "dm_discord_id", nullable = false)
+    var dmDiscordId: Long = 0,
+
+    @Column(name = "name", nullable = false, length = 100)
+    var name: String = "",
+
+    @Column(name = "initiative_modifier", nullable = false)
+    var initiativeModifier: Int = 0,
+
+    @Column(name = "max_hp")
+    var maxHp: Int? = null,
+
+    @Column(name = "ac")
+    var ac: Int? = null,
+
+    @Column(name = "created_at", nullable = false)
+    var createdAt: LocalDateTime = LocalDateTime.now(),
+
+    @Column(name = "updated_at", nullable = false)
+    var updatedAt: LocalDateTime = LocalDateTime.now()
+) : Serializable {
+
+    override fun toString(): String =
+        "MonsterTemplateDto(id=$id, dmDiscordId=$dmDiscordId, name=$name, initiativeModifier=$initiativeModifier)"
+}

--- a/database/src/main/kotlin/database/persistence/MonsterTemplatePersistence.kt
+++ b/database/src/main/kotlin/database/persistence/MonsterTemplatePersistence.kt
@@ -1,0 +1,10 @@
+package database.persistence
+
+import database.dto.MonsterTemplateDto
+
+interface MonsterTemplatePersistence {
+    fun save(template: MonsterTemplateDto): MonsterTemplateDto
+    fun getById(id: Long): MonsterTemplateDto?
+    fun listByDm(dmDiscordId: Long): List<MonsterTemplateDto>
+    fun deleteById(id: Long)
+}

--- a/database/src/main/kotlin/database/persistence/impl/DefaultMonsterTemplatePersistence.kt
+++ b/database/src/main/kotlin/database/persistence/impl/DefaultMonsterTemplatePersistence.kt
@@ -1,0 +1,50 @@
+package database.persistence.impl
+
+import database.dto.MonsterTemplateDto
+import database.persistence.MonsterTemplatePersistence
+import jakarta.persistence.EntityManager
+import jakarta.persistence.PersistenceContext
+import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+
+@Repository
+@Transactional
+class DefaultMonsterTemplatePersistence : MonsterTemplatePersistence {
+
+    @PersistenceContext
+    private lateinit var entityManager: EntityManager
+
+    override fun save(template: MonsterTemplateDto): MonsterTemplateDto {
+        val now = LocalDateTime.now()
+        template.updatedAt = now
+        return if (template.id == 0L) {
+            template.createdAt = now
+            entityManager.persist(template)
+            entityManager.flush()
+            template
+        } else {
+            val merged = entityManager.merge(template)
+            entityManager.flush()
+            merged
+        }
+    }
+
+    override fun getById(id: Long): MonsterTemplateDto? {
+        val q = entityManager.createNamedQuery("MonsterTemplateDto.getById", MonsterTemplateDto::class.java)
+        q.setParameter("id", id)
+        return runCatching { q.singleResult }.getOrNull()
+    }
+
+    override fun listByDm(dmDiscordId: Long): List<MonsterTemplateDto> {
+        val q = entityManager.createNamedQuery("MonsterTemplateDto.getByDm", MonsterTemplateDto::class.java)
+        q.setParameter("dmDiscordId", dmDiscordId)
+        return q.resultList
+    }
+
+    override fun deleteById(id: Long) {
+        val q = entityManager.createNamedQuery("MonsterTemplateDto.deleteById")
+        q.setParameter("id", id)
+        q.executeUpdate()
+    }
+}

--- a/database/src/main/kotlin/database/service/MonsterTemplateService.kt
+++ b/database/src/main/kotlin/database/service/MonsterTemplateService.kt
@@ -1,0 +1,10 @@
+package database.service
+
+import database.dto.MonsterTemplateDto
+
+interface MonsterTemplateService {
+    fun save(template: MonsterTemplateDto): MonsterTemplateDto
+    fun getById(id: Long): MonsterTemplateDto?
+    fun listByDm(dmDiscordId: Long): List<MonsterTemplateDto>
+    fun deleteById(id: Long)
+}

--- a/database/src/main/kotlin/database/service/impl/DefaultMonsterTemplateService.kt
+++ b/database/src/main/kotlin/database/service/impl/DefaultMonsterTemplateService.kt
@@ -1,0 +1,26 @@
+package database.service.impl
+
+import database.dto.MonsterTemplateDto
+import database.persistence.MonsterTemplatePersistence
+import database.service.MonsterTemplateService
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional
+class DefaultMonsterTemplateService(
+    private val monsterTemplatePersistence: MonsterTemplatePersistence
+) : MonsterTemplateService {
+
+    override fun save(template: MonsterTemplateDto): MonsterTemplateDto =
+        monsterTemplatePersistence.save(template)
+
+    override fun getById(id: Long): MonsterTemplateDto? =
+        monsterTemplatePersistence.getById(id)
+
+    override fun listByDm(dmDiscordId: Long): List<MonsterTemplateDto> =
+        monsterTemplatePersistence.listByDm(dmDiscordId)
+
+    override fun deleteById(id: Long) =
+        monsterTemplatePersistence.deleteById(id)
+}

--- a/database/src/main/resources/db/migration/V6__dnd_monster_template.sql
+++ b/database/src/main/resources/db/migration/V6__dnd_monster_template.sql
@@ -1,0 +1,16 @@
+-- Saved monster templates a DM can reuse when composing initiative. Scoped to the
+-- DM's Discord id so a single library follows them across every guild / campaign
+-- they run. HP and AC are optional so minimal templates are just (name, modifier).
+CREATE TABLE IF NOT EXISTS dnd_monster_template (
+    id BIGSERIAL PRIMARY KEY,
+    dm_discord_id BIGINT NOT NULL,
+    name VARCHAR(100) NOT NULL,
+    initiative_modifier INT NOT NULL DEFAULT 0,
+    max_hp INT,
+    ac INT,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_dnd_monster_template_dm
+    ON dnd_monster_template(dm_discord_id);

--- a/discord-bot/src/main/kotlin/bot/toby/button/buttons/InitiativeNextButton.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/button/buttons/InitiativeNextButton.kt
@@ -32,7 +32,7 @@ class InitiativeNextButton @Autowired constructor(
             actorDiscordId = event.user.idLong,
             actorName = event.member?.effectiveName ?: event.user.effectiveName,
             payload = mapOf(
-                "currentName" to current?.key,
+                "currentName" to current?.name,
                 "currentIndex" to state.initiativeIndex.get()
             )
         )

--- a/discord-bot/src/main/kotlin/bot/toby/button/buttons/InitiativePreviousButton.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/button/buttons/InitiativePreviousButton.kt
@@ -32,7 +32,7 @@ class InitiativePreviousButton @Autowired constructor(
             actorDiscordId = event.user.idLong,
             actorName = event.member?.effectiveName ?: event.user.effectiveName,
             payload = mapOf(
-                "currentName" to current?.key,
+                "currentName" to current?.name,
                 "currentIndex" to state.initiativeIndex.get()
             )
         )

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/dnd/InitiativeCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/dnd/InitiativeCommand.kt
@@ -54,7 +54,7 @@ class InitiativeCommand @Autowired constructor(
         displayAllValues(guildId, event.hook, deleteDelay)
 
         val entries = dndHelper.stateFor(guildId).sortedEntries
-            .map { mapOf("name" to it.key, "roll" to it.value) }
+            .map { mapOf("name" to it.name, "roll" to it.roll) }
         sessionLog.publish(
             guildId = guildId,
             type = CampaignEventType.INITIATIVE_ROLLED,

--- a/discord-bot/src/main/kotlin/bot/toby/helpers/DnDHelper.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/helpers/DnDHelper.kt
@@ -42,6 +42,17 @@ class DnDHelper(private val userDtoHelper: UserDtoHelper) {
         stateFor(guildId).restoreFrom(snapshot)
     }
 
+    /**
+     * Seed the per-guild initiative tracker with a pre-rolled, pre-sorted roster
+     * (players + monsters). Used by the web-side initiative composer; Discord's
+     * voice-channel / name-list paths continue through [rollInitiativeForMembers]
+     * and [rollInitiativeForString].
+     */
+    fun seedInitiative(guildId: Long, entries: List<RolledEntry>) {
+        val sorted = entries.sortedByDescending { it.roll }
+        stateFor(guildId).seedFromSorted(sorted)
+    }
+
     fun rollInitiativeForMembers(
         guildId: Long,
         memberList: List<Member>,
@@ -106,7 +117,7 @@ class DnDHelper(private val userDtoHelper: UserDtoHelper) {
                 .setComponents(ActionRow.of(initButtons.prev, initButtons.clear, initButtons.next))
                 .queue()
             hook.setEphemeral(true)
-                .sendMessage("Next turn: ${state.sortedEntries[state.initiativeIndex.get()].key}")
+                .sendMessage("Next turn: ${state.sortedEntries[state.initiativeIndex.get()].name}")
                 .queue(core.command.Command.invokeDeleteOnMessageResponse(deleteDelay))
         }
     }

--- a/discord-bot/src/main/kotlin/bot/toby/helpers/DndHelperInitiativeStore.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/helpers/DndHelperInitiativeStore.kt
@@ -1,0 +1,34 @@
+package bot.toby.helpers
+
+import org.springframework.stereotype.Service
+import web.service.InitiativeEntryData
+import web.service.InitiativeStore
+
+/**
+ * Default [InitiativeStore] implementation that proxies to [DnDHelper]. Lets
+ * the web module seed and read the per-guild initiative tracker without taking
+ * a compile-time dependency on discord-bot's Discord types.
+ */
+@Service
+class DndHelperInitiativeStore(
+    private val dndHelper: DnDHelper
+) : InitiativeStore {
+
+    override fun seed(guildId: Long, entries: List<InitiativeEntryData>) {
+        dndHelper.seedInitiative(
+            guildId,
+            entries.map { RolledEntry(name = it.name, roll = it.roll, kind = it.kind) }
+        )
+    }
+
+    override fun currentEntries(guildId: Long): List<InitiativeEntryData> =
+        dndHelper.stateFor(guildId).sortedEntries.map {
+            InitiativeEntryData(name = it.name, roll = it.roll, kind = it.kind)
+        }
+
+    override fun currentIndex(guildId: Long): Int =
+        dndHelper.stateFor(guildId).initiativeIndex.get()
+
+    override fun isActive(guildId: Long): Boolean =
+        dndHelper.stateFor(guildId).isActive()
+}

--- a/discord-bot/src/main/kotlin/bot/toby/helpers/InitiativeState.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/helpers/InitiativeState.kt
@@ -13,13 +13,30 @@ import java.util.concurrent.atomic.AtomicInteger
 class InitiativeState {
 
     val initiativeIndex: AtomicInteger = AtomicInteger(0)
-    var sortedEntries: LinkedList<Map.Entry<String, Int>> = LinkedList()
+    var sortedEntries: LinkedList<RolledEntry> = LinkedList()
         private set
 
     fun isActive(): Boolean = sortedEntries.isNotEmpty()
 
+    /**
+     * Rebuild the sorted list from a `name -> roll` map produced by Discord
+     * name-list / voice-channel rolls. Entries produced here carry no `kind`.
+     */
     internal fun sortMap(initiativeMap: Map<String, Int>) {
-        sortedEntries = LinkedList(initiativeMap.entries.sortedByDescending { it.value })
+        sortedEntries = LinkedList(
+            initiativeMap.entries
+                .sortedByDescending { it.value }
+                .map { RolledEntry(it.key, it.value, kind = null) }
+        )
+    }
+
+    /**
+     * Web-composer entry point: accept an already-sorted list of rolled entries
+     * (players + monsters). Overwrites the current order and resets the pointer.
+     */
+    internal fun seedFromSorted(entries: List<RolledEntry>) {
+        sortedEntries = LinkedList(entries)
+        initiativeIndex.set(0)
     }
 
     fun clear() {
@@ -47,7 +64,7 @@ class InitiativeState {
             embedBuilder.setColor(Color.GREEN)
             embedBuilder.setTitle("Initiative Order")
             val description = sortedEntries.withIndex().joinToString("\n") { (index, entry) ->
-                "${index + initiativeIndex.get() % sortedEntries.size}: ${entry.key}: ${entry.value}"
+                "${index + initiativeIndex.get() % sortedEntries.size}: ${entry.name}: ${entry.roll}"
             }
             embedBuilder.setDescription(description)
             return embedBuilder
@@ -55,14 +72,24 @@ class InitiativeState {
 
     fun snapshot(): InitiativeStateSnapshot = InitiativeStateSnapshot(
         initiativeIndex = initiativeIndex.get(),
-        entries = sortedEntries.map { InitiativeEntry(it.key, it.value) }
+        entries = sortedEntries.map { InitiativeEntry(it.name, it.roll, it.kind) }
     )
 
     fun restoreFrom(snapshot: InitiativeStateSnapshot) {
         initiativeIndex.set(snapshot.initiativeIndex)
-        sortedEntries = LinkedList(snapshot.entries.map { java.util.AbstractMap.SimpleEntry(it.name, it.roll) })
+        sortedEntries = LinkedList(snapshot.entries.map { RolledEntry(it.name, it.roll, it.kind) })
     }
 }
+
+/**
+ * A single rolled initiative entry. [kind] is `"PLAYER"` or `"MONSTER"` when set
+ * by the web composer; nullable so legacy Discord-originated rolls still work.
+ */
+data class RolledEntry(
+    val name: String = "",
+    val roll: Int = 0,
+    val kind: String? = null
+)
 
 /** JSON-friendly snapshot of an [InitiativeState], persisted in CampaignDto.state. */
 data class InitiativeStateSnapshot(
@@ -72,5 +99,6 @@ data class InitiativeStateSnapshot(
 
 data class InitiativeEntry(
     val name: String = "",
-    val roll: Int = 0
+    val roll: Int = 0,
+    val kind: String? = null
 )

--- a/discord-bot/src/test/kotlin/bot/toby/helpers/DnDHelperTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/helpers/DnDHelperTest.kt
@@ -283,6 +283,35 @@ internal class DnDHelperTest {
         Assertions.assertFalse(dndHelper.stateFor(otherGuild).isActive())
     }
 
+    @Test
+    fun testSeedInitiativeInstallsSortedEntries() {
+        dndHelper.seedInitiative(
+            guildId,
+            listOf(
+                RolledEntry("Alice", 12, "PLAYER"),
+                RolledEntry("Goblin", 19, "MONSTER"),
+                RolledEntry("Bob", 8, "PLAYER")
+            )
+        )
+        val state = dndHelper.stateFor(guildId)
+        Assertions.assertTrue(state.isActive())
+        Assertions.assertEquals(3, state.sortedEntries.size)
+        Assertions.assertEquals("Goblin", state.sortedEntries[0].name)
+        Assertions.assertEquals("MONSTER", state.sortedEntries[0].kind)
+        Assertions.assertEquals("Alice", state.sortedEntries[1].name)
+        Assertions.assertEquals("Bob", state.sortedEntries[2].name)
+        Assertions.assertEquals(0, state.initiativeIndex.get())
+    }
+
+    @Test
+    fun testSeedInitiativeReplacesPriorState() {
+        dndHelper.seedInitiative(guildId, listOf(RolledEntry("Old", 10)))
+        dndHelper.seedInitiative(guildId, listOf(RolledEntry("New", 15)))
+        val state = dndHelper.stateFor(guildId)
+        Assertions.assertEquals(1, state.sortedEntries.size)
+        Assertions.assertEquals("New", state.sortedEntries[0].name)
+    }
+
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun testDoInitialLookupWithSpell() = runTest {

--- a/web/src/main/kotlin/web/controller/CampaignController.kt
+++ b/web/src/main/kotlin/web/controller/CampaignController.kt
@@ -403,7 +403,8 @@ class CampaignController(
     fun rollInitiative(
         @PathVariable guildId: Long,
         @RequestParam(name = "playerDiscordIds", required = false) playerDiscordIds: List<Long>?,
-        @RequestParam(name = "templateIds", required = false) templateIds: List<Long>?,
+        @RequestParam(name = "templateId", required = false) templateIds: List<Long>?,
+        @RequestParam(name = "templateQty", required = false) templateQtys: List<Int>?,
         @RequestParam(name = "adhocName", required = false) adhocNames: List<String>?,
         @RequestParam(name = "adhocMod", required = false) adhocMods: List<Int>?,
         @AuthenticationPrincipal user: OAuth2User,
@@ -411,6 +412,13 @@ class CampaignController(
     ): String {
         val discordId = user.discordIdOrNull()
             ?: return "redirect:/dnd/campaign"
+
+        val tplIds = templateIds.orEmpty()
+        val tplQtys = templateQtys.orEmpty()
+        val expandedTemplateIds = tplIds.flatMapIndexed { i, id ->
+            val qty = tplQtys.getOrElse(i) { 1 }.coerceAtLeast(0)
+            List(qty) { id }
+        }
 
         val names = adhocNames.orEmpty()
         val mods = adhocMods.orEmpty()
@@ -421,7 +429,7 @@ class CampaignController(
         }
         val request = InitiativeRollRequest(
             playerDiscordIds = playerDiscordIds.orEmpty(),
-            templateIds = templateIds.orEmpty(),
+            templateIds = expandedTemplateIds,
             adhocMonsters = adhoc
         )
 

--- a/web/src/main/kotlin/web/controller/CampaignController.kt
+++ b/web/src/main/kotlin/web/controller/CampaignController.kt
@@ -10,15 +10,21 @@ import org.springframework.web.bind.annotation.*
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
 import org.springframework.web.servlet.mvc.support.RedirectAttributes
 import web.service.AddNoteResult
+import web.service.AdhocMonster
 import web.service.AnnotateRollResult
 import web.service.CampaignEventBroadcaster
 import web.service.CampaignWebService
 import web.service.DeleteNoteResult
+import web.service.DeleteTemplateResult
 import web.service.EndResult
+import web.service.InitiativeRollRequest
 import web.service.JoinResult
 import web.service.KickResult
 import web.service.LeaveResult
+import web.service.MonsterTemplateView
 import web.service.NarrateResult
+import web.service.RollInitiativeResult
+import web.service.SaveTemplateResult
 import web.service.SessionEventView
 import web.service.SetAliveResult
 import web.service.SetCharacterResult
@@ -74,6 +80,8 @@ class CampaignController(
         model.addAttribute("currentUserCharacterId", campaignDetail?.currentUserCharacterId)
         model.addAttribute("notes", campaignDetail?.notes ?: emptyList<Any>())
         model.addAttribute("recentEvents", campaignDetail?.recentEvents ?: emptyList<Any>())
+        model.addAttribute("initiativeState", campaignDetail?.initiativeState)
+        model.addAttribute("monsterLibrary", campaignDetail?.monsterLibrary ?: emptyList<Any>())
         model.addAttribute("username", user.displayName())
 
         return "campaignDetail"
@@ -332,6 +340,102 @@ class CampaignController(
             NarrateResult.BODY_TOO_LONG -> ra.addFlashAttribute(
                 "error",
                 "Narration is too long (max ${web.service.CampaignWebService.MAX_NARRATE_BODY_LENGTH} characters)."
+            )
+        }
+        return "redirect:/dnd/campaign/$guildId"
+    }
+
+    @GetMapping("/monsters/templates")
+    @ResponseBody
+    fun listMonsterTemplates(
+        @AuthenticationPrincipal user: OAuth2User
+    ): List<MonsterTemplateView> {
+        val discordId = user.discordIdOrNull() ?: return emptyList()
+        return campaignWebService.listTemplatesForDm(discordId)
+    }
+
+    @PostMapping("/campaign/{guildId}/monsters/templates")
+    fun saveMonsterTemplate(
+        @PathVariable guildId: Long,
+        @RequestParam(name = "id", required = false) id: Long?,
+        @RequestParam("name") name: String,
+        @RequestParam("initiativeModifier") initiativeModifier: Int,
+        @RequestParam(name = "maxHp", required = false) maxHp: Int?,
+        @RequestParam(name = "ac", required = false) ac: Int?,
+        @AuthenticationPrincipal user: OAuth2User,
+        ra: RedirectAttributes
+    ): String {
+        val discordId = user.discordIdOrNull()
+            ?: return "redirect:/dnd/campaign"
+
+        when (campaignWebService.saveTemplate(discordId, id, name, initiativeModifier, maxHp, ac)) {
+            SaveTemplateResult.SAVED -> {}
+            SaveTemplateResult.NAME_BLANK -> ra.addFlashAttribute("error", "Monster name can't be empty.")
+            SaveTemplateResult.NAME_TOO_LONG -> ra.addFlashAttribute(
+                "error",
+                "Monster name is too long (max ${web.service.CampaignWebService.MAX_TEMPLATE_NAME_LENGTH} characters)."
+            )
+            SaveTemplateResult.NOT_FOUND -> ra.addFlashAttribute("error", "That template doesn't exist.")
+            SaveTemplateResult.NOT_OWNER -> ra.addFlashAttribute("error", "You can only edit your own templates.")
+        }
+        return "redirect:/dnd/campaign/$guildId"
+    }
+
+    @PostMapping("/campaign/{guildId}/monsters/templates/{templateId}/delete")
+    fun deleteMonsterTemplate(
+        @PathVariable guildId: Long,
+        @PathVariable templateId: Long,
+        @AuthenticationPrincipal user: OAuth2User,
+        ra: RedirectAttributes
+    ): String {
+        val discordId = user.discordIdOrNull()
+            ?: return "redirect:/dnd/campaign"
+
+        when (campaignWebService.deleteTemplate(discordId, templateId)) {
+            DeleteTemplateResult.DELETED -> {}
+            DeleteTemplateResult.NOT_FOUND -> ra.addFlashAttribute("error", "That template doesn't exist.")
+            DeleteTemplateResult.NOT_OWNER -> ra.addFlashAttribute("error", "You can only delete your own templates.")
+        }
+        return "redirect:/dnd/campaign/$guildId"
+    }
+
+    @PostMapping("/campaign/{guildId}/initiative/roll")
+    fun rollInitiative(
+        @PathVariable guildId: Long,
+        @RequestParam(name = "playerDiscordIds", required = false) playerDiscordIds: List<Long>?,
+        @RequestParam(name = "templateIds", required = false) templateIds: List<Long>?,
+        @RequestParam(name = "adhocName", required = false) adhocNames: List<String>?,
+        @RequestParam(name = "adhocMod", required = false) adhocMods: List<Int>?,
+        @AuthenticationPrincipal user: OAuth2User,
+        ra: RedirectAttributes
+    ): String {
+        val discordId = user.discordIdOrNull()
+            ?: return "redirect:/dnd/campaign"
+
+        val names = adhocNames.orEmpty()
+        val mods = adhocMods.orEmpty()
+        val adhoc = names.mapIndexedNotNull { i, n ->
+            val cleaned = n.trim()
+            if (cleaned.isBlank()) null
+            else AdhocMonster(cleaned, mods.getOrElse(i) { 0 })
+        }
+        val request = InitiativeRollRequest(
+            playerDiscordIds = playerDiscordIds.orEmpty(),
+            templateIds = templateIds.orEmpty(),
+            adhocMonsters = adhoc
+        )
+
+        when (campaignWebService.rollInitiative(guildId, discordId, request)) {
+            RollInitiativeResult.ROLLED -> {}
+            RollInitiativeResult.NO_ACTIVE_CAMPAIGN -> ra.addFlashAttribute("error", "No active campaign in this server.")
+            RollInitiativeResult.NOT_DM -> ra.addFlashAttribute("error", "Only the Dungeon Master can roll initiative here.")
+            RollInitiativeResult.EMPTY_ROSTER -> ra.addFlashAttribute(
+                "error",
+                "Pick at least one player or monster before rolling."
+            )
+            RollInitiativeResult.TEMPLATE_NOT_FOUND -> ra.addFlashAttribute(
+                "error",
+                "One of the selected monster templates couldn't be found."
             )
         }
         return "redirect:/dnd/campaign/$guildId"

--- a/web/src/main/kotlin/web/service/CampaignWebService.kt
+++ b/web/src/main/kotlin/web/service/CampaignWebService.kt
@@ -7,17 +7,20 @@ import common.helpers.parseDndBeyondCharacterId
 import database.dto.CampaignDto
 import database.dto.CampaignPlayerDto
 import database.dto.CampaignPlayerId
+import database.dto.MonsterTemplateDto
 import database.dto.SessionNoteDto
 import database.dto.UserDto
 import database.service.CampaignEventService
 import database.service.CampaignPlayerService
 import database.service.CampaignService
 import database.service.CharacterSheetService
+import database.service.MonsterTemplateService
 import database.service.SessionNoteService
 import database.service.UserService
 import net.dv8tion.jda.api.JDA
 import org.springframework.stereotype.Service
 import java.time.LocalDateTime
+import kotlin.random.Random
 
 data class CampaignDetail(
     val campaign: CampaignDto,
@@ -26,10 +29,39 @@ data class CampaignDetail(
     val isCurrentUserPlayer: Boolean = false,
     val currentUserCharacterId: Long? = null,
     val notes: List<SessionNoteView> = emptyList(),
-    val recentEvents: List<SessionEventView> = emptyList()
+    val recentEvents: List<SessionEventView> = emptyList(),
+    val initiativeState: InitiativeStateView? = null,
+    val monsterLibrary: List<MonsterTemplateView> = emptyList()
 ) {
     fun isDm(discordId: Long): Boolean = campaign.dmDiscordId == discordId
 }
+
+data class InitiativeStateView(
+    val entries: List<RolledEntryView>,
+    val currentIndex: Int
+)
+
+data class RolledEntryView(
+    val name: String,
+    val roll: Int,
+    val kind: String?
+)
+
+data class MonsterTemplateView(
+    val id: Long,
+    val name: String,
+    val initiativeModifier: Int,
+    val maxHp: Int?,
+    val ac: Int?
+)
+
+data class AdhocMonster(val name: String, val initiativeModifier: Int)
+
+data class InitiativeRollRequest(
+    val playerDiscordIds: List<Long> = emptyList(),
+    val templateIds: List<Long> = emptyList(),
+    val adhocMonsters: List<AdhocMonster> = emptyList()
+)
 
 data class SessionNoteView(
     val id: Long,
@@ -84,6 +116,9 @@ enum class AddNoteResult { ADDED, NO_ACTIVE_CAMPAIGN, NOT_PARTICIPANT, EMPTY_BOD
 enum class DeleteNoteResult { DELETED, NO_ACTIVE_CAMPAIGN, NOT_FOUND, NOT_ALLOWED }
 enum class AnnotateRollResult { ANNOTATED, NO_ACTIVE_CAMPAIGN, NOT_DM, NOT_FOUND, NOT_A_ROLL, INVALID_KIND }
 enum class NarrateResult { NARRATED, NO_ACTIVE_CAMPAIGN, NOT_DM, EMPTY_BODY, BODY_TOO_LONG }
+enum class SaveTemplateResult { SAVED, NAME_BLANK, NAME_TOO_LONG, NOT_FOUND, NOT_OWNER }
+enum class DeleteTemplateResult { DELETED, NOT_FOUND, NOT_OWNER }
+enum class RollInitiativeResult { ROLLED, NO_ACTIVE_CAMPAIGN, NOT_DM, EMPTY_ROSTER, TEMPLATE_NOT_FOUND }
 
 @Service
 class CampaignWebService(
@@ -94,6 +129,8 @@ class CampaignWebService(
     private val characterSheetService: CharacterSheetService,
     private val sessionNoteService: SessionNoteService,
     private val campaignEventService: CampaignEventService,
+    private val monsterTemplateService: MonsterTemplateService,
+    private val initiativeStore: InitiativeStore,
     private val sessionLog: SessionLogPublisher,
     private val jda: JDA
 ) {
@@ -106,6 +143,7 @@ class CampaignWebService(
         const val MAX_NOTE_BODY_LENGTH = 2000
         const val MAX_NARRATE_BODY_LENGTH = 1000
         const val DEFAULT_EVENT_LIMIT = 100
+        const val MAX_TEMPLATE_NAME_LENGTH = 100
     }
 
     fun getMutualGuildsWithCampaigns(accessToken: String): List<GuildCampaignInfo> {
@@ -174,6 +212,19 @@ class CampaignWebService(
             .listRecent(campaign.id, DEFAULT_EVENT_LIMIT)
             .map(::toSessionEventView)
 
+        val initiativeState = if (initiativeStore.isActive(guildId)) {
+            InitiativeStateView(
+                entries = initiativeStore.currentEntries(guildId).map {
+                    RolledEntryView(it.name, it.roll, it.kind)
+                },
+                currentIndex = initiativeStore.currentIndex(guildId)
+            )
+        } else null
+
+        val monsterLibrary = if (isDm) {
+            monsterTemplateService.listByDm(requestingDiscordId).map(::toMonsterTemplateView)
+        } else emptyList()
+
         return CampaignDetail(
             campaign = campaign,
             players = players,
@@ -181,9 +232,20 @@ class CampaignWebService(
             isCurrentUserPlayer = isCurrentUserPlayer,
             currentUserCharacterId = currentUserCharacterId,
             notes = notes,
-            recentEvents = recentEvents
+            recentEvents = recentEvents,
+            initiativeState = initiativeState,
+            monsterLibrary = monsterLibrary
         )
     }
+
+    private fun toMonsterTemplateView(dto: MonsterTemplateDto): MonsterTemplateView =
+        MonsterTemplateView(
+            id = dto.id,
+            name = dto.name,
+            initiativeModifier = dto.initiativeModifier,
+            maxHp = dto.maxHp,
+            ac = dto.ac
+        )
 
     fun listRecentEvents(guildId: Long, sinceId: Long?, limit: Int): List<SessionEventView> {
         val campaign = campaignService.getActiveCampaignForGuild(guildId) ?: return emptyList()
@@ -436,6 +498,126 @@ class CampaignWebService(
         )
         return NarrateResult.NARRATED
     }
+
+    fun listTemplatesForDm(dmDiscordId: Long): List<MonsterTemplateView> =
+        monsterTemplateService.listByDm(dmDiscordId).map(::toMonsterTemplateView)
+
+    fun saveTemplate(
+        dmDiscordId: Long,
+        id: Long?,
+        name: String,
+        initiativeModifier: Int,
+        maxHp: Int?,
+        ac: Int?
+    ): SaveTemplateResult {
+        val trimmed = name.trim()
+        if (trimmed.isEmpty()) return SaveTemplateResult.NAME_BLANK
+        if (trimmed.length > MAX_TEMPLATE_NAME_LENGTH) return SaveTemplateResult.NAME_TOO_LONG
+
+        val dto = if (id != null && id > 0) {
+            val existing = monsterTemplateService.getById(id) ?: return SaveTemplateResult.NOT_FOUND
+            if (existing.dmDiscordId != dmDiscordId) return SaveTemplateResult.NOT_OWNER
+            existing.apply {
+                this.name = trimmed
+                this.initiativeModifier = initiativeModifier
+                this.maxHp = maxHp
+                this.ac = ac
+            }
+        } else {
+            MonsterTemplateDto(
+                dmDiscordId = dmDiscordId,
+                name = trimmed,
+                initiativeModifier = initiativeModifier,
+                maxHp = maxHp,
+                ac = ac
+            )
+        }
+        monsterTemplateService.save(dto)
+        return SaveTemplateResult.SAVED
+    }
+
+    fun deleteTemplate(dmDiscordId: Long, id: Long): DeleteTemplateResult {
+        val existing = monsterTemplateService.getById(id) ?: return DeleteTemplateResult.NOT_FOUND
+        if (existing.dmDiscordId != dmDiscordId) return DeleteTemplateResult.NOT_OWNER
+        monsterTemplateService.deleteById(id)
+        return DeleteTemplateResult.DELETED
+    }
+
+    fun rollInitiative(
+        guildId: Long,
+        requestingDiscordId: Long,
+        request: InitiativeRollRequest
+    ): RollInitiativeResult {
+        val campaign = campaignService.getActiveCampaignForGuild(guildId)
+            ?: return RollInitiativeResult.NO_ACTIVE_CAMPAIGN
+        if (campaign.dmDiscordId != requestingDiscordId) return RollInitiativeResult.NOT_DM
+        if (request.playerDiscordIds.isEmpty() &&
+            request.templateIds.isEmpty() &&
+            request.adhocMonsters.isEmpty()
+        ) {
+            return RollInitiativeResult.EMPTY_ROSTER
+        }
+
+        val entries = mutableListOf<InitiativeEntryData>()
+
+        request.playerDiscordIds.forEach { playerDiscordId ->
+            val modifier = userService.getUserById(playerDiscordId, guildId)?.initiativeModifier ?: 0
+            val displayName = resolveMemberName(guildId, playerDiscordId) ?: "Player $playerDiscordId"
+            entries += InitiativeEntryData(
+                name = displayName,
+                roll = rollD20() + modifier,
+                kind = "PLAYER",
+                modifier = modifier
+            )
+        }
+
+        request.templateIds.forEach { templateId ->
+            val template = monsterTemplateService.getById(templateId)
+                ?: return RollInitiativeResult.TEMPLATE_NOT_FOUND
+            if (template.dmDiscordId != requestingDiscordId) {
+                return RollInitiativeResult.TEMPLATE_NOT_FOUND
+            }
+            entries += InitiativeEntryData(
+                name = template.name,
+                roll = rollD20() + template.initiativeModifier,
+                kind = "MONSTER",
+                modifier = template.initiativeModifier
+            )
+        }
+
+        request.adhocMonsters.forEach { monster ->
+            val cleanName = monster.name.trim().ifEmpty { "Monster" }
+            entries += InitiativeEntryData(
+                name = cleanName,
+                roll = rollD20() + monster.initiativeModifier,
+                kind = "MONSTER",
+                modifier = monster.initiativeModifier
+            )
+        }
+
+        val sorted = entries.sortedByDescending { it.roll }
+        initiativeStore.seed(guildId, sorted)
+
+        sessionLog.publish(
+            guildId = guildId,
+            type = CampaignEventType.INITIATIVE_ROLLED,
+            actorDiscordId = requestingDiscordId,
+            actorName = resolveMemberName(guildId, requestingDiscordId),
+            payload = mapOf(
+                "entries" to sorted.map {
+                    mapOf(
+                        "name" to it.name,
+                        "roll" to it.roll,
+                        "kind" to it.kind,
+                        "modifier" to it.modifier
+                    )
+                }
+            )
+        )
+        return RollInitiativeResult.ROLLED
+    }
+
+    private fun rollD20(): Int = Random.nextInt(1, 21)
 
     private fun loadCharacterSummary(characterId: Long): CharacterSummary? {
         val json = characterSheetService.getSheet(characterId) ?: return null

--- a/web/src/main/kotlin/web/service/CampaignWebService.kt
+++ b/web/src/main/kotlin/web/service/CampaignWebService.kt
@@ -595,7 +595,8 @@ class CampaignWebService(
             )
         }
 
-        val sorted = entries.sortedByDescending { it.roll }
+        val disambiguated = disambiguateDuplicates(entries)
+        val sorted = disambiguated.sortedByDescending { it.roll }
         initiativeStore.seed(guildId, sorted)
 
         sessionLog.publish(
@@ -615,6 +616,25 @@ class CampaignWebService(
             )
         )
         return RollInitiativeResult.ROLLED
+    }
+
+    /**
+     * When the same name appears more than once in the roster (e.g. two Goblins
+     * from a template picked with quantity = 2, or two ad-hoc rows named
+     * "Kobold"), suffix each occurrence with a 1-based index so the turn table
+     * can tell them apart. Names that appear only once are left untouched.
+     */
+    private fun disambiguateDuplicates(entries: List<InitiativeEntryData>): List<InitiativeEntryData> {
+        val counts = entries.groupingBy { it.name }.eachCount()
+        val seen = mutableMapOf<String, Int>()
+        return entries.map { entry ->
+            if ((counts[entry.name] ?: 0) <= 1) entry
+            else {
+                val idx = (seen[entry.name] ?: 0) + 1
+                seen[entry.name] = idx
+                entry.copy(name = "${entry.name} #$idx")
+            }
+        }
     }
 
     private fun rollD20(): Int = Random.nextInt(1, 21)

--- a/web/src/main/kotlin/web/service/InitiativeStore.kt
+++ b/web/src/main/kotlin/web/service/InitiativeStore.kt
@@ -1,0 +1,35 @@
+package web.service
+
+/**
+ * Thin abstraction over the per-guild initiative tracker owned by discord-bot's
+ * `DnDHelper`. Lives in the web module because web can't depend on discord-bot
+ * directly; discord-bot provides the concrete implementation that proxies to
+ * `DnDHelper` so both modules read/write the same state.
+ */
+interface InitiativeStore {
+
+    /**
+     * Overwrite the guild's initiative with [entries]. Entries are sorted
+     * descending by roll before being installed; index resets to 0.
+     */
+    fun seed(guildId: Long, entries: List<InitiativeEntryData>)
+
+    /** Current sorted entries for [guildId], or empty if no active tracker. */
+    fun currentEntries(guildId: Long): List<InitiativeEntryData>
+
+    /** 0-based index of whose turn it is, or 0 when the tracker is empty. */
+    fun currentIndex(guildId: Long): Int
+
+    fun isActive(guildId: Long): Boolean
+}
+
+/**
+ * Module-agnostic rolled-entry payload. [kind] is `"PLAYER"` / `"MONSTER"` for
+ * web-composed rolls and `null` for Discord-originated rolls.
+ */
+data class InitiativeEntryData(
+    val name: String,
+    val roll: Int,
+    val kind: String? = null,
+    val modifier: Int = 0
+)

--- a/web/src/main/resources/static/js/sessionLog.js
+++ b/web/src/main/resources/static/js/sessionLog.js
@@ -143,9 +143,96 @@
         })
         .catch(function () { /* non-fatal; SSE will catch up */ });
 
+    // Turn-table widget: listens to the same stream and reflects initiative state.
+    const turnTable = document.getElementById('turn-table');
+    const turnList = document.getElementById('turn-table-list');
+    const turnEmpty = document.getElementById('turn-table-empty');
+
+    function ensureList() {
+        if (turnList) return turnList;
+        if (!turnTable) return null;
+        const ol = document.createElement('ol');
+        ol.id = 'turn-table-list';
+        turnTable.appendChild(ol);
+        return ol;
+    }
+
+    function rebuildTurnTable(entries, currentIndex) {
+        if (!turnTable) return;
+        const list = ensureList();
+        if (!list) return;
+        list.innerHTML = '';
+        if (!entries.length) {
+            if (turnEmpty) turnEmpty.style.display = '';
+            return;
+        }
+        if (turnEmpty) turnEmpty.style.display = 'none';
+        entries.forEach(function (entry, i) {
+            const li = document.createElement('li');
+            if (i === currentIndex) li.className = 'active';
+            const idx = document.createElement('span');
+            idx.className = 'idx';
+            idx.textContent = (i + 1);
+            const name = document.createElement('span');
+            name.className = 'name';
+            name.textContent = entry.name || 'Unknown';
+            li.appendChild(idx);
+            li.appendChild(name);
+            if (entry.kind === 'PLAYER' || entry.kind === 'MONSTER') {
+                const chip = document.createElement('span');
+                chip.className = 'chip ' + entry.kind.toLowerCase();
+                chip.textContent = entry.kind === 'PLAYER' ? 'Player' : 'Monster';
+                li.appendChild(chip);
+            }
+            const roll = document.createElement('span');
+            roll.className = 'roll';
+            roll.textContent = entry.roll;
+            li.appendChild(roll);
+            list.appendChild(li);
+        });
+        turnTable.dataset.currentIndex = String(currentIndex);
+    }
+
+    function highlightIndex(idx) {
+        if (!turnTable) return;
+        const list = turnTable.querySelector('ol');
+        if (!list) return;
+        Array.prototype.forEach.call(list.children, function (node, i) {
+            if (i === idx) node.classList.add('active');
+            else node.classList.remove('active');
+        });
+        turnTable.dataset.currentIndex = String(idx);
+    }
+
+    function handleInitiativeEvent(event) {
+        if (!turnTable) return;
+        const p = event.payload || {};
+        switch (event.type) {
+            case 'INITIATIVE_ROLLED': {
+                const entries = Array.isArray(p.entries) ? p.entries : [];
+                rebuildTurnTable(entries, 0);
+                break;
+            }
+            case 'INITIATIVE_NEXT':
+            case 'INITIATIVE_PREV': {
+                const idx = typeof p.currentIndex === 'number' ? p.currentIndex : 0;
+                highlightIndex(idx);
+                break;
+            }
+            case 'INITIATIVE_CLEARED': {
+                rebuildTurnTable([], 0);
+                break;
+            }
+        }
+    }
+
     const source = new EventSource('/dnd/campaign/' + guildId + '/events/stream');
     source.addEventListener('event', function (e) {
-        try { renderEvent(JSON.parse(e.data)); } catch (_) { /* skip malformed */ }
+        try {
+            const parsed = JSON.parse(e.data);
+            renderEvent(parsed);
+            handleInitiativeEvent(parsed);
+        } catch (_) { /* skip malformed */ }
     });
     source.addEventListener('error', function () {
         // EventSource retries automatically; nothing to do here.

--- a/web/src/main/resources/templates/campaignDetail.html
+++ b/web/src/main/resources/templates/campaignDetail.html
@@ -395,6 +395,37 @@
             padding: 6px 10px;
             font-size: 0.85rem;
         }
+        .initiative-composer .template-picker {
+            display: flex;
+            flex-direction: column;
+            gap: 4px;
+            margin: 10px 0;
+        }
+        .initiative-composer .picker-heading {
+            font-size: 0.75rem;
+            color: #a0a0b0;
+            margin-bottom: 4px;
+        }
+        .initiative-composer .picker-row {
+            display: flex;
+            gap: 8px;
+            align-items: center;
+            background: #1e2d50;
+            border: 1px solid #2a3a60;
+            border-radius: 6px;
+            padding: 4px 10px;
+        }
+        .initiative-composer .picker-row input[type=number] {
+            width: 56px;
+            padding: 4px 6px;
+            border-radius: 4px;
+            border: 1px solid #2a2a4a;
+            background: #1a1a2e;
+            color: #e0e0e0;
+            font-size: 0.85rem;
+        }
+        .initiative-composer .picker-name { flex: 1; font-size: 0.9rem; color: #e0e0e0; font-weight: 600; }
+        .initiative-composer .picker-meta { font-size: 0.75rem; color: #a0a0b0; font-family: monospace; }
         .initiative-composer .monster-add {
             display: flex;
             gap: 8px;
@@ -667,12 +698,18 @@
                         <span th:text="${player.displayName}">Player</span>
                     </label>
                 </div>
-                <div class="monster-add">
-                    <select name="templateIds" multiple size="3">
-                        <option th:each="tpl : ${monsterLibrary}"
-                                th:value="${tpl.id}"
-                                th:text="${tpl.name + ' (+' + tpl.initiativeModifier + ')'}">Goblin (+2)</option>
-                    </select>
+                <div class="template-picker" th:if="${not #lists.isEmpty(monsterLibrary)}">
+                    <div class="picker-heading">From library (qty 0 to skip):</div>
+                    <div class="picker-row" th:each="tpl : ${monsterLibrary}">
+                        <input type="hidden" name="templateId" th:value="${tpl.id}">
+                        <input type="number" name="templateQty" value="0" min="0" max="99"
+                               th:title="${'How many ' + tpl.name + ' to include'}">
+                        <span class="picker-name" th:text="${tpl.name}">Goblin</span>
+                        <span class="picker-meta"
+                              th:text="${'+' + tpl.initiativeModifier
+                                         + (tpl.maxHp != null ? ' · HP ' + tpl.maxHp : '')
+                                         + (tpl.ac != null ? ' · AC ' + tpl.ac : '')}">+2</span>
+                    </div>
                 </div>
                 <div class="adhoc-rows" id="adhoc-rows">
                     <div class="row">

--- a/web/src/main/resources/templates/campaignDetail.html
+++ b/web/src/main/resources/templates/campaignDetail.html
@@ -345,6 +345,124 @@
             color: #e0e0e0;
             font-size: 0.9rem;
         }
+
+        .monster-library, .initiative-composer, .turn-table {
+            background: #16213e;
+            border: 1px solid #2a2a4a;
+            border-radius: 10px;
+            padding: 16px 20px;
+            margin-bottom: 20px;
+        }
+        .monster-library summary,
+        .initiative-composer .title {
+            font-weight: 600;
+            cursor: pointer;
+            color: #e0e0e0;
+            margin-bottom: 8px;
+        }
+        .monster-library table { width: 100%; border-collapse: collapse; margin: 10px 0; }
+        .monster-library th, .monster-library td {
+            padding: 6px 8px;
+            text-align: left;
+            font-size: 0.85rem;
+            border-bottom: 1px solid #2a2a4a;
+        }
+        .monster-library th { color: #a0a0b0; font-weight: 500; }
+        .monster-library input[type=text], .monster-library input[type=number] {
+            padding: 6px 8px;
+            border-radius: 4px;
+            border: 1px solid #2a2a4a;
+            background: #1a1a2e;
+            color: #e0e0e0;
+            font-size: 0.85rem;
+            width: 100%;
+        }
+        .monster-library input[type=number] { width: 70px; }
+        .monster-library tr.row-form td { vertical-align: top; }
+        .initiative-composer .players-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+            gap: 6px;
+            margin: 10px 0;
+        }
+        .initiative-composer label.player-pill {
+            display: flex;
+            align-items: center;
+            gap: 6px;
+            background: #1e2d50;
+            border: 1px solid #2a3a60;
+            border-radius: 6px;
+            padding: 6px 10px;
+            font-size: 0.85rem;
+        }
+        .initiative-composer .monster-add {
+            display: flex;
+            gap: 8px;
+            flex-wrap: wrap;
+            margin-bottom: 10px;
+        }
+        .initiative-composer .monster-add select {
+            flex: 1;
+            min-width: 180px;
+            padding: 6px 8px;
+            background: #1a1a2e;
+            color: #e0e0e0;
+            border: 1px solid #2a2a4a;
+            border-radius: 6px;
+            font-size: 0.85rem;
+        }
+        .initiative-composer .adhoc-rows { display: flex; flex-direction: column; gap: 6px; }
+        .initiative-composer .adhoc-rows .row {
+            display: flex;
+            gap: 6px;
+        }
+        .initiative-composer .adhoc-rows input[type=text] {
+            flex: 1;
+            padding: 6px 8px;
+            border-radius: 4px;
+            border: 1px solid #2a2a4a;
+            background: #1a1a2e;
+            color: #e0e0e0;
+            font-size: 0.85rem;
+        }
+        .initiative-composer .adhoc-rows input[type=number] {
+            width: 70px;
+            padding: 6px 8px;
+            border-radius: 4px;
+            border: 1px solid #2a2a4a;
+            background: #1a1a2e;
+            color: #e0e0e0;
+            font-size: 0.85rem;
+        }
+        .turn-table ol { list-style: none; padding: 0; margin: 8px 0 0; display: flex; flex-direction: column; gap: 4px; }
+        .turn-table li {
+            display: flex;
+            gap: 10px;
+            align-items: center;
+            padding: 8px 12px;
+            border-radius: 6px;
+            background: #1a2140;
+            border: 1px solid #2a3460;
+            font-size: 0.9rem;
+        }
+        .turn-table li.active {
+            background: rgba(88,101,242,0.2);
+            border-color: rgba(88,101,242,0.6);
+        }
+        .turn-table .idx { color: #6a6a80; font-family: monospace; min-width: 18px; }
+        .turn-table .name { flex: 1; color: #e0e0e0; font-weight: 600; }
+        .turn-table .roll { color: #e0e0e0; font-weight: 700; font-family: monospace; }
+        .turn-table .chip {
+            font-size: 0.7rem;
+            text-transform: uppercase;
+            padding: 2px 6px;
+            border-radius: 10px;
+            letter-spacing: 0.03em;
+            border: 1px solid transparent;
+        }
+        .turn-table .chip.player { background: rgba(40,167,69,0.15); color: #5cb85c; border-color: rgba(40,167,69,0.3); }
+        .turn-table .chip.monster { background: rgba(192,57,43,0.15); color: #e74c3c; border-color: rgba(192,57,43,0.3); }
+        .turn-table .empty { color: #a0a0b0; font-size: 0.85rem; padding: 8px 0; }
     </style>
 </head>
 <body>
@@ -486,6 +604,110 @@
 
         <div class="empty-players" th:if="${#lists.isEmpty(players)}">
             No players have joined yet.
+        </div>
+
+        <!-- Monster library (DM only) -->
+        <details class="monster-library" th:if="${isUserDm}">
+            <summary>Monster library (<span th:text="${#lists.size(monsterLibrary)}">0</span>)</summary>
+            <table th:if="${not #lists.isEmpty(monsterLibrary)}">
+                <thead>
+                <tr><th>Name</th><th>Init</th><th>HP</th><th>AC</th><th></th></tr>
+                </thead>
+                <tbody>
+                <tr th:each="tpl : ${monsterLibrary}" class="row-form">
+                    <form th:action="@{/dnd/campaign/{id}/monsters/templates(id=${guildId})}" method="post"
+                          style="display:contents;">
+                        <input type="hidden" name="id" th:value="${tpl.id}">
+                        <td><input type="text" name="name" th:value="${tpl.name}" maxlength="100" required></td>
+                        <td><input type="number" name="initiativeModifier" th:value="${tpl.initiativeModifier}"></td>
+                        <td><input type="number" name="maxHp" th:value="${tpl.maxHp}"></td>
+                        <td><input type="number" name="ac" th:value="${tpl.ac}"></td>
+                        <td>
+                            <button type="submit" class="btn-xs" title="Save changes">Save</button>
+                        </td>
+                    </form>
+                    <td style="width:1%;white-space:nowrap;">
+                        <form th:action="@{/dnd/campaign/{id}/monsters/templates/{tid}/delete(id=${guildId},tid=${tpl.id})}"
+                              method="post"
+                              th:onsubmit="|return confirm('Delete ${tpl.name}?');|"
+                              style="display:inline;">
+                            <button type="submit" class="btn-xs kick" title="Delete template">Delete</button>
+                        </form>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+            <p th:if="${#lists.isEmpty(monsterLibrary)}" class="empty">
+                No monster templates yet. Add one below.
+            </p>
+            <form th:action="@{/dnd/campaign/{id}/monsters/templates(id=${guildId})}" method="post"
+                  style="display:flex;gap:8px;flex-wrap:wrap;margin-top:8px;">
+                <input type="text" name="name" placeholder="Monster name" maxlength="100" required
+                       style="flex:1;min-width:160px;padding:6px 8px;border-radius:4px;border:1px solid #2a2a4a;background:#1a1a2e;color:#e0e0e0;font-size:0.85rem;">
+                <input type="number" name="initiativeModifier" placeholder="init" value="0"
+                       style="width:70px;padding:6px 8px;border-radius:4px;border:1px solid #2a2a4a;background:#1a1a2e;color:#e0e0e0;font-size:0.85rem;">
+                <input type="number" name="maxHp" placeholder="HP"
+                       style="width:70px;padding:6px 8px;border-radius:4px;border:1px solid #2a2a4a;background:#1a1a2e;color:#e0e0e0;font-size:0.85rem;">
+                <input type="number" name="ac" placeholder="AC"
+                       style="width:70px;padding:6px 8px;border-radius:4px;border:1px solid #2a2a4a;background:#1a1a2e;color:#e0e0e0;font-size:0.85rem;">
+                <button type="submit" class="btn btn-primary">Add template</button>
+            </form>
+        </details>
+
+        <!-- Initiative composer (DM only) -->
+        <div class="initiative-composer" th:if="${isUserDm}">
+            <div class="title">Roll initiative</div>
+            <form th:action="@{/dnd/campaign/{id}/initiative/roll(id=${guildId})}" method="post"
+                  id="initiative-composer-form">
+                <div class="players-grid" th:if="${not #lists.isEmpty(players)}">
+                    <label th:each="player : ${players}" class="player-pill">
+                        <input type="checkbox" name="playerDiscordIds"
+                               th:value="${player.discordId}"
+                               th:checked="${player.alive}">
+                        <span th:text="${player.displayName}">Player</span>
+                    </label>
+                </div>
+                <div class="monster-add">
+                    <select name="templateIds" multiple size="3">
+                        <option th:each="tpl : ${monsterLibrary}"
+                                th:value="${tpl.id}"
+                                th:text="${tpl.name + ' (+' + tpl.initiativeModifier + ')'}">Goblin (+2)</option>
+                    </select>
+                </div>
+                <div class="adhoc-rows" id="adhoc-rows">
+                    <div class="row">
+                        <input type="text" name="adhocName" placeholder="Ad-hoc monster name (optional)" maxlength="100">
+                        <input type="number" name="adhocMod" placeholder="init" value="0">
+                    </div>
+                    <div class="row">
+                        <input type="text" name="adhocName" placeholder="Ad-hoc monster name (optional)" maxlength="100">
+                        <input type="number" name="adhocMod" placeholder="init" value="0">
+                    </div>
+                </div>
+                <div style="margin-top:12px;display:flex;justify-content:flex-end;">
+                    <button type="submit" class="btn btn-primary">🎲 Roll initiative</button>
+                </div>
+            </form>
+        </div>
+
+        <!-- Turn table (everyone) -->
+        <div class="turn-table" id="turn-table"
+             th:attr="data-current-index=${initiativeState != null ? initiativeState.currentIndex : 0}">
+            <div class="title" style="font-weight:600;color:#e0e0e0;">Turn order</div>
+            <ol id="turn-table-list" th:if="${initiativeState != null and not #lists.isEmpty(initiativeState.entries)}">
+                <li th:each="entry, iter : ${initiativeState.entries}"
+                    th:classappend="${iter.index == initiativeState.currentIndex ? 'active' : ''}">
+                    <span class="idx" th:text="${iter.index + 1}">1</span>
+                    <span class="name" th:text="${entry.name}">Name</span>
+                    <span th:if="${entry.kind == 'PLAYER'}" class="chip player">Player</span>
+                    <span th:if="${entry.kind == 'MONSTER'}" class="chip monster">Monster</span>
+                    <span class="roll" th:text="${entry.roll}">15</span>
+                </li>
+            </ol>
+            <div id="turn-table-empty" class="empty"
+                 th:if="${initiativeState == null or #lists.isEmpty(initiativeState.entries)}">
+                No initiative rolled yet. The DM can compose and roll above.
+            </div>
         </div>
 
         <div class="section-title">Session notes</div>


### PR DESCRIPTION
## Summary

Adds a DM-only web path for rolling initiative that mixes campaign players with monsters — either saved templates from the DM's personal library or one-off entries — and broadcasts the result to every open tab via the existing SSE bus. The Discord `/initiative` command is untouched; this sits on top.

PR 2 (follow-up) will add the d20 tumble animation to the same INITIATIVE_ROLLED events; this PR ships static reveal + turn table.

### Schema (V6)
`dnd_monster_template(id, dm_discord_id, name, initiative_modifier, max_hp?, ac?, ...)` — per-DM library that travels across guilds & campaigns.

### InitiativeState refactor
`sortedEntries` becomes `LinkedList<RolledEntry(name, roll, kind?)>` so the web composer can tag entries as `PLAYER` or `MONSTER`. Discord name-list / voice-channel rolls continue through `sortMap(...)` with `kind = null`.

`DnDHelper.seedInitiative(guildId, entries)` installs a pre-rolled, pre-sorted list for the web path.

### Cross-module bridge
`web` can't depend on `discord-bot`, so initiative reads/writes route through a small `InitiativeStore` interface in web, implemented by `DndHelperInitiativeStore` in discord-bot. Both modules see the exact same state.

### Web service & controller
- `listTemplatesForDm`, `saveTemplate` (with owner checks), `deleteTemplate`, `rollInitiative`.
- `rollInitiative` computes `1d20 + modifier` for each participant, seeds the store, publishes an enriched `INITIATIVE_ROLLED` event whose entries now include `kind` and `modifier` (PR 2 will use these).
- `CampaignDetail` gains `initiativeState` (everyone sees it — server-render survives refresh) and `monsterLibrary` (DM only).
- New endpoints: `GET /dnd/monsters/templates`, `POST /dnd/campaign/{g}/monsters/templates[/{id}/delete]`, `POST /dnd/campaign/{g}/initiative/roll`.

### UI (campaignDetail.html)
- **Monster library** — DM-only collapsible panel with inline edit per template, delete button, append-form.
- **Roll initiative composer** — DM-only. Player checkboxes (pre-ticked for alive players), multi-select for saved templates, two ad-hoc monster rows, Roll button.
- **Turn order** — visible to everyone. Server-renders the current state; each row shows index + name + Player/Monster chip + roll; the current-turn row gets `.active` styling.

### Client
`sessionLog.js` reuses the existing `EventSource`. On `INITIATIVE_ROLLED` it rebuilds the turn-order list; on `INITIATIVE_NEXT`/`INITIATIVE_PREV` it moves the highlight; on `INITIATIVE_CLEARED` it empties.

### Tests
- `CampaignWebServiceTest` — 13 new cases: template save/delete branches + rollInitiative (no campaign, not DM, empty roster, missing template, wrong-owner template, successful roll that seeds store + publishes).
- `CampaignControllerTest` — list/save/delete endpoints plus rollInitiative happy path, adhoc parallel-array merge, each flash-error branch.
- `DnDHelperTest` — `seedInitiative` installs sorted list with `kind` preserved; replaces prior state.

## Test plan

- [ ] `./gradlew build` passes
- [ ] Flyway applies V6 cleanly
- [ ] Manual: as DM, save a Goblin template (+2, 7 HP, 15 AC). Open composer, pick two players, pick Goblin×2, add ad-hoc Bugbear +1, Roll. Every tab shows 5 turn-order rows, sorted desc.
- [ ] Manual: Discord `/init next` advances the current-turn highlight in every web tab.
- [ ] Manual: refresh the page after a roll — turn table re-renders from `CampaignDetail.initiativeState`.
- [ ] Manual: as a non-DM player, no library / composer panels visible, but the turn table is.
- [ ] Manual: Discord `/initiative` still works with voice-channel members and shows on the web as an entry without kind chips.

## What's next

- **PR 2** — CSS d20 tumble + staggered dice reveal layered on top of the same `INITIATIVE_ROLLED` payload. Pure client-side; no schema or server changes needed.

https://claude.ai/code/session_01DgKBYeiGaxmLg5xaPasU4r