### PR TITLE
feat(intros): start/end timestamps with live clip preview

### DIFF
--- a/application/src/test/kotlin/web/controller/IntroWebControllerTest.kt
+++ b/application/src/test/kotlin/web/controller/IntroWebControllerTest.kt
@@ -104,9 +104,9 @@ class IntroWebControllerTest {
 
     @Test
     fun `setIntro with url adds success flash on success`() {
-        every { introWebService.setIntroByUrl(any(), any(), any(), any(), any()) } returns null
+        every { introWebService.setIntroByUrl(any(), any(), any(), any(), any(), any(), any()) } returns null
 
-        val view = controller.setIntro(guildId, mockUser, "url", "https://example.com", null, 90, null, null, mockRa)
+        val view = controller.setIntro(guildId, mockUser, "url", "https://example.com", null, 90, null, null, null, null, mockRa)
 
         assertEquals("redirect:/intro/$guildId", view)
         verify { mockRa.addFlashAttribute("success", "Intro saved successfully.") }
@@ -114,9 +114,9 @@ class IntroWebControllerTest {
 
     @Test
     fun `setIntro with url adds error flash on failure`() {
-        every { introWebService.setIntroByUrl(any(), any(), any(), any(), any()) } returns "Invalid URL provided."
+        every { introWebService.setIntroByUrl(any(), any(), any(), any(), any(), any(), any()) } returns "Invalid URL provided."
 
-        val view = controller.setIntro(guildId, mockUser, "url", "bad-url", null, 90, null, null, mockRa)
+        val view = controller.setIntro(guildId, mockUser, "url", "bad-url", null, 90, null, null, null, null, mockRa)
 
         assertEquals("redirect:/intro/$guildId", view)
         verify { mockRa.addFlashAttribute("error", "Invalid URL provided.") }
@@ -125,9 +125,9 @@ class IntroWebControllerTest {
     @Test
     fun `setIntro with file adds success flash`() {
         val file = mockk<MultipartFile> { every { isEmpty } returns false }
-        every { introWebService.setIntroByFile(any(), any(), any(), any(), any()) } returns null
+        every { introWebService.setIntroByFile(any(), any(), any(), any(), any(), any(), any()) } returns null
 
-        val view = controller.setIntro(guildId, mockUser, "file", null, file, 90, null, null, mockRa)
+        val view = controller.setIntro(guildId, mockUser, "file", null, file, 90, null, null, null, null, mockRa)
 
         assertEquals("redirect:/intro/$guildId", view)
         verify { mockRa.addFlashAttribute("success", "Intro saved successfully.") }
@@ -135,7 +135,7 @@ class IntroWebControllerTest {
 
     @Test
     fun `setIntro with missing file returns error`() {
-        val view = controller.setIntro(guildId, mockUser, "file", null, null, 90, null, null, mockRa)
+        val view = controller.setIntro(guildId, mockUser, "file", null, null, 90, null, null, null, null, mockRa)
 
         assertEquals("redirect:/intro/$guildId", view)
         verify { mockRa.addFlashAttribute("error", "No file provided.") }
@@ -143,20 +143,20 @@ class IntroWebControllerTest {
 
     @Test
     fun `setIntro clamps volume above 100 to 100`() {
-        every { introWebService.setIntroByUrl(any(), any(), any(), any(), any()) } returns null
+        every { introWebService.setIntroByUrl(any(), any(), any(), any(), any(), any(), any()) } returns null
 
-        controller.setIntro(guildId, mockUser, "url", "https://example.com", null, 200, null, null, mockRa)
+        controller.setIntro(guildId, mockUser, "url", "https://example.com", null, 200, null, null, null, null, mockRa)
 
-        verify { introWebService.setIntroByUrl(any(), any(), any(), 100, any()) }
+        verify { introWebService.setIntroByUrl(any(), any(), any(), 100, any(), any(), any()) }
     }
 
     @Test
     fun `setIntro clamps volume below 1 to 1`() {
-        every { introWebService.setIntroByUrl(any(), any(), any(), any(), any()) } returns null
+        every { introWebService.setIntroByUrl(any(), any(), any(), any(), any(), any(), any()) } returns null
 
-        controller.setIntro(guildId, mockUser, "url", "https://example.com", null, 0, null, null, mockRa)
+        controller.setIntro(guildId, mockUser, "url", "https://example.com", null, 0, null, null, null, null, mockRa)
 
-        verify { introWebService.setIntroByUrl(any(), any(), any(), 1, any()) }
+        verify { introWebService.setIntroByUrl(any(), any(), any(), 1, any(), any(), any()) }
     }
 
     // deleteIntro
@@ -179,5 +179,30 @@ class IntroWebControllerTest {
 
         assertEquals("redirect:/intro/$guildId", view)
         verify { mockRa.addFlashAttribute("error", "Intro not found.") }
+    }
+
+    // updateTimestamps
+
+    @Test
+    fun `updateTimestamps returns ok on success`() {
+        every { introWebService.updateIntroTimestamps(any(), any(), any(), any(), any()) } returns null
+
+        val body = UpdateTimestampsRequest("${guildId}_${discordId}_1", 1000, 8000)
+        val response = controller.updateTimestamps(guildId, body, mockUser, null)
+
+        assertEquals(200, response.statusCode.value())
+        assertEquals(true, response.body?.ok)
+    }
+
+    @Test
+    fun `updateTimestamps returns bad request with error`() {
+        every { introWebService.updateIntroTimestamps(any(), any(), any(), any(), any()) } returns "End time must be greater than start time."
+
+        val body = UpdateTimestampsRequest("${guildId}_${discordId}_1", 5000, 5000)
+        val response = controller.updateTimestamps(guildId, body, mockUser, null)
+
+        assertEquals(400, response.statusCode.value())
+        assertEquals(false, response.body?.ok)
+        assertEquals("End time must be greater than start time.", response.body?.error)
     }
 }

--- a/application/src/test/kotlin/web/service/IntroWebServiceTest.kt
+++ b/application/src/test/kotlin/web/service/IntroWebServiceTest.kt
@@ -183,7 +183,7 @@ class IntroWebServiceTest {
 
     @Test
     fun `setIntroByUrl returns error for invalid URL`() {
-        val error = service.setIntroByUrl(discordId, guildId, "not-a-url", 90, null)
+        val error = service.setIntroByUrl(discordId, guildId, "not-a-url", 90, null, null, null)
         assertEquals("Invalid URL provided.", error)
     }
 
@@ -193,7 +193,7 @@ class IntroWebServiceTest {
         every { userService.getUserById(discordId, guildId) } returns user
         every { musicFileService.createNewMusicFile(any()) } returns mockk()
 
-        val error = service.setIntroByUrl(discordId, guildId, "https://example.com/audio.mp3", 90, null)
+        val error = service.setIntroByUrl(discordId, guildId, "https://example.com/audio.mp3", 90, null, null, null)
         assertNull(error)
         verify(exactly = 1) { musicFileService.createNewMusicFile(any()) }
     }
@@ -205,7 +205,7 @@ class IntroWebServiceTest {
         }
         every { userService.getUserById(discordId, guildId) } returns user
 
-        val error = service.setIntroByUrl(discordId, guildId, "https://example.com/audio.mp3", 90, null)
+        val error = service.setIntroByUrl(discordId, guildId, "https://example.com/audio.mp3", 90, null, null, null)
         assertNotNull(error)
         assertTrue(error!!.contains("${IntroWebService.MAX_INTRO_COUNT}"))
     }
@@ -219,7 +219,7 @@ class IntroWebServiceTest {
         every { userService.getUserById(discordId, guildId) } returns user
         every { musicFileService.updateMusicFile(any()) } returns mockk()
 
-        val error = service.setIntroByUrl(discordId, guildId, "https://example.com/new.mp3", 80, 1)
+        val error = service.setIntroByUrl(discordId, guildId, "https://example.com/new.mp3", 80, 1, null, null)
         assertNull(error)
         verify { musicFileService.updateMusicFile(match { it.fileName == "https://example.com/new.mp3" && it.introVolume == 80 }) }
     }
@@ -229,13 +229,13 @@ class IntroWebServiceTest {
     @Test
     fun `setIntroByFile returns error for non-mp3 file`() {
         val file = MockMultipartFile("file", "audio.wav", "audio/wav", ByteArray(100))
-        assertEquals("Only MP3 files are supported.", service.setIntroByFile(discordId, guildId, file, 90, null))
+        assertEquals("Only MP3 files are supported.", service.setIntroByFile(discordId, guildId, file, 90, null, null, null))
     }
 
     @Test
     fun `setIntroByFile returns error when file too large`() {
         val file = MockMultipartFile("file", "audio.mp3", "audio/mpeg", ByteArray(IntroWebService.MAX_FILE_SIZE + 1))
-        val error = service.setIntroByFile(discordId, guildId, file, 90, null)
+        val error = service.setIntroByFile(discordId, guildId, file, 90, null, null, null)
         assertNotNull(error)
         assertTrue(error!!.contains("KB"))
     }
@@ -247,7 +247,7 @@ class IntroWebServiceTest {
         every { musicFileService.createNewMusicFile(any()) } returns mockk()
 
         val file = MockMultipartFile("file", "audio.mp3", "audio/mpeg", ByteArray(1000))
-        assertNull(service.setIntroByFile(discordId, guildId, file, 90, null))
+        assertNull(service.setIntroByFile(discordId, guildId, file, 90, null, null, null))
         verify(exactly = 1) { musicFileService.createNewMusicFile(any()) }
     }
 
@@ -258,7 +258,7 @@ class IntroWebServiceTest {
         every { musicFileService.createNewMusicFile(any()) } returns null
 
         val file = MockMultipartFile("file", "audio.mp3", "audio/mpeg", ByteArray(1000))
-        assertEquals("This file already exists as one of your intros.", service.setIntroByFile(discordId, guildId, file, 90, null))
+        assertEquals("This file already exists as one of your intros.", service.setIntroByFile(discordId, guildId, file, 90, null, null, null))
     }
 
     // deleteIntro
@@ -307,7 +307,7 @@ class IntroWebServiceTest {
             durationSeconds = null
         )
 
-        val error = spyService.setIntroByUrl(discordId, guildId, "https://www.youtube.com/watch?v=dQw4w9WgXcQ", 90, null)
+        val error = spyService.setIntroByUrl(discordId, guildId, "https://www.youtube.com/watch?v=dQw4w9WgXcQ", 90, null, null, null)
 
         assertNull(error)
         assertEquals("My Video Title", slot.captured.fileName)
@@ -323,7 +323,7 @@ class IntroWebServiceTest {
         val spyService = spyk(service)
         every { spyService.fetchYouTubePreview(any()) } returns null
 
-        val error = spyService.setIntroByUrl(discordId, guildId, url, 90, null)
+        val error = spyService.setIntroByUrl(discordId, guildId, url, 90, null, null, null)
 
         assertNull(error)
         assertEquals(url, slot.captured.fileName)
@@ -344,7 +344,7 @@ class IntroWebServiceTest {
             durationSeconds = null
         )
 
-        spyService.setIntroByUrl(discordId, guildId, url, 90, null)
+        spyService.setIntroByUrl(discordId, guildId, url, 90, null, null, null)
 
         assertEquals(url, slot.captured.musicBlob?.let { String(it) })
     }
@@ -361,7 +361,7 @@ class IntroWebServiceTest {
             durationSeconds = 30
         )
 
-        val error = spyService.setIntroByUrl(discordId, guildId, "https://www.youtube.com/watch?v=dQw4w9WgXcQ", 90, null)
+        val error = spyService.setIntroByUrl(discordId, guildId, "https://www.youtube.com/watch?v=dQw4w9WgXcQ", 90, null, null, null)
 
         assertNotNull(error)
         assertTrue(error!!.contains("too long"))
@@ -432,6 +432,103 @@ class IntroWebServiceTest {
 
         val error = service.reorderIntros(discordId, guildId, listOf("${guildId}_${discordId}_2"))
         assertNotNull(error)
+    }
+
+    // validateClip
+
+    @Test
+    fun `validateClip accepts null clip when source is short enough`() {
+        assertNull(service.validateClip(null, null, 10_000))
+    }
+
+    @Test
+    fun `validateClip rejects null clip when source longer than cap`() {
+        assertNotNull(service.validateClip(null, null, 60_000))
+    }
+
+    @Test
+    fun `validateClip accepts a tight clip on a long source`() {
+        assertNull(service.validateClip(10_000, 22_000, 120_000))
+    }
+
+    @Test
+    fun `validateClip rejects clip longer than cap`() {
+        assertNotNull(service.validateClip(0, 16_000, 60_000))
+    }
+
+    @Test
+    fun `validateClip rejects end at or before start`() {
+        assertNotNull(service.validateClip(5_000, 5_000, 60_000))
+        assertNotNull(service.validateClip(5_000, 3_000, 60_000))
+    }
+
+    @Test
+    fun `validateClip rejects end beyond source duration`() {
+        assertNotNull(service.validateClip(0, 20_000, 10_000))
+    }
+
+    @Test
+    fun `validateClip rejects negative start`() {
+        assertNotNull(service.validateClip(-1, 1_000, 60_000))
+    }
+
+    // setIntroByUrl persists timestamps
+
+    @Test
+    fun `setIntroByUrl persists startMs and endMs on new intro`() {
+        val user = UserDto(discordId = discordId, guildId = guildId).apply { musicDtos = mutableListOf() }
+        every { userService.getUserById(discordId, guildId) } returns user
+        val slot = slot<MusicDto>()
+        every { musicFileService.createNewMusicFile(capture(slot)) } answers { slot.captured }
+
+        val err = service.setIntroByUrl(discordId, guildId, "https://example.com/a.mp3", 80, null, 3_000, 11_000)
+        assertNull(err)
+        assertEquals(3_000, slot.captured.startMs)
+        assertEquals(11_000, slot.captured.endMs)
+    }
+
+    @Test
+    fun `setIntroByFile persists startMs and endMs on new intro`() {
+        val user = UserDto(discordId = discordId, guildId = guildId).apply { musicDtos = mutableListOf() }
+        every { userService.getUserById(discordId, guildId) } returns user
+        val slot = slot<MusicDto>()
+        every { musicFileService.createNewMusicFile(capture(slot)) } answers { slot.captured }
+
+        val file = MockMultipartFile("file", "intro.mp3", "audio/mpeg", "bytes".toByteArray())
+        val err = service.setIntroByFile(discordId, guildId, file, 80, null, 500, 6_500)
+
+        assertNull(err)
+        assertEquals(500, slot.captured.startMs)
+        assertEquals(6_500, slot.captured.endMs)
+    }
+
+    // updateIntroTimestamps
+
+    @Test
+    fun `updateIntroTimestamps rejects ownership mismatch`() {
+        val err = service.updateIntroTimestamps(discordId, guildId, "999_000_1", 0, 1000)
+        assertEquals("Intro does not belong to you.", err)
+    }
+
+    @Test
+    fun `updateIntroTimestamps rejects invalid clip`() {
+        val dto = MusicDto(id = "${guildId}_${discordId}_1", index = 1, fileName = "a.mp3")
+        every { musicFileService.getMusicFileById(any()) } returns dto
+
+        val err = service.updateIntroTimestamps(discordId, guildId, "${guildId}_${discordId}_1", 5_000, 3_000)
+        assertNotNull(err)
+    }
+
+    @Test
+    fun `updateIntroTimestamps persists timestamps when valid`() {
+        val dto = MusicDto(id = "${guildId}_${discordId}_1", index = 1, fileName = "a.mp3")
+        every { musicFileService.getMusicFileById(any()) } returns dto
+        every { musicFileService.updateMusicFile(any()) } returns dto
+
+        val err = service.updateIntroTimestamps(discordId, guildId, "${guildId}_${discordId}_1", 1_000, 8_000)
+        assertNull(err)
+        assertEquals(1_000, dto.startMs)
+        assertEquals(8_000, dto.endMs)
     }
 }
 

--- a/application/src/test/resources/schema.sql
+++ b/application/src/test/resources/schema.sql
@@ -30,7 +30,9 @@ CREATE TABLE public.music_files (
     guild_id BIGINT,
     index INT,
     music_blob BYTEA,
-    music_blob_hash VARCHAR(64)
+    music_blob_hash VARCHAR(64),
+    clip_start_ms INT,
+    clip_end_ms INT
 );
 
 DROP TABLE IF EXISTS public."user";

--- a/database/src/main/kotlin/database/dto/MusicDto.kt
+++ b/database/src/main/kotlin/database/dto/MusicDto.kt
@@ -43,7 +43,13 @@ class MusicDto(
     var musicBlob: ByteArray? = null,
 
     @Column(name = "music_blob_hash")
-    var musicBlobHash: String? = null
+    var musicBlobHash: String? = null,
+
+    @Column(name = "clip_start_ms")
+    var startMs: Int? = null,
+
+    @Column(name = "clip_end_ms")
+    var endMs: Int? = null
 ) : Serializable {
 
     constructor(
@@ -51,7 +57,9 @@ class MusicDto(
         index: Int = 1,
         fileName: String? = null,
         introVolume: Int = 20,
-        musicBlob: ByteArray? = null
+        musicBlob: ByteArray? = null,
+        startMs: Int? = null,
+        endMs: Int? = null
     ) : this(
         id = "${userDto.guildId}_${userDto.discordId}_${index}",
         index = index,
@@ -59,7 +67,9 @@ class MusicDto(
         fileName = fileName,
         introVolume = introVolume,
         musicBlob = musicBlob,
-        musicBlobHash = musicBlob?.let { computeHash(it) }
+        musicBlobHash = musicBlob?.let { computeHash(it) },
+        startMs = startMs,
+        endMs = endMs
     )
 
     enum class Adjustment(val adjustment: String) {

--- a/database/src/main/resources/db/migration/V11__intro_timestamps.sql
+++ b/database/src/main/resources/db/migration/V11__intro_timestamps.sql
@@ -1,0 +1,8 @@
+-- Start/end timestamps (milliseconds) for clipping intro playback.
+-- Both optional: null means play from 0 / to end of track.
+-- Column names are prefixed with clip_ so they don't collide with the SQL
+-- reserved words END/START (which trip up H2 in PostgreSQL mode).
+
+ALTER TABLE public.music_files
+    ADD COLUMN IF NOT EXISTS clip_start_ms INT,
+    ADD COLUMN IF NOT EXISTS clip_end_ms   INT;

--- a/discord-bot/src/main/kotlin/bot/toby/helpers/MusicPlayerHelper.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/helpers/MusicPlayerHelper.kt
@@ -47,8 +47,13 @@ object MusicPlayerHelper {
                 val introVolume = it.introVolume
                 instance.setPreviousVolume(currentVolume)
                 val url = determineUrlFromMusicDto(it)
-                logger.info { "Url to play is: '$url'" }
-                instance.loadAndPlay(guild, event, url, true, deleteDelay, startPosition, introVolume ?: currentVolume)
+                val clipStart = it.startMs?.toLong() ?: startPosition
+                val clipEnd = it.endMs?.toLong()
+                logger.info { "Url to play is: '$url' (clip ${clipStart}ms -> ${clipEnd ?: "end"})" }
+                instance.loadAndPlay(
+                    guild, event, url, true, deleteDelay, clipStart,
+                    introVolume ?: currentVolume, clipEnd
+                )
             }
         }.onFailure {
             logger.warn { "User does not have a musicDto. Cannot play intro." }

--- a/discord-bot/src/main/kotlin/bot/toby/lavaplayer/PlayerManager.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/lavaplayer/PlayerManager.kt
@@ -61,22 +61,37 @@ class PlayerManager(private val audioPlayerManager: AudioPlayerManager) {
         isSkippable: Boolean,
         deleteDelay: Int,
         startPosition: Long,
-        volume: Int
+        volume: Int,
+        endPosition: Long?
     ) {
         val musicManager = this.getMusicManager(guild)
         this.isCurrentlyStoppable = isSkippable
         audioPlayerManager.loadItemOrdered(
             musicManager,
             trackUrl,
-            getResultHandler(event, musicManager, trackUrl, startPosition, volume, deleteDelay)
+            getResultHandler(event, musicManager, trackUrl, startPosition, endPosition, volume, deleteDelay)
         )
     }
+
+    // Back-compat overload: previous 7-arg signature delegates to the new one with
+    // no end marker. Keeps existing call sites and MockK stubs binary-compatible.
+    @Synchronized
+    fun loadAndPlay(
+        guild: Guild,
+        event: SlashCommandInteractionEvent?,
+        trackUrl: String,
+        isSkippable: Boolean,
+        deleteDelay: Int,
+        startPosition: Long,
+        volume: Int
+    ) = loadAndPlay(guild, event, trackUrl, isSkippable, deleteDelay, startPosition, volume, null)
 
     private fun getResultHandler(
         event: SlashCommandInteractionEvent?,
         musicManager: GuildMusicManager,
         trackUrl: String,
         startPosition: Long,
+        endPosition: Long?,
         volume: Int,
         deleteDelay: Int
     ): AudioLoadResultHandler {
@@ -86,7 +101,7 @@ class PlayerManager(private val audioPlayerManager: AudioPlayerManager) {
             override fun trackLoaded(track: AudioTrack) {
                 scheduler.event = event
                 scheduler.deleteDelay = deleteDelay
-                scheduler.queue(track, startPosition, volume)
+                scheduler.queue(track, startPosition, endPosition, volume)
                 scheduler.setPreviousVolume(previousVolume)
             }
 

--- a/discord-bot/src/main/kotlin/bot/toby/lavaplayer/TrackScheduler.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/lavaplayer/TrackScheduler.kt
@@ -8,6 +8,8 @@ import com.sedmelluq.discord.lavaplayer.player.event.AudioEventAdapter
 import com.sedmelluq.discord.lavaplayer.track.AudioPlaylist
 import com.sedmelluq.discord.lavaplayer.track.AudioTrack
 import com.sedmelluq.discord.lavaplayer.track.AudioTrackEndReason
+import com.sedmelluq.discord.lavaplayer.track.TrackMarker
+import com.sedmelluq.discord.lavaplayer.track.TrackMarkerHandler
 import common.logging.DiscordLogger
 import core.command.Command.Companion.invokeDeleteOnMessageResponse
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
@@ -21,19 +23,34 @@ class TrackScheduler(val player: AudioPlayer, private val guildId: Long, var del
     private var previousVolume: Int? = null
     private val logger: DiscordLogger = DiscordLogger.createLogger(this::class.java)
 
-    fun queue(track: AudioTrack, startPosition: Long, volume: Int) {
+    fun queue(track: AudioTrack, startPosition: Long, endPosition: Long?, volume: Int) {
         logger.info("Adding ${track.info.title} by ${track.info.author} to the queue for guild $guildId")
+        val endNote = endPosition?.let { " (clipped to ${it} ms)" }.orEmpty()
         event?.hook
-            ?.sendMessage("Adding to queue: `${track.info.title}` by `${track.info.author}` starting at '${startPosition} ms' with volume '$volume'")
+            ?.sendMessage("Adding to queue: `${track.info.title}` by `${track.info.author}` starting at '${startPosition} ms'$endNote with volume '$volume'")
             ?.queue(invokeDeleteOnMessageResponse(deleteDelay))
         track.position = startPosition
         track.userData = volume
+        if (endPosition != null && endPosition > startPosition) {
+            track.setMarker(TrackMarker(endPosition, TrackMarkerHandler { state ->
+                // Stop the clipped track on reaching the end marker. onTrackEnd then
+                // advances the queue and restores the previous volume.
+                if (state == TrackMarkerHandler.MarkerState.REACHED) {
+                    logger.info("Clip end marker reached at ${endPosition} ms for ${track.info.title}, stopping track.")
+                    track.stop()
+                }
+            }))
+        }
         synchronized(queue) {
             if (!player.startTrack(track, true)) {
                 queue.offer(track)
             }
         }
     }
+
+    // Back-compat overload for the pre-clip call sites; currently unused but keeps
+    // the older signature compiling if anything else still calls it.
+    fun queue(track: AudioTrack, startPosition: Long, volume: Int) = queue(track, startPosition, null, volume)
 
     fun queueTrackList(playList: AudioPlaylist, volume: Int) {
         logger.info { "Adding ${playList.name} to the queue for guild $guildId" }

--- a/web/src/main/kotlin/web/controller/IntroWebController.kt
+++ b/web/src/main/kotlin/web/controller/IntroWebController.kt
@@ -103,6 +103,8 @@ class IntroWebController(
         @RequestParam(defaultValue = "90") volume: Int,
         @RequestParam(required = false) replaceIndex: Int?,
         @RequestParam(required = false) targetDiscordId: Long?,
+        @RequestParam(required = false) startMs: Int?,
+        @RequestParam(required = false) endMs: Int?,
         ra: RedirectAttributes
     ): String {
         val authDiscordId = user.discordIdOrNull()
@@ -111,9 +113,13 @@ class IntroWebController(
 
         val clampedVolume = volume.coerceIn(1, 100)
         val error: String? = when (inputType) {
-            "url" -> introWebService.setIntroByUrl(effectiveDiscordId, guildId, url.orEmpty().trim(), clampedVolume, replaceIndex)
+            "url" -> introWebService.setIntroByUrl(
+                effectiveDiscordId, guildId, url.orEmpty().trim(), clampedVolume, replaceIndex, startMs, endMs
+            )
             "file" -> if (file != null && !file.isEmpty) {
-                introWebService.setIntroByFile(effectiveDiscordId, guildId, file, clampedVolume, replaceIndex)
+                introWebService.setIntroByFile(
+                    effectiveDiscordId, guildId, file, clampedVolume, replaceIndex, startMs, endMs
+                )
             } else {
                 "No file provided."
             }
@@ -150,6 +156,8 @@ class IntroWebController(
                 fileName = it.fileName,
                 introVolume = it.introVolume ?: 90,
                 musicBlob = it.musicBlob?.copyOf(),
+                startMs = it.startMs,
+                endMs = it.endMs,
                 discordId = effectiveDiscordId,
                 guildId = guildId,
                 timestampMs = System.currentTimeMillis()
@@ -206,7 +214,15 @@ class IntroWebController(
         } else {
             (dbUser.musicDtos.map { it.index ?: 0 }.maxOrNull() ?: 0) + 1
         }
-        val restored = MusicDto(dbUser, targetIndex, snapshot.fileName, snapshot.introVolume, snapshot.musicBlob)
+        val restored = MusicDto(
+            dbUser,
+            targetIndex,
+            snapshot.fileName,
+            snapshot.introVolume,
+            snapshot.musicBlob,
+            snapshot.startMs,
+            snapshot.endMs
+        )
         musicFileService.createNewMusicFile(restored)
 
         ra.addFlashAttribute("success", "Intro restored.")
@@ -225,6 +241,22 @@ class IntroWebController(
             ?: return ResponseEntity.status(401).body(ApiResult(false, "Not signed in."))
         val effective = resolveEffectiveDiscordId(authDiscordId, guildId, targetDiscordId)
         val error = introWebService.updateIntroVolume(effective, guildId, body.introId, body.volume)
+        return if (error != null) ResponseEntity.badRequest().body(ApiResult(false, error))
+        else ResponseEntity.ok(ApiResult(true, null))
+    }
+
+    @PostMapping("/{guildId}/update-timestamps", consumes = ["application/json"])
+    @ResponseBody
+    fun updateTimestamps(
+        @PathVariable guildId: Long,
+        @RequestBody body: UpdateTimestampsRequest,
+        @AuthenticationPrincipal user: OAuth2User,
+        @RequestParam(required = false) targetDiscordId: Long?
+    ): ResponseEntity<ApiResult> {
+        val authDiscordId = user.discordIdOrNull()
+            ?: return ResponseEntity.status(401).body(ApiResult(false, "Not signed in."))
+        val effective = resolveEffectiveDiscordId(authDiscordId, guildId, targetDiscordId)
+        val error = introWebService.updateIntroTimestamps(effective, guildId, body.introId, body.startMs, body.endMs)
         return if (error != null) ResponseEntity.badRequest().body(ApiResult(false, error))
         else ResponseEntity.ok(ApiResult(true, null))
     }
@@ -301,6 +333,7 @@ class IntroWebController(
 
 data class UpdateVolumeRequest(val introId: String = "", val volume: Int = 0)
 data class UpdateNameRequest(val introId: String = "", val name: String = "")
+data class UpdateTimestampsRequest(val introId: String = "", val startMs: Int? = null, val endMs: Int? = null)
 data class ReorderRequest(val orderedIds: List<String> = emptyList())
 
 data class ApiResult(val ok: Boolean, val error: String?)
@@ -320,6 +353,8 @@ data class DeletedIntroSnapshot(
     val fileName: String?,
     val introVolume: Int,
     val musicBlob: ByteArray?,
+    val startMs: Int?,
+    val endMs: Int?,
     val discordId: Long,
     val guildId: Long,
     val timestampMs: Long

--- a/web/src/main/kotlin/web/service/IntroWebService.kt
+++ b/web/src/main/kotlin/web/service/IntroWebService.kt
@@ -22,6 +22,7 @@ class IntroWebService(
         const val MAX_FILE_SIZE = 550 * 1024
         const val MAX_INTRO_COUNT = 3
         const val MAX_INTRO_DURATION_SECONDS = 15
+        const val MAX_CLIP_DURATION_MS = MAX_INTRO_DURATION_SECONDS * 1000
         private val objectMapper = ObjectMapper()
     }
 
@@ -95,12 +96,31 @@ class IntroWebService(
             } else {
                 dto.fileName
             }
-            val thumbnailUrl = url?.let { extractVideoId(it) }?.let { "https://img.youtube.com/vi/$it/mqdefault.jpg" }
-            IntroViewModel(dto.id.orEmpty(), dto.index, displayName, dto.introVolume, url, thumbnailUrl)
+            val videoId = url?.let { extractVideoId(it) }
+            val thumbnailUrl = videoId?.let { "https://img.youtube.com/vi/$it/mqdefault.jpg" }
+            IntroViewModel(
+                id = dto.id.orEmpty(),
+                index = dto.index,
+                fileName = displayName,
+                introVolume = dto.introVolume,
+                url = url,
+                thumbnailUrl = thumbnailUrl,
+                videoId = videoId,
+                startMs = dto.startMs,
+                endMs = dto.endMs
+            )
         }
     }
 
-    fun setIntroByUrl(discordId: Long, guildId: Long, url: String, volume: Int, replaceIndex: Int?): String? {
+    fun setIntroByUrl(
+        discordId: Long,
+        guildId: Long,
+        url: String,
+        volume: Int,
+        replaceIndex: Int?,
+        startMs: Int?,
+        endMs: Int?
+    ): String? {
         if (!isValidUrl(url)) return "Invalid URL provided."
 
         val user = getOrCreateUser(discordId, guildId)
@@ -111,9 +131,9 @@ class IntroWebService(
         }
 
         val preview = fetchYouTubePreview(url)
-        if (preview?.durationSeconds != null && preview.durationSeconds > MAX_INTRO_DURATION_SECONDS) {
-            return "Video is too long (${preview.durationSeconds}s). Max allowed is ${MAX_INTRO_DURATION_SECONDS}s."
-        }
+        val sourceDurationMs = preview?.durationSeconds?.let { it * 1000 }
+
+        validateClip(startMs, endMs, sourceDurationMs)?.let { return it }
 
         val displayName = preview?.title ?: url
         val urlBytes = url.toByteArray()
@@ -124,17 +144,27 @@ class IntroWebService(
             selectedDto.musicBlob = urlBytes
             selectedDto.musicBlobHash = MusicDto.computeHash(urlBytes)
             selectedDto.introVolume = volume
+            selectedDto.startMs = startMs
+            selectedDto.endMs = endMs
             musicFileService.updateMusicFile(selectedDto)
         } else {
             val newIndex = existingIntros.size + 1
-            val newDto = MusicDto(user, newIndex, displayName, volume, urlBytes)
+            val newDto = MusicDto(user, newIndex, displayName, volume, urlBytes, startMs, endMs)
             musicFileService.createNewMusicFile(newDto)
         }
 
         return null
     }
 
-    fun setIntroByFile(discordId: Long, guildId: Long, file: MultipartFile, volume: Int, replaceIndex: Int?): String? {
+    fun setIntroByFile(
+        discordId: Long,
+        guildId: Long,
+        file: MultipartFile,
+        volume: Int,
+        replaceIndex: Int?,
+        startMs: Int?,
+        endMs: Int?
+    ): String? {
         if (file.isEmpty) return "No file provided."
         if (!file.originalFilename.orEmpty().endsWith(".mp3", ignoreCase = true)) {
             return "Only MP3 files are supported."
@@ -142,6 +172,10 @@ class IntroWebService(
         if (file.size > MAX_FILE_SIZE) {
             return "File exceeds maximum size of ${MAX_FILE_SIZE / 1024}KB."
         }
+
+        // Source duration is unknown for uploaded files here — let the client-side
+        // preview enforce bounds against the real audio. Clip-length rule still applies.
+        validateClip(startMs, endMs, sourceDurationMs = null)?.let { return it }
 
         val user = getOrCreateUser(discordId, guildId)
         val existingIntros = user.musicDtos.sortedBy { it.index }
@@ -159,14 +193,52 @@ class IntroWebService(
             selectedDto.musicBlob = fileBytes
             selectedDto.musicBlobHash = MusicDto.computeHash(fileBytes)
             selectedDto.introVolume = volume
+            selectedDto.startMs = startMs
+            selectedDto.endMs = endMs
             musicFileService.updateMusicFile(selectedDto)
         } else {
             val newIndex = existingIntros.size + 1
-            val newDto = MusicDto(user, newIndex, fileName, volume, fileBytes)
+            val newDto = MusicDto(user, newIndex, fileName, volume, fileBytes, startMs, endMs)
             musicFileService.createNewMusicFile(newDto)
                 ?: return "This file already exists as one of your intros."
         }
 
+        return null
+    }
+
+    /**
+     * Validates a clip range against the source duration.
+     *
+     * - Both null: no clipping. Only reject when source is known and longer than the 15s cap.
+     * - start/end present: start must be < end; clip span (end - start) must be <= MAX_CLIP_DURATION_MS.
+     * - When [sourceDurationMs] is known, end must be <= sourceDurationMs.
+     *
+     * Returns an error message or null if the clip is valid.
+     */
+    fun validateClip(startMs: Int?, endMs: Int?, sourceDurationMs: Int?): String? {
+        if (startMs == null && endMs == null) {
+            if (sourceDurationMs != null && sourceDurationMs > MAX_CLIP_DURATION_MS) {
+                val seconds = sourceDurationMs / 1000
+                return "Video is too long (${seconds}s). Max allowed is ${MAX_INTRO_DURATION_SECONDS}s — set a start/end clip to use a longer source."
+            }
+            return null
+        }
+        val start = startMs ?: 0
+        if (start < 0) return "Start time cannot be negative."
+        if (endMs != null) {
+            if (endMs <= start) return "End time must be greater than start time."
+            if (sourceDurationMs != null && endMs > sourceDurationMs) {
+                return "End time exceeds the source duration."
+            }
+            if (endMs - start > MAX_CLIP_DURATION_MS) {
+                return "Clip is too long (${(endMs - start) / 1000}s). Max allowed is ${MAX_INTRO_DURATION_SECONDS}s."
+            }
+        } else if (sourceDurationMs != null) {
+            // Only start was provided; the clip runs from start to end of source.
+            if (sourceDurationMs - start > MAX_CLIP_DURATION_MS) {
+                return "Clip is too long (${(sourceDurationMs - start) / 1000}s). Max allowed is ${MAX_INTRO_DURATION_SECONDS}s."
+            }
+        }
         return null
     }
 
@@ -187,6 +259,30 @@ class IntroWebService(
 
         val dto = musicFileService.getMusicFileById(introId) ?: return "Intro not found."
         dto.introVolume = volume.coerceIn(1, 100)
+        musicFileService.updateMusicFile(dto)
+        return null
+    }
+
+    fun updateIntroTimestamps(
+        discordId: Long,
+        guildId: Long,
+        introId: String,
+        startMs: Int?,
+        endMs: Int?
+    ): String? {
+        requireOwnedIntro(discordId, guildId, introId)?.let { return it }
+
+        val dto = musicFileService.getMusicFileById(introId) ?: return "Intro not found."
+        val sourceDurationMs = run {
+            val blobString = dto.musicBlob?.let { String(it) }.orEmpty()
+            if (blobString.startsWith("http://") || blobString.startsWith("https://")) {
+                fetchYouTubePreview(blobString)?.durationSeconds?.let { it * 1000 }
+            } else null
+        }
+        validateClip(startMs, endMs, sourceDurationMs)?.let { return it }
+
+        dto.startMs = startMs
+        dto.endMs = endMs
         musicFileService.updateMusicFile(dto)
         return null
     }
@@ -312,7 +408,10 @@ data class IntroViewModel(
     val fileName: String?,
     val introVolume: Int?,
     val url: String?,
-    val thumbnailUrl: String? = null
+    val thumbnailUrl: String? = null,
+    val videoId: String? = null,
+    val startMs: Int? = null,
+    val endMs: Int? = null
 )
 
 data class GuildInfo(

--- a/web/src/main/resources/static/css/intros.css
+++ b/web/src/main/resources/static/css/intros.css
@@ -231,11 +231,99 @@
     text-align: right;
 }
 
+/* ---- Clip (start/end) inputs ---- */
+.clip-inputs {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    flex-wrap: wrap;
+    padding: 10px 14px;
+    background: var(--bg-input);
+    border: 1px solid var(--border-strong);
+    border-radius: var(--radius-sm);
+}
+.clip-input-label {
+    display: flex;
+    flex-direction: column;
+    font-size: 0.75rem;
+    color: var(--text-muted);
+    margin: 0;
+    gap: 4px;
+}
+.clip-input-label input {
+    width: 7ch;
+    font-variant-numeric: tabular-nums;
+    background: var(--bg-elevated);
+    border: 1px solid var(--border-strong);
+    color: var(--text);
+    padding: 4px 8px;
+    border-radius: var(--radius-sm);
+    font-family: inherit;
+}
+.clip-input-label input[aria-invalid="true"] { border-color: var(--danger); }
+.clip-dash { color: var(--text-dim); padding: 0 2px; align-self: end; padding-bottom: 8px; }
+.clip-length {
+    margin-left: auto;
+    font-size: 0.8rem;
+    color: var(--text-muted);
+    font-variant-numeric: tabular-nums;
+}
+.clip-length.too-long { color: var(--danger); font-weight: 600; }
+
+/* Clip badge in the intros table */
+.clip-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    margin-left: 8px;
+    padding: 2px 8px;
+    background: var(--bg-input);
+    border: 1px solid var(--border-strong);
+    border-radius: 999px;
+    color: var(--text-muted);
+    font-size: 0.72rem;
+    cursor: pointer;
+    font-family: inherit;
+}
+.clip-badge:hover { border-color: var(--accent); color: var(--accent); }
+.clip-badge-label { font-size: 0.8rem; }
+
+/* Row-level clip editor popover */
+.clip-editor-popover {
+    position: absolute;
+    z-index: 20;
+    background: var(--bg-elevated);
+    border: 1px solid var(--border-strong);
+    border-radius: var(--radius-md);
+    padding: 12px;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    min-width: 260px;
+}
+.clip-editor-actions { display: flex; gap: 8px; flex-wrap: wrap; }
+
+/* YouTube iframe preview */
+.url-preview-iframe {
+    margin-top: var(--space-3);
+    display: none;
+}
+.url-preview-iframe.visible { display: block; }
+.url-preview-iframe iframe {
+    width: 100%;
+    aspect-ratio: 16 / 9;
+    border: 0;
+    border-radius: var(--radius-sm);
+    background: #000;
+}
+
 @media (max-width: 640px) {
     .url-preview { grid-template-columns: 1fr; }
     .url-preview img { width: 100%; height: 140px; }
     .form-row-split { grid-template-columns: 1fr; }
     .intros-table td.actions { text-align: left; }
+    .clip-length { margin-left: 0; width: 100%; }
 }
 
 @media (max-width: 480px) {

--- a/web/src/main/resources/static/js/intros.js
+++ b/web/src/main/resources/static/js/intros.js
@@ -2,12 +2,69 @@
    Intro page interactions
    ============================================================ */
 
+// Max clip length mirrors IntroWebService.MAX_INTRO_DURATION_SECONDS.
+const DEFAULT_MAX_CLIP_SECONDS = 15;
+
 // --- Back-compat helpers (kept for existing jest tests) ---
 function toggleInput(type) {
     const urlSection = document.getElementById('urlSection');
     const fileSection = document.getElementById('fileSection');
     if (urlSection) urlSection.style.display = (type === 'url') ? 'block' : 'none';
     if (fileSection) fileSection.style.display = (type === 'file') ? 'block' : 'none';
+}
+
+// --- Pure helpers (exported for tests) ---
+
+// Parses "mm:ss", "mm:ss.S", or raw "ss" / "ss.S" into integer milliseconds.
+// Returns null for blank input; NaN for malformed input.
+function parseTimeInput(raw) {
+    if (raw == null) return null;
+    const s = String(raw).trim();
+    if (s === '') return null;
+    // Raw seconds (possibly decimal)
+    if (!s.includes(':')) {
+        const n = Number(s);
+        if (!isFinite(n) || n < 0) return NaN;
+        return Math.round(n * 1000);
+    }
+    const parts = s.split(':');
+    if (parts.length !== 2) return NaN;
+    const mins = Number(parts[0]);
+    const secs = Number(parts[1]);
+    if (!isFinite(mins) || !isFinite(secs) || mins < 0 || secs < 0 || secs >= 60) return NaN;
+    return Math.round((mins * 60 + secs) * 1000);
+}
+
+function formatMs(ms) {
+    if (ms == null || !isFinite(ms) || ms < 0) return '';
+    const totalSec = ms / 1000;
+    const m = Math.floor(totalSec / 60);
+    const s = totalSec - m * 60;
+    // Show one decimal if non-integer, otherwise two-digit seconds.
+    const secStr = Number.isInteger(s) ? String(s).padStart(2, '0') : s.toFixed(1).padStart(4, '0');
+    return m + ':' + secStr;
+}
+
+// Mirrors IntroWebService.validateClip. Returns an error string, or '' if valid.
+function validateClipMs(startMs, endMs, sourceDurationMs, maxClipMs) {
+    const cap = maxClipMs || DEFAULT_MAX_CLIP_SECONDS * 1000;
+    if (startMs == null && endMs == null) {
+        if (sourceDurationMs != null && sourceDurationMs > cap) {
+            return 'Video is too long (' + Math.floor(sourceDurationMs / 1000) + 's). Max is '
+                + Math.floor(cap / 1000) + 's — set a start/end clip to use a longer source.';
+        }
+        return '';
+    }
+    const start = startMs == null ? 0 : startMs;
+    if (start < 0) return 'Start time cannot be negative.';
+    if (endMs != null) {
+        if (endMs <= start) return 'End time must be greater than start time.';
+        if (sourceDurationMs != null && endMs > sourceDurationMs) return 'End time exceeds the source duration.';
+        if (endMs - start > cap) return 'Clip is too long (' + Math.floor((endMs - start) / 1000) + 's). Max is ' + Math.floor(cap / 1000) + 's.';
+    } else if (sourceDurationMs != null) {
+        if (sourceDurationMs - start > cap) return 'Clip is too long. Max is ' + Math.floor(cap / 1000) + 's.';
+    }
+    return '';
 }
 
 function togglePlay(btn) {
@@ -44,6 +101,10 @@ function initIntroPage() {
         csrfToken: document.querySelector('meta[name="_csrf"]')?.content || '',
         csrfHeader: document.querySelector('meta[name="_csrf_header"]')?.content || 'X-CSRF-TOKEN',
     };
+    const maxClipMs = cfg.maxDurationSeconds * 1000;
+
+    // Current clip state for the add/replace form. null = unset; NaN = malformed input.
+    const clipState = { startMs: null, endMs: null, sourceDurationMs: null, valid: true };
 
     // --- Render any flash messages as toasts ---
     document.querySelectorAll('[data-flash]').forEach(el => {
@@ -94,13 +155,93 @@ function initIntroPage() {
         sync();
     });
 
+    // --- Clip (start/end) inputs ---
+    const startTimeInput = document.getElementById('startTime');
+    const endTimeInput = document.getElementById('endTime');
+    const startMsHidden = document.getElementById('startMs');
+    const endMsHidden = document.getElementById('endMs');
+    const clipErrorEl = document.getElementById('clipError');
+    const clipLengthEl = document.querySelector('[data-clip-length]');
+
+    function setClipError(msg) {
+        if (clipErrorEl) clipErrorEl.textContent = msg || '';
+        [startTimeInput, endTimeInput].forEach(el => {
+            if (el) el.setAttribute('aria-invalid', msg ? 'true' : 'false');
+        });
+    }
+
+    function renderClipLength() {
+        if (!clipLengthEl) return;
+        const { startMs, endMs } = clipState;
+        if (Number.isNaN(startMs) || Number.isNaN(endMs)) {
+            clipLengthEl.textContent = '—';
+            clipLengthEl.classList.remove('too-long');
+            return;
+        }
+        if (startMs == null && endMs == null) {
+            clipLengthEl.textContent = 'full track';
+            clipLengthEl.classList.remove('too-long');
+            return;
+        }
+        const effectiveStart = startMs == null ? 0 : startMs;
+        const effectiveEnd = endMs == null ? clipState.sourceDurationMs : endMs;
+        if (effectiveEnd != null && effectiveEnd > effectiveStart) {
+            const span = effectiveEnd - effectiveStart;
+            clipLengthEl.textContent = 'Clip length: ' + formatMs(span);
+            clipLengthEl.classList.toggle('too-long', span > maxClipMs);
+        } else {
+            clipLengthEl.textContent = '—';
+            clipLengthEl.classList.remove('too-long');
+        }
+    }
+
+    function recomputeClipState() {
+        const rawStart = startTimeInput ? startTimeInput.value : '';
+        const rawEnd = endTimeInput ? endTimeInput.value : '';
+        const startMs = parseTimeInput(rawStart);
+        const endMs = parseTimeInput(rawEnd);
+        clipState.startMs = startMs;
+        clipState.endMs = endMs;
+
+        if (Number.isNaN(startMs) || Number.isNaN(endMs)) {
+            clipState.valid = false;
+            setClipError('Use format mm:ss or raw seconds.');
+            if (startMsHidden) startMsHidden.value = '';
+            if (endMsHidden) endMsHidden.value = '';
+            renderClipLength();
+            return;
+        }
+
+        const err = validateClipMs(startMs, endMs, clipState.sourceDurationMs, maxClipMs);
+        clipState.valid = !err;
+        setClipError(err);
+
+        if (startMsHidden) startMsHidden.value = startMs == null ? '' : String(startMs);
+        if (endMsHidden) endMsHidden.value = endMs == null ? '' : String(endMs);
+        renderClipLength();
+    }
+
+    [startTimeInput, endTimeInput].forEach(el => {
+        if (!el) return;
+        el.addEventListener('input', () => {
+            recomputeClipState();
+            updateSubmitState();
+            if (activeUrlPreview) renderUrlIframe(activeUrlPreview);
+            if (activeFileAudio) applyClipBoundsToFilePreview(activeFileAudio);
+        });
+    });
+    recomputeClipState();
+
     // --- URL input: live YouTube preview ---
     const urlInput = document.getElementById('url');
     const urlPreview = document.getElementById('urlPreview');
+    const urlPreviewIframe = document.getElementById('urlPreviewIframe');
     const urlError = document.getElementById('urlError');
     const submitBtn = document.getElementById('submitBtn');
     let previewState = { tooLong: false };
     let debounceTimer = null;
+    let activeUrlPreview = null;
+    let activeFileAudio = null;
 
     function setUrlError(msg) {
         if (!urlError) return;
@@ -111,8 +252,17 @@ function initIntroPage() {
     function renderPreview(data) {
         if (!urlPreview) return;
         urlPreview.classList.remove('visible', 'error');
-        if (!data || !data.thumbnailUrl) return;
-        previewState.tooLong = data.durationSeconds != null && data.durationSeconds > cfg.maxDurationSeconds;
+        if (!data || !data.thumbnailUrl) {
+            activeUrlPreview = null;
+            clipState.sourceDurationMs = null;
+            renderUrlIframe(null);
+            renderClipLength();
+            return;
+        }
+        // Clip-length rule supersedes the old hard cap — oversize source is only
+        // rejected when the user hasn't picked a clip that fits.
+        clipState.sourceDurationMs = data.durationSeconds != null ? data.durationSeconds * 1000 : null;
+        previewState.tooLong = !!validateClipMs(clipState.startMs, clipState.endMs, clipState.sourceDurationMs, maxClipMs);
         const dur = data.durationSeconds != null ? formatDuration(data.durationSeconds) : '—';
         const title = data.title || '(Unknown title)';
         urlPreview.innerHTML =
@@ -126,6 +276,49 @@ function initIntroPage() {
             '</div>';
         if (previewState.tooLong) urlPreview.classList.add('error');
         urlPreview.classList.add('visible');
+        activeUrlPreview = data;
+        renderUrlIframe(data);
+        recomputeClipState();
+    }
+
+    // Renders a YouTube embed that honours the current start/end clip. When the
+    // source isn't YouTube (or is unknown), the iframe area stays hidden.
+    function renderUrlIframe(data) {
+        if (!urlPreviewIframe) return;
+        if (!data || !data.videoId) {
+            urlPreviewIframe.innerHTML = '';
+            urlPreviewIframe.classList.remove('visible');
+            urlPreviewIframe.setAttribute('aria-hidden', 'true');
+            return;
+        }
+        const startSec = Number.isInteger(clipState.startMs) ? Math.floor(clipState.startMs / 1000) : 0;
+        const endSec = Number.isInteger(clipState.endMs) ? Math.ceil(clipState.endMs / 1000) : null;
+        const params = new URLSearchParams();
+        if (startSec > 0) params.set('start', String(startSec));
+        if (endSec != null && endSec > startSec) params.set('end', String(endSec));
+        params.set('controls', '1');
+        params.set('rel', '0');
+        const qs = params.toString();
+        const src = 'https://www.youtube.com/embed/' + encodeURIComponent(data.videoId) + (qs ? '?' + qs : '');
+        urlPreviewIframe.innerHTML =
+            '<iframe src="' + escapeAttr(src) + '" ' +
+            'title="Clip preview" ' +
+            'allow="autoplay; encrypted-media" ' +
+            'allowfullscreen></iframe>';
+        urlPreviewIframe.classList.add('visible');
+        urlPreviewIframe.setAttribute('aria-hidden', 'false');
+    }
+
+    // Pauses/seeks an <audio> element to stay within the current clip bounds.
+    function applyClipBoundsToFilePreview(audio) {
+        if (!audio || !audio._clipBoundHandler) return;
+        audio._clipStartMs = Number.isInteger(clipState.startMs) ? clipState.startMs : 0;
+        audio._clipEndMs = Number.isInteger(clipState.endMs) ? clipState.endMs : null;
+        // If the element is currently past the (new) end, rewind it.
+        if (audio._clipEndMs != null && audio.currentTime * 1000 >= audio._clipEndMs) {
+            audio.pause();
+            audio.currentTime = audio._clipStartMs / 1000;
+        }
     }
 
     function fetchPreview(url) {
@@ -215,9 +408,36 @@ function initIntroPage() {
                 apply();
                 volSlider.addEventListener('input', apply);
             }
+            // Pick up source duration so the clip validator can check end <= duration.
+            audio.addEventListener('loadedmetadata', () => {
+                if (isFinite(audio.duration)) {
+                    clipState.sourceDurationMs = Math.floor(audio.duration * 1000);
+                    recomputeClipState();
+                    updateSubmitState();
+                }
+            });
+            // Enforce clip bounds on the preview audio element.
+            audio._clipBoundHandler = true;
+            audio._clipStartMs = Number.isInteger(clipState.startMs) ? clipState.startMs : 0;
+            audio._clipEndMs = Number.isInteger(clipState.endMs) ? clipState.endMs : null;
+            audio.addEventListener('play', () => {
+                const startSec = (audio._clipStartMs || 0) / 1000;
+                if (audio.currentTime < startSec - 0.25 || audio.currentTime > (audio._clipEndMs ?? Infinity) / 1000) {
+                    audio.currentTime = startSec;
+                }
+            });
+            audio.addEventListener('timeupdate', () => {
+                if (audio._clipEndMs != null && audio.currentTime * 1000 >= audio._clipEndMs) {
+                    audio.pause();
+                    audio.currentTime = (audio._clipStartMs || 0) / 1000;
+                }
+            });
+            activeFileAudio = audio;
             row.appendChild(label);
             row.appendChild(audio);
             fileSummary.appendChild(row);
+        } else {
+            activeFileAudio = null;
         }
         updateSubmitState();
     }
@@ -265,6 +485,7 @@ function initIntroPage() {
         } else if (source === 'file') {
             canSubmit = fileValid;
         }
+        if (!clipState.valid) canSubmit = false;
         submitBtn.disabled = !canSubmit;
     }
     if (form) {
@@ -320,6 +541,87 @@ function initIntroPage() {
             });
         });
     });
+
+    // --- Row-level clip editor (⏱ badge) ---
+    document.querySelectorAll('[data-edit-clip]').forEach(btn => {
+        btn.addEventListener('click', function (ev) {
+            ev.stopPropagation();
+            openRowClipEditor(btn);
+        });
+    });
+
+    function closeOpenRowEditor() {
+        document.querySelectorAll('.clip-editor-popover').forEach(el => el.remove());
+    }
+
+    function openRowClipEditor(badgeBtn) {
+        closeOpenRowEditor();
+        const tr = badgeBtn.closest('tr[data-intro-id]');
+        if (!tr) return;
+        const introId = tr.dataset.introId;
+        const currentStartMs = tr.dataset.startMs ? parseInt(tr.dataset.startMs, 10) : null;
+        const currentEndMs = tr.dataset.endMs ? parseInt(tr.dataset.endMs, 10) : null;
+
+        const tpl = document.getElementById('clipEditorTemplate');
+        if (!tpl || !tpl.content) return;
+        const popover = tpl.content.firstElementChild.cloneNode(true);
+        const startEl = popover.querySelector('[data-row-clip="start"]');
+        const endEl = popover.querySelector('[data-row-clip="end"]');
+        const errEl = popover.querySelector('[data-row-clip-error]');
+        const saveBtn = popover.querySelector('[data-row-clip-save]');
+        const clearBtn = popover.querySelector('[data-row-clip-clear]');
+        const cancelBtn = popover.querySelector('[data-row-clip-cancel]');
+
+        if (startEl && currentStartMs != null) startEl.value = formatMs(currentStartMs);
+        if (endEl && currentEndMs != null) endEl.value = formatMs(currentEndMs);
+
+        // Anchor to the badge.
+        const rect = badgeBtn.getBoundingClientRect();
+        popover.style.top = (window.scrollY + rect.bottom + 6) + 'px';
+        popover.style.left = (window.scrollX + rect.left) + 'px';
+        document.body.appendChild(popover);
+
+        function submit(startMs, endMs) {
+            const err = validateClipMs(startMs, endMs, null, maxClipMs);
+            if (err) { if (errEl) errEl.textContent = err; return; }
+            apiCall(buildUrl('/update-timestamps'), { introId: introId, startMs: startMs, endMs: endMs }, {
+                onSuccess: () => {
+                    tr.dataset.startMs = startMs == null ? '' : String(startMs);
+                    tr.dataset.endMs = endMs == null ? '' : String(endMs);
+                    const rangeLabel = badgeBtn.querySelector('.clip-badge-range');
+                    if (rangeLabel) {
+                        rangeLabel.textContent = (startMs == null && endMs == null) ? 'full track' : 'clip set';
+                    }
+                    window.TobyToast.show('Clip updated.', { type: 'success', duration: 2000 });
+                    closeOpenRowEditor();
+                },
+                onError: (r) => {
+                    if (errEl) errEl.textContent = r ? (r.error || 'Update failed.') : 'Network error.';
+                }
+            });
+        }
+
+        saveBtn.addEventListener('click', () => {
+            const startMs = parseTimeInput(startEl.value);
+            const endMs = parseTimeInput(endEl.value);
+            if (Number.isNaN(startMs) || Number.isNaN(endMs)) {
+                errEl.textContent = 'Use format mm:ss or raw seconds.';
+                return;
+            }
+            submit(startMs, endMs);
+        });
+        clearBtn.addEventListener('click', () => submit(null, null));
+        cancelBtn.addEventListener('click', closeOpenRowEditor);
+        // Dismiss on outside click.
+        setTimeout(() => {
+            document.addEventListener('click', function outside(e) {
+                if (!popover.contains(e.target) && e.target !== badgeBtn) {
+                    closeOpenRowEditor();
+                    document.removeEventListener('click', outside);
+                }
+            });
+        }, 0);
+    }
 
     // --- Inline name edit ---
     function bindNameEdit(cell) {
@@ -505,5 +807,5 @@ if (typeof document !== 'undefined' && typeof window !== 'undefined') {
 }
 
 if (typeof module !== 'undefined') {
-    module.exports = { toggleInput, togglePlay };
+    module.exports = { toggleInput, togglePlay, parseTimeInput, formatMs, validateClipMs };
 }

--- a/web/src/main/resources/templates/intros.html
+++ b/web/src/main/resources/templates/intros.html
@@ -72,7 +72,10 @@
                     </tr>
                 </thead>
                 <tbody id="introsTbody">
-                    <tr th:each="intro : ${intros}" th:attr="data-intro-id=${intro.id}">
+                    <tr th:each="intro : ${intros}"
+                        th:attr="data-intro-id=${intro.id},
+                                 data-start-ms=${intro.startMs != null ? intro.startMs : ''},
+                                 data-end-ms=${intro.endMs != null ? intro.endMs : ''}">
                         <td data-label="Slot">
                             <span class="drag-handle" title="Drag to reorder" aria-hidden="true">⋮⋮</span>
                             <span class="slot-index" th:text="${intro.index}">1</span>
@@ -83,6 +86,15 @@
                                   th:style="'background-image:url(' + ${intro.thumbnailUrl} + ')'"
                                   aria-hidden="true"></span>
                             <span class="name-label" th:text="${intro.fileName}">intro.mp3</span>
+                            <button type="button"
+                                    class="clip-badge"
+                                    th:attr="data-edit-clip=true,data-intro-id=${intro.id}"
+                                    th:aria-label="'Edit clip for ' + ${intro.fileName}"
+                                    title="Edit clip timestamps">
+                                <span class="clip-badge-label">⏱</span>
+                                <span class="clip-badge-range"
+                                      th:text="${intro.startMs != null or intro.endMs != null} ? 'clip set' : 'full track'">clip</span>
+                            </button>
                         </td>
                         <td data-label="Volume">
                             <div class="volume-inline">
@@ -179,6 +191,7 @@
                     </p>
                     <span id="urlError" class="field-error" role="alert"></span>
                     <div id="urlPreview" class="url-preview" aria-live="polite"></div>
+                    <div id="urlPreviewIframe" class="url-preview-iframe" aria-hidden="true"></div>
                 </div>
 
                 <!-- File input -->
@@ -220,6 +233,40 @@
                     <p id="volHint" class="hint">Live preview uses this volume. The bot will too.</p>
                 </div>
 
+                <!-- Clip (start/end timestamps) -->
+                <div class="form-group" id="clipSection">
+                    <label id="clipLabel">Clip (optional)</label>
+                    <div class="clip-inputs" role="group" aria-labelledby="clipLabel">
+                        <label for="startTime" class="clip-input-label">Start
+                            <input type="text" id="startTime"
+                                   data-clip-time="start"
+                                   placeholder="0:00"
+                                   pattern="^(?:\d+:)?\d+(?:\.\d+)?$"
+                                   inputmode="numeric"
+                                   autocomplete="off"
+                                   aria-describedby="clipHint clipError">
+                        </label>
+                        <span class="clip-dash" aria-hidden="true">–</span>
+                        <label for="endTime" class="clip-input-label">End
+                            <input type="text" id="endTime"
+                                   data-clip-time="end"
+                                   placeholder="0:00"
+                                   pattern="^(?:\d+:)?\d+(?:\.\d+)?$"
+                                   inputmode="numeric"
+                                   autocomplete="off"
+                                   aria-describedby="clipHint clipError">
+                        </label>
+                        <span class="clip-length" aria-live="polite" data-clip-length>—</span>
+                    </div>
+                    <input type="hidden" id="startMs" name="startMs">
+                    <input type="hidden" id="endMs" name="endMs">
+                    <p id="clipHint" class="hint">
+                        Format <code>mm:ss</code> or raw seconds. Leave blank to play the whole track.
+                        Max clip length: <span th:text="${maxDurationSeconds}">15</span>s.
+                    </p>
+                    <span id="clipError" class="field-error" role="alert"></span>
+                </div>
+
                 <div class="flex-gap-3" style="margin-top: 24px;">
                     <button type="submit" id="submitBtn" class="btn"
                             th:text="${atLimit} ? 'Replace intro' : 'Add intro'">Add intro</button>
@@ -228,6 +275,27 @@
         </div>
     </section>
 </main>
+
+<!-- Hidden template for the row-level clip editor popover -->
+<template id="clipEditorTemplate">
+    <div class="clip-editor-popover" role="dialog" aria-label="Edit clip">
+        <div class="clip-inputs">
+            <label class="clip-input-label">Start
+                <input type="text" data-row-clip="start" placeholder="0:00" inputmode="numeric" autocomplete="off">
+            </label>
+            <span class="clip-dash" aria-hidden="true">–</span>
+            <label class="clip-input-label">End
+                <input type="text" data-row-clip="end" placeholder="0:00" inputmode="numeric" autocomplete="off">
+            </label>
+        </div>
+        <span class="field-error" data-row-clip-error role="alert"></span>
+        <div class="clip-editor-actions">
+            <button type="button" class="btn btn-sm" data-row-clip-save>Save</button>
+            <button type="button" class="btn btn-sm btn-secondary" data-row-clip-clear>Clear clip</button>
+            <button type="button" class="btn btn-sm btn-secondary" data-row-clip-cancel>Cancel</button>
+        </div>
+    </div>
+</template>
 
 <script th:src="@{/js/toasts.js}"></script>
 <script th:src="@{/js/modal.js}"></script>

--- a/web/src/test/js/intros.test.js
+++ b/web/src/test/js/intros.test.js
@@ -1,4 +1,4 @@
-const { toggleInput, togglePlay } = require('../../main/resources/static/js/intros');
+const { toggleInput, togglePlay, parseTimeInput, formatMs, validateClipMs } = require('../../main/resources/static/js/intros');
 
 // ---------------------------------------------------------------------------
 // toggleInput
@@ -157,5 +157,95 @@ describe('togglePlay — stops other audio', () => {
     test('plays the clicked audio after stopping others', () => {
         togglePlay(btn1);
         expect(audio1.play).toHaveBeenCalled();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// parseTimeInput
+// ---------------------------------------------------------------------------
+
+describe('parseTimeInput', () => {
+    test('returns null for blank or nullish input', () => {
+        expect(parseTimeInput('')).toBeNull();
+        expect(parseTimeInput('   ')).toBeNull();
+        expect(parseTimeInput(null)).toBeNull();
+        expect(parseTimeInput(undefined)).toBeNull();
+    });
+
+    test('parses mm:ss format', () => {
+        expect(parseTimeInput('0:00')).toBe(0);
+        expect(parseTimeInput('0:07')).toBe(7000);
+        expect(parseTimeInput('1:30')).toBe(90000);
+        expect(parseTimeInput('0:07.5')).toBe(7500);
+    });
+
+    test('parses raw seconds', () => {
+        expect(parseTimeInput('10')).toBe(10000);
+        expect(parseTimeInput('1.5')).toBe(1500);
+    });
+
+    test('returns NaN for malformed input', () => {
+        expect(Number.isNaN(parseTimeInput('abc'))).toBe(true);
+        expect(Number.isNaN(parseTimeInput('1:2:3'))).toBe(true);
+        expect(Number.isNaN(parseTimeInput('1:60'))).toBe(true); // seconds >= 60
+        expect(Number.isNaN(parseTimeInput('-5'))).toBe(true);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// formatMs
+// ---------------------------------------------------------------------------
+
+describe('formatMs', () => {
+    test('formats integer-second values as m:ss', () => {
+        expect(formatMs(0)).toBe('0:00');
+        expect(formatMs(7000)).toBe('0:07');
+        expect(formatMs(90000)).toBe('1:30');
+    });
+
+    test('formats sub-second values with one decimal', () => {
+        expect(formatMs(7500)).toBe('0:07.5');
+    });
+
+    test('returns empty string for invalid input', () => {
+        expect(formatMs(null)).toBe('');
+        expect(formatMs(-1)).toBe('');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// validateClipMs
+// ---------------------------------------------------------------------------
+
+describe('validateClipMs', () => {
+    const MAX = 15 * 1000;
+
+    test('accepts empty clip when source is short enough', () => {
+        expect(validateClipMs(null, null, 10000, MAX)).toBe('');
+    });
+
+    test('rejects empty clip when source is longer than cap', () => {
+        expect(validateClipMs(null, null, 60000, MAX)).toMatch(/too long/i);
+    });
+
+    test('accepts a tight clip on a long source', () => {
+        expect(validateClipMs(10000, 22000, 120000, MAX)).toBe(''); // 12s
+    });
+
+    test('rejects clip longer than cap', () => {
+        expect(validateClipMs(0, 16000, 60000, MAX)).toMatch(/too long/i);
+    });
+
+    test('rejects end <= start', () => {
+        expect(validateClipMs(5000, 5000, 60000, MAX)).toMatch(/greater than start/i);
+        expect(validateClipMs(5000, 3000, 60000, MAX)).toMatch(/greater than start/i);
+    });
+
+    test('rejects end beyond source duration', () => {
+        expect(validateClipMs(0, 20000, 10000, MAX)).toMatch(/exceeds/i);
+    });
+
+    test('rejects negative start', () => {
+        expect(validateClipMs(-1, 1000, 60000, MAX)).toMatch(/negative/i);
     });
 });


### PR DESCRIPTION
## Summary

- Users can now keep just a short moment from a longer song/video as an intro instead of the source being rejected outright.
- The add/replace form gets optional `Start` / `End` inputs (`mm:ss` or raw seconds) with a live clip-length readout. YouTube URLs render an embedded iframe honouring the selected start/end; uploaded MP3s seek to start on play and auto-pause at end.
- Existing intros in the table get a ⏱ badge that opens a popover editor saving via a new `POST /intro/{guildId}/update-timestamps` JSON endpoint.
- Source videos longer than `MAX_INTRO_DURATION_SECONDS` are now only rejected when no clip is set; the 15s cap applies to the *clip*, not the source.
- Lavaplayer `TrackMarker` stops the track at `endMs`, so only the chosen slice plays when the user joins voice.

### Data model

- New Flyway migration `V9__intro_timestamps.sql` adds `start_ms` and `end_ms` columns to `music_files`.
- `MusicDto` picks up matching nullable fields (not included in `computeHash` so re-editing timestamps on the same blob doesn't collide with itself).
- `DeletedIntroSnapshot` carries the timestamps so delete/undo round-trips them.

### Web

- `IntroWebService.validateClip(startMs, endMs, sourceDurationMs)` is the single source of truth: start < end, clip length ≤ cap, end ≤ source duration when known.
- `setIntroByUrl` / `setIntroByFile` persist the timestamps, and `updateIntroTimestamps` handles inline edits.
- `IntroWebController.setIntro` accepts `startMs` / `endMs` form params and the new JSON endpoint for row-level edits.
- `intros.js` adds pure helpers `parseTimeInput`, `formatMs`, `validateClipMs` (exported for tests) and wires them into submit gating, the YouTube iframe, and the uploaded-audio preview.

### Bot

- `PlayerManager.loadAndPlay` gains an `endPosition` parameter (7-arg back-compat overload preserved for existing callers / MockK stubs).
- `TrackScheduler.queue` sets a `TrackMarker` at `endPosition` to stop the clipped track cleanly, letting the existing end-of-track path restore the previous volume and advance the queue.
- `MusicPlayerHelper.playUserIntro` threads the DTO's `startMs`/`endMs` into `loadAndPlay`.

## Test plan

- [x] `cd web && npm test` — Jest suites green (30/30), including new `parseTimeInput`, `formatMs`, `validateClipMs` cases.
- [ ] `./gradlew :application:test :web:test :discord-bot:test` — gradle wrapper couldn't be fetched from this sandbox; CI will run it.
- [ ] Smoke test end-to-end in a dev stack:
  - Paste a 3-minute YouTube URL, set clip `0:10–0:17`, save; join voice and confirm the intro starts at 10s and cuts off at 17s.
  - Upload an MP3 longer than 15s, set clip `0:02–0:08`, hit play in the preview: confirm it seeks to 2s and pauses at 8s.
  - Edit timestamps from the ⏱ badge on an existing row; confirm the JSON endpoint updates the value.
  - Delete the intro then undo: confirm timestamps come back.
  - Leave start/end blank on a ≤15s source: behavior should be unchanged from today.