### PR TITLE
fix(highlow): commit stake before revealing the anchor card

### DIFF
--- a/application/src/test/kotlin/integration/bot/ButtonManagerTest.kt
+++ b/application/src/test/kotlin/integration/bot/ButtonManagerTest.kt
@@ -70,6 +70,7 @@ class ButtonManagerTest {
     @Test
     fun testButtonManagerFindsAllButtons() {
         val availableButtons = listOf(
+            HighlowButton::class.java,
             InitiativeClearButton::class.java,
             InitiativeNextButton::class.java,
             InitiativePreviousButton::class.java,
@@ -80,7 +81,7 @@ class ButtonManagerTest {
         )
 
         assertTrue(availableButtons.containsAll(buttonManager.buttons.map { it.javaClass }.toList()))
-        assertEquals(7, buttonManager.buttons.size)
+        assertEquals(8, buttonManager.buttons.size)
     }
 
     @Test

--- a/discord-bot/src/main/kotlin/bot/toby/button/buttons/HighlowButton.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/button/buttons/HighlowButton.kt
@@ -5,6 +5,7 @@ import core.button.Button
 import core.button.ButtonContext
 import database.dto.UserDto
 import database.service.HighlowService
+import net.dv8tion.jda.api.components.MessageTopLevelComponent
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
@@ -31,7 +32,7 @@ class HighlowButton @Autowired constructor(
             return
         }
 
-        if (event.user.idLong != parsed.userId) {
+        if (requestingUserDto.discordId != parsed.userId) {
             event.reply("This isn't your /highlow round — run `/highlow` to start your own.")
                 .setEphemeral(true)
                 .queue()
@@ -47,7 +48,7 @@ class HighlowButton @Autowired constructor(
         )
 
         event.editMessageEmbeds(HighlowEmbeds.outcomeEmbed(outcome))
-            .setComponents()
+            .setComponents(emptyList<MessageTopLevelComponent>())
             .queue()
     }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/button/buttons/HighlowButton.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/button/buttons/HighlowButton.kt
@@ -1,0 +1,53 @@
+package bot.toby.button.buttons
+
+import bot.toby.command.commands.economy.HighlowEmbeds
+import core.button.Button
+import core.button.ButtonContext
+import database.dto.UserDto
+import database.service.HighlowService
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+/**
+ * Resolves a `/highlow` round once the player clicks HIGHER or LOWER.
+ * Anchor + stake + direction + owning user are all encoded in the
+ * component ID by [bot.toby.command.commands.economy.HighlowCommand], so
+ * no server-side state is needed between the slash command and the
+ * click. Edits the original message in place and removes the buttons
+ * so the round can't be re-clicked.
+ */
+@Component
+class HighlowButton @Autowired constructor(
+    private val highlowService: HighlowService
+) : Button {
+
+    override val name: String get() = HighlowEmbeds.BUTTON_NAME
+    override val description: String get() = "Resolves a /highlow round in the player's chosen direction."
+
+    override fun handle(ctx: ButtonContext, requestingUserDto: UserDto, deleteDelay: Int) {
+        val event = ctx.event
+        val parsed = HighlowEmbeds.parseButtonId(event.componentId) ?: run {
+            event.deferEdit().queue()
+            return
+        }
+
+        if (event.user.idLong != parsed.userId) {
+            event.reply("This isn't your /highlow round — run `/highlow` to start your own.")
+                .setEphemeral(true)
+                .queue()
+            return
+        }
+
+        val outcome = highlowService.play(
+            requestingUserDto.discordId,
+            ctx.guild.idLong,
+            parsed.stake,
+            parsed.direction,
+            parsed.anchor
+        )
+
+        event.editMessageEmbeds(HighlowEmbeds.outcomeEmbed(outcome))
+            .setComponents()
+            .queue()
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/HighlowCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/HighlowCommand.kt
@@ -5,20 +5,23 @@ import core.command.CommandContext
 import database.dto.UserDto
 import database.economy.Highlow
 import database.service.HighlowService
-import database.service.HighlowService.PlayOutcome
-import net.dv8tion.jda.api.EmbedBuilder
+import net.dv8tion.jda.api.components.actionrow.ActionRow
+import net.dv8tion.jda.api.components.buttons.Button
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
 import net.dv8tion.jda.api.interactions.commands.OptionType
 import net.dv8tion.jda.api.interactions.commands.build.OptionData
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import java.awt.Color
 
 /**
- * `/highlow direction:<HIGHER|LOWER> stake:<int>` — pre-commit the
- * direction; the embed reveals both cards. 2× payout on a correct
- * call, tie loses. Calls through to [HighlowService.play]; same path
- * the web `/casino/{guildId}/highlow` page uses.
+ * `/highlow stake:<int>` — deals an anchor card and asks the player to
+ * call HIGHER or LOWER via buttons. The wager only settles when the
+ * player picks a direction. Mirrors the web `/casino/{guildId}/highlow`
+ * flow so the player isn't forced to commit blind.
+ *
+ * The button click is handled by [bot.toby.button.buttons.HighlowButton],
+ * which decodes the anchor + stake from the component ID and resolves
+ * via [HighlowService.play] (anchored entry point).
  */
 @Component
 class HighlowCommand @Autowired constructor(
@@ -30,20 +33,11 @@ class HighlowCommand @Autowired constructor(
         "Predict if the next card is higher or lower than the anchor. Bet ${Highlow.MIN_STAKE}-${Highlow.MAX_STAKE} credits."
 
     companion object {
-        private const val OPT_DIRECTION = "direction"
         private const val OPT_STAKE = "stake"
-        private const val DIR_HIGHER = "HIGHER"
-        private const val DIR_LOWER = "LOWER"
-        private val WIN_COLOR = Color(87, 242, 135)
-        private val LOSE_COLOR = Color(160, 160, 176)
-        private val ERROR_COLOR = Color(237, 66, 69)
     }
 
     override val optionData: List<OptionData> = listOf(
-        OptionData(OptionType.STRING, OPT_DIRECTION, "Higher or lower than the anchor card", true)
-            .addChoice("Higher", DIR_HIGHER)
-            .addChoice("Lower", DIR_LOWER),
-        OptionData(OptionType.INTEGER, OPT_STAKE, "Credits to wager (10-500)", true)
+        OptionData(OptionType.INTEGER, OPT_STAKE, "Credits to wager (${Highlow.MIN_STAKE}-${Highlow.MAX_STAKE})", true)
             .setMinValue(Highlow.MIN_STAKE)
             .setMaxValue(Highlow.MAX_STAKE)
     )
@@ -52,85 +46,35 @@ class HighlowCommand @Autowired constructor(
         val event = ctx.event
         event.deferReply().queue()
 
-        val guild = event.guild ?: run {
+        if (event.guild == null) {
             replyError(event, "This command can only be used in a server.", deleteDelay); return
-        }
-        val direction = parseDirection(event.getOption(OPT_DIRECTION)?.asString) ?: run {
-            replyError(event, "Pick a direction: higher or lower.", deleteDelay); return
         }
         val stake = event.getOption(OPT_STAKE)?.asLong ?: run {
             replyError(event, "You must specify a stake.", deleteDelay); return
         }
 
-        val outcome = highlowService.play(requestingUserDto.discordId, guild.idLong, stake, direction)
-        replyOutcome(event, outcome, deleteDelay)
+        val anchor = highlowService.dealAnchor()
+        val userId = requestingUserDto.discordId
+        val higher = Button.primary(
+            HighlowEmbeds.directionButtonId(Highlow.Direction.HIGHER, anchor, stake, userId),
+            Highlow.Direction.HIGHER.display
+        )
+        val lower = Button.primary(
+            HighlowEmbeds.directionButtonId(Highlow.Direction.LOWER, anchor, stake, userId),
+            Highlow.Direction.LOWER.display
+        )
+
+        event.hook.sendMessageEmbeds(HighlowEmbeds.anchorEmbed(anchor, stake))
+            .addComponents(ActionRow.of(higher, lower))
+            .queue()
     }
-
-    private fun parseDirection(raw: String?): Highlow.Direction? = when (raw) {
-        DIR_HIGHER -> Highlow.Direction.HIGHER
-        DIR_LOWER -> Highlow.Direction.LOWER
-        else -> null
-    }
-
-    private fun cardLabel(n: Int): String = when (n) {
-        1 -> "A"
-        11 -> "J"
-        12 -> "Q"
-        13 -> "K"
-        else -> n.toString()
-    }
-
-    private fun replyOutcome(
-        event: SlashCommandInteractionEvent,
-        outcome: PlayOutcome,
-        deleteDelay: Int
-    ) {
-        val embed = when (outcome) {
-            is PlayOutcome.Win -> EmbedBuilder()
-                .setTitle("🃏 ${cardLabel(outcome.anchor)} → ${cardLabel(outcome.next)}")
-                .setDescription("You called **${outcome.direction.display}** and won **+${outcome.net} credits**.")
-                .addField("New balance", "${outcome.newBalance} credits", true)
-                .setColor(WIN_COLOR)
-                .build()
-
-            is PlayOutcome.Lose -> EmbedBuilder()
-                .setTitle("🃏 ${cardLabel(outcome.anchor)} → ${cardLabel(outcome.next)}")
-                .setDescription("You called **${outcome.direction.display}**. Lost **${outcome.stake} credits**.")
-                .addField("New balance", "${outcome.newBalance} credits", true)
-                .setColor(LOSE_COLOR)
-                .build()
-
-            is PlayOutcome.InsufficientCredits -> errorEmbed(
-                "Not enough credits. You need ${outcome.stake} but only have ${outcome.have}."
-            )
-
-            is PlayOutcome.InsufficientCoinsForTopUp -> errorEmbed(
-                "Not enough credits, and not enough TOBY to cover. " +
-                    "Need ${outcome.needed} TOBY, you have ${outcome.have}."
-            )
-
-            is PlayOutcome.InvalidStake -> errorEmbed(
-                "Stake must be between ${outcome.min} and ${outcome.max} credits."
-            )
-
-            PlayOutcome.UnknownUser -> errorEmbed(
-                "No user record yet. Try another TobyBot command first."
-            )
-        }
-        event.hook.sendMessageEmbeds(embed).queue(invokeDeleteOnMessageResponse(deleteDelay))
-    }
-
-    private fun errorEmbed(message: String) = EmbedBuilder()
-        .setTitle("🃏 High-Low")
-        .setDescription(message)
-        .setColor(ERROR_COLOR)
-        .build()
 
     private fun replyError(
         event: SlashCommandInteractionEvent,
         message: String,
         deleteDelay: Int
     ) {
-        event.hook.sendMessageEmbeds(errorEmbed(message)).queue(invokeDeleteOnMessageResponse(deleteDelay))
+        event.hook.sendMessageEmbeds(HighlowEmbeds.errorEmbed(message))
+            .queue(invokeDeleteOnMessageResponse(deleteDelay))
     }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/HighlowEmbeds.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/HighlowEmbeds.kt
@@ -1,0 +1,98 @@
+package bot.toby.command.commands.economy
+
+import database.economy.Highlow
+import database.service.HighlowService.PlayOutcome
+import net.dv8tion.jda.api.EmbedBuilder
+import net.dv8tion.jda.api.entities.MessageEmbed
+import java.awt.Color
+
+/**
+ * Shared embed/component plumbing for the Discord `/highlow` flow.
+ * The slash command uses [anchorEmbed] + [directionButtonId] to deal
+ * the first card; [HighlowButton] uses [outcomeEmbed] to render the
+ * resolution.
+ */
+internal object HighlowEmbeds {
+
+    const val BUTTON_NAME = "highlow"
+    private const val BUTTON_DELIM = ":"
+
+    private val ANCHOR_COLOR = Color(88, 101, 242)
+    private val WIN_COLOR = Color(87, 242, 135)
+    private val LOSE_COLOR = Color(160, 160, 176)
+    private val ERROR_COLOR = Color(237, 66, 69)
+
+    fun cardLabel(n: Int): String = when (n) {
+        1 -> "A"
+        11 -> "J"
+        12 -> "Q"
+        13 -> "K"
+        else -> n.toString()
+    }
+
+    fun directionButtonId(direction: Highlow.Direction, anchor: Int, stake: Long, userId: Long): String =
+        listOf(BUTTON_NAME, direction.name, anchor.toString(), stake.toString(), userId.toString())
+            .joinToString(BUTTON_DELIM)
+
+    data class ParsedButtonId(
+        val direction: Highlow.Direction,
+        val anchor: Int,
+        val stake: Long,
+        val userId: Long
+    )
+
+    fun parseButtonId(componentId: String): ParsedButtonId? {
+        val parts = componentId.split(BUTTON_DELIM)
+        if (parts.size != 5 || !parts[0].equals(BUTTON_NAME, ignoreCase = true)) return null
+        val direction = runCatching { Highlow.Direction.valueOf(parts[1].uppercase()) }.getOrNull() ?: return null
+        val anchor = parts[2].toIntOrNull() ?: return null
+        val stake = parts[3].toLongOrNull() ?: return null
+        val userId = parts[4].toLongOrNull() ?: return null
+        return ParsedButtonId(direction, anchor, stake, userId)
+    }
+
+    fun anchorEmbed(anchor: Int, stake: Long): MessageEmbed = EmbedBuilder()
+        .setTitle("🃏 Anchor: ${cardLabel(anchor)}")
+        .setDescription("Stake **$stake credits**. Will the next card be **higher** or **lower**?")
+        .setColor(ANCHOR_COLOR)
+        .build()
+
+    fun outcomeEmbed(outcome: PlayOutcome): MessageEmbed = when (outcome) {
+        is PlayOutcome.Win -> EmbedBuilder()
+            .setTitle("🃏 ${cardLabel(outcome.anchor)} → ${cardLabel(outcome.next)}")
+            .setDescription("You called **${outcome.direction.display}** and won **+${outcome.net} credits**.")
+            .addField("New balance", "${outcome.newBalance} credits", true)
+            .setColor(WIN_COLOR)
+            .build()
+
+        is PlayOutcome.Lose -> EmbedBuilder()
+            .setTitle("🃏 ${cardLabel(outcome.anchor)} → ${cardLabel(outcome.next)}")
+            .setDescription("You called **${outcome.direction.display}**. Lost **${outcome.stake} credits**.")
+            .addField("New balance", "${outcome.newBalance} credits", true)
+            .setColor(LOSE_COLOR)
+            .build()
+
+        is PlayOutcome.InsufficientCredits -> errorEmbed(
+            "Not enough credits. You need ${outcome.stake} but only have ${outcome.have}."
+        )
+
+        is PlayOutcome.InsufficientCoinsForTopUp -> errorEmbed(
+            "Not enough credits, and not enough TOBY to cover. " +
+                "Need ${outcome.needed} TOBY, you have ${outcome.have}."
+        )
+
+        is PlayOutcome.InvalidStake -> errorEmbed(
+            "Stake must be between ${outcome.min} and ${outcome.max} credits."
+        )
+
+        PlayOutcome.UnknownUser -> errorEmbed(
+            "No user record yet. Try another TobyBot command first."
+        )
+    }
+
+    fun errorEmbed(message: String): MessageEmbed = EmbedBuilder()
+        .setTitle("🃏 High-Low")
+        .setDescription(message)
+        .setColor(ERROR_COLOR)
+        .build()
+}

--- a/discord-bot/src/test/kotlin/bot/toby/button/buttons/HighlowButtonTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/button/buttons/HighlowButtonTest.kt
@@ -7,10 +7,15 @@ import bot.toby.button.DefaultButtonContext
 import database.dto.UserDto
 import database.economy.Highlow
 import database.service.HighlowService
+import io.mockk.Runs
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
+import net.dv8tion.jda.api.components.MessageTopLevelComponent
 import net.dv8tion.jda.api.entities.MessageEmbed
+import net.dv8tion.jda.api.requests.restaction.interactions.MessageEditCallbackAction
+import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -19,6 +24,8 @@ class HighlowButtonTest : ButtonTest {
 
     private lateinit var highlowService: HighlowService
     private lateinit var button: HighlowButton
+    private lateinit var editAction: MessageEditCallbackAction
+    private lateinit var replyAction: ReplyCallbackAction
 
     private val ownerId = 6L
     private val guildId = 1L
@@ -32,6 +39,19 @@ class HighlowButtonTest : ButtonTest {
 
         highlowService = mockk(relaxed = true)
         button = HighlowButton(highlowService)
+
+        // F-bounded generics on JDA's MessageEditCallbackAction don't survive
+        // mockk's relaxed deep-stubs cleanly, so we wire the chain manually.
+        editAction = mockk(relaxed = true)
+        every { editAction.setComponents(any<Collection<MessageTopLevelComponent>>()) } returns editAction
+        every { editAction.setComponents(*anyVararg<MessageTopLevelComponent>()) } returns editAction
+        every { editAction.queue() } just Runs
+        every { event.editMessageEmbeds(any<MessageEmbed>()) } returns editAction
+
+        replyAction = mockk(relaxed = true)
+        every { replyAction.setEphemeral(any()) } returns replyAction
+        every { replyAction.queue() } just Runs
+        every { event.reply(any<String>()) } returns replyAction
     }
 
     @AfterEach
@@ -43,8 +63,6 @@ class HighlowButtonTest : ButtonTest {
     @Test
     fun `routes click to HighlowService with parsed direction anchor and stake`() {
         every { event.componentId } returns "highlow:HIGHER:$anchor:$stake:$ownerId"
-        every { event.user.idLong } returns ownerId
-
         every {
             highlowService.play(ownerId, guildId, stake, Highlow.Direction.HIGHER, anchor)
         } returns HighlowService.PlayOutcome.Win(
@@ -63,12 +81,12 @@ class HighlowButtonTest : ButtonTest {
             highlowService.play(ownerId, guildId, stake, Highlow.Direction.HIGHER, anchor)
         }
         verify { event.editMessageEmbeds(any<MessageEmbed>()) }
+        verify { editAction.queue() }
     }
 
     @Test
     fun `LOWER direction parses correctly`() {
         every { event.componentId } returns "highlow:LOWER:5:25:$ownerId"
-        every { event.user.idLong } returns ownerId
 
         button.handle(DefaultButtonContext(event), UserDto(ownerId, guildId), 0)
 
@@ -80,8 +98,6 @@ class HighlowButtonTest : ButtonTest {
     @Test
     fun `edits the original message and clears components`() {
         every { event.componentId } returns "highlow:HIGHER:$anchor:$stake:$ownerId"
-        every { event.user.idLong } returns ownerId
-
         every {
             highlowService.play(ownerId, guildId, stake, Highlow.Direction.HIGHER, anchor)
         } returns HighlowService.PlayOutcome.Lose(
@@ -94,29 +110,25 @@ class HighlowButtonTest : ButtonTest {
 
         button.handle(DefaultButtonContext(event), UserDto(ownerId, guildId), 0)
 
-        verify {
-            event.editMessageEmbeds(any<MessageEmbed>())
-                .setComponents()
-        }
+        verify { event.editMessageEmbeds(any<MessageEmbed>()) }
+        verify { editAction.setComponents(any<Collection<MessageTopLevelComponent>>()) }
     }
 
     @Test
     fun `someone else clicking another player's round is rejected ephemerally without resolving`() {
         every { event.componentId } returns "highlow:HIGHER:$anchor:$stake:$ownerId"
-        every { event.user.idLong } returns 999L
 
         button.handle(DefaultButtonContext(event), UserDto(999L, guildId), 0)
 
         verify(exactly = 0) { highlowService.play(any(), any(), any(), any(), any()) }
-        verify {
-            event.reply(any<String>()).setEphemeral(true)
-        }
+        verify { event.reply(any<String>()) }
+        verify { replyAction.setEphemeral(true) }
+        verify { replyAction.queue() }
     }
 
     @Test
     fun `malformed component id is acked without resolving`() {
         every { event.componentId } returns "highlow:bogus"
-        every { event.user.idLong } returns ownerId
 
         button.handle(DefaultButtonContext(event), UserDto(ownerId, guildId), 0)
 

--- a/discord-bot/src/test/kotlin/bot/toby/button/buttons/HighlowButtonTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/button/buttons/HighlowButtonTest.kt
@@ -1,0 +1,125 @@
+package bot.toby.button.buttons
+
+import bot.toby.button.ButtonTest
+import bot.toby.button.ButtonTest.Companion.event
+import bot.toby.button.ButtonTest.Companion.mockGuild
+import bot.toby.button.DefaultButtonContext
+import database.dto.UserDto
+import database.economy.Highlow
+import database.service.HighlowService
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import net.dv8tion.jda.api.entities.MessageEmbed
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class HighlowButtonTest : ButtonTest {
+
+    private lateinit var highlowService: HighlowService
+    private lateinit var button: HighlowButton
+
+    private val ownerId = 6L
+    private val guildId = 1L
+    private val anchor = 9
+    private val stake = 50L
+
+    @BeforeEach
+    override fun setup() {
+        super.setup()
+        every { mockGuild.idLong } returns guildId
+
+        highlowService = mockk(relaxed = true)
+        button = HighlowButton(highlowService)
+    }
+
+    @AfterEach
+    @Throws(Exception::class)
+    override fun tearDown() {
+        super.tearDown()
+    }
+
+    @Test
+    fun `routes click to HighlowService with parsed direction anchor and stake`() {
+        every { event.componentId } returns "highlow:HIGHER:$anchor:$stake:$ownerId"
+        every { event.user.idLong } returns ownerId
+
+        every {
+            highlowService.play(ownerId, guildId, stake, Highlow.Direction.HIGHER, anchor)
+        } returns HighlowService.PlayOutcome.Win(
+            stake = stake,
+            payout = 100L,
+            net = stake,
+            anchor = anchor,
+            next = 12,
+            direction = Highlow.Direction.HIGHER,
+            newBalance = 1_050L
+        )
+
+        button.handle(DefaultButtonContext(event), UserDto(ownerId, guildId), 0)
+
+        verify(exactly = 1) {
+            highlowService.play(ownerId, guildId, stake, Highlow.Direction.HIGHER, anchor)
+        }
+        verify { event.editMessageEmbeds(any<MessageEmbed>()) }
+    }
+
+    @Test
+    fun `LOWER direction parses correctly`() {
+        every { event.componentId } returns "highlow:LOWER:5:25:$ownerId"
+        every { event.user.idLong } returns ownerId
+
+        button.handle(DefaultButtonContext(event), UserDto(ownerId, guildId), 0)
+
+        verify(exactly = 1) {
+            highlowService.play(ownerId, guildId, 25L, Highlow.Direction.LOWER, 5)
+        }
+    }
+
+    @Test
+    fun `edits the original message and clears components`() {
+        every { event.componentId } returns "highlow:HIGHER:$anchor:$stake:$ownerId"
+        every { event.user.idLong } returns ownerId
+
+        every {
+            highlowService.play(ownerId, guildId, stake, Highlow.Direction.HIGHER, anchor)
+        } returns HighlowService.PlayOutcome.Lose(
+            stake = stake,
+            anchor = anchor,
+            next = anchor,
+            direction = Highlow.Direction.HIGHER,
+            newBalance = 950L
+        )
+
+        button.handle(DefaultButtonContext(event), UserDto(ownerId, guildId), 0)
+
+        verify {
+            event.editMessageEmbeds(any<MessageEmbed>())
+                .setComponents()
+        }
+    }
+
+    @Test
+    fun `someone else clicking another player's round is rejected ephemerally without resolving`() {
+        every { event.componentId } returns "highlow:HIGHER:$anchor:$stake:$ownerId"
+        every { event.user.idLong } returns 999L
+
+        button.handle(DefaultButtonContext(event), UserDto(999L, guildId), 0)
+
+        verify(exactly = 0) { highlowService.play(any(), any(), any(), any(), any()) }
+        verify {
+            event.reply(any<String>()).setEphemeral(true)
+        }
+    }
+
+    @Test
+    fun `malformed component id is acked without resolving`() {
+        every { event.componentId } returns "highlow:bogus"
+        every { event.user.idLong } returns ownerId
+
+        button.handle(DefaultButtonContext(event), UserDto(ownerId, guildId), 0)
+
+        verify(exactly = 0) { highlowService.play(any(), any(), any(), any(), any()) }
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/economy/HighlowCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/economy/HighlowCommandTest.kt
@@ -3,6 +3,7 @@ package bot.toby.command.commands.economy
 import bot.toby.command.CommandTest
 import bot.toby.command.CommandTest.Companion.event
 import bot.toby.command.CommandTest.Companion.guild
+import bot.toby.command.CommandTest.Companion.webhookMessageCreateAction
 import bot.toby.command.DefaultCommandContext
 import database.dto.UserDto
 import database.economy.Highlow
@@ -11,6 +12,8 @@ import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import net.dv8tion.jda.api.components.actionrow.ActionRow
+import net.dv8tion.jda.api.entities.MessageEmbed
 import net.dv8tion.jda.api.interactions.commands.OptionMapping
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
@@ -37,62 +40,51 @@ internal class HighlowCommandTest : CommandTest {
         clearAllMocks()
     }
 
-    private fun strOpt(value: String): OptionMapping = mockk<OptionMapping>(relaxed = true).also {
-        every { it.asString } returns value
-    }
-
     private fun intOpt(value: Long): OptionMapping = mockk<OptionMapping>(relaxed = true).also {
         every { it.asLong } returns value
     }
 
     @Test
-    fun `delegates to HighlowService with parsed direction and stake`() {
+    fun `deals anchor and sends embed with direction buttons without resolving the wager`() {
         val user = UserDto(discordId = discordId, guildId = guildId)
-        every { event.getOption("direction") } returns strOpt("HIGHER")
         every { event.getOption("stake") } returns intOpt(50L)
-        every { highlowService.play(discordId, guildId, 50L, Highlow.Direction.HIGHER) } returns
-            HighlowService.PlayOutcome.Lose(stake = 50L, anchor = 7, next = 7, direction = Highlow.Direction.HIGHER, newBalance = 950L)
+        every { highlowService.dealAnchor() } returns 7
 
         command.handle(DefaultCommandContext(event), user, 5)
 
-        verify(exactly = 1) {
-            highlowService.play(discordId, guildId, 50L, Highlow.Direction.HIGHER)
-        }
+        verify(exactly = 1) { highlowService.dealAnchor() }
+        verify(exactly = 0) { highlowService.play(any(), any(), any(), any()) }
+        verify { event.hook.sendMessageEmbeds(any<MessageEmbed>()) }
+        verify { webhookMessageCreateAction.addComponents(any<ActionRow>()) }
     }
 
     @Test
-    fun `replies with embed on each outcome variant`() {
-        val user = UserDto(discordId = discordId, guildId = guildId)
-        every { event.getOption("direction") } returns strOpt("LOWER")
-        every { event.getOption("stake") } returns intOpt(100L)
+    fun `encodes direction anchor stake and user into the button component ids`() {
+        val anchor = 9
+        val stake = 50L
+        val higherId = HighlowEmbeds.directionButtonId(Highlow.Direction.HIGHER, anchor, stake, discordId)
+        val lowerId = HighlowEmbeds.directionButtonId(Highlow.Direction.LOWER, anchor, stake, discordId)
 
-        val outcomes = listOf(
-            HighlowService.PlayOutcome.Win(stake = 100L, payout = 200L, net = 100L,
-                anchor = 10, next = 3, direction = Highlow.Direction.LOWER, newBalance = 1_100L),
-            HighlowService.PlayOutcome.Lose(stake = 100L, anchor = 5, next = 10,
-                direction = Highlow.Direction.LOWER, newBalance = 900L),
-            HighlowService.PlayOutcome.InsufficientCredits(stake = 100L, have = 50L),
-            HighlowService.PlayOutcome.InvalidStake(min = 10L, max = 500L),
-            HighlowService.PlayOutcome.UnknownUser
-        )
-        outcomes.forEach { outcome ->
-            every { highlowService.play(any(), any(), any(), any()) } returns outcome
-            command.handle(DefaultCommandContext(event), user, 5)
-        }
+        // Round-trip through the same parser HighlowButton uses.
+        val parsedHigher = HighlowEmbeds.parseButtonId(higherId)
+        val parsedLower = HighlowEmbeds.parseButtonId(lowerId)
 
-        verify(atLeast = outcomes.size) {
-            event.hook.sendMessageEmbeds(any<net.dv8tion.jda.api.entities.MessageEmbed>())
-        }
+        check(parsedHigher != null && parsedHigher.direction == Highlow.Direction.HIGHER &&
+              parsedHigher.anchor == anchor && parsedHigher.stake == stake &&
+              parsedHigher.userId == discordId)
+        check(parsedLower != null && parsedLower.direction == Highlow.Direction.LOWER &&
+              parsedLower.anchor == anchor && parsedLower.stake == stake &&
+              parsedLower.userId == discordId)
     }
 
     @Test
-    fun `unknown direction short-circuits`() {
+    fun `does not call play or deal an anchor when no stake is provided`() {
         val user = UserDto(discordId = discordId, guildId = guildId)
-        every { event.getOption("direction") } returns strOpt("SIDEWAYS")
-        every { event.getOption("stake") } returns intOpt(100L)
+        every { event.getOption("stake") } returns null
 
         command.handle(DefaultCommandContext(event), user, 5)
 
+        verify(exactly = 0) { highlowService.dealAnchor() }
         verify(exactly = 0) { highlowService.play(any(), any(), any(), any()) }
     }
 }

--- a/web/src/main/kotlin/web/controller/HighlowController.kt
+++ b/web/src/main/kotlin/web/controller/HighlowController.kt
@@ -59,10 +59,11 @@ class HighlowController(
         val tobyCoins = profile?.tobyCoins ?: 0L
         val marketPrice = marketService.getMarket(guildId)?.price ?: 0.0
 
-        // Anchor sticks to the user's session so refreshing the page
-        // can't reroll a fresh card. Drawn lazily on first hit.
-        val anchor = activeAnchor(session, guildId)
-            ?: highlowService.dealAnchor().also { storeAnchor(session, guildId, it) }
+        // Stake commits first, anchor is dealt after the player locks it.
+        // If a round is already locked in this session, surface it so the
+        // player isn't asked to lock again on refresh.
+        val activeAnchor = activeAnchor(session, guildId)
+        val activeStake = activeStake(session, guildId)
 
         model.addAttribute("guildId", guildId.toString())
         model.addAttribute("guildName", guild.name)
@@ -72,11 +73,39 @@ class HighlowController(
         model.addAttribute("minStake", Highlow.MIN_STAKE)
         model.addAttribute("maxStake", Highlow.MAX_STAKE)
         model.addAttribute("multiplier", Highlow.DEFAULT_MULTIPLIER)
-        model.addAttribute("anchor", anchor)
-        model.addAttribute("anchorLabel", cardLabel(anchor))
+        model.addAttribute("anchor", activeAnchor)
+        model.addAttribute("anchorLabel", activeAnchor?.let { cardLabel(it) } ?: "?")
+        model.addAttribute("activeStake", activeStake)
         model.addAttribute("jackpotPool", jackpotService.getPool(guildId))
         model.addAttribute("username", user.displayName())
         return "highlow"
+    }
+
+    @PostMapping("/start")
+    @ResponseBody
+    fun start(
+        @PathVariable guildId: Long,
+        @RequestBody request: StartRequest,
+        @AuthenticationPrincipal user: OAuth2User,
+        session: HttpSession
+    ): ResponseEntity<StartResponse> {
+        val discordId = user.discordIdOrNull()
+            ?: return ResponseEntity.status(401).body(StartResponse(false, "Not signed in."))
+        if (!economyWebService.isMember(discordId, guildId)) {
+            return ResponseEntity.status(403).body(StartResponse(false, "You are not a member of that server."))
+        }
+        if (request.stake < Highlow.MIN_STAKE || request.stake > Highlow.MAX_STAKE) {
+            return ResponseEntity.badRequest().body(
+                StartResponse(false, "Stake must be between ${Highlow.MIN_STAKE} and ${Highlow.MAX_STAKE} credits.")
+            )
+        }
+
+        val anchor = highlowService.dealAnchor()
+        storeStake(session, guildId, request.stake)
+        storeAutoTopUp(session, guildId, request.autoTopUp)
+        storeAnchor(session, guildId, anchor)
+
+        return ResponseEntity.ok(StartResponse(ok = true, anchor = anchor, anchorLabel = cardLabel(anchor)))
     }
 
     @PostMapping("/play")
@@ -96,21 +125,23 @@ class HighlowController(
             ?: return ResponseEntity.badRequest().body(PlayResponse(false, "Pick a direction: HIGHER or LOWER."))
 
         val anchor = activeAnchor(session, guildId)
-            ?: return ResponseEntity.badRequest().body(
-                PlayResponse(false, "No active round — refresh the page to draw a new card.")
+        val stake = activeStake(session, guildId)
+        if (anchor == null || stake == null) {
+            return ResponseEntity.badRequest().body(
+                PlayResponse(false, "No active round — lock a stake first.")
             )
+        }
+        val autoTopUp = activeAutoTopUp(session, guildId)
 
-        val outcome = highlowService.play(discordId, guildId, request.stake, direction, anchor, request.autoTopUp)
+        val outcome = highlowService.play(discordId, guildId, stake, direction, anchor, autoTopUp)
 
-        // Only consume the anchor on outcomes that actually drew a next
-        // card. Validation rejections (invalid stake, insufficient
-        // credits, unknown user) leave the same anchor in place so the
-        // player can retry without losing the card they were looking at.
+        // Once a card is drawn the round is over either way; clear the
+        // session so the next round starts with a fresh stake commit.
+        // Validation/credit failures *do not* draw the next card, so we
+        // keep the locked stake+anchor in place for the player to retry.
         val consumed = outcome is PlayOutcome.Win || outcome is PlayOutcome.Lose
-        val nextRoundAnchor: Int? = if (consumed) {
-            highlowService.dealAnchor().also { storeAnchor(session, guildId, it) }
-        } else {
-            null
+        if (consumed) {
+            clearRound(session, guildId)
         }
 
         return when (outcome) {
@@ -124,7 +155,6 @@ class HighlowController(
                     payout = outcome.payout,
                     newBalance = outcome.newBalance,
                     win = true,
-                    nextAnchor = nextRoundAnchor,
                     jackpotPayout = outcome.jackpotPayout.takeIf { it > 0L },
                     soldTobyCoins = outcome.soldTobyCoins.takeIf { it > 0L },
                     newPrice = outcome.newPrice
@@ -141,7 +171,6 @@ class HighlowController(
                     payout = 0L,
                     newBalance = outcome.newBalance,
                     win = false,
-                    nextAnchor = nextRoundAnchor,
                     soldTobyCoins = outcome.soldTobyCoins.takeIf { it > 0L },
                     newPrice = outcome.newPrice
                 )
@@ -172,12 +201,34 @@ class HighlowController(
     }
 
     private fun anchorKey(guildId: Long): String = "highlow.anchor.$guildId"
+    private fun stakeKey(guildId: Long): String = "highlow.stake.$guildId"
+    private fun autoTopUpKey(guildId: Long): String = "highlow.autoTopUp.$guildId"
 
     private fun activeAnchor(session: HttpSession, guildId: Long): Int? =
         session.getAttribute(anchorKey(guildId)) as? Int
 
+    private fun activeStake(session: HttpSession, guildId: Long): Long? =
+        session.getAttribute(stakeKey(guildId)) as? Long
+
+    private fun activeAutoTopUp(session: HttpSession, guildId: Long): Boolean =
+        (session.getAttribute(autoTopUpKey(guildId)) as? Boolean) == true
+
     private fun storeAnchor(session: HttpSession, guildId: Long, anchor: Int) {
         session.setAttribute(anchorKey(guildId), anchor)
+    }
+
+    private fun storeStake(session: HttpSession, guildId: Long, stake: Long) {
+        session.setAttribute(stakeKey(guildId), stake)
+    }
+
+    private fun storeAutoTopUp(session: HttpSession, guildId: Long, autoTopUp: Boolean) {
+        session.setAttribute(autoTopUpKey(guildId), autoTopUp)
+    }
+
+    private fun clearRound(session: HttpSession, guildId: Long) {
+        session.removeAttribute(anchorKey(guildId))
+        session.removeAttribute(stakeKey(guildId))
+        session.removeAttribute(autoTopUpKey(guildId))
     }
 
     private fun cardLabel(n: Int): String = when (n) {
@@ -189,7 +240,16 @@ class HighlowController(
     }
 }
 
-data class PlayRequest(val direction: String = "", val stake: Long = 0, val autoTopUp: Boolean = false)
+data class StartRequest(val stake: Long = 0, val autoTopUp: Boolean = false)
+
+data class StartResponse(
+    val ok: Boolean,
+    val error: String? = null,
+    val anchor: Int? = null,
+    val anchorLabel: String? = null
+)
+
+data class PlayRequest(val direction: String = "")
 
 data class PlayResponse(
     val ok: Boolean,
@@ -201,7 +261,6 @@ data class PlayResponse(
     val payout: Long? = null,
     val newBalance: Long? = null,
     val win: Boolean? = null,
-    val nextAnchor: Int? = null,
     val jackpotPayout: Long? = null,
     val soldTobyCoins: Long? = null,
     val newPrice: Double? = null

--- a/web/src/main/resources/static/css/highlow.css
+++ b/web/src/main/resources/static/css/highlow.css
@@ -113,6 +113,18 @@
     outline-offset: 2px;
 }
 
+.highlow-direction-btn {
+    flex: 1;
+    padding: 12px;
+    font-weight: 600;
+    border-radius: 8px;
+    cursor: pointer;
+}
+.highlow-direction-btn:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+}
+
 .highlow-stake-label {
     font-size: 0.85rem;
     color: var(--text-muted);

--- a/web/src/main/resources/static/js/highlow.js
+++ b/web/src/main/resources/static/js/highlow.js
@@ -67,8 +67,12 @@ function renderHighlowResult(resultEl, body) {
     const balanceEl = document.getElementById('highlow-balance');
     const resultEl = document.getElementById('highlow-result');
     const form = document.getElementById('highlow-bet');
+    const directionPicker = document.getElementById('highlow-direction-picker');
+    const higherBtn = document.getElementById('highlow-call-higher');
+    const lowerBtn = document.getElementById('highlow-call-lower');
 
     if (!form || !dealBtn || !stakeInput || !anchorFace || !nextFace) return;
+    if (!directionPicker || !higherBtn || !lowerBtn) return;
 
     const topUp = (window.TobyTopUp && dealTobyBtn) ? window.TobyTopUp.init({
         form: form,
@@ -78,20 +82,46 @@ function renderHighlowResult(resultEl, body) {
         balanceEl: balanceEl,
         tobyCoins: initialTobyCoins,
         marketPrice: initialMarketPrice,
-        onSubmit: function (autoTopUp) { runDeal(autoTopUp); },
+        onSubmit: function (autoTopUp) { runStart(autoTopUp); },
     }) : null;
 
     const NEXT_DEAL_MS = 900;
     const SHUFFLE_INTERVAL_MS = 70;
+    const ROUND_RESET_MS = 1500;
 
     let dealing = false;
-
-    function selectedDirection() {
-        const checked = form.querySelector('input[name="direction"]:checked');
-        return checked ? checked.value : null;
-    }
+    // Tracks which lock variant the player picked so we can pass autoTopUp
+    // through to /play if they hit the shortfall on the actual wager.
+    let pendingAutoTopUp = false;
 
     const cardLabel = highlowCardLabel;
+
+    function showLockMode() {
+        directionPicker.hidden = true;
+        higherBtn.disabled = false;
+        lowerBtn.disabled = false;
+        form.hidden = false;
+        dealBtn.disabled = false;
+        if (dealTobyBtn) dealTobyBtn.disabled = false;
+        anchorFace.textContent = '?';
+        if (anchorCard) delete anchorCard.dataset.value;
+        nextFace.textContent = '?';
+        if (nextCard) delete nextCard.dataset.value;
+    }
+
+    function showCallMode(anchorValue) {
+        if (typeof anchorValue === 'number') {
+            anchorFace.textContent = cardLabel(anchorValue);
+            if (anchorCard) anchorCard.dataset.value = String(anchorValue);
+        }
+        nextFace.textContent = '?';
+        if (nextCard) delete nextCard.dataset.value;
+        form.hidden = true;
+        directionPicker.hidden = false;
+        higherBtn.disabled = false;
+        lowerBtn.disabled = false;
+        if (resultEl) resultEl.hidden = true;
+    }
 
     function startNextShuffle() {
         dealing = true;
@@ -114,17 +144,6 @@ function renderHighlowResult(resultEl, body) {
         }
     }
 
-    // After a settled round, surface the next round's anchor in the
-    // anchor slot and reset the next-card placeholder so the player can
-    // see the new draw without refreshing the page.
-    function rollAnchorTo(value) {
-        if (typeof value !== 'number') return;
-        anchorFace.textContent = cardLabel(value);
-        anchorCard.dataset.value = String(value);
-        nextFace.textContent = '?';
-        delete nextCard.dataset.value;
-    }
-
     function applyBalance(newBalance) {
         if (typeof newBalance !== 'number') return;
         if (balanceEl) balanceEl.textContent = newBalance;
@@ -139,35 +158,57 @@ function renderHighlowResult(resultEl, body) {
         if (typeof body.newPrice === 'number') topUp.setMarketPrice(body.newPrice);
     }
 
-    function runDeal(autoTopUp) {
+    function runStart(autoTopUp) {
         if (dealing) return;
 
-        const direction = selectedDirection();
-        if (!direction) {
-            toast('Pick a direction first.', 'error');
-            return;
-        }
         const stake = parseInt(stakeInput.value, 10);
         if (!stake || stake <= 0) {
             toast('Enter a positive stake.', 'error');
             return;
         }
 
-        dealBtn.disabled = true;
-        if (dealTobyBtn) dealTobyBtn.disabled = true;
-        const intervalId = startNextShuffle();
-        const requestStart = Date.now();
-
         if (!postJson) {
-            stopNextShuffle(intervalId);
-            dealBtn.disabled = false;
-            if (dealTobyBtn) dealTobyBtn.disabled = false;
             toast('API helper missing — refresh the page.', 'error');
             return;
         }
 
+        dealBtn.disabled = true;
+        if (dealTobyBtn) dealTobyBtn.disabled = true;
+        pendingAutoTopUp = !!autoTopUp;
+
+        postJson('/casino/' + guildId + '/highlow/start', {
+            stake: stake, autoTopUp: pendingAutoTopUp,
+        })
+            .then(function (body) {
+                if (body && body.ok && typeof body.anchor === 'number') {
+                    showCallMode(body.anchor);
+                } else {
+                    dealBtn.disabled = false;
+                    if (dealTobyBtn) dealTobyBtn.disabled = false;
+                    toast((body && body.error) || 'Could not lock the round.', 'error');
+                }
+            })
+            .catch(function () {
+                dealBtn.disabled = false;
+                if (dealTobyBtn) dealTobyBtn.disabled = false;
+                toast('Network error.', 'error');
+            });
+    }
+
+    function runPlay(direction) {
+        if (dealing) return;
+        if (!postJson) {
+            toast('API helper missing — refresh the page.', 'error');
+            return;
+        }
+
+        higherBtn.disabled = true;
+        lowerBtn.disabled = true;
+        const intervalId = startNextShuffle();
+        const requestStart = Date.now();
+
         postJson('/casino/' + guildId + '/highlow/play', {
-            direction: direction, stake: stake, autoTopUp: !!autoTopUp,
+            direction: direction,
         })
             .then(function (body) {
                 const elapsed = Date.now() - requestStart;
@@ -178,23 +219,21 @@ function renderHighlowResult(resultEl, body) {
                         renderHighlowResult(resultEl, body);
                         applyBalance(body.newBalance);
                         applyTobyDelta(body);
-                        if (typeof body.nextAnchor === 'number') {
-                            setTimeout(function () { rollAnchorTo(body.nextAnchor); }, 1200);
-                        }
+                        // Round consumed → reset to lock mode after the
+                        // player has had a moment to read the result.
+                        setTimeout(showLockMode, ROUND_RESET_MS);
                     } else {
                         stopNextShuffle(intervalId);
-                        if (resultEl) resultEl.hidden = true;
+                        higherBtn.disabled = false;
+                        lowerBtn.disabled = false;
                         toast((body && body.error) || 'Deal failed.', 'error');
                     }
-                    dealBtn.disabled = false;
-                    if (dealTobyBtn) dealTobyBtn.disabled = false;
                 }, remaining);
             })
             .catch(function () {
                 stopNextShuffle(intervalId);
-                dealBtn.disabled = false;
-                if (dealTobyBtn) dealTobyBtn.disabled = false;
-                if (resultEl) resultEl.hidden = true;
+                higherBtn.disabled = false;
+                lowerBtn.disabled = false;
                 toast('Network error.', 'error');
             });
     }
@@ -202,8 +241,18 @@ function renderHighlowResult(resultEl, body) {
     if (!topUp) {
         form.addEventListener('submit', function (e) {
             e.preventDefault();
-            runDeal(false);
+            runStart(false);
         });
+    }
+
+    higherBtn.addEventListener('click', function () { runPlay('HIGHER'); });
+    lowerBtn.addEventListener('click', function () { runPlay('LOWER'); });
+
+    // If the server pre-rendered an active round (page refresh mid-round),
+    // jump straight to call mode so the player can finish their bet.
+    const preloadedAnchor = parseInt(main.dataset.activeAnchor || '', 10);
+    if (Number.isFinite(preloadedAnchor) && preloadedAnchor > 0) {
+        showCallMode(preloadedAnchor);
     }
 })();
 

--- a/web/src/main/resources/templates/highlow.html
+++ b/web/src/main/resources/templates/highlow.html
@@ -6,12 +6,12 @@
 <div th:replace="~{fragments/navbar :: navbar}"></div>
 
 <main id="main" class="container"
-      th:attr="data-guild-id=${guildId}, data-toby-coins=${tobyCoins}, data-market-price=${marketPrice}">
+      th:attr="data-guild-id=${guildId}, data-toby-coins=${tobyCoins}, data-market-price=${marketPrice}, data-active-anchor=${anchor}, data-active-stake=${activeStake}">
 
     <div class="highlow-header">
         <a class="back-link" th:href="@{/casino/guilds}">&larr; All casino servers</a>
         <h1 th:text="'🃏 High-Low • ' + ${guildName}">🃏 High-Low</h1>
-        <p class="muted">Pre-commit higher or lower. Cards are 1 (Ace) through 13 (King).
+        <p class="muted">Lock your stake first — the anchor is dealt only after you commit.
             Match → <strong th:text="${multiplier} + '×'">2×</strong> stake. Tie loses.
             Bet <span th:text="${minStake}">10</span>-<span th:text="${maxStake}">500</span> credits.</p>
     </div>
@@ -36,29 +36,27 @@
         <div class="highlow-result" id="highlow-result" hidden></div>
 
         <form class="highlow-bet" id="highlow-bet" autocomplete="off">
-            <div class="highlow-direction-picker" role="radiogroup" aria-label="Pick a direction">
-                <label class="highlow-direction">
-                    <input type="radio" name="direction" value="HIGHER" checked>
-                    <span>▲ Higher</span>
-                </label>
-                <label class="highlow-direction">
-                    <input type="radio" name="direction" value="LOWER">
-                    <span>▼ Lower</span>
-                </label>
-            </div>
             <label for="highlow-stake" class="highlow-stake-label">Stake (credits)</label>
             <input id="highlow-stake"
                    name="stake"
                    type="number"
                    th:attr="min=${minStake}, max=${maxStake}"
-                   th:value="${minStake}"
+                   th:value="${activeStake ?: minStake}"
                    step="1">
-            <button type="submit" id="highlow-deal" class="btn-primary">Deal</button>
+            <button type="submit" id="highlow-deal" class="btn-primary">Lock stake &amp; deal</button>
             <button type="submit" id="highlow-deal-toby" class="btn-secondary casino-bet-toby" hidden
-                    title="Sells just enough TOBY at the live market price to cover the shortfall, then deals.">
-                Deal (sell <span class="casino-bet-toby-coins">0</span> TOBY)
+                    title="Sells just enough TOBY at the live market price to cover the shortfall, then locks.">
+                Lock (sell <span class="casino-bet-toby-coins">0</span> TOBY)
             </button>
         </form>
+
+        <div class="highlow-direction-picker" id="highlow-direction-picker" hidden
+             role="group" aria-label="Pick a direction">
+            <button type="button" class="btn-primary highlow-direction-btn"
+                    id="highlow-call-higher" data-direction="HIGHER">▲ Higher</button>
+            <button type="button" class="btn-primary highlow-direction-btn"
+                    id="highlow-call-lower" data-direction="LOWER">▼ Lower</button>
+        </div>
 
         <div class="highlow-balance">
             Balance: <strong id="highlow-balance" th:text="${balance}">0</strong> credits
@@ -73,11 +71,11 @@
     <section class="highlow-rules">
         <h2>Rules</h2>
         <ul>
-            <li>The anchor card is revealed up front — you see it before betting.</li>
-            <li>Pick higher or lower, set a stake, then deal the next card.</li>
+            <li>Set your stake and click <strong>Lock stake &amp; deal</strong>; the anchor is revealed only after.</li>
+            <li>Once the anchor is up, call higher or lower to draw the next card.</li>
             <li>Direction matches → <strong th:text="${multiplier} + '×'">2×</strong> stake.</li>
             <li>Wrong direction or tie (anchor == next) → lose stake.</li>
-            <li>The anchor is locked to your session, so refreshing won't reroll it.</li>
+            <li>The locked stake + anchor sticks to your session, so refreshing won't reroll the round.</li>
             <li>Average RTP ≈ 12/13 ≈ 0.923 (~7.7% house edge from the tie-loses rule).</li>
         </ul>
     </section>

--- a/web/src/test/kotlin/web/controller/HighlowControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/HighlowControllerTest.kt
@@ -28,6 +28,8 @@ class HighlowControllerTest {
     private val guildId = 42L
     private val discordId = 100L
     private val anchorKey = "highlow.anchor.$guildId"
+    private val stakeKey = "highlow.stake.$guildId"
+    private val autoTopUpKey = "highlow.autoTopUp.$guildId"
 
     private lateinit var highlowService: HighlowService
     private lateinit var economyWebService: EconomyWebService
@@ -51,7 +53,6 @@ class HighlowControllerTest {
             every { getAttribute<String>("id") } returns discordId.toString()
             every { getAttribute<String>("username") } returns "tester"
         }
-        // Lightweight in-memory session — only get/set/remove are exercised.
         session = inMemorySession()
 
         every { economyWebService.isMember(discordId, guildId) } returns true
@@ -64,31 +65,81 @@ class HighlowControllerTest {
     }
 
     @Test
-    fun `GET draws an anchor on first hit and stores it in session`() {
-        every { highlowService.dealAnchor() } returns 7
-
+    fun `GET does not draw an anchor`() {
         val view = controller.page(guildId, user, session, ConcurrentModel(), RedirectAttributesModelMap())
 
         assertEquals("highlow", view)
-        assertEquals(7, session.getAttribute(anchorKey))
-        verify(exactly = 1) { highlowService.dealAnchor() }
-    }
-
-    @Test
-    fun `GET reuses the session anchor on subsequent hits without redrawing`() {
-        session.setAttribute(anchorKey, 11)
-
-        controller.page(guildId, user, session, ConcurrentModel(), RedirectAttributesModelMap())
-
+        assertNull(session.getAttribute(anchorKey))
         verify(exactly = 0) { highlowService.dealAnchor() }
-        assertEquals(11, session.getAttribute(anchorKey))
     }
 
     @Test
-    fun `POST without an active anchor returns 400`() {
+    fun `GET surfaces an in-progress round so refreshing mid-round still works`() {
+        session.setAttribute(anchorKey, 11)
+        session.setAttribute(stakeKey, 75L)
+
+        val model = ConcurrentModel()
+        controller.page(guildId, user, session, model, RedirectAttributesModelMap())
+
+        assertEquals(11, model.getAttribute("anchor"))
+        assertEquals("J", model.getAttribute("anchorLabel"))
+        assertEquals(75L, model.getAttribute("activeStake"))
+        verify(exactly = 0) { highlowService.dealAnchor() }
+    }
+
+    @Test
+    fun `start locks stake and deals anchor into session`() {
+        every { highlowService.dealAnchor() } returns 9
+
+        val response = controller.start(
+            guildId,
+            StartRequest(stake = 50L, autoTopUp = false),
+            user,
+            session
+        )
+
+        assertTrue(response.statusCode.is2xxSuccessful)
+        assertEquals(true, response.body!!.ok)
+        assertEquals(9, response.body!!.anchor)
+        assertEquals(9, session.getAttribute(anchorKey))
+        assertEquals(50L, session.getAttribute(stakeKey))
+        assertEquals(false, session.getAttribute(autoTopUpKey))
+    }
+
+    @Test
+    fun `start records autoTopUp in session for the eventual play call`() {
+        every { highlowService.dealAnchor() } returns 4
+
+        controller.start(
+            guildId,
+            StartRequest(stake = 50L, autoTopUp = true),
+            user,
+            session
+        )
+
+        assertEquals(true, session.getAttribute(autoTopUpKey))
+    }
+
+    @Test
+    fun `start rejects an out-of-range stake without dealing or persisting`() {
+        val response = controller.start(
+            guildId,
+            StartRequest(stake = 9_999L),
+            user,
+            session
+        )
+
+        assertEquals(400, response.statusCode.value())
+        assertEquals(false, response.body!!.ok)
+        assertNull(session.getAttribute(anchorKey))
+        verify(exactly = 0) { highlowService.dealAnchor() }
+    }
+
+    @Test
+    fun `play without an active round returns 400`() {
         val response = controller.play(
             guildId,
-            PlayRequest(direction = "HIGHER", stake = 50L),
+            PlayRequest(direction = "HIGHER"),
             user,
             session
         )
@@ -100,21 +151,22 @@ class HighlowControllerTest {
     }
 
     @Test
-    fun `POST consumes the session anchor and seeds a new one for the next round`() {
+    fun `play resolves with the session's stake and anchor and clears the round on a settled outcome`() {
         session.setAttribute(anchorKey, 5)
+        session.setAttribute(stakeKey, 50L)
+        session.setAttribute(autoTopUpKey, false)
         every {
-            highlowService.play(discordId, guildId, 50L, Highlow.Direction.HIGHER, 5)
+            highlowService.play(discordId, guildId, 50L, Highlow.Direction.HIGHER, 5, false)
         } returns PlayOutcome.Win(
             stake = 50L, payout = 100L, net = 50L,
             anchor = 5, next = 12,
             direction = Highlow.Direction.HIGHER,
             newBalance = 1_050L
         )
-        every { highlowService.dealAnchor() } returns 9
 
         val response = controller.play(
             guildId,
-            PlayRequest(direction = "HIGHER", stake = 50L),
+            PlayRequest(direction = "HIGHER"),
             user,
             session
         )
@@ -124,36 +176,58 @@ class HighlowControllerTest {
         assertEquals(true, body.win)
         assertEquals(5, body.anchor)
         assertEquals(12, body.next)
-        assertEquals(9, body.nextAnchor, "next round's anchor must be in the response")
-        assertEquals(9, session.getAttribute(anchorKey), "session must hold the new anchor")
+        assertNull(session.getAttribute(anchorKey), "round must be cleared so the next bet starts fresh")
+        assertNull(session.getAttribute(stakeKey))
     }
 
     @Test
-    fun `POST with insufficient credits keeps the session anchor in place for retry`() {
+    fun `play forwards the session autoTopUp flag to the service`() {
+        session.setAttribute(anchorKey, 5)
+        session.setAttribute(stakeKey, 50L)
+        session.setAttribute(autoTopUpKey, true)
+        every {
+            highlowService.play(discordId, guildId, 50L, Highlow.Direction.HIGHER, 5, true)
+        } returns PlayOutcome.Lose(
+            stake = 50L, anchor = 5, next = 5,
+            direction = Highlow.Direction.HIGHER,
+            newBalance = 950L
+        )
+
+        controller.play(guildId, PlayRequest(direction = "HIGHER"), user, session)
+
+        verify(exactly = 1) {
+            highlowService.play(discordId, guildId, 50L, Highlow.Direction.HIGHER, 5, true)
+        }
+    }
+
+    @Test
+    fun `play with insufficient credits keeps the locked round in place for retry`() {
         session.setAttribute(anchorKey, 6)
-        every { highlowService.play(discordId, guildId, 9_999L, Highlow.Direction.HIGHER, 6) } returns
-            PlayOutcome.InsufficientCredits(stake = 9_999L, have = 100L)
+        session.setAttribute(stakeKey, 9_999L)
+        every {
+            highlowService.play(discordId, guildId, 9_999L, Highlow.Direction.HIGHER, 6, false)
+        } returns PlayOutcome.InsufficientCredits(stake = 9_999L, have = 100L)
 
         val response = controller.play(
             guildId,
-            PlayRequest(direction = "HIGHER", stake = 9_999L),
+            PlayRequest(direction = "HIGHER"),
             user,
             session
         )
 
         assertEquals(400, response.statusCode.value())
-        assertEquals(6, session.getAttribute(anchorKey), "anchor stays so the user can correct stake and retry")
-        assertNull(response.body!!.nextAnchor)
-        verify(exactly = 0) { highlowService.dealAnchor() }
+        assertEquals(6, session.getAttribute(anchorKey), "anchor stays so the user can retry")
+        assertEquals(9_999L, session.getAttribute(stakeKey), "stake also stays")
     }
 
     @Test
-    fun `POST with invalid direction returns 400 without touching the service`() {
+    fun `play with invalid direction returns 400 without touching the service`() {
         session.setAttribute(anchorKey, 4)
+        session.setAttribute(stakeKey, 25L)
 
         val response = controller.play(
             guildId,
-            PlayRequest(direction = "SIDEWAYS", stake = 50L),
+            PlayRequest(direction = "SIDEWAYS"),
             user,
             session
         )
@@ -166,8 +240,9 @@ class HighlowControllerTest {
     @Test
     fun `jackpot win surfaces jackpotPayout in the response body`() {
         session.setAttribute(anchorKey, 5)
+        session.setAttribute(stakeKey, 50L)
         every {
-            highlowService.play(discordId, guildId, 50L, Highlow.Direction.HIGHER, 5)
+            highlowService.play(discordId, guildId, 50L, Highlow.Direction.HIGHER, 5, false)
         } returns PlayOutcome.Win(
             stake = 50L, payout = 100L, net = 50L,
             anchor = 5, next = 12,
@@ -175,11 +250,10 @@ class HighlowControllerTest {
             newBalance = 5_050L,
             jackpotPayout = 4_000L
         )
-        every { highlowService.dealAnchor() } returns 9
 
         val response = controller.play(
             guildId,
-            PlayRequest(direction = "HIGHER", stake = 50L),
+            PlayRequest(direction = "HIGHER"),
             user,
             session
         )


### PR DESCRIPTION
## Summary

Both `/highlow` flows used to expose the anchor card before the player committed to a stake — the web rendered it server-side on page load, and Discord required `stake` + `direction` up front. That made the game trivial: you could size your bet to the card. This PR splits the round so the **stake locks first, the anchor is revealed second, and only then does the player pick HIGHER or LOWER**.

### Discord
- `/highlow` now takes only a `stake` option. `HighlowCommand` deals an anchor via the existing `HighlowService.dealAnchor()` and replies with an embed showing the anchor card plus HIGHER/LOWER buttons.
- Anchor + stake + owning user are encoded in each button's component ID (`highlow:DIRECTION:ANCHOR:STAKE:USERID`) — no server-side state needed, follows the existing `RollButton` pattern.
- New `HighlowButton` parses the component ID, calls the anchored `HighlowService.play(...)` overload (same atomic check/lock + jackpot path the web uses), edits the original message in place, and clears the buttons so the round can't be re-clicked.
- Clicks from non-owners are rejected ephemerally so other users can't grief a player's locked round.

### Web
- `GET /casino/{guildId}/highlow` no longer deals the anchor on page load.
- New `POST /start` validates the stake range; the dealt anchor + stake (+ autoTopUp choice) are pinned to the session, and the anchor is returned.
- `POST /play` now reads stake/anchor/autoTopUp from the session and clears them on a settled outcome (validation/credit failures keep the locked round so the player can retry).
- Two-stage UI: stake form → direction buttons. Refreshing mid-round restores the call-mode UI from session state.

## Test plan
- [x] `:web:test --tests web.controller.HighlowControllerTest` passes locally.
- [x] `npx jest web/src/test/js/highlow.test.js` passes locally.
- [ ] CI runs `:discord-bot:test --tests "*Highlow*"` (couldn't run locally — environment couldn't reach the lavalink/jitpack maven repos).
- [ ] Manual smoke (Discord): `/highlow stake:50` → anchor embed with two buttons → click → outcome embed in place, buttons gone. Below-min stake rejected by JDA. Other user clicking gets ephemeral rejection.
- [ ] Manual smoke (web): page loads with stake input only, no anchor visible. Click "Lock stake & deal" → anchor reveals + Higher/Lower buttons appear. Click a direction → result animates and UI returns to stake-input mode.

https://claude.ai/code/session_01GBXtXxVmqjfppQMU9ckcWt

---
_Generated by [Claude Code](https://claude.ai/code/session_01GBXtXxVmqjfppQMU9ckcWt)_