### PR TITLE
refactor(economy): extract WagerHelper for the 5 minigame services

### DIFF
--- a/database/src/main/kotlin/database/service/CoinflipService.kt
+++ b/database/src/main/kotlin/database/service/CoinflipService.kt
@@ -43,40 +43,33 @@ class CoinflipService(
     }
 
     fun flip(discordId: Long, guildId: Long, stake: Long, predicted: Coinflip.Side): FlipOutcome {
-        if (stake < Coinflip.MIN_STAKE || stake > Coinflip.MAX_STAKE) {
-            return FlipOutcome.InvalidStake(Coinflip.MIN_STAKE, Coinflip.MAX_STAKE)
-        }
-        val user = userService.getUserByIdForUpdate(discordId, guildId)
-            ?: return FlipOutcome.UnknownUser
-        val balance = user.socialCredit ?: 0L
-        if (balance < stake) return FlipOutcome.InsufficientCredits(stake, balance)
-
-        val flip = coinflip.flip(predicted, random)
-        // payout = multiplier × stake on a match, 0 on a miss. Net change
-        // to the user's balance is (payout - stake): positive on wins, -stake
-        // on losses.
-        val payout = flip.multiplier * stake
-        val net = payout - stake
-        user.socialCredit = balance + net
-        userService.updateUser(user)
-        val newBalance = user.socialCredit ?: 0L
-
-        return if (flip.isWin) {
-            FlipOutcome.Win(
-                stake = stake,
-                payout = payout,
-                net = net,
-                landed = flip.landed,
-                predicted = flip.predicted,
-                newBalance = newBalance
-            )
-        } else {
-            FlipOutcome.Lose(
-                stake = stake,
-                landed = flip.landed,
-                predicted = flip.predicted,
-                newBalance = newBalance
-            )
+        return when (val check = WagerHelper.checkAndLock(
+            userService, discordId, guildId, stake, Coinflip.MIN_STAKE, Coinflip.MAX_STAKE
+        )) {
+            is BalanceCheck.InvalidStake -> FlipOutcome.InvalidStake(check.min, check.max)
+            BalanceCheck.UnknownUser -> FlipOutcome.UnknownUser
+            is BalanceCheck.Insufficient -> FlipOutcome.InsufficientCredits(check.stake, check.have)
+            is BalanceCheck.Ok -> {
+                val flip = coinflip.flip(predicted, random)
+                val r = WagerHelper.applyMultiplier(userService, check.user, check.balance, stake, flip.multiplier)
+                if (flip.isWin) {
+                    FlipOutcome.Win(
+                        stake = stake,
+                        payout = r.payout,
+                        net = r.net,
+                        landed = flip.landed,
+                        predicted = flip.predicted,
+                        newBalance = r.newBalance
+                    )
+                } else {
+                    FlipOutcome.Lose(
+                        stake = stake,
+                        landed = flip.landed,
+                        predicted = flip.predicted,
+                        newBalance = r.newBalance
+                    )
+                }
+            }
         }
     }
 }

