### PR TITLE
feat: /dice minigame — Discord command + web UI

### DIFF
--- a/application/src/test/kotlin/integration/bot/CommandManagerTest.kt
+++ b/application/src/test/kotlin/integration/bot/CommandManagerTest.kt
@@ -10,6 +10,7 @@ import bot.toby.command.commands.dnd.LinkCharacterCommand
 import bot.toby.command.commands.dnd.RefreshCharacterCommand
 import bot.toby.command.commands.dnd.RollCommand
 import bot.toby.command.commands.economy.CoinflipCommand
+import bot.toby.command.commands.economy.DiceCommand
 import bot.toby.command.commands.economy.SlotsCommand
 import bot.toby.command.commands.economy.TitleCommand
 import bot.toby.command.commands.economy.TobyCoinCommand
@@ -132,12 +133,13 @@ class CommandManagerTest {
             TobyCoinCommand::class.java,
             SlotsCommand::class.java,
             CoinflipCommand::class.java,
+            DiceCommand::class.java,
             ActivityCommand::class.java
         )
 
         Assertions.assertTrue(availableCommands.containsAll(commandManager.allCommands.map { it.javaClass }.toList()))
-        Assertions.assertEquals(48, commandManager.allCommands.size)
-        Assertions.assertEquals(48, commandManager.allSlashCommands.size)
+        Assertions.assertEquals(49, commandManager.allCommands.size)
+        Assertions.assertEquals(49, commandManager.allSlashCommands.size)
     }
 
     @Test

--- a/database/src/main/kotlin/database/economy/Dice.kt
+++ b/database/src/main/kotlin/database/economy/Dice.kt
@@ -1,0 +1,47 @@
+package database.economy
+
+import kotlin.random.Random
+
+/**
+ * Pure-logic 6-sided dice. No Spring, no DB, no JDA — just a uniform
+ * draw 1..sides and a comparison against the caller's prediction.
+ *
+ * Mechanic
+ *   User picks a number 1..6, rolls a die. Match → `multiplier × stake`
+ *   payout. True odds of a hit are 1/6 ≈ 0.1667; with a 5× payout,
+ *   RTP = 5/6 ≈ 0.833 (~17% house edge). Sits between `/coinflip`
+ *   (no edge) and `/slots` (~11% edge) on the risk/sink scale.
+ *
+ * Stake bounds (`MIN_STAKE` / `MAX_STAKE`) live here so the Discord
+ * command, the web controller, and the service all agree on what's
+ * valid.
+ */
+class Dice(
+    private val sides: Int = DEFAULT_SIDES,
+    private val multiplier: Long = DEFAULT_MULTIPLIER
+) {
+
+    data class Roll(val landed: Int, val predicted: Int, val multiplier: Long) {
+        val isWin: Boolean get() = landed == predicted
+    }
+
+    fun roll(predicted: Int, random: Random): Roll {
+        val landed = random.nextInt(1, sides + 1)
+        return Roll(
+            landed = landed,
+            predicted = predicted,
+            multiplier = if (landed == predicted) multiplier else 0L
+        )
+    }
+
+    fun isValidPrediction(predicted: Int): Boolean = predicted in 1..sides
+    val sidesCount: Int get() = sides
+
+    companion object {
+        const val MIN_STAKE: Long = 10L
+        const val MAX_STAKE: Long = 500L
+        const val DEFAULT_SIDES: Int = 6
+        // 5× on hit; with 1/6 true odds the RTP is 5/6 ≈ 0.833 (~17% edge).
+        const val DEFAULT_MULTIPLIER: Long = 5L
+    }
+}

--- a/database/src/main/kotlin/database/service/DiceService.kt
+++ b/database/src/main/kotlin/database/service/DiceService.kt
@@ -1,0 +1,82 @@
+package database.service
+
+import database.economy.Dice
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import kotlin.random.Random
+
+/**
+ * Atomic roll path for the `/dice` minigame. Same lock-then-mutate
+ * pattern as [SlotsService] / [CoinflipService] via
+ * [UserService.getUserByIdForUpdate] so concurrent rolls from the same
+ * user (Discord + web at once, or spam-clicking) can't double-spend.
+ */
+@Service
+@Transactional
+class DiceService(
+    private val userService: UserService,
+    private val dice: Dice = Dice(),
+    private val random: Random = Random.Default
+) {
+
+    sealed interface RollOutcome {
+        data class Win(
+            val stake: Long,
+            val payout: Long,
+            val net: Long,
+            val landed: Int,
+            val predicted: Int,
+            val newBalance: Long
+        ) : RollOutcome
+
+        data class Lose(
+            val stake: Long,
+            val landed: Int,
+            val predicted: Int,
+            val newBalance: Long
+        ) : RollOutcome
+
+        data class InsufficientCredits(val stake: Long, val have: Long) : RollOutcome
+        data class InvalidStake(val min: Long, val max: Long) : RollOutcome
+        data class InvalidPrediction(val min: Int, val max: Int) : RollOutcome
+        data object UnknownUser : RollOutcome
+    }
+
+    fun roll(discordId: Long, guildId: Long, stake: Long, predicted: Int): RollOutcome {
+        if (stake < Dice.MIN_STAKE || stake > Dice.MAX_STAKE) {
+            return RollOutcome.InvalidStake(Dice.MIN_STAKE, Dice.MAX_STAKE)
+        }
+        if (!dice.isValidPrediction(predicted)) {
+            return RollOutcome.InvalidPrediction(1, dice.sidesCount)
+        }
+        val user = userService.getUserByIdForUpdate(discordId, guildId)
+            ?: return RollOutcome.UnknownUser
+        val balance = user.socialCredit ?: 0L
+        if (balance < stake) return RollOutcome.InsufficientCredits(stake, balance)
+
+        val roll = dice.roll(predicted, random)
+        val payout = roll.multiplier * stake
+        val net = payout - stake
+        user.socialCredit = balance + net
+        userService.updateUser(user)
+        val newBalance = user.socialCredit ?: 0L
+
+        return if (roll.isWin) {
+            RollOutcome.Win(
+                stake = stake,
+                payout = payout,
+                net = net,
+                landed = roll.landed,
+                predicted = roll.predicted,
+                newBalance = newBalance
+            )
+        } else {
+            RollOutcome.Lose(
+                stake = stake,
+                landed = roll.landed,
+                predicted = roll.predicted,
+                newBalance = newBalance
+            )
+        }
+    }
+}

