### PR TITLE
chore(qodana): address highest-severity inspection findings

### DIFF
--- a/application/src/main/kotlin/Application.kt
+++ b/application/src/main/kotlin/Application.kt
@@ -1,3 +1,5 @@
+import database.configuration.CampaignShutdownHook
+import database.configuration.CampaignStartupHook
 import database.configuration.FlywayGuardConfig
 import org.springframework.boot.SpringApplication
 import org.springframework.boot.autoconfigure.SpringBootApplication
@@ -6,7 +8,7 @@ import org.springframework.context.annotation.Import
 
 @SpringBootApplication(scanBasePackages = ["bot", "common", "core", "database", "web"])
 @EnableCaching
-@Import(FlywayGuardConfig::class)
+@Import(FlywayGuardConfig::class, CampaignShutdownHook::class, CampaignStartupHook::class)
 class Application {
     companion object {
         @JvmStatic

--- a/application/src/main/kotlin/database/configuration/CampaignShutdownHook.kt
+++ b/application/src/main/kotlin/database/configuration/CampaignShutdownHook.kt
@@ -1,3 +1,5 @@
+package database.configuration
+
 import bot.toby.helpers.DnDHelper
 import com.fasterxml.jackson.databind.ObjectMapper
 import common.logging.DiscordLogger

--- a/application/src/main/kotlin/database/configuration/CampaignStartupHook.kt
+++ b/application/src/main/kotlin/database/configuration/CampaignStartupHook.kt
@@ -1,3 +1,5 @@
+package database.configuration
+
 import bot.toby.helpers.DnDHelper
 import bot.toby.helpers.InitiativeStateSnapshot
 import com.fasterxml.jackson.databind.ObjectMapper

--- a/database/build.gradle
+++ b/database/build.gradle
@@ -23,7 +23,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework:spring-jdbc'
     implementation 'org.springframework:spring-orm'
-    implementation 'org.apache.commons:commons-lang3:3.13.0'
+    implementation 'org.apache.commons:commons-lang3:3.18.0'
     runtimeOnly 'org.hibernate.orm:hibernate-core:6.6.1.Final'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation project(configuration: 'testArtifacts', path: ':common')

--- a/discord-bot/build.gradle
+++ b/discord-bot/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3")
     testImplementation "io.ktor:ktor-client-mock:$ktor_version"
     implementation 'org.springframework:spring-context'
-    implementation 'org.jsoup:jsoup:1.15.3'
+    implementation 'org.jsoup:jsoup:1.18.3'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinx_version"
     implementation "dev.lavalink.youtube:common:$youtube_common_version"

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/misc/EightBallCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/misc/EightBallCommand.kt
@@ -47,7 +47,7 @@ class EightBallCommand @Autowired constructor(private val userService: UserServi
             userService.updateUser(requestingUserDto)
             return
         }
-        event.hook.sendMessage("MAGIC 8-BALL SAYS: ${response}.").queue(invokeDeleteOnMessageResponse(deleteDelay))
+        event.hook.sendMessage("MAGIC 8-BALL SAYS: $response.").queue(invokeDeleteOnMessageResponse(deleteDelay))
     }
 
     override val name: String

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/misc/UserInfoCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/misc/UserInfoCommand.kt
@@ -48,7 +48,7 @@ class UserInfoCommand @Autowired constructor(private val userDtoHelper: UserDtoH
         logger.info { " Doing lookup on user for guildId '${this.guild.idLong}' and discordId '${this.idLong}' " }
         val userSearched = userDtoHelper.calculateUserDto(this.idLong, this.guild.idLong)
         val userInfoMessage = userSearched.let {
-            logger.info { " Found user '${it}' from lookup " }
+            logger.info { " Found user '$it' from lookup " }
             val introMessage = produceMusicFileDataStringForPrinting(event.member!!, userSearched)
             "Here are the permissions for '${this.effectiveName}': '${userSearched.getPermissionsAsString()}'. \n $introMessage"
         }

--- a/web/src/main/kotlin/web/controller/IntroWebController.kt
+++ b/web/src/main/kotlin/web/controller/IntroWebController.kt
@@ -347,7 +347,7 @@ data class PreviewResponse(
     val error: String?
 )
 
-data class DeletedIntroSnapshot(
+class DeletedIntroSnapshot(
     val id: String,
     val index: Int,
     val fileName: String?,


### PR DESCRIPTION
## Summary

Targets the top-severity problems in the current Qodana JVM report (37 total on PR #256). Not a full sweep — focuses on the items that are either real correctness bugs or safe mechanical fixes.

### Fixes

- **Invalid Spring Boot application setup (🔴 Failure)** — `CampaignShutdownHook` and `CampaignStartupHook` were in the default package, so `@SpringBootApplication(scanBasePackages = ["bot", "common", "core", "database", "web"])` never picked them up. Same bug that #244 fixed for `FlywayGuardConfig` / `CampaignEventListener`: shutdown was not persisting initiative state and the startup restore never ran. Moved both under `database.configuration` and `@Import`ed them on `Application` as belt-and-braces.
- **Vulnerable declared dependency (🔶 Warning + ◽ Notice)** — bumped `commons-lang3` 3.13.0 → 3.18.0 and `jsoup` 1.15.3 → 1.18.3.
- **Array property in data class (🔶 Warning)** — `DeletedIntroSnapshot` held a `ByteArray` but was a `data class`; auto-generated `equals`/`hashCode` would compare the blob by reference. It's only ever session-stored, so dropped `data` since we don't need value semantics.
- **Redundant curly braces in string template (◽ Notice)** — two occurrences (`EightBallCommand`, `UserInfoCommand`).

### Not addressed in this PR

- `Application.kt` itself is still in the default package. Moving it would require updating 9 `@SpringBootTest(classes = [Application::class])` imports and the `bootJar { mainClass }` reference — happy to do it in a follow-up if the noise is worth it.
- "Unused symbol" warnings (16) are mostly public helpers kept for tests / potential callers — needs a case-by-case review.
- Duplicated code fragments / range-check / SAM constructor notices — left alone pending confirmation on exact Qodana locations.

## Test plan
- [ ] CI build passes (compile, tests)
- [ ] Qodana scan re-runs and the three Failure-severity findings drop (or at least the Spring Boot one does)
- [ ] Deploy sanity check: shutdown/startup campaign state persistence now actually fires

https://claude.ai/code/session_01QBEC7FZ5YBKdWgaSf418oT

---
_Generated by [Claude Code](https://claude.ai/code/session_01QBEC7FZ5YBKdWgaSf418oT)_