### PR TITLE
feat(jackpot): 10% (configurable) of every lost stake feeds the jackpot pool

### DIFF
--- a/database/src/main/kotlin/database/dto/ConfigDto.kt
+++ b/database/src/main/kotlin/database/dto/ConfigDto.kt
@@ -35,7 +35,10 @@ class ConfigDto(
         DELETE_DELAY("DELETE_MESSAGE_DELAY"),
         LEADERBOARD_CHANNEL("LEADERBOARD_CHANNEL"),
         ACTIVITY_TRACKING("ACTIVITY_TRACKING"),
-        ACTIVITY_TRACKING_NOTIFIED("ACTIVITY_TRACKING_NOTIFIED");
+        ACTIVITY_TRACKING_NOTIFIED("ACTIVITY_TRACKING_NOTIFIED"),
+        // Whole-number percentage (0-50) of every lost casino stake that
+        // routes into the per-guild jackpot pool. Defaults to 10 if unset.
+        JACKPOT_LOSS_TRIBUTE_PCT("JACKPOT_LOSS_TRIBUTE_PCT");
     }
 
     override fun toString(): String {

--- a/database/src/main/kotlin/database/service/CoinflipService.kt
+++ b/database/src/main/kotlin/database/service/CoinflipService.kt
@@ -23,6 +23,7 @@ class CoinflipService(
     private val jackpotService: JackpotService,
     private val tradeService: EconomyTradeService,
     private val marketService: TobyCoinMarketService,
+    private val configService: ConfigService,
     private val coinflip: Coinflip = Coinflip(),
     private val random: Random = Random.Default
 ) {
@@ -46,7 +47,8 @@ class CoinflipService(
             val predicted: Coinflip.Side,
             val newBalance: Long,
             val soldTobyCoins: Long = 0L,
-            val newPrice: Double? = null
+            val newPrice: Double? = null,
+            val lossTribute: Long = 0L
         ) : FlipOutcome
 
         data class InsufficientCredits(val stake: Long, val have: Long) : FlipOutcome
@@ -109,13 +111,15 @@ class CoinflipService(
                 newPrice = newPrice
             )
         } else {
+            val tribute = JackpotHelper.divertOnLoss(jackpotService, configService, guildId, stake)
             FlipOutcome.Lose(
                 stake = stake,
                 landed = flip.landed,
                 predicted = flip.predicted,
                 newBalance = r.newBalance,
                 soldTobyCoins = soldCoins,
-                newPrice = newPrice
+                newPrice = newPrice,
+                lossTribute = tribute
             )
         }
     }

--- a/database/src/main/kotlin/database/service/DiceService.kt
+++ b/database/src/main/kotlin/database/service/DiceService.kt
@@ -22,6 +22,7 @@ class DiceService(
     private val jackpotService: JackpotService,
     private val tradeService: EconomyTradeService,
     private val marketService: TobyCoinMarketService,
+    private val configService: ConfigService,
     private val dice: Dice = Dice(),
     private val random: Random = Random.Default
 ) {
@@ -45,7 +46,8 @@ class DiceService(
             val predicted: Int,
             val newBalance: Long,
             val soldTobyCoins: Long = 0L,
-            val newPrice: Double? = null
+            val newPrice: Double? = null,
+            val lossTribute: Long = 0L
         ) : RollOutcome
 
         data class InsufficientCredits(val stake: Long, val have: Long) : RollOutcome
@@ -112,13 +114,15 @@ class DiceService(
                 newPrice = newPrice
             )
         } else {
+            val tribute = JackpotHelper.divertOnLoss(jackpotService, configService, guildId, stake)
             RollOutcome.Lose(
                 stake = stake,
                 landed = roll.landed,
                 predicted = roll.predicted,
                 newBalance = r.newBalance,
                 soldTobyCoins = soldCoins,
-                newPrice = newPrice
+                newPrice = newPrice,
+                lossTribute = tribute
             )
         }
     }

--- a/database/src/main/kotlin/database/service/HighlowService.kt
+++ b/database/src/main/kotlin/database/service/HighlowService.kt
@@ -28,6 +28,7 @@ class HighlowService(
     private val jackpotService: JackpotService,
     private val tradeService: EconomyTradeService,
     private val marketService: TobyCoinMarketService,
+    private val configService: ConfigService,
     private val highlow: Highlow = Highlow(),
     private val random: Random = Random.Default
 ) {
@@ -53,7 +54,8 @@ class HighlowService(
             val direction: Highlow.Direction,
             val newBalance: Long,
             val soldTobyCoins: Long = 0L,
-            val newPrice: Double? = null
+            val newPrice: Double? = null,
+            val lossTribute: Long = 0L
         ) : PlayOutcome
 
         data class InsufficientCredits(val stake: Long, val have: Long) : PlayOutcome
@@ -142,6 +144,7 @@ class HighlowService(
                 newPrice = soldNewPrice
             )
         } else {
+            val tribute = JackpotHelper.divertOnLoss(jackpotService, configService, guildId, stake)
             PlayOutcome.Lose(
                 stake = stake,
                 anchor = hand.anchor,
@@ -149,7 +152,8 @@ class HighlowService(
                 direction = hand.direction,
                 newBalance = r.newBalance,
                 soldTobyCoins = soldCoins,
-                newPrice = soldNewPrice
+                newPrice = soldNewPrice,
+                lossTribute = tribute
             )
         }
     }

--- a/database/src/main/kotlin/database/service/JackpotHelper.kt
+++ b/database/src/main/kotlin/database/service/JackpotHelper.kt
@@ -1,23 +1,51 @@
 package database.service
 
