### PR TITLE
feat(web): searchable opponent/recipient picker on /duel and /tip

### DIFF
--- a/web/src/main/kotlin/web/controller/DuelController.kt
+++ b/web/src/main/kotlin/web/controller/DuelController.kt
@@ -76,6 +76,7 @@ class DuelController(
         val profile = userService.getUserById(discordId, guildId)
         val balance = profile?.socialCredit ?: 0L
         val pending = duelWebService.pendingForOpponent(discordId, guildId)
+        val members = economyWebService.getGuildMembers(guildId).filter { it.id != discordId.toString() }
 
         model.addAttribute("guildId", guildId.toString())
         model.addAttribute("guildName", guild.name)
@@ -83,6 +84,7 @@ class DuelController(
         model.addAttribute("minStake", DuelService.MIN_STAKE)
         model.addAttribute("maxStake", DuelService.MAX_STAKE)
         model.addAttribute("pending", pending)
+        model.addAttribute("members", members)
         model.addAttribute("username", user.displayName())
         return "duel"
     }
@@ -114,6 +116,9 @@ class DuelController(
         }
         if (request.opponentDiscordId == discordId) {
             return ResponseEntity.badRequest().body(ChallengeResponse(false, error = "You can't duel yourself."))
+        }
+        if (!economyWebService.isMember(request.opponentDiscordId, guildId)) {
+            return ResponseEntity.badRequest().body(ChallengeResponse(false, error = "Pick someone from this server."))
         }
 
         duelWebService.ensureOpponent(request.opponentDiscordId, guildId)

--- a/web/src/main/kotlin/web/controller/TipController.kt
+++ b/web/src/main/kotlin/web/controller/TipController.kt
@@ -77,6 +77,7 @@ class TipController(
         val balance = profile?.socialCredit ?: 0L
         val today = LocalDate.now(ZoneOffset.UTC)
         val sentToday = tipWebService.getDailyTipped(discordId, guildId, today)
+        val members = economyWebService.getGuildMembers(guildId).filter { it.id != discordId.toString() }
 
         model.addAttribute("guildId", guildId.toString())
         model.addAttribute("guildName", guild.name)
@@ -86,6 +87,7 @@ class TipController(
         model.addAttribute("dailyCap", TipService.DEFAULT_TIP_DAILY_CAP)
         model.addAttribute("sentToday", sentToday)
         model.addAttribute("dailyHeadroom", (TipService.DEFAULT_TIP_DAILY_CAP - sentToday).coerceAtLeast(0L))
+        model.addAttribute("members", members)
         model.addAttribute("username", user.displayName())
         return "tip"
     }
@@ -104,6 +106,9 @@ class TipController(
         }
         if (request.recipientDiscordId == discordId) {
             return ResponseEntity.badRequest().body(TipResponse(false, error = "You can't tip yourself."))
+        }
+        if (!economyWebService.isMember(request.recipientDiscordId, guildId)) {
+            return ResponseEntity.badRequest().body(TipResponse(false, error = "Pick someone from this server."))
         }
 
         // Ensure recipient row exists (lazy-create through the helper-style path).

--- a/web/src/main/kotlin/web/service/EconomyWebService.kt
+++ b/web/src/main/kotlin/web/service/EconomyWebService.kt
@@ -22,6 +22,14 @@ class EconomyWebService(
         return guild.getMemberById(discordId) != null
     }
 
+    fun getGuildMembers(guildId: Long): List<MemberInfo> {
+        val guild = jda.getGuildById(guildId) ?: return emptyList()
+        return guild.members
+            .filter { !it.user.isBot }
+            .map { MemberInfo(id = it.id, name = it.effectiveName, avatarUrl = it.effectiveAvatarUrl) }
+            .sortedBy { it.name.lowercase() }
+    }
+
     fun getGuildsWhereUserCanView(accessToken: String, discordId: Long): List<EconomyGuildCard> {
         return introWebService.getMutualGuilds(accessToken).mapNotNull { info ->
             val guildId = info.id.toLongOrNull() ?: return@mapNotNull null

--- a/web/src/main/resources/static/js/duel.js
+++ b/web/src/main/resources/static/js/duel.js
@@ -50,13 +50,26 @@
             .catch(function () { /* keep last known state */ });
     }
 
+    function resolveOpponentId() {
+        const typed = (document.getElementById('duel-opponent').value || '').trim();
+        if (!typed) return null;
+        const escaped = (window.CSS && window.CSS.escape) ? window.CSS.escape(typed) : typed.replace(/"/g, '\\"');
+        const opt = document.querySelector('#duel-member-list option[value="' + escaped + '"]');
+        const id = opt && opt.dataset.id ? parseInt(opt.dataset.id, 10) : NaN;
+        return Number.isFinite(id) ? id : null;
+    }
+
     if (challengeForm) {
         challengeForm.addEventListener('submit', function (e) {
             e.preventDefault();
-            const opponent = parseInt(document.getElementById('duel-opponent').value, 10);
+            const opponent = resolveOpponentId();
             const stake = parseInt(document.getElementById('duel-stake').value, 10);
-            if (!opponent || !stake) {
-                showToast('error', 'Opponent and stake are required.');
+            if (!opponent) {
+                showToast('error', 'Pick someone from the list.');
+                return;
+            }
+            if (!stake) {
+                showToast('error', 'Stake is required.');
                 return;
             }
             window.TobyApi.postJson('/duel/' + guildId + '/challenge', {

--- a/web/src/main/resources/static/js/tip.js
+++ b/web/src/main/resources/static/js/tip.js
@@ -17,14 +17,26 @@
 
     if (!form) return;
 
+    function resolveRecipientId() {
+        const typed = (document.getElementById('tip-recipient').value || '').trim();
+        if (!typed) return null;
+        const escaped = (window.CSS && window.CSS.escape) ? window.CSS.escape(typed) : typed.replace(/"/g, '\\"');
+        const opt = document.querySelector('#tip-member-list option[value="' + escaped + '"]');
+        const id = opt && opt.dataset.id ? parseInt(opt.dataset.id, 10) : NaN;
+        return Number.isFinite(id) ? id : null;
+    }
+
     form.addEventListener('submit', function (e) {
         e.preventDefault();
-        const recipientStr = (document.getElementById('tip-recipient').value || '').trim();
-        const recipient = parseInt(recipientStr, 10);
+        const recipient = resolveRecipientId();
         const amount = parseInt(document.getElementById('tip-amount').value, 10);
         const note = (document.getElementById('tip-note').value || '').trim() || null;
-        if (!recipient || !amount) {
-            window.TobyToasts && window.TobyToasts.error('Recipient and amount are required.');
+        if (!recipient) {
+            window.TobyToasts && window.TobyToasts.error('Pick someone from the list.');
+            return;
+        }
+        if (!amount) {
+            window.TobyToasts && window.TobyToasts.error('Amount is required.');
             return;
         }
         window.TobyApi.postJson('/tip/' + guildId, {

--- a/web/src/main/resources/templates/duel.html
+++ b/web/src/main/resources/templates/duel.html
@@ -23,9 +23,12 @@
     <section class="duel-card">
         <h2>Challenge someone</h2>
         <form id="duel-challenge" autocomplete="off">
-            <label for="duel-opponent">Opponent Discord ID</label>
-            <input id="duel-opponent" name="opponentDiscordId" type="text" inputmode="numeric"
-                   placeholder="e.g. 312691905030782977" required>
+            <label for="duel-opponent">Opponent</label>
+            <input id="duel-opponent" name="opponentName" type="text" list="duel-member-list"
+                   autocomplete="off" placeholder="Type a name…" required>
+            <datalist id="duel-member-list">
+                <option th:each="m : ${members}" th:value="${m.name}" th:attr="data-id=${m.id}"></option>
+            </datalist>
 
             <label for="duel-stake">Stake (credits)</label>
             <input id="duel-stake" name="stake" type="number"

--- a/web/src/main/resources/templates/tip.html
+++ b/web/src/main/resources/templates/tip.html
@@ -22,9 +22,12 @@
 
     <section class="tip-card">
         <form id="tip-form" autocomplete="off">
-            <label for="tip-recipient">Recipient Discord ID</label>
-            <input id="tip-recipient" name="recipientDiscordId" type="text" inputmode="numeric"
-                   placeholder="e.g. 312691905030782977" required>
+            <label for="tip-recipient">Recipient</label>
+            <input id="tip-recipient" name="recipientName" type="text" list="tip-member-list"
+                   autocomplete="off" placeholder="Type a name…" required>
+            <datalist id="tip-member-list">
+                <option th:each="m : ${members}" th:value="${m.name}" th:attr="data-id=${m.id}"></option>
+            </datalist>
 
             <label for="tip-amount">Amount (credits)</label>
             <input id="tip-amount" name="amount" type="number"

--- a/web/src/test/kotlin/web/controller/DuelControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/DuelControllerTest.kt
@@ -48,6 +48,7 @@ class DuelControllerTest {
             every { getAttribute<String>("username") } returns "tester"
         }
         every { economyWebService.isMember(discordId, guildId) } returns true
+        every { economyWebService.isMember(opponentId, guildId) } returns true
         controller = DuelController(
             duelService, duelWebService, pendingDuelRegistry,
             economyWebService, userService, jda
@@ -89,6 +90,18 @@ class DuelControllerTest {
         assertFalse(response.body!!.ok)
         verify(exactly = 0) { duelService.startDuel(any(), any(), any(), any()) }
         verify(exactly = 0) { pendingDuelRegistry.register(any(), any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `challenge of non-member opponent returns 400 without registering`() {
+        every { economyWebService.isMember(opponentId, guildId) } returns false
+
+        val response = controller.challenge(guildId, ChallengeRequest(opponentId, 50L), user)
+
+        assertEquals(400, response.statusCode.value())
+        assertFalse(response.body!!.ok)
+        verify(exactly = 0) { duelWebService.ensureOpponent(any(), any()) }
+        verify(exactly = 0) { duelService.startDuel(any(), any(), any(), any()) }
     }
 
     @Test

--- a/web/src/test/kotlin/web/controller/TipControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/TipControllerTest.kt
@@ -43,6 +43,7 @@ class TipControllerTest {
             every { getAttribute<String>("username") } returns "tester"
         }
         every { economyWebService.isMember(discordId, guildId) } returns true
+        every { economyWebService.isMember(recipientId, guildId) } returns true
         controller = TipController(tipService, tipWebService, economyWebService, userService, jda)
     }
 
@@ -90,6 +91,18 @@ class TipControllerTest {
 
         assertEquals(403, response.statusCode.value())
         assertFalse(response.body!!.ok)
+    }
+
+    @Test
+    fun `tip to non-member returns 400 without calling service`() {
+        every { economyWebService.isMember(recipientId, guildId) } returns false
+
+        val response = controller.tip(guildId, TipRequest(recipientId, 50L, null), user)
+
+        assertEquals(400, response.statusCode.value())
+        assertFalse(response.body!!.ok)
+        verify(exactly = 0) { tipWebService.ensureRecipient(any(), any()) }
+        verify(exactly = 0) { tipService.tip(any(), any(), any(), any(), any(), any(), any()) }
     }
 
     @Test

--- a/web/src/test/kotlin/web/service/EconomyWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/EconomyWebServiceTest.kt
@@ -12,7 +12,9 @@ import io.mockk.mockk
 import net.dv8tion.jda.api.JDA
 import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.entities.Member
+import net.dv8tion.jda.api.entities.User
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -131,5 +133,43 @@ class EconomyWebServiceTest {
         every { marketService.listTradesSince(guildId, any()) } returns emptyList()
         val markers = service.getTrades(guildId, "1d")
         assertTrue(markers.isEmpty())
+    }
+
+    @Test
+    fun `getGuildMembers returns empty when bot is not in the guild`() {
+        every { jda.getGuildById(guildId) } returns null
+        assertTrue(service.getGuildMembers(guildId).isEmpty())
+    }
+
+    @Test
+    fun `getGuildMembers filters bots and sorts by lowercase name`() {
+        val guild = mockk<Guild>(relaxed = true)
+        val human = mockk<Member>(relaxed = true)
+        val humanUser = mockk<User>(relaxed = true)
+        val botMember = mockk<Member>(relaxed = true)
+        val botUser = mockk<User>(relaxed = true)
+        val zUser = mockk<User>(relaxed = true)
+        val zMember = mockk<Member>(relaxed = true)
+        every { humanUser.isBot } returns false
+        every { human.user } returns humanUser
+        every { human.id } returns "100"
+        every { human.effectiveName } returns "alice"
+        every { botUser.isBot } returns true
+        every { botMember.user } returns botUser
+        every { botMember.id } returns "999"
+        every { botMember.effectiveName } returns "TobyBot"
+        every { zUser.isBot } returns false
+        every { zMember.user } returns zUser
+        every { zMember.id } returns "200"
+        every { zMember.effectiveName } returns "Zed"
+        every { guild.members } returns listOf(zMember, botMember, human)
+        every { jda.getGuildById(guildId) } returns guild
+
+        val members = service.getGuildMembers(guildId)
+
+        assertEquals(2, members.size)
+        assertFalse(members.any { it.id == "999" })
+        assertEquals("alice", members[0].name)
+        assertEquals("Zed", members[1].name)
     }
 }


### PR DESCRIPTION
## Summary

- The web `/duel` and `/tip` forms used to require pasting a raw Discord ID into a text input. That's awkward for your own ID and worse for someone else's. This PR replaces that input with an HTML5 `<datalist>`-backed name picker seeded with the guild's non-bot members.
- Server-side, the name → ID resolution happens client-side via the option's `data-id` attribute. The wire format (`opponentDiscordId` / `recipientDiscordId`) is unchanged. The `POST /challenge` and `POST /tip` handlers gain an explicit `economyWebService.isMember(targetId, guildId)` guard so a hand-crafted request can't slip a non-member ID past the dropdown.
- Slash commands `/duel` and `/tip` are untouched: they already use JDA's `OptionType.USER`, which is Discord's native searchable user picker.

## Implementation notes

- New `EconomyWebService.getGuildMembers(guildId)` reuses `IntroWebService.MemberInfo` (same package) and follows the same pattern already used by the intros member-picker.
- Both `DuelController.page` and `TipController.page` now pass `members` to the model. The list is filtered to exclude the requesting user (you can't duel/tip yourself anyway, so showing yourself is just noise).
- `duel.js` / `tip.js` use `document.querySelector('#…-member-list option[value="<typed>"]')` plus `dataset.id` to resolve the ID — no extra fetch, no inline JSON blob.

## Test plan

- [x] `./gradlew :web:test` — full web test suite green, including new tests:
  - `EconomyWebServiceTest`: `getGuildMembers` filters bots and sorts case-insensitively
  - `DuelControllerTest`: challenge of non-member returns 400 without registering
  - `TipControllerTest`: tip to non-member returns 400 without calling the service
- [ ] Manual: open `/duel/{guildId}`, type to autocomplete an opponent, submit; confirm "Challenge sent" toast and that the opponent sees the offer in their inbox.
- [ ] Manual: same for `/tip/{guildId}`.
- [ ] Manual: type a name not in the dropdown — should toast "Pick someone from the list." and not call the API.

https://claude.ai/code/session_01Pw6P9dNVk5aHSHicLh8U3N

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pw6P9dNVk5aHSHicLh8U3N)_