### PR TITLE
feat(poker): side pots and call-for-less at showdown (v2-1)

### DIFF
--- a/database/src/main/kotlin/database/dto/PokerHandPotDto.kt
+++ b/database/src/main/kotlin/database/dto/PokerHandPotDto.kt
@@ -1,0 +1,52 @@
+package database.dto
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.springframework.transaction.annotation.Transactional
+import java.io.Serializable
+
+/**
+ * One side-pot tier from a settled hand. See `V23__poker_hand_pot.sql`
+ * for column semantics. Stored unjoined (no FK relation in JPA) — we
+ * write rows directly via [database.persistence.PokerHandPotPersistence]
+ * and only read them back in the hand-history projection.
+ */
+@Entity
+@Table(name = "poker_hand_pot", schema = "public")
+@Transactional
+class PokerHandPotDto(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    var id: Long? = null,
+
+    @Column(name = "hand_log_id", nullable = false)
+    var handLogId: Long = 0,
+
+    /** 0 = main pot; 1, 2, ... = increasing side-pot tiers. */
+    @Column(name = "tier_index", nullable = false)
+    var tierIndex: Int = 0,
+
+    @Column(name = "cap", nullable = false)
+    var cap: Long = 0,
+
+    /** Chips in this tier AFTER its share of the rake. */
+    @Column(name = "amount", nullable = false)
+    var amount: Long = 0,
+
+    /** Comma-separated discord IDs eligible to win this tier. */
+    @Column(name = "eligible", nullable = false, length = 512)
+    var eligible: String = "",
+
+    /** Comma-separated discord IDs that took the tier. */
+    @Column(name = "winners", nullable = false, length = 512)
+    var winners: String = "",
+
+    /** `discordId:amount` pairs comma-separated, one per winner. */
+    @Column(name = "payouts", nullable = false, length = 512)
+    var payouts: String = ""
+) : Serializable

--- a/database/src/main/kotlin/database/persistence/PokerHandPotPersistence.kt
+++ b/database/src/main/kotlin/database/persistence/PokerHandPotPersistence.kt
@@ -1,0 +1,8 @@
+package database.persistence
+
+import database.dto.PokerHandPotDto
+
+interface PokerHandPotPersistence {
+    fun insert(row: PokerHandPotDto): PokerHandPotDto
+    fun findByHandLogId(handLogId: Long): List<PokerHandPotDto>
+}

--- a/database/src/main/kotlin/database/persistence/impl/DefaultPokerHandPotPersistence.kt
+++ b/database/src/main/kotlin/database/persistence/impl/DefaultPokerHandPotPersistence.kt
@@ -1,0 +1,28 @@
+package database.persistence.impl
+
+import database.dto.PokerHandPotDto
+import database.persistence.PokerHandPotPersistence
+import jakarta.persistence.EntityManager
+import jakarta.persistence.PersistenceContext
+import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
+
+@Repository
+@Transactional
+class DefaultPokerHandPotPersistence : PokerHandPotPersistence {
+
+    @PersistenceContext
+    private lateinit var entityManager: EntityManager
+
+    override fun insert(row: PokerHandPotDto): PokerHandPotDto {
+        entityManager.persist(row)
+        entityManager.flush()
+        return row
+    }
+
+    override fun findByHandLogId(handLogId: Long): List<PokerHandPotDto> =
+        entityManager.createQuery(
+            "SELECT p FROM PokerHandPotDto p WHERE p.handLogId = :id ORDER BY p.tierIndex ASC",
+            PokerHandPotDto::class.java
+        ).setParameter("id", handLogId).resultList
+}

--- a/database/src/main/kotlin/database/poker/PokerEngine.kt
+++ b/database/src/main/kotlin/database/poker/PokerEngine.kt
@@ -15,12 +15,15 @@ import kotlin.random.Random
  * size is `smallBet` pre-flop/flop and `bigBet` turn/river. Raises are
  * capped per street.
  *