+import database.dto.ConfigDto
 import database.dto.UserDto
 import kotlin.random.Random
 
 /**
- * On every minigame win, roll a small probability of hitting the
- * per-guild jackpot pool. On a hit the player banks the entire pool
- * and the counter resets to zero — same lock-then-mutate path as the
- * other balance changes, threaded through the user row that
- * [WagerHelper.checkAndLock] already write-locked.
+ * Two casino-side feeders for the per-guild jackpot pool:
  *
- * Loses don't roll. The fee that funds the pool is paid on every
- * trade leg (see [EconomyTradeService]), so the "casino wins what
- * traders pay" loop is closed without slowing the trade path.
+ *   - [rollOnWin] — on every minigame WIN, roll a small probability
+ *     to bank the entire pool and reset it to zero.
+ *   - [divertOnLoss] — on every minigame LOSS, deposit a fraction of
+ *     the lost stake into the pool. The remaining fraction keeps
+ *     vanishing as house edge; tribute is the visible chunk that
+ *     funnels into the pool a future winner might claim. The fraction
+ *     is per-guild configurable via the `JACKPOT_LOSS_TRIBUTE_PCT`
+ *     config entry; defaults to [DEFAULT_LOSS_TRIBUTE] (10 %).
+ *
+ * Both paths go through [JackpotService] for the actual pool mutation
+ * (pessimistic-lock per row), so concurrent winners can't double-bank
+ * the same pool and concurrent losers can't lose deposits to last-
+ * write-wins. Caller is expected to have already locked the user via
+ * [WagerHelper.checkAndLock] — that lock implicitly serialises a
+ * single user's casino actions.
+ *
+ * The third feeder is the trade fee in [EconomyTradeService] —
+ * traders fund the pool, casino winners empty it, casino losers top
+ * it up some more.
  */
 internal object JackpotHelper {
 
     /** 1% chance to hit the jackpot per minigame win. Tuned alongside the trade fee. */
     const val WIN_PROBABILITY: Double = 0.01
+
+    /**
+     * Default fraction of a lost stake that feeds the per-guild
+     * jackpot pool when the server hasn't overridden the rate via
+     * the `JACKPOT_LOSS_TRIBUTE_PCT` config entry.
+     */
+    const val DEFAULT_LOSS_TRIBUTE: Double = 0.10
+
+    /**
+     * Hard cap on the configurable tribute. 50 % keeps the house edge
+     * meaningful even with the most aggressive admin setting — without
+     * it an admin could route every lost stake straight to the pool,
+     * removing the gambling feedback loop entirely.
+     */
+    const val MAX_LOSS_TRIBUTE: Double = 0.50
 
     /**
      * If the random roll hits and the pool is non-empty, atomically
@@ -38,5 +66,45 @@ internal object JackpotHelper {
         user.socialCredit = (user.socialCredit ?: 0L) + won
         userService.updateUser(user)
         return won
+    }
+
+    /**
+     * On a Lose outcome, deposit `floor(stake × rate)` into the per-
+     * guild pool, where `rate` comes from
+     * [lossTributeRate] for [guildId]. The lost stake itself is
+     * already deducted from the user's balance by
+     * [WagerHelper.applyMultiplier] — this is a separate write into
+     * the jackpot row, not a refund. Returns the amount deposited so
+     * callers can surface it on the response (e.g. "+10 to jackpot"
+     * on the lose line); `0L` if the floor produces nothing.
+     */
+    fun divertOnLoss(
+        jackpotService: JackpotService,
+        configService: ConfigService,
+        guildId: Long,
+        stake: Long
+    ): Long {
+        if (stake <= 0L) return 0L
+        val rate = lossTributeRate(configService, guildId)
+        if (rate <= 0.0) return 0L
+        val tribute = kotlin.math.floor(stake * rate).toLong()
+        if (tribute <= 0L) return 0L
+        jackpotService.addToPool(guildId, tribute)
+        return tribute
+    }
+
+    /**
+     * Live tribute fraction for [guildId] — admin-set whole-number
+     * percent (0-50) parsed from the `JACKPOT_LOSS_TRIBUTE_PCT` config
+     * entry. Returns [DEFAULT_LOSS_TRIBUTE] when unset or unparseable;
+     * clamps anything above [MAX_LOSS_TRIBUTE].
+     */
+    fun lossTributeRate(configService: ConfigService, guildId: Long): Double {
+        val cfg = configService.getConfigByName(
+            ConfigDto.Configurations.JACKPOT_LOSS_TRIBUTE_PCT.configValue,
+            guildId.toString()
+        )
+        val pct = cfg?.value?.toDoubleOrNull() ?: return DEFAULT_LOSS_TRIBUTE
+        return (pct / 100.0).coerceIn(0.0, MAX_LOSS_TRIBUTE)
     }
 }

--- a/database/src/main/kotlin/database/service/ScratchService.kt
+++ b/database/src/main/kotlin/database/service/ScratchService.kt
@@ -20,6 +20,7 @@ class ScratchService(
     private val jackpotService: JackpotService,
     private val tradeService: EconomyTradeService,
     private val marketService: TobyCoinMarketService,
+    private val configService: ConfigService,
     private val card: ScratchCard = ScratchCard(),
     private val random: Random = Random.Default
 ) {
@@ -43,7 +44,8 @@ class ScratchService(
             val cells: List<database.economy.SlotMachine.Symbol>,
             val newBalance: Long,
             val soldTobyCoins: Long = 0L,
-            val newPrice: Double? = null
+            val newPrice: Double? = null,
+            val lossTribute: Long = 0L
         ) : ScratchOutcome
 
         data class InsufficientCredits(val stake: Long, val have: Long) : ScratchOutcome
@@ -101,12 +103,14 @@ class ScratchService(
                 newPrice = newPrice
             )
         } else {
+            val tribute = JackpotHelper.divertOnLoss(jackpotService, configService, guildId, stake)
             ScratchOutcome.Lose(
                 stake = stake,
                 cells = result.cells,
                 newBalance = r.newBalance,
                 soldTobyCoins = soldCoins,
-                newPrice = newPrice
+                newPrice = newPrice,
+                lossTribute = tribute
             )
         }
     }

--- a/database/src/main/kotlin/database/service/SlotsService.kt
+++ b/database/src/main/kotlin/database/service/SlotsService.kt
@@ -33,6 +33,7 @@ class SlotsService(
     private val jackpotService: JackpotService,
     private val tradeService: EconomyTradeService,
     private val marketService: TobyCoinMarketService,
+    private val configService: ConfigService,
     private val machine: SlotMachine = SlotMachine(),
     private val random: Random = Random.Default
 ) {
@@ -55,7 +56,8 @@ class SlotsService(
             val symbols: List<SlotMachine.Symbol>,
             val newBalance: Long,
             val soldTobyCoins: Long = 0L,
-            val newPrice: Double? = null
+            val newPrice: Double? = null,
+            val lossTribute: Long = 0L
         ) : SpinOutcome
 
         data class InsufficientCredits(val stake: Long, val have: Long) : SpinOutcome
@@ -114,12 +116,14 @@ class SlotsService(
                 newPrice = newPrice
             )
         } else {
+            val tribute = JackpotHelper.divertOnLoss(jackpotService, configService, guildId, stake)
             SpinOutcome.Lose(
                 stake = stake,
                 symbols = pull.symbols,
                 newBalance = r.newBalance,
                 soldTobyCoins = soldCoins,
-                newPrice = newPrice
+                newPrice = newPrice,
+                lossTribute = tribute
             )
         }
     }

