### PR TITLE
feat(web): client-side member search on the moderation Users tab

### DIFF
--- a/web/src/main/resources/static/css/moderation.css
+++ b/web/src/main/resources/static/css/moderation.css
@@ -9,6 +9,38 @@
     color: var(--text-muted);
 }
 
+/* Member search bar on the Users tab — client-side filter. */
+.mod-search {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    margin-bottom: var(--space-3);
+}
+.mod-search-input {
+    flex: 1;
+    max-width: 360px;
+    background: var(--bg-input);
+    color: var(--text);
+    border: 1px solid var(--border-strong);
+    border-radius: var(--radius-md);
+    padding: 8px 12px;
+    font-size: 0.95rem;
+    font-family: inherit;
+    transition: border-color 0.15s, box-shadow 0.15s;
+}
+.mod-search-input::placeholder { color: var(--text-muted); }
+.mod-search-input:focus {
+    outline: none;
+    border-color: var(--accent);
+    box-shadow: 0 0 0 3px rgba(88, 101, 242, 0.2);
+}
+.mod-search-count {
+    font-size: 0.82rem;
+    color: var(--text-muted);
+    font-variant-numeric: tabular-nums;
+}
+.mod-table tr.is-hidden { display: none; }
+
 .tabs {
     display: flex;
     flex-wrap: wrap;

--- a/web/src/main/resources/static/js/moderation.js
+++ b/web/src/main/resources/static/js/moderation.js
@@ -33,6 +33,44 @@
         });
     });
 
+    // --- Users tab: client-side search filter ---
+    (function setupUserSearch() {
+        const input = document.getElementById('user-search');
+        const count = document.getElementById('user-search-count');
+        const usersPanel = document.querySelector('.tab-panel[data-panel="users"]');
+        if (!input || !usersPanel) return;
+
+        // Cache each row's lowercased display name so we don't touch the DOM
+        // per keystroke.
+        const rows = Array.from(usersPanel.querySelectorAll('.mod-table tbody tr[data-member-id]'));
+        const nameByRow = new Map(
+            rows.map(tr => {
+                const nameCell = tr.querySelector('.member-cell span');
+                return [tr, (nameCell?.textContent || '').trim().toLowerCase()];
+            })
+        );
+        const total = rows.length;
+
+        function apply(query) {
+            const q = query.trim().toLowerCase();
+            let shown = 0;
+            rows.forEach(tr => {
+                const hit = q === '' || (nameByRow.get(tr) || '').includes(q);
+                tr.classList.toggle('is-hidden', !hit);
+                if (hit) shown++;
+            });
+            if (count) {
+                count.textContent = q === '' ? '' : shown + ' of ' + total;
+            }
+        }
+
+        input.addEventListener('input', () => apply(input.value));
+        // Esc clears the filter.
+        input.addEventListener('keydown', e => {
+            if (e.key === 'Escape') { input.value = ''; apply(''); }
+        });
+    })();
+
     // --- Users tab: permission toggles ---
     document.querySelectorAll('.toggle-btn').forEach(btn => {
         btn.addEventListener('click', () => {

--- a/web/src/main/resources/templates/moderation.html
+++ b/web/src/main/resources/templates/moderation.html
@@ -36,6 +36,16 @@
             View the full credit standings on the
             <a th:href="@{/leaderboard/{id}(id=${overview.guildId})}">leaderboard page</a>.
         </p>
+        <div class="mod-search">
+            <label for="user-search" class="sr-only">Search members</label>
+            <input id="user-search"
+                   type="search"
+                   class="mod-search-input"
+                   placeholder="Search members by name…"
+                   autocomplete="off"
+                   aria-describedby="user-search-count">
+            <span id="user-search-count" class="mod-search-count" aria-live="polite"></span>
+        </div>
         <div class="mod-table-wrap">
             <table class="mod-table">
                 <thead>


### PR DESCRIPTION
## Summary

Scanning the full member list to find one person was painful on busy servers. Adds a small search input above the users table that filters rows by name as you type.

- Pure client-side — no new endpoints, no round-trips per keystroke.
- Names are lowercased and cached per row on page load, so the filter is O(n) per keystroke against in-memory strings.
- Live-region count (`aria-live="polite"`) announces `N of M` as you type.
- **Esc clears** the filter.
- `.is-hidden` class just toggles `display: none` — existing permission toggles and social-credit adjust still wire up to hidden rows, so clearing the filter restores them as-is.

### Files changed

| File | Change |
|---|---|
| `web/src/main/resources/templates/moderation.html` | New search input + live count above the user table. |
| `web/src/main/resources/static/css/moderation.css` | `.mod-search` / `.mod-search-input` / `.is-hidden` styles. |
| `web/src/main/resources/static/js/moderation.js` | `setupUserSearch()` closure caches row names and filters on input. |

### Test plan

- [x] `:web:test` green (no server-side change).
- [ ] Manual: `/moderation/{guildId}` Users tab → type a name fragment, non-matching rows vanish, count updates; Esc clears; backspace restores full list; toggling a permission on a filtered row still updates correctly.

https://claude.ai/code/session_01JvuveFBoCvMFTK8XxXVN56

---
_Generated by [Claude Code](https://claude.ai/code/session_01JvuveFBoCvMFTK8XxXVN56)_