### PR TITLE
feat(casino): sell-TOBY-to-fund-bet button + reason-tagged trades on chart

### DIFF
--- a/database/src/main/kotlin/database/dto/TobyCoinTradeDto.kt
+++ b/database/src/main/kotlin/database/dto/TobyCoinTradeDto.kt
@@ -49,5 +49,12 @@ class TobyCoinTradeDto(
     var pricePerCoin: Double = 0.0,
 
     @Column(name = "executed_at", nullable = false)
-    var executedAt: Instant = Instant.now()
+    var executedAt: Instant = Instant.now(),
+
+    // 'USER' (default) → manual `/economy sell` or `/tobycoin sell`.
+    // 'TITLE_TOPUP' → TitlesWebService.buyTitleWithTobyCoin auto-sold
+    // to cover a credit shortfall. 'CASINO_TOPUP' → a casino minigame
+    // (slots/coinflip/dice/highlow/scratch) auto-sold to fund a wager.
+    @Column(name = "reason", nullable = false)
+    var reason: String = "USER"
 ) : Serializable

--- a/database/src/main/kotlin/database/economy/TobyCoinEngine.kt
+++ b/database/src/main/kotlin/database/economy/TobyCoinEngine.kt
@@ -81,6 +81,47 @@ object TobyCoinEngine {
     fun applySellPressure(price: Double, coins: Long): Double =
         max(PRICE_FLOOR, price * (1.0 - TRADE_IMPACT * coins))
 
+    /**
+     * Net credits the seller actually receives for [coins] sold at
+     * pre-pressure [price] — the same math `EconomyTradeService.sell`
+     * applies, exposed so callers that need to size a sell to a
+     * target shortfall (Titles' "Buy with TOBY", casino top-up) don't
+     * re-derive it.
+     *
+     * = floor(midpoint × N) − floor(floor(midpoint × N) × TRADE_FEE)
+     */
+    fun proceedsForSell(price: Double, coins: Long): Long {
+        if (coins <= 0L || price <= 0.0) return 0L
+        val newPrice = applySellPressure(price, coins)
+        val midpoint = (price + newPrice) / 2.0
+        val gross = kotlin.math.floor(midpoint * coins).toLong()
+        val fee = kotlin.math.floor(gross * TRADE_FEE).toLong()
+        return gross - fee
+    }
+
+    /**
+     * Smallest coin count whose sell proceeds (after slippage + fee)
+     * cover [shortfall]. The naive `ceil(shortfall / price)` undercounts
+     * by 1–2 coins because the trader eats half the slippage and 1 %
+     * goes to the jackpot pool. We bump iteratively; bounded for
+     * safety against pathological `k × N` regimes.
+     *
+     * Returns the *true* required coin count regardless of what the
+     * user actually holds — callers compare against the balance and
+     * surface "insufficient coins" themselves.
+     */
+    fun coinsNeededForShortfall(shortfall: Long, price: Double): Long {
+        if (shortfall <= 0L || price <= 0.0) return 0L
+        var n = kotlin.math.ceil(shortfall.toDouble() / price).toLong().coerceAtLeast(1L)
+        // 16 iterations: empirically the loop converges in 1–2 for sane
+        // shortfalls. The cap is just paranoia for adversarial inputs.
+        repeat(16) {
+            if (proceedsForSell(price, n) >= shortfall) return n
+            n += 1L
+        }
+        return n
+    }
+
     /** Box–Muller — Kotlin's stdlib has nextDouble() but no normal sampler. */
     private fun gaussian(random: Random): Double {
         var u1: Double

--- a/database/src/main/kotlin/database/service/CasinoTopUpHelper.kt
+++ b/database/src/main/kotlin/database/service/CasinoTopUpHelper.kt
@@ -1,0 +1,89 @@
+package database.service
+
+import database.dto.UserDto
+import database.economy.TobyCoinEngine
+import database.service.EconomyTradeService.TradeOutcome
+
+/**
+ * Shared sell-to-cover-shortfall helper for the casino minigame
+ * services. Mirrors the shape of [TitlesWebService.buyTitleWithTobyCoin]:
+ * size the sell to cover the shortfall under midpoint slippage + the
+ * jackpot fee, validate the player holds enough TOBY, then delegate to
+ * [EconomyTradeService.sell] with `reason="CASINO_TOPUP"` so the
+ * resulting trade row shows up on the chart with the right attribution.
+ *
+ * Caller is expected to have already locked the user row via
+ * [WagerHelper.checkAndLock]. The market row is locked here because
+ * `EconomyTradeService.sell` re-locks it under the same transaction —
+ * Hibernate returns the same managed entity, no second DB lock acquired.
+ */
+internal sealed interface TopUpResult {
+    data class ToppedUp(
+        val user: UserDto,
+        val balance: Long,
+        val soldCoins: Long,
+        val newPrice: Double
+    ) : TopUpResult
+
+    data class InsufficientCoins(val needed: Long, val have: Long) : TopUpResult
+
+    data object MarketUnavailable : TopUpResult
+}
+
+internal object CasinoTopUpHelper {
+
+    /**
+     * Sell exactly enough TOBY to lift [user]'s balance from
+     * [currentBalance] up to at least [stake], using the live market
+     * price. No-op responsibility lives in the caller — only invoke
+     * this when balance < stake.
+     */
+    fun ensureCreditsForWager(
+        tradeService: EconomyTradeService,
+        marketService: TobyCoinMarketService,
+        userService: UserService,
+        user: UserDto,
+        guildId: Long,
+        currentBalance: Long,
+        stake: Long
+    ): TopUpResult {
+        val shortfall = (stake - currentBalance).coerceAtLeast(0L)
+        if (shortfall == 0L) {
+            // Defensive — caller should have skipped the call entirely.
+            return TopUpResult.ToppedUp(user, currentBalance, soldCoins = 0L, newPrice = 0.0)
+        }
+
+        val market = marketService.getMarketForUpdate(guildId)
+            ?: return TopUpResult.MarketUnavailable
+        if (market.price <= 0.0) return TopUpResult.MarketUnavailable
+
+        val coinsNeeded = TobyCoinEngine.coinsNeededForShortfall(shortfall, market.price)
+        if (user.tobyCoins < coinsNeeded) {
+            return TopUpResult.InsufficientCoins(needed = coinsNeeded, have = user.tobyCoins)
+        }
+
+        val sell = tradeService.sell(
+            discordId = user.discordId,
+            guildId = guildId,
+            amount = coinsNeeded,
+            reason = EconomyTradeService.REASON_CASINO_TOPUP
+        )
+        if (sell !is TradeOutcome.Ok) {
+            // Sell shouldn't realistically fail here — we already checked
+            // coin count and market price. But surface as MarketUnavailable
+            // rather than crashing the wager.
+            return TopUpResult.MarketUnavailable
+        }
+
+        // Re-read the user under the same transaction so the wager sees
+        // the post-sell balance — Hibernate returns the same managed
+        // entity, no extra round-trip.
+        val refreshed = userService.getUserByIdForUpdate(user.discordId, guildId) ?: user
+        return TopUpResult.ToppedUp(
+            user = refreshed,
+            balance = refreshed.socialCredit ?: 0L,
+            soldCoins = coinsNeeded,
+            newPrice = sell.newPrice
+        )
+    }
+}

--- a/database/src/main/kotlin/database/service/CoinflipService.kt
+++ b/database/src/main/kotlin/database/service/CoinflipService.kt
@@ -11,12 +11,18 @@ import kotlin.random.Random
  * here, mirroring the [SlotsService] pattern: lock the user row first
  * via [UserService.getUserByIdForUpdate], validate inputs, mutate,
  * persist, all inside a single `@Transactional` boundary.
+ *
+ * Web callers can request `autoTopUp` to sell TOBY for the credit
+ * shortfall via [CasinoTopUpHelper]; the resulting trade row is tagged
+ * `CASINO_TOPUP`.
  */
 @Service
 @Transactional
 class CoinflipService(
     private val userService: UserService,
     private val jackpotService: JackpotService,
+    private val tradeService: EconomyTradeService,
+    private val marketService: TobyCoinMarketService,
     private val coinflip: Coinflip = Coinflip(),
     private val random: Random = Random.Default
 ) {
@@ -29,51 +35,88 @@ class CoinflipService(
             val landed: Coinflip.Side,
             val predicted: Coinflip.Side,
             val newBalance: Long,
-            val jackpotPayout: Long = 0L
+            val jackpotPayout: Long = 0L,
+            val soldTobyCoins: Long = 0L,
+            val newPrice: Double? = null
         ) : FlipOutcome
 
         data class Lose(
             val stake: Long,
             val landed: Coinflip.Side,
             val predicted: Coinflip.Side,
-            val newBalance: Long
+            val newBalance: Long,
+            val soldTobyCoins: Long = 0L,
+            val newPrice: Double? = null
         ) : FlipOutcome
 
         data class InsufficientCredits(val stake: Long, val have: Long) : FlipOutcome
+        data class InsufficientCoinsForTopUp(val needed: Long, val have: Long) : FlipOutcome
         data class InvalidStake(val min: Long, val max: Long) : FlipOutcome
         data object UnknownUser : FlipOutcome
     }
 
-    fun flip(discordId: Long, guildId: Long, stake: Long, predicted: Coinflip.Side): FlipOutcome {
-        return when (val check = WagerHelper.checkAndLock(
+    fun flip(
+        discordId: Long,
+        guildId: Long,
+        stake: Long,
+        predicted: Coinflip.Side,
+        autoTopUp: Boolean = false
+    ): FlipOutcome {
+        val initial = WagerHelper.checkAndLock(
             userService, discordId, guildId, stake, Coinflip.MIN_STAKE, Coinflip.MAX_STAKE
-        )) {
-            is BalanceCheck.InvalidStake -> FlipOutcome.InvalidStake(check.min, check.max)
-            BalanceCheck.UnknownUser -> FlipOutcome.UnknownUser
-            is BalanceCheck.Insufficient -> FlipOutcome.InsufficientCredits(check.stake, check.have)
-            is BalanceCheck.Ok -> {
-                val flip = coinflip.flip(predicted, random)
-                val r = WagerHelper.applyMultiplier(userService, check.user, check.balance, stake, flip.multiplier)
-                if (flip.isWin) {
-                    val jackpot = JackpotHelper.rollOnWin(jackpotService, userService, check.user, guildId, random)
-                    FlipOutcome.Win(
-                        stake = stake,
-                        payout = r.payout,
-                        net = r.net,
-                        landed = flip.landed,
-                        predicted = flip.predicted,
-                        newBalance = r.newBalance + jackpot,
-                        jackpotPayout = jackpot
-                    )
-                } else {
-                    FlipOutcome.Lose(
-                        stake = stake,
-                        landed = flip.landed,
-                        predicted = flip.predicted,
-                        newBalance = r.newBalance
-                    )
+        )
+        var soldCoins = 0L
+        var newPrice: Double? = null
+        val resolved = when (initial) {
+            is BalanceCheck.InvalidStake -> return FlipOutcome.InvalidStake(initial.min, initial.max)
+            BalanceCheck.UnknownUser -> return FlipOutcome.UnknownUser
+            is BalanceCheck.Insufficient -> {
+                if (!autoTopUp) return FlipOutcome.InsufficientCredits(initial.stake, initial.have)
+                val user = userService.getUserByIdForUpdate(discordId, guildId)
+                    ?: return FlipOutcome.UnknownUser
+                val topUp = CasinoTopUpHelper.ensureCreditsForWager(
+                    tradeService, marketService, userService,
+                    user, guildId, currentBalance = initial.have, stake = stake
+                )
+                when (topUp) {
+                    is TopUpResult.InsufficientCoins ->
+                        return FlipOutcome.InsufficientCoinsForTopUp(topUp.needed, topUp.have)
+                    TopUpResult.MarketUnavailable ->
+                        return FlipOutcome.InsufficientCredits(initial.stake, initial.have)
+                    is TopUpResult.ToppedUp -> {
+                        soldCoins = topUp.soldCoins
+                        newPrice = topUp.newPrice
+                        BalanceCheck.Ok(topUp.user, topUp.balance)
+                    }
                 }
             }
+            is BalanceCheck.Ok -> initial
+        }
+
+        val flip = coinflip.flip(predicted, random)
+        val r = WagerHelper.applyMultiplier(userService, resolved.user, resolved.balance, stake, flip.multiplier)
+        return if (flip.isWin) {
+            val jackpot = JackpotHelper.rollOnWin(jackpotService, userService, resolved.user, guildId, random)
+            FlipOutcome.Win(
+                stake = stake,
+                payout = r.payout,
+                net = r.net,
+                landed = flip.landed,
+                predicted = flip.predicted,
+                newBalance = r.newBalance + jackpot,
+                jackpotPayout = jackpot,
+                soldTobyCoins = soldCoins,
+                newPrice = newPrice
+            )
+        } else {
+            FlipOutcome.Lose(
+                stake = stake,
+                landed = flip.landed,
+                predicted = flip.predicted,
+                newBalance = r.newBalance,
+                soldTobyCoins = soldCoins,
+                newPrice = newPrice
+            )
         }
     }
 }

--- a/database/src/main/kotlin/database/service/DiceService.kt
+++ b/database/src/main/kotlin/database/service/DiceService.kt
@@ -10,12 +10,18 @@ import kotlin.random.Random
  * pattern as [SlotsService] / [CoinflipService] via
  * [UserService.getUserByIdForUpdate] so concurrent rolls from the same
  * user (Discord + web at once, or spam-clicking) can't double-spend.
+ *
+ * Web callers can request `autoTopUp` to sell TOBY for the credit
+ * shortfall via [CasinoTopUpHelper]; the resulting trade row is tagged
+ * `CASINO_TOPUP`.
  */
 @Service
 @Transactional
 class DiceService(
     private val userService: UserService,
     private val jackpotService: JackpotService,
+    private val tradeService: EconomyTradeService,
+    private val marketService: TobyCoinMarketService,
     private val dice: Dice = Dice(),
     private val random: Random = Random.Default
 ) {
@@ -28,55 +34,92 @@ class DiceService(
             val landed: Int,
             val predicted: Int,
             val newBalance: Long,
-            val jackpotPayout: Long = 0L
+            val jackpotPayout: Long = 0L,
+            val soldTobyCoins: Long = 0L,
+            val newPrice: Double? = null
         ) : RollOutcome
 
         data class Lose(
             val stake: Long,
             val landed: Int,
             val predicted: Int,
-            val newBalance: Long
+            val newBalance: Long,
+            val soldTobyCoins: Long = 0L,
+            val newPrice: Double? = null
         ) : RollOutcome
 
         data class InsufficientCredits(val stake: Long, val have: Long) : RollOutcome
+        data class InsufficientCoinsForTopUp(val needed: Long, val have: Long) : RollOutcome
         data class InvalidStake(val min: Long, val max: Long) : RollOutcome
         data class InvalidPrediction(val min: Int, val max: Int) : RollOutcome
         data object UnknownUser : RollOutcome
     }
 
-    fun roll(discordId: Long, guildId: Long, stake: Long, predicted: Int): RollOutcome {
+    fun roll(
+        discordId: Long,
+        guildId: Long,
+        stake: Long,
+        predicted: Int,
+        autoTopUp: Boolean = false
+    ): RollOutcome {
         if (!dice.isValidPrediction(predicted)) {
             return RollOutcome.InvalidPrediction(1, dice.sidesCount)
         }
-        return when (val check = WagerHelper.checkAndLock(
+        val initial = WagerHelper.checkAndLock(
             userService, discordId, guildId, stake, Dice.MIN_STAKE, Dice.MAX_STAKE
-        )) {
-            is BalanceCheck.InvalidStake -> RollOutcome.InvalidStake(check.min, check.max)
-            BalanceCheck.UnknownUser -> RollOutcome.UnknownUser
-            is BalanceCheck.Insufficient -> RollOutcome.InsufficientCredits(check.stake, check.have)
-            is BalanceCheck.Ok -> {
-                val roll = dice.roll(predicted, random)
-                val r = WagerHelper.applyMultiplier(userService, check.user, check.balance, stake, roll.multiplier)
-                if (roll.isWin) {
-                    val jackpot = JackpotHelper.rollOnWin(jackpotService, userService, check.user, guildId, random)
-                    RollOutcome.Win(
-                        stake = stake,
-                        payout = r.payout,
-                        net = r.net,
-                        landed = roll.landed,
-                        predicted = roll.predicted,
-                        newBalance = r.newBalance + jackpot,
-                        jackpotPayout = jackpot
-                    )
-                } else {
-                    RollOutcome.Lose(
-                        stake = stake,
-                        landed = roll.landed,
-                        predicted = roll.predicted,
-                        newBalance = r.newBalance
-                    )
+        )
+        var soldCoins = 0L
+        var newPrice: Double? = null
+        val resolved = when (initial) {
+            is BalanceCheck.InvalidStake -> return RollOutcome.InvalidStake(initial.min, initial.max)
+            BalanceCheck.UnknownUser -> return RollOutcome.UnknownUser
+            is BalanceCheck.Insufficient -> {
+                if (!autoTopUp) return RollOutcome.InsufficientCredits(initial.stake, initial.have)
+                val user = userService.getUserByIdForUpdate(discordId, guildId)
+                    ?: return RollOutcome.UnknownUser
+                val topUp = CasinoTopUpHelper.ensureCreditsForWager(
+                    tradeService, marketService, userService,
+                    user, guildId, currentBalance = initial.have, stake = stake
+                )
+                when (topUp) {
+                    is TopUpResult.InsufficientCoins ->
+                        return RollOutcome.InsufficientCoinsForTopUp(topUp.needed, topUp.have)
+                    TopUpResult.MarketUnavailable ->
+                        return RollOutcome.InsufficientCredits(initial.stake, initial.have)
+                    is TopUpResult.ToppedUp -> {
+                        soldCoins = topUp.soldCoins
+                        newPrice = topUp.newPrice
+                        BalanceCheck.Ok(topUp.user, topUp.balance)
+                    }
                 }
             }
+            is BalanceCheck.Ok -> initial
+        }
+
+        val roll = dice.roll(predicted, random)
+        val r = WagerHelper.applyMultiplier(userService, resolved.user, resolved.balance, stake, roll.multiplier)
+        return if (roll.isWin) {
+            val jackpot = JackpotHelper.rollOnWin(jackpotService, userService, resolved.user, guildId, random)
+            RollOutcome.Win(
+                stake = stake,
+                payout = r.payout,
+                net = r.net,
+                landed = roll.landed,
+                predicted = roll.predicted,
+                newBalance = r.newBalance + jackpot,
+                jackpotPayout = jackpot,
+                soldTobyCoins = soldCoins,
+                newPrice = newPrice
+            )
+        } else {
+            RollOutcome.Lose(
+                stake = stake,
+                landed = roll.landed,
+                predicted = roll.predicted,
+                newBalance = r.newBalance,
+                soldTobyCoins = soldCoins,
+                newPrice = newPrice
+            )
         }
     }
 }

--- a/database/src/main/kotlin/database/service/EconomyTradeService.kt
+++ b/database/src/main/kotlin/database/service/EconomyTradeService.kt
@@ -80,7 +80,12 @@ class EconomyTradeService(
         return fresh
     }
 
-    fun buy(discordId: Long, guildId: Long, amount: Long): TradeOutcome {
+    fun buy(
+        discordId: Long,
+        guildId: Long,
+        amount: Long,
+        reason: String = REASON_USER
+    ): TradeOutcome {
         if (amount <= 0) return TradeOutcome.InvalidAmount
         // Lock order — user first, then market. Same in sell() to avoid deadlock.
         val user = userService.getUserByIdForUpdate(discordId, guildId)
@@ -104,7 +109,7 @@ class EconomyTradeService(
 
         if (fee > 0L) jackpotService.addToPool(guildId, fee)
 
-        commitPriceChange(market, newPrice, executionPrice, discordId, "BUY", amount)
+        commitPriceChange(market, newPrice, executionPrice, discordId, "BUY", amount, reason)
 
         return TradeOutcome.Ok(
             amount = amount,
@@ -116,7 +121,12 @@ class EconomyTradeService(
         )
     }
 
-    fun sell(discordId: Long, guildId: Long, amount: Long): TradeOutcome {
+    fun sell(
+        discordId: Long,
+        guildId: Long,
+        amount: Long,
+        reason: String = REASON_USER
+    ): TradeOutcome {
         if (amount <= 0) return TradeOutcome.InvalidAmount
         // Lock order — user first, then market. Same in buy() to avoid deadlock.
         val user = userService.getUserByIdForUpdate(discordId, guildId)
@@ -139,7 +149,7 @@ class EconomyTradeService(
 
         if (fee > 0L) jackpotService.addToPool(guildId, fee)
 
-        commitPriceChange(market, newPrice, executionPrice, discordId, "SELL", amount)
+        commitPriceChange(market, newPrice, executionPrice, discordId, "SELL", amount, reason)
 
         return TradeOutcome.Ok(
             amount = amount,
@@ -149,6 +159,17 @@ class EconomyTradeService(
             newPrice = newPrice,
             fee = fee
         )
+    }
+
+    companion object {
+        /** Manual `/economy` or `/tobycoin` trade — the default attribution. */
+        const val REASON_USER = "USER"
+
+        /** TitlesWebService.buyTitleWithTobyCoin auto-sold to cover a credit shortfall. */
+        const val REASON_TITLE_TOPUP = "TITLE_TOPUP"
+
+        /** A casino minigame auto-sold to fund a wager. */
+        const val REASON_CASINO_TOPUP = "CASINO_TOPUP"
     }
 
     // Seed the market row if missing, then re-read it with a write lock. Only
@@ -167,7 +188,8 @@ class EconomyTradeService(
         executionPrice: Double,
         discordId: Long,
         side: String,
-        amount: Long
+        amount: Long,
+        reason: String
     ) {
         val now = Instant.now()
         market.price = newPrice
@@ -183,7 +205,8 @@ class EconomyTradeService(
                 side = side,
                 amount = amount,
                 pricePerCoin = executionPrice,
-                executedAt = now
+                executedAt = now,
+                reason = reason
             )
         )
     }

--- a/database/src/main/kotlin/database/service/HighlowService.kt
+++ b/database/src/main/kotlin/database/service/HighlowService.kt
@@ -16,12 +16,18 @@ import kotlin.random.Random
  *   - [play] with an anchor — the web caller has already revealed the
  *     anchor to the player; this resolves the next card against that
  *     anchor inside the same transaction as the wager.
+ *
+ * Web callers can request `autoTopUp` to sell TOBY for the credit
+ * shortfall via [CasinoTopUpHelper]; the resulting trade row is tagged
+ * `CASINO_TOPUP`.
  */
 @Service
 @Transactional
 class HighlowService(
     private val userService: UserService,
     private val jackpotService: JackpotService,
+    private val tradeService: EconomyTradeService,
+    private val marketService: TobyCoinMarketService,
     private val highlow: Highlow = Highlow(),
     private val random: Random = Random.Default
 ) {
@@ -35,7 +41,9 @@ class HighlowService(
             val next: Int,
             val direction: Highlow.Direction,
             val newBalance: Long,
-            val jackpotPayout: Long = 0L
+            val jackpotPayout: Long = 0L,
+            val soldTobyCoins: Long = 0L,
+            val newPrice: Double? = null
         ) : PlayOutcome
 
         data class Lose(
@@ -43,10 +51,13 @@ class HighlowService(
             val anchor: Int,
             val next: Int,
             val direction: Highlow.Direction,
-            val newBalance: Long
+            val newBalance: Long,
+            val soldTobyCoins: Long = 0L,
+            val newPrice: Double? = null
         ) : PlayOutcome
 
         data class InsufficientCredits(val stake: Long, val have: Long) : PlayOutcome
+        data class InsufficientCoinsForTopUp(val needed: Long, val have: Long) : PlayOutcome
         data class InvalidStake(val min: Long, val max: Long) : PlayOutcome
         data object UnknownUser : PlayOutcome
     }
@@ -54,9 +65,9 @@ class HighlowService(
     /** Draw a fresh anchor without committing any state. The web flow uses this on page load. */
     fun dealAnchor(): Int = highlow.dealAnchor(random)
 
-    /** Bundled flow: server draws both cards inside this call. */
+    /** Bundled flow: server draws both cards inside this call. Discord uses this. */
     fun play(discordId: Long, guildId: Long, stake: Long, direction: Highlow.Direction): PlayOutcome =
-        playInternal(discordId, guildId, stake, direction, anchor = null)
+        playInternal(discordId, guildId, stake, direction, anchor = null, autoTopUp = false)
 
     /**
      * Stepwise flow: caller already revealed [anchor] to the player.
@@ -67,51 +78,79 @@ class HighlowService(
         guildId: Long,
         stake: Long,
         direction: Highlow.Direction,
-        anchor: Int
-    ): PlayOutcome = playInternal(discordId, guildId, stake, direction, anchor = anchor)
+        anchor: Int,
+        autoTopUp: Boolean = false
+    ): PlayOutcome = playInternal(discordId, guildId, stake, direction, anchor = anchor, autoTopUp = autoTopUp)
 
     private fun playInternal(
         discordId: Long,
         guildId: Long,
         stake: Long,
         direction: Highlow.Direction,
-        anchor: Int?
+        anchor: Int?,
+        autoTopUp: Boolean
     ): PlayOutcome {
-        return when (val check = WagerHelper.checkAndLock(
+        val initial = WagerHelper.checkAndLock(
             userService, discordId, guildId, stake, Highlow.MIN_STAKE, Highlow.MAX_STAKE
-        )) {
-            is BalanceCheck.InvalidStake -> PlayOutcome.InvalidStake(check.min, check.max)
-            BalanceCheck.UnknownUser -> PlayOutcome.UnknownUser
-            is BalanceCheck.Insufficient -> PlayOutcome.InsufficientCredits(check.stake, check.have)
-            is BalanceCheck.Ok -> {
-                val hand = if (anchor != null) {
-                    highlow.resolve(anchor, direction, random)
-                } else {
-                    highlow.play(direction, random)
-                }
-                val r = WagerHelper.applyMultiplier(userService, check.user, check.balance, stake, hand.multiplier)
-                if (hand.isWin) {
-                    val jackpot = JackpotHelper.rollOnWin(jackpotService, userService, check.user, guildId, random)
-                    PlayOutcome.Win(
-                        stake = stake,
-                        payout = r.payout,
-                        net = r.net,
-                        anchor = hand.anchor,
-                        next = hand.next,
-                        direction = hand.direction,
-                        newBalance = r.newBalance + jackpot,
-                        jackpotPayout = jackpot
-                    )
-                } else {
-                    PlayOutcome.Lose(
-                        stake = stake,
-                        anchor = hand.anchor,
-                        next = hand.next,
-                        direction = hand.direction,
-                        newBalance = r.newBalance
-                    )
+        )
+        var soldCoins = 0L
+        var soldNewPrice: Double? = null
+        val resolved = when (initial) {
+            is BalanceCheck.InvalidStake -> return PlayOutcome.InvalidStake(initial.min, initial.max)
+            BalanceCheck.UnknownUser -> return PlayOutcome.UnknownUser
+            is BalanceCheck.Insufficient -> {
+                if (!autoTopUp) return PlayOutcome.InsufficientCredits(initial.stake, initial.have)
+                val user = userService.getUserByIdForUpdate(discordId, guildId)
+                    ?: return PlayOutcome.UnknownUser
+                val topUp = CasinoTopUpHelper.ensureCreditsForWager(
+                    tradeService, marketService, userService,
+                    user, guildId, currentBalance = initial.have, stake = stake
+                )
+                when (topUp) {
+                    is TopUpResult.InsufficientCoins ->
+                        return PlayOutcome.InsufficientCoinsForTopUp(topUp.needed, topUp.have)
+                    TopUpResult.MarketUnavailable ->
+                        return PlayOutcome.InsufficientCredits(initial.stake, initial.have)
+                    is TopUpResult.ToppedUp -> {
+                        soldCoins = topUp.soldCoins
+                        soldNewPrice = topUp.newPrice
+                        BalanceCheck.Ok(topUp.user, topUp.balance)
+                    }
                 }
             }
+            is BalanceCheck.Ok -> initial
+        }
+
+        val hand = if (anchor != null) {
+            highlow.resolve(anchor, direction, random)
+        } else {
+            highlow.play(direction, random)
+        }
+        val r = WagerHelper.applyMultiplier(userService, resolved.user, resolved.balance, stake, hand.multiplier)
+        return if (hand.isWin) {
+            val jackpot = JackpotHelper.rollOnWin(jackpotService, userService, resolved.user, guildId, random)
+            PlayOutcome.Win(
+                stake = stake,
+                payout = r.payout,
+                net = r.net,
+                anchor = hand.anchor,
+                next = hand.next,
+                direction = hand.direction,
+                newBalance = r.newBalance + jackpot,
+                jackpotPayout = jackpot,
+                soldTobyCoins = soldCoins,
+                newPrice = soldNewPrice
+            )
+        } else {
+            PlayOutcome.Lose(
+                stake = stake,
+                anchor = hand.anchor,
+                next = hand.next,
+                direction = hand.direction,
+                newBalance = r.newBalance,
+                soldTobyCoins = soldCoins,
+                newPrice = soldNewPrice
+            )
         }
     }
 }

--- a/database/src/main/kotlin/database/service/ScratchService.kt
+++ b/database/src/main/kotlin/database/service/ScratchService.kt
@@ -8,12 +8,18 @@ import kotlin.random.Random
 /**
  * Atomic scratch path for the `/scratch` minigame. Same lock-then-mutate
  * pattern as the other minigame services.
+ *
+ * Web callers can request `autoTopUp` to sell TOBY for the credit
+ * shortfall via [CasinoTopUpHelper]; the resulting trade row is tagged
+ * `CASINO_TOPUP`.
  */
 @Service
 @Transactional
 class ScratchService(
     private val userService: UserService,
     private val jackpotService: JackpotService,
+    private val tradeService: EconomyTradeService,
+    private val marketService: TobyCoinMarketService,
     private val card: ScratchCard = ScratchCard(),
     private val random: Random = Random.Default
 ) {
@@ -27,46 +33,81 @@ class ScratchService(
             val winningSymbol: database.economy.SlotMachine.Symbol,
             val matchCount: Int,
             val newBalance: Long,
-            val jackpotPayout: Long = 0L
+            val jackpotPayout: Long = 0L,
+            val soldTobyCoins: Long = 0L,
+            val newPrice: Double? = null
         ) : ScratchOutcome
 
         data class Lose(
             val stake: Long,
             val cells: List<database.economy.SlotMachine.Symbol>,
-            val newBalance: Long
+            val newBalance: Long,
+            val soldTobyCoins: Long = 0L,
+            val newPrice: Double? = null
         ) : ScratchOutcome
 
         data class InsufficientCredits(val stake: Long, val have: Long) : ScratchOutcome
+        data class InsufficientCoinsForTopUp(val needed: Long, val have: Long) : ScratchOutcome
         data class InvalidStake(val min: Long, val max: Long) : ScratchOutcome
         data object UnknownUser : ScratchOutcome
     }
 
-    fun scratch(discordId: Long, guildId: Long, stake: Long): ScratchOutcome {
-        return when (val check = WagerHelper.checkAndLock(
+    fun scratch(discordId: Long, guildId: Long, stake: Long, autoTopUp: Boolean = false): ScratchOutcome {
+        val initial = WagerHelper.checkAndLock(
             userService, discordId, guildId, stake, ScratchCard.MIN_STAKE, ScratchCard.MAX_STAKE
-        )) {
-            is BalanceCheck.InvalidStake -> ScratchOutcome.InvalidStake(check.min, check.max)
-            BalanceCheck.UnknownUser -> ScratchOutcome.UnknownUser
-            is BalanceCheck.Insufficient -> ScratchOutcome.InsufficientCredits(check.stake, check.have)
-            is BalanceCheck.Ok -> {
-                val result = card.scratch(random)
-                val r = WagerHelper.applyMultiplier(userService, check.user, check.balance, stake, result.multiplier)
-                if (result.isWin && result.winningSymbol != null) {
-                    val jackpot = JackpotHelper.rollOnWin(jackpotService, userService, check.user, guildId, random)
-                    ScratchOutcome.Win(
-                        stake = stake,
-                        payout = r.payout,
-                        net = r.net,
-                        cells = result.cells,
-                        winningSymbol = result.winningSymbol,
-                        matchCount = result.matchCount,
-                        newBalance = r.newBalance + jackpot,
-                        jackpotPayout = jackpot
-                    )
-                } else {
-                    ScratchOutcome.Lose(stake = stake, cells = result.cells, newBalance = r.newBalance)
+        )
+        var soldCoins = 0L
+        var newPrice: Double? = null
+        val resolved = when (initial) {
+            is BalanceCheck.InvalidStake -> return ScratchOutcome.InvalidStake(initial.min, initial.max)
+            BalanceCheck.UnknownUser -> return ScratchOutcome.UnknownUser
+            is BalanceCheck.Insufficient -> {
+                if (!autoTopUp) return ScratchOutcome.InsufficientCredits(initial.stake, initial.have)
+                val user = userService.getUserByIdForUpdate(discordId, guildId)
+                    ?: return ScratchOutcome.UnknownUser
+                val topUp = CasinoTopUpHelper.ensureCreditsForWager(
+                    tradeService, marketService, userService,
+                    user, guildId, currentBalance = initial.have, stake = stake
+                )
+                when (topUp) {
+                    is TopUpResult.InsufficientCoins ->
+                        return ScratchOutcome.InsufficientCoinsForTopUp(topUp.needed, topUp.have)
+                    TopUpResult.MarketUnavailable ->
+                        return ScratchOutcome.InsufficientCredits(initial.stake, initial.have)
+                    is TopUpResult.ToppedUp -> {
+                        soldCoins = topUp.soldCoins
+                        newPrice = topUp.newPrice
+                        BalanceCheck.Ok(topUp.user, topUp.balance)
+                    }
                 }
             }
+            is BalanceCheck.Ok -> initial
+        }
+
+        val result = card.scratch(random)
+        val r = WagerHelper.applyMultiplier(userService, resolved.user, resolved.balance, stake, result.multiplier)
+        return if (result.isWin && result.winningSymbol != null) {
+            val jackpot = JackpotHelper.rollOnWin(jackpotService, userService, resolved.user, guildId, random)
+            ScratchOutcome.Win(
+                stake = stake,
+                payout = r.payout,
+                net = r.net,
+                cells = result.cells,
+                winningSymbol = result.winningSymbol,
+                matchCount = result.matchCount,
+                newBalance = r.newBalance + jackpot,
+                jackpotPayout = jackpot,
+                soldTobyCoins = soldCoins,
+                newPrice = newPrice
+            )
+        } else {
+            ScratchOutcome.Lose(
+                stake = stake,
+                cells = result.cells,
+                newBalance = r.newBalance,
+                soldTobyCoins = soldCoins,
+                newPrice = newPrice
+            )
         }
     }
 }

--- a/database/src/main/kotlin/database/service/SlotsService.kt
+++ b/database/src/main/kotlin/database/service/SlotsService.kt
@@ -19,12 +19,20 @@ import kotlin.random.Random
  *
  * Wins also roll [JackpotHelper] for a chance to bank the per-guild
  * jackpot pool (fed by trade fees in [EconomyTradeService]).
+ *
+ * When the caller passes `autoTopUp=true` and the player's credits
+ * fall short of the stake, [CasinoTopUpHelper] sells just enough TOBY
+ * to cover (mirroring TitlesWebService's "Buy with TOBY" flow). The
+ * resulting trade row is tagged `CASINO_TOPUP` so the chart marker
+ * can show why the sale happened.
  */
 @Service
 @Transactional
 class SlotsService(
     private val userService: UserService,
     private val jackpotService: JackpotService,
+    private val tradeService: EconomyTradeService,
+    private val marketService: TobyCoinMarketService,
     private val machine: SlotMachine = SlotMachine(),
     private val random: Random = Random.Default
 ) {
@@ -37,45 +45,82 @@ class SlotsService(
             val net: Long,
             val symbols: List<SlotMachine.Symbol>,
             val newBalance: Long,
-            val jackpotPayout: Long = 0L
+            val jackpotPayout: Long = 0L,
+            val soldTobyCoins: Long = 0L,
+            val newPrice: Double? = null
         ) : SpinOutcome
 
         data class Lose(
             val stake: Long,
             val symbols: List<SlotMachine.Symbol>,
-            val newBalance: Long
+            val newBalance: Long,
+            val soldTobyCoins: Long = 0L,
+            val newPrice: Double? = null
         ) : SpinOutcome
 
         data class InsufficientCredits(val stake: Long, val have: Long) : SpinOutcome
+        data class InsufficientCoinsForTopUp(val needed: Long, val have: Long) : SpinOutcome
         data class InvalidStake(val min: Long, val max: Long) : SpinOutcome
         data object UnknownUser : SpinOutcome
     }
 
-    fun spin(discordId: Long, guildId: Long, stake: Long): SpinOutcome {
-        return when (val check = WagerHelper.checkAndLock(
+    fun spin(discordId: Long, guildId: Long, stake: Long, autoTopUp: Boolean = false): SpinOutcome {
+        val initial = WagerHelper.checkAndLock(
             userService, discordId, guildId, stake, SlotMachine.MIN_STAKE, SlotMachine.MAX_STAKE
-        )) {
-            is BalanceCheck.InvalidStake -> SpinOutcome.InvalidStake(check.min, check.max)
-            BalanceCheck.UnknownUser -> SpinOutcome.UnknownUser
-            is BalanceCheck.Insufficient -> SpinOutcome.InsufficientCredits(check.stake, check.have)
-            is BalanceCheck.Ok -> {
-                val pull = machine.pull(random)
-                val r = WagerHelper.applyMultiplier(userService, check.user, check.balance, stake, pull.multiplier)
-                if (pull.isWin) {
-                    val jackpot = JackpotHelper.rollOnWin(jackpotService, userService, check.user, guildId, random)
-                    SpinOutcome.Win(
-                        stake = stake,
-                        multiplier = pull.multiplier,
-                        payout = r.payout,
-                        net = r.net,
-                        symbols = pull.symbols,
-                        newBalance = r.newBalance + jackpot,
-                        jackpotPayout = jackpot
-                    )
-                } else {
-                    SpinOutcome.Lose(stake = stake, symbols = pull.symbols, newBalance = r.newBalance)
+        )
+        var soldCoins = 0L
+        var newPrice: Double? = null
+        val resolved = when (initial) {
+            is BalanceCheck.InvalidStake -> return SpinOutcome.InvalidStake(initial.min, initial.max)
+            BalanceCheck.UnknownUser -> return SpinOutcome.UnknownUser
+            is BalanceCheck.Insufficient -> {
+                if (!autoTopUp) return SpinOutcome.InsufficientCredits(initial.stake, initial.have)
+                // Lock the user row to feed the helper. WagerHelper already
+                // returned Insufficient — re-acquire to get the managed entity.
+                val user = userService.getUserByIdForUpdate(discordId, guildId)
+                    ?: return SpinOutcome.UnknownUser
+                val topUp = CasinoTopUpHelper.ensureCreditsForWager(
+                    tradeService, marketService, userService,
+                    user, guildId, currentBalance = initial.have, stake = stake
+                )
+                when (topUp) {
+                    is TopUpResult.InsufficientCoins ->
+                        return SpinOutcome.InsufficientCoinsForTopUp(topUp.needed, topUp.have)
+                    TopUpResult.MarketUnavailable ->
+                        return SpinOutcome.InsufficientCredits(initial.stake, initial.have)
+                    is TopUpResult.ToppedUp -> {
+                        soldCoins = topUp.soldCoins
+                        newPrice = topUp.newPrice
+                        BalanceCheck.Ok(topUp.user, topUp.balance)
+                    }
                 }
             }
+            is BalanceCheck.Ok -> initial
+        }
+
+        val pull = machine.pull(random)
+        val r = WagerHelper.applyMultiplier(userService, resolved.user, resolved.balance, stake, pull.multiplier)
+        return if (pull.isWin) {
+            val jackpot = JackpotHelper.rollOnWin(jackpotService, userService, resolved.user, guildId, random)
+            SpinOutcome.Win(
+                stake = stake,
+                multiplier = pull.multiplier,
+                payout = r.payout,
+                net = r.net,
+                symbols = pull.symbols,
+                newBalance = r.newBalance + jackpot,
+                jackpotPayout = jackpot,
+                soldTobyCoins = soldCoins,
+                newPrice = newPrice
+            )
+        } else {
+            SpinOutcome.Lose(
+                stake = stake,
+                symbols = pull.symbols,
+                newBalance = r.newBalance,
+                soldTobyCoins = soldCoins,
+                newPrice = newPrice
+            )
         }
     }
 }

--- a/database/src/main/resources/db/migration/V19__toby_coin_trade_reason.sql
+++ b/database/src/main/resources/db/migration/V19__toby_coin_trade_reason.sql
@@ -7,11 +7,10 @@
 -- the trade happened — "(title top-up)", "(casino top-up)" — so a
 -- viewer can tell organic activity from automated tops-up.
 --
--- Backfill is per-row; pre-existing rows can't tell you their source
--- after the fact, so they get the catch-all 'USER'. New writes are
--- explicit.
+-- Done in one ALTER so the DEFAULT lands together with the NOT NULL
+-- constraint (Postgres back-fills existing rows with the default in
+-- the same statement). Pre-migration trades get the catch-all 'USER'
+-- since we can't know retroactively what tagged them.
 
-ALTER TABLE toby_coin_trade ADD COLUMN reason VARCHAR(32);
-UPDATE toby_coin_trade SET reason = 'USER' WHERE reason IS NULL;
-ALTER TABLE toby_coin_trade ALTER COLUMN reason SET NOT NULL;
-ALTER TABLE toby_coin_trade ALTER COLUMN reason SET DEFAULT 'USER';
+ALTER TABLE toby_coin_trade
+    ADD COLUMN reason VARCHAR(32) NOT NULL DEFAULT 'USER';

--- a/database/src/main/resources/db/migration/V19__toby_coin_trade_reason.sql
+++ b/database/src/main/resources/db/migration/V19__toby_coin_trade_reason.sql
@@ -1,0 +1,17 @@
+-- Per-trade attribution for the chart marker tooltip.
+--
+-- Until now every trade row looked the same on the chart whether the
+-- trader hit `/economy sell` themselves, the Titles "Buy with TOBY"
+-- button auto-sold to top up a credit shortfall, or the casino sold to
+-- fund a wager. Adding a discriminator lets the chart label say WHY
+-- the trade happened — "(title top-up)", "(casino top-up)" — so a
+-- viewer can tell organic activity from automated tops-up.
+--
+-- Backfill is per-row; pre-existing rows can't tell you their source
+-- after the fact, so they get the catch-all 'USER'. New writes are
+-- explicit.
+
+ALTER TABLE toby_coin_trade ADD COLUMN reason VARCHAR(32);
+UPDATE toby_coin_trade SET reason = 'USER' WHERE reason IS NULL;
+ALTER TABLE toby_coin_trade ALTER COLUMN reason SET NOT NULL;
+ALTER TABLE toby_coin_trade ALTER COLUMN reason SET DEFAULT 'USER';

--- a/database/src/test/kotlin/database/economy/TobyCoinEngineTopUpTest.kt
+++ b/database/src/test/kotlin/database/economy/TobyCoinEngineTopUpTest.kt
@@ -1,0 +1,59 @@
+package database.economy
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Pure-math tests for the sell-to-cover-shortfall helper used by
+ * [web.service.TitlesWebService] and [database.service.CasinoTopUpHelper].
+ * Pinned to the same sale arithmetic [database.service.EconomyTradeService]
+ * applies — drift between the two would mean the chosen N would land
+ * a few credits short of the shortfall after the fee + slippage land,
+ * which is exactly what these helpers are written to prevent.
+ */
+class TobyCoinEngineTopUpTest {
+
+    @Test
+    fun `proceedsForSell matches the trade engine math`() {
+        // Reference values: P=2.5, N=205. midpoint = (2.5 + 2.5*0.9795)/2
+        // = 2.474375. gross = floor(2.474375 * 205) = 507. fee = floor(5.07) = 5.
+        assertEquals(502L, TobyCoinEngine.proceedsForSell(2.5, 205))
+    }
+
+    @Test
+    fun `proceedsForSell is zero when coins is non-positive`() {
+        assertEquals(0L, TobyCoinEngine.proceedsForSell(2.5, 0))
+        assertEquals(0L, TobyCoinEngine.proceedsForSell(2.5, -10))
+    }
+
+    @Test
+    fun `proceedsForSell is zero when price is zero`() {
+        assertEquals(0L, TobyCoinEngine.proceedsForSell(0.0, 100))
+    }
+
+    @Test
+    fun `coinsNeededForShortfall covers cleanly when ceil already works`() {
+        // Tiny shortfall, large price — no slippage / fee bump needed.
+        assertEquals(1L, TobyCoinEngine.coinsNeededForShortfall(50L, 100.0))
+    }
+
+    @Test
+    fun `coinsNeededForShortfall bumps for fee + slippage`() {
+        // Reference: shortfall=500, P=2.5. ceil=200 nets 491; bumps to 205.
+        assertEquals(205L, TobyCoinEngine.coinsNeededForShortfall(500L, 2.5))
+    }
+
+    @Test
+    fun `coinsNeededForShortfall returns the true required N regardless of caller balance`() {
+        // The engine helper doesn't peek at the user — caller compares
+        // against their balance and surfaces "insufficient coins".
+        val needed = TobyCoinEngine.coinsNeededForShortfall(1_000L, 1.0)
+        assertTrue(needed >= 1_000L, "1000-credit shortfall at price=1 needs at least 1000 coins (was $needed)")
+    }
+
+    @Test
+    fun `coinsNeededForShortfall is zero on a zero shortfall`() {
+        assertEquals(0L, TobyCoinEngine.coinsNeededForShortfall(0L, 100.0))
+    }
+}

--- a/database/src/test/kotlin/database/service/CasinoTopUpHelperTest.kt
+++ b/database/src/test/kotlin/database/service/CasinoTopUpHelperTest.kt
@@ -1,0 +1,144 @@
+package database.service
+
+import database.dto.TobyCoinMarketDto
+import database.dto.UserDto
+import database.service.EconomyTradeService.TradeOutcome
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+class CasinoTopUpHelperTest {
+
+    private val discordId = 100L
+    private val guildId = 200L
+
+    private lateinit var tradeService: EconomyTradeService
+    private lateinit var marketService: TobyCoinMarketService
+    private lateinit var userService: UserService
+
+    @BeforeEach
+    fun setup() {
+        tradeService = mockk(relaxed = true)
+        marketService = mockk(relaxed = true)
+        userService = mockk(relaxed = true)
+    }
+
+    private fun userWith(balance: Long, coins: Long): UserDto =
+        UserDto(discordId = discordId, guildId = guildId).apply {
+            socialCredit = balance
+            tobyCoins = coins
+        }
+
+    private fun market(price: Double): TobyCoinMarketDto =
+        TobyCoinMarketDto(guildId = guildId, price = price, lastTickAt = Instant.now())
+
+    @Test
+    fun `MarketUnavailable when no market row exists`() {
+        every { marketService.getMarketForUpdate(guildId) } returns null
+
+        val result = CasinoTopUpHelper.ensureCreditsForWager(
+            tradeService, marketService, userService,
+            user = userWith(balance = 0L, coins = 1_000L),
+            guildId = guildId, currentBalance = 0L, stake = 100L
+        )
+
+        assertEquals(TopUpResult.MarketUnavailable, result)
+        verify(exactly = 0) { tradeService.sell(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `MarketUnavailable when price is zero or negative`() {
+        every { marketService.getMarketForUpdate(guildId) } returns market(0.0)
+
+        val result = CasinoTopUpHelper.ensureCreditsForWager(
+            tradeService, marketService, userService,
+            user = userWith(balance = 0L, coins = 1_000L),
+            guildId = guildId, currentBalance = 0L, stake = 100L
+        )
+
+        assertEquals(TopUpResult.MarketUnavailable, result)
+    }
+
+    @Test
+    fun `InsufficientCoins when user holds fewer TOBY than needed`() {
+        every { marketService.getMarketForUpdate(guildId) } returns market(2.5)
+
+        val result = CasinoTopUpHelper.ensureCreditsForWager(
+            tradeService, marketService, userService,
+            user = userWith(balance = 0L, coins = 5L),  // way short of ~205 needed
+            guildId = guildId, currentBalance = 0L, stake = 500L
+        )
+
+        val ic = assertInstanceOf(TopUpResult.InsufficientCoins::class.java, result)
+        assertEquals(5L, ic.have)
+        // True needed is computed by TobyCoinEngine — we just sanity-
+        // check it's much greater than what the user has.
+        assert(ic.needed > 5L) { "needed should reflect the engine's computation, was ${ic.needed}" }
+        verify(exactly = 0) { tradeService.sell(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `ToppedUp delegates to tradeService sell with CASINO_TOPUP reason`() {
+        val user = userWith(balance = 0L, coins = 1_000L)
+        every { marketService.getMarketForUpdate(guildId) } returns market(2.5)
+        every {
+            tradeService.sell(discordId, guildId, any(), EconomyTradeService.REASON_CASINO_TOPUP)
+        } answers {
+            val sold = thirdArg<Long>()
+            user.tobyCoins -= sold
+            user.socialCredit = (user.socialCredit ?: 0L) + 502L
+            TradeOutcome.Ok(
+                amount = sold,
+                transactedCredits = 502L,
+                newCoins = user.tobyCoins,
+                newCredits = user.socialCredit ?: 0L,
+                newPrice = 2.44875,
+                fee = 5L
+            )
+        }
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns user
+
+        val result = CasinoTopUpHelper.ensureCreditsForWager(
+            tradeService, marketService, userService,
+            user = user, guildId = guildId, currentBalance = 0L, stake = 500L
+        )
+
+        val topped = assertInstanceOf(TopUpResult.ToppedUp::class.java, result)
+        assertEquals(502L, topped.balance, "post-topup balance is the user's new credit total")
+        assert(topped.soldCoins > 0L) { "soldCoins should be the engine's computed N" }
+        assertEquals(2.44875, topped.newPrice, 1e-9)
+        verify(exactly = 1) {
+            tradeService.sell(discordId, guildId, any(), EconomyTradeService.REASON_CASINO_TOPUP)
+        }
+    }
+
+    @Test
+    fun `ToppedUp returns the post-sell user when re-read succeeds`() {
+        val user = userWith(balance = 0L, coins = 1_000L)
+        val refreshed = userWith(balance = 502L, coins = 795L)
+        every { marketService.getMarketForUpdate(guildId) } returns market(2.5)
+        every {
+            tradeService.sell(any(), any(), any(), any())
+        } returns TradeOutcome.Ok(
+            amount = 205L, transactedCredits = 502L,
+            newCoins = 795L, newCredits = 502L, newPrice = 2.44875, fee = 5L
+        )
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns refreshed
+
+        val result = CasinoTopUpHelper.ensureCreditsForWager(
+            tradeService, marketService, userService,
+            user = user, guildId = guildId, currentBalance = 0L, stake = 500L
+        )
+
+        val topped = assertInstanceOf(TopUpResult.ToppedUp::class.java, result)
+        // The handle returned IS the re-read entity — important so the
+        // wager that follows operates on the post-sell balance.
+        assertEquals(refreshed, topped.user)
+        assertEquals(502L, topped.balance)
+    }
+}

--- a/database/src/test/kotlin/database/service/CoinflipServiceTest.kt
+++ b/database/src/test/kotlin/database/service/CoinflipServiceTest.kt
@@ -16,6 +16,8 @@ class CoinflipServiceTest {
 
     private lateinit var userService: UserService
     private lateinit var jackpotService: JackpotService
+    private lateinit var tradeService: EconomyTradeService
+    private lateinit var marketService: TobyCoinMarketService
     private lateinit var coinflip: Coinflip
     private lateinit var service: CoinflipService
 
@@ -26,8 +28,10 @@ class CoinflipServiceTest {
     fun setup() {
         userService = mockk(relaxed = true)
         jackpotService = mockk(relaxed = true)
+        tradeService = mockk(relaxed = true)
+        marketService = mockk(relaxed = true)
         coinflip = mockk(relaxed = true)
-        service = CoinflipService(userService, jackpotService, coinflip, Random(0))
+        service = CoinflipService(userService, jackpotService, tradeService, marketService, coinflip, Random(0))
     }
 
     private fun userWithBalance(balance: Long): UserDto {

--- a/database/src/test/kotlin/database/service/DiceServiceTest.kt
+++ b/database/src/test/kotlin/database/service/DiceServiceTest.kt
@@ -16,6 +16,8 @@ class DiceServiceTest {
 
     private lateinit var userService: UserService
     private lateinit var jackpotService: JackpotService
+    private lateinit var tradeService: EconomyTradeService
+    private lateinit var marketService: TobyCoinMarketService
     private lateinit var dice: Dice
     private lateinit var service: DiceService
 
@@ -26,11 +28,13 @@ class DiceServiceTest {
     fun setup() {
         userService = mockk(relaxed = true)
         jackpotService = mockk(relaxed = true)
+        tradeService = mockk(relaxed = true)
+        marketService = mockk(relaxed = true)
         dice = mockk(relaxed = true) {
             every { isValidPrediction(any()) } answers { firstArg<Int>() in 1..6 }
             every { sidesCount } returns 6
         }
-        service = DiceService(userService, jackpotService, dice, Random(0))
+        service = DiceService(userService, jackpotService, tradeService, marketService, dice, Random(0))
     }
 
     private fun userWithBalance(balance: Long): UserDto {

--- a/database/src/test/kotlin/database/service/HighlowServiceTest.kt
+++ b/database/src/test/kotlin/database/service/HighlowServiceTest.kt
@@ -16,6 +16,8 @@ class HighlowServiceTest {
 
     private lateinit var userService: UserService
     private lateinit var jackpotService: JackpotService
+    private lateinit var tradeService: EconomyTradeService
+    private lateinit var marketService: TobyCoinMarketService
     private lateinit var highlow: Highlow
     private lateinit var service: HighlowService
 
@@ -26,8 +28,10 @@ class HighlowServiceTest {
     fun setup() {
         userService = mockk(relaxed = true)
         jackpotService = mockk(relaxed = true)
+        tradeService = mockk(relaxed = true)
+        marketService = mockk(relaxed = true)
         highlow = mockk(relaxed = true)
-        service = HighlowService(userService, jackpotService, highlow, Random(0))
+        service = HighlowService(userService, jackpotService, tradeService, marketService, highlow, Random(0))
     }
 
     private fun userWithBalance(balance: Long): UserDto =

--- a/database/src/test/kotlin/database/service/ScratchServiceTest.kt
+++ b/database/src/test/kotlin/database/service/ScratchServiceTest.kt
@@ -17,6 +17,8 @@ class ScratchServiceTest {
 
     private lateinit var userService: UserService
     private lateinit var jackpotService: JackpotService
+    private lateinit var tradeService: EconomyTradeService
+    private lateinit var marketService: TobyCoinMarketService
     private lateinit var card: ScratchCard
     private lateinit var service: ScratchService
 
@@ -27,8 +29,10 @@ class ScratchServiceTest {
     fun setup() {
         userService = mockk(relaxed = true)
         jackpotService = mockk(relaxed = true)
+        tradeService = mockk(relaxed = true)
+        marketService = mockk(relaxed = true)
         card = mockk(relaxed = true)
-        service = ScratchService(userService, jackpotService, card, Random(0))
+        service = ScratchService(userService, jackpotService, tradeService, marketService, card, Random(0))
     }
 
     private fun userWithBalance(balance: Long): UserDto =

--- a/database/src/test/kotlin/database/service/SlotsServiceTest.kt
+++ b/database/src/test/kotlin/database/service/SlotsServiceTest.kt
@@ -16,6 +16,8 @@ class SlotsServiceTest {
 
     private lateinit var userService: UserService
     private lateinit var jackpotService: JackpotService
+    private lateinit var tradeService: EconomyTradeService
+    private lateinit var marketService: TobyCoinMarketService
     private lateinit var machine: SlotMachine
     private lateinit var service: SlotsService
 
@@ -26,8 +28,10 @@ class SlotsServiceTest {
     fun setup() {
         userService = mockk(relaxed = true)
         jackpotService = mockk(relaxed = true)
+        tradeService = mockk(relaxed = true)
+        marketService = mockk(relaxed = true)
         machine = mockk(relaxed = true)
-        service = SlotsService(userService, jackpotService, machine, Random(0))
+        service = SlotsService(userService, jackpotService, tradeService, marketService, machine, Random(0))
     }
 
     private fun userWithBalance(balance: Long): UserDto {

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/CoinflipCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/CoinflipCommand.kt
@@ -97,6 +97,11 @@ class CoinflipCommand @Autowired constructor(
                 "Not enough credits. You need ${outcome.stake} but only have ${outcome.have}."
             )
 
+            is FlipOutcome.InsufficientCoinsForTopUp -> errorEmbed(
+                "Not enough credits, and not enough TOBY to cover. " +
+                    "Need ${outcome.needed} TOBY, you have ${outcome.have}."
+            )
+
             is FlipOutcome.InvalidStake -> errorEmbed(
                 "Stake must be between ${outcome.min} and ${outcome.max} credits."
             )

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/DiceCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/DiceCommand.kt
@@ -93,6 +93,11 @@ class DiceCommand @Autowired constructor(
                 "Not enough credits. You need ${outcome.stake} but only have ${outcome.have}."
             )
 
+            is RollOutcome.InsufficientCoinsForTopUp -> errorEmbed(
+                "Not enough credits, and not enough TOBY to cover. " +
+                    "Need ${outcome.needed} TOBY, you have ${outcome.have}."
+            )
+
             is RollOutcome.InvalidStake -> errorEmbed(
                 "Stake must be between ${outcome.min} and ${outcome.max} credits."
             )

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/HighlowCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/HighlowCommand.kt
@@ -104,6 +104,11 @@ class HighlowCommand @Autowired constructor(
                 "Not enough credits. You need ${outcome.stake} but only have ${outcome.have}."
             )
 
+            is PlayOutcome.InsufficientCoinsForTopUp -> errorEmbed(
+                "Not enough credits, and not enough TOBY to cover. " +
+                    "Need ${outcome.needed} TOBY, you have ${outcome.have}."
+            )
+
             is PlayOutcome.InvalidStake -> errorEmbed(
                 "Stake must be between ${outcome.min} and ${outcome.max} credits."
             )

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/ScratchCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/ScratchCommand.kt
@@ -89,6 +89,11 @@ class ScratchCommand @Autowired constructor(
                 "Not enough credits. You need ${outcome.stake} but only have ${outcome.have}."
             )
 
+            is ScratchOutcome.InsufficientCoinsForTopUp -> errorEmbed(
+                "Not enough credits, and not enough TOBY to cover. " +
+                    "Need ${outcome.needed} TOBY, you have ${outcome.have}."
+            )
+
             is ScratchOutcome.InvalidStake -> errorEmbed(
                 "Stake must be between ${outcome.min} and ${outcome.max} credits."
             )

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/SlotsCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/SlotsCommand.kt
@@ -81,6 +81,11 @@ class SlotsCommand @Autowired constructor(
                 "Not enough credits. You need ${outcome.stake} but only have ${outcome.have}."
             )
 
+            is SpinOutcome.InsufficientCoinsForTopUp -> errorEmbed(
+                "Not enough credits, and not enough TOBY to cover. " +
+                    "Need ${outcome.needed} TOBY, you have ${outcome.have}."
+            )
+
             is SpinOutcome.InvalidStake -> errorEmbed(
                 "Stake must be between ${outcome.min} and ${outcome.max} credits."
             )

--- a/web/src/main/kotlin/web/controller/CoinflipController.kt
+++ b/web/src/main/kotlin/web/controller/CoinflipController.kt
@@ -4,6 +4,7 @@ import database.economy.Coinflip
 import database.service.CoinflipService
 import database.service.CoinflipService.FlipOutcome
 import database.service.JackpotService
+import database.service.TobyCoinMarketService
 import database.service.UserService
 import net.dv8tion.jda.api.JDA
 import org.springframework.http.ResponseEntity
@@ -38,6 +39,7 @@ class CoinflipController(
     private val economyWebService: EconomyWebService,
     private val userService: UserService,
     private val jackpotService: JackpotService,
+    private val marketService: TobyCoinMarketService,
     private val jda: JDA
 ) {
 
@@ -60,11 +62,16 @@ class CoinflipController(
             return "redirect:/casino/guilds"
         }
 
-        val balance = userService.getUserById(discordId, guildId)?.socialCredit ?: 0L
+        val profile = userService.getUserById(discordId, guildId)
+        val balance = profile?.socialCredit ?: 0L
+        val tobyCoins = profile?.tobyCoins ?: 0L
+        val marketPrice = marketService.getMarket(guildId)?.price ?: 0.0
 
         model.addAttribute("guildId", guildId.toString())
         model.addAttribute("guildName", guild.name)
         model.addAttribute("balance", balance)
+        model.addAttribute("tobyCoins", tobyCoins)
+        model.addAttribute("marketPrice", marketPrice)
         model.addAttribute("minStake", Coinflip.MIN_STAKE)
         model.addAttribute("maxStake", Coinflip.MAX_STAKE)
         model.addAttribute("multiplier", Coinflip.DEFAULT_MULTIPLIER)
@@ -88,7 +95,7 @@ class CoinflipController(
         val side = parseSide(request.side)
             ?: return ResponseEntity.badRequest().body(FlipResponse(false, "Pick a side: HEADS or TAILS."))
 
-        return when (val outcome = coinflipService.flip(discordId, guildId, request.stake, side)) {
+        return when (val outcome = coinflipService.flip(discordId, guildId, request.stake, side, request.autoTopUp)) {
             is FlipOutcome.Win -> ResponseEntity.ok(
                 FlipResponse(
                     ok = true,
@@ -98,7 +105,9 @@ class CoinflipController(
                     payout = outcome.payout,
                     newBalance = outcome.newBalance,
                     win = true,
-                    jackpotPayout = outcome.jackpotPayout.takeIf { it > 0L }
+                    jackpotPayout = outcome.jackpotPayout.takeIf { it > 0L },
+                    soldTobyCoins = outcome.soldTobyCoins.takeIf { it > 0L },
+                    newPrice = outcome.newPrice
                 )
             )
 
@@ -110,12 +119,18 @@ class CoinflipController(
                     net = -outcome.stake,
                     payout = 0L,
                     newBalance = outcome.newBalance,
-                    win = false
+                    win = false,
+                    soldTobyCoins = outcome.soldTobyCoins.takeIf { it > 0L },
+                    newPrice = outcome.newPrice
                 )
             )
 
             is FlipOutcome.InsufficientCredits -> ResponseEntity.badRequest().body(
                 FlipResponse(false, "Need ${outcome.stake} credits, you have ${outcome.have}.")
+            )
+
+            is FlipOutcome.InsufficientCoinsForTopUp -> ResponseEntity.badRequest().body(
+                FlipResponse(false, "Need ${outcome.needed} TOBY to cover the shortfall, you have ${outcome.have}.")
             )
 
             is FlipOutcome.InvalidStake -> ResponseEntity.badRequest().body(
@@ -135,7 +150,7 @@ class CoinflipController(
     }
 }
 
-data class FlipRequest(val side: String = "", val stake: Long = 0)
+data class FlipRequest(val side: String = "", val stake: Long = 0, val autoTopUp: Boolean = false)
 
 data class FlipResponse(
     val ok: Boolean,
@@ -146,5 +161,7 @@ data class FlipResponse(
     val payout: Long? = null,
     val newBalance: Long? = null,
     val win: Boolean? = null,
-    val jackpotPayout: Long? = null
+    val jackpotPayout: Long? = null,
+    val soldTobyCoins: Long? = null,
+    val newPrice: Double? = null
 )

--- a/web/src/main/kotlin/web/controller/DiceController.kt
+++ b/web/src/main/kotlin/web/controller/DiceController.kt
@@ -4,6 +4,7 @@ import database.economy.Dice
 import database.service.DiceService
 import database.service.DiceService.RollOutcome
 import database.service.JackpotService
+import database.service.TobyCoinMarketService
 import database.service.UserService
 import net.dv8tion.jda.api.JDA
 import org.springframework.http.ResponseEntity
@@ -36,6 +37,7 @@ class DiceController(
     private val economyWebService: EconomyWebService,
     private val userService: UserService,
     private val jackpotService: JackpotService,
+    private val marketService: TobyCoinMarketService,
     private val jda: JDA
 ) {
 
@@ -57,11 +59,16 @@ class DiceController(
             return "redirect:/casino/guilds"
         }
 
-        val balance = userService.getUserById(discordId, guildId)?.socialCredit ?: 0L
+        val profile = userService.getUserById(discordId, guildId)
+        val balance = profile?.socialCredit ?: 0L
+        val tobyCoins = profile?.tobyCoins ?: 0L
+        val marketPrice = marketService.getMarket(guildId)?.price ?: 0.0
 
         model.addAttribute("guildId", guildId.toString())
         model.addAttribute("guildName", guild.name)
         model.addAttribute("balance", balance)
+        model.addAttribute("tobyCoins", tobyCoins)
+        model.addAttribute("marketPrice", marketPrice)
         model.addAttribute("minStake", Dice.MIN_STAKE)
         model.addAttribute("maxStake", Dice.MAX_STAKE)
         model.addAttribute("sides", Dice.DEFAULT_SIDES)
@@ -84,7 +91,7 @@ class DiceController(
             return ResponseEntity.status(403).body(RollResponse(false, "You are not a member of that server."))
         }
 
-        return when (val outcome = diceService.roll(discordId, guildId, request.stake, request.prediction)) {
+        return when (val outcome = diceService.roll(discordId, guildId, request.stake, request.prediction, request.autoTopUp)) {
             is RollOutcome.Win -> ResponseEntity.ok(
                 RollResponse(
                     ok = true,
@@ -94,7 +101,9 @@ class DiceController(
                     payout = outcome.payout,
                     newBalance = outcome.newBalance,
                     win = true,
-                    jackpotPayout = outcome.jackpotPayout.takeIf { it > 0L }
+                    jackpotPayout = outcome.jackpotPayout.takeIf { it > 0L },
+                    soldTobyCoins = outcome.soldTobyCoins.takeIf { it > 0L },
+                    newPrice = outcome.newPrice
                 )
             )
 
@@ -106,12 +115,18 @@ class DiceController(
                     net = -outcome.stake,
                     payout = 0L,
                     newBalance = outcome.newBalance,
-                    win = false
+                    win = false,
+                    soldTobyCoins = outcome.soldTobyCoins.takeIf { it > 0L },
+                    newPrice = outcome.newPrice
                 )
             )
 
             is RollOutcome.InsufficientCredits -> ResponseEntity.badRequest().body(
                 RollResponse(false, "Need ${outcome.stake} credits, you have ${outcome.have}.")
+            )
+
+            is RollOutcome.InsufficientCoinsForTopUp -> ResponseEntity.badRequest().body(
+                RollResponse(false, "Need ${outcome.needed} TOBY to cover the shortfall, you have ${outcome.have}.")
             )
 
             is RollOutcome.InvalidStake -> ResponseEntity.badRequest().body(
@@ -129,7 +144,7 @@ class DiceController(
     }
 }
 
-data class RollRequest(val prediction: Int = 0, val stake: Long = 0)
+data class RollRequest(val prediction: Int = 0, val stake: Long = 0, val autoTopUp: Boolean = false)
 
 data class RollResponse(
     val ok: Boolean,
@@ -140,5 +155,7 @@ data class RollResponse(
     val payout: Long? = null,
     val newBalance: Long? = null,
     val win: Boolean? = null,
-    val jackpotPayout: Long? = null
+    val jackpotPayout: Long? = null,
+    val soldTobyCoins: Long? = null,
+    val newPrice: Double? = null
 )

--- a/web/src/main/kotlin/web/controller/HighlowController.kt
+++ b/web/src/main/kotlin/web/controller/HighlowController.kt
@@ -4,6 +4,7 @@ import database.economy.Highlow
 import database.service.HighlowService
 import database.service.HighlowService.PlayOutcome
 import database.service.JackpotService
+import database.service.TobyCoinMarketService
 import database.service.UserService
 import jakarta.servlet.http.HttpSession
 import net.dv8tion.jda.api.JDA
@@ -30,6 +31,7 @@ class HighlowController(
     private val economyWebService: EconomyWebService,
     private val userService: UserService,
     private val jackpotService: JackpotService,
+    private val marketService: TobyCoinMarketService,
     private val jda: JDA
 ) {
 
@@ -52,7 +54,10 @@ class HighlowController(
             return "redirect:/casino/guilds"
         }
 
-        val balance = userService.getUserById(discordId, guildId)?.socialCredit ?: 0L
+        val profile = userService.getUserById(discordId, guildId)
+        val balance = profile?.socialCredit ?: 0L
+        val tobyCoins = profile?.tobyCoins ?: 0L
+        val marketPrice = marketService.getMarket(guildId)?.price ?: 0.0
 
         // Anchor sticks to the user's session so refreshing the page
         // can't reroll a fresh card. Drawn lazily on first hit.
@@ -62,6 +67,8 @@ class HighlowController(
         model.addAttribute("guildId", guildId.toString())
         model.addAttribute("guildName", guild.name)
         model.addAttribute("balance", balance)
+        model.addAttribute("tobyCoins", tobyCoins)
+        model.addAttribute("marketPrice", marketPrice)
         model.addAttribute("minStake", Highlow.MIN_STAKE)
         model.addAttribute("maxStake", Highlow.MAX_STAKE)
         model.addAttribute("multiplier", Highlow.DEFAULT_MULTIPLIER)
@@ -93,7 +100,7 @@ class HighlowController(
                 PlayResponse(false, "No active round — refresh the page to draw a new card.")
             )
 
-        val outcome = highlowService.play(discordId, guildId, request.stake, direction, anchor)
+        val outcome = highlowService.play(discordId, guildId, request.stake, direction, anchor, request.autoTopUp)
 
         // Only consume the anchor on outcomes that actually drew a next
         // card. Validation rejections (invalid stake, insufficient
@@ -118,7 +125,9 @@ class HighlowController(
                     newBalance = outcome.newBalance,
                     win = true,
                     nextAnchor = nextRoundAnchor,
-                    jackpotPayout = outcome.jackpotPayout.takeIf { it > 0L }
+                    jackpotPayout = outcome.jackpotPayout.takeIf { it > 0L },
+                    soldTobyCoins = outcome.soldTobyCoins.takeIf { it > 0L },
+                    newPrice = outcome.newPrice
                 )
             )
 
@@ -132,12 +141,18 @@ class HighlowController(
                     payout = 0L,
                     newBalance = outcome.newBalance,
                     win = false,
-                    nextAnchor = nextRoundAnchor
+                    nextAnchor = nextRoundAnchor,
+                    soldTobyCoins = outcome.soldTobyCoins.takeIf { it > 0L },
+                    newPrice = outcome.newPrice
                 )
             )
 
             is PlayOutcome.InsufficientCredits -> ResponseEntity.badRequest().body(
                 PlayResponse(false, "Need ${outcome.stake} credits, you have ${outcome.have}.")
+            )
+
+            is PlayOutcome.InsufficientCoinsForTopUp -> ResponseEntity.badRequest().body(
+                PlayResponse(false, "Need ${outcome.needed} TOBY to cover the shortfall, you have ${outcome.have}.")
             )
 
             is PlayOutcome.InvalidStake -> ResponseEntity.badRequest().body(
@@ -174,7 +189,7 @@ class HighlowController(
     }
 }
 
-data class PlayRequest(val direction: String = "", val stake: Long = 0)
+data class PlayRequest(val direction: String = "", val stake: Long = 0, val autoTopUp: Boolean = false)
 
 data class PlayResponse(
     val ok: Boolean,
@@ -187,5 +202,7 @@ data class PlayResponse(
     val newBalance: Long? = null,
     val win: Boolean? = null,
     val nextAnchor: Int? = null,
-    val jackpotPayout: Long? = null
+    val jackpotPayout: Long? = null,
+    val soldTobyCoins: Long? = null,
+    val newPrice: Double? = null
 )

--- a/web/src/main/kotlin/web/controller/ScratchController.kt
+++ b/web/src/main/kotlin/web/controller/ScratchController.kt
@@ -5,6 +5,7 @@ import database.economy.SlotMachine
 import database.service.JackpotService
 import database.service.ScratchService
 import database.service.ScratchService.ScratchOutcome
+import database.service.TobyCoinMarketService
 import database.service.UserService
 import net.dv8tion.jda.api.JDA
 import org.springframework.http.ResponseEntity
@@ -30,6 +31,7 @@ class ScratchController(
     private val economyWebService: EconomyWebService,
     private val userService: UserService,
     private val jackpotService: JackpotService,
+    private val marketService: TobyCoinMarketService,
     private val jda: JDA
 ) {
 
@@ -51,11 +53,16 @@ class ScratchController(
             return "redirect:/casino/guilds"
         }
 
-        val balance = userService.getUserById(discordId, guildId)?.socialCredit ?: 0L
+        val profile = userService.getUserById(discordId, guildId)
+        val balance = profile?.socialCredit ?: 0L
+        val tobyCoins = profile?.tobyCoins ?: 0L
+        val marketPrice = marketService.getMarket(guildId)?.price ?: 0.0
 
         model.addAttribute("guildId", guildId.toString())
         model.addAttribute("guildName", guild.name)
         model.addAttribute("balance", balance)
+        model.addAttribute("tobyCoins", tobyCoins)
+        model.addAttribute("marketPrice", marketPrice)
         model.addAttribute("minStake", ScratchCard.MIN_STAKE)
         model.addAttribute("maxStake", ScratchCard.MAX_STAKE)
         model.addAttribute("cellCount", ScratchCard.CELL_COUNT)
@@ -94,7 +101,7 @@ class ScratchController(
             return ResponseEntity.status(403).body(ScratchResponse(false, "You are not a member of that server."))
         }
 
-        return when (val outcome = scratchService.scratch(discordId, guildId, request.stake)) {
+        return when (val outcome = scratchService.scratch(discordId, guildId, request.stake, request.autoTopUp)) {
             is ScratchOutcome.Win -> ResponseEntity.ok(
                 ScratchResponse(
                     ok = true,
@@ -105,7 +112,9 @@ class ScratchController(
                     payout = outcome.payout,
                     newBalance = outcome.newBalance,
                     win = true,
-                    jackpotPayout = outcome.jackpotPayout.takeIf { it > 0L }
+                    jackpotPayout = outcome.jackpotPayout.takeIf { it > 0L },
+                    soldTobyCoins = outcome.soldTobyCoins.takeIf { it > 0L },
+                    newPrice = outcome.newPrice
                 )
             )
 
@@ -116,12 +125,18 @@ class ScratchController(
                     net = -outcome.stake,
                     payout = 0L,
                     newBalance = outcome.newBalance,
-                    win = false
+                    win = false,
+                    soldTobyCoins = outcome.soldTobyCoins.takeIf { it > 0L },
+                    newPrice = outcome.newPrice
                 )
             )
 
             is ScratchOutcome.InsufficientCredits -> ResponseEntity.badRequest().body(
                 ScratchResponse(false, "Need ${outcome.stake} credits, you have ${outcome.have}.")
+            )
+
+            is ScratchOutcome.InsufficientCoinsForTopUp -> ResponseEntity.badRequest().body(
+                ScratchResponse(false, "Need ${outcome.needed} TOBY to cover the shortfall, you have ${outcome.have}.")
             )
 
             is ScratchOutcome.InvalidStake -> ResponseEntity.badRequest().body(
@@ -137,7 +152,7 @@ class ScratchController(
 
 data class ScratchPayoutRow(val symbol: String, val multipliers: List<String>)
 
-data class ScratchRequest(val stake: Long = 0)
+data class ScratchRequest(val stake: Long = 0, val autoTopUp: Boolean = false)
 
 data class ScratchResponse(
     val ok: Boolean,
@@ -149,5 +164,7 @@ data class ScratchResponse(
     val payout: Long? = null,
     val newBalance: Long? = null,
     val win: Boolean? = null,
-    val jackpotPayout: Long? = null
+    val jackpotPayout: Long? = null,
+    val soldTobyCoins: Long? = null,
+    val newPrice: Double? = null
 )

--- a/web/src/main/kotlin/web/controller/SlotsController.kt
+++ b/web/src/main/kotlin/web/controller/SlotsController.kt
@@ -4,6 +4,7 @@ import database.economy.SlotMachine
 import database.service.JackpotService
 import database.service.SlotsService
 import database.service.SlotsService.SpinOutcome
+import database.service.TobyCoinMarketService
 import database.service.UserService
 import net.dv8tion.jda.api.JDA
 import org.springframework.http.ResponseEntity
@@ -38,6 +39,7 @@ class SlotsController(
     private val economyWebService: EconomyWebService,
     private val userService: UserService,
     private val jackpotService: JackpotService,
+    private val marketService: TobyCoinMarketService,
     private val jda: JDA
 ) {
 
@@ -60,11 +62,16 @@ class SlotsController(
             return "redirect:/leaderboards"
         }
 
-        val balance = userService.getUserById(discordId, guildId)?.socialCredit ?: 0L
+        val profile = userService.getUserById(discordId, guildId)
+        val balance = profile?.socialCredit ?: 0L
+        val tobyCoins = profile?.tobyCoins ?: 0L
+        val marketPrice = marketService.getMarket(guildId)?.price ?: 0.0
 
         model.addAttribute("guildId", guildId.toString())
         model.addAttribute("guildName", guild.name)
         model.addAttribute("balance", balance)
+        model.addAttribute("tobyCoins", tobyCoins)
+        model.addAttribute("marketPrice", marketPrice)
         model.addAttribute("minStake", SlotMachine.MIN_STAKE)
         model.addAttribute("maxStake", SlotMachine.MAX_STAKE)
         model.addAttribute("payoutTable", payoutRows())
@@ -85,7 +92,7 @@ class SlotsController(
         if (!economyWebService.isMember(discordId, guildId)) {
             return ResponseEntity.status(403).body(SpinResponse(false, "You are not a member of that server."))
         }
-        return when (val outcome = slotsService.spin(discordId, guildId, request.stake)) {
+        return when (val outcome = slotsService.spin(discordId, guildId, request.stake, request.autoTopUp)) {
             is SpinOutcome.Win -> ResponseEntity.ok(
                 SpinResponse(
                     ok = true,
@@ -95,7 +102,9 @@ class SlotsController(
                     net = outcome.net,
                     newBalance = outcome.newBalance,
                     win = true,
-                    jackpotPayout = outcome.jackpotPayout.takeIf { it > 0L }
+                    jackpotPayout = outcome.jackpotPayout.takeIf { it > 0L },
+                    soldTobyCoins = outcome.soldTobyCoins.takeIf { it > 0L },
+                    newPrice = outcome.newPrice
                 )
             )
 
@@ -107,12 +116,18 @@ class SlotsController(
                     payout = 0L,
                     net = -outcome.stake,
                     newBalance = outcome.newBalance,
-                    win = false
+                    win = false,
+                    soldTobyCoins = outcome.soldTobyCoins.takeIf { it > 0L },
+                    newPrice = outcome.newPrice
                 )
             )
 
             is SpinOutcome.InsufficientCredits -> ResponseEntity.badRequest().body(
                 SpinResponse(false, "Need ${outcome.stake} credits, you have ${outcome.have}.")
+            )
+
+            is SpinOutcome.InsufficientCoinsForTopUp -> ResponseEntity.badRequest().body(
+                SpinResponse(false, "Need ${outcome.needed} TOBY to cover the shortfall, you have ${outcome.have}.")
             )
 
             is SpinOutcome.InvalidStake -> ResponseEntity.badRequest().body(
@@ -140,7 +155,7 @@ class SlotsController(
     }
 }
 
-data class SpinRequest(val stake: Long = 0)
+data class SpinRequest(val stake: Long = 0, val autoTopUp: Boolean = false)
 
 data class SpinResponse(
     val ok: Boolean,
@@ -151,7 +166,9 @@ data class SpinResponse(
     val net: Long? = null,
     val newBalance: Long? = null,
     val win: Boolean? = null,
-    val jackpotPayout: Long? = null
+    val jackpotPayout: Long? = null,
+    val soldTobyCoins: Long? = null,
+    val newPrice: Double? = null
 )
 
 data class PayoutRow(val symbols: String, val multiplier: String)

--- a/web/src/main/kotlin/web/service/EconomyWebService.kt
+++ b/web/src/main/kotlin/web/service/EconomyWebService.kt
@@ -83,7 +83,8 @@ class EconomyWebService(
                 side = trade.side,
                 amount = trade.amount,
                 price = trade.pricePerCoin,
-                name = name
+                name = name,
+                reason = trade.reason
             )
         }
     }
@@ -138,5 +139,7 @@ data class TradeMarker(
     val side: String,
     val amount: Long,
     val price: Double,
-    val name: String
+    val name: String,
+    /** USER / TITLE_TOPUP / CASINO_TOPUP — see TobyCoinTradeDto. */
+    val reason: String = "USER"
 )

--- a/web/src/main/kotlin/web/service/TitlesWebService.kt
+++ b/web/src/main/kotlin/web/service/TitlesWebService.kt
@@ -12,8 +12,6 @@ import database.economy.TobyCoinEngine
 import net.dv8tion.jda.api.JDA
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import kotlin.math.ceil
-import kotlin.math.floor
 
 @Service
 class TitlesWebService(
@@ -137,17 +135,20 @@ class TitlesWebService(
             if (market.price <= 0.0) {
                 return BuyWithTobyOutcome.Error("Market price is not available right now.")
             }
-            // EconomyTradeService now fills sells at the midpoint of pre-
-            // and post-pressure prices (slippage). The naive
-            // `ceil(shortfall / market.price)` underestimates the coins
-            // needed by 1 because proceeds = floor(N×P×(1 − k×N/2)).
-            // Bump until proceeds-at-midpoint cover the shortfall.
-            val coinsNeeded = coinsNeededForShortfall(shortfall, market.price)
+            // EconomyTradeService fills sells at the midpoint of pre-
+            // and post-pressure prices (slippage) AND skims a flat
+            // TRADE_FEE off the proceeds for the jackpot pool. Naive
+            // ceil(shortfall / price) under-counts; ask the engine for
+            // the right N.
+            val coinsNeeded = TobyCoinEngine.coinsNeededForShortfall(shortfall, market.price)
             if (actor.tobyCoins < coinsNeeded) {
                 return BuyWithTobyOutcome.InsufficientCoins(needed = coinsNeeded, have = actor.tobyCoins)
             }
 
-            val sellOutcome = tradeService.sell(actorDiscordId, guildId, coinsNeeded)
+            val sellOutcome = tradeService.sell(
+                actorDiscordId, guildId, coinsNeeded,
+                reason = EconomyTradeService.REASON_TITLE_TOPUP
+            )
             if (sellOutcome !is TradeOutcome.Ok) {
                 return BuyWithTobyOutcome.Error("Sell failed: $sellOutcome")
             }
@@ -171,27 +172,6 @@ class TitlesWebService(
             newCredits = refreshed.socialCredit ?: 0L,
             newPrice = priceAfterSell
         )
-    }
-
-    /**
-     * Smallest coin count whose midpoint-price proceeds cover [shortfall].
-     * Closed-form would be a quadratic; in practice the naive
-     * `ceil(shortfall / price)` is at most one coin short of correct, so
-     * we bump iteratively. Bounded for safety against extreme `k×N`.
-     */
-    private fun coinsNeededForShortfall(shortfall: Long, price: Double): Long {
-        var n = ceil(shortfall.toDouble() / price).toLong().coerceAtLeast(1L)
-        repeat(8) {
-            if (proceedsAtMidpoint(n, price) >= shortfall) return n
-            n += 1L
-        }
-        return n
-    }
-
-    private fun proceedsAtMidpoint(coins: Long, price: Double): Long {
-        val newPrice = TobyCoinEngine.applySellPressure(price, coins)
-        val midpoint = (price + newPrice) / 2.0
-        return floor(midpoint * coins).toLong()
     }
 
     fun equipTitle(actorDiscordId: Long, guildId: Long, titleId: Long): String? {

--- a/web/src/main/resources/static/css/economy.css
+++ b/web/src/main/resources/static/css/economy.css
@@ -188,6 +188,12 @@
 }
 
 .economy-trade-who { font-weight: 600; }
+.economy-trade-reason {
+    color: var(--text-muted);
+    font-size: 0.85rem;
+    font-style: italic;
+    margin-left: 4px;
+}
 
 @media (max-width: 640px) {
     .economy-header { flex-direction: column; align-items: stretch; }

--- a/web/src/main/resources/static/js/casino-topup.js
+++ b/web/src/main/resources/static/js/casino-topup.js
@@ -1,0 +1,152 @@
+// Shared "Bet (sell TOBY)" button wiring for the casino minigame
+// pages. Each game's IIFE-style page JS calls TobyTopUp.init() once
+// to bind the second submit button to the same shortfall-recompute
+// logic, so /slots, /coinflip, /dice, /highlow, /scratch all behave
+// identically when a player has TOBY but not enough credits to cover
+// their stake.
+//
+// Mirrors `EconomyTradeService.sell` math (midpoint slippage + 1 %
+// trade fee → jackpot pool) so the displayed "sell N TOBY" amount on
+// the button matches the actual coins debited server-side.
+
+(function (root) {
+    'use strict';
+
+    // Keep these in lockstep with TobyCoinEngine.kt — drift means the
+    // button promises a sell size the server then rejects as too small.
+    const TRADE_IMPACT = 0.0001;
+    const TRADE_FEE = 0.01;
+
+    function proceedsForSell(price, coins) {
+        if (coins <= 0 || price <= 0) return 0;
+        const newPrice = Math.max(1.0, price * (1.0 - TRADE_IMPACT * coins));
+        const midpoint = (price + newPrice) / 2.0;
+        const gross = Math.floor(midpoint * coins);
+        const fee = Math.floor(gross * TRADE_FEE);
+        return gross - fee;
+    }
+
+    function coinsNeededForShortfall(shortfall, price, maxCoins) {
+        if (shortfall <= 0 || price <= 0) return 0;
+        let n = Math.max(1, Math.ceil(shortfall / price));
+        for (let i = 0; i < 16; i++) {
+            if (n > maxCoins) return maxCoins + 1;
+            if (proceedsForSell(price, n) >= shortfall) return n;
+            n += 1;
+        }
+        return n;
+    }
+
+    /**
+     * Wire the second "Bet (sell TOBY)" submit button. Recomputes the
+     * required coin count whenever the stake input changes, hides the
+     * button when the player has enough credits to cover the wager.
+     *
+     * Caller supplies `onSubmit(autoTopUp)` to actually trigger the
+     * wager request — the helper is concerned only with shortfall
+     * math + button state, not with networking.
+     *
+     * Options:
+     *   form           — the bet form
+     *   stakeInput     — number input
+     *   primaryBtn     — main submit button
+     *   tobyBtn        — secondary submit button (the one this helper drives)
+     *   balanceEl      — element whose textContent is the live credit balance
+     *   tobyCoins      — initial TOBY count (refreshed by setTobyCoins)
+     *   marketPrice    — pre-pressure market price for sell quoting
+     *   onSubmit(autoTopUp) — handler invoked when either button is clicked
+     */
+    function init(opts) {
+        const form = opts.form;
+        const stakeInput = opts.stakeInput;
+        const primaryBtn = opts.primaryBtn;
+        const tobyBtn = opts.tobyBtn;
+        const balanceEl = opts.balanceEl;
+        const onSubmit = opts.onSubmit;
+        let tobyCoins = Number(opts.tobyCoins) || 0;
+        let marketPrice = Number(opts.marketPrice) || 0;
+
+        if (!form || !stakeInput || !tobyBtn) return null;
+
+        const coinsLabel = tobyBtn.querySelector('.casino-bet-toby-coins');
+
+        function liveBalance() {
+            if (!balanceEl) return 0;
+            const parsed = parseInt(balanceEl.textContent, 10);
+            return isNaN(parsed) ? 0 : parsed;
+        }
+
+        function refresh() {
+            const stake = parseInt(stakeInput.value, 10);
+            const balance = liveBalance();
+            if (!stake || stake <= 0 || balance >= stake) {
+                // Either no stake yet or credits already cover it — only
+                // the primary button is relevant.
+                tobyBtn.hidden = true;
+                return;
+            }
+            const shortfall = stake - balance;
+            const coinsNeeded = coinsNeededForShortfall(shortfall, marketPrice, tobyCoins);
+            if (marketPrice <= 0 || coinsNeeded > tobyCoins) {
+                // Either no market yet or the player's TOBY can't cover.
+                tobyBtn.hidden = true;
+                return;
+            }
+            if (coinsLabel) coinsLabel.textContent = String(coinsNeeded);
+            tobyBtn.hidden = false;
+        }
+
+        function setTobyCoins(n) {
+            tobyCoins = Number(n) || 0;
+            refresh();
+        }
+
+        function setMarketPrice(p) {
+            marketPrice = Number(p) || 0;
+            refresh();
+        }
+
+        // Track which button initiated the submit so the form handler
+        // can pass autoTopUp through to the caller.
+        let lastClickedToby = false;
+        if (primaryBtn) {
+            primaryBtn.addEventListener('click', function () { lastClickedToby = false; });
+        }
+        tobyBtn.addEventListener('click', function () { lastClickedToby = true; });
+
+        form.addEventListener('submit', function (e) {
+            e.preventDefault();
+            if (typeof onSubmit === 'function') onSubmit(lastClickedToby);
+            lastClickedToby = false;
+        });
+
+        stakeInput.addEventListener('input', refresh);
+        refresh();
+
+        return {
+            refresh: refresh,
+            setTobyCoins: setTobyCoins,
+            setMarketPrice: setMarketPrice,
+        };
+    }
+
+    /** Tiny formatter for the "Sold N TOBY @ price" prefix on result lines. */
+    function soldPrefixHtml(soldTobyCoins, newPrice) {
+        if (!soldTobyCoins || soldTobyCoins <= 0) return '';
+        const priceText = (typeof newPrice === 'number') ? ' @ ' + newPrice.toFixed(2) : '';
+        return '<small class="casino-bet-toby-sold">Sold ' + soldTobyCoins +
+            ' TOBY' + priceText + '</small><br>';
+    }
+
+    const api = {
+        init: init,
+        proceedsForSell: proceedsForSell,
+        coinsNeededForShortfall: coinsNeededForShortfall,
+        soldPrefixHtml: soldPrefixHtml,
+    };
+
+    if (root) root.TobyTopUp = api;
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = api;
+    }
+})(typeof window !== 'undefined' ? window : null);

--- a/web/src/main/resources/static/js/coinflip.js
+++ b/web/src/main/resources/static/js/coinflip.js
@@ -6,16 +6,20 @@ function renderCoinflipResult(resultEl, body) {
     resultEl.classList.remove('coinflip-result-win', 'coinflip-result-lose', 'coinflip-result-jackpot');
     const landedLabel = body.landed === 'HEADS' ? 'Heads' : 'Tails';
     const predictedLabel = body.predicted === 'HEADS' ? 'Heads' : 'Tails';
+    const topUpPrefix = (typeof window !== 'undefined' && window.TobyTopUp)
+        ? window.TobyTopUp.soldPrefixHtml(body.soldTobyCoins, body.newPrice)
+        : '';
     if (body.win) {
         resultEl.classList.add('coinflip-result-win');
         const winLine = '<strong>' + landedLabel + '!</strong> You called ' +
             predictedLabel + ' &middot; <strong>+' + body.net + ' credits</strong>';
-        resultEl.innerHTML = (typeof window !== 'undefined' && window.TobyJackpot)
+        const withJackpot = (typeof window !== 'undefined' && window.TobyJackpot)
             ? window.TobyJackpot.renderWinHtml(resultEl, body, 'coinflip-result-jackpot', winLine)
             : winLine;
+        resultEl.innerHTML = topUpPrefix + withJackpot;
     } else {
         resultEl.classList.add('coinflip-result-lose');
-        resultEl.innerHTML = '<strong>' + landedLabel + '.</strong> You called ' +
+        resultEl.innerHTML = topUpPrefix + '<strong>' + landedLabel + '.</strong> You called ' +
             predictedLabel + ' &middot; lost <strong>' + Math.abs(body.net) + ' credits</strong>';
     }
 }
@@ -27,6 +31,8 @@ function renderCoinflipResult(resultEl, body) {
     if (!main) return;
 
     const guildId = main.dataset.guildId;
+    const initialTobyCoins = Number(main.dataset.tobyCoins) || 0;
+    const initialMarketPrice = Number(main.dataset.marketPrice) || 0;
     const postJson = window.TobyApi && window.TobyApi.postJson;
 
     function toast(msg, type) {
@@ -41,11 +47,23 @@ function renderCoinflipResult(resultEl, body) {
     const coinFace = document.getElementById('coinflip-coin-face');
     const stakeInput = document.getElementById('coinflip-stake');
     const flipBtn = document.getElementById('coinflip-flip');
+    const flipTobyBtn = document.getElementById('coinflip-flip-toby');
     const balanceEl = document.getElementById('coinflip-balance');
     const resultEl = document.getElementById('coinflip-result');
     const form = document.getElementById('coinflip-bet');
 
     if (!form || !flipBtn || !stakeInput || !coin || !coinFace) return;
+
+    const topUp = (window.TobyTopUp && flipTobyBtn) ? window.TobyTopUp.init({
+        form: form,
+        stakeInput: stakeInput,
+        primaryBtn: flipBtn,
+        tobyBtn: flipTobyBtn,
+        balanceEl: balanceEl,
+        tobyCoins: initialTobyCoins,
+        marketPrice: initialMarketPrice,
+        onSubmit: function (autoTopUp) { runFlip(autoTopUp); },
+    }) : null;
 
     const FLIP_DURATION_MS = 800;
     const FLIP_INTERVAL_MS = 80;
@@ -91,8 +109,16 @@ function renderCoinflipResult(resultEl, body) {
         if (balanceEl) balanceEl.textContent = newBalance;
     }
 
-    form.addEventListener('submit', function (e) {
-        e.preventDefault();
+    function applyTobyDelta(body) {
+        if (!topUp) return;
+        if (typeof body.soldTobyCoins === 'number') {
+            const remaining = Math.max(0, initialTobyCoins - body.soldTobyCoins);
+            topUp.setTobyCoins(remaining);
+        }
+        if (typeof body.newPrice === 'number') topUp.setMarketPrice(body.newPrice);
+    }
+
+    function runFlip(autoTopUp) {
         if (flipping) return;
 
         const side = selectedSide();
@@ -107,26 +133,32 @@ function renderCoinflipResult(resultEl, body) {
         }
 
         flipBtn.disabled = true;
+        if (flipTobyBtn) flipTobyBtn.disabled = true;
         const intervalId = startFlipAnimation();
         const requestStart = Date.now();
 
         if (!postJson) {
             stopFlipAnimation(intervalId);
             flipBtn.disabled = false;
+            if (flipTobyBtn) flipTobyBtn.disabled = false;
             toast('API helper missing — refresh the page.', 'error');
             return;
         }
 
-        postJson('/casino/' + guildId + '/coinflip/flip', { side: side, stake: stake })
+        postJson('/casino/' + guildId + '/coinflip/flip', {
+            side: side, stake: stake, autoTopUp: !!autoTopUp,
+        })
             .then(function (body) {
                 const elapsed = Date.now() - requestStart;
                 const remaining = Math.max(0, FLIP_DURATION_MS - elapsed);
                 setTimeout(function () {
                     stopFlipAnimation(intervalId, body && body.landed);
                     flipBtn.disabled = false;
+                    if (flipTobyBtn) flipTobyBtn.disabled = false;
                     if (body && body.ok) {
                         renderCoinflipResult(resultEl, body);
                         applyBalance(body.newBalance);
+                        applyTobyDelta(body);
                     } else {
                         if (resultEl) resultEl.hidden = true;
                         toast((body && body.error) || 'Flip failed.', 'error');
@@ -136,10 +168,18 @@ function renderCoinflipResult(resultEl, body) {
             .catch(function () {
                 stopFlipAnimation(intervalId);
                 flipBtn.disabled = false;
+                if (flipTobyBtn) flipTobyBtn.disabled = false;
                 if (resultEl) resultEl.hidden = true;
                 toast('Network error.', 'error');
             });
-    });
+    }
+
+    if (!topUp) {
+        form.addEventListener('submit', function (e) {
+            e.preventDefault();
+            runFlip(false);
+        });
+    }
 })();
 
 if (typeof module !== 'undefined' && module.exports) {

--- a/web/src/main/resources/static/js/dice.js
+++ b/web/src/main/resources/static/js/dice.js
@@ -4,16 +4,20 @@ function renderDiceResult(resultEl, body) {
     if (!resultEl) return;
     resultEl.hidden = false;
     resultEl.classList.remove('dice-result-win', 'dice-result-lose', 'dice-result-jackpot');
+    const topUpPrefix = (typeof window !== 'undefined' && window.TobyTopUp)
+        ? window.TobyTopUp.soldPrefixHtml(body.soldTobyCoins, body.newPrice)
+        : '';
     if (body.win) {
         resultEl.classList.add('dice-result-win');
         const winLine = '<strong>' + body.landed + '!</strong> You called ' +
             body.predicted + ' &middot; <strong>+' + body.net + ' credits</strong>';
-        resultEl.innerHTML = (typeof window !== 'undefined' && window.TobyJackpot)
+        const withJackpot = (typeof window !== 'undefined' && window.TobyJackpot)
             ? window.TobyJackpot.renderWinHtml(resultEl, body, 'dice-result-jackpot', winLine)
             : winLine;
+        resultEl.innerHTML = topUpPrefix + withJackpot;
     } else {
         resultEl.classList.add('dice-result-lose');
-        resultEl.innerHTML = '<strong>' + body.landed + '.</strong> You called ' +
+        resultEl.innerHTML = topUpPrefix + '<strong>' + body.landed + '.</strong> You called ' +
             body.predicted + ' &middot; lost <strong>' + Math.abs(body.net) + ' credits</strong>';
     }
 }
@@ -25,6 +29,8 @@ function renderDiceResult(resultEl, body) {
     if (!main) return;
 
     const guildId = main.dataset.guildId;
+    const initialTobyCoins = Number(main.dataset.tobyCoins) || 0;
+    const initialMarketPrice = Number(main.dataset.marketPrice) || 0;
     const postJson = window.TobyApi && window.TobyApi.postJson;
 
     function toast(msg, type) {
@@ -39,11 +45,23 @@ function renderDiceResult(resultEl, body) {
     const dieFace = document.getElementById('dice-die-face');
     const stakeInput = document.getElementById('dice-stake');
     const rollBtn = document.getElementById('dice-roll');
+    const rollTobyBtn = document.getElementById('dice-roll-toby');
     const balanceEl = document.getElementById('dice-balance');
     const resultEl = document.getElementById('dice-result');
     const form = document.getElementById('dice-bet');
 
     if (!form || !rollBtn || !stakeInput || !die || !dieFace) return;
+
+    const topUp = (window.TobyTopUp && rollTobyBtn) ? window.TobyTopUp.init({
+        form: form,
+        stakeInput: stakeInput,
+        primaryBtn: rollBtn,
+        tobyBtn: rollTobyBtn,
+        balanceEl: balanceEl,
+        tobyCoins: initialTobyCoins,
+        marketPrice: initialMarketPrice,
+        onSubmit: function (autoTopUp) { runRoll(autoTopUp); },
+    }) : null;
 
     const FACES = { 1: '⚀', 2: '⚁', 3: '⚂', 4: '⚃', 5: '⚄', 6: '⚅' };
     const ROLL_DURATION_MS = 800;
@@ -84,8 +102,16 @@ function renderDiceResult(resultEl, body) {
         if (balanceEl) balanceEl.textContent = newBalance;
     }
 
-    form.addEventListener('submit', function (e) {
-        e.preventDefault();
+    function applyTobyDelta(body) {
+        if (!topUp) return;
+        if (typeof body.soldTobyCoins === 'number') {
+            const remaining = Math.max(0, initialTobyCoins - body.soldTobyCoins);
+            topUp.setTobyCoins(remaining);
+        }
+        if (typeof body.newPrice === 'number') topUp.setMarketPrice(body.newPrice);
+    }
+
+    function runRoll(autoTopUp) {
         if (rolling) return;
 
         const prediction = selectedPrediction();
@@ -100,26 +126,32 @@ function renderDiceResult(resultEl, body) {
         }
 
         rollBtn.disabled = true;
+        if (rollTobyBtn) rollTobyBtn.disabled = true;
         const intervalId = startRollAnimation();
         const requestStart = Date.now();
 
         if (!postJson) {
             stopRollAnimation(intervalId);
             rollBtn.disabled = false;
+            if (rollTobyBtn) rollTobyBtn.disabled = false;
             toast('API helper missing — refresh the page.', 'error');
             return;
         }
 
-        postJson('/casino/' + guildId + '/dice/roll', { prediction: prediction, stake: stake })
+        postJson('/casino/' + guildId + '/dice/roll', {
+            prediction: prediction, stake: stake, autoTopUp: !!autoTopUp,
+        })
             .then(function (body) {
                 const elapsed = Date.now() - requestStart;
                 const remaining = Math.max(0, ROLL_DURATION_MS - elapsed);
                 setTimeout(function () {
                     stopRollAnimation(intervalId, body && body.landed);
                     rollBtn.disabled = false;
+                    if (rollTobyBtn) rollTobyBtn.disabled = false;
                     if (body && body.ok) {
                         renderDiceResult(resultEl, body);
                         applyBalance(body.newBalance);
+                        applyTobyDelta(body);
                     } else {
                         if (resultEl) resultEl.hidden = true;
                         toast((body && body.error) || 'Roll failed.', 'error');
@@ -129,10 +161,18 @@ function renderDiceResult(resultEl, body) {
             .catch(function () {
                 stopRollAnimation(intervalId);
                 rollBtn.disabled = false;
+                if (rollTobyBtn) rollTobyBtn.disabled = false;
                 if (resultEl) resultEl.hidden = true;
                 toast('Network error.', 'error');
             });
-    });
+    }
+
+    if (!topUp) {
+        form.addEventListener('submit', function (e) {
+            e.preventDefault();
+            runRoll(false);
+        });
+    }
 })();
 
 if (typeof module !== 'undefined' && module.exports) {

--- a/web/src/main/resources/static/js/economy.js
+++ b/web/src/main/resources/static/js/economy.js
@@ -78,6 +78,17 @@
         return Math.floor(hours / 24) + 'd ago';
     }
 
+    // Map of reason discriminator → human-readable suffix shown next to
+    // a trade. USER trades render no suffix; the others get a tag so the
+    // viewer can tell organic activity from automated tops-up.
+    function reasonSuffix(reason) {
+        switch (reason) {
+            case 'TITLE_TOPUP': return ' (title top-up)';
+            case 'CASINO_TOPUP': return ' (casino top-up)';
+            default: return '';
+        }
+    }
+
     function renderRecentTrades(trades) {
         if (!recentTradesList || !recentTradesPanel) return;
         if (!trades.length) {
@@ -94,12 +105,14 @@
             li.className = 'economy-trade-row';
             const verb = t.side === 'BUY' ? 'bought' : 'sold';
             const verbClass = t.side === 'BUY' ? 'economy-trade-buy' : 'economy-trade-sell';
+            const suffix = reasonSuffix(t.reason);
             li.innerHTML =
                 '<span class="economy-trade-when">' + formatRelative(t.t) + '</span>' +
                 '<span class="economy-trade-who">' + escapeHtml(t.name) + '</span>' +
                 ' <span class="' + verbClass + '">' + verb + '</span> ' +
                 '<strong>' + t.amount + '</strong> @ ' +
-                t.price.toFixed(2);
+                t.price.toFixed(2) +
+                (suffix ? '<span class="economy-trade-reason">' + escapeHtml(suffix) + '</span>' : '');
             recentTradesList.appendChild(li);
         });
     }
@@ -150,7 +163,8 @@
                                 const trade = item.raw && item.raw.trade;
                                 if (trade) {
                                     const verb = trade.side === 'BUY' ? 'bought' : 'sold';
-                                    return trade.name + ' ' + verb + ' ' + trade.amount + ' @ ' + trade.price.toFixed(2);
+                                    return trade.name + ' ' + verb + ' ' + trade.amount + ' @ ' +
+                                        trade.price.toFixed(2) + reasonSuffix(trade.reason);
                                 }
                                 return item.parsed.y.toFixed(2) + ' credits';
                             }

--- a/web/src/main/resources/static/js/highlow.js
+++ b/web/src/main/resources/static/js/highlow.js
@@ -16,18 +16,22 @@ function renderHighlowResult(resultEl, body) {
     resultEl.hidden = false;
     resultEl.classList.remove('highlow-result-win', 'highlow-result-lose', 'highlow-result-jackpot');
     const dirLabel = body.direction === 'HIGHER' ? 'Higher' : 'Lower';
+    const topUpPrefix = (typeof window !== 'undefined' && window.TobyTopUp)
+        ? window.TobyTopUp.soldPrefixHtml(body.soldTobyCoins, body.newPrice)
+        : '';
     if (body.win) {
         resultEl.classList.add('highlow-result-win');
         const winLine = '<strong>' + highlowCardLabel(body.next) + '</strong> ' +
             (body.next > body.anchor ? '>' : '<') + ' <strong>' + highlowCardLabel(body.anchor) +
             '</strong> &middot; you called ' + dirLabel + ' &middot; <strong>+' + body.net + ' credits</strong>';
-        resultEl.innerHTML = (typeof window !== 'undefined' && window.TobyJackpot)
+        const withJackpot = (typeof window !== 'undefined' && window.TobyJackpot)
             ? window.TobyJackpot.renderWinHtml(resultEl, body, 'highlow-result-jackpot', winLine)
             : winLine;
+        resultEl.innerHTML = topUpPrefix + withJackpot;
     } else {
         resultEl.classList.add('highlow-result-lose');
         const tie = body.next === body.anchor;
-        resultEl.innerHTML = '<strong>' + highlowCardLabel(body.next) + '</strong> ' +
+        resultEl.innerHTML = topUpPrefix + '<strong>' + highlowCardLabel(body.next) + '</strong> ' +
             (tie ? '=' : (body.next > body.anchor ? '>' : '<')) +
             ' <strong>' + highlowCardLabel(body.anchor) + '</strong> &middot; you called ' +
             dirLabel + ' &middot; lost <strong>' + Math.abs(body.net) + ' credits</strong>';
@@ -41,6 +45,8 @@ function renderHighlowResult(resultEl, body) {
     if (!main) return;
 
     const guildId = main.dataset.guildId;
+    const initialTobyCoins = Number(main.dataset.tobyCoins) || 0;
+    const initialMarketPrice = Number(main.dataset.marketPrice) || 0;
     const postJson = window.TobyApi && window.TobyApi.postJson;
 
     function toast(msg, type) {
@@ -57,11 +63,23 @@ function renderHighlowResult(resultEl, body) {
     const nextCard = document.getElementById('highlow-next');
     const stakeInput = document.getElementById('highlow-stake');
     const dealBtn = document.getElementById('highlow-deal');
+    const dealTobyBtn = document.getElementById('highlow-deal-toby');
     const balanceEl = document.getElementById('highlow-balance');
     const resultEl = document.getElementById('highlow-result');
     const form = document.getElementById('highlow-bet');
 
     if (!form || !dealBtn || !stakeInput || !anchorFace || !nextFace) return;
+
+    const topUp = (window.TobyTopUp && dealTobyBtn) ? window.TobyTopUp.init({
+        form: form,
+        stakeInput: stakeInput,
+        primaryBtn: dealBtn,
+        tobyBtn: dealTobyBtn,
+        balanceEl: balanceEl,
+        tobyCoins: initialTobyCoins,
+        marketPrice: initialMarketPrice,
+        onSubmit: function (autoTopUp) { runDeal(autoTopUp); },
+    }) : null;
 
     const NEXT_DEAL_MS = 900;
     const SHUFFLE_INTERVAL_MS = 70;
@@ -112,8 +130,16 @@ function renderHighlowResult(resultEl, body) {
         if (balanceEl) balanceEl.textContent = newBalance;
     }
 
-    form.addEventListener('submit', function (e) {
-        e.preventDefault();
+    function applyTobyDelta(body) {
+        if (!topUp) return;
+        if (typeof body.soldTobyCoins === 'number') {
+            const remaining = Math.max(0, initialTobyCoins - body.soldTobyCoins);
+            topUp.setTobyCoins(remaining);
+        }
+        if (typeof body.newPrice === 'number') topUp.setMarketPrice(body.newPrice);
+    }
+
+    function runDeal(autoTopUp) {
         if (dealing) return;
 
         const direction = selectedDirection();
@@ -128,17 +154,21 @@ function renderHighlowResult(resultEl, body) {
         }
 
         dealBtn.disabled = true;
+        if (dealTobyBtn) dealTobyBtn.disabled = true;
         const intervalId = startNextShuffle();
         const requestStart = Date.now();
 
         if (!postJson) {
             stopNextShuffle(intervalId);
             dealBtn.disabled = false;
+            if (dealTobyBtn) dealTobyBtn.disabled = false;
             toast('API helper missing — refresh the page.', 'error');
             return;
         }
 
-        postJson('/casino/' + guildId + '/highlow/play', { direction: direction, stake: stake })
+        postJson('/casino/' + guildId + '/highlow/play', {
+            direction: direction, stake: stake, autoTopUp: !!autoTopUp,
+        })
             .then(function (body) {
                 const elapsed = Date.now() - requestStart;
                 const remaining = Math.max(0, NEXT_DEAL_MS - elapsed);
@@ -147,9 +177,7 @@ function renderHighlowResult(resultEl, body) {
                         stopNextShuffle(intervalId, body.next);
                         renderHighlowResult(resultEl, body);
                         applyBalance(body.newBalance);
-                        // Pause briefly so the player reads the result, then
-                        // surface the next round's anchor without requiring
-                        // a page refresh.
+                        applyTobyDelta(body);
                         if (typeof body.nextAnchor === 'number') {
                             setTimeout(function () { rollAnchorTo(body.nextAnchor); }, 1200);
                         }
@@ -159,15 +187,24 @@ function renderHighlowResult(resultEl, body) {
                         toast((body && body.error) || 'Deal failed.', 'error');
                     }
                     dealBtn.disabled = false;
+                    if (dealTobyBtn) dealTobyBtn.disabled = false;
                 }, remaining);
             })
             .catch(function () {
                 stopNextShuffle(intervalId);
                 dealBtn.disabled = false;
+                if (dealTobyBtn) dealTobyBtn.disabled = false;
                 if (resultEl) resultEl.hidden = true;
                 toast('Network error.', 'error');
             });
-    });
+    }
+
+    if (!topUp) {
+        form.addEventListener('submit', function (e) {
+            e.preventDefault();
+            runDeal(false);
+        });
+    }
 })();
 
 if (typeof module !== 'undefined' && module.exports) {

--- a/web/src/main/resources/static/js/scratch.js
+++ b/web/src/main/resources/static/js/scratch.js
@@ -7,16 +7,20 @@ function renderScratchResult(resultEl, body, matchThreshold, balanceEl) {
     if (!resultEl) return;
     resultEl.hidden = false;
     resultEl.classList.remove('scratch-result-win', 'scratch-result-lose', 'scratch-result-jackpot');
+    const topUpPrefix = (typeof window !== 'undefined' && window.TobyTopUp)
+        ? window.TobyTopUp.soldPrefixHtml(body.soldTobyCoins, body.newPrice)
+        : '';
     if (body.win) {
         resultEl.classList.add('scratch-result-win');
         const winLine = '<strong>' + body.matchCount + '× ' + body.winningSymbol +
             '</strong> &middot; <strong>+' + body.net + ' credits</strong>';
-        resultEl.innerHTML = (typeof window !== 'undefined' && window.TobyJackpot)
+        const withJackpot = (typeof window !== 'undefined' && window.TobyJackpot)
             ? window.TobyJackpot.renderWinHtml(resultEl, body, 'scratch-result-jackpot', winLine)
             : winLine;
+        resultEl.innerHTML = topUpPrefix + withJackpot;
     } else {
         resultEl.classList.add('scratch-result-lose');
-        resultEl.innerHTML = 'No ' + matchThreshold + '-of-a-kind &middot; lost <strong>' +
+        resultEl.innerHTML = topUpPrefix + 'No ' + matchThreshold + '-of-a-kind &middot; lost <strong>' +
             Math.abs(body.net) + ' credits</strong>';
     }
     if (typeof body.newBalance === 'number' && balanceEl) balanceEl.textContent = body.newBalance;
@@ -30,6 +34,8 @@ function renderScratchResult(resultEl, body, matchThreshold, balanceEl) {
 
     const guildId = main.dataset.guildId;
     const matchThreshold = parseInt(main.dataset.matchThreshold, 10) || 5;
+    const initialTobyCoins = Number(main.dataset.tobyCoins) || 0;
+    const initialMarketPrice = Number(main.dataset.marketPrice) || 0;
     const postJson = window.TobyApi && window.TobyApi.postJson;
 
     function toast(msg, type) {
@@ -44,12 +50,24 @@ function renderScratchResult(resultEl, body, matchThreshold, balanceEl) {
     const cellButtons = Array.from(cellsContainer ? cellsContainer.querySelectorAll('.scratch-cell') : []);
     const stakeInput = document.getElementById('scratch-stake');
     const buyBtn = document.getElementById('scratch-buy');
+    const buyTobyBtn = document.getElementById('scratch-buy-toby');
     const revealBtn = document.getElementById('scratch-reveal-all');
     const balanceEl = document.getElementById('scratch-balance');
     const resultEl = document.getElementById('scratch-result');
     const form = document.getElementById('scratch-bet');
 
     if (!form || !buyBtn || !stakeInput || cellButtons.length === 0) return;
+
+    const topUp = (window.TobyTopUp && buyTobyBtn) ? window.TobyTopUp.init({
+        form: form,
+        stakeInput: stakeInput,
+        primaryBtn: buyBtn,
+        tobyBtn: buyTobyBtn,
+        balanceEl: balanceEl,
+        tobyCoins: initialTobyCoins,
+        marketPrice: initialMarketPrice,
+        onSubmit: function (autoTopUp) { runBuy(autoTopUp); },
+    }) : null;
 
     let busy = false;
     // Latest active card. Server returns the symbols up front; cells are
@@ -119,8 +137,7 @@ function renderScratchResult(resultEl, body, matchThreshold, balanceEl) {
 
     if (revealBtn) revealBtn.addEventListener('click', revealAll);
 
-    form.addEventListener('submit', function (e) {
-        e.preventDefault();
+    function runBuy(autoTopUp) {
         if (busy) return;
 
         const stake = parseInt(stakeInput.value, 10);
@@ -131,23 +148,32 @@ function renderScratchResult(resultEl, body, matchThreshold, balanceEl) {
 
         busy = true;
         buyBtn.disabled = true;
+        if (buyTobyBtn) buyTobyBtn.disabled = true;
         if (resultEl) resultEl.hidden = true;
         resetCells();
 
         if (!postJson) {
             buyBtn.disabled = false;
+            if (buyTobyBtn) buyTobyBtn.disabled = false;
             busy = false;
             toast('API helper missing — refresh the page.', 'error');
             return;
         }
 
-        postJson('/casino/' + guildId + '/scratch/scratch', { stake: stake })
+        postJson('/casino/' + guildId + '/scratch/scratch', { stake: stake, autoTopUp: !!autoTopUp })
             .then(function (body) {
                 buyBtn.disabled = false;
+                if (buyTobyBtn) buyTobyBtn.disabled = false;
                 busy = false;
                 if (body && body.ok) {
                     activeCard = body;
                     if (revealBtn) revealBtn.hidden = false;
+                    if (topUp) {
+                        if (typeof body.soldTobyCoins === 'number') {
+                            topUp.setTobyCoins(Math.max(0, initialTobyCoins - body.soldTobyCoins));
+                        }
+                        if (typeof body.newPrice === 'number') topUp.setMarketPrice(body.newPrice);
+                    }
                     // Don't auto-reveal — the user clicks each cell. The
                     // result and balance only apply when all cells are
                     // scratched (or "Reveal all" is hit), so the player
@@ -160,10 +186,18 @@ function renderScratchResult(resultEl, body, matchThreshold, balanceEl) {
             })
             .catch(function () {
                 buyBtn.disabled = false;
+                if (buyTobyBtn) buyTobyBtn.disabled = false;
                 busy = false;
                 toast('Network error.', 'error');
             });
-    });
+    }
+
+    if (!topUp) {
+        form.addEventListener('submit', function (e) {
+            e.preventDefault();
+            runBuy(false);
+        });
+    }
 })();
 
 if (typeof module !== 'undefined' && module.exports) {

--- a/web/src/main/resources/static/js/slots.js
+++ b/web/src/main/resources/static/js/slots.js
@@ -5,16 +5,20 @@ function renderSlotsResult(resultEl, body) {
     if (!resultEl) return;
     resultEl.hidden = false;
     resultEl.classList.remove('slots-result-win', 'slots-result-lose', 'slots-result-jackpot');
+    const topUpPrefix = (typeof window !== 'undefined' && window.TobyTopUp)
+        ? window.TobyTopUp.soldPrefixHtml(body.soldTobyCoins, body.newPrice)
+        : '';
     if (body.win) {
         resultEl.classList.add('slots-result-win');
         const winLine = '<strong>+' + body.net + ' credits</strong> &middot; ' +
             body.multiplier + '× on a stake';
-        resultEl.innerHTML = (typeof window !== 'undefined' && window.TobyJackpot)
+        const withJackpot = (typeof window !== 'undefined' && window.TobyJackpot)
             ? window.TobyJackpot.renderWinHtml(resultEl, body, 'slots-result-jackpot', winLine)
             : winLine;
+        resultEl.innerHTML = topUpPrefix + withJackpot;
     } else {
         resultEl.classList.add('slots-result-lose');
-        resultEl.innerHTML = 'Lost <strong>' + Math.abs(body.net) + ' credits</strong>';
+        resultEl.innerHTML = topUpPrefix + 'Lost <strong>' + Math.abs(body.net) + ' credits</strong>';
     }
 }
 
@@ -25,6 +29,8 @@ function renderSlotsResult(resultEl, body) {
     if (!main) return;
 
     const guildId = main.dataset.guildId;
+    const initialTobyCoins = Number(main.dataset.tobyCoins) || 0;
+    const initialMarketPrice = Number(main.dataset.marketPrice) || 0;
     const postJson = window.TobyApi && window.TobyApi.postJson;
 
     function toast(msg, type) {
@@ -42,11 +48,23 @@ function renderSlotsResult(resultEl, body) {
     ];
     const stakeInput = document.getElementById('slots-stake');
     const spinBtn = document.getElementById('slots-spin');
+    const spinTobyBtn = document.getElementById('slots-spin-toby');
     const balanceEl = document.getElementById('slots-balance');
     const resultEl = document.getElementById('slots-result');
     const form = document.getElementById('slots-bet');
 
     if (!form || !spinBtn || !stakeInput || reels.some(function (r) { return !r; })) return;
+
+    const topUp = (window.TobyTopUp && spinTobyBtn) ? window.TobyTopUp.init({
+        form: form,
+        stakeInput: stakeInput,
+        primaryBtn: spinBtn,
+        tobyBtn: spinTobyBtn,
+        balanceEl: balanceEl,
+        tobyCoins: initialTobyCoins,
+        marketPrice: initialMarketPrice,
+        onSubmit: function (autoTopUp) { runSpin(autoTopUp); },
+    }) : null;
 
     const SPIN_SYMBOLS = ['🍒', '🍋', '🔔', '⭐'];
     const SPIN_INTERVAL_MS = 60;
@@ -78,8 +96,19 @@ function renderSlotsResult(resultEl, body) {
         if (balanceEl) balanceEl.textContent = newBalance;
     }
 
-    form.addEventListener('submit', function (e) {
-        e.preventDefault();
+    function applyTobyDelta(body) {
+        // After a successful spin (top-up or otherwise) refresh the
+        // helper's tobyCoins so the second-button state reflects the
+        // post-sale wallet.
+        if (!topUp) return;
+        if (typeof body.soldTobyCoins === 'number') {
+            const remaining = Math.max(0, initialTobyCoins - body.soldTobyCoins);
+            topUp.setTobyCoins(remaining);
+        }
+        if (typeof body.newPrice === 'number') topUp.setMarketPrice(body.newPrice);
+    }
+
+    function runSpin(autoTopUp) {
         if (spinning) return;
 
         const stake = parseInt(stakeInput.value, 10);
@@ -89,26 +118,30 @@ function renderSlotsResult(resultEl, body) {
         }
 
         spinBtn.disabled = true;
+        if (spinTobyBtn) spinTobyBtn.disabled = true;
         const intervalId = startSpinAnimation();
         const requestStart = Date.now();
 
         if (!postJson) {
             stopSpinAnimation(intervalId);
             spinBtn.disabled = false;
+            if (spinTobyBtn) spinTobyBtn.disabled = false;
             toast('API helper missing — refresh the page.', 'error');
             return;
         }
 
-        postJson('/casino/' + guildId + '/slots/spin', { stake: stake })
+        postJson('/casino/' + guildId + '/slots/spin', { stake: stake, autoTopUp: !!autoTopUp })
             .then(function (body) {
                 const elapsed = Date.now() - requestStart;
                 const remaining = Math.max(0, SPIN_DURATION_MS - elapsed);
                 setTimeout(function () {
                     stopSpinAnimation(intervalId, body && body.symbols);
                     spinBtn.disabled = false;
+                    if (spinTobyBtn) spinTobyBtn.disabled = false;
                     if (body && body.ok) {
                         renderSlotsResult(resultEl, body);
                         applyBalance(body.newBalance);
+                        applyTobyDelta(body);
                     } else {
                         if (resultEl) resultEl.hidden = true;
                         toast((body && body.error) || 'Spin failed.', 'error');
@@ -118,10 +151,20 @@ function renderSlotsResult(resultEl, body) {
             .catch(function () {
                 stopSpinAnimation(intervalId);
                 spinBtn.disabled = false;
+                if (spinTobyBtn) spinTobyBtn.disabled = false;
                 if (resultEl) resultEl.hidden = true;
                 toast('Network error.', 'error');
             });
-    });
+    }
+
+    if (!topUp) {
+        // No TobyTopUp helper loaded — the page still works without
+        // the auto-topup flow, plain submit posts a normal spin.
+        form.addEventListener('submit', function (e) {
+            e.preventDefault();
+            runSpin(false);
+        });
+    }
 })();
 
 if (typeof module !== 'undefined' && module.exports) {

--- a/web/src/main/resources/templates/coinflip.html
+++ b/web/src/main/resources/templates/coinflip.html
@@ -5,7 +5,8 @@
 <a href="#main" class="skip-link">Skip to content</a>
 <div th:replace="~{fragments/navbar :: navbar}"></div>
 
-<main id="main" class="container" th:attr="data-guild-id=${guildId}">
+<main id="main" class="container"
+      th:attr="data-guild-id=${guildId}, data-toby-coins=${tobyCoins}, data-market-price=${marketPrice}">
 
     <div class="coinflip-header">
         <a class="back-link" th:href="@{/casino/guilds}">&larr; All casino servers</a>
@@ -43,6 +44,10 @@
                    th:value="${minStake}"
                    step="1">
             <button type="submit" id="coinflip-flip" class="btn-primary">Flip</button>
+            <button type="submit" id="coinflip-flip-toby" class="btn-secondary casino-bet-toby" hidden
+                    title="Sells just enough TOBY at the live market price to cover the shortfall, then flips.">
+                Flip (sell <span class="casino-bet-toby-coins">0</span> TOBY)
+            </button>
         </form>
 
         <div class="coinflip-balance">
@@ -71,6 +76,7 @@
 <script th:src="@{/js/api.js}"></script>
 <script th:src="@{/js/toasts.js}"></script>
 <script th:src="@{/js/casino-jackpot.js}"></script>
+<script th:src="@{/js/casino-topup.js}"></script>
 <script th:src="@{/js/coinflip.js}"></script>
 </body>
 </html>

--- a/web/src/main/resources/templates/dice.html
+++ b/web/src/main/resources/templates/dice.html
@@ -5,7 +5,8 @@
 <a href="#main" class="skip-link">Skip to content</a>
 <div th:replace="~{fragments/navbar :: navbar}"></div>
 
-<main id="main" class="container" th:attr="data-guild-id=${guildId}">
+<main id="main" class="container"
+      th:attr="data-guild-id=${guildId}, data-toby-coins=${tobyCoins}, data-market-price=${marketPrice}">
 
     <div class="dice-header">
         <a class="back-link" th:href="@{/casino/guilds}">&larr; All casino servers</a>
@@ -40,6 +41,10 @@
                    th:value="${minStake}"
                    step="1">
             <button type="submit" id="dice-roll" class="btn-primary">Roll</button>
+            <button type="submit" id="dice-roll-toby" class="btn-secondary casino-bet-toby" hidden
+                    title="Sells just enough TOBY at the live market price to cover the shortfall, then rolls.">
+                Roll (sell <span class="casino-bet-toby-coins">0</span> TOBY)
+            </button>
         </form>
 
         <div class="dice-balance">
@@ -68,6 +73,7 @@
 <script th:src="@{/js/api.js}"></script>
 <script th:src="@{/js/toasts.js}"></script>
 <script th:src="@{/js/casino-jackpot.js}"></script>
+<script th:src="@{/js/casino-topup.js}"></script>
 <script th:src="@{/js/dice.js}"></script>
 </body>
 </html>

--- a/web/src/main/resources/templates/highlow.html
+++ b/web/src/main/resources/templates/highlow.html
@@ -5,7 +5,8 @@
 <a href="#main" class="skip-link">Skip to content</a>
 <div th:replace="~{fragments/navbar :: navbar}"></div>
 
-<main id="main" class="container" th:attr="data-guild-id=${guildId}">
+<main id="main" class="container"
+      th:attr="data-guild-id=${guildId}, data-toby-coins=${tobyCoins}, data-market-price=${marketPrice}">
 
     <div class="highlow-header">
         <a class="back-link" th:href="@{/casino/guilds}">&larr; All casino servers</a>
@@ -53,6 +54,10 @@
                    th:value="${minStake}"
                    step="1">
             <button type="submit" id="highlow-deal" class="btn-primary">Deal</button>
+            <button type="submit" id="highlow-deal-toby" class="btn-secondary casino-bet-toby" hidden
+                    title="Sells just enough TOBY at the live market price to cover the shortfall, then deals.">
+                Deal (sell <span class="casino-bet-toby-coins">0</span> TOBY)
+            </button>
         </form>
 
         <div class="highlow-balance">
@@ -83,6 +88,7 @@
 <script th:src="@{/js/api.js}"></script>
 <script th:src="@{/js/toasts.js}"></script>
 <script th:src="@{/js/casino-jackpot.js}"></script>
+<script th:src="@{/js/casino-topup.js}"></script>
 <script th:src="@{/js/highlow.js}"></script>
 </body>
 </html>

--- a/web/src/main/resources/templates/scratch.html
+++ b/web/src/main/resources/templates/scratch.html
@@ -6,7 +6,8 @@
 <div th:replace="~{fragments/navbar :: navbar}"></div>
 
 <main id="main" class="container"
-      th:attr="data-guild-id=${guildId}, data-match-threshold=${matchThreshold}">
+      th:attr="data-guild-id=${guildId}, data-match-threshold=${matchThreshold},
+               data-toby-coins=${tobyCoins}, data-market-price=${marketPrice}">
 
     <div class="scratch-header">
         <a class="back-link" th:href="@{/casino/guilds}">&larr; All casino servers</a>
@@ -40,6 +41,10 @@
                    th:value="${minStake}"
                    step="1">
             <button type="submit" id="scratch-buy" class="btn-primary">Buy ticket</button>
+            <button type="submit" id="scratch-buy-toby" class="btn-secondary casino-bet-toby" hidden
+                    title="Sells just enough TOBY at the live market price to cover the shortfall, then buys the ticket.">
+                Buy (sell <span class="casino-bet-toby-coins">0</span> TOBY)
+            </button>
             <button type="button" id="scratch-reveal-all" class="btn-secondary" hidden>Reveal all</button>
         </form>
 
@@ -87,6 +92,7 @@
 <script th:src="@{/js/api.js}"></script>
 <script th:src="@{/js/toasts.js}"></script>
 <script th:src="@{/js/casino-jackpot.js}"></script>
+<script th:src="@{/js/casino-topup.js}"></script>
 <script th:src="@{/js/scratch.js}"></script>
 </body>
 </html>

--- a/web/src/main/resources/templates/slots.html
+++ b/web/src/main/resources/templates/slots.html
@@ -5,7 +5,8 @@
 <a href="#main" class="skip-link">Skip to content</a>
 <div th:replace="~{fragments/navbar :: navbar}"></div>
 
-<main id="main" class="container" th:attr="data-guild-id=${guildId}">
+<main id="main" class="container"
+      th:attr="data-guild-id=${guildId}, data-toby-coins=${tobyCoins}, data-market-price=${marketPrice}">
 
     <div class="slots-header">
         <a class="back-link" th:href="@{/leaderboards}">&larr; All servers</a>
@@ -35,6 +36,10 @@
                    th:value="${minStake}"
                    step="1">
             <button type="submit" id="slots-spin" class="btn-primary">Spin</button>
+            <button type="submit" id="slots-spin-toby" class="btn-secondary casino-bet-toby" hidden
+                    title="Sells just enough TOBY at the live market price to cover the shortfall, then spins.">
+                Spin (sell <span class="casino-bet-toby-coins">0</span> TOBY)
+            </button>
         </form>
 
         <div class="slots-balance">
@@ -71,6 +76,7 @@
 <script th:src="@{/js/api.js}"></script>
 <script th:src="@{/js/toasts.js}"></script>
 <script th:src="@{/js/casino-jackpot.js}"></script>
+<script th:src="@{/js/casino-topup.js}"></script>
 <script th:src="@{/js/slots.js}"></script>
 </body>
 </html>

--- a/web/src/test/js/casino-topup.test.js
+++ b/web/src/test/js/casino-topup.test.js
@@ -1,0 +1,177 @@
+// Smoke-test the shared "Bet (sell TOBY)" helper. The math has to
+// match TobyCoinEngine's proceeds-for-sell so the button promises
+// the same coin count the server then actually sells.
+
+const TobyTopUp = require('../../main/resources/static/js/casino-topup');
+
+// ---------------------------------------------------------------------------
+// proceedsForSell — must match Kotlin's TobyCoinEngine.proceedsForSell
+// ---------------------------------------------------------------------------
+
+describe('proceedsForSell', () => {
+    test('returns 0 for non-positive coins', () => {
+        expect(TobyTopUp.proceedsForSell(2.5, 0)).toBe(0);
+        expect(TobyTopUp.proceedsForSell(2.5, -10)).toBe(0);
+    });
+
+    test('returns 0 for zero price', () => {
+        expect(TobyTopUp.proceedsForSell(0, 100)).toBe(0);
+    });
+
+    test('matches the Kotlin engine reference (P=2.5, N=205)', () => {
+        // midpoint = (2.5 + 2.5*0.9795)/2 = 2.474375.
+        // gross = floor(2.474375 * 205) = 507. fee = floor(5.07) = 5.
+        // net = 502.
+        expect(TobyTopUp.proceedsForSell(2.5, 205)).toBe(502);
+    });
+
+    test('matches the Kotlin engine reference (P=10, N=31)', () => {
+        // midpoint = (10 + 10*0.9969)/2 = 9.9845.
+        // gross = floor(309.5195) = 309. fee = floor(3.09) = 3. net = 306.
+        expect(TobyTopUp.proceedsForSell(10, 31)).toBe(306);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// coinsNeededForShortfall
+// ---------------------------------------------------------------------------
+
+describe('coinsNeededForShortfall', () => {
+    test('returns 0 for zero or negative shortfall', () => {
+        expect(TobyTopUp.coinsNeededForShortfall(0, 10, 1000)).toBe(0);
+        expect(TobyTopUp.coinsNeededForShortfall(-50, 10, 1000)).toBe(0);
+    });
+
+    test('returns 0 for non-positive price', () => {
+        expect(TobyTopUp.coinsNeededForShortfall(100, 0, 1000)).toBe(0);
+    });
+
+    test('bumps for fee + slippage to match the backend (shortfall=500, P=2.5)', () => {
+        expect(TobyTopUp.coinsNeededForShortfall(500, 2.5, 1000)).toBe(205);
+    });
+
+    test('bumps for fee + slippage (shortfall=300, P=10)', () => {
+        expect(TobyTopUp.coinsNeededForShortfall(300, 10, 1000)).toBe(31);
+    });
+
+    test('signals "not enough coins" by returning maxCoins+1', () => {
+        // user has 5, shortfall actually needs ~205 — helper short-
+        // circuits early instead of looping through 200 wasted iterations.
+        expect(TobyTopUp.coinsNeededForShortfall(500, 2.5, 5)).toBe(6);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// soldPrefixHtml
+// ---------------------------------------------------------------------------
+
+describe('soldPrefixHtml', () => {
+    test('renders the sold-coins line plus price when both supplied', () => {
+        const html = TobyTopUp.soldPrefixHtml(12, 2.5);
+        expect(html).toContain('Sold 12 TOBY');
+        expect(html).toContain('@ 2.50');
+        expect(html).toContain('<br>');
+    });
+
+    test('omits the price when newPrice is missing', () => {
+        const html = TobyTopUp.soldPrefixHtml(5);
+        expect(html).toContain('Sold 5 TOBY');
+        expect(html).not.toContain('@');
+    });
+
+    test('returns empty string when soldTobyCoins is 0 or absent', () => {
+        expect(TobyTopUp.soldPrefixHtml(0, 2.5)).toBe('');
+        expect(TobyTopUp.soldPrefixHtml(undefined)).toBe('');
+        expect(TobyTopUp.soldPrefixHtml(-1)).toBe('');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// init — wires the secondary "Bet (sell TOBY)" button
+// ---------------------------------------------------------------------------
+
+describe('init', () => {
+    function setupDom(opts) {
+        document.body.innerHTML = `
+            <form id="form">
+                <input id="stake" type="number" value="${opts.stake || ''}">
+                <button id="primary" type="submit"></button>
+                <button id="toby" type="submit" hidden>
+                    <span class="casino-bet-toby-coins">0</span>
+                </button>
+            </form>
+            <span id="balance">${opts.balance || 0}</span>
+        `;
+        return TobyTopUp.init({
+            form: document.getElementById('form'),
+            stakeInput: document.getElementById('stake'),
+            primaryBtn: document.getElementById('primary'),
+            tobyBtn: document.getElementById('toby'),
+            balanceEl: document.getElementById('balance'),
+            tobyCoins: opts.tobyCoins || 0,
+            marketPrice: opts.marketPrice || 0,
+            onSubmit: opts.onSubmit || jest.fn(),
+        });
+    }
+
+    test('hides the second button when balance covers the stake', () => {
+        setupDom({ stake: 100, balance: 200, tobyCoins: 1000, marketPrice: 2.5 });
+        expect(document.getElementById('toby').hidden).toBe(true);
+    });
+
+    test('shows the second button with the right coin count when balance is short', () => {
+        setupDom({ stake: 500, balance: 0, tobyCoins: 1000, marketPrice: 2.5 });
+        const btn = document.getElementById('toby');
+        expect(btn.hidden).toBe(false);
+        expect(btn.querySelector('.casino-bet-toby-coins').textContent).toBe('205');
+    });
+
+    test('hides the button when the market price is zero', () => {
+        setupDom({ stake: 500, balance: 0, tobyCoins: 1000, marketPrice: 0 });
+        expect(document.getElementById('toby').hidden).toBe(true);
+    });
+
+    test('hides the button when the player does not hold enough TOBY', () => {
+        setupDom({ stake: 500, balance: 0, tobyCoins: 5, marketPrice: 2.5 });
+        expect(document.getElementById('toby').hidden).toBe(true);
+    });
+
+    test('clicking the toby button triggers onSubmit with autoTopUp=true', () => {
+        const onSubmit = jest.fn();
+        setupDom({ stake: 500, balance: 0, tobyCoins: 1000, marketPrice: 2.5, onSubmit: onSubmit });
+        document.getElementById('toby').click();
+        document.getElementById('form').dispatchEvent(new Event('submit'));
+        expect(onSubmit).toHaveBeenCalledWith(true);
+    });
+
+    test('clicking the primary button triggers onSubmit with autoTopUp=false', () => {
+        const onSubmit = jest.fn();
+        setupDom({ stake: 100, balance: 1000, tobyCoins: 1000, marketPrice: 2.5, onSubmit: onSubmit });
+        document.getElementById('primary').click();
+        document.getElementById('form').dispatchEvent(new Event('submit'));
+        expect(onSubmit).toHaveBeenCalledWith(false);
+    });
+
+    test('setTobyCoins refreshes the button state with new wallet info', () => {
+        const handle = setupDom({ stake: 500, balance: 0, tobyCoins: 1000, marketPrice: 2.5 });
+        expect(document.getElementById('toby').hidden).toBe(false);
+
+        handle.setTobyCoins(5);  // simulate wallet drained by a prior trade
+        expect(document.getElementById('toby').hidden).toBe(true);
+    });
+
+    test('setMarketPrice refreshes the button state when the price moves', () => {
+        const handle = setupDom({ stake: 500, balance: 0, tobyCoins: 1000, marketPrice: 2.5 });
+        expect(document.getElementById('toby').hidden).toBe(false);
+
+        handle.setMarketPrice(0);  // market crashed mid-session
+        expect(document.getElementById('toby').hidden).toBe(true);
+    });
+
+    test('returns null when essential elements are missing', () => {
+        const handle = TobyTopUp.init({
+            form: null, stakeInput: null, primaryBtn: null, tobyBtn: null,
+        });
+        expect(handle).toBeNull();
+    });
+});

--- a/web/src/test/kotlin/web/controller/CoinflipControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/CoinflipControllerTest.kt
@@ -4,6 +4,7 @@ import database.economy.Coinflip
 import database.service.CoinflipService
 import database.service.CoinflipService.FlipOutcome
 import database.service.JackpotService
+import database.service.TobyCoinMarketService
 import database.service.UserService
 import io.mockk.every
 import io.mockk.mockk
@@ -25,6 +26,7 @@ class CoinflipControllerTest {
     private lateinit var economyWebService: EconomyWebService
     private lateinit var userService: UserService
     private lateinit var jackpotService: JackpotService
+    private lateinit var marketService: TobyCoinMarketService
     private lateinit var jda: JDA
     private lateinit var user: OAuth2User
     private lateinit var controller: CoinflipController
@@ -35,13 +37,14 @@ class CoinflipControllerTest {
         economyWebService = mockk(relaxed = true)
         userService = mockk(relaxed = true)
         jackpotService = mockk(relaxed = true)
+        marketService = mockk(relaxed = true)
         jda = mockk(relaxed = true)
         user = mockk {
             every { getAttribute<String>("id") } returns discordId.toString()
             every { getAttribute<String>("username") } returns "tester"
         }
         every { economyWebService.isMember(discordId, guildId) } returns true
-        controller = CoinflipController(coinflipService, economyWebService, userService, jackpotService, jda)
+        controller = CoinflipController(coinflipService, economyWebService, userService, jackpotService, marketService, jda)
     }
 
     @Test

--- a/web/src/test/kotlin/web/controller/DiceControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/DiceControllerTest.kt
@@ -3,6 +3,7 @@ package web.controller
 import database.service.DiceService
 import database.service.DiceService.RollOutcome
 import database.service.JackpotService
+import database.service.TobyCoinMarketService
 import database.service.UserService
 import io.mockk.every
 import io.mockk.mockk
@@ -24,6 +25,7 @@ class DiceControllerTest {
     private lateinit var economyWebService: EconomyWebService
     private lateinit var userService: UserService
     private lateinit var jackpotService: JackpotService
+    private lateinit var marketService: TobyCoinMarketService
     private lateinit var jda: JDA
     private lateinit var user: OAuth2User
     private lateinit var controller: DiceController
@@ -34,13 +36,14 @@ class DiceControllerTest {
         economyWebService = mockk(relaxed = true)
         userService = mockk(relaxed = true)
         jackpotService = mockk(relaxed = true)
+        marketService = mockk(relaxed = true)
         jda = mockk(relaxed = true)
         user = mockk {
             every { getAttribute<String>("id") } returns discordId.toString()
             every { getAttribute<String>("username") } returns "tester"
         }
         every { economyWebService.isMember(discordId, guildId) } returns true
-        controller = DiceController(diceService, economyWebService, userService, jackpotService, jda)
+        controller = DiceController(diceService, economyWebService, userService, jackpotService, marketService, jda)
     }
 
     @Test

--- a/web/src/test/kotlin/web/controller/HighlowControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/HighlowControllerTest.kt
@@ -4,6 +4,7 @@ import database.economy.Highlow
 import database.service.HighlowService
 import database.service.HighlowService.PlayOutcome
 import database.service.JackpotService
+import database.service.TobyCoinMarketService
 import database.service.UserService
 import io.mockk.every
 import io.mockk.mockk
@@ -32,6 +33,7 @@ class HighlowControllerTest {
     private lateinit var economyWebService: EconomyWebService
     private lateinit var userService: UserService
     private lateinit var jackpotService: JackpotService
+    private lateinit var marketService: TobyCoinMarketService
     private lateinit var jda: JDA
     private lateinit var user: OAuth2User
     private lateinit var session: HttpSession
@@ -43,6 +45,7 @@ class HighlowControllerTest {
         economyWebService = mockk(relaxed = true)
         userService = mockk(relaxed = true)
         jackpotService = mockk(relaxed = true)
+        marketService = mockk(relaxed = true)
         jda = mockk(relaxed = true)
         user = mockk {
             every { getAttribute<String>("id") } returns discordId.toString()
@@ -57,7 +60,7 @@ class HighlowControllerTest {
         }
         every { jda.getGuildById(guildId) } returns guild
 
-        controller = HighlowController(highlowService, economyWebService, userService, jackpotService, jda)
+        controller = HighlowController(highlowService, economyWebService, userService, jackpotService, marketService, jda)
     }
 
     @Test

--- a/web/src/test/kotlin/web/controller/ScratchControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/ScratchControllerTest.kt
@@ -4,6 +4,7 @@ import database.economy.SlotMachine
 import database.service.JackpotService
 import database.service.ScratchService
 import database.service.ScratchService.ScratchOutcome
+import database.service.TobyCoinMarketService
 import database.service.UserService
 import io.mockk.every
 import io.mockk.mockk
@@ -25,6 +26,7 @@ class ScratchControllerTest {
     private lateinit var economyWebService: EconomyWebService
     private lateinit var userService: UserService
     private lateinit var jackpotService: JackpotService
+    private lateinit var marketService: TobyCoinMarketService
     private lateinit var jda: JDA
     private lateinit var user: OAuth2User
     private lateinit var controller: ScratchController
@@ -35,13 +37,14 @@ class ScratchControllerTest {
         economyWebService = mockk(relaxed = true)
         userService = mockk(relaxed = true)
         jackpotService = mockk(relaxed = true)
+        marketService = mockk(relaxed = true)
         jda = mockk(relaxed = true)
         user = mockk {
             every { getAttribute<String>("id") } returns discordId.toString()
             every { getAttribute<String>("username") } returns "tester"
         }
         every { economyWebService.isMember(discordId, guildId) } returns true
-        controller = ScratchController(scratchService, economyWebService, userService, jackpotService, jda)
+        controller = ScratchController(scratchService, economyWebService, userService, jackpotService, marketService, jda)
     }
 
     @Test

--- a/web/src/test/kotlin/web/controller/SlotsControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/SlotsControllerTest.kt
@@ -4,6 +4,7 @@ import database.economy.SlotMachine
 import database.service.JackpotService
 import database.service.SlotsService
 import database.service.SlotsService.SpinOutcome
+import database.service.TobyCoinMarketService
 import database.service.UserService
 import io.mockk.every
 import io.mockk.mockk
@@ -31,6 +32,7 @@ class SlotsControllerTest {
     private lateinit var economyWebService: EconomyWebService
     private lateinit var userService: UserService
     private lateinit var jackpotService: JackpotService
+    private lateinit var marketService: TobyCoinMarketService
     private lateinit var jda: JDA
     private lateinit var user: OAuth2User
     private lateinit var controller: SlotsController
@@ -41,13 +43,14 @@ class SlotsControllerTest {
         economyWebService = mockk(relaxed = true)
         userService = mockk(relaxed = true)
         jackpotService = mockk(relaxed = true)
+        marketService = mockk(relaxed = true)
         jda = mockk(relaxed = true)
         user = mockk {
             every { getAttribute<String>("id") } returns discordId.toString()
             every { getAttribute<String>("username") } returns "tester"
         }
         every { economyWebService.isMember(discordId, guildId) } returns true
-        controller = SlotsController(slotsService, economyWebService, userService, jackpotService, jda)
+        controller = SlotsController(slotsService, economyWebService, userService, jackpotService, marketService, jda)
     }
 
     @Test

--- a/web/src/test/kotlin/web/service/TitlesWebServicePurchaseTest.kt
+++ b/web/src/test/kotlin/web/service/TitlesWebServicePurchaseTest.kt
@@ -66,35 +66,40 @@ class TitlesWebServicePurchaseTest {
         val title = TitleDto(id = 9L, label = "Gold", cost = 500L)
         val actor = UserDto(discordId = discordId, guildId = guildId).apply {
             socialCredit = 0L
-            // ceil(500/2.5) = 200, but under midpoint slippage the
-            // proceeds for 200 coins fall to 495 (5 short of cost).
-            // The compensator bumps to 203 — first N whose midpoint
-            // proceeds clear 500.
+            // ceil(500/2.5) = 200, but the proceeds-after-fee math
+            // (midpoint slippage + 1 % jackpot fee) needs N=205 to
+            // clear the cost. The compensator bumps until net proceeds
+            // ≥ shortfall.
             tobyCoins = 1_000L
         }
         every { titleService.getById(9L) } returns title
         every { titleService.owns(discordId, 9L) } returns false
         every { userService.getUserByIdForUpdate(discordId, guildId) } returns actor
         every { marketService.getMarketForUpdate(guildId) } returns market(2.5)
-        every { tradeService.sell(discordId, guildId, 203L) } answers {
-            actor.socialCredit = 502L  // proceeds at midpoint for N=203 / P=2.5
-            actor.tobyCoins -= 203L
+        every {
+            tradeService.sell(discordId, guildId, 205L, EconomyTradeService.REASON_TITLE_TOPUP)
+        } answers {
+            actor.socialCredit = 502L  // net proceeds at N=205 / P=2.5: 507 gross − 5 fee
+            actor.tobyCoins -= 205L
             TradeOutcome.Ok(
-                amount = 203L,
+                amount = 205L,
                 transactedCredits = 502L,
                 newCoins = actor.tobyCoins,
                 newCredits = actor.socialCredit ?: 0L,
-                newPrice = 2.4495
+                newPrice = 2.44875,
+                fee = 5L
             )
         }
 
         val outcome = service.buyTitleWithTobyCoin(discordId, guildId, 9L)
 
         val ok = assertInstanceOf(BuyWithTobyOutcome.Ok::class.java, outcome)
-        assertEquals(203L, ok.soldTobyCoins, "midpoint slippage adds 3 to ceil(500/2.5)")
+        assertEquals(205L, ok.soldTobyCoins, "fee + slippage push ceil(500/2.5)=200 up to 205")
         assertEquals(2L, ok.newCredits, "credits = 502 sold − 500 cost")
-        assertEquals(2.4495, ok.newPrice, 1e-9)
-        verify(exactly = 1) { tradeService.sell(discordId, guildId, 203L) }
+        assertEquals(2.44875, ok.newPrice, 1e-9)
+        verify(exactly = 1) {
+            tradeService.sell(discordId, guildId, 205L, EconomyTradeService.REASON_TITLE_TOPUP)
+        }
         verify(exactly = 1) { titleService.recordPurchase(discordId, 9L) }
     }
 
@@ -109,18 +114,21 @@ class TitlesWebServicePurchaseTest {
         every { titleService.owns(discordId, 9L) } returns false
         every { userService.getUserByIdForUpdate(discordId, guildId) } returns actor
         every { marketService.getMarketForUpdate(guildId) } returns market(10.0)
-        // shortfall = 500 − 200 = 300, price = 10. ceil(300/10) = 30, but
-        // midpoint proceeds for N=30 fall to 299 — slippage compensator
-        // bumps to 31.
-        every { tradeService.sell(discordId, guildId, 31L) } answers {
-            actor.socialCredit = (actor.socialCredit ?: 0L) + 309L  // midpoint proceeds at N=31, P=10
+        // shortfall = 500 − 200 = 300, price = 10. ceil(300/10) = 30,
+        // but with midpoint slippage + the 1 % fee N=30 nets only 297.
+        // The compensator bumps to N=31 (gross 309, fee 3, net 306).
+        every {
+            tradeService.sell(discordId, guildId, 31L, EconomyTradeService.REASON_TITLE_TOPUP)
+        } answers {
+            actor.socialCredit = (actor.socialCredit ?: 0L) + 306L  // net proceeds at N=31
             actor.tobyCoins -= 31L
             TradeOutcome.Ok(
                 amount = 31L,
-                transactedCredits = 309L,
+                transactedCredits = 306L,
                 newCoins = actor.tobyCoins,
                 newCredits = actor.socialCredit ?: 0L,
-                newPrice = 9.969
+                newPrice = 9.969,
+                fee = 3L
             )
         }
 
@@ -128,9 +136,11 @@ class TitlesWebServicePurchaseTest {
 
         val ok = assertInstanceOf(BuyWithTobyOutcome.Ok::class.java, outcome)
         assertEquals(31L, ok.soldTobyCoins)
-        assertEquals(9L, ok.newCredits, "200 + 309 − 500 = 9 (slippage delta lands in the leftover credits)")
+        assertEquals(6L, ok.newCredits, "200 + 306 − 500 = 6 (fee + slippage land in the leftover credits)")
         assertEquals(69L, ok.newCoins, "100 TOBY − 31 sold")
-        verify(exactly = 1) { tradeService.sell(discordId, guildId, 31L) }
+        verify(exactly = 1) {
+            tradeService.sell(discordId, guildId, 31L, EconomyTradeService.REASON_TITLE_TOPUP)
+        }
     }
 
     @Test
@@ -151,7 +161,7 @@ class TitlesWebServicePurchaseTest {
         assertEquals(0L, ok.soldTobyCoins)
         assertEquals(900L, ok.newCredits)
         assertEquals(10L, ok.newCoins, "coins untouched")
-        verify(exactly = 0) { tradeService.sell(any(), any(), any()) }
+        verify(exactly = 0) { tradeService.sell(any(), any(), any(), any()) }
         verify(exactly = 0) { marketService.getMarketForUpdate(any()) }
     }
 
@@ -170,9 +180,9 @@ class TitlesWebServicePurchaseTest {
         val outcome = service.buyTitleWithTobyCoin(discordId, guildId, 9L)
 
         val insufficient = assertInstanceOf(BuyWithTobyOutcome.InsufficientCoins::class.java, outcome)
-        assertEquals(203L, insufficient.needed, "midpoint slippage compensator bumps ceil(500/2.5)=200 to 203")
+        assertEquals(205L, insufficient.needed, "fee + slippage compensator bumps ceil(500/2.5)=200 to 205")
         assertEquals(5L, insufficient.have)
-        verify(exactly = 0) { tradeService.sell(any(), any(), any()) }
+        verify(exactly = 0) { tradeService.sell(any(), any(), any(), any()) }
         verify(exactly = 0) { titleService.recordPurchase(any(), any()) }
         verify(exactly = 0) { userService.updateUser(any()) }
     }
@@ -193,7 +203,7 @@ class TitlesWebServicePurchaseTest {
         val outcome = service.buyTitleWithTobyCoin(discordId, guildId, 9L)
 
         assertEquals(BuyWithTobyOutcome.AlreadyOwns, outcome)
-        verify(exactly = 0) { tradeService.sell(any(), any(), any()) }
+        verify(exactly = 0) { tradeService.sell(any(), any(), any(), any()) }
         verify(exactly = 0) { titleService.recordPurchase(any(), any()) }
         verify(exactly = 0) { userService.updateUser(any()) }
     }
@@ -279,7 +289,7 @@ class TitlesWebServicePurchaseTest {
         every { titleService.owns(discordId, 9L) } returns false
         every { userService.getUserByIdForUpdate(discordId, guildId) } returns actor
         every { marketService.getMarketForUpdate(guildId) } returns market(2.5)
-        every { tradeService.sell(any(), any(), any()) } returns TradeOutcome.InvalidAmount
+        every { tradeService.sell(any(), any(), any(), any()) } returns TradeOutcome.InvalidAmount
 
         val outcome = service.buyTitleWithTobyCoin(discordId, guildId, 9L)
 


### PR DESCRIPTION
## Summary

The original casino top-up feature, mirroring Titles' "Buy with TOBY":

- Player on a casino page is short on credits → a second submit button appears: **Bet (sell N TOBY)**.
- One click sells exactly enough TOBY at the live market price to cover the stake, then plays, atomic in one transaction.
- The resulting trade row carries a **reason** tag so the chart can attribute the sale (`USER` / `TITLE_TOPUP` / `CASINO_TOPUP`) — every minigame top-up, plus Titles' existing top-up, now show up labelled in the tooltip and the recent-trades list.

## Stack

| Layer | Change |
|---|---|
| **DB** | `V19__toby_coin_trade_reason.sql` adds `reason VARCHAR(32) NOT NULL DEFAULT 'USER'` to `toby_coin_trade`. Pre-existing rows backfilled. |
| **Engine** | `TobyCoinEngine.proceedsForSell()` + `TobyCoinEngine.coinsNeededForShortfall()` — single source of truth for the midpoint-slippage + 1 % fee math, called by Titles, the new helper, and the JS button. |
| **Service** | `EconomyTradeService.buy/sell` thread `reason` (default `REASON_USER`); constants on the companion: `USER` / `TITLE_TOPUP` / `CASINO_TOPUP`. |
| **Helper** | New `CasinoTopUpHelper` mirrors `TitlesWebService.buyTitleWithTobyCoin`'s shape: market lookup → coinsNeeded → coin-balance check → atomic sell with `CASINO_TOPUP` reason → re-read user. |
| **Minigame services** | 5 services gain `autoTopUp: Boolean = false` + `tradeService` + `marketService` deps. New `InsufficientCoinsForTopUp` outcome. Win/Lose carry `soldTobyCoins` and `newPrice`. |
| **Controllers** | Threading `autoTopUp` request, `soldTobyCoins` + `newPrice` response, page model gets `tobyCoins` + `marketPrice` for the JS to read. |
| **Templates** | Each adds a hidden `Bet (sell N TOBY)` second submit button next to the primary. |
| **JS** | New `casino-topup.js` shared helper: shortfall math + button show/hide + click wiring. Each game's IIFE inits it and exposes a `runX(autoTopUp)` function. Result line gets a "Sold N TOBY @ price" prefix when applicable. |
| **Chart** | `TradeMarker` carries `reason`; `economy.js` tooltip + recent-trades list append `(title top-up)` / `(casino top-up)` for non-USER trades. |

## Tests

**Kotlin** — `:database:test` + `:web:test` both green.
- New `TobyCoinEngineTopUpTest` — pins `proceedsForSell` and `coinsNeededForShortfall` against the trade engine's actual sell math (the reference values are in lockstep with what's in `EconomyTradeService.sell`).
- New `CasinoTopUpHelperTest` — `MarketUnavailable`, `InsufficientCoins`, `ToppedUp` with `CASINO_TOPUP` reason, post-sell user re-read.
- `TitlesWebServicePurchaseTest` — coinsNeeded recalculated for fee + slippage; updated to the new 4-arg `tradeService.sell(..., reason)` signature.
- 5 minigame service tests + 5 controller tests updated for the new constructor params.

**Jest** — 140/140 pass (was 119).
- New `casino-topup.test.js` — the helper math (`proceedsForSell`, `coinsNeededForShortfall`) reference-matches the Kotlin engine; second-button show/hide; click → `onSubmit(autoTopUp)`; setters refresh state.
- The 5 per-game render tests already cover the response shape changes (the new `soldTobyCoins` + `newPrice` fields land on `body` and `renderXResult` paths render them via `TobyTopUp.soldPrefixHtml`).

## Test plan
- [x] `:database:test`, `:web:test` (offline)
- [x] `npm test` (140/140)
- [ ] Manual: open `/casino/{guildId}/slots` with credits=0 and TOBY≥220, set stake=500. Confirm the "Spin (sell ~205 TOBY)" button appears. Click it. Verify a) the response renders "Sold 205 TOBY @ ..." prefix, b) credits update, c) `/economy/{guildId}` chart shows a SELL marker tagged "(casino top-up)".
- [ ] Manual: same flow but with TOBY=5 (insufficient). Verify the button is hidden.
- [ ] Manual: place a Titles top-up purchase. Verify chart marker says "(title top-up)".
- [ ] Manual: place a normal `/economy sell`. Verify no parenthetical suffix.

## Out of scope (future)
- Live trade-row updates without page reload after a top-up.
- Casino-history page summarising per-guild top-up activity.
- Per-game reason granularity (`SLOTS_TOPUP` etc.) — current design uses one `CASINO_TOPUP` value.

https://claude.ai/code/session_01JvuveFBoCvMFTK8XxXVN56

---
_Generated by [Claude Code](https://claude.ai/code/session_01JvuveFBoCvMFTK8XxXVN56)_