### PR TITLE
feat(web): wire Tip and Duel into the nav and home page

### DIFF
--- a/web/src/main/resources/templates/fragments/navbar.html
+++ b/web/src/main/resources/templates/fragments/navbar.html
@@ -21,6 +21,8 @@
             <div class="nav-dropdown-menu" role="menu">
                 <a href="/economy/guilds" role="menuitem">Market</a>
                 <a href="/titles/guilds" role="menuitem">Titles</a>
+                <a href="/tip/guilds" role="menuitem">&#128184; Tip</a>
+                <a href="/duel/guilds" role="menuitem">&#9876;&#65039; Duel</a>
             </div>
         </div>
         <div class="nav-dropdown">

--- a/web/src/main/resources/templates/home.html
+++ b/web/src/main/resources/templates/home.html
@@ -222,6 +222,16 @@
             <h3>Titles</h3>
             <p>Spend credit on vanity titles that grant a matching Discord role when equipped.</p>
         </a>
+        <a class="feature-card" href="/tip/guilds">
+            <div class="feature-icon">&#128184;</div>
+            <h3>Tip A Friend</h3>
+            <p>Send some of your social credit to another user in the same server, with an optional message.</p>
+        </a>
+        <a class="feature-card" href="/duel/guilds">
+            <div class="feature-icon">&#9876;&#65039;</div>
+            <h3>Duel</h3>
+            <p>Stake credit and challenge someone to a coin-flip duel — winner takes most of the pot.</p>
+        </a>
         <a class="feature-card" href="/leaderboards">
             <div class="feature-icon">&#128200;</div>
             <h3>Leaderboards</h3>


### PR DESCRIPTION
## Summary
- Add Tip and Duel sub-entries to the Economy nav dropdown so the features are reachable from any page.
- Add matching feature cards on the home page next to Market and Titles so the discovery surface shows them.

The pages and APIs landed in #314, but nothing pointed at them — you had to know `/tip/guilds` and `/duel/guilds` to find them. This is the discoverability follow-up.

## Test plan
- [ ] Load `/` and confirm two new feature cards appear (Tip A Friend, Duel) and link to the right places.
- [ ] Open the Economy dropdown in the nav and confirm Tip and Duel are listed and navigate correctly.
- [ ] Existing nav entries (Market, Titles) still work.

https://claude.ai/code/session_01TE7Bvmtf7bNvhYKJDN73ha

---
_Generated by [Claude Code](https://claude.ai/code/session_01TE7Bvmtf7bNvhYKJDN73ha)_