### PR TITLE
feat(poker): multiplayer Texas Hold'em over the credits economy

### DIFF
--- a/application/src/test/kotlin/integration/bot/ButtonManagerTest.kt
+++ b/application/src/test/kotlin/integration/bot/ButtonManagerTest.kt
@@ -76,13 +76,14 @@ class ButtonManagerTest {
             InitiativeNextButton::class.java,
             InitiativePreviousButton::class.java,
             PausePlayButton::class.java,
+            PokerActionButton::class.java,
             ResendLastRequestButton::class.java,
             RollButton::class.java,
             StopButton::class.java,
         )
 
         assertTrue(availableButtons.containsAll(buttonManager.buttons.map { it.javaClass }.toList()))
-        assertEquals(9, buttonManager.buttons.size)
+        assertEquals(10, buttonManager.buttons.size)
     }
 
     @Test

--- a/application/src/test/kotlin/integration/bot/CommandManagerTest.kt
+++ b/application/src/test/kotlin/integration/bot/CommandManagerTest.kt
@@ -13,6 +13,7 @@ import bot.toby.command.commands.economy.CoinflipCommand
 import bot.toby.command.commands.economy.DiceCommand
 import bot.toby.command.commands.economy.DuelCommand
 import bot.toby.command.commands.economy.HighlowCommand
+import bot.toby.command.commands.economy.PokerCommand
 import bot.toby.command.commands.economy.ScratchCommand
 import bot.toby.command.commands.economy.SlotsCommand
 import bot.toby.command.commands.economy.TipCommand
@@ -142,12 +143,13 @@ class CommandManagerTest {
             ScratchCommand::class.java,
             ActivityCommand::class.java,
             TipCommand::class.java,
-            DuelCommand::class.java
+            DuelCommand::class.java,
+            PokerCommand::class.java
         )
 
         Assertions.assertTrue(availableCommands.containsAll(commandManager.allCommands.map { it.javaClass }.toList()))
-        Assertions.assertEquals(53, commandManager.allCommands.size)
-        Assertions.assertEquals(53, commandManager.allSlashCommands.size)
+        Assertions.assertEquals(54, commandManager.allCommands.size)
+        Assertions.assertEquals(54, commandManager.allSlashCommands.size)
     }
 
     @Test

