### PR TITLE
feat(economy): trade fees fund a per-guild jackpot pool, casino wins can hit it

### DIFF
--- a/database/src/main/kotlin/database/dto/TobyCoinJackpotDto.kt
+++ b/database/src/main/kotlin/database/dto/TobyCoinJackpotDto.kt
@@ -1,0 +1,28 @@
+package database.dto
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.NamedQueries
+import jakarta.persistence.NamedQuery
+import jakarta.persistence.Table
+import org.springframework.transaction.annotation.Transactional
+import java.io.Serializable
+
+@NamedQueries(
+    NamedQuery(
+        name = "TobyCoinJackpotDto.getByGuild",
+        query = "select j from TobyCoinJackpotDto j where j.guildId = :guildId"
+    )
+)
+@Entity
+@Table(name = "toby_coin_jackpot", schema = "public")
+@Transactional
+class TobyCoinJackpotDto(
+    @Id
+    @Column(name = "guild_id")
+    var guildId: Long = 0,
+
+    @Column(name = "pool", nullable = false)
+    var pool: Long = 0
+) : Serializable

--- a/database/src/main/kotlin/database/economy/TobyCoinEngine.kt
+++ b/database/src/main/kotlin/database/economy/TobyCoinEngine.kt
@@ -48,6 +48,16 @@ object TobyCoinEngine {
      */
     const val TRADE_IMPACT = 0.0001
 
+    /**
+     * Flat fee charged on each trade leg. The fee is skimmed off the
+     * trader's payment (or proceeds) and routed into the per-guild
+     * jackpot pool, which casino minigame wins can hit for a payout.
+     * 1 % per leg means a buy-then-sell round trip pays ~2 % to the
+     * pool, which together with midpoint pricing makes the
+     * round-trip exploit unprofitable at any size and seeds gameplay.
+     */
+    const val TRADE_FEE = 0.01
+
     private const val SECONDS_PER_YEAR = 365.0 * 24.0 * 60.0 * 60.0
 
     /**

--- a/database/src/main/kotlin/database/persistence/TobyCoinJackpotPersistence.kt
+++ b/database/src/main/kotlin/database/persistence/TobyCoinJackpotPersistence.kt
@@ -1,0 +1,12 @@
+package database.persistence
+
+import database.dto.TobyCoinJackpotDto
+
+interface TobyCoinJackpotPersistence {
+    fun getByGuild(guildId: Long): TobyCoinJackpotDto?
+
+    /** SELECT … FOR UPDATE. Only call inside an active @Transactional. */
+    fun getByGuildForUpdate(guildId: Long): TobyCoinJackpotDto?
+
+    fun upsert(jackpot: TobyCoinJackpotDto): TobyCoinJackpotDto
+}

--- a/database/src/main/kotlin/database/persistence/impl/DefaultTobyCoinJackpotPersistence.kt
+++ b/database/src/main/kotlin/database/persistence/impl/DefaultTobyCoinJackpotPersistence.kt
@@ -1,0 +1,45 @@
+package database.persistence.impl
+
+import database.dto.TobyCoinJackpotDto
+import database.persistence.TobyCoinJackpotPersistence
+import jakarta.persistence.EntityManager
+import jakarta.persistence.LockModeType
+import jakarta.persistence.PersistenceContext
+import jakarta.persistence.TypedQuery
+import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
+
+@Repository
+@Transactional
+class DefaultTobyCoinJackpotPersistence : TobyCoinJackpotPersistence {
+    @PersistenceContext
+    private lateinit var entityManager: EntityManager
+
+    override fun getByGuild(guildId: Long): TobyCoinJackpotDto? {
+        val q: TypedQuery<TobyCoinJackpotDto> = entityManager.createNamedQuery(
+            "TobyCoinJackpotDto.getByGuild", TobyCoinJackpotDto::class.java
+        )
+        q.setParameter("guildId", guildId)
+        return runCatching { q.singleResult }.getOrNull()
+    }
+
+    override fun getByGuildForUpdate(guildId: Long): TobyCoinJackpotDto? {
+        return entityManager.find(
+            TobyCoinJackpotDto::class.java,
+            guildId,
+            LockModeType.PESSIMISTIC_WRITE
+        )
+    }
+
+    override fun upsert(jackpot: TobyCoinJackpotDto): TobyCoinJackpotDto {
+        val existing = entityManager.find(TobyCoinJackpotDto::class.java, jackpot.guildId)
+        val saved = if (existing == null) {
+            entityManager.persist(jackpot)
+            jackpot
+        } else {
+            entityManager.merge(jackpot)
+        }
+        entityManager.flush()
+        return saved
+    }
+}

