### PR TITLE
feat(dnd): BG3-style combat HUD with attack-vs-AC + HP tracking

### DIFF
--- a/application/src/test/kotlin/web/controller/CampaignControllerTest.kt
+++ b/application/src/test/kotlin/web/controller/CampaignControllerTest.kt
@@ -18,6 +18,9 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes
 import web.service.AddNoteResult
 import web.service.AdhocMonster
 import web.service.AnnotateRollResult
+import web.service.ApplyDamageResult
+import web.service.AttackOutcome
+import web.service.AttackResult
 import web.service.CampaignDetail
 import web.service.CampaignEventBroadcaster
 import web.service.CampaignWebService
@@ -770,6 +773,8 @@ class CampaignControllerTest {
             templateQtys = null,
             adhocNames = null,
             adhocMods = null,
+            adhocHps = null,
+            adhocAcs = null,
             user = mockUser,
             ra = mockRa
         )
@@ -800,6 +805,8 @@ class CampaignControllerTest {
             templateQtys = null,
             adhocNames = listOf("Bugbear", "", "Kobold"),
             adhocMods = listOf(1, 0, 2),
+            adhocHps = null,
+            adhocAcs = null,
             user = mockUser,
             ra = mockRa
         )
@@ -824,6 +831,8 @@ class CampaignControllerTest {
             templateQtys = listOf(2, 1, 0),
             adhocNames = null,
             adhocMods = null,
+            adhocHps = null,
+            adhocAcs = null,
             user = mockUser,
             ra = mockRa
         )
@@ -835,7 +844,7 @@ class CampaignControllerTest {
             campaignWebService.rollInitiative(guildId, 1L, any())
         } returns RollInitiativeResult.NOT_DM
 
-        controller.rollInitiative(guildId, listOf(7L), null, null, null, null, mockUser, mockRa)
+        controller.rollInitiative(guildId, listOf(7L), null, null, null, null, null, null, mockUser, mockRa)
 
         verify { mockRa.addFlashAttribute("error", "Only the Dungeon Master can roll initiative here.") }
     }
@@ -846,7 +855,7 @@ class CampaignControllerTest {
             campaignWebService.rollInitiative(guildId, 1L, any())
         } returns RollInitiativeResult.EMPTY_ROSTER
 
-        controller.rollInitiative(guildId, null, null, null, null, null, mockUser, mockRa)
+        controller.rollInitiative(guildId, null, null, null, null, null, null, null, mockUser, mockRa)
 
         verify { mockRa.addFlashAttribute("error", "Pick at least one player or monster before rolling.") }
     }
@@ -857,7 +866,7 @@ class CampaignControllerTest {
             campaignWebService.rollInitiative(guildId, 1L, any())
         } returns RollInitiativeResult.TEMPLATE_NOT_FOUND
 
-        controller.rollInitiative(guildId, null, listOf(77L), listOf(1), null, null, mockUser, mockRa)
+        controller.rollInitiative(guildId, null, listOf(77L), listOf(1), null, null, null, null, mockUser, mockRa)
 
         verify {
             mockRa.addFlashAttribute("error", "One of the selected monster templates couldn't be found.")
@@ -919,5 +928,64 @@ class CampaignControllerTest {
 
         assertEquals("redirect:/dnd/campaign", view)
         verify(exactly = 0) { campaignWebService.rollDice(any(), any(), any(), any(), any(), any()) }
+    }
+
+    // combat
+
+    @Test
+    fun `attack redirects on hit without flash error`() {
+        every {
+            campaignWebService.attack(guildId, 1L, "Goblin", 3)
+        } returns AttackOutcome(result = AttackResult.HIT, attacker = "Alice", target = "Goblin")
+
+        val view = controller.attack(guildId, "Goblin", 3, mockUser, mockRa)
+
+        assertEquals("redirect:/dnd/campaign/$guildId", view)
+        verify(exactly = 0) { mockRa.addFlashAttribute(any<String>(), any()) }
+    }
+
+    @Test
+    fun `attack sets flash error when not my turn`() {
+        every {
+            campaignWebService.attack(guildId, 1L, any(), any())
+        } returns AttackOutcome(result = AttackResult.NOT_MY_TURN)
+
+        controller.attack(guildId, "Goblin", 0, mockUser, mockRa)
+
+        verify { mockRa.addFlashAttribute("error", "You can only attack on your own turn (or as the DM).") }
+    }
+
+    @Test
+    fun `attack trims target name`() {
+        every {
+            campaignWebService.attack(guildId, 1L, "Goblin", 0)
+        } returns AttackOutcome(result = AttackResult.HIT)
+
+        controller.attack(guildId, "  Goblin  ", 0, mockUser, mockRa)
+
+        verify(exactly = 0) { mockRa.addFlashAttribute(any<String>(), any()) }
+    }
+
+    @Test
+    fun `applyDamage redirects on applied`() {
+        every {
+            campaignWebService.applyDamage(guildId, 1L, "Goblin", 4)
+        } returns ApplyDamageResult.APPLIED
+
+        val view = controller.applyDamage(guildId, "Goblin", 4, mockUser, mockRa)
+
+        assertEquals("redirect:/dnd/campaign/$guildId", view)
+        verify(exactly = 0) { mockRa.addFlashAttribute(any<String>(), any()) }
+    }
+
+    @Test
+    fun `applyDamage sets flash error when target missing`() {
+        every {
+            campaignWebService.applyDamage(guildId, 1L, any(), any())
+        } returns ApplyDamageResult.TARGET_NOT_FOUND
+
+        controller.applyDamage(guildId, "Nobody", 4, mockUser, mockRa)
+
+        verify { mockRa.addFlashAttribute("error", "That target isn't in the initiative order.") }
     }
 }

--- a/application/src/test/kotlin/web/service/CampaignWebServiceTest.kt
+++ b/application/src/test/kotlin/web/service/CampaignWebServiceTest.kt
@@ -1328,4 +1328,181 @@ class CampaignWebServiceTest {
             )
         }
     }
