### PR TITLE
fix(web): lazy-fill missing monthly baselines so credit/coin deltas work now

### DIFF
--- a/application/src/test/kotlin/integration/database/MonthlyCreditSnapshotServiceIntegrationTest.kt
+++ b/application/src/test/kotlin/integration/database/MonthlyCreditSnapshotServiceIntegrationTest.kt
@@ -119,4 +119,37 @@ class MonthlyCreditSnapshotServiceIntegrationTest {
         assertEquals(9L, rows[444L]?.tobyCoins)
         assertEquals(80L, rows[444L]?.socialCredit)
     }
+
+    @Test
+    fun `upsertIfMissing inserts when absent and is a no-op when present`() {
+        val date = snapshotDate.plusMonths(2)
+        val discordId = 555L
+
+        // First call: row doesn't exist, should be inserted.
+        val inserted = service.upsertIfMissing(
+            MonthlyCreditSnapshotDto(
+                discordId = discordId, guildId = guildId, snapshotDate = date,
+                socialCredit = 100L, tobyCoins = 20L
+            )
+        )
+        assertEquals(100L, inserted.socialCredit)
+        assertEquals(20L, inserted.tobyCoins)
+
+        // Second call with different values: must NOT clobber the existing row,
+        // because lazy-baseline is meant to snapshot once per month, not
+        // overwrite each page load.
+        val attempted = service.upsertIfMissing(
+            MonthlyCreditSnapshotDto(
+                discordId = discordId, guildId = guildId, snapshotDate = date,
+                socialCredit = 999L, tobyCoins = 999L
+            )
+        )
+        assertEquals(100L, attempted.socialCredit, "must return existing, not the new dto")
+        assertEquals(20L, attempted.tobyCoins)
+
+        // Persisted state matches existing row, not the attempted overwrite.
+        val persisted = service.get(discordId, guildId, date)!!
+        assertEquals(100L, persisted.socialCredit)
+        assertEquals(20L, persisted.tobyCoins)
+    }
 }

--- a/database/src/main/kotlin/database/persistence/MonthlyCreditSnapshotPersistence.kt
+++ b/database/src/main/kotlin/database/persistence/MonthlyCreditSnapshotPersistence.kt
@@ -7,4 +7,15 @@ interface MonthlyCreditSnapshotPersistence {
     fun get(discordId: Long, guildId: Long, snapshotDate: LocalDate): MonthlyCreditSnapshotDto?
     fun listForGuildDate(guildId: Long, snapshotDate: LocalDate): List<MonthlyCreditSnapshotDto>
     fun upsert(dto: MonthlyCreditSnapshotDto): MonthlyCreditSnapshotDto
+
+    /**
+     * Inserts the snapshot only when none exists for that (discordId, guildId,
+     * snapshotDate). Returns the existing row unmodified if one is present —
+     * unlike [upsert], this does not clobber existing counter values.
+     *
+     * Used to lazy-fill baselines when the monthly scheduler hasn't run (fresh
+     * deploy, new guild, bot was down on the 1st) so "this month" deltas
+     * become meaningful from the next earn onwards.
+     */
+    fun upsertIfMissing(dto: MonthlyCreditSnapshotDto): MonthlyCreditSnapshotDto
 }

--- a/database/src/main/kotlin/database/persistence/impl/DefaultMonthlyCreditSnapshotPersistence.kt
+++ b/database/src/main/kotlin/database/persistence/impl/DefaultMonthlyCreditSnapshotPersistence.kt
@@ -47,4 +47,12 @@ class DefaultMonthlyCreditSnapshotPersistence : MonthlyCreditSnapshotPersistence
             existing
         }
     }
+
+    override fun upsertIfMissing(dto: MonthlyCreditSnapshotDto): MonthlyCreditSnapshotDto {
+        val existing = get(dto.discordId, dto.guildId, dto.snapshotDate)
+        if (existing != null) return existing
+        entityManager.persist(dto)
+        entityManager.flush()
+        return dto
+    }
 }

--- a/database/src/main/kotlin/database/service/MonthlyCreditSnapshotService.kt
+++ b/database/src/main/kotlin/database/service/MonthlyCreditSnapshotService.kt
@@ -7,4 +7,5 @@ interface MonthlyCreditSnapshotService {
     fun get(discordId: Long, guildId: Long, snapshotDate: LocalDate): MonthlyCreditSnapshotDto?
     fun listForGuildDate(guildId: Long, snapshotDate: LocalDate): List<MonthlyCreditSnapshotDto>
     fun upsert(dto: MonthlyCreditSnapshotDto): MonthlyCreditSnapshotDto
+    fun upsertIfMissing(dto: MonthlyCreditSnapshotDto): MonthlyCreditSnapshotDto
 }

