### PR TITLE
feat: /slots minigame — Discord command + web UI

### DIFF
--- a/application/src/test/kotlin/integration/bot/CommandManagerTest.kt
+++ b/application/src/test/kotlin/integration/bot/CommandManagerTest.kt
@@ -9,6 +9,7 @@ import bot.toby.command.commands.dnd.InitiativeCommand
 import bot.toby.command.commands.dnd.LinkCharacterCommand
 import bot.toby.command.commands.dnd.RefreshCharacterCommand
 import bot.toby.command.commands.dnd.RollCommand
+import bot.toby.command.commands.economy.SlotsCommand
 import bot.toby.command.commands.economy.TitleCommand
 import bot.toby.command.commands.economy.TobyCoinCommand
 import bot.toby.command.commands.fetch.DbdRandomKillerCommand
@@ -128,12 +129,13 @@ class CommandManagerTest {
             CampaignCommand::class.java,
             TitleCommand::class.java,
             TobyCoinCommand::class.java,
+            SlotsCommand::class.java,
             ActivityCommand::class.java
         )
 
         Assertions.assertTrue(availableCommands.containsAll(commandManager.allCommands.map { it.javaClass }.toList()))
-        Assertions.assertEquals(46, commandManager.allCommands.size)
-        Assertions.assertEquals(46, commandManager.allSlashCommands.size)
+        Assertions.assertEquals(47, commandManager.allCommands.size)
+        Assertions.assertEquals(47, commandManager.allSlashCommands.size)
     }
 
     @Test

--- a/database/build.gradle
+++ b/database/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     testImplementation 'org.testcontainers:junit-jupiter'
     testImplementation 'org.testcontainers:postgresql'
     testRuntimeOnly 'org.postgresql:postgresql'
+    testImplementation "io.mockk:mockk:$mockk_version"
     testImplementation project(configuration: 'testArtifacts', path: ':common')
 }
 

--- a/database/src/main/kotlin/database/economy/SlotMachine.kt
+++ b/database/src/main/kotlin/database/economy/SlotMachine.kt
@@ -1,0 +1,78 @@
+package database.economy
+
+import kotlin.random.Random
+
+/**
+ * Pure-logic 3-reel slot machine. No Spring, no DB, no JDA — just weighted
+ * reel draws and a payout table.
+ *
+ * Reel design:
+ *   Same symbols on all three reels, drawn independently. Weights are out
+ *   of 10:
+ *     🍒 (4) common
+ *     🍋 (3) common
+ *     🔔 (2) uncommon
+ *     ⭐ (1) rare
+ *
+ * Payouts (multiplier × stake on 3-of-a-kind):
+ *     🍒🍒🍒  =   5×   P=0.064  EV=0.320
+ *     🍋🍋🍋  =  10×   P=0.027  EV=0.270
+ *     🔔🔔🔔  =  25×   P=0.008  EV=0.200
+ *     ⭐⭐⭐  = 100×   P=0.001  EV=0.100
+ *     anything else: 0× (lose stake)
+ *
+ * RTP ≈ 0.890 (~11% house edge). 100× jackpot at MAX_STAKE = 500 credits
+ * pays out 50,000 — meaningful but not "buy every title in one pull"
+ * territory (cheapest title costs 100 credits, most expensive 5,000).
+ *
+ * Stake bounds (MIN_STAKE / MAX_STAKE) live here so the Discord command,
+ * the web controller, and the service all agree on what's valid.
+ */
+class SlotMachine(
+    private val reel: List<Symbol> = DEFAULT_REEL,
+    private val payouts: Map<Symbol, Long> = DEFAULT_PAYOUTS
+) {
+
+    enum class Symbol(val display: String) {
+        CHERRY("🍒"),
+        LEMON("🍋"),
+        BELL("🔔"),
+        STAR("⭐")
+    }
+
+    data class Pull(val symbols: List<Symbol>, val multiplier: Long) {
+        val isWin: Boolean get() = multiplier > 0L
+    }
+
+    fun pull(random: Random): Pull {
+        val drawn = List(REEL_COUNT) { reel[random.nextInt(reel.size)] }
+        val multiplier = if (drawn.toSet().size == 1) {
+            payouts[drawn.first()] ?: 0L
+        } else {
+            0L
+        }
+        return Pull(drawn, multiplier)
+    }
+
+    companion object {
+        const val REEL_COUNT: Int = 3
+        const val MIN_STAKE: Long = 10L
+        const val MAX_STAKE: Long = 500L
+
+        // Weighted reel: 4 cherries + 3 lemons + 2 bells + 1 star = 10 cells.
+        // Same reel on all three slots; independent draws.
+        val DEFAULT_REEL: List<Symbol> = buildList {
+            repeat(4) { add(Symbol.CHERRY) }
+            repeat(3) { add(Symbol.LEMON) }
+            repeat(2) { add(Symbol.BELL) }
+            repeat(1) { add(Symbol.STAR) }
+        }
+
+        val DEFAULT_PAYOUTS: Map<Symbol, Long> = mapOf(
+            Symbol.CHERRY to 5L,
+            Symbol.LEMON to 10L,
+            Symbol.BELL to 25L,
+            Symbol.STAR to 100L
+        )
+    }
+}

--- a/database/src/main/kotlin/database/service/SlotsService.kt
+++ b/database/src/main/kotlin/database/service/SlotsService.kt
@@ -1,0 +1,81 @@
+package database.service
+
+import database.economy.SlotMachine
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import kotlin.random.Random
+
+/**
+ * Atomic spin path for the `/slots` minigame. Both the Discord `/slots`
+ * command and the web `/casino/{guildId}/slots` page call through here so
+ * the debit/credit maths and the random draw only live in one place.
+ *
+ * Pattern mirrors [EconomyTradeService]: lock the user row first
+ * ([UserService.getUserByIdForUpdate]), validate inputs against the live
+ * balance, mutate, persist. The whole thing runs inside one
+ * `@Transactional` boundary so concurrent `/slots` invocations from the
+ * same user (Discord + web at once, or just spam-clicking) can't double-
+ * spend the stake.
+ */
+@Service
+@Transactional
+class SlotsService(
+    private val userService: UserService,
+    private val machine: SlotMachine = SlotMachine(),
+    private val random: Random = Random.Default
+) {
+
+    sealed interface SpinOutcome {
+        data class Win(
+            val stake: Long,
+            val multiplier: Long,
+            val payout: Long,
+            val net: Long,
+            val symbols: List<SlotMachine.Symbol>,
+            val newBalance: Long
+        ) : SpinOutcome
+
+        data class Lose(
+            val stake: Long,
+            val symbols: List<SlotMachine.Symbol>,
+            val newBalance: Long
+        ) : SpinOutcome
+
+        data class InsufficientCredits(val stake: Long, val have: Long) : SpinOutcome
+        data class InvalidStake(val min: Long, val max: Long) : SpinOutcome
+        data object UnknownUser : SpinOutcome
+    }
+
+    fun spin(discordId: Long, guildId: Long, stake: Long): SpinOutcome {
+        if (stake < SlotMachine.MIN_STAKE || stake > SlotMachine.MAX_STAKE) {
+            return SpinOutcome.InvalidStake(SlotMachine.MIN_STAKE, SlotMachine.MAX_STAKE)
+        }
+        val user = userService.getUserByIdForUpdate(discordId, guildId)
+            ?: return SpinOutcome.UnknownUser
+        val balance = user.socialCredit ?: 0L
+        if (balance < stake) return SpinOutcome.InsufficientCredits(stake, balance)
+
+        val pull = machine.pull(random)
+        // payout = multiplier × stake on a win, 0 on a loss. Net change to
+        // the user's balance is (payout - stake): positive on wins (we eat
+        // their stake first then pay them out), -stake on losses.
+        val payout = pull.multiplier * stake
+        val net = payout - stake
+        user.socialCredit = balance + net
+        userService.updateUser(user)
+        val newBalance = user.socialCredit ?: 0L
+
+        return if (pull.isWin) {
+            SpinOutcome.Win(
+                stake = stake,
+                multiplier = pull.multiplier,
+                payout = payout,
+                net = net,
+                symbols = pull.symbols,
+                newBalance = newBalance
+            )
+        } else {
+            SpinOutcome.Lose(stake = stake, symbols = pull.symbols, newBalance = newBalance)
+        }
+    }
+}

