### PR TITLE
fix(poker): surface free-play in the web UI (v2-7 follow-up)

### DIFF
--- a/web/src/main/kotlin/web/service/PokerWebService.kt
+++ b/web/src/main/kotlin/web/service/PokerWebService.kt
@@ -27,6 +27,8 @@ class PokerWebService(
         val handNumber: Long,
         val minBuyIn: Long,
         val maxBuyIn: Long,
+        /** v2-7: free-play flag. Used by the lobby table list to render a "🆓 Free" tag. */
+        val isFreePlay: Boolean = false,
     )
 
     data class TableStateView(
@@ -131,6 +133,7 @@ class PokerWebService(
                 handNumber = it.handNumber,
                 minBuyIn = it.minBuyIn,
                 maxBuyIn = it.maxBuyIn,
+                isFreePlay = it.isFreePlay,
             )
         }.sortedBy { it.tableId }
 

--- a/web/src/main/resources/static/css/poker.css
+++ b/web/src/main/resources/static/css/poker.css
@@ -6,6 +6,29 @@
     margin: 0.25rem 0 0.5rem;
 }
 
+/* v2-7: free-play badge — shown next to a table title or in the lobby
+   row when the table is a no-credit / no-payout sandbox table. */
+.poker-free-tag {
+    display: inline-block;
+    margin-left: 0.5rem;
+    padding: 0.1rem 0.5rem;
+    border-radius: 999px;
+    background: rgba(87, 242, 135, 0.15);
+    color: #57f287;
+    font-size: 0.85rem;
+    font-weight: 500;
+    vertical-align: middle;
+}
+
+/* Free-play checkbox row on the lobby create form. */
+.poker-create-free {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin: 0.5rem 0;
+    font-size: 0.95rem;
+}
+
 .poker-card {
     background: var(--surface, #1f2128);
     border-radius: 0.75rem;

--- a/web/src/main/resources/static/js/poker-lobby.js
+++ b/web/src/main/resources/static/js/poker-lobby.js
@@ -24,7 +24,9 @@
                 showToast('error', 'Buy-in is required.');
                 return;
             }
-            window.TobyApi.postJson('/poker/' + guildId + '/create', { buyIn: buyIn })
+            const freeCheckbox = document.getElementById('poker-create-free');
+            const free = !!(freeCheckbox && freeCheckbox.checked);
+            window.TobyApi.postJson('/poker/' + guildId + '/create', { buyIn: buyIn, free: free })
                 .then(function (resp) {
                     if (!resp || !resp.ok) {
                         showToast('error', (resp && resp.error) || 'Could not create table.');

--- a/web/src/main/resources/static/js/poker-table.js
+++ b/web/src/main/resources/static/js/poker-table.js
@@ -187,6 +187,8 @@
             })
             .then(function (state) {
                 if (!state) return;
+                const freeBadge = document.getElementById('poker-free-badge');
+                if (freeBadge) freeBadge.hidden = !state.isFreePlay;
                 phaseEl.textContent = state.phase;
                 handNumberEl.textContent = state.handNumber;
                 potEl.textContent = state.pot;

--- a/web/src/main/resources/templates/poker-lobby.html
+++ b/web/src/main/resources/templates/poker-lobby.html
@@ -28,6 +28,10 @@
             <label for="poker-create-buyin">Buy-in (credits)</label>
             <input id="poker-create-buyin" name="buyIn" type="number"
                    th:attr="min=${minBuyIn}, max=${maxBuyIn}" th:value="${minBuyIn}" step="1" required>
+            <label class="poker-create-free">
+                <input id="poker-create-free" name="free" type="checkbox">
+                Free play <span class="muted">(no credits debited, no payouts)</span>
+            </label>
             <button type="submit" class="btn-primary">Create table</button>
         </form>
         <div>Wallet: <strong id="poker-balance" th:text="${balance}">0</strong> credits</div>
@@ -43,7 +47,8 @@
                  th:attr="data-table-id=${t.tableId}">
                 <div>
                     <div>Table #<strong th:text="${t.tableId}">1</strong>
-                        — <span th:text="${t.seats}">0</span>/<span th:text="${t.maxSeats}">6</span> seats</div>
+                        — <span th:text="${t.seats}">0</span>/<span th:text="${t.maxSeats}">6</span> seats
+                        <span th:if="${t.isFreePlay}" class="poker-free-tag" title="Free play — no credits, no payouts">🆓 Free</span></div>
                     <div class="muted">Host: <span th:text="${t.hostDiscordId}">000</span> ·
                         Phase: <span th:text="${t.phase}">WAITING</span> ·
                         Hand #<span th:text="${t.handNumber}">0</span></div>

--- a/web/src/main/resources/templates/poker-table.html
+++ b/web/src/main/resources/templates/poker-table.html
@@ -14,7 +14,11 @@
 
     <div class="poker-header">
         <a class="back-link" th:href="@{/poker/{g}(g=${guildId})}">&larr; Back to lobby</a>
-        <h1 th:text="'🃏 Table #' + ${tableId}">🃏 Poker table</h1>
+        <h1>
+            <span th:text="'🃏 Table #' + ${tableId}">🃏 Poker table</span>
+            <span id="poker-free-badge" class="poker-free-tag" hidden
+                  title="Free play — no credits debited, no payouts">🆓 Free play</span>
+        </h1>
         <p class="muted">
             Wallet: <strong id="poker-balance" th:text="${balance}">0</strong> credits.
             Buy-in <span th:text="${minBuyIn}">100</span>–<span th:text="${maxBuyIn}">5000</span> credits.


### PR DESCRIPTION
## Summary

PR #343 plumbed the free-play flag through `PokerService` / `PokerController` / `TableStateView` but **didn't actually expose it in the web templates or JS** — there's no checkbox on the lobby create form, no badge on the table page, and no tag in the open-tables list. Backend supports free play but a web user has no way to opt into it or see that they're already in one.

This PR closes that gap.

## Changes

- **`poker-lobby.html`**: add a "Free play (no credits debited, no payouts)" checkbox to the create form; render a `🆓 Free` tag on free table rows in the open-tables list.
- **`poker-lobby.js`**: read the checkbox and POST `{ buyIn, free }` so the existing `CreateRequest.free` field gets a value.
- **`poker-table.html`**: add a `🆓 Free play` badge next to the table title, hidden by default.
- **`poker-table.js`**: toggle the badge from `state.isFreePlay` on each `refresh()`.
- **`PokerWebService.TableSummaryView`**: add `isFreePlay` (was missing from v2-7 — only `TableStateView` carried it, so the lobby list had no way to render the tag).
- **`poker.css`**: small style for the badge pill + checkbox row.

## Test plan

- [x] `./gradlew :web:compileKotlin :database:test` — clean (no test changes; behaviour is identical for non-free tables, additive for free)
- [ ] Web smoke (CI): tick the new "Free play" checkbox on `/poker/{guildId}`, confirm the resulting table renders the badge in the header and the lobby tag, and the wallet balance never decrements through buy-in / hand resolution / cash-out

https://claude.ai/code/session_0169MvtJ2BSbwkoB9GrFhfZC

---
_Generated by [Claude Code](https://claude.ai/code/session_0169MvtJ2BSbwkoB9GrFhfZC)_