### PR TITLE
feat(web): Discord channel notifications for web-initiated tips and duels

### DIFF
--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/TipCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/TipCommand.kt
@@ -6,13 +6,11 @@ import core.command.CommandContext
 import database.dto.UserDto
 import database.service.TipService
 import database.service.TipService.TipOutcome
-import net.dv8tion.jda.api.EmbedBuilder
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
 import net.dv8tion.jda.api.interactions.commands.OptionType
 import net.dv8tion.jda.api.interactions.commands.build.OptionData
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import java.awt.Color
 
 /**
  * `/tip user:<member> amount:<int> message:<text?>` — peer-to-peer
@@ -34,8 +32,6 @@ class TipCommand @Autowired constructor(
         private const val OPT_USER = "user"
         private const val OPT_AMOUNT = "amount"
         private const val OPT_MESSAGE = "message"
-        private val OK_COLOR = Color(87, 242, 135)
-        private val ERROR_COLOR = Color(237, 66, 69)
     }
 
     override val optionData: List<OptionData> = listOf(
@@ -92,70 +88,43 @@ class TipCommand @Autowired constructor(
         deleteDelay: Int
     ) {
         if (outcome is TipOutcome.Ok) {
-            val embed = EmbedBuilder()
-                .setTitle("💸 Tip sent")
-                .setDescription(
-                    "<@${outcome.sender}> tipped <@${outcome.recipient}> **${outcome.amount} credits**." +
-                        outcome.note?.let { "\n*${it}*" }.orEmpty()
-                )
-                .addField("Your balance", "${outcome.senderNewBalance} credits", true)
-                .addField(
-                    "Tipped today",
-                    "${outcome.sentTodayAfter}/${outcome.dailyCap}",
-                    true
-                )
-                .setColor(OK_COLOR)
-                .build()
             // addContent on the message (not the embed description) so the
             // <@recipient> mention actually pings — embed-mention pings are silent.
-            event.hook.sendMessageEmbeds(embed)
+            event.hook.sendMessageEmbeds(TipEmbeds.okEmbed(outcome))
                 .addContent("<@${outcome.recipient}>")
                 .queue(invokeDeleteOnMessageResponse(deleteDelay))
             return
         }
 
-        val embed = when (outcome) {
-            is TipOutcome.InvalidAmount -> errorEmbed(
+        val message = when (outcome) {
+            is TipOutcome.InvalidAmount ->
                 "Tip amount must be between ${outcome.min} and ${outcome.max} credits."
-            )
 
-            is TipOutcome.InvalidRecipient -> errorEmbed(
-                when (outcome.reason) {
-                    TipOutcome.InvalidRecipient.Reason.SELF -> "You can't tip yourself."
-                    TipOutcome.InvalidRecipient.Reason.BOT -> "You can't tip a bot."
-                    TipOutcome.InvalidRecipient.Reason.MISSING -> "Recipient does not exist."
-                }
-            )
+            is TipOutcome.InvalidRecipient -> when (outcome.reason) {
+                TipOutcome.InvalidRecipient.Reason.SELF -> "You can't tip yourself."
+                TipOutcome.InvalidRecipient.Reason.BOT -> "You can't tip a bot."
+                TipOutcome.InvalidRecipient.Reason.MISSING -> "Recipient does not exist."
+            }
 
-            is TipOutcome.InsufficientCredits -> errorEmbed(
+            is TipOutcome.InsufficientCredits ->
                 "You only have ${outcome.have} credits but tried to send ${outcome.needed}."
-            )
 
-            is TipOutcome.DailyCapExceeded -> errorEmbed(
+            is TipOutcome.DailyCapExceeded ->
                 "Daily tip cap reached. You've sent ${outcome.sentToday}/${outcome.cap} today; " +
                     "${outcome.cap - outcome.sentToday} credits of headroom remain."
-            )
 
-            TipOutcome.UnknownSender -> errorEmbed(
-                "No user record yet. Try another TobyBot command first."
-            )
+            TipOutcome.UnknownSender -> "No user record yet. Try another TobyBot command first."
 
-            TipOutcome.UnknownRecipient -> errorEmbed(
-                "Recipient has no user record in this guild yet."
-            )
+            TipOutcome.UnknownRecipient -> "Recipient has no user record in this guild yet."
 
             is TipOutcome.Ok -> error("unreachable") // handled above
         }
-        event.hook.sendMessageEmbeds(embed).queue(invokeDeleteOnMessageResponse(deleteDelay))
+        event.hook.sendMessageEmbeds(TipEmbeds.errorEmbed(message))
+            .queue(invokeDeleteOnMessageResponse(deleteDelay))
     }
 
-    private fun errorEmbed(message: String) = EmbedBuilder()
-        .setTitle("💸 Tip")
-        .setDescription(message)
-        .setColor(ERROR_COLOR)
-        .build()
-
     private fun replyError(event: SlashCommandInteractionEvent, message: String, deleteDelay: Int) {
-        event.hook.sendMessageEmbeds(errorEmbed(message)).queue(invokeDeleteOnMessageResponse(deleteDelay))
+        event.hook.sendMessageEmbeds(TipEmbeds.errorEmbed(message))
+            .queue(invokeDeleteOnMessageResponse(deleteDelay))
     }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/TipEmbeds.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/TipEmbeds.kt
@@ -1,0 +1,39 @@
+package bot.toby.command.commands.economy
+
+import database.service.TipService.TipOutcome
+import net.dv8tion.jda.api.EmbedBuilder
+import net.dv8tion.jda.api.entities.MessageEmbed
+import java.awt.Color
+
+/**
+ * Shared embed builders for the `/tip` flow. Used by [TipCommand] for
+ * the slash-command reply and by `WebTipNotifier` for the system-channel
+ * notification when a tip is initiated from the web UI — both surfaces
+ * render identical embeds so the recipient's experience is consistent.
+ */
+internal object TipEmbeds {
+
+    private val OK_COLOR = Color(87, 242, 135)
+    private val ERROR_COLOR = Color(237, 66, 69)
+
+    fun okEmbed(outcome: TipOutcome.Ok): MessageEmbed = EmbedBuilder()
+        .setTitle("💸 Tip sent")
+        .setDescription(
+            "<@${outcome.sender}> tipped <@${outcome.recipient}> **${outcome.amount} credits**." +
+                outcome.note?.let { "\n*${it}*" }.orEmpty()
+        )
+        .addField("Sender balance", "${outcome.senderNewBalance} credits", true)
+        .addField(
+            "Sender tipped today",
+            "${outcome.sentTodayAfter}/${outcome.dailyCap}",
+            true
+        )
+        .setColor(OK_COLOR)
+        .build()
+
+    fun errorEmbed(message: String): MessageEmbed = EmbedBuilder()
+        .setTitle("💸 Tip")
+        .setDescription(message)
+        .setColor(ERROR_COLOR)
+        .build()
+}

