### PR TITLE
feat(web): member-facing Titles, Profile, Utils pages; slim moderation panel

### DIFF
--- a/web/build.gradle
+++ b/web/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
+    implementation 'org.jsoup:jsoup:1.18.3'
     testImplementation project(path: ':common', configuration: 'testArtifacts')
     testImplementation project(path: ':core-api', configuration: 'testArtifacts')
     testImplementation project(path: ':database', configuration: 'testArtifacts')

--- a/web/src/main/kotlin/web/controller/ModerationController.kt
+++ b/web/src/main/kotlin/web/controller/ModerationController.kt
@@ -10,7 +10,6 @@ import org.springframework.security.oauth2.client.annotation.RegisteredOAuth2Aut
 import org.springframework.security.oauth2.core.user.OAuth2User
 import org.springframework.stereotype.Controller
 import org.springframework.ui.Model
-import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -19,7 +18,6 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseBody
 import org.springframework.web.servlet.mvc.support.RedirectAttributes
 import web.service.ModerationWebService
-import web.service.TitleShopView
 import web.util.discordIdOrNull
 import web.util.discordIdString
 import web.util.displayName
@@ -71,57 +69,12 @@ class ModerationController(
             ra.addFlashAttribute("error", "Bot is not in that server.")
             return "redirect:/moderation/guilds"
         }
-        val leaderboard = moderationWebService.getLeaderboard(guildId)
-        val titleShop = moderationWebService.getTitlesForGuild(guildId, discordId)
 
         model.addAttribute("overview", overview)
-        model.addAttribute("leaderboard", leaderboard)
-        model.addAttribute("titleShop", titleShop)
         model.addAttribute("isOwner", moderationWebService.isOwner(discordId, guildId))
         model.addAttribute("username", user.displayName())
         model.addAttribute("actorDiscordId", discordId.toString())
         return "moderation"
-    }
-
-    @PostMapping("/{guildId}/titles/{titleId}/buy")
-    @ResponseBody
-    fun buyTitle(
-        @PathVariable guildId: Long,
-        @PathVariable titleId: Long,
-        @AuthenticationPrincipal user: OAuth2User
-    ): ResponseEntity<ApiResult> {
-        val actor = user.discordIdOrNull()
-            ?: return ResponseEntity.status(401).body(ApiResult(false, "Not signed in."))
-        val error = moderationWebService.buyTitle(actor, guildId, titleId)
-        return if (error != null) ResponseEntity.badRequest().body(ApiResult(false, error))
-        else ResponseEntity.ok(ApiResult(true, null))
-    }
-
-    @PostMapping("/{guildId}/titles/{titleId}/equip")
-    @ResponseBody
-    fun equipTitle(
-        @PathVariable guildId: Long,
-        @PathVariable titleId: Long,
-        @AuthenticationPrincipal user: OAuth2User
-    ): ResponseEntity<ApiResult> {
-        val actor = user.discordIdOrNull()
-            ?: return ResponseEntity.status(401).body(ApiResult(false, "Not signed in."))
-        val error = moderationWebService.equipTitle(actor, guildId, titleId)
-        return if (error != null) ResponseEntity.badRequest().body(ApiResult(false, error))
-        else ResponseEntity.ok(ApiResult(true, null))
-    }
-
-    @DeleteMapping("/{guildId}/titles/equipped")
-    @ResponseBody
-    fun unequipTitle(
-        @PathVariable guildId: Long,
-        @AuthenticationPrincipal user: OAuth2User
-    ): ResponseEntity<ApiResult> {
-        val actor = user.discordIdOrNull()
-            ?: return ResponseEntity.status(401).body(ApiResult(false, "Not signed in."))
-        val error = moderationWebService.unequipTitle(actor, guildId)
-        return if (error != null) ResponseEntity.badRequest().body(ApiResult(false, error))
-        else ResponseEntity.ok(ApiResult(true, null))
     }
 
     @PostMapping("/{guildId}/user/{targetDiscordId}/permission", consumes = ["application/json"])

--- a/web/src/main/kotlin/web/controller/ProfileController.kt
+++ b/web/src/main/kotlin/web/controller/ProfileController.kt
@@ -1,0 +1,63 @@
+package web.controller
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient
+import org.springframework.security.oauth2.client.annotation.RegisteredOAuth2AuthorizedClient
+import org.springframework.security.oauth2.core.user.OAuth2User
+import org.springframework.stereotype.Controller
+import org.springframework.ui.Model
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.servlet.mvc.support.RedirectAttributes
+import web.service.ProfileWebService
+import web.util.discordIdOrNull
+import web.util.displayName
+
+@Controller
+@RequestMapping("/profile")
+class ProfileController(
+    private val profileWebService: ProfileWebService
+) {
+
+    @GetMapping("/guilds")
+    fun guildList(
+        @RegisteredOAuth2AuthorizedClient("discord") client: OAuth2AuthorizedClient,
+        @AuthenticationPrincipal user: OAuth2User,
+        model: Model
+    ): String {
+        val discordId = user.discordIdOrNull()
+        val guilds = if (discordId != null) {
+            profileWebService.getMemberGuilds(client.accessToken.tokenValue, discordId)
+        } else emptyList()
+
+        model.addAttribute("guilds", guilds)
+        model.addAttribute("username", user.displayName())
+        return "profile-guilds"
+    }
+
+    @GetMapping("/{guildId}")
+    fun profilePage(
+        @PathVariable guildId: Long,
+        @AuthenticationPrincipal user: OAuth2User,
+        model: Model,
+        ra: RedirectAttributes
+    ): String {
+        val discordId = user.discordIdOrNull()
+            ?: return "redirect:/profile/guilds"
+
+        if (!profileWebService.isMember(discordId, guildId)) {
+            ra.addFlashAttribute("error", "You are not a member of that server.")
+            return "redirect:/profile/guilds"
+        }
+
+        val profile = profileWebService.getProfile(discordId, guildId) ?: run {
+            ra.addFlashAttribute("error", "Bot is not in that server.")
+            return "redirect:/profile/guilds"
+        }
+
+        model.addAttribute("profile", profile)
+        model.addAttribute("username", user.displayName())
+        return "profile"
+    }
+}

--- a/web/src/main/kotlin/web/controller/TitlesController.kt
+++ b/web/src/main/kotlin/web/controller/TitlesController.kt
@@ -1,0 +1,114 @@
+package web.controller
+
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient
+import org.springframework.security.oauth2.client.annotation.RegisteredOAuth2AuthorizedClient
+import org.springframework.security.oauth2.core.user.OAuth2User
+import org.springframework.stereotype.Controller
+import org.springframework.ui.Model
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseBody
+import org.springframework.web.servlet.mvc.support.RedirectAttributes
+import web.service.TitlesWebService
+import web.util.discordIdOrNull
+import web.util.displayName
+
+@Controller
+@RequestMapping("/titles")
+class TitlesController(
+    private val titlesWebService: TitlesWebService
+) {
+
+    @GetMapping("/guilds")
+    fun guildList(
+        @RegisteredOAuth2AuthorizedClient("discord") client: OAuth2AuthorizedClient,
+        @AuthenticationPrincipal user: OAuth2User,
+        model: Model
+    ): String {
+        val discordId = user.discordIdOrNull()
+        val guilds = if (discordId != null) {
+            titlesWebService.getMemberGuilds(client.accessToken.tokenValue, discordId)
+        } else emptyList()
+
+        model.addAttribute("guilds", guilds)
+        model.addAttribute("username", user.displayName())
+        return "titles-guilds"
+    }
+
+    @GetMapping("/{guildId}")
+    fun titlesPage(
+        @PathVariable guildId: Long,
+        @AuthenticationPrincipal user: OAuth2User,
+        model: Model,
+        ra: RedirectAttributes
+    ): String {
+        val discordId = user.discordIdOrNull()
+            ?: return "redirect:/titles/guilds"
+
+        if (!titlesWebService.isMember(discordId, guildId)) {
+            ra.addFlashAttribute("error", "You are not a member of that server.")
+            return "redirect:/titles/guilds"
+        }
+
+        val titleShop = titlesWebService.getTitlesForGuild(guildId, discordId)
+        model.addAttribute("titleShop", titleShop)
+        model.addAttribute("guildId", guildId.toString())
+        model.addAttribute("username", user.displayName())
+        return "titles"
+    }
+
+    @PostMapping("/{guildId}/{titleId}/buy")
+    @ResponseBody
+    fun buy(
+        @PathVariable guildId: Long,
+        @PathVariable titleId: Long,
+        @AuthenticationPrincipal user: OAuth2User
+    ): ResponseEntity<ApiResult> {
+        val actor = user.discordIdOrNull()
+            ?: return ResponseEntity.status(401).body(ApiResult(false, "Not signed in."))
+        if (!titlesWebService.isMember(actor, guildId)) {
+            return ResponseEntity.status(403).body(ApiResult(false, "You are not a member of that server."))
+        }
+        val error = titlesWebService.buyTitle(actor, guildId, titleId)
+        return if (error != null) ResponseEntity.badRequest().body(ApiResult(false, error))
+        else ResponseEntity.ok(ApiResult(true, null))
+    }
+
+    @PostMapping("/{guildId}/{titleId}/equip")
+    @ResponseBody
+    fun equip(
+        @PathVariable guildId: Long,
+        @PathVariable titleId: Long,
+        @AuthenticationPrincipal user: OAuth2User
+    ): ResponseEntity<ApiResult> {
+        val actor = user.discordIdOrNull()
+            ?: return ResponseEntity.status(401).body(ApiResult(false, "Not signed in."))
+        if (!titlesWebService.isMember(actor, guildId)) {
+            return ResponseEntity.status(403).body(ApiResult(false, "You are not a member of that server."))
+        }
+        val error = titlesWebService.equipTitle(actor, guildId, titleId)
+        return if (error != null) ResponseEntity.badRequest().body(ApiResult(false, error))
+        else ResponseEntity.ok(ApiResult(true, null))
+    }
+
+    @DeleteMapping("/{guildId}/equipped")
+    @ResponseBody
+    fun unequip(
+        @PathVariable guildId: Long,
+        @AuthenticationPrincipal user: OAuth2User
+    ): ResponseEntity<ApiResult> {
+        val actor = user.discordIdOrNull()
+            ?: return ResponseEntity.status(401).body(ApiResult(false, "Not signed in."))
+        if (!titlesWebService.isMember(actor, guildId)) {
+            return ResponseEntity.status(403).body(ApiResult(false, "You are not a member of that server."))
+        }
+        val error = titlesWebService.unequipTitle(actor, guildId)
+        return if (error != null) ResponseEntity.badRequest().body(ApiResult(false, error))
+        else ResponseEntity.ok(ApiResult(true, null))
+    }
+}

--- a/web/src/main/kotlin/web/controller/UtilsController.kt
+++ b/web/src/main/kotlin/web/controller/UtilsController.kt
@@ -1,0 +1,70 @@
+package web.controller
+
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.security.oauth2.core.user.OAuth2User
+import org.springframework.stereotype.Controller
+import org.springframework.ui.Model
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.ResponseBody
+import web.service.MemeResult
+import web.service.UtilsWebService
+import web.util.displayName
+
+@Controller
+@RequestMapping("/utils")
+class UtilsController(
+    private val utilsWebService: UtilsWebService
+) {
+
+    @GetMapping
+    fun page(
+        @AuthenticationPrincipal user: OAuth2User?,
+        model: Model
+    ): String {
+        model.addAttribute("username", user.displayName())
+        return "utils"
+    }
+
+    @GetMapping("/api/meme", produces = ["application/json"])
+    @ResponseBody
+    fun meme(
+        @RequestParam("subreddit", defaultValue = "") subreddit: String,
+        @RequestParam("timePeriod", defaultValue = "day") timePeriod: String,
+        @RequestParam("limit", defaultValue = "10") limit: Int
+    ): ResponseEntity<MemeResponse> {
+        val result = utilsWebService.randomMeme(subreddit, timePeriod, limit)
+        return if (result.error != null || result.value == null) {
+            ResponseEntity.badRequest().body(MemeResponse(false, result.error, null))
+        } else {
+            ResponseEntity.ok(MemeResponse(true, null, result.value))
+        }
+    }
+
+    @GetMapping("/api/dbd-killer", produces = ["application/json"])
+    @ResponseBody
+    fun dbdKiller(): ResponseEntity<TextResponse> {
+        val result = utilsWebService.randomDbdKiller()
+        return if (result.error != null || result.value == null) {
+            ResponseEntity.badRequest().body(TextResponse(false, result.error, null))
+        } else {
+            ResponseEntity.ok(TextResponse(true, null, result.value))
+        }
+    }
+
+    @GetMapping("/api/kf2-map", produces = ["application/json"])
+    @ResponseBody
+    fun kf2Map(): ResponseEntity<TextResponse> {
+        val result = utilsWebService.randomKf2Map()
+        return if (result.error != null || result.value == null) {
+            ResponseEntity.badRequest().body(TextResponse(false, result.error, null))
+        } else {
+            ResponseEntity.ok(TextResponse(true, null, result.value))
+        }
+    }
+}
+
+data class MemeResponse(val ok: Boolean, val error: String?, val meme: MemeResult?)
+data class TextResponse(val ok: Boolean, val error: String?, val text: String?)