--- a/database/src/test/kotlin/database/service/CoinflipServiceTest.kt
+++ b/database/src/test/kotlin/database/service/CoinflipServiceTest.kt
@@ -18,6 +18,7 @@ class CoinflipServiceTest {
     private lateinit var jackpotService: JackpotService
     private lateinit var tradeService: EconomyTradeService
     private lateinit var marketService: TobyCoinMarketService
+    private lateinit var configService: ConfigService
     private lateinit var coinflip: Coinflip
     private lateinit var service: CoinflipService
 
@@ -30,8 +31,9 @@ class CoinflipServiceTest {
         jackpotService = mockk(relaxed = true)
         tradeService = mockk(relaxed = true)
         marketService = mockk(relaxed = true)
+        configService = mockk(relaxed = true)
         coinflip = mockk(relaxed = true)
-        service = CoinflipService(userService, jackpotService, tradeService, marketService, coinflip, Random(0))
+        service = CoinflipService(userService, jackpotService, tradeService, marketService, configService, coinflip, Random(0))
     }
 
     private fun userWithBalance(balance: Long): UserDto {
@@ -121,5 +123,21 @@ class CoinflipServiceTest {
 
         assertEquals(CoinflipService.FlipOutcome.UnknownUser, outcome)
         verify(exactly = 0) { userService.updateUser(any()) }
+    }
+
+    @Test
+    fun `loss tributes 10 percent of the stake into the jackpot pool`() {
+        val user = userWithBalance(500L)
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns user
+        every { coinflip.flip(any(), any()) } returns Coinflip.Flip(
+            landed = Coinflip.Side.TAILS, predicted = Coinflip.Side.HEADS, multiplier = 0L
+        )
+        every { userService.updateUser(any()) } returns user
+
+        val outcome = service.flip(discordId, guildId, stake = 100L, predicted = Coinflip.Side.HEADS)
+
+        val lose = assertInstanceOf(CoinflipService.FlipOutcome.Lose::class.java, outcome)
+        assertEquals(10L, lose.lossTribute)
+        verify(exactly = 1) { jackpotService.addToPool(guildId, 10L) }
     }
 }

--- a/database/src/test/kotlin/database/service/DiceServiceTest.kt
+++ b/database/src/test/kotlin/database/service/DiceServiceTest.kt
@@ -18,6 +18,7 @@ class DiceServiceTest {
     private lateinit var jackpotService: JackpotService
     private lateinit var tradeService: EconomyTradeService
     private lateinit var marketService: TobyCoinMarketService
+    private lateinit var configService: ConfigService
     private lateinit var dice: Dice
     private lateinit var service: DiceService
 
@@ -30,11 +31,12 @@ class DiceServiceTest {
         jackpotService = mockk(relaxed = true)
         tradeService = mockk(relaxed = true)
         marketService = mockk(relaxed = true)
+        configService = mockk(relaxed = true)
         dice = mockk(relaxed = true) {
             every { isValidPrediction(any()) } answers { firstArg<Int>() in 1..6 }
             every { sidesCount } returns 6
         }
-        service = DiceService(userService, jackpotService, tradeService, marketService, dice, Random(0))
+        service = DiceService(userService, jackpotService, tradeService, marketService, configService, dice, Random(0))
     }
 
     private fun userWithBalance(balance: Long): UserDto {
@@ -115,5 +117,19 @@ class DiceServiceTest {
 
         assertEquals(DiceService.RollOutcome.UnknownUser, outcome)
         verify(exactly = 0) { userService.updateUser(any()) }
+    }
+
+    @Test
+    fun `loss tributes 10 percent of the stake into the jackpot pool`() {
+        val user = UserDto(discordId, guildId).apply { socialCredit = 500L }
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns user
+        every { dice.roll(any(), any()) } returns Dice.Roll(landed = 1, predicted = 4, multiplier = 0L)
+        every { userService.updateUser(any()) } returns user
+
+        val outcome = service.roll(discordId, guildId, stake = 100L, predicted = 4)
+
+        val lose = assertInstanceOf(DiceService.RollOutcome.Lose::class.java, outcome)
+        assertEquals(10L, lose.lossTribute)
+        verify(exactly = 1) { jackpotService.addToPool(guildId, 10L) }
     }
 }

--- a/database/src/test/kotlin/database/service/HighlowServiceTest.kt
+++ b/database/src/test/kotlin/database/service/HighlowServiceTest.kt
@@ -18,6 +18,7 @@ class HighlowServiceTest {
     private lateinit var jackpotService: JackpotService
     private lateinit var tradeService: EconomyTradeService
     private lateinit var marketService: TobyCoinMarketService
+    private lateinit var configService: ConfigService
     private lateinit var highlow: Highlow
     private lateinit var service: HighlowService
 
@@ -30,8 +31,9 @@ class HighlowServiceTest {
         jackpotService = mockk(relaxed = true)
         tradeService = mockk(relaxed = true)
         marketService = mockk(relaxed = true)
+        configService = mockk(relaxed = true)
         highlow = mockk(relaxed = true)
-        service = HighlowService(userService, jackpotService, tradeService, marketService, highlow, Random(0))
+        service = HighlowService(userService, jackpotService, tradeService, marketService, configService, highlow, Random(0))
     }
 
     private fun userWithBalance(balance: Long): UserDto =
@@ -135,5 +137,21 @@ class HighlowServiceTest {
         assertEquals(4, anchor)
         verify(exactly = 0) { userService.getUserByIdForUpdate(any(), any()) }
         verify(exactly = 0) { userService.updateUser(any()) }
+    }
+
+    @Test
+    fun `loss tributes 10 percent of the stake into the jackpot pool`() {
+        val user = userWithBalance(500L)
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns user
+        every { highlow.play(Highlow.Direction.HIGHER, any()) } returns Highlow.Hand(
+            anchor = 7, next = 7, direction = Highlow.Direction.HIGHER, multiplier = 0L
+        )
+        every { userService.updateUser(any()) } returns user
+
+        val outcome = service.play(discordId, guildId, stake = 100L, direction = Highlow.Direction.HIGHER)
+
+        val lose = assertInstanceOf(HighlowService.PlayOutcome.Lose::class.java, outcome)
+        assertEquals(10L, lose.lossTribute)
+        verify(exactly = 1) { jackpotService.addToPool(guildId, 10L) }
     }
 }

--- a/database/src/test/kotlin/database/service/JackpotHelperTest.kt
+++ b/database/src/test/kotlin/database/service/JackpotHelperTest.kt
@@ -1,0 +1,116 @@
+package database.service
+
+import database.dto.ConfigDto
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class JackpotHelperTest {
+
+    private val guildId = 200L
+
+    private lateinit var jackpotService: JackpotService
+    private lateinit var configService: ConfigService
+
+    @BeforeEach
+    fun setup() {
+        jackpotService = mockk(relaxed = true)
+        configService = mockk(relaxed = true)
+    }
+
+    private fun configReturns(value: String?) {
+        every {
+            configService.getConfigByName(
+                ConfigDto.Configurations.JACKPOT_LOSS_TRIBUTE_PCT.configValue,
+                guildId.toString()
+            )
+        } returns value?.let { ConfigDto(name = "x", value = it, guildId = guildId.toString()) }
+    }
+
+    @Test
+    fun `lossTributeRate returns the default fraction when no config row exists`() {
+        configReturns(null)
+
+        assertEquals(JackpotHelper.DEFAULT_LOSS_TRIBUTE, JackpotHelper.lossTributeRate(configService, guildId))
+    }
+
+    @Test
+    fun `lossTributeRate parses whole-number percent into a fraction`() {
+        configReturns("25")
+
+        assertEquals(0.25, JackpotHelper.lossTributeRate(configService, guildId), 1e-9)
+    }
+
+    @Test
+    fun `lossTributeRate clamps above MAX_LOSS_TRIBUTE`() {
+        configReturns("99")
+
+        assertEquals(JackpotHelper.MAX_LOSS_TRIBUTE, JackpotHelper.lossTributeRate(configService, guildId))
+    }
+
+    @Test
+    fun `lossTributeRate falls back to default on unparseable value`() {
+        configReturns("bogus")
+
+        assertEquals(JackpotHelper.DEFAULT_LOSS_TRIBUTE, JackpotHelper.lossTributeRate(configService, guildId))
+    }
+
+    @Test
+    fun `lossTributeRate accepts zero (admin disables tribute entirely)`() {
+        configReturns("0")
+
+        assertEquals(0.0, JackpotHelper.lossTributeRate(configService, guildId), 1e-9)
+    }
+
+    @Test
+    fun `divertOnLoss deposits floor(stake * default rate) into the pool`() {
+        configReturns(null)  // 10 % default
+
+        val tribute = JackpotHelper.divertOnLoss(jackpotService, configService, guildId, stake = 100L)
+
+        assertEquals(10L, tribute)
+        verify(exactly = 1) { jackpotService.addToPool(guildId, 10L) }
+    }
+
+    @Test
+    fun `divertOnLoss honours the per-guild override`() {
+        configReturns("25")  // 25 %
+
+        val tribute = JackpotHelper.divertOnLoss(jackpotService, configService, guildId, stake = 200L)
+
+        assertEquals(50L, tribute)
+        verify(exactly = 1) { jackpotService.addToPool(guildId, 50L) }
+    }
+
+    @Test
+    fun `divertOnLoss is a no-op when admin set rate to zero`() {
+        configReturns("0")
+
+        val tribute = JackpotHelper.divertOnLoss(jackpotService, configService, guildId, stake = 1_000L)
+
+        assertEquals(0L, tribute)
+        verify(exactly = 0) { jackpotService.addToPool(any(), any()) }
+    }
+
+    @Test
+    fun `divertOnLoss is a no-op when the floor produces zero`() {
+        configReturns(null)  // 10 % default → floor(9 * 0.10) = 0
+
+        val tribute = JackpotHelper.divertOnLoss(jackpotService, configService, guildId, stake = 9L)
+
+        assertEquals(0L, tribute)
+        verify(exactly = 0) { jackpotService.addToPool(any(), any()) }
+    }
+
+    @Test
+    fun `divertOnLoss ignores non-positive stakes`() {
+        configReturns(null)
+
+        assertEquals(0L, JackpotHelper.divertOnLoss(jackpotService, configService, guildId, stake = 0L))
+        assertEquals(0L, JackpotHelper.divertOnLoss(jackpotService, configService, guildId, stake = -10L))
+        verify(exactly = 0) { jackpotService.addToPool(any(), any()) }
+    }
+}

--- a/database/src/test/kotlin/database/service/ScratchServiceTest.kt
+++ b/database/src/test/kotlin/database/service/ScratchServiceTest.kt
@@ -19,6 +19,7 @@ class ScratchServiceTest {
     private lateinit var jackpotService: JackpotService
     private lateinit var tradeService: EconomyTradeService
     private lateinit var marketService: TobyCoinMarketService
+    private lateinit var configService: ConfigService
     private lateinit var card: ScratchCard
     private lateinit var service: ScratchService
 
@@ -31,8 +32,9 @@ class ScratchServiceTest {
         jackpotService = mockk(relaxed = true)
         tradeService = mockk(relaxed = true)
         marketService = mockk(relaxed = true)
+        configService = mockk(relaxed = true)
         card = mockk(relaxed = true)
-        service = ScratchService(userService, jackpotService, tradeService, marketService, card, Random(0))
+        service = ScratchService(userService, jackpotService, tradeService, marketService, configService, card, Random(0))
     }
 
     private fun userWithBalance(balance: Long): UserDto =
@@ -108,5 +110,24 @@ class ScratchServiceTest {
         every { userService.getUserByIdForUpdate(discordId, guildId) } returns null
         val outcome = service.scratch(discordId, guildId, stake = 100L)
         assertEquals(ScratchService.ScratchOutcome.UnknownUser, outcome)
+    }
+
+    @Test
+    fun `loss tributes 10 percent of the stake into the jackpot pool`() {
+        val user = userWithBalance(500L)
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns user
+        every { card.scratch(any()) } returns ScratchCard.Scratch(
+            cells = List(9) { SlotMachine.Symbol.CHERRY },
+            winningSymbol = null,
+            matchCount = 0,
+            multiplier = 0L
+        )
+        every { userService.updateUser(any()) } returns user
+
+        val outcome = service.scratch(discordId, guildId, stake = 100L)
+
+        val lose = assertInstanceOf(ScratchService.ScratchOutcome.Lose::class.java, outcome)
+        assertEquals(10L, lose.lossTribute)
+        verify(exactly = 1) { jackpotService.addToPool(guildId, 10L) }
     }
 }

--- a/database/src/test/kotlin/database/service/SlotsServiceTest.kt
+++ b/database/src/test/kotlin/database/service/SlotsServiceTest.kt
@@ -18,6 +18,7 @@ class SlotsServiceTest {
     private lateinit var jackpotService: JackpotService
     private lateinit var tradeService: EconomyTradeService
     private lateinit var marketService: TobyCoinMarketService
+    private lateinit var configService: ConfigService
     private lateinit var machine: SlotMachine
     private lateinit var service: SlotsService
 
@@ -30,8 +31,9 @@ class SlotsServiceTest {
         jackpotService = mockk(relaxed = true)
         tradeService = mockk(relaxed = true)
         marketService = mockk(relaxed = true)
+        configService = mockk(relaxed = true)
         machine = mockk(relaxed = true)
-        service = SlotsService(userService, jackpotService, tradeService, marketService, machine, Random(0))
+        service = SlotsService(userService, jackpotService, tradeService, marketService, configService, machine, Random(0))
     }
 
     private fun userWithBalance(balance: Long): UserDto {
@@ -129,5 +131,22 @@ class SlotsServiceTest {
 
         val rej = assertInstanceOf(SlotsService.SpinOutcome.InsufficientCredits::class.java, outcome)
         assertEquals(0L, rej.have)
+    }
+
+    @Test
+    fun `loss tributes 10 percent of the stake into the jackpot pool`() {
+        val user = userWithBalance(500L)
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns user
+        every { machine.pull(any()) } returns SlotMachine.Pull(
+            symbols = listOf(SlotMachine.Symbol.CHERRY, SlotMachine.Symbol.LEMON, SlotMachine.Symbol.BELL),
+            multiplier = 0L
+        )
+        every { userService.updateUser(any()) } returns user
+
+        val outcome = service.spin(discordId, guildId, stake = 100L)
+
+        val lose = assertInstanceOf(SlotsService.SpinOutcome.Lose::class.java, outcome)
+        assertEquals(10L, lose.lossTribute, "10 % of 100 stake → 10 to jackpot")
+        verify(exactly = 1) { jackpotService.addToPool(guildId, 10L) }
     }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/moderation/SetConfigCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/moderation/SetConfigCommand.kt
@@ -155,7 +155,7 @@ class SetConfigCommand @Autowired constructor(
         deleteDelay: Int
     ) {
         val pct = optionMapping.asInt
-        if (pct < 0 || pct > 50) {
+        if (pct !in 0..50) {
             event.hook.sendMessage("Tribute percent must be between 0 and 50 (default 10).")
                 .setEphemeral(true).queue(invokeDeleteOnMessageResponse(deleteDelay))
             return

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/moderation/SetConfigCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/moderation/SetConfigCommand.kt
@@ -59,6 +59,7 @@ class SetConfigCommand @Autowired constructor(
                 ConfigDto.Configurations.LEADERBOARD_CHANNEL -> setLeaderboardChannel(event, deleteDelay)
                 ConfigDto.Configurations.ACTIVITY_TRACKING -> setActivityTracking(event, optionMapping, deleteDelay)
                 ConfigDto.Configurations.ACTIVITY_TRACKING_NOTIFIED -> Unit
+                ConfigDto.Configurations.JACKPOT_LOSS_TRIBUTE_PCT -> setJackpotLossTribute(event, optionMapping, deleteDelay)
             }
         }
     }
@@ -148,6 +149,30 @@ class SetConfigCommand @Autowired constructor(
         event.hook.sendMessage(messageToSend).queue(invokeDeleteOnMessageResponse(deleteDelay))
     }
 
+    private fun setJackpotLossTribute(
+        event: SlashCommandInteractionEvent,
+        optionMapping: OptionMapping,
+        deleteDelay: Int
+    ) {
+        val pct = optionMapping.asInt
+        if (pct < 0 || pct > 50) {
+            event.hook.sendMessage("Tribute percent must be between 0 and 50 (default 10).")
+                .setEphemeral(true).queue(invokeDeleteOnMessageResponse(deleteDelay))
+            return
+        }
+        val configValue = ConfigDto.Configurations.JACKPOT_LOSS_TRIBUTE_PCT.configValue
+        val guildId = event.guild?.id ?: return
+        val newConfigDto = ConfigDto(configValue, pct.toString(), guildId)
+        val existing = configService.getConfigByName(configValue, guildId)
+        if (existing != null && existing.guildId == newConfigDto.guildId) {
+            configService.updateConfig(newConfigDto)
+        } else {
+            configService.createNewConfig(newConfigDto)
+        }
+        event.hook.sendMessage("Jackpot loss-tribute set to $pct % of every lost casino stake.")
+            .queue(invokeDeleteOnMessageResponse(deleteDelay))
+    }
+
     private fun setMove(event: SlashCommandInteractionEvent, deleteDelay: Int) {
         val movePropertyName = ConfigDto.Configurations.MOVE.configValue
         val guildId = event.guild?.id ?: return
@@ -213,6 +238,12 @@ class SetConfigCommand @Autowired constructor(
                 OptionType.BOOLEAN,
                 ConfigDto.Configurations.ACTIVITY_TRACKING.name.lowercase(Locale.getDefault()),
                 "Enable game-activity tracking in this server (users can opt out individually)",
+                false
+            ),
+            OptionData(
+                OptionType.INTEGER,
+                ConfigDto.Configurations.JACKPOT_LOSS_TRIBUTE_PCT.name.lowercase(Locale.getDefault()),
+                "Percent (0-50) of every lost casino stake routed into the per-guild jackpot pool. Default 10.",
                 false
             )
         )

--- a/web/src/main/kotlin/web/controller/CoinflipController.kt
+++ b/web/src/main/kotlin/web/controller/CoinflipController.kt
@@ -121,7 +121,8 @@ class CoinflipController(
                     newBalance = outcome.newBalance,
                     win = false,
                     soldTobyCoins = outcome.soldTobyCoins.takeIf { it > 0L },
-                    newPrice = outcome.newPrice
+                    newPrice = outcome.newPrice,
+                    lossTribute = outcome.lossTribute.takeIf { it > 0L }
                 )
             )
 
@@ -163,5 +164,6 @@ data class FlipResponse(
     val win: Boolean? = null,
     val jackpotPayout: Long? = null,
     val soldTobyCoins: Long? = null,
-    val newPrice: Double? = null
+    val newPrice: Double? = null,
+    val lossTribute: Long? = null
 )

--- a/web/src/main/kotlin/web/controller/DiceController.kt
+++ b/web/src/main/kotlin/web/controller/DiceController.kt
@@ -117,7 +117,8 @@ class DiceController(
                     newBalance = outcome.newBalance,
                     win = false,
                     soldTobyCoins = outcome.soldTobyCoins.takeIf { it > 0L },
-                    newPrice = outcome.newPrice
+                    newPrice = outcome.newPrice,
+                    lossTribute = outcome.lossTribute.takeIf { it > 0L }
                 )
             )
 
@@ -157,5 +158,6 @@ data class RollResponse(
     val win: Boolean? = null,
     val jackpotPayout: Long? = null,
     val soldTobyCoins: Long? = null,
-    val newPrice: Double? = null
+    val newPrice: Double? = null,
+    val lossTribute: Long? = null
 )

--- a/web/src/main/kotlin/web/controller/HighlowController.kt
+++ b/web/src/main/kotlin/web/controller/HighlowController.kt
@@ -172,7 +172,8 @@ class HighlowController(
                     newBalance = outcome.newBalance,
                     win = false,
                     soldTobyCoins = outcome.soldTobyCoins.takeIf { it > 0L },
-                    newPrice = outcome.newPrice
+                    newPrice = outcome.newPrice,
+                    lossTribute = outcome.lossTribute.takeIf { it > 0L }
                 )
             )
 
@@ -263,5 +264,6 @@ data class PlayResponse(
     val win: Boolean? = null,
     val jackpotPayout: Long? = null,
     val soldTobyCoins: Long? = null,
-    val newPrice: Double? = null
+    val newPrice: Double? = null,
+    val lossTribute: Long? = null
 )

--- a/web/src/main/kotlin/web/controller/ScratchController.kt
+++ b/web/src/main/kotlin/web/controller/ScratchController.kt
@@ -127,7 +127,8 @@ class ScratchController(
                     newBalance = outcome.newBalance,
                     win = false,
                     soldTobyCoins = outcome.soldTobyCoins.takeIf { it > 0L },
-                    newPrice = outcome.newPrice
+                    newPrice = outcome.newPrice,
+                    lossTribute = outcome.lossTribute.takeIf { it > 0L }
                 )
             )
 
@@ -166,5 +167,6 @@ data class ScratchResponse(
     val win: Boolean? = null,
     val jackpotPayout: Long? = null,
     val soldTobyCoins: Long? = null,
-    val newPrice: Double? = null
+    val newPrice: Double? = null,
+    val lossTribute: Long? = null
 )

--- a/web/src/main/kotlin/web/controller/SlotsController.kt
+++ b/web/src/main/kotlin/web/controller/SlotsController.kt
@@ -118,7 +118,8 @@ class SlotsController(
                     newBalance = outcome.newBalance,
                     win = false,
                     soldTobyCoins = outcome.soldTobyCoins.takeIf { it > 0L },
-                    newPrice = outcome.newPrice
+                    newPrice = outcome.newPrice,
+                    lossTribute = outcome.lossTribute.takeIf { it > 0L }
                 )
             )
 
