### PR TITLE
fix(scratch): drop 2× floor so 5🍒 ≠ 5🍋, pin RTP via closed form

### DIFF
--- a/database/src/main/kotlin/database/economy/ScratchCard.kt
+++ b/database/src/main/kotlin/database/economy/ScratchCard.kt
@@ -9,11 +9,9 @@ import kotlin.random.Random
  *   Nine cells drawn independently from a weighted reel (same shape as
  *   [SlotMachine]: 4🍒 + 3🍋 + 2🔔 + 1⭐ = 10 cells). Win condition:
  *   5 or more cells of the SAME symbol anywhere on the card.
- *   Payout multiplier = max(2, basePayout × (matchCount − (MATCH_THRESHOLD − 1)))
- *   — so 5-of-a-kind pays base (floored to 2), 6 pays 2×, … 9 pays 5×.
- *   The 2× floor only matters for 5-of-a-kind cherry (base 1) — every
- *   other path is already ≥ 2 — and keeps that boundary a real win
- *   (net ≥ stake) instead of a stake-back no-op.
+ *   Payout multiplier = basePayout × (matchCount − (MATCH_THRESHOLD − 1)) —
+ *   pure closed form, every (symbol, k) pair distinct, no special cases.
+ *   So 5🍒 = 1× (stake refund / push, net 0), 5🍋 = 2×, … 9⭐ = 200×.
  *
  *   Two symbols both hitting ≥5 is impossible with 9 cells (5+5 > 9),
  *   so the tie-break in `scratch` is a guard rather than a gameplay
@@ -23,9 +21,7 @@ import kotlin.random.Random
  *   - 9 cells in a 3×3 grid vs 3 reels → wider hit space, big-card feel
  *   - "≥5 of a kind" vs "exactly 3 of a kind" → counts of 6–9 scale
  *     payouts up linearly