--- a/database/src/test/kotlin/database/economy/DiceTest.kt
+++ b/database/src/test/kotlin/database/economy/DiceTest.kt
@@ -1,0 +1,77 @@
+package database.economy
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import kotlin.random.Random
+
+class DiceTest {
+
+    @Test
+    fun `roll lands within 1 to sides`() {
+        val dice = Dice()
+        val rng = Random(42)
+        repeat(1_000) {
+            val roll = dice.roll(predicted = 1, random = rng)
+            assertTrue(roll.landed in 1..dice.sidesCount, "landed=${roll.landed}")
+            assertTrue(roll.multiplier >= 0L)
+        }
+    }
+
+    @Test
+    fun `match yields configured multiplier`() {
+        val dice = Dice(sides = 6, multiplier = 5L)
+        // Find a seed where the next int is e.g. 4, then predict 4.
+        val rng = Random(7)
+        val landed = rng.nextInt(1, 7)
+        val roll = dice.roll(predicted = landed, random = Random(7))
+        assertTrue(roll.isWin)
+        assertEquals(5L, roll.multiplier)
+        assertEquals(landed, roll.landed)
+        assertEquals(landed, roll.predicted)
+    }
+
+    @Test
+    fun `mismatch yields zero multiplier`() {
+        val dice = Dice(sides = 6, multiplier = 5L)
+        val rng = Random(7)
+        val landed = rng.nextInt(1, 7)
+        // Predict something different from landed
+        val opposite = if (landed == 1) 2 else 1
+        val roll = dice.roll(predicted = opposite, random = Random(7))
+        assertFalse(roll.isWin)
+        assertEquals(0L, roll.multiplier)
+    }
+
+    @Test
+    fun `isValidPrediction enforces 1 to sides`() {
+        val dice = Dice(sides = 6)
+        assertFalse(dice.isValidPrediction(0))
+        assertTrue(dice.isValidPrediction(1))
+        assertTrue(dice.isValidPrediction(6))
+        assertFalse(dice.isValidPrediction(7))
+        assertFalse(dice.isValidPrediction(-1))
+    }
+
+    @Test
+    fun `RTP across 200k rolls is within 5pp of 5 over 6`() {
+        // 5× payout at 1/6 odds → expected RTP = 5/6 ≈ 0.833. ±5pp floor
+        // is forgiving; n=200k 95% CI is much tighter.
+        val dice = Dice(sides = 6, multiplier = 5L)
+        val rng = Random(2026)
+        val stake = 1_000L
+        val n = 200_000
+        var totalWagered = 0L
+        var totalReturned = 0L
+        repeat(n) {
+            val predicted = rng.nextInt(1, 7)
+            val roll = dice.roll(predicted, rng)
+            totalWagered += stake
+            totalReturned += roll.multiplier * stake
+        }
+        val rtp = totalReturned.toDouble() / totalWagered.toDouble()
+        val expected = 5.0 / 6.0
+        assertTrue(rtp in (expected - 0.05)..(expected + 0.05), "expected RTP near $expected (±0.05) but saw $rtp")
+    }
+}

