### PR TITLE
fix(activity): re-enable CacheFlag.ACTIVITY so game sessions record

### DIFF
--- a/discord-bot/src/main/kotlin/bot/configuration/BotConfig.kt
+++ b/discord-bot/src/main/kotlin/bot/configuration/BotConfig.kt
@@ -49,7 +49,6 @@ class BotConfig {
             .disableCache(
                 EnumSet.of(
                     CacheFlag.CLIENT_STATUS,
-                    CacheFlag.ACTIVITY,
                     CacheFlag.SCHEDULED_EVENTS
                 )
             )


### PR DESCRIPTION
## Summary

The opt-in game-activity tracking feature (PR #268) has been silently broken since it shipped. `ActivityEventHandler.onUserUpdateActivities` listens for `UserUpdateActivitiesEvent`, but **JDA only fires that event when `CacheFlag.ACTIVITY` is enabled** — without it, `Member.getActivities()` returns empty and the change-detection logic never runs. The handler exists, the listener is registered (`JdaListenerRegistrar:22`), the service writes rows correctly — but the gateway side never delivers the event.

User-visible symptom (the report): "I played Slay the Spire for an hour and nothing got recorded." Correct — nothing was. Same for every other game on every guild that opted into tracking.

## Fix

One line: drop `CacheFlag.ACTIVITY` from the `disableCache` list. `GUILD_PRESENCES` intent was already requested.

`CacheFlag.CLIENT_STATUS` (online/idle/dnd) and `CacheFlag.SCHEDULED_EVENTS` stay disabled — those genuinely aren't used anywhere.

## Memory cost

Each cached `Member` now also holds their current `Activity` list (~100–300 bytes per active gamer). With `MemberCachePolicy.ALL` that's a few MB across all guilds — dwarfed by the existing member cache.

## Test plan

- [ ] CI green (no test changes needed; this is a JDA gateway-config flip)
- [ ] After deploy: open a game (Slay the Spire, anything `Activity.ActivityType.PLAYING`) for >60s in a guild with `ACTIVITY_TRACKING=true`. Then `/activity me` — the game should appear with logged seconds.
- [ ] Confirm the bot logs contain a `Activity change for <id> in <guild>: 'null' -> 'Slay the Spire'` line at the start of the session and `'Slay the Spire' -> 'null'` at the end.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JvuveFBoCvMFTK8XxXVN56)_