### PR TITLE
feat(dnd): encounter library with drag-drop roster setup

### DIFF
--- a/application/src/test/kotlin/web/service/CampaignWebServiceTest.kt
+++ b/application/src/test/kotlin/web/service/CampaignWebServiceTest.kt
@@ -13,6 +13,8 @@ import database.service.CampaignEventService
 import database.service.CampaignPlayerService
 import database.service.CampaignService
 import database.service.CharacterSheetService
+import database.service.EncounterEntryService
+import database.service.EncounterService
 import database.service.MonsterAttackService
 import database.service.MonsterTemplateService
 import database.service.SessionNoteService
@@ -41,6 +43,8 @@ class CampaignWebServiceTest {
     private lateinit var campaignEventService: CampaignEventService
     private lateinit var monsterTemplateService: MonsterTemplateService
     private lateinit var monsterAttackService: MonsterAttackService
+    private lateinit var encounterService: EncounterService
+    private lateinit var encounterEntryService: EncounterEntryService
     private lateinit var initiativeStore: InitiativeStore
     private lateinit var sessionLog: SessionLogPublisher
     private lateinit var jda: JDA
@@ -69,6 +73,8 @@ class CampaignWebServiceTest {
         campaignEventService = mockk(relaxed = true)
         monsterTemplateService = mockk(relaxed = true)
         monsterAttackService = mockk(relaxed = true)
+        encounterService = mockk(relaxed = true)
+        encounterEntryService = mockk(relaxed = true)
         initiativeStore = mockk(relaxed = true)
         sessionLog = mockk(relaxed = true)
         jda = mockk(relaxed = true)
@@ -82,6 +88,8 @@ class CampaignWebServiceTest {
             campaignEventService,
             monsterTemplateService,
             monsterAttackService,
+            encounterService,
+            encounterEntryService,
             initiativeStore,
             sessionLog,
             jda

--- a/database/src/main/kotlin/database/dto/EncounterDto.kt
+++ b/database/src/main/kotlin/database/dto/EncounterDto.kt
@@ -1,0 +1,47 @@
+package database.dto
+
+import jakarta.persistence.*
+import java.io.Serializable
+import java.time.LocalDateTime
+
+@NamedQueries(
+    NamedQuery(
+        name = "EncounterDto.getByDm",
+        query = "select e from EncounterDto e where e.dmDiscordId = :dmDiscordId order by e.name asc"
+    ),
+    NamedQuery(
+        name = "EncounterDto.getById",
+        query = "select e from EncounterDto e where e.id = :id"
+    ),
+    NamedQuery(
+        name = "EncounterDto.deleteById",
+        query = "delete from EncounterDto e where e.id = :id"
+    )
+)
+@Entity
+@Table(name = "dnd_encounter", schema = "public")
+class EncounterDto(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    var id: Long = 0,
+
+    @Column(name = "dm_discord_id", nullable = false)
+    var dmDiscordId: Long = 0,
+
+    @Column(name = "name", nullable = false, length = 100)
+    var name: String = "",
+
+    @Column(name = "notes", length = 500)
+    var notes: String? = null,
+
+    @Column(name = "created_at", nullable = false)
+    var createdAt: LocalDateTime = LocalDateTime.now(),
+
+    @Column(name = "updated_at", nullable = false)
+    var updatedAt: LocalDateTime = LocalDateTime.now()
+) : Serializable {
+
+    override fun toString(): String =
+        "EncounterDto(id=$id, dmDiscordId=$dmDiscordId, name=$name)"
+}

--- a/database/src/main/kotlin/database/dto/EncounterEntryDto.kt
+++ b/database/src/main/kotlin/database/dto/EncounterEntryDto.kt
@@ -1,0 +1,72 @@
+package database.dto
+
+import jakarta.persistence.*
+import java.io.Serializable
+import java.time.LocalDateTime
+
+@NamedQueries(
+    NamedQuery(
+        name = "EncounterEntryDto.listByEncounter",
+        query = "select e from EncounterEntryDto e where e.encounterId = :encounterId order by e.sortOrder asc, e.id asc"
+    ),
+    NamedQuery(
+        name = "EncounterEntryDto.countByEncounter",
+        query = "select count(e) from EncounterEntryDto e where e.encounterId = :encounterId"
+    ),
+    NamedQuery(
+        name = "EncounterEntryDto.maxSortOrder",
+        query = "select coalesce(max(e.sortOrder), -1) from EncounterEntryDto e where e.encounterId = :encounterId"
+    ),
+    NamedQuery(
+        name = "EncounterEntryDto.getById",
+        query = "select e from EncounterEntryDto e where e.id = :id"
+    ),
+    NamedQuery(
+        name = "EncounterEntryDto.deleteById",
+        query = "delete from EncounterEntryDto e where e.id = :id"
+    ),
+    NamedQuery(
+        name = "EncounterEntryDto.deleteByEncounter",
+        query = "delete from EncounterEntryDto e where e.encounterId = :encounterId"
+    )
+)
+@Entity
+@Table(name = "dnd_encounter_entry", schema = "public")
+class EncounterEntryDto(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    var id: Long = 0,
+
+    @Column(name = "encounter_id", nullable = false)
+    var encounterId: Long = 0,
+
+    @Column(name = "sort_order", nullable = false)
+    var sortOrder: Int = 0,
+
+    @Column(name = "monster_template_id")
+    var monsterTemplateId: Long? = null,
+
+    @Column(name = "quantity", nullable = false)
+    var quantity: Int = 1,
+
+    @Column(name = "adhoc_name", length = 100)
+    var adhocName: String? = null,
+
+    @Column(name = "adhoc_initiative_modifier", nullable = false)
+    var adhocInitiativeModifier: Int = 0,
+
+    @Column(name = "adhoc_hp_expression", length = 32)
+    var adhocHpExpression: String? = null,
+
+    @Column(name = "adhoc_ac")
+    var adhocAc: Int? = null,
+
+    @Column(name = "created_at", nullable = false)
+    var createdAt: LocalDateTime = LocalDateTime.now()
+) : Serializable {
+
+    override fun toString(): String =
+        "EncounterEntryDto(id=$id, encounterId=$encounterId, sortOrder=$sortOrder, " +
+            "monsterTemplateId=$monsterTemplateId, quantity=$quantity, adhocName=$adhocName)"
+}

--- a/database/src/main/kotlin/database/persistence/EncounterEntryPersistence.kt
+++ b/database/src/main/kotlin/database/persistence/EncounterEntryPersistence.kt
@@ -1,0 +1,14 @@
+package database.persistence
+
+import database.dto.EncounterEntryDto
+
+interface EncounterEntryPersistence {
+    fun save(entry: EncounterEntryDto): EncounterEntryDto
+    fun saveAll(entries: List<EncounterEntryDto>): List<EncounterEntryDto>
+    fun getById(id: Long): EncounterEntryDto?
+    fun listByEncounter(encounterId: Long): List<EncounterEntryDto>
+    fun countByEncounter(encounterId: Long): Long
+    fun maxSortOrder(encounterId: Long): Int
+    fun deleteById(id: Long)
+    fun deleteByEncounter(encounterId: Long)
+}

--- a/database/src/main/kotlin/database/persistence/EncounterPersistence.kt
+++ b/database/src/main/kotlin/database/persistence/EncounterPersistence.kt
@@ -1,0 +1,10 @@
+package database.persistence
+
+import database.dto.EncounterDto
+
+interface EncounterPersistence {
+    fun save(encounter: EncounterDto): EncounterDto
+    fun getById(id: Long): EncounterDto?
+    fun listByDm(dmDiscordId: Long): List<EncounterDto>
+    fun deleteById(id: Long)
+}

--- a/database/src/main/kotlin/database/persistence/impl/DefaultEncounterEntryPersistence.kt
+++ b/database/src/main/kotlin/database/persistence/impl/DefaultEncounterEntryPersistence.kt
@@ -1,0 +1,80 @@
+package database.persistence.impl
+
+import database.dto.EncounterEntryDto
+import database.persistence.EncounterEntryPersistence
+import jakarta.persistence.EntityManager
+import jakarta.persistence.PersistenceContext
+import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+
+@Repository
+@Transactional
+class DefaultEncounterEntryPersistence : EncounterEntryPersistence {
+
+    @PersistenceContext
+    private lateinit var entityManager: EntityManager
+
+    override fun save(entry: EncounterEntryDto): EncounterEntryDto {
+        return if (entry.id == 0L) {
+            entry.createdAt = LocalDateTime.now()
+            entityManager.persist(entry)
+            entityManager.flush()
+            entry
+        } else {
+            val merged = entityManager.merge(entry)
+            entityManager.flush()
+            merged
+        }
+    }
+
+    override fun saveAll(entries: List<EncounterEntryDto>): List<EncounterEntryDto> {
+        val saved = entries.map { entry ->
+            if (entry.id == 0L) {
+                entry.createdAt = LocalDateTime.now()
+                entityManager.persist(entry)
+                entry
+            } else {
+                entityManager.merge(entry)
+            }
+        }
+        entityManager.flush()
+        return saved
+    }
+
+    override fun getById(id: Long): EncounterEntryDto? {
+        val q = entityManager.createNamedQuery("EncounterEntryDto.getById", EncounterEntryDto::class.java)
+        q.setParameter("id", id)
+        return runCatching { q.singleResult }.getOrNull()
+    }
+
+    override fun listByEncounter(encounterId: Long): List<EncounterEntryDto> {
+        val q = entityManager.createNamedQuery("EncounterEntryDto.listByEncounter", EncounterEntryDto::class.java)
+        q.setParameter("encounterId", encounterId)
+        return q.resultList
+    }
+
+    override fun countByEncounter(encounterId: Long): Long {
+        val q = entityManager.createNamedQuery("EncounterEntryDto.countByEncounter")
+        q.setParameter("encounterId", encounterId)
+        return (q.singleResult as Number).toLong()
+    }
+
+    override fun maxSortOrder(encounterId: Long): Int {
+        val q = entityManager.createNamedQuery("EncounterEntryDto.maxSortOrder")
+        q.setParameter("encounterId", encounterId)
+        return (q.singleResult as Number).toInt()
+    }
+
+    override fun deleteById(id: Long) {
+        val q = entityManager.createNamedQuery("EncounterEntryDto.deleteById")
+        q.setParameter("id", id)
+        q.executeUpdate()
+    }
+
+    override fun deleteByEncounter(encounterId: Long) {
+        val q = entityManager.createNamedQuery("EncounterEntryDto.deleteByEncounter")
+        q.setParameter("encounterId", encounterId)
+        q.executeUpdate()
+    }
+}

--- a/database/src/main/kotlin/database/persistence/impl/DefaultEncounterPersistence.kt
+++ b/database/src/main/kotlin/database/persistence/impl/DefaultEncounterPersistence.kt
@@ -1,0 +1,50 @@
+package database.persistence.impl
+
+import database.dto.EncounterDto
+import database.persistence.EncounterPersistence
+import jakarta.persistence.EntityManager
+import jakarta.persistence.PersistenceContext
+import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+
+@Repository
+@Transactional
+class DefaultEncounterPersistence : EncounterPersistence {
+
+    @PersistenceContext
+    private lateinit var entityManager: EntityManager
+
+    override fun save(encounter: EncounterDto): EncounterDto {
+        val now = LocalDateTime.now()
+        encounter.updatedAt = now
+        return if (encounter.id == 0L) {
+            encounter.createdAt = now
+            entityManager.persist(encounter)
+            entityManager.flush()
+            encounter
+        } else {
+            val merged = entityManager.merge(encounter)
+            entityManager.flush()
+            merged
+        }
+    }
+
+    override fun getById(id: Long): EncounterDto? {
+        val q = entityManager.createNamedQuery("EncounterDto.getById", EncounterDto::class.java)
+        q.setParameter("id", id)
+        return runCatching { q.singleResult }.getOrNull()
+    }
+
+    override fun listByDm(dmDiscordId: Long): List<EncounterDto> {
+        val q = entityManager.createNamedQuery("EncounterDto.getByDm", EncounterDto::class.java)
+        q.setParameter("dmDiscordId", dmDiscordId)
+        return q.resultList
+    }
+
+    override fun deleteById(id: Long) {
+        val q = entityManager.createNamedQuery("EncounterDto.deleteById")
+        q.setParameter("id", id)
+        q.executeUpdate()
+    }
+}

--- a/database/src/main/kotlin/database/service/EncounterEntryService.kt
+++ b/database/src/main/kotlin/database/service/EncounterEntryService.kt
@@ -1,0 +1,14 @@
+package database.service
+
+import database.dto.EncounterEntryDto
+
+interface EncounterEntryService {
+    fun save(entry: EncounterEntryDto): EncounterEntryDto
+    fun saveAll(entries: List<EncounterEntryDto>): List<EncounterEntryDto>
+    fun getById(id: Long): EncounterEntryDto?
+    fun listByEncounter(encounterId: Long): List<EncounterEntryDto>
+    fun countByEncounter(encounterId: Long): Long
+    fun maxSortOrder(encounterId: Long): Int
+    fun deleteById(id: Long)
+    fun deleteByEncounter(encounterId: Long)
+}

--- a/database/src/main/kotlin/database/service/EncounterService.kt
+++ b/database/src/main/kotlin/database/service/EncounterService.kt
@@ -1,0 +1,10 @@
+package database.service
+
+import database.dto.EncounterDto
+
+interface EncounterService {
+    fun save(encounter: EncounterDto): EncounterDto
+    fun getById(id: Long): EncounterDto?
+    fun listByDm(dmDiscordId: Long): List<EncounterDto>
+    fun deleteById(id: Long)
+}

--- a/database/src/main/kotlin/database/service/impl/DefaultEncounterEntryService.kt
+++ b/database/src/main/kotlin/database/service/impl/DefaultEncounterEntryService.kt
@@ -1,0 +1,38 @@
+package database.service.impl
+
+import database.dto.EncounterEntryDto
+import database.persistence.EncounterEntryPersistence
+import database.service.EncounterEntryService
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional
+class DefaultEncounterEntryService(
+    private val encounterEntryPersistence: EncounterEntryPersistence
+) : EncounterEntryService {
+
+    override fun save(entry: EncounterEntryDto): EncounterEntryDto =
+        encounterEntryPersistence.save(entry)
+
+    override fun saveAll(entries: List<EncounterEntryDto>): List<EncounterEntryDto> =
+        encounterEntryPersistence.saveAll(entries)
+
+    override fun getById(id: Long): EncounterEntryDto? =
+        encounterEntryPersistence.getById(id)
+
+    override fun listByEncounter(encounterId: Long): List<EncounterEntryDto> =
+        encounterEntryPersistence.listByEncounter(encounterId)
+
+    override fun countByEncounter(encounterId: Long): Long =
+        encounterEntryPersistence.countByEncounter(encounterId)
+
+    override fun maxSortOrder(encounterId: Long): Int =
+        encounterEntryPersistence.maxSortOrder(encounterId)
+
+    override fun deleteById(id: Long) =
+        encounterEntryPersistence.deleteById(id)
+
+    override fun deleteByEncounter(encounterId: Long) =
+        encounterEntryPersistence.deleteByEncounter(encounterId)
+}

--- a/database/src/main/kotlin/database/service/impl/DefaultEncounterService.kt
+++ b/database/src/main/kotlin/database/service/impl/DefaultEncounterService.kt
@@ -1,0 +1,26 @@
+package database.service.impl
+
+import database.dto.EncounterDto
+import database.persistence.EncounterPersistence
+import database.service.EncounterService
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional
+class DefaultEncounterService(
+    private val encounterPersistence: EncounterPersistence
+) : EncounterService {
+
+    override fun save(encounter: EncounterDto): EncounterDto =
+        encounterPersistence.save(encounter)
+
+    override fun getById(id: Long): EncounterDto? =
+        encounterPersistence.getById(id)
+
+    override fun listByDm(dmDiscordId: Long): List<EncounterDto> =
+        encounterPersistence.listByDm(dmDiscordId)
+
+    override fun deleteById(id: Long) =
+        encounterPersistence.deleteById(id)
+}

--- a/database/src/main/resources/db/migration/V10__dnd_encounter_entry.sql
+++ b/database/src/main/resources/db/migration/V10__dnd_encounter_entry.sql
@@ -1,0 +1,27 @@
+-- Roster rows on an encounter. Exactly one of (monster_template_id) or
+-- (adhoc_name) is populated. For template entries, quantity expands into that
+-- many initiative entries at roll time (e.g. 4 x Goblin). Ad-hoc entries are
+-- single monsters defined inline (quantity is ignored).
+--
+-- monster_template_id is ON DELETE SET NULL so deleting a saved monster
+-- doesn't wipe a pre-built encounter; the web layer renders the orphan row
+-- with a "(missing template)" label and keeps the delete action available.
+--
+-- sort_order drives drag-and-drop reordering via the reorder endpoint.
+CREATE TABLE IF NOT EXISTS dnd_encounter_entry (
+    id BIGSERIAL PRIMARY KEY,
+    encounter_id BIGINT NOT NULL
+        REFERENCES dnd_encounter(id) ON DELETE CASCADE,
+    sort_order INT NOT NULL DEFAULT 0,
+    monster_template_id BIGINT
+        REFERENCES dnd_monster_template(id) ON DELETE SET NULL,
+    quantity INT NOT NULL DEFAULT 1,
+    adhoc_name VARCHAR(100),
+    adhoc_initiative_modifier INT NOT NULL DEFAULT 0,
+    adhoc_hp_expression VARCHAR(32),
+    adhoc_ac INT,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_dnd_encounter_entry_encounter
+    ON dnd_encounter_entry(encounter_id, sort_order);

--- a/database/src/main/resources/db/migration/V9__dnd_encounter.sql
+++ b/database/src/main/resources/db/migration/V9__dnd_encounter.sql
@@ -1,0 +1,14 @@
+-- Saved encounters a DM can set up in advance and load into the initiative
+-- composer (or roll immediately). Scoped to the DM's Discord id, identical in
+-- shape to dnd_monster_template, so one library follows them across guilds.
+CREATE TABLE IF NOT EXISTS dnd_encounter (
+    id BIGSERIAL PRIMARY KEY,
+    dm_discord_id BIGINT NOT NULL,
+    name VARCHAR(100) NOT NULL,
+    notes VARCHAR(500),
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_dnd_encounter_dm
+    ON dnd_encounter(dm_discord_id);

--- a/web/src/main/kotlin/web/controller/CampaignController.kt
+++ b/web/src/main/kotlin/web/controller/CampaignController.kt
@@ -18,8 +18,11 @@ import web.service.AttackResult
 import web.service.CampaignEventBroadcaster
 import web.service.CampaignWebService
 import web.service.DeleteAttackResult
+import web.service.DeleteEncounterEntryResult
+import web.service.DeleteEncounterResult
 import web.service.DeleteNoteResult
 import web.service.DeleteTemplateResult
+import web.service.EncounterView
 import web.service.MonsterAttackResult
 import web.service.EndResult
 import web.service.InitiativeRollRequest
@@ -28,9 +31,13 @@ import web.service.KickResult
 import web.service.LeaveResult
 import web.service.MonsterTemplateView
 import web.service.NarrateResult
+import web.service.ReorderEncounterEntriesResult
 import web.service.RollDiceResult
+import web.service.RollEncounterResult
 import web.service.RollInitiativeResult
 import web.service.SaveAttackResult
+import web.service.SaveEncounterEntryResult
+import web.service.SaveEncounterResult
 import web.service.SaveTemplateResult
 import web.service.SessionEventView
 import web.service.SetAliveResult
@@ -89,6 +96,7 @@ class CampaignController(
         model.addAttribute("recentEvents", campaignDetail?.recentEvents ?: emptyList<Any>())
         model.addAttribute("initiativeState", campaignDetail?.initiativeState)
         model.addAttribute("monsterLibrary", campaignDetail?.monsterLibrary ?: emptyList<Any>())
+        model.addAttribute("encounters", campaignDetail?.encounters ?: emptyList<Any>())
         model.addAttribute("freshEventIds", campaignDetail?.freshEventIds ?: emptyList<Long>())
         model.addAttribute("username", user.displayName())
 
@@ -473,6 +481,235 @@ class CampaignController(
             DeleteAttackResult.ATTACK_TEMPLATE_MISMATCH -> ra.addFlashAttribute(
                 "error",
                 "That attack belongs to a different monster."
+            )
+        }
+        return "redirect:/dnd/campaign/$guildId"
+    }
+
+    // ----------------------------------------------------------------------
+    // Encounter Library endpoints. Form-post + redirect for mutations so the
+    // existing flash-message pattern gives the DM inline feedback; JSON GET
+    // for the list (used by encounters.js when pre-filling the composer)
+    // and a JSON POST for reorder so drag-drop doesn't full-reload the page.
+    // ----------------------------------------------------------------------
+
+    @GetMapping("/encounters")
+    @ResponseBody
+    fun listEncounters(
+        @AuthenticationPrincipal user: OAuth2User
+    ): List<EncounterView> {
+        val discordId = user.discordIdOrNull() ?: return emptyList()
+        return campaignWebService.listEncountersForDm(discordId)
+    }
+
+    @GetMapping("/encounters/{encounterId}")
+    @ResponseBody
+    fun getEncounter(
+        @PathVariable encounterId: Long,
+        @AuthenticationPrincipal user: OAuth2User
+    ): EncounterView? {
+        val discordId = user.discordIdOrNull() ?: return null
+        return campaignWebService.getEncounterForDm(discordId, encounterId)
+    }
+
+    @PostMapping("/campaign/{guildId}/encounters")
+    fun saveEncounter(
+        @PathVariable guildId: Long,
+        @RequestParam(name = "id", required = false) id: Long?,
+        @RequestParam("name") name: String,
+        @RequestParam(name = "notes", required = false) notes: String?,
+        @AuthenticationPrincipal user: OAuth2User,
+        ra: RedirectAttributes
+    ): String {
+        val discordId = user.discordIdOrNull()
+            ?: return "redirect:/dnd/campaign"
+
+        when (campaignWebService.saveEncounter(discordId, id, name, notes)) {
+            SaveEncounterResult.SAVED -> {}
+            SaveEncounterResult.NAME_BLANK -> ra.addFlashAttribute("error", "Encounter name can't be empty.")
+            SaveEncounterResult.NAME_TOO_LONG -> ra.addFlashAttribute(
+                "error",
+                "Encounter name is too long (max ${CampaignWebService.MAX_ENCOUNTER_NAME_LENGTH} characters)."
+            )
+            SaveEncounterResult.NOTES_TOO_LONG -> ra.addFlashAttribute(
+                "error",
+                "Encounter notes are too long (max ${CampaignWebService.MAX_ENCOUNTER_NOTES_LENGTH} characters)."
+            )
+            SaveEncounterResult.NOT_FOUND -> ra.addFlashAttribute("error", "That encounter doesn't exist.")
+            SaveEncounterResult.NOT_OWNER -> ra.addFlashAttribute("error", "You can only edit your own encounters.")
+        }
+        return "redirect:/dnd/campaign/$guildId"
+    }
+
+    @PostMapping("/campaign/{guildId}/encounters/{encounterId}/delete")
+    fun deleteEncounter(
+        @PathVariable guildId: Long,
+        @PathVariable encounterId: Long,
+        @AuthenticationPrincipal user: OAuth2User,
+        ra: RedirectAttributes
+    ): String {
+        val discordId = user.discordIdOrNull()
+            ?: return "redirect:/dnd/campaign"
+
+        when (campaignWebService.deleteEncounter(discordId, encounterId)) {
+            DeleteEncounterResult.DELETED -> {}
+            DeleteEncounterResult.NOT_FOUND -> ra.addFlashAttribute("error", "That encounter doesn't exist.")
+            DeleteEncounterResult.NOT_OWNER -> ra.addFlashAttribute("error", "You can only delete your own encounters.")
+        }
+        return "redirect:/dnd/campaign/$guildId"
+    }
+
+    @PostMapping("/campaign/{guildId}/encounters/{encounterId}/entries")
+    fun saveEncounterEntry(
+        @PathVariable guildId: Long,
+        @PathVariable encounterId: Long,
+        @RequestParam(name = "id", required = false) entryId: Long?,
+        @RequestParam(name = "monsterTemplateId", required = false) monsterTemplateId: Long?,
+        @RequestParam(name = "quantity", defaultValue = "1") quantity: Int,
+        @RequestParam(name = "adhocName", required = false) adhocName: String?,
+        @RequestParam(name = "adhocInitiativeModifier", defaultValue = "0") adhocInitiativeModifier: Int,
+        @RequestParam(name = "adhocHpExpression", required = false) adhocHpExpression: String?,
+        @RequestParam(name = "adhocAc", required = false) adhocAc: Int?,
+        @AuthenticationPrincipal user: OAuth2User,
+        ra: RedirectAttributes
+    ): String {
+        val discordId = user.discordIdOrNull()
+            ?: return "redirect:/dnd/campaign"
+
+        when (campaignWebService.saveEncounterEntry(
+            discordId, encounterId, entryId,
+            monsterTemplateId, quantity,
+            adhocName, adhocInitiativeModifier, adhocHpExpression, adhocAc
+        )) {
+            SaveEncounterEntryResult.SAVED -> {}
+            SaveEncounterEntryResult.ENCOUNTER_NOT_FOUND -> ra.addFlashAttribute(
+                "error", "That encounter doesn't exist."
+            )
+            SaveEncounterEntryResult.NOT_OWNER -> ra.addFlashAttribute(
+                "error", "You can only edit your own encounters."
+            )
+            SaveEncounterEntryResult.TEMPLATE_NOT_FOUND -> ra.addFlashAttribute(
+                "error", "That monster template doesn't exist."
+            )
+            SaveEncounterEntryResult.TEMPLATE_NOT_OWNED -> ra.addFlashAttribute(
+                "error", "You can only use your own monster templates."
+            )
+            SaveEncounterEntryResult.NAME_TOO_LONG -> ra.addFlashAttribute(
+                "error",
+                "Ad-hoc monster name is too long (max ${CampaignWebService.MAX_ENCOUNTER_NAME_LENGTH} characters)."
+            )
+            SaveEncounterEntryResult.INVALID_HP -> ra.addFlashAttribute(
+                "error", "HP must be a number or a dice expression like '3d20+30'."
+            )
+            SaveEncounterEntryResult.INVALID_QUANTITY -> ra.addFlashAttribute(
+                "error",
+                "Quantity must be between 1 and ${CampaignWebService.MAX_QUANTITY_PER_ENTRY}."
+            )
+            SaveEncounterEntryResult.TOO_MANY_ENTRIES -> ra.addFlashAttribute(
+                "error",
+                "This encounter already has the maximum of ${CampaignWebService.MAX_ENTRIES_PER_ENCOUNTER} rows."
+            )
+            SaveEncounterEntryResult.MISSING_SOURCE -> ra.addFlashAttribute(
+                "error", "Pick a monster from the library or fill in an ad-hoc name."
+            )
+            SaveEncounterEntryResult.ENTRY_NOT_FOUND -> ra.addFlashAttribute(
+                "error", "That entry doesn't exist."
+            )
+            SaveEncounterEntryResult.ENTRY_ENCOUNTER_MISMATCH -> ra.addFlashAttribute(
+                "error", "That entry belongs to a different encounter."
+            )
+        }
+        return "redirect:/dnd/campaign/$guildId"
+    }
+
+    @PostMapping("/campaign/{guildId}/encounters/{encounterId}/entries/{entryId}/delete")
+    fun deleteEncounterEntry(
+        @PathVariable guildId: Long,
+        @PathVariable encounterId: Long,
+        @PathVariable entryId: Long,
+        @AuthenticationPrincipal user: OAuth2User,
+        ra: RedirectAttributes
+    ): String {
+        val discordId = user.discordIdOrNull()
+            ?: return "redirect:/dnd/campaign"
+
+        when (campaignWebService.deleteEncounterEntry(discordId, encounterId, entryId)) {
+            DeleteEncounterEntryResult.DELETED -> {}
+            DeleteEncounterEntryResult.ENCOUNTER_NOT_FOUND -> ra.addFlashAttribute(
+                "error", "That encounter doesn't exist."
+            )
+            DeleteEncounterEntryResult.NOT_OWNER -> ra.addFlashAttribute(
+                "error", "You can only edit your own encounters."
+            )
+            DeleteEncounterEntryResult.ENTRY_NOT_FOUND -> ra.addFlashAttribute(
+                "error", "That entry doesn't exist."
+            )
+            DeleteEncounterEntryResult.ENTRY_ENCOUNTER_MISMATCH -> ra.addFlashAttribute(
+                "error", "That entry belongs to a different encounter."
+            )
+        }
+        return "redirect:/dnd/campaign/$guildId"
+    }
+
+    data class ReorderEntriesBody(val orderedIds: List<Long> = emptyList())
+
+    @PostMapping(
+        "/campaign/{guildId}/encounters/{encounterId}/entries/reorder",
+        consumes = ["application/json"]
+    )
+    @ResponseBody
+    fun reorderEncounterEntries(
+        @PathVariable guildId: Long,
+        @PathVariable encounterId: Long,
+        @RequestBody body: ReorderEntriesBody,
+        @AuthenticationPrincipal user: OAuth2User
+    ): Map<String, Any?> {
+        val discordId = user.discordIdOrNull()
+            ?: return mapOf("ok" to false, "error" to "Not authenticated.")
+
+        return when (campaignWebService.reorderEncounterEntries(discordId, encounterId, body.orderedIds)) {
+            ReorderEncounterEntriesResult.REORDERED -> mapOf("ok" to true)
+            ReorderEncounterEntriesResult.ENCOUNTER_NOT_FOUND ->
+                mapOf("ok" to false, "error" to "That encounter doesn't exist.")
+            ReorderEncounterEntriesResult.NOT_OWNER ->
+                mapOf("ok" to false, "error" to "You can only edit your own encounters.")
+            ReorderEncounterEntriesResult.ENTRY_MISMATCH ->
+                mapOf("ok" to false, "error" to "Entry list doesn't match this encounter.")
+        }
+    }
+
+    @PostMapping("/campaign/{guildId}/encounters/{encounterId}/roll")
+    fun rollEncounter(
+        @PathVariable guildId: Long,
+        @PathVariable encounterId: Long,
+        @RequestParam(name = "playerDiscordIds", required = false) playerDiscordIds: List<Long>?,
+        @AuthenticationPrincipal user: OAuth2User,
+        ra: RedirectAttributes
+    ): String {
+        val discordId = user.discordIdOrNull()
+            ?: return "redirect:/dnd/campaign"
+
+        when (campaignWebService.rollEncounter(
+            guildId, discordId, encounterId, playerDiscordIds.orEmpty()
+        )) {
+            RollEncounterResult.ROLLED -> {}
+            RollEncounterResult.ENCOUNTER_NOT_FOUND -> ra.addFlashAttribute(
+                "error", "That encounter doesn't exist."
+            )
+            RollEncounterResult.NOT_OWNER -> ra.addFlashAttribute(
+                "error", "You can only roll your own encounters."
+            )
+            RollEncounterResult.NO_ACTIVE_CAMPAIGN -> ra.addFlashAttribute(
+                "error", "No active campaign in this server."
+            )
+            RollEncounterResult.NOT_DM -> ra.addFlashAttribute(
+                "error", "Only the Dungeon Master can roll an encounter."
+            )
+            RollEncounterResult.EMPTY_ROSTER -> ra.addFlashAttribute(
+                "error", "This encounter has no monsters yet."
+            )
+            RollEncounterResult.TEMPLATE_NOT_FOUND -> ra.addFlashAttribute(
+                "error", "One of the encounter's monster templates couldn't be found."
             )
         }
         return "redirect:/dnd/campaign/$guildId"

--- a/web/src/main/kotlin/web/service/CampaignWebService.kt
+++ b/web/src/main/kotlin/web/service/CampaignWebService.kt
@@ -10,6 +10,8 @@ import database.dto.CampaignDto
 import database.dto.CampaignEventDto
 import database.dto.CampaignPlayerDto
 import database.dto.CampaignPlayerId
+import database.dto.EncounterDto
+import database.dto.EncounterEntryDto
 import database.dto.MonsterTemplateDto
 import database.dto.SessionNoteDto
 import database.dto.UserDto
@@ -18,6 +20,8 @@ import database.service.CampaignPlayerService
 import database.service.CampaignService
 import database.service.CharacterSheetService
 import database.dto.MonsterAttackDto
+import database.service.EncounterEntryService
+import database.service.EncounterService
 import database.service.MonsterAttackService
 import database.service.MonsterTemplateService
 import database.service.SessionNoteService
@@ -37,6 +41,7 @@ data class CampaignDetail(
     val recentEvents: List<SessionEventView> = emptyList(),
     val initiativeState: InitiativeStateView? = null,
     val monsterLibrary: List<MonsterTemplateView> = emptyList(),
+    val encounters: List<EncounterView> = emptyList(),
     val freshEventIds: List<Long> = emptyList()
 ) {
     fun isDm(discordId: Long): Boolean = campaign.dmDiscordId == discordId
@@ -74,6 +79,35 @@ data class MonsterTemplateView(
     val ac: Int?,
     val attacks: List<MonsterAttackView> = emptyList()
 )
+
+data class EncounterEntryView(
+    val id: Long,
+    val sortOrder: Int,
+    val quantity: Int,
+    val monsterTemplate: MonsterTemplateView?,
+    val adhocName: String?,
+    val adhocInitiativeModifier: Int,
+    val adhocHpExpression: String?,
+    val adhocAc: Int?
+) {
+    val displayName: String
+        get() = monsterTemplate?.name
+            ?: adhocName?.takeIf { it.isNotBlank() }
+            ?: "(missing)"
+
+    val effectiveQuantity: Int
+        get() = if (monsterTemplate != null) quantity else 1
+}
+
+data class EncounterView(
+    val id: Long,
+    val name: String,
+    val notes: String?,
+    val entries: List<EncounterEntryView> = emptyList()
+) {
+    val totalRosterSize: Int
+        get() = entries.sumOf { it.effectiveQuantity }
+}
 
 data class AdhocMonster(
     val name: String,
@@ -148,6 +182,26 @@ enum class SaveAttackResult {
     TOO_MANY, TEMPLATE_NOT_FOUND, NOT_OWNER, ATTACK_NOT_FOUND, ATTACK_TEMPLATE_MISMATCH
 }
 enum class DeleteAttackResult { DELETED, ATTACK_NOT_FOUND, NOT_OWNER, ATTACK_TEMPLATE_MISMATCH }
+enum class SaveEncounterResult { SAVED, NAME_BLANK, NAME_TOO_LONG, NOTES_TOO_LONG, NOT_FOUND, NOT_OWNER }
+enum class DeleteEncounterResult { DELETED, NOT_FOUND, NOT_OWNER }
+enum class SaveEncounterEntryResult {
+    SAVED,
+    ENCOUNTER_NOT_FOUND, NOT_OWNER,
+    TEMPLATE_NOT_FOUND, TEMPLATE_NOT_OWNED,
+    NAME_TOO_LONG, INVALID_HP, INVALID_QUANTITY,
+    TOO_MANY_ENTRIES, MISSING_SOURCE,
+    ENTRY_NOT_FOUND, ENTRY_ENCOUNTER_MISMATCH
+}
+enum class DeleteEncounterEntryResult {
+    DELETED, ENCOUNTER_NOT_FOUND, NOT_OWNER, ENTRY_NOT_FOUND, ENTRY_ENCOUNTER_MISMATCH
+}
+enum class ReorderEncounterEntriesResult {
+    REORDERED, ENCOUNTER_NOT_FOUND, NOT_OWNER, ENTRY_MISMATCH
+}
+enum class RollEncounterResult {
+    ROLLED, ENCOUNTER_NOT_FOUND, NOT_OWNER,
+    NO_ACTIVE_CAMPAIGN, NOT_DM, EMPTY_ROSTER, TEMPLATE_NOT_FOUND
+}
 enum class MonsterAttackResult {
     HIT, MISS,
     NO_ACTIVE_CAMPAIGN, NO_ACTIVE_COMBAT, NOT_DM,
@@ -205,6 +259,8 @@ class CampaignWebService(
     private val campaignEventService: CampaignEventService,
     private val monsterTemplateService: MonsterTemplateService,
     private val monsterAttackService: MonsterAttackService,
+    private val encounterService: EncounterService,
+    private val encounterEntryService: EncounterEntryService,
     private val initiativeStore: InitiativeStore,
     private val sessionLog: SessionLogPublisher,
     private val jda: JDA
@@ -224,6 +280,10 @@ class CampaignWebService(
         const val MAX_ATTACK_NAME_LENGTH = 60
         const val MAX_ATTACKS_PER_TEMPLATE = 12
         const val MAX_ATTACK_MODIFIER = 30
+        const val MAX_ENCOUNTER_NAME_LENGTH = 100
+        const val MAX_ENCOUNTER_NOTES_LENGTH = 500
+        const val MAX_ENTRIES_PER_ENCOUNTER = 40
+        const val MAX_QUANTITY_PER_ENTRY = 20
         const val MAX_DICE_COUNT = DiceExpressionRoller.MAX_DICE_COUNT
         const val MAX_DICE_MODIFIER = DiceExpressionRoller.MAX_DICE_MODIFIER
         const val MAX_DAMAGE_AMOUNT = DiceExpressionRoller.MAX_LITERAL_AMOUNT
@@ -325,6 +385,15 @@ class CampaignWebService(
             }
         } else emptyList()
 
+        val encounters = if (isDm) {
+            safeFetch("encounters", requestingDiscordId) {
+                val templatesById = monsterLibrary.associateBy { it.id }
+                encounterService.listByDm(requestingDiscordId).map { dto ->
+                    toEncounterView(dto, templatesById)
+                }
+            }
+        } else emptyList()
+
         // Events published in the last few seconds are likely the action the user
         // just submitted. Their own POST→redirect cycle means the new EventSource
         // connects after the publish, so SSE won't replay the event and the
@@ -343,6 +412,7 @@ class CampaignWebService(
             recentEvents = recentEvents,
             initiativeState = initiativeState,
             monsterLibrary = monsterLibrary,
+            encounters = encounters,
             freshEventIds = freshEventIds
         )
     }
@@ -375,6 +445,36 @@ class CampaignWebService(
             name = dto.name,
             toHitModifier = dto.toHitModifier,
             damageExpression = dto.damageExpression
+        )
+
+    private fun toEncounterView(
+        dto: EncounterDto,
+        templatesById: Map<Long, MonsterTemplateView>
+    ): EncounterView {
+        val entries = encounterEntryService.listByEncounter(dto.id).map { entry ->
+            toEncounterEntryView(entry, templatesById)
+        }
+        return EncounterView(
+            id = dto.id,
+            name = dto.name,
+            notes = dto.notes,
+            entries = entries
+        )
+    }
+
+    private fun toEncounterEntryView(
+        dto: EncounterEntryDto,
+        templatesById: Map<Long, MonsterTemplateView>
+    ): EncounterEntryView =
+        EncounterEntryView(
+            id = dto.id,
+            sortOrder = dto.sortOrder,
+            quantity = dto.quantity,
+            monsterTemplate = dto.monsterTemplateId?.let { templatesById[it] },
+            adhocName = dto.adhocName,
+            adhocInitiativeModifier = dto.adhocInitiativeModifier,
+            adhocHpExpression = dto.adhocHpExpression,
+            adhocAc = dto.adhocAc
         )
 
     fun listRecentEvents(guildId: Long, sinceId: Long?, limit: Int): List<SessionEventView> {
@@ -794,6 +894,257 @@ class CampaignWebService(
         if (template.dmDiscordId != dmDiscordId) return DeleteAttackResult.NOT_OWNER
         monsterAttackService.deleteById(attackId)
         return DeleteAttackResult.DELETED
+    }
+
+    // ----------------------------------------------------------------------
+    // Encounter Library: DM-scoped reusable encounter drafts. Each encounter
+    // owns an ordered list of roster entries that either reference a monster
+    // template (with a quantity, expanded at roll time) or define an ad-hoc
+    // monster inline. The DM can load a saved encounter into the initiative
+    // composer for final tweaks, or roll it directly from the card.
+    // ----------------------------------------------------------------------
+
+    fun listEncountersForDm(dmDiscordId: Long): List<EncounterView> {
+        val templatesById = monsterTemplateService.listByDm(dmDiscordId)
+            .map(::toMonsterTemplateView)
+            .associateBy { it.id }
+        return encounterService.listByDm(dmDiscordId).map { toEncounterView(it, templatesById) }
+    }
+
+    fun getEncounterForDm(dmDiscordId: Long, encounterId: Long): EncounterView? {
+        val encounter = encounterService.getById(encounterId) ?: return null
+        if (encounter.dmDiscordId != dmDiscordId) return null
+        val templatesById = monsterTemplateService.listByDm(dmDiscordId)
+            .map(::toMonsterTemplateView)
+            .associateBy { it.id }
+        return toEncounterView(encounter, templatesById)
+    }
+
+    fun saveEncounter(
+        dmDiscordId: Long,
+        id: Long?,
+        name: String,
+        notes: String?
+    ): SaveEncounterResult {
+        val trimmed = name.trim()
+        if (trimmed.isEmpty()) return SaveEncounterResult.NAME_BLANK
+        if (trimmed.length > MAX_ENCOUNTER_NAME_LENGTH) return SaveEncounterResult.NAME_TOO_LONG
+
+        val cleanedNotes = notes?.trim()?.takeIf { it.isNotEmpty() }
+        if (cleanedNotes != null && cleanedNotes.length > MAX_ENCOUNTER_NOTES_LENGTH) {
+            return SaveEncounterResult.NOTES_TOO_LONG
+        }
+
+        val dto = if (id != null && id > 0) {
+            val existing = encounterService.getById(id) ?: return SaveEncounterResult.NOT_FOUND
+            if (existing.dmDiscordId != dmDiscordId) return SaveEncounterResult.NOT_OWNER
+            existing.apply {
+                this.name = trimmed
+                this.notes = cleanedNotes
+            }
+        } else {
+            EncounterDto(
+                dmDiscordId = dmDiscordId,
+                name = trimmed,
+                notes = cleanedNotes
+            )
+        }
+        encounterService.save(dto)
+        return SaveEncounterResult.SAVED
+    }
+
+    fun deleteEncounter(dmDiscordId: Long, encounterId: Long): DeleteEncounterResult {
+        val existing = encounterService.getById(encounterId) ?: return DeleteEncounterResult.NOT_FOUND
+        if (existing.dmDiscordId != dmDiscordId) return DeleteEncounterResult.NOT_OWNER
+        encounterService.deleteById(encounterId)
+        return DeleteEncounterResult.DELETED
+    }
+
+    /**
+     * Create or update a roster entry on an encounter. Exactly one of
+     * [monsterTemplateId] or [adhocName] must resolve to a usable source.
+     * Template entries honor [quantity]; ad-hoc entries are always size one.
+     * On insert, the new row appends to the end of the current ordering.
+     */
+    fun saveEncounterEntry(
+        dmDiscordId: Long,
+        encounterId: Long,
+        entryId: Long?,
+        monsterTemplateId: Long?,
+        quantity: Int,
+        adhocName: String?,
+        adhocInitiativeModifier: Int,
+        adhocHpExpression: String?,
+        adhocAc: Int?
+    ): SaveEncounterEntryResult {
+        val encounter = encounterService.getById(encounterId)
+            ?: return SaveEncounterEntryResult.ENCOUNTER_NOT_FOUND
+        if (encounter.dmDiscordId != dmDiscordId) return SaveEncounterEntryResult.NOT_OWNER
+
+        val cleanedAdhocName = adhocName?.trim()?.takeIf { it.isNotEmpty() }
+        val usesTemplate = monsterTemplateId != null
+        val usesAdhoc = cleanedAdhocName != null
+
+        if (!usesTemplate && !usesAdhoc) return SaveEncounterEntryResult.MISSING_SOURCE
+
+        if (usesTemplate) {
+            val template = monsterTemplateService.getById(monsterTemplateId!!)
+                ?: return SaveEncounterEntryResult.TEMPLATE_NOT_FOUND
+            if (template.dmDiscordId != dmDiscordId) return SaveEncounterEntryResult.TEMPLATE_NOT_OWNED
+            if (quantity < 1 || quantity > MAX_QUANTITY_PER_ENTRY) {
+                return SaveEncounterEntryResult.INVALID_QUANTITY
+            }
+        }
+
+        if (usesAdhoc) {
+            if (cleanedAdhocName!!.length > MAX_ENCOUNTER_NAME_LENGTH) {
+                return SaveEncounterEntryResult.NAME_TOO_LONG
+            }
+            val hp = adhocHpExpression?.trim()?.takeIf { it.isNotEmpty() }
+            if (hp != null && DiceExpressionRoller.parseAmount(hp) == null) {
+                return SaveEncounterEntryResult.INVALID_HP
+            }
+        }
+
+        val cleanedAdhocHp = adhocHpExpression?.trim()?.takeIf { it.isNotEmpty() }
+
+        val dto = if (entryId != null && entryId > 0) {
+            val existing = encounterEntryService.getById(entryId)
+                ?: return SaveEncounterEntryResult.ENTRY_NOT_FOUND
+            if (existing.encounterId != encounterId) {
+                return SaveEncounterEntryResult.ENTRY_ENCOUNTER_MISMATCH
+            }
+            existing.apply {
+                this.monsterTemplateId = if (usesTemplate) monsterTemplateId else null
+                this.quantity = if (usesTemplate) quantity else 1
+                this.adhocName = if (usesAdhoc) cleanedAdhocName else null
+                this.adhocInitiativeModifier = if (usesAdhoc) adhocInitiativeModifier else 0
+                this.adhocHpExpression = if (usesAdhoc) cleanedAdhocHp else null
+                this.adhocAc = if (usesAdhoc) adhocAc else null
+            }
+        } else {
+            if (encounterEntryService.countByEncounter(encounterId) >= MAX_ENTRIES_PER_ENCOUNTER) {
+                return SaveEncounterEntryResult.TOO_MANY_ENTRIES
+            }
+            val nextSortOrder = encounterEntryService.maxSortOrder(encounterId) + 1
+            EncounterEntryDto(
+                encounterId = encounterId,
+                sortOrder = nextSortOrder,
+                monsterTemplateId = if (usesTemplate) monsterTemplateId else null,
+                quantity = if (usesTemplate) quantity else 1,
+                adhocName = if (usesAdhoc) cleanedAdhocName else null,
+                adhocInitiativeModifier = if (usesAdhoc) adhocInitiativeModifier else 0,
+                adhocHpExpression = if (usesAdhoc) cleanedAdhocHp else null,
+                adhocAc = if (usesAdhoc) adhocAc else null
+            )
+        }
+        encounterEntryService.save(dto)
+        return SaveEncounterEntryResult.SAVED
+    }
+
+    fun deleteEncounterEntry(
+        dmDiscordId: Long,
+        encounterId: Long,
+        entryId: Long
+    ): DeleteEncounterEntryResult {
+        val encounter = encounterService.getById(encounterId)
+            ?: return DeleteEncounterEntryResult.ENCOUNTER_NOT_FOUND
+        if (encounter.dmDiscordId != dmDiscordId) return DeleteEncounterEntryResult.NOT_OWNER
+        val entry = encounterEntryService.getById(entryId)
+            ?: return DeleteEncounterEntryResult.ENTRY_NOT_FOUND
+        if (entry.encounterId != encounterId) {
+            return DeleteEncounterEntryResult.ENTRY_ENCOUNTER_MISMATCH
+        }
+        encounterEntryService.deleteById(entryId)
+        return DeleteEncounterEntryResult.DELETED
+    }
+
+    /**
+     * Rewrites the [sortOrder] of each entry to match the provided id list.
+     * Fails atomically if any id in [orderedIds] doesn't belong to the
+     * encounter, or if the set of ids doesn't match the encounter's entries
+     * (prevents partial reorderings leaving unlisted entries out-of-place).
+     */
+    fun reorderEncounterEntries(
+        dmDiscordId: Long,
+        encounterId: Long,
+        orderedIds: List<Long>
+    ): ReorderEncounterEntriesResult {
+        val encounter = encounterService.getById(encounterId)
+            ?: return ReorderEncounterEntriesResult.ENCOUNTER_NOT_FOUND
+        if (encounter.dmDiscordId != dmDiscordId) return ReorderEncounterEntriesResult.NOT_OWNER
+
+        val existing = encounterEntryService.listByEncounter(encounterId)
+        if (existing.size != orderedIds.size) return ReorderEncounterEntriesResult.ENTRY_MISMATCH
+        val existingIds = existing.map { it.id }.toSet()
+        if (orderedIds.toSet() != existingIds) return ReorderEncounterEntriesResult.ENTRY_MISMATCH
+
+        val byId = existing.associateBy { it.id }
+        val updated = orderedIds.mapIndexed { index, id ->
+            byId.getValue(id).apply { sortOrder = index }
+        }
+        encounterEntryService.saveAll(updated)
+        return ReorderEncounterEntriesResult.REORDERED
+    }
+
+    /**
+     * Expand an encounter's roster into an [InitiativeRollRequest] and
+     * delegate to [rollInitiative], which handles dice rolls, event publish,
+     * and seeding the [InitiativeStore]. Orphaned template references
+     * (monsterTemplateId pointing at a deleted template) are skipped so
+     * rolling still works even after a cleanup.
+     */
+    fun rollEncounter(
+        guildId: Long,
+        requestingDiscordId: Long,
+        encounterId: Long,
+        playerDiscordIds: List<Long> = emptyList()
+    ): RollEncounterResult {
+        val campaign = campaignService.getActiveCampaignForGuild(guildId)
+            ?: return RollEncounterResult.NO_ACTIVE_CAMPAIGN
+        if (campaign.dmDiscordId != requestingDiscordId) return RollEncounterResult.NOT_DM
+
+        val encounter = encounterService.getById(encounterId)
+            ?: return RollEncounterResult.ENCOUNTER_NOT_FOUND
+        if (encounter.dmDiscordId != requestingDiscordId) return RollEncounterResult.NOT_OWNER
+
+        val entries = encounterEntryService.listByEncounter(encounterId)
+        val templateIds = mutableListOf<Long>()
+        val adhocMonsters = mutableListOf<AdhocMonster>()
+
+        entries.forEach { entry ->
+            val templateId = entry.monsterTemplateId
+            if (templateId != null) {
+                val template = monsterTemplateService.getById(templateId) ?: return@forEach
+                if (template.dmDiscordId != requestingDiscordId) return@forEach
+                repeat(entry.quantity.coerceAtLeast(1)) { templateIds += templateId }
+            } else if (!entry.adhocName.isNullOrBlank()) {
+                adhocMonsters += AdhocMonster(
+                    name = entry.adhocName!!,
+                    initiativeModifier = entry.adhocInitiativeModifier,
+                    hpExpression = entry.adhocHpExpression,
+                    ac = entry.adhocAc
+                )
+            }
+        }
+
+        if (templateIds.isEmpty() && adhocMonsters.isEmpty() && playerDiscordIds.isEmpty()) {
+            return RollEncounterResult.EMPTY_ROSTER
+        }
+
+        val request = InitiativeRollRequest(
+            playerDiscordIds = playerDiscordIds,
+            templateIds = templateIds,
+            adhocMonsters = adhocMonsters
+        )
+
+        return when (rollInitiative(guildId, requestingDiscordId, request)) {
+            RollInitiativeResult.ROLLED -> RollEncounterResult.ROLLED
+            RollInitiativeResult.NO_ACTIVE_CAMPAIGN -> RollEncounterResult.NO_ACTIVE_CAMPAIGN
+            RollInitiativeResult.NOT_DM -> RollEncounterResult.NOT_DM
+            RollInitiativeResult.EMPTY_ROSTER -> RollEncounterResult.EMPTY_ROSTER
+            RollInitiativeResult.TEMPLATE_NOT_FOUND -> RollEncounterResult.TEMPLATE_NOT_FOUND
+        }
     }
 
     /**

--- a/web/src/main/resources/static/js/encounters.js
+++ b/web/src/main/resources/static/js/encounters.js
@@ -1,0 +1,264 @@
+// Encounter Library behaviors on the campaign detail page:
+//   1. Drag-and-drop (native HTML5) reordering of entry rows per encounter,
+//      persisted via a JSON POST to /entries/reorder.
+//   2. Alt+ArrowUp / Alt+ArrowDown on the drag handle as a keyboard
+//      accessible equivalent.
+//   3. The add-entry form toggles between "from library" and "ad-hoc"
+//      input groups without full-page round-trips.
+//   4. Both the per-card "Load into composer" button and the composer's
+//      "Load encounter" select fetch the encounter JSON and populate the
+//      initiative composer inputs so the DM can tweak before rolling.
+//
+// Mirrors the drag-drop + apiPostJson pattern from intros.js.
+
+function initEncounterLibrary() {
+    const root = document.querySelector('.encounter-library');
+    const composer = document.getElementById('initiative-composer-form');
+    if (!root && !composer) return;
+
+    const guildIdAttr =
+        document.body.dataset.guildId ||
+        document.querySelector('[data-guild-id]')?.dataset.guildId;
+    const guildId = guildIdAttr || inferGuildIdFromUrl();
+
+    const csrfToken =
+        document.querySelector('meta[name="_csrf"]')?.content || '';
+    const csrfHeader =
+        document.querySelector('meta[name="_csrf_header"]')?.content ||
+        'X-CSRF-TOKEN';
+
+    if (root) {
+        bindAddEntryMode(root);
+        bindDragReorder(root, guildId, csrfToken, csrfHeader);
+        bindLoadButtons(root);
+    }
+    if (composer) {
+        bindEncounterLoaderSelect(composer);
+    }
+
+    // --- Add-entry form: toggle library vs ad-hoc inputs ----------------
+    function bindAddEntryMode(scope) {
+        scope.querySelectorAll('.add-entry-form').forEach(form => {
+            const mode = form.querySelectorAll('input[name="__mode"]');
+            const libraryInputs = [
+                form.querySelector('select[name="monsterTemplateId"]'),
+                form.querySelector('input[name="quantity"]')
+            ];
+            const adhocInputs = form.querySelectorAll('.entry-adhoc-input');
+            const apply = () => {
+                const value = form.querySelector('input[name="__mode"]:checked')?.value || 'template';
+                const isTemplate = value === 'template';
+                libraryInputs.forEach(i => { if (i) i.style.display = isTemplate ? '' : 'none'; });
+                adhocInputs.forEach(i => { i.style.display = isTemplate ? 'none' : ''; });
+                // Required flips with mode so browser validation matches the visible state.
+                const select = form.querySelector('select[name="monsterTemplateId"]');
+                if (select) select.required = isTemplate;
+                const adhocName = form.querySelector('input[name="adhocName"]');
+                if (adhocName) adhocName.required = !isTemplate;
+            };
+            mode.forEach(r => r.addEventListener('change', apply));
+            apply();
+        });
+    }
+
+    // --- Drag-and-drop reorder per encounter tbody ----------------------
+    function bindDragReorder(scope, guildId, csrfToken, csrfHeader) {
+        scope.querySelectorAll('tbody.encounter-entry-tbody').forEach(tbody => {
+            const encounterId = tbody.dataset.encounterId;
+            let dragged = null;
+
+            const rows = tbody.querySelectorAll('tr.encounter-entry-row');
+            rows.forEach(row => {
+                row.addEventListener('dragstart', e => {
+                    dragged = row;
+                    row.classList.add('dragging');
+                    e.dataTransfer.effectAllowed = 'move';
+                    e.dataTransfer.setData('text/plain', row.dataset.entryId || '');
+                });
+                row.addEventListener('dragend', () => {
+                    row.classList.remove('dragging');
+                    tbody.querySelectorAll('tr').forEach(r => r.classList.remove('drag-over'));
+                    dragged = null;
+                });
+                row.addEventListener('dragover', e => {
+                    e.preventDefault();
+                    if (dragged && dragged !== row) row.classList.add('drag-over');
+                });
+                row.addEventListener('dragleave', () => row.classList.remove('drag-over'));
+                row.addEventListener('drop', e => {
+                    e.preventDefault();
+                    row.classList.remove('drag-over');
+                    if (!dragged || dragged === row) return;
+                    const rect = row.getBoundingClientRect();
+                    const before = (e.clientY - rect.top) < rect.height / 2;
+                    tbody.insertBefore(dragged, before ? row : row.nextSibling);
+                    saveOrder(tbody, encounterId);
+                });
+
+                // Keyboard-accessible reorder via the drag handle.
+                const handle = row.querySelector('.drag-handle');
+                if (handle) {
+                    handle.addEventListener('keydown', e => {
+                        if (!e.altKey) return;
+                        if (e.key === 'ArrowUp' && row.previousElementSibling) {
+                            tbody.insertBefore(row, row.previousElementSibling);
+                            saveOrder(tbody, encounterId);
+                            handle.focus();
+                            e.preventDefault();
+                        } else if (e.key === 'ArrowDown' && row.nextElementSibling) {
+                            tbody.insertBefore(row.nextElementSibling, row);
+                            saveOrder(tbody, encounterId);
+                            handle.focus();
+                            e.preventDefault();
+                        }
+                    });
+                }
+            });
+        });
+
+        function saveOrder(tbody, encounterId) {
+            const orderedIds = Array.from(tbody.querySelectorAll('tr.encounter-entry-row'))
+                .map(r => Number(r.dataset.entryId))
+                .filter(Number.isFinite);
+            const url = `/dnd/campaign/${guildId}/encounters/${encounterId}/entries/reorder`;
+            apiPostJson(url, { orderedIds: orderedIds })
+                .then(r => {
+                    if (r && r.ok) {
+                        toast('Order saved.', 'success', 1800);
+                    } else {
+                        const msg = (r && r.error) || 'Reorder failed. Reloading.';
+                        toast(msg, 'error');
+                        setTimeout(() => location.reload(), 800);
+                    }
+                })
+                .catch(() => {
+                    toast('Network error. Reloading.', 'error');
+                    setTimeout(() => location.reload(), 800);
+                });
+        }
+    }
+
+    // --- Load-into-composer buttons on each encounter card --------------
+    function bindLoadButtons(scope) {
+        scope.querySelectorAll('.btn-load-encounter').forEach(btn => {
+            btn.addEventListener('click', () => {
+                const id = btn.dataset.encounterId;
+                if (id) loadEncounter(id);
+            });
+        });
+    }
+
+    // --- Composer "Load encounter" select -------------------------------
+    function bindEncounterLoaderSelect(composer) {
+        const select = document.getElementById('encounterLoader');
+        if (!select) return;
+        select.addEventListener('change', e => {
+            const value = e.target.value;
+            if (value) loadEncounter(value);
+        });
+    }
+
+    // --- Populate composer from an encounter id -------------------------
+    function loadEncounter(encounterId) {
+        fetch(`/dnd/encounters/${encounterId}`, { credentials: 'same-origin' })
+            .then(r => r.ok ? r.json() : null)
+            .then(enc => {
+                if (!enc) {
+                    toast('Could not load that encounter.', 'error');
+                    return;
+                }
+                populateComposer(enc);
+                toast(`Loaded "${enc.name}".`, 'success', 2200);
+                composer?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            })
+            .catch(() => toast('Network error loading encounter.', 'error'));
+    }
+
+    function populateComposer(enc) {
+        if (!composer) return;
+
+        // Zero out all template quantities so we start from a clean slate.
+        composer.querySelectorAll('input[name="templateQty"]').forEach(i => { i.value = '0'; });
+
+        // Collect current ad-hoc rows — we'll clear and rewrite their values.
+        const adhocRows = composer.querySelectorAll('.adhoc-rows .row');
+        adhocRows.forEach(row => {
+            const nameInput = row.querySelector('input[name="adhocName"]');
+            const modInput = row.querySelector('input[name="adhocMod"]');
+            const hpInput = row.querySelector('input[name="adhocHpExpr"]');
+            const acInput = row.querySelector('input[name="adhocAc"]');
+            if (nameInput) nameInput.value = '';
+            if (modInput) modInput.value = '0';
+            if (hpInput) hpInput.value = '';
+            if (acInput) acInput.value = '';
+        });
+
+        const templateRows = composer.querySelectorAll('.template-picker .picker-row');
+        const templateRowsById = {};
+        templateRows.forEach(row => {
+            const idInput = row.querySelector('input[name="templateId"]');
+            if (idInput) templateRowsById[idInput.value] = row;
+        });
+
+        let adhocIndex = 0;
+        (enc.entries || []).forEach(entry => {
+            if (entry.monsterTemplate && entry.monsterTemplate.id != null) {
+                const row = templateRowsById[String(entry.monsterTemplate.id)];
+                if (row) {
+                    const qtyInput = row.querySelector('input[name="templateQty"]');
+                    if (qtyInput) qtyInput.value = String(entry.quantity || 1);
+                }
+            } else if (entry.adhocName) {
+                const row = adhocRows[adhocIndex];
+                if (row) {
+                    row.querySelector('input[name="adhocName"]').value = entry.adhocName;
+                    row.querySelector('input[name="adhocMod"]').value =
+                        String(entry.adhocInitiativeModifier || 0);
+                    if (entry.adhocHpExpression) {
+                        row.querySelector('input[name="adhocHpExpr"]').value = entry.adhocHpExpression;
+                    }
+                    if (entry.adhocAc != null) {
+                        row.querySelector('input[name="adhocAc"]').value = String(entry.adhocAc);
+                    }
+                    adhocIndex += 1;
+                }
+                // If the encounter has more ad-hoc entries than the composer
+                // has rows, the extras are silently dropped. The DM can re-add
+                // them manually; keeping the composer schema fixed avoids
+                // ballooning the page with arbitrary row counts.
+            }
+        });
+    }
+
+    // --- Helpers -------------------------------------------------------
+
+    function apiPostJson(url, body) {
+        const headers = { 'Content-Type': 'application/json', 'Accept': 'application/json' };
+        if (csrfToken) headers[csrfHeader] = csrfToken;
+        return fetch(url, {
+            method: 'POST',
+            credentials: 'same-origin',
+            headers: headers,
+            body: JSON.stringify(body)
+        }).then(r => r.json().catch(() => ({ ok: r.ok, error: r.ok ? null : 'Request failed.' })));
+    }
+
+    function toast(message, type, duration) {
+        if (window.TobyToast && typeof window.TobyToast.show === 'function') {
+            window.TobyToast.show(message, { type: type || 'info', duration: duration || 3000 });
+        }
+    }
+
+    function inferGuildIdFromUrl() {
+        const m = window.location.pathname.match(/\/dnd\/campaign\/(\d+)/);
+        return m ? m[1] : '';
+    }
+}
+
+if (typeof document !== 'undefined') {
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', initEncounterLibrary);
+    } else {
+        initEncounterLibrary();
+    }
+}

--- a/web/src/main/resources/templates/campaignDetail.html
+++ b/web/src/main/resources/templates/campaignDetail.html
@@ -3,6 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="_csrf" th:if="${_csrf != null}" th:content="${_csrf.token}">
+    <meta name="_csrf_header" th:if="${_csrf != null}" th:content="${_csrf.headerName}">
     <title th:text="'TobyBot - ' + ${guildName} + ' Campaign'">TobyBot - Campaign</title>
     <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
     <link rel="stylesheet" th:href="@{/css/base.css}">
@@ -347,20 +349,24 @@
             font-size: 0.9rem;
         }
 
-        .monster-library, .initiative-composer, .turn-table {
+        .monster-library, .encounter-library, .initiative-composer, .turn-table {
             background: #16213e;
             border: 1px solid #2a2a4a;
             border-radius: 10px;
             padding: 16px 20px;
             margin-bottom: 20px;
         }
+        .monster-library { border-left: 3px solid #c87bff; }
+        .encounter-library { border-left: 3px solid #6b8afd; }
         .monster-library summary,
+        .encounter-library summary,
         .initiative-composer .title {
             font-weight: 600;
             cursor: pointer;
             color: #e0e0e0;
             margin-bottom: 8px;
         }
+        .encounter-library summary .section-icon { margin-right: 6px; }
         .monster-library table { width: 100%; border-collapse: collapse; margin: 10px 0; }
         .monster-library th, .monster-library td {
             padding: 6px 8px;
@@ -380,6 +386,179 @@
         }
         .monster-library input[type=number] { width: 70px; }
         .monster-library tr.row-form td { vertical-align: top; }
+
+        /* Encounter Library ------------------------------------------------ */
+        .encounter-library .empty-state {
+            text-align: center;
+            color: #a0a0b0;
+            padding: 18px;
+            border: 1px dashed #2a2a4a;
+            border-radius: 6px;
+            margin: 10px 0;
+        }
+        .encounter-library .empty-state .empty-icon {
+            display: block;
+            font-size: 1.6rem;
+            margin-bottom: 6px;
+            opacity: 0.85;
+        }
+        .encounter-card {
+            background: #1a1a2e;
+            border: 1px solid #2a2a4a;
+            border-radius: 8px;
+            padding: 12px 14px;
+            margin: 12px 0;
+            transition: box-shadow .15s ease, border-color .15s ease;
+        }
+        .encounter-card:hover { border-color: #3a3a66; box-shadow: 0 0 0 1px #6b8afd33; }
+        .encounter-card-head {
+            display: flex;
+            flex-wrap: wrap;
+            align-items: center;
+            gap: 8px;
+            margin-bottom: 8px;
+            justify-content: space-between;
+        }
+        .encounter-card-head .encounter-rename {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 6px;
+            flex: 1 1 320px;
+        }
+        .encounter-card-head .encounter-rename input[type=text] {
+            padding: 6px 8px;
+            border-radius: 4px;
+            border: 1px solid #2a2a4a;
+            background: #1a1a2e;
+            color: #e0e0e0;
+            font-size: 0.85rem;
+        }
+        .encounter-card-head .encounter-rename input[name="name"] { flex: 1 1 160px; min-width: 120px; }
+        .encounter-card-head .encounter-rename input[name="notes"] { flex: 2 1 220px; min-width: 160px; }
+        .encounter-badges { display: flex; gap: 6px; flex-wrap: wrap; }
+        .badge {
+            display: inline-block;
+            padding: 2px 10px;
+            border-radius: 999px;
+            font-size: 0.72rem;
+            font-weight: 600;
+            letter-spacing: 0.03em;
+            white-space: nowrap;
+        }
+        .badge-roster { background: #6b8afd22; color: #a9bcff; border: 1px solid #6b8afd55; }
+        .badge-count { background: #ffffff0a; color: #a0a0b0; border: 1px solid #ffffff1a; }
+        .encounter-actions { display: flex; gap: 6px; flex-wrap: wrap; }
+        .encounter-entries { width: 100%; border-collapse: collapse; font-size: 0.85rem; margin: 6px 0; }
+        .encounter-entries th {
+            color: #a0a0b0;
+            font-weight: 500;
+            text-align: left;
+            padding: 4px 6px;
+            border-bottom: 1px solid #2a2a4a;
+        }
+        .encounter-entries td {
+            padding: 4px 6px;
+            border-bottom: 1px solid #2a2a4a;
+            vertical-align: middle;
+        }
+        .encounter-entry-row { transition: background-color .15s ease; }
+        .encounter-entry-row.dragging { opacity: 0.4; }
+        .encounter-entry-row.drag-over { box-shadow: inset 0 2px 0 #6b8afd; }
+        .encounter-entry-row .drag-handle {
+            cursor: grab;
+            color: #6b8afd;
+            user-select: none;
+            width: 1.8em;
+            text-align: center;
+            border-radius: 3px;
+            font-size: 1.1rem;
+            line-height: 1;
+        }
+        .encounter-entry-row .drag-handle:active { cursor: grabbing; }
+        .encounter-entry-row .drag-handle:focus {
+            outline: 2px solid #6b8afd;
+            outline-offset: 2px;
+        }
+        .encounter-entry-row .entry-orphan { color: #ff9a9a; font-style: italic; }
+        .add-entry-form {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 6px;
+            align-items: center;
+            margin-top: 8px;
+            padding: 8px;
+            background: #ffffff05;
+            border-radius: 6px;
+        }
+        .add-entry-form .add-entry-mode {
+            display: flex;
+            gap: 10px;
+            margin-right: 6px;
+            font-size: 0.8rem;
+            color: #a0a0b0;
+        }
+        .add-entry-form .add-entry-mode label { display: inline-flex; gap: 4px; cursor: pointer; }
+        .add-entry-form select,
+        .add-entry-form input[type=text],
+        .add-entry-form input[type=number] {
+            padding: 6px 8px;
+            border-radius: 4px;
+            border: 1px solid #2a2a4a;
+            background: #1a1a2e;
+            color: #e0e0e0;
+            font-size: 0.85rem;
+        }
+        .add-entry-form input[type=number] { width: 70px; }
+        .add-entry-form select { min-width: 160px; }
+        .new-encounter-form {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px;
+            align-items: center;
+            margin-top: 10px;
+            padding-top: 10px;
+            border-top: 1px dashed #2a2a4a;
+        }
+        .new-encounter-form input[type=text] {
+            padding: 6px 8px;
+            border-radius: 4px;
+            border: 1px solid #2a2a4a;
+            background: #1a1a2e;
+            color: #e0e0e0;
+            font-size: 0.85rem;
+        }
+        .new-encounter-form input[name="name"] { flex: 1 1 180px; min-width: 160px; }
+        .new-encounter-form input[name="notes"] { flex: 2 1 240px; min-width: 160px; }
+        .encounter-loader {
+            display: flex;
+            gap: 8px;
+            align-items: center;
+            margin-bottom: 10px;
+            padding: 8px 10px;
+            background: #6b8afd11;
+            border: 1px solid #6b8afd33;
+            border-radius: 6px;
+            font-size: 0.85rem;
+        }
+        .encounter-loader label { color: #a9bcff; font-weight: 500; }
+        .encounter-loader select {
+            flex: 1;
+            min-width: 160px;
+            padding: 6px 8px;
+            border-radius: 4px;
+            border: 1px solid #2a2a4a;
+            background: #1a1a2e;
+            color: #e0e0e0;
+            font-size: 0.85rem;
+        }
+
+        @media (max-width: 720px) {
+            .encounter-card-head { flex-direction: column; align-items: stretch; }
+            .encounter-actions { justify-content: flex-end; }
+            .add-entry-form { flex-direction: column; align-items: stretch; }
+            .add-entry-form select, .add-entry-form input { width: 100%; }
+        }
+
         .initiative-composer .players-grid {
             display: grid;
             grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
@@ -1151,9 +1330,162 @@
             </form>
         </details>
 
+        <!-- Encounter library (DM only) -->
+        <details class="encounter-library" th:if="${isUserDm}">
+            <summary>
+                <span class="section-icon" aria-hidden="true">&#9876;</span>
+                Encounter library (<span th:text="${#lists.size(encounters)}">0</span>)
+            </summary>
+
+            <p th:if="${#lists.isEmpty(encounters)}" class="empty-state">
+                <span class="empty-icon" aria-hidden="true">&#128220;</span>
+                No saved encounters yet. Create one below, then drag monsters in to build the roster.
+            </p>
+
+            <div class="encounter-card" th:each="enc : ${encounters}"
+                 th:attr="data-encounter-id=${enc.id}">
+
+                <header class="encounter-card-head">
+                    <form th:action="@{/dnd/campaign/{gid}/encounters(gid=${guildId})}" method="post"
+                          class="encounter-rename">
+                        <input type="hidden" name="id" th:value="${enc.id}">
+                        <input type="text" name="name" th:value="${enc.name}" maxlength="100" required>
+                        <input type="text" name="notes" th:value="${enc.notes}" maxlength="500"
+                               placeholder="Notes (optional)">
+                        <button type="submit" class="btn-xs" title="Save name / notes">Save</button>
+                    </form>
+
+                    <div class="encounter-badges">
+                        <span class="badge badge-roster"
+                              th:text="|${enc.totalRosterSize} monster(s)|">0 monsters</span>
+                        <span class="badge badge-count"
+                              th:text="|${#lists.size(enc.entries)} row(s)|">0 rows</span>
+                    </div>
+
+                    <div class="encounter-actions">
+                        <button type="button" class="btn-xs btn-load-encounter"
+                                th:attr="data-encounter-id=${enc.id}"
+                                title="Fill the initiative composer with this encounter's roster">
+                            Load into composer
+                        </button>
+                        <form th:action="@{/dnd/campaign/{gid}/encounters/{eid}/roll(gid=${guildId},eid=${enc.id})}"
+                              method="post" style="display:inline;">
+                            <button type="submit" class="btn-xs" title="Roll initiative with this roster">
+                                &#127922; Roll now
+                            </button>
+                        </form>
+                        <form th:action="@{/dnd/campaign/{gid}/encounters/{eid}/delete(gid=${guildId},eid=${enc.id})}"
+                              method="post"
+                              th:onsubmit="|return confirm('Delete encounter ${enc.name}?');|"
+                              style="display:inline;">
+                            <button type="submit" class="btn-xs kick" title="Delete encounter">Delete</button>
+                        </form>
+                    </div>
+                </header>
+
+                <table th:if="${not #lists.isEmpty(enc.entries)}" class="encounter-entries">
+                    <thead>
+                    <tr>
+                        <th></th>
+                        <th>Source</th>
+                        <th>Qty</th>
+                        <th>Init</th>
+                        <th>HP</th>
+                        <th>AC</th>
+                        <th></th>
+                    </tr>
+                    </thead>
+                    <tbody class="encounter-entry-tbody" th:attr="data-encounter-id=${enc.id}">
+                    <tr th:each="entry : ${enc.entries}"
+                        class="encounter-entry-row"
+                        draggable="true"
+                        th:attr="data-entry-id=${entry.id}">
+                        <td class="drag-handle" tabindex="0" role="button"
+                            aria-label="Drag to reorder (Alt+ArrowUp / Alt+ArrowDown)">&#8942;&#8942;</td>
+                        <td>
+                            <span th:if="${entry.monsterTemplate != null}"
+                                  th:text="${entry.monsterTemplate.name}">Goblin</span>
+                            <span th:if="${entry.monsterTemplate == null and entry.adhocName != null}"
+                                  th:text="|&#9998; ${entry.adhocName}|">&#9998; Ad-hoc</span>
+                            <span th:if="${entry.monsterTemplate == null and entry.adhocName == null}"
+                                  class="entry-orphan">(missing template)</span>
+                        </td>
+                        <td th:text="${entry.monsterTemplate != null ? entry.quantity : 1}">1</td>
+                        <td th:text="${entry.monsterTemplate != null
+                                      ? (entry.monsterTemplate.initiativeModifier &gt;= 0 ? '+' : '') + entry.monsterTemplate.initiativeModifier
+                                      : (entry.adhocInitiativeModifier &gt;= 0 ? '+' : '') + entry.adhocInitiativeModifier}">+2</td>
+                        <td th:text="${entry.monsterTemplate != null
+                                      ? (entry.monsterTemplate.hpExpression != null ? entry.monsterTemplate.hpExpression : '—')
+                                      : (entry.adhocHpExpression != null ? entry.adhocHpExpression : '—')}">—</td>
+                        <td th:text="${entry.monsterTemplate != null
+                                      ? (entry.monsterTemplate.ac != null ? entry.monsterTemplate.ac : '—')
+                                      : (entry.adhocAc != null ? entry.adhocAc : '—')}">—</td>
+                        <td>
+                            <form th:action="@{/dnd/campaign/{gid}/encounters/{eid}/entries/{entryId}/delete
+                                              (gid=${guildId},eid=${enc.id},entryId=${entry.id})}"
+                                  method="post"
+                                  style="display:inline;">
+                                <button type="submit" class="btn-xs kick" title="Remove entry">&#10005;</button>
+                            </form>
+                        </td>
+                    </tr>
+                    </tbody>
+                </table>
+
+                <form th:action="@{/dnd/campaign/{gid}/encounters/{eid}/entries(gid=${guildId},eid=${enc.id})}"
+                      method="post" class="add-entry-form"
+                      th:attr="data-encounter-id=${enc.id}">
+                    <div class="add-entry-mode">
+                        <label><input type="radio" name="__mode" value="template" checked> From library</label>
+                        <label><input type="radio" name="__mode" value="adhoc"> Ad-hoc</label>
+                    </div>
+                    <select name="monsterTemplateId" class="entry-template-select">
+                        <option value="" disabled selected>&mdash; pick a monster &mdash;</option>
+                        <option th:each="tpl : ${monsterLibrary}"
+                                th:value="${tpl.id}"
+                                th:text="${tpl.name}">Goblin</option>
+                    </select>
+                    <input type="number" name="quantity" min="1" max="20" value="1"
+                           class="entry-template-input" title="Quantity">
+                    <input type="text" name="adhocName" placeholder="Ad-hoc name" maxlength="100"
+                           class="entry-adhoc-input" style="display:none;">
+                    <input type="number" name="adhocInitiativeModifier" value="0"
+                           min="-30" max="30" placeholder="init"
+                           class="entry-adhoc-input" style="display:none;">
+                    <input type="text" name="adhocHpExpression"
+                           pattern="^\s*(\d+|\d*[dD]\d+([+-]\d+)?)\s*$"
+                           title="Plain integer or dice expression like 3d20+30"
+                           placeholder="HP or 3d20+30" maxlength="32"
+                           class="entry-adhoc-input" style="display:none;">
+                    <input type="number" name="adhocAc" placeholder="AC" min="0" max="50"
+                           class="entry-adhoc-input" style="display:none;">
+                    <button type="submit" class="btn btn-primary btn-sm">Add</button>
+                </form>
+            </div>
+
+            <form th:action="@{/dnd/campaign/{gid}/encounters(gid=${guildId})}" method="post"
+                  class="new-encounter-form">
+                <input type="text" name="name" placeholder="New encounter name" maxlength="100" required>
+                <input type="text" name="notes" placeholder="Notes (optional)" maxlength="500">
+                <button type="submit" class="btn btn-primary">Create encounter</button>
+            </form>
+        </details>
+
         <!-- Initiative composer (DM only) -->
         <div class="initiative-composer" th:if="${isUserDm}">
             <div class="title">Roll initiative</div>
+            <div class="encounter-loader" th:if="${not #lists.isEmpty(encounters)}">
+                <label for="encounterLoader">Load encounter:</label>
+                <select id="encounterLoader">
+                    <option value="">&mdash; none &mdash;</option>
+                    <option th:each="enc : ${encounters}"
+                            th:value="${enc.id}"
+                            th:text="|${enc.name} (${enc.totalRosterSize})|">Goblin ambush (4)</option>
+                </select>
+                <span style="color:#a0a0b0;font-size:0.78rem;">
+                    Pre-fills the roster below &mdash; tweak, then roll.
+                </span>
+            </div>
             <form th:action="@{/dnd/campaign/{id}/initiative/roll(id=${guildId})}" method="post"
                   id="initiative-composer-form">
                 <div class="players-grid" th:if="${not #lists.isEmpty(players)}">
@@ -1467,5 +1799,6 @@
 <script th:src="@{/js/home.js}"></script>
 <script th:if="${campaign != null}" th:src="@{/js/sessionLog.js}"></script>
 <script th:if="${campaign != null}" th:src="@{/js/diceRoller.js}"></script>
+<script th:if="${isUserDm}" th:src="@{/js/encounters.js}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Adds an **Encounter Library** parallel to the existing Monster Library so DMs can prep combats in advance instead of assembling every fight from scratch in the initiative composer.

- **DM-scoped, reusable encounters** with a name + notes and an ordered roster. Each entry is either a reference to a monster template (with a quantity that expands at roll time — e.g. `4 x Goblin`) or an ad-hoc monster defined inline.
- **Drag-and-drop reordering** of roster rows, mirroring the native HTML5 pattern from `intros.js`. Alt+ArrowUp / Alt+ArrowDown on the drag handle is the keyboard-accessible equivalent.
- **"Load into composer"** on each encounter card fetches the encounter JSON and pre-fills the initiative composer (player checkboxes untouched, template quantities set, ad-hoc rows populated) so the DM can tweak before rolling. A **"Roll now"** button on each card skips the composer and seeds the turn table directly by delegating to the existing `rollInitiative` pipeline (same `INITIATIVE_ROLLED` session event).
- **UI polish**: card layout per encounter, roster + row-count pill badges, dashed empty-state, distinct blue accent (vs. purple for the monster library), `@media` collapse on narrow screens, subtle hover shadow, grab cursor + focus outline on drag handles.

## Data model

- `V9__dnd_encounter.sql` &mdash; parent, indexed on `dm_discord_id`.
- `V10__dnd_encounter_entry.sql` &mdash; roster rows; `encounter_id ON DELETE CASCADE`, `monster_template_id ON DELETE SET NULL` so deleting a monster doesn't wipe saved encounters (the UI shows `(missing template)` and keeps the delete action available).

## Architecture

Mirrors the Monster Library layering exactly: DTO + `@NamedQueries`, `@Repository @Transactional` persistence over `EntityManager`, thin `@Service` pass-through, `CampaignWebService` methods that return Result enums, `CampaignController` endpoints that translate results into flash messages (form-post + redirect) plus one JSON POST for reorder and two JSON GETs for the composer's client-side populate.

No changes to the roll path itself: `rollEncounter` expands the roster into an `InitiativeRollRequest` and delegates to the existing `rollInitiative`.

## Test plan

- [ ] `\d dnd_encounter` and `\d dnd_encounter_entry` show the expected schema; cascade + set-null FKs behave correctly.
- [ ] As DM: create an encounter; add template rows + ad-hoc row; drag to reorder (and Alt+Arrow keyboard reorder); delete row; delete encounter.
- [ ] Click "Roll now" &rarr; turn table populates with the expanded roster; session log records `INITIATIVE_ROLLED`.
- [ ] Use the "Load encounter" select in the composer &rarr; `templateQty` inputs and ad-hoc rows pre-fill without touching player checkboxes; tweak and roll normally.
- [ ] Non-DM: Encounter Library is not rendered (gated by `th:if="${isUserDm}"`).
- [ ] DM A cannot edit/delete/reorder/roll DM B's encounter &rarr; flash error.
- [ ] Delete a monster template referenced by an encounter &rarr; entry persists as orphaned; UI shows "(missing template)" and the remove action still works.
- [ ] Over-cap (41st entry) &rarr; `TOO_MANY_ENTRIES` flash.
- [ ] Regression: Monster Library still saves/deletes; initiative composer still rolls ad-hoc without an encounter; `/intro` drag-reorder still works.

Note: the project's Gradle wrapper pins 9.4.0, which the sandbox couldn't download for a build run here. Code was reviewed by hand against the existing Monster Library patterns, which it mirrors closely.