### PR TITLE
feat: /highlow minigame — Discord command + web UI

### DIFF
--- a/application/src/test/kotlin/integration/bot/CommandManagerTest.kt
+++ b/application/src/test/kotlin/integration/bot/CommandManagerTest.kt
@@ -11,6 +11,7 @@ import bot.toby.command.commands.dnd.RefreshCharacterCommand
 import bot.toby.command.commands.dnd.RollCommand
 import bot.toby.command.commands.economy.CoinflipCommand
 import bot.toby.command.commands.economy.DiceCommand
+import bot.toby.command.commands.economy.HighlowCommand
 import bot.toby.command.commands.economy.SlotsCommand
 import bot.toby.command.commands.economy.TitleCommand
 import bot.toby.command.commands.economy.TobyCoinCommand
@@ -134,12 +135,13 @@ class CommandManagerTest {
             SlotsCommand::class.java,
             CoinflipCommand::class.java,
             DiceCommand::class.java,
+            HighlowCommand::class.java,
             ActivityCommand::class.java
         )
 
         Assertions.assertTrue(availableCommands.containsAll(commandManager.allCommands.map { it.javaClass }.toList()))
-        Assertions.assertEquals(49, commandManager.allCommands.size)
-        Assertions.assertEquals(49, commandManager.allSlashCommands.size)
+        Assertions.assertEquals(50, commandManager.allCommands.size)
+        Assertions.assertEquals(50, commandManager.allSlashCommands.size)
     }
 
     @Test

--- a/database/src/main/kotlin/database/economy/Highlow.kt
+++ b/database/src/main/kotlin/database/economy/Highlow.kt
@@ -1,0 +1,68 @@
+package database.economy
+
+import kotlin.random.Random
+
+/**
+ * Pure-logic high-low. No Spring, no DB, no JDA — just two uniform
+ * card draws and a comparison against the caller's direction.
+ *
+ * Mechanic
+ *   Server draws an anchor card (1..13). User pre-commits HIGHER or
+ *   LOWER. Server draws the next card. Win condition:
+ *     - HIGHER → next > anchor
+ *     - LOWER  → next < anchor
+ *     - tie (next == anchor) → lose
+ *   Payout is flat 2× on win. Average RTP ≈ 12/13 ≈ 0.923
+ *   (~7.7% house edge from the tie-loses rule). Sits between
+ *   /coinflip (no edge) and /slots (~11% edge).
+ *
+ * Why pre-commit instead of "show card, then pick"
+ *   Single API call, no sticky state, identical Discord and web shape.
+ *   Anchor is part of the result, not a pre-state. Variance is real
+ *   though — anchor=13 + HIGHER is a sure loss.
+ */
+class Highlow(
+    private val deckSize: Int = DEFAULT_DECK_SIZE,
+    private val multiplier: Long = DEFAULT_MULTIPLIER
+) {
+
+    enum class Direction(val display: String) {
+        HIGHER("Higher"),
+        LOWER("Lower")
+    }
+
+    data class Hand(
+        val anchor: Int,
+        val next: Int,
+        val direction: Direction,
+        val multiplier: Long
+    ) {
+        val isWin: Boolean get() = multiplier > 0L
+    }
+
+    fun play(direction: Direction, random: Random): Hand {
+        val anchor = random.nextInt(1, deckSize + 1)
+        val next = random.nextInt(1, deckSize + 1)
+        val won = when (direction) {
+            Direction.HIGHER -> next > anchor
+            Direction.LOWER -> next < anchor
+        }
+        return Hand(
+            anchor = anchor,
+            next = next,
+            direction = direction,
+            multiplier = if (won) multiplier else 0L
+        )
+    }
+
+    val deckSizeValue: Int get() = deckSize
+
+    companion object {
+        const val MIN_STAKE: Long = 10L
+        const val MAX_STAKE: Long = 500L
+        const val DEFAULT_DECK_SIZE: Int = 13
+        // 2× on win; with tie-loses the average win probability is ≈ 6/13,
+        // so RTP ≈ 12/13 ≈ 0.923.
+        const val DEFAULT_MULTIPLIER: Long = 2L
+    }
+}

--- a/database/src/main/kotlin/database/service/HighlowService.kt
+++ b/database/src/main/kotlin/database/service/HighlowService.kt
@@ -1,0 +1,81 @@
+package database.service
+
+import database.economy.Highlow
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import kotlin.random.Random
+
+/**
+ * Atomic play path for the `/highlow` minigame. Same lock-then-mutate
+ * pattern as the other minigame services via
+ * [UserService.getUserByIdForUpdate].
+ */
+@Service
+@Transactional
+class HighlowService(
+    private val userService: UserService,
+    private val highlow: Highlow = Highlow(),
+    private val random: Random = Random.Default
+) {
+
+    sealed interface PlayOutcome {
+        data class Win(
+            val stake: Long,
+            val payout: Long,
+            val net: Long,
+            val anchor: Int,
+            val next: Int,
+            val direction: Highlow.Direction,
+            val newBalance: Long
+        ) : PlayOutcome
+
+        data class Lose(
+            val stake: Long,
+            val anchor: Int,
+            val next: Int,
+            val direction: Highlow.Direction,
+            val newBalance: Long
+        ) : PlayOutcome
+
+        data class InsufficientCredits(val stake: Long, val have: Long) : PlayOutcome
+        data class InvalidStake(val min: Long, val max: Long) : PlayOutcome
+        data object UnknownUser : PlayOutcome
+    }
+
+    fun play(discordId: Long, guildId: Long, stake: Long, direction: Highlow.Direction): PlayOutcome {
+        if (stake < Highlow.MIN_STAKE || stake > Highlow.MAX_STAKE) {
+            return PlayOutcome.InvalidStake(Highlow.MIN_STAKE, Highlow.MAX_STAKE)
+        }
+        val user = userService.getUserByIdForUpdate(discordId, guildId)
+            ?: return PlayOutcome.UnknownUser
+        val balance = user.socialCredit ?: 0L
+        if (balance < stake) return PlayOutcome.InsufficientCredits(stake, balance)
+
+        val hand = highlow.play(direction, random)
+        val payout = hand.multiplier * stake
+        val net = payout - stake
+        user.socialCredit = balance + net
+        userService.updateUser(user)
+        val newBalance = user.socialCredit ?: 0L
+
+        return if (hand.isWin) {
+            PlayOutcome.Win(
+                stake = stake,
+                payout = payout,
+                net = net,
+                anchor = hand.anchor,
+                next = hand.next,
+                direction = hand.direction,
+                newBalance = newBalance
+            )
+        } else {
+            PlayOutcome.Lose(
+                stake = stake,
+                anchor = hand.anchor,
+                next = hand.next,
+                direction = hand.direction,
+                newBalance = newBalance
+            )
+        }
+    }
+}

