### PR TITLE
fix(dnd): register default-package Flyway guard + campaign event listener beans

### DIFF
--- a/.slugignore
+++ b/.slugignore
@@ -40,7 +40,7 @@ README.md
 *.tmp
 
 # Ignore SQL and backup files
-*.sql
+# (SQL migrations MUST stay — Flyway reads V*.sql from the classpath at boot.)
 *.bak
 
 # Ignore media files like mp3s, images, etc.

--- a/application/build.gradle
+++ b/application/build.gradle
@@ -94,8 +94,12 @@ bootJar {
  * missing table.
  */
 def migrationsDir = file("${rootDir}/database/src/main/resources/db/migration")
+def bootJarFileProvider = tasks.named('bootJar', org.springframework.boot.gradle.tasks.bundling.BootJar)
+    .flatMap { it.archiveFile }
 tasks.register('verifyMigrationsInBootJar') {
     dependsOn tasks.named('bootJar')
+    inputs.dir migrationsDir
+    inputs.file bootJarFileProvider
     doLast {
         def expected = new TreeSet<String>()
         if (migrationsDir.exists()) {
@@ -108,8 +112,7 @@ tasks.register('verifyMigrationsInBootJar') {
             return
         }
 
-        def bootJarTask = tasks.named('bootJar').get()
-        def jar = bootJarTask.archiveFile.get().asFile
+        def jar = bootJarFileProvider.get().asFile
         def found = new TreeSet<String>()
         new java.util.zip.ZipFile(jar).withCloseable { outer ->
             outer.entries().each { entry ->

--- a/application/build.gradle
+++ b/application/build.gradle
@@ -83,6 +83,66 @@ bootJar {
     mainClass.set('Application')
 }
 
+/**
+ * Fails the build when one or more Flyway migrations from
+ * :database/src/main/resources/db/migration/V*.sql fail to land inside
+ * BOOT-INF/lib/database-*.jar in the produced bootJar.
+ *
+ * Catches the class of failure we saw on Heroku where a stale gradle /
+ * buildpack cache produced a jar missing the SQL resources — Flyway then
+ * quietly did nothing and the app 500'd on the first query that hit a
+ * missing table.
+ */
+def migrationsDir = file("${rootDir}/database/src/main/resources/db/migration")
+tasks.register('verifyMigrationsInBootJar') {
+    dependsOn tasks.named('bootJar')
+    doLast {
+        def expected = new TreeSet<String>()
+        if (migrationsDir.exists()) {
+            migrationsDir.eachFile { f ->
+                if (f.name.startsWith('V') && f.name.endsWith('.sql')) expected << f.name
+            }
+        }
+        if (expected.isEmpty()) {
+            println "verifyMigrationsInBootJar: no migrations found at ${migrationsDir}, skipping."
+            return
+        }
+
+        def bootJarTask = tasks.named('bootJar').get()
+        def jar = bootJarTask.archiveFile.get().asFile
+        def found = new TreeSet<String>()
+        new java.util.zip.ZipFile(jar).withCloseable { outer ->
+            outer.entries().each { entry ->
+                if (entry.name ==~ /^BOOT-INF\/lib\/database-.*\.jar$/) {
+                    outer.getInputStream(entry).withCloseable { raw ->
+                        new java.util.zip.ZipInputStream(raw).withCloseable { zis ->
+                            def e
+                            while ((e = zis.nextEntry) != null) {
+                                if (e.name.startsWith('db/migration/') && e.name.endsWith('.sql')) {
+                                    found << e.name.substring('db/migration/'.length())
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        def missing = expected - found
+        if (!missing.isEmpty()) {
+            throw new GradleException(
+                "bootJar is missing ${missing.size()} migration(s): ${missing}. " +
+                    "The fat jar packaging dropped them — fix before deploying."
+            )
+        }
+        println "verifyMigrationsInBootJar: ${expected.size()} migration(s) packaged inside ${jar.name}."
+    }
+}
+
+tasks.named('bootJar').configure {
+    finalizedBy 'verifyMigrationsInBootJar'
+}
+
 tasks.withType(JavaCompile).configureEach {
     options.encoding = 'UTF-8'
 }

--- a/application/build.gradle
+++ b/application/build.gradle
@@ -101,15 +101,24 @@ tasks.register('verifyMigrationsInBootJar') {
     inputs.dir migrationsDir
     inputs.file bootJarFileProvider
     doLast {
+        if (!migrationsDir.exists()) {
+            throw new GradleException(
+                "verifyMigrationsInBootJar: migrations directory does not exist at ${migrationsDir}. " +
+                    "The repo checkout is incomplete — the fat jar will ship without any schema migrations."
+            )
+        }
         def expected = new TreeSet<String>()
-        if (migrationsDir.exists()) {
-            migrationsDir.eachFile { f ->
-                if (f.name.startsWith('V') && f.name.endsWith('.sql')) expected << f.name
-            }
+        def otherFiles = new ArrayList<String>()
+        migrationsDir.eachFile { f ->
+            if (f.name.startsWith('V') && f.name.endsWith('.sql')) expected << f.name
+            else otherFiles << f.name
         }
         if (expected.isEmpty()) {
-            println "verifyMigrationsInBootJar: no migrations found at ${migrationsDir}, skipping."
-            return
+            throw new GradleException(
+                "verifyMigrationsInBootJar: ${migrationsDir} exists but contains no V*.sql files. " +
+                    "Directory contents: ${otherFiles.isEmpty() ? '[empty]' : otherFiles}. " +
+                    "Something in the build checkout is stripping Flyway migrations."
+            )
         }
 
         def jar = bootJarFileProvider.get().asFile

--- a/application/src/main/kotlin/Application.kt
+++ b/application/src/main/kotlin/Application.kt
@@ -1,9 +1,12 @@
+import database.configuration.FlywayGuardConfig
 import org.springframework.boot.SpringApplication
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.cache.annotation.EnableCaching
+import org.springframework.context.annotation.Import
 
 @SpringBootApplication(scanBasePackages = ["bot", "common", "core", "database", "web"])
 @EnableCaching
+@Import(FlywayGuardConfig::class)
 class Application {
     companion object {
         @JvmStatic

--- a/application/src/main/kotlin/database/configuration/CampaignEventListener.kt
+++ b/application/src/main/kotlin/database/configuration/CampaignEventListener.kt
@@ -1,3 +1,5 @@
+package database.configuration
+
 import common.events.CampaignEventOccurred
 import common.logging.DiscordLogger
 import database.dto.CampaignEventDto

--- a/application/src/main/kotlin/database/configuration/FlywayGuardConfig.kt
+++ b/application/src/main/kotlin/database/configuration/FlywayGuardConfig.kt
@@ -1,3 +1,5 @@
+package database.configuration
+
 import common.logging.DiscordLogger
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.flyway.FlywayMigrationStrategy

--- a/application/src/test/kotlin/CampaignEventListenerTest.kt
+++ b/application/src/test/kotlin/CampaignEventListenerTest.kt
@@ -1,5 +1,6 @@
 import common.events.CampaignEventOccurred
 import common.events.CampaignEventType
+import database.configuration.CampaignEventListener
 import database.dto.CampaignDto
 import database.dto.CampaignEventDto
 import database.service.CampaignEventService

--- a/application/src/test/kotlin/FlywayGuardConfigTest.kt
+++ b/application/src/test/kotlin/FlywayGuardConfigTest.kt
@@ -1,3 +1,4 @@
+import database.configuration.FlywayGuardConfig
 import org.junit.jupiter.api.Assertions.assertDoesNotThrow
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test


### PR DESCRIPTION
## Context

Every Heroku boot has been logging `Schema "public" has a version (3) that is newer than the latest available migration (0) !`. Two independent bugs, together:

1. **`FlywayGuardConfig` never loaded.** I placed it in the default package. `Application.kt` uses `@SpringBootApplication(scanBasePackages = ["bot", "common", "core", "database", "web"])` which explicitly replaces the default scan and doesn't include the root package. The guard is silently discarded, which is why every deploy since V4–V6 landed has silently 500'd on `/events` instead of crash-looping like it should have.
2. **`CampaignEventListener` never loaded** either — same root cause. ROLL / HIT / MISS / DM_NOTE `CampaignEventOccurred` events publish in-process and broadcast over SSE, but the listener that persists them to `dnd_campaign_event` was never even registered.

## What this PR changes

- Move `FlywayGuardConfig.kt` and `CampaignEventListener.kt` out of the default package and into `database/configuration/` so component scanning picks them up.
- Add `@Import(FlywayGuardConfig::class)` on `Application` as belt-and-braces insurance against future `scanBasePackages` edits.
- Update the two test files' imports to the new FQNs.
- **Restore the `verifyMigrationsInBootJar` Gradle task** (reverted earlier in #241 after my KDoc comment bug cascaded). Now that the Kotlin compile issue is long since fixed, re-enable the finaliser so CI fails the build if any `V*.sql` is missing from `BOOT-INF/lib/database-*.jar` inside the fat jar. Per your "do concurrency" ask — this lands in the same PR so one CI cycle validates both fixes.

## Files

| Path | Change |
|------|--------|
| `application/src/main/kotlin/database/configuration/FlywayGuardConfig.kt` | Moved from default package |
| `application/src/main/kotlin/database/configuration/CampaignEventListener.kt` | Moved from default package |
| `application/src/main/kotlin/Application.kt` | `@Import(FlywayGuardConfig::class)` |
| `application/src/test/kotlin/FlywayGuardConfigTest.kt` | New import |
| `application/src/test/kotlin/CampaignEventListenerTest.kt` | New import |
| `application/build.gradle` | Restored `verifyMigrationsInBootJar` + `bootJar.finalizedBy` |

## Manual prod SQL (run once after this merges + Heroku redeploys)

If the CI `verifyMigrationsInBootJar` check goes green but Heroku's dyno still logs "0 migration(s) on classpath" (guard crash-loops), run the following in `heroku pg:psql -a toby-bot` to unblock session log immediately:

```sql
BEGIN;

-- V4: dnd_campaign_session_note
CREATE TABLE IF NOT EXISTS dnd_campaign_session_note (
    id BIGSERIAL PRIMARY KEY,
    campaign_id BIGINT NOT NULL REFERENCES dnd_campaign(id) ON DELETE CASCADE,
    author_discord_id BIGINT NOT NULL,
    body TEXT NOT NULL,
    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
);
CREATE INDEX IF NOT EXISTS idx_dnd_campaign_session_note_campaign_id
    ON dnd_campaign_session_note(campaign_id);

-- V5: dnd_campaign_event
CREATE TABLE IF NOT EXISTS dnd_campaign_event (
    id BIGSERIAL PRIMARY KEY,
    campaign_id BIGINT NOT NULL REFERENCES dnd_campaign(id) ON DELETE CASCADE,
    event_type VARCHAR(40) NOT NULL,
    actor_discord_id BIGINT,
    actor_name VARCHAR(100),
    ref_event_id BIGINT REFERENCES dnd_campaign_event(id) ON DELETE CASCADE,
    payload TEXT NOT NULL,
    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
);
CREATE INDEX IF NOT EXISTS idx_dnd_campaign_event_campaign_created
    ON dnd_campaign_event(campaign_id, created_at);
CREATE INDEX IF NOT EXISTS idx_dnd_campaign_event_ref
    ON dnd_campaign_event(ref_event_id);

-- V6: dnd_monster_template
CREATE TABLE IF NOT EXISTS dnd_monster_template (
    id BIGSERIAL PRIMARY KEY,
    dm_discord_id BIGINT NOT NULL,
    name VARCHAR(100) NOT NULL,
    initiative_modifier INT NOT NULL DEFAULT 0,
    max_hp INT,
    ac INT,
    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
);
CREATE INDEX IF NOT EXISTS idx_dnd_monster_template_dm
    ON dnd_monster_template(dm_discord_id);

INSERT INTO flyway_schema_history
    (installed_rank, version, description, type, script, checksum, installed_by, installed_on, execution_time, success)
VALUES
    (4, '4', 'dnd campaign session note', 'SQL', 'V4__dnd_campaign_session_note.sql', 0, 'manual', now(), 0, true),
    (5, '5', 'dnd campaign event',        'SQL', 'V5__dnd_campaign_event.sql',        0, 'manual', now(), 0, true),
    (6, '6', 'dnd monster template',      'SQL', 'V6__dnd_monster_template.sql',      0, 'manual', now(), 0, true);

COMMIT;
```

The recorded `checksum` is `0` — if a future deploy's Flyway scan starts working, that run will fail with a checksum mismatch; resolve with `flyway repair` or update the stored checksum to match.

## Test plan

- [ ] CI green — including `verifyMigrationsInBootJar` printing `6 migration(s) packaged`. If it prints `bootJar is missing N migration(s): [...]` instead, that's the smoking gun for the jar-packaging bug.
- [ ] FlywayGuardConfigTest + CampaignEventListenerTest stay green with new imports.
- [ ] After deploy: `heroku logs --tail -a toby-bot | grep -i flyway` shows `Flyway: 6 migration(s) on classpath (required=true)` followed by successful migrate.
- [ ] `/events?since=0&limit=200` returns 200 + JSON (empty array if the DB is fresh, or existing events after the SQL above runs).
- [ ] Roll a die from the popover → the event appears in the session log for every open tab via SSE.

https://claude.ai/code/session_01DgKBYeiGaxmLg5xaPasU4r