### PR TITLE
refactor(web): drain controller + frontend duplication

### DIFF
--- a/web/src/main/kotlin/web/casino/CasinoOutcomeMapper.kt
+++ b/web/src/main/kotlin/web/casino/CasinoOutcomeMapper.kt
@@ -1,0 +1,68 @@
+package web.casino
+
+import org.springframework.http.ResponseEntity
+
+/**
+ * Centralised translation from casino-game failure outcomes
+ * (insufficient credits, invalid stake, unknown user, …) and
+ * sign-in/membership guard failures into [ResponseEntity] with the
+ * controller's per-game response shape.
+ *
+ * Before this lived as 6+ copies of the same `when (outcome)` arms
+ * across DiceController, CoinflipController, SlotsController,
+ * ScratchController and HighlowController — the strings were identical
+ * but had to be edited in five places. Now there is one place.
+ *
+ * The mapper is parameterised on the concrete response type so each
+ * controller keeps its typed Win/Lose construction; only the failure
+ * shape (`{ ok = false, error = "..." }`) is unified. Callers supply
+ * an [errorFactory] that wraps a message into their response type, e.g.
+ *
+ * ```
+ * private val errors = CasinoOutcomeMapper { msg -> RollResponse(false, msg) }
+ * ```
+ */
+class CasinoOutcomeMapper<R : CasinoResponseLike>(
+    private val errorFactory: (String) -> R,
+) {
+    /**
+     * 401 / 403 builder for [WebGuildAccess.requireMemberForJson].
+     * Hand it directly to the `errorBuilder = …` argument.
+     */
+    val errorBuilder: (Int) -> ResponseEntity<R> = { status ->
+        ResponseEntity.status(status).body(errorFactory(memberGuardMessage(status)))
+    }
+
+    fun insufficientCredits(stake: Long, have: Long): ResponseEntity<R> =
+        ResponseEntity.badRequest().body(errorFactory(insufficientCreditsMessage(stake, have)))
+
+    fun insufficientCoinsForTopUp(needed: Long, have: Long): ResponseEntity<R> =
+        ResponseEntity.badRequest().body(errorFactory(insufficientCoinsForTopUpMessage(needed, have)))
+
+    fun invalidStake(min: Long, max: Long): ResponseEntity<R> =
+        ResponseEntity.badRequest().body(errorFactory(invalidStakeMessage(min, max)))
+
+    fun unknownUser(): ResponseEntity<R> =
+        ResponseEntity.badRequest().body(errorFactory(UNKNOWN_USER))
+
+    fun badRequest(message: String): ResponseEntity<R> =
+        ResponseEntity.badRequest().body(errorFactory(message))
+
+    companion object {
+        const val NOT_SIGNED_IN = "Not signed in."
+        const val NOT_MEMBER = "You are not a member of that server."
+        const val UNKNOWN_USER = "No user record yet. Try another TobyBot command first."
+
+        fun memberGuardMessage(status: Int): String =
+            if (status == 401) NOT_SIGNED_IN else NOT_MEMBER
+
+        fun insufficientCreditsMessage(stake: Long, have: Long): String =
+            "Need $stake credits, you have $have."
+
+        fun insufficientCoinsForTopUpMessage(needed: Long, have: Long): String =
+            "Need $needed TOBY to cover the shortfall, you have $have."
+
+        fun invalidStakeMessage(min: Long, max: Long): String =
+            "Stake must be between $min and $max credits."
+    }
+}

--- a/web/src/main/kotlin/web/casino/CasinoPageContext.kt
+++ b/web/src/main/kotlin/web/casino/CasinoPageContext.kt
@@ -1,0 +1,50 @@
+package web.casino
+
+import database.service.JackpotService
+import database.service.TobyCoinMarketService
+import database.service.UserService
+import net.dv8tion.jda.api.JDA
+import net.dv8tion.jda.api.entities.Guild
+import org.springframework.security.oauth2.core.user.OAuth2User
+import org.springframework.stereotype.Component
+import org.springframework.ui.Model
+import web.util.displayName
+
+/**
+ * Resolves the model attributes every casino-game page needs:
+ * `guildId`, `guildName`, `balance`, `tobyCoins`, `marketPrice`,
+ * `jackpotPool`, `username`. Returns the resolved [Guild] (or `null`
+ * when the bot has been kicked from the guild between the auth check
+ * and now) so the caller can short-circuit with a flash error.
+ *
+ * Each per-game page handler used to repeat ~15 lines of `addAttribute`
+ * calls; centralising them here means a new common attribute (e.g. a
+ * cosmetic theme, an account flag) is one edit instead of five.
+ * Game-specific attributes (min/max stake, payout tables, anchors) are
+ * still set by the controller after this returns.
+ */
+@Component
+class CasinoPageContext(
+    private val userService: UserService,
+    private val jackpotService: JackpotService,
+    private val marketService: TobyCoinMarketService,
+    private val jda: JDA,
+) {
+    fun populate(
+        model: Model,
+        guildId: Long,
+        discordId: Long,
+        user: OAuth2User,
+    ): Guild? {
+        val guild = jda.getGuildById(guildId) ?: return null
+        val profile = userService.getUserById(discordId, guildId)
+        model.addAttribute("guildId", guildId.toString())
+        model.addAttribute("guildName", guild.name)
+        model.addAttribute("balance", profile?.socialCredit ?: 0L)
+        model.addAttribute("tobyCoins", profile?.tobyCoins ?: 0L)
+        model.addAttribute("marketPrice", marketService.getMarket(guildId)?.price ?: 0.0)
+        model.addAttribute("jackpotPool", jackpotService.getPool(guildId))
+        model.addAttribute("username", user.displayName())
+        return guild
+    }
+}

--- a/web/src/main/kotlin/web/casino/CasinoResponse.kt
+++ b/web/src/main/kotlin/web/casino/CasinoResponse.kt
@@ -1,0 +1,16 @@
+package web.casino
+
+/**
+ * Marker for casino-game JSON response DTOs that share the
+ * `{ ok, error, ... }` envelope. Implemented by every per-game response
+ * (RollResponse, FlipResponse, SpinResponse, ScratchResponse,
+ * StartResponse, PlayResponse) so [CasinoOutcomeMapper] can build their
+ * error variants generically.
+ *
+ * Game-specific success fields stay on the concrete data class — only
+ * the failure shape needs to be unified.
+ */
+interface CasinoResponseLike {
+    val ok: Boolean
+    val error: String?
+}

--- a/web/src/main/kotlin/web/controller/CoinflipController.kt
+++ b/web/src/main/kotlin/web/controller/CoinflipController.kt
@@ -3,10 +3,6 @@ package web.controller
 import database.economy.Coinflip
 import database.service.CoinflipService
 import database.service.CoinflipService.FlipOutcome
-import database.service.JackpotService
-import database.service.TobyCoinMarketService
-import database.service.UserService
-import net.dv8tion.jda.api.JDA
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.security.oauth2.core.user.OAuth2User
@@ -19,9 +15,11 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseBody
 import org.springframework.web.servlet.mvc.support.RedirectAttributes
+import web.casino.CasinoOutcomeMapper
+import web.casino.CasinoPageContext
+import web.casino.CasinoResponseLike
 import web.service.EconomyWebService
 import web.util.WebGuildAccess
