### PR TITLE
feat(web): Casino + Economy navbar dropdowns

### DIFF
--- a/web/src/main/resources/static/css/nav.css
+++ b/web/src/main/resources/static/css/nav.css
@@ -47,10 +47,80 @@ nav {
     cursor: pointer;
 }
 
+/* Dropdown menus (Economy, Casino, ...). Trigger looks like a regular nav
+   link; menu absolutely positioned below on desktop, inlined on mobile. */
+.nav-dropdown { position: relative; }
+.nav-dropdown-toggle {
+    background: transparent;
+    border: none;
+    color: #a0a0b0;
+    font-size: 0.9rem;
+    cursor: pointer;
+    padding: 0;
+    transition: color 0.2s;
+    font-family: inherit;
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+}
+.nav-dropdown-toggle:hover,
+.nav-dropdown.open > .nav-dropdown-toggle { color: #fff; }
+.nav-dropdown-caret { font-size: 0.75em; transition: transform 0.2s; }
+.nav-dropdown:hover .nav-dropdown-caret,
+.nav-dropdown.open .nav-dropdown-caret { transform: rotate(180deg); }
+.nav-dropdown-menu {
+    display: none;
+    position: absolute;
+    top: 100%;
+    left: 0;
+    margin-top: 8px;
+    background: #16213e;
+    border: 1px solid #2a2a4a;
+    border-radius: 6px;
+    padding: 6px 0;
+    min-width: 160px;
+    z-index: 10;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+    flex-direction: column;
+}
+.nav-dropdown:hover .nav-dropdown-menu,
+.nav-dropdown.open .nav-dropdown-menu { display: flex; }
+.nav-dropdown-menu a,
+.nav-dropdown-menu .nav-dropdown-coming-soon {
+    padding: 8px 16px;
+    color: #a0a0b0;
+    text-decoration: none;
+    font-size: 0.9rem;
+    transition: background 0.2s, color 0.2s;
+    white-space: nowrap;
+}
+.nav-dropdown-menu a:hover { background: #2a2a4a; color: #fff; }
+.nav-dropdown-coming-soon { color: #555; cursor: default; font-style: italic; }
+
 @media (max-width: 600px) {
     .nav-toggle { display: block; min-height: 40px; min-width: 40px; }
     .nav-links { display: none; flex-direction: column; align-items: stretch; gap: 4px; width: 100%; padding: 8px 0; }
     .nav-links.open { display: flex; }
     .nav-links a, .nav-user { padding: 10px 4px; min-height: 40px; display: flex; align-items: center; }
     .nav-links .btn-discord, .nav-links .btn-logout { align-self: flex-start; min-height: 40px; display: inline-flex; align-items: center; }
+
+    /* On mobile, dropdown items render inline under the trigger so the
+       whole menu is one vertical scroll — no second tap required. */
+    .nav-dropdown { width: 100%; }
+    .nav-dropdown-toggle { padding: 10px 4px; min-height: 40px; width: 100%; justify-content: flex-start; }
+    .nav-dropdown-menu {
+        position: static;
+        display: flex;
+        margin-top: 0;
+        border: none;
+        padding: 0 0 0 16px;
+        background: transparent;
+        box-shadow: none;
+        min-width: 0;
+    }
+    .nav-dropdown-menu a, .nav-dropdown-menu .nav-dropdown-coming-soon {
+        padding: 8px 4px;
+        min-height: 36px;
+        white-space: normal;
+    }
 }

--- a/web/src/main/resources/static/js/home.js
+++ b/web/src/main/resources/static/js/home.js
@@ -4,6 +4,45 @@ function toggleNav() {
     return menu.classList.toggle('open');
 }
 
+// Click-toggle for navbar dropdowns. Desktop also opens on :hover via CSS;
+// click is the keyboard/touch path. Closing any other open dropdown keeps
+// only one expanded at a time.
+function toggleDropdown(toggle) {
+    if (!toggle) return false;
+    const dropdown = toggle.closest('.nav-dropdown');
+    if (!dropdown) return false;
+    const willOpen = !dropdown.classList.contains('open');
+    closeAllDropdowns();
+    if (willOpen) {
+        dropdown.classList.add('open');
+        toggle.setAttribute('aria-expanded', 'true');
+    }
+    return willOpen;
+}
+
+function closeAllDropdowns() {
+    const open = document.querySelectorAll('.nav-dropdown.open');
+    open.forEach(function (d) {
+        d.classList.remove('open');
+        const t = d.querySelector('.nav-dropdown-toggle');
+        if (t) t.setAttribute('aria-expanded', 'false');
+    });
+}
+
+if (typeof document !== 'undefined' && document.addEventListener) {
+    // Click outside any dropdown collapses them all. Doesn't interfere with
+    // clicks on dropdown menu items themselves — those navigate to a new
+    // page, which discards the document anyway.
+    document.addEventListener('click', function (e) {
+        if (e.target && e.target.closest && e.target.closest('.nav-dropdown')) return;
+        closeAllDropdowns();
+    });
+    // Esc closes any open dropdown.
+    document.addEventListener('keydown', function (e) {
+        if (e.key === 'Escape') closeAllDropdowns();
+    });
+}
+
 if (typeof module !== 'undefined') {
-    module.exports = { toggleNav };
+    module.exports = { toggleNav, toggleDropdown, closeAllDropdowns };
 }

--- a/web/src/main/resources/templates/fragments/navbar.html
+++ b/web/src/main/resources/templates/fragments/navbar.html
@@ -3,14 +3,36 @@
 <body>
 <nav th:fragment="navbar">
     <a class="brand" href="/">TobyBot</a>
-    <!-- Order: personal anchor -> daily-driver features (leaderboards, market,
-         titles) -> social features -> utilities/docs -> admin. Keep admin-ish
-         Moderation last so it doesn't sit next to the everyday links. -->
+    <!-- Order: personal anchor -> daily-driver dropdowns (Economy, Casino)
+         -> social/observational features -> utilities/docs -> admin. Economy
+         folds Market + Titles into one navbar item; Casino is the home for
+         /slots and future minigames (currently shows a "Coming soon" entry
+         until the Slots feature lands). Keep admin-ish Moderation last so
+         it doesn't sit next to the everyday links. -->
     <div class="nav-links" id="nav-menu">
         <a href="/profile/guilds">Profile</a>
         <a href="/leaderboards">Leaderboards</a>
-        <a href="/economy/guilds">Market</a>
-        <a href="/titles/guilds">Titles</a>
+        <div class="nav-dropdown">
+            <button type="button"
+                    class="nav-dropdown-toggle"
+                    aria-haspopup="true"
+                    aria-expanded="false"
+                    onclick="toggleDropdown(this)">Economy <span class="nav-dropdown-caret" aria-hidden="true">&#9662;</span></button>
+            <div class="nav-dropdown-menu" role="menu">
+                <a href="/economy/guilds" role="menuitem">Market</a>
+                <a href="/titles/guilds" role="menuitem">Titles</a>
+            </div>
+        </div>
+        <div class="nav-dropdown">
+            <button type="button"
+                    class="nav-dropdown-toggle"
+                    aria-haspopup="true"
+                    aria-expanded="false"
+                    onclick="toggleDropdown(this)">Casino <span class="nav-dropdown-caret" aria-hidden="true">&#9662;</span></button>
+            <div class="nav-dropdown-menu" role="menu">
+                <span class="nav-dropdown-coming-soon" aria-disabled="true">&#127920; Slots &mdash; coming soon</span>
+            </div>
+        </div>
         <a href="/intro/guilds">Intro Songs</a>
         <a href="/dnd/campaign">Campaigns</a>
         <a href="/utils">Utils</a>

--- a/web/src/test/js/navbar.test.js
+++ b/web/src/test/js/navbar.test.js
@@ -51,4 +51,45 @@ describe('navbar fragment', () => {
             /<script[^>]*th:src\s*=\s*"@\{\s*\/js\/home\.js\s*}"/
         );
     });
+
+    // PR 2 (navbar dropdowns): Economy folds Market + Titles; Casino is
+    // the home for the upcoming /slots minigame. Both must render as
+    // <button class="nav-dropdown-toggle"> with their menu links inside
+    // a sibling .nav-dropdown-menu — anything else breaks the CSS
+    // selectors that show/hide the menu on hover/click.
+    test('Economy dropdown contains the Market and Titles links', () => {
+        const economy = html.match(
+            /<div class="nav-dropdown">[\s\S]*?Economy[\s\S]*?<\/div>\s*<\/div>/
+        );
+        expect(economy).not.toBeNull();
+        expect(economy[0]).toMatch(/href="\/economy\/guilds"[^>]*>\s*Market\s*</);
+        expect(economy[0]).toMatch(/href="\/titles\/guilds"[^>]*>\s*Titles\s*</);
+        expect(economy[0]).toMatch(
+            /<button[^>]*class="[^"]*\bnav-dropdown-toggle\b[^"]*"[^>]*onclick="toggleDropdown\(this\)"/
+        );
+    });
+
+    test('Casino dropdown ships with a Coming soon placeholder', () => {
+        const casino = html.match(
+            /<div class="nav-dropdown">[\s\S]*?Casino[\s\S]*?<\/div>\s*<\/div>/
+        );
+        expect(casino).not.toBeNull();
+        expect(casino[0]).toMatch(/class="nav-dropdown-coming-soon"/);
+        expect(casino[0]).toMatch(/coming soon/i);
+    });
+
+    test('Market and Titles are no longer top-level nav-links siblings', () => {
+        // Regression: if someone re-introduces them at the top level the
+        // navbar grows by two items and the dropdown becomes redundant.
+        const navLinks = html.match(
+            /<div class="nav-links" id="nav-menu">([\s\S]*?)<button class="nav-toggle"/
+        );
+        expect(navLinks).not.toBeNull();
+        const topLevel = navLinks[1];
+        // Market / Titles links exist (inside dropdowns) but not as direct
+        // children of nav-links — strip out the dropdown subtrees first.
+        const stripped = topLevel.replace(/<div class="nav-dropdown">[\s\S]*?<\/div>\s*<\/div>/g, '');
+        expect(stripped).not.toMatch(/href="\/economy\/guilds"/);
+        expect(stripped).not.toMatch(/href="\/titles\/guilds"/);
+    });
 });


