### PR TITLE
feat(voice): flush open sessions cleanly on shutdown (DisposableBean)

### DIFF
--- a/discord-bot/src/main/kotlin/bot/toby/voice/VoiceCreditAwardService.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/voice/VoiceCreditAwardService.kt
@@ -56,4 +56,22 @@ class VoiceCreditAwardService @Autowired constructor(
         val cappedSeconds = rawSeconds.coerceAtMost(VoiceCreditConfig.MAX_RECOVERED_SESSION_SECONDS)
         closeSessionAndAward(session, closedAt, cappedSeconds)
     }
+
+    /**
+     * Close a still-open session because the bot is shutting down cleanly.
+     * The user's session was live right up to this moment, so we treat the
+     * entire duration as counted — no 8h recovery cap, since a session can't
+     * outlive the uptime that spawned it. Stopping the bot here means:
+     *
+     *   - `leftAt` reflects the actual shutdown time (not whenever the bot
+     *     wakes up next, which can be hours later and would inflate credit)
+     *   - Credits get awarded immediately rather than deferred to startup
+     *   - On the next boot, [VoiceSessionRecoveryHook] sees nothing to
+     *     recover for this user, so no over-count path exists for clean
+     *     deploys. Crash shutdowns still fall through to recovery.
+     */
+    fun closeSessionAtShutdown(session: VoiceSessionDto, closedAt: Instant) {
+        val rawSeconds = Duration.between(session.joinedAt, closedAt).seconds.coerceAtLeast(0)
+        closeSessionAndAward(session, closedAt, rawSeconds)
+    }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/voice/VoiceSessionShutdownHook.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/voice/VoiceSessionShutdownHook.kt
@@ -1,0 +1,52 @@
+package bot.toby.voice
+
+import common.logging.DiscordLogger
+import database.service.VoiceSessionService
+import org.springframework.beans.factory.DisposableBean
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+import java.time.Instant
+
+/**
+ * Closes any open voice sessions at the moment of a clean shutdown (Spring
+ * context destroy — deploys, rolling restarts, SIGTERM under a sensible
+ * orchestrator).
+ *
+ * Complements [VoiceSessionRecoveryHook], which handles the *crash* case
+ * after the fact. Without this hook, every deploy leaves open sessions on
+ * disk that the next boot closes using bot-wake-time — which inflates
+ * counted seconds for any user that actually left voice during the outage.
+ * With this hook, clean deploys close sessions at their true leave moment
+ * (i.e. right now) and the recovery path on the next boot has nothing to do.
+ */
+@Component
+class VoiceSessionShutdownHook @Autowired constructor(
+    private val voiceSessionService: VoiceSessionService,
+    private val voiceCreditAwardService: VoiceCreditAwardService
+) : DisposableBean {
+    private val logger: DiscordLogger = DiscordLogger.createLogger(this::class.java)
+
+    override fun destroy() {
+        closeOpenSessions()
+    }
+
+    fun closeOpenSessions() {
+        val now = Instant.now()
+        val open = runCatching { voiceSessionService.findAllOpenSessions() }
+            .onFailure { logger.error("Could not query open voice sessions on shutdown: ${it.message}") }
+            .getOrDefault(emptyList())
+
+        if (open.isEmpty()) {
+            logger.info { "No live voice sessions to flush on shutdown." }
+            return
+        }
+
+        logger.info { "Flushing ${open.size} live voice session(s) before shutdown." }
+        open.forEach { session ->
+            runCatching { voiceCreditAwardService.closeSessionAtShutdown(session, now) }
+                .onFailure {
+                    logger.error("Failed to close voice session id=${session.id} on shutdown: ${it.message}")
+                }
+        }
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/voice/VoiceCreditAwardServiceTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/voice/VoiceCreditAwardServiceTest.kt
@@ -146,6 +146,36 @@ class VoiceCreditAwardServiceTest {
     }
 
     @Test
+    fun `closeSessionAtShutdown awards full raw seconds without the recovery cap`() {
+        val t0 = Instant.parse("2026-04-10T10:00:00Z")
+        every { awardService.award(any(), any(), any(), any(), any(), any(), any()) } returns 0L
+        val closed = slot<VoiceSessionDto>()
+        every { voiceSessionService.closeSession(capture(closed)) } answers { closed.captured }
+
+        // 3600s session, shutdown right at the end. Whole duration must count —
+        // this is the reason shutdown is different from recovery: we KNOW the
+        // user was present up to this instant.
+        service.closeSessionAtShutdown(session(t0), t0.plusSeconds(3600L))
+
+        assertEquals(3600L, closed.captured.countedSeconds)
+        assertEquals(t0.plusSeconds(3600L), closed.captured.leftAt,
+            "leftAt must reflect the actual shutdown moment, not any later wake-time")
+    }
+
+    @Test
+    fun `closeSessionAtShutdown treats a negative duration as zero`() {
+        // Clock skew / backwards-moving Instant.now — shouldn't produce negative credits.
+        val t0 = Instant.parse("2026-04-10T10:00:00Z")
+        every { awardService.award(any(), any(), any(), any(), any(), any(), any()) } returns 0L
+        val closed = slot<VoiceSessionDto>()
+        every { voiceSessionService.closeSession(capture(closed)) } answers { closed.captured }
+
+        service.closeSessionAtShutdown(session(t0), t0.minusSeconds(10L))
+
+        assertEquals(0L, closed.captured.countedSeconds)
+    }
+
+    @Test
     fun `closeSessionAndAward records zero when award service returns zero (unknown user)`() {
         val t0 = Instant.parse("2026-04-10T10:00:00Z")
         // Simulate "user doesn't exist" — central service returns 0 without consuming cap.

--- a/discord-bot/src/test/kotlin/bot/toby/voice/VoiceSessionShutdownHookTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/voice/VoiceSessionShutdownHookTest.kt
@@ -1,0 +1,85 @@
+package bot.toby.voice
+
+import database.dto.VoiceSessionDto
+import database.service.VoiceSessionService
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+class VoiceSessionShutdownHookTest {
+
+    private lateinit var voiceSessionService: VoiceSessionService
+    private lateinit var voiceCreditAwardService: VoiceCreditAwardService
+    private lateinit var hook: VoiceSessionShutdownHook
+
+    @BeforeEach
+    fun setup() {
+        voiceSessionService = mockk(relaxed = true)
+        voiceCreditAwardService = mockk(relaxed = true)
+        hook = VoiceSessionShutdownHook(voiceSessionService, voiceCreditAwardService)
+    }
+
+    @Test
+    fun `closeOpenSessions calls closeSessionAtShutdown for each live session`() {
+        val s1 = VoiceSessionDto(id = 1L, discordId = 1L, guildId = 10L, channelId = 100L, joinedAt = Instant.now())
+        val s2 = VoiceSessionDto(id = 2L, discordId = 2L, guildId = 10L, channelId = 100L, joinedAt = Instant.now())
+        every { voiceSessionService.findAllOpenSessions() } returns listOf(s1, s2)
+
+        hook.closeOpenSessions()
+
+        // Must use the shutdown-specific close method, not closeRecoveredSession.
+        // closeRecoveredSession applies an 8h cap and is intended for the boot-
+        // time recovery path (where the real leave moment is unknown). On
+        // shutdown we KNOW the session was live up to this instant, so we award
+        // the full duration via closeSessionAtShutdown.
+        verify(exactly = 1) { voiceCreditAwardService.closeSessionAtShutdown(s1, any()) }
+        verify(exactly = 1) { voiceCreditAwardService.closeSessionAtShutdown(s2, any()) }
+        verify(exactly = 0) { voiceCreditAwardService.closeRecoveredSession(any(), any()) }
+    }
+
+    @Test
+    fun `closeOpenSessions is a no-op when nobody is in voice`() {
+        every { voiceSessionService.findAllOpenSessions() } returns emptyList()
+
+        hook.closeOpenSessions()
+
+        verify(exactly = 0) { voiceCreditAwardService.closeSessionAtShutdown(any(), any()) }
+    }
+
+    @Test
+    fun `closeOpenSessions continues after per-session failure so deploy can finish`() {
+        val s1 = VoiceSessionDto(id = 1L, discordId = 1L, guildId = 10L, channelId = 100L, joinedAt = Instant.now())
+        val s2 = VoiceSessionDto(id = 2L, discordId = 2L, guildId = 10L, channelId = 100L, joinedAt = Instant.now())
+        every { voiceSessionService.findAllOpenSessions() } returns listOf(s1, s2)
+        every { voiceCreditAwardService.closeSessionAtShutdown(s1, any()) } throws RuntimeException("boom")
+
+        // Must not propagate — blowing up in destroy() could leave subsequent
+        // shutdown hooks unrun and corrupt a rolling deploy.
+        hook.closeOpenSessions()
+
+        verify(exactly = 1) { voiceCreditAwardService.closeSessionAtShutdown(s2, any()) }
+    }
+
+    @Test
+    fun `destroy delegates to closeOpenSessions so Spring triggers the flush`() {
+        val s1 = VoiceSessionDto(id = 1L, discordId = 1L, guildId = 10L, channelId = 100L, joinedAt = Instant.now())
+        every { voiceSessionService.findAllOpenSessions() } returns listOf(s1)
+
+        hook.destroy()
+
+        verify(exactly = 1) { voiceCreditAwardService.closeSessionAtShutdown(s1, any()) }
+    }
+
+    @Test
+    fun `closeOpenSessions survives the query itself failing`() {
+        every { voiceSessionService.findAllOpenSessions() } throws RuntimeException("db down")
+
+        // Don't want a failed DB read to crash shutdown — log and move on.
+        hook.closeOpenSessions()
+
+        verify(exactly = 0) { voiceCreditAwardService.closeSessionAtShutdown(any(), any()) }
+    }
+}


### PR DESCRIPTION
## Summary

When the bot goes down uncleanly, `VoiceSessionRecoveryHook` closes open sessions on the next boot using `Instant.now()` (bot-wake time) as `leftAt`, capped at 8h. Users who left voice **during** the downtime get credited for time they weren't there.

For crashes that's unavoidable. For **deploys and rolling restarts** — the vast majority of shutdowns — we can do better: we're still alive when the JVM begins shutting down, so flush open sessions with the real "now" and let `leftAt` reflect reality.

## Changes

### `VoiceSessionShutdownHook` (new, `DisposableBean`)

Symmetric partner of `VoiceSessionRecoveryHook`. On Spring context destroy:

1. `voiceSessionService.findAllOpenSessions()`
2. For each, `voiceCreditAwardService.closeSessionAtShutdown(session, Instant.now())`
3. Next boot: recovery path finds nothing to recover for clean deploys.

Crash case still falls through to `VoiceSessionRecoveryHook` unchanged — the two hooks cooperate.

### `VoiceCreditAwardService.closeSessionAtShutdown` (new)

Awards the full raw session duration **without** the 8h recovery cap, since a session can't outlive bot uptime. Semantic distinction from `closeRecoveredSession` (which guesses the leave moment and caps accordingly).

## Tests

| Test file | Assertion |
|---|---|
| `VoiceSessionShutdownHookTest` (new) | Uses shutdown-specific close method (not recovery); no-op when empty; continues after per-session failure; `destroy()` delegates to `closeOpenSessions`; survives DB query failure |
| `VoiceCreditAwardServiceTest` (+2 tests) | Awards full raw seconds with no cap; `leftAt` is the shutdown moment; clamps negative clock-skew durations to 0 |

### Sandbox limitation

Couldn't run `:discord-bot:test` locally — sandbox can't resolve the `libdave-impl-jni` JDA native dep. CI will exercise both new test files.

## Test plan

- [ ] CI `build` job green (runs `:discord-bot:test`).
- [ ] Manual: on next deploy, bot logs `Flushing N live voice session(s) before shutdown.` during termination; next boot logs `No stale voice sessions to recover.`; no inflated voice credit on users who were in a channel during the deploy.

https://claude.ai/code/session_01JvuveFBoCvMFTK8XxXVN56

---
_Generated by [Claude Code](https://claude.ai/code/session_01JvuveFBoCvMFTK8XxXVN56)_