### PR TITLE
fix(economy): close buy/sell round-trip exploit + scrollable trade history

### DIFF
--- a/application/src/test/kotlin/integration/database/EconomyTradeServiceIntegrationTest.kt
+++ b/application/src/test/kotlin/integration/database/EconomyTradeServiceIntegrationTest.kt
@@ -103,15 +103,19 @@ class EconomyTradeServiceIntegrationTest {
         assertEquals(openingHistorySize + 1, samples.size, "one sample should be appended")
         assertEquals(market.price, samples.last().price, 1e-9)
 
-        // Trade ledger: one row recorded with the PRE-pressure price (so the
-        // market chart marker shows what the user paid, not the post-trade price).
+        // Trade ledger: one row recorded with the MIDPOINT price (the
+        // average of pre- and post-pressure — what the trader actually
+        // paid per coin once slippage is accounted for).
         val trades = marketService.listTradesSince(fx.guildId, java.time.Instant.EPOCH)
         assertEquals(1, trades.size, "buy should record exactly one trade row")
         val trade = trades.single()
         assertEquals("BUY", trade.side)
         assertEquals(5L, trade.amount)
         assertEquals(fx.discordId, trade.discordId)
-        assertEquals(openingPrice, trade.pricePerCoin, 1e-9, "marker must show pre-pressure price")
+        val expectedMidpoint = (openingPrice + market.price) / 2.0
+        assertEquals(expectedMidpoint, trade.pricePerCoin, 1e-9, "marker must show midpoint fill price")
+        assertTrue(trade.pricePerCoin > openingPrice, "midpoint above pre-pressure for a buy")
+        assertTrue(trade.pricePerCoin < market.price, "midpoint below post-pressure for a buy")
     }
 
     @Test
@@ -187,6 +191,32 @@ class EconomyTradeServiceIntegrationTest {
 
         assertInstanceOf(TradeOutcome.InvalidAmount::class.java, tradeService.buy(fx.discordId, fx.guildId, 0L))
         assertInstanceOf(TradeOutcome.InvalidAmount::class.java, tradeService.sell(fx.discordId, fx.guildId, -5L))
+    }
+
+    /**
+     * Regression guard for the buy/sell round-trip exploit. Before
+     * midpoint pricing, a trader could buy N coins at the pre-pressure
+     * price, then immediately sell them at the (pumped) post-pressure
+     * price — pocketing roughly `TRADE_IMPACT × N² × P` credits per
+     * round-trip. With midpoint fills both legs eat half the slippage,
+     * so the round-trip is guaranteed to net non-positive.
+     */
+    @Test
+    fun `buy then immediate sell does not net credits`() {
+        // 1000 coins @ P0=100 used to print +10k credits; pick a budget
+        // big enough to make the exploit visible if it regressed.
+        val fx = newFixture(openingCredits = 200_000L)
+        tradeService.loadOrCreateMarket(fx.guildId)
+
+        val openingCredits = userService.getUserById(fx.discordId, fx.guildId)!!.socialCredit ?: 0L
+
+        assertInstanceOf(TradeOutcome.Ok::class.java, tradeService.buy(fx.discordId, fx.guildId, 1_000L))
+        assertInstanceOf(TradeOutcome.Ok::class.java, tradeService.sell(fx.discordId, fx.guildId, 1_000L))
+
+        val finalUser = userService.getUserById(fx.discordId, fx.guildId)!!
+        assertEquals(0L, finalUser.tobyCoins)
+        val net = (finalUser.socialCredit ?: 0L) - openingCredits
+        assertTrue(net <= 0L, "round-trip must net non-positive (was $net)")
     }
 
     /**

--- a/database/src/main/kotlin/database/service/EconomyTradeService.kt
+++ b/database/src/main/kotlin/database/service/EconomyTradeService.kt
@@ -21,6 +21,17 @@ import kotlin.math.floor
  * user balances + market price + history append, and returns a
  * descriptive result so the caller can render messaging in whatever
  * form suits (Discord embed, web JSON, etc.).
+ *
+ * Pricing: trades execute at the **midpoint** of the pre-pressure and
+ * post-pressure prices, i.e. the average price the trader's order
+ * walks across as it consumes liquidity. Without this — when buys paid
+ * the pre-pressure price and sells received the post-pressure price —
+ * a buy-then-immediate-sell of N coins printed `TRADE_IMPACT × N² × P`
+ * credits per round-trip (with N=1000 / P=100 / k=0.0001 that's 10k
+ * credits a cycle, the live exploit this service was patched to
+ * close). Midpoint slips the trader by half the impact on each leg,
+ * which is what real markets approximate via "average fill price"
+ * anyway, and it makes round-trips a strict net loss.
  */
 @Service
 @Transactional