@@ -168,7 +169,8 @@ data class SpinResponse(
     val win: Boolean? = null,
     val jackpotPayout: Long? = null,
     val soldTobyCoins: Long? = null,
-    val newPrice: Double? = null
+    val newPrice: Double? = null,
+    val lossTribute: Long? = null
 )
 
 data class PayoutRow(val symbols: String, val multiplier: String)

--- a/web/src/main/kotlin/web/service/ModerationWebService.kt
+++ b/web/src/main/kotlin/web/service/ModerationWebService.kt
@@ -273,6 +273,12 @@ class ModerationWebService(
             }
             ConfigDto.Configurations.ACTIVITY_TRACKING_NOTIFIED ->
                 return "This flag is managed automatically and cannot be edited."
+            ConfigDto.Configurations.JACKPOT_LOSS_TRIBUTE_PCT -> {
+                val n = rawValue.trim().toIntOrNull()
+                    ?: return "Value must be a whole number percentage (0-50)."
+                if (n < 0 || n > 50) return "Value must be between 0 and 50 (capped server-side)."
+                n.toString()
+            }
         }
 
         val guildIdString = guild.id

--- a/web/src/main/kotlin/web/service/ModerationWebService.kt
+++ b/web/src/main/kotlin/web/service/ModerationWebService.kt
@@ -276,7 +276,7 @@ class ModerationWebService(
             ConfigDto.Configurations.JACKPOT_LOSS_TRIBUTE_PCT -> {
                 val n = rawValue.trim().toIntOrNull()
                     ?: return "Value must be a whole number percentage (0-50)."
-                if (n < 0 || n > 50) return "Value must be between 0 and 50 (capped server-side)."
+                if (n !in 0..50) return "Value must be between 0 and 50 (capped server-side)."
                 n.toString()
             }
         }