--- a/database/src/test/kotlin/database/economy/SlotMachineTest.kt
+++ b/database/src/test/kotlin/database/economy/SlotMachineTest.kt
@@ -1,0 +1,75 @@
+package database.economy
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import kotlin.random.Random
+
+class SlotMachineTest {
+
+    @Test
+    fun `pull always returns 3 symbols and a non-negative multiplier`() {
+        val machine = SlotMachine()
+        val rng = Random(42)
+        repeat(1_000) {
+            val pull = machine.pull(rng)
+            assertEquals(SlotMachine.REEL_COUNT, pull.symbols.size)
+            assertTrue(pull.multiplier >= 0L, "multiplier must never go negative")
+        }
+    }
+
+    @Test
+    fun `three of the same symbol returns the configured multiplier for that symbol`() {
+        SlotMachine.Symbol.entries.forEach { symbol ->
+            val singleSymbolReel = listOf(symbol)
+            val machine = SlotMachine(reel = singleSymbolReel, payouts = SlotMachine.DEFAULT_PAYOUTS)
+            val pull = machine.pull(Random(1))
+            assertEquals(listOf(symbol, symbol, symbol), pull.symbols)
+            assertEquals(SlotMachine.DEFAULT_PAYOUTS.getValue(symbol), pull.multiplier)
+            assertTrue(pull.isWin, "3-of-a-kind must be a win")
+        }
+    }
+
+    @Test
+    fun `mixed symbols return zero multiplier`() {
+        // Reel where draws will rotate through different symbols, ensuring
+        // mismatched results.
+        val mixedReel = listOf(SlotMachine.Symbol.CHERRY, SlotMachine.Symbol.LEMON, SlotMachine.Symbol.BELL)
+        val machine = SlotMachine(reel = mixedReel, payouts = SlotMachine.DEFAULT_PAYOUTS)
+        val rng = Random(123)
+        var sawMix = false
+        repeat(200) {
+            val pull = machine.pull(rng)
+            if (pull.symbols.toSet().size > 1) {
+                sawMix = true
+                assertEquals(0L, pull.multiplier, "mixed symbols must lose")
+                assertTrue(!pull.isWin)
+            }
+        }
+        assertTrue(sawMix, "expected at least one mixed-symbol pull in 200 draws")
+    }
+
+    @Test
+    fun `RTP across 100k pulls is within +- 5 percent of 0_89`() {
+        // The machine's expected return-to-player is 0.890 with the default
+        // weights and payouts (see SlotMachine kdoc). With n = 100k the 95%
+        // CI is much tighter than ±0.05; the loose ±5pp bound is a forgiving
+        // floor that won't flake on CI.
+        val machine = SlotMachine()
+        val rng = Random(2026)
+        val stake = 1_000L
+        val n = 100_000
+        var totalWagered = 0L
+        var totalReturned = 0L
+        repeat(n) {
+            val pull = machine.pull(rng)
+            totalWagered += stake
+            totalReturned += pull.multiplier * stake
+        }
+        val rtp = totalReturned.toDouble() / totalWagered.toDouble()
+        assertTrue(
+            rtp in 0.84..0.94,
+            "expected RTP near 0.890 (±0.05) across $n pulls but saw $rtp"
+        )
+    }
+}

