### PR TITLE
refactor(config): collapse get-or-create boilerplate into ConfigService.upsertConfig

### DIFF
--- a/application/src/test/kotlin/integration/database/ConfigServiceImplIntegrationTest.kt
+++ b/application/src/test/kotlin/integration/database/ConfigServiceImplIntegrationTest.kt
@@ -79,4 +79,47 @@ class ConfigServiceImplIntegrationTest {
         Assertions.assertEquals(1, configSize)
         configService.deleteAll("test")
     }
+
+    @Test
+    fun upsertConfig_returnsCreated_andInsertsRow_whenNoneExists() {
+        val result = configService.upsertConfig("TOKEN", "1234", "test")
+
+        Assertions.assertTrue(result is ConfigService.UpsertResult.Created)
+        configService.clearCache()
+        val read = configService.getConfigByName("TOKEN", "test")
+        Assertions.assertEquals("1234", read?.value)
+        Assertions.assertEquals(1, configService.listGuildConfig("test")!!.size)
+        configService.deleteAll("test")
+    }
+
+    @Test
+    fun upsertConfig_returnsUpdated_withPreviousValue_whenRowExists() {
+        configService.createNewConfig(ConfigDto("TOKEN", "1234", "test"))
+        configService.clearCache()
+
+        val result = configService.upsertConfig("TOKEN", "5678", "test")
+
+        Assertions.assertTrue(result is ConfigService.UpsertResult.Updated)
+        Assertions.assertEquals("1234", (result as ConfigService.UpsertResult.Updated).previousValue)
+        configService.clearCache()
+        Assertions.assertEquals("5678", configService.getConfigByName("TOKEN", "test")?.value)
+        Assertions.assertEquals(1, configService.listGuildConfig("test")!!.size, "must not double-write")
+        configService.deleteAll("test")
+    }
+
+    @Test
+    fun upsertConfig_does_not_collide_across_guilds() {
+        configService.createNewConfig(ConfigDto("TOKEN", "guildA-value", "guildA"))
+        configService.clearCache()
+
+        // Upserting the same name for a different guild creates a new row.
+        val result = configService.upsertConfig("TOKEN", "guildB-value", "guildB")
+
+        Assertions.assertTrue(result is ConfigService.UpsertResult.Created)
+        configService.clearCache()
+        Assertions.assertEquals("guildA-value", configService.getConfigByName("TOKEN", "guildA")?.value)
+        Assertions.assertEquals("guildB-value", configService.getConfigByName("TOKEN", "guildB")?.value)
+        configService.deleteAll("guildA")
+        configService.deleteAll("guildB")
+    }
 }

--- a/database/src/main/kotlin/database/service/ConfigService.kt
+++ b/database/src/main/kotlin/database/service/ConfigService.kt
@@ -11,4 +11,25 @@ interface ConfigService {
     fun deleteAll(guildId: String?)
     fun deleteConfig(guildId: String?, name: String?)
     fun clearCache()
+
+    /**
+     * Insert-or-update a single (name, guildId) config row to [value].
+     * Looks up the existing row via [getConfigByName] and updates if it
+     * matches the same guild; otherwise creates a fresh row. Returns
+     * `Created` or `Updated` so callers that care about the difference
+     * (log lines, first-enable side effects) can branch on it; callers
+     * that don't can ignore the result.
+     *
+     * Replaces the open-coded `if (existing != null && existing.guildId
+     * == newDto.guildId) update else create` boilerplate that used to
+     * sit in every `/setconfig` subcommand and in the moderation web
+     * service.
+     */
+    fun upsertConfig(name: String, value: String, guildId: String): UpsertResult
+
+    sealed interface UpsertResult {
+        val dto: ConfigDto
+        data class Created(override val dto: ConfigDto) : UpsertResult
+        data class Updated(override val dto: ConfigDto, val previousValue: String?) : UpsertResult
+    }
 }