--- a/database/src/test/kotlin/database/economy/HighlowTest.kt
+++ b/database/src/test/kotlin/database/economy/HighlowTest.kt
@@ -1,0 +1,92 @@
+package database.economy
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import kotlin.random.Random
+
+class HighlowTest {
+
+    @Test
+    fun `play returns cards in 1 to deckSize`() {
+        val highlow = Highlow()
+        val rng = Random(42)
+        repeat(1_000) {
+            val hand = highlow.play(Highlow.Direction.HIGHER, rng)
+            assertTrue(hand.anchor in 1..highlow.deckSizeValue)
+            assertTrue(hand.next in 1..highlow.deckSizeValue)
+        }
+    }
+
+    @Test
+    fun `HIGHER wins when next greater than anchor`() {
+        // Force a deterministic sequence: anchor=5, next=10
+        val rng = mockSequenceRng(intArrayOf(5, 10))
+        val hand = Highlow(deckSize = 13).play(Highlow.Direction.HIGHER, rng)
+        assertEquals(5, hand.anchor)
+        assertEquals(10, hand.next)
+        assertTrue(hand.isWin)
+        assertEquals(2L, hand.multiplier)
+    }
+
+    @Test
+    fun `HIGHER loses on tie`() {
+        val rng = mockSequenceRng(intArrayOf(7, 7))
+        val hand = Highlow(deckSize = 13).play(Highlow.Direction.HIGHER, rng)
+        assertEquals(7, hand.anchor)
+        assertEquals(7, hand.next)
+        assertFalse(hand.isWin, "tie loses")
+        assertEquals(0L, hand.multiplier)
+    }
+
+    @Test
+    fun `LOWER wins when next less than anchor`() {
+        val rng = mockSequenceRng(intArrayOf(10, 3))
+        val hand = Highlow(deckSize = 13).play(Highlow.Direction.LOWER, rng)
+        assertTrue(hand.isWin)
+    }
+
+    @Test
+    fun `LOWER loses on tie`() {
+        val rng = mockSequenceRng(intArrayOf(8, 8))
+        val hand = Highlow(deckSize = 13).play(Highlow.Direction.LOWER, rng)
+        assertFalse(hand.isWin)
+    }
+
+    @Test
+    fun `RTP across 200k hands is within 5pp of 12 over 13`() {
+        // With tie-loses and a 2x payout, expected RTP is 12/13 ≈ 0.923.
+        val highlow = Highlow(deckSize = 13, multiplier = 2L)
+        val rng = Random(2026)
+        val stake = 1_000L
+        val n = 200_000
+        var totalWagered = 0L
+        var totalReturned = 0L
+        repeat(n) {
+            val direction = if (rng.nextBoolean()) Highlow.Direction.HIGHER else Highlow.Direction.LOWER
+            val hand = highlow.play(direction, rng)
+            totalWagered += stake
+            totalReturned += hand.multiplier * stake
+        }
+        val rtp = totalReturned.toDouble() / totalWagered.toDouble()
+        val expected = 12.0 / 13.0
+        assertTrue(rtp in (expected - 0.05)..(expected + 0.05), "expected RTP near $expected (±0.05) but saw $rtp")
+    }
+
+    /**
+     * Returns a Random whose nextInt(from, until) walks through [seq]
+     * in order. Anything beyond the sequence falls back to a real RNG.
+     * Highlow.play() calls nextInt twice per hand (anchor then next),
+     * which matches our 2-element fixtures exactly.
+     */
+    private fun mockSequenceRng(seq: IntArray): Random {
+        return object : Random() {
+            private var i = 0
+            override fun nextBits(bitCount: Int): Int = Random.Default.nextBits(bitCount)
+            override fun nextInt(from: Int, until: Int): Int {
+                return if (i < seq.size) seq[i++] else Random.Default.nextInt(from, until)
+            }
+        }
+    }
+}