--- a/database/src/main/kotlin/database/service/DiceService.kt
+++ b/database/src/main/kotlin/database/service/DiceService.kt
@@ -43,40 +43,36 @@ class DiceService(
     }
 
     fun roll(discordId: Long, guildId: Long, stake: Long, predicted: Int): RollOutcome {
-        if (stake < Dice.MIN_STAKE || stake > Dice.MAX_STAKE) {
-            return RollOutcome.InvalidStake(Dice.MIN_STAKE, Dice.MAX_STAKE)
-        }
         if (!dice.isValidPrediction(predicted)) {
             return RollOutcome.InvalidPrediction(1, dice.sidesCount)
         }
-        val user = userService.getUserByIdForUpdate(discordId, guildId)
-            ?: return RollOutcome.UnknownUser
-        val balance = user.socialCredit ?: 0L
-        if (balance < stake) return RollOutcome.InsufficientCredits(stake, balance)
-
-        val roll = dice.roll(predicted, random)
-        val payout = roll.multiplier * stake
-        val net = payout - stake
-        user.socialCredit = balance + net
-        userService.updateUser(user)
-        val newBalance = user.socialCredit ?: 0L
-
-        return if (roll.isWin) {
-            RollOutcome.Win(
-                stake = stake,
-                payout = payout,
-                net = net,
-                landed = roll.landed,
-                predicted = roll.predicted,
-                newBalance = newBalance
-            )
-        } else {
-            RollOutcome.Lose(
-                stake = stake,
-                landed = roll.landed,
-                predicted = roll.predicted,
-                newBalance = newBalance
-            )
+        return when (val check = WagerHelper.checkAndLock(
+            userService, discordId, guildId, stake, Dice.MIN_STAKE, Dice.MAX_STAKE
+        )) {
+            is BalanceCheck.InvalidStake -> RollOutcome.InvalidStake(check.min, check.max)
+            BalanceCheck.UnknownUser -> RollOutcome.UnknownUser
+            is BalanceCheck.Insufficient -> RollOutcome.InsufficientCredits(check.stake, check.have)
+            is BalanceCheck.Ok -> {
+                val roll = dice.roll(predicted, random)
+                val r = WagerHelper.applyMultiplier(userService, check.user, check.balance, stake, roll.multiplier)
+                if (roll.isWin) {
+                    RollOutcome.Win(
+                        stake = stake,
+                        payout = r.payout,
+                        net = r.net,
+                        landed = roll.landed,
+                        predicted = roll.predicted,
+                        newBalance = r.newBalance
+                    )
+                } else {
+                    RollOutcome.Lose(
+                        stake = stake,
+                        landed = roll.landed,
+                        predicted = roll.predicted,
+                        newBalance = r.newBalance
+                    )
+                }
+            }
         }
     }
 }

--- a/database/src/main/kotlin/database/service/HighlowService.kt
+++ b/database/src/main/kotlin/database/service/HighlowService.kt
@@ -43,39 +43,35 @@ class HighlowService(
     }
 
     fun play(discordId: Long, guildId: Long, stake: Long, direction: Highlow.Direction): PlayOutcome {
-        if (stake < Highlow.MIN_STAKE || stake > Highlow.MAX_STAKE) {
-            return PlayOutcome.InvalidStake(Highlow.MIN_STAKE, Highlow.MAX_STAKE)
-        }
-        val user = userService.getUserByIdForUpdate(discordId, guildId)
-            ?: return PlayOutcome.UnknownUser
-        val balance = user.socialCredit ?: 0L
-        if (balance < stake) return PlayOutcome.InsufficientCredits(stake, balance)
-
-        val hand = highlow.play(direction, random)
-        val payout = hand.multiplier * stake
-        val net = payout - stake
-        user.socialCredit = balance + net
-        userService.updateUser(user)
-        val newBalance = user.socialCredit ?: 0L
-
-        return if (hand.isWin) {
-            PlayOutcome.Win(
-                stake = stake,
-                payout = payout,
-                net = net,
-                anchor = hand.anchor,
-                next = hand.next,
-                direction = hand.direction,
-                newBalance = newBalance
-            )
-        } else {
-            PlayOutcome.Lose(
-                stake = stake,
-                anchor = hand.anchor,
-                next = hand.next,
-                direction = hand.direction,
-                newBalance = newBalance
-            )
+        return when (val check = WagerHelper.checkAndLock(
+            userService, discordId, guildId, stake, Highlow.MIN_STAKE, Highlow.MAX_STAKE
+        )) {
+            is BalanceCheck.InvalidStake -> PlayOutcome.InvalidStake(check.min, check.max)
+            BalanceCheck.UnknownUser -> PlayOutcome.UnknownUser
+            is BalanceCheck.Insufficient -> PlayOutcome.InsufficientCredits(check.stake, check.have)
+            is BalanceCheck.Ok -> {
+                val hand = highlow.play(direction, random)
+                val r = WagerHelper.applyMultiplier(userService, check.user, check.balance, stake, hand.multiplier)
+                if (hand.isWin) {
+                    PlayOutcome.Win(
+                        stake = stake,
+                        payout = r.payout,
+                        net = r.net,
+                        anchor = hand.anchor,
+                        next = hand.next,
+                        direction = hand.direction,
+                        newBalance = r.newBalance
+                    )
+                } else {
+                    PlayOutcome.Lose(
+                        stake = stake,
+                        anchor = hand.anchor,
+                        next = hand.next,
+                        direction = hand.direction,
+                        newBalance = r.newBalance
+                    )
+                }
+            }
         }
     }
 }

