### PR TITLE
feat(web): owner can toggle game-activity tracking from the moderation UI

### DIFF
--- a/common/src/main/kotlin/common/events/ActivityTrackingEnabled.kt
+++ b/common/src/main/kotlin/common/events/ActivityTrackingEnabled.kt
@@ -1,0 +1,15 @@
+package common.events
+
+/**
+ * Fact emitted via Spring's [org.springframework.context.ApplicationEventPublisher]
+ * whenever the ACTIVITY_TRACKING guild config is set to `true` — whether via the
+ * Discord `/setconfig activity_tracking on` command or the web moderation UI.
+ *
+ * The listener ([bot.toby.activity.ActivityTrackingNotifier.onActivityTrackingEnabled])
+ * resolves the guild from [guildId] and runs the first-enable notification; that
+ * flow is internally idempotent via the `ACTIVITY_TRACKING_NOTIFIED` flag, so
+ * publishers don't need to de-duplicate across false→true vs true→true writes.
+ */
+data class ActivityTrackingEnabled(
+    val guildId: Long
+)

--- a/discord-bot/src/main/kotlin/bot/toby/activity/ActivityTrackingNotifier.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/activity/ActivityTrackingNotifier.kt
@@ -1,19 +1,42 @@
 package bot.toby.activity
 
+import common.events.ActivityTrackingEnabled
 import common.logging.DiscordLogger
 import database.dto.ConfigDto
 import database.dto.ConfigDto.Configurations.ACTIVITY_TRACKING_NOTIFIED
 import database.service.ConfigService
