### PR TITLE
feat(dnd): monster HP ranges + attached attacks

### DIFF
--- a/application/src/test/kotlin/web/controller/CampaignControllerTest.kt
+++ b/application/src/test/kotlin/web/controller/CampaignControllerTest.kt
@@ -690,7 +690,7 @@ class CampaignControllerTest {
 
     @Test
     fun `listMonsterTemplates delegates to service`() {
-        val templates = listOf(MonsterTemplateView(1L, "Goblin", 2, 7, 15))
+        val templates = listOf(MonsterTemplateView(1L, "Goblin", 2, "7", 15))
         every { campaignWebService.listTemplatesForDm(1L) } returns templates
 
         val result = controller.listMonsterTemplates(mockUser)

--- a/application/src/test/kotlin/web/service/CampaignWebServiceTest.kt
+++ b/application/src/test/kotlin/web/service/CampaignWebServiceTest.kt
@@ -4,6 +4,7 @@ import database.dto.CampaignDto
 import database.dto.CampaignEventDto
 import database.dto.CampaignPlayerDto
 import database.dto.CampaignPlayerId
+import database.dto.MonsterAttackDto
 import database.dto.MonsterTemplateDto
 import database.dto.SessionNoteDto
 import database.dto.UserDto
@@ -11,6 +12,7 @@ import database.service.CampaignEventService
 import database.service.CampaignPlayerService
 import database.service.CampaignService
 import database.service.CharacterSheetService
+import database.service.MonsterAttackService
 import database.service.MonsterTemplateService
 import database.service.SessionNoteService
 import database.service.UserService
@@ -37,6 +39,7 @@ class CampaignWebServiceTest {
     private lateinit var sessionNoteService: SessionNoteService
     private lateinit var campaignEventService: CampaignEventService
     private lateinit var monsterTemplateService: MonsterTemplateService
+    private lateinit var monsterAttackService: MonsterAttackService
     private lateinit var initiativeStore: InitiativeStore
     private lateinit var sessionLog: SessionLogPublisher
     private lateinit var jda: JDA
@@ -64,6 +67,7 @@ class CampaignWebServiceTest {
         sessionNoteService = mockk(relaxed = true)
         campaignEventService = mockk(relaxed = true)
         monsterTemplateService = mockk(relaxed = true)
+        monsterAttackService = mockk(relaxed = true)
         initiativeStore = mockk(relaxed = true)
         sessionLog = mockk(relaxed = true)
         jda = mockk(relaxed = true)
@@ -76,6 +80,7 @@ class CampaignWebServiceTest {
             sessionNoteService,
             campaignEventService,
             monsterTemplateService,
+            monsterAttackService,
             initiativeStore,
             sessionLog,
             jda
@@ -944,7 +949,7 @@ class CampaignWebServiceTest {
     fun `saveTemplate rejects blank name`() {
         assertEquals(
             SaveTemplateResult.NAME_BLANK,
-            service.saveTemplate(dmDiscordId, id = null, name = "   ", initiativeModifier = 0, maxHp = null, ac = null)
+            service.saveTemplate(dmDiscordId, id = null, name = "   ", initiativeModifier = 0, hpExpression = null, ac = null)
         )
     }
 
@@ -953,7 +958,7 @@ class CampaignWebServiceTest {
         val long = "x".repeat(CampaignWebService.MAX_TEMPLATE_NAME_LENGTH + 1)
         assertEquals(
             SaveTemplateResult.NAME_TOO_LONG,
-            service.saveTemplate(dmDiscordId, id = null, name = long, initiativeModifier = 0, maxHp = null, ac = null)
+            service.saveTemplate(dmDiscordId, id = null, name = long, initiativeModifier = 0, hpExpression = null, ac = null)
         )
     }
 
@@ -961,14 +966,41 @@ class CampaignWebServiceTest {
     fun `saveTemplate creates when id is null`() {
         assertEquals(
             SaveTemplateResult.SAVED,
-            service.saveTemplate(dmDiscordId, id = null, name = "Goblin", initiativeModifier = 2, maxHp = 7, ac = 15)
+            service.saveTemplate(dmDiscordId, id = null, name = "Goblin", initiativeModifier = 2, hpExpression = "7", ac = 15)
         )
         verify {
             monsterTemplateService.save(match {
                 it.id == 0L && it.dmDiscordId == dmDiscordId && it.name == "Goblin" &&
-                    it.initiativeModifier == 2 && it.maxHp == 7 && it.ac == 15
+                    it.initiativeModifier == 2 && it.hpExpression == "7" && it.ac == 15
             })
         }
+    }
+
+    @Test
+    fun `saveTemplate accepts dice expression for HP`() {
+        assertEquals(
+            SaveTemplateResult.SAVED,
+            service.saveTemplate(dmDiscordId, id = null, name = "Ogre", initiativeModifier = 0, hpExpression = "3d20+30", ac = 11)
+        )
+        verify {
+            monsterTemplateService.save(match { it.hpExpression == "3d20+30" })
+        }
+    }
+
+    @Test
+    fun `saveTemplate rejects unparseable HP expression`() {
+        assertEquals(
+            SaveTemplateResult.INVALID_HP,
+            service.saveTemplate(dmDiscordId, id = null, name = "Bad", initiativeModifier = 0, hpExpression = "garbage", ac = null)
+        )
+    }
+
+    @Test
+    fun `saveTemplate rejects HP dice expression past caps`() {
+        assertEquals(
+            SaveTemplateResult.INVALID_HP,
+            service.saveTemplate(dmDiscordId, id = null, name = "Huge", initiativeModifier = 0, hpExpression = "99d20+30", ac = null)
+        )
     }
 
     @Test
@@ -976,7 +1008,7 @@ class CampaignWebServiceTest {
         every { monsterTemplateService.getById(99L) } returns null
         assertEquals(
             SaveTemplateResult.NOT_FOUND,
-            service.saveTemplate(dmDiscordId, id = 99L, name = "X", initiativeModifier = 0, maxHp = null, ac = null)
+            service.saveTemplate(dmDiscordId, id = 99L, name = "X", initiativeModifier = 0, hpExpression = null, ac = null)
         )
     }
 
@@ -987,7 +1019,7 @@ class CampaignWebServiceTest {
         )
         assertEquals(
             SaveTemplateResult.NOT_OWNER,
-            service.saveTemplate(dmDiscordId, id = 99L, name = "X", initiativeModifier = 0, maxHp = null, ac = null)
+            service.saveTemplate(dmDiscordId, id = 99L, name = "X", initiativeModifier = 0, hpExpression = null, ac = null)
         )
     }
 
@@ -1151,6 +1183,113 @@ class CampaignWebServiceTest {
                 eq(guildId),
                 match { seeded ->
                     seeded.map { it.name }.toSet() == setOf("Goblin", "Bugbear")
+                }
+            )
+        }
+    }
+
+    @Test
+    fun `rollInitiative uses literal HP from template hpExpression`() {
+        every { campaignService.getActiveCampaignForGuild(guildId) } returns makeCampaign()
+        every { monsterTemplateService.getById(77L) } returns MonsterTemplateDto(
+            id = 77L, dmDiscordId = dmDiscordId, name = "Goblin",
+            initiativeModifier = 2, hpExpression = "45"
+        )
+
+        service.rollInitiative(
+            guildId,
+            dmDiscordId,
+            InitiativeRollRequest(templateIds = listOf(77L))
+        )
+
+        verify {
+            initiativeStore.seed(
+                eq(guildId),
+                match { seeded ->
+                    val goblin = seeded.single()
+                    goblin.maxHp == 45 && goblin.currentHp == 45
+                }
+            )
+        }
+    }
+
+    @Test
+    fun `rollInitiative rolls HP independently per instance from dice expression`() {
+        every { campaignService.getActiveCampaignForGuild(guildId) } returns makeCampaign()
+        every { monsterTemplateService.getById(77L) } returns MonsterTemplateDto(
+            id = 77L, dmDiscordId = dmDiscordId, name = "Ogre",
+            initiativeModifier = 0, hpExpression = "3d20+30"
+        )
+
+        service.rollInitiative(
+            guildId,
+            dmDiscordId,
+            InitiativeRollRequest(templateIds = listOf(77L, 77L))
+        )
+
+        verify {
+            initiativeStore.seed(
+                eq(guildId),
+                match { seeded ->
+                    seeded.size == 2 && seeded.all {
+                        val hp = it.maxHp
+                        hp != null && hp in 33..90 && it.currentHp == hp
+                    }
+                }
+            )
+        }
+    }
+
+    @Test
+    fun `rollInitiative threads templateId for template-spawned monsters and leaves it null for ad-hoc and players`() {
+        every { campaignService.getActiveCampaignForGuild(guildId) } returns makeCampaign()
+        every { monsterTemplateService.getById(77L) } returns MonsterTemplateDto(
+            id = 77L, dmDiscordId = dmDiscordId, name = "Goblin", initiativeModifier = 2
+        )
+        every { userService.getUserById(playerDiscordId, guildId) } returns UserDto(playerDiscordId, guildId)
+
+        service.rollInitiative(
+            guildId,
+            dmDiscordId,
+            InitiativeRollRequest(
+                playerDiscordIds = listOf(playerDiscordId),
+                templateIds = listOf(77L),
+                adhocMonsters = listOf(AdhocMonster("Bugbear", 1))
+            )
+        )
+
+        verify {
+            initiativeStore.seed(
+                eq(guildId),
+                match { seeded ->
+                    val byName = seeded.associateBy { it.name }
+                    byName["Goblin"]?.templateId == 77L &&
+                        byName["Bugbear"]?.templateId == null &&
+                        byName.values.single { it.kind == "PLAYER" }.templateId == null
+                }
+            )
+        }
+    }
+
+    @Test
+    fun `rollInitiative leaves null HP when template has no hpExpression`() {
+        every { campaignService.getActiveCampaignForGuild(guildId) } returns makeCampaign()
+        every { monsterTemplateService.getById(77L) } returns MonsterTemplateDto(
+            id = 77L, dmDiscordId = dmDiscordId, name = "Goblin", initiativeModifier = 2
+        )
+
+        service.rollInitiative(
+            guildId,
+            dmDiscordId,
+            InitiativeRollRequest(templateIds = listOf(77L))
+        )
+
+        verify {
+            initiativeStore.seed(
+                eq(guildId),
+                match { seeded ->
+                    val goblin = seeded.single()
+                    goblin.maxHp == null && goblin.currentHp == null
                 }
             )
         }
@@ -1750,5 +1889,311 @@ class CampaignWebServiceTest {
 
         val result = service.applyHeal(guildId, playerDiscordId, "Alice", "5")
         assertEquals(ApplyHealResult.NOT_ATTACKER, result)
+    }
+
+    // saveAttack / deleteAttack
+
+    @Test
+    fun `saveAttack rejects when template missing`() {
+        every { monsterTemplateService.getById(77L) } returns null
+        assertEquals(
+            SaveAttackResult.TEMPLATE_NOT_FOUND,
+            service.saveAttack(dmDiscordId, 77L, attackId = null, name = "Bite", toHitModifier = 5, damageExpression = "2d6+3")
+        )
+    }
+
+    @Test
+    fun `saveAttack rejects non-owner`() {
+        every { monsterTemplateService.getById(77L) } returns MonsterTemplateDto(
+            id = 77L, dmDiscordId = 999L, name = "Someone Else's"
+        )
+        assertEquals(
+            SaveAttackResult.NOT_OWNER,
+            service.saveAttack(dmDiscordId, 77L, attackId = null, name = "Bite", toHitModifier = 5, damageExpression = "2d6+3")
+        )
+    }
+
+    @Test
+    fun `saveAttack rejects blank name`() {
+        every { monsterTemplateService.getById(77L) } returns MonsterTemplateDto(
+            id = 77L, dmDiscordId = dmDiscordId, name = "Goblin"
+        )
+        assertEquals(
+            SaveAttackResult.NAME_BLANK,
+            service.saveAttack(dmDiscordId, 77L, attackId = null, name = "   ", toHitModifier = 5, damageExpression = "1d6")
+        )
+    }
+
+    @Test
+    fun `saveAttack rejects modifier outside caps`() {
+        every { monsterTemplateService.getById(77L) } returns MonsterTemplateDto(
+            id = 77L, dmDiscordId = dmDiscordId, name = "Goblin"
+        )
+        assertEquals(
+            SaveAttackResult.INVALID_MODIFIER,
+            service.saveAttack(dmDiscordId, 77L, attackId = null, name = "Bite", toHitModifier = 99, damageExpression = "1d6")
+        )
+    }
+
+    @Test
+    fun `saveAttack rejects unparseable damage expression`() {
+        every { monsterTemplateService.getById(77L) } returns MonsterTemplateDto(
+            id = 77L, dmDiscordId = dmDiscordId, name = "Goblin"
+        )
+        assertEquals(
+            SaveAttackResult.INVALID_DAMAGE,
+            service.saveAttack(dmDiscordId, 77L, attackId = null, name = "Bite", toHitModifier = 0, damageExpression = "garbage")
+        )
+    }
+
+    @Test
+    fun `saveAttack rejects when per-template cap reached`() {
+        every { monsterTemplateService.getById(77L) } returns MonsterTemplateDto(
+            id = 77L, dmDiscordId = dmDiscordId, name = "Goblin"
+        )
+        every { monsterAttackService.countByTemplate(77L) } returns CampaignWebService.MAX_ATTACKS_PER_TEMPLATE.toLong()
+        assertEquals(
+            SaveAttackResult.TOO_MANY,
+            service.saveAttack(dmDiscordId, 77L, attackId = null, name = "Bite", toHitModifier = 5, damageExpression = "2d6+3")
+        )
+    }
+
+    @Test
+    fun `saveAttack creates when id is null and persists trimmed values`() {
+        every { monsterTemplateService.getById(77L) } returns MonsterTemplateDto(
+            id = 77L, dmDiscordId = dmDiscordId, name = "Goblin"
+        )
+        every { monsterAttackService.countByTemplate(77L) } returns 0L
+
+        assertEquals(
+            SaveAttackResult.SAVED,
+            service.saveAttack(dmDiscordId, 77L, attackId = null, name = "  Bite  ", toHitModifier = 5, damageExpression = " 2d6+3 ")
+        )
+        verify {
+            monsterAttackService.save(match {
+                it.monsterTemplateId == 77L && it.name == "Bite" &&
+                    it.toHitModifier == 5 && it.damageExpression == "2d6+3"
+            })
+        }
+    }
+
+    @Test
+    fun `saveAttack updates existing and skips the cap check`() {
+        every { monsterTemplateService.getById(77L) } returns MonsterTemplateDto(
+            id = 77L, dmDiscordId = dmDiscordId, name = "Goblin"
+        )
+        every { monsterAttackService.getById(42L) } returns MonsterAttackDto(
+            id = 42L, monsterTemplateId = 77L, name = "Old", toHitModifier = 1, damageExpression = "1d4"
+        )
+        every { monsterAttackService.countByTemplate(77L) } returns CampaignWebService.MAX_ATTACKS_PER_TEMPLATE.toLong()
+
+        assertEquals(
+            SaveAttackResult.SAVED,
+            service.saveAttack(dmDiscordId, 77L, attackId = 42L, name = "Bite", toHitModifier = 5, damageExpression = "2d6+3")
+        )
+        verify {
+            monsterAttackService.save(match {
+                it.id == 42L && it.name == "Bite" && it.damageExpression == "2d6+3"
+            })
+        }
+    }
+
+    @Test
+    fun `saveAttack rejects updating across templates`() {
+        every { monsterTemplateService.getById(77L) } returns MonsterTemplateDto(
+            id = 77L, dmDiscordId = dmDiscordId, name = "Goblin"
+        )
+        every { monsterAttackService.getById(42L) } returns MonsterAttackDto(
+            id = 42L, monsterTemplateId = 999L, name = "Other", toHitModifier = 0, damageExpression = "1d4"
+        )
+        assertEquals(
+            SaveAttackResult.ATTACK_TEMPLATE_MISMATCH,
+            service.saveAttack(dmDiscordId, 77L, attackId = 42L, name = "Bite", toHitModifier = 5, damageExpression = "2d6+3")
+        )
+    }
+
+    @Test
+    fun `deleteAttack rejects missing attack`() {
+        every { monsterAttackService.getById(42L) } returns null
+        assertEquals(DeleteAttackResult.ATTACK_NOT_FOUND, service.deleteAttack(dmDiscordId, 77L, 42L))
+    }
+
+    @Test
+    fun `deleteAttack rejects mismatched template`() {
+        every { monsterAttackService.getById(42L) } returns MonsterAttackDto(
+            id = 42L, monsterTemplateId = 999L, name = "Bite", toHitModifier = 5, damageExpression = "2d6+3"
+        )
+        assertEquals(
+            DeleteAttackResult.ATTACK_TEMPLATE_MISMATCH,
+            service.deleteAttack(dmDiscordId, 77L, 42L)
+        )
+    }
+
+    @Test
+    fun `deleteAttack rejects non-owner`() {
+        every { monsterAttackService.getById(42L) } returns MonsterAttackDto(
+            id = 42L, monsterTemplateId = 77L, name = "Bite", toHitModifier = 5, damageExpression = "2d6+3"
+        )
+        every { monsterTemplateService.getById(77L) } returns MonsterTemplateDto(
+            id = 77L, dmDiscordId = 999L, name = "Someone Else's"
+        )
+        assertEquals(DeleteAttackResult.NOT_OWNER, service.deleteAttack(dmDiscordId, 77L, 42L))
+    }
+
+    @Test
+    fun `deleteAttack removes when caller owns the template`() {
+        every { monsterAttackService.getById(42L) } returns MonsterAttackDto(
+            id = 42L, monsterTemplateId = 77L, name = "Bite", toHitModifier = 5, damageExpression = "2d6+3"
+        )
+        every { monsterTemplateService.getById(77L) } returns MonsterTemplateDto(
+            id = 77L, dmDiscordId = dmDiscordId, name = "Goblin"
+        )
+        assertEquals(DeleteAttackResult.DELETED, service.deleteAttack(dmDiscordId, 77L, 42L))
+        verify { monsterAttackService.deleteById(42L) }
+    }
+
+    // monsterAttack
+
+    private fun stubMonsterCombat(attack: MonsterAttackDto, target: InitiativeEntryData) {
+        val campaign = makeCampaign()
+        every { campaignService.getActiveCampaignForGuild(guildId) } returns campaign
+        every { initiativeStore.isActive(guildId) } returns true
+        every { initiativeStore.currentEntry(guildId) } returns
+            InitiativeEntryData("Goblin", 18, "MONSTER", templateId = 77L)
+        every { initiativeStore.currentEntries(guildId) } returns listOf(
+            InitiativeEntryData("Goblin", 18, "MONSTER", templateId = 77L),
+            target
+        )
+        every { monsterAttackService.getById(attack.id) } returns attack
+    }
+
+    @Test
+    fun `monsterAttack rejects non-DM requester`() {
+        every { campaignService.getActiveCampaignForGuild(guildId) } returns makeCampaign()
+        val outcome = service.monsterAttack(guildId, playerDiscordId, 42L, "Alice")
+        assertEquals(MonsterAttackResult.NOT_DM, outcome.result)
+    }
+
+    @Test
+    fun `monsterAttack rejects when current entry is not a monster`() {
+        every { campaignService.getActiveCampaignForGuild(guildId) } returns makeCampaign()
+        every { initiativeStore.isActive(guildId) } returns true
+        every { initiativeStore.currentEntry(guildId) } returns
+            InitiativeEntryData("Alice", 18, "PLAYER")
+        val outcome = service.monsterAttack(guildId, dmDiscordId, 42L, "Bob")
+        assertEquals(MonsterAttackResult.CURRENT_NOT_MONSTER, outcome.result)
+    }
+
+    @Test
+    fun `monsterAttack rejects when current monster has no templateId`() {
+        every { campaignService.getActiveCampaignForGuild(guildId) } returns makeCampaign()
+        every { initiativeStore.isActive(guildId) } returns true
+        every { initiativeStore.currentEntry(guildId) } returns
+            InitiativeEntryData("Adhoc", 18, "MONSTER", templateId = null)
+        val outcome = service.monsterAttack(guildId, dmDiscordId, 42L, "Alice")
+        assertEquals(MonsterAttackResult.NO_TEMPLATE, outcome.result)
+    }
+
+    @Test
+    fun `monsterAttack rejects attack from different template`() {
+        val attack = MonsterAttackDto(
+            id = 42L, monsterTemplateId = 999L, name = "Bite", toHitModifier = 5, damageExpression = "1d6"
+        )
+        stubMonsterCombat(attack, InitiativeEntryData("Alice", 12, "PLAYER", maxHp = 20, currentHp = 20, ac = 10))
+        val outcome = service.monsterAttack(guildId, dmDiscordId, 42L, "Alice")
+        assertEquals(MonsterAttackResult.ATTACK_TEMPLATE_MISMATCH, outcome.result)
+    }
+
+    @Test
+    fun `monsterAttack rejects missing target`() {
+        val attack = MonsterAttackDto(
+            id = 42L, monsterTemplateId = 77L, name = "Bite", toHitModifier = 5, damageExpression = "1d6"
+        )
+        stubMonsterCombat(attack, InitiativeEntryData("Alice", 12, "PLAYER", maxHp = 20, currentHp = 20, ac = 10))
+        val outcome = service.monsterAttack(guildId, dmDiscordId, 42L, "Ghost")
+        assertEquals(MonsterAttackResult.TARGET_NOT_FOUND, outcome.result)
+    }
+
+    @Test
+    fun `monsterAttack on hit publishes ATTACK_HIT and DAMAGE_DEALT and applies damage`() {
+        val attack = MonsterAttackDto(
+            id = 42L, monsterTemplateId = 77L, name = "Bite", toHitModifier = 20, damageExpression = "1d4"
+        )
+        // AC 1 + mod 20 guarantees hit regardless of d20 roll.
+        stubMonsterCombat(attack, InitiativeEntryData("Alice", 12, "PLAYER", maxHp = 20, currentHp = 20, ac = 1))
+        every { initiativeStore.applyDamage(guildId, "Alice", any()) } returns
+            InitiativeEntryData("Alice", 12, "PLAYER", maxHp = 20, currentHp = 15)
+
+        val outcome = service.monsterAttack(guildId, dmDiscordId, 42L, "Alice")
+        assertEquals(MonsterAttackResult.HIT, outcome.result)
+        assertEquals("Bite", outcome.attackName)
+        verify {
+            sessionLog.publish(
+                guildId = guildId,
+                type = common.events.CampaignEventType.ATTACK_HIT,
+                actorDiscordId = dmDiscordId,
+                actorName = any(),
+                payload = match { it["attackName"] == "Bite" && it["attacker"] == "Goblin" && it["target"] == "Alice" },
+                refEventId = null
+            )
+        }
+        verify {
+            sessionLog.publish(
+                guildId = guildId,
+                type = common.events.CampaignEventType.DAMAGE_DEALT,
+                actorDiscordId = dmDiscordId,
+                actorName = any(),
+                payload = match { it["attackName"] == "Bite" && it["target"] == "Alice" },
+                refEventId = null
+            )
+        }
+        verify { initiativeStore.applyDamage(guildId, "Alice", any()) }
+    }
+
+    @Test
+    fun `monsterAttack on miss publishes only ATTACK_MISS and does not damage`() {
+        val attack = MonsterAttackDto(
+            id = 42L, monsterTemplateId = 77L, name = "Bite", toHitModifier = 0, damageExpression = "1d4"
+        )
+        // AC 30 + any d20 + mod 0 never reaches 30.
+        stubMonsterCombat(attack, InitiativeEntryData("Alice", 12, "PLAYER", maxHp = 20, currentHp = 20, ac = 30))
+
+        val outcome = service.monsterAttack(guildId, dmDiscordId, 42L, "Alice")
+        assertEquals(MonsterAttackResult.MISS, outcome.result)
+        verify {
+            sessionLog.publish(
+                guildId = guildId,
+                type = common.events.CampaignEventType.ATTACK_MISS,
+                actorDiscordId = dmDiscordId,
+                actorName = any(),
+                payload = match { it["attackName"] == "Bite" && it["targetAc"] == 30 },
+                refEventId = null
+            )
+        }
+        verify(exactly = 0) { initiativeStore.applyDamage(any(), any(), any()) }
+    }
+
+    @Test
+    fun `monsterAttack publishes PARTICIPANT_DEFEATED when damage drops target`() {
+        val attack = MonsterAttackDto(
+            id = 42L, monsterTemplateId = 77L, name = "Bite", toHitModifier = 20, damageExpression = "1d4"
+        )
+        stubMonsterCombat(attack, InitiativeEntryData("Alice", 12, "PLAYER", maxHp = 20, currentHp = 1, ac = 1))
+        every { initiativeStore.applyDamage(guildId, "Alice", any()) } returns
+            InitiativeEntryData("Alice", 12, "PLAYER", maxHp = 20, currentHp = 0, defeated = true)
+
+        val outcome = service.monsterAttack(guildId, dmDiscordId, 42L, "Alice")
+        assertEquals(MonsterAttackResult.HIT, outcome.result)
+        assertEquals(true, outcome.targetDefeated)
+        verify {
+            sessionLog.publish(
+                guildId = guildId,
+                type = common.events.CampaignEventType.PARTICIPANT_DEFEATED,
+                actorDiscordId = dmDiscordId,
+                actorName = any(),
+                payload = match { it["target"] == "Alice" },
+                refEventId = null
+            )
+        }
     }
 }

--- a/application/src/test/kotlin/web/service/DiceExpressionRollerTest.kt
+++ b/application/src/test/kotlin/web/service/DiceExpressionRollerTest.kt
@@ -1,0 +1,88 @@
+package web.service
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import kotlin.random.Random
+
+class DiceExpressionRollerTest {
+
+    @Test
+    fun `parseAmount accepts bare integer`() {
+        val r = DiceExpressionRoller.parseAmount("45")
+        assertEquals(45, r?.total)
+        assertNull(r?.expression)
+        assertNull(r?.rolls)
+    }
+
+    @Test
+    fun `parseAmount rejects negative integer`() {
+        assertNull(DiceExpressionRoller.parseAmount("-1"))
+    }
+
+    @Test
+    fun `parseAmount rejects integer above literal cap`() {
+        assertNull(DiceExpressionRoller.parseAmount("${DiceExpressionRoller.MAX_LITERAL_AMOUNT + 1}"))
+    }
+
+    @Test
+    fun `parseAmount rolls dice expression within range`() {
+        repeat(50) {
+            val r = DiceExpressionRoller.parseAmount("3d20+30", Random(it.toLong()))
+            assertNotNull(r)
+            assertEquals("3d20+30", r!!.expression)
+            assertEquals(3, r.rolls?.size)
+            assertTrue(r.total in 33..90, "Total ${r.total} should be in 33..90")
+        }
+    }
+
+    @Test
+    fun `parseAmount with implicit count one`() {
+        val r = DiceExpressionRoller.parseAmount("d20", Random(7))
+        assertNotNull(r)
+        assertEquals(1, r!!.rolls?.size)
+        assertEquals("1d20", r.expression)
+        assertTrue(r.total in 1..20)
+    }
+
+    @Test
+    fun `parseAmount accepts negative modifier`() {
+        val r = DiceExpressionRoller.parseAmount("1d4-2", Random(0))
+        assertNotNull(r)
+        assertEquals("1d4-2", r!!.expression)
+        assertTrue(r.total >= 0, "Total ${r.total} clamped to >= 0")
+    }
+
+    @Test
+    fun `parseAmount rejects disallowed die sides`() {
+        assertNull(DiceExpressionRoller.parseAmount("1d7"))
+        assertNull(DiceExpressionRoller.parseAmount("1d13"))
+    }
+
+    @Test
+    fun `parseAmount rejects dice count over cap`() {
+        assertNull(DiceExpressionRoller.parseAmount("99d20"))
+    }
+
+    @Test
+    fun `parseAmount rejects modifier over cap`() {
+        assertNull(DiceExpressionRoller.parseAmount("1d20+999"))
+    }
+
+    @Test
+    fun `parseAmount rejects garbage`() {
+        assertNull(DiceExpressionRoller.parseAmount("garbage"))
+        assertNull(DiceExpressionRoller.parseAmount(""))
+        assertNull(DiceExpressionRoller.parseAmount("d"))
+    }
+
+    @Test
+    fun `parseAmount tolerates surrounding whitespace and case`() {
+        val r = DiceExpressionRoller.parseAmount("  2D6+3  ", Random(1))
+        assertNotNull(r)
+        assertEquals("2d6+3", r!!.expression)
+        assertTrue(r.total in 5..15)
+    }
+}

--- a/database/src/main/kotlin/database/dto/MonsterAttackDto.kt
+++ b/database/src/main/kotlin/database/dto/MonsterAttackDto.kt
@@ -1,0 +1,51 @@
+package database.dto
+
+import jakarta.persistence.*
+import java.io.Serializable
+import java.time.LocalDateTime
+
+@NamedQueries(
+    NamedQuery(
+        name = "MonsterAttackDto.listByTemplate",
+        query = "select a from MonsterAttackDto a where a.monsterTemplateId = :templateId order by a.id asc"
+    ),
+    NamedQuery(
+        name = "MonsterAttackDto.countByTemplate",
+        query = "select count(a) from MonsterAttackDto a where a.monsterTemplateId = :templateId"
+    ),
+    NamedQuery(
+        name = "MonsterAttackDto.getById",
+        query = "select a from MonsterAttackDto a where a.id = :id"
+    ),
+    NamedQuery(
+        name = "MonsterAttackDto.deleteById",
+        query = "delete from MonsterAttackDto a where a.id = :id"
+    )
+)
+@Entity
+@Table(name = "dnd_monster_attack", schema = "public")
+class MonsterAttackDto(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    var id: Long = 0,
+
+    @Column(name = "monster_template_id", nullable = false)
+    var monsterTemplateId: Long = 0,
+
+    @Column(name = "name", nullable = false, length = 60)
+    var name: String = "",
+
+    @Column(name = "to_hit_modifier", nullable = false)
+    var toHitModifier: Int = 0,
+
+    @Column(name = "damage_expression", nullable = false, length = 32)
+    var damageExpression: String = "",
+
+    @Column(name = "created_at", nullable = false)
+    var createdAt: LocalDateTime = LocalDateTime.now()
+) : Serializable {
+
+    override fun toString(): String =
+        "MonsterAttackDto(id=$id, monsterTemplateId=$monsterTemplateId, name=$name, toHit=$toHitModifier, dmg=$damageExpression)"
+}

--- a/database/src/main/kotlin/database/dto/MonsterTemplateDto.kt
+++ b/database/src/main/kotlin/database/dto/MonsterTemplateDto.kt
@@ -35,8 +35,8 @@ class MonsterTemplateDto(
     @Column(name = "initiative_modifier", nullable = false)
     var initiativeModifier: Int = 0,
 
-    @Column(name = "max_hp")
-    var maxHp: Int? = null,
+    @Column(name = "hp_expression", length = 32)
+    var hpExpression: String? = null,
 
     @Column(name = "ac")
     var ac: Int? = null,

--- a/database/src/main/kotlin/database/persistence/MonsterAttackPersistence.kt
+++ b/database/src/main/kotlin/database/persistence/MonsterAttackPersistence.kt
@@ -1,0 +1,11 @@
+package database.persistence
+
+import database.dto.MonsterAttackDto
+
+interface MonsterAttackPersistence {
+    fun save(attack: MonsterAttackDto): MonsterAttackDto
+    fun getById(id: Long): MonsterAttackDto?
+    fun listByTemplate(templateId: Long): List<MonsterAttackDto>
+    fun countByTemplate(templateId: Long): Long
+    fun deleteById(id: Long)
+}

--- a/database/src/main/kotlin/database/persistence/impl/DefaultMonsterAttackPersistence.kt
+++ b/database/src/main/kotlin/database/persistence/impl/DefaultMonsterAttackPersistence.kt
@@ -1,0 +1,54 @@
+package database.persistence.impl
+
+import database.dto.MonsterAttackDto
+import database.persistence.MonsterAttackPersistence
+import jakarta.persistence.EntityManager
+import jakarta.persistence.PersistenceContext
+import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+
+@Repository
+@Transactional
+class DefaultMonsterAttackPersistence : MonsterAttackPersistence {
+
+    @PersistenceContext
+    private lateinit var entityManager: EntityManager
+
+    override fun save(attack: MonsterAttackDto): MonsterAttackDto {
+        return if (attack.id == 0L) {
+            attack.createdAt = LocalDateTime.now()
+            entityManager.persist(attack)
+            entityManager.flush()
+            attack
+        } else {
+            val merged = entityManager.merge(attack)
+            entityManager.flush()
+            merged
+        }
+    }
+
+    override fun getById(id: Long): MonsterAttackDto? {
+        val q = entityManager.createNamedQuery("MonsterAttackDto.getById", MonsterAttackDto::class.java)
+        q.setParameter("id", id)
+        return runCatching { q.singleResult }.getOrNull()
+    }
+
+    override fun listByTemplate(templateId: Long): List<MonsterAttackDto> {
+        val q = entityManager.createNamedQuery("MonsterAttackDto.listByTemplate", MonsterAttackDto::class.java)
+        q.setParameter("templateId", templateId)
+        return q.resultList
+    }
+
+    override fun countByTemplate(templateId: Long): Long {
+        val q = entityManager.createNamedQuery("MonsterAttackDto.countByTemplate")
+        q.setParameter("templateId", templateId)
+        return (q.singleResult as Number).toLong()
+    }
+
+    override fun deleteById(id: Long) {
+        val q = entityManager.createNamedQuery("MonsterAttackDto.deleteById")
+        q.setParameter("id", id)
+        q.executeUpdate()
+    }
+}

--- a/database/src/main/kotlin/database/service/MonsterAttackService.kt
+++ b/database/src/main/kotlin/database/service/MonsterAttackService.kt
@@ -1,0 +1,11 @@
+package database.service
+
+import database.dto.MonsterAttackDto
+
+interface MonsterAttackService {
+    fun save(attack: MonsterAttackDto): MonsterAttackDto
+    fun getById(id: Long): MonsterAttackDto?
+    fun listByTemplate(templateId: Long): List<MonsterAttackDto>
+    fun countByTemplate(templateId: Long): Long
+    fun deleteById(id: Long)
+}

--- a/database/src/main/kotlin/database/service/impl/DefaultMonsterAttackService.kt
+++ b/database/src/main/kotlin/database/service/impl/DefaultMonsterAttackService.kt
@@ -1,0 +1,29 @@
+package database.service.impl
+
+import database.dto.MonsterAttackDto
+import database.persistence.MonsterAttackPersistence
+import database.service.MonsterAttackService
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional
+class DefaultMonsterAttackService(
+    private val monsterAttackPersistence: MonsterAttackPersistence
+) : MonsterAttackService {
+
+    override fun save(attack: MonsterAttackDto): MonsterAttackDto =
+        monsterAttackPersistence.save(attack)
+
+    override fun getById(id: Long): MonsterAttackDto? =
+        monsterAttackPersistence.getById(id)
+
+    override fun listByTemplate(templateId: Long): List<MonsterAttackDto> =
+        monsterAttackPersistence.listByTemplate(templateId)
+
+    override fun countByTemplate(templateId: Long): Long =
+        monsterAttackPersistence.countByTemplate(templateId)
+
+    override fun deleteById(id: Long) =
+        monsterAttackPersistence.deleteById(id)
+}

--- a/database/src/main/resources/db/migration/V7__dnd_monster_template_hp_expression.sql
+++ b/database/src/main/resources/db/migration/V7__dnd_monster_template_hp_expression.sql
@@ -1,0 +1,8 @@
+-- Allow monster HP to be a dice expression like "3d20+30" so each spawned
+-- instance can roll its own HP at initiative time. Existing fixed integers
+-- round-trip through text (the same parser accepts a bare integer literal).
+ALTER TABLE dnd_monster_template
+    ALTER COLUMN max_hp TYPE VARCHAR(32) USING max_hp::text;
+
+ALTER TABLE dnd_monster_template
+    RENAME COLUMN max_hp TO hp_expression;

--- a/database/src/main/resources/db/migration/V8__dnd_monster_attack.sql
+++ b/database/src/main/resources/db/migration/V8__dnd_monster_attack.sql
@@ -1,0 +1,16 @@
+-- Per-monster attacks. On its turn the DM picks one of these and a target;
+-- the bot rolls 1d20+to_hit_modifier vs target AC, and on hit rolls the
+-- damage_expression and applies it to the target. Cascade-deletes with the
+-- parent template so deleting a monster from the library cleans up its kit.
+CREATE TABLE IF NOT EXISTS dnd_monster_attack (
+    id BIGSERIAL PRIMARY KEY,
+    monster_template_id BIGINT NOT NULL
+        REFERENCES dnd_monster_template(id) ON DELETE CASCADE,
+    name VARCHAR(60) NOT NULL,
+    to_hit_modifier INT NOT NULL DEFAULT 0,
+    damage_expression VARCHAR(32) NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_dnd_monster_attack_template
+    ON dnd_monster_attack(monster_template_id);

--- a/discord-bot/src/main/kotlin/bot/toby/helpers/DndHelperInitiativeStore.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/helpers/DndHelperInitiativeStore.kt
@@ -25,7 +25,8 @@ class DndHelperInitiativeStore(
                     maxHp = it.maxHp,
                     currentHp = it.currentHp,
                     ac = it.ac,
-                    defeated = it.defeated
+                    defeated = it.defeated,
+                    templateId = it.templateId
                 )
             }
         )
@@ -66,6 +67,7 @@ class DndHelperInitiativeStore(
         maxHp = entry.maxHp,
         currentHp = entry.currentHp,
         ac = entry.ac,
-        defeated = entry.defeated
+        defeated = entry.defeated,
+        templateId = entry.templateId
     )
 }

--- a/discord-bot/src/main/kotlin/bot/toby/helpers/InitiativeState.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/helpers/InitiativeState.kt
@@ -73,14 +73,14 @@ class InitiativeState {
     fun snapshot(): InitiativeStateSnapshot = InitiativeStateSnapshot(
         initiativeIndex = initiativeIndex.get(),
         entries = sortedEntries.map {
-            InitiativeEntry(it.name, it.roll, it.kind, it.maxHp, it.currentHp, it.ac, it.defeated)
+            InitiativeEntry(it.name, it.roll, it.kind, it.maxHp, it.currentHp, it.ac, it.defeated, it.templateId)
         }
     )
 
     fun restoreFrom(snapshot: InitiativeStateSnapshot) {
         initiativeIndex.set(snapshot.initiativeIndex)
         sortedEntries = LinkedList(snapshot.entries.map {
-            RolledEntry(it.name, it.roll, it.kind, it.maxHp, it.currentHp, it.ac, it.defeated)
+            RolledEntry(it.name, it.roll, it.kind, it.maxHp, it.currentHp, it.ac, it.defeated, it.templateId)
         })
     }
 
@@ -134,7 +134,8 @@ data class RolledEntry(
     val maxHp: Int? = null,
     val currentHp: Int? = null,
     val ac: Int? = null,
-    val defeated: Boolean = false
+    val defeated: Boolean = false,
+    val templateId: Long? = null
 )
 
 /** JSON-friendly snapshot of an [InitiativeState], persisted in CampaignDto.state. */
@@ -150,5 +151,6 @@ data class InitiativeEntry(
     val maxHp: Int? = null,
     val currentHp: Int? = null,
     val ac: Int? = null,
-    val defeated: Boolean = false
+    val defeated: Boolean = false,
+    val templateId: Long? = null
 )

--- a/web/src/main/kotlin/web/controller/CampaignController.kt
+++ b/web/src/main/kotlin/web/controller/CampaignController.kt
@@ -17,8 +17,10 @@ import web.service.ApplyHealResult
 import web.service.AttackResult
 import web.service.CampaignEventBroadcaster
 import web.service.CampaignWebService
+import web.service.DeleteAttackResult
 import web.service.DeleteNoteResult
 import web.service.DeleteTemplateResult
+import web.service.MonsterAttackResult
 import web.service.EndResult
 import web.service.InitiativeRollRequest
 import web.service.JoinResult
@@ -28,6 +30,7 @@ import web.service.MonsterTemplateView
 import web.service.NarrateResult
 import web.service.RollDiceResult
 import web.service.RollInitiativeResult
+import web.service.SaveAttackResult
 import web.service.SaveTemplateResult
 import web.service.SessionEventView
 import web.service.SetAliveResult
@@ -364,7 +367,7 @@ class CampaignController(
         @RequestParam(name = "id", required = false) id: Long?,
         @RequestParam("name") name: String,
         @RequestParam("initiativeModifier") initiativeModifier: Int,
-        @RequestParam(name = "maxHp", required = false) maxHp: Int?,
+        @RequestParam(name = "hpExpression", required = false) hpExpression: String?,
         @RequestParam(name = "ac", required = false) ac: Int?,
         @AuthenticationPrincipal user: OAuth2User,
         ra: RedirectAttributes
@@ -372,12 +375,16 @@ class CampaignController(
         val discordId = user.discordIdOrNull()
             ?: return "redirect:/dnd/campaign"
 
-        when (campaignWebService.saveTemplate(discordId, id, name, initiativeModifier, maxHp, ac)) {
+        when (campaignWebService.saveTemplate(discordId, id, name, initiativeModifier, hpExpression, ac)) {
             SaveTemplateResult.SAVED -> {}
             SaveTemplateResult.NAME_BLANK -> ra.addFlashAttribute("error", "Monster name can't be empty.")
             SaveTemplateResult.NAME_TOO_LONG -> ra.addFlashAttribute(
                 "error",
                 "Monster name is too long (max ${web.service.CampaignWebService.MAX_TEMPLATE_NAME_LENGTH} characters)."
+            )
+            SaveTemplateResult.INVALID_HP -> ra.addFlashAttribute(
+                "error",
+                "HP must be a number or a dice expression like '3d20+30'."
             )
             SaveTemplateResult.NOT_FOUND -> ra.addFlashAttribute("error", "That template doesn't exist.")
             SaveTemplateResult.NOT_OWNER -> ra.addFlashAttribute("error", "You can only edit your own templates.")
@@ -403,6 +410,114 @@ class CampaignController(
         return "redirect:/dnd/campaign/$guildId"
     }
 
+    @PostMapping("/campaign/{guildId}/monsters/templates/{templateId}/attacks")
+    fun saveMonsterAttack(
+        @PathVariable guildId: Long,
+        @PathVariable templateId: Long,
+        @RequestParam(name = "id", required = false) attackId: Long?,
+        @RequestParam("name") name: String,
+        @RequestParam(name = "toHitModifier", defaultValue = "0") toHitModifier: Int,
+        @RequestParam("damageExpression") damageExpression: String,
+        @AuthenticationPrincipal user: OAuth2User,
+        ra: RedirectAttributes
+    ): String {
+        val discordId = user.discordIdOrNull()
+            ?: return "redirect:/dnd/campaign"
+
+        when (campaignWebService.saveAttack(discordId, templateId, attackId, name, toHitModifier, damageExpression)) {
+            SaveAttackResult.SAVED -> {}
+            SaveAttackResult.NAME_BLANK -> ra.addFlashAttribute("error", "Attack name can't be empty.")
+            SaveAttackResult.NAME_TOO_LONG -> ra.addFlashAttribute(
+                "error",
+                "Attack name is too long (max ${web.service.CampaignWebService.MAX_ATTACK_NAME_LENGTH} characters)."
+            )
+            SaveAttackResult.INVALID_MODIFIER -> ra.addFlashAttribute(
+                "error",
+                "To-hit modifier must be between -${web.service.CampaignWebService.MAX_ATTACK_MODIFIER} and ${web.service.CampaignWebService.MAX_ATTACK_MODIFIER}."
+            )
+            SaveAttackResult.INVALID_DAMAGE -> ra.addFlashAttribute(
+                "error",
+                "Damage must be a number or a dice expression like '2d6+3'."
+            )
+            SaveAttackResult.TOO_MANY -> ra.addFlashAttribute(
+                "error",
+                "This monster already has the maximum of ${web.service.CampaignWebService.MAX_ATTACKS_PER_TEMPLATE} attacks."
+            )
+            SaveAttackResult.TEMPLATE_NOT_FOUND -> ra.addFlashAttribute("error", "That monster template doesn't exist.")
+            SaveAttackResult.NOT_OWNER -> ra.addFlashAttribute("error", "You can only edit your own monsters.")
+            SaveAttackResult.ATTACK_NOT_FOUND -> ra.addFlashAttribute("error", "That attack doesn't exist.")
+            SaveAttackResult.ATTACK_TEMPLATE_MISMATCH -> ra.addFlashAttribute(
+                "error",
+                "That attack belongs to a different monster."
+            )
+        }
+        return "redirect:/dnd/campaign/$guildId"
+    }
+
+    @PostMapping("/campaign/{guildId}/monsters/templates/{templateId}/attacks/{attackId}/delete")
+    fun deleteMonsterAttack(
+        @PathVariable guildId: Long,
+        @PathVariable templateId: Long,
+        @PathVariable attackId: Long,
+        @AuthenticationPrincipal user: OAuth2User,
+        ra: RedirectAttributes
+    ): String {
+        val discordId = user.discordIdOrNull()
+            ?: return "redirect:/dnd/campaign"
+
+        when (campaignWebService.deleteAttack(discordId, templateId, attackId)) {
+            DeleteAttackResult.DELETED -> {}
+            DeleteAttackResult.ATTACK_NOT_FOUND -> ra.addFlashAttribute("error", "That attack doesn't exist.")
+            DeleteAttackResult.NOT_OWNER -> ra.addFlashAttribute("error", "You can only delete your own monsters' attacks.")
+            DeleteAttackResult.ATTACK_TEMPLATE_MISMATCH -> ra.addFlashAttribute(
+                "error",
+                "That attack belongs to a different monster."
+            )
+        }
+        return "redirect:/dnd/campaign/$guildId"
+    }
+
+    @PostMapping("/campaign/{guildId}/combat/monster-attack")
+    fun monsterAttack(
+        @PathVariable guildId: Long,
+        @RequestParam("attackId") attackId: Long,
+        @RequestParam("targetName") targetName: String,
+        @AuthenticationPrincipal user: OAuth2User,
+        ra: RedirectAttributes
+    ): String {
+        val discordId = user.discordIdOrNull()
+            ?: return "redirect:/dnd/campaign"
+
+        val outcome = campaignWebService.monsterAttack(guildId, discordId, attackId, targetName.trim())
+        when (outcome.result) {
+            MonsterAttackResult.HIT, MonsterAttackResult.MISS -> {}
+            MonsterAttackResult.NO_ACTIVE_CAMPAIGN -> ra.addFlashAttribute("error", "No active campaign in this server.")
+            MonsterAttackResult.NO_ACTIVE_COMBAT -> ra.addFlashAttribute("error", "Combat isn't active.")
+            MonsterAttackResult.NOT_DM -> ra.addFlashAttribute("error", "Only the Dungeon Master can drive monster attacks.")
+            MonsterAttackResult.CURRENT_NOT_MONSTER -> ra.addFlashAttribute(
+                "error",
+                "It's not a monster's turn right now."
+            )
+            MonsterAttackResult.NO_TEMPLATE -> ra.addFlashAttribute(
+                "error",
+                "This monster has no template — add it to your library first."
+            )
+            MonsterAttackResult.ATTACK_NOT_FOUND -> ra.addFlashAttribute("error", "That attack doesn't exist.")
+            MonsterAttackResult.ATTACK_TEMPLATE_MISMATCH -> ra.addFlashAttribute(
+                "error",
+                "That attack doesn't belong to the current monster."
+            )
+            MonsterAttackResult.INVALID_DAMAGE -> ra.addFlashAttribute(
+                "error",
+                "This attack's damage expression is invalid — please re-save it."
+            )
+            MonsterAttackResult.TARGET_NOT_FOUND -> ra.addFlashAttribute("error", "Target not found in initiative.")
+            MonsterAttackResult.TARGET_DEFEATED -> ra.addFlashAttribute("error", "That target is already defeated.")
+            MonsterAttackResult.CANT_TARGET_SELF -> ra.addFlashAttribute("error", "A monster can't attack itself.")
+        }
+        return "redirect:/dnd/campaign/$guildId"
+    }
+
     @PostMapping("/campaign/{guildId}/initiative/roll")
     fun rollInitiative(
         @PathVariable guildId: Long,
@@ -411,7 +526,7 @@ class CampaignController(
         @RequestParam(name = "templateQty", required = false) templateQtys: List<Int>?,
         @RequestParam(name = "adhocName", required = false) adhocNames: List<String>?,
         @RequestParam(name = "adhocMod", required = false) adhocMods: List<Int>?,
-        @RequestParam(name = "adhocHp", required = false) adhocHps: List<Int>?,
+        @RequestParam(name = "adhocHpExpr", required = false) adhocHpExprs: List<String>?,
         @RequestParam(name = "adhocAc", required = false) adhocAcs: List<Int>?,
         @AuthenticationPrincipal user: OAuth2User,
         ra: RedirectAttributes
@@ -428,7 +543,7 @@ class CampaignController(
 
         val names = adhocNames.orEmpty()
         val mods = adhocMods.orEmpty()
-        val hps = adhocHps.orEmpty()
+        val hpExprs = adhocHpExprs.orEmpty()
         val acs = adhocAcs.orEmpty()
         val adhoc = names.mapIndexedNotNull { i, n ->
             val cleaned = n.trim()
@@ -436,7 +551,7 @@ class CampaignController(
             else AdhocMonster(
                 name = cleaned,
                 initiativeModifier = mods.getOrElse(i) { 0 },
-                maxHp = hps.getOrNull(i)?.takeIf { it > 0 },
+                hpExpression = hpExprs.getOrNull(i)?.trim()?.takeIf { it.isNotEmpty() },
                 ac = acs.getOrNull(i)?.takeIf { it > 0 }
             )
         }

--- a/web/src/main/kotlin/web/service/CampaignWebService.kt
+++ b/web/src/main/kotlin/web/service/CampaignWebService.kt
@@ -158,16 +158,7 @@ enum class MonsterAttackResult {
 
 data class MonsterAttackOutcome(
     val result: MonsterAttackResult,
-    val attacker: String? = null,
-    val target: String? = null,
     val attackName: String? = null,
-    val rawRoll: Int? = null,
-    val toHit: Int? = null,
-    val total: Int? = null,
-    val targetAc: Int? = null,
-    val damageTotal: Int? = null,
-    val damageExpression: String? = null,
-    val damageRolls: List<Int>? = null,
     val targetDefeated: Boolean = false
 )
 enum class RollInitiativeResult { ROLLED, NO_ACTIVE_CAMPAIGN, NOT_DM, EMPTY_ROSTER, TEMPLATE_NOT_FOUND }
@@ -873,21 +864,13 @@ class CampaignWebService(
         if (!hit) {
             return MonsterAttackOutcome(
                 result = MonsterAttackResult.MISS,
-                attacker = current.name,
-                target = target.name,
-                attackName = attack.name,
-                rawRoll = raw,
-                toHit = attack.toHitModifier,
-                total = total,
-                targetAc = target.ac
+                attackName = attack.name
             )
         }
 
         val rolledDamage = DiceExpressionRoller.parseAmount(attack.damageExpression)
             ?: return MonsterAttackOutcome(
                 result = MonsterAttackResult.INVALID_DAMAGE,
-                attacker = current.name,
-                target = target.name,
                 attackName = attack.name
             )
         val updated = initiativeStore.applyDamage(guildId, target.name, rolledDamage.total)
@@ -922,16 +905,7 @@ class CampaignWebService(
 
         return MonsterAttackOutcome(
             result = MonsterAttackResult.HIT,
-            attacker = current.name,
-            target = updated.name,
             attackName = attack.name,
-            rawRoll = raw,
-            toHit = attack.toHitModifier,
-            total = total,
-            targetAc = target.ac,
-            damageTotal = rolledDamage.total,
-            damageExpression = rolledDamage.expression,
-            damageRolls = rolledDamage.rolls,
             targetDefeated = updated.defeated
         )
     }

--- a/web/src/main/kotlin/web/service/CampaignWebService.kt
+++ b/web/src/main/kotlin/web/service/CampaignWebService.kt
@@ -15,6 +15,8 @@ import database.service.CampaignEventService
 import database.service.CampaignPlayerService
 import database.service.CampaignService
 import database.service.CharacterSheetService
+import database.dto.MonsterAttackDto
+import database.service.MonsterAttackService
 import database.service.MonsterTemplateService
 import database.service.SessionNoteService
 import database.service.UserService
@@ -49,21 +51,31 @@ data class RolledEntryView(
     val maxHp: Int? = null,
     val currentHp: Int? = null,
     val ac: Int? = null,
-    val defeated: Boolean = false
+    val defeated: Boolean = false,
+    val templateId: Long? = null,
+    val attacks: List<MonsterAttackView> = emptyList()
+)
+
+data class MonsterAttackView(
+    val id: Long,
+    val name: String,
+    val toHitModifier: Int,
+    val damageExpression: String
 )
 
 data class MonsterTemplateView(
     val id: Long,
     val name: String,
     val initiativeModifier: Int,
-    val maxHp: Int?,
-    val ac: Int?
+    val hpExpression: String?,
+    val ac: Int?,
+    val attacks: List<MonsterAttackView> = emptyList()
 )
 
 data class AdhocMonster(
     val name: String,
     val initiativeModifier: Int,
-    val maxHp: Int? = null,
+    val hpExpression: String? = null,
     val ac: Int? = null
 )
 
@@ -126,8 +138,35 @@ enum class AddNoteResult { ADDED, NO_ACTIVE_CAMPAIGN, NOT_PARTICIPANT, EMPTY_BOD
 enum class DeleteNoteResult { DELETED, NO_ACTIVE_CAMPAIGN, NOT_FOUND, NOT_ALLOWED }
 enum class AnnotateRollResult { ANNOTATED, NO_ACTIVE_CAMPAIGN, NOT_DM, NOT_FOUND, NOT_A_ROLL, INVALID_KIND }
 enum class NarrateResult { NARRATED, NO_ACTIVE_CAMPAIGN, NOT_DM, EMPTY_BODY, BODY_TOO_LONG }
-enum class SaveTemplateResult { SAVED, NAME_BLANK, NAME_TOO_LONG, NOT_FOUND, NOT_OWNER }
+enum class SaveTemplateResult { SAVED, NAME_BLANK, NAME_TOO_LONG, INVALID_HP, NOT_FOUND, NOT_OWNER }
 enum class DeleteTemplateResult { DELETED, NOT_FOUND, NOT_OWNER }
+enum class SaveAttackResult {
+    SAVED, NAME_BLANK, NAME_TOO_LONG, INVALID_MODIFIER, INVALID_DAMAGE,
+    TOO_MANY, TEMPLATE_NOT_FOUND, NOT_OWNER, ATTACK_NOT_FOUND, ATTACK_TEMPLATE_MISMATCH
+}
+enum class DeleteAttackResult { DELETED, ATTACK_NOT_FOUND, NOT_OWNER, ATTACK_TEMPLATE_MISMATCH }
+enum class MonsterAttackResult {
+    HIT, MISS,
+    NO_ACTIVE_CAMPAIGN, NO_ACTIVE_COMBAT, NOT_DM,
+    CURRENT_NOT_MONSTER, NO_TEMPLATE,
+    ATTACK_NOT_FOUND, ATTACK_TEMPLATE_MISMATCH, INVALID_DAMAGE,
+    TARGET_NOT_FOUND, TARGET_DEFEATED, CANT_TARGET_SELF
+}
+
+data class MonsterAttackOutcome(
+    val result: MonsterAttackResult,
+    val attacker: String? = null,
+    val target: String? = null,
+    val attackName: String? = null,
+    val rawRoll: Int? = null,
+    val toHit: Int? = null,
+    val total: Int? = null,
+    val targetAc: Int? = null,
+    val damageTotal: Int? = null,
+    val damageExpression: String? = null,
+    val damageRolls: List<Int>? = null,
+    val targetDefeated: Boolean = false
+)
 enum class RollInitiativeResult { ROLLED, NO_ACTIVE_CAMPAIGN, NOT_DM, EMPTY_ROSTER, TEMPLATE_NOT_FOUND }
 enum class RollDiceResult { ROLLED, NO_ACTIVE_CAMPAIGN, NOT_PARTICIPANT, INVALID_SIDES, INVALID_COUNT, INVALID_MODIFIER, INVALID_EXPRESSION }
 
@@ -171,6 +210,7 @@ class CampaignWebService(
     private val sessionNoteService: SessionNoteService,
     private val campaignEventService: CampaignEventService,
     private val monsterTemplateService: MonsterTemplateService,
+    private val monsterAttackService: MonsterAttackService,
     private val initiativeStore: InitiativeStore,
     private val sessionLog: SessionLogPublisher,
     private val jda: JDA
@@ -186,12 +226,13 @@ class CampaignWebService(
         const val MAX_NARRATE_BODY_LENGTH = 1000
         const val DEFAULT_EVENT_LIMIT = 100
         const val MAX_TEMPLATE_NAME_LENGTH = 100
-        const val MAX_DICE_COUNT = 20
-        const val MAX_DICE_MODIFIER = 50
+        const val MAX_ATTACK_NAME_LENGTH = 60
+        const val MAX_ATTACKS_PER_TEMPLATE = 12
         const val MAX_ATTACK_MODIFIER = 30
-        const val MAX_DAMAGE_AMOUNT = 1000
-        val ALLOWED_DIE_SIDES = setOf(4, 6, 8, 10, 12, 20, 100)
-        private val DICE_EXPR_REGEX = Regex("^(\\d*)d(\\d+)([+-]\\d+)?$", RegexOption.IGNORE_CASE)
+        const val MAX_DICE_COUNT = DiceExpressionRoller.MAX_DICE_COUNT
+        const val MAX_DICE_MODIFIER = DiceExpressionRoller.MAX_DICE_MODIFIER
+        const val MAX_DAMAGE_AMOUNT = DiceExpressionRoller.MAX_LITERAL_AMOUNT
+        val ALLOWED_DIE_SIDES = DiceExpressionRoller.ALLOWED_DIE_SIDES
     }
 
     fun getMutualGuildsWithCampaigns(accessToken: String): List<GuildCampaignInfo> {
@@ -272,7 +313,11 @@ class CampaignWebService(
                         maxHp = it.maxHp,
                         currentHp = it.currentHp,
                         ac = it.ac,
-                        defeated = it.defeated
+                        defeated = it.defeated,
+                        templateId = it.templateId,
+                        attacks = it.templateId?.let { tid ->
+                            monsterAttackService.listByTemplate(tid).map(::toMonsterAttackView)
+                        } ?: emptyList()
                     )
                 },
                 currentIndex = initiativeStore.currentIndex(guildId)
@@ -315,8 +360,17 @@ class CampaignWebService(
             id = dto.id,
             name = dto.name,
             initiativeModifier = dto.initiativeModifier,
-            maxHp = dto.maxHp,
-            ac = dto.ac
+            hpExpression = dto.hpExpression,
+            ac = dto.ac,
+            attacks = monsterAttackService.listByTemplate(dto.id).map(::toMonsterAttackView)
+        )
+
+    private fun toMonsterAttackView(dto: MonsterAttackDto): MonsterAttackView =
+        MonsterAttackView(
+            id = dto.id,
+            name = dto.name,
+            toHitModifier = dto.toHitModifier,
+            damageExpression = dto.damageExpression
         )
 
     fun listRecentEvents(guildId: Long, sinceId: Long?, limit: Int): List<SessionEventView> {
@@ -589,7 +643,9 @@ class CampaignWebService(
         expression: String? = null
     ): RollDiceResult {
         val trimmedExpr = expression?.trim()?.takeIf { it.isNotEmpty() }
-        val parsed = trimmedExpr?.let { parseDiceExpression(it) ?: return RollDiceResult.INVALID_EXPRESSION }
+        val parsed = trimmedExpr?.let {
+            DiceExpressionRoller.parseDiceExpression(it) ?: return RollDiceResult.INVALID_EXPRESSION
+        }
         val finalCount = parsed?.count ?: count
         val finalSides = parsed?.sides ?: sides
         val finalMod = parsed?.modifier ?: modifier
@@ -619,18 +675,6 @@ class CampaignWebService(
         return RollDiceResult.ROLLED
     }
 
-    private data class ParsedDice(val count: Int, val sides: Int, val modifier: Int)
-
-    private fun parseDiceExpression(raw: String): ParsedDice? {
-        val cleaned = raw.filterNot { it.isWhitespace() }
-        if (cleaned.isEmpty()) return null
-        val match = DICE_EXPR_REGEX.matchEntire(cleaned) ?: return null
-        val count = match.groupValues[1].ifEmpty { "1" }.toIntOrNull() ?: return null
-        val sides = match.groupValues[2].toIntOrNull() ?: return null
-        val modifier = match.groupValues[3].takeIf { it.isNotEmpty() }?.toIntOrNull() ?: 0
-        return ParsedDice(count, sides, modifier)
-    }
-
     fun listTemplatesForDm(dmDiscordId: Long): List<MonsterTemplateView> =
         monsterTemplateService.listByDm(dmDiscordId).map(::toMonsterTemplateView)
 
@@ -639,12 +683,17 @@ class CampaignWebService(
         id: Long?,
         name: String,
         initiativeModifier: Int,
-        maxHp: Int?,
+        hpExpression: String?,
         ac: Int?
     ): SaveTemplateResult {
         val trimmed = name.trim()
         if (trimmed.isEmpty()) return SaveTemplateResult.NAME_BLANK
         if (trimmed.length > MAX_TEMPLATE_NAME_LENGTH) return SaveTemplateResult.NAME_TOO_LONG
+
+        val cleanedHp = hpExpression?.trim()?.takeIf { it.isNotEmpty() }
+        if (cleanedHp != null && DiceExpressionRoller.parseAmount(cleanedHp) == null) {
+            return SaveTemplateResult.INVALID_HP
+        }
 
         val dto = if (id != null && id > 0) {
             val existing = monsterTemplateService.getById(id) ?: return SaveTemplateResult.NOT_FOUND
@@ -652,7 +701,7 @@ class CampaignWebService(
             existing.apply {
                 this.name = trimmed
                 this.initiativeModifier = initiativeModifier
-                this.maxHp = maxHp
+                this.hpExpression = cleanedHp
                 this.ac = ac
             }
         } else {
@@ -660,7 +709,7 @@ class CampaignWebService(
                 dmDiscordId = dmDiscordId,
                 name = trimmed,
                 initiativeModifier = initiativeModifier,
-                maxHp = maxHp,
+                hpExpression = cleanedHp,
                 ac = ac
             )
         }
@@ -673,6 +722,205 @@ class CampaignWebService(
         if (existing.dmDiscordId != dmDiscordId) return DeleteTemplateResult.NOT_OWNER
         monsterTemplateService.deleteById(id)
         return DeleteTemplateResult.DELETED
+    }
+
+    /**
+     * Create or update an attack on a monster template. Validates that the
+     * caller owns the template, the name and damage expression are sane, and
+     * the per-template attack cap isn't exceeded. The attack's
+     * [damageExpression] is stored verbatim and rolled fresh on each use.
+     */
+    fun saveAttack(
+        dmDiscordId: Long,
+        templateId: Long,
+        attackId: Long?,
+        name: String,
+        toHitModifier: Int,
+        damageExpression: String
+    ): SaveAttackResult {
+        val template = monsterTemplateService.getById(templateId)
+            ?: return SaveAttackResult.TEMPLATE_NOT_FOUND
+        if (template.dmDiscordId != dmDiscordId) return SaveAttackResult.NOT_OWNER
+
+        val trimmedName = name.trim()
+        if (trimmedName.isEmpty()) return SaveAttackResult.NAME_BLANK
+        if (trimmedName.length > MAX_ATTACK_NAME_LENGTH) return SaveAttackResult.NAME_TOO_LONG
+        if (toHitModifier !in -MAX_ATTACK_MODIFIER..MAX_ATTACK_MODIFIER) {
+            return SaveAttackResult.INVALID_MODIFIER
+        }
+        val trimmedDamage = damageExpression.trim()
+        if (trimmedDamage.isEmpty() || DiceExpressionRoller.parseAmount(trimmedDamage) == null) {
+            return SaveAttackResult.INVALID_DAMAGE
+        }
+
+        val dto = if (attackId != null && attackId > 0) {
+            val existing = monsterAttackService.getById(attackId)
+                ?: return SaveAttackResult.ATTACK_NOT_FOUND
+            if (existing.monsterTemplateId != templateId) {
+                return SaveAttackResult.ATTACK_TEMPLATE_MISMATCH
+            }
+            existing.apply {
+                this.name = trimmedName
+                this.toHitModifier = toHitModifier
+                this.damageExpression = trimmedDamage
+            }
+        } else {
+            if (monsterAttackService.countByTemplate(templateId) >= MAX_ATTACKS_PER_TEMPLATE) {
+                return SaveAttackResult.TOO_MANY
+            }
+            MonsterAttackDto(
+                monsterTemplateId = templateId,
+                name = trimmedName,
+                toHitModifier = toHitModifier,
+                damageExpression = trimmedDamage
+            )
+        }
+        monsterAttackService.save(dto)
+        return SaveAttackResult.SAVED
+    }
+
+    fun deleteAttack(dmDiscordId: Long, templateId: Long, attackId: Long): DeleteAttackResult {
+        val existing = monsterAttackService.getById(attackId)
+            ?: return DeleteAttackResult.ATTACK_NOT_FOUND
+        if (existing.monsterTemplateId != templateId) {
+            return DeleteAttackResult.ATTACK_TEMPLATE_MISMATCH
+        }
+        val template = monsterTemplateService.getById(existing.monsterTemplateId)
+            ?: return DeleteAttackResult.ATTACK_NOT_FOUND
+        if (template.dmDiscordId != dmDiscordId) return DeleteAttackResult.NOT_OWNER
+        monsterAttackService.deleteById(attackId)
+        return DeleteAttackResult.DELETED
+    }
+
+    /**
+     * Execute one of the current monster's attacks against [targetName]. The
+     * DM drives this on the monster's turn. Rolls 1d20 + the attack's to-hit
+     * modifier vs target AC (auto-hit when target.ac is null), publishes
+     * ATTACK_HIT/MISS, and on hit rolls the attack's damage expression and
+     * applies it via the existing [InitiativeStore.applyDamage] (publishing
+     * DAMAGE_DEALT and PARTICIPANT_DEFEATED as appropriate).
+     */
+    fun monsterAttack(
+        guildId: Long,
+        requestingDiscordId: Long,
+        attackId: Long,
+        targetName: String
+    ): MonsterAttackOutcome {
+        val campaign = campaignService.getActiveCampaignForGuild(guildId)
+            ?: return MonsterAttackOutcome(MonsterAttackResult.NO_ACTIVE_CAMPAIGN)
+        if (campaign.dmDiscordId != requestingDiscordId) {
+            return MonsterAttackOutcome(MonsterAttackResult.NOT_DM)
+        }
+        if (!initiativeStore.isActive(guildId)) {
+            return MonsterAttackOutcome(MonsterAttackResult.NO_ACTIVE_COMBAT)
+        }
+        val current = initiativeStore.currentEntry(guildId)
+            ?: return MonsterAttackOutcome(MonsterAttackResult.NO_ACTIVE_COMBAT)
+        if (current.kind != "MONSTER") {
+            return MonsterAttackOutcome(MonsterAttackResult.CURRENT_NOT_MONSTER)
+        }
+        val templateId = current.templateId
+            ?: return MonsterAttackOutcome(MonsterAttackResult.NO_TEMPLATE)
+
+        val attack = monsterAttackService.getById(attackId)
+            ?: return MonsterAttackOutcome(MonsterAttackResult.ATTACK_NOT_FOUND)
+        if (attack.monsterTemplateId != templateId) {
+            return MonsterAttackOutcome(MonsterAttackResult.ATTACK_TEMPLATE_MISMATCH)
+        }
+
+        val target = initiativeStore.currentEntries(guildId).firstOrNull { it.name == targetName }
+            ?: return MonsterAttackOutcome(MonsterAttackResult.TARGET_NOT_FOUND)
+        if (target.name == current.name) {
+            return MonsterAttackOutcome(MonsterAttackResult.CANT_TARGET_SELF)
+        }
+        if (target.defeated) return MonsterAttackOutcome(MonsterAttackResult.TARGET_DEFEATED)
+
+        val raw = Random.nextInt(1, 21)
+        val total = raw + attack.toHitModifier
+        val hit = target.ac?.let { total >= it } ?: true
+        val type = if (hit) CampaignEventType.ATTACK_HIT else CampaignEventType.ATTACK_MISS
+        val requesterName = resolveMemberName(guildId, requestingDiscordId)
+
+        sessionLog.publish(
+            guildId = guildId,
+            type = type,
+            actorDiscordId = requestingDiscordId,
+            actorName = requesterName,
+            payload = mapOf(
+                "attacker" to current.name,
+                "target" to target.name,
+                "attackName" to attack.name,
+                "roll" to raw,
+                "modifier" to attack.toHitModifier,
+                "total" to total,
+                "targetAc" to target.ac
+            )
+        )
+
+        if (!hit) {
+            return MonsterAttackOutcome(
+                result = MonsterAttackResult.MISS,
+                attacker = current.name,
+                target = target.name,
+                attackName = attack.name,
+                rawRoll = raw,
+                toHit = attack.toHitModifier,
+                total = total,
+                targetAc = target.ac
+            )
+        }
+
+        val rolledDamage = DiceExpressionRoller.parseAmount(attack.damageExpression)
+            ?: return MonsterAttackOutcome(
+                result = MonsterAttackResult.INVALID_DAMAGE,
+                attacker = current.name,
+                target = target.name,
+                attackName = attack.name
+            )
+        val updated = initiativeStore.applyDamage(guildId, target.name, rolledDamage.total)
+            ?: return MonsterAttackOutcome(MonsterAttackResult.TARGET_NOT_FOUND)
+
+        sessionLog.publish(
+            guildId = guildId,
+            type = CampaignEventType.DAMAGE_DEALT,
+            actorDiscordId = requestingDiscordId,
+            actorName = requesterName,
+            payload = buildCombatAmountPayload(
+                base = mapOf(
+                    "attacker" to current.name,
+                    "target" to updated.name,
+                    "attackName" to attack.name,
+                    "amount" to rolledDamage.total,
+                    "remainingHp" to updated.currentHp,
+                    "maxHp" to updated.maxHp
+                ),
+                parsed = rolledDamage
+            )
+        )
+        if (updated.defeated) {
+            sessionLog.publish(
+                guildId = guildId,
+                type = CampaignEventType.PARTICIPANT_DEFEATED,
+                actorDiscordId = requestingDiscordId,
+                actorName = requesterName,
+                payload = mapOf("target" to updated.name)
+            )
+        }
+
+        return MonsterAttackOutcome(
+            result = MonsterAttackResult.HIT,
+            attacker = current.name,
+            target = updated.name,
+            attackName = attack.name,
+            rawRoll = raw,
+            toHit = attack.toHitModifier,
+            total = total,
+            targetAc = target.ac,
+            damageTotal = rolledDamage.total,
+            damageExpression = rolledDamage.expression,
+            damageRolls = rolledDamage.rolls,
+            targetDefeated = updated.defeated
+        )
     }
 
     fun rollInitiative(
@@ -709,26 +957,29 @@ class CampaignWebService(
             if (template.dmDiscordId != requestingDiscordId) {
                 return RollInitiativeResult.TEMPLATE_NOT_FOUND
             }
+            val rolledHp = rollMonsterHp(template.hpExpression)
             entries += InitiativeEntryData(
                 name = template.name,
                 roll = rollD20() + template.initiativeModifier,
                 kind = "MONSTER",
                 modifier = template.initiativeModifier,
-                maxHp = template.maxHp,
-                currentHp = template.maxHp,
-                ac = template.ac
+                maxHp = rolledHp,
+                currentHp = rolledHp,
+                ac = template.ac,
+                templateId = template.id
             )
         }
 
         request.adhocMonsters.forEach { monster ->
             val cleanName = monster.name.trim().ifEmpty { "Monster" }
+            val rolledHp = rollMonsterHp(monster.hpExpression)
             entries += InitiativeEntryData(
                 name = cleanName,
                 roll = rollD20() + monster.initiativeModifier,
                 kind = "MONSTER",
                 modifier = monster.initiativeModifier,
-                maxHp = monster.maxHp,
-                currentHp = monster.maxHp,
+                maxHp = rolledHp,
+                currentHp = rolledHp,
                 ac = monster.ac
             )
         }
@@ -833,46 +1084,8 @@ class CampaignWebService(
      * typed a dice formula; in that case [rolls] holds the individual rolled
      * faces so the session log can narrate "rolled 2d6+3 = 11".
      */
-    private data class CombatAmount(
-        val total: Int,
-        val expression: String?,
-        val rolls: List<Int>?
-    )
-
-    /**
-     * Accepts either an integer (`"6"`) or a dice expression (`"2d6+3"`, `"d20-1"`)
-     * and returns a parsed [CombatAmount]. Integer totals outside [1, MAX_DAMAGE_AMOUNT]
-     * are rejected; dice expressions inherit the same count/modifier caps used
-     * by the generic dice roller so a single form can't be used to DOS us.
-     */
-    private fun parseCombatAmount(raw: String): CombatAmount? {
-        val trimmed = raw.trim()
-        if (trimmed.isEmpty()) return null
-        trimmed.toIntOrNull()?.let { literal ->
-            if (literal < 0 || literal > MAX_DAMAGE_AMOUNT) return null
-            return CombatAmount(total = literal, expression = null, rolls = null)
-        }
-        val parsed = parseDiceExpression(trimmed) ?: return null
-        if (parsed.sides !in ALLOWED_DIE_SIDES) return null
-        if (parsed.count !in 1..MAX_DICE_COUNT) return null
-        if (parsed.modifier !in -MAX_DICE_MODIFIER..MAX_DICE_MODIFIER) return null
-        val rolled = (0 until parsed.count).map { Random.nextInt(1, parsed.sides + 1) }
-        val total = (rolled.sum() + parsed.modifier).coerceAtLeast(0)
-        return CombatAmount(
-            total = total,
-            expression = normaliseExpression(parsed),
-            rolls = rolled
-        )
-    }
-
-    private fun normaliseExpression(parsed: ParsedDice): String {
-        val mod = when {
-            parsed.modifier > 0 -> "+${parsed.modifier}"
-            parsed.modifier < 0 -> parsed.modifier.toString()
-            else -> ""
-        }
-        return "${parsed.count}d${parsed.sides}$mod"
-    }
+    private fun parseCombatAmount(raw: String): DiceExpressionRoller.RolledAmount? =
+        DiceExpressionRoller.parseAmount(raw)
 
     /**
      * Applies damage to the named target in the guild's combat tracker.
@@ -992,7 +1205,7 @@ class CampaignWebService(
 
     private fun buildCombatAmountPayload(
         base: Map<String, Any?>,
-        parsed: CombatAmount
+        parsed: DiceExpressionRoller.RolledAmount
     ): Map<String, Any?> {
         if (parsed.expression == null) return base
         return base + mapOf(
@@ -1021,6 +1234,23 @@ class CampaignWebService(
     }
 
     private fun rollD20(): Int = Random.nextInt(1, 21)
+
+    /**
+     * Roll a monster's HP from its template/ad-hoc [hpExpression]. Accepts a
+     * literal integer (`"45"`) or dice expression (`"3d20+30"`); each call
+     * produces an independent roll, so two instances of the same template get
+     * different totals. Returns null when the input is null/blank, or when an
+     * already-stored expression no longer parses (logged + treated as untracked HP).
+     */
+    private fun rollMonsterHp(hpExpression: String?): Int? {
+        val cleaned = hpExpression?.trim()?.takeIf { it.isNotEmpty() } ?: return null
+        val rolled = DiceExpressionRoller.parseAmount(cleaned)
+        if (rolled == null) {
+            logger.warn("Unparseable monster HP expression: $cleaned")
+            return null
+        }
+        return rolled.total
+    }
 
     private fun loadCharacterSummary(characterId: Long): CharacterSummary? {
         val json = characterSheetService.getSheet(characterId) ?: return null

--- a/web/src/main/kotlin/web/service/DiceExpressionRoller.kt
+++ b/web/src/main/kotlin/web/service/DiceExpressionRoller.kt
@@ -49,7 +49,7 @@ object DiceExpressionRoller {
         val trimmed = raw.trim()
         if (trimmed.isEmpty()) return null
         trimmed.toIntOrNull()?.let { literal ->
-            if (literal < 0 || literal > MAX_LITERAL_AMOUNT) return null
+            if (literal !in 0..MAX_LITERAL_AMOUNT) return null
             return RolledAmount(total = literal, expression = null, rolls = null)
         }
         val parsed = parseDiceExpression(trimmed) ?: return null
@@ -65,7 +65,7 @@ object DiceExpressionRoller {
         )
     }
 
-    fun normaliseExpression(parsed: ParsedDice): String {
+    private fun normaliseExpression(parsed: ParsedDice): String {
         val mod = when {
             parsed.modifier > 0 -> "+${parsed.modifier}"
             parsed.modifier < 0 -> parsed.modifier.toString()

--- a/web/src/main/kotlin/web/service/DiceExpressionRoller.kt
+++ b/web/src/main/kotlin/web/service/DiceExpressionRoller.kt
@@ -1,0 +1,76 @@
+package web.service
+
+import kotlin.random.Random
+
+/**
+ * Parser + roller for dice expressions like `2d6+3` and bare integers like `45`.
+ * Shared by combat damage/heal application, monster HP rolling, and monster
+ * attack damage rolling so they stay consistent on caps and accepted syntax.
+ */
+object DiceExpressionRoller {
+
+    const val MAX_DICE_COUNT = 20
+    const val MAX_DICE_MODIFIER = 50
+    const val MAX_LITERAL_AMOUNT = 1000
+    val ALLOWED_DIE_SIDES = setOf(4, 6, 8, 10, 12, 20, 100)
+
+    private val DICE_EXPR_REGEX = Regex("^(\\d*)d(\\d+)([+-]\\d+)?$", RegexOption.IGNORE_CASE)
+
+    data class ParsedDice(val count: Int, val sides: Int, val modifier: Int)
+
+    /**
+     * Parsed result of a [parseAmount] call. [expression] is non-null only when
+     * the input was a dice formula; in that case [rolls] holds the individual
+     * faces so callers can narrate "rolled 2d6+3 = 11".
+     */
+    data class RolledAmount(
+        val total: Int,
+        val expression: String?,
+        val rolls: List<Int>?
+    )
+
+    fun parseDiceExpression(raw: String): ParsedDice? {
+        val cleaned = raw.filterNot { it.isWhitespace() }
+        if (cleaned.isEmpty()) return null
+        val match = DICE_EXPR_REGEX.matchEntire(cleaned) ?: return null
+        val count = match.groupValues[1].ifEmpty { "1" }.toIntOrNull() ?: return null
+        val sides = match.groupValues[2].toIntOrNull() ?: return null
+        val modifier = match.groupValues[3].takeIf { it.isNotEmpty() }?.toIntOrNull() ?: 0
+        return ParsedDice(count, sides, modifier)
+    }
+
+    /**
+     * Accept either an integer (`"6"`) or a dice expression (`"2d6+3"`, `"d20-1"`)
+     * and return a rolled amount. Integer totals outside `[0, MAX_LITERAL_AMOUNT]`
+     * and dice expressions exceeding the count/side/modifier caps are rejected
+     * (returns null).
+     */
+    fun parseAmount(raw: String, random: Random = Random): RolledAmount? {
+        val trimmed = raw.trim()
+        if (trimmed.isEmpty()) return null
+        trimmed.toIntOrNull()?.let { literal ->
+            if (literal < 0 || literal > MAX_LITERAL_AMOUNT) return null
+            return RolledAmount(total = literal, expression = null, rolls = null)
+        }
+        val parsed = parseDiceExpression(trimmed) ?: return null
+        if (parsed.sides !in ALLOWED_DIE_SIDES) return null
+        if (parsed.count !in 1..MAX_DICE_COUNT) return null
+        if (parsed.modifier !in -MAX_DICE_MODIFIER..MAX_DICE_MODIFIER) return null
+        val rolled = (0 until parsed.count).map { random.nextInt(1, parsed.sides + 1) }
+        val total = (rolled.sum() + parsed.modifier).coerceAtLeast(0)
+        return RolledAmount(
+            total = total,
+            expression = normaliseExpression(parsed),
+            rolls = rolled
+        )
+    }
+
+    fun normaliseExpression(parsed: ParsedDice): String {
+        val mod = when {
+            parsed.modifier > 0 -> "+${parsed.modifier}"
+            parsed.modifier < 0 -> parsed.modifier.toString()
+            else -> ""
+        }
+        return "${parsed.count}d${parsed.sides}$mod"
+    }
+}

--- a/web/src/main/kotlin/web/service/InitiativeStore.kt
+++ b/web/src/main/kotlin/web/service/InitiativeStore.kt
@@ -56,5 +56,11 @@ data class InitiativeEntryData(
     val maxHp: Int? = null,
     val currentHp: Int? = null,
     val ac: Int? = null,
-    val defeated: Boolean = false
+    val defeated: Boolean = false,
+    /**
+     * `MonsterTemplateDto.id` for monsters spawned from a saved template, so
+     * combat code can resolve the monster's attack list. Null for ad-hoc
+     * monsters and players.
+     */
+    val templateId: Long? = null
 )

--- a/web/src/main/resources/static/js/sessionLog.js
+++ b/web/src/main/resources/static/js/sessionLog.js
@@ -93,16 +93,19 @@
                 return 'marked as MISS' + (p.target ? ' on ' + p.target : '');
             case 'ATTACK_HIT': {
                 const ac = (p.targetAc != null) ? ' vs AC ' + p.targetAc : '';
-                return (p.attacker || '?') + ' hits ' + (p.target || '?') + ' — ' + p.total + ac;
+                const weapon = p.attackName ? ' with ' + p.attackName : '';
+                return (p.attacker || '?') + ' hits ' + (p.target || '?') + weapon + ' — ' + p.total + ac;
             }
             case 'ATTACK_MISS': {
                 const ac = (p.targetAc != null) ? ' vs AC ' + p.targetAc : '';
-                return (p.attacker || '?') + ' misses ' + (p.target || '?') + ' — ' + p.total + ac;
+                const weapon = p.attackName ? ' with ' + p.attackName : '';
+                return (p.attacker || '?') + ' misses ' + (p.target || '?') + weapon + ' — ' + p.total + ac;
             }
             case 'DAMAGE_DEALT': {
                 const remaining = (p.remainingHp != null) ? ' (' + p.remainingHp + ' HP left)' : '';
                 const amt = p.expression ? (p.expression + ' = ' + p.amount) : p.amount;
-                return (p.target || '?') + ' takes ' + amt + ' damage' + remaining;
+                const weapon = p.attackName ? ' from ' + p.attackName : '';
+                return (p.target || '?') + ' takes ' + amt + ' damage' + weapon + remaining;
             }
             case 'HEAL_APPLIED': {
                 const hp = (p.remainingHp != null && p.maxHp != null)

--- a/web/src/main/resources/templates/campaignDetail.html
+++ b/web/src/main/resources/templates/campaignDetail.html
@@ -1066,13 +1066,16 @@
                 <tr><th>Name</th><th>Init</th><th>HP</th><th>AC</th><th></th></tr>
                 </thead>
                 <tbody>
-                <tr th:each="tpl : ${monsterLibrary}" class="row-form">
+                <tr th:each="tpl,iter : ${monsterLibrary}" class="row-form">
                     <form th:action="@{/dnd/campaign/{id}/monsters/templates(id=${guildId})}" method="post"
                           style="display:contents;">
                         <input type="hidden" name="id" th:value="${tpl.id}">
                         <td><input type="text" name="name" th:value="${tpl.name}" maxlength="100" required></td>
                         <td><input type="number" name="initiativeModifier" th:value="${tpl.initiativeModifier}"></td>
-                        <td><input type="number" name="maxHp" th:value="${tpl.maxHp}"></td>
+                        <td><input type="text" name="hpExpression" th:value="${tpl.hpExpression}"
+                                   maxlength="32" placeholder="HP or 3d20+30"
+                                   pattern="^\s*(\d+|\d*[dD]\d+([+-]\d+)?)\s*$"
+                                   title="Plain integer or dice expression like 3d20+30"></td>
                         <td><input type="number" name="ac" th:value="${tpl.ac}"></td>
                         <td>
                             <button type="submit" class="btn-xs" title="Save changes">Save</button>
@@ -1087,6 +1090,45 @@
                         </form>
                     </td>
                 </tr>
+                <tr class="row-attacks">
+                    <td colspan="6" style="padding:4px 8px 10px;">
+                        <details style="margin-left:8px;">
+                            <summary style="cursor:pointer;color:#a0a0b0;font-size:0.85rem;">
+                                Attacks (<span th:text="${#lists.size(tpl.attacks)}">0</span>)
+                            </summary>
+                            <ul th:if="${not #lists.isEmpty(tpl.attacks)}"
+                                style="list-style:none;padding:6px 0 0 0;margin:0;display:flex;flex-direction:column;gap:4px;">
+                                <li th:each="atk : ${tpl.attacks}"
+                                    style="display:flex;gap:8px;align-items:center;font-size:0.85rem;">
+                                    <span th:text="${atk.name}" style="min-width:120px;">Bite</span>
+                                    <span th:text="${(atk.toHitModifier >= 0 ? '+' : '') + atk.toHitModifier}"
+                                          style="min-width:40px;color:#a0a0b0;">+5</span>
+                                    <span th:text="${atk.damageExpression}" style="min-width:80px;color:#a0a0b0;">2d6+3</span>
+                                    <form th:action="@{/dnd/campaign/{gid}/monsters/templates/{tid}/attacks/{aid}/delete(gid=${guildId},tid=${tpl.id},aid=${atk.id})}"
+                                          method="post"
+                                          th:onsubmit="|return confirm('Delete attack ${atk.name}?');|"
+                                          style="margin:0;">
+                                        <button type="submit" class="btn-xs kick" title="Delete attack">Delete</button>
+                                    </form>
+                                </li>
+                            </ul>
+                            <form th:action="@{/dnd/campaign/{gid}/monsters/templates/{tid}/attacks(gid=${guildId},tid=${tpl.id})}"
+                                  method="post"
+                                  style="display:flex;gap:6px;align-items:center;margin-top:8px;flex-wrap:wrap;">
+                                <input type="text" name="name" placeholder="Attack name" maxlength="60" required
+                                       style="min-width:140px;">
+                                <input type="number" name="toHitModifier" placeholder="+hit" value="0" min="-30" max="30"
+                                       style="width:70px;">
+                                <input type="text" name="damageExpression" placeholder="Damage (e.g. 2d6+3)"
+                                       maxlength="32" required
+                                       pattern="^\s*(\d+|\d*[dD]\d+([+-]\d+)?)\s*$"
+                                       title="Plain integer or dice expression like 2d6+3"
+                                       style="min-width:140px;">
+                                <button type="submit" class="btn-xs" title="Add attack">Add attack</button>
+                            </form>
+                        </details>
+                    </td>
+                </tr>
                 </tbody>
             </table>
             <p th:if="${#lists.isEmpty(monsterLibrary)}" class="empty">
@@ -1098,8 +1140,11 @@
                        style="flex:1;min-width:160px;padding:6px 8px;border-radius:4px;border:1px solid #2a2a4a;background:#1a1a2e;color:#e0e0e0;font-size:0.85rem;">
                 <input type="number" name="initiativeModifier" placeholder="init" value="0"
                        style="width:70px;padding:6px 8px;border-radius:4px;border:1px solid #2a2a4a;background:#1a1a2e;color:#e0e0e0;font-size:0.85rem;">
-                <input type="number" name="maxHp" placeholder="HP"
-                       style="width:70px;padding:6px 8px;border-radius:4px;border:1px solid #2a2a4a;background:#1a1a2e;color:#e0e0e0;font-size:0.85rem;">
+                <input type="text" name="hpExpression" placeholder="HP or 3d20+30"
+                       maxlength="32"
+                       pattern="^\s*(\d+|\d*[dD]\d+([+-]\d+)?)\s*$"
+                       title="Plain integer or dice expression like 3d20+30"
+                       style="width:120px;padding:6px 8px;border-radius:4px;border:1px solid #2a2a4a;background:#1a1a2e;color:#e0e0e0;font-size:0.85rem;">
                 <input type="number" name="ac" placeholder="AC"
                        style="width:70px;padding:6px 8px;border-radius:4px;border:1px solid #2a2a4a;background:#1a1a2e;color:#e0e0e0;font-size:0.85rem;">
                 <button type="submit" class="btn btn-primary">Add template</button>
@@ -1128,7 +1173,7 @@
                         <span class="picker-name" th:text="${tpl.name}">Goblin</span>
                         <span class="picker-meta"
                               th:text="${'+' + tpl.initiativeModifier
-                                         + (tpl.maxHp != null ? ' · HP ' + tpl.maxHp : '')
+                                         + (tpl.hpExpression != null ? ' · HP ' + tpl.hpExpression : '')
                                          + (tpl.ac != null ? ' · AC ' + tpl.ac : '')}">+2</span>
                     </div>
                 </div>
@@ -1136,13 +1181,19 @@
                     <div class="row">
                         <input type="text" name="adhocName" placeholder="Ad-hoc monster name (optional)" maxlength="100">
                         <input type="number" name="adhocMod" placeholder="init" value="0">
-                        <input type="number" name="adhocHp" placeholder="HP" min="0" max="1000">
+                        <input type="text" name="adhocHpExpr" placeholder="HP or 3d20+30"
+                               maxlength="32"
+                               pattern="^\s*(\d+|\d*[dD]\d+([+-]\d+)?)\s*$"
+                               title="Plain integer or dice expression like 3d20+30">
                         <input type="number" name="adhocAc" placeholder="AC" min="0" max="50">
                     </div>
                     <div class="row">
                         <input type="text" name="adhocName" placeholder="Ad-hoc monster name (optional)" maxlength="100">
                         <input type="number" name="adhocMod" placeholder="init" value="0">
-                        <input type="number" name="adhocHp" placeholder="HP" min="0" max="1000">
+                        <input type="text" name="adhocHpExpr" placeholder="HP or 3d20+30"
+                               maxlength="32"
+                               pattern="^\s*(\d+|\d*[dD]\d+([+-]\d+)?)\s*$"
+                               title="Plain integer or dice expression like 3d20+30">
                         <input type="number" name="adhocAc" placeholder="AC" min="0" max="50">
                     </div>
                 </div>
@@ -1192,6 +1243,25 @@
                             <label>Mod</label>
                             <input type="number" name="attackModifier" value="0" min="-30" max="30">
                             <button type="submit" class="btn btn-primary btn-sm">🎯 Attack</button>
+                        </form>
+                        <form th:if="${entry.kind == 'MONSTER' and entry.templateId != null and not #lists.isEmpty(entry.attacks)}"
+                              th:action="@{/dnd/campaign/{id}/combat/monster-attack(id=${guildId})}" method="post" class="row">
+                            <label>Monster attack</label>
+                            <select name="attackId" required>
+                                <option th:each="atk : ${entry.attacks}"
+                                        th:value="${atk.id}"
+                                        th:text="${atk.name + ' (' + (atk.toHitModifier >= 0 ? '+' : '') + atk.toHitModifier + ', ' + atk.damageExpression + ')'}">
+                                    Bite (+5, 2d6+3)
+                                </option>
+                            </select>
+                            <label>Target</label>
+                            <select name="targetName" required>
+                                <option th:each="t : ${initiativeState.entries}"
+                                        th:if="${t.name != entry.name and not t.defeated}"
+                                        th:value="${t.name}"
+                                        th:text="${t.name + (t.ac != null ? ' (AC ' + t.ac + ')' : '')}">Target</option>
+                            </select>
+                            <button type="submit" class="btn btn-primary btn-sm">🗡️ Roll attack</button>
                         </form>
                         <form th:action="@{/dnd/campaign/{id}/combat/damage(id=${guildId})}" method="post" class="row">
                             <label>Damage</label>
@@ -1321,23 +1391,26 @@
                                     : 'marked MISS'}">marked MISS</span>
                     <span th:case="'ATTACK_HIT'"
                           th:text="${event.payload['attacker'] + ' hits ' + event.payload['target'] +
+                                    (event.payload['attackName'] != null ? ' with ' + event.payload['attackName'] : '') +
                                     ' — ' + event.payload['total'] +
                                     (event.payload['targetAc'] != null ? ' vs AC ' + event.payload['targetAc'] : '')}">
-                        hits Target — 18 vs AC 15
+                        hits Target with Bite — 18 vs AC 15
                     </span>
                     <span th:case="'ATTACK_MISS'"
                           th:text="${event.payload['attacker'] + ' misses ' + event.payload['target'] +
+                                    (event.payload['attackName'] != null ? ' with ' + event.payload['attackName'] : '') +
                                     ' — ' + event.payload['total'] +
                                     (event.payload['targetAc'] != null ? ' vs AC ' + event.payload['targetAc'] : '')}">
-                        misses Target — 7 vs AC 15
+                        misses Target with Bite — 7 vs AC 15
                     </span>
                     <span th:case="'DAMAGE_DEALT'"
                           th:text="${event.payload['target'] + ' takes ' +
                                     (event.payload['expression'] != null
                                         ? event.payload['expression'] + ' = ' + event.payload['amount']
                                         : event.payload['amount']) + ' damage' +
+                                    (event.payload['attackName'] != null ? ' from ' + event.payload['attackName'] : '') +
                                     (event.payload['remainingHp'] != null ? ' (' + event.payload['remainingHp'] + ' HP left)' : '')}">
-                        Target takes 6 damage (1 HP left)
+                        Target takes 6 damage from Bite (1 HP left)
                     </span>
                     <span th:case="'HEAL_APPLIED'"
                           th:text="${(event.payload['healer'] != null ? event.payload['healer'] + ' heals ' : 'heals ') +


### PR DESCRIPTION
## Summary

Two DM-facing upgrades to the monster library + combat HUD:

1. **HP as a dice expression.** `MonsterTemplate.max_hp` (INT) → `hp_expression` (VARCHAR). DMs can type `45` or `3d20+30`; at initiative time each instance rolls its own HP, so two goblins from the same template get different bars. Integers still work unchanged.
2. **Monster attacks.** Each template gets a list of attacks (name, to-hit modifier, damage expression — e.g. `Bite, +5, 2d6+3`). On a monster's turn the DM picks an attack and target from the combat HUD; the bot rolls `1d20 + to_hit` vs target AC, and on hit rolls the damage expression and applies it. `ATTACK_HIT`/`ATTACK_MISS` and `DAMAGE_DEALT` events flow through the existing session feed with the attack name, so the log reads e.g. "Goblin hits Alice with Bite — 18 vs AC 14 … Alice takes 2d6+3 = 11 damage from Bite".

## What's in it

- **Migrations.** `V7__dnd_monster_template_hp_expression.sql` (type change + rename, round-trips integers); `V8__dnd_monster_attack.sql` (new table, FK with `ON DELETE CASCADE`).
- **Persistence.** New `MonsterAttackDto` + persistence + service, mirroring the template stack. No JPA associations — attacks are fetched through a service method to avoid Thymeleaf/lazy-init traps.
- **Shared dice parser.** Extracted `DiceExpressionRoller` from `CampaignWebService` (the old `parseCombatAmount` still delegates). Reused for HP rolling, attack damage, and existing damage/heal so caps stay consistent (`MAX_DICE_COUNT=20`, `MAX_DICE_MODIFIER=50`, `ALLOWED_DIE_SIDES`, `MAX_LITERAL_AMOUNT=1000`).
- **Combat flow.** New `CampaignWebService.monsterAttack(guildId, dm, attackId, targetName)` posts to `/dnd/campaign/{guildId}/combat/monster-attack`. DM-only; requires current entry be `kind == "MONSTER"` with a non-null `templateId`; verifies the attack belongs to that template. Damage is applied via existing `InitiativeStore.applyDamage`, and the defeat/revive flow is unchanged.
- **Initiative snapshot.** `templateId: Long? = null` added to `InitiativeEntryData`, `RolledEntry`, `InitiativeEntry`. Jackson tolerates missing fields, so snapshots from existing in-flight combats keep working (they just can't drive the monster-attack picker until re-rolled).
- **UI.**
  - Monster library row: new collapsible "Attacks (N)" with inline add/delete forms per template.
  - HP inputs: `<input type="number">` → `<input type="text">` with a pattern for `\d+` or `\d*d\d+([+-]\d+)?`.
  - Combat HUD: when it's a template-backed monster's turn and it has attacks, an extra "Monster attack" form appears with attack and target dropdowns.
  - Session log (server-rendered HTML + live SSE JS): `ATTACK_HIT` / `ATTACK_MISS` / `DAMAGE_DEALT` include the attack name when present.
- **Tests.** New `DiceExpressionRollerTest`, and additions to `CampaignWebServiceTest` covering HP-expression save/roll, `templateId` propagation, attack save/delete, and the three monster-attack branches (hit + DAMAGE_DEALT, miss + no damage, hit + PARTICIPANT_DEFEATED).

## Scope notes

- DM-only for monster attacks in v1 (monsters are DM-driven).
- Per-template attack cap set to 12.
- N+1 query on the monster library page load (one `listByTemplate` per template). Acceptable given library sizes; flagged for later if it becomes hot.
- Existing integer HP rows (from V6) convert via `USING max_hp::text`, then are parsed by the same parser at roll time — no data loss.

## Test plan

- [ ] `./gradlew clean build` passes (local sandbox can't resolve the lavalink/libdave repos for `discord-bot`; CI will have them).
- [ ] Flyway applies V7 and V8 cleanly against a fresh Postgres.
- [ ] Monster library: set a template's HP to `3d20+30`; roll initiative with qty=2; two different HP bars appear.
- [ ] Add attack `Bite (+5, 2d6+3)` to a template; re-roll initiative; advance to the monster's turn.
- [ ] "Monster attack" form shows with the new attack; pick a target and submit. Session log shows the hit/miss + damage with the attack name. HP bar of the target drops; if HP hits 0 the skull animation fires and `PARTICIPANT_DEFEATED` appears.
- [ ] Existing flows (player attack, manual damage, heal) unchanged.

https://claude.ai/code/session_01Jfri3qcB8oEtniPiayRkCW
