### PR TITLE
fix(economy): surface the 1% trade fee before & after every buy/sell

### DIFF
--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/TobyCoinCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/TobyCoinCommand.kt
@@ -102,6 +102,11 @@ class TobyCoinCommand @Autowired constructor(
             .addField("Price", "%.2f credits / coin".format(market.price), true)
             .addField("24h change", changeText, true)
             .addField("Last tick", "<t:${market.lastTickAt.epochSecond}:R>", true)
+            .addField(
+                "Fee",
+                "1% on every buy & sell — feeds the server jackpot.",
+                false
+            )
             .setColor(priceColor(change))
             .setFooter("Try /tobycoin chart to see the market")
             .build()
@@ -136,7 +141,7 @@ class TobyCoinCommand @Autowired constructor(
             reply(event, "You must specify an amount.", deleteDelay); return
         }
         val outcome = tradeService.buy(userDto.discordId, userDto.guildId, amount)
-        reply(event, describe(outcome, "Bought", amount), deleteDelay)
+        reply(event, describe(outcome, "Bought", amount, isBuy = true), deleteDelay)
     }
 
     private fun handleSell(
@@ -148,7 +153,7 @@ class TobyCoinCommand @Autowired constructor(
             reply(event, "You must specify an amount.", deleteDelay); return
         }
         val outcome = tradeService.sell(userDto.discordId, userDto.guildId, amount)
-        reply(event, describe(outcome, "Sold", amount), deleteDelay)
+        reply(event, describe(outcome, "Sold", amount, isBuy = false), deleteDelay)
     }
 
     private fun handleChart(
@@ -195,12 +200,21 @@ class TobyCoinCommand @Autowired constructor(
             .queue(invokeDeleteOnMessageResponse(deleteDelay))
     }
 
-    private fun describe(outcome: TradeOutcome, verb: String, amount: Long): String = when (outcome) {
-        is TradeOutcome.Ok -> ("$verb **${outcome.amount} TOBY** for ${outcome.transactedCredits} credits. " +
-                "New price: %.2f. You now hold ${outcome.newCoins} TOBY and ${outcome.newCredits} credits.")
-            .format(outcome.newPrice)
+    private fun describe(outcome: TradeOutcome, verb: String, amount: Long, isBuy: Boolean): String = when (outcome) {
+        is TradeOutcome.Ok -> {
+            val breakdown = if (outcome.fee > 0L) {
+                // Buyers pay gross + fee; sellers receive gross − fee.
+                val gross = if (isBuy) outcome.transactedCredits - outcome.fee
+                            else outcome.transactedCredits + outcome.fee
+                val sign = if (isBuy) "+" else "−"
+                " ($gross gross $sign ${outcome.fee} fee, 1%)"
+            } else ""
+            ("$verb **${outcome.amount} TOBY** for ${outcome.transactedCredits} credits$breakdown. " +
+                    "New price: %.2f. You now hold ${outcome.newCoins} TOBY and ${outcome.newCredits} credits.")
+                .format(outcome.newPrice)
+        }
         is TradeOutcome.InsufficientCredits ->
-            "You need ${outcome.needed} credits for this trade but only have ${outcome.have}."
+            "You need ${outcome.needed} credits for this trade (price + 1% fee) but only have ${outcome.have}."
         is TradeOutcome.InsufficientCoins ->
             "You need ${outcome.needed} TOBY for this trade but only have ${outcome.have}."
         TradeOutcome.InvalidAmount -> "Amount must be a positive number. You asked for $amount."

--- a/web/src/main/kotlin/web/controller/EconomyController.kt
+++ b/web/src/main/kotlin/web/controller/EconomyController.kt
@@ -146,7 +146,8 @@ class EconomyController(
                         newCoins = outcome.newCoins,
                         newCredits = outcome.newCredits + granted,
                         newPrice = outcome.newPrice,
-                        transactedCredits = outcome.transactedCredits
+                        transactedCredits = outcome.transactedCredits,
+                        fee = outcome.fee
                     )
                 )
             }
@@ -174,7 +175,8 @@ data class TradeResponse(
     val newCoins: Long? = null,
     val newCredits: Long? = null,
     val newPrice: Double? = null,
-    val transactedCredits: Long? = null
+    val transactedCredits: Long? = null,
+    val fee: Long? = null
 )
 
 data class HistoryResponse(

--- a/web/src/main/resources/static/css/economy.css
+++ b/web/src/main/resources/static/css/economy.css
@@ -37,6 +37,11 @@
 .economy-price-change.up { color: var(--success); }
 .economy-price-change.down { color: var(--danger); }
 
+.economy-price-fee {
+    font-size: 0.8rem;
+    margin-top: 2px;
+}
+
 .economy-chart-card {
     background: var(--bg-elevated);
     border: 1px solid var(--border);

--- a/web/src/main/resources/static/js/economy.js
+++ b/web/src/main/resources/static/js/economy.js
@@ -264,6 +264,18 @@
     const portfolioEl = document.getElementById('economy-portfolio');
     const priceEl = document.getElementById('economy-price');
 
+    function formatTradeMessage(kind, amount, r) {
+        const verb = kind === 'buy' ? 'Bought' : 'Sold';
+        const head = verb + ' ' + amount + ' TOBY';
+        if (r.transactedCredits == null) return head + '.';
+        const base = head + ' for ' + r.transactedCredits + ' credits';
+        if (!r.fee) return base + '.';
+        const note = kind === 'buy'
+            ? ' (incl. ' + r.fee + ' fee, 1%)'
+            : ' (after ' + r.fee + ' fee, 1%)';
+        return base + note + '.';
+    }
+
     function applyTradeResult(r) {
         if (r.newCoins !== null && coinsEl) coinsEl.textContent = r.newCoins + ' TOBY';
         if (r.newCredits !== null && creditsEl) creditsEl.textContent = r.newCredits + ' credits';
@@ -281,7 +293,7 @@
             .then(function (r) {
                 btn.disabled = false;
                 if (r && r.ok) {
-                    toast(kind === 'buy' ? 'Bought ' + amount + ' TOBY.' : 'Sold ' + amount + ' TOBY.', 'success');
+                    toast(formatTradeMessage(kind, amount, r), 'success');
                     applyTradeResult(r);
                     loadHistory(currentWindow);
                 } else {

--- a/web/src/main/resources/templates/economy.html
+++ b/web/src/main/resources/templates/economy.html
@@ -17,6 +17,7 @@
                  th:text="${#numbers.formatDecimal(view.price, 1, 2)}">0.00</div>
             <!-- Populated by economy.js once /history responds; tracks the active chart window. -->
             <div class="economy-price-change">&nbsp;</div>
+            <div class="economy-price-fee muted">+ 1% fee on buys &amp; sells</div>
         </div>
     </div>
 
@@ -83,7 +84,8 @@
             </div>
             <p class="hint">
                 Buys push the price up, sells push it down. The market also
-                drifts on its own every few minutes.
+                drifts on its own every few minutes. Every trade pays a 1%
+                fee into the server jackpot pool.
             </p>
         </section>
     </div>


### PR DESCRIPTION
## Summary

Niall reported that buying TOBY at a listed price of 99.95 actually cost 100.83 — the 1% jackpot-pool fee, but with no disclosure before or after the trade. The fee was already calculated correctly and exposed on `TradeOutcome.Ok.fee`; it just wasn't surfaced in the UI.

This change makes the fee visible in both the Discord and web flows, before and after each trade. No pricing logic was touched.

**Discord (`/tobycoin`)**
- `price` embed gains a "Fee" field: *"1% on every buy & sell — feeds the server jackpot."*
- `buy`/`sell` reply now breaks out the gross + fee, e.g.
  *"Bought **100 TOBY** for 102 credits (101 gross + 1 fee, 1%)."*
  Sells use *"(102 gross − 1 fee, 1%)"*. When the fee rounds to zero (sub-coin amounts, test fixtures), the parenthetical is suppressed so existing `TradeOutcome.Ok` fixtures with the default `fee = 0L` still render the legacy short form.
- `InsufficientCredits` message now reads "for this trade (price + 1% fee)" so the threshold isn't surprising.

**Web (`/economy/{guildId}`)**
- New "+ 1% fee on buys & sells" line under the price value.
- Trade card hint adds: *"Every trade pays a 1% fee into the server jackpot pool."*
- `TradeResponse` gains a `fee: Long?` field, populated from `outcome.fee`.
- Success toast now reads e.g. *"Bought 100 TOBY for 102 credits (incl. 1 fee, 1%)."* (or *"after"* for sells), falling back to the previous short message if `fee` or `transactedCredits` is absent.

## Files

- `discord-bot/src/main/kotlin/bot/toby/command/commands/economy/TobyCoinCommand.kt` — price embed, `describe()` breakdown, `isBuy` plumbing.
- `web/src/main/kotlin/web/controller/EconomyController.kt` — `TradeResponse.fee` field + populate.
- `web/src/main/resources/templates/economy.html` — price-area fee label + updated trade hint.
- `web/src/main/resources/static/js/economy.js` — `formatTradeMessage()` helper for the success toast.
- `web/src/main/resources/static/css/economy.css` — small `.economy-price-fee` rule so the label sits nicely under the price.

## Test plan

- [x] JS suite — `cd web && npm test` (162 passing).
- [ ] Kotlin suites — could not run locally in the sandbox (plugins.gradle.org returning 503 for the foojay toolchain plugin); CI will execute `:discord-bot:test`, `:web:test`, `:database:test` on push. Existing tests use `TradeOutcome.Ok` with default `fee = 0L`, which still hits the no-breakdown branch and matches the old wording.
- [ ] Discord smoke: run `/tobycoin price` → confirm fee field, `/tobycoin buy 100` and `/tobycoin sell 100` → confirm gross/fee split, totals match `transactedCredits`.
- [ ] Web smoke: load `/economy/{guildId}` → confirm fee label under price + 1% line in trade hint; buy and sell small amounts → confirm toast shows breakdown and `fee` is in the JSON response.

https://claude.ai/code/session_01SmAV6XfismZWqojB9CWeRG

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmAV6XfismZWqojB9CWeRG)_