### PR TITLE
style(web): full-surface mobile polish pass

### DIFF
--- a/web/src/main/resources/static/css/base.css
+++ b/web/src/main/resources/static/css/base.css
@@ -396,3 +396,23 @@ td { font-size: 0.95rem; }
         margin-bottom: 2px;
     }
 }
+
+/* Phones (iPhone SE 320 up to large phones) — tighter spacing + smaller headings */
+@media (max-width: 480px) {
+    .container, .container-wide { margin: 16px auto; padding: 0 var(--space-3); }
+    h1 { font-size: 1.25rem; }
+    h2 { font-size: 1rem; }
+    .card { padding: var(--space-4); }
+    .modal { padding: var(--space-4); max-width: 100%; }
+    .modal-actions { flex-wrap: wrap; }
+    .toast-stack { left: 12px; right: 12px; bottom: 12px; max-width: none; }
+}
+
+/* Grow tap targets on any touch device without ballooning desktop buttons */
+@media (hover: none) and (pointer: coarse) {
+    .btn-sm { padding: 8px 14px; min-height: 40px; }
+    .btn-icon { width: 40px; height: 40px; }
+    .btn { min-height: 44px; }
+    input[type=text], input[type=url], input[type=number], input[type=search],
+    input[type=email], input[type=password], select { min-height: 40px; }
+}

--- a/web/src/main/resources/static/css/intros.css
+++ b/web/src/main/resources/static/css/intros.css
@@ -237,3 +237,12 @@
     .form-row-split { grid-template-columns: 1fr; }
     .intros-table td.actions { text-align: left; }
 }
+
+@media (max-width: 480px) {
+    .volume-control input[type=range] { min-width: 0; }
+    .volume-inline { min-width: 0; }
+    .slot-select-row select { min-width: 0; flex: 1 1 160px; }
+    .intros-table td.actions { white-space: normal; display: flex; flex-wrap: wrap; gap: 6px; }
+    .name-edit-input { max-width: 100%; }
+    .empty-hero { padding: 28px 16px; }
+}

--- a/web/src/main/resources/static/css/nav.css
+++ b/web/src/main/resources/static/css/nav.css
@@ -48,7 +48,9 @@ nav {
 }
 
 @media (max-width: 600px) {
-    .nav-toggle { display: block; }
-    .nav-links { display: none; flex-direction: column; align-items: flex-start; gap: 12px; width: 100%; padding: 8px 0; }
+    .nav-toggle { display: block; min-height: 40px; min-width: 40px; }
+    .nav-links { display: none; flex-direction: column; align-items: stretch; gap: 4px; width: 100%; padding: 8px 0; }
     .nav-links.open { display: flex; }
+    .nav-links a, .nav-user { padding: 10px 4px; min-height: 40px; display: flex; align-items: center; }
+    .nav-links .btn-discord, .nav-links .btn-logout { align-self: flex-start; min-height: 40px; display: inline-flex; align-items: center; }
 }

--- a/web/src/main/resources/templates/campaign.html
+++ b/web/src/main/resources/templates/campaign.html
@@ -100,6 +100,10 @@
             border-radius: 4px;
             font-family: monospace;
         }
+        @media (max-width: 480px) {
+            .guild-grid { grid-template-columns: 1fr; gap: 12px; }
+            .guild-card { padding: 14px 16px; }
+        }
     </style>
 </head>
 <body>

--- a/web/src/main/resources/templates/campaignDetail.html
+++ b/web/src/main/resources/templates/campaignDetail.html
@@ -675,6 +675,69 @@
             gap: 8px;
             margin-top: 12px;
         }
+
+        /* ---- Mobile polish (<= 480px) ---- */
+        @media (max-width: 480px) {
+            /* Dice popover becomes a bottom sheet */
+            .dice-popover {
+                position: fixed;
+                inset: auto 8px 8px 8px;
+                left: 8px;
+                right: 8px;
+                top: auto;
+                min-width: 0;
+                max-width: none;
+                width: auto;
+            }
+
+            /* Session-log rows stack instead of squashing */
+            .event-row {
+                flex-wrap: wrap;
+                column-gap: 10px;
+                row-gap: 4px;
+            }
+            .event-type { min-width: 0; }
+            .event-body {
+                flex-basis: 100%;
+                word-break: break-word;
+            }
+            .event-time { margin-left: auto; }
+            .event-dm-actions {
+                flex-basis: 100%;
+                display: flex;
+                gap: 6px;
+                margin-top: 4px;
+            }
+            .btn-xs, .btn-xs.kick {
+                padding: 8px 12px;
+                min-height: 36px;
+                font-size: 0.8rem;
+            }
+
+            /* Composer inputs shrink instead of overflowing */
+            .initiative-composer .monster-add select { min-width: 0; }
+            .initiative-composer .adhoc-rows input[type=text] { min-width: 0; }
+            .initiative-composer .picker-row { flex-wrap: wrap; }
+            .initiative-composer .players-grid {
+                grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+            }
+
+            /* Character form input shrinks */
+            .character-form { flex-wrap: wrap; }
+            .character-form input { min-width: 0; flex: 1 1 160px; }
+
+            /* Panel padding loosens */
+            .monster-library,
+            .initiative-composer,
+            .turn-table {
+                padding: 12px 14px;
+                margin-bottom: 16px;
+            }
+
+            /* Turn-table rows wrap long names */
+            .turn-table li { flex-wrap: wrap; row-gap: 4px; }
+            .turn-table .name { min-width: 0; flex: 1 1 auto; }
+        }
     </style>
 </head>
 <body>

