### PR TITLE
fix(scratch): 3×3 grid, threshold 5, scratch-off animation, no win-spoiler

### DIFF
--- a/database/src/main/kotlin/database/economy/ScratchCard.kt
+++ b/database/src/main/kotlin/database/economy/ScratchCard.kt
@@ -3,25 +3,26 @@ package database.economy
 import kotlin.random.Random
 
 /**
- * Pure-logic 5-cell scratchcard. No Spring, no DB, no JDA.
+ * Pure-logic 3×3 scratchcard. No Spring, no DB, no JDA.
  *
  * Mechanic
- *   Five cells drawn independently from a weighted reel (same shape as
+ *   Nine cells drawn independently from a weighted reel (same shape as
  *   [SlotMachine]: 4🍒 + 3🍋 + 2🔔 + 1⭐ = 10 cells). Win condition:
- *   3 or more cells of the SAME symbol anywhere on the card.
+ *   5 or more cells of the SAME symbol anywhere on the card.
  *   Payout multiplier = (basePayout for the matching symbol) ×
- *   (matchCount - 2) — so 3-of-a-kind pays the base, 4 pays 2×, 5 pays 3×.
+ *   (matchCount − (MATCH_THRESHOLD − 1)) — so 5-of-a-kind pays base, 6
+ *   pays 2×, … 9 pays 5×.
  *
- *   When two symbols both hit ≥3 (impossible with 5 cells, since
- *   3+3 > 5), we'd take the rarer one — but it can't happen, so the
- *   tie-break is a guard rather than a gameplay knob.
+ *   Two symbols both hitting ≥5 is impossible with 9 cells (5+5 > 9),
+ *   so the tie-break in `scratch` is a guard rather than a gameplay
+ *   knob.
  *
  * Differentiates from /slots:
- *   - 5 cells vs 3 → wider hit space, smaller-but-more-frequent wins
- *   - "≥3 of a kind" vs "exactly 3 of a kind" → counts of 4 and 5
- *     scale up payouts
- *   - Different RTP profile (around ~75-80% on these tunings; the
- *     RTP test in ScratchCardTest pins the actual number)
+ *   - 9 cells in a 3×3 grid vs 3 reels → wider hit space, big-card feel
+ *   - "≥5 of a kind" vs "exactly 3 of a kind" → counts of 6–9 scale
+ *     payouts up linearly
+ *   - Different RTP profile (~85-90% on these tunings; the RTP test in
+ *     ScratchCardTest pins the actual number)
  */
 class ScratchCard(
     private val reel: List<SlotMachine.Symbol> = SlotMachine.DEFAULT_REEL,
@@ -39,10 +40,6 @@ class ScratchCard(
 
     fun scratch(random: Random): Scratch {
         val cells = List(CELL_COUNT) { reel[random.nextInt(reel.size)] }
-        // Find the symbol with the highest count. If two are tied at
-        // the top (can't happen with 5 cells and a max of 2 different
-        // ≥3 groups, but defend anyway), prefer the one with the higher
-        // base payout so the player gets the better outcome.
         val counts = cells.groupingBy { it }.eachCount()
         val winner = counts.entries
             .filter { it.value >= MATCH_THRESHOLD }
@@ -59,21 +56,22 @@ class ScratchCard(
     companion object {
         const val MIN_STAKE: Long = 10L
         const val MAX_STAKE: Long = 500L
-        const val CELL_COUNT: Int = 5
-        // 4-of-a-kind threshold (was 3 in the first rev — 3 led to ~1.78×
-        // RTP because P(≥3 cherries) ≈ 0.317 dominated the EV. Bumping to
-        // 4 drops the win rate to ~12% and lets the multiplier table land
-        // RTP in the 85-91% range).
-        const val MATCH_THRESHOLD: Int = 4
+        const val CELL_COUNT: Int = 9
+        // 5-of-a-kind on a 9-cell card. The ratio threshold/cells (~0.55)
+        // keeps win rate around 38% while still feeling skill-of-luck-y.
+        // Earlier 5-cell rev sat at threshold 4 — moving to 9 cells without
+        // bumping threshold would have gone back to wins-too-often.
+        const val MATCH_THRESHOLD: Int = 5
 
-        // Base multipliers (paid on a 4-of-a-kind; doubled for 5). Tuned
-        // alongside the RTP convergence test — adjust here, rerun
+        // Base multipliers (paid on a 5-of-a-kind; each additional matching
+        // cell adds another `base` to the multiplier — so 9⭐ = 5× base).
+        // Tuned alongside the RTP convergence test — adjust here, rerun
         // ScratchCardTest's RTP case, accept the new bound.
         val DEFAULT_BASE_PAYOUTS: Map<SlotMachine.Symbol, Long> = mapOf(
-            SlotMachine.Symbol.CHERRY to 5L,    // 4🍒=5×,  5🍒=10×
-            SlotMachine.Symbol.LEMON to 7L,     // 4🍋=7×,  5🍋=14×
-            SlotMachine.Symbol.BELL to 22L,     // 4🔔=22×, 5🔔=44×
-            SlotMachine.Symbol.STAR to 90L      // 4⭐=90×, 5⭐=180×
+            SlotMachine.Symbol.CHERRY to 1L,    // 5🍒=1×,  …, 9🍒=5×
+            SlotMachine.Symbol.LEMON to 2L,     // 5🍋=2×,  …, 9🍋=10×
+            SlotMachine.Symbol.BELL to 8L,      // 5🔔=8×,  …, 9🔔=40×
+            SlotMachine.Symbol.STAR to 40L      // 5⭐=40×, …, 9⭐=200×
         )
     }
 }

--- a/database/src/test/kotlin/database/economy/ScratchCardTest.kt
+++ b/database/src/test/kotlin/database/economy/ScratchCardTest.kt
@@ -10,7 +10,7 @@ import kotlin.random.Random
 class ScratchCardTest {
 
     @Test
-    fun `scratch always returns 5 cells`() {
+    fun `scratch always returns 9 cells`() {
         val card = ScratchCard()
         val rng = Random(42)
         repeat(1_000) {
@@ -21,31 +21,31 @@ class ScratchCardTest {
     }
 
     @Test
-    fun `five-of-a-kind cherry pays base cherry times 2`() {
-        // Reel of only cherries → all 5 cells will be cherries → match=5.
-        // multiplier = base 5 × (5 - (4-1)) = 5 × 2 = 10.
+    fun `nine-of-a-kind cherry pays base cherry times 5`() {
+        // Reel of only cherries → all 9 cells will be cherries → match=9.
+        // multiplier = base 1 × (9 - (5-1)) = 1 × 5 = 5.
         val card = ScratchCard(reel = listOf(SlotMachine.Symbol.CHERRY))
         val result = card.scratch(Random(0))
         assertTrue(result.isWin)
         assertEquals(SlotMachine.Symbol.CHERRY, result.winningSymbol)
-        assertEquals(5, result.matchCount)
-        assertEquals(10L, result.multiplier, "5 cherries × base 5 × (5-3) = 10")
+        assertEquals(9, result.matchCount)
+        assertEquals(5L, result.multiplier, "9 cherries × base 1 × (9-4) = 5")
     }
 
     @Test
-    fun `five-of-a-kind star pays the rare payout scaled`() {
+    fun `nine-of-a-kind star pays the rare payout scaled`() {
         val card = ScratchCard(reel = listOf(SlotMachine.Symbol.STAR))
         val result = card.scratch(Random(0))
         assertEquals(SlotMachine.Symbol.STAR, result.winningSymbol)
-        assertEquals(5, result.matchCount)
-        // 5 stars × base 90 × (5-3) = 180
-        assertEquals(180L, result.multiplier)
+        assertEquals(9, result.matchCount)
+        // 9 stars × base 40 × (9-4) = 200
+        assertEquals(200L, result.multiplier)
     }
 
     @Test
-    fun `no 4-of-a-kind is a loss`() {
-        // With the default weighted reel (4🍒+3🍋+2🔔+1⭐) and 5 cells,
-        // sub-4 cards hit ~88% of the time, so seed 0 already produces
+    fun `no 5-of-a-kind is a loss`() {
+        // With the default weighted reel (4🍒+3🍋+2🔔+1⭐) and 9 cells,
+        // sub-5 cards hit ~61% of the time, so seed 0 already produces
         // one. Iterating to 200 keeps this future-proof against rng
         // ordering shifts.
         val card = ScratchCard()
@@ -66,10 +66,10 @@ class ScratchCardTest {
     fun `RTP across 200k cards lands in casino-style range`() {
         // ScratchCard's RTP isn't a clean closed-form — it depends on the
         // multinomial over the 4-symbol weighted reel × the multiplier
-        // table. With the 4-of-a-kind threshold and the current bases
-        // (5/7/22/90) we expect ~0.85-0.91 RTP. ±10pp around that range
-        // catches gross misconfiguration (back-to-3-of-a-kind would
-        // overshoot 1.7×; payout-zero would undershoot to 0).
+        // table. With the 5-of-a-kind threshold on 9 cells and the current
+        // bases (1/2/8/40) the closed-form math lands ~0.875. ±10pp around
+        // that range catches gross misconfiguration (back-to-3-of-a-kind
+        // would overshoot 1.7×; payout-zero would undershoot to 0).
         val card = ScratchCard()
         val rng = Random(2026)
         val stake = 1_000L
@@ -82,6 +82,6 @@ class ScratchCardTest {
             totalReturned += result.multiplier * stake
         }
         val rtp = totalReturned.toDouble() / totalWagered.toDouble()
-        assertTrue(rtp in 0.75..1.0, "RTP $rtp outside expected casino range")
+        assertTrue(rtp in 0.78..0.97, "RTP $rtp outside expected casino range")
     }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/ScratchCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/ScratchCommand.kt
@@ -16,10 +16,10 @@ import org.springframework.stereotype.Component
 import java.awt.Color
 
 /**
- * `/scratch stake:<int>` — buy a 5-cell scratchcard. Win on 3+ of any
- * symbol; payouts scale with match count. Calls through to
- * [ScratchService.scratch]; same path the web
- * `/casino/{guildId}/scratch` page uses.
+ * `/scratch stake:<int>` — buy a scratchcard. Win on
+ * [ScratchCard.MATCH_THRESHOLD]+ of any symbol; payouts scale with
+ * match count. Calls through to [ScratchService.scratch]; same path
+ * the web `/casino/{guildId}/scratch` page uses.
  */
 @Component
 class ScratchCommand @Autowired constructor(
@@ -28,7 +28,8 @@ class ScratchCommand @Autowired constructor(
 
     override val name: String = "scratch"
     override val description: String =
-        "Buy a 5-cell scratchcard. Match 3+ of any symbol. Bet ${ScratchCard.MIN_STAKE}-${ScratchCard.MAX_STAKE} credits."
+        "Buy a ${ScratchCard.CELL_COUNT}-cell scratchcard. Match ${ScratchCard.MATCH_THRESHOLD}+ of any symbol. " +
+            "Bet ${ScratchCard.MIN_STAKE}-${ScratchCard.MAX_STAKE} credits."
 
     companion object {
         private const val OPT_STAKE = "stake"
@@ -79,7 +80,7 @@ class ScratchCommand @Autowired constructor(
 
             is ScratchOutcome.Lose -> EmbedBuilder()
                 .setTitle("🎟️ ${cellsLine(outcome.cells)}")
-                .setDescription("No 3-of-a-kind. Lost **${outcome.stake} credits**.")
+                .setDescription("No ${ScratchCard.MATCH_THRESHOLD}-of-a-kind. Lost **${outcome.stake} credits**.")
                 .addField("New balance", "${outcome.newBalance} credits", true)
                 .setColor(LOSE_COLOR)
                 .build()

--- a/web/src/main/resources/static/css/scratch.css
+++ b/web/src/main/resources/static/css/scratch.css
@@ -14,10 +14,10 @@
 
 .scratch-cells {
     display: grid;
-    grid-template-columns: repeat(5, 1fr);
+    grid-template-columns: repeat(3, 1fr);
     gap: var(--space-2);
     width: 100%;
-    max-width: 480px;
+    max-width: 360px;
 }
 
 .scratch-cell {
@@ -28,12 +28,16 @@
     color: #1a1a2e;
     cursor: pointer;
     position: relative;
+    overflow: hidden;
     transition: transform 0.1s, border-color 0.2s;
     user-select: none;
 }
 .scratch-cell:hover:not(:disabled) {
     transform: translateY(-2px);
     border-color: #f1c40f;
+}
+.scratch-cell:active:not(:disabled) {
+    transform: translateY(0) scale(0.96);
 }
 .scratch-cell:focus-visible {
     outline: 2px solid #5865F2;
@@ -49,9 +53,19 @@
     justify-content: center;
     font-size: 1.8rem;
     font-weight: 700;
-    transition: opacity 0.25s;
 }
-.scratch-cell-cover { opacity: 1; }
+.scratch-cell-cover {
+    opacity: 1;
+    background: linear-gradient(135deg, #c0c0c8 0%, #8a8a92 100%);
+    /* Diagonal scuff lines that get "scraped off" by the keyframe. */
+    background-image:
+        repeating-linear-gradient(
+            115deg,
+            rgba(255, 255, 255, 0.10) 0 4px,
+            transparent 4px 12px
+        ),
+        linear-gradient(135deg, #c0c0c8 0%, #8a8a92 100%);
+}
 .scratch-cell-face {
     opacity: 0;
     background: #0f1830;
@@ -63,11 +77,37 @@
     border-color: var(--border);
     background: transparent;
 }
-.scratch-cell.revealed .scratch-cell-cover { opacity: 0; }
-.scratch-cell.revealed .scratch-cell-face { opacity: 1; }
+.scratch-cell.revealed .scratch-cell-cover {
+    animation: scratch-off 0.45s ease-out forwards;
+}
+.scratch-cell.revealed .scratch-cell-face {
+    animation: scratch-pop 0.4s 0.12s ease-out backwards;
+    opacity: 1;
+}
 .scratch-cell.win-cell .scratch-cell-face {
     background: #1a3322;
     border: 2px solid #57F287;
+}
+
+@keyframes scratch-off {
+    0%   { opacity: 1; transform: translateX(0)    rotate(0deg);  filter: brightness(1); }
+    20%  { opacity: 1; transform: translateX(-4px) rotate(-3deg); filter: brightness(1.25); }
+    40%  { opacity: 0.85; transform: translateX(6px)  rotate(4deg); }
+    60%  { opacity: 0.55; transform: translateX(-3px) rotate(-2deg); }
+    80%  { opacity: 0.25; transform: translateX(4px)  rotate(2deg); }
+    100% { opacity: 0;    transform: translateX(0)    rotate(0deg); }
+}
+@keyframes scratch-pop {
+    0%   { transform: scale(0.78); opacity: 0; }
+    60%  { transform: scale(1.08); opacity: 1; }
+    100% { transform: scale(1);    opacity: 1; }
+}
+@media (prefers-reduced-motion: reduce) {
+    .scratch-cell.revealed .scratch-cell-cover,
+    .scratch-cell.revealed .scratch-cell-face {
+        animation: none;
+    }
+    .scratch-cell.revealed .scratch-cell-cover { opacity: 0; }
 }
 
 .scratch-result {
@@ -134,6 +174,6 @@
 }
 
 @media (max-width: 600px) {
-    .scratch-cells { max-width: 360px; }
+    .scratch-cells { max-width: 300px; }
     .scratch-cell-cover, .scratch-cell-face { font-size: 1.4rem; }
 }

--- a/web/src/main/resources/static/js/scratch.js
+++ b/web/src/main/resources/static/js/scratch.js
@@ -5,6 +5,7 @@
     if (!main) return;
 
     const guildId = main.dataset.guildId;
+    const matchThreshold = parseInt(main.dataset.matchThreshold, 10) || 5;
     const postJson = window.TobyApi && window.TobyApi.postJson;
 
     function toast(msg, type) {
@@ -51,10 +52,11 @@
         btn.disabled = true;
         const face = btn.querySelector('.scratch-cell-face');
         if (face) face.textContent = activeCard.cells[index] || '?';
-        if (activeCard.winningSymbol && activeCard.cells[index] === activeCard.winningSymbol) {
-            btn.classList.add('win-cell');
-        }
+        // Don't paint the winning cells green yet — that would spoil the
+        // outcome before the user has finished scratching. We tag the
+        // win cells once everything is revealed (see below).
         if (cellButtons.every(function (b) { return b.classList.contains('revealed'); })) {
+            highlightWinCells(activeCard);
             showResult(activeCard);
             // Card consumed — next "Buy ticket" starts a fresh one.
             activeCard = null;
@@ -62,9 +64,22 @@
         }
     }
 
+    function highlightWinCells(body) {
+        if (!body || !body.winningSymbol) return;
+        cellButtons.forEach(function (btn, i) {
+            if (body.cells[i] === body.winningSymbol) {
+                btn.classList.add('win-cell');
+            }
+        });
+    }
+
     function revealAll() {
         if (!activeCard) return;
-        cellButtons.forEach(function (_, i) { revealCell(i); });
+        // Stagger so the scratch-off animation cascades across the grid
+        // instead of all 9 cells popping open simultaneously.
+        cellButtons.forEach(function (_, i) {
+            setTimeout(function () { revealCell(i); }, i * 60);
+        });
     }
 
     function showResult(body) {
@@ -77,7 +92,7 @@
                 '</strong> &middot; <strong>+' + body.net + ' credits</strong>';
         } else {
             resultEl.classList.add('scratch-result-lose');
-            resultEl.innerHTML = 'No 3-of-a-kind &middot; lost <strong>' + Math.abs(body.net) + ' credits</strong>';
+            resultEl.innerHTML = 'No ' + matchThreshold + '-of-a-kind &middot; lost <strong>' + Math.abs(body.net) + ' credits</strong>';
         }
         if (typeof body.newBalance === 'number' && balanceEl) balanceEl.textContent = body.newBalance;
     }

--- a/web/src/main/resources/templates/scratch.html
+++ b/web/src/main/resources/templates/scratch.html
@@ -5,13 +5,14 @@
 <a href="#main" class="skip-link">Skip to content</a>
 <div th:replace="~{fragments/navbar :: navbar}"></div>
 
-<main id="main" class="container" th:attr="data-guild-id=${guildId}">
+<main id="main" class="container"
+      th:attr="data-guild-id=${guildId}, data-match-threshold=${matchThreshold}">
 
     <div class="scratch-header">
         <a class="back-link" th:href="@{/casino/guilds}">&larr; All casino servers</a>
         <h1 th:text="'🎟️ Scratch • ' + ${guildName}">🎟️ Scratch</h1>
-        <p class="muted">Buy a <span th:text="${cellCount}">5</span>-cell scratchcard. Match
-            <span th:text="${matchThreshold}">3</span>+ of any symbol to win;
+        <p class="muted">Buy a <span th:text="${cellCount}">9</span>-cell scratchcard. Match
+            <span th:text="${matchThreshold}">5</span>+ of any symbol to win;
             payouts scale with match count. Bet
             <span th:text="${minStake}">10</span>-<span th:text="${maxStake}">500</span> credits.</p>
     </div>
@@ -20,23 +21,9 @@
 
     <section class="scratch-table">
         <div class="scratch-cells" id="scratch-cells">
-            <button type="button" class="scratch-cell" data-index="0" aria-label="Scratch cell 1">
-                <span class="scratch-cell-cover">?</span>
-                <span class="scratch-cell-face"></span>
-            </button>
-            <button type="button" class="scratch-cell" data-index="1" aria-label="Scratch cell 2">
-                <span class="scratch-cell-cover">?</span>
-                <span class="scratch-cell-face"></span>
-            </button>
-            <button type="button" class="scratch-cell" data-index="2" aria-label="Scratch cell 3">
-                <span class="scratch-cell-cover">?</span>
-                <span class="scratch-cell-face"></span>
-            </button>
-            <button type="button" class="scratch-cell" data-index="3" aria-label="Scratch cell 4">
-                <span class="scratch-cell-cover">?</span>
-                <span class="scratch-cell-face"></span>
-            </button>
-            <button type="button" class="scratch-cell" data-index="4" aria-label="Scratch cell 5">
+            <button th:each="i : ${#numbers.sequence(0, cellCount - 1)}"
+                    type="button" class="scratch-cell"
+                    th:attr="data-index=${i}, aria-label='Scratch cell ' + (${i} + 1)">
                 <span class="scratch-cell-cover">?</span>
                 <span class="scratch-cell-face"></span>
             </button>
@@ -65,10 +52,10 @@
         <h2>Rules</h2>
         <ul>
             <li>Buy a ticket for any stake between <span th:text="${minStake}">10</span> and <span th:text="${maxStake}">500</span> credits.</li>
-            <li>The card has <span th:text="${cellCount}">5</span> cells, each a random symbol from a weighted pool (4🍒, 3🍋, 2🔔, 1⭐).</li>
+            <li>The 3×3 card has <span th:text="${cellCount}">9</span> cells, each a random symbol from a weighted pool (4🍒, 3🍋, 2🔔, 1⭐).</li>
             <li>Click each cell to scratch it off, OR hit "Reveal all".</li>
-            <li>Match <span th:text="${matchThreshold}">3</span>+ of one symbol → win the symbol's payout × (match count − 2).</li>
-            <li>Base payouts: 🍒=1×, 🍋=3×, 🔔=8×, ⭐=30×. So 3⭐=30×, 5⭐=90× stake.</li>
+            <li>Match <span th:text="${matchThreshold}">5</span>+ of one symbol → win the symbol's payout × (match count − 4).</li>
+            <li>Base payouts: 🍒=1×, 🍋=2×, 🔔=8×, ⭐=40×. So 5⭐=40×, 9⭐=200× stake.</li>
         </ul>
     </section>
 </main>


### PR DESCRIPTION
## Summary

Player screenshot caught two stale-text bugs and prompted a UX pass.

**Bugs**
- JS result said `No 3-of-a-kind` but the threshold had been bumped to 4 during the original RTP retune. Now reads `matchThreshold` off a `data-` attribute on `main`, so this can't drift again.
- Template rules text still listed the original `🍒=1× / 🍋=3× / 🔔=8× / ⭐=30×` payouts long after bases moved to `5/7/22/90`. Rewritten against the new `1/2/8/40` table.
- `ScratchCommand` (Discord side) had the same hardcoded `"5-cell"` / `"3+"` / `"No 3-of-a-kind"` text — now built from `ScratchCard.CELL_COUNT` / `MATCH_THRESHOLD`.

**UX**
- Bumped to a 3×3 / 9-cell grid (canonical scratchcard look). Threshold raised to 5 so the win rate stays in the "feels rare" zone (~38%). Bases retuned to `1/2/8/40` — closed-form RTP ~0.875.
- The `win-cell` green highlight previously appeared on each winning cell as it was revealed, spoiling the result before all cells were scratched. Now applied only after the final cell is revealed.
- Cells now animate off with a wiggle + opacity fade and the symbol pops in. "Reveal all" staggers the cascade across the grid (60 ms each). Honours `prefers-reduced-motion`.
- Template renders cell buttons via Thymeleaf `#numbers.sequence(0, cellCount - 1)` so any future grid change is one constant.

## Test plan
- [x] `:database:test --tests ScratchCardTest` — passes; updated 5-of-a-kind expectations + RTP bound (0.78–0.97).
- [x] `:web:test --tests ScratchControllerTest` — passes (mocked, count-agnostic).
- [x] `npm test` — 85/85 pass.
- [ ] Manual: open `/casino/{guildId}/scratch`, buy a low-stake ticket repeatedly, verify scratch-off animation feels right, no green tint until last cell revealed, "Reveal all" cascades, mobile layout fits a 3×3.
- [ ] Manual: `/scratch stake:50` in Discord, confirm description / lose embed text references the new constants.

https://claude.ai/code/session_01JvuveFBoCvMFTK8XxXVN56

---
_Generated by [Claude Code](https://claude.ai/code/session_01JvuveFBoCvMFTK8XxXVN56)_