### PR TITLE
feat: /coinflip minigame — Discord command + web UI

### DIFF
--- a/application/src/test/kotlin/integration/bot/CommandManagerTest.kt
+++ b/application/src/test/kotlin/integration/bot/CommandManagerTest.kt
@@ -9,6 +9,7 @@ import bot.toby.command.commands.dnd.InitiativeCommand
 import bot.toby.command.commands.dnd.LinkCharacterCommand
 import bot.toby.command.commands.dnd.RefreshCharacterCommand
 import bot.toby.command.commands.dnd.RollCommand
+import bot.toby.command.commands.economy.CoinflipCommand
 import bot.toby.command.commands.economy.SlotsCommand
 import bot.toby.command.commands.economy.TitleCommand
 import bot.toby.command.commands.economy.TobyCoinCommand
@@ -130,12 +131,13 @@ class CommandManagerTest {
             TitleCommand::class.java,
             TobyCoinCommand::class.java,
             SlotsCommand::class.java,
+            CoinflipCommand::class.java,
             ActivityCommand::class.java
         )
 
         Assertions.assertTrue(availableCommands.containsAll(commandManager.allCommands.map { it.javaClass }.toList()))
-        Assertions.assertEquals(47, commandManager.allCommands.size)
-        Assertions.assertEquals(47, commandManager.allSlashCommands.size)
+        Assertions.assertEquals(48, commandManager.allCommands.size)
+        Assertions.assertEquals(48, commandManager.allSlashCommands.size)
     }
 
     @Test

--- a/database/src/main/kotlin/database/economy/Coinflip.kt
+++ b/database/src/main/kotlin/database/economy/Coinflip.kt
@@ -1,0 +1,54 @@
+package database.economy
+
+import kotlin.random.Random
+
+/**
+ * Pure-logic coin flip. No Spring, no DB, no JDA — just a random binary
+ * draw and a comparison against the caller's prediction.
+ *
+ * Mechanic
+ *   Fair 50/50 coin. User picks a side; if the flip matches, the payout
+ *   is `2 × stake` (i.e. they keep their stake AND win an equal amount).
+ *   No house edge — `/coinflip` is the "double or nothing" pivot in the
+ *   minigame portfolio. `/slots` is the actual credit sink (~11% house
+ *   edge).
+ *
+ * Stake bounds (`MIN_STAKE` / `MAX_STAKE`) live here so the Discord
+ * command, the web controller, and the service all agree on what's
+ * valid. Higher MAX than `/slots` because the max payout is just 2×
+ * (1,000 → 2,000 credits) — meaningful all-in without being
+ * server-breaking.
+ */
+class Coinflip(
+    private val multiplier: Long = DEFAULT_MULTIPLIER
+) {
+
+    enum class Side(val display: String) {
+        HEADS("Heads"),
+        TAILS("Tails")
+    }
+
+    data class Flip(
+        val landed: Side,
+        val predicted: Side,
+        val multiplier: Long
+    ) {
+        val isWin: Boolean get() = landed == predicted
+    }
+
+    fun flip(predicted: Side, random: Random): Flip {
+        val landed = if (random.nextBoolean()) Side.HEADS else Side.TAILS
+        return Flip(
+            landed = landed,
+            predicted = predicted,
+            multiplier = if (landed == predicted) multiplier else 0L
+        )
+    }
+
+    companion object {
+        const val MIN_STAKE: Long = 10L
+        const val MAX_STAKE: Long = 1_000L
+        // 2× = stake doubled on win. RTP = 1.0 (no house edge by design).
+        const val DEFAULT_MULTIPLIER: Long = 2L
+    }
+}

--- a/database/src/main/kotlin/database/service/CoinflipService.kt
+++ b/database/src/main/kotlin/database/service/CoinflipService.kt
@@ -1,0 +1,82 @@
+package database.service
+
+import database.economy.Coinflip
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import kotlin.random.Random
+
+/**
+ * Atomic flip path for the `/coinflip` minigame. Both Discord
+ * `/coinflip` and the web `/casino/{guildId}/coinflip` page call through
+ * here, mirroring the [SlotsService] pattern: lock the user row first
+ * via [UserService.getUserByIdForUpdate], validate inputs, mutate,
+ * persist, all inside a single `@Transactional` boundary.
+ */
+@Service
+@Transactional
+class CoinflipService(
+    private val userService: UserService,
+    private val coinflip: Coinflip = Coinflip(),
+    private val random: Random = Random.Default
+) {
+
+    sealed interface FlipOutcome {
+        data class Win(
+            val stake: Long,
+            val payout: Long,
+            val net: Long,
+            val landed: Coinflip.Side,
+            val predicted: Coinflip.Side,
+            val newBalance: Long
+        ) : FlipOutcome
+
+        data class Lose(
+            val stake: Long,
+            val landed: Coinflip.Side,
+            val predicted: Coinflip.Side,
+            val newBalance: Long
+        ) : FlipOutcome
+
+        data class InsufficientCredits(val stake: Long, val have: Long) : FlipOutcome
+        data class InvalidStake(val min: Long, val max: Long) : FlipOutcome
+        data object UnknownUser : FlipOutcome
+    }
+
+    fun flip(discordId: Long, guildId: Long, stake: Long, predicted: Coinflip.Side): FlipOutcome {
+        if (stake < Coinflip.MIN_STAKE || stake > Coinflip.MAX_STAKE) {
+            return FlipOutcome.InvalidStake(Coinflip.MIN_STAKE, Coinflip.MAX_STAKE)
+        }
+        val user = userService.getUserByIdForUpdate(discordId, guildId)
+            ?: return FlipOutcome.UnknownUser
+        val balance = user.socialCredit ?: 0L
+        if (balance < stake) return FlipOutcome.InsufficientCredits(stake, balance)
+
+        val flip = coinflip.flip(predicted, random)
+        // payout = multiplier × stake on a match, 0 on a miss. Net change
+        // to the user's balance is (payout - stake): positive on wins, -stake
+        // on losses.
+        val payout = flip.multiplier * stake
+        val net = payout - stake
+        user.socialCredit = balance + net
+        userService.updateUser(user)
+        val newBalance = user.socialCredit ?: 0L
+
+        return if (flip.isWin) {
+            FlipOutcome.Win(
+                stake = stake,
+                payout = payout,
+                net = net,
+                landed = flip.landed,
+                predicted = flip.predicted,
+                newBalance = newBalance
+            )
+        } else {
+            FlipOutcome.Lose(
+                stake = stake,
+                landed = flip.landed,
+                predicted = flip.predicted,
+                newBalance = newBalance
+            )
+        }
+    }
+}