--- a/database/src/test/kotlin/database/service/HighlowServiceTest.kt
+++ b/database/src/test/kotlin/database/service/HighlowServiceTest.kt
@@ -1,0 +1,101 @@
+package database.service
+
+import database.dto.UserDto
+import database.economy.Highlow
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import kotlin.random.Random
+
+class HighlowServiceTest {
+
+    private lateinit var userService: UserService
+    private lateinit var highlow: Highlow
+    private lateinit var service: HighlowService
+
+    private val discordId = 100L
+    private val guildId = 200L
+
+    @BeforeEach
+    fun setup() {
+        userService = mockk(relaxed = true)
+        highlow = mockk(relaxed = true)
+        service = HighlowService(userService, highlow, Random(0))
+    }
+
+    private fun userWithBalance(balance: Long): UserDto =
+        UserDto(discordId, guildId).apply { socialCredit = balance }
+
+    @Test
+    fun `win debits stake and credits payout atomically`() {
+        val user = userWithBalance(1_000L)
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns user
+        every { highlow.play(Highlow.Direction.HIGHER, any()) } returns Highlow.Hand(
+            anchor = 5, next = 10, direction = Highlow.Direction.HIGHER, multiplier = 2L
+        )
+        val captured = slot<UserDto>()
+        every { userService.updateUser(capture(captured)) } returns user
+
+        val outcome = service.play(discordId, guildId, stake = 100L, direction = Highlow.Direction.HIGHER)
+
+        val win = assertInstanceOf(HighlowService.PlayOutcome.Win::class.java, outcome)
+        assertEquals(100L, win.stake)
+        assertEquals(200L, win.payout)
+        assertEquals(100L, win.net)
+        assertEquals(1_100L, win.newBalance)
+        assertEquals(5, win.anchor)
+        assertEquals(10, win.next)
+        assertEquals(1_100L, captured.captured.socialCredit)
+    }
+
+    @Test
+    fun `loss debits stake only`() {
+        val user = userWithBalance(500L)
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns user
+        every { highlow.play(Highlow.Direction.HIGHER, any()) } returns Highlow.Hand(
+            anchor = 7, next = 7, direction = Highlow.Direction.HIGHER, multiplier = 0L
+        )
+        every { userService.updateUser(any()) } returns user
+
+        val outcome = service.play(discordId, guildId, stake = 100L, direction = Highlow.Direction.HIGHER)
+
+        val lose = assertInstanceOf(HighlowService.PlayOutcome.Lose::class.java, outcome)
+        assertEquals(100L, lose.stake)
+        assertEquals(400L, lose.newBalance)
+        assertEquals(7, lose.anchor)
+        assertEquals(7, lose.next)
+    }
+
+    @Test
+    fun `insufficient credits is rejected`() {
+        val user = userWithBalance(50L)
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns user
+
+        val outcome = service.play(discordId, guildId, stake = 100L, direction = Highlow.Direction.HIGHER)
+
+        assertInstanceOf(HighlowService.PlayOutcome.InsufficientCredits::class.java, outcome)
+        verify(exactly = 0) { userService.updateUser(any()) }
+    }
+
+    @Test
+    fun `invalid stake is rejected before locking the user`() {
+        val outcome = service.play(discordId, guildId, stake = Highlow.MIN_STAKE - 1, direction = Highlow.Direction.HIGHER)
+
+        assertInstanceOf(HighlowService.PlayOutcome.InvalidStake::class.java, outcome)
+        verify(exactly = 0) { userService.getUserByIdForUpdate(any(), any()) }
+    }
+
+    @Test
+    fun `unknown user is rejected`() {
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns null
+
+        val outcome = service.play(discordId, guildId, stake = 100L, direction = Highlow.Direction.HIGHER)
+
+        assertEquals(HighlowService.PlayOutcome.UnknownUser, outcome)
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/HighlowCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/HighlowCommand.kt
@@ -1,0 +1,131 @@
+package bot.toby.command.commands.economy
+
+import core.command.Command.Companion.invokeDeleteOnMessageResponse
+import core.command.CommandContext
+import database.dto.UserDto
+import database.economy.Highlow
+import database.service.HighlowService
+import database.service.HighlowService.PlayOutcome
+import net.dv8tion.jda.api.EmbedBuilder
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
+import net.dv8tion.jda.api.interactions.commands.OptionType
+import net.dv8tion.jda.api.interactions.commands.build.OptionData
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+import java.awt.Color
+
+/**
+ * `/highlow direction:<HIGHER|LOWER> stake:<int>` — pre-commit the
+ * direction; the embed reveals both cards. 2× payout on a correct
+ * call, tie loses. Calls through to [HighlowService.play]; same path
+ * the web `/casino/{guildId}/highlow` page uses.
+ */
+@Component
+class HighlowCommand @Autowired constructor(
+    private val highlowService: HighlowService
+) : EconomyCommand {
+
+    override val name: String = "highlow"
+    override val description: String =
+        "Predict if the next card is higher or lower than the anchor. Bet ${Highlow.MIN_STAKE}-${Highlow.MAX_STAKE} credits."
+
+    companion object {
+        private const val OPT_DIRECTION = "direction"
+        private const val OPT_STAKE = "stake"
+        private const val DIR_HIGHER = "HIGHER"
+        private const val DIR_LOWER = "LOWER"
+        private val WIN_COLOR = Color(87, 242, 135)
+        private val LOSE_COLOR = Color(160, 160, 176)
+        private val ERROR_COLOR = Color(237, 66, 69)
+    }
+
+    override val optionData: List<OptionData> = listOf(
+        OptionData(OptionType.STRING, OPT_DIRECTION, "Higher or lower than the anchor card", true)
+            .addChoice("Higher", DIR_HIGHER)
+            .addChoice("Lower", DIR_LOWER),
+        OptionData(OptionType.INTEGER, OPT_STAKE, "Credits to wager (10-500)", true)
+            .setMinValue(Highlow.MIN_STAKE)
+            .setMaxValue(Highlow.MAX_STAKE)
+    )
+
+    override fun handle(ctx: CommandContext, requestingUserDto: UserDto, deleteDelay: Int) {
+        val event = ctx.event
+        event.deferReply().queue()
+
+        val guild = event.guild ?: run {
+            replyError(event, "This command can only be used in a server.", deleteDelay); return
+        }
+        val direction = parseDirection(event.getOption(OPT_DIRECTION)?.asString) ?: run {
+            replyError(event, "Pick a direction: higher or lower.", deleteDelay); return
+        }
+        val stake = event.getOption(OPT_STAKE)?.asLong ?: run {
+            replyError(event, "You must specify a stake.", deleteDelay); return
+        }
+
+        val outcome = highlowService.play(requestingUserDto.discordId, guild.idLong, stake, direction)
+        replyOutcome(event, outcome, deleteDelay)
+    }
+
+    private fun parseDirection(raw: String?): Highlow.Direction? = when (raw) {
+        DIR_HIGHER -> Highlow.Direction.HIGHER
+        DIR_LOWER -> Highlow.Direction.LOWER
+        else -> null
+    }
+
+    private fun cardLabel(n: Int): String = when (n) {
+        1 -> "A"
+        11 -> "J"
+        12 -> "Q"
+        13 -> "K"
+        else -> n.toString()
+    }
+
+    private fun replyOutcome(
+        event: SlashCommandInteractionEvent,
+        outcome: PlayOutcome,
+        deleteDelay: Int
+    ) {
+        val embed = when (outcome) {
+            is PlayOutcome.Win -> EmbedBuilder()
+                .setTitle("🃏 ${cardLabel(outcome.anchor)} → ${cardLabel(outcome.next)}")
+                .setDescription("You called **${outcome.direction.display}** and won **+${outcome.net} credits**.")
+                .addField("New balance", "${outcome.newBalance} credits", true)
+                .setColor(WIN_COLOR)
+                .build()
+
+            is PlayOutcome.Lose -> EmbedBuilder()
+                .setTitle("🃏 ${cardLabel(outcome.anchor)} → ${cardLabel(outcome.next)}")
+                .setDescription("You called **${outcome.direction.display}**. Lost **${outcome.stake} credits**.")
+                .addField("New balance", "${outcome.newBalance} credits", true)
+                .setColor(LOSE_COLOR)
+                .build()
+
+            is PlayOutcome.InsufficientCredits -> errorEmbed(
+                "Not enough credits. You need ${outcome.stake} but only have ${outcome.have}."
+            )
+
+            is PlayOutcome.InvalidStake -> errorEmbed(
+                "Stake must be between ${outcome.min} and ${outcome.max} credits."
+            )
+
+            PlayOutcome.UnknownUser -> errorEmbed(
+                "No user record yet. Try another TobyBot command first."
+            )
+        }
+        event.hook.sendMessageEmbeds(embed).queue(invokeDeleteOnMessageResponse(deleteDelay))
+    }
+
+    private fun errorEmbed(message: String) = EmbedBuilder()
+        .setTitle("🃏 High-Low")
+        .setDescription(message)
+        .setColor(ERROR_COLOR)
+        .build()
+
+    private fun replyError(
+        event: SlashCommandInteractionEvent,
+        message: String,
+        deleteDelay: Int
+    ) {
+        event.hook.sendMessageEmbeds(errorEmbed(message)).queue(invokeDeleteOnMessageResponse(deleteDelay))
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/economy/HighlowCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/economy/HighlowCommandTest.kt
@@ -1,0 +1,98 @@
+package bot.toby.command.commands.economy
+
+import bot.toby.command.CommandTest
+import bot.toby.command.CommandTest.Companion.event
+import bot.toby.command.CommandTest.Companion.guild
+import bot.toby.command.DefaultCommandContext
+import database.dto.UserDto
+import database.economy.Highlow
+import database.service.HighlowService
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import net.dv8tion.jda.api.interactions.commands.OptionMapping
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class HighlowCommandTest : CommandTest {
+    private lateinit var highlowService: HighlowService
+    private lateinit var command: HighlowCommand
+
+    private val discordId = 1L
+    private val guildId = 42L
+
+    @BeforeEach
+    fun setUp() {
+        setUpCommonMocks()
+        highlowService = mockk(relaxed = true)
+        command = HighlowCommand(highlowService)
+        every { guild.idLong } returns guildId
+    }
+
+    @AfterEach
+    fun tearDown() {
+        tearDownCommonMocks()
+        clearAllMocks()
+    }
+
+    private fun strOpt(value: String): OptionMapping = mockk<OptionMapping>(relaxed = true).also {
+        every { it.asString } returns value
+    }
+
+    private fun intOpt(value: Long): OptionMapping = mockk<OptionMapping>(relaxed = true).also {
+        every { it.asLong } returns value
+    }
+
+    @Test
+    fun `delegates to HighlowService with parsed direction and stake`() {
+        val user = UserDto(discordId = discordId, guildId = guildId)
+        every { event.getOption("direction") } returns strOpt("HIGHER")
+        every { event.getOption("stake") } returns intOpt(50L)
+        every { highlowService.play(discordId, guildId, 50L, Highlow.Direction.HIGHER) } returns
+            HighlowService.PlayOutcome.Lose(stake = 50L, anchor = 7, next = 7, direction = Highlow.Direction.HIGHER, newBalance = 950L)
+
+        command.handle(DefaultCommandContext(event), user, 5)
+
+        verify(exactly = 1) {
+            highlowService.play(discordId, guildId, 50L, Highlow.Direction.HIGHER)
+        }
+    }
+
+    @Test
+    fun `replies with embed on each outcome variant`() {
+        val user = UserDto(discordId = discordId, guildId = guildId)
+        every { event.getOption("direction") } returns strOpt("LOWER")
+        every { event.getOption("stake") } returns intOpt(100L)
+
+        val outcomes = listOf(
+            HighlowService.PlayOutcome.Win(stake = 100L, payout = 200L, net = 100L,
+                anchor = 10, next = 3, direction = Highlow.Direction.LOWER, newBalance = 1_100L),
+            HighlowService.PlayOutcome.Lose(stake = 100L, anchor = 5, next = 10,
+                direction = Highlow.Direction.LOWER, newBalance = 900L),
+            HighlowService.PlayOutcome.InsufficientCredits(stake = 100L, have = 50L),
+            HighlowService.PlayOutcome.InvalidStake(min = 10L, max = 500L),
+            HighlowService.PlayOutcome.UnknownUser
+        )
+        outcomes.forEach { outcome ->
+            every { highlowService.play(any(), any(), any(), any()) } returns outcome
+            command.handle(DefaultCommandContext(event), user, 5)
+        }
+
+        verify(atLeast = outcomes.size) {
+            event.hook.sendMessageEmbeds(any<net.dv8tion.jda.api.entities.MessageEmbed>())
+        }
+    }
+
+    @Test
+    fun `unknown direction short-circuits`() {
+        val user = UserDto(discordId = discordId, guildId = guildId)
+        every { event.getOption("direction") } returns strOpt("SIDEWAYS")
+        every { event.getOption("stake") } returns intOpt(100L)
+
+        command.handle(DefaultCommandContext(event), user, 5)
+
+        verify(exactly = 0) { highlowService.play(any(), any(), any(), any()) }
+    }
+}

--- a/web/src/main/kotlin/web/controller/HighlowController.kt
+++ b/web/src/main/kotlin/web/controller/HighlowController.kt
@@ -1,0 +1,138 @@
+package web.controller
+
+import database.economy.Highlow
+import database.service.HighlowService
+import database.service.HighlowService.PlayOutcome
+import database.service.UserService
+import net.dv8tion.jda.api.JDA
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.security.oauth2.core.user.OAuth2User
+import org.springframework.stereotype.Controller
+import org.springframework.ui.Model
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseBody
+import org.springframework.web.servlet.mvc.support.RedirectAttributes
+import web.service.EconomyWebService
+import web.util.discordIdOrNull
+import web.util.displayName
+
+@Controller
+@RequestMapping("/casino/{guildId}/highlow")
+class HighlowController(
+    private val highlowService: HighlowService,
+    private val economyWebService: EconomyWebService,
+    private val userService: UserService,
+    private val jda: JDA
+) {
+
+    @GetMapping
+    fun page(
+        @PathVariable guildId: Long,
+        @AuthenticationPrincipal user: OAuth2User,
+        model: Model,
+        ra: RedirectAttributes
+    ): String {
+        val discordId = user.discordIdOrNull()
+            ?: return "redirect:/casino/guilds"
+        if (!economyWebService.isMember(discordId, guildId)) {
+            ra.addFlashAttribute("error", "You are not a member of that server.")
+            return "redirect:/casino/guilds"
+        }
+        val guild = jda.getGuildById(guildId) ?: run {
+            ra.addFlashAttribute("error", "Bot is not in that server.")
+            return "redirect:/casino/guilds"
+        }
+
+        val balance = userService.getUserById(discordId, guildId)?.socialCredit ?: 0L
+
+        model.addAttribute("guildId", guildId.toString())
+        model.addAttribute("guildName", guild.name)
+        model.addAttribute("balance", balance)
+        model.addAttribute("minStake", Highlow.MIN_STAKE)
+        model.addAttribute("maxStake", Highlow.MAX_STAKE)
+        model.addAttribute("multiplier", Highlow.DEFAULT_MULTIPLIER)
+        model.addAttribute("username", user.displayName())
+        return "highlow"
+    }
+
+    @PostMapping("/play")
+    @ResponseBody
+    fun play(
+        @PathVariable guildId: Long,
+        @RequestBody request: PlayRequest,
+        @AuthenticationPrincipal user: OAuth2User
+    ): ResponseEntity<PlayResponse> {
+        val discordId = user.discordIdOrNull()
+            ?: return ResponseEntity.status(401).body(PlayResponse(false, "Not signed in."))
+        if (!economyWebService.isMember(discordId, guildId)) {
+            return ResponseEntity.status(403).body(PlayResponse(false, "You are not a member of that server."))
+        }
+        val direction = parseDirection(request.direction)
+            ?: return ResponseEntity.badRequest().body(PlayResponse(false, "Pick a direction: HIGHER or LOWER."))
+
+        return when (val outcome = highlowService.play(discordId, guildId, request.stake, direction)) {
+            is PlayOutcome.Win -> ResponseEntity.ok(
+                PlayResponse(
+                    ok = true,
+                    anchor = outcome.anchor,
+                    next = outcome.next,
+                    direction = outcome.direction.name,
+                    net = outcome.net,
+                    payout = outcome.payout,
+                    newBalance = outcome.newBalance,
+                    win = true
+                )
+            )
+
+            is PlayOutcome.Lose -> ResponseEntity.ok(
+                PlayResponse(
+                    ok = true,
+                    anchor = outcome.anchor,
+                    next = outcome.next,
+                    direction = outcome.direction.name,
+                    net = -outcome.stake,
+                    payout = 0L,
+                    newBalance = outcome.newBalance,
+                    win = false
+                )
+            )
+
+            is PlayOutcome.InsufficientCredits -> ResponseEntity.badRequest().body(
+                PlayResponse(false, "Need ${outcome.stake} credits, you have ${outcome.have}.")
+            )
+
+            is PlayOutcome.InvalidStake -> ResponseEntity.badRequest().body(
+                PlayResponse(false, "Stake must be between ${outcome.min} and ${outcome.max} credits.")
+            )
+
+            PlayOutcome.UnknownUser -> ResponseEntity.badRequest().body(
+                PlayResponse(false, "No user record yet. Try another TobyBot command first.")
+            )
+        }
+    }
+
+    private fun parseDirection(raw: String?): Highlow.Direction? = when (raw?.uppercase()) {
+        "HIGHER" -> Highlow.Direction.HIGHER
+        "LOWER" -> Highlow.Direction.LOWER
+        else -> null
+    }
+}
+
+data class PlayRequest(val direction: String = "", val stake: Long = 0)
+
+data class PlayResponse(
+    val ok: Boolean,
+    val error: String? = null,
+    val anchor: Int? = null,
+    val next: Int? = null,
+    val direction: String? = null,
+    val net: Long? = null,
+    val payout: Long? = null,
+    val newBalance: Long? = null,
+    val win: Boolean? = null
+)

--- a/web/src/main/resources/static/css/highlow.css
+++ b/web/src/main/resources/static/css/highlow.css
@@ -1,0 +1,168 @@
+.highlow-header { margin-bottom: var(--space-5); }
+.highlow-header h1 { margin: var(--space-2) 0; }
+.highlow-header strong { color: #fff; }
+
+.highlow-table {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: var(--space-5);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--space-4);
+}
+
+.highlow-cards {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+}
+.highlow-card {
+    width: 96px;
+    height: 134px;
+    border-radius: 12px;
+    background: linear-gradient(135deg, #fff 0%, #e8e8f0 100%);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    user-select: none;
+    position: relative;
+}
+.highlow-card-face {
+    font-size: 2.4rem;
+    font-weight: 700;
+    color: #1a1a2e;
+    line-height: 1;
+    font-variant-numeric: tabular-nums;
+}
+.highlow-card-label {
+    position: absolute;
+    bottom: 8px;
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: #666;
+    font-weight: 600;
+}
+.highlow-card.shuffling { animation: highlow-pulse 0.4s linear infinite; }
+@keyframes highlow-pulse {
+    0%, 100% { transform: translateY(0) scale(1); }
+    50% { transform: translateY(-4px) scale(1.02); }
+}
+.highlow-arrow {
+    font-size: 2rem;
+    color: var(--text-muted);
+    user-select: none;
+}
+
+.highlow-result {
+    min-height: 1.5em;
+    font-size: 1rem;
+    text-align: center;
+    font-variant-numeric: tabular-nums;
+}
+.highlow-result-win { color: #57F287; }
+.highlow-result-lose { color: #a0a0b0; }
+.highlow-result strong { color: inherit; }
+
+.highlow-bet {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--space-3);
+    width: 100%;
+    max-width: 360px;
+}
+
+.highlow-direction-picker {
+    display: flex;
+    gap: var(--space-3);
+    width: 100%;
+}
+.highlow-direction {
+    flex: 1;
+    cursor: pointer;
+    user-select: none;
+}
+.highlow-direction input[type="radio"] {
+    position: absolute;
+    opacity: 0;
+    pointer-events: none;
+}
+.highlow-direction span {
+    display: block;
+    text-align: center;
+    padding: 12px;
+    background: #0f1830;
+    border: 2px solid var(--border);
+    border-radius: 8px;
+    color: var(--text-muted);
+    font-weight: 600;
+    transition: border-color 0.2s, color 0.2s, background 0.2s;
+}
+.highlow-direction input[type="radio"]:checked + span {
+    border-color: #f1c40f;
+    color: #fff;
+    background: #1a2240;
+}
+.highlow-direction input[type="radio"]:focus-visible + span {
+    outline: 2px solid #5865F2;
+    outline-offset: 2px;
+}
+
+.highlow-stake-label {
+    font-size: 0.85rem;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    align-self: flex-start;
+}
+.highlow-bet input[type="number"] {
+    width: 100%;
+    padding: 8px 10px;
+    background: #0f1830;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    color: #fff;
+    font-size: 1rem;
+    font-variant-numeric: tabular-nums;
+}
+.highlow-bet button[type="submit"] { width: 100%; }
+
+.highlow-balance {
+    color: var(--text-muted);
+    font-variant-numeric: tabular-nums;
+}
+.highlow-balance strong { color: #fff; }
+
+.highlow-rules {
+    margin-top: var(--space-5);
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: var(--space-4);
+}
+.highlow-rules h2 {
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--text-muted);
+    margin-bottom: var(--space-3);
+}
+.highlow-rules ul {
+    list-style: disc;
+    padding-left: 20px;
+    color: var(--text-muted);
+    font-size: 0.95rem;
+    line-height: 1.7;
+}
+.highlow-rules strong { color: #fff; }
+
+@media (max-width: 600px) {
+    .highlow-card { width: 76px; height: 110px; }
+    .highlow-card-face { font-size: 2rem; }
+    .highlow-arrow { font-size: 1.5rem; }
+}

--- a/web/src/main/resources/static/js/highlow.js
+++ b/web/src/main/resources/static/js/highlow.js
@@ -1,0 +1,150 @@
+(function () {
+    'use strict';
+
+    const main = document.querySelector('main[data-guild-id]');
+    if (!main) return;
+
+    const guildId = main.dataset.guildId;
+    const postJson = window.TobyApi && window.TobyApi.postJson;
+
+    function toast(msg, type) {
+        if (window.TobyToast && typeof window.TobyToast.show === 'function') {
+            window.TobyToast.show(msg, { type: type || 'info' });
+        } else {
+            console.log('[' + (type || 'info') + '] ' + msg);
+        }
+    }
+
+    const anchorFace = document.getElementById('highlow-anchor-face');
+    const nextFace = document.getElementById('highlow-next-face');
+    const anchorCard = document.getElementById('highlow-anchor');
+    const nextCard = document.getElementById('highlow-next');
+    const stakeInput = document.getElementById('highlow-stake');
+    const dealBtn = document.getElementById('highlow-deal');
+    const balanceEl = document.getElementById('highlow-balance');
+    const resultEl = document.getElementById('highlow-result');
+    const form = document.getElementById('highlow-bet');
+
+    if (!form || !dealBtn || !stakeInput || !anchorFace || !nextFace) return;
+
+    const DEAL_DURATION_MS = 1000;
+    const SHUFFLE_INTERVAL_MS = 70;
+
+    let dealing = false;
+
+    function selectedDirection() {
+        const checked = form.querySelector('input[name="direction"]:checked');
+        return checked ? checked.value : null;
+    }
+
+    function cardLabel(n) {
+        switch (n) {
+            case 1: return 'A';
+            case 11: return 'J';
+            case 12: return 'Q';
+            case 13: return 'K';
+            default: return String(n);
+        }
+    }
+
+    function startShuffle() {
+        dealing = true;
+        anchorCard.classList.add('shuffling');
+        nextCard.classList.add('shuffling');
+        return setInterval(function () {
+            anchorFace.textContent = cardLabel(1 + Math.floor(Math.random() * 13));
+            nextFace.textContent = cardLabel(1 + Math.floor(Math.random() * 13));
+        }, SHUFFLE_INTERVAL_MS);
+    }
+
+    function stopShuffle(intervalId, body) {
+        clearInterval(intervalId);
+        dealing = false;
+        anchorCard.classList.remove('shuffling');
+        nextCard.classList.remove('shuffling');
+        if (body && typeof body.anchor === 'number' && typeof body.next === 'number') {
+            anchorFace.textContent = cardLabel(body.anchor);
+            nextFace.textContent = cardLabel(body.next);
+            anchorCard.dataset.value = String(body.anchor);
+            nextCard.dataset.value = String(body.next);
+        } else {
+            anchorFace.textContent = '?';
+            nextFace.textContent = '?';
+        }
+    }
+
+    function showResult(body) {
+        if (!resultEl) return;
+        resultEl.hidden = false;
+        resultEl.classList.remove('highlow-result-win', 'highlow-result-lose');
+        const dirLabel = body.direction === 'HIGHER' ? 'Higher' : 'Lower';
+        if (body.win) {
+            resultEl.classList.add('highlow-result-win');
+            resultEl.innerHTML = '<strong>' + cardLabel(body.next) + '</strong> ' +
+                (body.next > body.anchor ? '>' : '<') + ' <strong>' + cardLabel(body.anchor) +
+                '</strong> &middot; you called ' + dirLabel + ' &middot; <strong>+' + body.net + ' credits</strong>';
+        } else {
+            resultEl.classList.add('highlow-result-lose');
+            const tie = body.next === body.anchor;
+            resultEl.innerHTML = '<strong>' + cardLabel(body.next) + '</strong> ' +
+                (tie ? '=' : (body.next > body.anchor ? '>' : '<')) +
+                ' <strong>' + cardLabel(body.anchor) + '</strong> &middot; you called ' +
+                dirLabel + ' &middot; lost <strong>' + Math.abs(body.net) + ' credits</strong>';
+        }
+    }
+
+    function applyBalance(newBalance) {
+        if (typeof newBalance !== 'number') return;
+        if (balanceEl) balanceEl.textContent = newBalance;
+    }
+
+    form.addEventListener('submit', function (e) {
+        e.preventDefault();
+        if (dealing) return;
+
+        const direction = selectedDirection();
+        if (!direction) {
+            toast('Pick a direction first.', 'error');
+            return;
+        }
+        const stake = parseInt(stakeInput.value, 10);
+        if (!stake || stake <= 0) {
+            toast('Enter a positive stake.', 'error');
+            return;
+        }
+
+        dealBtn.disabled = true;
+        const intervalId = startShuffle();
+        const requestStart = Date.now();
+
+        if (!postJson) {
+            stopShuffle(intervalId);
+            dealBtn.disabled = false;
+            toast('API helper missing — refresh the page.', 'error');
+            return;
+        }
+
+        postJson('/casino/' + guildId + '/highlow/play', { direction: direction, stake: stake })
+            .then(function (body) {
+                const elapsed = Date.now() - requestStart;
+                const remaining = Math.max(0, DEAL_DURATION_MS - elapsed);
+                setTimeout(function () {
+                    stopShuffle(intervalId, body);
+                    dealBtn.disabled = false;
+                    if (body && body.ok) {
+                        showResult(body);
+                        applyBalance(body.newBalance);
+                    } else {
+                        if (resultEl) resultEl.hidden = true;
+                        toast((body && body.error) || 'Deal failed.', 'error');
+                    }
+                }, remaining);
+            })
+            .catch(function () {
+                stopShuffle(intervalId);
+                dealBtn.disabled = false;
+                if (resultEl) resultEl.hidden = true;
+                toast('Network error.', 'error');
+            });
+    });
+})();

--- a/web/src/main/resources/templates/casino-guilds.html
+++ b/web/src/main/resources/templates/casino-guilds.html
@@ -39,6 +39,8 @@
                    th:href="@{/casino/{id}/coinflip(id=${g.id})}">🪙 Coinflip</a>
                 <a class="btn-secondary"
                    th:href="@{/casino/{id}/dice(id=${g.id})}">🎲 Dice</a>
+                <a class="btn-secondary"
+                   th:href="@{/casino/{id}/highlow(id=${g.id})}">🃏 High-Low</a>
             </div>
         </div>
     </div>

--- a/web/src/main/resources/templates/fragments/navbar.html
+++ b/web/src/main/resources/templates/fragments/navbar.html
@@ -33,6 +33,7 @@
                 <a href="/casino/guilds" role="menuitem">&#127920; Slots</a>
                 <a href="/casino/guilds" role="menuitem">&#129689; Coinflip</a>
                 <a href="/casino/guilds" role="menuitem">&#127922; Dice</a>
+                <a href="/casino/guilds" role="menuitem">&#127183; High-Low</a>
             </div>
         </div>
         <a href="/intro/guilds">Intro Songs</a>

--- a/web/src/main/resources/templates/highlow.html
+++ b/web/src/main/resources/templates/highlow.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="en">
+<head th:replace="~{fragments/head :: head('TobyBot - High-Low', '/css/highlow.css')}"></head>
+<body>
+<a href="#main" class="skip-link">Skip to content</a>
+<div th:replace="~{fragments/navbar :: navbar}"></div>
+
+<main id="main" class="container" th:attr="data-guild-id=${guildId}">
+
+    <div class="highlow-header">
+        <a class="back-link" th:href="@{/casino/guilds}">&larr; All casino servers</a>
+        <h1 th:text="'🃏 High-Low • ' + ${guildName}">🃏 High-Low</h1>
+        <p class="muted">Pre-commit higher or lower. Cards are 1 (Ace) through 13 (King).
+            Match → <strong th:text="${multiplier} + '×'">2×</strong> stake. Tie loses.
+            Bet <span th:text="${minStake}">10</span>-<span th:text="${maxStake}">500</span> credits.</p>
+    </div>
+
+    <div th:if="${error}" class="alert alert-error" th:text="${error}"></div>
+
+    <section class="highlow-table">
+        <div class="highlow-cards">
+            <div class="highlow-card" id="highlow-anchor" aria-live="polite">
+                <span class="highlow-card-face" id="highlow-anchor-face">?</span>
+                <span class="highlow-card-label">Anchor</span>
+            </div>
+            <div class="highlow-arrow" id="highlow-arrow" aria-hidden="true">→</div>
+            <div class="highlow-card" id="highlow-next" aria-live="polite">
+                <span class="highlow-card-face" id="highlow-next-face">?</span>
+                <span class="highlow-card-label">Next</span>
+            </div>
+        </div>
+
+        <div class="highlow-result" id="highlow-result" hidden></div>
+
+        <form class="highlow-bet" id="highlow-bet" autocomplete="off">
+            <div class="highlow-direction-picker" role="radiogroup" aria-label="Pick a direction">
+                <label class="highlow-direction">
+                    <input type="radio" name="direction" value="HIGHER" checked>
+                    <span>▲ Higher</span>
+                </label>
+                <label class="highlow-direction">
+                    <input type="radio" name="direction" value="LOWER">
+                    <span>▼ Lower</span>
+                </label>
+            </div>
+            <label for="highlow-stake" class="highlow-stake-label">Stake (credits)</label>
+            <input id="highlow-stake"
+                   name="stake"
+                   type="number"
+                   th:attr="min=${minStake}, max=${maxStake}"
+                   th:value="${minStake}"
+                   step="1">
+            <button type="submit" id="highlow-deal" class="btn-primary">Deal</button>
+        </form>
+
+        <div class="highlow-balance">
+            Balance: <strong id="highlow-balance" th:text="${balance}">0</strong> credits
+        </div>
+    </section>
+
+    <section class="highlow-rules">
+        <h2>Rules</h2>
+        <ul>
+            <li>Pick higher or lower, set a stake.</li>
+            <li>The anchor and next card are drawn together — you don't see the anchor first.</li>
+            <li>Direction matches → <strong th:text="${multiplier} + '×'">2×</strong> stake.</li>
+            <li>Wrong direction or tie (anchor == next) → lose stake.</li>
+            <li>Average RTP ≈ 12/13 ≈ 0.923 (~7.7% house edge from the tie-loses rule).</li>
+        </ul>
+    </section>
+</main>
+
+<div class="toast-stack" id="toast-stack" aria-live="polite"></div>
+
+<script th:src="@{/js/api.js}"></script>
+<script th:src="@{/js/toasts.js}"></script>
+<script th:src="@{/js/highlow.js}"></script>
+</body>
+</html>

--- a/web/src/test/js/navbar.test.js
+++ b/web/src/test/js/navbar.test.js
@@ -77,6 +77,7 @@ describe('navbar fragment', () => {
         expect(casino[0]).toMatch(/href="\/casino\/guilds"[^>]*>[^<]*Slots/);
         expect(casino[0]).toMatch(/href="\/casino\/guilds"[^>]*>[^<]*Coinflip/);
         expect(casino[0]).toMatch(/href="\/casino\/guilds"[^>]*>[^<]*Dice/);
+        expect(casino[0]).toMatch(/href="\/casino\/guilds"[^>]*>[^<]*High-Low/);
         // Coming-soon placeholder is gone now that the games ship.
         expect(casino[0]).not.toMatch(/coming soon/i);
     });


### PR DESCRIPTION
## Summary

Fourth gambling minigame after [#295 Slots](https://github.com/ml404/toby-bot/pull/295), [#296 Coinflip](https://github.com/ml404/toby-bot/pull/296), [#299 Dice](https://github.com/ml404/toby-bot/pull/299). **`/highlow direction:<HIGHER|LOWER> stake:<int>`** — server draws an anchor card (1-13), user pre-commits, server draws the next card; 2× payout on a correct call, tie loses.

## Mechanic

- 13-card deck (1=A, 11=J, 12=Q, 13=K), uniform random with replacement, drawn server-side
- User pre-commits HIGHER or LOWER before the anchor is revealed
- Direction match → 2× stake. Tie or wrong direction → lose stake.
- Average **RTP ≈ 12/13 ≈ 0.923** (~7.7% house edge from the tie-loses rule)
- Sits between `/coinflip` (0%) and `/slots` (~11%) on the risk/sink scale

## Why pre-commit instead of "show card, then pick"

Single API call, no sticky state, identical Discord and web shape. Anchor is part of the result, not a pre-state. Variance is real — anchor=13 + HIGHER is a sure loss — but it keeps the implementation symmetrical with the other minigames.

## Casino integration

- Casino navbar dropdown gains 🃏 High-Low entry
- `/casino/guilds` picker shows four game buttons per guild card

## Refactor watch

Four services with identical shape now (Slots/Coinflip/Dice/Highlow). Same sealed `Outcome` hierarchy modulo game-specific payload, same lock-then-mutate flow, same stake-bound validation. Extracting a base `WagerService<P, R>` with a `play(P, Random) -> R` callback is starting to look mechanical. **`/scratch` is the fifth example coming next** — if it fits, refactor lands then.

## Tests

- `HighlowTest` — cards in 1..deckSize; HIGHER wins on `next > anchor`; HIGHER and LOWER both lose on tie; RTP within ±5pp of 12/13 across 200k hands
- `HighlowServiceTest` — atomic balance maths, insufficient/invalid stake, unknown user
- `HighlowCommandTest` — delegates with parsed direction+stake; every `PlayOutcome` variant produces an embed; unknown direction short-circuits
- `CommandManagerTest` count bumped 49 → 50
- `navbar.test.js` — Casino dropdown asserts Slots + Coinflip + Dice + **High-Low**
- All 85 JS + `:database:test` + `:web:test` green locally

## Test plan

- [ ] CI green
- [ ] Manual Discord: `/highlow direction:Higher stake:10` repeatedly; ~50% win rate; bounds enforced
- [ ] Manual web: nav Casino ▾ → High-Low → guild picker → click High-Low on a card → page loads; pick direction, set stake, click Deal → cards shuffle ~1s then reveal; balance updates

---
_Generated by [Claude Code](https://claude.ai/code/session_01JvuveFBoCvMFTK8XxXVN56)_