@@ -67,9 +78,12 @@ class EconomyTradeService(
             ?: return TradeOutcome.UnknownUser
         val market = loadOrCreateMarketForUpdate(guildId)
 
-        // Capture pre-pressure price so the recorded trade reflects what
-        // the trader actually paid per coin, not the post-trade price.
-        val executionPrice = market.price
+        val prePrice = market.price
+        val newPrice = TobyCoinEngine.applyBuyPressure(prePrice, amount)
+        // Midpoint fill — the trader pays the average of the pre- and
+        // post-pressure prices, eating half the slippage they cause.
+        // See class kdoc for why this exists.
+        val executionPrice = (prePrice + newPrice) / 2.0
         val cost = ceil(executionPrice * amount).toLong()
         val credits = user.socialCredit ?: 0L
         if (credits < cost) return TradeOutcome.InsufficientCredits(cost, credits)
@@ -78,7 +92,6 @@ class EconomyTradeService(
         user.tobyCoins += amount
         userService.updateUser(user)
 
-        val newPrice = TobyCoinEngine.applyBuyPressure(executionPrice, amount)
         commitPriceChange(market, newPrice, executionPrice, discordId, "BUY", amount)
 
         return TradeOutcome.Ok(
@@ -99,13 +112,16 @@ class EconomyTradeService(
 
         if (user.tobyCoins < amount) return TradeOutcome.InsufficientCoins(amount, user.tobyCoins)
 
-        val executionPrice = market.price
+        val prePrice = market.price
+        val newPrice = TobyCoinEngine.applySellPressure(prePrice, amount)
+        // Midpoint fill — the trader receives the average of the pre- and
+        // post-pressure prices, paying half the slippage they cause.
+        val executionPrice = (prePrice + newPrice) / 2.0
         val proceeds = floor(executionPrice * amount).toLong()
         user.tobyCoins -= amount
         user.socialCredit = (user.socialCredit ?: 0L) + proceeds
         userService.updateUser(user)
 
-        val newPrice = TobyCoinEngine.applySellPressure(executionPrice, amount)
         commitPriceChange(market, newPrice, executionPrice, discordId, "SELL", amount)
 
         return TradeOutcome.Ok(

--- a/web/src/main/kotlin/web/service/TitlesWebService.kt
+++ b/web/src/main/kotlin/web/service/TitlesWebService.kt
@@ -8,10 +8,12 @@ import database.service.EconomyTradeService.TradeOutcome
 import database.service.TitleService
 import database.service.TobyCoinMarketService
 import database.service.UserService
+import database.economy.TobyCoinEngine
 import net.dv8tion.jda.api.JDA
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import kotlin.math.ceil
+import kotlin.math.floor
 
 @Service
 class TitlesWebService(
@@ -135,7 +137,12 @@ class TitlesWebService(
             if (market.price <= 0.0) {
                 return BuyWithTobyOutcome.Error("Market price is not available right now.")
             }
-            val coinsNeeded = ceil(shortfall.toDouble() / market.price).toLong()
+            // EconomyTradeService now fills sells at the midpoint of pre-
+            // and post-pressure prices (slippage). The naive
+            // `ceil(shortfall / market.price)` underestimates the coins
+            // needed by 1 because proceeds = floor(N×P×(1 − k×N/2)).
+            // Bump until proceeds-at-midpoint cover the shortfall.
+            val coinsNeeded = coinsNeededForShortfall(shortfall, market.price)
             if (actor.tobyCoins < coinsNeeded) {
                 return BuyWithTobyOutcome.InsufficientCoins(needed = coinsNeeded, have = actor.tobyCoins)
             }
@@ -164,6 +171,27 @@ class TitlesWebService(
             newCredits = refreshed.socialCredit ?: 0L,
             newPrice = priceAfterSell
         )
+    }
+
+    /**
+     * Smallest coin count whose midpoint-price proceeds cover [shortfall].
+     * Closed-form would be a quadratic; in practice the naive
+     * `ceil(shortfall / price)` is at most one coin short of correct, so
+     * we bump iteratively. Bounded for safety against extreme `k×N`.
+     */
+    private fun coinsNeededForShortfall(shortfall: Long, price: Double): Long {
+        var n = ceil(shortfall.toDouble() / price).toLong().coerceAtLeast(1L)
+        repeat(8) {
+            if (proceedsAtMidpoint(n, price) >= shortfall) return n
+            n += 1L
+        }
+        return n
+    }
+
+    private fun proceedsAtMidpoint(coins: Long, price: Double): Long {
+        val newPrice = TobyCoinEngine.applySellPressure(price, coins)
+        val midpoint = (price + newPrice) / 2.0
+        return floor(midpoint * coins).toLong()
     }
 
     fun equipTitle(actorDiscordId: Long, guildId: Long, titleId: Long): String? {

--- a/web/src/main/resources/static/css/economy.css
+++ b/web/src/main/resources/static/css/economy.css
@@ -146,6 +146,26 @@
     display: flex;
     flex-direction: column;
     gap: var(--space-2);
+    /* Cap the visible height — once the list grows past ~6 rows, it
+       scrolls in place rather than pushing the rest of the page down. */
+    max-height: 320px;
+    overflow-y: auto;
+    /* Keep the bottom border off the scrollbar gutter on Firefox. */
+    scrollbar-width: thin;
+    /* Subtle inner shadow at the edges hints at scrollable overflow. */
+    background:
+        linear-gradient(var(--surface) 30%, rgba(22, 33, 62, 0)) center top,
+        linear-gradient(rgba(22, 33, 62, 0), var(--surface) 70%) center bottom,
+        radial-gradient(farthest-side at 50% 0, rgba(0, 0, 0, 0.25), rgba(0, 0, 0, 0)) center top,
+        radial-gradient(farthest-side at 50% 100%, rgba(0, 0, 0, 0.25), rgba(0, 0, 0, 0)) center bottom;
+    background-repeat: no-repeat;
+    background-size: 100% 24px, 100% 24px, 100% 8px, 100% 8px;
+    background-attachment: local, local, scroll, scroll;
+}
+.economy-recent-trades::-webkit-scrollbar { width: 6px; }
+.economy-recent-trades::-webkit-scrollbar-thumb {
+    background: var(--border);
+    border-radius: 3px;
 }
 
 .economy-trade-row {

--- a/web/src/main/resources/static/js/economy.js
+++ b/web/src/main/resources/static/js/economy.js
@@ -21,7 +21,9 @@
     const windowButtons = document.querySelectorAll('#economy-windows button');
     const recentTradesPanel = document.getElementById('economy-recent-trades-panel');
     const recentTradesList = document.getElementById('economy-recent-trades');
-    const RECENT_TRADES_LIMIT = 20;
+    // Cap is generous — the panel scrolls (see economy.css), so the
+    // only ceiling is rendering cost on very busy markets.
+    const RECENT_TRADES_LIMIT = 100;
 
     const BUY_COLOR = '#57F287';
     const SELL_COLOR = '#ED4245';

--- a/web/src/test/kotlin/web/service/TitlesWebServicePurchaseTest.kt
+++ b/web/src/test/kotlin/web/service/TitlesWebServicePurchaseTest.kt
@@ -62,41 +62,44 @@ class TitlesWebServicePurchaseTest {
     private fun market(price: Double) = TobyCoinMarketDto(guildId = guildId, price = price, lastTickAt = Instant.now())
 
     @Test
-    fun `pure-TOBY path sells exactly ceil(cost price) coins`() {
+    fun `pure-TOBY path sells enough coins to cover the shortfall under midpoint pricing`() {
         val title = TitleDto(id = 9L, label = "Gold", cost = 500L)
         val actor = UserDto(discordId = discordId, guildId = guildId).apply {
             socialCredit = 0L
-            tobyCoins = 1_000L  // plenty to cover ceil(500/2.5) = 200
+            // ceil(500/2.5) = 200, but under midpoint slippage the
+            // proceeds for 200 coins fall to 495 (5 short of cost).
+            // The compensator bumps to 203 — first N whose midpoint
+            // proceeds clear 500.
+            tobyCoins = 1_000L
         }
         every { titleService.getById(9L) } returns title
         every { titleService.owns(discordId, 9L) } returns false
         every { userService.getUserByIdForUpdate(discordId, guildId) } returns actor
         every { marketService.getMarketForUpdate(guildId) } returns market(2.5)
-        // sell adjusts the mocked user in-memory so the re-read sees new values
-        every { tradeService.sell(discordId, guildId, 200L) } answers {
-            actor.socialCredit = 500L
-            actor.tobyCoins -= 200L
+        every { tradeService.sell(discordId, guildId, 203L) } answers {
+            actor.socialCredit = 502L  // proceeds at midpoint for N=203 / P=2.5
+            actor.tobyCoins -= 203L
             TradeOutcome.Ok(
-                amount = 200L,
-                transactedCredits = 500L,
+                amount = 203L,
+                transactedCredits = 502L,
                 newCoins = actor.tobyCoins,
                 newCredits = actor.socialCredit ?: 0L,
-                newPrice = 2.49
+                newPrice = 2.4495
             )
         }
 
         val outcome = service.buyTitleWithTobyCoin(discordId, guildId, 9L)
 
         val ok = assertInstanceOf(BuyWithTobyOutcome.Ok::class.java, outcome)
-        assertEquals(200L, ok.soldTobyCoins, "ceil(500/2.5) = 200")
-        assertEquals(0L, ok.newCredits, "credits = 500 sold - 500 cost")
-        assertEquals(2.49, ok.newPrice, 1e-9)
-        verify(exactly = 1) { tradeService.sell(discordId, guildId, 200L) }
+        assertEquals(203L, ok.soldTobyCoins, "midpoint slippage adds 3 to ceil(500/2.5)")
+        assertEquals(2L, ok.newCredits, "credits = 502 sold − 500 cost")
+        assertEquals(2.4495, ok.newPrice, 1e-9)
+        verify(exactly = 1) { tradeService.sell(discordId, guildId, 203L) }
         verify(exactly = 1) { titleService.recordPurchase(discordId, 9L) }
     }
 
     @Test
-    fun `top-up path sells just the shortfall`() {
+    fun `top-up path sells enough to cover the shortfall under midpoint pricing`() {
         val title = TitleDto(id = 9L, label = "Gold", cost = 500L)
         val actor = UserDto(discordId = discordId, guildId = guildId).apply {
             socialCredit = 200L
@@ -106,26 +109,28 @@ class TitlesWebServicePurchaseTest {
         every { titleService.owns(discordId, 9L) } returns false
         every { userService.getUserByIdForUpdate(discordId, guildId) } returns actor
         every { marketService.getMarketForUpdate(guildId) } returns market(10.0)
-        // shortfall = 500 - 200 = 300, price = 10 → 30 coins needed
-        every { tradeService.sell(discordId, guildId, 30L) } answers {
-            actor.socialCredit = (actor.socialCredit ?: 0L) + 300L
-            actor.tobyCoins -= 30L
+        // shortfall = 500 − 200 = 300, price = 10. ceil(300/10) = 30, but
+        // midpoint proceeds for N=30 fall to 299 — slippage compensator
+        // bumps to 31.
+        every { tradeService.sell(discordId, guildId, 31L) } answers {
+            actor.socialCredit = (actor.socialCredit ?: 0L) + 309L  // midpoint proceeds at N=31, P=10
+            actor.tobyCoins -= 31L
             TradeOutcome.Ok(
-                amount = 30L,
-                transactedCredits = 300L,
+                amount = 31L,
+                transactedCredits = 309L,
                 newCoins = actor.tobyCoins,
                 newCredits = actor.socialCredit ?: 0L,
-                newPrice = 9.7
+                newPrice = 9.969
             )
         }
 
         val outcome = service.buyTitleWithTobyCoin(discordId, guildId, 9L)
 
         val ok = assertInstanceOf(BuyWithTobyOutcome.Ok::class.java, outcome)
-        assertEquals(30L, ok.soldTobyCoins)
-        assertEquals(0L, ok.newCredits, "200 + 300 - 500 = 0")
-        assertEquals(70L, ok.newCoins, "100 TOBY - 30 sold")
-        verify(exactly = 1) { tradeService.sell(discordId, guildId, 30L) }
+        assertEquals(31L, ok.soldTobyCoins)
+        assertEquals(9L, ok.newCredits, "200 + 309 − 500 = 9 (slippage delta lands in the leftover credits)")
+        assertEquals(69L, ok.newCoins, "100 TOBY − 31 sold")
+        verify(exactly = 1) { tradeService.sell(discordId, guildId, 31L) }
     }
 
     @Test
@@ -151,7 +156,7 @@ class TitlesWebServicePurchaseTest {
     }
 
     @Test
-    fun `insufficient TOBY reports needed vs have without touching state`() {
+    fun `insufficient TOBY reports slippage-adjusted needed vs have without touching state`() {
         val title = TitleDto(id = 9L, label = "Gold", cost = 500L)
         val actor = UserDto(discordId = discordId, guildId = guildId).apply {
             socialCredit = 0L
@@ -165,7 +170,7 @@ class TitlesWebServicePurchaseTest {
         val outcome = service.buyTitleWithTobyCoin(discordId, guildId, 9L)
 
         val insufficient = assertInstanceOf(BuyWithTobyOutcome.InsufficientCoins::class.java, outcome)
-        assertEquals(200L, insufficient.needed)
+        assertEquals(203L, insufficient.needed, "midpoint slippage compensator bumps ceil(500/2.5)=200 to 203")
         assertEquals(5L, insufficient.have)
         verify(exactly = 0) { tradeService.sell(any(), any(), any()) }
         verify(exactly = 0) { titleService.recordPurchase(any(), any()) }


### PR DESCRIPTION
## Summary

**Live exploit, fixed.** A trader could buy `N` coins at the pre-pressure price, then immediately sell them at the (now pumped) post-pressure price — pocketing roughly `TRADE_IMPACT × N² × P` credits per round-trip. At `N=1000` / `P=100` / `k=0.0001` that's **10k credits per cycle**, repeatable.

`EconomyTradeService` now executes both legs at the **midpoint** of the pre- and post-pressure prices — the trader eats half the slippage they cause on each leg. Round-trips become a strict net loss at any `N`. The recorded trade `price_per_coin` is now the midpoint (i.e. the actual fill the trader saw), not the pre-pressure quote.

Bundled in (related, small):
- `TitlesWebService.buyTitleWithTobyCoin` slippage compensator: `ceil(shortfall/price)` under-counts coins needed by ~1 under midpoint pricing, so the service bumps iteratively (bounded, ≤8 steps) until midpoint proceeds cover the cost.
- The `/economy` recent-trades list now scrolls in place (`max-height: 320px`, custom thin scrollbar). `RECENT_TRADES_LIMIT` bumped 20→100 so the panel has more to scroll through.

## Math

- Pre-fix: trader pays `ceil(P×N)` to buy, receives `floor(P×(1+kN)×N)` to sell instantly. Profit `≈ k × P × N²`.
- Post-fix: trader pays `ceil(P×(1+kN/2)×N)`, receives `floor(P×(1-kN/2)×N×(1+kN))` after sell pumps. Net `≈ -k²×P×N²/2` — strictly negative for any `N≥1` once ceil/floor lands.

## Follow-ups (separate PRs)
- Trade fee → jackpot pool (gameplay layer; in-flight next).
- Casino top-up via TOBY (sell coins to fund a bet, like Titles' "Buy with TOBY").

## Test plan
- [x] `EconomyTradeServiceIntegrationTest` — assertion now expects midpoint on the recorded trade row; new regression test asserts buy-then-sell of 1000 coins nets non-positive.
- [x] `TitlesWebServicePurchaseTest` — three cases updated for slippage-compensated `coinsNeeded` (200→203 at P=2.5, 30→31 at P=10).
- [x] `:web:test` full suite — 148/148 green offline.
- [ ] Manual: open `/casino/{guildId}` (when bot is up), buy then immediately sell N coins — verify final balance is < starting balance, not >.
- [ ] Manual: visit `/economy/{guildId}` with >6 trades — confirm the recent-trades list scrolls within its panel.

https://claude.ai/code/session_01JvuveFBoCvMFTK8XxXVN56

---
_Generated by [Claude Code](https://claude.ai/code/session_01JvuveFBoCvMFTK8XxXVN56)_