### PR TITLE
feat(poker): per-guild config + per-action shot clock (v2-2)

### DIFF
--- a/database/src/main/kotlin/database/dto/ConfigDto.kt
+++ b/database/src/main/kotlin/database/dto/ConfigDto.kt
@@ -42,7 +42,27 @@ class ConfigDto(
 
         // Whole-number percentage (0-20) of every settled poker pot that
         // routes into the per-guild jackpot pool. Defaults to 5 if unset.
-        POKER_RAKE_PCT("POKER_RAKE_PCT");
+        POKER_RAKE_PCT("POKER_RAKE_PCT"),
+
+        // v2 (PR #v2-2): per-guild poker table parameters. All defaults
+        // come from `PokerService.companion` constants if unset; admins
+        // can tune the limits via /setconfig (Discord) or the
+        // /moderation web tab. Each table snapshots these values at
+        // creation time so a mid-hand admin tweak doesn't break
+        // invariants for the in-flight game.
+        POKER_SMALL_BLIND("POKER_SMALL_BLIND"),
+        POKER_BIG_BLIND("POKER_BIG_BLIND"),
+        POKER_SMALL_BET("POKER_SMALL_BET"),
+        POKER_BIG_BET("POKER_BIG_BET"),
+        POKER_MIN_BUY_IN("POKER_MIN_BUY_IN"),
+        POKER_MAX_BUY_IN("POKER_MAX_BUY_IN"),
+        // 2-9 (Texas Hold'em practical max). Smaller values just cap a
+        // table early; existing seats are not evicted on shrink.
+        POKER_MAX_SEATS("POKER_MAX_SEATS"),
+        // Per-actor decision deadline in seconds. 0 disables the clock
+        // entirely; otherwise the table registry auto-folds whoever is
+        // up if they don't act in time. Default 30s when unset.
+        POKER_SHOT_CLOCK_SECONDS("POKER_SHOT_CLOCK_SECONDS");
     }
 
     override fun toString(): String {

--- a/database/src/main/kotlin/database/poker/PokerTable.kt
+++ b/database/src/main/kotlin/database/poker/PokerTable.kt
@@ -22,6 +22,14 @@ class PokerTable(
     val bigBet: Long,
     val maxRaisesPerStreet: Int,
     val maxSeats: Int,
+    /**
+     * v2 (PR #v2-2): per-actor decision deadline snapshotted at table
+     * creation. `0` means the shot clock is disabled and the table
+     * only ever closes via the idle sweeper. Snapshotted (not read
+     * live) so a guild admin can't shorten the clock under a player
+     * who is actively thinking about a decision.
+     */
+    val shotClockSeconds: Int = 0,
     var phase: Phase = Phase.WAITING,
     val seats: MutableList<Seat> = mutableListOf(),
     val community: MutableList<Card> = mutableListOf(),
@@ -34,7 +42,16 @@ class PokerTable(
     var deck: Deck? = null,
     var handNumber: Long = 0L,
     var lastActivityAt: Instant = Instant.now(),
-    var lastResult: HandResult? = null
+    var lastResult: HandResult? = null,
+    /**
+     * v2: when the current actor's shot clock fires, or null if no
+     * hand is in progress, the clock is disabled, or the deadline
+     * has not yet been armed for this actor. The registry's
+     * scheduled future does the actual auto-fold; this field exists
+     * so the [database.service.PokerService] / web projection can
+     * render a countdown without touching scheduler internals.
+     */
+    var currentActorDeadline: Instant? = null
 ) {
 
     enum class Phase { WAITING, PRE_FLOP, FLOP, TURN, RIVER }

--- a/database/src/main/kotlin/database/poker/PokerTableRegistry.kt
+++ b/database/src/main/kotlin/database/poker/PokerTableRegistry.kt
@@ -7,6 +7,7 @@ import java.time.Instant
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicLong
 
@@ -40,6 +41,14 @@ class PokerTableRegistry(
     private val seq = AtomicLong()
     private var onIdleEvict: ((PokerTable) -> Unit)? = null
 
+    /**
+     * Per-table pending shot-clock task. Keyed by tableId; value is
+     * the scheduled future that will fire [shotClockExpired] if the
+     * actor doesn't act in time.
+     */
+    private val shotClocks = ConcurrentHashMap<Long, ScheduledFuture<*>>()
+    private var onShotClockExpired: ((PokerTable) -> Unit)? = null
+
     init {
         scheduler.scheduleAtFixedRate(
             { runCatching { sweepIdle(Instant.now()) } },
@@ -58,6 +67,16 @@ class PokerTableRegistry(
         this.onIdleEvict = callback
     }
 
+    /**
+     * Register a callback invoked when a table's shot clock expires
+     * before the actor has acted. [database.service.PokerService] wires
+     * this to its auto-fold path so the registry stays free of
+     * Spring-managed dependencies.
+     */
+    fun setOnShotClockExpired(callback: (PokerTable) -> Unit) {
+        this.onShotClockExpired = callback
+    }
+
     fun create(
         guildId: Long,
         hostDiscordId: Long,
@@ -69,6 +88,7 @@ class PokerTableRegistry(
         bigBet: Long,
         maxRaisesPerStreet: Int,
         maxSeats: Int,
+        shotClockSeconds: Int = 0,
         now: Instant = Instant.now()
     ): PokerTable {
         val id = seq.incrementAndGet()
@@ -84,10 +104,65 @@ class PokerTableRegistry(
             bigBet = bigBet,
             maxRaisesPerStreet = maxRaisesPerStreet,
             maxSeats = maxSeats,
+            shotClockSeconds = shotClockSeconds,
             lastActivityAt = now
         )
         tables[id] = table
         return table
+    }
+
+    /**
+     * Cancel the pending shot-clock task for [tableId] (if any) and
+     * arm a fresh one for the table's current actor. No-op when the
+     * table's [PokerTable.shotClockSeconds] is `0` (clock disabled).
+     *
+     * Called by [database.service.PokerService.applyAction] /
+     * [startHand] / [advanceStreet] every time the actor changes,
+     * keyed off `(tableId, handNumber, actorIndex)` so a stale fire
+     * (one whose actor has already acted) is harmless.
+     */
+    fun rearmShotClock(tableId: Long, now: Instant = Instant.now()) {
+        val table = tables[tableId] ?: return
+        cancelShotClock(tableId)
+        val seconds = table.shotClockSeconds
+        if (seconds <= 0 || table.phase == PokerTable.Phase.WAITING) {
+            table.currentActorDeadline = null
+            return
+        }
+        val deadline = now.plusSeconds(seconds.toLong())
+        table.currentActorDeadline = deadline
+        val expectedHand = table.handNumber
+        val expectedActor = table.actorIndex
+        val future = scheduler.schedule(
+            {
+                runCatching {
+                    val live = tables[tableId] ?: return@runCatching
+                    synchronized(live) {
+                        // If the actor moved on or the hand ended, the fire
+                        // is stale — drop it. Production callers cancel the
+                        // task explicitly, but a near-deadline action could
+                        // still race the scheduler.
+                        if (live.handNumber != expectedHand ||
+                            live.actorIndex != expectedActor ||
+                            live.phase == PokerTable.Phase.WAITING
+                        ) return@synchronized
+                        onShotClockExpired?.invoke(live)
+                    }
+                }
+            },
+            seconds.toLong(),
+            TimeUnit.SECONDS
+        )
+        shotClocks[tableId] = future
+    }
+
+    /**
+     * Cancel any pending shot-clock task for [tableId]. Idempotent.
+     * Used between hands and at table-evict time.
+     */
+    fun cancelShotClock(tableId: Long) {
+        val task = shotClocks.remove(tableId) ?: return
+        task.cancel(false)
     }
 
     fun get(tableId: Long): PokerTable? = tables[tableId]
@@ -123,6 +198,7 @@ class PokerTableRegistry(
             synchronized(table) {
                 if (table.lastActivityAt.isBefore(cutoff)) {
                     val evicted = tables.remove(id)
+                    cancelShotClock(id)
                     if (evicted != null) runCatching { onIdleEvict?.invoke(evicted) }
                 }
             }

--- a/database/src/main/kotlin/database/service/PokerService.kt
+++ b/database/src/main/kotlin/database/service/PokerService.kt
@@ -105,6 +105,21 @@ class PokerService @Autowired constructor(
     @PostConstruct
     fun wireRegistry() {
         tableRegistry.setOnIdleEvict { table -> evictAllSeats(table) }
+        tableRegistry.setOnShotClockExpired { table -> autoFoldOnTimeout(table) }
+    }
+
+    /**
+     * Invoked by [PokerTableRegistry] when an actor's shot clock fires
+     * before they've acted. Folds them on their behalf and pushes the
+     * action through the same engine path a manual fold would take, so
+     * the rest of the table sees a normal "actor folded" event.
+     */
+    private fun autoFoldOnTimeout(table: PokerTable) {
+        val timedOut = synchronized(table) {
+            if (table.phase == PokerTable.Phase.WAITING) return
+            table.seats.getOrNull(table.actorIndex)?.discordId
+        } ?: return
+        applyAction(timedOut, table.guildId, table.id, PokerAction.Fold)
     }
 
     /**
@@ -119,8 +134,12 @@ class PokerService @Autowired constructor(
         guildId: Long,
         buyIn: Long
     ): CreateOutcome {
-        if (buyIn !in MIN_BUY_IN..MAX_BUY_IN) {
-            return CreateOutcome.InvalidBuyIn(MIN_BUY_IN, MAX_BUY_IN)
+        // v2 (PR #v2-2): each table snapshots the guild's poker config
+        // at creation. Mid-hand admin tweaks don't affect the in-flight
+        // table — they take effect on the next [createTable] call.
+        val params = readTableParams(guildId)
+        if (buyIn !in params.minBuyIn..params.maxBuyIn) {
+            return CreateOutcome.InvalidBuyIn(params.minBuyIn, params.maxBuyIn)
         }
         val user = userService.getUserByIdForUpdate(hostDiscordId, guildId)
             ?: return CreateOutcome.UnknownUser
@@ -131,14 +150,15 @@ class PokerService @Autowired constructor(
         val table = tableRegistry.create(
             guildId = guildId,
             hostDiscordId = hostDiscordId,
-            minBuyIn = MIN_BUY_IN,
-            maxBuyIn = MAX_BUY_IN,
-            smallBlind = SMALL_BLIND,
-            bigBlind = BIG_BLIND,
-            smallBet = SMALL_BET,
-            bigBet = BIG_BET,
+            minBuyIn = params.minBuyIn,
+            maxBuyIn = params.maxBuyIn,
+            smallBlind = params.smallBlind,
+            bigBlind = params.bigBlind,
+            smallBet = params.smallBet,
+            bigBet = params.bigBet,
             maxRaisesPerStreet = MAX_RAISES_PER_STREET,
-            maxSeats = MAX_SEATS
+            maxSeats = params.maxSeats,
+            shotClockSeconds = params.shotClockSeconds
         )
         // Debit and seat under the same lock so we can't end up with an
         // empty table after a credit-debit failure.
@@ -148,6 +168,47 @@ class PokerService @Autowired constructor(
             table.seats.add(PokerTable.Seat(discordId = hostDiscordId, chips = buyIn))
         }
         return CreateOutcome.Ok(table.id)
+    }
+
+    /**
+     * Snapshot of every per-guild poker table parameter, populated
+     * from [ConfigService] with each value falling back to the
+     * `PokerService.companion` default if unset or unparseable.
+     */
+    data class TableParams(
+        val smallBlind: Long,
+        val bigBlind: Long,
+        val smallBet: Long,
+        val bigBet: Long,
+        val minBuyIn: Long,
+        val maxBuyIn: Long,
+        val maxSeats: Int,
+        val shotClockSeconds: Int
+    )
+
+    fun readTableParams(guildId: Long): TableParams {
+        fun cfgLong(key: ConfigDto.Configurations, default: Long, min: Long): Long {
+            val raw = configService.getConfigByName(key.configValue, guildId.toString())?.value
+            return raw?.toLongOrNull()?.coerceAtLeast(min) ?: default
+        }
+        fun cfgInt(key: ConfigDto.Configurations, default: Int, range: IntRange): Int {
+            val raw = configService.getConfigByName(key.configValue, guildId.toString())?.value
+            return raw?.toIntOrNull()?.coerceIn(range) ?: default
+        }
+        return TableParams(
+            smallBlind = cfgLong(ConfigDto.Configurations.POKER_SMALL_BLIND, SMALL_BLIND, 1L),
+            bigBlind = cfgLong(ConfigDto.Configurations.POKER_BIG_BLIND, BIG_BLIND, 1L),
+            smallBet = cfgLong(ConfigDto.Configurations.POKER_SMALL_BET, SMALL_BET, 1L),
+            bigBet = cfgLong(ConfigDto.Configurations.POKER_BIG_BET, BIG_BET, 1L),
+            minBuyIn = cfgLong(ConfigDto.Configurations.POKER_MIN_BUY_IN, MIN_BUY_IN, 1L),
+            maxBuyIn = cfgLong(ConfigDto.Configurations.POKER_MAX_BUY_IN, MAX_BUY_IN, 1L),
+            maxSeats = cfgInt(ConfigDto.Configurations.POKER_MAX_SEATS, MAX_SEATS, 2..9),
+            shotClockSeconds = cfgInt(
+                ConfigDto.Configurations.POKER_SHOT_CLOCK_SECONDS,
+                DEFAULT_SHOT_CLOCK_SECONDS,
+                0..600
+            )
+        )
     }
 
     @Transactional
@@ -239,13 +300,15 @@ class PokerService @Autowired constructor(
         val table = tableRegistry.get(tableId) ?: return StartHandOutcome.TableNotFound
         if (table.guildId != guildId) return StartHandOutcome.TableNotFound
         if (table.hostDiscordId != hostDiscordId) return StartHandOutcome.NotHost
-        return synchronized(table) {
+        val started = synchronized(table) {
             when (val r = PokerEngine.startHand(table, random, now)) {
                 is PokerEngine.StartResult.Started -> StartHandOutcome.Ok(r.handNumber)
                 PokerEngine.StartResult.HandAlreadyInProgress -> StartHandOutcome.HandAlreadyInProgress
                 PokerEngine.StartResult.NotEnoughPlayers -> StartHandOutcome.NotEnoughPlayers
             }
         }
+        if (started is StartHandOutcome.Ok) tableRegistry.rearmShotClock(tableId, now)
+        return started
     }
 
     /**
@@ -268,6 +331,19 @@ class PokerService @Autowired constructor(
         val rakeRate = rakeRate(guildId)
         val outcome = synchronized(table) {
             PokerEngine.applyAction(table, discordId, action, rakeRate, now)
+        }
+        // Reset the per-actor clock based on what the engine produced:
+        // a continuing or street-advancing event puts a fresh decision
+        // on a different (or same) actor; a resolved hand stops the
+        // clock entirely until [startHand] arms it again.
+        when (outcome) {
+            is PokerEngine.ApplyResult.Applied -> when (outcome.event) {
+                is PokerEngine.ActionEvent.Continued,
+                is PokerEngine.ActionEvent.StreetAdvanced ->
+                    tableRegistry.rearmShotClock(tableId, now)
+                is PokerEngine.ActionEvent.HandResolved -> tableRegistry.cancelShotClock(tableId)
+            }
+            is PokerEngine.ApplyResult.Rejected -> Unit
         }
         return when (outcome) {
             is PokerEngine.ApplyResult.Rejected -> ActionOutcome.Rejected(outcome.reason)
@@ -375,6 +451,9 @@ class PokerService @Autowired constructor(
         const val BIG_BET: Long = 20L
         const val MAX_RAISES_PER_STREET: Int = 4
         const val MAX_SEATS: Int = 6
+        // 30s shot clock by default; 0 disables auto-fold and the table
+        // only ever closes via the 10-minute idle sweeper.
+        const val DEFAULT_SHOT_CLOCK_SECONDS: Int = 30
 
         const val DEFAULT_RAKE: Double = 0.05
         const val MAX_RAKE: Double = 0.20

--- a/database/src/main/kotlin/database/service/PokerService.kt
+++ b/database/src/main/kotlin/database/service/PokerService.kt
@@ -11,6 +11,7 @@ import database.poker.PokerTable
 import database.poker.PokerTableRegistry
 import jakarta.annotation.PostConstruct
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.annotation.Lazy
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.Instant
@@ -102,9 +103,27 @@ class PokerService @Autowired constructor(
         data object TableNotFound : ActionOutcome
     }
 
+    /**
+     * Self-injection so registry callbacks (which are invoked from a
+     * scheduler thread holding `this`, not the Spring proxy) still
+     * route `@Transactional` methods through the proxy. Without this,
+     * `applyAction` and `evictAllSeats` would bypass their tx advice
+     * when called from the idle-evict / shot-clock paths.
+     *
+     * Nullable + `@Lazy` so a test that constructs the service
+     * directly (no Spring) doesn't hit a `lateinit` NPE; in that case
+     * [transactionalSelf] falls back to `this`. Production is always
+     * Spring-managed so the field is non-null at first use.
+     */
+    @Autowired
+    @Lazy
+    private var self: PokerService? = null
+
+    private val transactionalSelf: PokerService get() = self ?: this
+
     @PostConstruct
     fun wireRegistry() {
-        tableRegistry.setOnIdleEvict { table -> evictAllSeats(table) }
+        tableRegistry.setOnIdleEvict { table -> transactionalSelf.evictAllSeats(table) }
         tableRegistry.setOnShotClockExpired { table -> autoFoldOnTimeout(table) }
     }
 
@@ -113,13 +132,17 @@ class PokerService @Autowired constructor(
      * before they've acted. Folds them on their behalf and pushes the
      * action through the same engine path a manual fold would take, so
      * the rest of the table sees a normal "actor folded" event.
+     *
+     * Calls `self.applyAction` (not `this.applyAction`) so the
+     * `@Transactional` boundary on the action handler is honoured —
+     * scheduler-thread callbacks otherwise bypass the proxy.
      */
     private fun autoFoldOnTimeout(table: PokerTable) {
         val timedOut = synchronized(table) {
             if (table.phase == PokerTable.Phase.WAITING) return
             table.seats.getOrNull(table.actorIndex)?.discordId
         } ?: return
-        applyAction(timedOut, table.guildId, table.id, PokerAction.Fold)
+        transactionalSelf.applyAction(timedOut, table.guildId, table.id, PokerAction.Fold)
     }
 
     /**

--- a/database/src/test/kotlin/database/poker/PokerTableRegistryShotClockTest.kt
+++ b/database/src/test/kotlin/database/poker/PokerTableRegistryShotClockTest.kt
@@ -1,0 +1,177 @@
+package database.poker
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.time.Instant
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+/**
+ * Drives the per-table shot-clock plumbing in [PokerTableRegistry]
+ * directly, without the [database.service.PokerService] auto-fold
+ * path. The clock is a small piece of scheduler bookkeeping that
+ * deserves coverage on its own — the production callback (auto-fold
+ * via PokerService) is exercised separately by the service tests.
+ */
+class PokerTableRegistryShotClockTest {
+
+    private fun newRegistry() = PokerTableRegistry(
+        idleTtl = Duration.ofMinutes(10),
+        sweepInterval = Duration.ofHours(1),
+        scheduler = Executors.newScheduledThreadPool(2)
+    )
+
+    private fun PokerTableRegistry.createTestTable(shotClockSeconds: Int = 30): PokerTable =
+        create(
+            guildId = 1L,
+            hostDiscordId = 7L,
+            minBuyIn = 100L,
+            maxBuyIn = 5000L,
+            smallBlind = 5L,
+            bigBlind = 10L,
+            smallBet = 10L,
+            bigBet = 20L,
+            maxRaisesPerStreet = 4,
+            maxSeats = 6,
+            shotClockSeconds = shotClockSeconds
+        )
+
+    @Test
+    fun `rearmShotClock is a no-op when the table has the clock disabled`() {
+        val reg = newRegistry()
+        val table = reg.createTestTable(shotClockSeconds = 0)
+        // Even with phase != WAITING, a 0 clock means no deadline and no fire.
+        table.phase = PokerTable.Phase.PRE_FLOP
+        reg.rearmShotClock(table.id)
+        assertNull(table.currentActorDeadline, "0-second clock leaves the deadline null")
+    }
+
+    @Test
+    fun `rearmShotClock leaves deadline null when the table is WAITING`() {
+        val reg = newRegistry()
+        val table = reg.createTestTable(shotClockSeconds = 30)
+        // Brand-new table sits in WAITING — no actor to clock.
+        reg.rearmShotClock(table.id)
+        assertNull(table.currentActorDeadline)
+    }
+
+    @Test
+    fun `rearmShotClock sets currentActorDeadline based on now plus shot clock`() {
+        val reg = newRegistry()
+        val table = reg.createTestTable(shotClockSeconds = 30)
+        table.phase = PokerTable.Phase.PRE_FLOP
+        val now = Instant.parse("2026-05-01T10:00:00Z")
+        reg.rearmShotClock(table.id, now)
+        assertEquals(now.plusSeconds(30), table.currentActorDeadline)
+    }
+
+    @Test
+    fun `cancelShotClock clears the pending task and is idempotent`() {
+        val reg = newRegistry()
+        val table = reg.createTestTable(shotClockSeconds = 30)
+        table.phase = PokerTable.Phase.PRE_FLOP
+        reg.rearmShotClock(table.id)
+        reg.cancelShotClock(table.id)
+        // Calling cancel again must not throw.
+        reg.cancelShotClock(table.id)
+        // A second cancel is harmless even when nothing is armed.
+        reg.cancelShotClock(table.id + 99)
+    }
+
+    @Test
+    fun `clock fires onShotClockExpired when the actor doesn't act in time`() {
+        val reg = newRegistry()
+        val fired = CountDownLatch(1)
+        var firedTable: PokerTable? = null
+        reg.setOnShotClockExpired { t -> firedTable = t; fired.countDown() }
+
+        val table = reg.createTestTable(shotClockSeconds = 1)
+        table.phase = PokerTable.Phase.PRE_FLOP
+        table.handNumber = 1L
+        reg.rearmShotClock(table.id)
+
+        val fired2sec = fired.await(3, TimeUnit.SECONDS)
+        assertTrue(fired2sec, "shot clock did not fire within 3s")
+        assertNotNull(firedTable)
+        assertEquals(table.id, firedTable!!.id)
+    }
+
+    @Test
+    fun `clock does NOT fire if the actor acted before the deadline`() {
+        val reg = newRegistry()
+        val fired = CountDownLatch(1)
+        reg.setOnShotClockExpired { _ -> fired.countDown() }
+
+        val table = reg.createTestTable(shotClockSeconds = 1)
+        table.phase = PokerTable.Phase.PRE_FLOP
+        table.handNumber = 1L
+        reg.rearmShotClock(table.id)
+        reg.cancelShotClock(table.id)
+
+        val fired2sec = fired.await(2, TimeUnit.SECONDS)
+        assertFalse(fired2sec, "clock fired despite cancellation")
+    }
+
+    @Test
+    fun `stale clock task is suppressed when the actor has moved on`() {
+        // A clock fires for actor=0 hand=1, but by the time the
+        // scheduled task runs we've already advanced to actor=1.
+        // The registry must detect the staleness and suppress the
+        // callback rather than auto-folding the wrong actor.
+        val reg = newRegistry()
+        var fireCount = 0
+        reg.setOnShotClockExpired { _ -> fireCount++ }
+
+        val table = reg.createTestTable(shotClockSeconds = 1)
+        table.phase = PokerTable.Phase.PRE_FLOP
+        table.handNumber = 1L
+        table.actorIndex = 0
+        reg.rearmShotClock(table.id)
+
+        // Simulate the actor acting (advancing actorIndex) without
+        // cancelling — the in-flight task should detect the change.
+        table.actorIndex = 1
+
+        Thread.sleep(1500)
+        // Either the task no-ops (stale-detect path) OR has been
+        // cancelled — either way fireCount stays at 0 because the
+        // current actor is different.
+        assertEquals(0, fireCount, "stale fire was not suppressed (count=$fireCount)")
+    }
+
+    @Test
+    fun `sweepIdle cancels the shot clock for evicted tables`() {
+        val reg = PokerTableRegistry(
+            idleTtl = Duration.ofMillis(10),
+            sweepInterval = Duration.ofHours(1),
+            scheduler = Executors.newScheduledThreadPool(2)
+        )
+        val fired = CountDownLatch(1)
+        reg.setOnShotClockExpired { _ -> fired.countDown() }
+
+        val table = reg.create(
+            guildId = 1L, hostDiscordId = 7L,
+            minBuyIn = 100L, maxBuyIn = 5000L,
+            smallBlind = 5L, bigBlind = 10L, smallBet = 10L, bigBet = 20L,
+            maxRaisesPerStreet = 4, maxSeats = 6,
+            shotClockSeconds = 1,
+            now = Instant.now().minus(Duration.ofMinutes(1))
+        )
+        table.phase = PokerTable.Phase.PRE_FLOP
+        table.handNumber = 1L
+        reg.rearmShotClock(table.id)
+
+        // The table is already past its idle TTL — sweep evicts it
+        // and should cancel the pending shot-clock task.
+        reg.sweepIdle(Instant.now())
+
+        val firedAfterSweep = fired.await(2, TimeUnit.SECONDS)
+        assertFalse(firedAfterSweep, "shot clock fired for an evicted table")
+    }
+}

--- a/database/src/test/kotlin/database/service/PokerServiceConfigSnapshotTest.kt
+++ b/database/src/test/kotlin/database/service/PokerServiceConfigSnapshotTest.kt
@@ -1,0 +1,204 @@
+package database.service
+
+import database.dto.ConfigDto
+import database.dto.UserDto
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import database.persistence.PokerHandLogPersistence
+import database.persistence.PokerHandPotPersistence
+import database.dto.PokerHandLogDto
+import database.dto.PokerHandPotDto
+import database.poker.PokerTableRegistry
+import java.time.Duration
+import kotlin.random.Random
+
+/**
+ * Verifies that [PokerService.createTable] reads the per-guild
+ * poker config and snapshots those values onto the new table —
+ * subsequent admin tweaks must not bleed into an in-flight table.
+ */
+class PokerServiceConfigSnapshotTest {
+
+    private val guildId = 99L
+    private val host = 1L
+
+    private lateinit var userService: RecordingUserService
+    private lateinit var jackpotService: JackpotService
+    private lateinit var configService: ConfigService
+    private lateinit var registry: PokerTableRegistry
+    private lateinit var service: PokerService
+
+    @BeforeEach
+    fun setup() {
+        userService = RecordingUserService()
+        jackpotService = mockk(relaxed = true)
+        configService = mockk(relaxed = true)
+        registry = PokerTableRegistry(
+            idleTtl = Duration.ofMinutes(5),
+            sweepInterval = Duration.ofHours(1)
+        )
+        service = PokerService(
+            userService = userService,
+            jackpotService = jackpotService,
+            configService = configService,
+            tableRegistry = registry,
+            handLogPersistence = NoopHandLog(),
+            handPotPersistence = NoopHandPot(),
+            random = Random(0)
+        )
+        // Default — every config key returns null so the service falls
+        // back to its compile-time defaults. Specific tests override.
+        every { configService.getConfigByName(any(), guildId.toString()) } returns null
+    }
+
+    private fun seedConfig(key: ConfigDto.Configurations, value: String) {
+        every {
+            configService.getConfigByName(key.configValue, guildId.toString())
+        } returns ConfigDto(name = key.configValue, value = value, guildId = guildId.toString())
+    }
+
+    @Test
+    fun `createTable falls back to defaults when no guild config is set`() {
+        userService.seed(UserDto(host, guildId).apply { socialCredit = 5000L })
+        val outcome = service.createTable(host, guildId, buyIn = 200L) as PokerService.CreateOutcome.Ok
+        val table = registry.get(outcome.tableId)!!
+        assertEquals(PokerService.SMALL_BLIND, table.smallBlind)
+        assertEquals(PokerService.BIG_BLIND, table.bigBlind)
+        assertEquals(PokerService.SMALL_BET, table.smallBet)
+        assertEquals(PokerService.BIG_BET, table.bigBet)
+        assertEquals(PokerService.MIN_BUY_IN, table.minBuyIn)
+        assertEquals(PokerService.MAX_BUY_IN, table.maxBuyIn)
+        assertEquals(PokerService.MAX_SEATS, table.maxSeats)
+        assertEquals(PokerService.DEFAULT_SHOT_CLOCK_SECONDS, table.shotClockSeconds)
+    }
+
+    @Test
+    fun `createTable reads each per-guild key and snapshots them on the table`() {
+        seedConfig(ConfigDto.Configurations.POKER_SMALL_BLIND, "25")
+        seedConfig(ConfigDto.Configurations.POKER_BIG_BLIND, "50")
+        seedConfig(ConfigDto.Configurations.POKER_SMALL_BET, "50")
+        seedConfig(ConfigDto.Configurations.POKER_BIG_BET, "100")
+        seedConfig(ConfigDto.Configurations.POKER_MIN_BUY_IN, "1000")
+        seedConfig(ConfigDto.Configurations.POKER_MAX_BUY_IN, "20000")
+        seedConfig(ConfigDto.Configurations.POKER_MAX_SEATS, "9")
+        seedConfig(ConfigDto.Configurations.POKER_SHOT_CLOCK_SECONDS, "60")
+        userService.seed(UserDto(host, guildId).apply { socialCredit = 50_000L })
+
+        val outcome = service.createTable(host, guildId, buyIn = 5000L) as PokerService.CreateOutcome.Ok
+        val table = registry.get(outcome.tableId)!!
+
+        assertEquals(25L, table.smallBlind)
+        assertEquals(50L, table.bigBlind)
+        assertEquals(50L, table.smallBet)
+        assertEquals(100L, table.bigBet)
+        assertEquals(1000L, table.minBuyIn)
+        assertEquals(20000L, table.maxBuyIn)
+        assertEquals(9, table.maxSeats)
+        assertEquals(60, table.shotClockSeconds)
+    }
+
+    @Test
+    fun `createTable rejects buy-in outside the per-guild bounds`() {
+        seedConfig(ConfigDto.Configurations.POKER_MIN_BUY_IN, "500")
+        seedConfig(ConfigDto.Configurations.POKER_MAX_BUY_IN, "1000")
+        userService.seed(UserDto(host, guildId).apply { socialCredit = 5000L })
+
+        // Below the per-guild floor — would have passed under the
+        // hardcoded default of 100.
+        val low = service.createTable(host, guildId, buyIn = 200L)
+        assertTrue(low is PokerService.CreateOutcome.InvalidBuyIn,
+            "expected per-guild floor to reject 200, got $low")
+        low as PokerService.CreateOutcome.InvalidBuyIn
+        assertEquals(500L, low.min)
+        assertEquals(1000L, low.max)
+
+        // Within the per-guild window.
+        val ok = service.createTable(host, guildId, buyIn = 600L)
+        assertTrue(ok is PokerService.CreateOutcome.Ok)
+    }
+
+    @Test
+    fun `mid-hand admin tweak does not affect an in-flight table`() {
+        seedConfig(ConfigDto.Configurations.POKER_SMALL_BLIND, "5")
+        seedConfig(ConfigDto.Configurations.POKER_BIG_BLIND, "10")
+        seedConfig(ConfigDto.Configurations.POKER_SHOT_CLOCK_SECONDS, "15")
+        userService.seed(UserDto(host, guildId).apply { socialCredit = 5000L })
+
+        val first = (service.createTable(host, guildId, buyIn = 200L) as PokerService.CreateOutcome.Ok).tableId
+        val firstTable = registry.get(first)!!
+
+        // Admin doubles the blinds while the table is sitting in WAITING.
+        seedConfig(ConfigDto.Configurations.POKER_SMALL_BLIND, "100")
+        seedConfig(ConfigDto.Configurations.POKER_BIG_BLIND, "200")
+        seedConfig(ConfigDto.Configurations.POKER_SHOT_CLOCK_SECONDS, "5")
+
+        // The first table keeps its snapshot — players who joined under
+        // the old limits don't get blindsided mid-session.
+        assertEquals(5L, firstTable.smallBlind)
+        assertEquals(10L, firstTable.bigBlind)
+        assertEquals(15, firstTable.shotClockSeconds)
+
+        // A *new* table picks up the new values.
+        userService.seed(UserDto(host + 1, guildId).apply { socialCredit = 5000L })
+        val secondId = (service.createTable(host + 1, guildId, buyIn = 200L) as PokerService.CreateOutcome.Ok).tableId
+        val secondTable = registry.get(secondId)!!
+        assertEquals(100L, secondTable.smallBlind)
+        assertEquals(200L, secondTable.bigBlind)
+        assertEquals(5, secondTable.shotClockSeconds)
+    }
+
+    @Test
+    fun `unparseable config falls back to default rather than blowing up`() {
+        seedConfig(ConfigDto.Configurations.POKER_SMALL_BLIND, "asdf")
+        seedConfig(ConfigDto.Configurations.POKER_MAX_SEATS, "not-a-number")
+        seedConfig(ConfigDto.Configurations.POKER_SHOT_CLOCK_SECONDS, "")
+        userService.seed(UserDto(host, guildId).apply { socialCredit = 5000L })
+
+        val tableId = (service.createTable(host, guildId, buyIn = 200L) as PokerService.CreateOutcome.Ok).tableId
+        val table = registry.get(tableId)!!
+        assertEquals(PokerService.SMALL_BLIND, table.smallBlind)
+        assertEquals(PokerService.MAX_SEATS, table.maxSeats)
+        assertEquals(PokerService.DEFAULT_SHOT_CLOCK_SECONDS, table.shotClockSeconds)
+    }
+
+    @Test
+    fun `out-of-range integer config is clamped to the allowed range`() {
+        seedConfig(ConfigDto.Configurations.POKER_MAX_SEATS, "20") // above max
+        seedConfig(ConfigDto.Configurations.POKER_SHOT_CLOCK_SECONDS, "9999") // above max
+        userService.seed(UserDto(host, guildId).apply { socialCredit = 5000L })
+
+        val tableId = (service.createTable(host, guildId, buyIn = 200L) as PokerService.CreateOutcome.Ok).tableId
+        val table = registry.get(tableId)!!
+        assertEquals(9, table.maxSeats, "clamped to upper bound 9")
+        assertEquals(600, table.shotClockSeconds, "clamped to upper bound 600s")
+    }
+
+    private class NoopHandLog : PokerHandLogPersistence {
+        override fun insert(row: PokerHandLogDto): PokerHandLogDto {
+            row.id = 1L; return row
+        }
+    }
+
+    private class NoopHandPot : PokerHandPotPersistence {
+        override fun insert(row: PokerHandPotDto): PokerHandPotDto = row
+        override fun findByHandLogId(handLogId: Long): List<PokerHandPotDto> = emptyList()
+    }
+
+    private class RecordingUserService : UserService {
+        private val users = mutableMapOf<Pair<Long, Long>, UserDto>()
+        fun seed(dto: UserDto) { users[dto.discordId to dto.guildId] = dto }
+        override fun listGuildUsers(guildId: Long?): List<UserDto?> = users.values.filter { it.guildId == guildId }
+        override fun createNewUser(userDto: UserDto): UserDto = userDto.also(::seed)
+        override fun getUserById(discordId: Long?, guildId: Long?): UserDto? = users[discordId!! to guildId!!]
+        override fun getUserByIdForUpdate(discordId: Long?, guildId: Long?): UserDto? = users[discordId!! to guildId!!]
+        override fun updateUser(userDto: UserDto): UserDto { users[userDto.discordId to userDto.guildId] = userDto; return userDto }
+        override fun deleteUser(userDto: UserDto) { users.remove(userDto.discordId to userDto.guildId) }
+        override fun deleteUserById(discordId: Long?, guildId: Long?) { users.remove(discordId!! to guildId!!) }
+        override fun clearCache() {}
+        override fun evictUserFromCache(discordId: Long?, guildId: Long?) {}
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/moderation/SetConfigCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/moderation/SetConfigCommand.kt
@@ -61,6 +61,23 @@ class SetConfigCommand @Autowired constructor(
                 ConfigDto.Configurations.ACTIVITY_TRACKING_NOTIFIED -> Unit
                 ConfigDto.Configurations.JACKPOT_LOSS_TRIBUTE_PCT -> setJackpotLossTribute(event, optionMapping, deleteDelay)
                 ConfigDto.Configurations.POKER_RAKE_PCT -> setPokerRake(event, optionMapping, deleteDelay)
+                ConfigDto.Configurations.POKER_SMALL_BLIND -> setPokerLong(event, optionMapping, deleteDelay,
+                    config = ConfigDto.Configurations.POKER_SMALL_BLIND, label = "small blind", min = 1L)
+                ConfigDto.Configurations.POKER_BIG_BLIND -> setPokerLong(event, optionMapping, deleteDelay,
+                    config = ConfigDto.Configurations.POKER_BIG_BLIND, label = "big blind", min = 1L)
+                ConfigDto.Configurations.POKER_SMALL_BET -> setPokerLong(event, optionMapping, deleteDelay,
+                    config = ConfigDto.Configurations.POKER_SMALL_BET, label = "small bet", min = 1L)
+                ConfigDto.Configurations.POKER_BIG_BET -> setPokerLong(event, optionMapping, deleteDelay,
+                    config = ConfigDto.Configurations.POKER_BIG_BET, label = "big bet", min = 1L)
+                ConfigDto.Configurations.POKER_MIN_BUY_IN -> setPokerLong(event, optionMapping, deleteDelay,
+                    config = ConfigDto.Configurations.POKER_MIN_BUY_IN, label = "minimum buy-in", min = 1L)
+                ConfigDto.Configurations.POKER_MAX_BUY_IN -> setPokerLong(event, optionMapping, deleteDelay,
+                    config = ConfigDto.Configurations.POKER_MAX_BUY_IN, label = "maximum buy-in", min = 1L)
+                ConfigDto.Configurations.POKER_MAX_SEATS -> setPokerInt(event, optionMapping, deleteDelay,
+                    config = ConfigDto.Configurations.POKER_MAX_SEATS, label = "max seats", range = 2..9)
+                ConfigDto.Configurations.POKER_SHOT_CLOCK_SECONDS -> setPokerInt(event, optionMapping, deleteDelay,
+                    config = ConfigDto.Configurations.POKER_SHOT_CLOCK_SECONDS,
+                    label = "shot-clock seconds", range = 0..600)
             }
         }
     }
@@ -173,6 +190,57 @@ class SetConfigCommand @Autowired constructor(
             .queue(invokeDeleteOnMessageResponse(deleteDelay))
     }
 
+    /**
+     * Shared "validate a non-negative whole-number poker config value
+     * within [[min], [Long.MAX_VALUE]] and persist it" helper. Each
+     * specific table-shape config (blind / bet / buy-in) only differs
+     * in the human-readable [label] and the floor; the message and
+     * upsert plumbing is the same.
+     */
+    private fun setPokerLong(
+        event: SlashCommandInteractionEvent,
+        optionMapping: OptionMapping,
+        deleteDelay: Int,
+        config: ConfigDto.Configurations,
+        label: String,
+        min: Long
+    ) {
+        val value = optionMapping.asLong
+        if (value < min) {
+            event.hook.sendMessage("Poker $label must be at least $min.")
+                .setEphemeral(true).queue(invokeDeleteOnMessageResponse(deleteDelay))
+            return
+        }
+        val guildId = event.guild?.id ?: return
+        configService.upsertConfig(config.configValue, value.toString(), guildId)
+        event.hook.sendMessage("Poker $label set to $value chips for new tables.")
+            .queue(invokeDeleteOnMessageResponse(deleteDelay))
+    }
+
+    /**
+     * As [setPokerLong] but for integer-bounded knobs (max seats,
+     * shot-clock seconds). The range is inclusive on both ends.
+     */
+    private fun setPokerInt(
+        event: SlashCommandInteractionEvent,
+        optionMapping: OptionMapping,
+        deleteDelay: Int,
+        config: ConfigDto.Configurations,
+        label: String,
+        range: IntRange
+    ) {
+        val value = optionMapping.asInt
+        if (value !in range) {
+            event.hook.sendMessage("Poker $label must be between ${range.first} and ${range.last}.")
+                .setEphemeral(true).queue(invokeDeleteOnMessageResponse(deleteDelay))
+            return
+        }
+        val guildId = event.guild?.id ?: return
+        configService.upsertConfig(config.configValue, value.toString(), guildId)
+        event.hook.sendMessage("Poker $label set to $value for new tables.")
+            .queue(invokeDeleteOnMessageResponse(deleteDelay))
+    }
+
     private fun setMove(event: SlashCommandInteractionEvent, deleteDelay: Int) {
         val movePropertyName = ConfigDto.Configurations.MOVE.configValue
         val guildId = event.guild?.id ?: return
@@ -243,6 +311,54 @@ class SetConfigCommand @Autowired constructor(
                 OptionType.INTEGER,
                 ConfigDto.Configurations.POKER_RAKE_PCT.name.lowercase(Locale.getDefault()),
                 "Percent (0-20) of every settled poker pot routed into the per-guild jackpot pool. Default 5.",
+                false
+            ),
+            OptionData(
+                OptionType.INTEGER,
+                ConfigDto.Configurations.POKER_SMALL_BLIND.name.lowercase(Locale.getDefault()),
+                "Per-guild poker small blind for new tables. Default 5.",
+                false
+            ),
+            OptionData(
+                OptionType.INTEGER,
+                ConfigDto.Configurations.POKER_BIG_BLIND.name.lowercase(Locale.getDefault()),
+                "Per-guild poker big blind for new tables. Default 10.",
+                false
+            ),
+            OptionData(
+                OptionType.INTEGER,
+                ConfigDto.Configurations.POKER_SMALL_BET.name.lowercase(Locale.getDefault()),
+                "Per-guild fixed-limit small bet (pre-flop / flop). Default 10.",
+                false
+            ),
+            OptionData(
+                OptionType.INTEGER,
+                ConfigDto.Configurations.POKER_BIG_BET.name.lowercase(Locale.getDefault()),
+                "Per-guild fixed-limit big bet (turn / river). Default 20.",
+                false
+            ),
+            OptionData(
+                OptionType.INTEGER,
+                ConfigDto.Configurations.POKER_MIN_BUY_IN.name.lowercase(Locale.getDefault()),
+                "Per-guild minimum poker buy-in. Default 100.",
+                false
+            ),
+            OptionData(
+                OptionType.INTEGER,
+                ConfigDto.Configurations.POKER_MAX_BUY_IN.name.lowercase(Locale.getDefault()),
+                "Per-guild maximum poker buy-in. Default 5000.",
+                false
+            ),
+            OptionData(
+                OptionType.INTEGER,
+                ConfigDto.Configurations.POKER_MAX_SEATS.name.lowercase(Locale.getDefault()),
+                "Maximum players per poker table (2-9). Default 6.",
+                false
+            ),
+            OptionData(
+                OptionType.INTEGER,
+                ConfigDto.Configurations.POKER_SHOT_CLOCK_SECONDS.name.lowercase(Locale.getDefault()),
+                "Per-actor decision deadline in seconds (0 disables). Default 30.",
                 false
             )
         )

--- a/web/src/main/kotlin/web/service/ModerationWebService.kt
+++ b/web/src/main/kotlin/web/service/ModerationWebService.kt
@@ -285,6 +285,29 @@ class ModerationWebService(
                 if (n !in 0..20) return "Value must be between 0 and 20 (capped server-side)."
                 n.toString()
             }
+            ConfigDto.Configurations.POKER_SMALL_BLIND,
+            ConfigDto.Configurations.POKER_BIG_BLIND,
+            ConfigDto.Configurations.POKER_SMALL_BET,
+            ConfigDto.Configurations.POKER_BIG_BET,
+            ConfigDto.Configurations.POKER_MIN_BUY_IN,
+            ConfigDto.Configurations.POKER_MAX_BUY_IN -> {
+                val n = rawValue.trim().toLongOrNull()
+                    ?: return "Value must be a whole number of chips."
+                if (n < 1L) return "Value must be at least 1 chip."
+                n.toString()
+            }
+            ConfigDto.Configurations.POKER_MAX_SEATS -> {
+                val n = rawValue.trim().toIntOrNull()
+                    ?: return "Value must be a whole number."
+                if (n !in 2..9) return "Value must be between 2 and 9 seats."
+                n.toString()
+            }
+            ConfigDto.Configurations.POKER_SHOT_CLOCK_SECONDS -> {
+                val n = rawValue.trim().toIntOrNull()
+                    ?: return "Value must be a whole number of seconds."
+                if (n !in 0..600) return "Value must be between 0 and 600 seconds."
+                n.toString()
+            }
         }
 
         val guildIdString = guild.id

--- a/web/src/main/kotlin/web/service/PokerWebService.kt
+++ b/web/src/main/kotlin/web/service/PokerWebService.kt
@@ -59,6 +59,16 @@ class PokerWebService(
         val callAmount: Long,
         val raiseAmount: Long,
         val lastResult: HandResultView?,
+        /**
+         * v2 (PR #v2-2): shot-clock visibility for the polling JS.
+         * `shotClockSeconds = 0` → clock is disabled for this table.
+         * `currentActorDeadlineEpochMillis = null` → no actor decision
+         * is pending right now (waiting for next hand). The client
+         * computes the live remaining seconds so a slow poll cycle
+         * doesn't stall the countdown.
+         */
+        val shotClockSeconds: Int = 0,
+        val currentActorDeadlineEpochMillis: Long? = null,
     )
 
     data class SeatView(
@@ -183,6 +193,8 @@ class PokerWebService(
                 canRaise = canRaise,
                 callAmount = owe,
                 raiseAmount = owe + betUnit,
+                shotClockSeconds = table.shotClockSeconds,
+                currentActorDeadlineEpochMillis = table.currentActorDeadline?.toEpochMilli(),
                 lastResult = table.lastResult?.let { result ->
                     HandResultView(
                         handNumber = result.handNumber,

--- a/web/src/main/resources/static/js/poker-table.js
+++ b/web/src/main/resources/static/js/poker-table.js
@@ -22,6 +22,8 @@
     const statusEl = document.getElementById('poker-status');
     const resultEl = document.getElementById('poker-result');
     const potsEl = document.getElementById('poker-pots');
+    const shotClockEl = document.getElementById('poker-shot-clock');
+    let shotClockTicker = null;
     const balanceEl = document.getElementById('poker-balance');
     const joinCard = document.getElementById('poker-join-card');
 
@@ -117,6 +119,37 @@
         btnCashout.disabled = state.phase !== 'WAITING';
     }
 
+    /**
+     * Render the per-actor shot-clock countdown. The server sends a
+     * deadline epoch-millis instead of a "seconds remaining" so the
+     * client can drive a smooth 1Hz tick without depending on the 2s
+     * polling cadence — otherwise the visible countdown would jump in
+     * 2-second steps and feel laggy. When no clock is armed, the
+     * element is hidden and any running ticker is stopped.
+     */
+    function renderShotClock(state) {
+        if (!shotClockEl) return;
+        if (shotClockTicker) { clearInterval(shotClockTicker); shotClockTicker = null; }
+        const deadline = state.currentActorDeadlineEpochMillis;
+        if (!state.shotClockSeconds || !deadline || state.phase === 'WAITING') {
+            shotClockEl.hidden = true;
+            shotClockEl.textContent = '';
+            return;
+        }
+        function tick() {
+            const remainingMs = deadline - Date.now();
+            if (remainingMs <= 0) {
+                shotClockEl.textContent = 'Time!';
+                if (shotClockTicker) { clearInterval(shotClockTicker); shotClockTicker = null; }
+                return;
+            }
+            shotClockEl.textContent = Math.ceil(remainingMs / 1000) + 's';
+        }
+        shotClockEl.hidden = false;
+        tick();
+        shotClockTicker = setInterval(tick, 1000);
+    }
+
     function renderResult(result) {
         if (!result) {
             resultEl.textContent = '';
@@ -166,6 +199,7 @@
                 renderBoard(state.community);
                 renderSeats(state);
                 renderActions(state);
+                renderShotClock(state);
                 renderResult(state.lastResult);
             })
             .catch(function () { /* keep last known state */ });

--- a/web/src/main/resources/templates/poker-table.html
+++ b/web/src/main/resources/templates/poker-table.html
@@ -52,6 +52,7 @@
         </div>
 
         <div id="poker-status" class="muted" style="margin-top: 0.75rem;"></div>
+        <div id="poker-shot-clock" class="muted poker-shot-clock" style="margin-top: 0.25rem;" hidden></div>
         <div id="poker-result" class="muted" style="margin-top: 0.5rem;"></div>
         <div id="poker-pots" class="poker-pots-container" style="margin-top: 0.5rem;" hidden></div>
     </section>

--- a/web/src/test/js/poker-shot-clock.test.js
+++ b/web/src/test/js/poker-shot-clock.test.js
@@ -1,0 +1,135 @@
+/**
+ * Pure-DOM unit test for the shot-clock countdown. We can't load the
+ * full poker-table.js because it relies on the page's `#main` data-*
+ * attributes and a fetch-driven loop; instead we re-implement the
+ * tiny `renderShotClock` function here mirror-style and assert on its
+ * DOM behaviour. The production source is the canonical version —
+ * this test serves as a contract check that the rendering shape (hide
+ * when 0/null, "Ns" countdown, "Time!" at zero) is what we want.
+ */
+describe('poker-table shot-clock countdown', () => {
+    let shotClockEl;
+    let shotClockTicker;
+
+    function renderShotClock(state) {
+        if (!shotClockEl) return;
+        if (shotClockTicker) { clearInterval(shotClockTicker); shotClockTicker = null; }
+        const deadline = state.currentActorDeadlineEpochMillis;
+        if (!state.shotClockSeconds || !deadline || state.phase === 'WAITING') {
+            shotClockEl.hidden = true;
+            shotClockEl.textContent = '';
+            return;
+        }
+        function tick() {
+            const remainingMs = deadline - Date.now();
+            if (remainingMs <= 0) {
+                shotClockEl.textContent = 'Time!';
+                if (shotClockTicker) { clearInterval(shotClockTicker); shotClockTicker = null; }
+                return;
+            }
+            shotClockEl.textContent = Math.ceil(remainingMs / 1000) + 's';
+        }
+        shotClockEl.hidden = false;
+        tick();
+        shotClockTicker = setInterval(tick, 1000);
+    }
+
+    beforeEach(() => {
+        document.body.innerHTML = '<div id="clock" hidden></div>';
+        shotClockEl = document.getElementById('clock');
+        shotClockTicker = null;
+        jest.useFakeTimers();
+        jest.setSystemTime(new Date('2026-05-01T10:00:00Z'));
+    });
+
+    afterEach(() => {
+        if (shotClockTicker) clearInterval(shotClockTicker);
+        jest.useRealTimers();
+    });
+
+    test('stays hidden when shot clock is disabled (0)', () => {
+        renderShotClock({
+            phase: 'PRE_FLOP',
+            shotClockSeconds: 0,
+            currentActorDeadlineEpochMillis: Date.now() + 30_000,
+        });
+        expect(shotClockEl.hidden).toBe(true);
+        expect(shotClockEl.textContent).toBe('');
+    });
+
+    test('stays hidden when no actor deadline is set', () => {
+        renderShotClock({
+            phase: 'PRE_FLOP',
+            shotClockSeconds: 30,
+            currentActorDeadlineEpochMillis: null,
+        });
+        expect(shotClockEl.hidden).toBe(true);
+    });
+
+    test('stays hidden when phase is WAITING (between hands)', () => {
+        renderShotClock({
+            phase: 'WAITING',
+            shotClockSeconds: 30,
+            currentActorDeadlineEpochMillis: Date.now() + 30_000,
+        });
+        expect(shotClockEl.hidden).toBe(true);
+    });
+
+    test('renders rounded-up seconds remaining when armed', () => {
+        renderShotClock({
+            phase: 'PRE_FLOP',
+            shotClockSeconds: 30,
+            currentActorDeadlineEpochMillis: Date.now() + 12_400,
+        });
+        expect(shotClockEl.hidden).toBe(false);
+        // 12.4s remaining → ceil = 13s.
+        expect(shotClockEl.textContent).toBe('13s');
+    });
+
+    test('ticks down every second', () => {
+        renderShotClock({
+            phase: 'PRE_FLOP',
+            shotClockSeconds: 30,
+            currentActorDeadlineEpochMillis: Date.now() + 5000,
+        });
+        expect(shotClockEl.textContent).toBe('5s');
+        jest.advanceTimersByTime(1000);
+        expect(shotClockEl.textContent).toBe('4s');
+        jest.advanceTimersByTime(2000);
+        expect(shotClockEl.textContent).toBe('2s');
+    });
+
+    test('shows "Time!" once the deadline elapses', () => {
+        renderShotClock({
+            phase: 'PRE_FLOP',
+            shotClockSeconds: 30,
+            currentActorDeadlineEpochMillis: Date.now() + 1500,
+        });
+        expect(shotClockEl.textContent).toBe('2s');
+        jest.advanceTimersByTime(2000);
+        expect(shotClockEl.textContent).toBe('Time!');
+        // Further ticks must not flip it back to a positive number.
+        jest.advanceTimersByTime(5000);
+        expect(shotClockEl.textContent).toBe('Time!');
+    });
+
+    test('switching from "armed" to "WAITING" clears the previous tick', () => {
+        renderShotClock({
+            phase: 'PRE_FLOP',
+            shotClockSeconds: 30,
+            currentActorDeadlineEpochMillis: Date.now() + 30_000,
+        });
+        expect(shotClockEl.hidden).toBe(false);
+        renderShotClock({
+            phase: 'WAITING',
+            shotClockSeconds: 30,
+            currentActorDeadlineEpochMillis: null,
+        });
+        expect(shotClockEl.hidden).toBe(true);
+        expect(shotClockEl.textContent).toBe('');
+        // Advance past the prior deadline — the disabled state must
+        // not start counting again.
+        jest.advanceTimersByTime(60_000);
+        expect(shotClockEl.textContent).toBe('');
+    });
+});

--- a/web/src/test/kotlin/web/service/ModerationWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/ModerationWebServiceTest.kt
@@ -252,6 +252,69 @@ class ModerationWebServiceTest {
     }
 
     @Test
+    fun `updateConfig accepts POKER chip-amount keys when value is a positive long`() {
+        mockMember(ownerId, isOwner = true)
+        val keys = listOf(
+            ConfigDto.Configurations.POKER_SMALL_BLIND,
+            ConfigDto.Configurations.POKER_BIG_BLIND,
+            ConfigDto.Configurations.POKER_SMALL_BET,
+            ConfigDto.Configurations.POKER_BIG_BET,
+            ConfigDto.Configurations.POKER_MIN_BUY_IN,
+            ConfigDto.Configurations.POKER_MAX_BUY_IN,
+        )
+        for (key in keys) {
+            val err = service.updateConfig(ownerId, guildId, key, "250")
+            assertNull(err, "expected $key to accept 250")
+            verify { configService.upsertConfig(key.configValue, "250", guildId.toString()) }
+        }
+    }
+
+    @Test
+    fun `updateConfig rejects POKER chip-amount keys when value is non-numeric or below 1`() {
+        mockMember(ownerId, isOwner = true)
+        val key = ConfigDto.Configurations.POKER_SMALL_BLIND
+
+        val nonNumeric = service.updateConfig(ownerId, guildId, key, "abc")
+        assertNotNull(nonNumeric)
+        val zero = service.updateConfig(ownerId, guildId, key, "0")
+        assertNotNull(zero)
+        val negative = service.updateConfig(ownerId, guildId, key, "-5")
+        assertNotNull(negative)
+        verify(exactly = 0) { configService.upsertConfig(key.configValue, any(), any()) }
+    }
+
+    @Test
+    fun `updateConfig accepts POKER_MAX_SEATS only within 2 to 9`() {
+        mockMember(ownerId, isOwner = true)
+        val key = ConfigDto.Configurations.POKER_MAX_SEATS
+
+        assertNull(service.updateConfig(ownerId, guildId, key, "2"))
+        assertNull(service.updateConfig(ownerId, guildId, key, "9"))
+        verify { configService.upsertConfig(key.configValue, "2", guildId.toString()) }
+        verify { configService.upsertConfig(key.configValue, "9", guildId.toString()) }
+
+        assertNotNull(service.updateConfig(ownerId, guildId, key, "1"))
+        assertNotNull(service.updateConfig(ownerId, guildId, key, "10"))
+        assertNotNull(service.updateConfig(ownerId, guildId, key, "n/a"))
+    }
+
+    @Test
+    fun `updateConfig accepts POKER_SHOT_CLOCK_SECONDS in 0 to 600 (0 disables)`() {
+        mockMember(ownerId, isOwner = true)
+        val key = ConfigDto.Configurations.POKER_SHOT_CLOCK_SECONDS
+
+        assertNull(service.updateConfig(ownerId, guildId, key, "0"))
+        assertNull(service.updateConfig(ownerId, guildId, key, "30"))
+        assertNull(service.updateConfig(ownerId, guildId, key, "600"))
+        verify { configService.upsertConfig(key.configValue, "0", guildId.toString()) }
+        verify { configService.upsertConfig(key.configValue, "30", guildId.toString()) }
+
+        assertNotNull(service.updateConfig(ownerId, guildId, key, "-1"))
+        assertNotNull(service.updateConfig(ownerId, guildId, key, "601"))
+        assertNotNull(service.updateConfig(ownerId, guildId, key, "asdf"))
+    }
+
+    @Test
     fun `updateConfig accepts MOVE when channel name exists`() {
         mockMember(ownerId, isOwner = true)
         val vc = mockk<VoiceChannel>(relaxed = true)


### PR DESCRIPTION
## Summary

Second poker v2 PR: per-guild config + per-actor shot clock. v1 hardcoded all table limits and had no per-action timeout; this wires every parameter to `ConfigService` and adds an auto-fold clock for slow actors.

## What changed

**Config keys** (`ConfigDto.Configurations`)
- `POKER_SMALL_BLIND`, `POKER_BIG_BLIND`
- `POKER_SMALL_BET`, `POKER_BIG_BET`
- `POKER_MIN_BUY_IN`, `POKER_MAX_BUY_IN`
- `POKER_MAX_SEATS` (2–9)
- `POKER_SHOT_CLOCK_SECONDS` (0 disables; default 30s)

All optional with sensible defaults. Discord `/setconfig` and the `/moderation` web tab both validate per the key's range; chip amounts must be positive longs, seats are 2–9, the clock is 0–600.

**Snapshot, don't read live** — `PokerService.createTable` now reads the guild's poker config and stores those values on the table at creation. A mid-hand admin tweak doesn't change limits under an in-flight hand; the next `createTable` call picks up the new values.

**Per-actor shot clock** — `PokerTableRegistry` keeps a `ConcurrentHashMap<Long, ScheduledFuture<*>>` of pending timeouts. Each `applyAction` `Continued` / `StreetAdvanced` event rearms the clock for the new actor; `HandResolved` cancels it. When the clock fires, `onShotClockExpired` calls back into `PokerService.applyAction(...Fold...)`. Stale fires (the clock task races a near-deadline action) are detected and dropped — the task checks `(handNumber, actorIndex)` against the live table state before invoking the callback. `sweepIdle` also cancels the pending task on table eviction.

**Web visibility** — `PokerWebService.TableStateView` exposes `shotClockSeconds` + `currentActorDeadlineEpochMillis`. The page runs a 1Hz ticker so the countdown is smooth between 2-second polls instead of jumping in 2-second steps.

## Tests

Backend
- `PokerServiceConfigSnapshotTest` — defaults fallback, per-key read, mid-hand admin tweak does NOT affect in-flight tables, unparseable / out-of-range values clamp correctly.
- `PokerTableRegistryShotClockTest` — arm/cancel/fire happy paths, stale-fire suppression when the actor advances under a race, `sweepIdle` cancels evicted tables' clocks.
- `ModerationWebServiceTest` — every new key has accept/reject coverage at its boundaries.

Frontend
- `poker-shot-clock.test.js` — hidden on `0` / null / `WAITING`, rounded countdown, "Time!" once the deadline elapses, prior tick cleared on re-render.

## Test plan

- [x] `./gradlew :database:test` — passes (incl. new tests)
- [x] `./gradlew :web:test` — passes
- [x] `npx jest` — 188 tests pass
- [ ] `:discord-bot:test` — couldn't run locally (sandbox blocks lavalink/libdave deps); CI should confirm
- [ ] Manual: set `POKER_SHOT_CLOCK_SECONDS=10` via web `/moderation`, start a hand, let an actor sit on the clock, confirm they auto-fold; set to `0`, confirm the countdown disappears

https://claude.ai/code/session_0169MvtJ2BSbwkoB9GrFhfZC

---
_Generated by [Claude Code](https://claude.ai/code/session_0169MvtJ2BSbwkoB9GrFhfZC)_