### PR TITLE
feat(titles): expand catalog with cheap, mid, and prestige tiers up to 1M

### DIFF
--- a/database/src/main/resources/db/migration/V20__more_titles.sql
+++ b/database/src/main/resources/db/migration/V20__more_titles.sql
@@ -1,0 +1,16 @@
+-- Extends the vanity-title catalog with cheap-entry, mid-band, and
+-- prestige tiers. The new top tier (1,000,000 credits) exists to give
+-- users sitting on inflated balances from a previously-bugged minigame
+-- a visible drain back into the shop.
+
+INSERT INTO title (label, cost, description, color_hex, hoisted) VALUES
+    ('🐣 Hatchling',          50,      'Just landed on the server.',                     '#95A5A6', FALSE),
+    ('☕ Caffeinated',         350,     'Knows the morning queue by name.',               '#6E4B3A', FALSE),
+    ('🎲 High Roller',        1200,    'Lives for the wager.',                           '#E74C3C', FALSE),
+    ('📈 Day Trader',         1750,    'Watches every TOBY tick.',                       '#16A085', FALSE),
+    ('💎 Diamond Hands',      3500,    'Wouldn''t sell, wouldn''t fold.',                '#B9F2FF', TRUE),
+    ('🏆 Champion',           25000,   'Top of the leaderboard.',                        '#D4AF37', TRUE),
+    ('🌟 Luminary',           100000,  'Outshines the rest.',                            '#F39C12', TRUE),
+    ('🐉 Dragon',             250000,  'Hoards the credits.',                            '#C0392B', TRUE),
+    ('🦅 Sovereign Eagle',    500000,  'Soars far above the citizens.',                  '#4A6FA5', TRUE),
+    ('🪐 Cosmic Comrade',     1000000, 'A balance beyond the stratosphere — drained.',   '#8E44AD', TRUE);


### PR DESCRIPTION
## Summary

- Adds 10 new purchasable titles in `V20__more_titles.sql`, spanning **50 → 1,000,000 credits**
- 1 cheap-entry tier, 4 mid-band gap-fillers, 5 prestige tiers above the existing 5,000-credit ceiling
- Top tier (🪐 Cosmic Comrade, 1,000,000) exists as a credit sink for users sitting on inflated balances from a previously-bugged minigame

### New rows

| Cost      | Label              | Hoisted |
|----------:|--------------------|:-------:|
|        50 | 🐣 Hatchling        |    no   |
|       350 | ☕ Caffeinated      |    no   |
|     1,200 | 🎲 High Roller      |    no   |
|     1,750 | 📈 Day Trader       |    no   |
|     3,500 | 💎 Diamond Hands    |   yes   |
|    25,000 | 🏆 Champion         |   yes   |
|   100,000 | 🌟 Luminary         |   yes   |
|   250,000 | 🐉 Dragon           |   yes   |
|   500,000 | 🦅 Sovereign Eagle  |   yes   |
| 1,000,000 | 🪐 Cosmic Comrade   |   yes   |

Combined catalog after this migration: **20 titles, range 50 → 1,000,000**.

### Why no other code changes

- `TitleDto.cost: Long` already covers values up to 9 quintillion.
- `/title shop` (Discord) and `GET /titles/{guildId}` (web) both iterate `titleService.listAll()` — auto-discovered.
- `TitlesWebService.buyTitle` deducts `title.cost` with no hard-coded ceiling; the "not enough credits" branch handles million-credit purchases naturally.
- `titles.html:53` pipes `t.colorHex` straight into inline CSS, so any hex code renders as-is.
- Existing tests build `TitleDto` fixtures inline; nothing asserts on the seeded count or labels.

## Test plan

- [x] `:database:test` — green
- [x] `:web:test` — green
- [ ] After deploy: `SELECT count(*) FROM title;` → 20 and `SELECT max(cost) FROM title;` → 1000000
- [ ] `/title shop` lists all 20 titles ordered by cost
- [ ] `GET /titles/{guildId}` renders the full table; 🐣 Hatchling first, 🪐 Cosmic Comrade last
- [ ] User with ~1.2M credits can buy 🪐 Cosmic Comrade; balance drops to ~200k
- [ ] User under 1M attempting 🪐 Cosmic Comrade hits the "Not enough credits" branch
- [ ] 💎 Diamond Hands and 🪐 Cosmic Comrade roles are hoisted; 🎲 High Roller is not

https://claude.ai/code/session_01JvuveFBoCvMFTK8XxXVN56

---
_Generated by [Claude Code](https://claude.ai/code/session_01JvuveFBoCvMFTK8XxXVN56)_