-import web.util.displayName
 
 /**
  * Web surface for the `/coinflip` minigame. GET renders the picker UI
@@ -37,11 +35,10 @@ import web.util.displayName
 class CoinflipController(
     private val coinflipService: CoinflipService,
     private val economyWebService: EconomyWebService,
-    private val userService: UserService,
-    private val jackpotService: JackpotService,
-    private val marketService: TobyCoinMarketService,
-    private val jda: JDA
+    private val pageContext: CasinoPageContext,
 ) {
+
+    private val errors = CasinoOutcomeMapper { msg -> FlipResponse(false, msg) }
 
     @GetMapping
     fun page(
@@ -52,26 +49,13 @@ class CoinflipController(
     ): String = WebGuildAccess.requireMemberForPage(
         user, guildId, economyWebService, ra, lobbyPath = "/casino/guilds"
     ) { discordId ->
-        val guild = jda.getGuildById(guildId) ?: run {
+        pageContext.populate(model, guildId, discordId, user) ?: run {
             ra.addFlashAttribute("error", "Bot is not in that server.")
             return@requireMemberForPage "redirect:/casino/guilds"
         }
-
-        val profile = userService.getUserById(discordId, guildId)
-        val balance = profile?.socialCredit ?: 0L
-        val tobyCoins = profile?.tobyCoins ?: 0L
-        val marketPrice = marketService.getMarket(guildId)?.price ?: 0.0
-
-        model.addAttribute("guildId", guildId.toString())
-        model.addAttribute("guildName", guild.name)
-        model.addAttribute("balance", balance)
-        model.addAttribute("tobyCoins", tobyCoins)
-        model.addAttribute("marketPrice", marketPrice)
         model.addAttribute("minStake", Coinflip.MIN_STAKE)
         model.addAttribute("maxStake", Coinflip.MAX_STAKE)
         model.addAttribute("multiplier", Coinflip.DEFAULT_MULTIPLIER)
-        model.addAttribute("jackpotPool", jackpotService.getPool(guildId))
-        model.addAttribute("username", user.displayName())
         "coinflip"
     }
 
@@ -82,20 +66,10 @@ class CoinflipController(
         @RequestBody request: FlipRequest,
         @AuthenticationPrincipal user: OAuth2User
     ): ResponseEntity<FlipResponse> = WebGuildAccess.requireMemberForJson(
-        user, guildId, economyWebService,
-        errorBuilder = { status ->
-            ResponseEntity.status(status).body(
-                FlipResponse(
-                    false,
-                    if (status == 401) "Not signed in." else "You are not a member of that server."
-                )
-            )
-        }
+        user, guildId, economyWebService, errorBuilder = errors.errorBuilder
     ) { discordId ->
         val side = parseSide(request.side)
-            ?: return@requireMemberForJson ResponseEntity.badRequest().body(
-                FlipResponse(false, "Pick a side: HEADS or TAILS.")
-            )
+            ?: return@requireMemberForJson errors.badRequest("Pick a side: HEADS or TAILS.")
 
         when (val outcome = coinflipService.flip(discordId, guildId, request.stake, side, request.autoTopUp)) {
             is FlipOutcome.Win -> ResponseEntity.ok(
@@ -128,21 +102,10 @@ class CoinflipController(
                 )
             )
 
-            is FlipOutcome.InsufficientCredits -> ResponseEntity.badRequest().body(
-                FlipResponse(false, "Need ${outcome.stake} credits, you have ${outcome.have}.")
-            )
-
-            is FlipOutcome.InsufficientCoinsForTopUp -> ResponseEntity.badRequest().body(
-                FlipResponse(false, "Need ${outcome.needed} TOBY to cover the shortfall, you have ${outcome.have}.")
-            )
-
-            is FlipOutcome.InvalidStake -> ResponseEntity.badRequest().body(
-                FlipResponse(false, "Stake must be between ${outcome.min} and ${outcome.max} credits.")
-            )
-
-            FlipOutcome.UnknownUser -> ResponseEntity.badRequest().body(
-                FlipResponse(false, "No user record yet. Try another TobyBot command first.")
-            )
+            is FlipOutcome.InsufficientCredits -> errors.insufficientCredits(outcome.stake, outcome.have)
+            is FlipOutcome.InsufficientCoinsForTopUp -> errors.insufficientCoinsForTopUp(outcome.needed, outcome.have)
+            is FlipOutcome.InvalidStake -> errors.invalidStake(outcome.min, outcome.max)
+            FlipOutcome.UnknownUser -> errors.unknownUser()
         }
     }
 
@@ -156,8 +119,8 @@ class CoinflipController(
 data class FlipRequest(val side: String = "", val stake: Long = 0, val autoTopUp: Boolean = false)
 
 data class FlipResponse(
-    val ok: Boolean,
-    val error: String? = null,
+    override val ok: Boolean,
+    override val error: String? = null,
     val landed: String? = null,
     val predicted: String? = null,
     val net: Long? = null,
@@ -168,4 +131,4 @@ data class FlipResponse(
     val soldTobyCoins: Long? = null,
     val newPrice: Double? = null,
     val lossTribute: Long? = null
-)
+) : CasinoResponseLike

--- a/web/src/main/kotlin/web/controller/DiceController.kt
+++ b/web/src/main/kotlin/web/controller/DiceController.kt
@@ -3,10 +3,6 @@ package web.controller
 import database.economy.Dice
 import database.service.DiceService
 import database.service.DiceService.RollOutcome
-import database.service.JackpotService
-import database.service.TobyCoinMarketService
-import database.service.UserService
-import net.dv8tion.jda.api.JDA
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.security.oauth2.core.user.OAuth2User
@@ -19,9 +15,11 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseBody
 import org.springframework.web.servlet.mvc.support.RedirectAttributes
+import web.casino.CasinoOutcomeMapper
+import web.casino.CasinoPageContext
+import web.casino.CasinoResponseLike
 import web.service.EconomyWebService
 import web.util.WebGuildAccess
-import web.util.displayName
 
 /**
  * Web surface for the `/dice` minigame. GET renders the picker UI;
@@ -35,11 +33,10 @@ import web.util.displayName
 class DiceController(
     private val diceService: DiceService,
     private val economyWebService: EconomyWebService,
-    private val userService: UserService,
-    private val jackpotService: JackpotService,
-    private val marketService: TobyCoinMarketService,
-    private val jda: JDA
+    private val pageContext: CasinoPageContext,
 ) {
+
+    private val errors = CasinoOutcomeMapper { msg -> RollResponse(false, msg) }
 
     @GetMapping
     fun page(
@@ -50,27 +47,14 @@ class DiceController(
     ): String = WebGuildAccess.requireMemberForPage(
         user, guildId, economyWebService, ra, lobbyPath = "/casino/guilds"
     ) { discordId ->
-        val guild = jda.getGuildById(guildId) ?: run {
+        pageContext.populate(model, guildId, discordId, user) ?: run {
             ra.addFlashAttribute("error", "Bot is not in that server.")
             return@requireMemberForPage "redirect:/casino/guilds"
         }
-
-        val profile = userService.getUserById(discordId, guildId)
-        val balance = profile?.socialCredit ?: 0L
-        val tobyCoins = profile?.tobyCoins ?: 0L
-        val marketPrice = marketService.getMarket(guildId)?.price ?: 0.0
-
-        model.addAttribute("guildId", guildId.toString())
-        model.addAttribute("guildName", guild.name)
-        model.addAttribute("balance", balance)
-        model.addAttribute("tobyCoins", tobyCoins)
-        model.addAttribute("marketPrice", marketPrice)
         model.addAttribute("minStake", Dice.MIN_STAKE)
         model.addAttribute("maxStake", Dice.MAX_STAKE)
         model.addAttribute("sides", Dice.DEFAULT_SIDES)
         model.addAttribute("multiplier", Dice.DEFAULT_MULTIPLIER)
-        model.addAttribute("jackpotPool", jackpotService.getPool(guildId))
-        model.addAttribute("username", user.displayName())
         "dice"
     }
 
@@ -81,15 +65,7 @@ class DiceController(
         @RequestBody request: RollRequest,
         @AuthenticationPrincipal user: OAuth2User
     ): ResponseEntity<RollResponse> = WebGuildAccess.requireMemberForJson(
-        user, guildId, economyWebService,
-        errorBuilder = { status ->
-            ResponseEntity.status(status).body(
-                RollResponse(
-                    false,
-                    if (status == 401) "Not signed in." else "You are not a member of that server."
-                )
-            )
-        }
+        user, guildId, economyWebService, errorBuilder = errors.errorBuilder
     ) { discordId ->
         when (val outcome = diceService.roll(discordId, guildId, request.stake, request.prediction, request.autoTopUp)) {
             is RollOutcome.Win -> ResponseEntity.ok(
@@ -122,25 +98,13 @@ class DiceController(
                 )
             )
 
-            is RollOutcome.InsufficientCredits -> ResponseEntity.badRequest().body(
-                RollResponse(false, "Need ${outcome.stake} credits, you have ${outcome.have}.")
-            )
+            is RollOutcome.InsufficientCredits -> errors.insufficientCredits(outcome.stake, outcome.have)
+            is RollOutcome.InsufficientCoinsForTopUp -> errors.insufficientCoinsForTopUp(outcome.needed, outcome.have)
+            is RollOutcome.InvalidStake -> errors.invalidStake(outcome.min, outcome.max)
+            is RollOutcome.InvalidPrediction ->
+                errors.badRequest("Pick a number between ${outcome.min} and ${outcome.max}.")
 
-            is RollOutcome.InsufficientCoinsForTopUp -> ResponseEntity.badRequest().body(
-                RollResponse(false, "Need ${outcome.needed} TOBY to cover the shortfall, you have ${outcome.have}.")
-            )
-
-            is RollOutcome.InvalidStake -> ResponseEntity.badRequest().body(
-                RollResponse(false, "Stake must be between ${outcome.min} and ${outcome.max} credits.")
-            )
-
-            is RollOutcome.InvalidPrediction -> ResponseEntity.badRequest().body(
-                RollResponse(false, "Pick a number between ${outcome.min} and ${outcome.max}.")
-            )
-
-            RollOutcome.UnknownUser -> ResponseEntity.badRequest().body(
-                RollResponse(false, "No user record yet. Try another TobyBot command first.")
-            )
+            RollOutcome.UnknownUser -> errors.unknownUser()
         }
     }
 }
@@ -148,8 +112,8 @@ class DiceController(
 data class RollRequest(val prediction: Int = 0, val stake: Long = 0, val autoTopUp: Boolean = false)
 
 data class RollResponse(
-    val ok: Boolean,
-    val error: String? = null,
+    override val ok: Boolean,
+    override val error: String? = null,
     val landed: Int? = null,
     val predicted: Int? = null,
     val net: Long? = null,
@@ -160,4 +124,4 @@ data class RollResponse(
     val soldTobyCoins: Long? = null,
     val newPrice: Double? = null,
     val lossTribute: Long? = null
-)
+) : CasinoResponseLike

--- a/web/src/main/kotlin/web/controller/EconomyController.kt
+++ b/web/src/main/kotlin/web/controller/EconomyController.kt
@@ -20,6 +20,7 @@ import database.service.EconomyTradeService.TradeOutcome
 import database.service.SocialCreditAwardService
 import web.service.PricePoint
 import web.service.TradeMarker
+import web.util.WebGuildAccess
 import web.util.discordIdOrNull
 import web.util.displayName
 
@@ -57,24 +58,18 @@ class EconomyController(
         @AuthenticationPrincipal user: OAuth2User,
         model: Model,
         ra: RedirectAttributes
-    ): String {
-        val discordId = user.discordIdOrNull()
-            ?: return "redirect:/economy/guilds"
-
-        if (!economyWebService.isMember(discordId, guildId)) {
-            ra.addFlashAttribute("error", "You are not a member of that server.")
-            return "redirect:/economy/guilds"
-        }
-
+    ): String = WebGuildAccess.requireMemberForPage(
+        user, guildId, economyWebService, ra, lobbyPath = "/economy/guilds"
+    ) { discordId ->
         val view = economyWebService.getEconomyView(guildId, discordId) ?: run {
             ra.addFlashAttribute("error", "Bot is not in that server.")
-            return "redirect:/economy/guilds"
+            return@requireMemberForPage "redirect:/economy/guilds"
         }
 
         model.addAttribute("view", view)
         model.addAttribute("guildId", guildId.toString())
         model.addAttribute("username", user.displayName())
-        return "economy"
+        "economy"
     }
 
     @GetMapping("/{guildId}/history")
@@ -83,13 +78,10 @@ class EconomyController(
         @PathVariable guildId: Long,
         @RequestParam(defaultValue = "1d") window: String,
         @AuthenticationPrincipal user: OAuth2User
-    ): ResponseEntity<HistoryResponse> {
-        val discordId = user.discordIdOrNull()
-            ?: return ResponseEntity.status(401).build()
-        if (!economyWebService.isMember(discordId, guildId)) {
-            return ResponseEntity.status(403).build()
-        }
-        return ResponseEntity.ok(
+    ): ResponseEntity<HistoryResponse> = WebGuildAccess.requireMemberForJsonNoBody(
+        user, guildId, economyWebService
+    ) { _ ->
+        ResponseEntity.ok(
             HistoryResponse(
                 points = economyWebService.getHistory(guildId, window),
                 trades = economyWebService.getTrades(guildId, window)
@@ -122,16 +114,23 @@ class EconomyController(
         guildId: Long,
         request: TradeRequest,
         action: (Long) -> TradeOutcome
-    ): ResponseEntity<TradeResponse> {
-        val discordId = user.discordIdOrNull()
-            ?: return ResponseEntity.status(401).body(TradeResponse(false, "Not signed in."))
-        if (!economyWebService.isMember(discordId, guildId)) {
-            return ResponseEntity.status(403).body(TradeResponse(false, "You are not a member of that server."))
+    ): ResponseEntity<TradeResponse> = WebGuildAccess.requireMemberForJson(
+        user, guildId, economyWebService,
+        errorBuilder = { status ->
+            ResponseEntity.status(status).body(
+                TradeResponse(
+                    false,
+                    if (status == 401) "Not signed in." else "You are not a member of that server."
+                )
+            )
         }
+    ) { discordId ->
         if (request.amount <= 0) {
-            return ResponseEntity.badRequest().body(TradeResponse(false, "Amount must be positive."))
+            return@requireMemberForJson ResponseEntity.badRequest().body(
+                TradeResponse(false, "Amount must be positive.")
+            )
         }
-        return when (val outcome = action(discordId)) {
+        when (val outcome = action(discordId)) {
             is TradeOutcome.Ok -> {
                 val granted = awardService.award(
                     discordId = discordId,

--- a/web/src/main/kotlin/web/controller/HighlowController.kt
+++ b/web/src/main/kotlin/web/controller/HighlowController.kt
@@ -3,11 +3,7 @@ package web.controller
 import database.economy.Highlow
 import database.service.HighlowService
 import database.service.HighlowService.PlayOutcome
-import database.service.JackpotService
-import database.service.TobyCoinMarketService
-import database.service.UserService
 import jakarta.servlet.http.HttpSession
-import net.dv8tion.jda.api.JDA
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.security.oauth2.core.user.OAuth2User
@@ -20,20 +16,22 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseBody
 import org.springframework.web.servlet.mvc.support.RedirectAttributes
+import web.casino.CasinoOutcomeMapper
+import web.casino.CasinoPageContext
+import web.casino.CasinoResponseLike
 import web.service.EconomyWebService
 import web.util.WebGuildAccess
-import web.util.displayName
 
 @Controller
 @RequestMapping("/casino/{guildId}/highlow")
 class HighlowController(
     private val highlowService: HighlowService,
     private val economyWebService: EconomyWebService,
-    private val userService: UserService,
-    private val jackpotService: JackpotService,
-    private val marketService: TobyCoinMarketService,
-    private val jda: JDA
+    private val pageContext: CasinoPageContext,
 ) {
+
+    private val startErrors = CasinoOutcomeMapper { msg -> StartResponse(false, msg) }
+    private val playErrors = CasinoOutcomeMapper { msg -> PlayResponse(false, msg) }
 
     @GetMapping
     fun page(
@@ -45,15 +43,10 @@ class HighlowController(
     ): String = WebGuildAccess.requireMemberForPage(
         user, guildId, economyWebService, ra, lobbyPath = "/casino/guilds"
     ) { discordId ->
-        val guild = jda.getGuildById(guildId) ?: run {
+        pageContext.populate(model, guildId, discordId, user) ?: run {
             ra.addFlashAttribute("error", "Bot is not in that server.")
             return@requireMemberForPage "redirect:/casino/guilds"
         }
-
-        val profile = userService.getUserById(discordId, guildId)
-        val balance = profile?.socialCredit ?: 0L
-        val tobyCoins = profile?.tobyCoins ?: 0L
-        val marketPrice = marketService.getMarket(guildId)?.price ?: 0.0
 
         // Stake commits first, anchor is dealt after the player locks it.
         // If a round is already locked in this session, surface it so the
@@ -61,11 +54,6 @@ class HighlowController(
         val activeAnchor = activeAnchor(session, guildId)
         val activeStake = activeStake(session, guildId)
 
-        model.addAttribute("guildId", guildId.toString())
-        model.addAttribute("guildName", guild.name)
-        model.addAttribute("balance", balance)
-        model.addAttribute("tobyCoins", tobyCoins)
-        model.addAttribute("marketPrice", marketPrice)
         model.addAttribute("minStake", Highlow.MIN_STAKE)
         model.addAttribute("maxStake", Highlow.MAX_STAKE)
         model.addAttribute("anchor", activeAnchor)
@@ -77,8 +65,6 @@ class HighlowController(
             highlowService.payoutMultiplier(it, Highlow.Direction.LOWER)
         })
         model.addAttribute("activeStake", activeStake)
-        model.addAttribute("jackpotPool", jackpotService.getPool(guildId))
-        model.addAttribute("username", user.displayName())
         "highlow"
     }
 
@@ -90,20 +76,10 @@ class HighlowController(
         @AuthenticationPrincipal user: OAuth2User,
         session: HttpSession
     ): ResponseEntity<StartResponse> = WebGuildAccess.requireMemberForJson(
-        user, guildId, economyWebService,
-        errorBuilder = { status ->
-            ResponseEntity.status(status).body(
-                StartResponse(
-                    false,
-                    if (status == 401) "Not signed in." else "You are not a member of that server."
-                )
-            )
-        }
+        user, guildId, economyWebService, errorBuilder = startErrors.errorBuilder
     ) { _ ->
         if (request.stake < Highlow.MIN_STAKE || request.stake > Highlow.MAX_STAKE) {
-            return@requireMemberForJson ResponseEntity.badRequest().body(
-                StartResponse(false, "Stake must be between ${Highlow.MIN_STAKE} and ${Highlow.MAX_STAKE} credits.")
-            )
+            return@requireMemberForJson startErrors.invalidStake(Highlow.MIN_STAKE, Highlow.MAX_STAKE)
         }
 
         val anchor = highlowService.dealAnchor()
@@ -130,27 +106,15 @@ class HighlowController(
         @AuthenticationPrincipal user: OAuth2User,
         session: HttpSession
     ): ResponseEntity<PlayResponse> = WebGuildAccess.requireMemberForJson(
-        user, guildId, economyWebService,
-        errorBuilder = { status ->
-            ResponseEntity.status(status).body(
-                PlayResponse(
-                    false,
-                    if (status == 401) "Not signed in." else "You are not a member of that server."
-                )
-            )
-        }
+        user, guildId, economyWebService, errorBuilder = playErrors.errorBuilder
     ) { discordId ->
         val direction = parseDirection(request.direction)
-            ?: return@requireMemberForJson ResponseEntity.badRequest().body(
-                PlayResponse(false, "Pick a direction: HIGHER or LOWER.")
-            )
+            ?: return@requireMemberForJson playErrors.badRequest("Pick a direction: HIGHER or LOWER.")
 
         val anchor = activeAnchor(session, guildId)
         val stake = activeStake(session, guildId)
         if (anchor == null || stake == null) {
-            return@requireMemberForJson ResponseEntity.badRequest().body(
-                PlayResponse(false, "No active round — lock a stake first.")
-            )
+            return@requireMemberForJson playErrors.badRequest("No active round — lock a stake first.")
         }
         val autoTopUp = activeAutoTopUp(session, guildId)
 
@@ -199,21 +163,10 @@ class HighlowController(
                 )
             )
 
-            is PlayOutcome.InsufficientCredits -> ResponseEntity.badRequest().body(
-                PlayResponse(false, "Need ${outcome.stake} credits, you have ${outcome.have}.")
-            )
-
-            is PlayOutcome.InsufficientCoinsForTopUp -> ResponseEntity.badRequest().body(
-                PlayResponse(false, "Need ${outcome.needed} TOBY to cover the shortfall, you have ${outcome.have}.")
-            )
-
-            is PlayOutcome.InvalidStake -> ResponseEntity.badRequest().body(
-                PlayResponse(false, "Stake must be between ${outcome.min} and ${outcome.max} credits.")
-            )
-
-            PlayOutcome.UnknownUser -> ResponseEntity.badRequest().body(
-                PlayResponse(false, "No user record yet. Try another TobyBot command first.")
-            )
+            is PlayOutcome.InsufficientCredits -> playErrors.insufficientCredits(outcome.stake, outcome.have)
+            is PlayOutcome.InsufficientCoinsForTopUp -> playErrors.insufficientCoinsForTopUp(outcome.needed, outcome.have)
+            is PlayOutcome.InvalidStake -> playErrors.invalidStake(outcome.min, outcome.max)
+            PlayOutcome.UnknownUser -> playErrors.unknownUser()
         }
     }
 
@@ -266,19 +219,19 @@ class HighlowController(
 data class StartRequest(val stake: Long = 0, val autoTopUp: Boolean = false)
 
 data class StartResponse(
-    val ok: Boolean,
-    val error: String? = null,
+    override val ok: Boolean,
+    override val error: String? = null,
     val anchor: Int? = null,
     val anchorLabel: String? = null,
     val higherMultiplier: Double? = null,
     val lowerMultiplier: Double? = null
-)
+) : CasinoResponseLike
 
 data class PlayRequest(val direction: String = "")
 
 data class PlayResponse(
-    val ok: Boolean,
-    val error: String? = null,
+    override val ok: Boolean,
+    override val error: String? = null,
     val anchor: Int? = null,
     val next: Int? = null,
     val direction: String? = null,
@@ -291,4 +244,4 @@ data class PlayResponse(
     val soldTobyCoins: Long? = null,
     val newPrice: Double? = null,
     val lossTribute: Long? = null
-)
+) : CasinoResponseLike

--- a/web/src/main/kotlin/web/controller/LeaderboardController.kt
+++ b/web/src/main/kotlin/web/controller/LeaderboardController.kt
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.servlet.mvc.support.RedirectAttributes
 import web.service.LeaderboardSort
 import web.service.LeaderboardWebService
+import web.util.WebGuildAccess
 import web.util.discordIdOrNull
 import web.util.displayName
 
@@ -43,23 +44,18 @@ class LeaderboardController(
         @AuthenticationPrincipal user: OAuth2User,
         model: Model,
         ra: RedirectAttributes
-    ): String {
-        val discordId = user.discordIdOrNull()
-            ?: return "redirect:/leaderboards"
-
-        if (!leaderboardWebService.isMember(discordId, guildId)) {
-            ra.addFlashAttribute("error", "You are not a member of that server.")
-            return "redirect:/leaderboards"
-        }
-
+    ): String = WebGuildAccess.requireForPage(
+        user, guildId, ra, lobbyPath = "/leaderboards",
+        check = leaderboardWebService::isMember,
+    ) { _ ->
         val view = leaderboardWebService.getGuildView(guildId, LeaderboardSort.fromQuery(sort)) ?: run {
             ra.addFlashAttribute("error", "Bot is not in that server.")
-            return "redirect:/leaderboards"
+            return@requireForPage "redirect:/leaderboards"
         }
 
         model.addAttribute("view", view)
         model.addAttribute("guildId", guildId.toString())
         model.addAttribute("username", user.displayName())
-        return "leaderboard"
+        "leaderboard"
     }
 }

--- a/web/src/main/kotlin/web/controller/ModerationController.kt
+++ b/web/src/main/kotlin/web/controller/ModerationController.kt
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseBody
 import org.springframework.web.servlet.mvc.support.RedirectAttributes
 import web.service.ModerationWebService
+import web.util.WebGuildAccess
 import web.util.discordIdOrNull
 import web.util.discordIdString
 import web.util.displayName
@@ -56,25 +57,21 @@ class ModerationController(
         @AuthenticationPrincipal user: OAuth2User,
         model: Model,
         ra: RedirectAttributes
-    ): String {
-        val discordId = user.discordIdOrNull()
-            ?: return "redirect:/moderation/guilds"
-
-        if (!moderationWebService.canModerate(discordId, guildId)) {
-            ra.addFlashAttribute("error", "You are not allowed to moderate that server.")
-            return "redirect:/moderation/guilds"
-        }
-
+    ): String = WebGuildAccess.requireForPage(
+        user, guildId, ra, lobbyPath = "/moderation/guilds",
+        check = moderationWebService::canModerate,
+        deniedMessage = "You are not allowed to moderate that server.",
+    ) { discordId ->
         val overview = moderationWebService.getGuildOverview(guildId) ?: run {
             ra.addFlashAttribute("error", "Bot is not in that server.")
-            return "redirect:/moderation/guilds"
+            return@requireForPage "redirect:/moderation/guilds"
         }
 
         model.addAttribute("overview", overview)
         model.addAttribute("isOwner", moderationWebService.isOwner(discordId, guildId))
         model.addAttribute("username", user.displayName())
         model.addAttribute("actorDiscordId", discordId.toString())
-        return "moderation"
+        "moderation"
     }
 
     @PostMapping("/{guildId}/user/{targetDiscordId}/permission", consumes = ["application/json"])
@@ -84,13 +81,11 @@ class ModerationController(
         @PathVariable targetDiscordId: Long,
         @RequestBody body: PermissionRequest,
         @AuthenticationPrincipal user: OAuth2User
-    ): ResponseEntity<ApiResult> {
-        val actor = user.discordIdOrNull()
-            ?: return ResponseEntity.status(401).body(ApiResult(false, "Not signed in."))
+    ): ResponseEntity<ApiResult> = withSignedInActor(user, ::ApiResult) { actor ->
         val perm = runCatching { UserDto.Permissions.valueOf(body.permission.uppercase()) }.getOrNull()
-            ?: return ResponseEntity.badRequest().body(ApiResult(false, "Unknown permission."))
+            ?: return@withSignedInActor ResponseEntity.badRequest().body(ApiResult(false, "Unknown permission."))
         val error = moderationWebService.togglePermission(actor, guildId, targetDiscordId, perm)
-        return if (error != null) ResponseEntity.badRequest().body(ApiResult(false, error))
+        if (error != null) ResponseEntity.badRequest().body(ApiResult(false, error))
         else ResponseEntity.ok(ApiResult(true, null))
     }
 
@@ -101,11 +96,9 @@ class ModerationController(
         @PathVariable targetDiscordId: Long,
         @RequestBody body: SocialCreditRequest,
         @AuthenticationPrincipal user: OAuth2User
-    ): ResponseEntity<ApiResult> {
-        val actor = user.discordIdOrNull()
-            ?: return ResponseEntity.status(401).body(ApiResult(false, "Not signed in."))
+    ): ResponseEntity<ApiResult> = withSignedInActor(user, ::ApiResult) { actor ->
         val error = moderationWebService.adjustSocialCredit(actor, guildId, targetDiscordId, body.delta)
-        return if (error != null) ResponseEntity.badRequest().body(ApiResult(false, error))
+        if (error != null) ResponseEntity.badRequest().body(ApiResult(false, error))
         else ResponseEntity.ok(ApiResult(true, null))
     }
 
@@ -115,13 +108,11 @@ class ModerationController(
         @PathVariable guildId: Long,
         @RequestBody body: ConfigRequest,
         @AuthenticationPrincipal user: OAuth2User
-    ): ResponseEntity<ApiResult> {
-        val actor = user.discordIdOrNull()
-            ?: return ResponseEntity.status(401).body(ApiResult(false, "Not signed in."))
+    ): ResponseEntity<ApiResult> = withSignedInActor(user, ::ApiResult) { actor ->
         val key = runCatching { ConfigDto.Configurations.valueOf(body.key.uppercase()) }.getOrNull()
-            ?: return ResponseEntity.badRequest().body(ApiResult(false, "Unknown config key."))
+            ?: return@withSignedInActor ResponseEntity.badRequest().body(ApiResult(false, "Unknown config key."))
         val error = moderationWebService.updateConfig(actor, guildId, key, body.value)
-        return if (error != null) ResponseEntity.badRequest().body(ApiResult(false, error))
+        if (error != null) ResponseEntity.badRequest().body(ApiResult(false, error))
         else ResponseEntity.ok(ApiResult(true, null))
     }
 
@@ -131,11 +122,9 @@ class ModerationController(
         @PathVariable guildId: Long,
         @RequestBody body: KickRequest,
         @AuthenticationPrincipal user: OAuth2User
-    ): ResponseEntity<ApiResult> {
-        val actor = user.discordIdOrNull()
-            ?: return ResponseEntity.status(401).body(ApiResult(false, "Not signed in."))
+    ): ResponseEntity<ApiResult> = withSignedInActor(user, ::ApiResult) { actor ->
         val error = moderationWebService.kickMember(actor, guildId, body.targetDiscordId, body.reason)
-        return if (error != null) ResponseEntity.badRequest().body(ApiResult(false, error))
+        if (error != null) ResponseEntity.badRequest().body(ApiResult(false, error))
         else ResponseEntity.ok(ApiResult(true, null))
     }
 
@@ -145,14 +134,15 @@ class ModerationController(
         @PathVariable guildId: Long,
         @RequestBody body: MoveRequest,
         @AuthenticationPrincipal user: OAuth2User
-    ): ResponseEntity<MoveResponse> {
-        val actor = user.discordIdOrNull()
-            ?: return ResponseEntity.status(401).body(MoveResponse(false, "Not signed in."))
+    ): ResponseEntity<MoveResponse> = withSignedInActor(
+        user, { ok, err -> MoveResponse(ok, err) }
+    ) { actor ->
         val result = moderationWebService.moveMembers(actor, guildId, body.targetChannelId, body.memberIds)
         if (result.error != null) {
-            return ResponseEntity.badRequest().body(MoveResponse(false, result.error, result.moved, result.skipped))
+            ResponseEntity.badRequest().body(MoveResponse(false, result.error, result.moved, result.skipped))
+        } else {
+            ResponseEntity.ok(MoveResponse(true, null, result.moved, result.skipped))
         }
-        return ResponseEntity.ok(MoveResponse(true, null, result.moved, result.skipped))
     }
 
     @PostMapping("/{guildId}/voice/{channelId}/mute", consumes = ["application/json"])
@@ -162,14 +152,15 @@ class ModerationController(
         @PathVariable channelId: Long,
         @RequestBody body: MuteRequest,
         @AuthenticationPrincipal user: OAuth2User
-    ): ResponseEntity<MuteResponse> {
-        val actor = user.discordIdOrNull()
-            ?: return ResponseEntity.status(401).body(MuteResponse(false, "Not signed in."))
+    ): ResponseEntity<MuteResponse> = withSignedInActor(
+        user, { ok, err -> MuteResponse(ok, err) }
+    ) { actor ->
         val result = moderationWebService.muteVoiceChannel(actor, guildId, channelId, body.mute)
         if (result.error != null) {
-            return ResponseEntity.badRequest().body(MuteResponse(false, result.error, result.changed, result.skipped))
+            ResponseEntity.badRequest().body(MuteResponse(false, result.error, result.changed, result.skipped))
+        } else {
+            ResponseEntity.ok(MuteResponse(true, null, result.changed, result.skipped))
         }
-        return ResponseEntity.ok(MuteResponse(true, null, result.changed, result.skipped))
     }
 
     @PostMapping("/{guildId}/poll", consumes = ["application/json"])
@@ -178,12 +169,27 @@ class ModerationController(
         @PathVariable guildId: Long,
         @RequestBody body: PollRequest,
         @AuthenticationPrincipal user: OAuth2User
-    ): ResponseEntity<ApiResult> {
-        val actor = user.discordIdOrNull()
-            ?: return ResponseEntity.status(401).body(ApiResult(false, "Not signed in."))
+    ): ResponseEntity<ApiResult> = withSignedInActor(user, ::ApiResult) { actor ->
         val error = moderationWebService.createPoll(actor, guildId, body.channelId, body.question, body.options)
-        return if (error != null) ResponseEntity.badRequest().body(ApiResult(false, error))
+        if (error != null) ResponseEntity.badRequest().body(ApiResult(false, error))
         else ResponseEntity.ok(ApiResult(true, null))
+    }
+
+    /**
+     * Per-action JSON endpoints don't re-check membership — the service
+     * does its own permission audit on the actor — so all the controller
+     * needs is "401 if not signed in." This collapses 6 copies of the
+     * same `discordIdOrNull() ?: return ResponseEntity.status(401)…`
+     * into one place.
+     */
+    private inline fun <T : Any> withSignedInActor(
+        user: OAuth2User,
+        noinline notSignedInBuilder: (ok: Boolean, error: String) -> T,
+        block: (actor: Long) -> ResponseEntity<T>,
+    ): ResponseEntity<T> {
+        val actor = user.discordIdOrNull()
+            ?: return ResponseEntity.status(401).body(notSignedInBuilder(false, "Not signed in."))
+        return block(actor)
     }
 }
 