+import net.dv8tion.jda.api.JDA
 import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.entities.User
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.event.EventListener
 import org.springframework.stereotype.Service
 
 @Service
 class ActivityTrackingNotifier @Autowired constructor(
-    private val configService: ConfigService
+    private val configService: ConfigService,
+    private val jda: JDA
 ) {
     private val logger: DiscordLogger = DiscordLogger.createLogger(this::class.java)
+
+    /**
+     * Cross-module entry point for the web moderation UI. Web publishes an
+     * [ActivityTrackingEnabled] event whenever ACTIVITY_TRACKING is set to
+     * `true`; this listener resolves the guild via JDA and runs the same
+     * first-enable flow the Discord `/setconfig` command runs. Already-
+     * notified guilds short-circuit inside [notifyMembersOnFirstEnable].
+     */
+    @EventListener
+    fun onActivityTrackingEnabled(event: ActivityTrackingEnabled) {
+        val guild = jda.getGuildById(event.guildId)
+        if (guild == null) {
+            logger.warn(
+                "ActivityTrackingEnabled received for guild ${event.guildId} but JDA has no matching guild; skipping."
+            )
+            return
+        }
+        notifyMembersOnFirstEnable(guild)
+    }
 
     fun notifyMembersOnFirstEnable(guild: Guild) {
         val guildIdStr = guild.id

--- a/web/src/main/kotlin/web/service/ModerationWebService.kt
+++ b/web/src/main/kotlin/web/service/ModerationWebService.kt
@@ -1,5 +1,6 @@
 package web.service
 
+import common.events.ActivityTrackingEnabled
 import common.logging.DiscordLogger
 import database.dto.ConfigDto
 import database.dto.UserDto
@@ -13,6 +14,7 @@ import net.dv8tion.jda.api.JDA
 import net.dv8tion.jda.api.Permission
 import net.dv8tion.jda.api.entities.Member
 import net.dv8tion.jda.api.entities.emoji.Emoji
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
 import java.time.LocalDate
 import java.time.ZoneOffset
@@ -25,7 +27,8 @@ class ModerationWebService(
     private val introWebService: IntroWebService,
     private val voiceSessionService: VoiceSessionService,
     private val titleService: TitleService,
-    private val snapshotService: MonthlyCreditSnapshotService
+    private val snapshotService: MonthlyCreditSnapshotService,
+    private val eventPublisher: ApplicationEventPublisher
 ) {
     companion object {
         const val MAX_POLL_OPTIONS = 10
@@ -286,6 +289,17 @@ class ModerationWebService(
             "Config $path: guild=$guildIdString actor=$actorDiscordId key=${key.configValue} " +
                 "value=$value existing.guildId=${existing?.guildId}"
         )
+
+        // Mirror SetConfigCommand's Discord-side behaviour: when activity
+        // tracking is switched on, fire the first-enable notifier. The
+        // ActivityTrackingNotifier listener de-duplicates via the
+        // ACTIVITY_TRACKING_NOTIFIED flag, so it's safe to publish on every
+        // "true" write (including true->true no-ops) — no false-positive DM
+        // floods. We publish regardless of the previous value for the same
+        // reason.
+        if (key == ConfigDto.Configurations.ACTIVITY_TRACKING && value == "true") {
+            eventPublisher.publishEvent(ActivityTrackingEnabled(guildId))
+        }
         return null
     }
 

--- a/web/src/main/resources/templates/moderation.html
+++ b/web/src/main/resources/templates/moderation.html
@@ -182,6 +182,24 @@
                 </select>
                 <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
             </div>
+            <!-- Saving "true" here kicks an ActivityTrackingEnabled event that
+                 fires the first-enable DM flow, matching the Discord
+                 /setconfig behaviour. Default value is "false" when no row
+                 exists yet — matches ActivityTrackingService's read default. -->
+            <div class="config-row" data-key="ACTIVITY_TRACKING">
+                <label>Game-activity tracking</label>
+                <select th:disabled="${!isOwner}">
+                    <option value="false"
+                            th:selected="${overview.config['ACTIVITY_TRACKING'] == null or overview.config['ACTIVITY_TRACKING'] == 'false'}">
+                        Disabled
+                    </option>
+                    <option value="true"
+                            th:selected="${overview.config['ACTIVITY_TRACKING'] == 'true'}">
+                        Enabled
+                    </option>
+                </select>
+                <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+            </div>
         </div>
     </section>
 

--- a/web/src/test/kotlin/web/service/ModerationWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/ModerationWebServiceTest.kt
@@ -49,6 +49,8 @@ class ModerationWebServiceTest {
     private val plainUserId = 102L
     private val targetUserId = 103L
 
+    private lateinit var eventPublisher: org.springframework.context.ApplicationEventPublisher
+
     @BeforeEach
     fun setup() {
         jda = mockk(relaxed = true)
@@ -58,6 +60,7 @@ class ModerationWebServiceTest {
         voiceSessionService = mockk(relaxed = true)
         titleService = mockk(relaxed = true)
         snapshotService = mockk(relaxed = true)
+        eventPublisher = mockk(relaxed = true)
         guild = mockk(relaxed = true)
         service = ModerationWebService(
             jda,
@@ -66,7 +69,8 @@ class ModerationWebServiceTest {
             introWebService,
             voiceSessionService,
             titleService,
-            snapshotService
+            snapshotService,
+            eventPublisher
         )
 
         every { jda.getGuildById(guildId) } returns guild
@@ -567,6 +571,49 @@ class ModerationWebServiceTest {
         val err = service.updateConfig(ownerId, guildId, ConfigDto.Configurations.LEADERBOARD_CHANNEL, "111")
         assertNull(err)
         verify(exactly = 1) { configService.createNewConfig(any()) }
+    }
+
+    @Test
+    fun `updateConfig ACTIVITY_TRACKING=true publishes the first-enable event`() {
+        mockMember(ownerId, isOwner = true)
+        every { configService.getConfigByName(any(), any()) } returns null
+
+        val err = service.updateConfig(ownerId, guildId, ConfigDto.Configurations.ACTIVITY_TRACKING, "true")
+
+        assertNull(err)
+        // Event must fire regardless of previous value — the listener
+        // de-duplicates via ACTIVITY_TRACKING_NOTIFIED, so publishing on
+        // every "true" write is the right contract.
+        verify(exactly = 1) {
+            eventPublisher.publishEvent(common.events.ActivityTrackingEnabled(guildId))
+        }
+    }
+
+    @Test
+    fun `updateConfig ACTIVITY_TRACKING=false does NOT publish the event`() {
+        mockMember(ownerId, isOwner = true)
+        every { configService.getConfigByName(any(), any()) } returns null
+
+        service.updateConfig(ownerId, guildId, ConfigDto.Configurations.ACTIVITY_TRACKING, "false")
+
+        // Disabling tracking must never trigger member DMs.
+        verify(exactly = 0) {
+            eventPublisher.publishEvent(any<common.events.ActivityTrackingEnabled>())
+        }
+    }
+
+    @Test
+    fun `updateConfig ACTIVITY_TRACKING rejects non-boolean values`() {
+        mockMember(ownerId, isOwner = true)
+
+        val err = service.updateConfig(ownerId, guildId, ConfigDto.Configurations.ACTIVITY_TRACKING, "maybe")
+
+        assertEquals("Value must be true or false.", err)
+        verify(exactly = 0) { configService.createNewConfig(any()) }
+        verify(exactly = 0) { configService.updateConfig(any()) }
+        verify(exactly = 0) {
+            eventPublisher.publishEvent(any<common.events.ActivityTrackingEnabled>())
+        }
     }
 
     @Test


### PR DESCRIPTION
## Why

`ACTIVITY_TRACKING` has always been settable via the Discord `/setconfig` command, but the web moderation Config tab had no row for it — owners managing via the browser had no way to turn it on/off without hopping into Discord. Adds the toggle AND wires up **parity with the Discord UX**: flipping to `"true"` from the web triggers the same first-enable member-DM flow (option B from the earlier design discussion).

## How parity works

The web module can't reach `bot.toby.activity` directly (`web → common / database / core-api`, no dep on `discord-bot`), so cross-module talk goes via Spring's `ApplicationEventPublisher` — same pattern the codebase already uses for `CampaignEventOccurred`.

1. **`common/events/ActivityTrackingEnabled(guildId)`** — new event DTO.
2. **`ModerationWebService.updateConfig`** publishes it when the write is `ACTIVITY_TRACKING=true`. Publishes on every `"true"` write (not just false→true) because the listener is idempotent via the `ACTIVITY_TRACKING_NOTIFIED` flag; spamming Save on the same value does not DM members twice.
3. **`ActivityTrackingNotifier`** gains an `@EventListener` method that resolves the guild via the injected JDA bean and delegates to the existing `notifyMembersOnFirstEnable(guild)`.
4. **`moderation.html`** gets a config-row with a `<select>` of Enabled/Disabled, disabled for non-owners (same pattern as the other rows). Default "Disabled" when no config row exists, matching `ActivityTrackingService.isGuildTrackingEnabled`'s read default.

## Tests

Three new `ModerationWebServiceTest` cases:

| Test | Assertion |
|---|---|
| `updateConfig ACTIVITY_TRACKING=true publishes the first-enable event` | `eventPublisher.publishEvent(ActivityTrackingEnabled(guildId))` called once |
| `updateConfig ACTIVITY_TRACKING=false does NOT publish the event` | Verifies no spurious DMs when disabling |
| `updateConfig ACTIVITY_TRACKING rejects non-boolean values` | Rejects `"maybe"`, no persist, no event |

Existing tests updated to pass the new `ApplicationEventPublisher` constructor arg (relaxed mock).

### Sandbox limitation

Couldn't run `:discord-bot:test` locally — same `libdave-impl-jni` fetch issue as before. CI will exercise the new listener. Its wiring is a `@EventListener` + JDA lookup with no new business logic, so risk is low.

## Test plan

- [x] `:web:test` green.
- [ ] Manual: `/moderation/{guildId}` Config tab → set Game-activity tracking to Enabled, Save. Members receive the opt-in DM (first enable). Flip back to Disabled → no DMs. Flip on again → no DMs (already notified, idempotent).

https://claude.ai/code/session_01JvuveFBoCvMFTK8XxXVN56

---
_Generated by [Claude Code](https://claude.ai/code/session_01JvuveFBoCvMFTK8XxXVN56)_