--- a/database/src/main/kotlin/database/service/CoinflipService.kt
+++ b/database/src/main/kotlin/database/service/CoinflipService.kt
@@ -16,6 +16,7 @@ import kotlin.random.Random
 @Transactional
 class CoinflipService(
     private val userService: UserService,
+    private val jackpotService: JackpotService,
     private val coinflip: Coinflip = Coinflip(),
     private val random: Random = Random.Default
 ) {
@@ -27,7 +28,8 @@ class CoinflipService(
             val net: Long,
             val landed: Coinflip.Side,
             val predicted: Coinflip.Side,
-            val newBalance: Long
+            val newBalance: Long,
+            val jackpotPayout: Long = 0L
         ) : FlipOutcome
 
         data class Lose(
@@ -53,13 +55,15 @@ class CoinflipService(
                 val flip = coinflip.flip(predicted, random)
                 val r = WagerHelper.applyMultiplier(userService, check.user, check.balance, stake, flip.multiplier)
                 if (flip.isWin) {
+                    val jackpot = JackpotHelper.rollOnWin(jackpotService, userService, check.user, guildId, random)
                     FlipOutcome.Win(
                         stake = stake,
                         payout = r.payout,
                         net = r.net,
                         landed = flip.landed,
                         predicted = flip.predicted,
-                        newBalance = r.newBalance
+                        newBalance = r.newBalance + jackpot,
+                        jackpotPayout = jackpot
                     )
                 } else {
                     FlipOutcome.Lose(

--- a/database/src/main/kotlin/database/service/DiceService.kt
+++ b/database/src/main/kotlin/database/service/DiceService.kt
@@ -15,6 +15,7 @@ import kotlin.random.Random
 @Transactional
 class DiceService(
     private val userService: UserService,
+    private val jackpotService: JackpotService,
     private val dice: Dice = Dice(),
     private val random: Random = Random.Default
 ) {
@@ -26,7 +27,8 @@ class DiceService(
             val net: Long,
             val landed: Int,
             val predicted: Int,
-            val newBalance: Long
+            val newBalance: Long,
+            val jackpotPayout: Long = 0L
         ) : RollOutcome
 
         data class Lose(
@@ -56,13 +58,15 @@ class DiceService(
                 val roll = dice.roll(predicted, random)
                 val r = WagerHelper.applyMultiplier(userService, check.user, check.balance, stake, roll.multiplier)
                 if (roll.isWin) {
+                    val jackpot = JackpotHelper.rollOnWin(jackpotService, userService, check.user, guildId, random)
                     RollOutcome.Win(
                         stake = stake,
                         payout = r.payout,
                         net = r.net,
                         landed = roll.landed,
                         predicted = roll.predicted,
-                        newBalance = r.newBalance
+                        newBalance = r.newBalance + jackpot,
+                        jackpotPayout = jackpot
                     )
                 } else {
                     RollOutcome.Lose(

--- a/database/src/main/kotlin/database/service/EconomyTradeService.kt
+++ b/database/src/main/kotlin/database/service/EconomyTradeService.kt
@@ -32,12 +32,18 @@ import kotlin.math.floor
  * close). Midpoint slips the trader by half the impact on each leg,
  * which is what real markets approximate via "average fill price"
  * anyway, and it makes round-trips a strict net loss.
+ *
+ * Fees: a flat [TobyCoinEngine.TRADE_FEE] is skimmed off each leg and
+ * routed into the per-guild jackpot pool ([JackpotService]). The
+ * pool is paid out to casino minigame winners that hit the jackpot
+ * roll, so trade activity directly seeds gambling rewards.
  */
 @Service
 @Transactional
 class EconomyTradeService(
     private val userService: UserService,
-    private val marketService: TobyCoinMarketService
+    private val marketService: TobyCoinMarketService,
+    private val jackpotService: JackpotService
 ) {
 
     sealed interface TradeOutcome {
@@ -46,7 +52,10 @@ class EconomyTradeService(
             val transactedCredits: Long,
             val newCoins: Long,
             val newCredits: Long,
-            val newPrice: Double
+            val newPrice: Double,
+            // Fee skimmed off this trade and routed to the jackpot pool.
+            // Defaulted so existing test fixtures keep compiling.
+            val fee: Long = 0L
         ) : TradeOutcome
 
         data class InsufficientCredits(val needed: Long, val have: Long) : TradeOutcome
@@ -80,17 +89,20 @@ class EconomyTradeService(
 
         val prePrice = market.price
         val newPrice = TobyCoinEngine.applyBuyPressure(prePrice, amount)
-        // Midpoint fill — the trader pays the average of the pre- and
-        // post-pressure prices, eating half the slippage they cause.
-        // See class kdoc for why this exists.
         val executionPrice = (prePrice + newPrice) / 2.0
-        val cost = ceil(executionPrice * amount).toLong()
+        // Buyer pays the midpoint price plus the fee on top — the fee
+        // lives in the jackpot pool, not on the user's coin allotment.
+        val gross = ceil(executionPrice * amount).toLong()
+        val fee = ceil(gross * TobyCoinEngine.TRADE_FEE).toLong()
+        val cost = gross + fee
         val credits = user.socialCredit ?: 0L
         if (credits < cost) return TradeOutcome.InsufficientCredits(cost, credits)
 
         user.socialCredit = credits - cost
         user.tobyCoins += amount
         userService.updateUser(user)
+
+        if (fee > 0L) jackpotService.addToPool(guildId, fee)
 
         commitPriceChange(market, newPrice, executionPrice, discordId, "BUY", amount)
 
@@ -99,7 +111,8 @@ class EconomyTradeService(
             transactedCredits = cost,
             newCoins = user.tobyCoins,
             newCredits = user.socialCredit ?: 0L,
-            newPrice = newPrice
+            newPrice = newPrice,
+            fee = fee
         )
     }
 
@@ -114,13 +127,17 @@ class EconomyTradeService(
 
         val prePrice = market.price
         val newPrice = TobyCoinEngine.applySellPressure(prePrice, amount)
-        // Midpoint fill — the trader receives the average of the pre- and
-        // post-pressure prices, paying half the slippage they cause.
         val executionPrice = (prePrice + newPrice) / 2.0
-        val proceeds = floor(executionPrice * amount).toLong()
+        // Seller's fee is taken off the midpoint proceeds before they
+        // hit the wallet — the fee feeds the jackpot pool.
+        val gross = floor(executionPrice * amount).toLong()
+        val fee = floor(gross * TobyCoinEngine.TRADE_FEE).toLong()
+        val proceeds = gross - fee
         user.tobyCoins -= amount
         user.socialCredit = (user.socialCredit ?: 0L) + proceeds
         userService.updateUser(user)
+
+        if (fee > 0L) jackpotService.addToPool(guildId, fee)
 
         commitPriceChange(market, newPrice, executionPrice, discordId, "SELL", amount)
 
@@ -129,7 +146,8 @@ class EconomyTradeService(
             transactedCredits = proceeds,
             newCoins = user.tobyCoins,
             newCredits = user.socialCredit ?: 0L,
-            newPrice = newPrice
+            newPrice = newPrice,
+            fee = fee
         )
     }
 

--- a/database/src/main/kotlin/database/service/HighlowService.kt
+++ b/database/src/main/kotlin/database/service/HighlowService.kt
@@ -21,6 +21,7 @@ import kotlin.random.Random
 @Transactional
 class HighlowService(
     private val userService: UserService,
+    private val jackpotService: JackpotService,
     private val highlow: Highlow = Highlow(),
     private val random: Random = Random.Default
 ) {
@@ -33,7 +34,8 @@ class HighlowService(
             val anchor: Int,
             val next: Int,
             val direction: Highlow.Direction,
-            val newBalance: Long
+            val newBalance: Long,
+            val jackpotPayout: Long = 0L
         ) : PlayOutcome
 
         data class Lose(
@@ -89,6 +91,7 @@ class HighlowService(
                 }
                 val r = WagerHelper.applyMultiplier(userService, check.user, check.balance, stake, hand.multiplier)
                 if (hand.isWin) {
+                    val jackpot = JackpotHelper.rollOnWin(jackpotService, userService, check.user, guildId, random)
                     PlayOutcome.Win(
                         stake = stake,
                         payout = r.payout,
@@ -96,7 +99,8 @@ class HighlowService(
                         anchor = hand.anchor,
                         next = hand.next,
                         direction = hand.direction,
-                        newBalance = r.newBalance
+                        newBalance = r.newBalance + jackpot,
+                        jackpotPayout = jackpot
                     )
                 } else {
                     PlayOutcome.Lose(

--- a/database/src/main/kotlin/database/service/JackpotHelper.kt
+++ b/database/src/main/kotlin/database/service/JackpotHelper.kt
@@ -1,0 +1,42 @@
+package database.service
+
+import database.dto.UserDto
+import kotlin.random.Random
+
+/**
+ * On every minigame win, roll a small probability of hitting the
+ * per-guild jackpot pool. On a hit the player banks the entire pool
+ * and the counter resets to zero — same lock-then-mutate path as the
+ * other balance changes, threaded through the user row that
+ * [WagerHelper.checkAndLock] already write-locked.
+ *
+ * Loses don't roll. The fee that funds the pool is paid on every
+ * trade leg (see [EconomyTradeService]), so the "casino wins what
+ * traders pay" loop is closed without slowing the trade path.
+ */
+internal object JackpotHelper {
+
+    /** 1% chance to hit the jackpot per minigame win. Tuned alongside the trade fee. */
+    const val WIN_PROBABILITY: Double = 0.01
+
+    /**
+     * If the random roll hits and the pool is non-empty, atomically
+     * pull the entire pool, credit it to [user] (already locked by
+     * [WagerHelper.checkAndLock]), persist, and return the amount
+     * awarded. Returns `0L` on miss or empty pool.
+     */
+    fun rollOnWin(
+        jackpotService: JackpotService,
+        userService: UserService,
+        user: UserDto,
+        guildId: Long,
+        random: Random
+    ): Long {
+        if (random.nextDouble() >= WIN_PROBABILITY) return 0L
+        val won = jackpotService.awardJackpot(guildId)
+        if (won == 0L) return 0L
+        user.socialCredit = (user.socialCredit ?: 0L) + won
+        userService.updateUser(user)
+        return won
+    }
+}

--- a/database/src/main/kotlin/database/service/JackpotService.kt
+++ b/database/src/main/kotlin/database/service/JackpotService.kt
@@ -1,0 +1,63 @@
+package database.service
+
+import database.dto.TobyCoinJackpotDto
+import database.persistence.TobyCoinJackpotPersistence
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * Atomic operations on the per-guild jackpot pool.
+ *
+ * The pool is fed by a flat fee on every Toby Coin trade (see
+ * [EconomyTradeService]). Casino minigame wins roll a small chance to
+ * hit the jackpot — on a hit the player banks the entire pool and the
+ * counter resets to zero. All mutations go through pessimistic row
+ * locks so two concurrent winners can't both bank the same pool.
+ */
+@Service
+@Transactional
+class JackpotService(
+    private val persistence: TobyCoinJackpotPersistence
+) {
+
+    /** Current pool size; 0 if no row yet for this guild. */
+    fun getPool(guildId: Long): Long =
+        persistence.getByGuild(guildId)?.pool ?: 0L
+
+    /**
+     * Add [amount] credits to the pool. Caller must already be inside a
+     * @Transactional boundary; we lock the row to serialise concurrent
+     * fee deposits. Negative or zero amounts are no-ops (so the trade
+     * service doesn't need to special-case rounding-down to zero).
+     */
+    fun addToPool(guildId: Long, amount: Long): Long {
+        if (amount <= 0L) return getPool(guildId)
+        val row = lockOrCreate(guildId)
+        row.pool += amount
+        persistence.upsert(row)
+        return row.pool
+    }
+
+    /**
+     * Pay out the entire pool atomically. Returns the amount that was
+     * in the pool at the moment of the lock; caller is responsible for
+     * crediting that amount to the winner. Pool is set to zero in the
+     * same transaction.
+     */
+    fun awardJackpot(guildId: Long): Long {
+        val row = lockOrCreate(guildId)
+        val won = row.pool
+        if (won == 0L) return 0L
+        row.pool = 0L
+        persistence.upsert(row)
+        return won
+    }
+
+    private fun lockOrCreate(guildId: Long): TobyCoinJackpotDto {
+        persistence.getByGuildForUpdate(guildId)?.let { return it }
+        // First fee for this guild — seed and re-read with the write lock.
+        persistence.upsert(TobyCoinJackpotDto(guildId = guildId, pool = 0L))
+        return persistence.getByGuildForUpdate(guildId)
+            ?: error("Jackpot row for guild $guildId could not be locked after creation")
+    }
+}

--- a/database/src/main/kotlin/database/service/ScratchService.kt
+++ b/database/src/main/kotlin/database/service/ScratchService.kt
@@ -13,6 +13,7 @@ import kotlin.random.Random
 @Transactional
 class ScratchService(
     private val userService: UserService,
+    private val jackpotService: JackpotService,
     private val card: ScratchCard = ScratchCard(),
     private val random: Random = Random.Default
 ) {
@@ -25,7 +26,8 @@ class ScratchService(
             val cells: List<database.economy.SlotMachine.Symbol>,
             val winningSymbol: database.economy.SlotMachine.Symbol,
             val matchCount: Int,
-            val newBalance: Long
+            val newBalance: Long,
+            val jackpotPayout: Long = 0L
         ) : ScratchOutcome
 
         data class Lose(
@@ -50,6 +52,7 @@ class ScratchService(
                 val result = card.scratch(random)
                 val r = WagerHelper.applyMultiplier(userService, check.user, check.balance, stake, result.multiplier)
                 if (result.isWin && result.winningSymbol != null) {
+                    val jackpot = JackpotHelper.rollOnWin(jackpotService, userService, check.user, guildId, random)
                     ScratchOutcome.Win(
                         stake = stake,
                         payout = r.payout,
@@ -57,7 +60,8 @@ class ScratchService(
                         cells = result.cells,
                         winningSymbol = result.winningSymbol,
                         matchCount = result.matchCount,
-                        newBalance = r.newBalance
+                        newBalance = r.newBalance + jackpot,
+                        jackpotPayout = jackpot
                     )
                 } else {
                     ScratchOutcome.Lose(stake = stake, cells = result.cells, newBalance = r.newBalance)

--- a/database/src/main/kotlin/database/service/SlotsService.kt
+++ b/database/src/main/kotlin/database/service/SlotsService.kt
@@ -16,11 +16,15 @@ import kotlin.random.Random
  * `@Transactional` boundary so concurrent `/slots` invocations from the
  * same user (Discord + web at once, or just spam-clicking) can't double-
  * spend the stake.
+ *
+ * Wins also roll [JackpotHelper] for a chance to bank the per-guild
+ * jackpot pool (fed by trade fees in [EconomyTradeService]).
  */
 @Service
 @Transactional
 class SlotsService(
     private val userService: UserService,
+    private val jackpotService: JackpotService,
     private val machine: SlotMachine = SlotMachine(),
     private val random: Random = Random.Default
 ) {
@@ -32,7 +36,8 @@ class SlotsService(
             val payout: Long,
             val net: Long,
             val symbols: List<SlotMachine.Symbol>,
-            val newBalance: Long
+            val newBalance: Long,
+            val jackpotPayout: Long = 0L
         ) : SpinOutcome
 
         data class Lose(
@@ -57,13 +62,15 @@ class SlotsService(
                 val pull = machine.pull(random)
                 val r = WagerHelper.applyMultiplier(userService, check.user, check.balance, stake, pull.multiplier)
                 if (pull.isWin) {
+                    val jackpot = JackpotHelper.rollOnWin(jackpotService, userService, check.user, guildId, random)
                     SpinOutcome.Win(
                         stake = stake,
                         multiplier = pull.multiplier,
                         payout = r.payout,
                         net = r.net,
                         symbols = pull.symbols,
-                        newBalance = r.newBalance
+                        newBalance = r.newBalance + jackpot,
+                        jackpotPayout = jackpot
                     )
                 } else {
                     SpinOutcome.Lose(stake = stake, symbols = pull.symbols, newBalance = r.newBalance)

--- a/database/src/main/resources/db/migration/V18__toby_coin_jackpot.sql
+++ b/database/src/main/resources/db/migration/V18__toby_coin_jackpot.sql
@@ -1,0 +1,16 @@
+-- Per-guild jackpot pool fed by Toby Coin trade fees.
+--
+-- Every buy and sell pays a small flat fee (TRADE_FEE in
+-- TobyCoinEngine) that lands here instead of dissolving into the
+-- market. Casino minigame wins roll a small probability of hitting
+-- the pool — on a hit, the player banks the entire pool and the
+-- counter resets to zero.
+--
+-- The pool is per-guild because the rest of the economy is per-guild
+-- (market price, trade history, balances) — fees in one server
+-- shouldn't show up as a payout in another.
+
+CREATE TABLE toby_coin_jackpot (
+    guild_id BIGINT PRIMARY KEY,
+    pool     BIGINT NOT NULL DEFAULT 0 CHECK (pool >= 0)
+);

--- a/database/src/test/kotlin/database/service/CoinflipServiceTest.kt
+++ b/database/src/test/kotlin/database/service/CoinflipServiceTest.kt
@@ -15,6 +15,7 @@ import kotlin.random.Random
 class CoinflipServiceTest {
 
     private lateinit var userService: UserService
+    private lateinit var jackpotService: JackpotService
     private lateinit var coinflip: Coinflip
     private lateinit var service: CoinflipService
 
@@ -24,8 +25,9 @@ class CoinflipServiceTest {
     @BeforeEach
     fun setup() {
         userService = mockk(relaxed = true)
+        jackpotService = mockk(relaxed = true)
         coinflip = mockk(relaxed = true)
-        service = CoinflipService(userService, coinflip, Random(0))
+        service = CoinflipService(userService, jackpotService, coinflip, Random(0))
     }
 
     private fun userWithBalance(balance: Long): UserDto {

--- a/database/src/test/kotlin/database/service/DiceServiceTest.kt
+++ b/database/src/test/kotlin/database/service/DiceServiceTest.kt
@@ -15,6 +15,7 @@ import kotlin.random.Random
 class DiceServiceTest {
 
     private lateinit var userService: UserService
+    private lateinit var jackpotService: JackpotService
     private lateinit var dice: Dice
     private lateinit var service: DiceService
 
@@ -24,11 +25,12 @@ class DiceServiceTest {
     @BeforeEach
     fun setup() {
         userService = mockk(relaxed = true)
+        jackpotService = mockk(relaxed = true)
         dice = mockk(relaxed = true) {
             every { isValidPrediction(any()) } answers { firstArg<Int>() in 1..6 }
             every { sidesCount } returns 6
         }
-        service = DiceService(userService, dice, Random(0))
+        service = DiceService(userService, jackpotService, dice, Random(0))
     }
 
     private fun userWithBalance(balance: Long): UserDto {

--- a/database/src/test/kotlin/database/service/HighlowServiceTest.kt
+++ b/database/src/test/kotlin/database/service/HighlowServiceTest.kt
@@ -15,6 +15,7 @@ import kotlin.random.Random
 class HighlowServiceTest {
 
     private lateinit var userService: UserService
+    private lateinit var jackpotService: JackpotService
     private lateinit var highlow: Highlow
     private lateinit var service: HighlowService
 
@@ -24,8 +25,9 @@ class HighlowServiceTest {
     @BeforeEach
     fun setup() {
         userService = mockk(relaxed = true)
+        jackpotService = mockk(relaxed = true)
         highlow = mockk(relaxed = true)
-        service = HighlowService(userService, highlow, Random(0))
+        service = HighlowService(userService, jackpotService, highlow, Random(0))
     }
 
     private fun userWithBalance(balance: Long): UserDto =

--- a/database/src/test/kotlin/database/service/JackpotServiceTest.kt
+++ b/database/src/test/kotlin/database/service/JackpotServiceTest.kt
@@ -1,0 +1,103 @@
+package database.service
+
+import database.dto.TobyCoinJackpotDto
+import database.persistence.TobyCoinJackpotPersistence
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class JackpotServiceTest {
+
+    private val guildId = 42L
+
+    private lateinit var persistence: TobyCoinJackpotPersistence
+    private lateinit var service: JackpotService
+
+    @BeforeEach
+    fun setup() {
+        persistence = mockk(relaxed = true)
+        service = JackpotService(persistence)
+    }
+
+    @Test
+    fun `getPool returns 0 when no row exists yet`() {
+        every { persistence.getByGuild(guildId) } returns null
+
+        assertEquals(0L, service.getPool(guildId))
+    }
+
+    @Test
+    fun `getPool returns the row's pool`() {
+        every { persistence.getByGuild(guildId) } returns TobyCoinJackpotDto(guildId = guildId, pool = 1_234L)
+
+        assertEquals(1_234L, service.getPool(guildId))
+    }
+
+    @Test
+    fun `addToPool seeds + increments on the first deposit`() {
+        // First locked-read returns null (no row), service seeds via upsert,
+        // re-reads with the lock and finds the freshly-persisted row.
+        val seeded = TobyCoinJackpotDto(guildId = guildId, pool = 0L)
+        every { persistence.getByGuildForUpdate(guildId) } returnsMany listOf(null, seeded)
+        val saved = slot<TobyCoinJackpotDto>()
+        every { persistence.upsert(capture(saved)) } answers { saved.captured }
+
+        val newPool = service.addToPool(guildId, 100L)
+
+        assertEquals(100L, newPool)
+        // The seed and the increment both go through upsert, so we expect
+        // two writes — verify the final state, not the call shape.
+        verify(atLeast = 1) { persistence.upsert(any()) }
+        assertEquals(100L, seeded.pool, "seeded row mutated to 100 in place")
+    }
+
+    @Test
+    fun `addToPool increments an existing row's pool`() {
+        val existing = TobyCoinJackpotDto(guildId = guildId, pool = 500L)
+        every { persistence.getByGuildForUpdate(guildId) } returns existing
+        every { persistence.upsert(any()) } answers { firstArg() }
+
+        val newPool = service.addToPool(guildId, 250L)
+
+        assertEquals(750L, newPool)
+        assertEquals(750L, existing.pool, "row mutation matches the increment")
+    }
+
+    @Test
+    fun `addToPool ignores non-positive amounts`() {
+        every { persistence.getByGuild(guildId) } returns TobyCoinJackpotDto(guildId = guildId, pool = 99L)
+
+        assertEquals(99L, service.addToPool(guildId, 0L))
+        assertEquals(99L, service.addToPool(guildId, -10L))
+
+        verify(exactly = 0) { persistence.getByGuildForUpdate(any()) }
+        verify(exactly = 0) { persistence.upsert(any()) }
+    }
+
+    @Test
+    fun `awardJackpot returns the prior pool and zeroes the row`() {
+        val existing = TobyCoinJackpotDto(guildId = guildId, pool = 1_500L)
+        every { persistence.getByGuildForUpdate(guildId) } returns existing
+        every { persistence.upsert(any()) } answers { firstArg() }
+
+        val won = service.awardJackpot(guildId)
+
+        assertEquals(1_500L, won, "winner banks the entire pool")
+        assertEquals(0L, existing.pool, "pool resets in the same transaction")
+    }
+
+    @Test
+    fun `awardJackpot is a no-op (returns 0) when the pool is empty`() {
+        val empty = TobyCoinJackpotDto(guildId = guildId, pool = 0L)
+        every { persistence.getByGuildForUpdate(guildId) } returns empty
+
+        assertEquals(0L, service.awardJackpot(guildId))
+        verify(exactly = 0) { persistence.upsert(any()) }
+    }
+}

--- a/database/src/test/kotlin/database/service/ScratchServiceTest.kt
+++ b/database/src/test/kotlin/database/service/ScratchServiceTest.kt
@@ -16,6 +16,7 @@ import kotlin.random.Random
 class ScratchServiceTest {
 
     private lateinit var userService: UserService
+    private lateinit var jackpotService: JackpotService
     private lateinit var card: ScratchCard
     private lateinit var service: ScratchService
 
@@ -25,8 +26,9 @@ class ScratchServiceTest {
     @BeforeEach
     fun setup() {
         userService = mockk(relaxed = true)
+        jackpotService = mockk(relaxed = true)
         card = mockk(relaxed = true)
-        service = ScratchService(userService, card, Random(0))
+        service = ScratchService(userService, jackpotService, card, Random(0))
     }
 
     private fun userWithBalance(balance: Long): UserDto =

--- a/database/src/test/kotlin/database/service/SlotsServiceTest.kt
+++ b/database/src/test/kotlin/database/service/SlotsServiceTest.kt
@@ -15,6 +15,7 @@ import kotlin.random.Random
 class SlotsServiceTest {
 
     private lateinit var userService: UserService
+    private lateinit var jackpotService: JackpotService
     private lateinit var machine: SlotMachine
     private lateinit var service: SlotsService
 
@@ -24,8 +25,9 @@ class SlotsServiceTest {
     @BeforeEach
     fun setup() {
         userService = mockk(relaxed = true)
+        jackpotService = mockk(relaxed = true)
         machine = mockk(relaxed = true)
-        service = SlotsService(userService, machine, Random(0))
+        service = SlotsService(userService, jackpotService, machine, Random(0))
     }
 
     private fun userWithBalance(balance: Long): UserDto {

--- a/web/src/main/kotlin/web/controller/CoinflipController.kt
+++ b/web/src/main/kotlin/web/controller/CoinflipController.kt
@@ -3,6 +3,7 @@ package web.controller
 import database.economy.Coinflip
 import database.service.CoinflipService
 import database.service.CoinflipService.FlipOutcome
+import database.service.JackpotService
 import database.service.UserService
 import net.dv8tion.jda.api.JDA
 import org.springframework.http.ResponseEntity
@@ -36,6 +37,7 @@ class CoinflipController(
     private val coinflipService: CoinflipService,
     private val economyWebService: EconomyWebService,
     private val userService: UserService,
+    private val jackpotService: JackpotService,
     private val jda: JDA
 ) {
 
@@ -66,6 +68,7 @@ class CoinflipController(
         model.addAttribute("minStake", Coinflip.MIN_STAKE)
         model.addAttribute("maxStake", Coinflip.MAX_STAKE)
         model.addAttribute("multiplier", Coinflip.DEFAULT_MULTIPLIER)
+        model.addAttribute("jackpotPool", jackpotService.getPool(guildId))
         model.addAttribute("username", user.displayName())
         return "coinflip"
     }
@@ -94,7 +97,8 @@ class CoinflipController(
                     net = outcome.net,
                     payout = outcome.payout,
                     newBalance = outcome.newBalance,
-                    win = true
+                    win = true,
+                    jackpotPayout = outcome.jackpotPayout.takeIf { it > 0L }
                 )
             )
 
@@ -141,5 +145,6 @@ data class FlipResponse(
     val net: Long? = null,
     val payout: Long? = null,
     val newBalance: Long? = null,
-    val win: Boolean? = null
+    val win: Boolean? = null,
+    val jackpotPayout: Long? = null
 )

--- a/web/src/main/kotlin/web/controller/DiceController.kt
+++ b/web/src/main/kotlin/web/controller/DiceController.kt
@@ -3,6 +3,7 @@ package web.controller
 import database.economy.Dice
 import database.service.DiceService
 import database.service.DiceService.RollOutcome
+import database.service.JackpotService
 import database.service.UserService
 import net.dv8tion.jda.api.JDA
 import org.springframework.http.ResponseEntity
@@ -34,6 +35,7 @@ class DiceController(
     private val diceService: DiceService,
     private val economyWebService: EconomyWebService,
     private val userService: UserService,
+    private val jackpotService: JackpotService,
     private val jda: JDA
 ) {
 
@@ -64,6 +66,7 @@ class DiceController(
         model.addAttribute("maxStake", Dice.MAX_STAKE)
         model.addAttribute("sides", Dice.DEFAULT_SIDES)
         model.addAttribute("multiplier", Dice.DEFAULT_MULTIPLIER)
+        model.addAttribute("jackpotPool", jackpotService.getPool(guildId))
         model.addAttribute("username", user.displayName())
         return "dice"
     }
@@ -90,7 +93,8 @@ class DiceController(
                     net = outcome.net,
                     payout = outcome.payout,
                     newBalance = outcome.newBalance,
-                    win = true
+                    win = true,
+                    jackpotPayout = outcome.jackpotPayout.takeIf { it > 0L }
                 )
             )
 
@@ -135,5 +139,6 @@ data class RollResponse(
     val net: Long? = null,
     val payout: Long? = null,
     val newBalance: Long? = null,
-    val win: Boolean? = null
+    val win: Boolean? = null,
+    val jackpotPayout: Long? = null
 )

--- a/web/src/main/kotlin/web/controller/HighlowController.kt
+++ b/web/src/main/kotlin/web/controller/HighlowController.kt
@@ -3,6 +3,7 @@ package web.controller
 import database.economy.Highlow
 import database.service.HighlowService
 import database.service.HighlowService.PlayOutcome
+import database.service.JackpotService
 import database.service.UserService
 import jakarta.servlet.http.HttpSession
 import net.dv8tion.jda.api.JDA
@@ -28,6 +29,7 @@ class HighlowController(
     private val highlowService: HighlowService,
     private val economyWebService: EconomyWebService,
     private val userService: UserService,
+    private val jackpotService: JackpotService,
     private val jda: JDA
 ) {
 
@@ -65,6 +67,7 @@ class HighlowController(
         model.addAttribute("multiplier", Highlow.DEFAULT_MULTIPLIER)
         model.addAttribute("anchor", anchor)
         model.addAttribute("anchorLabel", cardLabel(anchor))
+        model.addAttribute("jackpotPool", jackpotService.getPool(guildId))
         model.addAttribute("username", user.displayName())
         return "highlow"
     }
@@ -114,7 +117,8 @@ class HighlowController(
                     payout = outcome.payout,
                     newBalance = outcome.newBalance,
                     win = true,
-                    nextAnchor = nextRoundAnchor
+                    nextAnchor = nextRoundAnchor,
+                    jackpotPayout = outcome.jackpotPayout.takeIf { it > 0L }
                 )
             )
 
@@ -182,5 +186,6 @@ data class PlayResponse(
     val payout: Long? = null,
     val newBalance: Long? = null,
     val win: Boolean? = null,
-    val nextAnchor: Int? = null
+    val nextAnchor: Int? = null,
+    val jackpotPayout: Long? = null
 )

--- a/web/src/main/kotlin/web/controller/ScratchController.kt
+++ b/web/src/main/kotlin/web/controller/ScratchController.kt
@@ -1,6 +1,7 @@
 package web.controller
 
 import database.economy.ScratchCard
+import database.service.JackpotService
 import database.service.ScratchService
 import database.service.ScratchService.ScratchOutcome
 import database.service.UserService
@@ -27,6 +28,7 @@ class ScratchController(
     private val scratchService: ScratchService,
     private val economyWebService: EconomyWebService,
     private val userService: UserService,
+    private val jackpotService: JackpotService,
     private val jda: JDA
 ) {
 
@@ -57,6 +59,7 @@ class ScratchController(
         model.addAttribute("maxStake", ScratchCard.MAX_STAKE)
         model.addAttribute("cellCount", ScratchCard.CELL_COUNT)
         model.addAttribute("matchThreshold", ScratchCard.MATCH_THRESHOLD)
+        model.addAttribute("jackpotPool", jackpotService.getPool(guildId))
         model.addAttribute("username", user.displayName())
         return "scratch"
     }
@@ -84,7 +87,8 @@ class ScratchController(
                     net = outcome.net,
                     payout = outcome.payout,
                     newBalance = outcome.newBalance,
-                    win = true
+                    win = true,
+                    jackpotPayout = outcome.jackpotPayout.takeIf { it > 0L }
                 )
             )
 
@@ -125,5 +129,6 @@ data class ScratchResponse(
     val net: Long? = null,
     val payout: Long? = null,
     val newBalance: Long? = null,
-    val win: Boolean? = null
+    val win: Boolean? = null,
+    val jackpotPayout: Long? = null
 )

--- a/web/src/main/kotlin/web/controller/SlotsController.kt
+++ b/web/src/main/kotlin/web/controller/SlotsController.kt
@@ -1,6 +1,7 @@
 package web.controller
 
 import database.economy.SlotMachine
+import database.service.JackpotService
 import database.service.SlotsService
 import database.service.SlotsService.SpinOutcome
 import database.service.UserService
@@ -36,6 +37,7 @@ class SlotsController(
     private val slotsService: SlotsService,
     private val economyWebService: EconomyWebService,
     private val userService: UserService,
+    private val jackpotService: JackpotService,
     private val jda: JDA
 ) {
 
@@ -66,6 +68,7 @@ class SlotsController(
         model.addAttribute("minStake", SlotMachine.MIN_STAKE)
         model.addAttribute("maxStake", SlotMachine.MAX_STAKE)
         model.addAttribute("payoutTable", payoutRows())
+        model.addAttribute("jackpotPool", jackpotService.getPool(guildId))
         model.addAttribute("username", user.displayName())
         return "slots"
     }
@@ -91,7 +94,8 @@ class SlotsController(
                     payout = outcome.payout,
                     net = outcome.net,
                     newBalance = outcome.newBalance,
-                    win = true
+                    win = true,
+                    jackpotPayout = outcome.jackpotPayout.takeIf { it > 0L }
                 )
             )
 
@@ -146,7 +150,8 @@ data class SpinResponse(
     val payout: Long? = null,
     val net: Long? = null,
     val newBalance: Long? = null,
-    val win: Boolean? = null
+    val win: Boolean? = null,
+    val jackpotPayout: Long? = null
 )
 
 data class PayoutRow(val symbols: String, val multiplier: String)

--- a/web/src/main/resources/static/css/base.css
+++ b/web/src/main/resources/static/css/base.css
@@ -408,6 +408,35 @@ td { font-size: 0.95rem; }
     .toast-stack { left: 12px; right: 12px; bottom: 12px; max-width: none; }
 }
 
+/* Per-guild casino jackpot banner — rendered on every minigame page so
+   players can see the pool before they spin. Styling is intentionally
+   loud so the pool is the eye-grabbing element of the table. */
+.casino-jackpot-banner {
+    margin-top: var(--space-3);
+    padding: var(--space-2) var(--space-3);
+    background: linear-gradient(90deg, rgba(241, 196, 15, 0.18), rgba(241, 196, 15, 0.06));
+    border: 1px solid rgba(241, 196, 15, 0.55);
+    border-radius: 10px;
+    color: #f1c40f;
+    font-size: 0.95rem;
+    font-variant-numeric: tabular-nums;
+    text-align: center;
+}
+.casino-jackpot-banner strong { color: #ffe066; }
+.casino-jackpot-banner .muted { color: var(--text-muted); font-size: 0.85rem; }
+
+/* Game result lines paint themselves with `<game>-result-jackpot` when a
+   spin/flip/roll/play/scratch wins the jackpot. Shared accent so each
+   game's CSS doesn't have to redefine the colour. */
+.slots-result-jackpot,
+.coinflip-result-jackpot,
+.dice-result-jackpot,
+.highlow-result-jackpot,
+.scratch-result-jackpot {
+    color: #f1c40f;
+    text-shadow: 0 0 8px rgba(241, 196, 15, 0.4);
+}
+
 /* Grow tap targets on any touch device without ballooning desktop buttons */
 @media (hover: none) and (pointer: coarse) {
     .btn-sm { padding: 8px 14px; min-height: 40px; }

--- a/web/src/main/resources/static/js/casino-jackpot.js
+++ b/web/src/main/resources/static/js/casino-jackpot.js
@@ -1,0 +1,40 @@
+// Shared helpers for the per-guild casino jackpot pool. Each minigame's
+// result-rendering JS prepends a "🎰 JACKPOT!" banner when the spin /
+// flip / roll / play / scratch hit the jackpot, so the visual treatment
+// stays identical across slots, coinflip, dice, highlow, and scratch.
+
+(function (root) {
+    'use strict';
+
+    function isJackpotHit(body) {
+        return !!(body && typeof body.jackpotPayout === 'number' && body.jackpotPayout > 0);
+    }
+
+    function jackpotPrefixHtml(payout) {
+        if (typeof payout !== 'number' || payout <= 0) return '';
+        return '🎰 <strong>JACKPOT!</strong> +' + payout + ' credits<br>';
+    }
+
+    /**
+     * Apply jackpot styling + prefix on top of an existing win-line HTML
+     * fragment. Returns the HTML the result element should display.
+     * Pass the body straight from the server response.
+     *
+     *   element.innerHTML = renderWinHtml(resEl, body, 'slots-result-jackpot', winLine)
+     */
+    function renderWinHtml(resultEl, body, jackpotClassName, winLineHtml) {
+        if (!isJackpotHit(body)) return winLineHtml;
+        if (resultEl && jackpotClassName) resultEl.classList.add(jackpotClassName);
+        return jackpotPrefixHtml(body.jackpotPayout) + winLineHtml;
+    }
+
+    const api = { isJackpotHit, jackpotPrefixHtml, renderWinHtml };
+
+    // Browser global so each game's IIFE-style JS can reach it without
+    // bundler plumbing.
+    if (root) root.TobyJackpot = api;
+
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = api;
+    }
+})(typeof window !== 'undefined' ? window : null);

--- a/web/src/main/resources/static/js/coinflip.js
+++ b/web/src/main/resources/static/js/coinflip.js
@@ -1,3 +1,25 @@
+// Pure-DOM render for a /flip response. Hoisted out of the IIFE so the
+// jest test in `coinflip.test.js` can drive it without booting the page.
+function renderCoinflipResult(resultEl, body) {
+    if (!resultEl) return;
+    resultEl.hidden = false;
+    resultEl.classList.remove('coinflip-result-win', 'coinflip-result-lose', 'coinflip-result-jackpot');
+    const landedLabel = body.landed === 'HEADS' ? 'Heads' : 'Tails';
+    const predictedLabel = body.predicted === 'HEADS' ? 'Heads' : 'Tails';
+    if (body.win) {
+        resultEl.classList.add('coinflip-result-win');
+        const winLine = '<strong>' + landedLabel + '!</strong> You called ' +
+            predictedLabel + ' &middot; <strong>+' + body.net + ' credits</strong>';
+        resultEl.innerHTML = (typeof window !== 'undefined' && window.TobyJackpot)
+            ? window.TobyJackpot.renderWinHtml(resultEl, body, 'coinflip-result-jackpot', winLine)
+            : winLine;
+    } else {
+        resultEl.classList.add('coinflip-result-lose');
+        resultEl.innerHTML = '<strong>' + landedLabel + '.</strong> You called ' +
+            predictedLabel + ' &middot; lost <strong>' + Math.abs(body.net) + ' credits</strong>';
+    }
+}
+
 (function () {
     'use strict';
 
@@ -64,23 +86,6 @@
         }
     }
 
-    function showResult(body) {
-        if (!resultEl) return;
-        resultEl.hidden = false;
-        resultEl.classList.remove('coinflip-result-win', 'coinflip-result-lose');
-        const landedLabel = body.landed === 'HEADS' ? 'Heads' : 'Tails';
-        const predictedLabel = body.predicted === 'HEADS' ? 'Heads' : 'Tails';
-        if (body.win) {
-            resultEl.classList.add('coinflip-result-win');
-            resultEl.innerHTML = '<strong>' + landedLabel + '!</strong> You called ' +
-                predictedLabel + ' &middot; <strong>+' + body.net + ' credits</strong>';
-        } else {
-            resultEl.classList.add('coinflip-result-lose');
-            resultEl.innerHTML = '<strong>' + landedLabel + '.</strong> You called ' +
-                predictedLabel + ' &middot; lost <strong>' + Math.abs(body.net) + ' credits</strong>';
-        }
-    }
-
     function applyBalance(newBalance) {
         if (typeof newBalance !== 'number') return;
         if (balanceEl) balanceEl.textContent = newBalance;
@@ -120,7 +125,7 @@
                     stopFlipAnimation(intervalId, body && body.landed);
                     flipBtn.disabled = false;
                     if (body && body.ok) {
-                        showResult(body);
+                        renderCoinflipResult(resultEl, body);
                         applyBalance(body.newBalance);
                     } else {
                         if (resultEl) resultEl.hidden = true;
@@ -136,3 +141,7 @@
             });
     });
 })();
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { renderCoinflipResult };
+}

--- a/web/src/main/resources/static/js/dice.js
+++ b/web/src/main/resources/static/js/dice.js
@@ -1,3 +1,23 @@
+// Pure-DOM render for a /roll response. Hoisted out of the IIFE so the
+// jest test in `dice.test.js` can drive it without booting the page.
+function renderDiceResult(resultEl, body) {
+    if (!resultEl) return;
+    resultEl.hidden = false;
+    resultEl.classList.remove('dice-result-win', 'dice-result-lose', 'dice-result-jackpot');
+    if (body.win) {
+        resultEl.classList.add('dice-result-win');
+        const winLine = '<strong>' + body.landed + '!</strong> You called ' +
+            body.predicted + ' &middot; <strong>+' + body.net + ' credits</strong>';
+        resultEl.innerHTML = (typeof window !== 'undefined' && window.TobyJackpot)
+            ? window.TobyJackpot.renderWinHtml(resultEl, body, 'dice-result-jackpot', winLine)
+            : winLine;
+    } else {
+        resultEl.classList.add('dice-result-lose');
+        resultEl.innerHTML = '<strong>' + body.landed + '.</strong> You called ' +
+            body.predicted + ' &middot; lost <strong>' + Math.abs(body.net) + ' credits</strong>';
+    }
+}
+
 (function () {
     'use strict';
 
@@ -58,20 +78,6 @@
         }
     }
 
-    function showResult(body) {
-        if (!resultEl) return;
-        resultEl.hidden = false;
-        resultEl.classList.remove('dice-result-win', 'dice-result-lose');
-        if (body.win) {
-            resultEl.classList.add('dice-result-win');
-            resultEl.innerHTML = '<strong>' + body.landed + '!</strong> You called ' +
-                body.predicted + ' &middot; <strong>+' + body.net + ' credits</strong>';
-        } else {
-            resultEl.classList.add('dice-result-lose');
-            resultEl.innerHTML = '<strong>' + body.landed + '.</strong> You called ' +
-                body.predicted + ' &middot; lost <strong>' + Math.abs(body.net) + ' credits</strong>';
-        }
-    }
 
     function applyBalance(newBalance) {
         if (typeof newBalance !== 'number') return;
@@ -112,7 +118,7 @@
                     stopRollAnimation(intervalId, body && body.landed);
                     rollBtn.disabled = false;
                     if (body && body.ok) {
-                        showResult(body);
+                        renderDiceResult(resultEl, body);
                         applyBalance(body.newBalance);
                     } else {
                         if (resultEl) resultEl.hidden = true;
@@ -128,3 +134,7 @@
             });
     });
 })();
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { renderDiceResult };
+}

--- a/web/src/main/resources/static/js/highlow.js
+++ b/web/src/main/resources/static/js/highlow.js
@@ -1,3 +1,39 @@
+// Pure card-face label. Hoisted so the jest test can call it directly.
+function highlowCardLabel(n) {
+    switch (n) {
+        case 1: return 'A';
+        case 11: return 'J';
+        case 12: return 'Q';
+        case 13: return 'K';
+        default: return String(n);
+    }
+}
+
+// Pure-DOM render for a /play response. Hoisted out of the IIFE so the
+// jest test in `highlow.test.js` can drive it without booting the page.
+function renderHighlowResult(resultEl, body) {
+    if (!resultEl) return;
+    resultEl.hidden = false;
+    resultEl.classList.remove('highlow-result-win', 'highlow-result-lose', 'highlow-result-jackpot');
+    const dirLabel = body.direction === 'HIGHER' ? 'Higher' : 'Lower';
+    if (body.win) {
+        resultEl.classList.add('highlow-result-win');
+        const winLine = '<strong>' + highlowCardLabel(body.next) + '</strong> ' +
+            (body.next > body.anchor ? '>' : '<') + ' <strong>' + highlowCardLabel(body.anchor) +
+            '</strong> &middot; you called ' + dirLabel + ' &middot; <strong>+' + body.net + ' credits</strong>';
+        resultEl.innerHTML = (typeof window !== 'undefined' && window.TobyJackpot)
+            ? window.TobyJackpot.renderWinHtml(resultEl, body, 'highlow-result-jackpot', winLine)
+            : winLine;
+    } else {
+        resultEl.classList.add('highlow-result-lose');
+        const tie = body.next === body.anchor;
+        resultEl.innerHTML = '<strong>' + highlowCardLabel(body.next) + '</strong> ' +
+            (tie ? '=' : (body.next > body.anchor ? '>' : '<')) +
+            ' <strong>' + highlowCardLabel(body.anchor) + '</strong> &middot; you called ' +
+            dirLabel + ' &middot; lost <strong>' + Math.abs(body.net) + ' credits</strong>';
+    }
+}
+
 (function () {
     'use strict';
 
@@ -37,15 +73,7 @@
         return checked ? checked.value : null;
     }
 
-    function cardLabel(n) {
-        switch (n) {
-            case 1: return 'A';
-            case 11: return 'J';
-            case 12: return 'Q';
-            case 13: return 'K';
-            default: return String(n);
-        }
-    }
+    const cardLabel = highlowCardLabel;
 
     function startNextShuffle() {
         dealing = true;
@@ -77,26 +105,6 @@
         anchorCard.dataset.value = String(value);
         nextFace.textContent = '?';
         delete nextCard.dataset.value;
-    }
-
-    function showResult(body) {
-        if (!resultEl) return;
-        resultEl.hidden = false;
-        resultEl.classList.remove('highlow-result-win', 'highlow-result-lose');
-        const dirLabel = body.direction === 'HIGHER' ? 'Higher' : 'Lower';
-        if (body.win) {
-            resultEl.classList.add('highlow-result-win');
-            resultEl.innerHTML = '<strong>' + cardLabel(body.next) + '</strong> ' +
-                (body.next > body.anchor ? '>' : '<') + ' <strong>' + cardLabel(body.anchor) +
-                '</strong> &middot; you called ' + dirLabel + ' &middot; <strong>+' + body.net + ' credits</strong>';
-        } else {
-            resultEl.classList.add('highlow-result-lose');
-            const tie = body.next === body.anchor;
-            resultEl.innerHTML = '<strong>' + cardLabel(body.next) + '</strong> ' +
-                (tie ? '=' : (body.next > body.anchor ? '>' : '<')) +
-                ' <strong>' + cardLabel(body.anchor) + '</strong> &middot; you called ' +
-                dirLabel + ' &middot; lost <strong>' + Math.abs(body.net) + ' credits</strong>';
-        }
     }
 
     function applyBalance(newBalance) {
@@ -137,7 +145,7 @@
                 setTimeout(function () {
                     if (body && body.ok) {
                         stopNextShuffle(intervalId, body.next);
-                        showResult(body);
+                        renderHighlowResult(resultEl, body);
                         applyBalance(body.newBalance);
                         // Pause briefly so the player reads the result, then
                         // surface the next round's anchor without requiring
@@ -161,3 +169,7 @@
             });
     });
 })();
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { renderHighlowResult, highlowCardLabel };
+}

--- a/web/src/main/resources/static/js/scratch.js
+++ b/web/src/main/resources/static/js/scratch.js
@@ -1,3 +1,27 @@
+// Pure-DOM render for a /scratch response. Hoisted out of the IIFE so
+// the jest test in `scratch.test.js` can drive it without booting the
+// page. matchThreshold and balanceEl are passed in (they live as DOM
+// attributes / element references inside the IIFE) to keep this fully
+// stateless.
+function renderScratchResult(resultEl, body, matchThreshold, balanceEl) {
+    if (!resultEl) return;
+    resultEl.hidden = false;
+    resultEl.classList.remove('scratch-result-win', 'scratch-result-lose', 'scratch-result-jackpot');
+    if (body.win) {
+        resultEl.classList.add('scratch-result-win');
+        const winLine = '<strong>' + body.matchCount + '× ' + body.winningSymbol +
+            '</strong> &middot; <strong>+' + body.net + ' credits</strong>';
+        resultEl.innerHTML = (typeof window !== 'undefined' && window.TobyJackpot)
+            ? window.TobyJackpot.renderWinHtml(resultEl, body, 'scratch-result-jackpot', winLine)
+            : winLine;
+    } else {
+        resultEl.classList.add('scratch-result-lose');
+        resultEl.innerHTML = 'No ' + matchThreshold + '-of-a-kind &middot; lost <strong>' +
+            Math.abs(body.net) + ' credits</strong>';
+    }
+    if (typeof body.newBalance === 'number' && balanceEl) balanceEl.textContent = body.newBalance;
+}
+
 (function () {
     'use strict';
 
@@ -83,18 +107,7 @@
     }
 
     function showResult(body) {
-        if (!resultEl) return;
-        resultEl.hidden = false;
-        resultEl.classList.remove('scratch-result-win', 'scratch-result-lose');
-        if (body.win) {
-            resultEl.classList.add('scratch-result-win');
-            resultEl.innerHTML = '<strong>' + body.matchCount + '× ' + body.winningSymbol +
-                '</strong> &middot; <strong>+' + body.net + ' credits</strong>';
-        } else {
-            resultEl.classList.add('scratch-result-lose');
-            resultEl.innerHTML = 'No ' + matchThreshold + '-of-a-kind &middot; lost <strong>' + Math.abs(body.net) + ' credits</strong>';
-        }
-        if (typeof body.newBalance === 'number' && balanceEl) balanceEl.textContent = body.newBalance;
+        renderScratchResult(resultEl, body, matchThreshold, balanceEl);
     }
 
     cellButtons.forEach(function (btn) {
@@ -152,3 +165,7 @@
             });
     });
 })();
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { renderScratchResult };
+}

--- a/web/src/main/resources/static/js/slots.js
+++ b/web/src/main/resources/static/js/slots.js
@@ -1,3 +1,23 @@
+// Pure-DOM render for a /spin response. Hoisted out of the IIFE so the
+// jest test in `slots.test.js` can drive it without booting the whole
+// page. The IIFE below calls it with the live result element.
+function renderSlotsResult(resultEl, body) {
+    if (!resultEl) return;
+    resultEl.hidden = false;
+    resultEl.classList.remove('slots-result-win', 'slots-result-lose', 'slots-result-jackpot');
+    if (body.win) {
+        resultEl.classList.add('slots-result-win');
+        const winLine = '<strong>+' + body.net + ' credits</strong> &middot; ' +
+            body.multiplier + '× on a stake';
+        resultEl.innerHTML = (typeof window !== 'undefined' && window.TobyJackpot)
+            ? window.TobyJackpot.renderWinHtml(resultEl, body, 'slots-result-jackpot', winLine)
+            : winLine;
+    } else {
+        resultEl.classList.add('slots-result-lose');
+        resultEl.innerHTML = 'Lost <strong>' + Math.abs(body.net) + ' credits</strong>';
+    }
+}
+
 (function () {
     'use strict';
 
@@ -28,9 +48,6 @@
 
     if (!form || !spinBtn || !stakeInput || reels.some(function (r) { return !r; })) return;
 
-    // Symbols the reel cycles through during the spin animation. Order
-    // is purely cosmetic — the final symbols are set from the server
-    // response when the request resolves.
     const SPIN_SYMBOLS = ['🍒', '🍋', '🔔', '⭐'];
     const SPIN_INTERVAL_MS = 60;
     const SPIN_DURATION_MS = 800;
@@ -54,20 +71,6 @@
             reel.classList.remove('spinning');
             if (finalSymbols && finalSymbols[i]) reel.textContent = finalSymbols[i];
         });
-    }
-
-    function showResult(body) {
-        if (!resultEl) return;
-        resultEl.hidden = false;
-        resultEl.classList.remove('slots-result-win', 'slots-result-lose');
-        if (body.win) {
-            resultEl.classList.add('slots-result-win');
-            resultEl.innerHTML = '<strong>+' + body.net + ' credits</strong> &middot; ' +
-                body.multiplier + '× on a stake';
-        } else {
-            resultEl.classList.add('slots-result-lose');
-            resultEl.innerHTML = 'Lost <strong>' + Math.abs(body.net) + ' credits</strong>';
-        }
     }
 
     function applyBalance(newBalance) {
@@ -98,15 +101,13 @@
 
         postJson('/casino/' + guildId + '/slots/spin', { stake: stake })
             .then(function (body) {
-                // Wait at least SPIN_DURATION_MS so a fast network doesn't
-                // make the spin look snappy-and-jarring.
                 const elapsed = Date.now() - requestStart;
                 const remaining = Math.max(0, SPIN_DURATION_MS - elapsed);
                 setTimeout(function () {
                     stopSpinAnimation(intervalId, body && body.symbols);
                     spinBtn.disabled = false;
                     if (body && body.ok) {
-                        showResult(body);
+                        renderSlotsResult(resultEl, body);
                         applyBalance(body.newBalance);
                     } else {
                         if (resultEl) resultEl.hidden = true;
@@ -122,3 +123,7 @@
             });
     });
 })();
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { renderSlotsResult };
+}

--- a/web/src/main/resources/templates/coinflip.html
+++ b/web/src/main/resources/templates/coinflip.html
@@ -48,6 +48,11 @@
         <div class="coinflip-balance">
             Balance: <strong id="coinflip-balance" th:text="${balance}">0</strong> credits
         </div>
+        <div class="casino-jackpot-banner">
+            🎰 Jackpot pool:
+            <strong th:text="${jackpotPool}">0</strong> credits
+            <span class="muted">— win any minigame for a 1% chance to bank the pool.</span>
+        </div>
     </section>
 
     <section class="coinflip-rules">
@@ -65,6 +70,7 @@
 
 <script th:src="@{/js/api.js}"></script>
 <script th:src="@{/js/toasts.js}"></script>
+<script th:src="@{/js/casino-jackpot.js}"></script>
 <script th:src="@{/js/coinflip.js}"></script>
 </body>
 </html>

--- a/web/src/main/resources/templates/dice.html
+++ b/web/src/main/resources/templates/dice.html
@@ -45,6 +45,11 @@
         <div class="dice-balance">
             Balance: <strong id="dice-balance" th:text="${balance}">0</strong> credits
         </div>
+        <div class="casino-jackpot-banner">
+            🎰 Jackpot pool:
+            <strong th:text="${jackpotPool}">0</strong> credits
+            <span class="muted">— win any minigame for a 1% chance to bank the pool.</span>
+        </div>
     </section>
 
     <section class="dice-rules">
@@ -62,6 +67,7 @@
 
 <script th:src="@{/js/api.js}"></script>
 <script th:src="@{/js/toasts.js}"></script>
+<script th:src="@{/js/casino-jackpot.js}"></script>
 <script th:src="@{/js/dice.js}"></script>
 </body>
 </html>

--- a/web/src/main/resources/templates/highlow.html
+++ b/web/src/main/resources/templates/highlow.html
@@ -58,6 +58,11 @@
         <div class="highlow-balance">
             Balance: <strong id="highlow-balance" th:text="${balance}">0</strong> credits
         </div>
+        <div class="casino-jackpot-banner">
+            🎰 Jackpot pool:
+            <strong th:text="${jackpotPool}">0</strong> credits
+            <span class="muted">— win any minigame for a 1% chance to bank the pool.</span>
+        </div>
     </section>
 
     <section class="highlow-rules">
@@ -77,6 +82,7 @@
 
 <script th:src="@{/js/api.js}"></script>
 <script th:src="@{/js/toasts.js}"></script>
+<script th:src="@{/js/casino-jackpot.js}"></script>
 <script th:src="@{/js/highlow.js}"></script>
 </body>
 </html>

--- a/web/src/main/resources/templates/scratch.html
+++ b/web/src/main/resources/templates/scratch.html
@@ -46,6 +46,11 @@
         <div class="scratch-balance">
             Balance: <strong id="scratch-balance" th:text="${balance}">0</strong> credits
         </div>
+        <div class="casino-jackpot-banner">
+            🎰 Jackpot pool:
+            <strong th:text="${jackpotPool}">0</strong> credits
+            <span class="muted">— win any minigame for a 1% chance to bank the pool.</span>
+        </div>
     </section>
 
     <section class="scratch-rules">
@@ -64,6 +69,7 @@
 
 <script th:src="@{/js/api.js}"></script>
 <script th:src="@{/js/toasts.js}"></script>
+<script th:src="@{/js/casino-jackpot.js}"></script>
 <script th:src="@{/js/scratch.js}"></script>
 </body>
 </html>

--- a/web/src/main/resources/templates/slots.html
+++ b/web/src/main/resources/templates/slots.html
@@ -40,6 +40,12 @@
         <div class="slots-balance">
             Balance: <strong id="slots-balance" th:text="${balance}">0</strong> credits
         </div>
+
+        <div class="casino-jackpot-banner">
+            🎰 Jackpot pool:
+            <strong th:text="${jackpotPool}">0</strong> credits
+            <span class="muted">— win any minigame for a 1% chance to bank the pool.</span>
+        </div>
     </section>
 
     <section class="slots-payouts">
@@ -64,6 +70,7 @@
 
 <script th:src="@{/js/api.js}"></script>
 <script th:src="@{/js/toasts.js}"></script>
+<script th:src="@{/js/casino-jackpot.js}"></script>
 <script th:src="@{/js/slots.js}"></script>
 </body>
 </html>

--- a/web/src/test/js/casino-jackpot.test.js
+++ b/web/src/test/js/casino-jackpot.test.js
@@ -1,0 +1,105 @@
+const {
+    isJackpotHit,
+    jackpotPrefixHtml,
+    renderWinHtml,
+} = require('../../main/resources/static/js/casino-jackpot');
+
+// ---------------------------------------------------------------------------
+// isJackpotHit
+// ---------------------------------------------------------------------------
+
+describe('isJackpotHit', () => {
+    test('truthy on positive payout', () => {
+        expect(isJackpotHit({ jackpotPayout: 250 })).toBe(true);
+    });
+
+    test('false on zero payout', () => {
+        expect(isJackpotHit({ jackpotPayout: 0 })).toBe(false);
+    });
+
+    test('false on missing payout', () => {
+        expect(isJackpotHit({})).toBe(false);
+    });
+
+    test('false on null body', () => {
+        expect(isJackpotHit(null)).toBe(false);
+    });
+
+    test('false on non-numeric payout', () => {
+        expect(isJackpotHit({ jackpotPayout: '100' })).toBe(false);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// jackpotPrefixHtml
+// ---------------------------------------------------------------------------
+
+describe('jackpotPrefixHtml', () => {
+    test('renders the JACKPOT banner with payout amount and a trailing <br>', () => {
+        const html = jackpotPrefixHtml(1234);
+        expect(html).toContain('🎰');
+        expect(html).toContain('<strong>JACKPOT!</strong>');
+        expect(html).toContain('+1234 credits');
+        expect(html).toContain('<br>');
+    });
+
+    test('returns empty string when payout is 0', () => {
+        expect(jackpotPrefixHtml(0)).toBe('');
+    });
+
+    test('returns empty string when payout is undefined', () => {
+        expect(jackpotPrefixHtml(undefined)).toBe('');
+    });
+
+    test('returns empty string when payout is negative', () => {
+        expect(jackpotPrefixHtml(-50)).toBe('');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// renderWinHtml
+// ---------------------------------------------------------------------------
+
+describe('renderWinHtml', () => {
+    let resultEl;
+    const winLine = '<strong>+100 credits</strong>';
+
+    beforeEach(() => {
+        document.body.innerHTML = '<div id="r"></div>';
+        resultEl = document.getElementById('r');
+    });
+
+    test('returns the win line as-is when no jackpot was hit', () => {
+        const html = renderWinHtml(resultEl, { jackpotPayout: 0 }, 'slots-result-jackpot', winLine);
+
+        expect(html).toBe(winLine);
+        expect(resultEl.classList.contains('slots-result-jackpot')).toBe(false);
+    });
+
+    test('prepends the jackpot prefix and adds the jackpot class on a hit', () => {
+        const html = renderWinHtml(
+            resultEl,
+            { jackpotPayout: 500 },
+            'slots-result-jackpot',
+            winLine,
+        );
+
+        expect(html.startsWith('🎰')).toBe(true);
+        expect(html).toContain('+500 credits');
+        expect(html.endsWith(winLine)).toBe(true);
+        expect(resultEl.classList.contains('slots-result-jackpot')).toBe(true);
+    });
+
+    test('honours per-game class names', () => {
+        renderWinHtml(resultEl, { jackpotPayout: 1 }, 'highlow-result-jackpot', winLine);
+
+        expect(resultEl.classList.contains('highlow-result-jackpot')).toBe(true);
+        expect(resultEl.classList.contains('slots-result-jackpot')).toBe(false);
+    });
+
+    test('does not touch the element when there is no hit and no class', () => {
+        renderWinHtml(resultEl, null, 'slots-result-jackpot', winLine);
+
+        expect(resultEl.classList.length).toBe(0);
+    });
+});

--- a/web/src/test/js/coinflip.test.js
+++ b/web/src/test/js/coinflip.test.js
@@ -1,0 +1,45 @@
+const { renderCoinflipResult } = require('../../main/resources/static/js/coinflip');
+require('../../main/resources/static/js/casino-jackpot');
+
+describe('renderCoinflipResult', () => {
+    let resultEl;
+
+    beforeEach(() => {
+        document.body.innerHTML = '<div id="r"></div>';
+        resultEl = document.getElementById('r');
+    });
+
+    test('renders a win line with HEADS/TAILS labels and net', () => {
+        renderCoinflipResult(resultEl, {
+            win: true, landed: 'HEADS', predicted: 'HEADS', net: 100
+        });
+
+        expect(resultEl.classList.contains('coinflip-result-win')).toBe(true);
+        expect(resultEl.innerHTML).toContain('Heads');
+        expect(resultEl.innerHTML).toContain('+100 credits');
+    });
+
+    test('lose path explicitly says you called X but landed Y', () => {
+        renderCoinflipResult(resultEl, {
+            win: false, landed: 'TAILS', predicted: 'HEADS', net: -50
+        });
+
+        expect(resultEl.classList.contains('coinflip-result-lose')).toBe(true);
+        expect(resultEl.innerHTML).toContain('Tails');
+        expect(resultEl.innerHTML).toContain('Heads');
+        expect(resultEl.innerHTML).toContain('50 credits');
+    });
+
+    test('jackpot win prepends the JACKPOT banner', () => {
+        renderCoinflipResult(resultEl, {
+            win: true, landed: 'HEADS', predicted: 'HEADS', net: 100, jackpotPayout: 999
+        });
+
+        expect(resultEl.classList.contains('coinflip-result-jackpot')).toBe(true);
+        expect(resultEl.innerHTML).toContain('+999 credits');
+    });
+
+    test('returns early on missing result element', () => {
+        expect(() => renderCoinflipResult(null, { win: true })).not.toThrow();
+    });
+});

--- a/web/src/test/js/dice.test.js
+++ b/web/src/test/js/dice.test.js
@@ -1,0 +1,35 @@
+const { renderDiceResult } = require('../../main/resources/static/js/dice');
+require('../../main/resources/static/js/casino-jackpot');
+
+describe('renderDiceResult', () => {
+    let resultEl;
+
+    beforeEach(() => {
+        document.body.innerHTML = '<div id="r"></div>';
+        resultEl = document.getElementById('r');
+    });
+
+    test('win shows landed and predicted face plus net', () => {
+        renderDiceResult(resultEl, { win: true, landed: 4, predicted: 4, net: 500 });
+
+        expect(resultEl.classList.contains('dice-result-win')).toBe(true);
+        expect(resultEl.innerHTML).toContain('+500 credits');
+        expect(resultEl.innerHTML).toContain('4');
+    });
+
+    test('lose distinguishes predicted vs landed', () => {
+        renderDiceResult(resultEl, { win: false, landed: 2, predicted: 4, net: -100 });
+
+        expect(resultEl.classList.contains('dice-result-lose')).toBe(true);
+        expect(resultEl.innerHTML).toContain('100 credits');
+    });
+
+    test('jackpot win prepends the JACKPOT banner', () => {
+        renderDiceResult(resultEl, {
+            win: true, landed: 6, predicted: 6, net: 500, jackpotPayout: 2000
+        });
+
+        expect(resultEl.classList.contains('dice-result-jackpot')).toBe(true);
+        expect(resultEl.innerHTML).toContain('+2000 credits');
+    });
+});

--- a/web/src/test/js/highlow.test.js
+++ b/web/src/test/js/highlow.test.js
@@ -1,0 +1,60 @@
+const {
+    renderHighlowResult,
+    highlowCardLabel,
+} = require('../../main/resources/static/js/highlow');
+require('../../main/resources/static/js/casino-jackpot');
+
+describe('highlowCardLabel', () => {
+    test('maps face cards to letters', () => {
+        expect(highlowCardLabel(1)).toBe('A');
+        expect(highlowCardLabel(11)).toBe('J');
+        expect(highlowCardLabel(12)).toBe('Q');
+        expect(highlowCardLabel(13)).toBe('K');
+    });
+
+    test('returns the number string for spot cards', () => {
+        expect(highlowCardLabel(2)).toBe('2');
+        expect(highlowCardLabel(7)).toBe('7');
+        expect(highlowCardLabel(10)).toBe('10');
+    });
+});
+
+describe('renderHighlowResult', () => {
+    let resultEl;
+
+    beforeEach(() => {
+        document.body.innerHTML = '<div id="r"></div>';
+        resultEl = document.getElementById('r');
+    });
+
+    test('win on HIGHER renders next > anchor', () => {
+        renderHighlowResult(resultEl, {
+            win: true, anchor: 5, next: 11, direction: 'HIGHER', net: 100
+        });
+
+        expect(resultEl.classList.contains('highlow-result-win')).toBe(true);
+        expect(resultEl.innerHTML).toContain('J'); // 11 -> J
+        expect(resultEl.innerHTML).toContain('5');
+        expect(resultEl.innerHTML).toContain('Higher');
+        expect(resultEl.innerHTML).toContain('+100 credits');
+    });
+
+    test('lose on tie shows = and lost', () => {
+        renderHighlowResult(resultEl, {
+            win: false, anchor: 7, next: 7, direction: 'HIGHER', net: -50
+        });
+
+        expect(resultEl.classList.contains('highlow-result-lose')).toBe(true);
+        expect(resultEl.innerHTML).toContain('=');
+        expect(resultEl.innerHTML).toContain('lost');
+    });
+
+    test('jackpot win prepends the JACKPOT banner', () => {
+        renderHighlowResult(resultEl, {
+            win: true, anchor: 4, next: 12, direction: 'HIGHER', net: 100, jackpotPayout: 1500
+        });
+
+        expect(resultEl.classList.contains('highlow-result-jackpot')).toBe(true);
+        expect(resultEl.innerHTML).toContain('+1500 credits');
+    });
+});

--- a/web/src/test/js/scratch.test.js
+++ b/web/src/test/js/scratch.test.js
@@ -1,0 +1,52 @@
+const { renderScratchResult } = require('../../main/resources/static/js/scratch');
+require('../../main/resources/static/js/casino-jackpot');
+
+describe('renderScratchResult', () => {
+    let resultEl;
+    let balanceEl;
+
+    beforeEach(() => {
+        document.body.innerHTML = '<div id="r"></div><span id="b">0</span>';
+        resultEl = document.getElementById('r');
+        balanceEl = document.getElementById('b');
+    });
+
+    test('win shows match count, winning symbol, and net', () => {
+        renderScratchResult(resultEl, {
+            win: true, matchCount: 5, winningSymbol: '⭐', net: 200, newBalance: 1_200
+        }, 5, balanceEl);
+
+        expect(resultEl.classList.contains('scratch-result-win')).toBe(true);
+        expect(resultEl.innerHTML).toContain('5×');
+        expect(resultEl.innerHTML).toContain('⭐');
+        expect(resultEl.innerHTML).toContain('+200 credits');
+        expect(balanceEl.textContent).toBe('1200');
+    });
+
+    test('lose path uses the matchThreshold parameter in the message', () => {
+        renderScratchResult(resultEl, {
+            win: false, net: -50, newBalance: 950
+        }, 5, balanceEl);
+
+        expect(resultEl.classList.contains('scratch-result-lose')).toBe(true);
+        expect(resultEl.innerHTML).toContain('No 5-of-a-kind');
+        expect(resultEl.innerHTML).toContain('50 credits');
+    });
+
+    test('jackpot win prepends the JACKPOT banner', () => {
+        renderScratchResult(resultEl, {
+            win: true, matchCount: 9, winningSymbol: '⭐', net: 18000, newBalance: 25_000,
+            jackpotPayout: 7000
+        }, 5, balanceEl);
+
+        expect(resultEl.classList.contains('scratch-result-jackpot')).toBe(true);
+        expect(resultEl.innerHTML).toContain('+7000 credits');
+    });
+
+    test('skips balance update when newBalance is missing', () => {
+        balanceEl.textContent = '500';
+        renderScratchResult(resultEl, { win: false, net: -10 }, 3, balanceEl);
+
+        expect(balanceEl.textContent).toBe('500');
+    });
+});

--- a/web/src/test/js/slots.test.js
+++ b/web/src/test/js/slots.test.js
@@ -1,0 +1,62 @@
+// Smoke-test the pure render contract for the /spin response. The
+// IIFE in slots.js wires the form, postJson, and animation; this test
+// only exercises the render function so DOM mutations are deterministic.
+
+const { renderSlotsResult } = require('../../main/resources/static/js/slots');
+require('../../main/resources/static/js/casino-jackpot');
+
+describe('renderSlotsResult', () => {
+    let resultEl;
+
+    beforeEach(() => {
+        document.body.innerHTML = '<div id="r"></div>';
+        resultEl = document.getElementById('r');
+    });
+
+    test('renders a win line with the multiplier and net', () => {
+        renderSlotsResult(resultEl, {
+            win: true, multiplier: 5, net: 400, symbols: ['🍒', '🍒', '🍒']
+        });
+
+        expect(resultEl.classList.contains('slots-result-win')).toBe(true);
+        expect(resultEl.classList.contains('slots-result-lose')).toBe(false);
+        expect(resultEl.innerHTML).toContain('+400 credits');
+        expect(resultEl.innerHTML).toContain('5×');
+        expect(resultEl.hidden).toBe(false);
+    });
+
+    test('lose path shows the loss amount and the lose class', () => {
+        renderSlotsResult(resultEl, { win: false, net: -100, symbols: ['🍒', '🍋', '⭐'] });
+
+        expect(resultEl.classList.contains('slots-result-lose')).toBe(true);
+        expect(resultEl.classList.contains('slots-result-win')).toBe(false);
+        expect(resultEl.innerHTML).toContain('100 credits');
+    });
+
+    test('jackpot win prepends the JACKPOT banner via TobyJackpot helper', () => {
+        renderSlotsResult(resultEl, {
+            win: true, multiplier: 30, net: 2900, jackpotPayout: 5000,
+            symbols: ['⭐', '⭐', '⭐']
+        });
+
+        expect(resultEl.classList.contains('slots-result-jackpot')).toBe(true);
+        expect(resultEl.innerHTML.startsWith('🎰')).toBe(true);
+        expect(resultEl.innerHTML).toContain('+5000 credits');
+        expect(resultEl.innerHTML).toContain('+2900 credits');
+    });
+
+    test('clears prior win/lose/jackpot classes between renders', () => {
+        resultEl.classList.add('slots-result-jackpot');
+        resultEl.classList.add('slots-result-lose');
+
+        renderSlotsResult(resultEl, { win: true, multiplier: 2, net: 100, symbols: [] });
+
+        expect(resultEl.classList.contains('slots-result-jackpot')).toBe(false);
+        expect(resultEl.classList.contains('slots-result-lose')).toBe(false);
+        expect(resultEl.classList.contains('slots-result-win')).toBe(true);
+    });
+
+    test('returns early on missing result element', () => {
+        expect(() => renderSlotsResult(null, { win: true })).not.toThrow();
+    });
+});

--- a/web/src/test/kotlin/web/controller/CoinflipControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/CoinflipControllerTest.kt
@@ -3,6 +3,7 @@ package web.controller
 import database.economy.Coinflip
 import database.service.CoinflipService
 import database.service.CoinflipService.FlipOutcome
+import database.service.JackpotService
 import database.service.UserService
 import io.mockk.every
 import io.mockk.mockk
@@ -23,6 +24,7 @@ class CoinflipControllerTest {
     private lateinit var coinflipService: CoinflipService
     private lateinit var economyWebService: EconomyWebService
     private lateinit var userService: UserService
+    private lateinit var jackpotService: JackpotService
     private lateinit var jda: JDA
     private lateinit var user: OAuth2User
     private lateinit var controller: CoinflipController
@@ -32,13 +34,14 @@ class CoinflipControllerTest {
         coinflipService = mockk(relaxed = true)
         economyWebService = mockk(relaxed = true)
         userService = mockk(relaxed = true)
+        jackpotService = mockk(relaxed = true)
         jda = mockk(relaxed = true)
         user = mockk {
             every { getAttribute<String>("id") } returns discordId.toString()
             every { getAttribute<String>("username") } returns "tester"
         }
         every { economyWebService.isMember(discordId, guildId) } returns true
-        controller = CoinflipController(coinflipService, economyWebService, userService, jda)
+        controller = CoinflipController(coinflipService, economyWebService, userService, jackpotService, jda)
     }
 
     @Test
@@ -142,5 +145,39 @@ class CoinflipControllerTest {
 
         assertEquals(403, response.statusCode.value())
         verify(exactly = 0) { coinflipService.flip(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `jackpot win surfaces jackpotPayout in the response body`() {
+        every { coinflipService.flip(discordId, guildId, 100L, Coinflip.Side.HEADS) } returns FlipOutcome.Win(
+            stake = 100L,
+            payout = 200L,
+            net = 100L,
+            landed = Coinflip.Side.HEADS,
+            predicted = Coinflip.Side.HEADS,
+            newBalance = 5_100L,
+            jackpotPayout = 4_000L
+        )
+
+        val response = controller.flip(guildId, FlipRequest(side = "HEADS", stake = 100L), user)
+
+        assertTrue(response.statusCode.is2xxSuccessful)
+        assertEquals(4_000L, response.body!!.jackpotPayout)
+    }
+
+    @Test
+    fun `non-jackpot win does not include jackpotPayout`() {
+        every { coinflipService.flip(discordId, guildId, 100L, Coinflip.Side.HEADS) } returns FlipOutcome.Win(
+            stake = 100L,
+            payout = 200L,
+            net = 100L,
+            landed = Coinflip.Side.HEADS,
+            predicted = Coinflip.Side.HEADS,
+            newBalance = 1_100L
+        )
+
+        val response = controller.flip(guildId, FlipRequest(side = "HEADS", stake = 100L), user)
+
+        assertEquals(null, response.body!!.jackpotPayout)
     }
 }

--- a/web/src/test/kotlin/web/controller/DiceControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/DiceControllerTest.kt
@@ -2,6 +2,7 @@ package web.controller
 
 import database.service.DiceService
 import database.service.DiceService.RollOutcome
+import database.service.JackpotService
 import database.service.UserService
 import io.mockk.every
 import io.mockk.mockk
@@ -22,6 +23,7 @@ class DiceControllerTest {
     private lateinit var diceService: DiceService
     private lateinit var economyWebService: EconomyWebService
     private lateinit var userService: UserService
+    private lateinit var jackpotService: JackpotService
     private lateinit var jda: JDA
     private lateinit var user: OAuth2User
     private lateinit var controller: DiceController
@@ -31,13 +33,14 @@ class DiceControllerTest {
         diceService = mockk(relaxed = true)
         economyWebService = mockk(relaxed = true)
         userService = mockk(relaxed = true)
+        jackpotService = mockk(relaxed = true)
         jda = mockk(relaxed = true)
         user = mockk {
             every { getAttribute<String>("id") } returns discordId.toString()
             every { getAttribute<String>("username") } returns "tester"
         }
         every { economyWebService.isMember(discordId, guildId) } returns true
-        controller = DiceController(diceService, economyWebService, userService, jda)
+        controller = DiceController(diceService, economyWebService, userService, jackpotService, jda)
     }
 
     @Test
@@ -112,5 +115,28 @@ class DiceControllerTest {
 
         assertEquals(403, response.statusCode.value())
         verify(exactly = 0) { diceService.roll(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `jackpot win surfaces jackpotPayout in the response body`() {
+        every { diceService.roll(discordId, guildId, 100L, 4) } returns RollOutcome.Win(
+            stake = 100L, payout = 500L, net = 400L, landed = 4, predicted = 4,
+            newBalance = 11_400L, jackpotPayout = 10_000L
+        )
+
+        val response = controller.roll(guildId, RollRequest(prediction = 4, stake = 100L), user)
+
+        assertEquals(10_000L, response.body!!.jackpotPayout)
+    }
+
+    @Test
+    fun `non-jackpot win does not include jackpotPayout`() {
+        every { diceService.roll(discordId, guildId, 100L, 4) } returns RollOutcome.Win(
+            stake = 100L, payout = 500L, net = 400L, landed = 4, predicted = 4, newBalance = 1_400L
+        )
+
+        val response = controller.roll(guildId, RollRequest(prediction = 4, stake = 100L), user)
+
+        assertEquals(null, response.body!!.jackpotPayout)
     }
 }

--- a/web/src/test/kotlin/web/controller/HighlowControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/HighlowControllerTest.kt
@@ -3,6 +3,7 @@ package web.controller
 import database.economy.Highlow
 import database.service.HighlowService
 import database.service.HighlowService.PlayOutcome
+import database.service.JackpotService
 import database.service.UserService
 import io.mockk.every
 import io.mockk.mockk
@@ -30,6 +31,7 @@ class HighlowControllerTest {
     private lateinit var highlowService: HighlowService
     private lateinit var economyWebService: EconomyWebService
     private lateinit var userService: UserService
+    private lateinit var jackpotService: JackpotService
     private lateinit var jda: JDA
     private lateinit var user: OAuth2User
     private lateinit var session: HttpSession
@@ -40,6 +42,7 @@ class HighlowControllerTest {
         highlowService = mockk(relaxed = true)
         economyWebService = mockk(relaxed = true)
         userService = mockk(relaxed = true)
+        jackpotService = mockk(relaxed = true)
         jda = mockk(relaxed = true)
         user = mockk {
             every { getAttribute<String>("id") } returns discordId.toString()
@@ -54,7 +57,7 @@ class HighlowControllerTest {
         }
         every { jda.getGuildById(guildId) } returns guild
 
-        controller = HighlowController(highlowService, economyWebService, userService, jda)
+        controller = HighlowController(highlowService, economyWebService, userService, jackpotService, jda)
     }
 
     @Test
@@ -155,6 +158,30 @@ class HighlowControllerTest {
         assertEquals(400, response.statusCode.value())
         assertNotNull(response.body!!.error)
         verify(exactly = 0) { highlowService.play(any(), any(), any(), any(), any<Int>()) }
+    }
+
+    @Test
+    fun `jackpot win surfaces jackpotPayout in the response body`() {
+        session.setAttribute(anchorKey, 5)
+        every {
+            highlowService.play(discordId, guildId, 50L, Highlow.Direction.HIGHER, 5)
+        } returns PlayOutcome.Win(
+            stake = 50L, payout = 100L, net = 50L,
+            anchor = 5, next = 12,
+            direction = Highlow.Direction.HIGHER,
+            newBalance = 5_050L,
+            jackpotPayout = 4_000L
+        )
+        every { highlowService.dealAnchor() } returns 9
+
+        val response = controller.play(
+            guildId,
+            PlayRequest(direction = "HIGHER", stake = 50L),
+            user,
+            session
+        )
+
+        assertEquals(4_000L, response.body!!.jackpotPayout)
     }
 
     private fun inMemorySession(): HttpSession {

--- a/web/src/test/kotlin/web/controller/ScratchControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/ScratchControllerTest.kt
@@ -1,6 +1,7 @@
 package web.controller
 
 import database.economy.SlotMachine
+import database.service.JackpotService
 import database.service.ScratchService
 import database.service.ScratchService.ScratchOutcome
 import database.service.UserService
@@ -23,6 +24,7 @@ class ScratchControllerTest {
     private lateinit var scratchService: ScratchService
     private lateinit var economyWebService: EconomyWebService
     private lateinit var userService: UserService
+    private lateinit var jackpotService: JackpotService
     private lateinit var jda: JDA
     private lateinit var user: OAuth2User
     private lateinit var controller: ScratchController
@@ -32,13 +34,14 @@ class ScratchControllerTest {
         scratchService = mockk(relaxed = true)
         economyWebService = mockk(relaxed = true)
         userService = mockk(relaxed = true)
+        jackpotService = mockk(relaxed = true)
         jda = mockk(relaxed = true)
         user = mockk {
             every { getAttribute<String>("id") } returns discordId.toString()
             every { getAttribute<String>("username") } returns "tester"
         }
         every { economyWebService.isMember(discordId, guildId) } returns true
-        controller = ScratchController(scratchService, economyWebService, userService, jda)
+        controller = ScratchController(scratchService, economyWebService, userService, jackpotService, jda)
     }
 
     @Test
@@ -112,5 +115,21 @@ class ScratchControllerTest {
 
         assertEquals(403, response.statusCode.value())
         verify(exactly = 0) { scratchService.scratch(any(), any(), any()) }
+    }
+
+    @Test
+    fun `jackpot win surfaces jackpotPayout in the response body`() {
+        every { scratchService.scratch(discordId, guildId, 100L) } returns ScratchOutcome.Win(
+            stake = 100L, payout = 3_000L, net = 2_900L,
+            cells = List(9) { SlotMachine.Symbol.STAR },
+            winningSymbol = SlotMachine.Symbol.STAR,
+            matchCount = 9,
+            newBalance = 8_900L,
+            jackpotPayout = 6_000L
+        )
+
+        val response = controller.scratch(guildId, ScratchRequest(stake = 100L), user)
+
+        assertEquals(6_000L, response.body!!.jackpotPayout)
     }
 }

--- a/web/src/test/kotlin/web/controller/SlotsControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/SlotsControllerTest.kt
@@ -1,6 +1,7 @@
 package web.controller
 
 import database.economy.SlotMachine
+import database.service.JackpotService
 import database.service.SlotsService
 import database.service.SlotsService.SpinOutcome
 import database.service.UserService
@@ -29,6 +30,7 @@ class SlotsControllerTest {
     private lateinit var slotsService: SlotsService
     private lateinit var economyWebService: EconomyWebService
     private lateinit var userService: UserService
+    private lateinit var jackpotService: JackpotService
     private lateinit var jda: JDA
     private lateinit var user: OAuth2User
     private lateinit var controller: SlotsController
@@ -38,13 +40,14 @@ class SlotsControllerTest {
         slotsService = mockk(relaxed = true)
         economyWebService = mockk(relaxed = true)
         userService = mockk(relaxed = true)
+        jackpotService = mockk(relaxed = true)
         jda = mockk(relaxed = true)
         user = mockk {
             every { getAttribute<String>("id") } returns discordId.toString()
             every { getAttribute<String>("username") } returns "tester"
         }
         every { economyWebService.isMember(discordId, guildId) } returns true
-        controller = SlotsController(slotsService, economyWebService, userService, jda)
+        controller = SlotsController(slotsService, economyWebService, userService, jackpotService, jda)
     }
 
     @Test
@@ -141,5 +144,43 @@ class SlotsControllerTest {
 
         assertEquals(403, response.statusCode.value())
         verify(exactly = 0) { slotsService.spin(any(), any(), any()) }
+    }
+
+    @Test
+    fun `jackpot win surfaces jackpotPayout in the response body`() {
+        every { slotsService.spin(discordId, guildId, 100L) } returns SpinOutcome.Win(
+            stake = 100L,
+            multiplier = 5L,
+            payout = 500L,
+            net = 400L,
+            symbols = listOf(SlotMachine.Symbol.STAR, SlotMachine.Symbol.STAR, SlotMachine.Symbol.STAR),
+            newBalance = 9_000L,
+            jackpotPayout = 7_500L
+        )
+
+        val response = controller.spin(guildId, SpinRequest(stake = 100L), user)
+
+        assertTrue(response.statusCode.is2xxSuccessful)
+        val body = response.body!!
+        assertEquals(true, body.win)
+        assertEquals(7_500L, body.jackpotPayout, "jackpot payout passes straight through")
+        assertEquals(9_000L, body.newBalance, "newBalance already includes the jackpot per service contract")
+    }
+
+    @Test
+    fun `non-jackpot win does not include jackpotPayout`() {
+        every { slotsService.spin(discordId, guildId, 100L) } returns SpinOutcome.Win(
+            stake = 100L,
+            multiplier = 2L,
+            payout = 200L,
+            net = 100L,
+            symbols = listOf(SlotMachine.Symbol.CHERRY, SlotMachine.Symbol.CHERRY, SlotMachine.Symbol.CHERRY),
+            newBalance = 1_100L,
+            jackpotPayout = 0L
+        )
+
+        val response = controller.spin(guildId, SpinRequest(stake = 100L), user)
+
+        assertEquals(null, response.body!!.jackpotPayout, "zero jackpot is omitted from the JSON shape")
     }
 }

--- a/web/src/test/kotlin/web/static/CasinoJackpotCssRegressionTest.kt
+++ b/web/src/test/kotlin/web/static/CasinoJackpotCssRegressionTest.kt
@@ -1,0 +1,48 @@
+package web.static
+
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * The jackpot banner and per-game `*-result-jackpot` accent live in
+ * `base.css` so every minigame page (slots / coinflip / dice / highlow /
+ * scratch) renders them without duplicating styles. If a future cleanup
+ * relocates these to a per-game stylesheet without porting them all, the
+ * banner reverts to default text styling and the jackpot win line stops
+ * looking distinct — both regressions players have explicitly asked us
+ * to keep visible.
+ */
+class CasinoJackpotCssRegressionTest {
+
+    private val css: String by lazy {
+        javaClass.classLoader
+            .getResourceAsStream("static/css/base.css")
+            ?.bufferedReader()
+            ?.readText()
+            ?: error("base.css is not on the classpath")
+    }
+
+    @Test
+    fun `base css declares the casino-jackpot-banner class`() {
+        assertTrue(
+            css.contains(".casino-jackpot-banner"),
+            "base.css must define .casino-jackpot-banner so every minigame template's pool render is styled."
+        )
+    }
+
+    @Test
+    fun `base css declares the per-game result-jackpot accents`() {
+        listOf(
+            ".slots-result-jackpot",
+            ".coinflip-result-jackpot",
+            ".dice-result-jackpot",
+            ".highlow-result-jackpot",
+            ".scratch-result-jackpot"
+        ).forEach { selector ->
+            assertTrue(
+                css.contains(selector),
+                "base.css must include $selector so JS-attached jackpot wins render with the shared accent."
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Trade fees now fund a per-guild **jackpot pool**, and casino minigame wins can bank it.

- Every `/economy buy` and `/economy sell` skims a flat **1 % fee** off the leg's total and routes it into a per-guild jackpot pool.
- Every minigame **Win** rolls a **1 %** chance to hit the jackpot. If hit, the player banks the entire pool atomically and the counter resets. Active traders directly fund the gambling rewards loop.
- Mechanically, fees+jackpot also reinforce the round-trip exploit fix: a buy-then-sell round-trip eats ~2 % to the pool on top of midpoint slippage.

## Stack

| Layer | What changed |
|---|---|
| **DB** | `V18__toby_coin_jackpot.sql` adds `(guild_id PK, pool BIGINT)`. |
| **Persistence** | `TobyCoinJackpotDto`, `TobyCoinJackpotPersistence` (+ default impl) — same `PESSIMISTIC_WRITE` pattern as the market row. |
| **Service** | `JackpotService` (`getPool` / `addToPool` / `awardJackpot`) with row-locked mutations so two concurrent winners can't both bank the same pool. |
| **Trade fee** | `EconomyTradeService.buy/sell` skim `TobyCoinEngine.TRADE_FEE` (1 %) on top of the midpoint cost / off the midpoint proceeds, then deposit via `JackpotService.addToPool`. Outcome.Ok carries a new `fee` field. |
| **Minigame integration** | `JackpotHelper.rollOnWin` rolls the per-game dice on a Win, pulls the pool atomically if hit, credits the already-locked user. All 5 services accept `JackpotService` and surface a `jackpotPayout` on Win. |
| **Web** | All 5 controllers thread `jackpotPayout` (omitted when zero) and render the live pool size on the GET model. All 5 templates show a `🎰 Jackpot pool: X credits` banner. Per-game `*-result-jackpot` accents in `base.css`. |
| **Frontend** | Each `showResult` hoisted out of its IIFE wrapper so jest can drive it directly. Shared `🎰 JACKPOT!` prefix lives in `casino-jackpot.js`, used by all 5 games. |

## Tests

- **Kotlin (`:database:test` + `:web:test`)** — both green.
  - `JackpotServiceTest` — seed/increment/award/no-op cases.
  - 5× minigame controller tests gained `jackpot win surfaces jackpotPayout` + `non-jackpot win does not include jackpotPayout`.
  - 5× service tests updated for the new `JackpotService` ctor.
  - `CasinoJackpotCssRegressionTest` pins the banner + accents in `base.css`.
- **Jest** — 119/119 green (was 85 before).
  - `casino-jackpot.test.js` — 12 cases on the shared helper.
  - `slots/coinflip/dice/highlow/scratch.test.js` — render contract per game (win, lose, jackpot-win paths).

## Test plan
- [x] `:database:test :web:test --offline`
- [x] `npm test` (119 pass)
- [ ] Manual: open `/casino/{guildId}/slots`. Confirm the jackpot banner renders. Spin until a win — verify the response carries no `jackpotPayout` ~99 % of the time. Force a hit (or just trade enough to grow the pool, then play many spins) and confirm the result line prepends the JACKPOT banner.
- [ ] Manual: `/economy buy 100` then check the trade row's reported fee. Confirm `/casino/{guildId}` shows the pool growing.

## Out of scope (follow-ups)
- Live pool refresh after a jackpot hit (currently relies on page reload).
- Trade-record `reason` column (was queued for the casino top-up PR).
- Jackpot win recap on a future "casino history" page.

https://claude.ai/code/session_01JvuveFBoCvMFTK8XxXVN56

---
_Generated by [Claude Code](https://claude.ai/code/session_01JvuveFBoCvMFTK8XxXVN56)_