### PR TITLE
fix(web): make mobile hamburger menu work on all pages

### DIFF
--- a/web/src/main/resources/templates/fragments/navbar.html
+++ b/web/src/main/resources/templates/fragments/navbar.html
@@ -21,6 +21,7 @@
         <a th:if="${username == null}" href="/oauth2/authorization/discord" class="btn-discord">Login</a>
     </div>
     <button class="nav-toggle" onclick="toggleNav()" aria-label="Toggle navigation">&#9776;</button>
+    <script th:src="@{/js/home.js}"></script>
 </nav>
 </body>
 </html>

--- a/web/src/test/js/navbar.test.js
+++ b/web/src/test/js/navbar.test.js
@@ -1,0 +1,54 @@
+const fs = require('fs');
+const path = require('path');
+
+// Locks in the fix for the mobile hamburger menu: the navbar fragment must
+// ship its own script dependency so every page that imports the fragment
+// gets a working toggleNav(), regardless of which page-specific scripts the
+// page itself loads.
+//
+// Previously toggleNav() lived in home.js and only ~10 of 18 pages loaded
+// it, so the hamburger rendered but did nothing on the other pages.
+
+const NAVBAR_FRAGMENT = path.resolve(
+    __dirname,
+    '../../main/resources/templates/fragments/navbar.html'
+);
+
+describe('navbar fragment', () => {
+    let html;
+
+    beforeAll(() => {
+        html = fs.readFileSync(NAVBAR_FRAGMENT, 'utf8');
+    });
+
+    test('declares a Thymeleaf fragment named "navbar"', () => {
+        expect(html).toMatch(/th:fragment\s*=\s*"navbar"/);
+    });
+
+    test('renders a hamburger toggle button wired to toggleNav()', () => {
+        expect(html).toMatch(
+            /<button[^>]*class="[^"]*\bnav-toggle\b[^"]*"[^>]*onclick="toggleNav\(\)"/
+        );
+    });
+
+    test('renders the collapsible menu container with id="nav-menu"', () => {
+        expect(html).toMatch(/id="nav-menu"/);
+        expect(html).toMatch(/class="[^"]*\bnav-links\b[^"]*"[^>]*id="nav-menu"/);
+    });
+
+    test('includes the home.js script so toggleNav() is defined wherever the fragment is used', () => {
+        expect(html).toMatch(
+            /<script[^>]*th:src\s*=\s*"@\{\s*\/js\/home\.js\s*}"[^>]*>\s*<\/script>/
+        );
+    });
+
+    test('places the script inside the navbar fragment element', () => {
+        const fragmentMatch = html.match(
+            /<nav\s+th:fragment="navbar"[\s\S]*?<\/nav>/
+        );
+        expect(fragmentMatch).not.toBeNull();
+        expect(fragmentMatch[0]).toMatch(
+            /<script[^>]*th:src\s*=\s*"@\{\s*\/js\/home\.js\s*}"/
+        );
+    });
+});


### PR DESCRIPTION
## Summary

- The navbar markup and CSS were already shared via `fragments/navbar.html` + `nav.css`, but `toggleNav()` lived in `static/js/home.js` which only ~10 of 18 pages actually loaded. On the rest (leaderboards, leaderboard, profile, profile-guilds, titles, titles-guilds, moderation, utils), the hamburger button rendered but tapping it silently did nothing because the handler was undefined.
- Fix: include `<script th:src="@{/js/home.js}"></script>` inside the `th:fragment="navbar"` element. Now every page that imports the fragment automatically ships its behaviour, and the bug can't recur when a new page is added.
- Added `web/src/test/js/navbar.test.js` (5 tests) to lock in the invariant: the fragment must declare its own script dependency.

## Test plan

- [x] `npm test` in `web/` — all 82 tests pass (3 suites, including the new navbar suite).
- [ ] Manual: run the app, switch to a <600 px viewport, tap ☰ on each previously-broken route (`/leaderboards`, `/leaderboard/{id}`, `/profile/guilds`, `/profile/{id}`, `/titles/guilds`, `/titles/{id}`, `/moderation/{id}`, `/utils`) and confirm the menu expands/collapses.
- [ ] Regression check on `/` and `/privacy` (pages that already worked).

https://claude.ai/code/session_01KjpgDD1WaszgUT35ybWeTF

---
_Generated by [Claude Code](https://claude.ai/code/session_01KjpgDD1WaszgUT35ybWeTF)_