### PR TITLE
feat(duel): ping opponent, 3-minute TTL, outgoing offers + cancel

### DIFF
--- a/database/src/main/kotlin/database/duel/PendingDuelRegistry.kt
+++ b/database/src/main/kotlin/database/duel/PendingDuelRegistry.kt
@@ -11,18 +11,18 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicLong
 
 /**
- * In-memory book of pending duel offers (the 60-second Accept/Decline
- * window between `/duel` and the opponent's button click). Shared
- * across the whole Spring context so the Discord button handler and
- * the web controller see the same offers — there is exactly one
+ * In-memory book of pending duel offers (the Accept/Decline window
+ * between `/duel` and the opponent's button click; see [DEFAULT_TTL]).
+ * Shared across the whole Spring context so the Discord button handler
+ * and the web controller see the same offers — there is exactly one
  * authoritative bean.
  *
  * Mid-flight offers are lost on bot restart. Acceptable since the TTL
- * is 60 seconds and offers don't move credits until accepted.
+ * is short and offers don't move credits until accepted.
  */
 @Component
 class PendingDuelRegistry(
-    private val ttl: Duration = DEFAULT_TTL,
+    val ttl: Duration = DEFAULT_TTL,
     private val scheduler: ScheduledExecutorService = Executors.newScheduledThreadPool(2)
 ) {
     data class PendingDuel(
@@ -81,6 +81,10 @@ class PendingDuelRegistry(
     fun pendingForOpponent(discordId: Long, guildId: Long): List<PendingDuel> =
         offers.values.filter { it.opponentDiscordId == discordId && it.guildId == guildId }
 
+    /** All offers where [discordId] is the initiator — used by the web outbox. */
+    fun pendingForInitiator(discordId: Long, guildId: Long): List<PendingDuel> =
+        offers.values.filter { it.initiatorDiscordId == discordId && it.guildId == guildId }
+
     fun get(id: Long): PendingDuel? = offers[id]
 
     @PreDestroy
@@ -89,6 +93,21 @@ class PendingDuelRegistry(
     }
 
     companion object {
-        val DEFAULT_TTL: Duration = Duration.ofSeconds(60)
+        val DEFAULT_TTL: Duration = Duration.ofMinutes(3)
+
+        /** "3m" / "90s" / "1h 5m" — short-form TTL display for embed copy and web UI. */
+        fun formatTtl(ttl: Duration): String {
+            val total = ttl.seconds.coerceAtLeast(0)
+            val hours = total / 3600
+            val minutes = (total % 3600) / 60
+            val seconds = total % 60
+            return when {
+                hours > 0 && minutes > 0 -> "${hours}h ${minutes}m"
+                hours > 0 -> "${hours}h"
+                minutes > 0 && seconds > 0 -> "${minutes}m ${seconds}s"
+                minutes > 0 -> "${minutes}m"
+                else -> "${seconds}s"
+            }
+        }
     }
 }

--- a/database/src/test/kotlin/database/duel/PendingDuelRegistryTest.kt
+++ b/database/src/test/kotlin/database/duel/PendingDuelRegistryTest.kt
@@ -95,4 +95,25 @@ class PendingDuelRegistryTest {
         assertEquals(2, rows.size)
         assertTrue(rows.all { it.opponentDiscordId == 20L && it.guildId == 1L })
     }
+
+    @Test
+    fun `pendingForInitiator returns only matching offers`() {
+        val registry = newRegistry(ttl = Duration.ofSeconds(60))
+        registry.register(1L, 10L, 20L, 50L)   // initiator 10 in guild 1
+        registry.register(1L, 10L, 21L, 75L)   // initiator 10 in guild 1, different opponent
+        registry.register(2L, 10L, 22L, 25L)   // initiator 10 in guild 2 — different guild
+        registry.register(1L, 99L, 23L, 30L)   // different initiator
+
+        val rows = registry.pendingForInitiator(10L, 1L)
+        assertEquals(2, rows.size)
+        assertTrue(rows.all { it.initiatorDiscordId == 10L && it.guildId == 1L })
+    }
+
+    @Test
+    fun `formatTtl renders short forms`() {
+        assertEquals("3m", PendingDuelRegistry.formatTtl(Duration.ofMinutes(3)))
+        assertEquals("45s", PendingDuelRegistry.formatTtl(Duration.ofSeconds(45)))
+        assertEquals("1m 30s", PendingDuelRegistry.formatTtl(Duration.ofSeconds(90)))
+        assertEquals("1h 5m", PendingDuelRegistry.formatTtl(Duration.ofMinutes(65)))
+    }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/DuelCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/DuelCommand.kt
@@ -115,10 +115,10 @@ class DuelCommand @Autowired constructor(
             "Decline"
         )
 
-        // sendMessage(content) (not sendMessageEmbeds) so the <@opponent> in the
-        // content actually pings — embed-mention pings are silent.
-        event.hook.sendMessage("<@$opponentId>")
-            .setEmbeds(DuelEmbeds.offerEmbed(initiatorId, opponentId, stake, pendingDuelRegistry.ttl))
+        // addContent on the message (not the embed description) so the
+        // <@opponent> mention actually pings — embed-mention pings are silent.
+        event.hook.sendMessageEmbeds(DuelEmbeds.offerEmbed(initiatorId, opponentId, stake, pendingDuelRegistry.ttl))
+            .addContent("<@$opponentId>")
             .addComponents(ActionRow.of(accept, decline))
             .queue()
     }

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/DuelCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/DuelCommand.kt
@@ -40,7 +40,6 @@ class DuelCommand @Autowired constructor(
     companion object {
         private const val OPT_USER = "user"
         private const val OPT_STAKE = "stake"
-        private const val TTL_SECONDS = 60L
     }
 
     override val optionData: List<OptionData> = listOf(
@@ -116,9 +115,12 @@ class DuelCommand @Autowired constructor(
             "Decline"
         )
 
-        event.hook.sendMessageEmbeds(
-            DuelEmbeds.offerEmbed(initiatorId, opponentId, stake, TTL_SECONDS)
-        ).addComponents(ActionRow.of(accept, decline)).queue()
+        // sendMessage(content) (not sendMessageEmbeds) so the <@opponent> in the
+        // content actually pings — embed-mention pings are silent.
+        event.hook.sendMessage("<@$opponentId>")
+            .setEmbeds(DuelEmbeds.offerEmbed(initiatorId, opponentId, stake, pendingDuelRegistry.ttl))
+            .addComponents(ActionRow.of(accept, decline))
+            .queue()
     }
 
     private fun replyError(

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/DuelEmbeds.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/DuelEmbeds.kt
@@ -1,10 +1,12 @@
 package bot.toby.command.commands.economy
 
+import database.duel.PendingDuelRegistry
 import database.service.DuelService.AcceptOutcome
 import database.service.DuelService.StartOutcome
 import net.dv8tion.jda.api.EmbedBuilder
 import net.dv8tion.jda.api.entities.MessageEmbed
 import java.awt.Color
+import java.time.Duration
 
 /**
  * Shared embed/component plumbing for the Discord `/duel` flow.
@@ -54,13 +56,13 @@ internal object DuelEmbeds {
         initiatorDiscordId: Long,
         opponentDiscordId: Long,
         stake: Long,
-        ttlSeconds: Long
+        ttl: Duration
     ): MessageEmbed = EmbedBuilder()
         .setTitle("⚔️ Duel offered")
         .setDescription(
             "<@$initiatorDiscordId> challenges <@$opponentDiscordId> to a duel for **$stake credits** each. " +
                 "Winner takes the pot (minus a small jackpot tribute). " +
-                "Accept within ${ttlSeconds}s."
+                "Accept within ${PendingDuelRegistry.formatTtl(ttl)}."
         )
         .setColor(OFFER_COLOR)
         .build()

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/economy/DuelCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/economy/DuelCommandTest.kt
@@ -17,6 +17,7 @@ import net.dv8tion.jda.api.interactions.commands.OptionMapping
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import java.time.Duration
 
 internal class DuelCommandTest : CommandTest {
     private lateinit var duelService: DuelService
@@ -33,6 +34,7 @@ internal class DuelCommandTest : CommandTest {
         setUpCommonMocks()
         duelService = mockk(relaxed = true)
         pendingDuelRegistry = mockk(relaxed = true)
+        every { pendingDuelRegistry.ttl } returns Duration.ofMinutes(3)
         userDtoHelper = mockk(relaxed = true)
         command = DuelCommand(duelService, pendingDuelRegistry, userDtoHelper)
         every { guild.idLong } returns guildId

--- a/web/src/main/kotlin/web/controller/DuelController.kt
+++ b/web/src/main/kotlin/web/controller/DuelController.kt
@@ -76,6 +76,7 @@ class DuelController(
         val profile = userService.getUserById(discordId, guildId)
         val balance = profile?.socialCredit ?: 0L
         val pending = duelWebService.pendingForOpponent(discordId, guildId)
+        val outgoing = duelWebService.pendingForInitiator(discordId, guildId)
         val members = economyWebService.getGuildMembers(guildId).filter { it.id != discordId.toString() }
 
         model.addAttribute("guildId", guildId.toString())
@@ -84,6 +85,8 @@ class DuelController(
         model.addAttribute("minStake", DuelService.MIN_STAKE)
         model.addAttribute("maxStake", DuelService.MAX_STAKE)
         model.addAttribute("pending", pending)
+        model.addAttribute("outgoing", outgoing)
+        model.addAttribute("ttlLabel", PendingDuelRegistry.formatTtl(pendingDuelRegistry.ttl))
         model.addAttribute("members", members)
         model.addAttribute("username", user.displayName())
         return "duel"
@@ -100,6 +103,19 @@ class DuelController(
             return ResponseEntity.status(403).build()
         }
         return ResponseEntity.ok(duelWebService.pendingForOpponent(discordId, guildId))
+    }
+
+    @GetMapping("/{guildId}/outgoing")
+    @ResponseBody
+    fun outgoingForMe(
+        @PathVariable guildId: Long,
+        @AuthenticationPrincipal user: OAuth2User,
+    ): ResponseEntity<List<DuelWebService.PendingDuelView>> {
+        val discordId = user.discordIdOrNull() ?: return ResponseEntity.status(401).build()
+        if (!economyWebService.isMember(discordId, guildId)) {
+            return ResponseEntity.status(403).build()
+        }
+        return ResponseEntity.ok(duelWebService.pendingForInitiator(discordId, guildId))
     }
 
     @PostMapping("/{guildId}/challenge")
@@ -217,6 +233,29 @@ class DuelController(
             return ResponseEntity.badRequest().body(DuelActionResponse(false, error = "Wrong guild for this offer."))
         }
         if (offer.opponentDiscordId != discordId) {
+            return ResponseEntity.status(403).body(DuelActionResponse(false, error = "This isn't your duel offer."))
+        }
+        pendingDuelRegistry.cancel(duelId)
+            ?: return ResponseEntity.status(410).body(DuelActionResponse(false, error = "This offer already resolved or expired."))
+        return ResponseEntity.ok(DuelActionResponse(ok = true))
+    }
+
+    @PostMapping("/{guildId}/{duelId}/cancel")
+    @ResponseBody
+    fun cancel(
+        @PathVariable guildId: Long,
+        @PathVariable duelId: Long,
+        @AuthenticationPrincipal user: OAuth2User,
+    ): ResponseEntity<DuelActionResponse> {
+        val discordId = user.discordIdOrNull()
+            ?: return ResponseEntity.status(401).body(DuelActionResponse(false, error = "Not signed in."))
+
+        val offer = pendingDuelRegistry.get(duelId)
+            ?: return ResponseEntity.status(410).body(DuelActionResponse(false, error = "This offer already resolved or expired."))
+        if (offer.guildId != guildId) {
+            return ResponseEntity.badRequest().body(DuelActionResponse(false, error = "Wrong guild for this offer."))
+        }
+        if (offer.initiatorDiscordId != discordId) {
             return ResponseEntity.status(403).body(DuelActionResponse(false, error = "This isn't your duel offer."))
         }
         pendingDuelRegistry.cancel(duelId)

--- a/web/src/main/kotlin/web/service/DuelWebService.kt
+++ b/web/src/main/kotlin/web/service/DuelWebService.kt
@@ -23,14 +23,18 @@ class DuelWebService(
     )
 
     fun pendingForOpponent(discordId: Long, guildId: Long): List<PendingDuelView> =
-        pendingDuelRegistry.pendingForOpponent(discordId, guildId).map {
-            PendingDuelView(
-                duelId = it.id,
-                initiatorDiscordId = it.initiatorDiscordId,
-                opponentDiscordId = it.opponentDiscordId,
-                stake = it.stake
-            )
-        }
+        pendingDuelRegistry.pendingForOpponent(discordId, guildId).map(::toView)
+
+    fun pendingForInitiator(discordId: Long, guildId: Long): List<PendingDuelView> =
+        pendingDuelRegistry.pendingForInitiator(discordId, guildId).map(::toView)
+
+    private fun toView(d: PendingDuelRegistry.PendingDuel): PendingDuelView =
+        PendingDuelView(
+            duelId = d.id,
+            initiatorDiscordId = d.initiatorDiscordId,
+            opponentDiscordId = d.opponentDiscordId,
+            stake = d.stake
+        )
 
     fun ensureOpponent(opponentDiscordId: Long, guildId: Long): UserDto {
         return userService.getUserById(opponentDiscordId, guildId)

--- a/web/src/main/resources/static/js/duel.js
+++ b/web/src/main/resources/static/js/duel.js
@@ -12,6 +12,7 @@
     const balanceEl = document.getElementById('duel-balance');
     const challengeForm = document.getElementById('duel-challenge');
     const pendingList = document.getElementById('duel-pending-list');
+    const outgoingList = document.getElementById('duel-outgoing-list');
 
     function showToast(level, msg) {
         if (window.TobyToasts && window.TobyToasts[level]) window.TobyToasts[level](msg);
@@ -50,6 +51,43 @@
             .catch(function () { /* keep last known state */ });
     }
 
