### PR TITLE
feat(economy): /tip and /duel social-PvP credit spends (Discord + web)

### DIFF
--- a/application/src/test/kotlin/integration/bot/ButtonManagerTest.kt
+++ b/application/src/test/kotlin/integration/bot/ButtonManagerTest.kt
@@ -70,6 +70,7 @@ class ButtonManagerTest {
     @Test
     fun testButtonManagerFindsAllButtons() {
         val availableButtons = listOf(
+            DuelButton::class.java,
             HighlowButton::class.java,
             InitiativeClearButton::class.java,
             InitiativeNextButton::class.java,
@@ -81,7 +82,7 @@ class ButtonManagerTest {
         )
 
         assertTrue(availableButtons.containsAll(buttonManager.buttons.map { it.javaClass }.toList()))
-        assertEquals(8, buttonManager.buttons.size)
+        assertEquals(9, buttonManager.buttons.size)
     }
 
     @Test

--- a/application/src/test/kotlin/integration/bot/CommandManagerTest.kt
+++ b/application/src/test/kotlin/integration/bot/CommandManagerTest.kt
@@ -11,9 +11,11 @@ import bot.toby.command.commands.dnd.RefreshCharacterCommand
 import bot.toby.command.commands.dnd.RollCommand
 import bot.toby.command.commands.economy.CoinflipCommand
 import bot.toby.command.commands.economy.DiceCommand
+import bot.toby.command.commands.economy.DuelCommand
 import bot.toby.command.commands.economy.HighlowCommand
 import bot.toby.command.commands.economy.ScratchCommand
 import bot.toby.command.commands.economy.SlotsCommand
+import bot.toby.command.commands.economy.TipCommand
 import bot.toby.command.commands.economy.TitleCommand
 import bot.toby.command.commands.economy.TobyCoinCommand
 import bot.toby.command.commands.fetch.DbdRandomKillerCommand
@@ -138,12 +140,14 @@ class CommandManagerTest {
             DiceCommand::class.java,
             HighlowCommand::class.java,
             ScratchCommand::class.java,
-            ActivityCommand::class.java
+            ActivityCommand::class.java,
+            TipCommand::class.java,
+            DuelCommand::class.java
         )
 
         Assertions.assertTrue(availableCommands.containsAll(commandManager.allCommands.map { it.javaClass }.toList()))
-        Assertions.assertEquals(51, commandManager.allCommands.size)
-        Assertions.assertEquals(51, commandManager.allSlashCommands.size)
+        Assertions.assertEquals(53, commandManager.allCommands.size)
+        Assertions.assertEquals(53, commandManager.allSlashCommands.size)
     }
 
     @Test

--- a/database/src/main/kotlin/database/dto/DuelLogDto.kt
+++ b/database/src/main/kotlin/database/dto/DuelLogDto.kt
@@ -1,0 +1,48 @@
+package database.dto
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.springframework.transaction.annotation.Transactional
+import java.io.Serializable
+import java.time.Instant
+
+@Entity
+@Table(name = "duel_log", schema = "public")
+@Transactional
+class DuelLogDto(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    var id: Long? = null,
+
+    @Column(name = "guild_id", nullable = false)
+    var guildId: Long = 0,
+
+    @Column(name = "initiator_discord_id", nullable = false)
+    var initiatorDiscordId: Long = 0,
+
+    @Column(name = "opponent_discord_id", nullable = false)
+    var opponentDiscordId: Long = 0,
+
+    @Column(name = "winner_discord_id", nullable = false)
+    var winnerDiscordId: Long = 0,
+
+    @Column(name = "loser_discord_id", nullable = false)
+    var loserDiscordId: Long = 0,
+
+    @Column(name = "stake", nullable = false)
+    var stake: Long = 0,
+
+    @Column(name = "pot", nullable = false)
+    var pot: Long = 0,
+
+    @Column(name = "loss_tribute", nullable = false)
+    var lossTribute: Long = 0,
+
+    @Column(name = "resolved_at", nullable = false)
+    var resolvedAt: Instant = Instant.now()
+) : Serializable

--- a/database/src/main/kotlin/database/dto/TipDailyDto.kt
+++ b/database/src/main/kotlin/database/dto/TipDailyDto.kt
@@ -1,0 +1,40 @@
+package database.dto
+
+import jakarta.persistence.*
+import org.springframework.transaction.annotation.Transactional
+import java.io.Serializable
+import java.time.LocalDate
+
+@NamedQueries(
+    NamedQuery(
+        name = "TipDailyDto.get",
+        query = "select d from TipDailyDto d " +
+                "where d.senderDiscordId = :senderDiscordId and d.guildId = :guildId and d.tipDate = :tipDate"
+    )
+)
+@Entity
+@Table(name = "tip_daily", schema = "public")
+@IdClass(TipDailyId::class)
+@Transactional
+class TipDailyDto(
+    @Id
+    @Column(name = "sender_discord_id")
+    var senderDiscordId: Long = 0,
+
+    @Id
+    @Column(name = "guild_id")
+    var guildId: Long = 0,
+
+    @Id
+    @Column(name = "tip_date")
+    var tipDate: LocalDate = LocalDate.now(),
+
+    @Column(name = "credits_sent", nullable = false)
+    var creditsSent: Long = 0
+) : Serializable
+
+data class TipDailyId(
+    var senderDiscordId: Long = 0,
+    var guildId: Long = 0,
+    var tipDate: LocalDate = LocalDate.now()
+) : Serializable

--- a/database/src/main/kotlin/database/dto/TipLogDto.kt
+++ b/database/src/main/kotlin/database/dto/TipLogDto.kt
@@ -1,0 +1,39 @@
+package database.dto
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.springframework.transaction.annotation.Transactional
+import java.io.Serializable
+import java.time.Instant
+
+@Entity
+@Table(name = "tip_log", schema = "public")
+@Transactional
+class TipLogDto(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    var id: Long? = null,
+
+    @Column(name = "guild_id", nullable = false)
+    var guildId: Long = 0,
+
+    @Column(name = "sender_discord_id", nullable = false)
+    var senderDiscordId: Long = 0,
+
+    @Column(name = "recipient_discord_id", nullable = false)
+    var recipientDiscordId: Long = 0,
+
+    @Column(name = "amount", nullable = false)
+    var amount: Long = 0,
+
+    @Column(name = "note")
+    var note: String? = null,
+
+    @Column(name = "created_at", nullable = false)
+    var createdAt: Instant = Instant.now()
+) : Serializable

--- a/database/src/main/kotlin/database/duel/PendingDuelRegistry.kt
+++ b/database/src/main/kotlin/database/duel/PendingDuelRegistry.kt
@@ -1,0 +1,94 @@
+package database.duel
+
+import jakarta.annotation.PreDestroy
+import org.springframework.stereotype.Component
+import java.time.Duration
+import java.time.Instant
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * In-memory book of pending duel offers (the 60-second Accept/Decline
+ * window between `/duel` and the opponent's button click). Shared
+ * across the whole Spring context so the Discord button handler and
+ * the web controller see the same offers — there is exactly one
+ * authoritative bean.
+ *
+ * Mid-flight offers are lost on bot restart. Acceptable since the TTL
+ * is 60 seconds and offers don't move credits until accepted.
+ */
+@Component
+class PendingDuelRegistry(
+    private val ttl: Duration = DEFAULT_TTL,
+    private val scheduler: ScheduledExecutorService = Executors.newScheduledThreadPool(2)
+) {
+    data class PendingDuel(
+        val id: Long,
+        val guildId: Long,
+        val initiatorDiscordId: Long,
+        val opponentDiscordId: Long,
+        val stake: Long,
+        val createdAt: Instant
+    )
+
+    private val offers = ConcurrentHashMap<Long, PendingDuel>()
+    private val seq = AtomicLong()
+
+    /**
+     * Stores a new pending offer with a unique id and schedules expiry
+     * at `now + ttl`. If the offer is still in the registry when the
+     * timer fires, [onTimeout] is invoked exactly once. If the offer
+     * was already consumed (accept) or cancelled (decline) before the
+     * timer fires, the timer is a no-op.
+     */
+    fun register(
+        guildId: Long,
+        initiatorDiscordId: Long,
+        opponentDiscordId: Long,
+        stake: Long,
+        createdAt: Instant = Instant.now(),
+        onTimeout: (PendingDuel) -> Unit = {}
+    ): PendingDuel {
+        val id = seq.incrementAndGet()
+        val offer = PendingDuel(
+            id = id,
+            guildId = guildId,
+            initiatorDiscordId = initiatorDiscordId,
+            opponentDiscordId = opponentDiscordId,
+            stake = stake,
+            createdAt = createdAt
+        )
+        offers[id] = offer
+        scheduler.schedule({
+            val expired = offers.remove(id)
+            if (expired != null) {
+                runCatching { onTimeout(expired) }
+            }
+        }, ttl.toMillis(), TimeUnit.MILLISECONDS)
+        return offer
+    }
+
+    /** Atomic remove for accept. Returns the offer or null if already gone. */
+    fun consumeForAccept(id: Long): PendingDuel? = offers.remove(id)
+
+    /** Atomic remove for decline. Returns the offer or null if already gone. */
+    fun cancel(id: Long): PendingDuel? = offers.remove(id)
+
+    /** All offers where [discordId] is the opponent — used by the web inbox. */
+    fun pendingForOpponent(discordId: Long, guildId: Long): List<PendingDuel> =
+        offers.values.filter { it.opponentDiscordId == discordId && it.guildId == guildId }
+
+    fun get(id: Long): PendingDuel? = offers[id]
+
+    @PreDestroy
+    fun shutdown() {
+        scheduler.shutdownNow()
+    }
+
+    companion object {
+        val DEFAULT_TTL: Duration = Duration.ofSeconds(60)
+    }
+}

--- a/database/src/main/kotlin/database/persistence/DuelLogPersistence.kt
+++ b/database/src/main/kotlin/database/persistence/DuelLogPersistence.kt
@@ -1,0 +1,7 @@
+package database.persistence
+
+import database.dto.DuelLogDto
+
+interface DuelLogPersistence {
+    fun insert(row: DuelLogDto): DuelLogDto
+}

--- a/database/src/main/kotlin/database/persistence/TipDailyPersistence.kt
+++ b/database/src/main/kotlin/database/persistence/TipDailyPersistence.kt
@@ -1,0 +1,9 @@
+package database.persistence
+
+import database.dto.TipDailyDto
+import java.time.LocalDate
+
+interface TipDailyPersistence {
+    fun get(senderDiscordId: Long, guildId: Long, date: LocalDate): TipDailyDto?
+    fun upsert(row: TipDailyDto): TipDailyDto
+}

--- a/database/src/main/kotlin/database/persistence/TipLogPersistence.kt
+++ b/database/src/main/kotlin/database/persistence/TipLogPersistence.kt
@@ -1,0 +1,7 @@
+package database.persistence
+
+import database.dto.TipLogDto
+
+interface TipLogPersistence {
+    fun insert(row: TipLogDto): TipLogDto
+}

--- a/database/src/main/kotlin/database/persistence/impl/DefaultDuelLogPersistence.kt
+++ b/database/src/main/kotlin/database/persistence/impl/DefaultDuelLogPersistence.kt
@@ -1,0 +1,22 @@
+package database.persistence.impl
+
+import database.dto.DuelLogDto
+import database.persistence.DuelLogPersistence
+import jakarta.persistence.EntityManager
+import jakarta.persistence.PersistenceContext
+import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
+
+@Repository
+@Transactional
+class DefaultDuelLogPersistence : DuelLogPersistence {
+
+    @PersistenceContext
+    private lateinit var entityManager: EntityManager
+
+    override fun insert(row: DuelLogDto): DuelLogDto {
+        entityManager.persist(row)
+        entityManager.flush()
+        return row
+    }
+}

--- a/database/src/main/kotlin/database/persistence/impl/DefaultTipDailyPersistence.kt
+++ b/database/src/main/kotlin/database/persistence/impl/DefaultTipDailyPersistence.kt
@@ -1,0 +1,41 @@
+package database.persistence.impl
+
+import database.dto.TipDailyDto
+import database.persistence.TipDailyPersistence
+import jakarta.persistence.EntityManager
+import jakarta.persistence.PersistenceContext
+import jakarta.persistence.TypedQuery
+import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+
+@Repository
+@Transactional
+class DefaultTipDailyPersistence : TipDailyPersistence {
+
+    @PersistenceContext
+    private lateinit var entityManager: EntityManager
+
+    override fun get(senderDiscordId: Long, guildId: Long, date: LocalDate): TipDailyDto? {
+        val q: TypedQuery<TipDailyDto> =
+            entityManager.createNamedQuery("TipDailyDto.get", TipDailyDto::class.java)
+        q.setParameter("senderDiscordId", senderDiscordId)
+        q.setParameter("guildId", guildId)
+        q.setParameter("tipDate", date)
+        return q.resultList.firstOrNull()
+    }
+
+    override fun upsert(row: TipDailyDto): TipDailyDto {
+        val existing = get(row.senderDiscordId, row.guildId, row.tipDate)
+        return if (existing == null) {
+            entityManager.persist(row)
+            entityManager.flush()
+            row
+        } else {
+            existing.creditsSent = row.creditsSent
+            entityManager.merge(existing)
+            entityManager.flush()
+            existing
+        }
+    }
+}

--- a/database/src/main/kotlin/database/persistence/impl/DefaultTipLogPersistence.kt
+++ b/database/src/main/kotlin/database/persistence/impl/DefaultTipLogPersistence.kt
@@ -1,0 +1,22 @@
+package database.persistence.impl
+
+import database.dto.TipLogDto
+import database.persistence.TipLogPersistence
+import jakarta.persistence.EntityManager
+import jakarta.persistence.PersistenceContext
+import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
+
+@Repository
+@Transactional
+class DefaultTipLogPersistence : TipLogPersistence {
+
+    @PersistenceContext
+    private lateinit var entityManager: EntityManager
+
+    override fun insert(row: TipLogDto): TipLogDto {
+        entityManager.persist(row)
+        entityManager.flush()
+        return row
+    }
+}

--- a/database/src/main/kotlin/database/service/DuelService.kt
+++ b/database/src/main/kotlin/database/service/DuelService.kt
@@ -1,0 +1,184 @@
+package database.service
+
+import database.dto.DuelLogDto
+import database.dto.UserDto
+import database.economy.Coinflip
+import database.persistence.DuelLogPersistence
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+import kotlin.random.Random
+
+/**
+ * Head-to-head 50/50 wager between two users. Two phases:
+ *
+ *   - [startDuel] — pre-flight balance check at offer time. Does NOT
+ *     debit. Allows the bot/web layer to refuse a clearly-doomed offer
+ *     up-front, but the authoritative check happens at accept time.
+ *   - [acceptDuel] — atomic resolve. Locks both users in ascending
+ *     discord-id order, re-verifies both balances, picks a winner
+ *     by a fair coinflip, debits both and credits the winner the pot
+ *     minus the jackpot tribute. Persists a [DuelLogDto] row.
+ *
+ * Loss tribute (10 % of stake by default, configurable per-guild via
+ * `JACKPOT_LOSS_TRIBUTE_PCT`) is paid out of the pot before the winner
+ * is credited — the winner receives `2*stake - tribute`. This keeps
+ * the loser's accounting identical to a casino loss (`-stake`,
+ * period) and routes a small bleed into the per-guild jackpot pool,
+ * matching how `/slots`, `/dice`, etc. feed it.
+ *
+ * Pending offer state (the 60-second Accept/Decline window between a
+ * `/duel` slash invocation and the opponent's click) is NOT persisted
+ * here — see `database.duel.PendingDuelRegistry`, an in-memory
+ * @Component shared across the whole Spring context (Discord bot and
+ * web layer). Decline and timeout therefore produce no DB writes.
+ */
+@Service
+@Transactional
+class DuelService @Autowired constructor(
+    private val userService: UserService,
+    private val jackpotService: JackpotService,
+    private val configService: ConfigService,
+    private val duelLogPersistence: DuelLogPersistence,
+    private val random: Random = Random.Default,
+) {
+    sealed interface StartOutcome {
+        data class Ok(val initiatorBalance: Long) : StartOutcome
+        data class InvalidStake(val min: Long, val max: Long) : StartOutcome
+        data class InvalidOpponent(val reason: Reason) : StartOutcome {
+            enum class Reason { SELF, BOT }
+        }
+        data class InitiatorInsufficient(val have: Long, val needed: Long) : StartOutcome
+        data class OpponentInsufficient(val have: Long, val needed: Long) : StartOutcome
+        data object UnknownInitiator : StartOutcome
+        data object UnknownOpponent : StartOutcome
+    }
+
+    sealed interface AcceptOutcome {
+        data class Win(
+            val winnerDiscordId: Long,
+            val loserDiscordId: Long,
+            val stake: Long,
+            val pot: Long,
+            val winnerNewBalance: Long,
+            val loserNewBalance: Long,
+            val lossTribute: Long
+        ) : AcceptOutcome
+
+        data class InitiatorInsufficient(val have: Long, val needed: Long) : AcceptOutcome
+        data class OpponentInsufficient(val have: Long, val needed: Long) : AcceptOutcome
+        data object UnknownInitiator : AcceptOutcome
+        data object UnknownOpponent : AcceptOutcome
+    }
+
+    fun startDuel(
+        initiatorDiscordId: Long,
+        opponentDiscordId: Long,
+        guildId: Long,
+        stake: Long,
+    ): StartOutcome {
+        if (stake < MIN_STAKE || stake > MAX_STAKE) {
+            return StartOutcome.InvalidStake(MIN_STAKE, MAX_STAKE)
+        }
+        if (initiatorDiscordId == opponentDiscordId) {
+            return StartOutcome.InvalidOpponent(StartOutcome.InvalidOpponent.Reason.SELF)
+        }
+
+        val initiator = userService.getUserById(initiatorDiscordId, guildId)
+            ?: return StartOutcome.UnknownInitiator
+        val opponent = userService.getUserById(opponentDiscordId, guildId)
+            ?: return StartOutcome.UnknownOpponent
+
+        val initiatorBalance = initiator.socialCredit ?: 0L
+        if (initiatorBalance < stake) {
+            return StartOutcome.InitiatorInsufficient(initiatorBalance, stake)
+        }
+        val opponentBalance = opponent.socialCredit ?: 0L
+        if (opponentBalance < stake) {
+            return StartOutcome.OpponentInsufficient(opponentBalance, stake)
+        }
+
+        return StartOutcome.Ok(initiatorBalance)
+    }
+
+    fun acceptDuel(
+        initiatorDiscordId: Long,
+        opponentDiscordId: Long,
+        guildId: Long,
+        stake: Long,
+        at: Instant = Instant.now(),
+    ): AcceptOutcome {
+        // Lock both rows in deterministic ascending order to avoid deadlocks.
+        val (initiator, opponent) = lockBoth(initiatorDiscordId, opponentDiscordId, guildId)
+        initiator ?: return AcceptOutcome.UnknownInitiator
+        opponent ?: return AcceptOutcome.UnknownOpponent
+
+        val initiatorBalance = initiator.socialCredit ?: 0L
+        if (initiatorBalance < stake) {
+            return AcceptOutcome.InitiatorInsufficient(initiatorBalance, stake)
+        }
+        val opponentBalance = opponent.socialCredit ?: 0L
+        if (opponentBalance < stake) {
+            return AcceptOutcome.OpponentInsufficient(opponentBalance, stake)
+        }
+
+        val initiatorWins = random.nextBoolean()
+        val winner = if (initiatorWins) initiator else opponent
+        val loser = if (initiatorWins) opponent else initiator
+        val winnerStartBalance = if (initiatorWins) initiatorBalance else opponentBalance
+        val loserStartBalance = if (initiatorWins) opponentBalance else initiatorBalance
+
+        val tribute = JackpotHelper.divertOnLoss(jackpotService, configService, guildId, stake)
+        val pot = 2L * stake
+        val winnerPayout = pot - tribute
+
+        // Loser is debited their full stake. Winner gets back their stake plus
+        // the loser's stake minus the tribute (the bleed into the jackpot).
+        winner.socialCredit = winnerStartBalance - stake + winnerPayout
+        loser.socialCredit = loserStartBalance - stake
+        userService.updateUser(winner)
+        userService.updateUser(loser)
+
+        duelLogPersistence.insert(
+            DuelLogDto(
+                guildId = guildId,
+                initiatorDiscordId = initiatorDiscordId,
+                opponentDiscordId = opponentDiscordId,
+                winnerDiscordId = winner.discordId,
+                loserDiscordId = loser.discordId,
+                stake = stake,
+                pot = pot,
+                lossTribute = tribute,
+                resolvedAt = at
+            )
+        )
+
+        return AcceptOutcome.Win(
+            winnerDiscordId = winner.discordId,
+            loserDiscordId = loser.discordId,
+            stake = stake,
+            pot = pot,
+            winnerNewBalance = winner.socialCredit ?: 0L,
+            loserNewBalance = loser.socialCredit ?: 0L,
+            lossTribute = tribute
+        )
+    }
+
+    private fun lockBoth(aId: Long, bId: Long, guildId: Long): Pair<UserDto?, UserDto?> {
+        return if (aId < bId) {
+            val a = userService.getUserByIdForUpdate(aId, guildId)
+            val b = userService.getUserByIdForUpdate(bId, guildId)
+            a to b
+        } else {
+            val b = userService.getUserByIdForUpdate(bId, guildId)
+            val a = userService.getUserByIdForUpdate(aId, guildId)
+            a to b
+        }
+    }
+
+    companion object {
+        const val MIN_STAKE: Long = Coinflip.MIN_STAKE
+        const val MAX_STAKE: Long = 500L
+    }
+}

--- a/database/src/main/kotlin/database/service/SocialCreditAwardService.kt
+++ b/database/src/main/kotlin/database/service/SocialCreditAwardService.kt
@@ -79,6 +79,6 @@ class SocialCreditAwardService(
 
     companion object {
         // Matches the voice credit cap so all daily-capped sources share one bucket.
-        const val DEFAULT_DAILY_CAP: Long = 60L
+        const val DEFAULT_DAILY_CAP: Long = 90L
     }
 }

--- a/database/src/main/kotlin/database/service/TipDailyService.kt
+++ b/database/src/main/kotlin/database/service/TipDailyService.kt
@@ -1,0 +1,9 @@
+package database.service
+
+import database.dto.TipDailyDto
+import java.time.LocalDate
+
+interface TipDailyService {
+    fun get(senderDiscordId: Long, guildId: Long, date: LocalDate): TipDailyDto?
+    fun upsert(row: TipDailyDto): TipDailyDto
+}

--- a/database/src/main/kotlin/database/service/TipService.kt
+++ b/database/src/main/kotlin/database/service/TipService.kt
@@ -1,0 +1,145 @@
+package database.service
+
+import database.dto.TipDailyDto
+import database.dto.TipLogDto
+import database.persistence.TipLogPersistence
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneOffset
+
+/**
+ * Atomic peer-to-peer transfer of social credit. Daily outgoing cap is
+ * tracked separately from the voice/command earn cap — tips are
+ * transfers, not earnings, so they must not consume the daily-earn
+ * bucket and must not let an alt funnel its capped earnings to a main.
+ *
+ * Both user rows are locked in ascending discord-id order to avoid
+ * deadlocks against a concurrent reverse-direction tip. The
+ * `tip_daily` row for the sender is locked after the user rows; only
+ * the sender ever touches their own row, so there is no cross-tip
+ * deadlock to worry about there.
+ */
+@Service
+@Transactional
+class TipService @Autowired constructor(
+    private val userService: UserService,
+    private val tipDailyService: TipDailyService,
+    private val tipLogPersistence: TipLogPersistence,
+) {
+    sealed interface TipOutcome {
+        data class Ok(
+            val sender: Long,
+            val recipient: Long,
+            val amount: Long,
+            val note: String?,
+            val senderNewBalance: Long,
+            val recipientNewBalance: Long,
+            val sentTodayAfter: Long,
+            val dailyCap: Long
+        ) : TipOutcome
+
+        data class InvalidAmount(val min: Long, val max: Long) : TipOutcome
+        data class InvalidRecipient(val reason: Reason) : TipOutcome {
+            enum class Reason { SELF, BOT, MISSING }
+        }
+        data class InsufficientCredits(val have: Long, val needed: Long) : TipOutcome
+        data class DailyCapExceeded(val sentToday: Long, val cap: Long, val attempted: Long) : TipOutcome
+        data object UnknownSender : TipOutcome
+        data object UnknownRecipient : TipOutcome
+    }
+
+    fun tip(
+        senderDiscordId: Long,
+        recipientDiscordId: Long,
+        guildId: Long,
+        amount: Long,
+        note: String? = null,
+        at: Instant = Instant.now(),
+        dailyCap: Long = DEFAULT_TIP_DAILY_CAP,
+    ): TipOutcome {
+        if (amount < MIN_TIP || amount > MAX_TIP) {
+            return TipOutcome.InvalidAmount(MIN_TIP, MAX_TIP)
+        }
+        if (senderDiscordId == recipientDiscordId) {
+            return TipOutcome.InvalidRecipient(TipOutcome.InvalidRecipient.Reason.SELF)
+        }
+
+        // Lock both user rows in deterministic order to prevent A→B vs B→A deadlocks.
+        val (sender, recipient) = lockBoth(senderDiscordId, recipientDiscordId, guildId)
+        sender ?: return TipOutcome.UnknownSender
+        recipient ?: return TipOutcome.UnknownRecipient
+
+        val today = LocalDate.ofInstant(at, ZoneOffset.UTC)
+        val existingDaily = tipDailyService.get(senderDiscordId, guildId, today)
+        val sentToday = existingDaily?.creditsSent ?: 0L
+        if (sentToday + amount > dailyCap) {
+            return TipOutcome.DailyCapExceeded(sentToday, dailyCap, amount)
+        }
+
+        val senderBalance = sender.socialCredit ?: 0L
+        if (senderBalance < amount) {
+            return TipOutcome.InsufficientCredits(senderBalance, amount)
+        }
+
+        val recipientBalance = recipient.socialCredit ?: 0L
+        sender.socialCredit = senderBalance - amount
+        recipient.socialCredit = recipientBalance + amount
+        userService.updateUser(sender)
+        userService.updateUser(recipient)
+
+        val newDailyTotal = sentToday + amount
+        tipDailyService.upsert(
+            TipDailyDto(
+                senderDiscordId = senderDiscordId,
+                guildId = guildId,
+                tipDate = today,
+                creditsSent = newDailyTotal
+            )
+        )
+
+        val truncatedNote = note?.take(MAX_NOTE_LENGTH)
+        tipLogPersistence.insert(
+            TipLogDto(
+                guildId = guildId,
+                senderDiscordId = senderDiscordId,
+                recipientDiscordId = recipientDiscordId,
+                amount = amount,
+                note = truncatedNote,
+                createdAt = at
+            )
+        )
+
+        return TipOutcome.Ok(
+            sender = senderDiscordId,
+            recipient = recipientDiscordId,
+            amount = amount,
+            note = truncatedNote,
+            senderNewBalance = senderBalance - amount,
+            recipientNewBalance = recipientBalance + amount,
+            sentTodayAfter = newDailyTotal,
+            dailyCap = dailyCap
+        )
+    }
+
+    private fun lockBoth(aId: Long, bId: Long, guildId: Long): Pair<database.dto.UserDto?, database.dto.UserDto?> {
+        return if (aId < bId) {
+            val a = userService.getUserByIdForUpdate(aId, guildId)
+            val b = userService.getUserByIdForUpdate(bId, guildId)
+            a to b
+        } else {
+            val b = userService.getUserByIdForUpdate(bId, guildId)
+            val a = userService.getUserByIdForUpdate(aId, guildId)
+            a to b
+        }
+    }
+
+    companion object {
+        const val MIN_TIP: Long = 10L
+        const val MAX_TIP: Long = 500L
+        const val DEFAULT_TIP_DAILY_CAP: Long = 500L
+        const val MAX_NOTE_LENGTH: Int = 200
+    }
+}

--- a/database/src/main/kotlin/database/service/impl/DefaultTipDailyService.kt
+++ b/database/src/main/kotlin/database/service/impl/DefaultTipDailyService.kt
@@ -1,0 +1,18 @@
+package database.service.impl
+
+import database.dto.TipDailyDto
+import database.persistence.TipDailyPersistence
+import database.service.TipDailyService
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Service
+import java.time.LocalDate
+
+@Service
+class DefaultTipDailyService @Autowired constructor(
+    private val persistence: TipDailyPersistence
+) : TipDailyService {
+    override fun get(senderDiscordId: Long, guildId: Long, date: LocalDate): TipDailyDto? =
+        persistence.get(senderDiscordId, guildId, date)
+
+    override fun upsert(row: TipDailyDto): TipDailyDto = persistence.upsert(row)
+}

--- a/database/src/main/resources/db/migration/V21__social_pvp.sql
+++ b/database/src/main/resources/db/migration/V21__social_pvp.sql
@@ -1,0 +1,44 @@
+-- Social/PvP credit-spend ledgers and per-day outgoing-tip cap.
+-- Tips are transfers (not earnings) and must NOT route through the
+-- voice_credit_daily bucket — otherwise alts could launder daily-capped
+-- earnings. tip_daily is a separate per-sender per-day ledger.
+
+-- Per-sender per-guild per-day total tipped out. Pessimistically locked
+-- inside TipService.tip() so concurrent /tip invocations from the same
+-- sender can't both clear the cap check and double-debit.
+CREATE TABLE tip_daily (
+    sender_discord_id BIGINT NOT NULL,
+    guild_id          BIGINT NOT NULL,
+    tip_date          DATE   NOT NULL,
+    credits_sent      BIGINT NOT NULL DEFAULT 0 CHECK (credits_sent >= 0),
+    PRIMARY KEY (sender_discord_id, guild_id, tip_date)
+);
+
+-- Append-only audit log for every successful tip.
+CREATE TABLE tip_log (
+    id                   BIGSERIAL  PRIMARY KEY,
+    guild_id             BIGINT     NOT NULL,
+    sender_discord_id    BIGINT     NOT NULL,
+    recipient_discord_id BIGINT     NOT NULL,
+    amount               BIGINT     NOT NULL CHECK (amount > 0),
+    note                 TEXT,
+    created_at           TIMESTAMPTZ NOT NULL
+);
+CREATE INDEX idx_tip_log_guild_time   ON tip_log (guild_id, created_at DESC);
+CREATE INDEX idx_tip_log_sender_time  ON tip_log (sender_discord_id, guild_id, created_at DESC);
+
+-- Append-only audit log for every accepted duel resolution.
+-- Decline/timeout produce no row (no credit movement to record).
+CREATE TABLE duel_log (
+    id                    BIGSERIAL  PRIMARY KEY,
+    guild_id              BIGINT     NOT NULL,
+    initiator_discord_id  BIGINT     NOT NULL,
+    opponent_discord_id   BIGINT     NOT NULL,
+    winner_discord_id     BIGINT     NOT NULL,
+    loser_discord_id      BIGINT     NOT NULL,
+    stake                 BIGINT     NOT NULL CHECK (stake > 0),
+    pot                   BIGINT     NOT NULL CHECK (pot > 0),
+    loss_tribute          BIGINT     NOT NULL DEFAULT 0 CHECK (loss_tribute >= 0),
+    resolved_at           TIMESTAMPTZ NOT NULL
+);
+CREATE INDEX idx_duel_log_guild_time ON duel_log (guild_id, resolved_at DESC);

--- a/database/src/test/kotlin/database/duel/PendingDuelRegistryTest.kt
+++ b/database/src/test/kotlin/database/duel/PendingDuelRegistryTest.kt
@@ -1,0 +1,98 @@
+package database.duel
+
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+class PendingDuelRegistryTest {
+
+    private val scheduler = Executors.newScheduledThreadPool(2)
+
+    @AfterEach
+    fun shutdown() {
+        scheduler.shutdownNow()
+    }
+
+    private fun newRegistry(ttl: Duration = Duration.ofMillis(50)): PendingDuelRegistry =
+        PendingDuelRegistry(ttl = ttl, scheduler = scheduler)
+
+    @Test
+    fun `register returns increasing ids and stores the offer`() {
+        val registry = newRegistry(ttl = Duration.ofSeconds(60))
+        val a = registry.register(guildId = 1, initiatorDiscordId = 10, opponentDiscordId = 20, stake = 50L)
+        val b = registry.register(guildId = 1, initiatorDiscordId = 11, opponentDiscordId = 21, stake = 75L)
+
+        assertNotEquals(a.id, b.id)
+        assertTrue(b.id > a.id)
+        assertEquals(50L, registry.get(a.id)?.stake)
+        assertEquals(75L, registry.get(b.id)?.stake)
+    }
+
+    @Test
+    fun `consumeForAccept removes the offer and a second call returns null`() {
+        val registry = newRegistry(ttl = Duration.ofSeconds(60))
+        val offer = registry.register(1L, 10L, 20L, 50L)
+
+        val first = registry.consumeForAccept(offer.id)
+        val second = registry.consumeForAccept(offer.id)
+
+        assertEquals(offer.id, first?.id)
+        assertNull(second)
+    }
+
+    @Test
+    fun `cancel removes the offer and consumeForAccept afterwards returns null`() {
+        val registry = newRegistry(ttl = Duration.ofSeconds(60))
+        val offer = registry.register(1L, 10L, 20L, 50L)
+
+        val cancelled = registry.cancel(offer.id)
+        val consumed = registry.consumeForAccept(offer.id)
+
+        assertEquals(offer.id, cancelled?.id)
+        assertNull(consumed)
+    }
+
+    @Test
+    fun `expiry callback fires after the configured ttl when offer still pending`() {
+        val registry = newRegistry(ttl = Duration.ofMillis(50))
+        val latch = CountDownLatch(1)
+        registry.register(1L, 10L, 20L, 50L) { _ -> latch.countDown() }
+
+        assertTrue(latch.await(2, TimeUnit.SECONDS), "timeout callback should fire within ttl + slack")
+    }
+
+    @Test
+    fun `expiry is a no-op after consumeForAccept`() {
+        val registry = newRegistry(ttl = Duration.ofMillis(50))
+        val callbackFired = java.util.concurrent.atomic.AtomicBoolean(false)
+        val offer = registry.register(1L, 10L, 20L, 50L) { _ -> callbackFired.set(true) }
+
+        // Consume immediately so the timer's later remove() returns null and skips the callback.
+        registry.consumeForAccept(offer.id)
+        Thread.sleep(150)
+
+        // Either the timer fired and saw a null offer (callback skipped), or it didn't fire yet.
+        // Either way, callback must not have fired.
+        assertEquals(false, callbackFired.get(), "expiry callback must not run after consume")
+    }
+
+    @Test
+    fun `pendingForOpponent returns only matching offers`() {
+        val registry = newRegistry(ttl = Duration.ofSeconds(60))
+        registry.register(1L, 10L, 20L, 50L)   // for opponent 20 in guild 1
+        registry.register(1L, 11L, 20L, 75L)   // for opponent 20 in guild 1
+        registry.register(2L, 12L, 20L, 25L)   // for opponent 20 in guild 2 — different guild
+        registry.register(1L, 13L, 99L, 30L)   // different opponent
+
+        val rows = registry.pendingForOpponent(20L, 1L)
+        assertEquals(2, rows.size)
+        assertTrue(rows.all { it.opponentDiscordId == 20L && it.guildId == 1L })
+    }
+}

--- a/database/src/test/kotlin/database/service/DuelServiceTest.kt
+++ b/database/src/test/kotlin/database/service/DuelServiceTest.kt
@@ -1,0 +1,247 @@
+package database.service
+
+import database.dto.ConfigDto
+import database.dto.DuelLogDto
+import database.dto.UserDto
+import database.persistence.DuelLogPersistence
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import kotlin.random.Random
+
+class DuelServiceTest {
+
+    private val now: Instant = Instant.parse("2026-04-10T10:00:00Z")
+    private val guildId = 42L
+    private val initiator = 1L
+    private val opponent = 2L
+
+    private lateinit var userService: RecordingUserService
+    private lateinit var jackpotService: JackpotService
+    private lateinit var configService: ConfigService
+    private lateinit var duelLogPersistence: RecordingDuelLogPersistence
+
+    @BeforeEach
+    fun setup() {
+        userService = RecordingUserService()
+        jackpotService = mockk(relaxed = true)
+        configService = mockk(relaxed = true)
+        duelLogPersistence = RecordingDuelLogPersistence()
+
+        // Default tribute config: empty → JackpotHelper falls back to 10%.
+        every {
+            configService.getConfigByName(
+                ConfigDto.Configurations.JACKPOT_LOSS_TRIBUTE_PCT.configValue,
+                guildId.toString()
+            )
+        } returns null
+    }
+
+    private fun service(random: Random = AlwaysHeadsRandom): DuelService =
+        DuelService(userService, jackpotService, configService, duelLogPersistence, random)
+
+    @Test
+    fun `startDuel returns Ok when both players have enough credits`() {
+        userService.seed(UserDto(initiator, guildId).apply { socialCredit = 200L })
+        userService.seed(UserDto(opponent, guildId).apply { socialCredit = 200L })
+
+        val outcome = service().startDuel(initiator, opponent, guildId, stake = 50L)
+
+        assertTrue(outcome is DuelService.StartOutcome.Ok)
+        assertEquals(0, userService.updateCount, "startDuel must not debit anyone")
+    }
+
+    @Test
+    fun `startDuel rejects invalid stake`() {
+        userService.seed(UserDto(initiator, guildId).apply { socialCredit = 1000L })
+        userService.seed(UserDto(opponent, guildId).apply { socialCredit = 1000L })
+
+        val tooLow = service().startDuel(initiator, opponent, guildId, stake = 5L)
+        val tooHigh = service().startDuel(initiator, opponent, guildId, stake = 10_000L)
+        assertTrue(tooLow is DuelService.StartOutcome.InvalidStake)
+        assertTrue(tooHigh is DuelService.StartOutcome.InvalidStake)
+    }
+
+    @Test
+    fun `startDuel rejects self-duel`() {
+        userService.seed(UserDto(initiator, guildId).apply { socialCredit = 1000L })
+
+        val outcome = service().startDuel(initiator, initiator, guildId, stake = 50L)
+
+        assertTrue(outcome is DuelService.StartOutcome.InvalidOpponent)
+    }
+
+    @Test
+    fun `startDuel reports initiator and opponent insufficiency separately`() {
+        userService.seed(UserDto(initiator, guildId).apply { socialCredit = 5L })
+        userService.seed(UserDto(opponent, guildId).apply { socialCredit = 1000L })
+
+        val initiatorLow = service().startDuel(initiator, opponent, guildId, stake = 50L)
+        assertTrue(initiatorLow is DuelService.StartOutcome.InitiatorInsufficient)
+
+        userService.seed(UserDto(initiator, guildId).apply { socialCredit = 1000L })
+        userService.seed(UserDto(opponent, guildId).apply { socialCredit = 5L })
+        val opponentLow = service().startDuel(initiator, opponent, guildId, stake = 50L)
+        assertTrue(opponentLow is DuelService.StartOutcome.OpponentInsufficient)
+    }
+
+    @Test
+    fun `acceptDuel debits both players, credits the winner pot minus tribute, and logs`() {
+        userService.seed(UserDto(initiator, guildId).apply { socialCredit = 200L })
+        userService.seed(UserDto(opponent, guildId).apply { socialCredit = 100L })
+
+        // AlwaysHeadsRandom → initiator wins.
+        val outcome = service().acceptDuel(initiator, opponent, guildId, stake = 50L, at = now)
+
+        assertTrue(outcome is DuelService.AcceptOutcome.Win)
+        outcome as DuelService.AcceptOutcome.Win
+        assertEquals(initiator, outcome.winnerDiscordId)
+        assertEquals(opponent, outcome.loserDiscordId)
+        assertEquals(100L, outcome.pot)
+        assertEquals(5L, outcome.lossTribute, "10% of 50 = 5")
+        // Initiator: 200 - 50 (stake) + 95 (pot - tribute) = 245
+        assertEquals(245L, outcome.winnerNewBalance)
+        // Opponent: 100 - 50 = 50
+        assertEquals(50L, outcome.loserNewBalance)
+
+        assertEquals(245L, userService.current(initiator, guildId)?.socialCredit)
+        assertEquals(50L, userService.current(opponent, guildId)?.socialCredit)
+        assertEquals(1, duelLogPersistence.inserted.size)
+        assertEquals(5L, duelLogPersistence.inserted[0].lossTribute)
+        assertEquals(100L, duelLogPersistence.inserted[0].pot)
+    }
+
+    @Test
+    fun `acceptDuel awards opponent when RNG says so`() {
+        userService.seed(UserDto(initiator, guildId).apply { socialCredit = 200L })
+        userService.seed(UserDto(opponent, guildId).apply { socialCredit = 100L })
+
+        val outcome = service(AlwaysTailsRandom).acceptDuel(initiator, opponent, guildId, stake = 50L, at = now)
+
+        assertTrue(outcome is DuelService.AcceptOutcome.Win)
+        outcome as DuelService.AcceptOutcome.Win
+        assertEquals(opponent, outcome.winnerDiscordId)
+        assertEquals(initiator, outcome.loserDiscordId)
+        // Opponent: 100 - 50 (stake) + 95 (pot - tribute) = 145
+        assertEquals(145L, outcome.winnerNewBalance)
+        // Initiator: 200 - 50 = 150
+        assertEquals(150L, outcome.loserNewBalance)
+    }
+
+    @Test
+    fun `acceptDuel returns InitiatorInsufficient and writes nothing when initiator balance dropped`() {
+        userService.seed(UserDto(initiator, guildId).apply { socialCredit = 30L })
+        userService.seed(UserDto(opponent, guildId).apply { socialCredit = 100L })
+
+        val outcome = service().acceptDuel(initiator, opponent, guildId, stake = 50L, at = now)
+
+        assertTrue(outcome is DuelService.AcceptOutcome.InitiatorInsufficient)
+        assertEquals(0, duelLogPersistence.inserted.size)
+        assertEquals(0, userService.updateCount)
+    }
+
+    @Test
+    fun `acceptDuel returns OpponentInsufficient when opponent balance dropped`() {
+        userService.seed(UserDto(initiator, guildId).apply { socialCredit = 100L })
+        userService.seed(UserDto(opponent, guildId).apply { socialCredit = 30L })
+
+        val outcome = service().acceptDuel(initiator, opponent, guildId, stake = 50L, at = now)
+
+        assertTrue(outcome is DuelService.AcceptOutcome.OpponentInsufficient)
+        assertEquals(0, duelLogPersistence.inserted.size)
+        assertEquals(0, userService.updateCount)
+    }
+
+    @Test
+    fun `acceptDuel tribute floors small stakes correctly`() {
+        userService.seed(UserDto(initiator, guildId).apply { socialCredit = 50L })
+        userService.seed(UserDto(opponent, guildId).apply { socialCredit = 50L })
+
+        val outcome10 = service().acceptDuel(initiator, opponent, guildId, stake = 10L, at = now)
+        assertTrue(outcome10 is DuelService.AcceptOutcome.Win)
+        assertEquals(1L, (outcome10 as DuelService.AcceptOutcome.Win).lossTribute, "floor(10 * 0.10) = 1")
+
+        // Reset and re-test with stake = 7 (acceptDuel itself doesn't gate
+        // stake bounds — startDuel does — so we can probe the floor=0 path).
+        userService = RecordingUserService()
+        userService.seed(UserDto(initiator, guildId).apply { socialCredit = 50L })
+        userService.seed(UserDto(opponent, guildId).apply { socialCredit = 50L })
+        val outcome7 = service().acceptDuel(initiator, opponent, guildId, stake = 7L, at = now)
+        assertTrue(outcome7 is DuelService.AcceptOutcome.Win)
+        assertEquals(0L, (outcome7 as DuelService.AcceptOutcome.Win).lossTribute, "floor(7 * 0.10) = 0")
+    }
+
+    @Test
+    fun `acceptDuel locks both users in ascending discord-id order`() {
+        userService.seed(UserDto(initiator, guildId).apply { socialCredit = 200L })
+        userService.seed(UserDto(opponent, guildId).apply { socialCredit = 200L })
+
+        service().acceptDuel(initiator, opponent, guildId, stake = 50L, at = now)
+        assertEquals(listOf(initiator, opponent), userService.lockOrder)
+
+        userService.lockOrder.clear()
+        // Reverse direction — locks should still be by ascending id.
+        service().acceptDuel(opponent, initiator, guildId, stake = 50L, at = now)
+        assertEquals(listOf(initiator, opponent), userService.lockOrder)
+    }
+
+    @Test
+    fun `acceptDuel returns UnknownInitiator and UnknownOpponent for missing rows`() {
+        // Only opponent seeded.
+        userService.seed(UserDto(opponent, guildId).apply { socialCredit = 200L })
+        assertEquals(
+            DuelService.AcceptOutcome.UnknownInitiator,
+            service().acceptDuel(initiator, opponent, guildId, stake = 50L, at = now)
+        )
+
+        // Reset; only initiator.
+        userService = RecordingUserService()
+        userService.seed(UserDto(initiator, guildId).apply { socialCredit = 200L })
+        assertEquals(
+            DuelService.AcceptOutcome.UnknownOpponent,
+            service().acceptDuel(initiator, opponent, guildId, stake = 50L, at = now)
+        )
+    }
+
+    private object AlwaysHeadsRandom : Random() {
+        override fun nextBits(bitCount: Int): Int = 0
+        override fun nextBoolean(): Boolean = true
+    }
+
+    private object AlwaysTailsRandom : Random() {
+        override fun nextBits(bitCount: Int): Int = 0
+        override fun nextBoolean(): Boolean = false
+    }
+
+    private class RecordingUserService : UserService {
+        private val users = mutableMapOf<Pair<Long, Long>, UserDto>()
+        var updateCount: Int = 0
+            private set
+        val lockOrder: MutableList<Long> = mutableListOf()
+
+        fun seed(dto: UserDto) { users[dto.discordId to dto.guildId] = dto }
+        fun current(discordId: Long, guildId: Long): UserDto? = users[discordId to guildId]
+
+        override fun listGuildUsers(guildId: Long?): List<UserDto?> = users.values.filter { it.guildId == guildId }
+        override fun createNewUser(userDto: UserDto): UserDto = userDto.also(::seed)
+        override fun getUserById(discordId: Long?, guildId: Long?): UserDto? = users[discordId!! to guildId!!]
+        override fun getUserByIdForUpdate(discordId: Long?, guildId: Long?): UserDto? {
+            lockOrder.add(discordId!!)
+            return users[discordId to guildId!!]
+        }
+        override fun updateUser(userDto: UserDto): UserDto { updateCount++; users[userDto.discordId to userDto.guildId] = userDto; return userDto }
+        override fun deleteUser(userDto: UserDto) { users.remove(userDto.discordId to userDto.guildId) }
+        override fun deleteUserById(discordId: Long?, guildId: Long?) { users.remove(discordId!! to guildId!!) }
+        override fun clearCache() {}
+        override fun evictUserFromCache(discordId: Long?, guildId: Long?) {}
+    }
+
+    private class RecordingDuelLogPersistence : DuelLogPersistence {
+        val inserted: MutableList<DuelLogDto> = mutableListOf()
+        override fun insert(row: DuelLogDto): DuelLogDto { inserted.add(row); return row }
+    }
+}

--- a/database/src/test/kotlin/database/service/SocialCreditAwardServiceTest.kt
+++ b/database/src/test/kotlin/database/service/SocialCreditAwardServiceTest.kt
@@ -52,20 +52,20 @@ class SocialCreditAwardServiceTest {
     @Test
     fun `award respects the daily cap and consumes the remaining headroom only`() {
         userService.seed(UserDto(discordId, guildId).apply { socialCredit = 0L })
-        // 55/60 already used today.
-        dailyService.upsert(VoiceCreditDailyDto(discordId, guildId, today, credits = 55L))
+        // 85/90 already used today.
+        dailyService.upsert(VoiceCreditDailyDto(discordId, guildId, today, credits = 85L))
 
         val granted = service.award(discordId, guildId, amount = 20L, reason = "test", at = now)
 
         assertEquals(5L, granted, "only 5 credits of headroom remain under the default cap")
         assertEquals(5L, userService.current(discordId, guildId)?.socialCredit)
-        assertEquals(60L, dailyService.get(discordId, guildId, today)?.credits)
+        assertEquals(90L, dailyService.get(discordId, guildId, today)?.credits)
     }
 
     @Test
     fun `award with countsAgainstDailyCap false bypasses the cap and the ledger`() {
         userService.seed(UserDto(discordId, guildId).apply { socialCredit = 0L })
-        dailyService.upsert(VoiceCreditDailyDto(discordId, guildId, today, credits = 60L)) // capped
+        dailyService.upsert(VoiceCreditDailyDto(discordId, guildId, today, credits = 90L)) // capped
 
         val granted = service.award(
             discordId, guildId,
@@ -77,7 +77,7 @@ class SocialCreditAwardServiceTest {
 
         assertEquals(10L, granted, "uncapped award should pass through the full amount")
         assertEquals(10L, userService.current(discordId, guildId)?.socialCredit)
-        assertEquals(60L, dailyService.get(discordId, guildId, today)?.credits, "ledger untouched")
+        assertEquals(90L, dailyService.get(discordId, guildId, today)?.credits, "ledger untouched")
     }
 
     @Test

--- a/database/src/test/kotlin/database/service/TipDailyServiceTest.kt
+++ b/database/src/test/kotlin/database/service/TipDailyServiceTest.kt
@@ -1,0 +1,54 @@
+package database.service
+
+import database.dto.TipDailyDto
+import database.persistence.TipDailyPersistence
+import database.service.impl.DefaultTipDailyService
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class TipDailyServiceTest {
+
+    private val sender = 1L
+    private val guildId = 42L
+    private val today: LocalDate = LocalDate.parse("2026-04-10")
+
+    private lateinit var persistence: TipDailyPersistence
+    private lateinit var service: TipDailyService
+
+    @BeforeEach
+    fun setup() {
+        persistence = mockk(relaxed = true)
+        service = DefaultTipDailyService(persistence)
+    }
+
+    @Test
+    fun `get delegates to persistence`() {
+        val row = TipDailyDto(sender, guildId, today, creditsSent = 75L)
+        every { persistence.get(sender, guildId, today) } returns row
+
+        assertEquals(row, service.get(sender, guildId, today))
+        verify(exactly = 1) { persistence.get(sender, guildId, today) }
+    }
+
+    @Test
+    fun `get returns null when persistence has no row`() {
+        every { persistence.get(sender, guildId, today) } returns null
+
+        assertNull(service.get(sender, guildId, today))
+    }
+
+    @Test
+    fun `upsert delegates to persistence and returns its row`() {
+        val row = TipDailyDto(sender, guildId, today, creditsSent = 100L)
+        every { persistence.upsert(row) } returns row
+
+        assertEquals(row, service.upsert(row))
+        verify(exactly = 1) { persistence.upsert(row) }
+    }
+}

--- a/database/src/test/kotlin/database/service/TipServiceTest.kt
+++ b/database/src/test/kotlin/database/service/TipServiceTest.kt
@@ -1,0 +1,212 @@
+package database.service
+
+import database.dto.TipDailyDto
+import database.dto.TipLogDto
+import database.dto.UserDto
+import database.persistence.TipLogPersistence
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneOffset
+
+class TipServiceTest {
+
+    private val now: Instant = Instant.parse("2026-04-10T10:00:00Z")
+    private val today: LocalDate = LocalDate.ofInstant(now, ZoneOffset.UTC)
+    private val guildId = 42L
+    private val sender = 1L
+    private val recipient = 2L
+
+    private lateinit var userService: RecordingUserService
+    private lateinit var tipDailyService: InMemoryTipDailyService
+    private lateinit var tipLogPersistence: RecordingTipLogPersistence
+    private lateinit var service: TipService
+
+    @BeforeEach
+    fun setup() {
+        userService = RecordingUserService()
+        tipDailyService = InMemoryTipDailyService()
+        tipLogPersistence = RecordingTipLogPersistence()
+        service = TipService(userService, tipDailyService, tipLogPersistence)
+    }
+
+    @Test
+    fun `tip happy path moves balances and records ledger plus log`() {
+        userService.seed(UserDto(sender, guildId).apply { socialCredit = 200L })
+        userService.seed(UserDto(recipient, guildId).apply { socialCredit = 50L })
+
+        val outcome = service.tip(sender, recipient, guildId, amount = 75L, note = "thanks", at = now)
+
+        assertTrue(outcome is TipService.TipOutcome.Ok, "expected Ok but got $outcome")
+        outcome as TipService.TipOutcome.Ok
+        assertEquals(125L, outcome.senderNewBalance)
+        assertEquals(125L, outcome.recipientNewBalance)
+        assertEquals(75L, outcome.sentTodayAfter)
+
+        assertEquals(125L, userService.current(sender, guildId)?.socialCredit)
+        assertEquals(125L, userService.current(recipient, guildId)?.socialCredit)
+        assertEquals(75L, tipDailyService.get(sender, guildId, today)?.creditsSent)
+        assertEquals(1, tipLogPersistence.inserted.size)
+        assertEquals("thanks", tipLogPersistence.inserted[0].note)
+    }
+
+    @Test
+    fun `tip rejects amount below minimum or above maximum`() {
+        userService.seed(UserDto(sender, guildId).apply { socialCredit = 1000L })
+        userService.seed(UserDto(recipient, guildId).apply { socialCredit = 0L })
+
+        val tooLow = service.tip(sender, recipient, guildId, amount = TipService.MIN_TIP - 1, at = now)
+        val tooHigh = service.tip(sender, recipient, guildId, amount = TipService.MAX_TIP + 1, at = now)
+
+        assertTrue(tooLow is TipService.TipOutcome.InvalidAmount)
+        assertTrue(tooHigh is TipService.TipOutcome.InvalidAmount)
+        assertEquals(0, tipLogPersistence.inserted.size)
+        assertEquals(0, userService.updateCount)
+    }
+
+    @Test
+    fun `tip rejects self-tip`() {
+        userService.seed(UserDto(sender, guildId).apply { socialCredit = 200L })
+
+        val outcome = service.tip(sender, sender, guildId, amount = 50L, at = now)
+
+        assertTrue(outcome is TipService.TipOutcome.InvalidRecipient)
+        outcome as TipService.TipOutcome.InvalidRecipient
+        assertEquals(TipService.TipOutcome.InvalidRecipient.Reason.SELF, outcome.reason)
+        assertEquals(0, userService.updateCount)
+    }
+
+    @Test
+    fun `tip with insufficient credits writes nothing`() {
+        userService.seed(UserDto(sender, guildId).apply { socialCredit = 30L })
+        userService.seed(UserDto(recipient, guildId).apply { socialCredit = 0L })
+
+        val outcome = service.tip(sender, recipient, guildId, amount = 100L, at = now)
+
+        assertTrue(outcome is TipService.TipOutcome.InsufficientCredits)
+        assertEquals(30L, userService.current(sender, guildId)?.socialCredit)
+        assertEquals(0L, userService.current(recipient, guildId)?.socialCredit)
+        assertNull(tipDailyService.get(sender, guildId, today))
+        assertEquals(0, tipLogPersistence.inserted.size)
+        assertEquals(0, userService.updateCount)
+    }
+
+    @Test
+    fun `tip respects daily cap boundary`() {
+        userService.seed(UserDto(sender, guildId).apply { socialCredit = 1000L })
+        userService.seed(UserDto(recipient, guildId).apply { socialCredit = 0L })
+        // Already sent 480 today against the default 500-credit cap.
+        tipDailyService.upsert(TipDailyDto(sender, guildId, today, creditsSent = 480L))
+
+        val rejected = service.tip(sender, recipient, guildId, amount = 50L, at = now)
+        assertTrue(rejected is TipService.TipOutcome.DailyCapExceeded, "50 over cap should be rejected")
+        assertEquals(0, tipLogPersistence.inserted.size, "no log row when rejected")
+
+        val accepted = service.tip(sender, recipient, guildId, amount = 20L, at = now)
+        assertTrue(accepted is TipService.TipOutcome.Ok, "exactly cap should pass")
+        assertEquals(500L, tipDailyService.get(sender, guildId, today)?.creditsSent)
+    }
+
+    @Test
+    fun `tip returns UnknownSender when sender row is missing`() {
+        userService.seed(UserDto(recipient, guildId).apply { socialCredit = 0L })
+
+        val outcome = service.tip(sender, recipient, guildId, amount = 50L, at = now)
+
+        assertEquals(TipService.TipOutcome.UnknownSender, outcome)
+        assertEquals(0, tipLogPersistence.inserted.size)
+    }
+
+    @Test
+    fun `tip returns UnknownRecipient when recipient row is missing`() {
+        userService.seed(UserDto(sender, guildId).apply { socialCredit = 200L })
+
+        val outcome = service.tip(sender, recipient, guildId, amount = 50L, at = now)
+
+        assertEquals(TipService.TipOutcome.UnknownRecipient, outcome)
+        assertEquals(0, tipLogPersistence.inserted.size)
+    }
+
+    @Test
+    fun `tip locks both users in ascending discord-id order regardless of direction`() {
+        userService.seed(UserDto(sender, guildId).apply { socialCredit = 200L })
+        userService.seed(UserDto(recipient, guildId).apply { socialCredit = 50L })
+
+        // sender (1) → recipient (2): lock order should be 1, 2.
+        service.tip(sender, recipient, guildId, amount = 20L, at = now)
+        assertEquals(listOf(sender, recipient), userService.lockOrder)
+
+        // Reset and try the reverse direction.
+        userService.lockOrder.clear()
+        service.tip(recipient, sender, guildId, amount = 20L, at = now)
+        // sender (1) is still the lower id even when we tip from recipient → sender.
+        assertEquals(listOf(sender, recipient), userService.lockOrder)
+    }
+
+    @Test
+    fun `tip truncates note to MAX_NOTE_LENGTH`() {
+        userService.seed(UserDto(sender, guildId).apply { socialCredit = 200L })
+        userService.seed(UserDto(recipient, guildId).apply { socialCredit = 0L })
+
+        val longNote = "x".repeat(TipService.MAX_NOTE_LENGTH + 50)
+        val outcome = service.tip(sender, recipient, guildId, amount = 10L, note = longNote, at = now)
+
+        assertTrue(outcome is TipService.TipOutcome.Ok)
+        assertNotNull(tipLogPersistence.inserted[0].note)
+        assertEquals(TipService.MAX_NOTE_LENGTH, tipLogPersistence.inserted[0].note!!.length)
+    }
+
+    private class RecordingUserService : UserService {
+        private val users = mutableMapOf<Pair<Long, Long>, UserDto>()
+        var updateCount: Int = 0
+            private set
+        val lockOrder: MutableList<Long> = mutableListOf()
+
+        fun seed(dto: UserDto) {
+            users[dto.discordId to dto.guildId] = dto
+        }
+
+        fun current(discordId: Long, guildId: Long): UserDto? = users[discordId to guildId]
+
+        override fun listGuildUsers(guildId: Long?): List<UserDto?> = users.values.filter { it.guildId == guildId }
+        override fun createNewUser(userDto: UserDto): UserDto = userDto.also(::seed)
+        override fun getUserById(discordId: Long?, guildId: Long?): UserDto? =
+            users[discordId!! to guildId!!]
+
+        override fun getUserByIdForUpdate(discordId: Long?, guildId: Long?): UserDto? {
+            lockOrder.add(discordId!!)
+            return getUserById(discordId, guildId)
+        }
+
+        override fun updateUser(userDto: UserDto): UserDto {
+            updateCount++
+            seed(userDto)
+            return userDto
+        }
+
+        override fun deleteUser(userDto: UserDto) { users.remove(userDto.discordId to userDto.guildId) }
+        override fun deleteUserById(discordId: Long?, guildId: Long?) { users.remove(discordId!! to guildId!!) }
+        override fun clearCache() {}
+        override fun evictUserFromCache(discordId: Long?, guildId: Long?) {}
+    }
+
+    private class InMemoryTipDailyService : TipDailyService {
+        private val rows = mutableMapOf<Triple<Long, Long, LocalDate>, TipDailyDto>()
+        override fun get(senderDiscordId: Long, guildId: Long, date: LocalDate): TipDailyDto? =
+            rows[Triple(senderDiscordId, guildId, date)]
+        override fun upsert(row: TipDailyDto): TipDailyDto {
+            rows[Triple(row.senderDiscordId, row.guildId, row.tipDate)] = row
+            return row
+        }
+    }
+
+    private class RecordingTipLogPersistence : TipLogPersistence {
+        val inserted: MutableList<TipLogDto> = mutableListOf()
+        override fun insert(row: TipLogDto): TipLogDto { inserted.add(row); return row }
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/button/buttons/DuelButton.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/button/buttons/DuelButton.kt
@@ -6,6 +6,7 @@ import core.button.Button
 import core.button.ButtonContext
 import database.dto.UserDto
 import database.service.DuelService
+import net.dv8tion.jda.api.components.MessageTopLevelComponent
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
@@ -62,7 +63,7 @@ class DuelButton @Autowired constructor(
         }
         event.message.editMessageEmbeds(
             DuelEmbeds.declineEmbed(offer.initiatorDiscordId, offer.opponentDiscordId, offer.stake)
-        ).setComponents(emptyList()).queue()
+        ).setComponents(emptyList<MessageTopLevelComponent>()).queue()
     }
 
     private fun handleAccept(
@@ -84,11 +85,11 @@ class DuelButton @Autowired constructor(
         when (outcome) {
             is DuelService.AcceptOutcome.Win -> {
                 event.message.editMessageEmbeds(DuelEmbeds.winEmbed(outcome))
-                    .setComponents(emptyList()).queue()
+                    .setComponents(emptyList<MessageTopLevelComponent>()).queue()
             }
             else -> {
                 event.message.editMessageEmbeds(DuelEmbeds.acceptErrorEmbed(outcome))
-                    .setComponents(emptyList()).queue()
+                    .setComponents(emptyList<MessageTopLevelComponent>()).queue()
             }
         }
     }

--- a/discord-bot/src/main/kotlin/bot/toby/button/buttons/DuelButton.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/button/buttons/DuelButton.kt
@@ -1,0 +1,95 @@
+package bot.toby.button.buttons
+
+import bot.toby.command.commands.economy.DuelEmbeds
+import database.duel.PendingDuelRegistry
+import core.button.Button
+import core.button.ButtonContext
+import database.dto.UserDto
+import database.service.DuelService
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+/**
+ * Resolves a `/duel` offer once the opponent clicks Accept or Decline.
+ * The duel id and the opponent's discord id are encoded in the
+ * component ID, so this handler doesn't need to look up the offer by
+ * any other key.
+ *
+ * Race-safety: [PendingDuelRegistry.consumeForAccept] and
+ * [PendingDuelRegistry.cancel] both use atomic remove. Double-clicks,
+ * accept-vs-decline races, and timeout-vs-click races all collapse to
+ * "exactly one path sees the offer; everyone else's branch logs
+ * 'offer already resolved or expired'".
+ */
+@Component
+class DuelButton @Autowired constructor(
+    private val duelService: DuelService,
+    private val pendingDuelRegistry: PendingDuelRegistry,
+) : Button {
+
+    override val name: String get() = DuelEmbeds.BUTTON_NAME
+    override val description: String get() = "Resolves a /duel offer in the opponent's chosen direction."
+
+    override fun handle(ctx: ButtonContext, requestingUserDto: UserDto, deleteDelay: Int) {
+        val event = ctx.event
+        val parsed = DuelEmbeds.parseButtonId(event.componentId) ?: run {
+            event.hook.sendMessage("Couldn't parse this duel button.").setEphemeral(true).queue()
+            return
+        }
+
+        if (requestingUserDto.discordId != parsed.opponentDiscordId) {
+            event.hook.sendMessage(
+                "This isn't your duel offer — wait for the challenged user to respond, " +
+                    "or run `/duel` to start your own."
+            ).setEphemeral(true).queue()
+            return
+        }
+
+        when (parsed.action) {
+            DuelEmbeds.Action.DECLINE -> handleDecline(event, parsed)
+            DuelEmbeds.Action.ACCEPT -> handleAccept(event, parsed)
+        }
+    }
+
+    private fun handleDecline(
+        event: net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent,
+        parsed: DuelEmbeds.ParsedButtonId,
+    ) {
+        val offer = pendingDuelRegistry.cancel(parsed.duelId)
+        if (offer == null) {
+            event.hook.sendMessage("This duel offer already resolved or expired.").setEphemeral(true).queue()
+            return
+        }
+        event.message.editMessageEmbeds(
+            DuelEmbeds.declineEmbed(offer.initiatorDiscordId, offer.opponentDiscordId, offer.stake)
+        ).setComponents(emptyList()).queue()
+    }
+
+    private fun handleAccept(
+        event: net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent,
+        parsed: DuelEmbeds.ParsedButtonId,
+    ) {
+        val offer = pendingDuelRegistry.consumeForAccept(parsed.duelId)
+        if (offer == null) {
+            event.hook.sendMessage("This duel offer already resolved or expired.").setEphemeral(true).queue()
+            return
+        }
+
+        val outcome = duelService.acceptDuel(
+            initiatorDiscordId = offer.initiatorDiscordId,
+            opponentDiscordId = offer.opponentDiscordId,
+            guildId = offer.guildId,
+            stake = offer.stake
+        )
+        when (outcome) {
+            is DuelService.AcceptOutcome.Win -> {
+                event.message.editMessageEmbeds(DuelEmbeds.winEmbed(outcome))
+                    .setComponents(emptyList()).queue()
+            }
+            else -> {
+                event.message.editMessageEmbeds(DuelEmbeds.acceptErrorEmbed(outcome))
+                    .setComponents(emptyList()).queue()
+            }
+        }
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/DuelCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/DuelCommand.kt
@@ -7,6 +7,7 @@ import core.command.CommandContext
 import database.dto.UserDto
 import database.service.DuelService
 import database.service.DuelService.StartOutcome
+import net.dv8tion.jda.api.components.MessageTopLevelComponent
 import net.dv8tion.jda.api.components.actionrow.ActionRow
 import net.dv8tion.jda.api.components.buttons.Button
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
@@ -102,7 +103,7 @@ class DuelCommand @Autowired constructor(
             runCatching {
                 event.hook.editOriginalEmbeds(
                     DuelEmbeds.timeoutEmbed(expired.initiatorDiscordId, expired.opponentDiscordId, expired.stake)
-                ).setComponents(emptyList()).queue()
+                ).setComponents(emptyList<MessageTopLevelComponent>()).queue()
             }
         }
 

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/DuelCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/DuelCommand.kt
@@ -1,0 +1,131 @@
+package bot.toby.command.commands.economy
+
+import database.duel.PendingDuelRegistry
+import bot.toby.helpers.UserDtoHelper
+import core.command.Command.Companion.invokeDeleteOnMessageResponse
+import core.command.CommandContext
+import database.dto.UserDto
+import database.service.DuelService
+import database.service.DuelService.StartOutcome
+import net.dv8tion.jda.api.components.actionrow.ActionRow
+import net.dv8tion.jda.api.components.buttons.Button
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
+import net.dv8tion.jda.api.interactions.commands.OptionType
+import net.dv8tion.jda.api.interactions.commands.build.OptionData
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+/**
+ * `/duel user:<member> stake:<int>` — challenge another user to a 50/50
+ * duel. Both players ante up the same stake when the opponent accepts;
+ * winner takes the pot minus the per-guild jackpot tribute.
+ *
+ * The opponent's accept/decline click is handled by
+ * [bot.toby.button.buttons.DuelButton], which atomically consumes the
+ * pending offer from [PendingDuelRegistry] and resolves through
+ * [DuelService.acceptDuel].
+ */
+@Component
+class DuelCommand @Autowired constructor(
+    private val duelService: DuelService,
+    private val pendingDuelRegistry: PendingDuelRegistry,
+    private val userDtoHelper: UserDtoHelper,
+) : EconomyCommand {
+
+    override val name: String = "duel"
+    override val description: String =
+        "Challenge another user to a 50/50 duel. Stake ${DuelService.MIN_STAKE}-${DuelService.MAX_STAKE} credits."
+
+    companion object {
+        private const val OPT_USER = "user"
+        private const val OPT_STAKE = "stake"
+        private const val TTL_SECONDS = 60L
+    }
+
+    override val optionData: List<OptionData> = listOf(
+        OptionData(OptionType.USER, OPT_USER, "Opponent", true),
+        OptionData(
+            OptionType.INTEGER,
+            OPT_STAKE,
+            "Credits to wager each (${DuelService.MIN_STAKE}-${DuelService.MAX_STAKE})",
+            true
+        )
+            .setMinValue(DuelService.MIN_STAKE)
+            .setMaxValue(DuelService.MAX_STAKE)
+    )
+
+    override fun handle(ctx: CommandContext, requestingUserDto: UserDto, deleteDelay: Int) {
+        val event = ctx.event
+        event.deferReply().queue()
+
+        val guild = event.guild ?: run {
+            replyError(event, "This command can only be used in a server.", deleteDelay); return
+        }
+        val targetUser = event.getOption(OPT_USER)?.asUser ?: run {
+            replyError(event, "You must specify an opponent.", deleteDelay); return
+        }
+        if (targetUser.isBot) {
+            replyError(event, "You can't duel a bot.", deleteDelay); return
+        }
+        if (targetUser.idLong == requestingUserDto.discordId) {
+            replyError(event, "You can't duel yourself.", deleteDelay); return
+        }
+        val stake = event.getOption(OPT_STAKE)?.asLong ?: run {
+            replyError(event, "You must specify a stake.", deleteDelay); return
+        }
+
+        // Lazy-create the opponent's user row so the pre-flight check can read their balance.
+        userDtoHelper.calculateUserDto(targetUser.idLong, guild.idLong)
+
+        val start = duelService.startDuel(
+            initiatorDiscordId = requestingUserDto.discordId,
+            opponentDiscordId = targetUser.idLong,
+            guildId = guild.idLong,
+            stake = stake
+        )
+        if (start !is StartOutcome.Ok) {
+            event.hook.sendMessageEmbeds(DuelEmbeds.startErrorEmbed(start))
+                .queue(invokeDeleteOnMessageResponse(deleteDelay))
+            return
+        }
+
+        val initiatorId = requestingUserDto.discordId
+        val opponentId = targetUser.idLong
+        val offer = pendingDuelRegistry.register(
+            guildId = guild.idLong,
+            initiatorDiscordId = initiatorId,
+            opponentDiscordId = opponentId,
+            stake = stake
+        ) { expired ->
+            // Edit the offer message in place when the timer fires and the offer is still pending.
+            // Use a best-effort lookup; if the message is gone there's nothing useful to do.
+            runCatching {
+                event.hook.editOriginalEmbeds(
+                    DuelEmbeds.timeoutEmbed(expired.initiatorDiscordId, expired.opponentDiscordId, expired.stake)
+                ).setComponents(emptyList()).queue()
+            }
+        }
+
+        val accept = Button.success(
+            DuelEmbeds.acceptButtonId(offer.id, opponentId),
+            "Accept"
+        )
+        val decline = Button.danger(
+            DuelEmbeds.declineButtonId(offer.id, opponentId),
+            "Decline"
+        )
+
+        event.hook.sendMessageEmbeds(
+            DuelEmbeds.offerEmbed(initiatorId, opponentId, stake, TTL_SECONDS)
+        ).addComponents(ActionRow.of(accept, decline)).queue()
+    }
+
+    private fun replyError(
+        event: SlashCommandInteractionEvent,
+        message: String,
+        deleteDelay: Int
+    ) {
+        event.hook.sendMessageEmbeds(DuelEmbeds.errorEmbed(message))
+            .queue(invokeDeleteOnMessageResponse(deleteDelay))
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/DuelEmbeds.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/DuelEmbeds.kt
@@ -1,0 +1,130 @@
+package bot.toby.command.commands.economy
+
+import database.service.DuelService.AcceptOutcome
+import database.service.DuelService.StartOutcome
+import net.dv8tion.jda.api.EmbedBuilder
+import net.dv8tion.jda.api.entities.MessageEmbed
+import java.awt.Color
+
+/**
+ * Shared embed/component plumbing for the Discord `/duel` flow.
+ * Component IDs encode the action, duel id, and the opponent's discord
+ * id so the button handler can both verify the clicker and look up
+ * the pending offer in [database.duel.PendingDuelRegistry] without
+ * any extra round-trip.
+ */
+internal object DuelEmbeds {
+
+    const val BUTTON_NAME = "duel"
+    private const val BUTTON_DELIM = ":"
+
+    private val OFFER_COLOR = Color(88, 101, 242)
+    private val WIN_COLOR = Color(87, 242, 135)
+    private val NEUTRAL_COLOR = Color(160, 160, 176)
+    private val ERROR_COLOR = Color(237, 66, 69)
+
+    enum class Action { ACCEPT, DECLINE }
+
+    fun acceptButtonId(duelId: Long, opponentDiscordId: Long): String =
+        encodeButtonId(Action.ACCEPT, duelId, opponentDiscordId)
+
+    fun declineButtonId(duelId: Long, opponentDiscordId: Long): String =
+        encodeButtonId(Action.DECLINE, duelId, opponentDiscordId)
+
+    private fun encodeButtonId(action: Action, duelId: Long, opponentDiscordId: Long): String =
+        listOf(BUTTON_NAME, action.name, duelId.toString(), opponentDiscordId.toString())
+            .joinToString(BUTTON_DELIM)
+
+    data class ParsedButtonId(
+        val action: Action,
+        val duelId: Long,
+        val opponentDiscordId: Long
+    )
+
+    fun parseButtonId(componentId: String): ParsedButtonId? {
+        val parts = componentId.split(BUTTON_DELIM)
+        if (parts.size != 4 || !parts[0].equals(BUTTON_NAME, ignoreCase = true)) return null
+        val action = runCatching { Action.valueOf(parts[1].uppercase()) }.getOrNull() ?: return null
+        val duelId = parts[2].toLongOrNull() ?: return null
+        val opponentDiscordId = parts[3].toLongOrNull() ?: return null
+        return ParsedButtonId(action, duelId, opponentDiscordId)
+    }
+
+    fun offerEmbed(
+        initiatorDiscordId: Long,
+        opponentDiscordId: Long,
+        stake: Long,
+        ttlSeconds: Long
+    ): MessageEmbed = EmbedBuilder()
+        .setTitle("⚔️ Duel offered")
+        .setDescription(
+            "<@$initiatorDiscordId> challenges <@$opponentDiscordId> to a duel for **$stake credits** each. " +
+                "Winner takes the pot (minus a small jackpot tribute). " +
+                "Accept within ${ttlSeconds}s."
+        )
+        .setColor(OFFER_COLOR)
+        .build()
+
+    fun winEmbed(outcome: AcceptOutcome.Win): MessageEmbed = EmbedBuilder()
+        .setTitle("⚔️ Duel resolved")
+        .setDescription(
+            "<@${outcome.winnerDiscordId}> beat <@${outcome.loserDiscordId}> for **+${outcome.stake - outcome.lossTribute} credits** " +
+                "(pot ${outcome.pot}, jackpot tribute ${outcome.lossTribute})."
+        )
+        .addField("Winner balance", "${outcome.winnerNewBalance} credits", true)
+        .addField("Loser balance", "${outcome.loserNewBalance} credits", true)
+        .setColor(WIN_COLOR)
+        .build()
+
+    fun declineEmbed(initiatorDiscordId: Long, opponentDiscordId: Long, stake: Long): MessageEmbed = EmbedBuilder()
+        .setTitle("⚔️ Duel declined")
+        .setDescription(
+            "<@$opponentDiscordId> declined the **$stake credit** challenge from <@$initiatorDiscordId>. " +
+                "No credits moved."
+        )
+        .setColor(NEUTRAL_COLOR)
+        .build()
+
+    fun timeoutEmbed(initiatorDiscordId: Long, opponentDiscordId: Long, stake: Long): MessageEmbed = EmbedBuilder()
+        .setTitle("⚔️ Duel offer expired")
+        .setDescription(
+            "<@$opponentDiscordId> didn't respond to <@$initiatorDiscordId>'s **$stake credit** challenge in time."
+        )
+        .setColor(NEUTRAL_COLOR)
+        .build()
+
+    fun startErrorEmbed(outcome: StartOutcome): MessageEmbed = errorEmbed(
+        when (outcome) {
+            is StartOutcome.InvalidStake -> "Stake must be between ${outcome.min} and ${outcome.max} credits."
+            is StartOutcome.InvalidOpponent -> when (outcome.reason) {
+                StartOutcome.InvalidOpponent.Reason.SELF -> "You can't duel yourself."
+                StartOutcome.InvalidOpponent.Reason.BOT -> "You can't duel a bot."
+            }
+            is StartOutcome.InitiatorInsufficient ->
+                "You need ${outcome.needed} credits to duel, but only have ${outcome.have}."
+            is StartOutcome.OpponentInsufficient ->
+                "Opponent only has ${outcome.have} credits — they can't cover a ${outcome.needed} stake."
+            StartOutcome.UnknownInitiator -> "No user record yet. Try another TobyBot command first."
+            StartOutcome.UnknownOpponent -> "Opponent has no user record in this guild yet."
+            is StartOutcome.Ok -> "OK" // unreachable
+        }
+    )
+
+    fun acceptErrorEmbed(outcome: AcceptOutcome): MessageEmbed = errorEmbed(
+        when (outcome) {
+            is AcceptOutcome.InitiatorInsufficient ->
+                "Challenger no longer has enough credits — they have ${outcome.have} but need ${outcome.needed}."
+            is AcceptOutcome.OpponentInsufficient ->
+                "You no longer have enough credits — you have ${outcome.have} but need ${outcome.needed}."
+            AcceptOutcome.UnknownInitiator -> "Challenger's user record vanished."
+            AcceptOutcome.UnknownOpponent -> "Your user record vanished."
+            is AcceptOutcome.Win -> "OK" // unreachable
+        }
+    )
+
+    fun errorEmbed(message: String): MessageEmbed = EmbedBuilder()
+        .setTitle("⚔️ Duel")
+        .setDescription(message)
+        .setColor(ERROR_COLOR)
+        .build()
+}

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/TipCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/TipCommand.kt
@@ -1,0 +1,153 @@
+package bot.toby.command.commands.economy
+
+import bot.toby.helpers.UserDtoHelper
+import core.command.Command.Companion.invokeDeleteOnMessageResponse
+import core.command.CommandContext
+import database.dto.UserDto
+import database.service.TipService
+import database.service.TipService.TipOutcome
+import net.dv8tion.jda.api.EmbedBuilder
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
+import net.dv8tion.jda.api.interactions.commands.OptionType
+import net.dv8tion.jda.api.interactions.commands.build.OptionData
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+import java.awt.Color
+
+/**
+ * `/tip user:<member> amount:<int> message:<text?>` — peer-to-peer
+ * social-credit transfer. Goes through the same [TipService] the web
+ * UI uses, so the per-sender daily outgoing cap and the audit log
+ * stay consistent across surfaces.
+ */
+@Component
+class TipCommand @Autowired constructor(
+    private val tipService: TipService,
+    private val userDtoHelper: UserDtoHelper,
+) : EconomyCommand {
+
+    override val name: String = "tip"
+    override val description: String =
+        "Send another user some social credit. ${TipService.MIN_TIP}-${TipService.MAX_TIP} per tip."
+
+    companion object {
+        private const val OPT_USER = "user"
+        private const val OPT_AMOUNT = "amount"
+        private const val OPT_MESSAGE = "message"
+        private val OK_COLOR = Color(87, 242, 135)
+        private val ERROR_COLOR = Color(237, 66, 69)
+    }
+
+    override val optionData: List<OptionData> = listOf(
+        OptionData(OptionType.USER, OPT_USER, "Recipient", true),
+        OptionData(
+            OptionType.INTEGER,
+            OPT_AMOUNT,
+            "Credits to send (${TipService.MIN_TIP}–${TipService.MAX_TIP})",
+            true
+        )
+            .setMinValue(TipService.MIN_TIP)
+            .setMaxValue(TipService.MAX_TIP),
+        OptionData(OptionType.STRING, OPT_MESSAGE, "Optional note", false)
+    )
+
+    override fun handle(ctx: CommandContext, requestingUserDto: UserDto, deleteDelay: Int) {
+        val event = ctx.event
+        event.deferReply().queue()
+
+        val guild = event.guild ?: run {
+            replyError(event, "This command can only be used in a server.", deleteDelay); return
+        }
+        val targetUser = event.getOption(OPT_USER)?.asUser ?: run {
+            replyError(event, "You must specify a recipient.", deleteDelay); return
+        }
+        if (targetUser.isBot) {
+            replyError(event, "You can't tip a bot.", deleteDelay); return
+        }
+        if (targetUser.idLong == requestingUserDto.discordId) {
+            replyError(event, "You can't tip yourself.", deleteDelay); return
+        }
+        val amount = event.getOption(OPT_AMOUNT)?.asLong ?: run {
+            replyError(event, "You must specify an amount.", deleteDelay); return
+        }
+        val note = event.getOption(OPT_MESSAGE)?.asString
+
+        // Lazy-create the recipient row so we can credit them even if they've
+        // never run a TobyBot command before.
+        userDtoHelper.calculateUserDto(targetUser.idLong, guild.idLong)
+
+        val outcome = tipService.tip(
+            senderDiscordId = requestingUserDto.discordId,
+            recipientDiscordId = targetUser.idLong,
+            guildId = guild.idLong,
+            amount = amount,
+            note = note
+        )
+        replyOutcome(event, outcome, deleteDelay)
+    }
+
+    private fun replyOutcome(
+        event: SlashCommandInteractionEvent,
+        outcome: TipOutcome,
+        deleteDelay: Int
+    ) {
+        val embed = when (outcome) {
+            is TipOutcome.Ok -> {
+                val builder = EmbedBuilder()
+                    .setTitle("💸 Tip sent")
+                    .setDescription(
+                        "<@${outcome.sender}> tipped <@${outcome.recipient}> **${outcome.amount} credits**." +
+                            outcome.note?.let { "\n*${it}*" }.orEmpty()
+                    )
+                    .addField("Your balance", "${outcome.senderNewBalance} credits", true)
+                    .addField(
+                        "Tipped today",
+                        "${outcome.sentTodayAfter}/${outcome.dailyCap}",
+                        true
+                    )
+                    .setColor(OK_COLOR)
+                builder.build()
+            }
+
+            is TipOutcome.InvalidAmount -> errorEmbed(
+                "Tip amount must be between ${outcome.min} and ${outcome.max} credits."
+            )
+
+            is TipOutcome.InvalidRecipient -> errorEmbed(
+                when (outcome.reason) {
+                    TipOutcome.InvalidRecipient.Reason.SELF -> "You can't tip yourself."
+                    TipOutcome.InvalidRecipient.Reason.BOT -> "You can't tip a bot."
+                    TipOutcome.InvalidRecipient.Reason.MISSING -> "Recipient does not exist."
+                }
+            )
+
+            is TipOutcome.InsufficientCredits -> errorEmbed(
+                "You only have ${outcome.have} credits but tried to send ${outcome.needed}."
+            )
+
+            is TipOutcome.DailyCapExceeded -> errorEmbed(
+                "Daily tip cap reached. You've sent ${outcome.sentToday}/${outcome.cap} today; " +
+                    "${outcome.cap - outcome.sentToday} credits of headroom remain."
+            )
+
+            TipOutcome.UnknownSender -> errorEmbed(
+                "No user record yet. Try another TobyBot command first."
+            )
+
+            TipOutcome.UnknownRecipient -> errorEmbed(
+                "Recipient has no user record in this guild yet."
+            )
+        }
+        event.hook.sendMessageEmbeds(embed).queue(invokeDeleteOnMessageResponse(deleteDelay))
+    }
+
+    private fun errorEmbed(message: String) = EmbedBuilder()
+        .setTitle("💸 Tip")
+        .setDescription(message)
+        .setColor(ERROR_COLOR)
+        .build()
+
+    private fun replyError(event: SlashCommandInteractionEvent, message: String, deleteDelay: Int) {
+        event.hook.sendMessageEmbeds(errorEmbed(message)).queue(invokeDeleteOnMessageResponse(deleteDelay))
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/managers/DefaultButtonManager.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/managers/DefaultButtonManager.kt
@@ -38,5 +38,10 @@ class DefaultButtonManager @Autowired constructor(
         }
     }
 
-    override fun getButton(search: String): Button? = buttons.find { it.name.equals(search, true) }
+    // Component IDs may be stateful (e.g. "highlow:HIGHER:9:50:6", "duel:accept:1:42").
+    // Match on the colon-prefix so a single Button bean handles every variant.
+    override fun getButton(search: String): Button? {
+        val prefix = search.substringBefore(':').lowercase()
+        return buttons.find { it.name.equals(prefix, true) }
+    }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/voice/VoiceCreditConfig.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/voice/VoiceCreditConfig.kt
@@ -3,7 +3,7 @@ package bot.toby.voice
 object VoiceCreditConfig {
     const val SECONDS_PER_CREDIT: Long = 120L
 
-    const val DAILY_CREDIT_CAP: Long = 60L
+    const val DAILY_CREDIT_CAP: Long = 90L
 
     const val MAX_RECOVERED_SESSION_SECONDS: Long = 8L * 60L * 60L
 }

--- a/discord-bot/src/test/kotlin/bot/toby/button/buttons/DuelButtonTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/button/buttons/DuelButtonTest.kt
@@ -1,0 +1,151 @@
+package bot.toby.button.buttons
+
+import bot.toby.button.ButtonTest
+import bot.toby.button.ButtonTest.Companion.event
+import bot.toby.button.ButtonTest.Companion.mockGuild
+import bot.toby.button.ButtonTest.Companion.mockHook
+import bot.toby.button.DefaultButtonContext
+import bot.toby.command.commands.economy.DuelEmbeds
+import database.duel.PendingDuelRegistry
+import database.dto.UserDto
+import database.service.DuelService
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import net.dv8tion.jda.api.components.MessageTopLevelComponent
+import net.dv8tion.jda.api.entities.Message
+import net.dv8tion.jda.api.entities.MessageEmbed
+import net.dv8tion.jda.api.requests.RestAction
+import net.dv8tion.jda.api.requests.restaction.WebhookMessageCreateAction
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+class DuelButtonTest : ButtonTest {
+
+    private lateinit var duelService: DuelService
+    private lateinit var pendingDuelRegistry: PendingDuelRegistry
+    private lateinit var button: DuelButton
+
+    private val initiatorId = 1L
+    private val opponentId = 2L
+    private val guildId = 1L
+    private val stake = 50L
+    private val duelId = 100L
+
+    private lateinit var message: Message
+    private lateinit var messageEditAction: RestAction<Void>
+    @Suppress("UNCHECKED_CAST")
+    private fun anyEditAction(): RestAction<Void> = mockk(relaxed = true) {
+        every { queue() } just Runs
+    }
+
+    @BeforeEach
+    override fun setup() {
+        super.setup()
+        every { mockGuild.idLong } returns guildId
+
+        duelService = mockk(relaxed = true)
+        pendingDuelRegistry = mockk(relaxed = true)
+        button = DuelButton(duelService, pendingDuelRegistry)
+
+        message = mockk(relaxed = true)
+        every { event.message } returns message
+
+        // Wire the edit-message chain. JDA returns a MessageEditAction; we
+        // care about the queue() at the end.
+        val edit = mockk<net.dv8tion.jda.api.requests.restaction.MessageEditAction>(relaxed = true)
+        every { message.editMessageEmbeds(any<MessageEmbed>()) } returns edit
+        every { edit.setComponents(any<Collection<MessageTopLevelComponent>>()) } returns edit
+        every { edit.setComponents(*anyVararg<MessageTopLevelComponent>()) } returns edit
+        every { edit.queue() } just Runs
+
+        // Hook send for ephemeral replies.
+        val send = mockk<WebhookMessageCreateAction<Message>>(relaxed = true)
+        every { mockHook.sendMessage(any<String>()) } returns send
+        every { send.setEphemeral(any()) } returns send
+        every { send.queue() } just Runs
+    }
+
+    @AfterEach
+    @Throws(Exception::class)
+    override fun tearDown() {
+        super.tearDown()
+    }
+
+    private fun pendingDuel() = PendingDuelRegistry.PendingDuel(
+        id = duelId, guildId = guildId,
+        initiatorDiscordId = initiatorId, opponentDiscordId = opponentId,
+        stake = stake, createdAt = Instant.now()
+    )
+
+    @Test
+    fun `non-opponent gets ephemeral reject without resolving`() {
+        every { event.componentId } returns DuelEmbeds.acceptButtonId(duelId, opponentId)
+
+        button.handle(DefaultButtonContext(event), UserDto(999L, guildId), 0)
+
+        verify(exactly = 0) { duelService.acceptDuel(any(), any(), any(), any(), any()) }
+        verify(exactly = 0) { pendingDuelRegistry.consumeForAccept(any()) }
+        verify { mockHook.sendMessage(any<String>()) }
+    }
+
+    @Test
+    fun `accept happy path resolves via DuelService and edits the offer message`() {
+        every { event.componentId } returns DuelEmbeds.acceptButtonId(duelId, opponentId)
+        every { pendingDuelRegistry.consumeForAccept(duelId) } returns pendingDuel()
+        every {
+            duelService.acceptDuel(initiatorId, opponentId, guildId, stake)
+        } returns DuelService.AcceptOutcome.Win(
+            winnerDiscordId = initiatorId, loserDiscordId = opponentId,
+            stake = stake, pot = 100L,
+            winnerNewBalance = 245L, loserNewBalance = 50L,
+            lossTribute = 5L
+        )
+
+        button.handle(DefaultButtonContext(event), UserDto(opponentId, guildId), 0)
+
+        verify(exactly = 1) { pendingDuelRegistry.consumeForAccept(duelId) }
+        verify(exactly = 1) { duelService.acceptDuel(initiatorId, opponentId, guildId, stake) }
+        verify { event.message.editMessageEmbeds(any<MessageEmbed>()) }
+    }
+
+    @Test
+    fun `accept after offer expired returns ephemeral expired message`() {
+        every { event.componentId } returns DuelEmbeds.acceptButtonId(duelId, opponentId)
+        every { pendingDuelRegistry.consumeForAccept(duelId) } returns null
+
+        button.handle(DefaultButtonContext(event), UserDto(opponentId, guildId), 0)
+
+        verify(exactly = 0) { duelService.acceptDuel(any(), any(), any(), any(), any()) }
+        verify { mockHook.sendMessage(any<String>()) }
+    }
+
+    @Test
+    fun `decline cancels offer in registry without calling service`() {
+        every { event.componentId } returns DuelEmbeds.declineButtonId(duelId, opponentId)
+        every { pendingDuelRegistry.cancel(duelId) } returns pendingDuel()
+
+        button.handle(DefaultButtonContext(event), UserDto(opponentId, guildId), 0)
+
+        verify(exactly = 1) { pendingDuelRegistry.cancel(duelId) }
+        verify(exactly = 0) { duelService.acceptDuel(any(), any(), any(), any(), any()) }
+        verify { event.message.editMessageEmbeds(any<MessageEmbed>()) }
+    }
+
+    @Test
+    fun `accept where service reports insufficient credits renders error embed`() {
+        every { event.componentId } returns DuelEmbeds.acceptButtonId(duelId, opponentId)
+        every { pendingDuelRegistry.consumeForAccept(duelId) } returns pendingDuel()
+        every {
+            duelService.acceptDuel(initiatorId, opponentId, guildId, stake)
+        } returns DuelService.AcceptOutcome.InitiatorInsufficient(have = 5L, needed = 50L)
+
+        button.handle(DefaultButtonContext(event), UserDto(opponentId, guildId), 0)
+
+        verify { event.message.editMessageEmbeds(any<MessageEmbed>()) }
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/button/buttons/DuelButtonTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/button/buttons/DuelButtonTest.kt
@@ -17,7 +17,6 @@ import io.mockk.verify
 import net.dv8tion.jda.api.components.MessageTopLevelComponent
 import net.dv8tion.jda.api.entities.Message
 import net.dv8tion.jda.api.entities.MessageEmbed
-import net.dv8tion.jda.api.requests.RestAction
 import net.dv8tion.jda.api.requests.restaction.WebhookMessageCreateAction
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
@@ -37,11 +36,6 @@ class DuelButtonTest : ButtonTest {
     private val duelId = 100L
 
     private lateinit var message: Message
-    private lateinit var messageEditAction: RestAction<Void>
-    @Suppress("UNCHECKED_CAST")
-    private fun anyEditAction(): RestAction<Void> = mockk(relaxed = true) {
-        every { queue() } just Runs
-    }
 
     @BeforeEach
     override fun setup() {

--- a/discord-bot/src/test/kotlin/bot/toby/button/buttons/DuelButtonTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/button/buttons/DuelButtonTest.kt
@@ -92,7 +92,7 @@ class DuelButtonTest : ButtonTest {
         every { event.componentId } returns DuelEmbeds.acceptButtonId(duelId, opponentId)
         every { pendingDuelRegistry.consumeForAccept(duelId) } returns pendingDuel()
         every {
-            duelService.acceptDuel(initiatorId, opponentId, guildId, stake)
+            duelService.acceptDuel(initiatorId, opponentId, guildId, stake, any())
         } returns DuelService.AcceptOutcome.Win(
             winnerDiscordId = initiatorId, loserDiscordId = opponentId,
             stake = stake, pot = 100L,
@@ -103,8 +103,8 @@ class DuelButtonTest : ButtonTest {
         button.handle(DefaultButtonContext(event), UserDto(opponentId, guildId), 0)
 
         verify(exactly = 1) { pendingDuelRegistry.consumeForAccept(duelId) }
-        verify(exactly = 1) { duelService.acceptDuel(initiatorId, opponentId, guildId, stake) }
-        verify { event.message.editMessageEmbeds(any<MessageEmbed>()) }
+        verify(exactly = 1) { duelService.acceptDuel(initiatorId, opponentId, guildId, stake, any()) }
+        verify { message.editMessageEmbeds(any<MessageEmbed>()) }
     }
 
     @Test
@@ -127,7 +127,7 @@ class DuelButtonTest : ButtonTest {
 
         verify(exactly = 1) { pendingDuelRegistry.cancel(duelId) }
         verify(exactly = 0) { duelService.acceptDuel(any(), any(), any(), any(), any()) }
-        verify { event.message.editMessageEmbeds(any<MessageEmbed>()) }
+        verify { message.editMessageEmbeds(any<MessageEmbed>()) }
     }
 
     @Test
@@ -135,11 +135,11 @@ class DuelButtonTest : ButtonTest {
         every { event.componentId } returns DuelEmbeds.acceptButtonId(duelId, opponentId)
         every { pendingDuelRegistry.consumeForAccept(duelId) } returns pendingDuel()
         every {
-            duelService.acceptDuel(initiatorId, opponentId, guildId, stake)
+            duelService.acceptDuel(initiatorId, opponentId, guildId, stake, any())
         } returns DuelService.AcceptOutcome.InitiatorInsufficient(have = 5L, needed = 50L)
 
         button.handle(DefaultButtonContext(event), UserDto(opponentId, guildId), 0)
 
-        verify { event.message.editMessageEmbeds(any<MessageEmbed>()) }
+        verify { message.editMessageEmbeds(any<MessageEmbed>()) }
     }
 }

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/economy/DuelCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/economy/DuelCommandTest.kt
@@ -1,0 +1,139 @@
+package bot.toby.command.commands.economy
+
+import bot.toby.command.CommandTest
+import bot.toby.command.CommandTest.Companion.event
+import bot.toby.command.CommandTest.Companion.guild
+import bot.toby.command.DefaultCommandContext
+import database.duel.PendingDuelRegistry
+import bot.toby.helpers.UserDtoHelper
+import database.dto.UserDto
+import database.service.DuelService
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import net.dv8tion.jda.api.entities.User
+import net.dv8tion.jda.api.interactions.commands.OptionMapping
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class DuelCommandTest : CommandTest {
+    private lateinit var duelService: DuelService
+    private lateinit var pendingDuelRegistry: PendingDuelRegistry
+    private lateinit var userDtoHelper: UserDtoHelper
+    private lateinit var command: DuelCommand
+
+    private val initiatorId = 1L
+    private val opponentId = 2L
+    private val guildId = 42L
+
+    @BeforeEach
+    fun setUp() {
+        setUpCommonMocks()
+        duelService = mockk(relaxed = true)
+        pendingDuelRegistry = mockk(relaxed = true)
+        userDtoHelper = mockk(relaxed = true)
+        command = DuelCommand(duelService, pendingDuelRegistry, userDtoHelper)
+        every { guild.idLong } returns guildId
+    }
+
+    @AfterEach
+    fun tearDown() {
+        tearDownCommonMocks()
+        clearAllMocks()
+    }
+
+    private fun userOpt(target: User): OptionMapping {
+        val o = mockk<OptionMapping>(relaxed = true)
+        every { o.asUser } returns target
+        return o
+    }
+
+    private fun intOpt(value: Long): OptionMapping {
+        val o = mockk<OptionMapping>(relaxed = true)
+        every { o.asLong } returns value
+        return o
+    }
+
+    private fun targetUser(idLong: Long, isBot: Boolean = false): User {
+        val u = mockk<User>(relaxed = true)
+        every { u.idLong } returns idLong
+        every { u.isBot } returns isBot
+        return u
+    }
+
+    @Test
+    fun `on Ok startDuel registers a pending offer`() {
+        val initiator = UserDto(discordId = initiatorId, guildId = guildId).apply { socialCredit = 200L }
+        val opponent = targetUser(opponentId)
+        every { event.getOption("user") } returns userOpt(opponent)
+        every { event.getOption("stake") } returns intOpt(50L)
+        every {
+            duelService.startDuel(initiatorId, opponentId, guildId, 50L)
+        } returns DuelService.StartOutcome.Ok(initiatorBalance = 200L)
+        every {
+            pendingDuelRegistry.register(any(), any(), any(), any(), any(), any())
+        } returns PendingDuelRegistry.PendingDuel(
+            id = 99L, guildId = guildId,
+            initiatorDiscordId = initiatorId, opponentDiscordId = opponentId,
+            stake = 50L, createdAt = java.time.Instant.now()
+        )
+
+        command.handle(DefaultCommandContext(event), initiator, 5)
+
+        verify(exactly = 1) {
+            duelService.startDuel(initiatorId, opponentId, guildId, 50L)
+        }
+        verify(exactly = 1) {
+            pendingDuelRegistry.register(
+                guildId = guildId,
+                initiatorDiscordId = initiatorId,
+                opponentDiscordId = opponentId,
+                stake = 50L,
+                createdAt = any(),
+                onTimeout = any()
+            )
+        }
+    }
+
+    @Test
+    fun `bot opponent is rejected before service is called`() {
+        val initiator = UserDto(discordId = initiatorId, guildId = guildId).apply { socialCredit = 200L }
+        val bot = targetUser(opponentId, isBot = true)
+        every { event.getOption("user") } returns userOpt(bot)
+        every { event.getOption("stake") } returns intOpt(50L)
+
+        command.handle(DefaultCommandContext(event), initiator, 5)
+
+        verify(exactly = 0) { duelService.startDuel(any(), any(), any(), any()) }
+        verify(exactly = 0) { pendingDuelRegistry.register(any(), any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `self opponent is rejected before service is called`() {
+        val initiator = UserDto(discordId = initiatorId, guildId = guildId).apply { socialCredit = 200L }
+        val self = targetUser(initiatorId)
+        every { event.getOption("user") } returns userOpt(self)
+        every { event.getOption("stake") } returns intOpt(50L)
+
+        command.handle(DefaultCommandContext(event), initiator, 5)
+
+        verify(exactly = 0) { duelService.startDuel(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `non-Ok start outcomes do not register an offer`() {
+        val initiator = UserDto(discordId = initiatorId, guildId = guildId).apply { socialCredit = 5L }
+        val opponent = targetUser(opponentId)
+        every { event.getOption("user") } returns userOpt(opponent)
+        every { event.getOption("stake") } returns intOpt(50L)
+        every {
+            duelService.startDuel(initiatorId, opponentId, guildId, 50L)
+        } returns DuelService.StartOutcome.InitiatorInsufficient(have = 5L, needed = 50L)
+
+        command.handle(DefaultCommandContext(event), initiator, 5)
+
+        verify(exactly = 0) { pendingDuelRegistry.register(any(), any(), any(), any(), any(), any()) }
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/economy/DuelCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/economy/DuelCommandTest.kt
@@ -86,14 +86,7 @@ internal class DuelCommandTest : CommandTest {
             duelService.startDuel(initiatorId, opponentId, guildId, 50L)
         }
         verify(exactly = 1) {
-            pendingDuelRegistry.register(
-                guildId = guildId,
-                initiatorDiscordId = initiatorId,
-                opponentDiscordId = opponentId,
-                stake = 50L,
-                createdAt = any(),
-                onTimeout = any()
-            )
+            pendingDuelRegistry.register(guildId, initiatorId, opponentId, 50L, any(), any())
         }
     }
 

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/economy/TipCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/economy/TipCommandTest.kt
@@ -1,0 +1,146 @@
+package bot.toby.command.commands.economy
+
+import bot.toby.command.CommandTest
+import bot.toby.command.CommandTest.Companion.event
+import bot.toby.command.CommandTest.Companion.guild
+import bot.toby.command.CommandTest.Companion.user
+import bot.toby.command.DefaultCommandContext
+import bot.toby.helpers.UserDtoHelper
+import database.dto.UserDto
+import database.service.TipService
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import net.dv8tion.jda.api.entities.User
+import net.dv8tion.jda.api.interactions.commands.OptionMapping
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class TipCommandTest : CommandTest {
+    private lateinit var tipService: TipService
+    private lateinit var userDtoHelper: UserDtoHelper
+    private lateinit var command: TipCommand
+
+    private val senderId = 1L
+    private val recipientId = 2L
+    private val guildId = 42L
+
+    @BeforeEach
+    fun setUp() {
+        setUpCommonMocks()
+        tipService = mockk(relaxed = true)
+        userDtoHelper = mockk(relaxed = true)
+        command = TipCommand(tipService, userDtoHelper)
+        every { guild.idLong } returns guildId
+    }
+
+    @AfterEach
+    fun tearDown() {
+        tearDownCommonMocks()
+        clearAllMocks()
+    }
+
+    private fun userOpt(target: User): OptionMapping {
+        val o = mockk<OptionMapping>(relaxed = true)
+        every { o.asUser } returns target
+        return o
+    }
+
+    private fun intOpt(value: Long): OptionMapping {
+        val o = mockk<OptionMapping>(relaxed = true)
+        every { o.asLong } returns value
+        return o
+    }
+
+    private fun strOpt(value: String): OptionMapping {
+        val o = mockk<OptionMapping>(relaxed = true)
+        every { o.asString } returns value
+        return o
+    }
+
+    private fun targetUser(idLong: Long, isBot: Boolean = false): User {
+        val u = mockk<User>(relaxed = true)
+        every { u.idLong } returns idLong
+        every { u.isBot } returns isBot
+        return u
+    }
+
+    @Test
+    fun `delegates to TipService with parsed args`() {
+        val sender = UserDto(discordId = senderId, guildId = guildId).apply { socialCredit = 200L }
+        val target = targetUser(recipientId)
+        every { event.getOption("user") } returns userOpt(target)
+        every { event.getOption("amount") } returns intOpt(50L)
+        every { event.getOption("message") } returns strOpt("thanks")
+        every {
+            tipService.tip(senderId, recipientId, guildId, 50L, "thanks")
+        } returns TipService.TipOutcome.Ok(
+            sender = senderId, recipient = recipientId, amount = 50L, note = "thanks",
+            senderNewBalance = 150L, recipientNewBalance = 50L,
+            sentTodayAfter = 50L, dailyCap = 500L
+        )
+
+        command.handle(DefaultCommandContext(event), sender, 5)
+
+        verify(exactly = 1) {
+            tipService.tip(senderId, recipientId, guildId, 50L, "thanks")
+        }
+        verify(exactly = 1) {
+            userDtoHelper.calculateUserDto(recipientId, guildId, false)
+        }
+    }
+
+    @Test
+    fun `rejects bot recipient before calling service`() {
+        val sender = UserDto(discordId = senderId, guildId = guildId).apply { socialCredit = 200L }
+        val bot = targetUser(recipientId, isBot = true)
+        every { event.getOption("user") } returns userOpt(bot)
+        every { event.getOption("amount") } returns intOpt(50L)
+
+        command.handle(DefaultCommandContext(event), sender, 5)
+
+        verify(exactly = 0) { tipService.tip(any(), any(), any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `rejects self recipient before calling service`() {
+        val sender = UserDto(discordId = senderId, guildId = guildId).apply { socialCredit = 200L }
+        val self = targetUser(senderId)
+        every { event.getOption("user") } returns userOpt(self)
+        every { event.getOption("amount") } returns intOpt(50L)
+
+        command.handle(DefaultCommandContext(event), sender, 5)
+
+        verify(exactly = 0) { tipService.tip(any(), any(), any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `renders embed for each TipOutcome variant`() {
+        val sender = UserDto(discordId = senderId, guildId = guildId).apply { socialCredit = 200L }
+        val target = targetUser(recipientId)
+        every { event.getOption("user") } returns userOpt(target)
+        every { event.getOption("amount") } returns intOpt(50L)
+        every { event.getOption("message") } returns null
+
+        val outcomes = listOf(
+            TipService.TipOutcome.Ok(senderId, recipientId, 50L, null, 150L, 50L, 50L, 500L),
+            TipService.TipOutcome.InvalidAmount(10L, 500L),
+            TipService.TipOutcome.InvalidRecipient(TipService.TipOutcome.InvalidRecipient.Reason.SELF),
+            TipService.TipOutcome.InsufficientCredits(have = 30L, needed = 50L),
+            TipService.TipOutcome.DailyCapExceeded(sentToday = 480L, cap = 500L, attempted = 50L),
+            TipService.TipOutcome.UnknownSender,
+            TipService.TipOutcome.UnknownRecipient,
+        )
+
+        outcomes.forEach { variant ->
+            every {
+                tipService.tip(senderId, recipientId, guildId, 50L, null)
+            } returns variant
+
+            // Should not throw on any variant.
+            command.handle(DefaultCommandContext(event), sender, 5)
+        }
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/economy/TipCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/economy/TipCommandTest.kt
@@ -75,7 +75,7 @@ internal class TipCommandTest : CommandTest {
         every { event.getOption("amount") } returns intOpt(50L)
         every { event.getOption("message") } returns strOpt("thanks")
         every {
-            tipService.tip(senderId, recipientId, guildId, 50L, "thanks")
+            tipService.tip(senderId, recipientId, guildId, 50L, "thanks", any(), any())
         } returns TipService.TipOutcome.Ok(
             sender = senderId, recipient = recipientId, amount = 50L, note = "thanks",
             senderNewBalance = 150L, recipientNewBalance = 50L,
@@ -85,7 +85,7 @@ internal class TipCommandTest : CommandTest {
         command.handle(DefaultCommandContext(event), sender, 5)
 
         verify(exactly = 1) {
-            tipService.tip(senderId, recipientId, guildId, 50L, "thanks")
+            tipService.tip(senderId, recipientId, guildId, 50L, "thanks", any(), any())
         }
         verify(exactly = 1) {
             userDtoHelper.calculateUserDto(recipientId, guildId, false)
@@ -136,7 +136,7 @@ internal class TipCommandTest : CommandTest {
 
         outcomes.forEach { variant ->
             every {
-                tipService.tip(senderId, recipientId, guildId, 50L, null)
+                tipService.tip(senderId, recipientId, guildId, 50L, null, any(), any())
             } returns variant
 
             // Should not throw on any variant.

--- a/discord-bot/src/test/kotlin/bot/toby/managers/DefaultButtonManagerTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/managers/DefaultButtonManagerTest.kt
@@ -1,0 +1,73 @@
+package bot.toby.managers
+
+import bot.toby.helpers.UserDtoHelper
+import core.button.Button
+import core.button.ButtonContext
+import database.dto.UserDto
+import database.service.ConfigService
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+/**
+ * Confirms the colon-prefix routing required by stateful component IDs
+ * such as `highlow:HIGHER:9:50:6` and `duel:accept:1:42`. With exact
+ * equals, every existing button using a colon-suffixed component id
+ * would silently fail to dispatch.
+ */
+class DefaultButtonManagerTest {
+
+    private class FakeButton(override val name: String) : Button {
+        override val description: String = "test"
+        override fun handle(ctx: ButtonContext, requestingUserDto: UserDto, deleteDelay: Int) = Unit
+    }
+
+    private fun manager(vararg buttons: Button): DefaultButtonManager {
+        val configService = mockk<ConfigService>(relaxed = true)
+        val userDtoHelper = mockk<UserDtoHelper>(relaxed = true)
+        return DefaultButtonManager(configService, userDtoHelper, buttons.toList())
+    }
+
+    @Test
+    fun `getButton resolves stateful highlow componentId via colon-prefix`() {
+        val highlow = FakeButton("highlow")
+        val mgr = manager(highlow)
+
+        assertEquals(highlow, mgr.getButton("highlow:HIGHER:9:50:6"))
+    }
+
+    @Test
+    fun `getButton resolves stateful duel componentId via colon-prefix`() {
+        val duel = FakeButton("duel")
+        val mgr = manager(duel)
+
+        assertEquals(duel, mgr.getButton("duel:accept:1:42"))
+        assertEquals(duel, mgr.getButton("duel:decline:1:42"))
+    }
+
+    @Test
+    fun `getButton matches exact name when no colon present`() {
+        val plain = FakeButton("plain")
+        val mgr = manager(plain)
+
+        assertEquals(plain, mgr.getButton("plain"))
+    }
+
+    @Test
+    fun `getButton returns null when no button matches`() {
+        val mgr = manager(FakeButton("highlow"), FakeButton("duel"))
+
+        assertNull(mgr.getButton("nonexistent:whatever"))
+        assertNull(mgr.getButton("nonexistent"))
+    }
+
+    @Test
+    fun `getButton matching is case-insensitive on the prefix`() {
+        val duel = FakeButton("duel")
+        val mgr = manager(duel)
+
+        assertEquals(duel, mgr.getButton("DUEL:ACCEPT:1:42"))
+        assertEquals(duel, mgr.getButton("Duel:Accept:1:42"))
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/voice/VoiceCreditAwardServiceTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/voice/VoiceCreditAwardServiceTest.kt
@@ -101,7 +101,7 @@ class VoiceCreditAwardServiceTest {
             awardService.award(
                 discordId = discordId,
                 guildId = guildId,
-                amount = 60L,
+                amount = 90L,
                 reason = "voice-session",
                 countsAgainstDailyCap = any(),
                 at = any(),
@@ -112,8 +112,8 @@ class VoiceCreditAwardServiceTest {
         val closed = slot<VoiceSessionDto>()
         every { voiceSessionService.closeSession(capture(closed)) } answers { closed.captured }
 
-        // 7200s / 120s = 60 credits requested; awardService only grants 5 (cap).
-        service.closeSessionAndAward(session(t0), t0.plusSeconds(7200), hadCompanyDurationSeconds = 7200L)
+        // 10800s / 120s = 90 credits requested; awardService only grants 5 (cap).
+        service.closeSessionAndAward(session(t0), t0.plusSeconds(10800), hadCompanyDurationSeconds = 10800L)
 
         assertEquals(5L, closed.captured.creditsAwarded)
     }

--- a/web/src/main/kotlin/web/configuration/WebSecurityConfig.kt
+++ b/web/src/main/kotlin/web/configuration/WebSecurityConfig.kt
@@ -24,6 +24,8 @@ class WebSecurityConfig {
                 auth.requestMatchers("/dnd/**").authenticated()
                 auth.requestMatchers("/moderation/**").authenticated()
                 auth.requestMatchers("/economy/**").authenticated()
+                auth.requestMatchers("/tip/**").authenticated()
+                auth.requestMatchers("/duel/**").authenticated()
                 auth.anyRequest().authenticated()
             }
             .oauth2Login { oauth2 ->

--- a/web/src/main/kotlin/web/controller/DuelController.kt
+++ b/web/src/main/kotlin/web/controller/DuelController.kt
@@ -1,0 +1,257 @@
+package web.controller
+
+import database.duel.PendingDuelRegistry
+import database.service.DuelService
+import database.service.DuelService.AcceptOutcome
+import database.service.DuelService.StartOutcome
+import database.service.UserService
+import net.dv8tion.jda.api.JDA
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient
+import org.springframework.security.oauth2.client.annotation.RegisteredOAuth2AuthorizedClient
+import org.springframework.security.oauth2.core.user.OAuth2User
+import org.springframework.stereotype.Controller
+import org.springframework.ui.Model
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseBody
+import org.springframework.web.servlet.mvc.support.RedirectAttributes
+import web.service.DuelWebService
+import web.service.EconomyWebService
+import web.util.discordIdOrNull
+import web.util.displayName
+
+/**
+ * Web surface for /duel. Same [DuelService] the Discord command uses,
+ * and the same in-memory [PendingDuelRegistry] — a duel offered in
+ * Discord can be accepted via the web inbox and vice versa.
+ */
+@Controller
+@RequestMapping("/duel")
+class DuelController(
+    private val duelService: DuelService,
+    private val duelWebService: DuelWebService,
+    private val pendingDuelRegistry: PendingDuelRegistry,
+    private val economyWebService: EconomyWebService,
+    private val userService: UserService,
+    private val jda: JDA,
+) {
+    @GetMapping("/guilds")
+    fun guildList(
+        @RegisteredOAuth2AuthorizedClient("discord") client: OAuth2AuthorizedClient,
+        @AuthenticationPrincipal user: OAuth2User,
+        model: Model,
+    ): String {
+        val discordId = user.discordIdOrNull()
+        val guilds = if (discordId != null) {
+            economyWebService.getGuildsWhereUserCanView(client.accessToken.tokenValue, discordId)
+        } else emptyList()
+        model.addAttribute("guilds", guilds)
+        model.addAttribute("username", user.displayName())
+        return "duel-guilds"
+    }
+
+    @GetMapping("/{guildId}")
+    fun page(
+        @PathVariable guildId: Long,
+        @AuthenticationPrincipal user: OAuth2User,
+        model: Model,
+        ra: RedirectAttributes,
+    ): String {
+        val discordId = user.discordIdOrNull()
+            ?: return "redirect:/duel/guilds"
+        if (!economyWebService.isMember(discordId, guildId)) {
+            ra.addFlashAttribute("error", "You are not a member of that server.")
+            return "redirect:/duel/guilds"
+        }
+        val guild = jda.getGuildById(guildId) ?: run {
+            ra.addFlashAttribute("error", "Bot is not in that server.")
+            return "redirect:/duel/guilds"
+        }
+
+        val profile = userService.getUserById(discordId, guildId)
+        val balance = profile?.socialCredit ?: 0L
+        val pending = duelWebService.pendingForOpponent(discordId, guildId)
+
+        model.addAttribute("guildId", guildId.toString())
+        model.addAttribute("guildName", guild.name)
+        model.addAttribute("balance", balance)
+        model.addAttribute("minStake", DuelService.MIN_STAKE)
+        model.addAttribute("maxStake", DuelService.MAX_STAKE)
+        model.addAttribute("pending", pending)
+        model.addAttribute("username", user.displayName())
+        return "duel"
+    }
+
+    @GetMapping("/{guildId}/pending")
+    @ResponseBody
+    fun pendingForMe(
+        @PathVariable guildId: Long,
+        @AuthenticationPrincipal user: OAuth2User,
+    ): ResponseEntity<List<DuelWebService.PendingDuelView>> {
+        val discordId = user.discordIdOrNull() ?: return ResponseEntity.status(401).build()
+        if (!economyWebService.isMember(discordId, guildId)) {
+            return ResponseEntity.status(403).build()
+        }
+        return ResponseEntity.ok(duelWebService.pendingForOpponent(discordId, guildId))
+    }
+
+    @PostMapping("/{guildId}/challenge")
+    @ResponseBody
+    fun challenge(
+        @PathVariable guildId: Long,
+        @RequestBody request: ChallengeRequest,
+        @AuthenticationPrincipal user: OAuth2User,
+    ): ResponseEntity<ChallengeResponse> {
+        val discordId = user.discordIdOrNull()
+            ?: return ResponseEntity.status(401).body(ChallengeResponse(false, error = "Not signed in."))
+        if (!economyWebService.isMember(discordId, guildId)) {
+            return ResponseEntity.status(403).body(ChallengeResponse(false, error = "You are not a member of that server."))
+        }
+        if (request.opponentDiscordId == discordId) {
+            return ResponseEntity.badRequest().body(ChallengeResponse(false, error = "You can't duel yourself."))
+        }
+
+        duelWebService.ensureOpponent(request.opponentDiscordId, guildId)
+
+        val start = duelService.startDuel(
+            initiatorDiscordId = discordId,
+            opponentDiscordId = request.opponentDiscordId,
+            guildId = guildId,
+            stake = request.stake
+        )
+        if (start !is StartOutcome.Ok) {
+            return ResponseEntity.badRequest().body(ChallengeResponse(false, error = startErrorMessage(start)))
+        }
+
+        val offer = pendingDuelRegistry.register(
+            guildId = guildId,
+            initiatorDiscordId = discordId,
+            opponentDiscordId = request.opponentDiscordId,
+            stake = request.stake
+        )
+        return ResponseEntity.ok(
+            ChallengeResponse(ok = true, duelId = offer.id, stake = request.stake)
+        )
+    }
+
+    @PostMapping("/{guildId}/{duelId}/accept")
+    @ResponseBody
+    fun accept(
+        @PathVariable guildId: Long,
+        @PathVariable duelId: Long,
+        @AuthenticationPrincipal user: OAuth2User,
+    ): ResponseEntity<DuelActionResponse> {
+        val discordId = user.discordIdOrNull()
+            ?: return ResponseEntity.status(401).body(DuelActionResponse(false, error = "Not signed in."))
+
+        val offer = pendingDuelRegistry.get(duelId)
+            ?: return ResponseEntity.status(410).body(DuelActionResponse(false, error = "This offer already resolved or expired."))
+        if (offer.guildId != guildId) {
+            return ResponseEntity.badRequest().body(DuelActionResponse(false, error = "Wrong guild for this offer."))
+        }
+        if (offer.opponentDiscordId != discordId) {
+            return ResponseEntity.status(403).body(DuelActionResponse(false, error = "This isn't your duel offer."))
+        }
+
+        // Atomically claim the offer; if we lose the race (timeout / Discord-side accept), 410.
+        val claimed = pendingDuelRegistry.consumeForAccept(duelId)
+            ?: return ResponseEntity.status(410).body(DuelActionResponse(false, error = "This offer already resolved or expired."))
+
+        val outcome = duelService.acceptDuel(
+            initiatorDiscordId = claimed.initiatorDiscordId,
+            opponentDiscordId = claimed.opponentDiscordId,
+            guildId = claimed.guildId,
+            stake = claimed.stake
+        )
+        return when (outcome) {
+            is AcceptOutcome.Win -> ResponseEntity.ok(
+                DuelActionResponse(
+                    ok = true,
+                    winnerDiscordId = outcome.winnerDiscordId,
+                    loserDiscordId = outcome.loserDiscordId,
+                    stake = outcome.stake,
+                    pot = outcome.pot,
+                    winnerNewBalance = outcome.winnerNewBalance,
+                    loserNewBalance = outcome.loserNewBalance,
+                    lossTribute = outcome.lossTribute
+                )
+            )
+            is AcceptOutcome.InitiatorInsufficient -> ResponseEntity.badRequest().body(
+                DuelActionResponse(false, error = "Challenger no longer has enough credits.")
+            )
+            is AcceptOutcome.OpponentInsufficient -> ResponseEntity.badRequest().body(
+                DuelActionResponse(false, error = "You no longer have enough credits.")
+            )
+            AcceptOutcome.UnknownInitiator -> ResponseEntity.badRequest().body(
+                DuelActionResponse(false, error = "Challenger's user record vanished.")
+            )
+            AcceptOutcome.UnknownOpponent -> ResponseEntity.badRequest().body(
+                DuelActionResponse(false, error = "Your user record vanished.")
+            )
+        }
+    }
+
+    @PostMapping("/{guildId}/{duelId}/decline")
+    @ResponseBody
+    fun decline(
+        @PathVariable guildId: Long,
+        @PathVariable duelId: Long,
+        @AuthenticationPrincipal user: OAuth2User,
+    ): ResponseEntity<DuelActionResponse> {
+        val discordId = user.discordIdOrNull()
+            ?: return ResponseEntity.status(401).body(DuelActionResponse(false, error = "Not signed in."))
+
+        val offer = pendingDuelRegistry.get(duelId)
+            ?: return ResponseEntity.status(410).body(DuelActionResponse(false, error = "This offer already resolved or expired."))
+        if (offer.guildId != guildId) {
+            return ResponseEntity.badRequest().body(DuelActionResponse(false, error = "Wrong guild for this offer."))
+        }
+        if (offer.opponentDiscordId != discordId) {
+            return ResponseEntity.status(403).body(DuelActionResponse(false, error = "This isn't your duel offer."))
+        }
+        pendingDuelRegistry.cancel(duelId)
+            ?: return ResponseEntity.status(410).body(DuelActionResponse(false, error = "This offer already resolved or expired."))
+        return ResponseEntity.ok(DuelActionResponse(ok = true))
+    }
+
+    private fun startErrorMessage(outcome: StartOutcome): String = when (outcome) {
+        is StartOutcome.InvalidStake -> "Stake must be between ${outcome.min} and ${outcome.max} credits."
+        is StartOutcome.InvalidOpponent -> when (outcome.reason) {
+            StartOutcome.InvalidOpponent.Reason.SELF -> "You can't duel yourself."
+            StartOutcome.InvalidOpponent.Reason.BOT -> "You can't duel a bot."
+        }
+        is StartOutcome.InitiatorInsufficient ->
+            "You need ${outcome.needed} credits but only have ${outcome.have}."
+        is StartOutcome.OpponentInsufficient ->
+            "Opponent only has ${outcome.have} credits — they can't cover a ${outcome.needed} stake."
+        StartOutcome.UnknownInitiator -> "No user record yet. Try another TobyBot command first."
+        StartOutcome.UnknownOpponent -> "Opponent has no user record in this guild yet."
+        is StartOutcome.Ok -> "OK"
+    }
+}
+
+data class ChallengeRequest(val opponentDiscordId: Long = 0, val stake: Long = 0)
+
+data class ChallengeResponse(
+    val ok: Boolean,
+    val error: String? = null,
+    val duelId: Long? = null,
+    val stake: Long? = null
+)
+
+data class DuelActionResponse(
+    val ok: Boolean,
+    val error: String? = null,
+    val winnerDiscordId: Long? = null,
+    val loserDiscordId: Long? = null,
+    val stake: Long? = null,
+    val pot: Long? = null,
+    val winnerNewBalance: Long? = null,
+    val loserNewBalance: Long? = null,
+    val lossTribute: Long? = null
+)

--- a/web/src/main/kotlin/web/controller/TipController.kt
+++ b/web/src/main/kotlin/web/controller/TipController.kt
@@ -1,0 +1,175 @@
+package web.controller
+
+import database.service.TipService
+import database.service.TipService.TipOutcome
+import database.service.UserService
+import net.dv8tion.jda.api.JDA
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient
+import org.springframework.security.oauth2.client.annotation.RegisteredOAuth2AuthorizedClient
+import org.springframework.security.oauth2.core.user.OAuth2User
+import org.springframework.stereotype.Controller
+import org.springframework.ui.Model
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseBody
+import org.springframework.web.servlet.mvc.support.RedirectAttributes
+import web.service.EconomyWebService
+import web.service.TipWebService
+import web.util.discordIdOrNull
+import web.util.displayName
+import java.time.LocalDate
+import java.time.ZoneOffset
+
+/**
+ * Web surface for /tip. Mirrors the Discord [bot.toby.command.commands.economy.TipCommand]
+ * — same [TipService.tip] call, same daily-cap accounting, same audit log.
+ */
+@Controller
+@RequestMapping("/tip")
+class TipController(
+    private val tipService: TipService,
+    private val tipWebService: TipWebService,
+    private val economyWebService: EconomyWebService,
+    private val userService: UserService,
+    private val jda: JDA,
+) {
+    @GetMapping("/guilds")
+    fun guildList(
+        @RegisteredOAuth2AuthorizedClient("discord") client: OAuth2AuthorizedClient,
+        @AuthenticationPrincipal user: OAuth2User,
+        model: Model,
+    ): String {
+        val discordId = user.discordIdOrNull()
+        val guilds = if (discordId != null) {
+            economyWebService.getGuildsWhereUserCanView(client.accessToken.tokenValue, discordId)
+        } else emptyList()
+
+        model.addAttribute("guilds", guilds)
+        model.addAttribute("username", user.displayName())
+        return "tip-guilds"
+    }
+
+    @GetMapping("/{guildId}")
+    fun page(
+        @PathVariable guildId: Long,
+        @AuthenticationPrincipal user: OAuth2User,
+        model: Model,
+        ra: RedirectAttributes,
+    ): String {
+        val discordId = user.discordIdOrNull()
+            ?: return "redirect:/tip/guilds"
+
+        if (!economyWebService.isMember(discordId, guildId)) {
+            ra.addFlashAttribute("error", "You are not a member of that server.")
+            return "redirect:/tip/guilds"
+        }
+        val guild = jda.getGuildById(guildId) ?: run {
+            ra.addFlashAttribute("error", "Bot is not in that server.")
+            return "redirect:/tip/guilds"
+        }
+
+        val profile = userService.getUserById(discordId, guildId)
+        val balance = profile?.socialCredit ?: 0L
+        val today = LocalDate.now(ZoneOffset.UTC)
+        val sentToday = tipWebService.getDailyTipped(discordId, guildId, today)
+
+        model.addAttribute("guildId", guildId.toString())
+        model.addAttribute("guildName", guild.name)
+        model.addAttribute("balance", balance)
+        model.addAttribute("minTip", TipService.MIN_TIP)
+        model.addAttribute("maxTip", TipService.MAX_TIP)
+        model.addAttribute("dailyCap", TipService.DEFAULT_TIP_DAILY_CAP)
+        model.addAttribute("sentToday", sentToday)
+        model.addAttribute("dailyHeadroom", (TipService.DEFAULT_TIP_DAILY_CAP - sentToday).coerceAtLeast(0L))
+        model.addAttribute("username", user.displayName())
+        return "tip"
+    }
+
+    @PostMapping("/{guildId}")
+    @ResponseBody
+    fun tip(
+        @PathVariable guildId: Long,
+        @RequestBody request: TipRequest,
+        @AuthenticationPrincipal user: OAuth2User,
+    ): ResponseEntity<TipResponse> {
+        val discordId = user.discordIdOrNull()
+            ?: return ResponseEntity.status(401).body(TipResponse(false, error = "Not signed in."))
+        if (!economyWebService.isMember(discordId, guildId)) {
+            return ResponseEntity.status(403).body(TipResponse(false, error = "You are not a member of that server."))
+        }
+        if (request.recipientDiscordId == discordId) {
+            return ResponseEntity.badRequest().body(TipResponse(false, error = "You can't tip yourself."))
+        }
+
+        // Ensure recipient row exists (lazy-create through the helper-style path).
+        tipWebService.ensureRecipient(request.recipientDiscordId, guildId)
+
+        val outcome = tipService.tip(
+            senderDiscordId = discordId,
+            recipientDiscordId = request.recipientDiscordId,
+            guildId = guildId,
+            amount = request.amount,
+            note = request.note?.takeIf { it.isNotBlank() }
+        )
+        return when (outcome) {
+            is TipOutcome.Ok -> ResponseEntity.ok(
+                TipResponse(
+                    ok = true,
+                    senderNewBalance = outcome.senderNewBalance,
+                    recipientNewBalance = outcome.recipientNewBalance,
+                    sentTodayAfter = outcome.sentTodayAfter,
+                    dailyCap = outcome.dailyCap,
+                    amount = outcome.amount,
+                    note = outcome.note
+                )
+            )
+            is TipOutcome.InvalidAmount -> ResponseEntity.badRequest().body(
+                TipResponse(false, error = "Tip must be between ${outcome.min} and ${outcome.max} credits.")
+            )
+            is TipOutcome.InvalidRecipient -> ResponseEntity.badRequest().body(
+                TipResponse(false, error = when (outcome.reason) {
+                    TipOutcome.InvalidRecipient.Reason.SELF -> "You can't tip yourself."
+                    TipOutcome.InvalidRecipient.Reason.BOT -> "You can't tip a bot."
+                    TipOutcome.InvalidRecipient.Reason.MISSING -> "Recipient does not exist."
+                })
+            )
+            is TipOutcome.InsufficientCredits -> ResponseEntity.badRequest().body(
+                TipResponse(false, error = "You have ${outcome.have} credits but tried to send ${outcome.needed}.")
+            )
+            is TipOutcome.DailyCapExceeded -> ResponseEntity.badRequest().body(
+                TipResponse(
+                    false,
+                    error = "Daily tip cap reached. Sent ${outcome.sentToday}/${outcome.cap} today."
+                )
+            )
+            TipOutcome.UnknownSender -> ResponseEntity.badRequest().body(
+                TipResponse(false, error = "No user record yet. Try another TobyBot command first.")
+            )
+            TipOutcome.UnknownRecipient -> ResponseEntity.badRequest().body(
+                TipResponse(false, error = "Recipient has no user record in this guild yet.")
+            )
+        }
+    }
+}
+
+data class TipRequest(
+    val recipientDiscordId: Long = 0,
+    val amount: Long = 0,
+    val note: String? = null
+)
+
+data class TipResponse(
+    val ok: Boolean,
+    val error: String? = null,
+    val amount: Long? = null,
+    val note: String? = null,
+    val senderNewBalance: Long? = null,
+    val recipientNewBalance: Long? = null,
+    val sentTodayAfter: Long? = null,
+    val dailyCap: Long? = null
+)

--- a/web/src/main/kotlin/web/service/DuelWebService.kt
+++ b/web/src/main/kotlin/web/service/DuelWebService.kt
@@ -1,0 +1,39 @@
+package web.service
+
+import database.duel.PendingDuelRegistry
+import database.dto.UserDto
+import database.service.UserService
+import org.springframework.stereotype.Service
+
+/**
+ * Read-only projection helpers around the in-memory
+ * [PendingDuelRegistry] for the web UI plus a lazy-create for the
+ * opponent's [UserDto] row.
+ */
+@Service
+class DuelWebService(
+    private val pendingDuelRegistry: PendingDuelRegistry,
+    private val userService: UserService,
+) {
+    data class PendingDuelView(
+        val duelId: Long,
+        val initiatorDiscordId: Long,
+        val opponentDiscordId: Long,
+        val stake: Long
+    )
+
+    fun pendingForOpponent(discordId: Long, guildId: Long): List<PendingDuelView> =
+        pendingDuelRegistry.pendingForOpponent(discordId, guildId).map {
+            PendingDuelView(
+                duelId = it.id,
+                initiatorDiscordId = it.initiatorDiscordId,
+                opponentDiscordId = it.opponentDiscordId,
+                stake = it.stake
+            )
+        }
+
+    fun ensureOpponent(opponentDiscordId: Long, guildId: Long): UserDto {
+        return userService.getUserById(opponentDiscordId, guildId)
+            ?: userService.createNewUser(UserDto(opponentDiscordId, guildId))
+    }
+}

--- a/web/src/main/kotlin/web/service/TipWebService.kt
+++ b/web/src/main/kotlin/web/service/TipWebService.kt
@@ -1,0 +1,29 @@
+package web.service
+
+import database.dto.UserDto
+import database.service.TipDailyService
+import database.service.UserService
+import org.springframework.stereotype.Service
+import java.time.LocalDate
+
+/**
+ * Read-only helpers the [web.controller.TipController] needs that
+ * don't belong on [database.service.TipService] proper:
+ *  - daily-tipped lookup for the page render (TipService.tip itself
+ *    only returns post-tip state).
+ *  - lazy-create of the recipient's [UserDto] row so a tip to a
+ *    not-yet-seen user works without a Discord-side bootstrap.
+ */
+@Service
+class TipWebService(
+    private val tipDailyService: TipDailyService,
+    private val userService: UserService,
+) {
+    fun getDailyTipped(senderDiscordId: Long, guildId: Long, date: LocalDate): Long =
+        tipDailyService.get(senderDiscordId, guildId, date)?.creditsSent ?: 0L
+
+    fun ensureRecipient(recipientDiscordId: Long, guildId: Long): UserDto {
+        return userService.getUserById(recipientDiscordId, guildId)
+            ?: userService.createNewUser(UserDto(recipientDiscordId, guildId))
+    }
+}

--- a/web/src/main/resources/static/css/duel.css
+++ b/web/src/main/resources/static/css/duel.css
@@ -1,0 +1,67 @@
+.duel-header {
+    margin-bottom: 1.5rem;
+}
+
+.duel-header h1 {
+    margin: 0.25rem 0 0.5rem;
+}
+
+.duel-card,
+.duel-inbox {
+    background: var(--surface, #1f2128);
+    border-radius: 0.75rem;
+    padding: 1.5rem;
+    max-width: 36rem;
+    margin-bottom: 1.5rem;
+}
+
+.duel-card h2,
+.duel-inbox h2 {
+    margin-top: 0;
+    margin-bottom: 1rem;
+}
+
+.duel-card form {
+    display: grid;
+    gap: 0.5rem;
+    margin-bottom: 1.25rem;
+}
+
+.duel-card input {
+    background: var(--surface-2, #16181d);
+    color: inherit;
+    border: 1px solid var(--border, #2a2d35);
+    border-radius: 0.4rem;
+    padding: 0.5rem 0.75rem;
+    font: inherit;
+}
+
+.duel-card input:focus {
+    outline: 2px solid var(--accent, #5865f2);
+    outline-offset: 2px;
+}
+
+.duel-balance {
+    border-top: 1px solid var(--border, #2a2d35);
+    padding-top: 1rem;
+}
+
+.duel-pending-list {
+    display: grid;
+    gap: 0.5rem;
+}
+
+.duel-pending-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 0.75rem 1rem;
+    border: 1px solid var(--border, #2a2d35);
+    border-radius: 0.5rem;
+}
+
+.duel-pending-actions {
+    display: flex;
+    gap: 0.5rem;
+}

--- a/web/src/main/resources/static/css/tip.css
+++ b/web/src/main/resources/static/css/tip.css
@@ -1,0 +1,46 @@
+.tip-header {
+    margin-bottom: 1.5rem;
+}
+
+.tip-header h1 {
+    margin: 0.25rem 0 0.5rem;
+}
+
+.tip-card {
+    background: var(--surface, #1f2128);
+    border-radius: 0.75rem;
+    padding: 1.5rem;
+    max-width: 32rem;
+}
+
+.tip-card form {
+    display: grid;
+    gap: 0.5rem;
+    margin-bottom: 1.25rem;
+}
+
+.tip-card input {
+    background: var(--surface-2, #16181d);
+    color: inherit;
+    border: 1px solid var(--border, #2a2d35);
+    border-radius: 0.4rem;
+    padding: 0.5rem 0.75rem;
+    font: inherit;
+}
+
+.tip-card input:focus {
+    outline: 2px solid var(--accent, #5865f2);
+    outline-offset: 2px;
+}
+
+.tip-card .btn-primary {
+    margin-top: 0.5rem;
+    align-self: flex-start;
+}
+
+.tip-balance {
+    display: grid;
+    gap: 0.25rem;
+    border-top: 1px solid var(--border, #2a2d35);
+    padding-top: 1rem;
+}

--- a/web/src/main/resources/static/js/duel.js
+++ b/web/src/main/resources/static/js/duel.js
@@ -1,0 +1,112 @@
+// /duel — challenge form posts to /duel/{guildId}/challenge; the
+// inbox panel polls /duel/{guildId}/pending every 5 seconds and posts
+// to /accept or /decline via the shared CSRF-aware fetch wrapper.
+(function () {
+    'use strict';
+
+    const main = document.getElementById('main');
+    if (!main) return;
+    const guildId = main.dataset.guildId;
+    if (!guildId) return;
+
+    const balanceEl = document.getElementById('duel-balance');
+    const challengeForm = document.getElementById('duel-challenge');
+    const pendingList = document.getElementById('duel-pending-list');
+
+    function showToast(level, msg) {
+        if (window.TobyToasts && window.TobyToasts[level]) window.TobyToasts[level](msg);
+    }
+
+    function renderPending(rows) {
+        if (!pendingList) return;
+        pendingList.innerHTML = '';
+        if (!rows || rows.length === 0) {
+            const empty = document.createElement('div');
+            empty.className = 'muted';
+            empty.textContent = 'No pending duels right now.';
+            pendingList.appendChild(empty);
+            return;
+        }
+        rows.forEach(function (row) {
+            const node = document.createElement('div');
+            node.className = 'duel-pending-row';
+            node.dataset.duelId = String(row.duelId);
+            node.dataset.stake = String(row.stake);
+            node.innerHTML =
+                '<div><span>From <strong>' + row.initiatorDiscordId + '</strong></span>' +
+                '<span> for <strong>' + row.stake + '</strong> credits</span></div>' +
+                '<div class="duel-pending-actions">' +
+                '<button class="btn-primary duel-accept" type="button">Accept</button>' +
+                '<button class="btn-secondary duel-decline" type="button">Decline</button>' +
+                '</div>';
+            pendingList.appendChild(node);
+        });
+    }
+
+    function refreshPending() {
+        fetch('/duel/' + guildId + '/pending', { credentials: 'same-origin' })
+            .then(function (r) { return r.ok ? r.json() : []; })
+            .then(renderPending)
+            .catch(function () { /* keep last known state */ });
+    }
+
+    if (challengeForm) {
+        challengeForm.addEventListener('submit', function (e) {
+            e.preventDefault();
+            const opponent = parseInt(document.getElementById('duel-opponent').value, 10);
+            const stake = parseInt(document.getElementById('duel-stake').value, 10);
+            if (!opponent || !stake) {
+                showToast('error', 'Opponent and stake are required.');
+                return;
+            }
+            window.TobyApi.postJson('/duel/' + guildId + '/challenge', {
+                opponentDiscordId: opponent,
+                stake: stake
+            }).then(function (resp) {
+                if (!resp || !resp.ok) {
+                    showToast('error', (resp && resp.error) || 'Challenge failed.');
+                    return;
+                }
+                showToast('success', 'Challenge sent. Waiting for them to accept (60s window).');
+            }).catch(function () { showToast('error', 'Network error sending challenge.'); });
+        });
+    }
+
+    if (pendingList) {
+        pendingList.addEventListener('click', function (e) {
+            const btn = e.target.closest('button');
+            if (!btn) return;
+            const row = btn.closest('.duel-pending-row');
+            if (!row) return;
+            const duelId = row.dataset.duelId;
+            if (!duelId) return;
+            const isAccept = btn.classList.contains('duel-accept');
+            const isDecline = btn.classList.contains('duel-decline');
+            if (!isAccept && !isDecline) return;
+
+            const path = '/duel/' + guildId + '/' + duelId + (isAccept ? '/accept' : '/decline');
+            window.TobyApi.postJson(path, {}).then(function (resp) {
+                if (!resp || !resp.ok) {
+                    showToast('error', (resp && resp.error) || 'Action failed.');
+                    refreshPending();
+                    return;
+                }
+                if (isAccept && resp.winnerDiscordId) {
+                    const youWon = resp.winnerNewBalance != null && resp.loserNewBalance != null;
+                    showToast('success',
+                        'Resolved: <@' + resp.winnerDiscordId + '> won the ' + resp.pot +
+                        ' pot (' + resp.lossTribute + ' to jackpot).');
+                    if (balanceEl) {
+                        // We don't know which side we are without comparing, but the
+                        // page will refresh the next poll cycle.
+                    }
+                } else if (isDecline) {
+                    showToast('success', 'Declined.');
+                }
+                refreshPending();
+            }).catch(function () { showToast('error', 'Network error.'); });
+        });
+    }
+
+    setInterval(refreshPending, 5000);
+})();

--- a/web/src/main/resources/static/js/tip.js
+++ b/web/src/main/resources/static/js/tip.js
@@ -1,0 +1,53 @@
+// /tip — JSON POST to /tip/{guildId} via the shared CSRF-aware fetch
+// wrapper. Updates balance + daily-tipped counters in place; surfaces
+// service errors as toasts.
+(function () {
+    'use strict';
+
+    const main = document.getElementById('main');
+    if (!main) return;
+    const guildId = main.dataset.guildId;
+    if (!guildId) return;
+    const dailyCap = parseInt(main.dataset.dailyCap, 10) || 0;
+
+    const form = document.getElementById('tip-form');
+    const balanceEl = document.getElementById('tip-balance');
+    const sentEl = document.getElementById('tip-sent-today');
+    const headroomEl = document.getElementById('tip-headroom');
+
+    if (!form) return;
+
+    form.addEventListener('submit', function (e) {
+        e.preventDefault();
+        const recipientStr = (document.getElementById('tip-recipient').value || '').trim();
+        const recipient = parseInt(recipientStr, 10);
+        const amount = parseInt(document.getElementById('tip-amount').value, 10);
+        const note = (document.getElementById('tip-note').value || '').trim() || null;
+        if (!recipient || !amount) {
+            window.TobyToasts && window.TobyToasts.error('Recipient and amount are required.');
+            return;
+        }
+        window.TobyApi.postJson('/tip/' + guildId, {
+            recipientDiscordId: recipient,
+            amount: amount,
+            note: note
+        }).then(function (resp) {
+            if (!resp || !resp.ok) {
+                window.TobyToasts && window.TobyToasts.error((resp && resp.error) || 'Tip failed.');
+                return;
+            }
+            if (balanceEl) balanceEl.textContent = String(resp.senderNewBalance);
+            if (sentEl) sentEl.textContent = String(resp.sentTodayAfter);
+            if (headroomEl) {
+                const cap = resp.dailyCap || dailyCap;
+                headroomEl.textContent = String(Math.max(0, cap - resp.sentTodayAfter));
+            }
+            const noteSuffix = resp.note ? ' (' + resp.note + ')' : '';
+            window.TobyToasts && window.TobyToasts.success(
+                'Sent ' + resp.amount + ' credits' + noteSuffix + '.'
+            );
+        }).catch(function () {
+            window.TobyToasts && window.TobyToasts.error('Network error sending tip.');
+        });
+    });
+})();

--- a/web/src/main/resources/templates/duel-guilds.html
+++ b/web/src/main/resources/templates/duel-guilds.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="en">
+<head th:replace="~{fragments/head :: head('TobyBot - Duel', '/css/leaderboard.css')}"></head>
+<body>
+<a href="#main" class="skip-link">Skip to content</a>
+<div th:replace="~{fragments/navbar :: navbar}"></div>
+
+<main id="main" class="container">
+    <h1 class="mb-3">⚔️ Duel</h1>
+    <p class="muted mb-5">
+        Challenge another user to a head-to-head 50/50 wager. Winner takes the pot
+        (minus a small jackpot tribute).
+    </p>
+
+    <div th:if="${error}" class="alert alert-error" th:text="${error}"></div>
+
+    <div class="lb-guild-grid" th:if="${not #lists.isEmpty(guilds)}">
+        <div class="lb-guild-card lb-guild-card-static" th:each="g : ${guilds}">
+            <div class="lb-guild-card-header">
+                <img th:if="${g.iconUrl != null}"
+                     th:src="${g.iconUrl}"
+                     th:alt="${g.name} + ' icon'"
+                     class="lb-guild-icon"
+                     onerror="this.style.display='none'">
+                <div th:unless="${g.iconUrl != null}"
+                     class="lb-guild-icon-placeholder"
+                     aria-hidden="true"
+                     th:text="${#strings.substring(g.name, 0, 1).toUpperCase()}">G</div>
+                <div class="lb-guild-name" th:text="${g.name}" th:title="${g.name}">Guild</div>
+            </div>
+            <div class="lb-guild-top">
+                <span class="muted">Your wallet:</span>
+                <span th:text="${g.credits} + ' credits'">0 credits</span>
+            </div>
+            <div class="lb-guild-games">
+                <a class="btn-secondary" th:href="@{/duel/{id}(id=${g.id})}">⚔️ Duel</a>
+            </div>
+        </div>
+    </div>
+
+    <div class="empty-hero" th:if="${#lists.isEmpty(guilds)}">
+        <span class="emoji" aria-hidden="true">⚔️</span>
+        <h2>No servers to duel in yet</h2>
+        <p class="mb-5">
+            You need to share at least one server with TobyBot to challenge someone.
+        </p>
+    </div>
+</main>
+</body>
+</html>

--- a/web/src/main/resources/templates/duel.html
+++ b/web/src/main/resources/templates/duel.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="en">
+<head th:replace="~{fragments/head :: head('TobyBot - Duel', '/css/duel.css')}"></head>
+<body>
+<a href="#main" class="skip-link">Skip to content</a>
+<div th:replace="~{fragments/navbar :: navbar}"></div>
+
+<main id="main" class="container"
+      th:attr="data-guild-id=${guildId}, data-min-stake=${minStake}, data-max-stake=${maxStake}">
+
+    <div class="duel-header">
+        <a class="back-link" th:href="@{/duel/guilds}">&larr; All servers</a>
+        <h1 th:text="'⚔️ Duel • ' + ${guildName}">⚔️ Duel</h1>
+        <p class="muted">
+            Stake between <span th:text="${minStake}">10</span> and
+            <span th:text="${maxStake}">500</span> credits each. Both players ante; winner
+            takes the pot minus the per-guild jackpot tribute.
+        </p>
+    </div>
+
+    <div th:if="${error}" class="alert alert-error" th:text="${error}"></div>
+
+    <section class="duel-card">
+        <h2>Challenge someone</h2>
+        <form id="duel-challenge" autocomplete="off">
+            <label for="duel-opponent">Opponent Discord ID</label>
+            <input id="duel-opponent" name="opponentDiscordId" type="text" inputmode="numeric"
+                   placeholder="e.g. 312691905030782977" required>
+
+            <label for="duel-stake">Stake (credits)</label>
+            <input id="duel-stake" name="stake" type="number"
+                   th:attr="min=${minStake}, max=${maxStake}" th:value="${minStake}" step="1" required>
+
+            <button type="submit" id="duel-send" class="btn-primary">Send challenge</button>
+        </form>
+
+        <div class="duel-balance">
+            Balance: <strong id="duel-balance" th:text="${balance}">0</strong> credits
+        </div>
+    </section>
+
+    <section class="duel-inbox">
+        <h2>Pending offers for you</h2>
+        <div id="duel-pending-list" class="duel-pending-list">
+            <div th:if="${#lists.isEmpty(pending)}" class="muted">No pending duels right now.</div>
+            <div class="duel-pending-row" th:each="p : ${pending}"
+                 th:attr="data-duel-id=${p.duelId}, data-stake=${p.stake}">
+                <div>
+                    <span>From <strong th:text="${p.initiatorDiscordId}">user</strong></span>
+                    <span> for <strong th:text="${p.stake}">100</strong> credits</span>
+                </div>
+                <div class="duel-pending-actions">
+                    <button class="btn-primary duel-accept" type="button">Accept</button>
+                    <button class="btn-secondary duel-decline" type="button">Decline</button>
+                </div>
+            </div>
+        </div>
+        <p class="muted">Offers expire after 60 seconds. Refreshes automatically.</p>
+    </section>
+</main>
+
+<div class="toast-stack" id="toast-stack" aria-live="polite"></div>
+
+<script th:src="@{/js/api.js}"></script>
+<script th:src="@{/js/toasts.js}"></script>
+<script th:src="@{/js/duel.js}"></script>
+</body>
+</html>

--- a/web/src/main/resources/templates/tip-guilds.html
+++ b/web/src/main/resources/templates/tip-guilds.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="en">
+<head th:replace="~{fragments/head :: head('TobyBot - Tip', '/css/leaderboard.css')}"></head>
+<body>
+<a href="#main" class="skip-link">Skip to content</a>
+<div th:replace="~{fragments/navbar :: navbar}"></div>
+
+<main id="main" class="container">
+    <h1 class="mb-3">💸 Tip</h1>
+    <p class="muted mb-5">
+        Send another user some social credit. Daily outgoing cap applies per server.
+    </p>
+
+    <div th:if="${error}" class="alert alert-error" th:text="${error}"></div>
+
+    <div class="lb-guild-grid" th:if="${not #lists.isEmpty(guilds)}">
+        <div class="lb-guild-card lb-guild-card-static" th:each="g : ${guilds}">
+            <div class="lb-guild-card-header">
+                <img th:if="${g.iconUrl != null}"
+                     th:src="${g.iconUrl}"
+                     th:alt="${g.name} + ' icon'"
+                     class="lb-guild-icon"
+                     onerror="this.style.display='none'">
+                <div th:unless="${g.iconUrl != null}"
+                     class="lb-guild-icon-placeholder"
+                     aria-hidden="true"
+                     th:text="${#strings.substring(g.name, 0, 1).toUpperCase()}">G</div>
+                <div class="lb-guild-name" th:text="${g.name}" th:title="${g.name}">Guild</div>
+            </div>
+            <div class="lb-guild-top">
+                <span class="muted">Your wallet:</span>
+                <span th:text="${g.credits} + ' credits'">0 credits</span>
+            </div>
+            <div class="lb-guild-games">
+                <a class="btn-secondary" th:href="@{/tip/{id}(id=${g.id})}">💸 Send a tip</a>
+            </div>
+        </div>
+    </div>
+
+    <div class="empty-hero" th:if="${#lists.isEmpty(guilds)}">
+        <span class="emoji" aria-hidden="true">💸</span>
+        <h2>No servers to tip in yet</h2>
+        <p class="mb-5">
+            You need to share at least one server with TobyBot to send a tip.
+        </p>
+    </div>
+</main>
+</body>
+</html>

--- a/web/src/main/resources/templates/tip.html
+++ b/web/src/main/resources/templates/tip.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="en">
+<head th:replace="~{fragments/head :: head('TobyBot - Tip', '/css/tip.css')}"></head>
+<body>
+<a href="#main" class="skip-link">Skip to content</a>
+<div th:replace="~{fragments/navbar :: navbar}"></div>
+
+<main id="main" class="container"
+      th:attr="data-guild-id=${guildId}, data-min-tip=${minTip}, data-max-tip=${maxTip}, data-daily-cap=${dailyCap}">
+
+    <div class="tip-header">
+        <a class="back-link" th:href="@{/tip/guilds}">&larr; All servers</a>
+        <h1 th:text="'💸 Tip • ' + ${guildName}">💸 Tip</h1>
+        <p class="muted">
+            Send between <span th:text="${minTip}">10</span> and
+            <span th:text="${maxTip}">500</span> credits to another user. Daily outgoing
+            cap is <span th:text="${dailyCap}">500</span> credits.
+        </p>
+    </div>
+
+    <div th:if="${error}" class="alert alert-error" th:text="${error}"></div>
+
+    <section class="tip-card">
+        <form id="tip-form" autocomplete="off">
+            <label for="tip-recipient">Recipient Discord ID</label>
+            <input id="tip-recipient" name="recipientDiscordId" type="text" inputmode="numeric"
+                   placeholder="e.g. 312691905030782977" required>
+
+            <label for="tip-amount">Amount (credits)</label>
+            <input id="tip-amount" name="amount" type="number"
+                   th:attr="min=${minTip}, max=${maxTip}" th:value="${minTip}" step="1" required>
+
+            <label for="tip-note">Note (optional)</label>
+            <input id="tip-note" name="note" type="text" maxlength="200" placeholder="thanks!">
+
+            <button type="submit" id="tip-send" class="btn-primary">Send tip</button>
+        </form>
+
+        <div class="tip-balance">
+            <div>Balance: <strong id="tip-balance" th:text="${balance}">0</strong> credits</div>
+            <div>
+                Tipped today:
+                <strong id="tip-sent-today" th:text="${sentToday}">0</strong>
+                / <span th:text="${dailyCap}">500</span>
+                <span class="muted">(<span id="tip-headroom" th:text="${dailyHeadroom}">500</span> credits remaining)</span>
+            </div>
+        </div>
+    </section>
+</main>
+
+<div class="toast-stack" id="toast-stack" aria-live="polite"></div>
+
+<script th:src="@{/js/api.js}"></script>
+<script th:src="@{/js/toasts.js}"></script>
+<script th:src="@{/js/tip.js}"></script>
+</body>
+</html>

--- a/web/src/test/kotlin/web/controller/DuelControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/DuelControllerTest.kt
@@ -1,0 +1,181 @@
+package web.controller
+
+import database.duel.PendingDuelRegistry
+import database.service.DuelService
+import database.service.DuelService.AcceptOutcome
+import database.service.DuelService.StartOutcome
+import database.service.UserService
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import net.dv8tion.jda.api.JDA
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.security.oauth2.core.user.OAuth2User
+import web.service.DuelWebService
+import web.service.EconomyWebService
+import java.time.Instant
+
+class DuelControllerTest {
+
+    private val guildId = 42L
+    private val discordId = 100L
+    private val opponentId = 200L
+    private val duelId = 99L
+
+    private lateinit var duelService: DuelService
+    private lateinit var duelWebService: DuelWebService
+    private lateinit var pendingDuelRegistry: PendingDuelRegistry
+    private lateinit var economyWebService: EconomyWebService
+    private lateinit var userService: UserService
+    private lateinit var jda: JDA
+    private lateinit var user: OAuth2User
+    private lateinit var controller: DuelController
+
+    @BeforeEach
+    fun setup() {
+        duelService = mockk(relaxed = true)
+        duelWebService = mockk(relaxed = true)
+        pendingDuelRegistry = mockk(relaxed = true)
+        economyWebService = mockk(relaxed = true)
+        userService = mockk(relaxed = true)
+        jda = mockk(relaxed = true)
+        user = mockk {
+            every { getAttribute<String>("id") } returns discordId.toString()
+            every { getAttribute<String>("username") } returns "tester"
+        }
+        every { economyWebService.isMember(discordId, guildId) } returns true
+        controller = DuelController(
+            duelService, duelWebService, pendingDuelRegistry,
+            economyWebService, userService, jda
+        )
+    }
+
+    private fun pendingFor(opponent: Long) = PendingDuelRegistry.PendingDuel(
+        id = duelId, guildId = guildId,
+        initiatorDiscordId = discordId, opponentDiscordId = opponent,
+        stake = 50L, createdAt = Instant.now()
+    )
+
+    @Test
+    fun `challenge happy path registers in registry and returns the duelId`() {
+        every {
+            duelService.startDuel(discordId, opponentId, guildId, 50L)
+        } returns StartOutcome.Ok(initiatorBalance = 200L)
+        every {
+            pendingDuelRegistry.register(guildId, discordId, opponentId, 50L)
+        } returns PendingDuelRegistry.PendingDuel(
+            id = duelId, guildId = guildId,
+            initiatorDiscordId = discordId, opponentDiscordId = opponentId,
+            stake = 50L, createdAt = Instant.now()
+        )
+
+        val response = controller.challenge(guildId, ChallengeRequest(opponentId, 50L), user)
+
+        assertEquals(200, response.statusCode.value())
+        assertTrue(response.body!!.ok)
+        assertEquals(duelId, response.body!!.duelId)
+        verify { duelWebService.ensureOpponent(opponentId, guildId) }
+    }
+
+    @Test
+    fun `challenge to self returns 400 without registering`() {
+        val response = controller.challenge(guildId, ChallengeRequest(discordId, 50L), user)
+
+        assertEquals(400, response.statusCode.value())
+        assertFalse(response.body!!.ok)
+        verify(exactly = 0) { duelService.startDuel(any(), any(), any(), any()) }
+        verify(exactly = 0) { pendingDuelRegistry.register(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `challenge with bad start outcome returns 400 without registering`() {
+        every {
+            duelService.startDuel(discordId, opponentId, guildId, 50L)
+        } returns StartOutcome.InitiatorInsufficient(have = 5L, needed = 50L)
+
+        val response = controller.challenge(guildId, ChallengeRequest(opponentId, 50L), user)
+
+        assertEquals(400, response.statusCode.value())
+        assertFalse(response.body!!.ok)
+        verify(exactly = 0) { pendingDuelRegistry.register(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `accept happy path resolves via DuelService and returns Win`() {
+        every { pendingDuelRegistry.get(duelId) } returns pendingFor(discordId)
+        every { pendingDuelRegistry.consumeForAccept(duelId) } returns pendingFor(discordId)
+        every {
+            duelService.acceptDuel(discordId, discordId, guildId, 50L)
+        } returns AcceptOutcome.Win(
+            winnerDiscordId = discordId, loserDiscordId = 0L,
+            stake = 50L, pot = 100L,
+            winnerNewBalance = 245L, loserNewBalance = 50L,
+            lossTribute = 5L
+        )
+
+        val response = controller.accept(guildId, duelId, user)
+
+        assertEquals(200, response.statusCode.value())
+        assertTrue(response.body!!.ok)
+        assertEquals(100L, response.body!!.pot)
+        assertEquals(5L, response.body!!.lossTribute)
+    }
+
+    @Test
+    fun `accept by non-opponent returns 403`() {
+        // Offer's opponent is someone OTHER than the requesting user.
+        every { pendingDuelRegistry.get(duelId) } returns pendingFor(opponentId + 1)
+
+        val response = controller.accept(guildId, duelId, user)
+
+        assertEquals(403, response.statusCode.value())
+        verify(exactly = 0) { duelService.acceptDuel(any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `accept of expired offer returns 410`() {
+        every { pendingDuelRegistry.get(duelId) } returns null
+
+        val response = controller.accept(guildId, duelId, user)
+
+        assertEquals(410, response.statusCode.value())
+        verify(exactly = 0) { duelService.acceptDuel(any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `accept loses the consume race returns 410`() {
+        // Offer was visible at the get() probe but vanished before consume.
+        every { pendingDuelRegistry.get(duelId) } returns pendingFor(discordId)
+        every { pendingDuelRegistry.consumeForAccept(duelId) } returns null
+
+        val response = controller.accept(guildId, duelId, user)
+
+        assertEquals(410, response.statusCode.value())
+        verify(exactly = 0) { duelService.acceptDuel(any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `decline cancels the offer in registry without calling service`() {
+        every { pendingDuelRegistry.get(duelId) } returns pendingFor(discordId)
+        every { pendingDuelRegistry.cancel(duelId) } returns pendingFor(discordId)
+
+        val response = controller.decline(guildId, duelId, user)
+
+        assertEquals(200, response.statusCode.value())
+        assertTrue(response.body!!.ok)
+        verify(exactly = 0) { duelService.acceptDuel(any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `decline by non-opponent returns 403`() {
+        every { pendingDuelRegistry.get(duelId) } returns pendingFor(opponentId + 1)
+
+        val response = controller.decline(guildId, duelId, user)
+
+        assertEquals(403, response.statusCode.value())
+    }
+}

--- a/web/src/test/kotlin/web/controller/DuelControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/DuelControllerTest.kt
@@ -66,7 +66,7 @@ class DuelControllerTest {
             duelService.startDuel(discordId, opponentId, guildId, 50L)
         } returns StartOutcome.Ok(initiatorBalance = 200L)
         every {
-            pendingDuelRegistry.register(guildId, discordId, opponentId, 50L)
+            pendingDuelRegistry.register(guildId, discordId, opponentId, 50L, any(), any())
         } returns PendingDuelRegistry.PendingDuel(
             id = duelId, guildId = guildId,
             initiatorDiscordId = discordId, opponentDiscordId = opponentId,
@@ -88,7 +88,7 @@ class DuelControllerTest {
         assertEquals(400, response.statusCode.value())
         assertFalse(response.body!!.ok)
         verify(exactly = 0) { duelService.startDuel(any(), any(), any(), any()) }
-        verify(exactly = 0) { pendingDuelRegistry.register(any(), any(), any(), any()) }
+        verify(exactly = 0) { pendingDuelRegistry.register(any(), any(), any(), any(), any(), any()) }
     }
 
     @Test
@@ -101,7 +101,7 @@ class DuelControllerTest {
 
         assertEquals(400, response.statusCode.value())
         assertFalse(response.body!!.ok)
-        verify(exactly = 0) { pendingDuelRegistry.register(any(), any(), any(), any()) }
+        verify(exactly = 0) { pendingDuelRegistry.register(any(), any(), any(), any(), any(), any()) }
     }
 
     @Test
@@ -109,7 +109,7 @@ class DuelControllerTest {
         every { pendingDuelRegistry.get(duelId) } returns pendingFor(discordId)
         every { pendingDuelRegistry.consumeForAccept(duelId) } returns pendingFor(discordId)
         every {
-            duelService.acceptDuel(discordId, discordId, guildId, 50L)
+            duelService.acceptDuel(discordId, discordId, guildId, 50L, any())
         } returns AcceptOutcome.Win(
             winnerDiscordId = discordId, loserDiscordId = 0L,
             stake = 50L, pot = 100L,

--- a/web/src/test/kotlin/web/controller/TipControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/TipControllerTest.kt
@@ -49,7 +49,7 @@ class TipControllerTest {
     @Test
     fun `tip Ok returns 200 with balances and daily totals`() {
         every {
-            tipService.tip(discordId, recipientId, guildId, 50L, "thanks")
+            tipService.tip(discordId, recipientId, guildId, 50L, "thanks", any(), any())
         } returns TipOutcome.Ok(
             sender = discordId, recipient = recipientId,
             amount = 50L, note = "thanks",
@@ -112,7 +112,7 @@ class TipControllerTest {
             TipOutcome.UnknownRecipient,
         )
         outcomes.forEach { variant ->
-            every { tipService.tip(discordId, recipientId, guildId, 50L, null) } returns variant
+            every { tipService.tip(discordId, recipientId, guildId, 50L, null, any(), any()) } returns variant
             val response = controller.tip(guildId, TipRequest(recipientId, 50L, null), user)
             assertEquals(400, response.statusCode.value(), "outcome $variant should be 400")
             assertFalse(response.body!!.ok)

--- a/web/src/test/kotlin/web/controller/TipControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/TipControllerTest.kt
@@ -1,0 +1,122 @@
+package web.controller
+
+import database.service.TipService
+import database.service.TipService.TipOutcome
+import database.service.UserService
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import net.dv8tion.jda.api.JDA
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.security.oauth2.core.user.OAuth2User
+import web.service.EconomyWebService
+import web.service.TipWebService
+
+class TipControllerTest {
+
+    private val guildId = 42L
+    private val discordId = 100L
+    private val recipientId = 200L
+
+    private lateinit var tipService: TipService
+    private lateinit var tipWebService: TipWebService
+    private lateinit var economyWebService: EconomyWebService
+    private lateinit var userService: UserService
+    private lateinit var jda: JDA
+    private lateinit var user: OAuth2User
+    private lateinit var controller: TipController
+
+    @BeforeEach
+    fun setup() {
+        tipService = mockk(relaxed = true)
+        tipWebService = mockk(relaxed = true)
+        economyWebService = mockk(relaxed = true)
+        userService = mockk(relaxed = true)
+        jda = mockk(relaxed = true)
+        user = mockk {
+            every { getAttribute<String>("id") } returns discordId.toString()
+            every { getAttribute<String>("username") } returns "tester"
+        }
+        every { economyWebService.isMember(discordId, guildId) } returns true
+        controller = TipController(tipService, tipWebService, economyWebService, userService, jda)
+    }
+
+    @Test
+    fun `tip Ok returns 200 with balances and daily totals`() {
+        every {
+            tipService.tip(discordId, recipientId, guildId, 50L, "thanks")
+        } returns TipOutcome.Ok(
+            sender = discordId, recipient = recipientId,
+            amount = 50L, note = "thanks",
+            senderNewBalance = 950L, recipientNewBalance = 1050L,
+            sentTodayAfter = 50L, dailyCap = 500L
+        )
+
+        val response = controller.tip(guildId, TipRequest(recipientId, 50L, "thanks"), user)
+
+        assertEquals(200, response.statusCode.value())
+        val body = response.body!!
+        assertTrue(body.ok)
+        assertEquals(50L, body.amount)
+        assertEquals(950L, body.senderNewBalance)
+        assertEquals(1050L, body.recipientNewBalance)
+        assertEquals(50L, body.sentTodayAfter)
+        assertEquals(500L, body.dailyCap)
+        verify { tipWebService.ensureRecipient(recipientId, guildId) }
+    }
+
+    @Test
+    fun `tip without auth returns 401`() {
+        val anon = mockk<OAuth2User> {
+            every { getAttribute<String>("id") } returns null
+        }
+
+        val response = controller.tip(guildId, TipRequest(recipientId, 50L, null), anon)
+
+        assertEquals(401, response.statusCode.value())
+        assertFalse(response.body!!.ok)
+    }
+
+    @Test
+    fun `tip when not a member returns 403`() {
+        every { economyWebService.isMember(discordId, guildId) } returns false
+
+        val response = controller.tip(guildId, TipRequest(recipientId, 50L, null), user)
+
+        assertEquals(403, response.statusCode.value())
+        assertFalse(response.body!!.ok)
+    }
+
+    @Test
+    fun `tip to self returns 400 before service is called`() {
+        val response = controller.tip(guildId, TipRequest(discordId, 50L, null), user)
+
+        assertEquals(400, response.statusCode.value())
+        assertFalse(response.body!!.ok)
+        verify(exactly = 0) { tipService.tip(any(), any(), any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `each non-Ok TipOutcome maps to a 400 with error`() {
+        val outcomes = listOf(
+            TipOutcome.InvalidAmount(10L, 500L),
+            TipOutcome.InvalidRecipient(TipOutcome.InvalidRecipient.Reason.BOT),
+            TipOutcome.InsufficientCredits(have = 30L, needed = 50L),
+            TipOutcome.DailyCapExceeded(sentToday = 480L, cap = 500L, attempted = 50L),
+            TipOutcome.UnknownSender,
+            TipOutcome.UnknownRecipient,
+        )
+        outcomes.forEach { variant ->
+            every { tipService.tip(discordId, recipientId, guildId, 50L, null) } returns variant
+            val response = controller.tip(guildId, TipRequest(recipientId, 50L, null), user)
+            assertEquals(400, response.statusCode.value(), "outcome $variant should be 400")
+            assertFalse(response.body!!.ok)
+            assertNull(response.body!!.amount)
+        }
+    }
+}

--- a/web/src/test/kotlin/web/service/DuelWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/DuelWebServiceTest.kt
@@ -1,0 +1,75 @@
+package web.service
+
+import database.duel.PendingDuelRegistry
+import database.dto.UserDto
+import database.service.UserService
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+class DuelWebServiceTest {
+
+    private val opponentId = 200L
+    private val guildId = 42L
+
+    private lateinit var pendingDuelRegistry: PendingDuelRegistry
+    private lateinit var userService: UserService
+    private lateinit var service: DuelWebService
+
+    @BeforeEach
+    fun setup() {
+        pendingDuelRegistry = mockk(relaxed = true)
+        userService = mockk(relaxed = true)
+        service = DuelWebService(pendingDuelRegistry, userService)
+    }
+
+    @Test
+    fun `pendingForOpponent projects registry entries to view DTOs`() {
+        every { pendingDuelRegistry.pendingForOpponent(opponentId, guildId) } returns listOf(
+            PendingDuelRegistry.PendingDuel(
+                id = 1L, guildId = guildId,
+                initiatorDiscordId = 100L, opponentDiscordId = opponentId,
+                stake = 50L, createdAt = Instant.now()
+            ),
+            PendingDuelRegistry.PendingDuel(
+                id = 2L, guildId = guildId,
+                initiatorDiscordId = 101L, opponentDiscordId = opponentId,
+                stake = 75L, createdAt = Instant.now()
+            ),
+        )
+
+        val rows = service.pendingForOpponent(opponentId, guildId)
+
+        assertEquals(2, rows.size)
+        assertTrue(rows.all { it.opponentDiscordId == opponentId })
+        assertEquals(50L, rows[0].stake)
+        assertEquals(75L, rows[1].stake)
+    }
+
+    @Test
+    fun `ensureOpponent returns existing user without creating`() {
+        val existing = UserDto(opponentId, guildId)
+        every { userService.getUserById(opponentId, guildId) } returns existing
+
+        val result = service.ensureOpponent(opponentId, guildId)
+
+        assertEquals(existing, result)
+        verify(exactly = 0) { userService.createNewUser(any()) }
+    }
+
+    @Test
+    fun `ensureOpponent lazily creates a row when none exists`() {
+        every { userService.getUserById(opponentId, guildId) } returns null
+        every { userService.createNewUser(any()) } answers { firstArg() }
+
+        val result = service.ensureOpponent(opponentId, guildId)
+
+        assertEquals(opponentId, result.discordId)
+        assertEquals(guildId, result.guildId)
+    }
+}

--- a/web/src/test/kotlin/web/service/TipWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/TipWebServiceTest.kt
@@ -1,0 +1,71 @@
+package web.service
+
+import database.dto.TipDailyDto
+import database.dto.UserDto
+import database.service.TipDailyService
+import database.service.UserService
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class TipWebServiceTest {
+    private val sender = 1L
+    private val recipient = 2L
+    private val guildId = 42L
+    private val today: LocalDate = LocalDate.parse("2026-04-10")
+
+    private lateinit var tipDailyService: TipDailyService
+    private lateinit var userService: UserService
+    private lateinit var service: TipWebService
+
+    @BeforeEach
+    fun setup() {
+        tipDailyService = mockk(relaxed = true)
+        userService = mockk(relaxed = true)
+        service = TipWebService(tipDailyService, userService)
+    }
+
+    @Test
+    fun `getDailyTipped returns 0 when no row exists`() {
+        every { tipDailyService.get(sender, guildId, today) } returns null
+
+        assertEquals(0L, service.getDailyTipped(sender, guildId, today))
+    }
+
+    @Test
+    fun `getDailyTipped returns row credits_sent`() {
+        every { tipDailyService.get(sender, guildId, today) } returns
+            TipDailyDto(sender, guildId, today, creditsSent = 175L)
+
+        assertEquals(175L, service.getDailyTipped(sender, guildId, today))
+    }
+
+    @Test
+    fun `ensureRecipient returns existing user without creating`() {
+        val existing = UserDto(recipient, guildId)
+        every { userService.getUserById(recipient, guildId) } returns existing
+
+        val result = service.ensureRecipient(recipient, guildId)
+
+        assertEquals(existing, result)
+        verify(exactly = 0) { userService.createNewUser(any()) }
+    }
+
+    @Test
+    fun `ensureRecipient lazily creates a row when none exists`() {
+        every { userService.getUserById(recipient, guildId) } returns null
+        val captured = slot()
+        every { userService.createNewUser(capture(captured)) } answers { captured.captured }
+
+        val result = service.ensureRecipient(recipient, guildId)
+
+        assertEquals(recipient, result.discordId)
+        assertEquals(guildId, result.guildId)
+    }
+
+    private inline fun <reified T : Any> slot(): io.mockk.CapturingSlot<T> = io.mockk.slot()
+}

--- a/web/src/test/kotlin/web/service/TipWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/TipWebServiceTest.kt
@@ -58,14 +58,11 @@ class TipWebServiceTest {
     @Test
     fun `ensureRecipient lazily creates a row when none exists`() {
         every { userService.getUserById(recipient, guildId) } returns null
-        val captured = slot()
-        every { userService.createNewUser(capture(captured)) } answers { captured.captured }
+        every { userService.createNewUser(any()) } answers { firstArg() }
 
         val result = service.ensureRecipient(recipient, guildId)
 
         assertEquals(recipient, result.discordId)
         assertEquals(guildId, result.guildId)
     }
-
-    private inline fun <reified T : Any> slot(): io.mockk.CapturingSlot<T> = io.mockk.slot()
 }


### PR DESCRIPTION
## Summary

Adds two new social/PvP credit-spend commands available in **both Discord and the web UI**:

- **`/tip @user <amount> [message]`** — peer-to-peer credit transfer. 10–500c per call, no fee, **500c/day outgoing cap per sender** (separate ledger from the voice/command earn bucket so alts can't launder daily-capped earnings).
- **`/duel @user <stake>`** — head-to-head 50/50 wager with Accept/Decline buttons (60s TTL). Winner takes the pot minus a 10% jackpot tribute, matching existing casino loss-tribute semantics.

Daily earn cap also bumped **60 → 90** so the new spends don't starve players.

## Notable design points

- **Web parity**: `TipController` + `DuelController` are thin wrappers over the same `TipService`/`DuelService` the Discord commands use. `PendingDuelRegistry` lives in the `database` module as a shared `@Component`, so a duel offered in Discord can be accepted via the web inbox and vice versa.
- **Atomicity**: Both `/tip` and `/duel acceptDuel` lock two `user` rows; the `lockBoth` helpers always lock by ascending `discord_id` to prevent A→B vs B→A deadlocks.
- **Loss tribute**: Paid out of the pot before crediting the winner — winner receives `2*stake - floor(stake*0.10)`. Loser's accounting is exactly `-stake`, identical to a casino loss.
- **Button-manager fix**: `DefaultButtonManager.getButton` previously did exact-match against `Button.name`, so stateful component IDs like `highlow:HIGHER:9:50:6` and `duel:accept:1:42` would silently fail to dispatch. Now matches on the colon-prefix.
- **V21 migration**: adds `tip_daily`, `tip_log`, `duel_log` tables.

## Test plan

- [ ] CI runs `./gradlew test` (sandboxed env couldn't fetch the foojay plugin to compile-check locally).
- [ ] `:database:test` covers `TipServiceTest`, `DuelServiceTest`, `TipDailyServiceTest`, `PendingDuelRegistryTest`, and the updated `SocialCreditAwardServiceTest`.
- [ ] `:discord-bot:test` covers `TipCommandTest`, `DuelCommandTest`, `DuelButtonTest`, `DefaultButtonManagerTest`, and the updated `VoiceCreditAwardServiceTest`.
- [ ] `:web:test` covers `TipControllerTest`, `DuelControllerTest`, `TipWebServiceTest`, `DuelWebServiceTest`.
- [ ] Apply `V21__social_pvp.sql` against a local Postgres and confirm `\d+ tip_daily | tip_log | duel_log` shows expected columns + indexes.
- [ ] Live exercise in a test guild:
  - [ ] `/tip @userB 50 thanks!` → public embed, `tip_log` row, `tip_daily.credits_sent = 50`.
  - [ ] Tip self → ephemeral error.
  - [ ] Tip bot → ephemeral error.
  - [ ] Tip past the 500c/day cap → `DailyCapExceeded`, no movement.
  - [ ] `/duel @userB 50` → embed with Accept/Decline; on userB Accept, embed updates with winner / pot / tribute. `duel_log` row present.
  - [ ] Decline / 60s timeout updates the embed and moves no credits.
  - [ ] Initiator spends down via `/slots` between offer and accept → `InitiatorInsufficient`, no movement.
  - [ ] Voice cap now climbs to 90 instead of 60.
- [ ] Web exercise: visit `/tip/{guildId}` and `/duel/{guildId}`, confirm challenge → accept flow works across two browsers logged in as different users.

https://claude.ai/code/session_01TE7Bvmtf7bNvhYKJDN73ha

---
_Generated by [Claude Code](https://claude.ai/code/session_01TE7Bvmtf7bNvhYKJDN73ha)_