### PR TITLE
feat(dnd): heal action + dice-expression damage & heal in combat HUD

### DIFF
--- a/application/src/test/kotlin/web/controller/CampaignControllerTest.kt
+++ b/application/src/test/kotlin/web/controller/CampaignControllerTest.kt
@@ -19,6 +19,7 @@ import web.service.AddNoteResult
 import web.service.AdhocMonster
 import web.service.AnnotateRollResult
 import web.service.ApplyDamageResult
+import web.service.ApplyHealResult
 import web.service.AttackOutcome
 import web.service.AttackResult
 import web.service.CampaignDetail
@@ -969,13 +970,24 @@ class CampaignControllerTest {
     @Test
     fun `applyDamage redirects on applied`() {
         every {
-            campaignWebService.applyDamage(guildId, 1L, "Goblin", 4)
+            campaignWebService.applyDamage(guildId, 1L, "Goblin", "4")
         } returns ApplyDamageResult.APPLIED
 
-        val view = controller.applyDamage(guildId, "Goblin", 4, mockUser, mockRa)
+        val view = controller.applyDamage(guildId, "Goblin", "4", mockUser, mockRa)
 
         assertEquals("redirect:/dnd/campaign/$guildId", view)
         verify(exactly = 0) { mockRa.addFlashAttribute(any<String>(), any()) }
+    }
+
+    @Test
+    fun `applyDamage passes dice expression through to service`() {
+        every {
+            campaignWebService.applyDamage(guildId, 1L, "Goblin", "2d6+3")
+        } returns ApplyDamageResult.APPLIED
+
+        controller.applyDamage(guildId, "Goblin", "2d6+3", mockUser, mockRa)
+
+        verify { campaignWebService.applyDamage(guildId, 1L, "Goblin", "2d6+3") }
     }
 
     @Test
@@ -984,8 +996,64 @@ class CampaignControllerTest {
             campaignWebService.applyDamage(guildId, 1L, any(), any())
         } returns ApplyDamageResult.TARGET_NOT_FOUND
 
-        controller.applyDamage(guildId, "Nobody", 4, mockUser, mockRa)
+        controller.applyDamage(guildId, "Nobody", "4", mockUser, mockRa)
 
         verify { mockRa.addFlashAttribute("error", "That target isn't in the initiative order.") }
+    }
+
+    @Test
+    fun `applyDamage sets flash error when amount is invalid`() {
+        every {
+            campaignWebService.applyDamage(guildId, 1L, any(), any())
+        } returns ApplyDamageResult.INVALID_AMOUNT
+
+        controller.applyDamage(guildId, "Goblin", "nope", mockUser, mockRa)
+
+        verify { mockRa.addFlashAttribute("error", match<String> { it.contains("dice expression") }) }
+    }
+
+    @Test
+    fun `applyHeal redirects on applied`() {
+        every {
+            campaignWebService.applyHeal(guildId, 1L, "Alice", "5")
+        } returns ApplyHealResult.APPLIED
+
+        val view = controller.applyHeal(guildId, "Alice", "5", mockUser, mockRa)
+
+        assertEquals("redirect:/dnd/campaign/$guildId", view)
+        verify(exactly = 0) { mockRa.addFlashAttribute(any<String>(), any()) }
+    }
+
+    @Test
+    fun `applyHeal redirects on revived without flash`() {
+        every {
+            campaignWebService.applyHeal(guildId, 1L, "Alice", "8")
+        } returns ApplyHealResult.REVIVED
+
+        controller.applyHeal(guildId, "Alice", "8", mockUser, mockRa)
+
+        verify(exactly = 0) { mockRa.addFlashAttribute(any<String>(), any()) }
+    }
+
+    @Test
+    fun `applyHeal sets flash error when target has no HP tracked`() {
+        every {
+            campaignWebService.applyHeal(guildId, 1L, any(), any())
+        } returns ApplyHealResult.TARGET_HAS_NO_HP
+
+        controller.applyHeal(guildId, "Alice", "5", mockUser, mockRa)
+
+        verify { mockRa.addFlashAttribute("error", match<String> { it.contains("HP tracked") }) }
+    }
+
+    @Test
+    fun `applyHeal sets flash error when amount is invalid`() {
+        every {
+            campaignWebService.applyHeal(guildId, 1L, any(), any())
+        } returns ApplyHealResult.INVALID_AMOUNT
+
+        controller.applyHeal(guildId, "Alice", "garbage", mockUser, mockRa)
+
+        verify { mockRa.addFlashAttribute("error", match<String> { it.contains("dice expression") }) }
     }
 }

