### PR TITLE
fix(economy): % indicator follows the active chart window, not just 1D

### DIFF
--- a/web/src/main/kotlin/web/service/EconomyWebService.kt
+++ b/web/src/main/kotlin/web/service/EconomyWebService.kt
@@ -43,15 +43,11 @@ class EconomyWebService(
         val guild = jda.getGuildById(guildId) ?: return null
         val market = tradeService.loadOrCreateMarket(guildId)
         val user = userService.getUserById(discordId, guildId)
-        val since = Instant.now().minus(Duration.ofDays(1))
-        val dayAgo = marketService.listHistory(guildId, since).firstOrNull()?.price
-        val change = dayAgo?.let { ((market.price - it) / it) * 100.0 }
 
         return EconomyView(
             guildName = guild.name,
             price = market.price,
             lastTickAt = market.lastTickAt,
-            change24h = change,
             coins = user?.tobyCoins ?: 0L,
             credits = user?.socialCredit ?: 0L,
             portfolioCredits = ((user?.tobyCoins ?: 0L).toDouble() * market.price).toLong()
@@ -123,7 +119,6 @@ data class EconomyView(
     val guildName: String,
     val price: Double,
     val lastTickAt: Instant,
-    val change24h: Double?,
     val coins: Long,
     val credits: Long,
     val portfolioCredits: Long

--- a/web/src/main/resources/static/js/economy-change.js
+++ b/web/src/main/resources/static/js/economy-change.js
@@ -1,0 +1,50 @@
+// Pure helpers for the percent-change indicator next to the market
+// price on /economy/{guildId}. Lives in its own module so the page IIFE
+// stays focused on chart wiring and so the math can be unit-tested
+// under jsdom (see web/src/test/js/economy-change.test.js).
+//
+// Browser callers reach this via window.TobyEconomyChange; tests pull
+// it in with require().
+
+(function (root) {
+    'use strict';
+
+    function computeChangePct(points) {
+        if (!points || points.length < 2) return null;
+        const first = points[0].price;
+        const last = points[points.length - 1].price;
+        if (!first) return null;
+        return ((last - first) / first) * 100;
+    }
+
+    function formatChangeText(pct, label) {
+        if (pct === null || pct === undefined || Number.isNaN(pct)) {
+            return 'no data yet';
+        }
+        const sign = pct >= 0 ? '+' : '';
+        return sign + pct.toFixed(2) + '% (' + label + ')';
+    }
+
+    function applyChange(el, points, label) {
+        if (!el) return;
+        const pct = computeChangePct(points);
+        el.classList.remove('up', 'down');
+        if (pct === null) {
+            el.textContent = 'no data yet';
+            return;
+        }
+        el.classList.add(pct >= 0 ? 'up' : 'down');
+        el.textContent = formatChangeText(pct, label);
+    }
+
+    const api = {
+        computeChangePct: computeChangePct,
+        formatChangeText: formatChangeText,
+        applyChange: applyChange,
+    };
+
+    if (root) root.TobyEconomyChange = api;
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = api;
+    }
+})(typeof window !== 'undefined' ? window : null);

--- a/web/src/main/resources/static/js/economy.js
+++ b/web/src/main/resources/static/js/economy.js
@@ -21,6 +21,7 @@
     const windowButtons = document.querySelectorAll('#economy-windows button');
     const recentTradesPanel = document.getElementById('economy-recent-trades-panel');
     const recentTradesList = document.getElementById('economy-recent-trades');
+    const priceChangeEl = document.querySelector('.economy-price-change');
     // Cap is generous — the panel scrolls (see economy.css), so the
     // only ceiling is rendering cost on very busy markets.
     const RECENT_TRADES_LIMIT = 100;
@@ -197,6 +198,18 @@
         };
     }
 