+    function renderOutgoing(rows) {
+        if (!outgoingList) return;
+        outgoingList.innerHTML = '';
+        if (!rows || rows.length === 0) {
+            const empty = document.createElement('div');
+            empty.className = 'muted';
+            empty.textContent = 'No outgoing challenges right now.';
+            outgoingList.appendChild(empty);
+            return;
+        }
+        rows.forEach(function (row) {
+            const node = document.createElement('div');
+            node.className = 'duel-pending-row';
+            node.dataset.duelId = String(row.duelId);
+            node.dataset.stake = String(row.stake);
+            node.innerHTML =
+                '<div><span>To <strong>' + row.opponentDiscordId + '</strong></span>' +
+                '<span> for <strong>' + row.stake + '</strong> credits</span></div>' +
+                '<div class="duel-pending-actions">' +
+                '<button class="btn-secondary duel-cancel" type="button">Cancel</button>' +
+                '</div>';
+            outgoingList.appendChild(node);
+        });
+    }
+
+    function refreshOutgoing() {
+        fetch('/duel/' + guildId + '/outgoing', { credentials: 'same-origin' })
+            .then(function (r) { return r.ok ? r.json() : []; })
+            .then(renderOutgoing)
+            .catch(function () { /* keep last known state */ });
+    }
+
+    function refreshAll() {
+        refreshPending();
+        refreshOutgoing();
+    }
+
     if (challengeForm) {
         challengeForm.addEventListener('submit', function (e) {
             e.preventDefault();
@@ -71,7 +109,8 @@
                     showToast('error', (resp && resp.error) || 'Challenge failed.');
                     return;
                 }
-                showToast('success', 'Challenge sent. Waiting for them to accept (60s window).');
+                showToast('success', 'Challenge sent. Waiting for them to accept.');
+                refreshOutgoing();
             }).catch(function () { showToast('error', 'Network error sending challenge.'); });
         });
     }
