### PR TITLE
feat(intros): clip-aware playback for saved rows + submit-gate fix

### DIFF
--- a/web/src/main/resources/static/css/intros.css
+++ b/web/src/main/resources/static/css/intros.css
@@ -318,6 +318,22 @@
     background: #000;
 }
 
+/* Inline clip preview row — shown when the user clicks ▶ on a saved YouTube
+   intro in the "Your intros" table. */
+.video-preview-row > td {
+    padding: 0;
+    background: var(--bg-input);
+    border-top: 1px solid var(--border);
+}
+.video-preview-row iframe {
+    width: 100%;
+    aspect-ratio: 16 / 9;
+    max-height: 360px;
+    border: 0;
+    display: block;
+    background: #000;
+}
+
 @media (max-width: 640px) {
     .url-preview { grid-template-columns: 1fr; }
     .url-preview img { width: 100%; height: 140px; }

--- a/web/src/main/resources/static/js/intros.js
+++ b/web/src/main/resources/static/js/intros.js
@@ -67,6 +67,67 @@ function validateClipMs(startMs, endMs, sourceDurationMs, maxClipMs) {
     return '';
 }
 
+// Escape helper shared by togglePlayClip. Matches the per-page version in
+// initIntroPage; kept at module scope so the helper is usable outside the
+// page bootstrap (and reachable by Jest tests).
+function escapeAttrSafe(s) {
+    return String(s).replace(/[&<>"']/g, c => ({
+        '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
+    })[c]);
+}
+
+// Closes any currently-open YouTube clip preview row and resets its launch
+// button. Called both by togglePlayClip (second-click collapse) and
+// togglePlay (another intro is taking over playback).
+function closeClipPreviewRow() {
+    document.querySelectorAll('tr.video-preview-row').forEach(r => r.remove());
+    document.querySelectorAll('[data-play-clip-video-id].playing').forEach(b => {
+        b.textContent = '▶';
+        b.classList.remove('playing');
+    });
+}
+
+// Injects a YouTube iframe clip preview as a new row beneath the clicked
+// button's row, seeding start/end from the row's data-start-ms /
+// data-end-ms attributes. A second click tears the preview back down.
+function togglePlayClip(btn) {
+    const row = btn.closest && btn.closest('tr[data-intro-id]');
+    if (!row) return;
+    const isOpen = btn.classList.contains('playing');
+    closeClipPreviewRow();
+    if (typeof document !== 'undefined') {
+        document.querySelectorAll('audio').forEach(a => { a.pause(); a.currentTime = 0; });
+        document.querySelectorAll('.btn-play').forEach(b => {
+            b.textContent = '▶';
+            b.classList.remove('playing');
+        });
+    }
+    if (isOpen) return;
+    const videoId = btn.dataset.playClipVideoId;
+    if (!videoId) return;
+    const startMs = row.dataset.startMs ? parseInt(row.dataset.startMs, 10) : NaN;
+    const endMs = row.dataset.endMs ? parseInt(row.dataset.endMs, 10) : NaN;
+    const startSec = Number.isFinite(startMs) ? Math.max(0, Math.floor(startMs / 1000)) : 0;
+    const endSec = Number.isFinite(endMs) && endMs > startMs ? Math.ceil(endMs / 1000) : null;
+    const params = new URLSearchParams();
+    if (startSec > 0) params.set('start', String(startSec));
+    if (endSec != null) params.set('end', String(endSec));
+    params.set('autoplay', '1');
+    params.set('controls', '1');
+    params.set('rel', '0');
+    const src = 'https://www.youtube.com/embed/' + encodeURIComponent(videoId) + '?' + params.toString();
+    const previewRow = document.createElement('tr');
+    previewRow.className = 'video-preview-row';
+    const td = document.createElement('td');
+    td.colSpan = row.children.length;
+    td.innerHTML = '<iframe src="' + escapeAttrSafe(src) + '" ' +
+        'title="Clip preview" allow="autoplay; encrypted-media" allowfullscreen></iframe>';
+    previewRow.appendChild(td);
+    row.parentNode.insertBefore(previewRow, row.nextSibling);
+    btn.textContent = '⏹';
+    btn.classList.add('playing');
+}
+
 function togglePlay(btn) {
     const audioId = btn.dataset.audioId;
     const audio = document.getElementById(audioId);
@@ -74,9 +135,37 @@ function togglePlay(btn) {
     if (audio.paused) {
         document.querySelectorAll('audio').forEach(a => { a.pause(); a.currentTime = 0; });
         document.querySelectorAll('.btn-play').forEach(b => { b.textContent = '▶'; b.classList.remove('playing'); });
+        closeClipPreviewRow();
         // Apply saved volume if present on the button
         const vol = parseInt(btn.dataset.volume || '100', 10);
         if (!isNaN(vol)) audio.volume = Math.max(0, Math.min(1, vol / 100));
+
+        // Honour the row's saved clip (data-start-ms / data-end-ms) if present.
+        // Seek to startSec before playing and pause at endSec via a one-time
+        // timeupdate listener so replay triggers the same seek.
+        const row = btn.closest('tr[data-intro-id]');
+        const startMs = row && row.dataset.startMs ? parseInt(row.dataset.startMs, 10) : NaN;
+        const endMs = row && row.dataset.endMs ? parseInt(row.dataset.endMs, 10) : NaN;
+        const startSec = Number.isFinite(startMs) ? startMs / 1000 : 0;
+        try { audio.currentTime = startSec; } catch (_) {}
+        if (Number.isFinite(endMs) && endMs > startMs) {
+            if (audio._clipTimeupdateHandler) {
+                audio.removeEventListener('timeupdate', audio._clipTimeupdateHandler);
+            }
+            const endSec = endMs / 1000;
+            const handler = function () {
+                if (audio.currentTime >= endSec) {
+                    audio.pause();
+                    try { audio.currentTime = startSec; } catch (_) {}
+                    btn.textContent = '▶';
+                    btn.classList.remove('playing');
+                    audio.removeEventListener('timeupdate', handler);
+                    audio._clipTimeupdateHandler = null;
+                }
+            };
+            audio.addEventListener('timeupdate', handler);
+            audio._clipTimeupdateHandler = handler;
+        }
         audio.play();
         btn.textContent = '⏹';
         btn.classList.add('playing');
@@ -215,6 +304,22 @@ function initIntroPage() {
         const err = validateClipMs(startMs, endMs, clipState.sourceDurationMs, maxClipMs);
         clipState.valid = !err;
         setClipError(err);
+
+        // Sync the too-long hint on the preview card. Without this the "Video is
+        // too long" red text + duration-badge lingers after the user has entered
+        // a clip that fits under the cap, and the submit button stays disabled.
+        if (typeof previewState !== 'undefined') {
+            previewState.tooLong = !clipState.valid && clipState.sourceDurationMs != null;
+            if (urlPreview) {
+                urlPreview.classList.toggle('error', previewState.tooLong);
+                const badge = urlPreview.querySelector('.duration-badge');
+                if (badge) badge.classList.toggle('too-long', previewState.tooLong);
+            }
+            // Clear the stale "too long" url-level error when the clip now fits.
+            if (clipState.valid && urlError && /too long/i.test(urlError.textContent)) {
+                setUrlError('');
+            }
+        }
 
         if (startMsHidden) startMsHidden.value = startMs == null ? '' : String(startMs);
         if (endMsHidden) endMsHidden.value = endMs == null ? '' : String(endMs);
@@ -496,6 +601,11 @@ function initIntroPage() {
         });
     }
     updateSubmitState();
+
+    // --- Clip-aware YouTube preview on saved rows ---
+    document.querySelectorAll('[data-play-clip-video-id]').forEach(btn => {
+        btn.addEventListener('click', function () { togglePlayClip(btn); });
+    });
 
     // --- Delete modal ---
     document.querySelectorAll('[data-delete-intro]').forEach(btn => {
@@ -803,9 +913,18 @@ if (typeof document !== 'undefined' && typeof window !== 'undefined') {
     }
     // Expose ▶ handler to inline onclick bindings that still exist in the template
     window.togglePlay = togglePlay;
+    window.togglePlayClip = togglePlayClip;
     window.toggleInput = toggleInput;
 }
 
 if (typeof module !== 'undefined') {
-    module.exports = { toggleInput, togglePlay, parseTimeInput, formatMs, validateClipMs };
+    module.exports = {
+        toggleInput,
+        togglePlay,
+        togglePlayClip,
+        closeClipPreviewRow,
+        parseTimeInput,
+        formatMs,
+        validateClipMs
+    };
 }

--- a/web/src/main/resources/templates/intros.html
+++ b/web/src/main/resources/templates/intros.html
@@ -75,7 +75,8 @@
                     <tr th:each="intro : ${intros}"
                         th:attr="data-intro-id=${intro.id},
                                  data-start-ms=${intro.startMs != null ? intro.startMs : ''},
-                                 data-end-ms=${intro.endMs != null ? intro.endMs : ''}">
+                                 data-end-ms=${intro.endMs != null ? intro.endMs : ''},
+                                 data-video-id=${intro.videoId != null ? intro.videoId : ''}">
                         <td data-label="Slot">
                             <span class="drag-handle" title="Drag to reorder" aria-hidden="true">⋮⋮</span>
                             <span class="slot-index" th:text="${intro.index}">1</span>
@@ -106,13 +107,21 @@
                             </div>
                         </td>
                         <td data-label="Actions" class="actions">
-                            <!-- Play or open-link -->
+                            <!-- Clip-aware preview for YouTube intros -->
+                            <button th:if="${intro.videoId != null}"
+                                    type="button" class="btn-play"
+                                    th:attr="data-play-clip-video-id=${intro.videoId},
+                                             data-intro-id=${intro.id},
+                                             aria-label='Preview clip of ' + ${intro.fileName}"
+                                    title="Preview clip">▶</button>
+                            <!-- External link for every URL intro (YouTube or otherwise) -->
                             <a th:if="${intro.url != null}"
                                th:href="${intro.url}"
                                target="_blank" rel="noopener"
                                class="btn-link-icon"
                                th:aria-label="'Open ' + ${intro.fileName} + ' in new tab'"
                                title="Open link">↗</a>
+                            <!-- Direct play for file intros -->
                             <span th:unless="${intro.url != null}">
                                 <audio th:id="'audio-' + ${intro.id}"
                                        th:src="@{/music(id=${intro.id})}"

--- a/web/src/test/js/intros.test.js
+++ b/web/src/test/js/intros.test.js
@@ -1,4 +1,12 @@
-const { toggleInput, togglePlay, parseTimeInput, formatMs, validateClipMs } = require('../../main/resources/static/js/intros');
+const {
+    toggleInput,
+    togglePlay,
+    togglePlayClip,
+    closeClipPreviewRow,
+    parseTimeInput,
+    formatMs,
+    validateClipMs,
+} = require('../../main/resources/static/js/intros');
 
 // ---------------------------------------------------------------------------
 // toggleInput
@@ -33,12 +41,20 @@ function makeAudio(id) {
     const audio = document.createElement('audio');
     audio.id = id;
     audio.src = `/music?id=${id}`;
-    // JSDOM doesn't implement media APIs; provide stubs
+    // JSDOM doesn't implement media APIs; provide stubs.
     audio.play = jest.fn().mockResolvedValue(undefined);
     audio.pause = jest.fn();
     // Start paused
     Object.defineProperty(audio, 'paused', {
         get: jest.fn().mockReturnValue(true),
+        configurable: true,
+    });
+    // JSDOM's HTMLMediaElement.currentTime setter is a no-op with no media
+    // loaded; swap in a plain getter/setter so tests can drive playback time.
+    let _currentTime = 0;
+    Object.defineProperty(audio, 'currentTime', {
+        get: () => _currentTime,
+        set: (v) => { _currentTime = v; },
         configurable: true,
     });
     return audio;
@@ -247,5 +263,172 @@ describe('validateClipMs', () => {
 
     test('rejects negative start', () => {
         expect(validateClipMs(-1, 1000, 60000, MAX)).toMatch(/negative/i);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// togglePlay — clip-aware playback on saved rows
+// ---------------------------------------------------------------------------
+
+function makeRowWithAudio(id, { startMs, endMs } = {}) {
+    const table = document.createElement('table');
+    const tbody = document.createElement('tbody');
+    const tr = document.createElement('tr');
+    tr.dataset.introId = id;
+    if (startMs != null) tr.dataset.startMs = String(startMs);
+    if (endMs != null) tr.dataset.endMs = String(endMs);
+    const td = document.createElement('td');
+    const audio = makeAudio('audio-' + id);
+    const btn = makeButton('audio-' + id);
+    td.appendChild(audio);
+    td.appendChild(btn);
+    tr.appendChild(td);
+    tbody.appendChild(tr);
+    table.appendChild(tbody);
+    document.body.appendChild(table);
+    return { tr, audio, btn };
+}
+
+describe('togglePlay — saved-row clip bounds', () => {
+    beforeEach(() => {
+        document.body.innerHTML = '';
+    });
+
+    test('seeks to data-start-ms / 1000 before playing', () => {
+        const { audio, btn } = makeRowWithAudio('1', { startMs: 2500, endMs: 9000 });
+        togglePlay(btn);
+        expect(audio.currentTime).toBe(2.5);
+        expect(audio.play).toHaveBeenCalled();
+    });
+
+    test('starts at 0 when no start-ms is set on the row', () => {
+        const { audio, btn } = makeRowWithAudio('1');
+        togglePlay(btn);
+        expect(audio.currentTime).toBe(0);
+    });
+
+    test('pauses and resets to start when timeupdate crosses end-ms', () => {
+        const { audio, btn } = makeRowWithAudio('1', { startMs: 1000, endMs: 4000 });
+        togglePlay(btn);
+        audio.currentTime = 4.25;
+        audio.dispatchEvent(new Event('timeupdate'));
+        expect(audio.pause).toHaveBeenCalled();
+        expect(audio.currentTime).toBe(1);
+        expect(btn.textContent).toBe('▶');
+        expect(btn.classList.contains('playing')).toBe(false);
+    });
+
+    test('does not auto-pause on timeupdate when no end-ms is set', () => {
+        const { audio, btn } = makeRowWithAudio('1', { startMs: 1000 });
+        togglePlay(btn);
+        // togglePlay sweeps every <audio> to pause(); ignore that and verify
+        // no subsequent auto-pause fires from the timeupdate path.
+        audio.pause.mockClear();
+        audio.currentTime = 10;
+        audio.dispatchEvent(new Event('timeupdate'));
+        expect(audio.pause).not.toHaveBeenCalled();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// togglePlayClip — inline YouTube iframe for saved rows
+// ---------------------------------------------------------------------------
+
+function makeClipRow(id, { videoId, startMs, endMs } = {}) {
+    const table = document.createElement('table');
+    const tbody = document.createElement('tbody');
+    const tr = document.createElement('tr');
+    tr.dataset.introId = id;
+    if (videoId != null) tr.dataset.videoId = videoId;
+    if (startMs != null) tr.dataset.startMs = String(startMs);
+    if (endMs != null) tr.dataset.endMs = String(endMs);
+    for (let i = 0; i < 3; i++) tr.appendChild(document.createElement('td'));
+    const actionsTd = document.createElement('td');
+    const btn = document.createElement('button');
+    btn.className = 'btn-play';
+    btn.dataset.playClipVideoId = videoId;
+    btn.dataset.introId = id;
+    btn.textContent = '▶';
+    actionsTd.appendChild(btn);
+    tr.appendChild(actionsTd);
+    tbody.appendChild(tr);
+    table.appendChild(tbody);
+    document.body.appendChild(table);
+    return { tr, btn, tbody };
+}
+
+describe('togglePlayClip', () => {
+    beforeEach(() => {
+        document.body.innerHTML = '';
+    });
+
+    test('injects a video-preview-row with a clip-configured iframe', () => {
+        const { tr, btn } = makeClipRow('1_2_1', { videoId: 'dQw4w9WgXcQ', startMs: 5000, endMs: 12000 });
+        togglePlayClip(btn);
+
+        const previewRow = tr.nextElementSibling;
+        expect(previewRow).not.toBeNull();
+        expect(previewRow.className).toBe('video-preview-row');
+
+        const iframe = previewRow.querySelector('iframe');
+        expect(iframe).not.toBeNull();
+        const src = iframe.getAttribute('src');
+        expect(src).toContain('/embed/dQw4w9WgXcQ');
+        expect(src).toContain('start=5');
+        expect(src).toContain('end=12');
+        expect(src).toContain('autoplay=1');
+
+        expect(btn.textContent).toBe('⏹');
+        expect(btn.classList.contains('playing')).toBe(true);
+    });
+
+    test('second click tears the preview row back down', () => {
+        const { tr, btn } = makeClipRow('1_2_1', { videoId: 'abc', startMs: 0, endMs: 7000 });
+        togglePlayClip(btn);
+        togglePlayClip(btn);
+
+        expect(tr.nextElementSibling).toBeNull();
+        expect(btn.textContent).toBe('▶');
+        expect(btn.classList.contains('playing')).toBe(false);
+    });
+
+    test('omits start / end params when no clip is set', () => {
+        const { tr, btn } = makeClipRow('1_2_1', { videoId: 'abc' });
+        togglePlayClip(btn);
+
+        const iframe = tr.nextElementSibling.querySelector('iframe');
+        const src = iframe.getAttribute('src');
+        expect(src).not.toContain('start=');
+        expect(src).not.toContain('end=');
+    });
+
+    test('starting a clip preview closes any previously-open preview', () => {
+        const first = makeClipRow('1_2_1', { videoId: 'first' });
+        const second = makeClipRow('1_2_2', { videoId: 'second' });
+        togglePlayClip(first.btn);
+        expect(first.tr.nextElementSibling.className).toBe('video-preview-row');
+
+        togglePlayClip(second.btn);
+
+        // Only one preview row exists at a time; first button reset, second open.
+        expect(document.querySelectorAll('.video-preview-row').length).toBe(1);
+        expect(first.btn.classList.contains('playing')).toBe(false);
+        expect(second.btn.classList.contains('playing')).toBe(true);
+        expect(second.tr.nextElementSibling.className).toBe('video-preview-row');
+    });
+});
+
+describe('closeClipPreviewRow', () => {
+    beforeEach(() => {
+        document.body.innerHTML = '';
+    });
+
+    test('removes injected preview rows and resets their buttons', () => {
+        const { tr, btn } = makeClipRow('1_2_1', { videoId: 'abc' });
+        togglePlayClip(btn);
+        closeClipPreviewRow();
+        expect(tr.nextElementSibling).toBeNull();
+        expect(btn.classList.contains('playing')).toBe(false);
+        expect(btn.textContent).toBe('▶');
     });
 });


### PR DESCRIPTION
Saved intros in the "Your intros" table couldn't be previewed at the clip boundaries users had saved — URL rows only had an "open in a new tab" link (which drops the clip entirely) and file rows played the whole track. This adds:

- A ▶ button beside the ↗ link on YouTube rows. Clicking it injects an inline <tr class="video-preview-row"> below the row with a YouTube iframe seeded with start/end from the row's data attributes. Clicking ▶ again — or starting another intro — tears it back down.
- Clip-awareness in togglePlay for file rows: seek to data-start-ms before playing and auto-pause (+ rewind to start) when currentTime crosses data-end-ms via a one-shot timeupdate listener.

Also fixes a submit-gating bug left over from #252: when the user pasted a URL longer than 15s, previewState.tooLong and the "Video is too long" url-level error were set on first fetch but never cleared once the user entered a clip that fit under the cap. recomputeClipState now resyncs previewState.tooLong, the duration-badge styling, and clears the stale URL error so the Add intro button re-enables.

Tests: 10 new Jest cases covering togglePlay clip seek + auto-pause, togglePlayClip iframe injection / teardown / cross-row switching, and closeClipPreviewRow.