--- a/application/src/test/kotlin/web/service/CampaignWebServiceTest.kt
+++ b/application/src/test/kotlin/web/service/CampaignWebServiceTest.kt
@@ -1474,7 +1474,7 @@ class CampaignWebServiceTest {
         every { initiativeStore.applyDamage(guildId, "Alice", 4) } returns
             InitiativeEntryData("Alice", 12, "PLAYER", maxHp = 20, currentHp = 16)
 
-        val result = service.applyDamage(guildId, dmDiscordId, "Alice", 4)
+        val result = service.applyDamage(guildId, dmDiscordId, "Alice", "4")
         assertEquals(ApplyDamageResult.APPLIED, result)
         verify {
             sessionLog.publish(
@@ -1482,7 +1482,7 @@ class CampaignWebServiceTest {
                 type = common.events.CampaignEventType.DAMAGE_DEALT,
                 actorDiscordId = dmDiscordId,
                 actorName = any(),
-                payload = match { it["amount"] == 4 && it["remainingHp"] == 16 }
+                payload = match { it["amount"] == 4 && it["remainingHp"] == 16 && !it.containsKey("expression") }
             )
         }
     }
@@ -1497,7 +1497,7 @@ class CampaignWebServiceTest {
         every { initiativeStore.applyDamage(guildId, "Alice", 99) } returns
             InitiativeEntryData("Alice", 12, "PLAYER", maxHp = 20, currentHp = 0, defeated = true)
 
-        val result = service.applyDamage(guildId, dmDiscordId, "Alice", 99)
+        val result = service.applyDamage(guildId, dmDiscordId, "Alice", "99")
         assertEquals(ApplyDamageResult.DEFEATED, result)
         verify {
             sessionLog.publish(
@@ -1514,8 +1514,72 @@ class CampaignWebServiceTest {
     fun `applyDamage rejects negative amount`() {
         assertEquals(
             ApplyDamageResult.INVALID_AMOUNT,
-            service.applyDamage(guildId, dmDiscordId, "Alice", -1)
+            service.applyDamage(guildId, dmDiscordId, "Alice", "-1")
         )
+    }
+
+    @Test
+    fun `applyDamage rejects unparseable amount`() {
+        assertEquals(
+            ApplyDamageResult.INVALID_AMOUNT,
+            service.applyDamage(guildId, dmDiscordId, "Alice", "nonsense")
+        )
+    }
+
+    @Test
+    fun `applyDamage rejects integer above max cap`() {
+        assertEquals(
+            ApplyDamageResult.INVALID_AMOUNT,
+            service.applyDamage(guildId, dmDiscordId, "Alice", (CampaignWebService.MAX_DAMAGE_AMOUNT + 1).toString())
+        )
+    }
+
+    @Test
+    fun `applyDamage rolls dice expression and includes expression + rolls in payload`() {
+        val campaign = makeCampaign()
+        every { campaignService.getActiveCampaignForGuild(guildId) } returns campaign
+        every { initiativeStore.isActive(guildId) } returns true
+        every { initiativeStore.currentEntry(guildId) } returns
+            InitiativeEntryData("Goblin", 18, "MONSTER")
+        every { initiativeStore.applyDamage(guildId, "Alice", any()) } returns
+            InitiativeEntryData("Alice", 12, "PLAYER", maxHp = 20, currentHp = 10)
+
+        val result = service.applyDamage(guildId, dmDiscordId, "Alice", "2d6+3")
+        assertEquals(ApplyDamageResult.APPLIED, result)
+        verify {
+            initiativeStore.applyDamage(guildId, "Alice", match {
+                // 2d6+3: min 5, max 15. Server rolled a value in that range.
+                it in 5..15
+            })
+        }
+        verify {
+            sessionLog.publish(
+                guildId = guildId,
+                type = common.events.CampaignEventType.DAMAGE_DEALT,
+                actorDiscordId = dmDiscordId,
+                actorName = any(),
+                payload = match {
+                    it["expression"] == "2d6+3" &&
+                        (it["rolls"] as? List<*>)?.size == 2 &&
+                        (it["amount"] as Int) in 5..15
+                }
+            )
+        }
+    }
+
+    @Test
+    fun `applyDamage rejects dice expression that exceeds caps`() {
+        val campaign = makeCampaign()
+        every { campaignService.getActiveCampaignForGuild(guildId) } returns campaign
+        every { initiativeStore.isActive(guildId) } returns true
+        every { initiativeStore.currentEntry(guildId) } returns
+            InitiativeEntryData("Goblin", 18, "MONSTER")
+
+        assertEquals(
+            ApplyDamageResult.INVALID_AMOUNT,
+            service.applyDamage(guildId, dmDiscordId, "Alice", "99d6")
+        )
+        verify(exactly = 0) { initiativeStore.applyDamage(any(), any(), any()) }
     }
 
     @Test
@@ -1529,7 +1593,162 @@ class CampaignWebServiceTest {
 
         assertEquals(
             ApplyDamageResult.TARGET_NOT_FOUND,
-            service.applyDamage(guildId, dmDiscordId, "Nobody", 4)
+            service.applyDamage(guildId, dmDiscordId, "Nobody", "4")
         )
+    }
+
+    // combat: applyHeal
+
+    private fun stubHealActive(campaign: CampaignDto, entries: List<InitiativeEntryData>) {
+        every { campaignService.getActiveCampaignForGuild(guildId) } returns campaign
+        every { initiativeStore.isActive(guildId) } returns true
+        every { initiativeStore.currentEntry(guildId) } returns
+            InitiativeEntryData("Cleric", 15, "PLAYER")
+        every { initiativeStore.currentEntries(guildId) } returns entries
+    }
+
+    @Test
+    fun `applyHeal publishes HEAL_APPLIED and returns APPLIED for integer amount`() {
+        val campaign = makeCampaign()
+        stubHealActive(campaign, listOf(
+            InitiativeEntryData("Cleric", 15, "PLAYER"),
+            InitiativeEntryData("Alice", 12, "PLAYER", maxHp = 20, currentHp = 10)
+        ))
+        every { initiativeStore.applyHeal(guildId, "Alice", 5) } returns
+            InitiativeEntryData("Alice", 12, "PLAYER", maxHp = 20, currentHp = 15)
+
+        val result = service.applyHeal(guildId, dmDiscordId, "Alice", "5")
+        assertEquals(ApplyHealResult.APPLIED, result)
+        verify {
+            sessionLog.publish(
+                guildId = guildId,
+                type = common.events.CampaignEventType.HEAL_APPLIED,
+                actorDiscordId = dmDiscordId,
+                actorName = any(),
+                payload = match {
+                    it["healer"] == "Cleric" && it["target"] == "Alice" &&
+                        it["amount"] == 5 && it["remainingHp"] == 15 &&
+                        it["maxHp"] == 20 && it["revived"] == false
+                }
+            )
+        }
+    }
+
+    @Test
+    fun `applyHeal rolls dice expression and includes expression + rolls in payload`() {
+        val campaign = makeCampaign()
+        stubHealActive(campaign, listOf(
+            InitiativeEntryData("Cleric", 15, "PLAYER"),
+            InitiativeEntryData("Alice", 12, "PLAYER", maxHp = 20, currentHp = 10)
+        ))
+        every { initiativeStore.applyHeal(guildId, "Alice", any()) } returns
+            InitiativeEntryData("Alice", 12, "PLAYER", maxHp = 20, currentHp = 14)
+
+        val result = service.applyHeal(guildId, dmDiscordId, "Alice", "1d8+2")
+        assertEquals(ApplyHealResult.APPLIED, result)
+        verify {
+            sessionLog.publish(
+                guildId = guildId,
+                type = common.events.CampaignEventType.HEAL_APPLIED,
+                actorDiscordId = dmDiscordId,
+                actorName = any(),
+                payload = match {
+                    it["expression"] == "1d8+2" &&
+                        (it["rolls"] as? List<*>)?.size == 1
+                }
+            )
+        }
+    }
+
+    @Test
+    fun `applyHeal marks revived when defeated target HP rises above 0`() {
+        val campaign = makeCampaign()
+        stubHealActive(campaign, listOf(
+            InitiativeEntryData("Cleric", 15, "PLAYER"),
+            InitiativeEntryData("Alice", 12, "PLAYER", maxHp = 20, currentHp = 0, defeated = true)
+        ))
+        every { initiativeStore.applyHeal(guildId, "Alice", 8) } returns
+            InitiativeEntryData("Alice", 12, "PLAYER", maxHp = 20, currentHp = 8, defeated = false)
+
+        val result = service.applyHeal(guildId, dmDiscordId, "Alice", "8")
+        assertEquals(ApplyHealResult.REVIVED, result)
+        verify {
+            sessionLog.publish(
+                guildId = guildId,
+                type = common.events.CampaignEventType.HEAL_APPLIED,
+                actorDiscordId = dmDiscordId,
+                actorName = any(),
+                payload = match { it["revived"] == true }
+            )
+        }
+    }
+
+    @Test
+    fun `applyHeal rejects target without HP tracked`() {
+        val campaign = makeCampaign()
+        stubHealActive(campaign, listOf(
+            InitiativeEntryData("Cleric", 15, "PLAYER"),
+            InitiativeEntryData("Alice", 12, "PLAYER")
+        ))
+
+        val result = service.applyHeal(guildId, dmDiscordId, "Alice", "5")
+        assertEquals(ApplyHealResult.TARGET_HAS_NO_HP, result)
+        verify(exactly = 0) { initiativeStore.applyHeal(any(), any(), any()) }
+    }
+
+    @Test
+    fun `applyHeal returns TARGET_NOT_FOUND when target missing from tracker`() {
+        val campaign = makeCampaign()
+        stubHealActive(campaign, listOf(
+            InitiativeEntryData("Cleric", 15, "PLAYER")
+        ))
+
+        val result = service.applyHeal(guildId, dmDiscordId, "Nobody", "5")
+        assertEquals(ApplyHealResult.TARGET_NOT_FOUND, result)
+    }
+
+    @Test
+    fun `applyHeal rejects invalid amount`() {
+        assertEquals(
+            ApplyHealResult.INVALID_AMOUNT,
+            service.applyHeal(guildId, dmDiscordId, "Alice", "not a number")
+        )
+    }
+
+    @Test
+    fun `applyHeal rejects when no active campaign`() {
+        every { campaignService.getActiveCampaignForGuild(guildId) } returns null
+        assertEquals(
+            ApplyHealResult.NO_ACTIVE_CAMPAIGN,
+            service.applyHeal(guildId, dmDiscordId, "Alice", "5")
+        )
+    }
+
+    @Test
+    fun `applyHeal rejects when no active combat`() {
+        val campaign = makeCampaign()
+        every { campaignService.getActiveCampaignForGuild(guildId) } returns campaign
+        every { initiativeStore.isActive(guildId) } returns false
+
+        assertEquals(
+            ApplyHealResult.NO_ACTIVE_COMBAT,
+            service.applyHeal(guildId, dmDiscordId, "Alice", "5")
+        )
+    }
+
+    @Test
+    fun `applyHeal rejects when requester is not current turn or DM`() {
+        val campaign = makeCampaign()
+        every { campaignService.getActiveCampaignForGuild(guildId) } returns campaign
+        every { initiativeStore.isActive(guildId) } returns true
+        every { initiativeStore.currentEntry(guildId) } returns
+            InitiativeEntryData("Goblin", 15, "MONSTER")
+        every { initiativeStore.currentEntries(guildId) } returns listOf(
+            InitiativeEntryData("Goblin", 15, "MONSTER"),
+            InitiativeEntryData("Alice", 12, "PLAYER", maxHp = 20, currentHp = 10)
+        )
+
+        val result = service.applyHeal(guildId, playerDiscordId, "Alice", "5")
+        assertEquals(ApplyHealResult.NOT_ATTACKER, result)
     }
 }

--- a/common/src/main/kotlin/common/events/CampaignEventType.kt
+++ b/common/src/main/kotlin/common/events/CampaignEventType.kt
@@ -23,5 +23,6 @@ enum class CampaignEventType {
     ATTACK_HIT,
     ATTACK_MISS,
     DAMAGE_DEALT,
+    HEAL_APPLIED,
     PARTICIPANT_DEFEATED
 }

--- a/discord-bot/src/main/kotlin/bot/toby/helpers/DndHelperInitiativeStore.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/helpers/DndHelperInitiativeStore.kt
@@ -50,6 +50,15 @@ class DndHelperInitiativeStore(
         return toData(state.findByName(targetName) ?: return null)
     }
 
+    override fun applyHeal(guildId: Long, targetName: String, amount: Int): InitiativeEntryData? {
+        val state = dndHelper.stateFor(guildId)
+        if (!state.isActive()) return null
+        val existing = state.findByName(targetName) ?: return null
+        if (existing.maxHp == null) return null
+        state.applyHeal(targetName, amount)
+        return toData(state.findByName(targetName) ?: return null)
+    }
+
     private fun toData(entry: RolledEntry) = InitiativeEntryData(
         name = entry.name,
         roll = entry.roll,

--- a/discord-bot/src/main/kotlin/bot/toby/helpers/InitiativeState.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/helpers/InitiativeState.kt
@@ -98,6 +98,25 @@ class InitiativeState {
     internal fun findByName(name: String): RolledEntry? =
         sortedEntries.firstOrNull { it.name == name }
 
+    /**
+     * Restore [amount] HP to [name], clamped to maxHp. If the entry was
+     * defeated and the heal brings HP above 0, the defeated flag is cleared.
+     * No-op when the name isn't present or the entry has no HP tracked.
+     */
+    internal fun applyHeal(name: String, amount: Int) {
+        val existing = findByName(name) ?: return
+        val max = existing.maxHp ?: return
+        val base = existing.currentHp ?: 0
+        val newHp = (base + amount).coerceAtMost(max)
+        val revived = existing.defeated && newHp > 0
+        updateEntry(name) {
+            it.copy(
+                currentHp = newHp,
+                defeated = if (revived) false else it.defeated
+            )
+        }
+    }
+
     internal val currentEntry: RolledEntry?
         get() = sortedEntries.getOrNull(initiativeIndex.get())
 }

--- a/discord-bot/src/test/kotlin/bot/toby/helpers/DnDHelperTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/helpers/DnDHelperTest.kt
@@ -346,6 +346,58 @@ internal class DnDHelperTest {
         Assertions.assertEquals(15, restored.ac)
     }
 
+    @Test
+    fun testApplyHealClampsToMaxHp() {
+        dndHelper.seedInitiative(
+            guildId,
+            listOf(RolledEntry("Alice", 12, "PLAYER", maxHp = 20, currentHp = 15))
+        )
+        val state = dndHelper.stateFor(guildId)
+        state.applyHeal("Alice", 999)
+        Assertions.assertEquals(20, state.findByName("Alice")?.currentHp)
+    }
+
+    @Test
+    fun testApplyHealRevivesDefeatedTarget() {
+        dndHelper.seedInitiative(
+            guildId,
+            listOf(RolledEntry("Alice", 12, "PLAYER", maxHp = 20, currentHp = 0, defeated = true))
+        )
+        val state = dndHelper.stateFor(guildId)
+        state.applyHeal("Alice", 5)
+        val restored = state.findByName("Alice")
+        Assertions.assertEquals(5, restored?.currentHp)
+        Assertions.assertFalse(restored?.defeated ?: true, "heal above 0 should clear the defeated flag")
+    }
+
+    @Test
+    fun testApplyHealRevivedFlagSurvivesSnapshotRoundTrip() {
+        dndHelper.seedInitiative(
+            guildId,
+            listOf(RolledEntry("Alice", 12, "PLAYER", maxHp = 20, currentHp = 0, defeated = true))
+        )
+        dndHelper.stateFor(guildId).applyHeal("Alice", 5)
+
+        val snapshot = dndHelper.activeSnapshots().getValue(guildId)
+        dndHelper.clearInitiative(guildId)
+        dndHelper.restore(guildId, snapshot)
+
+        val restored = dndHelper.stateFor(guildId).findByName("Alice")
+        Assertions.assertEquals(5, restored?.currentHp)
+        Assertions.assertFalse(restored?.defeated ?: true)
+    }
+
+    @Test
+    fun testApplyHealIsNoOpWhenMaxHpMissing() {
+        dndHelper.seedInitiative(
+            guildId,
+            listOf(RolledEntry("Alice", 12, "PLAYER"))
+        )
+        val state = dndHelper.stateFor(guildId)
+        state.applyHeal("Alice", 5)
+        Assertions.assertNull(state.findByName("Alice")?.currentHp)
+    }
+
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun testDoInitialLookupWithSpell() = runTest {

--- a/web/src/main/kotlin/web/controller/CampaignController.kt
+++ b/web/src/main/kotlin/web/controller/CampaignController.kt
@@ -13,6 +13,7 @@ import web.service.AddNoteResult
 import web.service.AdhocMonster
 import web.service.AnnotateRollResult
 import web.service.ApplyDamageResult
+import web.service.ApplyHealResult
 import web.service.AttackResult
 import web.service.CampaignEventBroadcaster
 import web.service.CampaignWebService
@@ -536,7 +537,7 @@ class CampaignController(
     fun applyDamage(
         @PathVariable guildId: Long,
         @RequestParam("targetName") targetName: String,
-        @RequestParam("amount") amount: Int,
+        @RequestParam("amount") amount: String,
         @AuthenticationPrincipal user: OAuth2User,
         ra: RedirectAttributes
     ): String {
@@ -554,7 +555,39 @@ class CampaignController(
             ApplyDamageResult.TARGET_NOT_FOUND -> ra.addFlashAttribute("error", "That target isn't in the initiative order.")
             ApplyDamageResult.INVALID_AMOUNT -> ra.addFlashAttribute(
                 "error",
-                "Damage must be between 0 and ${web.service.CampaignWebService.MAX_DAMAGE_AMOUNT}."
+                "Damage must be a number (0-${web.service.CampaignWebService.MAX_DAMAGE_AMOUNT}) or a dice expression like 2d6+3."
+            )
+        }
+        return "redirect:/dnd/campaign/$guildId"
+    }
+
+    @PostMapping("/campaign/{guildId}/combat/heal")
+    fun applyHeal(
+        @PathVariable guildId: Long,
+        @RequestParam("targetName") targetName: String,
+        @RequestParam("amount") amount: String,
+        @AuthenticationPrincipal user: OAuth2User,
+        ra: RedirectAttributes
+    ): String {
+        val discordId = user.discordIdOrNull()
+            ?: return "redirect:/dnd/campaign"
+
+        when (campaignWebService.applyHeal(guildId, discordId, targetName.trim(), amount)) {
+            ApplyHealResult.APPLIED, ApplyHealResult.REVIVED -> {}
+            ApplyHealResult.NO_ACTIVE_CAMPAIGN -> ra.addFlashAttribute("error", "No active campaign in this server.")
+            ApplyHealResult.NO_ACTIVE_COMBAT -> ra.addFlashAttribute("error", "No active combat — roll initiative first.")
+            ApplyHealResult.NOT_ATTACKER -> ra.addFlashAttribute(
+                "error",
+                "You can only heal on your own turn (or as the DM)."
+            )
+            ApplyHealResult.TARGET_NOT_FOUND -> ra.addFlashAttribute("error", "That target isn't in the initiative order.")
+            ApplyHealResult.TARGET_HAS_NO_HP -> ra.addFlashAttribute(
+                "error",
+                "That target has no HP tracked — can't heal them."
+            )
+            ApplyHealResult.INVALID_AMOUNT -> ra.addFlashAttribute(
+                "error",
+                "Heal must be a number (0-${web.service.CampaignWebService.MAX_DAMAGE_AMOUNT}) or a dice expression like 1d8+2."
             )
         }
         return "redirect:/dnd/campaign/$guildId"

--- a/web/src/main/kotlin/web/service/CampaignWebService.kt
+++ b/web/src/main/kotlin/web/service/CampaignWebService.kt
@@ -144,6 +144,12 @@ enum class ApplyDamageResult {
     TARGET_NOT_FOUND, INVALID_AMOUNT
 }
 
+enum class ApplyHealResult {
+    APPLIED, REVIVED,
+    NO_ACTIVE_CAMPAIGN, NO_ACTIVE_COMBAT, NOT_ATTACKER,
+    TARGET_NOT_FOUND, TARGET_HAS_NO_HP, INVALID_AMOUNT
+}
+
 data class AttackOutcome(
     val result: AttackResult,
     val attacker: String? = null,
@@ -822,19 +828,67 @@ class CampaignWebService(
     }
 
     /**
-     * Applies integer [amount] of damage to the named target in the guild's
-     * combat tracker. Publishes DAMAGE_DEALT, and if the target's HP drops
-     * to 0 or below, also publishes PARTICIPANT_DEFEATED. The current-turn
-     * participant (or DM) may apply damage — we don't re-check target AC
-     * here since that's the role of [attack].
+     * Parsed combat amount: a raw integer typed into a form, or a rolled dice
+     * expression like `2d6+3`. [expression] is non-null only when the caller
+     * typed a dice formula; in that case [rolls] holds the individual rolled
+     * faces so the session log can narrate "rolled 2d6+3 = 11".
+     */
+    private data class CombatAmount(
+        val total: Int,
+        val expression: String?,
+        val rolls: List<Int>?
+    )
+
+    /**
+     * Accepts either an integer (`"6"`) or a dice expression (`"2d6+3"`, `"d20-1"`)
+     * and returns a parsed [CombatAmount]. Integer totals outside [1, MAX_DAMAGE_AMOUNT]
+     * are rejected; dice expressions inherit the same count/modifier caps used
+     * by the generic dice roller so a single form can't be used to DOS us.
+     */
+    private fun parseCombatAmount(raw: String): CombatAmount? {
+        val trimmed = raw.trim()
+        if (trimmed.isEmpty()) return null
+        trimmed.toIntOrNull()?.let { literal ->
+            if (literal < 0 || literal > MAX_DAMAGE_AMOUNT) return null
+            return CombatAmount(total = literal, expression = null, rolls = null)
+        }
+        val parsed = parseDiceExpression(trimmed) ?: return null
+        if (parsed.sides !in ALLOWED_DIE_SIDES) return null
+        if (parsed.count !in 1..MAX_DICE_COUNT) return null
+        if (parsed.modifier !in -MAX_DICE_MODIFIER..MAX_DICE_MODIFIER) return null
+        val rolled = (0 until parsed.count).map { Random.nextInt(1, parsed.sides + 1) }
+        val total = (rolled.sum() + parsed.modifier).coerceAtLeast(0)
+        return CombatAmount(
+            total = total,
+            expression = normaliseExpression(parsed),
+            rolls = rolled
+        )
+    }
+
+    private fun normaliseExpression(parsed: ParsedDice): String {
+        val mod = when {
+            parsed.modifier > 0 -> "+${parsed.modifier}"
+            parsed.modifier < 0 -> parsed.modifier.toString()
+            else -> ""
+        }
+        return "${parsed.count}d${parsed.sides}$mod"
+    }
+
+    /**
+     * Applies damage to the named target in the guild's combat tracker.
+     * [amountInput] accepts either a plain integer or a dice expression like
+     * `2d6+3`. Publishes DAMAGE_DEALT, and if the target's HP drops to 0 or
+     * below, also publishes PARTICIPANT_DEFEATED. The current-turn participant
+     * (or DM) may apply damage — we don't re-check target AC here since that's
+     * the role of [attack].
      */
     fun applyDamage(
         guildId: Long,
         requestingDiscordId: Long,
         targetName: String,
-        amount: Int
+        amountInput: String
     ): ApplyDamageResult {
-        if (amount < 0 || amount > MAX_DAMAGE_AMOUNT) return ApplyDamageResult.INVALID_AMOUNT
+        val parsed = parseCombatAmount(amountInput) ?: return ApplyDamageResult.INVALID_AMOUNT
         val campaign = campaignService.getActiveCampaignForGuild(guildId)
             ?: return ApplyDamageResult.NO_ACTIVE_CAMPAIGN
         if (!initiativeStore.isActive(guildId)) return ApplyDamageResult.NO_ACTIVE_COMBAT
@@ -846,21 +900,25 @@ class CampaignWebService(
         val authorised = isDm || (current.kind == "PLAYER" && current.name == requesterName)
         if (!authorised) return ApplyDamageResult.NOT_ATTACKER
 
-        val updated = initiativeStore.applyDamage(guildId, targetName, amount)
+        val updated = initiativeStore.applyDamage(guildId, targetName, parsed.total)
             ?: return ApplyDamageResult.TARGET_NOT_FOUND
 
+        val payload = buildCombatAmountPayload(
+            base = mapOf(
+                "attacker" to current.name,
+                "target" to updated.name,
+                "amount" to parsed.total,
+                "remainingHp" to updated.currentHp,
+                "maxHp" to updated.maxHp
+            ),
+            parsed = parsed
+        )
         sessionLog.publish(
             guildId = guildId,
             type = CampaignEventType.DAMAGE_DEALT,
             actorDiscordId = requestingDiscordId,
             actorName = requesterName,
-            payload = mapOf(
-                "attacker" to current.name,
-                "target" to updated.name,
-                "amount" to amount,
-                "remainingHp" to updated.currentHp,
-                "maxHp" to updated.maxHp
-            )
+            payload = payload
         )
 
         return if (updated.defeated) {
@@ -875,6 +933,72 @@ class CampaignWebService(
         } else {
             ApplyDamageResult.APPLIED
         }
+    }
+
+    /**
+     * Restores HP on the named target. Mirrors [applyDamage]: accepts an integer
+     * or a dice expression, requires the caller to be the current-turn
+     * participant or DM, and clamps the result to the target's maxHp.
+     * Publishes HEAL_APPLIED with `revived=true` when the heal brings a
+     * previously-defeated target above 0 HP.
+     */
+    fun applyHeal(
+        guildId: Long,
+        requestingDiscordId: Long,
+        targetName: String,
+        amountInput: String
+    ): ApplyHealResult {
+        val parsed = parseCombatAmount(amountInput) ?: return ApplyHealResult.INVALID_AMOUNT
+        val campaign = campaignService.getActiveCampaignForGuild(guildId)
+            ?: return ApplyHealResult.NO_ACTIVE_CAMPAIGN
+        if (!initiativeStore.isActive(guildId)) return ApplyHealResult.NO_ACTIVE_COMBAT
+        val current = initiativeStore.currentEntry(guildId)
+            ?: return ApplyHealResult.NO_ACTIVE_COMBAT
+
+        val isDm = campaign.dmDiscordId == requestingDiscordId
+        val requesterName = resolveMemberName(guildId, requestingDiscordId)
+        val authorised = isDm || (current.kind == "PLAYER" && current.name == requesterName)
+        if (!authorised) return ApplyHealResult.NOT_ATTACKER
+
+        val target = initiativeStore.currentEntries(guildId).firstOrNull { it.name == targetName }
+            ?: return ApplyHealResult.TARGET_NOT_FOUND
+        if (target.maxHp == null) return ApplyHealResult.TARGET_HAS_NO_HP
+        val wasDefeated = target.defeated
+
+        val updated = initiativeStore.applyHeal(guildId, targetName, parsed.total)
+            ?: return ApplyHealResult.TARGET_NOT_FOUND
+
+        val revived = wasDefeated && !updated.defeated
+        val payload = buildCombatAmountPayload(
+            base = mapOf(
+                "healer" to current.name,
+                "target" to updated.name,
+                "amount" to parsed.total,
+                "remainingHp" to updated.currentHp,
+                "maxHp" to updated.maxHp,
+                "revived" to revived
+            ),
+            parsed = parsed
+        )
+        sessionLog.publish(
+            guildId = guildId,
+            type = CampaignEventType.HEAL_APPLIED,
+            actorDiscordId = requestingDiscordId,
+            actorName = requesterName,
+            payload = payload
+        )
+        return if (revived) ApplyHealResult.REVIVED else ApplyHealResult.APPLIED
+    }
+
+    private fun buildCombatAmountPayload(
+        base: Map<String, Any?>,
+        parsed: CombatAmount
+    ): Map<String, Any?> {
+        if (parsed.expression == null) return base
+        return base + mapOf(
+            "expression" to parsed.expression,
+            "rolls" to parsed.rolls
+        )
     }
 
     /**

--- a/web/src/main/kotlin/web/service/InitiativeStore.kt
+++ b/web/src/main/kotlin/web/service/InitiativeStore.kt
@@ -33,6 +33,15 @@ interface InitiativeStore {
      * null when there's no active tracker or no participant with that name.
      */
     fun applyDamage(guildId: Long, targetName: String, damage: Int): InitiativeEntryData?
+
+    /**
+     * Restore [amount] HP to the participant named [targetName] in [guildId]'s
+     * tracker, clamped to their maxHp. If the target was defeated and the heal
+     * brings them above 0 HP, the defeated flag is cleared. Returns the updated
+     * entry, or null when there's no active tracker, no participant with that
+     * name, or the participant has no HP tracked (maxHp is null).
+     */
+    fun applyHeal(guildId: Long, targetName: String, amount: Int): InitiativeEntryData?
 }
 
 /**

--- a/web/src/main/resources/static/css/combat.css
+++ b/web/src/main/resources/static/css/combat.css
@@ -116,6 +116,10 @@
     animation: damage-float 900ms cubic-bezier(.2, .8, .2, 1) forwards;
     transform: translate(-50%, 0);
 }
+.damage-floater.heal {
+    color: #5bffa4;
+    text-shadow: 0 2px 6px rgba(0, 0, 0, 0.7), 0 0 14px rgba(46, 204, 113, 0.7);
+}
 @keyframes damage-float {
     0%   { opacity: 0; transform: translate(-50%, 4px) scale(0.7); }
     15%  { opacity: 1; transform: translate(-50%, -4px) scale(1.15); }

--- a/web/src/main/resources/static/js/sessionLog.js
+++ b/web/src/main/resources/static/js/sessionLog.js
@@ -101,7 +101,17 @@
             }
             case 'DAMAGE_DEALT': {
                 const remaining = (p.remainingHp != null) ? ' (' + p.remainingHp + ' HP left)' : '';
-                return (p.target || '?') + ' takes ' + p.amount + ' damage' + remaining;
+                const amt = p.expression ? (p.expression + ' = ' + p.amount) : p.amount;
+                return (p.target || '?') + ' takes ' + amt + ' damage' + remaining;
+            }
+            case 'HEAL_APPLIED': {
+                const hp = (p.remainingHp != null && p.maxHp != null)
+                    ? ' (' + p.remainingHp + '/' + p.maxHp + ' HP)'
+                    : '';
+                const amt = p.expression ? (p.expression + ' = ' + p.amount) : p.amount;
+                const who = p.healer ? (p.healer + ' heals ') : 'heals ';
+                const revived = p.revived ? ' — revived' : '';
+                return who + (p.target || '?') + ' for ' + amt + hp + revived;
             }
             case 'PARTICIPANT_DEFEATED':
                 return (p.target || '?') + ' is defeated';
@@ -301,7 +311,7 @@
         row.classList.add(cls);
     }
 
-    function applyDamageToRow(name, remainingHp) {
+    function applyHpToRow(name, currentHp) {
         const row = findRow(name);
         if (!row) return;
         const fill = row.querySelector('.hp-fill');
@@ -309,7 +319,7 @@
         if (!fill || !row.querySelector('.hp-wrap')) return;
         const maxSpan = row.querySelectorAll('.hp-label span')[1];
         const max = maxSpan ? parseInt(maxSpan.textContent, 10) : 0;
-        const hp = Math.max(0, remainingHp == null ? 0 : remainingHp);
+        const hp = Math.max(0, currentHp == null ? 0 : currentHp);
         if (label) label.textContent = String(hp);
         if (max > 0) {
             const pct = Math.max(0, Math.min(100, (hp * 100) / max));
@@ -324,6 +334,15 @@
         const row = findRow(name);
         if (!row) return;
         row.classList.add('defeated');
+    }
+
+    function reviveRow(name) {
+        const row = findRow(name);
+        if (!row) return;
+        row.classList.remove('defeated');
+        row.classList.remove('just-revived');
+        void row.offsetWidth;
+        row.classList.add('just-revived');
     }
 
     // ---- Combat cinematic ----------------------------------------------
@@ -378,15 +397,17 @@
         });
     }
 
-    function spawnDamageFloater(payload) {
+    function spawnCombatFloater(payload, tone) {
         const center = rowCenter(payload.target);
         if (!center) return;
         const stage = getCombatStage();
         const el = document.createElement('div');
-        el.className = 'damage-floater';
+        const toneClass = tone === 'heal' ? 'heal' : 'damage';
+        el.className = 'damage-floater ' + toneClass;
         el.style.setProperty('--start-x', center.x + 'px');
         el.style.setProperty('--start-y', (center.y - 8) + 'px');
-        el.textContent = '-' + (payload.amount != null ? payload.amount : '?');
+        const sign = tone === 'heal' ? '+' : '-';
+        el.textContent = sign + (payload.amount != null ? payload.amount : '?');
         stage.appendChild(el);
         setTimeout(function () { el.remove(); }, 1000);
     }
@@ -432,8 +453,13 @@
                 setTimeout(function () { flashRow(p.target, 'just-missed'); }, 600);
                 break;
             case 'DAMAGE_DEALT':
-                spawnDamageFloater(p);
-                applyDamageToRow(p.target, p.remainingHp);
+                spawnCombatFloater(p, 'damage');
+                applyHpToRow(p.target, p.remainingHp);
+                break;
+            case 'HEAL_APPLIED':
+                spawnCombatFloater(p, 'heal');
+                applyHpToRow(p.target, p.remainingHp);
+                if (p.revived) reviveRow(p.target);
                 break;
             case 'PARTICIPANT_DEFEATED':
                 spawnDefeatSkull(p);

--- a/web/src/main/resources/templates/campaignDetail.html
+++ b/web/src/main/resources/templates/campaignDetail.html
@@ -608,6 +608,7 @@
         }
         .turn-table li.just-hit { animation: combat-hit-flash 420ms ease-out; }
         .turn-table li.just-missed { animation: combat-miss-flash 420ms ease-out; }
+        .turn-table li.just-revived { animation: combat-revive-glow 900ms ease-out; }
         @keyframes combat-hit-flash {
             0%   { box-shadow: 0 0 0 0 rgba(231,76,60,0); }
             30%  { box-shadow: 0 0 0 3px rgba(231,76,60,0.45); background: rgba(231,76,60,0.12); }
@@ -617,6 +618,16 @@
             0%   { box-shadow: 0 0 0 0 rgba(160,160,176,0); }
             30%  { box-shadow: 0 0 0 3px rgba(160,160,176,0.45); background: rgba(160,160,176,0.08); }
             100% { box-shadow: 0 0 0 0 rgba(160,160,176,0); }
+        }
+        @keyframes combat-revive-glow {
+            0%   { box-shadow: 0 0 0 0 rgba(241,196,15,0); }
+            25%  { box-shadow: 0 0 0 4px rgba(241,196,15,0.55); background: rgba(46,204,113,0.15); }
+            100% { box-shadow: 0 0 0 0 rgba(241,196,15,0); }
+        }
+        @media (prefers-reduced-motion: reduce) {
+            .turn-table li.just-hit,
+            .turn-table li.just-missed,
+            .turn-table li.just-revived { animation: none; }
         }
 
         .combat-panel {
@@ -642,16 +653,20 @@
             letter-spacing: 0.05em;
             margin: 0;
         }
-        .combat-panel select, .combat-panel input[type=number] {
+        .combat-panel select,
+        .combat-panel input[type=number],
+        .combat-panel input[type=text] {
             background: #1a1a2e;
             border: 1px solid #2a3460;
             color: #e0e0e0;
             padding: 6px 8px;
             border-radius: 6px;
             font-size: 0.85rem;
+            font-family: inherit;
         }
         .combat-panel select { flex: 1; min-width: 160px; }
         .combat-panel input[type=number] { width: 70px; }
+        .combat-panel input[type=text] { width: 110px; font-family: monospace; }
         .combat-panel .spacer { flex: 1; }
         .combat-panel form { display: contents; }
         .combat-panel .title {
@@ -847,7 +862,8 @@
             .combat-panel { padding: 10px; }
             .combat-panel .row { flex-direction: column; align-items: stretch; gap: 6px; }
             .combat-panel select { min-width: 0; width: 100%; }
-            .combat-panel input[type=number] { width: 100%; }
+            .combat-panel input[type=number],
+            .combat-panel input[type=text] { width: 100%; }
             .combat-panel label { margin-top: 4px; }
         }
     </style>
@@ -1185,8 +1201,23 @@
                                         th:value="${t.name}"
                                         th:text="${t.name}">Target</option>
                             </select>
-                            <input type="number" name="amount" value="1" min="0" max="1000" required>
+                            <input type="text" name="amount" value="1"
+                                   placeholder="6 or 2d6+3" maxlength="20"
+                                   autocomplete="off" required>
                             <button type="submit" class="btn btn-secondary btn-sm">💥 Apply</button>
+                        </form>
+                        <form th:action="@{/dnd/campaign/{id}/combat/heal(id=${guildId})}" method="post" class="row">
+                            <label>Heal</label>
+                            <select name="targetName" required>
+                                <option th:each="t : ${initiativeState.entries}"
+                                        th:if="${t.maxHp != null}"
+                                        th:value="${t.name}"
+                                        th:text="${t.name + ' (' + (t.currentHp != null ? t.currentHp : 0) + '/' + t.maxHp + ')'}">Target</option>
+                            </select>
+                            <input type="text" name="amount" value="1"
+                                   placeholder="1 or 1d8+2" maxlength="20"
+                                   autocomplete="off" required>
+                            <button type="submit" class="btn btn-secondary btn-sm">💚 Heal</button>
                         </form>
                     </div>
                 </li>
@@ -1301,9 +1332,23 @@
                         misses Target — 7 vs AC 15
                     </span>
                     <span th:case="'DAMAGE_DEALT'"
-                          th:text="${event.payload['target'] + ' takes ' + event.payload['amount'] + ' damage' +
+                          th:text="${event.payload['target'] + ' takes ' +
+                                    (event.payload['expression'] != null
+                                        ? event.payload['expression'] + ' = ' + event.payload['amount']
+                                        : event.payload['amount']) + ' damage' +
                                     (event.payload['remainingHp'] != null ? ' (' + event.payload['remainingHp'] + ' HP left)' : '')}">
                         Target takes 6 damage (1 HP left)
+                    </span>
+                    <span th:case="'HEAL_APPLIED'"
+                          th:text="${(event.payload['healer'] != null ? event.payload['healer'] + ' heals ' : 'heals ') +
+                                    event.payload['target'] + ' for ' +
+                                    (event.payload['expression'] != null
+                                        ? event.payload['expression'] + ' = ' + event.payload['amount']
+                                        : event.payload['amount']) +
+                                    (event.payload['remainingHp'] != null and event.payload['maxHp'] != null
+                                        ? ' (' + event.payload['remainingHp'] + '/' + event.payload['maxHp'] + ' HP)' : '') +
+                                    (event.payload['revived'] == true ? ' — revived' : '')}">
+                        Cleric heals Target for 1d8+2 = 6 (6/10 HP)
                     </span>
                     <span th:case="'PARTICIPANT_DEFEATED'"
                           th:text="${event.payload['target'] + ' is defeated'}">Target is defeated</span>

--- a/web/src/main/resources/templates/login.html
+++ b/web/src/main/resources/templates/login.html
@@ -54,7 +54,7 @@
 <div class="login-wrap">
 <div class="card">
     <h1>TobyBot</h1>
-    <p>Manage your Discord server intro songs.</p>
+    <p>Sign in with Discord to manage your server's TobyBot integration.</p>
 
     <div th:if="${loginError}" class="error">
         Login failed. Please try again.


### PR DESCRIPTION
## Summary

Closes two gaps in the combat HUD shipped in #245/#246:

- **No heal.** Once a participant took damage, there was no way to restore HP short of the DM's alive/dead toggle. A new `💚 Heal` form alongside the existing attack + damage forms lets the current-turn participant (or DM) restore HP, clamped to `maxHp`, with a `revived: true` signal when the heal brings a defeated target above 0 HP.
- **Integer-only damage.** The generic dice popover has parsed `NdS±M` for a while; now the damage + heal forms accept the same syntax. The server rolls, includes the rolled faces + normalised expression on the event payload, and the session log narrates "Alice takes 2d6+3 = 11 damage". Integer inputs still work unchanged.

## What's new

- `HEAL_APPLIED` event type; `DAMAGE_DEALT` payload gains optional `expression` + `rolls` fields (additive).
- `CampaignWebService.applyHeal` mirroring `applyDamage`, with a shared `parseCombatAmount` helper that inherits the same count/modifier caps used by `rollDice` so `999d1000` can't DOS us.
- `InitiativeState.applyHeal` clamps to `maxHp` and clears `defeated` on revive; snapshot round-trip preserved.
- Green `+N` floater + a brief golden revive glow on the row when a defeated target is brought back.
- `POST /dnd/campaign/{guildId}/combat/heal`; damage endpoint's `amount` param switched from `Int` → `String` so one handler covers both integer and expression input.

Multi-attack (`attacksPerTurn` on monster templates) is deliberately split into a follow-up PR — it needs a schema migration + monster library form surface and doesn't share the combat service touch-points.

## Test plan

- [x] `CampaignWebServiceTest` — applyHeal happy path (integer + expression), revive flow, invalid amount, no-HP target, target missing, not-my-turn, no-campaign, no-combat; applyDamage with dice expression including server-side caps enforcement.
- [x] `CampaignControllerTest` — new `/combat/heal` redirects + flash branches; damage endpoint's new String signature.
- [x] `DnDHelperTest` — `applyHeal` clamps to max, revives defeated target, survives snapshot round-trip, no-ops without maxHp.
- [ ] Manual after deploy: dice-expression damage on a Goblin, heal-revive flow with golden glow, spectator tab sees HEAL_APPLIED live via SSE, `99d99+999` rejected with flash, mobile layout stacks the new heal form.
- [ ] `prefers-reduced-motion` — heal floater + revive glow collapse to an instant fade.

https://claude.ai/code/session_01DgKBYeiGaxmLg5xaPasU4r