--- a/database/src/test/kotlin/database/economy/CoinflipTest.kt
+++ b/database/src/test/kotlin/database/economy/CoinflipTest.kt
@@ -1,0 +1,65 @@
+package database.economy
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import kotlin.random.Random
+
+class CoinflipTest {
+
+    @Test
+    fun `flip returns landed side and predicted side back unchanged`() {
+        val coinflip = Coinflip()
+        val pull = coinflip.flip(Coinflip.Side.HEADS, Random(0))
+        assertEquals(Coinflip.Side.HEADS, pull.predicted)
+        // landed is one of the two sides — exact value depends on RNG.
+        assertTrue(pull.landed == Coinflip.Side.HEADS || pull.landed == Coinflip.Side.TAILS)
+    }
+
+    @Test
+    fun `match yields configured multiplier and isWin = true`() {
+        val coinflip = Coinflip(multiplier = 2L)
+        // Find a seed whose first nextBoolean() is true (HEADS).
+        val rngHeads = Random(0)
+        val flip = coinflip.flip(predicted = if (rngHeads.nextBoolean()) Coinflip.Side.HEADS else Coinflip.Side.TAILS, random = Random(0))
+        assertTrue(flip.isWin)
+        assertEquals(2L, flip.multiplier)
+    }
+
+    @Test
+    fun `mismatch yields zero multiplier and isWin = false`() {
+        val coinflip = Coinflip(multiplier = 2L)
+        // Pick the OPPOSITE of what the seed will draw.
+        val rng = Random(0)
+        val landed = if (rng.nextBoolean()) Coinflip.Side.HEADS else Coinflip.Side.TAILS
+        val opposite = if (landed == Coinflip.Side.HEADS) Coinflip.Side.TAILS else Coinflip.Side.HEADS
+        val flip = coinflip.flip(predicted = opposite, random = Random(0))
+        assertFalse(flip.isWin)
+        assertEquals(0L, flip.multiplier)
+        assertEquals(landed, flip.landed)
+        assertEquals(opposite, flip.predicted)
+    }
+
+    @Test
+    fun `RTP across 200k flips is within 5pp of 1_0`() {
+        // No house edge by design — fair 50/50 with 2× payout. Across n flips
+        // with random predictions, expected return is exactly 1.0 stake. The
+        // ±0.05 floor is forgiving for the n=200k draw; the 95% CI is much
+        // tighter.
+        val coinflip = Coinflip(multiplier = 2L)
+        val rng = Random(2026)
+        val stake = 1_000L
+        val n = 200_000
+        var totalWagered = 0L
+        var totalReturned = 0L
+        repeat(n) {
+            val predicted = if (rng.nextBoolean()) Coinflip.Side.HEADS else Coinflip.Side.TAILS
+            val flip = coinflip.flip(predicted, rng)
+            totalWagered += stake
+            totalReturned += flip.multiplier * stake
+        }
+        val rtp = totalReturned.toDouble() / totalWagered.toDouble()
+        assertTrue(rtp in 0.95..1.05, "expected RTP near 1.0 (±0.05) but saw $rtp")
+    }
+}