--- a/web/src/main/kotlin/web/service/ModerationWebService.kt
+++ b/web/src/main/kotlin/web/service/ModerationWebService.kt
@@ -25,8 +25,7 @@ class ModerationWebService(
     private val introWebService: IntroWebService,
     private val voiceSessionService: VoiceSessionService,
     private val titleService: TitleService,
-    private val snapshotService: MonthlyCreditSnapshotService,
-    private val titleRoleService: TitleRoleService
+    private val snapshotService: MonthlyCreditSnapshotService
 ) {
     companion object {
         const val MAX_POLL_OPTIONS = 10
@@ -78,7 +77,8 @@ class ModerationWebService(
                 musicPermission = dto?.musicPermission ?: true,
                 memePermission = dto?.memePermission ?: true,
                 digPermission = dto?.digPermission ?: true,
-                superUser = dto?.superUser ?: false
+                superUser = dto?.superUser ?: false,
+                socialCredit = dto?.socialCredit ?: 0L
             )
         }.sortedBy { it.name.lowercase() }
 
@@ -150,77 +150,6 @@ class ModerationWebService(
                     creditsEarnedThisMonth = creditsDelta
                 )
             }
-    }
-
-    fun getTitlesForGuild(guildId: Long, actorDiscordId: Long): TitleShopView {
-        val catalog = safely("title catalog", emptyList<database.dto.TitleDto>()) {
-            titleService.listAll()
-        }.map { t ->
-            TitleShopEntry(
-                id = t.id ?: 0,
-                label = t.label,
-                cost = t.cost,
-                description = t.description,
-                colorHex = t.colorHex
-            )
-        }
-        val ownedIds: Set<Long> = safely("owned titles", emptyList<database.dto.UserOwnedTitleDto>()) {
-            titleService.listOwned(actorDiscordId)
-        }.mapTo(HashSet()) { it.titleId }
-        val actorDto = userService.getUserById(actorDiscordId, guildId)
-        val equippedId = actorDto?.activeTitleId
-        val balance = actorDto?.socialCredit ?: 0L
-        return TitleShopView(
-            catalog = catalog,
-            ownedTitleIds = ownedIds,
-            equippedTitleId = equippedId,
-            balance = balance
-        )
-    }
-
-    fun buyTitle(actorDiscordId: Long, guildId: Long, titleId: Long): String? {
-        if (jda.getGuildById(guildId) == null) return "Bot is not in that server."
-        val title = titleService.getById(titleId) ?: return "Title not found."
-        val actor = userService.getUserById(actorDiscordId, guildId) ?: return "You don't have a profile in that server yet."
-        if (titleService.owns(actorDiscordId, titleId)) return "You already own this title."
-        val balance = actor.socialCredit ?: 0L
-        if (balance < title.cost) return "Not enough credits. You need ${title.cost}, you have $balance."
-        actor.socialCredit = balance - title.cost
-        userService.updateUser(actor)
-        titleService.recordPurchase(actorDiscordId, titleId)
-        return null
-    }
-
-    fun equipTitle(actorDiscordId: Long, guildId: Long, titleId: Long): String? {
-        val guild = jda.getGuildById(guildId) ?: return "Bot is not in that server."
-        val member = guild.getMemberById(actorDiscordId) ?: return "You are not a member of that server."
-        val actor = userService.getUserById(actorDiscordId, guildId) ?: return "No profile in that server."
-        val title = titleService.getById(titleId) ?: return "Title not found."
-        if (!titleService.owns(actorDiscordId, titleId)) return "You don't own this title."
-        val ownedIds = titleService.listOwned(actorDiscordId).map { it.titleId }.toSet()
-        return when (val r = titleRoleService.equip(guild, member, title, ownedIds)) {
-            is TitleRoleResult.Ok -> {
-                actor.activeTitleId = titleId
-                userService.updateUser(actor)
-                null
-            }
-            is TitleRoleResult.Error -> r.message
-        }
-    }
-
-    fun unequipTitle(actorDiscordId: Long, guildId: Long): String? {
-        val guild = jda.getGuildById(guildId) ?: return "Bot is not in that server."
-        val member = guild.getMemberById(actorDiscordId) ?: return "You are not a member of that server."
-        val actor = userService.getUserById(actorDiscordId, guildId) ?: return "No profile in that server."
-        val ownedIds = titleService.listOwned(actorDiscordId).map { it.titleId }.toSet()
-        return when (val r = titleRoleService.unequip(guild, member, ownedIds)) {
-            is TitleRoleResult.Ok -> {
-                actor.activeTitleId = null
-                userService.updateUser(actor)
-                null
-            }
-            is TitleRoleResult.Error -> r.message
-        }
     }
 
     fun togglePermission(
@@ -513,7 +442,8 @@ data class ModeratedMember(
     val musicPermission: Boolean,
     val memePermission: Boolean,
     val digPermission: Boolean,
-    val superUser: Boolean
+    val superUser: Boolean,
+    val socialCredit: Long
 )
 
 data class VoiceChannelInfo(
@@ -548,21 +478,6 @@ data class LeaderboardRow(
         return if (hours > 0) "${hours}h ${minutes}m" else "${minutes}m"
     }
 }
-
-data class TitleShopEntry(
-    val id: Long,
-    val label: String,
-    val cost: Long,
-    val description: String?,
-    val colorHex: String?
-)
-
-data class TitleShopView(
-    val catalog: List<TitleShopEntry>,
-    val ownedTitleIds: Set<Long>,
-    val equippedTitleId: Long?,
-    val balance: Long
-)
 
 data class MoveResult(
     val moved: List<String> = emptyList(),

--- a/web/src/main/kotlin/web/service/ProfileWebService.kt
+++ b/web/src/main/kotlin/web/service/ProfileWebService.kt
@@ -1,0 +1,112 @@
+package web.service
+
+import database.dto.UserDto
+import database.service.TitleService
+import database.service.UserService
+import net.dv8tion.jda.api.JDA
+import org.springframework.stereotype.Service
+
+@Service
+class ProfileWebService(
+    private val jda: JDA,
+    private val userService: UserService,
+    private val titleService: TitleService,
+    private val introWebService: IntroWebService
+) {
+
+    fun getMemberGuilds(accessToken: String, discordId: Long): List<ProfileGuildCard> {
+        return introWebService.getMutualGuilds(accessToken).mapNotNull { info ->
+            val guildId = info.id.toLongOrNull() ?: return@mapNotNull null
+            val guild = jda.getGuildById(guildId) ?: return@mapNotNull null
+            if (guild.getMemberById(discordId) == null) return@mapNotNull null
+            val user = userService.getUserById(discordId, guildId)
+            ProfileGuildCard(
+                id = info.id,
+                name = info.name,
+                iconUrl = info.iconUrl,
+                balance = user?.socialCredit ?: 0L
+            )
+        }.sortedBy { it.name.lowercase() }
+    }
+
+    fun isMember(discordId: Long, guildId: Long): Boolean {
+        val guild = jda.getGuildById(guildId) ?: return false
+        return guild.getMemberById(discordId) != null
+    }
+
+    fun getProfile(discordId: Long, guildId: Long): ProfileView? {
+        val guild = jda.getGuildById(guildId) ?: return null
+        val member = guild.getMemberById(discordId) ?: return null
+        val user = userService.getUserById(discordId, guildId)
+        val equippedTitle = user?.activeTitleId?.let { titleService.getById(it) }
+        val ownedTitles = titleService.listOwned(discordId)
+            .mapNotNull { owned -> titleService.getById(owned.titleId) }
+            .map {
+                ProfileTitleEntry(
+                    id = it.id ?: 0L,
+                    label = it.label,
+                    cost = it.cost,
+                    description = it.description,
+                    colorHex = it.colorHex,
+                    equipped = it.id == equippedTitle?.id
+                )
+            }
+            .sortedBy { it.label.lowercase() }
+
+        return ProfileView(
+            guildId = guild.id,
+            guildName = guild.name,
+            displayName = member.effectiveName,
+            avatarUrl = member.effectiveAvatarUrl,
+            isOwner = member.isOwner,
+            balance = user?.socialCredit ?: 0L,
+            equippedTitleLabel = equippedTitle?.label,
+            equippedTitleColorHex = equippedTitle?.colorHex,
+            ownedTitles = ownedTitles,
+            permissions = permissionsFor(user)
+        )
+    }
+
+    private fun permissionsFor(user: UserDto?): List<ProfilePermission> {
+        return listOf(
+            ProfilePermission("Music", user?.musicPermission ?: true),
+            ProfilePermission("Meme", user?.memePermission ?: true),
+            ProfilePermission("Dig", user?.digPermission ?: true),
+            ProfilePermission("Superuser", user?.superUser ?: false)
+        )
+    }
+}
+
+data class ProfileGuildCard(
+    val id: String,
+    val name: String,
+    val iconUrl: String?,
+    val balance: Long
+)
+
+data class ProfileView(
+    val guildId: String,
+    val guildName: String,
+    val displayName: String,
+    val avatarUrl: String?,
+    val isOwner: Boolean,
+    val balance: Long,
+    val equippedTitleLabel: String?,
+    val equippedTitleColorHex: String?,
+    val ownedTitles: List<ProfileTitleEntry>,
+    val permissions: List<ProfilePermission>
+)
+
+data class ProfileTitleEntry(
+    val id: Long,
+    val label: String,
+    val cost: Long,
+    val description: String?,
+    val colorHex: String?,
+    val equipped: Boolean
+)
+
+data class ProfilePermission(
+    val name: String,
+    val enabled: Boolean
+)

--- a/web/src/main/kotlin/web/service/TitlesWebService.kt
+++ b/web/src/main/kotlin/web/service/TitlesWebService.kt
@@ -1,0 +1,144 @@
+package web.service
+
+import common.logging.DiscordLogger
+import database.dto.TitleDto
+import database.dto.UserOwnedTitleDto
+import database.service.TitleService
+import database.service.UserService
+import net.dv8tion.jda.api.JDA
+import org.springframework.stereotype.Service
+
+@Service
+class TitlesWebService(
+    private val jda: JDA,
+    private val userService: UserService,
+    private val titleService: TitleService,
+    private val titleRoleService: TitleRoleService,
+    private val introWebService: IntroWebService
+) {
+    companion object {
+        private val logger = DiscordLogger(TitlesWebService::class.java)
+    }
+
+    private fun <T> safely(label: String, default: T, block: () -> T): T =
+        runCatching(block)
+            .onFailure { logger.warn("Title shop enrichment failed ($label): ${it::class.simpleName}: ${it.message}") }
+            .getOrDefault(default)
+
+    fun getMemberGuilds(accessToken: String, discordId: Long): List<TitlesGuildCard> {
+        return introWebService.getMutualGuilds(accessToken).mapNotNull { info ->
+            val guildId = info.id.toLongOrNull() ?: return@mapNotNull null
+            if (!isMember(discordId, guildId)) return@mapNotNull null
+            val user = userService.getUserById(discordId, guildId)
+            val equippedTitle = safely("equipped title for $discordId@$guildId", null as TitleDto?) {
+                user?.activeTitleId?.let { titleService.getById(it) }
+            }
+            TitlesGuildCard(
+                id = info.id,
+                name = info.name,
+                iconUrl = info.iconUrl,
+                balance = user?.socialCredit ?: 0L,
+                equippedTitle = equippedTitle?.label
+            )
+        }.sortedBy { it.name.lowercase() }
+    }
+
+    fun isMember(discordId: Long, guildId: Long): Boolean {
+        val guild = jda.getGuildById(guildId) ?: return false
+        return guild.getMemberById(discordId) != null
+    }
+
+    fun getTitlesForGuild(guildId: Long, actorDiscordId: Long): TitleShopView {
+        val catalog = safely("title catalog", emptyList<TitleDto>()) {
+            titleService.listAll()
+        }.map { t ->
+            TitleShopEntry(
+                id = t.id ?: 0,
+                label = t.label,
+                cost = t.cost,
+                description = t.description,
+                colorHex = t.colorHex
+            )
+        }
+        val ownedIds: Set<Long> = safely("owned titles", emptyList<UserOwnedTitleDto>()) {
+            titleService.listOwned(actorDiscordId)
+        }.mapTo(HashSet()) { it.titleId }
+        val actorDto = userService.getUserById(actorDiscordId, guildId)
+        val equippedId = actorDto?.activeTitleId
+        val balance = actorDto?.socialCredit ?: 0L
+        return TitleShopView(
+            catalog = catalog,
+            ownedTitleIds = ownedIds,
+            equippedTitleId = equippedId,
+            balance = balance
+        )
+    }
+
+    fun buyTitle(actorDiscordId: Long, guildId: Long, titleId: Long): String? {
+        if (jda.getGuildById(guildId) == null) return "Bot is not in that server."
+        val title = titleService.getById(titleId) ?: return "Title not found."
+        val actor = userService.getUserById(actorDiscordId, guildId) ?: return "You don't have a profile in that server yet."
+        if (titleService.owns(actorDiscordId, titleId)) return "You already own this title."
+        val balance = actor.socialCredit ?: 0L
+        if (balance < title.cost) return "Not enough credits. You need ${title.cost}, you have $balance."
+        actor.socialCredit = balance - title.cost
+        userService.updateUser(actor)
+        titleService.recordPurchase(actorDiscordId, titleId)
+        return null
+    }
+
+    fun equipTitle(actorDiscordId: Long, guildId: Long, titleId: Long): String? {
+        val guild = jda.getGuildById(guildId) ?: return "Bot is not in that server."
+        val member = guild.getMemberById(actorDiscordId) ?: return "You are not a member of that server."
+        val actor = userService.getUserById(actorDiscordId, guildId) ?: return "No profile in that server."
+        val title = titleService.getById(titleId) ?: return "Title not found."
+        if (!titleService.owns(actorDiscordId, titleId)) return "You don't own this title."
+        val ownedIds = titleService.listOwned(actorDiscordId).map { it.titleId }.toSet()
+        return when (val r = titleRoleService.equip(guild, member, title, ownedIds)) {
+            is TitleRoleResult.Ok -> {
+                actor.activeTitleId = titleId
+                userService.updateUser(actor)
+                null
+            }
+            is TitleRoleResult.Error -> r.message
+        }
+    }
+
+    fun unequipTitle(actorDiscordId: Long, guildId: Long): String? {
+        val guild = jda.getGuildById(guildId) ?: return "Bot is not in that server."
+        val member = guild.getMemberById(actorDiscordId) ?: return "You are not a member of that server."
+        val actor = userService.getUserById(actorDiscordId, guildId) ?: return "No profile in that server."
+        val ownedIds = titleService.listOwned(actorDiscordId).map { it.titleId }.toSet()
+        return when (val r = titleRoleService.unequip(guild, member, ownedIds)) {
+            is TitleRoleResult.Ok -> {
+                actor.activeTitleId = null
+                userService.updateUser(actor)
+                null
+            }
+            is TitleRoleResult.Error -> r.message
+        }
+    }
+}
+
+data class TitlesGuildCard(
+    val id: String,
+    val name: String,
+    val iconUrl: String?,
+    val balance: Long,
+    val equippedTitle: String?
+)
+
+data class TitleShopEntry(
+    val id: Long,
+    val label: String,
+    val cost: Long,
+    val description: String?,
+    val colorHex: String?
+)
+
+data class TitleShopView(
+    val catalog: List<TitleShopEntry>,
+    val ownedTitleIds: Set<Long>,
+    val equippedTitleId: Long?,
+    val balance: Long
+)

--- a/web/src/main/kotlin/web/service/UtilsWebService.kt
+++ b/web/src/main/kotlin/web/service/UtilsWebService.kt
@@ -1,0 +1,155 @@
+package web.service
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import common.helpers.Cache
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Element
+import org.springframework.stereotype.Service
+import java.io.IOException
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.time.Duration
+import kotlin.random.Random
+
+@Service
+class UtilsWebService(
+    private val cache: Cache
+) {
+    private val http: HttpClient = HttpClient.newBuilder()
+        .connectTimeout(Duration.ofSeconds(5))
+        .build()
+    private val jackson = ObjectMapper()
+
+    fun randomMeme(subreddit: String, timePeriod: String, limit: Int): UtilsResult<MemeResult> {
+        val sub = subreddit.trim()
+        if (sub.isEmpty()) return UtilsResult.error("Subreddit is required.")
+        if (sub.equals("sneakybackgroundfeet", ignoreCase = true)) {
+            return UtilsResult.error("Don't talk to me.")
+        }
+        val tp = validTimePeriod(timePeriod)
+        val capped = limit.coerceIn(1, 100)
+        val url = "https://old.reddit.com/r/$sub/top/.json?limit=$capped&t=$tp"
+
+        return try {
+            val response = http.send(
+                HttpRequest.newBuilder(URI.create(url))
+                    .header("User-Agent", "tobybot-web/1.0")
+                    .timeout(Duration.ofSeconds(10))
+                    .GET()
+                    .build(),
+                HttpResponse.BodyHandlers.ofString()
+            )
+            if (response.statusCode() != 200) {
+                return UtilsResult.error("Reddit returned ${response.statusCode()}.")
+            }
+            val root = jackson.readTree(response.body())
+            val children = root.path("data").path("children")
+            if (!children.isArray || children.isEmpty) {
+                return UtilsResult.error("No memes found in r/$sub.")
+            }
+            val candidates = children
+                .mapNotNull { it.path("data").takeIf { d -> d.isObject } }
+                .filter { it.path("over_18").asBoolean(false).not() }
+                .filter { it.path("is_video").asBoolean(false).not() }
+            if (candidates.isEmpty()) {
+                return UtilsResult.error("No SFW image posts found in r/$sub.")
+            }
+            val picked = candidates[Random.nextInt(candidates.size)]
+            UtilsResult.ok(
+                MemeResult(
+                    title = picked.path("title").asText(""),
+                    author = picked.path("author").asText(""),
+                    imageUrl = picked.path("url_overridden_by_dest").asText(picked.path("url").asText("")),
+                    permalink = "https://reddit.com" + picked.path("permalink").asText(""),
+                    subreddit = sub
+                )
+            )
+        } catch (e: IOException) {
+            UtilsResult.error("Could not reach Reddit: ${e.message}")
+        } catch (e: InterruptedException) {
+            Thread.currentThread().interrupt()
+            UtilsResult.error("Request interrupted.")
+        }
+    }
+
+    fun randomDbdKiller(): UtilsResult<String> {
+        return try {
+            val killers = fetchWiki(
+                cacheKey = "dbdKillers",
+                url = "https://deadbydaylight.fandom.com/wiki/Killers",
+                className = "mw-content-ltr"
+            ) { root -> parseDbdKillers(root) }
+            if (killers.isEmpty()) UtilsResult.error("No killers parsed.")
+            else UtilsResult.ok(killers[Random.nextInt(killers.size)])
+        } catch (e: IOException) {
+            UtilsResult.error("Could not reach the wiki: ${e.message}")
+        }
+    }
+
+    fun randomKf2Map(): UtilsResult<String> {
+        return try {
+            val maps = fetchWiki(
+                cacheKey = "kf2Maps",
+                url = "https://wiki.killingfloor2.com/index.php?title=Maps_(Killing_Floor_2)",
+                className = "mw-parser-output"
+            ) { root -> root.select("b").eachText() }
+            if (maps.isEmpty()) UtilsResult.error("No maps parsed.")
+            else UtilsResult.ok(maps[Random.nextInt(maps.size)])
+        } catch (e: IOException) {
+            UtilsResult.error("Could not reach the wiki: ${e.message}")
+        }
+    }
+
+    private fun fetchWiki(
+        cacheKey: String,
+        url: String,
+        className: String,
+        parse: (Element) -> List<String>
+    ): List<String> {
+        cache.get(cacheKey)?.let { return it }
+        val doc = Jsoup.connect(url).get()
+        val root = doc.getElementsByClass(className).first()
+            ?: throw IOException("Element with class '$className' not found")
+        val values = parse(root).filter { it.isNotBlank() }
+        cache.put(cacheKey, values)
+        return values
+    }
+
+    private fun parseDbdKillers(root: Element): List<String> {
+        val outerDivs = root.select("div")
+        val container = outerDivs.getOrNull(3) ?: return emptyList()
+        return container.select("> div").mapNotNull { div ->
+            val realName = div.selectFirst("a")?.text()?.trim()
+            val alias = div.ownText().trim()
+            when {
+                !realName.isNullOrBlank() && alias.isNotBlank() -> "$realName — $alias"
+                !realName.isNullOrBlank() -> realName
+                alias.isNotBlank() -> alias
+                else -> null
+            }
+        }
+    }
+
+    private fun validTimePeriod(tp: String): String =
+        when (tp.lowercase()) {
+            "day", "week", "month", "all" -> tp.lowercase()
+            else -> "day"
+        }
+}
+
+data class UtilsResult<T>(val value: T?, val error: String?) {
+    companion object {
+        fun <T> ok(value: T) = UtilsResult(value, null)
+        fun <T> error(message: String) = UtilsResult<T>(null, message)
+    }
+}
+
+data class MemeResult(
+    val title: String,
+    val author: String,
+    val imageUrl: String,
+    val permalink: String,
+    val subreddit: String
+)

--- a/web/src/main/resources/static/css/profile.css
+++ b/web/src/main/resources/static/css/profile.css
@@ -1,0 +1,108 @@
+.profile-header {
+    margin-bottom: var(--space-5);
+}
+.profile-header h1 { margin-bottom: var(--space-2); }
+.back-link {
+    display: inline-block;
+    margin-bottom: var(--space-2);
+    font-size: 0.85rem;
+    color: var(--text-muted);
+}
+
+.profile-grid {
+    display: grid;
+    gap: var(--space-4);
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.profile-card {
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    padding: var(--space-4);
+}
+.profile-card h2 {
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--text-muted);
+    margin-bottom: var(--space-3);
+}
+.profile-card-wide { grid-column: 1 / -1; }
+
+.profile-identity {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+}
+.profile-avatar {
+    width: 64px;
+    height: 64px;
+    border-radius: 50%;
+    object-fit: cover;
+    background: var(--border);
+}
+.profile-name {
+    font-size: 1.1rem;
+    font-weight: 600;
+}
+
+.profile-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 8px 0;
+    border-bottom: 1px solid var(--border);
+}
+.profile-row:last-of-type { border-bottom: 0; }
+.profile-action {
+    margin-top: var(--space-3);
+    display: inline-block;
+}
+
+.profile-perms,
+.profile-titles {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    gap: 10px;
+}
+.profile-perms li,
+.profile-titles li {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex-wrap: wrap;
+}
+.profile-perms li { justify-content: space-between; }
+
+.title-pill {
+    display: inline-block;
+    padding: 2px 10px;
+    border-radius: 999px;
+    background: var(--bg);
+    border: 1px solid var(--border-strong);
+    font-size: 0.85rem;
+    font-weight: 600;
+}
+
+.badge {
+    font-size: 0.7rem;
+    padding: 2px 8px;
+    border-radius: 999px;
+    font-weight: 600;
+    text-transform: uppercase;
+}
+.badge.on {
+    background: var(--accent-soft);
+    color: var(--accent);
+}
+.badge.off {
+    background: var(--border);
+    color: var(--text-muted);
+}
+.badge.owner {
+    background: var(--accent-soft);
+    color: var(--accent);
+}

--- a/web/src/main/resources/static/css/utils.css
+++ b/web/src/main/resources/static/css/utils.css
@@ -1,0 +1,80 @@
+.utils-grid {
+    display: grid;
+    gap: var(--space-4);
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+}
+
+.util-card {
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    padding: var(--space-4);
+}
+
+.util-card h2 {
+    font-size: 1rem;
+    margin-bottom: 4px;
+}
+
+.util-card p.muted {
+    font-size: 0.85rem;
+    margin-bottom: var(--space-3);
+}
+
+.util-form {
+    display: grid;
+    gap: 10px;
+    margin-bottom: var(--space-3);
+}
+
+.util-form label {
+    display: grid;
+    gap: 4px;
+    font-size: 0.85rem;
+    color: var(--text-muted);
+}
+
+.util-form input,
+.util-form select {
+    padding: 6px 10px;
+    background: var(--bg);
+    color: var(--text);
+    border: 1px solid var(--border-strong);
+    border-radius: var(--radius-sm);
+    font: inherit;
+}
+
+.util-form button {
+    justify-self: start;
+}
+
+.util-output {
+    margin: 0;
+    padding: 10px 12px;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    color: var(--text);
+    font-family: inherit;
+    font-size: 0.9rem;
+    white-space: pre-wrap;
+    min-height: 20px;
+}
+
+.meme-output {
+    display: grid;
+    gap: 6px;
+}
+
+.meme-title a {
+    font-weight: 600;
+    color: var(--accent);
+}
+
+.meme-image {
+    max-width: 100%;
+    max-height: 360px;
+    object-fit: contain;
+    border-radius: var(--radius-sm);
+    background: var(--border);
+}

--- a/web/src/main/resources/static/js/moderation.js
+++ b/web/src/main/resources/static/js/moderation.js
@@ -9,10 +9,6 @@
     const actorId = main.dataset.actorId;
 
     const postJson = window.TobyApi.postJson;
-    const deleteJson = (window.TobyApi && window.TobyApi.deleteJson) || function (url) {
-        return fetch(url, { method: 'DELETE', headers: { 'Accept': 'application/json' } })
-            .then(r => r.json().catch(() => ({ ok: r.ok })));
-    };
 
     function toast(msg, type) {
         if (window.TobyToast && typeof window.TobyToast.show === 'function') {
@@ -130,7 +126,7 @@
         });
     });
 
