### PR TITLE
fix(highlow): anchor-aware payout multiplier closes the web exploit

### DIFF
--- a/database/src/main/kotlin/database/economy/Highlow.kt
+++ b/database/src/main/kotlin/database/economy/Highlow.kt
@@ -7,14 +7,19 @@ import kotlin.random.Random
  * card draws and a comparison against the caller's direction.
  *
  * Mechanic
- *   Server draws an anchor card (1..13). User commits HIGHER or LOWER.
- *   Server draws the next card. Win condition:
+ *   Server draws an anchor card (2..deckSize-1; extremes are clipped so
+ *   every dealt hand is winnable in both directions). User commits
+ *   HIGHER or LOWER. Server draws the next card from the full 1..deckSize
+ *   range. Win condition:
  *     - HIGHER → next > anchor
  *     - LOWER  → next < anchor
  *     - tie (next == anchor) → lose
- *   Payout is flat 2× on win. Average RTP ≈ 12/13 ≈ 0.923
- *   (~7.7% house edge from the tie-loses rule). Sits between
- *   /coinflip (no edge) and /slots (~11% edge).
+ *   Payout is anchor- and direction-aware: a winning bet pays
+ *   `(deckSize - 1) / winningOutcomes` × stake. Average RTP per hand is
+ *   `(deckSize - 1) / deckSize` ≈ 12/13 ≈ 0.923 regardless of which
+ *   direction the player picks, so a player who can see the anchor (web
+ *   flow) cannot exploit extreme anchors for a positive edge. Sits
+ *   between /coinflip (no edge) and /slots (~11% edge).
  *
  * Two flows live here:
  *   - [play] — bundled draw used by Discord. Anchor + next come out