--- a/web/src/main/resources/static/css/base.css
+++ b/web/src/main/resources/static/css/base.css
@@ -437,6 +437,13 @@ td { font-size: 0.95rem; }
     text-shadow: 0 0 8px rgba(241, 196, 15, 0.4);
 }
 
+/* "+N to jackpot" suffix on lose lines — same accent gold as the
+   banner so the visual loop reads "loss → pool grows". */
+.casino-loss-tribute {
+    color: #f1c40f;
+    font-size: 0.85rem;
+}
+
 /* Grow tap targets on any touch device without ballooning desktop buttons */
 @media (hover: none) and (pointer: coarse) {
     .btn-sm { padding: 8px 14px; min-height: 40px; }

--- a/web/src/main/resources/static/js/casino-jackpot.js
+++ b/web/src/main/resources/static/js/casino-jackpot.js
@@ -28,7 +28,18 @@
         return jackpotPrefixHtml(body.jackpotPayout) + winLineHtml;
     }
 
-    const api = { isJackpotHit, jackpotPrefixHtml, renderWinHtml };
+    /**
+     * Suffix appended to a lose-line when the loss tributed credits
+     * into the per-guild jackpot pool. Empty string when no tribute
+     * (e.g. tiny stake floored to zero, or admin set tribute to 0 %).
+     */
+    function lossTributeSuffix(body) {
+        if (!body || typeof body.lossTribute !== 'number' || body.lossTribute <= 0) return '';
+        return ' &middot; <span class="casino-loss-tribute">+' +
+            body.lossTribute + ' to jackpot</span>';
+    }
+
+    const api = { isJackpotHit, jackpotPrefixHtml, renderWinHtml, lossTributeSuffix };
 
     // Browser global so each game's IIFE-style JS can reach it without
     // bundler plumbing.

