### PR TITLE
fix(dnd): animate generic dice rolls on mobile

### DIFF
--- a/web/src/main/resources/static/css/combat.css
+++ b/web/src/main/resources/static/css/combat.css
@@ -95,6 +95,14 @@
     transform: translate(calc(var(--end-x) - var(--start-x)), calc(var(--end-y) - var(--start-y))) scale(0) rotate(45deg);
     opacity: 0;
 }
+/* Generic dice-roller cinematic: neutral gold accent, slightly quicker
+   flight than a combat attack, same settle/fade phases. */
+.attack-die.roll {
+    --duration: 550ms;
+    background: linear-gradient(135deg, #8892f5, #2e3a5c);
+    border-color: #8892f5;
+    box-shadow: 0 6px 24px rgba(0, 0, 0, 0.45), 0 0 22px rgba(136, 146, 245, 0.6);
+}
 @keyframes crit-shake {
     0%, 100% { translate: 0 0; }
     25%      { translate: -3px 1px; }

--- a/web/src/main/resources/static/js/sessionLog.js
+++ b/web/src/main/resources/static/js/sessionLog.js
@@ -453,9 +453,62 @@
         setTimeout(function () { el.remove(); }, 1200);
     }
 
+    // Generic dice-roller cinematic — not tied to a combat row. Throws a die
+    // from near the dice-toggle button (or viewport top-right fallback) and
+    // settles it in the viewport centre, revealing the total. Runs whether or
+    // not combat is active, so the popover feels responsive on mobile where
+    // the user's own POST→redirect cycle would otherwise suppress the SSE
+    // catch-up cinematic.
+    function spawnRollDie(payload) {
+        if (prefersReducedMotion) return;
+        const total = (payload && payload.total != null)
+            ? payload.total
+            : (payload && payload.rawTotal != null ? payload.rawTotal : null);
+        if (total == null) return;
+        const vw = window.innerWidth;
+        const vh = window.innerHeight;
+        const toggle = document.getElementById('dice-toggle');
+        let start;
+        if (toggle) {
+            const r = toggle.getBoundingClientRect();
+            start = { x: r.left + r.width / 2, y: r.top + r.height / 2 };
+        } else {
+            start = { x: vw - 48, y: 48 };
+        }
+        const end = { x: vw / 2, y: vh / 2 };
+        const stage = getCombatStage();
+        const die = document.createElement('div');
+        die.className = 'attack-die roll';
+        die.style.setProperty('--start-x', start.x + 'px');
+        die.style.setProperty('--start-y', start.y + 'px');
+        die.style.setProperty('--end-x', end.x + 'px');
+        die.style.setProperty('--end-y', end.y + 'px');
+        const face = document.createElement('span');
+        face.className = 'attack-die__face';
+        face.textContent = String(total);
+        die.appendChild(face);
+        stage.appendChild(die);
+
+        die.addEventListener('animationend', function onFlight(ev) {
+            if (ev.animationName !== 'attack-die-flight') return;
+            die.removeEventListener('animationend', onFlight);
+            die.classList.add('settling');
+            setTimeout(function () {
+                die.classList.add('fading');
+                setTimeout(function () { die.remove(); }, 350);
+            }, 700);
+        });
+    }
+
     function handleInitiativeEvent(event) {
-        if (!turnTable) return;
         const p = event.payload || {};
+        // ROLL is campaign-wide and not gated on the turn table, so handle it
+        // before the turnTable guard below.
+        if (event.type === 'ROLL') {
+            spawnRollDie(p);
+            return;
+        }
+        if (!turnTable) return;
         switch (event.type) {
             case 'INITIATIVE_ROLLED': {
                 const entries = Array.isArray(p.entries) ? p.entries : [];


### PR DESCRIPTION
## Summary

Generic dice rolls never animated. The ROLL event was published,
included in `freshEventIds`, backfilled, and rendered as a session-log
line — but `sessionLog.js`' `handleInitiativeEvent` had no `'ROLL'`
branch, so no cinematic ever fired. On desktop the miss didn't matter
(multi-window, quiet text). On mobile, where the dice-roller popover
is the primary input, the action felt unresponsive. PR #249 fixed the
POST→redirect replay path for combat cinematics; this hooks the one
event type that users actually trigger from outside combat into the
same path.

## What's in it

- **`sessionLog.js`**: new `spawnRollDie()` that throws a die from the
  dice-toggle button's centre (fallback: viewport top-right) to
  viewport centre, revealing `payload.total`. Reuses `#combat-stage`
  and the existing `attack-die-flight` → `settling` → `fading`
  keyframe cascade — no new animation primitives.
- **`sessionLog.js`**: hoist the `if (!turnTable) return;` guard out
  of `handleInitiativeEvent` and short-circuit ROLL first, since the
  dice roller works campaign-wide (combat or not). All other branches
  still require the turn table.
- **`combat.css`**: add `.attack-die.roll` — neutral blurple accent,
  slightly quicker flight (550ms vs 700ms). The existing
  `@media (max-width: 480px)` and `@media (prefers-reduced-motion: reduce)`
  blocks target `.attack-die` broadly, so the `.roll` variant inherits
  the mobile 2D-only spin and reduced-motion strip for free.

## Scope notes

- Spectator flow (SSE) was already correct — this only fills the
  submitter-side boot-replay gap.
- No client-side optimism on submit: that would double-fire for the
  submitter on desktop where SSE is still live. Fresh-replay on the
  redirect is the single source of truth.
- No backend or DTO changes; ROLL event + payload are already wired.

## Test plan

- [ ] Mobile viewport (or DevTools mobile emulation): open the
  dice-roller popover, pick `2d6+3`, submit. Expect a die to fly from
  near the toggle to viewport centre with the total; log row appears.
- [ ] Repeat with combat inactive (empty turn table) — still animates.
- [ ] Repeat with combat active — still animates; turn-table /
  attack / damage / heal cinematics unaffected.
- [ ] Enable OS "reduce motion" — no animation, log row still renders.
- [ ] Desktop two-tab regression: trigger roll from tab A. Both tabs
  see the animation exactly once (A via fresh-replay, B via SSE).
- [ ] `npm test` passes.
- [ ] `./gradlew build` passes.

https://claude.ai/code/session_01Jfri3qcB8oEtniPiayRkCW