@@ -92,7 +131,7 @@
             window.TobyApi.postJson(path, {}).then(function (resp) {
                 if (!resp || !resp.ok) {
                     showToast('error', (resp && resp.error) || 'Action failed.');
-                    refreshPending();
+                    refreshAll();
                     return;
                 }
                 if (isAccept && resp.winnerDiscordId) {
@@ -107,10 +146,31 @@
                 } else if (isDecline) {
                     showToast('success', 'Declined.');
                 }
-                refreshPending();
+                refreshAll();
             }).catch(function () { showToast('error', 'Network error.'); });
         });
     }
 
-    setInterval(refreshPending, 5000);
+    if (outgoingList) {
+        outgoingList.addEventListener('click', function (e) {
+            const btn = e.target.closest('button.duel-cancel');
+            if (!btn) return;
+            const row = btn.closest('.duel-pending-row');
+            if (!row) return;
+            const duelId = row.dataset.duelId;
+            if (!duelId) return;
+            window.TobyApi.postJson('/duel/' + guildId + '/' + duelId + '/cancel', {})
+                .then(function (resp) {
+                    if (!resp || !resp.ok) {
+                        showToast('error', (resp && resp.error) || 'Cancel failed.');
+                    } else {
+                        showToast('success', 'Cancelled.');
+                    }
+                    refreshOutgoing();
+                })
+                .catch(function () { showToast('error', 'Network error.'); });
+        });
+    }
+
+    setInterval(refreshAll, 5000);
 })();

