### PR TITLE
docs(poker): refresh stale v1 class kdoc + lobby footer

### DIFF
--- a/database/src/main/kotlin/database/service/PokerService.kt
+++ b/database/src/main/kotlin/database/service/PokerService.kt
@@ -26,31 +26,36 @@ import kotlin.random.Random
  *     [UserService.getUserByIdForUpdate], identical to the casino
  *     minigame services.
  *   - [PokerEngine] mutates seat chip counts as hands play out.
- *   - [cashOut] — only allowed between hands ([PokerTable.Phase.WAITING]) —
- *     credits the seat's remaining chips back into `socialCredit` and
- *     removes the seat. The idle-table sweeper does the same thing
- *     automatically when a table goes quiet for [PokerTableRegistry.DEFAULT_IDLE_TTL].
+ *   - [rebuy] (v2-3) — top up an already-seated player's stack between
+ *     hands, capped at the table's `maxBuyIn`.
+ *   - [cashOut] — credits the seat's remaining chips back into
+ *     `socialCredit` and removes the seat. Between hands the cash-out
+ *     is immediate; mid-hand (v2-3) the seat is flagged `pendingLeave`,
+ *     auto-folded on its turn, and chips return to the wallet as soon
+ *     as the hand resolves. The idle-table sweeper does an analogous
+ *     refund automatically when a table goes quiet for
+ *     [PokerTableRegistry.DEFAULT_IDLE_TTL].
  *
  * Hand resolution flows back through [applyAction] / [startHand]; on a
  * resolved hand the rake (default 5 %, configurable per guild via
  * [ConfigDto.Configurations.POKER_RAKE_PCT]) is routed to the existing
  * per-guild jackpot pool via [JackpotService.addToPool], matching how
  * `/duel` and the slot machines feed it. A row is appended to
- * `poker_hand_log` for audit/leaderboard purposes.
+ * `poker_hand_log` (and per-tier rows to `poker_hand_pot`) for audit
+ * and the [recentHandsForTable] / [recentHandsForGuild] reads behind
+ * `/poker history`.
  *
- * v2 (PR #v2-1) — proper side pots and call-for-less. When players
- * go all-in for different amounts, [PokerTable.HandResult.pots]
- * splits the pot into tiers. A short stack can no longer scoop chips
- * they didn't match. Each tier is persisted as its own row in
- * `poker_hand_pot` for audit; `poker_hand_log.pot` stays the
- * across-tiers aggregate for v1 readers.
+ * v2 PRs delivered so far:
+ *   - v2-1: side pots and call-for-less at showdown.
+ *   - v2-2: per-guild config (blinds / bets / seat cap / shot clock)
+ *     snapshotted at table creation, plus a per-actor shot clock that
+ *     auto-folds on timeout via [PokerTableRegistry.rearmShotClock].
+ *   - v2-3: `/poker rebuy`, mid-hand `/poker leave`, `/poker history`.
  *
- * Remaining v1 simplifications (slated for later v2 PRs):
- *   - Buy-in / cash-out only allowed when the table isn't mid-hand.
- *     If a player wants to leave during a hand, they fold and wait.
- *   - Auto-topup (sell TOBY to make rent like the other casinos do via
- *     [CasinoTopUpHelper]) is available at buy-in time only — the chips
- *     are escrowed once and aren't refilled mid-table.
+ * Outstanding v1 simplification:
+ *   - No auto-topup (sell TOBY to make rent like the other casinos do
+ *     via [CasinoTopUpHelper]) on buy-in / rebuy. Players must hold
+ *     enough `socialCredit` directly. Slated for v2-4.
  */
 @Service
 class PokerService @Autowired constructor(

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/PokerEmbeds.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/PokerEmbeds.kt
@@ -60,7 +60,7 @@ internal object PokerEmbeds {
                 "Host (<@${table.hostDiscordId}>) starts the hand with `/poker start table:${table.id}`.",
             false
         )
-        .setFooter("v1: no side pots — short stacks can win the whole pot at showdown.")
+        .setFooter("Side pots split the pot when players go all-in for different amounts.")
         .setColor(TABLE_COLOR)
         .build()
 


### PR DESCRIPTION
Pure docstring / user-visible-string refresh — no behaviour change.

## Summary

- `PokerService` class kdoc still listed mid-hand `/poker leave` under "Remaining v1 simplifications" even though v2-3 (#338) shipped it. Now lists v2-1 / v2-2 / v2-3 explicitly and pins the only outstanding v1 simplification (no auto-topup on buy-in or rebuy) as the v2-4 candidate. Lifecycle bullets gain `rebuy` and the mid-hand leave flow.
- `PokerEmbeds.lobbyEmbed` footer told players _"v1: no side pots — short stacks can win the whole pot at showdown"_ even though v2-1 (#333) added side pots. Replaced with a one-liner that's actually true.

## Test plan

- [x] `./gradlew :database:compileKotlin` — clean
- [ ] CI builds + lints

(Migration `V22__poker_hand_log.sql` has a stale comment too, but Flyway checksums migration files — editing the SQL post-merge would break validation in prod, so left alone.)

https://claude.ai/code/session_0169MvtJ2BSbwkoB9GrFhfZC

---
_Generated by [Claude Code](https://claude.ai/code/session_0169MvtJ2BSbwkoB9GrFhfZC)_