### PR TITLE
refactor(user): extract lockUsersInAscendingOrder for deadlock-safe multi-user locking

### DIFF
--- a/database/src/main/kotlin/database/service/DuelService.kt
+++ b/database/src/main/kotlin/database/service/DuelService.kt
@@ -1,7 +1,6 @@
 package database.service
 
 import database.dto.DuelLogDto
-import database.dto.UserDto
 import database.economy.Coinflip
 import database.persistence.DuelLogPersistence
 import org.springframework.beans.factory.annotation.Autowired
@@ -110,9 +109,12 @@ class DuelService @Autowired constructor(
         at: Instant = Instant.now(),
     ): AcceptOutcome {
         // Lock both rows in deterministic ascending order to avoid deadlocks.
-        val (initiator, opponent) = lockBoth(initiatorDiscordId, opponentDiscordId, guildId)
-        initiator ?: return AcceptOutcome.UnknownInitiator
-        opponent ?: return AcceptOutcome.UnknownOpponent
+        val locked = userService.lockUsersInAscendingOrder(
+            listOf(initiatorDiscordId, opponentDiscordId),
+            guildId
+        )
+        val initiator = locked[initiatorDiscordId] ?: return AcceptOutcome.UnknownInitiator
+        val opponent = locked[opponentDiscordId] ?: return AcceptOutcome.UnknownOpponent
 
         val initiatorBalance = initiator.socialCredit ?: 0L
         if (initiatorBalance < stake) {
@@ -163,18 +165,6 @@ class DuelService @Autowired constructor(
             loserNewBalance = loser.socialCredit ?: 0L,
             lossTribute = tribute
         )
-    }
-
-    private fun lockBoth(aId: Long, bId: Long, guildId: Long): Pair<UserDto?, UserDto?> {
-        return if (aId < bId) {
-            val a = userService.getUserByIdForUpdate(aId, guildId)
-            val b = userService.getUserByIdForUpdate(bId, guildId)
-            a to b
-        } else {
-            val b = userService.getUserByIdForUpdate(bId, guildId)
-            val a = userService.getUserByIdForUpdate(aId, guildId)
-            a to b
-        }
     }
 
     companion object {

--- a/database/src/main/kotlin/database/service/PokerService.kt
+++ b/database/src/main/kotlin/database/service/PokerService.kt
@@ -319,16 +319,22 @@ class PokerService @Autowired constructor(
      */
     @Transactional
     fun evictAllSeats(table: PokerTable) {
-        val refunds: List<Pair<Long, Long>> = synchronized(table) {
+        val refunds: Map<Long, Long> = synchronized(table) {
             // Treat anyone with chips as a refund target. Mid-hand evictions
             // donate uncalled bets to the survivors via the table pot, but
             // for an idle wipe we just pay back what's on each stack.
-            val out = table.seats.filter { it.chips > 0L }.map { it.discordId to it.chips }
+            val out = table.seats.filter { it.chips > 0L }.associate { it.discordId to it.chips }
             table.seats.clear()
             out
         }
+        if (refunds.isEmpty()) return
+
+        // Lock all refund recipients in ascending discord-id order to avoid
+        // cycles with concurrent /tip, /duel, /coinflip, etc. transactions
+        // that touch the same users.
+        val locked = userService.lockUsersInAscendingOrder(refunds.keys, table.guildId)
         for ((discordId, amount) in refunds) {
-            val user = userService.getUserByIdForUpdate(discordId, table.guildId) ?: continue
+            val user = locked[discordId] ?: continue
             user.socialCredit = (user.socialCredit ?: 0L) + amount
             userService.updateUser(user)
         }

--- a/database/src/main/kotlin/database/service/UserService.kt
+++ b/database/src/main/kotlin/database/service/UserService.kt
@@ -16,3 +16,31 @@ interface UserService {
     fun clearCache()
     fun evictUserFromCache(discordId: Long?, guildId: Long?)
 }
+
+/**
+ * Lock every user row in [ids] for the given [guildId] in deterministic
+ * ascending discord-id order. This is the standard deadlock-avoidance
+ * pattern any time a transaction needs to take pessimistic locks on
+ * multiple users at once: if every caller acquires in the same order,
+ * two concurrent transactions can never form a cycle.
+ *
+ * Duplicates in [ids] are de-duped before locking. The returned map is
+ * keyed by discord id; missing rows surface as `null` values so callers
+ * can decide whether the absence is fatal (e.g. `DuelService` returns
+ * `UnknownInitiator`/`UnknownOpponent`) or expected (e.g. `PokerService`
+ * eviction skips already-vanished users).
+ *
+ * Must run inside a `@Transactional` boundary — that's where the FOR
+ * UPDATE locks live.
+ */
+fun UserService.lockUsersInAscendingOrder(
+    ids: Collection<Long>,
+    guildId: Long
+): Map<Long, UserDto?> {
+    val sorted = ids.toSet().sorted()
+    val result = LinkedHashMap<Long, UserDto?>(sorted.size)
+    for (id in sorted) {
+        result[id] = getUserByIdForUpdate(id, guildId)
+    }
+    return result
+}

--- a/database/src/test/kotlin/database/service/UserServiceLockOrderTest.kt
+++ b/database/src/test/kotlin/database/service/UserServiceLockOrderTest.kt
@@ -1,0 +1,113 @@
+package database.service
+
+import database.dto.UserDto
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+/**
+ * Pure unit test for the `UserService.lockUsersInAscendingOrder` extension.
+ *
+ * The behaviour we lock down here is the deadlock-avoidance contract:
+ * locks always happen in ascending discord-id order regardless of the
+ * caller's input order, duplicates collapse to a single lock, and
+ * missing rows surface as `null` values without aborting the rest.
+ */
+class UserServiceLockOrderTest {
+
+    private val guildId = 42L
+
+    @Test
+    fun `locks in ascending order regardless of input order`() {
+        val recording = RecordingUserService()
+        recording.seed(7L); recording.seed(3L); recording.seed(11L)
+
+        recording.lockUsersInAscendingOrder(listOf(11L, 3L, 7L), guildId)
+
+        assertEquals(listOf(3L, 7L, 11L), recording.lockOrder)
+    }
+
+    @Test
+    fun `dedups before locking`() {
+        val recording = RecordingUserService()
+        recording.seed(5L); recording.seed(2L)
+
+        val map = recording.lockUsersInAscendingOrder(listOf(5L, 2L, 5L, 2L, 5L), guildId)
+
+        assertEquals(listOf(2L, 5L), recording.lockOrder, "duplicate ids must lock once")
+        assertEquals(setOf(2L, 5L), map.keys, "result keyed by discord id, dedup'd")
+    }
+
+    @Test
+    fun `missing rows surface as null without aborting`() {
+        val recording = RecordingUserService()
+        recording.seed(2L)
+        // 5 is not seeded.
+
+        val map = recording.lockUsersInAscendingOrder(listOf(2L, 5L), guildId)
+
+        assertEquals(listOf(2L, 5L), recording.lockOrder, "still attempts the lock for the missing id")
+        assertEquals(2L, map[2L]?.discordId)
+        assertNull(map[5L])
+    }
+
+    @Test
+    fun `empty input does no work`() {
+        val recording = RecordingUserService()
+        val map = recording.lockUsersInAscendingOrder(emptyList(), guildId)
+        assertEquals(emptyList<Long>(), recording.lockOrder)
+        assertEquals(emptyMap<Long, UserDto?>(), map)
+    }
+
+    @Test
+    fun `result map preserves ascending iteration order`() {
+        val recording = RecordingUserService()
+        listOf(10L, 1L, 5L).forEach(recording::seed)
+
+        val map = recording.lockUsersInAscendingOrder(listOf(10L, 1L, 5L), guildId)
+
+        assertEquals(listOf(1L, 5L, 10L), map.keys.toList())
+    }
+
+    @Test
+    fun `passing a Set still locks in ascending order`() {
+        val recording = RecordingUserService()
+        listOf(9L, 4L, 6L).forEach(recording::seed)
+
+        recording.lockUsersInAscendingOrder(setOf(9L, 4L, 6L), guildId)
+
+        assertEquals(listOf(4L, 6L, 9L), recording.lockOrder)
+    }
+
+    private class RecordingUserService : UserService {
+        private val users = mutableMapOf<Pair<Long, Long>, UserDto>()
+        val lockOrder: MutableList<Long> = mutableListOf()
+
+        fun seed(discordId: Long, guildId: Long = 42L) {
+            users[discordId to guildId] = UserDto(discordId, guildId)
+        }
+
+        override fun listGuildUsers(guildId: Long?): List<UserDto?> =
+            users.values.filter { it.guildId == guildId }
+        override fun createNewUser(userDto: UserDto): UserDto {
+            users[userDto.discordId to userDto.guildId] = userDto
+            return userDto
+        }
+        override fun getUserById(discordId: Long?, guildId: Long?): UserDto? =
+            users[discordId!! to guildId!!]
+        override fun getUserByIdForUpdate(discordId: Long?, guildId: Long?): UserDto? {
+            lockOrder.add(discordId!!)
+            return users[discordId to guildId!!]
+        }
+        override fun updateUser(userDto: UserDto): UserDto {
+            users[userDto.discordId to userDto.guildId] = userDto
+            return userDto
+        }
+        override fun deleteUser(userDto: UserDto) { users.remove(userDto.discordId to userDto.guildId) }
+        override fun deleteUserById(discordId: Long?, guildId: Long?) {
+            users.remove(discordId!! to guildId!!)
+        }
+        override fun clearCache() {}
+        override fun evictUserFromCache(discordId: Long?, guildId: Long?) {}
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `UserService.lockUsersInAscendingOrder(ids, guildId)` extension — dedups, sorts, locks via the existing `getUserByIdForUpdate`, returns a map keyed by discord id with `null` for missing rows.
- Replaces `DuelService.lockBoth` (deleted) and the unsorted seat-loop in `PokerService.evictAllSeats` with the new helper.

## Why

`DuelService.acceptDuel` already had this right with a hand-rolled `lockBoth(aId, bId)` that locked in ascending order to dodge deadlocks. `PokerService.evictAllSeats` did **not** — it walked `table.seats` in arbitrary seat order, so two concurrent transactions touching overlapping users (idle eviction during a `/tip`, for example) could form a lock cycle and deadlock on the DB. This is the concurrency footgun flagged by the follow-up refactor plan after the poker PR landed.

Centralising the helper means any future N-user transfer (side-pot resolver, multi-recipient tip, leaderboard payout) gets the deadlock-avoidance for free.

## Test plan
- [x] `./gradlew :database:test` — passes (sandbox can't fetch discord-bot's lavaplayer transitive deps; CI exercises those).
- [x] New `UserServiceLockOrderTest` (6 cases): input order doesn't matter, duplicates collapse, missing rows surface as `null`, empty input is a no-op, result preserves ascending iteration order, works with `Set` inputs.
- [x] Existing `DuelServiceTest.acceptDuel locks both users in ascending discord-id order` continues to pass — its `RecordingUserService` records every `getUserByIdForUpdate` and the new helper invokes them in the same order.
- [x] Existing `PokerServiceTest.evictAllSeats refunds chips to all seated players` continues to pass.

## What this isn't

No user-visible behaviour change. Pure refactor.

https://claude.ai/code/session_0169MvtJ2BSbwkoB9GrFhfZC

---
_Generated by [Claude Code](https://claude.ai/code/session_0169MvtJ2BSbwkoB9GrFhfZC)_