### PR TITLE
fix(web): leaderboard renders negative this-month credit deltas

### DIFF
--- a/web/src/main/resources/templates/leaderboard.html
+++ b/web/src/main/resources/templates/leaderboard.html
@@ -66,7 +66,8 @@
                   class="lb-title-pill"
                   th:text="${view.podium[1].title}">Title</span>
             <div class="lb-podium-credits">
-                <strong th:if="${isMonth}" th:text="'+' + ${view.podium[1].creditsEarnedThisMonth}">+0</strong>
+                <strong th:if="${isMonth}"
+                        th:text="|${view.podium[1].creditsEarnedThisMonth >= 0 ? '+' : ''}${view.podium[1].creditsEarnedThisMonth}|">+0</strong>
                 <strong th:unless="${isMonth}" th:text="${view.podium[1].socialCredit}">0</strong>
                 <span th:text="${isMonth ? 'this month' : 'credits'}">credits</span>
             </div>
@@ -74,8 +75,8 @@
                  th:if="${isMonth}"
                  th:text="${view.podium[1].socialCredit} + ' total'">0 total</div>
             <div class="lb-podium-month"
-                 th:if="${!isMonth and view.podium[1].creditsEarnedThisMonth > 0}"
-                 th:text="'+' + ${view.podium[1].creditsEarnedThisMonth} + ' this month'">+0 this month</div>
+                 th:if="${!isMonth and view.podium[1].creditsEarnedThisMonth != 0}"
+                 th:text="|${view.podium[1].creditsEarnedThisMonth > 0 ? '+' : ''}${view.podium[1].creditsEarnedThisMonth} this month|">+0 this month</div>
             <div class="lb-podium-voice" th:text="${view.podium[1].voiceThisMonthDisplay} + ' voice'">0m voice</div>
         </div>
 
@@ -91,7 +92,8 @@
                   class="lb-title-pill"
                   th:text="${view.podium[0].title}">Title</span>
             <div class="lb-podium-credits">
-                <strong th:if="${isMonth}" th:text="'+' + ${view.podium[0].creditsEarnedThisMonth}">+0</strong>
+                <strong th:if="${isMonth}"
+                        th:text="|${view.podium[0].creditsEarnedThisMonth >= 0 ? '+' : ''}${view.podium[0].creditsEarnedThisMonth}|">+0</strong>
                 <strong th:unless="${isMonth}" th:text="${view.podium[0].socialCredit}">0</strong>
                 <span th:text="${isMonth ? 'this month' : 'credits'}">credits</span>
             </div>
@@ -99,8 +101,8 @@
                  th:if="${isMonth}"
                  th:text="${view.podium[0].socialCredit} + ' total'">0 total</div>
             <div class="lb-podium-month"
-                 th:if="${!isMonth and view.podium[0].creditsEarnedThisMonth > 0}"
-                 th:text="'+' + ${view.podium[0].creditsEarnedThisMonth} + ' this month'">+0 this month</div>
+                 th:if="${!isMonth and view.podium[0].creditsEarnedThisMonth != 0}"
+                 th:text="|${view.podium[0].creditsEarnedThisMonth > 0 ? '+' : ''}${view.podium[0].creditsEarnedThisMonth} this month|">+0 this month</div>
             <div class="lb-podium-voice" th:text="${view.podium[0].voiceThisMonthDisplay} + ' voice'">0m voice</div>
         </div>
 
@@ -116,7 +118,8 @@
                   class="lb-title-pill"
                   th:text="${view.podium[2].title}">Title</span>
             <div class="lb-podium-credits">
-                <strong th:if="${isMonth}" th:text="'+' + ${view.podium[2].creditsEarnedThisMonth}">+0</strong>
+                <strong th:if="${isMonth}"
+                        th:text="|${view.podium[2].creditsEarnedThisMonth >= 0 ? '+' : ''}${view.podium[2].creditsEarnedThisMonth}|">+0</strong>
                 <strong th:unless="${isMonth}" th:text="${view.podium[2].socialCredit}">0</strong>
                 <span th:text="${isMonth ? 'this month' : 'credits'}">credits</span>
             </div>
@@ -124,8 +127,8 @@
                  th:if="${isMonth}"
                  th:text="${view.podium[2].socialCredit} + ' total'">0 total</div>
             <div class="lb-podium-month"
-                 th:if="${!isMonth and view.podium[2].creditsEarnedThisMonth > 0}"
-                 th:text="'+' + ${view.podium[2].creditsEarnedThisMonth} + ' this month'">+0 this month</div>
+                 th:if="${!isMonth and view.podium[2].creditsEarnedThisMonth != 0}"
+                 th:text="|${view.podium[2].creditsEarnedThisMonth > 0 ? '+' : ''}${view.podium[2].creditsEarnedThisMonth} this month|">+0 this month</div>
             <div class="lb-podium-voice" th:text="${view.podium[2].voiceThisMonthDisplay} + ' voice'">0m voice</div>
         </div>
     </section>
@@ -185,7 +188,10 @@
                             <span th:if="${row.creditsEarnedThisMonth > 0}"
                                   class="lb-value-month"
                                   th:text="'+' + ${row.creditsEarnedThisMonth}">+0</span>
-                            <span th:unless="${row.creditsEarnedThisMonth > 0}" class="muted">—</span>
+                            <span th:if="${row.creditsEarnedThisMonth &lt; 0}"
+                                  class="lb-value-month-down"
+                                  th:text="${row.creditsEarnedThisMonth}">-0</span>
+                            <span th:if="${row.creditsEarnedThisMonth == 0}" class="muted">—</span>
                         </td>
                         <td data-label="Voice" th:text="${row.voiceThisMonthDisplay}">0m</td>
                     </tr>


### PR DESCRIPTION
## Summary

The leaderboard's "This month" column hid anything ≤ 0 behind a muted "—". With gambling losses (`/slots`, `/coinflip`) and market sells now in the mix, the monthly delta routinely goes negative — silently rendering those as "—" wasn't honest about what's happening to a user's wallet.

Now mirrors the existing TobyCoin `coinsThisMonth` pattern that's been there since #279:

| value | rendering |
|---|---|
| **positive** | `+N` in green (`.lb-value-month`) |
| **negative** | `-N` in red (`.lb-value-month-down`) |
| zero | `—` muted |

Both CSS classes already existed (used by the TobyCoin column today), so this is templates-only — no CSS work, no service-layer change.

## Podium

- **Primary value (THIS_MONTH sort):** was always prefixed `"+"` → would render `+−50` for losses. Now `${expr >= 0 ? '+' : ''}${expr}` so positives keep the explicit `+` sign and negatives carry their own `-`.
- **Subtitle (LIFETIME sort):** was hidden entirely when `≤ 0`. Now renders for any non-zero with the right sign.

## What stays

- THIS_MONTH `sortedByDescending` — negatives naturally fall to the bottom; the top still surfaces the biggest earner.
- Home guild-picker "Top this month" `> 0` filter — a card claiming a "Top earner" with `-50` would be misleading.

## Test plan

- [ ] CI green (template-only diff; no service or test changes needed)
- [ ] Manual: a user with a net negative month (after gambling/market losses) shows up in the standings with `-N` in red instead of `—`.
- [ ] Manual: the podium subtitle on the LIFETIME sort tab shows `-N this month` for a user with negative deltas; positive deltas still show `+N this month`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JvuveFBoCvMFTK8XxXVN56)_