@@ -26,8 +31,7 @@ import kotlin.random.Random
  *     player can't reroll a fresh anchor by refreshing the page.
  */
 class Highlow(
-    private val deckSize: Int = DEFAULT_DECK_SIZE,
-    private val multiplier: Long = DEFAULT_MULTIPLIER
+    private val deckSize: Int = DEFAULT_DECK_SIZE
 ) {
 
     enum class Direction(val display: String) {
@@ -39,9 +43,9 @@ class Highlow(
         val anchor: Int,
         val next: Int,
         val direction: Direction,
-        val multiplier: Long
+        val multiplier: Double
     ) {
-        val isWin: Boolean get() = multiplier > 0L
+        val isWin: Boolean get() = multiplier > 0.0
     }
 
     /** Bundled draw — anchor + next in a single call. Discord uses this. */
@@ -50,8 +54,14 @@ class Highlow(
         return resolve(anchor, direction, random)
     }
 
-    /** Standalone anchor draw for the split web flow. */
-    fun dealAnchor(random: Random): Int = random.nextInt(1, deckSize + 1)
+    /**
+     * Standalone anchor draw for the split web flow. Capped to
+     * 2..deckSize-1 so both HIGHER and LOWER are winnable for every
+     * dealt anchor (the formula in [payoutMultiplier] would yield a 0
+     * payout for an impossible direction or a 1× refund for the trivial
+     * one on the extremes, which is poor UX).
+     */
+    fun dealAnchor(random: Random): Int = random.nextInt(2, deckSize)
 
     /**
      * Given an anchor that's already been revealed, draw the next card
@@ -69,8 +79,26 @@ class Highlow(
             anchor = anchor,
             next = next,
             direction = direction,
-            multiplier = if (won) multiplier else 0L
+            multiplier = if (won) payoutMultiplier(anchor, direction) else 0.0
         )
+    }
+
+    /**
+     * Payout multiplier for a winning bet on [anchor] in [direction].
+     * Equal to `(deckSize - 1) / winningOutcomes`, which holds RTP at
+     * `(deckSize - 1) / deckSize` for every (anchor, direction) pair.
+     * Returns `0.0` for an impossible direction (no winning outcomes),
+     * which happens only on extreme anchors that [dealAnchor] does not
+     * produce — kept defensive in case a stale session-stored anchor
+     * reaches [resolve].
+     */
+    fun payoutMultiplier(anchor: Int, direction: Direction): Double {
+        val winningOutcomes = when (direction) {
+            Direction.HIGHER -> deckSize - anchor
+            Direction.LOWER -> anchor - 1
+        }
+        if (winningOutcomes <= 0) return 0.0
+        return (deckSize - 1).toDouble() / winningOutcomes
     }
 
     val deckSizeValue: Int get() = deckSize
@@ -79,8 +107,5 @@ class Highlow(
         const val MIN_STAKE: Long = 10L
         const val MAX_STAKE: Long = 500L
         const val DEFAULT_DECK_SIZE: Int = 13
-        // 2× on win; with tie-loses the average win probability is ≈ 6/13,
-        // so RTP ≈ 12/13 ≈ 0.923.
-        const val DEFAULT_MULTIPLIER: Long = 2L
     }
 }

--- a/database/src/main/kotlin/database/service/HighlowService.kt
+++ b/database/src/main/kotlin/database/service/HighlowService.kt
@@ -41,6 +41,7 @@ class HighlowService(
             val anchor: Int,
             val next: Int,
             val direction: Highlow.Direction,
+            val multiplier: Double,
             val newBalance: Long,
             val jackpotPayout: Long = 0L,
             val soldTobyCoins: Long = 0L,
@@ -66,6 +67,14 @@ class HighlowService(
 
     /** Draw a fresh anchor without committing any state. The web flow uses this on page load. */
     fun dealAnchor(): Int = highlow.dealAnchor(random)
+
+    /**
+     * Per-anchor payout multiplier for [direction]. Surfaced so the web
+     * page and the Discord embed can label each direction button with
+     * what it actually pays before the player commits.
+     */
+    fun payoutMultiplier(anchor: Int, direction: Highlow.Direction): Double =
+        highlow.payoutMultiplier(anchor, direction)
 
     /** Bundled flow: server draws both cards inside this call. Discord uses this. */
     fun play(discordId: Long, guildId: Long, stake: Long, direction: Highlow.Direction): PlayOutcome =
@@ -138,6 +147,7 @@ class HighlowService(
                 anchor = hand.anchor,
                 next = hand.next,
                 direction = hand.direction,
+                multiplier = hand.multiplier,
                 newBalance = r.newBalance + jackpot,
                 jackpotPayout = jackpot,
                 soldTobyCoins = soldCoins,

--- a/database/src/main/kotlin/database/service/WagerHelper.kt
+++ b/database/src/main/kotlin/database/service/WagerHelper.kt
@@ -75,4 +75,25 @@ internal object WagerHelper {
         userService.updateUser(user)
         return WagerResolution(payout = payout, net = net, newBalance = user.socialCredit ?: 0L)
     }
+
+    /**
+     * Fractional-multiplier variant for games whose payout schedule
+     * isn't a clean integer (currently only [database.economy.Highlow]'s
+     * anchor-aware payouts). payout truncates toward zero so any
+     * remainder stays with the house, matching the Long overload's
+     * implicit semantics.
+     */
+    fun applyMultiplier(
+        userService: UserService,
+        user: UserDto,
+        balance: Long,
+        stake: Long,
+        multiplier: Double
+    ): WagerResolution {
+        val payout = (stake * multiplier).toLong()
+        val net = payout - stake
+        user.socialCredit = balance + net
+        userService.updateUser(user)
+        return WagerResolution(payout = payout, net = net, newBalance = user.socialCredit ?: 0L)
+    }
 }

--- a/database/src/test/kotlin/database/economy/HighlowTest.kt
+++ b/database/src/test/kotlin/database/economy/HighlowTest.kt
@@ -9,25 +9,28 @@ import kotlin.random.Random
 class HighlowTest {
 
     @Test
-    fun `play returns cards in 1 to deckSize`() {
+    fun `play returns anchor in 2 to deckSize-1 and next in 1 to deckSize`() {
         val highlow = Highlow()
         val rng = Random(42)
         repeat(1_000) {
             val hand = highlow.play(Highlow.Direction.HIGHER, rng)
-            assertTrue(hand.anchor in 1..highlow.deckSizeValue)
+            assertTrue(hand.anchor in 2..(highlow.deckSizeValue - 1)) {
+                "anchor ${hand.anchor} outside 2..${highlow.deckSizeValue - 1}"
+            }
             assertTrue(hand.next in 1..highlow.deckSizeValue)
         }
     }
 
     @Test
-    fun `HIGHER wins when next greater than anchor`() {
+    fun `HIGHER wins when next greater than anchor and pays the anchor-aware multiplier`() {
         // Force a deterministic sequence: anchor=5, next=10
         val rng = mockSequenceRng(intArrayOf(5, 10))
         val hand = Highlow(deckSize = 13).play(Highlow.Direction.HIGHER, rng)
         assertEquals(5, hand.anchor)
         assertEquals(10, hand.next)
         assertTrue(hand.isWin)
-        assertEquals(2L, hand.multiplier)
+        // anchor=5, HIGHER → winning outcomes = 13-5 = 8, multiplier = 12/8 = 1.5
+        assertEquals(1.5, hand.multiplier, 1e-9)
     }
 
     @Test
@@ -37,14 +40,16 @@ class HighlowTest {
         assertEquals(7, hand.anchor)
         assertEquals(7, hand.next)
         assertFalse(hand.isWin, "tie loses")
-        assertEquals(0L, hand.multiplier)
+        assertEquals(0.0, hand.multiplier, 1e-9)
     }
 
     @Test
-    fun `LOWER wins when next less than anchor`() {
+    fun `LOWER wins when next less than anchor and pays the anchor-aware multiplier`() {
         val rng = mockSequenceRng(intArrayOf(10, 3))
         val hand = Highlow(deckSize = 13).play(Highlow.Direction.LOWER, rng)
         assertTrue(hand.isWin)
+        // anchor=10, LOWER → winning outcomes = 10-1 = 9, multiplier = 12/9 ≈ 1.333…
+        assertEquals(12.0 / 9.0, hand.multiplier, 1e-9)
     }
 
     @Test
@@ -55,12 +60,12 @@ class HighlowTest {
     }
 
     @Test
-    fun `dealAnchor returns a card in 1 to deckSize`() {
+    fun `dealAnchor never returns 1 or deckSize`() {
         val highlow = Highlow(deckSize = 13)
         val rng = Random(2026)
-        repeat(1_000) {
+        repeat(10_000) {
             val a = highlow.dealAnchor(rng)
-            assertTrue(a in 1..13)
+            assertTrue(a in 2..12) { "dealt anchor $a outside 2..12" }
         }
     }
 
@@ -82,7 +87,7 @@ class HighlowTest {
         val hand = Highlow(deckSize = 13).resolve(anchor, Highlow.Direction.LOWER, rng)
         assertEquals(9, hand.next)
         assertFalse(hand.isWin)
-        assertEquals(0L, hand.multiplier)
+        assertEquals(0.0, hand.multiplier, 1e-9)
     }
 
     @Test
@@ -97,35 +102,98 @@ class HighlowTest {
     }
 
     @Test
-    fun `winning multiplier is greater than 1`() {
-        // WagerHelper computes net = multiplier × stake − stake, so a payout
-        // of 1× nets zero — a "win" that pays nothing. Pin the default win
-        // multiplier strictly above 1× so future tuning can't introduce that
-        // boundary bug.
-        assertTrue(
-            Highlow.DEFAULT_MULTIPLIER > 1L,
-            "Highlow win multiplier ${Highlow.DEFAULT_MULTIPLIER} must be > 1 so a correct call nets > 0"
-        )
+    fun `payoutMultiplier is greater than 1 for every dealt anchor and direction`() {
+        // dealAnchor only produces anchors in 2..deckSize-1, and for those
+        // both HIGHER and LOWER have at least one winning outcome short of
+        // the trivial sweep. WagerHelper computes net = multiplier × stake
+        // − stake, so any multiplier ≤ 1 yields a "win" that nets ≤ 0.
+        // Pin the schedule strictly above 1× across the dealt range.
+        val highlow = Highlow()
+        val deckSize = highlow.deckSizeValue
+        for (anchor in 2..(deckSize - 1)) {
+            for (direction in Highlow.Direction.entries) {
+                val m = highlow.payoutMultiplier(anchor, direction)
+                assertTrue(m > 1.0) {
+                    "anchor=$anchor direction=$direction multiplier=$m must be > 1.0"
+                }
+            }
+        }
     }
 
     @Test
-    fun `RTP across 200k hands is within 5pp of 12 over 13`() {
-        // With tie-loses and a 2x payout, expected RTP is 12/13 ≈ 0.923.
-        val highlow = Highlow(deckSize = 13, multiplier = 2L)
+    fun `payoutMultiplier yields RTP of (deckSize-1) over deckSize for every (anchor, direction)`() {
+        // Exact algebraic check: payout × winProb = (deckSize-1) / deckSize.
+        val highlow = Highlow()
+        val deckSize = highlow.deckSizeValue
+        val expected = (deckSize - 1).toDouble() / deckSize
+        for (anchor in 2..(deckSize - 1)) {
+            for (direction in Highlow.Direction.entries) {
+                val winningOutcomes = when (direction) {
+                    Highlow.Direction.HIGHER -> deckSize - anchor
+                    Highlow.Direction.LOWER -> anchor - 1
+                }
+                val winProb = winningOutcomes.toDouble() / deckSize
+                val rtp = highlow.payoutMultiplier(anchor, direction) * winProb
+                assertEquals(expected, rtp, 1e-9) {
+                    "anchor=$anchor direction=$direction expected RTP $expected but saw $rtp"
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `RTP across 200k blind hands is within 5pp of 12 over 13`() {
+        // Bundled (Discord) flow: player picks direction blind. Per-hand
+        // RTP is constant under the new schedule, so the long-run RTP
+        // hugs 12/13 ≈ 0.923 just like before.
+        val highlow = Highlow(deckSize = 13)
         val rng = Random(2026)
         val stake = 1_000L
         val n = 200_000
         var totalWagered = 0L
-        var totalReturned = 0L
+        var totalReturned = 0.0
         repeat(n) {
             val direction = if (rng.nextBoolean()) Highlow.Direction.HIGHER else Highlow.Direction.LOWER
             val hand = highlow.play(direction, rng)
             totalWagered += stake
             totalReturned += hand.multiplier * stake
         }
-        val rtp = totalReturned.toDouble() / totalWagered.toDouble()
+        val rtp = totalReturned / totalWagered.toDouble()
         val expected = 12.0 / 13.0
         assertTrue(rtp in (expected - 0.05)..(expected + 0.05), "expected RTP near $expected (±0.05) but saw $rtp")
+    }
+
+    @Test
+    fun `RTP across 200k optimal-direction hands is within 5pp of 12 over 13`() {
+        // Web flow exploit guard: the player can see the anchor first
+        // and pick whichever direction has more winning cards. With a
+        // flat 2× multiplier this used to push RTP to ~1.42 (player
+        // edge); under the anchor-aware schedule both directions share
+        // the same EV, so optimal play also lands at 12/13.
+        val highlow = Highlow(deckSize = 13)
+        val rng = Random(2026)
+        val stake = 1_000L
+        val n = 200_000
+        var totalWagered = 0L
+        var totalReturned = 0.0
+        repeat(n) {
+            val anchor = highlow.dealAnchor(rng)
+            // "Optimal" = whichever direction has more winning outcomes.
+            val direction = if ((highlow.deckSizeValue - anchor) >= (anchor - 1)) {
+                Highlow.Direction.HIGHER
+            } else {
+                Highlow.Direction.LOWER
+            }
+            val hand = highlow.resolve(anchor, direction, rng)
+            totalWagered += stake
+            totalReturned += hand.multiplier * stake
+        }
+        val rtp = totalReturned / totalWagered.toDouble()
+        val expected = 12.0 / 13.0
+        assertTrue(
+            rtp in (expected - 0.05)..(expected + 0.05),
+            "optimal-play RTP must stay near $expected (±0.05) but saw $rtp — house edge regressed"
+        )
     }
 
     /**

--- a/database/src/test/kotlin/database/service/HighlowServiceTest.kt
+++ b/database/src/test/kotlin/database/service/HighlowServiceTest.kt
@@ -44,7 +44,7 @@ class HighlowServiceTest {
         val user = userWithBalance(1_000L)
         every { userService.getUserByIdForUpdate(discordId, guildId) } returns user
         every { highlow.play(Highlow.Direction.HIGHER, any()) } returns Highlow.Hand(
-            anchor = 5, next = 10, direction = Highlow.Direction.HIGHER, multiplier = 2L
+            anchor = 7, next = 10, direction = Highlow.Direction.HIGHER, multiplier = 2.0
         )
         val captured = slot<UserDto>()
         every { userService.updateUser(capture(captured)) } returns user
@@ -55,8 +55,9 @@ class HighlowServiceTest {
         assertEquals(100L, win.stake)
         assertEquals(200L, win.payout)
         assertEquals(100L, win.net)
+        assertEquals(2.0, win.multiplier, 1e-9)
         assertEquals(1_100L, win.newBalance)
-        assertEquals(5, win.anchor)
+        assertEquals(7, win.anchor)
         assertEquals(10, win.next)
         assertEquals(1_100L, captured.captured.socialCredit)
     }
@@ -66,7 +67,7 @@ class HighlowServiceTest {
         val user = userWithBalance(500L)
         every { userService.getUserByIdForUpdate(discordId, guildId) } returns user
         every { highlow.play(Highlow.Direction.HIGHER, any()) } returns Highlow.Hand(
-            anchor = 7, next = 7, direction = Highlow.Direction.HIGHER, multiplier = 0L
+            anchor = 7, next = 7, direction = Highlow.Direction.HIGHER, multiplier = 0.0
         )
         every { userService.updateUser(any()) } returns user
 
@@ -112,7 +113,7 @@ class HighlowServiceTest {
         val user = userWithBalance(1_000L)
         every { userService.getUserByIdForUpdate(discordId, guildId) } returns user
         every { highlow.resolve(anchor = 7, direction = Highlow.Direction.HIGHER, random = any()) } returns
-            Highlow.Hand(anchor = 7, next = 12, direction = Highlow.Direction.HIGHER, multiplier = 2L)
+            Highlow.Hand(anchor = 7, next = 12, direction = Highlow.Direction.HIGHER, multiplier = 2.0)
         every { userService.updateUser(any()) } returns user
 
         val outcome = service.play(
@@ -144,7 +145,7 @@ class HighlowServiceTest {
         val user = userWithBalance(500L)
         every { userService.getUserByIdForUpdate(discordId, guildId) } returns user
         every { highlow.play(Highlow.Direction.HIGHER, any()) } returns Highlow.Hand(
-            anchor = 7, next = 7, direction = Highlow.Direction.HIGHER, multiplier = 0L
+            anchor = 7, next = 7, direction = Highlow.Direction.HIGHER, multiplier = 0.0
         )
         every { userService.updateUser(any()) } returns user
 

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/HighlowCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/HighlowCommand.kt
@@ -54,17 +54,19 @@ class HighlowCommand @Autowired constructor(
         }
 
         val anchor = highlowService.dealAnchor()
+        val higherMultiplier = highlowService.payoutMultiplier(anchor, Highlow.Direction.HIGHER)
+        val lowerMultiplier = highlowService.payoutMultiplier(anchor, Highlow.Direction.LOWER)
         val userId = requestingUserDto.discordId
         val higher = Button.primary(
             HighlowEmbeds.directionButtonId(Highlow.Direction.HIGHER, anchor, stake, userId),
-            Highlow.Direction.HIGHER.display
+            "${Highlow.Direction.HIGHER.display} (${HighlowEmbeds.multiplierLabel(higherMultiplier)})"
         )
         val lower = Button.primary(
             HighlowEmbeds.directionButtonId(Highlow.Direction.LOWER, anchor, stake, userId),
-            Highlow.Direction.LOWER.display
+            "${Highlow.Direction.LOWER.display} (${HighlowEmbeds.multiplierLabel(lowerMultiplier)})"
         )
 
-        event.hook.sendMessageEmbeds(HighlowEmbeds.anchorEmbed(anchor, stake))
+        event.hook.sendMessageEmbeds(HighlowEmbeds.anchorEmbed(anchor, stake, higherMultiplier, lowerMultiplier))
             .addComponents(ActionRow.of(higher, lower))
             .queue()
     }

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/HighlowEmbeds.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/HighlowEmbeds.kt
@@ -30,6 +30,9 @@ internal object HighlowEmbeds {
         else -> n.toString()
     }
 
+    /** "1.50×"-style label for direction buttons / embed copy. */
+    fun multiplierLabel(multiplier: Double): String = "%.2f×".format(multiplier)
+
     fun directionButtonId(direction: Highlow.Direction, anchor: Int, stake: Long, userId: Long): String =
         listOf(BUTTON_NAME, direction.name, anchor.toString(), stake.toString(), userId.toString())
             .joinToString(BUTTON_DELIM)
@@ -51,16 +54,24 @@ internal object HighlowEmbeds {
         return ParsedButtonId(direction, anchor, stake, userId)
     }
 
-    fun anchorEmbed(anchor: Int, stake: Long): MessageEmbed = EmbedBuilder()
-        .setTitle("🃏 Anchor: ${cardLabel(anchor)}")
-        .setDescription("Stake **$stake credits**. Will the next card be **higher** or **lower**?")
-        .setColor(ANCHOR_COLOR)
-        .build()
+    fun anchorEmbed(anchor: Int, stake: Long, higherMultiplier: Double, lowerMultiplier: Double): MessageEmbed =
+        EmbedBuilder()
+            .setTitle("🃏 Anchor: ${cardLabel(anchor)}")
+            .setDescription(
+                "Stake **$stake credits**. Will the next card be **higher** or **lower**?\n" +
+                    "Higher pays **${multiplierLabel(higherMultiplier)}**, " +
+                    "lower pays **${multiplierLabel(lowerMultiplier)}**."
+            )
+            .setColor(ANCHOR_COLOR)
+            .build()
 
     fun outcomeEmbed(outcome: PlayOutcome): MessageEmbed = when (outcome) {
         is PlayOutcome.Win -> EmbedBuilder()
             .setTitle("🃏 ${cardLabel(outcome.anchor)} → ${cardLabel(outcome.next)}")
-            .setDescription("You called **${outcome.direction.display}** and won **+${outcome.net} credits**.")
+            .setDescription(
+                "You called **${outcome.direction.display}** at " +
+                    "**${multiplierLabel(outcome.multiplier)}** and won **+${outcome.net} credits**."
+            )
             .addField("New balance", "${outcome.newBalance} credits", true)
             .setColor(WIN_COLOR)
             .build()

--- a/discord-bot/src/test/kotlin/bot/toby/button/buttons/HighlowButtonTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/button/buttons/HighlowButtonTest.kt
@@ -72,6 +72,7 @@ class HighlowButtonTest : ButtonTest {
             anchor = anchor,
             next = 12,
             direction = Highlow.Direction.HIGHER,
+            multiplier = 2.0,
             newBalance = 1_050L
         )
 

--- a/web/src/main/kotlin/web/controller/HighlowController.kt
+++ b/web/src/main/kotlin/web/controller/HighlowController.kt
@@ -72,9 +72,14 @@ class HighlowController(
         model.addAttribute("marketPrice", marketPrice)
         model.addAttribute("minStake", Highlow.MIN_STAKE)
         model.addAttribute("maxStake", Highlow.MAX_STAKE)
-        model.addAttribute("multiplier", Highlow.DEFAULT_MULTIPLIER)
         model.addAttribute("anchor", activeAnchor)
         model.addAttribute("anchorLabel", activeAnchor?.let { cardLabel(it) } ?: "?")
+        model.addAttribute("higherMultiplier", activeAnchor?.let {
+            highlowService.payoutMultiplier(it, Highlow.Direction.HIGHER)
+        })
+        model.addAttribute("lowerMultiplier", activeAnchor?.let {
+            highlowService.payoutMultiplier(it, Highlow.Direction.LOWER)
+        })
         model.addAttribute("activeStake", activeStake)
         model.addAttribute("jackpotPool", jackpotService.getPool(guildId))
         model.addAttribute("username", user.displayName())
@@ -105,7 +110,15 @@ class HighlowController(
         storeAutoTopUp(session, guildId, request.autoTopUp)
         storeAnchor(session, guildId, anchor)
 
-        return ResponseEntity.ok(StartResponse(ok = true, anchor = anchor, anchorLabel = cardLabel(anchor)))
+        return ResponseEntity.ok(
+            StartResponse(
+                ok = true,
+                anchor = anchor,
+                anchorLabel = cardLabel(anchor),
+                higherMultiplier = highlowService.payoutMultiplier(anchor, Highlow.Direction.HIGHER),
+                lowerMultiplier = highlowService.payoutMultiplier(anchor, Highlow.Direction.LOWER)
+            )
+        )
     }
 
     @PostMapping("/play")
@@ -153,6 +166,7 @@ class HighlowController(
                     direction = outcome.direction.name,
                     net = outcome.net,
                     payout = outcome.payout,
+                    multiplier = outcome.multiplier,
                     newBalance = outcome.newBalance,
                     win = true,
                     jackpotPayout = outcome.jackpotPayout.takeIf { it > 0L },
@@ -247,7 +261,9 @@ data class StartResponse(
     val ok: Boolean,
     val error: String? = null,
     val anchor: Int? = null,
-    val anchorLabel: String? = null
+    val anchorLabel: String? = null,
+    val higherMultiplier: Double? = null,
+    val lowerMultiplier: Double? = null
 )
 
 data class PlayRequest(val direction: String = "")
@@ -260,6 +276,7 @@ data class PlayResponse(
     val direction: String? = null,
     val net: Long? = null,
     val payout: Long? = null,
+    val multiplier: Double? = null,
     val newBalance: Long? = null,
     val win: Boolean? = null,
     val jackpotPayout: Long? = null,

--- a/web/src/main/resources/static/js/highlow.js
+++ b/web/src/main/resources/static/js/highlow.js
@@ -9,6 +9,15 @@ function highlowCardLabel(n) {
     }
 }
 
+// Format a payout multiplier for the UI (e.g. 1.50× ). Returns an
+// empty string for non-finite or non-positive values so a missing
+// multiplier just collapses the label rather than rendering "0.00×".
+function highlowFormatMultiplier(m) {
+    const num = Number(m);
+    if (!Number.isFinite(num) || num <= 0) return '';
+    return num.toFixed(2) + '×';
+}
+
 // Pure-DOM render for a /play response. Hoisted out of the IIFE so the
 // jest test in `highlow.test.js` can drive it without booting the page.
 function renderHighlowResult(resultEl, body) {
@@ -21,9 +30,12 @@ function renderHighlowResult(resultEl, body) {
         : '';
     if (body.win) {
         resultEl.classList.add('highlow-result-win');
+        const multSuffix = highlowFormatMultiplier(body.multiplier);
         const winLine = '<strong>' + highlowCardLabel(body.next) + '</strong> ' +
             (body.next > body.anchor ? '>' : '<') + ' <strong>' + highlowCardLabel(body.anchor) +
-            '</strong> &middot; you called ' + dirLabel + ' &middot; <strong>+' + body.net + ' credits</strong>';
+            '</strong> &middot; you called ' + dirLabel +
+            (multSuffix ? ' (' + multSuffix + ')' : '') +
+            ' &middot; <strong>+' + body.net + ' credits</strong>';
         const withJackpot = (typeof window !== 'undefined' && window.TobyJackpot)
             ? window.TobyJackpot.renderWinHtml(resultEl, body, 'highlow-result-jackpot', winLine)
             : winLine;
@@ -74,9 +86,20 @@ function renderHighlowResult(resultEl, body) {
     const directionPicker = document.getElementById('highlow-direction-picker');
     const higherBtn = document.getElementById('highlow-call-higher');
     const lowerBtn = document.getElementById('highlow-call-lower');
+    const higherMultEl = document.getElementById('highlow-call-higher-mult');
+    const lowerMultEl = document.getElementById('highlow-call-lower-mult');
 
     if (!form || !dealBtn || !stakeInput || !anchorFace || !nextFace) return;
     if (!directionPicker || !higherBtn || !lowerBtn) return;
+
+    function setMultiplierLabels(higher, lower) {
+        if (higherMultEl) higherMultEl.textContent = highlowFormatMultiplier(higher);
+        if (lowerMultEl) lowerMultEl.textContent = highlowFormatMultiplier(lower);
+    }
+
+    function clearMultiplierLabels() {
+        setMultiplierLabels(null, null);
+    }
 
     const topUp = (window.TobyTopUp && dealTobyBtn) ? window.TobyTopUp.init({
         form: form,
@@ -111,9 +134,10 @@ function renderHighlowResult(resultEl, body) {
         if (anchorCard) delete anchorCard.dataset.value;
         nextFace.textContent = '?';
         if (nextCard) delete nextCard.dataset.value;
+        clearMultiplierLabels();
     }
 
-    function showCallMode(anchorValue) {
+    function showCallMode(anchorValue, higherMult, lowerMult) {
         if (typeof anchorValue === 'number') {
             anchorFace.textContent = cardLabel(anchorValue);
             if (anchorCard) anchorCard.dataset.value = String(anchorValue);
@@ -124,6 +148,7 @@ function renderHighlowResult(resultEl, body) {
         directionPicker.hidden = false;
         higherBtn.disabled = false;
         lowerBtn.disabled = false;
+        setMultiplierLabels(higherMult, lowerMult);
         if (resultEl) resultEl.hidden = true;
     }
 
@@ -185,7 +210,7 @@ function renderHighlowResult(resultEl, body) {
         })
             .then(function (body) {
                 if (body && body.ok && typeof body.anchor === 'number') {
-                    showCallMode(body.anchor);
+                    showCallMode(body.anchor, body.higherMultiplier, body.lowerMultiplier);
                 } else {
                     dealBtn.disabled = false;
                     if (dealTobyBtn) dealTobyBtn.disabled = false;
@@ -256,10 +281,12 @@ function renderHighlowResult(resultEl, body) {
     // jump straight to call mode so the player can finish their bet.
     const preloadedAnchor = parseInt(main.dataset.activeAnchor || '', 10);
     if (Number.isFinite(preloadedAnchor) && preloadedAnchor > 0) {
-        showCallMode(preloadedAnchor);
+        const preloadedHigher = parseFloat(main.dataset.higherMultiplier || '');
+        const preloadedLower = parseFloat(main.dataset.lowerMultiplier || '');
+        showCallMode(preloadedAnchor, preloadedHigher, preloadedLower);
     }
 })();
 
 if (typeof module !== 'undefined' && module.exports) {
-    module.exports = { renderHighlowResult, highlowCardLabel };
+    module.exports = { renderHighlowResult, highlowCardLabel, highlowFormatMultiplier };
 }

--- a/web/src/main/resources/templates/highlow.html
+++ b/web/src/main/resources/templates/highlow.html
@@ -6,13 +6,13 @@
 <div th:replace="~{fragments/navbar :: navbar}"></div>
 
 <main id="main" class="container"
-      th:attr="data-guild-id=${guildId}, data-toby-coins=${tobyCoins}, data-market-price=${marketPrice}, data-active-anchor=${anchor}, data-active-stake=${activeStake}">
+      th:attr="data-guild-id=${guildId}, data-toby-coins=${tobyCoins}, data-market-price=${marketPrice}, data-active-anchor=${anchor}, data-active-stake=${activeStake}, data-higher-multiplier=${higherMultiplier}, data-lower-multiplier=${lowerMultiplier}">
 
     <div class="highlow-header">
         <a class="back-link" th:href="@{/casino/guilds}">&larr; All casino servers</a>
         <h1 th:text="'🃏 High-Low • ' + ${guildName}">🃏 High-Low</h1>
         <p class="muted">Lock your stake first — the anchor is dealt only after you commit.
-            Match → <strong th:text="${multiplier} + '×'">2×</strong> stake. Tie loses.
+            Each direction's payout depends on the anchor; safer calls pay less. Tie loses.
             Bet <span th:text="${minStake}">10</span>-<span th:text="${maxStake}">500</span> credits.</p>
     </div>
 
@@ -53,9 +53,15 @@
         <div class="highlow-direction-picker" id="highlow-direction-picker" hidden
              role="group" aria-label="Pick a direction">
             <button type="button" class="btn-primary highlow-direction-btn"
-                    id="highlow-call-higher" data-direction="HIGHER">▲ Higher</button>
+                    id="highlow-call-higher" data-direction="HIGHER">
+                <span class="highlow-direction-label">▲ Higher</span>
+                <span class="highlow-direction-mult" id="highlow-call-higher-mult"></span>
+            </button>
             <button type="button" class="btn-primary highlow-direction-btn"
-                    id="highlow-call-lower" data-direction="LOWER">▼ Lower</button>
+                    id="highlow-call-lower" data-direction="LOWER">
+                <span class="highlow-direction-label">▼ Lower</span>
+                <span class="highlow-direction-mult" id="highlow-call-lower-mult"></span>
+            </button>
         </div>
 
         <div class="highlow-balance">
@@ -73,10 +79,10 @@
         <ul>
             <li>Set your stake and click <strong>Lock stake &amp; deal</strong>; the anchor is revealed only after.</li>
             <li>Once the anchor is up, call higher or lower to draw the next card.</li>
-            <li>Direction matches → <strong th:text="${multiplier} + '×'">2×</strong> stake.</li>
+            <li>Each direction's payout multiplier is shown on its button — safer calls pay less, riskier calls pay more.</li>
             <li>Wrong direction or tie (anchor == next) → lose stake.</li>
             <li>The locked stake + anchor sticks to your session, so refreshing won't reroll the round.</li>
-            <li>Average RTP ≈ 12/13 ≈ 0.923 (~7.7% house edge from the tie-loses rule).</li>
+            <li>Average RTP ≈ 12/13 ≈ 0.923 (~7.7% house edge regardless of direction).</li>
         </ul>
     </section>
 </main>

--- a/web/src/test/js/highlow.test.js
+++ b/web/src/test/js/highlow.test.js
@@ -1,6 +1,7 @@
 const {
     renderHighlowResult,
     highlowCardLabel,
+    highlowFormatMultiplier,
 } = require('../../main/resources/static/js/highlow');
 require('../../main/resources/static/js/casino-jackpot');
 
@@ -19,6 +20,21 @@ describe('highlowCardLabel', () => {
     });
 });
 
+describe('highlowFormatMultiplier', () => {
+    test('formats positive multipliers with two decimals and a x suffix', () => {
+        expect(highlowFormatMultiplier(1.5)).toBe('1.50×');
+        expect(highlowFormatMultiplier(12)).toBe('12.00×');
+        expect(highlowFormatMultiplier('2.4')).toBe('2.40×');
+    });
+
+    test('returns empty string for missing or non-positive values', () => {
+        expect(highlowFormatMultiplier(undefined)).toBe('');
+        expect(highlowFormatMultiplier(null)).toBe('');
+        expect(highlowFormatMultiplier(0)).toBe('');
+        expect(highlowFormatMultiplier(NaN)).toBe('');
+    });
+});
+
 describe('renderHighlowResult', () => {
     let resultEl;
 
@@ -27,15 +43,16 @@ describe('renderHighlowResult', () => {
         resultEl = document.getElementById('r');
     });
 
-    test('win on HIGHER renders next > anchor', () => {
+    test('win on HIGHER renders next > anchor and shows the realised multiplier', () => {
         renderHighlowResult(resultEl, {
-            win: true, anchor: 5, next: 11, direction: 'HIGHER', net: 100
+            win: true, anchor: 5, next: 11, direction: 'HIGHER', net: 100, multiplier: 1.5
         });
 
         expect(resultEl.classList.contains('highlow-result-win')).toBe(true);
         expect(resultEl.innerHTML).toContain('J'); // 11 -> J
         expect(resultEl.innerHTML).toContain('5');
         expect(resultEl.innerHTML).toContain('Higher');
+        expect(resultEl.innerHTML).toContain('1.50×');
         expect(resultEl.innerHTML).toContain('+100 credits');
     });
 

--- a/web/src/test/kotlin/web/controller/HighlowControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/HighlowControllerTest.kt
@@ -90,6 +90,8 @@ class HighlowControllerTest {
     @Test
     fun `start locks stake and deals anchor into session`() {
         every { highlowService.dealAnchor() } returns 9
+        every { highlowService.payoutMultiplier(9, Highlow.Direction.HIGHER) } returns 3.0
+        every { highlowService.payoutMultiplier(9, Highlow.Direction.LOWER) } returns 1.5
 
         val response = controller.start(
             guildId,
@@ -101,6 +103,8 @@ class HighlowControllerTest {
         assertTrue(response.statusCode.is2xxSuccessful)
         assertEquals(true, response.body!!.ok)
         assertEquals(9, response.body!!.anchor)
+        assertEquals(3.0, response.body!!.higherMultiplier)
+        assertEquals(1.5, response.body!!.lowerMultiplier)
         assertEquals(9, session.getAttribute(anchorKey))
         assertEquals(50L, session.getAttribute(stakeKey))
         assertEquals(false, session.getAttribute(autoTopUpKey))
@@ -161,6 +165,7 @@ class HighlowControllerTest {
             stake = 50L, payout = 100L, net = 50L,
             anchor = 5, next = 12,
             direction = Highlow.Direction.HIGHER,
+            multiplier = 2.0,
             newBalance = 1_050L
         )
 
@@ -176,6 +181,7 @@ class HighlowControllerTest {
         assertEquals(true, body.win)
         assertEquals(5, body.anchor)
         assertEquals(12, body.next)
+        assertEquals(2.0, body.multiplier)
         assertNull(session.getAttribute(anchorKey), "round must be cleared so the next bet starts fresh")
         assertNull(session.getAttribute(stakeKey))
     }
@@ -247,6 +253,7 @@ class HighlowControllerTest {
             stake = 50L, payout = 100L, net = 50L,
             anchor = 5, next = 12,
             direction = Highlow.Direction.HIGHER,
+            multiplier = 2.0,
             newBalance = 5_050L,
             jackpotPayout = 4_000L
         )


### PR DESCRIPTION
## Summary

The web `/highlow` flow revealed the anchor card before the player picked HIGHER/LOWER and still paid a flat **2× on win**. Optimal play (HIGHER on low anchors, LOWER on high ones) wins ~71% of hands, lifting effective RTP to **~1.42** — a player edge, not a house edge. That is why payouts felt too easy.

This PR replaces the flat `Long` multiplier with an **anchor- and direction-aware `Double` schedule** of `(deckSize - 1) / winningOutcomes`. With `deckSize = 13` that is `12 / winningOutcomes`, which holds RTP at `12/13 ≈ 0.923` (~7.7% house edge) for every `(anchor, direction)` pair regardless of strategy. The Discord bundled flow inherits the same per-hand fairness; the long-run RTP is unchanged for blind play but no longer exploitable when the anchor is visible.

| Anchor | HIGHER pays | LOWER pays |
|--------|-------------|------------|
| 2      | 12/11 ≈ 1.09× | 12/1 = 12× |
| 5      | 12/8 = 1.5×   | 12/4 = 3×  |
| 7      | 12/6 = 2×     | 12/6 = 2×  |
| 9      | 12/4 = 3×     | 12/8 = 1.5×|
| 12     | 12/1 = 12×    | 12/11 ≈ 1.09× |

`dealAnchor` is now capped to `2..deckSize-1` so every dealt hand has both directions winnable above 1× (avoids the awkward 1.0× refund corner case at the deck extremes). The realised multiplier flows through the service `PlayOutcome.Win`, the web JSON response, and the Discord embed so each direction button shows what it actually pays before the player commits.

- Core: `Highlow` now exposes `payoutMultiplier(anchor, direction)`; `Hand.multiplier: Long → Double`; `dealAnchor` clipped to `2..deckSize-1`.
- Wager plumbing: `WagerHelper.applyMultiplier` gets a `Double` overload (truncates payout toward zero, so any remainder stays with the house). The existing `Long` overload is untouched, keeping Slots/Coinflip/Dice/Scratch unaffected.
- UX: web buttons and the Discord embed now label each direction with its per-anchor multiplier (e.g. "Higher (1.50×)").
- Tests: replaced the old `multiplier > 1` pin with an exhaustive sweep over every `(anchor, direction)` pair, added an algebraic RTP check, and added a 200k-hand **optimal-play** RTP regression test that would have caught the original exploit.

## Test plan

- [x] `:database:test --tests HighlowTest` (covers card ranges, win/loss, multipliers, RTP under blind and optimal play)
- [x] `:database:test --tests HighlowServiceTest` (Win/Lose flow with new `multiplier: Double`)
- [x] `:web:test --tests HighlowControllerTest` (StartResponse exposes multipliers; PlayResponse echoes the realised multiplier)
- [x] `web/jest highlow.test.js` (new `highlowFormatMultiplier` helper + multiplier label rendered in the result panel)
- [ ] `:discord-bot:test --tests HighlowCommandTest --tests HighlowButtonTest` — could not run locally (libdave dependency 403 from JitPack); **needs CI**.
- [ ] Manual web smoke test: lock 100 credits, confirm anchor is always 2–12, confirm direction buttons show their multipliers, confirm balance changes by `floor(stake × multiplier) − stake` on win and `−stake` on loss.
- [ ] Manual Discord smoke test: `/highlow stake:100`, confirm both buttons display their payout multipliers and the credit delta matches the displayed multiplier on win.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YcE5vBe8RHXyVX9848D45N)_