### PR TITLE
fix(social-credit): evict list cache + chart overlay + trade locks + price tick + award hooks + wallet leaderboard

### DIFF
--- a/application/src/test/kotlin/integration/bot/CommandManagerTest.kt
+++ b/application/src/test/kotlin/integration/bot/CommandManagerTest.kt
@@ -58,6 +58,7 @@ class CommandManagerTest {
 
     lateinit var configService: ConfigService
     lateinit var userDtoHelper: UserDtoHelper
+    lateinit var awardService: SocialCreditAwardService
     private lateinit var commandManager: DefaultCommandManager
 
     @Autowired
@@ -67,7 +68,8 @@ class CommandManagerTest {
     fun openMocks() {
         configService = mockk()
         userDtoHelper = mockk()
-        commandManager = DefaultCommandManager(configService, userDtoHelper, commands)
+        awardService = mockk(relaxed = true)
+        commandManager = DefaultCommandManager(configService, userDtoHelper, awardService, commands)
         mockkStatic(PlayerManager::class)
         mockkObject(MusicPlayerHelper)
     }

--- a/application/src/test/kotlin/integration/database/EconomyTradeServiceIntegrationTest.kt
+++ b/application/src/test/kotlin/integration/database/EconomyTradeServiceIntegrationTest.kt
@@ -20,6 +20,8 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicLong
 
 @SpringBootTest(
@@ -169,5 +171,85 @@ class EconomyTradeServiceIntegrationTest {
 
         assertInstanceOf(TradeOutcome.InvalidAmount::class.java, tradeService.buy(fx.discordId, fx.guildId, 0L))
         assertInstanceOf(TradeOutcome.InvalidAmount::class.java, tradeService.sell(fx.discordId, fx.guildId, -5L))
+    }
+
+    /**
+     * Regression guard for the trade TOCTOU race. Before
+     * [EconomyTradeService] took a pessimistic row lock, two concurrent
+     * buys could both read the same balance and both succeed — double
+     * spending the user's credits. The @Transactional + SELECT FOR UPDATE
+     * lock forces serialisation so the final numbers reconcile.
+     */
+    @Test
+    fun `concurrent buys cannot double-spend credits`() {
+        val threads = 8
+        val amount = 1L
+        // Price 100, balance = 3 coins worth. Attempting 8 concurrent buys
+        // must yield at most 3 successes.
+        val fx = newFixture(openingCredits = 300L)
+        tradeService.loadOrCreateMarket(fx.guildId)
+        val openingPrice = marketService.getMarket(fx.guildId)!!.price
+
+        val executor = Executors.newFixedThreadPool(threads)
+        val outcomes = try {
+            (1..threads)
+                .map { executor.submit<TradeOutcome> { tradeService.buy(fx.discordId, fx.guildId, amount) } }
+                .map { it.get(30, TimeUnit.SECONDS) }
+        } finally {
+            executor.shutdownNow()
+        }
+
+        val successes = outcomes.count { it is TradeOutcome.Ok }
+        val failures = outcomes.count { it is TradeOutcome.InsufficientCredits }
+        assertEquals(threads, successes + failures, "every outcome must be Ok or InsufficientCredits")
+        assertTrue(successes in 1..3, "affordable coins = 3 but saw $successes successes")
+
+        val user = userService.getUserById(fx.discordId, fx.guildId)!!
+        assertTrue(user.socialCredit!! >= 0L, "credits never go negative")
+        assertEquals(successes.toLong(), user.tobyCoins, "coins must equal the number of successful buys")
+
+        val totalSpent = outcomes.filterIsInstance<TradeOutcome.Ok>().sumOf { it.transactedCredits }
+        assertEquals(300L - totalSpent, user.socialCredit, "credits accounting must balance")
+
+        val market = marketService.getMarket(fx.guildId)!!
+        assertTrue(market.price >= openingPrice, "buys can only push the market up")
+    }
+
+    /**
+     * Regression guard for lost market-price updates. Each concurrent trade
+     * applies buy/sell pressure; without the market row lock, two writes
+     * could read the same `market.price` and one update would be clobbered.
+     * After the fix the final price equals the deterministic serial product
+     * of pressures — independent of execution order.
+     */
+    @Test
+    fun `concurrent trades do not lose market-price updates`() {
+        val fx = newFixture(openingCredits = 1_000_000L)
+        tradeService.loadOrCreateMarket(fx.guildId)
+        val openingPrice = marketService.getMarket(fx.guildId)!!.price
+
+        val buys = 10
+        val coinsPerBuy = 1L
+        val executor = Executors.newFixedThreadPool(4)
+        try {
+            (1..buys)
+                .map { executor.submit { tradeService.buy(fx.discordId, fx.guildId, coinsPerBuy) } }
+                .forEach { it.get(30, TimeUnit.SECONDS) }
+        } finally {
+            executor.shutdownNow()
+        }
+
+        // Pressure is multiplicative: n sequential buys of c coins produce
+        // price = p0 * (1 + k*c)^n regardless of order, because multiplication
+        // commutes. The lock guarantees each buy sees its predecessor's price.
+        val expected = generateSequence(openingPrice) { TobyCoinEngine.applyBuyPressure(it, coinsPerBuy) }
+            .drop(1)
+            .take(buys)
+            .last()
+        val actual = marketService.getMarket(fx.guildId)!!.price
+        assertEquals(expected, actual, 1e-6, "market price must match serial-application regardless of thread order")
+
+        val user = userService.getUserById(fx.discordId, fx.guildId)!!
+        assertEquals(buys.toLong() * coinsPerBuy, user.tobyCoins)
     }
 }

--- a/database/src/main/kotlin/database/economy/TobyCoinEngine.kt
+++ b/database/src/main/kotlin/database/economy/TobyCoinEngine.kt
@@ -28,8 +28,11 @@ object TobyCoinEngine {
     /** Annualised volatility. 0.6 ≈ typical small-cap / crypto territory. */
     const val VOLATILITY = 0.6
 
-    /** Long-term drift. Zero = no systemic bias up or down. */
-    const val DRIFT = 0.0
+    // Drift chosen so E[log(S_{t+dt}/S_t)] = 0 — the median path is flat and
+    // the walk is equally likely to go up or down each tick. With DRIFT=0 the
+    // lognormal Itô correction makes the median decay, so most observed paths
+    // trend downward even though the mean is conserved.
+    const val DRIFT = 0.5 * VOLATILITY * VOLATILITY
 
     /** Per-coin trade impact on price. 1000 coins moves the market ~40 %. */
     const val TRADE_IMPACT = 0.0004

--- a/database/src/main/kotlin/database/persistence/TobyCoinMarketPersistence.kt
+++ b/database/src/main/kotlin/database/persistence/TobyCoinMarketPersistence.kt
@@ -4,6 +4,10 @@ import database.dto.TobyCoinMarketDto
 
 interface TobyCoinMarketPersistence {
     fun getByGuild(guildId: Long): TobyCoinMarketDto?
+
+    // SELECT ... FOR UPDATE. Only call inside an active @Transactional.
+    fun getByGuildForUpdate(guildId: Long): TobyCoinMarketDto?
+
     fun listAll(): List<TobyCoinMarketDto>
     fun upsert(market: TobyCoinMarketDto): TobyCoinMarketDto
 }

--- a/database/src/main/kotlin/database/persistence/UserPersistence.kt
+++ b/database/src/main/kotlin/database/persistence/UserPersistence.kt
@@ -6,6 +6,11 @@ interface UserPersistence {
     fun listGuildUsers(guildId: Long?): List<UserDto?>
     fun createNewUser(userDto: UserDto): UserDto
     fun getUserById(discordId: Long?, guildId: Long?): UserDto?
+
+    // SELECT ... FOR UPDATE. Only call inside an active @Transactional — the
+    // row lock is released when the enclosing transaction commits/rolls back.
+    fun getUserByIdForUpdate(discordId: Long?, guildId: Long?): UserDto?
+
     fun updateUser(userDto: UserDto): UserDto
     fun deleteUser(userDto: UserDto)
     fun deleteUserById(discordId: Long?, guildId: Long?)

--- a/database/src/main/kotlin/database/persistence/impl/DefaultTobyCoinMarketPersistence.kt
+++ b/database/src/main/kotlin/database/persistence/impl/DefaultTobyCoinMarketPersistence.kt
@@ -3,6 +3,7 @@ package database.persistence.impl
 import database.dto.TobyCoinMarketDto
 import database.persistence.TobyCoinMarketPersistence
 import jakarta.persistence.EntityManager
+import jakarta.persistence.LockModeType
 import jakarta.persistence.PersistenceContext
 import jakarta.persistence.TypedQuery
 import org.springframework.stereotype.Repository
@@ -20,6 +21,14 @@ class DefaultTobyCoinMarketPersistence : TobyCoinMarketPersistence {
         )
         q.setParameter("guildId", guildId)
         return runCatching { q.singleResult }.getOrNull()
+    }
+
+    override fun getByGuildForUpdate(guildId: Long): TobyCoinMarketDto? {
+        return entityManager.find(
+            TobyCoinMarketDto::class.java,
+            guildId,
+            LockModeType.PESSIMISTIC_WRITE
+        )
     }
 
     override fun listAll(): List<TobyCoinMarketDto> {

--- a/database/src/main/kotlin/database/persistence/impl/DefaultUserPersistence.kt
+++ b/database/src/main/kotlin/database/persistence/impl/DefaultUserPersistence.kt
@@ -3,6 +3,7 @@ package database.persistence.impl
 import database.dto.UserDto
 import database.persistence.UserPersistence
 import jakarta.persistence.EntityManager
+import jakarta.persistence.LockModeType
 import jakarta.persistence.PersistenceContext
 import jakarta.persistence.Query
 import jakarta.persistence.TypedQuery
@@ -32,6 +33,15 @@ class DefaultUserPersistence : UserPersistence {
         userQuery.setParameter("discordId", discordId)
         userQuery.setParameter("guildId", guildId)
         return runCatching { userQuery.singleResult as UserDto? }.getOrNull()
+    }
+
+    override fun getUserByIdForUpdate(discordId: Long?, guildId: Long?): UserDto? {
+        val q: TypedQuery<UserDto> = entityManager
+            .createNamedQuery("UserDto.getById", UserDto::class.java)
+            .setLockMode(LockModeType.PESSIMISTIC_WRITE)
+        q.setParameter("discordId", discordId)
+        q.setParameter("guildId", guildId)
+        return runCatching { q.singleResult }.getOrNull()
     }
 
     override fun updateUser(userDto: UserDto): UserDto {

--- a/database/src/main/kotlin/database/service/EconomyTradeService.kt
+++ b/database/src/main/kotlin/database/service/EconomyTradeService.kt
@@ -5,6 +5,7 @@ import database.dto.TobyCoinPricePointDto
 import database.dto.UserDto
 import database.economy.TobyCoinEngine
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 import java.time.Instant
 import kotlin.math.ceil
 import kotlin.math.floor
@@ -21,6 +22,7 @@ import kotlin.math.floor
  * form suits (Discord embed, web JSON, etc.).
  */
 @Service
+@Transactional
 class EconomyTradeService(
     private val userService: UserService,
     private val marketService: TobyCoinMarketService
@@ -59,8 +61,10 @@ class EconomyTradeService(
 
     fun buy(discordId: Long, guildId: Long, amount: Long): TradeOutcome {
         if (amount <= 0) return TradeOutcome.InvalidAmount
-        val user = userService.getUserById(discordId, guildId) ?: return TradeOutcome.UnknownUser
-        val market = loadOrCreateMarket(guildId)
+        // Lock order — user first, then market. Same in sell() to avoid deadlock.
+        val user = userService.getUserByIdForUpdate(discordId, guildId)
+            ?: return TradeOutcome.UnknownUser
+        val market = loadOrCreateMarketForUpdate(guildId)
 
         val cost = ceil(market.price * amount).toLong()
         val credits = user.socialCredit ?: 0L
@@ -84,8 +88,10 @@ class EconomyTradeService(
 
     fun sell(discordId: Long, guildId: Long, amount: Long): TradeOutcome {
         if (amount <= 0) return TradeOutcome.InvalidAmount
-        val user = userService.getUserById(discordId, guildId) ?: return TradeOutcome.UnknownUser
-        val market = loadOrCreateMarket(guildId)
+        // Lock order — user first, then market. Same in buy() to avoid deadlock.
+        val user = userService.getUserByIdForUpdate(discordId, guildId)
+            ?: return TradeOutcome.UnknownUser
+        val market = loadOrCreateMarketForUpdate(guildId)
 
         if (user.tobyCoins < amount) return TradeOutcome.InsufficientCoins(amount, user.tobyCoins)
 
@@ -104,6 +110,16 @@ class EconomyTradeService(
             newCredits = user.socialCredit ?: 0L,
             newPrice = newPrice
         )
+    }
+
+    // Seed the market row if missing, then re-read it with a write lock. Only
+    // the first trade for a brand-new guild hits the seed branch; after that
+    // `getMarketForUpdate` finds the row immediately.
+    private fun loadOrCreateMarketForUpdate(guildId: Long): TobyCoinMarketDto {
+        marketService.getMarketForUpdate(guildId)?.let { return it }
+        loadOrCreateMarket(guildId)
+        return marketService.getMarketForUpdate(guildId)
+            ?: error("Market row for guild $guildId could not be locked after creation")
     }
 
     private fun commitPriceChange(market: TobyCoinMarketDto, newPrice: Double) {

--- a/database/src/main/kotlin/database/service/SocialCreditAwardService.kt
+++ b/database/src/main/kotlin/database/service/SocialCreditAwardService.kt
@@ -1,0 +1,84 @@
+package database.service
+
+import database.dto.VoiceCreditDailyDto
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneOffset
+
+/**
+ * Single entry point for awarding positive social credit. All award paths
+ * (command completion, voice-session, intro playback, web UI participation)
+ * route through here so the daily cap accounting and cache invalidation stay
+ * in one place.
+ */
+@Service
+@Transactional
+class SocialCreditAwardService(
+    private val userService: UserService,
+    private val voiceCreditDailyService: VoiceCreditDailyService
+) {
+    /**
+     * Add [amount] credits to the user, respecting the daily cap when
+     * [countsAgainstDailyCap] is true. Returns the amount that was actually
+     * granted (clamped to remaining daily headroom). No-ops and returns 0 for
+     * non-positive [amount] or unknown users.
+     */
+    fun award(
+        discordId: Long,
+        guildId: Long,
+        amount: Long,
+        reason: String,
+        countsAgainstDailyCap: Boolean = true,
+        at: Instant = Instant.now(),
+        dailyCap: Long = DEFAULT_DAILY_CAP,
+    ): Long {
+        if (amount <= 0L) return 0L
+
+        // Resolve the user first so we never debit the daily cap for a phantom
+        // award to a user that doesn't exist.
+        val user = userService.getUserById(discordId, guildId) ?: return 0L
+
+        val granted = if (countsAgainstDailyCap) {
+            clampToDailyCap(discordId, guildId, amount, at, dailyCap)
+        } else {
+            amount
+        }
+        if (granted <= 0L) return 0L
+
+        user.socialCredit = (user.socialCredit ?: 0L) + granted
+        userService.updateUser(user)
+        return granted
+    }
+
+    private fun clampToDailyCap(
+        discordId: Long,
+        guildId: Long,
+        requested: Long,
+        at: Instant,
+        dailyCap: Long
+    ): Long {
+        val today = LocalDate.ofInstant(at, ZoneOffset.UTC)
+        val existing = voiceCreditDailyService.get(discordId, guildId, today)
+        val usedToday = existing?.credits ?: 0L
+        val headroom = (dailyCap - usedToday).coerceAtLeast(0L)
+        val granted = requested.coerceAtMost(headroom)
+        if (granted > 0L) {
+            voiceCreditDailyService.upsert(
+                VoiceCreditDailyDto(
+                    discordId = discordId,
+                    guildId = guildId,
+                    earnDate = today,
+                    credits = usedToday + granted
+                )
+            )
+        }
+        return granted
+    }
+
+    companion object {
+        // Matches the voice credit cap so all daily-capped sources share one bucket.
+        const val DEFAULT_DAILY_CAP: Long = 60L
+    }
+}

--- a/database/src/main/kotlin/database/service/TobyCoinMarketService.kt
+++ b/database/src/main/kotlin/database/service/TobyCoinMarketService.kt
@@ -6,6 +6,10 @@ import java.time.Instant
 
 interface TobyCoinMarketService {
     fun getMarket(guildId: Long): TobyCoinMarketDto?
+
+    // Non-cached pessimistic-lock read — must run inside @Transactional.
+    fun getMarketForUpdate(guildId: Long): TobyCoinMarketDto?
+
     fun listMarkets(): List<TobyCoinMarketDto>
     fun saveMarket(market: TobyCoinMarketDto): TobyCoinMarketDto
 

--- a/database/src/main/kotlin/database/service/UserService.kt
+++ b/database/src/main/kotlin/database/service/UserService.kt
@@ -6,6 +6,10 @@ interface UserService {
     fun listGuildUsers(guildId: Long?): List<UserDto?>
     fun createNewUser(userDto: UserDto): UserDto
     fun getUserById(discordId: Long?, guildId: Long?): UserDto?
+
+    // Non-cached pessimistic-lock read — must run inside @Transactional.
+    fun getUserByIdForUpdate(discordId: Long?, guildId: Long?): UserDto?
+
     fun updateUser(userDto: UserDto): UserDto?
     fun deleteUser(userDto: UserDto)
     fun deleteUserById(discordId: Long?, guildId: Long?)

--- a/database/src/main/kotlin/database/service/impl/DefaultTobyCoinMarketService.kt
+++ b/database/src/main/kotlin/database/service/impl/DefaultTobyCoinMarketService.kt
@@ -24,6 +24,11 @@ class DefaultTobyCoinMarketService : TobyCoinMarketService {
         return marketPersistence.getByGuild(guildId)
     }
 
+    // Bypass cache deliberately: the trade path needs a fresh DB row + row lock.
+    override fun getMarketForUpdate(guildId: Long): TobyCoinMarketDto? {
+        return marketPersistence.getByGuildForUpdate(guildId)
+    }
+
     override fun listMarkets(): List<TobyCoinMarketDto> {
         return marketPersistence.listAll()
     }

--- a/database/src/main/kotlin/database/service/impl/DefaultUserService.kt
+++ b/database/src/main/kotlin/database/service/impl/DefaultUserService.kt
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.cache.annotation.CacheEvict
 import org.springframework.cache.annotation.CachePut
 import org.springframework.cache.annotation.Cacheable
+import org.springframework.cache.annotation.Caching
 import org.springframework.stereotype.Service
 
 @Service
@@ -14,32 +15,49 @@ class DefaultUserService : UserService {
     @Autowired
     private lateinit var userService: UserPersistence
 
-    @Cacheable(value = ["users"])
+    @Cacheable(value = ["users"], key = "'list-' + #a0")
     override fun listGuildUsers(guildId: Long?): List<UserDto?> {
         return userService.listGuildUsers(guildId)
     }
 
-    @CachePut(value = ["users"], key = "#userDto.discordId+#userDto.guildId")
+    @Caching(
+        put = [CachePut(value = ["users"], key = "#a0.discordId + #a0.guildId")],
+        evict = [CacheEvict(value = ["users"], key = "'list-' + #a0.guildId")]
+    )
     override fun createNewUser(userDto: UserDto): UserDto {
         return userService.createNewUser(userDto)
     }
 
-    @CachePut(value = ["users"], key = "#discordId+#guildId")
+    @CachePut(value = ["users"], key = "#a0 + #a1")
     override fun getUserById(discordId: Long?, guildId: Long?): UserDto? {
         return userService.getUserById(discordId, guildId)
     }
 
-    @CachePut(value = ["users"], key = "#userDto.discordId+#userDto.guildId")
+    // Bypass cache deliberately: the trade path needs a fresh DB row + row lock.
+    override fun getUserByIdForUpdate(discordId: Long?, guildId: Long?): UserDto? {
+        return userService.getUserByIdForUpdate(discordId, guildId)
+    }
+
+    @Caching(
+        put = [CachePut(value = ["users"], key = "#a0.discordId + #a0.guildId")],
+        evict = [CacheEvict(value = ["users"], key = "'list-' + #a0.guildId")]
+    )
     override fun updateUser(userDto: UserDto): UserDto {
         return userService.updateUser(userDto)
     }
 
-    @CacheEvict(value = ["users"], key = "#userDto.discordId+#userDto.guildId")
+    @Caching(evict = [
+        CacheEvict(value = ["users"], key = "#a0.discordId + #a0.guildId"),
+        CacheEvict(value = ["users"], key = "'list-' + #a0.guildId")
+    ])
     override fun deleteUser(userDto: UserDto) {
         userService.deleteUser(userDto)
     }
 
-    @CacheEvict(value = ["users"], key = "#discordId+#guildId")
+    @Caching(evict = [
+        CacheEvict(value = ["users"], key = "#a0 + #a1"),
+        CacheEvict(value = ["users"], key = "'list-' + #a1")
+    ])
     override fun deleteUserById(discordId: Long?, guildId: Long?) {
         userService.deleteUserById(discordId, guildId)
     }
@@ -48,7 +66,7 @@ class DefaultUserService : UserService {
     override fun clearCache() {
     }
 
-    @CacheEvict(value = ["users"], key = "#discordId+#guildId")
+    @CacheEvict(value = ["users"], key = "#a0 + #a1")
     override fun evictUserFromCache(discordId: Long?, guildId: Long?) {
     }
 }

--- a/database/src/test/kotlin/database/economy/TobyCoinEngineTest.kt
+++ b/database/src/test/kotlin/database/economy/TobyCoinEngineTest.kt
@@ -43,4 +43,30 @@ internal class TobyCoinEngineTest {
         val result = TobyCoinEngine.applySellPressure(2.0, 1_000_000L)
         assertEquals(TobyCoinEngine.PRICE_FLOOR, result, 1e-9)
     }
+
+    /**
+     * Regression guard: with DRIFT=0 the lognormal Itô correction made the
+     * median of many ticks decay, so users saw charts that "only went down".
+     * Drift is now set so the median step is zero — a Monte-Carlo run should
+     * land the median trajectory very close to where it started.
+     */
+    @Test
+    fun `median of many ticks stays close to the starting price`() {
+        val runs = 5_000
+        val ticksPerRun = 200
+        val startPrice = 100.0
+        val rng = Random(20260424L)
+
+        val finals = DoubleArray(runs) {
+            var price = startPrice
+            repeat(ticksPerRun) { price = TobyCoinEngine.tickRandomWalk(price, random = rng) }
+            price
+        }.also { it.sort() }
+
+        val median = finals[finals.size / 2]
+        assertTrue(
+            median in 85.0..115.0,
+            "median final price after $ticksPerRun ticks should stay near $startPrice but was $median"
+        )
+    }
 }

--- a/database/src/test/kotlin/database/service/SocialCreditAwardServiceTest.kt
+++ b/database/src/test/kotlin/database/service/SocialCreditAwardServiceTest.kt
@@ -1,0 +1,149 @@
+package database.service
+
+import database.dto.UserDto
+import database.dto.VoiceCreditDailyDto
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneOffset
+
+class SocialCreditAwardServiceTest {
+
+    private val discordId = 1L
+    private val guildId = 42L
+    private val now: Instant = Instant.parse("2026-04-10T10:00:00Z")
+    private val today: LocalDate = LocalDate.ofInstant(now, ZoneOffset.UTC)
+
+    private lateinit var userService: RecordingUserService
+    private lateinit var dailyService: InMemoryVoiceCreditDailyService
+    private lateinit var service: SocialCreditAwardService
+
+    @BeforeEach
+    fun setup() {
+        userService = RecordingUserService()
+        dailyService = InMemoryVoiceCreditDailyService()
+        service = SocialCreditAwardService(userService, dailyService)
+    }
+
+    @Test
+    fun `award adds credits and persists via updateUser`() {
+        userService.seed(UserDto(discordId, guildId).apply { socialCredit = 10L })
+
+        val granted = service.award(discordId, guildId, amount = 5L, reason = "test", at = now)
+
+        assertEquals(5L, granted)
+        assertEquals(15L, userService.current(discordId, guildId)?.socialCredit)
+        assertEquals(1, userService.updateCount)
+    }
+
+    @Test
+    fun `award returns zero and no-ops for non-positive amounts`() {
+        userService.seed(UserDto(discordId, guildId).apply { socialCredit = 10L })
+
+        assertEquals(0L, service.award(discordId, guildId, amount = 0L, reason = "test", at = now))
+        assertEquals(0L, service.award(discordId, guildId, amount = -3L, reason = "test", at = now))
+
+        assertEquals(10L, userService.current(discordId, guildId)?.socialCredit)
+        assertEquals(0, userService.updateCount)
+    }
+
+    @Test
+    fun `award respects the daily cap and consumes the remaining headroom only`() {
+        userService.seed(UserDto(discordId, guildId).apply { socialCredit = 0L })
+        // 55/60 already used today.
+        dailyService.upsert(VoiceCreditDailyDto(discordId, guildId, today, credits = 55L))
+
+        val granted = service.award(discordId, guildId, amount = 20L, reason = "test", at = now)
+
+        assertEquals(5L, granted, "only 5 credits of headroom remain under the default cap")
+        assertEquals(5L, userService.current(discordId, guildId)?.socialCredit)
+        assertEquals(60L, dailyService.get(discordId, guildId, today)?.credits)
+    }
+
+    @Test
+    fun `award with countsAgainstDailyCap false bypasses the cap and the ledger`() {
+        userService.seed(UserDto(discordId, guildId).apply { socialCredit = 0L })
+        dailyService.upsert(VoiceCreditDailyDto(discordId, guildId, today, credits = 60L)) // capped
+
+        val granted = service.award(
+            discordId, guildId,
+            amount = 10L,
+            reason = "test",
+            countsAgainstDailyCap = false,
+            at = now
+        )
+
+        assertEquals(10L, granted, "uncapped award should pass through the full amount")
+        assertEquals(10L, userService.current(discordId, guildId)?.socialCredit)
+        assertEquals(60L, dailyService.get(discordId, guildId, today)?.credits, "ledger untouched")
+    }
+
+    @Test
+    fun `award returns zero and does not consume the cap when user row is missing`() {
+        // No seed → unknown user.
+        val granted = service.award(discordId, guildId, amount = 5L, reason = "test", at = now)
+
+        assertEquals(0L, granted)
+        assertEquals(0, userService.updateCount)
+        assertEquals(null, dailyService.get(discordId, guildId, today), "ledger must not be charged for phantom award")
+    }
+
+    @Test
+    fun `award with a custom dailyCap overrides the default`() {
+        userService.seed(UserDto(discordId, guildId).apply { socialCredit = 0L })
+
+        val granted = service.award(discordId, guildId, amount = 100L, reason = "test", at = now, dailyCap = 7L)
+
+        assertEquals(7L, granted)
+        assertEquals(7L, userService.current(discordId, guildId)?.socialCredit)
+        assertEquals(7L, dailyService.get(discordId, guildId, today)?.credits)
+    }
+
+    private class RecordingUserService : UserService {
+        private val users = mutableMapOf<Pair<Long, Long>, UserDto>()
+        var updateCount: Int = 0
+            private set
+
+        fun seed(dto: UserDto) {
+            users[dto.discordId to dto.guildId] = dto
+        }
+
+        fun current(discordId: Long, guildId: Long): UserDto? = users[discordId to guildId]
+
+        override fun listGuildUsers(guildId: Long?): List<UserDto?> =
+            users.values.filter { it.guildId == guildId }
+
+        override fun createNewUser(userDto: UserDto): UserDto = userDto.also(::seed)
+
+        override fun getUserById(discordId: Long?, guildId: Long?): UserDto? =
+            users[discordId!! to guildId!!]
+
+        override fun getUserByIdForUpdate(discordId: Long?, guildId: Long?): UserDto? =
+            getUserById(discordId, guildId)
+
+        override fun updateUser(userDto: UserDto): UserDto {
+            updateCount++
+            seed(userDto)
+            return userDto
+        }
+
+        override fun deleteUser(userDto: UserDto) { users.remove(userDto.discordId to userDto.guildId) }
+        override fun deleteUserById(discordId: Long?, guildId: Long?) { users.remove(discordId!! to guildId!!) }
+        override fun clearCache() {}
+        override fun evictUserFromCache(discordId: Long?, guildId: Long?) {}
+    }
+
+    private class InMemoryVoiceCreditDailyService : VoiceCreditDailyService {
+        private val rows = mutableMapOf<Triple<Long, Long, LocalDate>, VoiceCreditDailyDto>()
+
+        override fun get(discordId: Long, guildId: Long, date: LocalDate): VoiceCreditDailyDto? =
+            rows[Triple(discordId, guildId, date)]
+
+        override fun upsert(row: VoiceCreditDailyDto): VoiceCreditDailyDto {
+            rows[Triple(row.discordId, row.guildId, row.earnDate)] = row
+            return row
+        }
+    }
+}

--- a/database/src/test/kotlin/database/service/impl/DefaultUserServiceCacheTest.kt
+++ b/database/src/test/kotlin/database/service/impl/DefaultUserServiceCacheTest.kt
@@ -1,0 +1,154 @@
+package database.service.impl
+
+import database.dto.UserDto
+import database.persistence.UserPersistence
+import database.service.UserService
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.cache.CacheManager
+import org.springframework.cache.annotation.EnableCaching
+import org.springframework.cache.concurrent.ConcurrentMapCache
+import org.springframework.cache.support.SimpleCacheManager
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Import
+import org.springframework.test.annotation.DirtiesContext
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Regression tests for the user cache. A write through any of the mutating methods on
+ * [DefaultUserService] must evict the cached `listGuildUsers` result for that guild —
+ * otherwise `ModerationWebService.getGuildOverview` serves a stale list after
+ * `adjustSocialCredit`, exactly the "applying social credit doesn't update on refresh" bug.
+ */
+@ExtendWith(SpringExtension::class)
+@ContextConfiguration(classes = [DefaultUserServiceCacheTest.TestContext::class])
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+class DefaultUserServiceCacheTest {
+
+    @Autowired
+    private lateinit var userService: UserService
+
+    @Autowired
+    private lateinit var persistence: CountingUserPersistence
+
+    @BeforeEach
+    fun reset() {
+        persistence.reset()
+        userService.clearCache()
+    }
+
+    @Test
+    fun `listGuildUsers is cached between reads for the same guild`() {
+        userService.listGuildUsers(GUILD_ID)
+        userService.listGuildUsers(GUILD_ID)
+        userService.listGuildUsers(GUILD_ID)
+
+        assertEquals(1, persistence.listCalls.get(), "second & third read should be served from cache")
+    }
+
+    @Test
+    fun `updateUser evicts the guild-user list cache`() {
+        userService.listGuildUsers(GUILD_ID)
+        assertEquals(1, persistence.listCalls.get())
+
+        userService.updateUser(UserDto(discordId = USER_ID, guildId = GUILD_ID))
+
+        userService.listGuildUsers(GUILD_ID)
+        assertEquals(2, persistence.listCalls.get(), "list cache must be evicted on updateUser")
+    }
+
+    @Test
+    fun `createNewUser evicts the guild-user list cache`() {
+        userService.listGuildUsers(GUILD_ID)
+        assertEquals(1, persistence.listCalls.get())
+
+        userService.createNewUser(UserDto(discordId = 99L, guildId = GUILD_ID))
+
+        userService.listGuildUsers(GUILD_ID)
+        assertEquals(2, persistence.listCalls.get(), "list cache must be evicted on createNewUser")
+    }
+
+    @Test
+    fun `deleteUser evicts the guild-user list cache`() {
+        userService.listGuildUsers(GUILD_ID)
+        assertEquals(1, persistence.listCalls.get())
+
+        userService.deleteUser(UserDto(discordId = USER_ID, guildId = GUILD_ID))
+
+        userService.listGuildUsers(GUILD_ID)
+        assertEquals(2, persistence.listCalls.get(), "list cache must be evicted on deleteUser")
+    }
+
+    @Test
+    fun `deleteUserById evicts the guild-user list cache`() {
+        userService.listGuildUsers(GUILD_ID)
+        assertEquals(1, persistence.listCalls.get())
+
+        userService.deleteUserById(USER_ID, GUILD_ID)
+
+        userService.listGuildUsers(GUILD_ID)
+        assertEquals(2, persistence.listCalls.get(), "list cache must be evicted on deleteUserById")
+    }
+
+    @Test
+    fun `list cache for one guild is not evicted when a different guild is mutated`() {
+        userService.listGuildUsers(GUILD_ID)
+        userService.listGuildUsers(OTHER_GUILD_ID)
+        assertEquals(2, persistence.listCalls.get())
+
+        userService.updateUser(UserDto(discordId = USER_ID, guildId = OTHER_GUILD_ID))
+
+        userService.listGuildUsers(GUILD_ID)
+        assertEquals(2, persistence.listCalls.get(), "GUILD_ID list should still be cached")
+
+        userService.listGuildUsers(OTHER_GUILD_ID)
+        assertEquals(3, persistence.listCalls.get(), "OTHER_GUILD_ID list should be evicted")
+    }
+
+    companion object {
+        private const val GUILD_ID = 42L
+        private const val OTHER_GUILD_ID = 43L
+        private const val USER_ID = 1L
+    }
+
+    @Configuration
+    @EnableCaching
+    @Import(DefaultUserService::class)
+    open class TestContext {
+
+        @Bean
+        open fun userPersistence(): CountingUserPersistence = CountingUserPersistence()
+
+        @Bean
+        open fun cacheManager(): CacheManager = SimpleCacheManager().apply {
+            setCaches(listOf(ConcurrentMapCache("users")))
+            initializeCaches()
+        }
+    }
+
+    class CountingUserPersistence : UserPersistence {
+        val listCalls = AtomicInteger(0)
+
+        fun reset() {
+            listCalls.set(0)
+        }
+
+        override fun listGuildUsers(guildId: Long?): List<UserDto?> {
+            listCalls.incrementAndGet()
+            return emptyList()
+        }
+
+        override fun createNewUser(userDto: UserDto): UserDto = userDto
+        override fun getUserById(discordId: Long?, guildId: Long?): UserDto? = null
+        override fun getUserByIdForUpdate(discordId: Long?, guildId: Long?): UserDto? = null
+        override fun updateUser(userDto: UserDto): UserDto = userDto
+        override fun deleteUser(userDto: UserDto) {}
+        override fun deleteUserById(discordId: Long?, guildId: Long?) {}
+    }
+}

--- a/database/src/test/kotlin/database/service/impl/DefaultUserServiceCacheTest.kt
+++ b/database/src/test/kotlin/database/service/impl/DefaultUserServiceCacheTest.kt
@@ -8,12 +8,12 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.cache.CacheManager
 import org.springframework.cache.annotation.EnableCaching
 import org.springframework.cache.concurrent.ConcurrentMapCache
 import org.springframework.cache.support.SimpleCacheManager
 import org.springframework.context.annotation.Bean
-import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Import
 import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.context.ContextConfiguration
@@ -117,7 +117,11 @@ class DefaultUserServiceCacheTest {
         private const val USER_ID = 1L
     }
 
-    @Configuration
+    // @TestConfiguration (not @Configuration) so Spring Boot's component scan
+    // excludes this class from the main Application context. Otherwise the
+    // cacheManager bean here would collide with TestCachingConfig's when this
+    // test's compiled output is on the classpath via the :database testArtifacts.
+    @TestConfiguration
     @EnableCaching
     @Import(DefaultUserService::class)
     open class TestContext {

--- a/database/src/test/kotlin/database/service/impl/DefaultUserServiceCacheTest.kt
+++ b/database/src/test/kotlin/database/service/impl/DefaultUserServiceCacheTest.kt
@@ -15,10 +15,14 @@ import org.springframework.cache.concurrent.ConcurrentMapCache
 import org.springframework.cache.support.SimpleCacheManager
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Import
+import org.springframework.context.annotation.Profile
 import org.springframework.test.annotation.DirtiesContext
+import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.ContextConfiguration
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import java.util.concurrent.atomic.AtomicInteger
+
+private const val CACHE_EVICTION_TEST_PROFILE = "cache-eviction-unit-test"
 
 /**
  * Regression tests for the user cache. A write through any of the mutating methods on
@@ -28,6 +32,7 @@ import java.util.concurrent.atomic.AtomicInteger
  */
 @ExtendWith(SpringExtension::class)
 @ContextConfiguration(classes = [DefaultUserServiceCacheTest.TestContext::class])
+@ActiveProfiles(CACHE_EVICTION_TEST_PROFILE)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 class DefaultUserServiceCacheTest {
 
@@ -117,11 +122,13 @@ class DefaultUserServiceCacheTest {
         private const val USER_ID = 1L
     }
 
-    // @TestConfiguration (not @Configuration) so Spring Boot's component scan
-    // excludes this class from the main Application context. Otherwise the
-    // cacheManager bean here would collide with TestCachingConfig's when this
-    // test's compiled output is on the classpath via the :database testArtifacts.
+    // Guarded by an isolated profile so this nested config never activates
+    // in the main Application context (loaded from :database testArtifacts by
+    // downstream test modules). Without the profile, the `cacheManager` bean
+    // below collides with TestCachingConfig's and throws BeanDefinitionOverrideException
+    // across every @SpringBootTest in :application.
     @TestConfiguration
+    @Profile(CACHE_EVICTION_TEST_PROFILE)
     @EnableCaching
     @Import(DefaultUserService::class)
     open class TestContext {

--- a/discord-bot/src/main/kotlin/bot/configuration/ManagerConfig.kt
+++ b/discord-bot/src/main/kotlin/bot/configuration/ManagerConfig.kt
@@ -13,6 +13,7 @@ import core.managers.CommandManager
 import core.managers.MenuManager
 import core.menu.Menu
 import database.service.ConfigService
+import database.service.SocialCreditAwardService
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Profile
@@ -25,11 +26,13 @@ class ManagerConfig {
     fun commandManager(
         configService: ConfigService,
         userDtoHelper: UserDtoHelper,
+        awardService: SocialCreditAwardService,
         commandList: List<core.command.Command>
     ): CommandManager {
         return DefaultCommandManager(
             configService,
             userDtoHelper,
+            awardService,
             commandList
         )
     }

--- a/discord-bot/src/main/kotlin/bot/toby/handler/VoiceEventHandler.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/handler/VoiceEventHandler.kt
@@ -42,12 +42,6 @@ class VoiceEventHandler @Autowired constructor(
     private val awardService: SocialCreditAwardService
 ) : ListenerAdapter() {
 
-    companion object {
-        // Small, daily-capped reward so joining a channel with an intro set
-        // feels like something without becoming farmable via rejoin spam.
-        const val INTRO_PLAY_CREDIT: Long = 2L
-    }
-
     private val logger: DiscordLogger = DiscordLogger.createLogger(this::class.java)
 
     override fun onReady(event: ReadyEvent) {
@@ -285,5 +279,9 @@ class VoiceEventHandler @Autowired constructor(
 
     companion object {
         val lastConnectedChannel = ConcurrentHashMap<Long, VoiceChannel>()
+
+        // Small, daily-capped reward so joining a channel with an intro set
+        // feels like something without becoming farmable via rejoin spam.
+        const val INTRO_PLAY_CREDIT: Long = 2L
     }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/handler/VoiceEventHandler.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/handler/VoiceEventHandler.kt
@@ -13,6 +13,7 @@ import database.dto.ConfigDto.Configurations.DELETE_DELAY
 import database.dto.ConfigDto.Configurations.VOLUME
 import database.dto.VoiceSessionDto
 import database.service.ConfigService
+import database.service.SocialCreditAwardService
 import database.service.VoiceSessionService
 import bot.toby.helpers.MusicPlayerHelper
 import net.dv8tion.jda.api.entities.Guild
@@ -37,8 +38,15 @@ class VoiceEventHandler @Autowired constructor(
     private val introHelper: IntroHelper,
     private val voiceSessionService: VoiceSessionService,
     private val voiceCompanyTracker: VoiceCompanyTracker,
-    private val voiceCreditAwardService: VoiceCreditAwardService
+    private val voiceCreditAwardService: VoiceCreditAwardService,
+    private val awardService: SocialCreditAwardService
 ) : ListenerAdapter() {
+
+    companion object {
+        // Small, daily-capped reward so joining a channel with an intro set
+        // feels like something without becoming farmable via rejoin spam.
+        const val INTRO_PLAY_CREDIT: Long = 2L
+    }
 
     private val logger: DiscordLogger = DiscordLogger.createLogger(this::class.java)
 
@@ -201,6 +209,12 @@ class VoiceEventHandler @Autowired constructor(
                 guild,
                 deleteDelay = deleteDelay,
                 member = member
+            )
+            awardService.award(
+                discordId = requestingUserDto.discordId,
+                guildId = requestingUserDto.guildId,
+                amount = INTRO_PLAY_CREDIT,
+                reason = "intro-play"
             )
         } else {
             logger.info { "User has no musicDto associated with them, no intro will be played" }

--- a/discord-bot/src/main/kotlin/bot/toby/managers/DefaultCommandManager.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/managers/DefaultCommandManager.kt
@@ -14,6 +14,7 @@ import core.managers.CommandManager
 import database.dto.ConfigDto
 import database.dto.UserDto
 import database.service.ConfigService
+import database.service.SocialCreditAwardService
 import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
 import net.dv8tion.jda.api.interactions.commands.build.CommandData
@@ -25,6 +26,7 @@ import java.util.*
 class DefaultCommandManager @Autowired constructor(
     private val configService: ConfigService,
     private val userDtoHelper: UserDtoHelper,
+    private val awardService: SocialCreditAwardService,
     override val commands: List<Command>
 ) : CommandManager {
     override val slashCommands: MutableList<CommandData?> = ArrayList()
@@ -90,23 +92,21 @@ class DefaultCommandManager @Autowired constructor(
             val ctx = DefaultCommandContext(event)
             lastCommands[event.guild!!] = Pair(it, ctx)
             requestingUserDto?.let { userDto ->
+                // Award before dispatch so a throwing command still earns credit
+                // and so all user-initiated actions share the same hook point.
+                awardCommandCredit(userDto, invoke)
                 it.handle(ctx, userDto, deleteDelay)
-                attributeSocialCredit(ctx, userDtoHelper, userDto, deleteDelay)
             }
         }
     }
 
-    private fun attributeSocialCredit(
-        ctx: CommandContext,
-        userDtoHelper: UserDtoHelper,
-        requestingUserDto: UserDto,
-        deleteDelay: Int
-    ) {
-        val socialCreditScore = requestingUserDto.socialCredit
-        val r = Random()
-        val socialCredit = r.nextInt(5)
-        val awardedSocialCredit = socialCredit * 5
-        requestingUserDto.socialCredit = socialCreditScore?.plus(awardedSocialCredit)
-        userDtoHelper.updateUser(requestingUserDto)
+    private fun awardCommandCredit(userDto: UserDto, invoke: String) {
+        val amount = Random().nextInt(5) * 5L
+        awardService.award(
+            discordId = userDto.discordId,
+            guildId = userDto.guildId,
+            amount = amount,
+            reason = "command:$invoke"
+        )
     }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/scheduling/TobyCoinPriceTickJob.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/scheduling/TobyCoinPriceTickJob.kt
@@ -29,6 +29,11 @@ class TobyCoinPriceTickJob @Autowired constructor(
 ) {
     private val logger: DiscordLogger = DiscordLogger.createLogger(this::class.java)
 
+    // Single long-lived PRNG. Reseeding per tick with predictable seeds
+    // (epoch-ms xor guildId) biases consecutive outputs; letting the state
+    // evolve naturally gives an honest random walk.
+    private val random: Random = Random.Default
+
     companion object {
         // Kept long enough that the /economy 1Y view always has real data
         // to draw. Pruning older samples still protects the table from
@@ -53,10 +58,7 @@ class TobyCoinPriceTickJob @Autowired constructor(
             price = TobyCoinEngine.INITIAL_PRICE,
             lastTickAt = now
         )
-        // Seed the walk from epoch-millis xor'd with the guild id so each
-        // guild's market moves independently and every tick is a fresh draw.
-        val seed = now.toEpochMilli() xor guildId
-        val newPrice = TobyCoinEngine.tickRandomWalk(market.price, random = Random(seed))
+        val newPrice = TobyCoinEngine.tickRandomWalk(market.price, random = random)
         market.price = newPrice
         market.lastTickAt = now
         marketService.saveMarket(market)

--- a/discord-bot/src/main/kotlin/bot/toby/voice/VoiceCreditAwardService.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/voice/VoiceCreditAwardService.kt
@@ -1,23 +1,18 @@
 package bot.toby.voice
 
 import common.logging.DiscordLogger
-import database.dto.VoiceCreditDailyDto
 import database.dto.VoiceSessionDto
-import database.service.UserService
-import database.service.VoiceCreditDailyService
+import database.service.SocialCreditAwardService
 import database.service.VoiceSessionService
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
 import java.time.Duration
 import java.time.Instant
-import java.time.LocalDate
-import java.time.ZoneOffset
 
 @Service
 class VoiceCreditAwardService @Autowired constructor(
     private val voiceSessionService: VoiceSessionService,
-    private val voiceCreditDailyService: VoiceCreditDailyService,
-    private val userService: UserService
+    private val awardService: SocialCreditAwardService
 ) {
     private val logger: DiscordLogger = DiscordLogger.createLogger(this::class.java)
 
@@ -29,26 +24,29 @@ class VoiceCreditAwardService @Autowired constructor(
         val rawSeconds = Duration.between(session.joinedAt, closedAt).seconds.coerceAtLeast(0)
         val countedSeconds = hadCompanyDurationSeconds.coerceIn(0, rawSeconds)
         val rawCredits = countedSeconds / VoiceCreditConfig.SECONDS_PER_CREDIT
-        val awardedCredits = clampToDailyCap(session.discordId, session.guildId, rawCredits, closedAt)
+
+        val awardedCredits = awardService.award(
+            discordId = session.discordId,
+            guildId = session.guildId,
+            amount = rawCredits,
+            reason = "voice-session",
+            at = closedAt,
+            dailyCap = VoiceCreditConfig.DAILY_CREDIT_CAP
+        )
 
         session.leftAt = closedAt
         session.countedSeconds = countedSeconds
         session.creditsAwarded = awardedCredits
         voiceSessionService.closeSession(session)
 
-        if (awardedCredits > 0) {
-            val user = userService.getUserById(session.discordId, session.guildId)
-            if (user != null) {
-                user.socialCredit = (user.socialCredit ?: 0L) + awardedCredits
-                userService.updateUser(user)
-                logger.info {
-                    "Awarded $awardedCredits voice credits to user ${session.discordId} in guild ${session.guildId} " +
-                            "(counted=${countedSeconds}s, raw=${rawSeconds}s)"
-                }
-            } else {
-                logger.warn(
-                    "No user row for discordId=${session.discordId} guildId=${session.guildId}; skipped awarding"
-                )
+        if (rawCredits > 0 && awardedCredits == 0L) {
+            logger.warn(
+                "No user row for discordId=${session.discordId} guildId=${session.guildId}; skipped awarding"
+            )
+        } else if (awardedCredits > 0) {
+            logger.info {
+                "Awarded $awardedCredits voice credits to user ${session.discordId} in guild ${session.guildId} " +
+                        "(counted=${countedSeconds}s, raw=${rawSeconds}s)"
             }
         }
     }
@@ -57,25 +55,5 @@ class VoiceCreditAwardService @Autowired constructor(
         val rawSeconds = Duration.between(session.joinedAt, closedAt).seconds.coerceAtLeast(0)
         val cappedSeconds = rawSeconds.coerceAtMost(VoiceCreditConfig.MAX_RECOVERED_SESSION_SECONDS)
         closeSessionAndAward(session, closedAt, cappedSeconds)
-    }
-
-    private fun clampToDailyCap(discordId: Long, guildId: Long, newCredits: Long, at: Instant): Long {
-        if (newCredits <= 0) return 0L
-        val today = LocalDate.ofInstant(at, ZoneOffset.UTC)
-        val existing = voiceCreditDailyService.get(discordId, guildId, today)
-        val usedToday = existing?.credits ?: 0L
-        val headroom = (VoiceCreditConfig.DAILY_CREDIT_CAP - usedToday).coerceAtLeast(0L)
-        val granted = newCredits.coerceAtMost(headroom)
-        if (granted > 0) {
-            voiceCreditDailyService.upsert(
-                VoiceCreditDailyDto(
-                    discordId = discordId,
-                    guildId = guildId,
-                    earnDate = today,
-                    credits = usedToday + granted
-                )
-            )
-        }
-        return granted
     }
 }

--- a/discord-bot/src/test/kotlin/bot/toby/handler/StartUpHandlerTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/handler/StartUpHandlerTest.kt
@@ -2,6 +2,7 @@ import bot.toby.handler.StartUpHandler
 import bot.toby.helpers.UserDtoHelper
 import bot.toby.managers.DefaultCommandManager
 import database.service.ConfigService
+import database.service.SocialCreditAwardService
 import io.mockk.*
 import io.mockk.junit5.MockKExtension
 import net.dv8tion.jda.api.JDA
@@ -18,7 +19,8 @@ class StartUpHandlerTest {
     private val jda: JDA = mockk()
     private val configService: ConfigService = mockk()
     private val userDtoHelper: UserDtoHelper = mockk()
-    private val commandManager: DefaultCommandManager = DefaultCommandManager(configService, userDtoHelper, emptyList())
+    private val awardService: SocialCreditAwardService = mockk(relaxed = true)
+    private val commandManager: DefaultCommandManager = DefaultCommandManager(configService, userDtoHelper, awardService, emptyList())
     private val handler = spyk(
         StartUpHandler(
             commandManager

--- a/discord-bot/src/test/kotlin/bot/toby/handler/VoiceEventHandlerTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/handler/VoiceEventHandlerTest.kt
@@ -9,6 +9,7 @@ import bot.toby.voice.VoiceCreditAwardService
 import database.dto.ConfigDto
 import database.dto.MusicDto
 import database.service.ConfigService
+import database.service.SocialCreditAwardService
 import database.service.VoiceSessionService
 import io.mockk.*
 import io.mockk.junit5.MockKExtension
@@ -42,6 +43,7 @@ class VoiceEventHandlerTest {
     private val voiceSessionService: VoiceSessionService = mockk(relaxed = true)
     private val voiceCompanyTracker: VoiceCompanyTracker = mockk(relaxed = true)
     private val voiceCreditAwardService: VoiceCreditAwardService = mockk(relaxed = true)
+    private val awardService: SocialCreditAwardService = mockk(relaxed = true)
 
     private val handler = spyk(
         VoiceEventHandler(
@@ -50,7 +52,8 @@ class VoiceEventHandlerTest {
             introHelper,
             voiceSessionService,
             voiceCompanyTracker,
-            voiceCreditAwardService
+            voiceCreditAwardService,
+            awardService
         )
     )
 
@@ -125,7 +128,8 @@ class VoiceEventHandlerTest {
             introHelper = mockk(),
             voiceSessionService = mockk(relaxed = true),
             voiceCompanyTracker = mockk(relaxed = true),
-            voiceCreditAwardService = mockk(relaxed = true)
+            voiceCreditAwardService = mockk(relaxed = true),
+            awardService = mockk(relaxed = true)
         )
 
         handler.onReady(readyEvent)
@@ -445,5 +449,108 @@ class VoiceEventHandlerTest {
 
         unmockkObject(PlayerManager)
         unmockkObject(MusicPlayerHelper)
+    }
+
+    @Test
+    fun `intro play awards social credit via award service`() {
+        val guild = mockk<Guild>(relaxed = true)
+        val event = mockk<GuildVoiceUpdateEvent>(relaxed = true)
+        val audioManager = mockk<AudioManager>(relaxed = true)
+        val member = mockk<Member>(relaxed = true)
+        val channel = mockk<AudioChannelUnion>(relaxed = true)
+        val audioPlayerManager = mockk<PlayerManager>(relaxed = true)
+
+        every { event.guild } returns guild
+        every { event.jda.selfUser } returns selfUser
+        every { guild.audioManager } returns audioManager
+        every { event.member } returns member
+        every { event.channelJoined } returns channel
+        every { event.channelLeft } returns null
+        every { channel.members } returns listOf(member)
+        every { member.user.isBot } returns false
+        every { member.guild } returns guild
+        every { member.isOwner } returns false
+        every { member.idLong } returns 1L
+        every { member.user.idLong } returns 1L
+        every { guild.idLong } returns 7L
+        every { guild.id } returns "7"
+        every { audioManager.isConnected } returns false
+
+        mockkObject(PlayerManager)
+        every { PlayerManager.instance } returns audioPlayerManager
+
+        every { configService.getConfigByName(ConfigDto.Configurations.DELETE_DELAY.configValue, "7") } returns
+            ConfigDto().apply { value = "30" }
+        every { configService.getConfigByName(ConfigDto.Configurations.VOLUME.configValue, "7") } returns null
+        every { userDtoHelper.calculateUserDto(1L, 7L, false) } returns mockk(relaxed = true) {
+            every { discordId } returns 1L
+            every { guildId } returns 7L
+            every { musicDtos } returns listOf(mockk<MusicDto>(relaxed = true)).toMutableList()
+        }
+
+        handler.onGuildVoiceUpdate(event)
+
+        verify(exactly = 1) {
+            awardService.award(
+                discordId = 1L,
+                guildId = 7L,
+                amount = VoiceEventHandler.INTRO_PLAY_CREDIT,
+                reason = "intro-play"
+            )
+        }
+
+        unmockkObject(PlayerManager)
+    }
+
+    @Test
+    fun `no intro award when user has no musicDto`() {
+        val guild = mockk<Guild>(relaxed = true)
+        val event = mockk<GuildVoiceUpdateEvent>(relaxed = true)
+        val audioManager = mockk<AudioManager>(relaxed = true)
+        val member = mockk<Member>(relaxed = true)
+        val channel = mockk<AudioChannelUnion>(relaxed = true)
+        val audioPlayerManager = mockk<PlayerManager>(relaxed = true)
+
+        every { event.guild } returns guild
+        every { event.jda.selfUser } returns selfUser
+        every { guild.audioManager } returns audioManager
+        every { event.member } returns member
+        every { event.channelJoined } returns channel
+        every { event.channelLeft } returns null
+        every { channel.members } returns listOf(member)
+        every { member.user.isBot } returns false
+        every { member.guild } returns guild
+        every { member.isOwner } returns false
+        every { member.idLong } returns 1L
+        every { member.user.idLong } returns 1L
+        every { guild.idLong } returns 8L
+        every { guild.id } returns "8"
+        every { audioManager.isConnected } returns false
+
+        mockkObject(PlayerManager)
+        every { PlayerManager.instance } returns audioPlayerManager
+
+        every { configService.getConfigByName(ConfigDto.Configurations.DELETE_DELAY.configValue, "8") } returns
+            ConfigDto().apply { value = "30" }
+        every { configService.getConfigByName(ConfigDto.Configurations.VOLUME.configValue, "8") } returns null
+        every { introHelper.promptUserForMusicInfo(any(), any()) } just Runs
+        every { userDtoHelper.calculateUserDto(1L, 8L, false) } returns mockk(relaxed = true) {
+            every { discordId } returns 1L
+            every { guildId } returns 8L
+            every { musicDtos } returns mutableListOf()
+        }
+
+        handler.onGuildVoiceUpdate(event)
+
+        verify(exactly = 0) {
+            awardService.award(
+                discordId = any(),
+                guildId = any(),
+                amount = VoiceEventHandler.INTRO_PLAY_CREDIT,
+                reason = "intro-play"
+            )
+        }
+
+        unmockkObject(PlayerManager)
     }
 }

--- a/discord-bot/src/test/kotlin/bot/toby/handler/VoiceEventHandlerTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/handler/VoiceEventHandlerTest.kt
@@ -475,6 +475,8 @@ class VoiceEventHandlerTest {
         every { guild.idLong } returns 7L
         every { guild.id } returns "7"
         every { audioManager.isConnected } returns false
+        // Must match event.channelJoined so setupAndPlayUserIntro fires (see VoiceEventHandler line 164).
+        every { audioManager.connectedChannel } returns channel
 
         mockkObject(PlayerManager)
         every { PlayerManager.instance } returns audioPlayerManager
@@ -521,6 +523,7 @@ class VoiceEventHandlerTest {
         every { guild.idLong } returns 8L
         every { guild.id } returns "8"
         every { audioManager.isConnected } returns false
+        every { audioManager.connectedChannel } returns channel
 
         mockkObject(PlayerManager)
         every { PlayerManager.instance } returns audioPlayerManager

--- a/discord-bot/src/test/kotlin/bot/toby/handler/VoiceEventHandlerTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/handler/VoiceEventHandlerTest.kt
@@ -491,12 +491,7 @@ class VoiceEventHandlerTest {
         handler.onGuildVoiceUpdate(event)
 
         verify(exactly = 1) {
-            awardService.award(
-                discordId = 1L,
-                guildId = 7L,
-                amount = VoiceEventHandler.INTRO_PLAY_CREDIT,
-                reason = "intro-play"
-            )
+            awardService.award(1L, 7L, VoiceEventHandler.INTRO_PLAY_CREDIT, "intro-play", any(), any(), any())
         }
 
         unmockkObject(PlayerManager)
@@ -543,12 +538,7 @@ class VoiceEventHandlerTest {
         handler.onGuildVoiceUpdate(event)
 
         verify(exactly = 0) {
-            awardService.award(
-                discordId = any(),
-                guildId = any(),
-                amount = VoiceEventHandler.INTRO_PLAY_CREDIT,
-                reason = "intro-play"
-            )
+            awardService.award(any(), any(), VoiceEventHandler.INTRO_PLAY_CREDIT, "intro-play", any(), any(), any())
         }
 
         unmockkObject(PlayerManager)

--- a/discord-bot/src/test/kotlin/bot/toby/managers/DefaultCommandManagerAwardTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/managers/DefaultCommandManagerAwardTest.kt
@@ -88,12 +88,7 @@ class DefaultCommandManagerAwardTest {
         spy.handle(eventFor("ping"))
 
         verifyOrder {
-            awardService.award(
-                discordId = discordId,
-                guildId = guildId,
-                amount = any(),
-                reason = "command:ping"
-            )
+            awardService.award(discordId, guildId, any(), "command:ping", any(), any(), any())
             command.handle(any(), any(), any())
         }
     }
@@ -113,12 +108,7 @@ class DefaultCommandManagerAwardTest {
         runCatching { spy.handle(eventFor("boom")) }
 
         verify(exactly = 1) {
-            awardService.award(
-                discordId = discordId,
-                guildId = guildId,
-                amount = any(),
-                reason = "command:boom"
-            )
+            awardService.award(discordId, guildId, any(), "command:boom", any(), any(), any())
         }
     }
 }

--- a/discord-bot/src/test/kotlin/bot/toby/managers/DefaultCommandManagerAwardTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/managers/DefaultCommandManagerAwardTest.kt
@@ -1,0 +1,124 @@
+package bot.toby.managers
+
+import bot.toby.helpers.UserDtoHelper
+import core.command.Command
+import database.dto.ConfigDto
+import database.dto.UserDto
+import database.service.ConfigService
+import database.service.SocialCreditAwardService
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.spyk
+import io.mockk.verify
+import io.mockk.verifyOrder
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.Member
+import net.dv8tion.jda.api.entities.User
+import net.dv8tion.jda.api.entities.channel.unions.MessageChannelUnion
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
+import net.dv8tion.jda.api.interactions.InteractionHook
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * Guard the ordering change introduced for Issue 4: the social-credit award
+ * is now fired **before** command dispatch so a thrown handler still earns
+ * credit and so every user-initiated action shares one hook point.
+ */
+class DefaultCommandManagerAwardTest {
+
+    private lateinit var configService: ConfigService
+    private lateinit var userDtoHelper: UserDtoHelper
+    private lateinit var awardService: SocialCreditAwardService
+    private lateinit var manager: DefaultCommandManager
+
+    private val guildId = 7L
+    private val discordId = 100L
+
+    @BeforeEach
+    fun setup() {
+        configService = mockk(relaxed = true) {
+            every { getConfigByName(any(), any()) } returns ConfigDto("x", "5")
+        }
+        userDtoHelper = mockk(relaxed = true) {
+            every { calculateUserDto(discordId, guildId, any()) } returns
+                UserDto(discordId = discordId, guildId = guildId).apply { socialCredit = 0L }
+        }
+        awardService = mockk(relaxed = true)
+        manager = DefaultCommandManager(configService, userDtoHelper, awardService, emptyList())
+    }
+
+    private fun eventFor(commandName: String): SlashCommandInteractionEvent {
+        val guild: Guild = mockk(relaxed = true) {
+            every { id } returns guildId.toString()
+            every { idLong } returns guildId
+        }
+        val member: Member = mockk(relaxed = true) {
+            every { isOwner } returns false
+        }
+        val user: User = mockk(relaxed = true) {
+            every { idLong } returns discordId
+        }
+        val channel: MessageChannelUnion = mockk(relaxed = true)
+        val hook: InteractionHook = mockk(relaxed = true)
+        val event: SlashCommandInteractionEvent = mockk(relaxed = true)
+        every { event.guild } returns guild
+        every { event.member } returns member
+        every { event.user } returns user
+        every { event.channel } returns channel
+        every { event.hook } returns hook
+        every { event.name } returns commandName
+        return event
+    }
+
+    @Test
+    fun `award fires before command handle`() {
+        val command = mockk<Command>(relaxed = true) {
+            every { name } returns "ping"
+            every { slashCommand } returns mockk(relaxed = true)
+            every { subCommands } returns emptyList()
+            every { optionData } returns emptyList()
+            every { handle(any(), any(), any()) } just Runs
+        }
+        val spy = spyk(manager)
+        every { spy.getCommand("ping") } returns command
+
+        spy.handle(eventFor("ping"))
+
+        verifyOrder {
+            awardService.award(
+                discordId = discordId,
+                guildId = guildId,
+                amount = any(),
+                reason = "command:ping"
+            )
+            command.handle(any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `award fires even when the command handler throws`() {
+        val command = mockk<Command>(relaxed = true) {
+            every { name } returns "boom"
+            every { slashCommand } returns mockk(relaxed = true)
+            every { subCommands } returns emptyList()
+            every { optionData } returns emptyList()
+            every { handle(any(), any(), any()) } throws RuntimeException("boom")
+        }
+        val spy = spyk(manager)
+        every { spy.getCommand("boom") } returns command
+
+        runCatching { spy.handle(eventFor("boom")) }
+
+        verify(exactly = 1) {
+            awardService.award(
+                discordId = discordId,
+                guildId = guildId,
+                amount = any(),
+                reason = "command:boom"
+            )
+        }
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/scheduling/TobyCoinPriceTickJobTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/scheduling/TobyCoinPriceTickJobTest.kt
@@ -1,0 +1,67 @@
+package bot.toby.scheduling
+
+import database.dto.TobyCoinMarketDto
+import database.dto.TobyCoinPricePointDto
+import database.service.TobyCoinMarketService
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import net.dv8tion.jda.api.JDA
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.utils.cache.SnowflakeCacheView
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+/**
+ * Regression guard for Issue 7: the old code reseeded `Random` each tick
+ * with `epochMillis xor guildId`, producing predictable/biased outputs.
+ * The job now uses a single long-lived `Random`, so consecutive ticks
+ * starting from the same price produce (overwhelmingly) different outputs.
+ */
+class TobyCoinPriceTickJobTest {
+
+    @Test
+    fun `consecutive ticks produce different prices with very high probability`() {
+        val jda: JDA = mockk(relaxed = true)
+        val marketService: TobyCoinMarketService = mockk(relaxed = true)
+        val guild: Guild = mockk(relaxed = true)
+        every { guild.idLong } returns 1L
+        val cache: SnowflakeCacheView<Guild> = mockk(relaxed = true) {
+            every { iterator() } answers { mutableListOf(guild).iterator() }
+            every { forEach(any()) } answers {
+                val consumer = firstArg<(Guild) -> Unit>()
+                consumer(guild)
+            }
+        }
+        every { jda.guildCache } returns cache
+
+        var currentPrice = 100.0
+        every { marketService.getMarket(1L) } answers {
+            TobyCoinMarketDto(guildId = 1L, price = currentPrice, lastTickAt = Instant.now())
+        }
+        val saved = slot<TobyCoinMarketDto>()
+        every { marketService.saveMarket(capture(saved)) } answers {
+            currentPrice = saved.captured.price
+            saved.captured
+        }
+        every { marketService.appendPricePoint(any()) } answers { firstArg<TobyCoinPricePointDto>() }
+        every { marketService.pruneHistoryOlderThan(any()) } returns 0
+
+        val job = TobyCoinPriceTickJob(jda, marketService)
+
+        val prices = (1..50).map {
+            job.tickAllGuilds()
+            currentPrice
+        }
+
+        // With a real PRNG every tick draws an independent Gaussian — two
+        // consecutive ticks landing on identical doubles is astronomically
+        // unlikely. The pre-fix job (reseeded from `nowMs xor guildId` every
+        // tick) could produce near-duplicate outputs for same-ms reseeds.
+        val duplicates = prices.zipWithNext().count { (a, b) -> a == b }
+        assertTrue(duplicates == 0, "expected every tick to produce a distinct price but saw $duplicates duplicates")
+        assertEquals(50, prices.toSet().size, "all 50 ticks should have distinct prices")
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/scheduling/TobyCoinPriceTickJobTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/scheduling/TobyCoinPriceTickJobTest.kt
@@ -28,13 +28,9 @@ class TobyCoinPriceTickJobTest {
         val marketService: TobyCoinMarketService = mockk(relaxed = true)
         val guild: Guild = mockk(relaxed = true)
         every { guild.idLong } returns 1L
-        val cache: SnowflakeCacheView<Guild> = mockk(relaxed = true) {
-            every { iterator() } answers { mutableListOf(guild).iterator() }
-            every { forEach(any()) } answers {
-                val consumer = firstArg<(Guild) -> Unit>()
-                consumer(guild)
-            }
-        }
+
+        val cache: SnowflakeCacheView<Guild> = mockk(relaxed = true)
+        every { cache.iterator() } answers { mutableListOf(guild).iterator() }
         every { jda.guildCache } returns cache
 
         var currentPrice = 100.0

--- a/discord-bot/src/test/kotlin/bot/toby/voice/VoiceCreditAwardServiceTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/voice/VoiceCreditAwardServiceTest.kt
@@ -1,10 +1,7 @@
 package bot.toby.voice
 
-import database.dto.UserDto
-import database.dto.VoiceCreditDailyDto
 import database.dto.VoiceSessionDto
-import database.service.UserService
-import database.service.VoiceCreditDailyService
+import database.service.SocialCreditAwardService
 import database.service.VoiceSessionService
 import io.mockk.every
 import io.mockk.mockk
@@ -15,14 +12,11 @@ import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.Instant
-import java.time.LocalDate
-import java.time.ZoneOffset
 
 class VoiceCreditAwardServiceTest {
 
     private lateinit var voiceSessionService: VoiceSessionService
-    private lateinit var voiceCreditDailyService: VoiceCreditDailyService
-    private lateinit var userService: UserService
+    private lateinit var awardService: SocialCreditAwardService
     private lateinit var service: VoiceCreditAwardService
 
     private val discordId = 1L
@@ -31,9 +25,8 @@ class VoiceCreditAwardServiceTest {
     @BeforeEach
     fun setup() {
         voiceSessionService = mockk(relaxed = true)
-        voiceCreditDailyService = mockk(relaxed = true)
-        userService = mockk(relaxed = true)
-        service = VoiceCreditAwardService(voiceSessionService, voiceCreditDailyService, userService)
+        awardService = mockk(relaxed = true)
+        service = VoiceCreditAwardService(voiceSessionService, awardService)
     }
 
     private fun session(joinedAt: Instant): VoiceSessionDto {
@@ -49,9 +42,17 @@ class VoiceCreditAwardServiceTest {
     @Test
     fun `closeSessionAndAward converts counted seconds to credits using configured ratio`() {
         val t0 = Instant.parse("2026-04-10T10:00:00Z")
-        val user = UserDto(discordId = discordId, guildId = guildId).apply { socialCredit = 10L }
-        every { userService.getUserById(discordId, guildId) } returns user
-        every { voiceCreditDailyService.get(discordId, guildId, any()) } returns null
+        every {
+            awardService.award(
+                discordId = discordId,
+                guildId = guildId,
+                amount = 5L,
+                reason = "voice-session",
+                countsAgainstDailyCap = any(),
+                at = any(),
+                dailyCap = VoiceCreditConfig.DAILY_CREDIT_CAP
+            )
+        } returns 5L
 
         val closed = slot<VoiceSessionDto>()
         every { voiceSessionService.closeSession(capture(closed)) } answers { closed.captured }
@@ -61,15 +62,27 @@ class VoiceCreditAwardServiceTest {
 
         assertEquals(600L, closed.captured.countedSeconds)
         assertEquals(5L, closed.captured.creditsAwarded)
-        assertEquals(15L, user.socialCredit)
-        verify(exactly = 1) { userService.updateUser(user) }
+        verify(exactly = 1) {
+            awardService.award(
+                discordId = discordId,
+                guildId = guildId,
+                amount = 5L,
+                reason = "voice-session",
+                countsAgainstDailyCap = any(),
+                at = any(),
+                dailyCap = VoiceCreditConfig.DAILY_CREDIT_CAP
+            )
+        }
     }
 
     @Test
     fun `closeSessionAndAward awards zero when no company time`() {
         val t0 = Instant.parse("2026-04-10T10:00:00Z")
-        val user = UserDto(discordId = discordId, guildId = guildId).apply { socialCredit = 10L }
-        every { userService.getUserById(discordId, guildId) } returns user
+        every {
+            awardService.award(
+                any(), any(), amount = 0L, any(), any(), any(), any()
+            )
+        } returns 0L
 
         val closed = slot<VoiceSessionDto>()
         every { voiceSessionService.closeSession(capture(closed)) } answers { closed.captured }
@@ -78,40 +91,37 @@ class VoiceCreditAwardServiceTest {
 
         assertEquals(0L, closed.captured.countedSeconds)
         assertEquals(0L, closed.captured.creditsAwarded)
-        assertEquals(10L, user.socialCredit)
-        verify(exactly = 0) { userService.updateUser(any()) }
     }
 
     @Test
-    fun `closeSessionAndAward clamps award to daily cap`() {
+    fun `closeSessionAndAward writes whatever the award service grants`() {
         val t0 = Instant.parse("2026-04-10T10:00:00Z")
-        val earnDate = LocalDate.ofInstant(t0.plusSeconds(7200), ZoneOffset.UTC)
-        val user = UserDto(discordId = discordId, guildId = guildId).apply { socialCredit = 0L }
-        every { userService.getUserById(discordId, guildId) } returns user
-        // Already at 55 credits today; cap is 60.
-        every { voiceCreditDailyService.get(discordId, guildId, earnDate) } returns
-            VoiceCreditDailyDto(discordId = discordId, guildId = guildId, earnDate = earnDate, credits = 55L)
+        // Central service may clamp to the daily cap — voice service trusts the returned value.
+        every {
+            awardService.award(
+                discordId = discordId,
+                guildId = guildId,
+                amount = 60L,
+                reason = "voice-session",
+                countsAgainstDailyCap = any(),
+                at = any(),
+                dailyCap = VoiceCreditConfig.DAILY_CREDIT_CAP
+            )
+        } returns 5L
 
         val closed = slot<VoiceSessionDto>()
         every { voiceSessionService.closeSession(capture(closed)) } answers { closed.captured }
-        val dailyUpsert = slot<VoiceCreditDailyDto>()
-        every { voiceCreditDailyService.upsert(capture(dailyUpsert)) } answers { dailyUpsert.captured }
 
-        // 7200s / 120s = 60 credits requested. Daily cap leaves only 5 headroom.
+        // 7200s / 120s = 60 credits requested; awardService only grants 5 (cap).
         service.closeSessionAndAward(session(t0), t0.plusSeconds(7200), hadCompanyDurationSeconds = 7200L)
 
         assertEquals(5L, closed.captured.creditsAwarded)
-        assertEquals(5L, user.socialCredit)
-        assertEquals(60L, dailyUpsert.captured.credits)
     }
 
     @Test
     fun `closeSessionAndAward clamps counted seconds to raw duration`() {
         val t0 = Instant.parse("2026-04-10T10:00:00Z")
-        val user = UserDto(discordId = discordId, guildId = guildId).apply { socialCredit = 0L }
-        every { userService.getUserById(discordId, guildId) } returns user
-        every { voiceCreditDailyService.get(discordId, guildId, any()) } returns null
-
+        every { awardService.award(any(), any(), any(), any(), any(), any(), any()) } returns 0L
         val closed = slot<VoiceSessionDto>()
         every { voiceSessionService.closeSession(capture(closed)) } answers { closed.captured }
 
@@ -124,10 +134,7 @@ class VoiceCreditAwardServiceTest {
     @Test
     fun `closeRecoveredSession caps duration at max recovered seconds`() {
         val t0 = Instant.parse("2026-04-01T00:00:00Z")
-        val user = UserDto(discordId = discordId, guildId = guildId).apply { socialCredit = 0L }
-        every { userService.getUserById(discordId, guildId) } returns user
-        every { voiceCreditDailyService.get(discordId, guildId, any()) } returns null
-
+        every { awardService.award(any(), any(), any(), any(), any(), any(), any()) } returns 0L
         val closed = slot<VoiceSessionDto>()
         every { voiceSessionService.closeSession(capture(closed)) } answers { closed.captured }
 
@@ -139,16 +146,25 @@ class VoiceCreditAwardServiceTest {
     }
 
     @Test
-    fun `closeSessionAndAward skips user update when dto is missing`() {
+    fun `closeSessionAndAward records zero when award service returns zero (unknown user)`() {
         val t0 = Instant.parse("2026-04-10T10:00:00Z")
-        every { userService.getUserById(discordId, guildId) } returns null
-        every { voiceCreditDailyService.get(discordId, guildId, any()) } returns null
+        // Simulate "user doesn't exist" — central service returns 0 without consuming cap.
+        every {
+            awardService.award(
+                discordId = discordId,
+                guildId = guildId,
+                amount = 5L,
+                reason = "voice-session",
+                countsAgainstDailyCap = any(),
+                at = any(),
+                dailyCap = VoiceCreditConfig.DAILY_CREDIT_CAP
+            )
+        } returns 0L
         val closed = slot<VoiceSessionDto>()
         every { voiceSessionService.closeSession(capture(closed)) } answers { closed.captured }
 
         service.closeSessionAndAward(session(t0), t0.plusSeconds(600), hadCompanyDurationSeconds = 600L)
 
-        assertEquals(5L, closed.captured.creditsAwarded)
-        verify(exactly = 0) { userService.updateUser(any()) }
+        assertEquals(0L, closed.captured.creditsAwarded)
     }
 }

--- a/web/src/main/kotlin/web/controller/EconomyController.kt
+++ b/web/src/main/kotlin/web/controller/EconomyController.kt
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.ResponseBody
 import org.springframework.web.servlet.mvc.support.RedirectAttributes
 import web.service.EconomyWebService
 import database.service.EconomyTradeService.TradeOutcome
+import database.service.SocialCreditAwardService
 import web.service.PricePoint
 import web.util.discordIdOrNull
 import web.util.displayName
@@ -24,8 +25,14 @@ import web.util.displayName
 @Controller
 @RequestMapping("/economy")
 class EconomyController(
-    private val economyWebService: EconomyWebService
+    private val economyWebService: EconomyWebService,
+    private val awardService: SocialCreditAwardService
 ) {
+
+    companion object {
+        // Tiny participation award — the daily cap absorbs trade-spam abuse.
+        const val UI_TRADE_CREDIT: Long = 1L
+    }
 
     @GetMapping("/guilds")
     fun guildList(
@@ -119,16 +126,24 @@ class EconomyController(
             return ResponseEntity.badRequest().body(TradeResponse(false, "Amount must be positive."))
         }
         return when (val outcome = action(discordId)) {
-            is TradeOutcome.Ok -> ResponseEntity.ok(
-                TradeResponse(
-                    ok = true,
-                    error = null,
-                    newCoins = outcome.newCoins,
-                    newCredits = outcome.newCredits,
-                    newPrice = outcome.newPrice,
-                    transactedCredits = outcome.transactedCredits
+            is TradeOutcome.Ok -> {
+                val granted = awardService.award(
+                    discordId = discordId,
+                    guildId = guildId,
+                    amount = UI_TRADE_CREDIT,
+                    reason = "ui-trade"
                 )
-            )
+                ResponseEntity.ok(
+                    TradeResponse(
+                        ok = true,
+                        error = null,
+                        newCoins = outcome.newCoins,
+                        newCredits = outcome.newCredits + granted,
+                        newPrice = outcome.newPrice,
+                        transactedCredits = outcome.transactedCredits
+                    )
+                )
+            }
             is TradeOutcome.InsufficientCredits -> ResponseEntity.badRequest().body(
                 TradeResponse(false, "Need ${outcome.needed} credits, you have ${outcome.have}.")
             )

--- a/web/src/main/kotlin/web/service/LeaderboardWebService.kt
+++ b/web/src/main/kotlin/web/service/LeaderboardWebService.kt
@@ -1,14 +1,25 @@
 package web.service
 
+import database.service.TobyCoinMarketService
+import database.service.UserService
 import net.dv8tion.jda.api.JDA
 import org.springframework.stereotype.Service
+import kotlin.math.floor
 
 @Service
 class LeaderboardWebService(
     private val jda: JDA,
     private val introWebService: IntroWebService,
-    private val moderationWebService: ModerationWebService
+    private val moderationWebService: ModerationWebService,
+    private val userService: UserService,
+    private val marketService: TobyCoinMarketService
 ) {
+
+    companion object {
+        // Keep the list tight so the leaderboard page stays scannable. Users
+        // below this don't meaningfully change the story of "who owns coin".
+        const val TOBY_COIN_LEADERBOARD_LIMIT = 10
+    }
 
     fun getGuildsWhereUserCanView(accessToken: String, discordId: Long): List<LeaderboardGuildCard> {
         return introWebService.getMutualGuilds(accessToken).mapNotNull { info ->
@@ -48,8 +59,31 @@ class LeaderboardWebService(
             totalCreditsThisMonth = totalCreditsThisMonth,
             totalVoiceThisMonth = totalVoiceThisMonth,
             mostActiveMember = mostActiveName,
-            totalMembers = rows.size
+            totalMembers = rows.size,
+            tobyCoinLeaders = buildTobyCoinLeaders(guildId)
         )
+    }
+
+    private fun buildTobyCoinLeaders(guildId: Long): List<TobyCoinLeaderRow> {
+        val guild = jda.getGuildById(guildId) ?: return emptyList()
+        val price = marketService.getMarket(guildId)?.price ?: 0.0
+        return userService.listGuildUsers(guildId).asSequence()
+            .filterNotNull()
+            .filter { it.tobyCoins > 0L }
+            .sortedByDescending { it.tobyCoins }
+            .take(TOBY_COIN_LEADERBOARD_LIMIT)
+            .mapIndexed { index, dto ->
+                val member = guild.getMemberById(dto.discordId)
+                TobyCoinLeaderRow(
+                    rank = index + 1,
+                    discordId = dto.discordId.toString(),
+                    name = member?.effectiveName ?: "Unknown",
+                    avatarUrl = member?.effectiveAvatarUrl,
+                    coins = dto.tobyCoins,
+                    portfolioCredits = floor(dto.tobyCoins.toDouble() * price).toLong()
+                )
+            }
+            .toList()
     }
 }
 
@@ -79,7 +113,8 @@ data class LeaderboardGuildView(
     val totalCreditsThisMonth: Long,
     val totalVoiceThisMonth: Long,
     val mostActiveMember: String?,
-    val totalMembers: Int
+    val totalMembers: Int,
+    val tobyCoinLeaders: List<TobyCoinLeaderRow> = emptyList()
 ) {
     val totalVoiceThisMonthDisplay: String get() = formatDuration(totalVoiceThisMonth)
     private fun formatDuration(seconds: Long): String {
@@ -89,3 +124,12 @@ data class LeaderboardGuildView(
         return if (hours > 0) "${hours}h ${minutes}m" else "${minutes}m"
     }
 }
+
+data class TobyCoinLeaderRow(
+    val rank: Int,
+    val discordId: String,
+    val name: String,
+    val avatarUrl: String?,
+    val coins: Long,
+    val portfolioCredits: Long
+)

--- a/web/src/main/resources/static/css/economy.css
+++ b/web/src/main/resources/static/css/economy.css
@@ -69,6 +69,11 @@
     font-size: 0.95rem;
 }
 
+/* [hidden] has lower specificity than .economy-chart-empty, so restore it. */
+.economy-chart-empty[hidden] {
+    display: none;
+}
+
 .economy-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));

--- a/web/src/main/resources/templates/leaderboard.html
+++ b/web/src/main/resources/templates/leaderboard.html
@@ -134,6 +134,39 @@
         </div>
     </section>
 
+    <section class="lb-tobycoins" aria-label="TobyCoin wallet leaders"
+             th:if="${not #lists.isEmpty(view.tobyCoinLeaders)}">
+        <h2 class="lb-standings-title">TobyCoin wallets</h2>
+        <div class="mod-table-wrap">
+            <table class="mod-table lb-standings-table">
+                <thead>
+                <tr>
+                    <th>#</th>
+                    <th>Member</th>
+                    <th>TOBY</th>
+                    <th>Portfolio (credits)</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr th:each="row : ${view.tobyCoinLeaders}">
+                    <td th:text="${row.rank}">1</td>
+                    <td>
+                        <div class="member-cell">
+                            <img th:if="${row.avatarUrl != null}"
+                                 th:src="${row.avatarUrl}"
+                                 class="avatar"
+                                 alt="">
+                            <span th:text="${row.name}">Name</span>
+                        </div>
+                    </td>
+                    <td th:text="${row.coins}">0</td>
+                    <td th:text="${row.portfolioCredits}">0</td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+    </section>
+
     <div class="empty-hero" th:if="${#lists.isEmpty(view.podium) and #lists.isEmpty(view.standings)}">
         <span class="emoji" aria-hidden="true">🏁</span>
         <h2>No credit has been earned here yet</h2>

--- a/web/src/test/kotlin/web/controller/EconomyControllerTradeAwardTest.kt
+++ b/web/src/test/kotlin/web/controller/EconomyControllerTradeAwardTest.kt
@@ -1,0 +1,141 @@
+package web.controller
+
+import database.service.EconomyTradeService.TradeOutcome
+import database.service.SocialCreditAwardService
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.security.oauth2.core.user.OAuth2User
+import web.service.EconomyWebService
+
+/**
+ * Every successful web-UI buy/sell should funnel one credit through the
+ * central award service; every failure outcome must NOT call it. Regression
+ * guard for the UI-participation award hook.
+ */
+class EconomyControllerTradeAwardTest {
+
+    private val guildId = 42L
+    private val discordId = 100L
+
+    private lateinit var economyWebService: EconomyWebService
+    private lateinit var awardService: SocialCreditAwardService
+    private lateinit var user: OAuth2User
+    private lateinit var controller: EconomyController
+
+    @BeforeEach
+    fun setup() {
+        economyWebService = mockk(relaxed = true)
+        awardService = mockk(relaxed = true)
+        user = mockk {
+            every { getAttribute<String>("id") } returns discordId.toString()
+            every { getAttribute<String>("username") } returns "tester"
+        }
+        every { economyWebService.isMember(discordId, guildId) } returns true
+        // Match the full signature including defaulted args via any().
+        every {
+            awardService.award(discordId, guildId, EconomyController.UI_TRADE_CREDIT, "ui-trade", any(), any(), any())
+        } returns EconomyController.UI_TRADE_CREDIT
+        controller = EconomyController(economyWebService, awardService)
+    }
+
+    @Test
+    fun `successful buy fires the UI trade award`() {
+        val outcome = TradeOutcome.Ok(
+            amount = 5L,
+            transactedCredits = 500L,
+            newCoins = 5L,
+            newCredits = 500L,
+            newPrice = 100.0
+        )
+        every { economyWebService.buy(discordId, guildId, 5L) } returns outcome
+
+        val response = controller.buy(guildId, TradeRequest(amount = 5L), user)
+
+        assertTrue(response.statusCode.is2xxSuccessful)
+        assertEquals(true, response.body?.ok)
+        assertEquals(500L + EconomyController.UI_TRADE_CREDIT, response.body?.newCredits)
+        verify(exactly = 1) {
+            awardService.award(discordId, guildId, EconomyController.UI_TRADE_CREDIT, "ui-trade", any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `successful sell fires the UI trade award`() {
+        val outcome = TradeOutcome.Ok(
+            amount = 3L,
+            transactedCredits = 300L,
+            newCoins = 2L,
+            newCredits = 1300L,
+            newPrice = 95.0
+        )
+        every { economyWebService.sell(discordId, guildId, 3L) } returns outcome
+
+        controller.sell(guildId, TradeRequest(amount = 3L), user)
+
+        verify(exactly = 1) {
+            awardService.award(discordId, guildId, EconomyController.UI_TRADE_CREDIT, "ui-trade", any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `insufficient credits outcome does not fire the award`() {
+        every { economyWebService.buy(discordId, guildId, 5L) } returns
+            TradeOutcome.InsufficientCredits(needed = 500L, have = 10L)
+
+        controller.buy(guildId, TradeRequest(amount = 5L), user)
+
+        verify(exactly = 0) { awardService.award(any(), any(), any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `insufficient coins outcome does not fire the award`() {
+        every { economyWebService.sell(discordId, guildId, 5L) } returns
+            TradeOutcome.InsufficientCoins(needed = 5L, have = 0L)
+
+        controller.sell(guildId, TradeRequest(amount = 5L), user)
+
+        verify(exactly = 0) { awardService.award(any(), any(), any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `unknown user outcome does not fire the award`() {
+        every { economyWebService.buy(discordId, guildId, 5L) } returns TradeOutcome.UnknownUser
+
+        controller.buy(guildId, TradeRequest(amount = 5L), user)
+
+        verify(exactly = 0) { awardService.award(any(), any(), any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `non-positive amount returns 400 without calling the web service or award`() {
+        val response = controller.buy(guildId, TradeRequest(amount = 0L), user)
+
+        assertEquals(400, response.statusCode.value())
+        verify(exactly = 0) { economyWebService.buy(any(), any(), any()) }
+        verify(exactly = 0) { awardService.award(any(), any(), any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `clamped award (0 granted) does not inflate the response credits`() {
+        val outcome = TradeOutcome.Ok(
+            amount = 1L,
+            transactedCredits = 100L,
+            newCoins = 1L,
+            newCredits = 900L,
+            newPrice = 100.0
+        )
+        every { economyWebService.buy(discordId, guildId, 1L) } returns outcome
+        every {
+            awardService.award(discordId, guildId, EconomyController.UI_TRADE_CREDIT, "ui-trade", any(), any(), any())
+        } returns 0L // daily cap reached
+
+        val response = controller.buy(guildId, TradeRequest(amount = 1L), user)
+
+        assertEquals(900L, response.body?.newCredits, "no award added when award returns 0")
+    }
+}

--- a/web/src/test/kotlin/web/service/LeaderboardWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/LeaderboardWebServiceTest.kt
@@ -1,5 +1,7 @@
 package web.service
 
+import database.service.TobyCoinMarketService
+import database.service.UserService
 import io.mockk.every
 import io.mockk.mockk
 import net.dv8tion.jda.api.JDA
@@ -17,6 +19,8 @@ class LeaderboardWebServiceTest {
     private lateinit var jda: JDA
     private lateinit var introWebService: IntroWebService
     private lateinit var moderationWebService: ModerationWebService
+    private lateinit var userService: UserService
+    private lateinit var marketService: TobyCoinMarketService
     private lateinit var service: LeaderboardWebService
 
     private val guildId = 42L
@@ -27,7 +31,9 @@ class LeaderboardWebServiceTest {
         jda = mockk(relaxed = true)
         introWebService = mockk(relaxed = true)
         moderationWebService = mockk(relaxed = true)
-        service = LeaderboardWebService(jda, introWebService, moderationWebService)
+        userService = mockk(relaxed = true)
+        marketService = mockk(relaxed = true)
+        service = LeaderboardWebService(jda, introWebService, moderationWebService, userService, marketService)
     }
 
     @Test

--- a/web/src/test/kotlin/web/service/LeaderboardWebServiceTobyCoinTest.kt
+++ b/web/src/test/kotlin/web/service/LeaderboardWebServiceTobyCoinTest.kt
@@ -1,0 +1,124 @@
+package web.service
+
+import database.dto.TobyCoinMarketDto
+import database.dto.UserDto
+import database.service.TobyCoinMarketService
+import database.service.UserService
+import io.mockk.every
+import io.mockk.mockk
+import net.dv8tion.jda.api.JDA
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.Member
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+class LeaderboardWebServiceTobyCoinTest {
+
+    private val guildId = 42L
+
+    private lateinit var jda: JDA
+    private lateinit var guild: Guild
+    private lateinit var userService: UserService
+    private lateinit var marketService: TobyCoinMarketService
+    private lateinit var service: LeaderboardWebService
+
+    @BeforeEach
+    fun setup() {
+        jda = mockk(relaxed = true)
+        guild = mockk(relaxed = true)
+        userService = mockk(relaxed = true)
+        marketService = mockk(relaxed = true)
+        every { jda.getGuildById(guildId) } returns guild
+        every { guild.name } returns "Test Guild"
+
+        service = LeaderboardWebService(
+            jda = jda,
+            introWebService = mockk(relaxed = true),
+            moderationWebService = mockk(relaxed = true) {
+                every { getLeaderboard(guildId) } returns emptyList()
+            },
+            userService = userService,
+            marketService = marketService
+        )
+    }
+
+    private fun member(id: Long, name: String): Member = mockk(relaxed = true) {
+        every { effectiveName } returns name
+        every { effectiveAvatarUrl } returns "https://cdn.discord/$id.png"
+    }
+
+    @Test
+    fun `tobyCoinLeaders sorts by coins desc filtering zero-coin holders and computes portfolio`() {
+        every { marketService.getMarket(guildId) } returns
+            TobyCoinMarketDto(guildId = guildId, price = 2.5, lastTickAt = Instant.now())
+        every { userService.listGuildUsers(guildId) } returns listOf(
+            UserDto(discordId = 1L, guildId = guildId).apply { tobyCoins = 100L },
+            UserDto(discordId = 2L, guildId = guildId).apply { tobyCoins = 50L },
+            UserDto(discordId = 3L, guildId = guildId).apply { tobyCoins = 0L },   // filtered out
+            UserDto(discordId = 4L, guildId = guildId).apply { tobyCoins = 200L }
+        )
+        every { guild.getMemberById(1L) } returns member(1L, "Alice")
+        every { guild.getMemberById(2L) } returns member(2L, "Bob")
+        every { guild.getMemberById(4L) } returns member(4L, "Carol")
+
+        val leaders = checkNotNull(service.getGuildView(guildId)).tobyCoinLeaders
+
+        assertEquals(3, leaders.size, "zero-coin holder should be filtered out")
+        assertEquals(listOf("Carol", "Alice", "Bob"), leaders.map { it.name })
+        assertEquals(listOf(1, 2, 3), leaders.map { it.rank })
+        // portfolio = floor(coins * price)
+        assertEquals(500L, leaders[0].portfolioCredits) // 200 * 2.5
+        assertEquals(250L, leaders[1].portfolioCredits) // 100 * 2.5
+        assertEquals(125L, leaders[2].portfolioCredits) // 50  * 2.5
+    }
+
+    @Test
+    fun `tobyCoinLeaders is empty when no one has coins`() {
+        every { marketService.getMarket(guildId) } returns
+            TobyCoinMarketDto(guildId = guildId, price = 100.0, lastTickAt = Instant.now())
+        every { userService.listGuildUsers(guildId) } returns listOf(
+            UserDto(discordId = 1L, guildId = guildId).apply { tobyCoins = 0L },
+            UserDto(discordId = 2L, guildId = guildId).apply { tobyCoins = 0L }
+        )
+
+        val leaders = checkNotNull(service.getGuildView(guildId)).tobyCoinLeaders
+
+        assertTrue(leaders.isEmpty())
+    }
+
+    @Test
+    fun `tobyCoinLeaders uses zero price gracefully when no market exists`() {
+        every { marketService.getMarket(guildId) } returns null
+        every { userService.listGuildUsers(guildId) } returns listOf(
+            UserDto(discordId = 1L, guildId = guildId).apply { tobyCoins = 10L }
+        )
+        every { guild.getMemberById(1L) } returns member(1L, "Alice")
+
+        val leaders = checkNotNull(service.getGuildView(guildId)).tobyCoinLeaders
+
+        assertEquals(1, leaders.size)
+        assertEquals(0L, leaders[0].portfolioCredits, "portfolio = 0 when price unknown")
+        assertEquals(10L, leaders[0].coins)
+    }
+
+    @Test
+    fun `tobyCoinLeaders respects the page limit`() {
+        every { marketService.getMarket(guildId) } returns
+            TobyCoinMarketDto(guildId = guildId, price = 1.0, lastTickAt = Instant.now())
+        val users = (1..15L).map { i ->
+            UserDto(discordId = i, guildId = guildId).apply { tobyCoins = i }
+        }
+        every { userService.listGuildUsers(guildId) } returns users
+        users.forEach { dto ->
+            every { guild.getMemberById(dto.discordId) } returns member(dto.discordId, "U${dto.discordId}")
+        }
+
+        val leaders = checkNotNull(service.getGuildView(guildId)).tobyCoinLeaders
+
+        assertEquals(LeaderboardWebService.TOBY_COIN_LEADERBOARD_LIMIT, leaders.size)
+        assertEquals("U15", leaders.first().name)
+    }
+}

--- a/web/src/test/kotlin/web/static/EconomyCssRegressionTest.kt
+++ b/web/src/test/kotlin/web/static/EconomyCssRegressionTest.kt
@@ -1,0 +1,34 @@
+package web.static
+
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * The chart overlay in `economy.html` is hidden/shown by toggling the HTML
+ * `hidden` attribute from `economy.js`. Because `.economy-chart-empty`
+ * sets `display: flex`, the UA-defined `[hidden] { display: none }` rule
+ * is overridden by class-selector specificity — which is why the overlay
+ * used to stay visible on top of a rendered chart. The CSS file must
+ * carry an explicit `.economy-chart-empty[hidden] { display: none }` rule.
+ */
+class EconomyCssRegressionTest {
+
+    @Test
+    fun `economy css hides the chart-empty overlay when the hidden attribute is set`() {
+        val css = javaClass.classLoader
+            .getResourceAsStream("static/css/economy.css")
+            ?.bufferedReader()
+            ?.readText()
+            ?: error("economy.css is not on the classpath")
+
+        val normalized = css.replace("\\s+".toRegex(), " ")
+        assertTrue(
+            normalized.contains(".economy-chart-empty[hidden]") &&
+                normalized.substringAfter(".economy-chart-empty[hidden]")
+                    .substringBefore("}")
+                    .contains("display: none"),
+            "economy.css must include `.economy-chart-empty[hidden] { display: none; }` " +
+                "so toggling the `hidden` attribute from JS actually hides the overlay."
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Fixes seven linked issues reported in conversation, each with its own test.

### Bugs

1. **Social-credit adjustment didn't survive a refresh.** `DefaultUserService` cached `listGuildUsers(guildId)` with `SimpleKey(guildId)` but never evicted it on write — `adjustSocialCredit` updated the individual user cache entry only, so `ModerationWebService.getGuildOverview` kept reading the stale list for up to the 30-min TTL. Added explicit `'list-' + guildId` key + eviction on every write path.
   - SpEL keys switched from parameter names (`#userDto.discordId`) to positional (`#a0.discordId`) so resolution doesn't depend on Kotlin parameter-name metadata being visible to the test context.

2. **"Not enough price history" overlay stayed on top of the rendered chart.** `.economy-chart-empty { display: flex }` overrode the UA `[hidden] { display: none }` rule, so toggling `empty.hidden` from JS was a no-op. Added `.economy-chart-empty[hidden] { display: none }`.

3. **TobyCoin scheduled price tick only went down.** Zero-drift GBM has a *negative median* log return of `-½σ²·dt`; even though the mean is conserved the typical path drifts down. Fixed by setting `DRIFT = 0.5 * VOLATILITY²` so `exp((DRIFT − 0.5σ²)dt + σ√dt·Z)` has median 1. Also removed the per-tick `Random(epochMillis xor guildId)` reseed — the predictable-seed pattern was itself biasing consecutive draws.

4. **`EconomyTradeService.buy/sell` could double-spend under concurrency.** Plain read-modify-write on user balance and market price with no transaction or row lock. Added `getUserByIdForUpdate` / `getByGuildForUpdate` persistence methods that issue `SELECT … FOR UPDATE`, annotated the service `@Transactional`, and fixed the lock order (user first, then market — same in both buy and sell to avoid deadlock).

### Features

5. **Centralised social-credit awards.** New `SocialCreditAwardService.award(...)` with shared daily-cap bookkeeping (via the existing `voice_credit_daily` bucket). Refactored the voice-session path and command-completion path to route through it.

6. **Command-completion award now fires pre-dispatch.** Users earn the random 0–20 whether the command throws or not.

7. **Joining a voice channel with an intro set now awards 2 credits** (daily-capped, so no farming via rejoin spam).

8. **Successful buy/sell in the web UI now awards 1 credit.** Response body reflects only what was actually granted (0 if the daily cap blocked it).

9. **TobyCoin wallet leaderboard.** New section on `/leaderboard/{guildId}` listing the top 10 holders with portfolio value in credits at the current market price. Hidden when nobody holds any coin.

## Test plan

Every issue has an automated test:

- [x] `DefaultUserServiceCacheTest` — list cache hit on reads, evicted on `updateUser`/`createNewUser`/`deleteUser`/`deleteUserById`; one-guild mutation doesn't evict another guild's list.
- [x] `EconomyCssRegressionTest` — `economy.css` contains the `[hidden]` override.
- [x] `TobyCoinEngineTest` — Monte-Carlo median-neutrality (5000 runs × 200 ticks; median stays ≈100).
- [x] `TobyCoinPriceTickJobTest` — consecutive ticks produce distinct prices (shared PRNG).
- [x] `EconomyTradeServiceIntegrationTest` — concurrent buys can't double-spend; concurrent trades reproduce the serial-commutative market price exactly.
- [x] `SocialCreditAwardServiceTest` — cap respected, `countsAgainstDailyCap=false` bypasses, phantom user doesn't consume cap, custom `dailyCap` override.
- [x] `DefaultCommandManagerAwardTest` — award fires before `command.handle` and even when the handler throws.
- [x] `VoiceEventHandlerTest` — intro award called when `musicDtos` non-empty, NOT called when empty.
- [x] `EconomyControllerTradeAwardTest` — award on `TradeOutcome.Ok`; no award on any failure outcome; clamped award doesn't inflate response credits.
- [x] `LeaderboardWebServiceTobyCoinTest` — sort, filter zero-coin holders, floor portfolio math, respect page limit.
- [x] `VoiceCreditAwardServiceTest` updated for the new constructor and delegation semantics.
- [ ] Manual smoke: apply social credit in moderation → refresh → new value persists.
- [ ] Manual smoke: `/economy/{guildId}` with ≥2 ticks → overlay disappears; with 0 ticks → overlay shows.
- [ ] Manual smoke: price chart wanders both ways over an hour.
- [ ] Manual smoke: join voice with intro set → credit goes up by 2; buy 1 TOBY in UI → credit goes up by 1.

Note: `:application` and `:discord-bot` modules couldn't be built locally (the sandbox can't reach jitpack for `moe.kyokobot.libdave` natives), so their tests are verified by CI only. `:common`, `:core-api`, `:database`, and `:web` all build and test green locally.

https://claude.ai/code/session_01JvuveFBoCvMFTK8XxXVN56

---
_Generated by [Claude Code](https://claude.ai/code/session_01JvuveFBoCvMFTK8XxXVN56)_