--- a/web/src/main/resources/templates/guilds.html
+++ b/web/src/main/resources/templates/guilds.html
@@ -69,6 +69,13 @@
     .empty-hero h2 { color: var(--text); margin-bottom: 10px; }
     .empty-hero .emoji { font-size: 2.4rem; display: block; margin-bottom: 12px; }
     .no-results { color: var(--text-muted); padding: 24px; text-align: center; display: none; }
+    @media (max-width: 480px) {
+        .guild-grid { grid-template-columns: 1fr; gap: 12px; }
+        .guild-card { padding: 14px 16px; }
+        .search-row { flex-direction: column; align-items: stretch; }
+        .search-row input { max-width: 100%; }
+        .empty-hero { padding: 32px 16px; }
+    }
 </style>
 
 <main id="main" class="container">

--- a/web/src/main/resources/templates/home.html
+++ b/web/src/main/resources/templates/home.html
@@ -173,6 +173,14 @@
         @media (max-width: 600px) {
             .cta-card { padding: 32px 20px; }
         }
+        @media (max-width: 480px) {
+            .hero { padding: 48px 16px 36px; }
+            .hero-actions { flex-direction: column; align-items: stretch; gap: 10px; }
+            .hero-actions .btn, .hero-actions a { width: 100%; text-align: center; }
+            .features { padding: 36px 16px; gap: 16px; }
+            .feature-card { padding: 20px 16px; }
+            .cta-card { padding: 24px 16px; }
+        }
     </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary

Retrofits a responsive pass across every Thymeleaf template and the three shared stylesheets so the site renders cleanly on phones (320–430 px) and small tablets, with touch-sized tap targets. **No behaviour changes — pure CSS + markup polish.**

### Breakpoints introduced

| Query | Targets | Used for |
|-------|---------|----------|
| `@media (max-width: 480px)` | Phones (iPhone SE 320 → iPhone 14 Pro Max 430) | Stacking, bottom-sheet popover, tightened spacing, card grids → single column |
| `@media (max-width: 640px)` *(existing)* | Large phones / small tablets | Left alone; covers the table-collapse rules |
| `@media (hover: none) and (pointer: coarse)` | Any touch device regardless of width | Tap targets ≥ 40 px without fattening desktop buttons |

### What actually got fixed

- **Dice-roller popover** had `min-width: 340px` and clipped off-screen under ~360 px. Now becomes a bottom sheet with `inset: auto 8px 8px 8px`.
- **Session-log rows** squashed under a `min-width: 70px` type label. Now the event body takes a full row; Hit/Miss DM actions move to their own line with 36 px min-height.
- **Initiative composer** (`select`, ad-hoc monster `input[type=text]`) and the character-link form dropped their hard `min-width` at mobile widths so fields shrink instead of pushing submit buttons off-screen.
- **Turn-table rows** wrap long names without squashing the d20 tile.
- **Nav hamburger** links now have 40 px min-height for touch.
- **Home hero** actions stack full-width under 480 px.
- **Campaign / guilds** card grids collapse to a single column.
- **Intros** volume slider + slot `select` stop clamping at hard min-widths.

### Files

- `web/src/main/resources/static/css/base.css` — new 480 px typography block + `pointer: coarse` tap-target block
- `web/src/main/resources/static/css/nav.css` — tap targets inside the existing 600 px breakpoint
- `web/src/main/resources/static/css/intros.css` — volume slider + slot select un-clamped
- `web/src/main/resources/templates/campaignDetail.html` — single new 480 px block covering popover, event rows, composer, character form, turn table
- `web/src/main/resources/templates/home.html` — hero stack
- `web/src/main/resources/templates/campaign.html` — guild-grid single column
- `web/src/main/resources/templates/guilds.html` — guild-grid + search row stacking

### Non-goals (intentionally deferred)

- Hamburger nav redesign / sticky nav
- Replacing inline `<style>` blocks with external CSS files (large refactor)
- Visual regression testing rig

### Test plan

Manual QA in Chrome DevTools → Device Toolbar at these widths:
- [ ] iPhone SE (375) — tightest mainstream phone
- [ ] Pixel 5 (393)
- [ ] iPhone 14 Pro Max (430)
- [ ] iPad Mini (768) — tablet sanity
- [ ] 1280 desktop — verify no regression

For each, walk through:
- [ ] `/dnd/campaign` — guild grid
- [ ] `/dnd/campaign/{guildId}` — open dice popover + roll; open monster library + add template; roll initiative; post + delete a note; session-log rows stay readable
- [ ] `/intros/{guildId}` — volume sliders + slot select + inline edit
- [ ] `/` — hero actions stack, nav hamburger opens/closes
- [ ] `prefers-reduced-motion` still disables the d20 tumble

https://claude.ai/code/session_01DgKBYeiGaxmLg5xaPasU4r