--- a/database/src/main/kotlin/database/service/impl/DefaultConfigService.kt
+++ b/database/src/main/kotlin/database/service/impl/DefaultConfigService.kt
@@ -39,6 +39,19 @@ class DefaultConfigService : ConfigService {
         return configService.updateConfig(configDto)
     }
 
+    override fun upsertConfig(name: String, value: String, guildId: String): ConfigService.UpsertResult {
+        val existing = getConfigByName(name, guildId)
+        val dto = ConfigDto(name, value, guildId)
+        return if (existing != null && existing.guildId == guildId) {
+            val previous = existing.value
+            updateConfig(dto)
+            ConfigService.UpsertResult.Updated(dto, previousValue = previous)
+        } else {
+            createNewConfig(dto)
+            ConfigService.UpsertResult.Created(dto)
+        }
+    }
+
     @CacheEvict(value = ["configs"], allEntries = true)
     override fun deleteAll(guildId: String?) {
         configService.deleteAll(guildId)

--- a/discord-bot/src/main/kotlin/bot/toby/activity/ActivityTrackingNotifier.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/activity/ActivityTrackingNotifier.kt
@@ -2,7 +2,6 @@ package bot.toby.activity
 
 import common.events.ActivityTrackingEnabled
 import common.logging.DiscordLogger
-import database.dto.ConfigDto
 import database.dto.ConfigDto.Configurations.ACTIVITY_TRACKING_NOTIFIED
 import database.service.ConfigService
 import net.dv8tion.jda.api.JDA
@@ -58,12 +57,7 @@ class ActivityTrackingNotifier @Autowired constructor(
             .filter { !it.isBot }
             .forEach { user -> sendDmSafely(user, message) }
 
-        val flag = ConfigDto(ACTIVITY_TRACKING_NOTIFIED.configValue, "true", guildIdStr)
-        if (existing != null && existing.guildId == guildIdStr) {
-            configService.updateConfig(flag)
-        } else {
-            configService.createNewConfig(flag)
-        }
+        configService.upsertConfig(ACTIVITY_TRACKING_NOTIFIED.configValue, "true", guildIdStr)
     }
 
     private fun sendDmSafely(user: User, body: String) {

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/moderation/SetConfigCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/moderation/SetConfigCommand.kt
@@ -76,13 +76,7 @@ class SetConfigCommand @Autowired constructor(
                 .setEphemeral(true).queue(invokeDeleteOnMessageResponse(deleteDelay))
             return
         }
-        val newConfigDto = ConfigDto(configValue, channel.id, guildId)
-        val databaseConfig = configService.getConfigByName(configValue, guildId)
-        if (databaseConfig != null && databaseConfig.guildId == newConfigDto.guildId) {
-            configService.updateConfig(newConfigDto)
-        } else {
-            configService.createNewConfig(newConfigDto)
-        }
+        configService.upsertConfig(configValue, channel.id, guildId)
         event.hook.sendMessage("Monthly leaderboards will now post in <#${channel.id}> on the 1st of each month.")
             .setEphemeral(true).queue(invokeDeleteOnMessageResponse(deleteDelay))
     }
@@ -96,14 +90,14 @@ class SetConfigCommand @Autowired constructor(
         val configValue = ConfigDto.Configurations.ACTIVITY_TRACKING.configValue
         val guildId = event.guild?.id ?: return
 
-        val newConfigDto = ConfigDto(configValue, enabled.toString(), guildId)
-        val existing = configService.getConfigByName(configValue, guildId)
-        val previouslyEnabled = existing?.value?.equals("true", ignoreCase = true) == true
-
-        if (existing != null && existing.guildId == newConfigDto.guildId) {
-            configService.updateConfig(newConfigDto)
-        } else {
-            configService.createNewConfig(newConfigDto)
+        // Need to know whether tracking was previously enabled to decide
+        // whether to fire the first-enable DM flow — that's why we branch
+        // on the result instead of ignoring it.
+        val result = configService.upsertConfig(configValue, enabled.toString(), guildId)
+        val previouslyEnabled = when (result) {
+            is ConfigService.UpsertResult.Created -> false
+            is ConfigService.UpsertResult.Updated ->
+                result.previousValue?.equals("true", ignoreCase = true) == true
         }
 
         val message = if (enabled) {
@@ -139,14 +133,7 @@ class SetConfigCommand @Autowired constructor(
             ConfigDto.Configurations.valueOf(optionMapping.name.uppercase(Locale.getDefault())).configValue
         val guildId = event.guild?.id ?: return
 
-        val newConfigDto = ConfigDto(configValue, newValue.toString(), guildId)
-        val databaseConfig = configService.getConfigByName(configValue, guildId)
-
-        if (databaseConfig != null && databaseConfig.guildId == newConfigDto.guildId) {
-            configService.updateConfig(newConfigDto)
-        } else {
-            configService.createNewConfig(newConfigDto)
-        }
+        configService.upsertConfig(configValue, newValue.toString(), guildId)
         event.hook.sendMessage(messageToSend).queue(invokeDeleteOnMessageResponse(deleteDelay))
     }
 
@@ -163,13 +150,7 @@ class SetConfigCommand @Autowired constructor(
         }
         val configValue = ConfigDto.Configurations.JACKPOT_LOSS_TRIBUTE_PCT.configValue
         val guildId = event.guild?.id ?: return
-        val newConfigDto = ConfigDto(configValue, pct.toString(), guildId)
-        val existing = configService.getConfigByName(configValue, guildId)
-        if (existing != null && existing.guildId == newConfigDto.guildId) {
-            configService.updateConfig(newConfigDto)
-        } else {
-            configService.createNewConfig(newConfigDto)
-        }
+        configService.upsertConfig(configValue, pct.toString(), guildId)
         event.hook.sendMessage("Jackpot loss-tribute set to $pct % of every lost casino stake.")
             .queue(invokeDeleteOnMessageResponse(deleteDelay))
     }
@@ -187,13 +168,7 @@ class SetConfigCommand @Autowired constructor(
         }
         val configValue = ConfigDto.Configurations.POKER_RAKE_PCT.configValue
         val guildId = event.guild?.id ?: return
-        val newConfigDto = ConfigDto(configValue, pct.toString(), guildId)
-        val existing = configService.getConfigByName(configValue, guildId)
-        if (existing != null && existing.guildId == newConfigDto.guildId) {
-            configService.updateConfig(newConfigDto)
-        } else {
-            configService.createNewConfig(newConfigDto)
-        }
+        configService.upsertConfig(configValue, pct.toString(), guildId)
         event.hook.sendMessage("Poker rake set to $pct % of every settled pot.")
             .queue(invokeDeleteOnMessageResponse(deleteDelay))
     }
@@ -205,14 +180,7 @@ class SetConfigCommand @Autowired constructor(
             event.getOption(ConfigDto.Configurations.MOVE.name.lowercase(Locale.getDefault()))?.asChannel
 
         if (newDefaultMoveChannel != null) {
-            val newConfigDto = ConfigDto(movePropertyName, newDefaultMoveChannel.name, guildId)
-            val databaseConfig = configService.getConfigByName(movePropertyName, guildId)
-
-            if (databaseConfig != null && databaseConfig.guildId == newConfigDto.guildId) {
-                configService.updateConfig(newConfigDto)
-            } else {
-                configService.createNewConfig(newConfigDto)
-            }
+            configService.upsertConfig(movePropertyName, newDefaultMoveChannel.name, guildId)
             event.hook.sendMessage("Set default move channel to '${newDefaultMoveChannel.name}'")
                 .setEphemeral(true).queue(invokeDeleteOnMessageResponse(deleteDelay))
         } else {

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/moderation/SetConfigCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/moderation/SetConfigCommandTest.kt
@@ -27,6 +27,11 @@ internal class SetConfigCommandTest : CommandTest {
         setUpCommonMocks()
         configService = mockk(relaxed = true)
         activityTrackingNotifier = mockk(relaxed = true)
+        // Default upsert: report Created. Tests that need Updated semantics
+        // (e.g. ACTIVITY_TRACKING first-enable) override per-test.
+        every { configService.upsertConfig(any(), any(), any()) } answers {
+            ConfigService.UpsertResult.Created(ConfigDto(firstArg(), secondArg(), thirdArg()))
+        }
         setConfigCommand = SetConfigCommand(configService, activityTrackingNotifier)
     }
 
@@ -38,7 +43,6 @@ internal class SetConfigCommandTest : CommandTest {
 
     @Test
     fun testSetConfig_notAsServerOwner_sendsErrorMessage() {
-        // Arrange
         val commandContext = DefaultCommandContext(event)
         val volumeOptionMapping = mockk<OptionMapping>()
 
@@ -47,22 +51,17 @@ internal class SetConfigCommandTest : CommandTest {
         every { volumeOptionMapping.name } returns VOLUME.name
         every { member.isOwner } returns false
         every { event.options } returns listOf(volumeOptionMapping)
-        every { configService.getConfigByName(VOLUME.name, "1") } returns null
 
-        // Act
         setConfigCommand.handle(commandContext, requestingUserDto, 0)
 
-        // Assert
-        verify(exactly = 0) { configService.getConfigByName(VOLUME.configValue, "1") }
-        verify(exactly = 0) { configService.createNewConfig(any()) }
+        verify(exactly = 0) { configService.upsertConfig(any(), any(), any()) }
         verify(exactly = 1) {
             event.hook.sendMessage("This is currently reserved for the owner of the server only, this may change in future")
         }
     }
 
     @Test
-    fun testSetConfig_withOneConfig_createsThatConfig() {
-        // Arrange
+    fun testSetConfig_withOneConfig_writesViaUpsert() {
         val commandContext = DefaultCommandContext(event)
         val volumeOptionMapping = mockk<OptionMapping>()
 
@@ -71,65 +70,52 @@ internal class SetConfigCommandTest : CommandTest {
         every { volumeOptionMapping.name } returns VOLUME.name
         every { member.isOwner } returns true
         every { event.options } returns listOf(volumeOptionMapping)
-        every { configService.getConfigByName(VOLUME.configValue, "1") } returns null
 
-        // Act
         setConfigCommand.handle(commandContext, requestingUserDto, 0)
 
-        // Assert
-        verify(exactly = 1) { configService.getConfigByName(VOLUME.configValue, "1") }
-        verify(exactly = 1) { configService.createNewConfig(any()) }
-        verify(exactly = 1) {
-            event.hook.sendMessage("Set default volume to '20'")
-        }
+        verify(exactly = 1) { configService.upsertConfig(VOLUME.configValue, "20", "1") }
+        verify(exactly = 1) { event.hook.sendMessage("Set default volume to '20'") }
     }
 
     @Test
-    fun testSetConfig_withOneConfig_updatesThatConfig() {
-        // Arrange
+    fun testSetConfig_updateBranch_isInvisibleToCallers() {
+        // The whole point of upsertConfig: the caller doesn't branch on
+        // exists-vs-not-exists. Verify a single call regardless of the
+        // pre-existing row.
         val commandContext = DefaultCommandContext(event)
         val volumeOptionMapping = mockk<OptionMapping>()
-        val dbConfig = ConfigDto(VOLUME.configValue, "20", "1")
-
+        every { configService.upsertConfig(VOLUME.configValue, "20", "1") } returns
+            ConfigService.UpsertResult.Updated(
+                ConfigDto(VOLUME.configValue, "20", "1"),
+                previousValue = "10"
+            )
 
         every { event.getOption(VOLUME.name.lowercase(Locale.getDefault())) } returns volumeOptionMapping
         every { volumeOptionMapping.asInt } returns 20
         every { volumeOptionMapping.name } returns VOLUME.name
         every { member.isOwner } returns true
         every { event.options } returns listOf(volumeOptionMapping)
-        every { configService.getConfigByName(VOLUME.configValue, "1") } returns dbConfig
 
-        // Act
         setConfigCommand.handle(commandContext, requestingUserDto, 0)
 
-        // Assert
-        verify(exactly = 1) { configService.getConfigByName(VOLUME.configValue, "1") }
-        verify(exactly = 1) { configService.updateConfig(any<ConfigDto>()) }
-        verify(exactly = 1) {
-            event.hook.sendMessage("Set default volume to '20'")
-        }
+        verify(exactly = 1) { configService.upsertConfig(VOLUME.configValue, "20", "1") }
+        verify(exactly = 1) { event.hook.sendMessage("Set default volume to '20'") }
     }
 
     @Test
-    fun testSetConfig_withDeleteDelay_createsThatConfig() {
-        // Arrange
+    fun testSetConfig_withDeleteDelay_writesViaUpsert() {
         val commandContext = DefaultCommandContext(event)
         val deleteDelayOptionMapping = mockk<OptionMapping>()
-        every { configService.createNewConfig(any()) } returns ConfigDto(DELETE_DELAY.name, "20", "1")
 
         every { event.getOption(DELETE_DELAY.name.lowercase(Locale.getDefault())) } returns deleteDelayOptionMapping
         every { deleteDelayOptionMapping.asInt } returns 20
         every { deleteDelayOptionMapping.name } returns DELETE_DELAY.name
         every { member.isOwner } returns true
         every { event.options } returns listOf(deleteDelayOptionMapping)
-        every { configService.getConfigByName(DELETE_DELAY.configValue, "1") } returns null
 
-        // Act
         setConfigCommand.handle(commandContext, requestingUserDto, 0)
 
-        // Assert
-        verify(exactly = 1) { configService.getConfigByName(DELETE_DELAY.configValue, "1") }
-        verify(exactly = 1) { configService.createNewConfig(any()) }
+        verify(exactly = 1) { configService.upsertConfig(DELETE_DELAY.configValue, "20", "1") }
         verify(exactly = 1) {
             event.hook.sendMessage(
                 "Set default delete message delay for TobyBot music messages to '20' seconds"
@@ -138,8 +124,7 @@ internal class SetConfigCommandTest : CommandTest {
     }
 
     @Test
-    fun testSetConfig_withMultipleSpecified_createsTwoConfig() {
-        // Arrange
+    fun testSetConfig_withMultipleSpecified_writesTwoUpserts() {
         val commandContext = DefaultCommandContext(event)
         val deleteDelayOptionMapping = mockk<OptionMapping>()
         val volumeOptionMapping = mockk<OptionMapping>()
@@ -154,29 +139,22 @@ internal class SetConfigCommandTest : CommandTest {
         every { event.guild } returns mockk {
             every { id } returns "1"
         }
-        every { configService.getConfigByName(DELETE_DELAY.configValue, "1") } returns null
-        every { configService.getConfigByName(VOLUME.configValue, "1") } returns null
-        every { configService.createNewConfig(any()) } returns null
         every { event.hook.sendMessage(any<String>()) } returns mockk {
             every { setEphemeral(any()) } returns this
             every { queue(any()) } just Runs
         }
 
-        // Act
         setConfigCommand.handle(commandContext, requestingUserDto, 0)
 
-        // Assert
-        verify(exactly = 1) { configService.getConfigByName(DELETE_DELAY.configValue, "1") }
-        verify(exactly = 1) { configService.getConfigByName(VOLUME.configValue, "1") }
-        verify(exactly = 2) { configService.createNewConfig(any()) }
+        verify(exactly = 1) { configService.upsertConfig(DELETE_DELAY.configValue, "20", "1") }
+        verify(exactly = 1) { configService.upsertConfig(VOLUME.configValue, "20", "1") }
         verify(exactly = 2) {
             event.hook.sendMessage(any<String>())
         }
     }
 
     @Test
-    fun testSetConfig_withMoveChannel_createsThatConfig() {
-        // Arrange
+    fun testSetConfig_withMoveChannel_writesViaUpsert() {
         val commandContext = DefaultCommandContext(event)
         val moveOptionMapping = mockk<OptionMapping>()
         val guildChannelUnion = mockk<GuildChannelUnion>()
@@ -187,16 +165,65 @@ internal class SetConfigCommandTest : CommandTest {
         every { guildChannelUnion.name } returns "Channel Name"
         every { member.isOwner } returns true
         every { event.options } returns listOf(moveOptionMapping)
-        every { configService.getConfigByName(MOVE.configValue, "1") } returns null
 
-        // Act
         setConfigCommand.handle(commandContext, requestingUserDto, 0)
 
-        // Assert
-        verify(exactly = 1) { configService.getConfigByName(MOVE.configValue, "1") }
-        verify(exactly = 1) { configService.createNewConfig(any()) }
+        verify(exactly = 1) { configService.upsertConfig(MOVE.configValue, "Channel Name", "1") }
         verify(exactly = 1) {
             event.hook.sendMessage("Set default move channel to 'Channel Name'")
         }
+    }
+
+    @Test
+    fun testSetConfig_activityTrackingFirstEnable_firesNotifierWhenPreviouslyDisabled() {
+        // Updated outcome with previousValue="false" → notifier should fire.
+        val commandContext = DefaultCommandContext(event)
+        val optionMapping = mockk<OptionMapping>()
+        val guildMock = mockk<net.dv8tion.jda.api.entities.Guild>(relaxed = true).also {
+            every { it.id } returns "1"
+            every { it.idLong } returns 1L
+        }
+        every { event.guild } returns guildMock
+        every { event.member } returns member
+        every { member.isOwner } returns true
+        every { event.options } returns listOf(optionMapping)
+        every { optionMapping.name } returns ACTIVITY_TRACKING.name.lowercase(Locale.getDefault())
+        every { optionMapping.asBoolean } returns true
+        every { configService.upsertConfig(ACTIVITY_TRACKING.configValue, "true", "1") } returns
+            ConfigService.UpsertResult.Updated(
+                ConfigDto(ACTIVITY_TRACKING.configValue, "true", "1"),
+                previousValue = "false"
+            )
+
+        setConfigCommand.handle(commandContext, requestingUserDto, 0)
+
+        verify(exactly = 1) { activityTrackingNotifier.notifyMembersOnFirstEnable(guildMock) }
+    }
+
+    @Test
+    fun testSetConfig_activityTrackingAlreadyEnabled_doesNotReFireNotifier() {
+        // Updated outcome with previousValue="true" → notifier already
+        // ran historically, so don't fire again.
+        val commandContext = DefaultCommandContext(event)
+        val optionMapping = mockk<OptionMapping>()
+        val guildMock = mockk<net.dv8tion.jda.api.entities.Guild>(relaxed = true).also {
+            every { it.id } returns "1"
+            every { it.idLong } returns 1L
+        }
+        every { event.guild } returns guildMock
+        every { event.member } returns member
+        every { member.isOwner } returns true
+        every { event.options } returns listOf(optionMapping)
+        every { optionMapping.name } returns ACTIVITY_TRACKING.name.lowercase(Locale.getDefault())
+        every { optionMapping.asBoolean } returns true
+        every { configService.upsertConfig(ACTIVITY_TRACKING.configValue, "true", "1") } returns
+            ConfigService.UpsertResult.Updated(
+                ConfigDto(ACTIVITY_TRACKING.configValue, "true", "1"),
+                previousValue = "true"
+            )
+
+        setConfigCommand.handle(commandContext, requestingUserDto, 0)
+
+        verify(exactly = 0) { activityTrackingNotifier.notifyMembersOnFirstEnable(any()) }
     }
 }

--- a/web/src/main/kotlin/web/service/ModerationWebService.kt
+++ b/web/src/main/kotlin/web/service/ModerationWebService.kt
@@ -288,18 +288,13 @@ class ModerationWebService(
         }
 
         val guildIdString = guild.id
-        val newDto = ConfigDto(key.configValue, value, guildIdString)
-        val existing = configService.getConfigByName(key.configValue, guildIdString)
-        val path = if (existing != null && existing.guildId == guildIdString) {
-            configService.updateConfig(newDto)
-            "update"
-        } else {
-            configService.createNewConfig(newDto)
-            "create"
+        val result = configService.upsertConfig(key.configValue, value, guildIdString)
+        val path = when (result) {
+            is ConfigService.UpsertResult.Created -> "create"
+            is ConfigService.UpsertResult.Updated -> "update"
         }
         logger.info(
-            "Config $path: guild=$guildIdString actor=$actorDiscordId key=${key.configValue} " +
-                "value=$value existing.guildId=${existing?.guildId}"
+            "Config $path: guild=$guildIdString actor=$actorDiscordId key=${key.configValue} value=$value"
         )
 
         // Mirror SetConfigCommand's Discord-side behaviour: when activity

--- a/web/src/test/kotlin/web/service/ModerationWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/ModerationWebServiceTest.kt
@@ -76,6 +76,11 @@ class ModerationWebServiceTest {
         every { jda.getGuildById(guildId) } returns guild
         every { guild.id } returns guildId.toString()
         every { guild.name } returns "Test Guild"
+        // Default upsert: report a "created" outcome so callers can branch
+        // on the result without each test having to wire it up.
+        every { configService.upsertConfig(any(), any(), any()) } answers {
+            ConfigService.UpsertResult.Created(ConfigDto(firstArg(), secondArg(), thirdArg()))
+        }
     }
 
     @AfterEach
@@ -228,13 +233,12 @@ class ModerationWebServiceTest {
     }
 
     @Test
-    fun `updateConfig creates new config when none exists`() {
+    fun `updateConfig writes the value when no row exists`() {
         mockMember(ownerId, isOwner = true)
-        every { configService.getConfigByName(ConfigDto.Configurations.VOLUME.configValue, guildId.toString()) } returns null
 
         val err = service.updateConfig(ownerId, guildId, ConfigDto.Configurations.VOLUME, "75")
         assertNull(err)
-        verify { configService.createNewConfig(match { it.value == "75" }) }
+        verify { configService.upsertConfig("DEFAULT_VOLUME", "75", guildId.toString()) }
     }
 
     @Test
@@ -244,8 +248,7 @@ class ModerationWebServiceTest {
 
         val err = service.updateConfig(ownerId, guildId, ConfigDto.Configurations.MOVE, "nope")
         assertNotNull(err)
-        verify(exactly = 0) { configService.createNewConfig(any()) }
-        verify(exactly = 0) { configService.updateConfig(any()) }
+        verify(exactly = 0) { configService.upsertConfig(any(), any(), any()) }
     }
 
     @Test
@@ -253,11 +256,10 @@ class ModerationWebServiceTest {
         mockMember(ownerId, isOwner = true)
         val vc = mockk<VoiceChannel>(relaxed = true)
         every { guild.getVoiceChannelsByName("afk", true) } returns listOf(vc)
-        every { configService.getConfigByName(ConfigDto.Configurations.MOVE.configValue, guildId.toString()) } returns null
 
         val err = service.updateConfig(ownerId, guildId, ConfigDto.Configurations.MOVE, "afk")
         assertNull(err)
-        verify { configService.createNewConfig(match { it.value == "afk" }) }
+        verify { configService.upsertConfig("DEFAULT_MOVE_CHANNEL", "afk", guildId.toString()) }
     }
 
     // ---- kickMember ----
@@ -566,17 +568,17 @@ class ModerationWebServiceTest {
         mockMember(ownerId, isOwner = true)
         val textChannel = mockk<TextChannel>(relaxed = true)
         every { guild.getTextChannelById(111L) } returns textChannel
-        every { configService.getConfigByName(any(), any()) } returns null
 
         val err = service.updateConfig(ownerId, guildId, ConfigDto.Configurations.LEADERBOARD_CHANNEL, "111")
         assertNull(err)
-        verify(exactly = 1) { configService.createNewConfig(any()) }
+        verify(exactly = 1) {
+            configService.upsertConfig("LEADERBOARD_CHANNEL", "111", guildId.toString())
+        }
     }
 
     @Test
     fun `updateConfig ACTIVITY_TRACKING=true publishes the first-enable event`() {
         mockMember(ownerId, isOwner = true)
-        every { configService.getConfigByName(any(), any()) } returns null
 
         val err = service.updateConfig(ownerId, guildId, ConfigDto.Configurations.ACTIVITY_TRACKING, "true")
 
@@ -592,7 +594,6 @@ class ModerationWebServiceTest {
     @Test
     fun `updateConfig ACTIVITY_TRACKING=false does NOT publish the event`() {
         mockMember(ownerId, isOwner = true)
-        every { configService.getConfigByName(any(), any()) } returns null
 
         service.updateConfig(ownerId, guildId, ConfigDto.Configurations.ACTIVITY_TRACKING, "false")
 
@@ -609,8 +610,7 @@ class ModerationWebServiceTest {
         val err = service.updateConfig(ownerId, guildId, ConfigDto.Configurations.ACTIVITY_TRACKING, "maybe")
 
         assertEquals("Value must be true or false.", err)
-        verify(exactly = 0) { configService.createNewConfig(any()) }
-        verify(exactly = 0) { configService.updateConfig(any()) }
+        verify(exactly = 0) { configService.upsertConfig(any(), any(), any()) }
         verify(exactly = 0) {
             eventPublisher.publishEvent(any<common.events.ActivityTrackingEnabled>())
         }


### PR DESCRIPTION
## Summary
- Adds `ConfigService.upsertConfig(name, value, guildId): UpsertResult` so callers don't open-code `getConfigByName` → branch → `updateConfig`/`createNewConfig` every time.
- `UpsertResult` is a sealed interface (`Created` | `Updated(previousValue)`). The previous value is exposed because `SetConfigCommand` needs it to decide whether to fire the activity-tracking first-enable DM flow.
- Refactors every existing open-coded site to use it.

## Why now

This is the first of the follow-up PRs from the poker plan ([poker plan](https://claude.ai/code/session_0169MvtJ2BSbwkoB9GrFhfZC), approved post-#322 merge). Qodana flagged 8 of these duplicate blocks against #322 alone and they’d pile up faster than we add new config keys. Smallest, biggest-payoff refactor on the queue — does not change any user-visible behaviour.

## Sites collapsed

| File | Sites |
|---|---|
| `discord-bot/.../moderation/SetConfigCommand.kt` | `setLeaderboardChannel`, `setActivityTracking`, `setConfigAndSendMessage`, `setJackpotLossTribute`, `setPokerRake`, `setMove` |
| `web/.../ModerationWebService.kt` | `updateConfig` |
| `discord-bot/.../activity/ActivityTrackingNotifier.kt` | NOTIFIED-flag persistence |

`createNewConfig` and `updateConfig` stay on the interface for places that genuinely need to distinguish (or for tests that want to spy on a single edge of the dispatch).

## Test plan
- [x] `./gradlew :database:test :web:test` — passing locally (sandbox can't fetch the discord-bot's lavaplayer transitive deps; CI exercises those).
- [x] New `ConfigServiceImplIntegrationTest` cases:
  - upsert with no row → `Created`
  - upsert with existing row → `Updated(previousValue=...)`
  - cross-guild upsert is independent (no row clobbering)
- [x] `SetConfigCommandTest` rewritten to verify `upsertConfig(...)` calls; adds two cases proving the activity-tracking notifier fires only when `previousValue` was `"false"`.
- [x] `ModerationWebServiceTest` updated to match — every former `createNewConfig`/`updateConfig` assertion is now an `upsertConfig` assertion.

https://claude.ai/code/session_0169MvtJ2BSbwkoB9GrFhfZC

---
_Generated by [Claude Code](https://claude.ai/code/session_0169MvtJ2BSbwkoB9GrFhfZC)_