### PR TITLE
fix(web): 'Most active this month' card silently showed lifetime leader

### DIFF
--- a/web/src/main/kotlin/web/service/LeaderboardWebService.kt
+++ b/web/src/main/kotlin/web/service/LeaderboardWebService.kt
@@ -74,7 +74,15 @@ class LeaderboardWebService(
 
         val totalCreditsThisMonth = rawRows.sumOf { it.creditsEarnedThisMonth }
         val totalVoiceThisMonth = rawRows.sumOf { it.voiceSecondsThisMonth }
-        val mostActiveName = rawRows.maxByOrNull { it.voiceSecondsThisMonth }?.name
+        // rawRows arrive ordered by current-total socialCredit desc. If nobody
+        // has any voice time this month, maxByOrNull returns the first row
+        // (tied-max at 0) — i.e. the lifetime leader — and the "Most active
+        // this month" card silently misrepresents them. Filter out the zeros
+        // so the card hides itself in that case (template guards on null).
+        val mostActiveName = rawRows
+            .filter { it.voiceSecondsThisMonth > 0L }
+            .maxByOrNull { it.voiceSecondsThisMonth }
+            ?.name
 
         return LeaderboardGuildView(
             guildName = guild.name,

--- a/web/src/main/resources/templates/leaderboard.html
+++ b/web/src/main/resources/templates/leaderboard.html
@@ -29,7 +29,7 @@
         </div>
         <div class="lb-stat" th:if="${view.mostActiveMember != null}">
             <div class="lb-stat-value lb-stat-name" th:text="${view.mostActiveMember}">—</div>
-            <div class="lb-stat-label">Most active this month</div>
+            <div class="lb-stat-label">Most voice time this month</div>
         </div>
     </section>
 

--- a/web/src/test/kotlin/web/service/LeaderboardWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/LeaderboardWebServiceTest.kt
@@ -93,6 +93,26 @@ class LeaderboardWebServiceTest {
     }
 
     @Test
+    fun `getGuildView leaves mostActiveMember null when no one has voice this month`() {
+        // Regression: rawRows arrive ordered by current-total socialCredit desc.
+        // If everyone's voiceSecondsThisMonth is 0, naive maxByOrNull picks the
+        // first row (the lifetime leader) and mislabels them as "Most active
+        // this month". Should be null so the template hides the stat card.
+        val guild = mockk<Guild>(relaxed = true)
+        every { jda.getGuildById(guildId) } returns guild
+        every { guild.name } returns "Quiet"
+        every { moderationWebService.getLeaderboard(guildId) } returns listOf(
+            LeaderboardRow(rank = 1, discordId = "1", name = "Whale", avatarUrl = null,
+                socialCredit = 10_000, voiceSecondsThisMonth = 0),
+            LeaderboardRow(rank = 2, discordId = "2", name = "Minnow", avatarUrl = null,
+                socialCredit = 100, voiceSecondsThisMonth = 0)
+        )
+
+        val view = service.getGuildView(guildId)!!
+        assertNull(view.mostActiveMember)
+    }
+
+    @Test
     fun `getGuildView with fewer than 3 users returns only what exists`() {
         val guild = mockk<Guild>(relaxed = true)
         every { jda.getGuildById(guildId) } returns guild


### PR DESCRIPTION
## Summary

`LeaderboardWebService.getGuildView` picked `mostActiveMember` via:

```kotlin
rawRows.maxByOrNull { it.voiceSecondsThisMonth }?.name
```

`rawRows` arrives from `ModerationWebService.getLeaderboard` already sorted by current-total `socialCredit` descending. When *everyone's* `voiceSecondsThisMonth` is `0` (start of the month, voice-session table empty for the range, etc.), `maxByOrNull` returns the FIRST tied-max row — i.e. the lifetime leader — and the "Most active this month" stat card silently misrepresents them as the active leader.

This is exactly the symptom you described: the card shows the user with the highest current total, not the most active one.

## Fix

Filter out the zeros before picking, so the card hides itself (template already guards on `mostActiveMember != null`) when there's no real activity to surface.

```kotlin
rawRows
    .filter { it.voiceSecondsThisMonth > 0L }
    .maxByOrNull { it.voiceSecondsThisMonth }
    ?.name
```

## Test plan

- [x] New regression test: two users with `voiceSecondsThisMonth=0` and a deliberate huge `socialCredit` gap — `view.mostActiveMember` must be null, not the high-credit user
- [x] Existing test (`getGuildView splits leaderboard into podium...`) still picks "A" — A has `voiceSecondsThisMonth=3600`, others 0; max-of-non-zero is still A
- [ ] Manual: load `/leaderboard/<id>` on a quiet guild, confirm the "Most active this month" card disappears instead of falsely naming someone

---
_Generated by [Claude Code](https://claude.ai/code/session_01JvuveFBoCvMFTK8XxXVN56)_