+
+    // combat: attack
+
+    @Test
+    fun `attack rejects when no active combat`() {
+        val campaign = makeCampaign()
+        every { campaignService.getActiveCampaignForGuild(guildId) } returns campaign
+        every { initiativeStore.isActive(guildId) } returns false
+
+        val outcome = service.attack(guildId, dmDiscordId, "Goblin", 0)
+        assertEquals(AttackResult.NO_ACTIVE_COMBAT, outcome.result)
+    }
+
+    @Test
+    fun `attack rejects non-DM non-current-turn requester`() {
+        val campaign = makeCampaign()
+        every { campaignService.getActiveCampaignForGuild(guildId) } returns campaign
+        every { initiativeStore.isActive(guildId) } returns true
+        every { initiativeStore.currentEntry(guildId) } returns
+            InitiativeEntryData(name = "Goblin", roll = 18, kind = "MONSTER", ac = 15)
+        every { initiativeStore.currentEntries(guildId) } returns
+            listOf(InitiativeEntryData("Goblin", 18, "MONSTER", ac = 15))
+
+        val outcome = service.attack(guildId, playerDiscordId, "Goblin", 0)
+        assertEquals(AttackResult.NOT_MY_TURN, outcome.result)
+    }
+
+    @Test
+    fun `attack hits when roll + mod meets AC and publishes ATTACK_HIT`() {
+        val campaign = makeCampaign()
+        every { campaignService.getActiveCampaignForGuild(guildId) } returns campaign
+        every { initiativeStore.isActive(guildId) } returns true
+        every { initiativeStore.currentEntry(guildId) } returns
+            InitiativeEntryData(name = "Goblin", roll = 18, kind = "MONSTER")
+        every { initiativeStore.currentEntries(guildId) } returns listOf(
+            InitiativeEntryData("Goblin", 18, "MONSTER"),
+            InitiativeEntryData("Alice", 12, "PLAYER", maxHp = 20, currentHp = 20, ac = 10)
+        )
+
+        val outcome = service.attack(guildId, dmDiscordId, "Alice", 5)
+        assertEquals(AttackResult.HIT, outcome.result)
+        verify {
+            sessionLog.publish(
+                guildId = guildId,
+                type = common.events.CampaignEventType.ATTACK_HIT,
+                actorDiscordId = dmDiscordId,
+                actorName = any(),
+                payload = match {
+                    it["attacker"] == "Goblin" && it["target"] == "Alice" &&
+                        it["modifier"] == 5 && it["targetAc"] == 10
+                }
+            )
+        }
+    }
+
+    @Test
+    fun `attack without AC publishes ATTACK_HIT unconditionally`() {
+        val campaign = makeCampaign()
+        every { campaignService.getActiveCampaignForGuild(guildId) } returns campaign
+        every { initiativeStore.isActive(guildId) } returns true
+        every { initiativeStore.currentEntry(guildId) } returns
+            InitiativeEntryData("Goblin", 18, "MONSTER")
+        every { initiativeStore.currentEntries(guildId) } returns listOf(
+            InitiativeEntryData("Goblin", 18, "MONSTER"),
+            InitiativeEntryData("Alice", 12, "PLAYER")
+        )
+
+        val outcome = service.attack(guildId, dmDiscordId, "Alice", -10)
+        assertEquals(AttackResult.HIT, outcome.result)
+    }
+
+    @Test
+    fun `attack rejects self-targeting`() {
+        val campaign = makeCampaign()
+        every { campaignService.getActiveCampaignForGuild(guildId) } returns campaign
+        every { initiativeStore.isActive(guildId) } returns true
+        every { initiativeStore.currentEntry(guildId) } returns
+            InitiativeEntryData("Goblin", 18, "MONSTER")
+        every { initiativeStore.currentEntries(guildId) } returns
+            listOf(InitiativeEntryData("Goblin", 18, "MONSTER"))
+
+        val outcome = service.attack(guildId, dmDiscordId, "Goblin", 0)
+        assertEquals(AttackResult.CANT_TARGET_SELF, outcome.result)
+    }
+
+    @Test
+    fun `attack rejects defeated target`() {
+        val campaign = makeCampaign()
+        every { campaignService.getActiveCampaignForGuild(guildId) } returns campaign
+        every { initiativeStore.isActive(guildId) } returns true
+        every { initiativeStore.currentEntry(guildId) } returns
+            InitiativeEntryData("Goblin", 18, "MONSTER")
+        every { initiativeStore.currentEntries(guildId) } returns listOf(
+            InitiativeEntryData("Goblin", 18, "MONSTER"),
+            InitiativeEntryData("Alice", 12, "PLAYER", defeated = true)
+        )
+
+        val outcome = service.attack(guildId, dmDiscordId, "Alice", 0)
+        assertEquals(AttackResult.TARGET_DEFEATED, outcome.result)
+    }
+
+    @Test
+    fun `attack rejects out-of-range modifier`() {
+        val outcome = service.attack(guildId, dmDiscordId, "Alice", 99)
+        assertEquals(AttackResult.INVALID_MODIFIER, outcome.result)
+    }
+
+    // combat: applyDamage
+
+    @Test
+    fun `applyDamage publishes DAMAGE_DEALT and returns APPLIED`() {
+        val campaign = makeCampaign()
+        every { campaignService.getActiveCampaignForGuild(guildId) } returns campaign
+        every { initiativeStore.isActive(guildId) } returns true
+        every { initiativeStore.currentEntry(guildId) } returns
+            InitiativeEntryData("Goblin", 18, "MONSTER")
+        every { initiativeStore.applyDamage(guildId, "Alice", 4) } returns
+            InitiativeEntryData("Alice", 12, "PLAYER", maxHp = 20, currentHp = 16)
+
+        val result = service.applyDamage(guildId, dmDiscordId, "Alice", 4)
+        assertEquals(ApplyDamageResult.APPLIED, result)
+        verify {
+            sessionLog.publish(
+                guildId = guildId,
+                type = common.events.CampaignEventType.DAMAGE_DEALT,
+                actorDiscordId = dmDiscordId,
+                actorName = any(),
+                payload = match { it["amount"] == 4 && it["remainingHp"] == 16 }
+            )
+        }
+    }
+
+    @Test
+    fun `applyDamage publishes PARTICIPANT_DEFEATED when hp reaches 0`() {
+        val campaign = makeCampaign()
+        every { campaignService.getActiveCampaignForGuild(guildId) } returns campaign
+        every { initiativeStore.isActive(guildId) } returns true
+        every { initiativeStore.currentEntry(guildId) } returns
+            InitiativeEntryData("Goblin", 18, "MONSTER")
+        every { initiativeStore.applyDamage(guildId, "Alice", 99) } returns
+            InitiativeEntryData("Alice", 12, "PLAYER", maxHp = 20, currentHp = 0, defeated = true)
+
+        val result = service.applyDamage(guildId, dmDiscordId, "Alice", 99)
+        assertEquals(ApplyDamageResult.DEFEATED, result)
+        verify {
+            sessionLog.publish(
+                guildId = guildId,
+                type = common.events.CampaignEventType.PARTICIPANT_DEFEATED,
+                actorDiscordId = dmDiscordId,
+                actorName = any(),
+                payload = match { it["target"] == "Alice" }
+            )
+        }
+    }
+
+    @Test
+    fun `applyDamage rejects negative amount`() {
+        assertEquals(
+            ApplyDamageResult.INVALID_AMOUNT,
+            service.applyDamage(guildId, dmDiscordId, "Alice", -1)
+        )
+    }
+
+    @Test
+    fun `applyDamage returns TARGET_NOT_FOUND when store can't find target`() {
+        val campaign = makeCampaign()
+        every { campaignService.getActiveCampaignForGuild(guildId) } returns campaign
+        every { initiativeStore.isActive(guildId) } returns true
+        every { initiativeStore.currentEntry(guildId) } returns
+            InitiativeEntryData("Goblin", 18, "MONSTER")
+        every { initiativeStore.applyDamage(guildId, "Nobody", 4) } returns null
+
+        assertEquals(
+            ApplyDamageResult.TARGET_NOT_FOUND,
+            service.applyDamage(guildId, dmDiscordId, "Nobody", 4)
+        )
+    }
 }

