### PR TITLE
refactor(web): extract casino-result.js for the shared minigame render scaffold

### DIFF
--- a/web/src/main/resources/static/js/casino-result.js
+++ b/web/src/main/resources/static/js/casino-result.js
@@ -1,0 +1,57 @@
+// Shared scaffolding for every minigame's result-rendering function:
+//   - clear the three game-prefixed result classes (-win, -lose, -jackpot)
+//   - prepend the TobyTopUp sold-coins prefix
+//   - either wrap the win line via TobyJackpot.renderWinHtml (jackpot
+//     banner if it hit) OR append TobyJackpot.lossTributeSuffix to the
+//     lose line.
+//
+// Each game's renderXResult used to open-code that exact dance with
+// only the inner win/lose HTML differing. Now they hand us those two
+// HTML fragments and the class prefix; we do the rest.
+
+(function (root) {
+    'use strict';
+
+    /**
+     * options:
+     *   resultEl:     DOM element receiving innerHTML (no-op if null)
+     *   body:         server response object (must include `win`, may
+     *                 include soldTobyCoins/newPrice/jackpotPayout/lossTribute)
+     *   classPrefix:  e.g. 'slots' for 'slots-result-win'/'-lose'/'-jackpot'
+     *   winLineHtml:  HTML string for the win line (game-specific)
+     *   loseLineHtml: HTML string for the lose line (game-specific)
+     */
+    function render(opts) {
+        const el = opts.resultEl;
+        if (!el) return;
+        const prefix = opts.classPrefix;
+        el.hidden = false;
+        el.classList.remove(
+            prefix + '-result-win',
+            prefix + '-result-lose',
+            prefix + '-result-jackpot'
+        );
+        const topUpPrefix = (root && root.TobyTopUp)
+            ? root.TobyTopUp.soldPrefixHtml(opts.body.soldTobyCoins, opts.body.newPrice)
+            : '';
+        if (opts.body.win) {
+            el.classList.add(prefix + '-result-win');
+            const withJackpot = (root && root.TobyJackpot)
+                ? root.TobyJackpot.renderWinHtml(el, opts.body, prefix + '-result-jackpot', opts.winLineHtml)
+                : opts.winLineHtml;
+            el.innerHTML = topUpPrefix + withJackpot;
+        } else {
+            el.classList.add(prefix + '-result-lose');
+            const tributeSuffix = (root && root.TobyJackpot)
+                ? root.TobyJackpot.lossTributeSuffix(opts.body)
+                : '';
+            el.innerHTML = topUpPrefix + opts.loseLineHtml + tributeSuffix;
+        }
+    }
+
+    const api = { render: render };
+    if (root) root.TobyCasinoResult = api;
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = api;
+    }
+})(typeof window !== 'undefined' ? window : null);

