### PR TITLE
chore(qodana): clear actionable inspection issues

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,13 @@ allprojects {
     version = "6.1-SNAPSHOT"
 
     ext['kotlin.version'] = kotlin_version
+    // Override Spring Boot 3.3.4's BOM-managed versions with patched releases.
+    // Spring's dependency-management plugin reads these ext properties before
+    // applying the BOM, so any transitive consumer resolves the patched
+    // version. resolutionStrategy.force in subprojects is a belt-and-braces
+    // fallback for configurations the dep-management plugin doesn't reach.
+    ext['jackson-bom.version'] = '2.18.2'           // GHSA-72hv-8253-57qq (jackson-core <2.18.x)
+    ext['commons-lang3.version'] = '3.18.0'         // CVE-2025-48924 (commons-lang3 <3.18.0)
 
     repositories {
         mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         jdaVersion = '6.3.1'
         kotlin_version = '2.3.0'
         kotlinx_version = '1.10.2'
-        ktor_version = '2.3.12'
+        ktor_version = '2.3.13'
         mockk_version = '1.13.13'
         lavaplayer_version = '2.2.6'
         youtube_common_version = '1.18.0'
@@ -59,6 +59,15 @@ subprojects {
     configurations {
         configureEach {
             exclude group: 'org.springframework.boot', module: 'spring-boot-starter-logging'
+            // Force patched versions for Qodana-flagged transitive CVEs.
+            // jackson-bom: GHSA-72hv-8253-57qq (jackson-core <2.18.x).
+            // commons-lang3: CVE-2025-48924 (<3.18.0).
+            resolutionStrategy {
+                force 'com.fasterxml.jackson.core:jackson-core:2.18.2'
+                force 'com.fasterxml.jackson.core:jackson-databind:2.18.2'
+                force 'com.fasterxml.jackson.core:jackson-annotations:2.18.2'
+                force 'org.apache.commons:commons-lang3:3.18.0'
+            }
         }
     }
 

--- a/common/src/main/kotlin/common/logging/DiscordLogger.kt
+++ b/common/src/main/kotlin/common/logging/DiscordLogger.kt
@@ -48,10 +48,6 @@ class DiscordLogger(clazz: Class<*>) {
         }
     }
 
-    fun clearContext() {
-        MDC.clear()
-    }
-
     // Construct a dynamic log message based on the context
     private fun buildLogMessage(message: String): String {
         val guildName = MDC.get("guildName") ?: ""

--- a/core-api/src/main/kotlin/core/button/ButtonContext.kt
+++ b/core-api/src/main/kotlin/core/button/ButtonContext.kt
@@ -43,6 +43,7 @@ interface ButtonContext {
          * @return the [author][net.dv8tion.jda.api.entities.Member] of the message as member
          */
         get() = event.member
+    @Suppress("unused") // public API surface on ButtonContext
     val jDA: JDA
         /**
          * Returns the current [jda][net.dv8tion.jda.api.JDA] instance

--- a/core-api/src/main/kotlin/core/command/CommandContext.kt
+++ b/core-api/src/main/kotlin/core/command/CommandContext.kt
@@ -53,6 +53,7 @@ interface CommandContext {
          * @return the current [jda][net.dv8tion.jda.api.JDA] instance
          */
         get() = event.jda
+    @Suppress("unused") // public API surface on CommandContext
     val shardManager: ShardManager?
         /**
          * Returns the current [net.dv8tion.jda.api.sharding.ShardManager] instance
@@ -60,6 +61,7 @@ interface CommandContext {
          * @return the current [net.dv8tion.jda.api.sharding.ShardManager] instance
          */
         get() = jDA.shardManager
+    @Suppress("unused") // public API surface on CommandContext
     val selfUser: User?
         /**
          * Returns the [user][net.dv8tion.jda.api.entities.User] for the currently logged in account

--- a/database/src/main/kotlin/database/dto/ActivityMonthlyRollupDto.kt
+++ b/database/src/main/kotlin/database/dto/ActivityMonthlyRollupDto.kt
@@ -29,6 +29,7 @@ import java.time.LocalDate
         query = "delete from ActivityMonthlyRollupDto r where r.monthStart < :cutoff"
     )
 )
+@Suppress("unused") // monthStart is used by NamedQueries above; flagged spuriously by Qodana
 @Entity
 @Table(name = "activity_monthly_rollup", schema = "public")
 @IdClass(ActivityMonthlyRollupId::class)

--- a/database/src/main/kotlin/database/dto/MusicDto.kt
+++ b/database/src/main/kotlin/database/dto/MusicDto.kt
@@ -72,10 +72,8 @@ class MusicDto(
         endMs = endMs
     )
 
-    enum class Adjustment(val adjustment: String) {
-        START("start"),
-        END("end");
-
+    enum class Adjustment {
+        START
     }
 
     override fun toString(): String {

--- a/database/src/main/kotlin/database/dto/UserOwnedTitleDto.kt
+++ b/database/src/main/kotlin/database/dto/UserOwnedTitleDto.kt
@@ -15,6 +15,7 @@ import java.time.Instant
         query = "select count(o) from UserOwnedTitleDto o where o.discordId = :discordId and o.titleId = :titleId"
     )
 )
+@Suppress("unused") // boughtAt is written via JPA from DefaultTitleService; flagged spuriously by Qodana
 @Entity
 @Table(name = "user_owned_title", schema = "public")
 @IdClass(UserOwnedTitleId::class)

--- a/database/src/main/kotlin/database/service/EconomyTradeService.kt
+++ b/database/src/main/kotlin/database/service/EconomyTradeService.kt
@@ -3,7 +3,6 @@ package database.service
 import database.dto.TobyCoinMarketDto
 import database.dto.TobyCoinPricePointDto
 import database.dto.TobyCoinTradeDto
-import database.dto.UserDto
 import database.economy.TobyCoinEngine
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional

--- a/discord-bot/src/main/kotlin/bot/toby/activity/ActivityTrackingNotifier.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/activity/ActivityTrackingNotifier.kt
@@ -69,10 +69,9 @@ class ActivityTrackingNotifier @Autowired constructor(
     private fun sendDmSafely(user: User, body: String) {
         runCatching {
             user.openPrivateChannel().queue({ pm ->
-                pm.sendMessage(body).queue(
-                    null,
-                    { err -> logger.warn("Could not DM ${user.id} about activity tracking: ${err.message}") }
-                )
+                pm.sendMessage(body).queue(null) { err ->
+                    logger.warn("Could not DM ${user.id} about activity tracking: ${err.message}")
+                }
             }, { err ->
                 logger.warn("Could not open DM with ${user.id}: ${err.message}")
             })

--- a/discord-bot/src/main/kotlin/bot/toby/dto/web/RedditAPIDto.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/dto/web/RedditAPIDto.kt
@@ -15,9 +15,6 @@ class RedditAPIDto {
     @SerializedName("permalink")
     var url: String? = null
 
-    @SerializedName("url_overridden_by_dest")
-    var image: String? = null
-
     @SerializedName("over_18")
     var isNsfw: Boolean? = null
 

--- a/discord-bot/src/main/kotlin/bot/toby/economy/TobyCoinChartRenderer.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/economy/TobyCoinChartRenderer.kt
@@ -97,7 +97,7 @@ class TobyCoinChartRenderer {
                     0f, 400f, Color(0x57, 0xF2, 0x87, 20)
                 )
             )
-            setOutline(true)
+            isOutline = true
         }
         plot.renderer = renderer
     }

--- a/discord-bot/src/main/kotlin/bot/toby/helpers/InitiativeState.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/helpers/InitiativeState.kt
@@ -117,8 +117,6 @@ class InitiativeState {
         }
     }
 
-    internal val currentEntry: RolledEntry?
-        get() = sortedEntries.getOrNull(initiativeIndex.get())
 }
 
 /**

--- a/discord-bot/src/main/kotlin/bot/toby/helpers/charactersheet/DndBeyondCharacterSheetProvider.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/helpers/charactersheet/DndBeyondCharacterSheetProvider.kt
@@ -16,7 +16,7 @@ import java.time.LocalDateTime
 class DndBeyondCharacterSheetProvider(
     private val fetcher: DndBeyondCharacterFetcher,
     private val characterSheetService: CharacterSheetService,
-    @param:Value("\${dnd.beyond.sheet.ttl-seconds:3600}") private val ttlSeconds: Long = 3600,
+    @param:Value($$"${dnd.beyond.sheet.ttl-seconds:3600}") private val ttlSeconds: Long = 3600,
 ) : CharacterSheetProvider {
 
     private val logger = LoggerFactory.getLogger(DndBeyondCharacterSheetProvider::class.java)

--- a/web/src/main/kotlin/web/service/CampaignWebService.kt
+++ b/web/src/main/kotlin/web/service/CampaignWebService.kt
@@ -87,6 +87,7 @@ data class EncounterView(
     val notes: String?,
     val entries: List<EncounterEntryView> = emptyList()
 ) {
+    @Suppress("unused") // consumed by templates/campaignDetail.html via Thymeleaf
     val totalRosterSize: Int
         get() = entries.sumOf { it.effectiveQuantity }
 }
@@ -133,6 +134,7 @@ data class PlayerInfo(
     val characterClasses: String? = null,
     val characterLevel: Int? = null
 ) {
+    @Suppress("unused") // consumed by templates/campaignDetail.html via Thymeleaf
     val characterLink: String?
         get() = characterId?.let { "https://www.dndbeyond.com/characters/$it" }
 }

--- a/web/src/main/kotlin/web/service/LeaderboardWebService.kt
+++ b/web/src/main/kotlin/web/service/LeaderboardWebService.kt
@@ -167,6 +167,7 @@ data class LeaderboardGuildCard(
     val totalVoiceSeconds: Long,
     val memberCount: Int
 ) {
+    @Suppress("unused") // consumed by templates/leaderboards.html via Thymeleaf
     val totalVoiceDisplay: String get() = formatDuration(totalVoiceSeconds)
     private fun formatDuration(seconds: Long): String {
         if (seconds <= 0) return "0m"
@@ -187,6 +188,7 @@ data class LeaderboardGuildView(
     val sort: LeaderboardSort = LeaderboardSort.THIS_MONTH,
     val tobyCoinLeaders: List<TobyCoinLeaderRow> = emptyList()
 ) {
+    @Suppress("unused") // consumed by templates/leaderboard.html via Thymeleaf
     val totalVoiceThisMonthDisplay: String get() = formatDuration(totalVoiceThisMonth)
     private fun formatDuration(seconds: Long): String {
         if (seconds <= 0) return "0m"

--- a/web/src/main/kotlin/web/service/ModerationWebService.kt
+++ b/web/src/main/kotlin/web/service/ModerationWebService.kt
@@ -117,21 +117,21 @@ class ModerationWebService(
         val thisMonthStart = LocalDate.now(ZoneOffset.UTC).withDayOfMonth(1)
         val nextMonthStart = thisMonthStart.plusMonths(1)
 
-        val lifetimeVoice = safely("lifetime voice", emptyMap<Long, Long>()) {
+        val lifetimeVoice = safely("lifetime voice", emptyMap()) {
             voiceSessionService.sumCountedSecondsLifetimeByUser(guildId)
         }
         // Range is [thisMonthStart, nextMonthStart) — sessions whose joinedAt
         // falls inside the current calendar month. The MonthlyLeaderboardJob
         // uses [prevMonthStart, thisMonthStart) because it runs on the 1st
         // and reports the JUST-FINISHED month; that range is wrong here.
-        val thisMonthVoice = safely("this-month voice", emptyMap<Long, Long>()) {
+        val thisMonthVoice = safely("this-month voice", emptyMap()) {
             voiceSessionService.sumCountedSecondsInRangeByUser(
                 guildId,
                 thisMonthStart.atStartOfDay().toInstant(ZoneOffset.UTC),
                 nextMonthStart.atStartOfDay().toInstant(ZoneOffset.UTC)
             )
         }
-        val existingBaselines = safely("prior snapshots", emptyList<database.dto.MonthlyCreditSnapshotDto>()) {
+        val existingBaselines = safely("prior snapshots", emptyList()) {
             snapshotService.listForGuildDate(guildId, thisMonthStart)
         }.associateBy { it.discordId }.toMutableMap()
 

--- a/web/src/main/kotlin/web/service/TitlesWebService.kt
+++ b/web/src/main/kotlin/web/service/TitlesWebService.kt
@@ -2,7 +2,6 @@ package web.service
 
 import common.logging.DiscordLogger
 import database.dto.TitleDto
-import database.dto.UserOwnedTitleDto
 import database.service.EconomyTradeService
 import database.service.EconomyTradeService.TradeOutcome
 import database.service.TitleService
@@ -56,7 +55,7 @@ class TitlesWebService(
     }
 
     fun getTitlesForGuild(guildId: Long, actorDiscordId: Long): TitleShopView {
-        val catalog = safely("title catalog", emptyList<TitleDto>()) {
+        val catalog = safely("title catalog", emptyList()) {
             titleService.listAll()
         }.map { t ->
             TitleShopEntry(
@@ -67,7 +66,7 @@ class TitlesWebService(
                 colorHex = t.colorHex
             )
         }
-        val ownedIds: Set<Long> = safely("owned titles", emptyList<UserOwnedTitleDto>()) {
+        val ownedIds: Set<Long> = safely("owned titles", emptyList()) {
             titleService.listOwned(actorDiscordId)
         }.mapTo(HashSet()) { it.titleId }
         val actorDto = userService.getUserById(actorDiscordId, guildId)
@@ -128,7 +127,7 @@ class TitlesWebService(
         val shortfall = (title.cost - currentCredits).coerceAtLeast(0L)
 
         var soldCoins = 0L
-        var priceAfterSell = 0.0
+        val priceAfterSell: Double
         if (shortfall > 0L) {
             val market = marketService.getMarketForUpdate(guildId)
                 ?: return BuyWithTobyOutcome.Error("No market yet for this server — try a Discord trade first.")

--- a/web/src/main/kotlin/web/service/UtilsWebService.kt
+++ b/web/src/main/kotlin/web/service/UtilsWebService.kt
@@ -25,6 +25,11 @@ class UtilsWebService(
     fun randomMeme(subreddit: String, timePeriod: String, limit: Int): UtilsResult<MemeResult> {
         val sub = subreddit.trim()
         if (sub.isEmpty()) return UtilsResult.error("Subreddit is required.")
+        // Reddit subreddit names are alphanumeric + underscore, 3-21 chars.
+        // Validating here scrubs the taint before it reaches the URL sink.
+        if (!SUBREDDIT_NAME.matches(sub)) {
+            return UtilsResult.error("Invalid subreddit name.")
+        }
         if (sub.equals("sneakybackgroundfeet", ignoreCase = true)) {
             return UtilsResult.error("Don't talk to me.")
         }
@@ -137,6 +142,10 @@ class UtilsWebService(
             "day", "week", "month", "all" -> tp.lowercase()
             else -> "day"
         }
+
+    private companion object {
+        val SUBREDDIT_NAME: Regex = Regex("^[A-Za-z0-9_]{1,50}$")
+    }
 }
 
 data class UtilsResult<T>(val value: T?, val error: String?) {


### PR DESCRIPTION
## Summary

Addresses the actionable Qodana findings from `019dc9cc-qodana.sarif1.json` (40 results across the repo).

### Dead code deleted
- `RedditAPIDto.image` (Gson field never read by any caller)
- `MusicDto.Adjustment.END` and the now-unused `adjustment` ctor param (only `START.name` is referenced)
- `DiscordLogger.clearContext()` (no callers)
- `InitiativeState.currentEntry` (the only `currentEntry` callers reference `InitiativeStore.currentEntry()`, a different symbol)
- Unused `UserDto` import in `EconomyTradeService` (and `UserOwnedTitleDto` import in `TitlesWebService` exposed by the type-arg cleanup below)

### `@Suppress("unused")` for symbols Qodana misses
These are reached via Thymeleaf templates, JPA NamedQueries, or public interface contracts — keeping them is intentional:
- `CampaignWebService.{totalRosterSize, characterLink}` (`templates/campaignDetail.html`)
- `LeaderboardWebService.{totalVoiceDisplay, totalVoiceThisMonthDisplay}` (`templates/leaderboard{,s}.html`)
- `ActivityMonthlyRollupDto` (`@Id monthStart` referenced by NamedQueries on the same class)
- `UserOwnedTitleDto` (`boughtAt` written via JPA from `DefaultTitleService`)
- `ButtonContext.jDA`, `CommandContext.{shardManager, selfUser}` (public API surface)

### Style / micro fixes
- Drop redundant explicit type args on `emptyMap()` / `emptyList()` in `ModerationWebService` and `TitlesWebService` (the `safely(label, default, block)` second arg already pins `T`)
- `priceAfterSell` `var = 0.0` → `val` (always assigned in both branches; drops the redundant initializer)
- Trailing-lambda form for the inner `pm.sendMessage(body).queue(null) { err -> ... }` in `ActivityTrackingNotifier`
- `setOutline(true)` → `isOutline = true` on JFreeChart's `XYAreaRenderer`
- Convert escaped `@Value("\${...}")` placeholder to Kotlin multi-dollar `@Value($$"${...}")` in `DndBeyondCharacterSheetProvider`

### Vulnerable dependencies
Bumped via root `build.gradle`:
- `ktor` 2.3.12 → 2.3.13 (CVE-2024-49580 — `ktor-client-core` cache-of-sensitive-info)
- Forced `jackson-{core,databind,annotations}` 2.18.2 via subprojects `resolutionStrategy.force` (GHSA-72hv-8253-57qq)
- Forced `commons-lang3` 3.18.0 (CVE-2025-48924) — only the `database` module was direct on a patched 3.18.0; the rest pulled the older transitive

### XSS taint scrub
`UtilsWebService.randomMeme` validates `subreddit` against `^[A-Za-z0-9_]{1,50}$` before it reaches the URL sink, clearing all five `JvmTaintAnalysis` warnings on the request → URL flow.

### Not addressed (intentional)
- 11 `DuplicatedCode` flags spanning controllers (`Casino`/`Economy`/`Leaderboard`/`Coinflip`/`Dice`/`Highlow`/`Scratch`/`Profile`/`Titles`), JS files, commands (`Scratch`/`Slots`/`SetConfig`/`Activity`/`SocialCredit`), persistence impls, and `LeaderboardWebService`/`ModerationWebService`. These are design-level recommendations, not bugs; refactoring across four languages would carry regression risk well above the value of clearing the warnings.

## Test plan

- [x] `:web:test`, `:database:test`, `:core-api:test`, `:common:test` — all pass locally with the new resolutionStrategy in effect
- [ ] CI to verify `:discord-bot` and `:application` (their `dev.lavalink.youtube` / `moe.kyokobot.libdave` deps are network-blocked from the local sandbox)
- [ ] Manual UI smoke (post-merge): `/leaderboard`, `/leaderboards`, `/campaign/<id>` render the suppressed-but-template-bound props; `/utils?subreddit=memes` works and `?subreddit=../etc` returns "Invalid subreddit name."

https://claude.ai/code/session_01My94TnNZ9vJpRcqLXtzY1m

---
_Generated by [Claude Code](https://claude.ai/code/session_01My94TnNZ9vJpRcqLXtzY1m)_