### PR TITLE
feat(poker): autoTopUp on createTable / buyIn / rebuy (v2-4)

### DIFF
--- a/database/src/main/kotlin/database/service/PokerService.kt
+++ b/database/src/main/kotlin/database/service/PokerService.kt
@@ -3,6 +3,7 @@ package database.service
 import database.dto.ConfigDto
 import database.dto.PokerHandLogDto
 import database.dto.PokerHandPotDto
+import database.dto.UserDto
 import database.persistence.PokerHandLogPersistence
 import database.persistence.PokerHandPotPersistence
 import database.poker.PokerEngine
@@ -65,23 +66,51 @@ class PokerService @Autowired constructor(
     private val tableRegistry: PokerTableRegistry,
     private val handLogPersistence: PokerHandLogPersistence,
     private val handPotPersistence: PokerHandPotPersistence,
+    /**
+     * v2-4: optional sell-to-cover wiring. When null (test-only path
+     * with no Spring context), [autoTopUp] requests degrade gracefully
+     * to plain [CreateOutcome.InsufficientCredits] /
+     * [BuyInOutcome.InsufficientCredits] /
+     * [RebuyOutcome.InsufficientCredits] so existing constructors
+     * without these collaborators keep working unchanged.
+     */
+    @Autowired(required = false) private val tradeService: EconomyTradeService? = null,
+    @Autowired(required = false) private val marketService: TobyCoinMarketService? = null,
     private val random: Random = Random.Default
 ) {
 
     sealed interface CreateOutcome {
-        data class Ok(val tableId: Long) : CreateOutcome
+        data class Ok(
+            val tableId: Long,
+            val soldTobyCoins: Long = 0L,
+            val newPrice: Double? = null
+        ) : CreateOutcome
         data class InvalidBuyIn(val min: Long, val max: Long) : CreateOutcome
         data class InsufficientCredits(val have: Long, val needed: Long) : CreateOutcome
+        /**
+         * v2-4: caller passed `autoTopUp=true` but the player's TOBY
+         * holdings can't cover the credit shortfall at the live market
+         * price. [needed] is the coin count required, [have] is what
+         * they hold.
+         */
+        data class InsufficientCoinsForTopUp(val needed: Long, val have: Long) : CreateOutcome
         data object UnknownUser : CreateOutcome
     }
 
     sealed interface BuyInOutcome {
-        data class Ok(val seatIndex: Int, val newBalance: Long) : BuyInOutcome
+        data class Ok(
+            val seatIndex: Int,
+            val newBalance: Long,
+            val soldTobyCoins: Long = 0L,
+            val newPrice: Double? = null
+        ) : BuyInOutcome
         data object TableNotFound : BuyInOutcome
         data object TableFull : BuyInOutcome
         data object AlreadySeated : BuyInOutcome
         data class InvalidBuyIn(val min: Long, val max: Long) : BuyInOutcome
         data class InsufficientCredits(val have: Long, val needed: Long) : BuyInOutcome
+        /** v2-4: see [CreateOutcome.InsufficientCoinsForTopUp]. */
+        data class InsufficientCoinsForTopUp(val needed: Long, val have: Long) : BuyInOutcome
         data object UnknownUser : BuyInOutcome
     }
 
@@ -115,13 +144,20 @@ class PokerService @Autowired constructor(
     }
 
     sealed interface RebuyOutcome {
-        data class Ok(val seatChips: Long, val newBalance: Long) : RebuyOutcome
+        data class Ok(
+            val seatChips: Long,
+            val newBalance: Long,
+            val soldTobyCoins: Long = 0L,
+            val newPrice: Double? = null
+        ) : RebuyOutcome
         data object TableNotFound : RebuyOutcome
         data object NotSeated : RebuyOutcome
         data object HandInProgress : RebuyOutcome
         data class InvalidAmount(val min: Long, val max: Long) : RebuyOutcome
         data class StackCapped(val cap: Long, val current: Long) : RebuyOutcome
         data class InsufficientCredits(val have: Long, val needed: Long) : RebuyOutcome
+        /** v2-4: see [CreateOutcome.InsufficientCoinsForTopUp]. */
+        data class InsufficientCoinsForTopUp(val needed: Long, val have: Long) : RebuyOutcome
         data object UnknownUser : RebuyOutcome
     }
 
@@ -193,7 +229,8 @@ class PokerService @Autowired constructor(
     fun createTable(
         hostDiscordId: Long,
         guildId: Long,
-        buyIn: Long
+        buyIn: Long,
+        autoTopUp: Boolean = false
     ): CreateOutcome {
         // v2 (PR #v2-2): each table snapshots the guild's poker config
         // at creation. Mid-hand admin tweaks don't affect the in-flight
@@ -204,9 +241,11 @@ class PokerService @Autowired constructor(
         }
         val user = userService.getUserByIdForUpdate(hostDiscordId, guildId)
             ?: return CreateOutcome.UnknownUser
-        val balance = user.socialCredit ?: 0L
-        if (balance < buyIn) {
-            return CreateOutcome.InsufficientCredits(have = balance, needed = buyIn)
+        val initialBalance = user.socialCredit ?: 0L
+        val resolved = when (val r = resolveBalanceWithOptionalTopUp(user, guildId, initialBalance, buyIn, autoTopUp)) {
+            is TopUpResolution.Ok -> r
+            is TopUpResolution.CreditsShort -> return CreateOutcome.InsufficientCredits(have = r.have, needed = r.needed)
+            is TopUpResolution.CoinsShort -> return CreateOutcome.InsufficientCoinsForTopUp(needed = r.needed, have = r.have)
         }
         val table = tableRegistry.create(
             guildId = guildId,
@@ -222,13 +261,19 @@ class PokerService @Autowired constructor(
             shotClockSeconds = params.shotClockSeconds
         )
         // Debit and seat under the same lock so we can't end up with an
-        // empty table after a credit-debit failure.
-        user.socialCredit = balance - buyIn
-        userService.updateUser(user)
+        // empty table after a credit-debit failure. Use the post-topup
+        // user / balance reference so the debit reflects whatever the
+        // sell delivered.
+        resolved.user.socialCredit = resolved.balance - buyIn
+        userService.updateUser(resolved.user)
         synchronized(table) {
             table.seats.add(PokerTable.Seat(discordId = hostDiscordId, chips = buyIn))
         }
-        return CreateOutcome.Ok(table.id)
+        return CreateOutcome.Ok(
+            tableId = table.id,
+            soldTobyCoins = resolved.soldCoins,
+            newPrice = resolved.newPrice
+        )
     }
 
     /**
@@ -277,7 +322,8 @@ class PokerService @Autowired constructor(
         discordId: Long,
         guildId: Long,
         tableId: Long,
-        buyIn: Long
+        buyIn: Long,
+        autoTopUp: Boolean = false
     ): BuyInOutcome {
         val table = tableRegistry.get(tableId) ?: return BuyInOutcome.TableNotFound
         if (table.guildId != guildId) return BuyInOutcome.TableNotFound
@@ -285,11 +331,29 @@ class PokerService @Autowired constructor(
             return BuyInOutcome.InvalidBuyIn(table.minBuyIn, table.maxBuyIn)
         }
 
+        // Peek seat availability before touching the wallet so an
+        // autoTopUp caller doesn't sell TOBY only to bounce off
+        // AlreadySeated / TableFull. The atomic add below re-checks
+        // under the same monitor — peek can race with another join,
+        // but the worst case is a topped-up caller who keeps their
+        // credits without a seat (no chip leak).
+        val seatPreflight = synchronized(table) {
+            when {
+                table.seats.any { it.discordId == discordId } -> -1
+                table.seats.size >= table.maxSeats -> -2
+                else -> 0
+            }
+        }
+        if (seatPreflight == -1) return BuyInOutcome.AlreadySeated
+        if (seatPreflight == -2) return BuyInOutcome.TableFull
+
         val user = userService.getUserByIdForUpdate(discordId, guildId)
             ?: return BuyInOutcome.UnknownUser
-        val balance = user.socialCredit ?: 0L
-        if (balance < buyIn) {
-            return BuyInOutcome.InsufficientCredits(have = balance, needed = buyIn)
+        val initialBalance = user.socialCredit ?: 0L
+        val resolved = when (val r = resolveBalanceWithOptionalTopUp(user, guildId, initialBalance, buyIn, autoTopUp)) {
+            is TopUpResolution.Ok -> r
+            is TopUpResolution.CreditsShort -> return BuyInOutcome.InsufficientCredits(have = r.have, needed = r.needed)
+            is TopUpResolution.CoinsShort -> return BuyInOutcome.InsufficientCoinsForTopUp(needed = r.needed, have = r.have)
         }
 
         val seatIndex = synchronized(table) {
@@ -301,9 +365,14 @@ class PokerService @Autowired constructor(
         if (seatIndex == -1) return BuyInOutcome.AlreadySeated
         if (seatIndex == -2) return BuyInOutcome.TableFull
 
-        user.socialCredit = balance - buyIn
-        userService.updateUser(user)
-        return BuyInOutcome.Ok(seatIndex = seatIndex, newBalance = user.socialCredit ?: 0L)
+        resolved.user.socialCredit = resolved.balance - buyIn
+        userService.updateUser(resolved.user)
+        return BuyInOutcome.Ok(
+            seatIndex = seatIndex,
+            newBalance = resolved.user.socialCredit ?: 0L,
+            soldTobyCoins = resolved.soldCoins,
+            newPrice = resolved.newPrice
+        )
     }
 
     /**
@@ -324,7 +393,8 @@ class PokerService @Autowired constructor(
         discordId: Long,
         guildId: Long,
         tableId: Long,
-        amount: Long
+        amount: Long,
+        autoTopUp: Boolean = false
     ): RebuyOutcome {
         val table = tableRegistry.get(tableId) ?: return RebuyOutcome.TableNotFound
         if (table.guildId != guildId) return RebuyOutcome.TableNotFound
@@ -332,11 +402,33 @@ class PokerService @Autowired constructor(
             return RebuyOutcome.InvalidAmount(table.minBuyIn, table.maxBuyIn)
         }
 
+        // Pre-flight the table-side conditions before the wallet so an
+        // autoTopUp caller doesn't sell TOBY only to bounce off
+        // HandInProgress / NotSeated / StackCapped. The atomic chip
+        // bump below re-checks under the same monitor.
+        val seatPreflight: RebuyOutcome? = synchronized(table) {
+            when {
+                table.phase != PokerTable.Phase.WAITING -> RebuyOutcome.HandInProgress
+                else -> {
+                    val seat = table.seats.firstOrNull { it.discordId == discordId }
+                    when {
+                        seat == null -> RebuyOutcome.NotSeated
+                        seat.chips + amount > table.maxBuyIn ->
+                            RebuyOutcome.StackCapped(cap = table.maxBuyIn, current = seat.chips)
+                        else -> null
+                    }
+                }
+            }
+        }
+        if (seatPreflight != null) return seatPreflight
+
         val user = userService.getUserByIdForUpdate(discordId, guildId)
             ?: return RebuyOutcome.UnknownUser
-        val balance = user.socialCredit ?: 0L
-        if (balance < amount) {
-            return RebuyOutcome.InsufficientCredits(have = balance, needed = amount)
+        val initialBalance = user.socialCredit ?: 0L
+        val resolved = when (val r = resolveBalanceWithOptionalTopUp(user, guildId, initialBalance, amount, autoTopUp)) {
+            is TopUpResolution.Ok -> r
+            is TopUpResolution.CreditsShort -> return RebuyOutcome.InsufficientCredits(have = r.have, needed = r.needed)
+            is TopUpResolution.CoinsShort -> return RebuyOutcome.InsufficientCoinsForTopUp(needed = r.needed, have = r.have)
         }
 
         val rebuyResult = synchronized(table) {
@@ -358,11 +450,13 @@ class PokerService @Autowired constructor(
         }
         if (rebuyResult !is RebuyOutcome.Ok) return rebuyResult
 
-        user.socialCredit = balance - amount
-        userService.updateUser(user)
+        resolved.user.socialCredit = resolved.balance - amount
+        userService.updateUser(resolved.user)
         return RebuyOutcome.Ok(
             seatChips = rebuyResult.seatChips,
-            newBalance = user.socialCredit ?: 0L
+            newBalance = resolved.user.socialCredit ?: 0L,
+            soldTobyCoins = resolved.soldCoins,
+            newPrice = resolved.newPrice
         )
     }
 
@@ -704,6 +798,59 @@ class PokerService @Autowired constructor(
             user.socialCredit = (user.socialCredit ?: 0L) + amount
             userService.updateUser(user)
         }
+    }
+
+    /**
+     * v2-4 shared between [createTable], [buyIn] and [rebuy]. If
+     * [currentBalance] already covers [target] this is a no-op (Ok
+     * with `soldCoins=0`). Otherwise, when [autoTopUp] is on AND the
+     * trade/market collaborators are present, sells the smallest
+     * TOBY amount that lifts the player above [target] via
+     * [CasinoTopUpHelper.ensureCreditsForWager]. Failures map back to
+     * the per-method `InsufficientCredits` / `InsufficientCoinsForTopUp`
+     * variants — caller decides which sealed type to construct.
+     */
+    private fun resolveBalanceWithOptionalTopUp(
+        user: UserDto,
+        guildId: Long,
+        currentBalance: Long,
+        target: Long,
+        autoTopUp: Boolean
+    ): TopUpResolution {
+        if (currentBalance >= target) {
+            return TopUpResolution.Ok(user = user, balance = currentBalance, soldCoins = 0L, newPrice = null)
+        }
+        // No collaborators (test path), or caller didn't opt-in: surface
+        // the regular credit-shortfall outcome unchanged.
+        val safeTrade = tradeService
+        val safeMarket = marketService
+        if (!autoTopUp || safeTrade == null || safeMarket == null) {
+            return TopUpResolution.CreditsShort(have = currentBalance, needed = target)
+        }
+        return when (val r = CasinoTopUpHelper.ensureCreditsForWager(
+            safeTrade, safeMarket, userService,
+            user, guildId, currentBalance, target
+        )) {
+            is TopUpResult.ToppedUp ->
+                TopUpResolution.Ok(user = r.user, balance = r.balance, soldCoins = r.soldCoins, newPrice = r.newPrice)
+            // Market degraded — same surfacing as a plain credit shortfall
+            // so the player gets the same retry experience.
+            TopUpResult.MarketUnavailable ->
+                TopUpResolution.CreditsShort(have = currentBalance, needed = target)
+            is TopUpResult.InsufficientCoins ->
+                TopUpResolution.CoinsShort(needed = r.needed, have = r.have)
+        }
+    }
+
+    private sealed interface TopUpResolution {
+        data class Ok(
+            val user: UserDto,
+            val balance: Long,
+            val soldCoins: Long,
+            val newPrice: Double?
+        ) : TopUpResolution
+        data class CreditsShort(val have: Long, val needed: Long) : TopUpResolution
+        data class CoinsShort(val needed: Long, val have: Long) : TopUpResolution
     }
 
     companion object {

--- a/database/src/test/kotlin/database/service/PokerServiceTest.kt
+++ b/database/src/test/kotlin/database/service/PokerServiceTest.kt
@@ -9,6 +9,7 @@ import database.persistence.PokerHandPotPersistence
 import database.poker.PokerEngine
 import database.poker.PokerTable
 import database.poker.PokerTableRegistry
+import database.service.EconomyTradeService.TradeOutcome
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -589,6 +590,203 @@ class PokerServiceTest {
         val outcome = service.buyIn(joiner, guildId = 999L, tableId = tableId, buyIn = 200L)
         assertEquals(PokerService.BuyInOutcome.TableNotFound, outcome)
         assertFalse(registry.get(tableId)!!.seats.any { it.discordId == joiner })
+    }
+
+    // -- v2-4: autoTopUp wiring -----------------------------------------
+
+    /**
+     * Build a [PokerService] with the optional trade/market collaborators
+     * stubbed to a happy-path sell that lifts balance from [startingBalance]
+     * to `startingBalance + creditsDelivered`. Returns the service plus
+     * the trade/market mocks for test-side verification.
+     */
+    private data class TopUpHarness(
+        val service: PokerService,
+        val tradeService: EconomyTradeService,
+        val marketService: TobyCoinMarketService,
+        val coinsSold: Long,
+        val newPrice: Double
+    )
+    private fun harnessWithTopUp(
+        seedUser: UserDto,
+        startingBalance: Long,
+        creditsDelivered: Long,
+        coinsSold: Long = 50L,
+        newPrice: Double = 2.5
+    ): TopUpHarness {
+        val tradeService = mockk<EconomyTradeService>(relaxed = true)
+        val marketService = mockk<TobyCoinMarketService>(relaxed = true)
+        // Market is online with a positive price.
+        every { marketService.getMarketForUpdate(seedUser.guildId) } returns
+            database.dto.TobyCoinMarketDto(
+                guildId = seedUser.guildId,
+                price = newPrice,
+                lastTickAt = java.time.Instant.now()
+            )
+        // Seller mutates the seeded user — RecordingUserService re-reads
+        // by id after sell, so the post-sell balance reflects whatever
+        // we credited here.
+        every {
+            tradeService.sell(seedUser.discordId, seedUser.guildId, any(), EconomyTradeService.REASON_CASINO_TOPUP)
+        } answers {
+            seedUser.tobyCoins -= coinsSold
+            seedUser.socialCredit = startingBalance + creditsDelivered
+            TradeOutcome.Ok(
+                amount = thirdArg(),
+                transactedCredits = creditsDelivered,
+                newCoins = seedUser.tobyCoins,
+                newCredits = seedUser.socialCredit ?: 0L,
+                newPrice = newPrice,
+                fee = 0L
+            )
+        }
+        val service = PokerService(
+            userService = userService,
+            jackpotService = jackpotService,
+            configService = configService,
+            tableRegistry = registry,
+            handLogPersistence = handLog,
+            handPotPersistence = handPot,
+            tradeService = tradeService,
+            marketService = marketService,
+            random = Random(42)
+        )
+        return TopUpHarness(service, tradeService, marketService, coinsSold, newPrice)
+    }
+
+    @Test
+    fun `createTable autoTopUp=false with insufficient credits keeps existing behaviour`() {
+        seed(host, 50L)
+        // Default service has no trade/market collaborators — autoTopUp
+        // path is unavailable regardless of the flag.
+        val outcome = service.createTable(host, guildId, buyIn = 200L, autoTopUp = false)
+        assertTrue(outcome is PokerService.CreateOutcome.InsufficientCredits)
+    }
+
+    @Test
+    fun `createTable autoTopUp=true degrades to InsufficientCredits when collaborators absent`() {
+        seed(host, 50L)
+        val outcome = service.createTable(host, guildId, buyIn = 200L, autoTopUp = true)
+        assertTrue(outcome is PokerService.CreateOutcome.InsufficientCredits, "no trade/market wiring → no topup")
+    }
+
+    @Test
+    fun `createTable autoTopUp=true sells TOBY then seats the host with chip escrow`() {
+        val user = UserDto(host, guildId).apply {
+            socialCredit = 50L
+            tobyCoins = 1_000L
+        }
+        userService.seed(user)
+        val harness = harnessWithTopUp(
+            seedUser = user, startingBalance = 50L, creditsDelivered = 200L,
+            coinsSold = 80L, newPrice = 2.5
+        )
+
+        val outcome = harness.service.createTable(host, guildId, buyIn = 200L, autoTopUp = true)
+
+        assertTrue(outcome is PokerService.CreateOutcome.Ok)
+        outcome as PokerService.CreateOutcome.Ok
+        // soldTobyCoins is the engine's computation of "coins needed for
+        // shortfall under midpoint slippage + jackpot fee" — its exact
+        // value lives in TobyCoinEngineTopUpTest, here we just check it
+        // surfaced.
+        assert(outcome.soldTobyCoins > 0L) { "soldTobyCoins propagates to outcome: ${outcome.soldTobyCoins}" }
+        assertEquals(2.5, outcome.newPrice)
+        // After topup (50 + 200 = 250) and 200-buy-in debit, balance is 50.
+        assertEquals(50L, userService.current(host)?.socialCredit)
+        verify(exactly = 1) {
+            harness.tradeService.sell(host, guildId, any(), EconomyTradeService.REASON_CASINO_TOPUP)
+        }
+        val table = registry.get(outcome.tableId)!!
+        assertEquals(200L, table.seats[0].chips, "seat funded with the full buy-in")
+    }
+
+    @Test
+    fun `buyIn autoTopUp=true tops up when joining an existing table`() {
+        seed(host, 1000L)
+        val joinerUser = UserDto(joiner, guildId).apply { socialCredit = 0L; tobyCoins = 1_000L }
+        userService.seed(joinerUser)
+        val harness = harnessWithTopUp(
+            seedUser = joinerUser, startingBalance = 0L, creditsDelivered = 300L
+        )
+        val tableId = (harness.service.createTable(host, guildId, buyIn = 200L) as PokerService.CreateOutcome.Ok).tableId
+
+        val outcome = harness.service.buyIn(joiner, guildId, tableId, buyIn = 300L, autoTopUp = true)
+
+        assertTrue(outcome is PokerService.BuyInOutcome.Ok)
+        outcome as PokerService.BuyInOutcome.Ok
+        assert(outcome.soldTobyCoins > 0L)
+        // After topup (0 + 300) and 300-buy-in debit, balance is 0.
+        assertEquals(0L, userService.current(joiner)?.socialCredit)
+        assertEquals(2, registry.get(tableId)!!.seats.size)
+    }
+
+    @Test
+    fun `buyIn autoTopUp does NOT sell when seat is already taken`() {
+        seed(host, 1000L)
+        val tableId = (service.createTable(host, guildId, buyIn = 200L) as PokerService.CreateOutcome.Ok).tableId
+        val joinerUser = UserDto(joiner, guildId).apply { socialCredit = 0L; tobyCoins = 1_000L }
+        userService.seed(joinerUser)
+        val harness = harnessWithTopUp(
+            seedUser = joinerUser, startingBalance = 0L, creditsDelivered = 300L
+        )
+        // First seating succeeds.
+        harness.service.buyIn(joiner, guildId, tableId, buyIn = 300L, autoTopUp = true)
+        // Reset stub to count fresh calls.
+        io.mockk.clearMocks(harness.tradeService, answers = false)
+
+        val outcome = harness.service.buyIn(joiner, guildId, tableId, buyIn = 300L, autoTopUp = true)
+        assertEquals(PokerService.BuyInOutcome.AlreadySeated, outcome)
+        verify(exactly = 0) {
+            harness.tradeService.sell(any(), any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `rebuy autoTopUp=true tops up a seated player between hands`() {
+        val user = UserDto(host, guildId).apply { socialCredit = 200L; tobyCoins = 1_000L }
+        userService.seed(user)
+        val harness = harnessWithTopUp(
+            seedUser = user, startingBalance = 0L, creditsDelivered = 300L
+        )
+        val tableId = (harness.service.createTable(host, guildId, buyIn = 200L) as PokerService.CreateOutcome.Ok).tableId
+        // Balance is 0 after createTable. Now rebuy 300 with autoTopUp.
+        // The harness mock sets balance to startingBalance + creditsDelivered = 300.
+        io.mockk.clearMocks(harness.tradeService, answers = false)
+        every {
+            harness.tradeService.sell(host, guildId, any(), EconomyTradeService.REASON_CASINO_TOPUP)
+        } answers {
+            user.tobyCoins -= 80L
+            user.socialCredit = 300L
+            TradeOutcome.Ok(thirdArg(), 300L, user.tobyCoins, 300L, 2.5, 0L)
+        }
+
+        val outcome = harness.service.rebuy(host, guildId, tableId, amount = 300L, autoTopUp = true)
+
+        assertTrue(outcome is PokerService.RebuyOutcome.Ok)
+        outcome as PokerService.RebuyOutcome.Ok
+        assertEquals(500L, outcome.seatChips, "200 createTable + 300 rebuy")
+        assert(outcome.soldTobyCoins > 0L)
+        assertEquals(0L, outcome.newBalance, "300 topup → 300 debit → 0 balance")
+    }
+
+    @Test
+    fun `rebuy autoTopUp does NOT sell when stack would breach maxBuyIn`() {
+        val user = UserDto(host, guildId).apply { socialCredit = 4_500L; tobyCoins = 1_000L }
+        userService.seed(user)
+        val harness = harnessWithTopUp(
+            seedUser = user, startingBalance = 0L, creditsDelivered = 300L
+        )
+        val tableId = (harness.service.createTable(host, guildId, buyIn = 4_500L) as PokerService.CreateOutcome.Ok).tableId
+        io.mockk.clearMocks(harness.tradeService, answers = false)
+
+        // 1_000 rebuy on top of 4_500 would push to 5_500 > MAX_BUY_IN (5_000).
+        val outcome = harness.service.rebuy(host, guildId, tableId, amount = 1_000L, autoTopUp = true)
+
+        assertTrue(outcome is PokerService.RebuyOutcome.StackCapped)
+        verify(exactly = 0) {
+            harness.tradeService.sell(any(), any(), any(), any())
+        }
     }
 
     private class RecordingUserService : UserService {

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/PokerCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/PokerCommand.kt
@@ -146,6 +146,12 @@ class PokerCommand @Autowired constructor(
                 replyError(event, "Buy-in must be between ${outcome.min} and ${outcome.max} credits.", deleteDelay)
             is CreateOutcome.InsufficientCredits ->
                 replyError(event, "You need ${outcome.needed} credits but only have ${outcome.have}.", deleteDelay)
+            // v2-4: Discord doesn't pass autoTopUp today (only the web
+            // layer does), so this branch is theoretically unreachable
+            // from a slash command — kept for `when` exhaustiveness so a
+            // future Discord-side autoTopUp toggle is a one-line change.
+            is CreateOutcome.InsufficientCoinsForTopUp ->
+                replyError(event, "Auto-topup needs ${outcome.needed} TOBY but you only have ${outcome.have}.", deleteDelay)
             CreateOutcome.UnknownUser ->
                 replyError(event, "No user record yet. Try another TobyBot command first.", deleteDelay)
         }
@@ -182,6 +188,9 @@ class PokerCommand @Autowired constructor(
                 replyError(event, "Buy-in must be between ${outcome.min} and ${outcome.max} credits.", deleteDelay)
             is BuyInOutcome.InsufficientCredits ->
                 replyError(event, "You need ${outcome.needed} credits but only have ${outcome.have}.", deleteDelay)
+            // v2-4: see CreateOutcome.InsufficientCoinsForTopUp note.
+            is BuyInOutcome.InsufficientCoinsForTopUp ->
+                replyError(event, "Auto-topup needs ${outcome.needed} TOBY but you only have ${outcome.have}.", deleteDelay)
             BuyInOutcome.UnknownUser ->
                 replyError(event, "No user record yet. Try another TobyBot command first.", deleteDelay)
         }
@@ -278,6 +287,9 @@ class PokerCommand @Autowired constructor(
                 )
             is RebuyOutcome.InsufficientCredits ->
                 replyError(event, "You need ${outcome.needed} credits but only have ${outcome.have}.", deleteDelay)
+            // v2-4: see CreateOutcome.InsufficientCoinsForTopUp note.
+            is RebuyOutcome.InsufficientCoinsForTopUp ->
+                replyError(event, "Auto-topup needs ${outcome.needed} TOBY but you only have ${outcome.have}.", deleteDelay)
             RebuyOutcome.HandInProgress ->
                 replyError(event, "Wait for the current hand to end before rebuying.", deleteDelay)
             RebuyOutcome.NotSeated ->

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/economy/PokerCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/economy/PokerCommandTest.kt
@@ -75,12 +75,12 @@ internal class PokerCommandTest : CommandTest {
     fun `create subcommand happy path delegates to PokerService and posts lobby embed`() {
         every { event.subcommandName } returns "create"
         every { event.getOption("chips") } returns intOpt(200L)
-        every { pokerService.createTable(hostId, guildId, 200L) } returns CreateOutcome.Ok(tableId = 7L)
+        every { pokerService.createTable(hostId, guildId, 200L, any()) } returns CreateOutcome.Ok(tableId = 7L)
         every { tableRegistry.get(7L) } returns stubTable(7L)
 
         command.handle(DefaultCommandContext(event), userDto(), 0)
 
-        verify(exactly = 1) { pokerService.createTable(hostId, guildId, 200L) }
+        verify(exactly = 1) { pokerService.createTable(hostId, guildId, 200L, any()) }
         verify(exactly = 1) { tableRegistry.get(7L) }
     }
 
@@ -88,7 +88,7 @@ internal class PokerCommandTest : CommandTest {
     fun `create with insufficient credits surfaces error and does not look up table`() {
         every { event.subcommandName } returns "create"
         every { event.getOption("chips") } returns intOpt(200L)
-        every { pokerService.createTable(hostId, guildId, 200L) } returns
+        every { pokerService.createTable(hostId, guildId, 200L, any()) } returns
             CreateOutcome.InsufficientCredits(have = 50L, needed = 200L)
 
         command.handle(DefaultCommandContext(event), userDto(), 0)
@@ -101,13 +101,13 @@ internal class PokerCommandTest : CommandTest {
         every { event.subcommandName } returns "join"
         every { event.getOption("table") } returns intOpt(7L)
         every { event.getOption("chips") } returns intOpt(300L)
-        every { pokerService.buyIn(hostId, guildId, 7L, 300L) } returns
+        every { pokerService.buyIn(hostId, guildId, 7L, 300L, any()) } returns
             BuyInOutcome.Ok(seatIndex = 1, newBalance = 700L)
         every { tableRegistry.get(7L) } returns stubTable(7L)
 
         command.handle(DefaultCommandContext(event), userDto(), 0)
 
-        verify(exactly = 1) { pokerService.buyIn(hostId, guildId, 7L, 300L) }
+        verify(exactly = 1) { pokerService.buyIn(hostId, guildId, 7L, 300L, any()) }
     }
 
     @Test
@@ -115,7 +115,7 @@ internal class PokerCommandTest : CommandTest {
         every { event.subcommandName } returns "join"
         every { event.getOption("table") } returns intOpt(7L)
         every { event.getOption("chips") } returns intOpt(300L)
-        every { pokerService.buyIn(hostId, guildId, 7L, 300L) } returns BuyInOutcome.AlreadySeated
+        every { pokerService.buyIn(hostId, guildId, 7L, 300L, any()) } returns BuyInOutcome.AlreadySeated
 
         command.handle(DefaultCommandContext(event), userDto(), 0)
 
@@ -200,12 +200,12 @@ internal class PokerCommandTest : CommandTest {
         every { event.subcommandName } returns "rebuy"
         every { event.getOption("table") } returns intOpt(7L)
         every { event.getOption("chips") } returns intOpt(300L)
-        every { pokerService.rebuy(hostId, guildId, 7L, 300L) } returns
+        every { pokerService.rebuy(hostId, guildId, 7L, 300L, any()) } returns
             RebuyOutcome.Ok(seatChips = 500L, newBalance = 700L)
 
         command.handle(DefaultCommandContext(event), userDto(), 0)
 
-        verify(exactly = 1) { pokerService.rebuy(hostId, guildId, 7L, 300L) }
+        verify(exactly = 1) { pokerService.rebuy(hostId, guildId, 7L, 300L, any()) }
         // Happy path renders an info embed; no need to look up the table.
         verify(exactly = 0) { tableRegistry.get(any()) }
     }
@@ -215,7 +215,7 @@ internal class PokerCommandTest : CommandTest {
         every { event.subcommandName } returns "rebuy"
         every { event.getOption("table") } returns intOpt(7L)
         every { event.getOption("chips") } returns intOpt(2000L)
-        every { pokerService.rebuy(hostId, guildId, 7L, 2000L) } returns
+        every { pokerService.rebuy(hostId, guildId, 7L, 2000L, any()) } returns
             RebuyOutcome.StackCapped(cap = 5000L, current = 4500L)
 
         command.handle(DefaultCommandContext(event), userDto(), 0)
@@ -255,8 +255,8 @@ internal class PokerCommandTest : CommandTest {
 
         command.handle(DefaultCommandContext(event), userDto(), 0)
 
-        verify(exactly = 0) { pokerService.createTable(any(), any(), any()) }
-        verify(exactly = 0) { pokerService.buyIn(any(), any(), any(), any()) }
+        verify(exactly = 0) { pokerService.createTable(any(), any(), any(), any()) }
+        verify(exactly = 0) { pokerService.buyIn(any(), any(), any(), any(), any()) }
         verify(exactly = 0) { pokerService.startHand(any(), any(), any(), any()) }
     }
 }

--- a/web/src/main/kotlin/web/controller/PokerController.kt
+++ b/web/src/main/kotlin/web/controller/PokerController.kt
@@ -146,13 +146,23 @@ class PokerController(
         user, guildId, economyWebService,
         errorBuilder = { status -> tableErrorResponse(status) }
     ) { discordId ->
-        when (val outcome = pokerService.createTable(discordId, guildId, request.buyIn)) {
-            is CreateOutcome.Ok -> ResponseEntity.ok(TableActionResponse(ok = true, tableId = outcome.tableId))
+        when (val outcome = pokerService.createTable(discordId, guildId, request.buyIn, request.autoTopUp)) {
+            is CreateOutcome.Ok -> ResponseEntity.ok(
+                TableActionResponse(
+                    ok = true,
+                    tableId = outcome.tableId,
+                    soldTobyCoins = outcome.soldTobyCoins.takeIf { it > 0L },
+                    newPrice = outcome.newPrice
+                )
+            )
             is CreateOutcome.InvalidBuyIn -> ResponseEntity.badRequest().body(
                 TableActionResponse(false, error = "Buy-in must be between ${outcome.min} and ${outcome.max}.")
             )
             is CreateOutcome.InsufficientCredits -> ResponseEntity.badRequest().body(
                 TableActionResponse(false, error = "Need ${outcome.needed} credits, you have ${outcome.have}.")
+            )
+            is CreateOutcome.InsufficientCoinsForTopUp -> ResponseEntity.badRequest().body(
+                TableActionResponse(false, error = "Auto-topup needs ${outcome.needed} TOBY, you have ${outcome.have}.")
             )
             CreateOutcome.UnknownUser -> ResponseEntity.badRequest().body(
                 TableActionResponse(false, error = "No user record yet — try another TobyBot command first.")
@@ -171,9 +181,15 @@ class PokerController(
         user, guildId, economyWebService,
         errorBuilder = { status -> tableErrorResponse(status) }
     ) { discordId ->
-        when (val outcome = pokerService.buyIn(discordId, guildId, tableId, request.buyIn)) {
+        when (val outcome = pokerService.buyIn(discordId, guildId, tableId, request.buyIn, request.autoTopUp)) {
             is BuyInOutcome.Ok -> ResponseEntity.ok(
-                TableActionResponse(ok = true, tableId = tableId, newBalance = outcome.newBalance)
+                TableActionResponse(
+                    ok = true,
+                    tableId = tableId,
+                    newBalance = outcome.newBalance,
+                    soldTobyCoins = outcome.soldTobyCoins.takeIf { it > 0L },
+                    newPrice = outcome.newPrice
+                )
             )
             BuyInOutcome.AlreadySeated -> ResponseEntity.badRequest().body(
                 TableActionResponse(false, error = "You're already at this table.")
@@ -189,6 +205,9 @@ class PokerController(
             )
             is BuyInOutcome.InsufficientCredits -> ResponseEntity.badRequest().body(
                 TableActionResponse(false, error = "Need ${outcome.needed} credits, you have ${outcome.have}.")
+            )
+            is BuyInOutcome.InsufficientCoinsForTopUp -> ResponseEntity.badRequest().body(
+                TableActionResponse(false, error = "Auto-topup needs ${outcome.needed} TOBY, you have ${outcome.have}.")
             )
             BuyInOutcome.UnknownUser -> ResponseEntity.badRequest().body(
                 TableActionResponse(false, error = "No user record yet — try another TobyBot command first.")
@@ -339,8 +358,8 @@ class PokerController(
     }
 }
 
-data class CreateRequest(val buyIn: Long = 0)
-data class JoinRequest(val buyIn: Long = 0)
+data class CreateRequest(val buyIn: Long = 0, val autoTopUp: Boolean = false)
+data class JoinRequest(val buyIn: Long = 0, val autoTopUp: Boolean = false)
 data class ActionRequest(val action: String = "")
 
 data class TableActionResponse(
@@ -361,4 +380,12 @@ data class TableActionResponse(
      * hand" instead of the regular cash-out toast.
      */
     val queued: Boolean? = null,
+    /**
+     * v2-4: set when an autoTopUp create / join sold TOBY to cover the
+     * buy-in shortfall. Null when no sell happened (caller didn't ask
+     * for autoTopUp, or balance already covered the buy-in).
+     */
+    val soldTobyCoins: Long? = null,
+    /** v2-4: post-sell market price, paired with [soldTobyCoins]. */
+    val newPrice: Double? = null,
 )

--- a/web/src/test/kotlin/web/controller/PokerControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/PokerControllerTest.kt
@@ -94,7 +94,7 @@ class PokerControllerTest {
 
     @Test
     fun `create happy path returns table id`() {
-        every { pokerService.createTable(discordId, guildId, 200L) } returns CreateOutcome.Ok(tableId = 42L)
+        every { pokerService.createTable(discordId, guildId, 200L, any()) } returns CreateOutcome.Ok(tableId = 42L)
 
         val response = controller.create(guildId, CreateRequest(buyIn = 200L), user)
 
@@ -105,7 +105,7 @@ class PokerControllerTest {
 
     @Test
     fun `create propagates invalid buy-in as 400`() {
-        every { pokerService.createTable(discordId, guildId, 1L) } returns CreateOutcome.InvalidBuyIn(100L, 5000L)
+        every { pokerService.createTable(discordId, guildId, 1L, any()) } returns CreateOutcome.InvalidBuyIn(100L, 5000L)
 
         val response = controller.create(guildId, CreateRequest(buyIn = 1L), user)
 
@@ -120,12 +120,12 @@ class PokerControllerTest {
         val response = controller.create(guildId, CreateRequest(buyIn = 200L), user)
 
         assertEquals(403, response.statusCode.value())
-        verify(exactly = 0) { pokerService.createTable(any(), any(), any()) }
+        verify(exactly = 0) { pokerService.createTable(any(), any(), any(), any()) }
     }
 
     @Test
     fun `join happy path returns ok with new balance`() {
-        every { pokerService.buyIn(discordId, guildId, tableId, 300L) } returns
+        every { pokerService.buyIn(discordId, guildId, tableId, 300L, any()) } returns
             BuyInOutcome.Ok(seatIndex = 1, newBalance = 700L)
 
         val response = controller.join(guildId, tableId, JoinRequest(buyIn = 300L), user)
@@ -137,14 +137,14 @@ class PokerControllerTest {
 
     @Test
     fun `join already-seated returns 400`() {
-        every { pokerService.buyIn(discordId, guildId, tableId, 300L) } returns BuyInOutcome.AlreadySeated
+        every { pokerService.buyIn(discordId, guildId, tableId, 300L, any()) } returns BuyInOutcome.AlreadySeated
         val response = controller.join(guildId, tableId, JoinRequest(buyIn = 300L), user)
         assertEquals(400, response.statusCode.value())
     }
 
     @Test
     fun `join unknown table returns 404`() {
-        every { pokerService.buyIn(discordId, guildId, tableId, 300L) } returns BuyInOutcome.TableNotFound
+        every { pokerService.buyIn(discordId, guildId, tableId, 300L, any()) } returns BuyInOutcome.TableNotFound
         val response = controller.join(guildId, tableId, JoinRequest(buyIn = 300L), user)
         assertEquals(404, response.statusCode.value())
     }


### PR DESCRIPTION
Closes the last "v1 simplification" called out in the post-#339 `PokerService` kdoc: poker now has the same sell-to-cover-shortfall path that `CoinflipService`, `DiceService`, `SlotsService`, `ScratchService` and `HighlowService` already have via `CasinoTopUpHelper`.

## Summary

- **Service contract** — `createTable`, `buyIn`, `rebuy` gain an optional `autoTopUp: Boolean = false`. When set and the wallet's `socialCredit` is short of the requested chip amount, sells the smallest TOBY amount that lifts the wallet over the line (tagged `CASINO_TOPUP` for chart attribution), then proceeds with chip escrow as if balance had always been enough.
- **Three new outcome variants** — `CreateOutcome.InsufficientCoinsForTopUp`, `BuyInOutcome.InsufficientCoinsForTopUp`, `RebuyOutcome.InsufficientCoinsForTopUp`. The `Ok` variants gain optional `soldTobyCoins` / `newPrice` so callers can render "sold N TOBY at $P" alongside the seat result.
- **Pre-flight ordering** — `buyIn` and `rebuy` peek their table-side preconditions (`AlreadySeated` / `TableFull` / `HandInProgress` / `NotSeated` / `StackCapped`) **before** entering the topup branch, so an autoTopUp caller never sells TOBY only to bounce off a doomed seat. The atomic post-topup mutation re-checks under the same monitor; the worst-case race is a topped-up caller who keeps their credits but loses the seat (no chip leak).
- **Web layer** — `CreateRequest` / `JoinRequest` accept `autoTopUp`; `TableActionResponse` adds `soldTobyCoins` + `newPrice`. Frontend can render "sold N TOBY at $P" alongside the seat toast.
- **Discord layer** — `PokerCommand` handles the new `InsufficientCoinsForTopUp` branches for `when` exhaustiveness. The slash commands themselves don't expose `autoTopUp` today (matching every other casino slash command — only the web layer surfaces it). Reachable only if a future Discord-side toggle wires it through.
- **Spring DI** — `tradeService` / `marketService` are `@Autowired(required = false)` so the existing test-only `PokerService(...)` constructors that don't pass them keep working unchanged. When the collaborators are absent, autoTopUp degrades to the regular `InsufficientCredits` outcome (same surface as live-market-unavailable).

## Test plan

- [x] `./gradlew :database:test` — 100% pass
  - autoTopUp=false keeps existing `InsufficientCredits` behaviour
  - autoTopUp=true with no collaborators degrades to `InsufficientCredits` (Spring autowire-required=false fallback)
  - autoTopUp=true with happy market sells TOBY then proceeds with the seat / chip-debit on the post-sell balance (createTable, buyIn, rebuy)
  - buyIn pre-flight: `AlreadySeated` short-circuits BEFORE `tradeService.sell` fires
  - rebuy pre-flight: `StackCapped` short-circuits BEFORE `tradeService.sell` fires
- [ ] `./gradlew :discord-bot:test` — CI; mockk stubs widened with `any()` for the new `autoTopUp` slot
- [ ] `./gradlew :web:test` — CI; same mockk widening + ensures `CreateRequest.autoTopUp` / `JoinRequest.autoTopUp` deserialize correctly

https://claude.ai/code/session_0169MvtJ2BSbwkoB9GrFhfZC

---
_Generated by [Claude Code](https://claude.ai/code/session_0169MvtJ2BSbwkoB9GrFhfZC)_