--- a/database/src/main/kotlin/database/service/impl/DefaultMonthlyCreditSnapshotService.kt
+++ b/database/src/main/kotlin/database/service/impl/DefaultMonthlyCreditSnapshotService.kt
@@ -18,4 +18,7 @@ class DefaultMonthlyCreditSnapshotService @Autowired constructor(
         persistence.listForGuildDate(guildId, snapshotDate)
 
     override fun upsert(dto: MonthlyCreditSnapshotDto): MonthlyCreditSnapshotDto = persistence.upsert(dto)
+
+    override fun upsertIfMissing(dto: MonthlyCreditSnapshotDto): MonthlyCreditSnapshotDto =
+        persistence.upsertIfMissing(dto)
 }

--- a/web/src/main/kotlin/web/service/LeaderboardWebService.kt
+++ b/web/src/main/kotlin/web/service/LeaderboardWebService.kt
@@ -89,13 +89,36 @@ class LeaderboardWebService(
         val thisMonthStart = LocalDate.now(ZoneOffset.UTC).withDayOfMonth(1)
         // Best-effort: if the snapshot table read fails (schema drift on an old
         // deploy), degrade gracefully and skip the delta rather than 500 the page.
-        val baselineByUser = runCatching {
+        val baselines = runCatching {
             snapshotService.listForGuildDate(guildId, thisMonthStart)
-                .associate { it.discordId to it.tobyCoins }
-        }.getOrDefault(emptyMap())
+                .associateBy { it.discordId }
+        }.getOrDefault(emptyMap()).toMutableMap()
 
-        return userService.listGuildUsers(guildId).asSequence()
-            .filterNotNull()
+        val allUsers = userService.listGuildUsers(guildId).filterNotNull()
+
+        // Lazy-baseline: if the scheduled monthly job hasn't yet snapshotted
+        // this user for this month's 1st, write one now using their current
+        // balance. Mirrors ModerationWebService so both leaderboards share
+        // the same baseline and the delta becomes meaningful from the next
+        // trade onwards. ModerationWebService usually wins this race because
+        // it runs first in getGuildView; this block is a safety net.
+        allUsers.forEach { dto ->
+            if (!baselines.containsKey(dto.discordId)) {
+                runCatching {
+                    snapshotService.upsertIfMissing(
+                        database.dto.MonthlyCreditSnapshotDto(
+                            discordId = dto.discordId,
+                            guildId = guildId,
+                            snapshotDate = thisMonthStart,
+                            socialCredit = dto.socialCredit ?: 0L,
+                            tobyCoins = dto.tobyCoins
+                        )
+                    )
+                }.getOrNull()?.let { baselines[dto.discordId] = it }
+            }
+        }
+
+        return allUsers.asSequence()
             .filter { it.tobyCoins > 0L }
             .sortedByDescending { it.tobyCoins }
             .take(TOBY_COIN_LEADERBOARD_LIMIT)
@@ -104,11 +127,7 @@ class LeaderboardWebService(
                 val title = runCatching {
                     dto.activeTitleId?.let { titleService.getById(it) }?.label
                 }.getOrNull()
-                // If there's no snapshot row for this user yet, report 0 rather
-                // than the full current balance — "all their coins this month"
-                // is misleading for users who held TOBY before we started
-                // tracking the delta.
-                val coinsThisMonth = baselineByUser[dto.discordId]?.let { dto.tobyCoins - it } ?: 0L
+                val coinsThisMonth = baselines[dto.discordId]?.let { dto.tobyCoins - it.tobyCoins } ?: 0L
                 TobyCoinLeaderRow(
                     rank = index + 1,
                     discordId = dto.discordId.toString(),

--- a/web/src/main/kotlin/web/service/ModerationWebService.kt
+++ b/web/src/main/kotlin/web/service/ModerationWebService.kt
@@ -124,9 +124,31 @@ class ModerationWebService(
                 thisMonthStart.atStartOfDay().toInstant(ZoneOffset.UTC)
             )
         }
-        val priorSnapshots = safely("prior snapshots", emptyList<database.dto.MonthlyCreditSnapshotDto>()) {
+        val existingBaselines = safely("prior snapshots", emptyList<database.dto.MonthlyCreditSnapshotDto>()) {
             snapshotService.listForGuildDate(guildId, thisMonthStart)
-        }.associateBy { it.discordId }
+        }.associateBy { it.discordId }.toMutableMap()
+
+        // Lazy-baseline: if a user has no snapshot row for this month's 1st
+        // (fresh deploy, new guild, bot was down on the 1st), the scheduled
+        // job hasn't run for them and "this month" delta would report 0
+        // forever. Snapshot their current balance now so the NEXT earn
+        // produces a correct delta. One-time cost: earnings between the 1st
+        // and this first visit are baked into the baseline.
+        users.forEach { dto ->
+            if (!existingBaselines.containsKey(dto.discordId)) {
+                safely("lazy baseline for ${dto.discordId}", null as database.dto.MonthlyCreditSnapshotDto?) {
+                    snapshotService.upsertIfMissing(
+                        database.dto.MonthlyCreditSnapshotDto(
+                            discordId = dto.discordId,
+                            guildId = guildId,
+                            snapshotDate = thisMonthStart,
+                            socialCredit = dto.socialCredit ?: 0L,
+                            tobyCoins = dto.tobyCoins
+                        )
+                    )
+                }?.let { existingBaselines[dto.discordId] = it }
+            }
+        }
 
         return users
             .sortedByDescending { it.socialCredit ?: 0L }
@@ -136,7 +158,7 @@ class ModerationWebService(
                     dto.activeTitleId?.let { titleService.getById(it) }?.label
                 }
                 val current = dto.socialCredit ?: 0L
-                val baseline = priorSnapshots[dto.discordId]?.socialCredit
+                val baseline = existingBaselines[dto.discordId]?.socialCredit
                 val creditsDelta = if (baseline == null) 0L else current - baseline
                 LeaderboardRow(
                     rank = index + 1,

--- a/web/src/test/kotlin/web/service/LeaderboardWebServiceTobyCoinTest.kt
+++ b/web/src/test/kotlin/web/service/LeaderboardWebServiceTobyCoinTest.kt
@@ -10,6 +10,7 @@ import database.service.TobyCoinMarketService
 import database.service.UserService
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
 import net.dv8tion.jda.api.JDA
 import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.entities.Member
@@ -211,12 +212,14 @@ class LeaderboardWebServiceTobyCoinTest {
         )
         every { guild.getMemberById(1L) } returns member(1L, "Alice")
         every { snapshotService.listForGuildDate(guildId, any()) } returns emptyList()
+        // Lazy-write returns a baseline = current, so the first-visit delta is 0.
+        every { snapshotService.upsertIfMissing(any()) } answers { firstArg() }
 
         val leaders = checkNotNull(service.getGuildView(guildId)).tobyCoinLeaders
 
         assertEquals(1, leaders.size)
         assertEquals(0L, leaders[0].coinsThisMonth,
-            "no snapshot yet -> report 0, not the full balance (otherwise first-month users look like whales)")
+            "no snapshot yet -> lazy-write baseline = current -> delta = 0 (future earns will show positive)")
         assertEquals(500L, leaders[0].coins, "current coin balance unaffected")
     }
 
@@ -230,10 +233,38 @@ class LeaderboardWebServiceTobyCoinTest {
         every { guild.getMemberById(1L) } returns member(1L, "Alice")
         every { snapshotService.listForGuildDate(guildId, any()) } throws
             RuntimeException("column toby_coins does not exist")
+        // If the read threw, the write would throw for the same reason —
+        // simulate that here so the fallback behaviour is honest.
+        every { snapshotService.upsertIfMissing(any()) } throws
+            RuntimeException("column toby_coins does not exist")
 
         val leaders = checkNotNull(service.getGuildView(guildId)).tobyCoinLeaders
 
         assertEquals(1, leaders.size, "page must still render even if the snapshot read fails")
         assertEquals(0L, leaders[0].coinsThisMonth)
+    }
+
+    @Test
+    fun `buildTobyCoinLeaders lazy-writes a baseline when none exists`() {
+        every { marketService.getMarket(guildId) } returns
+            TobyCoinMarketDto(guildId = guildId, price = 1.0, lastTickAt = Instant.now())
+        every { userService.listGuildUsers(guildId) } returns listOf(
+            UserDto(discordId = 1L, guildId = guildId).apply {
+                socialCredit = 500L
+                tobyCoins = 40L
+            }
+        )
+        every { guild.getMemberById(1L) } returns member(1L, "Alice")
+        every { snapshotService.listForGuildDate(guildId, any()) } returns emptyList()
+        val captured = slot<MonthlyCreditSnapshotDto>()
+        every { snapshotService.upsertIfMissing(capture(captured)) } answers { firstArg() }
+
+        val leaders = checkNotNull(service.getGuildView(guildId)).tobyCoinLeaders
+
+        assertEquals(0L, leaders[0].coinsThisMonth, "first visit: baseline = current, delta = 0")
+        assertEquals(1L, captured.captured.discordId)
+        assertEquals(40L, captured.captured.tobyCoins, "baseline must include current TOBY balance")
+        assertEquals(500L, captured.captured.socialCredit,
+            "baseline must also include social credit so the two leaderboards agree")
     }
 }