-    // --- Social credit tab ---
+    // --- Users tab: social credit adjust ---
     document.querySelectorAll('.sc-apply').forEach(btn => {
         btn.addEventListener('click', () => {
             const row = btn.closest('tr');
@@ -212,62 +208,6 @@
             }).catch(() => { submitBtn.disabled = false; toast('Network error.', 'error'); });
         });
     }
-
-    // --- Titles tab ---
-    document.querySelectorAll('.title-buy').forEach(btn => {
-        btn.addEventListener('click', () => {
-            const row = btn.closest('tr');
-            const titleId = row.dataset.titleId;
-            btn.disabled = true;
-            postJson('/moderation/' + guildId + '/titles/' + titleId + '/buy', {})
-                .then(r => {
-                    btn.disabled = false;
-                    if (r && r.ok) {
-                        toast('Title purchased. Reload to equip.', 'success');
-                        setTimeout(() => window.location.reload(), 600);
-                    } else {
-                        toast(r?.error || 'Could not buy.', 'error');
-                    }
-                })
-                .catch(() => { btn.disabled = false; toast('Network error.', 'error'); });
-        });
-    });
-
-    document.querySelectorAll('.title-equip').forEach(btn => {
-        btn.addEventListener('click', () => {
-            const row = btn.closest('tr');
-            const titleId = row.dataset.titleId;
-            btn.disabled = true;
-            postJson('/moderation/' + guildId + '/titles/' + titleId + '/equip', {})
-                .then(r => {
-                    btn.disabled = false;
-                    if (r && r.ok) {
-                        toast('Title equipped.', 'success');
-                        setTimeout(() => window.location.reload(), 600);
-                    } else {
-                        toast(r?.error || 'Could not equip.', 'error');
-                    }
-                })
-                .catch(() => { btn.disabled = false; toast('Network error.', 'error'); });
-        });
-    });
-
-    document.querySelectorAll('.title-unequip').forEach(btn => {
-        btn.addEventListener('click', () => {
-            btn.disabled = true;
-            deleteJson('/moderation/' + guildId + '/titles/equipped')
-                .then(r => {
-                    btn.disabled = false;
-                    if (r && r.ok) {
-                        toast('Title unequipped.', 'success');
-                        setTimeout(() => window.location.reload(), 600);
-                    } else {
-                        toast(r?.error || 'Could not unequip.', 'error');
-                    }
-                })
-                .catch(() => { btn.disabled = false; toast('Network error.', 'error'); });
-        });
-    });
 
     // --- Poll tab ---
     const pollForm = document.querySelector('.poll-form');

