### PR TITLE
fix(voice): reconcile open sessions on bot ready (deploys eating voice time)

### DIFF
--- a/discord-bot/src/main/kotlin/bot/toby/handler/VoiceEventHandler.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/handler/VoiceEventHandler.kt
@@ -45,9 +45,28 @@ class VoiceEventHandler @Autowired constructor(
     private val logger: DiscordLogger = DiscordLogger.createLogger(this::class.java)
 
     override fun onReady(event: ReadyEvent) {
-        event.jda.guildCache.forEach {
-            logger.setGuildContext(it)
-            it.connectToMostPopulatedVoiceChannel()
+        val now = Instant.now()
+        event.jda.guildCache.forEach { guild ->
+            logger.setGuildContext(guild)
+            // Reconcile voice state: any non-bot member already in a voice
+            // channel needs an open voice_session row, otherwise their
+            // eventual leave event has nothing to close and the post-restart
+            // span gets silently dropped. The recovery hook just closed any
+            // *pre-restart* sessions; this opens fresh ones from this moment.
+            guild.voiceChannels.forEach { channel ->
+                channel.members
+                    .filter { !it.user.isBot }
+                    .forEach { member ->
+                        runCatching { openSessionForUser(member.idLong, guild.idLong, channel, now) }
+                            .onFailure {
+                                logger.error(
+                                    "Failed to open startup voice session for user ${member.idLong} " +
+                                            "in channel ${channel.idLong}: ${it.message}"
+                                )
+                            }
+                    }
+            }
+            guild.connectToMostPopulatedVoiceChannel()
         }
     }
 

--- a/discord-bot/src/test/kotlin/bot/toby/handler/VoiceEventHandlerTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/handler/VoiceEventHandlerTest.kt
@@ -172,6 +172,7 @@ class VoiceEventHandlerTest {
         every { bot.user.isBot } returns true
         every { human1.idLong } returns 100L
         every { human2.idLong } returns 200L
+        every { bot.idLong } returns 999L  // explicit so the verify-block matcher doesn't touch the relaxed mock
 
         // No prior session for either human — fresh insert path.
         every { voiceSessionService.findOpenSession(any(), any()) } returns null
@@ -196,7 +197,7 @@ class VoiceEventHandlerTest {
             voiceSessionService.openSession(match { it.discordId == 200L && it.guildId == 7L && it.channelId == 99L })
         }
         verify(exactly = 0) {
-            voiceSessionService.openSession(match { it.discordId == bot.idLong })
+            voiceSessionService.openSession(match { it.discordId == 999L })
         }
     }
 

--- a/discord-bot/src/test/kotlin/bot/toby/handler/VoiceEventHandlerTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/handler/VoiceEventHandlerTest.kt
@@ -113,6 +113,12 @@ class VoiceEventHandlerTest {
         every { nonBotMember1.user.isBot } returns false
         every { nonBotMember2.user.isBot } returns false
         every { botMember.user.isBot } returns true
+        // Needed for the startup voice-session reconciliation that runs
+        // before connectToMostPopulatedVoiceChannel.
+        every { nonBotMember1.idLong } returns 11L
+        every { nonBotMember2.idLong } returns 22L
+        every { voiceChannel1.idLong } returns 101L
+        every { voiceChannel2.idLong } returns 102L
 
         every { guild1.audioManager } returns audioManager1
         every { guild2.audioManager } returns audioManager2
@@ -136,6 +142,62 @@ class VoiceEventHandlerTest {
 
         verify(exactly = 1) { audioManager1.openAudioConnection(voiceChannel1) }
         verify(exactly = 1) { audioManager2.openAudioConnection(voiceChannel2) }
+    }
+
+    @Test
+    fun `onReady opens a fresh voice session for every currently-connected non-bot member`() {
+        // Reproduces the "deploy in the middle of voice eats the post-deploy
+        // span" bug: without this reconciliation, the user's eventual leave
+        // event has no open session to close, and the time between bot-ready
+        // and leave is silently discarded.
+        val guild = mockk<Guild>(relaxed = true)
+        val readyEvent = mockk<ReadyEvent>(relaxed = true)
+        val voiceChannel = mockk<VoiceChannel>(relaxed = true)
+        val audioManager = mockk<AudioManager>(relaxed = true)
+        val human1 = mockk<Member>(relaxed = true)
+        val human2 = mockk<Member>(relaxed = true)
+        val bot = mockk<Member>(relaxed = true)
+        val voiceSessionService = mockk<database.service.VoiceSessionService>(relaxed = true)
+
+        every { readyEvent.jda } returns jda
+        every { jda.guildCache.iterator() } returns mutableListOf(guild).iterator()
+        every { guild.idLong } returns 7L
+        every { guild.voiceChannels } returns listOf(voiceChannel)
+        every { guild.audioManager } returns audioManager
+        every { voiceChannel.idLong } returns 99L
+        every { voiceChannel.guild } returns guild
+        every { voiceChannel.members } returns listOf(human1, human2, bot)
+        every { human1.user.isBot } returns false
+        every { human2.user.isBot } returns false
+        every { bot.user.isBot } returns true
+        every { human1.idLong } returns 100L
+        every { human2.idLong } returns 200L
+
+        // No prior session for either human — fresh insert path.
+        every { voiceSessionService.findOpenSession(any(), any()) } returns null
+
+        val handler = VoiceEventHandler(
+            configService = mockk(relaxed = true),
+            userDtoHelper = mockk(relaxed = true),
+            introHelper = mockk(relaxed = true),
+            voiceSessionService = voiceSessionService,
+            voiceCompanyTracker = mockk(relaxed = true),
+            voiceCreditAwardService = mockk(relaxed = true),
+            awardService = mockk(relaxed = true)
+        )
+
+        handler.onReady(readyEvent)
+
+        // Both humans get a session; the bot does NOT.
+        verify(exactly = 1) {
+            voiceSessionService.openSession(match { it.discordId == 100L && it.guildId == 7L && it.channelId == 99L })
+        }
+        verify(exactly = 1) {
+            voiceSessionService.openSession(match { it.discordId == 200L && it.guildId == 7L && it.channelId == 99L })
+        }
+        verify(exactly = 0) {
+            voiceSessionService.openSession(match { it.discordId == bot.idLong })
+        }
     }
 
 


### PR DESCRIPTION
## The bug

When the bot restarts during someone's voice session:

1. `VoiceSessionShutdownHook` (#281) closes the open row at shutdown — fine.
2. Bot restarts. Recovery hook finds nothing to recover.
3. **User is still in voice from JDA's perspective.** JDA does NOT fire a join event for them — their voice state didn't change, only the bot's gateway connection did.
4. User eventually leaves. `closeSessionForUser` runs but `findOpenSession` returns null (none opened post-restart) and returns early.
5. **The post-restart span is silently discarded** — no row, no `counted_seconds`, no leaderboard contribution.

Repeat-deploys compound this: every restart cuts the chain.

## Fix

In `VoiceEventHandler.onReady`, after JDA is connected, walk every voice channel in every guild and call `openSessionForUser` for each currently-connected non-bot member, with `joinedAt = now`.

- Their eventual leave event then has an open session to close, counted via the existing company-tracker path.
- `openSessionForUser` already handles a stale open row defensively, so re-running this is idempotent.
- Bots are excluded so we don't credit ourselves.

## Trade-off

Time during the actual downtime (between shutdown and ready) is not counted. We can't honestly account for it — the user might have left and rejoined, or stayed put, and JDA gives us no way to tell. We credit only what the bot directly observed.

## Tests

- Existing `onReady should connect to the most populated voice channel` — gets the missing `idLong` stubs the new code path needs.
- **New** `onReady opens a fresh voice session for every currently-connected non-bot member` — proves both humans in a channel get opened, the bot does NOT, and reproduces the bug being fixed.

### Sandbox limitation

Couldn't run `:discord-bot:test` locally — sandbox can't resolve the `libdave-impl-jni` JDA native dep. CI will exercise both files.

## Test plan

- [ ] CI green (`build` runs `:discord-bot:test`).
- [ ] Manual: deploy with someone in voice → bot logs no errors on the new openSession-for-each path → that person leaves voice → leaderboard "This month" voice column reflects the post-deploy span.

https://claude.ai/code/session_01JvuveFBoCvMFTK8XxXVN56

---
_Generated by [Claude Code](https://claude.ai/code/session_01JvuveFBoCvMFTK8XxXVN56)_