--- a/web/src/main/resources/templates/duel.html
+++ b/web/src/main/resources/templates/duel.html
@@ -60,7 +60,24 @@
                 </div>
             </div>
         </div>
-        <p class="muted">Offers expire after 60 seconds. Refreshes automatically.</p>
+        <p class="muted">Offers expire after <span th:text="${ttlLabel}">3m</span>. Refreshes automatically.</p>
+    </section>
+
+    <section class="duel-outbox">
+        <h2>Your outgoing offers</h2>
+        <div id="duel-outgoing-list" class="duel-pending-list">
+            <div th:if="${#lists.isEmpty(outgoing)}" class="muted">No outgoing challenges right now.</div>
+            <div class="duel-pending-row" th:each="p : ${outgoing}"
+                 th:attr="data-duel-id=${p.duelId}, data-stake=${p.stake}">
+                <div>
+                    <span>To <strong th:text="${p.opponentDiscordId}">user</strong></span>
+                    <span> for <strong th:text="${p.stake}">100</strong> credits</span>
+                </div>
+                <div class="duel-pending-actions">
+                    <button class="btn-secondary duel-cancel" type="button">Cancel</button>
+                </div>
+            </div>
+        </div>
     </section>
 </main>
 

--- a/web/src/test/kotlin/web/controller/DuelControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/DuelControllerTest.kt
@@ -191,4 +191,56 @@ class DuelControllerTest {
 
         assertEquals(403, response.statusCode.value())
     }