--- a/web/src/test/kotlin/web/service/ModerationWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/ModerationWebServiceTest.kt
@@ -11,6 +11,7 @@ import database.service.UserService
 import database.service.VoiceSessionService
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
 import io.mockk.unmockkAll
 import io.mockk.verify
 import net.dv8tion.jda.api.JDA
@@ -439,9 +440,58 @@ class ModerationWebServiceTest {
         every { voiceSessionService.sumCountedSecondsLifetimeByUser(guildId) } returns emptyMap()
         every { voiceSessionService.sumCountedSecondsInRangeByUser(guildId, any(), any()) } returns emptyMap()
         every { snapshotService.listForGuildDate(guildId, any()) } returns emptyList()
+        // Lazy-write returns a baseline DTO whose socialCredit matches current,
+        // so the delta for a first-time visit is 0 (consistent with the old
+        // behaviour — earnings from 1st-of-month to this visit get absorbed).
+        every { snapshotService.upsertIfMissing(any()) } answers { firstArg() }
 
         val rows = service.getLeaderboard(guildId)
         assertEquals(0L, rows.first().creditsEarnedThisMonth)
+    }
+
+    @Test
+    fun `getLeaderboard lazy-writes a baseline when none exists for this month`() {
+        val user = UserDto(discordId = plainUserId, guildId = guildId).apply {
+            socialCredit = 1_000L
+            tobyCoins = 12L
+        }
+        every { userService.listGuildUsers(guildId) } returns listOf(user)
+        mockMember(plainUserId)
+        every { voiceSessionService.sumCountedSecondsLifetimeByUser(guildId) } returns emptyMap()
+        every { voiceSessionService.sumCountedSecondsInRangeByUser(guildId, any(), any()) } returns emptyMap()
+        every { snapshotService.listForGuildDate(guildId, any()) } returns emptyList()
+        val captured = slot<MonthlyCreditSnapshotDto>()
+        every { snapshotService.upsertIfMissing(capture(captured)) } answers { firstArg() }
+
+        service.getLeaderboard(guildId)
+
+        // Baseline must capture BOTH counters so the wallet leaderboard is
+        // consistent with the social-credit leaderboard. Writing only
+        // socialCredit here and leaving tobyCoins = 0 would regress the
+        // wallet delta to "all current coins earned this month".
+        assertEquals(plainUserId, captured.captured.discordId)
+        assertEquals(guildId, captured.captured.guildId)
+        assertEquals(1_000L, captured.captured.socialCredit)
+        assertEquals(12L, captured.captured.tobyCoins)
+    }
+
+    @Test
+    fun `getLeaderboard does NOT lazy-write when baseline already exists`() {
+        val user = UserDto(discordId = plainUserId, guildId = guildId).apply { socialCredit = 1_050L }
+        every { userService.listGuildUsers(guildId) } returns listOf(user)
+        mockMember(plainUserId)
+        every { voiceSessionService.sumCountedSecondsLifetimeByUser(guildId) } returns emptyMap()
+        every { voiceSessionService.sumCountedSecondsInRangeByUser(guildId, any(), any()) } returns emptyMap()
+        every { snapshotService.listForGuildDate(guildId, any()) } returns listOf(
+            MonthlyCreditSnapshotDto(discordId = plainUserId, guildId = guildId, socialCredit = 1_000L)
+        )
+
+        val rows = service.getLeaderboard(guildId)
+
+        // Skipping lazy-write is the whole point — scheduled job already
+        // wrote the baseline, the user earned 50 since then.
+        assertEquals(50L, rows.first().creditsEarnedThisMonth)
+        verify(exactly = 0) { snapshotService.upsertIfMissing(any()) }
     }
 
     @Test
