### PR TITLE
fix(navbar): bridge dropdown hover gap so menus stay open

### DIFF
--- a/web/src/main/resources/static/css/nav.css
+++ b/web/src/main/resources/static/css/nav.css
@@ -85,6 +85,16 @@ nav {
 }
 .nav-dropdown:hover .nav-dropdown-menu,
 .nav-dropdown.open .nav-dropdown-menu { display: flex; }
+/* Transparent bridge across the 8px gap between toggle and menu so the
+   cursor can travel from button to menu items without dropping :hover. */
+.nav-dropdown-menu::before {
+    content: "";
+    position: absolute;
+    top: -8px;
+    left: 0;
+    right: 0;
+    height: 8px;
+}
 .nav-dropdown-menu a,
 .nav-dropdown-menu .nav-dropdown-coming-soon {
     padding: 8px 16px;
@@ -118,6 +128,8 @@ nav {
         box-shadow: none;
         min-width: 0;
     }
+    /* No gap to bridge in the inline mobile layout. */
+    .nav-dropdown-menu::before { content: none; }
     .nav-dropdown-menu a, .nav-dropdown-menu .nav-dropdown-coming-soon {
         padding: 8px 4px;
         min-height: 36px;


### PR DESCRIPTION
## Summary

The Economy / Casino dropdowns in the navbar are supposed to open on `:hover`, but the menu sits 8px below the toggle (`margin-top: 8px`). When the cursor moves from the button down toward a menu item, it crosses that 8px gap where neither the button nor the menu is hovered — `.nav-dropdown:hover` drops, and the menu disappears mid-motion. Users have been clicking the toggle to "anchor" the menu open, which is unintuitive (the toggle has no `href` and doesn't navigate).

This PR fixes the hover dead-zone with a CSS-only change:

- Add a transparent `::before` pseudo-element on `.nav-dropdown-menu` that fills the 8px gap above it. The cursor traveling through the gap now stays inside the dropdown's hover region, so the menu stays open until the cursor lands on a child link.
- Neutralize the bridge inside the `@media (max-width: 600px)` block (mobile renders the menu inline, so there's no gap to bridge).
- The visible 8px gap is preserved (the bridge is transparent) and the click-toggle JS path is untouched, so keyboard / touch users keep their existing fallback.

No HTML or JS changes; the existing `web/src/test/js/navbar.test.js` checks structure only and still passes (85/85 tests green).

## Test plan

- [ ] `cd web && npm test` — Jest suite passes.
- [ ] Run the web module locally and load any page with the navbar fragment.
- [ ] Hover "Economy": menu opens; move the cursor straight down through the gap onto Market / Titles — menu stays open the whole way.
- [ ] Repeat for "Casino" with all five game links.
- [ ] Click "Economy" without hovering: existing click-toggle behavior unchanged (click outside closes, Esc closes).
- [ ] Resize to ≤600px: dropdowns render inline below the toggle as before; no phantom hover strip or layout gap above the items.

https://claude.ai/code/session_01KxfHNiKG8sAA4YZvYTKgDm

---
_Generated by [Claude Code](https://claude.ai/code/session_01KxfHNiKG8sAA4YZvYTKgDm)_