+
+    private fun outgoing() = PendingDuelRegistry.PendingDuel(
+        id = duelId, guildId = guildId,
+        initiatorDiscordId = discordId, opponentDiscordId = opponentId,
+        stake = 50L, createdAt = Instant.now()
+    )
+
+    @Test
+    fun `cancel cancels the offer when caller is the initiator`() {
+        every { pendingDuelRegistry.get(duelId) } returns outgoing()
+        every { pendingDuelRegistry.cancel(duelId) } returns outgoing()
+
+        val response = controller.cancel(guildId, duelId, user)
+
+        assertEquals(200, response.statusCode.value())
+        assertTrue(response.body!!.ok)
+    }
+
+    @Test
+    fun `cancel by non-initiator returns 403`() {
+        // Offer's initiator is someone OTHER than the requesting user.
+        every { pendingDuelRegistry.get(duelId) } returns PendingDuelRegistry.PendingDuel(
+            id = duelId, guildId = guildId,
+            initiatorDiscordId = discordId + 1, opponentDiscordId = opponentId,
+            stake = 50L, createdAt = Instant.now()
+        )
+
+        val response = controller.cancel(guildId, duelId, user)
+
+        assertEquals(403, response.statusCode.value())
+        verify(exactly = 0) { pendingDuelRegistry.cancel(any()) }
+    }
+
+    @Test
+    fun `cancel of expired offer returns 410`() {
+        every { pendingDuelRegistry.get(duelId) } returns null
+
+        val response = controller.cancel(guildId, duelId, user)
+
+        assertEquals(410, response.statusCode.value())
+    }
+
+    @Test
+    fun `outgoingForMe returns the initiator's pending offers`() {
+        val view = DuelWebService.PendingDuelView(duelId, discordId, opponentId, 50L)
+        every { duelWebService.pendingForInitiator(discordId, guildId) } returns listOf(view)
+
+        val response = controller.outgoingForMe(guildId, user)
+
+        assertEquals(200, response.statusCode.value())
+        assertEquals(listOf(view), response.body)
+    }
 }