--- a/web/src/main/kotlin/web/controller/ProfileController.kt
+++ b/web/src/main/kotlin/web/controller/ProfileController.kt
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.servlet.mvc.support.RedirectAttributes
 import web.service.ProfileWebService
+import web.util.WebGuildAccess
 import web.util.discordIdOrNull
 import web.util.displayName
 
@@ -42,22 +43,17 @@ class ProfileController(
         @AuthenticationPrincipal user: OAuth2User,
         model: Model,
         ra: RedirectAttributes
-    ): String {
-        val discordId = user.discordIdOrNull()
-            ?: return "redirect:/profile/guilds"
-
-        if (!profileWebService.isMember(discordId, guildId)) {
-            ra.addFlashAttribute("error", "You are not a member of that server.")
-            return "redirect:/profile/guilds"
-        }
-
+    ): String = WebGuildAccess.requireForPage(
+        user, guildId, ra, lobbyPath = "/profile/guilds",
+        check = profileWebService::isMember,
+    ) { discordId ->
         val profile = profileWebService.getProfile(discordId, guildId) ?: run {
             ra.addFlashAttribute("error", "Bot is not in that server.")
-            return "redirect:/profile/guilds"
+            return@requireForPage "redirect:/profile/guilds"
         }
 
         model.addAttribute("profile", profile)
         model.addAttribute("username", user.displayName())
-        return "profile"
+        "profile"
     }
 }

--- a/web/src/main/kotlin/web/controller/ScratchController.kt
+++ b/web/src/main/kotlin/web/controller/ScratchController.kt
@@ -2,12 +2,8 @@ package web.controller
 
 import database.economy.ScratchCard
 import database.economy.SlotMachine
-import database.service.JackpotService
 import database.service.ScratchService
 import database.service.ScratchService.ScratchOutcome
-import database.service.TobyCoinMarketService
-import database.service.UserService
-import net.dv8tion.jda.api.JDA
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.security.oauth2.core.user.OAuth2User
@@ -20,20 +16,21 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseBody
 import org.springframework.web.servlet.mvc.support.RedirectAttributes
+import web.casino.CasinoOutcomeMapper
+import web.casino.CasinoPageContext
+import web.casino.CasinoResponseLike
 import web.service.EconomyWebService
 import web.util.WebGuildAccess
