### PR TITLE
feat(dnd): animated dice reveal on the turn table (PR 2 of 2)

### DIFF
--- a/web/src/main/resources/static/js/sessionLog.js
+++ b/web/src/main/resources/static/js/sessionLog.js
@@ -157,10 +157,25 @@
         return ol;
     }
 
-    function rebuildTurnTable(entries, currentIndex) {
+    const prefersReducedMotion = window.matchMedia
+        && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+    function buildD20(roll, rolling) {
+        const die = document.createElement('span');
+        die.className = rolling ? 'd20 rolling' : 'd20';
+        die.dataset.roll = String(roll);
+        const face = document.createElement('span');
+        face.className = 'd20__face';
+        face.textContent = rolling ? '?' : String(roll);
+        die.appendChild(face);
+        return die;
+    }
+
+    function rebuildTurnTable(entries, currentIndex, options) {
         if (!turnTable) return;
         const list = ensureList();
         if (!list) return;
+        const animate = !!(options && options.animate) && !prefersReducedMotion;
         list.innerHTML = '';
         if (!entries.length) {
             if (turnEmpty) turnEmpty.style.display = '';
@@ -184,13 +199,29 @@
                 chip.textContent = entry.kind === 'PLAYER' ? 'Player' : 'Monster';
                 li.appendChild(chip);
             }
-            const roll = document.createElement('span');
-            roll.className = 'roll';
-            roll.textContent = entry.roll;
-            li.appendChild(roll);
+            li.appendChild(buildD20(entry.roll, animate));
             list.appendChild(li);
         });
         turnTable.dataset.currentIndex = String(currentIndex);