--- a/web/src/main/resources/static/js/titles.js
+++ b/web/src/main/resources/static/js/titles.js
@@ -1,0 +1,77 @@
+(function () {
+    'use strict';
+
+    const main = document.querySelector('main[data-guild-id]');
+    if (!main) return;
+
+    const guildId = main.dataset.guildId;
+
+    const postJson = window.TobyApi.postJson;
+    const deleteJson = (window.TobyApi && window.TobyApi.deleteJson) || function (url) {
+        return fetch(url, { method: 'DELETE', headers: { 'Accept': 'application/json' } })
+            .then(r => r.json().catch(() => ({ ok: r.ok })));
+    };
+
+    function toast(msg, type) {
+        if (window.TobyToast && typeof window.TobyToast.show === 'function') {
+            window.TobyToast.show(msg, { type: type || 'info' });
+        } else {
+            console.log('[' + (type || 'info') + '] ' + msg);
+        }
+    }
+
+    document.querySelectorAll('.title-buy').forEach(btn => {
+        btn.addEventListener('click', () => {
+            const row = btn.closest('tr');
+            const titleId = row.dataset.titleId;
+            btn.disabled = true;
+            postJson('/titles/' + guildId + '/' + titleId + '/buy', {})
+                .then(r => {
+                    btn.disabled = false;
+                    if (r && r.ok) {
+                        toast('Title purchased. Reload to equip.', 'success');
+                        setTimeout(() => window.location.reload(), 600);
+                    } else {
+                        toast(r?.error || 'Could not buy.', 'error');
+                    }
+                })
+                .catch(() => { btn.disabled = false; toast('Network error.', 'error'); });
+        });
+    });
+
+    document.querySelectorAll('.title-equip').forEach(btn => {
+        btn.addEventListener('click', () => {
+            const row = btn.closest('tr');
+            const titleId = row.dataset.titleId;
+            btn.disabled = true;
+            postJson('/titles/' + guildId + '/' + titleId + '/equip', {})
+                .then(r => {
+                    btn.disabled = false;
+                    if (r && r.ok) {
+                        toast('Title equipped.', 'success');
+                        setTimeout(() => window.location.reload(), 600);
+                    } else {
+                        toast(r?.error || 'Could not equip.', 'error');
+                    }
+                })
+                .catch(() => { btn.disabled = false; toast('Network error.', 'error'); });
+        });
+    });
+
+    document.querySelectorAll('.title-unequip').forEach(btn => {
+        btn.addEventListener('click', () => {
+            btn.disabled = true;
+            deleteJson('/titles/' + guildId + '/equipped')
+                .then(r => {
+                    btn.disabled = false;
+                    if (r && r.ok) {
+                        toast('Title unequipped.', 'success');
+                        setTimeout(() => window.location.reload(), 600);
+                    } else {
+                        toast(r?.error || 'Could not unequip.', 'error');
+                    }
+                })
+                .catch(() => { btn.disabled = false; toast('Network error.', 'error'); });
+        });
+    });
+})();

--- a/web/src/main/resources/static/js/utils.js
+++ b/web/src/main/resources/static/js/utils.js
@@ -1,0 +1,198 @@
+(function () {
+    'use strict';
+
+    function toast(msg, type) {
+        if (window.TobyToast && typeof window.TobyToast.show === 'function') {
+            window.TobyToast.show(msg, { type: type || 'info' });
+        } else {
+            console.log('[' + (type || 'info') + '] ' + msg);
+        }
+    }
+
+    function output(name) {
+        return document.querySelector('[data-output="' + name + '"]');
+    }
+
+    function fetchJson(url) {
+        return fetch(url, { credentials: 'same-origin', headers: { 'Accept': 'application/json' } })
+            .then(function (r) {
+                return r.json().catch(function () {
+                    return { ok: r.ok, error: r.ok ? null : 'Request failed.' };
+                });
+            });
+    }
+
+    function randInt(maxInclusive) {
+        return 1 + Math.floor(Math.random() * maxInclusive);
+    }
+
+    // --- Dice roller ---
+    const diceForm = document.querySelector('[data-form="dice"]');
+    if (diceForm) {
+        diceForm.addEventListener('submit', e => {
+            e.preventDefault();
+            const count = parseInt(diceForm.elements.count.value, 10);
+            const sides = parseInt(diceForm.elements.sides.value, 10);
+            const modifier = parseInt(diceForm.elements.modifier.value, 10) || 0;
+            if (!Number.isFinite(count) || count < 1 || count > 100) {
+                toast('Count must be between 1 and 100.', 'error');
+                return;
+            }
+            if (!Number.isFinite(sides) || sides < 2 || sides > 1000) {
+                toast('Sides must be between 2 and 1000.', 'error');
+                return;
+            }
+            const rolls = [];
+            let total = 0;
+            for (let i = 0; i < count; i++) {
+                const r = randInt(sides);
+                rolls.push(r);
+                total += r;
+            }
+            const grand = total + modifier;
+            const label = count + 'd' + sides + (modifier ? (modifier > 0 ? ' + ' + modifier : ' - ' + Math.abs(modifier)) : '');
+            output('dice').textContent =
+                label + '\nRolls: [' + rolls.join(', ') + ']\nSum: ' + total +
+                (modifier ? '\nWith modifier: ' + grand : '');
+        });
+    }
+
+    // --- Random chooser ---
+    const randomForm = document.querySelector('[data-form="random"]');
+    if (randomForm) {
+        randomForm.addEventListener('submit', e => {
+            e.preventDefault();
+            const raw = randomForm.elements.list.value || '';
+            const items = raw.split(',').map(s => s.trim()).filter(s => s.length > 0);
+            if (items.length === 0) {
+                toast('Provide at least one option.', 'error');
+                return;
+            }
+            const pick = items[Math.floor(Math.random() * items.length)];
+            output('random').textContent = '> ' + pick;
+        });
+    }
+
+    // --- Magic 8-ball ---
+    const EIGHTBALL_RESPONSES = [
+        'It is certain',
+        'It is decidedly so',
+        'Without a doubt',
+        'Yes - definitely',
+        'You may rely on it',
+        'As I see it, yes',
+        'Most likely',
+        'Outlook good',
+        'Signs point to yes',
+        'Yes',
+        'Reply hazy, try again',
+        'Ask again later',
+        'Better not tell you now',
+        'Cannot predict now',
+        'Concentrate and ask again',
+        "Don't count on it",
+        'My reply is no',
+        'My sources say no',
+        'Outlook not so good',
+        'Very doubtful'
+    ];
+
+    const eightballBtn = document.querySelector('[data-action="eightball"]');
+    if (eightballBtn) {
+        eightballBtn.addEventListener('click', () => {
+            const choice = EIGHTBALL_RESPONSES[Math.floor(Math.random() * EIGHTBALL_RESPONSES.length)];
+            output('eightball').textContent = 'MAGIC 8-BALL SAYS: ' + choice + '.';
+        });
+    }
+
+    // --- Meme fetcher ---
+    const memeForm = document.querySelector('[data-form="meme"]');
+    if (memeForm) {
+        memeForm.addEventListener('submit', e => {
+            e.preventDefault();
+            const subreddit = memeForm.elements.subreddit.value.trim();
+            const timePeriod = memeForm.elements.timePeriod.value;
+            const limit = parseInt(memeForm.elements.limit.value, 10) || 10;
+            if (!subreddit) {
+                toast('Subreddit is required.', 'error');
+                return;
+            }
+            const submit = memeForm.querySelector('button[type="submit"]');
+            submit.disabled = true;
+            const params = new URLSearchParams({
+                subreddit: subreddit,
+                timePeriod: timePeriod,
+                limit: String(limit)
+            });
+            fetchJson('/utils/api/meme?' + params.toString())
+                .then(r => {
+                    submit.disabled = false;
+                    const slot = output('meme');
+                    if (r && r.ok && r.meme) {
+                        slot.innerHTML = '';
+                        const title = document.createElement('div');
+                        title.className = 'meme-title';
+                        const link = document.createElement('a');
+                        link.href = r.meme.permalink;
+                        link.target = '_blank';
+                        link.rel = 'noopener';
+                        link.textContent = r.meme.title;
+                        title.appendChild(link);
+                        const author = document.createElement('div');
+                        author.className = 'muted';
+                        author.textContent = 'by u/' + r.meme.author + ' in r/' + r.meme.subreddit;
+                        const img = document.createElement('img');
+                        img.src = r.meme.imageUrl;
+                        img.alt = r.meme.title;
+                        img.className = 'meme-image';
+                        img.loading = 'lazy';
+                        slot.appendChild(title);
+                        slot.appendChild(author);
+                        slot.appendChild(img);
+                    } else {
+                        slot.textContent = r?.error || 'Could not fetch meme.';
+                        toast(r?.error || 'Could not fetch meme.', 'error');
+                    }
+                })
+                .catch(() => { submit.disabled = false; toast('Network error.', 'error'); });
+        });
+    }
+
+    // --- DBD killer ---
+    const dbdBtn = document.querySelector('[data-action="dbd"]');
+    if (dbdBtn) {
+        dbdBtn.addEventListener('click', () => {
+            dbdBtn.disabled = true;
+            fetchJson('/utils/api/dbd-killer')
+                .then(r => {
+                    dbdBtn.disabled = false;
+                    if (r && r.ok && r.text) {
+                        output('dbd').textContent = r.text;
+                    } else {
+                        output('dbd').textContent = r?.error || 'Could not fetch killer.';
+                        toast(r?.error || 'Could not fetch killer.', 'error');
+                    }
+                })
+                .catch(() => { dbdBtn.disabled = false; toast('Network error.', 'error'); });
+        });
+    }
+
+    // --- KF2 map ---
+    const kf2Btn = document.querySelector('[data-action="kf2"]');
+    if (kf2Btn) {
+        kf2Btn.addEventListener('click', () => {
+            kf2Btn.disabled = true;
+            fetchJson('/utils/api/kf2-map')
+                .then(r => {
+                    kf2Btn.disabled = false;
+                    if (r && r.ok && r.text) {
+                        output('kf2').textContent = r.text;
+                    } else {
+                        output('kf2').textContent = r?.error || 'Could not fetch map.';
+                        toast(r?.error || 'Could not fetch map.', 'error');
+                    }
+                })
+                .catch(() => { kf2Btn.disabled = false; toast('Network error.', 'error'); });
+        });
+    }
+})();