--- a/application/src/test/kotlin/web/service/CampaignWebServiceTest.kt
+++ b/application/src/test/kotlin/web/service/CampaignWebServiceTest.kt
@@ -1364,10 +1364,11 @@ class CampaignWebServiceTest {
             InitiativeEntryData(name = "Goblin", roll = 18, kind = "MONSTER")
         every { initiativeStore.currentEntries(guildId) } returns listOf(
             InitiativeEntryData("Goblin", 18, "MONSTER"),
-            InitiativeEntryData("Alice", 12, "PLAYER", maxHp = 20, currentHp = 20, ac = 10)
+            // AC 1 + mod 0 → any d20 roll meets or beats it. Deterministic.
+            InitiativeEntryData("Alice", 12, "PLAYER", maxHp = 20, currentHp = 20, ac = 1)
         )
 
-        val outcome = service.attack(guildId, dmDiscordId, "Alice", 5)
+        val outcome = service.attack(guildId, dmDiscordId, "Alice", 0)
         assertEquals(AttackResult.HIT, outcome.result)
         verify {
             sessionLog.publish(
@@ -1377,8 +1378,34 @@ class CampaignWebServiceTest {
                 actorName = any(),
                 payload = match {
                     it["attacker"] == "Goblin" && it["target"] == "Alice" &&
-                        it["modifier"] == 5 && it["targetAc"] == 10
+                        it["modifier"] == 0 && it["targetAc"] == 1
                 }
+            )
+        }
+    }
+
+    @Test
+    fun `attack misses when roll + mod is below AC and publishes ATTACK_MISS`() {
+        val campaign = makeCampaign()
+        every { campaignService.getActiveCampaignForGuild(guildId) } returns campaign
+        every { initiativeStore.isActive(guildId) } returns true
+        every { initiativeStore.currentEntry(guildId) } returns
+            InitiativeEntryData(name = "Goblin", roll = 18, kind = "MONSTER")
+        every { initiativeStore.currentEntries(guildId) } returns listOf(
+            InitiativeEntryData("Goblin", 18, "MONSTER"),
+            // AC 30 + mod 0 → max d20 roll (20) is below 30. Always miss.
+            InitiativeEntryData("Alice", 12, "PLAYER", maxHp = 20, currentHp = 20, ac = 30)
+        )
+
+        val outcome = service.attack(guildId, dmDiscordId, "Alice", 0)
+        assertEquals(AttackResult.MISS, outcome.result)
+        verify {
+            sessionLog.publish(
+                guildId = guildId,
+                type = common.events.CampaignEventType.ATTACK_MISS,
+                actorDiscordId = dmDiscordId,
+                actorName = any(),
+                payload = match { it["targetAc"] == 30 }
             )
         }
     }

--- a/common/src/main/kotlin/common/events/CampaignEventType.kt
+++ b/common/src/main/kotlin/common/events/CampaignEventType.kt
@@ -19,5 +19,9 @@ enum class CampaignEventType {
     CAMPAIGN_ENDED,
     DM_NOTE,
     HIT,
-    MISS
+    MISS,
+    ATTACK_HIT,
+    ATTACK_MISS,
+    DAMAGE_DEALT,
+    PARTICIPANT_DEFEATED
 }

--- a/discord-bot/src/main/kotlin/bot/toby/helpers/DndHelperInitiativeStore.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/helpers/DndHelperInitiativeStore.kt
@@ -17,18 +17,46 @@ class DndHelperInitiativeStore(
     override fun seed(guildId: Long, entries: List<InitiativeEntryData>) {
         dndHelper.seedInitiative(
             guildId,
-            entries.map { RolledEntry(name = it.name, roll = it.roll, kind = it.kind) }
+            entries.map {
+                RolledEntry(
+                    name = it.name,
+                    roll = it.roll,
+                    kind = it.kind,
+                    maxHp = it.maxHp,
+                    currentHp = it.currentHp,
+                    ac = it.ac,
+                    defeated = it.defeated
+                )
+            }
         )
     }
 
     override fun currentEntries(guildId: Long): List<InitiativeEntryData> =
-        dndHelper.stateFor(guildId).sortedEntries.map {
-            InitiativeEntryData(name = it.name, roll = it.roll, kind = it.kind)
-        }
+        dndHelper.stateFor(guildId).sortedEntries.map(::toData)
 
     override fun currentIndex(guildId: Long): Int =
         dndHelper.stateFor(guildId).initiativeIndex.get()
 
     override fun isActive(guildId: Long): Boolean =
         dndHelper.stateFor(guildId).isActive()
+
+    override fun applyDamage(guildId: Long, targetName: String, damage: Int): InitiativeEntryData? {
+        val state = dndHelper.stateFor(guildId)
+        if (!state.isActive()) return null
+        val existing = state.findByName(targetName) ?: return null
+        val newHp = existing.currentHp?.let { (it - damage).coerceAtLeast(0) }
+        val defeated = existing.defeated || (newHp != null && newHp <= 0)
+        state.updateEntry(targetName) { it.copy(currentHp = newHp, defeated = defeated) }
+        return toData(state.findByName(targetName) ?: return null)
+    }
+
+    private fun toData(entry: RolledEntry) = InitiativeEntryData(
+        name = entry.name,
+        roll = entry.roll,
+        kind = entry.kind,
+        maxHp = entry.maxHp,
+        currentHp = entry.currentHp,
+        ac = entry.ac,
+        defeated = entry.defeated
+    )
 }

--- a/discord-bot/src/main/kotlin/bot/toby/helpers/InitiativeState.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/helpers/InitiativeState.kt
@@ -72,23 +72,50 @@ class InitiativeState {
 
     fun snapshot(): InitiativeStateSnapshot = InitiativeStateSnapshot(
         initiativeIndex = initiativeIndex.get(),
-        entries = sortedEntries.map { InitiativeEntry(it.name, it.roll, it.kind) }
+        entries = sortedEntries.map {
+            InitiativeEntry(it.name, it.roll, it.kind, it.maxHp, it.currentHp, it.ac, it.defeated)
+        }
     )
 
     fun restoreFrom(snapshot: InitiativeStateSnapshot) {
         initiativeIndex.set(snapshot.initiativeIndex)
-        sortedEntries = LinkedList(snapshot.entries.map { RolledEntry(it.name, it.roll, it.kind) })
+        sortedEntries = LinkedList(snapshot.entries.map {
+            RolledEntry(it.name, it.roll, it.kind, it.maxHp, it.currentHp, it.ac, it.defeated)
+        })
     }
+
+    /**
+     * Mutate a single entry in-place. Used by the web combat endpoints to
+     * apply damage without replacing the whole state. No-op if name isn't
+     * present.
+     */
+    internal fun updateEntry(name: String, transform: (RolledEntry) -> RolledEntry) {
+        val idx = sortedEntries.indexOfFirst { it.name == name }
+        if (idx < 0) return
+        sortedEntries[idx] = transform(sortedEntries[idx])
+    }
+
+    internal fun findByName(name: String): RolledEntry? =
+        sortedEntries.firstOrNull { it.name == name }
+
+    internal val currentEntry: RolledEntry?
+        get() = sortedEntries.getOrNull(initiativeIndex.get())
 }
 
 /**
  * A single rolled initiative entry. [kind] is `"PLAYER"` or `"MONSTER"` when set
  * by the web composer; nullable so legacy Discord-originated rolls still work.
+ * HP + AC + defeated are populated during web combat; nullable for entries that
+ * never entered combat state (e.g. Discord voice-channel rolls).
  */
 data class RolledEntry(
     val name: String = "",
     val roll: Int = 0,
-    val kind: String? = null
+    val kind: String? = null,
+    val maxHp: Int? = null,
+    val currentHp: Int? = null,
+    val ac: Int? = null,
+    val defeated: Boolean = false
 )
 
 /** JSON-friendly snapshot of an [InitiativeState], persisted in CampaignDto.state. */
@@ -100,5 +127,9 @@ data class InitiativeStateSnapshot(
 data class InitiativeEntry(
     val name: String = "",
     val roll: Int = 0,
-    val kind: String? = null
+    val kind: String? = null,
+    val maxHp: Int? = null,
+    val currentHp: Int? = null,
+    val ac: Int? = null,
+    val defeated: Boolean = false
 )

--- a/discord-bot/src/test/kotlin/bot/toby/helpers/DnDHelperTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/helpers/DnDHelperTest.kt
@@ -312,6 +312,40 @@ internal class DnDHelperTest {
         Assertions.assertEquals("New", state.sortedEntries[0].name)
     }
 
+    @Test
+    fun testSeedInitiativeCarriesHpAcAndDefeated() {
+        dndHelper.seedInitiative(
+            guildId,
+            listOf(
+                RolledEntry("Goblin", 15, "MONSTER", maxHp = 7, currentHp = 7, ac = 15),
+                RolledEntry("Alice", 12, "PLAYER")
+            )
+        )
+        val state = dndHelper.stateFor(guildId)
+        Assertions.assertEquals(7, state.sortedEntries[0].maxHp)
+        Assertions.assertEquals(7, state.sortedEntries[0].currentHp)
+        Assertions.assertEquals(15, state.sortedEntries[0].ac)
+        Assertions.assertFalse(state.sortedEntries[0].defeated)
+        Assertions.assertNull(state.sortedEntries[1].maxHp)
+        Assertions.assertNull(state.sortedEntries[1].ac)
+    }
+
+    @Test
+    fun testSnapshotRoundTripsCombatFields() {
+        dndHelper.seedInitiative(
+            guildId,
+            listOf(RolledEntry("Goblin", 15, "MONSTER", maxHp = 7, currentHp = 3, ac = 15, defeated = false))
+        )
+        val snapshot = dndHelper.activeSnapshots().getValue(guildId)
+        dndHelper.clearInitiative(guildId)
+        dndHelper.restore(guildId, snapshot)
+
+        val restored = dndHelper.stateFor(guildId).sortedEntries[0]
+        Assertions.assertEquals(7, restored.maxHp)
+        Assertions.assertEquals(3, restored.currentHp)
+        Assertions.assertEquals(15, restored.ac)
+    }
+
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun testDoInitialLookupWithSpell() = runTest {

--- a/web/src/main/kotlin/web/controller/CampaignController.kt
+++ b/web/src/main/kotlin/web/controller/CampaignController.kt
@@ -12,6 +12,8 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes
 import web.service.AddNoteResult
 import web.service.AdhocMonster
 import web.service.AnnotateRollResult
+import web.service.ApplyDamageResult
+import web.service.AttackResult
 import web.service.CampaignEventBroadcaster
 import web.service.CampaignWebService
 import web.service.DeleteNoteResult
@@ -408,6 +410,8 @@ class CampaignController(
         @RequestParam(name = "templateQty", required = false) templateQtys: List<Int>?,
         @RequestParam(name = "adhocName", required = false) adhocNames: List<String>?,
         @RequestParam(name = "adhocMod", required = false) adhocMods: List<Int>?,
+        @RequestParam(name = "adhocHp", required = false) adhocHps: List<Int>?,
+        @RequestParam(name = "adhocAc", required = false) adhocAcs: List<Int>?,
         @AuthenticationPrincipal user: OAuth2User,
         ra: RedirectAttributes
     ): String {
@@ -423,10 +427,17 @@ class CampaignController(
 
         val names = adhocNames.orEmpty()
         val mods = adhocMods.orEmpty()
+        val hps = adhocHps.orEmpty()
+        val acs = adhocAcs.orEmpty()
         val adhoc = names.mapIndexedNotNull { i, n ->
             val cleaned = n.trim()
             if (cleaned.isBlank()) null
-            else AdhocMonster(cleaned, mods.getOrElse(i) { 0 })
+            else AdhocMonster(
+                name = cleaned,
+                initiativeModifier = mods.getOrElse(i) { 0 },
+                maxHp = hps.getOrNull(i)?.takeIf { it > 0 },
+                ac = acs.getOrNull(i)?.takeIf { it > 0 }
+            )
         }
         val request = InitiativeRollRequest(
             playerDiscordIds = playerDiscordIds.orEmpty(),
@@ -485,6 +496,65 @@ class CampaignController(
             RollDiceResult.INVALID_EXPRESSION -> ra.addFlashAttribute(
                 "error",
                 "Custom expression must look like '2d6+3' or 'd20-1'."
+            )
+        }
+        return "redirect:/dnd/campaign/$guildId"
+    }
+
+    @PostMapping("/campaign/{guildId}/combat/attack")
+    fun attack(
+        @PathVariable guildId: Long,
+        @RequestParam("targetName") targetName: String,
+        @RequestParam(name = "attackModifier", defaultValue = "0") attackModifier: Int,
+        @AuthenticationPrincipal user: OAuth2User,
+        ra: RedirectAttributes
+    ): String {
+        val discordId = user.discordIdOrNull()
+            ?: return "redirect:/dnd/campaign"
+
+        val outcome = campaignWebService.attack(guildId, discordId, targetName.trim(), attackModifier)
+        when (outcome.result) {
+            AttackResult.HIT, AttackResult.MISS -> {}
+            AttackResult.NO_ACTIVE_CAMPAIGN -> ra.addFlashAttribute("error", "No active campaign in this server.")
+            AttackResult.NO_ACTIVE_COMBAT -> ra.addFlashAttribute("error", "No active combat — roll initiative first.")
+            AttackResult.NOT_MY_TURN -> ra.addFlashAttribute(
+                "error",
+                "You can only attack on your own turn (or as the DM)."
+            )
+            AttackResult.TARGET_NOT_FOUND -> ra.addFlashAttribute("error", "That target isn't in the initiative order.")
+            AttackResult.TARGET_DEFEATED -> ra.addFlashAttribute("error", "That target is already defeated.")
+            AttackResult.CANT_TARGET_SELF -> ra.addFlashAttribute("error", "You can't attack yourself.")
+            AttackResult.INVALID_MODIFIER -> ra.addFlashAttribute(
+                "error",
+                "Attack modifier must be between -${web.service.CampaignWebService.MAX_ATTACK_MODIFIER} and ${web.service.CampaignWebService.MAX_ATTACK_MODIFIER}."
+            )
+        }
+        return "redirect:/dnd/campaign/$guildId"
+    }
+
+    @PostMapping("/campaign/{guildId}/combat/damage")
+    fun applyDamage(
+        @PathVariable guildId: Long,
+        @RequestParam("targetName") targetName: String,
+        @RequestParam("amount") amount: Int,
+        @AuthenticationPrincipal user: OAuth2User,
+        ra: RedirectAttributes
+    ): String {
+        val discordId = user.discordIdOrNull()
+            ?: return "redirect:/dnd/campaign"
+
+        when (campaignWebService.applyDamage(guildId, discordId, targetName.trim(), amount)) {
+            ApplyDamageResult.APPLIED, ApplyDamageResult.DEFEATED -> {}
+            ApplyDamageResult.NO_ACTIVE_CAMPAIGN -> ra.addFlashAttribute("error", "No active campaign in this server.")
+            ApplyDamageResult.NO_ACTIVE_COMBAT -> ra.addFlashAttribute("error", "No active combat — roll initiative first.")
+            ApplyDamageResult.NOT_ATTACKER -> ra.addFlashAttribute(
+                "error",
+                "You can only apply damage on your own turn (or as the DM)."
+            )
+            ApplyDamageResult.TARGET_NOT_FOUND -> ra.addFlashAttribute("error", "That target isn't in the initiative order.")
+            ApplyDamageResult.INVALID_AMOUNT -> ra.addFlashAttribute(
+                "error",
+                "Damage must be between 0 and ${web.service.CampaignWebService.MAX_DAMAGE_AMOUNT}."
             )
         }
         return "redirect:/dnd/campaign/$guildId"

--- a/web/src/main/kotlin/web/service/CampaignWebService.kt
+++ b/web/src/main/kotlin/web/service/CampaignWebService.kt
@@ -45,7 +45,11 @@ data class InitiativeStateView(
 data class RolledEntryView(
     val name: String,
     val roll: Int,
-    val kind: String?
+    val kind: String?,
+    val maxHp: Int? = null,
+    val currentHp: Int? = null,
+    val ac: Int? = null,
+    val defeated: Boolean = false
 )
 
 data class MonsterTemplateView(
@@ -56,7 +60,12 @@ data class MonsterTemplateView(
     val ac: Int?
 )
 
-data class AdhocMonster(val name: String, val initiativeModifier: Int)
+data class AdhocMonster(
+    val name: String,
+    val initiativeModifier: Int,
+    val maxHp: Int? = null,
+    val ac: Int? = null
+)
 
 data class InitiativeRollRequest(
     val playerDiscordIds: List<Long> = emptyList(),
@@ -122,6 +131,30 @@ enum class DeleteTemplateResult { DELETED, NOT_FOUND, NOT_OWNER }
 enum class RollInitiativeResult { ROLLED, NO_ACTIVE_CAMPAIGN, NOT_DM, EMPTY_ROSTER, TEMPLATE_NOT_FOUND }
 enum class RollDiceResult { ROLLED, NO_ACTIVE_CAMPAIGN, NOT_PARTICIPANT, INVALID_SIDES, INVALID_COUNT, INVALID_MODIFIER, INVALID_EXPRESSION }
 
+enum class AttackResult {
+    HIT, MISS,
+    NO_ACTIVE_CAMPAIGN, NO_ACTIVE_COMBAT, NOT_MY_TURN,
+    TARGET_NOT_FOUND, TARGET_DEFEATED, CANT_TARGET_SELF,
+    INVALID_MODIFIER
+}
+
+enum class ApplyDamageResult {
+    APPLIED, DEFEATED,
+    NO_ACTIVE_CAMPAIGN, NO_ACTIVE_COMBAT, NOT_ATTACKER,
+    TARGET_NOT_FOUND, INVALID_AMOUNT
+}
+
+data class AttackOutcome(
+    val result: AttackResult,
+    val attacker: String? = null,
+    val target: String? = null,
+    val rawRoll: Int? = null,
+    val modifier: Int? = null,
+    val total: Int? = null,
+    val targetAc: Int? = null,
+    val eventId: Long? = null
+)
+
 @Service
 class CampaignWebService(
     private val campaignService: CampaignService,
@@ -149,6 +182,8 @@ class CampaignWebService(
         const val MAX_TEMPLATE_NAME_LENGTH = 100
         const val MAX_DICE_COUNT = 20
         const val MAX_DICE_MODIFIER = 50
+        const val MAX_ATTACK_MODIFIER = 30
+        const val MAX_DAMAGE_AMOUNT = 1000
         val ALLOWED_DIE_SIDES = setOf(4, 6, 8, 10, 12, 20, 100)
         private val DICE_EXPR_REGEX = Regex("^(\\d*)d(\\d+)([+-]\\d+)?$", RegexOption.IGNORE_CASE)
     }
@@ -224,7 +259,15 @@ class CampaignWebService(
         val initiativeState = if (initiativeStore.isActive(guildId)) {
             InitiativeStateView(
                 entries = initiativeStore.currentEntries(guildId).map {
-                    RolledEntryView(it.name, it.roll, it.kind)
+                    RolledEntryView(
+                        name = it.name,
+                        roll = it.roll,
+                        kind = it.kind,
+                        maxHp = it.maxHp,
+                        currentHp = it.currentHp,
+                        ac = it.ac,
+                        defeated = it.defeated
+                    )
                 },
                 currentIndex = initiativeStore.currentIndex(guildId)
             )
@@ -664,7 +707,10 @@ class CampaignWebService(
                 name = template.name,
                 roll = rollD20() + template.initiativeModifier,
                 kind = "MONSTER",
-                modifier = template.initiativeModifier
+                modifier = template.initiativeModifier,
+                maxHp = template.maxHp,
+                currentHp = template.maxHp,
+                ac = template.ac
             )
         }
 
@@ -674,7 +720,10 @@ class CampaignWebService(
                 name = cleanName,
                 roll = rollD20() + monster.initiativeModifier,
                 kind = "MONSTER",
-                modifier = monster.initiativeModifier
+                modifier = monster.initiativeModifier,
+                maxHp = monster.maxHp,
+                currentHp = monster.maxHp,
+                ac = monster.ac
             )
         }
 
@@ -693,12 +742,139 @@ class CampaignWebService(
                         "name" to it.name,
                         "roll" to it.roll,
                         "kind" to it.kind,
-                        "modifier" to it.modifier
+                        "modifier" to it.modifier,
+                        "maxHp" to it.maxHp,
+                        "currentHp" to it.currentHp,
+                        "ac" to it.ac
                     )
                 }
             )
         )
         return RollInitiativeResult.ROLLED
+    }
+
+    /**
+     * Web combat attack. The requester must be the current-turn participant
+     * (matched by display name), or the DM acting on behalf of the current
+     * participant when the current entry is a MONSTER.
+     *
+     * Rolls 1d20 + [attackModifier] and compares against the target's AC.
+     * When AC is unknown the attack always publishes as HIT (DM adjudicates).
+     * Publishes ATTACK_HIT / ATTACK_MISS on the session log.
+     */
+    fun attack(
+        guildId: Long,
+        requestingDiscordId: Long,
+        targetName: String,
+        attackModifier: Int
+    ): AttackOutcome {
+        if (attackModifier !in -MAX_ATTACK_MODIFIER..MAX_ATTACK_MODIFIER) {
+            return AttackOutcome(result = AttackResult.INVALID_MODIFIER)
+        }
+        val campaign = campaignService.getActiveCampaignForGuild(guildId)
+            ?: return AttackOutcome(result = AttackResult.NO_ACTIVE_CAMPAIGN)
+        if (!initiativeStore.isActive(guildId)) {
+            return AttackOutcome(result = AttackResult.NO_ACTIVE_COMBAT)
+        }
+        val current = initiativeStore.currentEntry(guildId)
+            ?: return AttackOutcome(result = AttackResult.NO_ACTIVE_COMBAT)
+
+        val isDm = campaign.dmDiscordId == requestingDiscordId
+        val requesterName = resolveMemberName(guildId, requestingDiscordId)
+        val authorised = isDm || (current.kind == "PLAYER" && current.name == requesterName)
+        if (!authorised) return AttackOutcome(result = AttackResult.NOT_MY_TURN)
+
+        val target = initiativeStore.currentEntries(guildId).firstOrNull { it.name == targetName }
+            ?: return AttackOutcome(result = AttackResult.TARGET_NOT_FOUND)
+        if (target.name == current.name) {
+            return AttackOutcome(result = AttackResult.CANT_TARGET_SELF)
+        }
+        if (target.defeated) return AttackOutcome(result = AttackResult.TARGET_DEFEATED)
+
+        val raw = Random.nextInt(1, 21)
+        val total = raw + attackModifier
+        val hit = target.ac?.let { total >= it } ?: true
+        val type = if (hit) CampaignEventType.ATTACK_HIT else CampaignEventType.ATTACK_MISS
+
+        sessionLog.publish(
+            guildId = guildId,
+            type = type,
+            actorDiscordId = requestingDiscordId,
+            actorName = requesterName,
+            payload = mapOf(
+                "attacker" to current.name,
+                "target" to target.name,
+                "roll" to raw,
+                "modifier" to attackModifier,
+                "total" to total,
+                "targetAc" to target.ac
+            )
+        )
+        return AttackOutcome(
+            result = if (hit) AttackResult.HIT else AttackResult.MISS,
+            attacker = current.name,
+            target = target.name,
+            rawRoll = raw,
+            modifier = attackModifier,
+            total = total,
+            targetAc = target.ac
+        )
+    }
+
+    /**
+     * Applies integer [amount] of damage to the named target in the guild's
+     * combat tracker. Publishes DAMAGE_DEALT, and if the target's HP drops
+     * to 0 or below, also publishes PARTICIPANT_DEFEATED. The current-turn
+     * participant (or DM) may apply damage — we don't re-check target AC
+     * here since that's the role of [attack].
+     */
+    fun applyDamage(
+        guildId: Long,
+        requestingDiscordId: Long,
+        targetName: String,
+        amount: Int
+    ): ApplyDamageResult {
+        if (amount < 0 || amount > MAX_DAMAGE_AMOUNT) return ApplyDamageResult.INVALID_AMOUNT
+        val campaign = campaignService.getActiveCampaignForGuild(guildId)
+            ?: return ApplyDamageResult.NO_ACTIVE_CAMPAIGN
+        if (!initiativeStore.isActive(guildId)) return ApplyDamageResult.NO_ACTIVE_COMBAT
+        val current = initiativeStore.currentEntry(guildId)
+            ?: return ApplyDamageResult.NO_ACTIVE_COMBAT
+
+        val isDm = campaign.dmDiscordId == requestingDiscordId
+        val requesterName = resolveMemberName(guildId, requestingDiscordId)
+        val authorised = isDm || (current.kind == "PLAYER" && current.name == requesterName)
+        if (!authorised) return ApplyDamageResult.NOT_ATTACKER
+
+        val updated = initiativeStore.applyDamage(guildId, targetName, amount)
+            ?: return ApplyDamageResult.TARGET_NOT_FOUND
+
+        sessionLog.publish(
+            guildId = guildId,
+            type = CampaignEventType.DAMAGE_DEALT,
+            actorDiscordId = requestingDiscordId,
+            actorName = requesterName,
+            payload = mapOf(
+                "attacker" to current.name,
+                "target" to updated.name,
+                "amount" to amount,
+                "remainingHp" to updated.currentHp,
+                "maxHp" to updated.maxHp
+            )
+        )
+
+        return if (updated.defeated) {
+            sessionLog.publish(
+                guildId = guildId,
+                type = CampaignEventType.PARTICIPANT_DEFEATED,
+                actorDiscordId = requestingDiscordId,
+                actorName = requesterName,
+                payload = mapOf("target" to updated.name)
+            )
+            ApplyDamageResult.DEFEATED
+        } else {
+            ApplyDamageResult.APPLIED
+        }
     }
 
     /**

--- a/web/src/main/kotlin/web/service/InitiativeStore.kt
+++ b/web/src/main/kotlin/web/service/InitiativeStore.kt
@@ -21,6 +21,18 @@ interface InitiativeStore {
     fun currentIndex(guildId: Long): Int
 
     fun isActive(guildId: Long): Boolean
+
+    /** The entry whose turn it currently is, or null if no active tracker. */
+    fun currentEntry(guildId: Long): InitiativeEntryData? =
+        currentEntries(guildId).getOrNull(currentIndex(guildId))
+
+    /**
+     * Apply [damage] HP to the participant named [targetName] in [guildId]'s
+     * tracker. If the target's HP drops to 0 or below, mark them defeated.
+     * Returns the updated entry (with new currentHp / defeated state), or
+     * null when there's no active tracker or no participant with that name.
+     */
+    fun applyDamage(guildId: Long, targetName: String, damage: Int): InitiativeEntryData?
 }
 
 /**
@@ -31,5 +43,9 @@ data class InitiativeEntryData(
     val name: String,
     val roll: Int,
     val kind: String? = null,
-    val modifier: Int = 0
+    val modifier: Int = 0,
+    val maxHp: Int? = null,
+    val currentHp: Int? = null,
+    val ac: Int? = null,
+    val defeated: Boolean = false
 )

--- a/web/src/main/resources/static/js/sessionLog.js
+++ b/web/src/main/resources/static/js/sessionLog.js
@@ -91,6 +91,20 @@
                 return 'marked as HIT' + (p.target ? ' on ' + p.target : '');
             case 'MISS':
                 return 'marked as MISS' + (p.target ? ' on ' + p.target : '');
+            case 'ATTACK_HIT': {
+                const ac = (p.targetAc != null) ? ' vs AC ' + p.targetAc : '';
+                return (p.attacker || '?') + ' hits ' + (p.target || '?') + ' — ' + p.total + ac;
+            }
+            case 'ATTACK_MISS': {
+                const ac = (p.targetAc != null) ? ' vs AC ' + p.targetAc : '';
+                return (p.attacker || '?') + ' misses ' + (p.target || '?') + ' — ' + p.total + ac;
+            }
+            case 'DAMAGE_DEALT': {
+                const remaining = (p.remainingHp != null) ? ' (' + p.remainingHp + ' HP left)' : '';
+                return (p.target || '?') + ' takes ' + p.amount + ' damage' + remaining;
+            }
+            case 'PARTICIPANT_DEFEATED':
+                return (p.target || '?') + ' is defeated';
             default:
                 return escapeText(JSON.stringify(p));
         }
@@ -184,7 +198,11 @@
         if (turnEmpty) turnEmpty.style.display = 'none';
         entries.forEach(function (entry, i) {
             const li = document.createElement('li');
-            if (i === currentIndex) li.className = 'active';
+            const classes = [];
+            if (i === currentIndex) classes.push('active');
+            if (entry.defeated) classes.push('defeated');
+            if (classes.length) li.className = classes.join(' ');
+            li.dataset.name = entry.name || '';
             const idx = document.createElement('span');
             idx.className = 'idx';
             idx.textContent = (i + 1);
@@ -198,6 +216,38 @@
                 chip.className = 'chip ' + entry.kind.toLowerCase();
                 chip.textContent = entry.kind === 'PLAYER' ? 'Player' : 'Monster';
                 li.appendChild(chip);
+            }
+            if (entry.ac != null) {
+                const ac = document.createElement('span');
+                ac.className = 'ac-chip';
+                ac.textContent = 'AC ' + entry.ac;
+                li.appendChild(ac);
+            }
+            if (entry.maxHp != null) {
+                const wrap = document.createElement('span');
+                wrap.className = 'hp-wrap';
+                const bar = document.createElement('span');
+                bar.className = 'hp-bar';
+                const fill = document.createElement('span');
+                fill.className = 'hp-fill';
+                const hp = entry.currentHp == null ? entry.maxHp : entry.currentHp;
+                const pct = entry.maxHp > 0 ? Math.max(0, Math.min(100, (hp * 100) / entry.maxHp)) : 0;
+                if (pct < 15) fill.classList.add('low');
+                else if (pct < 40) fill.classList.add('mid');
+                fill.style.width = pct + '%';
+                bar.appendChild(fill);
+                wrap.appendChild(bar);
+                const label = document.createElement('span');
+                label.className = 'hp-label';
+                const cur = document.createElement('span');
+                cur.textContent = String(hp);
+                const max = document.createElement('span');
+                max.textContent = String(entry.maxHp);
+                label.appendChild(cur);
+                label.appendChild(document.createTextNode('/'));
+                label.appendChild(max);
+                wrap.appendChild(label);
+                li.appendChild(wrap);
             }
             li.appendChild(buildD20(entry.roll, animate));
             list.appendChild(li);
@@ -235,6 +285,47 @@
         turnTable.dataset.currentIndex = String(idx);
     }
 
+    function findRow(name) {
+        if (!turnTable || !name) return null;
+        const list = turnTable.querySelector('ol');
+        if (!list) return null;
+        return list.querySelector('li[data-name="' + String(name).replace(/"/g, '\\"') + '"]');
+    }
+
+    function flashRow(name, cls) {
+        const row = findRow(name);
+        if (!row) return;
+        row.classList.remove('just-hit', 'just-missed');
+        // reflow so the animation re-triggers
+        void row.offsetWidth;
+        row.classList.add(cls);
+    }
+
+    function applyDamageToRow(name, remainingHp) {
+        const row = findRow(name);
+        if (!row) return;
+        const fill = row.querySelector('.hp-fill');
+        const label = row.querySelector('.hp-label span:first-child');
+        if (!fill || !row.querySelector('.hp-wrap')) return;
+        const maxSpan = row.querySelectorAll('.hp-label span')[1];
+        const max = maxSpan ? parseInt(maxSpan.textContent, 10) : 0;
+        const hp = Math.max(0, remainingHp == null ? 0 : remainingHp);
+        if (label) label.textContent = String(hp);
+        if (max > 0) {
+            const pct = Math.max(0, Math.min(100, (hp * 100) / max));
+            fill.style.width = pct + '%';
+            fill.classList.remove('low', 'mid');
+            if (pct < 15) fill.classList.add('low');
+            else if (pct < 40) fill.classList.add('mid');
+        }
+    }
+
+    function markDefeatedRow(name) {
+        const row = findRow(name);
+        if (!row) return;
+        row.classList.add('defeated');
+    }
+
     function handleInitiativeEvent(event) {
         if (!turnTable) return;
         const p = event.payload || {};
@@ -254,6 +345,18 @@
                 rebuildTurnTable([], 0);
                 break;
             }
+            case 'ATTACK_HIT':
+                flashRow(p.target, 'just-hit');
+                break;
+            case 'ATTACK_MISS':
+                flashRow(p.target, 'just-missed');
+                break;
+            case 'DAMAGE_DEALT':
+                applyDamageToRow(p.target, p.remainingHp);
+                break;
+            case 'PARTICIPANT_DEFEATED':
+                markDefeatedRow(p.target);
+                break;
         }
     }
 

--- a/web/src/main/resources/templates/campaignDetail.html
+++ b/web/src/main/resources/templates/campaignDetail.html
@@ -558,6 +558,109 @@
             .turn-table .d20.rolling .d20__face { animation: none; opacity: 1; }
         }
 
+        /* ---- Combat HUD ---- */
+        .turn-table .hp-wrap {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            min-width: 120px;
+            font-family: monospace;
+            font-size: 0.75rem;
+            color: #c0c0d0;
+        }
+        .turn-table .hp-bar {
+            position: relative;
+            flex: 1;
+            height: 8px;
+            border-radius: 4px;
+            background: #0f1530;
+            border: 1px solid #2a3460;
+            overflow: hidden;
+            min-width: 60px;
+        }
+        .turn-table .hp-fill {
+            position: absolute;
+            inset: 0 auto 0 0;
+            background: linear-gradient(90deg, #2ecc71, #1aa85a);
+            transition: width 0.4s ease-out, background 0.2s;
+        }
+        .turn-table .hp-fill.mid { background: linear-gradient(90deg, #f39c12, #c9801f); }
+        .turn-table .hp-fill.low { background: linear-gradient(90deg, #e74c3c, #a5321a); }
+        .turn-table .ac-chip {
+            display: inline-flex;
+            align-items: center;
+            gap: 3px;
+            font-size: 0.7rem;
+            padding: 2px 6px;
+            border-radius: 10px;
+            background: rgba(88,101,242,0.12);
+            border: 1px solid rgba(88,101,242,0.35);
+            color: #8b97ff;
+            font-family: monospace;
+        }
+        .turn-table li.defeated {
+            opacity: 0.5;
+        }
+        .turn-table li.defeated .name {
+            text-decoration: line-through;
+            color: #8a8aa0;
+        }
+        .turn-table li.just-hit { animation: combat-hit-flash 420ms ease-out; }
+        .turn-table li.just-missed { animation: combat-miss-flash 420ms ease-out; }
+        @keyframes combat-hit-flash {
+            0%   { box-shadow: 0 0 0 0 rgba(231,76,60,0); }
+            30%  { box-shadow: 0 0 0 3px rgba(231,76,60,0.45); background: rgba(231,76,60,0.12); }
+            100% { box-shadow: 0 0 0 0 rgba(231,76,60,0); }
+        }
+        @keyframes combat-miss-flash {
+            0%   { box-shadow: 0 0 0 0 rgba(160,160,176,0); }
+            30%  { box-shadow: 0 0 0 3px rgba(160,160,176,0.45); background: rgba(160,160,176,0.08); }
+            100% { box-shadow: 0 0 0 0 rgba(160,160,176,0); }
+        }
+
+        .combat-panel {
+            margin-top: 10px;
+            padding: 10px 12px;
+            background: rgba(88,101,242,0.08);
+            border: 1px solid rgba(88,101,242,0.35);
+            border-radius: 8px;
+            display: flex;
+            flex-direction: column;
+            gap: 8px;
+        }
+        .combat-panel .row {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px;
+            align-items: center;
+        }
+        .combat-panel label {
+            font-size: 0.75rem;
+            color: #a0a0b0;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            margin: 0;
+        }
+        .combat-panel select, .combat-panel input[type=number] {
+            background: #1a1a2e;
+            border: 1px solid #2a3460;
+            color: #e0e0e0;
+            padding: 6px 8px;
+            border-radius: 6px;
+            font-size: 0.85rem;
+        }
+        .combat-panel select { flex: 1; min-width: 160px; }
+        .combat-panel input[type=number] { width: 70px; }
+        .combat-panel .spacer { flex: 1; }
+        .combat-panel form { display: contents; }
+        .combat-panel .title {
+            font-size: 0.75rem;
+            color: #8b97ff;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.06em;
+        }
+
         .dice-roller { position: relative; }
         .dice-popover {
             display: none;
@@ -737,6 +840,14 @@
             /* Turn-table rows wrap long names */
             .turn-table li { flex-wrap: wrap; row-gap: 4px; }
             .turn-table .name { min-width: 0; flex: 1 1 auto; }
+            .turn-table .hp-wrap { flex-basis: 100%; min-width: 0; }
+
+            /* Combat panel stacks vertically on narrow screens */
+            .combat-panel { padding: 10px; }
+            .combat-panel .row { flex-direction: column; align-items: stretch; gap: 6px; }
+            .combat-panel select { min-width: 0; width: 100%; }
+            .combat-panel input[type=number] { width: 100%; }
+            .combat-panel label { margin-top: 4px; }
         }
     </style>
 </head>
@@ -1008,10 +1119,14 @@
                     <div class="row">
                         <input type="text" name="adhocName" placeholder="Ad-hoc monster name (optional)" maxlength="100">
                         <input type="number" name="adhocMod" placeholder="init" value="0">
+                        <input type="number" name="adhocHp" placeholder="HP" min="0" max="1000">
+                        <input type="number" name="adhocAc" placeholder="AC" min="0" max="50">
                     </div>
                     <div class="row">
                         <input type="text" name="adhocName" placeholder="Ad-hoc monster name (optional)" maxlength="100">
                         <input type="number" name="adhocMod" placeholder="init" value="0">
+                        <input type="number" name="adhocHp" placeholder="HP" min="0" max="1000">
+                        <input type="number" name="adhocAc" placeholder="AC" min="0" max="50">
                     </div>
                 </div>
                 <div style="margin-top:12px;display:flex;justify-content:flex-end;">
@@ -1026,14 +1141,53 @@
             <div class="title" style="font-weight:600;color:#e0e0e0;">Turn order</div>
             <ol id="turn-table-list" th:if="${initiativeState != null and not #lists.isEmpty(initiativeState.entries)}">
                 <li th:each="entry, iter : ${initiativeState.entries}"
-                    th:classappend="${iter.index == initiativeState.currentIndex ? 'active' : ''}">
+                    th:classappend="${(iter.index == initiativeState.currentIndex ? 'active ' : '') + (entry.defeated ? 'defeated' : '')}"
+                    th:attr="data-name=${entry.name}">
                     <span class="idx" th:text="${iter.index + 1}">1</span>
                     <span class="name" th:text="${entry.name}">Name</span>
                     <span th:if="${entry.kind == 'PLAYER'}" class="chip player">Player</span>
                     <span th:if="${entry.kind == 'MONSTER'}" class="chip monster">Monster</span>
+                    <span th:if="${entry.ac != null}" class="ac-chip">AC <span th:text="${entry.ac}">15</span></span>
+                    <span class="hp-wrap" th:if="${entry.maxHp != null}">
+                        <span class="hp-bar">
+                            <span class="hp-fill"
+                                  th:classappend="${entry.maxHp > 0 and entry.currentHp != null and (entry.currentHp * 100 / entry.maxHp) &lt; 15 ? 'low' : (entry.maxHp > 0 and entry.currentHp != null and (entry.currentHp * 100 / entry.maxHp) &lt; 40 ? 'mid' : '')}"
+                                  th:style="${'width:' + (entry.maxHp > 0 and entry.currentHp != null ? ((entry.currentHp * 100) / entry.maxHp) : 0) + '%;'}"></span>
+                        </span>
+                        <span class="hp-label">
+                            <span th:text="${entry.currentHp != null ? entry.currentHp : '?'}">7</span>/<span th:text="${entry.maxHp}">7</span>
+                        </span>
+                    </span>
                     <span class="d20" th:attr="data-roll=${entry.roll}">
                         <span class="d20__face" th:text="${entry.roll}">15</span>
                     </span>
+                    <div th:if="${iter.index == initiativeState.currentIndex and (isUserDm or (entry.kind == 'PLAYER' and isUserPlayer))}"
+                         class="combat-panel" th:attr="data-attacker=${entry.name}">
+                        <span class="title">Attack · <span th:text="${entry.name}">Actor</span></span>
+                        <form th:action="@{/dnd/campaign/{id}/combat/attack(id=${guildId})}" method="post" class="row">
+                            <label>Target</label>
+                            <select name="targetName" required>
+                                <option th:each="t : ${initiativeState.entries}"
+                                        th:if="${t.name != entry.name and not t.defeated}"
+                                        th:value="${t.name}"
+                                        th:text="${t.name + (t.ac != null ? ' (AC ' + t.ac + ')' : '')}">Target</option>
+                            </select>
+                            <label>Mod</label>
+                            <input type="number" name="attackModifier" value="0" min="-30" max="30">
+                            <button type="submit" class="btn btn-primary btn-sm">🎯 Attack</button>
+                        </form>
+                        <form th:action="@{/dnd/campaign/{id}/combat/damage(id=${guildId})}" method="post" class="row">
+                            <label>Damage</label>
+                            <select name="targetName" required>
+                                <option th:each="t : ${initiativeState.entries}"
+                                        th:if="${t.name != entry.name and not t.defeated}"
+                                        th:value="${t.name}"
+                                        th:text="${t.name}">Target</option>
+                            </select>
+                            <input type="number" name="amount" value="1" min="0" max="1000" required>
+                            <button type="submit" class="btn btn-secondary btn-sm">💥 Apply</button>
+                        </form>
+                    </div>
                 </li>
             </ol>
             <div id="turn-table-empty" class="empty"
@@ -1133,6 +1287,25 @@
                           th:text="${event.payload['target'] != null
                                     ? 'marked MISS on ' + event.payload['target']
                                     : 'marked MISS'}">marked MISS</span>
+                    <span th:case="'ATTACK_HIT'"
+                          th:text="${event.payload['attacker'] + ' hits ' + event.payload['target'] +
+                                    ' — ' + event.payload['total'] +
+                                    (event.payload['targetAc'] != null ? ' vs AC ' + event.payload['targetAc'] : '')}">
+                        hits Target — 18 vs AC 15
+                    </span>
+                    <span th:case="'ATTACK_MISS'"
+                          th:text="${event.payload['attacker'] + ' misses ' + event.payload['target'] +
+                                    ' — ' + event.payload['total'] +
+                                    (event.payload['targetAc'] != null ? ' vs AC ' + event.payload['targetAc'] : '')}">
+                        misses Target — 7 vs AC 15
+                    </span>
+                    <span th:case="'DAMAGE_DEALT'"
+                          th:text="${event.payload['target'] + ' takes ' + event.payload['amount'] + ' damage' +
+                                    (event.payload['remainingHp'] != null ? ' (' + event.payload['remainingHp'] + ' HP left)' : '')}">
+                        Target takes 6 damage (1 HP left)
+                    </span>
+                    <span th:case="'PARTICIPANT_DEFEATED'"
+                          th:text="${event.payload['target'] + ' is defeated'}">Target is defeated</span>
                     <span th:case="*" th:text="${event.payload}">raw payload</span>
                 </span>
                 <span class="event-time"


### PR DESCRIPTION
## Summary

Turns the existing turn-table into a **combat HUD** on the campaign page. Each participant row now shows an **AC chip** (when known) and a live **HP bar**. The current-turn row inlines an **Attack panel** with a target dropdown, attack-modifier input, and a damage form — only visible to the participant whose turn it is (or the DM). Every attack fans out over SSE so spectator tabs see the d20 land, the HP bar tick down, and the target dim when defeated.

Inspired by BG3's action-bar loop, scoped to one reviewable PR.

## What's new

### Data model

- `RolledEntry` / `InitiativeEntry` / `InitiativeStateSnapshot` gain nullable `maxHp` / `currentHp` / `ac` + a `defeated` flag. Snapshot round-trips them so state survives dyno restarts.
- `InitiativeState` gets `updateEntry` / `findByName` / `currentEntry` helpers so the web endpoints can mutate HP in place.
- `InitiativeStore.applyDamage(guildId, target, amount)` — new contract method; `DndHelperInitiativeStore` implements it against the state.
- `CampaignWebService.rollInitiative` seeds HP/AC from `MonsterTemplate` for templated monsters and accepts optional per-row HP/AC on ad-hoc monsters. The `INITIATIVE_ROLLED` payload now carries the new fields so spectator tabs rebuild HP bars live.

### Endpoints

- `POST /dnd/campaign/{guildId}/combat/attack` — rolls `1d20 + attackModifier`, compares to target AC (always hits when AC unknown), publishes `ATTACK_HIT` / `ATTACK_MISS` with `attacker, target, roll, modifier, total, targetAc`. Requester must be the current-turn participant by display name, or the DM. Rejects self-targeting / defeated targets / out-of-range modifiers.
- `POST /dnd/campaign/{guildId}/combat/damage` — subtracts an integer `amount` from target HP via `InitiativeStore.applyDamage`; publishes `DAMAGE_DEALT`, and `PARTICIPANT_DEFEATED` when HP reaches 0.

Four new `CampaignEventType` values (`ATTACK_HIT`, `ATTACK_MISS`, `DAMAGE_DEALT`, `PARTICIPANT_DEFEATED`) flow through the existing `SessionLogPublisher` → `CampaignEventListener` → SSE pipeline. No new infra.

### UI

- AC chip next to the Player/Monster chip.
- HP bar: green → amber (< 40 %) → red (< 15 %); strikes through + dims the row on defeat.
- Current-turn row expands with an Attack form (target `<select>`, attack-mod input, "🎯 Attack" submit) and a Damage form (target + amount + "💥 Apply"). Scoped to DM or current participant.
- `sessionLog.js` gets four new renderers + DOM helpers that flash hit/miss rows, tick HP bars down live, and mark the defeated row across all viewers.
- Mobile: inside the existing `@media (max-width: 480px)` block, the combat panel stacks vertically with full-width selects/inputs.
- Server-rendered session-log switch cases for each new type so page reload renders identically.

### Tests

- `DnDHelperTest` — HP/AC/defeated round-trip through snapshot + seed.
- `CampaignWebServiceTest` — `attack` hit/miss paths (with + without AC), self-targeting, defeated target, invalid modifier, not-my-turn. `applyDamage` APPLIED / DEFEATED / invalid / target missing.
- `CampaignControllerTest` — redirects + flash errors for both new endpoints; `adhocHps` / `adhocAcs` threaded through existing `rollInitiative` tests.

## Non-goals (deferred to follow-up)

- Dice-expression damage (e.g. `1d8+3`) — integer only for now.
- Parsing AC / attack bonus from the linked D&D Beyond character sheet.
- Healing / revive actions.
- Conditions (prone, poisoned, etc.) and reactions.
- "Cinematic" full-screen combat mode — this enhances the existing turn table rather than replacing it.

## Test plan

- [ ] CI green, including `verifyMigrationsInBootJar` (no schema changes).
- [ ] DM composes an encounter with a Goblin (HP 7 / AC 15) + player, rolls initiative.
- [ ] Current-turn row shows Attack panel. Pick target, +5 mod, roll → `ATTACK_HIT` / `ATTACK_MISS` appears in session log with `roll+mod vs AC 15`.
- [ ] Apply 6 damage → HP bar ticks 7 → 1 on this tab AND on a second viewer tab.
- [ ] Apply 2 more damage → Goblin dims, `PARTICIPANT_DEFEATED` renders, no longer in target dropdown.
- [ ] Reload the page → state survives, HP bars + defeated state intact.
- [ ] Mobile (iPhone SE): combat panel stacks, selects full-width.
- [ ] Discord `/initiative` still works unchanged (legacy path, kind = null, HP/AC absent).

https://claude.ai/code/session_01DgKBYeiGaxmLg5xaPasU4r