### PR TITLE
Mobile permission labels + derive initiative from character sheet

### DIFF
--- a/application/src/test/kotlin/web/service/CampaignWebServiceTest.kt
+++ b/application/src/test/kotlin/web/service/CampaignWebServiceTest.kt
@@ -48,6 +48,7 @@ class CampaignWebServiceTest {
     private lateinit var initiativeStore: InitiativeStore
     private lateinit var sessionLog: SessionLogPublisher
     private lateinit var jda: JDA
+    private lateinit var initiativeResolver: InitiativeResolver
     private lateinit var service: CampaignWebService
 
     private val guildId = 100L
@@ -78,6 +79,7 @@ class CampaignWebServiceTest {
         initiativeStore = mockk(relaxed = true)
         sessionLog = mockk(relaxed = true)
         jda = mockk(relaxed = true)
+        initiativeResolver = mockk(relaxed = true)
         service = CampaignWebService(
             campaignService,
             campaignPlayerService,
@@ -92,7 +94,8 @@ class CampaignWebServiceTest {
             encounterEntryService,
             initiativeStore,
             sessionLog,
-            jda
+            jda,
+            initiativeResolver
         )
     }
 
@@ -1153,9 +1156,9 @@ class CampaignWebServiceTest {
     @Test
     fun `rollInitiative seeds store and publishes INITIATIVE_ROLLED`() {
         every { campaignService.getActiveCampaignForGuild(guildId) } returns makeCampaign()
-        every { userService.getUserById(playerDiscordId, guildId) } returns UserDto(playerDiscordId, guildId).apply {
-            initiativeModifier = 3
-        }
+        val player = UserDto(playerDiscordId, guildId)
+        every { userService.getUserById(playerDiscordId, guildId) } returns player
+        every { initiativeResolver.resolve(player) } returns 3
         every { monsterTemplateService.getById(77L) } returns MonsterTemplateDto(
             id = 77L, dmDiscordId = dmDiscordId, name = "Goblin", initiativeModifier = 2
         )

--- a/database/src/main/kotlin/database/dto/UserDto.kt
+++ b/database/src/main/kotlin/database/dto/UserDto.kt
@@ -45,9 +45,6 @@ class UserDto(
     @Column(name = "social_credit")
     var socialCredit: Long? = 0L,
 
-    @Column(name = "initiative")
-    var initiativeModifier: Int? = 0,
-
     @Column(name = "dnd_beyond_character_id")
     var dndBeyondCharacterId: Long? = null,
 

--- a/database/src/main/resources/db/migration/V12__remove_user_initiative_column.sql
+++ b/database/src/main/resources/db/migration/V12__remove_user_initiative_column.sql
@@ -1,0 +1,5 @@
+-- Initiative is now derived from the linked D&D Beyond character sheet's
+-- DEX modifier rather than stored on the user. Drop the legacy column.
+
+ALTER TABLE public."user"
+    DROP COLUMN IF EXISTS initiative;

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/dnd/LinkCharacterCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/dnd/LinkCharacterCommand.kt
@@ -55,7 +55,6 @@ class LinkCharacterCommand @Autowired constructor(
 
             if (cachedSheet != null) {
                 val dexMod = cachedSheet.modifier(CharacterSheet.DEX)
-                requestingUserDto.initiativeModifier = dexMod
                 userDtoHelper.updateUser(requestingUserDto)
 
                 val embed = EmbedBuilder()

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/moderation/AdjustUserCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/moderation/AdjustUserCommand.kt
@@ -67,18 +67,15 @@ class AdjustUserCommand @Autowired constructor(
         deleteDelay: Int
     ) {
         val permission = event.getOption(PERMISSION_NAME)?.asString
-        val modifier = event.getOption(MODIFIER)?.asInt
 
-        if (permission == null && modifier == null) {
+        if (permission == null) {
             event.hook.sendMessage("You did not mention a valid permission to update")
                 .setEphemeral(true)
                 .queue(invokeDeleteOnMessageResponse(deleteDelay))
             return
         }
 
-        modifier?.let { targetUserDto.initiativeModifier = it }
-
-        permission?.uppercase()?.let {
+        permission.uppercase().let {
             when (UserDto.Permissions.valueOf(it)) {
                 UserDto.Permissions.MUSIC -> targetUserDto.musicPermission =
                     !targetUserDto.musicPermission
@@ -159,13 +156,11 @@ class AdjustUserCommand @Autowired constructor(
                     UserDto.Permissions.SUPERUSER.name
                 )
             }
-            val initiative = OptionData(OptionType.INTEGER, MODIFIER, "modifier for the initiative command when used on your user")
-            return listOf(userOption, permission, initiative)
+            return listOf(userOption, permission)
         }
 
     companion object {
         private const val PERMISSION_NAME = "name"
         private const val USERS = "users"
-        const val MODIFIER = "modifier"
     }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/helpers/DnDHelper.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/helpers/DnDHelper.kt
@@ -14,11 +14,15 @@ import net.dv8tion.jda.api.interactions.InteractionHook
 import net.dv8tion.jda.api.components.actionrow.ActionRow
 import net.dv8tion.jda.api.components.buttons.Button
 import org.springframework.stereotype.Service
+import web.service.InitiativeResolver
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.random.Random
 
 @Service
-class DnDHelper(private val userDtoHelper: UserDtoHelper) {
+class DnDHelper(
+    private val userDtoHelper: UserDtoHelper,
+    private val initiativeResolver: InitiativeResolver
+) {
 
     private val logger = DiscordLogger(this::class.java)
     private val states: ConcurrentHashMap<Long, InitiativeState> = ConcurrentHashMap()
@@ -62,7 +66,7 @@ class DnDHelper(private val userDtoHelper: UserDtoHelper) {
         val nonDmMembers = memberList.filter { it != dm }.nonBots()
         nonDmMembers.forEach { target ->
             val userDto = userDtoHelper.calculateUserDto(target.idLong, target.guild.idLong, target.isOwner)
-            rollAndAddToMap(initiativeMap, target.user.effectiveName, userDto.initiativeModifier ?: 0)
+            rollAndAddToMap(initiativeMap, target.user.effectiveName, initiativeResolver.resolve(userDto) ?: 0)
         }
         stateFor(guildId).sortMap(initiativeMap)
     }

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/dnd/DnDCommandQueryHandlerTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/dnd/DnDCommandQueryHandlerTest.kt
@@ -8,6 +8,7 @@ import bot.toby.command.commands.fetch.TestHttpHelperHelper.FIREBALL_INITIAL_RES
 import bot.toby.helpers.DnDHelper
 import bot.toby.helpers.HttpHelper
 import bot.toby.helpers.UserDtoHelper
+import web.service.InitiativeResolver
 import io.mockk.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -36,7 +37,7 @@ class DnDCommandQueryHandlerTest {
     fun setUp() {
         userDtoHelper = mockk(relaxed = true)
         httpHelper = mockk(relaxed = true)
-        dndHelper = DnDHelper(userDtoHelper)
+        dndHelper = DnDHelper(userDtoHelper, mockk<InitiativeResolver>(relaxed = true))
 
     }
 

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/dnd/InitiativeCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/dnd/InitiativeCommandTest.kt
@@ -11,6 +11,7 @@ import bot.toby.command.CommandTest.Companion.webhookMessageCreateAction
 import bot.toby.command.DefaultCommandContext
 import bot.toby.helpers.DnDHelper
 import bot.toby.helpers.UserDtoHelper
+import web.service.InitiativeResolver
 import database.service.UserService
 import io.mockk.*
 import net.dv8tion.jda.api.components.actionrow.ActionRow
@@ -39,7 +40,7 @@ internal class InitiativeCommandTest : CommandTest {
     fun setup() {
         setUpCommonMocks()
         userDtoHelper = mockk()
-        dndHelper = DnDHelper(userDtoHelper)
+        dndHelper = DnDHelper(userDtoHelper, mockk<InitiativeResolver>(relaxed = true))
         initiativeCommand = InitiativeCommand(dndHelper, mockk(relaxed = true))
         channelOption = mockk<OptionMapping>()
         initButtons = dndHelper.initButtons

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/dnd/LinkCharacterCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/dnd/LinkCharacterCommandTest.kt
@@ -52,7 +52,6 @@ class LinkCharacterCommandTest : CommandTest {
         userDtoHelper = mockk(relaxed = true)
         every { event.deferReply(true) } returns replyCallbackAction
         every { requestingUserDto.dndBeyondCharacterId = any() } just Runs
-        every { requestingUserDto.initiativeModifier = any() } just Runs
         command = LinkCharacterCommand(dispatcher, characterSheetProvider, userDtoHelper)
     }
 
@@ -62,7 +61,7 @@ class LinkCharacterCommandTest : CommandTest {
     }
 
     @Test
-    fun `valid dndbeyond URL links character and syncs DEX modifier`() = runTest {
+    fun `valid dndbeyond URL links character and shows DEX modifier in embed`() = runTest {
         val optionMapping = mockk<OptionMapping>()
         every { event.getOption(LinkCharacterCommand.CHARACTER) } returns optionMapping
         every { optionMapping.asString } returns "https://www.dndbeyond.com/characters/48690485"
@@ -72,7 +71,6 @@ class LinkCharacterCommandTest : CommandTest {
 
         coVerify { characterSheetProvider.getCharacterSheet(48690485L) }
         verify { requestingUserDto.dndBeyondCharacterId = 48690485L }
-        verify { requestingUserDto.initiativeModifier = 2 } // DEX 14 -> +2
         verify { userDtoHelper.updateUser(requestingUserDto) }
         verify { event.hook.sendMessageEmbeds(any(), *anyVararg()) }
     }

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/dnd/RollCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/dnd/RollCommandTest.kt
@@ -6,6 +6,7 @@ import bot.toby.command.CommandTest.Companion.webhookMessageCreateAction
 import bot.toby.command.DefaultCommandContext
 import bot.toby.helpers.DnDHelper
 import bot.toby.helpers.UserDtoHelper
+import web.service.InitiativeResolver
 import common.events.CampaignEventType
 import io.mockk.every
 import io.mockk.mockk
@@ -30,7 +31,7 @@ class RollCommandTest : CommandTest {
     fun setUp() {
         setUpCommonMocks()
         userDtoHelper = mockk()
-        dndHelper = DnDHelper(userDtoHelper)
+        dndHelper = DnDHelper(userDtoHelper, mockk<InitiativeResolver>(relaxed = true))
         sessionLog = mockk(relaxed = true)
         every { event.hook.sendMessageEmbeds(any(), *anyVararg()) } returns webhookMessageCreateAction
         rollCommand = RollCommand(dndHelper, sessionLog)

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/misc/EightBallCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/misc/EightBallCommandTest.kt
@@ -55,8 +55,7 @@ internal class EightBallCommandTest : CommandTest {
             musicPermission = true,
             digPermission = true,
             memePermission = true,
-            socialCredit = 0L,
-            initiativeModifier = 0
+            socialCredit = 0L
         ) // You can set the user as needed
         val deleteDelay = 0 // Set your desired deleteDelay
 

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/misc/UserInfoCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/misc/UserInfoCommandTest.kt
@@ -47,7 +47,6 @@ class UserInfoCommandTest : CommandTest {
             digPermission = true,
             memePermission = true,
             socialCredit = 0,
-            initiativeModifier = 0,
             musicDtos = emptyList<MusicDto>().toMutableList()
         )
         every { userDtoHelper.calculateUserDto(any(), any()) } returns userDto
@@ -78,7 +77,6 @@ class UserInfoCommandTest : CommandTest {
             digPermission = true,
             memePermission = true,
             socialCredit = 0,
-            initiativeModifier = 0,
             musicDtos = emptyList<MusicDto>().toMutableList()
         )
 

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/moderation/AdjustUserCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/moderation/AdjustUserCommandTest.kt
@@ -43,7 +43,6 @@ internal class AdjustUserCommandTest : CommandTest {
         val targetUserDto = mockk<database.dto.UserDto>(relaxed = true)
         val userOptionMapping = mockk<OptionMapping>()
         val permissionOptionMapping = mockk<OptionMapping>()
-        val modifier = mockk<OptionMapping>()
         val mentions = mockk<Mentions>()
 
         every { userService.getUserById(any(), any()) } returns targetUserDto
@@ -51,11 +50,9 @@ internal class AdjustUserCommandTest : CommandTest {
         every { targetUserDto.guildId } returns 1L
         every { event.getOption("users") } returns userOptionMapping
         every { event.getOption("name") } returns permissionOptionMapping
-        every { event.getOption("modifier") } returns modifier
         every { userOptionMapping.mentions } returns mentions
         every { permissionOptionMapping.asString } returns database.dto.UserDto.Permissions.MUSIC.name
         every { mentions.members } returns listOf(targetMember)
-        every { modifier.asInt } returns 1
 
         // Act
         adjustUserCommand.handle(commandContext, requestingUserDto, 0)

--- a/discord-bot/src/test/kotlin/bot/toby/helpers/DnDHelperTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/helpers/DnDHelperTest.kt
@@ -23,6 +23,7 @@ import net.dv8tion.jda.api.requests.restaction.AuditableRestAction
 import net.dv8tion.jda.api.requests.restaction.MessageEditAction
 import net.dv8tion.jda.api.requests.restaction.WebhookMessageCreateAction
 import net.dv8tion.jda.api.requests.restaction.WebhookMessageEditAction
+import web.service.InitiativeResolver
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
@@ -41,6 +42,7 @@ internal class DnDHelperTest {
     lateinit var memberList: List<Member>
     lateinit var initiativeMap: MutableMap<String, Int>
     lateinit var userDtoHelper: UserDtoHelper
+    lateinit var initiativeResolver: InitiativeResolver
     lateinit var dndHelper: DnDHelper
 
     private val guildId = 1L
@@ -59,7 +61,8 @@ internal class DnDHelperTest {
         memberList = mockk()
         initiativeMap = mutableMapOf()
         userDtoHelper = mockk()
-        dndHelper = DnDHelper(userDtoHelper)
+        initiativeResolver = mockk()
+        dndHelper = DnDHelper(userDtoHelper, initiativeResolver)
 
         val player1 = mockk<Member>()
         val player2 = mockk<Member>()
@@ -120,9 +123,9 @@ internal class DnDHelperTest {
         every { userDto1.guildId } returns 1L
         every { userDto2.guildId } returns 1L
         every { userDto3.guildId } returns 1L
-        every { userDto1.initiativeModifier } returns 0
-        every { userDto2.initiativeModifier } returns 1
-        every { userDto3.initiativeModifier } returns 2
+        every { initiativeResolver.resolve(userDto1) } returns 0
+        every { initiativeResolver.resolve(userDto2) } returns 1
+        every { initiativeResolver.resolve(userDto3) } returns 2
 
         every { userService.listGuildUsers(any()) } returns listOf(userDto1, userDto2, userDto3)
         every { userDtoHelper.calculateUserDto(1L, 1L) } returns userDto1

--- a/discord-bot/src/test/kotlin/bot/toby/menu/menus/dnd/DndApiCoroutineHandlerTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/menu/menus/dnd/DndApiCoroutineHandlerTest.kt
@@ -8,6 +8,7 @@ import bot.toby.command.commands.fetch.TestHttpHelperHelper.GRAPPLED_INITIAL_RES
 import bot.toby.helpers.DnDHelper
 import bot.toby.helpers.HttpHelper
 import bot.toby.helpers.UserDtoHelper
+import web.service.InitiativeResolver
 import io.mockk.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -34,7 +35,7 @@ class DndApiCoroutineHandlerTest {
     fun setup() {
         httpHelper = mockk(relaxed = true)
         userDtoHelper = mockk(relaxed = true)
-        dndHelper = DnDHelper(userDtoHelper)
+        dndHelper = DnDHelper(userDtoHelper, mockk<InitiativeResolver>(relaxed = true))
     }
 
     @AfterEach

--- a/web/src/main/kotlin/web/controller/ModerationController.kt
+++ b/web/src/main/kotlin/web/controller/ModerationController.kt
@@ -96,21 +96,6 @@ class ModerationController(
         else ResponseEntity.ok(ApiResult(true, null))
     }
 
-    @PostMapping("/{guildId}/user/{targetDiscordId}/initiative", consumes = ["application/json"])
-    @ResponseBody
-    fun setInitiative(
-        @PathVariable guildId: Long,
-        @PathVariable targetDiscordId: Long,
-        @RequestBody body: InitiativeRequest,
-        @AuthenticationPrincipal user: OAuth2User
-    ): ResponseEntity<ApiResult> {
-        val actor = user.discordIdOrNull()
-            ?: return ResponseEntity.status(401).body(ApiResult(false, "Not signed in."))
-        val error = moderationWebService.setInitiativeModifier(actor, guildId, targetDiscordId, body.modifier)
-        return if (error != null) ResponseEntity.badRequest().body(ApiResult(false, error))
-        else ResponseEntity.ok(ApiResult(true, null))
-    }
-
     @PostMapping("/{guildId}/user/{targetDiscordId}/social-credit", consumes = ["application/json"])
     @ResponseBody
     fun adjustSocialCredit(
@@ -205,7 +190,6 @@ class ModerationController(
 }
 
 data class PermissionRequest(val permission: String = "")
-data class InitiativeRequest(val modifier: Int = 0)
 data class SocialCreditRequest(val delta: Long = 0)
 data class ConfigRequest(val key: String = "", val value: String = "")
 data class KickRequest(val targetDiscordId: Long = 0, val reason: String? = null)

--- a/web/src/main/kotlin/web/service/CampaignWebService.kt
+++ b/web/src/main/kotlin/web/service/CampaignWebService.kt
@@ -245,7 +245,8 @@ class CampaignWebService(
     private val encounterEntryService: EncounterEntryService,
     private val initiativeStore: InitiativeStore,
     private val sessionLog: SessionLogPublisher,
-    private val jda: JDA
+    private val jda: JDA,
+    private val initiativeResolver: InitiativeResolver
 ) {
 
     private val objectMapper = ObjectMapper()
@@ -1261,7 +1262,7 @@ class CampaignWebService(
         val entries = mutableListOf<InitiativeEntryData>()
 
         request.playerDiscordIds.forEach { playerDiscordId ->
-            val modifier = userService.getUserById(playerDiscordId, guildId)?.initiativeModifier ?: 0
+            val modifier = userService.getUserById(playerDiscordId, guildId)?.let { initiativeResolver.resolve(it) } ?: 0
             val displayName = resolveMemberName(guildId, playerDiscordId) ?: "Player $playerDiscordId"
             entries += InitiativeEntryData(
                 name = displayName,

--- a/web/src/main/kotlin/web/service/InitiativeResolver.kt
+++ b/web/src/main/kotlin/web/service/InitiativeResolver.kt
@@ -1,0 +1,31 @@
+package web.service
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import database.dto.UserDto
+import database.service.CharacterSheetService
+import org.springframework.stereotype.Service
+
+@Service
+class InitiativeResolver(
+    private val characterSheetService: CharacterSheetService
+) {
+    private val mapper = ObjectMapper()
+
+    /** DEX modifier from the user's linked & cached character sheet, or null when unavailable. */
+    fun resolve(userDto: UserDto): Int? {
+        val characterId = userDto.dndBeyondCharacterId ?: return null
+        val json = characterSheetService.getSheet(characterId) ?: return null
+        return runCatching {
+            val statsNode = mapper.readTree(json).get("stats") ?: return@runCatching null
+            if (!statsNode.isArray) return@runCatching null
+            val dexNode = statsNode.firstOrNull { it.get("id")?.asInt() == DEX_STAT_ID }
+                ?: return@runCatching null
+            val dexValue = dexNode.get("value")?.asInt() ?: 10
+            Math.floorDiv(dexValue - 10, 2)
+        }.getOrNull()
+    }
+
+    companion object {
+        private const val DEX_STAT_ID = 2
+    }
+}

--- a/web/src/main/kotlin/web/service/ModerationWebService.kt
+++ b/web/src/main/kotlin/web/service/ModerationWebService.kt
@@ -16,7 +16,8 @@ class ModerationWebService(
     private val jda: JDA,
     private val userService: UserService,
     private val configService: ConfigService,
-    private val introWebService: IntroWebService
+    private val introWebService: IntroWebService,
+    private val initiativeResolver: InitiativeResolver
 ) {
     companion object {
         const val MAX_POLL_OPTIONS = 10
@@ -63,7 +64,7 @@ class ModerationWebService(
                 memePermission = dto?.memePermission ?: true,
                 digPermission = dto?.digPermission ?: true,
                 superUser = dto?.superUser ?: false,
-                initiativeModifier = dto?.initiativeModifier ?: 0
+                initiativeModifier = dto?.let { initiativeResolver.resolve(it) }
             )
         }.sortedBy { it.name.lowercase() }
 
@@ -139,21 +140,6 @@ class ModerationWebService(
             UserDto.Permissions.DIG -> target.digPermission = !target.digPermission
             UserDto.Permissions.SUPERUSER -> target.superUser = !target.superUser
         }
-        userService.updateUser(target)
-        return null
-    }
-
-    fun setInitiativeModifier(
-        actorDiscordId: Long,
-        guildId: Long,
-        targetDiscordId: Long,
-        modifier: Int
-    ): String? {
-        if (!canModerate(actorDiscordId, guildId)) return "You are not allowed to moderate this server."
-        if (modifier !in -20..20) return "Modifier must be between -20 and 20."
-        val target = userService.getUserById(targetDiscordId, guildId)
-            ?: UserDto(discordId = targetDiscordId, guildId = guildId).also { userService.createNewUser(it) }
-        target.initiativeModifier = modifier
         userService.updateUser(target)
         return null
     }
@@ -392,7 +378,7 @@ data class ModeratedMember(
     val memePermission: Boolean,
     val digPermission: Boolean,
     val superUser: Boolean,
-    val initiativeModifier: Int
+    val initiativeModifier: Int?
 )
 
 data class VoiceChannelInfo(

--- a/web/src/main/resources/static/css/moderation.css
+++ b/web/src/main/resources/static/css/moderation.css
@@ -57,6 +57,10 @@
     text-transform: uppercase;
     color: var(--text-muted);
     letter-spacing: 0.04em;
+    position: sticky;
+    top: 0;
+    background: var(--bg-elevated);
+    z-index: 1;
 }
 .mod-table tr:last-child td { border-bottom: 0; }
 
@@ -100,13 +104,9 @@
     cursor: not-allowed;
 }
 
-.initiative-input {
-    width: 68px;
-    padding: 4px 8px;
-    background: var(--bg);
-    color: var(--text);
-    border: 1px solid var(--border-strong);
-    border-radius: var(--radius-sm);
+.initiative-value {
+    color: var(--text-muted);
+    font-variant-numeric: tabular-nums;
 }
 
 .btn-danger {
@@ -224,4 +224,42 @@
 
 @media (max-width: 640px) {
     .tab-btn { padding: 8px 10px; font-size: 0.9rem; }
+
+    .mod-table-wrap {
+        overflow-x: visible;
+        border: 0;
+        background: transparent;
+        border-radius: 0;
+    }
+    .mod-table { min-width: 0; border-collapse: separate; border-spacing: 0; }
+    .mod-table thead { display: none; }
+    .mod-table tbody, .mod-table tr, .mod-table td { display: block; width: 100%; }
+    .mod-table tr {
+        background: var(--bg-elevated);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-md);
+        padding: 8px 12px;
+        margin-bottom: var(--space-3);
+    }
+    .mod-table tr:last-child td { border-bottom: 1px solid var(--border); }
+    .mod-table td {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        gap: 12px;
+        border-bottom: 1px solid var(--border);
+        padding: 8px 0;
+    }
+    .mod-table td:last-child { border-bottom: 0; }
+    .mod-table td::before {
+        content: attr(data-label);
+        font-size: 0.75rem;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        color: var(--text-muted);
+        font-weight: 600;
+        flex: 0 0 auto;
+    }
+    .mod-table td[data-label="Member"] { display: block; }
+    .mod-table td[data-label="Member"]::before { display: none; }
 }

--- a/web/src/main/resources/static/js/moderation.js
+++ b/web/src/main/resources/static/js/moderation.js
@@ -66,34 +66,6 @@
         });
     });
 
-    // --- Users tab: initiative modifier (commit on blur or Enter) ---
-    document.querySelectorAll('.initiative-input').forEach(input => {
-        let lastValue = input.value;
-        const commit = () => {
-            const val = parseInt(input.value, 10);
-            if (Number.isNaN(val) || val === parseInt(lastValue, 10)) {
-                input.value = lastValue;
-                return;
-            }
-            const memberId = input.closest('tr').dataset.memberId;
-            input.disabled = true;
-            postJson('/moderation/' + guildId + '/user/' + memberId + '/initiative', { modifier: val })
-                .then(r => {
-                    input.disabled = false;
-                    if (r && r.ok) {
-                        lastValue = String(val);
-                        toast('Initiative modifier saved.', 'success');
-                    } else {
-                        input.value = lastValue;
-                        toast(r?.error || 'Could not save modifier.', 'error');
-                    }
-                })
-                .catch(() => { input.disabled = false; input.value = lastValue; toast('Network error.', 'error'); });
-        };
-        input.addEventListener('blur', commit);
-        input.addEventListener('keydown', e => { if (e.key === 'Enter') { e.preventDefault(); input.blur(); } });
-    });
-
     // --- Users tab: kick ---
     document.querySelectorAll('.kick-btn').forEach(btn => {
         btn.addEventListener('click', () => {

--- a/web/src/main/resources/templates/moderation.html
+++ b/web/src/main/resources/templates/moderation.html
@@ -51,7 +51,7 @@
                 <tbody>
                 <tr th:each="m : ${overview.members}"
                     th:attr="data-member-id=${m.id}">
-                    <td>
+                    <td data-label="Member">
                         <div class="member-cell">
                             <img th:if="${m.avatarUrl != null}"
                                  th:src="${m.avatarUrl}"
@@ -61,42 +61,50 @@
                             <span class="badge owner" th:if="${m.isOwner}">owner</span>
                         </div>
                     </td>
-                    <td>
+                    <td data-label="Music">
                         <button type="button" class="toggle-btn"
                                 th:classappend="${m.musicPermission} ? ' on' : ''"
                                 th:attr="data-permission='MUSIC',
                                          data-owner=${m.isOwner}"
+                                th:title="'Music: ' + (${m.musicPermission} ? 'On' : 'Off')"
+                                th:aria-label="'Toggle Music permission for ' + ${m.name}"
                                 th:text="${m.musicPermission} ? 'On' : 'Off'">On</button>
                     </td>
-                    <td>
+                    <td data-label="Meme">
                         <button type="button" class="toggle-btn"
                                 th:classappend="${m.memePermission} ? ' on' : ''"
                                 th:attr="data-permission='MEME',
                                          data-owner=${m.isOwner}"
+                                th:title="'Meme: ' + (${m.memePermission} ? 'On' : 'Off')"
+                                th:aria-label="'Toggle Meme permission for ' + ${m.name}"
                                 th:text="${m.memePermission} ? 'On' : 'Off'">On</button>
                     </td>
-                    <td>
+                    <td data-label="Dig">
                         <button type="button" class="toggle-btn"
                                 th:classappend="${m.digPermission} ? ' on' : ''"
                                 th:attr="data-permission='DIG',
                                          data-owner=${m.isOwner}"
+                                th:title="'Dig: ' + (${m.digPermission} ? 'On' : 'Off')"
+                                th:aria-label="'Toggle Dig permission for ' + ${m.name}"
                                 th:text="${m.digPermission} ? 'On' : 'Off'">On</button>
                     </td>
-                    <td>
+                    <td data-label="Superuser">
                         <button type="button" class="toggle-btn"
                                 th:classappend="${m.superUser} ? ' on' : ''"
                                 th:attr="data-permission='SUPERUSER',
                                          data-owner=${m.isOwner},
                                          data-owner-only='true'"
                                 th:disabled="${!isOwner}"
+                                th:title="'Superuser: ' + (${m.superUser} ? 'On' : 'Off')"
+                                th:aria-label="'Toggle Superuser permission for ' + ${m.name}"
                                 th:text="${m.superUser} ? 'On' : 'Off'">Off</button>
                     </td>
-                    <td>
-                        <input type="number" class="initiative-input"
-                               th:value="${m.initiativeModifier}"
-                               min="-20" max="20" step="1" aria-label="Initiative modifier">
+                    <td data-label="Initiative">
+                        <span class="initiative-value"
+                              th:text="${m.initiativeModifier == null ? '—' : (m.initiativeModifier >= 0 ? '+' + m.initiativeModifier : m.initiativeModifier)}"
+                              th:title="${m.initiativeModifier == null ? 'Link a D&amp;D Beyond character with /linkcharacter to populate.' : 'Derived from linked character sheet (DEX modifier).'}">—</span>
                     </td>
-                    <td>
+                    <td data-label="Actions">
                         <button type="button" class="btn-danger kick-btn"
                                 th:attr="data-name=${m.name}"
                                 th:disabled="${m.isOwner}">Kick</button>

--- a/web/src/test/kotlin/web/service/ModerationWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/ModerationWebServiceTest.kt
@@ -30,6 +30,7 @@ class ModerationWebServiceTest {
     private lateinit var userService: UserService
     private lateinit var configService: ConfigService
     private lateinit var introWebService: IntroWebService
+    private lateinit var initiativeResolver: InitiativeResolver
     private lateinit var service: ModerationWebService
 
     private lateinit var guild: Guild
@@ -46,8 +47,9 @@ class ModerationWebServiceTest {
         userService = mockk(relaxed = true)
         configService = mockk(relaxed = true)
         introWebService = mockk(relaxed = true)
+        initiativeResolver = mockk(relaxed = true)
         guild = mockk(relaxed = true)
-        service = ModerationWebService(jda, userService, configService, introWebService)
+        service = ModerationWebService(jda, userService, configService, introWebService, initiativeResolver)
 
         every { jda.getGuildById(guildId) } returns guild
         every { guild.id } returns guildId.toString()
@@ -163,26 +165,6 @@ class ModerationWebServiceTest {
         assertNull(err)
         verify { userService.createNewUser(any()) }
         verify { userService.updateUser(any()) }
-    }
-
-    // ---- setInitiativeModifier ----
-
-    @Test
-    fun `setInitiativeModifier rejects out-of-range value`() {
-        mockMember(ownerId, isOwner = true)
-        assertNotNull(service.setInitiativeModifier(ownerId, guildId, targetUserId, 100))
-    }
-
-    @Test
-    fun `setInitiativeModifier persists value`() {
-        mockMember(ownerId, isOwner = true)
-        val target = UserDto(discordId = targetUserId, guildId = guildId)
-        every { userService.getUserById(targetUserId, guildId) } returns target
-
-        val err = service.setInitiativeModifier(ownerId, guildId, targetUserId, 5)
-        assertNull(err)
-        assertEquals(5, target.initiativeModifier)
-        verify { userService.updateUser(target) }
     }
 
     // ---- adjustSocialCredit ----


### PR DESCRIPTION
## Summary

Two improvements to the new `/moderation` page:

### Mobile permission visibility

The user table is wider than a phone viewport, so on vertical scroll the column headers disappeared and each toggle just read `On` / `Off` with no indication of which permission it controlled.

- Below 640px the table collapses each row into a stacked card whose cells render their column name inline via a `data-label` attribute. `Music / Meme / Dig / Superuser` labels stay beside their toggles regardless of scroll position.
- Sticky `<thead>` for desktop scroll.
- `title` and `aria-label` on every toggle so hover and screen-reader users also see the permission name.

### Initiative refactor

`UserDto.initiativeModifier` was a holdover from before D&D Beyond characters could be linked. `/linkcharacter` already seeded it from the linked sheet's DEX modifier, so the stored copy was redundant and could drift from the source of truth.

- New `InitiativeResolver` service in `web.service` reads the cached sheet via `CharacterSheetService` and returns the DEX modifier, or `null` when no character is linked / no cached sheet exists. It lives in `web` so both web services and `discord-bot` (which depends on `web`) can use it.
- `DnDHelper.rollInitiativeForMembers` and `CampaignWebService.rollInitiative` use the resolver instead of `UserDto.initiativeModifier`.
- `ModerationWebService.getGuildOverview` surfaces the resolved value as `ModeratedMember.initiativeModifier: Int?`. The moderation page shows a read-only signed value (e.g. `+2`) or `—` instead of an editable input. The `setInitiativeModifier` service method, the `/moderation/.../initiative` POST endpoint, the JS handler, and the input CSS are removed.
- `/adjustuser` drops its now-orphaned `modifier` option.
- `/linkcharacter` still embeds the DEX modifier in its confirmation reply but no longer stores it on the user.
- `UserDto` loses the `initiativeModifier` field; Flyway `V12` drops the legacy `initiative` column from `public."user"`.

Branch was rebased onto `main` (picking up #261 + #262) and squashed into a single commit.

## Test plan

- [ ] `./gradlew build` passes (Kotlin compiles, existing & updated tests green).
- [ ] On mobile, open `/moderation/{guildId}` → user list shows stacked cards with `Music / Meme / Dig / Superuser / Initiative / Actions` labels beside each value.
- [ ] On desktop, the table renders normally with column headers above each row, and they stay visible while scrolling vertically.
- [ ] Run `/linkcharacter https://www.dndbeyond.com/characters/<id>` for a member → moderation page Initiative column shows the signed DEX modifier (e.g. `+2`) for that user; users without a sheet show `—`.
- [ ] Run `/initiative` in a voice channel with a linked-character member → that member's roll uses their DEX modifier; unlinked members roll with +0.
- [ ] Confirm Flyway `V12` runs cleanly on a fresh DB (column dropped) and on an existing DB (idempotent via `IF EXISTS`).

https://claude.ai/code/session_01QRXoQyfD6gd3PFS6mFWDQK