+    function activeWindowLabel(windowCode) {
+        // Reuse the button text so the indicator stays in sync with the
+        // segmented control (1D / 5D / 1M / 3M / 1Y / ALL) without keeping
+        // a parallel label table around.
+        for (let i = 0; i < windowButtons.length; i++) {
+            if (windowButtons[i].dataset.window === windowCode) {
+                return (windowButtons[i].textContent || windowCode).trim();
+            }
+        }
+        return windowCode;
+    }
+
     function loadHistory(windowCode) {
         currentWindow = windowCode;
         windowButtons.forEach(function (b) {
@@ -210,6 +223,9 @@
             const points = (body && body.points) || [];
             const trades = (body && body.trades) || [];
             renderRecentTrades(trades);
+            if (window.TobyEconomyChange) {
+                window.TobyEconomyChange.applyChange(priceChangeEl, points, activeWindowLabel(windowCode));
+            }
             if (points.length < 2) {
                 if (chart) { chart.destroy(); chart = null; }
                 if (empty) empty.hidden = false;

--- a/web/src/main/resources/templates/economy.html
+++ b/web/src/main/resources/templates/economy.html
@@ -15,12 +15,8 @@
         <div class="economy-price">
             <div class="economy-price-value" id="economy-price"
                  th:text="${#numbers.formatDecimal(view.price, 1, 2)}">0.00</div>
-            <div class="economy-price-change"
-                 th:if="${view.change24h != null}"
-                 th:classappend="${view.change24h >= 0 ? 'up' : 'down'}"
-                 th:text="${#numbers.formatDecimal(view.change24h, 1, 2)} + '% (24h)'">0%</div>
-            <div class="economy-price-change muted"
-                 th:unless="${view.change24h != null}">no 24h data yet</div>
+            <!-- Populated by economy.js once /history responds; tracks the active chart window. -->
+            <div class="economy-price-change">&nbsp;</div>
         </div>
     </div>
 
@@ -98,6 +94,7 @@
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.4/dist/chart.umd.min.js"></script>
 <script th:src="@{/js/api.js}"></script>
 <script th:src="@{/js/toasts.js}"></script>
+<script th:src="@{/js/economy-change.js}"></script>
 <script th:src="@{/js/economy.js}"></script>
 </body>
 </html>

--- a/web/src/test/js/economy-change.test.js
+++ b/web/src/test/js/economy-change.test.js
@@ -1,0 +1,114 @@
+// Proves the market-page % indicator tracks the active chart window
+// instead of being stuck on a 24h delta. The browser code reads the
+// label from the active button's text content; here we pass the label
+// in directly to keep the helper assertions pure.
+
+const TobyEconomyChange = require('../../main/resources/static/js/economy-change');
+
+describe('computeChangePct', () => {
+    test('returns null when fewer than two points are supplied', () => {
+        expect(TobyEconomyChange.computeChangePct([])).toBeNull();
+        expect(TobyEconomyChange.computeChangePct([{ t: 1, price: 10 }])).toBeNull();
+        expect(TobyEconomyChange.computeChangePct(null)).toBeNull();
+        expect(TobyEconomyChange.computeChangePct(undefined)).toBeNull();
+    });
+
+    test('returns null when the anchor price is zero (avoids /0)', () => {
+        const points = [{ t: 1, price: 0 }, { t: 2, price: 5 }];
+        expect(TobyEconomyChange.computeChangePct(points)).toBeNull();
+    });
+
+    test('uses first and last price regardless of intermediate noise', () => {
+        const points = [
+            { t: 1, price: 100 },
+            { t: 2, price: 999 },  // noise in the middle should not move the result
+            { t: 3, price: 50 },
+            { t: 4, price: 110 },
+        ];
+        expect(TobyEconomyChange.computeChangePct(points)).toBeCloseTo(10, 5);
+    });
+
+    test('returns a negative pct when the window ends below where it started', () => {
+        const points = [{ t: 1, price: 200 }, { t: 2, price: 150 }];
+        expect(TobyEconomyChange.computeChangePct(points)).toBeCloseTo(-25, 5);
+    });
+});
+
+describe('formatChangeText', () => {
+    test('prefixes positive deltas with + and tags the active window', () => {
+        expect(TobyEconomyChange.formatChangeText(12.345, '1D')).toBe('+12.35% (1D)');
+    });
+
+    test('keeps the leading minus sign on negative deltas', () => {
+        expect(TobyEconomyChange.formatChangeText(-3.2, '1Y')).toBe('-3.20% (1Y)');
+    });
+
+    test('renders zero as +0.00% rather than -0.00%', () => {
+        expect(TobyEconomyChange.formatChangeText(0, 'ALL')).toBe('+0.00% (ALL)');
+    });
+
+    test('falls back to "no data yet" for null / undefined / NaN', () => {
+        expect(TobyEconomyChange.formatChangeText(null, '1D')).toBe('no data yet');
+        expect(TobyEconomyChange.formatChangeText(undefined, '1D')).toBe('no data yet');
+        expect(TobyEconomyChange.formatChangeText(Number.NaN, '1D')).toBe('no data yet');
+    });
+});
+
+describe('applyChange', () => {
+    function makeEl() {
+        const el = document.createElement('div');
+        el.className = 'economy-price-change';
+        return el;
+    }
+
+    test('marks an up move with the .up class and a + signed label', () => {
+        const el = makeEl();
+        TobyEconomyChange.applyChange(el, [
+            { t: 1, price: 10 }, { t: 2, price: 12 }
+        ], '5D');
+        expect(el.classList.contains('up')).toBe(true);
+        expect(el.classList.contains('down')).toBe(false);
+        expect(el.textContent).toBe('+20.00% (5D)');
+    });
+
+    test('marks a down move with the .down class and a negative label', () => {
+        const el = makeEl();
+        TobyEconomyChange.applyChange(el, [
+            { t: 1, price: 10 }, { t: 2, price: 8 }
+        ], '1M');
+        expect(el.classList.contains('down')).toBe(true);
+        expect(el.classList.contains('up')).toBe(false);
+        expect(el.textContent).toBe('-20.00% (1M)');
+    });
+
+    test('clears a stale up/down class when later applied to a sparse window', () => {
+        const el = makeEl();
+        el.classList.add('up'); // simulate a previous render
+        TobyEconomyChange.applyChange(el, [{ t: 1, price: 10 }], '1Y');
+        expect(el.classList.contains('up')).toBe(false);
+        expect(el.classList.contains('down')).toBe(false);
+        expect(el.textContent).toBe('no data yet');
+    });
+
+    test('flips classes when the same element is re-applied with a different window', () => {
+        const el = makeEl();
+        TobyEconomyChange.applyChange(el, [
+            { t: 1, price: 10 }, { t: 2, price: 12 }
+        ], '1D');
+        expect(el.classList.contains('up')).toBe(true);
+        expect(el.textContent).toBe('+20.00% (1D)');
+
+        // Switching to a longer window where the trend is reversed should
+        // re-render both class and label cleanly — no leftover .up.
+        TobyEconomyChange.applyChange(el, [
+            { t: 1, price: 50 }, { t: 2, price: 30 }
+        ], 'ALL');
+        expect(el.classList.contains('up')).toBe(false);
+        expect(el.classList.contains('down')).toBe(true);
+        expect(el.textContent).toBe('-40.00% (ALL)');
+    });
+
+    test('is a no-op when the element is missing', () => {
+        expect(() => TobyEconomyChange.applyChange(null, [], '1D')).not.toThrow();
+    });
+});

--- a/web/src/test/kotlin/web/service/EconomyWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/EconomyWebServiceTest.kt
@@ -60,7 +60,6 @@ class EconomyWebServiceTest {
             socialCredit = 200L
             tobyCoins = 4L
         }
-        every { marketService.listHistory(guildId, any()) } returns emptyList()
 
         val view = service.getEconomyView(guildId, discordId)
 
@@ -69,7 +68,6 @@ class EconomyWebServiceTest {
         assertEquals(4L, view.coins)
         assertEquals(200L, view.credits)
         assertEquals(600L, view.portfolioCredits) // 4 coins * 150.0 = 600
-        assertNull(view.change24h)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- The percent-change next to the market price was computed server-side against a hardcoded 24h lookback (`Duration.ofDays(1)` in `EconomyWebService.getEconomyView`) and rendered once into the page header. Switching the chart window (1D / 5D / 1M / 3M / 1Y / ALL) updated the chart but left the indicator stuck on yesterday's delta.
- Now compute the change client-side from the price points already returned by `/economy/{guildId}/history?window=…` and update the header on every `loadHistory` call (window switches **and** the existing 30s auto-refresh). The label also follows the active button (`+12.34% (1Y)` etc.).
- Extracted the math into a small reusable module (`economy-change.js`) so it can be unit-tested under jsdom alongside the other casino helpers.
- Removed the now-redundant server-side `change24h` field from `EconomyView` and the corresponding test assertion.

## Files
- `web/src/main/resources/static/js/economy-change.js` (new) — `computeChangePct`, `formatChangeText`, `applyChange`.
- `web/src/main/resources/static/js/economy.js` — caches `.economy-price-change`, derives the active window label from the segmented button, applies the new helper inside `loadHistory`.
- `web/src/main/resources/templates/economy.html` — drops the static `% (24h)` suffix and loads the new helper module.
- `web/src/main/kotlin/web/service/EconomyWebService.kt` — drops the `change24h` field and the 1-day lookback.
- `web/src/test/kotlin/web/service/EconomyWebServiceTest.kt` — drops the `assertNull(view.change24h)` line.
- `web/src/test/js/economy-change.test.js` (new) — 13 jest cases covering the math, formatting and DOM toggling.

## Test plan
- [x] `npx jest` — 11 suites, 153 tests pass (including 13 new cases in `economy-change.test.js`).
- [x] `./gradlew :web:test --tests "web.service.EconomyWebServiceTest"` — green.
- [ ] Manual: open `/economy/{guildId}` for a guild with several days of history; confirm header reads `±X.XX% (1D)` matching the 1D chart slope.
- [ ] Manual: click 5D / 1M / 3M / 1Y / ALL; confirm both label and value update each time, with green/red colour matching the slope.
- [ ] Manual: on a guild with <2 ticks in the active window, header should read `no data yet` (muted) and the empty-chart overlay should appear.
- [ ] Manual: leave the page open >30s on a non-1D window; auto-refresh should keep the header on the active window's value (not snap back to 24h).

https://claude.ai/code/session_01JveXMBjJ4W7jY9q2gpwkeb

---
_Generated by [Claude Code](https://claude.ai/code/session_01JveXMBjJ4W7jY9q2gpwkeb)_