--- a/discord-bot/src/main/kotlin/bot/toby/notify/WebDuelOfferNotifier.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/notify/WebDuelOfferNotifier.kt
@@ -1,0 +1,81 @@
+package bot.toby.notify
+
+import bot.toby.command.commands.economy.DuelEmbeds
+import common.logging.DiscordLogger
+import database.duel.PendingDuelRegistry
+import net.dv8tion.jda.api.JDA
+import net.dv8tion.jda.api.Permission
+import net.dv8tion.jda.api.components.actionrow.ActionRow
+import net.dv8tion.jda.api.components.buttons.Button
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
+import org.springframework.context.event.EventListener
+import org.springframework.stereotype.Component
+import web.event.WebDuelOfferedEvent
+
+/**
+ * Posts a Discord channel notification when a duel is offered from
+ * the web UI. The slash-command path posts inline to the channel
+ * where `/duel` was invoked; web-initiated offers have no such
+ * channel context, so this listener targets the guild's system
+ * channel.
+ *
+ * Accept/Decline buttons resolve through the shared
+ * [PendingDuelRegistry] regardless of which channel hosts the
+ * message, so they Just Work. Unlike the slash-command path, this
+ * notifier does NOT register an `onTimeout` callback — if the offer
+ * expires before the opponent clicks, the message stays as-is and
+ * the buttons go inert with the existing "already resolved or
+ * expired" reply (same UX as a stale slash-command offer).
+ */
+@Component
+class WebDuelOfferNotifier(
+    private val jda: JDA,
+    private val pendingDuelRegistry: PendingDuelRegistry,
+) {
+    private val logger = DiscordLogger.createLogger(this::class.java)
+
+    @EventListener
+    fun on(event: WebDuelOfferedEvent) {
+        val guild = jda.getGuildById(event.guildId) ?: run {
+            logger.warn("WebDuelOfferedEvent for guild ${event.guildId} but bot is not in that guild; skipping.")
+            return
+        }
+        val channel = resolveChannel(guild) ?: run {
+            logger.warn("No writable system channel in guild ${event.guildId}; skipping web-duel notification.")
+            return
+        }
+        val accept = Button.success(
+            DuelEmbeds.acceptButtonId(event.duelId, event.opponentDiscordId),
+            "Accept"
+        )
+        val decline = Button.danger(
+            DuelEmbeds.declineButtonId(event.duelId, event.opponentDiscordId),
+            "Decline"
+        )
+        // addContent on the message (not the embed description) so the
+        // <@opponent> mention actually pings — embed-mention pings are silent.
+        runCatching {
+            channel.sendMessageEmbeds(
+                DuelEmbeds.offerEmbed(
+                    event.initiatorDiscordId,
+                    event.opponentDiscordId,
+                    event.stake,
+                    pendingDuelRegistry.ttl
+                )
+            )
+                .addContent("<@${event.opponentDiscordId}>")
+                .addComponents(ActionRow.of(accept, decline))
+                .queue()
+        }.onFailure {
+            logger.error("Could not post web-duel notification to ${channel.id}: ${it.message}")
+        }
+    }
+
+    private fun resolveChannel(guild: Guild): TextChannel? {
+        val bot = guild.selfMember
+        return guild.systemChannel?.takeIf {
+            bot.hasPermission(it, Permission.MESSAGE_SEND, Permission.MESSAGE_EMBED_LINKS)
+        }
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/notify/WebTipNotifier.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/notify/WebTipNotifier.kt
@@ -1,0 +1,67 @@
+package bot.toby.notify
+
+import bot.toby.command.commands.economy.TipEmbeds
+import common.logging.DiscordLogger
+import database.service.TipService.TipOutcome
+import net.dv8tion.jda.api.JDA
+import net.dv8tion.jda.api.Permission
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
+import org.springframework.context.event.EventListener
+import org.springframework.stereotype.Component
+import web.event.WebTipSentEvent
+
+/**
+ * Posts a Discord channel notification when a tip is initiated from
+ * the web UI. The slash-command path posts inline to the channel
+ * where `/tip` was invoked; web-initiated tips have no such channel
+ * context, so this listener targets the guild's system channel.
+ *
+ * If the bot has no writable system channel, the post is skipped (the
+ * underlying transfer already happened — this is best-effort
+ * notification only).
+ */
+@Component
+class WebTipNotifier(
+    private val jda: JDA,
+) {
+    private val logger = DiscordLogger.createLogger(this::class.java)
+
+    @EventListener
+    fun on(event: WebTipSentEvent) {
+        val guild = jda.getGuildById(event.guildId) ?: run {
+            logger.warn("WebTipSentEvent for guild ${event.guildId} but bot is not in that guild; skipping.")
+            return
+        }
+        val channel = resolveChannel(guild) ?: run {
+            logger.warn("No writable system channel in guild ${event.guildId}; skipping web-tip notification.")
+            return
+        }
+        val outcome = TipOutcome.Ok(
+            sender = event.senderDiscordId,
+            recipient = event.recipientDiscordId,
+            amount = event.amount,
+            note = event.note,
+            senderNewBalance = event.senderNewBalance,
+            recipientNewBalance = event.recipientNewBalance,
+            sentTodayAfter = event.sentTodayAfter,
+            dailyCap = event.dailyCap
+        )
+        // addContent on the message (not the embed description) so the
+        // <@recipient> mention actually pings — embed-mention pings are silent.
+        runCatching {
+            channel.sendMessageEmbeds(TipEmbeds.okEmbed(outcome))
+                .addContent("<@${event.recipientDiscordId}>")
+                .queue()
+        }.onFailure {
+            logger.error("Could not post web-tip notification to ${channel.id}: ${it.message}")
+        }
+    }
+
+    private fun resolveChannel(guild: Guild): TextChannel? {
+        val bot = guild.selfMember
+        return guild.systemChannel?.takeIf {
+            bot.hasPermission(it, Permission.MESSAGE_SEND, Permission.MESSAGE_EMBED_LINKS)
+        }
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/notify/WebDuelOfferNotifierTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/notify/WebDuelOfferNotifierTest.kt
@@ -1,0 +1,90 @@
+package bot.toby.notify
+
+import database.duel.PendingDuelRegistry
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import net.dv8tion.jda.api.JDA
+import net.dv8tion.jda.api.Permission
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.MessageEmbed
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
+import net.dv8tion.jda.api.requests.restaction.MessageCreateAction
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import web.event.WebDuelOfferedEvent
+import java.time.Duration
+
+class WebDuelOfferNotifierTest {
+
+    private lateinit var jda: JDA
+    private lateinit var pendingDuelRegistry: PendingDuelRegistry
+    private lateinit var guild: Guild
+    private lateinit var channel: TextChannel
+    private lateinit var createAction: MessageCreateAction
+    private lateinit var notifier: WebDuelOfferNotifier
+
+    private val guildId = 42L
+    private val duelId = 99L
+    private val initiatorId = 100L
+    private val opponentId = 200L
+
+    private fun event(): WebDuelOfferedEvent = WebDuelOfferedEvent(
+        guildId = guildId,
+        duelId = duelId,
+        initiatorDiscordId = initiatorId,
+        opponentDiscordId = opponentId,
+        stake = 50L
+    )
+
+    @BeforeEach
+    fun setup() {
+        jda = mockk(relaxed = true)
+        pendingDuelRegistry = mockk(relaxed = true)
+        every { pendingDuelRegistry.ttl } returns Duration.ofMinutes(3)
+        guild = mockk(relaxed = true)
+        channel = mockk(relaxed = true)
+        createAction = mockk(relaxed = true)
+        every { jda.getGuildById(guildId) } returns guild
+        every { guild.systemChannel } returns channel
+        every { guild.selfMember.hasPermission(channel, *anyVararg<Permission>()) } returns true
+        every { channel.sendMessageEmbeds(any<MessageEmbed>()) } returns createAction
+        every { createAction.addContent(any()) } returns createAction
+        notifier = WebDuelOfferNotifier(jda, pendingDuelRegistry)
+    }
+
+    @Test
+    fun `happy path posts the embed and chains addContent for the opponent ping`() {
+        notifier.on(event())
+
+        verify(exactly = 1) { channel.sendMessageEmbeds(any<MessageEmbed>()) }
+        verify(exactly = 1) { createAction.addContent("<@$opponentId>") }
+    }
+
+    @Test
+    fun `skips when bot is not in the guild`() {
+        every { jda.getGuildById(guildId) } returns null
+
+        notifier.on(event())
+
+        verify(exactly = 0) { channel.sendMessageEmbeds(any<MessageEmbed>()) }
+    }
+
+    @Test
+    fun `skips when guild has no system channel`() {
+        every { guild.systemChannel } returns null
+
+        notifier.on(event())
+
+        verify(exactly = 0) { channel.sendMessageEmbeds(any<MessageEmbed>()) }
+    }
+
+    @Test
+    fun `skips when bot lacks permission on the system channel`() {
+        every { guild.selfMember.hasPermission(channel, *anyVararg<Permission>()) } returns false
+
+        notifier.on(event())
+
+        verify(exactly = 0) { channel.sendMessageEmbeds(any<MessageEmbed>()) }
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/notify/WebTipNotifierTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/notify/WebTipNotifierTest.kt
@@ -1,0 +1,88 @@
+package bot.toby.notify
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import net.dv8tion.jda.api.JDA
+import net.dv8tion.jda.api.Permission
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.MessageEmbed
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
+import net.dv8tion.jda.api.requests.restaction.MessageCreateAction
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import web.event.WebTipSentEvent
+
+class WebTipNotifierTest {
+
+    private lateinit var jda: JDA
+    private lateinit var guild: Guild
+    private lateinit var channel: TextChannel
+    private lateinit var createAction: MessageCreateAction
+    private lateinit var notifier: WebTipNotifier
+
+    private val guildId = 42L
+    private val senderId = 100L
+    private val recipientId = 200L
+
+    private fun event(): WebTipSentEvent = WebTipSentEvent(
+        guildId = guildId,
+        senderDiscordId = senderId,
+        recipientDiscordId = recipientId,
+        amount = 50L,
+        note = "thanks",
+        senderNewBalance = 950L,
+        recipientNewBalance = 1050L,
+        sentTodayAfter = 50L,
+        dailyCap = 500L
+    )
+
+    @BeforeEach
+    fun setup() {
+        jda = mockk(relaxed = true)
+        guild = mockk(relaxed = true)
+        channel = mockk(relaxed = true)
+        createAction = mockk(relaxed = true)
+        every { jda.getGuildById(guildId) } returns guild
+        every { guild.systemChannel } returns channel
+        every { guild.selfMember.hasPermission(channel, *anyVararg<Permission>()) } returns true
+        every { channel.sendMessageEmbeds(any<MessageEmbed>()) } returns createAction
+        every { createAction.addContent(any()) } returns createAction
+        notifier = WebTipNotifier(jda)
+    }
+
+    @Test
+    fun `happy path posts the embed and chains addContent for the recipient ping`() {
+        notifier.on(event())
+
+        verify(exactly = 1) { channel.sendMessageEmbeds(any<MessageEmbed>()) }
+        verify(exactly = 1) { createAction.addContent("<@$recipientId>") }
+    }
+
+    @Test
+    fun `skips when bot is not in the guild`() {
+        every { jda.getGuildById(guildId) } returns null
+
+        notifier.on(event())
+
+        verify(exactly = 0) { channel.sendMessageEmbeds(any<MessageEmbed>()) }
+    }
+
+    @Test
+    fun `skips when guild has no system channel`() {
+        every { guild.systemChannel } returns null
+
+        notifier.on(event())
+
+        verify(exactly = 0) { channel.sendMessageEmbeds(any<MessageEmbed>()) }
+    }
+
+    @Test
+    fun `skips when bot lacks permission on the system channel`() {
+        every { guild.selfMember.hasPermission(channel, *anyVararg<Permission>()) } returns false
+
+        notifier.on(event())
+
+        verify(exactly = 0) { channel.sendMessageEmbeds(any<MessageEmbed>()) }
+    }
+}

--- a/web/src/main/kotlin/web/controller/DuelController.kt
+++ b/web/src/main/kotlin/web/controller/DuelController.kt
@@ -6,6 +6,7 @@ import database.service.DuelService.AcceptOutcome
 import database.service.DuelService.StartOutcome
 import database.service.UserService
 import net.dv8tion.jda.api.JDA
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClient
@@ -20,6 +21,7 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseBody
 import org.springframework.web.servlet.mvc.support.RedirectAttributes
+import web.event.WebDuelOfferedEvent
 import web.service.DuelWebService
 import web.service.EconomyWebService
 import web.util.discordIdOrNull
@@ -39,6 +41,7 @@ class DuelController(
     private val economyWebService: EconomyWebService,
     private val userService: UserService,
     private val jda: JDA,
+    private val eventPublisher: ApplicationEventPublisher,
 ) {
     @GetMapping("/guilds")
     fun guildList(
@@ -154,6 +157,15 @@ class DuelController(
             initiatorDiscordId = discordId,
             opponentDiscordId = request.opponentDiscordId,
             stake = request.stake
+        )
+        eventPublisher.publishEvent(
+            WebDuelOfferedEvent(
+                guildId = guildId,
+                duelId = offer.id,
+                initiatorDiscordId = discordId,
+                opponentDiscordId = request.opponentDiscordId,
+                stake = request.stake
+            )
         )
         return ResponseEntity.ok(
             ChallengeResponse(ok = true, duelId = offer.id, stake = request.stake)

--- a/web/src/main/kotlin/web/controller/TipController.kt
+++ b/web/src/main/kotlin/web/controller/TipController.kt
@@ -4,6 +4,7 @@ import database.service.TipService
 import database.service.TipService.TipOutcome
 import database.service.UserService
 import net.dv8tion.jda.api.JDA
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClient
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseBody
 import org.springframework.web.servlet.mvc.support.RedirectAttributes
+import web.event.WebTipSentEvent
 import web.service.EconomyWebService
 import web.service.TipWebService
 import web.util.discordIdOrNull
@@ -37,6 +39,7 @@ class TipController(
     private val economyWebService: EconomyWebService,
     private val userService: UserService,
     private val jda: JDA,
+    private val eventPublisher: ApplicationEventPublisher,
 ) {
     @GetMapping("/guilds")
     fun guildList(
@@ -122,17 +125,32 @@ class TipController(
             note = request.note?.takeIf { it.isNotBlank() }
         )
         return when (outcome) {
-            is TipOutcome.Ok -> ResponseEntity.ok(
-                TipResponse(
-                    ok = true,
-                    senderNewBalance = outcome.senderNewBalance,
-                    recipientNewBalance = outcome.recipientNewBalance,
-                    sentTodayAfter = outcome.sentTodayAfter,
-                    dailyCap = outcome.dailyCap,
-                    amount = outcome.amount,
-                    note = outcome.note
+            is TipOutcome.Ok -> {
+                eventPublisher.publishEvent(
+                    WebTipSentEvent(
+                        guildId = guildId,
+                        senderDiscordId = outcome.sender,
+                        recipientDiscordId = outcome.recipient,
+                        amount = outcome.amount,
+                        note = outcome.note,
+                        senderNewBalance = outcome.senderNewBalance,
+                        recipientNewBalance = outcome.recipientNewBalance,
+                        sentTodayAfter = outcome.sentTodayAfter,
+                        dailyCap = outcome.dailyCap
+                    )
                 )
-            )
+                ResponseEntity.ok(
+                    TipResponse(
+                        ok = true,
+                        senderNewBalance = outcome.senderNewBalance,
+                        recipientNewBalance = outcome.recipientNewBalance,
+                        sentTodayAfter = outcome.sentTodayAfter,
+                        dailyCap = outcome.dailyCap,
+                        amount = outcome.amount,
+                        note = outcome.note
+                    )
+                )
+            }
             is TipOutcome.InvalidAmount -> ResponseEntity.badRequest().body(
                 TipResponse(false, error = "Tip must be between ${outcome.min} and ${outcome.max} credits.")
             )

--- a/web/src/main/kotlin/web/event/WebDuelOfferedEvent.kt
+++ b/web/src/main/kotlin/web/event/WebDuelOfferedEvent.kt
@@ -1,0 +1,18 @@
+package web.event
+
+/**
+ * Fired by [web.controller.DuelController] right after a successful
+ * web-initiated duel challenge. Listened to in `discord-bot`
+ * (`WebDuelOfferNotifier`), which posts the same embed + ping +
+ * Accept/Decline buttons the slash-command path produces. The
+ * slash-command path posts inline to the channel where `/duel` was
+ * invoked; web-initiated offers have no such channel context, so the
+ * listener targets the guild's system channel.
+ */
+data class WebDuelOfferedEvent(
+    val guildId: Long,
+    val duelId: Long,
+    val initiatorDiscordId: Long,
+    val opponentDiscordId: Long,
+    val stake: Long
+)

--- a/web/src/main/kotlin/web/event/WebTipSentEvent.kt
+++ b/web/src/main/kotlin/web/event/WebTipSentEvent.kt
@@ -1,0 +1,21 @@
+package web.event
+
+/**
+ * Fired by [web.controller.TipController] right after a successful
+ * web-initiated tip. Listened to in `discord-bot` (`WebTipNotifier`),
+ * which posts the same embed + ping the slash-command path produces
+ * — the slash-command path posts inline to the channel where `/tip`
+ * was invoked, while web-initiated tips have no such channel context,
+ * so the listener targets the guild's system channel.
+ */
+data class WebTipSentEvent(
+    val guildId: Long,
+    val senderDiscordId: Long,
+    val recipientDiscordId: Long,
+    val amount: Long,
+    val note: String?,
+    val senderNewBalance: Long,
+    val recipientNewBalance: Long,
+    val sentTodayAfter: Long,
+    val dailyCap: Long
+)

--- a/web/src/test/kotlin/web/controller/DuelControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/DuelControllerTest.kt
@@ -14,7 +14,9 @@ import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.security.oauth2.core.user.OAuth2User
+import web.event.WebDuelOfferedEvent
 import web.service.DuelWebService
 import web.service.EconomyWebService
 import java.time.Instant
@@ -32,6 +34,7 @@ class DuelControllerTest {
     private lateinit var economyWebService: EconomyWebService
     private lateinit var userService: UserService
     private lateinit var jda: JDA
+    private lateinit var eventPublisher: ApplicationEventPublisher
     private lateinit var user: OAuth2User
     private lateinit var controller: DuelController
 
@@ -43,6 +46,7 @@ class DuelControllerTest {
         economyWebService = mockk(relaxed = true)
         userService = mockk(relaxed = true)
         jda = mockk(relaxed = true)
+        eventPublisher = mockk(relaxed = true)
         user = mockk {
             every { getAttribute<String>("id") } returns discordId.toString()
             every { getAttribute<String>("username") } returns "tester"
@@ -51,7 +55,7 @@ class DuelControllerTest {
         every { economyWebService.isMember(opponentId, guildId) } returns true
         controller = DuelController(
             duelService, duelWebService, pendingDuelRegistry,
-            economyWebService, userService, jda
+            economyWebService, userService, jda, eventPublisher
         )
     }
 
@@ -62,7 +66,7 @@ class DuelControllerTest {
     )
 
     @Test
-    fun `challenge happy path registers in registry and returns the duelId`() {
+    fun `challenge happy path registers in registry and publishes WebDuelOfferedEvent`() {
         every {
             duelService.startDuel(discordId, opponentId, guildId, 50L)
         } returns StartOutcome.Ok(initiatorBalance = 200L)
@@ -80,6 +84,17 @@ class DuelControllerTest {
         assertTrue(response.body!!.ok)
         assertEquals(duelId, response.body!!.duelId)
         verify { duelWebService.ensureOpponent(opponentId, guildId) }
+        verify(exactly = 1) {
+            eventPublisher.publishEvent(
+                WebDuelOfferedEvent(
+                    guildId = guildId,
+                    duelId = duelId,
+                    initiatorDiscordId = discordId,
+                    opponentDiscordId = opponentId,
+                    stake = 50L
+                )
+            )
+        }
     }
 
     @Test
@@ -90,6 +105,7 @@ class DuelControllerTest {
         assertFalse(response.body!!.ok)
         verify(exactly = 0) { duelService.startDuel(any(), any(), any(), any()) }
         verify(exactly = 0) { pendingDuelRegistry.register(any(), any(), any(), any(), any(), any()) }
+        verify(exactly = 0) { eventPublisher.publishEvent(any<WebDuelOfferedEvent>()) }
     }
 
     @Test
@@ -102,6 +118,7 @@ class DuelControllerTest {
         assertFalse(response.body!!.ok)
         verify(exactly = 0) { duelWebService.ensureOpponent(any(), any()) }
         verify(exactly = 0) { duelService.startDuel(any(), any(), any(), any()) }
+        verify(exactly = 0) { eventPublisher.publishEvent(any<WebDuelOfferedEvent>()) }
     }
 
     @Test
@@ -115,6 +132,7 @@ class DuelControllerTest {
         assertEquals(400, response.statusCode.value())
         assertFalse(response.body!!.ok)
         verify(exactly = 0) { pendingDuelRegistry.register(any(), any(), any(), any(), any(), any()) }
+        verify(exactly = 0) { eventPublisher.publishEvent(any<WebDuelOfferedEvent>()) }
     }
 
     @Test

--- a/web/src/test/kotlin/web/controller/TipControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/TipControllerTest.kt
@@ -13,7 +13,9 @@ import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.security.oauth2.core.user.OAuth2User
+import web.event.WebTipSentEvent
 import web.service.EconomyWebService
 import web.service.TipWebService
 
@@ -28,6 +30,7 @@ class TipControllerTest {
     private lateinit var economyWebService: EconomyWebService
     private lateinit var userService: UserService
     private lateinit var jda: JDA
+    private lateinit var eventPublisher: ApplicationEventPublisher
     private lateinit var user: OAuth2User
     private lateinit var controller: TipController
 
@@ -38,17 +41,20 @@ class TipControllerTest {
         economyWebService = mockk(relaxed = true)
         userService = mockk(relaxed = true)
         jda = mockk(relaxed = true)
+        eventPublisher = mockk(relaxed = true)
         user = mockk {
             every { getAttribute<String>("id") } returns discordId.toString()
             every { getAttribute<String>("username") } returns "tester"
         }
         every { economyWebService.isMember(discordId, guildId) } returns true
         every { economyWebService.isMember(recipientId, guildId) } returns true
-        controller = TipController(tipService, tipWebService, economyWebService, userService, jda)
+        controller = TipController(
+            tipService, tipWebService, economyWebService, userService, jda, eventPublisher
+        )
     }
 
     @Test
-    fun `tip Ok returns 200 with balances and daily totals`() {
+    fun `tip Ok returns 200 with balances and daily totals and publishes WebTipSentEvent`() {
         every {
             tipService.tip(discordId, recipientId, guildId, 50L, "thanks", any(), any())
         } returns TipOutcome.Ok(
@@ -69,6 +75,21 @@ class TipControllerTest {
         assertEquals(50L, body.sentTodayAfter)
         assertEquals(500L, body.dailyCap)
         verify { tipWebService.ensureRecipient(recipientId, guildId) }
+        verify(exactly = 1) {
+            eventPublisher.publishEvent(
+                WebTipSentEvent(
+                    guildId = guildId,
+                    senderDiscordId = discordId,
+                    recipientDiscordId = recipientId,
+                    amount = 50L,
+                    note = "thanks",
+                    senderNewBalance = 950L,
+                    recipientNewBalance = 1050L,
+                    sentTodayAfter = 50L,
+                    dailyCap = 500L
+                )
+            )
+        }
     }
 
     @Test
@@ -131,5 +152,6 @@ class TipControllerTest {
             assertFalse(response.body!!.ok)
             assertNull(response.body!!.amount)
         }
+        verify(exactly = 0) { eventPublisher.publishEvent(any<WebTipSentEvent>()) }
     }
 }


### PR DESCRIPTION
## Summary

Closes the same parity gap on both `/tip` and `/duel`: the slash-command paths ping inline (after #323 / #324), but offers/transfers initiated via the web UI were silent on the Discord side — recipients/opponents stayed unaware until they happened to look at the web page.

Both controllers now publish a Spring `ApplicationEvent` on the Ok path (matches the existing `ActivityTrackingEnabled` pattern). Two new `@EventListener` components in the discord-bot module pick up those events and post the same embed + ping the slash-command path produces, into the guild's system channel.

## Tip side

- `web/event/WebTipSentEvent.kt` — NEW data class
- `web/controller/TipController.kt` — injects `ApplicationEventPublisher`, publishes on Ok
- `discord-bot/command/commands/economy/TipEmbeds.kt` — NEW; embed-building extracted from `TipCommand` (mirrors `DuelEmbeds`)
- `discord-bot/command/commands/economy/TipCommand.kt` — now delegates to `TipEmbeds`
- `discord-bot/notify/WebTipNotifier.kt` — NEW listener; resolves system channel + posts embed + `addContent("<@recipient>")`

## Duel side

- `web/event/WebDuelOfferedEvent.kt` — NEW data class
- `web/controller/DuelController.kt` — injects `ApplicationEventPublisher`, publishes on Ok branch of `challenge`
- `discord-bot/notify/WebDuelOfferNotifier.kt` — NEW listener; posts `DuelEmbeds.offerEmbed(...)` with `addContent("<@opponent>")` AND the existing Accept/Decline `ActionRow` (button IDs encode the duel ID, so `DuelButton` resolves through `PendingDuelRegistry` regardless of which channel hosts the message)

## Things deliberately not changing

- No per-guild channel config; system channel only. Add a `TIP_CHANNEL` / `DUEL_CHANNEL` config later if owners want different routing.
- No DM fallback — open-DMs requirement makes it unreliable.
- No edit-on-timeout for web-initiated duel offers. The slash-command path edits its message via `event.hook.editOriginalEmbeds` when the timeout fires; web-initiated offers just leave the message and the buttons go inert (same UX as a stale slash-command offer).
- Failures (insufficient credits, invalid stake, etc.) still don't post anywhere — same as the slash-command paths.
- Slash-command tip embed copy rephrased: "Your balance" → "Sender balance", "Tipped today" → "Sender tipped today" since the same embed is now seen by recipients too.

## Test plan

- [x] `./gradlew :web:test :database:test` — green, including updated `TipControllerTest` and `DuelControllerTest` plus new event-publish assertions.
- [ ] Discord-bot tests pending CI (lavalink deps don't resolve in the sandbox). New `WebTipNotifierTest` and `WebDuelOfferNotifierTest` mirror the existing `MonthlyLeaderboardJobTest` mocking pattern.
- [ ] Manual web tip and web duel from the browser in a guild with a writable system channel — recipient/opponent gets a Discord push and the embed appears with the right buttons (duel) or just the ping (tip).
- [ ] Manual: web actions in a guild with no system channel access — JSON response still succeeds, warning logged, no notification.

https://claude.ai/code/session_01Pw6P9dNVk5aHSHicLh8U3N