--- a/database/src/test/kotlin/database/service/CoinflipServiceTest.kt
+++ b/database/src/test/kotlin/database/service/CoinflipServiceTest.kt
@@ -1,0 +1,119 @@
+package database.service
+
+import database.dto.UserDto
+import database.economy.Coinflip
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import kotlin.random.Random
+
+class CoinflipServiceTest {
+
+    private lateinit var userService: UserService
+    private lateinit var coinflip: Coinflip
+    private lateinit var service: CoinflipService
+
+    private val discordId = 100L
+    private val guildId = 200L
+
+    @BeforeEach
+    fun setup() {
+        userService = mockk(relaxed = true)
+        coinflip = mockk(relaxed = true)
+        service = CoinflipService(userService, coinflip, Random(0))
+    }
+
+    private fun userWithBalance(balance: Long): UserDto {
+        return UserDto(discordId, guildId).apply { socialCredit = balance }
+    }
+
+    @Test
+    fun `win debits stake and credits payout atomically`() {
+        val user = userWithBalance(1_000L)
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns user
+        // Force a 2× win: HEADS predicted, HEADS landed.
+        every { coinflip.flip(Coinflip.Side.HEADS, any()) } returns Coinflip.Flip(
+            landed = Coinflip.Side.HEADS,
+            predicted = Coinflip.Side.HEADS,
+            multiplier = 2L
+        )
+        val captured = slot<UserDto>()
+        every { userService.updateUser(capture(captured)) } returns user
+
+        val outcome = service.flip(discordId, guildId, stake = 100L, predicted = Coinflip.Side.HEADS)
+
+        val win = assertInstanceOf(CoinflipService.FlipOutcome.Win::class.java, outcome)
+        assertEquals(100L, win.stake)
+        assertEquals(200L, win.payout)
+        assertEquals(100L, win.net, "net = payout (200) - stake (100)")
+        assertEquals(1_100L, win.newBalance, "1000 + (200 - 100)")
+        assertEquals(Coinflip.Side.HEADS, win.landed)
+        assertEquals(Coinflip.Side.HEADS, win.predicted)
+        assertEquals(1_100L, captured.captured.socialCredit)
+    }
+
+    @Test
+    fun `loss debits stake only`() {
+        val user = userWithBalance(500L)
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns user
+        every { coinflip.flip(Coinflip.Side.HEADS, any()) } returns Coinflip.Flip(
+            landed = Coinflip.Side.TAILS,
+            predicted = Coinflip.Side.HEADS,
+            multiplier = 0L
+        )
+        every { userService.updateUser(any()) } returns user
+
+        val outcome = service.flip(discordId, guildId, stake = 100L, predicted = Coinflip.Side.HEADS)
+
+        val lose = assertInstanceOf(CoinflipService.FlipOutcome.Lose::class.java, outcome)
+        assertEquals(100L, lose.stake)
+        assertEquals(400L, lose.newBalance)
+        assertEquals(Coinflip.Side.TAILS, lose.landed)
+        assertEquals(Coinflip.Side.HEADS, lose.predicted)
+    }
+
+    @Test
+    fun `insufficient credits is rejected without mutating balance`() {
+        val user = userWithBalance(50L)
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns user
+
+        val outcome = service.flip(discordId, guildId, stake = 100L, predicted = Coinflip.Side.HEADS)
+
+        val rej = assertInstanceOf(CoinflipService.FlipOutcome.InsufficientCredits::class.java, outcome)
+        assertEquals(100L, rej.stake)
+        assertEquals(50L, rej.have)
+        assertEquals(50L, user.socialCredit, "balance untouched on rejection")
+        verify(exactly = 0) { userService.updateUser(any()) }
+    }
+
+    @Test
+    fun `stake below MIN_STAKE is rejected before locking the user`() {
+        val outcome = service.flip(discordId, guildId, stake = Coinflip.MIN_STAKE - 1, predicted = Coinflip.Side.HEADS)
+
+        assertInstanceOf(CoinflipService.FlipOutcome.InvalidStake::class.java, outcome)
+        verify(exactly = 0) { userService.getUserByIdForUpdate(any(), any()) }
+    }
+
+    @Test
+    fun `stake above MAX_STAKE is rejected before locking the user`() {
+        val outcome = service.flip(discordId, guildId, stake = Coinflip.MAX_STAKE + 1, predicted = Coinflip.Side.HEADS)
+
+        assertInstanceOf(CoinflipService.FlipOutcome.InvalidStake::class.java, outcome)
+        verify(exactly = 0) { userService.getUserByIdForUpdate(any(), any()) }
+    }
+
+    @Test
+    fun `unknown user is rejected`() {
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns null
+
+        val outcome = service.flip(discordId, guildId, stake = 100L, predicted = Coinflip.Side.HEADS)
+
+        assertEquals(CoinflipService.FlipOutcome.UnknownUser, outcome)
+        verify(exactly = 0) { userService.updateUser(any()) }
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/CoinflipCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/CoinflipCommand.kt
@@ -1,0 +1,124 @@
+package bot.toby.command.commands.economy
+
+import core.command.Command.Companion.invokeDeleteOnMessageResponse
+import core.command.CommandContext
+import database.dto.UserDto
+import database.economy.Coinflip
+import database.service.CoinflipService
+import database.service.CoinflipService.FlipOutcome
+import net.dv8tion.jda.api.EmbedBuilder
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
+import net.dv8tion.jda.api.interactions.commands.OptionType
+import net.dv8tion.jda.api.interactions.commands.build.OptionData
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+import java.awt.Color
+
+/**
+ * `/coinflip side:<HEADS|TAILS> stake:<int>` — fair 50/50 double-or-
+ * nothing. Calls through to [CoinflipService.flip], which is the same
+ * path the web `/casino/{guildId}/coinflip` page uses, so the Discord
+ * and web surfaces can't drift on payout maths or balance debit/credit
+ * semantics.
+ */
+@Component
+class CoinflipCommand @Autowired constructor(
+    private val coinflipService: CoinflipService
+) : EconomyCommand {
+
+    override val name: String = "coinflip"
+    override val description: String =
+        "Flip a coin for double-or-nothing. Bet ${Coinflip.MIN_STAKE}-${Coinflip.MAX_STAKE} credits."
+
+    companion object {
+        private const val OPT_SIDE = "side"
+        private const val OPT_STAKE = "stake"
+        private const val SIDE_HEADS = "HEADS"
+        private const val SIDE_TAILS = "TAILS"
+        private val WIN_COLOR = Color(87, 242, 135)   // #57F287
+        private val LOSE_COLOR = Color(160, 160, 176) // #a0a0b0
+        private val ERROR_COLOR = Color(237, 66, 69)  // #ED4245
+    }
+
+    override val optionData: List<OptionData> = listOf(
+        OptionData(OptionType.STRING, OPT_SIDE, "Heads or tails", true)
+            .addChoice("Heads", SIDE_HEADS)
+            .addChoice("Tails", SIDE_TAILS),
+        OptionData(OptionType.INTEGER, OPT_STAKE, "Credits to wager (10–1000)", true)
+            .setMinValue(Coinflip.MIN_STAKE)
+            .setMaxValue(Coinflip.MAX_STAKE)
+    )
+
+    override fun handle(ctx: CommandContext, requestingUserDto: UserDto, deleteDelay: Int) {
+        val event = ctx.event
+        event.deferReply().queue()
+
+        val guild = event.guild ?: run {
+            replyError(event, "This command can only be used in a server.", deleteDelay); return
+        }
+        val side = parseSide(event.getOption(OPT_SIDE)?.asString) ?: run {
+            replyError(event, "Pick a side: heads or tails.", deleteDelay); return
+        }
+        val stake = event.getOption(OPT_STAKE)?.asLong ?: run {
+            replyError(event, "You must specify a stake.", deleteDelay); return
+        }
+
+        val outcome = coinflipService.flip(requestingUserDto.discordId, guild.idLong, stake, side)
+        replyOutcome(event, outcome, deleteDelay)
+    }
+
+    private fun parseSide(raw: String?): Coinflip.Side? = when (raw) {
+        SIDE_HEADS -> Coinflip.Side.HEADS
+        SIDE_TAILS -> Coinflip.Side.TAILS
+        else -> null
+    }
+
+    private fun replyOutcome(
+        event: SlashCommandInteractionEvent,
+        outcome: FlipOutcome,
+        deleteDelay: Int
+    ) {
+        val embed = when (outcome) {
+            is FlipOutcome.Win -> EmbedBuilder()
+                .setTitle("🪙 ${outcome.landed.display}!")
+                .setDescription("You called **${outcome.predicted.display}** and won **+${outcome.net} credits**.")
+                .addField("New balance", "${outcome.newBalance} credits", true)
+                .setColor(WIN_COLOR)
+                .build()
+
+            is FlipOutcome.Lose -> EmbedBuilder()
+                .setTitle("🪙 ${outcome.landed.display}!")
+                .setDescription("You called **${outcome.predicted.display}**. Lost **${outcome.stake} credits**.")
+                .addField("New balance", "${outcome.newBalance} credits", true)
+                .setColor(LOSE_COLOR)
+                .build()
+
+            is FlipOutcome.InsufficientCredits -> errorEmbed(
+                "Not enough credits. You need ${outcome.stake} but only have ${outcome.have}."
+            )
+
+            is FlipOutcome.InvalidStake -> errorEmbed(
+                "Stake must be between ${outcome.min} and ${outcome.max} credits."
+            )
+
+            FlipOutcome.UnknownUser -> errorEmbed(
+                "No user record yet. Try another TobyBot command first."
+            )
+        }
+        event.hook.sendMessageEmbeds(embed).queue(invokeDeleteOnMessageResponse(deleteDelay))
+    }
+
+    private fun errorEmbed(message: String) = EmbedBuilder()
+        .setTitle("🪙 Coinflip")
+        .setDescription(message)
+        .setColor(ERROR_COLOR)
+        .build()
+
+    private fun replyError(
+        event: SlashCommandInteractionEvent,
+        message: String,
+        deleteDelay: Int
+    ) {
+        event.hook.sendMessageEmbeds(errorEmbed(message)).queue(invokeDeleteOnMessageResponse(deleteDelay))
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/economy/CoinflipCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/economy/CoinflipCommandTest.kt
@@ -1,0 +1,128 @@
+package bot.toby.command.commands.economy
+
+import bot.toby.command.CommandTest
+import bot.toby.command.CommandTest.Companion.event
+import bot.toby.command.CommandTest.Companion.guild
+import bot.toby.command.DefaultCommandContext
+import database.dto.UserDto
+import database.economy.Coinflip
+import database.service.CoinflipService
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import net.dv8tion.jda.api.interactions.commands.OptionMapping
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class CoinflipCommandTest : CommandTest {
+    private lateinit var coinflipService: CoinflipService
+    private lateinit var command: CoinflipCommand
+
+    private val discordId = 1L
+    private val guildId = 42L
+
+    @BeforeEach
+    fun setUp() {
+        setUpCommonMocks()
+        coinflipService = mockk(relaxed = true)
+        command = CoinflipCommand(coinflipService)
+        every { guild.idLong } returns guildId
+    }
+
+    @AfterEach
+    fun tearDown() {
+        tearDownCommonMocks()
+        clearAllMocks()
+    }
+
+    private fun strOpt(value: String): OptionMapping {
+        val o = mockk<OptionMapping>(relaxed = true)
+        every { o.asString } returns value
+        return o
+    }
+
+    private fun intOpt(value: Long): OptionMapping {
+        val o = mockk<OptionMapping>(relaxed = true)
+        every { o.asLong } returns value
+        return o
+    }
+
+    @Test
+    fun `delegates to CoinflipService with the parsed side and stake`() {
+        val user = UserDto(discordId = discordId, guildId = guildId)
+        every { event.getOption("side") } returns strOpt("HEADS")
+        every { event.getOption("stake") } returns intOpt(50L)
+        every { coinflipService.flip(discordId, guildId, 50L, Coinflip.Side.HEADS) } returns
+            CoinflipService.FlipOutcome.Lose(
+                stake = 50L,
+                landed = Coinflip.Side.TAILS,
+                predicted = Coinflip.Side.HEADS,
+                newBalance = 950L
+            )
+
+        command.handle(DefaultCommandContext(event), user, 5)
+
+        verify(exactly = 1) {
+            coinflipService.flip(discordId, guildId, 50L, Coinflip.Side.HEADS)
+        }
+    }
+
+    @Test
+    fun `replies with embed on each outcome variant`() {
+        val user = UserDto(discordId = discordId, guildId = guildId)
+        every { event.getOption("side") } returns strOpt("TAILS")
+        every { event.getOption("stake") } returns intOpt(100L)
+
+        val outcomes = listOf(
+            CoinflipService.FlipOutcome.Win(
+                stake = 100L,
+                payout = 200L,
+                net = 100L,
+                landed = Coinflip.Side.TAILS,
+                predicted = Coinflip.Side.TAILS,
+                newBalance = 1_100L
+            ),
+            CoinflipService.FlipOutcome.Lose(
+                stake = 100L,
+                landed = Coinflip.Side.HEADS,
+                predicted = Coinflip.Side.TAILS,
+                newBalance = 900L
+            ),
+            CoinflipService.FlipOutcome.InsufficientCredits(stake = 100L, have = 50L),
+            CoinflipService.FlipOutcome.InvalidStake(min = 10L, max = 1_000L),
+            CoinflipService.FlipOutcome.UnknownUser
+        )
+        outcomes.forEach { outcome ->
+            every { coinflipService.flip(any(), any(), any(), any()) } returns outcome
+            command.handle(DefaultCommandContext(event), user, 5)
+        }
+
+        verify(atLeast = outcomes.size) {
+            event.hook.sendMessageEmbeds(any<net.dv8tion.jda.api.entities.MessageEmbed>())
+        }
+    }
+
+    @Test
+    fun `missing side option short-circuits without calling the service`() {
+        val user = UserDto(discordId = discordId, guildId = guildId)
+        every { event.getOption("side") } returns null
+        every { event.getOption("stake") } returns intOpt(100L)
+
+        command.handle(DefaultCommandContext(event), user, 5)
+
+        verify(exactly = 0) { coinflipService.flip(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `unknown side string short-circuits without calling the service`() {
+        val user = UserDto(discordId = discordId, guildId = guildId)
+        every { event.getOption("side") } returns strOpt("EDGE")
+        every { event.getOption("stake") } returns intOpt(100L)
+
+        command.handle(DefaultCommandContext(event), user, 5)
+
+        verify(exactly = 0) { coinflipService.flip(any(), any(), any(), any()) }
+    }
+}

--- a/web/src/main/kotlin/web/controller/CoinflipController.kt
+++ b/web/src/main/kotlin/web/controller/CoinflipController.kt
@@ -1,0 +1,145 @@
+package web.controller
+
+import database.economy.Coinflip
+import database.service.CoinflipService
+import database.service.CoinflipService.FlipOutcome
+import database.service.UserService
+import net.dv8tion.jda.api.JDA
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.security.oauth2.core.user.OAuth2User
+import org.springframework.stereotype.Controller
+import org.springframework.ui.Model
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseBody
+import org.springframework.web.servlet.mvc.support.RedirectAttributes
+import web.service.EconomyWebService
+import web.util.discordIdOrNull
+import web.util.displayName
+
+/**
+ * Web surface for the `/coinflip` minigame. GET renders the picker UI
+ * (heads vs tails buttons + stake input); POST runs the flip via
+ * [CoinflipService.flip] and returns JSON for the JS animation to settle
+ * on.
+ *
+ * Both surfaces share [CoinflipService] so Discord and web can't drift
+ * on payout maths or balance debit/credit semantics.
+ */
+@Controller
+@RequestMapping("/casino/{guildId}/coinflip")
+class CoinflipController(
+    private val coinflipService: CoinflipService,
+    private val economyWebService: EconomyWebService,
+    private val userService: UserService,
+    private val jda: JDA
+) {
+
+    @GetMapping
+    fun page(
+        @PathVariable guildId: Long,
+        @AuthenticationPrincipal user: OAuth2User,
+        model: Model,
+        ra: RedirectAttributes
+    ): String {
+        val discordId = user.discordIdOrNull()
+            ?: return "redirect:/casino/guilds"
+
+        if (!economyWebService.isMember(discordId, guildId)) {
+            ra.addFlashAttribute("error", "You are not a member of that server.")
+            return "redirect:/casino/guilds"
+        }
+        val guild = jda.getGuildById(guildId) ?: run {
+            ra.addFlashAttribute("error", "Bot is not in that server.")
+            return "redirect:/casino/guilds"
+        }
+
+        val balance = userService.getUserById(discordId, guildId)?.socialCredit ?: 0L
+
+        model.addAttribute("guildId", guildId.toString())
+        model.addAttribute("guildName", guild.name)
+        model.addAttribute("balance", balance)
+        model.addAttribute("minStake", Coinflip.MIN_STAKE)
+        model.addAttribute("maxStake", Coinflip.MAX_STAKE)
+        model.addAttribute("multiplier", Coinflip.DEFAULT_MULTIPLIER)
+        model.addAttribute("username", user.displayName())
+        return "coinflip"
+    }
+
+    @PostMapping("/flip")
+    @ResponseBody
+    fun flip(
+        @PathVariable guildId: Long,
+        @RequestBody request: FlipRequest,
+        @AuthenticationPrincipal user: OAuth2User
+    ): ResponseEntity<FlipResponse> {
+        val discordId = user.discordIdOrNull()
+            ?: return ResponseEntity.status(401).body(FlipResponse(false, "Not signed in."))
+        if (!economyWebService.isMember(discordId, guildId)) {
+            return ResponseEntity.status(403).body(FlipResponse(false, "You are not a member of that server."))
+        }
+        val side = parseSide(request.side)
+            ?: return ResponseEntity.badRequest().body(FlipResponse(false, "Pick a side: HEADS or TAILS."))
+
+        return when (val outcome = coinflipService.flip(discordId, guildId, request.stake, side)) {
+            is FlipOutcome.Win -> ResponseEntity.ok(
+                FlipResponse(
+                    ok = true,
+                    landed = outcome.landed.name,
+                    predicted = outcome.predicted.name,
+                    net = outcome.net,
+                    payout = outcome.payout,
+                    newBalance = outcome.newBalance,
+                    win = true
+                )
+            )
+
+            is FlipOutcome.Lose -> ResponseEntity.ok(
+                FlipResponse(
+                    ok = true,
+                    landed = outcome.landed.name,
+                    predicted = outcome.predicted.name,
+                    net = -outcome.stake,
+                    payout = 0L,
+                    newBalance = outcome.newBalance,
+                    win = false
+                )
+            )
+
+            is FlipOutcome.InsufficientCredits -> ResponseEntity.badRequest().body(
+                FlipResponse(false, "Need ${outcome.stake} credits, you have ${outcome.have}.")
+            )
+
+            is FlipOutcome.InvalidStake -> ResponseEntity.badRequest().body(
+                FlipResponse(false, "Stake must be between ${outcome.min} and ${outcome.max} credits.")
+            )
+
+            FlipOutcome.UnknownUser -> ResponseEntity.badRequest().body(
+                FlipResponse(false, "No user record yet. Try another TobyBot command first.")
+            )
+        }
+    }
+
+    private fun parseSide(raw: String?): Coinflip.Side? = when (raw?.uppercase()) {
+        "HEADS" -> Coinflip.Side.HEADS
+        "TAILS" -> Coinflip.Side.TAILS
+        else -> null
+    }
+}
+
+data class FlipRequest(val side: String = "", val stake: Long = 0)
+
+data class FlipResponse(
+    val ok: Boolean,
+    val error: String? = null,
+    val landed: String? = null,
+    val predicted: String? = null,
+    val net: Long? = null,
+    val payout: Long? = null,
+    val newBalance: Long? = null,
+    val win: Boolean? = null
+)

--- a/web/src/main/resources/static/css/coinflip.css
+++ b/web/src/main/resources/static/css/coinflip.css
@@ -1,0 +1,150 @@
+.coinflip-header { margin-bottom: var(--space-5); }
+.coinflip-header h1 { margin: var(--space-2) 0; }
+
+.coinflip-table {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: var(--space-5);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--space-4);
+}
+
+.coinflip-coin {
+    width: 120px;
+    height: 120px;
+    border-radius: 50%;
+    background: linear-gradient(135deg, #f1c40f 0%, #c89200 100%);
+    box-shadow: 0 4px 16px rgba(241, 196, 15, 0.25), inset 0 -4px 8px rgba(0, 0, 0, 0.2);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    user-select: none;
+    transition: transform 0.2s;
+}
+.coinflip-coin-face {
+    font-size: 3rem;
+    font-weight: 700;
+    color: #2a1a00;
+    letter-spacing: -0.05em;
+}
+.coinflip-coin.flipping {
+    animation: coinflip-flip 0.4s linear infinite;
+}
+@keyframes coinflip-flip {
+    0%, 100% { transform: rotateY(0deg) scale(1); }
+    50% { transform: rotateY(180deg) scale(1.05); }
+}
+
+.coinflip-result {
+    min-height: 1.5em;
+    font-size: 1.05rem;
+    text-align: center;
+    font-variant-numeric: tabular-nums;
+}
+.coinflip-result-win { color: #57F287; }
+.coinflip-result-lose { color: #a0a0b0; }
+
+.coinflip-bet {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--space-3);
+    width: 100%;
+    max-width: 320px;
+}
+
+.coinflip-side-picker {
+    display: flex;
+    gap: var(--space-3);
+    width: 100%;
+}
+.coinflip-side {
+    flex: 1;
+    cursor: pointer;
+    user-select: none;
+}
+.coinflip-side input[type="radio"] {
+    position: absolute;
+    opacity: 0;
+    pointer-events: none;
+}
+.coinflip-side span {
+    display: block;
+    text-align: center;
+    padding: 12px;
+    background: #0f1830;
+    border: 2px solid var(--border);
+    border-radius: 8px;
+    color: var(--text-muted);
+    font-weight: 600;
+    transition: border-color 0.2s, color 0.2s, background 0.2s;
+}
+.coinflip-side input[type="radio"]:checked + span {
+    border-color: #f1c40f;
+    color: #fff;
+    background: #1a2240;
+}
+.coinflip-side input[type="radio"]:focus-visible + span {
+    outline: 2px solid #5865F2;
+    outline-offset: 2px;
+}
+
+.coinflip-stake-label {
+    font-size: 0.85rem;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    align-self: flex-start;
+}
+
+.coinflip-bet input[type="number"] {
+    width: 100%;
+    padding: 8px 10px;
+    background: #0f1830;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    color: #fff;
+    font-size: 1rem;
+    font-variant-numeric: tabular-nums;
+}
+
+.coinflip-bet button[type="submit"] {
+    width: 100%;
+}
+
+.coinflip-balance {
+    color: var(--text-muted);
+    font-variant-numeric: tabular-nums;
+}
+.coinflip-balance strong { color: #fff; }
+
+.coinflip-rules {
+    margin-top: var(--space-5);
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: var(--space-4);
+}
+.coinflip-rules h2 {
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--text-muted);
+    margin-bottom: var(--space-3);
+}
+.coinflip-rules ul {
+    list-style: disc;
+    padding-left: 20px;
+    color: var(--text-muted);
+    font-size: 0.95rem;
+    line-height: 1.7;
+}
+.coinflip-rules strong { color: #fff; }
+
+@media (max-width: 600px) {
+    .coinflip-coin { width: 96px; height: 96px; }
+    .coinflip-coin-face { font-size: 2.4rem; }
+}

--- a/web/src/main/resources/static/css/leaderboard.css
+++ b/web/src/main/resources/static/css/leaderboard.css
@@ -24,6 +24,26 @@
     transform: translateY(-2px);
     color: var(--text);
 }
+/* Static guild cards (e.g. Casino picker) don't navigate as a whole — the
+   hover lift would be a misleading affordance, so suppress it. The internal
+   game buttons supply their own hover state. */
+.lb-guild-card-static:hover {
+    border-color: var(--border);
+    transform: none;
+}
+.lb-guild-games {
+    display: flex;
+    gap: var(--space-2);
+    flex-wrap: wrap;
+    margin-top: auto;
+}
+.lb-guild-games .btn-secondary {
+    flex: 1;
+    text-align: center;
+    text-decoration: none;
+    padding: 8px 12px;
+    font-size: 0.9rem;
+}
 .lb-guild-card-header {
     display: flex;
     align-items: center;

--- a/web/src/main/resources/static/js/coinflip.js
+++ b/web/src/main/resources/static/js/coinflip.js
@@ -1,0 +1,138 @@
+(function () {
+    'use strict';
+
+    const main = document.querySelector('main[data-guild-id]');
+    if (!main) return;
+
+    const guildId = main.dataset.guildId;
+    const postJson = window.TobyApi && window.TobyApi.postJson;
+
+    function toast(msg, type) {
+        if (window.TobyToast && typeof window.TobyToast.show === 'function') {
+            window.TobyToast.show(msg, { type: type || 'info' });
+        } else {
+            console.log('[' + (type || 'info') + '] ' + msg);
+        }
+    }
+
+    const coin = document.getElementById('coinflip-coin');
+    const coinFace = document.getElementById('coinflip-coin-face');
+    const stakeInput = document.getElementById('coinflip-stake');
+    const flipBtn = document.getElementById('coinflip-flip');
+    const balanceEl = document.getElementById('coinflip-balance');
+    const resultEl = document.getElementById('coinflip-result');
+    const form = document.getElementById('coinflip-bet');
+
+    if (!form || !flipBtn || !stakeInput || !coin || !coinFace) return;
+
+    const FLIP_DURATION_MS = 800;
+    const FLIP_INTERVAL_MS = 80;
+    // Faces shown during the flip animation. Final face comes from the
+    // server response.
+    const FLIP_FACES = ['🪙', '🟡'];
+
+    let flipping = false;
+
+    function selectedSide() {
+        const checked = form.querySelector('input[name="side"]:checked');
+        return checked ? checked.value : null;
+    }
+
+    function startFlipAnimation() {
+        flipping = true;
+        coin.classList.add('flipping');
+        let i = 0;
+        return setInterval(function () {
+            coinFace.textContent = FLIP_FACES[i % FLIP_FACES.length];
+            i++;
+        }, FLIP_INTERVAL_MS);
+    }
+
+    function stopFlipAnimation(intervalId, landedSide) {
+        clearInterval(intervalId);
+        flipping = false;
+        coin.classList.remove('flipping');
+        if (landedSide === 'HEADS') {
+            coinFace.textContent = 'H';
+            coin.dataset.landed = 'heads';
+        } else if (landedSide === 'TAILS') {
+            coinFace.textContent = 'T';
+            coin.dataset.landed = 'tails';
+        } else {
+            coinFace.textContent = '🪙';
+            delete coin.dataset.landed;
+        }
+    }
+
+    function showResult(body) {
+        if (!resultEl) return;
+        resultEl.hidden = false;
+        resultEl.classList.remove('coinflip-result-win', 'coinflip-result-lose');
+        const landedLabel = body.landed === 'HEADS' ? 'Heads' : 'Tails';
+        const predictedLabel = body.predicted === 'HEADS' ? 'Heads' : 'Tails';
+        if (body.win) {
+            resultEl.classList.add('coinflip-result-win');
+            resultEl.innerHTML = '<strong>' + landedLabel + '!</strong> You called ' +
+                predictedLabel + ' &middot; <strong>+' + body.net + ' credits</strong>';
+        } else {
+            resultEl.classList.add('coinflip-result-lose');
+            resultEl.innerHTML = '<strong>' + landedLabel + '.</strong> You called ' +
+                predictedLabel + ' &middot; lost <strong>' + Math.abs(body.net) + ' credits</strong>';
+        }
+    }
+
+    function applyBalance(newBalance) {
+        if (typeof newBalance !== 'number') return;
+        if (balanceEl) balanceEl.textContent = newBalance;
+    }
+
+    form.addEventListener('submit', function (e) {
+        e.preventDefault();
+        if (flipping) return;
+
+        const side = selectedSide();
+        if (!side) {
+            toast('Pick a side first.', 'error');
+            return;
+        }
+        const stake = parseInt(stakeInput.value, 10);
+        if (!stake || stake <= 0) {
+            toast('Enter a positive stake.', 'error');
+            return;
+        }
+
+        flipBtn.disabled = true;
+        const intervalId = startFlipAnimation();
+        const requestStart = Date.now();
+
+        if (!postJson) {
+            stopFlipAnimation(intervalId);
+            flipBtn.disabled = false;
+            toast('API helper missing — refresh the page.', 'error');
+            return;
+        }
+
+        postJson('/casino/' + guildId + '/coinflip/flip', { side: side, stake: stake })
+            .then(function (body) {
+                const elapsed = Date.now() - requestStart;
+                const remaining = Math.max(0, FLIP_DURATION_MS - elapsed);
+                setTimeout(function () {
+                    stopFlipAnimation(intervalId, body && body.landed);
+                    flipBtn.disabled = false;
+                    if (body && body.ok) {
+                        showResult(body);
+                        applyBalance(body.newBalance);
+                    } else {
+                        if (resultEl) resultEl.hidden = true;
+                        toast((body && body.error) || 'Flip failed.', 'error');
+                    }
+                }, remaining);
+            })
+            .catch(function () {
+                stopFlipAnimation(intervalId);
+                flipBtn.disabled = false;
+                if (resultEl) resultEl.hidden = true;
+                toast('Network error.', 'error');
+            });
+    });
+})();

--- a/web/src/main/resources/templates/casino-guilds.html
+++ b/web/src/main/resources/templates/casino-guilds.html
@@ -15,9 +15,7 @@
     <div th:if="${error}" class="alert alert-error" th:text="${error}"></div>
 
     <div class="lb-guild-grid" th:if="${not #lists.isEmpty(guilds)}">
-        <a class="lb-guild-card"
-           th:each="g : ${guilds}"
-           th:href="@{/casino/{id}/slots(id=${g.id})}">
+        <div class="lb-guild-card lb-guild-card-static" th:each="g : ${guilds}">
             <div class="lb-guild-card-header">
                 <img th:if="${g.iconUrl != null}"
                      th:src="${g.iconUrl}"
@@ -34,10 +32,13 @@
                 <span class="muted">Your wallet:</span>
                 <span th:text="${g.credits} + ' credits'">0 credits</span>
             </div>
-            <div class="lb-guild-stats">
-                <span>🎰 Slots</span>
+            <div class="lb-guild-games">
+                <a class="btn-secondary"
+                   th:href="@{/casino/{id}/slots(id=${g.id})}">🎰 Slots</a>
+                <a class="btn-secondary"
+                   th:href="@{/casino/{id}/coinflip(id=${g.id})}">🪙 Coinflip</a>
             </div>
-        </a>
+        </div>
     </div>
 
     <div class="empty-hero" th:if="${#lists.isEmpty(guilds)}">

--- a/web/src/main/resources/templates/coinflip.html
+++ b/web/src/main/resources/templates/coinflip.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="en">
+<head th:replace="~{fragments/head :: head('TobyBot - Coinflip', '/css/coinflip.css')}"></head>
+<body>
+<a href="#main" class="skip-link">Skip to content</a>
+<div th:replace="~{fragments/navbar :: navbar}"></div>
+
+<main id="main" class="container" th:attr="data-guild-id=${guildId}">
+
+    <div class="coinflip-header">
+        <a class="back-link" th:href="@{/casino/guilds}">&larr; All casino servers</a>
+        <h1 th:text="'🪙 Coinflip • ' + ${guildName}">🪙 Coinflip</h1>
+        <p class="muted">Fair 50/50 double-or-nothing. Pick a side, set a stake. Bet between
+            <span th:text="${minStake}">10</span> and
+            <span th:text="${maxStake}">1000</span> credits per flip.</p>
+    </div>
+
+    <div th:if="${error}" class="alert alert-error" th:text="${error}"></div>
+
+    <section class="coinflip-table">
+        <div class="coinflip-coin" id="coinflip-coin" aria-live="polite">
+            <span class="coinflip-coin-face" id="coinflip-coin-face">🪙</span>
+        </div>
+
+        <div class="coinflip-result" id="coinflip-result" hidden></div>
+
+        <form class="coinflip-bet" id="coinflip-bet" autocomplete="off">
+            <div class="coinflip-side-picker" role="radiogroup" aria-label="Pick a side">
+                <label class="coinflip-side">
+                    <input type="radio" name="side" value="HEADS" checked>
+                    <span>Heads</span>
+                </label>
+                <label class="coinflip-side">
+                    <input type="radio" name="side" value="TAILS">
+                    <span>Tails</span>
+                </label>
+            </div>
+            <label for="coinflip-stake" class="coinflip-stake-label">Stake (credits)</label>
+            <input id="coinflip-stake"
+                   name="stake"
+                   type="number"
+                   th:attr="min=${minStake}, max=${maxStake}"
+                   th:value="${minStake}"
+                   step="1">
+            <button type="submit" id="coinflip-flip" class="btn-primary">Flip</button>
+        </form>
+
+        <div class="coinflip-balance">
+            Balance: <strong id="coinflip-balance" th:text="${balance}">0</strong> credits
+        </div>
+    </section>
+
+    <section class="coinflip-rules">
+        <h2>Rules</h2>
+        <ul>
+            <li>Pick heads or tails, set a stake.</li>
+            <li>Match the flip → <strong th:text="${multiplier} + '×'">2×</strong> stake (you keep your stake and win the same amount on top).</li>
+            <li>Miss → lose your stake.</li>
+            <li>Fair 50/50, no house edge.</li>
+        </ul>
+    </section>
+</main>
+
+<div class="toast-stack" id="toast-stack" aria-live="polite"></div>
+
+<script th:src="@{/js/api.js}"></script>
+<script th:src="@{/js/toasts.js}"></script>
+<script th:src="@{/js/coinflip.js}"></script>
+</body>
+</html>

--- a/web/src/main/resources/templates/fragments/navbar.html
+++ b/web/src/main/resources/templates/fragments/navbar.html
@@ -31,6 +31,7 @@
                     onclick="toggleDropdown(this)">Casino <span class="nav-dropdown-caret" aria-hidden="true">&#9662;</span></button>
             <div class="nav-dropdown-menu" role="menu">
                 <a href="/casino/guilds" role="menuitem">&#127920; Slots</a>
+                <a href="/casino/guilds" role="menuitem">&#129689; Coinflip</a>
             </div>
         </div>
         <a href="/intro/guilds">Intro Songs</a>

--- a/web/src/test/js/navbar.test.js
+++ b/web/src/test/js/navbar.test.js
@@ -69,13 +69,14 @@ describe('navbar fragment', () => {
         );
     });
 
-    test('Casino dropdown links to the Slots guild picker', () => {
+    test('Casino dropdown lists every minigame and points at the picker', () => {
         const casino = html.match(
             /<div class="nav-dropdown">[\s\S]*?Casino[\s\S]*?<\/div>\s*<\/div>/
         );
         expect(casino).not.toBeNull();
         expect(casino[0]).toMatch(/href="\/casino\/guilds"[^>]*>[^<]*Slots/);
-        // Coming-soon placeholder is gone now that Slots ships.
+        expect(casino[0]).toMatch(/href="\/casino\/guilds"[^>]*>[^<]*Coinflip/);
+        // Coming-soon placeholder is gone now that the games ship.
         expect(casino[0]).not.toMatch(/coming soon/i);
     });
 

--- a/web/src/test/kotlin/web/controller/CoinflipControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/CoinflipControllerTest.kt
@@ -1,0 +1,146 @@
+package web.controller
+
+import database.economy.Coinflip
+import database.service.CoinflipService
+import database.service.CoinflipService.FlipOutcome
+import database.service.UserService
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import net.dv8tion.jda.api.JDA
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.security.oauth2.core.user.OAuth2User
+import web.service.EconomyWebService
+
+class CoinflipControllerTest {
+
+    private val guildId = 42L
+    private val discordId = 100L
+
+    private lateinit var coinflipService: CoinflipService
+    private lateinit var economyWebService: EconomyWebService
+    private lateinit var userService: UserService
+    private lateinit var jda: JDA
+    private lateinit var user: OAuth2User
+    private lateinit var controller: CoinflipController
+
+    @BeforeEach
+    fun setup() {
+        coinflipService = mockk(relaxed = true)
+        economyWebService = mockk(relaxed = true)
+        userService = mockk(relaxed = true)
+        jda = mockk(relaxed = true)
+        user = mockk {
+            every { getAttribute<String>("id") } returns discordId.toString()
+            every { getAttribute<String>("username") } returns "tester"
+        }
+        every { economyWebService.isMember(discordId, guildId) } returns true
+        controller = CoinflipController(coinflipService, economyWebService, userService, jda)
+    }
+
+    @Test
+    fun `flip win returns 200 with win-shaped payload`() {
+        every { coinflipService.flip(discordId, guildId, 100L, Coinflip.Side.HEADS) } returns FlipOutcome.Win(
+            stake = 100L,
+            payout = 200L,
+            net = 100L,
+            landed = Coinflip.Side.HEADS,
+            predicted = Coinflip.Side.HEADS,
+            newBalance = 1_100L
+        )
+
+        val response = controller.flip(guildId, FlipRequest(side = "HEADS", stake = 100L), user)
+
+        assertTrue(response.statusCode.is2xxSuccessful)
+        val body = response.body!!
+        assertEquals(true, body.ok)
+        assertEquals(true, body.win)
+        assertEquals(100L, body.net)
+        assertEquals(200L, body.payout)
+        assertEquals(1_100L, body.newBalance)
+        assertEquals("HEADS", body.landed)
+        assertEquals("HEADS", body.predicted)
+    }
+
+    @Test
+    fun `flip lose returns 200 with negative net and win=false`() {
+        every { coinflipService.flip(discordId, guildId, 50L, Coinflip.Side.TAILS) } returns FlipOutcome.Lose(
+            stake = 50L,
+            landed = Coinflip.Side.HEADS,
+            predicted = Coinflip.Side.TAILS,
+            newBalance = 950L
+        )
+
+        val response = controller.flip(guildId, FlipRequest(side = "TAILS", stake = 50L), user)
+
+        assertTrue(response.statusCode.is2xxSuccessful)
+        val body = response.body!!
+        assertEquals(true, body.ok)
+        assertEquals(false, body.win)
+        assertEquals(-50L, body.net)
+        assertEquals(950L, body.newBalance)
+        assertEquals("HEADS", body.landed)
+        assertEquals("TAILS", body.predicted)
+    }
+
+    @Test
+    fun `flip is case-insensitive on the side parameter`() {
+        every { coinflipService.flip(discordId, guildId, 10L, Coinflip.Side.TAILS) } returns FlipOutcome.Lose(
+            stake = 10L,
+            landed = Coinflip.Side.HEADS,
+            predicted = Coinflip.Side.TAILS,
+            newBalance = 990L
+        )
+
+        val response = controller.flip(guildId, FlipRequest(side = "tails", stake = 10L), user)
+
+        assertTrue(response.statusCode.is2xxSuccessful)
+        verify(exactly = 1) { coinflipService.flip(discordId, guildId, 10L, Coinflip.Side.TAILS) }
+    }
+
+    @Test
+    fun `flip rejects unknown side with 400`() {
+        val response = controller.flip(guildId, FlipRequest(side = "edge", stake = 10L), user)
+
+        assertEquals(400, response.statusCode.value())
+        assertEquals(false, response.body?.ok)
+        verify(exactly = 0) { coinflipService.flip(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `flip returns 400 on insufficient credits`() {
+        every { coinflipService.flip(discordId, guildId, 100L, Coinflip.Side.HEADS) } returns
+            FlipOutcome.InsufficientCredits(stake = 100L, have = 30L)
+
+        val response = controller.flip(guildId, FlipRequest(side = "HEADS", stake = 100L), user)
+
+        assertEquals(400, response.statusCode.value())
+        assertTrue(response.body?.error!!.contains("100"))
+        assertTrue(response.body?.error!!.contains("30"))
+    }
+
+    @Test
+    fun `flip returns 400 on invalid stake`() {
+        every { coinflipService.flip(discordId, guildId, 5L, Coinflip.Side.HEADS) } returns
+            FlipOutcome.InvalidStake(min = 10L, max = 1_000L)
+
+        val response = controller.flip(guildId, FlipRequest(side = "HEADS", stake = 5L), user)
+
+        assertEquals(400, response.statusCode.value())
+        assertTrue(response.body?.error!!.contains("10"))
+        assertTrue(response.body?.error!!.contains("1000"))
+    }
+
+    @Test
+    fun `flip rejects with 403 when user is not a member of the guild`() {
+        every { economyWebService.isMember(discordId, guildId) } returns false
+
+        val response = controller.flip(guildId, FlipRequest(side = "HEADS", stake = 100L), user)
+
+        assertEquals(403, response.statusCode.value())
+        verify(exactly = 0) { coinflipService.flip(any(), any(), any(), any()) }
+    }
+}


### PR DESCRIPTION
## Summary

Second gambling minigame after [#295 (`/slots`)](https://github.com/ml404/toby-bot/pull/295). **`/coinflip side:<HEADS|TAILS> stake:<int>`** ships on Discord and the web — same shared-service architecture as Slots so the two surfaces can't drift.

## Mechanic + design choice

- Fair 50/50, 2× payout on match
- **No house edge by design** — `/coinflip` is the "double or nothing" risk pivot. `/slots` (~11% house edge) remains the actual credit sink, so a fair `/coinflip` doesn't break the economy.
- Bet bounds 10–1000 credits (higher than `/slots`'s 10–500 since the max payout is just 2×, so 1000 → 2000 credits is a meaningful all-in without being server-breaking).

If you'd rather have a small house edge here too (e.g. 1.95× payout on win → ~2.5% rake), say the word and I'll bump it as a follow-up.

## Architecture

Same shape as `/slots`. Two examples is barely enough to spot the right abstraction, so I deliberately did **not** extract a shared base service yet — the third minigame (`/dice` or `/lottery`) will tell us whether the right seam lives at the pure-logic layer (`SlotMachine`/`Coinflip`/`Dice`) or the `WagerService` level.

| Layer | File |
|---|---|
| Pure logic | `database/economy/Coinflip.kt` |
| Service | `database/service/CoinflipService.kt` |
| Discord | `bot/toby/command/commands/economy/CoinflipCommand.kt` |
| Web | `web/controller/CoinflipController.kt` |
| Web UI | `coinflip.html` + `coinflip.js` + `coinflip.css` |

## Casino integration

- **Navbar dropdown** now lists both 🎰 Slots and 🪙 Coinflip.
- **Casino guild picker** (`/casino/guilds`) now renders two game buttons per guild card instead of being a one-click jump to Slots. New `.lb-guild-card-static` rule suppresses the whole-card hover lift (which would be a misleading affordance for a card with internal action buttons).

## Tests

- `CoinflipTest` — predicted side preserved; match → configured multiplier; mismatch → 0; RTP within ±5pp of 1.0 across 200k flips
- `CoinflipServiceTest` — atomic balance maths; insufficient/invalid stake short-circuits; null `socialCredit` paths
- `CoinflipCommandTest` — delegates with parsed side+stake; every `FlipOutcome` variant produces an embed; missing / unknown side short-circuits
- `CoinflipControllerTest` — every `FlipOutcome` maps to the right HTTP status; case-insensitive side parsing; 403 for non-members
- `CommandManagerTest` — count bumped 47 → 48
- `navbar.test.js` — Casino dropdown asserts both entries
- All locally green: `:database:test`, `:web:test`, `npm test` (85 JS tests).

## Test plan

- [ ] CI green
- [ ] Manual Discord: `/coinflip side:Heads stake:10` repeatedly — matches roughly 50%; `/coinflip side:Heads stake:5` rejected by JDA min/max; insufficient balance → friendly error
- [ ] Manual web: nav Casino ▾ → click either entry → guild picker → click Coinflip on a guild card → page loads; pick a side, set a stake, click Flip → coin animates 800ms then reveals; balance updates
- [ ] Both surfaces against the same user → balances stay in sync

---
_Generated by [Claude Code](https://claude.ai/code/session_01JvuveFBoCvMFTK8XxXVN56)_