### PR TITLE
feat(poker): rebuy + mid-hand leave + hand history (v2-3)

### DIFF
--- a/database/src/main/kotlin/database/persistence/PokerHandLogPersistence.kt
+++ b/database/src/main/kotlin/database/persistence/PokerHandLogPersistence.kt
@@ -4,4 +4,19 @@ import database.dto.PokerHandLogDto
 
 interface PokerHandLogPersistence {
     fun insert(row: PokerHandLogDto): PokerHandLogDto
+
+    /**
+     * Most recent settled hands on [tableId] within [guildId], newest
+     * first. The guild filter is intentional: tables share an in-memory
+     * id namespace across guilds, so a stale id from another server
+     * must never leak rows out of its own guild.
+     */
+    fun findRecentByTable(guildId: Long, tableId: Long, limit: Int): List<PokerHandLogDto>
+
+    /**
+     * Most recent settled hands across the entire guild (any table),
+     * newest first. Used by `/poker history` when no `table:` argument
+     * is given.
+     */
+    fun findRecentByGuild(guildId: Long, limit: Int): List<PokerHandLogDto>
 }

--- a/database/src/main/kotlin/database/persistence/impl/DefaultPokerHandLogPersistence.kt
+++ b/database/src/main/kotlin/database/persistence/impl/DefaultPokerHandLogPersistence.kt
@@ -19,4 +19,26 @@ class DefaultPokerHandLogPersistence : PokerHandLogPersistence {
         entityManager.flush()
         return row
     }
+
+    override fun findRecentByTable(guildId: Long, tableId: Long, limit: Int): List<PokerHandLogDto> =
+        entityManager.createQuery(
+            "SELECT h FROM PokerHandLogDto h " +
+                "WHERE h.guildId = :guildId AND h.tableId = :tableId " +
+                "ORDER BY h.resolvedAt DESC, h.id DESC",
+            PokerHandLogDto::class.java
+        )
+            .setParameter("guildId", guildId)
+            .setParameter("tableId", tableId)
+            .setMaxResults(limit.coerceAtLeast(0))
+            .resultList
+
+    override fun findRecentByGuild(guildId: Long, limit: Int): List<PokerHandLogDto> =
+        entityManager.createQuery(
+            "SELECT h FROM PokerHandLogDto h WHERE h.guildId = :guildId " +
+                "ORDER BY h.resolvedAt DESC, h.id DESC",
+            PokerHandLogDto::class.java
+        )
+            .setParameter("guildId", guildId)
+            .setMaxResults(limit.coerceAtLeast(0))
+            .resultList
 }

--- a/database/src/main/kotlin/database/poker/PokerTable.kt
+++ b/database/src/main/kotlin/database/poker/PokerTable.kt
@@ -64,7 +64,17 @@ class PokerTable(
         var holeCards: List<Card> = emptyList(),
         var committedThisRound: Long = 0L,
         var totalCommittedThisHand: Long = 0L,
-        var status: SeatStatus = SeatStatus.SITTING_OUT
+        var status: SeatStatus = SeatStatus.SITTING_OUT,
+        /**
+         * v2 (PR #v2-3): set when a seated player asks to leave during
+         * a hand. Honoured by [PokerEngine] (the seat is excluded from
+         * the next hand's start) and by [database.service.PokerService]
+         * (the seat is folded on its turn during the in-flight hand,
+         * then cashed out as soon as the hand resolves). Stays `false`
+         * for buy-in / between-hand cash-outs — those go through the
+         * synchronous flow that removes the seat directly.
+         */
+        var pendingLeave: Boolean = false
     )
 
     /**

--- a/database/src/main/kotlin/database/service/PokerService.kt
+++ b/database/src/main/kotlin/database/service/PokerService.kt
@@ -604,6 +604,28 @@ class PokerService @Autowired constructor(
      */
     fun snapshot(tableId: Long): PokerTable? = tableRegistry.get(tableId)
 