- *   - Different RTP profile (~100-105% on these tunings — the 2× floor on
- *     the otherwise-buggy 5🍒 boundary nudges scratch slightly above
- *     break-even, the RTP test in ScratchCardTest pins the actual number)
+ *   - RTP ≈ 0.875 (12.5% house edge), pinned by [expectedRtp] in tests
  */
 class ScratchCard(
     private val reel: List<SlotMachine.Symbol> = SlotMachine.DEFAULT_REEL,
@@ -66,12 +62,12 @@ class ScratchCard(
         const val MATCH_THRESHOLD: Int = 5
 
         // Base multipliers. Effective multiplier on a k-of-a-kind is
-        // max(2, base × (k - 4)). The floor only fires on 5🍒 (base 1, k=5
-        // → raw 1 → floored to 2); every other (symbol, k) combination is
-        // already ≥ 2. Tuned alongside the RTP convergence test — adjust
-        // here, rerun ScratchCardTest's RTP case, accept the new bound.
+        // base × (k - 4). 5🍒=1× is a stake-refund push (net 0), 5🍋=2×
+        // is the smallest real win — every (symbol, k) pair is distinct.
+        // Tuned alongside [expectedRtp]: adjust bases here, the RTP test
+        // pins the closed-form result so drift surfaces in CI.
         val DEFAULT_BASE_PAYOUTS: Map<SlotMachine.Symbol, Long> = mapOf(
-            SlotMachine.Symbol.CHERRY to 1L,    // 5🍒=2× (floored),  …, 9🍒=5×
+            SlotMachine.Symbol.CHERRY to 1L,    // 5🍒=1× (push), …, 9🍒=5×
             SlotMachine.Symbol.LEMON to 2L,     // 5🍋=2×,  …, 9🍋=10×
             SlotMachine.Symbol.BELL to 8L,      // 5🔔=8×,  …, 9🔔=40×
             SlotMachine.Symbol.STAR to 40L      // 5⭐=40×, …, 9⭐=200×
@@ -79,8 +75,8 @@ class ScratchCard(
 
         /**
          * Closed-form multiplier for [matchCount]-of-a-kind on [symbol].
-         * Single source of truth — the live [scratch] path and any UI that
-         * displays a payout table both call this so they can't drift.
+         * Single source of truth — the live [scratch] path and any UI
+         * that displays a payout table both call this so they can't drift.
          */
         fun multiplierFor(
             symbol: SlotMachine.Symbol,
@@ -89,7 +85,47 @@ class ScratchCard(
         ): Long {
             if (matchCount < MATCH_THRESHOLD) return 0L
             val base = basePayouts[symbol] ?: 0L
-            return maxOf(2L, base * (matchCount - (MATCH_THRESHOLD - 1)))
+            return base * (matchCount - (MATCH_THRESHOLD - 1))
+        }
+
+        /**
+         * Closed-form RTP given [reel], [basePayouts], and the card
+         * geometry. For each symbol s, sums the binomial probability of
+         * exactly k matches across [cellCount] independent draws (with
+         * p_s = reel.count(s) / reel.size) times [multiplierFor]`(s, k)`,
+         * over k ∈ [threshold..cellCount]. Two symbols both reaching
+         * threshold is impossible when threshold > cellCount/2, so the
+         * per-symbol sums don't double-count.
+         *
+         * Pure function — used by tests as the RTP source of truth so any
+         * tuning that drifts the house edge fails CI loudly.
+         */
+        fun expectedRtp(
+            reel: List<SlotMachine.Symbol> = SlotMachine.DEFAULT_REEL,
+            basePayouts: Map<SlotMachine.Symbol, Long> = DEFAULT_BASE_PAYOUTS,
+            cellCount: Int = CELL_COUNT,
+            threshold: Int = MATCH_THRESHOLD
+        ): Double {
+            val total = reel.size.toDouble()
+            return SlotMachine.Symbol.entries.sumOf { symbol ->
+                val p = reel.count { it == symbol } / total
+                if (p == 0.0) 0.0 else {
+                    (threshold..cellCount).sumOf { k ->
+                        binomialPmf(cellCount, k, p) *
+                            multiplierFor(symbol, k, basePayouts).toDouble()
+                    }
+                }
+            }
+        }
+
+        private fun binomialPmf(n: Int, k: Int, p: Double): Double {
+            if (k < 0 || k > n) return 0.0
+            // C(n, k) computed iteratively to avoid factorial overflow on
+            // moderate n; n=9 here so this is overkill, but it keeps the
+            // helper safe to reuse for larger geometries.
+            var coeff = 1.0
+            for (i in 1..k) coeff = coeff * (n - i + 1) / i
+            return coeff * Math.pow(p, k.toDouble()) * Math.pow(1.0 - p, (n - k).toDouble())
         }
     }
 }

--- a/database/src/test/kotlin/database/economy/ScratchCardTest.kt
+++ b/database/src/test/kotlin/database/economy/ScratchCardTest.kt
@@ -23,33 +23,45 @@ class ScratchCardTest {
     @Test
     fun `nine-of-a-kind cherry pays base cherry times 5`() {
         // Reel of only cherries → all 9 cells will be cherries → match=9.
-        // multiplier = max(2, base 1 × (9 - (5-1))) = max(2, 5) = 5.
+        // multiplier = base 1 × (9 - (5-1)) = 5.
         val card = ScratchCard(reel = listOf(SlotMachine.Symbol.CHERRY))
         val result = card.scratch(Random(0))
         assertTrue(result.isWin)
         assertEquals(SlotMachine.Symbol.CHERRY, result.winningSymbol)
         assertEquals(9, result.matchCount)
-        assertEquals(5L, result.multiplier, "9 cherries × base 1 × (9-4) = 5 (above floor)")
+        assertEquals(5L, result.multiplier, "9 cherries × base 1 × (9-4) = 5")
     }
 
     @Test
-    fun `five-of-a-kind cherry hits the 2x floor instead of paying nothing`() {
-        // Boundary regression: with the unfloored formula `base × (k - 4)`,
-        // a 5-of-a-kind cherry produces multiplier = 1, which WagerHelper
-        // turns into net = 0 — a "win" that pays nothing. The 2× floor in
-        // scratch() corrects that to multiplier = 2 (net = stake).
-        val card = ScratchCard(reel = listOf(SlotMachine.Symbol.CHERRY))
-        // Single-symbol reel → all 9 cells cherries. We cap matchCount via
-        // the public surface by inspecting the result and re-checking the
-        // formula closed-form for k=5..9, since the live draw will give k=9.
-        val result = card.scratch(Random(0))
-        assertEquals(9, result.matchCount, "single-symbol reel always draws full match")
-        // Closed-form: prove the 5-of-a-kind cherry path is floored to 2.
-        val cherryBase = ScratchCard.DEFAULT_BASE_PAYOUTS.getValue(SlotMachine.Symbol.CHERRY)
-        val rawAtThreshold = cherryBase * (ScratchCard.MATCH_THRESHOLD - (ScratchCard.MATCH_THRESHOLD - 1))
-        val flooredAtThreshold = maxOf(2L, rawAtThreshold)
-        assertEquals(1L, rawAtThreshold, "without the floor, 5🍒 would pay 1× (= net 0, the bug)")
-        assertEquals(2L, flooredAtThreshold, "the floor raises 5🍒 to 2× (net = stake, real win)")
+    fun `five-of-a-kind cherry is a stake-refund push`() {
+        // 5🍒 sits at the boundary: multiplier = 1 → payout = stake →
+        // net = 0. Intentional design — cherry is the cheapest symbol and
+        // its lowest tier returns the stake rather than paying out. This
+        // is what keeps cherry distinct from lemon at k=5 (5🍋 = 2×) while
+        // respecting the closed-form RTP target.
+        assertEquals(1L, ScratchCard.multiplierFor(SlotMachine.Symbol.CHERRY, 5))
+        assertEquals(2L, ScratchCard.multiplierFor(SlotMachine.Symbol.LEMON, 5))
+    }
+
+    @Test
+    fun `at each match-count every symbol pays a distinct multiplier`() {
+        // Regression for the floor-collision bug: the prior `max(2, base × (k-4))`
+        // wrapper made 5🍒 and 5🍋 both pay 2×, so players couldn't tell
+        // them apart at the most common winning tier. The pure formula
+        // separates the four symbols at every k. (Cross-k collisions like
+        // 6🍒=2=5🍋 are fine — within a single card a player only sees one
+        // matchCount.)
+        for (k in ScratchCard.MATCH_THRESHOLD..ScratchCard.CELL_COUNT) {
+            val perSymbol = SlotMachine.Symbol.entries.associateWith {
+                ScratchCard.multiplierFor(it, k)
+            }
+            val unique = perSymbol.values.toSet()
+            assertEquals(
+                perSymbol.size,
+                unique.size,
+                "at $k matches, multipliers $perSymbol have collisions — symbols indistinguishable"
+            )
+        }
     }
 
     @Test
@@ -58,7 +70,7 @@ class ScratchCardTest {
         val result = card.scratch(Random(0))
         assertEquals(SlotMachine.Symbol.STAR, result.winningSymbol)
         assertEquals(9, result.matchCount)
-        // 9 stars × base 40 × (9-4) = 200 (well above floor)
+        // 9 stars × base 40 × (9-4) = 200.
         assertEquals(200L, result.multiplier)
     }
 
@@ -101,48 +113,30 @@ class ScratchCardTest {
     }
 
     @Test
-    fun `every winning outcome has multiplier greater than 1`() {
-        // Regression guard: the prior formula was `base × (k - 4)`, which
-        // collapsed to multiplier=1 for 5🍒 (base=1) — a "win" that nets 0
-        // in WagerHelper. The 2× floor in scratch() must keep every match
-        // count k=5..9 on every symbol strictly above 1× (so net > 0).
+    fun `multipliers are monotonic non-decreasing in k for every symbol`() {
+        // Soft guard against a future tuning that accidentally inverts the
+        // payout curve (e.g. negative base, or a typo that makes 6-of-a-kind
+        // pay less than 5). Strict monotonicity isn't required — what
+        // matters is that more matches never pays less.
         for (symbol in SlotMachine.Symbol.entries) {
-            val card = ScratchCard(reel = listOf(symbol))
-            val base = ScratchCard.DEFAULT_BASE_PAYOUTS.getValue(symbol)
+            var prev = Long.MIN_VALUE
             for (k in ScratchCard.MATCH_THRESHOLD..ScratchCard.CELL_COUNT) {
-                val raw = base * (k - (ScratchCard.MATCH_THRESHOLD - 1))
-                val floored = maxOf(2L, raw)
-                assertTrue(floored > 1L, "$symbol $k-of-a-kind floored multiplier $floored must be > 1")
+                val mult = ScratchCard.multiplierFor(symbol, k)
+                assertTrue(mult >= prev, "$symbol $k-of-a-kind multiplier $mult below k-1's $prev")
+                prev = mult
             }
-            // And confirm the wired-up card itself produces > 1 on a real draw.
-            val result = card.scratch(Random(0))
-            assertTrue(result.multiplier > 1L, "$symbol 9-of-a-kind via scratch() must produce multiplier > 1")
         }
     }
 
     @Test
-    fun `RTP across 200k cards lands in casino-style range`() {
-        // ScratchCard's RTP isn't a clean closed-form — it depends on the
-        // multinomial over the 4-symbol weighted reel × the multiplier
-        // table. With the 5-of-a-kind threshold on 9 cells, current bases
-        // (1/2/8/40), and the 2× floor on 5🍒, the closed-form math lands
-        // ~1.04 (slightly above break-even — the floor on the otherwise
-        // buggy boundary case adds ~P(5🍒) ≈ +0.17 on top of the unfloored
-        // 0.875). The bound below catches gross misconfiguration: payout-
-        // zero would undershoot to 0, removing the floor would dip back to
-        // ~0.875, and a back-to-3-of-a-kind change would overshoot 1.7×.
-        val card = ScratchCard()
-        val rng = Random(2026)
-        val stake = 1_000L
-        val n = 200_000
-        var totalWagered = 0L
-        var totalReturned = 0L
-        repeat(n) {
-            val result = card.scratch(rng)
-            totalWagered += stake
-            totalReturned += result.multiplier * stake
-        }
-        val rtp = totalReturned.toDouble() / totalWagered.toDouble()
-        assertTrue(rtp in 0.95..1.10, "RTP $rtp outside expected casino range")
+    fun `expected RTP lands in target band`() {
+        // Closed-form RTP via the binomial-PMF helper: deterministic, no
+        // Monte Carlo. With current bases (1/2/8/40) on the default reel
+        // the math lands ~0.875 — a 12.5% house edge. The lower bound
+        // catches accidental payout-zero / threshold-too-high; the upper
+        // bound is the real guard, ensuring tuning changes can't push RTP
+        // back over break-even and have users always winning.
+        val rtp = ScratchCard.expectedRtp()
+        assertTrue(rtp in 0.85..0.92, "RTP $rtp outside target band 0.85..0.92")
     }
 }


### PR DESCRIPTION
## Summary

Scratch card payouts looked the same for cherries and lemons — the 2× floor added in #308 collided cherry's payout with lemon's at 5-of-a-kind (the most common winning tier), since `max(2, 1×1)` and `max(2, 2×1)` both equal 2. Players couldn't tell the symbols apart by payout where it mattered most.

**The fix:** drop the floor. `multiplierFor` returns the clean closed-form `base × (k - 4)`. `5🍒 = 1×` is now an intentional **stake-refund push** (net = 0), distinct from `5🍋 = 2×` (real win). At every match-count, the four symbols pay distinct multipliers.

**Why not bump cherry's base instead?** Mathematically incompatible with house-has-an-edge: cherry's reel weight (0.4) means any cherry base ≥ 2 contributes ≥ 0.79 to RTP on its own; adding lemon base ≥ 3 pushes RTP > 1.18 before bell/star are even counted. Cherry must stay base 1 to keep RTP under break-even.

**RTP becomes a code-checked invariant.** New `ScratchCard.expectedRtp()` helper sums binomial PMFs × multipliers in closed form. The unit test asserts RTP lands in `0.85..0.92` — any future tuning that drifts the house edge fails CI loudly. The 200k Monte Carlo RTP test is replaced by this deterministic check.

### New payout table

| Symbol | k=5 | k=6 | k=7 | k=8 | k=9 |
|--------|-----|-----|-----|-----|-----|
| 🍒 (base 1) | 1× (push) | 2× | 3× | 4× | 5× |
| 🍋 (base 2) | 2× | 4× | 6× | 8× | 10× |
| 🔔 (base 8) | 8× | 16× | 24× | 32× | 40× |
| ⭐ (base 40) | 40× | 80× | 120× | 160× | 200× |

RTP ≈ 0.875 (12.5% house edge), pinned by `expectedRtp()` test.

## Test plan

- [x] `./gradlew :database:test --tests 'database.economy.ScratchCardTest'` — all 10 pass
- [x] `./gradlew :web:compileKotlin :web:test` — web controller picks up new payout values via `multiplierFor` (no hardcoded duplication, single source of truth)
- [ ] Manual play: scratch a few cards in Discord, confirm 5🍒 returns stake (net 0) while 5🍋 doubles it. *(If the existing message template reads awkwardly for `Win(net=0)`, follow up by adding a "push" branch in the embed builder — out of scope for this fix.)*

https://claude.ai/code/session_01Ggf9S5oLV7E2GFkXxAULVe

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ggf9S5oLV7E2GFkXxAULVe)_