### PR TITLE
refactor(web): second pass — Campaign + Intro + isMember dedup, navbar bridge

### DIFF
--- a/web/src/main/kotlin/web/controller/CampaignController.kt
+++ b/web/src/main/kotlin/web/controller/CampaignController.kt
@@ -42,6 +42,7 @@ import web.service.SaveTemplateResult
 import web.service.SessionEventView
 import web.service.SetAliveResult
 import web.service.SetCharacterResult
+import web.util.WebGuildAccess
 import web.util.discordIdOrNull
 import web.util.displayName
 
@@ -73,13 +74,10 @@ class CampaignController(
         @AuthenticationPrincipal user: OAuth2User,
         model: Model,
         ra: RedirectAttributes
-    ): String {
-        val discordId = user.discordIdOrNull()
-            ?: return "redirect:/dnd/campaign"
-
+    ): String = WebGuildAccess.requireSignedInForPage(user, "/dnd/campaign") { discordId ->
         val guildName = campaignWebService.getGuildName(guildId) ?: run {
             ra.addFlashAttribute("error", "Bot is not in that server.")
-            return "redirect:/dnd/campaign"
+            return@requireSignedInForPage "redirect:/dnd/campaign"
         }
 
         val campaignDetail = campaignWebService.getCampaignDetail(guildId, discordId)
@@ -100,7 +98,7 @@ class CampaignController(
         model.addAttribute("freshEventIds", campaignDetail?.freshEventIds ?: emptyList<Long>())
         model.addAttribute("username", user.displayName())
 
-        return "campaignDetail"
+        "campaignDetail"
     }
 
     @GetMapping("/campaign/{guildId}/events")
@@ -140,19 +138,17 @@ class CampaignController(
         @RequestParam name: String,
         @AuthenticationPrincipal user: OAuth2User,
         ra: RedirectAttributes
-    ): String {
-        val discordId = user.discordIdOrNull()
-            ?: return "redirect:/dnd/campaign"
-
+    ): String = WebGuildAccess.requireSignedInForPage(user, "/dnd/campaign") { discordId ->
+        // Special-cased vs. the helper because "Bot not in server" needs to
+        // bounce to the campaign list, not the (non-existent) detail page.
         campaignWebService.getGuildName(guildId) ?: run {
             ra.addFlashAttribute("error", "Bot is not in that server.")
-            return "redirect:/dnd/campaign"
+            return@requireSignedInForPage "redirect:/dnd/campaign"
         }
-
         if (campaignWebService.createCampaign(guildId, discordId, name) == null) {
             ra.addFlashAttribute("error", "A campaign is already active in this server.")
         }
-        return "redirect:/dnd/campaign/$guildId"
+        "redirect:/dnd/campaign/$guildId"
     }
 
     @PostMapping("/campaign/{guildId}/join")
@@ -160,17 +156,13 @@ class CampaignController(
         @PathVariable guildId: Long,
         @AuthenticationPrincipal user: OAuth2User,
         ra: RedirectAttributes
-    ): String {
-        val discordId = user.discordIdOrNull()
-            ?: return "redirect:/dnd/campaign"
-
+    ): String = withCampaignAuth(user, guildId, ra) { discordId ->
         when (campaignWebService.joinCampaign(guildId, discordId)) {
-            JoinResult.JOINED -> {}
-            JoinResult.NO_ACTIVE_CAMPAIGN -> ra.addFlashAttribute("error", "No active campaign in this server.")
-            JoinResult.ALREADY_JOINED -> ra.addFlashAttribute("error", "You are already in this campaign.")
-            JoinResult.IS_DM -> ra.addFlashAttribute("error", "You are the DM and cannot join as a player.")
+            JoinResult.JOINED -> null
+            JoinResult.NO_ACTIVE_CAMPAIGN -> "No active campaign in this server."
+            JoinResult.ALREADY_JOINED -> "You are already in this campaign."
+            JoinResult.IS_DM -> "You are the DM and cannot join as a player."
         }
-        return "redirect:/dnd/campaign/$guildId"
     }
 
     @PostMapping("/campaign/{guildId}/leave")
@@ -178,16 +170,12 @@ class CampaignController(
         @PathVariable guildId: Long,
         @AuthenticationPrincipal user: OAuth2User,
         ra: RedirectAttributes
-    ): String {
-        val discordId = user.discordIdOrNull()
-            ?: return "redirect:/dnd/campaign"
-
+    ): String = withCampaignAuth(user, guildId, ra) { discordId ->
         when (campaignWebService.leaveCampaign(guildId, discordId)) {
-            LeaveResult.LEFT -> {}
-            LeaveResult.NO_ACTIVE_CAMPAIGN -> ra.addFlashAttribute("error", "No active campaign in this server.")
-            LeaveResult.NOT_A_PLAYER -> ra.addFlashAttribute("error", "You are not in this campaign.")
+            LeaveResult.LEFT -> null
+            LeaveResult.NO_ACTIVE_CAMPAIGN -> "No active campaign in this server."
+            LeaveResult.NOT_A_PLAYER -> "You are not in this campaign."
         }
-        return "redirect:/dnd/campaign/$guildId"
     }
 
     @PostMapping("/campaign/{guildId}/character")
@@ -196,18 +184,11 @@ class CampaignController(
         @RequestParam(name = "characterInput", required = false, defaultValue = "") characterInput: String,
         @AuthenticationPrincipal user: OAuth2User,
         ra: RedirectAttributes
-    ): String {
-        val discordId = user.discordIdOrNull()
-            ?: return "redirect:/dnd/campaign"
-
+    ): String = withCampaignAuth(user, guildId, ra) { discordId ->
         when (campaignWebService.setLinkedCharacter(guildId, discordId, characterInput)) {
-            SetCharacterResult.UPDATED, SetCharacterResult.CLEARED -> {}
-            SetCharacterResult.INVALID -> ra.addFlashAttribute(
-                "error",
-                "Could not extract a valid character ID. Paste a D&D Beyond URL or numeric ID."
-            )
+            SetCharacterResult.UPDATED, SetCharacterResult.CLEARED -> null
+            SetCharacterResult.INVALID -> "Could not extract a valid character ID. Paste a D&D Beyond URL or numeric ID."
         }
-        return "redirect:/dnd/campaign/$guildId"
     }
 
     @PostMapping("/campaign/{guildId}/end")
@@ -215,16 +196,12 @@ class CampaignController(
         @PathVariable guildId: Long,
         @AuthenticationPrincipal user: OAuth2User,
         ra: RedirectAttributes
-    ): String {
-        val discordId = user.discordIdOrNull()
-            ?: return "redirect:/dnd/campaign"
-
+    ): String = withCampaignAuth(user, guildId, ra) { discordId ->
         when (campaignWebService.endCampaign(guildId, discordId)) {
-            EndResult.ENDED -> {}
-            EndResult.NO_ACTIVE_CAMPAIGN -> ra.addFlashAttribute("error", "No active campaign in this server.")
-            EndResult.NOT_DM -> ra.addFlashAttribute("error", "Only the Dungeon Master can end the campaign.")
+            EndResult.ENDED -> null
+            EndResult.NO_ACTIVE_CAMPAIGN -> "No active campaign in this server."
+            EndResult.NOT_DM -> "Only the Dungeon Master can end the campaign."
         }
-        return "redirect:/dnd/campaign/$guildId"
     }
 
     @PostMapping("/campaign/{guildId}/players/{targetDiscordId}/kick")
@@ -233,18 +210,14 @@ class CampaignController(
         @PathVariable targetDiscordId: Long,
         @AuthenticationPrincipal user: OAuth2User,
         ra: RedirectAttributes
-    ): String {
-        val discordId = user.discordIdOrNull()
-            ?: return "redirect:/dnd/campaign"
-
+    ): String = withCampaignAuth(user, guildId, ra) { discordId ->
         when (campaignWebService.kickPlayer(guildId, discordId, targetDiscordId)) {
-            KickResult.KICKED -> {}
-            KickResult.NO_ACTIVE_CAMPAIGN -> ra.addFlashAttribute("error", "No active campaign in this server.")
-            KickResult.NOT_DM -> ra.addFlashAttribute("error", "Only the Dungeon Master can kick players.")
-            KickResult.NOT_A_PLAYER -> ra.addFlashAttribute("error", "That user isn't in the campaign.")
-            KickResult.CANNOT_KICK_DM -> ra.addFlashAttribute("error", "The DM can't be kicked.")
+            KickResult.KICKED -> null
+            KickResult.NO_ACTIVE_CAMPAIGN -> "No active campaign in this server."
+            KickResult.NOT_DM -> "Only the Dungeon Master can kick players."
+            KickResult.NOT_A_PLAYER -> "That user isn't in the campaign."
+            KickResult.CANNOT_KICK_DM -> "The DM can't be kicked."
         }
-        return "redirect:/dnd/campaign/$guildId"
     }
 
     @PostMapping("/campaign/{guildId}/players/{targetDiscordId}/alive")
@@ -254,17 +227,13 @@ class CampaignController(
         @RequestParam alive: Boolean,
         @AuthenticationPrincipal user: OAuth2User,
         ra: RedirectAttributes
-    ): String {
-        val discordId = user.discordIdOrNull()
-            ?: return "redirect:/dnd/campaign"
-
+    ): String = withCampaignAuth(user, guildId, ra) { discordId ->
         when (campaignWebService.setPlayerAlive(guildId, discordId, targetDiscordId, alive)) {
-            SetAliveResult.UPDATED -> {}
-            SetAliveResult.NO_ACTIVE_CAMPAIGN -> ra.addFlashAttribute("error", "No active campaign in this server.")
-            SetAliveResult.NOT_DM -> ra.addFlashAttribute("error", "Only the Dungeon Master can change player status.")
-            SetAliveResult.NOT_A_PLAYER -> ra.addFlashAttribute("error", "That user isn't in the campaign.")
+            SetAliveResult.UPDATED -> null
+            SetAliveResult.NO_ACTIVE_CAMPAIGN -> "No active campaign in this server."
+            SetAliveResult.NOT_DM -> "Only the Dungeon Master can change player status."
+            SetAliveResult.NOT_A_PLAYER -> "That user isn't in the campaign."
         }
-        return "redirect:/dnd/campaign/$guildId"
     }
 
     @PostMapping("/campaign/{guildId}/notes")
@@ -273,24 +242,14 @@ class CampaignController(
         @RequestParam body: String,
         @AuthenticationPrincipal user: OAuth2User,
         ra: RedirectAttributes
-    ): String {
-        val discordId = user.discordIdOrNull()
-            ?: return "redirect:/dnd/campaign"
-
+    ): String = withCampaignAuth(user, guildId, ra) { discordId ->
         when (campaignWebService.addNote(guildId, discordId, body)) {
-            AddNoteResult.ADDED -> {}
-            AddNoteResult.NO_ACTIVE_CAMPAIGN -> ra.addFlashAttribute("error", "No active campaign in this server.")
-            AddNoteResult.NOT_PARTICIPANT -> ra.addFlashAttribute(
-                "error",
-                "Only the DM and campaign players can add notes."
-            )
-            AddNoteResult.EMPTY_BODY -> ra.addFlashAttribute("error", "Note body can't be empty.")
-            AddNoteResult.BODY_TOO_LONG -> ra.addFlashAttribute(
-                "error",
-                "Note is too long (max 2000 characters)."
-            )
+            AddNoteResult.ADDED -> null
+            AddNoteResult.NO_ACTIVE_CAMPAIGN -> "No active campaign in this server."
+            AddNoteResult.NOT_PARTICIPANT -> "Only the DM and campaign players can add notes."
+            AddNoteResult.EMPTY_BODY -> "Note body can't be empty."
+            AddNoteResult.BODY_TOO_LONG -> "Note is too long (max 2000 characters)."
         }
-        return "redirect:/dnd/campaign/$guildId"
     }
 
     @PostMapping("/campaign/{guildId}/notes/{noteId}/delete")
@@ -299,20 +258,13 @@ class CampaignController(
         @PathVariable noteId: Long,
         @AuthenticationPrincipal user: OAuth2User,
         ra: RedirectAttributes
-    ): String {
-        val discordId = user.discordIdOrNull()
-            ?: return "redirect:/dnd/campaign"
-
+    ): String = withCampaignAuth(user, guildId, ra) { discordId ->
         when (campaignWebService.deleteNote(guildId, discordId, noteId)) {
-            DeleteNoteResult.DELETED -> {}
-            DeleteNoteResult.NO_ACTIVE_CAMPAIGN -> ra.addFlashAttribute("error", "No active campaign in this server.")
-            DeleteNoteResult.NOT_FOUND -> ra.addFlashAttribute("error", "That note doesn't exist.")
-            DeleteNoteResult.NOT_ALLOWED -> ra.addFlashAttribute(
-                "error",
-                "You can only delete your own notes (or any note if you're the DM)."
-            )
+            DeleteNoteResult.DELETED -> null
+            DeleteNoteResult.NO_ACTIVE_CAMPAIGN -> "No active campaign in this server."
+            DeleteNoteResult.NOT_FOUND -> "That note doesn't exist."
+            DeleteNoteResult.NOT_ALLOWED -> "You can only delete your own notes (or any note if you're the DM)."
         }
-        return "redirect:/dnd/campaign/$guildId"
     }
 
     @PostMapping("/campaign/{guildId}/events/{eventId}/annotate")
@@ -323,19 +275,15 @@ class CampaignController(
         @RequestParam(name = "target", required = false) target: String?,
         @AuthenticationPrincipal user: OAuth2User,
         ra: RedirectAttributes
-    ): String {
-        val discordId = user.discordIdOrNull()
-            ?: return "redirect:/dnd/campaign"
-
+    ): String = withCampaignAuth(user, guildId, ra) { discordId ->
         when (campaignWebService.annotateRoll(guildId, discordId, eventId, kind, target)) {
-            AnnotateRollResult.ANNOTATED -> {}
-            AnnotateRollResult.NO_ACTIVE_CAMPAIGN -> ra.addFlashAttribute("error", "No active campaign in this server.")
-            AnnotateRollResult.NOT_DM -> ra.addFlashAttribute("error", "Only the Dungeon Master can annotate rolls.")
-            AnnotateRollResult.NOT_FOUND -> ra.addFlashAttribute("error", "That roll doesn't exist in this campaign.")
-            AnnotateRollResult.NOT_A_ROLL -> ra.addFlashAttribute("error", "You can only mark Hit/Miss on a roll.")
-            AnnotateRollResult.INVALID_KIND -> ra.addFlashAttribute("error", "Annotation kind must be HIT or MISS.")
+            AnnotateRollResult.ANNOTATED -> null
+            AnnotateRollResult.NO_ACTIVE_CAMPAIGN -> "No active campaign in this server."
+            AnnotateRollResult.NOT_DM -> "Only the Dungeon Master can annotate rolls."
+            AnnotateRollResult.NOT_FOUND -> "That roll doesn't exist in this campaign."
+            AnnotateRollResult.NOT_A_ROLL -> "You can only mark Hit/Miss on a roll."
+            AnnotateRollResult.INVALID_KIND -> "Annotation kind must be HIT or MISS."
         }
-        return "redirect:/dnd/campaign/$guildId"
     }
 
     @PostMapping("/campaign/{guildId}/narrate")
@@ -344,21 +292,14 @@ class CampaignController(
         @RequestParam body: String,
         @AuthenticationPrincipal user: OAuth2User,
         ra: RedirectAttributes
-    ): String {
-        val discordId = user.discordIdOrNull()
-            ?: return "redirect:/dnd/campaign"
-
+    ): String = withCampaignAuth(user, guildId, ra) { discordId ->
         when (campaignWebService.narrate(guildId, discordId, body)) {
-            NarrateResult.NARRATED -> {}
-            NarrateResult.NO_ACTIVE_CAMPAIGN -> ra.addFlashAttribute("error", "No active campaign in this server.")
-            NarrateResult.NOT_DM -> ra.addFlashAttribute("error", "Only the Dungeon Master can narrate.")
-            NarrateResult.EMPTY_BODY -> ra.addFlashAttribute("error", "Narration can't be empty.")
-            NarrateResult.BODY_TOO_LONG -> ra.addFlashAttribute(
-                "error",
-                "Narration is too long (max ${CampaignWebService.MAX_NARRATE_BODY_LENGTH} characters)."
-            )
+            NarrateResult.NARRATED -> null
+            NarrateResult.NO_ACTIVE_CAMPAIGN -> "No active campaign in this server."
+            NarrateResult.NOT_DM -> "Only the Dungeon Master can narrate."
+            NarrateResult.EMPTY_BODY -> "Narration can't be empty."
+            NarrateResult.BODY_TOO_LONG -> "Narration is too long (max ${CampaignWebService.MAX_NARRATE_BODY_LENGTH} characters)."
         }
-        return "redirect:/dnd/campaign/$guildId"
     }
 
     @GetMapping("/monsters/templates")
@@ -380,25 +321,16 @@ class CampaignController(
         @RequestParam(name = "ac", required = false) ac: Int?,
         @AuthenticationPrincipal user: OAuth2User,
         ra: RedirectAttributes
-    ): String {
-        val discordId = user.discordIdOrNull()
-            ?: return "redirect:/dnd/campaign"
-
+    ): String = withCampaignAuth(user, guildId, ra) { discordId ->
         when (campaignWebService.saveTemplate(discordId, id, name, initiativeModifier, hpExpression, ac)) {
-            SaveTemplateResult.SAVED -> {}
-            SaveTemplateResult.NAME_BLANK -> ra.addFlashAttribute("error", "Monster name can't be empty.")
-            SaveTemplateResult.NAME_TOO_LONG -> ra.addFlashAttribute(
-                "error",
+            SaveTemplateResult.SAVED -> null
+            SaveTemplateResult.NAME_BLANK -> "Monster name can't be empty."
+            SaveTemplateResult.NAME_TOO_LONG ->
                 "Monster name is too long (max ${CampaignWebService.MAX_TEMPLATE_NAME_LENGTH} characters)."
-            )
-            SaveTemplateResult.INVALID_HP -> ra.addFlashAttribute(
-                "error",
-                "HP must be a number or a dice expression like '3d20+30'."
-            )
-            SaveTemplateResult.NOT_FOUND -> ra.addFlashAttribute("error", "That template doesn't exist.")
-            SaveTemplateResult.NOT_OWNER -> ra.addFlashAttribute("error", "You can only edit your own templates.")
+            SaveTemplateResult.INVALID_HP -> "HP must be a number or a dice expression like '3d20+30'."
+            SaveTemplateResult.NOT_FOUND -> "That template doesn't exist."
+            SaveTemplateResult.NOT_OWNER -> "You can only edit your own templates."
         }
-        return "redirect:/dnd/campaign/$guildId"
     }
 
     @PostMapping("/campaign/{guildId}/monsters/templates/{templateId}/delete")
@@ -407,16 +339,12 @@ class CampaignController(
         @PathVariable templateId: Long,
         @AuthenticationPrincipal user: OAuth2User,
         ra: RedirectAttributes
-    ): String {
-        val discordId = user.discordIdOrNull()
-            ?: return "redirect:/dnd/campaign"
-
+    ): String = withCampaignAuth(user, guildId, ra) { discordId ->
         when (campaignWebService.deleteTemplate(discordId, templateId)) {
-            DeleteTemplateResult.DELETED -> {}
-            DeleteTemplateResult.NOT_FOUND -> ra.addFlashAttribute("error", "That template doesn't exist.")
-            DeleteTemplateResult.NOT_OWNER -> ra.addFlashAttribute("error", "You can only delete your own templates.")
+            DeleteTemplateResult.DELETED -> null
+            DeleteTemplateResult.NOT_FOUND -> "That template doesn't exist."
+            DeleteTemplateResult.NOT_OWNER -> "You can only delete your own templates."
         }
-        return "redirect:/dnd/campaign/$guildId"
     }
 
     @PostMapping("/campaign/{guildId}/monsters/templates/{templateId}/attacks")
@@ -429,38 +357,22 @@ class CampaignController(
         @RequestParam("damageExpression") damageExpression: String,
         @AuthenticationPrincipal user: OAuth2User,
         ra: RedirectAttributes
-    ): String {
-        val discordId = user.discordIdOrNull()
-            ?: return "redirect:/dnd/campaign"
-
+    ): String = withCampaignAuth(user, guildId, ra) { discordId ->
         when (campaignWebService.saveAttack(discordId, templateId, attackId, name, toHitModifier, damageExpression)) {
-            SaveAttackResult.SAVED -> {}
-            SaveAttackResult.NAME_BLANK -> ra.addFlashAttribute("error", "Attack name can't be empty.")
-            SaveAttackResult.NAME_TOO_LONG -> ra.addFlashAttribute(
-                "error",
+            SaveAttackResult.SAVED -> null
+            SaveAttackResult.NAME_BLANK -> "Attack name can't be empty."
+            SaveAttackResult.NAME_TOO_LONG ->
                 "Attack name is too long (max ${CampaignWebService.MAX_ATTACK_NAME_LENGTH} characters)."
-            )
-            SaveAttackResult.INVALID_MODIFIER -> ra.addFlashAttribute(
-                "error",
+            SaveAttackResult.INVALID_MODIFIER ->
                 "To-hit modifier must be between -${CampaignWebService.MAX_ATTACK_MODIFIER} and ${CampaignWebService.MAX_ATTACK_MODIFIER}."
-            )
-            SaveAttackResult.INVALID_DAMAGE -> ra.addFlashAttribute(
-                "error",
-                "Damage must be a number or a dice expression like '2d6+3'."
-            )
-            SaveAttackResult.TOO_MANY -> ra.addFlashAttribute(
-                "error",
+            SaveAttackResult.INVALID_DAMAGE -> "Damage must be a number or a dice expression like '2d6+3'."
+            SaveAttackResult.TOO_MANY ->
                 "This monster already has the maximum of ${CampaignWebService.MAX_ATTACKS_PER_TEMPLATE} attacks."
-            )
-            SaveAttackResult.TEMPLATE_NOT_FOUND -> ra.addFlashAttribute("error", "That monster template doesn't exist.")
-            SaveAttackResult.NOT_OWNER -> ra.addFlashAttribute("error", "You can only edit your own monsters.")
-            SaveAttackResult.ATTACK_NOT_FOUND -> ra.addFlashAttribute("error", "That attack doesn't exist.")
-            SaveAttackResult.ATTACK_TEMPLATE_MISMATCH -> ra.addFlashAttribute(
-                "error",
-                "That attack belongs to a different monster."
-            )
+            SaveAttackResult.TEMPLATE_NOT_FOUND -> "That monster template doesn't exist."
+            SaveAttackResult.NOT_OWNER -> "You can only edit your own monsters."
+            SaveAttackResult.ATTACK_NOT_FOUND -> "That attack doesn't exist."
+            SaveAttackResult.ATTACK_TEMPLATE_MISMATCH -> "That attack belongs to a different monster."
         }
-        return "redirect:/dnd/campaign/$guildId"
     }
 
     @PostMapping("/campaign/{guildId}/monsters/templates/{templateId}/attacks/{attackId}/delete")
@@ -470,20 +382,13 @@ class CampaignController(
         @PathVariable attackId: Long,
         @AuthenticationPrincipal user: OAuth2User,
         ra: RedirectAttributes
-    ): String {
-        val discordId = user.discordIdOrNull()
-            ?: return "redirect:/dnd/campaign"
-
+    ): String = withCampaignAuth(user, guildId, ra) { discordId ->
         when (campaignWebService.deleteAttack(discordId, templateId, attackId)) {
-            DeleteAttackResult.DELETED -> {}
-            DeleteAttackResult.ATTACK_NOT_FOUND -> ra.addFlashAttribute("error", "That attack doesn't exist.")
-            DeleteAttackResult.NOT_OWNER -> ra.addFlashAttribute("error", "You can only delete your own monsters' attacks.")
-            DeleteAttackResult.ATTACK_TEMPLATE_MISMATCH -> ra.addFlashAttribute(
-                "error",
-                "That attack belongs to a different monster."
-            )
+            DeleteAttackResult.DELETED -> null
+            DeleteAttackResult.ATTACK_NOT_FOUND -> "That attack doesn't exist."
+            DeleteAttackResult.NOT_OWNER -> "You can only delete your own monsters' attacks."
+            DeleteAttackResult.ATTACK_TEMPLATE_MISMATCH -> "That attack belongs to a different monster."
         }
-        return "redirect:/dnd/campaign/$guildId"
     }
 
     // ----------------------------------------------------------------------
@@ -520,25 +425,17 @@ class CampaignController(
         @RequestParam(name = "notes", required = false) notes: String?,
         @AuthenticationPrincipal user: OAuth2User,
         ra: RedirectAttributes
-    ): String {
-        val discordId = user.discordIdOrNull()
-            ?: return "redirect:/dnd/campaign"
-
+    ): String = withCampaignAuth(user, guildId, ra) { discordId ->
         when (campaignWebService.saveEncounter(discordId, id, name, notes)) {
-            SaveEncounterResult.SAVED -> {}
-            SaveEncounterResult.NAME_BLANK -> ra.addFlashAttribute("error", "Encounter name can't be empty.")
-            SaveEncounterResult.NAME_TOO_LONG -> ra.addFlashAttribute(
-                "error",
+            SaveEncounterResult.SAVED -> null
+            SaveEncounterResult.NAME_BLANK -> "Encounter name can't be empty."
+            SaveEncounterResult.NAME_TOO_LONG ->
                 "Encounter name is too long (max ${CampaignWebService.MAX_ENCOUNTER_NAME_LENGTH} characters)."
-            )
-            SaveEncounterResult.NOTES_TOO_LONG -> ra.addFlashAttribute(
-                "error",
+            SaveEncounterResult.NOTES_TOO_LONG ->
                 "Encounter notes are too long (max ${CampaignWebService.MAX_ENCOUNTER_NOTES_LENGTH} characters)."
-            )
-            SaveEncounterResult.NOT_FOUND -> ra.addFlashAttribute("error", "That encounter doesn't exist.")
-            SaveEncounterResult.NOT_OWNER -> ra.addFlashAttribute("error", "You can only edit your own encounters.")
+            SaveEncounterResult.NOT_FOUND -> "That encounter doesn't exist."
+            SaveEncounterResult.NOT_OWNER -> "You can only edit your own encounters."
         }
-        return "redirect:/dnd/campaign/$guildId"
     }
 
     @PostMapping("/campaign/{guildId}/encounters/{encounterId}/delete")
@@ -547,16 +444,12 @@ class CampaignController(
         @PathVariable encounterId: Long,
         @AuthenticationPrincipal user: OAuth2User,
         ra: RedirectAttributes
-    ): String {
-        val discordId = user.discordIdOrNull()
-            ?: return "redirect:/dnd/campaign"
-
+    ): String = withCampaignAuth(user, guildId, ra) { discordId ->
         when (campaignWebService.deleteEncounter(discordId, encounterId)) {
-            DeleteEncounterResult.DELETED -> {}
-            DeleteEncounterResult.NOT_FOUND -> ra.addFlashAttribute("error", "That encounter doesn't exist.")
-            DeleteEncounterResult.NOT_OWNER -> ra.addFlashAttribute("error", "You can only delete your own encounters.")
+            DeleteEncounterResult.DELETED -> null
+            DeleteEncounterResult.NOT_FOUND -> "That encounter doesn't exist."
+            DeleteEncounterResult.NOT_OWNER -> "You can only delete your own encounters."
         }
-        return "redirect:/dnd/campaign/$guildId"
     }
 
     @PostMapping("/campaign/{guildId}/encounters/{encounterId}/entries")
@@ -572,54 +465,28 @@ class CampaignController(
         @RequestParam(name = "adhocAc", required = false) adhocAc: Int?,
         @AuthenticationPrincipal user: OAuth2User,
         ra: RedirectAttributes
-    ): String {
-        val discordId = user.discordIdOrNull()
-            ?: return "redirect:/dnd/campaign"
-
+    ): String = withCampaignAuth(user, guildId, ra) { discordId ->
         when (campaignWebService.saveEncounterEntry(
             discordId, encounterId, entryId,
             monsterTemplateId, quantity,
             adhocName, adhocInitiativeModifier, adhocHpExpression, adhocAc
         )) {
-            SaveEncounterEntryResult.SAVED -> {}
-            SaveEncounterEntryResult.ENCOUNTER_NOT_FOUND -> ra.addFlashAttribute(
-                "error", "That encounter doesn't exist."
-            )
-            SaveEncounterEntryResult.NOT_OWNER -> ra.addFlashAttribute(
-                "error", "You can only edit your own encounters."
-            )
-            SaveEncounterEntryResult.TEMPLATE_NOT_FOUND -> ra.addFlashAttribute(
-                "error", "That monster template doesn't exist."
-            )
-            SaveEncounterEntryResult.TEMPLATE_NOT_OWNED -> ra.addFlashAttribute(
-                "error", "You can only use your own monster templates."
-            )
-            SaveEncounterEntryResult.NAME_TOO_LONG -> ra.addFlashAttribute(
-                "error",
+            SaveEncounterEntryResult.SAVED -> null
+            SaveEncounterEntryResult.ENCOUNTER_NOT_FOUND -> "That encounter doesn't exist."
+            SaveEncounterEntryResult.NOT_OWNER -> "You can only edit your own encounters."
+            SaveEncounterEntryResult.TEMPLATE_NOT_FOUND -> "That monster template doesn't exist."
+            SaveEncounterEntryResult.TEMPLATE_NOT_OWNED -> "You can only use your own monster templates."
+            SaveEncounterEntryResult.NAME_TOO_LONG ->
                 "Ad-hoc monster name is too long (max ${CampaignWebService.MAX_ENCOUNTER_NAME_LENGTH} characters)."
-            )
-            SaveEncounterEntryResult.INVALID_HP -> ra.addFlashAttribute(
-                "error", "HP must be a number or a dice expression like '3d20+30'."
-            )
-            SaveEncounterEntryResult.INVALID_QUANTITY -> ra.addFlashAttribute(
-                "error",
+            SaveEncounterEntryResult.INVALID_HP -> "HP must be a number or a dice expression like '3d20+30'."
+            SaveEncounterEntryResult.INVALID_QUANTITY ->
                 "Quantity must be between 1 and ${CampaignWebService.MAX_QUANTITY_PER_ENTRY}."
-            )
-            SaveEncounterEntryResult.TOO_MANY_ENTRIES -> ra.addFlashAttribute(
-                "error",
+            SaveEncounterEntryResult.TOO_MANY_ENTRIES ->
                 "This encounter already has the maximum of ${CampaignWebService.MAX_ENTRIES_PER_ENCOUNTER} rows."
-            )
-            SaveEncounterEntryResult.MISSING_SOURCE -> ra.addFlashAttribute(
-                "error", "Pick a monster from the library or fill in an ad-hoc name."
-            )
-            SaveEncounterEntryResult.ENTRY_NOT_FOUND -> ra.addFlashAttribute(
-                "error", "That entry doesn't exist."
-            )
-            SaveEncounterEntryResult.ENTRY_ENCOUNTER_MISMATCH -> ra.addFlashAttribute(
-                "error", "That entry belongs to a different encounter."
-            )
+            SaveEncounterEntryResult.MISSING_SOURCE -> "Pick a monster from the library or fill in an ad-hoc name."
+            SaveEncounterEntryResult.ENTRY_NOT_FOUND -> "That entry doesn't exist."
+            SaveEncounterEntryResult.ENTRY_ENCOUNTER_MISMATCH -> "That entry belongs to a different encounter."
         }
-        return "redirect:/dnd/campaign/$guildId"
     }
 
     @PostMapping("/campaign/{guildId}/encounters/{encounterId}/entries/{entryId}/delete")
@@ -629,26 +496,14 @@ class CampaignController(
         @PathVariable entryId: Long,
         @AuthenticationPrincipal user: OAuth2User,
         ra: RedirectAttributes
-    ): String {
-        val discordId = user.discordIdOrNull()
-            ?: return "redirect:/dnd/campaign"
-
+    ): String = withCampaignAuth(user, guildId, ra) { discordId ->
         when (campaignWebService.deleteEncounterEntry(discordId, encounterId, entryId)) {
-            DeleteEncounterEntryResult.DELETED -> {}
-            DeleteEncounterEntryResult.ENCOUNTER_NOT_FOUND -> ra.addFlashAttribute(
-                "error", "That encounter doesn't exist."
-            )
-            DeleteEncounterEntryResult.NOT_OWNER -> ra.addFlashAttribute(
-                "error", "You can only edit your own encounters."
-            )
-            DeleteEncounterEntryResult.ENTRY_NOT_FOUND -> ra.addFlashAttribute(
-                "error", "That entry doesn't exist."
-            )
-            DeleteEncounterEntryResult.ENTRY_ENCOUNTER_MISMATCH -> ra.addFlashAttribute(
-                "error", "That entry belongs to a different encounter."
-            )
+            DeleteEncounterEntryResult.DELETED -> null
+            DeleteEncounterEntryResult.ENCOUNTER_NOT_FOUND -> "That encounter doesn't exist."
+            DeleteEncounterEntryResult.NOT_OWNER -> "You can only edit your own encounters."
+            DeleteEncounterEntryResult.ENTRY_NOT_FOUND -> "That entry doesn't exist."
+            DeleteEncounterEntryResult.ENTRY_ENCOUNTER_MISMATCH -> "That entry belongs to a different encounter."
         }
-        return "redirect:/dnd/campaign/$guildId"
     }
 
     data class ReorderEntriesBody(val orderedIds: List<Long> = emptyList())
@@ -685,34 +540,16 @@ class CampaignController(
         @RequestParam(name = "playerDiscordIds", required = false) playerDiscordIds: List<Long>?,
         @AuthenticationPrincipal user: OAuth2User,
         ra: RedirectAttributes
-    ): String {
-        val discordId = user.discordIdOrNull()
-            ?: return "redirect:/dnd/campaign"
-
-        when (campaignWebService.rollEncounter(
-            guildId, discordId, encounterId, playerDiscordIds.orEmpty()
-        )) {
-            RollEncounterResult.ROLLED -> {}
-            RollEncounterResult.ENCOUNTER_NOT_FOUND -> ra.addFlashAttribute(
-                "error", "That encounter doesn't exist."
-            )
-            RollEncounterResult.NOT_OWNER -> ra.addFlashAttribute(
-                "error", "You can only roll your own encounters."
-            )
-            RollEncounterResult.NO_ACTIVE_CAMPAIGN -> ra.addFlashAttribute(
-                "error", "No active campaign in this server."
-            )
-            RollEncounterResult.NOT_DM -> ra.addFlashAttribute(
-                "error", "Only the Dungeon Master can roll an encounter."
-            )
-            RollEncounterResult.EMPTY_ROSTER -> ra.addFlashAttribute(
-                "error", "This encounter has no monsters yet."
-            )
-            RollEncounterResult.TEMPLATE_NOT_FOUND -> ra.addFlashAttribute(
-                "error", "One of the encounter's monster templates couldn't be found."
-            )
+    ): String = withCampaignAuth(user, guildId, ra) { discordId ->
+        when (campaignWebService.rollEncounter(guildId, discordId, encounterId, playerDiscordIds.orEmpty())) {
+            RollEncounterResult.ROLLED -> null
+            RollEncounterResult.ENCOUNTER_NOT_FOUND -> "That encounter doesn't exist."
+            RollEncounterResult.NOT_OWNER -> "You can only roll your own encounters."
+            RollEncounterResult.NO_ACTIVE_CAMPAIGN -> "No active campaign in this server."
+            RollEncounterResult.NOT_DM -> "Only the Dungeon Master can roll an encounter."
+            RollEncounterResult.EMPTY_ROSTER -> "This encounter has no monsters yet."
+            RollEncounterResult.TEMPLATE_NOT_FOUND -> "One of the encounter's monster templates couldn't be found."
         }
-        return "redirect:/dnd/campaign/$guildId"
     }
 
     @PostMapping("/campaign/{guildId}/combat/monster-attack")
@@ -722,38 +559,22 @@ class CampaignController(
         @RequestParam("targetName") targetName: String,
         @AuthenticationPrincipal user: OAuth2User,
         ra: RedirectAttributes
-    ): String {
-        val discordId = user.discordIdOrNull()
-            ?: return "redirect:/dnd/campaign"
-
+    ): String = withCampaignAuth(user, guildId, ra) { discordId ->
         val outcome = campaignWebService.monsterAttack(guildId, discordId, attackId, targetName.trim())
         when (outcome.result) {
-            MonsterAttackResult.HIT, MonsterAttackResult.MISS -> {}
-            MonsterAttackResult.NO_ACTIVE_CAMPAIGN -> ra.addFlashAttribute("error", "No active campaign in this server.")
-            MonsterAttackResult.NO_ACTIVE_COMBAT -> ra.addFlashAttribute("error", "Combat isn't active.")
-            MonsterAttackResult.NOT_DM -> ra.addFlashAttribute("error", "Only the Dungeon Master can drive monster attacks.")
-            MonsterAttackResult.CURRENT_NOT_MONSTER -> ra.addFlashAttribute(
-                "error",
-                "It's not a monster's turn right now."
-            )
-            MonsterAttackResult.NO_TEMPLATE -> ra.addFlashAttribute(
-                "error",
-                "This monster has no template — add it to your library first."
-            )
-            MonsterAttackResult.ATTACK_NOT_FOUND -> ra.addFlashAttribute("error", "That attack doesn't exist.")
-            MonsterAttackResult.ATTACK_TEMPLATE_MISMATCH -> ra.addFlashAttribute(
-                "error",
-                "That attack doesn't belong to the current monster."
-            )
-            MonsterAttackResult.INVALID_DAMAGE -> ra.addFlashAttribute(
-                "error",
-                "This attack's damage expression is invalid — please re-save it."
-            )
-            MonsterAttackResult.TARGET_NOT_FOUND -> ra.addFlashAttribute("error", "Target not found in initiative.")
-            MonsterAttackResult.TARGET_DEFEATED -> ra.addFlashAttribute("error", "That target is already defeated.")
-            MonsterAttackResult.CANT_TARGET_SELF -> ra.addFlashAttribute("error", "A monster can't attack itself.")
+            MonsterAttackResult.HIT, MonsterAttackResult.MISS -> null
+            MonsterAttackResult.NO_ACTIVE_CAMPAIGN -> "No active campaign in this server."
+            MonsterAttackResult.NO_ACTIVE_COMBAT -> "Combat isn't active."
+            MonsterAttackResult.NOT_DM -> "Only the Dungeon Master can drive monster attacks."
+            MonsterAttackResult.CURRENT_NOT_MONSTER -> "It's not a monster's turn right now."
+            MonsterAttackResult.NO_TEMPLATE -> "This monster has no template — add it to your library first."
+            MonsterAttackResult.ATTACK_NOT_FOUND -> "That attack doesn't exist."
+            MonsterAttackResult.ATTACK_TEMPLATE_MISMATCH -> "That attack doesn't belong to the current monster."
+            MonsterAttackResult.INVALID_DAMAGE -> "This attack's damage expression is invalid — please re-save it."
+            MonsterAttackResult.TARGET_NOT_FOUND -> "Target not found in initiative."
+            MonsterAttackResult.TARGET_DEFEATED -> "That target is already defeated."
+            MonsterAttackResult.CANT_TARGET_SELF -> "A monster can't attack itself."
         }
-        return "redirect:/dnd/campaign/$guildId"
     }
 
     @PostMapping("/campaign/{guildId}/initiative/roll")
@@ -768,10 +589,7 @@ class CampaignController(
         @RequestParam(name = "adhocAc", required = false) adhocAcs: List<String>?,
         @AuthenticationPrincipal user: OAuth2User,
         ra: RedirectAttributes
-    ): String {
-        val discordId = user.discordIdOrNull()
-            ?: return "redirect:/dnd/campaign"
-
+    ): String = withCampaignAuth(user, guildId, ra) { discordId ->
         // The ad-hoc monster rows have optional HP/AC inputs with no default,
         // so empty strings reach us for un-filled rows. Bind as List<String>
         // and parse leniently so empties become null/0 rather than 400/500.
@@ -803,19 +621,12 @@ class CampaignController(
         )
 
         when (campaignWebService.rollInitiative(guildId, discordId, request)) {
-            RollInitiativeResult.ROLLED -> {}
-            RollInitiativeResult.NO_ACTIVE_CAMPAIGN -> ra.addFlashAttribute("error", "No active campaign in this server.")
-            RollInitiativeResult.NOT_DM -> ra.addFlashAttribute("error", "Only the Dungeon Master can roll initiative here.")
-            RollInitiativeResult.EMPTY_ROSTER -> ra.addFlashAttribute(
-                "error",
-                "Pick at least one player or monster before rolling."
-            )
-            RollInitiativeResult.TEMPLATE_NOT_FOUND -> ra.addFlashAttribute(
-                "error",
-                "One of the selected monster templates couldn't be found."
-            )
+            RollInitiativeResult.ROLLED -> null
+            RollInitiativeResult.NO_ACTIVE_CAMPAIGN -> "No active campaign in this server."
+            RollInitiativeResult.NOT_DM -> "Only the Dungeon Master can roll initiative here."
+            RollInitiativeResult.EMPTY_ROSTER -> "Pick at least one player or monster before rolling."
+            RollInitiativeResult.TEMPLATE_NOT_FOUND -> "One of the selected monster templates couldn't be found."
         }
-        return "redirect:/dnd/campaign/$guildId"
     }
 
     @PostMapping("/campaign/{guildId}/roll")
@@ -827,35 +638,17 @@ class CampaignController(
         @RequestParam(name = "expression", required = false) expression: String?,
         @AuthenticationPrincipal user: OAuth2User,
         ra: RedirectAttributes
-    ): String {
-        val discordId = user.discordIdOrNull()
-            ?: return "redirect:/dnd/campaign"
-
+    ): String = withCampaignAuth(user, guildId, ra) { discordId ->
         when (campaignWebService.rollDice(guildId, discordId, count, sides, modifier, expression?.trim())) {
-            RollDiceResult.ROLLED -> {}
-            RollDiceResult.NO_ACTIVE_CAMPAIGN -> ra.addFlashAttribute("error", "No active campaign in this server.")
-            RollDiceResult.NOT_PARTICIPANT -> ra.addFlashAttribute(
-                "error",
-                "Only campaign participants can roll here."
-            )
-            RollDiceResult.INVALID_SIDES -> ra.addFlashAttribute(
-                "error",
-                "Die must be one of d4, d6, d8, d10, d12, d20, or d100."
-            )
-            RollDiceResult.INVALID_COUNT -> ra.addFlashAttribute(
-                "error",
-                "Dice count must be between 1 and ${CampaignWebService.MAX_DICE_COUNT}."
-            )
-            RollDiceResult.INVALID_MODIFIER -> ra.addFlashAttribute(
-                "error",
+            RollDiceResult.ROLLED -> null
+            RollDiceResult.NO_ACTIVE_CAMPAIGN -> "No active campaign in this server."
+            RollDiceResult.NOT_PARTICIPANT -> "Only campaign participants can roll here."
+            RollDiceResult.INVALID_SIDES -> "Die must be one of d4, d6, d8, d10, d12, d20, or d100."
+            RollDiceResult.INVALID_COUNT -> "Dice count must be between 1 and ${CampaignWebService.MAX_DICE_COUNT}."
+            RollDiceResult.INVALID_MODIFIER ->
                 "Modifier must be between -${CampaignWebService.MAX_DICE_MODIFIER} and ${CampaignWebService.MAX_DICE_MODIFIER}."
-            )
-            RollDiceResult.INVALID_EXPRESSION -> ra.addFlashAttribute(
-                "error",
-                "Custom expression must look like '2d6+3' or 'd20-1'."
-            )
+            RollDiceResult.INVALID_EXPRESSION -> "Custom expression must look like '2d6+3' or 'd20-1'."
         }
-        return "redirect:/dnd/campaign/$guildId"
     }
 
     @PostMapping("/campaign/{guildId}/combat/attack")
@@ -865,28 +658,19 @@ class CampaignController(
         @RequestParam(name = "attackModifier", defaultValue = "0") attackModifier: Int,
         @AuthenticationPrincipal user: OAuth2User,
         ra: RedirectAttributes
-    ): String {
-        val discordId = user.discordIdOrNull()
-            ?: return "redirect:/dnd/campaign"
-
+    ): String = withCampaignAuth(user, guildId, ra) { discordId ->
         val outcome = campaignWebService.attack(guildId, discordId, targetName.trim(), attackModifier)
         when (outcome.result) {
-            AttackResult.HIT, AttackResult.MISS -> {}
-            AttackResult.NO_ACTIVE_CAMPAIGN -> ra.addFlashAttribute("error", "No active campaign in this server.")
-            AttackResult.NO_ACTIVE_COMBAT -> ra.addFlashAttribute("error", "No active combat — roll initiative first.")
-            AttackResult.NOT_MY_TURN -> ra.addFlashAttribute(
-                "error",
-                "You can only attack on your own turn (or as the DM)."
-            )
-            AttackResult.TARGET_NOT_FOUND -> ra.addFlashAttribute("error", "That target isn't in the initiative order.")
-            AttackResult.TARGET_DEFEATED -> ra.addFlashAttribute("error", "That target is already defeated.")
-            AttackResult.CANT_TARGET_SELF -> ra.addFlashAttribute("error", "You can't attack yourself.")
-            AttackResult.INVALID_MODIFIER -> ra.addFlashAttribute(
-                "error",
+            AttackResult.HIT, AttackResult.MISS -> null
+            AttackResult.NO_ACTIVE_CAMPAIGN -> "No active campaign in this server."
+            AttackResult.NO_ACTIVE_COMBAT -> "No active combat — roll initiative first."
+            AttackResult.NOT_MY_TURN -> "You can only attack on your own turn (or as the DM)."
+            AttackResult.TARGET_NOT_FOUND -> "That target isn't in the initiative order."
+            AttackResult.TARGET_DEFEATED -> "That target is already defeated."
+            AttackResult.CANT_TARGET_SELF -> "You can't attack yourself."
+            AttackResult.INVALID_MODIFIER ->
                 "Attack modifier must be between -${CampaignWebService.MAX_ATTACK_MODIFIER} and ${CampaignWebService.MAX_ATTACK_MODIFIER}."
-            )
         }
-        return "redirect:/dnd/campaign/$guildId"
     }
 
     @PostMapping("/campaign/{guildId}/combat/damage")
@@ -896,25 +680,16 @@ class CampaignController(
         @RequestParam("amount") amount: String,
         @AuthenticationPrincipal user: OAuth2User,
         ra: RedirectAttributes
-    ): String {
-        val discordId = user.discordIdOrNull()
-            ?: return "redirect:/dnd/campaign"
-
+    ): String = withCampaignAuth(user, guildId, ra) { discordId ->
         when (campaignWebService.applyDamage(guildId, discordId, targetName.trim(), amount)) {
-            ApplyDamageResult.APPLIED, ApplyDamageResult.DEFEATED -> {}
-            ApplyDamageResult.NO_ACTIVE_CAMPAIGN -> ra.addFlashAttribute("error", "No active campaign in this server.")
-            ApplyDamageResult.NO_ACTIVE_COMBAT -> ra.addFlashAttribute("error", "No active combat — roll initiative first.")
-            ApplyDamageResult.NOT_ATTACKER -> ra.addFlashAttribute(
-                "error",
-                "You can only apply damage on your own turn (or as the DM)."
-            )
-            ApplyDamageResult.TARGET_NOT_FOUND -> ra.addFlashAttribute("error", "That target isn't in the initiative order.")
-            ApplyDamageResult.INVALID_AMOUNT -> ra.addFlashAttribute(
-                "error",
+            ApplyDamageResult.APPLIED, ApplyDamageResult.DEFEATED -> null
+            ApplyDamageResult.NO_ACTIVE_CAMPAIGN -> "No active campaign in this server."
+            ApplyDamageResult.NO_ACTIVE_COMBAT -> "No active combat — roll initiative first."
+            ApplyDamageResult.NOT_ATTACKER -> "You can only apply damage on your own turn (or as the DM)."
+            ApplyDamageResult.TARGET_NOT_FOUND -> "That target isn't in the initiative order."
+            ApplyDamageResult.INVALID_AMOUNT ->
                 "Damage must be a number (0-${CampaignWebService.MAX_DAMAGE_AMOUNT}) or a dice expression like 2d6+3."
-            )
         }
-        return "redirect:/dnd/campaign/$guildId"
     }
 
     @PostMapping("/campaign/{guildId}/combat/heal")
@@ -924,28 +699,39 @@ class CampaignController(
         @RequestParam("amount") amount: String,
         @AuthenticationPrincipal user: OAuth2User,
         ra: RedirectAttributes
-    ): String {
-        val discordId = user.discordIdOrNull()
-            ?: return "redirect:/dnd/campaign"
-
+    ): String = withCampaignAuth(user, guildId, ra) { discordId ->
         when (campaignWebService.applyHeal(guildId, discordId, targetName.trim(), amount)) {
-            ApplyHealResult.APPLIED, ApplyHealResult.REVIVED -> {}
-            ApplyHealResult.NO_ACTIVE_CAMPAIGN -> ra.addFlashAttribute("error", "No active campaign in this server.")
-            ApplyHealResult.NO_ACTIVE_COMBAT -> ra.addFlashAttribute("error", "No active combat — roll initiative first.")
-            ApplyHealResult.NOT_ATTACKER -> ra.addFlashAttribute(
-                "error",
-                "You can only heal on your own turn (or as the DM)."
-            )
-            ApplyHealResult.TARGET_NOT_FOUND -> ra.addFlashAttribute("error", "That target isn't in the initiative order.")
-            ApplyHealResult.TARGET_HAS_NO_HP -> ra.addFlashAttribute(
-                "error",
-                "That target has no HP tracked — can't heal them."
-            )
-            ApplyHealResult.INVALID_AMOUNT -> ra.addFlashAttribute(
-                "error",
+            ApplyHealResult.APPLIED, ApplyHealResult.REVIVED -> null
+            ApplyHealResult.NO_ACTIVE_CAMPAIGN -> "No active campaign in this server."
+            ApplyHealResult.NO_ACTIVE_COMBAT -> "No active combat — roll initiative first."
+            ApplyHealResult.NOT_ATTACKER -> "You can only heal on your own turn (or as the DM)."
+            ApplyHealResult.TARGET_NOT_FOUND -> "That target isn't in the initiative order."
+            ApplyHealResult.TARGET_HAS_NO_HP -> "That target has no HP tracked — can't heal them."
+            ApplyHealResult.INVALID_AMOUNT ->
                 "Heal must be a number (0-${CampaignWebService.MAX_DAMAGE_AMOUNT}) or a dice expression like 1d8+2."
-            )
         }
-        return "redirect:/dnd/campaign/$guildId"
+    }
+
+    /**
+     * The campaign mutation endpoints all share the same shape:
+     *
+     *   1. Reject anonymous callers back to the campaign list.
+     *   2. Run the service operation.
+     *   3. Translate the result into either success (no flash) or a flash
+     *      `error` message.
+     *   4. Redirect back to the campaign detail page.
+     *
+     * Wrapping that in one place means each endpoint is just the
+     * service call and the result→message map; the auth + flash + redirect
+     * scaffolding stops being duplicated 20+ times.
+     */
+    private inline fun withCampaignAuth(
+        user: OAuth2User,
+        guildId: Long,
+        ra: RedirectAttributes,
+        block: (discordId: Long) -> String?,
+    ): String = WebGuildAccess.requireSignedInForPage(user, "/dnd/campaign") { discordId ->
+        block(discordId)?.let { ra.addFlashAttribute("error", it) }
+        "redirect:/dnd/campaign/$guildId"
     }
 }

--- a/web/src/main/kotlin/web/controller/IntroWebController.kt
+++ b/web/src/main/kotlin/web/controller/IntroWebController.kt
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.*
 import org.springframework.web.multipart.MultipartFile
 import org.springframework.web.servlet.mvc.support.RedirectAttributes
 import web.service.IntroWebService
+import web.util.WebGuildAccess
 import web.util.discordIdOrNull
 import web.util.discordIdString
 import web.util.displayName
@@ -62,13 +63,10 @@ class IntroWebController(
         @AuthenticationPrincipal user: OAuth2User,
         model: Model,
         ra: RedirectAttributes
-    ): String {
-        val authDiscordId = user.discordIdOrNull()
-            ?: return "redirect:/intro/guilds"
-
+    ): String = WebGuildAccess.requireSignedInForPage(user, "/intro/guilds") { authDiscordId ->
         val guildName = introWebService.getGuildName(guildId) ?: run {
             ra.addFlashAttribute("error", "Bot is not in that server.")
-            return "redirect:/intro/guilds"
+            return@requireSignedInForPage "redirect:/intro/guilds"
         }
 
         val isSuperUser = introWebService.isSuperUser(authDiscordId, guildId)
@@ -90,7 +88,7 @@ class IntroWebController(
         model.addAttribute("targetDiscordId", if (isSuperUser) targetDiscordId else null)
         model.addAttribute("effectiveDiscordId", effectiveDiscordId)
 
-        return "intros"
+        "intros"
     }
 
     @PostMapping("/{guildId}/set")
@@ -106,9 +104,7 @@ class IntroWebController(
         @RequestParam(required = false) startMs: Int?,
         @RequestParam(required = false) endMs: Int?,
         ra: RedirectAttributes
-    ): String {
-        val authDiscordId = user.discordIdOrNull()
-            ?: return "redirect:/intro/guilds"
+    ): String = WebGuildAccess.requireSignedInForPage(user, "/intro/guilds") { authDiscordId ->
         val effectiveDiscordId = resolveEffectiveDiscordId(authDiscordId, guildId, targetDiscordId)
 
         val clampedVolume = volume.coerceIn(1, 100)
@@ -132,7 +128,7 @@ class IntroWebController(
             ra.addFlashAttribute("success", "Intro saved successfully.")
         }
 
-        return redirectToIntroPage(guildId, authDiscordId, targetDiscordId)
+        redirectToIntroPage(guildId, authDiscordId, targetDiscordId)
     }
 
     @PostMapping("/{guildId}/delete/{introId:.+}")
@@ -143,9 +139,7 @@ class IntroWebController(
         @RequestParam(required = false) targetDiscordId: Long?,
         session: HttpSession,
         ra: RedirectAttributes
-    ): String {
-        val authDiscordId = user.discordIdOrNull()
-            ?: return "redirect:/intro/guilds"
+    ): String = WebGuildAccess.requireSignedInForPage(user, "/intro/guilds") { authDiscordId ->
         val effectiveDiscordId = resolveEffectiveDiscordId(authDiscordId, guildId, targetDiscordId)
 
         // Snapshot the DTO before deletion so undo can restore it.
@@ -173,7 +167,7 @@ class IntroWebController(
             ra.addFlashAttribute("undoDelete", true)
         }
 
-        return redirectToIntroPage(guildId, authDiscordId, targetDiscordId)
+        redirectToIntroPage(guildId, authDiscordId, targetDiscordId)
     }
 
     @PostMapping("/{guildId}/undo-delete")
@@ -183,9 +177,7 @@ class IntroWebController(
         @RequestParam(required = false) targetDiscordId: Long?,
         session: HttpSession,
         ra: RedirectAttributes
-    ): String {
-        val authDiscordId = user.discordIdOrNull()
-            ?: return "redirect:/intro/guilds"
+    ): String = WebGuildAccess.requireSignedInForPage(user, "/intro/guilds") { authDiscordId ->
         val effectiveDiscordId = resolveEffectiveDiscordId(authDiscordId, guildId, targetDiscordId)
 
         val key = undoKey(guildId, effectiveDiscordId)
@@ -194,19 +186,19 @@ class IntroWebController(
 
         if (snapshot == null) {
             ra.addFlashAttribute("error", "Nothing to undo.")
-            return redirectToIntroPage(guildId, authDiscordId, targetDiscordId)
+            return@requireSignedInForPage redirectToIntroPage(guildId, authDiscordId, targetDiscordId)
         }
 
         // 10 minute undo window
         if (System.currentTimeMillis() - snapshot.timestampMs > 10 * 60 * 1000) {
             ra.addFlashAttribute("error", "Undo window has expired.")
-            return redirectToIntroPage(guildId, authDiscordId, targetDiscordId)
+            return@requireSignedInForPage redirectToIntroPage(guildId, authDiscordId, targetDiscordId)
         }
 
         val dbUser = introWebService.getOrCreateUser(effectiveDiscordId, guildId)
         if (dbUser.musicDtos.size >= IntroWebService.MAX_INTRO_COUNT) {
             ra.addFlashAttribute("error", "Cannot restore — intro limit already reached.")
-            return redirectToIntroPage(guildId, authDiscordId, targetDiscordId)
+            return@requireSignedInForPage redirectToIntroPage(guildId, authDiscordId, targetDiscordId)
         }
 
         val targetIndex = if (dbUser.musicDtos.none { it.index == snapshot.index }) {
@@ -226,7 +218,7 @@ class IntroWebController(
         musicFileService.createNewMusicFile(restored)
 
         ra.addFlashAttribute("success", "Intro restored.")
-        return redirectToIntroPage(guildId, authDiscordId, targetDiscordId)
+        redirectToIntroPage(guildId, authDiscordId, targetDiscordId)
     }
 
     @PostMapping("/{guildId}/update-volume", consumes = ["application/json"])
@@ -236,12 +228,12 @@ class IntroWebController(
         @RequestBody body: UpdateVolumeRequest,
         @AuthenticationPrincipal user: OAuth2User,
         @RequestParam(required = false) targetDiscordId: Long?
-    ): ResponseEntity<ApiResult> {
-        val authDiscordId = user.discordIdOrNull()
-            ?: return ResponseEntity.status(401).body(ApiResult(false, "Not signed in."))
+    ): ResponseEntity<ApiResult> = WebGuildAccess.requireSignedInForJson(
+        user, notSignedInApi
+    ) { authDiscordId ->
         val effective = resolveEffectiveDiscordId(authDiscordId, guildId, targetDiscordId)
         val error = introWebService.updateIntroVolume(effective, guildId, body.introId, body.volume)
-        return if (error != null) ResponseEntity.badRequest().body(ApiResult(false, error))
+        if (error != null) ResponseEntity.badRequest().body(ApiResult(false, error))
         else ResponseEntity.ok(ApiResult(true, null))
     }
 
@@ -252,12 +244,12 @@ class IntroWebController(
         @RequestBody body: UpdateTimestampsRequest,
         @AuthenticationPrincipal user: OAuth2User,
         @RequestParam(required = false) targetDiscordId: Long?
-    ): ResponseEntity<ApiResult> {
-        val authDiscordId = user.discordIdOrNull()
-            ?: return ResponseEntity.status(401).body(ApiResult(false, "Not signed in."))
+    ): ResponseEntity<ApiResult> = WebGuildAccess.requireSignedInForJson(
+        user, notSignedInApi
+    ) { authDiscordId ->
         val effective = resolveEffectiveDiscordId(authDiscordId, guildId, targetDiscordId)
         val error = introWebService.updateIntroTimestamps(effective, guildId, body.introId, body.startMs, body.endMs)
-        return if (error != null) ResponseEntity.badRequest().body(ApiResult(false, error))
+        if (error != null) ResponseEntity.badRequest().body(ApiResult(false, error))
         else ResponseEntity.ok(ApiResult(true, null))
     }
 
@@ -268,12 +260,12 @@ class IntroWebController(
         @RequestBody body: UpdateNameRequest,
         @AuthenticationPrincipal user: OAuth2User,
         @RequestParam(required = false) targetDiscordId: Long?
-    ): ResponseEntity<ApiResult> {
-        val authDiscordId = user.discordIdOrNull()
-            ?: return ResponseEntity.status(401).body(ApiResult(false, "Not signed in."))
+    ): ResponseEntity<ApiResult> = WebGuildAccess.requireSignedInForJson(
+        user, notSignedInApi
+    ) { authDiscordId ->
         val effective = resolveEffectiveDiscordId(authDiscordId, guildId, targetDiscordId)
         val error = introWebService.updateIntroName(effective, guildId, body.introId, body.name)
-        return if (error != null) ResponseEntity.badRequest().body(ApiResult(false, error))
+        if (error != null) ResponseEntity.badRequest().body(ApiResult(false, error))
         else ResponseEntity.ok(ApiResult(true, null))
     }
 
@@ -284,14 +276,16 @@ class IntroWebController(
         @RequestBody body: ReorderRequest,
         @AuthenticationPrincipal user: OAuth2User,
         @RequestParam(required = false) targetDiscordId: Long?
-    ): ResponseEntity<ApiResult> {
-        val authDiscordId = user.discordIdOrNull()
-            ?: return ResponseEntity.status(401).body(ApiResult(false, "Not signed in."))
+    ): ResponseEntity<ApiResult> = WebGuildAccess.requireSignedInForJson(
+        user, notSignedInApi
+    ) { authDiscordId ->
         val effective = resolveEffectiveDiscordId(authDiscordId, guildId, targetDiscordId)
         val error = introWebService.reorderIntros(effective, guildId, body.orderedIds)
-        return if (error != null) ResponseEntity.badRequest().body(ApiResult(false, error))
+        if (error != null) ResponseEntity.badRequest().body(ApiResult(false, error))
         else ResponseEntity.ok(ApiResult(true, null))
     }
+
+    private val notSignedInApi: () -> ApiResult = { ApiResult(false, "Not signed in.") }
 
     @GetMapping("/preview")
     @ResponseBody

--- a/web/src/main/kotlin/web/controller/ModerationController.kt
+++ b/web/src/main/kotlin/web/controller/ModerationController.kt
@@ -81,9 +81,11 @@ class ModerationController(
         @PathVariable targetDiscordId: Long,
         @RequestBody body: PermissionRequest,
         @AuthenticationPrincipal user: OAuth2User
-    ): ResponseEntity<ApiResult> = withSignedInActor(user, ::ApiResult) { actor ->
+    ): ResponseEntity<ApiResult> = WebGuildAccess.requireSignedInForJson(
+        user, notSignedInApi
+    ) { actor ->
         val perm = runCatching { UserDto.Permissions.valueOf(body.permission.uppercase()) }.getOrNull()
-            ?: return@withSignedInActor ResponseEntity.badRequest().body(ApiResult(false, "Unknown permission."))
+            ?: return@requireSignedInForJson ResponseEntity.badRequest().body(ApiResult(false, "Unknown permission."))
         val error = moderationWebService.togglePermission(actor, guildId, targetDiscordId, perm)
         if (error != null) ResponseEntity.badRequest().body(ApiResult(false, error))
         else ResponseEntity.ok(ApiResult(true, null))
@@ -96,7 +98,9 @@ class ModerationController(
         @PathVariable targetDiscordId: Long,
         @RequestBody body: SocialCreditRequest,
         @AuthenticationPrincipal user: OAuth2User
-    ): ResponseEntity<ApiResult> = withSignedInActor(user, ::ApiResult) { actor ->
+    ): ResponseEntity<ApiResult> = WebGuildAccess.requireSignedInForJson(
+        user, notSignedInApi
+    ) { actor ->
         val error = moderationWebService.adjustSocialCredit(actor, guildId, targetDiscordId, body.delta)
         if (error != null) ResponseEntity.badRequest().body(ApiResult(false, error))
         else ResponseEntity.ok(ApiResult(true, null))
@@ -108,9 +112,11 @@ class ModerationController(
         @PathVariable guildId: Long,
         @RequestBody body: ConfigRequest,
         @AuthenticationPrincipal user: OAuth2User
-    ): ResponseEntity<ApiResult> = withSignedInActor(user, ::ApiResult) { actor ->
+    ): ResponseEntity<ApiResult> = WebGuildAccess.requireSignedInForJson(
+        user, notSignedInApi
+    ) { actor ->
         val key = runCatching { ConfigDto.Configurations.valueOf(body.key.uppercase()) }.getOrNull()
-            ?: return@withSignedInActor ResponseEntity.badRequest().body(ApiResult(false, "Unknown config key."))
+            ?: return@requireSignedInForJson ResponseEntity.badRequest().body(ApiResult(false, "Unknown config key."))
         val error = moderationWebService.updateConfig(actor, guildId, key, body.value)
         if (error != null) ResponseEntity.badRequest().body(ApiResult(false, error))
         else ResponseEntity.ok(ApiResult(true, null))
@@ -122,7 +128,9 @@ class ModerationController(
         @PathVariable guildId: Long,
         @RequestBody body: KickRequest,
         @AuthenticationPrincipal user: OAuth2User
-    ): ResponseEntity<ApiResult> = withSignedInActor(user, ::ApiResult) { actor ->
+    ): ResponseEntity<ApiResult> = WebGuildAccess.requireSignedInForJson(
+        user, notSignedInApi
+    ) { actor ->
         val error = moderationWebService.kickMember(actor, guildId, body.targetDiscordId, body.reason)
         if (error != null) ResponseEntity.badRequest().body(ApiResult(false, error))
         else ResponseEntity.ok(ApiResult(true, null))
@@ -134,8 +142,8 @@ class ModerationController(
         @PathVariable guildId: Long,
         @RequestBody body: MoveRequest,
         @AuthenticationPrincipal user: OAuth2User
-    ): ResponseEntity<MoveResponse> = withSignedInActor(
-        user, { ok, err -> MoveResponse(ok, err) }
+    ): ResponseEntity<MoveResponse> = WebGuildAccess.requireSignedInForJson(
+        user, { MoveResponse(false, "Not signed in.") }
     ) { actor ->
         val result = moderationWebService.moveMembers(actor, guildId, body.targetChannelId, body.memberIds)
         if (result.error != null) {
@@ -152,8 +160,8 @@ class ModerationController(
         @PathVariable channelId: Long,
         @RequestBody body: MuteRequest,
         @AuthenticationPrincipal user: OAuth2User
-    ): ResponseEntity<MuteResponse> = withSignedInActor(
-        user, { ok, err -> MuteResponse(ok, err) }
+    ): ResponseEntity<MuteResponse> = WebGuildAccess.requireSignedInForJson(
+        user, { MuteResponse(false, "Not signed in.") }
     ) { actor ->
         val result = moderationWebService.muteVoiceChannel(actor, guildId, channelId, body.mute)
         if (result.error != null) {
@@ -169,28 +177,15 @@ class ModerationController(
         @PathVariable guildId: Long,
         @RequestBody body: PollRequest,
         @AuthenticationPrincipal user: OAuth2User
-    ): ResponseEntity<ApiResult> = withSignedInActor(user, ::ApiResult) { actor ->
+    ): ResponseEntity<ApiResult> = WebGuildAccess.requireSignedInForJson(
+        user, notSignedInApi
+    ) { actor ->
         val error = moderationWebService.createPoll(actor, guildId, body.channelId, body.question, body.options)
         if (error != null) ResponseEntity.badRequest().body(ApiResult(false, error))
         else ResponseEntity.ok(ApiResult(true, null))
     }
 
-    /**
-     * Per-action JSON endpoints don't re-check membership — the service
-     * does its own permission audit on the actor — so all the controller
-     * needs is "401 if not signed in." This collapses 6 copies of the
-     * same `discordIdOrNull() ?: return ResponseEntity.status(401)…`
-     * into one place.
-     */
-    private inline fun <T : Any> withSignedInActor(
-        user: OAuth2User,
-        noinline notSignedInBuilder: (ok: Boolean, error: String) -> T,
-        block: (actor: Long) -> ResponseEntity<T>,
-    ): ResponseEntity<T> {
-        val actor = user.discordIdOrNull()
-            ?: return ResponseEntity.status(401).body(notSignedInBuilder(false, "Not signed in."))
-        return block(actor)
-    }
+    private val notSignedInApi: () -> ApiResult = { ApiResult(false, "Not signed in.") }
 }
 
 data class PermissionRequest(val permission: String = "")

--- a/web/src/main/kotlin/web/service/EconomyWebService.kt
+++ b/web/src/main/kotlin/web/service/EconomyWebService.kt
@@ -6,6 +6,7 @@ import database.service.TobyCoinMarketService
 import database.service.UserService
 import net.dv8tion.jda.api.JDA
 import org.springframework.stereotype.Service
+import web.util.GuildMembership
 import java.time.Duration
 import java.time.Instant
 
@@ -15,13 +16,11 @@ class EconomyWebService(
     private val introWebService: IntroWebService,
     private val tradeService: EconomyTradeService,
     private val marketService: TobyCoinMarketService,
-    private val userService: UserService
+    private val userService: UserService,
+    private val membership: GuildMembership,
 ) {
 
-    fun isMember(discordId: Long, guildId: Long): Boolean {
-        val guild = jda.getGuildById(guildId) ?: return false
-        return guild.getMemberById(discordId) != null
-    }
+    fun isMember(discordId: Long, guildId: Long): Boolean = membership.isMember(discordId, guildId)
 
     fun getGuildMembers(guildId: Long): List<MemberInfo> {
         val guild = jda.getGuildById(guildId) ?: return emptyList()

--- a/web/src/main/kotlin/web/service/LeaderboardWebService.kt
+++ b/web/src/main/kotlin/web/service/LeaderboardWebService.kt
@@ -6,6 +6,7 @@ import database.service.TobyCoinMarketService
 import database.service.UserService
 import net.dv8tion.jda.api.JDA
 import org.springframework.stereotype.Service
+import web.util.GuildMembership
 import java.time.LocalDate
 import java.time.ZoneOffset
 import kotlin.math.floor
@@ -18,7 +19,8 @@ class LeaderboardWebService(
     private val userService: UserService,
     private val marketService: TobyCoinMarketService,
     private val titleService: TitleService,
-    private val snapshotService: MonthlyCreditSnapshotService
+    private val snapshotService: MonthlyCreditSnapshotService,
+    private val membership: GuildMembership,
 ) {
 
     companion object {
@@ -52,10 +54,7 @@ class LeaderboardWebService(
         }.sortedBy { it.name.lowercase() }
     }
 
-    fun isMember(discordId: Long, guildId: Long): Boolean {
-        val guild = jda.getGuildById(guildId) ?: return false
-        return guild.getMemberById(discordId) != null
-    }
+    fun isMember(discordId: Long, guildId: Long): Boolean = membership.isMember(discordId, guildId)
 
     fun getGuildView(
         guildId: Long,

--- a/web/src/main/kotlin/web/service/ProfileWebService.kt
+++ b/web/src/main/kotlin/web/service/ProfileWebService.kt
@@ -5,13 +5,15 @@ import database.service.TitleService
 import database.service.UserService
 import net.dv8tion.jda.api.JDA
 import org.springframework.stereotype.Service
+import web.util.GuildMembership
 
 @Service
 class ProfileWebService(
     private val jda: JDA,
     private val userService: UserService,
     private val titleService: TitleService,
-    private val introWebService: IntroWebService
+    private val introWebService: IntroWebService,
+    private val membership: GuildMembership,
 ) {
 
     fun getMemberGuilds(accessToken: String, discordId: Long): List<ProfileGuildCard> {
@@ -29,10 +31,7 @@ class ProfileWebService(
         }.sortedBy { it.name.lowercase() }
     }
 
-    fun isMember(discordId: Long, guildId: Long): Boolean {
-        val guild = jda.getGuildById(guildId) ?: return false
-        return guild.getMemberById(discordId) != null
-    }
+    fun isMember(discordId: Long, guildId: Long): Boolean = membership.isMember(discordId, guildId)
 
     fun getProfile(discordId: Long, guildId: Long): ProfileView? {
         val guild = jda.getGuildById(guildId) ?: return null

--- a/web/src/main/kotlin/web/service/TitlesWebService.kt
+++ b/web/src/main/kotlin/web/service/TitlesWebService.kt
@@ -11,6 +11,7 @@ import database.economy.TobyCoinEngine
 import net.dv8tion.jda.api.JDA
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import web.util.GuildMembership
 
 @Service
 class TitlesWebService(
@@ -20,7 +21,8 @@ class TitlesWebService(
     private val titleRoleService: TitleRoleService,
     private val introWebService: IntroWebService,
     private val marketService: TobyCoinMarketService,
-    private val tradeService: EconomyTradeService
+    private val tradeService: EconomyTradeService,
+    private val membership: GuildMembership,
 ) {
     companion object {
         private val logger = DiscordLogger(TitlesWebService::class.java)
@@ -49,10 +51,7 @@ class TitlesWebService(
         }.sortedBy { it.name.lowercase() }
     }
 
-    fun isMember(discordId: Long, guildId: Long): Boolean {
-        val guild = jda.getGuildById(guildId) ?: return false
-        return guild.getMemberById(discordId) != null
-    }
+    fun isMember(discordId: Long, guildId: Long): Boolean = membership.isMember(discordId, guildId)
 
     fun getTitlesForGuild(guildId: Long, actorDiscordId: Long): TitleShopView {
         val catalog = safely("title catalog", emptyList()) {

--- a/web/src/main/kotlin/web/util/GuildMembership.kt
+++ b/web/src/main/kotlin/web/util/GuildMembership.kt
@@ -1,0 +1,26 @@
+package web.util
+
+import net.dv8tion.jda.api.JDA
+import org.springframework.stereotype.Component
+
+/**
+ * Single source of truth for "is this Discord user currently a member of
+ * this guild?". Previously each per-area web service
+ * (EconomyWebService, LeaderboardWebService, ProfileWebService,
+ * TitlesWebService) shipped its own copy of the same two-line
+ * `jda.getGuildById(g)?.getMemberById(d) != null` check; tweaking the
+ * membership rule (e.g. bot exclusion, caching, bans list) had to
+ * happen in four places.
+ *
+ * The per-service `isMember` methods now delegate here so external
+ * callers (controllers passing `service::isMember` to [WebGuildAccess])
+ * keep working, but the actual JDA call lives in one place.
+ */
+@Component
+class GuildMembership(private val jda: JDA) {
+
+    fun isMember(discordId: Long, guildId: Long): Boolean {
+        val guild = jda.getGuildById(guildId) ?: return false
+        return guild.getMemberById(discordId) != null
+    }
+}

--- a/web/src/main/kotlin/web/util/WebGuildAccess.kt
+++ b/web/src/main/kotlin/web/util/WebGuildAccess.kt
@@ -131,4 +131,43 @@ object WebGuildAccess {
         if (!economyWebService.isMember(discordId, guildId)) return ResponseEntity.status(403).build()
         return block(discordId)
     }
+
+    /**
+     * Auth-only wrapper for page handlers that don't need a guild
+     * membership check — e.g. CampaignController where membership is
+     * implicit in the campaign service, or IntroWebController where the
+     * superuser branch needs to bypass the standard member guard.
+     * Anonymous callers redirect to [lobbyPath]; signed-in callers
+     * invoke [block] with their resolved Discord id.
+     */
+    inline fun requireSignedInForPage(
+        user: OAuth2User?,
+        lobbyPath: String,
+        block: (discordId: Long) -> String,
+    ): String {
+        val discordId = user?.discordIdOrNull() ?: return "redirect:$lobbyPath"
+        return block(discordId)
+    }
+
+    /**
+     * Auth-only wrapper for JSON endpoints that don't need a guild
+     * membership check — the service does its own permission audit on
+     * the actor (e.g. ModerationController, IntroWebController).
+     * Collapses the repeated `discordIdOrNull() ?: return 401(...)`
+     * pattern into one call.
+     *
+     * Callers supply a [notSignedInBody] factory so the 401 body matches
+     * the endpoint's response shape. Returns 401 with that body when
+     * the principal isn't a real Discord user, otherwise invokes
+     * [block] with the resolved id.
+     */
+    inline fun <T : Any> requireSignedInForJson(
+        user: OAuth2User?,
+        notSignedInBody: () -> T,
+        block: (discordId: Long) -> ResponseEntity<T>,
+    ): ResponseEntity<T> {
+        val discordId = user?.discordIdOrNull()
+            ?: return ResponseEntity.status(401).body(notSignedInBody())
+        return block(discordId)
+    }
 }

--- a/web/src/main/resources/static/css/nav.css
+++ b/web/src/main/resources/static/css/nav.css
@@ -48,8 +48,16 @@ nav {
 }
 
 /* Dropdown menus (Economy, Casino, ...). Trigger looks like a regular nav
-   link; menu absolutely positioned below on desktop, inlined on mobile. */
-.nav-dropdown { position: relative; }
+   link; menu absolutely positioned below on desktop, inlined on mobile.
+   The dropdown's hoverable box extends 8px below the toggle (via
+   padding-bottom + a negative margin-bottom that hides the visual size
+   change) so the gap between toggle and menu items is part of the
+   dropdown itself — no risk of dropping :hover mid-traverse. */
+.nav-dropdown {
+    position: relative;
+    padding-bottom: 8px;
+    margin-bottom: -8px;
+}
 .nav-dropdown-toggle {
     background: transparent;
     border: none;
@@ -73,7 +81,7 @@ nav {
     position: absolute;
     top: 100%;
     left: 0;
-    margin-top: 8px;
+    margin-top: 0;
     background: #16213e;
     border: 1px solid #2a2a4a;
     border-radius: 6px;
@@ -85,16 +93,6 @@ nav {
 }
 .nav-dropdown:hover .nav-dropdown-menu,
 .nav-dropdown.open .nav-dropdown-menu { display: flex; }
-/* Transparent bridge across the 8px gap between toggle and menu so the
-   cursor can travel from button to menu items without dropping :hover. */
-.nav-dropdown-menu::before {
-    content: "";
-    position: absolute;
-    top: -8px;
-    left: 0;
-    right: 0;
-    height: 8px;
-}
 .nav-dropdown-menu a,
 .nav-dropdown-menu .nav-dropdown-coming-soon {
     padding: 8px 16px;
@@ -115,8 +113,10 @@ nav {
     .nav-links .btn-discord, .nav-links .btn-logout { align-self: flex-start; min-height: 40px; display: inline-flex; align-items: center; }
 
     /* On mobile, dropdown items render inline under the trigger so the
-       whole menu is one vertical scroll — no second tap required. */
-    .nav-dropdown { width: 100%; }
+       whole menu is one vertical scroll — no second tap required. The
+       desktop hover-bridge padding is also neutralised so it doesn't
+       push items apart. */
+    .nav-dropdown { width: 100%; padding-bottom: 0; margin-bottom: 0; }
     .nav-dropdown-toggle { padding: 10px 4px; min-height: 40px; width: 100%; justify-content: flex-start; }
     .nav-dropdown-menu {
         position: static;
@@ -128,8 +128,6 @@ nav {
         box-shadow: none;
         min-width: 0;
     }
-    /* No gap to bridge in the inline mobile layout. */
-    .nav-dropdown-menu::before { content: none; }
     .nav-dropdown-menu a, .nav-dropdown-menu .nav-dropdown-coming-soon {
         padding: 8px 4px;
         min-height: 36px;

--- a/web/src/main/resources/templates/casino-guilds.html
+++ b/web/src/main/resources/templates/casino-guilds.html
@@ -16,18 +16,7 @@
 
     <div class="lb-guild-grid" th:if="${not #lists.isEmpty(guilds)}">
         <div class="lb-guild-card lb-guild-card-static" th:each="g : ${guilds}">
-            <div class="lb-guild-card-header">
-                <img th:if="${g.iconUrl != null}"
-                     th:src="${g.iconUrl}"
-                     th:alt="${g.name} + ' icon'"
-                     class="lb-guild-icon"
-                     onerror="this.style.display='none'">
-                <div th:unless="${g.iconUrl != null}"
-                     class="lb-guild-icon-placeholder"
-                     aria-hidden="true"
-                     th:text="${#strings.substring(g.name, 0, 1).toUpperCase()}">G</div>
-                <div class="lb-guild-name" th:text="${g.name}" th:title="${g.name}">Guild</div>
-            </div>
+            <div th:replace="~{fragments/guildCard :: header(${g})}"></div>
             <div class="lb-guild-top">
                 <span class="muted">Your wallet:</span>
                 <span th:text="${g.credits} + ' credits'">0 credits</span>

--- a/web/src/main/resources/templates/duel-guilds.html
+++ b/web/src/main/resources/templates/duel-guilds.html
@@ -16,18 +16,7 @@
 
     <div class="lb-guild-grid" th:if="${not #lists.isEmpty(guilds)}">
         <div class="lb-guild-card lb-guild-card-static" th:each="g : ${guilds}">
-            <div class="lb-guild-card-header">
-                <img th:if="${g.iconUrl != null}"
-                     th:src="${g.iconUrl}"
-                     th:alt="${g.name} + ' icon'"
-                     class="lb-guild-icon"
-                     onerror="this.style.display='none'">
-                <div th:unless="${g.iconUrl != null}"
-                     class="lb-guild-icon-placeholder"
-                     aria-hidden="true"
-                     th:text="${#strings.substring(g.name, 0, 1).toUpperCase()}">G</div>
-                <div class="lb-guild-name" th:text="${g.name}" th:title="${g.name}">Guild</div>
-            </div>
+            <div th:replace="~{fragments/guildCard :: header(${g})}"></div>
             <div class="lb-guild-top">
                 <span class="muted">Your wallet:</span>
                 <span th:text="${g.credits} + ' credits'">0 credits</span>

--- a/web/src/main/resources/templates/economy-guilds.html
+++ b/web/src/main/resources/templates/economy-guilds.html
@@ -19,18 +19,7 @@
         <a class="lb-guild-card"
            th:each="g : ${guilds}"
            th:href="@{/economy/{id}(id=${g.id})}">
-            <div class="lb-guild-card-header">
-                <img th:if="${g.iconUrl != null}"
-                     th:src="${g.iconUrl}"
-                     th:alt="${g.name} + ' icon'"
-                     class="lb-guild-icon"
-                     onerror="this.style.display='none'">
-                <div th:unless="${g.iconUrl != null}"
-                     class="lb-guild-icon-placeholder"
-                     aria-hidden="true"
-                     th:text="${#strings.substring(g.name, 0, 1).toUpperCase()}">G</div>
-                <div class="lb-guild-name" th:text="${g.name}" th:title="${g.name}">Guild</div>
-            </div>
+            <div th:replace="~{fragments/guildCard :: header(${g})}"></div>
             <div class="lb-guild-top">
                 <span class="muted">Price:</span>
                 <span th:if="${g.price != null}"

--- a/web/src/main/resources/templates/fragments/guildCard.html
+++ b/web/src/main/resources/templates/fragments/guildCard.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<body>
+<!--
+    Shared header for the guild-card grid that fronts every per-area
+    landing page (casino-guilds, economy-guilds, leaderboards, …).
+    Renders the guild's Discord icon when available, otherwise a single-
+    letter placeholder, plus the guild name.
+
+    Usage:
+        <div class="lb-guild-card-header"
+             th:replace="~{fragments/guildCard :: header(${g})}"></div>
+
+    The 9 guild-list templates each used to inline ~10 lines of
+    img/onerror/placeholder/name HTML — centralising it means a tweak
+    (e.g. dropping onerror once Discord icons stop 404ing, swapping the
+    placeholder strategy) is one edit instead of nine.
+-->
+<div th:fragment="header(g)" class="lb-guild-card-header">
+    <img th:if="${g.iconUrl != null}"
+         th:src="${g.iconUrl}"
+         th:alt="${g.name} + ' icon'"
+         class="lb-guild-icon"
+         onerror="this.style.display='none'">
+    <div th:unless="${g.iconUrl != null}"
+         class="lb-guild-icon-placeholder"
+         aria-hidden="true"
+         th:text="${#strings.substring(g.name, 0, 1).toUpperCase()}">G</div>
+    <div class="lb-guild-name" th:text="${g.name}" th:title="${g.name}">Guild</div>
+</div>
+</body>
+</html>

--- a/web/src/main/resources/templates/leaderboards.html
+++ b/web/src/main/resources/templates/leaderboards.html
@@ -18,18 +18,7 @@
         <a class="lb-guild-card"
            th:each="g : ${guilds}"
            th:href="@{/leaderboard/{id}(id=${g.id})}">
-            <div class="lb-guild-card-header">
-                <img th:if="${g.iconUrl != null}"
-                     th:src="${g.iconUrl}"
-                     th:alt="${g.name} + ' icon'"
-                     class="lb-guild-icon"
-                     onerror="this.style.display='none'">
-                <div th:unless="${g.iconUrl != null}"
-                     class="lb-guild-icon-placeholder"
-                     aria-hidden="true"
-                     th:text="${#strings.substring(g.name, 0, 1).toUpperCase()}">G</div>
-                <div class="lb-guild-name" th:text="${g.name}" th:title="${g.name}">Guild</div>
-            </div>
+            <div th:replace="~{fragments/guildCard :: header(${g})}"></div>
             <div class="lb-guild-top" th:if="${g.topName != null}">
                 <span class="muted">Top this month:</span>
                 <span class="lb-top-name">

--- a/web/src/main/resources/templates/poker-guilds.html
+++ b/web/src/main/resources/templates/poker-guilds.html
@@ -17,18 +17,7 @@
 
     <div class="lb-guild-grid" th:if="${not #lists.isEmpty(guilds)}">
         <div class="lb-guild-card lb-guild-card-static" th:each="g : ${guilds}">
-            <div class="lb-guild-card-header">
-                <img th:if="${g.iconUrl != null}"
-                     th:src="${g.iconUrl}"
-                     th:alt="${g.name} + ' icon'"
-                     class="lb-guild-icon"
-                     onerror="this.style.display='none'">
-                <div th:unless="${g.iconUrl != null}"
-                     class="lb-guild-icon-placeholder"
-                     aria-hidden="true"
-                     th:text="${#strings.substring(g.name, 0, 1).toUpperCase()}">G</div>
-                <div class="lb-guild-name" th:text="${g.name}" th:title="${g.name}">Guild</div>
-            </div>
+            <div th:replace="~{fragments/guildCard :: header(${g})}"></div>
             <div class="lb-guild-top">
                 <span class="muted">Your wallet:</span>
                 <span th:text="${g.credits} + ' credits'">0 credits</span>

--- a/web/src/main/resources/templates/profile-guilds.html
+++ b/web/src/main/resources/templates/profile-guilds.html
@@ -17,18 +17,7 @@
         <a class="lb-guild-card"
            th:each="g : ${guilds}"
            th:href="@{/profile/{id}(id=${g.id})}">
-            <div class="lb-guild-card-header">
-                <img th:if="${g.iconUrl != null}"
-                     th:src="${g.iconUrl}"
-                     th:alt="${g.name} + ' icon'"
-                     class="lb-guild-icon"
-                     onerror="this.style.display='none'">
-                <div th:unless="${g.iconUrl != null}"
-                     class="lb-guild-icon-placeholder"
-                     aria-hidden="true"
-                     th:text="${#strings.substring(g.name, 0, 1).toUpperCase()}">G</div>
-                <div class="lb-guild-name" th:text="${g.name}" th:title="${g.name}">Guild</div>
-            </div>
+            <div th:replace="~{fragments/guildCard :: header(${g})}"></div>
             <div class="lb-guild-top">
                 <span class="muted">Balance:</span>
                 <span th:text="${g.balance} + ' credits'">0 credits</span>

--- a/web/src/main/resources/templates/tip-guilds.html
+++ b/web/src/main/resources/templates/tip-guilds.html
@@ -15,18 +15,7 @@
 
     <div class="lb-guild-grid" th:if="${not #lists.isEmpty(guilds)}">
         <div class="lb-guild-card lb-guild-card-static" th:each="g : ${guilds}">
-            <div class="lb-guild-card-header">
-                <img th:if="${g.iconUrl != null}"
-                     th:src="${g.iconUrl}"
-                     th:alt="${g.name} + ' icon'"
-                     class="lb-guild-icon"
-                     onerror="this.style.display='none'">
-                <div th:unless="${g.iconUrl != null}"
-                     class="lb-guild-icon-placeholder"
-                     aria-hidden="true"
-                     th:text="${#strings.substring(g.name, 0, 1).toUpperCase()}">G</div>
-                <div class="lb-guild-name" th:text="${g.name}" th:title="${g.name}">Guild</div>
-            </div>
+            <div th:replace="~{fragments/guildCard :: header(${g})}"></div>
             <div class="lb-guild-top">
                 <span class="muted">Your wallet:</span>
                 <span th:text="${g.credits} + ' credits'">0 credits</span>

--- a/web/src/main/resources/templates/titles-guilds.html
+++ b/web/src/main/resources/templates/titles-guilds.html
@@ -18,18 +18,7 @@
         <a class="lb-guild-card"
            th:each="g : ${guilds}"
            th:href="@{/titles/{id}(id=${g.id})}">
-            <div class="lb-guild-card-header">
-                <img th:if="${g.iconUrl != null}"
-                     th:src="${g.iconUrl}"
-                     th:alt="${g.name} + ' icon'"
-                     class="lb-guild-icon"
-                     onerror="this.style.display='none'">
-                <div th:unless="${g.iconUrl != null}"
-                     class="lb-guild-icon-placeholder"
-                     aria-hidden="true"
-                     th:text="${#strings.substring(g.name, 0, 1).toUpperCase()}">G</div>
-                <div class="lb-guild-name" th:text="${g.name}" th:title="${g.name}">Guild</div>
-            </div>
+            <div th:replace="~{fragments/guildCard :: header(${g})}"></div>
             <div class="lb-guild-top">
                 <span class="muted">Balance:</span>
                 <span th:text="${g.balance} + ' credits'">0 credits</span>

--- a/web/src/test/kotlin/web/service/EconomyWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/EconomyWebServiceTest.kt
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import web.util.GuildMembership
 import java.time.Instant
 
 class EconomyWebServiceTest {
@@ -41,7 +42,7 @@ class EconomyWebServiceTest {
         tradeService = mockk(relaxed = true)
         marketService = mockk(relaxed = true)
         userService = mockk(relaxed = true)
-        service = EconomyWebService(jda, introWebService, tradeService, marketService, userService)
+        service = EconomyWebService(jda, introWebService, tradeService, marketService, userService, GuildMembership(jda))
     }
 
     @Test

--- a/web/src/test/kotlin/web/service/LeaderboardWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/LeaderboardWebServiceTest.kt
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import web.util.GuildMembership
 
 class LeaderboardWebServiceTest {
 
@@ -33,7 +34,13 @@ class LeaderboardWebServiceTest {
         moderationWebService = mockk(relaxed = true)
         userService = mockk(relaxed = true)
         marketService = mockk(relaxed = true)
-        service = LeaderboardWebService(jda, introWebService, moderationWebService, userService, marketService, mockk(relaxed = true), mockk(relaxed = true))
+        // Real GuildMembership over the mocked JDA — keeps the existing
+        // `isMember` tests black-boxed against JDA, not against the helper.
+        service = LeaderboardWebService(
+            jda, introWebService, moderationWebService, userService, marketService,
+            mockk(relaxed = true), mockk(relaxed = true),
+            GuildMembership(jda)
+        )
     }
 
     @Test

--- a/web/src/test/kotlin/web/service/LeaderboardWebServiceTobyCoinTest.kt
+++ b/web/src/test/kotlin/web/service/LeaderboardWebServiceTobyCoinTest.kt
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import web.util.GuildMembership
 import java.time.Instant
 
 class LeaderboardWebServiceTobyCoinTest {
@@ -52,7 +53,8 @@ class LeaderboardWebServiceTobyCoinTest {
             userService = userService,
             marketService = marketService,
             titleService = titleService,
-            snapshotService = snapshotService
+            snapshotService = snapshotService,
+            membership = GuildMembership(jda),
         )
     }
 

--- a/web/src/test/kotlin/web/service/TitlesWebServicePurchaseTest.kt
+++ b/web/src/test/kotlin/web/service/TitlesWebServicePurchaseTest.kt
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Assertions.assertInstanceOf
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import web.util.GuildMembership
 import java.time.Instant
 
 /**
@@ -60,7 +61,8 @@ class TitlesWebServicePurchaseTest {
             titleRoleService = mockk(relaxed = true),
             introWebService = mockk(relaxed = true),
             marketService = marketService,
-            tradeService = tradeService
+            tradeService = tradeService,
+            membership = GuildMembership(jda),
         )
     }
 

--- a/web/src/test/kotlin/web/service/TitlesWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/TitlesWebServiceTest.kt
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import web.util.GuildMembership
 
 class TitlesWebServiceTest {
 
@@ -55,7 +56,8 @@ class TitlesWebServiceTest {
             titleRoleService,
             introWebService,
             marketService,
-            tradeService
+            tradeService,
+            GuildMembership(jda),
         )
 
         every { jda.getGuildById(guildId) } returns guild


### PR DESCRIPTION
## Summary

Second refactor pass — picks up the controllers PR #334 deferred plus
two patterns spotted in passing. Net: **24 files, +408 / -616 lines.**

### Backend

- **`GuildMembership` @Component** is the single home for the
  `jda.getGuildById(g)?.getMemberById(d) != null` check. The 4 web
  services (Economy / Leaderboard / Profile / Titles) each shipped
  their own copy; they now delegate to the shared component.
- **`WebGuildAccess` gains `requireSignedInForPage` /
  `requireSignedInForJson`** — auth-only variants for callers whose
  service does its own permission audit (Campaign, Intro,
  Moderation). ModerationController's private `withSignedInActor`
  helper is gone; the 6 call-sites use the shared overload.
- **`IntroWebController`**: 11 endpoints now share the auth
  scaffolding instead of re-implementing `discordIdOrNull() ?: return
  …` inline.
- **`CampaignController`** (the big one): a new private
  `withCampaignAuth` helper wraps the auth + flash + redirect dance
  that every mutation endpoint repeated. 22 endpoints each lose the
  `discordIdOrNull` line, the trailing redirect, and the per-arm
  `ra.addFlashAttribute("error", …)`. The `when` arms now return a
  `String?` (null = success) — the helper handles the flash.

### Frontend

- **nav.css dropdown hover gap**: replace the `::before` pseudo-element
  bridge with a real `padding-bottom: 8px` + `margin-bottom: -8px` on
  `.nav-dropdown`. The bridge is now part of the dropdown's
  hover-area (always present, not dependent on the menu being visible),
  so the cursor traversing from toggle to menu items never loses hover.
  Mobile inline layout neutralises the padding so items don't get
  pushed apart.
- **`fragments/guildCard.html`** extracts the icon-or-placeholder +
  name HTML that 8 guild-list templates inlined (~10 lines each).
  Each of `casino-guilds`, `duel-guilds`, `economy-guilds`,
  `leaderboards`, `poker-guilds`, `profile-guilds`, `tip-guilds`,
  `titles-guilds` now uses
  `<div th:replace="~{fragments/guildCard :: header(${g})}">`.

### Out of scope

The 5 `/guilds` listing endpoints (Economy / Leaderboard / Profile /
Titles / Moderation) look similar but each calls a different service
method and returns a different template — extracting them would hide
real variation behind a parameter list. Same call as PR #334's plan.

## Test plan

- [x] `./gradlew :web:test` — 271 tests, 0 failures
- [x] `npm test` (web jest) — 203 tests, 0 failures
- [ ] Manual smoke: hover Casino / Economy navbar dropdowns and confirm
      menu stays open while moving the cursor down to an item (the
      original disappear bug is the regression target)
- [ ] Manual smoke: visit `/economy/guilds`, `/leaderboards`,
      `/profile/guilds`, `/titles/guilds`, `/casino/guilds`,
      `/duel/guilds`, `/tip/guilds`, `/poker/guilds` and confirm the
      icon/placeholder + name still render correctly
- [ ] Manual smoke: visit `/dnd/campaign`, create a campaign, join,
      leave, end — confirm flash messages on each error path
- [ ] Manual smoke: visit `/intro/{g}`, confirm rename / volume slider
      / clip editor still work and toast on errors
- [ ] Manual smoke: visit `/moderation/{g}`, confirm permission /
      kick / mute / poll endpoints still 401 anonymous and succeed for
      a moderator

https://claude.ai/code/session_01WmnYPpCagA3BMLmM9g5g9n

---
_Generated by [Claude Code](https://claude.ai/code/session_01WmnYPpCagA3BMLmM9g5g9n)_