- * v1 simplifications (see docstring on [PokerService]):
- *   - Single pot, no side pots. An all-in short stack can win the whole
- *     pot at showdown, which is incorrect poker but acceptable for a
- *     casual cash table.
- *   - "Call for less" is rejected; the player must fold instead. This
- *     keeps the pot trivially divisible and avoids partial calls.
+ * v2 (PR #v2-1) — proper poker correctness:
+ *   - Side pots. When players go all-in for different amounts, the pot
+ *     splits into tiers; each tier is awarded to the best hand among
+ *     the contributors who could match that tier. An all-in short
+ *     stack can no longer scoop chips they didn't match.
+ *   - Call-for-less. A player who can't cover the current bet pushes
+ *     all-in for whatever they have. The remaining seats keep betting
+ *     against each other on top — those over-bets become side pot
+ *     contributions, or are refunded if no one can match them.
  */
 object PokerEngine {
 
@@ -167,10 +170,15 @@ object PokerEngine {
             PokerAction.Call -> {
                 val owe = table.currentBet - seat.committedThisRound
                 if (owe <= 0L) return ApplyResult.Rejected(RejectReason.ILLEGAL_CALL)
-                if (seat.chips < owe) {
+                // Call-for-less: a seat with fewer chips than `owe` pushes
+                // all-in for whatever they have rather than being forced to
+                // fold. Side-pot resolution at showdown sorts out who can
+                // win which tier of chips.
+                if (seat.chips == 0L) {
                     return ApplyResult.Rejected(RejectReason.INSUFFICIENT_CHIPS_TO_CALL)
                 }
-                commit(table, seat, owe)
+                val toPay = minOf(seat.chips, owe)
+                commit(table, seat, toPay)
                 if (seat.chips == 0L) seat.status = SeatStatus.ALL_IN
                 table.seatsToAct = (table.seatsToAct - 1).coerceAtLeast(0)
             }
@@ -260,53 +268,169 @@ object PokerEngine {
         return ApplyResult.Applied(ActionEvent.StreetAdvanced(nextPhase, table.community.toList()))
     }
 
-    private fun resolveHand(
+    /**
+     * `internal` (not `private`) so the side-pot tests in
+     * `PokerEngineSidePotTest` can drive showdown scenarios without
+     * having to play out an entire pre-constructed betting sequence.
+     * Production callers go through [applyAction]; only the engine
+     * itself and same-module tests should call this directly.
+     */
+    internal fun resolveHand(
         table: PokerTable,
         rakeRate: Double,
         now: Instant
     ): PokerTable.HandResult {
-        val pot = table.pot
-        val rake = (pot * rakeRate).toLong().coerceAtLeast(0L).coerceAtMost(pot)
-        val distributable = pot - rake
-
+        val totalCommitted = table.pot
         val contenders = table.seats.filter {
             it.status == SeatStatus.ACTIVE || it.status == SeatStatus.ALL_IN
         }
 
-        val winners: List<PokerTable.Seat> = when {
-            contenders.size == 1 -> listOf(contenders.single())
-            else -> {
-                val ranked = contenders.map { it to HandEvaluator.bestHand(it.holeCards, table.community) }
+        // Step 1 — compute each contender's effective commitment as
+        // `min(self.totalCommit, max(others' totalCommit))`. Anything
+        // above that level was uncalled (no other seat — contender
+        // OR folded — committed enough to match it) and is refunded
+        // unraked. This is standard "uncalled-bet returned" poker.
+        //
+        // Skip the refund pass when only one contender remains
+        // (everyone else folded around to them): they take the whole
+        // pot uncontested, including the forced-blind portion no one
+        // ever matched. The arithmetic of "win the matched part +
+        // refund the rest" is chip-equivalent to "win it all", and
+        // v1 callers expect `payoutByDiscordId` to reflect the pot
+        // total in that uncontested case.
+        val refunds = mutableMapOf<Long, Long>()
+        val effectiveByDiscordId = mutableMapOf<Long, Long>()
+        if (contenders.size >= 2) {
+            for (c in contenders) {
+                val maxOther = table.seats
+                    .filter { it !== c }
+                    .maxOfOrNull { it.totalCommittedThisHand } ?: 0L
+                val effective = minOf(c.totalCommittedThisHand, maxOther)
+                effectiveByDiscordId[c.discordId] = effective
+                val excess = c.totalCommittedThisHand - effective
+                if (excess > 0L) {
+                    c.chips += excess
+                    refunds[c.discordId] = excess
+                }
+            }
+        } else {
+            for (c in contenders) {
+                effectiveByDiscordId[c.discordId] = c.totalCommittedThisHand
+            }
+        }
+
+        // Folded seats' committed chips are dead money that goes into
+        // whichever tier they fall into — but never above the highest
+        // contender level (you can't pay into a tier nobody can win).
+        // In legal play this clamp is a no-op; it only matters if a
+        // test constructs a pathological commitment shape.
+        val maxContenderLevel = effectiveByDiscordId.values.maxOrNull() ?: 0L
+        fun effectiveCommit(seat: PokerTable.Seat): Long =
+            effectiveByDiscordId[seat.discordId]
+                ?: minOf(seat.totalCommittedThisHand, maxContenderLevel)
+
+        // Step 2 — build pot tiers from the distinct contender levels.
+        data class Tier(val cap: Long, val eligible: List<PokerTable.Seat>, val amount: Long)
+        val contenderLevels = effectiveByDiscordId.values
+            .filter { it > 0L }
+            .distinct()
+            .sorted()
+        val tiers = mutableListOf<Tier>()
+        var prevCap = 0L
+        for (level in contenderLevels) {
+            val tierAmount = table.seats.sumOf { seat ->
+                val effective = effectiveCommit(seat)
+                val capped = minOf(effective, level)
+                val prevCapped = minOf(effective, prevCap)
+                (capped - prevCapped).coerceAtLeast(0L)
+            }
+            if (tierAmount > 0L) {
+                val eligible = contenders.filter { effectiveCommit(it) >= level }
+                tiers.add(Tier(cap = level, eligible = eligible, amount = tierAmount))
+            }
+            prevCap = level
+        }
+
+        // Step 3 — rake the contested portion only. Refunds are unraked.
+        // Pull from the smallest tier first so the truly-contested upper
+        // tiers stay closer to par (heads-up scenarios bear the cut on
+        // the only tier they've got).
+        val contestedTotal = tiers.sumOf { it.amount }
+        val rake = (contestedTotal * rakeRate).toLong()
+            .coerceAtLeast(0L).coerceAtMost(contestedTotal)
+        val rakedTiers = run {
+            var rakeRemaining = rake
+            tiers.map { tier ->
+                val take = minOf(rakeRemaining, tier.amount)
+                rakeRemaining -= take
+                tier to (tier.amount - take)
+            }
+        }
+
+        // Step 4 — award each tier to its best hand among eligibles.
+        val payouts = mutableMapOf<Long, Long>()
+        val potResults = mutableListOf<PokerTable.PotResult>()
+        for ((tier, postRakeAmount) in rakedTiers) {
+            if (postRakeAmount <= 0L) {
+                potResults.add(
+                    PokerTable.PotResult(
+                        cap = tier.cap,
+                        eligibleDiscordIds = tier.eligible.map { it.discordId },
+                        amount = 0L,
+                        winners = emptyList(),
+                        payoutByDiscordId = emptyMap()
+                    )
+                )
+                continue
+            }
+            val tierWinners: List<PokerTable.Seat> = if (tier.eligible.size == 1) {
+                listOf(tier.eligible.single())
+            } else {
+                val ranked = tier.eligible.map { it to HandEvaluator.bestHand(it.holeCards, table.community) }
                 val best = ranked.maxOf { it.second }
                 ranked.filter { it.second.compareTo(best) == 0 }.map { it.first }
             }
-        }
-
-        // Even split, with the remainder going to the first listed winner so
-        // total chip count is preserved exactly.
-        val payouts = mutableMapOf<Long, Long>()
-        if (winners.isNotEmpty()) {
-            val share = distributable / winners.size
-            val remainder = distributable - share * winners.size
-            for ((i, winner) in winners.withIndex()) {
+            val share = postRakeAmount / tierWinners.size
+            val remainder = postRakeAmount - share * tierWinners.size
+            val tierPayouts = mutableMapOf<Long, Long>()
+            for ((i, winner) in tierWinners.withIndex()) {
                 val take = share + if (i == 0) remainder else 0L
                 winner.chips += take
-                payouts[winner.discordId] = take
+                tierPayouts[winner.discordId] = take
+                payouts.merge(winner.discordId, take, Long::plus)
             }
+            potResults.add(
+                PokerTable.PotResult(
+                    cap = tier.cap,
+                    eligibleDiscordIds = tier.eligible.map { it.discordId },
+                    amount = postRakeAmount,
+                    winners = tierWinners.map { it.discordId },
+                    payoutByDiscordId = tierPayouts.toMap()
+                )
+            )
         }
 
+        // Aggregate winners across all pots (smallest tier first so the
+        // main-pot winner appears first if multiple seats win).
+        val allWinners: List<Long> = potResults.flatMap { it.winners }.distinct()
+
+        // Reveal hole cards only when there's a real showdown — i.e. more
+        // than one contender. Single-contender (everyone folded) keeps
+        // everyone's cards private.
         val revealedHoleCards: Map<Long, List<Card>> =
             if (contenders.size > 1) contenders.associate { it.discordId to it.holeCards } else emptyMap()
 
         val result = PokerTable.HandResult(
             handNumber = table.handNumber,
-            winners = winners.map { it.discordId },
+            winners = allWinners,
             payoutByDiscordId = payouts.toMap(),
-            pot = pot,
+            pot = totalCommitted,
             rake = rake,
             board = table.community.toList(),
             revealedHoleCards = revealedHoleCards,
-            resolvedAt = now
+            resolvedAt = now,
+            pots = potResults.toList(),
+            refundedByDiscordId = refunds.toMap()
         )
 
         // Reset table for the next hand.

--- a/database/src/main/kotlin/database/poker/PokerTable.kt
+++ b/database/src/main/kotlin/database/poker/PokerTable.kt
@@ -56,6 +56,14 @@ class PokerTable(
      * netted from the pot (the slice they were credited as chips, after
      * the rake came off). Seat-level chip mutations have already been
      * applied to [seats] when this is returned.
+     *
+     * As of v2 (PR #v2-1), the hand splits into [pots] tiers when
+     * players go all-in for different amounts. `pot` and
+     * `payoutByDiscordId` remain the across-all-tiers totals for
+     * back-compat with v1 callers; `pots` exposes the per-tier breakdown
+     * for richer rendering and the side-pot audit log. `refundedByDiscordId`
+     * captures uncontested over-commits returned to the over-committer
+     * (no rake applied).
      */
     data class HandResult(
         val handNumber: Long,
@@ -65,6 +73,36 @@ class PokerTable(
         val rake: Long,
         val board: List<Card>,
         val revealedHoleCards: Map<Long, List<Card>>,
-        val resolvedAt: Instant
+        val resolvedAt: Instant,
+        val pots: List<PotResult> = emptyList(),
+        val refundedByDiscordId: Map<Long, Long> = emptyMap()
+    )
+
+    /**
+     * One side-pot tier from a multi-way all-in resolution.
+     *
+     *   - [cap] — the per-seat commitment level that this tier was
+     *     peeled at (every contributor put in `cap - previousCap` to
+     *     reach this tier).
+     *   - [eligibleDiscordIds] — the contenders eligible to win this
+     *     tier (anyone whose total commitment matched `cap`). FOLDED
+     *     players are NOT eligible even if they contributed.
+     *   - [amount] — chips in this tier AFTER its share of the rake.
+     *   - [winners] — discord ids of the seat(s) that took this tier
+     *     after hand evaluation against [eligibleDiscordIds].
+     *   - [payoutByDiscordId] — chip credit each winner received from
+     *     this tier specifically.
+     *
+     * For a hand with no all-ins (everyone matches the same final bet),
+     * there is exactly one [PotResult] whose `eligibleDiscordIds`
+     * equals the full contender list. Tracking it as a list either way
+     * keeps the rendering layer agnostic.
+     */
+    data class PotResult(
+        val cap: Long,
+        val eligibleDiscordIds: List<Long>,
+        val amount: Long,
+        val winners: List<Long>,
+        val payoutByDiscordId: Map<Long, Long>
     )
 }

--- a/database/src/main/kotlin/database/service/PokerService.kt
+++ b/database/src/main/kotlin/database/service/PokerService.kt
@@ -2,7 +2,9 @@ package database.service
 
 import database.dto.ConfigDto
 import database.dto.PokerHandLogDto
+import database.dto.PokerHandPotDto
 import database.persistence.PokerHandLogPersistence
+import database.persistence.PokerHandPotPersistence
 import database.poker.PokerEngine
 import database.poker.PokerEngine.PokerAction
 import database.poker.PokerTable
@@ -35,9 +37,14 @@ import kotlin.random.Random
  * `/duel` and the slot machines feed it. A row is appended to
  * `poker_hand_log` for audit/leaderboard purposes.
  *
- * v1 simplifications:
- *   - Single pot per hand, no side pots. An all-in short stack can
- *     win the entire pot at showdown — incorrect poker, fine for v1.
+ * v2 (PR #v2-1) — proper side pots and call-for-less. When players
+ * go all-in for different amounts, [PokerTable.HandResult.pots]
+ * splits the pot into tiers. A short stack can no longer scoop chips
+ * they didn't match. Each tier is persisted as its own row in
+ * `poker_hand_pot` for audit; `poker_hand_log.pot` stays the
+ * across-tiers aggregate for v1 readers.
+ *
+ * Remaining v1 simplifications (slated for later v2 PRs):
  *   - Buy-in / cash-out only allowed when the table isn't mid-hand.
  *     If a player wants to leave during a hand, they fold and wait.
  *   - Auto-topup (sell TOBY to make rent like the other casinos do via
@@ -51,6 +58,7 @@ class PokerService @Autowired constructor(
     private val configService: ConfigService,
     private val tableRegistry: PokerTableRegistry,
     private val handLogPersistence: PokerHandLogPersistence,
+    private val handPotPersistence: PokerHandPotPersistence,
     private val random: Random = Random.Default
 ) {
 
@@ -297,7 +305,7 @@ class PokerService @Autowired constructor(
         val playerIds = table.seats.joinToString(",") { it.discordId.toString() }
         val winnerIds = result.winners.joinToString(",")
         val board = result.board.joinToString(",") { it.toString() }
-        handLogPersistence.insert(
+        val log = handLogPersistence.insert(
             PokerHandLogDto(
                 guildId = table.guildId,
                 tableId = table.id,
@@ -310,6 +318,24 @@ class PokerService @Autowired constructor(
                 resolvedAt = result.resolvedAt
             )
         )
+        // v2: persist the per-tier breakdown alongside the aggregate
+        // log row. Older hands (pre-v2 or single-pot resolutions) just
+        // produce one tier row.
+        val handLogId = log.id ?: return
+        for ((idx, tier) in result.pots.withIndex()) {
+            handPotPersistence.insert(
+                PokerHandPotDto(
+                    handLogId = handLogId,
+                    tierIndex = idx,
+                    cap = tier.cap,
+                    amount = tier.amount,
+                    eligible = tier.eligibleDiscordIds.joinToString(",") { it.toString() },
+                    winners = tier.winners.joinToString(",") { it.toString() },
+                    payouts = tier.payoutByDiscordId.entries
+                        .joinToString(",") { (id, amt) -> "$id:$amt" }
+                )
+            )
+        }
     }
 
     /**

--- a/database/src/main/resources/db/migration/V23__poker_hand_pot.sql
+++ b/database/src/main/resources/db/migration/V23__poker_hand_pot.sql
@@ -1,0 +1,29 @@
+-- Per-tier breakdown of a settled poker hand. v1 stored a single
+-- `pot` column on `poker_hand_log`; v2's side-pot resolver can
+-- split a hand into multiple tiers (one main pot + N side pots
+-- when players go all-in for different amounts), and we want each
+-- tier auditable on its own row instead of just the aggregate.
+--
+-- One row per side-pot tier per hand. The aggregate `pot` and
+-- `winners`/`rake` columns on `poker_hand_log` stay populated for
+-- back-compat with v1 readers.
+--
+-- `cap` is the per-seat commitment level this tier was peeled at
+-- (every contributor put in `cap - prev_cap` to reach this tier).
+-- `eligible` is the comma-separated discord IDs of seats that could
+-- win this tier (those whose totalCommittedThisHand reached `cap`).
+-- `winners` is the subset of `eligible` who actually won the tier
+-- after hand evaluation. `payouts` is `discordId:amount,...` for
+-- each winner's slice of the post-rake `amount`.
+CREATE TABLE poker_hand_pot (
+    id            BIGSERIAL    PRIMARY KEY,
+    hand_log_id   BIGINT       NOT NULL REFERENCES poker_hand_log(id) ON DELETE CASCADE,
+    tier_index    INT          NOT NULL CHECK (tier_index >= 0),
+    cap           BIGINT       NOT NULL CHECK (cap >= 0),
+    amount        BIGINT       NOT NULL CHECK (amount >= 0),
+    eligible      VARCHAR(512) NOT NULL,
+    winners       VARCHAR(512) NOT NULL,
+    payouts       VARCHAR(512) NOT NULL,
+    UNIQUE (hand_log_id, tier_index)
+);
+CREATE INDEX idx_poker_hand_pot_log ON poker_hand_pot (hand_log_id);

--- a/database/src/test/kotlin/database/poker/PokerEngineSidePotTest.kt
+++ b/database/src/test/kotlin/database/poker/PokerEngineSidePotTest.kt
@@ -1,0 +1,339 @@
+package database.poker
+
+import database.poker.PokerTable.Phase
+import database.poker.PokerTable.SeatStatus
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import kotlin.random.Random
+
+/**
+ * Multi-tier side-pot resolution. Drives [PokerEngine.resolveHand]
+ * directly with hand-crafted post-betting table states so each
+ * scenario tests one specific tier-construction or eligibility rule
+ * in isolation.
+ *
+ * The test seeds known hole cards into each seat by reaching into the
+ * mutable [PokerTable.Seat.holeCards] field, so the winners are
+ * deterministic without needing to seed a deck and play through a
+ * real hand. The board is also fixed.
+ */
+class PokerEngineSidePotTest {
+
+    private val now: Instant = Instant.parse("2026-04-10T10:00:00Z")
+    private val rakeZero = 0.0
+    private val rake = 0.05
+
+    private fun card(rank: Rank, suit: Suit) = Card(rank, suit)
+
+    private fun makeTable(): PokerTable = PokerTable(
+        id = 1L,
+        guildId = 42L,
+        hostDiscordId = 1L,
+        minBuyIn = 100L,
+        maxBuyIn = 5000L,
+        smallBlind = 5L,
+        bigBlind = 10L,
+        smallBet = 10L,
+        bigBet = 20L,
+        maxRaisesPerStreet = 4,
+        maxSeats = 6,
+    )
+
+    /**
+     * Build a table at the "river complete, ready to settle" point.
+     * Each entry in [seats] gives `(discordId, chipsRemaining, totalCommitted, status, holeCards)`.
+     * Board is fixed across tests so winners are deterministic from hole cards.
+     */
+    private fun showdown(
+        seats: List<SeatSetup>,
+        board: List<Card> = STD_BOARD
+    ): PokerTable {
+        val table = makeTable()
+        table.phase = Phase.RIVER
+        table.community.addAll(board)
+        table.pot = seats.sumOf { it.totalCommitted }
+        for (s in seats) {
+            val seat = PokerTable.Seat(discordId = s.discordId, chips = s.chips)
+            seat.totalCommittedThisHand = s.totalCommitted
+            seat.committedThisRound = 0L
+            seat.status = s.status
+            seat.holeCards = s.holeCards
+            table.seats.add(seat)
+        }
+        return table
+    }
+
+    private data class SeatSetup(
+        val discordId: Long,
+        val chips: Long,
+        val totalCommitted: Long,
+        val status: SeatStatus,
+        val holeCards: List<Card>
+    )
+
+    companion object {
+        // Plain rainbow board with no straight/flush draw on it. Each
+        // seat's "best hand" is determined by their hole cards alone.
+        private val STD_BOARD = listOf(
+            Card(Rank.TWO, Suit.CLUBS),
+            Card(Rank.THREE, Suit.DIAMONDS),
+            Card(Rank.SEVEN, Suit.HEARTS),
+            Card(Rank.NINE, Suit.SPADES),
+            Card(Rank.JACK, Suit.CLUBS)
+        )
+    }
+
+    // High-card-only hole cards that play exactly to the listed rank
+    // when paired with STD_BOARD. e.g. ACE_HOLE makes "ace high".
+    private val ACE_HOLE = listOf(Card(Rank.ACE, Suit.SPADES), Card(Rank.FOUR, Suit.CLUBS))
+    private val KING_HOLE = listOf(Card(Rank.KING, Suit.SPADES), Card(Rank.FIVE, Suit.CLUBS))
+    private val QUEEN_HOLE = listOf(Card(Rank.QUEEN, Suit.SPADES), Card(Rank.SIX, Suit.CLUBS))
+
+    // Pocket pairs. With STD_BOARD (no T/J/K duplicates of these), each
+    // plays to its own pocket-pair rank; relative strength is just the
+    // pair rank. POCKET_TENS and ALT_TENS make the SAME hand (pair of
+    // tens with identical board kickers) so they chop at showdown.
+    private val POCKET_TENS = listOf(Card(Rank.TEN, Suit.SPADES), Card(Rank.TEN, Suit.HEARTS))
+    private val ALT_TENS = listOf(Card(Rank.TEN, Suit.CLUBS), Card(Rank.TEN, Suit.DIAMONDS))
+    // Pair of jacks via the board jack — beats every pocket pair below
+    // jacks because the kickers come off the board identically.
+    private val JACK_PAIR = listOf(Card(Rank.JACK, Suit.SPADES), Card(Rank.FIVE, Suit.HEARTS))
+
+    @Test
+    fun `single contender (everyone else folded) takes the whole pot`() {
+        // No all-in tiers needed. One seat survived the betting round.
+        val table = showdown(
+            seats = listOf(
+                SeatSetup(1L, chips = 0L, totalCommitted = 60L, status = SeatStatus.ACTIVE, holeCards = ACE_HOLE),
+                SeatSetup(2L, chips = 0L, totalCommitted = 30L, status = SeatStatus.FOLDED, holeCards = KING_HOLE),
+                SeatSetup(3L, chips = 0L, totalCommitted = 60L, status = SeatStatus.FOLDED, holeCards = QUEEN_HOLE),
+            )
+        )
+
+        val result = PokerEngine.resolveHand(table, rakeRate = rakeZero, now = now)
+
+        assertEquals(150L, result.pot)
+        assertEquals(0L, result.rake)
+        assertEquals(listOf(1L), result.winners)
+        assertEquals(150L, result.payoutByDiscordId[1L])
+        assertEquals(1, result.pots.size, "single contender → single tier")
+        assertEquals(150L, result.pots[0].amount)
+        assertTrue(result.refundedByDiscordId.isEmpty(), "fully contested, nothing to refund")
+        assertTrue(result.revealedHoleCards.isEmpty(), "no showdown, no reveal")
+    }
+
+    @Test
+    fun `3-way different all-in amounts produces main + side pot`() {
+        // A all-in 50, B all-in 200, C all-in 200. A has the strongest
+        // hand (pair of jacks via board) and wins the main pot; B has
+        // pocket tens and wins the side pot over C's king-high.
+        val table = showdown(
+            seats = listOf(
+                SeatSetup(1L, chips = 0L, totalCommitted = 50L,  status = SeatStatus.ALL_IN, holeCards = JACK_PAIR),
+                SeatSetup(2L, chips = 0L, totalCommitted = 200L, status = SeatStatus.ALL_IN, holeCards = POCKET_TENS),
+                SeatSetup(3L, chips = 0L, totalCommitted = 200L, status = SeatStatus.ACTIVE, holeCards = KING_HOLE),
+            )
+        )
+
+        val result = PokerEngine.resolveHand(table, rakeRate = rakeZero, now = now)
+
+        // Main pot: 50 × 3 = 150, eligible {1,2,3}.
+        // Side pot: 150 × 2 = 300, eligible {2,3}.
+        assertEquals(450L, result.pot)
+        assertEquals(2, result.pots.size)
+        assertEquals(50L, result.pots[0].cap)
+        assertEquals(150L, result.pots[0].amount)
+        assertEquals(setOf(1L, 2L, 3L), result.pots[0].eligibleDiscordIds.toSet())
+        assertEquals(200L, result.pots[1].cap)
+        assertEquals(300L, result.pots[1].amount)
+        assertEquals(setOf(2L, 3L), result.pots[1].eligibleDiscordIds.toSet())
+
+        // A has pair of jacks — wins main pot. B has pocket TT — wins
+        // side pot over C's king-high.
+        assertEquals(listOf(1L), result.pots[0].winners)
+        assertEquals(listOf(2L), result.pots[1].winners)
+        assertEquals(150L, result.payoutByDiscordId[1L])
+        assertEquals(300L, result.payoutByDiscordId[2L])
+        // C committed 200 but won nothing.
+        assertEquals(null, result.payoutByDiscordId[3L])
+    }
+
+    @Test
+    fun `winner of side pot is not the winner of main pot`() {
+        // Same shape as above but: A has the strongest hand (pair of jacks),
+        // B has medium (pocket tens — pair of tens), C has weakest (king-high).
+        // Main pot eligibles {A, B, C} → A wins. Side pot eligibles {B, C} → B wins.
+        // This proves eligibility filters the winner pool, not just hand strength.
+        val table = showdown(
+            seats = listOf(
+                SeatSetup(1L, chips = 0L, totalCommitted = 50L,  status = SeatStatus.ALL_IN, holeCards = JACK_PAIR),
+                SeatSetup(2L, chips = 0L, totalCommitted = 200L, status = SeatStatus.ALL_IN, holeCards = POCKET_TENS),
+                SeatSetup(3L, chips = 0L, totalCommitted = 200L, status = SeatStatus.ACTIVE, holeCards = KING_HOLE),
+            )
+        )
+
+        val result = PokerEngine.resolveHand(table, rakeRate = rakeZero, now = now)
+
+        assertEquals(listOf(1L), result.pots[0].winners, "A wins main pot")
+        assertEquals(listOf(2L), result.pots[1].winners, "B wins side pot, NOT A")
+        assertEquals(150L, result.payoutByDiscordId[1L])
+        assertEquals(300L, result.payoutByDiscordId[2L])
+        assertNotEquals(result.pots[0].winners, result.pots[1].winners)
+    }
+
+    @Test
+    fun `4-way all-in at two distinct tiers builds two side pots`() {
+        // A all-in 50, B all-in 50, C all-in 200, D all-in 200.
+        // Tier 1 cap 50: 4 × 50 = 200, eligible {A,B,C,D}.
+        // Tier 2 cap 200: 2 × 150 = 300, eligible {C,D}.
+        val table = showdown(
+            seats = listOf(
+                SeatSetup(1L, chips = 0L, totalCommitted = 50L,  status = SeatStatus.ALL_IN, holeCards = JACK_PAIR),
+                SeatSetup(2L, chips = 0L, totalCommitted = 50L,  status = SeatStatus.ALL_IN, holeCards = QUEEN_HOLE),
+                SeatSetup(3L, chips = 0L, totalCommitted = 200L, status = SeatStatus.ALL_IN, holeCards = POCKET_TENS),
+                SeatSetup(4L, chips = 0L, totalCommitted = 200L, status = SeatStatus.ACTIVE, holeCards = KING_HOLE),
+            )
+        )
+
+        val result = PokerEngine.resolveHand(table, rakeRate = rakeZero, now = now)
+
+        assertEquals(500L, result.pot)
+        assertEquals(2, result.pots.size)
+        assertEquals(200L, result.pots[0].amount)
+        assertEquals(setOf(1L, 2L, 3L, 4L), result.pots[0].eligibleDiscordIds.toSet())
+        assertEquals(300L, result.pots[1].amount)
+        assertEquals(setOf(3L, 4L), result.pots[1].eligibleDiscordIds.toSet())
+        assertEquals(listOf(1L), result.pots[0].winners, "A's pair of jacks wins tier 1")
+        assertEquals(listOf(3L), result.pots[1].winners, "C's pocket TT wins tier 2 over D's K-high")
+    }
+
+    @Test
+    fun `distinct winner takes one tier, tied hands chop the other`() {
+        // A all-in 50 with the strongest hand (pair of jacks). B and C
+        // both committed 200 with identical pocket tens (different
+        // suits, same hand strength against the board).
+        // Tier 1 (50): all three eligible — A wins outright.
+        // Tier 2 (200): only B and C eligible — they chop, splitting
+        // the side pot evenly.
+        val table = showdown(
+            seats = listOf(
+                SeatSetup(1L, chips = 0L, totalCommitted = 50L,  status = SeatStatus.ALL_IN, holeCards = JACK_PAIR),
+                SeatSetup(2L, chips = 0L, totalCommitted = 200L, status = SeatStatus.ALL_IN, holeCards = POCKET_TENS),
+                SeatSetup(3L, chips = 0L, totalCommitted = 200L, status = SeatStatus.ACTIVE, holeCards = ALT_TENS),
+            )
+        )
+
+        val result = PokerEngine.resolveHand(table, rakeRate = rakeZero, now = now)
+
+        assertEquals(2, result.pots.size)
+        // Main pot 150 — A wins outright with pair of jacks.
+        assertEquals(listOf(1L), result.pots[0].winners)
+        assertEquals(150L, result.pots[0].payoutByDiscordId[1L])
+        // Side pot 300 chopped between B and C → 150 each.
+        assertEquals(setOf(2L, 3L), result.pots[1].winners.toSet())
+        assertEquals(150L, result.pots[1].payoutByDiscordId[2L])
+        assertEquals(150L, result.pots[1].payoutByDiscordId[3L])
+    }
+
+    @Test
+    fun `over-commit beyond highest contender is refunded uncontested`() {
+        // A all-in 50 (the only contender at the high end), B over-bet 200.
+        // No one can match B's commitment beyond 50, so B's 150 excess is
+        // refunded directly — no rake on the refund.
+        val table = showdown(
+            seats = listOf(
+                SeatSetup(1L, chips = 0L, totalCommitted = 50L,  status = SeatStatus.ALL_IN, holeCards = ACE_HOLE),
+                SeatSetup(2L, chips = 0L, totalCommitted = 200L, status = SeatStatus.ACTIVE, holeCards = POCKET_TENS),
+            )
+        )
+
+        val result = PokerEngine.resolveHand(table, rakeRate = rakeZero, now = now)
+
+        // Single contested tier of 100 (50 each), B's 150 excess returned.
+        assertEquals(1, result.pots.size, "no side pot when only one tier is contested")
+        assertEquals(100L, result.pots[0].amount)
+        assertEquals(150L, result.refundedByDiscordId[2L])
+        assertEquals(listOf(2L), result.pots[0].winners, "B's pocket tens beats A's ace-high")
+        // B's chips are credited the refund in-memory.
+        val bSeat = table.seats.first { it.discordId == 2L }
+        assertEquals(150L + 100L, bSeat.chips, "refund + winning tier credited to chips")
+    }
+
+    @Test
+    fun `chip total is conserved across a 3-way all-in resolution (with rake)`() {
+        val table = showdown(
+            seats = listOf(
+                SeatSetup(1L, chips = 0L, totalCommitted = 50L,  status = SeatStatus.ALL_IN, holeCards = ACE_HOLE),
+                SeatSetup(2L, chips = 0L, totalCommitted = 200L, status = SeatStatus.ALL_IN, holeCards = POCKET_TENS),
+                SeatSetup(3L, chips = 0L, totalCommitted = 200L, status = SeatStatus.ACTIVE, holeCards = KING_HOLE),
+            )
+        )
+        val totalCommitted = table.pot
+
+        val result = PokerEngine.resolveHand(table, rakeRate = rake, now = now)
+
+        val chipsAfter = table.seats.sumOf { it.chips }
+        assertEquals(totalCommitted - result.rake, chipsAfter,
+            "every chip lands somewhere: payouts + refunds = totalCommitted - rake")
+        assertEquals(result.payoutByDiscordId.values.sum() + result.refundedByDiscordId.values.sum(),
+            chipsAfter)
+    }
+
+    @Test
+    fun `rake comes off smallest pot first so over-tier players keep more`() {
+        // A all-in 50, B all-in 50, C 1000 (over-commit will refund 950
+        // of C's stake since no contender matched above 50).
+        // Single contested tier of 150. 5% rake = 7. Tier amount = 143.
+        // C's 950 over-commit returns unraked.
+        val table = showdown(
+            seats = listOf(
+                SeatSetup(1L, chips = 0L, totalCommitted = 50L,   status = SeatStatus.ALL_IN, holeCards = ACE_HOLE),
+                SeatSetup(2L, chips = 0L, totalCommitted = 50L,   status = SeatStatus.ALL_IN, holeCards = QUEEN_HOLE),
+                SeatSetup(3L, chips = 0L, totalCommitted = 1000L, status = SeatStatus.ACTIVE, holeCards = KING_HOLE),
+            )
+        )
+
+        val result = PokerEngine.resolveHand(table, rakeRate = rake, now = now)
+
+        assertEquals(1100L, result.pot, "totalCommitted across all seats")
+        assertEquals(7L, result.rake, "5% of contested 150")
+        assertEquals(950L, result.refundedByDiscordId[3L], "C's over-commit returned unraked")
+        assertEquals(143L, result.pots[0].amount, "150 - 7 rake")
+    }
+
+    @Test
+    fun `folded players still contribute their committed chips to the pots`() {
+        // A all-in 50, B folded after committing 80, C committed 200.
+        // C's effective level is capped at 80 (B's commit, the largest
+        // any other seat put in), so C's 120 above 80 is uncalled and
+        // refunded.
+        //   Tier 1 cap 50: 50 (A) + 50 (B) + 50 (C) = 150. Eligible: A, C.
+        //   Tier 2 cap 80:  0 (A) + 30 (B) + 30 (C) = 60.  Eligible: C.
+        // B is folded so contributes dead money but isn't eligible to
+        // win either tier despite putting chips in.
+        val table = showdown(
+            seats = listOf(
+                SeatSetup(1L, chips = 0L, totalCommitted = 50L,  status = SeatStatus.ALL_IN, holeCards = ACE_HOLE),
+                SeatSetup(2L, chips = 0L, totalCommitted = 80L,  status = SeatStatus.FOLDED, holeCards = POCKET_TENS),
+                SeatSetup(3L, chips = 0L, totalCommitted = 200L, status = SeatStatus.ACTIVE, holeCards = KING_HOLE),
+            )
+        )
+
+        val result = PokerEngine.resolveHand(table, rakeRate = rakeZero, now = now)
+
+        assertEquals(2, result.pots.size)
+        assertEquals(150L, result.pots[0].amount, "tier 1: 50 from each of A/B/C")
+        assertEquals(setOf(1L, 3L), result.pots[0].eligibleDiscordIds.toSet(),
+            "B is folded so not eligible despite contributing")
+        assertEquals(listOf(1L), result.pots[0].winners, "A's ace-high beats C's K-high")
+        assertEquals(60L, result.pots[1].amount, "tier 2: B's 30 + C's 30 (matched against B's dead money)")
+        assertEquals(setOf(3L), result.pots[1].eligibleDiscordIds.toSet(),
+            "only C is contender at the 80 cap")
+        assertEquals(listOf(3L), result.pots[1].winners)
+        assertEquals(120L, result.refundedByDiscordId[3L],
+            "C's commitment above what anyone else could match (200 - 80 = 120) is returned")
+    }
+}

--- a/database/src/test/kotlin/database/service/PokerServiceTest.kt
+++ b/database/src/test/kotlin/database/service/PokerServiceTest.kt
@@ -2,8 +2,10 @@ package database.service
 
 import database.dto.ConfigDto
 import database.dto.PokerHandLogDto
+import database.dto.PokerHandPotDto
 import database.dto.UserDto
 import database.persistence.PokerHandLogPersistence
+import database.persistence.PokerHandPotPersistence
 import database.poker.PokerEngine
 import database.poker.PokerTable
 import database.poker.PokerTableRegistry
@@ -32,6 +34,7 @@ class PokerServiceTest {
     private lateinit var configService: ConfigService
     private lateinit var registry: PokerTableRegistry
     private lateinit var handLog: RecordingPokerHandLogPersistence
+    private lateinit var handPot: RecordingPokerHandPotPersistence
     private lateinit var service: PokerService
 
     @BeforeEach
@@ -44,6 +47,7 @@ class PokerServiceTest {
             sweepInterval = Duration.ofHours(1)
         )
         handLog = RecordingPokerHandLogPersistence()
+        handPot = RecordingPokerHandPotPersistence()
         // Default config — fall back to 5% rake.
         every {
             configService.getConfigByName(
@@ -57,6 +61,7 @@ class PokerServiceTest {
             configService = configService,
             tableRegistry = registry,
             handLogPersistence = handLog,
+            handPotPersistence = handPot,
             random = Random(42)
         )
     }
@@ -230,6 +235,14 @@ class PokerServiceTest {
         assertEquals(1, handLog.inserted.size)
         assertEquals(100L, handLog.inserted[0].pot)
         assertEquals(5L, handLog.inserted[0].rake)
+        // v2: single-pot hand still produces exactly one pot-tier row
+        // joined to the hand log so the audit table is consistent
+        // whether or not side pots formed.
+        val handLogId = handLog.inserted[0].id!!
+        val tiers = handPot.findByHandLogId(handLogId)
+        assertEquals(1, tiers.size, "single-pot hand → single audit tier row")
+        assertEquals(0, tiers[0].tierIndex)
+        assertEquals(95L, tiers[0].amount, "tier amount net of rake (100 - 5)")
     }
 
     @Test
@@ -355,8 +368,21 @@ class PokerServiceTest {
 
     private class RecordingPokerHandLogPersistence : PokerHandLogPersistence {
         val inserted = mutableListOf<PokerHandLogDto>()
+        private var nextId = 1L
         override fun insert(row: PokerHandLogDto): PokerHandLogDto {
+            // Production assigns id via @GeneratedValue + flush. Stub it
+            // here so persistResult can pass it on to the pot rows.
+            if (row.id == null) row.id = nextId++
             inserted.add(row); return row
         }
+    }
+
+    private class RecordingPokerHandPotPersistence : PokerHandPotPersistence {
+        val inserted = mutableListOf<PokerHandPotDto>()
+        override fun insert(row: PokerHandPotDto): PokerHandPotDto {
+            inserted.add(row); return row
+        }
+        override fun findByHandLogId(handLogId: Long): List<PokerHandPotDto> =
+            inserted.filter { it.handLogId == handLogId }.sortedBy { it.tierIndex }
     }
 }

--- a/web/src/main/kotlin/web/service/PokerWebService.kt
+++ b/web/src/main/kotlin/web/service/PokerWebService.kt
@@ -79,6 +79,28 @@ class PokerWebService(
         val rake: Long,
         val board: List<String>,
         val revealedHoleCards: Map<String, List<String>>,
+        /**
+         * v2 (PR #v2-1): per-tier breakdown of the pot. For a hand with
+         * no all-ins this is exactly one entry covering the full pot.
+         * Multi-way all-ins at different stack sizes split into a main
+         * pot + N side pots so the renderer can label each tier with
+         * its eligible-player set.
+         */
+        val pots: List<PotResultView> = emptyList(),
+        /**
+         * Discord IDs to chips that came back unraked because no other
+         * seat could match the over-commitment (standard "uncalled bet
+         * returned" rule).
+         */
+        val refundedByDiscordId: Map<String, Long> = emptyMap(),
+    )
+
+    data class PotResultView(
+        val cap: Long,
+        val amount: Long,
+        val eligibleDiscordIds: List<Long>,
+        val winners: List<Long>,
+        val payoutByDiscordId: Map<String, Long>,
     )
 
     fun listGuildTables(guildId: Long): List<TableSummaryView> =
@@ -171,7 +193,17 @@ class PokerWebService(
                         board = result.board.map(Card::toString),
                         revealedHoleCards = result.revealedHoleCards
                             .mapKeys { it.key.toString() }
-                            .mapValues { e -> e.value.map(Card::toString) }
+                            .mapValues { e -> e.value.map(Card::toString) },
+                        pots = result.pots.map { p ->
+                            PotResultView(
+                                cap = p.cap,
+                                amount = p.amount,
+                                eligibleDiscordIds = p.eligibleDiscordIds,
+                                winners = p.winners,
+                                payoutByDiscordId = p.payoutByDiscordId.mapKeys { it.key.toString() },
+                            )
+                        },
+                        refundedByDiscordId = result.refundedByDiscordId.mapKeys { it.key.toString() },
                     )
                 }
             )

--- a/web/src/main/resources/static/js/poker-pots.js
+++ b/web/src/main/resources/static/js/poker-pots.js
@@ -1,0 +1,81 @@
+// Multi-tier side-pot rendering helper. Used by poker-table.js to
+// render PokerWebService.HandResultView.pots after a hand resolves.
+//
+// Exposed as window.TobyPokerPots so the same module can be required
+// from Jest (jsdom) tests without bundler magic — same convention as
+// the casino-result.js helper.
+(function (root) {
+    'use strict';
+
+    function asString(id) { return String(id); }
+
+    function tierLabel(index, total) {
+        if (total <= 1) return 'Pot';
+        if (index === 0) return 'Main pot';
+        return 'Side pot ' + index;
+    }
+
+    function renderTier(tier, index, total) {
+        const li = document.createElement('li');
+        li.className = 'poker-pot-tier';
+
+        const label = document.createElement('span');
+        label.className = 'poker-pot-tier-label';
+        label.textContent = tierLabel(index, total);
+        li.appendChild(label);
+
+        const amount = document.createElement('span');
+        amount.className = 'poker-pot-tier-amount';
+        amount.textContent = String(tier.amount);
+        li.appendChild(amount);
+
+        const eligibleIds = (tier.eligibleDiscordIds || []).map(asString);
+        if (eligibleIds.length) {
+            const eligible = document.createElement('span');
+            eligible.className = 'poker-pot-tier-eligible';
+            eligible.textContent = 'eligible: ' + eligibleIds.join(', ');
+            li.appendChild(eligible);
+        }
+
+        const winnerIds = (tier.winners || []).map(asString);
+        if (winnerIds.length) {
+            const winners = document.createElement('span');
+            winners.className = 'poker-pot-tier-winners';
+            winners.textContent = 'won by: ' + winnerIds.join(', ');
+            li.appendChild(winners);
+        }
+        return li;
+    }
+
+    function render(opts) {
+        const containerEl = opts && opts.containerEl;
+        if (!containerEl) return;
+        const pots = (opts.pots || []).slice();
+        containerEl.innerHTML = '';
+        if (pots.length === 0) {
+            containerEl.hidden = true;
+            return;
+        }
+        containerEl.hidden = false;
+
+        const list = document.createElement('ul');
+        list.className = 'poker-pots';
+        pots.forEach(function (tier, idx) {
+            list.appendChild(renderTier(tier, idx, pots.length));
+        });
+        containerEl.appendChild(list);
+
+        const refunds = opts.refundedByDiscordId || {};
+        const refundIds = Object.keys(refunds);
+        if (refundIds.length) {
+            const note = document.createElement('p');
+            note.className = 'poker-pots-refunds';
+            note.textContent = 'Refunded: ' + refundIds
+                .map(function (id) { return id + ' (' + refunds[id] + ')'; })
+                .join(', ');
+            containerEl.appendChild(note);
+        }
+    }
+
+    root.TobyPokerPots = { render: render };
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/web/src/main/resources/static/js/poker-table.js
+++ b/web/src/main/resources/static/js/poker-table.js
@@ -21,6 +21,7 @@
     const seatsEl = document.getElementById('poker-seats');
     const statusEl = document.getElementById('poker-status');
     const resultEl = document.getElementById('poker-result');
+    const potsEl = document.getElementById('poker-pots');
     const balanceEl = document.getElementById('poker-balance');
     const joinCard = document.getElementById('poker-join-card');
 
@@ -117,7 +118,11 @@
     }
 
     function renderResult(result) {
-        if (!result) { resultEl.textContent = ''; return; }
+        if (!result) {
+            resultEl.textContent = '';
+            if (potsEl) { potsEl.innerHTML = ''; potsEl.hidden = true; }
+            return;
+        }
         const winners = (result.winners || []).map(function (id) { return String(id); }).join(', ');
         const reveals = result.revealedHoleCards || {};
         const lines = [];
@@ -128,6 +133,13 @@
             ' resolved. Winners: ' + winners +
             ' · pot ' + result.pot + ' (rake ' + result.rake + ' → jackpot)' +
             (lines.length ? ' · showdown: ' + lines.join(' | ') : '');
+        if (potsEl && window.TobyPokerPots) {
+            window.TobyPokerPots.render({
+                containerEl: potsEl,
+                pots: result.pots || [],
+                refundedByDiscordId: result.refundedByDiscordId || {},
+            });
+        }
     }
 
     function refresh() {

--- a/web/src/main/resources/templates/poker-table.html
+++ b/web/src/main/resources/templates/poker-table.html
@@ -53,6 +53,7 @@
 
         <div id="poker-status" class="muted" style="margin-top: 0.75rem;"></div>
         <div id="poker-result" class="muted" style="margin-top: 0.5rem;"></div>
+        <div id="poker-pots" class="poker-pots-container" style="margin-top: 0.5rem;" hidden></div>
     </section>
 </main>
 
@@ -60,6 +61,7 @@
 
 <script th:src="@{/js/api.js}"></script>
 <script th:src="@{/js/toasts.js}"></script>
+<script th:src="@{/js/poker-pots.js}"></script>
 <script th:src="@{/js/poker-table.js}"></script>
 </body>
 </html>

--- a/web/src/test/js/poker-pots.test.js
+++ b/web/src/test/js/poker-pots.test.js
@@ -1,0 +1,127 @@
+// DOM unit test for the multi-tier side-pot renderer. Pulls the
+// production JS in through the same window global the page uses.
+require('../../main/resources/static/js/poker-pots');
+
+describe('TobyPokerPots.render', () => {
+    let container;
+
+    beforeEach(() => {
+        document.body.innerHTML = '<div id="pots"></div>';
+        container = document.getElementById('pots');
+    });
+
+    test('no-op when containerEl is null', () => {
+        expect(() => window.TobyPokerPots.render({
+            containerEl: null,
+            pots: [{ amount: 100, cap: 50, eligibleDiscordIds: [1], winners: [1], payoutByDiscordId: { '1': 100 } }],
+        })).not.toThrow();
+    });
+
+    test('hides the container when no pots are provided', () => {
+        container.hidden = false;
+        window.TobyPokerPots.render({ containerEl: container, pots: [] });
+        expect(container.hidden).toBe(true);
+        expect(container.innerHTML).toBe('');
+    });
+
+    test('single pot is labelled simply "Pot" (no main/side distinction)', () => {
+        window.TobyPokerPots.render({
+            containerEl: container,
+            pots: [{
+                amount: 95,
+                cap: 100,
+                eligibleDiscordIds: [1, 2],
+                winners: [1],
+                payoutByDiscordId: { '1': 95 },
+            }],
+        });
+        const labels = container.querySelectorAll('.poker-pot-tier-label');
+        expect(labels.length).toBe(1);
+        expect(labels[0].textContent).toBe('Pot');
+        expect(container.querySelector('.poker-pot-tier-amount').textContent).toBe('95');
+    });
+
+    test('multi-tier renders Main pot + Side pot N labels in order', () => {
+        window.TobyPokerPots.render({
+            containerEl: container,
+            pots: [
+                { amount: 150, cap: 50, eligibleDiscordIds: [1, 2, 3], winners: [1], payoutByDiscordId: { '1': 150 } },
+                { amount: 300, cap: 200, eligibleDiscordIds: [2, 3], winners: [2], payoutByDiscordId: { '2': 300 } },
+            ],
+        });
+        const labels = Array.from(container.querySelectorAll('.poker-pot-tier-label'))
+            .map(function (n) { return n.textContent; });
+        expect(labels).toEqual(['Main pot', 'Side pot 1']);
+        const amounts = Array.from(container.querySelectorAll('.poker-pot-tier-amount'))
+            .map(function (n) { return n.textContent; });
+        expect(amounts).toEqual(['150', '300']);
+    });
+
+    test('eligible-player set is rendered per tier', () => {
+        window.TobyPokerPots.render({
+            containerEl: container,
+            pots: [
+                { amount: 200, cap: 50, eligibleDiscordIds: [1, 2, 3, 4], winners: [1], payoutByDiscordId: { '1': 200 } },
+                { amount: 300, cap: 200, eligibleDiscordIds: [3, 4], winners: [3], payoutByDiscordId: { '3': 300 } },
+            ],
+        });
+        const eligibleNodes = container.querySelectorAll('.poker-pot-tier-eligible');
+        expect(eligibleNodes.length).toBe(2);
+        expect(eligibleNodes[0].textContent).toContain('1, 2, 3, 4');
+        expect(eligibleNodes[1].textContent).toContain('3, 4');
+        expect(eligibleNodes[1].textContent).not.toContain('1');
+    });
+
+    test('chopped tier lists each winner', () => {
+        window.TobyPokerPots.render({
+            containerEl: container,
+            pots: [
+                { amount: 150, cap: 50, eligibleDiscordIds: [1, 2, 3], winners: [1], payoutByDiscordId: { '1': 150 } },
+                { amount: 300, cap: 200, eligibleDiscordIds: [2, 3], winners: [2, 3], payoutByDiscordId: { '2': 150, '3': 150 } },
+            ],
+        });
+        const winnersNodes = container.querySelectorAll('.poker-pot-tier-winners');
+        expect(winnersNodes[0].textContent).toContain('1');
+        expect(winnersNodes[1].textContent).toContain('2, 3');
+    });
+
+    test('refundedByDiscordId is rendered as a footnote when present', () => {
+        window.TobyPokerPots.render({
+            containerEl: container,
+            pots: [{ amount: 100, cap: 50, eligibleDiscordIds: [1, 2], winners: [2], payoutByDiscordId: { '2': 100 } }],
+            refundedByDiscordId: { '2': 150 },
+        });
+        const note = container.querySelector('.poker-pots-refunds');
+        expect(note).not.toBeNull();
+        expect(note.textContent).toContain('2');
+        expect(note.textContent).toContain('150');
+    });
+
+    test('no refund footnote when the map is empty', () => {
+        window.TobyPokerPots.render({
+            containerEl: container,
+            pots: [{ amount: 100, cap: 50, eligibleDiscordIds: [1, 2], winners: [2], payoutByDiscordId: { '2': 100 } }],
+            refundedByDiscordId: {},
+        });
+        expect(container.querySelector('.poker-pots-refunds')).toBeNull();
+    });
+
+    test('clears prior render before drawing the next one', () => {
+        window.TobyPokerPots.render({
+            containerEl: container,
+            pots: [
+                { amount: 150, cap: 50, eligibleDiscordIds: [1, 2, 3], winners: [1], payoutByDiscordId: { '1': 150 } },
+                { amount: 300, cap: 200, eligibleDiscordIds: [2, 3], winners: [2], payoutByDiscordId: { '2': 300 } },
+            ],
+        });
+        // Second render with a single pot should drop the second tier from the DOM.
+        window.TobyPokerPots.render({
+            containerEl: container,
+            pots: [
+                { amount: 95, cap: 100, eligibleDiscordIds: [1, 2], winners: [1], payoutByDiscordId: { '1': 95 } },
+            ],
+        });
+        expect(container.querySelectorAll('.poker-pot-tier').length).toBe(1);
+        expect(container.querySelector('.poker-pot-tier-label').textContent).toBe('Pot');
+    });
+});

--- a/web/src/test/kotlin/web/service/PokerWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/PokerWebServiceTest.kt
@@ -151,5 +151,59 @@ class PokerWebServiceTest {
         assertEquals(5L, lastResult.rake)
         assertEquals(listOf("A♠", "K♥"), lastResult.board)
         assertEquals(listOf("Q♠"), lastResult.revealedHoleCards["1"])
+        // Pre-v2 HandResult constructions default `pots` to empty and
+        // `refundedByDiscordId` to empty — projection must surface those
+        // shapes without crashing on missing fields.
+        assertEquals(emptyList<PokerWebService.PotResultView>(), lastResult.pots)
+        assertEquals(emptyMap<String, Long>(), lastResult.refundedByDiscordId)
+    }
+
+    @Test
+    fun `multi-tier pots are projected in order with masked discord-id keys`() {
+        val table = makeTable()
+        // 3-way side-pot scenario: A all-in 50 wins main, B wins side
+        // over C. The HandResultView should mirror the engine's pot
+        // tier list one-for-one so the JS layer can render it.
+        table.lastResult = PokerTable.HandResult(
+            handNumber = 7L,
+            winners = listOf(1L, 2L),
+            payoutByDiscordId = mapOf(1L to 150L, 2L to 300L),
+            pot = 450L,
+            rake = 0L,
+            board = listOf(Card(Rank.TWO, Suit.CLUBS)),
+            revealedHoleCards = emptyMap(),
+            resolvedAt = Instant.now(),
+            pots = listOf(
+                PokerTable.PotResult(
+                    cap = 50L,
+                    eligibleDiscordIds = listOf(1L, 2L, 3L),
+                    amount = 150L,
+                    winners = listOf(1L),
+                    payoutByDiscordId = mapOf(1L to 150L),
+                ),
+                PokerTable.PotResult(
+                    cap = 200L,
+                    eligibleDiscordIds = listOf(2L, 3L),
+                    amount = 300L,
+                    winners = listOf(2L),
+                    payoutByDiscordId = mapOf(2L to 300L),
+                ),
+            ),
+            refundedByDiscordId = mapOf(3L to 25L),
+        )
+        val view = service.snapshot(table.id, viewerDiscordId = 1L)!!
+        val lastResult = view.lastResult!!
+        val pots = lastResult.pots
+        assertEquals(2, pots.size)
+        assertEquals(50L, pots[0].cap)
+        assertEquals(150L, pots[0].amount)
+        assertEquals(listOf(1L, 2L, 3L), pots[0].eligibleDiscordIds)
+        assertEquals(listOf(1L), pots[0].winners)
+        assertEquals(150L, pots[0].payoutByDiscordId["1"])
+        assertEquals(200L, pots[1].cap)
+        assertEquals(listOf(2L, 3L), pots[1].eligibleDiscordIds)
+        assertEquals(listOf(2L), pots[1].winners)
+        assertEquals(300L, pots[1].payoutByDiscordId["2"])
+        assertEquals(25L, lastResult.refundedByDiscordId["3"])
     }
 }


### PR DESCRIPTION
## Summary

First poker v2 PR: proper side-pot resolution + call-for-less. v1 stuffed every hand into a single pot, which let an all-in short stack scoop chips no one matched. This PR makes the engine split the pot into tiers and award each tier to the best hand among that tier's eligible contributors.

## What changed

**Engine correctness (`database/poker/PokerEngine.kt`)**
- `resolveHand` now computes each contender's effective commit as `min(self.commit, max(others' commits))`. Anything above that level is returned to the over-committer unraked (standard "uncalled bet returned"). When there's only one contender (everyone folded around to them), the refund pass is skipped — they take the pot uncontested, including the forced-blind portion no one matched. Tiers are built from the distinct effective-commit levels; folded dead money is capped at the highest contender level so it falls into the contested tiers rather than vanishing.
- `applyAction` Call branch lets a short stack push all-in for whatever they have left instead of forcing a fold. The existing all-in run-out path resolves the board automatically once everyone remaining is at-stake.

**Result shape (`database/poker/PokerTable.kt`)**
- `HandResult` gains `pots: List<PotResult>` and `refundedByDiscordId: Map<Long, Long>`. `pot` and `payoutByDiscordId` remain the across-tiers totals for v1 readers.

**Persistence**
- New `poker_hand_pot` table (Flyway `V23`) with one row per tier per hand. `PokerService.persistResult` writes the aggregate `poker_hand_log` row first, then a `PokerHandPotDto` per tier with the cap, post-rake amount, eligible IDs, winners, and per-winner payouts.

**Web surface**
- `PokerWebService.HandResultView` projects `pots` and `refundedByDiscordId`.
- New `poker-pots.js` (`window.TobyPokerPots`) renders each tier with its eligible-player set, winner list, and an optional refund footnote. Wired into `poker-table.html` / `poker-table.js`.

## Tests

- `PokerEngineSidePotTest` — 9 deterministic scenarios driving `resolveHand` directly: single contender, 3-way different all-ins, side-pot-winner ≠ main-pot-winner, 4-way two-tier, chop-on-one-tier-with-distinct-winner-on-the-other, over-commit refund, chip conservation under rake, rake-from-smallest-tier-first, folded contributions matched against contender effective commits.
- `PokerServiceTest` — single-pot hand still produces exactly one audit-tier row joined to the hand log.
- `PokerWebServiceTest` — multi-tier projection preserves order, masks discord-id keys to strings, and surfaces the refund map.
- `poker-pots.test.js` — labelling (single "Pot" vs "Main pot"/"Side pot N"), eligible-set rendering, chopped-tier winner lists, and refund footnote presence/absence.

## Test plan

- [x] `./gradlew :database:test` — 234 tests
- [x] `./gradlew :web:test`
- [x] `npx jest` — 181 tests
- [ ] `:discord-bot:test` — couldn't run in the sandbox (network-restricted dep `moe.kyokobot.libdave:impl-jni`); no discord-bot files were touched, but CI should confirm
- [ ] Manual: 3-way all-in at different stack sizes resolves into main + side pot, side-pot winner is correctly the second-highest stack with the strongest hand, refunded chips show up in the JS footnote

https://claude.ai/code/session_0169MvtJ2BSbwkoB9GrFhfZC

---
_Generated by [Claude Code](https://claude.ai/code/session_0169MvtJ2BSbwkoB9GrFhfZC)_