--- a/database/src/main/kotlin/database/service/ScratchService.kt
+++ b/database/src/main/kotlin/database/service/ScratchService.kt
@@ -40,33 +40,29 @@ class ScratchService(
     }
 
     fun scratch(discordId: Long, guildId: Long, stake: Long): ScratchOutcome {
-        if (stake < ScratchCard.MIN_STAKE || stake > ScratchCard.MAX_STAKE) {
-            return ScratchOutcome.InvalidStake(ScratchCard.MIN_STAKE, ScratchCard.MAX_STAKE)
-        }
-        val user = userService.getUserByIdForUpdate(discordId, guildId)
-            ?: return ScratchOutcome.UnknownUser
-        val balance = user.socialCredit ?: 0L
-        if (balance < stake) return ScratchOutcome.InsufficientCredits(stake, balance)
-
-        val result = card.scratch(random)
-        val payout = result.multiplier * stake
-        val net = payout - stake
-        user.socialCredit = balance + net
-        userService.updateUser(user)
-        val newBalance = user.socialCredit ?: 0L
-
-        return if (result.isWin && result.winningSymbol != null) {
-            ScratchOutcome.Win(
-                stake = stake,
-                payout = payout,
-                net = net,
-                cells = result.cells,
-                winningSymbol = result.winningSymbol,
-                matchCount = result.matchCount,
-                newBalance = newBalance
-            )
-        } else {
-            ScratchOutcome.Lose(stake = stake, cells = result.cells, newBalance = newBalance)
+        return when (val check = WagerHelper.checkAndLock(
+            userService, discordId, guildId, stake, ScratchCard.MIN_STAKE, ScratchCard.MAX_STAKE
+        )) {
+            is BalanceCheck.InvalidStake -> ScratchOutcome.InvalidStake(check.min, check.max)
+            BalanceCheck.UnknownUser -> ScratchOutcome.UnknownUser
+            is BalanceCheck.Insufficient -> ScratchOutcome.InsufficientCredits(check.stake, check.have)
+            is BalanceCheck.Ok -> {
+                val result = card.scratch(random)
+                val r = WagerHelper.applyMultiplier(userService, check.user, check.balance, stake, result.multiplier)
+                if (result.isWin && result.winningSymbol != null) {
+                    ScratchOutcome.Win(
+                        stake = stake,
+                        payout = r.payout,
+                        net = r.net,
+                        cells = result.cells,
+                        winningSymbol = result.winningSymbol,
+                        matchCount = result.matchCount,
+                        newBalance = r.newBalance
+                    )
+                } else {
+                    ScratchOutcome.Lose(stake = stake, cells = result.cells, newBalance = r.newBalance)
+                }
+            }
         }
     }
 }

--- a/database/src/main/kotlin/database/service/SlotsService.kt
+++ b/database/src/main/kotlin/database/service/SlotsService.kt
@@ -47,35 +47,28 @@ class SlotsService(
     }
 
     fun spin(discordId: Long, guildId: Long, stake: Long): SpinOutcome {
-        if (stake < SlotMachine.MIN_STAKE || stake > SlotMachine.MAX_STAKE) {
-            return SpinOutcome.InvalidStake(SlotMachine.MIN_STAKE, SlotMachine.MAX_STAKE)
-        }
-        val user = userService.getUserByIdForUpdate(discordId, guildId)
-            ?: return SpinOutcome.UnknownUser
-        val balance = user.socialCredit ?: 0L
-        if (balance < stake) return SpinOutcome.InsufficientCredits(stake, balance)
-
-        val pull = machine.pull(random)
-        // payout = multiplier × stake on a win, 0 on a loss. Net change to
-        // the user's balance is (payout - stake): positive on wins (we eat
-        // their stake first then pay them out), -stake on losses.
-        val payout = pull.multiplier * stake
-        val net = payout - stake
-        user.socialCredit = balance + net
-        userService.updateUser(user)
-        val newBalance = user.socialCredit ?: 0L
-
-        return if (pull.isWin) {
-            SpinOutcome.Win(
-                stake = stake,
-                multiplier = pull.multiplier,
-                payout = payout,
-                net = net,
-                symbols = pull.symbols,
-                newBalance = newBalance
-            )
-        } else {
-            SpinOutcome.Lose(stake = stake, symbols = pull.symbols, newBalance = newBalance)
+        return when (val check = WagerHelper.checkAndLock(
+            userService, discordId, guildId, stake, SlotMachine.MIN_STAKE, SlotMachine.MAX_STAKE
+        )) {
+            is BalanceCheck.InvalidStake -> SpinOutcome.InvalidStake(check.min, check.max)
+            BalanceCheck.UnknownUser -> SpinOutcome.UnknownUser
+            is BalanceCheck.Insufficient -> SpinOutcome.InsufficientCredits(check.stake, check.have)
+            is BalanceCheck.Ok -> {
+                val pull = machine.pull(random)
+                val r = WagerHelper.applyMultiplier(userService, check.user, check.balance, stake, pull.multiplier)
+                if (pull.isWin) {
+                    SpinOutcome.Win(
+                        stake = stake,
+                        multiplier = pull.multiplier,
+                        payout = r.payout,
+                        net = r.net,
+                        symbols = pull.symbols,
+                        newBalance = r.newBalance
+                    )
+                } else {
+                    SpinOutcome.Lose(stake = stake, symbols = pull.symbols, newBalance = r.newBalance)
+                }
+            }
         }
     }
 }

