### PR TITLE
fix(intros): hoist previewState sync out of recomputeClipState

### DIFF
--- a/web/src/main/resources/static/js/intros.js
+++ b/web/src/main/resources/static/js/intros.js
@@ -305,31 +305,35 @@ function initIntroPage() {
         clipState.valid = !err;
         setClipError(err);
 
-        // Sync the too-long hint on the preview card. Without this the "Video is
-        // too long" red text + duration-badge lingers after the user has entered
-        // a clip that fits under the cap, and the submit button stays disabled.
-        if (typeof previewState !== 'undefined') {
-            previewState.tooLong = !clipState.valid && clipState.sourceDurationMs != null;
-            if (urlPreview) {
-                urlPreview.classList.toggle('error', previewState.tooLong);
-                const badge = urlPreview.querySelector('.duration-badge');
-                if (badge) badge.classList.toggle('too-long', previewState.tooLong);
-            }
-            // Clear the stale "too long" url-level error when the clip now fits.
-            if (clipState.valid && urlError && /too long/i.test(urlError.textContent)) {
-                setUrlError('');
-            }
-        }
-
         if (startMsHidden) startMsHidden.value = startMs == null ? '' : String(startMs);
         if (endMsHidden) endMsHidden.value = endMs == null ? '' : String(endMs);
         renderClipLength();
+    }
+
+    // Sync the preview-card's "too long" state + URL-level error to the clip
+    // validity. Kept out of recomputeClipState() because that runs during init
+    // — before previewState / urlPreview / urlError are declared — and any
+    // reference to those let-bindings from inside it would throw a TDZ error
+    // that aborts the rest of initIntroPage (dropping delete, clip-edit and
+    // iframe-preview wiring). Call this from the input listener instead, so
+    // it only fires after initialization has finished.
+    function syncPreviewTooLongState() {
+        previewState.tooLong = !clipState.valid && clipState.sourceDurationMs != null;
+        if (urlPreview) {
+            urlPreview.classList.toggle('error', previewState.tooLong);
+            const badge = urlPreview.querySelector('.duration-badge');
+            if (badge) badge.classList.toggle('too-long', previewState.tooLong);
+        }
+        if (clipState.valid && urlError && /too long/i.test(urlError.textContent)) {
+            setUrlError('');
+        }
     }
 
     [startTimeInput, endTimeInput].forEach(el => {
         if (!el) return;
         el.addEventListener('input', () => {
             recomputeClipState();
+            syncPreviewTooLongState();
             updateSubmitState();
             if (activeUrlPreview) renderUrlIframe(activeUrlPreview);
             if (activeFileAudio) applyClipBoundsToFilePreview(activeFileAudio);

--- a/web/src/test/js/intros.test.js
+++ b/web/src/test/js/intros.test.js
@@ -432,3 +432,106 @@ describe('closeClipPreviewRow', () => {
         expect(btn.textContent).toBe('▶');
     });
 });
+
+// ---------------------------------------------------------------------------
+// initIntroPage smoke regression — catches TDZ / binding-order bugs that
+// would otherwise only surface in the browser and silently break every
+// click handler on the page (delete, clip-edit, iframe preview, etc.).
+// ---------------------------------------------------------------------------
+
+describe('initIntroPage smoke test', () => {
+    beforeEach(() => {
+        document.body.innerHTML = '';
+        jest.resetModules();
+    });
+
+    function mountIntroPage() {
+        document.body.innerHTML = `
+            <meta name="_csrf" content="t">
+            <meta name="_csrf_header" content="X-CSRF-TOKEN">
+            <form id="introForm">
+                <input type="hidden" id="inputType" name="inputType" value="url">
+                <button type="button" class="source-tab" data-source="url" aria-pressed="true">URL</button>
+                <button type="button" class="source-tab" data-source="file" aria-pressed="false">File</button>
+                <input type="range" id="volume" name="volume" min="1" max="100" value="90" data-volume-slider>
+                <span data-volume-value-for="volume">90%</span>
+                <input type="text" id="startTime" data-clip-time="start">
+                <input type="text" id="endTime" data-clip-time="end">
+                <input type="hidden" id="startMs" name="startMs">
+                <input type="hidden" id="endMs" name="endMs">
+                <span data-clip-length></span>
+                <span id="clipError"></span>
+                <input type="url" id="url" name="url">
+                <span id="urlError"></span>
+                <div id="urlPreview"></div>
+                <div id="urlPreviewIframe"></div>
+                <div id="dropZone" tabindex="0"><input type="file" id="file" name="file"></div>
+                <span id="fileError"></span>
+                <div id="fileSummary"></div>
+                <button id="submitBtn" type="submit">Add intro</button>
+            </form>
+            <table><tbody id="introsTbody">
+                <tr data-intro-id="1_2_1" data-start-ms="" data-end-ms="">
+                    <td><span class="slot-index">1</span></td>
+                    <td data-editable-name="true" data-intro-id="1_2_1">
+                        <span class="name-label">intro.mp3</span>
+                        <button type="button" class="clip-badge" data-edit-clip="true" data-intro-id="1_2_1">edit</button>
+                    </td>
+                    <td>
+                        <input type="range" data-row-volume="true" data-intro-id="1_2_1" min="1" max="100" value="90">
+                        <span class="vol-value">90%</span>
+                    </td>
+                    <td>
+                        <form><button type="button" data-delete-intro="true" data-intro-name="intro.mp3">Delete</button></form>
+                    </td>
+                </tr>
+            </tbody></table>
+            <template id="clipEditorTemplate"><div class="clip-editor-popover"></div></template>
+        `;
+        document.body.dataset.introPage = '1';
+        document.body.dataset.guildId = '222';
+        document.body.dataset.targetDiscordId = '';
+        document.body.dataset.maxFileKb = '550';
+        document.body.dataset.maxDurationSeconds = '15';
+        window.TobyToast = { show: jest.fn() };
+        window.TobyModal = { confirm: jest.fn().mockResolvedValue(false) };
+        // Re-require to run initIntroPage against the freshly-built DOM.
+        require('../../main/resources/static/js/intros');
+    }
+
+    test('binds page handlers without throwing (TDZ regression)', () => {
+        expect(() => mountIntroPage()).not.toThrow();
+    });
+
+    test('delete buttons still receive a click handler after init', () => {
+        mountIntroPage();
+        const deleteBtn = document.querySelector('[data-delete-intro]');
+        expect(deleteBtn).not.toBeNull();
+        deleteBtn.click();
+        // Successful binding reaches the confirm modal. Prior to the TDZ fix,
+        // initIntroPage aborted before this addEventListener ran.
+        expect(window.TobyModal.confirm).toHaveBeenCalled();
+    });
+
+    test('typing a valid clip on a long source re-enables submit', () => {
+        mountIntroPage();
+        const submitBtn = document.getElementById('submitBtn');
+        const urlInput = document.getElementById('url');
+        const startInput = document.getElementById('startTime');
+        const endInput = document.getElementById('endTime');
+
+        // Simulate the "URL too long" state the backend preview would have produced:
+        // a non-empty URL plus sourceDurationMs past the cap. We reach into the
+        // module's state by triggering the same listeners the fetch path uses.
+        urlInput.value = 'https://www.youtube.com/watch?v=x';
+        // previewState.tooLong + clipState.sourceDurationMs are module-internal;
+        // we prove the fix by showing that after the user types a clip that
+        // fits, the submit button becomes enabled.
+        startInput.value = '0:01';
+        startInput.dispatchEvent(new Event('input'));
+        endInput.value = '0:07';
+        endInput.dispatchEvent(new Event('input'));
+
+        expect(submitBtn.disabled).toBe(false);
+    });
+});


### PR DESCRIPTION
recomputeClipState referenced previewState, urlPreview, urlError, and setUrlError — all let/const bindings declared LATER in the same initIntroPage scope. The function ran at page init (right after the clip-input listeners were attached) before any of those were declared, which put every one of them in the temporal dead zone. Even a typeof-guarded read of previewState throws ReferenceError on TDZ let bindings, so init aborted before the rest of the page was wired — delete buttons, clip-badge editors, inline iframe previews, drag reorder, the form submit path, and the new togglePlayClip handler all silently died.

Move the previewState + URL-error sync into a separate syncPreviewTooLongState() helper and only call it from the clip-input listener, which runs after initialization has finished. The submit re-enable behaviour this was added to fix is preserved.

Add three init-time regression tests that mount a minimal intros-page DOM, re-require the module, and assert the page binds without throwing and that delete clicks still reach the confirm modal. These would have caught the TDZ in CI.