### PR TITLE
feat(tip): ping the recipient when a tip lands

### DIFF
--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/TipCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/TipCommand.kt
@@ -91,24 +91,30 @@ class TipCommand @Autowired constructor(
         outcome: TipOutcome,
         deleteDelay: Int
     ) {
-        val embed = when (outcome) {
-            is TipOutcome.Ok -> {
-                val builder = EmbedBuilder()
-                    .setTitle("💸 Tip sent")
-                    .setDescription(
-                        "<@${outcome.sender}> tipped <@${outcome.recipient}> **${outcome.amount} credits**." +
-                            outcome.note?.let { "\n*${it}*" }.orEmpty()
-                    )
-                    .addField("Your balance", "${outcome.senderNewBalance} credits", true)
-                    .addField(
-                        "Tipped today",
-                        "${outcome.sentTodayAfter}/${outcome.dailyCap}",
-                        true
-                    )
-                    .setColor(OK_COLOR)
-                builder.build()
-            }
+        if (outcome is TipOutcome.Ok) {
+            val embed = EmbedBuilder()
+                .setTitle("💸 Tip sent")
+                .setDescription(
+                    "<@${outcome.sender}> tipped <@${outcome.recipient}> **${outcome.amount} credits**." +
+                        outcome.note?.let { "\n*${it}*" }.orEmpty()
+                )
+                .addField("Your balance", "${outcome.senderNewBalance} credits", true)
+                .addField(
+                    "Tipped today",
+                    "${outcome.sentTodayAfter}/${outcome.dailyCap}",
+                    true
+                )
+                .setColor(OK_COLOR)
+                .build()
+            // addContent on the message (not the embed description) so the
+            // <@recipient> mention actually pings — embed-mention pings are silent.
+            event.hook.sendMessageEmbeds(embed)
+                .addContent("<@${outcome.recipient}>")
+                .queue(invokeDeleteOnMessageResponse(deleteDelay))
+            return
+        }
 
+        val embed = when (outcome) {
             is TipOutcome.InvalidAmount -> errorEmbed(
                 "Tip amount must be between ${outcome.min} and ${outcome.max} credits."
             )
@@ -137,6 +143,8 @@ class TipCommand @Autowired constructor(
             TipOutcome.UnknownRecipient -> errorEmbed(
                 "Recipient has no user record in this guild yet."
             )
+
+            is TipOutcome.Ok -> error("unreachable") // handled above
         }
         event.hook.sendMessageEmbeds(embed).queue(invokeDeleteOnMessageResponse(deleteDelay))
     }


### PR DESCRIPTION
## Summary

Brings `/tip` in line with the recent `/duel` notification fix (#323). `<@id>` mentions inside an embed description don't trigger Discord pings, so a tipped user previously had no idea they'd been tipped until they happened to look at the channel.

On the Ok path, `addContent("<@recipient>")` is now chained onto the embed reply so the recipient gets a real notification — same pattern as the duel offer ping.

The other two duel changes don't apply here: tips are instantaneous, so there's no pending state to lengthen the TTL of, and no outgoing-offer list to surface (nothing to cancel).

## Changes

- `TipCommand.replyOutcome`: split the `Ok` path out so it sends the embed with `addContent` for the ping; error paths unchanged (they're addressed to the sender, nobody to ping).

## Test plan

- [x] `./gradlew :web:test :database:test` — green (no behavior change in those modules).
- [ ] Discord-bot tests pending CI (lavalink deps don't resolve in the sandbox). Existing `TipCommandTest` `renders embed for each TipOutcome variant` covers all branches including Ok; the new chain (`sendMessageEmbeds → addContent → queue`) is fully covered by the existing `CommandTest` mock stubs.
- [ ] Manual: `/tip @someone 50 thanks!` in Discord — the recipient should receive a real notification.

https://claude.ai/code/session_01Pw6P9dNVk5aHSHicLh8U3N

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pw6P9dNVk5aHSHicLh8U3N)_