### PR TITLE
tune(market): more volatile, slight upward bias, gentler trade impact

### DIFF
--- a/database/src/main/kotlin/database/economy/TobyCoinEngine.kt
+++ b/database/src/main/kotlin/database/economy/TobyCoinEngine.kt
@@ -25,17 +25,28 @@ object TobyCoinEngine {
     /** Scheduled tick cadence — also used as Δt in the GBM formula. */
     const val TICK_INTERVAL_SECONDS = 5L * 60L
 
-    /** Annualised volatility. 0.6 ≈ typical small-cap / crypto territory. */
-    const val VOLATILITY = 0.6
+    /**
+     * Annualised volatility. 1.5 ≈ memecoin / small-cap territory — gives
+     * roughly ±0.5 % per 5-min tick and ±8 % per day, dramatic enough that
+     * the chart visibly moves but recoverable enough that holders aren't
+     * wiped out by a bad afternoon.
+     */
+    const val VOLATILITY = 1.5
 
-    // Drift chosen so E[log(S_{t+dt}/S_t)] = 0 — the median path is flat and
-    // the walk is equally likely to go up or down each tick. With DRIFT=0 the
-    // lognormal Itô correction makes the median decay, so most observed paths
-    // trend downward even though the mean is conserved.
-    const val DRIFT = 0.5 * VOLATILITY * VOLATILITY
+    /**
+     * Slight positive drift on top of the lognormal Itô correction, so the
+     * median path trends upward instead of being flat. With pure
+     * `0.5 * σ²` the median is technically flat but human eyes read the
+     * lognormal asymmetry as "always sinking"; a small bias counters that.
+     */
+    const val DRIFT = 0.5 * VOLATILITY * VOLATILITY + 0.05
 
-    /** Per-coin trade impact on price. 1000 coins moves the market ~40 %. */
-    const val TRADE_IMPACT = 0.0004
+    /**
+     * Per-coin trade impact on price. 1000 coins moves the market ~10 %.
+     * Whales can still shift the chart but a single big sell no longer nukes
+     * the market for everyone else.
+     */
+    const val TRADE_IMPACT = 0.0001
 
     private const val SECONDS_PER_YEAR = 365.0 * 24.0 * 60.0 * 60.0
 

--- a/database/src/test/kotlin/database/economy/TobyCoinEngineTest.kt
+++ b/database/src/test/kotlin/database/economy/TobyCoinEngineTest.kt
@@ -47,8 +47,10 @@ internal class TobyCoinEngineTest {
     /**
      * Regression guard: with DRIFT=0 the lognormal Itô correction made the
      * median of many ticks decay, so users saw charts that "only went down".
-     * Drift is now set so the median step is zero — a Monte-Carlo run should
-     * land the median trajectory very close to where it started.
+     * Drift is now slightly positive so the median trends gently up — a
+     * Monte-Carlo run over a short window should land the median close to
+     * the starting price (the upward bias only meaningfully accumulates
+     * over much longer horizons).
      */
     @Test
     fun `median of many ticks stays close to the starting price`() {
@@ -65,8 +67,45 @@ internal class TobyCoinEngineTest {
 
         val median = finals[finals.size / 2]
         assertTrue(
-            median in 85.0..115.0,
+            median in 80.0..120.0,
             "median final price after $ticksPerRun ticks should stay near $startPrice but was $median"
         )
+    }
+
+    /**
+     * The market is meant to feel volatile enough to be fun. After a day's
+     * worth of ticks (~288), the spread between the 5th and 95th percentiles
+     * should be wide — a flat-line chart is boring.
+     */
+    @Test
+    fun `daily ticks produce visibly volatile spread across paths`() {
+        val runs = 5_000
+        val ticksPerDay = 288   // 5-min ticks * 12 per hour * 24
+        val startPrice = 100.0
+        val rng = Random(20260424L)
+
+        val finals = DoubleArray(runs) {
+            var price = startPrice
+            repeat(ticksPerDay) { price = TobyCoinEngine.tickRandomWalk(price, random = rng) }
+            price
+        }.also { it.sort() }
+
+        val p5 = finals[(runs * 0.05).toInt()]
+        val p95 = finals[(runs * 0.95).toInt()]
+        // With σ=1.5 annualised, 1-day log-stdev ≈ 0.078; ~95% band should
+        // span at least ±10% from the start price.
+        assertTrue(p5 < 90.0,  "5th percentile after a day should be below 90 but was $p5")
+        assertTrue(p95 > 110.0, "95th percentile after a day should be above 110 but was $p95")
+    }
+
+    @Test
+    fun `trade impact is meaningful but not market-nuking`() {
+        // 1000 coins should move the price by roughly 10%, not 40%.
+        val priceAfterBuy  = TobyCoinEngine.applyBuyPressure(100.0, 1_000L)
+        val priceAfterSell = TobyCoinEngine.applySellPressure(100.0, 1_000L)
+        assertTrue(priceAfterBuy in 105.0..115.0,
+            "1000 coins bought should move price ~10% up, was ${priceAfterBuy}")
+        assertTrue(priceAfterSell in 85.0..95.0,
+            "1000 coins sold should move price ~10% down, was ${priceAfterSell}")
     }
 }


### PR DESCRIPTION
## Summary

Three knobs adjusted to make the TOBY market feel less like it's always sinking.

| Knob | Before | After | Effect |
|---|---|---|---|
| `VOLATILITY` | `0.6` | `1.5` | Per-tick stdev ~0.18 % → ~0.46 %; daily vol ~3 % → ~8 %. Memecoin / small-cap territory — charts visibly move, holders survive a bad afternoon. |
| `DRIFT` | `0.5 * σ²` | `0.5 * σ² + 0.05` | Pure `0.5σ²` makes the median path mathematically flat, but human eyes read lognormal asymmetry as "always sinking". Small positive bias counters the perception without making the market a one-way ramp. |
| `TRADE_IMPACT` | `0.0004` | `0.0001` | 1000 coins moves price ~10 % instead of ~40 %. Whales can still shift the chart but a single sell no longer nukes the market for everyone else — likely the bigger driver of the "downward trend" feeling than the random walk itself. |

## Tests

- **Existing**: `median of many ticks stays close to the starting price` — bounds widened from `85..115` to `80..120` to accommodate the larger σ; comment updated to reflect the new gentle drift.
- **New**: `daily ticks produce visibly volatile spread across paths` — locks in the "actually fun" intent: 5th and 95th percentiles after a day must span at least ±10 % from start.
- **New**: `trade impact is meaningful but not market-nuking` — pins a 1000-coin move into the 5–15 % range.

## Test plan

- [x] `:database:test --tests TobyCoinEngineTest` green locally.
- [ ] Manual: deploy → watch the chart on `/economy/{guildId}` for an hour. Expect more visible jitter than before. Trade 100–1000 coins → expect a noticeable but not catastrophic price move.

## Easy to revert

Three numeric constants, no behavioural code changed. If the new volatility feels chaotic, dial `VOLATILITY` back to `1.0` (bigger than before, smaller than now) without touching anything else.

https://claude.ai/code/session_01JvuveFBoCvMFTK8XxXVN56

---
_Generated by [Claude Code](https://claude.ai/code/session_01JvuveFBoCvMFTK8XxXVN56)_