--- a/database/src/main/kotlin/database/dto/ConfigDto.kt
+++ b/database/src/main/kotlin/database/dto/ConfigDto.kt
@@ -38,7 +38,11 @@ class ConfigDto(
         ACTIVITY_TRACKING_NOTIFIED("ACTIVITY_TRACKING_NOTIFIED"),
         // Whole-number percentage (0-50) of every lost casino stake that
         // routes into the per-guild jackpot pool. Defaults to 10 if unset.
-        JACKPOT_LOSS_TRIBUTE_PCT("JACKPOT_LOSS_TRIBUTE_PCT");
+        JACKPOT_LOSS_TRIBUTE_PCT("JACKPOT_LOSS_TRIBUTE_PCT"),
+
+        // Whole-number percentage (0-20) of every settled poker pot that
+        // routes into the per-guild jackpot pool. Defaults to 5 if unset.
+        POKER_RAKE_PCT("POKER_RAKE_PCT");
     }
 
     override fun toString(): String {

--- a/database/src/main/kotlin/database/dto/PokerHandLogDto.kt
+++ b/database/src/main/kotlin/database/dto/PokerHandLogDto.kt
@@ -1,0 +1,51 @@
+package database.dto
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.springframework.transaction.annotation.Transactional
+import java.io.Serializable
+import java.time.Instant
+
+@Entity
+@Table(name = "poker_hand_log", schema = "public")
+@Transactional
+class PokerHandLogDto(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    var id: Long? = null,
+
+    @Column(name = "guild_id", nullable = false)
+    var guildId: Long = 0,
+
+    @Column(name = "table_id", nullable = false)
+    var tableId: Long = 0,
+
+    @Column(name = "hand_number", nullable = false)
+    var handNumber: Long = 0,
+
+    /** Comma-separated list of seated players' Discord IDs at hand start. */
+    @Column(name = "players", nullable = false, length = 512)
+    var players: String = "",
+
+    /** Comma-separated list of winner Discord IDs (one for outright, multiple on chop). */
+    @Column(name = "winners", nullable = false, length = 512)
+    var winners: String = "",
+
+    @Column(name = "pot", nullable = false)
+    var pot: Long = 0,
+
+    @Column(name = "rake", nullable = false)
+    var rake: Long = 0,
+
+    /** Compact text rendering of the community board, e.g. "AS,KH,QD,JC,TS". */
+    @Column(name = "board", nullable = false, length = 64)
+    var board: String = "",
+
+    @Column(name = "resolved_at", nullable = false)
+    var resolvedAt: Instant = Instant.now()
+) : Serializable

--- a/database/src/main/kotlin/database/persistence/PokerHandLogPersistence.kt
+++ b/database/src/main/kotlin/database/persistence/PokerHandLogPersistence.kt
@@ -1,0 +1,7 @@
+package database.persistence
+
+import database.dto.PokerHandLogDto
+
+interface PokerHandLogPersistence {
+    fun insert(row: PokerHandLogDto): PokerHandLogDto
+}

--- a/database/src/main/kotlin/database/persistence/impl/DefaultPokerHandLogPersistence.kt
+++ b/database/src/main/kotlin/database/persistence/impl/DefaultPokerHandLogPersistence.kt
@@ -1,0 +1,22 @@
+package database.persistence.impl
+
+import database.dto.PokerHandLogDto
+import database.persistence.PokerHandLogPersistence
+import jakarta.persistence.EntityManager
+import jakarta.persistence.PersistenceContext
+import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
+
+@Repository
+@Transactional
+class DefaultPokerHandLogPersistence : PokerHandLogPersistence {
+
+    @PersistenceContext
+    private lateinit var entityManager: EntityManager
+
+    override fun insert(row: PokerHandLogDto): PokerHandLogDto {
+        entityManager.persist(row)
+        entityManager.flush()
+        return row
+    }
+}

--- a/database/src/main/kotlin/database/poker/Card.kt
+++ b/database/src/main/kotlin/database/poker/Card.kt
@@ -1,0 +1,23 @@
+package database.poker
+
+enum class Suit(val symbol: Char) {
+    CLUBS('♣'), DIAMONDS('♦'), HEARTS('♥'), SPADES('♠');
+
+    override fun toString(): String = symbol.toString()
+}
+
+enum class Rank(val value: Int, val symbol: String) {
+    TWO(2, "2"), THREE(3, "3"), FOUR(4, "4"), FIVE(5, "5"),
+    SIX(6, "6"), SEVEN(7, "7"), EIGHT(8, "8"), NINE(9, "9"),
+    TEN(10, "T"), JACK(11, "J"), QUEEN(12, "Q"), KING(13, "K"), ACE(14, "A");
+
+    override fun toString(): String = symbol
+}
+
+data class Card(val rank: Rank, val suit: Suit) {
+    override fun toString(): String = "$rank$suit"
+
+    companion object {
+        fun all(): List<Card> = Rank.entries.flatMap { r -> Suit.entries.map { s -> Card(r, s) } }
+    }
+}

--- a/database/src/main/kotlin/database/poker/Deck.kt
+++ b/database/src/main/kotlin/database/poker/Deck.kt
@@ -1,0 +1,19 @@
+package database.poker
+
+import kotlin.random.Random
+
+/**
+ * Mutable 52-card deck. Cards are dealt off the top until the deck is
+ * empty. Pass a seeded [Random] for deterministic shuffles in tests
+ * (mirrors how `DuelService` injects `Random.Default` for production
+ * and a deterministic stub in unit tests).
+ */
+class Deck(random: Random = Random.Default) {
+    private val cards: ArrayDeque<Card> = ArrayDeque(Card.all().shuffled(random))
+
+    fun deal(): Card = cards.removeFirst()
+
+    fun deal(count: Int): List<Card> = List(count) { deal() }
+
+    val size: Int get() = cards.size
+}

--- a/database/src/main/kotlin/database/poker/HandEvaluator.kt
+++ b/database/src/main/kotlin/database/poker/HandEvaluator.kt
@@ -1,0 +1,130 @@
+package database.poker
+
+/**
+ * Pure 5-from-7 Texas Hold'em hand evaluator. Given a player's two hole
+ * cards plus up to five community cards, returns the best 5-card
+ * [HandRank] reachable. [HandRank] is `Comparable`: higher category
+ * wins, ties broken by descending kicker ranks.
+ *
+ * Wheel handling: A-2-3-4-5 is a straight with the Ace playing low; its
+ * high card is 5, not the Ace. Likewise A-2-3-4-5 of one suit is a
+ * straight flush valued at "5-high straight flush", strictly below
+ * 6-high straight flush.
+ */
+object HandEvaluator {
+
+    enum class Category {
+        HIGH_CARD,
+        PAIR,
+        TWO_PAIR,
+        THREE_OF_A_KIND,
+        STRAIGHT,
+        FLUSH,
+        FULL_HOUSE,
+        FOUR_OF_A_KIND,
+        STRAIGHT_FLUSH
+    }
+
+    data class HandRank(
+        val category: Category,
+        val tiebreakers: List<Int>
+    ) : Comparable<HandRank> {
+        override fun compareTo(other: HandRank): Int {
+            val byCategory = category.ordinal.compareTo(other.category.ordinal)
+            if (byCategory != 0) return byCategory
+            for (i in tiebreakers.indices) {
+                if (i >= other.tiebreakers.size) return 1
+                val c = tiebreakers[i].compareTo(other.tiebreakers[i])
+                if (c != 0) return c
+            }
+            if (other.tiebreakers.size > tiebreakers.size) return -1
+            return 0
+        }
+    }
+
+    /**
+     * Best [HandRank] across all 5-card subsets of [holeCards] + [board].
+     * Either list may be partial (e.g. on the flop the board is 3 cards),
+     * provided their union has at least 5 cards.
+     */
+    fun bestHand(holeCards: List<Card>, board: List<Card>): HandRank {
+        val all = holeCards + board
+        require(all.size >= 5) { "Need at least 5 cards to evaluate, got ${all.size}" }
+        return combinations(all, 5).map(::scoreFive).max()
+    }
+
+    /** Direct 5-card scoring; exposed for unit tests and short-circuit paths. */
+    fun scoreFive(hand: List<Card>): HandRank {
+        require(hand.size == 5) { "scoreFive needs exactly 5 cards" }
+        val ranksDesc = hand.map { it.rank.value }.sortedDescending()
+        val isFlush = hand.map { it.suit }.toSet().size == 1
+        val straightHigh = straightHighCard(ranksDesc)
+
+        val rankCounts = ranksDesc.groupingBy { it }.eachCount()
+        val byCount = rankCounts.entries
+            .sortedWith(compareByDescending<Map.Entry<Int, Int>> { it.value }.thenByDescending { it.key })
+
+        if (isFlush && straightHigh != null) {
+            return HandRank(Category.STRAIGHT_FLUSH, listOf(straightHigh))
+        }
+        if (byCount[0].value == 4) {
+            val quad = byCount[0].key
+            val kicker = byCount[1].key
+            return HandRank(Category.FOUR_OF_A_KIND, listOf(quad, kicker))
+        }
+        if (byCount[0].value == 3 && byCount[1].value == 2) {
+            return HandRank(Category.FULL_HOUSE, listOf(byCount[0].key, byCount[1].key))
+        }
+        if (isFlush) {
+            return HandRank(Category.FLUSH, ranksDesc)
+        }
+        if (straightHigh != null) {
+            return HandRank(Category.STRAIGHT, listOf(straightHigh))
+        }
+        if (byCount[0].value == 3) {
+            val trip = byCount[0].key
+            val kickers = byCount.drop(1).map { it.key }
+            return HandRank(Category.THREE_OF_A_KIND, listOf(trip) + kickers)
+        }
+        if (byCount[0].value == 2 && byCount[1].value == 2) {
+            val highPair = byCount[0].key
+            val lowPair = byCount[1].key
+            val kicker = byCount[2].key
+            return HandRank(Category.TWO_PAIR, listOf(highPair, lowPair, kicker))
+        }
+        if (byCount[0].value == 2) {
+            val pair = byCount[0].key
+            val kickers = byCount.drop(1).map { it.key }
+            return HandRank(Category.PAIR, listOf(pair) + kickers)
+        }
+        return HandRank(Category.HIGH_CARD, ranksDesc)
+    }
+
+    /** High card of a 5-card straight, or null if the hand isn't a straight. */
+    private fun straightHighCard(ranksDesc: List<Int>): Int? {
+        val unique = ranksDesc.toSortedSet()
+        if (unique.size != 5) return null
+        val sorted = unique.toList() // ascending
+        val high = sorted.last()
+        val low = sorted.first()
+        if (high - low == 4) return high
+        // Wheel: A-2-3-4-5 (Ace acts as 1).
+        if (sorted == listOf(2, 3, 4, 5, Rank.ACE.value)) return 5
+        return null
+    }
+
+    private fun <T> combinations(items: List<T>, k: Int): Sequence<List<T>> = sequence {
+        if (k == 0) { yield(emptyList()); return@sequence }
+        if (k > items.size) return@sequence
+        val n = items.size
+        val idx = IntArray(k) { it }
+        while (true) {
+            yield(idx.map { items[it] })
+            var i = k - 1
+            while (i >= 0 && idx[i] == n - k + i) i--
+            if (i < 0) return@sequence
+            idx[i]++
+            for (j in i + 1 until k) idx[j] = idx[j - 1] + 1
+        }
+    }
+}

--- a/database/src/main/kotlin/database/poker/HandEvaluator.kt
+++ b/database/src/main/kotlin/database/poker/HandEvaluator.kt
@@ -50,7 +50,7 @@ object HandEvaluator {
     fun bestHand(holeCards: List<Card>, board: List<Card>): HandRank {
         val all = holeCards + board
         require(all.size >= 5) { "Need at least 5 cards to evaluate, got ${all.size}" }
-        return combinations(all, 5).map(::scoreFive).max()
+        return combinations(all, 5).maxOf(::scoreFive)
     }
 
     /** Direct 5-card scoring; exposed for unit tests and short-circuit paths. */

--- a/database/src/main/kotlin/database/poker/PokerEngine.kt
+++ b/database/src/main/kotlin/database/poker/PokerEngine.kt
@@ -1,0 +1,399 @@
+package database.poker
+
+import database.poker.PokerTable.Phase
+import database.poker.PokerTable.SeatStatus
+import java.time.Instant
+import kotlin.random.Random
+
+/**
+ * Pure state-machine over [PokerTable]. Mutates the table in place but
+ * holds no Spring or DB dependencies — easily unit-testable with a
+ * seeded [Random] (mirrors `DuelService(random = ...)`).
+ *
+ * Fixed-limit Texas Hold'em flow: post blinds → deal 2 hole cards →
+ * pre-flop bet → flop + bet → turn + bet → river + bet → showdown. Bet
+ * size is `smallBet` pre-flop/flop and `bigBet` turn/river. Raises are
+ * capped per street.
+ *
+ * v1 simplifications (see docstring on [PokerService]):
+ *   - Single pot, no side pots. An all-in short stack can win the whole
+ *     pot at showdown, which is incorrect poker but acceptable for a
+ *     casual cash table.
+ *   - "Call for less" is rejected; the player must fold instead. This
+ *     keeps the pot trivially divisible and avoids partial calls.
+ */
+object PokerEngine {
+
+    sealed interface PokerAction {
+        data object Fold : PokerAction
+        data object Check : PokerAction
+        data object Call : PokerAction
+        data object Raise : PokerAction
+    }
+
+    sealed interface ApplyResult {
+        data class Applied(val event: ActionEvent) : ApplyResult
+        data class Rejected(val reason: RejectReason) : ApplyResult
+    }
+
+    sealed interface ActionEvent {
+        data object Continued : ActionEvent
+        data class StreetAdvanced(val newPhase: Phase, val community: List<Card>) : ActionEvent
+        data class HandResolved(val result: PokerTable.HandResult) : ActionEvent
+    }
+
+    enum class RejectReason {
+        NO_HAND_IN_PROGRESS,
+        NOT_AT_TABLE,
+        NOT_YOUR_TURN,
+        ILLEGAL_CHECK,
+        ILLEGAL_CALL,
+        ILLEGAL_RAISE,
+        RAISE_CAP_REACHED,
+        INSUFFICIENT_CHIPS_TO_CALL,
+        INSUFFICIENT_CHIPS_TO_RAISE
+    }
+
+    sealed interface StartResult {
+        data class Started(val handNumber: Long) : StartResult
+        data object NotEnoughPlayers : StartResult
+        data object HandAlreadyInProgress : StartResult
+    }
+
+    /**
+     * Begin a new hand: rotate dealer, post blinds, deal hole cards,
+     * set the first actor. Requires the table to be in [Phase.WAITING]
+     * with at least 2 chip-holding seats. Idempotent guards return
+     * sealed [StartResult] variants without mutating the table.
+     */
+    fun startHand(
+        table: PokerTable,
+        random: Random = Random.Default,
+        now: Instant = Instant.now()
+    ): StartResult {
+        if (table.phase != Phase.WAITING) return StartResult.HandAlreadyInProgress
+        val playable = table.seats.withIndex().filter { it.value.chips > 0 }
+        if (playable.size < 2) return StartResult.NotEnoughPlayers
+
+        table.handNumber++
+        table.phase = Phase.PRE_FLOP
+        table.deck = Deck(random)
+        table.community.clear()
+        table.pot = 0L
+        table.currentBet = 0L
+        table.raisesThisStreet = 0
+        table.lastActivityAt = now
+        table.lastResult = null
+
+        for (seat in table.seats) {
+            seat.committedThisRound = 0L
+            seat.totalCommittedThisHand = 0L
+            seat.holeCards = emptyList()
+            seat.status = if (seat.chips > 0) SeatStatus.ACTIVE else SeatStatus.SITTING_OUT
+        }
+
+        // Rotate dealer button to the next chip-holding seat.
+        table.dealerIndex = nextActiveIndex(table, table.dealerIndex)
+
+        val active = activeIndicesInOrder(table)
+        val sbIndex: Int
+        val bbIndex: Int
+        val firstActorIndex: Int
+        if (active.size == 2) {
+            // Heads-up: dealer is SB and acts first pre-flop.
+            sbIndex = table.dealerIndex
+            bbIndex = nextActiveIndex(table, sbIndex)
+            firstActorIndex = sbIndex
+        } else {
+            sbIndex = nextActiveIndex(table, table.dealerIndex)
+            bbIndex = nextActiveIndex(table, sbIndex)
+            firstActorIndex = nextActiveIndex(table, bbIndex)
+        }
+
+        postBlind(table, sbIndex, table.smallBlind)
+        postBlind(table, bbIndex, table.bigBlind)
+        table.currentBet = table.bigBlind
+
+        // Deal two hole cards to each active seat starting left of the dealer.
+        val deck = table.deck!!
+        val dealOrder = activeIndicesStartingFrom(table, nextActiveIndex(table, table.dealerIndex))
+        repeat(2) {
+            for (i in dealOrder) {
+                table.seats[i].holeCards = table.seats[i].holeCards + deck.deal()
+            }
+        }
+
+        table.actorIndex = firstActorIndex
+        table.seatsToAct = countNotFoldedNotAllIn(table)
+        return StartResult.Started(table.handNumber)
+    }
+
+    /**
+     * Apply [action] for [discordId] at the current street. Rejects with
+     * [RejectReason] if the action is illegal. On success, returns
+     * either [ActionEvent.Continued] (street still in progress),
+     * [ActionEvent.StreetAdvanced] (round closed, dealt next street),
+     * or [ActionEvent.HandResolved] (hand fully settled — chips already
+     * credited to winners, [PokerTable.HandResult] populated, table
+     * back in [Phase.WAITING]).
+     */
+    fun applyAction(
+        table: PokerTable,
+        discordId: Long,
+        action: PokerAction,
+        rakeRate: Double,
+        now: Instant = Instant.now()
+    ): ApplyResult {
+        if (table.phase == Phase.WAITING) return ApplyResult.Rejected(RejectReason.NO_HAND_IN_PROGRESS)
+        val seatIndex = table.seats.indexOfFirst { it.discordId == discordId }
+        if (seatIndex < 0) return ApplyResult.Rejected(RejectReason.NOT_AT_TABLE)
+        if (seatIndex != table.actorIndex) return ApplyResult.Rejected(RejectReason.NOT_YOUR_TURN)
+        val seat = table.seats[seatIndex]
+        if (seat.status != SeatStatus.ACTIVE) return ApplyResult.Rejected(RejectReason.NOT_YOUR_TURN)
+
+        val betUnit = currentBetUnit(table)
+        when (action) {
+            PokerAction.Fold -> {
+                seat.status = SeatStatus.FOLDED
+                // The folded seat no longer needs a decision this round.
+                table.seatsToAct = (table.seatsToAct - 1).coerceAtLeast(0)
+            }
+            PokerAction.Check -> {
+                if (seat.committedThisRound != table.currentBet) {
+                    return ApplyResult.Rejected(RejectReason.ILLEGAL_CHECK)
+                }
+                table.seatsToAct = (table.seatsToAct - 1).coerceAtLeast(0)
+            }
+            PokerAction.Call -> {
+                val owe = table.currentBet - seat.committedThisRound
+                if (owe <= 0L) return ApplyResult.Rejected(RejectReason.ILLEGAL_CALL)
+                if (seat.chips < owe) {
+                    return ApplyResult.Rejected(RejectReason.INSUFFICIENT_CHIPS_TO_CALL)
+                }
+                commit(table, seat, owe)
+                if (seat.chips == 0L) seat.status = SeatStatus.ALL_IN
+                table.seatsToAct = (table.seatsToAct - 1).coerceAtLeast(0)
+            }
+            PokerAction.Raise -> {
+                if (table.raisesThisStreet >= table.maxRaisesPerStreet) {
+                    return ApplyResult.Rejected(RejectReason.RAISE_CAP_REACHED)
+                }
+                val owe = table.currentBet - seat.committedThisRound
+                val total = owe + betUnit
+                if (seat.chips < total) {
+                    return ApplyResult.Rejected(RejectReason.INSUFFICIENT_CHIPS_TO_RAISE)
+                }
+                commit(table, seat, total)
+                table.currentBet += betUnit
+                table.raisesThisStreet++
+                if (seat.chips == 0L) seat.status = SeatStatus.ALL_IN
+                // Everyone else who can still act needs another decision.
+                table.seatsToAct = countNotFoldedNotAllIn(table) - 1
+            }
+        }
+
+        table.lastActivityAt = now
+
+        // Short-circuit: only one non-folded seat? They take the pot uncontested.
+        val nonFolded = table.seats.filter { it.status != SeatStatus.FOLDED && it.status != SeatStatus.SITTING_OUT }
+        if (nonFolded.size <= 1) {
+            return ApplyResult.Applied(ActionEvent.HandResolved(resolveHand(table, rakeRate, now)))
+        }
+
+        // Round still has actors to bet?
+        val canStillBet = nonFolded.any { it.status == SeatStatus.ACTIVE }
+        if (table.seatsToAct > 0 && canStillBet) {
+            advanceActor(table)
+            return ApplyResult.Applied(ActionEvent.Continued)
+        }
+
+        // Round closed — advance street or resolve.
+        return advanceStreet(table, rakeRate, now)
+    }
+
+    private fun advanceStreet(
+        table: PokerTable,
+        rakeRate: Double,
+        now: Instant
+    ): ApplyResult {
+        val deck = table.deck ?: return ApplyResult.Rejected(RejectReason.NO_HAND_IN_PROGRESS)
+
+        // Sweep round commitments into the pot via committedThisRound reset.
+        for (seat in table.seats) seat.committedThisRound = 0L
+        table.currentBet = 0L
+        table.raisesThisStreet = 0
+
+        val nextPhase = when (table.phase) {
+            Phase.PRE_FLOP -> {
+                table.community.addAll(deck.deal(3)); Phase.FLOP
+            }
+            Phase.FLOP -> {
+                table.community.add(deck.deal()); Phase.TURN
+            }
+            Phase.TURN -> {
+                table.community.add(deck.deal()); Phase.RIVER
+            }
+            Phase.RIVER -> {
+                return ApplyResult.Applied(ActionEvent.HandResolved(resolveHand(table, rakeRate, now)))
+            }
+            Phase.WAITING -> return ApplyResult.Rejected(RejectReason.NO_HAND_IN_PROGRESS)
+        }
+        table.phase = nextPhase
+
+        // If everyone left in the hand is all-in, no more betting possible —
+        // run out the rest of the board and resolve in one shot.
+        val activeBetters = table.seats.count { it.status == SeatStatus.ACTIVE }
+        if (activeBetters <= 1) {
+            while (table.phase != Phase.RIVER) {
+                when (table.phase) {
+                    Phase.FLOP -> { table.community.add(deck.deal()); table.phase = Phase.TURN }
+                    Phase.TURN -> { table.community.add(deck.deal()); table.phase = Phase.RIVER }
+                    else -> Unit
+                }
+            }
+            return ApplyResult.Applied(ActionEvent.HandResolved(resolveHand(table, rakeRate, now)))
+        }
+
+        // First actor postflop: first ACTIVE seat left of the dealer.
+        table.actorIndex = nextActiveIndex(table, table.dealerIndex)
+        table.seatsToAct = countNotFoldedNotAllIn(table)
+        return ApplyResult.Applied(ActionEvent.StreetAdvanced(nextPhase, table.community.toList()))
+    }
+
+    private fun resolveHand(
+        table: PokerTable,
+        rakeRate: Double,
+        now: Instant
+    ): PokerTable.HandResult {
+        val pot = table.pot
+        val rake = (pot * rakeRate).toLong().coerceAtLeast(0L).coerceAtMost(pot)
+        val distributable = pot - rake
+
+        val contenders = table.seats.filter {
+            it.status == SeatStatus.ACTIVE || it.status == SeatStatus.ALL_IN
+        }
+
+        val winners: List<PokerTable.Seat> = when {
+            contenders.size == 1 -> listOf(contenders.single())
+            else -> {
+                val ranked = contenders.map { it to HandEvaluator.bestHand(it.holeCards, table.community) }
+                val best = ranked.maxOf { it.second }
+                ranked.filter { it.second.compareTo(best) == 0 }.map { it.first }
+            }
+        }
+
+        // Even split, with the remainder going to the first listed winner so
+        // total chip count is preserved exactly.
+        val payouts = mutableMapOf<Long, Long>()
+        if (winners.isNotEmpty()) {
+            val share = distributable / winners.size
+            val remainder = distributable - share * winners.size
+            for ((i, winner) in winners.withIndex()) {
+                val take = share + if (i == 0) remainder else 0L
+                winner.chips += take
+                payouts[winner.discordId] = take
+            }
+        }
+
+        val revealedHoleCards: Map<Long, List<Card>> =
+            if (contenders.size > 1) contenders.associate { it.discordId to it.holeCards } else emptyMap()
+
+        val result = PokerTable.HandResult(
+            handNumber = table.handNumber,
+            winners = winners.map { it.discordId },
+            payoutByDiscordId = payouts.toMap(),
+            pot = pot,
+            rake = rake,
+            board = table.community.toList(),
+            revealedHoleCards = revealedHoleCards,
+            resolvedAt = now
+        )
+
+        // Reset table for the next hand.
+        table.phase = Phase.WAITING
+        table.pot = 0L
+        table.currentBet = 0L
+        table.raisesThisStreet = 0
+        table.community.clear()
+        table.deck = null
+        for (seat in table.seats) {
+            seat.committedThisRound = 0L
+            seat.totalCommittedThisHand = 0L
+            seat.holeCards = emptyList()
+            seat.status = if (seat.chips > 0) SeatStatus.SITTING_OUT else SeatStatus.SITTING_OUT
+        }
+        table.lastActivityAt = now
+        table.lastResult = result
+        return result
+    }
+
+    private fun postBlind(table: PokerTable, seatIndex: Int, amount: Long) {
+        val seat = table.seats[seatIndex]
+        val toPost = minOf(seat.chips, amount)
+        commit(table, seat, toPost)
+        if (seat.chips == 0L) seat.status = SeatStatus.ALL_IN
+    }
+
+    private fun commit(table: PokerTable, seat: PokerTable.Seat, amount: Long) {
+        seat.chips -= amount
+        seat.committedThisRound += amount
+        seat.totalCommittedThisHand += amount
+        table.pot += amount
+    }
+
+    private fun currentBetUnit(table: PokerTable): Long = when (table.phase) {
+        Phase.PRE_FLOP, Phase.FLOP -> table.smallBet
+        Phase.TURN, Phase.RIVER -> table.bigBet
+        Phase.WAITING -> table.smallBet
+    }
+
+    private fun advanceActor(table: PokerTable) {
+        table.actorIndex = nextSeatToAct(table, table.actorIndex)
+    }
+
+    private fun nextSeatToAct(table: PokerTable, fromIndex: Int): Int {
+        val n = table.seats.size
+        if (n == 0) return -1
+        var i = (fromIndex + 1) % n
+        repeat(n) {
+            val seat = table.seats[i]
+            if (seat.status == SeatStatus.ACTIVE) return i
+            i = (i + 1) % n
+        }
+        return fromIndex
+    }
+
+    private fun nextActiveIndex(table: PokerTable, fromIndex: Int): Int {
+        val n = table.seats.size
+        if (n == 0) return -1
+        var i = (fromIndex + 1) % n
+        repeat(n) {
+            val seat = table.seats[i]
+            if (seat.status == SeatStatus.ACTIVE || seat.status == SeatStatus.ALL_IN) return i
+            i = (i + 1) % n
+        }
+        return fromIndex
+    }
+
+    private fun activeIndicesInOrder(table: PokerTable): List<Int> =
+        table.seats.withIndex()
+            .filter { it.value.status == SeatStatus.ACTIVE || it.value.status == SeatStatus.ALL_IN }
+            .map { it.index }
+
+    private fun activeIndicesStartingFrom(table: PokerTable, startIndex: Int): List<Int> {
+        val n = table.seats.size
+        val out = mutableListOf<Int>()
+        var i = startIndex
+        repeat(n) {
+            val seat = table.seats[i]
+            if (seat.status == SeatStatus.ACTIVE || seat.status == SeatStatus.ALL_IN) {
+                out.add(i)
+            }
+            i = (i + 1) % n
+        }
+        return out
+    }
+
+    private fun countNotFoldedNotAllIn(table: PokerTable): Int =
+        table.seats.count { it.status == SeatStatus.ACTIVE }
+}

--- a/database/src/main/kotlin/database/poker/PokerEngine.kt
+++ b/database/src/main/kotlin/database/poker/PokerEngine.kt
@@ -119,7 +119,7 @@ object PokerEngine {
         val dealOrder = activeIndicesStartingFrom(table, nextActiveIndex(table, table.dealerIndex))
         repeat(2) {
             for (i in dealOrder) {
-                table.seats[i].holeCards = table.seats[i].holeCards + deck.deal()
+                table.seats[i].holeCards += deck.deal()
             }
         }
 

--- a/database/src/main/kotlin/database/poker/PokerTable.kt
+++ b/database/src/main/kotlin/database/poker/PokerTable.kt
@@ -1,0 +1,70 @@
+package database.poker
+
+import java.time.Instant
+
+/**
+ * Mutable state of a single poker table. All mutations happen inside a
+ * monitor on the table object (see [PokerTableRegistry.lockTable]) so
+ * concurrent button clicks / web POSTs serialise around hand state.
+ *
+ * `chips` on each [Seat] are escrow — the player's `socialCredit` was
+ * debited at buy-in; nothing else touches it until cash-out.
+ */
+class PokerTable(
+    val id: Long,
+    val guildId: Long,
+    val hostDiscordId: Long,
+    val minBuyIn: Long,
+    val maxBuyIn: Long,
+    val smallBlind: Long,
+    val bigBlind: Long,
+    val smallBet: Long,
+    val bigBet: Long,
+    val maxRaisesPerStreet: Int,
+    val maxSeats: Int,
+    var phase: Phase = Phase.WAITING,
+    val seats: MutableList<Seat> = mutableListOf(),
+    val community: MutableList<Card> = mutableListOf(),
+    var pot: Long = 0L,
+    var currentBet: Long = 0L,
+    var raisesThisStreet: Int = 0,
+    var dealerIndex: Int = 0,
+    var actorIndex: Int = 0,
+    var seatsToAct: Int = 0,
+    var deck: Deck? = null,
+    var handNumber: Long = 0L,
+    var lastActivityAt: Instant = Instant.now(),
+    var lastResult: HandResult? = null
+) {
+
+    enum class Phase { WAITING, PRE_FLOP, FLOP, TURN, RIVER }
+
+    enum class SeatStatus { ACTIVE, FOLDED, ALL_IN, SITTING_OUT }
+
+    class Seat(
+        val discordId: Long,
+        var chips: Long,
+        var holeCards: List<Card> = emptyList(),
+        var committedThisRound: Long = 0L,
+        var totalCommittedThisHand: Long = 0L,
+        var status: SeatStatus = SeatStatus.SITTING_OUT
+    )
+
+    /**
+     * Snapshot of how the hand resolved. `winners` may have multiple
+     * entries on a chopped pot. `payoutByDiscordId` is what each winner
+     * netted from the pot (the slice they were credited as chips, after
+     * the rake came off). Seat-level chip mutations have already been
+     * applied to [seats] when this is returned.
+     */
+    data class HandResult(
+        val handNumber: Long,
+        val winners: List<Long>,
+        val payoutByDiscordId: Map<Long, Long>,
+        val pot: Long,
+        val rake: Long,
+        val board: List<Card>,
+        val revealedHoleCards: Map<Long, List<Card>>,
+        val resolvedAt: Instant
+    )
+}

--- a/database/src/main/kotlin/database/poker/PokerTableRegistry.kt
+++ b/database/src/main/kotlin/database/poker/PokerTableRegistry.kt
@@ -1,0 +1,141 @@
+package database.poker
+
+import jakarta.annotation.PreDestroy
+import org.springframework.stereotype.Component
+import java.time.Duration
+import java.time.Instant
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * In-memory book of poker tables (lobby + in-progress hands). Shared
+ * across the whole Spring context so the Discord button handler and
+ * the web controller see the same table state — there is exactly one
+ * authoritative bean.
+ *
+ * Per-table mutations must be performed inside a [lockTable] block so
+ * concurrent button clicks / web POSTs serialise around hand state.
+ *
+ * Tables are flushed by an idle sweeper after [idleTtl] of no activity:
+ * any seated chips are returned to the player's wallet via the supplied
+ * [onIdleEvict] callback (wired by [database.service.PokerService] at
+ * startup so the registry stays Spring-only).
+ *
+ * Mid-flight tables vanish on bot restart. Each player's chips have
+ * been debited from `socialCredit` at buy-in time, so a restart loses
+ * those stakes — acceptable for a casual cash table since tables are
+ * meant to be short-lived and the idle sweep would have cashed them
+ * out anyway.
+ */
+@Component
+class PokerTableRegistry(
+    private val idleTtl: Duration = DEFAULT_IDLE_TTL,
+    private val sweepInterval: Duration = DEFAULT_SWEEP_INTERVAL,
+    private val scheduler: ScheduledExecutorService = Executors.newScheduledThreadPool(2)
+) {
+    private val tables = ConcurrentHashMap<Long, PokerTable>()
+    private val seq = AtomicLong()
+    private var onIdleEvict: ((PokerTable) -> Unit)? = null
+
+    init {
+        scheduler.scheduleAtFixedRate(
+            { runCatching { sweepIdle(Instant.now()) } },
+            sweepInterval.toMillis(),
+            sweepInterval.toMillis(),
+            TimeUnit.MILLISECONDS
+        )
+    }
+
+    /**
+     * Register a per-table cleanup callback invoked when an idle table
+     * is evicted. Wired once at startup by [database.service.PokerService]
+     * so the registry can stay free of Spring-managed dependencies.
+     */
+    fun setOnIdleEvict(callback: (PokerTable) -> Unit) {
+        this.onIdleEvict = callback
+    }
+
+    fun create(
+        guildId: Long,
+        hostDiscordId: Long,
+        minBuyIn: Long,
+        maxBuyIn: Long,
+        smallBlind: Long,
+        bigBlind: Long,
+        smallBet: Long,
+        bigBet: Long,
+        maxRaisesPerStreet: Int,
+        maxSeats: Int,
+        now: Instant = Instant.now()
+    ): PokerTable {
+        val id = seq.incrementAndGet()
+        val table = PokerTable(
+            id = id,
+            guildId = guildId,
+            hostDiscordId = hostDiscordId,
+            minBuyIn = minBuyIn,
+            maxBuyIn = maxBuyIn,
+            smallBlind = smallBlind,
+            bigBlind = bigBlind,
+            smallBet = smallBet,
+            bigBet = bigBet,
+            maxRaisesPerStreet = maxRaisesPerStreet,
+            maxSeats = maxSeats,
+            lastActivityAt = now
+        )
+        tables[id] = table
+        return table
+    }
+
+    fun get(tableId: Long): PokerTable? = tables[tableId]
+
+    fun listForGuild(guildId: Long): List<PokerTable> =
+        tables.values.filter { it.guildId == guildId }
+
+    fun remove(tableId: Long): PokerTable? = tables.remove(tableId)
+
+    /**
+     * Run [action] under the table monitor — every state-mutating
+     * operation (seat, leave, action, start) must go through here so
+     * concurrent Discord button clicks and web POSTs serialise around a
+     * consistent view of the hand.
+     */
+    fun <T> lockTable(tableId: Long, action: (PokerTable) -> T): T? {
+        val table = tables[tableId] ?: return null
+        synchronized(table) {
+            // Re-check under the monitor in case removal raced with us.
+            if (tables[tableId] == null) return null
+            return action(table)
+        }
+    }
+
+    /**
+     * Force-evict every table whose `lastActivityAt` is older than
+     * [idleTtl]. Public + parameterised so tests can drive it without
+     * waiting for the scheduler.
+     */
+    fun sweepIdle(now: Instant) {
+        val cutoff = now.minus(idleTtl)
+        for ((id, table) in tables) {
+            synchronized(table) {
+                if (table.lastActivityAt.isBefore(cutoff)) {
+                    val evicted = tables.remove(id)
+                    if (evicted != null) runCatching { onIdleEvict?.invoke(evicted) }
+                }
+            }
+        }
+    }
+
+    @PreDestroy
+    fun shutdown() {
+        scheduler.shutdownNow()
+    }
+
+    companion object {
+        val DEFAULT_IDLE_TTL: Duration = Duration.ofMinutes(10)
+        val DEFAULT_SWEEP_INTERVAL: Duration = Duration.ofMinutes(1)
+    }
+}

--- a/database/src/main/kotlin/database/poker/PokerTableRegistry.kt
+++ b/database/src/main/kotlin/database/poker/PokerTableRegistry.kt
@@ -33,7 +33,7 @@ import java.util.concurrent.atomic.AtomicLong
 @Component
 class PokerTableRegistry(
     private val idleTtl: Duration = DEFAULT_IDLE_TTL,
-    private val sweepInterval: Duration = DEFAULT_SWEEP_INTERVAL,
+    sweepInterval: Duration = DEFAULT_SWEEP_INTERVAL,
     private val scheduler: ScheduledExecutorService = Executors.newScheduledThreadPool(2)
 ) {
     private val tables = ConcurrentHashMap<Long, PokerTable>()

--- a/database/src/main/kotlin/database/service/PokerService.kt
+++ b/database/src/main/kotlin/database/service/PokerService.kt
@@ -1,0 +1,351 @@
+package database.service
+
+import database.dto.ConfigDto
+import database.dto.PokerHandLogDto
+import database.persistence.PokerHandLogPersistence
+import database.poker.PokerEngine
+import database.poker.PokerEngine.PokerAction
+import database.poker.PokerTable
+import database.poker.PokerTable.SeatStatus
+import database.poker.PokerTableRegistry
+import jakarta.annotation.PostConstruct
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+import kotlin.random.Random
+
+/**
+ * Multiplayer fixed-limit Texas Hold'em over the social-credit economy.
+ *
+ * Lifecycle of a player's chips:
+ *   - [buyIn] — debits `socialCredit` and seats the player at the table
+ *     with that many chips in escrow. Locked via
+ *     [UserService.getUserByIdForUpdate], identical to the casino
+ *     minigame services.
+ *   - [PokerEngine] mutates seat chip counts as hands play out.
+ *   - [cashOut] — only allowed between hands ([PokerTable.Phase.WAITING]) —
+ *     credits the seat's remaining chips back into `socialCredit` and
+ *     removes the seat. The idle-table sweeper does the same thing
+ *     automatically when a table goes quiet for [PokerTableRegistry.DEFAULT_IDLE_TTL].
+ *
+ * Hand resolution flows back through [applyAction] / [startHand]; on a
+ * resolved hand the rake (default 5 %, configurable per guild via
+ * [ConfigDto.Configurations.POKER_RAKE_PCT]) is routed to the existing
+ * per-guild jackpot pool via [JackpotService.addToPool], matching how
+ * `/duel` and the slot machines feed it. A row is appended to
+ * `poker_hand_log` for audit/leaderboard purposes.
+ *
+ * v1 simplifications:
+ *   - Single pot per hand, no side pots. An all-in short stack can
+ *     win the entire pot at showdown — incorrect poker, fine for v1.
+ *   - Buy-in / cash-out only allowed when the table isn't mid-hand.
+ *     If a player wants to leave during a hand, they fold and wait.
+ *   - Auto-topup (sell TOBY to make rent like the other casinos do via
+ *     [CasinoTopUpHelper]) is available at buy-in time only — the chips
+ *     are escrowed once and aren't refilled mid-table.
+ */
+@Service
+class PokerService @Autowired constructor(
+    private val userService: UserService,
+    private val jackpotService: JackpotService,
+    private val configService: ConfigService,
+    private val tableRegistry: PokerTableRegistry,
+    private val handLogPersistence: PokerHandLogPersistence,
+    private val random: Random = Random.Default
+) {
+
+    sealed interface CreateOutcome {
+        data class Ok(val tableId: Long) : CreateOutcome
+        data class InvalidBuyIn(val min: Long, val max: Long) : CreateOutcome
+        data class InsufficientCredits(val have: Long, val needed: Long) : CreateOutcome
+        data object UnknownUser : CreateOutcome
+    }
+
+    sealed interface BuyInOutcome {
+        data class Ok(val seatIndex: Int, val newBalance: Long) : BuyInOutcome
+        data object TableNotFound : BuyInOutcome
+        data object TableFull : BuyInOutcome
+        data object AlreadySeated : BuyInOutcome
+        data class InvalidBuyIn(val min: Long, val max: Long) : BuyInOutcome
+        data class InsufficientCredits(val have: Long, val needed: Long) : BuyInOutcome
+        data object UnknownUser : BuyInOutcome
+    }
+
+    sealed interface CashOutOutcome {
+        data class Ok(val chipsReturned: Long, val newBalance: Long) : CashOutOutcome
+        data object TableNotFound : CashOutOutcome
+        data object NotSeated : CashOutOutcome
+        data object HandInProgress : CashOutOutcome
+    }
+
+    sealed interface StartHandOutcome {
+        data class Ok(val handNumber: Long) : StartHandOutcome
+        data object TableNotFound : StartHandOutcome
+        data object NotHost : StartHandOutcome
+        data object HandAlreadyInProgress : StartHandOutcome
+        data object NotEnoughPlayers : StartHandOutcome
+    }
+
+    sealed interface ActionOutcome {
+        data object Continued : ActionOutcome
+        data class StreetAdvanced(val phase: PokerTable.Phase) : ActionOutcome
+        data class HandResolved(val result: PokerTable.HandResult) : ActionOutcome
+        data class Rejected(val reason: PokerEngine.RejectReason) : ActionOutcome
+        data object TableNotFound : ActionOutcome
+    }
+
+    @PostConstruct
+    fun wireRegistry() {
+        tableRegistry.setOnIdleEvict { table -> evictAllSeats(table) }
+    }
+
+    /**
+     * Create a new table and seat [hostDiscordId] with [buyIn] chips
+     * (debited from `socialCredit`). Combines a [PokerTableRegistry.create]
+     * + [buyIn] in a single user-locked transaction so a half-created
+     * table can never exist.
+     */
+    @Transactional
+    fun createTable(
+        hostDiscordId: Long,
+        guildId: Long,
+        buyIn: Long
+    ): CreateOutcome {
+        if (buyIn < MIN_BUY_IN || buyIn > MAX_BUY_IN) {
+            return CreateOutcome.InvalidBuyIn(MIN_BUY_IN, MAX_BUY_IN)
+        }
+        val user = userService.getUserByIdForUpdate(hostDiscordId, guildId)
+            ?: return CreateOutcome.UnknownUser
+        val balance = user.socialCredit ?: 0L
+        if (balance < buyIn) {
+            return CreateOutcome.InsufficientCredits(have = balance, needed = buyIn)
+        }
+        val table = tableRegistry.create(
+            guildId = guildId,
+            hostDiscordId = hostDiscordId,
+            minBuyIn = MIN_BUY_IN,
+            maxBuyIn = MAX_BUY_IN,
+            smallBlind = SMALL_BLIND,
+            bigBlind = BIG_BLIND,
+            smallBet = SMALL_BET,
+            bigBet = BIG_BET,
+            maxRaisesPerStreet = MAX_RAISES_PER_STREET,
+            maxSeats = MAX_SEATS
+        )
+        // Debit and seat under the same lock so we can't end up with an
+        // empty table after a credit-debit failure.
+        user.socialCredit = balance - buyIn
+        userService.updateUser(user)
+        synchronized(table) {
+            table.seats.add(PokerTable.Seat(discordId = hostDiscordId, chips = buyIn))
+        }
+        return CreateOutcome.Ok(table.id)
+    }
+
+    @Transactional
+    fun buyIn(
+        discordId: Long,
+        guildId: Long,
+        tableId: Long,
+        buyIn: Long
+    ): BuyInOutcome {
+        val table = tableRegistry.get(tableId) ?: return BuyInOutcome.TableNotFound
+        if (table.guildId != guildId) return BuyInOutcome.TableNotFound
+        if (buyIn < table.minBuyIn || buyIn > table.maxBuyIn) {
+            return BuyInOutcome.InvalidBuyIn(table.minBuyIn, table.maxBuyIn)
+        }
+
+        val user = userService.getUserByIdForUpdate(discordId, guildId)
+            ?: return BuyInOutcome.UnknownUser
+        val balance = user.socialCredit ?: 0L
+        if (balance < buyIn) {
+            return BuyInOutcome.InsufficientCredits(have = balance, needed = buyIn)
+        }
+
+        val seatIndex = synchronized(table) {
+            if (table.seats.any { it.discordId == discordId }) return@synchronized -1
+            if (table.seats.size >= table.maxSeats) return@synchronized -2
+            table.seats.add(PokerTable.Seat(discordId = discordId, chips = buyIn))
+            table.seats.size - 1
+        }
+        if (seatIndex == -1) return BuyInOutcome.AlreadySeated
+        if (seatIndex == -2) return BuyInOutcome.TableFull
+
+        user.socialCredit = balance - buyIn
+        userService.updateUser(user)
+        return BuyInOutcome.Ok(seatIndex = seatIndex, newBalance = user.socialCredit ?: 0L)
+    }
+
+    @Transactional
+    fun cashOut(
+        discordId: Long,
+        guildId: Long,
+        tableId: Long
+    ): CashOutOutcome {
+        val table = tableRegistry.get(tableId) ?: return CashOutOutcome.TableNotFound
+        if (table.guildId != guildId) return CashOutOutcome.TableNotFound
+
+        val chipsToReturn = synchronized(table) {
+            if (table.phase != PokerTable.Phase.WAITING) return@synchronized -1L
+            val idx = table.seats.indexOfFirst { it.discordId == discordId }
+            if (idx < 0) return@synchronized -2L
+            val seat = table.seats.removeAt(idx)
+            // Adjust dealer index so the next hand starts in a consistent spot.
+            if (table.seats.isEmpty()) {
+                table.dealerIndex = 0
+            } else if (idx <= table.dealerIndex) {
+                table.dealerIndex = (table.dealerIndex - 1).coerceAtLeast(0) % table.seats.size
+            }
+            seat.chips
+        }
+        if (chipsToReturn == -1L) return CashOutOutcome.HandInProgress
+        if (chipsToReturn == -2L) return CashOutOutcome.NotSeated
+
+        val newBalance = if (chipsToReturn > 0L) {
+            val user = userService.getUserByIdForUpdate(discordId, guildId)
+                ?: return CashOutOutcome.NotSeated
+            user.socialCredit = (user.socialCredit ?: 0L) + chipsToReturn
+            userService.updateUser(user)
+            user.socialCredit ?: 0L
+        } else {
+            userService.getUserById(discordId, guildId)?.socialCredit ?: 0L
+        }
+
+        // Drop empty tables so they don't sit forever in the registry.
+        synchronized(table) {
+            if (table.seats.isEmpty()) tableRegistry.remove(tableId)
+        }
+        return CashOutOutcome.Ok(chipsReturned = chipsToReturn, newBalance = newBalance)
+    }
+
+    /**
+     * Begin the next hand on a table. Only the table host can start a
+     * hand (matches the lobby/host pattern of similar Discord games).
+     */
+    fun startHand(
+        hostDiscordId: Long,
+        guildId: Long,
+        tableId: Long,
+        now: Instant = Instant.now()
+    ): StartHandOutcome {
+        val table = tableRegistry.get(tableId) ?: return StartHandOutcome.TableNotFound
+        if (table.guildId != guildId) return StartHandOutcome.TableNotFound
+        if (table.hostDiscordId != hostDiscordId) return StartHandOutcome.NotHost
+        return synchronized(table) {
+            when (val r = PokerEngine.startHand(table, random, now)) {
+                is PokerEngine.StartResult.Started -> StartHandOutcome.Ok(r.handNumber)
+                PokerEngine.StartResult.HandAlreadyInProgress -> StartHandOutcome.HandAlreadyInProgress
+                PokerEngine.StartResult.NotEnoughPlayers -> StartHandOutcome.NotEnoughPlayers
+            }
+        }
+    }
+
+    /**
+     * Apply a betting action ([PokerAction]) for [discordId] on the
+     * current street. Returns the engine's outcome plus, on a resolved
+     * hand, persists the audit row and routes the rake into the
+     * jackpot pool.
+     */
+    @Transactional
+    fun applyAction(
+        discordId: Long,
+        guildId: Long,
+        tableId: Long,
+        action: PokerAction,
+        now: Instant = Instant.now()
+    ): ActionOutcome {
+        val table = tableRegistry.get(tableId) ?: return ActionOutcome.TableNotFound
+        if (table.guildId != guildId) return ActionOutcome.TableNotFound
+
+        val rakeRate = rakeRate(guildId)
+        val outcome = synchronized(table) {
+            PokerEngine.applyAction(table, discordId, action, rakeRate, now)
+        }
+        return when (outcome) {
+            is PokerEngine.ApplyResult.Rejected -> ActionOutcome.Rejected(outcome.reason)
+            is PokerEngine.ApplyResult.Applied -> when (val ev = outcome.event) {
+                is PokerEngine.ActionEvent.Continued -> ActionOutcome.Continued
+                is PokerEngine.ActionEvent.StreetAdvanced -> ActionOutcome.StreetAdvanced(ev.newPhase)
+                is PokerEngine.ActionEvent.HandResolved -> {
+                    persistResult(table, ev.result)
+                    if (ev.result.rake > 0L) {
+                        jackpotService.addToPool(guildId, ev.result.rake)
+                    }
+                    ActionOutcome.HandResolved(ev.result)
+                }
+            }
+        }
+    }
+
+    /**
+     * Read-only snapshot of [tableId] suitable for the web/JSON layer
+     * (does not mutate; safe to call without [PokerTableRegistry.lockTable]).
+     */
+    fun snapshot(tableId: Long): PokerTable? = tableRegistry.get(tableId)
+
+    /** Pure helper exposed for the embeds layer. */
+    fun rakeRate(guildId: Long): Double {
+        val cfg = configService.getConfigByName(
+            ConfigDto.Configurations.POKER_RAKE_PCT.configValue,
+            guildId.toString()
+        )
+        val pct = cfg?.value?.toDoubleOrNull() ?: return DEFAULT_RAKE
+        return (pct / 100.0).coerceIn(0.0, MAX_RAKE)
+    }
+
+    private fun persistResult(table: PokerTable, result: PokerTable.HandResult) {
+        val playerIds = table.seats.joinToString(",") { it.discordId.toString() }
+        val winnerIds = result.winners.joinToString(",")
+        val board = result.board.joinToString(",") { it.toString() }
+        handLogPersistence.insert(
+            PokerHandLogDto(
+                guildId = table.guildId,
+                tableId = table.id,
+                handNumber = result.handNumber,
+                players = playerIds,
+                winners = winnerIds,
+                pot = result.pot,
+                rake = result.rake,
+                board = board,
+                resolvedAt = result.resolvedAt
+            )
+        )
+    }
+
+    /**
+     * Refund every seated player's chip stack to their wallet and drop
+     * the table. Used by the registry's idle sweeper and the table-host
+     * "force close" path.
+     */
+    @Transactional
+    fun evictAllSeats(table: PokerTable) {
+        val refunds: List<Pair<Long, Long>> = synchronized(table) {
+            // Treat anyone with chips as a refund target. Mid-hand evictions
+            // donate uncalled bets to the survivors via the table pot, but
+            // for an idle wipe we just pay back what's on each stack.
+            val out = table.seats.filter { it.chips > 0L }.map { it.discordId to it.chips }
+            table.seats.clear()
+            out
+        }
+        for ((discordId, amount) in refunds) {
+            val user = userService.getUserByIdForUpdate(discordId, table.guildId) ?: continue
+            user.socialCredit = (user.socialCredit ?: 0L) + amount
+            userService.updateUser(user)
+        }
+    }
+
+    companion object {
+        const val MIN_BUY_IN: Long = 100L
+        const val MAX_BUY_IN: Long = 5_000L
+        const val SMALL_BLIND: Long = 5L
+        const val BIG_BLIND: Long = 10L
+        const val SMALL_BET: Long = 10L
+        const val BIG_BET: Long = 20L
+        const val MAX_RAISES_PER_STREET: Int = 4
+        const val MAX_SEATS: Int = 6
+
+        const val DEFAULT_RAKE: Double = 0.05
+        const val MAX_RAKE: Double = 0.20
+    }
+}

--- a/database/src/main/kotlin/database/service/PokerService.kt
+++ b/database/src/main/kotlin/database/service/PokerService.kt
@@ -6,7 +6,6 @@ import database.persistence.PokerHandLogPersistence
 import database.poker.PokerEngine
 import database.poker.PokerEngine.PokerAction
 import database.poker.PokerTable
-import database.poker.PokerTable.SeatStatus
 import database.poker.PokerTableRegistry
 import jakarta.annotation.PostConstruct
 import org.springframework.beans.factory.annotation.Autowired
@@ -112,7 +111,7 @@ class PokerService @Autowired constructor(
         guildId: Long,
         buyIn: Long
     ): CreateOutcome {
-        if (buyIn < MIN_BUY_IN || buyIn > MAX_BUY_IN) {
+        if (buyIn !in MIN_BUY_IN..MAX_BUY_IN) {
             return CreateOutcome.InvalidBuyIn(MIN_BUY_IN, MAX_BUY_IN)
         }
         val user = userService.getUserByIdForUpdate(hostDiscordId, guildId)

--- a/database/src/main/resources/db/migration/V22__poker_hand_log.sql
+++ b/database/src/main/resources/db/migration/V22__poker_hand_log.sql
@@ -1,0 +1,24 @@
+-- Append-only audit log for every settled poker hand.
+-- A hand row is written exactly once per /poker hand resolution (showdown
+-- OR everyone-folded short-circuit). The actual chip movements happen
+-- on PokerTable seats in memory; the user.social_credit balance is only
+-- touched at /poker buy-in (debit) and /poker leave (credit remaining
+-- chips). This log captures the hand-level outcome for a chart/audit.
+--
+-- `players` and `winners` are comma-separated discord IDs. Multiple
+-- winners only appear on chops where two contenders' best 5-card hands
+-- are exactly equal.
+CREATE TABLE poker_hand_log (
+    id           BIGSERIAL    PRIMARY KEY,
+    guild_id     BIGINT       NOT NULL,
+    table_id     BIGINT       NOT NULL,
+    hand_number  BIGINT       NOT NULL,
+    players      VARCHAR(512) NOT NULL,
+    winners      VARCHAR(512) NOT NULL,
+    pot          BIGINT       NOT NULL CHECK (pot >= 0),
+    rake         BIGINT       NOT NULL DEFAULT 0 CHECK (rake >= 0),
+    board        VARCHAR(64)  NOT NULL,
+    resolved_at  TIMESTAMPTZ  NOT NULL
+);
+CREATE INDEX idx_poker_hand_log_guild_time ON poker_hand_log (guild_id, resolved_at DESC);
+CREATE INDEX idx_poker_hand_log_table      ON poker_hand_log (table_id, hand_number);

--- a/database/src/test/kotlin/database/poker/CardTest.kt
+++ b/database/src/test/kotlin/database/poker/CardTest.kt
@@ -1,0 +1,34 @@
+package database.poker
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class CardTest {
+
+    @Test
+    fun `Card all returns 52 unique cards`() {
+        val all = Card.all()
+        assertEquals(52, all.size)
+        assertEquals(52, all.toSet().size)
+    }
+
+    @Test
+    fun `all 13 ranks across all 4 suits`() {
+        val all = Card.all()
+        assertEquals(4, all.count { it.rank == Rank.ACE })
+        assertEquals(13, all.count { it.suit == Suit.SPADES })
+    }
+
+    @Test
+    fun `Card toString joins rank symbol and suit symbol`() {
+        assertEquals("A♠", Card(Rank.ACE, Suit.SPADES).toString())
+        assertEquals("T♥", Card(Rank.TEN, Suit.HEARTS).toString())
+    }
+
+    @Test
+    fun `Rank values are ordered weakest-to-strongest`() {
+        assertTrue(Rank.TWO.value < Rank.JACK.value)
+        assertTrue(Rank.JACK.value < Rank.ACE.value)
+    }
+}

--- a/database/src/test/kotlin/database/poker/DeckTest.kt
+++ b/database/src/test/kotlin/database/poker/DeckTest.kt
@@ -1,0 +1,37 @@
+package database.poker
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Test
+import kotlin.random.Random
+
+class DeckTest {
+
+    @Test
+    fun `fresh deck has 52 unique cards`() {
+        val cards = Deck(Random(0)).run { deal(52) }
+        assertEquals(52, cards.size)
+        assertEquals(52, cards.toSet().size, "no duplicates")
+    }
+
+    @Test
+    fun `same seed produces same shuffle`() {
+        val a = Deck(Random(1234)).deal(10)
+        val b = Deck(Random(1234)).deal(10)
+        assertEquals(a, b)
+    }
+
+    @Test
+    fun `different seeds produce different shuffles`() {
+        val a = Deck(Random(1234)).deal(10)
+        val b = Deck(Random(5678)).deal(10)
+        assertNotEquals(a, b)
+    }
+
+    @Test
+    fun `deal reduces deck size`() {
+        val deck = Deck(Random(0))
+        deck.deal(7)
+        assertEquals(45, deck.size)
+    }
+}

--- a/database/src/test/kotlin/database/poker/HandEvaluatorTest.kt
+++ b/database/src/test/kotlin/database/poker/HandEvaluatorTest.kt
@@ -1,0 +1,154 @@
+package database.poker
+
+import database.poker.HandEvaluator.Category
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class HandEvaluatorTest {
+
+    private fun c(rank: Rank, suit: Suit) = Card(rank, suit)
+    private fun parse(notation: String): Card {
+        // "AS" = ace of spades, "TH" = ten of hearts.
+        val r = when (notation[0]) {
+            '2' -> Rank.TWO; '3' -> Rank.THREE; '4' -> Rank.FOUR; '5' -> Rank.FIVE
+            '6' -> Rank.SIX; '7' -> Rank.SEVEN; '8' -> Rank.EIGHT; '9' -> Rank.NINE
+            'T' -> Rank.TEN; 'J' -> Rank.JACK; 'Q' -> Rank.QUEEN; 'K' -> Rank.KING
+            'A' -> Rank.ACE; else -> error("bad rank in $notation")
+        }
+        val s = when (notation[1]) {
+            'C' -> Suit.CLUBS; 'D' -> Suit.DIAMONDS; 'H' -> Suit.HEARTS; 'S' -> Suit.SPADES
+            else -> error("bad suit in $notation")
+        }
+        return Card(r, s)
+    }
+
+    private fun hand(vararg notations: String): List<Card> = notations.map(::parse)
+
+    @Test
+    fun `straight flush beats four of a kind`() {
+        val sf = HandEvaluator.scoreFive(hand("9S", "8S", "7S", "6S", "5S"))
+        val quads = HandEvaluator.scoreFive(hand("AS", "AC", "AH", "AD", "KS"))
+        assertEquals(Category.STRAIGHT_FLUSH, sf.category)
+        assertEquals(Category.FOUR_OF_A_KIND, quads.category)
+        assertTrue(sf > quads)
+    }
+
+    @Test
+    fun `royal flush is just an ace-high straight flush`() {
+        val royal = HandEvaluator.scoreFive(hand("AS", "KS", "QS", "JS", "TS"))
+        assertEquals(Category.STRAIGHT_FLUSH, royal.category)
+        assertEquals(listOf(Rank.ACE.value), royal.tiebreakers)
+    }
+
+    @Test
+    fun `wheel A-2-3-4-5 is a five-high straight not ace-high`() {
+        val wheel = HandEvaluator.scoreFive(hand("AS", "2H", "3D", "4C", "5S"))
+        assertEquals(Category.STRAIGHT, wheel.category)
+        assertEquals(listOf(5), wheel.tiebreakers)
+
+        val sixHigh = HandEvaluator.scoreFive(hand("2S", "3H", "4D", "5C", "6S"))
+        assertTrue(sixHigh > wheel, "6-high straight beats the wheel")
+    }
+
+    @Test
+    fun `steel wheel is a 5-high straight flush, weaker than 6-high straight flush`() {
+        val steelWheel = HandEvaluator.scoreFive(hand("AS", "2S", "3S", "4S", "5S"))
+        assertEquals(Category.STRAIGHT_FLUSH, steelWheel.category)
+        assertEquals(listOf(5), steelWheel.tiebreakers)
+
+        val sixHighSF = HandEvaluator.scoreFive(hand("2S", "3S", "4S", "5S", "6S"))
+        assertTrue(sixHighSF > steelWheel)
+    }
+
+    @Test
+    fun `four of a kind tiebreak by quad rank then kicker`() {
+        val fkQueens = HandEvaluator.scoreFive(hand("QS", "QC", "QH", "QD", "2S"))
+        val fkJacksAceKicker = HandEvaluator.scoreFive(hand("JS", "JC", "JH", "JD", "AS"))
+        assertTrue(fkQueens > fkJacksAceKicker, "quad queens beat quad jacks regardless of kicker")
+
+        val fkJacksKingKicker = HandEvaluator.scoreFive(hand("JS", "JC", "JH", "JD", "KS"))
+        assertTrue(fkJacksAceKicker > fkJacksKingKicker, "ace kicker beats king kicker on equal quads")
+    }
+
+    @Test
+    fun `full house compared by trips first then pair`() {
+        val aoeKings = HandEvaluator.scoreFive(hand("AS", "AC", "AH", "KD", "KS")) // aces full of kings
+        val kingsOverAces = HandEvaluator.scoreFive(hand("KS", "KC", "KH", "AD", "AS")) // kings full of aces
+        assertTrue(aoeKings > kingsOverAces)
+    }
+
+    @Test
+    fun `flush vs straight - flush wins`() {
+        val straight = HandEvaluator.scoreFive(hand("9S", "8H", "7D", "6C", "5S"))
+        val flushSeven = HandEvaluator.scoreFive(hand("7H", "5H", "3H", "2H", "9H"))
+        assertTrue(flushSeven > straight)
+    }
+
+    @Test
+    fun `flush tiebreakers run all five ranks descending`() {
+        val flushAce = HandEvaluator.scoreFive(hand("AH", "TH", "9H", "5H", "2H"))
+        val flushKing = HandEvaluator.scoreFive(hand("KH", "QH", "JH", "9H", "5H"))
+        assertTrue(flushAce > flushKing, "ace-high flush beats king-high flush")
+
+        val flushAceTen = HandEvaluator.scoreFive(hand("AH", "TH", "9H", "5H", "2H"))
+        val flushAceNine = HandEvaluator.scoreFive(hand("AH", "9H", "8H", "5H", "2H"))
+        assertTrue(flushAceTen > flushAceNine, "second-highest card breaks the tie")
+    }
+
+    @Test
+    fun `three of a kind tiebreak by trip rank then kickers`() {
+        val tripsAces = HandEvaluator.scoreFive(hand("AS", "AC", "AH", "5D", "2S"))
+        val tripsKings = HandEvaluator.scoreFive(hand("KS", "KC", "KH", "AD", "QS"))
+        assertTrue(tripsAces > tripsKings)
+
+        val tripsAcesAceQueen = HandEvaluator.scoreFive(hand("AS", "AC", "AH", "QD", "JS"))
+        assertTrue(tripsAcesAceQueen > tripsAces, "QJ kickers beat 52 kickers on equal trips")
+    }
+
+    @Test
+    fun `two pair tiebreak by high pair, low pair, then kicker`() {
+        val acesAndKings = HandEvaluator.scoreFive(hand("AS", "AC", "KH", "KD", "2S"))
+        val acesAndQueens = HandEvaluator.scoreFive(hand("AS", "AC", "QH", "QD", "JS"))
+        assertTrue(acesAndKings > acesAndQueens)
+
+        val acesAndKingsHigherKicker = HandEvaluator.scoreFive(hand("AS", "AC", "KH", "KD", "QS"))
+        assertTrue(acesAndKingsHigherKicker > acesAndKings, "kicker breaks tied two pair")
+    }
+
+    @Test
+    fun `pair tiebreak by pair rank then three kickers`() {
+        val pairAces = HandEvaluator.scoreFive(hand("AS", "AC", "QH", "JD", "2S"))
+        val pairKings = HandEvaluator.scoreFive(hand("KS", "KC", "AH", "QD", "JS"))
+        assertTrue(pairAces > pairKings)
+    }
+
+    @Test
+    fun `bestHand picks the strongest 5-from-7`() {
+        // Hole AH AD plus board KH QH JH TH 2C → royal flush!
+        val best = HandEvaluator.bestHand(
+            holeCards = hand("AH", "AD"),
+            board = hand("KH", "QH", "JH", "TH", "2C")
+        )
+        assertEquals(Category.STRAIGHT_FLUSH, best.category)
+        assertEquals(listOf(Rank.ACE.value), best.tiebreakers)
+    }
+
+    @Test
+    fun `bestHand prefers a flush over a pair when both available`() {
+        // Hole 5H 9H, board AH KH 2H 7C 7D → 7s pair OR ace-high flush.
+        val best = HandEvaluator.bestHand(
+            holeCards = hand("5H", "9H"),
+            board = hand("AH", "KH", "2H", "7C", "7D")
+        )
+        assertEquals(Category.FLUSH, best.category)
+    }
+
+    @Test
+    fun `equal hands compare equal regardless of suit`() {
+        val a = HandEvaluator.scoreFive(hand("AS", "KS", "QS", "JS", "9S"))
+        val b = HandEvaluator.scoreFive(hand("AH", "KH", "QH", "JH", "9H"))
+        // Both ace-high flushes with the same ranks — exactly equal.
+        assertEquals(0, a.compareTo(b))
+    }
+}

--- a/database/src/test/kotlin/database/poker/PokerEngineTest.kt
+++ b/database/src/test/kotlin/database/poker/PokerEngineTest.kt
@@ -1,0 +1,268 @@
+package database.poker
+
+import database.poker.PokerEngine.PokerAction
+import database.poker.PokerTable.Phase
+import database.poker.PokerTable.SeatStatus
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import kotlin.random.Random
+
+class PokerEngineTest {
+
+    private val now: Instant = Instant.parse("2026-04-10T10:00:00Z")
+    private val rake = 0.05
+
+    private fun newTable(seatChips: List<Long> = listOf(1000L, 1000L, 1000L)): PokerTable {
+        val table = PokerTable(
+            id = 1L,
+            guildId = 42L,
+            hostDiscordId = 1L,
+            minBuyIn = 100L,
+            maxBuyIn = 5000L,
+            smallBlind = 5L,
+            bigBlind = 10L,
+            smallBet = 10L,
+            bigBet = 20L,
+            maxRaisesPerStreet = 4,
+            maxSeats = 6,
+        )
+        seatChips.forEachIndexed { i, chips ->
+            table.seats.add(PokerTable.Seat(discordId = (i + 1).toLong(), chips = chips))
+        }
+        return table
+    }
+
+    @Test
+    fun `startHand requires at least 2 chip-holding seats`() {
+        val empty = newTable(seatChips = emptyList())
+        assertEquals(PokerEngine.StartResult.NotEnoughPlayers, PokerEngine.startHand(empty, Random(0), now))
+
+        val solo = newTable(seatChips = listOf(1000L))
+        assertEquals(PokerEngine.StartResult.NotEnoughPlayers, PokerEngine.startHand(solo, Random(0), now))
+    }
+
+    @Test
+    fun `startHand cannot start a hand already in progress`() {
+        val table = newTable()
+        PokerEngine.startHand(table, Random(0), now)
+        assertEquals(
+            PokerEngine.StartResult.HandAlreadyInProgress,
+            PokerEngine.startHand(table, Random(0), now)
+        )
+    }
+
+    @Test
+    fun `startHand 3 players posts SB and BB and dealt 2 hole cards each`() {
+        val table = newTable()
+        val r = PokerEngine.startHand(table, Random(0), now)
+        assertTrue(r is PokerEngine.StartResult.Started)
+        assertEquals(Phase.PRE_FLOP, table.phase)
+        assertEquals(15L, table.pot, "SB 5 + BB 10 = 15 pot")
+        assertEquals(10L, table.currentBet)
+        for (seat in table.seats) {
+            assertEquals(2, seat.holeCards.size, "every seat dealt 2 hole cards")
+        }
+        // 3-handed: dealer rotated to 1, SB=2, BB=0, first actor=1 (UTG=dealer position).
+        assertEquals(1, table.dealerIndex)
+        assertEquals(1, table.actorIndex)
+        assertEquals(3, table.seatsToAct)
+    }
+
+    @Test
+    fun `startHand heads-up - dealer is SB and acts first preflop`() {
+        val table = newTable(seatChips = listOf(1000L, 1000L))
+        PokerEngine.startHand(table, Random(0), now)
+        // dealer=1 after rotation, SB also at 1 (HU rule), BB at 0.
+        assertEquals(1, table.dealerIndex)
+        // SB (dealer) acts first preflop.
+        assertEquals(table.dealerIndex, table.actorIndex)
+    }
+
+    @Test
+    fun `everyone folding to one player ends hand without showdown`() {
+        val table = newTable() // 3 players
+        PokerEngine.startHand(table, Random(0), now)
+        // First actor (seat 0) folds.
+        val firstActor = table.seats[table.actorIndex].discordId
+        var r1 = PokerEngine.applyAction(table, firstActor, PokerAction.Fold, rake, now)
+        assertTrue(r1 is PokerEngine.ApplyResult.Applied)
+        // Next actor folds → only one player left, hand resolves immediately to them with no reveals.
+        val nextActor = table.seats[table.actorIndex].discordId
+        val r2 = PokerEngine.applyAction(table, nextActor, PokerAction.Fold, rake, now)
+        assertTrue(r2 is PokerEngine.ApplyResult.Applied)
+        val ev = (r2 as PokerEngine.ApplyResult.Applied).event
+        assertTrue(ev is PokerEngine.ActionEvent.HandResolved)
+        val result = (ev as PokerEngine.ActionEvent.HandResolved).result
+        assertEquals(1, result.winners.size)
+        assertTrue(result.revealedHoleCards.isEmpty(), "no showdown when one player remains")
+        // Pot was SB+BB=15, rake=floor(15*0.05)=0, winner takes 15.
+        assertEquals(15L, result.pot)
+        assertEquals(0L, result.rake)
+        assertEquals(15L, result.payoutByDiscordId.values.single())
+    }
+
+    @Test
+    fun `check round can advance street when no betting action`() {
+        // Set up post-flop where everyone is checked-down
+        val table = newTable(seatChips = listOf(500L, 500L)) // heads-up
+        PokerEngine.startHand(table, Random(0), now)
+        // HU preflop: SB=dealer=1 acts first, owes 5 to call BB.
+        val sbId = table.seats[table.dealerIndex].discordId
+        val bbId = table.seats[(table.dealerIndex + 1) % 2].discordId
+        // SB calls.
+        var r = PokerEngine.applyAction(table, sbId, PokerAction.Call, rake, now)
+        assertEquals(PokerEngine.ActionEvent.Continued, (r as PokerEngine.ApplyResult.Applied).event)
+        // BB checks.
+        r = PokerEngine.applyAction(table, bbId, PokerAction.Check, rake, now)
+        val ev = (r as PokerEngine.ApplyResult.Applied).event
+        assertTrue(ev is PokerEngine.ActionEvent.StreetAdvanced)
+        assertEquals(Phase.FLOP, (ev as PokerEngine.ActionEvent.StreetAdvanced).newPhase)
+        assertEquals(3, table.community.size, "flop dealt 3 community cards")
+    }
+
+    @Test
+    fun `raise resets seatsToAct and locks others into another decision`() {
+        val table = newTable() // 3 players
+        PokerEngine.startHand(table, Random(0), now)
+        val firstActor = table.seats[table.actorIndex].discordId
+        val r = PokerEngine.applyAction(table, firstActor, PokerAction.Raise, rake, now)
+        assertTrue(r is PokerEngine.ApplyResult.Applied)
+        // After a raise from the first actor, the other two still need to respond.
+        assertEquals(2, table.seatsToAct)
+        assertEquals(20L, table.currentBet, "BB 10 + raise 10 small bet = 20")
+        assertEquals(1, table.raisesThisStreet)
+    }
+
+    @Test
+    fun `raise cap rejects further raises`() {
+        val table = newTable(seatChips = listOf(2000L, 2000L))
+        PokerEngine.startHand(table, Random(0), now)
+        var actor = table.seats[table.actorIndex].discordId
+        // Raise 4 times alternating between the two players.
+        repeat(4) {
+            val r = PokerEngine.applyAction(table, actor, PokerAction.Raise, rake, now)
+            assertTrue(r is PokerEngine.ApplyResult.Applied, "raise #${it + 1} should succeed")
+            actor = table.seats[table.actorIndex].discordId
+        }
+        // 5th raise hits the cap.
+        val r5 = PokerEngine.applyAction(table, actor, PokerAction.Raise, rake, now)
+        assertTrue(r5 is PokerEngine.ApplyResult.Rejected)
+        assertEquals(PokerEngine.RejectReason.RAISE_CAP_REACHED, (r5 as PokerEngine.ApplyResult.Rejected).reason)
+    }
+
+    @Test
+    fun `not-your-turn rejection`() {
+        val table = newTable()
+        PokerEngine.startHand(table, Random(0), now)
+        val notTheActor = table.seats.first { table.seats.indexOf(it) != table.actorIndex }.discordId
+        val r = PokerEngine.applyAction(table, notTheActor, PokerAction.Check, rake, now)
+        assertTrue(r is PokerEngine.ApplyResult.Rejected)
+        assertEquals(PokerEngine.RejectReason.NOT_YOUR_TURN, (r as PokerEngine.ApplyResult.Rejected).reason)
+    }
+
+    @Test
+    fun `check rejected when there is a bet to call`() {
+        val table = newTable()
+        PokerEngine.startHand(table, Random(0), now)
+        val actor = table.seats[table.actorIndex].discordId
+        // Pre-flop owes the BB amount to the action.
+        val r = PokerEngine.applyAction(table, actor, PokerAction.Check, rake, now)
+        assertTrue(r is PokerEngine.ApplyResult.Rejected)
+        assertEquals(PokerEngine.RejectReason.ILLEGAL_CHECK, (r as PokerEngine.ApplyResult.Rejected).reason)
+    }
+
+    @Test
+    fun `call rejected when nothing is owed`() {
+        // Engineer a state where call would be illegal: post-flop after both checked.
+        val table = newTable(seatChips = listOf(500L, 500L))
+        PokerEngine.startHand(table, Random(0), now)
+        val sbId = table.seats[table.dealerIndex].discordId
+        val bbId = table.seats[(table.dealerIndex + 1) % 2].discordId
+        PokerEngine.applyAction(table, sbId, PokerAction.Call, rake, now)
+        PokerEngine.applyAction(table, bbId, PokerAction.Check, rake, now)
+        // Now on the flop, first actor postflop is BB (left of dealer in HU).
+        val firstFlopActor = table.seats[table.actorIndex].discordId
+        val r = PokerEngine.applyAction(table, firstFlopActor, PokerAction.Call, rake, now)
+        assertTrue(r is PokerEngine.ApplyResult.Rejected)
+        assertEquals(PokerEngine.RejectReason.ILLEGAL_CALL, (r as PokerEngine.ApplyResult.Rejected).reason)
+    }
+
+    @Test
+    fun `chips conserved across a full hand and rake routed off`() {
+        val table = newTable(seatChips = listOf(500L, 500L))
+        val totalChipsBefore = table.seats.sumOf { it.chips }
+        PokerEngine.startHand(table, Random(42), now)
+        // Both players check-down all four streets.
+        val sbId = table.seats[table.dealerIndex].discordId
+        val bbId = table.seats[(table.dealerIndex + 1) % 2].discordId
+        // Preflop: SB calls, BB checks.
+        PokerEngine.applyAction(table, sbId, PokerAction.Call, rake, now)
+        PokerEngine.applyAction(table, bbId, PokerAction.Check, rake, now)
+        // Flop, Turn, River — both check.
+        for (street in 1..3) {
+            val firstActor = table.seats[table.actorIndex].discordId
+            PokerEngine.applyAction(table, firstActor, PokerAction.Check, rake, now)
+            val secondActor = table.seats[table.actorIndex].discordId
+            val r = PokerEngine.applyAction(table, secondActor, PokerAction.Check, rake, now)
+            // Last check on the river resolves the hand.
+            if (street == 3) {
+                assertTrue((r as PokerEngine.ApplyResult.Applied).event is PokerEngine.ActionEvent.HandResolved)
+            }
+        }
+        val totalChipsAfter = table.seats.sumOf { it.chips }
+        // Pot was 20 (BB ante x 2). Rake = floor(20 * 0.05) = 1.
+        assertEquals(totalChipsBefore - 1L, totalChipsAfter, "exactly the rake is missing")
+        assertEquals(Phase.WAITING, table.phase, "table reset to lobby after resolution")
+        assertNotNull(table.lastResult)
+        assertEquals(1L, table.lastResult!!.rake)
+    }
+
+    @Test
+    fun `resolveHand picks best 5-card hand at showdown`() {
+        // Force a deterministic hand by seeding deck and walking everyone to the river.
+        val table = newTable(seatChips = listOf(500L, 500L))
+        PokerEngine.startHand(table, Random(7), now)
+        val sbId = table.seats[table.dealerIndex].discordId
+        val bbId = table.seats[(table.dealerIndex + 1) % 2].discordId
+        PokerEngine.applyAction(table, sbId, PokerAction.Call, rake, now)
+        PokerEngine.applyAction(table, bbId, PokerAction.Check, rake, now)
+        // Flop, turn, river — both check.
+        for (street in 1..3) {
+            val a = table.seats[table.actorIndex].discordId
+            PokerEngine.applyAction(table, a, PokerAction.Check, rake, now)
+            val b = table.seats[table.actorIndex].discordId
+            PokerEngine.applyAction(table, b, PokerAction.Check, rake, now)
+        }
+        val result = table.lastResult!!
+        assertTrue(result.winners.isNotEmpty(), "showdown picks at least one winner")
+        // Pot=20, rake=1 → winner(s) split 19.
+        assertEquals(19L, result.payoutByDiscordId.values.sum())
+        assertEquals(2, result.revealedHoleCards.size, "showdown reveals both contenders")
+    }
+
+    @Test
+    fun `applyAction on WAITING table is rejected`() {
+        val table = newTable()
+        val r = PokerEngine.applyAction(table, 1L, PokerAction.Check, rake, now)
+        assertTrue(r is PokerEngine.ApplyResult.Rejected)
+        assertEquals(PokerEngine.RejectReason.NO_HAND_IN_PROGRESS, (r as PokerEngine.ApplyResult.Rejected).reason)
+    }
+
+    @Test
+    fun `seat status resets to SITTING_OUT after a hand`() {
+        val table = newTable(seatChips = listOf(500L, 500L))
+        PokerEngine.startHand(table, Random(0), now)
+        // Fold to end immediately.
+        val a = table.seats[table.actorIndex].discordId
+        PokerEngine.applyAction(table, a, PokerAction.Fold, rake, now)
+        for (seat in table.seats) {
+            assertEquals(SeatStatus.SITTING_OUT, seat.status, "all seats reset between hands")
+            assertTrue(seat.holeCards.isEmpty())
+        }
+        assertNull(table.deck)
+    }
+}

--- a/database/src/test/kotlin/database/poker/PokerTableRegistryTest.kt
+++ b/database/src/test/kotlin/database/poker/PokerTableRegistryTest.kt
@@ -1,0 +1,132 @@
+package database.poker
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.time.Instant
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicInteger
+
+class PokerTableRegistryTest {
+
+    private fun newRegistry() = PokerTableRegistry(
+        idleTtl = Duration.ofMinutes(5),
+        sweepInterval = Duration.ofHours(1) // effectively disabled in tests
+    )
+
+    private fun PokerTableRegistry.makeTable(guildId: Long = 42L, host: Long = 1L) =
+        create(
+            guildId = guildId,
+            hostDiscordId = host,
+            minBuyIn = 100L,
+            maxBuyIn = 5000L,
+            smallBlind = 5L,
+            bigBlind = 10L,
+            smallBet = 10L,
+            bigBet = 20L,
+            maxRaisesPerStreet = 4,
+            maxSeats = 6,
+        )
+
+    @Test
+    fun `create assigns increasing ids`() {
+        val reg = newRegistry()
+        val t1 = reg.makeTable()
+        val t2 = reg.makeTable()
+        assertNotEquals(t1.id, t2.id)
+        assertTrue(t2.id > t1.id)
+    }
+
+    @Test
+    fun `get returns the registered table`() {
+        val reg = newRegistry()
+        val t = reg.makeTable()
+        assertEquals(t, reg.get(t.id))
+        assertNull(reg.get(t.id + 999))
+    }
+
+    @Test
+    fun `listForGuild filters by guildId`() {
+        val reg = newRegistry()
+        val a = reg.makeTable(guildId = 1L)
+        val b = reg.makeTable(guildId = 1L)
+        reg.makeTable(guildId = 2L) // different guild
+        val list = reg.listForGuild(1L)
+        assertEquals(setOf(a.id, b.id), list.map { it.id }.toSet())
+    }
+
+    @Test
+    fun `remove drops the table from the registry`() {
+        val reg = newRegistry()
+        val t = reg.makeTable()
+        reg.remove(t.id)
+        assertNull(reg.get(t.id))
+    }
+
+    @Test
+    fun `lockTable serialises mutations across threads`() {
+        val reg = newRegistry()
+        val t = reg.makeTable()
+        val counter = AtomicInteger(0)
+        val pool = Executors.newFixedThreadPool(8)
+        val seen = mutableListOf<Int>()
+        try {
+            val tasks = List(100) {
+                java.util.concurrent.Callable {
+                    reg.lockTable(t.id) { table ->
+                        // Inside the monitor: unsynchronized increment must produce
+                        // monotonically-strictly-increasing observations because no
+                        // two callers can be inside the block at once.
+                        val v = counter.incrementAndGet()
+                        synchronized(seen) { seen.add(v) }
+                        // Touch the table to prove we have the live reference.
+                        table.lastActivityAt = Instant.now()
+                        v
+                    }
+                }
+            }
+            pool.invokeAll(tasks).forEach { it.get() }
+        } finally {
+            pool.shutdown()
+        }
+        assertEquals(100, seen.size)
+        // Strictly increasing — no two threads ran the body in parallel.
+        for (i in 1 until seen.size) {
+            assertTrue(seen[i] > seen[i - 1], "out-of-order observation at index $i: ${seen.subList(0, i+1)}")
+        }
+    }
+
+    @Test
+    fun `sweepIdle evicts stale tables and invokes callback`() {
+        val reg = PokerTableRegistry(
+            idleTtl = Duration.ofSeconds(10),
+            sweepInterval = Duration.ofHours(1)
+        )
+        val evicted = mutableListOf<Long>()
+        reg.setOnIdleEvict { table -> evicted.add(table.id) }
+
+        val stale = reg.makeTable()
+        // Force the lastActivityAt back in time.
+        stale.lastActivityAt = Instant.now().minus(Duration.ofMinutes(1))
+        val fresh = reg.makeTable()
+        fresh.lastActivityAt = Instant.now()
+
+        reg.sweepIdle(Instant.now())
+        assertNull(reg.get(stale.id), "stale table should be removed")
+        assertNotNull(reg.get(fresh.id), "fresh table survives the sweep")
+        assertEquals(listOf(stale.id), evicted)
+    }
+
+    @Test
+    fun `lockTable returns null after table removed`() {
+        val reg = newRegistry()
+        val t = reg.makeTable()
+        reg.remove(t.id)
+        val r = reg.lockTable(t.id) { 7 }
+        assertNull(r)
+    }
+}

--- a/database/src/test/kotlin/database/service/PokerServiceTest.kt
+++ b/database/src/test/kotlin/database/service/PokerServiceTest.kt
@@ -1,0 +1,362 @@
+package database.service
+
+import database.dto.ConfigDto
+import database.dto.PokerHandLogDto
+import database.dto.UserDto
+import database.persistence.PokerHandLogPersistence
+import database.poker.PokerEngine
+import database.poker.PokerTable
+import database.poker.PokerTableRegistry
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import kotlin.random.Random
+
+class PokerServiceTest {
+
+    private val guildId = 42L
+    private val host = 1L
+    private val joiner = 2L
+    private val third = 3L
+
+    private lateinit var userService: RecordingUserService
+    private lateinit var jackpotService: JackpotService
+    private lateinit var configService: ConfigService
+    private lateinit var registry: PokerTableRegistry
+    private lateinit var handLog: RecordingPokerHandLogPersistence
+    private lateinit var service: PokerService
+
+    @BeforeEach
+    fun setup() {
+        userService = RecordingUserService()
+        jackpotService = mockk(relaxed = true)
+        configService = mockk(relaxed = true)
+        registry = PokerTableRegistry(
+            idleTtl = Duration.ofMinutes(5),
+            sweepInterval = Duration.ofHours(1)
+        )
+        handLog = RecordingPokerHandLogPersistence()
+        // Default config — fall back to 5% rake.
+        every {
+            configService.getConfigByName(
+                ConfigDto.Configurations.POKER_RAKE_PCT.configValue,
+                guildId.toString()
+            )
+        } returns null
+        service = PokerService(
+            userService = userService,
+            jackpotService = jackpotService,
+            configService = configService,
+            tableRegistry = registry,
+            handLogPersistence = handLog,
+            random = Random(42)
+        )
+    }
+
+    private fun seed(discordId: Long, balance: Long) {
+        userService.seed(UserDto(discordId, guildId).apply { socialCredit = balance })
+    }
+
+    @Test
+    fun `createTable debits credits and seats the host with chip escrow`() {
+        seed(host, 1000L)
+
+        val outcome = service.createTable(host, guildId, buyIn = 200L)
+
+        assertTrue(outcome is PokerService.CreateOutcome.Ok)
+        val tableId = (outcome as PokerService.CreateOutcome.Ok).tableId
+        val table = registry.get(tableId)!!
+        assertEquals(1, table.seats.size)
+        assertEquals(host, table.seats[0].discordId)
+        assertEquals(200L, table.seats[0].chips)
+        assertEquals(800L, userService.current(host)?.socialCredit, "200 debited from balance")
+    }
+
+    @Test
+    fun `createTable rejects invalid buy-in without seating or debiting`() {
+        seed(host, 1000L)
+        val outcome = service.createTable(host, guildId, buyIn = 1L)
+        assertTrue(outcome is PokerService.CreateOutcome.InvalidBuyIn)
+        assertEquals(0, registry.listForGuild(guildId).size)
+        assertEquals(1000L, userService.current(host)?.socialCredit)
+    }
+
+    @Test
+    fun `createTable rejects insufficient credits without seating`() {
+        seed(host, 50L)
+        val outcome = service.createTable(host, guildId, buyIn = 200L)
+        assertTrue(outcome is PokerService.CreateOutcome.InsufficientCredits)
+        assertEquals(0, registry.listForGuild(guildId).size)
+        assertEquals(50L, userService.current(host)?.socialCredit)
+    }
+
+    @Test
+    fun `buyIn debits credits and seats the player`() {
+        seed(host, 1000L)
+        seed(joiner, 600L)
+        val createOutcome = service.createTable(host, guildId, buyIn = 200L) as PokerService.CreateOutcome.Ok
+
+        val outcome = service.buyIn(joiner, guildId, createOutcome.tableId, buyIn = 300L)
+
+        assertTrue(outcome is PokerService.BuyInOutcome.Ok)
+        outcome as PokerService.BuyInOutcome.Ok
+        assertEquals(300L, userService.current(joiner)?.socialCredit)
+        assertEquals(2, registry.get(createOutcome.tableId)!!.seats.size)
+        assertEquals(300L, outcome.newBalance)
+    }
+
+    @Test
+    fun `buyIn rejects double-seating`() {
+        seed(host, 1000L)
+        val tableId = (service.createTable(host, guildId, buyIn = 200L) as PokerService.CreateOutcome.Ok).tableId
+        val outcome = service.buyIn(host, guildId, tableId, buyIn = 200L)
+        assertEquals(PokerService.BuyInOutcome.AlreadySeated, outcome)
+    }
+
+    @Test
+    fun `buyIn rejects unknown table`() {
+        seed(joiner, 1000L)
+        val outcome = service.buyIn(joiner, guildId, tableId = 999L, buyIn = 200L)
+        assertEquals(PokerService.BuyInOutcome.TableNotFound, outcome)
+    }
+
+    @Test
+    fun `cashOut credits remaining chips back to balance and removes empty tables`() {
+        seed(host, 1000L)
+        val tableId = (service.createTable(host, guildId, buyIn = 200L) as PokerService.CreateOutcome.Ok).tableId
+
+        val outcome = service.cashOut(host, guildId, tableId)
+
+        assertTrue(outcome is PokerService.CashOutOutcome.Ok)
+        outcome as PokerService.CashOutOutcome.Ok
+        assertEquals(200L, outcome.chipsReturned)
+        assertEquals(1000L, outcome.newBalance, "balance restored to original 1000")
+        assertNull(registry.get(tableId), "empty table dropped from registry")
+    }
+
+    @Test
+    fun `cashOut while hand in progress is rejected`() {
+        seed(host, 1000L); seed(joiner, 1000L)
+        val tableId = (service.createTable(host, guildId, buyIn = 500L) as PokerService.CreateOutcome.Ok).tableId
+        service.buyIn(joiner, guildId, tableId, buyIn = 500L)
+        service.startHand(host, guildId, tableId)
+
+        val outcome = service.cashOut(host, guildId, tableId)
+        assertEquals(PokerService.CashOutOutcome.HandInProgress, outcome)
+    }
+
+    @Test
+    fun `cashOut on table you don't sit at is rejected`() {
+        seed(host, 1000L); seed(joiner, 1000L)
+        val tableId = (service.createTable(host, guildId, buyIn = 200L) as PokerService.CreateOutcome.Ok).tableId
+        val outcome = service.cashOut(joiner, guildId, tableId)
+        assertEquals(PokerService.CashOutOutcome.NotSeated, outcome)
+    }
+
+    @Test
+    fun `startHand requires host`() {
+        seed(host, 1000L); seed(joiner, 1000L)
+        val tableId = (service.createTable(host, guildId, buyIn = 500L) as PokerService.CreateOutcome.Ok).tableId
+        service.buyIn(joiner, guildId, tableId, buyIn = 500L)
+
+        val byJoiner = service.startHand(joiner, guildId, tableId)
+        assertEquals(PokerService.StartHandOutcome.NotHost, byJoiner)
+
+        val byHost = service.startHand(host, guildId, tableId)
+        assertTrue(byHost is PokerService.StartHandOutcome.Ok)
+        assertEquals(1L, (byHost as PokerService.StartHandOutcome.Ok).handNumber)
+    }
+
+    @Test
+    fun `applyAction routes rake to jackpot and persists hand log on resolution`() {
+        seed(host, 1000L); seed(joiner, 1000L); seed(third, 1000L)
+        val tableId = (service.createTable(host, guildId, buyIn = 500L) as PokerService.CreateOutcome.Ok).tableId
+        service.buyIn(joiner, guildId, tableId, buyIn = 500L)
+        service.buyIn(third, guildId, tableId, buyIn = 500L)
+        service.startHand(host, guildId, tableId)
+
+        val table = registry.get(tableId)!!
+        // Make all 3 players fold around — winner takes uncontested pot.
+        // Apply two folds to leave one player. Pot is SB+BB=15, rake=floor(15*0.05)=0.
+        val firstActor = table.seats[table.actorIndex].discordId
+        service.applyAction(firstActor, guildId, tableId, PokerEngine.PokerAction.Fold)
+        val secondActor = table.seats[table.actorIndex].discordId
+        val outcome = service.applyAction(secondActor, guildId, tableId, PokerEngine.PokerAction.Fold)
+
+        assertTrue(outcome is PokerService.ActionOutcome.HandResolved)
+        // Tiny pot, rake floors to 0, so jackpot service NOT called.
+        verify(exactly = 0) { jackpotService.addToPool(any(), any()) }
+        assertEquals(1, handLog.inserted.size, "hand log row written")
+        assertEquals(15L, handLog.inserted[0].pot)
+        assertEquals(0L, handLog.inserted[0].rake)
+    }
+
+    @Test
+    fun `applyAction with raise grows pot enough that rake routes to jackpot`() {
+        seed(host, 5000L); seed(joiner, 5000L)
+        val tableId = (service.createTable(host, guildId, buyIn = 2000L) as PokerService.CreateOutcome.Ok).tableId
+        service.buyIn(joiner, guildId, tableId, buyIn = 2000L)
+        service.startHand(host, guildId, tableId)
+
+        val table = registry.get(tableId)!!
+        // HU preflop: dealer (SB) acts first.
+        val sbId = table.seats[table.dealerIndex].discordId
+        val bbId = table.seats[(table.dealerIndex + 1) % 2].discordId
+        // SB raises to 20 → BB raises to 30 → SB raises to 40 → BB raises to 50 (cap) → SB calls.
+        service.applyAction(sbId, guildId, tableId, PokerEngine.PokerAction.Raise)
+        service.applyAction(bbId, guildId, tableId, PokerEngine.PokerAction.Raise)
+        service.applyAction(sbId, guildId, tableId, PokerEngine.PokerAction.Raise)
+        service.applyAction(bbId, guildId, tableId, PokerEngine.PokerAction.Raise)
+        service.applyAction(sbId, guildId, tableId, PokerEngine.PokerAction.Call)
+
+        // Now flop, turn, river — both check.
+        for (street in 1..3) {
+            val a = registry.get(tableId)!!.seats[registry.get(tableId)!!.actorIndex].discordId
+            service.applyAction(a, guildId, tableId, PokerEngine.PokerAction.Check)
+            val b = registry.get(tableId)!!.seats[registry.get(tableId)!!.actorIndex].discordId
+            service.applyAction(b, guildId, tableId, PokerEngine.PokerAction.Check)
+        }
+
+        // Pot = 100 (50 each), rake = floor(100 * 0.05) = 5.
+        verify(exactly = 1) { jackpotService.addToPool(guildId, 5L) }
+        assertEquals(1, handLog.inserted.size)
+        assertEquals(100L, handLog.inserted[0].pot)
+        assertEquals(5L, handLog.inserted[0].rake)
+    }
+
+    @Test
+    fun `applyAction NotYourTurn surfaces engine rejection`() {
+        seed(host, 1000L); seed(joiner, 1000L)
+        val tableId = (service.createTable(host, guildId, buyIn = 500L) as PokerService.CreateOutcome.Ok).tableId
+        service.buyIn(joiner, guildId, tableId, buyIn = 500L)
+        service.startHand(host, guildId, tableId)
+
+        val table = registry.get(tableId)!!
+        val notTurn = table.seats.first { table.seats.indexOf(it) != table.actorIndex }.discordId
+        val outcome = service.applyAction(notTurn, guildId, tableId, PokerEngine.PokerAction.Check)
+        assertTrue(outcome is PokerService.ActionOutcome.Rejected)
+        assertEquals(PokerEngine.RejectReason.NOT_YOUR_TURN, (outcome as PokerService.ActionOutcome.Rejected).reason)
+    }
+
+    @Test
+    fun `applyAction on missing table returns TableNotFound`() {
+        val outcome = service.applyAction(host, guildId, tableId = 999L, action = PokerEngine.PokerAction.Check)
+        assertEquals(PokerService.ActionOutcome.TableNotFound, outcome)
+    }
+
+    @Test
+    fun `evictAllSeats refunds chips to all seated players`() {
+        seed(host, 1000L); seed(joiner, 1000L)
+        val tableId = (service.createTable(host, guildId, buyIn = 200L) as PokerService.CreateOutcome.Ok).tableId
+        service.buyIn(joiner, guildId, tableId, buyIn = 300L)
+        val table = registry.get(tableId)!!
+
+        service.evictAllSeats(table)
+
+        assertEquals(1000L, userService.current(host)?.socialCredit, "host refunded 200")
+        assertEquals(1000L, userService.current(joiner)?.socialCredit, "joiner refunded 300")
+        assertEquals(0, table.seats.size)
+    }
+
+    @Test
+    fun `rakeRate falls back to default when config unset and clamps to MAX`() {
+        // Default
+        assertEquals(0.05, service.rakeRate(guildId), 0.0001)
+        // Unparseable → default
+        every {
+            configService.getConfigByName(ConfigDto.Configurations.POKER_RAKE_PCT.configValue, guildId.toString())
+        } returns ConfigDto(name = "x", value = "asdf", guildId = guildId.toString())
+        assertEquals(0.05, service.rakeRate(guildId), 0.0001)
+        // Above max → clamped
+        every {
+            configService.getConfigByName(ConfigDto.Configurations.POKER_RAKE_PCT.configValue, guildId.toString())
+        } returns ConfigDto(name = "x", value = "99", guildId = guildId.toString())
+        assertEquals(PokerService.MAX_RAKE, service.rakeRate(guildId), 0.0001)
+        // Sane custom value
+        every {
+            configService.getConfigByName(ConfigDto.Configurations.POKER_RAKE_PCT.configValue, guildId.toString())
+        } returns ConfigDto(name = "x", value = "10", guildId = guildId.toString())
+        assertEquals(0.10, service.rakeRate(guildId), 0.0001)
+    }
+
+    @Test
+    fun `wireRegistry hooks the idle-evict callback`() {
+        // Sanity check that the registry would actually call our refund logic
+        // when sweep evicts a table. We exercise the wired callback explicitly
+        // since the scheduler runs on a long interval in tests.
+        seed(host, 1000L)
+        val tableId = (service.createTable(host, guildId, buyIn = 200L) as PokerService.CreateOutcome.Ok).tableId
+        service.wireRegistry()
+        // Force an eviction by backdating activity and sweeping.
+        registry.get(tableId)!!.lastActivityAt = java.time.Instant.now().minus(Duration.ofHours(1))
+        registry.sweepIdle(java.time.Instant.now())
+        assertEquals(1000L, userService.current(host)?.socialCredit, "evicted chips refunded via callback")
+        assertNull(registry.get(tableId), "table removed by sweep")
+    }
+
+    @Test
+    fun `snapshot returns the live table reference`() {
+        seed(host, 1000L)
+        val tableId = (service.createTable(host, guildId, buyIn = 200L) as PokerService.CreateOutcome.Ok).tableId
+        val snap = service.snapshot(tableId)
+        assertNotNull(snap)
+        assertEquals(tableId, snap!!.id)
+        assertNull(service.snapshot(999L))
+    }
+
+    @Test
+    fun `cashOut on an unknown table returns TableNotFound`() {
+        val outcome = service.cashOut(host, guildId, tableId = 999L)
+        assertEquals(PokerService.CashOutOutcome.TableNotFound, outcome)
+    }
+
+    @Test
+    fun `startHand on missing table returns TableNotFound`() {
+        val outcome = service.startHand(host, guildId, tableId = 999L)
+        assertEquals(PokerService.StartHandOutcome.TableNotFound, outcome)
+    }
+
+    @Test
+    fun `buyIn rejects mismatched guild as TableNotFound`() {
+        seed(host, 1000L)
+        val tableId = (service.createTable(host, guildId, buyIn = 200L) as PokerService.CreateOutcome.Ok).tableId
+        // Wrong guild id should not let a player from another server peek into this guild's table.
+        val outcome = service.buyIn(joiner, guildId = 999L, tableId = tableId, buyIn = 200L)
+        assertEquals(PokerService.BuyInOutcome.TableNotFound, outcome)
+        assertFalse(registry.get(tableId)!!.seats.any { it.discordId == joiner })
+    }
+
+    private class RecordingUserService : UserService {
+        private val users = mutableMapOf<Pair<Long, Long>, UserDto>()
+        var updateCount = 0
+            private set
+        fun seed(dto: UserDto) { users[dto.discordId to dto.guildId] = dto }
+        fun current(discordId: Long, guildId: Long = 42L): UserDto? = users[discordId to guildId]
+
+        override fun listGuildUsers(guildId: Long?): List<UserDto?> = users.values.filter { it.guildId == guildId }
+        override fun createNewUser(userDto: UserDto): UserDto = userDto.also(::seed)
+        override fun getUserById(discordId: Long?, guildId: Long?): UserDto? = users[discordId!! to guildId!!]
+        override fun getUserByIdForUpdate(discordId: Long?, guildId: Long?): UserDto? =
+            users[discordId!! to guildId!!]
+        override fun updateUser(userDto: UserDto): UserDto { updateCount++; users[userDto.discordId to userDto.guildId] = userDto; return userDto }
+        override fun deleteUser(userDto: UserDto) { users.remove(userDto.discordId to userDto.guildId) }
+        override fun deleteUserById(discordId: Long?, guildId: Long?) { users.remove(discordId!! to guildId!!) }
+        override fun clearCache() {}
+        override fun evictUserFromCache(discordId: Long?, guildId: Long?) {}
+    }
+
+    private class RecordingPokerHandLogPersistence : PokerHandLogPersistence {
+        val inserted = mutableListOf<PokerHandLogDto>()
+        override fun insert(row: PokerHandLogDto): PokerHandLogDto {
+            inserted.add(row); return row
+        }
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/button/buttons/PokerActionButton.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/button/buttons/PokerActionButton.kt
@@ -1,0 +1,133 @@
+package bot.toby.button.buttons
+
+import bot.toby.command.commands.economy.PokerEmbeds
+import core.button.Button
+import core.button.ButtonContext
+import database.dto.UserDto
+import database.poker.PokerEngine
+import database.poker.PokerTable
+import database.poker.PokerTableRegistry
+import database.service.PokerService
+import database.service.PokerService.ActionOutcome
+import net.dv8tion.jda.api.components.MessageTopLevelComponent
+import net.dv8tion.jda.api.components.actionrow.ActionRow
+import net.dv8tion.jda.api.components.buttons.Button as JdaButton
+import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+/**
+ * Resolves a betting action under a `/poker` hand-state embed. The
+ * action and table id are encoded in the component ID
+ * (`poker:CHECK_CALL:<tableId>` etc.) so the handler is stateless.
+ *
+ * The PEEK action is a no-op against the engine — it just sends the
+ * caller their hole cards in an ephemeral reply, so that everyone at
+ * the table can see the table state without leaking each other's
+ * cards.
+ *
+ * Actor enforcement (turn discipline, valid action shape) lives in
+ * [PokerEngine.applyAction]; this handler just translates the rejection
+ * reasons into a friendly ephemeral message.
+ */
+@Component
+class PokerActionButton @Autowired constructor(
+    private val pokerService: PokerService,
+    private val tableRegistry: PokerTableRegistry,
+) : Button {
+
+    override val name: String get() = PokerEmbeds.BUTTON_NAME
+    override val description: String get() = "Bet/check/call/fold/peek under a /poker hand-state embed."
+
+    override fun handle(ctx: ButtonContext, requestingUserDto: UserDto, deleteDelay: Int) {
+        val event = ctx.event
+        val parsed = PokerEmbeds.parseButtonId(event.componentId) ?: run {
+            event.reply("Couldn't parse this poker button.").setEphemeral(true).queue()
+            return
+        }
+        val table = tableRegistry.get(parsed.tableId)
+        if (table == null || table.guildId != ctx.guild.idLong) {
+            event.reply("This poker table no longer exists.").setEphemeral(true).queue()
+            return
+        }
+
+        if (parsed.action == PokerEmbeds.Action.PEEK) {
+            handlePeek(event, table, requestingUserDto.discordId)
+            return
+        }
+
+        if (table.seats.none { it.discordId == requestingUserDto.discordId }) {
+            event.reply("You aren't seated at this table — `/poker join` first.").setEphemeral(true).queue()
+            return
+        }
+
+        val pokerAction = when (parsed.action) {
+            PokerEmbeds.Action.CHECK_CALL -> {
+                // Auto-pick check vs. call based on whether anything is owed.
+                val seat = table.seats.first { it.discordId == requestingUserDto.discordId }
+                if (table.currentBet > seat.committedThisRound) PokerEngine.PokerAction.Call
+                else PokerEngine.PokerAction.Check
+            }
+            PokerEmbeds.Action.RAISE -> PokerEngine.PokerAction.Raise
+            PokerEmbeds.Action.FOLD -> PokerEngine.PokerAction.Fold
+            PokerEmbeds.Action.PEEK -> return // unreachable, handled above
+        }
+
+        event.deferEdit().queue()
+        val outcome = pokerService.applyAction(
+            discordId = requestingUserDto.discordId,
+            guildId = ctx.guild.idLong,
+            tableId = parsed.tableId,
+            action = pokerAction
+        )
+        when (outcome) {
+            is ActionOutcome.Rejected -> sendError(event, rejectionMessage(outcome.reason))
+            ActionOutcome.TableNotFound -> sendError(event, "This poker table no longer exists.")
+            is ActionOutcome.HandResolved -> {
+                event.message.editMessageEmbeds(PokerEmbeds.resultEmbed(table, outcome.result))
+                    .setComponents(emptyList<MessageTopLevelComponent>())
+                    .queue()
+            }
+            is ActionOutcome.StreetAdvanced, ActionOutcome.Continued -> {
+                // Re-render the embed in place so everyone watching sees the new state.
+                event.message.editMessageEmbeds(PokerEmbeds.handStateEmbed(table))
+                    .setComponents(actionRow(parsed.tableId))
+                    .queue()
+            }
+        }
+    }
+
+    private fun handlePeek(event: ButtonInteractionEvent, table: PokerTable, discordId: Long) {
+        val seat = table.seats.firstOrNull { it.discordId == discordId }
+        if (seat == null) {
+            event.reply("You aren't seated at this table.").setEphemeral(true).queue()
+            return
+        }
+        event.replyEmbeds(PokerEmbeds.peekEmbed(seat.holeCards)).setEphemeral(true).queue()
+    }
+
+    private fun sendError(event: ButtonInteractionEvent, message: String) {
+        event.hook.sendMessageEmbeds(PokerEmbeds.errorEmbed(message)).setEphemeral(true).queue()
+    }
+
+    private fun actionRow(tableId: Long): List<ActionRow> = listOf(
+        ActionRow.of(
+            JdaButton.primary(PokerEmbeds.buttonId(PokerEmbeds.Action.CHECK_CALL, tableId), "Check / Call"),
+            JdaButton.success(PokerEmbeds.buttonId(PokerEmbeds.Action.RAISE, tableId), "Raise"),
+            JdaButton.danger(PokerEmbeds.buttonId(PokerEmbeds.Action.FOLD, tableId), "Fold"),
+            JdaButton.secondary(PokerEmbeds.buttonId(PokerEmbeds.Action.PEEK, tableId), "Peek cards"),
+        )
+    )
+
+    private fun rejectionMessage(reason: PokerEngine.RejectReason): String = when (reason) {
+        PokerEngine.RejectReason.NO_HAND_IN_PROGRESS -> "There's no hand in progress on this table."
+        PokerEngine.RejectReason.NOT_AT_TABLE -> "You aren't seated at this table."
+        PokerEngine.RejectReason.NOT_YOUR_TURN -> "It isn't your turn yet."
+        PokerEngine.RejectReason.ILLEGAL_CHECK -> "You can't check — there's a bet to call."
+        PokerEngine.RejectReason.ILLEGAL_CALL -> "Nothing to call — try Check or Raise."
+        PokerEngine.RejectReason.ILLEGAL_RAISE -> "You can't raise here."
+        PokerEngine.RejectReason.RAISE_CAP_REACHED -> "Raise cap reached for this street."
+        PokerEngine.RejectReason.INSUFFICIENT_CHIPS_TO_CALL -> "Not enough chips to call — fold or buy more credits."
+        PokerEngine.RejectReason.INSUFFICIENT_CHIPS_TO_RAISE -> "Not enough chips to raise — try Call instead."
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/PokerCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/PokerCommand.kt
@@ -7,7 +7,6 @@ import database.dto.UserDto
 import database.poker.PokerTable
 import database.poker.PokerTableRegistry
 import database.service.PokerService
-import database.service.PokerService.ActionOutcome
 import database.service.PokerService.BuyInOutcome
 import database.service.PokerService.CashOutOutcome
 import database.service.PokerService.CreateOutcome
@@ -114,8 +113,7 @@ class PokerCommand @Autowired constructor(
             replyError(event, "Buy-in is required.", deleteDelay); return
         }
         userDtoHelper.calculateUserDto(userDto.discordId, guildId)
-        val outcome = pokerService.createTable(userDto.discordId, guildId, buyIn)
-        when (outcome) {
+        when (val outcome = pokerService.createTable(userDto.discordId, guildId, buyIn)) {
             is CreateOutcome.Ok -> {
                 val table = tableRegistry.get(outcome.tableId)
                     ?: return replyError(event, "Table vanished.", deleteDelay)
@@ -143,8 +141,7 @@ class PokerCommand @Autowired constructor(
         val buyIn = event.getOption(OPT_BUYIN)?.asLong ?: run {
             replyError(event, "Buy-in is required.", deleteDelay); return
         }
-        val outcome = pokerService.buyIn(userDto.discordId, guildId, tableId, buyIn)
-        when (outcome) {
+        when (val outcome = pokerService.buyIn(userDto.discordId, guildId, tableId, buyIn)) {
             is BuyInOutcome.Ok -> {
                 val table = tableRegistry.get(tableId)
                     ?: return replyError(event, "Table vanished.", deleteDelay)
@@ -204,8 +201,7 @@ class PokerCommand @Autowired constructor(
         val tableId = event.getOption(OPT_TABLE)?.asLong ?: run {
             replyError(event, "Table id is required.", deleteDelay); return
         }
-        val outcome = pokerService.cashOut(userDto.discordId, guildId, tableId)
-        when (outcome) {
+        when (val outcome = pokerService.cashOut(userDto.discordId, guildId, tableId)) {
             is CashOutOutcome.Ok -> event.hook.sendMessageEmbeds(
                 PokerEmbeds.infoEmbed(
                     "<@${userDto.discordId}> cashed out **${outcome.chipsReturned}** chips. " +

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/PokerCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/PokerCommand.kt
@@ -1,0 +1,289 @@
+package bot.toby.command.commands.economy
+
+import bot.toby.helpers.UserDtoHelper
+import core.command.Command.Companion.invokeDeleteOnMessageResponse
+import core.command.CommandContext
+import database.dto.UserDto
+import database.poker.PokerTable
+import database.poker.PokerTableRegistry
+import database.service.PokerService
+import database.service.PokerService.ActionOutcome
+import database.service.PokerService.BuyInOutcome
+import database.service.PokerService.CashOutOutcome
+import database.service.PokerService.CreateOutcome
+import database.service.PokerService.StartHandOutcome
+import net.dv8tion.jda.api.components.actionrow.ActionRow
+import net.dv8tion.jda.api.components.buttons.Button
+import net.dv8tion.jda.api.entities.MessageEmbed
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
+import net.dv8tion.jda.api.interactions.commands.OptionType
+import net.dv8tion.jda.api.interactions.commands.build.OptionData
+import net.dv8tion.jda.api.interactions.commands.build.SubcommandData
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+/**
+ * `/poker create|join|start|leave|tables` — multiplayer fixed-limit
+ * Texas Hold'em over the social-credit economy.
+ *
+ * The state machine lives in [database.poker.PokerEngine] and is driven
+ * by [PokerService], which keeps tables in [PokerTableRegistry] (shared
+ * with the web layer) and routes 5 % of every settled pot into the
+ * existing per-guild jackpot pool. Per-turn betting is handled by
+ * [bot.toby.button.buttons.PokerActionButton] under the hand-state
+ * embed posted by `/poker start` (and re-posted on each street).
+ */
+@Component
+class PokerCommand @Autowired constructor(
+    private val pokerService: PokerService,
+    private val tableRegistry: PokerTableRegistry,
+    private val userDtoHelper: UserDtoHelper,
+) : EconomyCommand {
+
+    override val name: String = "poker"
+    override val description: String =
+        "Multiplayer Texas Hold'em (fixed-limit). Buy in, deal hands, take credits from your friends."
+
+    companion object {
+        private const val OPT_BUYIN = "chips"
+        private const val OPT_TABLE = "table"
+
+        private const val SUB_CREATE = "create"
+        private const val SUB_JOIN = "join"
+        private const val SUB_START = "start"
+        private const val SUB_LEAVE = "leave"
+        private const val SUB_TABLES = "tables"
+        private const val SUB_PEEK = "peek"
+    }
+
+    override val subCommands: List<SubcommandData> = listOf(
+        SubcommandData(SUB_CREATE, "Create a new poker table and seat yourself with the given buy-in.")
+            .addOptions(
+                OptionData(OptionType.INTEGER, OPT_BUYIN, "Chips to buy in for", true)
+                    .setMinValue(PokerService.MIN_BUY_IN)
+                    .setMaxValue(PokerService.MAX_BUY_IN)
+            ),
+        SubcommandData(SUB_JOIN, "Join an existing table with a buy-in.")
+            .addOptions(
+                OptionData(OptionType.INTEGER, OPT_TABLE, "Table id", true).setMinValue(1),
+                OptionData(OptionType.INTEGER, OPT_BUYIN, "Chips to buy in for", true)
+                    .setMinValue(PokerService.MIN_BUY_IN)
+                    .setMaxValue(PokerService.MAX_BUY_IN)
+            ),
+        SubcommandData(SUB_START, "Deal the next hand on a table you host.")
+            .addOptions(
+                OptionData(OptionType.INTEGER, OPT_TABLE, "Table id", true).setMinValue(1)
+            ),
+        SubcommandData(SUB_LEAVE, "Cash out your remaining chips and leave a table (between hands only).")
+            .addOptions(
+                OptionData(OptionType.INTEGER, OPT_TABLE, "Table id", true).setMinValue(1)
+            ),
+        SubcommandData(SUB_TABLES, "List active poker tables in this server."),
+        SubcommandData(SUB_PEEK, "Show your hole cards (only visible to you).")
+            .addOptions(
+                OptionData(OptionType.INTEGER, OPT_TABLE, "Table id", true).setMinValue(1)
+            ),
+    )
+
+    override fun handle(ctx: CommandContext, requestingUserDto: UserDto, deleteDelay: Int) {
+        val event = ctx.event
+        event.deferReply().queue()
+
+        val guild = event.guild ?: run {
+            replyError(event, "This command can only be used in a server.", deleteDelay); return
+        }
+
+        when (event.subcommandName) {
+            SUB_CREATE -> handleCreate(event, requestingUserDto, guild.idLong, deleteDelay)
+            SUB_JOIN -> handleJoin(event, requestingUserDto, guild.idLong, deleteDelay)
+            SUB_START -> handleStart(event, requestingUserDto, guild.idLong, deleteDelay)
+            SUB_LEAVE -> handleLeave(event, requestingUserDto, guild.idLong, deleteDelay)
+            SUB_TABLES -> handleTables(event, guild.idLong, deleteDelay)
+            SUB_PEEK -> handlePeek(event, requestingUserDto, guild.idLong)
+            else -> replyError(event, "Unknown subcommand.", deleteDelay)
+        }
+    }
+
+    private fun handleCreate(
+        event: SlashCommandInteractionEvent,
+        userDto: UserDto,
+        guildId: Long,
+        deleteDelay: Int
+    ) {
+        val buyIn = event.getOption(OPT_BUYIN)?.asLong ?: run {
+            replyError(event, "Buy-in is required.", deleteDelay); return
+        }
+        userDtoHelper.calculateUserDto(userDto.discordId, guildId)
+        val outcome = pokerService.createTable(userDto.discordId, guildId, buyIn)
+        when (outcome) {
+            is CreateOutcome.Ok -> {
+                val table = tableRegistry.get(outcome.tableId)
+                    ?: return replyError(event, "Table vanished.", deleteDelay)
+                event.hook.sendMessageEmbeds(PokerEmbeds.lobbyEmbed(table))
+                    .queue(invokeDeleteOnMessageResponse(deleteDelay))
+            }
+            is CreateOutcome.InvalidBuyIn ->
+                replyError(event, "Buy-in must be between ${outcome.min} and ${outcome.max} credits.", deleteDelay)
+            is CreateOutcome.InsufficientCredits ->
+                replyError(event, "You need ${outcome.needed} credits but only have ${outcome.have}.", deleteDelay)
+            CreateOutcome.UnknownUser ->
+                replyError(event, "No user record yet. Try another TobyBot command first.", deleteDelay)
+        }
+    }
+
+    private fun handleJoin(
+        event: SlashCommandInteractionEvent,
+        userDto: UserDto,
+        guildId: Long,
+        deleteDelay: Int
+    ) {
+        val tableId = event.getOption(OPT_TABLE)?.asLong ?: run {
+            replyError(event, "Table id is required.", deleteDelay); return
+        }
+        val buyIn = event.getOption(OPT_BUYIN)?.asLong ?: run {
+            replyError(event, "Buy-in is required.", deleteDelay); return
+        }
+        val outcome = pokerService.buyIn(userDto.discordId, guildId, tableId, buyIn)
+        when (outcome) {
+            is BuyInOutcome.Ok -> {
+                val table = tableRegistry.get(tableId)
+                    ?: return replyError(event, "Table vanished.", deleteDelay)
+                event.hook.sendMessageEmbeds(
+                    PokerEmbeds.infoEmbed("<@${userDto.discordId}> joined table #$tableId with $buyIn chips."),
+                    PokerEmbeds.lobbyEmbed(table)
+                ).queue(invokeDeleteOnMessageResponse(deleteDelay))
+            }
+            is BuyInOutcome.AlreadySeated ->
+                replyError(event, "You're already at this table.", deleteDelay)
+            is BuyInOutcome.TableFull ->
+                replyError(event, "Table #$tableId is full (${PokerService.MAX_SEATS} seats).", deleteDelay)
+            is BuyInOutcome.TableNotFound ->
+                replyError(event, "No such table in this server.", deleteDelay)
+            is BuyInOutcome.InvalidBuyIn ->
+                replyError(event, "Buy-in must be between ${outcome.min} and ${outcome.max} credits.", deleteDelay)
+            is BuyInOutcome.InsufficientCredits ->
+                replyError(event, "You need ${outcome.needed} credits but only have ${outcome.have}.", deleteDelay)
+            BuyInOutcome.UnknownUser ->
+                replyError(event, "No user record yet. Try another TobyBot command first.", deleteDelay)
+        }
+    }
+
+    private fun handleStart(
+        event: SlashCommandInteractionEvent,
+        userDto: UserDto,
+        guildId: Long,
+        deleteDelay: Int
+    ) {
+        val tableId = event.getOption(OPT_TABLE)?.asLong ?: run {
+            replyError(event, "Table id is required.", deleteDelay); return
+        }
+        val outcome = pokerService.startHand(userDto.discordId, guildId, tableId)
+        when (outcome) {
+            is StartHandOutcome.Ok -> {
+                val table = tableRegistry.get(tableId)
+                    ?: return replyError(event, "Table vanished.", deleteDelay)
+                postHandState(event, table, deleteDelay)
+            }
+            StartHandOutcome.NotEnoughPlayers ->
+                replyError(event, "Need at least 2 seated players with chips to deal a hand.", deleteDelay)
+            StartHandOutcome.HandAlreadyInProgress ->
+                replyError(event, "A hand is already in progress on this table.", deleteDelay)
+            StartHandOutcome.NotHost ->
+                replyError(event, "Only the table host can deal hands.", deleteDelay)
+            StartHandOutcome.TableNotFound ->
+                replyError(event, "No such table in this server.", deleteDelay)
+        }
+    }
+
+    private fun handleLeave(
+        event: SlashCommandInteractionEvent,
+        userDto: UserDto,
+        guildId: Long,
+        deleteDelay: Int
+    ) {
+        val tableId = event.getOption(OPT_TABLE)?.asLong ?: run {
+            replyError(event, "Table id is required.", deleteDelay); return
+        }
+        val outcome = pokerService.cashOut(userDto.discordId, guildId, tableId)
+        when (outcome) {
+            is CashOutOutcome.Ok -> event.hook.sendMessageEmbeds(
+                PokerEmbeds.infoEmbed(
+                    "<@${userDto.discordId}> cashed out **${outcome.chipsReturned}** chips. " +
+                        "New balance: ${outcome.newBalance} credits."
+                )
+            ).queue(invokeDeleteOnMessageResponse(deleteDelay))
+            CashOutOutcome.HandInProgress ->
+                replyError(event, "Wait for the current hand to end before leaving (fold first if you don't want to play it out).", deleteDelay)
+            CashOutOutcome.NotSeated ->
+                replyError(event, "You're not seated at this table.", deleteDelay)
+            CashOutOutcome.TableNotFound ->
+                replyError(event, "No such table in this server.", deleteDelay)
+        }
+    }
+
+    private fun handleTables(
+        event: SlashCommandInteractionEvent,
+        guildId: Long,
+        deleteDelay: Int
+    ) {
+        val tables = tableRegistry.listForGuild(guildId)
+        if (tables.isEmpty()) {
+            event.hook.sendMessageEmbeds(
+                PokerEmbeds.infoEmbed("No active poker tables in this server. `/poker create chips:<amount>` to start one.")
+            ).queue(invokeDeleteOnMessageResponse(deleteDelay))
+            return
+        }
+        val description = tables.joinToString("\n") {
+            "• Table #${it.id} — ${it.seats.size}/${it.maxSeats} seats, host <@${it.hostDiscordId}>, phase ${it.phase}"
+        }
+        event.hook.sendMessageEmbeds(PokerEmbeds.infoEmbed(description))
+            .queue(invokeDeleteOnMessageResponse(deleteDelay))
+    }
+
+    private fun handlePeek(
+        event: SlashCommandInteractionEvent,
+        userDto: UserDto,
+        guildId: Long,
+    ) {
+        val tableId = event.getOption(OPT_TABLE)?.asLong ?: run {
+            event.hook.sendMessageEmbeds(PokerEmbeds.errorEmbed("Table id is required."))
+                .setEphemeral(true).queue(); return
+        }
+        val table = tableRegistry.get(tableId)
+        if (table == null || table.guildId != guildId) {
+            event.hook.sendMessageEmbeds(PokerEmbeds.errorEmbed("No such table in this server."))
+                .setEphemeral(true).queue(); return
+        }
+        val seat = table.seats.firstOrNull { it.discordId == userDto.discordId }
+        if (seat == null) {
+            event.hook.sendMessageEmbeds(PokerEmbeds.errorEmbed("You're not seated at this table."))
+                .setEphemeral(true).queue(); return
+        }
+        event.hook.sendMessageEmbeds(PokerEmbeds.peekEmbed(seat.holeCards))
+            .setEphemeral(true).queue()
+    }
+
+    private fun postHandState(
+        event: SlashCommandInteractionEvent,
+        table: PokerTable,
+        deleteDelay: Int
+    ) {
+        val embed: MessageEmbed = PokerEmbeds.handStateEmbed(table)
+        val row = ActionRow.of(
+            Button.primary(PokerEmbeds.buttonId(PokerEmbeds.Action.CHECK_CALL, table.id), "Check / Call"),
+            Button.success(PokerEmbeds.buttonId(PokerEmbeds.Action.RAISE, table.id), "Raise"),
+            Button.danger(PokerEmbeds.buttonId(PokerEmbeds.Action.FOLD, table.id), "Fold"),
+            Button.secondary(PokerEmbeds.buttonId(PokerEmbeds.Action.PEEK, table.id), "Peek cards"),
+        )
+        event.hook.sendMessageEmbeds(embed).addComponents(row).queue(invokeDeleteOnMessageResponse(deleteDelay))
+    }
+
+    private fun replyError(
+        event: SlashCommandInteractionEvent,
+        message: String,
+        deleteDelay: Int
+    ) {
+        event.hook.sendMessageEmbeds(PokerEmbeds.errorEmbed(message))
+            .queue(invokeDeleteOnMessageResponse(deleteDelay))
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/PokerEmbeds.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/PokerEmbeds.kt
@@ -1,0 +1,142 @@
+package bot.toby.command.commands.economy
+
+import database.poker.Card
+import database.poker.PokerTable
+import database.poker.PokerTable.Phase
+import database.service.PokerService
+import net.dv8tion.jda.api.EmbedBuilder
+import net.dv8tion.jda.api.entities.MessageEmbed
+import java.awt.Color
+
+/**
+ * Shared embed/component plumbing for the Discord `/poker` flow.
+ *
+ * Component IDs encode the action and table id:
+ *   `poker:CHECK_CALL:<tableId>`
+ * The `bot.toby.button.buttons.PokerActionButton` handler parses this
+ * back out and routes to [PokerService.applyAction]. The "peek" button
+ * has no game effect — it just sends the clicker an ephemeral list of
+ * their hole cards.
+ */
+internal object PokerEmbeds {
+
+    const val BUTTON_NAME = "poker"
+    private const val BUTTON_DELIM = ":"
+
+    private val TABLE_COLOR = Color(0x2C, 0x3E, 0x50)
+    private val WIN_COLOR = Color(0x57, 0xF2, 0x87)
+    private val NEUTRAL_COLOR = Color(0xA0, 0xA0, 0xB0)
+    private val ERROR_COLOR = Color(0xED, 0x42, 0x45)
+
+    enum class Action { CHECK_CALL, RAISE, FOLD, PEEK }
+
+    fun buttonId(action: Action, tableId: Long): String =
+        listOf(BUTTON_NAME, action.name, tableId.toString()).joinToString(BUTTON_DELIM)
+
+    data class ParsedButtonId(val action: Action, val tableId: Long)
+
+    fun parseButtonId(componentId: String): ParsedButtonId? {
+        val parts = componentId.split(BUTTON_DELIM)
+        if (parts.size != 3 || !parts[0].equals(BUTTON_NAME, ignoreCase = true)) return null
+        val action = runCatching { Action.valueOf(parts[1].uppercase()) }.getOrNull() ?: return null
+        val tableId = parts[2].toLongOrNull() ?: return null
+        return ParsedButtonId(action, tableId)
+    }
+
+    fun lobbyEmbed(table: PokerTable): MessageEmbed = EmbedBuilder()
+        .setTitle("🃏 Poker table #${table.id}")
+        .setDescription(
+            "Fixed-limit Texas Hold'em. Buy-in **${table.minBuyIn}–${table.maxBuyIn}** credits. " +
+                "Blinds **${table.smallBlind}/${table.bigBlind}**, bets **${table.smallBet}/${table.bigBet}** " +
+                "(pre-flop & flop / turn & river)."
+        )
+        .addField("Players", playerList(table), false)
+        .addField(
+            "How to join",
+            "Run `/poker join table:${table.id} chips:<amount>`. " +
+                "Host (<@${table.hostDiscordId}>) starts the hand with `/poker start table:${table.id}`.",
+            false
+        )
+        .setFooter("v1: no side pots — short stacks can win the whole pot at showdown.")
+        .setColor(TABLE_COLOR)
+        .build()
+
+    fun handStateEmbed(table: PokerTable): MessageEmbed {
+        val community = if (table.community.isEmpty()) "—" else table.community.joinToString(" ") { "`$it`" }
+        val actor = table.seats.getOrNull(table.actorIndex)
+        val toAct = actor?.let { "<@${it.discordId}>" } ?: "—"
+        return EmbedBuilder()
+            .setTitle("🃏 Hand #${table.handNumber} • ${phaseLabel(table.phase)}")
+            .setDescription("Pot: **${table.pot}** • Bet to call: **${table.currentBet}**")
+            .addField("Community", community, false)
+            .addField("Seats", seatList(table), false)
+            .addField("To act", toAct, false)
+            .setColor(TABLE_COLOR)
+            .setFooter("Click Check/Call, Raise, or Fold below. Peek to see your hole cards.")
+            .build()
+    }
+
+    fun resultEmbed(table: PokerTable, result: PokerTable.HandResult): MessageEmbed {
+        val board = if (result.board.isEmpty()) "—" else result.board.joinToString(" ") { "`$it`" }
+        val winners = result.winners.joinToString(", ") { "<@$it>" }
+        val payouts = result.payoutByDiscordId.entries.joinToString(", ") { (id, amt) -> "<@$id>: +$amt" }
+        val reveals = if (result.revealedHoleCards.isEmpty()) {
+            "Everyone else folded — winner takes pot uncontested."
+        } else {
+            result.revealedHoleCards.entries.joinToString("\n") { (id, cards) ->
+                "<@$id>: ${cards.joinToString(" ") { "`$it`" }}"
+            }
+        }
+        return EmbedBuilder()
+            .setTitle("🃏 Hand #${result.handNumber} settled")
+            .setDescription("Winners: $winners")
+            .addField("Pot", "${result.pot} (rake ${result.rake} → jackpot)", true)
+            .addField("Payouts", payouts.ifEmpty { "—" }, true)
+            .addField("Board", board, false)
+            .addField("Showdown", reveals, false)
+            .addField("Stacks", seatList(table, includeStatus = false), false)
+            .setColor(WIN_COLOR)
+            .setFooter("Host: /poker start to deal the next hand. /poker leave to cash out.")
+            .build()
+    }
+
+    fun peekEmbed(holeCards: List<Card>): MessageEmbed = EmbedBuilder()
+        .setTitle("🃏 Your hole cards")
+        .setDescription(if (holeCards.isEmpty()) "You haven't been dealt in yet." else holeCards.joinToString(" ") { "`$it`" })
+        .setColor(NEUTRAL_COLOR)
+        .build()
+
+    fun errorEmbed(message: String): MessageEmbed = EmbedBuilder()
+        .setTitle("🃏 Poker")
+        .setDescription(message)
+        .setColor(ERROR_COLOR)
+        .build()
+
+    fun infoEmbed(message: String): MessageEmbed = EmbedBuilder()
+        .setTitle("🃏 Poker")
+        .setDescription(message)
+        .setColor(NEUTRAL_COLOR)
+        .build()
+
+    private fun playerList(table: PokerTable): String =
+        if (table.seats.isEmpty()) "—" else table.seats.joinToString("\n") { "• <@${it.discordId}> (${it.chips} chips)" }
+
+    private fun seatList(table: PokerTable, includeStatus: Boolean = true): String =
+        if (table.seats.isEmpty()) "—" else table.seats.mapIndexed { i, s ->
+            val markers = buildList {
+                if (i == table.dealerIndex) add("D")
+                if (i == table.actorIndex && table.phase != Phase.WAITING) add("●")
+                if (includeStatus && s.status != PokerTable.SeatStatus.SITTING_OUT) add(s.status.name)
+            }.joinToString(" ")
+            val tag = if (markers.isBlank()) "" else " [$markers]"
+            "• <@${s.discordId}> — ${s.chips} chips$tag"
+        }.joinToString("\n")
+
+    private fun phaseLabel(phase: Phase): String = when (phase) {
+        Phase.WAITING -> "Waiting"
+        Phase.PRE_FLOP -> "Pre-flop"
+        Phase.FLOP -> "Flop"
+        Phase.TURN -> "Turn"
+        Phase.RIVER -> "River"
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/moderation/SetConfigCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/moderation/SetConfigCommand.kt
@@ -60,6 +60,7 @@ class SetConfigCommand @Autowired constructor(
                 ConfigDto.Configurations.ACTIVITY_TRACKING -> setActivityTracking(event, optionMapping, deleteDelay)
                 ConfigDto.Configurations.ACTIVITY_TRACKING_NOTIFIED -> Unit
                 ConfigDto.Configurations.JACKPOT_LOSS_TRIBUTE_PCT -> setJackpotLossTribute(event, optionMapping, deleteDelay)
+                ConfigDto.Configurations.POKER_RAKE_PCT -> setPokerRake(event, optionMapping, deleteDelay)
             }
         }
     }
@@ -173,6 +174,30 @@ class SetConfigCommand @Autowired constructor(
             .queue(invokeDeleteOnMessageResponse(deleteDelay))
     }
 
+    private fun setPokerRake(
+        event: SlashCommandInteractionEvent,
+        optionMapping: OptionMapping,
+        deleteDelay: Int
+    ) {
+        val pct = optionMapping.asInt
+        if (pct !in 0..20) {
+            event.hook.sendMessage("Poker rake must be between 0 and 20 (default 5).")
+                .setEphemeral(true).queue(invokeDeleteOnMessageResponse(deleteDelay))
+            return
+        }
+        val configValue = ConfigDto.Configurations.POKER_RAKE_PCT.configValue
+        val guildId = event.guild?.id ?: return
+        val newConfigDto = ConfigDto(configValue, pct.toString(), guildId)
+        val existing = configService.getConfigByName(configValue, guildId)
+        if (existing != null && existing.guildId == newConfigDto.guildId) {
+            configService.updateConfig(newConfigDto)
+        } else {
+            configService.createNewConfig(newConfigDto)
+        }
+        event.hook.sendMessage("Poker rake set to $pct % of every settled pot.")
+            .queue(invokeDeleteOnMessageResponse(deleteDelay))
+    }
+
     private fun setMove(event: SlashCommandInteractionEvent, deleteDelay: Int) {
         val movePropertyName = ConfigDto.Configurations.MOVE.configValue
         val guildId = event.guild?.id ?: return
@@ -244,6 +269,12 @@ class SetConfigCommand @Autowired constructor(
                 OptionType.INTEGER,
                 ConfigDto.Configurations.JACKPOT_LOSS_TRIBUTE_PCT.name.lowercase(Locale.getDefault()),
                 "Percent (0-50) of every lost casino stake routed into the per-guild jackpot pool. Default 10.",
+                false
+            ),
+            OptionData(
+                OptionType.INTEGER,
+                ConfigDto.Configurations.POKER_RAKE_PCT.name.lowercase(Locale.getDefault()),
+                "Percent (0-20) of every settled poker pot routed into the per-guild jackpot pool. Default 5.",
                 false
             )
         )

--- a/discord-bot/src/test/kotlin/bot/toby/button/buttons/PokerActionButtonTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/button/buttons/PokerActionButtonTest.kt
@@ -1,0 +1,240 @@
+package bot.toby.button.buttons
+
+import bot.toby.button.ButtonTest
+import bot.toby.button.ButtonTest.Companion.event
+import bot.toby.button.ButtonTest.Companion.mockGuild
+import bot.toby.button.ButtonTest.Companion.mockHook
+import bot.toby.button.DefaultButtonContext
+import bot.toby.command.commands.economy.PokerEmbeds
+import database.dto.UserDto
+import database.poker.PokerEngine
+import database.poker.PokerTable
+import database.poker.PokerTableRegistry
+import database.service.PokerService
+import database.service.PokerService.ActionOutcome
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import net.dv8tion.jda.api.components.MessageTopLevelComponent
+import net.dv8tion.jda.api.entities.Message
+import net.dv8tion.jda.api.entities.MessageEmbed
+import net.dv8tion.jda.api.requests.restaction.WebhookMessageCreateAction
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class PokerActionButtonTest : ButtonTest {
+
+    private lateinit var pokerService: PokerService
+    private lateinit var tableRegistry: PokerTableRegistry
+    private lateinit var button: PokerActionButton
+
+    private val seatedId = 100L
+    private val guildId = 1L
+    private val tableId = 7L
+
+    private lateinit var message: Message
+
+    @BeforeEach
+    override fun setup() {
+        super.setup()
+        every { mockGuild.idLong } returns guildId
+
+        pokerService = mockk(relaxed = true)
+        tableRegistry = mockk(relaxed = true)
+        button = PokerActionButton(pokerService, tableRegistry)
+
+        message = mockk(relaxed = true)
+        every { event.message } returns message
+
+        val edit = mockk<net.dv8tion.jda.api.requests.restaction.MessageEditAction>(relaxed = true)
+        every { message.editMessageEmbeds(any<MessageEmbed>()) } returns edit
+        every { edit.setComponents(any<Collection<MessageTopLevelComponent>>()) } returns edit
+        every { edit.setComponents(*anyVararg<MessageTopLevelComponent>()) } returns edit
+        every { edit.queue() } just Runs
+
+        val send = mockk<WebhookMessageCreateAction<Message>>(relaxed = true)
+        every { mockHook.sendMessageEmbeds(any<MessageEmbed>(), *anyVararg()) } returns send
+        every { send.setEphemeral(any()) } returns send
+        every { send.queue() } just Runs
+
+        val reply = mockk<net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction>(relaxed = true)
+        every { event.reply(any<String>()) } returns reply
+        every { reply.setEphemeral(any()) } returns reply
+        every { reply.queue() } just Runs
+        every { event.replyEmbeds(any<MessageEmbed>(), *anyVararg()) } returns reply
+
+        val deferEdit = mockk<net.dv8tion.jda.api.requests.restaction.interactions.MessageEditCallbackAction>(relaxed = true)
+        every { event.deferEdit() } returns deferEdit
+        every { deferEdit.queue() } just Runs
+    }
+
+    @AfterEach
+    @Throws(Exception::class)
+    override fun tearDown() {
+        super.tearDown()
+    }
+
+    private fun stubTable(seatChips: List<Pair<Long, Long>> = listOf(seatedId to 1000L)): PokerTable {
+        return PokerTable(
+            id = tableId,
+            guildId = guildId,
+            hostDiscordId = seatedId,
+            minBuyIn = 100L,
+            maxBuyIn = 5000L,
+            smallBlind = 5L,
+            bigBlind = 10L,
+            smallBet = 10L,
+            bigBet = 20L,
+            maxRaisesPerStreet = 4,
+            maxSeats = 6,
+        ).also { t ->
+            seatChips.forEach { (id, chips) ->
+                t.seats.add(PokerTable.Seat(discordId = id, chips = chips))
+            }
+        }
+    }
+
+    @Test
+    fun `unparseable component id sends ephemeral error and does nothing`() {
+        every { event.componentId } returns "garbage"
+
+        button.handle(DefaultButtonContext(event), UserDto(seatedId, guildId), 0)
+
+        verify(exactly = 0) { pokerService.applyAction(any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `missing table sends ephemeral error and does not call service`() {
+        every { event.componentId } returns PokerEmbeds.buttonId(PokerEmbeds.Action.FOLD, tableId)
+        every { tableRegistry.get(tableId) } returns null
+
+        button.handle(DefaultButtonContext(event), UserDto(seatedId, guildId), 0)
+
+        verify(exactly = 0) { pokerService.applyAction(any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `unseated user trying to fold gets ephemeral reject`() {
+        every { event.componentId } returns PokerEmbeds.buttonId(PokerEmbeds.Action.FOLD, tableId)
+        every { tableRegistry.get(tableId) } returns stubTable(seatChips = listOf(999L to 1000L))
+
+        button.handle(DefaultButtonContext(event), UserDto(seatedId, guildId), 0)
+
+        verify(exactly = 0) { pokerService.applyAction(any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `peek replies ephemerally with the seat hole cards and does not touch service`() {
+        every { event.componentId } returns PokerEmbeds.buttonId(PokerEmbeds.Action.PEEK, tableId)
+        every { tableRegistry.get(tableId) } returns stubTable()
+
+        button.handle(DefaultButtonContext(event), UserDto(seatedId, guildId), 0)
+
+        verify(exactly = 0) { pokerService.applyAction(any(), any(), any(), any(), any()) }
+        verify { event.replyEmbeds(any<MessageEmbed>(), *anyVararg()) }
+    }
+
+    @Test
+    fun `peek by unseated user sends ephemeral error`() {
+        every { event.componentId } returns PokerEmbeds.buttonId(PokerEmbeds.Action.PEEK, tableId)
+        every { tableRegistry.get(tableId) } returns stubTable(seatChips = listOf(999L to 1000L))
+
+        button.handle(DefaultButtonContext(event), UserDto(seatedId, guildId), 0)
+
+        verify(exactly = 0) { pokerService.applyAction(any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `check_call resolves to Call when seat owes money`() {
+        every { event.componentId } returns PokerEmbeds.buttonId(PokerEmbeds.Action.CHECK_CALL, tableId)
+        val table = stubTable()
+        // Seat owes 10 (currentBet 10, committed 0).
+        table.currentBet = 10L
+        every { tableRegistry.get(tableId) } returns table
+        every {
+            pokerService.applyAction(seatedId, guildId, tableId, PokerEngine.PokerAction.Call, any())
+        } returns ActionOutcome.Continued
+
+        button.handle(DefaultButtonContext(event), UserDto(seatedId, guildId), 0)
+
+        verify(exactly = 1) {
+            pokerService.applyAction(seatedId, guildId, tableId, PokerEngine.PokerAction.Call, any())
+        }
+    }
+
+    @Test
+    fun `check_call resolves to Check when seat is square`() {
+        every { event.componentId } returns PokerEmbeds.buttonId(PokerEmbeds.Action.CHECK_CALL, tableId)
+        val table = stubTable()
+        table.currentBet = 10L
+        table.seats[0].committedThisRound = 10L
+        every { tableRegistry.get(tableId) } returns table
+        every {
+            pokerService.applyAction(seatedId, guildId, tableId, PokerEngine.PokerAction.Check, any())
+        } returns ActionOutcome.Continued
+
+        button.handle(DefaultButtonContext(event), UserDto(seatedId, guildId), 0)
+
+        verify(exactly = 1) {
+            pokerService.applyAction(seatedId, guildId, tableId, PokerEngine.PokerAction.Check, any())
+        }
+    }
+
+    @Test
+    fun `fold dispatches Fold and edits the message in place`() {
+        every { event.componentId } returns PokerEmbeds.buttonId(PokerEmbeds.Action.FOLD, tableId)
+        every { tableRegistry.get(tableId) } returns stubTable()
+        every {
+            pokerService.applyAction(seatedId, guildId, tableId, PokerEngine.PokerAction.Fold, any())
+        } returns ActionOutcome.Continued
+
+        button.handle(DefaultButtonContext(event), UserDto(seatedId, guildId), 0)
+
+        verify(exactly = 1) {
+            pokerService.applyAction(seatedId, guildId, tableId, PokerEngine.PokerAction.Fold, any())
+        }
+        verify { message.editMessageEmbeds(any<MessageEmbed>()) }
+    }
+
+    @Test
+    fun `service rejection surfaces ephemeral error without editing the message`() {
+        every { event.componentId } returns PokerEmbeds.buttonId(PokerEmbeds.Action.FOLD, tableId)
+        every { tableRegistry.get(tableId) } returns stubTable()
+        every {
+            pokerService.applyAction(seatedId, guildId, tableId, PokerEngine.PokerAction.Fold, any())
+        } returns ActionOutcome.Rejected(PokerEngine.RejectReason.NOT_YOUR_TURN)
+
+        button.handle(DefaultButtonContext(event), UserDto(seatedId, guildId), 0)
+
+        // Hook send was used for ephemeral error (not message edit).
+        verify(exactly = 0) { message.editMessageEmbeds(any<MessageEmbed>()) }
+        verify { mockHook.sendMessageEmbeds(any<MessageEmbed>(), *anyVararg()) }
+    }
+
+    @Test
+    fun `hand resolved edits the message with result and clears components`() {
+        every { event.componentId } returns PokerEmbeds.buttonId(PokerEmbeds.Action.FOLD, tableId)
+        val table = stubTable(seatChips = listOf(seatedId to 1000L, 200L to 1000L))
+        every { tableRegistry.get(tableId) } returns table
+        val result = PokerTable.HandResult(
+            handNumber = 1L,
+            winners = listOf(seatedId),
+            payoutByDiscordId = mapOf(seatedId to 95L),
+            pot = 100L,
+            rake = 5L,
+            board = emptyList(),
+            revealedHoleCards = emptyMap(),
+            resolvedAt = java.time.Instant.now()
+        )
+        every {
+            pokerService.applyAction(seatedId, guildId, tableId, PokerEngine.PokerAction.Fold, any())
+        } returns ActionOutcome.HandResolved(result)
+
+        button.handle(DefaultButtonContext(event), UserDto(seatedId, guildId), 0)
+
+        verify { message.editMessageEmbeds(any<MessageEmbed>()) }
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/economy/PokerCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/economy/PokerCommandTest.kt
@@ -1,0 +1,194 @@
+package bot.toby.command.commands.economy
+
+import bot.toby.command.CommandTest
+import bot.toby.command.CommandTest.Companion.event
+import bot.toby.command.CommandTest.Companion.guild
+import bot.toby.command.DefaultCommandContext
+import bot.toby.helpers.UserDtoHelper
+import database.dto.UserDto
+import database.poker.PokerTable
+import database.poker.PokerTableRegistry
+import database.service.PokerService
+import database.service.PokerService.BuyInOutcome
+import database.service.PokerService.CashOutOutcome
+import database.service.PokerService.CreateOutcome
+import database.service.PokerService.StartHandOutcome
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import net.dv8tion.jda.api.interactions.commands.OptionMapping
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class PokerCommandTest : CommandTest {
+
+    private lateinit var pokerService: PokerService
+    private lateinit var tableRegistry: PokerTableRegistry
+    private lateinit var userDtoHelper: UserDtoHelper
+    private lateinit var command: PokerCommand
+
+    private val hostId = 1L
+    private val guildId = 42L
+
+    @BeforeEach
+    fun setUp() {
+        setUpCommonMocks()
+        pokerService = mockk(relaxed = true)
+        tableRegistry = mockk(relaxed = true)
+        userDtoHelper = mockk(relaxed = true)
+        command = PokerCommand(pokerService, tableRegistry, userDtoHelper)
+        every { guild.idLong } returns guildId
+    }
+
+    @AfterEach
+    fun tearDown() {
+        tearDownCommonMocks()
+        clearAllMocks()
+    }
+
+    private fun intOpt(value: Long): OptionMapping {
+        val o = mockk<OptionMapping>(relaxed = true)
+        every { o.asLong } returns value
+        return o
+    }
+
+    private fun userDto() = UserDto(discordId = hostId, guildId = guildId).apply { socialCredit = 1000L }
+
+    private fun stubTable(tableId: Long): PokerTable = PokerTable(
+        id = tableId,
+        guildId = guildId,
+        hostDiscordId = hostId,
+        minBuyIn = 100L,
+        maxBuyIn = 5000L,
+        smallBlind = 5L,
+        bigBlind = 10L,
+        smallBet = 10L,
+        bigBet = 20L,
+        maxRaisesPerStreet = 4,
+        maxSeats = 6,
+    )
+
+    @Test
+    fun `create subcommand happy path delegates to PokerService and posts lobby embed`() {
+        every { event.subcommandName } returns "create"
+        every { event.getOption("chips") } returns intOpt(200L)
+        every { pokerService.createTable(hostId, guildId, 200L) } returns CreateOutcome.Ok(tableId = 7L)
+        every { tableRegistry.get(7L) } returns stubTable(7L)
+
+        command.handle(DefaultCommandContext(event), userDto(), 0)
+
+        verify(exactly = 1) { pokerService.createTable(hostId, guildId, 200L) }
+        verify(exactly = 1) { tableRegistry.get(7L) }
+    }
+
+    @Test
+    fun `create with insufficient credits surfaces error and does not look up table`() {
+        every { event.subcommandName } returns "create"
+        every { event.getOption("chips") } returns intOpt(200L)
+        every { pokerService.createTable(hostId, guildId, 200L) } returns
+            CreateOutcome.InsufficientCredits(have = 50L, needed = 200L)
+
+        command.handle(DefaultCommandContext(event), userDto(), 0)
+
+        verify(exactly = 0) { tableRegistry.get(any()) }
+    }
+
+    @Test
+    fun `join subcommand delegates to PokerService buyIn`() {
+        every { event.subcommandName } returns "join"
+        every { event.getOption("table") } returns intOpt(7L)
+        every { event.getOption("chips") } returns intOpt(300L)
+        every { pokerService.buyIn(hostId, guildId, 7L, 300L) } returns
+            BuyInOutcome.Ok(seatIndex = 1, newBalance = 700L)
+        every { tableRegistry.get(7L) } returns stubTable(7L)
+
+        command.handle(DefaultCommandContext(event), userDto(), 0)
+
+        verify(exactly = 1) { pokerService.buyIn(hostId, guildId, 7L, 300L) }
+    }
+
+    @Test
+    fun `join with already-seated does not look up table`() {
+        every { event.subcommandName } returns "join"
+        every { event.getOption("table") } returns intOpt(7L)
+        every { event.getOption("chips") } returns intOpt(300L)
+        every { pokerService.buyIn(hostId, guildId, 7L, 300L) } returns BuyInOutcome.AlreadySeated
+
+        command.handle(DefaultCommandContext(event), userDto(), 0)
+
+        // Failure branch: no further lookups.
+        verify(exactly = 0) { tableRegistry.get(any()) }
+    }
+
+    @Test
+    fun `start subcommand delegates to PokerService startHand and looks up table`() {
+        every { event.subcommandName } returns "start"
+        every { event.getOption("table") } returns intOpt(7L)
+        every { pokerService.startHand(hostId, guildId, 7L) } returns StartHandOutcome.Ok(handNumber = 1L)
+        every { tableRegistry.get(7L) } returns stubTable(7L)
+
+        command.handle(DefaultCommandContext(event), userDto(), 0)
+
+        verify(exactly = 1) { pokerService.startHand(hostId, guildId, 7L) }
+    }
+
+    @Test
+    fun `start by non-host does not call tableRegistry get`() {
+        every { event.subcommandName } returns "start"
+        every { event.getOption("table") } returns intOpt(7L)
+        every { pokerService.startHand(hostId, guildId, 7L) } returns StartHandOutcome.NotHost
+
+        command.handle(DefaultCommandContext(event), userDto(), 0)
+
+        verify(exactly = 0) { tableRegistry.get(any()) }
+    }
+
+    @Test
+    fun `leave subcommand delegates to PokerService cashOut`() {
+        every { event.subcommandName } returns "leave"
+        every { event.getOption("table") } returns intOpt(7L)
+        every { pokerService.cashOut(hostId, guildId, 7L) } returns
+            CashOutOutcome.Ok(chipsReturned = 200L, newBalance = 1200L)
+
+        command.handle(DefaultCommandContext(event), userDto(), 0)
+
+        verify(exactly = 1) { pokerService.cashOut(hostId, guildId, 7L) }
+    }
+
+    @Test
+    fun `tables subcommand renders registry list`() {
+        every { event.subcommandName } returns "tables"
+        every { tableRegistry.listForGuild(guildId) } returns listOf(stubTable(7L), stubTable(8L))
+
+        command.handle(DefaultCommandContext(event), userDto(), 0)
+
+        verify(exactly = 1) { tableRegistry.listForGuild(guildId) }
+    }
+
+    @Test
+    fun `peek subcommand uses table registry but never calls service`() {
+        every { event.subcommandName } returns "peek"
+        every { event.getOption("table") } returns intOpt(7L)
+        val table = stubTable(7L).apply {
+            seats.add(PokerTable.Seat(discordId = hostId, chips = 1000L, holeCards = emptyList()))
+        }
+        every { tableRegistry.get(7L) } returns table
+
+        command.handle(DefaultCommandContext(event), userDto(), 0)
+
+        verify(exactly = 0) { pokerService.applyAction(any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `unknown subcommand returns error without dispatching`() {
+        every { event.subcommandName } returns "wibble"
+
+        command.handle(DefaultCommandContext(event), userDto(), 0)
+
+        verify(exactly = 0) { pokerService.createTable(any(), any(), any()) }
+        verify(exactly = 0) { pokerService.buyIn(any(), any(), any(), any()) }
+        verify(exactly = 0) { pokerService.startHand(any(), any(), any(), any()) }
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/economy/PokerCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/economy/PokerCommandTest.kt
@@ -126,19 +126,20 @@ internal class PokerCommandTest : CommandTest {
     fun `start subcommand delegates to PokerService startHand and looks up table`() {
         every { event.subcommandName } returns "start"
         every { event.getOption("table") } returns intOpt(7L)
-        every { pokerService.startHand(hostId, guildId, 7L) } returns StartHandOutcome.Ok(handNumber = 1L)
+        every { pokerService.startHand(hostId, guildId, 7L, any()) } returns
+            StartHandOutcome.Ok(handNumber = 1L)
         every { tableRegistry.get(7L) } returns stubTable(7L)
 
         command.handle(DefaultCommandContext(event), userDto(), 0)
 
-        verify(exactly = 1) { pokerService.startHand(hostId, guildId, 7L) }
+        verify(exactly = 1) { pokerService.startHand(hostId, guildId, 7L, any()) }
     }
 
     @Test
     fun `start by non-host does not call tableRegistry get`() {
         every { event.subcommandName } returns "start"
         every { event.getOption("table") } returns intOpt(7L)
-        every { pokerService.startHand(hostId, guildId, 7L) } returns StartHandOutcome.NotHost
+        every { pokerService.startHand(hostId, guildId, 7L, any()) } returns StartHandOutcome.NotHost
 
         command.handle(DefaultCommandContext(event), userDto(), 0)
 

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/economy/PokerEmbedsTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/economy/PokerEmbedsTest.kt
@@ -1,0 +1,109 @@
+package bot.toby.command.commands.economy
+
+import database.poker.Card
+import database.poker.PokerTable
+import database.poker.Rank
+import database.poker.Suit
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class PokerEmbedsTest {
+
+    @Test
+    fun `buttonId encodes action and table id`() {
+        val id = PokerEmbeds.buttonId(PokerEmbeds.Action.FOLD, tableId = 7L)
+        assertEquals("poker:FOLD:7", id)
+    }
+
+    @Test
+    fun `parseButtonId round-trips every action`() {
+        for (action in PokerEmbeds.Action.entries) {
+            val encoded = PokerEmbeds.buttonId(action, tableId = 42L)
+            val parsed = PokerEmbeds.parseButtonId(encoded)
+            assertNotNull(parsed)
+            assertEquals(action, parsed!!.action)
+            assertEquals(42L, parsed.tableId)
+        }
+    }
+
+    @Test
+    fun `parseButtonId rejects malformed ids`() {
+        assertNull(PokerEmbeds.parseButtonId("nope"))
+        assertNull(PokerEmbeds.parseButtonId("poker:UNKNOWN_ACTION:1"))
+        assertNull(PokerEmbeds.parseButtonId("poker:FOLD:notanumber"))
+        assertNull(PokerEmbeds.parseButtonId("notpoker:FOLD:1"))
+    }
+
+    @Test
+    fun `lobbyEmbed renders and includes table id`() {
+        val table = stubTable()
+        val embed = PokerEmbeds.lobbyEmbed(table)
+        assertTrue(embed.title!!.contains("#${table.id}"))
+    }
+
+    @Test
+    fun `peekEmbed handles empty hand gracefully`() {
+        val embed = PokerEmbeds.peekEmbed(emptyList())
+        assertTrue(embed.description!!.contains("haven't been dealt"))
+    }
+
+    @Test
+    fun `peekEmbed lists the cards when present`() {
+        val embed = PokerEmbeds.peekEmbed(listOf(Card(Rank.ACE, Suit.SPADES)))
+        assertTrue(embed.description!!.contains("A♠"))
+    }
+
+    @Test
+    fun `errorEmbed and infoEmbed produce distinct titles or colors`() {
+        val err = PokerEmbeds.errorEmbed("boom")
+        val info = PokerEmbeds.infoEmbed("ok")
+        assertTrue(err.description!!.contains("boom"))
+        assertTrue(info.description!!.contains("ok"))
+    }
+
+    @Test
+    fun `handStateEmbed and resultEmbed render without throwing`() {
+        val table = stubTable().apply {
+            phase = PokerTable.Phase.FLOP
+            community.add(Card(Rank.ACE, Suit.SPADES))
+            seats.add(PokerTable.Seat(discordId = 1L, chips = 500L))
+            seats.add(PokerTable.Seat(discordId = 2L, chips = 500L))
+            actorIndex = 0
+            currentBet = 10L
+            pot = 30L
+            handNumber = 3L
+        }
+        val state = PokerEmbeds.handStateEmbed(table)
+        assertTrue(state.title!!.contains("Hand #3"))
+
+        val result = PokerTable.HandResult(
+            handNumber = 3L,
+            winners = listOf(1L),
+            payoutByDiscordId = mapOf(1L to 28L),
+            pot = 30L,
+            rake = 2L,
+            board = listOf(Card(Rank.ACE, Suit.SPADES)),
+            revealedHoleCards = mapOf(1L to listOf(Card(Rank.KING, Suit.HEARTS))),
+            resolvedAt = java.time.Instant.now()
+        )
+        val rendered = PokerEmbeds.resultEmbed(table, result)
+        assertTrue(rendered.title!!.contains("Hand #3 settled"))
+    }
+
+    private fun stubTable() = PokerTable(
+        id = 11L,
+        guildId = 42L,
+        hostDiscordId = 1L,
+        minBuyIn = 100L,
+        maxBuyIn = 5000L,
+        smallBlind = 5L,
+        bigBlind = 10L,
+        smallBet = 10L,
+        bigBet = 20L,
+        maxRaisesPerStreet = 4,
+        maxSeats = 6,
+    )
+}

--- a/web/src/main/kotlin/web/configuration/WebSecurityConfig.kt
+++ b/web/src/main/kotlin/web/configuration/WebSecurityConfig.kt
@@ -26,6 +26,7 @@ class WebSecurityConfig {
                 auth.requestMatchers("/economy/**").authenticated()
                 auth.requestMatchers("/tip/**").authenticated()
                 auth.requestMatchers("/duel/**").authenticated()
+                auth.requestMatchers("/poker/**").authenticated()
                 auth.anyRequest().authenticated()
             }
             .oauth2Login { oauth2 ->

--- a/web/src/main/kotlin/web/controller/PokerController.kt
+++ b/web/src/main/kotlin/web/controller/PokerController.kt
@@ -1,0 +1,352 @@
+package web.controller
+
+import database.poker.PokerEngine
+import database.poker.PokerTable
+import database.service.PokerService
+import database.service.PokerService.ActionOutcome
+import database.service.PokerService.BuyInOutcome
+import database.service.PokerService.CashOutOutcome
+import database.service.PokerService.CreateOutcome
+import database.service.PokerService.StartHandOutcome
+import database.service.UserService
+import net.dv8tion.jda.api.JDA
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient
+import org.springframework.security.oauth2.client.annotation.RegisteredOAuth2AuthorizedClient
+import org.springframework.security.oauth2.core.user.OAuth2User
+import org.springframework.stereotype.Controller
+import org.springframework.ui.Model
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseBody
+import org.springframework.web.servlet.mvc.support.RedirectAttributes
+import web.service.EconomyWebService
+import web.service.PokerWebService
+import web.util.discordIdOrNull
+import web.util.displayName
+
+/**
+ * Web surface for /poker. Same [PokerService] the Discord command uses,
+ * and the same in-memory [database.poker.PokerTableRegistry] — a hand
+ * dealt in Discord can be played from the web inbox and vice versa.
+ *
+ * The viewer's own hole cards are projected by [PokerWebService] under
+ * a server-side mask so other players' cards never leave the JVM in
+ * the JSON snapshot. The browser polls `/poker/{guildId}/{tableId}/state`
+ * every 2s for live updates.
+ */
+@Controller
+@RequestMapping("/poker")
+class PokerController(
+    private val pokerService: PokerService,
+    private val pokerWebService: PokerWebService,
+    private val economyWebService: EconomyWebService,
+    private val userService: UserService,
+    private val jda: JDA,
+) {
+    @GetMapping("/guilds")
+    fun guildList(
+        @RegisteredOAuth2AuthorizedClient("discord") client: OAuth2AuthorizedClient,
+        @AuthenticationPrincipal user: OAuth2User,
+        model: Model,
+    ): String {
+        val discordId = user.discordIdOrNull()
+        val guilds = if (discordId != null) {
+            economyWebService.getGuildsWhereUserCanView(client.accessToken.tokenValue, discordId)
+        } else emptyList()
+        model.addAttribute("guilds", guilds)
+        model.addAttribute("username", user.displayName())
+        return "poker-guilds"
+    }
+
+    @GetMapping("/{guildId}")
+    fun lobby(
+        @PathVariable guildId: Long,
+        @AuthenticationPrincipal user: OAuth2User,
+        model: Model,
+        ra: RedirectAttributes,
+    ): String {
+        val discordId = user.discordIdOrNull()
+            ?: return "redirect:/poker/guilds"
+        if (!economyWebService.isMember(discordId, guildId)) {
+            ra.addFlashAttribute("error", "You are not a member of that server.")
+            return "redirect:/poker/guilds"
+        }
+        val guild = jda.getGuildById(guildId) ?: run {
+            ra.addFlashAttribute("error", "Bot is not in that server.")
+            return "redirect:/poker/guilds"
+        }
+
+        val profile = userService.getUserById(discordId, guildId)
+        model.addAttribute("guildId", guildId.toString())
+        model.addAttribute("guildName", guild.name)
+        model.addAttribute("balance", profile?.socialCredit ?: 0L)
+        model.addAttribute("minBuyIn", PokerService.MIN_BUY_IN)
+        model.addAttribute("maxBuyIn", PokerService.MAX_BUY_IN)
+        model.addAttribute("smallBlind", PokerService.SMALL_BLIND)
+        model.addAttribute("bigBlind", PokerService.BIG_BLIND)
+        model.addAttribute("smallBet", PokerService.SMALL_BET)
+        model.addAttribute("bigBet", PokerService.BIG_BET)
+        model.addAttribute("maxSeats", PokerService.MAX_SEATS)
+        model.addAttribute("tables", pokerWebService.listGuildTables(guildId))
+        model.addAttribute("username", user.displayName())
+        return "poker-lobby"
+    }
+
+    @GetMapping("/{guildId}/{tableId}")
+    fun tablePage(
+        @PathVariable guildId: Long,
+        @PathVariable tableId: Long,
+        @AuthenticationPrincipal user: OAuth2User,
+        model: Model,
+        ra: RedirectAttributes,
+    ): String {
+        val discordId = user.discordIdOrNull()
+            ?: return "redirect:/poker/guilds"
+        if (!economyWebService.isMember(discordId, guildId)) {
+            ra.addFlashAttribute("error", "You are not a member of that server.")
+            return "redirect:/poker/guilds"
+        }
+        if (pokerWebService.snapshot(tableId, discordId) == null) {
+            ra.addFlashAttribute("error", "That table no longer exists.")
+            return "redirect:/poker/$guildId"
+        }
+        val profile = userService.getUserById(discordId, guildId)
+        model.addAttribute("guildId", guildId.toString())
+        model.addAttribute("tableId", tableId.toString())
+        model.addAttribute("balance", profile?.socialCredit ?: 0L)
+        model.addAttribute("minBuyIn", PokerService.MIN_BUY_IN)
+        model.addAttribute("maxBuyIn", PokerService.MAX_BUY_IN)
+        model.addAttribute("username", user.displayName())
+        model.addAttribute("myDiscordId", discordId.toString())
+        return "poker-table"
+    }
+
+    @GetMapping("/{guildId}/{tableId}/state")
+    @ResponseBody
+    fun state(
+        @PathVariable guildId: Long,
+        @PathVariable tableId: Long,
+        @AuthenticationPrincipal user: OAuth2User,
+    ): ResponseEntity<PokerWebService.TableStateView> {
+        val discordId = user.discordIdOrNull() ?: return ResponseEntity.status(401).build()
+        if (!economyWebService.isMember(discordId, guildId)) {
+            return ResponseEntity.status(403).build()
+        }
+        val view = pokerWebService.snapshot(tableId, discordId)
+            ?: return ResponseEntity.status(404).build()
+        if (view.guildId != guildId) return ResponseEntity.status(404).build()
+        return ResponseEntity.ok(view)
+    }
+
+    @PostMapping("/{guildId}/create")
+    @ResponseBody
+    fun create(
+        @PathVariable guildId: Long,
+        @RequestBody request: CreateRequest,
+        @AuthenticationPrincipal user: OAuth2User,
+    ): ResponseEntity<TableActionResponse> {
+        val discordId = user.discordIdOrNull()
+            ?: return ResponseEntity.status(401).body(TableActionResponse(false, error = "Not signed in."))
+        if (!economyWebService.isMember(discordId, guildId)) {
+            return ResponseEntity.status(403).body(TableActionResponse(false, error = "You are not a member of that server."))
+        }
+        return when (val outcome = pokerService.createTable(discordId, guildId, request.buyIn)) {
+            is CreateOutcome.Ok -> ResponseEntity.ok(TableActionResponse(ok = true, tableId = outcome.tableId))
+            is CreateOutcome.InvalidBuyIn -> ResponseEntity.badRequest().body(
+                TableActionResponse(false, error = "Buy-in must be between ${outcome.min} and ${outcome.max}.")
+            )
+            is CreateOutcome.InsufficientCredits -> ResponseEntity.badRequest().body(
+                TableActionResponse(false, error = "Need ${outcome.needed} credits, you have ${outcome.have}.")
+            )
+            CreateOutcome.UnknownUser -> ResponseEntity.badRequest().body(
+                TableActionResponse(false, error = "No user record yet — try another TobyBot command first.")
+            )
+        }
+    }
+
+    @PostMapping("/{guildId}/{tableId}/join")
+    @ResponseBody
+    fun join(
+        @PathVariable guildId: Long,
+        @PathVariable tableId: Long,
+        @RequestBody request: JoinRequest,
+        @AuthenticationPrincipal user: OAuth2User,
+    ): ResponseEntity<TableActionResponse> {
+        val discordId = user.discordIdOrNull()
+            ?: return ResponseEntity.status(401).body(TableActionResponse(false, error = "Not signed in."))
+        if (!economyWebService.isMember(discordId, guildId)) {
+            return ResponseEntity.status(403).body(TableActionResponse(false, error = "You are not a member of that server."))
+        }
+        return when (val outcome = pokerService.buyIn(discordId, guildId, tableId, request.buyIn)) {
+            is BuyInOutcome.Ok -> ResponseEntity.ok(
+                TableActionResponse(ok = true, tableId = tableId, newBalance = outcome.newBalance)
+            )
+            BuyInOutcome.AlreadySeated -> ResponseEntity.badRequest().body(
+                TableActionResponse(false, error = "You're already at this table.")
+            )
+            BuyInOutcome.TableFull -> ResponseEntity.badRequest().body(
+                TableActionResponse(false, error = "Table is full.")
+            )
+            BuyInOutcome.TableNotFound -> ResponseEntity.status(404).body(
+                TableActionResponse(false, error = "No such table.")
+            )
+            is BuyInOutcome.InvalidBuyIn -> ResponseEntity.badRequest().body(
+                TableActionResponse(false, error = "Buy-in must be between ${outcome.min} and ${outcome.max}.")
+            )
+            is BuyInOutcome.InsufficientCredits -> ResponseEntity.badRequest().body(
+                TableActionResponse(false, error = "Need ${outcome.needed} credits, you have ${outcome.have}.")
+            )
+            BuyInOutcome.UnknownUser -> ResponseEntity.badRequest().body(
+                TableActionResponse(false, error = "No user record yet — try another TobyBot command first.")
+            )
+        }
+    }
+
+    @PostMapping("/{guildId}/{tableId}/start")
+    @ResponseBody
+    fun start(
+        @PathVariable guildId: Long,
+        @PathVariable tableId: Long,
+        @AuthenticationPrincipal user: OAuth2User,
+    ): ResponseEntity<TableActionResponse> {
+        val discordId = user.discordIdOrNull()
+            ?: return ResponseEntity.status(401).body(TableActionResponse(false, error = "Not signed in."))
+        if (!economyWebService.isMember(discordId, guildId)) {
+            return ResponseEntity.status(403).body(TableActionResponse(false, error = "You are not a member of that server."))
+        }
+        return when (val outcome = pokerService.startHand(discordId, guildId, tableId)) {
+            is StartHandOutcome.Ok -> ResponseEntity.ok(TableActionResponse(ok = true, handNumber = outcome.handNumber))
+            StartHandOutcome.HandAlreadyInProgress -> ResponseEntity.badRequest().body(
+                TableActionResponse(false, error = "A hand is already in progress.")
+            )
+            StartHandOutcome.NotEnoughPlayers -> ResponseEntity.badRequest().body(
+                TableActionResponse(false, error = "Need at least 2 seated players with chips.")
+            )
+            StartHandOutcome.NotHost -> ResponseEntity.status(403).body(
+                TableActionResponse(false, error = "Only the table host can deal hands.")
+            )
+            StartHandOutcome.TableNotFound -> ResponseEntity.status(404).body(
+                TableActionResponse(false, error = "No such table.")
+            )
+        }
+    }
+
+    @PostMapping("/{guildId}/{tableId}/action")
+    @ResponseBody
+    fun action(
+        @PathVariable guildId: Long,
+        @PathVariable tableId: Long,
+        @RequestBody request: ActionRequest,
+        @AuthenticationPrincipal user: OAuth2User,
+    ): ResponseEntity<TableActionResponse> {
+        val discordId = user.discordIdOrNull()
+            ?: return ResponseEntity.status(401).body(TableActionResponse(false, error = "Not signed in."))
+        if (!economyWebService.isMember(discordId, guildId)) {
+            return ResponseEntity.status(403).body(TableActionResponse(false, error = "You are not a member of that server."))
+        }
+        val pokerAction = parseAction(request.action, tableId, discordId)
+            ?: return ResponseEntity.badRequest().body(TableActionResponse(false, error = "Unknown or illegal action: ${request.action}"))
+
+        return when (val outcome = pokerService.applyAction(discordId, guildId, tableId, pokerAction)) {
+            ActionOutcome.Continued -> ResponseEntity.ok(TableActionResponse(ok = true))
+            is ActionOutcome.StreetAdvanced -> ResponseEntity.ok(
+                TableActionResponse(ok = true, phase = outcome.phase.name)
+            )
+            is ActionOutcome.HandResolved -> ResponseEntity.ok(
+                TableActionResponse(
+                    ok = true,
+                    handNumber = outcome.result.handNumber,
+                    pot = outcome.result.pot,
+                    rake = outcome.result.rake
+                )
+            )
+            ActionOutcome.TableNotFound -> ResponseEntity.status(404).body(
+                TableActionResponse(false, error = "No such table.")
+            )
+            is ActionOutcome.Rejected -> ResponseEntity.badRequest().body(
+                TableActionResponse(false, error = describeRejection(outcome.reason))
+            )
+        }
+    }
+
+    @PostMapping("/{guildId}/{tableId}/cashout")
+    @ResponseBody
+    fun cashOut(
+        @PathVariable guildId: Long,
+        @PathVariable tableId: Long,
+        @AuthenticationPrincipal user: OAuth2User,
+    ): ResponseEntity<TableActionResponse> {
+        val discordId = user.discordIdOrNull()
+            ?: return ResponseEntity.status(401).body(TableActionResponse(false, error = "Not signed in."))
+        if (!economyWebService.isMember(discordId, guildId)) {
+            return ResponseEntity.status(403).body(TableActionResponse(false, error = "You are not a member of that server."))
+        }
+        return when (val outcome = pokerService.cashOut(discordId, guildId, tableId)) {
+            is CashOutOutcome.Ok -> ResponseEntity.ok(
+                TableActionResponse(ok = true, chipsReturned = outcome.chipsReturned, newBalance = outcome.newBalance)
+            )
+            CashOutOutcome.HandInProgress -> ResponseEntity.badRequest().body(
+                TableActionResponse(false, error = "Hand in progress — fold first if you don't want to play it out.")
+            )
+            CashOutOutcome.NotSeated -> ResponseEntity.badRequest().body(
+                TableActionResponse(false, error = "You're not seated at this table.")
+            )
+            CashOutOutcome.TableNotFound -> ResponseEntity.status(404).body(
+                TableActionResponse(false, error = "No such table.")
+            )
+        }
+    }
+
+    private fun parseAction(raw: String, tableId: Long, discordId: Long): PokerEngine.PokerAction? {
+        return when (raw.lowercase()) {
+            "fold" -> PokerEngine.PokerAction.Fold
+            "raise" -> PokerEngine.PokerAction.Raise
+            "check" -> PokerEngine.PokerAction.Check
+            "call" -> PokerEngine.PokerAction.Call
+            // "checkcall" auto-picks based on what the seat owes — saves the
+            // client from re-deriving the table state on every click.
+            "checkcall", "check_call" -> {
+                val table: PokerTable = pokerService.snapshot(tableId) ?: return null
+                synchronized(table) {
+                    val seat = table.seats.firstOrNull { it.discordId == discordId } ?: return@synchronized null
+                    if (table.currentBet > seat.committedThisRound) PokerEngine.PokerAction.Call
+                    else PokerEngine.PokerAction.Check
+                }
+            }
+            else -> null
+        }
+    }
+
+    private fun describeRejection(reason: PokerEngine.RejectReason): String = when (reason) {
+        PokerEngine.RejectReason.NO_HAND_IN_PROGRESS -> "No hand in progress."
+        PokerEngine.RejectReason.NOT_AT_TABLE -> "You aren't seated at this table."
+        PokerEngine.RejectReason.NOT_YOUR_TURN -> "It isn't your turn."
+        PokerEngine.RejectReason.ILLEGAL_CHECK -> "You can't check — there's a bet to call."
+        PokerEngine.RejectReason.ILLEGAL_CALL -> "Nothing to call."
+        PokerEngine.RejectReason.ILLEGAL_RAISE -> "You can't raise here."
+        PokerEngine.RejectReason.RAISE_CAP_REACHED -> "Raise cap reached for this street."
+        PokerEngine.RejectReason.INSUFFICIENT_CHIPS_TO_CALL -> "Not enough chips to call — fold instead."
+        PokerEngine.RejectReason.INSUFFICIENT_CHIPS_TO_RAISE -> "Not enough chips to raise — try Call."
+    }
+}
+
+data class CreateRequest(val buyIn: Long = 0)
+data class JoinRequest(val buyIn: Long = 0)
+data class ActionRequest(val action: String = "")
+
+data class TableActionResponse(
+    val ok: Boolean,
+    val error: String? = null,
+    val tableId: Long? = null,
+    val newBalance: Long? = null,
+    val handNumber: Long? = null,
+    val phase: String? = null,
+    val pot: Long? = null,
+    val rake: Long? = null,
+    val chipsReturned: Long? = null,
+)

--- a/web/src/main/kotlin/web/service/ModerationWebService.kt
+++ b/web/src/main/kotlin/web/service/ModerationWebService.kt
@@ -279,6 +279,12 @@ class ModerationWebService(
                 if (n !in 0..50) return "Value must be between 0 and 50 (capped server-side)."
                 n.toString()
             }
+            ConfigDto.Configurations.POKER_RAKE_PCT -> {
+                val n = rawValue.trim().toIntOrNull()
+                    ?: return "Value must be a whole number percentage (0-20)."
+                if (n !in 0..20) return "Value must be between 0 and 20 (capped server-side)."
+                n.toString()
+            }
         }
 
         val guildIdString = guild.id

--- a/web/src/main/kotlin/web/service/PokerWebService.kt
+++ b/web/src/main/kotlin/web/service/PokerWebService.kt
@@ -106,12 +106,21 @@ class PokerWebService(
                 mySeat?.status == PokerTable.SeatStatus.ACTIVE
 
             val betUnit = currentBetUnit(table)
-            val owe = if (mySeat != null) (table.currentBet - mySeat.committedThisRound).coerceAtLeast(0L) else 0L
-            val canCall = isMyTurn && owe > 0L && (mySeat?.chips ?: 0L) >= owe
-            val canCheck = isMyTurn && owe == 0L
-            val canRaise = isMyTurn &&
-                table.raisesThisStreet < table.maxRaisesPerStreet &&
-                (mySeat?.chips ?: 0L) >= owe + betUnit
+            val owe: Long
+            val canCall: Boolean
+            val canCheck: Boolean
+            val canRaise: Boolean
+            if (mySeat != null && isMyTurn) {
+                owe = (table.currentBet - mySeat.committedThisRound).coerceAtLeast(0L)
+                canCall = owe > 0L && mySeat.chips >= owe
+                canCheck = owe == 0L
+                canRaise = table.raisesThisStreet < table.maxRaisesPerStreet && mySeat.chips >= owe + betUnit
+            } else {
+                owe = if (mySeat != null) (table.currentBet - mySeat.committedThisRound).coerceAtLeast(0L) else 0L
+                canCall = false
+                canCheck = false
+                canRaise = false
+            }
 
             return TableStateView(
                 tableId = table.id,

--- a/web/src/main/kotlin/web/service/PokerWebService.kt
+++ b/web/src/main/kotlin/web/service/PokerWebService.kt
@@ -1,0 +1,177 @@
+package web.service
+
+import database.poker.Card
+import database.poker.PokerTable
+import database.poker.PokerTableRegistry
+import org.springframework.stereotype.Service
+
+/**
+ * Read-only projection of [PokerTable] for the web UI. Crucially, the
+ * caller's own hole cards are returned face-up while every other
+ * player's hole cards are masked server-side — so even if a hostile
+ * client reads the JSON snapshot directly, they can't see the rest of
+ * the table's cards. This is enforced here, not in the template, so
+ * tests can assert it.
+ */
+@Service
+class PokerWebService(
+    private val tableRegistry: PokerTableRegistry,
+) {
+
+    data class TableSummaryView(
+        val tableId: Long,
+        val hostDiscordId: Long,
+        val seats: Int,
+        val maxSeats: Int,
+        val phase: String,
+        val handNumber: Long,
+        val minBuyIn: Long,
+        val maxBuyIn: Long,
+    )
+
+    data class TableStateView(
+        val tableId: Long,
+        val guildId: Long,
+        val hostDiscordId: Long,
+        val phase: String,
+        val handNumber: Long,
+        val pot: Long,
+        val currentBet: Long,
+        val raisesThisStreet: Int,
+        val maxRaisesPerStreet: Int,
+        val smallBlind: Long,
+        val bigBlind: Long,
+        val smallBet: Long,
+        val bigBet: Long,
+        val minBuyIn: Long,
+        val maxBuyIn: Long,
+        val maxSeats: Int,
+        val dealerIndex: Int,
+        val actorIndex: Int,
+        val community: List<String>,
+        val seats: List<SeatView>,
+        val mySeatIndex: Int?,
+        val myHoleCards: List<String>,
+        val isMyTurn: Boolean,
+        val canCheck: Boolean,
+        val canCall: Boolean,
+        val canRaise: Boolean,
+        val callAmount: Long,
+        val raiseAmount: Long,
+        val lastResult: HandResultView?,
+    )
+
+    data class SeatView(
+        val discordId: Long,
+        val chips: Long,
+        val committedThisRound: Long,
+        val totalCommittedThisHand: Long,
+        val status: String,
+        /** Other players' cards are always masked; only the viewer sees their own. */
+        val holeCards: List<String>,
+    )
+
+    data class HandResultView(
+        val handNumber: Long,
+        val winners: List<Long>,
+        val payoutByDiscordId: Map<String, Long>,
+        val pot: Long,
+        val rake: Long,
+        val board: List<String>,
+        val revealedHoleCards: Map<String, List<String>>,
+    )
+
+    fun listGuildTables(guildId: Long): List<TableSummaryView> =
+        tableRegistry.listForGuild(guildId).map {
+            TableSummaryView(
+                tableId = it.id,
+                hostDiscordId = it.hostDiscordId,
+                seats = it.seats.size,
+                maxSeats = it.maxSeats,
+                phase = it.phase.name,
+                handNumber = it.handNumber,
+                minBuyIn = it.minBuyIn,
+                maxBuyIn = it.maxBuyIn,
+            )
+        }.sortedBy { it.tableId }
+
+    fun snapshot(tableId: Long, viewerDiscordId: Long): TableStateView? {
+        val table = tableRegistry.get(tableId) ?: return null
+        synchronized(table) {
+            val mySeatIndex = table.seats.indexOfFirst { it.discordId == viewerDiscordId }.takeIf { it >= 0 }
+            val mySeat = mySeatIndex?.let { table.seats[it] }
+            val isMyTurn = mySeatIndex != null &&
+                mySeatIndex == table.actorIndex &&
+                table.phase != PokerTable.Phase.WAITING &&
+                mySeat?.status == PokerTable.SeatStatus.ACTIVE
+
+            val betUnit = currentBetUnit(table)
+            val owe = if (mySeat != null) (table.currentBet - mySeat.committedThisRound).coerceAtLeast(0L) else 0L
+            val canCall = isMyTurn && owe > 0L && (mySeat?.chips ?: 0L) >= owe
+            val canCheck = isMyTurn && owe == 0L
+            val canRaise = isMyTurn &&
+                table.raisesThisStreet < table.maxRaisesPerStreet &&
+                (mySeat?.chips ?: 0L) >= owe + betUnit
+
+            return TableStateView(
+                tableId = table.id,
+                guildId = table.guildId,
+                hostDiscordId = table.hostDiscordId,
+                phase = table.phase.name,
+                handNumber = table.handNumber,
+                pot = table.pot,
+                currentBet = table.currentBet,
+                raisesThisStreet = table.raisesThisStreet,
+                maxRaisesPerStreet = table.maxRaisesPerStreet,
+                smallBlind = table.smallBlind,
+                bigBlind = table.bigBlind,
+                smallBet = table.smallBet,
+                bigBet = table.bigBet,
+                minBuyIn = table.minBuyIn,
+                maxBuyIn = table.maxBuyIn,
+                maxSeats = table.maxSeats,
+                dealerIndex = table.dealerIndex,
+                actorIndex = table.actorIndex,
+                community = table.community.map(Card::toString),
+                seats = table.seats.mapIndexed { idx, seat ->
+                    SeatView(
+                        discordId = seat.discordId,
+                        chips = seat.chips,
+                        committedThisRound = seat.committedThisRound,
+                        totalCommittedThisHand = seat.totalCommittedThisHand,
+                        status = seat.status.name,
+                        // Server-side mask: only the viewer's own cards are returned.
+                        holeCards = if (idx == mySeatIndex) seat.holeCards.map(Card::toString) else emptyList()
+                    )
+                },
+                mySeatIndex = mySeatIndex,
+                myHoleCards = mySeat?.holeCards?.map(Card::toString) ?: emptyList(),
+                isMyTurn = isMyTurn,
+                canCheck = canCheck,
+                canCall = canCall,
+                canRaise = canRaise,
+                callAmount = owe,
+                raiseAmount = owe + betUnit,
+                lastResult = table.lastResult?.let { result ->
+                    HandResultView(
+                        handNumber = result.handNumber,
+                        winners = result.winners,
+                        payoutByDiscordId = result.payoutByDiscordId.mapKeys { it.key.toString() },
+                        pot = result.pot,
+                        rake = result.rake,
+                        board = result.board.map(Card::toString),
+                        revealedHoleCards = result.revealedHoleCards
+                            .mapKeys { it.key.toString() }
+                            .mapValues { e -> e.value.map(Card::toString) }
+                    )
+                }
+            )
+        }
+    }
+
+    private fun currentBetUnit(table: PokerTable): Long = when (table.phase) {
+        PokerTable.Phase.PRE_FLOP, PokerTable.Phase.FLOP -> table.smallBet
+        PokerTable.Phase.TURN, PokerTable.Phase.RIVER -> table.bigBet
+        PokerTable.Phase.WAITING -> table.smallBet
+    }
+}

--- a/web/src/main/resources/static/css/poker.css
+++ b/web/src/main/resources/static/css/poker.css
@@ -1,0 +1,172 @@
+.poker-header {
+    margin-bottom: 1.5rem;
+}
+
+.poker-header h1 {
+    margin: 0.25rem 0 0.5rem;
+}
+
+.poker-card {
+    background: var(--surface, #1f2128);
+    border-radius: 0.75rem;
+    padding: 1.5rem;
+    max-width: 48rem;
+    margin-bottom: 1.5rem;
+}
+
+.poker-card h2 {
+    margin-top: 0;
+    margin-bottom: 1rem;
+}
+
+.poker-card form {
+    display: grid;
+    gap: 0.5rem;
+    margin-bottom: 1.25rem;
+}
+
+.poker-card input,
+.poker-card select {
+    background: var(--surface-2, #16181d);
+    color: inherit;
+    border: 1px solid var(--border, #2a2d35);
+    border-radius: 0.4rem;
+    padding: 0.5rem 0.75rem;
+    font: inherit;
+}
+
+.poker-card input:focus {
+    outline: 2px solid var(--accent, #5865f2);
+    outline-offset: 2px;
+}
+
+.poker-table {
+    background: linear-gradient(135deg, #1c3d2c, #143324);
+    border: 1px solid var(--border, #2a2d35);
+    border-radius: 1rem;
+    padding: 1.5rem;
+    margin-bottom: 1.5rem;
+    color: #f0f0f0;
+}
+
+.poker-board {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+    justify-content: center;
+    margin: 1rem 0;
+    min-height: 4.5rem;
+    align-items: center;
+}
+
+.poker-card-face {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 3rem;
+    height: 4.5rem;
+    background: #f7f7f5;
+    color: #1a1a1a;
+    border-radius: 0.4rem;
+    font-weight: 700;
+    font-size: 1.4rem;
+    box-shadow: 0 1px 4px rgba(0,0,0,0.4);
+    font-family: 'Cambria', serif;
+}
+
+.poker-card-face.poker-card-red {
+    color: #c0392b;
+}
+
+.poker-card-back {
+    background: linear-gradient(135deg, #5865f2, #3a44a3);
+    color: transparent;
+    background-image:
+        repeating-linear-gradient(45deg, rgba(255,255,255,0.05) 0 8px, transparent 8px 16px),
+        linear-gradient(135deg, #5865f2, #3a44a3);
+}
+
+.poker-info {
+    display: flex;
+    gap: 1rem;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    margin-bottom: 1rem;
+}
+
+.poker-info > div {
+    background: rgba(0,0,0,0.25);
+    padding: 0.5rem 0.75rem;
+    border-radius: 0.4rem;
+}
+
+.poker-seats {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));
+    gap: 0.75rem;
+    margin: 1rem 0;
+}
+
+.poker-seat {
+    background: rgba(0,0,0,0.3);
+    border: 1px solid rgba(255,255,255,0.05);
+    border-radius: 0.5rem;
+    padding: 0.75rem;
+}
+
+.poker-seat-me {
+    border-color: var(--accent, #5865f2);
+    box-shadow: 0 0 0 1px var(--accent, #5865f2);
+}
+
+.poker-seat-active {
+    box-shadow: 0 0 0 2px #f1c40f;
+}
+
+.poker-seat-folded {
+    opacity: 0.5;
+}
+
+.poker-seat-name {
+    font-weight: 600;
+    margin-bottom: 0.25rem;
+}
+
+.poker-seat-meta {
+    font-size: 0.85rem;
+    opacity: 0.85;
+}
+
+.poker-seat-cards {
+    display: flex;
+    gap: 0.4rem;
+    margin-top: 0.5rem;
+}
+
+.poker-actions {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+    margin-top: 1rem;
+}
+
+.poker-actions button[disabled] {
+    opacity: 0.4;
+    cursor: not-allowed;
+}
+
+.poker-table-list {
+    display: grid;
+    gap: 0.5rem;
+}
+
+.poker-table-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 0.75rem 1rem;
+    border: 1px solid var(--border, #2a2d35);
+    border-radius: 0.5rem;
+    background: var(--surface-2, #16181d);
+}

--- a/web/src/main/resources/static/js/poker-lobby.js
+++ b/web/src/main/resources/static/js/poker-lobby.js
@@ -1,0 +1,45 @@
+// /poker lobby — list of tables in this guild + new-table form. Polls
+// the same /poker/{guildId}/{tableId}/state-style data via the lobby
+// endpoint isn't strictly needed since tables update on action; we just
+// re-render the list every 5s by re-fetching the lobby HTML's data via
+// a JSON projection. For v1 we trigger a full reload after create/join.
+(function () {
+    'use strict';
+
+    const main = document.getElementById('main');
+    if (!main) return;
+    const guildId = main.dataset.guildId;
+    if (!guildId) return;
+
+    function showToast(level, msg) {
+        if (window.TobyToasts && window.TobyToasts[level]) window.TobyToasts[level](msg);
+    }
+
+    const createForm = document.getElementById('poker-create');
+    if (createForm) {
+        createForm.addEventListener('submit', function (e) {
+            e.preventDefault();
+            const buyIn = parseInt(document.getElementById('poker-create-buyin').value, 10);
+            if (!buyIn) {
+                showToast('error', 'Buy-in is required.');
+                return;
+            }
+            window.TobyApi.postJson('/poker/' + guildId + '/create', { buyIn: buyIn })
+                .then(function (resp) {
+                    if (!resp || !resp.ok) {
+                        showToast('error', (resp && resp.error) || 'Could not create table.');
+                        return;
+                    }
+                    showToast('success', 'Table #' + resp.tableId + ' created.');
+                    window.location.href = '/poker/' + guildId + '/' + resp.tableId;
+                })
+                .catch(function () { showToast('error', 'Network error.'); });
+        });
+    }
+
+    // Auto-refresh table list so newly-created tables show up without a
+    // manual reload. Cheap: just reload the page on a long interval.
+    setTimeout(function reload() {
+        window.location.reload();
+    }, 30000);
+})();

--- a/web/src/main/resources/static/js/poker-table.js
+++ b/web/src/main/resources/static/js/poker-table.js
@@ -1,0 +1,235 @@
+// /poker table — polls /poker/{guildId}/{tableId}/state every 2s and
+// renders the table state, then drives Check/Call/Raise/Fold/Cashout
+// via /poker/{guildId}/{tableId}/{action}. Hole cards for other
+// players are masked server-side, so a hostile client can't read the
+// JSON to see opponents' cards — we just render whatever we receive.
+(function () {
+    'use strict';
+
+    const main = document.getElementById('main');
+    if (!main) return;
+    const guildId = main.dataset.guildId;
+    const tableId = main.dataset.tableId;
+    const myDiscordId = main.dataset.myDiscordId;
+    if (!guildId || !tableId) return;
+
+    const phaseEl = document.getElementById('poker-phase');
+    const handNumberEl = document.getElementById('poker-hand-number');
+    const potEl = document.getElementById('poker-pot');
+    const currentBetEl = document.getElementById('poker-current-bet');
+    const boardEl = document.getElementById('poker-board');
+    const seatsEl = document.getElementById('poker-seats');
+    const statusEl = document.getElementById('poker-status');
+    const resultEl = document.getElementById('poker-result');
+    const balanceEl = document.getElementById('poker-balance');
+    const joinCard = document.getElementById('poker-join-card');
+
+    const btnCheckCall = document.getElementById('poker-action-checkcall');
+    const btnRaise = document.getElementById('poker-action-raise');
+    const btnFold = document.getElementById('poker-action-fold');
+    const btnStart = document.getElementById('poker-action-start');
+    const btnCashout = document.getElementById('poker-action-cashout');
+
+    function showToast(level, msg) {
+        if (window.TobyToasts && window.TobyToasts[level]) window.TobyToasts[level](msg);
+    }
+
+    function renderCard(c, faceDown) {
+        const span = document.createElement('span');
+        span.className = 'poker-card-face';
+        if (faceDown) {
+            span.classList.add('poker-card-back');
+            span.textContent = '?';
+            return span;
+        }
+        // Card strings look like "A♠", "T♥", "9♦", "K♣"
+        const suit = c.charAt(c.length - 1);
+        if (suit === '♥' || suit === '♦') span.classList.add('poker-card-red');
+        span.textContent = c;
+        return span;
+    }
+
+    function renderBoard(community) {
+        boardEl.innerHTML = '';
+        if (!community || community.length === 0) {
+            const ph = document.createElement('span');
+            ph.className = 'muted';
+            ph.textContent = '— no community cards yet —';
+            boardEl.appendChild(ph);
+            return;
+        }
+        community.forEach(function (c) { boardEl.appendChild(renderCard(c, false)); });
+    }
+
+    function renderSeats(state) {
+        seatsEl.innerHTML = '';
+        const meIdx = state.mySeatIndex;
+        state.seats.forEach(function (s, idx) {
+            const node = document.createElement('div');
+            node.className = 'poker-seat';
+            if (idx === meIdx) node.classList.add('poker-seat-me');
+            if (idx === state.actorIndex && state.phase !== 'WAITING') node.classList.add('poker-seat-active');
+            if (s.status === 'FOLDED') node.classList.add('poker-seat-folded');
+
+            const name = document.createElement('div');
+            name.className = 'poker-seat-name';
+            name.textContent = (idx === meIdx ? 'You' : 'Player ' + s.discordId) +
+                (idx === state.dealerIndex ? ' (D)' : '');
+            node.appendChild(name);
+
+            const meta = document.createElement('div');
+            meta.className = 'poker-seat-meta';
+            meta.textContent = s.chips + ' chips · ' + s.status +
+                (s.committedThisRound > 0 ? ' · in: ' + s.committedThisRound : '');
+            node.appendChild(meta);
+
+            if (state.phase !== 'WAITING') {
+                const cards = document.createElement('div');
+                cards.className = 'poker-seat-cards';
+                if (idx === meIdx && s.holeCards && s.holeCards.length > 0) {
+                    s.holeCards.forEach(function (c) { cards.appendChild(renderCard(c, false)); });
+                } else if (s.status !== 'FOLDED' && s.status !== 'SITTING_OUT') {
+                    // Server returns empty list for masked seats; render two backs.
+                    cards.appendChild(renderCard('', true));
+                    cards.appendChild(renderCard('', true));
+                }
+                node.appendChild(cards);
+            }
+            seatsEl.appendChild(node);
+        });
+    }
+
+    function renderActions(state) {
+        const seated = state.mySeatIndex !== null && state.mySeatIndex !== undefined;
+        if (joinCard) joinCard.hidden = seated;
+
+        btnCheckCall.disabled = !state.isMyTurn;
+        btnCheckCall.textContent = state.canCall
+            ? 'Call ' + state.callAmount
+            : 'Check';
+        btnRaise.disabled = !state.canRaise;
+        btnRaise.textContent = 'Raise (+' + (state.raiseAmount - state.callAmount) + ')';
+        btnFold.disabled = !state.isMyTurn;
+
+        const isHost = String(state.hostDiscordId) === String(myDiscordId);
+        const canStart = isHost && state.phase === 'WAITING' && state.seats.length >= 2;
+        btnStart.hidden = !isHost;
+        btnStart.disabled = !canStart;
+
+        btnCashout.hidden = !seated;
+        btnCashout.disabled = state.phase !== 'WAITING';
+    }
+
+    function renderResult(result) {
+        if (!result) { resultEl.textContent = ''; return; }
+        const winners = (result.winners || []).map(function (id) { return String(id); }).join(', ');
+        const reveals = result.revealedHoleCards || {};
+        const lines = [];
+        Object.keys(reveals).forEach(function (id) {
+            lines.push(id + ': ' + (reveals[id] || []).join(' '));
+        });
+        resultEl.textContent = 'Hand #' + result.handNumber +
+            ' resolved. Winners: ' + winners +
+            ' · pot ' + result.pot + ' (rake ' + result.rake + ' → jackpot)' +
+            (lines.length ? ' · showdown: ' + lines.join(' | ') : '');
+    }
+
+    function refresh() {
+        fetch('/poker/' + guildId + '/' + tableId + '/state', { credentials: 'same-origin' })
+            .then(function (r) {
+                if (r.status === 404) {
+                    statusEl.textContent = 'Table closed.';
+                    return null;
+                }
+                if (!r.ok) return null;
+                return r.json();
+            })
+            .then(function (state) {
+                if (!state) return;
+                phaseEl.textContent = state.phase;
+                handNumberEl.textContent = state.handNumber;
+                potEl.textContent = state.pot;
+                currentBetEl.textContent = state.currentBet;
+                statusEl.textContent = state.isMyTurn
+                    ? 'Your turn.'
+                    : (state.phase === 'WAITING'
+                        ? 'Waiting for the host to deal.'
+                        : 'Waiting for player ' + (state.seats[state.actorIndex] || {}).discordId + '.');
+                renderBoard(state.community);
+                renderSeats(state);
+                renderActions(state);
+                renderResult(state.lastResult);
+            })
+            .catch(function () { /* keep last known state */ });
+    }
+
+    function postAction(action) {
+        return window.TobyApi.postJson(
+            '/poker/' + guildId + '/' + tableId + '/action',
+            { action: action }
+        ).then(function (resp) {
+            if (!resp || !resp.ok) {
+                showToast('error', (resp && resp.error) || 'Action failed.');
+            }
+            refresh();
+        }).catch(function () { showToast('error', 'Network error.'); });
+    }
+
+    btnCheckCall.addEventListener('click', function () { postAction('checkcall'); });
+    btnRaise.addEventListener('click', function () { postAction('raise'); });
+    btnFold.addEventListener('click', function () { postAction('fold'); });
+
+    btnStart.addEventListener('click', function () {
+        window.TobyApi.postJson('/poker/' + guildId + '/' + tableId + '/start', {})
+            .then(function (resp) {
+                if (!resp || !resp.ok) {
+                    showToast('error', (resp && resp.error) || 'Could not deal.');
+                } else {
+                    showToast('success', 'Hand #' + resp.handNumber + ' dealt.');
+                }
+                refresh();
+            })
+            .catch(function () { showToast('error', 'Network error.'); });
+    });
+
+    btnCashout.addEventListener('click', function () {
+        window.TobyApi.postJson('/poker/' + guildId + '/' + tableId + '/cashout', {})
+            .then(function (resp) {
+                if (!resp || !resp.ok) {
+                    showToast('error', (resp && resp.error) || 'Could not cash out.');
+                    refresh();
+                    return;
+                }
+                showToast('success', 'Cashed out ' + resp.chipsReturned + ' chips.');
+                if (balanceEl && resp.newBalance != null) balanceEl.textContent = resp.newBalance;
+                window.location.href = '/poker/' + guildId;
+            })
+            .catch(function () { showToast('error', 'Network error.'); });
+    });
+
+    const joinForm = document.getElementById('poker-join');
+    if (joinForm) {
+        joinForm.addEventListener('submit', function (e) {
+            e.preventDefault();
+            const buyIn = parseInt(document.getElementById('poker-join-buyin').value, 10);
+            if (!buyIn) {
+                showToast('error', 'Buy-in is required.');
+                return;
+            }
+            window.TobyApi.postJson('/poker/' + guildId + '/' + tableId + '/join', { buyIn: buyIn })
+                .then(function (resp) {
+                    if (!resp || !resp.ok) {
+                        showToast('error', (resp && resp.error) || 'Could not join.');
+                        return;
+                    }
+                    showToast('success', 'You sat down with ' + buyIn + ' chips.');
+                    if (balanceEl && resp.newBalance != null) balanceEl.textContent = resp.newBalance;
+                    refresh();
+                })
+                .catch(function () { showToast('error', 'Network error.'); });
+        });
+    }
+
+    refresh();
+    setInterval(refresh, 2000);
+})();

--- a/web/src/main/resources/templates/casino-guilds.html
+++ b/web/src/main/resources/templates/casino-guilds.html
@@ -43,6 +43,8 @@
                    th:href="@{/casino/{id}/highlow(id=${g.id})}">🃏 High-Low</a>
                 <a class="btn-secondary"
                    th:href="@{/casino/{id}/scratch(id=${g.id})}">🎟️ Scratch</a>
+                <a class="btn-secondary"
+                   th:href="@{/poker/{id}(id=${g.id})}">🎴 Poker</a>
             </div>
         </div>
     </div>

--- a/web/src/main/resources/templates/fragments/navbar.html
+++ b/web/src/main/resources/templates/fragments/navbar.html
@@ -23,6 +23,7 @@
                 <a href="/titles/guilds" role="menuitem">Titles</a>
                 <a href="/tip/guilds" role="menuitem">&#128184; Tip</a>
                 <a href="/duel/guilds" role="menuitem">&#9876;&#65039; Duel</a>
+                <a href="/poker/guilds" role="menuitem">&#127924; Poker</a>
             </div>
         </div>
         <div class="nav-dropdown">
@@ -37,6 +38,7 @@
                 <a href="/casino/guilds" role="menuitem">&#127922; Dice</a>
                 <a href="/casino/guilds" role="menuitem">&#127183; High-Low</a>
                 <a href="/casino/guilds" role="menuitem">&#127903;&#65039; Scratch</a>
+                <a href="/poker/guilds" role="menuitem">&#127924; Poker</a>
             </div>
         </div>
         <a href="/intro/guilds">Intro Songs</a>

--- a/web/src/main/resources/templates/home.html
+++ b/web/src/main/resources/templates/home.html
@@ -232,6 +232,11 @@
             <h3>Duel</h3>
             <p>Stake credit and challenge someone to a coin-flip duel — winner takes most of the pot.</p>
         </a>
+        <a class="feature-card" href="/poker/guilds">
+            <div class="feature-icon">&#127924;</div>
+            <h3>Poker</h3>
+            <p>Multiplayer fixed-limit Texas Hold'em with up to six seats. Buy in, deal hands, take credits from your friends.</p>
+        </a>
         <a class="feature-card" href="/leaderboards">
             <div class="feature-icon">&#128200;</div>
             <h3>Leaderboards</h3>

--- a/web/src/main/resources/templates/moderation.html
+++ b/web/src/main/resources/templates/moderation.html
@@ -200,6 +200,22 @@
                 </select>
                 <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
             </div>
+            <div class="config-row" data-key="JACKPOT_LOSS_TRIBUTE_PCT">
+                <label>Jackpot loss tribute (% of every lost casino stake)</label>
+                <input type="number" min="0" max="50"
+                       th:value="${overview.config['JACKPOT_LOSS_TRIBUTE_PCT']}"
+                       placeholder="10"
+                       th:disabled="${!isOwner}">
+                <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+            </div>
+            <div class="config-row" data-key="POKER_RAKE_PCT">
+                <label>Poker rake (% of every settled pot)</label>
+                <input type="number" min="0" max="20"
+                       th:value="${overview.config['POKER_RAKE_PCT']}"
+                       placeholder="5"
+                       th:disabled="${!isOwner}">
+                <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+            </div>
         </div>
     </section>
 

--- a/web/src/main/resources/templates/poker-guilds.html
+++ b/web/src/main/resources/templates/poker-guilds.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="en">
+<head th:replace="~{fragments/head :: head('TobyBot - Poker', '/css/leaderboard.css')}"></head>
+<body>
+<a href="#main" class="skip-link">Skip to content</a>
+<div th:replace="~{fragments/navbar :: navbar}"></div>
+
+<main id="main" class="container">
+    <h1 class="mb-3">🃏 Poker</h1>
+    <p class="muted mb-5">
+        Multiplayer fixed-limit Texas Hold'em over the social-credit economy.
+        Buy in, deal hands, take credits from your friends. 5% rake feeds the
+        per-server jackpot.
+    </p>
+
+    <div th:if="${error}" class="alert alert-error" th:text="${error}"></div>
+
+    <div class="lb-guild-grid" th:if="${not #lists.isEmpty(guilds)}">
+        <div class="lb-guild-card lb-guild-card-static" th:each="g : ${guilds}">
+            <div class="lb-guild-card-header">
+                <img th:if="${g.iconUrl != null}"
+                     th:src="${g.iconUrl}"
+                     th:alt="${g.name} + ' icon'"
+                     class="lb-guild-icon"
+                     onerror="this.style.display='none'">
+                <div th:unless="${g.iconUrl != null}"
+                     class="lb-guild-icon-placeholder"
+                     aria-hidden="true"
+                     th:text="${#strings.substring(g.name, 0, 1).toUpperCase()}">G</div>
+                <div class="lb-guild-name" th:text="${g.name}" th:title="${g.name}">Guild</div>
+            </div>
+            <div class="lb-guild-top">
+                <span class="muted">Your wallet:</span>
+                <span th:text="${g.credits} + ' credits'">0 credits</span>
+            </div>
+            <div class="lb-guild-games">
+                <a class="btn-secondary" th:href="@{/poker/{id}(id=${g.id})}">🃏 Poker tables</a>
+            </div>
+        </div>
+    </div>
+
+    <div class="empty-hero" th:if="${#lists.isEmpty(guilds)}">
+        <span class="emoji" aria-hidden="true">🃏</span>
+        <h2>No servers to play poker in yet</h2>
+        <p class="mb-5">
+            You need to share at least one server with TobyBot to sit down at a table.
+        </p>
+    </div>
+</main>
+</body>
+</html>

--- a/web/src/main/resources/templates/poker-lobby.html
+++ b/web/src/main/resources/templates/poker-lobby.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="en">
+<head th:replace="~{fragments/head :: head('TobyBot - Poker lobby', '/css/poker.css')}"></head>
+<body>
+<a href="#main" class="skip-link">Skip to content</a>
+<div th:replace="~{fragments/navbar :: navbar}"></div>
+
+<main id="main" class="container"
+      th:attr="data-guild-id=${guildId}, data-min-buyin=${minBuyIn}, data-max-buyin=${maxBuyIn}">
+
+    <div class="poker-header">
+        <a class="back-link" th:href="@{/poker/guilds}">&larr; All servers</a>
+        <h1 th:text="'🃏 Poker • ' + ${guildName}">🃏 Poker</h1>
+        <p class="muted">
+            Fixed-limit Texas Hold'em.
+            Blinds <span th:text="${smallBlind}">5</span>/<span th:text="${bigBlind}">10</span>,
+            bets <span th:text="${smallBet}">10</span>/<span th:text="${bigBet}">20</span>,
+            up to <span th:text="${maxSeats}">6</span> seats per table.
+            5% rake on each pot feeds the per-server jackpot.
+        </p>
+    </div>
+
+    <div th:if="${error}" class="alert alert-error" th:text="${error}"></div>
+
+    <section class="poker-card">
+        <h2>Create a new table</h2>
+        <form id="poker-create" autocomplete="off">
+            <label for="poker-create-buyin">Buy-in (credits)</label>
+            <input id="poker-create-buyin" name="buyIn" type="number"
+                   th:attr="min=${minBuyIn}, max=${maxBuyIn}" th:value="${minBuyIn}" step="1" required>
+            <button type="submit" class="btn-primary">Create table</button>
+        </form>
+        <div>Wallet: <strong id="poker-balance" th:text="${balance}">0</strong> credits</div>
+    </section>
+
+    <section class="poker-card">
+        <h2>Open tables</h2>
+        <div id="poker-table-list" class="poker-table-list">
+            <div th:if="${#lists.isEmpty(tables)}" class="muted">
+                No active tables yet. Create one above.
+            </div>
+            <div class="poker-table-row" th:each="t : ${tables}"
+                 th:attr="data-table-id=${t.tableId}">
+                <div>
+                    <div>Table #<strong th:text="${t.tableId}">1</strong>
+                        — <span th:text="${t.seats}">0</span>/<span th:text="${t.maxSeats}">6</span> seats</div>
+                    <div class="muted">Host: <span th:text="${t.hostDiscordId}">000</span> ·
+                        Phase: <span th:text="${t.phase}">WAITING</span> ·
+                        Hand #<span th:text="${t.handNumber}">0</span></div>
+                </div>
+                <div>
+                    <a class="btn-primary" th:href="@{/poker/{g}/{t}(g=${guildId}, t=${t.tableId})}">Open table</a>
+                </div>
+            </div>
+        </div>
+        <p class="muted">Refreshes automatically.</p>
+    </section>
+</main>
+
+<div class="toast-stack" id="toast-stack" aria-live="polite"></div>
+
+<script th:src="@{/js/api.js}"></script>
+<script th:src="@{/js/toasts.js}"></script>
+<script th:src="@{/js/poker-lobby.js}"></script>
+</body>
+</html>

--- a/web/src/main/resources/templates/poker-table.html
+++ b/web/src/main/resources/templates/poker-table.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="en">
+<head th:replace="~{fragments/head :: head('TobyBot - Poker table', '/css/poker.css')}"></head>
+<body>
+<a href="#main" class="skip-link">Skip to content</a>
+<div th:replace="~{fragments/navbar :: navbar}"></div>
+
+<main id="main" class="container"
+      th:attr="data-guild-id=${guildId},
+               data-table-id=${tableId},
+               data-min-buyin=${minBuyIn},
+               data-max-buyin=${maxBuyIn},
+               data-my-discord-id=${myDiscordId}">
+
+    <div class="poker-header">
+        <a class="back-link" th:href="@{/poker/{g}(g=${guildId})}">&larr; Back to lobby</a>
+        <h1 th:text="'🃏 Table #' + ${tableId}">🃏 Poker table</h1>
+        <p class="muted">
+            Wallet: <strong id="poker-balance" th:text="${balance}">0</strong> credits.
+            Buy-in <span th:text="${minBuyIn}">100</span>–<span th:text="${maxBuyIn}">5000</span> credits.
+        </p>
+    </div>
+
+    <section class="poker-card" id="poker-join-card" hidden>
+        <h2>Join this table</h2>
+        <form id="poker-join" autocomplete="off">
+            <label for="poker-join-buyin">Buy-in</label>
+            <input id="poker-join-buyin" name="buyIn" type="number"
+                   th:attr="min=${minBuyIn}, max=${maxBuyIn}" th:value="${minBuyIn}" step="1" required>
+            <button type="submit" class="btn-primary">Sit down</button>
+        </form>
+    </section>
+
+    <section class="poker-table">
+        <div class="poker-info">
+            <div>Phase: <strong id="poker-phase">—</strong></div>
+            <div>Hand #<strong id="poker-hand-number">0</strong></div>
+            <div>Pot: <strong id="poker-pot">0</strong></div>
+            <div>To call: <strong id="poker-current-bet">0</strong></div>
+        </div>
+
+        <div class="poker-board" id="poker-board"></div>
+
+        <div class="poker-seats" id="poker-seats"></div>
+
+        <div class="poker-actions">
+            <button id="poker-action-checkcall" class="btn-primary" type="button" disabled>Check / Call</button>
+            <button id="poker-action-raise" class="btn-success" type="button" disabled>Raise</button>
+            <button id="poker-action-fold" class="btn-danger" type="button" disabled>Fold</button>
+            <button id="poker-action-start" class="btn-secondary" type="button" hidden>Deal next hand</button>
+            <button id="poker-action-cashout" class="btn-secondary" type="button" hidden>Cash out</button>
+        </div>
+
+        <div id="poker-status" class="muted" style="margin-top: 0.75rem;"></div>
+        <div id="poker-result" class="muted" style="margin-top: 0.5rem;"></div>
+    </section>
+</main>
+
+<div class="toast-stack" id="toast-stack" aria-live="polite"></div>
+
+<script th:src="@{/js/api.js}"></script>
+<script th:src="@{/js/toasts.js}"></script>
+<script th:src="@{/js/poker-table.js}"></script>
+</body>
+</html>

--- a/web/src/test/kotlin/web/controller/PokerControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/PokerControllerTest.kt
@@ -1,0 +1,316 @@
+package web.controller
+
+import database.poker.PokerEngine
+import database.poker.PokerTable
+import database.service.PokerService
+import database.service.PokerService.ActionOutcome
+import database.service.PokerService.BuyInOutcome
+import database.service.PokerService.CashOutOutcome
+import database.service.PokerService.CreateOutcome
+import database.service.PokerService.StartHandOutcome
+import database.service.UserService
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import net.dv8tion.jda.api.JDA
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.security.oauth2.core.user.OAuth2User
+import web.service.EconomyWebService
+import web.service.PokerWebService
+
+class PokerControllerTest {
+
+    private val guildId = 42L
+    private val discordId = 100L
+    private val tableId = 7L
+
+    private lateinit var pokerService: PokerService
+    private lateinit var pokerWebService: PokerWebService
+    private lateinit var economyWebService: EconomyWebService
+    private lateinit var userService: UserService
+    private lateinit var jda: JDA
+    private lateinit var user: OAuth2User
+    private lateinit var controller: PokerController
+
+    @BeforeEach
+    fun setup() {
+        pokerService = mockk(relaxed = true)
+        pokerWebService = mockk(relaxed = true)
+        economyWebService = mockk(relaxed = true)
+        userService = mockk(relaxed = true)
+        jda = mockk(relaxed = true)
+        user = mockk {
+            every { getAttribute<String>("id") } returns discordId.toString()
+            every { getAttribute<String>("username") } returns "tester"
+        }
+        every { economyWebService.isMember(discordId, guildId) } returns true
+        controller = PokerController(pokerService, pokerWebService, economyWebService, userService, jda)
+    }
+
+    @Test
+    fun `state returns 401 for anonymous request`() {
+        val anon = mockk<OAuth2User> {
+            every { getAttribute<String>("id") } returns null
+            every { getAttribute<String>("username") } returns "guest"
+        }
+        val response = controller.state(guildId, tableId, anon)
+        assertEquals(401, response.statusCode.value())
+    }
+
+    @Test
+    fun `state returns 403 for non-member`() {
+        every { economyWebService.isMember(discordId, guildId) } returns false
+        val response = controller.state(guildId, tableId, user)
+        assertEquals(403, response.statusCode.value())
+    }
+
+    @Test
+    fun `state returns 404 when table missing`() {
+        every { pokerWebService.snapshot(tableId, discordId) } returns null
+        val response = controller.state(guildId, tableId, user)
+        assertEquals(404, response.statusCode.value())
+    }
+
+    @Test
+    fun `state returns 404 when table belongs to another guild`() {
+        every { pokerWebService.snapshot(tableId, discordId) } returns sampleView(guildId = 999L)
+        val response = controller.state(guildId, tableId, user)
+        assertEquals(404, response.statusCode.value())
+    }
+
+    @Test
+    fun `state happy path returns the projected snapshot`() {
+        val view = sampleView()
+        every { pokerWebService.snapshot(tableId, discordId) } returns view
+        val response = controller.state(guildId, tableId, user)
+        assertEquals(200, response.statusCode.value())
+        assertEquals(view, response.body)
+    }
+
+    @Test
+    fun `create happy path returns table id`() {
+        every { pokerService.createTable(discordId, guildId, 200L) } returns CreateOutcome.Ok(tableId = 42L)
+
+        val response = controller.create(guildId, CreateRequest(buyIn = 200L), user)
+
+        assertEquals(200, response.statusCode.value())
+        assertTrue(response.body!!.ok)
+        assertEquals(42L, response.body!!.tableId)
+    }
+
+    @Test
+    fun `create propagates invalid buy-in as 400`() {
+        every { pokerService.createTable(discordId, guildId, 1L) } returns CreateOutcome.InvalidBuyIn(100L, 5000L)
+
+        val response = controller.create(guildId, CreateRequest(buyIn = 1L), user)
+
+        assertEquals(400, response.statusCode.value())
+        assertFalse(response.body!!.ok)
+    }
+
+    @Test
+    fun `create rejects non-member`() {
+        every { economyWebService.isMember(discordId, guildId) } returns false
+
+        val response = controller.create(guildId, CreateRequest(buyIn = 200L), user)
+
+        assertEquals(403, response.statusCode.value())
+        verify(exactly = 0) { pokerService.createTable(any(), any(), any()) }
+    }
+
+    @Test
+    fun `join happy path returns ok with new balance`() {
+        every { pokerService.buyIn(discordId, guildId, tableId, 300L) } returns
+            BuyInOutcome.Ok(seatIndex = 1, newBalance = 700L)
+
+        val response = controller.join(guildId, tableId, JoinRequest(buyIn = 300L), user)
+
+        assertEquals(200, response.statusCode.value())
+        assertTrue(response.body!!.ok)
+        assertEquals(700L, response.body!!.newBalance)
+    }
+
+    @Test
+    fun `join already-seated returns 400`() {
+        every { pokerService.buyIn(discordId, guildId, tableId, 300L) } returns BuyInOutcome.AlreadySeated
+        val response = controller.join(guildId, tableId, JoinRequest(buyIn = 300L), user)
+        assertEquals(400, response.statusCode.value())
+    }
+
+    @Test
+    fun `join unknown table returns 404`() {
+        every { pokerService.buyIn(discordId, guildId, tableId, 300L) } returns BuyInOutcome.TableNotFound
+        val response = controller.join(guildId, tableId, JoinRequest(buyIn = 300L), user)
+        assertEquals(404, response.statusCode.value())
+    }
+
+    @Test
+    fun `start happy path`() {
+        every { pokerService.startHand(discordId, guildId, tableId, any()) } returns
+            StartHandOutcome.Ok(handNumber = 5L)
+        val response = controller.start(guildId, tableId, user)
+        assertEquals(200, response.statusCode.value())
+        assertEquals(5L, response.body!!.handNumber)
+    }
+
+    @Test
+    fun `start by non-host returns 403`() {
+        every { pokerService.startHand(discordId, guildId, tableId, any()) } returns StartHandOutcome.NotHost
+        val response = controller.start(guildId, tableId, user)
+        assertEquals(403, response.statusCode.value())
+    }
+
+    @Test
+    fun `action with unknown verb returns 400 without calling service`() {
+        val response = controller.action(guildId, tableId, ActionRequest(action = "wibble"), user)
+        assertEquals(400, response.statusCode.value())
+        verify(exactly = 0) { pokerService.applyAction(any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `action fold happy path returns 200 continued`() {
+        every {
+            pokerService.applyAction(discordId, guildId, tableId, PokerEngine.PokerAction.Fold, any())
+        } returns ActionOutcome.Continued
+        val response = controller.action(guildId, tableId, ActionRequest(action = "fold"), user)
+        assertEquals(200, response.statusCode.value())
+        assertTrue(response.body!!.ok)
+    }
+
+    @Test
+    fun `action raise rejection returns 400 with error reason`() {
+        every {
+            pokerService.applyAction(discordId, guildId, tableId, PokerEngine.PokerAction.Raise, any())
+        } returns ActionOutcome.Rejected(PokerEngine.RejectReason.RAISE_CAP_REACHED)
+
+        val response = controller.action(guildId, tableId, ActionRequest(action = "raise"), user)
+
+        assertEquals(400, response.statusCode.value())
+        assertFalse(response.body!!.ok)
+        assertNotNull(response.body!!.error)
+    }
+
+    @Test
+    fun `action checkcall auto-picks Call when bet owed`() {
+        // Synthesise a snapshot where the viewer owes money.
+        val table = mockk<PokerTable>()
+        every { pokerService.snapshot(tableId) } returns table
+        val seat = PokerTable.Seat(discordId = discordId, chips = 1000L, committedThisRound = 0L)
+        every { table.seats } returns mutableListOf(seat)
+        every { table.currentBet } returns 10L
+
+        every {
+            pokerService.applyAction(discordId, guildId, tableId, PokerEngine.PokerAction.Call, any())
+        } returns ActionOutcome.Continued
+
+        val response = controller.action(guildId, tableId, ActionRequest(action = "checkcall"), user)
+        assertEquals(200, response.statusCode.value())
+        verify {
+            pokerService.applyAction(discordId, guildId, tableId, PokerEngine.PokerAction.Call, any())
+        }
+    }
+
+    @Test
+    fun `action checkcall auto-picks Check when nothing owed`() {
+        val table = mockk<PokerTable>()
+        every { pokerService.snapshot(tableId) } returns table
+        val seat = PokerTable.Seat(discordId = discordId, chips = 1000L, committedThisRound = 10L)
+        every { table.seats } returns mutableListOf(seat)
+        every { table.currentBet } returns 10L
+
+        every {
+            pokerService.applyAction(discordId, guildId, tableId, PokerEngine.PokerAction.Check, any())
+        } returns ActionOutcome.Continued
+
+        val response = controller.action(guildId, tableId, ActionRequest(action = "checkcall"), user)
+        assertEquals(200, response.statusCode.value())
+        verify {
+            pokerService.applyAction(discordId, guildId, tableId, PokerEngine.PokerAction.Check, any())
+        }
+    }
+
+    @Test
+    fun `action handResolved returns ok with pot+rake`() {
+        val result = PokerTable.HandResult(
+            handNumber = 7L,
+            winners = listOf(discordId),
+            payoutByDiscordId = mapOf(discordId to 95L),
+            pot = 100L,
+            rake = 5L,
+            board = emptyList(),
+            revealedHoleCards = emptyMap(),
+            resolvedAt = java.time.Instant.now()
+        )
+        every {
+            pokerService.applyAction(discordId, guildId, tableId, PokerEngine.PokerAction.Fold, any())
+        } returns ActionOutcome.HandResolved(result)
+
+        val response = controller.action(guildId, tableId, ActionRequest(action = "fold"), user)
+
+        assertEquals(200, response.statusCode.value())
+        assertEquals(7L, response.body!!.handNumber)
+        assertEquals(100L, response.body!!.pot)
+        assertEquals(5L, response.body!!.rake)
+    }
+
+    @Test
+    fun `cashout happy path returns ok with chips returned`() {
+        every { pokerService.cashOut(discordId, guildId, tableId) } returns
+            CashOutOutcome.Ok(chipsReturned = 250L, newBalance = 1250L)
+        val response = controller.cashOut(guildId, tableId, user)
+        assertEquals(200, response.statusCode.value())
+        assertEquals(250L, response.body!!.chipsReturned)
+    }
+
+    @Test
+    fun `cashout while hand in progress returns 400`() {
+        every { pokerService.cashOut(discordId, guildId, tableId) } returns CashOutOutcome.HandInProgress
+        val response = controller.cashOut(guildId, tableId, user)
+        assertEquals(400, response.statusCode.value())
+    }
+
+    @Test
+    fun `cashout missing table returns 404`() {
+        every { pokerService.cashOut(discordId, guildId, tableId) } returns CashOutOutcome.TableNotFound
+        val response = controller.cashOut(guildId, tableId, user)
+        assertEquals(404, response.statusCode.value())
+    }
+
+    private fun sampleView(guildId: Long = this.guildId): PokerWebService.TableStateView =
+        PokerWebService.TableStateView(
+            tableId = tableId,
+            guildId = guildId,
+            hostDiscordId = discordId,
+            phase = "WAITING",
+            handNumber = 0L,
+            pot = 0L,
+            currentBet = 0L,
+            raisesThisStreet = 0,
+            maxRaisesPerStreet = 4,
+            smallBlind = 5L,
+            bigBlind = 10L,
+            smallBet = 10L,
+            bigBet = 20L,
+            minBuyIn = 100L,
+            maxBuyIn = 5000L,
+            maxSeats = 6,
+            dealerIndex = 0,
+            actorIndex = 0,
+            community = emptyList(),
+            seats = emptyList(),
+            mySeatIndex = null,
+            myHoleCards = emptyList(),
+            isMyTurn = false,
+            canCheck = false,
+            canCall = false,
+            canRaise = false,
+            callAmount = 0L,
+            raiseAmount = 0L,
+            lastResult = null
+        )
+}

--- a/web/src/test/kotlin/web/service/PokerWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/PokerWebServiceTest.kt
@@ -8,7 +8,6 @@ import database.poker.Rank
 import database.poker.Suit
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
-import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
@@ -145,12 +144,12 @@ class PokerWebServiceTest {
             resolvedAt = Instant.now()
         )
         val view = service.snapshot(table.id, viewerDiscordId = 1L)!!
-        assertNotNull(view.lastResult)
-        assertEquals(1L, view.lastResult!!.handNumber)
-        assertEquals(95L, view.lastResult!!.payoutByDiscordId["1"])
-        assertEquals(100L, view.lastResult!!.pot)
-        assertEquals(5L, view.lastResult!!.rake)
-        assertEquals(listOf("A♠", "K♥"), view.lastResult!!.board)
-        assertEquals(listOf("Q♠"), view.lastResult!!.revealedHoleCards["1"])
+        val lastResult = view.lastResult!!
+        assertEquals(1L, lastResult.handNumber)
+        assertEquals(95L, lastResult.payoutByDiscordId["1"])
+        assertEquals(100L, lastResult.pot)
+        assertEquals(5L, lastResult.rake)
+        assertEquals(listOf("A♠", "K♥"), lastResult.board)
+        assertEquals(listOf("Q♠"), lastResult.revealedHoleCards["1"])
     }
 }

--- a/web/src/test/kotlin/web/service/PokerWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/PokerWebServiceTest.kt
@@ -1,0 +1,156 @@
+package web.service
+
+import database.poker.Card
+import database.poker.PokerEngine
+import database.poker.PokerTable
+import database.poker.PokerTableRegistry
+import database.poker.Rank
+import database.poker.Suit
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.time.Instant
+import kotlin.random.Random
+
+class PokerWebServiceTest {
+
+    private lateinit var registry: PokerTableRegistry
+    private lateinit var service: PokerWebService
+
+    @BeforeEach
+    fun setup() {
+        registry = PokerTableRegistry(
+            idleTtl = Duration.ofMinutes(5),
+            sweepInterval = Duration.ofHours(1)
+        )
+        service = PokerWebService(registry)
+    }
+
+    private fun makeTable(seatChips: List<Pair<Long, Long>> = listOf(1L to 1000L, 2L to 1000L)): PokerTable {
+        val t = registry.create(
+            guildId = 42L,
+            hostDiscordId = seatChips.first().first,
+            minBuyIn = 100L,
+            maxBuyIn = 5000L,
+            smallBlind = 5L,
+            bigBlind = 10L,
+            smallBet = 10L,
+            bigBet = 20L,
+            maxRaisesPerStreet = 4,
+            maxSeats = 6,
+        )
+        seatChips.forEach { (id, chips) ->
+            t.seats.add(PokerTable.Seat(discordId = id, chips = chips))
+        }
+        return t
+    }
+
+    @Test
+    fun `snapshot of unknown table is null`() {
+        assertNull(service.snapshot(tableId = 999L, viewerDiscordId = 1L))
+    }
+
+    @Test
+    fun `snapshot in lobby phase returns empty community and zero pot`() {
+        val table = makeTable()
+        val view = service.snapshot(table.id, viewerDiscordId = 1L)!!
+        assertEquals(table.id, view.tableId)
+        assertEquals("WAITING", view.phase)
+        assertEquals(0L, view.pot)
+        assertTrue(view.community.isEmpty())
+        assertFalse(view.isMyTurn)
+        assertFalse(view.canCheck)
+        assertFalse(view.canCall)
+        assertFalse(view.canRaise)
+    }
+
+    @Test
+    fun `snapshot masks other players hole cards but reveals viewer cards`() {
+        val table = makeTable()
+        // Force a hand to be in flight.
+        PokerEngine.startHand(table, Random(0), Instant.now())
+
+        // Viewer is seat 0 (discordId 1).
+        val viewAsSeat0 = service.snapshot(table.id, viewerDiscordId = 1L)!!
+        val seat0 = viewAsSeat0.seats[0]
+        val seat1 = viewAsSeat0.seats[1]
+
+        assertEquals(2, seat0.holeCards.size, "viewer's own seat shows hole cards")
+        assertTrue(seat1.holeCards.isEmpty(), "other seats are masked server-side")
+        // The flat helper returns the same view as the seat slice.
+        assertEquals(seat0.holeCards, viewAsSeat0.myHoleCards)
+
+        // Now from seat 1's perspective, seat 1 should see their own and seat 0 masked.
+        val viewAsSeat1 = service.snapshot(table.id, viewerDiscordId = 2L)!!
+        assertTrue(viewAsSeat1.seats[0].holeCards.isEmpty())
+        assertEquals(2, viewAsSeat1.seats[1].holeCards.size)
+        // Seats are different cards (same deck but different positions).
+        assertEquals(viewAsSeat1.seats[1].holeCards, viewAsSeat1.myHoleCards)
+    }
+
+    @Test
+    fun `snapshot for a non-seated viewer returns mySeatIndex null and empty hole cards`() {
+        val table = makeTable()
+        PokerEngine.startHand(table, Random(0), Instant.now())
+        val view = service.snapshot(table.id, viewerDiscordId = 999L)!!
+        assertNull(view.mySeatIndex)
+        assertTrue(view.myHoleCards.isEmpty())
+        // Every other seat is also masked.
+        view.seats.forEach { assertTrue(it.holeCards.isEmpty()) }
+    }
+
+    @Test
+    fun `snapshot computes canCheck canCall canRaise based on the betting state`() {
+        val table = makeTable()
+        PokerEngine.startHand(table, Random(0), Instant.now())
+        // Heads-up: dealer = SB acts first preflop with 5 owed to the BB.
+        val sbDiscordId = table.seats[table.dealerIndex].discordId
+        val view = service.snapshot(table.id, viewerDiscordId = sbDiscordId)!!
+        assertTrue(view.isMyTurn)
+        assertTrue(view.canCall, "SB owes the difference and has chips")
+        assertFalse(view.canCheck, "can't check facing a bet")
+        assertTrue(view.canRaise)
+        assertEquals(5L, view.callAmount)
+        assertEquals(15L, view.raiseAmount, "callAmount + smallBet = 5 + 10")
+    }
+
+    @Test
+    fun `listGuildTables returns a sorted summary view`() {
+        val a = makeTable(listOf(1L to 1000L, 2L to 1000L))
+        val b = makeTable(listOf(3L to 1000L, 4L to 1000L))
+        val rows = service.listGuildTables(guildId = 42L)
+        assertEquals(2, rows.size)
+        assertTrue(rows[0].tableId < rows[1].tableId, "sorted by tableId")
+        assertEquals(a.maxSeats, rows[0].maxSeats)
+        assertEquals(b.seats.size, rows[1].seats)
+    }
+
+    @Test
+    fun `lastResult is projected when populated`() {
+        val table = makeTable()
+        // Synthesise a HandResult by hand to test projection without running a hand.
+        table.lastResult = PokerTable.HandResult(
+            handNumber = 1L,
+            winners = listOf(1L),
+            payoutByDiscordId = mapOf(1L to 95L),
+            pot = 100L,
+            rake = 5L,
+            board = listOf(Card(Rank.ACE, Suit.SPADES), Card(Rank.KING, Suit.HEARTS)),
+            revealedHoleCards = mapOf(1L to listOf(Card(Rank.QUEEN, Suit.SPADES))),
+            resolvedAt = Instant.now()
+        )
+        val view = service.snapshot(table.id, viewerDiscordId = 1L)!!
+        assertNotNull(view.lastResult)
+        assertEquals(1L, view.lastResult!!.handNumber)
+        assertEquals(95L, view.lastResult!!.payoutByDiscordId["1"])
+        assertEquals(100L, view.lastResult!!.pot)
+        assertEquals(5L, view.lastResult!!.rake)
+        assertEquals(listOf("A♠", "K♥"), view.lastResult!!.board)
+        assertEquals(listOf("Q♠"), view.lastResult!!.revealedHoleCards["1"])
+    }
+}


### PR DESCRIPTION
## Summary
- Adds multiplayer fixed-limit Texas Hold'em as both a Discord slash command (`/poker create|join|start|leave|tables|peek`) and a web UI (`/poker/{guildId}/{tableId}`), 2-6 players per table.
- Mirrors the `/duel` architecture exactly: in-memory `PokerTableRegistry` shared between Discord and web; `PokerService` handles atomic buy-in/cash-out against `social_credit`; engine logic lives in pure `PokerEngine` for unit-testability.
- 5% rake (configurable per guild via `POKER_RAKE_PCT`, capped at 20%) on every settled pot routes to the existing `JackpotService`, matching how `/duel` and the slot machines feed it.

## How it works
- **Buy-in / cash-out** debits/credits `social_credit` once per session; chips are escrowed at the table during play (no DB write per bet, no rollback complexity).
- **State machine** in `PokerEngine`: post blinds → pre-flop → flop → turn → river → showdown. Standard small/big blind, fixed-limit bets (10 pre-flop/flop, 20 turn/river), 4 raises per street.
- **Hand evaluator** is pure 5-from-7 with full tiebreakers (kickers, wheel handling, steel wheel as 5-high straight flush).
- **Web UI** polls `/state` every 2s. **Opponent hole cards are masked server-side** in `PokerWebService` — even a hostile client reading the JSON can't see other players' cards (asserted in tests).
- **Per-table monitor** (`PokerTableRegistry.lockTable`) serialises Discord button clicks and web POSTs against the same hand state.
- **Idle-table sweeper** auto-cashes-out tables after 10 min of inactivity so abandoned games don't trap players' credits.

## v1 simplifications
- **No side pots.** An all-in short stack can win the entire pot at showdown. Documented in code; v2 can add proper side-pot accounting.
- **Buy-in/cash-out only between hands.** Mid-hand leavers must fold first, then `/poker leave`.
- Fixed-limit only; no-limit can come later.

## Files
- `database/poker/` — `Card`, `Deck`, `HandEvaluator`, `PokerTable`, `PokerEngine`, `PokerTableRegistry`
- `database/service/PokerService.kt` + `dto/PokerHandLogDto.kt` + `persistence/PokerHandLogPersistence.kt` (+ default impl)
- `discord-bot/.../economy/PokerCommand.kt`, `PokerEmbeds.kt`, `button/buttons/PokerActionButton.kt`
- `web/.../controller/PokerController.kt`, `service/PokerWebService.kt`, templates `poker-{guilds,lobby,table}.html`, JS `poker-{lobby,table}.js`, CSS `poker.css`
- Migration `V22__poker_hand_log.sql` + `POKER_RAKE_PCT` enum entry + `WebSecurityConfig` route gate

## Tests
**94 new tests, all passing** locally for the database + web modules:
- `HandEvaluatorTest` (14): every category, kicker tiebreakers, wheel + steel wheel, flush vs straight precedence
- `PokerEngineTest` (15): blind posting, raise cap, fold short-circuit, street advance, chip conservation across full hand, all-in path
- `PokerTableRegistryTest` (7): concurrent `lockTable` invocations strictly serialise; idle sweep evicts via callback
- `PokerServiceTest` (21): buy-in debits, cash-out refunds, settlement awards pot − rake, rake routes to jackpot
- `PokerWebServiceTest` (7): **hole-card masking is server-side**, projection round-trip, betting-state derivation
- `PokerControllerTest` (22): every endpoint × every error path, `checkcall` auto-pick correctness
- `CardTest`, `DeckTest`: deterministic-seed shuffles
- Plus `PokerEmbedsTest`, `PokerCommandTest`, `PokerActionButtonTest` for the Discord layer (couldn't run locally — see Test plan)

## Test plan
- [x] `./gradlew :database:test` — 65 poker tests pass (CardTest 4, DeckTest 4, HandEvaluatorTest 14, PokerEngineTest 15, PokerTableRegistryTest 7, PokerServiceTest 21)
- [x] `./gradlew :web:test` — 29 poker tests pass (PokerWebServiceTest 7, PokerControllerTest 22)
- [ ] `./gradlew :discord-bot:test` — couldn't verify in the dev sandbox: `dev.lavalink.youtube:common:1.18.0` and `moe.kyokobot.libdave:*` 403'd from every configured maven repo (pre-existing transitive dep, unrelated to this PR). The 3 new Discord-side test files (`PokerCommandTest`, `PokerActionButtonTest`, `PokerEmbedsTest`) follow the exact patterns of `DuelCommandTest` / `DuelButtonTest` so should slot straight into CI.
- [ ] End-to-end Discord smoke: `/poker create chips:500`, second account `/poker join`, host `/poker start`, click Check/Call/Raise/Fold across two hands, verify credits debited at buy-in and credited at `/poker leave`, verify jackpot pool incremented by 5% of each pot.
- [ ] End-to-end web smoke: `./gradlew :application:bootRun`, log in via Discord OAuth, navigate `/poker/{guildId}`, create + join from two browser sessions, play a hand, confirm own hole cards visible and opponent's masked in the JSON snapshot (DevTools → Network → `/state`).

https://claude.ai/code/session_0169MvtJ2BSbwkoB9GrFhfZC

---
_Generated by [Claude Code](https://claude.ai/code/session_0169MvtJ2BSbwkoB9GrFhfZC)_