### PR TITLE
fix(web): use a native &lt;select&gt; for the duel/tip member picker

### DIFF
--- a/web/src/main/resources/static/js/duel.js
+++ b/web/src/main/resources/static/js/duel.js
@@ -50,19 +50,10 @@
             .catch(function () { /* keep last known state */ });
     }
 
-    function resolveOpponentId() {
-        const typed = (document.getElementById('duel-opponent').value || '').trim();
-        if (!typed) return null;
-        const escaped = (window.CSS && window.CSS.escape) ? window.CSS.escape(typed) : typed.replace(/"/g, '\\"');
-        const opt = document.querySelector('#duel-member-list option[value="' + escaped + '"]');
-        const id = opt && opt.dataset.id ? parseInt(opt.dataset.id, 10) : NaN;
-        return Number.isFinite(id) ? id : null;
-    }
-
     if (challengeForm) {
         challengeForm.addEventListener('submit', function (e) {
             e.preventDefault();
-            const opponent = resolveOpponentId();
+            const opponent = parseInt(document.getElementById('duel-opponent').value, 10);
             const stake = parseInt(document.getElementById('duel-stake').value, 10);
             if (!opponent) {
                 showToast('error', 'Pick someone from the list.');

--- a/web/src/main/resources/static/js/tip.js
+++ b/web/src/main/resources/static/js/tip.js
@@ -17,18 +17,9 @@
 
     if (!form) return;
 
-    function resolveRecipientId() {
-        const typed = (document.getElementById('tip-recipient').value || '').trim();
-        if (!typed) return null;
-        const escaped = (window.CSS && window.CSS.escape) ? window.CSS.escape(typed) : typed.replace(/"/g, '\\"');
-        const opt = document.querySelector('#tip-member-list option[value="' + escaped + '"]');
-        const id = opt && opt.dataset.id ? parseInt(opt.dataset.id, 10) : NaN;
-        return Number.isFinite(id) ? id : null;
-    }
-
     form.addEventListener('submit', function (e) {
         e.preventDefault();
-        const recipient = resolveRecipientId();
+        const recipient = parseInt(document.getElementById('tip-recipient').value, 10);
         const amount = parseInt(document.getElementById('tip-amount').value, 10);
         const note = (document.getElementById('tip-note').value || '').trim() || null;
         if (!recipient) {

--- a/web/src/main/resources/templates/duel.html
+++ b/web/src/main/resources/templates/duel.html
@@ -24,11 +24,13 @@
         <h2>Challenge someone</h2>
         <form id="duel-challenge" autocomplete="off">
             <label for="duel-opponent">Opponent</label>
-            <input id="duel-opponent" name="opponentName" type="text" list="duel-member-list"
-                   autocomplete="off" placeholder="Type a name…" required>
-            <datalist id="duel-member-list">
-                <option th:each="m : ${members}" th:value="${m.name}" th:attr="data-id=${m.id}"></option>
-            </datalist>
+            <select id="duel-opponent" name="opponentDiscordId" required>
+                <option value="">Pick an opponent…</option>
+                <option th:each="m : ${members}" th:value="${m.id}" th:text="${m.name}"></option>
+            </select>
+            <p th:if="${#lists.isEmpty(members)}" class="muted">
+                No other members found in this server. Try again in a moment if the bot just connected.
+            </p>
 
             <label for="duel-stake">Stake (credits)</label>
             <input id="duel-stake" name="stake" type="number"

--- a/web/src/main/resources/templates/tip.html
+++ b/web/src/main/resources/templates/tip.html
@@ -23,11 +23,13 @@
     <section class="tip-card">
         <form id="tip-form" autocomplete="off">
             <label for="tip-recipient">Recipient</label>
-            <input id="tip-recipient" name="recipientName" type="text" list="tip-member-list"
-                   autocomplete="off" placeholder="Type a name…" required>
-            <datalist id="tip-member-list">
-                <option th:each="m : ${members}" th:value="${m.name}" th:attr="data-id=${m.id}"></option>
-            </datalist>
+            <select id="tip-recipient" name="recipientDiscordId" required>
+                <option value="">Pick a recipient…</option>
+                <option th:each="m : ${members}" th:value="${m.id}" th:text="${m.name}"></option>
+            </select>
+            <p th:if="${#lists.isEmpty(members)}" class="muted">
+                No other members found in this server. Try again in a moment if the bot just connected.
+            </p>
 
             <label for="tip-amount">Amount (credits)</label>
             <input id="tip-amount" name="amount" type="number"


### PR DESCRIPTION
## Summary

Follow-up to #320. The `<datalist>`-based picker introduced in that PR didn't surface options reliably — users reported "i can't see any players, and typing a name isn't surfacing anything." `<datalist>` only renders suggestions when the browser feels like surfacing them and has known quirks (Safari, mobile), and it's invisible by default which makes a partial-cache state look like a complete failure.

This PR replaces the input + `<datalist>` with a plain `<select>` seeded with members on the server side — matching the existing `intros.html` member-picker pattern. The dropdown is now always visible on click, the selected value IS the Discord ID (no JS name→id resolution needed), and a fallback message appears when the list is empty so an empty member cache is self-explanatory.

## Changes

- `duel.html`, `tip.html`: `<input list>` + `<datalist>` → `<select>` + visible "no members found" hint when empty
- `duel.js`, `tip.js`: drop `resolveOpponentId` / `resolveRecipientId` — the select's `value` is the Discord ID directly
- No backend changes (the model attribute and POST contract are unchanged)

## Test plan

- [x] `./gradlew :web:test` — all green; existing controller tests still cover the wire format unchanged
- [ ] Manual: open `/duel/{guildId}` and `/tip/{guildId}` in a guild with several members; confirm the dropdown shows all non-bot members alphabetically, picking one + setting a stake/amount produces a successful challenge/tip
- [ ] Manual: confirm type-to-jump works in the dropdown (typing 'a' jumps to the first 'a…' name)

https://claude.ai/code/session_01Pw6P9dNVk5aHSHicLh8U3N

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pw6P9dNVk5aHSHicLh8U3N)_