### PR TITLE
feat(dnd): cinematic combat animations — flying d20, damage floater, skull

### DIFF
--- a/web/src/main/resources/static/css/combat.css
+++ b/web/src/main/resources/static/css/combat.css
@@ -1,0 +1,177 @@
+/* ============================================================
+   Combat cinematic — flying d20, damage floaters, defeat glyph
+   Driven from sessionLog.js on ATTACK_HIT / ATTACK_MISS /
+   DAMAGE_DEALT / PARTICIPANT_DEFEATED events. All overlay
+   elements live in #combat-stage which is fixed to the viewport
+   and pointer-events:none so they never eat clicks.
+   ============================================================ */
+
+#combat-stage {
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+    overflow: hidden;
+    z-index: 90;
+}
+
+.attack-die {
+    --duration: 700ms;
+    --start-x: 0px;
+    --start-y: 0px;
+    --end-x: 0px;
+    --end-y: 0px;
+    --face-color: #fff;
+    position: absolute;
+    left: var(--start-x);
+    top: var(--start-y);
+    width: 44px;
+    height: 44px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 8px;
+    background: linear-gradient(135deg, #5865F2, #2e3a5c);
+    border: 1px solid #5865F2;
+    color: var(--face-color);
+    font-family: monospace;
+    font-weight: 800;
+    font-size: 1.05rem;
+    box-shadow: 0 6px 24px rgba(0, 0, 0, 0.45), 0 0 18px rgba(88, 101, 242, 0.55);
+    transform: translate(0, 0) rotate3d(1, 1, 0.5, 0deg) scale(0.65);
+    opacity: 0;
+    animation: attack-die-flight var(--duration) cubic-bezier(.2, .7, .3, 1) forwards;
+}
+.attack-die__face {
+    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.6);
+}
+
+@keyframes attack-die-flight {
+    0%   { transform: translate(0, 0) rotate3d(1, 1, 0.5, 0deg) scale(0.7); opacity: 0; }
+    10%  { opacity: 1; }
+    50%  { transform: translate(calc((var(--end-x) - var(--start-x)) * 0.5), calc((var(--end-y) - var(--start-y)) * 0.5 - 60px)) rotate3d(1, 1, 0.5, 540deg) scale(1); }
+    100% { transform: translate(calc(var(--end-x) - var(--start-x)), calc(var(--end-y) - var(--start-y))) rotate3d(1, 1, 0.5, 1080deg) scale(1.15); opacity: 1; }
+}
+
+.attack-die.settling {
+    animation: attack-die-settle 380ms ease-out forwards;
+}
+@keyframes attack-die-settle {
+    0%   { transform: translate(calc(var(--end-x) - var(--start-x)), calc(var(--end-y) - var(--start-y))) rotate(0deg) scale(1.4); }
+    60%  { transform: translate(calc(var(--end-x) - var(--start-x)), calc(var(--end-y) - var(--start-y))) rotate(0deg) scale(0.9); }
+    100% { transform: translate(calc(var(--end-x) - var(--start-x)), calc(var(--end-y) - var(--start-y))) rotate(0deg) scale(1.05); }
+}
+.attack-die.fading {
+    transition: opacity 320ms ease-out, transform 320ms ease-out;
+    opacity: 0;
+    transform: translate(calc(var(--end-x) - var(--start-x)), calc(var(--end-y) - var(--start-y) - 30px)) scale(0.85);
+}
+
+.attack-die.hit {
+    background: linear-gradient(135deg, #e74c3c, #7a2218);
+    border-color: #e74c3c;
+    box-shadow: 0 6px 24px rgba(0, 0, 0, 0.45), 0 0 26px rgba(231, 76, 60, 0.7);
+}
+.attack-die.miss {
+    background: linear-gradient(135deg, #6a6a80, #2a2a3a);
+    border-color: #6a6a80;
+    box-shadow: 0 6px 24px rgba(0, 0, 0, 0.45), 0 0 18px rgba(160, 160, 176, 0.45);
+    --face-color: #d0d0d8;
+}
+.attack-die.crit {
+    background: linear-gradient(135deg, #f1c40f, #b8860b);
+    border-color: #f1c40f;
+    box-shadow: 0 6px 24px rgba(0, 0, 0, 0.5), 0 0 36px rgba(241, 196, 15, 0.85);
+    animation-name: attack-die-flight, crit-shake;
+    animation-duration: var(--duration), 360ms;
+    animation-delay: 0s, var(--duration);
+    animation-iteration-count: 1, 2;
+}
+.attack-die.fumble {
+    background: linear-gradient(135deg, #c0392b, #5a1a14);
+    border-color: #c0392b;
+    box-shadow: 0 6px 24px rgba(0, 0, 0, 0.5), 0 0 36px rgba(192, 57, 43, 0.8);
+}
+.attack-die.fumble.fading {
+    transform: translate(calc(var(--end-x) - var(--start-x)), calc(var(--end-y) - var(--start-y))) scale(0) rotate(45deg);
+    opacity: 0;
+}
+@keyframes crit-shake {
+    0%, 100% { translate: 0 0; }
+    25%      { translate: -3px 1px; }
+    75%      { translate: 3px -1px; }
+}
+
+.damage-floater {
+    --start-x: 0px;
+    --start-y: 0px;
+    position: absolute;
+    left: var(--start-x);
+    top: var(--start-y);
+    font-family: monospace;
+    font-weight: 800;
+    font-size: 1.4rem;
+    color: #ff6b5b;
+    text-shadow: 0 2px 6px rgba(0, 0, 0, 0.7), 0 0 12px rgba(231, 76, 60, 0.55);
+    pointer-events: none;
+    animation: damage-float 900ms cubic-bezier(.2, .8, .2, 1) forwards;
+    transform: translate(-50%, 0);
+}
+@keyframes damage-float {
+    0%   { opacity: 0; transform: translate(-50%, 4px) scale(0.7); }
+    15%  { opacity: 1; transform: translate(-50%, -4px) scale(1.15); }
+    100% { opacity: 0; transform: translate(-50%, -48px) scale(1); }
+}
+
+.defeat-skull {
+    position: absolute;
+    left: var(--start-x);
+    top: var(--start-y);
+    font-size: 2.4rem;
+    pointer-events: none;
+    animation: defeat-skull 1100ms ease-out forwards;
+    transform: translate(-50%, -50%) scale(0.4) rotate(-15deg);
+    opacity: 0;
+    filter: drop-shadow(0 0 8px rgba(231, 76, 60, 0.6));
+}
+@keyframes defeat-skull {
+    0%   { opacity: 0; transform: translate(-50%, -50%) scale(0.4) rotate(-15deg); }
+    25%  { opacity: 1; transform: translate(-50%, -50%) scale(1.4) rotate(0deg); }
+    70%  { opacity: 1; transform: translate(-50%, -50%) scale(1.1) rotate(0deg); }
+    100% { opacity: 0; transform: translate(-50%, -64px) scale(1) rotate(8deg); }
+}
+
+@media (max-width: 480px) {
+    .attack-die {
+        width: 32px;
+        height: 32px;
+        font-size: 0.85rem;
+        --duration: 500ms;
+    }
+    /* Mobile: 2D spin only — much cheaper on mid-range Android. */
+    @keyframes attack-die-flight {
+        0%   { transform: translate(0, 0) rotate(0deg) scale(0.7); opacity: 0; }
+        10%  { opacity: 1; }
+        50%  { transform: translate(calc((var(--end-x) - var(--start-x)) * 0.5), calc((var(--end-y) - var(--start-y)) * 0.5 - 36px)) rotate(360deg) scale(1); }
+        100% { transform: translate(calc(var(--end-x) - var(--start-x)), calc(var(--end-y) - var(--start-y))) rotate(720deg) scale(1.1); opacity: 1; }
+    }
+    .damage-floater { font-size: 1.15rem; }
+    .defeat-skull { font-size: 2rem; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .attack-die,
+    .attack-die.settling,
+    .attack-die.fading,
+    .damage-floater,
+    .defeat-skull {
+        animation: none;
+        transition: opacity 200ms ease-out;
+    }
+    .attack-die {
+        opacity: 1;
+        transform: translate(calc(var(--end-x) - var(--start-x)), calc(var(--end-y) - var(--start-y))) scale(1);
+    }
+    .attack-die.crit { animation: none; }
+    .damage-floater { opacity: 1; transform: translate(-50%, -20px); }
+    .defeat-skull { opacity: 1; transform: translate(-50%, -50%) scale(1); }
+}

--- a/web/src/main/resources/static/js/sessionLog.js
+++ b/web/src/main/resources/static/js/sessionLog.js
@@ -326,6 +326,84 @@
         row.classList.add('defeated');
     }
 
+    // ---- Combat cinematic ----------------------------------------------
+    function getCombatStage() {
+        let stage = document.getElementById('combat-stage');
+        if (stage) return stage;
+        stage = document.createElement('div');
+        stage.id = 'combat-stage';
+        document.body.appendChild(stage);
+        return stage;
+    }
+
+    function rowCenter(name) {
+        const row = findRow(name);
+        if (!row) return null;
+        const r = row.getBoundingClientRect();
+        return { x: r.left + r.width / 2, y: r.top + r.height / 2 };
+    }
+
+    function spawnAttackDie(payload) {
+        const start = rowCenter(payload.attacker);
+        const end = rowCenter(payload.target);
+        if (!start || !end) return;
+        const stage = getCombatStage();
+        const die = document.createElement('div');
+        die.className = 'attack-die';
+        const isHit = (payload.result === 'HIT') || (payload.eventType === 'ATTACK_HIT');
+        const isCrit = payload.roll === 20;
+        const isFumble = payload.roll === 1;
+        if (isCrit) die.classList.add('crit');
+        else if (isFumble) die.classList.add('fumble');
+        if (isHit) die.classList.add('hit');
+        else die.classList.add('miss');
+        die.style.setProperty('--start-x', start.x + 'px');
+        die.style.setProperty('--start-y', start.y + 'px');
+        die.style.setProperty('--end-x', end.x + 'px');
+        die.style.setProperty('--end-y', end.y + 'px');
+        const face = document.createElement('span');
+        face.className = 'attack-die__face';
+        face.textContent = String(payload.total != null ? payload.total : '?');
+        die.appendChild(face);
+        stage.appendChild(die);
+
+        die.addEventListener('animationend', function onFlight(ev) {
+            if (ev.animationName !== 'attack-die-flight') return;
+            die.removeEventListener('animationend', onFlight);
+            die.classList.add('settling');
+            setTimeout(function () {
+                die.classList.add('fading');
+                setTimeout(function () { die.remove(); }, 350);
+            }, 700);
+        });
+    }
+
+    function spawnDamageFloater(payload) {
+        const center = rowCenter(payload.target);
+        if (!center) return;
+        const stage = getCombatStage();
+        const el = document.createElement('div');
+        el.className = 'damage-floater';
+        el.style.setProperty('--start-x', center.x + 'px');
+        el.style.setProperty('--start-y', (center.y - 8) + 'px');
+        el.textContent = '-' + (payload.amount != null ? payload.amount : '?');
+        stage.appendChild(el);
+        setTimeout(function () { el.remove(); }, 1000);
+    }
+
+    function spawnDefeatSkull(payload) {
+        const center = rowCenter(payload.target);
+        if (!center) return;
+        const stage = getCombatStage();
+        const el = document.createElement('div');
+        el.className = 'defeat-skull';
+        el.style.setProperty('--start-x', center.x + 'px');
+        el.style.setProperty('--start-y', center.y + 'px');
+        el.textContent = '☠️';
+        stage.appendChild(el);
+        setTimeout(function () { el.remove(); }, 1200);
+    }
+
     function handleInitiativeEvent(event) {
         if (!turnTable) return;
         const p = event.payload || {};
@@ -346,15 +424,19 @@
                 break;
             }
             case 'ATTACK_HIT':
-                flashRow(p.target, 'just-hit');
+                spawnAttackDie({ ...p, eventType: 'ATTACK_HIT' });
+                setTimeout(function () { flashRow(p.target, 'just-hit'); }, 600);
                 break;
             case 'ATTACK_MISS':
-                flashRow(p.target, 'just-missed');
+                spawnAttackDie({ ...p, eventType: 'ATTACK_MISS' });
+                setTimeout(function () { flashRow(p.target, 'just-missed'); }, 600);
                 break;
             case 'DAMAGE_DEALT':
+                spawnDamageFloater(p);
                 applyDamageToRow(p.target, p.remainingHp);
                 break;
             case 'PARTICIPANT_DEFEATED':
+                spawnDefeatSkull(p);
                 markDefeatedRow(p.target);
                 break;
         }

--- a/web/src/main/resources/templates/campaignDetail.html
+++ b/web/src/main/resources/templates/campaignDetail.html
@@ -7,6 +7,7 @@
     <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
     <link rel="stylesheet" th:href="@{/css/base.css}">
     <link rel="stylesheet" th:href="@{/css/nav.css}">
+    <link rel="stylesheet" th:href="@{/css/combat.css}">
     <style>
         * { box-sizing: border-box; margin: 0; padding: 0; }
         body {


### PR DESCRIPTION
## Summary

Adds the cinematic layer on top of the combat HUD that landed in #245. Every `ATTACK_HIT` / `ATTACK_MISS` now spawns a tumbling **d20 that flies from the attacker's row to the target's row**, lands on the rolled total, then fades out. `DAMAGE_DEALT` pops a red `-N` floater up from the target. `PARTICIPANT_DEFEATED` puts a skull glyph on the target before the row dims.

Critical hits (raw 20) get a **golden glow + shake**; natural ones (raw 1) get the fumble palette and shatter on settle.

Pure client-side — no server / payload changes, fed by the SSE events #245 already publishes.

## Files

| Path | Change |
|------|--------|
| `web/src/main/resources/static/css/combat.css` | **new** — `#combat-stage` overlay + keyframes (`attack-die-flight`, `attack-die-settle`, `crit-shake`, `damage-float`, `defeat-skull`) |
| `web/src/main/resources/static/js/sessionLog.js` | adds `spawnAttackDie` / `spawnDamageFloater` / `spawnDefeatSkull`; wires them into the existing `handleInitiativeEvent` switch for the four combat event types |
| `web/src/main/resources/templates/campaignDetail.html` | one new `<link rel="stylesheet" th:href="@{/css/combat.css}">` |

## Mobile

Inside `@media (max-width: 480px)`:
- d20 shrinks to 32px (vs 44px desktop)
- 3D `rotate3d` swapped for a cheap 2D `rotate` — much kinder to mid-range Android GPUs
- Durations drop to 500ms (vs 700ms)
- Damage floater + skull glyph shrink

Same emotional beat (you see the die, you see the result), lighter cost.

## Reduced motion

`@media (prefers-reduced-motion: reduce)` strips every cinematic animation; elements just settle into their end state with a brief opacity fade.

## Test plan

- [ ] CI green (CSS + JS only, no Kotlin).
- [ ] DM with Goblin (HP 7, AC 15) + player. Roll initiative.
- [ ] On Goblin's turn → attack the player → die tumbles from Goblin's row to player's row, lands on the total, briefly flashes the player's row.
- [ ] Apply 6 damage → red "-6" floats up from player's row, HP bar ticks down.
- [ ] Final hit → "☠️" pops, player row dims.
- [ ] Open a second tab as another viewer → all of the above plays for them via SSE.
- [ ] Roll a natural 20 (or seed one in dev) → die flies in gold + shakes on settle.
- [ ] Chrome DevTools → Rendering → enable `prefers-reduced-motion` → verify no flight, just settled state.
- [ ] iPhone SE viewport → die smaller, flies straight, no jank on a low-end device emulator.

https://claude.ai/code/session_01DgKBYeiGaxmLg5xaPasU4r