### PR TITLE
fix(web): /leaderboards 404, harden moderation against schema drift

### DIFF
--- a/application/src/main/kotlin/database/configuration/FlywayGuardConfig.kt
+++ b/application/src/main/kotlin/database/configuration/FlywayGuardConfig.kt
@@ -1,6 +1,7 @@
 package database.configuration
 
 import common.logging.DiscordLogger
+import org.flywaydb.core.api.MigrationInfo
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.flyway.FlywayMigrationStrategy
 import org.springframework.context.annotation.Bean
@@ -12,6 +13,11 @@ import org.springframework.context.annotation.Configuration
  * its db.migration SQL resources. Without this guard Spring Boot would
  * happily start serving, silently skip every migration, and the first
  * request that touches a missing table returns 500.
+ *
+ * Also fails start-up when Flyway reports any migration as FAILED or still
+ * PENDING after `migrate()`. Without this, a partially-applied schema will
+ * let the bot come up but any feature that relies on the missing column or
+ * table will 500 on first use — exactly the symptom we saw post-#267.
  *
  * Can be disabled for specialised builds (ad-hoc test rigs, DB dumps) via the
  * `toby.flyway.require-migrations` property — default `true`.
@@ -29,6 +35,9 @@ class FlywayGuardConfig {
         ensureMigrationsAvailable(required, discovered)
         logger.info("Flyway: $discovered migration(s) on classpath (required=$required)")
         flyway.migrate()
+        if (required) {
+            ensureAllMigrationsApplied(flyway.info().all().toList())
+        }
     }
 
     companion object {
@@ -41,6 +50,30 @@ class FlywayGuardConfig {
                         "to override."
                 )
             }
+        }
+
+        internal fun ensureAllMigrationsApplied(all: List<MigrationInfo>) {
+            val failed = all.filter { it.state?.isFailed == true }
+            val pending = all.filter { it.state?.isApplied == false && it.state?.isFailed == false }
+            if (failed.isEmpty() && pending.isEmpty()) return
+
+            val details = buildString {
+                if (failed.isNotEmpty()) {
+                    append("FAILED: ")
+                    append(failed.joinToString(", ") { "${it.version}/${it.description}" })
+                    if (pending.isNotEmpty()) append("; ")
+                }
+                if (pending.isNotEmpty()) {
+                    append("PENDING: ")
+                    append(pending.joinToString(", ") { "${it.version}/${it.description}" })
+                }
+            }
+            throw IllegalStateException(
+                "Flyway migrations are not fully applied ($details). The schema is out of " +
+                    "sync with the deployed artifact — features that rely on the missing " +
+                    "columns or tables will return 500. Fix the broken migration state and " +
+                    "redeploy, or set toby.flyway.require-migrations=false to override."
+            )
         }
     }
 }

--- a/application/src/test/kotlin/FlywayGuardConfigTest.kt
+++ b/application/src/test/kotlin/FlywayGuardConfigTest.kt
@@ -1,6 +1,11 @@
 import database.configuration.FlywayGuardConfig