--- a/web/src/main/resources/static/js/coinflip.js
+++ b/web/src/main/resources/static/js/coinflip.js
@@ -19,8 +19,12 @@ function renderCoinflipResult(resultEl, body) {
         resultEl.innerHTML = topUpPrefix + withJackpot;
     } else {
         resultEl.classList.add('coinflip-result-lose');
+        const tributeSuffix = (typeof window !== 'undefined' && window.TobyJackpot)
+            ? window.TobyJackpot.lossTributeSuffix(body)
+            : '';
         resultEl.innerHTML = topUpPrefix + '<strong>' + landedLabel + '.</strong> You called ' +
-            predictedLabel + ' &middot; lost <strong>' + Math.abs(body.net) + ' credits</strong>';
+            predictedLabel + ' &middot; lost <strong>' + Math.abs(body.net) + ' credits</strong>' +
+            tributeSuffix;
     }
 }
 

--- a/web/src/main/resources/static/js/dice.js
+++ b/web/src/main/resources/static/js/dice.js
@@ -17,8 +17,12 @@ function renderDiceResult(resultEl, body) {
         resultEl.innerHTML = topUpPrefix + withJackpot;
     } else {
         resultEl.classList.add('dice-result-lose');
+        const tributeSuffix = (typeof window !== 'undefined' && window.TobyJackpot)
+            ? window.TobyJackpot.lossTributeSuffix(body)
+            : '';
         resultEl.innerHTML = topUpPrefix + '<strong>' + body.landed + '.</strong> You called ' +
-            body.predicted + ' &middot; lost <strong>' + Math.abs(body.net) + ' credits</strong>';
+            body.predicted + ' &middot; lost <strong>' + Math.abs(body.net) + ' credits</strong>' +
+            tributeSuffix;
     }
 }
 

--- a/web/src/main/resources/static/js/highlow.js
+++ b/web/src/main/resources/static/js/highlow.js
@@ -31,10 +31,14 @@ function renderHighlowResult(resultEl, body) {
     } else {
         resultEl.classList.add('highlow-result-lose');
         const tie = body.next === body.anchor;
+        const tributeSuffix = (typeof window !== 'undefined' && window.TobyJackpot)
+            ? window.TobyJackpot.lossTributeSuffix(body)
+            : '';
         resultEl.innerHTML = topUpPrefix + '<strong>' + highlowCardLabel(body.next) + '</strong> ' +
             (tie ? '=' : (body.next > body.anchor ? '>' : '<')) +
             ' <strong>' + highlowCardLabel(body.anchor) + '</strong> &middot; you called ' +
-            dirLabel + ' &middot; lost <strong>' + Math.abs(body.net) + ' credits</strong>';
+            dirLabel + ' &middot; lost <strong>' + Math.abs(body.net) + ' credits</strong>' +
+            tributeSuffix;
     }
 }
 

--- a/web/src/main/resources/static/js/scratch.js
+++ b/web/src/main/resources/static/js/scratch.js
@@ -20,8 +20,11 @@ function renderScratchResult(resultEl, body, matchThreshold, balanceEl) {
         resultEl.innerHTML = topUpPrefix + withJackpot;
     } else {
         resultEl.classList.add('scratch-result-lose');
+        const tributeSuffix = (typeof window !== 'undefined' && window.TobyJackpot)
+            ? window.TobyJackpot.lossTributeSuffix(body)
+            : '';
         resultEl.innerHTML = topUpPrefix + 'No ' + matchThreshold + '-of-a-kind &middot; lost <strong>' +
-            Math.abs(body.net) + ' credits</strong>';
+            Math.abs(body.net) + ' credits</strong>' + tributeSuffix;
     }
     if (typeof body.newBalance === 'number' && balanceEl) balanceEl.textContent = body.newBalance;
 }

--- a/web/src/main/resources/static/js/slots.js
+++ b/web/src/main/resources/static/js/slots.js
@@ -18,7 +18,11 @@ function renderSlotsResult(resultEl, body) {
         resultEl.innerHTML = topUpPrefix + withJackpot;
     } else {
         resultEl.classList.add('slots-result-lose');
-        resultEl.innerHTML = topUpPrefix + 'Lost <strong>' + Math.abs(body.net) + ' credits</strong>';
+        const tributeSuffix = (typeof window !== 'undefined' && window.TobyJackpot)
+            ? window.TobyJackpot.lossTributeSuffix(body)
+            : '';
+        resultEl.innerHTML = topUpPrefix + 'Lost <strong>' + Math.abs(body.net) +
+            ' credits</strong>' + tributeSuffix;
     }
 }
 

--- a/web/src/test/js/casino-jackpot.test.js
+++ b/web/src/test/js/casino-jackpot.test.js
@@ -2,6 +2,7 @@ const {
     isJackpotHit,
     jackpotPrefixHtml,
     renderWinHtml,
+    lossTributeSuffix,
 } = require('../../main/resources/static/js/casino-jackpot');
 
 // ---------------------------------------------------------------------------