### PR DESCRIPTION
## Summary

Three small `/duel` UX gaps addressed together:

1. **Real Discord ping.** The slash-command offer reply switches from `event.hook.sendMessageEmbeds(...)` to `event.hook.sendMessage("<@opponentId>").setEmbeds(...)`. Mentions inside an embed description don't ping; mentions in message *content* do. The opponent now gets a real notification instead of having to be looking at the channel.

2. **TTL → 3 minutes.** `PendingDuelRegistry.DEFAULT_TTL` goes from 60s to 180s and is exposed as a public property so `DuelCommand` reads it instead of duplicating a constant. A small `formatTtl` helper (`3m` / `90s` / `1h 5m`) renders the duration in both the Discord embed copy and the web inbox copy.

3. **Outgoing offers + cancel.** `PendingDuelRegistry.pendingForInitiator(...)` mirrors the existing `pendingForOpponent`. New `GET /duel/{guildId}/outgoing` and `POST /duel/{guildId}/{duelId}/cancel` endpoints expose initiator-side offers and let the sender withdraw them. `duel.html` has a new "Your outgoing offers" section, polled on the same 5s timer as the inbox.

When the initiator cancels via web, the Discord channel buttons go inert on next click ("already resolved or expired") — same as natural timeout before the timeout callback fires. A richer edit-on-cancel for the original channel message is deferred (would need an extra callback path on the registry).

## Test plan

- [x] `./gradlew :database:test :web:test` — green, including new tests:
  - `PendingDuelRegistryTest`: `pendingForInitiator returns only matching offers`, `formatTtl renders short forms`
  - `DuelControllerTest`: cancel happy path, cancel-by-non-initiator → 403, cancel-of-expired → 410, outgoingForMe returns initiator's offers
  - `DuelCommandTest` updated to stub `pendingDuelRegistry.ttl` for the new code path
- [ ] Discord-bot tests pending CI (lavalink deps don't resolve in the sandbox)
- [ ] Manual: run `/duel @someone 50` in Discord — opponent should receive an actual mention notification
- [ ] Manual: open `/duel/{guildId}` after issuing a Discord challenge; outgoing offer should appear within 5s; clicking Cancel removes it from the list

https://claude.ai/code/session_01Pw6P9dNVk5aHSHicLh8U3N

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pw6P9dNVk5aHSHicLh8U3N)_