### PR TITLE
fix(voice): ContextClosedEvent for shutdown + visibility on both hooks

### DIFF
--- a/discord-bot/src/main/kotlin/bot/toby/handler/VoiceEventHandler.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/handler/VoiceEventHandler.kt
@@ -53,11 +53,13 @@ class VoiceEventHandler @Autowired constructor(
             // eventual leave event has nothing to close and the post-restart
             // span gets silently dropped. The recovery hook just closed any
             // *pre-restart* sessions; this opens fresh ones from this moment.
+            var reopened = 0
             guild.voiceChannels.forEach { channel ->
                 channel.members
                     .filter { !it.user.isBot }
                     .forEach { member ->
                         runCatching { openSessionForUser(member.idLong, guild.idLong, channel, now) }
+                            .onSuccess { reopened++ }
                             .onFailure {
                                 logger.error(
                                     "Failed to open startup voice session for user ${member.idLong} " +
@@ -66,6 +68,10 @@ class VoiceEventHandler @Autowired constructor(
                             }
                     }
             }
+            // Always log the count, even when zero — silence is ambiguous, and
+            // we need to be able to confirm in production logs whether the
+            // reconciliation loop actually ran for this guild.
+            logger.info { "Startup voice reconciliation: opened $reopened session(s) in guild ${guild.idLong}." }
             guild.connectToMostPopulatedVoiceChannel()
         }
     }

--- a/discord-bot/src/main/kotlin/bot/toby/voice/VoiceSessionShutdownHook.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/voice/VoiceSessionShutdownHook.kt
@@ -2,31 +2,40 @@ package bot.toby.voice
 
 import common.logging.DiscordLogger
 import database.service.VoiceSessionService
-import org.springframework.beans.factory.DisposableBean
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.event.ContextClosedEvent
+import org.springframework.context.event.EventListener
 import org.springframework.stereotype.Component
 import java.time.Instant
 
 /**
- * Closes any open voice sessions at the moment of a clean shutdown (Spring
- * context destroy — deploys, rolling restarts, SIGTERM under a sensible
- * orchestrator).
+ * Closes any open voice sessions at the moment of a clean shutdown — deploys,
+ * rolling restarts, SIGTERM under a sensible orchestrator.
  *
- * Complements [VoiceSessionRecoveryHook], which handles the *crash* case
- * after the fact. Without this hook, every deploy leaves open sessions on
- * disk that the next boot closes using bot-wake-time — which inflates
- * counted seconds for any user that actually left voice during the outage.
- * With this hook, clean deploys close sessions at their true leave moment
- * (i.e. right now) and the recovery path on the next boot has nothing to do.
+ * Listens for [ContextClosedEvent] rather than implementing [DisposableBean]
+ * because destroy() runs *during* bean teardown — by then the JPA EntityManager,
+ * the AOP @Transactional interceptor, or the connection pool may already be
+ * partially destroyed, and the merge/flush calls go silently nowhere (or throw,
+ * which the per-session runCatching swallows). ContextClosedEvent fires at the
+ * very *start* of context shutdown, while the entire container is still alive,
+ * so the persistence write actually lands.
+ *
+ * Complements [VoiceSessionRecoveryHook], which handles the *crash* case after
+ * the fact. Without this hook, every deploy leaves open sessions on disk that
+ * the next boot closes using bot-wake-time — which inflates counted seconds
+ * for any user who actually left voice during the outage. With this hook,
+ * clean deploys close sessions at their true leave moment (i.e. right now)
+ * and the recovery path on the next boot has nothing to do.
  */
 @Component
 class VoiceSessionShutdownHook @Autowired constructor(
     private val voiceSessionService: VoiceSessionService,
     private val voiceCreditAwardService: VoiceCreditAwardService
-) : DisposableBean {
+) {
     private val logger: DiscordLogger = DiscordLogger.createLogger(this::class.java)
 
-    override fun destroy() {
+    @EventListener(ContextClosedEvent::class)
+    fun onContextClosed() {
         closeOpenSessions()
     }
 
@@ -42,11 +51,20 @@ class VoiceSessionShutdownHook @Autowired constructor(
         }
 
         logger.info { "Flushing ${open.size} live voice session(s) before shutdown." }
+        var flushed = 0
         open.forEach { session ->
             runCatching { voiceCreditAwardService.closeSessionAtShutdown(session, now) }
+                .onSuccess {
+                    flushed++
+                    logger.info {
+                        "Flushed voice session id=${session.id} for user=${session.discordId} " +
+                                "guild=${session.guildId} on shutdown."
+                    }
+                }
                 .onFailure {
                     logger.error("Failed to close voice session id=${session.id} on shutdown: ${it.message}")
                 }
         }
+        logger.info { "Voice session flush complete: $flushed/${open.size} succeeded." }
     }
 }

--- a/discord-bot/src/test/kotlin/bot/toby/voice/VoiceSessionShutdownHookTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/voice/VoiceSessionShutdownHookTest.kt
@@ -64,11 +64,14 @@ class VoiceSessionShutdownHookTest {
     }
 
     @Test
-    fun `destroy delegates to closeOpenSessions so Spring triggers the flush`() {
+    fun `onContextClosed delegates to closeOpenSessions so Spring triggers the flush`() {
+        // Listening for ContextClosedEvent (vs DisposableBean.destroy) is what
+        // makes this hook actually persist its writes — by destroy()-time the
+        // EntityManager and TransactionInterceptor may already be torn down.
         val s1 = VoiceSessionDto(id = 1L, discordId = 1L, guildId = 10L, channelId = 100L, joinedAt = Instant.now())
         every { voiceSessionService.findAllOpenSessions() } returns listOf(s1)
 
-        hook.destroy()
+        hook.onContextClosed()
 
         verify(exactly = 1) { voiceCreditAwardService.closeSessionAtShutdown(s1, any()) }
     }


### PR DESCRIPTION
## Why

User report: *"we are all in a voice chat, toby-bot shuts down because we deploy, then he comes back up. leaderboard still says 0 minutes."*

Bot logs show `No stale voice sessions to recover.` on the next startup but no log lines proving #281 or #283 actually ran their loops — both hooks log only on failure. Two surgical changes to make voice-time recording survive deploys, plus visibility so the next deploy is debuggable.

## Changes

### 1. `VoiceSessionShutdownHook`: `DisposableBean` → `@EventListener(ContextClosedEvent::class)`

`DisposableBean.destroy()` runs *during* Spring bean teardown. By the time it fires, the JPA EntityManager / AOP `@Transactional` interceptor / HikariCP DataSource may already be partially destroyed, and the merge/flush calls in `closeSessionAndAward` go silently nowhere (or throw, which the per-session `runCatching` swallows).

`ContextClosedEvent` fires at the very *start* of context shutdown, while the entire container is still alive. Same logic, earlier hook point — persistence write actually lands.

### 2. Visible success logging in both hooks

| Was | Now |
|---|---|
| Silent on success, only logged failures | `Flushed voice session id=X for user=Y guild=Z on shutdown.` per session |
| No summary | `Voice session flush complete: N/M succeeded.` |
| `onReady` reconciliation didn't log either way | `Startup voice reconciliation: opened N session(s) in guild G.` — always, including N=0 |

Silence is ambiguous; an explicit zero confirms the loop ran.

## Tests

Renamed `destroy delegates to closeOpenSessions` → `onContextClosed delegates to closeOpenSessions`, updated to call `hook.onContextClosed()`, comment explains why `ContextClosedEvent` is the right hook point.

### Sandbox limitation

Couldn't run `:discord-bot:test` locally — sandbox can't fetch `libdave-impl-jni`. CI will exercise both files.

## Test plan

- [ ] CI green.
- [ ] Manual: deploy → grep prod logs for `Voice session flush complete:` (in shutdown phase) and `Startup voice reconciliation: opened` (in startup phase). Both should appear with non-zero N if anyone was in voice. Once visible, we can localize any remaining issue from the actual numbers.

https://claude.ai/code/session_01JvuveFBoCvMFTK8XxXVN56

---
_Generated by [Claude Code](https://claude.ai/code/session_01JvuveFBoCvMFTK8XxXVN56)_