### PR TITLE
fix(intros): render saved Shorts previews via youtube-nocookie.com

### DIFF
--- a/application/src/test/kotlin/web/service/IntroWebServiceTest.kt
+++ b/application/src/test/kotlin/web/service/IntroWebServiceTest.kt
@@ -201,6 +201,25 @@ class IntroWebServiceTest {
     }
 
     @Test
+    fun `getUserIntros extracts videoId for Shorts URL with trailing slash`() {
+        val shortsUrl = "https://www.youtube.com/shorts/dQw4w9WgXcQ/"
+        val intro = MusicDto(
+            id = "${guildId}_${discordId}_1",
+            index = 1,
+            fileName = "Shorts with trailing slash",
+            musicBlob = shortsUrl.toByteArray()
+        )
+        val user = UserDto(discordId = discordId, guildId = guildId).apply {
+            musicDtos = mutableListOf(intro)
+        }
+        every { userService.getUserById(discordId, guildId) } returns user
+
+        val result = service.getUserIntros(discordId, guildId)
+        assertEquals(1, result.size)
+        assertEquals("dQw4w9WgXcQ", result[0].videoId)
+    }
+
+    @Test
     fun `getUserIntros extracts videoId for Shorts URL carrying query params`() {
         val shortsUrl = "https://www.youtube.com/shorts/dQw4w9WgXcQ?si=abc123"
         val intro = MusicDto(

--- a/discord-bot/src/main/kotlin/bot/toby/helpers/HttpHelper.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/helpers/HttpHelper.kt
@@ -75,7 +75,9 @@ class HttpHelper(
 
     // Helper function to extract video ID from YouTube URL
     private fun extractVideoIdFromUrl(url: String): String? {
-        val regex = Regex("(?<=v=|/videos/|embed/|youtu\\.be/|/v/|/e/|watch\\?v=|&v=|^youtu\\.be/|/shorts/)([^#&?\\n]+)")
+        // Exclude `/` from the capture so a trailing slash (e.g. `…/shorts/ID/`)
+        // doesn't leak into the id.
+        val regex = Regex("(?<=v=|/videos/|embed/|youtu\\.be/|/v/|/e/|watch\\?v=|&v=|^youtu\\.be/|/shorts/)([^#&?/\\n]+)")
         return regex.find(url)?.value
     }
 

--- a/web/src/main/kotlin/web/service/IntroWebService.kt
+++ b/web/src/main/kotlin/web/service/IntroWebService.kt
@@ -377,7 +377,9 @@ class IntroWebService(
     fun getYouTubeVideoTitle(url: String): String? = fetchYouTubePreview(url)?.title
 
     private fun extractVideoId(url: String): String? {
-        val regex = Regex("(?<=v=|/videos/|embed/|youtu\\.be/|/v/|/e/|watch\\?v=|&v=|^youtu\\.be/|/shorts/)([^#&?\\n]+)")
+        // Exclude `/` from the capture so a trailing slash (e.g. `…/shorts/ID/`)
+        // doesn't get baked into the videoId and break the iframe embed URL.
+        val regex = Regex("(?<=v=|/videos/|embed/|youtu\\.be/|/v/|/e/|watch\\?v=|&v=|^youtu\\.be/|/shorts/)([^#&?/\\n]+)")
         return regex.find(url)?.value
     }
 

--- a/web/src/main/resources/static/js/intros.js
+++ b/web/src/main/resources/static/js/intros.js
@@ -324,7 +324,13 @@ function togglePlayClip(btn) {
     params.set('autoplay', '1');
     params.set('controls', '1');
     params.set('rel', '0');
-    const src = 'https://www.youtube.com/embed/' + encodeURIComponent(videoId) + '?' + params.toString();
+    params.set('playsinline', '1');
+    // youtube-nocookie.com is YouTube's privacy-enhanced embed host. It has
+    // looser anti-bot behaviour (no "sign in to confirm you're not a bot"
+    // interstitial) and embeds Shorts reliably — the default youtube.com host
+    // often refuses to render Shorts in an iframe, which shows up as a blank
+    // preview row.
+    const src = 'https://www.youtube-nocookie.com/embed/' + encodeURIComponent(videoId) + '?' + params.toString();
     const previewRow = document.createElement('tr');
     previewRow.className = 'video-preview-row';
     const td = document.createElement('td');

--- a/web/src/test/js/intros.test.js
+++ b/web/src/test/js/intros.test.js
@@ -391,10 +391,13 @@ describe('togglePlayClip', () => {
         const iframe = previewRow.querySelector('iframe');
         expect(iframe).not.toBeNull();
         const src = iframe.getAttribute('src');
-        expect(src).toContain('/embed/dQw4w9WgXcQ');
+        // Use the privacy-enhanced host so Shorts (and strict-anti-bot videos)
+        // render reliably instead of blanking the preview row.
+        expect(src).toContain('https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ');
         expect(src).toContain('start=5');
         expect(src).toContain('end=12');
         expect(src).toContain('autoplay=1');
+        expect(src).toContain('playsinline=1');
 
         expect(btn.textContent).toBe('⏹');
         expect(btn.classList.contains('playing')).toBe(true);


### PR DESCRIPTION
## Summary
- Swap the saved-intro preview iframe host from `youtube.com/embed/` to `youtube-nocookie.com/embed/` and add `playsinline=1`. The default host frequently refuses to render YouTube Shorts (the row appears blank — "no iframe opens") and sometimes serves YouTube's "sign in to confirm you're not a bot" interstitial. The privacy-enhanced host has looser embed restrictions and plays Shorts reliably.
- Tighten `extractVideoId` (web + bot) to exclude `/` from the capture, so a stored Shorts URL with a trailing slash (`…/shorts/ID/`) doesn't bake the slash into the id and produce a 404-ing `…/embed/ID%2F` src.

## Test plan
- [x] `npm test` in `web/` — all 72 Jest tests pass; `togglePlayClip` now asserts the nocookie host + `playsinline=1`.
- [x] Manually verified the updated regex against `shorts/ID`, `shorts/ID/`, `shorts/ID?si=…`, `watch?v=ID`, `youtu.be/ID`, `embed/ID` in a Java harness (variable-length lookbehind matches Kotlin's engine).
- [ ] In-app sanity: open the intro UI as a super-user managing another member whose intro is a YouTube Short, click ▶, confirm the preview row renders and the clip plays without the anti-bot interstitial.

Fixes: "no iframe opens up" when previewing a stored YouTube Short via the intro UI, and the intermittent "sign in to confirm you're not a bot" in the preview.

https://claude.ai/code/session_01XSL5kUWBB47e7wHNCfsjEc

---
_Generated by [Claude Code](https://claude.ai/code/session_01XSL5kUWBB47e7wHNCfsjEc)_