+    /**
+     * Most recent settled hands for [tableId] within [guildId], newest
+     * first. Returns at most [limit] rows; passing a non-positive limit
+     * yields an empty list. Used by `/poker history` and the web
+     * audit panel.
+     */
+    fun recentHandsForTable(guildId: Long, tableId: Long, limit: Int = HISTORY_DEFAULT_LIMIT): List<PokerHandLogDto> =
+        if (limit <= 0) emptyList()
+        else handLogPersistence.findRecentByTable(
+            guildId, tableId, limit.coerceAtMost(HISTORY_MAX_LIMIT)
+        )
+
+    /**
+     * Most recent settled hands across the entire guild, newest first.
+     * Used when `/poker history` is invoked without a table id.
+     */
+    fun recentHandsForGuild(guildId: Long, limit: Int = HISTORY_DEFAULT_LIMIT): List<PokerHandLogDto> =
+        if (limit <= 0) emptyList()
+        else handLogPersistence.findRecentByGuild(
+            guildId, limit.coerceAtMost(HISTORY_MAX_LIMIT)
+        )
+
     /** Pure helper exposed for the embeds layer. */
     fun rakeRate(guildId: Long): Double {
         val cfg = configService.getConfigByName(
@@ -694,5 +716,12 @@ class PokerService @Autowired constructor(
 
         const val DEFAULT_RAKE: Double = 0.05
         const val MAX_RAKE: Double = 0.20
+
+        // /poker history defaults — matched to a single Discord embed
+        // that fits comfortably in the 4096-char description budget.
+        // The hard ceiling protects against a caller asking for so many
+        // rows that the JPA query gets pathological.
+        const val HISTORY_DEFAULT_LIMIT: Int = 10
+        const val HISTORY_MAX_LIMIT: Int = 25
     }
 }

--- a/database/src/main/kotlin/database/service/PokerService.kt
+++ b/database/src/main/kotlin/database/service/PokerService.kt
@@ -87,6 +87,17 @@ class PokerService @Autowired constructor(
         data object HandInProgress : CashOutOutcome
     }
 
+    sealed interface RebuyOutcome {
+        data class Ok(val seatChips: Long, val newBalance: Long) : RebuyOutcome
+        data object TableNotFound : RebuyOutcome
+        data object NotSeated : RebuyOutcome
+        data object HandInProgress : RebuyOutcome
+        data class InvalidAmount(val min: Long, val max: Long) : RebuyOutcome
+        data class StackCapped(val cap: Long, val current: Long) : RebuyOutcome
+        data class InsufficientCredits(val have: Long, val needed: Long) : RebuyOutcome
+        data object UnknownUser : RebuyOutcome
+    }
+
     sealed interface StartHandOutcome {
         data class Ok(val handNumber: Long) : StartHandOutcome
         data object TableNotFound : StartHandOutcome
@@ -266,6 +277,66 @@ class PokerService @Autowired constructor(
         user.socialCredit = balance - buyIn
         userService.updateUser(user)
         return BuyInOutcome.Ok(seatIndex = seatIndex, newBalance = user.socialCredit ?: 0L)
+    }
+
+    /**
+     * Top up an already-seated player's stack between hands. Mirrors
+     * [buyIn] (debits `socialCredit`, escrows the chips on the seat)
+     * but stacks onto an existing seat instead of adding a new one.
+     *
+     * Constraints:
+     *   - Only between hands ([PokerTable.Phase.WAITING]). Mid-hand
+     *     rebuys would let a busted player rejoin the same hand.
+     *   - Post-rebuy stack capped at [PokerTable.maxBuyIn]. A partial
+     *     top-up that would breach the cap is rejected outright; the
+     *     caller can re-issue with a smaller [amount]. Silent
+     *     truncation would be a footgun for the slash-command UX.
+     */
+    @Transactional
+    fun rebuy(
+        discordId: Long,
+        guildId: Long,
+        tableId: Long,
+        amount: Long
+    ): RebuyOutcome {
+        val table = tableRegistry.get(tableId) ?: return RebuyOutcome.TableNotFound
+        if (table.guildId != guildId) return RebuyOutcome.TableNotFound
+        if (amount < table.minBuyIn || amount > table.maxBuyIn) {
+            return RebuyOutcome.InvalidAmount(table.minBuyIn, table.maxBuyIn)
+        }
+
+        val user = userService.getUserByIdForUpdate(discordId, guildId)
+            ?: return RebuyOutcome.UnknownUser
+        val balance = user.socialCredit ?: 0L
+        if (balance < amount) {
+            return RebuyOutcome.InsufficientCredits(have = balance, needed = amount)
+        }
+
+        val rebuyResult = synchronized(table) {
+            when {
+                table.phase != PokerTable.Phase.WAITING -> RebuyOutcome.HandInProgress
+                else -> {
+                    val seat = table.seats.firstOrNull { it.discordId == discordId }
+                    when {
+                        seat == null -> RebuyOutcome.NotSeated
+                        seat.chips + amount > table.maxBuyIn ->
+                            RebuyOutcome.StackCapped(cap = table.maxBuyIn, current = seat.chips)
+                        else -> {
+                            seat.chips += amount
+                            RebuyOutcome.Ok(seatChips = seat.chips, newBalance = 0L)
+                        }
+                    }
+                }
+            }
+        }
+        if (rebuyResult !is RebuyOutcome.Ok) return rebuyResult
+
+        user.socialCredit = balance - amount
+        userService.updateUser(user)
+        return RebuyOutcome.Ok(
+            seatChips = rebuyResult.seatChips,
+            newBalance = user.socialCredit ?: 0L
+        )
     }
 
     @Transactional

--- a/database/src/main/kotlin/database/service/PokerService.kt
+++ b/database/src/main/kotlin/database/service/PokerService.kt
@@ -84,7 +84,29 @@ class PokerService @Autowired constructor(
         data class Ok(val chipsReturned: Long, val newBalance: Long) : CashOutOutcome
         data object TableNotFound : CashOutOutcome
         data object NotSeated : CashOutOutcome
+        /**
+         * Kept around for backward-compat with v1 callers that may still
+         * surface a "wait for the hand" message. v2-3 routes mid-hand
+         * leaves through [QueuedForEndOfHand] instead, but this remains
+         * a valid outcome for any pre-existing test that pinned to it.
+         */
         data object HandInProgress : CashOutOutcome
+        /**
+         * v2 (PR #v2-3): the player asked to leave during a hand. Their
+         * seat is marked `pendingLeave`; the engine auto-folds them on
+         * their turn, and the chips are returned to their wallet as soon
+         * as the hand resolves. [chipsHeld] is the seat's stack at the
+         * moment the leave was queued — it's NOT the final cash-out
+         * amount (the player can still bleed chips from the auto-fold's
+         * forced blinds if they were already past blinds, but in
+         * practice fold-on-turn after a leave costs nothing extra).
+         */
+        data class QueuedForEndOfHand(val chipsHeld: Long) : CashOutOutcome
+        /**
+         * The player already requested to leave this hand. Idempotent
+         * second click yields this rather than re-folding them.
+         */
+        data object AlreadyLeaving : CashOutOutcome
     }
 
     sealed interface RebuyOutcome {
@@ -345,10 +367,56 @@ class PokerService @Autowired constructor(
         guildId: Long,
         tableId: Long
     ): CashOutOutcome {
+        val now = Instant.now()
         val table = tableRegistry.get(tableId) ?: return CashOutOutcome.TableNotFound
         if (table.guildId != guildId) return CashOutOutcome.TableNotFound
 
+        // Mid-hand path: queue the leave instead of removing the seat.
+        // Sentinel-encode the seat-side outcome so we can release the
+        // monitor before deciding whether to drive an immediate fold
+        // (which itself takes the monitor again via [applyAction]).
+        val midHand = synchronized(table) {
+            if (table.phase == PokerTable.Phase.WAITING) {
+                MidHandOutcome.NotApplicable
+            } else {
+                val seatIdx = table.seats.indexOfFirst { it.discordId == discordId }
+                val seat = if (seatIdx >= 0) table.seats[seatIdx] else null
+                when {
+                    seat == null -> MidHandOutcome.NotSeated
+                    seat.pendingLeave -> MidHandOutcome.AlreadyLeaving
+                    else -> {
+                        seat.pendingLeave = true
+                        MidHandOutcome.Queued(
+                            chipsHeld = seat.chips,
+                            isCurrentActor = seatIdx == table.actorIndex &&
+                                seat.status == PokerTable.SeatStatus.ACTIVE
+                        )
+                    }
+                }
+            }
+        }
+        when (midHand) {
+            is MidHandOutcome.NotSeated -> return CashOutOutcome.NotSeated
+            is MidHandOutcome.AlreadyLeaving -> return CashOutOutcome.AlreadyLeaving
+            is MidHandOutcome.Queued -> {
+                // If it's the leaver's turn, drive the fold straight
+                // through the proxy so the @Transactional / shot-clock /
+                // hand-resolution plumbing in [applyAction] runs the same
+                // way it would for any other fold. The fold may resolve
+                // the hand outright, in which case the post-resolution
+                // sweep cashes us out before this method returns.
+                if (midHand.isCurrentActor) {
+                    transactionalSelf.applyAction(discordId, guildId, tableId, PokerAction.Fold, now)
+                }
+                return CashOutOutcome.QueuedForEndOfHand(chipsHeld = midHand.chipsHeld)
+            }
+            is MidHandOutcome.NotApplicable -> Unit // fall through to between-hands path
+        }
+
+        // Between-hands path: existing instant cash-out.
         val chipsToReturn = synchronized(table) {
+            // Re-check the phase under the monitor: a [startHand] could
+            // have raced us between the mid-hand probe and here.
             if (table.phase != PokerTable.Phase.WAITING) return@synchronized -1L
             val idx = table.seats.indexOfFirst { it.discordId == discordId }
             if (idx < 0) return@synchronized -2L
@@ -379,6 +447,13 @@ class PokerService @Autowired constructor(
             if (table.seats.isEmpty()) tableRegistry.remove(tableId)
         }
         return CashOutOutcome.Ok(chipsReturned = chipsToReturn, newBalance = newBalance)
+    }
+
+    private sealed interface MidHandOutcome {
+        data object NotApplicable : MidHandOutcome
+        data object NotSeated : MidHandOutcome
+        data object AlreadyLeaving : MidHandOutcome
+        data class Queued(val chipsHeld: Long, val isCurrentActor: Boolean) : MidHandOutcome
     }
 
     /**
@@ -423,8 +498,25 @@ class PokerService @Autowired constructor(
         if (table.guildId != guildId) return ActionOutcome.TableNotFound
 
         val rakeRate = rakeRate(guildId)
+        // Apply the player's action, then keep folding any subsequent
+        // actor whose seat is `pendingLeave` (v2-3 mid-hand /poker leave)
+        // so the hand never stalls on someone who's already asked to
+        // leave the table. The engine itself stays oblivious to
+        // pendingLeave — we just feed it Folds on those seats' behalf.
         val outcome = synchronized(table) {
-            PokerEngine.applyAction(table, discordId, action, rakeRate, now)
+            var current: PokerEngine.ApplyResult =
+                PokerEngine.applyAction(table, discordId, action, rakeRate, now)
+            cascadeLoop@ while (current is PokerEngine.ApplyResult.Applied) {
+                val ev = (current as PokerEngine.ApplyResult.Applied).event
+                if (ev is PokerEngine.ActionEvent.HandResolved) break@cascadeLoop
+                val nextSeat = table.seats.getOrNull(table.actorIndex) ?: break@cascadeLoop
+                if (!nextSeat.pendingLeave) break@cascadeLoop
+                if (nextSeat.status != PokerTable.SeatStatus.ACTIVE) break@cascadeLoop
+                current = PokerEngine.applyAction(
+                    table, nextSeat.discordId, PokerAction.Fold, rakeRate, now
+                )
+            }
+            current
         }
         // Reset the per-actor clock based on what the engine produced:
         // a continuing or street-advancing event puts a fresh decision
@@ -449,9 +541,60 @@ class PokerService @Autowired constructor(
                     if (ev.result.rake > 0L) {
                         jackpotService.addToPool(guildId, ev.result.rake)
                     }
+                    // v2-3: cash out any seats marked pendingLeave during
+                    // the hand. Done after rake / log so a side-pot
+                    // refund the engine credited to a leaver still gets
+                    // returned to their wallet on the same call.
+                    sweepPendingLeaves(table)
                     ActionOutcome.HandResolved(ev.result)
                 }
             }
+        }
+    }
+
+    /**
+     * Refund chips for every seat whose player asked to leave during
+     * the just-resolved hand. Called from [applyAction] right after
+     * [PokerEngine] reports `HandResolved`. Mirrors [evictAllSeats] but
+     * filtered to the pendingLeave subset and with seat removal from
+     * the table once the wallet credit lands.
+     */
+    private fun sweepPendingLeaves(table: PokerTable) {
+        val refunds: Map<Long, Long> = synchronized(table) {
+            val targets = table.seats.filter { it.pendingLeave }
+            if (targets.isEmpty()) return@synchronized emptyMap()
+            val out = targets.associate { it.discordId to it.chips }
+            // Remove leavers from the seat list. Adjust the dealer index
+            // so the next hand starts in a consistent spot, mirroring
+            // the between-hands cashOut.
+            for (target in targets) {
+                val idx = table.seats.indexOf(target)
+                table.seats.removeAt(idx)
+                if (table.seats.isEmpty()) {
+                    table.dealerIndex = 0
+                } else if (idx <= table.dealerIndex) {
+                    table.dealerIndex =
+                        (table.dealerIndex - 1).coerceAtLeast(0) % table.seats.size
+                }
+            }
+            out
+        }
+        if (refunds.isEmpty()) return
+
+        // Lock all refund recipients in ascending discord-id order to
+        // avoid cycles with concurrent /tip, /duel, /coinflip, etc.
+        // transactions touching the same users.
+        val locked = userService.lockUsersInAscendingOrder(refunds.keys, table.guildId)
+        for ((discordId, amount) in refunds) {
+            if (amount <= 0L) continue
+            val user = locked[discordId] ?: continue
+            user.socialCredit = (user.socialCredit ?: 0L) + amount
+            userService.updateUser(user)
+        }
+
+        // Drop the table if everyone left mid-hand.
+        synchronized(table) {
+            if (table.seats.isEmpty()) tableRegistry.remove(table.id)
         }
     }
 

--- a/database/src/test/kotlin/database/service/PokerServiceConfigSnapshotTest.kt
+++ b/database/src/test/kotlin/database/service/PokerServiceConfigSnapshotTest.kt
@@ -181,6 +181,8 @@ class PokerServiceConfigSnapshotTest {
         override fun insert(row: PokerHandLogDto): PokerHandLogDto {
             row.id = 1L; return row
         }
+        override fun findRecentByTable(guildId: Long, tableId: Long, limit: Int): List<PokerHandLogDto> = emptyList()
+        override fun findRecentByGuild(guildId: Long, limit: Int): List<PokerHandLogDto> = emptyList()
     }
 
     private class NoopHandPot : PokerHandPotPersistence {

--- a/database/src/test/kotlin/database/service/PokerServiceTest.kt
+++ b/database/src/test/kotlin/database/service/PokerServiceTest.kt
@@ -375,6 +375,14 @@ class PokerServiceTest {
             if (row.id == null) row.id = nextId++
             inserted.add(row); return row
         }
+        override fun findRecentByTable(guildId: Long, tableId: Long, limit: Int): List<PokerHandLogDto> =
+            inserted.asReversed()
+                .filter { it.guildId == guildId && it.tableId == tableId }
+                .take(limit.coerceAtLeast(0))
+        override fun findRecentByGuild(guildId: Long, limit: Int): List<PokerHandLogDto> =
+            inserted.asReversed()
+                .filter { it.guildId == guildId }
+                .take(limit.coerceAtLeast(0))
     }
 
     private class RecordingPokerHandPotPersistence : PokerHandPotPersistence {

--- a/database/src/test/kotlin/database/service/PokerServiceTest.kt
+++ b/database/src/test/kotlin/database/service/PokerServiceTest.kt
@@ -243,14 +243,84 @@ class PokerServiceTest {
     }
 
     @Test
-    fun `cashOut while hand in progress is rejected`() {
-        seed(host, 1000L); seed(joiner, 1000L)
+    fun `cashOut mid-hand queues leave and auto-folds the leaver if it's their turn`() {
+        seed(host, 1000L); seed(joiner, 1000L); seed(third, 1000L)
         val tableId = (service.createTable(host, guildId, buyIn = 500L) as PokerService.CreateOutcome.Ok).tableId
         service.buyIn(joiner, guildId, tableId, buyIn = 500L)
+        service.buyIn(third, guildId, tableId, buyIn = 500L)
         service.startHand(host, guildId, tableId)
 
-        val outcome = service.cashOut(host, guildId, tableId)
-        assertEquals(PokerService.CashOutOutcome.HandInProgress, outcome)
+        val table = registry.get(tableId)!!
+        val firstActorId = table.seats[table.actorIndex].discordId
+
+        // Whoever is first to act asks to leave. Should: mark pendingLeave,
+        // auto-fold them, and the table progresses to the next actor.
+        val outcome = service.cashOut(firstActorId, guildId, tableId)
+
+        assertTrue(outcome is PokerService.CashOutOutcome.QueuedForEndOfHand)
+        outcome as PokerService.CashOutOutcome.QueuedForEndOfHand
+        // Forced blind (5 or 10) may have been posted — chipsHeld captures
+        // post-blind stack. Just assert it's >0 and <buyIn.
+        assertTrue(outcome.chipsHeld in 1..500L, "chipsHeld snapshot from when leave queued: ${outcome.chipsHeld}")
+        // Seat still present (not removed until hand resolves) but folded.
+        val seat = registry.get(tableId)!!.seats.first { it.discordId == firstActorId }
+        assertTrue(seat.pendingLeave, "pendingLeave flag set")
+        assertEquals(PokerTable.SeatStatus.FOLDED, seat.status, "auto-folded since it was their turn")
+    }
+
+    @Test
+    fun `cashOut mid-hand returns chips when the hand later resolves`() {
+        seed(host, 1000L); seed(joiner, 1000L); seed(third, 1000L)
+        val tableId = (service.createTable(host, guildId, buyIn = 500L) as PokerService.CreateOutcome.Ok).tableId
+        service.buyIn(joiner, guildId, tableId, buyIn = 500L)
+        service.buyIn(third, guildId, tableId, buyIn = 500L)
+        service.startHand(host, guildId, tableId)
+
+        val table = registry.get(tableId)!!
+        // Pick a non-actor leaver: someone whose turn ISN'T up yet so we
+        // exercise the cascade path (fold-on-their-turn) rather than the
+        // immediate-fold path tested above.
+        val nonActorId = table.seats.first { table.seats.indexOf(it) != table.actorIndex }.discordId
+        service.cashOut(nonActorId, guildId, tableId)
+
+        // Drive the hand to completion: keep folding until a winner.
+        // Actors not in pendingLeave remain free to act normally; the
+        // cascade will auto-fold the leaver when their turn comes.
+        var safety = 12
+        while (registry.get(tableId)?.phase != PokerTable.Phase.WAITING && safety-- > 0) {
+            val live = registry.get(tableId) ?: break
+            val actor = live.seats.getOrNull(live.actorIndex) ?: break
+            service.applyAction(actor.discordId, guildId, tableId, PokerEngine.PokerAction.Fold)
+        }
+
+        // Leaver's seat should be gone (post-hand sweep removed it),
+        // their balance refunded.
+        val tableAfter = registry.get(tableId)
+        if (tableAfter != null) {
+            assertFalse(tableAfter.seats.any { it.discordId == nonActorId }, "leaver's seat removed")
+        }
+        // Their chip balance should have been refunded (1000 buy-in 500
+        // → 500 wallet at table start; refund brings them back ≥500
+        // since chips bled only via blinds at most).
+        val finalBalance = userService.current(nonActorId)?.socialCredit ?: 0L
+        assertTrue(finalBalance >= 490L, "leaver got their chips back, balance=$finalBalance")
+    }
+
+    @Test
+    fun `cashOut mid-hand twice returns AlreadyLeaving`() {
+        seed(host, 1000L); seed(joiner, 1000L); seed(third, 1000L)
+        val tableId = (service.createTable(host, guildId, buyIn = 500L) as PokerService.CreateOutcome.Ok).tableId
+        service.buyIn(joiner, guildId, tableId, buyIn = 500L)
+        service.buyIn(third, guildId, tableId, buyIn = 500L)
+        service.startHand(host, guildId, tableId)
+
+        val table = registry.get(tableId)!!
+        val nonActorId = table.seats.first { table.seats.indexOf(it) != table.actorIndex }.discordId
+        val first = service.cashOut(nonActorId, guildId, tableId)
+        assertTrue(first is PokerService.CashOutOutcome.QueuedForEndOfHand)
+
+        val second = service.cashOut(nonActorId, guildId, tableId)
+        assertEquals(PokerService.CashOutOutcome.AlreadyLeaving, second)
     }
 
     @Test

--- a/database/src/test/kotlin/database/service/PokerServiceTest.kt
+++ b/database/src/test/kotlin/database/service/PokerServiceTest.kt
@@ -324,6 +324,85 @@ class PokerServiceTest {
     }
 
     @Test
+    fun `recentHandsForTable returns guild-scoped rows newest-first capped by limit`() {
+        // Three hands at table 7 in our guild, one at table 7 in a different
+        // guild — must NOT leak across guilds.
+        val now = java.time.Instant.parse("2025-01-01T00:00:00Z")
+        handLog.insert(PokerHandLogDto(
+            guildId = guildId, tableId = 7L, handNumber = 1L,
+            players = "1,2", winners = "1", pot = 10, rake = 0, board = "AS",
+            resolvedAt = now
+        ))
+        handLog.insert(PokerHandLogDto(
+            guildId = guildId, tableId = 7L, handNumber = 2L,
+            players = "1,2", winners = "2", pot = 20, rake = 0, board = "AS,KD",
+            resolvedAt = now.plusSeconds(60)
+        ))
+        handLog.insert(PokerHandLogDto(
+            guildId = 999L, tableId = 7L, handNumber = 3L,
+            players = "9,8", winners = "9", pot = 30, rake = 0, board = "TC",
+            resolvedAt = now.plusSeconds(120)
+        ))
+        handLog.insert(PokerHandLogDto(
+            guildId = guildId, tableId = 7L, handNumber = 4L,
+            players = "1,2", winners = "1", pot = 40, rake = 0, board = "AH,KS,QC",
+            resolvedAt = now.plusSeconds(180)
+        ))
+
+        val rows = service.recentHandsForTable(guildId, tableId = 7L, limit = 5)
+
+        assertEquals(3, rows.size, "only this guild's rows for table 7")
+        // Recording stub orders newest-first.
+        assertEquals(listOf(4L, 2L, 1L), rows.map { it.handNumber })
+        assertTrue(rows.all { it.guildId == guildId }, "no cross-guild leakage")
+    }
+
+    @Test
+    fun `recentHandsForGuild returns all tables for the guild capped by limit`() {
+        val now = java.time.Instant.parse("2025-01-01T00:00:00Z")
+        handLog.insert(PokerHandLogDto(
+            guildId = guildId, tableId = 1L, handNumber = 1L,
+            players = "1", winners = "1", pot = 10, rake = 0, board = "",
+            resolvedAt = now
+        ))
+        handLog.insert(PokerHandLogDto(
+            guildId = guildId, tableId = 2L, handNumber = 1L,
+            players = "1", winners = "1", pot = 10, rake = 0, board = "",
+            resolvedAt = now.plusSeconds(30)
+        ))
+        handLog.insert(PokerHandLogDto(
+            guildId = 999L, tableId = 1L, handNumber = 1L,
+            players = "9", winners = "9", pot = 99, rake = 0, board = "",
+            resolvedAt = now.plusSeconds(60)
+        ))
+
+        val rows = service.recentHandsForGuild(guildId, limit = 10)
+
+        assertEquals(2, rows.size, "both this guild's hands across tables")
+        assertTrue(rows.all { it.guildId == guildId })
+    }
+
+    @Test
+    fun `recentHandsForGuild caps limit to HISTORY_MAX_LIMIT`() {
+        repeat(PokerService.HISTORY_MAX_LIMIT + 5) { i ->
+            handLog.insert(PokerHandLogDto(
+                guildId = guildId, tableId = 1L, handNumber = (i + 1).toLong(),
+                players = "1", winners = "1", pot = 10, rake = 0, board = "",
+                resolvedAt = java.time.Instant.now().plusSeconds(i.toLong())
+            ))
+        }
+        val rows = service.recentHandsForGuild(guildId, limit = 1000)
+        assertEquals(PokerService.HISTORY_MAX_LIMIT, rows.size, "limit clamped down to MAX")
+    }
+
+    @Test
+    fun `recentHands with non-positive limit returns empty without hitting persistence`() {
+        assertTrue(service.recentHandsForGuild(guildId, limit = 0).isEmpty())
+        assertTrue(service.recentHandsForGuild(guildId, limit = -3).isEmpty())
+        assertTrue(service.recentHandsForTable(guildId, tableId = 1L, limit = 0).isEmpty())
+    }
+
+    @Test
     fun `cashOut on table you don't sit at is rejected`() {
         seed(host, 1000L); seed(joiner, 1000L)
         val tableId = (service.createTable(host, guildId, buyIn = 200L) as PokerService.CreateOutcome.Ok).tableId

--- a/database/src/test/kotlin/database/service/PokerServiceTest.kt
+++ b/database/src/test/kotlin/database/service/PokerServiceTest.kt
@@ -134,6 +134,101 @@ class PokerServiceTest {
     }
 
     @Test
+    fun `rebuy adds chips to a seated player and debits balance`() {
+        seed(host, 1000L)
+        val tableId = (service.createTable(host, guildId, buyIn = 200L) as PokerService.CreateOutcome.Ok).tableId
+
+        val outcome = service.rebuy(host, guildId, tableId, amount = 300L)
+
+        assertTrue(outcome is PokerService.RebuyOutcome.Ok)
+        outcome as PokerService.RebuyOutcome.Ok
+        assertEquals(500L, outcome.seatChips, "200 + 300 stacks onto the seat")
+        assertEquals(500L, outcome.newBalance, "1000 - 200 createTable - 300 rebuy")
+        assertEquals(500L, registry.get(tableId)!!.seats[0].chips)
+    }
+
+    @Test
+    fun `rebuy that would breach max buy-in is rejected without debiting`() {
+        seed(host, 100_000L)
+        val tableId = (service.createTable(host, guildId, buyIn = 4_500L) as PokerService.CreateOutcome.Ok).tableId
+        // MAX_BUY_IN = 5000; seat sitting at 4500. A 1000 top-up would
+        // push to 5500 → reject. Player keeps their balance and stack.
+        val balanceBefore = userService.current(host)!!.socialCredit!!
+
+        val outcome = service.rebuy(host, guildId, tableId, amount = 1_000L)
+
+        assertTrue(outcome is PokerService.RebuyOutcome.StackCapped)
+        outcome as PokerService.RebuyOutcome.StackCapped
+        assertEquals(PokerService.MAX_BUY_IN, outcome.cap)
+        assertEquals(4_500L, outcome.current)
+        assertEquals(balanceBefore, userService.current(host)?.socialCredit, "no debit on cap rejection")
+        assertEquals(4_500L, registry.get(tableId)!!.seats[0].chips, "stack untouched on cap rejection")
+    }
+
+    @Test
+    fun `rebuy mid-hand is rejected`() {
+        seed(host, 1000L); seed(joiner, 1000L)
+        val tableId = (service.createTable(host, guildId, buyIn = 500L) as PokerService.CreateOutcome.Ok).tableId
+        service.buyIn(joiner, guildId, tableId, buyIn = 500L)
+        service.startHand(host, guildId, tableId)
+
+        val outcome = service.rebuy(host, guildId, tableId, amount = 200L)
+        assertEquals(PokerService.RebuyOutcome.HandInProgress, outcome)
+        // No debit, no chip change.
+        assertEquals(500L, userService.current(host)?.socialCredit, "balance untouched on HandInProgress")
+    }
+
+    @Test
+    fun `rebuy by someone not at the table is rejected`() {
+        seed(host, 1000L); seed(joiner, 1000L)
+        val tableId = (service.createTable(host, guildId, buyIn = 200L) as PokerService.CreateOutcome.Ok).tableId
+
+        val outcome = service.rebuy(joiner, guildId, tableId, amount = 200L)
+        assertEquals(PokerService.RebuyOutcome.NotSeated, outcome)
+    }
+
+    @Test
+    fun `rebuy with insufficient credits is rejected without seat change`() {
+        seed(host, 250L)
+        val tableId = (service.createTable(host, guildId, buyIn = 200L) as PokerService.CreateOutcome.Ok).tableId
+        // Balance is now 50 after the createTable debit; 200 rebuy unaffordable.
+
+        val outcome = service.rebuy(host, guildId, tableId, amount = 200L)
+
+        assertTrue(outcome is PokerService.RebuyOutcome.InsufficientCredits)
+        assertEquals(50L, userService.current(host)?.socialCredit, "balance unchanged")
+        assertEquals(200L, registry.get(tableId)!!.seats[0].chips, "seat chips unchanged")
+    }
+
+    @Test
+    fun `rebuy below table min or above table max is rejected`() {
+        seed(host, 100_000L)
+        val tableId = (service.createTable(host, guildId, buyIn = 200L) as PokerService.CreateOutcome.Ok).tableId
+
+        val tooSmall = service.rebuy(host, guildId, tableId, amount = 10L)
+        assertTrue(tooSmall is PokerService.RebuyOutcome.InvalidAmount)
+
+        val tooBig = service.rebuy(host, guildId, tableId, amount = 99_999L)
+        assertTrue(tooBig is PokerService.RebuyOutcome.InvalidAmount)
+    }
+
+    @Test
+    fun `rebuy on missing table returns TableNotFound`() {
+        val outcome = service.rebuy(host, guildId, tableId = 999L, amount = 200L)
+        assertEquals(PokerService.RebuyOutcome.TableNotFound, outcome)
+    }
+
+    @Test
+    fun `rebuy with mismatched guild returns TableNotFound`() {
+        seed(host, 1000L); seed(joiner, 1000L)
+        val tableId = (service.createTable(host, guildId, buyIn = 200L) as PokerService.CreateOutcome.Ok).tableId
+        // Wrong guild — must not let a player from another server top up
+        // a stack at this guild's table.
+        val outcome = service.rebuy(host, guildId = 999L, tableId = tableId, amount = 200L)
+        assertEquals(PokerService.RebuyOutcome.TableNotFound, outcome)
+    }
+
+    @Test
     fun `cashOut credits remaining chips back to balance and removes empty tables`() {
         seed(host, 1000L)
         val tableId = (service.createTable(host, guildId, buyIn = 200L) as PokerService.CreateOutcome.Ok).tableId

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/PokerCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/PokerCommand.kt
@@ -10,6 +10,7 @@ import database.service.PokerService
 import database.service.PokerService.BuyInOutcome
 import database.service.PokerService.CashOutOutcome
 import database.service.PokerService.CreateOutcome
+import database.service.PokerService.RebuyOutcome
 import database.service.PokerService.StartHandOutcome
 import net.dv8tion.jda.api.components.actionrow.ActionRow
 import net.dv8tion.jda.api.components.buttons.Button
@@ -53,6 +54,7 @@ class PokerCommand @Autowired constructor(
         private const val SUB_LEAVE = "leave"
         private const val SUB_TABLES = "tables"
         private const val SUB_PEEK = "peek"
+        private const val SUB_REBUY = "rebuy"
     }
 
     override val subCommands: List<SubcommandData> = listOf(
@@ -82,6 +84,13 @@ class PokerCommand @Autowired constructor(
             .addOptions(
                 OptionData(OptionType.INTEGER, OPT_TABLE, "Table id", true).setMinValue(1)
             ),
+        SubcommandData(SUB_REBUY, "Top up your stack between hands (capped at the table's max buy-in).")
+            .addOptions(
+                OptionData(OptionType.INTEGER, OPT_TABLE, "Table id", true).setMinValue(1),
+                OptionData(OptionType.INTEGER, OPT_BUYIN, "Chips to add", true)
+                    .setMinValue(PokerService.MIN_BUY_IN)
+                    .setMaxValue(PokerService.MAX_BUY_IN)
+            ),
     )
 
     override fun handle(ctx: CommandContext, requestingUserDto: UserDto, deleteDelay: Int) {
@@ -99,6 +108,7 @@ class PokerCommand @Autowired constructor(
             SUB_LEAVE -> handleLeave(event, requestingUserDto, guild.idLong, deleteDelay)
             SUB_TABLES -> handleTables(event, guild.idLong, deleteDelay)
             SUB_PEEK -> handlePeek(event, requestingUserDto, guild.idLong)
+            SUB_REBUY -> handleRebuy(event, requestingUserDto, guild.idLong, deleteDelay)
             else -> replyError(event, "Unknown subcommand.", deleteDelay)
         }
     }
@@ -214,6 +224,48 @@ class PokerCommand @Autowired constructor(
                 replyError(event, "You're not seated at this table.", deleteDelay)
             CashOutOutcome.TableNotFound ->
                 replyError(event, "No such table in this server.", deleteDelay)
+        }
+    }
+
+    private fun handleRebuy(
+        event: SlashCommandInteractionEvent,
+        userDto: UserDto,
+        guildId: Long,
+        deleteDelay: Int
+    ) {
+        val tableId = event.getOption(OPT_TABLE)?.asLong ?: run {
+            replyError(event, "Table id is required.", deleteDelay); return
+        }
+        val amount = event.getOption(OPT_BUYIN)?.asLong ?: run {
+            replyError(event, "Rebuy amount is required.", deleteDelay); return
+        }
+        userDtoHelper.calculateUserDto(userDto.discordId, guildId)
+        when (val outcome = pokerService.rebuy(userDto.discordId, guildId, tableId, amount)) {
+            is RebuyOutcome.Ok -> event.hook.sendMessageEmbeds(
+                PokerEmbeds.infoEmbed(
+                    "<@${userDto.discordId}> rebought **$amount** chips. " +
+                        "Stack: ${outcome.seatChips} • Balance: ${outcome.newBalance}."
+                )
+            ).queue(invokeDeleteOnMessageResponse(deleteDelay))
+            is RebuyOutcome.InvalidAmount ->
+                replyError(event, "Rebuy must be between ${outcome.min} and ${outcome.max} credits.", deleteDelay)
+            is RebuyOutcome.StackCapped ->
+                replyError(
+                    event,
+                    "Your stack would exceed this table's max buy-in (${outcome.cap}). " +
+                        "You currently have ${outcome.current} chips — try a smaller rebuy.",
+                    deleteDelay
+                )
+            is RebuyOutcome.InsufficientCredits ->
+                replyError(event, "You need ${outcome.needed} credits but only have ${outcome.have}.", deleteDelay)
+            RebuyOutcome.HandInProgress ->
+                replyError(event, "Wait for the current hand to end before rebuying.", deleteDelay)
+            RebuyOutcome.NotSeated ->
+                replyError(event, "You're not seated at this table.", deleteDelay)
+            RebuyOutcome.TableNotFound ->
+                replyError(event, "No such table in this server.", deleteDelay)
+            RebuyOutcome.UnknownUser ->
+                replyError(event, "No user record yet. Try another TobyBot command first.", deleteDelay)
         }
     }
 

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/PokerCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/PokerCommand.kt
@@ -55,6 +55,9 @@ class PokerCommand @Autowired constructor(
         private const val SUB_TABLES = "tables"
         private const val SUB_PEEK = "peek"
         private const val SUB_REBUY = "rebuy"
+        private const val SUB_HISTORY = "history"
+
+        private const val OPT_LIMIT = "limit"
     }
 
     override val subCommands: List<SubcommandData> = listOf(
@@ -91,6 +94,14 @@ class PokerCommand @Autowired constructor(
                     .setMinValue(PokerService.MIN_BUY_IN)
                     .setMaxValue(PokerService.MAX_BUY_IN)
             ),
+        SubcommandData(SUB_HISTORY, "Show recent settled hands. Pass a table id to scope to one table.")
+            .addOptions(
+                OptionData(OptionType.INTEGER, OPT_TABLE, "Table id (optional — omit for server-wide history)", false)
+                    .setMinValue(1),
+                OptionData(OptionType.INTEGER, OPT_LIMIT, "How many hands to show (default ${PokerService.HISTORY_DEFAULT_LIMIT})", false)
+                    .setMinValue(1)
+                    .setMaxValue(PokerService.HISTORY_MAX_LIMIT.toLong())
+            ),
     )
 
     override fun handle(ctx: CommandContext, requestingUserDto: UserDto, deleteDelay: Int) {
@@ -109,6 +120,7 @@ class PokerCommand @Autowired constructor(
             SUB_TABLES -> handleTables(event, guild.idLong, deleteDelay)
             SUB_PEEK -> handlePeek(event, requestingUserDto, guild.idLong)
             SUB_REBUY -> handleRebuy(event, requestingUserDto, guild.idLong, deleteDelay)
+            SUB_HISTORY -> handleHistory(event, guild.idLong, deleteDelay)
             else -> replyError(event, "Unknown subcommand.", deleteDelay)
         }
     }
@@ -275,6 +287,22 @@ class PokerCommand @Autowired constructor(
             RebuyOutcome.UnknownUser ->
                 replyError(event, "No user record yet. Try another TobyBot command first.", deleteDelay)
         }
+    }
+
+    private fun handleHistory(
+        event: SlashCommandInteractionEvent,
+        guildId: Long,
+        deleteDelay: Int
+    ) {
+        val tableId = event.getOption(OPT_TABLE)?.asLong
+        val limit = event.getOption(OPT_LIMIT)?.asLong?.toInt() ?: PokerService.HISTORY_DEFAULT_LIMIT
+        val (scope, hands) = if (tableId != null) {
+            "Table #$tableId" to pokerService.recentHandsForTable(guildId, tableId, limit)
+        } else {
+            "Server" to pokerService.recentHandsForGuild(guildId, limit)
+        }
+        event.hook.sendMessageEmbeds(PokerEmbeds.historyEmbed(scope, hands))
+            .queue(invokeDeleteOnMessageResponse(deleteDelay))
     }
 
     private fun handleTables(

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/PokerCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/PokerCommand.kt
@@ -218,6 +218,14 @@ class PokerCommand @Autowired constructor(
                         "New balance: ${outcome.newBalance} credits."
                 )
             ).queue(invokeDeleteOnMessageResponse(deleteDelay))
+            is CashOutOutcome.QueuedForEndOfHand -> event.hook.sendMessageEmbeds(
+                PokerEmbeds.infoEmbed(
+                    "<@${userDto.discordId}> is leaving — auto-folding for the rest of this hand. " +
+                        "Your **${outcome.chipsHeld}** chips will return to your balance once the hand resolves."
+                )
+            ).queue(invokeDeleteOnMessageResponse(deleteDelay))
+            CashOutOutcome.AlreadyLeaving ->
+                replyError(event, "You've already asked to leave this hand.", deleteDelay)
             CashOutOutcome.HandInProgress ->
                 replyError(event, "Wait for the current hand to end before leaving (fold first if you don't want to play it out).", deleteDelay)
             CashOutOutcome.NotSeated ->

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/PokerEmbeds.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/PokerEmbeds.kt
@@ -1,5 +1,6 @@
 package bot.toby.command.commands.economy
 
+import database.dto.PokerHandLogDto
 import database.poker.Card
 import database.poker.PokerTable
 import database.poker.PokerTable.Phase
@@ -7,6 +8,8 @@ import database.service.PokerService
 import net.dv8tion.jda.api.EmbedBuilder
 import net.dv8tion.jda.api.entities.MessageEmbed
 import java.awt.Color
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
 
 /**
  * Shared embed/component plumbing for the Discord `/poker` flow.
@@ -111,6 +114,35 @@ internal object PokerEmbeds {
         .setDescription(message)
         .setColor(ERROR_COLOR)
         .build()
+
+    /**
+     * v2-3: render up to a screenful of recent settled hands. [scope] is
+     * the title-friendly label (e.g. "Table #7" or "Server"); [hands] are
+     * the rows in the order they should be rendered (caller is expected
+     * to pass them newest-first to match the JPA query). Returns a
+     * compact summary if the list is empty rather than an empty embed.
+     */
+    fun historyEmbed(scope: String, hands: List<PokerHandLogDto>): MessageEmbed {
+        val builder = EmbedBuilder()
+            .setTitle("🃏 Recent hands • $scope")
+            .setColor(NEUTRAL_COLOR)
+        if (hands.isEmpty()) {
+            return builder.setDescription("No settled hands yet.").build()
+        }
+        val lines = hands.map { row ->
+            val winners = row.winners.split(",").filter { it.isNotBlank() }
+                .joinToString(", ") { "<@$it>" }
+                .ifBlank { "—" }
+            val board = if (row.board.isBlank()) "—" else row.board.replace(",", " ")
+            val ts = row.resolvedAt?.let { HISTORY_TIME_FMT.format(it) } ?: "—"
+            "`#${row.handNumber}` `${row.tableId}` • pot **${row.pot}** (rake ${row.rake}) • $winners • $board • _${ts}_"
+        }
+        return builder.setDescription(lines.joinToString("\n")).build()
+    }
+
+    private val HISTORY_TIME_FMT: DateTimeFormatter = DateTimeFormatter
+        .ofPattern("MMM d HH:mm")
+        .withZone(ZoneOffset.UTC)
 
     fun infoEmbed(message: String): MessageEmbed = EmbedBuilder()
         .setTitle("🃏 Poker")

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/economy/PokerCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/economy/PokerCommandTest.kt
@@ -160,6 +160,18 @@ internal class PokerCommandTest : CommandTest {
     }
 
     @Test
+    fun `leave subcommand surfaces queued-for-end-of-hand outcome`() {
+        every { event.subcommandName } returns "leave"
+        every { event.getOption("table") } returns intOpt(7L)
+        every { pokerService.cashOut(hostId, guildId, 7L) } returns
+            CashOutOutcome.QueuedForEndOfHand(chipsHeld = 480L)
+
+        command.handle(DefaultCommandContext(event), userDto(), 0)
+
+        verify(exactly = 1) { pokerService.cashOut(hostId, guildId, 7L) }
+    }
+
+    @Test
     fun `tables subcommand renders registry list`() {
         every { event.subcommandName } returns "tables"
         every { tableRegistry.listForGuild(guildId) } returns listOf(stubTable(7L), stubTable(8L))

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/economy/PokerCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/economy/PokerCommandTest.kt
@@ -224,6 +224,32 @@ internal class PokerCommandTest : CommandTest {
     }
 
     @Test
+    fun `history without table option queries guild-wide`() {
+        every { event.subcommandName } returns "history"
+        every { event.getOption("table") } returns null
+        every { event.getOption("limit") } returns null
+        every { pokerService.recentHandsForGuild(guildId, PokerService.HISTORY_DEFAULT_LIMIT) } returns emptyList()
+
+        command.handle(DefaultCommandContext(event), userDto(), 0)
+
+        verify(exactly = 1) { pokerService.recentHandsForGuild(guildId, PokerService.HISTORY_DEFAULT_LIMIT) }
+        verify(exactly = 0) { pokerService.recentHandsForTable(any(), any(), any()) }
+    }
+
+    @Test
+    fun `history with table option scopes the lookup to that table`() {
+        every { event.subcommandName } returns "history"
+        every { event.getOption("table") } returns intOpt(7L)
+        every { event.getOption("limit") } returns intOpt(5L)
+        every { pokerService.recentHandsForTable(guildId, 7L, 5) } returns emptyList()
+
+        command.handle(DefaultCommandContext(event), userDto(), 0)
+
+        verify(exactly = 1) { pokerService.recentHandsForTable(guildId, 7L, 5) }
+        verify(exactly = 0) { pokerService.recentHandsForGuild(any(), any()) }
+    }
+
+    @Test
     fun `unknown subcommand returns error without dispatching`() {
         every { event.subcommandName } returns "wibble"
 

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/economy/PokerCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/economy/PokerCommandTest.kt
@@ -12,6 +12,7 @@ import database.service.PokerService
 import database.service.PokerService.BuyInOutcome
 import database.service.PokerService.CashOutOutcome
 import database.service.PokerService.CreateOutcome
+import database.service.PokerService.RebuyOutcome
 import database.service.PokerService.StartHandOutcome
 import io.mockk.clearAllMocks
 import io.mockk.every
@@ -180,6 +181,34 @@ internal class PokerCommandTest : CommandTest {
         command.handle(DefaultCommandContext(event), userDto(), 0)
 
         verify(exactly = 0) { pokerService.applyAction(any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `rebuy subcommand delegates to PokerService rebuy`() {
+        every { event.subcommandName } returns "rebuy"
+        every { event.getOption("table") } returns intOpt(7L)
+        every { event.getOption("chips") } returns intOpt(300L)
+        every { pokerService.rebuy(hostId, guildId, 7L, 300L) } returns
+            RebuyOutcome.Ok(seatChips = 500L, newBalance = 700L)
+
+        command.handle(DefaultCommandContext(event), userDto(), 0)
+
+        verify(exactly = 1) { pokerService.rebuy(hostId, guildId, 7L, 300L) }
+        // Happy path renders an info embed; no need to look up the table.
+        verify(exactly = 0) { tableRegistry.get(any()) }
+    }
+
+    @Test
+    fun `rebuy with stack-cap rejection still surfaces an embed without table lookup`() {
+        every { event.subcommandName } returns "rebuy"
+        every { event.getOption("table") } returns intOpt(7L)
+        every { event.getOption("chips") } returns intOpt(2000L)
+        every { pokerService.rebuy(hostId, guildId, 7L, 2000L) } returns
+            RebuyOutcome.StackCapped(cap = 5000L, current = 4500L)
+
+        command.handle(DefaultCommandContext(event), userDto(), 0)
+
+        verify(exactly = 0) { tableRegistry.get(any()) }
     }
 
     @Test

--- a/web/src/main/kotlin/web/controller/PokerController.kt
+++ b/web/src/main/kotlin/web/controller/PokerController.kt
@@ -275,6 +275,12 @@ class PokerController(
             is CashOutOutcome.Ok -> ResponseEntity.ok(
                 TableActionResponse(ok = true, chipsReturned = outcome.chipsReturned, newBalance = outcome.newBalance)
             )
+            is CashOutOutcome.QueuedForEndOfHand -> ResponseEntity.ok(
+                TableActionResponse(ok = true, chipsReturned = outcome.chipsHeld, queued = true)
+            )
+            CashOutOutcome.AlreadyLeaving -> ResponseEntity.badRequest().body(
+                TableActionResponse(false, error = "You've already asked to leave this hand.")
+            )
             CashOutOutcome.HandInProgress -> ResponseEntity.badRequest().body(
                 TableActionResponse(false, error = "Hand in progress — fold first if you don't want to play it out.")
             )
@@ -347,4 +353,12 @@ data class TableActionResponse(
     val pot: Long? = null,
     val rake: Long? = null,
     val chipsReturned: Long? = null,
+    /**
+     * v2-3: set when /poker leave is queued mid-hand. The seat hasn't
+     * actually been cashed out yet — the engine will auto-fold the
+     * leaver, refund chips, and remove the seat once the hand resolves.
+     * Frontend uses this to render "leaving — chips return at end of
+     * hand" instead of the regular cash-out toast.
+     */
+    val queued: Boolean? = null,
 )


### PR DESCRIPTION
Three lifecycle features layered onto the v2 poker engine without touching the showdown / side-pot core delivered in v2-1 / v2-2.

## Summary

- **`/poker rebuy chips:<n> table:<id>`** — top up your stack between hands. Mirrors `buyIn` (`@Transactional`, `getUserByIdForUpdate`, chip escrow under the table monitor); only allowed in `Phase.WAITING`; post-rebuy stack capped at the table's `maxBuyIn`. A top-up that would breach the cap is rejected outright (`StackCapped`) rather than silently truncated, since the slash UX gives no chance to dry-run an invalid amount.
- **`/poker leave` during a hand** — flips `seat.pendingLeave = true` instead of returning `HandInProgress`. Engine stays oblivious; `applyAction` cascades a `Fold` for any subsequent `pendingLeave` actor, and `sweepPendingLeaves` refunds chips + removes the seat the moment `HandResolved` fires. If the leaver IS the current actor, `cashOut` drives an immediate fold through `transactionalSelf` so the table doesn't stall on the shot clock. Two new outcomes: `QueuedForEndOfHand` (chips return at end of hand) and `AlreadyLeaving` (idempotent second click). The old `HandInProgress` variant stays in the sealed hierarchy for any caller pinned to it.
- **`/poker history [table:<id>] [limit:<n>]`** — renders the most recent settled hands. New guild-scoped queries `findRecentByTable` / `findRecentByGuild` on `PokerHandLogPersistence` (guild filter is intentional — table ids share a namespace across servers). `recentHandsFor*` short-circuits non-positive limits (no JPA hit) and clamps to `HISTORY_MAX_LIMIT = 25` so a caller can't ask for a pathological number of rows.

Web `TableActionResponse` gains a `queued` flag so the frontend can render "leaving — chips return at end of hand" instead of the regular cash-out toast.

## Test plan

- [x] `./gradlew :database:test` — 100% pass (rebuy happy / cap / mid-hand / cross-guild paths; mid-hand leave + auto-fold cascade + post-hand sweep; history queries newest-first, guild-scoped, limit-clamped)
- [ ] `./gradlew :discord-bot:test` — local sandbox can't fetch Lavalink deps; CI will exercise the new `PokerCommandTest` cases (`rebuy`, `leave queued-for-end-of-hand`, `history` with/without table option)
- [ ] `./gradlew :web:test` — CI; `PokerControllerTest` already covers the existing cashOut paths and the new `queued` field is additive

## Manual verification (post-deploy)

- `/poker rebuy` between hands: stack grows by `chips`, balance debits, mid-hand call rejected
- `/poker leave` mid-hand from non-actor: queued message, hand continues, chips refunded on resolution
- `/poker leave` mid-hand from current actor: immediate fold, table doesn't stall
- `/poker history` without args: recent hands across all this guild's tables; with `table:` scoped to one table

https://claude.ai/code/session_0169MvtJ2BSbwkoB9GrFhfZC

---
_Generated by [Claude Code](https://claude.ai/code/session_0169MvtJ2BSbwkoB9GrFhfZC)_