--- a/database/src/test/kotlin/database/service/DiceServiceTest.kt
+++ b/database/src/test/kotlin/database/service/DiceServiceTest.kt
@@ -1,0 +1,113 @@
+package database.service
+
+import database.dto.UserDto
+import database.economy.Dice
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import kotlin.random.Random
+
+class DiceServiceTest {
+
+    private lateinit var userService: UserService
+    private lateinit var dice: Dice
+    private lateinit var service: DiceService
+
+    private val discordId = 100L
+    private val guildId = 200L
+
+    @BeforeEach
+    fun setup() {
+        userService = mockk(relaxed = true)
+        dice = mockk(relaxed = true) {
+            every { isValidPrediction(any()) } answers { firstArg<Int>() in 1..6 }
+            every { sidesCount } returns 6
+        }
+        service = DiceService(userService, dice, Random(0))
+    }
+
+    private fun userWithBalance(balance: Long): UserDto {
+        return UserDto(discordId, guildId).apply { socialCredit = balance }
+    }
+
+    @Test
+    fun `win debits stake and credits payout atomically`() {
+        val user = userWithBalance(1_000L)
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns user
+        every { dice.roll(4, any()) } returns Dice.Roll(landed = 4, predicted = 4, multiplier = 5L)
+        val captured = slot<UserDto>()
+        every { userService.updateUser(capture(captured)) } returns user
+
+        val outcome = service.roll(discordId, guildId, stake = 100L, predicted = 4)
+
+        val win = assertInstanceOf(DiceService.RollOutcome.Win::class.java, outcome)
+        assertEquals(100L, win.stake)
+        assertEquals(500L, win.payout)
+        assertEquals(400L, win.net, "net = payout (500) - stake (100)")
+        assertEquals(1_400L, win.newBalance)
+        assertEquals(4, win.landed)
+        assertEquals(4, win.predicted)
+        assertEquals(1_400L, captured.captured.socialCredit)
+    }
+
+    @Test
+    fun `loss debits stake only`() {
+        val user = userWithBalance(500L)
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns user
+        every { dice.roll(3, any()) } returns Dice.Roll(landed = 5, predicted = 3, multiplier = 0L)
+        every { userService.updateUser(any()) } returns user
+
+        val outcome = service.roll(discordId, guildId, stake = 100L, predicted = 3)
+
+        val lose = assertInstanceOf(DiceService.RollOutcome.Lose::class.java, outcome)
+        assertEquals(100L, lose.stake)
+        assertEquals(400L, lose.newBalance)
+        assertEquals(5, lose.landed)
+        assertEquals(3, lose.predicted)
+    }
+
+    @Test
+    fun `insufficient credits is rejected without mutating balance`() {
+        val user = userWithBalance(50L)
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns user
+
+        val outcome = service.roll(discordId, guildId, stake = 100L, predicted = 3)
+
+        val rej = assertInstanceOf(DiceService.RollOutcome.InsufficientCredits::class.java, outcome)
+        assertEquals(50L, rej.have)
+        verify(exactly = 0) { userService.updateUser(any()) }
+    }
+
+    @Test
+    fun `stake below MIN_STAKE is rejected before locking the user`() {
+        val outcome = service.roll(discordId, guildId, stake = Dice.MIN_STAKE - 1, predicted = 3)
+
+        assertInstanceOf(DiceService.RollOutcome.InvalidStake::class.java, outcome)
+        verify(exactly = 0) { userService.getUserByIdForUpdate(any(), any()) }
+    }
+
+    @Test
+    fun `prediction outside 1 to 6 is rejected before locking the user`() {
+        val outcome = service.roll(discordId, guildId, stake = 100L, predicted = 7)
+
+        val rej = assertInstanceOf(DiceService.RollOutcome.InvalidPrediction::class.java, outcome)
+        assertEquals(1, rej.min)
+        assertEquals(6, rej.max)
+        verify(exactly = 0) { userService.getUserByIdForUpdate(any(), any()) }
+    }
+
+    @Test
+    fun `unknown user is rejected`() {
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns null
+
+        val outcome = service.roll(discordId, guildId, stake = 100L, predicted = 3)
+
+        assertEquals(DiceService.RollOutcome.UnknownUser, outcome)
+        verify(exactly = 0) { userService.updateUser(any()) }
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/DiceCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/DiceCommand.kt
@@ -1,0 +1,127 @@
+package bot.toby.command.commands.economy
+
+import core.command.Command.Companion.invokeDeleteOnMessageResponse
+import core.command.CommandContext
+import database.dto.UserDto
+import database.economy.Dice
+import database.service.DiceService
+import database.service.DiceService.RollOutcome
+import net.dv8tion.jda.api.EmbedBuilder
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
+import net.dv8tion.jda.api.interactions.commands.OptionType
+import net.dv8tion.jda.api.interactions.commands.build.OptionData
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+import java.awt.Color
+
+/**
+ * `/dice prediction:<1-6> stake:<int>` — pick a number, roll the die,
+ * 5× payout on a hit (1/6 odds, ~17% house edge). Calls through to
+ * [DiceService.roll]; same path the web `/casino/{guildId}/dice` page
+ * uses.
+ */
+@Component
+class DiceCommand @Autowired constructor(
+    private val diceService: DiceService
+) : EconomyCommand {
+
+    override val name: String = "dice"
+    override val description: String =
+        "Pick a number 1-6, roll a die. Bet ${Dice.MIN_STAKE}-${Dice.MAX_STAKE} credits."
+
+    companion object {
+        private const val OPT_PREDICTION = "prediction"
+        private const val OPT_STAKE = "stake"
+        private val WIN_COLOR = Color(87, 242, 135)
+        private val LOSE_COLOR = Color(160, 160, 176)
+        private val ERROR_COLOR = Color(237, 66, 69)
+        private val DICE_FACES = mapOf(
+            1 to "⚀", 2 to "⚁", 3 to "⚂", 4 to "⚃", 5 to "⚄", 6 to "⚅"
+        )
+    }
+
+    override val optionData: List<OptionData> = listOf(
+        OptionData(OptionType.INTEGER, OPT_PREDICTION, "Number to predict (1-6)", true)
+            .setMinValue(1L)
+            .setMaxValue(Dice.DEFAULT_SIDES.toLong()),
+        OptionData(OptionType.INTEGER, OPT_STAKE, "Credits to wager (10-500)", true)
+            .setMinValue(Dice.MIN_STAKE)
+            .setMaxValue(Dice.MAX_STAKE)
+    )
+
+    override fun handle(ctx: CommandContext, requestingUserDto: UserDto, deleteDelay: Int) {
+        val event = ctx.event
+        event.deferReply().queue()
+
+        val guild = event.guild ?: run {
+            replyError(event, "This command can only be used in a server.", deleteDelay); return
+        }
+        val predicted = event.getOption(OPT_PREDICTION)?.asLong?.toInt() ?: run {
+            replyError(event, "Pick a number 1-6.", deleteDelay); return
+        }
+        val stake = event.getOption(OPT_STAKE)?.asLong ?: run {
+            replyError(event, "You must specify a stake.", deleteDelay); return
+        }
+
+        val outcome = diceService.roll(requestingUserDto.discordId, guild.idLong, stake, predicted)
+        replyOutcome(event, outcome, deleteDelay)
+    }
+
+    private fun face(n: Int): String = DICE_FACES[n] ?: n.toString()
+
+    private fun replyOutcome(
+        event: SlashCommandInteractionEvent,
+        outcome: RollOutcome,
+        deleteDelay: Int
+    ) {
+        val embed = when (outcome) {
+            is RollOutcome.Win -> EmbedBuilder()
+                .setTitle("🎲 ${face(outcome.landed)} (${outcome.landed})")
+                .setDescription("You called **${outcome.predicted}** and won **+${outcome.net} credits** (${outcome.multiplier()}× on a ${outcome.stake} stake).")
+                .addField("New balance", "${outcome.newBalance} credits", true)
+                .setColor(WIN_COLOR)
+                .build()
+
+            is RollOutcome.Lose -> EmbedBuilder()
+                .setTitle("🎲 ${face(outcome.landed)} (${outcome.landed})")
+                .setDescription("You called **${outcome.predicted}**. Lost **${outcome.stake} credits**.")
+                .addField("New balance", "${outcome.newBalance} credits", true)
+                .setColor(LOSE_COLOR)
+                .build()
+
+            is RollOutcome.InsufficientCredits -> errorEmbed(
+                "Not enough credits. You need ${outcome.stake} but only have ${outcome.have}."
+            )
+
+            is RollOutcome.InvalidStake -> errorEmbed(
+                "Stake must be between ${outcome.min} and ${outcome.max} credits."
+            )
+
+            is RollOutcome.InvalidPrediction -> errorEmbed(
+                "Pick a number between ${outcome.min} and ${outcome.max}."
+            )
+
+            RollOutcome.UnknownUser -> errorEmbed(
+                "No user record yet. Try another TobyBot command first."
+            )
+        }
+        event.hook.sendMessageEmbeds(embed).queue(invokeDeleteOnMessageResponse(deleteDelay))
+    }
+
+    // payout / stake = multiplier — derived for the "5× on" string in the win embed.
+    private fun RollOutcome.Win.multiplier(): Long = if (stake > 0L) payout / stake else 0L
+
+    private fun errorEmbed(message: String) = EmbedBuilder()
+        .setTitle("🎲 Dice")
+        .setDescription(message)
+        .setColor(ERROR_COLOR)
+        .build()
+
+    private fun replyError(
+        event: SlashCommandInteractionEvent,
+        message: String,
+        deleteDelay: Int
+    ) {
+        event.hook.sendMessageEmbeds(errorEmbed(message)).queue(invokeDeleteOnMessageResponse(deleteDelay))
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/economy/DiceCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/economy/DiceCommandTest.kt
@@ -1,0 +1,93 @@
+package bot.toby.command.commands.economy
+
+import bot.toby.command.CommandTest
+import bot.toby.command.CommandTest.Companion.event
+import bot.toby.command.CommandTest.Companion.guild
+import bot.toby.command.DefaultCommandContext
+import database.dto.UserDto
+import database.service.DiceService
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import net.dv8tion.jda.api.interactions.commands.OptionMapping
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class DiceCommandTest : CommandTest {
+    private lateinit var diceService: DiceService
+    private lateinit var command: DiceCommand
+
+    private val discordId = 1L
+    private val guildId = 42L
+
+    @BeforeEach
+    fun setUp() {
+        setUpCommonMocks()
+        diceService = mockk(relaxed = true)
+        command = DiceCommand(diceService)
+        every { guild.idLong } returns guildId
+    }
+
+    @AfterEach
+    fun tearDown() {
+        tearDownCommonMocks()
+        clearAllMocks()
+    }
+
+    private fun intOpt(value: Long): OptionMapping {
+        val o = mockk<OptionMapping>(relaxed = true)
+        every { o.asLong } returns value
+        return o
+    }
+
+    @Test
+    fun `delegates to DiceService with prediction and stake`() {
+        val user = UserDto(discordId = discordId, guildId = guildId)
+        every { event.getOption("prediction") } returns intOpt(3L)
+        every { event.getOption("stake") } returns intOpt(50L)
+        every { diceService.roll(discordId, guildId, 50L, 3) } returns DiceService.RollOutcome.Lose(
+            stake = 50L, landed = 5, predicted = 3, newBalance = 950L
+        )
+
+        command.handle(DefaultCommandContext(event), user, 5)
+
+        verify(exactly = 1) { diceService.roll(discordId, guildId, 50L, 3) }
+    }
+
+    @Test
+    fun `replies with embed on each outcome variant`() {
+        val user = UserDto(discordId = discordId, guildId = guildId)
+        every { event.getOption("prediction") } returns intOpt(4L)
+        every { event.getOption("stake") } returns intOpt(100L)
+
+        val outcomes = listOf(
+            DiceService.RollOutcome.Win(stake = 100L, payout = 500L, net = 400L, landed = 4, predicted = 4, newBalance = 1_400L),
+            DiceService.RollOutcome.Lose(stake = 100L, landed = 1, predicted = 4, newBalance = 900L),
+            DiceService.RollOutcome.InsufficientCredits(stake = 100L, have = 50L),
+            DiceService.RollOutcome.InvalidStake(min = 10L, max = 500L),
+            DiceService.RollOutcome.InvalidPrediction(min = 1, max = 6),
+            DiceService.RollOutcome.UnknownUser
+        )
+        outcomes.forEach { outcome ->
+            every { diceService.roll(any(), any(), any(), any()) } returns outcome
+            command.handle(DefaultCommandContext(event), user, 5)
+        }
+
+        verify(atLeast = outcomes.size) {
+            event.hook.sendMessageEmbeds(any<net.dv8tion.jda.api.entities.MessageEmbed>())
+        }
+    }
+
+    @Test
+    fun `missing prediction option short-circuits`() {
+        val user = UserDto(discordId = discordId, guildId = guildId)
+        every { event.getOption("prediction") } returns null
+        every { event.getOption("stake") } returns intOpt(100L)
+
+        command.handle(DefaultCommandContext(event), user, 5)
+
+        verify(exactly = 0) { diceService.roll(any(), any(), any(), any()) }
+    }
+}

--- a/web/src/main/kotlin/web/controller/DiceController.kt
+++ b/web/src/main/kotlin/web/controller/DiceController.kt
@@ -1,0 +1,139 @@
+package web.controller
+
+import database.economy.Dice
+import database.service.DiceService
+import database.service.DiceService.RollOutcome
+import database.service.UserService
+import net.dv8tion.jda.api.JDA
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.security.oauth2.core.user.OAuth2User
+import org.springframework.stereotype.Controller
+import org.springframework.ui.Model
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseBody
+import org.springframework.web.servlet.mvc.support.RedirectAttributes
+import web.service.EconomyWebService
+import web.util.discordIdOrNull
+import web.util.displayName
+
+/**
+ * Web surface for the `/dice` minigame. GET renders the picker UI;
+ * POST runs the roll via [DiceService.roll] and returns JSON.
+ *
+ * Both surfaces share [DiceService] so Discord and web can't drift on
+ * payout maths or balance debit/credit semantics.
+ */
+@Controller
+@RequestMapping("/casino/{guildId}/dice")
+class DiceController(
+    private val diceService: DiceService,
+    private val economyWebService: EconomyWebService,
+    private val userService: UserService,
+    private val jda: JDA
+) {
+
+    @GetMapping
+    fun page(
+        @PathVariable guildId: Long,
+        @AuthenticationPrincipal user: OAuth2User,
+        model: Model,
+        ra: RedirectAttributes
+    ): String {
+        val discordId = user.discordIdOrNull()
+            ?: return "redirect:/casino/guilds"
+        if (!economyWebService.isMember(discordId, guildId)) {
+            ra.addFlashAttribute("error", "You are not a member of that server.")
+            return "redirect:/casino/guilds"
+        }
+        val guild = jda.getGuildById(guildId) ?: run {
+            ra.addFlashAttribute("error", "Bot is not in that server.")
+            return "redirect:/casino/guilds"
+        }
+
+        val balance = userService.getUserById(discordId, guildId)?.socialCredit ?: 0L
+
+        model.addAttribute("guildId", guildId.toString())
+        model.addAttribute("guildName", guild.name)
+        model.addAttribute("balance", balance)
+        model.addAttribute("minStake", Dice.MIN_STAKE)
+        model.addAttribute("maxStake", Dice.MAX_STAKE)
+        model.addAttribute("sides", Dice.DEFAULT_SIDES)
+        model.addAttribute("multiplier", Dice.DEFAULT_MULTIPLIER)
+        model.addAttribute("username", user.displayName())
+        return "dice"
+    }
+
+    @PostMapping("/roll")
+    @ResponseBody
+    fun roll(
+        @PathVariable guildId: Long,
+        @RequestBody request: RollRequest,
+        @AuthenticationPrincipal user: OAuth2User
+    ): ResponseEntity<RollResponse> {
+        val discordId = user.discordIdOrNull()
+            ?: return ResponseEntity.status(401).body(RollResponse(false, "Not signed in."))
+        if (!economyWebService.isMember(discordId, guildId)) {
+            return ResponseEntity.status(403).body(RollResponse(false, "You are not a member of that server."))
+        }
+
+        return when (val outcome = diceService.roll(discordId, guildId, request.stake, request.prediction)) {
+            is RollOutcome.Win -> ResponseEntity.ok(
+                RollResponse(
+                    ok = true,
+                    landed = outcome.landed,
+                    predicted = outcome.predicted,
+                    net = outcome.net,
+                    payout = outcome.payout,
+                    newBalance = outcome.newBalance,
+                    win = true
+                )
+            )
+
+            is RollOutcome.Lose -> ResponseEntity.ok(
+                RollResponse(
+                    ok = true,
+                    landed = outcome.landed,
+                    predicted = outcome.predicted,
+                    net = -outcome.stake,
+                    payout = 0L,
+                    newBalance = outcome.newBalance,
+                    win = false
+                )
+            )
+
+            is RollOutcome.InsufficientCredits -> ResponseEntity.badRequest().body(
+                RollResponse(false, "Need ${outcome.stake} credits, you have ${outcome.have}.")
+            )
+
+            is RollOutcome.InvalidStake -> ResponseEntity.badRequest().body(
+                RollResponse(false, "Stake must be between ${outcome.min} and ${outcome.max} credits.")
+            )
+
+            is RollOutcome.InvalidPrediction -> ResponseEntity.badRequest().body(
+                RollResponse(false, "Pick a number between ${outcome.min} and ${outcome.max}.")
+            )
+
+            RollOutcome.UnknownUser -> ResponseEntity.badRequest().body(
+                RollResponse(false, "No user record yet. Try another TobyBot command first.")
+            )
+        }
+    }
+}
+
+data class RollRequest(val prediction: Int = 0, val stake: Long = 0)
+
+data class RollResponse(
+    val ok: Boolean,
+    val error: String? = null,
+    val landed: Int? = null,
+    val predicted: Int? = null,
+    val net: Long? = null,
+    val payout: Long? = null,
+    val newBalance: Long? = null,
+    val win: Boolean? = null
+)

--- a/web/src/main/resources/static/css/dice.css
+++ b/web/src/main/resources/static/css/dice.css
@@ -1,0 +1,152 @@
+.dice-header { margin-bottom: var(--space-5); }
+.dice-header h1 { margin: var(--space-2) 0; }
+.dice-header strong { color: #fff; }
+
+.dice-table {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: var(--space-5);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--space-4);
+}
+
+.dice-die {
+    width: 120px;
+    height: 120px;
+    border-radius: 16px;
+    background: #fff;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3), inset 0 -4px 8px rgba(0, 0, 0, 0.08);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    user-select: none;
+    transition: transform 0.2s;
+}
+.dice-die-face {
+    font-size: 5rem;
+    line-height: 1;
+    color: #1a1a2e;
+}
+.dice-die.rolling {
+    animation: dice-tumble 0.3s linear infinite;
+}
+@keyframes dice-tumble {
+    0% { transform: rotate(0deg) scale(1); }
+    25% { transform: rotate(90deg) scale(1.05); }
+    50% { transform: rotate(180deg) scale(1); }
+    75% { transform: rotate(270deg) scale(1.05); }
+    100% { transform: rotate(360deg) scale(1); }
+}
+
+.dice-result {
+    min-height: 1.5em;
+    font-size: 1.05rem;
+    text-align: center;
+    font-variant-numeric: tabular-nums;
+}
+.dice-result-win { color: #57F287; }
+.dice-result-lose { color: #a0a0b0; }
+
+.dice-bet {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--space-3);
+    width: 100%;
+    max-width: 360px;
+}
+
+.dice-prediction-picker {
+    display: grid;
+    grid-template-columns: repeat(6, 1fr);
+    gap: var(--space-2);
+    width: 100%;
+}
+.dice-prediction {
+    cursor: pointer;
+    user-select: none;
+}
+.dice-prediction input[type="radio"] {
+    position: absolute;
+    opacity: 0;
+    pointer-events: none;
+}
+.dice-prediction span {
+    display: block;
+    text-align: center;
+    padding: 12px 0;
+    background: #0f1830;
+    border: 2px solid var(--border);
+    border-radius: 8px;
+    color: var(--text-muted);
+    font-weight: 700;
+    font-size: 1.1rem;
+    font-variant-numeric: tabular-nums;
+    transition: border-color 0.2s, color 0.2s, background 0.2s;
+}
+.dice-prediction input[type="radio"]:checked + span {
+    border-color: #f1c40f;
+    color: #fff;
+    background: #1a2240;
+}
+.dice-prediction input[type="radio"]:focus-visible + span {
+    outline: 2px solid #5865F2;
+    outline-offset: 2px;
+}
+
+.dice-stake-label {
+    font-size: 0.85rem;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    align-self: flex-start;
+}
+.dice-bet input[type="number"] {
+    width: 100%;
+    padding: 8px 10px;
+    background: #0f1830;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    color: #fff;
+    font-size: 1rem;
+    font-variant-numeric: tabular-nums;
+}
+.dice-bet button[type="submit"] { width: 100%; }
+
+.dice-balance {
+    color: var(--text-muted);
+    font-variant-numeric: tabular-nums;
+}
+.dice-balance strong { color: #fff; }
+
+.dice-rules {
+    margin-top: var(--space-5);
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: var(--space-4);
+}
+.dice-rules h2 {
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--text-muted);
+    margin-bottom: var(--space-3);
+}
+.dice-rules ul {
+    list-style: disc;
+    padding-left: 20px;
+    color: var(--text-muted);
+    font-size: 0.95rem;
+    line-height: 1.7;
+}
+.dice-rules strong { color: #fff; }
+
+@media (max-width: 600px) {
+    .dice-die { width: 96px; height: 96px; }
+    .dice-die-face { font-size: 4rem; }
+    .dice-prediction-picker { grid-template-columns: repeat(3, 1fr); }
+}

--- a/web/src/main/resources/static/js/dice.js
+++ b/web/src/main/resources/static/js/dice.js
@@ -1,0 +1,130 @@
+(function () {
+    'use strict';
+
+    const main = document.querySelector('main[data-guild-id]');
+    if (!main) return;
+
+    const guildId = main.dataset.guildId;
+    const postJson = window.TobyApi && window.TobyApi.postJson;
+
+    function toast(msg, type) {
+        if (window.TobyToast && typeof window.TobyToast.show === 'function') {
+            window.TobyToast.show(msg, { type: type || 'info' });
+        } else {
+            console.log('[' + (type || 'info') + '] ' + msg);
+        }
+    }
+
+    const die = document.getElementById('dice-die');
+    const dieFace = document.getElementById('dice-die-face');
+    const stakeInput = document.getElementById('dice-stake');
+    const rollBtn = document.getElementById('dice-roll');
+    const balanceEl = document.getElementById('dice-balance');
+    const resultEl = document.getElementById('dice-result');
+    const form = document.getElementById('dice-bet');
+
+    if (!form || !rollBtn || !stakeInput || !die || !dieFace) return;
+
+    const FACES = { 1: '⚀', 2: '⚁', 3: '⚂', 4: '⚃', 5: '⚄', 6: '⚅' };
+    const ROLL_DURATION_MS = 800;
+    const ROLL_INTERVAL_MS = 70;
+
+    let rolling = false;
+
+    function selectedPrediction() {
+        const checked = form.querySelector('input[name="prediction"]:checked');
+        return checked ? parseInt(checked.value, 10) : null;
+    }
+
+    function startRollAnimation() {
+        rolling = true;
+        die.classList.add('rolling');
+        return setInterval(function () {
+            const n = 1 + Math.floor(Math.random() * 6);
+            dieFace.textContent = FACES[n] || String(n);
+        }, ROLL_INTERVAL_MS);
+    }
+
+    function stopRollAnimation(intervalId, landed) {
+        clearInterval(intervalId);
+        rolling = false;
+        die.classList.remove('rolling');
+        if (landed && FACES[landed]) {
+            dieFace.textContent = FACES[landed];
+            die.dataset.landed = String(landed);
+        } else {
+            dieFace.textContent = '⚀';
+            delete die.dataset.landed;
+        }
+    }
+
+    function showResult(body) {
+        if (!resultEl) return;
+        resultEl.hidden = false;
+        resultEl.classList.remove('dice-result-win', 'dice-result-lose');
+        if (body.win) {
+            resultEl.classList.add('dice-result-win');
+            resultEl.innerHTML = '<strong>' + body.landed + '!</strong> You called ' +
+                body.predicted + ' &middot; <strong>+' + body.net + ' credits</strong>';
+        } else {
+            resultEl.classList.add('dice-result-lose');
+            resultEl.innerHTML = '<strong>' + body.landed + '.</strong> You called ' +
+                body.predicted + ' &middot; lost <strong>' + Math.abs(body.net) + ' credits</strong>';
+        }
+    }
+
+    function applyBalance(newBalance) {
+        if (typeof newBalance !== 'number') return;
+        if (balanceEl) balanceEl.textContent = newBalance;
+    }
+
+    form.addEventListener('submit', function (e) {
+        e.preventDefault();
+        if (rolling) return;
+
+        const prediction = selectedPrediction();
+        if (!prediction) {
+            toast('Pick a number first.', 'error');
+            return;
+        }
+        const stake = parseInt(stakeInput.value, 10);
+        if (!stake || stake <= 0) {
+            toast('Enter a positive stake.', 'error');
+            return;
+        }
+
+        rollBtn.disabled = true;
+        const intervalId = startRollAnimation();
+        const requestStart = Date.now();
+
+        if (!postJson) {
+            stopRollAnimation(intervalId);
+            rollBtn.disabled = false;
+            toast('API helper missing — refresh the page.', 'error');
+            return;
+        }
+
+        postJson('/casino/' + guildId + '/dice/roll', { prediction: prediction, stake: stake })
+            .then(function (body) {
+                const elapsed = Date.now() - requestStart;
+                const remaining = Math.max(0, ROLL_DURATION_MS - elapsed);
+                setTimeout(function () {
+                    stopRollAnimation(intervalId, body && body.landed);
+                    rollBtn.disabled = false;
+                    if (body && body.ok) {
+                        showResult(body);
+                        applyBalance(body.newBalance);
+                    } else {
+                        if (resultEl) resultEl.hidden = true;
+                        toast((body && body.error) || 'Roll failed.', 'error');
+                    }
+                }, remaining);
+            })
+            .catch(function () {
+                stopRollAnimation(intervalId);
+                rollBtn.disabled = false;
+                if (resultEl) resultEl.hidden = true;
+                toast('Network error.', 'error');
+            });
+    });
+})();

--- a/web/src/main/resources/templates/casino-guilds.html
+++ b/web/src/main/resources/templates/casino-guilds.html
@@ -37,6 +37,8 @@
                    th:href="@{/casino/{id}/slots(id=${g.id})}">🎰 Slots</a>
                 <a class="btn-secondary"
                    th:href="@{/casino/{id}/coinflip(id=${g.id})}">🪙 Coinflip</a>
+                <a class="btn-secondary"
+                   th:href="@{/casino/{id}/dice(id=${g.id})}">🎲 Dice</a>
             </div>
         </div>
     </div>

--- a/web/src/main/resources/templates/dice.html
+++ b/web/src/main/resources/templates/dice.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="en">
+<head th:replace="~{fragments/head :: head('TobyBot - Dice', '/css/dice.css')}"></head>
+<body>
+<a href="#main" class="skip-link">Skip to content</a>
+<div th:replace="~{fragments/navbar :: navbar}"></div>
+
+<main id="main" class="container" th:attr="data-guild-id=${guildId}">
+
+    <div class="dice-header">
+        <a class="back-link" th:href="@{/casino/guilds}">&larr; All casino servers</a>
+        <h1 th:text="'🎲 Dice • ' + ${guildName}">🎲 Dice</h1>
+        <p class="muted">Pick a number 1-<span th:text="${sides}">6</span>, roll the die, match for
+            <strong th:text="${multiplier} + '×'">5×</strong> stake. Bet
+            <span th:text="${minStake}">10</span> to
+            <span th:text="${maxStake}">500</span> credits.</p>
+    </div>
+
+    <div th:if="${error}" class="alert alert-error" th:text="${error}"></div>
+
+    <section class="dice-table">
+        <div class="dice-die" id="dice-die" aria-live="polite">
+            <span class="dice-die-face" id="dice-die-face">⚀</span>
+        </div>
+
+        <div class="dice-result" id="dice-result" hidden></div>
+
+        <form class="dice-bet" id="dice-bet" autocomplete="off">
+            <div class="dice-prediction-picker" role="radiogroup" aria-label="Pick a number">
+                <label class="dice-prediction" th:each="n : ${#numbers.sequence(1, sides)}">
+                    <input type="radio" name="prediction" th:value="${n}" th:checked="${n == 1}">
+                    <span th:text="${n}">1</span>
+                </label>
+            </div>
+            <label for="dice-stake" class="dice-stake-label">Stake (credits)</label>
+            <input id="dice-stake"
+                   name="stake"
+                   type="number"
+                   th:attr="min=${minStake}, max=${maxStake}"
+                   th:value="${minStake}"
+                   step="1">
+            <button type="submit" id="dice-roll" class="btn-primary">Roll</button>
+        </form>
+
+        <div class="dice-balance">
+            Balance: <strong id="dice-balance" th:text="${balance}">0</strong> credits
+        </div>
+    </section>
+
+    <section class="dice-rules">
+        <h2>Rules</h2>
+        <ul>
+            <li>Pick a number 1-<span th:text="${sides}">6</span>, set a stake.</li>
+            <li>Roll matches your number → <strong th:text="${multiplier} + '×'">5×</strong> stake.</li>
+            <li>Anything else → lose your stake.</li>
+            <li>True odds 1/<span th:text="${sides}">6</span>; long-run RTP ≈ <span th:text="${multiplier} + '/' + ${sides}">5/6</span> ≈ 0.833 (~17% house edge).</li>
+        </ul>
+    </section>
+</main>
+
+<div class="toast-stack" id="toast-stack" aria-live="polite"></div>
+
+<script th:src="@{/js/api.js}"></script>
+<script th:src="@{/js/toasts.js}"></script>
+<script th:src="@{/js/dice.js}"></script>
+</body>
+</html>

--- a/web/src/main/resources/templates/fragments/navbar.html
+++ b/web/src/main/resources/templates/fragments/navbar.html
@@ -32,6 +32,7 @@
             <div class="nav-dropdown-menu" role="menu">
                 <a href="/casino/guilds" role="menuitem">&#127920; Slots</a>
                 <a href="/casino/guilds" role="menuitem">&#129689; Coinflip</a>
+                <a href="/casino/guilds" role="menuitem">&#127922; Dice</a>
             </div>
         </div>
         <a href="/intro/guilds">Intro Songs</a>

--- a/web/src/test/js/navbar.test.js
+++ b/web/src/test/js/navbar.test.js
@@ -76,6 +76,7 @@ describe('navbar fragment', () => {
         expect(casino).not.toBeNull();
         expect(casino[0]).toMatch(/href="\/casino\/guilds"[^>]*>[^<]*Slots/);
         expect(casino[0]).toMatch(/href="\/casino\/guilds"[^>]*>[^<]*Coinflip/);
+        expect(casino[0]).toMatch(/href="\/casino\/guilds"[^>]*>[^<]*Dice/);
         // Coming-soon placeholder is gone now that the games ship.
         expect(casino[0]).not.toMatch(/coming soon/i);
     });

--- a/web/src/test/kotlin/web/controller/DiceControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/DiceControllerTest.kt
@@ -1,0 +1,116 @@
+package web.controller
+
+import database.service.DiceService
+import database.service.DiceService.RollOutcome
+import database.service.UserService
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import net.dv8tion.jda.api.JDA
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.security.oauth2.core.user.OAuth2User
+import web.service.EconomyWebService
+
+class DiceControllerTest {
+
+    private val guildId = 42L
+    private val discordId = 100L
+
+    private lateinit var diceService: DiceService
+    private lateinit var economyWebService: EconomyWebService
+    private lateinit var userService: UserService
+    private lateinit var jda: JDA
+    private lateinit var user: OAuth2User
+    private lateinit var controller: DiceController
+
+    @BeforeEach
+    fun setup() {
+        diceService = mockk(relaxed = true)
+        economyWebService = mockk(relaxed = true)
+        userService = mockk(relaxed = true)
+        jda = mockk(relaxed = true)
+        user = mockk {
+            every { getAttribute<String>("id") } returns discordId.toString()
+            every { getAttribute<String>("username") } returns "tester"
+        }
+        every { economyWebService.isMember(discordId, guildId) } returns true
+        controller = DiceController(diceService, economyWebService, userService, jda)
+    }
+
+    @Test
+    fun `roll win returns 200 with win-shaped payload`() {
+        every { diceService.roll(discordId, guildId, 100L, 4) } returns RollOutcome.Win(
+            stake = 100L, payout = 500L, net = 400L, landed = 4, predicted = 4, newBalance = 1_400L
+        )
+
+        val response = controller.roll(guildId, RollRequest(prediction = 4, stake = 100L), user)
+
+        assertTrue(response.statusCode.is2xxSuccessful)
+        val body = response.body!!
+        assertEquals(true, body.ok)
+        assertEquals(true, body.win)
+        assertEquals(400L, body.net)
+        assertEquals(4, body.landed)
+        assertEquals(4, body.predicted)
+    }
+
+    @Test
+    fun `roll lose returns 200 with negative net and win=false`() {
+        every { diceService.roll(discordId, guildId, 50L, 3) } returns RollOutcome.Lose(
+            stake = 50L, landed = 1, predicted = 3, newBalance = 950L
+        )
+
+        val response = controller.roll(guildId, RollRequest(prediction = 3, stake = 50L), user)
+
+        assertTrue(response.statusCode.is2xxSuccessful)
+        val body = response.body!!
+        assertEquals(false, body.win)
+        assertEquals(-50L, body.net)
+        assertEquals(1, body.landed)
+    }
+
+    @Test
+    fun `roll returns 400 on invalid prediction`() {
+        every { diceService.roll(discordId, guildId, 100L, 7) } returns
+            RollOutcome.InvalidPrediction(min = 1, max = 6)
+
+        val response = controller.roll(guildId, RollRequest(prediction = 7, stake = 100L), user)
+
+        assertEquals(400, response.statusCode.value())
+        assertTrue(response.body?.error!!.contains("1"))
+        assertTrue(response.body?.error!!.contains("6"))
+    }
+
+    @Test
+    fun `roll returns 400 on insufficient credits`() {
+        every { diceService.roll(discordId, guildId, 100L, 3) } returns
+            RollOutcome.InsufficientCredits(stake = 100L, have = 30L)
+
+        val response = controller.roll(guildId, RollRequest(prediction = 3, stake = 100L), user)
+
+        assertEquals(400, response.statusCode.value())
+    }
+
+    @Test
+    fun `roll returns 400 on invalid stake`() {
+        every { diceService.roll(discordId, guildId, 5L, 3) } returns
+            RollOutcome.InvalidStake(min = 10L, max = 500L)
+
+        val response = controller.roll(guildId, RollRequest(prediction = 3, stake = 5L), user)
+
+        assertEquals(400, response.statusCode.value())
+    }
+
+    @Test
+    fun `roll rejects with 403 when user is not a member`() {
+        every { economyWebService.isMember(discordId, guildId) } returns false
+
+        val response = controller.roll(guildId, RollRequest(prediction = 3, stake = 100L), user)
+
+        assertEquals(403, response.statusCode.value())
+        verify(exactly = 0) { diceService.roll(any(), any(), any(), any()) }
+    }
+}


### PR DESCRIPTION
## Summary

Third gambling minigame after [#295 Slots](https://github.com/ml404/toby-bot/pull/295) and [#296 Coinflip](https://github.com/ml404/toby-bot/pull/296). **`/dice prediction:<1-6> stake:<int>`** — pick a number, roll a die, **5× payout on a hit**. Same shared-service architecture so Discord and web can't drift.

## Mechanic

- 1/6 true odds, 5× payout on match → **RTP = 5/6 ≈ 0.833 (~17% house edge)**
- Sits between `/coinflip` (no edge, double-or-nothing pivot) and `/slots` (~11% edge, the main sink) on the risk/sink scale
- Bet bounds 10–500 credits (same as Slots — variance is high)

## Architecture

Same shape as Slots and Coinflip. Pure logic + `@Transactional` service + Discord command + web controller + UI. Casino dropdown gains a third entry; per-guild picker now shows three game buttons.

## Refactor watch

Three services now with identical lock-then-mutate shape (`SlotsService`, `CoinflipService`, `DiceService`). Sealed `Outcome` hierarchies are nearly identical except for game-specific payload fields. The right abstraction probably lives at the service layer (a base `WagerService` or a higher-order spin/flip/roll combinator). I'm leaving as parallel for **one more iteration** (next: `/highlow`) to be sure of the seam — extracting prematurely on three examples and then having `/highlow`'s two-step flow not fit the shape would be worse than the duplication itself.

## Tests

- `DiceTest` — `roll` lands in 1..sides, match yields multiplier, mismatch yields 0, `isValidPrediction` enforces bounds, RTP within ±5pp of 5/6 across 200k rolls
- `DiceServiceTest` — atomic balance maths, insufficient/invalid stake, invalid prediction short-circuits before user lock
- `DiceCommandTest` — delegates with parsed prediction+stake, every `RollOutcome` variant produces an embed
- `DiceControllerTest` — outcome→HTTP status mapping; 403 for non-members
- `CommandManagerTest` count bumped 48 → 49
- `navbar.test.js` — Casino dropdown asserts Slots + Coinflip + **Dice**
- All 85 JS + `:database:test` + `:web:test` green locally

## Test plan

- [ ] CI green
- [ ] Manual Discord: `/dice prediction:3 stake:10` repeatedly — hits ~1/6 of the time at 5×; bounds enforced by JDA
- [ ] Manual web: nav Casino ▾ → Dice → guild picker → click Dice on a card → page loads; pick a number, set stake, click Roll → die tumbles ~800ms then reveals; balance updates
- [ ] Both surfaces against the same user → balances stay in sync

---
_Generated by [Claude Code](https://claude.ai/code/session_01JvuveFBoCvMFTK8XxXVN56)_