### PR TITLE
fix(intros): recognise YouTube Shorts URLs so preview/play/clip work

### DIFF
--- a/application/src/test/kotlin/web/service/IntroWebServiceTest.kt
+++ b/application/src/test/kotlin/web/service/IntroWebServiceTest.kt
@@ -179,6 +179,46 @@ class IntroWebServiceTest {
         assertEquals(youtubeUrl, result[0].url)
     }
 
+    @Test
+    fun `getUserIntros extracts videoId for YouTube Shorts URL so play-clip button renders`() {
+        val shortsUrl = "https://www.youtube.com/shorts/dQw4w9WgXcQ"
+        val intro = MusicDto(
+            id = "${guildId}_${discordId}_1",
+            index = 1,
+            fileName = "My Shorts Clip",
+            musicBlob = shortsUrl.toByteArray()
+        )
+        val user = UserDto(discordId = discordId, guildId = guildId).apply {
+            musicDtos = mutableListOf(intro)
+        }
+        every { userService.getUserById(discordId, guildId) } returns user
+
+        val result = service.getUserIntros(discordId, guildId)
+        assertEquals(1, result.size)
+        assertEquals(shortsUrl, result[0].url)
+        assertEquals("dQw4w9WgXcQ", result[0].videoId)
+        assertEquals("https://img.youtube.com/vi/dQw4w9WgXcQ/mqdefault.jpg", result[0].thumbnailUrl)
+    }
+
+    @Test
+    fun `getUserIntros extracts videoId for Shorts URL carrying query params`() {
+        val shortsUrl = "https://www.youtube.com/shorts/dQw4w9WgXcQ?si=abc123"
+        val intro = MusicDto(
+            id = "${guildId}_${discordId}_1",
+            index = 1,
+            fileName = "Shorts with query",
+            musicBlob = shortsUrl.toByteArray()
+        )
+        val user = UserDto(discordId = discordId, guildId = guildId).apply {
+            musicDtos = mutableListOf(intro)
+        }
+        every { userService.getUserById(discordId, guildId) } returns user
+
+        val result = service.getUserIntros(discordId, guildId)
+        assertEquals(1, result.size)
+        assertEquals("dQw4w9WgXcQ", result[0].videoId)
+    }
+
     // setIntroByUrl
 
     @Test

--- a/discord-bot/src/main/kotlin/bot/toby/helpers/HttpHelper.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/helpers/HttpHelper.kt
@@ -75,7 +75,7 @@ class HttpHelper(
 
     // Helper function to extract video ID from YouTube URL
     private fun extractVideoIdFromUrl(url: String): String? {
-        val regex = Regex("(?<=v=|/videos/|embed/|youtu.be/|/v/|/e/|watch\\?v=|&v=|^youtu\\.be/)([^#&?\\n]+)")
+        val regex = Regex("(?<=v=|/videos/|embed/|youtu\\.be/|/v/|/e/|watch\\?v=|&v=|^youtu\\.be/|/shorts/)([^#&?\\n]+)")
         return regex.find(url)?.value
     }
 

--- a/discord-bot/src/test/kotlin/bot/toby/helpers/HttpHelperTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/helpers/HttpHelperTest.kt
@@ -221,4 +221,11 @@ internal class HttpHelperTest {
         val result = httpClient.getYouTubeVideoTitle(PERSONA_VIDEO_URL)
         assertEquals("WOW. THIS IS GIVING ME MAJOR PERSONA VIBES.", result)
     }
+
+    @Test
+    fun `getYouTubeVideoTitle returns title for YouTube Shorts URL`() = runBlocking {
+        val httpClient = createYouTubeMockHttpClient()
+        val result = httpClient.getYouTubeVideoTitle("https://www.youtube.com/shorts/dQw4w9WgXcQ")
+        assertEquals("Never Gonna Give You Up", result)
+    }
 }

--- a/web/src/main/kotlin/web/service/IntroWebService.kt
+++ b/web/src/main/kotlin/web/service/IntroWebService.kt
@@ -377,7 +377,7 @@ class IntroWebService(
     fun getYouTubeVideoTitle(url: String): String? = fetchYouTubePreview(url)?.title
 
     private fun extractVideoId(url: String): String? {
-        val regex = Regex("(?<=v=|/videos/|embed/|youtu\\.be/|/v/|/e/|watch\\?v=|&v=|^youtu\\.be/)([^#&?\\n]+)")
+        val regex = Regex("(?<=v=|/videos/|embed/|youtu\\.be/|/v/|/e/|watch\\?v=|&v=|^youtu\\.be/|/shorts/)([^#&?\\n]+)")
         return regex.find(url)?.value
     }
 


### PR DESCRIPTION
## Summary
- The video-ID extraction regex in `IntroWebService.extractVideoId` and `HttpHelper.extractVideoIdFromUrl` missed the `/shorts/` path segment, so pasting a YouTube Shorts URL into the intro form produced `videoId = null`. That cascaded into: the URL-input preview iframe never mounting, the trim bar staying disabled, and the row-level ▶ Play Clip button being hidden (the template gates it on `videoId != null`). The Discord bot already had a `convertShortsUrls` workaround in `IntroHelper`, but the web path never applied it and the HTTP-side title/duration lookup had the same gap.
- Fix: add `|/shorts/` to the lookbehind alternation in both regexes. The extracted ID feeds directly into the `/embed/<id>` iframe, the YouTube Data API, and the thumbnail URL, so the one change lights up preview, trim bar, title/duration lookup, thumbnail, and the Play Clip button simultaneously. Also escaped the stray `youtu.be/` → `youtu\.be/` in `HttpHelper` while in there.
- Stored URL format is unchanged: we keep the user's original URL and only derive the ID via regex, mirroring how other YouTube URL variants are handled today.

## Test plan
- [x] New unit test `getUserIntros extracts videoId for YouTube Shorts URL so play-clip button renders` — feeds a Shorts URL through `getUserIntros` and asserts `IntroViewModel.videoId`, `url`, and `thumbnailUrl` are populated.
- [x] New unit test `getUserIntros extracts videoId for Shorts URL carrying query params` — covers `?si=…` tracking suffixes.
- [x] New unit test `getYouTubeVideoTitle returns title for YouTube Shorts URL` in `HttpHelperTest` — proves the Discord-bot-side lookup also extracts the ID correctly (reuses the existing `YOUTUBE_SNIPPET_API_URL` mock, which is keyed on `dQw4w9WgXcQ`).
- [ ] CI runs the full test suite. **Local note:** tests couldn't be run in the sandbox because `dev.lavalink.youtube` / `moe.kyokobot.libdave` / Spring artifact repos return 403 here, so dependency resolution fails before tests start. Fix is mechanical (single alternation added) and existing regex already used variable-width alternatives, so the engine path is unchanged.
- [ ] Manual smoke test once deployed: paste `https://www.youtube.com/shorts/<id>`, confirm preview iframe mounts + trim bar activates + submit works; reload and confirm the row's ▶ Play Clip button is present and plays within saved clip bounds.
- [ ] Regression check: repeat with a standard `watch?v=…` URL and a `youtu.be/…` URL.

https://claude.ai/code/session_017h3jxWJTDeZRxTkMRkF4Vd

---
_Generated by [Claude Code](https://claude.ai/code/session_017h3jxWJTDeZRxTkMRkF4Vd)_