### PR TITLE
fix(web): leaderboard relabel + guild-picker top-earner uses this-month

### DIFF
--- a/web/src/main/kotlin/web/service/LeaderboardWebService.kt
+++ b/web/src/main/kotlin/web/service/LeaderboardWebService.kt
@@ -32,14 +32,20 @@ class LeaderboardWebService(
             val guildId = info.id.toLongOrNull() ?: return@mapNotNull null
             if (!isMember(discordId, guildId)) return@mapNotNull null
             val leaderboard = moderationWebService.getLeaderboard(guildId)
-            val top = leaderboard.firstOrNull()
+            // Pick the top by this-month earnings to match the page's default
+            // sort. Only surface someone if they've actually earned > 0 this
+            // month — otherwise the card claims a "top earner" with +0, which
+            // is misleading at the start of the month.
+            val top = leaderboard
+                .filter { it.creditsEarnedThisMonth > 0L }
+                .maxByOrNull { it.creditsEarnedThisMonth }
             LeaderboardGuildCard(
                 id = info.id,
                 name = info.name,
                 iconUrl = info.iconUrl,
                 topName = top?.name,
                 topTitle = top?.title,
-                topCredits = top?.socialCredit ?: 0L,
+                topCreditsThisMonth = top?.creditsEarnedThisMonth ?: 0L,
                 totalVoiceSeconds = leaderboard.sumOf { it.voiceSecondsThisMonth },
                 memberCount = leaderboard.size
             )
@@ -149,7 +155,7 @@ data class LeaderboardGuildCard(
     val iconUrl: String?,
     val topName: String?,
     val topTitle: String?,
-    val topCredits: Long,
+    val topCreditsThisMonth: Long,
     val totalVoiceSeconds: Long,
     val memberCount: Int
 ) {

--- a/web/src/main/resources/templates/home.html
+++ b/web/src/main/resources/templates/home.html
@@ -286,7 +286,7 @@
 <section class="intro-cta">
     <div class="cta-card">
         <h2>&#128200; See The Leaderboards</h2>
-        <p>Monthly social-credit standings with a podium, TobyCoin wallet rankings, and a This month / Lifetime toggle so the top of the list actually changes.</p>
+        <p>Monthly social-credit standings with a podium, TobyCoin wallet rankings, and a This month / Current total toggle so the top of the list actually changes.</p>
         <a href="/leaderboards" class="btn-primary">View Leaderboards &#8594;</a>
     </div>
 </section>

--- a/web/src/main/resources/templates/leaderboard.html
+++ b/web/src/main/resources/templates/leaderboard.html
@@ -9,7 +9,7 @@
     <div class="lb-header">
         <a class="back-link" th:href="@{/leaderboards}">&larr; All leaderboards</a>
         <h1 th:text="${view.guildName}">Guild Name</h1>
-        <p class="muted">Social credit standings &middot; lifetime totals with this month's earnings highlighted</p>
+        <p class="muted">Social credit standings &middot; current totals with this month's earnings highlighted</p>
     </div>
 
     <div th:if="${error}" class="alert alert-error" th:text="${error}"></div>
@@ -46,7 +46,7 @@
            class="lb-sort-option"
            th:classappend="${view.sort.name() == 'LIFETIME' ? 'active' : ''}"
            th:aria-selected="${view.sort.name() == 'LIFETIME'}">
-            Lifetime
+            Current total
         </a>
     </nav>
 
@@ -72,7 +72,7 @@
             </div>
             <div class="lb-podium-month"
                  th:if="${isMonth}"
-                 th:text="${view.podium[1].socialCredit} + ' lifetime'">0 lifetime</div>
+                 th:text="${view.podium[1].socialCredit} + ' total'">0 total</div>
             <div class="lb-podium-month"
                  th:if="${!isMonth and view.podium[1].creditsEarnedThisMonth > 0}"
                  th:text="'+' + ${view.podium[1].creditsEarnedThisMonth} + ' this month'">+0 this month</div>
@@ -97,7 +97,7 @@
             </div>
             <div class="lb-podium-month"
                  th:if="${isMonth}"
-                 th:text="${view.podium[0].socialCredit} + ' lifetime'">0 lifetime</div>
+                 th:text="${view.podium[0].socialCredit} + ' total'">0 total</div>
             <div class="lb-podium-month"
                  th:if="${!isMonth and view.podium[0].creditsEarnedThisMonth > 0}"
                  th:text="'+' + ${view.podium[0].creditsEarnedThisMonth} + ' this month'">+0 this month</div>
@@ -122,7 +122,7 @@
             </div>
             <div class="lb-podium-month"
                  th:if="${isMonth}"
-                 th:text="${view.podium[2].socialCredit} + ' lifetime'">0 lifetime</div>
+                 th:text="${view.podium[2].socialCredit} + ' total'">0 total</div>
             <div class="lb-podium-month"
                  th:if="${!isMonth and view.podium[2].creditsEarnedThisMonth > 0}"
                  th:text="'+' + ${view.podium[2].creditsEarnedThisMonth} + ' this month'">+0 this month</div>

--- a/web/src/main/resources/templates/leaderboards.html
+++ b/web/src/main/resources/templates/leaderboards.html
@@ -31,12 +31,12 @@
                 <div class="lb-guild-name" th:text="${g.name}" th:title="${g.name}">Guild</div>
             </div>
             <div class="lb-guild-top" th:if="${g.topName != null}">
-                <span class="muted">Top earner:</span>
+                <span class="muted">Top this month:</span>
                 <span class="lb-top-name">
                     <span th:if="${g.topTitle != null}" class="lb-title-pill" th:text="${g.topTitle}"></span>
                     <span th:text="${g.topName}">Top user</span>
                 </span>
-                <span class="muted" th:text="${g.topCredits} + ' credits'">0 credits</span>
+                <span class="muted" th:text="'+' + ${g.topCreditsThisMonth} + ' credits'">+0 credits</span>
             </div>
             <div class="lb-guild-stats">
                 <span th:text="${g.memberCount} + ' tracked'">0 tracked</span>

--- a/web/src/test/kotlin/web/service/LeaderboardWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/LeaderboardWebServiceTest.kt
@@ -123,7 +123,11 @@ class LeaderboardWebServiceTest {
         every { guild43.getMemberById(discordId) } returns null // user not a member of Beta
         every { moderationWebService.getLeaderboard(42L) } returns listOf(
             LeaderboardRow(rank = 1, discordId = "1", name = "Ace", avatarUrl = null, socialCredit = 1000,
-                title = "🥇", voiceSecondsThisMonth = 1800)
+                title = "🥇", voiceSecondsThisMonth = 1800, creditsEarnedThisMonth = 250),
+            // Bigger lifetime balance but no earnings this month — should NOT be
+            // surfaced as the picker's top this-month earner.
+            LeaderboardRow(rank = 2, discordId = "2", name = "Stale", avatarUrl = null, socialCredit = 5000,
+                title = null, voiceSecondsThisMonth = 0, creditsEarnedThisMonth = 0)
         )
 
         val cards = service.getGuildsWhereUserCanView("token", discordId)
@@ -131,8 +135,30 @@ class LeaderboardWebServiceTest {
         assertEquals("42", cards.first().id)
         assertEquals("Ace", cards.first().topName)
         assertEquals("🥇", cards.first().topTitle)
-        assertEquals(1000L, cards.first().topCredits)
+        assertEquals(250L, cards.first().topCreditsThisMonth)
         assertEquals(1800L, cards.first().totalVoiceSeconds)
+    }
+
+    @Test
+    fun `getGuildsWhereUserCanView leaves topName null when no one earned this month`() {
+        val mutuals = listOf(GuildInfo(id = "42", name = "Quiet", iconHash = null))
+        every { introWebService.getMutualGuilds("token") } returns mutuals
+        val guild42 = mockk<Guild>(relaxed = true)
+        every { jda.getGuildById(42L) } returns guild42
+        every { guild42.getMemberById(discordId) } returns mockk<Member>(relaxed = true)
+        // Lifetime balances exist but creditsEarnedThisMonth is 0 for everyone —
+        // start of the month, fresh baselines, etc. Don't claim a "top earner".
+        every { moderationWebService.getLeaderboard(42L) } returns listOf(
+            LeaderboardRow(rank = 1, discordId = "1", name = "Ace", avatarUrl = null,
+                socialCredit = 1000, creditsEarnedThisMonth = 0),
+            LeaderboardRow(rank = 2, discordId = "2", name = "Bee", avatarUrl = null,
+                socialCredit = 500, creditsEarnedThisMonth = 0)
+        )
+
+        val cards = service.getGuildsWhereUserCanView("token", discordId)
+        assertEquals(1, cards.size)
+        assertEquals(null, cards.first().topName)
+        assertEquals(0L, cards.first().topCreditsThisMonth)
     }
 
     // ---- sort behaviour ----


### PR DESCRIPTION
## Summary

Two related accuracy fixes:

1. **Guild-picker "Top earner" was lifetime, not this-month.** Each card on `/leaderboards` rendered `${g.topCredits} + ' credits'`, sourced from `leaderboard.firstOrNull()` — and `getLeaderboard` is sorted by lifetime `socialCredit`. Result: a long-tenured but currently-quiet user permanently squatted the top slot regardless of actual activity. Switched the pick to `maxBy(creditsEarnedThisMonth)` and only show the line when someone has earned `> 0` this month (otherwise the card falls through to the basic stats — better than claiming a "top earner" with `+0`). Field renamed `topCredits → topCreditsThisMonth` so the meaning is visible at the call site.

2. **"Lifetime" relabelled to "Current total".** The secondary number on the leaderboard isn't a lifetime cumulative — users spend it down on titles, market trades, etc. — so "lifetime" overstates what's there. Relabel:
   - sort tab: "Lifetime" → "Current total"
   - podium subline: "X lifetime" → "X total"
   - page subtitle: "lifetime totals" → "current totals"
   - home-page CTA: "This month / Lifetime toggle" → "This month / Current total toggle"

   `?sort=lifetime` query value left alone for bookmark backward-compat.

## Test plan

- [x] Updated `getGuildsWhereUserCanView` test — feeds a row with high lifetime + zero this-month and confirms it's *not* picked over a row with a smaller lifetime but real this-month earnings
- [x] Added companion test: when nobody has earned this month, `topName` stays null (no "+0 credits" claim on the card)
- [ ] Manual: load `/leaderboards`, confirm "Top this month" line and `+N credits` formatting
- [ ] Manual: load `/leaderboard/<id>`, confirm tab reads "Current total" and the podium subline reads "X total"

## Out of scope

The 480MB memory question — separate thread.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JvuveFBoCvMFTK8XxXVN56)_