### PR TITLE
feat(poker): free-play tables with no credit debits or payouts (v2-7)

### DIFF
--- a/database/src/main/kotlin/database/poker/PokerTable.kt
+++ b/database/src/main/kotlin/database/poker/PokerTable.kt
@@ -8,7 +8,9 @@ import java.time.Instant
  * concurrent button clicks / web POSTs serialise around hand state.
  *
  * `chips` on each [Seat] are escrow — the player's `socialCredit` was
- * debited at buy-in; nothing else touches it until cash-out.
+ * debited at buy-in; nothing else touches it until cash-out. On
+ * free-play tables ([isFreePlay]), the same chip mechanics run but
+ * the wallet is never touched and the chips are play money.
  */
 class PokerTable(
     val id: Long,
@@ -30,6 +32,18 @@ class PokerTable(
      * who is actively thinking about a decision.
      */
     val shotClockSeconds: Int = 0,
+    /**
+     * v2-7: free-play flag snapshotted at create time. When `true`,
+     * [database.service.PokerService] skips every wallet write
+     * (buy-in / rebuy debit, cash-out / sweep / evict credit) and
+     * skips the jackpot route + `poker_hand_log` persistence on hand
+     * resolution. The engine itself stays oblivious — it only cares
+     * about chip counts, which are play money on free tables. Flag
+     * is per-table (not per-guild), set once at construction, and
+     * never mutates so a started hand can never flip into or out of
+     * free-play under a player.
+     */
+    val isFreePlay: Boolean = false,
     var phase: Phase = Phase.WAITING,
     val seats: MutableList<Seat> = mutableListOf(),
     val community: MutableList<Card> = mutableListOf(),

--- a/database/src/main/kotlin/database/poker/PokerTableRegistry.kt
+++ b/database/src/main/kotlin/database/poker/PokerTableRegistry.kt
@@ -89,6 +89,7 @@ class PokerTableRegistry(
         maxRaisesPerStreet: Int,
         maxSeats: Int,
         shotClockSeconds: Int = 0,
+        isFreePlay: Boolean = false,
         now: Instant = Instant.now()
     ): PokerTable {
         val id = seq.incrementAndGet()
@@ -105,6 +106,7 @@ class PokerTableRegistry(
             maxRaisesPerStreet = maxRaisesPerStreet,
             maxSeats = maxSeats,
             shotClockSeconds = shotClockSeconds,
+            isFreePlay = isFreePlay,
             lastActivityAt = now
         )
         tables[id] = table

--- a/database/src/main/kotlin/database/service/PokerService.kt
+++ b/database/src/main/kotlin/database/service/PokerService.kt
@@ -230,7 +230,8 @@ class PokerService @Autowired constructor(
         hostDiscordId: Long,
         guildId: Long,
         buyIn: Long,
-        autoTopUp: Boolean = false
+        autoTopUp: Boolean = false,
+        free: Boolean = false
     ): CreateOutcome {
         // v2 (PR #v2-2): each table snapshots the guild's poker config
         // at creation. Mid-hand admin tweaks don't affect the in-flight
@@ -239,6 +240,34 @@ class PokerService @Autowired constructor(
         if (buyIn !in params.minBuyIn..params.maxBuyIn) {
             return CreateOutcome.InvalidBuyIn(params.minBuyIn, params.maxBuyIn)
         }
+
+        // v2-7: free-play tables short-circuit the wallet entirely.
+        // The host's `socialCredit` is never touched, so autoTopUp is
+        // silently irrelevant. We still demand a chip allocation in
+        // [minBuyIn..maxBuyIn] so the table dynamics stay aligned with
+        // the configured stakes — the only difference is that those
+        // chips are play money.
+        if (free) {
+            val table = tableRegistry.create(
+                guildId = guildId,
+                hostDiscordId = hostDiscordId,
+                minBuyIn = params.minBuyIn,
+                maxBuyIn = params.maxBuyIn,
+                smallBlind = params.smallBlind,
+                bigBlind = params.bigBlind,
+                smallBet = params.smallBet,
+                bigBet = params.bigBet,
+                maxRaisesPerStreet = MAX_RAISES_PER_STREET,
+                maxSeats = params.maxSeats,
+                shotClockSeconds = params.shotClockSeconds,
+                isFreePlay = true
+            )
+            synchronized(table) {
+                table.seats.add(PokerTable.Seat(discordId = hostDiscordId, chips = buyIn))
+            }
+            return CreateOutcome.Ok(tableId = table.id)
+        }
+
         val user = userService.getUserByIdForUpdate(hostDiscordId, guildId)
             ?: return CreateOutcome.UnknownUser
         val initialBalance = user.socialCredit ?: 0L
@@ -347,6 +376,25 @@ class PokerService @Autowired constructor(
         if (seatPreflight == -1) return BuyInOutcome.AlreadySeated
         if (seatPreflight == -2) return BuyInOutcome.TableFull
 
+        // v2-7: free-play tables — short-circuit the wallet entirely.
+        // No user lock, no `socialCredit` debit, autoTopUp is silently
+        // irrelevant. The seat-add still re-checks under the monitor.
+        if (table.isFreePlay) {
+            val seatIndex = synchronized(table) {
+                if (table.seats.any { it.discordId == discordId }) return@synchronized -1
+                if (table.seats.size >= table.maxSeats) return@synchronized -2
+                table.seats.add(PokerTable.Seat(discordId = discordId, chips = buyIn))
+                table.seats.size - 1
+            }
+            if (seatIndex == -1) return BuyInOutcome.AlreadySeated
+            if (seatIndex == -2) return BuyInOutcome.TableFull
+            // Surface the player's untouched wallet balance for symmetry
+            // with the real-money path. Look up by id (no for-update
+            // lock — we're not mutating).
+            val newBalance = userService.getUserById(discordId, guildId)?.socialCredit ?: 0L
+            return BuyInOutcome.Ok(seatIndex = seatIndex, newBalance = newBalance)
+        }
+
         val user = userService.getUserByIdForUpdate(discordId, guildId)
             ?: return BuyInOutcome.UnknownUser
         val initialBalance = user.socialCredit ?: 0L
@@ -421,6 +469,32 @@ class PokerService @Autowired constructor(
             }
         }
         if (seatPreflight != null) return seatPreflight
+
+        // v2-7: free-play tables — short-circuit the wallet entirely.
+        // The atomic chip bump below stays the same; we just skip the
+        // `socialCredit` debit and any autoTopUp resolution.
+        if (table.isFreePlay) {
+            val rebuyResult = synchronized(table) {
+                when {
+                    table.phase != PokerTable.Phase.WAITING -> RebuyOutcome.HandInProgress
+                    else -> {
+                        val seat = table.seats.firstOrNull { it.discordId == discordId }
+                        when {
+                            seat == null -> RebuyOutcome.NotSeated
+                            seat.chips + amount > table.maxBuyIn ->
+                                RebuyOutcome.StackCapped(cap = table.maxBuyIn, current = seat.chips)
+                            else -> {
+                                seat.chips += amount
+                                RebuyOutcome.Ok(seatChips = seat.chips, newBalance = 0L)
+                            }
+                        }
+                    }
+                }
+            }
+            if (rebuyResult !is RebuyOutcome.Ok) return rebuyResult
+            val newBalance = userService.getUserById(discordId, guildId)?.socialCredit ?: 0L
+            return RebuyOutcome.Ok(seatChips = rebuyResult.seatChips, newBalance = newBalance)
+        }
 
         val user = userService.getUserByIdForUpdate(discordId, guildId)
             ?: return RebuyOutcome.UnknownUser
@@ -531,7 +605,13 @@ class PokerService @Autowired constructor(
         if (chipsToReturn == -1L) return CashOutOutcome.HandInProgress
         if (chipsToReturn == -2L) return CashOutOutcome.NotSeated
 
-        val newBalance = if (chipsToReturn > 0L) {
+        // v2-7: free-play tables — chips are play money, never credit
+        // the wallet. Surface the player's existing `socialCredit`
+        // unchanged so the response shape stays uniform with the
+        // real-money path.
+        val newBalance = if (table.isFreePlay) {
+            userService.getUserById(discordId, guildId)?.socialCredit ?: 0L
+        } else if (chipsToReturn > 0L) {
             val user = userService.getUserByIdForUpdate(discordId, guildId)
                 ?: return CashOutOutcome.NotSeated
             user.socialCredit = (user.socialCredit ?: 0L) + chipsToReturn
@@ -636,9 +716,16 @@ class PokerService @Autowired constructor(
                 is PokerEngine.ActionEvent.Continued -> ActionOutcome.Continued
                 is PokerEngine.ActionEvent.StreetAdvanced -> ActionOutcome.StreetAdvanced(ev.newPhase)
                 is PokerEngine.ActionEvent.HandResolved -> {
-                    persistResult(table, ev.result)
-                    if (ev.result.rake > 0L) {
-                        jackpotService.addToPool(guildId, ev.result.rake)
+                    // v2-7: free-play hands stay in memory only — no
+                    // audit row in poker_hand_log, no jackpot route.
+                    // sweepPendingLeaves still runs so leavers get
+                    // their seats removed (it short-circuits the
+                    // wallet credit on free tables).
+                    if (!table.isFreePlay) {
+                        persistResult(table, ev.result)
+                        if (ev.result.rake > 0L) {
+                            jackpotService.addToPool(guildId, ev.result.rake)
+                        }
                     }
                     // v2-3: cash out any seats marked pendingLeave during
                     // the hand. Done after rake / log so a side-pot
@@ -680,15 +767,20 @@ class PokerService @Autowired constructor(
         }
         if (refunds.isEmpty()) return
 
-        // Lock all refund recipients in ascending discord-id order to
-        // avoid cycles with concurrent /tip, /duel, /coinflip, etc.
-        // transactions touching the same users.
-        val locked = userService.lockUsersInAscendingOrder(refunds.keys, table.guildId)
-        for ((discordId, amount) in refunds) {
-            if (amount <= 0L) continue
-            val user = locked[discordId] ?: continue
-            user.socialCredit = (user.socialCredit ?: 0L) + amount
-            userService.updateUser(user)
+        // v2-7: free-play tables — chips are play money, never credit
+        // the wallet. The seat removal above already happened; just
+        // skip the user-lock + balance-update pass.
+        if (!table.isFreePlay) {
+            // Lock all refund recipients in ascending discord-id order to
+            // avoid cycles with concurrent /tip, /duel, /coinflip, etc.
+            // transactions touching the same users.
+            val locked = userService.lockUsersInAscendingOrder(refunds.keys, table.guildId)
+            for ((discordId, amount) in refunds) {
+                if (amount <= 0L) continue
+                val user = locked[discordId] ?: continue
+                user.socialCredit = (user.socialCredit ?: 0L) + amount
+                userService.updateUser(user)
+            }
         }
 
         // Drop the table if everyone left mid-hand.
@@ -788,6 +880,11 @@ class PokerService @Autowired constructor(
             out
         }
         if (refunds.isEmpty()) return
+
+        // v2-7: free-play tables — seats already cleared above; the
+        // chip stacks were play money and never came from a wallet,
+        // so there's nothing to refund.
+        if (table.isFreePlay) return
 
         // Lock all refund recipients in ascending discord-id order to avoid
         // cycles with concurrent /tip, /duel, /coinflip, etc. transactions

--- a/database/src/test/kotlin/database/service/PokerServiceTest.kt
+++ b/database/src/test/kotlin/database/service/PokerServiceTest.kt
@@ -789,6 +789,173 @@ class PokerServiceTest {
         }
     }
 
+    // -- v2-7: free-play tables ----------------------------------------
+
+    @Test
+    fun `createTable free=true does NOT debit socialCredit and seats the host with play chips`() {
+        seed(host, 1000L)
+
+        val outcome = service.createTable(host, guildId, buyIn = 200L, free = true)
+
+        assertTrue(outcome is PokerService.CreateOutcome.Ok)
+        val tableId = (outcome as PokerService.CreateOutcome.Ok).tableId
+        val table = registry.get(tableId)!!
+        assertTrue(table.isFreePlay, "table flagged as free-play")
+        assertEquals(1, table.seats.size)
+        assertEquals(200L, table.seats[0].chips, "host seated with the requested play chips")
+        assertEquals(1000L, userService.current(host)?.socialCredit, "wallet untouched")
+        assertEquals(0, userService.updateCount, "no userService.updateUser on a free createTable")
+    }
+
+    @Test
+    fun `createTable free=true with zero balance still succeeds`() {
+        // Free play has no wallet barrier — even a busted player can host.
+        seed(host, 0L)
+        val outcome = service.createTable(host, guildId, buyIn = 200L, free = true)
+        assertTrue(outcome is PokerService.CreateOutcome.Ok)
+        assertEquals(0L, userService.current(host)?.socialCredit, "wallet stays at zero")
+    }
+
+    @Test
+    fun `createTable free=true still validates buyIn against minBuyIn maxBuyIn`() {
+        seed(host, 1_000_000L)
+        val tooSmall = service.createTable(host, guildId, buyIn = 1L, free = true)
+        assertTrue(tooSmall is PokerService.CreateOutcome.InvalidBuyIn)
+        val tooBig = service.createTable(host, guildId, buyIn = 999_999L, free = true)
+        assertTrue(tooBig is PokerService.CreateOutcome.InvalidBuyIn)
+    }
+
+    @Test
+    fun `buyIn on a free-play table does NOT debit socialCredit`() {
+        seed(host, 1000L); seed(joiner, 1000L)
+        val tableId = (service.createTable(host, guildId, buyIn = 200L, free = true)
+            as PokerService.CreateOutcome.Ok).tableId
+
+        val outcome = service.buyIn(joiner, guildId, tableId, buyIn = 300L)
+
+        assertTrue(outcome is PokerService.BuyInOutcome.Ok)
+        assertEquals(2, registry.get(tableId)!!.seats.size)
+        assertEquals(300L, registry.get(tableId)!!.seats[1].chips)
+        assertEquals(1000L, userService.current(joiner)?.socialCredit, "joiner's wallet untouched")
+    }
+
+    @Test
+    fun `rebuy on a free-play table does NOT debit socialCredit`() {
+        seed(host, 1000L)
+        val tableId = (service.createTable(host, guildId, buyIn = 200L, free = true)
+            as PokerService.CreateOutcome.Ok).tableId
+
+        val outcome = service.rebuy(host, guildId, tableId, amount = 300L)
+
+        assertTrue(outcome is PokerService.RebuyOutcome.Ok)
+        outcome as PokerService.RebuyOutcome.Ok
+        assertEquals(500L, outcome.seatChips, "200 createTable + 300 rebuy")
+        assertEquals(1000L, userService.current(host)?.socialCredit, "wallet untouched on free rebuy")
+    }
+
+    @Test
+    fun `cashOut on a free-play table removes the seat without crediting socialCredit`() {
+        seed(host, 1000L)
+        val tableId = (service.createTable(host, guildId, buyIn = 200L, free = true)
+            as PokerService.CreateOutcome.Ok).tableId
+
+        val outcome = service.cashOut(host, guildId, tableId)
+
+        assertTrue(outcome is PokerService.CashOutOutcome.Ok)
+        outcome as PokerService.CashOutOutcome.Ok
+        assertEquals(200L, outcome.chipsReturned, "outcome reports the seat's chip count for parity")
+        assertEquals(1000L, userService.current(host)?.socialCredit, "wallet stays at the original balance")
+        // Empty free table dropped from the registry, same as real-money.
+        assertNull(registry.get(tableId))
+    }
+
+    @Test
+    fun `applyAction HandResolved on a free table skips jackpot route + persistence`() {
+        seed(host, 1000L); seed(joiner, 1000L); seed(third, 1000L)
+        val tableId = (service.createTable(host, guildId, buyIn = 500L, free = true)
+            as PokerService.CreateOutcome.Ok).tableId
+        service.buyIn(joiner, guildId, tableId, buyIn = 500L)
+        service.buyIn(third, guildId, tableId, buyIn = 500L)
+        service.startHand(host, guildId, tableId)
+
+        val table = registry.get(tableId)!!
+        // Drive the hand to HandResolved via two folds (uncontested win).
+        val firstActor = table.seats[table.actorIndex].discordId
+        service.applyAction(firstActor, guildId, tableId, PokerEngine.PokerAction.Fold)
+        val secondActor = table.seats[table.actorIndex].discordId
+        val outcome = service.applyAction(secondActor, guildId, tableId, PokerEngine.PokerAction.Fold)
+
+        assertTrue(outcome is PokerService.ActionOutcome.HandResolved)
+        // Jackpot pool NOT touched on free-play hands.
+        verify(exactly = 0) { jackpotService.addToPool(any(), any()) }
+        // No audit row written.
+        assertEquals(0, handLog.inserted.size, "no poker_hand_log row on a free hand")
+        assertEquals(0, handPot.inserted.size, "no poker_hand_pot rows on a free hand")
+    }
+
+    @Test
+    fun `evictAllSeats on a free-play table clears seats without crediting wallets`() {
+        seed(host, 1000L); seed(joiner, 1000L)
+        val tableId = (service.createTable(host, guildId, buyIn = 200L, free = true)
+            as PokerService.CreateOutcome.Ok).tableId
+        service.buyIn(joiner, guildId, tableId, buyIn = 300L)
+        val table = registry.get(tableId)!!
+        val updateCountBefore = userService.updateCount
+
+        service.evictAllSeats(table)
+
+        assertEquals(0, table.seats.size, "seats cleared")
+        assertEquals(updateCountBefore, userService.updateCount, "no wallet credit pass on free evict")
+        assertEquals(1000L, userService.current(host)?.socialCredit)
+        assertEquals(1000L, userService.current(joiner)?.socialCredit)
+    }
+
+    @Test
+    fun `mid-hand leave on a free table does not credit the wallet at hand resolution`() {
+        seed(host, 1000L); seed(joiner, 1000L); seed(third, 1000L)
+        val tableId = (service.createTable(host, guildId, buyIn = 500L, free = true)
+            as PokerService.CreateOutcome.Ok).tableId
+        service.buyIn(joiner, guildId, tableId, buyIn = 500L)
+        service.buyIn(third, guildId, tableId, buyIn = 500L)
+        service.startHand(host, guildId, tableId)
+
+        val table = registry.get(tableId)!!
+        // Pick a non-actor so we exercise the cascade auto-fold path.
+        val nonActorId = table.seats.first { table.seats.indexOf(it) != table.actorIndex }.discordId
+        service.cashOut(nonActorId, guildId, tableId)
+
+        // Drive to resolution.
+        var safety = 12
+        while (registry.get(tableId)?.phase != PokerTable.Phase.WAITING && safety-- > 0) {
+            val live = registry.get(tableId) ?: break
+            val actor = live.seats.getOrNull(live.actorIndex) ?: break
+            service.applyAction(actor.discordId, guildId, tableId, PokerEngine.PokerAction.Fold)
+        }
+
+        // Leaver's seat removed by sweepPendingLeaves; wallet unchanged.
+        val tableAfter = registry.get(tableId)
+        if (tableAfter != null) {
+            assertFalse(tableAfter.seats.any { it.discordId == nonActorId })
+        }
+        assertEquals(1000L, userService.current(nonActorId)?.socialCredit, "leaver's wallet untouched")
+    }
+
+    @Test
+    fun `autoTopUp=true on a free-play createTable is silently ignored`() {
+        seed(host, 0L)
+        // Even though the wallet is empty and autoTopUp is requested, free
+        // play short-circuits before any tradeService call. The default
+        // service has no trade/market collaborators wired anyway, so this
+        // also confirms the order: free-play check happens before any
+        // wallet-related branching.
+        val outcome = service.createTable(host, guildId, buyIn = 200L, autoTopUp = true, free = true)
+
+        assertTrue(outcome is PokerService.CreateOutcome.Ok)
+        outcome as PokerService.CreateOutcome.Ok
+        assertEquals(0L, outcome.soldTobyCoins, "no TOBY sold on a free table")
+        assertEquals(0L, userService.current(host)?.socialCredit, "wallet stays at zero")
+    }
+
     private class RecordingUserService : UserService {
         private val users = mutableMapOf<Pair<Long, Long>, UserDto>()
         var updateCount = 0

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/PokerCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/PokerCommand.kt
@@ -47,6 +47,7 @@ class PokerCommand @Autowired constructor(
     companion object {
         private const val OPT_BUYIN = "chips"
         private const val OPT_TABLE = "table"
+        private const val OPT_FREE = "free"
 
         private const val SUB_CREATE = "create"
         private const val SUB_JOIN = "join"
@@ -65,7 +66,8 @@ class PokerCommand @Autowired constructor(
             .addOptions(
                 OptionData(OptionType.INTEGER, OPT_BUYIN, "Chips to buy in for", true)
                     .setMinValue(PokerService.MIN_BUY_IN)
-                    .setMaxValue(PokerService.MAX_BUY_IN)
+                    .setMaxValue(PokerService.MAX_BUY_IN),
+                OptionData(OptionType.BOOLEAN, OPT_FREE, "Free play (no credits debited, no payouts).", false)
             ),
         SubcommandData(SUB_JOIN, "Join an existing table with a buy-in.")
             .addOptions(
@@ -134,8 +136,9 @@ class PokerCommand @Autowired constructor(
         val buyIn = event.getOption(OPT_BUYIN)?.asLong ?: run {
             replyError(event, "Buy-in is required.", deleteDelay); return
         }
+        val free = event.getOption(OPT_FREE)?.asBoolean ?: false
         userDtoHelper.calculateUserDto(userDto.discordId, guildId)
-        when (val outcome = pokerService.createTable(userDto.discordId, guildId, buyIn)) {
+        when (val outcome = pokerService.createTable(userDto.discordId, guildId, buyIn, free = free)) {
             is CreateOutcome.Ok -> {
                 val table = tableRegistry.get(outcome.tableId)
                     ?: return replyError(event, "Table vanished.", deleteDelay)

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/PokerEmbeds.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/PokerEmbeds.kt
@@ -46,23 +46,33 @@ internal object PokerEmbeds {
         return ParsedButtonId(action, tableId)
     }
 
-    fun lobbyEmbed(table: PokerTable): MessageEmbed = EmbedBuilder()
-        .setTitle("🃏 Poker table #${table.id}")
-        .setDescription(
-            "Fixed-limit Texas Hold'em. Buy-in **${table.minBuyIn}–${table.maxBuyIn}** credits. " +
-                "Blinds **${table.smallBlind}/${table.bigBlind}**, bets **${table.smallBet}/${table.bigBet}** " +
-                "(pre-flop & flop / turn & river)."
-        )
-        .addField("Players", playerList(table), false)
-        .addField(
-            "How to join",
-            "Run `/poker join table:${table.id} chips:<amount>`. " +
-                "Host (<@${table.hostDiscordId}>) starts the hand with `/poker start table:${table.id}`.",
-            false
-        )
-        .setFooter("Side pots split the pot when players go all-in for different amounts.")
-        .setColor(TABLE_COLOR)
-        .build()
+    fun lobbyEmbed(table: PokerTable): MessageEmbed {
+        // v2-7: free-play tables prepend a banner to the description so
+        // joiners can see at a glance that no credits are at stake. Same
+        // chip ranges + blinds still apply — only the wallet route is
+        // skipped on the service side.
+        val description = buildString {
+            if (table.isFreePlay) {
+                append("🆓 **Free play** — no credits debited, no payouts.\n")
+            }
+            append("Fixed-limit Texas Hold'em. Buy-in **${table.minBuyIn}–${table.maxBuyIn}** chips. ")
+            append("Blinds **${table.smallBlind}/${table.bigBlind}**, bets **${table.smallBet}/${table.bigBet}** ")
+            append("(pre-flop & flop / turn & river).")
+        }
+        return EmbedBuilder()
+            .setTitle("🃏 Poker table #${table.id}${if (table.isFreePlay) " 🆓" else ""}")
+            .setDescription(description)
+            .addField("Players", playerList(table), false)
+            .addField(
+                "How to join",
+                "Run `/poker join table:${table.id} chips:<amount>`. " +
+                    "Host (<@${table.hostDiscordId}>) starts the hand with `/poker start table:${table.id}`.",
+                false
+            )
+            .setFooter("Side pots split the pot when players go all-in for different amounts.")
+            .setColor(TABLE_COLOR)
+            .build()
+    }
 
     fun handStateEmbed(table: PokerTable): MessageEmbed {
         val community = if (table.community.isEmpty()) "—" else table.community.joinToString(" ") { "`$it`" }
@@ -90,10 +100,17 @@ internal object PokerEmbeds {
                 "<@$id>: ${cards.joinToString(" ") { "`$it`" }}"
             }
         }
+        // v2-7: free-play hands never route rake to the jackpot, so the
+        // pot field drops the "rake → jackpot" suffix.
+        val potField = if (table.isFreePlay) {
+            "${result.pot} (free play — no rake)"
+        } else {
+            "${result.pot} (rake ${result.rake} → jackpot)"
+        }
         return EmbedBuilder()
-            .setTitle("🃏 Hand #${result.handNumber} settled")
+            .setTitle("🃏 Hand #${result.handNumber} settled${if (table.isFreePlay) " 🆓" else ""}")
             .setDescription("Winners: $winners")
-            .addField("Pot", "${result.pot} (rake ${result.rake} → jackpot)", true)
+            .addField("Pot", potField, true)
             .addField("Payouts", payouts.ifEmpty { "—" }, true)
             .addField("Board", board, false)
             .addField("Showdown", reveals, false)

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/economy/PokerCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/economy/PokerCommandTest.kt
@@ -75,12 +75,12 @@ internal class PokerCommandTest : CommandTest {
     fun `create subcommand happy path delegates to PokerService and posts lobby embed`() {
         every { event.subcommandName } returns "create"
         every { event.getOption("chips") } returns intOpt(200L)
-        every { pokerService.createTable(hostId, guildId, 200L, any()) } returns CreateOutcome.Ok(tableId = 7L)
+        every { pokerService.createTable(hostId, guildId, 200L, any(), any()) } returns CreateOutcome.Ok(tableId = 7L)
         every { tableRegistry.get(7L) } returns stubTable(7L)
 
         command.handle(DefaultCommandContext(event), userDto(), 0)
 
-        verify(exactly = 1) { pokerService.createTable(hostId, guildId, 200L, any()) }
+        verify(exactly = 1) { pokerService.createTable(hostId, guildId, 200L, any(), any()) }
         verify(exactly = 1) { tableRegistry.get(7L) }
     }
 
@@ -88,7 +88,7 @@ internal class PokerCommandTest : CommandTest {
     fun `create with insufficient credits surfaces error and does not look up table`() {
         every { event.subcommandName } returns "create"
         every { event.getOption("chips") } returns intOpt(200L)
-        every { pokerService.createTable(hostId, guildId, 200L, any()) } returns
+        every { pokerService.createTable(hostId, guildId, 200L, any(), any()) } returns
             CreateOutcome.InsufficientCredits(have = 50L, needed = 200L)
 
         command.handle(DefaultCommandContext(event), userDto(), 0)
@@ -255,7 +255,7 @@ internal class PokerCommandTest : CommandTest {
 
         command.handle(DefaultCommandContext(event), userDto(), 0)
 
-        verify(exactly = 0) { pokerService.createTable(any(), any(), any(), any()) }
+        verify(exactly = 0) { pokerService.createTable(any(), any(), any(), any(), any()) }
         verify(exactly = 0) { pokerService.buyIn(any(), any(), any(), any(), any()) }
         verify(exactly = 0) { pokerService.startHand(any(), any(), any(), any()) }
     }

--- a/web/src/main/kotlin/web/controller/PokerController.kt
+++ b/web/src/main/kotlin/web/controller/PokerController.kt
@@ -146,7 +146,7 @@ class PokerController(
         user, guildId, economyWebService,
         errorBuilder = { status -> tableErrorResponse(status) }
     ) { discordId ->
-        when (val outcome = pokerService.createTable(discordId, guildId, request.buyIn, request.autoTopUp)) {
+        when (val outcome = pokerService.createTable(discordId, guildId, request.buyIn, request.autoTopUp, request.free)) {
             is CreateOutcome.Ok -> ResponseEntity.ok(
                 TableActionResponse(
                     ok = true,
@@ -358,7 +358,7 @@ class PokerController(
     }
 }
 
-data class CreateRequest(val buyIn: Long = 0, val autoTopUp: Boolean = false)
+data class CreateRequest(val buyIn: Long = 0, val autoTopUp: Boolean = false, val free: Boolean = false)
 data class JoinRequest(val buyIn: Long = 0, val autoTopUp: Boolean = false)
 data class ActionRequest(val action: String = "")
 

--- a/web/src/main/kotlin/web/service/PokerWebService.kt
+++ b/web/src/main/kotlin/web/service/PokerWebService.kt
@@ -69,6 +69,13 @@ class PokerWebService(
          */
         val shotClockSeconds: Int = 0,
         val currentActorDeadlineEpochMillis: Long? = null,
+        /**
+         * v2-7: free-play flag from [PokerTable.isFreePlay]. The
+         * frontend renders a "🆓 Free play" badge and hides
+         * jackpot-related affordances when set; service-side wallet
+         * mutations are already short-circuited.
+         */
+        val isFreePlay: Boolean = false,
     )
 
     data class SeatView(
@@ -195,6 +202,7 @@ class PokerWebService(
                 raiseAmount = owe + betUnit,
                 shotClockSeconds = table.shotClockSeconds,
                 currentActorDeadlineEpochMillis = table.currentActorDeadline?.toEpochMilli(),
+                isFreePlay = table.isFreePlay,
                 lastResult = table.lastResult?.let { result ->
                     HandResultView(
                         handNumber = result.handNumber,

--- a/web/src/test/kotlin/web/controller/PokerControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/PokerControllerTest.kt
@@ -94,7 +94,7 @@ class PokerControllerTest {
 
     @Test
     fun `create happy path returns table id`() {
-        every { pokerService.createTable(discordId, guildId, 200L, any()) } returns CreateOutcome.Ok(tableId = 42L)
+        every { pokerService.createTable(discordId, guildId, 200L, any(), any()) } returns CreateOutcome.Ok(tableId = 42L)
 
         val response = controller.create(guildId, CreateRequest(buyIn = 200L), user)
 
@@ -105,7 +105,7 @@ class PokerControllerTest {
 
     @Test
     fun `create propagates invalid buy-in as 400`() {
-        every { pokerService.createTable(discordId, guildId, 1L, any()) } returns CreateOutcome.InvalidBuyIn(100L, 5000L)
+        every { pokerService.createTable(discordId, guildId, 1L, any(), any()) } returns CreateOutcome.InvalidBuyIn(100L, 5000L)
 
         val response = controller.create(guildId, CreateRequest(buyIn = 1L), user)
 
@@ -120,7 +120,7 @@ class PokerControllerTest {
         val response = controller.create(guildId, CreateRequest(buyIn = 200L), user)
 
         assertEquals(403, response.statusCode.value())
-        verify(exactly = 0) { pokerService.createTable(any(), any(), any(), any()) }
+        verify(exactly = 0) { pokerService.createTable(any(), any(), any(), any(), any()) }
     }
 
     @Test


### PR DESCRIPTION
A new per-table mode where the engine, registry, side-pot resolver, shot clock, and v2-3 leave/rebuy paths all run unchanged but the wallet is never touched and the jackpot pool never grows. Lets players sandbox / learn / goof around without risking their balance.

## Summary

- **Single per-table flag** — `PokerTable.isFreePlay`, snapshotted at create time (mirrors v2-2's `shotClockSeconds` pattern). A started hand can never flip into or out of free-play under a player.
- **Seven service-level gates** in `PokerService` short-circuit on `table.isFreePlay`:
  - `createTable` / `buyIn` / `rebuy` skip the `socialCredit` debit + the v2-4 `autoTopUp` resolution
  - `cashOut` / `sweepPendingLeaves` / `evictAllSeats` skip the credit
  - `applyAction → HandResolved` skips both `jackpotService.addToPool` and `persistResult`
- **Free hands stay in memory only** — no `poker_hand_log` row, no `poker_hand_pot` rows, no `/poker history` entry. Avoids polluting the real-money ledger and avoids a Flyway migration.
- **Stack allocation** stays the same `[minBuyIn..maxBuyIn]` range as a real-money table — players pick their own play-chip stack so dynamics stay aligned with the configured stakes.

## Surfaces

- **Discord** — `/poker create chips:<n> free:true`. Lobby embed prepends a "🆓 Free play — no credits debited, no payouts" banner; result embed swaps the "rake → jackpot" suffix for "free play — no rake".
- **Web** — `CreateRequest.free` is plumbed through; `TableStateView.isFreePlay` exposed for frontend badges / hiding jackpot affordances.

## Test plan

- [x] `./gradlew :database:test` — 100% pass. New tests cover:
  - `createTable free=true` does NOT debit `socialCredit` and seats the host with play chips
  - `createTable free=true` succeeds with a zero-balance wallet (no credit barrier)
  - `createTable free=true` still validates the buy-in against `[minBuyIn..maxBuyIn]`
  - `buyIn` / `rebuy` on a free table do NOT debit
  - `cashOut` on a free table removes the seat without crediting; drops empty tables
  - `applyAction → HandResolved` on a free table does NOT call `jackpotService.addToPool` and writes no audit rows
  - `evictAllSeats` on a free table clears seats without a wallet credit pass
  - mid-hand `/poker leave` on a free table queues + cascades + cleans up without crediting
  - `autoTopUp=true` on a free `createTable` is silently ignored (no `tradeService.sell` ever fires)
- [ ] `./gradlew :discord-bot:test` — CI; existing `PokerCommandTest` mockk stubs widened with `any()` for the new `free` slot
- [ ] `./gradlew :web:test` — CI; same mockk widening + ensures `CreateRequest.free` deserializes correctly

## Out of scope

- **Per-guild config default for free-play** — every table picks its own mode at creation; matches v2-2's per-table snapshot pattern.
- **Mode switching mid-table** — once a table is free, it stays free until it dies. Simpler invariants; no chip-conversion edge cases.
- **Free-play hand history** — by design, free hands leave no trace. If "show me the wackiest free hand of the week" becomes a feature request later, a `free_play` column can be added then.

https://claude.ai/code/session_0169MvtJ2BSbwkoB9GrFhfZC

---
_Generated by [Claude Code](https://claude.ai/code/session_0169MvtJ2BSbwkoB9GrFhfZC)_