### PR TITLE
fix(web): generalise login subtitle from intros to Discord integration

### DIFF
--- a/web/src/main/resources/templates/login.html
+++ b/web/src/main/resources/templates/login.html
@@ -54,7 +54,7 @@
 <div class="login-wrap">
 <div class="card">
     <h1>TobyBot</h1>
-    <p>Manage your Discord server intro songs.</p>
+    <p>Sign in with Discord to manage your server's TobyBot integration.</p>
 
     <div th:if="${loginError}" class="error">
         Login failed. Please try again.


### PR DESCRIPTION
## Summary

The login page tagline still said *"Manage your Discord server intro songs"* — accurate back when intros were the only feature, but the bot now covers DnD campaigns, music, dice rolls, etc. Replace with a Discord-integration framing that doesn't lock to a single feature.

Before:
> Manage your Discord server intro songs.

After:
> Sign in with Discord to manage your server's TobyBot integration.

## Files

- `web/src/main/resources/templates/login.html` — one-line copy change.

## Test plan

- [ ] CI green.
- [ ] Visit `/login` (logged out) → see the new tagline above the **Login with Discord** button.

https://claude.ai/code/session_01DgKBYeiGaxmLg5xaPasU4r