--- a/web/src/main/resources/templates/fragments/navbar.html
+++ b/web/src/main/resources/templates/fragments/navbar.html
@@ -7,6 +7,9 @@
         <a href="/commands/wiki">Commands</a>
         <a href="/intro/guilds">Intro Songs</a>
         <a href="/dnd/campaign">Campaigns</a>
+        <a href="/titles/guilds">Titles</a>
+        <a href="/profile/guilds">Profile</a>
+        <a href="/utils">Utils</a>
         <a href="/leaderboards">Leaderboards</a>
         <a href="/moderation/guilds">Moderation</a>
         <span th:if="${username != null}" style="display:flex;align-items:center;gap:12px;">

--- a/web/src/main/resources/templates/moderation.html
+++ b/web/src/main/resources/templates/moderation.html
@@ -24,8 +24,6 @@
     <div class="tabs" role="tablist">
         <button class="tab-btn active" data-tab="users" role="tab" aria-selected="true">Users</button>
         <button class="tab-btn" data-tab="config" role="tab" aria-selected="false">Config</button>
-        <button class="tab-btn" data-tab="social" role="tab" aria-selected="false">Social Credit</button>
-        <button class="tab-btn" data-tab="titles" role="tab" aria-selected="false">Titles</button>
         <button class="tab-btn" data-tab="voice" role="tab" aria-selected="false">Voice</button>
         <button class="tab-btn" data-tab="poll" role="tab" aria-selected="false">Poll</button>
     </div>
@@ -34,7 +32,9 @@
     <section class="tab-panel active" data-panel="users">
         <p class="muted mb-4">
             Toggle TobyBot permissions for members of this server. Server owners
-            can also toggle SUPERUSER and kick members.
+            can also toggle SUPERUSER, adjust social credit, and kick members.
+            View the full credit standings on the
+            <a th:href="@{/leaderboard/{id}(id=${overview.guildId})}">leaderboard page</a>.
         </p>
         <div class="mod-table-wrap">
             <table class="mod-table">
@@ -45,6 +45,7 @@
                     <th>Meme</th>
                     <th>Dig</th>
                     <th>Superuser</th>
+                    <th>Credit</th>
                     <th>Actions</th>
                 </tr>
                 </thead>
@@ -98,6 +99,14 @@
                                 th:title="'Superuser: ' + (${m.superUser} ? 'On' : 'Off')"
                                 th:aria-label="'Toggle Superuser permission for ' + ${m.name}"
                                 th:text="${m.superUser} ? 'On' : 'Off'">Off</button>
+                    </td>
+                    <td data-label="Credit">
+                        <div class="sc-adjust" th:if="${isOwner}">
+                            <span class="sc-score" th:text="${m.socialCredit}">0</span>
+                            <input type="number" value="0" step="1" aria-label="Delta">
+                            <button type="button" class="btn sc-apply">Apply</button>
+                        </div>
+                        <span th:unless="${isOwner}" class="sc-score" th:text="${m.socialCredit}">0</span>
                     </td>
                     <td data-label="Actions">
                         <button type="button" class="btn-danger kick-btn"
@@ -163,118 +172,6 @@
                 </select>
                 <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
             </div>
-        </div>
-    </section>
-
-    <!-- SOCIAL CREDIT TAB -->
-    <section class="tab-panel" data-panel="social">
-        <p class="muted mb-4" th:if="${!isOwner}">
-            Only the server owner can adjust social credit.
-        </p>
-        <p class="muted mb-4">
-            Score is the lifetime total. "This month" shows credits earned and
-            counted voice time since the 1st. Monthly leaderboard is posted on the
-            1st of each month.
-            <a th:href="@{/leaderboard/{id}(id=${overview.guildId})}" style="margin-left:8px;">View full leaderboard &rarr;</a>
-        </p>
-        <div class="mod-table-wrap">
-            <table class="mod-table">
-                <thead>
-                <tr>
-                    <th>#</th>
-                    <th>Member</th>
-                    <th>Title</th>
-                    <th>Score</th>
-                    <th>Credits this month</th>
-                    <th>Voice (lifetime)</th>
-                    <th>Voice this month</th>
-                    <th th:if="${isOwner}">Adjust</th>
-                </tr>
-                </thead>
-                <tbody>
-                <tr th:each="row : ${leaderboard}" th:attr="data-member-id=${row.discordId}">
-                    <td th:text="${row.rank}">1</td>
-                    <td>
-                        <div class="member-cell">
-                            <img th:if="${row.avatarUrl != null}"
-                                 th:src="${row.avatarUrl}"
-                                 class="avatar"
-                                 alt="">
-                            <span th:text="${row.name}">Name</span>
-                        </div>
-                    </td>
-                    <td class="sc-title" th:text="${row.title != null ? row.title : '—'}">—</td>
-                    <td class="sc-score" th:text="${row.socialCredit}">0</td>
-                    <td th:text="${row.creditsEarnedThisMonth}">0</td>
-                    <td th:text="${row.voiceLifetimeDisplay}">0m</td>
-                    <td th:text="${row.voiceThisMonthDisplay}">0m</td>
-                    <td th:if="${isOwner}">
-                        <div class="sc-adjust">
-                            <input type="number" value="0" step="1" aria-label="Delta">
-                            <button type="button" class="btn sc-apply">Apply</button>
-                        </div>
-                    </td>
-                </tr>
-                <tr th:if="${#lists.isEmpty(leaderboard)}">
-                    <td colspan="8" class="muted" style="text-align:center;">No users tracked yet.</td>
-                </tr>
-                </tbody>
-            </table>
-        </div>
-    </section>
-
-    <!-- TITLES TAB -->
-    <section class="tab-panel" data-panel="titles">
-        <p class="muted mb-4">
-            Spend your social credit on vanity titles. Each purchased title also
-            grants you a matching Discord role on this server when equipped —
-            visible everywhere you appear in chat, member list and voice.
-            The bot needs the <strong>Manage Roles</strong> permission, and its
-            role must sit above the title roles in the hierarchy.
-        </p>
-        <p class="muted mb-4">
-            Your balance: <strong th:text="${titleShop.balance} + ' credits'">0 credits</strong>
-        </p>
-        <div class="mod-table-wrap">
-            <table class="mod-table">
-                <thead>
-                <tr>
-                    <th>Title</th>
-                    <th>Cost</th>
-                    <th>Description</th>
-                    <th>Status</th>
-                    <th>Action</th>
-                </tr>
-                </thead>
-                <tbody>
-                <tr th:each="t : ${titleShop.catalog}" th:attr="data-title-id=${t.id}">
-                    <td>
-                        <span class="title-label"
-                              th:text="${t.label}"
-                              th:style="${t.colorHex != null ? 'color: ' + t.colorHex : ''}">Title</span>
-                    </td>
-                    <td th:text="${t.cost}">0</td>
-                    <td th:text="${t.description != null ? t.description : ''}"></td>
-                    <td>
-                        <span th:if="${titleShop.equippedTitleId == t.id}" class="badge owner">equipped</span>
-                        <span th:if="${titleShop.equippedTitleId != t.id && titleShop.ownedTitleIds.contains(t.id)}" class="muted">owned</span>
-                        <span th:if="${!titleShop.ownedTitleIds.contains(t.id)}" class="muted">available</span>
-                    </td>
-                    <td>
-                        <button type="button" class="btn title-buy"
-                                th:if="${!titleShop.ownedTitleIds.contains(t.id)}"
-                                th:disabled="${titleShop.balance < t.cost}">Buy</button>
-                        <button type="button" class="btn title-equip"
-                                th:if="${titleShop.ownedTitleIds.contains(t.id) && titleShop.equippedTitleId != t.id}">Equip</button>
-                        <button type="button" class="btn title-unequip"
-                                th:if="${titleShop.equippedTitleId == t.id}">Unequip</button>
-                    </td>
-                </tr>
-                <tr th:if="${#lists.isEmpty(titleShop.catalog)}">
-                    <td colspan="5" class="muted" style="text-align:center;">No titles configured.</td>
-                </tr>
-                </tbody>
-            </table>
         </div>
     </section>
 

--- a/web/src/main/resources/templates/profile-guilds.html
+++ b/web/src/main/resources/templates/profile-guilds.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="en">
+<head th:replace="~{fragments/head :: head('TobyBot - Profile', '/css/leaderboard.css')}"></head>
+<body>
+<a href="#main" class="skip-link">Skip to content</a>
+<div th:replace="~{fragments/navbar :: navbar}"></div>
+
+<main id="main" class="container">
+    <h1 class="mb-3">Your Profile</h1>
+    <p class="muted mb-5">
+        Pick a server to see your balance, equipped title, and owned titles.
+    </p>
+
+    <div th:if="${error}" class="alert alert-error" th:text="${error}"></div>
+
+    <div class="lb-guild-grid" th:if="${not #lists.isEmpty(guilds)}">
+        <a class="lb-guild-card"
+           th:each="g : ${guilds}"
+           th:href="@{/profile/{id}(id=${g.id})}">
+            <div class="lb-guild-card-header">
+                <img th:if="${g.iconUrl != null}"
+                     th:src="${g.iconUrl}"
+                     th:alt="${g.name} + ' icon'"
+                     class="lb-guild-icon"
+                     onerror="this.style.display='none'">
+                <div th:unless="${g.iconUrl != null}"
+                     class="lb-guild-icon-placeholder"
+                     aria-hidden="true"
+                     th:text="${#strings.substring(g.name, 0, 1).toUpperCase()}">G</div>
+                <div class="lb-guild-name" th:text="${g.name}" th:title="${g.name}">Guild</div>
+            </div>
+            <div class="lb-guild-top">
+                <span class="muted">Balance:</span>
+                <span th:text="${g.balance} + ' credits'">0 credits</span>
+            </div>
+        </a>
+    </div>
+
+    <div class="empty-hero" th:if="${#lists.isEmpty(guilds)}">
+        <span class="emoji" aria-hidden="true">👤</span>
+        <h2>No servers to show</h2>
+        <p class="mb-5">
+            You need to share at least one server with TobyBot to see a profile.
+        </p>
+    </div>
+</main>
+</body>
+</html>