--- a/web/src/main/resources/static/js/coinflip.js
+++ b/web/src/main/resources/static/js/coinflip.js
@@ -1,30 +1,18 @@
 // Pure-DOM render for a /flip response. Hoisted out of the IIFE so the
 // jest test in `coinflip.test.js` can drive it without booting the page.
 function renderCoinflipResult(resultEl, body) {
-    if (!resultEl) return;
-    resultEl.hidden = false;
-    resultEl.classList.remove('coinflip-result-win', 'coinflip-result-lose', 'coinflip-result-jackpot');
     const landedLabel = body.landed === 'HEADS' ? 'Heads' : 'Tails';
     const predictedLabel = body.predicted === 'HEADS' ? 'Heads' : 'Tails';
-    const topUpPrefix = (typeof window !== 'undefined' && window.TobyTopUp)
-        ? window.TobyTopUp.soldPrefixHtml(body.soldTobyCoins, body.newPrice)
-        : '';
-    if (body.win) {
-        resultEl.classList.add('coinflip-result-win');
-        const winLine = '<strong>' + landedLabel + '!</strong> You called ' +
-            predictedLabel + ' &middot; <strong>+' + body.net + ' credits</strong>';
-        const withJackpot = (typeof window !== 'undefined' && window.TobyJackpot)
-            ? window.TobyJackpot.renderWinHtml(resultEl, body, 'coinflip-result-jackpot', winLine)
-            : winLine;
-        resultEl.innerHTML = topUpPrefix + withJackpot;
-    } else {
-        resultEl.classList.add('coinflip-result-lose');
-        const tributeSuffix = (typeof window !== 'undefined' && window.TobyJackpot)
-            ? window.TobyJackpot.lossTributeSuffix(body)
-            : '';
-        resultEl.innerHTML = topUpPrefix + '<strong>' + landedLabel + '.</strong> You called ' +
-            predictedLabel + ' &middot; lost <strong>' + Math.abs(body.net) + ' credits</strong>' +
-            tributeSuffix;
+    if (typeof window !== 'undefined' && window.TobyCasinoResult) {
+        window.TobyCasinoResult.render({
+            resultEl: resultEl,
+            body: body,
+            classPrefix: 'coinflip',
+            winLineHtml: '<strong>' + landedLabel + '!</strong> You called ' +
+                predictedLabel + ' &middot; <strong>+' + body.net + ' credits</strong>',
+            loseLineHtml: '<strong>' + landedLabel + '.</strong> You called ' +
+                predictedLabel + ' &middot; lost <strong>' + Math.abs(body.net) + ' credits</strong>',
+        });
     }
 }
 

--- a/web/src/main/resources/static/js/dice.js
+++ b/web/src/main/resources/static/js/dice.js
@@ -1,28 +1,16 @@
 // Pure-DOM render for a /roll response. Hoisted out of the IIFE so the
 // jest test in `dice.test.js` can drive it without booting the page.
 function renderDiceResult(resultEl, body) {
-    if (!resultEl) return;
-    resultEl.hidden = false;
-    resultEl.classList.remove('dice-result-win', 'dice-result-lose', 'dice-result-jackpot');
-    const topUpPrefix = (typeof window !== 'undefined' && window.TobyTopUp)
-        ? window.TobyTopUp.soldPrefixHtml(body.soldTobyCoins, body.newPrice)
-        : '';
-    if (body.win) {
-        resultEl.classList.add('dice-result-win');
-        const winLine = '<strong>' + body.landed + '!</strong> You called ' +
-            body.predicted + ' &middot; <strong>+' + body.net + ' credits</strong>';
-        const withJackpot = (typeof window !== 'undefined' && window.TobyJackpot)
-            ? window.TobyJackpot.renderWinHtml(resultEl, body, 'dice-result-jackpot', winLine)
-            : winLine;
-        resultEl.innerHTML = topUpPrefix + withJackpot;
-    } else {
-        resultEl.classList.add('dice-result-lose');
-        const tributeSuffix = (typeof window !== 'undefined' && window.TobyJackpot)
-            ? window.TobyJackpot.lossTributeSuffix(body)
-            : '';
-        resultEl.innerHTML = topUpPrefix + '<strong>' + body.landed + '.</strong> You called ' +
-            body.predicted + ' &middot; lost <strong>' + Math.abs(body.net) + ' credits</strong>' +
-            tributeSuffix;
+    if (typeof window !== 'undefined' && window.TobyCasinoResult) {
+        window.TobyCasinoResult.render({
+            resultEl: resultEl,
+            body: body,
+            classPrefix: 'dice',
+            winLineHtml: '<strong>' + body.landed + '!</strong> You called ' +
+                body.predicted + ' &middot; <strong>+' + body.net + ' credits</strong>',
+            loseLineHtml: '<strong>' + body.landed + '.</strong> You called ' +
+                body.predicted + ' &middot; lost <strong>' + Math.abs(body.net) + ' credits</strong>',
+        });
     }
 }
 

--- a/web/src/main/resources/static/js/highlow.js
+++ b/web/src/main/resources/static/js/highlow.js
@@ -21,37 +21,24 @@ function highlowFormatMultiplier(m) {
 // Pure-DOM render for a /play response. Hoisted out of the IIFE so the
 // jest test in `highlow.test.js` can drive it without booting the page.
 function renderHighlowResult(resultEl, body) {
-    if (!resultEl) return;
-    resultEl.hidden = false;
-    resultEl.classList.remove('highlow-result-win', 'highlow-result-lose', 'highlow-result-jackpot');
+    if (typeof window === 'undefined' || !window.TobyCasinoResult) return;
     const dirLabel = body.direction === 'HIGHER' ? 'Higher' : 'Lower';
-    const topUpPrefix = (typeof window !== 'undefined' && window.TobyTopUp)
-        ? window.TobyTopUp.soldPrefixHtml(body.soldTobyCoins, body.newPrice)
-        : '';
-    if (body.win) {
-        resultEl.classList.add('highlow-result-win');
-        const multSuffix = highlowFormatMultiplier(body.multiplier);
-        const winLine = '<strong>' + highlowCardLabel(body.next) + '</strong> ' +
+    const tie = body.next === body.anchor;
+    const multSuffix = highlowFormatMultiplier(body.multiplier);
+    window.TobyCasinoResult.render({
+        resultEl: resultEl,
+        body: body,
+        classPrefix: 'highlow',
+        winLineHtml: '<strong>' + highlowCardLabel(body.next) + '</strong> ' +
             (body.next > body.anchor ? '>' : '<') + ' <strong>' + highlowCardLabel(body.anchor) +
             '</strong> &middot; you called ' + dirLabel +
             (multSuffix ? ' (' + multSuffix + ')' : '') +
-            ' &middot; <strong>+' + body.net + ' credits</strong>';
-        const withJackpot = (typeof window !== 'undefined' && window.TobyJackpot)
-            ? window.TobyJackpot.renderWinHtml(resultEl, body, 'highlow-result-jackpot', winLine)
-            : winLine;
-        resultEl.innerHTML = topUpPrefix + withJackpot;
-    } else {
-        resultEl.classList.add('highlow-result-lose');
-        const tie = body.next === body.anchor;
-        const tributeSuffix = (typeof window !== 'undefined' && window.TobyJackpot)
-            ? window.TobyJackpot.lossTributeSuffix(body)
-            : '';
-        resultEl.innerHTML = topUpPrefix + '<strong>' + highlowCardLabel(body.next) + '</strong> ' +
+            ' &middot; <strong>+' + body.net + ' credits</strong>',
+        loseLineHtml: '<strong>' + highlowCardLabel(body.next) + '</strong> ' +
             (tie ? '=' : (body.next > body.anchor ? '>' : '<')) +
             ' <strong>' + highlowCardLabel(body.anchor) + '</strong> &middot; you called ' +
-            dirLabel + ' &middot; lost <strong>' + Math.abs(body.net) + ' credits</strong>' +
-            tributeSuffix;
-    }
+            dirLabel + ' &middot; lost <strong>' + Math.abs(body.net) + ' credits</strong>',
+    });
 }
 
 (function () {

--- a/web/src/main/resources/static/js/scratch.js
+++ b/web/src/main/resources/static/js/scratch.js
@@ -4,27 +4,16 @@
 // attributes / element references inside the IIFE) to keep this fully
 // stateless.
 function renderScratchResult(resultEl, body, matchThreshold, balanceEl) {
-    if (!resultEl) return;
-    resultEl.hidden = false;
-    resultEl.classList.remove('scratch-result-win', 'scratch-result-lose', 'scratch-result-jackpot');
-    const topUpPrefix = (typeof window !== 'undefined' && window.TobyTopUp)
-        ? window.TobyTopUp.soldPrefixHtml(body.soldTobyCoins, body.newPrice)
-        : '';
-    if (body.win) {
-        resultEl.classList.add('scratch-result-win');
-        const winLine = '<strong>' + body.matchCount + '× ' + body.winningSymbol +
-            '</strong> &middot; <strong>+' + body.net + ' credits</strong>';
-        const withJackpot = (typeof window !== 'undefined' && window.TobyJackpot)
-            ? window.TobyJackpot.renderWinHtml(resultEl, body, 'scratch-result-jackpot', winLine)
-            : winLine;
-        resultEl.innerHTML = topUpPrefix + withJackpot;
-    } else {
-        resultEl.classList.add('scratch-result-lose');
-        const tributeSuffix = (typeof window !== 'undefined' && window.TobyJackpot)
-            ? window.TobyJackpot.lossTributeSuffix(body)
-            : '';
-        resultEl.innerHTML = topUpPrefix + 'No ' + matchThreshold + '-of-a-kind &middot; lost <strong>' +
-            Math.abs(body.net) + ' credits</strong>' + tributeSuffix;
+    if (typeof window !== 'undefined' && window.TobyCasinoResult) {
+        window.TobyCasinoResult.render({
+            resultEl: resultEl,
+            body: body,
+            classPrefix: 'scratch',
+            winLineHtml: '<strong>' + body.matchCount + '× ' + body.winningSymbol +
+                '</strong> &middot; <strong>+' + body.net + ' credits</strong>',
+            loseLineHtml: 'No ' + matchThreshold + '-of-a-kind &middot; lost <strong>' +
+                Math.abs(body.net) + ' credits</strong>',
+        });
     }
     if (typeof body.newBalance === 'number' && balanceEl) balanceEl.textContent = body.newBalance;
 }

--- a/web/src/main/resources/static/js/slots.js
+++ b/web/src/main/resources/static/js/slots.js
@@ -2,27 +2,15 @@
 // jest test in `slots.test.js` can drive it without booting the whole
 // page. The IIFE below calls it with the live result element.
 function renderSlotsResult(resultEl, body) {
-    if (!resultEl) return;
-    resultEl.hidden = false;
-    resultEl.classList.remove('slots-result-win', 'slots-result-lose', 'slots-result-jackpot');
-    const topUpPrefix = (typeof window !== 'undefined' && window.TobyTopUp)
-        ? window.TobyTopUp.soldPrefixHtml(body.soldTobyCoins, body.newPrice)
-        : '';
-    if (body.win) {
-        resultEl.classList.add('slots-result-win');
-        const winLine = '<strong>+' + body.net + ' credits</strong> &middot; ' +
-            body.multiplier + '× on a stake';
-        const withJackpot = (typeof window !== 'undefined' && window.TobyJackpot)
-            ? window.TobyJackpot.renderWinHtml(resultEl, body, 'slots-result-jackpot', winLine)
-            : winLine;
-        resultEl.innerHTML = topUpPrefix + withJackpot;
-    } else {
-        resultEl.classList.add('slots-result-lose');
-        const tributeSuffix = (typeof window !== 'undefined' && window.TobyJackpot)
-            ? window.TobyJackpot.lossTributeSuffix(body)
-            : '';
-        resultEl.innerHTML = topUpPrefix + 'Lost <strong>' + Math.abs(body.net) +
-            ' credits</strong>' + tributeSuffix;
+    if (typeof window !== 'undefined' && window.TobyCasinoResult) {
+        window.TobyCasinoResult.render({
+            resultEl: resultEl,
+            body: body,
+            classPrefix: 'slots',
+            winLineHtml: '<strong>+' + body.net + ' credits</strong> &middot; ' +
+                body.multiplier + '× on a stake',
+            loseLineHtml: 'Lost <strong>' + Math.abs(body.net) + ' credits</strong>',
+        });
     }
 }
 

--- a/web/src/main/resources/templates/coinflip.html
+++ b/web/src/main/resources/templates/coinflip.html
@@ -77,6 +77,7 @@
 <script th:src="@{/js/toasts.js}"></script>
 <script th:src="@{/js/casino-jackpot.js}"></script>
 <script th:src="@{/js/casino-topup.js}"></script>
+<script th:src="@{/js/casino-result.js}"></script>
 <script th:src="@{/js/coinflip.js}"></script>
 </body>
 </html>

--- a/web/src/main/resources/templates/dice.html
+++ b/web/src/main/resources/templates/dice.html
@@ -74,6 +74,7 @@
 <script th:src="@{/js/toasts.js}"></script>
 <script th:src="@{/js/casino-jackpot.js}"></script>
 <script th:src="@{/js/casino-topup.js}"></script>
+<script th:src="@{/js/casino-result.js}"></script>
 <script th:src="@{/js/dice.js}"></script>
 </body>
 </html>

--- a/web/src/main/resources/templates/highlow.html
+++ b/web/src/main/resources/templates/highlow.html
@@ -93,6 +93,7 @@
 <script th:src="@{/js/toasts.js}"></script>
 <script th:src="@{/js/casino-jackpot.js}"></script>
 <script th:src="@{/js/casino-topup.js}"></script>
+<script th:src="@{/js/casino-result.js}"></script>
 <script th:src="@{/js/highlow.js}"></script>
 </body>
 </html>

--- a/web/src/main/resources/templates/scratch.html
+++ b/web/src/main/resources/templates/scratch.html
@@ -93,6 +93,7 @@
 <script th:src="@{/js/toasts.js}"></script>
 <script th:src="@{/js/casino-jackpot.js}"></script>
 <script th:src="@{/js/casino-topup.js}"></script>
+<script th:src="@{/js/casino-result.js}"></script>
 <script th:src="@{/js/scratch.js}"></script>
 </body>
 </html>

--- a/web/src/main/resources/templates/slots.html
+++ b/web/src/main/resources/templates/slots.html
@@ -77,6 +77,7 @@
 <script th:src="@{/js/toasts.js}"></script>
 <script th:src="@{/js/casino-jackpot.js}"></script>
 <script th:src="@{/js/casino-topup.js}"></script>
+<script th:src="@{/js/casino-result.js}"></script>
 <script th:src="@{/js/slots.js}"></script>
 </body>
 </html>

--- a/web/src/test/js/casino-result.test.js
+++ b/web/src/test/js/casino-result.test.js
@@ -1,0 +1,122 @@
+// Pure-DOM unit test for the shared casino-result helper. Loaded via the
+// browser global the production JS uses (window.TobyCasinoResult).
+require('../../main/resources/static/js/casino-jackpot');
+require('../../main/resources/static/js/casino-topup');
+require('../../main/resources/static/js/casino-result');
+
+describe('TobyCasinoResult.render', () => {
+    let el;
+
+    beforeEach(() => {
+        document.body.innerHTML = '<div id="r"></div>';
+        el = document.getElementById('r');
+    });
+
+    test('no-op when resultEl is null', () => {
+        expect(() =>
+            window.TobyCasinoResult.render({
+                resultEl: null,
+                body: { win: true },
+                classPrefix: 'slots',
+                winLineHtml: 'WIN',
+                loseLineHtml: 'LOSE',
+            })
+        ).not.toThrow();
+    });
+
+    test('win path adds the -result-win class and renders the win line', () => {
+        window.TobyCasinoResult.render({
+            resultEl: el,
+            body: { win: true, net: 100 },
+            classPrefix: 'slots',
+            winLineHtml: '<strong>+100 credits</strong>',
+            loseLineHtml: 'LOSE',
+        });
+        expect(el.classList.contains('slots-result-win')).toBe(true);
+        expect(el.classList.contains('slots-result-lose')).toBe(false);
+        expect(el.innerHTML).toContain('+100 credits');
+        expect(el.innerHTML).not.toContain('LOSE');
+    });
+
+    test('lose path adds the -result-lose class and renders the lose line', () => {
+        window.TobyCasinoResult.render({
+            resultEl: el,
+            body: { win: false, net: -50 },
+            classPrefix: 'dice',
+            winLineHtml: 'WIN',
+            loseLineHtml: 'lost <strong>50 credits</strong>',
+        });
+        expect(el.classList.contains('dice-result-lose')).toBe(true);
+        expect(el.classList.contains('dice-result-win')).toBe(false);
+        expect(el.innerHTML).toContain('50 credits');
+        expect(el.innerHTML).not.toContain('WIN');
+    });
+
+    test('clears all three game-prefixed classes before re-rendering', () => {
+        // Manually pre-stick all three classes on the element to simulate
+        // a previous render — the helper must drop them all so a fresh
+        // result doesn't carry over old win/lose/jackpot styling.
+        el.classList.add('coinflip-result-win', 'coinflip-result-lose', 'coinflip-result-jackpot');
+
+        window.TobyCasinoResult.render({
+            resultEl: el,
+            body: { win: false, net: -10 },
+            classPrefix: 'coinflip',
+            winLineHtml: 'WIN',
+            loseLineHtml: 'lose body',
+        });
+
+        expect(el.classList.contains('coinflip-result-win')).toBe(false);
+        expect(el.classList.contains('coinflip-result-jackpot')).toBe(false);
+        expect(el.classList.contains('coinflip-result-lose')).toBe(true);
+    });
+
+    test('jackpot win adds the -result-jackpot class and prepends the banner', () => {
+        window.TobyCasinoResult.render({
+            resultEl: el,
+            body: { win: true, net: 100, jackpotPayout: 999 },
+            classPrefix: 'slots',
+            winLineHtml: '<strong>+100 credits</strong>',
+            loseLineHtml: 'LOSE',
+        });
+        expect(el.classList.contains('slots-result-jackpot')).toBe(true);
+        expect(el.innerHTML).toContain('JACKPOT');
+        expect(el.innerHTML).toContain('+999 credits');
+    });
+
+    test('lose with lossTribute appends the +N to jackpot suffix', () => {
+        window.TobyCasinoResult.render({
+            resultEl: el,
+            body: { win: false, net: -50, lossTribute: 5 },
+            classPrefix: 'dice',
+            winLineHtml: 'WIN',
+            loseLineHtml: 'lost 50 credits',
+        });
+        expect(el.innerHTML).toContain('+5 to jackpot');
+    });
+
+    test('top-up prefix prepends to win and lose alike', () => {
+        window.TobyCasinoResult.render({
+            resultEl: el,
+            body: { win: true, net: 100, soldTobyCoins: 7, newPrice: 12.5 },
+            classPrefix: 'slots',
+            winLineHtml: 'WIN_LINE',
+            loseLineHtml: 'LOSE_LINE',
+        });
+        // TobyTopUp.soldPrefixHtml mentions the sold count somewhere.
+        expect(el.innerHTML).toContain('7');
+        expect(el.innerHTML).toContain('WIN_LINE');
+    });
+
+    test('removes hidden attribute on render', () => {
+        el.hidden = true;
+        window.TobyCasinoResult.render({
+            resultEl: el,
+            body: { win: true, net: 1 },
+            classPrefix: 'slots',
+            winLineHtml: 'x',
+            loseLineHtml: 'y',
+        });
+        expect(el.hidden).toBe(false);
+    });
+});

--- a/web/src/test/js/coinflip.test.js
+++ b/web/src/test/js/coinflip.test.js
@@ -1,5 +1,6 @@
 const { renderCoinflipResult } = require('../../main/resources/static/js/coinflip');
 require('../../main/resources/static/js/casino-jackpot');
+require('../../main/resources/static/js/casino-result');
 
 describe('renderCoinflipResult', () => {
     let resultEl;

--- a/web/src/test/js/dice.test.js
+++ b/web/src/test/js/dice.test.js
@@ -1,5 +1,6 @@
 const { renderDiceResult } = require('../../main/resources/static/js/dice');
 require('../../main/resources/static/js/casino-jackpot');
+require('../../main/resources/static/js/casino-result');
 
 describe('renderDiceResult', () => {
     let resultEl;

--- a/web/src/test/js/highlow.test.js
+++ b/web/src/test/js/highlow.test.js
@@ -4,6 +4,7 @@ const {
     highlowFormatMultiplier,
 } = require('../../main/resources/static/js/highlow');
 require('../../main/resources/static/js/casino-jackpot');
+require('../../main/resources/static/js/casino-result');
 
 describe('highlowCardLabel', () => {
     test('maps face cards to letters', () => {

--- a/web/src/test/js/scratch.test.js
+++ b/web/src/test/js/scratch.test.js
@@ -1,5 +1,6 @@
 const { renderScratchResult } = require('../../main/resources/static/js/scratch');
 require('../../main/resources/static/js/casino-jackpot');
+require('../../main/resources/static/js/casino-result');
 
 describe('renderScratchResult', () => {
     let resultEl;

--- a/web/src/test/js/slots.test.js
+++ b/web/src/test/js/slots.test.js
@@ -4,6 +4,7 @@
 
 const { renderSlotsResult } = require('../../main/resources/static/js/slots');
 require('../../main/resources/static/js/casino-jackpot');
+require('../../main/resources/static/js/casino-result');
 
 describe('renderSlotsResult', () => {
     let resultEl;


### PR DESCRIPTION
## Summary
- Adds `web/static/js/casino-result.js` exposing `window.TobyCasinoResult.render({ resultEl, body, classPrefix, winLineHtml, loseLineHtml })`.
- Migrates the five casino-game `renderXResult` functions (slots, coinflip, dice, highlow, scratch) to use it.
- Each game's renderer goes from ~30 lines of duplicated scaffolding to a single helper call passing the two game-specific HTML fragments.

## Why

Every game's renderer opened with the same 16-line dance:
1. Clear three game-prefixed classes (`-result-win`, `-result-lose`, `-result-jackpot`)
2. Ask `TobyTopUp.soldPrefixHtml` for the sold-coins prefix (with the `typeof window` guard)
3. Branch on `body.win`
4. Win path: build win line, wrap with `TobyJackpot.renderWinHtml`
5. Lose path: build lose line, append `TobyJackpot.lossTributeSuffix`
6. Set `innerHTML = topUpPrefix + content`

Only the per-game win/lose HTML varied. Qodana flagged the duplication; more importantly, any future change to the result envelope (e.g. animations, ARIA, telemetry) would have meant editing five files.

## Test plan
- [x] `npm test` in `web/` — 172 tests across 12 suites pass (was 11 suites; new `casino-result.test.js` adds 8 cases covering the helper).
- [x] Existing per-game render tests (`coinflip.test.js`, `slots.test.js`, `dice.test.js`, `highlow.test.js`, `scratch.test.js`) all pass with no edits beyond requiring `casino-result.js` — the helper is behaviour-preserving by construction.
- [ ] Manual smoke (CI verifies via integration when the templates load).

## Follow-up plan position

Fourth of the queued refactor PRs from the poker plan. One left:
5. `WagerCommandHelper` (Discord-side casino command scaffolding) — opening next, in parallel.

https://claude.ai/code/session_0169MvtJ2BSbwkoB9GrFhfZC

---
_Generated by [Claude Code](https://claude.ai/code/session_0169MvtJ2BSbwkoB9GrFhfZC)_