+        if (animate) scheduleReveal(list, entries);
+    }
+
+    function scheduleReveal(list, entries) {
+        const staggerMs = 280;
+        const popMs = 420;
+        entries.forEach(function (entry, i) {
+            const li = list.children[i];
+            if (!li) return;
+            const die = li.querySelector('.d20');
+            if (!die) return;
+            setTimeout(function () {
+                die.classList.remove('rolling');
+                die.classList.add('settled');
+                const face = die.querySelector('.d20__face');
+                if (face) face.textContent = String(entry.roll);
+                setTimeout(function () { die.classList.remove('settled'); }, popMs);
+            }, (i + 1) * staggerMs);
+        });
     }
 
     function highlightIndex(idx) {
@@ -210,7 +241,7 @@
         switch (event.type) {
             case 'INITIATIVE_ROLLED': {
                 const entries = Array.isArray(p.entries) ? p.entries : [];
-                rebuildTurnTable(entries, 0);
+                rebuildTurnTable(entries, 0, { animate: true });
                 break;
             }
             case 'INITIATIVE_NEXT':

--- a/web/src/main/resources/templates/campaignDetail.html
+++ b/web/src/main/resources/templates/campaignDetail.html
@@ -494,6 +494,69 @@
         .turn-table .chip.player { background: rgba(40,167,69,0.15); color: #5cb85c; border-color: rgba(40,167,69,0.3); }
         .turn-table .chip.monster { background: rgba(192,57,43,0.15); color: #e74c3c; border-color: rgba(192,57,43,0.3); }
         .turn-table .empty { color: #a0a0b0; font-size: 0.85rem; padding: 8px 0; }
+        .turn-table .d20 {
+            position: relative;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            width: 34px;
+            height: 34px;
+            border-radius: 6px;
+            background: linear-gradient(135deg, #2e3a5c, #1a2140);
+            border: 1px solid #3a4a70;
+            color: #e0e0e0;
+            font-weight: 700;
+            font-family: monospace;
+            font-size: 0.9rem;
+            transform: rotate(45deg);
+            box-shadow: inset 0 0 0 1px rgba(255,255,255,0.05);
+            flex-shrink: 0;
+        }
+        .turn-table .d20 .d20__face {
+            transform: rotate(-45deg);
+            display: inline-block;
+            min-width: 1.5ch;
+            text-align: center;
+        }
+        .turn-table li.active .d20 {
+            border-color: rgba(88,101,242,0.8);
+            background: linear-gradient(135deg, #3b4a80, #1a2140);
+        }
+        .turn-table .d20.rolling {
+            animation: d20-tumble 520ms cubic-bezier(.2,.7,.3,1.2) infinite;
+            background: linear-gradient(135deg, #5865F2, #2e3a5c);
+            border-color: #5865F2;
+        }
+        .turn-table .d20.rolling .d20__face {
+            animation: d20-flicker 90ms steps(2) infinite;
+            color: #fff;
+        }
+        .turn-table .d20.settled {
+            animation: d20-pop 420ms ease-out;
+        }
+        @keyframes d20-tumble {
+            0%   { transform: rotate(45deg) scale(1); }
+            50%  { transform: rotate(225deg) scale(1.08); }
+            100% { transform: rotate(405deg) scale(1); }
+        }
+        @keyframes d20-flicker {
+            0%   { opacity: 0.4; }
+            50%  { opacity: 1; }
+            100% { opacity: 0.5; }
+        }
+        @keyframes d20-pop {
+            0%   { transform: rotate(45deg) scale(1.3); box-shadow: 0 0 14px rgba(88,101,242,0.55); }
+            100% { transform: rotate(45deg) scale(1); box-shadow: inset 0 0 0 1px rgba(255,255,255,0.05); }
+        }
+        @media (prefers-reduced-motion: reduce) {
+            .turn-table .d20.rolling,
+            .turn-table .d20.settled { animation: none; }
+            .turn-table .d20.rolling {
+                background: linear-gradient(135deg, #2e3a5c, #1a2140);
+                border-color: #3a4a70;
+            }
+            .turn-table .d20.rolling .d20__face { animation: none; opacity: 1; }
+        }
     </style>
 </head>
 <body>
@@ -738,7 +801,9 @@
                     <span class="name" th:text="${entry.name}">Name</span>
                     <span th:if="${entry.kind == 'PLAYER'}" class="chip player">Player</span>
                     <span th:if="${entry.kind == 'MONSTER'}" class="chip monster">Monster</span>
-                    <span class="roll" th:text="${entry.roll}">15</span>
+                    <span class="d20" th:attr="data-roll=${entry.roll}">
+                        <span class="d20__face" th:text="${entry.roll}">15</span>
+                    </span>
                 </li>
             </ol>
             <div id="turn-table-empty" class="empty"


### PR DESCRIPTION
## Summary

- Swaps the turn-table's flat roll number for a rotated **d20 tile** and adds a staggered reveal animation keyed off the existing `INITIATIVE_ROLLED` SSE payload — no server-side changes.
- Each die starts in a `rolling` state with a spinning tile and a flickering `?` face, then settles in sequence (280 ms stagger) to its rolled number with a short pop.
- Static renders (page load / refresh) show dice already settled. `prefers-reduced-motion` disables the animation entirely.

## Shape

- `web/src/main/resources/templates/campaignDetail.html` — adds `.d20` tile styles + `@keyframes` (tumble, flicker, pop) + reduced-motion guard, and replaces the `<span class="roll">` with `<span class="d20"><span class="d20__face">…</span></span>` in the server render.
- `web/src/main/resources/static/js/sessionLog.js` — `rebuildTurnTable(entries, currentIndex, options)` now takes `{ animate: true }`. On `INITIATIVE_ROLLED` each row is built with a `rolling` die and `?` face; a staggered `setTimeout` loop swaps each face to its final roll and triggers the `settled` pop. `INITIATIVE_CLEARED` and `handleInitiativeEvent`'s NEXT/PREV paths are unchanged.

## Test plan

- [ ] CI green.
- [ ] Load a campaign that has initiative already set — dice render immediately with the correct numbers, no animation, no layout shift.
- [ ] Compose an encounter and click **Roll initiative** — every open tab sees the dice tumble and settle in order.
- [ ] Open DevTools → *Rendering* → enable *prefers-reduced-motion* → re-roll: final numbers appear instantly, no tumble/pop.
- [ ] `INITIATIVE_NEXT` / `INITIATIVE_PREV` / `INITIATIVE_CLEARED` still move the active highlight / empty the table correctly.
- [ ] Discord `/initiative` roll still populates the web turn table (just without the `?` preview, since all rolls arrive in one event).

https://claude.ai/code/session_01DgKBYeiGaxmLg5xaPasU4r