@@ -101,5 +102,29 @@ describe('renderWinHtml', () => {
         renderWinHtml(resultEl, null, 'slots-result-jackpot', winLine);
 
         expect(resultEl.classList.length).toBe(0);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// lossTributeSuffix
+// ---------------------------------------------------------------------------
+
+describe('lossTributeSuffix', () => {
+    test('renders a "+N to jackpot" span with the casino-loss-tribute class', () => {
+        const html = lossTributeSuffix({ lossTribute: 10 });
+        expect(html).toContain('+10 to jackpot');
+        expect(html).toContain('casino-loss-tribute');
+        expect(html.startsWith(' &middot; ')).toBe(true);
+    });
+
+    test('returns empty string when no tribute', () => {
+        expect(lossTributeSuffix({ lossTribute: 0 })).toBe('');
+        expect(lossTributeSuffix({})).toBe('');
+        expect(lossTributeSuffix(null)).toBe('');
+        expect(lossTributeSuffix({ lossTribute: -5 })).toBe('');
+    });
+
+    test('returns empty string for non-numeric tribute', () => {
+        expect(lossTributeSuffix({ lossTribute: '10' })).toBe('');
     });
 });

--- a/web/src/test/js/coinflip.test.js
+++ b/web/src/test/js/coinflip.test.js
@@ -42,4 +42,12 @@ describe('renderCoinflipResult', () => {
     test('returns early on missing result element', () => {
         expect(() => renderCoinflipResult(null, { win: true })).not.toThrow();
     });
+
+    test('lose with lossTribute appends "+N to jackpot" suffix', () => {
+        renderCoinflipResult(resultEl, {
+            win: false, landed: 'TAILS', predicted: 'HEADS', net: -50, lossTribute: 5
+        });
+
+        expect(resultEl.innerHTML).toContain('+5 to jackpot');
+    });
 });

--- a/web/src/test/js/dice.test.js
+++ b/web/src/test/js/dice.test.js
@@ -32,4 +32,12 @@ describe('renderDiceResult', () => {
         expect(resultEl.classList.contains('dice-result-jackpot')).toBe(true);
         expect(resultEl.innerHTML).toContain('+2000 credits');
     });
+
+    test('lose with lossTribute appends "+N to jackpot" suffix', () => {
+        renderDiceResult(resultEl, {
+            win: false, landed: 2, predicted: 4, net: -100, lossTribute: 10
+        });
+
+        expect(resultEl.innerHTML).toContain('+10 to jackpot');
+    });
 });

--- a/web/src/test/js/highlow.test.js
+++ b/web/src/test/js/highlow.test.js
@@ -57,4 +57,12 @@ describe('renderHighlowResult', () => {
         expect(resultEl.classList.contains('highlow-result-jackpot')).toBe(true);
         expect(resultEl.innerHTML).toContain('+1500 credits');
     });
+
+    test('lose with lossTribute appends "+N to jackpot" suffix', () => {
+        renderHighlowResult(resultEl, {
+            win: false, anchor: 7, next: 7, direction: 'HIGHER', net: -50, lossTribute: 5
+        });
+
+        expect(resultEl.innerHTML).toContain('+5 to jackpot');
+    });
 });

--- a/web/src/test/js/scratch.test.js
+++ b/web/src/test/js/scratch.test.js
@@ -49,4 +49,12 @@ describe('renderScratchResult', () => {
 
         expect(balanceEl.textContent).toBe('500');
     });
+
+    test('lose with lossTribute appends "+N to jackpot" suffix', () => {
+        renderScratchResult(resultEl, {
+            win: false, net: -100, newBalance: 900, lossTribute: 10
+        }, 5, balanceEl);
+
+        expect(resultEl.innerHTML).toContain('+10 to jackpot');
+    });
 });

--- a/web/src/test/js/slots.test.js
+++ b/web/src/test/js/slots.test.js
@@ -59,4 +59,19 @@ describe('renderSlotsResult', () => {
     test('returns early on missing result element', () => {
         expect(() => renderSlotsResult(null, { win: true })).not.toThrow();
     });
+
+    test('lose with lossTribute appends "+N to jackpot" suffix', () => {
+        renderSlotsResult(resultEl, { win: false, net: -100, symbols: [], lossTribute: 10 });
+
+        expect(resultEl.classList.contains('slots-result-lose')).toBe(true);
+        expect(resultEl.innerHTML).toContain('100 credits');
+        expect(resultEl.innerHTML).toContain('+10 to jackpot');
+        expect(resultEl.innerHTML).toContain('casino-loss-tribute');
+    });
+
+    test('lose with no lossTribute renders no suffix', () => {
+        renderSlotsResult(resultEl, { win: false, net: -100, symbols: [] });
+
+        expect(resultEl.innerHTML).not.toContain('to jackpot');
+    });
 });

--- a/web/src/test/kotlin/web/controller/CoinflipControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/CoinflipControllerTest.kt
@@ -183,4 +183,19 @@ class CoinflipControllerTest {
 
         assertEquals(null, response.body!!.jackpotPayout)
     }
+
+    @Test
+    fun `lose with loss tribute surfaces lossTribute on the response`() {
+        every { coinflipService.flip(discordId, guildId, 100L, Coinflip.Side.HEADS) } returns FlipOutcome.Lose(
+            stake = 100L,
+            landed = Coinflip.Side.TAILS,
+            predicted = Coinflip.Side.HEADS,
+            newBalance = 900L,
+            lossTribute = 10L
+        )
+
+        val response = controller.flip(guildId, FlipRequest(side = "HEADS", stake = 100L), user)
+
+        assertEquals(10L, response.body!!.lossTribute)
+    }
 }

--- a/web/src/test/kotlin/web/controller/DiceControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/DiceControllerTest.kt
@@ -142,4 +142,15 @@ class DiceControllerTest {
 
         assertEquals(null, response.body!!.jackpotPayout)
     }
+
+    @Test
+    fun `lose with loss tribute surfaces lossTribute on the response`() {
+        every { diceService.roll(discordId, guildId, 100L, 4) } returns RollOutcome.Lose(
+            stake = 100L, landed = 1, predicted = 4, newBalance = 900L, lossTribute = 10L
+        )
+
+        val response = controller.roll(guildId, RollRequest(prediction = 4, stake = 100L), user)
+
+        assertEquals(10L, response.body!!.lossTribute)
+    }
 }