--- a/database/src/main/kotlin/database/service/WagerHelper.kt
+++ b/database/src/main/kotlin/database/service/WagerHelper.kt
@@ -1,0 +1,78 @@
+package database.service
+
+import database.dto.UserDto
+
+/**
+ * Shared spine for the wager-style minigame services
+ * ([SlotsService], [CoinflipService], [DiceService], [HighlowService],
+ * [ScratchService]). Each had its own copy of:
+ *   - validate stake bounds → InvalidStake
+ *   - lock the user row → UnknownUser if absent
+ *   - check balance vs. stake → InsufficientCredits if short
+ *   - run game logic → returns a multiplier
+ *   - mutate balance: newBalance = balance + (multiplier × stake) - stake
+ *   - persist + return Win/Lose
+ *
+ * Keeping each service's bespoke `Outcome` sealed type was important —
+ * Win and Lose carry game-specific payload (symbols, sides, predicted
+ * value, cells, etc). So this helper only centralises the
+ * common pre-/post-mutation steps; the service translates [BalanceCheck]
+ * to its own outcome type and calls the game logic between them.
+ */
+internal sealed interface BalanceCheck {
+    data class Ok(val user: UserDto, val balance: Long) : BalanceCheck
+    data class Insufficient(val stake: Long, val have: Long) : BalanceCheck
+    data class InvalidStake(val min: Long, val max: Long) : BalanceCheck
+    data object UnknownUser : BalanceCheck
+}
+
+internal data class WagerResolution(val payout: Long, val net: Long, val newBalance: Long)
+
+internal object WagerHelper {
+
+    /**
+     * Validates [stake] is within [minStake]..[maxStake], locks the user
+     * via [UserService.getUserByIdForUpdate], and confirms balance >= stake.
+     * Caller switches on the result and translates each variant into its
+     * own service-specific outcome.
+     */
+    fun checkAndLock(
+        userService: UserService,
+        discordId: Long,
+        guildId: Long,
+        stake: Long,
+        minStake: Long,
+        maxStake: Long
+    ): BalanceCheck {
+        if (stake !in minStake..maxStake) {
+            return BalanceCheck.InvalidStake(minStake, maxStake)
+        }
+        val user = userService.getUserByIdForUpdate(discordId, guildId)
+            ?: return BalanceCheck.UnknownUser
+        val balance = user.socialCredit ?: 0L
+        if (balance < stake) return BalanceCheck.Insufficient(stake, balance)
+        return BalanceCheck.Ok(user, balance)
+    }
+
+    /**
+     * Applies a [multiplier] win/loss to a locked user. payout = multiplier
+     * × stake (0 on a loss); net = payout - stake (positive win, -stake
+     * loss). Persists via [UserService.updateUser] and returns the
+     * resolved (payout, net, newBalance) triple. Must be called with a
+     * user obtained from [checkAndLock]'s `Ok` branch — the [balance]
+     * argument should match what was checked there to avoid TOCTOU drift.
+     */
+    fun applyMultiplier(
+        userService: UserService,
+        user: UserDto,
+        balance: Long,
+        stake: Long,
+        multiplier: Long
+    ): WagerResolution {
+        val payout = multiplier * stake
+        val net = payout - stake
+        user.socialCredit = balance + net
+        userService.updateUser(user)
+        return WagerResolution(payout = payout, net = net, newBalance = user.socialCredit ?: 0L)
+    }
+}


