### PR TITLE
fix(web): cache Discord guild fetch, log non-200; reorder navbar

### DIFF
--- a/web/build.gradle
+++ b/web/build.gradle
@@ -34,6 +34,9 @@ dependencies {
     // Needed for @Transactional on service methods that coordinate DB writes
     // (e.g. TitlesWebService.buyTitleWithTobyCoin).
     implementation 'org.springframework:spring-tx'
+    // IntroWebService caches the Discord /users/@me/guilds response with
+    // Caffeine to avoid 429-triggered "no mutual servers" false empties.
+    implementation 'com.github.ben-manes.caffeine:caffeine'
     testImplementation project(path: ':common', configuration: 'testArtifacts')
     testImplementation project(path: ':core-api', configuration: 'testArtifacts')
     testImplementation project(path: ':database', configuration: 'testArtifacts')

--- a/web/src/main/kotlin/web/service/IntroWebService.kt
+++ b/web/src/main/kotlin/web/service/IntroWebService.kt
@@ -1,6 +1,7 @@
 package web.service
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.github.benmanes.caffeine.cache.Caffeine
 import common.logging.DiscordLogger
 import database.dto.MusicDto
 import database.dto.UserDto
@@ -12,6 +13,7 @@ import org.springframework.web.multipart.MultipartFile
 import java.net.HttpURLConnection
 import java.net.URI
 import java.net.URL
+import java.util.concurrent.TimeUnit
 
 @Service
 class IntroWebService(
@@ -28,26 +30,58 @@ class IntroWebService(
         private val logger = DiscordLogger(IntroWebService::class.java)
     }
 
+    // Caches the Discord-side guild list per access token so rapid navigation
+    // (Market -> Leaderboards -> Intros -> ...) doesn't hammer Discord's
+    // /users/@me/guilds endpoint and trip a 429, which previously manifested
+    // to users as "you share no servers with toby-bot" on otherwise-valid
+    // sessions. 60s is short enough that a user leaving/joining a guild
+    // recovers on the next navigation, long enough to absorb click-bursts.
+    //
+    // Keyed on the token itself (in memory, never logged). Expiring writes
+    // ensures a stale token fails fresh rather than serving bogus success.
+    private val guildListCache = Caffeine.newBuilder()
+        .expireAfterWrite(60, TimeUnit.SECONDS)
+        .maximumSize(1_000)
+        .build<String, List<GuildInfo>>()
+
     fun getMutualGuilds(accessToken: String): List<GuildInfo> {
         val userGuilds = fetchUserGuildsFromDiscord(accessToken)
         return userGuilds.filter { jda.getGuildById(it.id) != null }
     }
 
     private fun fetchUserGuildsFromDiscord(accessToken: String): List<GuildInfo> {
+        guildListCache.getIfPresent(accessToken)?.let { return it }
+
         val connection = URL("https://discord.com/api/users/@me/guilds").openConnection() as HttpURLConnection
         connection.setRequestProperty("Authorization", "Bearer $accessToken")
         connection.setRequestProperty("Content-Type", "application/json")
 
-        if (connection.responseCode != 200) return emptyList()
+        val status = connection.responseCode
+        if (status != 200) {
+            // Explicit logging so the next "I share no servers with toby-bot"
+            // is diagnosable from the bot's logs alone. Common cases:
+            //  401 — token expired; OAuth2 should refresh but may have lagged.
+            //  429 — rate-limited; Caffeine cache above should prevent this.
+            //  5xx — Discord outage; we degrade to empty and retry next call.
+            val body = runCatching {
+                (connection.errorStream ?: connection.inputStream).bufferedReader().readText()
+            }.getOrDefault("<no body>")
+            logger.warn(
+                "Discord /users/@me/guilds returned $status; treating as empty guild list. Body: $body"
+            )
+            return emptyList()
+        }
 
         val body = connection.inputStream.bufferedReader().readText()
-        return objectMapper.readTree(body).map { node ->
+        val parsed = objectMapper.readTree(body).map { node ->
             GuildInfo(
                 id = node["id"].asText(),
                 name = node["name"].asText(),
                 iconHash = node["icon"]?.takeUnless { it.isNull }?.asText()
             )
         }
+        guildListCache.put(accessToken, parsed)
+        return parsed
     }
 
     fun getGuildName(guildId: Long): String? = jda.getGuildById(guildId)?.name

--- a/web/src/main/resources/templates/fragments/navbar.html
+++ b/web/src/main/resources/templates/fragments/navbar.html
@@ -3,15 +3,18 @@
 <body>
 <nav th:fragment="navbar">
     <a class="brand" href="/">TobyBot</a>
+    <!-- Order: personal anchor -> daily-driver features (leaderboards, market,
+         titles) -> social features -> utilities/docs -> admin. Keep admin-ish
+         Moderation last so it doesn't sit next to the everyday links. -->
     <div class="nav-links" id="nav-menu">
-        <a href="/commands/wiki">Commands</a>
+        <a href="/profile/guilds">Profile</a>
+        <a href="/leaderboards">Leaderboards</a>
+        <a href="/economy/guilds">Market</a>
+        <a href="/titles/guilds">Titles</a>
         <a href="/intro/guilds">Intro Songs</a>
         <a href="/dnd/campaign">Campaigns</a>
-        <a href="/titles/guilds">Titles</a>
-        <a href="/economy/guilds">Market</a>
-        <a href="/profile/guilds">Profile</a>
         <a href="/utils">Utils</a>
-        <a href="/leaderboards">Leaderboards</a>
+        <a href="/commands/wiki">Commands</a>
         <a href="/moderation/guilds">Moderation</a>
         <span th:if="${username != null}" style="display:flex;align-items:center;gap:12px;">
             <span class="nav-user" th:text="${username}">User</span>


### PR DESCRIPTION
## Why

Two user-reported issues, both small.

### 1) "Sometimes clicking Market says I share no servers with TobyBot"

`IntroWebService.fetchUserGuildsFromDiscord` hit `https://discord.com/api/users/@me/guilds` on **every** navigation that needed the guild list AND silently returned an empty list on any non-200 response. Combo effects:

- Rapid navigation (Market → Leaderboards → Intros → Titles) chewed through Discord's per-token rate limit → 429 came back → page rendered "no servers" for an otherwise-valid session.
- Idle sessions whose OAuth token silently expired got the same empty treatment with no breadcrumb in the logs.
- Any Discord intermittent outage → identical mystery emptiness.

**Fix:**
- **Caffeine cache** per access token, 60s TTL, max 1000 entries. Short enough that joining/leaving a guild recovers on the next navigation; long enough to absorb click-bursts.
- **Log non-200** status and response body at WARN so the next "why no servers" report is a grep away. Comments explicitly call out 401 / 429 / 5xx.
- Continue to return empty on failure (degraded UX but not a broken page) and retry on the next call.
- `web/build.gradle`: caffeine needs to be declared explicitly — common's `implementation` scope doesn't leak the dep.

### 2) Navbar order

Was feature-chronological (shipped-order) and not user-priority. New order:

| Before | After |
|---|---|
| Commands · Intro Songs · Campaigns · Titles · Market · Profile · Utils · Leaderboards · Moderation | **Profile** · **Leaderboards** · **Market** · **Titles** · Intro Songs · Campaigns · Utils · Commands · Moderation |

Rationale inline in the template — personal anchor first, daily-driver features next, social, utilities/docs, admin last.

## Test plan

- [x] `:web:test` green.
- [ ] Manual: log in, click Market/Leaderboards/Intros in rapid succession — no more false "no servers". Logs show `Discord /users/@me/guilds returned N` only when there's an actual non-200.
- [ ] Manual: navbar renders in the new order on every page (fragment is shared).

https://claude.ai/code/session_01JvuveFBoCvMFTK8XxXVN56

---
_Generated by [Claude Code](https://claude.ai/code/session_01JvuveFBoCvMFTK8XxXVN56)_