### PR TITLE
fix(bot): cache all guild members so moderation UI sees offline users

### DIFF
--- a/discord-bot/src/main/kotlin/bot/configuration/BotConfig.kt
+++ b/discord-bot/src/main/kotlin/bot/configuration/BotConfig.kt
@@ -10,6 +10,7 @@ import net.dv8tion.jda.api.JDA
 import net.dv8tion.jda.api.JDABuilder
 import net.dv8tion.jda.api.audio.AudioModuleConfig
 import net.dv8tion.jda.api.requests.GatewayIntent
+import net.dv8tion.jda.api.utils.ChunkingFilter
 import net.dv8tion.jda.api.utils.MemberCachePolicy
 import net.dv8tion.jda.api.utils.cache.CacheFlag
 import org.springframework.context.annotation.Bean
@@ -43,7 +44,8 @@ class BotConfig {
             GatewayIntent.GUILD_VOICE_STATES,
             GatewayIntent.GUILD_EXPRESSIONS
         )
-            .setMemberCachePolicy(MemberCachePolicy.VOICE)
+            .setMemberCachePolicy(MemberCachePolicy.ALL)
+            .setChunkingFilter(ChunkingFilter.ALL)
             .disableCache(
                 EnumSet.of(
                     CacheFlag.CLIENT_STATUS,


### PR DESCRIPTION
## Summary

Fixes three symptoms on the new `/moderation/{guildId}` page that share one root cause:

- **Users tab was empty** even with ~20 guild members, when nobody was in a voice channel.
- **Social Credit leaderboard** showed `Unknown` in the Name column for every row.
- **Server owner couldn't change the Config tab** — save buttons were disabled, and the backend would have rejected the POST with "Only the server owner can change guild config."

Root cause: `BotConfig.kt` set `MemberCachePolicy.VOICE` with no chunking filter, so JDA only cached members currently in voice. `ModerationWebService` reads exclusively from the JDA cache:

- `getGuildOverview()` → `guild.members.filter { !it.user.isBot }` → empty.
- `isOwner()` → `guild.getMemberById(ownerId)?.isOwner` → null → owner treated as non-owner, and `th:disabled="${!isOwner}"` disabled the save buttons.
- `getLeaderboard()` → `guild.getMemberById(dto.discordId)` → null → name fallback of `"Unknown"`.

Fix: switch to `MemberCachePolicy.ALL` + `ChunkingFilter.ALL` so JDA requests the full member list for every guild on gateway connect. The `GUILD_MEMBERS` privileged intent was already enabled, so no Discord Developer Portal changes are required.

## Test plan

- [ ] `./gradlew :discord-bot:build :web:build` compiles and passes existing tests.
- [ ] Start the bot, wait for JDA to finish chunking guilds on startup.
- [ ] Log in as the guild owner and open `/moderation/{guildId}` with nobody in voice:
  - [ ] Users tab lists all ~20 members (including offline), with avatars and permission toggles.
  - [ ] Config tab inputs and save buttons are **enabled**; saving Volume returns no error and persists after refresh.
  - [ ] Social Credit tab rows show real effective names/avatars instead of `Unknown`.

https://claude.ai/code/session_01QRXoQyfD6gd3PFS6mFWDQK

---
_Generated by [Claude Code](https://claude.ai/code/session_01QRXoQyfD6gd3PFS6mFWDQK)_