+import io.mockk.every
+import io.mockk.mockk
+import org.flywaydb.core.api.MigrationInfo
+import org.flywaydb.core.api.MigrationState
 import org.junit.jupiter.api.Assertions.assertDoesNotThrow
 import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 class FlywayGuardConfigTest {
@@ -24,5 +29,54 @@ class FlywayGuardConfigTest {
         assertDoesNotThrow {
             FlywayGuardConfig.ensureMigrationsAvailable(required = false, discovered = 0)
         }
+    }
+
+    @Test
+    fun `allows boot when every migration is applied`() {
+        assertDoesNotThrow {
+            FlywayGuardConfig.ensureAllMigrationsApplied(
+                listOf(applied("1", "base"), applied("2", "more"))
+            )
+        }
+    }
+
+    @Test
+    fun `throws with FAILED in message when a migration failed`() {
+        val ex = assertThrows(IllegalStateException::class.java) {
+            FlywayGuardConfig.ensureAllMigrationsApplied(
+                listOf(applied("1", "base"), failed("13", "voice_activity_and_titles"))
+            )
+        }
+        assertTrue(ex.message!!.contains("FAILED"))
+        assertTrue(ex.message!!.contains("13"))
+    }
+
+    @Test
+    fun `throws with PENDING in message when a migration is still pending`() {
+        val ex = assertThrows(IllegalStateException::class.java) {
+            FlywayGuardConfig.ensureAllMigrationsApplied(
+                listOf(applied("1", "base"), pending("13", "voice_activity_and_titles"))
+            )
+        }
+        assertTrue(ex.message!!.contains("PENDING"))
+        assertTrue(ex.message!!.contains("13"))
+    }
+
+    private fun applied(version: String, description: String): MigrationInfo = mockk(relaxed = true) {
+        every { this@mockk.version } returns org.flywaydb.core.api.MigrationVersion.fromVersion(version)
+        every { this@mockk.description } returns description
+        every { state } returns MigrationState.SUCCESS
+    }
+
+    private fun failed(version: String, description: String): MigrationInfo = mockk(relaxed = true) {
+        every { this@mockk.version } returns org.flywaydb.core.api.MigrationVersion.fromVersion(version)
+        every { this@mockk.description } returns description
+        every { state } returns MigrationState.FAILED
+    }
+
+    private fun pending(version: String, description: String): MigrationInfo = mockk(relaxed = true) {
+        every { this@mockk.version } returns org.flywaydb.core.api.MigrationVersion.fromVersion(version)
+        every { this@mockk.description } returns description
+        every { state } returns MigrationState.PENDING
     }
 }

--- a/web/src/main/kotlin/web/controller/LeaderboardController.kt
+++ b/web/src/main/kotlin/web/controller/LeaderboardController.kt
@@ -8,19 +8,17 @@ import org.springframework.stereotype.Controller
 import org.springframework.ui.Model
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.servlet.mvc.support.RedirectAttributes
 import web.service.LeaderboardWebService
 import web.util.discordIdOrNull
 import web.util.displayName
 
 @Controller