--- a/web/src/main/resources/templates/profile.html
+++ b/web/src/main/resources/templates/profile.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="en">
+<head th:replace="~{fragments/head :: head('TobyBot - Profile', '/css/profile.css')}"></head>
+<body>
+<a href="#main" class="skip-link">Skip to content</a>
+<div th:replace="~{fragments/navbar :: navbar}"></div>
+
+<main id="main" class="container">
+    <div class="profile-header">
+        <a class="back-link" th:href="@{/profile/guilds}">&larr; All servers</a>
+        <h1 th:text="${profile.guildName}">Guild</h1>
+    </div>
+
+    <div th:if="${error}" class="alert alert-error" th:text="${error}"></div>
+
+    <div class="profile-grid">
+        <section class="profile-card">
+            <h2>Identity</h2>
+            <div class="profile-identity">
+                <img th:if="${profile.avatarUrl != null}"
+                     th:src="${profile.avatarUrl}"
+                     th:alt="${profile.displayName} + ' avatar'"
+                     class="profile-avatar">
+                <div>
+                    <div class="profile-name" th:text="${profile.displayName}">Name</div>
+                    <div class="muted" th:if="${profile.isOwner}">Server owner</div>
+                </div>
+            </div>
+        </section>
+
+        <section class="profile-card">
+            <h2>Economy</h2>
+            <div class="profile-row">
+                <span class="muted">Balance</span>
+                <strong th:text="${profile.balance} + ' credits'">0 credits</strong>
+            </div>
+            <div class="profile-row">
+                <span class="muted">Equipped title</span>
+                <span th:if="${profile.equippedTitleLabel != null}"
+                      class="title-pill"
+                      th:style="${profile.equippedTitleColorHex != null ? 'color: ' + profile.equippedTitleColorHex : ''}"
+                      th:text="${profile.equippedTitleLabel}">Title</span>
+                <span th:unless="${profile.equippedTitleLabel != null}" class="muted">—</span>
+            </div>
+            <a class="btn profile-action" th:href="@{/titles/{id}(id=${profile.guildId})}">Go to title shop &rarr;</a>
+        </section>
+
+        <section class="profile-card">
+            <h2>Permissions</h2>
+            <ul class="profile-perms">
+                <li th:each="p : ${profile.permissions}">
+                    <span th:text="${p.name}">Name</span>
+                    <span class="badge" th:classappend="${p.enabled} ? ' on' : ' off'"
+                          th:text="${p.enabled} ? 'On' : 'Off'">On</span>
+                </li>
+            </ul>
+        </section>
+
+        <section class="profile-card profile-card-wide">
+            <h2>Owned titles</h2>
+            <div th:if="${#lists.isEmpty(profile.ownedTitles)}" class="muted">
+                You don't own any titles yet.
+                <a th:href="@{/titles/{id}(id=${profile.guildId})}">Browse the shop &rarr;</a>
+            </div>
+            <ul class="profile-titles" th:if="${not #lists.isEmpty(profile.ownedTitles)}">
+                <li th:each="t : ${profile.ownedTitles}">
+                    <span class="title-pill"
+                          th:style="${t.colorHex != null ? 'color: ' + t.colorHex : ''}"
+                          th:text="${t.label}">Title</span>
+                    <span class="badge owner" th:if="${t.equipped}">equipped</span>
+                    <span class="muted" th:if="${t.description != null}" th:text="${t.description}"></span>
+                </li>
+            </ul>
+        </section>
+    </div>
+</main>
+</body>
+</html>

--- a/web/src/main/resources/templates/titles-guilds.html
+++ b/web/src/main/resources/templates/titles-guilds.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="en">
+<head th:replace="~{fragments/head :: head('TobyBot - Titles', '/css/leaderboard.css')}"></head>
+<body>
+<a href="#main" class="skip-link">Skip to content</a>
+<div th:replace="~{fragments/navbar :: navbar}"></div>
+
+<main id="main" class="container">
+    <h1 class="mb-3">Titles</h1>
+    <p class="muted mb-5">
+        Spend your social credit on vanity titles. Each purchased title also
+        grants a matching Discord role on that server. Pick a server below.
+    </p>
+
+    <div th:if="${error}" class="alert alert-error" th:text="${error}"></div>
+
+    <div class="lb-guild-grid" th:if="${not #lists.isEmpty(guilds)}">
+        <a class="lb-guild-card"
+           th:each="g : ${guilds}"
+           th:href="@{/titles/{id}(id=${g.id})}">
+            <div class="lb-guild-card-header">
+                <img th:if="${g.iconUrl != null}"
+                     th:src="${g.iconUrl}"
+                     th:alt="${g.name} + ' icon'"
+                     class="lb-guild-icon"
+                     onerror="this.style.display='none'">
+                <div th:unless="${g.iconUrl != null}"
+                     class="lb-guild-icon-placeholder"
+                     aria-hidden="true"
+                     th:text="${#strings.substring(g.name, 0, 1).toUpperCase()}">G</div>
+                <div class="lb-guild-name" th:text="${g.name}" th:title="${g.name}">Guild</div>
+            </div>
+            <div class="lb-guild-top">
+                <span class="muted">Balance:</span>
+                <span th:text="${g.balance} + ' credits'">0 credits</span>
+            </div>
+            <div class="lb-guild-stats" th:if="${g.equippedTitle != null}">
+                <span class="muted">Equipped:</span>
+                <span class="lb-title-pill" th:text="${g.equippedTitle}">Title</span>
+            </div>
+            <div class="lb-guild-stats" th:unless="${g.equippedTitle != null}">
+                <span class="muted">No title equipped</span>
+            </div>
+        </a>
+    </div>
+
+    <div class="empty-hero" th:if="${#lists.isEmpty(guilds)}">
+        <span class="emoji" aria-hidden="true">🏷️</span>
+        <h2>No servers to show</h2>
+        <p class="mb-5">
+            You need to share at least one server with TobyBot to buy titles.
+        </p>
+    </div>
+</main>
+</body>
+</html>

--- a/web/src/main/resources/templates/titles.html
+++ b/web/src/main/resources/templates/titles.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="en">
+<head th:replace="~{fragments/head :: head('TobyBot - Titles', '/css/moderation.css')}"></head>
+<body>
+<a href="#main" class="skip-link">Skip to content</a>
+<div th:replace="~{fragments/navbar :: navbar}"></div>
+
+<main id="main" class="container" th:attr="data-guild-id=${guildId}">
+
+    <div class="mod-header">
+        <div>
+            <a class="back-link" th:href="@{/titles/guilds}">&larr; All servers</a>
+            <h1>Title Shop</h1>
+        </div>
+    </div>
+
+    <div th:if="${error}" class="alert alert-error" th:text="${error}"></div>
+
+    <section>
+        <p class="muted mb-4">
+            Spend your social credit on vanity titles. Each purchased title also
+            grants you a matching Discord role on this server when equipped —
+            visible everywhere you appear in chat, member list and voice.
+            The bot needs the <strong>Manage Roles</strong> permission, and its
+            role must sit above the title roles in the hierarchy.
+        </p>
+        <p class="muted mb-4">
+            Your balance: <strong th:text="${titleShop.balance} + ' credits'">0 credits</strong>
+        </p>
+        <div class="mod-table-wrap">
+            <table class="mod-table">
+                <thead>
+                <tr>
+                    <th>Title</th>
+                    <th>Cost</th>
+                    <th>Description</th>
+                    <th>Status</th>
+                    <th>Action</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr th:each="t : ${titleShop.catalog}" th:attr="data-title-id=${t.id}">
+                    <td data-label="Title">
+                        <span class="title-label"
+                              th:text="${t.label}"
+                              th:style="${t.colorHex != null ? 'color: ' + t.colorHex : ''}">Title</span>
+                    </td>
+                    <td data-label="Cost" th:text="${t.cost}">0</td>
+                    <td data-label="Description" th:text="${t.description != null ? t.description : ''}"></td>
+                    <td data-label="Status">
+                        <span th:if="${titleShop.equippedTitleId == t.id}" class="badge owner">equipped</span>
+                        <span th:if="${titleShop.equippedTitleId != t.id && titleShop.ownedTitleIds.contains(t.id)}" class="muted">owned</span>
+                        <span th:if="${!titleShop.ownedTitleIds.contains(t.id)}" class="muted">available</span>
+                    </td>
+                    <td data-label="Action">
+                        <button type="button" class="btn title-buy"
+                                th:if="${!titleShop.ownedTitleIds.contains(t.id)}"
+                                th:disabled="${titleShop.balance < t.cost}">Buy</button>
+                        <button type="button" class="btn title-equip"
+                                th:if="${titleShop.ownedTitleIds.contains(t.id) && titleShop.equippedTitleId != t.id}">Equip</button>
+                        <button type="button" class="btn title-unequip"
+                                th:if="${titleShop.equippedTitleId == t.id}">Unequip</button>
+                    </td>
+                </tr>
+                <tr th:if="${#lists.isEmpty(titleShop.catalog)}">
+                    <td colspan="5" class="muted" style="text-align:center;">No titles configured.</td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+    </section>
+</main>
+
+<script th:src="@{/js/api.js}"></script>
+<script th:src="@{/js/toasts.js}"></script>
+<script th:src="@{/js/titles.js}"></script>
+</body>
+</html>

--- a/web/src/main/resources/templates/utils.html
+++ b/web/src/main/resources/templates/utils.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="en">
+<head th:replace="~{fragments/head :: head('TobyBot - Utilities', '/css/utils.css')}"></head>
+<body>
+<a href="#main" class="skip-link">Skip to content</a>
+<div th:replace="~{fragments/navbar :: navbar}"></div>
+
+<main id="main" class="container">
+    <h1 class="mb-3">Utilities</h1>
+    <p class="muted mb-5">
+        Quick tools that mirror some of TobyBot's chat commands. These don't
+        post to Discord — they just run here in your browser.
+    </p>
+
+    <div class="utils-grid">
+
+        <section class="util-card" data-util="dice">
+            <h2>Dice roller</h2>
+            <p class="muted">Equivalent to <code>/roll</code>.</p>
+            <form class="util-form" data-form="dice">
+                <label>Number of dice
+                    <input type="number" name="count" value="1" min="1" max="100" required>
+                </label>
+                <label>Sides
+                    <input type="number" name="sides" value="20" min="2" max="1000" required>
+                </label>
+                <label>Modifier
+                    <input type="number" name="modifier" value="0" step="1">
+                </label>
+                <button type="submit" class="btn">Roll</button>
+            </form>
+            <pre class="util-output" data-output="dice" aria-live="polite"></pre>
+        </section>
+
+        <section class="util-card" data-util="random">
+            <h2>Random chooser</h2>
+            <p class="muted">Equivalent to <code>/random</code>. Comma-separated list.</p>
+            <form class="util-form" data-form="random">
+                <label>Options
+                    <input type="text" name="list" placeholder="pizza, burger, tacos" required>
+                </label>
+                <button type="submit" class="btn">Pick one</button>
+            </form>
+            <pre class="util-output" data-output="random" aria-live="polite"></pre>
+        </section>
+
+        <section class="util-card" data-util="eightball">
+            <h2>Magic 8-ball</h2>
+            <p class="muted">Equivalent to <code>/8ball</code>.</p>
+            <button type="button" class="btn" data-action="eightball">Ask the ball</button>
+            <pre class="util-output" data-output="eightball" aria-live="polite"></pre>
+        </section>
+
+        <section class="util-card" data-util="meme">
+            <h2>Reddit meme</h2>
+            <p class="muted">Equivalent to <code>/meme</code>. Returns a SFW image post.</p>
+            <form class="util-form" data-form="meme">
+                <label>Subreddit
+                    <input type="text" name="subreddit" placeholder="memes" required>
+                </label>
+                <label>Time period
+                    <select name="timePeriod">
+                        <option value="day" selected>Day</option>
+                        <option value="week">Week</option>
+                        <option value="month">Month</option>
+                        <option value="all">All time</option>
+                    </select>
+                </label>
+                <label>Pick from top
+                    <input type="number" name="limit" value="10" min="1" max="100">
+                </label>
+                <button type="submit" class="btn">Fetch meme</button>
+            </form>
+            <div class="util-output meme-output" data-output="meme" aria-live="polite"></div>
+        </section>
+
+        <section class="util-card" data-util="dbd">
+            <h2>DBD random killer</h2>
+            <p class="muted">Equivalent to <code>/dbd-killer</code>.</p>
+            <button type="button" class="btn" data-action="dbd">Pick a killer</button>
+            <pre class="util-output" data-output="dbd" aria-live="polite"></pre>
+        </section>
+
+        <section class="util-card" data-util="kf2">
+            <h2>KF2 random map</h2>
+            <p class="muted">Equivalent to <code>/kf2</code>.</p>
+            <button type="button" class="btn" data-action="kf2">Pick a map</button>
+            <pre class="util-output" data-output="kf2" aria-live="polite"></pre>
+        </section>
+    </div>
+</main>
+
+<script th:src="@{/js/api.js}"></script>
+<script th:src="@{/js/toasts.js}"></script>
+<script th:src="@{/js/utils.js}"></script>
+</body>
+</html>

