### PR TITLE
feat(web): rank standings by this-month by default, add Lifetime toggle

### DIFF
--- a/web/src/main/kotlin/web/controller/LeaderboardController.kt
+++ b/web/src/main/kotlin/web/controller/LeaderboardController.kt
@@ -8,7 +8,9 @@ import org.springframework.stereotype.Controller
 import org.springframework.ui.Model
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.servlet.mvc.support.RedirectAttributes
+import web.service.LeaderboardSort
 import web.service.LeaderboardWebService
 import web.util.discordIdOrNull
 import web.util.displayName
@@ -37,6 +39,7 @@ class LeaderboardController(
     @GetMapping("/leaderboard/{guildId}")
     fun leaderboardPage(
         @PathVariable guildId: Long,
+        @RequestParam(required = false) sort: String?,
         @AuthenticationPrincipal user: OAuth2User,
         model: Model,
         ra: RedirectAttributes
@@ -49,7 +52,7 @@ class LeaderboardController(
             return "redirect:/leaderboards"
         }
 
-        val view = leaderboardWebService.getGuildView(guildId) ?: run {
+        val view = leaderboardWebService.getGuildView(guildId, LeaderboardSort.fromQuery(sort)) ?: run {
             ra.addFlashAttribute("error", "Bot is not in that server.")
             return "redirect:/leaderboards"
         }

--- a/web/src/main/kotlin/web/service/LeaderboardWebService.kt
+++ b/web/src/main/kotlin/web/service/LeaderboardWebService.kt
@@ -47,21 +47,34 @@ class LeaderboardWebService(
         return guild.getMemberById(discordId) != null
     }
 
-    fun getGuildView(guildId: Long): LeaderboardGuildView? {
+    fun getGuildView(
+        guildId: Long,
+        sort: LeaderboardSort = LeaderboardSort.THIS_MONTH
+    ): LeaderboardGuildView? {
         val guild = jda.getGuildById(guildId) ?: return null
-        val rows = moderationWebService.getLeaderboard(guildId)
-        val totalCreditsThisMonth = rows.sumOf { it.creditsEarnedThisMonth }
-        val totalVoiceThisMonth = rows.sumOf { it.voiceSecondsThisMonth }
-        val mostActiveName = rows.maxByOrNull { it.voiceSecondsThisMonth }?.name
+        val rawRows = moderationWebService.getLeaderboard(guildId)
+
+        // Moderation service emits rows ordered by lifetime socialCredit. Re-sort
+        // + re-rank so rank 1 is always the top of the active view — otherwise
+        // lifetime ranks leak into the this-month display.
+        val resorted = when (sort) {
+            LeaderboardSort.THIS_MONTH -> rawRows.sortedByDescending { it.creditsEarnedThisMonth }
+            LeaderboardSort.LIFETIME -> rawRows
+        }.mapIndexed { i, r -> r.copy(rank = i + 1) }
+
+        val totalCreditsThisMonth = rawRows.sumOf { it.creditsEarnedThisMonth }
+        val totalVoiceThisMonth = rawRows.sumOf { it.voiceSecondsThisMonth }
+        val mostActiveName = rawRows.maxByOrNull { it.voiceSecondsThisMonth }?.name
 
         return LeaderboardGuildView(
             guildName = guild.name,
-            podium = rows.take(3),
-            standings = rows.drop(3),
+            podium = resorted.take(3),
+            standings = resorted.drop(3),
             totalCreditsThisMonth = totalCreditsThisMonth,
             totalVoiceThisMonth = totalVoiceThisMonth,
             mostActiveMember = mostActiveName,
-            totalMembers = rows.size,
+            totalMembers = resorted.size,
+            sort = sort,
             tobyCoinLeaders = buildTobyCoinLeaders(guildId)
         )
     }
@@ -120,6 +133,7 @@ data class LeaderboardGuildView(
     val totalVoiceThisMonth: Long,
     val mostActiveMember: String?,
     val totalMembers: Int,
+    val sort: LeaderboardSort = LeaderboardSort.THIS_MONTH,
     val tobyCoinLeaders: List<TobyCoinLeaderRow> = emptyList()
 ) {
     val totalVoiceThisMonthDisplay: String get() = formatDuration(totalVoiceThisMonth)
@@ -128,6 +142,16 @@ data class LeaderboardGuildView(
         val hours = seconds / 3600
         val minutes = (seconds % 3600) / 60
         return if (hours > 0) "${hours}h ${minutes}m" else "${minutes}m"
+    }
+}
+
+enum class LeaderboardSort(val queryValue: String) {
+    THIS_MONTH("month"),
+    LIFETIME("lifetime");
+
+    companion object {
+        fun fromQuery(s: String?): LeaderboardSort =
+            entries.firstOrNull { it.queryValue == s } ?: THIS_MONTH
     }
 }
 

--- a/web/src/main/resources/static/css/leaderboard.css
+++ b/web/src/main/resources/static/css/leaderboard.css
@@ -179,6 +179,35 @@
     .lb-podium-1 { order: -1; }
 }
 
+/* -- Sort toggle (This month / Lifetime) -- */
+.lb-sort {
+    display: inline-flex;
+    background: var(--bg-input);
+    border: 1px solid var(--border-strong);
+    border-radius: var(--radius-md);
+    padding: 3px;
+    gap: 2px;
+    margin-bottom: var(--space-4);
+}
+.lb-sort-option {
+    color: var(--text-muted);
+    padding: 8px 16px;
+    border-radius: var(--radius-sm);
+    font-size: 0.9rem;
+    font-weight: 500;
+    text-decoration: none;
+    transition: background 0.15s, color 0.15s;
+}
+.lb-sort-option:hover { color: var(--text); }
+.lb-sort-option.active {
+    background: var(--accent);
+    color: #fff;
+}
+.lb-sort-option:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+}
+
 /* -- Standings table (reuses mod-table) -- */
 .lb-standings { margin-top: var(--space-5); }
 .lb-standings-title {

--- a/web/src/main/resources/templates/leaderboard.html
+++ b/web/src/main/resources/templates/leaderboard.html
@@ -33,7 +33,26 @@
         </div>
     </section>
 
-    <section class="lb-podium" aria-label="Top three" th:if="${not #lists.isEmpty(view.podium)}">
+    <nav class="lb-sort" role="tablist" aria-label="Ranking basis">
+        <a th:href="@{/leaderboard/{id}(id=${guildId}, sort='month')}"
+           role="tab"
+           class="lb-sort-option"
+           th:classappend="${view.sort.name() == 'THIS_MONTH' ? 'active' : ''}"
+           th:aria-selected="${view.sort.name() == 'THIS_MONTH'}">
+            This month
+        </a>
+        <a th:href="@{/leaderboard/{id}(id=${guildId}, sort='lifetime')}"
+           role="tab"
+           class="lb-sort-option"
+           th:classappend="${view.sort.name() == 'LIFETIME' ? 'active' : ''}"
+           th:aria-selected="${view.sort.name() == 'LIFETIME'}">
+            Lifetime
+        </a>
+    </nav>
+
+    <section class="lb-podium" aria-label="Top three"
+             th:if="${not #lists.isEmpty(view.podium)}"
+             th:with="isMonth=${view.sort.name() == 'THIS_MONTH'}">
         <!-- Render in order: 2nd, 1st, 3rd so 1st appears centered and elevated -->
         <div class="lb-podium-card lb-podium-2" th:if="${#lists.size(view.podium) >= 2}">
             <div class="lb-podium-rank">2</div>
@@ -46,9 +65,16 @@
             <span th:if="${view.podium[1].title != null}"
                   class="lb-title-pill"
                   th:text="${view.podium[1].title}">Title</span>
-            <div class="lb-podium-credits"><strong th:text="${view.podium[1].socialCredit}">0</strong> credits</div>
+            <div class="lb-podium-credits">
+                <strong th:if="${isMonth}" th:text="'+' + ${view.podium[1].creditsEarnedThisMonth}">+0</strong>
+                <strong th:unless="${isMonth}" th:text="${view.podium[1].socialCredit}">0</strong>
+                <span th:text="${isMonth ? 'this month' : 'credits'}">credits</span>
+            </div>
             <div class="lb-podium-month"
-                 th:if="${view.podium[1].creditsEarnedThisMonth > 0}"
+                 th:if="${isMonth}"
+                 th:text="${view.podium[1].socialCredit} + ' lifetime'">0 lifetime</div>
+            <div class="lb-podium-month"
+                 th:if="${!isMonth and view.podium[1].creditsEarnedThisMonth > 0}"
                  th:text="'+' + ${view.podium[1].creditsEarnedThisMonth} + ' this month'">+0 this month</div>
             <div class="lb-podium-voice" th:text="${view.podium[1].voiceThisMonthDisplay} + ' voice'">0m voice</div>
         </div>
@@ -64,9 +90,16 @@
             <span th:if="${view.podium[0].title != null}"
                   class="lb-title-pill"
                   th:text="${view.podium[0].title}">Title</span>
-            <div class="lb-podium-credits"><strong th:text="${view.podium[0].socialCredit}">0</strong> credits</div>
+            <div class="lb-podium-credits">
+                <strong th:if="${isMonth}" th:text="'+' + ${view.podium[0].creditsEarnedThisMonth}">+0</strong>
+                <strong th:unless="${isMonth}" th:text="${view.podium[0].socialCredit}">0</strong>
+                <span th:text="${isMonth ? 'this month' : 'credits'}">credits</span>
+            </div>
             <div class="lb-podium-month"
-                 th:if="${view.podium[0].creditsEarnedThisMonth > 0}"
+                 th:if="${isMonth}"
+                 th:text="${view.podium[0].socialCredit} + ' lifetime'">0 lifetime</div>
+            <div class="lb-podium-month"
+                 th:if="${!isMonth and view.podium[0].creditsEarnedThisMonth > 0}"
                  th:text="'+' + ${view.podium[0].creditsEarnedThisMonth} + ' this month'">+0 this month</div>
             <div class="lb-podium-voice" th:text="${view.podium[0].voiceThisMonthDisplay} + ' voice'">0m voice</div>
         </div>
@@ -82,9 +115,16 @@
             <span th:if="${view.podium[2].title != null}"
                   class="lb-title-pill"
                   th:text="${view.podium[2].title}">Title</span>
-            <div class="lb-podium-credits"><strong th:text="${view.podium[2].socialCredit}">0</strong> credits</div>
+            <div class="lb-podium-credits">
+                <strong th:if="${isMonth}" th:text="'+' + ${view.podium[2].creditsEarnedThisMonth}">+0</strong>
+                <strong th:unless="${isMonth}" th:text="${view.podium[2].socialCredit}">0</strong>
+                <span th:text="${isMonth ? 'this month' : 'credits'}">credits</span>
+            </div>
             <div class="lb-podium-month"
-                 th:if="${view.podium[2].creditsEarnedThisMonth > 0}"
+                 th:if="${isMonth}"
+                 th:text="${view.podium[2].socialCredit} + ' lifetime'">0 lifetime</div>
+            <div class="lb-podium-month"
+                 th:if="${!isMonth and view.podium[2].creditsEarnedThisMonth > 0}"
                  th:text="'+' + ${view.podium[2].creditsEarnedThisMonth} + ' this month'">+0 this month</div>
             <div class="lb-podium-voice" th:text="${view.podium[2].voiceThisMonthDisplay} + ' voice'">0m voice</div>
         </div>
@@ -108,8 +148,13 @@
                         <th class="lb-col-rank">#</th>
                         <th>Member</th>
                         <th>Title</th>
-                        <th class="lb-col-value">💰 Credits</th>
-                        <th>This month</th>
+                        <th class="lb-col-value"
+                            th:attr="aria-sort=${view.sort.name() == 'LIFETIME' ? 'descending' : 'none'}">
+                            💰 Credits
+                        </th>
+                        <th th:attr="aria-sort=${view.sort.name() == 'THIS_MONTH' ? 'descending' : 'none'}">
+                            This month
+                        </th>
                         <th>🎤 Voice this month</th>
                     </tr>
                     </thead>

--- a/web/src/test/kotlin/web/controller/LeaderboardControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/LeaderboardControllerTest.kt
@@ -1,0 +1,84 @@
+package web.controller
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.security.oauth2.core.user.OAuth2User
+import org.springframework.ui.Model
+import org.springframework.web.servlet.mvc.support.RedirectAttributes
+import web.service.LeaderboardGuildView
+import web.service.LeaderboardSort
+import web.service.LeaderboardWebService
+
+/**
+ * Ensures the `?sort=` query param maps to [LeaderboardSort] correctly. The
+ * view must default to THIS_MONTH when the param is missing or garbage, and
+ * must pass the active sort through to the service so the page state is
+ * consistent with the URL.
+ */
+class LeaderboardControllerTest {
+
+    private val guildId = 77L
+    private val discordId = 100L
+
+    private lateinit var leaderboardWebService: LeaderboardWebService
+    private lateinit var user: OAuth2User
+    private lateinit var controller: LeaderboardController
+
+    @BeforeEach
+    fun setup() {
+        leaderboardWebService = mockk(relaxed = true)
+        user = mockk {
+            every { getAttribute<String>("id") } returns discordId.toString()
+            every { getAttribute<String>("username") } returns "tester"
+        }
+        every { leaderboardWebService.isMember(discordId, guildId) } returns true
+        every { leaderboardWebService.getGuildView(guildId, any()) } returns emptyView()
+        controller = LeaderboardController(leaderboardWebService)
+    }
+
+    private fun emptyView() = LeaderboardGuildView(
+        guildName = "t", podium = emptyList(), standings = emptyList(),
+        totalCreditsThisMonth = 0, totalVoiceThisMonth = 0, mostActiveMember = null,
+        totalMembers = 0
+    )
+
+    private fun call(sort: String?): LeaderboardSort {
+        val model: Model = mockk(relaxed = true)
+        val ra: RedirectAttributes = mockk(relaxed = true)
+        val sortSlot = slot<LeaderboardSort>()
+        every { leaderboardWebService.getGuildView(guildId, capture(sortSlot)) } returns emptyView()
+        controller.leaderboardPage(guildId, sort, user, model, ra)
+        return sortSlot.captured
+    }
+
+    @Test
+    fun `sort=month maps to THIS_MONTH`() {
+        assertEquals(LeaderboardSort.THIS_MONTH, call("month"))
+    }
+
+    @Test
+    fun `sort=lifetime maps to LIFETIME`() {
+        assertEquals(LeaderboardSort.LIFETIME, call("lifetime"))
+    }
+
+    @Test
+    fun `missing sort defaults to THIS_MONTH`() {
+        assertEquals(LeaderboardSort.THIS_MONTH, call(null))
+    }
+
+    @Test
+    fun `unknown sort value falls back to THIS_MONTH`() {
+        assertEquals(LeaderboardSort.THIS_MONTH, call("garbage"))
+    }
+
+    @Test
+    fun `service is invoked with the resolved sort`() {
+        controller.leaderboardPage(guildId, "lifetime", user, mockk(relaxed = true), mockk(relaxed = true))
+        verify { leaderboardWebService.getGuildView(guildId, LeaderboardSort.LIFETIME) }
+    }
+}

--- a/web/src/test/kotlin/web/service/LeaderboardWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/LeaderboardWebServiceTest.kt
@@ -134,4 +134,62 @@ class LeaderboardWebServiceTest {
         assertEquals(1000L, cards.first().topCredits)
         assertEquals(1800L, cards.first().totalVoiceSeconds)
     }
+
+    // ---- sort behaviour ----
+
+    @Test
+    fun `getGuildView defaults to THIS_MONTH and ranks by creditsEarnedThisMonth`() {
+        val guild = mockk<Guild>(relaxed = true)
+        every { jda.getGuildById(guildId) } returns guild
+        every { guild.name } returns "Sort test"
+        // Alice has the biggest lifetime, Bob is the biggest earner THIS month.
+        every { moderationWebService.getLeaderboard(guildId) } returns listOf(
+            LeaderboardRow(rank = 1, discordId = "1", name = "Alice", avatarUrl = null,
+                socialCredit = 1_000, creditsEarnedThisMonth = 10),
+            LeaderboardRow(rank = 2, discordId = "2", name = "Bob", avatarUrl = null,
+                socialCredit = 500, creditsEarnedThisMonth = 400),
+            LeaderboardRow(rank = 3, discordId = "3", name = "Carol", avatarUrl = null,
+                socialCredit = 200, creditsEarnedThisMonth = 50)
+        )
+
+        val view = service.getGuildView(guildId)!!
+
+        assertEquals(LeaderboardSort.THIS_MONTH, view.sort)
+        assertEquals("Bob", view.podium[0].name, "top of podium in month mode is biggest monthly earner")
+        assertEquals(1, view.podium[0].rank, "rank reassigned to match the active sort")
+        assertEquals("Carol", view.podium[1].name)
+        assertEquals("Alice", view.podium[2].name)
+    }
+
+    @Test
+    fun `getGuildView with LIFETIME sort preserves the moderation service order`() {
+        val guild = mockk<Guild>(relaxed = true)
+        every { jda.getGuildById(guildId) } returns guild
+        every { guild.name } returns "Sort test"
+        every { moderationWebService.getLeaderboard(guildId) } returns listOf(
+            LeaderboardRow(rank = 1, discordId = "1", name = "Alice", avatarUrl = null,
+                socialCredit = 1_000, creditsEarnedThisMonth = 10),
+            LeaderboardRow(rank = 2, discordId = "2", name = "Bob", avatarUrl = null,
+                socialCredit = 500, creditsEarnedThisMonth = 400),
+            LeaderboardRow(rank = 3, discordId = "3", name = "Carol", avatarUrl = null,
+                socialCredit = 200, creditsEarnedThisMonth = 50)
+        )
+
+        val view = service.getGuildView(guildId, LeaderboardSort.LIFETIME)!!
+
+        assertEquals(LeaderboardSort.LIFETIME, view.sort)
+        assertEquals("Alice", view.podium[0].name)
+        assertEquals(1, view.podium[0].rank)
+        assertEquals("Bob", view.podium[1].name)
+        assertEquals("Carol", view.podium[2].name)
+    }
+
+    @Test
+    fun `LeaderboardSort fromQuery maps tokens and falls back to THIS_MONTH`() {
+        assertEquals(LeaderboardSort.THIS_MONTH, LeaderboardSort.fromQuery("month"))
+        assertEquals(LeaderboardSort.LIFETIME, LeaderboardSort.fromQuery("lifetime"))
+        assertEquals(LeaderboardSort.THIS_MONTH, LeaderboardSort.fromQuery(null))
+        assertEquals(LeaderboardSort.THIS_MONTH, LeaderboardSort.fromQuery(""))
+        assertEquals(LeaderboardSort.THIS_MONTH, LeaderboardSort.fromQuery("garbage"))
+    }
 }


### PR DESCRIPTION
## Summary

The podium's top three have been the same three people forever because the standings were sorted by lifetime `socialCredit`. Defaulting to `creditsEarnedThisMonth` makes the podium churn and gives newer members a realistic shot at the top.

Lifetime ranking stays reachable via a segmented toggle at the top of the page — no JS, just anchors that set `?sort=lifetime` so back button and keyboard work out of the box.

### What's different per sort

- **This month** (default): podium's big number is `+{earned this month}` with lifetime demoted to subtitle. `aria-sort="descending"` on the "This month" column header.
- **Lifetime**: podium's big number is the lifetime total, `+this month` surfaced as subtitle. `aria-sort="descending"` on the Credits column header.

### Files changed

| File | Change |
|---|---|
| `web/src/main/kotlin/web/service/LeaderboardWebService.kt` | New `LeaderboardSort` enum, `getGuildView(guildId, sort)`, re-sort + re-rank so rank 1 always matches the active view. |
| `web/src/main/kotlin/web/controller/LeaderboardController.kt` | Accept `?sort=month|lifetime`, swallow garbage tokens. |
| `web/src/main/resources/templates/leaderboard.html` | Toggle nav; podium primary/secondary swap; `aria-sort` on the active column. |
| `web/src/main/resources/static/css/leaderboard.css` | `.lb-sort` / `.lb-sort-option` styles matching the existing `.segmented` pattern. |
| `web/src/test/.../LeaderboardWebServiceTest.kt` | Default THIS_MONTH reorders podium; LIFETIME preserves moderation order; `fromQuery` maps tokens and handles null/garbage. |
| `web/src/test/.../LeaderboardControllerTest.kt` (new) | Each `?sort=` query-param token resolves to the expected `LeaderboardSort` passed into the service. |

### Test plan

- [x] `:web:test` green locally.
- [ ] Manual: visit `/leaderboard/{guildId}` → loads with "This month" active; podium ordered by monthly earnings; big number is `+{this-month}`. Click "Lifetime" → URL becomes `?sort=lifetime`; podium reorders; big number is lifetime total. Back button returns to monthly. `?sort=garbage` falls back to monthly without error.

https://claude.ai/code/session_01JvuveFBoCvMFTK8XxXVN56

---
_Generated by [Claude Code](https://claude.ai/code/session_01JvuveFBoCvMFTK8XxXVN56)_