### PR DESCRIPTION
## Summary

**Economy ▾** folds Market + Titles into one navbar item. **Casino ▾** ships with a "🎰 Slots — coming soon" placeholder so the menu position is reserved for the actual `/slots` page in the next PR.

Net navbar footprint stays the same — Market + Titles previously took two flat slots, the new Economy dropdown takes one and contains both. Adding Casino brings the count back to where it started, so the navbar isn't growing.

## How the dropdown works

- Trigger: `<button class="nav-dropdown-toggle" onclick="toggleDropdown(this)">`
- Menu: sibling `<div class="nav-dropdown-menu">` with the links inside
- Desktop: CSS `:hover` opens the menu
- Keyboard / touch: `toggleDropdown` adds `.open` to the parent `.nav-dropdown` — the same CSS reveals the menu
- Closes on: outside click, **Esc**, opening another dropdown (only one open at a time)

## Mobile (≤600px)

`.nav-dropdown-menu` becomes `position: static`, rendering inline beneath the trigger so the whole menu is one vertical scroll once the hamburger is opened. No second tap to reach Market / Titles.

## Tests

- All existing `navbar.test.js` contracts preserved (fragment name, hamburger `onclick="toggleNav()"`, `#nav-menu` with `.nav-links` class, `home.js` script inside fragment).
- Three new tests lock in the dropdown structure:
  - Economy dropdown contains Market + Titles links + the toggle button wired to `toggleDropdown(this)`
  - Casino dropdown contains the "Coming soon" placeholder
  - Market / Titles are NOT top-level `.nav-links` siblings (regression guard against accidental re-introduction)
- All **85 JS tests green** locally.

## Test plan

- [ ] CI green
- [ ] Manual: hover Economy on desktop — menu opens with Market + Titles, caret rotates
- [ ] Manual: click Casino — menu opens with the Coming soon entry, click elsewhere closes it
- [ ] Manual: press Esc with a dropdown open — it closes
- [ ] Manual: shrink viewport below 600px, open hamburger — Economy + Casino render with their items inline beneath each trigger

## Out of scope

- The `/slots` feature itself — that's PR 3. The "Coming soon" entry gets swapped for a real link there.
- Nested dropdowns / mega-menus — single level only.

Second in the 3-PR series. PR 1 ([#293](https://github.com/ml404/toby-bot/pull/293)) landed Flyway-in-tests via Testcontainers; PR 3 will ship `/slots`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JvuveFBoCvMFTK8XxXVN56)_