### PR TITLE
fix(dnd): mobile combat animations + robust initiative form

### DIFF
--- a/application/src/test/kotlin/web/controller/CampaignControllerTest.kt
+++ b/application/src/test/kotlin/web/controller/CampaignControllerTest.kt
@@ -899,7 +899,7 @@ class CampaignControllerTest {
             campaignWebService.rollInitiative(guildId, 1L, any())
         } returns RollInitiativeResult.TEMPLATE_NOT_FOUND
 
-        controller.rollInitiative(guildId, null, listOf(77L), listOf(1), null, null, null, null, mockUser, mockRa)
+        controller.rollInitiative(guildId, null, listOf(77L), listOf("1"), null, null, null, null, mockUser, mockRa)
 
         verify {
             mockRa.addFlashAttribute("error", "One of the selected monster templates couldn't be found.")

--- a/application/src/test/kotlin/web/controller/CampaignControllerTest.kt
+++ b/application/src/test/kotlin/web/controller/CampaignControllerTest.kt
@@ -805,7 +805,7 @@ class CampaignControllerTest {
             templateIds = null,
             templateQtys = null,
             adhocNames = listOf("Bugbear", "", "Kobold"),
-            adhocMods = listOf(1, 0, 2),
+            adhocMods = listOf("1", "0", "2"),
             adhocHps = null,
             adhocAcs = null,
             user = mockUser,
@@ -829,7 +829,7 @@ class CampaignControllerTest {
             guildId,
             playerDiscordIds = null,
             templateIds = listOf(10L, 20L, 30L),
-            templateQtys = listOf(2, 1, 0),
+            templateQtys = listOf("2", "1", "0"),
             adhocNames = null,
             adhocMods = null,
             adhocHps = null,
@@ -837,6 +837,38 @@ class CampaignControllerTest {
             user = mockUser,
             ra = mockRa
         )
+    }
+
+    @Test
+    fun `rollInitiative tolerates empty adhoc HP AC and mod strings from form`() {
+        every {
+            campaignWebService.rollInitiative(
+                guildId,
+                1L,
+                match<InitiativeRollRequest> { req ->
+                    req.adhocMonsters == listOf(
+                        AdhocMonster("Goblin", 0, maxHp = null, ac = null),
+                        AdhocMonster("Kobold", 0, maxHp = null, ac = null)
+                    )
+                }
+            )
+        } returns RollInitiativeResult.ROLLED
+
+        val view = controller.rollInitiative(
+            guildId,
+            playerDiscordIds = null,
+            templateIds = null,
+            templateQtys = null,
+            adhocNames = listOf("Goblin", "Kobold"),
+            adhocMods = listOf("", ""),
+            adhocHps = listOf("", ""),
+            adhocAcs = listOf("", ""),
+            user = mockUser,
+            ra = mockRa
+        )
+
+        assertEquals("redirect:/dnd/campaign/$guildId", view)
+        verify(exactly = 0) { mockRa.addFlashAttribute(any<String>(), any()) }
     }
 
     @Test

--- a/application/src/test/kotlin/web/service/CampaignWebServiceTest.kt
+++ b/application/src/test/kotlin/web/service/CampaignWebServiceTest.kt
@@ -776,6 +776,49 @@ class CampaignWebServiceTest {
         assertEquals(9L, detail.recentEvents[0].id)
     }
 
+    @Test
+    fun `getCampaignDetail flags recent events as fresh for animation`() {
+        val campaign = makeCampaign()
+        every { campaignService.getActiveCampaignForGuild(guildId) } returns campaign
+        every { jda.getGuildById(guildId) } returns mockk(relaxed = true)
+        every { campaignPlayerService.getPlayersForCampaign(campaign.id) } returns emptyList()
+        every { sessionNoteService.getNotesForCampaign(campaign.id) } returns emptyList()
+        val now = LocalDateTime.now()
+        every { campaignEventService.listRecent(campaign.id, 100) } returns listOf(
+            // Old — outside the fresh window
+            CampaignEventDto(id = 1, campaignId = campaign.id, eventType = "ROLL",
+                payload = "{}", createdAt = now.minusMinutes(5)),
+            // Old — just past the window
+            CampaignEventDto(id = 2, campaignId = campaign.id, eventType = "ATTACK_HIT",
+                payload = "{}", createdAt = now.minusSeconds(30)),
+            // Fresh — within the window
+            CampaignEventDto(id = 3, campaignId = campaign.id, eventType = "DAMAGE_DEALT",
+                payload = "{}", createdAt = now.minusSeconds(2)),
+            CampaignEventDto(id = 4, campaignId = campaign.id, eventType = "PARTICIPANT_DEFEATED",
+                payload = "{}", createdAt = now)
+        )
+
+        val detail = service.getCampaignDetail(guildId, dmDiscordId)!!
+        assertEquals(listOf(3L, 4L), detail.freshEventIds)
+    }
+
+    @Test
+    fun `getCampaignDetail returns empty freshEventIds when all events are old`() {
+        val campaign = makeCampaign()
+        every { campaignService.getActiveCampaignForGuild(guildId) } returns campaign
+        every { jda.getGuildById(guildId) } returns mockk(relaxed = true)
+        every { campaignPlayerService.getPlayersForCampaign(campaign.id) } returns emptyList()
+        every { sessionNoteService.getNotesForCampaign(campaign.id) } returns emptyList()
+        val old = LocalDateTime.now().minusMinutes(10)
+        every { campaignEventService.listRecent(campaign.id, 100) } returns listOf(
+            CampaignEventDto(id = 1, campaignId = campaign.id, eventType = "ROLL",
+                payload = "{}", createdAt = old)
+        )
+
+        val detail = service.getCampaignDetail(guildId, dmDiscordId)!!
+        assertTrue(detail.freshEventIds.isEmpty())
+    }
+
     // annotateRoll
 
     @Test

--- a/application/src/test/kotlin/web/service/CampaignWebServiceTest.kt
+++ b/application/src/test/kotlin/web/service/CampaignWebServiceTest.kt
@@ -1,5 +1,6 @@
 package web.service
 
+import common.events.CampaignEventType
 import database.dto.CampaignDto
 import database.dto.CampaignEventDto
 import database.dto.CampaignPlayerDto
@@ -899,7 +900,7 @@ class CampaignWebServiceTest {
         verify {
             sessionLog.publish(
                 guildId = guildId,
-                type = common.events.CampaignEventType.HIT,
+                type = CampaignEventType.HIT,
                 actorDiscordId = dmDiscordId,
                 actorName = any(),
                 payload = match { it["target"] == "goblin" },
@@ -921,7 +922,7 @@ class CampaignWebServiceTest {
         verify {
             sessionLog.publish(
                 guildId = guildId,
-                type = common.events.CampaignEventType.MISS,
+                type = CampaignEventType.MISS,
                 actorDiscordId = dmDiscordId,
                 actorName = any(),
                 payload = match { it.isEmpty() },
@@ -972,7 +973,7 @@ class CampaignWebServiceTest {
         verify {
             sessionLog.publish(
                 guildId = guildId,
-                type = common.events.CampaignEventType.DM_NOTE,
+                type = CampaignEventType.DM_NOTE,
                 actorDiscordId = dmDiscordId,
                 actorName = any(),
                 payload = match { it["body"] == "A dragon lands." },
@@ -1134,7 +1135,7 @@ class CampaignWebServiceTest {
         verify {
             sessionLog.publish(
                 guildId = guildId,
-                type = common.events.CampaignEventType.INITIATIVE_ROLLED,
+                type = CampaignEventType.INITIATIVE_ROLLED,
                 actorDiscordId = dmDiscordId,
                 actorName = any(),
                 payload = match { (it["entries"] as? List<*>)?.size == 3 },
@@ -1275,7 +1276,7 @@ class CampaignWebServiceTest {
         verify {
             sessionLog.publish(
                 guildId = guildId,
-                type = common.events.CampaignEventType.ROLL,
+                type = CampaignEventType.ROLL,
                 actorDiscordId = dmDiscordId,
                 actorName = any(),
                 payload = match {
@@ -1308,7 +1309,7 @@ class CampaignWebServiceTest {
         verify {
             sessionLog.publish(
                 guildId = guildId,
-                type = common.events.CampaignEventType.ROLL,
+                type = CampaignEventType.ROLL,
                 actorDiscordId = playerDiscordId,
                 actorName = any(),
                 payload = match {
@@ -1339,7 +1340,7 @@ class CampaignWebServiceTest {
         verify {
             sessionLog.publish(
                 guildId = guildId,
-                type = common.events.CampaignEventType.ROLL,
+                type = CampaignEventType.ROLL,
                 actorDiscordId = dmDiscordId,
                 actorName = any(),
                 payload = match {
@@ -1362,7 +1363,7 @@ class CampaignWebServiceTest {
         verify {
             sessionLog.publish(
                 guildId = guildId,
-                type = common.events.CampaignEventType.ROLL,
+                type = CampaignEventType.ROLL,
                 actorDiscordId = dmDiscordId,
                 actorName = any(),
                 payload = match {
@@ -1416,7 +1417,7 @@ class CampaignWebServiceTest {
         verify {
             sessionLog.publish(
                 guildId = guildId,
-                type = common.events.CampaignEventType.ATTACK_HIT,
+                type = CampaignEventType.ATTACK_HIT,
                 actorDiscordId = dmDiscordId,
                 actorName = any(),
                 payload = match {
@@ -1445,7 +1446,7 @@ class CampaignWebServiceTest {
         verify {
             sessionLog.publish(
                 guildId = guildId,
-                type = common.events.CampaignEventType.ATTACK_MISS,
+                type = CampaignEventType.ATTACK_MISS,
                 actorDiscordId = dmDiscordId,
                 actorName = any(),
                 payload = match { it["targetAc"] == 30 }
@@ -1522,7 +1523,7 @@ class CampaignWebServiceTest {
         verify {
             sessionLog.publish(
                 guildId = guildId,
-                type = common.events.CampaignEventType.DAMAGE_DEALT,
+                type = CampaignEventType.DAMAGE_DEALT,
                 actorDiscordId = dmDiscordId,
                 actorName = any(),
                 payload = match { it["amount"] == 4 && it["remainingHp"] == 16 && !it.containsKey("expression") }
@@ -1545,7 +1546,7 @@ class CampaignWebServiceTest {
         verify {
             sessionLog.publish(
                 guildId = guildId,
-                type = common.events.CampaignEventType.PARTICIPANT_DEFEATED,
+                type = CampaignEventType.PARTICIPANT_DEFEATED,
                 actorDiscordId = dmDiscordId,
                 actorName = any(),
                 payload = match { it["target"] == "Alice" }
@@ -1598,7 +1599,7 @@ class CampaignWebServiceTest {
         verify {
             sessionLog.publish(
                 guildId = guildId,
-                type = common.events.CampaignEventType.DAMAGE_DEALT,
+                type = CampaignEventType.DAMAGE_DEALT,
                 actorDiscordId = dmDiscordId,
                 actorName = any(),
                 payload = match {
@@ -1665,7 +1666,7 @@ class CampaignWebServiceTest {
         verify {
             sessionLog.publish(
                 guildId = guildId,
-                type = common.events.CampaignEventType.HEAL_APPLIED,
+                type = CampaignEventType.HEAL_APPLIED,
                 actorDiscordId = dmDiscordId,
                 actorName = any(),
                 payload = match {
@@ -1692,7 +1693,7 @@ class CampaignWebServiceTest {
         verify {
             sessionLog.publish(
                 guildId = guildId,
-                type = common.events.CampaignEventType.HEAL_APPLIED,
+                type = CampaignEventType.HEAL_APPLIED,
                 actorDiscordId = dmDiscordId,
                 actorName = any(),
                 payload = match {
@@ -1718,7 +1719,7 @@ class CampaignWebServiceTest {
         verify {
             sessionLog.publish(
                 guildId = guildId,
-                type = common.events.CampaignEventType.HEAL_APPLIED,
+                type = CampaignEventType.HEAL_APPLIED,
                 actorDiscordId = dmDiscordId,
                 actorName = any(),
                 payload = match { it["revived"] == true }

--- a/web/src/main/kotlin/web/controller/CampaignController.kt
+++ b/web/src/main/kotlin/web/controller/CampaignController.kt
@@ -344,7 +344,7 @@ class CampaignController(
             NarrateResult.EMPTY_BODY -> ra.addFlashAttribute("error", "Narration can't be empty.")
             NarrateResult.BODY_TOO_LONG -> ra.addFlashAttribute(
                 "error",
-                "Narration is too long (max ${web.service.CampaignWebService.MAX_NARRATE_BODY_LENGTH} characters)."
+                "Narration is too long (max ${CampaignWebService.MAX_NARRATE_BODY_LENGTH} characters)."
             )
         }
         return "redirect:/dnd/campaign/$guildId"
@@ -378,7 +378,7 @@ class CampaignController(
             SaveTemplateResult.NAME_BLANK -> ra.addFlashAttribute("error", "Monster name can't be empty.")
             SaveTemplateResult.NAME_TOO_LONG -> ra.addFlashAttribute(
                 "error",
-                "Monster name is too long (max ${web.service.CampaignWebService.MAX_TEMPLATE_NAME_LENGTH} characters)."
+                "Monster name is too long (max ${CampaignWebService.MAX_TEMPLATE_NAME_LENGTH} characters)."
             )
             SaveTemplateResult.NOT_FOUND -> ra.addFlashAttribute("error", "That template doesn't exist.")
             SaveTemplateResult.NOT_OWNER -> ra.addFlashAttribute("error", "You can only edit your own templates.")
@@ -492,11 +492,11 @@ class CampaignController(
             )
             RollDiceResult.INVALID_COUNT -> ra.addFlashAttribute(
                 "error",
-                "Dice count must be between 1 and ${web.service.CampaignWebService.MAX_DICE_COUNT}."
+                "Dice count must be between 1 and ${CampaignWebService.MAX_DICE_COUNT}."
             )
             RollDiceResult.INVALID_MODIFIER -> ra.addFlashAttribute(
                 "error",
-                "Modifier must be between -${web.service.CampaignWebService.MAX_DICE_MODIFIER} and ${web.service.CampaignWebService.MAX_DICE_MODIFIER}."
+                "Modifier must be between -${CampaignWebService.MAX_DICE_MODIFIER} and ${CampaignWebService.MAX_DICE_MODIFIER}."
             )
             RollDiceResult.INVALID_EXPRESSION -> ra.addFlashAttribute(
                 "error",
@@ -531,7 +531,7 @@ class CampaignController(
             AttackResult.CANT_TARGET_SELF -> ra.addFlashAttribute("error", "You can't attack yourself.")
             AttackResult.INVALID_MODIFIER -> ra.addFlashAttribute(
                 "error",
-                "Attack modifier must be between -${web.service.CampaignWebService.MAX_ATTACK_MODIFIER} and ${web.service.CampaignWebService.MAX_ATTACK_MODIFIER}."
+                "Attack modifier must be between -${CampaignWebService.MAX_ATTACK_MODIFIER} and ${CampaignWebService.MAX_ATTACK_MODIFIER}."
             )
         }
         return "redirect:/dnd/campaign/$guildId"
@@ -559,7 +559,7 @@ class CampaignController(
             ApplyDamageResult.TARGET_NOT_FOUND -> ra.addFlashAttribute("error", "That target isn't in the initiative order.")
             ApplyDamageResult.INVALID_AMOUNT -> ra.addFlashAttribute(
                 "error",
-                "Damage must be a number (0-${web.service.CampaignWebService.MAX_DAMAGE_AMOUNT}) or a dice expression like 2d6+3."
+                "Damage must be a number (0-${CampaignWebService.MAX_DAMAGE_AMOUNT}) or a dice expression like 2d6+3."
             )
         }
         return "redirect:/dnd/campaign/$guildId"
@@ -591,7 +591,7 @@ class CampaignController(
             )
             ApplyHealResult.INVALID_AMOUNT -> ra.addFlashAttribute(
                 "error",
-                "Heal must be a number (0-${web.service.CampaignWebService.MAX_DAMAGE_AMOUNT}) or a dice expression like 1d8+2."
+                "Heal must be a number (0-${CampaignWebService.MAX_DAMAGE_AMOUNT}) or a dice expression like 1d8+2."
             )
         }
         return "redirect:/dnd/campaign/$guildId"

--- a/web/src/main/kotlin/web/controller/CampaignController.kt
+++ b/web/src/main/kotlin/web/controller/CampaignController.kt
@@ -86,6 +86,7 @@ class CampaignController(
         model.addAttribute("recentEvents", campaignDetail?.recentEvents ?: emptyList<Any>())
         model.addAttribute("initiativeState", campaignDetail?.initiativeState)
         model.addAttribute("monsterLibrary", campaignDetail?.monsterLibrary ?: emptyList<Any>())
+        model.addAttribute("freshEventIds", campaignDetail?.freshEventIds ?: emptyList<Long>())
         model.addAttribute("username", user.displayName())
 
         return "campaignDetail"
@@ -408,21 +409,24 @@ class CampaignController(
         @PathVariable guildId: Long,
         @RequestParam(name = "playerDiscordIds", required = false) playerDiscordIds: List<Long>?,
         @RequestParam(name = "templateId", required = false) templateIds: List<Long>?,
-        @RequestParam(name = "templateQty", required = false) templateQtys: List<Int>?,
+        @RequestParam(name = "templateQty", required = false) templateQtys: List<String>?,
         @RequestParam(name = "adhocName", required = false) adhocNames: List<String>?,
-        @RequestParam(name = "adhocMod", required = false) adhocMods: List<Int>?,
-        @RequestParam(name = "adhocHp", required = false) adhocHps: List<Int>?,
-        @RequestParam(name = "adhocAc", required = false) adhocAcs: List<Int>?,
+        @RequestParam(name = "adhocMod", required = false) adhocMods: List<String>?,
+        @RequestParam(name = "adhocHp", required = false) adhocHps: List<String>?,
+        @RequestParam(name = "adhocAc", required = false) adhocAcs: List<String>?,
         @AuthenticationPrincipal user: OAuth2User,
         ra: RedirectAttributes
     ): String {
         val discordId = user.discordIdOrNull()
             ?: return "redirect:/dnd/campaign"
 
+        // The ad-hoc monster rows have optional HP/AC inputs with no default,
+        // so empty strings reach us for un-filled rows. Bind as List<String>
+        // and parse leniently so empties become null/0 rather than 400/500.
         val tplIds = templateIds.orEmpty()
         val tplQtys = templateQtys.orEmpty()
         val expandedTemplateIds = tplIds.flatMapIndexed { i, id ->
-            val qty = tplQtys.getOrElse(i) { 1 }.coerceAtLeast(0)
+            val qty = (tplQtys.getOrNull(i)?.toIntOrNull() ?: 1).coerceAtLeast(0)
             List(qty) { id }
         }
 
@@ -435,9 +439,9 @@ class CampaignController(
             if (cleaned.isBlank()) null
             else AdhocMonster(
                 name = cleaned,
-                initiativeModifier = mods.getOrElse(i) { 0 },
-                maxHp = hps.getOrNull(i)?.takeIf { it > 0 },
-                ac = acs.getOrNull(i)?.takeIf { it > 0 }
+                initiativeModifier = mods.getOrNull(i)?.toIntOrNull() ?: 0,
+                maxHp = hps.getOrNull(i)?.toIntOrNull()?.takeIf { it > 0 },
+                ac = acs.getOrNull(i)?.toIntOrNull()?.takeIf { it > 0 }
             )
         }
         val request = InitiativeRollRequest(

--- a/web/src/main/kotlin/web/service/CampaignEventBroadcaster.kt
+++ b/web/src/main/kotlin/web/service/CampaignEventBroadcaster.kt
@@ -1,5 +1,6 @@
 package web.service
 
+import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper
 import database.dto.CampaignEventDto
 import org.springframework.stereotype.Service
@@ -52,7 +53,7 @@ class CampaignEventBroadcaster(private val objectMapper: ObjectMapper) {
     fun subscriberCount(campaignId: Long): Int = emitters[campaignId]?.size ?: 0
 
     private val payloadTypeRef =
-        object : com.fasterxml.jackson.core.type.TypeReference<Map<String, Any?>>() {}
+        object : TypeReference<Map<String, Any?>>() {}
 
     private fun toSessionEventView(dto: CampaignEventDto): SessionEventView {
         val parsed = runCatching { objectMapper.readValue(dto.payload, payloadTypeRef) }

--- a/web/src/main/kotlin/web/service/CampaignWebService.kt
+++ b/web/src/main/kotlin/web/service/CampaignWebService.kt
@@ -32,7 +32,8 @@ data class CampaignDetail(
     val notes: List<SessionNoteView> = emptyList(),
     val recentEvents: List<SessionEventView> = emptyList(),
     val initiativeState: InitiativeStateView? = null,
-    val monsterLibrary: List<MonsterTemplateView> = emptyList()
+    val monsterLibrary: List<MonsterTemplateView> = emptyList(),
+    val freshEventIds: List<Long> = emptyList()
 ) {
     fun isDm(discordId: Long): Boolean = campaign.dmDiscordId == discordId
 }
@@ -185,6 +186,7 @@ class CampaignWebService(
         const val MAX_NOTE_BODY_LENGTH = 2000
         const val MAX_NARRATE_BODY_LENGTH = 1000
         const val DEFAULT_EVENT_LIMIT = 100
+        const val FRESH_EVENT_WINDOW_SECONDS = 5L
         const val MAX_TEMPLATE_NAME_LENGTH = 100
         const val MAX_DICE_COUNT = 20
         const val MAX_DICE_MODIFIER = 50
@@ -285,6 +287,14 @@ class CampaignWebService(
             }
         } else emptyList()
 
+        // Events published in the last few seconds are likely the action the user
+        // just submitted. Their own POST→redirect cycle means the new EventSource
+        // connects after the publish, so SSE won't replay the event and the
+        // cinematic would never fire. Expose these IDs so sessionLog.js can
+        // animate them on boot.
+        val freshCutoff = LocalDateTime.now().minusSeconds(FRESH_EVENT_WINDOW_SECONDS)
+        val freshEventIds = recentEvents.filter { it.createdAt.isAfter(freshCutoff) }.map { it.id }
+
         return CampaignDetail(
             campaign = campaign,
             players = players,
@@ -294,7 +304,8 @@ class CampaignWebService(
             notes = notes,
             recentEvents = recentEvents,
             initiativeState = initiativeState,
-            monsterLibrary = monsterLibrary
+            monsterLibrary = monsterLibrary,
+            freshEventIds = freshEventIds
         )
     }
 

--- a/web/src/main/kotlin/web/service/CampaignWebService.kt
+++ b/web/src/main/kotlin/web/service/CampaignWebService.kt
@@ -1,11 +1,13 @@
 package web.service
 
+import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import common.events.CampaignEventType
 import common.helpers.parseDndBeyondCharacterId
 import common.logging.DiscordLogger
 import database.dto.CampaignDto
+import database.dto.CampaignEventDto
 import database.dto.CampaignPlayerDto
 import database.dto.CampaignPlayerId
 import database.dto.MonsterTemplateDto
@@ -179,7 +181,7 @@ class CampaignWebService(
 
     private val objectMapper = ObjectMapper()
     private val payloadTypeRef =
-        object : com.fasterxml.jackson.core.type.TypeReference<Map<String, Any?>>() {}
+        object : TypeReference<Map<String, Any?>>() {}
     private val logger = DiscordLogger(CampaignWebService::class.java)
 
     companion object {
@@ -341,7 +343,7 @@ class CampaignWebService(
         return events.map(::toSessionEventView)
     }
 
-    private fun toSessionEventView(dto: database.dto.CampaignEventDto): SessionEventView {
+    private fun toSessionEventView(dto: CampaignEventDto): SessionEventView {
         val parsed = runCatching { objectMapper.readValue(dto.payload, payloadTypeRef) }
             .getOrDefault(emptyMap())
         return SessionEventView(

--- a/web/src/main/resources/static/js/sessionLog.js
+++ b/web/src/main/resources/static/js/sessionLog.js
@@ -7,6 +7,16 @@
 
     const isDm = logEl.dataset.isDm === 'true';
     let lastSeenId = parseInt(logEl.dataset.lastSeenId || '0', 10);
+    // Events the server marked as "just happened" — the user's own
+    // POST→redirect cycle subscribes a new EventSource after the publish, so
+    // SSE won't replay these. We animate them on boot so the actor sees their
+    // own cinematic (matters on mobile where single-window use is the norm).
+    const freshEventIds = new Set(
+        (logEl.dataset.freshEventIds || '')
+            .split(',')
+            .map(function (s) { return parseInt(s, 10); })
+            .filter(function (n) { return !isNaN(n); })
+    );
     const emptyEl = document.getElementById('session-log-empty');
 
     function postAnnotation(eventId, kind) {
@@ -157,13 +167,28 @@
         logEl.appendChild(row);
     }
 
-    // Backfill anything that landed between server render and JS boot, then subscribe.
-    fetch('/dnd/campaign/' + guildId + '/events?since=' + lastSeenId + '&limit=200', {
+    // Backfill anything that landed between server render and JS boot, and hydrate
+    // animations for "fresh" events (the action the current user likely just
+    // submitted). We widen the since-cursor below lastSeenId so fresh events the
+    // server already rendered are returned too; renderEvent's own guard skips
+    // duplicates.
+    const originalLastSeenId = lastSeenId;
+    const minFreshId = freshEventIds.size
+        ? Math.min.apply(null, Array.from(freshEventIds))
+        : lastSeenId + 1;
+    const backfillSince = Math.max(0, Math.min(lastSeenId, minFreshId - 1));
+    fetch('/dnd/campaign/' + guildId + '/events?since=' + backfillSince + '&limit=200', {
         credentials: 'same-origin'
     })
         .then(function (r) { return r.ok ? r.json() : []; })
         .then(function (events) {
-            if (Array.isArray(events)) events.forEach(renderEvent);
+            if (!Array.isArray(events)) return;
+            events.forEach(function (e) {
+                renderEvent(e);
+                if (e && (e.id > originalLastSeenId || freshEventIds.has(e.id))) {
+                    handleInitiativeEvent(e);
+                }
+            });
         })
         .catch(function () { /* non-fatal; SSE will catch up */ });
 

--- a/web/src/main/resources/templates/campaignDetail.html
+++ b/web/src/main/resources/templates/campaignDetail.html
@@ -1268,7 +1268,9 @@
              th:attr="data-guild-id=${guildId},
                       data-is-dm=${isUserDm},
                       data-last-seen-id=${recentEvents != null and not #lists.isEmpty(recentEvents)
-                        ? recentEvents[#lists.size(recentEvents) - 1].id : 0}">
+                        ? recentEvents[#lists.size(recentEvents) - 1].id : 0},
+                      data-fresh-event-ids=${freshEventIds != null and not #lists.isEmpty(freshEventIds)
+                        ? #strings.listJoin(freshEventIds, ',') : ''}">
             <div class="event-row" th:each="event : ${recentEvents}"
                  th:attr="data-event-id=${event.id},data-event-type=${event.type}">
                 <span class="event-type" th:text="${event.type}">ROLL</span>


### PR DESCRIPTION
## Summary

Two related follow-ups to #248 surfaced from real (mobile) testing.

### 1. Combat animations never played on mobile

Actor → POST attack/damage/heal → 302 → page reload. The reloaded page's `lastSeenId` already reflects the just-published event (server-rendered), so the backfill `/events?since=lastSeenId` returns empty and the new EventSource only sees *future* events. Result: the actor never sees their own cinematic. Desktop masked this because testing usually had a spectator tab open (live SSE); on mobile (single window) animations were never firing.

**Fix**

- `CampaignWebService.getCampaignDetail` computes `freshEventIds` — events whose `createdAt` is within the last `FRESH_EVENT_WINDOW_SECONDS` (5s), using the server clock to sidestep timezone drift.
- Controller passes them through as a model attribute.
- `campaignDetail.html` embeds them as `data-fresh-event-ids` on `#session-log`.
- `sessionLog.js` widens its backfill cursor to include the smallest fresh ID, and on each returned event fires `handleInitiativeEvent` when the event id is > the original `lastSeenId` **or** is in the fresh set. `renderEvent`'s own guard handles duplicate rendering.

The actor now sees the floating die / damage floater / HP bar update / defeat skull on their own action, on mobile, within the 5s window.

### 2. 500 on roll initiative with monsters-only rosters

The ad-hoc rows have `<input type="number">` HP/AC fields with no `value=` default. Unfilled rows submit empty strings. Spring binding `List<Int>?` with empty-string elements throws before the controller body runs → 500.

**Fix** — bind `templateQty`, `adhocMod`, `adhocHp`, `adhocAc` as `List<String>?` and parse each element with `toIntOrNull()`. Empties become `null` (HP/AC) or `0` (mod) — identical semantics to before for non-empty values, robust for empty ones.

## Test plan

- [x] `CampaignWebServiceTest` — `freshEventIds` populated for events inside the window, empty outside.
- [x] `CampaignControllerTest` — new case: empty-string ad-hoc HP/AC/mod rolls successfully (no 500); existing tests updated to pass `List<String>`.
- [ ] Manual after deploy: on mobile, attack + damage + heal + defeat all animate for the actor without needing a second window. Roll initiative with 2 ad-hoc monsters + 0 players, HP/AC fields blank — no 500.
- [ ] `prefers-reduced-motion` — fresh-event animations respect the existing collapse-to-fade rules.

https://claude.ai/code/session_01DgKBYeiGaxmLg5xaPasU4r