--- a/database/src/test/kotlin/database/service/SlotsServiceTest.kt
+++ b/database/src/test/kotlin/database/service/SlotsServiceTest.kt
@@ -1,0 +1,127 @@
+package database.service
+
+import database.dto.UserDto
+import database.economy.SlotMachine
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import kotlin.random.Random
+
+class SlotsServiceTest {
+
+    private lateinit var userService: UserService
+    private lateinit var machine: SlotMachine
+    private lateinit var service: SlotsService
+
+    private val discordId = 100L
+    private val guildId = 200L
+
+    @BeforeEach
+    fun setup() {
+        userService = mockk(relaxed = true)
+        machine = mockk(relaxed = true)
+        service = SlotsService(userService, machine, Random(0))
+    }
+
+    private fun userWithBalance(balance: Long): UserDto {
+        return UserDto(discordId, guildId).apply { socialCredit = balance }
+    }
+
+    @Test
+    fun `win debits stake and credits payout atomically`() {
+        val user = userWithBalance(1_000L)
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns user
+        // Force a 5x win on a 100 stake → +400 net.
+        every { machine.pull(any()) } returns SlotMachine.Pull(
+            symbols = listOf(SlotMachine.Symbol.CHERRY, SlotMachine.Symbol.CHERRY, SlotMachine.Symbol.CHERRY),
+            multiplier = 5L
+        )
+        val captured = slot<UserDto>()
+        every { userService.updateUser(capture(captured)) } returns user
+
+        val outcome = service.spin(discordId, guildId, stake = 100L)
+
+        val win = assertInstanceOf(SlotsService.SpinOutcome.Win::class.java, outcome)
+        assertEquals(100L, win.stake)
+        assertEquals(5L, win.multiplier)
+        assertEquals(500L, win.payout)
+        assertEquals(400L, win.net, "net = payout (500) - stake (100)")
+        assertEquals(1_400L, win.newBalance, "1000 + (500 - 100)")
+        assertEquals(1_400L, captured.captured.socialCredit)
+    }
+
+    @Test
+    fun `loss debits stake only`() {
+        val user = userWithBalance(500L)
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns user
+        every { machine.pull(any()) } returns SlotMachine.Pull(
+            symbols = listOf(SlotMachine.Symbol.CHERRY, SlotMachine.Symbol.LEMON, SlotMachine.Symbol.BELL),
+            multiplier = 0L
+        )
+        every { userService.updateUser(any()) } returns user
+
+        val outcome = service.spin(discordId, guildId, stake = 100L)
+
+        val lose = assertInstanceOf(SlotsService.SpinOutcome.Lose::class.java, outcome)
+        assertEquals(100L, lose.stake)
+        assertEquals(400L, lose.newBalance)
+        assertEquals(400L, user.socialCredit)
+    }
+
+    @Test
+    fun `insufficient credits is rejected without mutating balance`() {
+        val user = userWithBalance(50L)
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns user
+
+        val outcome = service.spin(discordId, guildId, stake = 100L)
+
+        val rej = assertInstanceOf(SlotsService.SpinOutcome.InsufficientCredits::class.java, outcome)
+        assertEquals(100L, rej.stake)
+        assertEquals(50L, rej.have)
+        assertEquals(50L, user.socialCredit, "balance untouched on rejection")
+        verify(exactly = 0) { userService.updateUser(any()) }
+    }
+
+    @Test
+    fun `stake below MIN_STAKE is rejected before locking the user`() {
+        val outcome = service.spin(discordId, guildId, stake = SlotMachine.MIN_STAKE - 1)
+
+        assertInstanceOf(SlotsService.SpinOutcome.InvalidStake::class.java, outcome)
+        verify(exactly = 0) { userService.getUserByIdForUpdate(any(), any()) }
+        verify(exactly = 0) { userService.updateUser(any()) }
+    }
+
+    @Test
+    fun `stake above MAX_STAKE is rejected before locking the user`() {
+        val outcome = service.spin(discordId, guildId, stake = SlotMachine.MAX_STAKE + 1)
+
+        assertInstanceOf(SlotsService.SpinOutcome.InvalidStake::class.java, outcome)
+        verify(exactly = 0) { userService.getUserByIdForUpdate(any(), any()) }
+    }
+
+    @Test
+    fun `unknown user is rejected`() {
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns null
+
+        val outcome = service.spin(discordId, guildId, stake = 100L)
+
+        assertEquals(SlotsService.SpinOutcome.UnknownUser, outcome)
+        verify(exactly = 0) { userService.updateUser(any()) }
+    }
+
+    @Test
+    fun `null socialCredit is treated as zero (insufficient)`() {
+        val user = UserDto(discordId, guildId).apply { socialCredit = null }
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns user
+
+        val outcome = service.spin(discordId, guildId, stake = 100L)
+
+        val rej = assertInstanceOf(SlotsService.SpinOutcome.InsufficientCredits::class.java, outcome)
+        assertEquals(0L, rej.have)
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/SlotsCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/SlotsCommand.kt
@@ -1,0 +1,111 @@
+package bot.toby.command.commands.economy
+
+import core.command.Command.Companion.invokeDeleteOnMessageResponse
+import core.command.CommandContext
+import database.dto.UserDto
+import database.economy.SlotMachine
+import database.service.SlotsService
+import database.service.SlotsService.SpinOutcome
+import net.dv8tion.jda.api.EmbedBuilder
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
+import net.dv8tion.jda.api.interactions.commands.OptionType
+import net.dv8tion.jda.api.interactions.commands.build.OptionData
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+import java.awt.Color
+
+/**
+ * `/slots stake:<int>` — first credit-spend gambling minigame. Calls
+ * through to [SlotsService.spin], which is the same path the web
+ * `/casino/{guildId}/slots` page uses, so the Discord and web surfaces
+ * can't drift on payout maths or balance debit/credit semantics.
+ */
+@Component
+class SlotsCommand @Autowired constructor(
+    private val slotsService: SlotsService
+) : EconomyCommand {
+
+    override val name: String = "slots"
+    override val description: String =
+        "Spin a 3-reel slot machine. Bet ${SlotMachine.MIN_STAKE}-${SlotMachine.MAX_STAKE} credits per pull."
+
+    companion object {
+        private const val OPT_STAKE = "stake"
+        private val WIN_COLOR = Color(87, 242, 135)   // #57F287 — same as market chart green
+        private val LOSE_COLOR = Color(160, 160, 176) // #a0a0b0 — muted grey
+        private val ERROR_COLOR = Color(237, 66, 69)  // #ED4245 — Discord red
+    }
+
+    override val optionData: List<OptionData> = listOf(
+        OptionData(OptionType.INTEGER, OPT_STAKE, "Credits to wager (10–500)", true)
+            .setMinValue(SlotMachine.MIN_STAKE)
+            .setMaxValue(SlotMachine.MAX_STAKE)
+    )
+
+    override fun handle(ctx: CommandContext, requestingUserDto: UserDto, deleteDelay: Int) {
+        val event = ctx.event
+        event.deferReply().queue()
+
+        val guild = event.guild ?: run {
+            replyError(event, "This command can only be used in a server.", deleteDelay); return
+        }
+        val stake = event.getOption(OPT_STAKE)?.asLong ?: run {
+            replyError(event, "You must specify a stake.", deleteDelay); return
+        }
+
+        val outcome = slotsService.spin(requestingUserDto.discordId, guild.idLong, stake)
+        replyOutcome(event, outcome, deleteDelay)
+    }
+
+    private fun replyOutcome(
+        event: SlashCommandInteractionEvent,
+        outcome: SpinOutcome,
+        deleteDelay: Int
+    ) {
+        val embed = when (outcome) {
+            is SpinOutcome.Win -> EmbedBuilder()
+                .setTitle("🎰 ${reelLine(outcome.symbols)}")
+                .setDescription("**+${outcome.net} credits** (${outcome.multiplier}× on a ${outcome.stake} stake)")
+                .addField("New balance", "${outcome.newBalance} credits", true)
+                .setColor(WIN_COLOR)
+                .build()
+
+            is SpinOutcome.Lose -> EmbedBuilder()
+                .setTitle("🎰 ${reelLine(outcome.symbols)}")
+                .setDescription("Lost **${outcome.stake} credits**.")
+                .addField("New balance", "${outcome.newBalance} credits", true)
+                .setColor(LOSE_COLOR)
+                .build()
+
+            is SpinOutcome.InsufficientCredits -> errorEmbed(
+                "Not enough credits. You need ${outcome.stake} but only have ${outcome.have}."
+            )
+
+            is SpinOutcome.InvalidStake -> errorEmbed(
+                "Stake must be between ${outcome.min} and ${outcome.max} credits."
+            )
+
+            SpinOutcome.UnknownUser -> errorEmbed(
+                "No user record yet. Try another TobyBot command first."
+            )
+        }
+        event.hook.sendMessageEmbeds(embed).queue(invokeDeleteOnMessageResponse(deleteDelay))
+    }
+
+    private fun reelLine(symbols: List<SlotMachine.Symbol>): String =
+        symbols.joinToString(separator = " ") { it.display }
+
+    private fun errorEmbed(message: String) = EmbedBuilder()
+        .setTitle("🎰 Slots")
+        .setDescription(message)
+        .setColor(ERROR_COLOR)
+        .build()
+
+    private fun replyError(
+        event: SlashCommandInteractionEvent,
+        message: String,
+        deleteDelay: Int
+    ) {
+        event.hook.sendMessageEmbeds(errorEmbed(message)).queue(invokeDeleteOnMessageResponse(deleteDelay))
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/economy/SlotsCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/economy/SlotsCommandTest.kt
@@ -1,0 +1,111 @@
+package bot.toby.command.commands.economy
+
+import bot.toby.command.CommandTest
+import bot.toby.command.CommandTest.Companion.event
+import bot.toby.command.CommandTest.Companion.guild
+import bot.toby.command.DefaultCommandContext
+import database.dto.UserDto
+import database.economy.SlotMachine
+import database.service.SlotsService
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import net.dv8tion.jda.api.interactions.commands.OptionMapping
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class SlotsCommandTest : CommandTest {
+    private lateinit var slotsService: SlotsService
+    private lateinit var command: SlotsCommand
+
+    private val discordId = 1L
+    private val guildId = 42L
+
+    @BeforeEach
+    fun setUp() {
+        setUpCommonMocks()
+        slotsService = mockk(relaxed = true)
+        command = SlotsCommand(slotsService)
+        every { guild.idLong } returns guildId
+    }
+
+    @AfterEach
+    fun tearDown() {
+        tearDownCommonMocks()
+        clearAllMocks()
+    }
+
+    private fun intOpt(value: Long): OptionMapping {
+        val o = mockk<OptionMapping>(relaxed = true)
+        every { o.asLong } returns value
+        return o
+    }
+
+    @Test
+    fun `delegates to SlotsService with the stake option`() {
+        val user = UserDto(discordId = discordId, guildId = guildId)
+        every { event.getOption("stake") } returns intOpt(50L)
+        every { slotsService.spin(discordId, guildId, 50L) } returns SlotsService.SpinOutcome.Lose(
+            stake = 50L,
+            symbols = listOf(SlotMachine.Symbol.CHERRY, SlotMachine.Symbol.LEMON, SlotMachine.Symbol.BELL),
+            newBalance = 950L
+        )
+
+        command.handle(DefaultCommandContext(event), user, 5)
+
+        verify(exactly = 1) { slotsService.spin(discordId, guildId, 50L) }
+    }
+
+    @Test
+    fun `replies with embed on each outcome variant`() {
+        val user = UserDto(discordId = discordId, guildId = guildId)
+        every { event.getOption("stake") } returns intOpt(100L)
+
+        // Each outcome should produce an embed reply through event.hook.
+        // Using relaxed mocks: just verify replyEmbeds is invoked.
+        val outcomes = listOf(
+            SlotsService.SpinOutcome.Win(
+                stake = 100L,
+                multiplier = 5L,
+                payout = 500L,
+                net = 400L,
+                symbols = listOf(
+                    SlotMachine.Symbol.CHERRY,
+                    SlotMachine.Symbol.CHERRY,
+                    SlotMachine.Symbol.CHERRY
+                ),
+                newBalance = 1_400L
+            ),
+            SlotsService.SpinOutcome.Lose(
+                stake = 100L,
+                symbols = listOf(
+                    SlotMachine.Symbol.CHERRY,
+                    SlotMachine.Symbol.LEMON,
+                    SlotMachine.Symbol.STAR
+                ),
+                newBalance = 900L
+            ),
+            SlotsService.SpinOutcome.InsufficientCredits(stake = 100L, have = 50L),
+            SlotsService.SpinOutcome.InvalidStake(min = 10L, max = 500L),
+            SlotsService.SpinOutcome.UnknownUser
+        )
+        outcomes.forEach { outcome ->
+            every { slotsService.spin(any(), any(), any()) } returns outcome
+            command.handle(DefaultCommandContext(event), user, 5)
+        }
+
+        verify(atLeast = outcomes.size) { event.hook.sendMessageEmbeds(any<net.dv8tion.jda.api.entities.MessageEmbed>()) }
+    }
+
+    @Test
+    fun `missing stake option short-circuits without calling the service`() {
+        val user = UserDto(discordId = discordId, guildId = guildId)
+        every { event.getOption("stake") } returns null
+
+        command.handle(DefaultCommandContext(event), user, 5)
+
+        verify(exactly = 0) { slotsService.spin(any(), any(), any()) }
+    }
+}

--- a/web/src/main/kotlin/web/controller/CasinoController.kt
+++ b/web/src/main/kotlin/web/controller/CasinoController.kt
@@ -1,0 +1,45 @@
+package web.controller
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient
+import org.springframework.security.oauth2.client.annotation.RegisteredOAuth2AuthorizedClient
+import org.springframework.security.oauth2.core.user.OAuth2User
+import org.springframework.stereotype.Controller
+import org.springframework.ui.Model
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import web.service.EconomyWebService
+import web.util.discordIdOrNull
+import web.util.displayName
+
+/**
+ * Casino landing pages. The minigames themselves (currently just `/slots`)
+ * live in their own controllers; this is just the guild picker that the
+ * Casino navbar dropdown lands on.
+ *
+ * Reuses [EconomyWebService.getGuildsWhereUserCanView] for the mutual-
+ * guild filter — same membership check, same view-card shape, no need
+ * for a parallel service method.
+ */
+@Controller
+@RequestMapping("/casino")
+class CasinoController(
+    private val economyWebService: EconomyWebService
+) {
+
+    @GetMapping("/guilds")
+    fun guildList(
+        @RegisteredOAuth2AuthorizedClient("discord") client: OAuth2AuthorizedClient,
+        @AuthenticationPrincipal user: OAuth2User,
+        model: Model
+    ): String {
+        val discordId = user.discordIdOrNull()
+        val guilds = if (discordId != null) {
+            economyWebService.getGuildsWhereUserCanView(client.accessToken.tokenValue, discordId)
+        } else emptyList()
+
+        model.addAttribute("guilds", guilds)
+        model.addAttribute("username", user.displayName())
+        return "casino-guilds"
+    }
+}

--- a/web/src/main/kotlin/web/controller/SlotsController.kt
+++ b/web/src/main/kotlin/web/controller/SlotsController.kt
@@ -1,0 +1,152 @@
+package web.controller
+
+import database.economy.SlotMachine
+import database.service.SlotsService
+import database.service.SlotsService.SpinOutcome
+import database.service.UserService
+import net.dv8tion.jda.api.JDA
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.security.oauth2.core.user.OAuth2User
+import org.springframework.stereotype.Controller
+import org.springframework.ui.Model
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseBody
+import org.springframework.web.servlet.mvc.support.RedirectAttributes
+import web.service.EconomyWebService
+import web.util.discordIdOrNull
+import web.util.displayName
+
+/**
+ * Web surface for the `/slots` minigame. GET renders the reel UI with the
+ * user's current credit balance and the payout table; POST runs the spin
+ * via [SlotsService.spin] and returns JSON for the JS animation to settle
+ * the reels onto.
+ *
+ * Both surfaces share [SlotsService] so Discord and web can't drift on
+ * payout maths, debit/credit semantics, or stake bounds.
+ */
+@Controller
+@RequestMapping("/casino/{guildId}/slots")
+class SlotsController(
+    private val slotsService: SlotsService,
+    private val economyWebService: EconomyWebService,
+    private val userService: UserService,
+    private val jda: JDA
+) {
+
+    @GetMapping
+    fun page(
+        @PathVariable guildId: Long,
+        @AuthenticationPrincipal user: OAuth2User,
+        model: Model,
+        ra: RedirectAttributes
+    ): String {
+        val discordId = user.discordIdOrNull()
+            ?: return "redirect:/leaderboards"
+
+        if (!economyWebService.isMember(discordId, guildId)) {
+            ra.addFlashAttribute("error", "You are not a member of that server.")
+            return "redirect:/leaderboards"
+        }
+        val guild = jda.getGuildById(guildId) ?: run {
+            ra.addFlashAttribute("error", "Bot is not in that server.")
+            return "redirect:/leaderboards"
+        }
+
+        val balance = userService.getUserById(discordId, guildId)?.socialCredit ?: 0L
+
+        model.addAttribute("guildId", guildId.toString())
+        model.addAttribute("guildName", guild.name)
+        model.addAttribute("balance", balance)
+        model.addAttribute("minStake", SlotMachine.MIN_STAKE)
+        model.addAttribute("maxStake", SlotMachine.MAX_STAKE)
+        model.addAttribute("payoutTable", payoutRows())
+        model.addAttribute("username", user.displayName())
+        return "slots"
+    }
+
+    @PostMapping("/spin")
+    @ResponseBody
+    fun spin(
+        @PathVariable guildId: Long,
+        @RequestBody request: SpinRequest,
+        @AuthenticationPrincipal user: OAuth2User
+    ): ResponseEntity<SpinResponse> {
+        val discordId = user.discordIdOrNull()
+            ?: return ResponseEntity.status(401).body(SpinResponse(false, "Not signed in."))
+        if (!economyWebService.isMember(discordId, guildId)) {
+            return ResponseEntity.status(403).body(SpinResponse(false, "You are not a member of that server."))
+        }
+        return when (val outcome = slotsService.spin(discordId, guildId, request.stake)) {
+            is SpinOutcome.Win -> ResponseEntity.ok(
+                SpinResponse(
+                    ok = true,
+                    symbols = outcome.symbols.map { it.display },
+                    multiplier = outcome.multiplier,
+                    payout = outcome.payout,
+                    net = outcome.net,
+                    newBalance = outcome.newBalance,
+                    win = true
+                )
+            )
+
+            is SpinOutcome.Lose -> ResponseEntity.ok(
+                SpinResponse(
+                    ok = true,
+                    symbols = outcome.symbols.map { it.display },
+                    multiplier = 0L,
+                    payout = 0L,
+                    net = -outcome.stake,
+                    newBalance = outcome.newBalance,
+                    win = false
+                )
+            )
+
+            is SpinOutcome.InsufficientCredits -> ResponseEntity.badRequest().body(
+                SpinResponse(false, "Need ${outcome.stake} credits, you have ${outcome.have}.")
+            )
+
+            is SpinOutcome.InvalidStake -> ResponseEntity.badRequest().body(
+                SpinResponse(false, "Stake must be between ${outcome.min} and ${outcome.max} credits.")
+            )
+
+            SpinOutcome.UnknownUser -> ResponseEntity.badRequest().body(
+                SpinResponse(false, "No user record yet. Try another TobyBot command first.")
+            )
+        }
+    }
+
+    // Render-side projection of the payout table. Exposed via Model so the
+    // template doesn't have to re-derive multipliers — single source of
+    // truth lives in SlotMachine.
+    private fun payoutRows(): List<PayoutRow> {
+        return SlotMachine.DEFAULT_PAYOUTS.entries
+            .sortedBy { it.value }
+            .map { (symbol, multiplier) ->
+                PayoutRow(
+                    symbols = "${symbol.display} ${symbol.display} ${symbol.display}",
+                    multiplier = "${multiplier}×"
+                )
+            }
+    }
+}
+
+data class SpinRequest(val stake: Long = 0)
+
+data class SpinResponse(
+    val ok: Boolean,
+    val error: String? = null,
+    val symbols: List<String>? = null,
+    val multiplier: Long? = null,
+    val payout: Long? = null,
+    val net: Long? = null,
+    val newBalance: Long? = null,
+    val win: Boolean? = null
+)
+
+data class PayoutRow(val symbols: String, val multiplier: String)

--- a/web/src/main/resources/static/css/slots.css
+++ b/web/src/main/resources/static/css/slots.css
@@ -1,0 +1,132 @@
+.slots-header {
+    margin-bottom: var(--space-5);
+}
+.slots-header h1 { margin: var(--space-2) 0; }
+
+.slots-machine {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: var(--space-5);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--space-4);
+}
+
+.slots-reels {
+    display: flex;
+    gap: var(--space-3);
+    justify-content: center;
+}
+
+.slots-reel {
+    width: 96px;
+    height: 96px;
+    background: #0f1830;
+    border: 2px solid var(--border);
+    border-radius: 12px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 3rem;
+    user-select: none;
+    transition: transform 0.1s, border-color 0.2s;
+}
+
+.slots-reel.spinning {
+    border-color: #57F287;
+    animation: slots-shake 0.15s linear infinite;
+}
+
+@keyframes slots-shake {
+    0%, 100% { transform: translateY(0); }
+    50% { transform: translateY(-4px); }
+}
+
+.slots-result {
+    min-height: 1.5em;
+    font-size: 1.05rem;
+    font-variant-numeric: tabular-nums;
+    text-align: center;
+}
+.slots-result-win { color: #57F287; }
+.slots-result-lose { color: #a0a0b0; }
+
+.slots-bet {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    flex-wrap: wrap;
+    justify-content: center;
+}
+
+.slots-bet label {
+    font-size: 0.85rem;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.slots-bet input[type="number"] {
+    width: 100px;
+    padding: 8px 10px;
+    background: #0f1830;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    color: #fff;
+    font-size: 1rem;
+    font-variant-numeric: tabular-nums;
+}
+
+.slots-balance {
+    color: var(--text-muted);
+    font-variant-numeric: tabular-nums;
+}
+.slots-balance strong { color: #fff; }
+
+.slots-payouts {
+    margin-top: var(--space-5);
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: var(--space-4);
+}
+
+.slots-payouts h2 {
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--text-muted);
+    margin-bottom: var(--space-3);
+}
+
+.slots-payouts table {
+    width: 100%;
+    border-collapse: collapse;
+    font-variant-numeric: tabular-nums;
+}
+
+.slots-payouts th,
+.slots-payouts td {
+    text-align: left;
+    padding: 8px 4px;
+    border-bottom: 1px solid var(--border);
+    font-size: 0.95rem;
+}
+
+.slots-payouts th {
+    color: var(--text-muted);
+    font-weight: 500;
+    text-transform: uppercase;
+    font-size: 0.75rem;
+    letter-spacing: 0.05em;
+}
+
+.slots-payouts tr:last-child td { border-bottom: none; }
+
+@media (max-width: 600px) {
+    .slots-reel { width: 72px; height: 72px; font-size: 2.4rem; }
+    .slots-bet { flex-direction: column; align-items: stretch; }
+    .slots-bet input[type="number"] { width: 100%; }
+}

--- a/web/src/main/resources/static/js/slots.js
+++ b/web/src/main/resources/static/js/slots.js
@@ -1,0 +1,124 @@
+(function () {
+    'use strict';
+
+    const main = document.querySelector('main[data-guild-id]');
+    if (!main) return;
+
+    const guildId = main.dataset.guildId;
+    const postJson = window.TobyApi && window.TobyApi.postJson;
+
+    function toast(msg, type) {
+        if (window.TobyToast && typeof window.TobyToast.show === 'function') {
+            window.TobyToast.show(msg, { type: type || 'info' });
+        } else {
+            console.log('[' + (type || 'info') + '] ' + msg);
+        }
+    }
+
+    const reels = [
+        document.getElementById('slots-reel-0'),
+        document.getElementById('slots-reel-1'),
+        document.getElementById('slots-reel-2')
+    ];
+    const stakeInput = document.getElementById('slots-stake');
+    const spinBtn = document.getElementById('slots-spin');
+    const balanceEl = document.getElementById('slots-balance');
+    const resultEl = document.getElementById('slots-result');
+    const form = document.getElementById('slots-bet');
+
+    if (!form || !spinBtn || !stakeInput || reels.some(function (r) { return !r; })) return;
+
+    // Symbols the reel cycles through during the spin animation. Order
+    // is purely cosmetic — the final symbols are set from the server
+    // response when the request resolves.
+    const SPIN_SYMBOLS = ['🍒', '🍋', '🔔', '⭐'];
+    const SPIN_INTERVAL_MS = 60;
+    const SPIN_DURATION_MS = 800;
+
+    let spinning = false;
+
+    function startSpinAnimation() {
+        spinning = true;
+        reels.forEach(function (reel) { reel.classList.add('spinning'); });
+        return setInterval(function () {
+            reels.forEach(function (reel) {
+                reel.textContent = SPIN_SYMBOLS[Math.floor(Math.random() * SPIN_SYMBOLS.length)];
+            });
+        }, SPIN_INTERVAL_MS);
+    }
+
+    function stopSpinAnimation(intervalId, finalSymbols) {
+        clearInterval(intervalId);
+        spinning = false;
+        reels.forEach(function (reel, i) {
+            reel.classList.remove('spinning');
+            if (finalSymbols && finalSymbols[i]) reel.textContent = finalSymbols[i];
+        });
+    }
+
+    function showResult(body) {
+        if (!resultEl) return;
+        resultEl.hidden = false;
+        resultEl.classList.remove('slots-result-win', 'slots-result-lose');
+        if (body.win) {
+            resultEl.classList.add('slots-result-win');
+            resultEl.innerHTML = '<strong>+' + body.net + ' credits</strong> &middot; ' +
+                body.multiplier + '× on a stake';
+        } else {
+            resultEl.classList.add('slots-result-lose');
+            resultEl.innerHTML = 'Lost <strong>' + Math.abs(body.net) + ' credits</strong>';
+        }
+    }
+
+    function applyBalance(newBalance) {
+        if (typeof newBalance !== 'number') return;
+        if (balanceEl) balanceEl.textContent = newBalance;
+    }
+
+    form.addEventListener('submit', function (e) {
+        e.preventDefault();
+        if (spinning) return;
+
+        const stake = parseInt(stakeInput.value, 10);
+        if (!stake || stake <= 0) {
+            toast('Enter a positive stake.', 'error');
+            return;
+        }
+
+        spinBtn.disabled = true;
+        const intervalId = startSpinAnimation();
+        const requestStart = Date.now();
+
+        if (!postJson) {
+            stopSpinAnimation(intervalId);
+            spinBtn.disabled = false;
+            toast('API helper missing — refresh the page.', 'error');
+            return;
+        }
+
+        postJson('/casino/' + guildId + '/slots/spin', { stake: stake })
+            .then(function (body) {
+                // Wait at least SPIN_DURATION_MS so a fast network doesn't
+                // make the spin look snappy-and-jarring.
+                const elapsed = Date.now() - requestStart;
+                const remaining = Math.max(0, SPIN_DURATION_MS - elapsed);
+                setTimeout(function () {
+                    stopSpinAnimation(intervalId, body && body.symbols);
+                    spinBtn.disabled = false;
+                    if (body && body.ok) {
+                        showResult(body);
+                        applyBalance(body.newBalance);
+                    } else {
+                        if (resultEl) resultEl.hidden = true;
+                        toast((body && body.error) || 'Spin failed.', 'error');
+                    }
+                }, remaining);
+            })
+            .catch(function () {
+                stopSpinAnimation(intervalId);
+                spinBtn.disabled = false;
+                if (resultEl) resultEl.hidden = true;
+                toast('Network error.', 'error');
+            });
+    });
+})();

--- a/web/src/main/resources/templates/casino-guilds.html
+++ b/web/src/main/resources/templates/casino-guilds.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="en">
+<head th:replace="~{fragments/head :: head('TobyBot - Casino', '/css/leaderboard.css')}"></head>
+<body>
+<a href="#main" class="skip-link">Skip to content</a>
+<div th:replace="~{fragments/navbar :: navbar}"></div>
+
+<main id="main" class="container">
+    <h1 class="mb-3">🎰 Casino</h1>
+    <p class="muted mb-5">
+        Wager social credit on the reels. Each server has its own slots room —
+        balances are per-guild. Pick a server below to spin.
+    </p>
+
+    <div th:if="${error}" class="alert alert-error" th:text="${error}"></div>
+
+    <div class="lb-guild-grid" th:if="${not #lists.isEmpty(guilds)}">
+        <a class="lb-guild-card"
+           th:each="g : ${guilds}"
+           th:href="@{/casino/{id}/slots(id=${g.id})}">
+            <div class="lb-guild-card-header">
+                <img th:if="${g.iconUrl != null}"
+                     th:src="${g.iconUrl}"
+                     th:alt="${g.name} + ' icon'"
+                     class="lb-guild-icon"
+                     onerror="this.style.display='none'">
+                <div th:unless="${g.iconUrl != null}"
+                     class="lb-guild-icon-placeholder"
+                     aria-hidden="true"
+                     th:text="${#strings.substring(g.name, 0, 1).toUpperCase()}">G</div>
+                <div class="lb-guild-name" th:text="${g.name}" th:title="${g.name}">Guild</div>
+            </div>
+            <div class="lb-guild-top">
+                <span class="muted">Your wallet:</span>
+                <span th:text="${g.credits} + ' credits'">0 credits</span>
+            </div>
+            <div class="lb-guild-stats">
+                <span>🎰 Slots</span>
+            </div>
+        </a>
+    </div>
+
+    <div class="empty-hero" th:if="${#lists.isEmpty(guilds)}">
+        <span class="emoji" aria-hidden="true">🎰</span>
+        <h2>No servers to play in yet</h2>
+        <p class="mb-5">
+            You need to share at least one server with TobyBot to use the casino.
+        </p>
+    </div>
+</main>
+</body>
+</html>

--- a/web/src/main/resources/templates/fragments/navbar.html
+++ b/web/src/main/resources/templates/fragments/navbar.html
@@ -30,7 +30,7 @@
                     aria-expanded="false"
                     onclick="toggleDropdown(this)">Casino <span class="nav-dropdown-caret" aria-hidden="true">&#9662;</span></button>
             <div class="nav-dropdown-menu" role="menu">
-                <span class="nav-dropdown-coming-soon" aria-disabled="true">&#127920; Slots &mdash; coming soon</span>
+                <a href="/casino/guilds" role="menuitem">&#127920; Slots</a>
             </div>
         </div>
         <a href="/intro/guilds">Intro Songs</a>

--- a/web/src/main/resources/templates/slots.html
+++ b/web/src/main/resources/templates/slots.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="en">
+<head th:replace="~{fragments/head :: head('TobyBot - Slots', '/css/slots.css')}"></head>
+<body>
+<a href="#main" class="skip-link">Skip to content</a>
+<div th:replace="~{fragments/navbar :: navbar}"></div>
+
+<main id="main" class="container" th:attr="data-guild-id=${guildId}">
+
+    <div class="slots-header">
+        <a class="back-link" th:href="@{/leaderboards}">&larr; All servers</a>
+        <h1 th:text="'🎰 Slots • ' + ${guildName}">🎰 Slots</h1>
+        <p class="muted">3-of-a-kind wins. Bet between
+            <span th:text="${minStake}">10</span> and
+            <span th:text="${maxStake}">500</span> credits per pull.</p>
+    </div>
+
+    <div th:if="${error}" class="alert alert-error" th:text="${error}"></div>
+
+    <section class="slots-machine">
+        <div class="slots-reels" id="slots-reels" aria-live="polite">
+            <div class="slots-reel" id="slots-reel-0" data-symbol="🍒">🍒</div>
+            <div class="slots-reel" id="slots-reel-1" data-symbol="🍋">🍋</div>
+            <div class="slots-reel" id="slots-reel-2" data-symbol="🔔">🔔</div>
+        </div>
+
+        <div class="slots-result" id="slots-result" hidden></div>
+
+        <form class="slots-bet" id="slots-bet" autocomplete="off">
+            <label for="slots-stake">Stake (credits)</label>
+            <input id="slots-stake"
+                   name="stake"
+                   type="number"
+                   th:attr="min=${minStake}, max=${maxStake}"
+                   th:value="${minStake}"
+                   step="1">
+            <button type="submit" id="slots-spin" class="btn-primary">Spin</button>
+        </form>
+
+        <div class="slots-balance">
+            Balance: <strong id="slots-balance" th:text="${balance}">0</strong> credits
+        </div>
+    </section>
+
+    <section class="slots-payouts">
+        <h2>Payouts</h2>
+        <table>
+            <thead>
+            <tr><th>Combo</th><th>Wins</th></tr>
+            </thead>
+            <tbody>
+            <tr th:each="row : ${payoutTable}">
+                <td th:text="${row.symbols}">🍒 🍒 🍒</td>
+                <td th:text="${row.multiplier}">5×</td>
+            </tr>
+            </tbody>
+        </table>
+        <p class="muted">Anything else loses your stake. Each reel draws independently from a weighted
+            set (4 🍒, 3 🍋, 2 🔔, 1 ⭐). Long-run RTP ≈ 89%.</p>
+    </section>
+</main>
+
+<div class="toast-stack" id="toast-stack" aria-live="polite"></div>
+
+<script th:src="@{/js/api.js}"></script>
+<script th:src="@{/js/toasts.js}"></script>
+<script th:src="@{/js/slots.js}"></script>
+</body>
+</html>

--- a/web/src/test/js/navbar.test.js
+++ b/web/src/test/js/navbar.test.js
@@ -69,13 +69,14 @@ describe('navbar fragment', () => {
         );
     });
 
-    test('Casino dropdown ships with a Coming soon placeholder', () => {
+    test('Casino dropdown links to the Slots guild picker', () => {
         const casino = html.match(
             /<div class="nav-dropdown">[\s\S]*?Casino[\s\S]*?<\/div>\s*<\/div>/
         );
         expect(casino).not.toBeNull();
-        expect(casino[0]).toMatch(/class="nav-dropdown-coming-soon"/);
-        expect(casino[0]).toMatch(/coming soon/i);
+        expect(casino[0]).toMatch(/href="\/casino\/guilds"[^>]*>[^<]*Slots/);
+        // Coming-soon placeholder is gone now that Slots ships.
+        expect(casino[0]).not.toMatch(/coming soon/i);
     });
 
     test('Market and Titles are no longer top-level nav-links siblings', () => {

--- a/web/src/test/kotlin/web/controller/SlotsControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/SlotsControllerTest.kt
@@ -1,0 +1,145 @@
+package web.controller
+
+import database.economy.SlotMachine
+import database.service.SlotsService
+import database.service.SlotsService.SpinOutcome
+import database.service.UserService
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import net.dv8tion.jda.api.JDA
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.security.oauth2.core.user.OAuth2User
+import web.service.EconomyWebService
+
+/**
+ * The /spin endpoint is the public surface for the web `/casino/{guildId}/slots`
+ * UI. Tests cover every SpinOutcome variant's HTTP shape — they're also the
+ * regression guard against accidentally sharing the Discord side's outcome
+ * mapping with the web's HTTP-status mapping (different concerns).
+ */
+class SlotsControllerTest {
+
+    private val guildId = 42L
+    private val discordId = 100L
+
+    private lateinit var slotsService: SlotsService
+    private lateinit var economyWebService: EconomyWebService
+    private lateinit var userService: UserService
+    private lateinit var jda: JDA
+    private lateinit var user: OAuth2User
+    private lateinit var controller: SlotsController
+
+    @BeforeEach
+    fun setup() {
+        slotsService = mockk(relaxed = true)
+        economyWebService = mockk(relaxed = true)
+        userService = mockk(relaxed = true)
+        jda = mockk(relaxed = true)
+        user = mockk {
+            every { getAttribute<String>("id") } returns discordId.toString()
+            every { getAttribute<String>("username") } returns "tester"
+        }
+        every { economyWebService.isMember(discordId, guildId) } returns true
+        controller = SlotsController(slotsService, economyWebService, userService, jda)
+    }
+
+    @Test
+    fun `spin win returns 200 with win-shaped payload`() {
+        every { slotsService.spin(discordId, guildId, 100L) } returns SpinOutcome.Win(
+            stake = 100L,
+            multiplier = 5L,
+            payout = 500L,
+            net = 400L,
+            symbols = listOf(
+                SlotMachine.Symbol.CHERRY,
+                SlotMachine.Symbol.CHERRY,
+                SlotMachine.Symbol.CHERRY
+            ),
+            newBalance = 1_400L
+        )
+
+        val response = controller.spin(guildId, SpinRequest(stake = 100L), user)
+
+        assertTrue(response.statusCode.is2xxSuccessful)
+        val body = response.body!!
+        assertEquals(true, body.ok)
+        assertEquals(true, body.win)
+        assertEquals(5L, body.multiplier)
+        assertEquals(500L, body.payout)
+        assertEquals(400L, body.net)
+        assertEquals(1_400L, body.newBalance)
+        assertEquals(listOf("🍒", "🍒", "🍒"), body.symbols)
+    }
+
+    @Test
+    fun `spin lose returns 200 with negative net and win=false`() {
+        every { slotsService.spin(discordId, guildId, 50L) } returns SpinOutcome.Lose(
+            stake = 50L,
+            symbols = listOf(
+                SlotMachine.Symbol.CHERRY,
+                SlotMachine.Symbol.LEMON,
+                SlotMachine.Symbol.STAR
+            ),
+            newBalance = 950L
+        )
+
+        val response = controller.spin(guildId, SpinRequest(stake = 50L), user)
+
+        assertTrue(response.statusCode.is2xxSuccessful)
+        val body = response.body!!
+        assertEquals(true, body.ok)
+        assertEquals(false, body.win)
+        assertEquals(-50L, body.net)
+        assertEquals(950L, body.newBalance)
+    }
+
+    @Test
+    fun `spin returns 400 with error message on insufficient credits`() {
+        every { slotsService.spin(discordId, guildId, 100L) } returns
+            SpinOutcome.InsufficientCredits(stake = 100L, have = 30L)
+
+        val response = controller.spin(guildId, SpinRequest(stake = 100L), user)
+
+        assertEquals(400, response.statusCode.value())
+        assertEquals(false, response.body?.ok)
+        assertTrue(response.body?.error!!.contains("100"))
+        assertTrue(response.body?.error!!.contains("30"))
+    }
+
+    @Test
+    fun `spin returns 400 on invalid stake`() {
+        every { slotsService.spin(discordId, guildId, 5L) } returns
+            SpinOutcome.InvalidStake(min = 10L, max = 500L)
+
+        val response = controller.spin(guildId, SpinRequest(stake = 5L), user)
+
+        assertEquals(400, response.statusCode.value())
+        assertEquals(false, response.body?.ok)
+        assertTrue(response.body?.error!!.contains("10"))
+        assertTrue(response.body?.error!!.contains("500"))
+    }
+
+    @Test
+    fun `spin returns 400 on unknown user`() {
+        every { slotsService.spin(discordId, guildId, 100L) } returns SpinOutcome.UnknownUser
+
+        val response = controller.spin(guildId, SpinRequest(stake = 100L), user)
+
+        assertEquals(400, response.statusCode.value())
+        assertEquals(false, response.body?.ok)
+    }
+
+    @Test
+    fun `spin rejects with 403 when user is not a member of the guild`() {
+        every { economyWebService.isMember(discordId, guildId) } returns false
+
+        val response = controller.spin(guildId, SpinRequest(stake = 100L), user)
+
+        assertEquals(403, response.statusCode.value())
+        verify(exactly = 0) { slotsService.spin(any(), any(), any()) }
+    }
+}


### PR DESCRIPTION
## Summary

First credit-spend gambling sink. **`/slots`** ships on both Discord and the web — both surfaces share `SlotsService` so the payout maths, balance debit/credit semantics, and stake bounds can't drift.

Third in the 3-PR series:
- ✅ PR 1 ([#293](https://github.com/ml404/toby-bot/pull/293)) — Flyway tests via Testcontainers
- ✅ PR 2 ([#294](https://github.com/ml404/toby-bot/pull/294)) — Casino + Economy navbar dropdowns
- 🎰 **PR 3 — this one**

## Architecture (3 layers, each independently testable)

| Layer | File | Role |
|---|---|---|
| Pure logic | `database/economy/SlotMachine.kt` | Reel weights, payout table, `pull(random)`. No Spring/DB/JDA. |
| Service | `database/service/SlotsService.kt` | `@Service @Transactional`. Atomic balance debit/credit via `getUserByIdForUpdate`. Single source of truth for both surfaces. |
| Discord | `bot/toby/command/commands/economy/SlotsCommand.kt` | `EconomyCommand`, `/slots stake:<int>`, embed per outcome. |
| Web | `web/controller/SlotsController.kt` + `CasinoController.kt` | GET `/casino/{guildId}/slots` UI; POST `/spin` JSON; GET `/casino/guilds` picker. |
| Web UI | `slots.html` + `slots.js` + `slots.css` | 3-reel display, 800ms cosmetic spin animation, then settles on server-returned symbols. |

## Reel + payout table (89% RTP)

| Combo | Multiplier | Probability |
|---|---|---|
| 🍒🍒🍒 | 5× | 0.064 |
| 🍋🍋🍋 | 10× | 0.027 |
| 🔔🔔🔔 | 25× | 0.008 |
| ⭐⭐⭐ | 100× | 0.001 |
| anything else | 0× | 0.900 |

Each reel draws independently from a weighted set (4 🍒, 3 🍋, 2 🔔, 1 ⭐). Stake bounds 10–500 credits. Max single payout = 50,000 credits — meaningful (~10× the most expensive title) without being server-breaking. **No daily loss cap** (per scoping decision — gambler-vs-saver tension is the point).

## Casino navbar wiring

PR 2 shipped the Casino dropdown with a "Coming soon" placeholder. This PR swaps it for the live `/casino/guilds` link. The corresponding `navbar.test.js` test was updated.

## Build change

Added `io.mockk` as a `testImplementation` on `:database` so service-layer mock tests (`SlotsServiceTest`) can live in the same module as the service rather than going through hand-rolled fakes. Future `:database` service tests benefit too.

## Tests (all green locally)

- **`SlotMachineTest`** — `pull` always returns 3 symbols + non-negative multiplier; 3-of-a-kind matches the payout table for every symbol; RTP within ±5pp of 0.890 across 100k pulls.
- **`SlotsServiceTest`** — win/lose balance maths atomic; insufficient credits doesn't mutate; invalid stake short-circuits before the user lock; null `socialCredit` treated as 0.
- **`SlotsCommandTest`** — delegates to `SlotsService` with the stake option; every `SpinOutcome` variant produces an embed reply; missing stake short-circuits.
- **`SlotsControllerTest`** — every `SpinOutcome` maps to the right HTTP status (200 win/lose, 400 errors, 403 not-a-member); response payload shape locked in.
- All 85 JS tests stay green.

## Test plan

- [ ] CI green
- [ ] Manual Discord: `/slots stake:10` repeatedly — varied symbols, occasional wins; `/slots stake:5` → bounds-rejected by JDA min/max; `/slots stake:99999` → bounds-rejected; insufficient balance → friendly error
- [ ] Manual web: nav to Casino ▾ → Slots → /casino/guilds → click a guild → reel UI loads with current balance; spin animates ~800ms then settles; balance updates; toast on errors
- [ ] Both surfaces against the same user → balances stay in sync (proves shared service)

## Out of scope

- Cooldown / rate-limit (Discord's own per-command throttle is enough for v1)
- Persisted spin ledger (balance changes are already observable)
- Pair payouts / bonus rounds / progressive jackpot (post-v1 polish)
- Per-guild reel/payout config (hardcoded for v1; tune via PR)
- The other minigames (`/coinflip`, `/dice`, `/lottery`) — `SlotMachine` + `SlotsService` are *deliberately* not generalised yet; we'll see the right shape after building the second one.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JvuveFBoCvMFTK8XxXVN56)_