### PR TITLE
fix(highlow): reveal anchor up front, then take the bet, then deal next

### DIFF
--- a/database/src/main/kotlin/database/economy/Highlow.kt
+++ b/database/src/main/kotlin/database/economy/Highlow.kt
@@ -7,8 +7,8 @@ import kotlin.random.Random
  * card draws and a comparison against the caller's direction.
  *
  * Mechanic
- *   Server draws an anchor card (1..13). User pre-commits HIGHER or
- *   LOWER. Server draws the next card. Win condition:
+ *   Server draws an anchor card (1..13). User commits HIGHER or LOWER.
+ *   Server draws the next card. Win condition:
  *     - HIGHER → next > anchor
  *     - LOWER  → next < anchor
  *     - tie (next == anchor) → lose
@@ -16,10 +16,14 @@ import kotlin.random.Random
  *   (~7.7% house edge from the tie-loses rule). Sits between
  *   /coinflip (no edge) and /slots (~11% edge).
  *
- * Why pre-commit instead of "show card, then pick"
- *   Single API call, no sticky state, identical Discord and web shape.
- *   Anchor is part of the result, not a pre-state. Variance is real
- *   though — anchor=13 + HIGHER is a sure loss.
+ * Two flows live here:
+ *   - [play] — bundled draw used by Discord. Anchor + next come out
+ *     together; the player has no chance to peek before committing.
+ *   - [dealAnchor] + [resolve] — split flow used by the web page.
+ *     Anchor is revealed first; the user picks direction having seen
+ *     it. The web caller is responsible for persisting the anchor
+ *     between requests (HttpSession in [HighlowController]) so the
+ *     player can't reroll a fresh anchor by refreshing the page.
  */
 class Highlow(
     private val deckSize: Int = DEFAULT_DECK_SIZE,
@@ -40,8 +44,22 @@ class Highlow(
         val isWin: Boolean get() = multiplier > 0L
     }
 
+    /** Bundled draw — anchor + next in a single call. Discord uses this. */
     fun play(direction: Direction, random: Random): Hand {
-        val anchor = random.nextInt(1, deckSize + 1)
+        val anchor = dealAnchor(random)
+        return resolve(anchor, direction, random)
+    }
+
+    /** Standalone anchor draw for the split web flow. */
+    fun dealAnchor(random: Random): Int = random.nextInt(1, deckSize + 1)
+
+    /**
+     * Given an anchor that's already been revealed, draw the next card
+     * and decide the outcome. Used by the web flow where the anchor was
+     * shown before the user picked direction.
+     */
+    fun resolve(anchor: Int, direction: Direction, random: Random): Hand {
+        require(anchor in 1..deckSize) { "anchor $anchor outside 1..$deckSize" }
         val next = random.nextInt(1, deckSize + 1)
         val won = when (direction) {
             Direction.HIGHER -> next > anchor

--- a/database/src/main/kotlin/database/service/HighlowService.kt
+++ b/database/src/main/kotlin/database/service/HighlowService.kt
@@ -9,6 +9,13 @@ import kotlin.random.Random
  * Atomic play path for the `/highlow` minigame. Same lock-then-mutate
  * pattern as the other minigame services via
  * [UserService.getUserByIdForUpdate].
+ *
+ * Two entry points:
+ *   - [play] without an anchor — Discord and any caller that wants the
+ *     bundled "draw both cards now" semantics.
+ *   - [play] with an anchor — the web caller has already revealed the
+ *     anchor to the player; this resolves the next card against that
+ *     anchor inside the same transaction as the wager.
  */
 @Service
 @Transactional
@@ -42,7 +49,32 @@ class HighlowService(
         data object UnknownUser : PlayOutcome
     }
 
-    fun play(discordId: Long, guildId: Long, stake: Long, direction: Highlow.Direction): PlayOutcome {
+    /** Draw a fresh anchor without committing any state. The web flow uses this on page load. */
+    fun dealAnchor(): Int = highlow.dealAnchor(random)
+
+    /** Bundled flow: server draws both cards inside this call. */
+    fun play(discordId: Long, guildId: Long, stake: Long, direction: Highlow.Direction): PlayOutcome =
+        playInternal(discordId, guildId, stake, direction, anchor = null)
+
+    /**
+     * Stepwise flow: caller already revealed [anchor] to the player.
+     * The next card is drawn here and the wager settles atomically.
+     */
+    fun play(
+        discordId: Long,
+        guildId: Long,
+        stake: Long,
+        direction: Highlow.Direction,
+        anchor: Int
+    ): PlayOutcome = playInternal(discordId, guildId, stake, direction, anchor = anchor)
+
+    private fun playInternal(
+        discordId: Long,
+        guildId: Long,
+        stake: Long,
+        direction: Highlow.Direction,
+        anchor: Int?
+    ): PlayOutcome {
         return when (val check = WagerHelper.checkAndLock(
             userService, discordId, guildId, stake, Highlow.MIN_STAKE, Highlow.MAX_STAKE
         )) {
@@ -50,7 +82,11 @@ class HighlowService(
             BalanceCheck.UnknownUser -> PlayOutcome.UnknownUser
             is BalanceCheck.Insufficient -> PlayOutcome.InsufficientCredits(check.stake, check.have)
             is BalanceCheck.Ok -> {
-                val hand = highlow.play(direction, random)
+                val hand = if (anchor != null) {
+                    highlow.resolve(anchor, direction, random)
+                } else {
+                    highlow.play(direction, random)
+                }
                 val r = WagerHelper.applyMultiplier(userService, check.user, check.balance, stake, hand.multiplier)
                 if (hand.isWin) {
                     PlayOutcome.Win(

--- a/database/src/test/kotlin/database/economy/HighlowTest.kt
+++ b/database/src/test/kotlin/database/economy/HighlowTest.kt
@@ -55,6 +55,48 @@ class HighlowTest {
     }
 
     @Test
+    fun `dealAnchor returns a card in 1 to deckSize`() {
+        val highlow = Highlow(deckSize = 13)
+        val rng = Random(2026)
+        repeat(1_000) {
+            val a = highlow.dealAnchor(rng)
+            assertTrue(a in 1..13)
+        }
+    }
+
+    @Test
+    fun `resolve uses the supplied anchor and draws next from rng`() {
+        // mockSequenceRng emits one value per nextInt — resolve only
+        // calls nextInt once (for `next`), so seq=[12] gives next=12.
+        val rng = mockSequenceRng(intArrayOf(12))
+        val hand = Highlow(deckSize = 13).resolve(anchor = 5, direction = Highlow.Direction.HIGHER, random = rng)
+        assertEquals(5, hand.anchor)
+        assertEquals(12, hand.next)
+        assertTrue(hand.isWin)
+    }
+
+    @Test
+    fun `resolve with a tie loses regardless of direction`() {
+        val anchor = 9
+        val rng = mockSequenceRng(intArrayOf(9))
+        val hand = Highlow(deckSize = 13).resolve(anchor, Highlow.Direction.LOWER, rng)
+        assertEquals(9, hand.next)
+        assertFalse(hand.isWin)
+        assertEquals(0L, hand.multiplier)
+    }
+
+    @Test
+    fun `resolve rejects an out-of-range anchor`() {
+        val highlow = Highlow(deckSize = 13)
+        org.junit.jupiter.api.assertThrows<IllegalArgumentException> {
+            highlow.resolve(anchor = 0, direction = Highlow.Direction.HIGHER, random = Random.Default)
+        }
+        org.junit.jupiter.api.assertThrows<IllegalArgumentException> {
+            highlow.resolve(anchor = 14, direction = Highlow.Direction.HIGHER, random = Random.Default)
+        }
+    }
+
+    @Test
     fun `RTP across 200k hands is within 5pp of 12 over 13`() {
         // With tie-loses and a 2x payout, expected RTP is 12/13 ≈ 0.923.
         val highlow = Highlow(deckSize = 13, multiplier = 2L)

--- a/database/src/test/kotlin/database/service/HighlowServiceTest.kt
+++ b/database/src/test/kotlin/database/service/HighlowServiceTest.kt
@@ -98,4 +98,36 @@ class HighlowServiceTest {
 
         assertEquals(HighlowService.PlayOutcome.UnknownUser, outcome)
     }
+
+    @Test
+    fun `play with anchor delegates to resolve, not the bundled play`() {
+        val user = userWithBalance(1_000L)
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns user
+        every { highlow.resolve(anchor = 7, direction = Highlow.Direction.HIGHER, random = any()) } returns
+            Highlow.Hand(anchor = 7, next = 12, direction = Highlow.Direction.HIGHER, multiplier = 2L)
+        every { userService.updateUser(any()) } returns user
+
+        val outcome = service.play(
+            discordId, guildId, stake = 100L,
+            direction = Highlow.Direction.HIGHER,
+            anchor = 7
+        )
+
+        val win = assertInstanceOf(HighlowService.PlayOutcome.Win::class.java, outcome)
+        assertEquals(7, win.anchor)
+        assertEquals(12, win.next)
+        verify(exactly = 1) { highlow.resolve(7, Highlow.Direction.HIGHER, any()) }
+        verify(exactly = 0) { highlow.play(any(), any()) }
+    }
+
+    @Test
+    fun `dealAnchor delegates to the underlying logic and does not touch the user`() {
+        every { highlow.dealAnchor(any()) } returns 4
+
+        val anchor = service.dealAnchor()
+
+        assertEquals(4, anchor)
+        verify(exactly = 0) { userService.getUserByIdForUpdate(any(), any()) }
+        verify(exactly = 0) { userService.updateUser(any()) }
+    }
 }

--- a/web/src/main/kotlin/web/controller/HighlowController.kt
+++ b/web/src/main/kotlin/web/controller/HighlowController.kt
@@ -4,6 +4,7 @@ import database.economy.Highlow
 import database.service.HighlowService
 import database.service.HighlowService.PlayOutcome
 import database.service.UserService
+import jakarta.servlet.http.HttpSession
 import net.dv8tion.jda.api.JDA
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
@@ -34,6 +35,7 @@ class HighlowController(
     fun page(
         @PathVariable guildId: Long,
         @AuthenticationPrincipal user: OAuth2User,
+        session: HttpSession,
         model: Model,
         ra: RedirectAttributes
     ): String {
@@ -50,12 +52,19 @@ class HighlowController(
 
         val balance = userService.getUserById(discordId, guildId)?.socialCredit ?: 0L
 
+        // Anchor sticks to the user's session so refreshing the page
+        // can't reroll a fresh card. Drawn lazily on first hit.
+        val anchor = activeAnchor(session, guildId)
+            ?: highlowService.dealAnchor().also { storeAnchor(session, guildId, it) }
+
         model.addAttribute("guildId", guildId.toString())
         model.addAttribute("guildName", guild.name)
         model.addAttribute("balance", balance)
         model.addAttribute("minStake", Highlow.MIN_STAKE)
         model.addAttribute("maxStake", Highlow.MAX_STAKE)
         model.addAttribute("multiplier", Highlow.DEFAULT_MULTIPLIER)
+        model.addAttribute("anchor", anchor)
+        model.addAttribute("anchorLabel", cardLabel(anchor))
         model.addAttribute("username", user.displayName())
         return "highlow"
     }
@@ -65,7 +74,8 @@ class HighlowController(
     fun play(
         @PathVariable guildId: Long,
         @RequestBody request: PlayRequest,
-        @AuthenticationPrincipal user: OAuth2User
+        @AuthenticationPrincipal user: OAuth2User,
+        session: HttpSession
     ): ResponseEntity<PlayResponse> {
         val discordId = user.discordIdOrNull()
             ?: return ResponseEntity.status(401).body(PlayResponse(false, "Not signed in."))
@@ -75,7 +85,25 @@ class HighlowController(
         val direction = parseDirection(request.direction)
             ?: return ResponseEntity.badRequest().body(PlayResponse(false, "Pick a direction: HIGHER or LOWER."))
 
-        return when (val outcome = highlowService.play(discordId, guildId, request.stake, direction)) {
+        val anchor = activeAnchor(session, guildId)
+            ?: return ResponseEntity.badRequest().body(
+                PlayResponse(false, "No active round — refresh the page to draw a new card.")
+            )
+
+        val outcome = highlowService.play(discordId, guildId, request.stake, direction, anchor)
+
+        // Only consume the anchor on outcomes that actually drew a next
+        // card. Validation rejections (invalid stake, insufficient
+        // credits, unknown user) leave the same anchor in place so the
+        // player can retry without losing the card they were looking at.
+        val consumed = outcome is PlayOutcome.Win || outcome is PlayOutcome.Lose
+        val nextRoundAnchor: Int? = if (consumed) {
+            highlowService.dealAnchor().also { storeAnchor(session, guildId, it) }
+        } else {
+            null
+        }
+
+        return when (outcome) {
             is PlayOutcome.Win -> ResponseEntity.ok(
                 PlayResponse(
                     ok = true,
@@ -85,7 +113,8 @@ class HighlowController(
                     net = outcome.net,
                     payout = outcome.payout,
                     newBalance = outcome.newBalance,
-                    win = true
+                    win = true,
+                    nextAnchor = nextRoundAnchor
                 )
             )
 
@@ -98,7 +127,8 @@ class HighlowController(
                     net = -outcome.stake,
                     payout = 0L,
                     newBalance = outcome.newBalance,
-                    win = false
+                    win = false,
+                    nextAnchor = nextRoundAnchor
                 )
             )
 
@@ -121,6 +151,23 @@ class HighlowController(
         "LOWER" -> Highlow.Direction.LOWER
         else -> null
     }
+
+    private fun anchorKey(guildId: Long): String = "highlow.anchor.$guildId"
+
+    private fun activeAnchor(session: HttpSession, guildId: Long): Int? =
+        session.getAttribute(anchorKey(guildId)) as? Int
+
+    private fun storeAnchor(session: HttpSession, guildId: Long, anchor: Int) {
+        session.setAttribute(anchorKey(guildId), anchor)
+    }
+
+    private fun cardLabel(n: Int): String = when (n) {
+        1 -> "A"
+        11 -> "J"
+        12 -> "Q"
+        13 -> "K"
+        else -> n.toString()
+    }
 }
 
 data class PlayRequest(val direction: String = "", val stake: Long = 0)
@@ -134,5 +181,6 @@ data class PlayResponse(
     val net: Long? = null,
     val payout: Long? = null,
     val newBalance: Long? = null,
-    val win: Boolean? = null
+    val win: Boolean? = null,
+    val nextAnchor: Int? = null
 )

--- a/web/src/main/resources/static/js/highlow.js
+++ b/web/src/main/resources/static/js/highlow.js
@@ -27,7 +27,7 @@
 
     if (!form || !dealBtn || !stakeInput || !anchorFace || !nextFace) return;
 
-    const DEAL_DURATION_MS = 1000;
+    const NEXT_DEAL_MS = 900;
     const SHUFFLE_INTERVAL_MS = 70;
 
     let dealing = false;
@@ -47,30 +47,36 @@
         }
     }
 
-    function startShuffle() {
+    function startNextShuffle() {
         dealing = true;
-        anchorCard.classList.add('shuffling');
         nextCard.classList.add('shuffling');
         return setInterval(function () {
-            anchorFace.textContent = cardLabel(1 + Math.floor(Math.random() * 13));
             nextFace.textContent = cardLabel(1 + Math.floor(Math.random() * 13));
         }, SHUFFLE_INTERVAL_MS);
     }
 
-    function stopShuffle(intervalId, body) {
+    function stopNextShuffle(intervalId, value) {
         clearInterval(intervalId);
         dealing = false;
-        anchorCard.classList.remove('shuffling');
         nextCard.classList.remove('shuffling');
-        if (body && typeof body.anchor === 'number' && typeof body.next === 'number') {
-            anchorFace.textContent = cardLabel(body.anchor);
-            nextFace.textContent = cardLabel(body.next);
-            anchorCard.dataset.value = String(body.anchor);
-            nextCard.dataset.value = String(body.next);
+        if (typeof value === 'number') {
+            nextFace.textContent = cardLabel(value);
+            nextCard.dataset.value = String(value);
         } else {
-            anchorFace.textContent = '?';
             nextFace.textContent = '?';
+            delete nextCard.dataset.value;
         }
+    }
+
+    // After a settled round, surface the next round's anchor in the
+    // anchor slot and reset the next-card placeholder so the player can
+    // see the new draw without refreshing the page.
+    function rollAnchorTo(value) {
+        if (typeof value !== 'number') return;
+        anchorFace.textContent = cardLabel(value);
+        anchorCard.dataset.value = String(value);
+        nextFace.textContent = '?';
+        delete nextCard.dataset.value;
     }
 
     function showResult(body) {
@@ -114,11 +120,11 @@
         }
 
         dealBtn.disabled = true;
-        const intervalId = startShuffle();
+        const intervalId = startNextShuffle();
         const requestStart = Date.now();
 
         if (!postJson) {
-            stopShuffle(intervalId);
+            stopNextShuffle(intervalId);
             dealBtn.disabled = false;
             toast('API helper missing — refresh the page.', 'error');
             return;
@@ -127,21 +133,28 @@
         postJson('/casino/' + guildId + '/highlow/play', { direction: direction, stake: stake })
             .then(function (body) {
                 const elapsed = Date.now() - requestStart;
-                const remaining = Math.max(0, DEAL_DURATION_MS - elapsed);
+                const remaining = Math.max(0, NEXT_DEAL_MS - elapsed);
                 setTimeout(function () {
-                    stopShuffle(intervalId, body);
-                    dealBtn.disabled = false;
                     if (body && body.ok) {
+                        stopNextShuffle(intervalId, body.next);
                         showResult(body);
                         applyBalance(body.newBalance);
+                        // Pause briefly so the player reads the result, then
+                        // surface the next round's anchor without requiring
+                        // a page refresh.
+                        if (typeof body.nextAnchor === 'number') {
+                            setTimeout(function () { rollAnchorTo(body.nextAnchor); }, 1200);
+                        }
                     } else {
+                        stopNextShuffle(intervalId);
                         if (resultEl) resultEl.hidden = true;
                         toast((body && body.error) || 'Deal failed.', 'error');
                     }
+                    dealBtn.disabled = false;
                 }, remaining);
             })
             .catch(function () {
-                stopShuffle(intervalId);
+                stopNextShuffle(intervalId);
                 dealBtn.disabled = false;
                 if (resultEl) resultEl.hidden = true;
                 toast('Network error.', 'error');

--- a/web/src/main/resources/templates/highlow.html
+++ b/web/src/main/resources/templates/highlow.html
@@ -19,8 +19,10 @@
 
     <section class="highlow-table">
         <div class="highlow-cards">
-            <div class="highlow-card" id="highlow-anchor" aria-live="polite">
-                <span class="highlow-card-face" id="highlow-anchor-face">?</span>
+            <div class="highlow-card" id="highlow-anchor"
+                 th:attr="data-value=${anchor}" aria-live="polite">
+                <span class="highlow-card-face" id="highlow-anchor-face"
+                      th:text="${anchorLabel}">?</span>
                 <span class="highlow-card-label">Anchor</span>
             </div>
             <div class="highlow-arrow" id="highlow-arrow" aria-hidden="true">→</div>
@@ -61,10 +63,11 @@
     <section class="highlow-rules">
         <h2>Rules</h2>
         <ul>
-            <li>Pick higher or lower, set a stake.</li>
-            <li>The anchor and next card are drawn together — you don't see the anchor first.</li>
+            <li>The anchor card is revealed up front — you see it before betting.</li>
+            <li>Pick higher or lower, set a stake, then deal the next card.</li>
             <li>Direction matches → <strong th:text="${multiplier} + '×'">2×</strong> stake.</li>
             <li>Wrong direction or tie (anchor == next) → lose stake.</li>
+            <li>The anchor is locked to your session, so refreshing won't reroll it.</li>
             <li>Average RTP ≈ 12/13 ≈ 0.923 (~7.7% house edge from the tie-loses rule).</li>
         </ul>
     </section>

--- a/web/src/test/kotlin/web/controller/HighlowControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/HighlowControllerTest.kt
@@ -1,0 +1,172 @@
+package web.controller
+
+import database.economy.Highlow
+import database.service.HighlowService
+import database.service.HighlowService.PlayOutcome
+import database.service.UserService
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import jakarta.servlet.http.HttpSession
+import net.dv8tion.jda.api.JDA
+import net.dv8tion.jda.api.entities.Guild
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.security.oauth2.core.user.OAuth2User
+import org.springframework.ui.ConcurrentModel
+import org.springframework.web.servlet.mvc.support.RedirectAttributesModelMap
+import web.service.EconomyWebService
+
+class HighlowControllerTest {
+
+    private val guildId = 42L
+    private val discordId = 100L
+    private val anchorKey = "highlow.anchor.$guildId"
+
+    private lateinit var highlowService: HighlowService
+    private lateinit var economyWebService: EconomyWebService
+    private lateinit var userService: UserService
+    private lateinit var jda: JDA
+    private lateinit var user: OAuth2User
+    private lateinit var session: HttpSession
+    private lateinit var controller: HighlowController
+
+    @BeforeEach
+    fun setup() {
+        highlowService = mockk(relaxed = true)
+        economyWebService = mockk(relaxed = true)
+        userService = mockk(relaxed = true)
+        jda = mockk(relaxed = true)
+        user = mockk {
+            every { getAttribute<String>("id") } returns discordId.toString()
+            every { getAttribute<String>("username") } returns "tester"
+        }
+        // Lightweight in-memory session — only get/set/remove are exercised.
+        session = inMemorySession()
+
+        every { economyWebService.isMember(discordId, guildId) } returns true
+        val guild = mockk<Guild>(relaxed = true).also {
+            every { it.name } returns "Test Guild"
+        }
+        every { jda.getGuildById(guildId) } returns guild
+
+        controller = HighlowController(highlowService, economyWebService, userService, jda)
+    }
+
+    @Test
+    fun `GET draws an anchor on first hit and stores it in session`() {
+        every { highlowService.dealAnchor() } returns 7
+
+        val view = controller.page(guildId, user, session, ConcurrentModel(), RedirectAttributesModelMap())
+
+        assertEquals("highlow", view)
+        assertEquals(7, session.getAttribute(anchorKey))
+        verify(exactly = 1) { highlowService.dealAnchor() }
+    }
+
+    @Test
+    fun `GET reuses the session anchor on subsequent hits without redrawing`() {
+        session.setAttribute(anchorKey, 11)
+
+        controller.page(guildId, user, session, ConcurrentModel(), RedirectAttributesModelMap())
+
+        verify(exactly = 0) { highlowService.dealAnchor() }
+        assertEquals(11, session.getAttribute(anchorKey))
+    }
+
+    @Test
+    fun `POST without an active anchor returns 400`() {
+        val response = controller.play(
+            guildId,
+            PlayRequest(direction = "HIGHER", stake = 50L),
+            user,
+            session
+        )
+
+        assertEquals(400, response.statusCode.value())
+        assertEquals(false, response.body!!.ok)
+        assertTrue(response.body!!.error!!.contains("No active round"))
+        verify(exactly = 0) { highlowService.play(any(), any(), any(), any(), any<Int>()) }
+    }
+
+    @Test
+    fun `POST consumes the session anchor and seeds a new one for the next round`() {
+        session.setAttribute(anchorKey, 5)
+        every {
+            highlowService.play(discordId, guildId, 50L, Highlow.Direction.HIGHER, 5)
+        } returns PlayOutcome.Win(
+            stake = 50L, payout = 100L, net = 50L,
+            anchor = 5, next = 12,
+            direction = Highlow.Direction.HIGHER,
+            newBalance = 1_050L
+        )
+        every { highlowService.dealAnchor() } returns 9
+
+        val response = controller.play(
+            guildId,
+            PlayRequest(direction = "HIGHER", stake = 50L),
+            user,
+            session
+        )
+
+        assertTrue(response.statusCode.is2xxSuccessful)
+        val body = response.body!!
+        assertEquals(true, body.win)
+        assertEquals(5, body.anchor)
+        assertEquals(12, body.next)
+        assertEquals(9, body.nextAnchor, "next round's anchor must be in the response")
+        assertEquals(9, session.getAttribute(anchorKey), "session must hold the new anchor")
+    }
+
+    @Test
+    fun `POST with insufficient credits keeps the session anchor in place for retry`() {
+        session.setAttribute(anchorKey, 6)
+        every { highlowService.play(discordId, guildId, 9_999L, Highlow.Direction.HIGHER, 6) } returns
+            PlayOutcome.InsufficientCredits(stake = 9_999L, have = 100L)
+
+        val response = controller.play(
+            guildId,
+            PlayRequest(direction = "HIGHER", stake = 9_999L),
+            user,
+            session
+        )
+
+        assertEquals(400, response.statusCode.value())
+        assertEquals(6, session.getAttribute(anchorKey), "anchor stays so the user can correct stake and retry")
+        assertNull(response.body!!.nextAnchor)
+        verify(exactly = 0) { highlowService.dealAnchor() }
+    }
+
+    @Test
+    fun `POST with invalid direction returns 400 without touching the service`() {
+        session.setAttribute(anchorKey, 4)
+
+        val response = controller.play(
+            guildId,
+            PlayRequest(direction = "SIDEWAYS", stake = 50L),
+            user,
+            session
+        )
+
+        assertEquals(400, response.statusCode.value())
+        assertNotNull(response.body!!.error)
+        verify(exactly = 0) { highlowService.play(any(), any(), any(), any(), any<Int>()) }
+    }
+
+    private fun inMemorySession(): HttpSession {
+        val store = HashMap<String, Any?>()
+        return mockk(relaxed = true) {
+            every { getAttribute(any()) } answers { store[firstArg()] }
+            every { setAttribute(any(), any()) } answers {
+                store[firstArg()] = secondArg()
+            }
+            every { removeAttribute(any()) } answers {
+                store.remove(firstArg<String>())
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Web `/highlow` revealed both cards together with a shared shuffle animation — the player never got to see the anchor before betting. The single `play(direction, stake)` server call always re-drew both cards. So in practice "high-low" played like a coin-flip-with-extra-steps.

This PR splits the flow on the web side only:

- Page-load shows the **anchor card** server-side. It's pinned to the user's session keyed by guild, so refreshing won't reroll a fresh card (which would otherwise let the player pick favourable anchors before committing).
- "Deal" submits direction + stake; the server uses the session anchor and only draws the **next** card.
- The response carries the next round's anchor, which the JS rolls into the anchor slot after a short pause so play continues without a refresh.
- Discord `/highlow` keeps its bundled-draw behaviour — same `Highlow.play(direction, random)` API.

## Implementation notes

- `Highlow.play()` still exists; new `Highlow.dealAnchor()` + `Highlow.resolve(anchor, direction, random)` split the same logic so both flows share it.
- `HighlowService.play(...,anchor)` overload threads a pre-drawn anchor through `WagerHelper.checkAndLock` + `applyMultiplier`.
- The anchor is only consumed on a **settled** outcome (Win/Lose). Validation rejections (invalid stake, insufficient credits, unknown user) leave the same anchor in place so the player can correct stake and retry without losing the card they were looking at.

## Tests

- `HighlowTest` — `dealAnchor` range, `resolve` anchor pass-through, tie-loses on resolve, range guard on bad anchor.
- `HighlowServiceTest` — new `play(...,anchor)` overload delegates to `resolve` (not the bundled `play`); `dealAnchor` doesn't touch the user.
- New `HighlowControllerTest` — session lifecycle: GET draws lazily, GET reuses, POST without anchor → 400, POST consumes + seeds next round, POST with insufficient credits keeps the anchor in place.
- Full `:web:test` and `:database:test` green locally.

## Test plan
- [x] `:database:test --tests HighlowTest --tests HighlowServiceTest`
- [x] `:web:test`
- [ ] Manual: open `/casino/{guildId}/highlow`. Anchor must show a real card on load. Refresh — same anchor. Deal — only the next card animates; result renders against the anchor; after ~1.2 s the new round's anchor appears.
- [ ] Manual: bet more than balance → 400 "Need X credits". Anchor stays. Reduce stake and retry — still the same anchor, then a clean win/loss.
- [ ] Discord `/highlow stake:50 direction:HIGHER` still resolves in one shot.

https://claude.ai/code/session_01JvuveFBoCvMFTK8XxXVN56

---
_Generated by [Claude Code](https://claude.ai/code/session_01JvuveFBoCvMFTK8XxXVN56)_