### PR TITLE
fix(web): voice 'this month' was summing LAST month (off-by-one date range)

### DIFF
--- a/web/src/main/kotlin/web/service/ModerationWebService.kt
+++ b/web/src/main/kotlin/web/service/ModerationWebService.kt
@@ -112,16 +112,20 @@ class ModerationWebService(
         val users = userService.listGuildUsers(guildId).filterNotNull()
 
         val thisMonthStart = LocalDate.now(ZoneOffset.UTC).withDayOfMonth(1)
-        val prevMonthStart = thisMonthStart.minusMonths(1)
+        val nextMonthStart = thisMonthStart.plusMonths(1)
 
         val lifetimeVoice = safely("lifetime voice", emptyMap<Long, Long>()) {
             voiceSessionService.sumCountedSecondsLifetimeByUser(guildId)
         }
+        // Range is [thisMonthStart, nextMonthStart) — sessions whose joinedAt
+        // falls inside the current calendar month. The MonthlyLeaderboardJob
+        // uses [prevMonthStart, thisMonthStart) because it runs on the 1st
+        // and reports the JUST-FINISHED month; that range is wrong here.
         val thisMonthVoice = safely("this-month voice", emptyMap<Long, Long>()) {
             voiceSessionService.sumCountedSecondsInRangeByUser(
                 guildId,
-                prevMonthStart.atStartOfDay().toInstant(ZoneOffset.UTC),
-                thisMonthStart.atStartOfDay().toInstant(ZoneOffset.UTC)
+                thisMonthStart.atStartOfDay().toInstant(ZoneOffset.UTC),
+                nextMonthStart.atStartOfDay().toInstant(ZoneOffset.UTC)
             )
         }
         val existingBaselines = safely("prior snapshots", emptyList<database.dto.MonthlyCreditSnapshotDto>()) {

--- a/web/src/test/kotlin/web/service/ModerationWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/ModerationWebServiceTest.kt
@@ -568,4 +568,40 @@ class ModerationWebServiceTest {
         assertNull(err)
         verify(exactly = 1) { configService.createNewConfig(any()) }
     }
+
+    @Test
+    fun `getLeaderboard queries voice for the CURRENT month, not the previous one`() {
+        // Regression: the old code passed [prevMonthStart, thisMonthStart),
+        // which is the just-finished month — copy-paste from
+        // MonthlyLeaderboardJob (which runs on the 1st and reports the
+        // previous month). The live web view should query [thisMonthStart,
+        // nextMonthStart) so today's sessions actually count.
+        val user = UserDto(discordId = plainUserId, guildId = guildId).apply { socialCredit = 100L }
+        every { userService.listGuildUsers(guildId) } returns listOf(user)
+        mockMember(plainUserId)
+        every { voiceSessionService.sumCountedSecondsLifetimeByUser(guildId) } returns emptyMap()
+        every { snapshotService.listForGuildDate(guildId, any()) } returns emptyList()
+
+        val fromCaptor = slot<java.time.Instant>()
+        val untilCaptor = slot<java.time.Instant>()
+        every {
+            voiceSessionService.sumCountedSecondsInRangeByUser(
+                guildId,
+                capture(fromCaptor),
+                capture(untilCaptor)
+            )
+        } returns emptyMap()
+
+        service.getLeaderboard(guildId)
+
+        val now = java.time.LocalDate.now(java.time.ZoneOffset.UTC)
+        val expectedFrom = now.withDayOfMonth(1)
+            .atStartOfDay().toInstant(java.time.ZoneOffset.UTC)
+        val expectedUntil = now.withDayOfMonth(1).plusMonths(1)
+            .atStartOfDay().toInstant(java.time.ZoneOffset.UTC)
+        assertEquals(expectedFrom, fromCaptor.captured,
+            "voice range must START at this month's 1st, not last month's 1st")
+        assertEquals(expectedUntil, untilCaptor.captured,
+            "voice range must END at next month's 1st, not this month's 1st")
+    }
 }


### PR DESCRIPTION
## The actual bug

User shared their `voice_session` table. They had **4 closed sessions on Apr 24 totalling ~243 minutes** but the leaderboard showed `0m VOICE TIME THIS MONTH` guild-wide.

Because `ModerationWebService.getLeaderboard` passes the wrong range to `sumCountedSecondsInRangeByUser`:

```kotlin
val thisMonthStart = LocalDate.now(ZoneOffset.UTC).withDayOfMonth(1)
val prevMonthStart = thisMonthStart.minusMonths(1)
...
voiceSessionService.sumCountedSecondsInRangeByUser(
    guildId,
    prevMonthStart.atStartOfDay()...,    // ← starts at LAST month
    thisMonthStart.atStartOfDay()...     // ← ends at THIS month
)
```

That's `[Mar 1, Apr 1)` — the **previous** month. Variable named `thisMonthVoice`, contained last month. Copy-pasted from `MonthlyLeaderboardJob`, which is correct *there* because that job runs on the 1st and reports the just-finished month.

Today's voice sessions fell outside the range, sum returned 0.

## Fix

Switch to `[thisMonthStart, nextMonthStart)`. Today's sessions now match.

## Test

New regression test that captures the actual `from`/`until` Instants passed to `sumCountedSecondsInRangeByUser` and asserts they're this month's start and next month's start respectively. Pre-fix the `from` assertion fails (it was last month's start).

## Test plan

- [x] `:web:test` green.
- [ ] Manual: deploy → refresh leaderboard → user's 4 closed Apr 24 sessions should now contribute their ~243 minutes.

This is independent of and orthogonal to #284 (which is about the shutdown hook persistence reliability).

https://claude.ai/code/session_01JvuveFBoCvMFTK8XxXVN56

---
_Generated by [Claude Code](https://claude.ai/code/session_01JvuveFBoCvMFTK8XxXVN56)_