### PR DESCRIPTION
## Summary

Slots, Coinflip, Dice, Highlow, and Scratch services all had the **identical** lock-then-mutate spine:

```
validate stake bounds → lock user row → check balance → run game logic
  → mutate balance → persist → return Win/Lose
```

The duplication had crept up to **8 "Duplicated code fragment" notices on Qodana** (one new entry per minigame as they shipped). Time to extract.

## Approach

A small internal `WagerHelper` (database/service/) with two functions:
- `checkAndLock(...)` → `BalanceCheck` sealed type (`Ok` | `Insufficient` | `InvalidStake` | `UnknownUser`). Caller switches on the variant and translates each into its own service-specific outcome.
- `applyMultiplier(...)` → `WagerResolution(payout, net, newBalance)` after persisting the balance change.

## Why a helper, not a base class

Each service's `Win`/`Lose` `Outcome` carries game-specific payload (slots symbols, dice landed/predicted, highlow anchor+next, etc.). Forcing those into a generic `Outcome<R>` would either constrain the tests significantly or require type parameters that fight Kotlin's sealed hierarchies.

A flat helper preserves each service's bespoke `Outcome` sealed type, keeps the signatures honest, and **doesn't churn ANY of the 5 services' unit tests** — they continue to mock `UserService.getUserByIdForUpdate` and `userService.updateUser` exactly as before, because the helper just calls those mocked methods. **All 5 service test suites green locally with zero modifications.**

## Service example (slots, before vs after)

```kotlin
// Before — 25 lines of validation/mutation spine
fun spin(...): SpinOutcome {
    if (stake < MIN || stake > MAX) return SpinOutcome.InvalidStake(MIN, MAX)
    val user = userService.getUserByIdForUpdate(...) ?: return SpinOutcome.UnknownUser
    val balance = user.socialCredit ?: 0L
    if (balance < stake) return SpinOutcome.InsufficientCredits(stake, balance)
    val pull = machine.pull(random)
    val payout = pull.multiplier * stake
    val net = payout - stake
    user.socialCredit = balance + net
    userService.updateUser(user)
    val newBalance = user.socialCredit ?: 0L
    return if (pull.isWin) SpinOutcome.Win(stake, pull.multiplier, payout, net, pull.symbols, newBalance)
    else SpinOutcome.Lose(stake, pull.symbols, newBalance)
}

// After — game logic + outcome translation, spine deferred to helper
fun spin(...): SpinOutcome = when (val check = WagerHelper.checkAndLock(userService, discordId, guildId, stake, MIN, MAX)) {
    is BalanceCheck.InvalidStake     -> SpinOutcome.InvalidStake(check.min, check.max)
    BalanceCheck.UnknownUser         -> SpinOutcome.UnknownUser
    is BalanceCheck.Insufficient     -> SpinOutcome.InsufficientCredits(check.stake, check.have)
    is BalanceCheck.Ok               -> {
        val pull = machine.pull(random)
        val r = WagerHelper.applyMultiplier(userService, check.user, check.balance, stake, pull.multiplier)
        if (pull.isWin) SpinOutcome.Win(stake, pull.multiplier, r.payout, r.net, pull.symbols, r.newBalance)
        else SpinOutcome.Lose(stake, pull.symbols, r.newBalance)
    }
}
```

## Dice prediction-check note

Stake-bounds check is now done inside `checkAndLock`, so dice's pre-existing prediction-validity check moved to **before** the helper call. Net effect: an invalid prediction + invalid stake now returns `InvalidPrediction` first instead of `InvalidStake` first. Tests assert each error case in isolation, so neither ordering trips them.

## Diff

| Metric | Value |
|---|---|
| Lines removed (duplicated spine) | 154 |
| Lines added (helper + 5 service rewrites + sealed type) | 206 |
| Net change | +52 |
| New duplicated-spine lines per future minigame | **0** (was ~25) |

The +52 isn't a "lines saved" win directly — it's that the new files are testable, named, and reused. Five identical copies of unnamed inline logic became one named helper plus five focused service implementations.

## Test plan

- [ ] CI green
- [ ] All 5 service test suites unchanged and green (verified locally)
- [ ] Smoke: hit each minigame once on a dev bot/web — same behaviour, same outcome shapes

---
_Generated by [Claude Code](https://claude.ai/code/session_01JvuveFBoCvMFTK8XxXVN56)_