--- a/web/src/test/kotlin/web/controller/HighlowControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/HighlowControllerTest.kt
@@ -264,8 +264,10 @@ class HighlowControllerTest {
     @Test
     fun `lose with loss tribute surfaces lossTribute on the response`() {
         session.setAttribute(anchorKey, 13)
+        session.setAttribute(stakeKey, 50L)
+        session.setAttribute(autoTopUpKey, false)
         every {
-            highlowService.play(discordId, guildId, 50L, Highlow.Direction.HIGHER, 13)
+            highlowService.play(discordId, guildId, 50L, Highlow.Direction.HIGHER, 13, false)
         } returns PlayOutcome.Lose(
             stake = 50L,
             anchor = 13,
@@ -278,7 +280,7 @@ class HighlowControllerTest {
 
         val response = controller.play(
             guildId,
-            PlayRequest(direction = "HIGHER", stake = 50L),
+            PlayRequest(direction = "HIGHER"),
             user,
             session
         )

--- a/web/src/test/kotlin/web/controller/HighlowControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/HighlowControllerTest.kt
@@ -261,6 +261,31 @@ class HighlowControllerTest {
         assertEquals(4_000L, response.body!!.jackpotPayout)
     }
 
+    @Test
+    fun `lose with loss tribute surfaces lossTribute on the response`() {
+        session.setAttribute(anchorKey, 13)
+        every {
+            highlowService.play(discordId, guildId, 50L, Highlow.Direction.HIGHER, 13)
+        } returns PlayOutcome.Lose(
+            stake = 50L,
+            anchor = 13,
+            next = 7,
+            direction = Highlow.Direction.HIGHER,
+            newBalance = 950L,
+            lossTribute = 5L
+        )
+        every { highlowService.dealAnchor() } returns 4
+
+        val response = controller.play(
+            guildId,
+            PlayRequest(direction = "HIGHER", stake = 50L),
+            user,
+            session
+        )
+
+        assertEquals(5L, response.body!!.lossTribute)
+    }
+
     private fun inMemorySession(): HttpSession {
         val store = HashMap<String, Any?>()
         return mockk(relaxed = true) {

--- a/web/src/test/kotlin/web/controller/ScratchControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/ScratchControllerTest.kt
@@ -135,4 +135,18 @@ class ScratchControllerTest {
 
         assertEquals(6_000L, response.body!!.jackpotPayout)
     }
+
+    @Test
+    fun `lose with loss tribute surfaces lossTribute on the response`() {
+        every { scratchService.scratch(discordId, guildId, 100L) } returns ScratchOutcome.Lose(
+            stake = 100L,
+            cells = List(9) { SlotMachine.Symbol.CHERRY },
+            newBalance = 900L,
+            lossTribute = 10L
+        )
+
+        val response = controller.scratch(guildId, ScratchRequest(stake = 100L), user)
+
+        assertEquals(10L, response.body!!.lossTribute)
+    }
 }

--- a/web/src/test/kotlin/web/controller/SlotsControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/SlotsControllerTest.kt
@@ -186,4 +186,33 @@ class SlotsControllerTest {
 
         assertEquals(null, response.body!!.jackpotPayout, "zero jackpot is omitted from the JSON shape")
     }
+
+    @Test
+    fun `lose with loss tribute surfaces lossTribute on the response`() {
+        every { slotsService.spin(discordId, guildId, 100L) } returns SpinOutcome.Lose(
+            stake = 100L,
+            symbols = listOf(SlotMachine.Symbol.CHERRY, SlotMachine.Symbol.LEMON, SlotMachine.Symbol.BELL),
+            newBalance = 900L,
+            lossTribute = 10L
+        )
+
+        val response = controller.spin(guildId, SpinRequest(stake = 100L), user)
+
+        assertEquals(10L, response.body!!.lossTribute)
+        assertEquals(false, response.body!!.win)
+    }
+
+    @Test
+    fun `lose with zero tribute (admin disabled) omits lossTribute`() {
+        every { slotsService.spin(discordId, guildId, 100L) } returns SpinOutcome.Lose(
+            stake = 100L,
+            symbols = listOf(SlotMachine.Symbol.CHERRY, SlotMachine.Symbol.LEMON, SlotMachine.Symbol.BELL),
+            newBalance = 900L,
+            lossTribute = 0L
+        )
+
+        val response = controller.spin(guildId, SpinRequest(stake = 100L), user)
+
+        assertEquals(null, response.body!!.lossTribute)
+    }
 }


### PR DESCRIPTION
## Summary

The jackpot pool currently grows from one source — trade fees. A server full of casino-only players watches the pool stay small until a trader shows up. This wires a **second feeder**: every minigame `Lose` deposits a fraction of the lost stake into the pool, so playing-but-not-winning visibly funds the next jackpot hit.

Player experience: the lose line gets a small `+N to jackpot` suffix in gold (matching the jackpot banner). House edge is unchanged — RTP from the player's perspective is the same; we just route a visible chunk of the existing loss into the pool instead of letting it vanish silently.

## Configurable per guild

The fraction is per-guild via the existing config table. Defaults to **10 %** when unset; capped at **50 %** so an admin can't drain every loss straight to the pool.

- Discord: `/setconfig jackpot_loss_tribute_pct:25` (owner only).
- Web admin: `ModerationWebService.updateConfig` validates 0-50.

## Stack

| Layer | Change |
|---|---|
| **Config** | New `ConfigDto.Configurations.JACKPOT_LOSS_TRIBUTE_PCT` enum entry. No migration needed — uses the existing `config` table. |
| **Helper** | `JackpotHelper.divertOnLoss(jackpotService, configService, guildId, stake)` mirrors `rollOnWin` (lock-then-mutate via `JackpotService.addToPool`). `JackpotHelper.lossTributeRate` reads the per-guild override, parses whole-number percent, falls back to `DEFAULT_LOSS_TRIBUTE` (0.10), clamps at `MAX_LOSS_TRIBUTE` (0.50). |
| **Services** | 5 minigame services gain `ConfigService` ctor dep + a one-line `divertOnLoss` call in their Lose branch. New `lossTribute: Long = 0L` field on each `Lose` data class (defaulted, so old test fixtures still compile). |
| **Discord** | `SetConfigCommand` gains a `setJackpotLossTribute` handler validating 0-50. |
| **Web admin** | `ModerationWebService.updateConfig` whens on the new enum value with the 0-50 validator. |
| **Controllers** | 5 controllers thread `lossTribute` through the response DTO (omitted when zero, like the existing `jackpotPayout`). |
| **JS** | New shared `TobyJackpot.lossTributeSuffix(body)` produces the `+N to jackpot` span on the lose line. 5 game JS files call it. |
| **CSS** | Single new `.casino-loss-tribute` rule in `base.css` — same gold as the jackpot banner so the loss-feeds-pool loop reads visually. |

## Tests

`:database:test` + `:web:test` both green.

- **`JackpotHelperTest`** *(new, 10 cases)* — rate parsing (default / parsed / clamped / unparseable / zero) and divert semantics (default / override / disabled / floor=0 / non-positive stake).
- **5 minigame service tests** gain `loss tributes 10 percent of the stake into the jackpot pool` — verifies `addToPool(guildId, 10L)` is called and the outcome carries `lossTribute = 10L`.
- **5 minigame controller tests** gain `lose with loss tribute surfaces lossTribute on the response`. Slots additionally tests the zero-tribute omission case.
- Updated 5 service test setups to inject the new `ConfigService` constructor parameter.

**Jest — 149/149 pass (was 140).**

- New `lossTributeSuffix` cases in `casino-jackpot.test.js`.
- Per-game "lose with lossTribute appends '+N to jackpot' suffix" case across slots / coinflip / dice / highlow / scratch.

## Test plan
- [x] `:database:test` and `:web:test` (offline)
- [x] `npm test` (149/149)
- [ ] Manual: open `/casino/{guildId}/slots`, set stake 100, spin until a Lose. Confirm "Lost 100 credits · +10 to jackpot" renders. Refresh the page — jackpot banner is +10.
- [ ] Manual: set stake 9 (below MIN_STAKE) — wager rejected with InvalidStake; doesn't reach the divert path. With stake 10 in a game, `floor(10 × 0.1) = 1` → tribute renders "+1".
- [ ] Manual (admin): `/setconfig jackpot_loss_tribute_pct:25` — Discord replies "Jackpot loss-tribute set to 25 % …". Subsequent losses tribute 25 %.
- [ ] Manual (admin): `/setconfig jackpot_loss_tribute_pct:0` — losses no longer tribute; lose line has no suffix.

## Out of scope
- Surfacing the cumulative tribute contribution on a player's history page (pool size on the casino banner is the only display).
- Per-game tribute rates (single uniform `JACKPOT_LOSS_TRIBUTE_PCT`).
- Real-time pool-counter update without a page reload after a tribute.

https://claude.ai/code/session_01JvuveFBoCvMFTK8XxXVN56

---
_Generated by [Claude Code](https://claude.ai/code/session_01JvuveFBoCvMFTK8XxXVN56)_