-import web.util.displayName
 
 @Controller
 @RequestMapping("/casino/{guildId}/scratch")
 class ScratchController(
     private val scratchService: ScratchService,
     private val economyWebService: EconomyWebService,
-    private val userService: UserService,
-    private val jackpotService: JackpotService,
-    private val marketService: TobyCoinMarketService,
-    private val jda: JDA
+    private val pageContext: CasinoPageContext,
 ) {
+
+    private val errors = CasinoOutcomeMapper { msg -> ScratchResponse(false, msg) }
 
     @GetMapping
     fun page(
@@ -44,29 +41,16 @@ class ScratchController(
     ): String = WebGuildAccess.requireMemberForPage(
         user, guildId, economyWebService, ra, lobbyPath = "/casino/guilds"
     ) { discordId ->
-        val guild = jda.getGuildById(guildId) ?: run {
+        pageContext.populate(model, guildId, discordId, user) ?: run {
             ra.addFlashAttribute("error", "Bot is not in that server.")
             return@requireMemberForPage "redirect:/casino/guilds"
         }
-
-        val profile = userService.getUserById(discordId, guildId)
-        val balance = profile?.socialCredit ?: 0L
-        val tobyCoins = profile?.tobyCoins ?: 0L
-        val marketPrice = marketService.getMarket(guildId)?.price ?: 0.0
-
-        model.addAttribute("guildId", guildId.toString())
-        model.addAttribute("guildName", guild.name)
-        model.addAttribute("balance", balance)
-        model.addAttribute("tobyCoins", tobyCoins)
-        model.addAttribute("marketPrice", marketPrice)
         model.addAttribute("minStake", ScratchCard.MIN_STAKE)
         model.addAttribute("maxStake", ScratchCard.MAX_STAKE)
         model.addAttribute("cellCount", ScratchCard.CELL_COUNT)
         model.addAttribute("matchThreshold", ScratchCard.MATCH_THRESHOLD)
         model.addAttribute("matchCounts", (ScratchCard.MATCH_THRESHOLD..ScratchCard.CELL_COUNT).toList())
         model.addAttribute("payoutTable", scratchPayoutRows())
-        model.addAttribute("jackpotPool", jackpotService.getPool(guildId))
-        model.addAttribute("username", user.displayName())
         "scratch"
     }
 
@@ -91,15 +75,7 @@ class ScratchController(
         @RequestBody request: ScratchRequest,
         @AuthenticationPrincipal user: OAuth2User
     ): ResponseEntity<ScratchResponse> = WebGuildAccess.requireMemberForJson(
-        user, guildId, economyWebService,
-        errorBuilder = { status ->
-            ResponseEntity.status(status).body(
-                ScratchResponse(
-                    false,
-                    if (status == 401) "Not signed in." else "You are not a member of that server."
-                )
-            )
-        }
+        user, guildId, economyWebService, errorBuilder = errors.errorBuilder
     ) { discordId ->
         when (val outcome = scratchService.scratch(discordId, guildId, request.stake, request.autoTopUp)) {
             is ScratchOutcome.Win -> ResponseEntity.ok(
@@ -132,21 +108,10 @@ class ScratchController(
                 )
             )
 
-            is ScratchOutcome.InsufficientCredits -> ResponseEntity.badRequest().body(
-                ScratchResponse(false, "Need ${outcome.stake} credits, you have ${outcome.have}.")
-            )
-
-            is ScratchOutcome.InsufficientCoinsForTopUp -> ResponseEntity.badRequest().body(
-                ScratchResponse(false, "Need ${outcome.needed} TOBY to cover the shortfall, you have ${outcome.have}.")
-            )
-
-            is ScratchOutcome.InvalidStake -> ResponseEntity.badRequest().body(
-                ScratchResponse(false, "Stake must be between ${outcome.min} and ${outcome.max} credits.")
-            )
-
-            ScratchOutcome.UnknownUser -> ResponseEntity.badRequest().body(
-                ScratchResponse(false, "No user record yet. Try another TobyBot command first.")
-            )
+            is ScratchOutcome.InsufficientCredits -> errors.insufficientCredits(outcome.stake, outcome.have)
+            is ScratchOutcome.InsufficientCoinsForTopUp -> errors.insufficientCoinsForTopUp(outcome.needed, outcome.have)
+            is ScratchOutcome.InvalidStake -> errors.invalidStake(outcome.min, outcome.max)
+            ScratchOutcome.UnknownUser -> errors.unknownUser()
         }
     }
 }
@@ -156,8 +121,8 @@ data class ScratchPayoutRow(val symbol: String, val multipliers: List<String>)
 data class ScratchRequest(val stake: Long = 0, val autoTopUp: Boolean = false)
 
 data class ScratchResponse(
-    val ok: Boolean,
-    val error: String? = null,
+    override val ok: Boolean,
+    override val error: String? = null,
     val cells: List<String>? = null,
     val winningSymbol: String? = null,
     val matchCount: Int? = null,
@@ -169,4 +134,4 @@ data class ScratchResponse(
     val soldTobyCoins: Long? = null,
     val newPrice: Double? = null,
     val lossTribute: Long? = null
-)
+) : CasinoResponseLike

--- a/web/src/main/kotlin/web/controller/SlotsController.kt
+++ b/web/src/main/kotlin/web/controller/SlotsController.kt
@@ -1,12 +1,8 @@
 package web.controller
 
 import database.economy.SlotMachine
-import database.service.JackpotService
 import database.service.SlotsService
 import database.service.SlotsService.SpinOutcome
-import database.service.TobyCoinMarketService
-import database.service.UserService
-import net.dv8tion.jda.api.JDA
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.security.oauth2.core.user.OAuth2User
@@ -19,9 +15,11 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseBody
 import org.springframework.web.servlet.mvc.support.RedirectAttributes
+import web.casino.CasinoOutcomeMapper
+import web.casino.CasinoPageContext
+import web.casino.CasinoResponseLike
 import web.service.EconomyWebService
 import web.util.WebGuildAccess
-import web.util.displayName
 
 /**
  * Web surface for the `/slots` minigame. GET renders the reel UI with the
@@ -37,11 +35,10 @@ import web.util.displayName
 class SlotsController(
     private val slotsService: SlotsService,
     private val economyWebService: EconomyWebService,
-    private val userService: UserService,
-    private val jackpotService: JackpotService,
-    private val marketService: TobyCoinMarketService,
-    private val jda: JDA
+    private val pageContext: CasinoPageContext,
 ) {
+
+    private val errors = CasinoOutcomeMapper { msg -> SpinResponse(false, msg) }
 
     @GetMapping
     fun page(
@@ -52,26 +49,13 @@ class SlotsController(
     ): String = WebGuildAccess.requireMemberForPage(
         user, guildId, economyWebService, ra, lobbyPath = "/leaderboards"
     ) { discordId ->
-        val guild = jda.getGuildById(guildId) ?: run {
+        pageContext.populate(model, guildId, discordId, user) ?: run {
             ra.addFlashAttribute("error", "Bot is not in that server.")
             return@requireMemberForPage "redirect:/leaderboards"
         }
-
-        val profile = userService.getUserById(discordId, guildId)
-        val balance = profile?.socialCredit ?: 0L
-        val tobyCoins = profile?.tobyCoins ?: 0L
-        val marketPrice = marketService.getMarket(guildId)?.price ?: 0.0
-
-        model.addAttribute("guildId", guildId.toString())
-        model.addAttribute("guildName", guild.name)
-        model.addAttribute("balance", balance)
-        model.addAttribute("tobyCoins", tobyCoins)
-        model.addAttribute("marketPrice", marketPrice)
         model.addAttribute("minStake", SlotMachine.MIN_STAKE)
         model.addAttribute("maxStake", SlotMachine.MAX_STAKE)
         model.addAttribute("payoutTable", payoutRows())
-        model.addAttribute("jackpotPool", jackpotService.getPool(guildId))
-        model.addAttribute("username", user.displayName())
         "slots"
     }
 
@@ -82,15 +66,7 @@ class SlotsController(
         @RequestBody request: SpinRequest,
         @AuthenticationPrincipal user: OAuth2User
     ): ResponseEntity<SpinResponse> = WebGuildAccess.requireMemberForJson(
-        user, guildId, economyWebService,
-        errorBuilder = { status ->
-            ResponseEntity.status(status).body(
-                SpinResponse(
-                    false,
-                    if (status == 401) "Not signed in." else "You are not a member of that server."
-                )
-            )
-        }
+        user, guildId, economyWebService, errorBuilder = errors.errorBuilder
     ) { discordId ->
         when (val outcome = slotsService.spin(discordId, guildId, request.stake, request.autoTopUp)) {
             is SpinOutcome.Win -> ResponseEntity.ok(
@@ -123,21 +99,10 @@ class SlotsController(
                 )
             )
 
-            is SpinOutcome.InsufficientCredits -> ResponseEntity.badRequest().body(
-                SpinResponse(false, "Need ${outcome.stake} credits, you have ${outcome.have}.")
-            )
-
-            is SpinOutcome.InsufficientCoinsForTopUp -> ResponseEntity.badRequest().body(
-                SpinResponse(false, "Need ${outcome.needed} TOBY to cover the shortfall, you have ${outcome.have}.")
-            )
-
-            is SpinOutcome.InvalidStake -> ResponseEntity.badRequest().body(
-                SpinResponse(false, "Stake must be between ${outcome.min} and ${outcome.max} credits.")
-            )
-
-            SpinOutcome.UnknownUser -> ResponseEntity.badRequest().body(
-                SpinResponse(false, "No user record yet. Try another TobyBot command first.")
-            )
+            is SpinOutcome.InsufficientCredits -> errors.insufficientCredits(outcome.stake, outcome.have)
+            is SpinOutcome.InsufficientCoinsForTopUp -> errors.insufficientCoinsForTopUp(outcome.needed, outcome.have)
+            is SpinOutcome.InvalidStake -> errors.invalidStake(outcome.min, outcome.max)
+            SpinOutcome.UnknownUser -> errors.unknownUser()
         }
     }
 
@@ -159,8 +124,8 @@ class SlotsController(
 data class SpinRequest(val stake: Long = 0, val autoTopUp: Boolean = false)
 
 data class SpinResponse(
-    val ok: Boolean,
-    val error: String? = null,
+    override val ok: Boolean,
+    override val error: String? = null,
     val symbols: List<String>? = null,
     val multiplier: Long? = null,
     val payout: Long? = null,
@@ -171,6 +136,6 @@ data class SpinResponse(
     val soldTobyCoins: Long? = null,
     val newPrice: Double? = null,
     val lossTribute: Long? = null
-)
+) : CasinoResponseLike
 
 data class PayoutRow(val symbols: String, val multiplier: String)

--- a/web/src/main/kotlin/web/controller/TitlesController.kt
+++ b/web/src/main/kotlin/web/controller/TitlesController.kt
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.ResponseBody
 import org.springframework.web.servlet.mvc.support.RedirectAttributes
 import web.service.BuyWithTobyOutcome
 import web.service.TitlesWebService
+import web.util.WebGuildAccess
 import web.util.discordIdOrNull
 import web.util.displayName
 
@@ -24,6 +25,24 @@ import web.util.displayName
 class TitlesController(
     private val titlesWebService: TitlesWebService
 ) {
+
+    private val apiErrorBuilder: (Int) -> ResponseEntity<ApiResult> = { status ->
+        ResponseEntity.status(status).body(
+            ApiResult(
+                false,
+                if (status == 401) "Not signed in." else "You are not a member of that server."
+            )
+        )
+    }
+
+    private val buyWithTobyErrorBuilder: (Int) -> ResponseEntity<BuyWithTobyResponse> = { status ->
+        ResponseEntity.status(status).body(
+            BuyWithTobyResponse(
+                false,
+                if (status == 401) "Not signed in." else "You are not a member of that server."
+            )
+        )
+    }
 
     @GetMapping("/guilds")
     fun guildList(
@@ -47,20 +66,15 @@ class TitlesController(
         @AuthenticationPrincipal user: OAuth2User,
         model: Model,
         ra: RedirectAttributes
-    ): String {
-        val discordId = user.discordIdOrNull()
-            ?: return "redirect:/titles/guilds"
-
-        if (!titlesWebService.isMember(discordId, guildId)) {
-            ra.addFlashAttribute("error", "You are not a member of that server.")
-            return "redirect:/titles/guilds"
-        }
-
+    ): String = WebGuildAccess.requireForPage(
+        user, guildId, ra, lobbyPath = "/titles/guilds",
+        check = titlesWebService::isMember,
+    ) { discordId ->
         val titleShop = titlesWebService.getTitlesForGuild(guildId, discordId)
         model.addAttribute("titleShop", titleShop)
         model.addAttribute("guildId", guildId.toString())
         model.addAttribute("username", user.displayName())
-        return "titles"
+        "titles"
     }
 
     @PostMapping("/{guildId}/{titleId}/buy")
@@ -69,14 +83,11 @@ class TitlesController(
         @PathVariable guildId: Long,
         @PathVariable titleId: Long,
         @AuthenticationPrincipal user: OAuth2User
-    ): ResponseEntity<ApiResult> {
-        val actor = user.discordIdOrNull()
-            ?: return ResponseEntity.status(401).body(ApiResult(false, "Not signed in."))
-        if (!titlesWebService.isMember(actor, guildId)) {
-            return ResponseEntity.status(403).body(ApiResult(false, "You are not a member of that server."))
-        }
+    ): ResponseEntity<ApiResult> = WebGuildAccess.requireForJson(
+        user, guildId, check = titlesWebService::isMember, errorBuilder = apiErrorBuilder
+    ) { actor ->
         val error = titlesWebService.buyTitle(actor, guildId, titleId)
-        return if (error != null) ResponseEntity.badRequest().body(ApiResult(false, error))
+        if (error != null) ResponseEntity.badRequest().body(ApiResult(false, error))
         else ResponseEntity.ok(ApiResult(true, null))
     }
 
@@ -86,13 +97,10 @@ class TitlesController(
         @PathVariable guildId: Long,
         @PathVariable titleId: Long,
         @AuthenticationPrincipal user: OAuth2User
-    ): ResponseEntity<BuyWithTobyResponse> {
-        val actor = user.discordIdOrNull()
-            ?: return ResponseEntity.status(401).body(BuyWithTobyResponse(false, "Not signed in."))
-        if (!titlesWebService.isMember(actor, guildId)) {
-            return ResponseEntity.status(403).body(BuyWithTobyResponse(false, "You are not a member of that server."))
-        }
-        return when (val outcome = titlesWebService.buyTitleWithTobyCoin(actor, guildId, titleId)) {
+    ): ResponseEntity<BuyWithTobyResponse> = WebGuildAccess.requireForJson(
+        user, guildId, check = titlesWebService::isMember, errorBuilder = buyWithTobyErrorBuilder
+    ) { actor ->
+        when (val outcome = titlesWebService.buyTitleWithTobyCoin(actor, guildId, titleId)) {
             is BuyWithTobyOutcome.Ok -> ResponseEntity.ok(
                 BuyWithTobyResponse(
                     ok = true,
@@ -121,14 +129,11 @@ class TitlesController(
         @PathVariable guildId: Long,
         @PathVariable titleId: Long,
         @AuthenticationPrincipal user: OAuth2User
-    ): ResponseEntity<ApiResult> {
-        val actor = user.discordIdOrNull()
-            ?: return ResponseEntity.status(401).body(ApiResult(false, "Not signed in."))
-        if (!titlesWebService.isMember(actor, guildId)) {
-            return ResponseEntity.status(403).body(ApiResult(false, "You are not a member of that server."))
-        }
+    ): ResponseEntity<ApiResult> = WebGuildAccess.requireForJson(
+        user, guildId, check = titlesWebService::isMember, errorBuilder = apiErrorBuilder
+    ) { actor ->
         val error = titlesWebService.equipTitle(actor, guildId, titleId)
-        return if (error != null) ResponseEntity.badRequest().body(ApiResult(false, error))
+        if (error != null) ResponseEntity.badRequest().body(ApiResult(false, error))
         else ResponseEntity.ok(ApiResult(true, null))
     }
 
@@ -137,14 +142,11 @@ class TitlesController(
     fun unequip(
         @PathVariable guildId: Long,
         @AuthenticationPrincipal user: OAuth2User
-    ): ResponseEntity<ApiResult> {
-        val actor = user.discordIdOrNull()
-            ?: return ResponseEntity.status(401).body(ApiResult(false, "Not signed in."))
-        if (!titlesWebService.isMember(actor, guildId)) {
-            return ResponseEntity.status(403).body(ApiResult(false, "You are not a member of that server."))
-        }
+    ): ResponseEntity<ApiResult> = WebGuildAccess.requireForJson(
+        user, guildId, check = titlesWebService::isMember, errorBuilder = apiErrorBuilder
+    ) { actor ->
         val error = titlesWebService.unequipTitle(actor, guildId)
-        return if (error != null) ResponseEntity.badRequest().body(ApiResult(false, error))
+        if (error != null) ResponseEntity.badRequest().body(ApiResult(false, error))
         else ResponseEntity.ok(ApiResult(true, null))
     }
 }

--- a/web/src/main/kotlin/web/util/WebGuildAccess.kt
+++ b/web/src/main/kotlin/web/util/WebGuildAccess.kt
@@ -22,8 +22,19 @@ import web.service.EconomyWebService
  *   - Each endpoint shrinks to one call + the actual logic, so the
  *     interesting code is no longer buried under five lines of guard
  *     scaffolding.
+ *
+ * Two flavours of membership check are supported:
+ *   - The common case (`isMember`) — controller passes
+ *     [EconomyWebService] and the helper calls
+ *     `economyWebService.isMember(...)`.
+ *   - A custom check (e.g. `canModerate`, a stricter ACL) — controller
+ *     passes a `(discordId, guildId) -> Boolean` lambda plus the
+ *     access-denied message that should appear in the redirect flash.
  */
 object WebGuildAccess {
+
+    @PublishedApi
+    internal const val NOT_A_MEMBER = "You are not a member of that server."
 
     /**
      * Page wrapper: validates auth + guild membership; on either failure
@@ -37,12 +48,35 @@ object WebGuildAccess {
         economyWebService: EconomyWebService,
         ra: RedirectAttributes,
         lobbyPath: String,
-        block: (discordId: Long) -> String
+        block: (discordId: Long) -> String,
+    ): String = requireForPage(
+        user = user,
+        guildId = guildId,
+        ra = ra,
+        lobbyPath = lobbyPath,
+        check = economyWebService::isMember,
+        deniedMessage = NOT_A_MEMBER,
+        block = block,
+    )
+
+    /**
+     * Page wrapper that takes any `(discordId, guildId) -> Boolean`
+     * check. Use when the access predicate isn't plain "is a guild
+     * member" — e.g. ModerationController's `canModerate`.
+     */
+    inline fun requireForPage(
+        user: OAuth2User?,
+        guildId: Long,
+        ra: RedirectAttributes,
+        lobbyPath: String,
+        check: (discordId: Long, guildId: Long) -> Boolean,
+        deniedMessage: String = NOT_A_MEMBER,
+        block: (discordId: Long) -> String,
     ): String {
         val discordId = user?.discordIdOrNull()
             ?: return "redirect:$lobbyPath"
-        if (!economyWebService.isMember(discordId, guildId)) {
-            ra.addFlashAttribute("error", "You are not a member of that server.")
+        if (!check(discordId, guildId)) {
+            ra.addFlashAttribute("error", deniedMessage)
             return "redirect:$lobbyPath"
         }
         return block(discordId)
@@ -58,10 +92,27 @@ object WebGuildAccess {
         guildId: Long,
         economyWebService: EconomyWebService,
         errorBuilder: (httpStatus: Int) -> ResponseEntity<T>,
-        block: (discordId: Long) -> ResponseEntity<T>
+        block: (discordId: Long) -> ResponseEntity<T>,
+    ): ResponseEntity<T> = requireForJson(
+        user = user,
+        guildId = guildId,
+        check = economyWebService::isMember,
+        errorBuilder = errorBuilder,
+        block = block,
+    )
+
+    /**
+     * JSON wrapper variant taking any membership predicate.
+     */
+    inline fun <T : Any> requireForJson(
+        user: OAuth2User?,
+        guildId: Long,
+        check: (discordId: Long, guildId: Long) -> Boolean,
+        errorBuilder: (httpStatus: Int) -> ResponseEntity<T>,
+        block: (discordId: Long) -> ResponseEntity<T>,
     ): ResponseEntity<T> {
         val discordId = user?.discordIdOrNull() ?: return errorBuilder(401)
-        if (!economyWebService.isMember(discordId, guildId)) return errorBuilder(403)
+        if (!check(discordId, guildId)) return errorBuilder(403)
         return block(discordId)
     }
 
@@ -74,7 +125,7 @@ object WebGuildAccess {
         user: OAuth2User?,
         guildId: Long,
         economyWebService: EconomyWebService,
-        block: (discordId: Long) -> ResponseEntity<T>
+        block: (discordId: Long) -> ResponseEntity<T>,
     ): ResponseEntity<T> {
         val discordId = user?.discordIdOrNull() ?: return ResponseEntity.status(401).build()
         if (!economyWebService.isMember(discordId, guildId)) return ResponseEntity.status(403).build()

--- a/web/src/main/resources/static/js/casino-game.js
+++ b/web/src/main/resources/static/js/casino-game.js
@@ -1,0 +1,180 @@
+// Shared scaffolding for the casino-game pages — every minigame
+// (dice, coinflip, slots, scratch, highlow) used to copy the same
+// validation/fetch/spinner/toast/balance-update plumbing. Centralising
+// it here means a tweak (e.g. a different toast on network errors,
+// changing the disabled-button protocol, swapping postJson for a new
+// API helper) is one edit instead of five.
+//
+// Per-game JS now provides only the bits that are actually different:
+//   - which input fields make up the request payload (buildPayload)
+//   - any extra validation beyond "stake > 0" (validate)
+//   - the settle animation hook (startAnimation / stopAnimation)
+//   - the win/lose result renderer (renderResult)
+//
+// The helper handles: TobyTopUp wiring, form submit, button disabling,
+// fetch, settle-animation timing, balance + topup-coin updates, error
+// toasts, and the "API helper missing" / network-error fallbacks.
+
+(function (root) {
+    'use strict';
+
+    function init(cfg) {
+        const form = cfg.form;
+        const stakeInput = cfg.stakeInput;
+        const primaryBtn = cfg.primaryBtn;
+        const tobyBtn = cfg.tobyBtn;
+        const balanceEl = cfg.balanceEl;
+        const resultEl = cfg.resultEl;
+        const guildId = cfg.guildId;
+        const endpoint = cfg.endpoint;
+        const initialTobyCoins = Number(cfg.tobyCoins) || 0;
+        const initialMarketPrice = Number(cfg.marketPrice) || 0;
+        const minSettleMs = (typeof cfg.minSettleMs === 'number') ? cfg.minSettleMs : 0;
+        const failureMessage = cfg.failureMessage || 'Request failed.';
+        const postJson = (root && root.TobyApi) ? root.TobyApi.postJson : null;
+
+        const buildPayload = cfg.buildPayload || defaultBuildPayload;
+        const validate = cfg.validate || (() => null);
+        const startAnimation = cfg.startAnimation || (() => null);
+        const stopAnimation = cfg.stopAnimation || (() => undefined);
+        const renderResult = cfg.renderResult || (() => undefined);
+        // Scratch defers balance + topup-coin updates until the player has
+        // revealed every cell (so credits don't visibly drop before the
+        // suspense beat is over). It opts out and updates manually.
+        const autoApplyBalance = cfg.autoApplyBalance !== false;
+
+        if (!form || !stakeInput || !primaryBtn) {
+            return { run: function () {} };
+        }
+
+        let busy = false;
+
+        const topUp = (root.TobyTopUp && tobyBtn) ? root.TobyTopUp.init({
+            form: form,
+            stakeInput: stakeInput,
+            primaryBtn: primaryBtn,
+            tobyBtn: tobyBtn,
+            balanceEl: balanceEl,
+            tobyCoins: initialTobyCoins,
+            marketPrice: initialMarketPrice,
+            onSubmit: function (autoTopUp) { run(!!autoTopUp); },
+        }) : null;
+
+        if (!topUp) {
+            // No TOBY top-up button on this page — just hook the form's
+            // primary submit so a single-button page still works.
+            form.addEventListener('submit', function (e) {
+                e.preventDefault();
+                run(false);
+            });
+        }
+
+        function setDisabled(disabled) {
+            primaryBtn.disabled = disabled;
+            if (tobyBtn) tobyBtn.disabled = disabled;
+        }
+
+        function applyBalance(newBalance) {
+            if (typeof newBalance !== 'number') return;
+            if (balanceEl) balanceEl.textContent = newBalance;
+        }
+
+        function applyTobyDelta(body) {
+            if (!topUp) return;
+            if (typeof body.soldTobyCoins === 'number') {
+                const remaining = Math.max(0, initialTobyCoins - body.soldTobyCoins);
+                topUp.setTobyCoins(remaining);
+            }
+            if (typeof body.newPrice === 'number') topUp.setMarketPrice(body.newPrice);
+        }
+
+        function showToast(message, type) {
+            const t = root.toast;
+            if (typeof t === 'function') t(message, type || 'info');
+        }
+
+        function hideResult() {
+            if (resultEl) resultEl.hidden = true;
+        }
+
+        function run(autoTopUp) {
+            if (busy) return;
+
+            const validationError = validate({
+                stake: parseInt(stakeInput.value, 10),
+                form: form,
+            });
+            if (typeof validationError === 'string') {
+                showToast(validationError, 'error');
+                return;
+            }
+
+            const stake = parseInt(stakeInput.value, 10);
+            if (!stake || stake <= 0) {
+                showToast('Enter a positive stake.', 'error');
+                return;
+            }
+
+            if (!postJson) {
+                showToast('API helper missing — refresh the page.', 'error');
+                return;
+            }
+
+            const payload = buildPayload({
+                stake: stake,
+                autoTopUp: !!autoTopUp,
+                form: form,
+            });
+
+            busy = true;
+            setDisabled(true);
+            const animationHandle = startAnimation();
+            const requestStart = Date.now();
+
+            postJson(endpoint, payload)
+                .then(function (body) {
+                    const elapsed = Date.now() - requestStart;
+                    const remaining = Math.max(0, minSettleMs - elapsed);
+                    setTimeout(function () {
+                        stopAnimation(animationHandle, body);
+                        busy = false;
+                        setDisabled(false);
+                        if (body && body.ok) {
+                            renderResult(body);
+                            if (autoApplyBalance) {
+                                applyBalance(body.newBalance);
+                                applyTobyDelta(body);
+                            }
+                        } else {
+                            hideResult();
+                            showToast((body && body.error) || failureMessage, 'error');
+                        }
+                    }, remaining);
+                })
+                .catch(function () {
+                    stopAnimation(animationHandle, null);
+                    busy = false;
+                    setDisabled(false);
+                    hideResult();
+                    showToast('Network error.', 'error');
+                });
+        }
+
+        function defaultBuildPayload(state) {
+            return { stake: state.stake, autoTopUp: state.autoTopUp };
+        }
+
+        return {
+            run: run,
+            applyBalance: applyBalance,
+            applyTobyDelta: applyTobyDelta,
+            isBusy: function () { return busy; },
+        };
+    }
+
+    const api = { init: init };
+    if (root) root.TobyCasinoGame = api;
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = api;
+    }
+})(typeof window !== 'undefined' ? window : null);

--- a/web/src/main/resources/static/js/coinflip.js
+++ b/web/src/main/resources/static/js/coinflip.js
@@ -23,10 +23,6 @@ function renderCoinflipResult(resultEl, body) {
     if (!main) return;
 
     const guildId = main.dataset.guildId;
-    const initialTobyCoins = Number(main.dataset.tobyCoins) || 0;
-    const initialMarketPrice = Number(main.dataset.marketPrice) || 0;
-    const postJson = window.TobyApi && window.TobyApi.postJson;
-
     const coin = document.getElementById('coinflip-coin');
     const coinFace = document.getElementById('coinflip-coin-face');
     const stakeInput = document.getElementById('coinflip-stake');
@@ -38,24 +34,10 @@ function renderCoinflipResult(resultEl, body) {
 
     if (!form || !flipBtn || !stakeInput || !coin || !coinFace) return;
 
-    const topUp = (window.TobyTopUp && flipTobyBtn) ? window.TobyTopUp.init({
-        form: form,
-        stakeInput: stakeInput,
-        primaryBtn: flipBtn,
-        tobyBtn: flipTobyBtn,
-        balanceEl: balanceEl,
-        tobyCoins: initialTobyCoins,
-        marketPrice: initialMarketPrice,
-        onSubmit: function (autoTopUp) { runFlip(autoTopUp); },
-    }) : null;
-
     const FLIP_DURATION_MS = 800;
     const FLIP_INTERVAL_MS = 80;
-    // Faces shown during the flip animation. Final face comes from the
-    // server response.
+    // Faces shown during the flip animation. Final face comes from the server.
     const FLIP_FACES = ['🪙', '🟡'];
-
-    let flipping = false;
 
     function selectedSide() {
         const checked = form.querySelector('input[name="side"]:checked');
@@ -63,7 +45,6 @@ function renderCoinflipResult(resultEl, body) {
     }
 
     function startFlipAnimation() {
-        flipping = true;
         coin.classList.add('flipping');
         let i = 0;
         return setInterval(function () {
@@ -72,10 +53,10 @@ function renderCoinflipResult(resultEl, body) {
         }, FLIP_INTERVAL_MS);
     }
 
-    function stopFlipAnimation(intervalId, landedSide) {
+    function stopFlipAnimation(intervalId, body) {
         clearInterval(intervalId);
-        flipping = false;
         coin.classList.remove('flipping');
+        const landedSide = body && body.landed;
         if (landedSide === 'HEADS') {
             coinFace.textContent = 'H';
             coin.dataset.landed = 'heads';
@@ -88,82 +69,30 @@ function renderCoinflipResult(resultEl, body) {
         }
     }
 
-    function applyBalance(newBalance) {
-        if (typeof newBalance !== 'number') return;
-        if (balanceEl) balanceEl.textContent = newBalance;
-    }
-
-    function applyTobyDelta(body) {
-        if (!topUp) return;
-        if (typeof body.soldTobyCoins === 'number') {
-            const remaining = Math.max(0, initialTobyCoins - body.soldTobyCoins);
-            topUp.setTobyCoins(remaining);
-        }
-        if (typeof body.newPrice === 'number') topUp.setMarketPrice(body.newPrice);
-    }
-
-    function runFlip(autoTopUp) {
-        if (flipping) return;
-
-        const side = selectedSide();
-        if (!side) {
-            toast('Pick a side first.', 'error');
-            return;
-        }
-        const stake = parseInt(stakeInput.value, 10);
-        if (!stake || stake <= 0) {
-            toast('Enter a positive stake.', 'error');
-            return;
-        }
-
-        flipBtn.disabled = true;
-        if (flipTobyBtn) flipTobyBtn.disabled = true;
-        const intervalId = startFlipAnimation();
-        const requestStart = Date.now();
-
-        if (!postJson) {
-            stopFlipAnimation(intervalId);
-            flipBtn.disabled = false;
-            if (flipTobyBtn) flipTobyBtn.disabled = false;
-            toast('API helper missing — refresh the page.', 'error');
-            return;
-        }
-
-        postJson('/casino/' + guildId + '/coinflip/flip', {
-            side: side, stake: stake, autoTopUp: !!autoTopUp,
-        })
-            .then(function (body) {
-                const elapsed = Date.now() - requestStart;
-                const remaining = Math.max(0, FLIP_DURATION_MS - elapsed);
-                setTimeout(function () {
-                    stopFlipAnimation(intervalId, body && body.landed);
-                    flipBtn.disabled = false;
-                    if (flipTobyBtn) flipTobyBtn.disabled = false;
-                    if (body && body.ok) {
-                        renderCoinflipResult(resultEl, body);
-                        applyBalance(body.newBalance);
-                        applyTobyDelta(body);
-                    } else {
-                        if (resultEl) resultEl.hidden = true;
-                        toast((body && body.error) || 'Flip failed.', 'error');
-                    }
-                }, remaining);
-            })
-            .catch(function () {
-                stopFlipAnimation(intervalId);
-                flipBtn.disabled = false;
-                if (flipTobyBtn) flipTobyBtn.disabled = false;
-                if (resultEl) resultEl.hidden = true;
-                toast('Network error.', 'error');
-            });
-    }
-
-    if (!topUp) {
-        form.addEventListener('submit', function (e) {
-            e.preventDefault();
-            runFlip(false);
-        });
-    }
+    window.TobyCasinoGame.init({
+        guildId: guildId,
+        endpoint: '/casino/' + guildId + '/coinflip/flip',
+        form: form,
+        stakeInput: stakeInput,
+        primaryBtn: flipBtn,
+        tobyBtn: flipTobyBtn,
+        balanceEl: balanceEl,
+        resultEl: resultEl,
+        tobyCoins: Number(main.dataset.tobyCoins) || 0,
+        marketPrice: Number(main.dataset.marketPrice) || 0,
+        minSettleMs: FLIP_DURATION_MS,
+        failureMessage: 'Flip failed.',
+        validate: function () {
+            if (!selectedSide()) return 'Pick a side first.';
+            return null;
+        },
+        buildPayload: function (state) {
+            return { side: selectedSide(), stake: state.stake, autoTopUp: state.autoTopUp };
+        },
+        startAnimation: startFlipAnimation,
+        stopAnimation: stopFlipAnimation,
+        renderResult: function (body) { renderCoinflipResult(resultEl, body); },
+    });
 })();
 
 if (typeof module !== 'undefined' && module.exports) {

--- a/web/src/main/resources/static/js/dice.js
+++ b/web/src/main/resources/static/js/dice.js
@@ -21,10 +21,6 @@ function renderDiceResult(resultEl, body) {
     if (!main) return;
 
     const guildId = main.dataset.guildId;
-    const initialTobyCoins = Number(main.dataset.tobyCoins) || 0;
-    const initialMarketPrice = Number(main.dataset.marketPrice) || 0;
-    const postJson = window.TobyApi && window.TobyApi.postJson;
-
     const die = document.getElementById('dice-die');
     const dieFace = document.getElementById('dice-die-face');
     const stakeInput = document.getElementById('dice-stake');
@@ -36,22 +32,9 @@ function renderDiceResult(resultEl, body) {
 
     if (!form || !rollBtn || !stakeInput || !die || !dieFace) return;
 
-    const topUp = (window.TobyTopUp && rollTobyBtn) ? window.TobyTopUp.init({
-        form: form,
-        stakeInput: stakeInput,
-        primaryBtn: rollBtn,
-        tobyBtn: rollTobyBtn,
-        balanceEl: balanceEl,
-        tobyCoins: initialTobyCoins,
-        marketPrice: initialMarketPrice,
-        onSubmit: function (autoTopUp) { runRoll(autoTopUp); },
-    }) : null;
-
     const FACES = { 1: '⚀', 2: '⚁', 3: '⚂', 4: '⚃', 5: '⚄', 6: '⚅' };
     const ROLL_DURATION_MS = 800;
     const ROLL_INTERVAL_MS = 70;
-
-    let rolling = false;
 
     function selectedPrediction() {
         const checked = form.querySelector('input[name="prediction"]:checked');
@@ -59,7 +42,6 @@ function renderDiceResult(resultEl, body) {
     }
 
     function startRollAnimation() {
-        rolling = true;
         die.classList.add('rolling');
         return setInterval(function () {
             const n = 1 + Math.floor(Math.random() * 6);
@@ -67,10 +49,10 @@ function renderDiceResult(resultEl, body) {
         }, ROLL_INTERVAL_MS);
     }
 
-    function stopRollAnimation(intervalId, landed) {
+    function stopRollAnimation(intervalId, body) {
         clearInterval(intervalId);
-        rolling = false;
         die.classList.remove('rolling');
+        const landed = body && body.landed;
         if (landed && FACES[landed]) {
             dieFace.textContent = FACES[landed];
             die.dataset.landed = String(landed);
@@ -80,83 +62,34 @@ function renderDiceResult(resultEl, body) {
         }
     }
 
-
-    function applyBalance(newBalance) {
-        if (typeof newBalance !== 'number') return;
-        if (balanceEl) balanceEl.textContent = newBalance;
-    }
-
-    function applyTobyDelta(body) {
-        if (!topUp) return;
-        if (typeof body.soldTobyCoins === 'number') {
-            const remaining = Math.max(0, initialTobyCoins - body.soldTobyCoins);
-            topUp.setTobyCoins(remaining);
-        }
-        if (typeof body.newPrice === 'number') topUp.setMarketPrice(body.newPrice);
-    }
-
-    function runRoll(autoTopUp) {
-        if (rolling) return;
-
-        const prediction = selectedPrediction();
-        if (!prediction) {
-            toast('Pick a number first.', 'error');
-            return;
-        }
-        const stake = parseInt(stakeInput.value, 10);
-        if (!stake || stake <= 0) {
-            toast('Enter a positive stake.', 'error');
-            return;
-        }
-
-        rollBtn.disabled = true;
-        if (rollTobyBtn) rollTobyBtn.disabled = true;
-        const intervalId = startRollAnimation();
-        const requestStart = Date.now();
-
-        if (!postJson) {
-            stopRollAnimation(intervalId);
-            rollBtn.disabled = false;
-            if (rollTobyBtn) rollTobyBtn.disabled = false;
-            toast('API helper missing — refresh the page.', 'error');
-            return;
-        }
-
-        postJson('/casino/' + guildId + '/dice/roll', {
-            prediction: prediction, stake: stake, autoTopUp: !!autoTopUp,
-        })
-            .then(function (body) {
-                const elapsed = Date.now() - requestStart;
-                const remaining = Math.max(0, ROLL_DURATION_MS - elapsed);
-                setTimeout(function () {
-                    stopRollAnimation(intervalId, body && body.landed);
-                    rollBtn.disabled = false;
-                    if (rollTobyBtn) rollTobyBtn.disabled = false;
-                    if (body && body.ok) {
-                        renderDiceResult(resultEl, body);
-                        applyBalance(body.newBalance);
-                        applyTobyDelta(body);
-                    } else {
-                        if (resultEl) resultEl.hidden = true;
-                        toast((body && body.error) || 'Roll failed.', 'error');
-                    }
-                }, remaining);
-            })
-            .catch(function () {
-                stopRollAnimation(intervalId);
-                rollBtn.disabled = false;
-                if (rollTobyBtn) rollTobyBtn.disabled = false;
-                if (resultEl) resultEl.hidden = true;
-                toast('Network error.', 'error');
-            });
-    }
-
-    if (!topUp) {
-        form.addEventListener('submit', function (e) {
-            e.preventDefault();
-            runRoll(false);
-        });
-    }
+    window.TobyCasinoGame.init({
+        guildId: guildId,
+        endpoint: '/casino/' + guildId + '/dice/roll',
+        form: form,
+        stakeInput: stakeInput,
+        primaryBtn: rollBtn,
+        tobyBtn: rollTobyBtn,
+        balanceEl: balanceEl,
+        resultEl: resultEl,
+        tobyCoins: Number(main.dataset.tobyCoins) || 0,
+        marketPrice: Number(main.dataset.marketPrice) || 0,
+        minSettleMs: ROLL_DURATION_MS,
+        failureMessage: 'Roll failed.',
+        validate: function () {
+            if (!selectedPrediction()) return 'Pick a number first.';
+            return null;
+        },
+        buildPayload: function (state) {
+            return {
+                prediction: selectedPrediction(),
+                stake: state.stake,
+                autoTopUp: state.autoTopUp,
+            };
+        },
+        startAnimation: startRollAnimation,
+        stopAnimation: stopRollAnimation,
+        renderResult: function (body) { renderDiceResult(resultEl, body); },
+    });
 })();
 
 if (typeof module !== 'undefined' && module.exports) {

--- a/web/src/main/resources/static/js/economy.js
+++ b/web/src/main/resources/static/js/economy.js
@@ -7,13 +7,10 @@
     const guildId = main.dataset.guildId;
     const postJson = window.TobyApi.postJson;
 
-    function toast(msg, type) {
-        if (window.TobyToast && typeof window.TobyToast.show === 'function') {
-            window.TobyToast.show(msg, { type: type || 'info' });
-        } else {
-            console.log('[' + (type || 'info') + '] ' + msg);
-        }
-    }
+    // Toasts go through the global window.toast / window.TobyToasts API
+    // (see static/js/toasts.js). Earlier this file shipped a private
+    // shim referencing window.TobyToast (singular, no 's') which never
+    // existed, so trade-flow toasts silently fell through to console.log.
 
     // -- Chart --------------------------------------------------------------
     const canvas = document.getElementById('economy-chart');

--- a/web/src/main/resources/static/js/highlow.js
+++ b/web/src/main/resources/static/js/highlow.js
@@ -48,8 +48,6 @@ function renderHighlowResult(resultEl, body) {
     if (!main) return;
 
     const guildId = main.dataset.guildId;
-    const initialTobyCoins = Number(main.dataset.tobyCoins) || 0;
-    const initialMarketPrice = Number(main.dataset.marketPrice) || 0;
     const postJson = window.TobyApi && window.TobyApi.postJson;
 
     const anchorFace = document.getElementById('highlow-anchor-face');
@@ -71,6 +69,14 @@ function renderHighlowResult(resultEl, body) {
     if (!form || !dealBtn || !stakeInput || !anchorFace || !nextFace) return;
     if (!directionPicker || !higherBtn || !lowerBtn) return;
 
+    const NEXT_DEAL_MS = 900;
+    const SHUFFLE_INTERVAL_MS = 70;
+    const ROUND_RESET_MS = 1500;
+
+    let playing = false;
+
+    const cardLabel = highlowCardLabel;
+
     function setMultiplierLabels(higher, lower) {
         if (higherMultEl) higherMultEl.textContent = highlowFormatMultiplier(higher);
         if (lowerMultEl) lowerMultEl.textContent = highlowFormatMultiplier(lower);
@@ -79,28 +85,6 @@ function renderHighlowResult(resultEl, body) {
     function clearMultiplierLabels() {
         setMultiplierLabels(null, null);
     }
-
-    const topUp = (window.TobyTopUp && dealTobyBtn) ? window.TobyTopUp.init({
-        form: form,
-        stakeInput: stakeInput,
-        primaryBtn: dealBtn,
-        tobyBtn: dealTobyBtn,
-        balanceEl: balanceEl,
-        tobyCoins: initialTobyCoins,
-        marketPrice: initialMarketPrice,
-        onSubmit: function (autoTopUp) { runStart(autoTopUp); },
-    }) : null;
-
-    const NEXT_DEAL_MS = 900;
-    const SHUFFLE_INTERVAL_MS = 70;
-    const ROUND_RESET_MS = 1500;
-
-    let dealing = false;
-    // Tracks which lock variant the player picked so we can pass autoTopUp
-    // through to /play if they hit the shortfall on the actual wager.
-    let pendingAutoTopUp = false;
-
-    const cardLabel = highlowCardLabel;
 
     function showLockMode() {
         directionPicker.hidden = true;
@@ -132,7 +116,6 @@ function renderHighlowResult(resultEl, body) {
     }
 
     function startNextShuffle() {
-        dealing = true;
         nextCard.classList.add('shuffling');
         return setInterval(function () {
             nextFace.textContent = cardLabel(1 + Math.floor(Math.random() * 13));
@@ -141,7 +124,6 @@ function renderHighlowResult(resultEl, body) {
 
     function stopNextShuffle(intervalId, value) {
         clearInterval(intervalId);
-        dealing = false;
         nextCard.classList.remove('shuffling');
         if (typeof value === 'number') {
             nextFace.textContent = cardLabel(value);
@@ -152,81 +134,57 @@ function renderHighlowResult(resultEl, body) {
         }
     }
 
-    function applyBalance(newBalance) {
-        if (typeof newBalance !== 'number') return;
-        if (balanceEl) balanceEl.textContent = newBalance;
-    }
-
-    function applyTobyDelta(body) {
-        if (!topUp) return;
-        if (typeof body.soldTobyCoins === 'number') {
-            const remaining = Math.max(0, initialTobyCoins - body.soldTobyCoins);
-            topUp.setTobyCoins(remaining);
-        }
-        if (typeof body.newPrice === 'number') topUp.setMarketPrice(body.newPrice);
-    }
-
-    function runStart(autoTopUp) {
-        if (dealing) return;
-
-        const stake = parseInt(stakeInput.value, 10);
-        if (!stake || stake <= 0) {
-            toast('Enter a positive stake.', 'error');
-            return;
-        }
-
-        if (!postJson) {
-            toast('API helper missing — refresh the page.', 'error');
-            return;
-        }
-
-        dealBtn.disabled = true;
-        if (dealTobyBtn) dealTobyBtn.disabled = true;
-        pendingAutoTopUp = !!autoTopUp;
-
-        postJson('/casino/' + guildId + '/highlow/start', {
-            stake: stake, autoTopUp: pendingAutoTopUp,
-        })
-            .then(function (body) {
-                if (body && body.ok && typeof body.anchor === 'number') {
-                    showCallMode(body.anchor, body.higherMultiplier, body.lowerMultiplier);
-                } else {
-                    dealBtn.disabled = false;
-                    if (dealTobyBtn) dealTobyBtn.disabled = false;
-                    toast((body && body.error) || 'Could not lock the round.', 'error');
-                }
-            })
-            .catch(function () {
-                dealBtn.disabled = false;
-                if (dealTobyBtn) dealTobyBtn.disabled = false;
-                toast('Network error.', 'error');
-            });
-    }
+    // /start uses the shared form + TOBY-topup scaffolding. /play has
+    // its own button pair below — different lifecycle, kept manual.
+    const game = window.TobyCasinoGame.init({
+        guildId: guildId,
+        endpoint: '/casino/' + guildId + '/highlow/start',
+        form: form,
+        stakeInput: stakeInput,
+        primaryBtn: dealBtn,
+        tobyBtn: dealTobyBtn,
+        balanceEl: balanceEl,
+        resultEl: resultEl,
+        tobyCoins: Number(main.dataset.tobyCoins) || 0,
+        marketPrice: Number(main.dataset.marketPrice) || 0,
+        failureMessage: 'Could not lock the round.',
+        // /start doesn't settle credit/coin movement — it just locks
+        // the stake and deals the anchor. Balance updates land via
+        // /play's response instead.
+        autoApplyBalance: false,
+        renderResult: function (body) {
+            if (typeof body.anchor === 'number') {
+                showCallMode(body.anchor, body.higherMultiplier, body.lowerMultiplier);
+            }
+        },
+    });
 
     function runPlay(direction) {
-        if (dealing) return;
+        if (playing) return;
         if (!postJson) {
-            toast('API helper missing — refresh the page.', 'error');
+            window.toast('API helper missing — refresh the page.', 'error');
             return;
         }
 
+        playing = true;
         higherBtn.disabled = true;
         lowerBtn.disabled = true;
         const intervalId = startNextShuffle();
         const requestStart = Date.now();
 
-        postJson('/casino/' + guildId + '/highlow/play', {
-            direction: direction,
-        })
+        postJson('/casino/' + guildId + '/highlow/play', { direction: direction })
             .then(function (body) {
                 const elapsed = Date.now() - requestStart;
                 const remaining = Math.max(0, NEXT_DEAL_MS - elapsed);
                 setTimeout(function () {
+                    playing = false;
                     if (body && body.ok) {
                         stopNextShuffle(intervalId, body.next);
                         renderHighlowResult(resultEl, body);
-                        applyBalance(body.newBalance);
-                        applyTobyDelta(body);
+                        if (game) {
+                            game.applyBalance(body.newBalance);
+                            game.applyTobyDelta(body);
+                        }
                         // Round consumed → reset to lock mode after the
                         // player has had a moment to read the result.
                         setTimeout(showLockMode, ROUND_RESET_MS);
@@ -234,23 +192,17 @@ function renderHighlowResult(resultEl, body) {
                         stopNextShuffle(intervalId);
                         higherBtn.disabled = false;
                         lowerBtn.disabled = false;
-                        toast((body && body.error) || 'Deal failed.', 'error');
+                        window.toast((body && body.error) || 'Deal failed.', 'error');
                     }
                 }, remaining);
             })
             .catch(function () {
                 stopNextShuffle(intervalId);
+                playing = false;
                 higherBtn.disabled = false;
                 lowerBtn.disabled = false;
-                toast('Network error.', 'error');
+                window.toast('Network error.', 'error');
             });
-    }
-
-    if (!topUp) {
-        form.addEventListener('submit', function (e) {
-            e.preventDefault();
-            runStart(false);
-        });
     }
 
     higherBtn.addEventListener('click', function () { runPlay('HIGHER'); });

--- a/web/src/main/resources/static/js/intros.js
+++ b/web/src/main/resources/static/js/intros.js
@@ -428,7 +428,7 @@ function initIntroPage() {
                 }
             };
         }
-        window.TobyToast.show(msg, opts);
+        window.TobyToasts.show(msg, opts);
         el.remove();
     });
 
@@ -951,7 +951,7 @@ function initIntroPage() {
             apiCall(buildUrl('/update-volume'), { introId: introId, volume: value }, {
                 onSuccess: () => {
                     lastSaved = String(value);
-                    window.TobyToast.show('Volume updated.', { type: 'success', duration: 2000 });
+                    window.TobyToasts.show('Volume updated.', { type: 'success', duration: 2000 });
                     // Keep row-level play button in sync for volume-aware preview
                     const playBtn = document.querySelector('button.btn-play[data-audio-id="audio-' + introId + '"]');
                     if (playBtn) playBtn.dataset.volume = String(value);
@@ -960,7 +960,7 @@ function initIntroPage() {
                     slider.value = lastSaved;
                     if (valueEl) valueEl.textContent = lastSaved + '%';
                     const msg = r ? (r.error || 'Failed to update volume.') : 'Network error.';
-                    window.TobyToast.show(msg, { type: 'error' });
+                    window.TobyToasts.show(msg, { type: 'error' });
                 }
             });
         });
@@ -1016,7 +1016,7 @@ function initIntroPage() {
                     if (rangeLabel) {
                         rangeLabel.textContent = (startMs == null && endMs == null) ? 'full track' : 'clip set';
                     }
-                    window.TobyToast.show('Clip updated.', { type: 'success', duration: 2000 });
+                    window.TobyToasts.show('Clip updated.', { type: 'success', duration: 2000 });
                     closeOpenRowEditor();
                 },
                 onError: (r) => {
@@ -1087,12 +1087,12 @@ function initIntroPage() {
                 apiCall(buildUrl('/update-name'), { introId: introId, name: value }, {
                     onSuccess: () => {
                         finish(value);
-                        window.TobyToast.show('Renamed.', { type: 'success', duration: 2000 });
+                        window.TobyToasts.show('Renamed.', { type: 'success', duration: 2000 });
                     },
                     onError: (r) => {
                         finish(current);
                         const msg = r ? (r.error || 'Rename failed.') : 'Network error.';
-                        window.TobyToast.show(msg, { type: 'error' });
+                        window.TobyToasts.show(msg, { type: 'error' });
                     }
                 });
             }
@@ -1148,7 +1148,7 @@ function initIntroPage() {
                 .map(r => r.dataset.introId);
             apiCall(buildUrl('/reorder'), { orderedIds: orderedIds }, {
                 onSuccess: () => {
-                    window.TobyToast.show('Order saved.', { type: 'success', duration: 2000 });
+                    window.TobyToasts.show('Order saved.', { type: 'success', duration: 2000 });
                     // Update slot numbers in first column
                     tbody.querySelectorAll('tr[data-intro-id]').forEach((r, i) => {
                         const idx = r.querySelector('.slot-index');
@@ -1157,7 +1157,7 @@ function initIntroPage() {
                 },
                 onError: (r) => {
                     const msg = r ? (r.error || 'Reorder failed. Reloading.') : 'Network error. Reloading.';
-                    window.TobyToast.show(msg, { type: 'error' });
+                    window.TobyToasts.show(msg, { type: 'error' });
                     setTimeout(() => location.reload(), 800);
                 }
             });

--- a/web/src/main/resources/static/js/scratch.js
+++ b/web/src/main/resources/static/js/scratch.js
@@ -27,8 +27,6 @@ function renderScratchResult(resultEl, body, matchThreshold, balanceEl) {
     const guildId = main.dataset.guildId;
     const matchThreshold = parseInt(main.dataset.matchThreshold, 10) || 5;
     const initialTobyCoins = Number(main.dataset.tobyCoins) || 0;
-    const initialMarketPrice = Number(main.dataset.marketPrice) || 0;
-    const postJson = window.TobyApi && window.TobyApi.postJson;
 
     const cellsContainer = document.getElementById('scratch-cells');
     const cellButtons = Array.from(cellsContainer ? cellsContainer.querySelectorAll('.scratch-cell') : []);
@@ -42,22 +40,11 @@ function renderScratchResult(resultEl, body, matchThreshold, balanceEl) {
 
     if (!form || !buyBtn || !stakeInput || cellButtons.length === 0) return;
 
-    const topUp = (window.TobyTopUp && buyTobyBtn) ? window.TobyTopUp.init({
-        form: form,
-        stakeInput: stakeInput,
-        primaryBtn: buyBtn,
-        tobyBtn: buyTobyBtn,
-        balanceEl: balanceEl,
-        tobyCoins: initialTobyCoins,
-        marketPrice: initialMarketPrice,
-        onSubmit: function (autoTopUp) { runBuy(autoTopUp); },
-    }) : null;
-
-    let busy = false;
     // Latest active card. Server returns the symbols up front; cells are
     // hidden until the user scratches each one. Once all are revealed (or
     // they hit "Reveal all") the result is shown.
     let activeCard = null;
+    let game;
 
     function resetCells() {
         cellButtons.forEach(function (btn) {
@@ -83,7 +70,10 @@ function renderScratchResult(resultEl, body, matchThreshold, balanceEl) {
         // win cells once everything is revealed (see below).
         if (cellButtons.every(function (b) { return b.classList.contains('revealed'); })) {
             highlightWinCells(activeCard);
-            showResult(activeCard);
+            renderScratchResult(resultEl, activeCard, matchThreshold, balanceEl);
+            // Now the credits visibly drop and the topup-coin recompute
+            // catches up too — see autoApplyBalance: false in the helper.
+            if (game) game.applyTobyDelta(activeCard);
             // Card consumed — next "Buy ticket" starts a fresh one.
             activeCard = null;
             if (revealBtn) revealBtn.hidden = true;
@@ -108,10 +98,6 @@ function renderScratchResult(resultEl, body, matchThreshold, balanceEl) {
         });
     }
 
-    function showResult(body) {
-        renderScratchResult(resultEl, body, matchThreshold, balanceEl);
-    }
-
     cellButtons.forEach(function (btn) {
         btn.addEventListener('click', function () {
             const idx = parseInt(btn.dataset.index, 10);
@@ -121,67 +107,40 @@ function renderScratchResult(resultEl, body, matchThreshold, balanceEl) {
 
     if (revealBtn) revealBtn.addEventListener('click', revealAll);
 
-    function runBuy(autoTopUp) {
-        if (busy) return;
-
-        const stake = parseInt(stakeInput.value, 10);
-        if (!stake || stake <= 0) {
-            toast('Enter a positive stake.', 'error');
-            return;
-        }
-
-        busy = true;
-        buyBtn.disabled = true;
-        if (buyTobyBtn) buyTobyBtn.disabled = true;
-        if (resultEl) resultEl.hidden = true;
-        resetCells();
-
-        if (!postJson) {
-            buyBtn.disabled = false;
-            if (buyTobyBtn) buyTobyBtn.disabled = false;
-            busy = false;
-            toast('API helper missing — refresh the page.', 'error');
-            return;
-        }
-
-        postJson('/casino/' + guildId + '/scratch/scratch', { stake: stake, autoTopUp: !!autoTopUp })
-            .then(function (body) {
-                buyBtn.disabled = false;
-                if (buyTobyBtn) buyTobyBtn.disabled = false;
-                busy = false;
-                if (body && body.ok) {
-                    activeCard = body;
-                    if (revealBtn) revealBtn.hidden = false;
-                    if (topUp) {
-                        if (typeof body.soldTobyCoins === 'number') {
-                            topUp.setTobyCoins(Math.max(0, initialTobyCoins - body.soldTobyCoins));
-                        }
-                        if (typeof body.newPrice === 'number') topUp.setMarketPrice(body.newPrice);
-                    }
-                    // Don't auto-reveal — the user clicks each cell. The
-                    // result and balance only apply when all cells are
-                    // scratched (or "Reveal all" is hit), so the player
-                    // gets the suspense beat.
-                } else {
-                    activeCard = null;
-                    if (revealBtn) revealBtn.hidden = true;
-                    toast((body && body.error) || 'Buy failed.', 'error');
-                }
-            })
-            .catch(function () {
-                buyBtn.disabled = false;
-                if (buyTobyBtn) buyTobyBtn.disabled = false;
-                busy = false;
-                toast('Network error.', 'error');
-            });
-    }
-
-    if (!topUp) {
-        form.addEventListener('submit', function (e) {
-            e.preventDefault();
-            runBuy(false);
-        });
-    }
+    game = window.TobyCasinoGame.init({
+        guildId: guildId,
+        endpoint: '/casino/' + guildId + '/scratch/scratch',
+        form: form,
+        stakeInput: stakeInput,
+        primaryBtn: buyBtn,
+        tobyBtn: buyTobyBtn,
+        balanceEl: balanceEl,
+        resultEl: resultEl,
+        tobyCoins: initialTobyCoins,
+        marketPrice: Number(main.dataset.marketPrice) || 0,
+        failureMessage: 'Buy failed.',
+        // Scratch shows the result only after every cell has been
+        // revealed, so the helper must NOT auto-update balance/coins on
+        // response. revealCell() does it once the suspense is over.
+        autoApplyBalance: false,
+        startAnimation: function () {
+            if (resultEl) resultEl.hidden = true;
+            resetCells();
+            return null;
+        },
+        stopAnimation: function (_handle, body) {
+            if (body && body.ok) {
+                activeCard = body;
+                if (revealBtn) revealBtn.hidden = false;
+            } else {
+                activeCard = null;
+                if (revealBtn) revealBtn.hidden = true;
+            }
+        },
+        renderResult: function () {
+            // Deliberately a no-op — see revealCell.
+        },
+    });
 })();
 
 if (typeof module !== 'undefined' && module.exports) {

--- a/web/src/main/resources/static/js/slots.js
+++ b/web/src/main/resources/static/js/slots.js
@@ -21,10 +21,6 @@ function renderSlotsResult(resultEl, body) {
     if (!main) return;
 
     const guildId = main.dataset.guildId;
-    const initialTobyCoins = Number(main.dataset.tobyCoins) || 0;
-    const initialMarketPrice = Number(main.dataset.marketPrice) || 0;
-    const postJson = window.TobyApi && window.TobyApi.postJson;
-
     const reels = [
         document.getElementById('slots-reel-0'),
         document.getElementById('slots-reel-1'),
@@ -39,25 +35,11 @@ function renderSlotsResult(resultEl, body) {
 
     if (!form || !spinBtn || !stakeInput || reels.some(function (r) { return !r; })) return;
 
-    const topUp = (window.TobyTopUp && spinTobyBtn) ? window.TobyTopUp.init({
-        form: form,
-        stakeInput: stakeInput,
-        primaryBtn: spinBtn,
-        tobyBtn: spinTobyBtn,
-        balanceEl: balanceEl,
-        tobyCoins: initialTobyCoins,
-        marketPrice: initialMarketPrice,
-        onSubmit: function (autoTopUp) { runSpin(autoTopUp); },
-    }) : null;
-
     const SPIN_SYMBOLS = ['🍒', '🍋', '🔔', '⭐'];
     const SPIN_INTERVAL_MS = 60;
     const SPIN_DURATION_MS = 800;
 
-    let spinning = false;
-
     function startSpinAnimation() {
-        spinning = true;
         reels.forEach(function (reel) { reel.classList.add('spinning'); });
         return setInterval(function () {
             reels.forEach(function (reel) {
@@ -66,89 +48,32 @@ function renderSlotsResult(resultEl, body) {
         }, SPIN_INTERVAL_MS);
     }
 
-    function stopSpinAnimation(intervalId, finalSymbols) {
+    function stopSpinAnimation(intervalId, body) {
         clearInterval(intervalId);
-        spinning = false;
+        const finalSymbols = body && body.symbols;
         reels.forEach(function (reel, i) {
             reel.classList.remove('spinning');
             if (finalSymbols && finalSymbols[i]) reel.textContent = finalSymbols[i];
         });
     }
 
-    function applyBalance(newBalance) {
-        if (typeof newBalance !== 'number') return;
-        if (balanceEl) balanceEl.textContent = newBalance;
-    }
-
-    function applyTobyDelta(body) {
-        // After a successful spin (top-up or otherwise) refresh the
-        // helper's tobyCoins so the second-button state reflects the
-        // post-sale wallet.
-        if (!topUp) return;
-        if (typeof body.soldTobyCoins === 'number') {
-            const remaining = Math.max(0, initialTobyCoins - body.soldTobyCoins);
-            topUp.setTobyCoins(remaining);
-        }
-        if (typeof body.newPrice === 'number') topUp.setMarketPrice(body.newPrice);
-    }
-
-    function runSpin(autoTopUp) {
-        if (spinning) return;
-
-        const stake = parseInt(stakeInput.value, 10);
-        if (!stake || stake <= 0) {
-            toast('Enter a positive stake.', 'error');
-            return;
-        }
-
-        spinBtn.disabled = true;
-        if (spinTobyBtn) spinTobyBtn.disabled = true;
-        const intervalId = startSpinAnimation();
-        const requestStart = Date.now();
-
-        if (!postJson) {
-            stopSpinAnimation(intervalId);
-            spinBtn.disabled = false;
-            if (spinTobyBtn) spinTobyBtn.disabled = false;
-            toast('API helper missing — refresh the page.', 'error');
-            return;
-        }
-
-        postJson('/casino/' + guildId + '/slots/spin', { stake: stake, autoTopUp: !!autoTopUp })
-            .then(function (body) {
-                const elapsed = Date.now() - requestStart;
-                const remaining = Math.max(0, SPIN_DURATION_MS - elapsed);
-                setTimeout(function () {
-                    stopSpinAnimation(intervalId, body && body.symbols);
-                    spinBtn.disabled = false;
-                    if (spinTobyBtn) spinTobyBtn.disabled = false;
-                    if (body && body.ok) {
-                        renderSlotsResult(resultEl, body);
-                        applyBalance(body.newBalance);
-                        applyTobyDelta(body);
-                    } else {
-                        if (resultEl) resultEl.hidden = true;
-                        toast((body && body.error) || 'Spin failed.', 'error');
-                    }
-                }, remaining);
-            })
-            .catch(function () {
-                stopSpinAnimation(intervalId);
-                spinBtn.disabled = false;
-                if (spinTobyBtn) spinTobyBtn.disabled = false;
-                if (resultEl) resultEl.hidden = true;
-                toast('Network error.', 'error');
-            });
-    }
-
-    if (!topUp) {
-        // No TobyTopUp helper loaded — the page still works without
-        // the auto-topup flow, plain submit posts a normal spin.
-        form.addEventListener('submit', function (e) {
-            e.preventDefault();
-            runSpin(false);
-        });
-    }
+    window.TobyCasinoGame.init({
+        guildId: guildId,
+        endpoint: '/casino/' + guildId + '/slots/spin',
+        form: form,
+        stakeInput: stakeInput,
+        primaryBtn: spinBtn,
+        tobyBtn: spinTobyBtn,
+        balanceEl: balanceEl,
+        resultEl: resultEl,
+        tobyCoins: Number(main.dataset.tobyCoins) || 0,
+        marketPrice: Number(main.dataset.marketPrice) || 0,
+        minSettleMs: SPIN_DURATION_MS,
+        failureMessage: 'Spin failed.',
+        startAnimation: startSpinAnimation,
+        stopAnimation: stopSpinAnimation,
+        renderResult: function (body) { renderSlotsResult(resultEl, body); },
+    });
 })();
 
 if (typeof module !== 'undefined' && module.exports) {

--- a/web/src/main/resources/templates/casino-guilds.html
+++ b/web/src/main/resources/templates/casino-guilds.html
@@ -12,7 +12,7 @@
         balances are per-guild. Pick a server below to spin.
     </p>
 
-    <div th:if="${error}" class="alert alert-error" th:text="${error}"></div>
+    <div th:replace="~{fragments/alerts :: error}"></div>
 
     <div class="lb-guild-grid" th:if="${not #lists.isEmpty(guilds)}">
         <div class="lb-guild-card lb-guild-card-static" th:each="g : ${guilds}">

--- a/web/src/main/resources/templates/coinflip.html
+++ b/web/src/main/resources/templates/coinflip.html
@@ -16,7 +16,7 @@
             <span th:text="${maxStake}">1000</span> credits per flip.</p>
     </div>
 
-    <div th:if="${error}" class="alert alert-error" th:text="${error}"></div>
+    <div th:replace="~{fragments/alerts :: error}"></div>
 
     <section class="coinflip-table">
         <div class="coinflip-coin" id="coinflip-coin" aria-live="polite">
@@ -53,11 +53,7 @@
         <div class="coinflip-balance">
             Balance: <strong id="coinflip-balance" th:text="${balance}">0</strong> credits
         </div>
-        <div class="casino-jackpot-banner">
-            🎰 Jackpot pool:
-            <strong th:text="${jackpotPool}">0</strong> credits
-            <span class="muted">— win any minigame for a 1% chance to bank the pool.</span>
-        </div>
+        <div th:replace="~{fragments/casino :: jackpotBanner}"></div>
     </section>
 
     <section class="coinflip-rules">
@@ -78,6 +74,7 @@
 <script th:src="@{/js/casino-jackpot.js}"></script>
 <script th:src="@{/js/casino-topup.js}"></script>
 <script th:src="@{/js/casino-result.js}"></script>
+<script th:src="@{/js/casino-game.js}"></script>
 <script th:src="@{/js/coinflip.js}"></script>
 </body>
 </html>

--- a/web/src/main/resources/templates/dice.html
+++ b/web/src/main/resources/templates/dice.html
@@ -17,7 +17,7 @@
             <span th:text="${maxStake}">500</span> credits.</p>
     </div>
 
-    <div th:if="${error}" class="alert alert-error" th:text="${error}"></div>
+    <div th:replace="~{fragments/alerts :: error}"></div>
 
     <section class="dice-table">
         <div class="dice-die" id="dice-die" aria-live="polite">
@@ -50,11 +50,7 @@
         <div class="dice-balance">
             Balance: <strong id="dice-balance" th:text="${balance}">0</strong> credits
         </div>
-        <div class="casino-jackpot-banner">
-            🎰 Jackpot pool:
-            <strong th:text="${jackpotPool}">0</strong> credits
-            <span class="muted">— win any minigame for a 1% chance to bank the pool.</span>
-        </div>
+        <div th:replace="~{fragments/casino :: jackpotBanner}"></div>
     </section>
 
     <section class="dice-rules">
@@ -75,6 +71,7 @@
 <script th:src="@{/js/casino-jackpot.js}"></script>
 <script th:src="@{/js/casino-topup.js}"></script>
 <script th:src="@{/js/casino-result.js}"></script>
+<script th:src="@{/js/casino-game.js}"></script>
 <script th:src="@{/js/dice.js}"></script>
 </body>
 </html>

--- a/web/src/main/resources/templates/duel-guilds.html
+++ b/web/src/main/resources/templates/duel-guilds.html
@@ -12,7 +12,7 @@
         (minus a small jackpot tribute).
     </p>
 
-    <div th:if="${error}" class="alert alert-error" th:text="${error}"></div>
+    <div th:replace="~{fragments/alerts :: error}"></div>
 
     <div class="lb-guild-grid" th:if="${not #lists.isEmpty(guilds)}">
         <div class="lb-guild-card lb-guild-card-static" th:each="g : ${guilds}">

--- a/web/src/main/resources/templates/duel.html
+++ b/web/src/main/resources/templates/duel.html
@@ -18,7 +18,7 @@
         </p>
     </div>
 
-    <div th:if="${error}" class="alert alert-error" th:text="${error}"></div>
+    <div th:replace="~{fragments/alerts :: error}"></div>
 
     <section class="duel-card">
         <h2>Challenge someone</h2>

--- a/web/src/main/resources/templates/economy-guilds.html
+++ b/web/src/main/resources/templates/economy-guilds.html
@@ -13,7 +13,7 @@
         a server below to see its market.
     </p>
 
-    <div th:if="${error}" class="alert alert-error" th:text="${error}"></div>
+    <div th:replace="~{fragments/alerts :: error}"></div>
 
     <div class="lb-guild-grid" th:if="${not #lists.isEmpty(guilds)}">
         <a class="lb-guild-card"

--- a/web/src/main/resources/templates/economy.html
+++ b/web/src/main/resources/templates/economy.html
@@ -21,7 +21,7 @@
         </div>
     </div>
 
-    <div th:if="${error}" class="alert alert-error" th:text="${error}"></div>
+    <div th:replace="~{fragments/alerts :: error}"></div>
 
     <section class="economy-chart-card">
         <div class="economy-chart-header">

--- a/web/src/main/resources/templates/fragments/alerts.html
+++ b/web/src/main/resources/templates/fragments/alerts.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<body>
+<!--
+    Inline server-rendered flash banners. Used for redirect-flow
+    feedback (`ra.addFlashAttribute("error", …)`) where the JS toast
+    system isn't available because we haven't reached the page yet.
+    Keeps the per-template scaffolding to one line:
+        <div th:replace="~{fragments/alerts :: error}"></div>
+-->
+<div th:fragment="error" th:if="${error}"
+     class="alert alert-error" role="alert" th:text="${error}"></div>
+<div th:fragment="success" th:if="${success}"
+     class="alert alert-success" role="status" th:text="${success}"></div>
+</body>
+</html>

--- a/web/src/main/resources/templates/fragments/casino.html
+++ b/web/src/main/resources/templates/fragments/casino.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<body>
+<!--
+    Shared building blocks for the casino-game pages (dice, coinflip,
+    slots, scratch, highlow). Each game's page used to inline this
+    HTML; centralising it means a copy/styling change ripples to every
+    game in one edit.
+-->
+<div th:fragment="jackpotBanner" class="casino-jackpot-banner">
+    🎰 Jackpot pool:
+    <strong th:text="${jackpotPool}">0</strong> credits
+    <span class="muted">— win any minigame for a 1% chance to bank the pool.</span>
+</div>
+</body>
+</html>

--- a/web/src/main/resources/templates/guilds.html
+++ b/web/src/main/resources/templates/guilds.html
@@ -82,7 +82,7 @@
     <h1 class="mb-3">Select a Server</h1>
     <p class="muted mb-5">Servers where both you and TobyBot are present.</p>
 
-    <div th:if="${error}" class="alert alert-error" th:text="${error}"></div>
+    <div th:replace="~{fragments/alerts :: error}"></div>
 
     <div class="search-row" th:if="${not #lists.isEmpty(guilds)}">
         <input type="search" id="guildSearch" placeholder="Search servers…"

--- a/web/src/main/resources/templates/highlow.html
+++ b/web/src/main/resources/templates/highlow.html
@@ -16,7 +16,7 @@
             Bet <span th:text="${minStake}">10</span>-<span th:text="${maxStake}">500</span> credits.</p>
     </div>
 
-    <div th:if="${error}" class="alert alert-error" th:text="${error}"></div>
+    <div th:replace="~{fragments/alerts :: error}"></div>
 
     <section class="highlow-table">
         <div class="highlow-cards">
@@ -67,11 +67,7 @@
         <div class="highlow-balance">
             Balance: <strong id="highlow-balance" th:text="${balance}">0</strong> credits
         </div>
-        <div class="casino-jackpot-banner">
-            🎰 Jackpot pool:
-            <strong th:text="${jackpotPool}">0</strong> credits
-            <span class="muted">— win any minigame for a 1% chance to bank the pool.</span>
-        </div>
+        <div th:replace="~{fragments/casino :: jackpotBanner}"></div>
     </section>
 
     <section class="highlow-rules">
@@ -94,6 +90,7 @@
 <script th:src="@{/js/casino-jackpot.js}"></script>
 <script th:src="@{/js/casino-topup.js}"></script>
 <script th:src="@{/js/casino-result.js}"></script>
+<script th:src="@{/js/casino-game.js}"></script>
 <script th:src="@{/js/highlow.js}"></script>
 </body>
 </html>

--- a/web/src/main/resources/templates/leaderboard.html
+++ b/web/src/main/resources/templates/leaderboard.html
@@ -12,7 +12,7 @@
         <p class="muted">Social credit standings &middot; current totals with this month's earnings highlighted</p>
     </div>
 
-    <div th:if="${error}" class="alert alert-error" th:text="${error}"></div>
+    <div th:replace="~{fragments/alerts :: error}"></div>
 
     <section class="lb-stats" aria-label="Server stats for this month">
         <div class="lb-stat">

--- a/web/src/main/resources/templates/leaderboards.html
+++ b/web/src/main/resources/templates/leaderboards.html
@@ -12,7 +12,7 @@
         by using commands and spending time in voice channels with others.
     </p>
 
-    <div th:if="${error}" class="alert alert-error" th:text="${error}"></div>
+    <div th:replace="~{fragments/alerts :: error}"></div>
 
     <div class="lb-guild-grid" th:if="${not #lists.isEmpty(guilds)}">
         <a class="lb-guild-card"

--- a/web/src/main/resources/templates/moderation-guilds.html
+++ b/web/src/main/resources/templates/moderation-guilds.html
@@ -55,7 +55,7 @@
         Servers where you are the owner or a TobyBot superuser.
     </p>
 
-    <div th:if="${error}" class="alert alert-error" th:text="${error}"></div>
+    <div th:replace="~{fragments/alerts :: error}"></div>
 
     <div class="guild-grid" th:if="${not #lists.isEmpty(guilds)}">
         <a class="guild-card"

--- a/web/src/main/resources/templates/moderation.html
+++ b/web/src/main/resources/templates/moderation.html
@@ -19,7 +19,7 @@
         </div>
     </div>
 
-    <div th:if="${error}" class="alert alert-error" th:text="${error}"></div>
+    <div th:replace="~{fragments/alerts :: error}"></div>
 
     <div class="tabs" role="tablist">
         <button class="tab-btn active" data-tab="users" role="tab" aria-selected="true">Users</button>

--- a/web/src/main/resources/templates/poker-guilds.html
+++ b/web/src/main/resources/templates/poker-guilds.html
@@ -13,7 +13,7 @@
         per-server jackpot.
     </p>
 
-    <div th:if="${error}" class="alert alert-error" th:text="${error}"></div>
+    <div th:replace="~{fragments/alerts :: error}"></div>
 
     <div class="lb-guild-grid" th:if="${not #lists.isEmpty(guilds)}">
         <div class="lb-guild-card lb-guild-card-static" th:each="g : ${guilds}">

--- a/web/src/main/resources/templates/poker-lobby.html
+++ b/web/src/main/resources/templates/poker-lobby.html
@@ -20,7 +20,7 @@
         </p>
     </div>
 
-    <div th:if="${error}" class="alert alert-error" th:text="${error}"></div>
+    <div th:replace="~{fragments/alerts :: error}"></div>
 
     <section class="poker-card">
         <h2>Create a new table</h2>

--- a/web/src/main/resources/templates/profile-guilds.html
+++ b/web/src/main/resources/templates/profile-guilds.html
@@ -11,7 +11,7 @@
         Pick a server to see your balance, equipped title, and owned titles.
     </p>
 
-    <div th:if="${error}" class="alert alert-error" th:text="${error}"></div>
+    <div th:replace="~{fragments/alerts :: error}"></div>
 
     <div class="lb-guild-grid" th:if="${not #lists.isEmpty(guilds)}">
         <a class="lb-guild-card"

--- a/web/src/main/resources/templates/profile.html
+++ b/web/src/main/resources/templates/profile.html
@@ -11,7 +11,7 @@
         <h1 th:text="${profile.guildName}">Guild</h1>
     </div>
 
-    <div th:if="${error}" class="alert alert-error" th:text="${error}"></div>
+    <div th:replace="~{fragments/alerts :: error}"></div>
 
     <div class="profile-grid">
         <section class="profile-card">

--- a/web/src/main/resources/templates/scratch.html
+++ b/web/src/main/resources/templates/scratch.html
@@ -18,7 +18,7 @@
             <span th:text="${minStake}">10</span>-<span th:text="${maxStake}">500</span> credits.</p>
     </div>
 
-    <div th:if="${error}" class="alert alert-error" th:text="${error}"></div>
+    <div th:replace="~{fragments/alerts :: error}"></div>
 
     <section class="scratch-table">
         <div class="scratch-cells" id="scratch-cells">
@@ -51,11 +51,7 @@
         <div class="scratch-balance">
             Balance: <strong id="scratch-balance" th:text="${balance}">0</strong> credits
         </div>
-        <div class="casino-jackpot-banner">
-            🎰 Jackpot pool:
-            <strong th:text="${jackpotPool}">0</strong> credits
-            <span class="muted">— win any minigame for a 1% chance to bank the pool.</span>
-        </div>
+        <div th:replace="~{fragments/casino :: jackpotBanner}"></div>
     </section>
 
     <section class="scratch-rules">
@@ -94,6 +90,7 @@
 <script th:src="@{/js/casino-jackpot.js}"></script>
 <script th:src="@{/js/casino-topup.js}"></script>
 <script th:src="@{/js/casino-result.js}"></script>
+<script th:src="@{/js/casino-game.js}"></script>
 <script th:src="@{/js/scratch.js}"></script>
 </body>
 </html>

--- a/web/src/main/resources/templates/slots.html
+++ b/web/src/main/resources/templates/slots.html
@@ -16,7 +16,7 @@
             <span th:text="${maxStake}">500</span> credits per pull.</p>
     </div>
 
-    <div th:if="${error}" class="alert alert-error" th:text="${error}"></div>
+    <div th:replace="~{fragments/alerts :: error}"></div>
 
     <section class="slots-machine">
         <div class="slots-reels" id="slots-reels" aria-live="polite">
@@ -46,11 +46,7 @@
             Balance: <strong id="slots-balance" th:text="${balance}">0</strong> credits
         </div>
 
-        <div class="casino-jackpot-banner">
-            🎰 Jackpot pool:
-            <strong th:text="${jackpotPool}">0</strong> credits
-            <span class="muted">— win any minigame for a 1% chance to bank the pool.</span>
-        </div>
+        <div th:replace="~{fragments/casino :: jackpotBanner}"></div>
     </section>
 
     <section class="slots-payouts">
@@ -78,6 +74,7 @@
 <script th:src="@{/js/casino-jackpot.js}"></script>
 <script th:src="@{/js/casino-topup.js}"></script>
 <script th:src="@{/js/casino-result.js}"></script>
+<script th:src="@{/js/casino-game.js}"></script>
 <script th:src="@{/js/slots.js}"></script>
 </body>
 </html>

--- a/web/src/main/resources/templates/tip-guilds.html
+++ b/web/src/main/resources/templates/tip-guilds.html
@@ -11,7 +11,7 @@
         Send another user some social credit. Daily outgoing cap applies per server.
     </p>
 
-    <div th:if="${error}" class="alert alert-error" th:text="${error}"></div>
+    <div th:replace="~{fragments/alerts :: error}"></div>
 
     <div class="lb-guild-grid" th:if="${not #lists.isEmpty(guilds)}">
         <div class="lb-guild-card lb-guild-card-static" th:each="g : ${guilds}">

--- a/web/src/main/resources/templates/tip.html
+++ b/web/src/main/resources/templates/tip.html
@@ -18,7 +18,7 @@
         </p>
     </div>
 
-    <div th:if="${error}" class="alert alert-error" th:text="${error}"></div>
+    <div th:replace="~{fragments/alerts :: error}"></div>
 
     <section class="tip-card">
         <form id="tip-form" autocomplete="off">

--- a/web/src/main/resources/templates/titles-guilds.html
+++ b/web/src/main/resources/templates/titles-guilds.html
@@ -12,7 +12,7 @@
         grants a matching Discord role on that server. Pick a server below.
     </p>
 
-    <div th:if="${error}" class="alert alert-error" th:text="${error}"></div>
+    <div th:replace="~{fragments/alerts :: error}"></div>
 
     <div class="lb-guild-grid" th:if="${not #lists.isEmpty(guilds)}">
         <a class="lb-guild-card"

--- a/web/src/main/resources/templates/titles.html
+++ b/web/src/main/resources/templates/titles.html
@@ -14,7 +14,7 @@
         </div>
     </div>
 
-    <div th:if="${error}" class="alert alert-error" th:text="${error}"></div>
+    <div th:replace="~{fragments/alerts :: error}"></div>
 
     <section>
         <p class="muted mb-4">

--- a/web/src/test/kotlin/web/casino/CasinoOutcomeMapperTest.kt
+++ b/web/src/test/kotlin/web/casino/CasinoOutcomeMapperTest.kt
@@ -1,0 +1,79 @@
+package web.casino
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+/**
+ * Locks down the canonical user-visible strings for casino-game failure
+ * outcomes and the auth/membership guard. Any of the per-game controller
+ * tests would catch a single drift, but this is the one place where
+ * those strings live now — guard them here instead of relying on five
+ * controller tests to all assert on the same substring.
+ */
+class CasinoOutcomeMapperTest {
+
+    private data class FakeResponse(
+        override val ok: Boolean,
+        override val error: String? = null,
+    ) : CasinoResponseLike
+
+    private val mapper = CasinoOutcomeMapper { msg -> FakeResponse(false, msg) }
+
+    @Test
+    fun `errorBuilder maps 401 to the not-signed-in message`() {
+        val response = mapper.errorBuilder(401)
+
+        assertEquals(401, response.statusCode.value())
+        assertEquals(false, response.body!!.ok)
+        assertEquals("Not signed in.", response.body!!.error)
+    }
+
+    @Test
+    fun `errorBuilder maps 403 to the not-a-member message`() {
+        val response = mapper.errorBuilder(403)
+
+        assertEquals(403, response.statusCode.value())
+        assertEquals(false, response.body!!.ok)
+        assertEquals("You are not a member of that server.", response.body!!.error)
+    }
+
+    @Test
+    fun `insufficientCredits surfaces the requested stake and current balance`() {
+        val response = mapper.insufficientCredits(stake = 100L, have = 30L)
+
+        assertEquals(400, response.statusCode.value())
+        assertEquals("Need 100 credits, you have 30.", response.body!!.error)
+    }
+
+    @Test
+    fun `insufficientCoinsForTopUp surfaces needed and held coin amounts`() {
+        val response = mapper.insufficientCoinsForTopUp(needed = 5L, have = 1L)
+
+        assertEquals(400, response.statusCode.value())
+        assertEquals("Need 5 TOBY to cover the shortfall, you have 1.", response.body!!.error)
+    }
+
+    @Test
+    fun `invalidStake surfaces both bounds in the message`() {
+        val response = mapper.invalidStake(min = 10L, max = 500L)
+
+        assertEquals(400, response.statusCode.value())
+        assertEquals("Stake must be between 10 and 500 credits.", response.body!!.error)
+    }
+
+    @Test
+    fun `unknownUser nudges the user toward another bot command first`() {
+        val response = mapper.unknownUser()
+
+        assertEquals(400, response.statusCode.value())
+        assertEquals("No user record yet. Try another TobyBot command first.", response.body!!.error)
+    }
+
+    @Test
+    fun `badRequest passes through an arbitrary message verbatim`() {
+        val response = mapper.badRequest("Pick a side: HEADS or TAILS.")
+
+        assertEquals(400, response.statusCode.value())
+        assertEquals("Pick a side: HEADS or TAILS.", response.body!!.error)
+    }
+}

--- a/web/src/test/kotlin/web/controller/CoinflipControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/CoinflipControllerTest.kt
@@ -3,18 +3,15 @@ package web.controller
 import database.economy.Coinflip
 import database.service.CoinflipService
 import database.service.CoinflipService.FlipOutcome
-import database.service.JackpotService
-import database.service.TobyCoinMarketService
-import database.service.UserService
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
-import net.dv8tion.jda.api.JDA
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.security.oauth2.core.user.OAuth2User
+import web.casino.CasinoPageContext
 import web.service.EconomyWebService
 
 class CoinflipControllerTest {
@@ -24,10 +21,7 @@ class CoinflipControllerTest {
 
     private lateinit var coinflipService: CoinflipService
     private lateinit var economyWebService: EconomyWebService
-    private lateinit var userService: UserService
-    private lateinit var jackpotService: JackpotService
-    private lateinit var marketService: TobyCoinMarketService
-    private lateinit var jda: JDA
+    private lateinit var pageContext: CasinoPageContext
     private lateinit var user: OAuth2User
     private lateinit var controller: CoinflipController
 
@@ -35,16 +29,13 @@ class CoinflipControllerTest {
     fun setup() {
         coinflipService = mockk(relaxed = true)
         economyWebService = mockk(relaxed = true)
-        userService = mockk(relaxed = true)
-        jackpotService = mockk(relaxed = true)
-        marketService = mockk(relaxed = true)
-        jda = mockk(relaxed = true)
+        pageContext = mockk(relaxed = true)
         user = mockk {
             every { getAttribute<String>("id") } returns discordId.toString()
             every { getAttribute<String>("username") } returns "tester"
         }
         every { economyWebService.isMember(discordId, guildId) } returns true
-        controller = CoinflipController(coinflipService, economyWebService, userService, jackpotService, marketService, jda)
+        controller = CoinflipController(coinflipService, economyWebService, pageContext)
     }
 
     @Test

--- a/web/src/test/kotlin/web/controller/DiceControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/DiceControllerTest.kt
@@ -2,18 +2,15 @@ package web.controller
 
 import database.service.DiceService
 import database.service.DiceService.RollOutcome
-import database.service.JackpotService
-import database.service.TobyCoinMarketService
-import database.service.UserService
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
-import net.dv8tion.jda.api.JDA
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.security.oauth2.core.user.OAuth2User
+import web.casino.CasinoPageContext
 import web.service.EconomyWebService
 
 class DiceControllerTest {
@@ -23,10 +20,7 @@ class DiceControllerTest {
 
     private lateinit var diceService: DiceService
     private lateinit var economyWebService: EconomyWebService
-    private lateinit var userService: UserService
-    private lateinit var jackpotService: JackpotService
-    private lateinit var marketService: TobyCoinMarketService
-    private lateinit var jda: JDA
+    private lateinit var pageContext: CasinoPageContext
     private lateinit var user: OAuth2User
     private lateinit var controller: DiceController
 
@@ -34,16 +28,13 @@ class DiceControllerTest {
     fun setup() {
         diceService = mockk(relaxed = true)
         economyWebService = mockk(relaxed = true)
-        userService = mockk(relaxed = true)
-        jackpotService = mockk(relaxed = true)
-        marketService = mockk(relaxed = true)
-        jda = mockk(relaxed = true)
+        pageContext = mockk(relaxed = true)
         user = mockk {
             every { getAttribute<String>("id") } returns discordId.toString()
             every { getAttribute<String>("username") } returns "tester"
         }
         every { economyWebService.isMember(discordId, guildId) } returns true
-        controller = DiceController(diceService, economyWebService, userService, jackpotService, marketService, jda)
+        controller = DiceController(diceService, economyWebService, pageContext)
     }
 
     @Test

--- a/web/src/test/kotlin/web/controller/HighlowControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/HighlowControllerTest.kt
@@ -3,14 +3,10 @@ package web.controller
 import database.economy.Highlow
 import database.service.HighlowService
 import database.service.HighlowService.PlayOutcome
-import database.service.JackpotService
-import database.service.TobyCoinMarketService
-import database.service.UserService
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import jakarta.servlet.http.HttpSession
-import net.dv8tion.jda.api.JDA
 import net.dv8tion.jda.api.entities.Guild
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -21,6 +17,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.security.oauth2.core.user.OAuth2User
 import org.springframework.ui.ConcurrentModel
 import org.springframework.web.servlet.mvc.support.RedirectAttributesModelMap
+import web.casino.CasinoPageContext
 import web.service.EconomyWebService
 
 class HighlowControllerTest {
@@ -33,10 +30,7 @@ class HighlowControllerTest {
 
     private lateinit var highlowService: HighlowService
     private lateinit var economyWebService: EconomyWebService
-    private lateinit var userService: UserService
-    private lateinit var jackpotService: JackpotService
-    private lateinit var marketService: TobyCoinMarketService
-    private lateinit var jda: JDA
+    private lateinit var pageContext: CasinoPageContext
     private lateinit var user: OAuth2User
     private lateinit var session: HttpSession
     private lateinit var controller: HighlowController
@@ -45,10 +39,7 @@ class HighlowControllerTest {
     fun setup() {
         highlowService = mockk(relaxed = true)
         economyWebService = mockk(relaxed = true)
-        userService = mockk(relaxed = true)
-        jackpotService = mockk(relaxed = true)
-        marketService = mockk(relaxed = true)
-        jda = mockk(relaxed = true)
+        pageContext = mockk(relaxed = true)
         user = mockk {
             every { getAttribute<String>("id") } returns discordId.toString()
             every { getAttribute<String>("username") } returns "tester"
@@ -59,9 +50,9 @@ class HighlowControllerTest {
         val guild = mockk<Guild>(relaxed = true).also {
             every { it.name } returns "Test Guild"
         }
-        every { jda.getGuildById(guildId) } returns guild
+        every { pageContext.populate(any(), guildId, discordId, user) } returns guild
 
-        controller = HighlowController(highlowService, economyWebService, userService, jackpotService, marketService, jda)
+        controller = HighlowController(highlowService, economyWebService, pageContext)
     }
 
     @Test

--- a/web/src/test/kotlin/web/controller/ScratchControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/ScratchControllerTest.kt
@@ -1,20 +1,17 @@
 package web.controller
 
 import database.economy.SlotMachine
-import database.service.JackpotService
 import database.service.ScratchService
 import database.service.ScratchService.ScratchOutcome
-import database.service.TobyCoinMarketService
-import database.service.UserService
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
-import net.dv8tion.jda.api.JDA
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.security.oauth2.core.user.OAuth2User
+import web.casino.CasinoPageContext
 import web.service.EconomyWebService
 
 class ScratchControllerTest {
@@ -24,10 +21,7 @@ class ScratchControllerTest {
 
     private lateinit var scratchService: ScratchService
     private lateinit var economyWebService: EconomyWebService
-    private lateinit var userService: UserService
-    private lateinit var jackpotService: JackpotService
-    private lateinit var marketService: TobyCoinMarketService
-    private lateinit var jda: JDA
+    private lateinit var pageContext: CasinoPageContext
     private lateinit var user: OAuth2User
     private lateinit var controller: ScratchController
 
@@ -35,16 +29,13 @@ class ScratchControllerTest {
     fun setup() {
         scratchService = mockk(relaxed = true)
         economyWebService = mockk(relaxed = true)
-        userService = mockk(relaxed = true)
-        jackpotService = mockk(relaxed = true)
-        marketService = mockk(relaxed = true)
-        jda = mockk(relaxed = true)
+        pageContext = mockk(relaxed = true)
         user = mockk {
             every { getAttribute<String>("id") } returns discordId.toString()
             every { getAttribute<String>("username") } returns "tester"
         }
         every { economyWebService.isMember(discordId, guildId) } returns true
-        controller = ScratchController(scratchService, economyWebService, userService, jackpotService, marketService, jda)
+        controller = ScratchController(scratchService, economyWebService, pageContext)
     }
 
     @Test

--- a/web/src/test/kotlin/web/controller/SlotsControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/SlotsControllerTest.kt
@@ -1,20 +1,17 @@
 package web.controller
 
 import database.economy.SlotMachine
-import database.service.JackpotService
 import database.service.SlotsService
 import database.service.SlotsService.SpinOutcome
-import database.service.TobyCoinMarketService
-import database.service.UserService
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
-import net.dv8tion.jda.api.JDA
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.security.oauth2.core.user.OAuth2User
+import web.casino.CasinoPageContext
 import web.service.EconomyWebService
 
 /**
@@ -30,10 +27,7 @@ class SlotsControllerTest {
 
     private lateinit var slotsService: SlotsService
     private lateinit var economyWebService: EconomyWebService
-    private lateinit var userService: UserService
-    private lateinit var jackpotService: JackpotService
-    private lateinit var marketService: TobyCoinMarketService
-    private lateinit var jda: JDA
+    private lateinit var pageContext: CasinoPageContext
     private lateinit var user: OAuth2User
     private lateinit var controller: SlotsController
 
@@ -41,16 +35,13 @@ class SlotsControllerTest {
     fun setup() {
         slotsService = mockk(relaxed = true)
         economyWebService = mockk(relaxed = true)
-        userService = mockk(relaxed = true)
-        jackpotService = mockk(relaxed = true)
-        marketService = mockk(relaxed = true)
-        jda = mockk(relaxed = true)
+        pageContext = mockk(relaxed = true)
         user = mockk {
             every { getAttribute<String>("id") } returns discordId.toString()
             every { getAttribute<String>("username") } returns "tester"
         }
         every { economyWebService.isMember(discordId, guildId) } returns true
-        controller = SlotsController(slotsService, economyWebService, userService, jackpotService, marketService, jda)
+        controller = SlotsController(slotsService, economyWebService, pageContext)
     }
 
     @Test


### PR DESCRIPTION
## Summary

Recent feature work copy-pasted controller/template/JS scaffolding so a
new outcome variant or model attribute had to be edited in 5+ places.
This collapses the recurring patterns into shared helpers so each
game/area shrinks to just the bits that are actually different.

### Backend (Kotlin)

- New `web.casino.CasinoOutcomeMapper` centralises the four common
  failure-outcome strings (insufficient credits / coins / stake bounds
  / unknown user) plus the 401/403 member-guard message. Per-game
  controllers delegate the four common error arms instead of repeating
  them.
- New `CasinoPageContext` loads the seven attributes every casino page
  needs (`guildId`, `guildName`, `balance`, `tobyCoins`, `marketPrice`,
  `jackpotPool`, `username`). Dice/Coinflip/Slots/Scratch/Highlow each
  drop ~15 lines of `addAttribute` calls.
- `WebGuildAccess` gains `requireForPage` / `requireForJson` overloads
  that take any `(discordId, guildId) -> Boolean`, so non-Economy
  callers can use the same guard.
- Economy / Leaderboard / Profile / Titles / Moderation page handlers
  stop re-implementing the auth+member guard manually. ModerationController
  also collapses six copies of `discordIdOrNull or 401` into a private
  `withSignedInActor` helper.

### Frontend

- New `static/js/casino-game.js` owns the validation / fetch /
  spinner / toast / balance-update plumbing every minigame had its
  own copy of. Per-game scripts (`dice.js`, `coinflip.js`, `slots.js`,
  `scratch.js`, `highlow.js`) configure the helper instead of inlining
  the boilerplate — they each lose ~60 lines.
- **Two genuine bugs fixed in the same sweep**: `economy.js` and
  `intros.js` called `window.TobyToast.show` (singular, no 's') which
  never existed, so trade-flow and intro-rename toasts silently fell
  through to `console.log`. Both now use `window.toast` /
  `window.TobyToasts`.
- New `fragments/alerts.html` and `fragments/casino.html` fragments
  replace the inline error-alert div (23 templates) and the inline
  `casino-jackpot-banner` (5 templates).

### Tests

- New `CasinoOutcomeMapperTest` locks down the canonical failure
  strings — there's now one place to edit those.
- Per-game controller tests updated for the new constructor signatures
  (mocked `CasinoPageContext` instead of `userService` / `jackpot` /
  `market` / `jda`).
- All 251 Kotlin web tests + 172 JS jest tests pass.

### Out of scope

`CampaignController` and `IntroWebController` have unique auth/redirect
patterns that don't fit `WebGuildAccess` cleanly (Campaign uses
`getGuildName` instead of `isMember`, Intro has a superuser branch).
Left for a follow-up. Duel/Tip/Poker controllers already use
`WebGuildAccess`.

## Test plan

- [x] `./gradlew :web:test` — 251 tests, 0 failures
- [x] `npm test` (web jest suite) — 172 tests, 0 failures
- [ ] Manual smoke on dev server: visit each game page, submit a bet
      with valid stake (win and lose paths), submit with stake = 0 and
      verify toast pops, submit with insufficient credits and verify
      400 error toast pops
- [ ] Manual smoke `/economy/{g}` buy/sell — confirm a toast appears
      (regression check for the `window.TobyToast` typo)
- [ ] Manual smoke `/intro/{g}` rename — confirm the success toast and
      "undo" action both fire (also a regression check)
- [ ] Manual smoke each guild-list page renders the card grid
- [ ] Manual: visit a guild-scoped page while signed out / not in the
      guild → standard "not a member" flash via `WebGuildAccess`

https://claude.ai/code/session_01WmnYPpCagA3BMLmM9g5g9n

---
_Generated by [Claude Code](https://claude.ai/code/session_01WmnYPpCagA3BMLmM9g5g9n)_