@@ -454,6 +504,10 @@ class ModerationWebServiceTest {
         every { voiceSessionService.sumCountedSecondsInRangeByUser(guildId, any(), any()) } throws
             RuntimeException("relation \"voice_session\" does not exist")
         every { snapshotService.listForGuildDate(guildId, any()) } throws
+            RuntimeException("relation \"monthly_credit_snapshot\" does not exist")
+        // Lazy-write would hit the same missing table; simulate that so the
+        // assertion reflects real-world behaviour.
+        every { snapshotService.upsertIfMissing(any()) } throws
             RuntimeException("relation \"monthly_credit_snapshot\" does not exist")
 
         val rows = service.getLeaderboard(guildId)


### PR DESCRIPTION
## Summary

The leaderboard's "This month" columns have been silently reporting **0** for any guild where the monthly scheduled job (cron `0 0 12 1 * *` UTC) hasn't run — fresh deploys, brand-new guilds, or bots that were down on the 1st. Credits/coins earned mid-month land on the user correctly, but without a baseline snapshot for this-month-1st, the delta formula returns 0 and "This month" looks dead.

Repro: user joined voice + played intro on a test server, `users.social_credit` went up, but `/moderation` / `/leaderboard` kept showing 0 for "This month" because the April-1st snapshot row never existed for that guild.

> **Stacked on #279** — targets `main`, so until #279 lands the diff will also include its commits. Compare branch-to-branch if you want just the lazy-fill delta.

## Fix

### `upsertIfMissing`

New method on `MonthlyCreditSnapshotService`: insert only if no row exists for `(discordId, guildId, snapshotDate)`; otherwise return the existing row unchanged. Unlike `upsert` it does NOT clobber counter values — idempotent across concurrent lazy-fills.

### `ModerationWebService.getLeaderboard`

For each user without a baseline for this-month-1st, lazy-write one capturing the user's current `(socialCredit, tobyCoins)`. Wrapped in the existing `safely` helper so schema-level failures still let the page render.

### `LeaderboardWebService.buildTobyCoinLeaders`

Mirrors the same lazy-fill under `runCatching`. Belt-and-braces: moderation usually runs first in `getGuildView` and wins the race; this covers the wallet-only path defensively.

### Why both counters in one write

If `ModerationWebService` wrote only `socialCredit` and `LeaderboardWebService` wrote only `tobyCoins`, whichever ran second would clobber the other's value via the existing `MonthlyCreditSnapshotDto` merge-both-fields upsert. The lazy-fill DTO therefore always carries both.

## Consequence

**One-time cost:** for any guild that hadn't been backfilled, earnings between the 1st and the first post-deploy leaderboard visit get absorbed into the baseline (reported as 0 earned this month). Every earn *after* that produces the correct delta.

## Tests

- **Integration** — `MonthlyCreditSnapshotServiceIntegrationTest` gains `upsertIfMissing inserts when absent and is a no-op when present`, exercising real H2 + JPA.
- **Unit (moderation)** — `ModerationWebServiceTest` gains `lazy-writes a baseline when none exists` (captures DTO, asserts both counters) and `does NOT lazy-write when baseline already exists` (verifies no spurious writes, delta=earned).
- **Unit (wallet)** — `LeaderboardWebServiceTobyCoinTest` gains `buildTobyCoinLeaders lazy-writes a baseline when none exists` (captures both counters).
- Existing tests adjusted to mock `upsertIfMissing` in the new code path. The schema-failure test also stubs the write as failing — which is honest: if the read fails because the table is missing, so would the write.

## Test plan

- [x] `:web:test :database:test` green locally.
- [ ] Deploy: visit `/leaderboard/{testGuildId}` once → baseline snapshot rows appear. Earn more social credit / trade TOBY → "This month" column shows `+N` on the next refresh. Confirms the user's repro is fixed going forward.

https://claude.ai/code/session_01JvuveFBoCvMFTK8XxXVN56

---
_Generated by [Claude Code](https://claude.ai/code/session_01JvuveFBoCvMFTK8XxXVN56)_