### PR TITLE
refactor(commands): extract WagerCommandHelper for the shared casino slash-command scaffold

### DIFF
--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/CoinflipCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/CoinflipCommand.kt
@@ -1,18 +1,15 @@
 package bot.toby.command.commands.economy
 
-import core.command.Command.Companion.invokeDeleteOnMessageResponse
 import core.command.CommandContext
 import database.dto.UserDto
 import database.economy.Coinflip
 import database.service.CoinflipService
 import database.service.CoinflipService.FlipOutcome
 import net.dv8tion.jda.api.EmbedBuilder
-import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
 import net.dv8tion.jda.api.interactions.commands.OptionType
 import net.dv8tion.jda.api.interactions.commands.build.OptionData
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import java.awt.Color
 
 /**
  * `/coinflip side:<HEADS|TAILS> stake:<int>` — fair 50/50 double-or-
@@ -35,9 +32,7 @@ class CoinflipCommand @Autowired constructor(
         private const val OPT_STAKE = "stake"
         private const val SIDE_HEADS = "HEADS"
         private const val SIDE_TAILS = "TAILS"
-        private val WIN_COLOR = Color(87, 242, 135)   // #57F287
-        private val LOSE_COLOR = Color(160, 160, 176) // #a0a0b0
-        private val ERROR_COLOR = Color(237, 66, 69)  // #ED4245
+        private const val TITLE = "🪙 Coinflip"
     }
 
     override val optionData: List<OptionData> = listOf(
@@ -54,17 +49,17 @@ class CoinflipCommand @Autowired constructor(
         event.deferReply().queue()
 
         val guild = event.guild ?: run {
-            replyError(event, "This command can only be used in a server.", deleteDelay); return
+            WagerCommandEmbeds.replyError(event, TITLE, "This command can only be used in a server.", deleteDelay); return
         }
         val side = parseSide(event.getOption(OPT_SIDE)?.asString) ?: run {
-            replyError(event, "Pick a side: heads or tails.", deleteDelay); return
+            WagerCommandEmbeds.replyError(event, TITLE, "Pick a side: heads or tails.", deleteDelay); return
         }
         val stake = event.getOption(OPT_STAKE)?.asLong ?: run {
-            replyError(event, "You must specify a stake.", deleteDelay); return
+            WagerCommandEmbeds.replyError(event, TITLE, "You must specify a stake.", deleteDelay); return
         }
 
         val outcome = coinflipService.flip(requestingUserDto.discordId, guild.idLong, stake, side)
-        replyOutcome(event, outcome, deleteDelay)
+        WagerCommandEmbeds.reply(event, embedFor(outcome), deleteDelay)
     }
 
     private fun parseSide(raw: String?): Coinflip.Side? = when (raw) {
@@ -73,57 +68,30 @@ class CoinflipCommand @Autowired constructor(
         else -> null
     }
 
-    private fun replyOutcome(
-        event: SlashCommandInteractionEvent,
-        outcome: FlipOutcome,
-        deleteDelay: Int
-    ) {
-        val embed = when (outcome) {
-            is FlipOutcome.Win -> EmbedBuilder()
-                .setTitle("🪙 ${outcome.landed.display}!")
-                .setDescription("You called **${outcome.predicted.display}** and won **+${outcome.net} credits**.")
-                .addField("New balance", "${outcome.newBalance} credits", true)
-                .setColor(WIN_COLOR)
-                .build()
+    private fun embedFor(outcome: FlipOutcome) = when (outcome) {
+        is FlipOutcome.Win -> EmbedBuilder()
+            .setTitle("🪙 ${outcome.landed.display}!")
+            .setDescription("You called **${outcome.predicted.display}** and won **+${outcome.net} credits**.")
+            .addField("New balance", "${outcome.newBalance} credits", true)
+            .setColor(WagerCommandColors.WIN)
+            .build()
 
-            is FlipOutcome.Lose -> EmbedBuilder()
-                .setTitle("🪙 ${outcome.landed.display}!")
-                .setDescription("You called **${outcome.predicted.display}**. Lost **${outcome.stake} credits**.")
-                .addField("New balance", "${outcome.newBalance} credits", true)
-                .setColor(LOSE_COLOR)
-                .build()
+        is FlipOutcome.Lose -> EmbedBuilder()
+            .setTitle("🪙 ${outcome.landed.display}!")
+            .setDescription("You called **${outcome.predicted.display}**. Lost **${outcome.stake} credits**.")
+            .addField("New balance", "${outcome.newBalance} credits", true)
+            .setColor(WagerCommandColors.LOSE)
+            .build()
 
-            is FlipOutcome.InsufficientCredits -> errorEmbed(
-                "Not enough credits. You need ${outcome.stake} but only have ${outcome.have}."
-            )
-
-            is FlipOutcome.InsufficientCoinsForTopUp -> errorEmbed(
-                "Not enough credits, and not enough TOBY to cover. " +
-                    "Need ${outcome.needed} TOBY, you have ${outcome.have}."
-            )
-
-            is FlipOutcome.InvalidStake -> errorEmbed(
-                "Stake must be between ${outcome.min} and ${outcome.max} credits."
-            )
-
-            FlipOutcome.UnknownUser -> errorEmbed(
-                "No user record yet. Try another TobyBot command first."
-            )
-        }
-        event.hook.sendMessageEmbeds(embed).queue(invokeDeleteOnMessageResponse(deleteDelay))
-    }
-
-    private fun errorEmbed(message: String) = EmbedBuilder()
-        .setTitle("🪙 Coinflip")
-        .setDescription(message)
-        .setColor(ERROR_COLOR)
-        .build()
-
-    private fun replyError(
-        event: SlashCommandInteractionEvent,
-        message: String,
-        deleteDelay: Int
-    ) {
-        event.hook.sendMessageEmbeds(errorEmbed(message)).queue(invokeDeleteOnMessageResponse(deleteDelay))
+        is FlipOutcome.InsufficientCredits -> WagerCommandEmbeds.failureEmbed(
+            TITLE, WagerCommandFailure.InsufficientCredits(outcome.stake, outcome.have)
+        )
+        is FlipOutcome.InsufficientCoinsForTopUp -> WagerCommandEmbeds.failureEmbed(
+            TITLE, WagerCommandFailure.InsufficientCoinsForTopUp(outcome.needed, outcome.have)
+        )
+        is FlipOutcome.InvalidStake -> WagerCommandEmbeds.failureEmbed(
+            TITLE, WagerCommandFailure.InvalidStake(outcome.min, outcome.max)
+        )
+        FlipOutcome.UnknownUser -> WagerCommandEmbeds.failureEmbed(TITLE, WagerCommandFailure.UnknownUser)
     }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/DiceCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/DiceCommand.kt
@@ -1,18 +1,15 @@
 package bot.toby.command.commands.economy
 
-import core.command.Command.Companion.invokeDeleteOnMessageResponse
 import core.command.CommandContext
 import database.dto.UserDto
 import database.economy.Dice
 import database.service.DiceService
 import database.service.DiceService.RollOutcome
 import net.dv8tion.jda.api.EmbedBuilder
-import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
 import net.dv8tion.jda.api.interactions.commands.OptionType
 import net.dv8tion.jda.api.interactions.commands.build.OptionData
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import java.awt.Color
 
 /**
  * `/dice prediction:<1-6> stake:<int>` — pick a number, roll the die,
@@ -32,9 +29,7 @@ class DiceCommand @Autowired constructor(
     companion object {
         private const val OPT_PREDICTION = "prediction"
         private const val OPT_STAKE = "stake"
-        private val WIN_COLOR = Color(87, 242, 135)
-        private val LOSE_COLOR = Color(160, 160, 176)
-        private val ERROR_COLOR = Color(237, 66, 69)
+        private const val TITLE = "🎲 Dice"
         private val DICE_FACES = mapOf(
             1 to "⚀", 2 to "⚁", 3 to "⚂", 4 to "⚃", 5 to "⚄", 6 to "⚅"
         )
@@ -54,79 +49,52 @@ class DiceCommand @Autowired constructor(
         event.deferReply().queue()
 
         val guild = event.guild ?: run {
-            replyError(event, "This command can only be used in a server.", deleteDelay); return
+            WagerCommandEmbeds.replyError(event, TITLE, "This command can only be used in a server.", deleteDelay); return
         }
         val predicted = event.getOption(OPT_PREDICTION)?.asLong?.toInt() ?: run {
-            replyError(event, "Pick a number 1-6.", deleteDelay); return
+            WagerCommandEmbeds.replyError(event, TITLE, "Pick a number 1-6.", deleteDelay); return
         }
         val stake = event.getOption(OPT_STAKE)?.asLong ?: run {
-            replyError(event, "You must specify a stake.", deleteDelay); return
+            WagerCommandEmbeds.replyError(event, TITLE, "You must specify a stake.", deleteDelay); return
         }
 
         val outcome = diceService.roll(requestingUserDto.discordId, guild.idLong, stake, predicted)
-        replyOutcome(event, outcome, deleteDelay)
+        WagerCommandEmbeds.reply(event, embedFor(outcome), deleteDelay)
     }
 
     private fun face(n: Int): String = DICE_FACES[n] ?: n.toString()
 
-    private fun replyOutcome(
-        event: SlashCommandInteractionEvent,
-        outcome: RollOutcome,
-        deleteDelay: Int
-    ) {
-        val embed = when (outcome) {
-            is RollOutcome.Win -> EmbedBuilder()
-                .setTitle("🎲 ${face(outcome.landed)} (${outcome.landed})")
-                .setDescription("You called **${outcome.predicted}** and won **+${outcome.net} credits** (${outcome.multiplier()}× on a ${outcome.stake} stake).")
-                .addField("New balance", "${outcome.newBalance} credits", true)
-                .setColor(WIN_COLOR)
-                .build()
+    private fun embedFor(outcome: RollOutcome) = when (outcome) {
+        is RollOutcome.Win -> EmbedBuilder()
+            .setTitle("🎲 ${face(outcome.landed)} (${outcome.landed})")
+            .setDescription("You called **${outcome.predicted}** and won **+${outcome.net} credits** (${outcome.multiplier()}× on a ${outcome.stake} stake).")
+            .addField("New balance", "${outcome.newBalance} credits", true)
+            .setColor(WagerCommandColors.WIN)
+            .build()
 
-            is RollOutcome.Lose -> EmbedBuilder()
-                .setTitle("🎲 ${face(outcome.landed)} (${outcome.landed})")
-                .setDescription("You called **${outcome.predicted}**. Lost **${outcome.stake} credits**.")
-                .addField("New balance", "${outcome.newBalance} credits", true)
-                .setColor(LOSE_COLOR)
-                .build()
+        is RollOutcome.Lose -> EmbedBuilder()
+            .setTitle("🎲 ${face(outcome.landed)} (${outcome.landed})")
+            .setDescription("You called **${outcome.predicted}**. Lost **${outcome.stake} credits**.")
+            .addField("New balance", "${outcome.newBalance} credits", true)
+            .setColor(WagerCommandColors.LOSE)
+            .build()
 
-            is RollOutcome.InsufficientCredits -> errorEmbed(
-                "Not enough credits. You need ${outcome.stake} but only have ${outcome.have}."
-            )
-
-            is RollOutcome.InsufficientCoinsForTopUp -> errorEmbed(
-                "Not enough credits, and not enough TOBY to cover. " +
-                    "Need ${outcome.needed} TOBY, you have ${outcome.have}."
-            )
-
-            is RollOutcome.InvalidStake -> errorEmbed(
-                "Stake must be between ${outcome.min} and ${outcome.max} credits."
-            )
-
-            is RollOutcome.InvalidPrediction -> errorEmbed(
-                "Pick a number between ${outcome.min} and ${outcome.max}."
-            )
-
-            RollOutcome.UnknownUser -> errorEmbed(
-                "No user record yet. Try another TobyBot command first."
-            )
-        }
-        event.hook.sendMessageEmbeds(embed).queue(invokeDeleteOnMessageResponse(deleteDelay))
+        is RollOutcome.InsufficientCredits -> WagerCommandEmbeds.failureEmbed(
+            TITLE, WagerCommandFailure.InsufficientCredits(outcome.stake, outcome.have)
+        )
+        is RollOutcome.InsufficientCoinsForTopUp -> WagerCommandEmbeds.failureEmbed(
+            TITLE, WagerCommandFailure.InsufficientCoinsForTopUp(outcome.needed, outcome.have)
+        )
+        is RollOutcome.InvalidStake -> WagerCommandEmbeds.failureEmbed(
+            TITLE, WagerCommandFailure.InvalidStake(outcome.min, outcome.max)
+        )
+        // Game-specific failure (no shared analogue): pick-a-number-N range error.
+        is RollOutcome.InvalidPrediction -> WagerCommandEmbeds.errorEmbed(
+            TITLE, "Pick a number between ${outcome.min} and ${outcome.max}."
+        )
+        RollOutcome.UnknownUser -> WagerCommandEmbeds.failureEmbed(TITLE, WagerCommandFailure.UnknownUser)
     }
 
     // payout / stake = multiplier — derived for the "5× on" string in the win embed.
     private fun RollOutcome.Win.multiplier(): Long = if (stake > 0L) payout / stake else 0L
-
-    private fun errorEmbed(message: String) = EmbedBuilder()
-        .setTitle("🎲 Dice")
-        .setDescription(message)
-        .setColor(ERROR_COLOR)
-        .build()
-
-    private fun replyError(
-        event: SlashCommandInteractionEvent,
-        message: String,
-        deleteDelay: Int
-    ) {
-        event.hook.sendMessageEmbeds(errorEmbed(message)).queue(invokeDeleteOnMessageResponse(deleteDelay))
-    }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/HighlowEmbeds.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/HighlowEmbeds.kt
@@ -17,10 +17,8 @@ internal object HighlowEmbeds {
     const val BUTTON_NAME = "highlow"
     private const val BUTTON_DELIM = ":"
 
+    private const val TITLE = "🃏 High-Low"
     private val ANCHOR_COLOR = Color(88, 101, 242)
-    private val WIN_COLOR = Color(87, 242, 135)
-    private val LOSE_COLOR = Color(160, 160, 176)
-    private val ERROR_COLOR = Color(237, 66, 69)
 
     fun cardLabel(n: Int): String = when (n) {
         1 -> "A"
@@ -73,37 +71,27 @@ internal object HighlowEmbeds {
                     "**${multiplierLabel(outcome.multiplier)}** and won **+${outcome.net} credits**."
             )
             .addField("New balance", "${outcome.newBalance} credits", true)
-            .setColor(WIN_COLOR)
+            .setColor(WagerCommandColors.WIN)
             .build()
 
         is PlayOutcome.Lose -> EmbedBuilder()
             .setTitle("🃏 ${cardLabel(outcome.anchor)} → ${cardLabel(outcome.next)}")
             .setDescription("You called **${outcome.direction.display}**. Lost **${outcome.stake} credits**.")
             .addField("New balance", "${outcome.newBalance} credits", true)
-            .setColor(LOSE_COLOR)
+            .setColor(WagerCommandColors.LOSE)
             .build()
 
-        is PlayOutcome.InsufficientCredits -> errorEmbed(
-            "Not enough credits. You need ${outcome.stake} but only have ${outcome.have}."
+        is PlayOutcome.InsufficientCredits -> WagerCommandEmbeds.failureEmbed(
+            TITLE, WagerCommandFailure.InsufficientCredits(outcome.stake, outcome.have)
         )
-
-        is PlayOutcome.InsufficientCoinsForTopUp -> errorEmbed(
-            "Not enough credits, and not enough TOBY to cover. " +
-                "Need ${outcome.needed} TOBY, you have ${outcome.have}."
+        is PlayOutcome.InsufficientCoinsForTopUp -> WagerCommandEmbeds.failureEmbed(
+            TITLE, WagerCommandFailure.InsufficientCoinsForTopUp(outcome.needed, outcome.have)
         )
-
-        is PlayOutcome.InvalidStake -> errorEmbed(
-            "Stake must be between ${outcome.min} and ${outcome.max} credits."
+        is PlayOutcome.InvalidStake -> WagerCommandEmbeds.failureEmbed(
+            TITLE, WagerCommandFailure.InvalidStake(outcome.min, outcome.max)
         )
-
-        PlayOutcome.UnknownUser -> errorEmbed(
-            "No user record yet. Try another TobyBot command first."
-        )
+        PlayOutcome.UnknownUser -> WagerCommandEmbeds.failureEmbed(TITLE, WagerCommandFailure.UnknownUser)
     }
 
-    fun errorEmbed(message: String): MessageEmbed = EmbedBuilder()
-        .setTitle("🃏 High-Low")
-        .setDescription(message)
-        .setColor(ERROR_COLOR)
-        .build()
+    fun errorEmbed(message: String): MessageEmbed = WagerCommandEmbeds.errorEmbed(TITLE, message)
 }

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/ScratchCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/ScratchCommand.kt
@@ -1,6 +1,5 @@
 package bot.toby.command.commands.economy
 
-import core.command.Command.Companion.invokeDeleteOnMessageResponse
 import core.command.CommandContext
 import database.dto.UserDto
 import database.economy.ScratchCard
@@ -8,12 +7,10 @@ import database.economy.SlotMachine
 import database.service.ScratchService
 import database.service.ScratchService.ScratchOutcome
 import net.dv8tion.jda.api.EmbedBuilder
-import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
 import net.dv8tion.jda.api.interactions.commands.OptionType
 import net.dv8tion.jda.api.interactions.commands.build.OptionData
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import java.awt.Color
 
 /**
  * `/scratch stake:<int>` — buy a scratchcard. Win on
@@ -33,9 +30,7 @@ class ScratchCommand @Autowired constructor(
 
     companion object {
         private const val OPT_STAKE = "stake"
-        private val WIN_COLOR = Color(87, 242, 135)
-        private val LOSE_COLOR = Color(160, 160, 176)
-        private val ERROR_COLOR = Color(237, 66, 69)
+        private const val TITLE = "🎟️ Scratch"
     }
 
     override val optionData: List<OptionData> = listOf(
@@ -49,73 +44,46 @@ class ScratchCommand @Autowired constructor(
         event.deferReply().queue()
 
         val guild = event.guild ?: run {
-            replyError(event, "This command can only be used in a server.", deleteDelay); return
+            WagerCommandEmbeds.replyError(event, TITLE, "This command can only be used in a server.", deleteDelay); return
         }
         val stake = event.getOption(OPT_STAKE)?.asLong ?: run {
-            replyError(event, "You must specify a stake.", deleteDelay); return
+            WagerCommandEmbeds.replyError(event, TITLE, "You must specify a stake.", deleteDelay); return
         }
 
         val outcome = scratchService.scratch(requestingUserDto.discordId, guild.idLong, stake)
-        replyOutcome(event, outcome, deleteDelay)
+        WagerCommandEmbeds.reply(event, embedFor(outcome), deleteDelay)
     }
 
     private fun cellsLine(cells: List<SlotMachine.Symbol>): String =
         cells.joinToString(separator = " ") { it.display }
 
-    private fun replyOutcome(
-        event: SlashCommandInteractionEvent,
-        outcome: ScratchOutcome,
-        deleteDelay: Int
-    ) {
-        val embed = when (outcome) {
-            is ScratchOutcome.Win -> EmbedBuilder()
-                .setTitle("🎟️ ${cellsLine(outcome.cells)}")
-                .setDescription(
-                    "**${outcome.matchCount}× ${outcome.winningSymbol.display}** &mdash; " +
-                        "won **+${outcome.net} credits**."
-                )
-                .addField("New balance", "${outcome.newBalance} credits", true)
-                .setColor(WIN_COLOR)
-                .build()
-
-            is ScratchOutcome.Lose -> EmbedBuilder()
-                .setTitle("🎟️ ${cellsLine(outcome.cells)}")
-                .setDescription("No ${ScratchCard.MATCH_THRESHOLD}-of-a-kind. Lost **${outcome.stake} credits**.")
-                .addField("New balance", "${outcome.newBalance} credits", true)
-                .setColor(LOSE_COLOR)
-                .build()
-
-            is ScratchOutcome.InsufficientCredits -> errorEmbed(
-                "Not enough credits. You need ${outcome.stake} but only have ${outcome.have}."
+    private fun embedFor(outcome: ScratchOutcome) = when (outcome) {
+        is ScratchOutcome.Win -> EmbedBuilder()
+            .setTitle("🎟️ ${cellsLine(outcome.cells)}")
+            .setDescription(
+                "**${outcome.matchCount}× ${outcome.winningSymbol.display}** &mdash; " +
+                    "won **+${outcome.net} credits**."
             )
+            .addField("New balance", "${outcome.newBalance} credits", true)
+            .setColor(WagerCommandColors.WIN)
+            .build()
 
-            is ScratchOutcome.InsufficientCoinsForTopUp -> errorEmbed(
-                "Not enough credits, and not enough TOBY to cover. " +
-                    "Need ${outcome.needed} TOBY, you have ${outcome.have}."
-            )
+        is ScratchOutcome.Lose -> EmbedBuilder()
+            .setTitle("🎟️ ${cellsLine(outcome.cells)}")
+            .setDescription("No ${ScratchCard.MATCH_THRESHOLD}-of-a-kind. Lost **${outcome.stake} credits**.")
+            .addField("New balance", "${outcome.newBalance} credits", true)
+            .setColor(WagerCommandColors.LOSE)
+            .build()
 
-            is ScratchOutcome.InvalidStake -> errorEmbed(
-                "Stake must be between ${outcome.min} and ${outcome.max} credits."
-            )
-
-            ScratchOutcome.UnknownUser -> errorEmbed(
-                "No user record yet. Try another TobyBot command first."
-            )
-        }
-        event.hook.sendMessageEmbeds(embed).queue(invokeDeleteOnMessageResponse(deleteDelay))
-    }
-
-    private fun errorEmbed(message: String) = EmbedBuilder()
-        .setTitle("🎟️ Scratch")
-        .setDescription(message)
-        .setColor(ERROR_COLOR)
-        .build()
-
-    private fun replyError(
-        event: SlashCommandInteractionEvent,
-        message: String,
-        deleteDelay: Int
-    ) {
-        event.hook.sendMessageEmbeds(errorEmbed(message)).queue(invokeDeleteOnMessageResponse(deleteDelay))
+        is ScratchOutcome.InsufficientCredits -> WagerCommandEmbeds.failureEmbed(
+            TITLE, WagerCommandFailure.InsufficientCredits(outcome.stake, outcome.have)
+        )
+        is ScratchOutcome.InsufficientCoinsForTopUp -> WagerCommandEmbeds.failureEmbed(
+            TITLE, WagerCommandFailure.InsufficientCoinsForTopUp(outcome.needed, outcome.have)
+        )
+        is ScratchOutcome.InvalidStake -> WagerCommandEmbeds.failureEmbed(
+            TITLE, WagerCommandFailure.InvalidStake(outcome.min, outcome.max)
+        )
+        ScratchOutcome.UnknownUser -> WagerCommandEmbeds.failureEmbed(TITLE, WagerCommandFailure.UnknownUser)
     }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/SlotsCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/SlotsCommand.kt
@@ -6,7 +6,6 @@ import database.economy.SlotMachine
 import database.service.SlotsService
 import database.service.SlotsService.SpinOutcome
 import net.dv8tion.jda.api.EmbedBuilder
-import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
 import net.dv8tion.jda.api.interactions.commands.OptionType
 import net.dv8tion.jda.api.interactions.commands.build.OptionData
 import org.springframework.beans.factory.annotation.Autowired

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/SlotsCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/SlotsCommand.kt
@@ -1,6 +1,5 @@
 package bot.toby.command.commands.economy
 
-import core.command.Command.Companion.invokeDeleteOnMessageResponse
 import core.command.CommandContext
 import database.dto.UserDto
 import database.economy.SlotMachine
@@ -12,7 +11,6 @@ import net.dv8tion.jda.api.interactions.commands.OptionType
 import net.dv8tion.jda.api.interactions.commands.build.OptionData
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import java.awt.Color
 
 /**
  * `/slots stake:<int>` — first credit-spend gambling minigame. Calls
@@ -31,9 +29,7 @@ class SlotsCommand @Autowired constructor(
 
     companion object {
         private const val OPT_STAKE = "stake"
-        private val WIN_COLOR = Color(87, 242, 135)   // #57F287 — same as market chart green
-        private val LOSE_COLOR = Color(160, 160, 176) // #a0a0b0 — muted grey
-        private val ERROR_COLOR = Color(237, 66, 69)  // #ED4245 — Discord red
+        private const val TITLE = "🎰 Slots"
     }
 
     override val optionData: List<OptionData> = listOf(
@@ -47,70 +43,43 @@ class SlotsCommand @Autowired constructor(
         event.deferReply().queue()
 
         val guild = event.guild ?: run {
-            replyError(event, "This command can only be used in a server.", deleteDelay); return
+            WagerCommandEmbeds.replyError(event, TITLE, "This command can only be used in a server.", deleteDelay); return
         }
         val stake = event.getOption(OPT_STAKE)?.asLong ?: run {
-            replyError(event, "You must specify a stake.", deleteDelay); return
+            WagerCommandEmbeds.replyError(event, TITLE, "You must specify a stake.", deleteDelay); return
         }
 
         val outcome = slotsService.spin(requestingUserDto.discordId, guild.idLong, stake)
-        replyOutcome(event, outcome, deleteDelay)
+        WagerCommandEmbeds.reply(event, embedFor(outcome), deleteDelay)
     }
 
-    private fun replyOutcome(
-        event: SlashCommandInteractionEvent,
-        outcome: SpinOutcome,
-        deleteDelay: Int
-    ) {
-        val embed = when (outcome) {
-            is SpinOutcome.Win -> EmbedBuilder()
-                .setTitle("🎰 ${reelLine(outcome.symbols)}")
-                .setDescription("**+${outcome.net} credits** (${outcome.multiplier}× on a ${outcome.stake} stake)")
-                .addField("New balance", "${outcome.newBalance} credits", true)
-                .setColor(WIN_COLOR)
-                .build()
+    private fun embedFor(outcome: SpinOutcome) = when (outcome) {
+        is SpinOutcome.Win -> EmbedBuilder()
+            .setTitle("🎰 ${reelLine(outcome.symbols)}")
+            .setDescription("**+${outcome.net} credits** (${outcome.multiplier}× on a ${outcome.stake} stake)")
+            .addField("New balance", "${outcome.newBalance} credits", true)
+            .setColor(WagerCommandColors.WIN)
+            .build()
 
-            is SpinOutcome.Lose -> EmbedBuilder()
-                .setTitle("🎰 ${reelLine(outcome.symbols)}")
-                .setDescription("Lost **${outcome.stake} credits**.")
-                .addField("New balance", "${outcome.newBalance} credits", true)
-                .setColor(LOSE_COLOR)
-                .build()
+        is SpinOutcome.Lose -> EmbedBuilder()
+            .setTitle("🎰 ${reelLine(outcome.symbols)}")
+            .setDescription("Lost **${outcome.stake} credits**.")
+            .addField("New balance", "${outcome.newBalance} credits", true)
+            .setColor(WagerCommandColors.LOSE)
+            .build()
 
-            is SpinOutcome.InsufficientCredits -> errorEmbed(
-                "Not enough credits. You need ${outcome.stake} but only have ${outcome.have}."
-            )
-
-            is SpinOutcome.InsufficientCoinsForTopUp -> errorEmbed(
-                "Not enough credits, and not enough TOBY to cover. " +
-                    "Need ${outcome.needed} TOBY, you have ${outcome.have}."
-            )
-
-            is SpinOutcome.InvalidStake -> errorEmbed(
-                "Stake must be between ${outcome.min} and ${outcome.max} credits."
-            )
-
-            SpinOutcome.UnknownUser -> errorEmbed(
-                "No user record yet. Try another TobyBot command first."
-            )
-        }
-        event.hook.sendMessageEmbeds(embed).queue(invokeDeleteOnMessageResponse(deleteDelay))
+        is SpinOutcome.InsufficientCredits -> WagerCommandEmbeds.failureEmbed(
+            TITLE, WagerCommandFailure.InsufficientCredits(outcome.stake, outcome.have)
+        )
+        is SpinOutcome.InsufficientCoinsForTopUp -> WagerCommandEmbeds.failureEmbed(
+            TITLE, WagerCommandFailure.InsufficientCoinsForTopUp(outcome.needed, outcome.have)
+        )
+        is SpinOutcome.InvalidStake -> WagerCommandEmbeds.failureEmbed(
+            TITLE, WagerCommandFailure.InvalidStake(outcome.min, outcome.max)
+        )
+        SpinOutcome.UnknownUser -> WagerCommandEmbeds.failureEmbed(TITLE, WagerCommandFailure.UnknownUser)
     }
 
     private fun reelLine(symbols: List<SlotMachine.Symbol>): String =
         symbols.joinToString(separator = " ") { it.display }
-
-    private fun errorEmbed(message: String) = EmbedBuilder()
-        .setTitle("🎰 Slots")
-        .setDescription(message)
-        .setColor(ERROR_COLOR)
-        .build()
-
-    private fun replyError(
-        event: SlashCommandInteractionEvent,
-        message: String,
-        deleteDelay: Int
-    ) {
-        event.hook.sendMessageEmbeds(errorEmbed(message)).queue(invokeDeleteOnMessageResponse(deleteDelay))
-    }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/WagerCommandHelper.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/WagerCommandHelper.kt
@@ -1,0 +1,116 @@
+package bot.toby.command.commands.economy
+
+import core.command.Command.Companion.invokeDeleteOnMessageResponse
+import net.dv8tion.jda.api.EmbedBuilder
+import net.dv8tion.jda.api.entities.MessageEmbed
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
+import java.awt.Color
+
+/**
+ * Shared scaffolding for the Discord casino-minigame commands
+ * (`/slots`, `/coinflip`, `/dice`, `/highlow`, `/scratch`). Each one
+ * was carrying a copy of:
+ *
+ *   - three identical color constants (win green, lose grey, error red)
+ *   - a private `errorEmbed(message)` that built an EmbedBuilder with
+ *     the game's title prefix and the shared error red color
+ *   - a private `replyError()` that wrapped `errorEmbed` in
+ *     `event.hook.sendMessageEmbeds(...).queue(invokeDeleteOnMessageResponse(...))`
+ *   - the same four error-case strings ("Not enough credits…",
+ *     "Stake must be between…", etc.) repeated verbatim per game
+ *
+ * This file pulls all of that into one place. The Win/Lose embeds
+ * stay in each command since their bodies are game-specific
+ * (reels for slots, dice face for dice, anchor cards for highlow…).
+ *
+ * Game-side migration is uniform:
+ *   - drop the three color constants (use [WagerCommandColors] direct)
+ *   - drop the private `errorEmbed` / `replyError` helpers (call
+ *     [WagerCommandEmbeds] direct, passing the game's title)
+ *   - replace the four failure-case message strings with calls to
+ *     [WagerCommandEmbeds.failureEmbed]
+ */
+internal object WagerCommandColors {
+    /** #57F287 — also used by the market chart. */
+    val WIN: Color = Color(87, 242, 135)
+
+    /** #a0a0b0 — muted grey for losses. */
+    val LOSE: Color = Color(160, 160, 176)
+
+    /** #ED4245 — Discord error red. */
+    val ERROR: Color = Color(237, 66, 69)
+}
+
+/**
+ * Standardised "wager service rejected the play" outcomes — a service-
+ * agnostic reflection of the failure variants every casino service
+ * sealed type carries (`*.InsufficientCredits`, `*.InsufficientCoinsForTopUp`,
+ * `*.InvalidStake`, `*.UnknownUser`).
+ *
+ * Each command's `replyOutcome` translates its own service outcome's
+ * failure case into one of these, then hands it to
+ * [WagerCommandEmbeds.failureEmbed] for uniform rendering.
+ */
+internal sealed interface WagerCommandFailure {
+    data class InsufficientCredits(val stake: Long, val have: Long) : WagerCommandFailure
+    data class InsufficientCoinsForTopUp(val needed: Long, val have: Long) : WagerCommandFailure
+    data class InvalidStake(val min: Long, val max: Long) : WagerCommandFailure
+    data object UnknownUser : WagerCommandFailure
+}
+
+internal object WagerCommandEmbeds {
+
+    /**
+     * Build an error embed with [title] and [message]. The title is the
+     * game-specific prefix (e.g. "🎰 Slots") so the player can tell at a
+     * glance which command produced the error.
+     */
+    fun errorEmbed(title: String, message: String): MessageEmbed = EmbedBuilder()
+        .setTitle(title)
+        .setDescription(message)
+        .setColor(WagerCommandColors.ERROR)
+        .build()
+
+    /**
+     * Translate a [WagerCommandFailure] into the canonical message
+     * shown for that failure shape across every casino game.
+     */
+    fun failureMessage(failure: WagerCommandFailure): String = when (failure) {
+        is WagerCommandFailure.InsufficientCredits ->
+            "Not enough credits. You need ${failure.stake} but only have ${failure.have}."
+        is WagerCommandFailure.InsufficientCoinsForTopUp ->
+            "Not enough credits, and not enough TOBY to cover. " +
+                "Need ${failure.needed} TOBY, you have ${failure.have}."
+        is WagerCommandFailure.InvalidStake ->
+            "Stake must be between ${failure.min} and ${failure.max} credits."
+        WagerCommandFailure.UnknownUser ->
+            "No user record yet. Try another TobyBot command first."
+    }
+
+    /**
+     * Composite of [errorEmbed] + [failureMessage] for the common case
+     * where a `when` branch wants to emit a typed failure embed in one
+     * call.
+     */
+    fun failureEmbed(title: String, failure: WagerCommandFailure): MessageEmbed =
+        errorEmbed(title, failureMessage(failure))
+
+    /** Send [embed] as the reply to [event] and schedule the delete-after. */
+    fun reply(event: SlashCommandInteractionEvent, embed: MessageEmbed, deleteDelay: Int) {
+        event.hook.sendMessageEmbeds(embed).queue(invokeDeleteOnMessageResponse(deleteDelay))
+    }
+
+    /**
+     * Convenience wrapper around [errorEmbed] + [reply] for early
+     * pre-service-call validation errors (e.g. missing option, command
+     * used in DM). Passes the title each command uses for its embeds.
+     */
+    fun replyError(
+        event: SlashCommandInteractionEvent,
+        title: String,
+        message: String,
+        deleteDelay: Int
+    ) {
+        reply(event, errorEmbed(title, message), deleteDelay)
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `WagerCommandHelper.kt` (`WagerCommandColors`, `WagerCommandFailure`, `WagerCommandEmbeds`) so every casino slash command stops re-implementing the same scaffold.
- Migrates `SlotsCommand`, `CoinflipCommand`, `DiceCommand`, `ScratchCommand`, and `HighlowEmbeds` to the helper.

## Why

Every casino slash command had its own copy of:
1. The same three `Color` constants (Discord green / grey / red)
2. A private `errorEmbed(message)` builder wrapping `EmbedBuilder` + `ERROR_COLOR`
3. A private `replyError(event, message, deleteDelay)` wrapping that in `event.hook.sendMessageEmbeds(...).queue(invokeDelete...)`
4. The same four error-message strings (`"Not enough credits…"`, `"Need N TOBY to cover…"`, `"Stake must be between…"`, `"No user record yet…"`) **identical verbatim** across games

Qodana flagged this duplication multiple times (`ActivityCommand.kt:149`, `ScratchCommand.kt:48`, etc.). More importantly, any future tweak to the error envelope — colors, embed style, telemetry, localisation — would have meant editing every file individually.

## Migration matrix

| Command | Lines saved | Notes |
|---|---|---|
| `SlotsCommand` | ~30 | Standard 4-failure shape |
| `CoinflipCommand` | ~32 | Standard 4-failure shape |
| `DiceCommand` | ~30 | Game-specific `InvalidPrediction` uses `WagerCommandEmbeds.errorEmbed` direct |
| `ScratchCommand` | ~30 | Standard 4-failure shape |
| `HighlowEmbeds` | ~9 | Drops private color constants + private `errorEmbed`; `HighlowCommand`'s public API stays stable |

`PokerCommand` stays as-is — its outcome shape (`TableNotFound`, `NotHost`, `NotEnoughPlayers`, multi-step lifecycle) doesn't fit the wager-failure mould.

## Test plan
- [ ] `./gradlew :discord-bot:test` — sandbox can't fetch lavaplayer transitive deps; CI exercises this. The helper is purely additive (each command's `event.hook.sendMessageEmbeds(...)` call shape is unchanged), so existing command tests should pass without edits.
- [x] Local diff inspection: every removed `errorEmbed`/`replyError`/color-constant block has an exact replacement via `WagerCommandEmbeds.{errorEmbed,replyError,failureEmbed}` + `WagerCommandColors`.

## Follow-up plan position

**Fifth and final** of the queued refactor PRs from the poker plan. After this lands, the original Qodana cleanup queue is fully addressed:

1. ✅ `ConfigService.upsertConfig` (#326)
2. ✅ `UserService.lockUsersInAscendingOrder` (#327)
3. ⏳ `WebGuildAccess` (#328 — open)
4. ⏳ `casino-result.js` (#329 — open)
5. ⏳ `WagerCommandHelper` (this PR)

https://claude.ai/code/session_0169MvtJ2BSbwkoB9GrFhfZC

---
_Generated by [Claude Code](https://claude.ai/code/session_0169MvtJ2BSbwkoB9GrFhfZC)_