-@RequestMapping("/leaderboard")
 class LeaderboardController(
     private val leaderboardWebService: LeaderboardWebService
 ) {
 
-    @GetMapping("s")
+    @GetMapping("/leaderboards")
     fun guildList(
         @RegisteredOAuth2AuthorizedClient("discord") client: OAuth2AuthorizedClient,
         @AuthenticationPrincipal user: OAuth2User,
@@ -36,7 +34,7 @@ class LeaderboardController(
         return "leaderboards"
     }
 
-    @GetMapping("/{guildId}")
+    @GetMapping("/leaderboard/{guildId}")
     fun leaderboardPage(
         @PathVariable guildId: Long,
         @AuthenticationPrincipal user: OAuth2User,

--- a/web/src/main/kotlin/web/service/ModerationWebService.kt
+++ b/web/src/main/kotlin/web/service/ModerationWebService.kt
@@ -1,5 +1,6 @@
 package web.service
 
+import common.logging.DiscordLogger
 import database.dto.ConfigDto
 import database.dto.UserDto
 import database.service.ConfigService
@@ -33,7 +34,13 @@ class ModerationWebService(
             "1️⃣", "2️⃣", "3️⃣", "4️⃣", "5️⃣",
             "6️⃣", "7️⃣", "8️⃣", "9️⃣", "🔟"
         )
+        private val logger = DiscordLogger(ModerationWebService::class.java)
     }
+
+    private fun <T> safely(label: String, default: T, block: () -> T): T =
+        runCatching(block)
+            .onFailure { logger.warn("Leaderboard enrichment failed ($label): ${it::class.simpleName}: ${it.message}") }
+            .getOrDefault(default)
 
     fun getModeratableGuilds(accessToken: String, discordId: Long): List<GuildInfo> {
         return introWebService.getMutualGuilds(accessToken).filter { info ->
@@ -103,23 +110,31 @@ class ModerationWebService(
     fun getLeaderboard(guildId: Long): List<LeaderboardRow> {
         val guild = jda.getGuildById(guildId) ?: return emptyList()
         val users = userService.listGuildUsers(guildId).filterNotNull()
-        val lifetimeVoice = voiceSessionService.sumCountedSecondsLifetimeByUser(guildId)
 
         val thisMonthStart = LocalDate.now(ZoneOffset.UTC).withDayOfMonth(1)
         val prevMonthStart = thisMonthStart.minusMonths(1)
-        val thisMonthVoice = voiceSessionService.sumCountedSecondsInRangeByUser(
-            guildId,
-            prevMonthStart.atStartOfDay().toInstant(ZoneOffset.UTC),
-            thisMonthStart.atStartOfDay().toInstant(ZoneOffset.UTC)
-        )
-        val priorSnapshots = snapshotService.listForGuildDate(guildId, thisMonthStart)
-            .associateBy { it.discordId }
+
+        val lifetimeVoice = safely("lifetime voice", emptyMap<Long, Long>()) {
+            voiceSessionService.sumCountedSecondsLifetimeByUser(guildId)
+        }
+        val thisMonthVoice = safely("this-month voice", emptyMap<Long, Long>()) {
+            voiceSessionService.sumCountedSecondsInRangeByUser(
+                guildId,
+                prevMonthStart.atStartOfDay().toInstant(ZoneOffset.UTC),
+                thisMonthStart.atStartOfDay().toInstant(ZoneOffset.UTC)
+            )
+        }
+        val priorSnapshots = safely("prior snapshots", emptyList<database.dto.MonthlyCreditSnapshotDto>()) {
+            snapshotService.listForGuildDate(guildId, thisMonthStart)
+        }.associateBy { it.discordId }
 
         return users
             .sortedByDescending { it.socialCredit ?: 0L }
             .mapIndexed { index, dto ->
                 val member = guild.getMemberById(dto.discordId)
-                val title = dto.activeTitleId?.let { titleService.getById(it) }?.label
+                val title = safely("title for ${dto.discordId}", null as String?) {
+                    dto.activeTitleId?.let { titleService.getById(it) }?.label
+                }
                 val current = dto.socialCredit ?: 0L
                 val baseline = priorSnapshots[dto.discordId]?.socialCredit
                 val creditsDelta = if (baseline == null) 0L else current - baseline
@@ -138,7 +153,9 @@ class ModerationWebService(
     }
 
     fun getTitlesForGuild(guildId: Long, actorDiscordId: Long): TitleShopView {
-        val catalog = titleService.listAll().map { t ->
+        val catalog = safely("title catalog", emptyList<database.dto.TitleDto>()) {
+            titleService.listAll()
+        }.map { t ->
             TitleShopEntry(
                 id = t.id ?: 0,
                 label = t.label,
@@ -147,7 +164,9 @@ class ModerationWebService(
                 colorHex = t.colorHex
             )
         }
-        val ownedIds = titleService.listOwned(actorDiscordId).map { it.titleId }.toSet()
+        val ownedIds = safely("owned titles", emptyList<database.dto.UserOwnedTitleDto>()) {
+            titleService.listOwned(actorDiscordId)
+        }.map { it.titleId }.toSet()
         val actorDto = userService.getUserById(actorDiscordId, guildId)
         val equippedId = actorDto?.activeTitleId
         val balance = actorDto?.socialCredit ?: 0L
@@ -301,11 +320,17 @@ class ModerationWebService(
         val guildIdString = guild.id
         val newDto = ConfigDto(key.configValue, value, guildIdString)
         val existing = configService.getConfigByName(key.configValue, guildIdString)
-        if (existing != null && existing.guildId == guildIdString) {
+        val path = if (existing != null && existing.guildId == guildIdString) {
             configService.updateConfig(newDto)
+            "update"
         } else {
             configService.createNewConfig(newDto)
+            "create"
         }
+        logger.info(
+            "Config $path: guild=$guildIdString actor=$actorDiscordId key=${key.configValue} " +
+                "value=$value existing.guildId=${existing?.guildId}"
+        )
         return null
     }
 

--- a/web/src/main/kotlin/web/service/ModerationWebService.kt
+++ b/web/src/main/kotlin/web/service/ModerationWebService.kt
@@ -164,9 +164,9 @@ class ModerationWebService(
                 colorHex = t.colorHex
             )
         }
-        val ownedIds = safely("owned titles", emptyList<database.dto.UserOwnedTitleDto>()) {
+        val ownedIds: Set<Long> = safely("owned titles", emptyList<database.dto.UserOwnedTitleDto>()) {
             titleService.listOwned(actorDiscordId)
-        }.map { it.titleId }.toSet()
+        }.mapTo(HashSet()) { it.titleId }
         val actorDto = userService.getUserById(actorDiscordId, guildId)
         val equippedId = actorDto?.activeTitleId
         val balance = actorDto?.socialCredit ?: 0L

--- a/web/src/main/resources/static/js/moderation.js
+++ b/web/src/main/resources/static/js/moderation.js
@@ -102,14 +102,31 @@
         if (!btn || !input) return;
         btn.addEventListener('click', () => {
             const value = (input.value || '').toString();
+            console.debug('[config save]', { key: key, value: value });
             btn.disabled = true;
             postJson('/moderation/' + guildId + '/config', { key: key, value: value })
                 .then(r => {
                     btn.disabled = false;
-                    if (r && r.ok) toast('Config saved.', 'success');
-                    else toast(r?.error || 'Could not save config.', 'error');
+                    console.debug('[config save response]', { key: key, response: r });
+                    if (r && r.ok) {
+                        toast('Config saved.', 'success');
+                        // Reflect the saved value as the new default so a refresh
+                        // doesn't look like "nothing happened" even if the read path
+                        // is cached stale somewhere.
+                        if (input.tagName === 'SELECT') {
+                            Array.from(input.options).forEach(o => o.defaultSelected = (o.value === value));
+                        } else {
+                            input.defaultValue = value;
+                        }
+                    } else {
+                        toast(r?.error || 'Could not save config.', 'error');
+                    }
                 })
-                .catch(() => { btn.disabled = false; toast('Network error.', 'error'); });
+                .catch((err) => {
+                    btn.disabled = false;
+                    console.error('[config save error]', { key: key, err: err });
+                    toast('Network error.', 'error');
+                });
         });
     });
 

--- a/web/src/main/resources/templates/moderation.html
+++ b/web/src/main/resources/templates/moderation.html
@@ -112,10 +112,13 @@
 
     <!-- CONFIG TAB -->
     <section class="tab-panel" data-panel="config">
-        <p class="muted mb-4" th:if="${!isOwner}">
-            Only the server owner can change guild config. Values are read-only
-            for you.
-        </p>
+        <div class="alert alert-error" th:if="${!isOwner}" style="margin-bottom: 16px;">
+            <strong>Read-only.</strong> Only the server owner can change guild
+            config. You're a TobyBot superuser, which lets you moderate
+            members on the Users tab, but not edit server-wide settings. Ask
+            the server owner to change these, or take ownership of the server
+            first.
+        </div>
         <div class="config-grid">
             <div class="config-row" data-key="VOLUME">
                 <label>Default volume</label>

--- a/web/src/test/kotlin/web/service/ModerationWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/ModerationWebServiceTest.kt
@@ -448,6 +448,47 @@ class ModerationWebServiceTest {
         assertEquals(0L, rows.first().creditsEarnedThisMonth)
     }
 
+    @Test
+    fun `getLeaderboard tolerates missing voice tables by returning zeroed voice stats`() {
+        val user = UserDto(discordId = plainUserId, guildId = guildId).apply { socialCredit = 500L }
+        every { userService.listGuildUsers(guildId) } returns listOf(user)
+        mockMember(plainUserId)
+        every { voiceSessionService.sumCountedSecondsLifetimeByUser(guildId) } throws
+            RuntimeException("relation \"voice_session\" does not exist")
+        every { voiceSessionService.sumCountedSecondsInRangeByUser(guildId, any(), any()) } throws
+            RuntimeException("relation \"voice_session\" does not exist")
+        every { snapshotService.listForGuildDate(guildId, any()) } throws
+            RuntimeException("relation \"monthly_credit_snapshot\" does not exist")
+
+        val rows = service.getLeaderboard(guildId)
+
+        assertEquals(1, rows.size)
+        assertEquals(500L, rows[0].socialCredit)
+        assertEquals(0L, rows[0].voiceSecondsLifetime)
+        assertEquals(0L, rows[0].voiceSecondsThisMonth)
+        assertEquals(0L, rows[0].creditsEarnedThisMonth)
+    }
+
+    @Test
+    fun `getLeaderboard tolerates missing title rows without breaking the whole page`() {
+        val user = UserDto(discordId = plainUserId, guildId = guildId).apply {
+            socialCredit = 100L
+            activeTitleId = 42L
+        }
+        every { userService.listGuildUsers(guildId) } returns listOf(user)
+        mockMember(plainUserId)
+        every { voiceSessionService.sumCountedSecondsLifetimeByUser(guildId) } returns emptyMap()
+        every { voiceSessionService.sumCountedSecondsInRangeByUser(guildId, any(), any()) } returns emptyMap()
+        every { snapshotService.listForGuildDate(guildId, any()) } returns emptyList()
+        every { titleService.getById(42L) } throws
+            RuntimeException("relation \"title\" does not exist")
+
+        val rows = service.getLeaderboard(guildId)
+
+        assertEquals(1, rows.size)
+        assertNull(rows[0].title)
+    }
+
     // ---- getTitlesForGuild ----
 
     @Test


### PR DESCRIPTION
Three regressions introduced by #267. Ships together as one follow-up.

## Summary

1. **`/leaderboards` → 404.** `LeaderboardController` declared `@RequestMapping("/leaderboard")` + `@GetMapping("s")`, which Spring resolves as `/leaderboard/s`, not `/leaderboards`. Fix: drop the class-level mapping and use absolute paths on each method.
2. **Moderation 500 on schema drift.** When V13 tables are missing or the `active_title_id` column hasn't migrated on a server, `getLeaderboard` / `getTitlesForGuild` 500 the whole page. Wrap the new V13-dependent reads in a `safely` helper that logs once and returns a neutral default. Also tighten `FlywayGuardConfig` to fail startup when any migration is in FAILED or PENDING state (was previously only checking "zero migrations found").
3. **Config tab "does nothing".** Reporter is the owner so it's not a permissions issue. Adds client + server-side diagnostic logging on every config save so the real failure mode can be read from the browser console and server logs, and reflects the saved value as the input's `defaultValue` after success so a page refresh doesn't look like nothing changed. Also adds a prominent read-only banner for non-owners (the disabled buttons previously looked broken for superusers).

## Test plan

- [ ] `/leaderboards` renders the guild list (not 404). Deep-link `/leaderboard/{guildId}` works.
- [ ] Moderation page loads on a server where V13 tables are dropped (simulated) — shows zeroed voice stats instead of 500; a warning is logged for each safely-wrapped failure.
- [ ] Flyway guard — with a migration forced into FAILED state, the bot refuses to start with a message naming the offending version.
- [ ] Config save as owner — toast shows "Config saved.", browser console shows `[config save]` + `[config save response]` debug entries, server log shows "Config create/update: guild=... actor=... key=... value=...". After save, reload shows the persisted value.
- [ ] Config view as superuser (non-owner) — prominent red read-only banner, all inputs/buttons disabled.
- [ ] Existing web + database tests still green (verified locally).

## Tests added

- `ModerationWebServiceTest` — `getLeaderboard tolerates missing voice tables`, `getLeaderboard tolerates missing title rows`.
- `FlywayGuardConfigTest` — `allows boot when every migration is applied`, `throws with FAILED in message when a migration failed`, `throws with PENDING in message when a migration is still pending`.

## Open diagnostic

For Bug 3 (config "does nothing" as owner), the static analysis doesn't pinpoint a specific persistence bug — the flow should work. The client + server logging added here is designed to expose the real failure on the next save attempt. Once you have:

- the browser-console entries for `[config save]` / `[config save response]` / `[config save error]`, and
- the server log line matching `Config create:` or `Config update:`,

we'll know whether it's a client-never-fires, 403-CSRF, server-rejects, or silent-persist-failure. Happy to send a follow-up PR once we have that data.

https://claude.ai/code/session_01MFAPjT3y2xULvg8hULvYir

---
_Generated by [Claude Code](https://claude.ai/code/session_01MFAPjT3y2xULvg8hULvYir)_