--- a/web/src/test/kotlin/web/service/ModerationWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/ModerationWebServiceTest.kt
@@ -4,7 +4,6 @@ import database.dto.ConfigDto
 import database.dto.MonthlyCreditSnapshotDto
 import database.dto.TitleDto
 import database.dto.UserDto
-import database.dto.UserOwnedTitleDto
 import database.service.ConfigService
 import database.service.MonthlyCreditSnapshotService
 import database.service.TitleService
@@ -39,7 +38,6 @@ class ModerationWebServiceTest {
     private lateinit var voiceSessionService: VoiceSessionService
     private lateinit var titleService: TitleService
     private lateinit var snapshotService: MonthlyCreditSnapshotService
-    private lateinit var titleRoleService: TitleRoleService
     private lateinit var service: ModerationWebService
 
     private lateinit var guild: Guild
@@ -59,7 +57,6 @@ class ModerationWebServiceTest {
         voiceSessionService = mockk(relaxed = true)
         titleService = mockk(relaxed = true)
         snapshotService = mockk(relaxed = true)
-        titleRoleService = mockk(relaxed = true)
         guild = mockk(relaxed = true)
         service = ModerationWebService(
             jda,
@@ -68,8 +65,7 @@ class ModerationWebServiceTest {
             introWebService,
             voiceSessionService,
             titleService,
-            snapshotService,
-            titleRoleService
+            snapshotService
         )
 
         every { jda.getGuildById(guildId) } returns guild
@@ -489,180 +485,6 @@ class ModerationWebServiceTest {
         assertNull(rows[0].title)
     }
 
-    // ---- getTitlesForGuild ----
-
-    @Test
-    fun `getTitlesForGuild returns catalog with ownership, equipped flag, and balance`() {
-        val titles = listOf(
-            TitleDto(id = 1L, label = "A", cost = 100L, description = "d1"),
-            TitleDto(id = 2L, label = "B", cost = 500L, description = null, colorHex = "#FFD700", hoisted = true)
-        )
-        val owned = listOf(UserOwnedTitleDto(discordId = plainUserId, titleId = 1L))
-        val actor = UserDto(discordId = plainUserId, guildId = guildId).apply {
-            socialCredit = 350L
-            activeTitleId = 1L
-        }
-        every { titleService.listAll() } returns titles
-        every { titleService.listOwned(plainUserId) } returns owned
-        every { userService.getUserById(plainUserId, guildId) } returns actor
-
-        val view = service.getTitlesForGuild(guildId, plainUserId)
-        assertEquals(2, view.catalog.size)
-        assertEquals(setOf(1L), view.ownedTitleIds)
-        assertEquals(1L, view.equippedTitleId)
-        assertEquals(350L, view.balance)
-    }
-
-    // ---- buyTitle ----
-
-    @Test
-    fun `buyTitle deducts credits and records purchase`() {
-        val title = TitleDto(id = 1L, label = "A", cost = 100L)
-        val actor = UserDto(discordId = plainUserId, guildId = guildId).apply { socialCredit = 500L }
-        every { titleService.getById(1L) } returns title
-        every { userService.getUserById(plainUserId, guildId) } returns actor
-        every { titleService.owns(plainUserId, 1L) } returns false
-
-        val err = service.buyTitle(plainUserId, guildId, 1L)
-        assertNull(err)
-        assertEquals(400L, actor.socialCredit)
-        verify(exactly = 1) { userService.updateUser(actor) }
-        verify(exactly = 1) { titleService.recordPurchase(plainUserId, 1L) }
-    }
-
-    @Test
-    fun `buyTitle rejects when user already owns the title`() {
-        val title = TitleDto(id = 1L, label = "A", cost = 100L)
-        val actor = UserDto(discordId = plainUserId, guildId = guildId).apply { socialCredit = 500L }
-        every { titleService.getById(1L) } returns title
-        every { userService.getUserById(plainUserId, guildId) } returns actor
-        every { titleService.owns(plainUserId, 1L) } returns true
-
-        val err = service.buyTitle(plainUserId, guildId, 1L)
-        assertEquals("You already own this title.", err)
-        verify(exactly = 0) { userService.updateUser(any()) }
-        verify(exactly = 0) { titleService.recordPurchase(any(), any()) }
-    }
-
-    @Test
-    fun `buyTitle rejects when credits insufficient`() {
-        val title = TitleDto(id = 1L, label = "A", cost = 1_000L)
-        val actor = UserDto(discordId = plainUserId, guildId = guildId).apply { socialCredit = 50L }
-        every { titleService.getById(1L) } returns title
-        every { userService.getUserById(plainUserId, guildId) } returns actor
-        every { titleService.owns(plainUserId, 1L) } returns false
-
-        val err = service.buyTitle(plainUserId, guildId, 1L)
-        assertNotNull(err)
-        assertTrue(err!!.contains("Not enough credits"))
-        assertEquals(50L, actor.socialCredit)
-        verify(exactly = 0) { userService.updateUser(any()) }
-    }
-
-    @Test
-    fun `buyTitle rejects when bot is not in guild`() {
-        every { jda.getGuildById(guildId) } returns null
-        val err = service.buyTitle(plainUserId, guildId, 1L)
-        assertEquals("Bot is not in that server.", err)
-    }
-
-    @Test
-    fun `buyTitle rejects when user has no profile`() {
-        val title = TitleDto(id = 1L, label = "A", cost = 100L)
-        every { titleService.getById(1L) } returns title
-        every { userService.getUserById(plainUserId, guildId) } returns null
-
-        val err = service.buyTitle(plainUserId, guildId, 1L)
-        assertEquals("You don't have a profile in that server yet.", err)
-    }
-
-    @Test
-    fun `buyTitle rejects when title does not exist`() {
-        every { titleService.getById(99L) } returns null
-        val err = service.buyTitle(plainUserId, guildId, 99L)
-        assertEquals("Title not found.", err)
-    }
-
-    // ---- equipTitle ----
-
-    @Test
-    fun `equipTitle sets activeTitleId when role service succeeds`() {
-        val title = TitleDto(id = 1L, label = "A", cost = 100L)
-        val actor = UserDto(discordId = plainUserId, guildId = guildId)
-        val member = mockMember(plainUserId)
-        every { userService.getUserById(plainUserId, guildId) } returns actor
-        every { titleService.getById(1L) } returns title
-        every { titleService.owns(plainUserId, 1L) } returns true
-        every { titleService.listOwned(plainUserId) } returns listOf(UserOwnedTitleDto(discordId = plainUserId, titleId = 1L))
-        every { titleRoleService.equip(guild, member, title, setOf(1L)) } returns TitleRoleResult.Ok
-
-        val err = service.equipTitle(plainUserId, guildId, 1L)
-        assertNull(err)
-        assertEquals(1L, actor.activeTitleId)
-        verify(exactly = 1) { userService.updateUser(actor) }
-    }
-
-    @Test
-    fun `equipTitle rejects when user does not own the title`() {
-        val title = TitleDto(id = 1L, label = "A", cost = 100L)
-        val actor = UserDto(discordId = plainUserId, guildId = guildId)
-        mockMember(plainUserId)
-        every { userService.getUserById(plainUserId, guildId) } returns actor
-        every { titleService.getById(1L) } returns title
-        every { titleService.owns(plainUserId, 1L) } returns false
-
-        val err = service.equipTitle(plainUserId, guildId, 1L)
-        assertEquals("You don't own this title.", err)
-        assertNull(actor.activeTitleId)
-        verify(exactly = 0) { userService.updateUser(any()) }
-    }
-
-    @Test
-    fun `equipTitle surfaces role service error and does not persist`() {
-        val title = TitleDto(id = 1L, label = "A", cost = 100L)
-        val actor = UserDto(discordId = plainUserId, guildId = guildId)
-        val member = mockMember(plainUserId)
-        every { userService.getUserById(plainUserId, guildId) } returns actor
-        every { titleService.getById(1L) } returns title
-        every { titleService.owns(plainUserId, 1L) } returns true
-        every { titleService.listOwned(plainUserId) } returns listOf(UserOwnedTitleDto(discordId = plainUserId, titleId = 1L))
-        every { titleRoleService.equip(guild, member, title, any()) } returns TitleRoleResult.Error("no Manage Roles")
-
-        val err = service.equipTitle(plainUserId, guildId, 1L)
-        assertEquals("no Manage Roles", err)
-        assertNull(actor.activeTitleId)
-        verify(exactly = 0) { userService.updateUser(any()) }
-    }
-
-    // ---- unequipTitle ----
-
-    @Test
-    fun `unequipTitle clears activeTitleId when role service succeeds`() {
-        val actor = UserDto(discordId = plainUserId, guildId = guildId).apply { activeTitleId = 1L }
-        val member = mockMember(plainUserId)
-        every { userService.getUserById(plainUserId, guildId) } returns actor
-        every { titleService.listOwned(plainUserId) } returns listOf(UserOwnedTitleDto(discordId = plainUserId, titleId = 1L))
-        every { titleRoleService.unequip(guild, member, setOf(1L)) } returns TitleRoleResult.Ok
-
-        val err = service.unequipTitle(plainUserId, guildId)
-        assertNull(err)
-        assertNull(actor.activeTitleId)
-        verify(exactly = 1) { userService.updateUser(actor) }
-    }
-
-    @Test
-    fun `unequipTitle surfaces role service error`() {
-        val actor = UserDto(discordId = plainUserId, guildId = guildId).apply { activeTitleId = 1L }
-        val member = mockMember(plainUserId)
-        every { userService.getUserById(plainUserId, guildId) } returns actor
-        every { titleService.listOwned(plainUserId) } returns emptyList()
-        every { titleRoleService.unequip(guild, member, any()) } returns TitleRoleResult.Error("bot has no Manage Roles")
-
-        val err = service.unequipTitle(plainUserId, guildId)
-        assertEquals("bot has no Manage Roles", err)
-        assertEquals(1L, actor.activeTitleId)
-        verify(exactly = 0) { userService.updateUser(any()) }
-    }
 
     // ---- updateConfig LEADERBOARD_CHANNEL ----
 

--- a/web/src/test/kotlin/web/service/TitlesWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/TitlesWebServiceTest.kt
@@ -1,0 +1,263 @@
+package web.service
+
+import database.dto.TitleDto
+import database.dto.UserDto
+import database.dto.UserOwnedTitleDto
+import database.service.TitleService
+import database.service.UserService
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.unmockkAll
+import io.mockk.verify
+import net.dv8tion.jda.api.JDA
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.Member
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class TitlesWebServiceTest {
+
+    private lateinit var jda: JDA
+    private lateinit var userService: UserService
+    private lateinit var titleService: TitleService
+    private lateinit var titleRoleService: TitleRoleService
+    private lateinit var introWebService: IntroWebService
+    private lateinit var service: TitlesWebService
+
+    private lateinit var guild: Guild
+
+    private val guildId = 222L
+    private val plainUserId = 102L
+
+    @BeforeEach
+    fun setup() {
+        jda = mockk(relaxed = true)
+        userService = mockk(relaxed = true)
+        titleService = mockk(relaxed = true)
+        titleRoleService = mockk(relaxed = true)
+        introWebService = mockk(relaxed = true)
+        guild = mockk(relaxed = true)
+        service = TitlesWebService(
+            jda,
+            userService,
+            titleService,
+            titleRoleService,
+            introWebService
+        )
+
+        every { jda.getGuildById(guildId) } returns guild
+        every { guild.id } returns guildId.toString()
+        every { guild.name } returns "Test Guild"
+    }
+
+    @AfterEach
+    fun tearDown() = unmockkAll()
+
+    private fun mockMember(id: Long): Member {
+        val m = mockk<Member>(relaxed = true)
+        every { m.idLong } returns id
+        every { m.id } returns id.toString()
+        every { guild.getMemberById(id) } returns m
+        return m
+    }
+
+    // ---- isMember ----
+
+    @Test
+    fun `isMember true when guild and member exist`() {
+        mockMember(plainUserId)
+        assertTrue(service.isMember(plainUserId, guildId))
+    }
+
+    @Test
+    fun `isMember false when guild missing`() {
+        every { jda.getGuildById(guildId) } returns null
+        assertEquals(false, service.isMember(plainUserId, guildId))
+    }
+
+    @Test
+    fun `isMember false when member not in guild`() {
+        every { guild.getMemberById(plainUserId) } returns null
+        assertEquals(false, service.isMember(plainUserId, guildId))
+    }
+
+    // ---- getTitlesForGuild ----
+
+    @Test
+    fun `getTitlesForGuild returns catalog with ownership, equipped flag, and balance`() {
+        val titles = listOf(
+            TitleDto(id = 1L, label = "A", cost = 100L, description = "d1"),
+            TitleDto(id = 2L, label = "B", cost = 500L, description = null, colorHex = "#FFD700", hoisted = true)
+        )
+        val owned = listOf(UserOwnedTitleDto(discordId = plainUserId, titleId = 1L))
+        val actor = UserDto(discordId = plainUserId, guildId = guildId).apply {
+            socialCredit = 350L
+            activeTitleId = 1L
+        }
+        every { titleService.listAll() } returns titles
+        every { titleService.listOwned(plainUserId) } returns owned
+        every { userService.getUserById(plainUserId, guildId) } returns actor
+
+        val view = service.getTitlesForGuild(guildId, plainUserId)
+        assertEquals(2, view.catalog.size)
+        assertEquals(setOf(1L), view.ownedTitleIds)
+        assertEquals(1L, view.equippedTitleId)
+        assertEquals(350L, view.balance)
+    }
+
+    // ---- buyTitle ----
+
+    @Test
+    fun `buyTitle deducts credits and records purchase`() {
+        val title = TitleDto(id = 1L, label = "A", cost = 100L)
+        val actor = UserDto(discordId = plainUserId, guildId = guildId).apply { socialCredit = 500L }
+        every { titleService.getById(1L) } returns title
+        every { userService.getUserById(plainUserId, guildId) } returns actor
+        every { titleService.owns(plainUserId, 1L) } returns false
+
+        val err = service.buyTitle(plainUserId, guildId, 1L)
+        assertNull(err)
+        assertEquals(400L, actor.socialCredit)
+        verify(exactly = 1) { userService.updateUser(actor) }
+        verify(exactly = 1) { titleService.recordPurchase(plainUserId, 1L) }
+    }
+
+    @Test
+    fun `buyTitle rejects when user already owns the title`() {
+        val title = TitleDto(id = 1L, label = "A", cost = 100L)
+        val actor = UserDto(discordId = plainUserId, guildId = guildId).apply { socialCredit = 500L }
+        every { titleService.getById(1L) } returns title
+        every { userService.getUserById(plainUserId, guildId) } returns actor
+        every { titleService.owns(plainUserId, 1L) } returns true
+
+        val err = service.buyTitle(plainUserId, guildId, 1L)
+        assertEquals("You already own this title.", err)
+        verify(exactly = 0) { userService.updateUser(any()) }
+        verify(exactly = 0) { titleService.recordPurchase(any(), any()) }
+    }
+
+    @Test
+    fun `buyTitle rejects when credits insufficient`() {
+        val title = TitleDto(id = 1L, label = "A", cost = 1_000L)
+        val actor = UserDto(discordId = plainUserId, guildId = guildId).apply { socialCredit = 50L }
+        every { titleService.getById(1L) } returns title
+        every { userService.getUserById(plainUserId, guildId) } returns actor
+        every { titleService.owns(plainUserId, 1L) } returns false
+
+        val err = service.buyTitle(plainUserId, guildId, 1L)
+        assertNotNull(err)
+        assertTrue(err!!.contains("Not enough credits"))
+        assertEquals(50L, actor.socialCredit)
+        verify(exactly = 0) { userService.updateUser(any()) }
+    }
+
+    @Test
+    fun `buyTitle rejects when bot is not in guild`() {
+        every { jda.getGuildById(guildId) } returns null
+        val err = service.buyTitle(plainUserId, guildId, 1L)
+        assertEquals("Bot is not in that server.", err)
+    }
+
+    @Test
+    fun `buyTitle rejects when user has no profile`() {
+        val title = TitleDto(id = 1L, label = "A", cost = 100L)
+        every { titleService.getById(1L) } returns title
+        every { userService.getUserById(plainUserId, guildId) } returns null
+
+        val err = service.buyTitle(plainUserId, guildId, 1L)
+        assertEquals("You don't have a profile in that server yet.", err)
+    }
+
+    @Test
+    fun `buyTitle rejects when title does not exist`() {
+        every { titleService.getById(99L) } returns null
+        val err = service.buyTitle(plainUserId, guildId, 99L)
+        assertEquals("Title not found.", err)
+    }
+
+    // ---- equipTitle ----
+
+    @Test
+    fun `equipTitle sets activeTitleId when role service succeeds`() {
+        val title = TitleDto(id = 1L, label = "A", cost = 100L)
+        val actor = UserDto(discordId = plainUserId, guildId = guildId)
+        val member = mockMember(plainUserId)
+        every { userService.getUserById(plainUserId, guildId) } returns actor
+        every { titleService.getById(1L) } returns title
+        every { titleService.owns(plainUserId, 1L) } returns true
+        every { titleService.listOwned(plainUserId) } returns listOf(UserOwnedTitleDto(discordId = plainUserId, titleId = 1L))
+        every { titleRoleService.equip(guild, member, title, setOf(1L)) } returns TitleRoleResult.Ok
+
+        val err = service.equipTitle(plainUserId, guildId, 1L)
+        assertNull(err)
+        assertEquals(1L, actor.activeTitleId)
+        verify(exactly = 1) { userService.updateUser(actor) }
+    }
+
+    @Test
+    fun `equipTitle rejects when user does not own the title`() {
+        val title = TitleDto(id = 1L, label = "A", cost = 100L)
+        val actor = UserDto(discordId = plainUserId, guildId = guildId)
+        mockMember(plainUserId)
+        every { userService.getUserById(plainUserId, guildId) } returns actor
+        every { titleService.getById(1L) } returns title
+        every { titleService.owns(plainUserId, 1L) } returns false
+
+        val err = service.equipTitle(plainUserId, guildId, 1L)
+        assertEquals("You don't own this title.", err)
+        assertNull(actor.activeTitleId)
+        verify(exactly = 0) { userService.updateUser(any()) }
+    }
+
+    @Test
+    fun `equipTitle surfaces role service error and does not persist`() {
+        val title = TitleDto(id = 1L, label = "A", cost = 100L)
+        val actor = UserDto(discordId = plainUserId, guildId = guildId)
+        val member = mockMember(plainUserId)
+        every { userService.getUserById(plainUserId, guildId) } returns actor
+        every { titleService.getById(1L) } returns title
+        every { titleService.owns(plainUserId, 1L) } returns true
+        every { titleService.listOwned(plainUserId) } returns listOf(UserOwnedTitleDto(discordId = plainUserId, titleId = 1L))
+        every { titleRoleService.equip(guild, member, title, any()) } returns TitleRoleResult.Error("no Manage Roles")
+
+        val err = service.equipTitle(plainUserId, guildId, 1L)
+        assertEquals("no Manage Roles", err)
+        assertNull(actor.activeTitleId)
+        verify(exactly = 0) { userService.updateUser(any()) }
+    }
+
+    // ---- unequipTitle ----
+
+    @Test
+    fun `unequipTitle clears activeTitleId when role service succeeds`() {
+        val actor = UserDto(discordId = plainUserId, guildId = guildId).apply { activeTitleId = 1L }
+        val member = mockMember(plainUserId)
+        every { userService.getUserById(plainUserId, guildId) } returns actor
+        every { titleService.listOwned(plainUserId) } returns listOf(UserOwnedTitleDto(discordId = plainUserId, titleId = 1L))
+        every { titleRoleService.unequip(guild, member, setOf(1L)) } returns TitleRoleResult.Ok
+
+        val err = service.unequipTitle(plainUserId, guildId)
+        assertNull(err)
+        assertNull(actor.activeTitleId)
+        verify(exactly = 1) { userService.updateUser(actor) }
+    }
+
+    @Test
+    fun `unequipTitle surfaces role service error`() {
+        val actor = UserDto(discordId = plainUserId, guildId = guildId).apply { activeTitleId = 1L }
+        val member = mockMember(plainUserId)
+        every { userService.getUserById(plainUserId, guildId) } returns actor
+        every { titleService.listOwned(plainUserId) } returns emptyList()
+        every { titleRoleService.unequip(guild, member, any()) } returns TitleRoleResult.Error("bot has no Manage Roles")
+
+        val err = service.unequipTitle(plainUserId, guildId)
+        assertEquals("bot has no Manage Roles", err)
+        assertEquals(1L, actor.activeTitleId)
+        verify(exactly = 0) { userService.updateUser(any()) }
+    }
+}


### PR DESCRIPTION
## Summary

- Any server **member** (not just admins) can now buy/equip/unequip titles from a new `/titles/{guildId}` page. Previously the shop lived inside `/moderation/{guildId}` behind `canModerate()`, which meant regular users had to run `/title …` in Discord.
- New read-only `/profile/{guildId}` showing the member's balance, equipped title, owned titles and permissions, with a deep link into the title shop.
- New `/utils` page mirroring non-voice commands: dice roller, random chooser, Magic 8-ball (client-side), plus `/meme`, `/dbd-random-killer`, `/kf2-random-map` (server-side endpoints that share the same Reddit + wiki logic as the Discord commands).
- Moderation panel slimmed: dropped the duplicated Social Credit leaderboard tab (use `/leaderboard/{guildId}` — already exists). Owner-only credit adjustment was moved inline into the Users tab, alongside the permission toggles and kick action.
- Navbar now links to Titles, Profile and Utils.

## Key files

- `web/.../controller/TitlesController.kt` + `service/TitlesWebService.kt` + `templates/titles.html|titles-guilds.html` + `static/js/titles.js` — new member-gated title shop.
- `web/.../controller/ProfileController.kt` + `service/ProfileWebService.kt` + `templates/profile.html|profile-guilds.html` + `static/css/profile.css`.
- `web/.../controller/UtilsController.kt` + `service/UtilsWebService.kt` + `templates/utils.html` + `static/js/utils.js` + `static/css/utils.css`. Added `org.jsoup:jsoup:1.18.3` to `web/build.gradle` for the DBD/KF2 wiki fetchers.
- `ModerationController.kt` / `ModerationWebService.kt` — removed title endpoints + view objects; removed the `leaderboard` model attribute. `ModeratedMember` now carries `socialCredit` so the Users tab can show it.
- `moderation.html` / `moderation.js` — removed Titles and Social Credit tabs; the existing `.sc-apply` handler now drives the inline owner adjust in the Users tab.
- Title-specific tests moved from `ModerationWebServiceTest` into a new `TitlesWebServiceTest`.

## Test plan

- [x] `./gradlew :web:compileKotlin :web:test` — web compiles and all unit tests pass (existing moderation tests + new title tests).
- [ ] Manual: sign in as a non-admin member, visit `/titles/{guildId}` → buy, equip, unequip; confirm Discord role is applied/removed.
- [ ] Manual: visit `/profile/{guildId}` → balance, equipped title, owned titles, permissions match Discord state.
- [ ] Manual: visit `/utils` → dice / random / 8-ball work client-side; meme / DBD killer / KF2 map buttons return data.
- [ ] Manual: visit `/moderation/{guildId}` as owner → no Titles or Social Credit tabs; Users tab shows the new Credit column with delta + Apply, and the adjust request still succeeds.
- [ ] Manual: non-member hitting `/titles/{guildId}` or `/profile/{guildId}` is redirected to the guild picker with the expected flash error.

https://claude.ai/code/session_01P5fJTerP1RraDqf7HD34hR

---
_Generated by [Claude Code](https://claude.ai/code/session_01P5fJTerP1RraDqf7HD34hR)_