### PR TITLE
feat(credit): voice-activity earnings, monthly leaderboards, vanity titles

### DIFF
--- a/application/src/main/kotlin/app/Application.kt
+++ b/application/src/main/kotlin/app/Application.kt
@@ -7,9 +7,11 @@ import org.springframework.boot.SpringApplication
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.cache.annotation.EnableCaching
 import org.springframework.context.annotation.Import
+import org.springframework.scheduling.annotation.EnableScheduling
 
 @SpringBootApplication(scanBasePackages = ["app", "bot", "common", "core", "database", "web"])
 @EnableCaching
+@EnableScheduling
 @Import(FlywayGuardConfig::class, CampaignShutdownHook::class, CampaignStartupHook::class)
 class Application {
     companion object {

--- a/application/src/test/kotlin/integration/bot/CommandManagerTest.kt
+++ b/application/src/test/kotlin/integration/bot/CommandManagerTest.kt
@@ -9,6 +9,7 @@ import bot.toby.command.commands.dnd.InitiativeCommand
 import bot.toby.command.commands.dnd.LinkCharacterCommand
 import bot.toby.command.commands.dnd.RefreshCharacterCommand
 import bot.toby.command.commands.dnd.RollCommand
+import bot.toby.command.commands.economy.TitleCommand
 import bot.toby.command.commands.fetch.DbdRandomKillerCommand
 import bot.toby.command.commands.fetch.Kf2RandomMapCommand
 import bot.toby.command.commands.fetch.MemeCommand
@@ -121,12 +122,13 @@ class CommandManagerTest {
             LinkCharacterCommand::class.java,
             CharacterCommand::class.java,
             RefreshCharacterCommand::class.java,
-            CampaignCommand::class.java
+            CampaignCommand::class.java,
+            TitleCommand::class.java
         )
 
         Assertions.assertTrue(availableCommands.containsAll(commandManager.allCommands.map { it.javaClass }.toList()))
-        Assertions.assertEquals(43, commandManager.allCommands.size)
-        Assertions.assertEquals(43, commandManager.allSlashCommands.size)
+        Assertions.assertEquals(44, commandManager.allCommands.size)
+        Assertions.assertEquals(44, commandManager.allSlashCommands.size)
     }
 
     @Test

--- a/application/src/test/resources/schema.sql
+++ b/application/src/test/resources/schema.sql
@@ -45,7 +45,64 @@ CREATE TABLE public."user" (
     meme_permission boolean DEFAULT true NOT NULL,
     social_credit bigint,
     initiative smallint default 0,
-    dnd_beyond_character_id bigint default null
+    dnd_beyond_character_id bigint default null,
+    active_title_id bigint default null
+);
+
+DROP TABLE IF EXISTS public.voice_session;
+CREATE TABLE public.voice_session (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    discord_id BIGINT NOT NULL,
+    guild_id BIGINT NOT NULL,
+    channel_id BIGINT NOT NULL,
+    joined_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    left_at TIMESTAMP WITH TIME ZONE,
+    counted_seconds BIGINT,
+    credits_awarded BIGINT NOT NULL DEFAULT 0
+);
+
+DROP TABLE IF EXISTS public.voice_credit_daily;
+CREATE TABLE public.voice_credit_daily (
+    discord_id BIGINT NOT NULL,
+    guild_id BIGINT NOT NULL,
+    earn_date DATE NOT NULL,
+    credits BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (discord_id, guild_id, earn_date)
+);
+
+DROP TABLE IF EXISTS public.monthly_credit_snapshot;
+CREATE TABLE public.monthly_credit_snapshot (
+    discord_id BIGINT NOT NULL,
+    guild_id BIGINT NOT NULL,
+    snapshot_date DATE NOT NULL,
+    social_credit BIGINT NOT NULL,
+    PRIMARY KEY (discord_id, guild_id, snapshot_date)
+);
+
+DROP TABLE IF EXISTS public.user_owned_title;
+DROP TABLE IF EXISTS public.guild_title_role;
+DROP TABLE IF EXISTS public.title;
+CREATE TABLE public.title (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    label TEXT NOT NULL UNIQUE,
+    cost BIGINT NOT NULL,
+    description TEXT,
+    color_hex TEXT,
+    hoisted BOOLEAN NOT NULL DEFAULT FALSE
+);
+
+CREATE TABLE public.user_owned_title (
+    discord_id BIGINT NOT NULL,
+    title_id BIGINT NOT NULL REFERENCES public.title(id),
+    bought_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (discord_id, title_id)
+);
+
+CREATE TABLE public.guild_title_role (
+    guild_id BIGINT NOT NULL,
+    title_id BIGINT NOT NULL REFERENCES public.title(id),
+    discord_role_id BIGINT NOT NULL,
+    PRIMARY KEY (guild_id, title_id)
 );
 
 DROP TABLE IF EXISTS public.dnd_campaign_player;

--- a/database/src/main/kotlin/database/dto/ConfigDto.kt
+++ b/database/src/main/kotlin/database/dto/ConfigDto.kt
@@ -32,7 +32,8 @@ class ConfigDto(
         INTRO_VOLUME("DEFAULT_INTRO_VOLUME"),
         VOLUME("DEFAULT_VOLUME"),
         MOVE("DEFAULT_MOVE_CHANNEL"),
-        DELETE_DELAY("DELETE_MESSAGE_DELAY");
+        DELETE_DELAY("DELETE_MESSAGE_DELAY"),
+        LEADERBOARD_CHANNEL("LEADERBOARD_CHANNEL");
     }
 
     override fun toString(): String {

--- a/database/src/main/kotlin/database/dto/GuildTitleRoleDto.kt
+++ b/database/src/main/kotlin/database/dto/GuildTitleRoleDto.kt
@@ -1,0 +1,37 @@
+package database.dto
+
+import jakarta.persistence.*
+import org.springframework.transaction.annotation.Transactional
+import java.io.Serializable
+
+@NamedQueries(
+    NamedQuery(
+        name = "GuildTitleRoleDto.get",
+        query = "select r from GuildTitleRoleDto r where r.guildId = :guildId and r.titleId = :titleId"
+    ),
+    NamedQuery(
+        name = "GuildTitleRoleDto.getByGuild",
+        query = "select r from GuildTitleRoleDto r where r.guildId = :guildId"
+    )
+)
+@Entity
+@Table(name = "guild_title_role", schema = "public")
+@IdClass(GuildTitleRoleId::class)
+@Transactional
+class GuildTitleRoleDto(
+    @Id
+    @Column(name = "guild_id")
+    var guildId: Long = 0,
+
+    @Id
+    @Column(name = "title_id")
+    var titleId: Long = 0,
+
+    @Column(name = "discord_role_id", nullable = false)
+    var discordRoleId: Long = 0
+) : Serializable
+
+data class GuildTitleRoleId(
+    var guildId: Long = 0,
+    var titleId: Long = 0
+) : Serializable

--- a/database/src/main/kotlin/database/dto/MonthlyCreditSnapshotDto.kt
+++ b/database/src/main/kotlin/database/dto/MonthlyCreditSnapshotDto.kt
@@ -1,0 +1,44 @@
+package database.dto
+
+import jakarta.persistence.*
+import org.springframework.transaction.annotation.Transactional
+import java.io.Serializable
+import java.time.LocalDate
+
+@NamedQueries(
+    NamedQuery(
+        name = "MonthlyCreditSnapshotDto.getForGuildDate",
+        query = "select s from MonthlyCreditSnapshotDto s where s.guildId = :guildId and s.snapshotDate = :snapshotDate"
+    ),
+    NamedQuery(
+        name = "MonthlyCreditSnapshotDto.getForUserDate",
+        query = "select s from MonthlyCreditSnapshotDto s " +
+                "where s.guildId = :guildId and s.discordId = :discordId and s.snapshotDate = :snapshotDate"
+    )
+)
+@Entity
+@Table(name = "monthly_credit_snapshot", schema = "public")
+@IdClass(MonthlyCreditSnapshotId::class)
+@Transactional
+class MonthlyCreditSnapshotDto(
+    @Id
+    @Column(name = "discord_id")
+    var discordId: Long = 0,
+
+    @Id
+    @Column(name = "guild_id")
+    var guildId: Long = 0,
+
+    @Id
+    @Column(name = "snapshot_date")
+    var snapshotDate: LocalDate = LocalDate.now(),
+
+    @Column(name = "social_credit", nullable = false)
+    var socialCredit: Long = 0
+) : Serializable
+
+data class MonthlyCreditSnapshotId(
+    var discordId: Long = 0,
+    var guildId: Long = 0,
+    var snapshotDate: LocalDate = LocalDate.now()
+) : Serializable

--- a/database/src/main/kotlin/database/dto/TitleDto.kt
+++ b/database/src/main/kotlin/database/dto/TitleDto.kt
@@ -1,0 +1,34 @@
+package database.dto
+
+import jakarta.persistence.*
+import org.springframework.transaction.annotation.Transactional
+import java.io.Serializable
+
+@NamedQueries(
+    NamedQuery(name = "TitleDto.getAll", query = "select t from TitleDto t order by t.cost asc"),
+    NamedQuery(name = "TitleDto.getByLabel", query = "select t from TitleDto t where lower(t.label) = lower(:label)")
+)
+@Entity
+@Table(name = "title", schema = "public")
+@Transactional
+class TitleDto(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    var id: Long? = null,
+
+    @Column(name = "label", nullable = false, unique = true)
+    var label: String = "",
+
+    @Column(name = "cost", nullable = false)
+    var cost: Long = 0,
+
+    @Column(name = "description")
+    var description: String? = null,
+
+    @Column(name = "color_hex")
+    var colorHex: String? = null,
+
+    @Column(name = "hoisted", nullable = false)
+    var hoisted: Boolean = false
+) : Serializable

--- a/database/src/main/kotlin/database/dto/UserDto.kt
+++ b/database/src/main/kotlin/database/dto/UserDto.kt
@@ -48,6 +48,9 @@ class UserDto(
     @Column(name = "dnd_beyond_character_id")
     var dndBeyondCharacterId: Long? = null,
 
+    @Column(name = "active_title_id")
+    var activeTitleId: Long? = null,
+
     @OneToMany(mappedBy = "userDto", fetch = FetchType.EAGER, cascade = [CascadeType.ALL], orphanRemoval = true)
     var musicDtos: MutableList<MusicDto> = mutableListOf()
 ) : Serializable {

--- a/database/src/main/kotlin/database/dto/UserOwnedTitleDto.kt
+++ b/database/src/main/kotlin/database/dto/UserOwnedTitleDto.kt
@@ -1,0 +1,38 @@
+package database.dto
+
+import jakarta.persistence.*
+import org.springframework.transaction.annotation.Transactional
+import java.io.Serializable
+import java.time.Instant
+
+@NamedQueries(
+    NamedQuery(
+        name = "UserOwnedTitleDto.getByUser",
+        query = "select o from UserOwnedTitleDto o where o.discordId = :discordId"
+    ),
+    NamedQuery(
+        name = "UserOwnedTitleDto.exists",
+        query = "select count(o) from UserOwnedTitleDto o where o.discordId = :discordId and o.titleId = :titleId"
+    )
+)
+@Entity
+@Table(name = "user_owned_title", schema = "public")
+@IdClass(UserOwnedTitleId::class)
+@Transactional
+class UserOwnedTitleDto(
+    @Id
+    @Column(name = "discord_id")
+    var discordId: Long = 0,
+
+    @Id
+    @Column(name = "title_id")
+    var titleId: Long = 0,
+
+    @Column(name = "bought_at", nullable = false)
+    var boughtAt: Instant = Instant.now()
+) : Serializable
+
+data class UserOwnedTitleId(
+    var discordId: Long = 0,
+    var titleId: Long = 0
+) : Serializable

--- a/database/src/main/kotlin/database/dto/VoiceCreditDailyDto.kt
+++ b/database/src/main/kotlin/database/dto/VoiceCreditDailyDto.kt
@@ -1,0 +1,40 @@
+package database.dto
+
+import jakarta.persistence.*
+import org.springframework.transaction.annotation.Transactional
+import java.io.Serializable
+import java.time.LocalDate
+
+@NamedQueries(
+    NamedQuery(
+        name = "VoiceCreditDailyDto.get",
+        query = "select d from VoiceCreditDailyDto d " +
+                "where d.discordId = :discordId and d.guildId = :guildId and d.earnDate = :earnDate"
+    )
+)
+@Entity
+@Table(name = "voice_credit_daily", schema = "public")
+@IdClass(VoiceCreditDailyId::class)
+@Transactional
+class VoiceCreditDailyDto(
+    @Id
+    @Column(name = "discord_id")
+    var discordId: Long = 0,
+
+    @Id
+    @Column(name = "guild_id")
+    var guildId: Long = 0,
+
+    @Id
+    @Column(name = "earn_date")
+    var earnDate: LocalDate = LocalDate.now(),
+
+    @Column(name = "credits", nullable = false)
+    var credits: Long = 0
+) : Serializable
+
+data class VoiceCreditDailyId(
+    var discordId: Long = 0,
+    var guildId: Long = 0,
+    var earnDate: LocalDate = LocalDate.now()
+) : Serializable

--- a/database/src/main/kotlin/database/dto/VoiceSessionDto.kt
+++ b/database/src/main/kotlin/database/dto/VoiceSessionDto.kt
@@ -1,0 +1,68 @@
+package database.dto
+
+import jakarta.persistence.*
+import org.springframework.transaction.annotation.Transactional
+import java.io.Serializable
+import java.time.Instant
+
+@NamedQueries(
+    NamedQuery(
+        name = "VoiceSessionDto.findOpen",
+        query = "select s from VoiceSessionDto s where s.discordId = :discordId and s.guildId = :guildId and s.leftAt is null"
+    ),
+    NamedQuery(
+        name = "VoiceSessionDto.findAllOpen",
+        query = "select s from VoiceSessionDto s where s.leftAt is null"
+    ),
+    NamedQuery(
+        name = "VoiceSessionDto.sumCountedSecondsInRange",
+        query = "select coalesce(sum(s.countedSeconds), 0) from VoiceSessionDto s " +
+                "where s.guildId = :guildId and s.discordId = :discordId " +
+                "and s.leftAt is not null " +
+                "and s.joinedAt >= :from and s.joinedAt < :until"
+    ),
+    NamedQuery(
+        name = "VoiceSessionDto.sumCountedSecondsInRangeAllUsers",
+        query = "select s.discordId, coalesce(sum(s.countedSeconds), 0) from VoiceSessionDto s " +
+                "where s.guildId = :guildId " +
+                "and s.leftAt is not null " +
+                "and s.joinedAt >= :from and s.joinedAt < :until " +
+                "group by s.discordId"
+    ),
+    NamedQuery(
+        name = "VoiceSessionDto.sumCountedSecondsLifetime",
+        query = "select s.discordId, coalesce(sum(s.countedSeconds), 0) from VoiceSessionDto s " +
+                "where s.guildId = :guildId and s.leftAt is not null " +
+                "group by s.discordId"
+    )
+)
+@Entity
+@Table(name = "voice_session", schema = "public")
+@Transactional
+class VoiceSessionDto(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    var id: Long? = null,
+
+    @Column(name = "discord_id", nullable = false)
+    var discordId: Long = 0,
+
+    @Column(name = "guild_id", nullable = false)
+    var guildId: Long = 0,
+
+    @Column(name = "channel_id", nullable = false)
+    var channelId: Long = 0,
+
+    @Column(name = "joined_at", nullable = false)
+    var joinedAt: Instant = Instant.now(),
+
+    @Column(name = "left_at")
+    var leftAt: Instant? = null,
+
+    @Column(name = "counted_seconds")
+    var countedSeconds: Long? = null,
+
+    @Column(name = "credits_awarded", nullable = false)
+    var creditsAwarded: Long = 0
+) : Serializable

--- a/database/src/main/kotlin/database/persistence/GuildTitleRolePersistence.kt
+++ b/database/src/main/kotlin/database/persistence/GuildTitleRolePersistence.kt
@@ -1,0 +1,10 @@
+package database.persistence
+
+import database.dto.GuildTitleRoleDto
+
+interface GuildTitleRolePersistence {
+    fun get(guildId: Long, titleId: Long): GuildTitleRoleDto?
+    fun listByGuild(guildId: Long): List<GuildTitleRoleDto>
+    fun save(dto: GuildTitleRoleDto): GuildTitleRoleDto
+    fun delete(guildId: Long, titleId: Long)
+}

--- a/database/src/main/kotlin/database/persistence/MonthlyCreditSnapshotPersistence.kt
+++ b/database/src/main/kotlin/database/persistence/MonthlyCreditSnapshotPersistence.kt
@@ -1,0 +1,10 @@
+package database.persistence
+
+import database.dto.MonthlyCreditSnapshotDto
+import java.time.LocalDate
+
+interface MonthlyCreditSnapshotPersistence {
+    fun get(discordId: Long, guildId: Long, snapshotDate: LocalDate): MonthlyCreditSnapshotDto?
+    fun listForGuildDate(guildId: Long, snapshotDate: LocalDate): List<MonthlyCreditSnapshotDto>
+    fun upsert(dto: MonthlyCreditSnapshotDto): MonthlyCreditSnapshotDto
+}

--- a/database/src/main/kotlin/database/persistence/TitlePersistence.kt
+++ b/database/src/main/kotlin/database/persistence/TitlePersistence.kt
@@ -1,0 +1,14 @@
+package database.persistence
+
+import database.dto.TitleDto
+import database.dto.UserOwnedTitleDto
+
+interface TitlePersistence {
+    fun listAll(): List<TitleDto>
+    fun getById(id: Long): TitleDto?
+    fun getByLabel(label: String): TitleDto?
+
+    fun listOwned(discordId: Long): List<UserOwnedTitleDto>
+    fun owns(discordId: Long, titleId: Long): Boolean
+    fun recordPurchase(owned: UserOwnedTitleDto): UserOwnedTitleDto
+}

--- a/database/src/main/kotlin/database/persistence/VoiceCreditDailyPersistence.kt
+++ b/database/src/main/kotlin/database/persistence/VoiceCreditDailyPersistence.kt
@@ -1,0 +1,9 @@
+package database.persistence
+
+import database.dto.VoiceCreditDailyDto
+import java.time.LocalDate
+
+interface VoiceCreditDailyPersistence {
+    fun get(discordId: Long, guildId: Long, date: LocalDate): VoiceCreditDailyDto?
+    fun upsert(row: VoiceCreditDailyDto): VoiceCreditDailyDto
+}

--- a/database/src/main/kotlin/database/persistence/VoiceSessionPersistence.kt
+++ b/database/src/main/kotlin/database/persistence/VoiceSessionPersistence.kt
@@ -1,0 +1,14 @@
+package database.persistence
+
+import database.dto.VoiceSessionDto
+import java.time.Instant
+
+interface VoiceSessionPersistence {
+    fun openSession(session: VoiceSessionDto): VoiceSessionDto
+    fun findOpenSession(discordId: Long, guildId: Long): VoiceSessionDto?
+    fun findAllOpenSessions(): List<VoiceSessionDto>
+    fun closeSession(session: VoiceSessionDto): VoiceSessionDto
+    fun sumCountedSecondsInRange(guildId: Long, discordId: Long, from: Instant, until: Instant): Long
+    fun sumCountedSecondsInRangeByUser(guildId: Long, from: Instant, until: Instant): Map<Long, Long>
+    fun sumCountedSecondsLifetimeByUser(guildId: Long): Map<Long, Long>
+}

--- a/database/src/main/kotlin/database/persistence/impl/DefaultGuildTitleRolePersistence.kt
+++ b/database/src/main/kotlin/database/persistence/impl/DefaultGuildTitleRolePersistence.kt
@@ -1,0 +1,55 @@
+package database.persistence.impl
+
+import database.dto.GuildTitleRoleDto
+import database.dto.GuildTitleRoleId
+import database.persistence.GuildTitleRolePersistence
+import jakarta.persistence.EntityManager
+import jakarta.persistence.PersistenceContext
+import jakarta.persistence.TypedQuery
+import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
+
+@Repository
+@Transactional
+class DefaultGuildTitleRolePersistence : GuildTitleRolePersistence {
+
+    @PersistenceContext
+    private lateinit var entityManager: EntityManager
+
+    override fun get(guildId: Long, titleId: Long): GuildTitleRoleDto? {
+        val q: TypedQuery<GuildTitleRoleDto> =
+            entityManager.createNamedQuery("GuildTitleRoleDto.get", GuildTitleRoleDto::class.java)
+        q.setParameter("guildId", guildId)
+        q.setParameter("titleId", titleId)
+        return q.resultList.firstOrNull()
+    }
+
+    override fun listByGuild(guildId: Long): List<GuildTitleRoleDto> {
+        val q: TypedQuery<GuildTitleRoleDto> =
+            entityManager.createNamedQuery("GuildTitleRoleDto.getByGuild", GuildTitleRoleDto::class.java)
+        q.setParameter("guildId", guildId)
+        return q.resultList
+    }
+
+    override fun save(dto: GuildTitleRoleDto): GuildTitleRoleDto {
+        val existing = get(dto.guildId, dto.titleId)
+        return if (existing == null) {
+            entityManager.persist(dto)
+            entityManager.flush()
+            dto
+        } else {
+            existing.discordRoleId = dto.discordRoleId
+            entityManager.merge(existing)
+            entityManager.flush()
+            existing
+        }
+    }
+
+    override fun delete(guildId: Long, titleId: Long) {
+        val existing = entityManager.find(GuildTitleRoleDto::class.java, GuildTitleRoleId(guildId, titleId))
+        if (existing != null) {
+            entityManager.remove(existing)
+            entityManager.flush()
+        }
+    }
+}

--- a/database/src/main/kotlin/database/persistence/impl/DefaultMonthlyCreditSnapshotPersistence.kt
+++ b/database/src/main/kotlin/database/persistence/impl/DefaultMonthlyCreditSnapshotPersistence.kt
@@ -1,0 +1,49 @@
+package database.persistence.impl
+
+import database.dto.MonthlyCreditSnapshotDto
+import database.persistence.MonthlyCreditSnapshotPersistence
+import jakarta.persistence.EntityManager
+import jakarta.persistence.PersistenceContext
+import jakarta.persistence.TypedQuery
+import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+
+@Repository
+@Transactional
+class DefaultMonthlyCreditSnapshotPersistence : MonthlyCreditSnapshotPersistence {
+
+    @PersistenceContext
+    private lateinit var entityManager: EntityManager
+
+    override fun get(discordId: Long, guildId: Long, snapshotDate: LocalDate): MonthlyCreditSnapshotDto? {
+        val q: TypedQuery<MonthlyCreditSnapshotDto> =
+            entityManager.createNamedQuery("MonthlyCreditSnapshotDto.getForUserDate", MonthlyCreditSnapshotDto::class.java)
+        q.setParameter("guildId", guildId)
+        q.setParameter("discordId", discordId)
+        q.setParameter("snapshotDate", snapshotDate)
+        return q.resultList.firstOrNull()
+    }
+
+    override fun listForGuildDate(guildId: Long, snapshotDate: LocalDate): List<MonthlyCreditSnapshotDto> {
+        val q: TypedQuery<MonthlyCreditSnapshotDto> =
+            entityManager.createNamedQuery("MonthlyCreditSnapshotDto.getForGuildDate", MonthlyCreditSnapshotDto::class.java)
+        q.setParameter("guildId", guildId)
+        q.setParameter("snapshotDate", snapshotDate)
+        return q.resultList
+    }
+
+    override fun upsert(dto: MonthlyCreditSnapshotDto): MonthlyCreditSnapshotDto {
+        val existing = get(dto.discordId, dto.guildId, dto.snapshotDate)
+        return if (existing == null) {
+            entityManager.persist(dto)
+            entityManager.flush()
+            dto
+        } else {
+            existing.socialCredit = dto.socialCredit
+            entityManager.merge(existing)
+            entityManager.flush()
+            existing
+        }
+    }
+}

--- a/database/src/main/kotlin/database/persistence/impl/DefaultTitlePersistence.kt
+++ b/database/src/main/kotlin/database/persistence/impl/DefaultTitlePersistence.kt
@@ -1,0 +1,52 @@
+package database.persistence.impl
+
+import database.dto.TitleDto
+import database.dto.UserOwnedTitleDto
+import database.persistence.TitlePersistence
+import jakarta.persistence.EntityManager
+import jakarta.persistence.PersistenceContext
+import jakarta.persistence.TypedQuery
+import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
+
+@Repository
+@Transactional
+class DefaultTitlePersistence : TitlePersistence {
+
+    @PersistenceContext
+    private lateinit var entityManager: EntityManager
+
+    override fun listAll(): List<TitleDto> {
+        val q: TypedQuery<TitleDto> = entityManager.createNamedQuery("TitleDto.getAll", TitleDto::class.java)
+        return q.resultList
+    }
+
+    override fun getById(id: Long): TitleDto? = entityManager.find(TitleDto::class.java, id)
+
+    override fun getByLabel(label: String): TitleDto? {
+        val q: TypedQuery<TitleDto> = entityManager.createNamedQuery("TitleDto.getByLabel", TitleDto::class.java)
+        q.setParameter("label", label)
+        return q.resultList.firstOrNull()
+    }
+
+    override fun listOwned(discordId: Long): List<UserOwnedTitleDto> {
+        val q: TypedQuery<UserOwnedTitleDto> =
+            entityManager.createNamedQuery("UserOwnedTitleDto.getByUser", UserOwnedTitleDto::class.java)
+        q.setParameter("discordId", discordId)
+        return q.resultList
+    }
+
+    override fun owns(discordId: Long, titleId: Long): Boolean {
+        val q = entityManager.createNamedQuery("UserOwnedTitleDto.exists")
+        q.setParameter("discordId", discordId)
+        q.setParameter("titleId", titleId)
+        val count = (q.singleResult as? Number)?.toLong() ?: 0L
+        return count > 0
+    }
+
+    override fun recordPurchase(owned: UserOwnedTitleDto): UserOwnedTitleDto {
+        entityManager.persist(owned)
+        entityManager.flush()
+        return owned
+    }
+}

--- a/database/src/main/kotlin/database/persistence/impl/DefaultVoiceCreditDailyPersistence.kt
+++ b/database/src/main/kotlin/database/persistence/impl/DefaultVoiceCreditDailyPersistence.kt
@@ -1,0 +1,41 @@
+package database.persistence.impl
+
+import database.dto.VoiceCreditDailyDto
+import database.persistence.VoiceCreditDailyPersistence
+import jakarta.persistence.EntityManager
+import jakarta.persistence.PersistenceContext
+import jakarta.persistence.TypedQuery
+import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+
+@Repository
+@Transactional
+class DefaultVoiceCreditDailyPersistence : VoiceCreditDailyPersistence {
+
+    @PersistenceContext
+    private lateinit var entityManager: EntityManager
+
+    override fun get(discordId: Long, guildId: Long, date: LocalDate): VoiceCreditDailyDto? {
+        val q: TypedQuery<VoiceCreditDailyDto> =
+            entityManager.createNamedQuery("VoiceCreditDailyDto.get", VoiceCreditDailyDto::class.java)
+        q.setParameter("discordId", discordId)
+        q.setParameter("guildId", guildId)
+        q.setParameter("earnDate", date)
+        return q.resultList.firstOrNull()
+    }
+
+    override fun upsert(row: VoiceCreditDailyDto): VoiceCreditDailyDto {
+        val existing = get(row.discordId, row.guildId, row.earnDate)
+        return if (existing == null) {
+            entityManager.persist(row)
+            entityManager.flush()
+            row
+        } else {
+            existing.credits = row.credits
+            entityManager.merge(existing)
+            entityManager.flush()
+            existing
+        }
+    }
+}

--- a/database/src/main/kotlin/database/persistence/impl/DefaultVoiceSessionPersistence.kt
+++ b/database/src/main/kotlin/database/persistence/impl/DefaultVoiceSessionPersistence.kt
@@ -1,0 +1,90 @@
+package database.persistence.impl
+
+import database.dto.VoiceSessionDto
+import database.persistence.VoiceSessionPersistence
+import jakarta.persistence.EntityManager
+import jakarta.persistence.PersistenceContext
+import jakarta.persistence.TypedQuery
+import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+
+@Repository
+@Transactional
+class DefaultVoiceSessionPersistence : VoiceSessionPersistence {
+
+    @PersistenceContext
+    private lateinit var entityManager: EntityManager
+
+    override fun openSession(session: VoiceSessionDto): VoiceSessionDto {
+        entityManager.persist(session)
+        entityManager.flush()
+        return session
+    }
+
+    override fun findOpenSession(discordId: Long, guildId: Long): VoiceSessionDto? {
+        val q: TypedQuery<VoiceSessionDto> = entityManager.createNamedQuery(
+            "VoiceSessionDto.findOpen",
+            VoiceSessionDto::class.java
+        )
+        q.setParameter("discordId", discordId)
+        q.setParameter("guildId", guildId)
+        return q.resultList.firstOrNull()
+    }
+
+    override fun findAllOpenSessions(): List<VoiceSessionDto> {
+        val q: TypedQuery<VoiceSessionDto> = entityManager.createNamedQuery(
+            "VoiceSessionDto.findAllOpen",
+            VoiceSessionDto::class.java
+        )
+        return q.resultList
+    }
+
+    override fun closeSession(session: VoiceSessionDto): VoiceSessionDto {
+        entityManager.merge(session)
+        entityManager.flush()
+        return session
+    }
+
+    override fun sumCountedSecondsInRange(
+        guildId: Long,
+        discordId: Long,
+        from: Instant,
+        until: Instant
+    ): Long {
+        val q = entityManager.createNamedQuery("VoiceSessionDto.sumCountedSecondsInRange")
+        q.setParameter("guildId", guildId)
+        q.setParameter("discordId", discordId)
+        q.setParameter("from", from)
+        q.setParameter("until", until)
+        return (q.singleResult as? Number)?.toLong() ?: 0L
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    override fun sumCountedSecondsInRangeByUser(
+        guildId: Long,
+        from: Instant,
+        until: Instant
+    ): Map<Long, Long> {
+        val q = entityManager.createNamedQuery("VoiceSessionDto.sumCountedSecondsInRangeAllUsers")
+        q.setParameter("guildId", guildId)
+        q.setParameter("from", from)
+        q.setParameter("until", until)
+        val rows = q.resultList as List<Array<Any?>>
+        return rows.associate {
+            (it[0] as Number).toLong() to (it[1] as? Number)?.toLong().orZero()
+        }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    override fun sumCountedSecondsLifetimeByUser(guildId: Long): Map<Long, Long> {
+        val q = entityManager.createNamedQuery("VoiceSessionDto.sumCountedSecondsLifetime")
+        q.setParameter("guildId", guildId)
+        val rows = q.resultList as List<Array<Any?>>
+        return rows.associate {
+            (it[0] as Number).toLong() to (it[1] as? Number)?.toLong().orZero()
+        }
+    }
+
+    private fun Long?.orZero(): Long = this ?: 0L
+}

--- a/database/src/main/kotlin/database/service/GuildTitleRoleService.kt
+++ b/database/src/main/kotlin/database/service/GuildTitleRoleService.kt
@@ -1,0 +1,10 @@
+package database.service
+
+import database.dto.GuildTitleRoleDto
+
+interface GuildTitleRoleService {
+    fun get(guildId: Long, titleId: Long): GuildTitleRoleDto?
+    fun listByGuild(guildId: Long): List<GuildTitleRoleDto>
+    fun save(dto: GuildTitleRoleDto): GuildTitleRoleDto
+    fun delete(guildId: Long, titleId: Long)
+}

--- a/database/src/main/kotlin/database/service/MonthlyCreditSnapshotService.kt
+++ b/database/src/main/kotlin/database/service/MonthlyCreditSnapshotService.kt
@@ -1,0 +1,10 @@
+package database.service
+
+import database.dto.MonthlyCreditSnapshotDto
+import java.time.LocalDate
+
+interface MonthlyCreditSnapshotService {
+    fun get(discordId: Long, guildId: Long, snapshotDate: LocalDate): MonthlyCreditSnapshotDto?
+    fun listForGuildDate(guildId: Long, snapshotDate: LocalDate): List<MonthlyCreditSnapshotDto>
+    fun upsert(dto: MonthlyCreditSnapshotDto): MonthlyCreditSnapshotDto
+}

--- a/database/src/main/kotlin/database/service/TitleService.kt
+++ b/database/src/main/kotlin/database/service/TitleService.kt
@@ -1,0 +1,14 @@
+package database.service
+
+import database.dto.TitleDto
+import database.dto.UserOwnedTitleDto
+
+interface TitleService {
+    fun listAll(): List<TitleDto>
+    fun getById(id: Long): TitleDto?
+    fun getByLabel(label: String): TitleDto?
+
+    fun listOwned(discordId: Long): List<UserOwnedTitleDto>
+    fun owns(discordId: Long, titleId: Long): Boolean
+    fun recordPurchase(discordId: Long, titleId: Long): UserOwnedTitleDto
+}

--- a/database/src/main/kotlin/database/service/VoiceCreditDailyService.kt
+++ b/database/src/main/kotlin/database/service/VoiceCreditDailyService.kt
@@ -1,0 +1,9 @@
+package database.service
+
+import database.dto.VoiceCreditDailyDto
+import java.time.LocalDate
+
+interface VoiceCreditDailyService {
+    fun get(discordId: Long, guildId: Long, date: LocalDate): VoiceCreditDailyDto?
+    fun upsert(row: VoiceCreditDailyDto): VoiceCreditDailyDto
+}

--- a/database/src/main/kotlin/database/service/VoiceSessionService.kt
+++ b/database/src/main/kotlin/database/service/VoiceSessionService.kt
@@ -1,0 +1,14 @@
+package database.service
+
+import database.dto.VoiceSessionDto
+import java.time.Instant
+
+interface VoiceSessionService {
+    fun openSession(session: VoiceSessionDto): VoiceSessionDto
+    fun findOpenSession(discordId: Long, guildId: Long): VoiceSessionDto?
+    fun findAllOpenSessions(): List<VoiceSessionDto>
+    fun closeSession(session: VoiceSessionDto): VoiceSessionDto
+    fun sumCountedSecondsInRange(guildId: Long, discordId: Long, from: Instant, until: Instant): Long
+    fun sumCountedSecondsInRangeByUser(guildId: Long, from: Instant, until: Instant): Map<Long, Long>
+    fun sumCountedSecondsLifetimeByUser(guildId: Long): Map<Long, Long>
+}

--- a/database/src/main/kotlin/database/service/impl/DefaultGuildTitleRoleService.kt
+++ b/database/src/main/kotlin/database/service/impl/DefaultGuildTitleRoleService.kt
@@ -1,0 +1,17 @@
+package database.service.impl
+
+import database.dto.GuildTitleRoleDto
+import database.persistence.GuildTitleRolePersistence
+import database.service.GuildTitleRoleService
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Service
+
+@Service
+class DefaultGuildTitleRoleService @Autowired constructor(
+    private val persistence: GuildTitleRolePersistence
+) : GuildTitleRoleService {
+    override fun get(guildId: Long, titleId: Long): GuildTitleRoleDto? = persistence.get(guildId, titleId)
+    override fun listByGuild(guildId: Long): List<GuildTitleRoleDto> = persistence.listByGuild(guildId)
+    override fun save(dto: GuildTitleRoleDto): GuildTitleRoleDto = persistence.save(dto)
+    override fun delete(guildId: Long, titleId: Long) = persistence.delete(guildId, titleId)
+}

--- a/database/src/main/kotlin/database/service/impl/DefaultMonthlyCreditSnapshotService.kt
+++ b/database/src/main/kotlin/database/service/impl/DefaultMonthlyCreditSnapshotService.kt
@@ -1,0 +1,21 @@
+package database.service.impl
+
+import database.dto.MonthlyCreditSnapshotDto
+import database.persistence.MonthlyCreditSnapshotPersistence
+import database.service.MonthlyCreditSnapshotService
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Service
+import java.time.LocalDate
+
+@Service
+class DefaultMonthlyCreditSnapshotService @Autowired constructor(
+    private val persistence: MonthlyCreditSnapshotPersistence
+) : MonthlyCreditSnapshotService {
+    override fun get(discordId: Long, guildId: Long, snapshotDate: LocalDate): MonthlyCreditSnapshotDto? =
+        persistence.get(discordId, guildId, snapshotDate)
+
+    override fun listForGuildDate(guildId: Long, snapshotDate: LocalDate): List<MonthlyCreditSnapshotDto> =
+        persistence.listForGuildDate(guildId, snapshotDate)
+
+    override fun upsert(dto: MonthlyCreditSnapshotDto): MonthlyCreditSnapshotDto = persistence.upsert(dto)
+}

--- a/database/src/main/kotlin/database/service/impl/DefaultTitleService.kt
+++ b/database/src/main/kotlin/database/service/impl/DefaultTitleService.kt
@@ -1,0 +1,30 @@
+package database.service.impl
+
+import database.dto.TitleDto
+import database.dto.UserOwnedTitleDto
+import database.persistence.TitlePersistence
+import database.service.TitleService
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Service
+import java.time.Instant
+
+@Service
+class DefaultTitleService @Autowired constructor(
+    private val persistence: TitlePersistence
+) : TitleService {
+
+    override fun listAll(): List<TitleDto> = persistence.listAll()
+    override fun getById(id: Long): TitleDto? = persistence.getById(id)
+    override fun getByLabel(label: String): TitleDto? = persistence.getByLabel(label)
+    override fun listOwned(discordId: Long): List<UserOwnedTitleDto> = persistence.listOwned(discordId)
+    override fun owns(discordId: Long, titleId: Long): Boolean = persistence.owns(discordId, titleId)
+
+    override fun recordPurchase(discordId: Long, titleId: Long): UserOwnedTitleDto {
+        val owned = UserOwnedTitleDto(
+            discordId = discordId,
+            titleId = titleId,
+            boughtAt = Instant.now()
+        )
+        return persistence.recordPurchase(owned)
+    }
+}

--- a/database/src/main/kotlin/database/service/impl/DefaultVoiceCreditDailyService.kt
+++ b/database/src/main/kotlin/database/service/impl/DefaultVoiceCreditDailyService.kt
@@ -1,0 +1,18 @@
+package database.service.impl
+
+import database.dto.VoiceCreditDailyDto
+import database.persistence.VoiceCreditDailyPersistence
+import database.service.VoiceCreditDailyService
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Service
+import java.time.LocalDate
+
+@Service
+class DefaultVoiceCreditDailyService @Autowired constructor(
+    private val persistence: VoiceCreditDailyPersistence
+) : VoiceCreditDailyService {
+    override fun get(discordId: Long, guildId: Long, date: LocalDate): VoiceCreditDailyDto? =
+        persistence.get(discordId, guildId, date)
+
+    override fun upsert(row: VoiceCreditDailyDto): VoiceCreditDailyDto = persistence.upsert(row)
+}

--- a/database/src/main/kotlin/database/service/impl/DefaultVoiceSessionService.kt
+++ b/database/src/main/kotlin/database/service/impl/DefaultVoiceSessionService.kt
@@ -1,0 +1,39 @@
+package database.service.impl
+
+import database.dto.VoiceSessionDto
+import database.persistence.VoiceSessionPersistence
+import database.service.VoiceSessionService
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Service
+import java.time.Instant
+
+@Service
+class DefaultVoiceSessionService @Autowired constructor(
+    private val persistence: VoiceSessionPersistence
+) : VoiceSessionService {
+
+    override fun openSession(session: VoiceSessionDto): VoiceSessionDto = persistence.openSession(session)
+
+    override fun findOpenSession(discordId: Long, guildId: Long): VoiceSessionDto? =
+        persistence.findOpenSession(discordId, guildId)
+
+    override fun findAllOpenSessions(): List<VoiceSessionDto> = persistence.findAllOpenSessions()
+
+    override fun closeSession(session: VoiceSessionDto): VoiceSessionDto = persistence.closeSession(session)
+
+    override fun sumCountedSecondsInRange(
+        guildId: Long,
+        discordId: Long,
+        from: Instant,
+        until: Instant
+    ): Long = persistence.sumCountedSecondsInRange(guildId, discordId, from, until)
+
+    override fun sumCountedSecondsInRangeByUser(
+        guildId: Long,
+        from: Instant,
+        until: Instant
+    ): Map<Long, Long> = persistence.sumCountedSecondsInRangeByUser(guildId, from, until)
+
+    override fun sumCountedSecondsLifetimeByUser(guildId: Long): Map<Long, Long> =
+        persistence.sumCountedSecondsLifetimeByUser(guildId)
+}

--- a/database/src/main/resources/db/migration/V13__voice_activity_and_titles.sql
+++ b/database/src/main/resources/db/migration/V13__voice_activity_and_titles.sql
@@ -1,0 +1,83 @@
+-- Voice activity tracking, monthly snapshots, and vanity titles.
+
+-- One row per user-in-channel session. Closed rows carry counted_seconds
+-- (only time when >=1 other non-bot human was present) and the credits
+-- that were awarded on close.
+CREATE TABLE voice_session (
+    id              BIGSERIAL PRIMARY KEY,
+    discord_id      BIGINT      NOT NULL,
+    guild_id        BIGINT      NOT NULL,
+    channel_id      BIGINT      NOT NULL,
+    joined_at       TIMESTAMPTZ NOT NULL,
+    left_at         TIMESTAMPTZ,
+    counted_seconds BIGINT,
+    credits_awarded BIGINT      NOT NULL DEFAULT 0
+);
+CREATE INDEX idx_voice_session_user_guild_time
+    ON voice_session (guild_id, discord_id, joined_at);
+CREATE INDEX idx_voice_session_open
+    ON voice_session (discord_id, guild_id)
+    WHERE left_at IS NULL;
+
+-- Daily cap ledger. Prevents AFK farming beyond a daily ceiling.
+CREATE TABLE voice_credit_daily (
+    discord_id BIGINT NOT NULL,
+    guild_id   BIGINT NOT NULL,
+    earn_date  DATE   NOT NULL,
+    credits    BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (discord_id, guild_id, earn_date)
+);
+
+-- Snapshot of social_credit at the start of each calendar month, per user
+-- per guild. The monthly leaderboard job derives deltas from this.
+CREATE TABLE monthly_credit_snapshot (
+    discord_id    BIGINT      NOT NULL,
+    guild_id      BIGINT      NOT NULL,
+    snapshot_date DATE        NOT NULL,
+    social_credit BIGINT      NOT NULL,
+    PRIMARY KEY (discord_id, guild_id, snapshot_date)
+);
+
+-- Vanity titles catalog.
+CREATE TABLE title (
+    id          BIGSERIAL PRIMARY KEY,
+    label       TEXT    NOT NULL UNIQUE,
+    cost        BIGINT  NOT NULL,
+    description TEXT,
+    color_hex   TEXT,
+    hoisted     BOOLEAN NOT NULL DEFAULT FALSE
+);
+
+INSERT INTO title (label, cost, description, color_hex, hoisted) VALUES
+    ('⭐ Comrade',             100,  'Loyal citizen.',                                    '#F1C40F', FALSE),
+    ('🎙️ Glorious Speaker',   500,  'Heard in voice channels far and wide.',             '#3498DB', FALSE),
+    ('👑 Party Chair',         2000, 'A pillar of the server.',                           '#E67E22', TRUE),
+    ('🥉 Bronze Citizen',      250,  'Dependable and present.',                           '#CD7F32', FALSE),
+    ('🥈 Silver Citizen',      750,  'A recognised regular.',                             '#C0C0C0', FALSE),
+    ('🥇 Gold Citizen',        2500, 'Among the server''s finest.',                       '#FFD700', TRUE),
+    ('🤖 Toby''s Favourite',   5000, 'Hand-picked by the bot itself.',                    '#9B59B6', TRUE),
+    ('💸 Big Spender',         1500, 'Knows how to move credits.',                        '#2ECC71', FALSE),
+    ('🎵 DJ',                  800,  'Always queueing the bangers.',                      '#1ABC9C', FALSE),
+    ('🌙 Night Owl',           600,  'Logs the late-night voice hours.',                  '#34495E', FALSE);
+
+-- Ownership join table. A user can own many titles across their guild memberships.
+CREATE TABLE user_owned_title (
+    discord_id BIGINT      NOT NULL,
+    title_id   BIGINT      NOT NULL REFERENCES title(id),
+    bought_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (discord_id, title_id)
+);
+
+-- Maps (guild, title) to the bot-created Discord role. Populated lazily
+-- the first time a user in a guild equips a title. Lets us reuse roles
+-- across restarts and across buyers.
+CREATE TABLE guild_title_role (
+    guild_id        BIGINT NOT NULL,
+    title_id        BIGINT NOT NULL REFERENCES title(id),
+    discord_role_id BIGINT NOT NULL,
+    PRIMARY KEY (guild_id, title_id)
+);
+
+-- Currently-equipped title per user per guild.
+ALTER TABLE public."user"
+    ADD COLUMN active_title_id BIGINT REFERENCES title(id);

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/EconomyCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/EconomyCommand.kt
@@ -1,0 +1,5 @@
+package bot.toby.command.commands.economy
+
+import core.command.Command
+
+interface EconomyCommand : Command

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/TitleCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/TitleCommand.kt
@@ -1,0 +1,200 @@
+package bot.toby.command.commands.economy
+
+import web.service.TitleRoleResult
+import web.service.TitleRoleService
+import core.command.Command.Companion.invokeDeleteOnMessageResponse
+import core.command.CommandContext
+import database.dto.UserDto
+import database.service.TitleService
+import database.service.UserService
+import net.dv8tion.jda.api.EmbedBuilder
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.Member
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
+import net.dv8tion.jda.api.interactions.commands.OptionType
+import net.dv8tion.jda.api.interactions.commands.build.OptionData
+import net.dv8tion.jda.api.interactions.commands.build.SubcommandData
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+@Component
+class TitleCommand @Autowired constructor(
+    private val titleService: TitleService,
+    private val userService: UserService,
+    private val titleRoleService: TitleRoleService
+) : EconomyCommand {
+
+    override val name: String = "title"
+    override val description: String = "Browse, buy, and equip vanity titles with your social credit."
+
+    companion object {
+        private const val OPT_TITLE = "title"
+    }
+
+    override val subCommands: List<SubcommandData> = listOf(
+        SubcommandData("shop", "List titles available for purchase."),
+        SubcommandData("buy", "Buy a title with your social credit.")
+            .addOptions(
+                OptionData(OptionType.STRING, OPT_TITLE, "Exact title label (e.g. '⭐ Comrade')", true)
+            ),
+        SubcommandData("equip", "Equip a title you own so it appears on the leaderboard and grants the matching Discord role.")
+            .addOptions(
+                OptionData(OptionType.STRING, OPT_TITLE, "Exact title label to equip", true)
+            ),
+        SubcommandData("unequip", "Remove your currently equipped title."),
+        SubcommandData("list", "List the titles you own and your currently equipped title.")
+    )
+
+    override fun handle(ctx: CommandContext, requestingUserDto: UserDto, deleteDelay: Int) {
+        val event = ctx.event
+        event.deferReply(true).queue()
+
+        val guild = event.guild ?: run {
+            event.hook.sendMessage("This command can only be used in a server.")
+                .setEphemeral(true)
+                .queue(invokeDeleteOnMessageResponse(deleteDelay))
+            return
+        }
+        val member = event.member ?: run {
+            event.hook.sendMessage("Could not resolve your member info.")
+                .setEphemeral(true)
+                .queue(invokeDeleteOnMessageResponse(deleteDelay))
+            return
+        }
+
+        when (event.subcommandName) {
+            "shop" -> handleShop(event, deleteDelay)
+            "buy" -> handleBuy(event, requestingUserDto, deleteDelay)
+            "equip" -> handleEquip(event, guild, member, requestingUserDto, deleteDelay)
+            "unequip" -> handleUnequip(event, guild, member, requestingUserDto, deleteDelay)
+            "list" -> handleList(event, requestingUserDto, deleteDelay)
+            else -> event.hook.sendMessage("Unknown subcommand.")
+                .setEphemeral(true)
+                .queue(invokeDeleteOnMessageResponse(deleteDelay))
+        }
+    }
+
+    private fun handleShop(event: SlashCommandInteractionEvent, deleteDelay: Int) {
+        val titles = titleService.listAll()
+        val body = if (titles.isEmpty()) {
+            "No titles are available right now."
+        } else {
+            titles.joinToString("\n") { t ->
+                val desc = if (!t.description.isNullOrBlank()) " — ${t.description}" else ""
+                "**${t.label}** · ${t.cost} credits$desc"
+            }
+        }
+        val embed = EmbedBuilder()
+            .setTitle("Title Shop")
+            .setDescription(body)
+            .setFooter("Buy with /title buy <exact label>")
+            .build()
+        event.hook.sendMessageEmbeds(embed)
+            .setEphemeral(true)
+            .queue(invokeDeleteOnMessageResponse(deleteDelay))
+    }
+
+    private fun handleBuy(event: SlashCommandInteractionEvent, userDto: UserDto, deleteDelay: Int) {
+        val label = event.getOption(OPT_TITLE)?.asString?.trim().orEmpty()
+        if (label.isEmpty()) {
+            reply(event, "You must specify a title label.", deleteDelay); return
+        }
+        val title = titleService.getByLabel(label)
+        if (title == null) {
+            reply(event, "No title matches '$label'. Use /title shop to see available titles.", deleteDelay); return
+        }
+        val titleId = title.id ?: run {
+            reply(event, "Title has no id. Try again.", deleteDelay); return
+        }
+        if (titleService.owns(userDto.discordId, titleId)) {
+            reply(event, "You already own **${title.label}**. Use /title equip to wear it.", deleteDelay); return
+        }
+        val balance = userDto.socialCredit ?: 0L
+        if (balance < title.cost) {
+            reply(event, "You need ${title.cost} credits but only have $balance. Earn more by chatting and spending time in voice.", deleteDelay); return
+        }
+
+        userDto.socialCredit = balance - title.cost
+        userService.updateUser(userDto)
+        titleService.recordPurchase(userDto.discordId, titleId)
+        reply(event, "Bought **${title.label}** for ${title.cost} credits. You now have ${userDto.socialCredit} credits. Equip it with /title equip.", deleteDelay)
+    }
+
+    private fun handleEquip(
+        event: SlashCommandInteractionEvent,
+        guild: Guild,
+        member: Member,
+        userDto: UserDto,
+        deleteDelay: Int
+    ) {
+        val label = event.getOption(OPT_TITLE)?.asString?.trim().orEmpty()
+        if (label.isEmpty()) {
+            reply(event, "You must specify a title label.", deleteDelay); return
+        }
+        val title = titleService.getByLabel(label)
+        if (title == null) {
+            reply(event, "No title matches '$label'.", deleteDelay); return
+        }
+        val titleId = title.id ?: run {
+            reply(event, "Title has no id. Try again.", deleteDelay); return
+        }
+        if (!titleService.owns(userDto.discordId, titleId)) {
+            reply(event, "You don't own **${title.label}**. Buy it with /title buy first.", deleteDelay); return
+        }
+
+        val ownedIds = titleService.listOwned(userDto.discordId).map { it.titleId }.toSet()
+        when (val result = titleRoleService.equip(guild, member, title, ownedIds)) {
+            is TitleRoleResult.Ok -> {
+                userDto.activeTitleId = titleId
+                userService.updateUser(userDto)
+                reply(event, "Equipped **${title.label}**. Your Discord role has been updated.", deleteDelay)
+            }
+            is TitleRoleResult.Error -> {
+                reply(event, "Could not equip **${title.label}** — ${result.message}", deleteDelay)
+            }
+        }
+    }
+
+    private fun handleUnequip(
+        event: SlashCommandInteractionEvent,
+        guild: Guild,
+        member: Member,
+        userDto: UserDto,
+        deleteDelay: Int
+    ) {
+        if (userDto.activeTitleId == null) {
+            reply(event, "You don't have a title equipped.", deleteDelay); return
+        }
+        val ownedIds = titleService.listOwned(userDto.discordId).map { it.titleId }.toSet()
+        when (val result = titleRoleService.unequip(guild, member, ownedIds)) {
+            is TitleRoleResult.Ok -> {
+                userDto.activeTitleId = null
+                userService.updateUser(userDto)
+                reply(event, "Title unequipped.", deleteDelay)
+            }
+            is TitleRoleResult.Error -> {
+                reply(event, "Could not unequip — ${result.message}", deleteDelay)
+            }
+        }
+    }
+
+    private fun handleList(event: SlashCommandInteractionEvent, userDto: UserDto, deleteDelay: Int) {
+        val owned = titleService.listOwned(userDto.discordId)
+        if (owned.isEmpty()) {
+            reply(event, "You don't own any titles yet. Use /title shop to see what's on offer.", deleteDelay); return
+        }
+        val titles = owned.mapNotNull { titleService.getById(it.titleId) }
+        val equippedId = userDto.activeTitleId
+        val lines = titles.joinToString("\n") { t ->
+            val marker = if (t.id == equippedId) " ← equipped" else ""
+            "• ${t.label}$marker"
+        }
+        reply(event, "**Your titles**\n$lines", deleteDelay)
+    }
+
+    private fun reply(event: SlashCommandInteractionEvent, message: String, deleteDelay: Int) {
+        event.hook.sendMessage(message)
+            .setEphemeral(true)
+            .queue(invokeDeleteOnMessageResponse(deleteDelay))
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/moderation/SetConfigCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/moderation/SetConfigCommand.kt
@@ -5,6 +5,7 @@ import core.command.CommandContext
 import database.dto.ConfigDto
 import database.dto.UserDto
 import database.service.ConfigService
+import net.dv8tion.jda.api.entities.channel.ChannelType
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
 import net.dv8tion.jda.api.interactions.commands.OptionMapping
 import net.dv8tion.jda.api.interactions.commands.OptionType
@@ -51,8 +52,31 @@ class SetConfigCommand @Autowired constructor(private val configService: ConfigS
                 )
                 ConfigDto.Configurations.INTRO_VOLUME -> setConfigAndSendMessage(event, optionMapping, deleteDelay,
                     "Set default intro volume to '${optionMapping.asInt}'")
+                ConfigDto.Configurations.LEADERBOARD_CHANNEL -> setLeaderboardChannel(event, deleteDelay)
             }
         }
+    }
+
+    private fun setLeaderboardChannel(event: SlashCommandInteractionEvent, deleteDelay: Int) {
+        val configValue = ConfigDto.Configurations.LEADERBOARD_CHANNEL.configValue
+        val guildId = event.guild?.id ?: return
+        val channel = event.getOption(
+            ConfigDto.Configurations.LEADERBOARD_CHANNEL.name.lowercase(Locale.getDefault())
+        )?.asChannel
+        if (channel == null) {
+            event.hook.sendMessage("No valid text channel was mentioned, so config was not updated")
+                .setEphemeral(true).queue(invokeDeleteOnMessageResponse(deleteDelay))
+            return
+        }
+        val newConfigDto = ConfigDto(configValue, channel.id, guildId)
+        val databaseConfig = configService.getConfigByName(configValue, guildId)
+        if (databaseConfig != null && databaseConfig.guildId == newConfigDto.guildId) {
+            configService.updateConfig(newConfigDto)
+        } else {
+            configService.createNewConfig(newConfigDto)
+        }
+        event.hook.sendMessage("Monthly leaderboards will now post in <#${channel.id}> on the 1st of each month.")
+            .setEphemeral(true).queue(invokeDeleteOnMessageResponse(deleteDelay))
     }
 
     private fun setConfigAndSendMessage(
@@ -137,6 +161,12 @@ class SetConfigCommand @Autowired constructor(private val configService: ConfigS
                 ConfigDto.Configurations.MOVE.name.lowercase(Locale.getDefault()),
                 "Value for the default move channel you want if using move command without arguments",
                 false
-            )
+            ),
+            OptionData(
+                OptionType.CHANNEL,
+                ConfigDto.Configurations.LEADERBOARD_CHANNEL.name.lowercase(Locale.getDefault()),
+                "Text channel for the monthly social credit leaderboard post",
+                false
+            ).setChannelTypes(ChannelType.TEXT)
         )
 }

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/moderation/SocialCreditCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/moderation/SocialCreditCommand.kt
@@ -3,7 +3,9 @@ package bot.toby.command.commands.moderation
 import core.command.Command.Companion.invokeDeleteOnMessageResponse
 import core.command.CommandContext
 import database.dto.UserDto
+import database.service.TitleService
 import database.service.UserService
+import database.service.VoiceSessionService
 import net.dv8tion.jda.api.entities.Member
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
 import net.dv8tion.jda.api.interactions.commands.OptionType
@@ -12,7 +14,11 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 @Component
-class SocialCreditCommand @Autowired constructor(private val userService: UserService) : ModerationCommand {
+class SocialCreditCommand @Autowired constructor(
+    private val userService: UserService,
+    private val voiceSessionService: VoiceSessionService,
+    private val titleService: TitleService
+) : ModerationCommand {
     companion object {
         private const val LEADERBOARD = "leaderboard"
         private const val USERS = "users"
@@ -64,13 +70,20 @@ class SocialCreditCommand @Autowired constructor(private val userService: UserSe
 
     private fun createAndPrintLeaderboard(event: SlashCommandInteractionEvent, deleteDelay: Int) {
         val guild = event.guild ?: return
-        val socialCreditMap = userService.listGuildUsers(guild.idLong).associate { it?.discordId to it?.socialCredit }
+        val users = userService.listGuildUsers(guild.idLong).filterNotNull()
+        val voiceSecondsByUser = voiceSessionService.sumCountedSecondsLifetimeByUser(guild.idLong)
 
-        val leaderboard = socialCreditMap.entries
-            .sortedByDescending { it.value }
-            .mapIndexed { index, entry ->
-                val member = entry.key?.let { guild.getMemberById(it) }
-                "#${index + 1}: ${member?.effectiveName ?: "Unknown"} - score: ${entry.value}"
+        val leaderboard = users
+            .sortedByDescending { it.socialCredit ?: 0L }
+            .mapIndexed { index, dto ->
+                val member = guild.getMemberById(dto.discordId)
+                val titlePrefix = dto.activeTitleId
+                    ?.let { titleService.getById(it) }
+                    ?.label
+                    ?.let { "$it " }
+                    ?: ""
+                val voice = formatDuration(voiceSecondsByUser[dto.discordId] ?: 0L)
+                "#${index + 1}: $titlePrefix${member?.effectiveName ?: "Unknown"} — ${dto.socialCredit ?: 0L} credits · $voice voice"
             }
 
         val message = buildString {
@@ -82,6 +95,13 @@ class SocialCreditCommand @Autowired constructor(private val userService: UserSe
         event.hook.sendMessage(message)
             .setEphemeral(true)
             .queue(invokeDeleteOnMessageResponse(deleteDelay))
+    }
+
+    private fun formatDuration(seconds: Long): String {
+        if (seconds <= 0) return "0m"
+        val hours = seconds / 3600
+        val minutes = (seconds % 3600) / 60
+        return if (hours > 0) "${hours}h ${minutes}m" else "${minutes}m"
     }
 
     private fun listSocialCreditScore(

--- a/discord-bot/src/main/kotlin/bot/toby/handler/VoiceEventHandler.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/handler/VoiceEventHandler.kt
@@ -6,10 +6,14 @@ import bot.toby.helpers.UserDtoHelper
 import bot.toby.helpers.UserDtoHelper.Companion.getRequestingUserDto
 import bot.toby.helpers.nonBots
 import bot.toby.lavaplayer.PlayerManager
+import bot.toby.voice.VoiceCompanyTracker
+import bot.toby.voice.VoiceCreditAwardService
 import common.logging.DiscordLogger
 import database.dto.ConfigDto.Configurations.DELETE_DELAY
 import database.dto.ConfigDto.Configurations.VOLUME
+import database.dto.VoiceSessionDto
 import database.service.ConfigService
+import database.service.VoiceSessionService
 import bot.toby.helpers.MusicPlayerHelper
 import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.entities.channel.concrete.VoiceChannel
@@ -21,6 +25,7 @@ import net.dv8tion.jda.api.hooks.ListenerAdapter
 import net.dv8tion.jda.api.managers.AudioManager
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
+import java.time.Instant
 import java.util.concurrent.ConcurrentHashMap
 
 private const val TEAM_REGEX = "(?i)team\\s[0-9]+"
@@ -29,7 +34,10 @@ private const val TEAM_REGEX = "(?i)team\\s[0-9]+"
 class VoiceEventHandler @Autowired constructor(
     private val configService: ConfigService,
     private val userDtoHelper: UserDtoHelper,
-    private val introHelper: IntroHelper
+    private val introHelper: IntroHelper,
+    private val voiceSessionService: VoiceSessionService,
+    private val voiceCompanyTracker: VoiceCompanyTracker,
+    private val voiceCreditAwardService: VoiceCreditAwardService
 ) : ListenerAdapter() {
 
     private val logger: DiscordLogger = DiscordLogger.createLogger(this::class.java)
@@ -116,6 +124,10 @@ class VoiceEventHandler @Autowired constructor(
             }
         } else {
             logger.info { "User '${member.effectiveName}' has moved, checking if AudioConnection should close..." }
+            val now = Instant.now()
+            closeSessionForUser(member.idLong, guild.idLong, now)
+            event.channelLeft?.let { voiceCompanyTracker.reconcileChannel(it, now) }
+            event.channelJoined?.let { openSessionForUser(member.idLong, guild.idLong, it, now) }
             audioManager.checkAudioManagerToCloseConnectionOnEmptyChannel()
             val defaultVolume = getConfigValue(VOLUME.configValue, guild.id)
             checkStateAndConnectToVoiceChannel(event, audioManager, guild, defaultVolume)
@@ -140,6 +152,11 @@ class VoiceEventHandler @Autowired constructor(
             getConfigValue(DELETE_DELAY.configValue, guild.id, 5)
 
         checkStateAndConnectToVoiceChannel(event, audioManager, guild, defaultVolume)
+
+        if (event.member.user.idLong != event.jda.selfUser.idLong) {
+            val now = Instant.now()
+            event.channelJoined?.let { openSessionForUser(event.member.idLong, guild.idLong, it, now) }
+        }
 
         val requestingUserDto = event.member.getRequestingUserDto(userDtoHelper)
         if (audioManager.connectedChannel == event.channelJoined) {
@@ -193,8 +210,40 @@ class VoiceEventHandler @Autowired constructor(
     private fun onGuildVoiceLeave(event: GuildVoiceUpdateEvent) {
         val guild = event.guild
         val audioManager = guild.audioManager
+        val member = event.member
+        if (member.user.idLong != event.jda.selfUser.idLong) {
+            val now = Instant.now()
+            closeSessionForUser(member.idLong, guild.idLong, now)
+            event.channelLeft?.let { voiceCompanyTracker.reconcileChannel(it, now) }
+        }
         audioManager.checkAudioManagerToCloseConnectionOnEmptyChannel()
         event.channelLeft?.let { deleteTemporaryChannelIfEmpty(it.members.nonBots().isEmpty(), it) }
+    }
+
+    private fun openSessionForUser(userId: Long, guildId: Long, channel: AudioChannel, now: Instant) {
+        runCatching {
+            voiceSessionService.findOpenSession(userId, guildId)?.let { stale ->
+                val companySeconds = voiceCompanyTracker.stopTracking(userId, guildId, now)
+                voiceCreditAwardService.closeSessionAndAward(stale, now, companySeconds)
+            }
+            voiceCompanyTracker.reconcileChannel(channel, now)
+            val session = VoiceSessionDto(
+                discordId = userId,
+                guildId = guildId,
+                channelId = channel.idLong,
+                joinedAt = now
+            )
+            voiceSessionService.openSession(session)
+            voiceCompanyTracker.startTracking(userId, guildId, channel, now)
+        }.onFailure { logger.error("Failed to open voice session for user $userId: ${it.message}") }
+    }
+
+    private fun closeSessionForUser(userId: Long, guildId: Long, now: Instant) {
+        runCatching {
+            val open = voiceSessionService.findOpenSession(userId, guildId) ?: return
+            val companySeconds = voiceCompanyTracker.stopTracking(userId, guildId, now)
+            voiceCreditAwardService.closeSessionAndAward(open, now, companySeconds)
+        }.onFailure { logger.error("Failed to close voice session for user $userId: ${it.message}") }
     }
 
     private fun AudioManager.checkAudioManagerToCloseConnectionOnEmptyChannel() {

--- a/discord-bot/src/main/kotlin/bot/toby/scheduling/MonthlyLeaderboardJob.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/scheduling/MonthlyLeaderboardJob.kt
@@ -1,0 +1,161 @@
+package bot.toby.scheduling
+
+import common.logging.DiscordLogger
+import database.dto.ConfigDto
+import database.dto.MonthlyCreditSnapshotDto
+import database.service.ConfigService
+import database.service.MonthlyCreditSnapshotService
+import database.service.UserService
+import database.service.VoiceSessionService
+import net.dv8tion.jda.api.EmbedBuilder
+import net.dv8tion.jda.api.JDA
+import net.dv8tion.jda.api.Permission
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.annotation.Profile
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import java.awt.Color
+import java.time.LocalDate
+import java.time.ZoneOffset
+
+@Component
+@Profile("prod")
+class MonthlyLeaderboardJob @Autowired constructor(
+    private val jda: JDA,
+    private val userService: UserService,
+    private val voiceSessionService: VoiceSessionService,
+    private val snapshotService: MonthlyCreditSnapshotService,
+    private val configService: ConfigService
+) {
+    private val logger: DiscordLogger = DiscordLogger.createLogger(this::class.java)
+
+    companion object {
+        const val TOP_N = 10
+    }
+
+    @Scheduled(cron = "0 0 12 1 * *", zone = "UTC")
+    fun postMonthlyLeaderboard() {
+        val today = LocalDate.now(ZoneOffset.UTC).withDayOfMonth(1)
+        val previousMonthStart = today.minusMonths(1)
+        logger.info { "Running monthly leaderboard job for month starting $previousMonthStart" }
+
+        jda.guildCache.forEach { guild ->
+            runCatching { postForGuild(guild, today, previousMonthStart) }
+                .onFailure { logger.error("Monthly leaderboard failed for guild ${guild.idLong}: ${it.message}") }
+        }
+    }
+
+    private fun postForGuild(guild: Guild, thisMonthStart: LocalDate, previousMonthStart: LocalDate) {
+        val users = userService.listGuildUsers(guild.idLong).filterNotNull()
+        if (users.isEmpty()) {
+            logger.info { "Skipping guild ${guild.idLong} — no tracked users." }
+            return
+        }
+
+        val priorSnapshots = snapshotService.listForGuildDate(guild.idLong, previousMonthStart)
+            .associateBy { it.discordId }
+
+        val previousMonthRange = previousMonthStart.atStartOfDay().toInstant(ZoneOffset.UTC) to
+                thisMonthStart.atStartOfDay().toInstant(ZoneOffset.UTC)
+        val voiceSecondsByUser = voiceSessionService.sumCountedSecondsInRangeByUser(
+            guild.idLong,
+            previousMonthRange.first,
+            previousMonthRange.second
+        )
+
+        val rows = users.map { dto ->
+            val current = dto.socialCredit ?: 0L
+            val baseline = priorSnapshots[dto.discordId]?.socialCredit
+            val creditsDelta = if (baseline == null) current else current - baseline
+            MonthlyRow(
+                discordId = dto.discordId,
+                creditsDelta = creditsDelta,
+                voiceSeconds = voiceSecondsByUser[dto.discordId] ?: 0L
+            )
+        }.sortedWith(
+            compareByDescending<MonthlyRow> { it.creditsDelta }
+                .thenByDescending { it.voiceSeconds }
+        ).take(TOP_N)
+
+        val channel = resolveChannel(guild)
+        if (channel == null) {
+            logger.warn(
+                "No channel to post monthly leaderboard in guild ${guild.idLong}. " +
+                        "Set one via /setleaderboardchannel or grant the bot a writable system channel."
+            )
+        } else {
+            val embed = buildEmbed(guild, previousMonthStart, rows)
+            runCatching { channel.sendMessageEmbeds(embed).queue() }
+                .onFailure { logger.error("Could not send leaderboard to ${channel.id}: ${it.message}") }
+        }
+
+        writeCurrentMonthSnapshot(guild.idLong, users, thisMonthStart)
+    }
+
+    private fun resolveChannel(guild: Guild): TextChannel? {
+        val bot = guild.selfMember
+        val configured = configService.getConfigByName(
+            ConfigDto.Configurations.LEADERBOARD_CHANNEL.configValue,
+            guild.id
+        )?.value?.toLongOrNull()
+        configured?.let {
+            val channel = guild.getTextChannelById(it)
+            if (channel != null && bot.hasPermission(channel, Permission.MESSAGE_SEND, Permission.MESSAGE_EMBED_LINKS)) {
+                return channel
+            }
+        }
+        return guild.systemChannel?.takeIf {
+            bot.hasPermission(it, Permission.MESSAGE_SEND, Permission.MESSAGE_EMBED_LINKS)
+        }
+    }
+
+    private fun buildEmbed(guild: Guild, previousMonthStart: LocalDate, rows: List<MonthlyRow>): net.dv8tion.jda.api.entities.MessageEmbed {
+        val monthLabel = previousMonthStart.month.name.lowercase().replaceFirstChar { it.titlecase() } +
+                " ${previousMonthStart.year}"
+
+        val description = if (rows.isEmpty()) {
+            "No activity recorded for $monthLabel."
+        } else {
+            rows.mapIndexed { idx, row ->
+                val name = guild.getMemberById(row.discordId)?.effectiveName ?: "Unknown (${row.discordId})"
+                val voice = formatDuration(row.voiceSeconds)
+                "**#${idx + 1}** $name — ${row.creditsDelta} credits · $voice"
+            }.joinToString("\n")
+        }
+
+        return EmbedBuilder()
+            .setTitle("Monthly Social Credit Leaderboard — $monthLabel")
+            .setDescription(description)
+            .setColor(Color(0xFFD700))
+            .setFooter("Totals reflect credits earned (including voice-time) and counted voice time.")
+            .build()
+    }
+
+    private fun writeCurrentMonthSnapshot(guildId: Long, users: List<database.dto.UserDto>, snapshotDate: LocalDate) {
+        users.forEach { dto ->
+            snapshotService.upsert(
+                MonthlyCreditSnapshotDto(
+                    discordId = dto.discordId,
+                    guildId = guildId,
+                    snapshotDate = snapshotDate,
+                    socialCredit = dto.socialCredit ?: 0L
+                )
+            )
+        }
+    }
+
+    private fun formatDuration(seconds: Long): String {
+        if (seconds <= 0) return "0m"
+        val hours = seconds / 3600
+        val minutes = (seconds % 3600) / 60
+        return if (hours > 0) "${hours}h ${minutes}m" else "${minutes}m"
+    }
+
+    private data class MonthlyRow(
+        val discordId: Long,
+        val creditsDelta: Long,
+        val voiceSeconds: Long
+    )
+}

--- a/discord-bot/src/main/kotlin/bot/toby/voice/VoiceCompanyTracker.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/voice/VoiceCompanyTracker.kt
@@ -1,0 +1,57 @@
+package bot.toby.voice
+
+import net.dv8tion.jda.api.entities.channel.middleman.AudioChannel
+import org.springframework.stereotype.Component
+import java.time.Instant
+import java.util.concurrent.ConcurrentHashMap
+
+@Component
+class VoiceCompanyTracker {
+
+    private data class Tracker(
+        @Volatile var companyAccumSeconds: Long = 0L,
+        @Volatile var companyStartedAt: Instant? = null
+    )
+
+    private val trackers = ConcurrentHashMap<Pair<Long, Long>, Tracker>()
+
+    fun startTracking(userId: Long, guildId: Long, channel: AudioChannel, now: Instant) {
+        val tracker = Tracker()
+        if (hasCompany(channel, userId)) {
+            tracker.companyStartedAt = now
+        }
+        trackers[userId to guildId] = tracker
+    }
+
+    fun stopTracking(userId: Long, guildId: Long, now: Instant): Long {
+        val tracker = trackers.remove(userId to guildId) ?: return 0L
+        tracker.companyStartedAt?.let { started ->
+            tracker.companyAccumSeconds += maxOf(0L, now.epochSecond - started.epochSecond)
+        }
+        return tracker.companyAccumSeconds
+    }
+
+    fun reconcileChannel(channel: AudioChannel, now: Instant) {
+        val guildId = channel.guild.idLong
+        channel.members.forEach { member ->
+            if (member.user.isBot) return@forEach
+            val key = member.idLong to guildId
+            val tracker = trackers[key] ?: return@forEach
+            val companyNow = hasCompany(channel, member.idLong)
+            val startedAt = tracker.companyStartedAt
+            when {
+                companyNow && startedAt == null -> tracker.companyStartedAt = now
+                !companyNow && startedAt != null -> {
+                    tracker.companyAccumSeconds += maxOf(0L, now.epochSecond - startedAt.epochSecond)
+                    tracker.companyStartedAt = null
+                }
+            }
+        }
+    }
+
+    private fun hasCompany(channel: AudioChannel, exceptUserId: Long): Boolean {
+        return channel.members.any { other ->
+            !other.user.isBot && other.idLong != exceptUserId
+        }
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/voice/VoiceCreditAwardService.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/voice/VoiceCreditAwardService.kt
@@ -1,0 +1,81 @@
+package bot.toby.voice
+
+import common.logging.DiscordLogger
+import database.dto.VoiceCreditDailyDto
+import database.dto.VoiceSessionDto
+import database.service.UserService
+import database.service.VoiceCreditDailyService
+import database.service.VoiceSessionService
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Service
+import java.time.Duration
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneOffset
+
+@Service
+class VoiceCreditAwardService @Autowired constructor(
+    private val voiceSessionService: VoiceSessionService,
+    private val voiceCreditDailyService: VoiceCreditDailyService,
+    private val userService: UserService
+) {
+    private val logger: DiscordLogger = DiscordLogger.createLogger(this::class.java)
+
+    fun closeSessionAndAward(
+        session: VoiceSessionDto,
+        closedAt: Instant,
+        hadCompanyDurationSeconds: Long
+    ) {
+        val rawSeconds = Duration.between(session.joinedAt, closedAt).seconds.coerceAtLeast(0)
+        val countedSeconds = hadCompanyDurationSeconds.coerceIn(0, rawSeconds)
+        val rawCredits = countedSeconds / VoiceCreditConfig.SECONDS_PER_CREDIT
+        val awardedCredits = clampToDailyCap(session.discordId, session.guildId, rawCredits, closedAt)
+
+        session.leftAt = closedAt
+        session.countedSeconds = countedSeconds
+        session.creditsAwarded = awardedCredits
+        voiceSessionService.closeSession(session)
+
+        if (awardedCredits > 0) {
+            val user = userService.getUserById(session.discordId, session.guildId)
+            if (user != null) {
+                user.socialCredit = (user.socialCredit ?: 0L) + awardedCredits
+                userService.updateUser(user)
+                logger.info {
+                    "Awarded $awardedCredits voice credits to user ${session.discordId} in guild ${session.guildId} " +
+                            "(counted=${countedSeconds}s, raw=${rawSeconds}s)"
+                }
+            } else {
+                logger.warn(
+                    "No user row for discordId=${session.discordId} guildId=${session.guildId}; skipped awarding"
+                )
+            }
+        }
+    }
+
+    fun closeRecoveredSession(session: VoiceSessionDto, closedAt: Instant) {
+        val rawSeconds = Duration.between(session.joinedAt, closedAt).seconds.coerceAtLeast(0)
+        val cappedSeconds = rawSeconds.coerceAtMost(VoiceCreditConfig.MAX_RECOVERED_SESSION_SECONDS)
+        closeSessionAndAward(session, closedAt, cappedSeconds)
+    }
+
+    private fun clampToDailyCap(discordId: Long, guildId: Long, newCredits: Long, at: Instant): Long {
+        if (newCredits <= 0) return 0L
+        val today = LocalDate.ofInstant(at, ZoneOffset.UTC)
+        val existing = voiceCreditDailyService.get(discordId, guildId, today)
+        val usedToday = existing?.credits ?: 0L
+        val headroom = (VoiceCreditConfig.DAILY_CREDIT_CAP - usedToday).coerceAtLeast(0L)
+        val granted = newCredits.coerceAtMost(headroom)
+        if (granted > 0) {
+            voiceCreditDailyService.upsert(
+                VoiceCreditDailyDto(
+                    discordId = discordId,
+                    guildId = guildId,
+                    earnDate = today,
+                    credits = usedToday + granted
+                )
+            )
+        }
+        return granted
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/voice/VoiceCreditConfig.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/voice/VoiceCreditConfig.kt
@@ -1,0 +1,9 @@
+package bot.toby.voice
+
+object VoiceCreditConfig {
+    const val SECONDS_PER_CREDIT: Long = 120L
+
+    const val DAILY_CREDIT_CAP: Long = 60L
+
+    const val MAX_RECOVERED_SESSION_SECONDS: Long = 8L * 60L * 60L
+}

--- a/discord-bot/src/main/kotlin/bot/toby/voice/VoiceSessionRecoveryHook.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/voice/VoiceSessionRecoveryHook.kt
@@ -1,0 +1,40 @@
+package bot.toby.voice
+
+import common.logging.DiscordLogger
+import database.service.VoiceSessionService
+import org.springframework.beans.factory.InitializingBean
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+import java.time.Instant
+
+@Component
+class VoiceSessionRecoveryHook @Autowired constructor(
+    private val voiceSessionService: VoiceSessionService,
+    private val voiceCreditAwardService: VoiceCreditAwardService
+) : InitializingBean {
+    private val logger: DiscordLogger = DiscordLogger.createLogger(this::class.java)
+
+    override fun afterPropertiesSet() {
+        closeStaleOpenSessions()
+    }
+
+    fun closeStaleOpenSessions() {
+        val now = Instant.now()
+        val open = runCatching { voiceSessionService.findAllOpenSessions() }
+            .onFailure { logger.error("Could not query open voice sessions on startup: ${it.message}") }
+            .getOrDefault(emptyList())
+
+        if (open.isEmpty()) {
+            logger.info { "No stale voice sessions to recover." }
+            return
+        }
+
+        logger.info { "Recovering ${open.size} stale voice session(s) left open by a prior shutdown." }
+        open.forEach { session ->
+            runCatching { voiceCreditAwardService.closeRecoveredSession(session, now) }
+                .onFailure {
+                    logger.error("Failed to close stale voice session id=${session.id}: ${it.message}")
+                }
+        }
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/economy/TitleCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/economy/TitleCommandTest.kt
@@ -1,0 +1,191 @@
+package bot.toby.command.commands.economy
+
+import bot.toby.command.CommandTest
+import bot.toby.command.CommandTest.Companion.event
+import bot.toby.command.CommandTest.Companion.guild
+import bot.toby.command.CommandTest.Companion.member
+import bot.toby.command.DefaultCommandContext
+import database.dto.TitleDto
+import database.dto.UserDto
+import database.dto.UserOwnedTitleDto
+import database.service.TitleService
+import database.service.UserService
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import net.dv8tion.jda.api.interactions.commands.OptionMapping
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import web.service.TitleRoleResult
+import web.service.TitleRoleService
+
+internal class TitleCommandTest : CommandTest {
+    private lateinit var titleService: TitleService
+    private lateinit var userService: UserService
+    private lateinit var titleRoleService: TitleRoleService
+    private lateinit var command: TitleCommand
+
+    private val discordId = 1L
+    private val guildId = 1L
+
+    @BeforeEach
+    fun setUp() {
+        setUpCommonMocks()
+        titleService = mockk(relaxed = true)
+        userService = mockk(relaxed = true)
+        titleRoleService = mockk(relaxed = true)
+        command = TitleCommand(titleService, userService, titleRoleService)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        tearDownCommonMocks()
+        clearAllMocks()
+    }
+
+    private fun stringOpt(value: String): OptionMapping {
+        val o = mockk<OptionMapping>(relaxed = true)
+        every { o.asString } returns value
+        return o
+    }
+
+    @Test
+    fun `buy deducts credits and records purchase when user has enough`() {
+        val user = UserDto(discordId = discordId, guildId = guildId).apply { socialCredit = 500L }
+        every { event.subcommandName } returns "buy"
+        every { event.getOption("title") } returns stringOpt("⭐ Comrade")
+        every { titleService.getByLabel("⭐ Comrade") } returns TitleDto(id = 7L, label = "⭐ Comrade", cost = 100L)
+        every { titleService.owns(discordId, 7L) } returns false
+
+        command.handle(DefaultCommandContext(event), user, 5)
+
+        assertEquals(400L, user.socialCredit)
+        verify(exactly = 1) { userService.updateUser(user) }
+        verify(exactly = 1) { titleService.recordPurchase(discordId, 7L) }
+    }
+
+    @Test
+    fun `buy rejects when balance is below cost`() {
+        val user = UserDto(discordId = discordId, guildId = guildId).apply { socialCredit = 50L }
+        every { event.subcommandName } returns "buy"
+        every { event.getOption("title") } returns stringOpt("Expensive")
+        every { titleService.getByLabel("Expensive") } returns TitleDto(id = 1L, label = "Expensive", cost = 1_000L)
+        every { titleService.owns(discordId, 1L) } returns false
+
+        command.handle(DefaultCommandContext(event), user, 5)
+
+        assertEquals(50L, user.socialCredit)
+        verify(exactly = 0) { userService.updateUser(any()) }
+        verify(exactly = 0) { titleService.recordPurchase(any(), any()) }
+    }
+
+    @Test
+    fun `buy rejects when title is already owned`() {
+        val user = UserDto(discordId = discordId, guildId = guildId).apply { socialCredit = 500L }
+        every { event.subcommandName } returns "buy"
+        every { event.getOption("title") } returns stringOpt("⭐ Comrade")
+        every { titleService.getByLabel("⭐ Comrade") } returns TitleDto(id = 7L, label = "⭐ Comrade", cost = 100L)
+        every { titleService.owns(discordId, 7L) } returns true
+
+        command.handle(DefaultCommandContext(event), user, 5)
+
+        assertEquals(500L, user.socialCredit)
+        verify(exactly = 0) { userService.updateUser(any()) }
+        verify(exactly = 0) { titleService.recordPurchase(any(), any()) }
+    }
+
+    @Test
+    fun `buy rejects unknown title label`() {
+        val user = UserDto(discordId = discordId, guildId = guildId).apply { socialCredit = 500L }
+        every { event.subcommandName } returns "buy"
+        every { event.getOption("title") } returns stringOpt("Unknown")
+        every { titleService.getByLabel("Unknown") } returns null
+
+        command.handle(DefaultCommandContext(event), user, 5)
+
+        verify(exactly = 0) { userService.updateUser(any()) }
+        verify(exactly = 0) { titleService.recordPurchase(any(), any()) }
+    }
+
+    @Test
+    fun `equip sets activeTitleId when user owns the title and role service succeeds`() {
+        val user = UserDto(discordId = discordId, guildId = guildId).apply { socialCredit = 100L }
+        val title = TitleDto(id = 7L, label = "⭐ Comrade", cost = 100L)
+        every { event.subcommandName } returns "equip"
+        every { event.getOption("title") } returns stringOpt("⭐ Comrade")
+        every { titleService.getByLabel("⭐ Comrade") } returns title
+        every { titleService.owns(discordId, 7L) } returns true
+        every { titleService.listOwned(discordId) } returns listOf(
+            UserOwnedTitleDto(discordId = discordId, titleId = 7L)
+        )
+        every { titleRoleService.equip(guild, member, title, setOf(7L)) } returns TitleRoleResult.Ok
+
+        command.handle(DefaultCommandContext(event), user, 5)
+
+        assertEquals(7L, user.activeTitleId)
+        verify(exactly = 1) { userService.updateUser(user) }
+    }
+
+    @Test
+    fun `equip rejects when user does not own the title`() {
+        val user = UserDto(discordId = discordId, guildId = guildId)
+        every { event.subcommandName } returns "equip"
+        every { event.getOption("title") } returns stringOpt("⭐ Comrade")
+        every { titleService.getByLabel("⭐ Comrade") } returns TitleDto(id = 7L, label = "⭐ Comrade", cost = 100L)
+        every { titleService.owns(discordId, 7L) } returns false
+
+        command.handle(DefaultCommandContext(event), user, 5)
+
+        assertNull(user.activeTitleId)
+        verify(exactly = 0) { userService.updateUser(any()) }
+    }
+
+    @Test
+    fun `equip rolls back activeTitleId when role service fails`() {
+        val user = UserDto(discordId = discordId, guildId = guildId)
+        val title = TitleDto(id = 7L, label = "⭐ Comrade", cost = 100L)
+        every { event.subcommandName } returns "equip"
+        every { event.getOption("title") } returns stringOpt("⭐ Comrade")
+        every { titleService.getByLabel("⭐ Comrade") } returns title
+        every { titleService.owns(discordId, 7L) } returns true
+        every { titleService.listOwned(discordId) } returns listOf(
+            UserOwnedTitleDto(discordId = discordId, titleId = 7L)
+        )
+        every { titleRoleService.equip(guild, member, title, any()) } returns TitleRoleResult.Error("no Manage Roles")
+
+        command.handle(DefaultCommandContext(event), user, 5)
+
+        assertNull(user.activeTitleId)
+        verify(exactly = 0) { userService.updateUser(any()) }
+    }
+
+    @Test
+    fun `unequip clears activeTitleId when role service succeeds`() {
+        val user = UserDto(discordId = discordId, guildId = guildId).apply { activeTitleId = 7L }
+        every { event.subcommandName } returns "unequip"
+        every { titleService.listOwned(discordId) } returns listOf(
+            UserOwnedTitleDto(discordId = discordId, titleId = 7L)
+        )
+        every { titleRoleService.unequip(guild, member, setOf(7L)) } returns TitleRoleResult.Ok
+
+        command.handle(DefaultCommandContext(event), user, 5)
+
+        assertNull(user.activeTitleId)
+        verify(exactly = 1) { userService.updateUser(user) }
+    }
+
+    @Test
+    fun `unequip is a no-op when no active title`() {
+        val user = UserDto(discordId = discordId, guildId = guildId)
+        every { event.subcommandName } returns "unequip"
+
+        command.handle(DefaultCommandContext(event), user, 5)
+
+        assertNull(user.activeTitleId)
+        verify(exactly = 0) { userService.updateUser(any()) }
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/moderation/SocialCreditCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/moderation/SocialCreditCommandTest.kt
@@ -8,7 +8,9 @@ import bot.toby.command.CommandTest.Companion.requestingUserDto
 import bot.toby.command.CommandTest.Companion.targetMember
 import bot.toby.command.CommandTest.Companion.user
 import bot.toby.command.DefaultCommandContext
+import database.service.TitleService
 import database.service.UserService
+import database.service.VoiceSessionService
 import io.mockk.clearMocks
 import io.mockk.every
 import io.mockk.mockk
@@ -24,18 +26,22 @@ internal class SocialCreditCommandTest : CommandTest {
     lateinit var socialCreditCommand: SocialCreditCommand
 
     private lateinit var userService: UserService
+    private lateinit var voiceSessionService: VoiceSessionService
+    private lateinit var titleService: TitleService
 
     @BeforeEach
     fun setUp() {
         setUpCommonMocks()
         userService = mockk(relaxed = true)
-        socialCreditCommand = SocialCreditCommand(userService)
+        voiceSessionService = mockk(relaxed = true)
+        titleService = mockk(relaxed = true)
+        socialCreditCommand = SocialCreditCommand(userService, voiceSessionService, titleService)
     }
 
     @AfterEach
     fun tearDown() {
         tearDownCommonMocks()
-        clearMocks(userService)
+        clearMocks(userService, voiceSessionService, titleService)
     }
 
     @Test
@@ -187,8 +193,12 @@ internal class SocialCreditCommandTest : CommandTest {
         every { targetUserDto.guildId } returns 1L
         every { userService.listGuildUsers(1L) } returns listOf(requestingUserDto, targetUserDto)
         every { requestingUserDto.socialCredit } returns 100L
+        every { requestingUserDto.discordId } returns 1L
+        every { requestingUserDto.activeTitleId } returns null
         every { targetUserDto.socialCredit } returns 50L
         every { targetUserDto.discordId } returns 2L
+        every { targetUserDto.activeTitleId } returns null
+        every { voiceSessionService.sumCountedSecondsLifetimeByUser(1L) } returns emptyMap()
         every { guild.members } returns memberList
         every { guild.getMemberById(1L) } returns member
         every { guild.getMemberById(2L) } returns targetMember
@@ -200,8 +210,8 @@ internal class SocialCreditCommandTest : CommandTest {
         val expectedMessage = buildString {
             append("**Social Credit Leaderboard**\n")
             append("**-----------------------------**\n")
-            append("#1: Effective Name - score: 100\n")
-            append("#2: Target Effective Name - score: 50\n")
+            append("#1: Effective Name — 100 credits · 0m voice\n")
+            append("#2: Target Effective Name — 50 credits · 0m voice")
         }
         // Act
         socialCreditCommand.handle(commandContext, requestingUserDto, 0)

--- a/discord-bot/src/test/kotlin/bot/toby/handler/VoiceEventHandlerTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/handler/VoiceEventHandlerTest.kt
@@ -4,9 +4,12 @@ import bot.toby.helpers.MusicPlayerHelper
 import bot.toby.helpers.UserDtoHelper
 import bot.toby.lavaplayer.PlayerManager
 import bot.toby.managers.NowPlayingManager
+import bot.toby.voice.VoiceCompanyTracker
+import bot.toby.voice.VoiceCreditAwardService
 import database.dto.ConfigDto
 import database.dto.MusicDto
 import database.service.ConfigService
+import database.service.VoiceSessionService
 import io.mockk.*
 import io.mockk.junit5.MockKExtension
 import net.dv8tion.jda.api.JDA
@@ -36,12 +39,18 @@ class VoiceEventHandlerTest {
     private val configService: ConfigService = mockk()
     private val userDtoHelper: UserDtoHelper = mockk()
     private val introHelper: IntroHelper = mockk()
+    private val voiceSessionService: VoiceSessionService = mockk(relaxed = true)
+    private val voiceCompanyTracker: VoiceCompanyTracker = mockk(relaxed = true)
+    private val voiceCreditAwardService: VoiceCreditAwardService = mockk(relaxed = true)
 
     private val handler = spyk(
         VoiceEventHandler(
             configService,
             userDtoHelper,
-            introHelper
+            introHelper,
+            voiceSessionService,
+            voiceCompanyTracker,
+            voiceCreditAwardService
         )
     )
 
@@ -113,7 +122,10 @@ class VoiceEventHandlerTest {
         val handler = VoiceEventHandler(
             configService = mockk(),
             userDtoHelper = mockk(),
-            introHelper = mockk()
+            introHelper = mockk(),
+            voiceSessionService = mockk(relaxed = true),
+            voiceCompanyTracker = mockk(relaxed = true),
+            voiceCreditAwardService = mockk(relaxed = true)
         )
 
         handler.onReady(readyEvent)

--- a/discord-bot/src/test/kotlin/bot/toby/scheduling/MonthlyLeaderboardJobTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/scheduling/MonthlyLeaderboardJobTest.kt
@@ -1,0 +1,189 @@
+package bot.toby.scheduling
+
+import database.dto.ConfigDto
+import database.dto.MonthlyCreditSnapshotDto
+import database.dto.UserDto
+import database.service.ConfigService
+import database.service.MonthlyCreditSnapshotService
+import database.service.UserService
+import database.service.VoiceSessionService
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import net.dv8tion.jda.api.JDA
+import net.dv8tion.jda.api.Permission
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.Member
+import net.dv8tion.jda.api.entities.MessageEmbed
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
+import net.dv8tion.jda.api.requests.restaction.MessageCreateAction
+import net.dv8tion.jda.api.utils.cache.SnowflakeCacheView
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class MonthlyLeaderboardJobTest {
+
+    private lateinit var jda: JDA
+    private lateinit var userService: UserService
+    private lateinit var voiceSessionService: VoiceSessionService
+    private lateinit var snapshotService: MonthlyCreditSnapshotService
+    private lateinit var configService: ConfigService
+    private lateinit var guild: Guild
+    private lateinit var channel: TextChannel
+    private lateinit var job: MonthlyLeaderboardJob
+
+    private val guildId = 100L
+
+    @BeforeEach
+    fun setup() {
+        jda = mockk(relaxed = true)
+        userService = mockk(relaxed = true)
+        voiceSessionService = mockk(relaxed = true)
+        snapshotService = mockk(relaxed = true)
+        configService = mockk(relaxed = true)
+        guild = mockk(relaxed = true)
+        channel = mockk(relaxed = true)
+
+        val cache: SnowflakeCacheView<Guild> = mockk(relaxed = true)
+        every { jda.guildCache } returns cache
+        every { cache.iterator() } returns mutableListOf(guild).iterator()
+        every { guild.idLong } returns guildId
+        every { guild.id } returns guildId.toString()
+        every { guild.name } returns "Test Guild"
+        every { guild.systemChannel } returns channel
+        every { guild.selfMember.hasPermission(channel, *anyVararg<Permission>()) } returns true
+        val createAction = mockk<MessageCreateAction>(relaxed = true)
+        every { channel.sendMessageEmbeds(any<MessageEmbed>()) } returns createAction
+
+        job = MonthlyLeaderboardJob(jda, userService, voiceSessionService, snapshotService, configService)
+    }
+
+    private fun member(id: Long, name: String): Member {
+        val m = mockk<Member>(relaxed = true)
+        every { m.effectiveName } returns name
+        every { guild.getMemberById(id) } returns m
+        return m
+    }
+
+    @Test
+    fun `postMonthlyLeaderboard skips guilds with no tracked users`() {
+        every { userService.listGuildUsers(guildId) } returns emptyList()
+
+        job.postMonthlyLeaderboard()
+
+        verify(exactly = 0) { channel.sendMessageEmbeds(any<MessageEmbed>()) }
+        verify(exactly = 0) { snapshotService.upsert(any()) }
+    }
+
+    @Test
+    fun `postMonthlyLeaderboard writes snapshot for each user for the current month`() {
+        val alice = UserDto(discordId = 1L, guildId = guildId).apply { socialCredit = 500L }
+        val bob = UserDto(discordId = 2L, guildId = guildId).apply { socialCredit = 300L }
+        every { userService.listGuildUsers(guildId) } returns listOf(alice, bob)
+        member(1L, "Alice")
+        member(2L, "Bob")
+        every { snapshotService.listForGuildDate(guildId, any()) } returns emptyList()
+        every { voiceSessionService.sumCountedSecondsInRangeByUser(guildId, any(), any()) } returns emptyMap()
+        every { configService.getConfigByName(any(), guildId.toString()) } returns null
+
+        val snapshots = mutableListOf<MonthlyCreditSnapshotDto>()
+        every { snapshotService.upsert(capture(snapshots)) } answers { firstArg() }
+
+        job.postMonthlyLeaderboard()
+
+        assertEquals(2, snapshots.size)
+        val byUser = snapshots.associateBy { it.discordId }
+        assertEquals(500L, byUser[1L]?.socialCredit)
+        assertEquals(300L, byUser[2L]?.socialCredit)
+    }
+
+    @Test
+    fun `postMonthlyLeaderboard sends embed to leaderboard channel when configured`() {
+        val alice = UserDto(discordId = 1L, guildId = guildId).apply { socialCredit = 500L }
+        every { userService.listGuildUsers(guildId) } returns listOf(alice)
+        member(1L, "Alice")
+        every { snapshotService.listForGuildDate(guildId, any()) } returns emptyList()
+        every { voiceSessionService.sumCountedSecondsInRangeByUser(guildId, any(), any()) } returns emptyMap()
+
+        val configuredChannel = mockk<TextChannel>(relaxed = true)
+        val configDto = ConfigDto(
+            name = "LEADERBOARD_CHANNEL",
+            value = "777",
+            guildId = guildId.toString()
+        )
+        every { configService.getConfigByName(any(), guildId.toString()) } answers {
+            val name = firstArg<String>()
+            if (name == "LEADERBOARD_CHANNEL") configDto else null
+        }
+        every { guild.getTextChannelById(777L) } returns configuredChannel
+        every { guild.selfMember.hasPermission(configuredChannel, *anyVararg<Permission>()) } returns true
+        val createAction = mockk<MessageCreateAction>(relaxed = true)
+        every { configuredChannel.sendMessageEmbeds(any<MessageEmbed>()) } returns createAction
+
+        job.postMonthlyLeaderboard()
+
+        verify(exactly = 1) { configuredChannel.sendMessageEmbeds(any<MessageEmbed>()) }
+        verify(exactly = 0) { channel.sendMessageEmbeds(any<MessageEmbed>()) }
+    }
+
+    @Test
+    fun `postMonthlyLeaderboard falls back to system channel when configured channel absent`() {
+        val alice = UserDto(discordId = 1L, guildId = guildId).apply { socialCredit = 500L }
+        every { userService.listGuildUsers(guildId) } returns listOf(alice)
+        member(1L, "Alice")
+        every { snapshotService.listForGuildDate(guildId, any()) } returns emptyList()
+        every { voiceSessionService.sumCountedSecondsInRangeByUser(guildId, any(), any()) } returns emptyMap()
+        every { configService.getConfigByName(any(), guildId.toString()) } returns null
+
+        val createAction = mockk<MessageCreateAction>(relaxed = true)
+        every { channel.sendMessageEmbeds(any<MessageEmbed>()) } returns createAction
+
+        job.postMonthlyLeaderboard()
+
+        verify(exactly = 1) { channel.sendMessageEmbeds(any<MessageEmbed>()) }
+    }
+
+    @Test
+    fun `postMonthlyLeaderboard computes month delta using prior snapshot`() {
+        val alice = UserDto(discordId = 1L, guildId = guildId).apply { socialCredit = 500L }
+        every { userService.listGuildUsers(guildId) } returns listOf(alice)
+        member(1L, "Alice")
+        // Prior snapshot says Alice had 200 at start of previous month → delta = 300.
+        every { snapshotService.listForGuildDate(guildId, any()) } answers {
+            val date = secondArg<java.time.LocalDate>()
+            if (date == java.time.LocalDate.now(java.time.ZoneOffset.UTC).withDayOfMonth(1).minusMonths(1))
+                listOf(MonthlyCreditSnapshotDto(discordId = 1L, guildId = guildId, socialCredit = 200L))
+            else emptyList()
+        }
+        every { voiceSessionService.sumCountedSecondsInRangeByUser(guildId, any(), any()) } returns mapOf(1L to 3600L)
+        every { configService.getConfigByName(any(), guildId.toString()) } returns null
+        val createAction = mockk<MessageCreateAction>(relaxed = true)
+        every { channel.sendMessageEmbeds(any<MessageEmbed>()) } returns createAction
+
+        job.postMonthlyLeaderboard()
+
+        // The embed was sent to the system channel
+        verify(exactly = 1) { channel.sendMessageEmbeds(any<MessageEmbed>()) }
+    }
+
+    @Test
+    fun `postMonthlyLeaderboard still writes snapshot even if posting fails`() {
+        val alice = UserDto(discordId = 1L, guildId = guildId).apply { socialCredit = 500L }
+        every { userService.listGuildUsers(guildId) } returns listOf(alice)
+        member(1L, "Alice")
+        every { snapshotService.listForGuildDate(guildId, any()) } returns emptyList()
+        every { voiceSessionService.sumCountedSecondsInRangeByUser(guildId, any(), any()) } returns emptyMap()
+        every { configService.getConfigByName(any(), guildId.toString()) } returns null
+        // System channel has no perms → resolveChannel returns null → no post, but snapshot still written.
+        every { guild.selfMember.hasPermission(channel, *anyVararg<Permission>()) } returns false
+
+        val snapshots = mutableListOf<MonthlyCreditSnapshotDto>()
+        every { snapshotService.upsert(capture(snapshots)) } answers { firstArg() }
+
+        job.postMonthlyLeaderboard()
+
+        verify(exactly = 0) { channel.sendMessageEmbeds(any<MessageEmbed>()) }
+        assertEquals(1, snapshots.size)
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/voice/VoiceCompanyTrackerTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/voice/VoiceCompanyTrackerTest.kt
@@ -1,0 +1,127 @@
+package bot.toby.voice
+
+import io.mockk.every
+import io.mockk.mockk
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.Member
+import net.dv8tion.jda.api.entities.User
+import net.dv8tion.jda.api.entities.channel.concrete.VoiceChannel
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+class VoiceCompanyTrackerTest {
+
+    private val guildId = 42L
+    private val guild: Guild = mockk<Guild>(relaxed = true).also {
+        every { it.idLong } returns guildId
+    }
+
+    private fun channelWith(vararg members: Member): VoiceChannel {
+        val ch = mockk<VoiceChannel>(relaxed = true)
+        every { ch.guild } returns guild
+        every { ch.members } returns members.toList()
+        return ch
+    }
+
+    private fun humanMember(id: Long): Member {
+        val m = mockk<Member>(relaxed = true)
+        val u = mockk<User>(relaxed = true)
+        every { m.idLong } returns id
+        every { m.user } returns u
+        every { u.isBot } returns false
+        return m
+    }
+
+    private fun botMember(id: Long): Member {
+        val m = mockk<Member>(relaxed = true)
+        val u = mockk<User>(relaxed = true)
+        every { m.idLong } returns id
+        every { m.user } returns u
+        every { u.isBot } returns true
+        return m
+    }
+
+    @Test
+    fun `solo user accumulates zero company seconds`() {
+        val tracker = VoiceCompanyTracker()
+        val alice = humanMember(1L)
+        val bot = botMember(99L)
+        val channel = channelWith(alice, bot)
+        val t0 = Instant.parse("2026-04-01T00:00:00Z")
+
+        tracker.startTracking(1L, guildId, channel, t0)
+        val counted = tracker.stopTracking(1L, guildId, t0.plusSeconds(600))
+        assertEquals(0L, counted)
+    }
+
+    @Test
+    fun `user with company from the start accumulates full duration`() {
+        val tracker = VoiceCompanyTracker()
+        val alice = humanMember(1L)
+        val bob = humanMember(2L)
+        val channel = channelWith(alice, bob)
+        val t0 = Instant.parse("2026-04-01T00:00:00Z")
+
+        tracker.startTracking(1L, guildId, channel, t0)
+        val counted = tracker.stopTracking(1L, guildId, t0.plusSeconds(300))
+        assertEquals(300L, counted)
+    }
+
+    @Test
+    fun `company accumulator flips on and off as other members join and leave`() {
+        val tracker = VoiceCompanyTracker()
+        val alice = humanMember(1L)
+        val bob = humanMember(2L)
+        val t0 = Instant.parse("2026-04-01T00:00:00Z")
+
+        // Alice joins alone
+        val channelSolo = channelWith(alice)
+        tracker.startTracking(1L, guildId, channelSolo, t0)
+
+        // 60s later Bob joins — company starts
+        val channelWithBoth = channelWith(alice, bob)
+        tracker.reconcileChannel(channelWithBoth, t0.plusSeconds(60))
+
+        // 120s after that Bob leaves — company window closes with 120s accumulated
+        tracker.reconcileChannel(channelSolo, t0.plusSeconds(180))
+
+        // Alice stays alone for another 100s before leaving
+        val counted = tracker.stopTracking(1L, guildId, t0.plusSeconds(280))
+        assertEquals(120L, counted)
+    }
+
+    @Test
+    fun `stopTracking closes any still-open company window`() {
+        val tracker = VoiceCompanyTracker()
+        val alice = humanMember(1L)
+        val bob = humanMember(2L)
+        val channel = channelWith(alice, bob)
+        val t0 = Instant.parse("2026-04-01T00:00:00Z")
+
+        tracker.startTracking(1L, guildId, channel, t0)
+        val counted = tracker.stopTracking(1L, guildId, t0.plusSeconds(500))
+        assertEquals(500L, counted)
+    }
+
+    @Test
+    fun `stopTracking on unknown user returns zero`() {
+        val tracker = VoiceCompanyTracker()
+        val counted = tracker.stopTracking(999L, guildId, Instant.now())
+        assertEquals(0L, counted)
+    }
+
+    @Test
+    fun `bots do not count as company`() {
+        val tracker = VoiceCompanyTracker()
+        val alice = humanMember(1L)
+        val bot1 = botMember(10L)
+        val bot2 = botMember(11L)
+        val channel = channelWith(alice, bot1, bot2)
+        val t0 = Instant.parse("2026-04-01T00:00:00Z")
+
+        tracker.startTracking(1L, guildId, channel, t0)
+        val counted = tracker.stopTracking(1L, guildId, t0.plusSeconds(200))
+        assertEquals(0L, counted)
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/voice/VoiceCreditAwardServiceTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/voice/VoiceCreditAwardServiceTest.kt
@@ -1,0 +1,154 @@
+package bot.toby.voice
+
+import database.dto.UserDto
+import database.dto.VoiceCreditDailyDto
+import database.dto.VoiceSessionDto
+import database.service.UserService
+import database.service.VoiceCreditDailyService
+import database.service.VoiceSessionService
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneOffset
+
+class VoiceCreditAwardServiceTest {
+
+    private lateinit var voiceSessionService: VoiceSessionService
+    private lateinit var voiceCreditDailyService: VoiceCreditDailyService
+    private lateinit var userService: UserService
+    private lateinit var service: VoiceCreditAwardService
+
+    private val discordId = 1L
+    private val guildId = 42L
+
+    @BeforeEach
+    fun setup() {
+        voiceSessionService = mockk(relaxed = true)
+        voiceCreditDailyService = mockk(relaxed = true)
+        userService = mockk(relaxed = true)
+        service = VoiceCreditAwardService(voiceSessionService, voiceCreditDailyService, userService)
+    }
+
+    private fun session(joinedAt: Instant): VoiceSessionDto {
+        return VoiceSessionDto(
+            id = 1L,
+            discordId = discordId,
+            guildId = guildId,
+            channelId = 2L,
+            joinedAt = joinedAt
+        )
+    }
+
+    @Test
+    fun `closeSessionAndAward converts counted seconds to credits using configured ratio`() {
+        val t0 = Instant.parse("2026-04-10T10:00:00Z")
+        val user = UserDto(discordId = discordId, guildId = guildId).apply { socialCredit = 10L }
+        every { userService.getUserById(discordId, guildId) } returns user
+        every { voiceCreditDailyService.get(discordId, guildId, any()) } returns null
+
+        val closed = slot<VoiceSessionDto>()
+        every { voiceSessionService.closeSession(capture(closed)) } answers { closed.captured }
+
+        // 600s company → 600/120 = 5 credits
+        service.closeSessionAndAward(session(t0), t0.plusSeconds(600), hadCompanyDurationSeconds = 600L)
+
+        assertEquals(600L, closed.captured.countedSeconds)
+        assertEquals(5L, closed.captured.creditsAwarded)
+        assertEquals(15L, user.socialCredit)
+        verify(exactly = 1) { userService.updateUser(user) }
+    }
+
+    @Test
+    fun `closeSessionAndAward awards zero when no company time`() {
+        val t0 = Instant.parse("2026-04-10T10:00:00Z")
+        val user = UserDto(discordId = discordId, guildId = guildId).apply { socialCredit = 10L }
+        every { userService.getUserById(discordId, guildId) } returns user
+
+        val closed = slot<VoiceSessionDto>()
+        every { voiceSessionService.closeSession(capture(closed)) } answers { closed.captured }
+
+        service.closeSessionAndAward(session(t0), t0.plusSeconds(1800), hadCompanyDurationSeconds = 0L)
+
+        assertEquals(0L, closed.captured.countedSeconds)
+        assertEquals(0L, closed.captured.creditsAwarded)
+        assertEquals(10L, user.socialCredit)
+        verify(exactly = 0) { userService.updateUser(any()) }
+    }
+
+    @Test
+    fun `closeSessionAndAward clamps award to daily cap`() {
+        val t0 = Instant.parse("2026-04-10T10:00:00Z")
+        val earnDate = LocalDate.ofInstant(t0.plusSeconds(7200), ZoneOffset.UTC)
+        val user = UserDto(discordId = discordId, guildId = guildId).apply { socialCredit = 0L }
+        every { userService.getUserById(discordId, guildId) } returns user
+        // Already at 55 credits today; cap is 60.
+        every { voiceCreditDailyService.get(discordId, guildId, earnDate) } returns
+            VoiceCreditDailyDto(discordId = discordId, guildId = guildId, earnDate = earnDate, credits = 55L)
+
+        val closed = slot<VoiceSessionDto>()
+        every { voiceSessionService.closeSession(capture(closed)) } answers { closed.captured }
+        val dailyUpsert = slot<VoiceCreditDailyDto>()
+        every { voiceCreditDailyService.upsert(capture(dailyUpsert)) } answers { dailyUpsert.captured }
+
+        // 7200s / 120s = 60 credits requested. Daily cap leaves only 5 headroom.
+        service.closeSessionAndAward(session(t0), t0.plusSeconds(7200), hadCompanyDurationSeconds = 7200L)
+
+        assertEquals(5L, closed.captured.creditsAwarded)
+        assertEquals(5L, user.socialCredit)
+        assertEquals(60L, dailyUpsert.captured.credits)
+    }
+
+    @Test
+    fun `closeSessionAndAward clamps counted seconds to raw duration`() {
+        val t0 = Instant.parse("2026-04-10T10:00:00Z")
+        val user = UserDto(discordId = discordId, guildId = guildId).apply { socialCredit = 0L }
+        every { userService.getUserById(discordId, guildId) } returns user
+        every { voiceCreditDailyService.get(discordId, guildId, any()) } returns null
+
+        val closed = slot<VoiceSessionDto>()
+        every { voiceSessionService.closeSession(capture(closed)) } answers { closed.captured }
+
+        // Raw = 300s. Company accumulator overstated at 9999s — must clamp to 300.
+        service.closeSessionAndAward(session(t0), t0.plusSeconds(300), hadCompanyDurationSeconds = 9999L)
+
+        assertEquals(300L, closed.captured.countedSeconds)
+    }
+
+    @Test
+    fun `closeRecoveredSession caps duration at max recovered seconds`() {
+        val t0 = Instant.parse("2026-04-01T00:00:00Z")
+        val user = UserDto(discordId = discordId, guildId = guildId).apply { socialCredit = 0L }
+        every { userService.getUserById(discordId, guildId) } returns user
+        every { voiceCreditDailyService.get(discordId, guildId, any()) } returns null
+
+        val closed = slot<VoiceSessionDto>()
+        every { voiceSessionService.closeSession(capture(closed)) } answers { closed.captured }
+
+        // Session was open for 24h. Should be capped at MAX_RECOVERED_SESSION_SECONDS (8h = 28800s).
+        service.closeRecoveredSession(session(t0), t0.plusSeconds(24 * 3600L))
+
+        assertNotNull(closed.captured.countedSeconds)
+        assertEquals(VoiceCreditConfig.MAX_RECOVERED_SESSION_SECONDS, closed.captured.countedSeconds)
+    }
+
+    @Test
+    fun `closeSessionAndAward skips user update when dto is missing`() {
+        val t0 = Instant.parse("2026-04-10T10:00:00Z")
+        every { userService.getUserById(discordId, guildId) } returns null
+        every { voiceCreditDailyService.get(discordId, guildId, any()) } returns null
+        val closed = slot<VoiceSessionDto>()
+        every { voiceSessionService.closeSession(capture(closed)) } answers { closed.captured }
+
+        service.closeSessionAndAward(session(t0), t0.plusSeconds(600), hadCompanyDurationSeconds = 600L)
+
+        assertEquals(5L, closed.captured.creditsAwarded)
+        verify(exactly = 0) { userService.updateUser(any()) }
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/voice/VoiceSessionRecoveryHookTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/voice/VoiceSessionRecoveryHookTest.kt
@@ -1,0 +1,57 @@
+package bot.toby.voice
+
+import database.dto.VoiceSessionDto
+import database.service.VoiceSessionService
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+class VoiceSessionRecoveryHookTest {
+
+    private lateinit var voiceSessionService: VoiceSessionService
+    private lateinit var voiceCreditAwardService: VoiceCreditAwardService
+    private lateinit var hook: VoiceSessionRecoveryHook
+
+    @BeforeEach
+    fun setup() {
+        voiceSessionService = mockk(relaxed = true)
+        voiceCreditAwardService = mockk(relaxed = true)
+        hook = VoiceSessionRecoveryHook(voiceSessionService, voiceCreditAwardService)
+    }
+
+    @Test
+    fun `closeStaleOpenSessions invokes award service for each open session`() {
+        val s1 = VoiceSessionDto(id = 1L, discordId = 1L, guildId = 10L, channelId = 100L, joinedAt = Instant.now())
+        val s2 = VoiceSessionDto(id = 2L, discordId = 2L, guildId = 10L, channelId = 100L, joinedAt = Instant.now())
+        every { voiceSessionService.findAllOpenSessions() } returns listOf(s1, s2)
+
+        hook.closeStaleOpenSessions()
+
+        verify(exactly = 1) { voiceCreditAwardService.closeRecoveredSession(s1, any()) }
+        verify(exactly = 1) { voiceCreditAwardService.closeRecoveredSession(s2, any()) }
+    }
+
+    @Test
+    fun `closeStaleOpenSessions is a no-op when no open sessions exist`() {
+        every { voiceSessionService.findAllOpenSessions() } returns emptyList()
+
+        hook.closeStaleOpenSessions()
+
+        verify(exactly = 0) { voiceCreditAwardService.closeRecoveredSession(any(), any()) }
+    }
+
+    @Test
+    fun `closeStaleOpenSessions continues after per-session failure`() {
+        val s1 = VoiceSessionDto(id = 1L, discordId = 1L, guildId = 10L, channelId = 100L, joinedAt = Instant.now())
+        val s2 = VoiceSessionDto(id = 2L, discordId = 2L, guildId = 10L, channelId = 100L, joinedAt = Instant.now())
+        every { voiceSessionService.findAllOpenSessions() } returns listOf(s1, s2)
+        every { voiceCreditAwardService.closeRecoveredSession(s1, any()) } throws RuntimeException("boom")
+
+        hook.closeStaleOpenSessions()
+
+        verify(exactly = 1) { voiceCreditAwardService.closeRecoveredSession(s2, any()) }
+    }
+}

--- a/web/src/main/kotlin/web/controller/LeaderboardController.kt
+++ b/web/src/main/kotlin/web/controller/LeaderboardController.kt
@@ -1,0 +1,63 @@
+package web.controller
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient
+import org.springframework.security.oauth2.client.annotation.RegisteredOAuth2AuthorizedClient
+import org.springframework.security.oauth2.core.user.OAuth2User
+import org.springframework.stereotype.Controller
+import org.springframework.ui.Model
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.servlet.mvc.support.RedirectAttributes
+import web.service.LeaderboardWebService
+import web.util.discordIdOrNull
+import web.util.displayName
+
+@Controller
+@RequestMapping("/leaderboard")
+class LeaderboardController(
+    private val leaderboardWebService: LeaderboardWebService
+) {
+
+    @GetMapping("s")
+    fun guildList(
+        @RegisteredOAuth2AuthorizedClient("discord") client: OAuth2AuthorizedClient,
+        @AuthenticationPrincipal user: OAuth2User,
+        model: Model
+    ): String {
+        val discordId = user.discordIdOrNull()
+        val guilds = if (discordId != null) {
+            leaderboardWebService.getGuildsWhereUserCanView(client.accessToken.tokenValue, discordId)
+        } else emptyList()
+
+        model.addAttribute("guilds", guilds)
+        model.addAttribute("username", user.displayName())
+        return "leaderboards"
+    }
+
+    @GetMapping("/{guildId}")
+    fun leaderboardPage(
+        @PathVariable guildId: Long,
+        @AuthenticationPrincipal user: OAuth2User,
+        model: Model,
+        ra: RedirectAttributes
+    ): String {
+        val discordId = user.discordIdOrNull()
+            ?: return "redirect:/leaderboards"
+
+        if (!leaderboardWebService.isMember(discordId, guildId)) {
+            ra.addFlashAttribute("error", "You are not a member of that server.")
+            return "redirect:/leaderboards"
+        }
+
+        val view = leaderboardWebService.getGuildView(guildId) ?: run {
+            ra.addFlashAttribute("error", "Bot is not in that server.")
+            return "redirect:/leaderboards"
+        }
+
+        model.addAttribute("view", view)
+        model.addAttribute("username", user.displayName())
+        return "leaderboard"
+    }
+}

--- a/web/src/main/kotlin/web/controller/ModerationController.kt
+++ b/web/src/main/kotlin/web/controller/ModerationController.kt
@@ -10,6 +10,7 @@ import org.springframework.security.oauth2.client.annotation.RegisteredOAuth2Aut
 import org.springframework.security.oauth2.core.user.OAuth2User
 import org.springframework.stereotype.Controller
 import org.springframework.ui.Model
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseBody
 import org.springframework.web.servlet.mvc.support.RedirectAttributes
 import web.service.ModerationWebService
+import web.service.TitleShopView
 import web.util.discordIdOrNull
 import web.util.discordIdString
 import web.util.displayName
@@ -70,13 +72,56 @@ class ModerationController(
             return "redirect:/moderation/guilds"
         }
         val leaderboard = moderationWebService.getLeaderboard(guildId)
+        val titleShop = moderationWebService.getTitlesForGuild(guildId, discordId)
 
         model.addAttribute("overview", overview)
         model.addAttribute("leaderboard", leaderboard)
+        model.addAttribute("titleShop", titleShop)
         model.addAttribute("isOwner", moderationWebService.isOwner(discordId, guildId))
         model.addAttribute("username", user.displayName())
         model.addAttribute("actorDiscordId", discordId.toString())
         return "moderation"
+    }
+
+    @PostMapping("/{guildId}/titles/{titleId}/buy")
+    @ResponseBody
+    fun buyTitle(
+        @PathVariable guildId: Long,
+        @PathVariable titleId: Long,
+        @AuthenticationPrincipal user: OAuth2User
+    ): ResponseEntity<ApiResult> {
+        val actor = user.discordIdOrNull()
+            ?: return ResponseEntity.status(401).body(ApiResult(false, "Not signed in."))
+        val error = moderationWebService.buyTitle(actor, guildId, titleId)
+        return if (error != null) ResponseEntity.badRequest().body(ApiResult(false, error))
+        else ResponseEntity.ok(ApiResult(true, null))
+    }
+
+    @PostMapping("/{guildId}/titles/{titleId}/equip")
+    @ResponseBody
+    fun equipTitle(
+        @PathVariable guildId: Long,
+        @PathVariable titleId: Long,
+        @AuthenticationPrincipal user: OAuth2User
+    ): ResponseEntity<ApiResult> {
+        val actor = user.discordIdOrNull()
+            ?: return ResponseEntity.status(401).body(ApiResult(false, "Not signed in."))
+        val error = moderationWebService.equipTitle(actor, guildId, titleId)
+        return if (error != null) ResponseEntity.badRequest().body(ApiResult(false, error))
+        else ResponseEntity.ok(ApiResult(true, null))
+    }
+
+    @DeleteMapping("/{guildId}/titles/equipped")
+    @ResponseBody
+    fun unequipTitle(
+        @PathVariable guildId: Long,
+        @AuthenticationPrincipal user: OAuth2User
+    ): ResponseEntity<ApiResult> {
+        val actor = user.discordIdOrNull()
+            ?: return ResponseEntity.status(401).body(ApiResult(false, "Not signed in."))
+        val error = moderationWebService.unequipTitle(actor, guildId)
+        return if (error != null) ResponseEntity.badRequest().body(ApiResult(false, error))
+        else ResponseEntity.ok(ApiResult(true, null))
     }
 
     @PostMapping("/{guildId}/user/{targetDiscordId}/permission", consumes = ["application/json"])

--- a/web/src/main/kotlin/web/service/LeaderboardWebService.kt
+++ b/web/src/main/kotlin/web/service/LeaderboardWebService.kt
@@ -1,0 +1,91 @@
+package web.service
+
+import net.dv8tion.jda.api.JDA
+import org.springframework.stereotype.Service
+
+@Service
+class LeaderboardWebService(
+    private val jda: JDA,
+    private val introWebService: IntroWebService,
+    private val moderationWebService: ModerationWebService
+) {
+
+    fun getGuildsWhereUserCanView(accessToken: String, discordId: Long): List<LeaderboardGuildCard> {
+        return introWebService.getMutualGuilds(accessToken).mapNotNull { info ->
+            val guildId = info.id.toLongOrNull() ?: return@mapNotNull null
+            if (!isMember(discordId, guildId)) return@mapNotNull null
+            val leaderboard = moderationWebService.getLeaderboard(guildId)
+            val top = leaderboard.firstOrNull()
+            LeaderboardGuildCard(
+                id = info.id,
+                name = info.name,
+                iconUrl = info.iconUrl,
+                topName = top?.name,
+                topTitle = top?.title,
+                topCredits = top?.socialCredit ?: 0L,
+                totalVoiceSeconds = leaderboard.sumOf { it.voiceSecondsThisMonth },
+                memberCount = leaderboard.size
+            )
+        }.sortedBy { it.name.lowercase() }
+    }
+
+    fun isMember(discordId: Long, guildId: Long): Boolean {
+        val guild = jda.getGuildById(guildId) ?: return false
+        return guild.getMemberById(discordId) != null
+    }
+
+    fun getGuildView(guildId: Long): LeaderboardGuildView? {
+        val guild = jda.getGuildById(guildId) ?: return null
+        val rows = moderationWebService.getLeaderboard(guildId)
+        val totalCreditsThisMonth = rows.sumOf { it.creditsEarnedThisMonth }
+        val totalVoiceThisMonth = rows.sumOf { it.voiceSecondsThisMonth }
+        val mostActiveName = rows.maxByOrNull { it.voiceSecondsThisMonth }?.name
+
+        return LeaderboardGuildView(
+            guildName = guild.name,
+            podium = rows.take(3),
+            standings = rows.drop(3),
+            totalCreditsThisMonth = totalCreditsThisMonth,
+            totalVoiceThisMonth = totalVoiceThisMonth,
+            mostActiveMember = mostActiveName,
+            totalMembers = rows.size
+        )
+    }
+}
+
+data class LeaderboardGuildCard(
+    val id: String,
+    val name: String,
+    val iconUrl: String?,
+    val topName: String?,
+    val topTitle: String?,
+    val topCredits: Long,
+    val totalVoiceSeconds: Long,
+    val memberCount: Int
+) {
+    val totalVoiceDisplay: String get() = formatDuration(totalVoiceSeconds)
+    private fun formatDuration(seconds: Long): String {
+        if (seconds <= 0) return "0m"
+        val hours = seconds / 3600
+        val minutes = (seconds % 3600) / 60
+        return if (hours > 0) "${hours}h ${minutes}m" else "${minutes}m"
+    }
+}
+
+data class LeaderboardGuildView(
+    val guildName: String,
+    val podium: List<LeaderboardRow>,
+    val standings: List<LeaderboardRow>,
+    val totalCreditsThisMonth: Long,
+    val totalVoiceThisMonth: Long,
+    val mostActiveMember: String?,
+    val totalMembers: Int
+) {
+    val totalVoiceThisMonthDisplay: String get() = formatDuration(totalVoiceThisMonth)
+    private fun formatDuration(seconds: Long): String {
+        if (seconds <= 0) return "0m"
+        val hours = seconds / 3600
+        val minutes = (seconds % 3600) / 60
+        return if (hours > 0) "${hours}h ${minutes}m" else "${minutes}m"
+    }
+}

--- a/web/src/main/kotlin/web/service/ModerationWebService.kt
+++ b/web/src/main/kotlin/web/service/ModerationWebService.kt
@@ -3,20 +3,29 @@ package web.service
 import database.dto.ConfigDto
 import database.dto.UserDto
 import database.service.ConfigService
+import database.service.MonthlyCreditSnapshotService
+import database.service.TitleService
 import database.service.UserService
+import database.service.VoiceSessionService
 import net.dv8tion.jda.api.EmbedBuilder
 import net.dv8tion.jda.api.JDA
 import net.dv8tion.jda.api.Permission
 import net.dv8tion.jda.api.entities.Member
 import net.dv8tion.jda.api.entities.emoji.Emoji
 import org.springframework.stereotype.Service
+import java.time.LocalDate
+import java.time.ZoneOffset
 
 @Service
 class ModerationWebService(
     private val jda: JDA,
     private val userService: UserService,
     private val configService: ConfigService,
-    private val introWebService: IntroWebService
+    private val introWebService: IntroWebService,
+    private val voiceSessionService: VoiceSessionService,
+    private val titleService: TitleService,
+    private val snapshotService: MonthlyCreditSnapshotService,
+    private val titleRoleService: TitleRoleService
 ) {
     companion object {
         const val MAX_POLL_OPTIONS = 10
@@ -93,19 +102,106 @@ class ModerationWebService(
 
     fun getLeaderboard(guildId: Long): List<LeaderboardRow> {
         val guild = jda.getGuildById(guildId) ?: return emptyList()
-        return userService.listGuildUsers(guildId)
-            .filterNotNull()
+        val users = userService.listGuildUsers(guildId).filterNotNull()
+        val lifetimeVoice = voiceSessionService.sumCountedSecondsLifetimeByUser(guildId)
+
+        val thisMonthStart = LocalDate.now(ZoneOffset.UTC).withDayOfMonth(1)
+        val prevMonthStart = thisMonthStart.minusMonths(1)
+        val thisMonthVoice = voiceSessionService.sumCountedSecondsInRangeByUser(
+            guildId,
+            prevMonthStart.atStartOfDay().toInstant(ZoneOffset.UTC),
+            thisMonthStart.atStartOfDay().toInstant(ZoneOffset.UTC)
+        )
+        val priorSnapshots = snapshotService.listForGuildDate(guildId, thisMonthStart)
+            .associateBy { it.discordId }
+
+        return users
             .sortedByDescending { it.socialCredit ?: 0L }
             .mapIndexed { index, dto ->
                 val member = guild.getMemberById(dto.discordId)
+                val title = dto.activeTitleId?.let { titleService.getById(it) }?.label
+                val current = dto.socialCredit ?: 0L
+                val baseline = priorSnapshots[dto.discordId]?.socialCredit
+                val creditsDelta = if (baseline == null) 0L else current - baseline
                 LeaderboardRow(
                     rank = index + 1,
                     discordId = dto.discordId.toString(),
                     name = member?.effectiveName ?: "Unknown",
                     avatarUrl = member?.effectiveAvatarUrl,
-                    socialCredit = dto.socialCredit ?: 0L
+                    socialCredit = current,
+                    title = title,
+                    voiceSecondsLifetime = lifetimeVoice[dto.discordId] ?: 0L,
+                    voiceSecondsThisMonth = thisMonthVoice[dto.discordId] ?: 0L,
+                    creditsEarnedThisMonth = creditsDelta
                 )
             }
+    }
+
+    fun getTitlesForGuild(guildId: Long, actorDiscordId: Long): TitleShopView {
+        val catalog = titleService.listAll().map { t ->
+            TitleShopEntry(
+                id = t.id ?: 0,
+                label = t.label,
+                cost = t.cost,
+                description = t.description,
+                colorHex = t.colorHex
+            )
+        }
+        val ownedIds = titleService.listOwned(actorDiscordId).map { it.titleId }.toSet()
+        val actorDto = userService.getUserById(actorDiscordId, guildId)
+        val equippedId = actorDto?.activeTitleId
+        val balance = actorDto?.socialCredit ?: 0L
+        return TitleShopView(
+            catalog = catalog,
+            ownedTitleIds = ownedIds,
+            equippedTitleId = equippedId,
+            balance = balance
+        )
+    }
+
+    fun buyTitle(actorDiscordId: Long, guildId: Long, titleId: Long): String? {
+        if (jda.getGuildById(guildId) == null) return "Bot is not in that server."
+        val title = titleService.getById(titleId) ?: return "Title not found."
+        val actor = userService.getUserById(actorDiscordId, guildId) ?: return "You don't have a profile in that server yet."
+        if (titleService.owns(actorDiscordId, titleId)) return "You already own this title."
+        val balance = actor.socialCredit ?: 0L
+        if (balance < title.cost) return "Not enough credits. You need ${title.cost}, you have $balance."
+        actor.socialCredit = balance - title.cost
+        userService.updateUser(actor)
+        titleService.recordPurchase(actorDiscordId, titleId)
+        return null
+    }
+
+    fun equipTitle(actorDiscordId: Long, guildId: Long, titleId: Long): String? {
+        val guild = jda.getGuildById(guildId) ?: return "Bot is not in that server."
+        val member = guild.getMemberById(actorDiscordId) ?: return "You are not a member of that server."
+        val actor = userService.getUserById(actorDiscordId, guildId) ?: return "No profile in that server."
+        val title = titleService.getById(titleId) ?: return "Title not found."
+        if (!titleService.owns(actorDiscordId, titleId)) return "You don't own this title."
+        val ownedIds = titleService.listOwned(actorDiscordId).map { it.titleId }.toSet()
+        return when (val r = titleRoleService.equip(guild, member, title, ownedIds)) {
+            is TitleRoleResult.Ok -> {
+                actor.activeTitleId = titleId
+                userService.updateUser(actor)
+                null
+            }
+            is TitleRoleResult.Error -> r.message
+        }
+    }
+
+    fun unequipTitle(actorDiscordId: Long, guildId: Long): String? {
+        val guild = jda.getGuildById(guildId) ?: return "Bot is not in that server."
+        val member = guild.getMemberById(actorDiscordId) ?: return "You are not a member of that server."
+        val actor = userService.getUserById(actorDiscordId, guildId) ?: return "No profile in that server."
+        val ownedIds = titleService.listOwned(actorDiscordId).map { it.titleId }.toSet()
+        return when (val r = titleRoleService.unequip(guild, member, ownedIds)) {
+            is TitleRoleResult.Ok -> {
+                actor.activeTitleId = null
+                userService.updateUser(actor)
+                null
+            }
+            is TitleRoleResult.Error -> r.message
+        }
     }
 
     fun togglePermission(
@@ -182,6 +278,16 @@ class ModerationWebService(
                     return "No voice channel with that name exists in this server."
                 }
                 name
+            }
+            ConfigDto.Configurations.LEADERBOARD_CHANNEL -> {
+                val id = rawValue.trim()
+                if (id.isEmpty()) return "Channel id is required."
+                val idLong = id.toLongOrNull()
+                    ?: return "Channel id must be numeric."
+                if (guild.getTextChannelById(idLong) == null) {
+                    return "No text channel with that id exists in this server."
+                }
+                id
             }
         }
 
@@ -394,7 +500,36 @@ data class LeaderboardRow(
     val discordId: String,
     val name: String,
     val avatarUrl: String?,
-    val socialCredit: Long
+    val socialCredit: Long,
+    val title: String? = null,
+    val voiceSecondsLifetime: Long = 0,
+    val voiceSecondsThisMonth: Long = 0,
+    val creditsEarnedThisMonth: Long = 0
+) {
+    val voiceLifetimeDisplay: String get() = formatDuration(voiceSecondsLifetime)
+    val voiceThisMonthDisplay: String get() = formatDuration(voiceSecondsThisMonth)
+
+    private fun formatDuration(seconds: Long): String {
+        if (seconds <= 0) return "0m"
+        val hours = seconds / 3600
+        val minutes = (seconds % 3600) / 60
+        return if (hours > 0) "${hours}h ${minutes}m" else "${minutes}m"
+    }
+}
+
+data class TitleShopEntry(
+    val id: Long,
+    val label: String,
+    val cost: Long,
+    val description: String?,
+    val colorHex: String?
+)
+
+data class TitleShopView(
+    val catalog: List<TitleShopEntry>,
+    val ownedTitleIds: Set<Long>,
+    val equippedTitleId: Long?,
+    val balance: Long
 )
 
 data class MoveResult(

--- a/web/src/main/kotlin/web/service/TitleRoleService.kt
+++ b/web/src/main/kotlin/web/service/TitleRoleService.kt
@@ -1,0 +1,123 @@
+package web.service
+
+import common.logging.DiscordLogger
+import database.dto.GuildTitleRoleDto
+import database.dto.TitleDto
+import database.service.GuildTitleRoleService
+import net.dv8tion.jda.api.Permission
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.Member
+import net.dv8tion.jda.api.entities.Role
+import net.dv8tion.jda.api.exceptions.HierarchyException
+import net.dv8tion.jda.api.exceptions.InsufficientPermissionException
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Service
+import java.awt.Color
+
+sealed class TitleRoleResult {
+    data object Ok : TitleRoleResult()
+    data class Error(val message: String) : TitleRoleResult()
+}
+
+@Service
+class TitleRoleService @Autowired constructor(
+    private val guildTitleRoleService: GuildTitleRoleService
+) {
+    private val logger: DiscordLogger = DiscordLogger.createLogger(this::class.java)
+
+    fun equip(guild: Guild, member: Member, title: TitleDto, ownedTitleIds: Set<Long>): TitleRoleResult {
+        if (!guild.selfMember.hasPermission(Permission.MANAGE_ROLES)) {
+            return TitleRoleResult.Error("Bot needs **Manage Roles** permission to grant title roles.")
+        }
+
+        val role = runCatching { ensureTitleRole(guild, title) }
+            .getOrElse { e ->
+                return TitleRoleResult.Error(
+                    (e as? IllegalStateException)?.message
+                        ?: "Could not create or fetch the title role: ${e.message}"
+                )
+            }
+
+        return runCatching {
+            removeOtherTitleRoles(guild, member, ownedTitleIds, exceptTitleId = title.id)
+            guild.addRoleToMember(member, role).complete()
+            TitleRoleResult.Ok
+        }.getOrElse { e ->
+            when (e) {
+                is HierarchyException -> TitleRoleResult.Error(
+                    "The bot's role must sit **above** the title roles in the role hierarchy."
+                )
+                is InsufficientPermissionException -> TitleRoleResult.Error(
+                    "Bot is missing a permission required to assign the title role: ${e.message}"
+                )
+                else -> TitleRoleResult.Error("Could not assign title role: ${e.message}")
+            }
+        }
+    }
+
+    fun unequip(guild: Guild, member: Member, ownedTitleIds: Set<Long>): TitleRoleResult {
+        if (!guild.selfMember.hasPermission(Permission.MANAGE_ROLES)) {
+            return TitleRoleResult.Error("Bot needs **Manage Roles** permission to remove title roles.")
+        }
+        return runCatching {
+            removeOtherTitleRoles(guild, member, ownedTitleIds, exceptTitleId = null)
+            TitleRoleResult.Ok
+        }.getOrElse { TitleRoleResult.Error("Could not remove title role: ${it.message}") }
+    }
+
+    private fun removeOtherTitleRoles(guild: Guild, member: Member, ownedTitleIds: Set<Long>, exceptTitleId: Long?) {
+        if (ownedTitleIds.isEmpty()) return
+        val guildRoles = guildTitleRoleService.listByGuild(guild.idLong)
+            .filter { it.titleId in ownedTitleIds && it.titleId != exceptTitleId }
+        guildRoles.forEach { mapping ->
+            val role = guild.getRoleById(mapping.discordRoleId) ?: return@forEach
+            if (member.roles.any { it.idLong == role.idLong }) {
+                runCatching { guild.removeRoleFromMember(member, role).complete() }
+                    .onFailure { logger.warn("Could not remove title role ${role.name}: ${it.message}") }
+            }
+        }
+    }
+
+    private fun ensureTitleRole(guild: Guild, title: TitleDto): Role {
+        val titleId = title.id ?: error("Title has no id.")
+        val mapping = guildTitleRoleService.get(guild.idLong, titleId)
+        if (mapping != null) {
+            val existing = guild.getRoleById(mapping.discordRoleId)
+            if (existing != null) return existing
+            guildTitleRoleService.delete(guild.idLong, titleId)
+        }
+
+        val color = parseColor(title.colorHex)
+        val newRole = runCatching {
+            guild.createRole()
+                .setName(title.label)
+                .setColor(color)
+                .setHoisted(title.hoisted)
+                .setMentionable(false)
+                .setPermissions(0L)
+                .complete()
+        }.getOrElse { e ->
+            when (e) {
+                is InsufficientPermissionException -> error(
+                    "Bot needs **Manage Roles** permission to create title roles."
+                )
+                else -> error("Could not create title role: ${e.message}")
+            }
+        }
+
+        guildTitleRoleService.save(
+            GuildTitleRoleDto(
+                guildId = guild.idLong,
+                titleId = titleId,
+                discordRoleId = newRole.idLong
+            )
+        )
+        return newRole
+    }
+
+    private fun parseColor(hex: String?): Color? {
+        if (hex.isNullOrBlank()) return null
+        val cleaned = hex.removePrefix("#")
+        return runCatching { Color(cleaned.toInt(16)) }.getOrNull()
+    }
+}

--- a/web/src/main/resources/static/css/leaderboard.css
+++ b/web/src/main/resources/static/css/leaderboard.css
@@ -1,0 +1,198 @@
+.lb-header { margin-bottom: var(--space-5); }
+.lb-header h1 { margin-bottom: var(--space-2); }
+
+/* -- Guild list grid -- */
+.lb-guild-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    gap: var(--space-4);
+}
+.lb-guild-card {
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    padding: var(--space-5);
+    color: var(--text);
+    text-decoration: none;
+    transition: border-color 0.15s, transform 0.1s;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+}
+.lb-guild-card:hover {
+    border-color: var(--accent);
+    transform: translateY(-2px);
+    color: var(--text);
+}
+.lb-guild-card-header {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+}
+.lb-guild-icon, .lb-guild-icon-placeholder {
+    width: 44px;
+    height: 44px;
+    border-radius: 50%;
+    flex-shrink: 0;
+}
+.lb-guild-icon-placeholder {
+    background: var(--accent);
+    color: #fff;
+    font-weight: 700;
+    font-size: 1.1rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+.lb-guild-name {
+    font-weight: 600;
+    font-size: 1rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.lb-guild-top {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2);
+    font-size: 0.9rem;
+    align-items: center;
+}
+.lb-guild-stats {
+    font-size: 0.8rem;
+    color: var(--text-muted);
+    display: flex;
+    gap: var(--space-2);
+    flex-wrap: wrap;
+}
+.lb-top-name { font-weight: 600; display: inline-flex; gap: 6px; align-items: center; }
+
+/* -- Stats strip -- */
+.lb-stats {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: var(--space-3);
+    margin-bottom: var(--space-5);
+}
+.lb-stat {
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    padding: var(--space-4);
+    text-align: center;
+}
+.lb-stat-value {
+    font-size: 1.6rem;
+    font-weight: 700;
+    color: var(--text);
+    line-height: 1.1;
+    margin-bottom: 4px;
+}
+.lb-stat-value.lb-stat-name {
+    font-size: 1.05rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+.lb-stat-label {
+    font-size: 0.8rem;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+/* -- Podium -- */
+.lb-podium {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    gap: var(--space-3);
+    align-items: end;
+    margin-bottom: var(--space-5);
+}
+.lb-podium-card {
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    padding: var(--space-4);
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 6px;
+    position: relative;
+}
+.lb-podium-1 {
+    border-color: #FFD700;
+    box-shadow: 0 0 0 1px #FFD70033, 0 4px 20px #00000044;
+    padding-top: calc(var(--space-4) + 10px);
+    padding-bottom: calc(var(--space-5) + 10px);
+    order: 2;
+}
+.lb-podium-2 {
+    border-color: #C0C0C0;
+    order: 1;
+}
+.lb-podium-3 {
+    border-color: #CD7F32;
+    order: 3;
+}
+.lb-podium-rank {
+    position: absolute;
+    top: 6px;
+    left: 10px;
+    font-size: 0.85rem;
+    color: var(--text-muted);
+    font-weight: 700;
+}
+.lb-podium-medal { font-size: 2rem; line-height: 1; }
+.lb-podium-avatar {
+    width: 72px;
+    height: 72px;
+    border-radius: 50%;
+    object-fit: cover;
+    margin-top: 4px;
+}
+.lb-podium-1 .lb-podium-avatar { width: 96px; height: 96px; }
+.lb-podium-name {
+    font-weight: 700;
+    font-size: 1rem;
+    color: var(--text);
+}
+.lb-podium-1 .lb-podium-name { font-size: 1.15rem; }
+.lb-podium-credits { color: var(--text); font-size: 0.95rem; }
+.lb-podium-credits strong { color: #FFD700; font-size: 1.1rem; }
+.lb-podium-month {
+    color: #2ECC71;
+    font-size: 0.85rem;
+    font-weight: 600;
+}
+.lb-podium-voice {
+    color: var(--text-muted);
+    font-size: 0.8rem;
+}
+
+@media (max-width: 600px) {
+    .lb-podium {
+        grid-template-columns: 1fr;
+    }
+    .lb-podium-1, .lb-podium-2, .lb-podium-3 { order: 0; }
+    .lb-podium-1 { order: -1; }
+}
+
+/* -- Standings table (reuses mod-table) -- */
+.lb-standings { margin-top: var(--space-5); }
+.lb-standings-title {
+    font-size: 1.1rem;
+    margin-bottom: var(--space-3);
+}
+
+/* -- Title pill -- */
+.lb-title-pill {
+    display: inline-block;
+    padding: 2px 8px;
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    font-size: 0.8rem;
+    background: var(--bg);
+    color: var(--text);
+}

--- a/web/src/main/resources/static/js/moderation.js
+++ b/web/src/main/resources/static/js/moderation.js
@@ -9,6 +9,10 @@
     const actorId = main.dataset.actorId;
 
     const postJson = window.TobyApi.postJson;
+    const deleteJson = (window.TobyApi && window.TobyApi.deleteJson) || function (url) {
+        return fetch(url, { method: 'DELETE', headers: { 'Accept': 'application/json' } })
+            .then(r => r.json().catch(() => ({ ok: r.ok })));
+    };
 
     function toast(msg, type) {
         if (window.TobyToast && typeof window.TobyToast.show === 'function') {
@@ -191,6 +195,62 @@
             }).catch(() => { submitBtn.disabled = false; toast('Network error.', 'error'); });
         });
     }
+
+    // --- Titles tab ---
+    document.querySelectorAll('.title-buy').forEach(btn => {
+        btn.addEventListener('click', () => {
+            const row = btn.closest('tr');
+            const titleId = row.dataset.titleId;
+            btn.disabled = true;
+            postJson('/moderation/' + guildId + '/titles/' + titleId + '/buy', {})
+                .then(r => {
+                    btn.disabled = false;
+                    if (r && r.ok) {
+                        toast('Title purchased. Reload to equip.', 'success');
+                        setTimeout(() => window.location.reload(), 600);
+                    } else {
+                        toast(r?.error || 'Could not buy.', 'error');
+                    }
+                })
+                .catch(() => { btn.disabled = false; toast('Network error.', 'error'); });
+        });
+    });
+
+    document.querySelectorAll('.title-equip').forEach(btn => {
+        btn.addEventListener('click', () => {
+            const row = btn.closest('tr');
+            const titleId = row.dataset.titleId;
+            btn.disabled = true;
+            postJson('/moderation/' + guildId + '/titles/' + titleId + '/equip', {})
+                .then(r => {
+                    btn.disabled = false;
+                    if (r && r.ok) {
+                        toast('Title equipped.', 'success');
+                        setTimeout(() => window.location.reload(), 600);
+                    } else {
+                        toast(r?.error || 'Could not equip.', 'error');
+                    }
+                })
+                .catch(() => { btn.disabled = false; toast('Network error.', 'error'); });
+        });
+    });
+
+    document.querySelectorAll('.title-unequip').forEach(btn => {
+        btn.addEventListener('click', () => {
+            btn.disabled = true;
+            deleteJson('/moderation/' + guildId + '/titles/equipped')
+                .then(r => {
+                    btn.disabled = false;
+                    if (r && r.ok) {
+                        toast('Title unequipped.', 'success');
+                        setTimeout(() => window.location.reload(), 600);
+                    } else {
+                        toast(r?.error || 'Could not unequip.', 'error');
+                    }
+                })
+                .catch(() => { btn.disabled = false; toast('Network error.', 'error'); });
+        });
+    });
 
     // --- Poll tab ---
     const pollForm = document.querySelector('.poll-form');

--- a/web/src/main/resources/templates/fragments/navbar.html
+++ b/web/src/main/resources/templates/fragments/navbar.html
@@ -7,6 +7,7 @@
         <a href="/commands/wiki">Commands</a>
         <a href="/intro/guilds">Intro Songs</a>
         <a href="/dnd/campaign">Campaigns</a>
+        <a href="/leaderboards">Leaderboards</a>
         <a href="/moderation/guilds">Moderation</a>
         <span th:if="${username != null}" style="display:flex;align-items:center;gap:12px;">
             <span class="nav-user" th:text="${username}">User</span>

--- a/web/src/main/resources/templates/leaderboard.html
+++ b/web/src/main/resources/templates/leaderboard.html
@@ -1,0 +1,146 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="en">
+<head th:replace="~{fragments/head :: head('TobyBot - Leaderboard', '/css/leaderboard.css')}"></head>
+<body>
+<a href="#main" class="skip-link">Skip to content</a>
+<div th:replace="~{fragments/navbar :: navbar}"></div>
+
+<main id="main" class="container">
+    <div class="lb-header">
+        <a class="back-link" th:href="@{/leaderboards}">&larr; All leaderboards</a>
+        <h1 th:text="${view.guildName}">Guild Name</h1>
+        <p class="muted">Social credit standings &middot; lifetime totals with this month's earnings highlighted</p>
+    </div>
+
+    <div th:if="${error}" class="alert alert-error" th:text="${error}"></div>
+
+    <section class="lb-stats" aria-label="Server stats for this month">
+        <div class="lb-stat">
+            <div class="lb-stat-value" th:text="${view.totalMembers}">0</div>
+            <div class="lb-stat-label">Tracked members</div>
+        </div>
+        <div class="lb-stat">
+            <div class="lb-stat-value" th:text="${view.totalCreditsThisMonth}">0</div>
+            <div class="lb-stat-label">Credits earned this month</div>
+        </div>
+        <div class="lb-stat">
+            <div class="lb-stat-value" th:text="${view.totalVoiceThisMonthDisplay}">0m</div>
+            <div class="lb-stat-label">Voice time this month</div>
+        </div>
+        <div class="lb-stat" th:if="${view.mostActiveMember != null}">
+            <div class="lb-stat-value lb-stat-name" th:text="${view.mostActiveMember}">—</div>
+            <div class="lb-stat-label">Most active this month</div>
+        </div>
+    </section>
+
+    <section class="lb-podium" aria-label="Top three" th:if="${not #lists.isEmpty(view.podium)}">
+        <!-- Render in order: 2nd, 1st, 3rd so 1st appears centered and elevated -->
+        <div class="lb-podium-card lb-podium-2" th:if="${#lists.size(view.podium) >= 2}">
+            <div class="lb-podium-rank">2</div>
+            <div class="lb-podium-medal">🥈</div>
+            <img th:if="${view.podium[1].avatarUrl != null}"
+                 th:src="${view.podium[1].avatarUrl}"
+                 class="lb-podium-avatar"
+                 alt="">
+            <div class="lb-podium-name" th:text="${view.podium[1].name}">Name</div>
+            <span th:if="${view.podium[1].title != null}"
+                  class="lb-title-pill"
+                  th:text="${view.podium[1].title}">Title</span>
+            <div class="lb-podium-credits"><strong th:text="${view.podium[1].socialCredit}">0</strong> credits</div>
+            <div class="lb-podium-month"
+                 th:if="${view.podium[1].creditsEarnedThisMonth > 0}"
+                 th:text="'+' + ${view.podium[1].creditsEarnedThisMonth} + ' this month'">+0 this month</div>
+            <div class="lb-podium-voice" th:text="${view.podium[1].voiceThisMonthDisplay} + ' voice'">0m voice</div>
+        </div>
+
+        <div class="lb-podium-card lb-podium-1" th:if="${#lists.size(view.podium) >= 1}">
+            <div class="lb-podium-rank">1</div>
+            <div class="lb-podium-medal">🥇</div>
+            <img th:if="${view.podium[0].avatarUrl != null}"
+                 th:src="${view.podium[0].avatarUrl}"
+                 class="lb-podium-avatar"
+                 alt="">
+            <div class="lb-podium-name" th:text="${view.podium[0].name}">Name</div>
+            <span th:if="${view.podium[0].title != null}"
+                  class="lb-title-pill"
+                  th:text="${view.podium[0].title}">Title</span>
+            <div class="lb-podium-credits"><strong th:text="${view.podium[0].socialCredit}">0</strong> credits</div>
+            <div class="lb-podium-month"
+                 th:if="${view.podium[0].creditsEarnedThisMonth > 0}"
+                 th:text="'+' + ${view.podium[0].creditsEarnedThisMonth} + ' this month'">+0 this month</div>
+            <div class="lb-podium-voice" th:text="${view.podium[0].voiceThisMonthDisplay} + ' voice'">0m voice</div>
+        </div>
+
+        <div class="lb-podium-card lb-podium-3" th:if="${#lists.size(view.podium) >= 3}">
+            <div class="lb-podium-rank">3</div>
+            <div class="lb-podium-medal">🥉</div>
+            <img th:if="${view.podium[2].avatarUrl != null}"
+                 th:src="${view.podium[2].avatarUrl}"
+                 class="lb-podium-avatar"
+                 alt="">
+            <div class="lb-podium-name" th:text="${view.podium[2].name}">Name</div>
+            <span th:if="${view.podium[2].title != null}"
+                  class="lb-title-pill"
+                  th:text="${view.podium[2].title}">Title</span>
+            <div class="lb-podium-credits"><strong th:text="${view.podium[2].socialCredit}">0</strong> credits</div>
+            <div class="lb-podium-month"
+                 th:if="${view.podium[2].creditsEarnedThisMonth > 0}"
+                 th:text="'+' + ${view.podium[2].creditsEarnedThisMonth} + ' this month'">+0 this month</div>
+            <div class="lb-podium-voice" th:text="${view.podium[2].voiceThisMonthDisplay} + ' voice'">0m voice</div>
+        </div>
+    </section>
+
+    <section class="lb-standings" aria-label="Standings 4 and below"
+             th:if="${not #lists.isEmpty(view.standings)}">
+        <h2 class="lb-standings-title">Rest of the field</h2>
+        <div class="mod-table-wrap">
+            <table class="mod-table lb-standings-table">
+                <thead>
+                <tr>
+                    <th>#</th>
+                    <th>Member</th>
+                    <th>Title</th>
+                    <th>Credits</th>
+                    <th>This month</th>
+                    <th>Voice this month</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr th:each="row : ${view.standings}">
+                    <td th:text="${row.rank}">4</td>
+                    <td>
+                        <div class="member-cell">
+                            <img th:if="${row.avatarUrl != null}"
+                                 th:src="${row.avatarUrl}"
+                                 class="avatar"
+                                 alt="">
+                            <span th:text="${row.name}">Name</span>
+                        </div>
+                    </td>
+                    <td>
+                        <span th:if="${row.title != null}" class="lb-title-pill" th:text="${row.title}"></span>
+                        <span th:unless="${row.title != null}" class="muted">—</span>
+                    </td>
+                    <td th:text="${row.socialCredit}">0</td>
+                    <td>
+                        <span th:if="${row.creditsEarnedThisMonth > 0}"
+                              th:text="'+' + ${row.creditsEarnedThisMonth}">+0</span>
+                        <span th:unless="${row.creditsEarnedThisMonth > 0}" class="muted">—</span>
+                    </td>
+                    <td th:text="${row.voiceThisMonthDisplay}">0m</td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+    </section>
+
+    <div class="empty-hero" th:if="${#lists.isEmpty(view.podium) and #lists.isEmpty(view.standings)}">
+        <span class="emoji" aria-hidden="true">🏁</span>
+        <h2>No credit has been earned here yet</h2>
+        <p class="mb-5">
+            Run commands, spend time in voice together, and check back soon.
+        </p>
+    </div>
+</main>
+</body>
+</html>

--- a/web/src/main/resources/templates/leaderboards.html
+++ b/web/src/main/resources/templates/leaderboards.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="en">
+<head th:replace="~{fragments/head :: head('TobyBot - Leaderboards', '/css/leaderboard.css')}"></head>
+<body>
+<a href="#main" class="skip-link">Skip to content</a>
+<div th:replace="~{fragments/navbar :: navbar}"></div>
+
+<main id="main" class="container">
+    <h1 class="mb-3">Leaderboards</h1>
+    <p class="muted mb-5">
+        Social credit standings for servers you share with TobyBot. Earn credits
+        by using commands and spending time in voice channels with others.
+    </p>
+
+    <div th:if="${error}" class="alert alert-error" th:text="${error}"></div>
+
+    <div class="lb-guild-grid" th:if="${not #lists.isEmpty(guilds)}">
+        <a class="lb-guild-card"
+           th:each="g : ${guilds}"
+           th:href="@{/leaderboard/{id}(id=${g.id})}">
+            <div class="lb-guild-card-header">
+                <img th:if="${g.iconUrl != null}"
+                     th:src="${g.iconUrl}"
+                     th:alt="${g.name} + ' icon'"
+                     class="lb-guild-icon"
+                     onerror="this.style.display='none'">
+                <div th:unless="${g.iconUrl != null}"
+                     class="lb-guild-icon-placeholder"
+                     aria-hidden="true"
+                     th:text="${#strings.substring(g.name, 0, 1).toUpperCase()}">G</div>
+                <div class="lb-guild-name" th:text="${g.name}" th:title="${g.name}">Guild</div>
+            </div>
+            <div class="lb-guild-top" th:if="${g.topName != null}">
+                <span class="muted">Top earner:</span>
+                <span class="lb-top-name">
+                    <span th:if="${g.topTitle != null}" class="lb-title-pill" th:text="${g.topTitle}"></span>
+                    <span th:text="${g.topName}">Top user</span>
+                </span>
+                <span class="muted" th:text="${g.topCredits} + ' credits'">0 credits</span>
+            </div>
+            <div class="lb-guild-stats">
+                <span th:text="${g.memberCount} + ' tracked'">0 tracked</span>
+                <span>&middot;</span>
+                <span th:text="${g.totalVoiceDisplay} + ' voice this month'">0m voice this month</span>
+            </div>
+        </a>
+    </div>
+
+    <div class="empty-hero" th:if="${#lists.isEmpty(guilds)}">
+        <span class="emoji" aria-hidden="true">🏆</span>
+        <h2>No leaderboards to show yet</h2>
+        <p class="mb-5">
+            You need to share at least one server with TobyBot to see a
+            leaderboard here.
+        </p>
+    </div>
+</main>
+</body>
+</html>

--- a/web/src/main/resources/templates/moderation.html
+++ b/web/src/main/resources/templates/moderation.html
@@ -25,6 +25,7 @@
         <button class="tab-btn active" data-tab="users" role="tab" aria-selected="true">Users</button>
         <button class="tab-btn" data-tab="config" role="tab" aria-selected="false">Config</button>
         <button class="tab-btn" data-tab="social" role="tab" aria-selected="false">Social Credit</button>
+        <button class="tab-btn" data-tab="titles" role="tab" aria-selected="false">Titles</button>
         <button class="tab-btn" data-tab="voice" role="tab" aria-selected="false">Voice</button>
         <button class="tab-btn" data-tab="poll" role="tab" aria-selected="false">Poll</button>
     </div>
@@ -148,6 +149,17 @@
                 </select>
                 <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
             </div>
+            <div class="config-row" data-key="LEADERBOARD_CHANNEL">
+                <label>Monthly leaderboard channel</label>
+                <select th:disabled="${!isOwner}">
+                    <option value="">&mdash; system channel &mdash;</option>
+                    <option th:each="tc : ${overview.textChannels}"
+                            th:value="${tc.id}"
+                            th:text="'#' + ${tc.name}"
+                            th:selected="${overview.config['LEADERBOARD_CHANNEL'] == tc.id}"></option>
+                </select>
+                <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+            </div>
         </div>
     </section>
 
@@ -156,13 +168,23 @@
         <p class="muted mb-4" th:if="${!isOwner}">
             Only the server owner can adjust social credit.
         </p>
+        <p class="muted mb-4">
+            Score is the lifetime total. "This month" shows credits earned and
+            counted voice time since the 1st. Monthly leaderboard is posted on the
+            1st of each month.
+            <a th:href="@{/leaderboard/{id}(id=${overview.guildId})}" style="margin-left:8px;">View full leaderboard &rarr;</a>
+        </p>
         <div class="mod-table-wrap">
             <table class="mod-table">
                 <thead>
                 <tr>
                     <th>#</th>
                     <th>Member</th>
+                    <th>Title</th>
                     <th>Score</th>
+                    <th>Credits this month</th>
+                    <th>Voice (lifetime)</th>
+                    <th>Voice this month</th>
                     <th th:if="${isOwner}">Adjust</th>
                 </tr>
                 </thead>
@@ -178,7 +200,11 @@
                             <span th:text="${row.name}">Name</span>
                         </div>
                     </td>
+                    <td class="sc-title" th:text="${row.title != null ? row.title : '—'}">—</td>
                     <td class="sc-score" th:text="${row.socialCredit}">0</td>
+                    <td th:text="${row.creditsEarnedThisMonth}">0</td>
+                    <td th:text="${row.voiceLifetimeDisplay}">0m</td>
+                    <td th:text="${row.voiceThisMonthDisplay}">0m</td>
                     <td th:if="${isOwner}">
                         <div class="sc-adjust">
                             <input type="number" value="0" step="1" aria-label="Delta">
@@ -187,7 +213,62 @@
                     </td>
                 </tr>
                 <tr th:if="${#lists.isEmpty(leaderboard)}">
-                    <td colspan="4" class="muted" style="text-align:center;">No users tracked yet.</td>
+                    <td colspan="8" class="muted" style="text-align:center;">No users tracked yet.</td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+    </section>
+
+    <!-- TITLES TAB -->
+    <section class="tab-panel" data-panel="titles">
+        <p class="muted mb-4">
+            Spend your social credit on vanity titles. Each purchased title also
+            grants you a matching Discord role on this server when equipped —
+            visible everywhere you appear in chat, member list and voice.
+            The bot needs the <strong>Manage Roles</strong> permission, and its
+            role must sit above the title roles in the hierarchy.
+        </p>
+        <p class="muted mb-4">
+            Your balance: <strong th:text="${titleShop.balance} + ' credits'">0 credits</strong>
+        </p>
+        <div class="mod-table-wrap">
+            <table class="mod-table">
+                <thead>
+                <tr>
+                    <th>Title</th>
+                    <th>Cost</th>
+                    <th>Description</th>
+                    <th>Status</th>
+                    <th>Action</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr th:each="t : ${titleShop.catalog}" th:attr="data-title-id=${t.id}">
+                    <td>
+                        <span class="title-label"
+                              th:text="${t.label}"
+                              th:style="${t.colorHex != null ? 'color: ' + t.colorHex : ''}">Title</span>
+                    </td>
+                    <td th:text="${t.cost}">0</td>
+                    <td th:text="${t.description != null ? t.description : ''}"></td>
+                    <td>
+                        <span th:if="${titleShop.equippedTitleId == t.id}" class="badge owner">equipped</span>
+                        <span th:if="${titleShop.equippedTitleId != t.id && titleShop.ownedTitleIds.contains(t.id)}" class="muted">owned</span>
+                        <span th:if="${!titleShop.ownedTitleIds.contains(t.id)}" class="muted">available</span>
+                    </td>
+                    <td>
+                        <button type="button" class="btn title-buy"
+                                th:if="${!titleShop.ownedTitleIds.contains(t.id)}"
+                                th:disabled="${titleShop.balance < t.cost}">Buy</button>
+                        <button type="button" class="btn title-equip"
+                                th:if="${titleShop.ownedTitleIds.contains(t.id) && titleShop.equippedTitleId != t.id}">Equip</button>
+                        <button type="button" class="btn title-unequip"
+                                th:if="${titleShop.equippedTitleId == t.id}">Unequip</button>
+                    </td>
+                </tr>
+                <tr th:if="${#lists.isEmpty(titleShop.catalog)}">
+                    <td colspan="5" class="muted" style="text-align:center;">No titles configured.</td>
                 </tr>
                 </tbody>
             </table>

--- a/web/src/main/resources/templates/privacy.html
+++ b/web/src/main/resources/templates/privacy.html
@@ -66,7 +66,7 @@
 <div class="container">
     <div class="page-header">
         <h1>Privacy Policy</h1>
-        <p class="updated">Last updated: March 2026</p>
+        <p class="updated">Last updated: April 2026</p>
     </div>
 
     <div class="section">
@@ -82,8 +82,11 @@
             <li><strong>Username</strong> — stored where attribution is needed (e.g. excuses, intro song ownership).</li>
             <li><strong>Intro audio files</strong> — audio clips you upload for the intro song feature, stored as binary data.</li>
             <li><strong>User preferences and permissions</strong> — music, meme, and dig permissions; social credit scores; superuser status.</li>
-            <li><strong>Server configuration</strong> — per-guild settings such as delete delay and volume level.</li>
+            <li><strong>Server configuration</strong> — per-guild settings such as delete delay, volume level, and the channel where the monthly leaderboard is posted.</li>
             <li><strong>Excuse entries</strong> — text excuses submitted by users for use within a guild.</li>
+            <li><strong>Voice channel activity</strong> — when you are in a voice channel with TobyBot we record the start and end time of each session, the channel and guild it occurred in, and how much of that time had at least one other non-bot user present. These records are used to award social credit (with a daily cap) and to produce monthly leaderboards.</li>
+            <li><strong>Monthly social-credit snapshots</strong> — on the first of each month we record each tracked user's current social-credit total so the leaderboard can show credits earned that month.</li>
+            <li><strong>Vanity title purchases and equipped title</strong> — the titles you have bought with social credit and which one (if any) you have equipped in each server.</li>
         </ul>
         <p>We do not collect passwords, email addresses, payment card numbers, or any data beyond what Discord makes available through its API.</p>
     </div>
@@ -96,6 +99,8 @@
             <li>Enforcing per-user permissions for commands.</li>
             <li>Persisting guild configuration between bot restarts.</li>
             <li>Displaying usernames on excuse and social credit features.</li>
+            <li>Awarding social credit for voice-channel time you spend with other users, subject to a daily cap, and posting a monthly leaderboard on the first of each month in a channel chosen by the server owner.</li>
+            <li>Creating and assigning a Discord role on the server when you equip a vanity title you have purchased, and removing that role when you unequip or switch titles. The role is cosmetic (no elevated permissions) and is managed entirely by the bot.</li>
         </ul>
         <p>We do not sell, rent, or share your data with third parties for marketing or advertising purposes.</p>
     </div>

--- a/web/src/test/kotlin/web/service/LeaderboardWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/LeaderboardWebServiceTest.kt
@@ -1,0 +1,131 @@
+package web.service
+
+import io.mockk.every
+import io.mockk.mockk
+import net.dv8tion.jda.api.JDA
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.Member
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class LeaderboardWebServiceTest {
+
+    private lateinit var jda: JDA
+    private lateinit var introWebService: IntroWebService
+    private lateinit var moderationWebService: ModerationWebService
+    private lateinit var service: LeaderboardWebService
+
+    private val guildId = 42L
+    private val discordId = 100L
+
+    @BeforeEach
+    fun setup() {
+        jda = mockk(relaxed = true)
+        introWebService = mockk(relaxed = true)
+        moderationWebService = mockk(relaxed = true)
+        service = LeaderboardWebService(jda, introWebService, moderationWebService)
+    }
+
+    @Test
+    fun `isMember returns true when user is in the guild`() {
+        val guild = mockk<Guild>(relaxed = true)
+        val member = mockk<Member>(relaxed = true)
+        every { jda.getGuildById(guildId) } returns guild
+        every { guild.getMemberById(discordId) } returns member
+        assertTrue(service.isMember(discordId, guildId))
+    }
+
+    @Test
+    fun `isMember returns false when user is not in the guild`() {
+        val guild = mockk<Guild>(relaxed = true)
+        every { jda.getGuildById(guildId) } returns guild
+        every { guild.getMemberById(discordId) } returns null
+        assertFalse(service.isMember(discordId, guildId))
+    }
+
+    @Test
+    fun `isMember returns false when bot is not in guild`() {
+        every { jda.getGuildById(guildId) } returns null
+        assertFalse(service.isMember(discordId, guildId))
+    }
+
+    @Test
+    fun `getGuildView returns null when bot is not in guild`() {
+        every { jda.getGuildById(guildId) } returns null
+        assertNull(service.getGuildView(guildId))
+    }
+
+    @Test
+    fun `getGuildView splits leaderboard into podium (top 3) and standings`() {
+        val guild = mockk<Guild>(relaxed = true)
+        every { jda.getGuildById(guildId) } returns guild
+        every { guild.id } returns guildId.toString()
+        every { guild.name } returns "Test"
+        every { moderationWebService.getLeaderboard(guildId) } returns listOf(
+            LeaderboardRow(rank = 1, discordId = "1", name = "A", avatarUrl = null, socialCredit = 500,
+                title = "⭐", voiceSecondsThisMonth = 3600, creditsEarnedThisMonth = 100),
+            LeaderboardRow(rank = 2, discordId = "2", name = "B", avatarUrl = null, socialCredit = 400),
+            LeaderboardRow(rank = 3, discordId = "3", name = "C", avatarUrl = null, socialCredit = 300),
+            LeaderboardRow(rank = 4, discordId = "4", name = "D", avatarUrl = null, socialCredit = 200),
+            LeaderboardRow(rank = 5, discordId = "5", name = "E", avatarUrl = null, socialCredit = 100)
+        )
+
+        val view = service.getGuildView(guildId)!!
+
+        assertEquals(3, view.podium.size)
+        assertEquals("A", view.podium[0].name)
+        assertEquals(2, view.standings.size)
+        assertEquals(4, view.standings[0].rank)
+        assertEquals(5, view.totalMembers)
+        assertEquals(100L, view.totalCreditsThisMonth)
+        assertEquals(3600L, view.totalVoiceThisMonth)
+        assertEquals("A", view.mostActiveMember)
+    }
+
+    @Test
+    fun `getGuildView with fewer than 3 users returns only what exists`() {
+        val guild = mockk<Guild>(relaxed = true)
+        every { jda.getGuildById(guildId) } returns guild
+        every { guild.id } returns guildId.toString()
+        every { guild.name } returns "Small"
+        every { moderationWebService.getLeaderboard(guildId) } returns listOf(
+            LeaderboardRow(rank = 1, discordId = "1", name = "Solo", avatarUrl = null, socialCredit = 50)
+        )
+
+        val view = service.getGuildView(guildId)!!
+        assertEquals(1, view.podium.size)
+        assertTrue(view.standings.isEmpty())
+    }
+
+    @Test
+    fun `getGuildsWhereUserCanView filters to guilds the user belongs to`() {
+        val mutuals = listOf(
+            GuildInfo(id = "42", name = "Alpha", iconHash = null),
+            GuildInfo(id = "43", name = "Beta", iconHash = null)
+        )
+        every { introWebService.getMutualGuilds("token") } returns mutuals
+        val guild42 = mockk<Guild>(relaxed = true)
+        val guild43 = mockk<Guild>(relaxed = true)
+        every { jda.getGuildById(42L) } returns guild42
+        every { jda.getGuildById(43L) } returns guild43
+        val memberMock = mockk<Member>(relaxed = true)
+        every { guild42.getMemberById(discordId) } returns memberMock
+        every { guild43.getMemberById(discordId) } returns null // user not a member of Beta
+        every { moderationWebService.getLeaderboard(42L) } returns listOf(
+            LeaderboardRow(rank = 1, discordId = "1", name = "Ace", avatarUrl = null, socialCredit = 1000,
+                title = "🥇", voiceSecondsThisMonth = 1800)
+        )
+
+        val cards = service.getGuildsWhereUserCanView("token", discordId)
+        assertEquals(1, cards.size)
+        assertEquals("42", cards.first().id)
+        assertEquals("Ace", cards.first().topName)
+        assertEquals("🥇", cards.first().topTitle)
+        assertEquals(1000L, cards.first().topCredits)
+        assertEquals(1800L, cards.first().totalVoiceSeconds)
+    }
+}

--- a/web/src/test/kotlin/web/service/ModerationWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/ModerationWebServiceTest.kt
@@ -1,9 +1,15 @@
 package web.service
 
 import database.dto.ConfigDto
+import database.dto.MonthlyCreditSnapshotDto
+import database.dto.TitleDto
 import database.dto.UserDto
+import database.dto.UserOwnedTitleDto
 import database.service.ConfigService
+import database.service.MonthlyCreditSnapshotService
+import database.service.TitleService
 import database.service.UserService
+import database.service.VoiceSessionService
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.unmockkAll
@@ -30,6 +36,10 @@ class ModerationWebServiceTest {
     private lateinit var userService: UserService
     private lateinit var configService: ConfigService
     private lateinit var introWebService: IntroWebService
+    private lateinit var voiceSessionService: VoiceSessionService
+    private lateinit var titleService: TitleService
+    private lateinit var snapshotService: MonthlyCreditSnapshotService
+    private lateinit var titleRoleService: TitleRoleService
     private lateinit var service: ModerationWebService
 
     private lateinit var guild: Guild
@@ -46,8 +56,21 @@ class ModerationWebServiceTest {
         userService = mockk(relaxed = true)
         configService = mockk(relaxed = true)
         introWebService = mockk(relaxed = true)
+        voiceSessionService = mockk(relaxed = true)
+        titleService = mockk(relaxed = true)
+        snapshotService = mockk(relaxed = true)
+        titleRoleService = mockk(relaxed = true)
         guild = mockk(relaxed = true)
-        service = ModerationWebService(jda, userService, configService, introWebService)
+        service = ModerationWebService(
+            jda,
+            userService,
+            configService,
+            introWebService,
+            voiceSessionService,
+            titleService,
+            snapshotService,
+            titleRoleService
+        )
 
         every { jda.getGuildById(guildId) } returns guild
         every { guild.id } returns guildId.toString()
@@ -358,5 +381,274 @@ class ModerationWebServiceTest {
         val result = service.getModeratableGuilds("token", ownerId)
         assertEquals(1, result.size)
         assertEquals(guildId.toString(), result.first().id)
+    }
+
+    // ---- getLeaderboard ----
+
+    @Test
+    fun `getLeaderboard returns rows sorted by socialCredit with title and voice stats`() {
+        val topUser = UserDto(discordId = plainUserId, guildId = guildId).apply {
+            socialCredit = 500L
+            activeTitleId = 7L
+        }
+        val midUser = UserDto(discordId = targetUserId, guildId = guildId).apply {
+            socialCredit = 200L
+            activeTitleId = null
+        }
+        every { userService.listGuildUsers(guildId) } returns listOf(topUser, midUser)
+        mockMember(plainUserId)
+        mockMember(targetUserId)
+        every { voiceSessionService.sumCountedSecondsLifetimeByUser(guildId) } returns mapOf(
+            plainUserId to 7200L,
+            targetUserId to 120L
+        )
+        every { voiceSessionService.sumCountedSecondsInRangeByUser(guildId, any(), any()) } returns mapOf(
+            plainUserId to 3600L
+        )
+        every { snapshotService.listForGuildDate(guildId, any()) } returns listOf(
+            MonthlyCreditSnapshotDto(discordId = plainUserId, guildId = guildId, socialCredit = 300L),
+            MonthlyCreditSnapshotDto(discordId = targetUserId, guildId = guildId, socialCredit = 200L)
+        )
+        every { titleService.getById(7L) } returns TitleDto(id = 7L, label = "⭐ Comrade", cost = 100L)
+
+        val rows = service.getLeaderboard(guildId)
+
+        assertEquals(2, rows.size)
+        assertEquals(1, rows[0].rank)
+        assertEquals(plainUserId.toString(), rows[0].discordId)
+        assertEquals(500L, rows[0].socialCredit)
+        assertEquals("⭐ Comrade", rows[0].title)
+        assertEquals(7200L, rows[0].voiceSecondsLifetime)
+        assertEquals(3600L, rows[0].voiceSecondsThisMonth)
+        assertEquals(200L, rows[0].creditsEarnedThisMonth)
+        assertEquals(2, rows[1].rank)
+        assertNull(rows[1].title)
+        assertEquals(0L, rows[1].creditsEarnedThisMonth)
+        assertEquals("2h 0m", rows[0].voiceLifetimeDisplay)
+        assertEquals("1h 0m", rows[0].voiceThisMonthDisplay)
+    }
+
+    @Test
+    fun `getLeaderboard returns empty list when bot is not in guild`() {
+        every { jda.getGuildById(guildId) } returns null
+        val rows = service.getLeaderboard(guildId)
+        assertTrue(rows.isEmpty())
+    }
+
+    @Test
+    fun `getLeaderboard treats users with no prior snapshot as zero delta`() {
+        val user = UserDto(discordId = plainUserId, guildId = guildId).apply { socialCredit = 1_000L }
+        every { userService.listGuildUsers(guildId) } returns listOf(user)
+        mockMember(plainUserId)
+        every { voiceSessionService.sumCountedSecondsLifetimeByUser(guildId) } returns emptyMap()
+        every { voiceSessionService.sumCountedSecondsInRangeByUser(guildId, any(), any()) } returns emptyMap()
+        every { snapshotService.listForGuildDate(guildId, any()) } returns emptyList()
+
+        val rows = service.getLeaderboard(guildId)
+        assertEquals(0L, rows.first().creditsEarnedThisMonth)
+    }
+
+    // ---- getTitlesForGuild ----
+
+    @Test
+    fun `getTitlesForGuild returns catalog with ownership, equipped flag, and balance`() {
+        val titles = listOf(
+            TitleDto(id = 1L, label = "A", cost = 100L, description = "d1"),
+            TitleDto(id = 2L, label = "B", cost = 500L, description = null, colorHex = "#FFD700", hoisted = true)
+        )
+        val owned = listOf(UserOwnedTitleDto(discordId = plainUserId, titleId = 1L))
+        val actor = UserDto(discordId = plainUserId, guildId = guildId).apply {
+            socialCredit = 350L
+            activeTitleId = 1L
+        }
+        every { titleService.listAll() } returns titles
+        every { titleService.listOwned(plainUserId) } returns owned
+        every { userService.getUserById(plainUserId, guildId) } returns actor
+
+        val view = service.getTitlesForGuild(guildId, plainUserId)
+        assertEquals(2, view.catalog.size)
+        assertEquals(setOf(1L), view.ownedTitleIds)
+        assertEquals(1L, view.equippedTitleId)
+        assertEquals(350L, view.balance)
+    }
+
+    // ---- buyTitle ----
+
+    @Test
+    fun `buyTitle deducts credits and records purchase`() {
+        val title = TitleDto(id = 1L, label = "A", cost = 100L)
+        val actor = UserDto(discordId = plainUserId, guildId = guildId).apply { socialCredit = 500L }
+        every { titleService.getById(1L) } returns title
+        every { userService.getUserById(plainUserId, guildId) } returns actor
+        every { titleService.owns(plainUserId, 1L) } returns false
+
+        val err = service.buyTitle(plainUserId, guildId, 1L)
+        assertNull(err)
+        assertEquals(400L, actor.socialCredit)
+        verify(exactly = 1) { userService.updateUser(actor) }
+        verify(exactly = 1) { titleService.recordPurchase(plainUserId, 1L) }
+    }
+
+    @Test
+    fun `buyTitle rejects when user already owns the title`() {
+        val title = TitleDto(id = 1L, label = "A", cost = 100L)
+        val actor = UserDto(discordId = plainUserId, guildId = guildId).apply { socialCredit = 500L }
+        every { titleService.getById(1L) } returns title
+        every { userService.getUserById(plainUserId, guildId) } returns actor
+        every { titleService.owns(plainUserId, 1L) } returns true
+
+        val err = service.buyTitle(plainUserId, guildId, 1L)
+        assertEquals("You already own this title.", err)
+        verify(exactly = 0) { userService.updateUser(any()) }
+        verify(exactly = 0) { titleService.recordPurchase(any(), any()) }
+    }
+
+    @Test
+    fun `buyTitle rejects when credits insufficient`() {
+        val title = TitleDto(id = 1L, label = "A", cost = 1_000L)
+        val actor = UserDto(discordId = plainUserId, guildId = guildId).apply { socialCredit = 50L }
+        every { titleService.getById(1L) } returns title
+        every { userService.getUserById(plainUserId, guildId) } returns actor
+        every { titleService.owns(plainUserId, 1L) } returns false
+
+        val err = service.buyTitle(plainUserId, guildId, 1L)
+        assertNotNull(err)
+        assertTrue(err!!.contains("Not enough credits"))
+        assertEquals(50L, actor.socialCredit)
+        verify(exactly = 0) { userService.updateUser(any()) }
+    }
+
+    @Test
+    fun `buyTitle rejects when bot is not in guild`() {
+        every { jda.getGuildById(guildId) } returns null
+        val err = service.buyTitle(plainUserId, guildId, 1L)
+        assertEquals("Bot is not in that server.", err)
+    }
+
+    @Test
+    fun `buyTitle rejects when user has no profile`() {
+        val title = TitleDto(id = 1L, label = "A", cost = 100L)
+        every { titleService.getById(1L) } returns title
+        every { userService.getUserById(plainUserId, guildId) } returns null
+
+        val err = service.buyTitle(plainUserId, guildId, 1L)
+        assertEquals("You don't have a profile in that server yet.", err)
+    }
+
+    @Test
+    fun `buyTitle rejects when title does not exist`() {
+        every { titleService.getById(99L) } returns null
+        val err = service.buyTitle(plainUserId, guildId, 99L)
+        assertEquals("Title not found.", err)
+    }
+
+    // ---- equipTitle ----
+
+    @Test
+    fun `equipTitle sets activeTitleId when role service succeeds`() {
+        val title = TitleDto(id = 1L, label = "A", cost = 100L)
+        val actor = UserDto(discordId = plainUserId, guildId = guildId)
+        val member = mockMember(plainUserId)
+        every { userService.getUserById(plainUserId, guildId) } returns actor
+        every { titleService.getById(1L) } returns title
+        every { titleService.owns(plainUserId, 1L) } returns true
+        every { titleService.listOwned(plainUserId) } returns listOf(UserOwnedTitleDto(discordId = plainUserId, titleId = 1L))
+        every { titleRoleService.equip(guild, member, title, setOf(1L)) } returns TitleRoleResult.Ok
+
+        val err = service.equipTitle(plainUserId, guildId, 1L)
+        assertNull(err)
+        assertEquals(1L, actor.activeTitleId)
+        verify(exactly = 1) { userService.updateUser(actor) }
+    }
+
+    @Test
+    fun `equipTitle rejects when user does not own the title`() {
+        val title = TitleDto(id = 1L, label = "A", cost = 100L)
+        val actor = UserDto(discordId = plainUserId, guildId = guildId)
+        mockMember(plainUserId)
+        every { userService.getUserById(plainUserId, guildId) } returns actor
+        every { titleService.getById(1L) } returns title
+        every { titleService.owns(plainUserId, 1L) } returns false
+
+        val err = service.equipTitle(plainUserId, guildId, 1L)
+        assertEquals("You don't own this title.", err)
+        assertNull(actor.activeTitleId)
+        verify(exactly = 0) { userService.updateUser(any()) }
+    }
+
+    @Test
+    fun `equipTitle surfaces role service error and does not persist`() {
+        val title = TitleDto(id = 1L, label = "A", cost = 100L)
+        val actor = UserDto(discordId = plainUserId, guildId = guildId)
+        val member = mockMember(plainUserId)
+        every { userService.getUserById(plainUserId, guildId) } returns actor
+        every { titleService.getById(1L) } returns title
+        every { titleService.owns(plainUserId, 1L) } returns true
+        every { titleService.listOwned(plainUserId) } returns listOf(UserOwnedTitleDto(discordId = plainUserId, titleId = 1L))
+        every { titleRoleService.equip(guild, member, title, any()) } returns TitleRoleResult.Error("no Manage Roles")
+
+        val err = service.equipTitle(plainUserId, guildId, 1L)
+        assertEquals("no Manage Roles", err)
+        assertNull(actor.activeTitleId)
+        verify(exactly = 0) { userService.updateUser(any()) }
+    }
+
+    // ---- unequipTitle ----
+
+    @Test
+    fun `unequipTitle clears activeTitleId when role service succeeds`() {
+        val actor = UserDto(discordId = plainUserId, guildId = guildId).apply { activeTitleId = 1L }
+        val member = mockMember(plainUserId)
+        every { userService.getUserById(plainUserId, guildId) } returns actor
+        every { titleService.listOwned(plainUserId) } returns listOf(UserOwnedTitleDto(discordId = plainUserId, titleId = 1L))
+        every { titleRoleService.unequip(guild, member, setOf(1L)) } returns TitleRoleResult.Ok
+
+        val err = service.unequipTitle(plainUserId, guildId)
+        assertNull(err)
+        assertNull(actor.activeTitleId)
+        verify(exactly = 1) { userService.updateUser(actor) }
+    }
+
+    @Test
+    fun `unequipTitle surfaces role service error`() {
+        val actor = UserDto(discordId = plainUserId, guildId = guildId).apply { activeTitleId = 1L }
+        val member = mockMember(plainUserId)
+        every { userService.getUserById(plainUserId, guildId) } returns actor
+        every { titleService.listOwned(plainUserId) } returns emptyList()
+        every { titleRoleService.unequip(guild, member, any()) } returns TitleRoleResult.Error("bot has no Manage Roles")
+
+        val err = service.unequipTitle(plainUserId, guildId)
+        assertEquals("bot has no Manage Roles", err)
+        assertEquals(1L, actor.activeTitleId)
+        verify(exactly = 0) { userService.updateUser(any()) }
+    }
+
+    // ---- updateConfig LEADERBOARD_CHANNEL ----
+
+    @Test
+    fun `updateConfig LEADERBOARD_CHANNEL rejects non-numeric id`() {
+        mockMember(ownerId, isOwner = true)
+        val err = service.updateConfig(ownerId, guildId, ConfigDto.Configurations.LEADERBOARD_CHANNEL, "not-a-number")
+        assertEquals("Channel id must be numeric.", err)
+    }
+
+    @Test
+    fun `updateConfig LEADERBOARD_CHANNEL rejects unknown channel id`() {
+        mockMember(ownerId, isOwner = true)
+        every { guild.getTextChannelById(111L) } returns null
+        val err = service.updateConfig(ownerId, guildId, ConfigDto.Configurations.LEADERBOARD_CHANNEL, "111")
+        assertEquals("No text channel with that id exists in this server.", err)
+    }
+
+    @Test
+    fun `updateConfig LEADERBOARD_CHANNEL persists valid channel id`() {
+        mockMember(ownerId, isOwner = true)
+        val textChannel = mockk<TextChannel>(relaxed = true)
+        every { guild.getTextChannelById(111L) } returns textChannel
+        every { configService.getConfigByName(any(), any()) } returns null
+
+        val err = service.updateConfig(ownerId, guildId, ConfigDto.Configurations.LEADERBOARD_CHANNEL, "111")
+        assertNull(err)
+        verify(exactly = 1) { configService.createNewConfig(any()) }
     }
 }

--- a/web/src/test/kotlin/web/service/TitleRoleServiceTest.kt
+++ b/web/src/test/kotlin/web/service/TitleRoleServiceTest.kt
@@ -1,0 +1,196 @@
+package web.service
+
+import database.dto.GuildTitleRoleDto
+import database.dto.TitleDto
+import database.service.GuildTitleRoleService
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import net.dv8tion.jda.api.Permission
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.Member
+import net.dv8tion.jda.api.entities.Role
+import net.dv8tion.jda.api.entities.SelfMember
+import net.dv8tion.jda.api.exceptions.HierarchyException
+import net.dv8tion.jda.api.requests.restaction.AuditableRestAction
+import net.dv8tion.jda.api.requests.restaction.RoleAction
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class TitleRoleServiceTest {
+
+    private lateinit var guildTitleRoleService: GuildTitleRoleService
+    private lateinit var service: TitleRoleService
+    private lateinit var guild: Guild
+    private lateinit var selfMember: SelfMember
+    private lateinit var member: Member
+
+    private val guildId = 42L
+    private val titleId = 7L
+
+    @BeforeEach
+    fun setup() {
+        guildTitleRoleService = mockk(relaxed = true)
+        service = TitleRoleService(guildTitleRoleService)
+        guild = mockk(relaxed = true)
+        selfMember = mockk(relaxed = true)
+        member = mockk(relaxed = true)
+        every { guild.idLong } returns guildId
+        every { guild.selfMember } returns selfMember
+        every { selfMember.hasPermission(Permission.MANAGE_ROLES) } returns true
+    }
+
+    private fun role(id: Long, name: String = "role-$id"): Role {
+        val r = mockk<Role>(relaxed = true)
+        every { r.idLong } returns id
+        every { r.name } returns name
+        return r
+    }
+
+    @Test
+    fun `equip returns error when bot lacks Manage Roles`() {
+        every { selfMember.hasPermission(Permission.MANAGE_ROLES) } returns false
+        val title = TitleDto(id = titleId, label = "A", cost = 100L)
+        val result = service.equip(guild, member, title, emptySet())
+        assertTrue(result is TitleRoleResult.Error)
+        assertTrue((result as TitleRoleResult.Error).message.contains("Manage Roles"))
+    }
+
+    @Test
+    fun `equip reuses existing role mapping when the role still exists`() {
+        val existingRole = role(200L, "⭐ Comrade")
+        every { guildTitleRoleService.get(guildId, titleId) } returns GuildTitleRoleDto(
+            guildId = guildId, titleId = titleId, discordRoleId = 200L
+        )
+        every { guild.getRoleById(200L) } returns existingRole
+        every { member.roles } returns emptyList()
+
+        val title = TitleDto(id = titleId, label = "⭐ Comrade", cost = 100L)
+        val result = service.equip(guild, member, title, emptySet())
+
+        assertEquals(TitleRoleResult.Ok, result)
+        verify(exactly = 0) { guild.createRole() }
+        verify(exactly = 1) { guild.addRoleToMember(member, existingRole) }
+    }
+
+    @Test
+    fun `equip creates new role and persists mapping when none exists`() {
+        every { guildTitleRoleService.get(guildId, titleId) } returns null
+        val newRole = role(300L, "⭐ Comrade")
+        val roleAction = mockk<RoleAction>(relaxed = true)
+        every { guild.createRole() } returns roleAction
+        every { roleAction.setName(any()) } returns roleAction
+        every { roleAction.setColor(any<java.awt.Color>()) } returns roleAction
+        every { roleAction.setHoisted(any()) } returns roleAction
+        every { roleAction.setMentionable(any()) } returns roleAction
+        every { roleAction.setPermissions(any<Long>()) } returns roleAction
+        every { roleAction.complete() } returns newRole
+        every { member.roles } returns emptyList()
+
+        val title = TitleDto(id = titleId, label = "⭐ Comrade", cost = 100L, colorHex = "#F1C40F", hoisted = false)
+        val result = service.equip(guild, member, title, emptySet())
+
+        assertEquals(TitleRoleResult.Ok, result)
+        val saved = slot<GuildTitleRoleDto>()
+        verify(exactly = 1) { guildTitleRoleService.save(capture(saved)) }
+        assertEquals(guildId, saved.captured.guildId)
+        assertEquals(titleId, saved.captured.titleId)
+        assertEquals(300L, saved.captured.discordRoleId)
+    }
+
+    @Test
+    fun `equip removes previously equipped title role when owned`() {
+        val oldRole = role(100L, "old")
+        val newRole = role(200L, "new")
+        every { guildTitleRoleService.get(guildId, titleId) } returns GuildTitleRoleDto(
+            guildId = guildId, titleId = titleId, discordRoleId = 200L
+        )
+        every { guild.getRoleById(200L) } returns newRole
+        every { guildTitleRoleService.listByGuild(guildId) } returns listOf(
+            GuildTitleRoleDto(guildId = guildId, titleId = 5L, discordRoleId = 100L),
+            GuildTitleRoleDto(guildId = guildId, titleId = titleId, discordRoleId = 200L)
+        )
+        every { guild.getRoleById(100L) } returns oldRole
+        every { member.roles } returns listOf(oldRole)
+
+        val title = TitleDto(id = titleId, label = "new", cost = 100L)
+        val result = service.equip(guild, member, title, ownedTitleIds = setOf(5L, titleId))
+
+        assertEquals(TitleRoleResult.Ok, result)
+        verify(exactly = 1) { guild.removeRoleFromMember(member, oldRole) }
+        verify(exactly = 1) { guild.addRoleToMember(member, newRole) }
+    }
+
+    @Test
+    fun `equip surfaces hierarchy exception from JDA`() {
+        val existingRole = role(200L, "⭐")
+        every { guildTitleRoleService.get(guildId, titleId) } returns GuildTitleRoleDto(
+            guildId = guildId, titleId = titleId, discordRoleId = 200L
+        )
+        every { guild.getRoleById(200L) } returns existingRole
+        every { member.roles } returns emptyList()
+        val action = mockk<AuditableRestAction<*>>(relaxed = true)
+        @Suppress("UNCHECKED_CAST")
+        every { guild.addRoleToMember(member, existingRole) } returns action as AuditableRestAction<Void>
+        every { action.complete() } throws HierarchyException("too high")
+
+        val title = TitleDto(id = titleId, label = "⭐", cost = 100L)
+        val result = service.equip(guild, member, title, emptySet())
+
+        assertTrue(result is TitleRoleResult.Error)
+        assertTrue((result as TitleRoleResult.Error).message.contains("hierarchy"))
+    }
+
+    @Test
+    fun `equip deletes stale mapping when referenced role is gone and creates a fresh one`() {
+        every { guildTitleRoleService.get(guildId, titleId) } returns GuildTitleRoleDto(
+            guildId = guildId, titleId = titleId, discordRoleId = 999L
+        )
+        every { guild.getRoleById(999L) } returns null
+        val newRole = role(500L, "fresh")
+        val roleAction = mockk<RoleAction>(relaxed = true)
+        every { guild.createRole() } returns roleAction
+        every { roleAction.setName(any()) } returns roleAction
+        every { roleAction.setColor(any<java.awt.Color>()) } returns roleAction
+        every { roleAction.setHoisted(any()) } returns roleAction
+        every { roleAction.setMentionable(any()) } returns roleAction
+        every { roleAction.setPermissions(any<Long>()) } returns roleAction
+        every { roleAction.complete() } returns newRole
+        every { member.roles } returns emptyList()
+
+        val title = TitleDto(id = titleId, label = "fresh", cost = 100L)
+        val result = service.equip(guild, member, title, emptySet())
+
+        assertEquals(TitleRoleResult.Ok, result)
+        verify(exactly = 1) { guildTitleRoleService.delete(guildId, titleId) }
+    }
+
+    @Test
+    fun `unequip removes all owned title roles on the member`() {
+        val roleA = role(100L)
+        val roleB = role(200L)
+        every { guildTitleRoleService.listByGuild(guildId) } returns listOf(
+            GuildTitleRoleDto(guildId = guildId, titleId = 1L, discordRoleId = 100L),
+            GuildTitleRoleDto(guildId = guildId, titleId = 2L, discordRoleId = 200L)
+        )
+        every { guild.getRoleById(100L) } returns roleA
+        every { guild.getRoleById(200L) } returns roleB
+        every { member.roles } returns listOf(roleA, roleB)
+
+        val result = service.unequip(guild, member, setOf(1L, 2L))
+
+        assertEquals(TitleRoleResult.Ok, result)
+        verify(exactly = 1) { guild.removeRoleFromMember(member, roleA) }
+        verify(exactly = 1) { guild.removeRoleFromMember(member, roleB) }
+    }
+
+    @Test
+    fun `unequip is a no-op when user owns no titles`() {
+        val result = service.unequip(guild, member, emptySet())
+        assertEquals(TitleRoleResult.Ok, result)
+        verify(exactly = 0) { guild.removeRoleFromMember(any<Member>(), any<Role>()) }
+    }
+}


### PR DESCRIPTION
## Summary

Grow the social credit system from "earn by using commands" into a full engagement loop:

- **Earn by voice presence** — users accumulate credits for time spent in voice channels that the bot is in, alongside the existing per-command rewards. AFK guard requires at least one other non-bot human in the channel *and* enforces a daily cap (60 credits/day by default).
- **Monthly leaderboards** — a new `@Scheduled` job posts a top-N embed on the 1st of each month per guild, showing credits earned *that month* plus counted voice time. Target channel configurable per guild via `/setconfig leaderboard_channel ...` (falls back to the system channel).
- **Vanity titles (credit sink)** — a new `/title` command (and matching Titles tab in the mod web UI) lets users spend credits on decorative titles. Each equipped title grants a **bot-managed Discord role** (color, optional hoist, no permissions) that users cannot grant themselves — providing visible, unforgeable status in every Discord surface.
- **Richer leaderboard rendering** — Discord `/socialcredit leaderboard` and the web leaderboard now show title prefix, lifetime voice time, voice this month, and credits this month.

## Implementation highlights

- New Flyway migration `V13__voice_activity_and_titles.sql` introduces `voice_session`, `voice_credit_daily`, `monthly_credit_snapshot`, `title`, `user_owned_title`, `guild_title_role`, and adds `user.active_title_id`. 10 seeded titles with color + optional hoist.
- New enum value `ConfigDto.Configurations.LEADERBOARD_CHANNEL` stores the per-guild channel using the existing key-value config pattern (no schema change to `config`).
- `VoiceEventHandler` gets session open/close on join/leave/move, plus defensive cleanup of stale open sessions if a leave was missed. An in-memory `VoiceCompanyTracker` accumulates per-user "company" seconds so AFK-with-bot-only time doesn't count.
- `VoiceSessionRecoveryHook` runs on startup to close any voice sessions left open by a crash/restart, capped at 8h to avoid runaway awards.
- `TitleRoleService` (in the `web` module, since `web` is a dep of `discord-bot`) creates title roles lazily per guild, reuses them via the `guild_title_role` map, and handles permission / hierarchy errors with helpful user-facing messages.
- `@EnableScheduling` added to `Application.kt`; `MonthlyLeaderboardJob` is `@Profile("prod")`-gated since it depends on the JDA bean.

## Test plan

- [ ] `bash gradlew build` succeeds for every module (sandbox here couldn't fetch a few specialized Maven repos — verify in CI)
- [ ] Migration applies cleanly; `SELECT * FROM title` shows 10 seeded rows
- [ ] Join a voice channel with another non-bot user, leave after a few minutes; `voice_session` has a closed row with `counted_seconds > 0` and `credits_awarded > 0`. Join solo, leave — `counted_seconds = 0`.
- [ ] Temporarily lower the daily cap, run a long session, confirm cap is enforced and `voice_credit_daily.credits` reflects the clamped total
- [ ] `/title shop`, `/title buy ⭐ Comrade`, `/title equip ⭐ Comrade` — confirm role is created, assigned, colored, hoisted where configured; confirm credits deducted
- [ ] `/title unequip` removes the role
- [ ] `/setconfig leaderboard_channel: #some-channel` writes the config; monthly job (temporarily run manually) posts into that channel, falls back to system channel if unset
- [ ] Web mod UI renders Titles tab with Buy/Equip/Unequip; Social Credit tab renders the new title + voice time columns
- [ ] Kill the bot mid-voice-session, restart, confirm `VoiceSessionRecoveryHook` closes the session with `left_at` populated and credits awarded (capped at 8h)

## Follow-up

- [ ] Build a dedicated public `/leaderboard/{guildId}` page with a podium for top 3 and a stats strip (separate PR per in-thread feedback).

https://claude.ai/code/session_01MFAPjT3y2xULvg8hULvYir

---
_Generated by [Claude Code](https://claude.ai/code/session_01MFAPjT3y2xULvg8hULvYir)_