### PR TITLE
fix(web): expose CSRF token from shared head fragment

### DIFF
--- a/web/src/main/resources/templates/fragments/head.html
+++ b/web/src/main/resources/templates/fragments/head.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="color-scheme" content="dark">
+    <meta name="_csrf" th:if="${_csrf != null}" th:content="${_csrf.token}">
+    <meta name="_csrf_header" th:if="${_csrf != null}" th:content="${_csrf.headerName}">
     <title th:text="${pageTitle}">TobyBot</title>
     <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
     <link rel="stylesheet" th:href="@{/css/base.css}">


### PR DESCRIPTION
## Summary

Pages using `fragments/head.html` (intros, home, guilds) were not emitting the `<meta name="_csrf">` / `<meta name="_csrf_header">` tags. `intros.js` reads them to attach `X-CSRF-TOKEN` to its fetch calls — without them, the JSON endpoints all 403:

- `POST /intro/{guildId}/update-volume`
- `POST /intro/{guildId}/update-name`
- `POST /intro/{guildId}/reorder`
- `POST /intro/{guildId}/update-timestamps` (just added in #252)

Thymeleaf auto-injects the hidden `_csrf` input on `th:action` form POSTs, which is why the main `/set` multipart submit kept working.

This adds the meta tags to the shared head fragment so every page that uses it picks them up. `campaignDetail.html` already declares its own head with the same two tags and is unaffected.

## Test plan

- [ ] Load `/intro/{guildId}` in a browser, drag-reorder an intro, rename one, adjust the volume slider — each should return 200 instead of 403.
- [ ] Click the ⏱ clip badge and save; the `/update-timestamps` POST should succeed.
- [ ] Inspect the page source — `<meta name="_csrf">` and `<meta name="_csrf_header">` should be present in `<head>`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QFyK4Y4ieK1ZSWGq6zFCeD)_