### PR TITLE
chore(build): downgrade JDK 22 → JDK 21 LTS

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -18,10 +18,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 22
-        uses: actions/setup-java@v1
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
         with:
-          java-version: 1.22
+          distribution: 'temurin'
+          java-version: '21'
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM eclipse-temurin:22-jdk AS build
+FROM eclipse-temurin:21-jdk AS build
 WORKDIR /home/gradle/src
 COPY --chown=root:root . .
 RUN chmod +x gradlew && ./gradlew :application:bootJar --no-daemon
 
-FROM eclipse-temurin:22-jre
+FROM eclipse-temurin:21-jre
 RUN mkdir /app
 COPY --from=build /home/gradle/src/application/build/libs/*.jar /app/toby-bot.jar
 EXPOSE 8080

--- a/application/build.gradle
+++ b/application/build.gradle
@@ -1,6 +1,6 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
-import static org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_22
+import static org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21
 
 plugins {
     id 'java'
@@ -89,13 +89,13 @@ tasks.withType(JavaCompile).configureEach {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(22)
+        languageVersion = JavaLanguageVersion.of(21)
     }
 }
 
 tasks.withType(KotlinCompile).configureEach {
     compilerOptions {
-        jvmTarget.set(JVM_22)
+        jvmTarget.set(JVM_21)
     }
 }
 
@@ -104,5 +104,5 @@ test {
 }
 
 kotlin {
-    jvmToolchain(22)
+    jvmToolchain(21)
 }

--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,7 @@ subprojects {
 
     tasks.withType(KotlinCompile).configureEach {
         compilerOptions {
-            jvmTarget.set(JvmTarget.JVM_22)
+            jvmTarget.set(JvmTarget.JVM_21)
         }
     }
 
@@ -85,7 +85,7 @@ tasks.withType(JavaCompile).configureEach {
 
 tasks.withType(KotlinCompile).configureEach {
     compilerOptions {
-        jvmTarget.set(JvmTarget.JVM_22)
+        jvmTarget.set(JvmTarget.JVM_21)
     }
 }
 repositories {
@@ -93,5 +93,5 @@ repositories {
 }
 
 kotlin {
-    jvmToolchain(22)
+    jvmToolchain(21)
 }

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -48,6 +48,6 @@ artifacts {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(22)
+        languageVersion = JavaLanguageVersion.of(21)
     }
 }

--- a/core-api/build.gradle
+++ b/core-api/build.gradle
@@ -46,6 +46,6 @@ artifacts {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(22)
+        languageVersion = JavaLanguageVersion.of(21)
     }
 }

--- a/database/build.gradle
+++ b/database/build.gradle
@@ -43,7 +43,7 @@ jar {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(22)
+        languageVersion = JavaLanguageVersion.of(21)
     }
 }
 

--- a/discord-bot/build.gradle
+++ b/discord-bot/build.gradle
@@ -1,6 +1,6 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
-import static org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_22
+import static org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21
 
 plugins {
     id 'java'
@@ -82,13 +82,13 @@ tasks.withType(JavaCompile).configureEach {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(22)
+        languageVersion = JavaLanguageVersion.of(21)
     }
 }
 
 tasks.withType(KotlinCompile).configureEach {
     compilerOptions {
-        jvmTarget.set(JVM_22)
+        jvmTarget.set(JVM_21)
     }
 }
 
@@ -97,7 +97,7 @@ test {
 }
 
 kotlin {
-    jvmToolchain(22)
+    jvmToolchain(21)
 }
 
 configurations {

--- a/system.properties
+++ b/system.properties
@@ -1,1 +1,1 @@
-java.runtime.version=22
+java.runtime.version=21

--- a/web/build.gradle
+++ b/web/build.gradle
@@ -39,7 +39,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(22)
+        languageVersion = JavaLanguageVersion.of(21)
     }
 }
 


### PR DESCRIPTION
## Summary

Drops the repo's JDK requirement from 22 (non-LTS) to **21 LTS** across every build file, CI workflow, Dockerfile, and Heroku `system.properties`. Kotlin 2.3 already supports JVM 21 as a compile target and Spring Boot 3.3.4 runs fine on it, so no application code changes are needed — this is pure tooling alignment.

### Why

JDK 22 went out of support in Sept 2024 with no LTS path; most contributor machines (and my own local setup) already have JDK 21. Local `./gradlew build` / `test` wasn't runnable here, which led directly to a couple of avoidable CI round-trips on the previous PR (#241). Switching to 21 lets me (and anyone else on a stock JDK) actually reproduce the build before pushing.

### Scope

- `system.properties` — Heroku buildpack JDK selector
- `Dockerfile` — both build and runtime stages (`eclipse-temurin:21-{jdk,jre}`)
- `.github/workflows/gradle.yml` — upgraded to `actions/setup-java@v4` + `distribution: temurin` + `java-version: '21'` (the old `@v1` + `1.22` syntax is deprecated anyway)
- Root + per-module `build.gradle` files: `JavaLanguageVersion.of(22) → of(21)`, `JvmTarget.JVM_22 → JVM_21`, `kotlin { jvmToolchain(22) } → jvmToolchain(21)`

### Test plan

- [ ] CI (Gradle job) completes green — this is the full test for the build-file/workflow changes.
- [ ] Heroku deploy picks JDK 21 via `system.properties` and starts cleanly — `java -version` visible in dyno startup logs.
- [ ] Docker `./rebuild.sh` still produces a working image (local only, no CI).
- [ ] Confirm I can `./gradlew build` from my own JDK 21 shell after this merges.

https://claude.ai/code/session_01DgKBYeiGaxmLg5xaPasU4r