### PR TITLE
feat(blackjack): per-guild config, auto-topup, and hand history

### DIFF
--- a/database/src/main/kotlin/database/blackjack/Blackjack.kt
+++ b/database/src/main/kotlin/database/blackjack/Blackjack.kt
@@ -59,12 +59,21 @@ class Blackjack(private val random: Random = Random.Default) {
 
     /**
      * Dealer's mechanical play-out: draw until the best total is at
-     * least 17. Stands on soft 17 (S17). Mutates [dealer].
+     * least [DEALER_STAND_VALUE] (17). When [hitsSoft17] is true the
+     * dealer also hits a soft 17 (H17 rule, slightly worse for the
+     * player). Default is S17. Mutates [dealer].
      */
-    fun playOutDealer(dealer: MutableList<Card>, deck: Deck) {
-        while (bestTotal(dealer) < DEALER_STAND_VALUE) {
+    fun playOutDealer(dealer: MutableList<Card>, deck: Deck, hitsSoft17: Boolean = false) {
+        while (shouldDealerHit(dealer, hitsSoft17)) {
             dealer.add(deck.deal())
         }
+    }
+
+    private fun shouldDealerHit(dealer: List<Card>, hitsSoft17: Boolean): Boolean {
+        val total = bestTotal(dealer)
+        if (total < DEALER_STAND_VALUE) return true
+        if (total == DEALER_STAND_VALUE && hitsSoft17 && isSoft(dealer)) return true
+        return false
     }
 
     /**
@@ -102,10 +111,11 @@ class Blackjack(private val random: Random = Random.Default) {
      * Payout multiplier on the player's (possibly doubled) stake for
      * the given [result]. Same shape as [database.economy.Highlow] —
      * fed straight to [database.service.WagerHelper.applyMultiplier]
-     * for solo settlement.
+     * for solo settlement. [blackjackPayoutMult] overrides the natural
+     * blackjack multiplier (default 2.5 i.e. 3:2; set to 2.2 for 6:5).
      */
-    fun multiplier(result: Result): Double = when (result) {
-        Result.PLAYER_BLACKJACK -> BLACKJACK_MULT
+    fun multiplier(result: Result, blackjackPayoutMult: Double = BLACKJACK_MULT): Double = when (result) {
+        Result.PLAYER_BLACKJACK -> blackjackPayoutMult
         Result.PLAYER_WIN -> WIN_MULT
         Result.PUSH -> PUSH_MULT
         Result.DEALER_WIN, Result.PLAYER_BUST -> 0.0

--- a/database/src/main/kotlin/database/blackjack/BlackjackTable.kt
+++ b/database/src/main/kotlin/database/blackjack/BlackjackTable.kt
@@ -52,8 +52,28 @@ class BlackjackTable(
      * on their behalf. `0` disables the clock — the table only ever
      * closes via the idle sweeper.
      */
-    val shotClockSeconds: Int = 0
+    val shotClockSeconds: Int = 0,
+    /**
+     * Per-guild rule snapshot taken at table creation. Held on the table
+     * (not read live) so an admin retuning `BLACKJACK_BJ_PAYOUT_NUM` etc.
+     * mid-hand can't change the payout schedule for an in-flight hand.
+     */
+    val rules: TableRules = TableRules()
 ) {
+
+    /**
+     * Snapshot of the configurable house rules for a single table. All
+     * defaults match the v1 hardcoded behaviour so callers that don't
+     * thread the rules through still get the original semantics.
+     */
+    data class TableRules(
+        /** True for H17 (dealer hits soft 17), false for S17 (default). */
+        val dealerHitsSoft17: Boolean = false,
+        /** Natural-blackjack multiplier on the player's stake. 2.5 = 3:2 (default), 2.2 = 6:5. */
+        val blackjackPayoutMultiplier: Double = 2.5,
+        /** Fraction of the multi losers' pool routed to the jackpot pool. */
+        val rakeFraction: Double = 0.05,
+    )
 
     enum class Mode { SOLO, MULTI }
 

--- a/database/src/main/kotlin/database/blackjack/BlackjackTableRegistry.kt
+++ b/database/src/main/kotlin/database/blackjack/BlackjackTableRegistry.kt
@@ -70,6 +70,7 @@ class BlackjackTableRegistry(
         ante: Long,
         maxSeats: Int,
         shotClockSeconds: Int = 0,
+        rules: BlackjackTable.TableRules = BlackjackTable.TableRules(),
         now: Instant = Instant.now()
     ): BlackjackTable {
         val id = seq.incrementAndGet()
@@ -81,6 +82,7 @@ class BlackjackTableRegistry(
             ante = ante,
             maxSeats = maxSeats,
             shotClockSeconds = shotClockSeconds,
+            rules = rules,
             lastActivityAt = now
         )
         tables[id] = table

--- a/database/src/main/kotlin/database/dto/BlackjackHandLogDto.kt
+++ b/database/src/main/kotlin/database/dto/BlackjackHandLogDto.kt
@@ -1,0 +1,69 @@
+package database.dto
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.springframework.transaction.annotation.Transactional
+import java.io.Serializable
+import java.time.Instant
+
+/**
+ * One settled blackjack hand. Written by
+ * [database.service.BlackjackService] in the same transaction as the
+ * payout. Mirrors [PokerHandLogDto] but captures blackjack-specific
+ * fields (mode = SOLO/MULTI, dealer hand text + total, seat-level
+ * result map).
+ */
+@Entity
+@Table(name = "blackjack_hand_log", schema = "public")
+@Transactional
+class BlackjackHandLogDto(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    var id: Long? = null,
+
+    @Column(name = "guild_id", nullable = false)
+    var guildId: Long = 0,
+
+    @Column(name = "table_id", nullable = false)
+    var tableId: Long = 0,
+
+    @Column(name = "hand_number", nullable = false)
+    var handNumber: Long = 0,
+
+    /** "SOLO" or "MULTI". */
+    @Column(name = "mode", nullable = false, length = 8)
+    var mode: String = "",
+
+    /** Comma-separated list of seated players' Discord IDs. */
+    @Column(name = "players", nullable = false, length = 512)
+    var players: String = "",
+
+    /** Final dealer hand, comma-separated card glyphs (e.g. "K♠,7♥,A♦"). */
+    @Column(name = "dealer", nullable = false, length = 64)
+    var dealer: String = "",
+
+    @Column(name = "dealer_total", nullable = false)
+    var dealerTotal: Int = 0,
+
+    /** Comma-separated `discordId:RESULT` (e.g. "100:PLAYER_WIN,101:PLAYER_BUST"). */
+    @Column(name = "seat_results", nullable = false, length = 512)
+    var seatResults: String = "",
+
+    /** Comma-separated `discordId:amount`. Empty if no payouts (everyone bust). */
+    @Column(name = "payouts", nullable = false, length = 512)
+    var payouts: String = "",
+
+    @Column(name = "pot", nullable = false)
+    var pot: Long = 0,
+
+    @Column(name = "rake", nullable = false)
+    var rake: Long = 0,
+
+    @Column(name = "resolved_at", nullable = false)
+    var resolvedAt: Instant = Instant.now()
+) : Serializable

--- a/database/src/main/kotlin/database/dto/ConfigDto.kt
+++ b/database/src/main/kotlin/database/dto/ConfigDto.kt
@@ -79,6 +79,31 @@ class ConfigDto(
         // up if they don't act in time. Default 30s when unset.
         POKER_SHOT_CLOCK_SECONDS("POKER_SHOT_CLOCK_SECONDS"),
 
+        // Per-guild blackjack table parameters. All defaults come from
+        // `Blackjack.companion` constants if unset. Each table snapshots
+        // these values at creation time so a mid-hand admin tweak doesn't
+        // break invariants for the in-flight hand.
+        // Whole-number percentage (0-20) of the multi-table losers' pool
+        // routed to the jackpot pool. Default 5 if unset.
+        BLACKJACK_RAKE_PCT("BLACKJACK_RAKE_PCT"),
+        // Min/max ante per multi hand (also bounds for /blackjack solo
+        // stakes). Defaults to 10 / 500.
+        BLACKJACK_MIN_ANTE("BLACKJACK_MIN_ANTE"),
+        BLACKJACK_MAX_ANTE("BLACKJACK_MAX_ANTE"),
+        // 2-7 seats per multi table. Default 5.
+        BLACKJACK_MAX_SEATS("BLACKJACK_MAX_SEATS"),
+        // Per-actor shot clock for multi tables. Default 30s; 0 disables.
+        BLACKJACK_SHOT_CLOCK_SECONDS("BLACKJACK_SHOT_CLOCK_SECONDS"),
+        // "true" = dealer hits soft 17 (H17, slightly worse for player).
+        // Anything else = stands on all 17 (S17, default).
+        BLACKJACK_DEALER_HITS_SOFT_17("BLACKJACK_DEALER_HITS_SOFT_17"),
+        // Natural-blackjack payout numerator/denominator. Defaults to
+        // 3/2 (i.e. classic 3:2 payout). Set to 6/5 for a stingier room
+        // (typical Vegas low-limit table). Total payout multiplier =
+        // 1 + (num/den), e.g. 3:2 → 2.5×, 6:5 → 2.2×.
+        BLACKJACK_BJ_PAYOUT_NUM("BLACKJACK_BJ_PAYOUT_NUM"),
+        BLACKJACK_BJ_PAYOUT_DEN("BLACKJACK_BJ_PAYOUT_DEN"),
+
         // Whole-number social credits granted to every known user in the
         // guild once per UTC day, regardless of voice activity. 0 (or unset)
         // disables UBI. Bypasses DAILY_CREDIT_CAP — the whole point is to

--- a/database/src/main/kotlin/database/persistence/BlackjackHandLogPersistence.kt
+++ b/database/src/main/kotlin/database/persistence/BlackjackHandLogPersistence.kt
@@ -1,0 +1,22 @@
+package database.persistence
+
+import database.dto.BlackjackHandLogDto
+
+interface BlackjackHandLogPersistence {
+    fun insert(row: BlackjackHandLogDto): BlackjackHandLogDto
+
+    /**
+     * Most recent settled hands on [tableId] within [guildId], newest
+     * first. The guild filter is intentional: tables share an in-memory
+     * id namespace across guilds, so a stale id from another server
+     * must never leak rows out of its own guild.
+     */
+    fun findRecentByTable(guildId: Long, tableId: Long, limit: Int): List<BlackjackHandLogDto>
+
+    /**
+     * Most recent settled hands across the entire guild (any table),
+     * newest first. Used by `/blackjack history` when no `table:`
+     * argument is given.
+     */
+    fun findRecentByGuild(guildId: Long, limit: Int): List<BlackjackHandLogDto>
+}

--- a/database/src/main/kotlin/database/persistence/impl/DefaultBlackjackHandLogPersistence.kt
+++ b/database/src/main/kotlin/database/persistence/impl/DefaultBlackjackHandLogPersistence.kt
@@ -1,0 +1,44 @@
+package database.persistence.impl
+
+import database.dto.BlackjackHandLogDto
+import database.persistence.BlackjackHandLogPersistence
+import jakarta.persistence.EntityManager
+import jakarta.persistence.PersistenceContext
+import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
+
+@Repository
+@Transactional
+class DefaultBlackjackHandLogPersistence : BlackjackHandLogPersistence {
+
+    @PersistenceContext
+    private lateinit var entityManager: EntityManager
+
+    override fun insert(row: BlackjackHandLogDto): BlackjackHandLogDto {
+        entityManager.persist(row)
+        entityManager.flush()
+        return row
+    }
+
+    override fun findRecentByTable(guildId: Long, tableId: Long, limit: Int): List<BlackjackHandLogDto> =
+        entityManager.createQuery(
+            "SELECT h FROM BlackjackHandLogDto h " +
+                "WHERE h.guildId = :guildId AND h.tableId = :tableId " +
+                "ORDER BY h.resolvedAt DESC, h.id DESC",
+            BlackjackHandLogDto::class.java
+        )
+            .setParameter("guildId", guildId)
+            .setParameter("tableId", tableId)
+            .setMaxResults(limit.coerceAtLeast(0))
+            .resultList
+
+    override fun findRecentByGuild(guildId: Long, limit: Int): List<BlackjackHandLogDto> =
+        entityManager.createQuery(
+            "SELECT h FROM BlackjackHandLogDto h WHERE h.guildId = :guildId " +
+                "ORDER BY h.resolvedAt DESC, h.id DESC",
+            BlackjackHandLogDto::class.java
+        )
+            .setParameter("guildId", guildId)
+            .setMaxResults(limit.coerceAtLeast(0))
+            .resultList
+}

--- a/database/src/main/kotlin/database/service/BlackjackService.kt
+++ b/database/src/main/kotlin/database/service/BlackjackService.kt
@@ -6,6 +6,9 @@ import database.blackjack.BlackjackTableRegistry
 import database.blackjack.bestTotal
 import database.blackjack.isBlackjack
 import database.blackjack.isBust
+import database.dto.BlackjackHandLogDto
+import database.dto.ConfigDto
+import database.persistence.BlackjackHandLogPersistence
 import jakarta.annotation.PostConstruct
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Lazy
@@ -41,22 +44,45 @@ class BlackjackService @Autowired constructor(
     private val configService: ConfigService,
     private val tableRegistry: BlackjackTableRegistry,
     private val blackjack: Blackjack = Blackjack(),
+    /**
+     * Optional sell-to-cover wiring (mirrors [PokerService]). When
+     * either is null (test path with no Spring context), `autoTopUp`
+     * requests degrade gracefully to plain `InsufficientCredits` so
+     * existing constructors without these collaborators keep working.
+     */
+    @Autowired(required = false) private val tradeService: EconomyTradeService? = null,
+    @Autowired(required = false) private val marketService: TobyCoinMarketService? = null,
+    /**
+     * Optional hand-log persistence. When null (test path with no
+     * Spring context), settled hands are not logged — service still
+     * pays out correctly, the audit row just doesn't appear.
+     */
+    @Autowired(required = false) private val handLogPersistence: BlackjackHandLogPersistence? = null,
     private val random: Random = Random.Default
 ) {
 
     sealed interface SoloDealOutcome {
         /** Hand dealt; player must act. [snapshot] is a live reference — embeds should read it under [BlackjackTableRegistry.lockTable] if precise consistency is needed. */
-        data class Dealt(val tableId: Long, val snapshot: BlackjackTable) : SoloDealOutcome
+        data class Dealt(
+            val tableId: Long,
+            val snapshot: BlackjackTable,
+            val soldTobyCoins: Long = 0L,
+            val newPrice: Double? = null
+        ) : SoloDealOutcome
         /** Natural blackjack short-circuit (player BJ vs non-BJ dealer, or both BJ → push). */
         data class Resolved(
             val tableId: Long,
             val result: BlackjackTable.HandResult,
             val newBalance: Long,
             val jackpotPayout: Long,
-            val lossTribute: Long
+            val lossTribute: Long,
+            val soldTobyCoins: Long = 0L,
+            val newPrice: Double? = null
         ) : SoloDealOutcome
         data class InvalidStake(val min: Long, val max: Long) : SoloDealOutcome
         data class InsufficientCredits(val stake: Long, val have: Long) : SoloDealOutcome
+        /** [autoTopUp] = true but the player's TOBY can't cover the credit shortfall. */
+        data class InsufficientCoinsForTopUp(val needed: Long, val have: Long) : SoloDealOutcome
         data object UnknownUser : SoloDealOutcome
     }
 
@@ -76,19 +102,30 @@ class BlackjackService @Autowired constructor(
     }
 
     sealed interface MultiCreateOutcome {
-        data class Ok(val tableId: Long) : MultiCreateOutcome
+        data class Ok(
+            val tableId: Long,
+            val soldTobyCoins: Long = 0L,
+            val newPrice: Double? = null
+        ) : MultiCreateOutcome
         data class InvalidAnte(val min: Long, val max: Long) : MultiCreateOutcome
         data class InsufficientCredits(val stake: Long, val have: Long) : MultiCreateOutcome
+        data class InsufficientCoinsForTopUp(val needed: Long, val have: Long) : MultiCreateOutcome
         data object UnknownUser : MultiCreateOutcome
     }
 
     sealed interface MultiJoinOutcome {
-        data class Ok(val seatIndex: Int, val newBalance: Long) : MultiJoinOutcome
+        data class Ok(
+            val seatIndex: Int,
+            val newBalance: Long,
+            val soldTobyCoins: Long = 0L,
+            val newPrice: Double? = null
+        ) : MultiJoinOutcome
         data object TableNotFound : MultiJoinOutcome
         data object TableFull : MultiJoinOutcome
         data object AlreadySeated : MultiJoinOutcome
         data object HandInProgress : MultiJoinOutcome
         data class InsufficientCredits(val stake: Long, val have: Long) : MultiJoinOutcome
+        data class InsufficientCoinsForTopUp(val needed: Long, val have: Long) : MultiJoinOutcome
         data object UnknownUser : MultiJoinOutcome
     }
 
@@ -167,26 +204,48 @@ class BlackjackService @Autowired constructor(
     // -------------------------------------------------------------------------
 
     @Transactional
-    fun dealSolo(discordId: Long, guildId: Long, stake: Long): SoloDealOutcome {
+    fun dealSolo(
+        discordId: Long,
+        guildId: Long,
+        stake: Long,
+        autoTopUp: Boolean = false
+    ): SoloDealOutcome {
+        val params = readMultiTableParams(guildId)
         val check = WagerHelper.checkAndLock(
-            userService, discordId, guildId, stake, Blackjack.MIN_STAKE, Blackjack.MAX_STAKE
+            userService, discordId, guildId, stake, params.minAnte, params.maxAnte
         )
-        val ok = when (check) {
+        var soldCoins = 0L
+        var soldNewPrice: Double? = null
+        val resolved = when (check) {
             is BalanceCheck.InvalidStake -> return SoloDealOutcome.InvalidStake(check.min, check.max)
             BalanceCheck.UnknownUser -> return SoloDealOutcome.UnknownUser
-            is BalanceCheck.Insufficient -> return SoloDealOutcome.InsufficientCredits(check.stake, check.have)
+            is BalanceCheck.Insufficient -> {
+                if (!autoTopUp) return SoloDealOutcome.InsufficientCredits(check.stake, check.have)
+                val user = userService.getUserByIdForUpdate(discordId, guildId)
+                    ?: return SoloDealOutcome.UnknownUser
+                when (val r = resolveBalanceWithOptionalTopUp(user, guildId, check.have, stake)) {
+                    is TopUpResolution.Ok -> {
+                        soldCoins = r.soldCoins
+                        soldNewPrice = r.newPrice
+                        BalanceCheck.Ok(r.user, r.balance)
+                    }
+                    is TopUpResolution.CreditsShort -> return SoloDealOutcome.InsufficientCredits(stake, r.have)
+                    is TopUpResolution.CoinsShort -> return SoloDealOutcome.InsufficientCoinsForTopUp(r.needed, r.have)
+                }
+            }
             is BalanceCheck.Ok -> check
         }
         // Debit stake into seat escrow.
-        ok.user.socialCredit = ok.balance - stake
-        userService.updateUser(ok.user)
+        resolved.user.socialCredit = resolved.balance - stake
+        userService.updateUser(resolved.user)
 
         val table = tableRegistry.create(
             guildId = guildId,
             mode = BlackjackTable.Mode.SOLO,
             hostDiscordId = discordId,
             ante = stake,
-            maxSeats = 1
+            maxSeats = 1,
+            rules = params.rules
         )
         val initial = tableRegistry.lockTable(table.id) { t ->
             val deck = blackjack.newDeck()
@@ -222,7 +281,9 @@ class BlackjackService @Autowired constructor(
         return when (initial) {
             ResolveDecision.AwaitPlayer -> SoloDealOutcome.Dealt(
                 tableId = table.id,
-                snapshot = table
+                snapshot = table,
+                soldTobyCoins = soldCoins,
+                newPrice = soldNewPrice
             )
             is ResolveDecision.ResolveImmediately -> {
                 val settlement = settleSolo(table, initial.seat, initial.result, guildId)
@@ -231,7 +292,9 @@ class BlackjackService @Autowired constructor(
                     result = settlement.handResult,
                     newBalance = settlement.newBalance,
                     jackpotPayout = settlement.jackpotPayout,
-                    lossTribute = settlement.lossTribute
+                    lossTribute = settlement.lossTribute,
+                    soldTobyCoins = soldCoins,
+                    newPrice = soldNewPrice
                 )
             }
         }
@@ -358,7 +421,7 @@ class BlackjackService @Autowired constructor(
     ): SoloTransition {
         val deck = t.deck ?: return SoloTransition.HandNotFound
         t.phase = BlackjackTable.Phase.DEALER_TURN
-        blackjack.playOutDealer(t.dealer, deck)
+        blackjack.playOutDealer(t.dealer, deck, hitsSoft17 = t.rules.dealerHitsSoft17)
         t.phase = BlackjackTable.Phase.RESOLVED
         return SoloTransition.Resolve(seat, blackjack.evaluate(seat.hand, t.dealer))
     }
@@ -397,7 +460,7 @@ class BlackjackService @Autowired constructor(
         result: Blackjack.Result,
         guildId: Long
     ): SoloSettlement {
-        val multiplier = blackjack.multiplier(result)
+        val multiplier = blackjack.multiplier(result, table.rules.blackjackPayoutMultiplier)
         val payout = (seat.stake * multiplier).toLong()
 
         val user = userService.getUserByIdForUpdate(seat.discordId, guildId)
@@ -435,7 +498,38 @@ class BlackjackService @Autowired constructor(
             table.lastResult = handResult
             table.lastActivityAt = Instant.now()
         }
+        persistHandLog(table, handResult)
         return SoloSettlement(handResult, newBalance, jackpotPayout, lossTribute)
+    }
+
+    /**
+     * Append the resolved hand to `blackjack_hand_log` if persistence
+     * is wired. Compact card glyphs match what the embed renders.
+     */
+    private fun persistHandLog(table: BlackjackTable, result: BlackjackTable.HandResult) {
+        val persistence = handLogPersistence ?: return
+        val players = result.seatResults.keys.joinToString(",")
+        val seatResultsStr = result.seatResults.entries.joinToString(",") { (id, r) -> "$id:${r.name}" }
+        val payoutsStr = result.payouts.entries.joinToString(",") { (id, amt) -> "$id:$amt" }
+        val dealerStr = result.dealer.joinToString(",") { it.toString() }
+        runCatching {
+            persistence.insert(
+                BlackjackHandLogDto(
+                    guildId = table.guildId,
+                    tableId = table.id,
+                    handNumber = result.handNumber,
+                    mode = table.mode.name,
+                    players = players,
+                    dealer = dealerStr,
+                    dealerTotal = result.dealerTotal,
+                    seatResults = seatResultsStr,
+                    payouts = payoutsStr,
+                    pot = result.pot,
+                    rake = result.rake,
+                    resolvedAt = result.resolvedAt
+                )
+            )
+        }
     }
 
     private fun statusFor(
@@ -464,27 +558,44 @@ class BlackjackService @Autowired constructor(
     fun createMultiTable(
         hostDiscordId: Long,
         guildId: Long,
-        ante: Long
+        ante: Long,
+        autoTopUp: Boolean = false
     ): MultiCreateOutcome {
+        val params = readMultiTableParams(guildId)
         val check = WagerHelper.checkAndLock(
-            userService, hostDiscordId, guildId, ante,
-            Blackjack.MULTI_MIN_ANTE, Blackjack.MULTI_MAX_ANTE
+            userService, hostDiscordId, guildId, ante, params.minAnte, params.maxAnte
         )
-        val ok = when (check) {
+        var soldCoins = 0L
+        var soldNewPrice: Double? = null
+        val resolved = when (check) {
             is BalanceCheck.InvalidStake -> return MultiCreateOutcome.InvalidAnte(check.min, check.max)
             BalanceCheck.UnknownUser -> return MultiCreateOutcome.UnknownUser
-            is BalanceCheck.Insufficient -> return MultiCreateOutcome.InsufficientCredits(check.stake, check.have)
+            is BalanceCheck.Insufficient -> {
+                if (!autoTopUp) return MultiCreateOutcome.InsufficientCredits(check.stake, check.have)
+                val user = userService.getUserByIdForUpdate(hostDiscordId, guildId)
+                    ?: return MultiCreateOutcome.UnknownUser
+                when (val r = resolveBalanceWithOptionalTopUp(user, guildId, check.have, ante)) {
+                    is TopUpResolution.Ok -> {
+                        soldCoins = r.soldCoins
+                        soldNewPrice = r.newPrice
+                        BalanceCheck.Ok(r.user, r.balance)
+                    }
+                    is TopUpResolution.CreditsShort -> return MultiCreateOutcome.InsufficientCredits(ante, r.have)
+                    is TopUpResolution.CoinsShort -> return MultiCreateOutcome.InsufficientCoinsForTopUp(r.needed, r.have)
+                }
+            }
             is BalanceCheck.Ok -> check
         }
-        ok.user.socialCredit = ok.balance - ante
-        userService.updateUser(ok.user)
+        resolved.user.socialCredit = resolved.balance - ante
+        userService.updateUser(resolved.user)
         val table = tableRegistry.create(
             guildId = guildId,
             mode = BlackjackTable.Mode.MULTI,
             hostDiscordId = hostDiscordId,
             ante = ante,
-            maxSeats = Blackjack.MULTI_MAX_SEATS,
-            shotClockSeconds = Blackjack.MULTI_SHOT_CLOCK_SECONDS
+            maxSeats = params.maxSeats,
+            shotClockSeconds = params.shotClockSeconds,
+            rules = params.rules
         )
         synchronized(table) {
             table.seats.add(
@@ -495,14 +606,19 @@ class BlackjackService @Autowired constructor(
                 )
             )
         }
-        return MultiCreateOutcome.Ok(table.id)
+        return MultiCreateOutcome.Ok(
+            tableId = table.id,
+            soldTobyCoins = soldCoins,
+            newPrice = soldNewPrice
+        )
     }
 
     @Transactional
     fun joinMultiTable(
         discordId: Long,
         guildId: Long,
-        tableId: Long
+        tableId: Long,
+        autoTopUp: Boolean = false
     ): MultiJoinOutcome {
         val table = tableRegistry.get(tableId) ?: return MultiJoinOutcome.TableNotFound
         if (table.guildId != guildId) return MultiJoinOutcome.TableNotFound
@@ -527,7 +643,26 @@ class BlackjackService @Autowired constructor(
         val user = userService.getUserByIdForUpdate(discordId, guildId)
             ?: return MultiJoinOutcome.UnknownUser
         val balance = user.socialCredit ?: 0L
-        if (balance < ante) return MultiJoinOutcome.InsufficientCredits(ante, balance)
+        var soldCoins = 0L
+        var soldNewPrice: Double? = null
+        val payerBalance: Long
+        val payerUser: database.dto.UserDto
+        if (balance < ante) {
+            if (!autoTopUp) return MultiJoinOutcome.InsufficientCredits(ante, balance)
+            when (val r = resolveBalanceWithOptionalTopUp(user, guildId, balance, ante)) {
+                is TopUpResolution.Ok -> {
+                    soldCoins = r.soldCoins
+                    soldNewPrice = r.newPrice
+                    payerUser = r.user
+                    payerBalance = r.balance
+                }
+                is TopUpResolution.CreditsShort -> return MultiJoinOutcome.InsufficientCredits(ante, r.have)
+                is TopUpResolution.CoinsShort -> return MultiJoinOutcome.InsufficientCoinsForTopUp(r.needed, r.have)
+            }
+        } else {
+            payerUser = user
+            payerBalance = balance
+        }
 
         val seatIndex = synchronized(table) {
             if (table.phase != BlackjackTable.Phase.LOBBY) return@synchronized -3
@@ -547,9 +682,14 @@ class BlackjackService @Autowired constructor(
         if (seatIndex == -2) return MultiJoinOutcome.TableFull
         if (seatIndex == -3) return MultiJoinOutcome.HandInProgress
 
-        user.socialCredit = balance - ante
-        userService.updateUser(user)
-        return MultiJoinOutcome.Ok(seatIndex = seatIndex, newBalance = user.socialCredit ?: 0L)
+        payerUser.socialCredit = payerBalance - ante
+        userService.updateUser(payerUser)
+        return MultiJoinOutcome.Ok(
+            seatIndex = seatIndex,
+            newBalance = payerUser.socialCredit ?: 0L,
+            soldTobyCoins = soldCoins,
+            newPrice = soldNewPrice
+        )
     }
 
     @Transactional
@@ -928,7 +1068,7 @@ class BlackjackService @Autowired constructor(
         val deck = t.deck ?: error("missing deck on resolve")
         val allBust = t.seats.all { it.status == BlackjackTable.SeatStatus.BUSTED }
         if (!allBust) {
-            blackjack.playOutDealer(t.dealer, deck)
+            blackjack.playOutDealer(t.dealer, deck, hitsSoft17 = t.rules.dealerHitsSoft17)
         }
         t.phase = BlackjackTable.Phase.RESOLVED
 
@@ -962,15 +1102,17 @@ class BlackjackService @Autowired constructor(
         val regularWinners = winnerSeats.filter {
             results[it.discordId] == Blackjack.Result.PLAYER_WIN
         }
+        // BJ premium = (payoutMultiplier - 1) × stake, e.g. 3:2 → 1.5×, 6:5 → 1.2×.
+        val bjPremiumFraction = (t.rules.blackjackPayoutMultiplier - 1.0).coerceAtLeast(0.0)
         var rake = 0L
         if (winnerSeats.isEmpty()) {
             // No winners: entire losers' pool routes to the jackpot.
             rake = losersPool
         } else if (losersPool > 0L) {
-            val baseRake = (losersPool * Blackjack.MULTI_RAKE).toLong()
+            val baseRake = (losersPool * t.rules.rakeFraction).toLong()
             val payable = losersPool - baseRake
             val regularEntitled = regularWinners.sumOf { it.stake }
-            val bjEntitled = bjWinners.sumOf { (it.stake * 3L) / 2L }
+            val bjEntitled = bjWinners.sumOf { (it.stake * bjPremiumFraction).toLong() }
             val totalEntitled = regularEntitled + bjEntitled
 
             if (totalEntitled > 0L && payable >= totalEntitled) {
@@ -979,7 +1121,7 @@ class BlackjackService @Autowired constructor(
                     payouts.merge(seat.discordId, seat.stake) { a, b -> a + b }
                 }
                 for (seat in bjWinners) {
-                    payouts.merge(seat.discordId, (seat.stake * 3L) / 2L) { a, b -> a + b }
+                    payouts.merge(seat.discordId, (seat.stake * bjPremiumFraction).toLong()) { a, b -> a + b }
                 }
                 val surplus = payable - totalEntitled
                 rake = baseRake + surplus
@@ -990,7 +1132,7 @@ class BlackjackService @Autowired constructor(
                     payouts.merge(seat.discordId, share) { a, b -> a + b }
                 }
                 for (seat in bjWinners) {
-                    val owed = (seat.stake * 3L) / 2L
+                    val owed = (seat.stake * bjPremiumFraction).toLong()
                     val share = (owed * payable) / totalEntitled
                     payouts.merge(seat.discordId, share) { a, b -> a + b }
                 }
@@ -1023,6 +1165,7 @@ class BlackjackService @Autowired constructor(
         )
         t.lastResult = handResult
         t.lastActivityAt = Instant.now()
+        persistHandLog(t, handResult)
 
         // Reset to LOBBY but KEEP seats. Each surviving seat needs to re-
         // ante on the next [startMultiHand] — set stake=0 to mark "no
@@ -1073,4 +1216,161 @@ class BlackjackService @Autowired constructor(
     private enum class JoinPreflight { Ok, AlreadySeated, TableFull, HandInProgress }
 
     fun snapshot(tableId: Long): BlackjackTable? = tableRegistry.get(tableId)
+
+    // -------------------------------------------------------------------------
+    // HISTORY
+    // -------------------------------------------------------------------------
+
+    /**
+     * Most recent settled hands for [tableId] within [guildId], newest
+     * first. At most [limit] rows; non-positive limits yield empty.
+     * Returns empty when persistence isn't wired (test path).
+     */
+    fun recentHandsForTable(
+        guildId: Long,
+        tableId: Long,
+        limit: Int = HISTORY_DEFAULT_LIMIT
+    ): List<BlackjackHandLogDto> {
+        if (limit <= 0) return emptyList()
+        val persistence = handLogPersistence ?: return emptyList()
+        return persistence.findRecentByTable(guildId, tableId, limit.coerceAtMost(HISTORY_MAX_LIMIT))
+    }
+
+    /**
+     * Most recent settled hands across the entire guild, newest first.
+     * Used when `/blackjack history` is invoked without a table id.
+     */
+    fun recentHandsForGuild(
+        guildId: Long,
+        limit: Int = HISTORY_DEFAULT_LIMIT
+    ): List<BlackjackHandLogDto> {
+        if (limit <= 0) return emptyList()
+        val persistence = handLogPersistence ?: return emptyList()
+        return persistence.findRecentByGuild(guildId, limit.coerceAtMost(HISTORY_MAX_LIMIT))
+    }
+
+    // -------------------------------------------------------------------------
+    // CONFIG SNAPSHOT + AUTO-TOPUP
+    // -------------------------------------------------------------------------
+
+    /**
+     * Snapshot of every per-guild blackjack table parameter. Each value
+     * falls back to the [Blackjack.companion] default if unset or
+     * unparseable. Read once per table at create time, never live, so a
+     * mid-hand admin tweak can't change the rules under an in-flight game.
+     */
+    data class TableParams(
+        val minAnte: Long,
+        val maxAnte: Long,
+        val maxSeats: Int,
+        val shotClockSeconds: Int,
+        val rules: BlackjackTable.TableRules,
+    )
+
+    fun readMultiTableParams(guildId: Long): TableParams {
+        fun cfgLong(key: ConfigDto.Configurations, default: Long, min: Long): Long {
+            val raw = configService.getConfigByName(key.configValue, guildId.toString())?.value
+            return raw?.toLongOrNull()?.coerceAtLeast(min) ?: default
+        }
+        fun cfgInt(key: ConfigDto.Configurations, default: Int, range: IntRange): Int {
+            val raw = configService.getConfigByName(key.configValue, guildId.toString())?.value
+            return raw?.toIntOrNull()?.coerceIn(range) ?: default
+        }
+        fun cfgBool(key: ConfigDto.Configurations, default: Boolean): Boolean {
+            val raw = configService.getConfigByName(key.configValue, guildId.toString())?.value
+            return raw?.lowercase()?.let { it == "true" || it == "1" || it == "yes" } ?: default
+        }
+        fun cfgPctFraction(key: ConfigDto.Configurations, default: Double, max: Double): Double {
+            val raw = configService.getConfigByName(key.configValue, guildId.toString())?.value
+            val pct = raw?.toDoubleOrNull() ?: return default
+            if (pct.isNaN() || pct.isInfinite() || pct < 0.0) return default
+            return (pct / 100.0).coerceAtMost(max)
+        }
+        val minAnte = cfgLong(ConfigDto.Configurations.BLACKJACK_MIN_ANTE, Blackjack.MULTI_MIN_ANTE, 1L)
+        val maxAnte = cfgLong(ConfigDto.Configurations.BLACKJACK_MAX_ANTE, Blackjack.MULTI_MAX_ANTE, minAnte)
+        val maxSeats = cfgInt(ConfigDto.Configurations.BLACKJACK_MAX_SEATS, Blackjack.MULTI_MAX_SEATS, 2..7)
+        val shotClock = cfgInt(
+            ConfigDto.Configurations.BLACKJACK_SHOT_CLOCK_SECONDS,
+            Blackjack.MULTI_SHOT_CLOCK_SECONDS,
+            0..600
+        )
+        val hitsSoft17 = cfgBool(ConfigDto.Configurations.BLACKJACK_DEALER_HITS_SOFT_17, default = false)
+        val rake = cfgPctFraction(ConfigDto.Configurations.BLACKJACK_RAKE_PCT, default = Blackjack.MULTI_RAKE, max = 0.20)
+        // BJ payout num/den → multiplier = 1 + num/den. Fall back to 3:2.
+        val numRaw = configService.getConfigByName(
+            ConfigDto.Configurations.BLACKJACK_BJ_PAYOUT_NUM.configValue, guildId.toString()
+        )?.value?.toIntOrNull()?.coerceAtLeast(1)
+        val denRaw = configService.getConfigByName(
+            ConfigDto.Configurations.BLACKJACK_BJ_PAYOUT_DEN.configValue, guildId.toString()
+        )?.value?.toIntOrNull()?.coerceAtLeast(1)
+        val payoutMult: Double = if (numRaw != null && denRaw != null) {
+            1.0 + numRaw.toDouble() / denRaw.toDouble()
+        } else {
+            Blackjack.BLACKJACK_MULT
+        }
+        return TableParams(
+            minAnte = minAnte,
+            maxAnte = maxAnte,
+            maxSeats = maxSeats,
+            shotClockSeconds = shotClock,
+            rules = BlackjackTable.TableRules(
+                dealerHitsSoft17 = hitsSoft17,
+                blackjackPayoutMultiplier = payoutMult,
+                rakeFraction = rake,
+            )
+        )
+    }
+
+    /**
+     * v2-4 (auto-topup) shared between [dealSolo], [createMultiTable]
+     * and [joinMultiTable]. If [currentBalance] already covers [target]
+     * this is a no-op (Ok with `soldCoins=0`). Otherwise sells just
+     * enough TOBY via [CasinoTopUpHelper.ensureCreditsForWager].
+     * Failures map back to the per-method `InsufficientCredits` /
+     * `InsufficientCoinsForTopUp` variants.
+     */
+    private fun resolveBalanceWithOptionalTopUp(
+        user: database.dto.UserDto,
+        guildId: Long,
+        currentBalance: Long,
+        target: Long,
+    ): TopUpResolution {
+        if (currentBalance >= target) {
+            return TopUpResolution.Ok(user = user, balance = currentBalance, soldCoins = 0L, newPrice = null)
+        }
+        val safeTrade = tradeService
+        val safeMarket = marketService
+        if (safeTrade == null || safeMarket == null) {
+            return TopUpResolution.CreditsShort(have = currentBalance, needed = target)
+        }
+        return when (val r = CasinoTopUpHelper.ensureCreditsForWager(
+            safeTrade, safeMarket, userService, user, guildId, currentBalance, target
+        )) {
+            is TopUpResult.ToppedUp ->
+                TopUpResolution.Ok(user = r.user, balance = r.balance, soldCoins = r.soldCoins, newPrice = r.newPrice)
+            TopUpResult.MarketUnavailable ->
+                TopUpResolution.CreditsShort(have = currentBalance, needed = target)
+            is TopUpResult.InsufficientCoins ->
+                TopUpResolution.CoinsShort(needed = r.needed, have = r.have)
+        }
+    }
+
+    private sealed interface TopUpResolution {
+        data class Ok(
+            val user: database.dto.UserDto,
+            val balance: Long,
+            val soldCoins: Long,
+            val newPrice: Double?,
+        ) : TopUpResolution
+        data class CreditsShort(val have: Long, val needed: Long) : TopUpResolution
+        data class CoinsShort(val needed: Long, val have: Long) : TopUpResolution
+    }
+
+    companion object {
+        // Default and ceiling for /blackjack history depth. Matched to a
+        // single Discord embed that fits in the 4096-char description
+        // budget; the cap protects against pathological queries.
+        const val HISTORY_DEFAULT_LIMIT: Int = 10
+        const val HISTORY_MAX_LIMIT: Int = 25
+    }
 }

--- a/database/src/main/resources/db/migration/V25__blackjack_hand_log.sql
+++ b/database/src/main/resources/db/migration/V25__blackjack_hand_log.sql
@@ -1,0 +1,30 @@
+-- Append-only audit log for every settled blackjack hand.
+-- Mirrors poker_hand_log: a row is written exactly once per resolved
+-- /blackjack hand (solo or multi). Captures the per-seat outcome and
+-- the hand-level totals (pot, rake) for chart/audit purposes.
+--
+-- For SOLO hands, `players`, `seat_results`, and `payouts` always have
+-- exactly one entry. For MULTI hands they list every seat at the moment
+-- of resolution, including seats that were dropped post-hand via
+-- pendingLeave (those still settled this hand before being removed).
+--
+-- `seat_results` is a comma-separated `discord_id:RESULT` list, with
+-- RESULT one of PLAYER_BLACKJACK / PLAYER_WIN / PUSH / DEALER_WIN /
+-- PLAYER_BUST. `payouts` is the same shape with credit amounts.
+CREATE TABLE blackjack_hand_log (
+    id            BIGSERIAL    PRIMARY KEY,
+    guild_id      BIGINT       NOT NULL,
+    table_id      BIGINT       NOT NULL,
+    hand_number   BIGINT       NOT NULL,
+    mode          VARCHAR(8)   NOT NULL,            -- 'SOLO' or 'MULTI'
+    players       VARCHAR(512) NOT NULL,
+    dealer        VARCHAR(64)  NOT NULL,            -- e.g. "K♠,7♥,A♦"
+    dealer_total  INT          NOT NULL,
+    seat_results  VARCHAR(512) NOT NULL,
+    payouts       VARCHAR(512) NOT NULL,
+    pot           BIGINT       NOT NULL CHECK (pot >= 0),
+    rake          BIGINT       NOT NULL DEFAULT 0 CHECK (rake >= 0),
+    resolved_at   TIMESTAMPTZ  NOT NULL
+);
+CREATE INDEX idx_blackjack_hand_log_guild_time ON blackjack_hand_log (guild_id, resolved_at DESC);
+CREATE INDEX idx_blackjack_hand_log_table      ON blackjack_hand_log (table_id, hand_number);

--- a/database/src/test/kotlin/database/service/BlackjackServiceTest.kt
+++ b/database/src/test/kotlin/database/service/BlackjackServiceTest.kt
@@ -48,8 +48,15 @@ class BlackjackServiceTest {
         // Default: deck creation always succeeds; service code calls newDeck()
         // and stashes the result on the table — we don't care which deck it is.
         every { blackjack.newDeck() } returns Deck(Random(0))
-        every { blackjack.multiplier(any()) } answers { realMultiplier(arg(0)) }
-        service = BlackjackService(userService, jackpotService, configService, registry, blackjack, Random(0))
+        every { blackjack.multiplier(any(), any()) } answers { realMultiplier(arg(0)) }
+        service = BlackjackService(
+            userService = userService,
+            jackpotService = jackpotService,
+            configService = configService,
+            tableRegistry = registry,
+            blackjack = blackjack,
+            random = Random(0)
+        )
     }
 
     private fun userWithBalance(balance: Long, id: Long = discordId): UserDto =

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/BlackjackCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/BlackjackCommand.kt
@@ -47,10 +47,13 @@ class BlackjackCommand @Autowired constructor(
         private const val SUB_LEAVE = "leave"
         private const val SUB_TABLES = "tables"
         private const val SUB_PEEK = "peek"
+        private const val SUB_HISTORY = "history"
 
         private const val OPT_STAKE = "stake"
         private const val OPT_ANTE = "ante"
         private const val OPT_TABLE = "table"
+        private const val OPT_LIMIT = "limit"
+        private const val OPT_AUTO_TOPUP = "auto_topup"
     }
 
     override val subCommands: List<SubcommandData> = listOf(
@@ -58,17 +61,20 @@ class BlackjackCommand @Autowired constructor(
             .addOptions(
                 OptionData(OptionType.INTEGER, OPT_STAKE, "Credits to wager (${Blackjack.MIN_STAKE}-${Blackjack.MAX_STAKE})", true)
                     .setMinValue(Blackjack.MIN_STAKE)
-                    .setMaxValue(Blackjack.MAX_STAKE)
+                    .setMaxValue(Blackjack.MAX_STAKE),
+                OptionData(OptionType.BOOLEAN, OPT_AUTO_TOPUP, "Sell TOBY at market to cover any credit shortfall", false)
             ),
         SubcommandData(SUB_CREATE, "Create a multiplayer blackjack table and seat yourself.")
             .addOptions(
                 OptionData(OptionType.INTEGER, OPT_ANTE, "Per-hand ante (${Blackjack.MULTI_MIN_ANTE}-${Blackjack.MULTI_MAX_ANTE})", true)
                     .setMinValue(Blackjack.MULTI_MIN_ANTE)
-                    .setMaxValue(Blackjack.MULTI_MAX_ANTE)
+                    .setMaxValue(Blackjack.MULTI_MAX_ANTE),
+                OptionData(OptionType.BOOLEAN, OPT_AUTO_TOPUP, "Sell TOBY at market to cover any credit shortfall", false)
             ),
         SubcommandData(SUB_JOIN, "Join an existing blackjack table at its ante.")
             .addOptions(
-                OptionData(OptionType.INTEGER, OPT_TABLE, "Table id", true).setMinValue(1)
+                OptionData(OptionType.INTEGER, OPT_TABLE, "Table id", true).setMinValue(1),
+                OptionData(OptionType.BOOLEAN, OPT_AUTO_TOPUP, "Sell TOBY at market to cover any credit shortfall", false)
             ),
         SubcommandData(SUB_START, "Deal the next hand on a table you host.")
             .addOptions(
@@ -82,6 +88,14 @@ class BlackjackCommand @Autowired constructor(
         SubcommandData(SUB_PEEK, "Show your hand mid-round (only visible to you).")
             .addOptions(
                 OptionData(OptionType.INTEGER, OPT_TABLE, "Table id", true).setMinValue(1)
+            ),
+        SubcommandData(SUB_HISTORY, "Show recent settled blackjack hands.")
+            .addOptions(
+                OptionData(OptionType.INTEGER, OPT_TABLE, "Table id (optional — omit for server-wide history)", false)
+                    .setMinValue(1),
+                OptionData(OptionType.INTEGER, OPT_LIMIT, "How many hands to show (default ${BlackjackService.HISTORY_DEFAULT_LIMIT})", false)
+                    .setMinValue(1)
+                    .setMaxValue(BlackjackService.HISTORY_MAX_LIMIT.toLong())
             ),
     )
 
@@ -100,6 +114,7 @@ class BlackjackCommand @Autowired constructor(
             SUB_LEAVE -> handleLeave(event, requestingUserDto, guild.idLong, deleteDelay)
             SUB_TABLES -> handleTables(event, guild.idLong, deleteDelay)
             SUB_PEEK -> handlePeek(event, requestingUserDto, guild.idLong)
+            SUB_HISTORY -> handleHistory(event, guild.idLong, deleteDelay)
             else -> replyError(event, "Unknown subcommand.", deleteDelay)
         }
     }
@@ -113,7 +128,8 @@ class BlackjackCommand @Autowired constructor(
         val stake = event.getOption(OPT_STAKE)?.asLong ?: run {
             replyError(event, "You must specify a stake.", deleteDelay); return
         }
-        when (val outcome = blackjackService.dealSolo(userDto.discordId, guildId, stake)) {
+        val autoTopUp = event.getOption(OPT_AUTO_TOPUP)?.asBoolean ?: false
+        when (val outcome = blackjackService.dealSolo(userDto.discordId, guildId, stake, autoTopUp)) {
             is SoloDealOutcome.Dealt -> {
                 val table = tableRegistry.get(outcome.tableId)
                     ?: return replyError(event, "Hand vanished.", deleteDelay)
@@ -137,6 +153,9 @@ class BlackjackCommand @Autowired constructor(
             is SoloDealOutcome.InsufficientCredits -> replyFailure(
                 event, WagerCommandFailure.InsufficientCredits(outcome.stake, outcome.have), deleteDelay
             )
+            is SoloDealOutcome.InsufficientCoinsForTopUp -> replyFailure(
+                event, WagerCommandFailure.InsufficientCoinsForTopUp(outcome.needed, outcome.have), deleteDelay
+            )
             SoloDealOutcome.UnknownUser -> replyFailure(
                 event, WagerCommandFailure.UnknownUser, deleteDelay
             )
@@ -152,7 +171,8 @@ class BlackjackCommand @Autowired constructor(
         val ante = event.getOption(OPT_ANTE)?.asLong ?: run {
             replyError(event, "Ante is required.", deleteDelay); return
         }
-        when (val outcome = blackjackService.createMultiTable(userDto.discordId, guildId, ante)) {
+        val autoTopUp = event.getOption(OPT_AUTO_TOPUP)?.asBoolean ?: false
+        when (val outcome = blackjackService.createMultiTable(userDto.discordId, guildId, ante, autoTopUp)) {
             is MultiCreateOutcome.Ok -> {
                 val table = tableRegistry.get(outcome.tableId)
                     ?: return replyError(event, "Table vanished.", deleteDelay)
@@ -164,6 +184,9 @@ class BlackjackCommand @Autowired constructor(
             )
             is MultiCreateOutcome.InsufficientCredits -> replyFailure(
                 event, WagerCommandFailure.InsufficientCredits(outcome.stake, outcome.have), deleteDelay
+            )
+            is MultiCreateOutcome.InsufficientCoinsForTopUp -> replyFailure(
+                event, WagerCommandFailure.InsufficientCoinsForTopUp(outcome.needed, outcome.have), deleteDelay
             )
             MultiCreateOutcome.UnknownUser -> replyFailure(
                 event, WagerCommandFailure.UnknownUser, deleteDelay
@@ -180,7 +203,8 @@ class BlackjackCommand @Autowired constructor(
         val tableId = event.getOption(OPT_TABLE)?.asLong ?: run {
             replyError(event, "Table id is required.", deleteDelay); return
         }
-        when (val outcome = blackjackService.joinMultiTable(userDto.discordId, guildId, tableId)) {
+        val autoTopUp = event.getOption(OPT_AUTO_TOPUP)?.asBoolean ?: false
+        when (val outcome = blackjackService.joinMultiTable(userDto.discordId, guildId, tableId, autoTopUp)) {
             is MultiJoinOutcome.Ok -> {
                 val table = tableRegistry.get(tableId)
                     ?: return replyError(event, "Table vanished.", deleteDelay)
@@ -199,6 +223,9 @@ class BlackjackCommand @Autowired constructor(
                 replyError(event, "Wait for the current hand to end before joining.", deleteDelay)
             is MultiJoinOutcome.InsufficientCredits -> replyFailure(
                 event, WagerCommandFailure.InsufficientCredits(outcome.stake, outcome.have), deleteDelay
+            )
+            is MultiJoinOutcome.InsufficientCoinsForTopUp -> replyFailure(
+                event, WagerCommandFailure.InsufficientCoinsForTopUp(outcome.needed, outcome.have), deleteDelay
             )
             MultiJoinOutcome.UnknownUser -> replyFailure(
                 event, WagerCommandFailure.UnknownUser, deleteDelay
@@ -310,6 +337,22 @@ class BlackjackCommand @Autowired constructor(
         }
         event.hook.sendMessageEmbeds(BlackjackEmbeds.peekEmbed(seat.hand))
             .setEphemeral(true).queue()
+    }
+
+    private fun handleHistory(
+        event: SlashCommandInteractionEvent,
+        guildId: Long,
+        deleteDelay: Int
+    ) {
+        val tableId = event.getOption(OPT_TABLE)?.asLong
+        val limit = event.getOption(OPT_LIMIT)?.asLong?.toInt() ?: BlackjackService.HISTORY_DEFAULT_LIMIT
+        val (scope, hands) = if (tableId != null) {
+            "Table #$tableId" to blackjackService.recentHandsForTable(guildId, tableId, limit)
+        } else {
+            "Server" to blackjackService.recentHandsForGuild(guildId, limit)
+        }
+        event.hook.sendMessageEmbeds(BlackjackEmbeds.historyEmbed(scope, hands))
+            .queue(invokeDeleteOnMessageResponse(deleteDelay))
     }
 
     private fun soloActionRow(tableId: Long, allowDouble: Boolean): ActionRow {

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/BlackjackEmbeds.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/BlackjackEmbeds.kt
@@ -5,9 +5,12 @@ import database.blackjack.BlackjackTable
 import database.blackjack.bestTotal
 import database.blackjack.isSoft
 import database.card.Card
+import database.dto.BlackjackHandLogDto
 import net.dv8tion.jda.api.EmbedBuilder
 import net.dv8tion.jda.api.entities.MessageEmbed
 import java.awt.Color
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
 
 /**
  * Shared embed/component plumbing for the Discord `/blackjack` flow.
@@ -212,4 +215,43 @@ internal object BlackjackEmbeds {
         .build()
 
     fun errorEmbed(message: String): MessageEmbed = WagerCommandEmbeds.errorEmbed(TITLE, message)
+
+    /**
+     * Render up to a screenful of recent settled hands, mirroring
+     * `PokerEmbeds.historyEmbed`. [scope] is the title-friendly label
+     * ("Server" or "Table #7"); [hands] are the rows in the order they
+     * should be rendered (caller passes them newest-first to match the
+     * JPA query). Falls back to a compact "no hands yet" line if empty.
+     */
+    fun historyEmbed(scope: String, hands: List<BlackjackHandLogDto>): MessageEmbed {
+        val builder = EmbedBuilder()
+            .setTitle("$TITLE • Recent hands • $scope")
+            .setColor(NEUTRAL_COLOR)
+        if (hands.isEmpty()) {
+            return builder.setDescription("No settled hands yet.").build()
+        }
+        val lines = hands.map { row ->
+            val dealer = if (row.dealer.isBlank()) "—" else row.dealer.replace(",", " ")
+            val results = row.seatResults.split(",").filter { it.isNotBlank() }.joinToString(" · ") { entry ->
+                val parts = entry.split(":", limit = 2)
+                if (parts.size == 2) "<@${parts[0]}> ${shortResult(parts[1])}" else entry
+            }
+            val ts = row.resolvedAt.let { HISTORY_TIME_FMT.format(it) }
+            "`#${row.handNumber}` `${row.tableId}` ${row.mode} • dealer $dealer (${row.dealerTotal}) • $results • pot **${row.pot}** (rake ${row.rake}) • _${ts}_"
+        }
+        return builder.setDescription(lines.joinToString("\n")).build()
+    }
+
+    private fun shortResult(name: String): String = when (name) {
+        "PLAYER_BLACKJACK" -> "🎉BJ"
+        "PLAYER_WIN" -> "✅"
+        "PUSH" -> "🤝"
+        "DEALER_WIN" -> "❌"
+        "PLAYER_BUST" -> "💥"
+        else -> name
+    }
+
+    private val HISTORY_TIME_FMT: DateTimeFormatter = DateTimeFormatter
+        .ofPattern("MMM d HH:mm")
+        .withZone(ZoneOffset.UTC)
 }

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/moderation/SetConfigCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/moderation/SetConfigCommand.kt
@@ -70,40 +70,40 @@ class SetConfigCommand @Autowired constructor(
                     config = ConfigDto.Configurations.TRADE_SELL_FEE_PCT, label = "sell"
                 )
                 ConfigDto.Configurations.POKER_RAKE_PCT -> setPokerRake(event, optionMapping, deleteDelay)
-                ConfigDto.Configurations.POKER_SMALL_BLIND -> setPokerLong(event, optionMapping, deleteDelay,
-                    config = ConfigDto.Configurations.POKER_SMALL_BLIND, label = "small blind", min = 1L)
-                ConfigDto.Configurations.POKER_BIG_BLIND -> setPokerLong(event, optionMapping, deleteDelay,
-                    config = ConfigDto.Configurations.POKER_BIG_BLIND, label = "big blind", min = 1L)
-                ConfigDto.Configurations.POKER_SMALL_BET -> setPokerLong(event, optionMapping, deleteDelay,
-                    config = ConfigDto.Configurations.POKER_SMALL_BET, label = "small bet", min = 1L)
-                ConfigDto.Configurations.POKER_BIG_BET -> setPokerLong(event, optionMapping, deleteDelay,
-                    config = ConfigDto.Configurations.POKER_BIG_BET, label = "big bet", min = 1L)
-                ConfigDto.Configurations.POKER_MIN_BUY_IN -> setPokerLong(event, optionMapping, deleteDelay,
-                    config = ConfigDto.Configurations.POKER_MIN_BUY_IN, label = "minimum buy-in", min = 1L)
-                ConfigDto.Configurations.POKER_MAX_BUY_IN -> setPokerLong(event, optionMapping, deleteDelay,
-                    config = ConfigDto.Configurations.POKER_MAX_BUY_IN, label = "maximum buy-in", min = 1L)
-                ConfigDto.Configurations.POKER_MAX_SEATS -> setPokerInt(event, optionMapping, deleteDelay,
-                    config = ConfigDto.Configurations.POKER_MAX_SEATS, label = "max seats", range = 2..9)
-                ConfigDto.Configurations.POKER_SHOT_CLOCK_SECONDS -> setPokerInt(event, optionMapping, deleteDelay,
-                    config = ConfigDto.Configurations.POKER_SHOT_CLOCK_SECONDS,
+                ConfigDto.Configurations.POKER_SMALL_BLIND -> setMinimumLongConfig(event, optionMapping, deleteDelay,
+                    config = ConfigDto.Configurations.POKER_SMALL_BLIND, gameLabel = "Poker", label = "small blind", min = 1L, unit = "chips")
+                ConfigDto.Configurations.POKER_BIG_BLIND -> setMinimumLongConfig(event, optionMapping, deleteDelay,
+                    config = ConfigDto.Configurations.POKER_BIG_BLIND, gameLabel = "Poker", label = "big blind", min = 1L, unit = "chips")
+                ConfigDto.Configurations.POKER_SMALL_BET -> setMinimumLongConfig(event, optionMapping, deleteDelay,
+                    config = ConfigDto.Configurations.POKER_SMALL_BET, gameLabel = "Poker", label = "small bet", min = 1L, unit = "chips")
+                ConfigDto.Configurations.POKER_BIG_BET -> setMinimumLongConfig(event, optionMapping, deleteDelay,
+                    config = ConfigDto.Configurations.POKER_BIG_BET, gameLabel = "Poker", label = "big bet", min = 1L, unit = "chips")
+                ConfigDto.Configurations.POKER_MIN_BUY_IN -> setMinimumLongConfig(event, optionMapping, deleteDelay,
+                    config = ConfigDto.Configurations.POKER_MIN_BUY_IN, gameLabel = "Poker", label = "minimum buy-in", min = 1L, unit = "chips")
+                ConfigDto.Configurations.POKER_MAX_BUY_IN -> setMinimumLongConfig(event, optionMapping, deleteDelay,
+                    config = ConfigDto.Configurations.POKER_MAX_BUY_IN, gameLabel = "Poker", label = "maximum buy-in", min = 1L, unit = "chips")
+                ConfigDto.Configurations.POKER_MAX_SEATS -> setRangedIntConfig(event, optionMapping, deleteDelay,
+                    config = ConfigDto.Configurations.POKER_MAX_SEATS, gameLabel = "Poker", label = "max seats", range = 2..9)
+                ConfigDto.Configurations.POKER_SHOT_CLOCK_SECONDS -> setRangedIntConfig(event, optionMapping, deleteDelay,
+                    config = ConfigDto.Configurations.POKER_SHOT_CLOCK_SECONDS, gameLabel = "Poker",
                     label = "shot-clock seconds", range = 0..600)
-                ConfigDto.Configurations.BLACKJACK_RAKE_PCT -> setBlackjackInt(event, optionMapping, deleteDelay,
-                    config = ConfigDto.Configurations.BLACKJACK_RAKE_PCT, label = "rake percent", range = 0..20)
-                ConfigDto.Configurations.BLACKJACK_MIN_ANTE -> setBlackjackLong(event, optionMapping, deleteDelay,
-                    config = ConfigDto.Configurations.BLACKJACK_MIN_ANTE, label = "minimum ante", min = 1L)
-                ConfigDto.Configurations.BLACKJACK_MAX_ANTE -> setBlackjackLong(event, optionMapping, deleteDelay,
-                    config = ConfigDto.Configurations.BLACKJACK_MAX_ANTE, label = "maximum ante", min = 1L)
-                ConfigDto.Configurations.BLACKJACK_MAX_SEATS -> setBlackjackInt(event, optionMapping, deleteDelay,
-                    config = ConfigDto.Configurations.BLACKJACK_MAX_SEATS, label = "max seats", range = 2..7)
-                ConfigDto.Configurations.BLACKJACK_SHOT_CLOCK_SECONDS -> setBlackjackInt(event, optionMapping, deleteDelay,
-                    config = ConfigDto.Configurations.BLACKJACK_SHOT_CLOCK_SECONDS,
+                ConfigDto.Configurations.BLACKJACK_RAKE_PCT -> setRangedIntConfig(event, optionMapping, deleteDelay,
+                    config = ConfigDto.Configurations.BLACKJACK_RAKE_PCT, gameLabel = "Blackjack", label = "rake percent", range = 0..20)
+                ConfigDto.Configurations.BLACKJACK_MIN_ANTE -> setMinimumLongConfig(event, optionMapping, deleteDelay,
+                    config = ConfigDto.Configurations.BLACKJACK_MIN_ANTE, gameLabel = "Blackjack", label = "minimum ante", min = 1L, unit = "credits")
+                ConfigDto.Configurations.BLACKJACK_MAX_ANTE -> setMinimumLongConfig(event, optionMapping, deleteDelay,
+                    config = ConfigDto.Configurations.BLACKJACK_MAX_ANTE, gameLabel = "Blackjack", label = "maximum ante", min = 1L, unit = "credits")
+                ConfigDto.Configurations.BLACKJACK_MAX_SEATS -> setRangedIntConfig(event, optionMapping, deleteDelay,
+                    config = ConfigDto.Configurations.BLACKJACK_MAX_SEATS, gameLabel = "Blackjack", label = "max seats", range = 2..7)
+                ConfigDto.Configurations.BLACKJACK_SHOT_CLOCK_SECONDS -> setRangedIntConfig(event, optionMapping, deleteDelay,
+                    config = ConfigDto.Configurations.BLACKJACK_SHOT_CLOCK_SECONDS, gameLabel = "Blackjack",
                     label = "shot-clock seconds", range = 0..600)
                 ConfigDto.Configurations.BLACKJACK_DEALER_HITS_SOFT_17 -> setBlackjackBool(event, optionMapping, deleteDelay)
-                ConfigDto.Configurations.BLACKJACK_BJ_PAYOUT_NUM -> setBlackjackInt(event, optionMapping, deleteDelay,
-                    config = ConfigDto.Configurations.BLACKJACK_BJ_PAYOUT_NUM,
+                ConfigDto.Configurations.BLACKJACK_BJ_PAYOUT_NUM -> setRangedIntConfig(event, optionMapping, deleteDelay,
+                    config = ConfigDto.Configurations.BLACKJACK_BJ_PAYOUT_NUM, gameLabel = "Blackjack",
                     label = "blackjack payout numerator", range = 1..10)
-                ConfigDto.Configurations.BLACKJACK_BJ_PAYOUT_DEN -> setBlackjackInt(event, optionMapping, deleteDelay,
-                    config = ConfigDto.Configurations.BLACKJACK_BJ_PAYOUT_DEN,
+                ConfigDto.Configurations.BLACKJACK_BJ_PAYOUT_DEN -> setRangedIntConfig(event, optionMapping, deleteDelay,
+                    config = ConfigDto.Configurations.BLACKJACK_BJ_PAYOUT_DEN, gameLabel = "Blackjack",
                     label = "blackjack payout denominator", range = 1..10)
                 ConfigDto.Configurations.UBI_DAILY_AMOUNT -> setUbiDailyAmount(event, optionMapping, deleteDelay)
                 ConfigDto.Configurations.DAILY_CREDIT_CAP -> setDailyCreditCap(event, optionMapping, deleteDelay)
@@ -111,43 +111,59 @@ class SetConfigCommand @Autowired constructor(
         }
     }
 
-    private fun setBlackjackInt(
+    /**
+     * Validate an integer config knob within an inclusive [range],
+     * persist it, and reply with a uniform "$gameLabel $label set to $value
+     * for new tables." message. Generic across the per-game integer
+     * settings (poker max seats, poker shot clock, blackjack max seats,
+     * blackjack rake percent, blackjack BJ payout num/den, etc.).
+     */
+    private fun setRangedIntConfig(
         event: SlashCommandInteractionEvent,
         optionMapping: OptionMapping,
         deleteDelay: Int,
         config: ConfigDto.Configurations,
+        gameLabel: String,
         label: String,
-        range: IntRange
+        range: IntRange,
     ) {
         val value = optionMapping.asInt
         if (value !in range) {
-            event.hook.sendMessage("Blackjack $label must be between ${range.first} and ${range.last}.")
+            event.hook.sendMessage("$gameLabel $label must be between ${range.first} and ${range.last}.")
                 .setEphemeral(true).queue(invokeDeleteOnMessageResponse(deleteDelay))
             return
         }
         val guildId = event.guild?.id ?: return
         configService.upsertConfig(config.configValue, value.toString(), guildId)
-        event.hook.sendMessage("Blackjack $label set to $value for new tables.")
+        event.hook.sendMessage("$gameLabel $label set to $value for new tables.")
             .queue(invokeDeleteOnMessageResponse(deleteDelay))
     }
 
-    private fun setBlackjackLong(
+    /**
+     * Validate a non-negative whole-number config knob with a floor of
+     * [min], persist it, and reply with a "$gameLabel $label set to
+     * $value $unit for new tables." message. Generic across poker chip
+     * thresholds (chips) and blackjack ante bounds (credits).
+     */
+    private fun setMinimumLongConfig(
         event: SlashCommandInteractionEvent,
         optionMapping: OptionMapping,
         deleteDelay: Int,
         config: ConfigDto.Configurations,
+        gameLabel: String,
         label: String,
-        min: Long
+        min: Long,
+        unit: String,
     ) {
         val value = optionMapping.asLong
         if (value < min) {
-            event.hook.sendMessage("Blackjack $label must be at least $min.")
+            event.hook.sendMessage("$gameLabel $label must be at least $min.")
                 .setEphemeral(true).queue(invokeDeleteOnMessageResponse(deleteDelay))
             return
         }
         val guildId = event.guild?.id ?: return
         configService.upsertConfig(config.configValue, value.toString(), guildId)
-        event.hook.sendMessage("Blackjack $label set to $value credits for new tables.")
+        event.hook.sendMessage("$gameLabel $label set to $value $unit for new tables.")
             .queue(invokeDeleteOnMessageResponse(deleteDelay))
     }
 
@@ -307,57 +323,6 @@ class SetConfigCommand @Autowired constructor(
         val guildId = event.guild?.id ?: return
         configService.upsertConfig(configValue, pct.toString(), guildId)
         event.hook.sendMessage("Poker rake set to $pct % of every settled pot.")
-            .queue(invokeDeleteOnMessageResponse(deleteDelay))
-    }
-
-    /**
-     * Shared "validate a non-negative whole-number poker config value
-     * within [[min], [Long.MAX_VALUE]] and persist it" helper. Each
-     * specific table-shape config (blind / bet / buy-in) only differs
-     * in the human-readable [label] and the floor; the message and
-     * upsert plumbing is the same.
-     */
-    private fun setPokerLong(
-        event: SlashCommandInteractionEvent,
-        optionMapping: OptionMapping,
-        deleteDelay: Int,
-        config: ConfigDto.Configurations,
-        label: String,
-        min: Long
-    ) {
-        val value = optionMapping.asLong
-        if (value < min) {
-            event.hook.sendMessage("Poker $label must be at least $min.")
-                .setEphemeral(true).queue(invokeDeleteOnMessageResponse(deleteDelay))
-            return
-        }
-        val guildId = event.guild?.id ?: return
-        configService.upsertConfig(config.configValue, value.toString(), guildId)
-        event.hook.sendMessage("Poker $label set to $value chips for new tables.")
-            .queue(invokeDeleteOnMessageResponse(deleteDelay))
-    }
-
-    /**
-     * As [setPokerLong] but for integer-bounded knobs (max seats,
-     * shot-clock seconds). The range is inclusive on both ends.
-     */
-    private fun setPokerInt(
-        event: SlashCommandInteractionEvent,
-        optionMapping: OptionMapping,
-        deleteDelay: Int,
-        config: ConfigDto.Configurations,
-        label: String,
-        range: IntRange
-    ) {
-        val value = optionMapping.asInt
-        if (value !in range) {
-            event.hook.sendMessage("Poker $label must be between ${range.first} and ${range.last}.")
-                .setEphemeral(true).queue(invokeDeleteOnMessageResponse(deleteDelay))
-            return
-        }
-        val guildId = event.guild?.id ?: return
-        configService.upsertConfig(config.configValue, value.toString(), guildId)
-        event.hook.sendMessage("Poker $label set to $value for new tables.")
             .queue(invokeDeleteOnMessageResponse(deleteDelay))
     }
 

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/moderation/SetConfigCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/moderation/SetConfigCommand.kt
@@ -87,10 +87,82 @@ class SetConfigCommand @Autowired constructor(
                 ConfigDto.Configurations.POKER_SHOT_CLOCK_SECONDS -> setPokerInt(event, optionMapping, deleteDelay,
                     config = ConfigDto.Configurations.POKER_SHOT_CLOCK_SECONDS,
                     label = "shot-clock seconds", range = 0..600)
+                ConfigDto.Configurations.BLACKJACK_RAKE_PCT -> setBlackjackInt(event, optionMapping, deleteDelay,
+                    config = ConfigDto.Configurations.BLACKJACK_RAKE_PCT, label = "rake percent", range = 0..20)
+                ConfigDto.Configurations.BLACKJACK_MIN_ANTE -> setBlackjackLong(event, optionMapping, deleteDelay,
+                    config = ConfigDto.Configurations.BLACKJACK_MIN_ANTE, label = "minimum ante", min = 1L)
+                ConfigDto.Configurations.BLACKJACK_MAX_ANTE -> setBlackjackLong(event, optionMapping, deleteDelay,
+                    config = ConfigDto.Configurations.BLACKJACK_MAX_ANTE, label = "maximum ante", min = 1L)
+                ConfigDto.Configurations.BLACKJACK_MAX_SEATS -> setBlackjackInt(event, optionMapping, deleteDelay,
+                    config = ConfigDto.Configurations.BLACKJACK_MAX_SEATS, label = "max seats", range = 2..7)
+                ConfigDto.Configurations.BLACKJACK_SHOT_CLOCK_SECONDS -> setBlackjackInt(event, optionMapping, deleteDelay,
+                    config = ConfigDto.Configurations.BLACKJACK_SHOT_CLOCK_SECONDS,
+                    label = "shot-clock seconds", range = 0..600)
+                ConfigDto.Configurations.BLACKJACK_DEALER_HITS_SOFT_17 -> setBlackjackBool(event, optionMapping, deleteDelay)
+                ConfigDto.Configurations.BLACKJACK_BJ_PAYOUT_NUM -> setBlackjackInt(event, optionMapping, deleteDelay,
+                    config = ConfigDto.Configurations.BLACKJACK_BJ_PAYOUT_NUM,
+                    label = "blackjack payout numerator", range = 1..10)
+                ConfigDto.Configurations.BLACKJACK_BJ_PAYOUT_DEN -> setBlackjackInt(event, optionMapping, deleteDelay,
+                    config = ConfigDto.Configurations.BLACKJACK_BJ_PAYOUT_DEN,
+                    label = "blackjack payout denominator", range = 1..10)
                 ConfigDto.Configurations.UBI_DAILY_AMOUNT -> setUbiDailyAmount(event, optionMapping, deleteDelay)
                 ConfigDto.Configurations.DAILY_CREDIT_CAP -> setDailyCreditCap(event, optionMapping, deleteDelay)
             }
         }
+    }
+
+    private fun setBlackjackInt(
+        event: SlashCommandInteractionEvent,
+        optionMapping: OptionMapping,
+        deleteDelay: Int,
+        config: ConfigDto.Configurations,
+        label: String,
+        range: IntRange
+    ) {
+        val value = optionMapping.asInt
+        if (value !in range) {
+            event.hook.sendMessage("Blackjack $label must be between ${range.first} and ${range.last}.")
+                .setEphemeral(true).queue(invokeDeleteOnMessageResponse(deleteDelay))
+            return
+        }
+        val guildId = event.guild?.id ?: return
+        configService.upsertConfig(config.configValue, value.toString(), guildId)
+        event.hook.sendMessage("Blackjack $label set to $value for new tables.")
+            .queue(invokeDeleteOnMessageResponse(deleteDelay))
+    }
+
+    private fun setBlackjackLong(
+        event: SlashCommandInteractionEvent,
+        optionMapping: OptionMapping,
+        deleteDelay: Int,
+        config: ConfigDto.Configurations,
+        label: String,
+        min: Long
+    ) {
+        val value = optionMapping.asLong
+        if (value < min) {
+            event.hook.sendMessage("Blackjack $label must be at least $min.")
+                .setEphemeral(true).queue(invokeDeleteOnMessageResponse(deleteDelay))
+            return
+        }
+        val guildId = event.guild?.id ?: return
+        configService.upsertConfig(config.configValue, value.toString(), guildId)
+        event.hook.sendMessage("Blackjack $label set to $value credits for new tables.")
+            .queue(invokeDeleteOnMessageResponse(deleteDelay))
+    }
+
+    private fun setBlackjackBool(
+        event: SlashCommandInteractionEvent,
+        optionMapping: OptionMapping,
+        deleteDelay: Int
+    ) {
+        val value = optionMapping.asBoolean
+        val configValue = ConfigDto.Configurations.BLACKJACK_DEALER_HITS_SOFT_17.configValue
+        val guildId = event.guild?.id ?: return
+        configService.upsertConfig(configValue, value.toString(), guildId)
+        val rule = if (value) "hit on soft 17 (H17)" else "stand on all 17 (S17)"
+        event.hook.sendMessage("Blackjack dealer will now $rule.")
+            .queue(invokeDeleteOnMessageResponse(deleteDelay))
     }
 
     private fun setLeaderboardChannel(event: SlashCommandInteractionEvent, deleteDelay: Int) {
@@ -466,6 +538,54 @@ class SetConfigCommand @Autowired constructor(
                 OptionType.INTEGER,
                 ConfigDto.Configurations.POKER_SHOT_CLOCK_SECONDS.name.lowercase(Locale.getDefault()),
                 "Per-actor decision deadline in seconds (0 disables). Default 30.",
+                false
+            ),
+            OptionData(
+                OptionType.INTEGER,
+                ConfigDto.Configurations.BLACKJACK_RAKE_PCT.name.lowercase(Locale.getDefault()),
+                "Percent (0-20) of every settled blackjack pot routed into the per-guild jackpot pool. Default 5.",
+                false
+            ),
+            OptionData(
+                OptionType.INTEGER,
+                ConfigDto.Configurations.BLACKJACK_MIN_ANTE.name.lowercase(Locale.getDefault()),
+                "Per-guild minimum blackjack ante (also the solo stake floor). Default 10.",
+                false
+            ),
+            OptionData(
+                OptionType.INTEGER,
+                ConfigDto.Configurations.BLACKJACK_MAX_ANTE.name.lowercase(Locale.getDefault()),
+                "Per-guild maximum blackjack ante (also the solo stake ceiling). Default 500.",
+                false
+            ),
+            OptionData(
+                OptionType.INTEGER,
+                ConfigDto.Configurations.BLACKJACK_MAX_SEATS.name.lowercase(Locale.getDefault()),
+                "Maximum players per blackjack multi table (2-7). Default 5.",
+                false
+            ),
+            OptionData(
+                OptionType.INTEGER,
+                ConfigDto.Configurations.BLACKJACK_SHOT_CLOCK_SECONDS.name.lowercase(Locale.getDefault()),
+                "Per-actor blackjack decision deadline in seconds (0 disables). Default 30.",
+                false
+            ),
+            OptionData(
+                OptionType.BOOLEAN,
+                ConfigDto.Configurations.BLACKJACK_DEALER_HITS_SOFT_17.name.lowercase(Locale.getDefault()),
+                "True = dealer hits soft 17 (H17). False = stands on all 17 (S17). Default false.",
+                false
+            ),
+            OptionData(
+                OptionType.INTEGER,
+                ConfigDto.Configurations.BLACKJACK_BJ_PAYOUT_NUM.name.lowercase(Locale.getDefault()),
+                "Natural blackjack payout numerator. Pair with denominator (e.g. 3 with 2 for 3:2). Default 3.",
+                false
+            ),
+            OptionData(
+                OptionType.INTEGER,
+                ConfigDto.Configurations.BLACKJACK_BJ_PAYOUT_DEN.name.lowercase(Locale.getDefault()),
+                "Natural blackjack payout denominator. Pair with numerator (e.g. 5 with 6 for 6:5). Default 2.",
                 false
             ),
             OptionData(

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/moderation/SetConfigCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/moderation/SetConfigCommand.kt
@@ -564,30 +564,12 @@ class SetConfigCommand @Autowired constructor(
                 "Maximum players per blackjack multi table (2-7). Default 5.",
                 false
             ),
-            OptionData(
-                OptionType.INTEGER,
-                ConfigDto.Configurations.BLACKJACK_SHOT_CLOCK_SECONDS.name.lowercase(Locale.getDefault()),
-                "Per-actor blackjack decision deadline in seconds (0 disables). Default 30.",
-                false
-            ),
-            OptionData(
-                OptionType.BOOLEAN,
-                ConfigDto.Configurations.BLACKJACK_DEALER_HITS_SOFT_17.name.lowercase(Locale.getDefault()),
-                "True = dealer hits soft 17 (H17). False = stands on all 17 (S17). Default false.",
-                false
-            ),
-            OptionData(
-                OptionType.INTEGER,
-                ConfigDto.Configurations.BLACKJACK_BJ_PAYOUT_NUM.name.lowercase(Locale.getDefault()),
-                "Natural blackjack payout numerator. Pair with denominator (e.g. 3 with 2 for 3:2). Default 3.",
-                false
-            ),
-            OptionData(
-                OptionType.INTEGER,
-                ConfigDto.Configurations.BLACKJACK_BJ_PAYOUT_DEN.name.lowercase(Locale.getDefault()),
-                "Natural blackjack payout denominator. Pair with numerator (e.g. 5 with 6 for 6:5). Default 2.",
-                false
-            ),
+            // BLACKJACK_SHOT_CLOCK_SECONDS, BLACKJACK_DEALER_HITS_SOFT_17,
+            // BLACKJACK_BJ_PAYOUT_NUM/DEN are intentionally NOT registered
+            // as /setconfig options because Discord caps a single slash
+            // command at 25 options total. They're still settable via the
+            // /moderation web tab (ModerationWebService.updateConfig) and
+            // their `when` validation in this file stays exhaustive.
             OptionData(
                 OptionType.INTEGER,
                 ConfigDto.Configurations.UBI_DAILY_AMOUNT.name.lowercase(Locale.getDefault()),

--- a/web/src/main/kotlin/web/controller/BlackjackController.kt
+++ b/web/src/main/kotlin/web/controller/BlackjackController.kt
@@ -27,6 +27,8 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseBody
 import org.springframework.web.servlet.mvc.support.RedirectAttributes
+import web.casino.CasinoOutcomeMapper
+import web.casino.CasinoResponseLike
 import web.service.BlackjackWebService
 import web.service.EconomyWebService
 import web.util.WebGuildAccess
@@ -66,6 +68,14 @@ class BlackjackController(
     private val userService: UserService,
     private val jda: JDA,
 ) {
+
+    /**
+     * Shared mapper from auth/guard rejections (401 / 403) and casino-
+     * style failure outcomes (insufficient credits / coins / invalid
+     * stake / unknown user) into [BlackjackActionResponse]. Mirrors the
+     * pattern HighlowController / SlotsController / etc. already use.
+     */
+    private val errors = CasinoOutcomeMapper { msg -> BlackjackActionResponse(ok = false, error = msg) }
 
     @GetMapping("/guilds")
     fun guildList(
@@ -177,7 +187,7 @@ class BlackjackController(
         @RequestBody request: BlackjackSoloDealRequest,
         @AuthenticationPrincipal user: OAuth2User,
     ): ResponseEntity<BlackjackActionResponse> = WebGuildAccess.requireMemberForJson(
-        user, guildId, economyWebService, errorBuilder = { errResp(it) }
+        user, guildId, economyWebService, errorBuilder = errors.errorBuilder
     ) { discordId ->
         when (val outcome = blackjackService.dealSolo(discordId, guildId, request.stake, request.autoTopUp)) {
             is SoloDealOutcome.Dealt -> ResponseEntity.ok(
@@ -198,14 +208,10 @@ class BlackjackController(
                     newPrice = outcome.newPrice
                 )
             )
-            is SoloDealOutcome.InvalidStake -> ResponseEntity.badRequest()
-                .body(BlackjackActionResponse(false, error = "Stake must be between ${outcome.min} and ${outcome.max}."))
-            is SoloDealOutcome.InsufficientCredits -> ResponseEntity.badRequest()
-                .body(BlackjackActionResponse(false, error = "Need ${outcome.stake} credits, you have ${outcome.have}."))
-            is SoloDealOutcome.InsufficientCoinsForTopUp -> ResponseEntity.badRequest()
-                .body(BlackjackActionResponse(false, error = "Auto-topup needs ${outcome.needed} TOBY, you have ${outcome.have}."))
-            SoloDealOutcome.UnknownUser -> ResponseEntity.badRequest()
-                .body(BlackjackActionResponse(false, error = "No user record yet — try another TobyBot command first."))
+            is SoloDealOutcome.InvalidStake -> errors.invalidStake(outcome.min, outcome.max)
+            is SoloDealOutcome.InsufficientCredits -> errors.insufficientCredits(outcome.stake, outcome.have)
+            is SoloDealOutcome.InsufficientCoinsForTopUp -> errors.insufficientCoinsForTopUp(outcome.needed, outcome.have)
+            SoloDealOutcome.UnknownUser -> errors.unknownUser()
         }
     }
 
@@ -216,14 +222,13 @@ class BlackjackController(
         @RequestBody request: BlackjackActionRequest,
         @AuthenticationPrincipal user: OAuth2User,
     ): ResponseEntity<BlackjackActionResponse> = WebGuildAccess.requireMemberForJson(
-        user, guildId, economyWebService, errorBuilder = { errResp(it) }
+        user, guildId, economyWebService, errorBuilder = errors.errorBuilder
     ) { discordId ->
         val tableId = findActiveSoloTable(guildId, discordId)
             ?: return@requireMemberForJson ResponseEntity.status(404)
                 .body(BlackjackActionResponse(false, error = "No active solo hand. Click Deal first."))
         val action = parseAction(request.action)
-            ?: return@requireMemberForJson ResponseEntity.badRequest()
-                .body(BlackjackActionResponse(false, error = "Unknown action: ${request.action}"))
+            ?: return@requireMemberForJson errors.badRequest("Unknown action: ${request.action}")
 
         when (val outcome = blackjackService.applySoloAction(discordId, guildId, tableId, action)) {
             is SoloActionOutcome.Continued -> ResponseEntity.ok(BlackjackActionResponse(ok = true, tableId = tableId))
@@ -242,10 +247,9 @@ class BlackjackController(
                 .body(BlackjackActionResponse(false, error = "Hand no longer exists."))
             SoloActionOutcome.NotYourHand -> ResponseEntity.status(403)
                 .body(BlackjackActionResponse(false, error = "This isn't your hand."))
-            SoloActionOutcome.IllegalAction -> ResponseEntity.badRequest()
-                .body(BlackjackActionResponse(false, error = "You can't do that right now."))
-            is SoloActionOutcome.InsufficientCreditsForDouble -> ResponseEntity.badRequest()
-                .body(BlackjackActionResponse(false, error = "Need ${outcome.needed} credits to double — you have ${outcome.have}."))
+            SoloActionOutcome.IllegalAction -> errors.badRequest("You can't do that right now.")
+            is SoloActionOutcome.InsufficientCreditsForDouble ->
+                errors.insufficientCredits(outcome.needed, outcome.have)
         }
     }
 
@@ -275,7 +279,7 @@ class BlackjackController(
         @RequestBody request: BlackjackCreateRequest,
         @AuthenticationPrincipal user: OAuth2User,
     ): ResponseEntity<BlackjackActionResponse> = WebGuildAccess.requireMemberForJson(
-        user, guildId, economyWebService, errorBuilder = { errResp(it) }
+        user, guildId, economyWebService, errorBuilder = errors.errorBuilder
     ) { discordId ->
         when (val outcome = blackjackService.createMultiTable(discordId, guildId, request.ante, request.autoTopUp)) {
             is MultiCreateOutcome.Ok -> ResponseEntity.ok(
@@ -286,14 +290,11 @@ class BlackjackController(
                     newPrice = outcome.newPrice
                 )
             )
-            is MultiCreateOutcome.InvalidAnte -> ResponseEntity.badRequest()
-                .body(BlackjackActionResponse(false, error = "Ante must be between ${outcome.min} and ${outcome.max}."))
-            is MultiCreateOutcome.InsufficientCredits -> ResponseEntity.badRequest()
-                .body(BlackjackActionResponse(false, error = "Need ${outcome.stake} credits, you have ${outcome.have}."))
-            is MultiCreateOutcome.InsufficientCoinsForTopUp -> ResponseEntity.badRequest()
-                .body(BlackjackActionResponse(false, error = "Auto-topup needs ${outcome.needed} TOBY, you have ${outcome.have}."))
-            MultiCreateOutcome.UnknownUser -> ResponseEntity.badRequest()
-                .body(BlackjackActionResponse(false, error = "No user record yet — try another TobyBot command first."))
+            is MultiCreateOutcome.InvalidAnte ->
+                errors.badRequest("Ante must be between ${outcome.min} and ${outcome.max}.")
+            is MultiCreateOutcome.InsufficientCredits -> errors.insufficientCredits(outcome.stake, outcome.have)
+            is MultiCreateOutcome.InsufficientCoinsForTopUp -> errors.insufficientCoinsForTopUp(outcome.needed, outcome.have)
+            MultiCreateOutcome.UnknownUser -> errors.unknownUser()
         }
     }
 
@@ -305,7 +306,7 @@ class BlackjackController(
         @RequestBody(required = false) request: BlackjackJoinRequest? = null,
         @AuthenticationPrincipal user: OAuth2User,
     ): ResponseEntity<BlackjackActionResponse> = WebGuildAccess.requireMemberForJson(
-        user, guildId, economyWebService, errorBuilder = { errResp(it) }
+        user, guildId, economyWebService, errorBuilder = errors.errorBuilder
     ) { discordId ->
         val autoTopUp = request?.autoTopUp ?: false
         when (val outcome = blackjackService.joinMultiTable(discordId, guildId, tableId, autoTopUp)) {
@@ -316,20 +317,15 @@ class BlackjackController(
                     newPrice = outcome.newPrice
                 )
             )
-            MultiJoinOutcome.AlreadySeated -> ResponseEntity.badRequest()
-                .body(BlackjackActionResponse(false, error = "You're already at this table."))
-            MultiJoinOutcome.TableFull -> ResponseEntity.badRequest()
-                .body(BlackjackActionResponse(false, error = "Table is full."))
+            MultiJoinOutcome.AlreadySeated -> errors.badRequest("You're already at this table.")
+            MultiJoinOutcome.TableFull -> errors.badRequest("Table is full.")
             MultiJoinOutcome.TableNotFound -> ResponseEntity.status(404)
                 .body(BlackjackActionResponse(false, error = "No such table."))
-            MultiJoinOutcome.HandInProgress -> ResponseEntity.badRequest()
-                .body(BlackjackActionResponse(false, error = "Wait for the current hand to end before joining."))
-            is MultiJoinOutcome.InsufficientCredits -> ResponseEntity.badRequest()
-                .body(BlackjackActionResponse(false, error = "Need ${outcome.stake} credits, you have ${outcome.have}."))
-            is MultiJoinOutcome.InsufficientCoinsForTopUp -> ResponseEntity.badRequest()
-                .body(BlackjackActionResponse(false, error = "Auto-topup needs ${outcome.needed} TOBY, you have ${outcome.have}."))
-            MultiJoinOutcome.UnknownUser -> ResponseEntity.badRequest()
-                .body(BlackjackActionResponse(false, error = "No user record yet — try another TobyBot command first."))
+            MultiJoinOutcome.HandInProgress ->
+                errors.badRequest("Wait for the current hand to end before joining.")
+            is MultiJoinOutcome.InsufficientCredits -> errors.insufficientCredits(outcome.stake, outcome.have)
+            is MultiJoinOutcome.InsufficientCoinsForTopUp -> errors.insufficientCoinsForTopUp(outcome.needed, outcome.have)
+            MultiJoinOutcome.UnknownUser -> errors.unknownUser()
         }
     }
 
@@ -340,16 +336,16 @@ class BlackjackController(
         @PathVariable tableId: Long,
         @AuthenticationPrincipal user: OAuth2User,
     ): ResponseEntity<BlackjackActionResponse> = WebGuildAccess.requireMemberForJson(
-        user, guildId, economyWebService, errorBuilder = { errResp(it) }
+        user, guildId, economyWebService, errorBuilder = errors.errorBuilder
     ) { discordId ->
         when (val outcome = blackjackService.startMultiHand(discordId, guildId, tableId)) {
             is MultiStartOutcome.Ok -> ResponseEntity.ok(
                 BlackjackActionResponse(ok = true, tableId = tableId, handNumber = outcome.handNumber)
             )
-            MultiStartOutcome.NotEnoughPlayers -> ResponseEntity.badRequest()
-                .body(BlackjackActionResponse(false, error = "Need at least ${Blackjack.MULTI_MIN_SEATS} seated players who can afford the ante."))
-            MultiStartOutcome.HandAlreadyInProgress -> ResponseEntity.badRequest()
-                .body(BlackjackActionResponse(false, error = "A hand is already in progress."))
+            MultiStartOutcome.NotEnoughPlayers ->
+                errors.badRequest("Need at least ${Blackjack.MULTI_MIN_SEATS} seated players who can afford the ante.")
+            MultiStartOutcome.HandAlreadyInProgress ->
+                errors.badRequest("A hand is already in progress.")
             MultiStartOutcome.NotHost -> ResponseEntity.status(403)
                 .body(BlackjackActionResponse(false, error = "Only the table host can deal hands."))
             MultiStartOutcome.TableNotFound -> ResponseEntity.status(404)
@@ -364,7 +360,7 @@ class BlackjackController(
         @PathVariable tableId: Long,
         @AuthenticationPrincipal user: OAuth2User,
     ): ResponseEntity<BlackjackActionResponse> = WebGuildAccess.requireMemberForJson(
-        user, guildId, economyWebService, errorBuilder = { errResp(it) }
+        user, guildId, economyWebService, errorBuilder = errors.errorBuilder
     ) { discordId ->
         when (val outcome = blackjackService.leaveMultiTable(discordId, guildId, tableId)) {
             is MultiLeaveOutcome.Ok -> ResponseEntity.ok(
@@ -373,10 +369,10 @@ class BlackjackController(
             is MultiLeaveOutcome.QueuedForEndOfHand -> ResponseEntity.ok(
                 BlackjackActionResponse(ok = true, tableId = tableId, refund = outcome.stakeHeld, queued = true)
             )
-            MultiLeaveOutcome.AlreadyLeaving -> ResponseEntity.badRequest()
-                .body(BlackjackActionResponse(false, error = "You've already asked to leave this hand."))
-            MultiLeaveOutcome.NotSeated -> ResponseEntity.badRequest()
-                .body(BlackjackActionResponse(false, error = "You're not seated at this table."))
+            MultiLeaveOutcome.AlreadyLeaving ->
+                errors.badRequest("You've already asked to leave this hand.")
+            MultiLeaveOutcome.NotSeated ->
+                errors.badRequest("You're not seated at this table.")
             MultiLeaveOutcome.TableNotFound -> ResponseEntity.status(404)
                 .body(BlackjackActionResponse(false, error = "No such table."))
         }
@@ -390,29 +386,24 @@ class BlackjackController(
         @RequestBody request: BlackjackActionRequest,
         @AuthenticationPrincipal user: OAuth2User,
     ): ResponseEntity<BlackjackActionResponse> = WebGuildAccess.requireMemberForJson(
-        user, guildId, economyWebService, errorBuilder = { errResp(it) }
+        user, guildId, economyWebService, errorBuilder = errors.errorBuilder
     ) { discordId ->
         val action = parseAction(request.action)
-            ?: return@requireMemberForJson ResponseEntity.badRequest()
-                .body(BlackjackActionResponse(false, error = "Unknown action: ${request.action}"))
+            ?: return@requireMemberForJson errors.badRequest("Unknown action: ${request.action}")
 
         when (val outcome = blackjackService.applyMultiAction(discordId, guildId, tableId, action)) {
             is MultiActionOutcome.Continued -> ResponseEntity.ok(BlackjackActionResponse(ok = true, tableId = tableId))
             is MultiActionOutcome.HandResolved -> ResponseEntity.ok(
                 BlackjackActionResponse(ok = true, tableId = tableId, resolved = true, handNumber = outcome.result.handNumber)
             )
-            MultiActionOutcome.NotYourTurn -> ResponseEntity.badRequest()
-                .body(BlackjackActionResponse(false, error = "It isn't your turn yet."))
-            MultiActionOutcome.NotSeated -> ResponseEntity.badRequest()
-                .body(BlackjackActionResponse(false, error = "You aren't seated at this table."))
-            MultiActionOutcome.NoHandInProgress -> ResponseEntity.badRequest()
-                .body(BlackjackActionResponse(false, error = "No hand in progress on this table."))
-            MultiActionOutcome.IllegalAction -> ResponseEntity.badRequest()
-                .body(BlackjackActionResponse(false, error = "You can't do that right now."))
+            MultiActionOutcome.NotYourTurn -> errors.badRequest("It isn't your turn yet.")
+            MultiActionOutcome.NotSeated -> errors.badRequest("You aren't seated at this table.")
+            MultiActionOutcome.NoHandInProgress -> errors.badRequest("No hand in progress on this table.")
+            MultiActionOutcome.IllegalAction -> errors.badRequest("You can't do that right now.")
             MultiActionOutcome.TableNotFound -> ResponseEntity.status(404)
                 .body(BlackjackActionResponse(false, error = "No such table."))
-            is MultiActionOutcome.InsufficientCreditsForDouble -> ResponseEntity.badRequest()
-                .body(BlackjackActionResponse(false, error = "Need ${outcome.needed} credits to double — you have ${outcome.have}."))
+            is MultiActionOutcome.InsufficientCreditsForDouble ->
+                errors.insufficientCredits(outcome.needed, outcome.have)
         }
     }
 
@@ -430,13 +421,6 @@ class BlackjackController(
         else -> null
     }
 
-    private fun errResp(status: Int): ResponseEntity<BlackjackActionResponse> =
-        ResponseEntity.status(status).body(
-            BlackjackActionResponse(
-                false,
-                error = if (status == 401) "Not signed in." else "You are not a member of that server."
-            )
-        )
 }
 
 data class BlackjackSoloDealRequest(val stake: Long = 0, val autoTopUp: Boolean = false)
@@ -445,8 +429,8 @@ data class BlackjackJoinRequest(val autoTopUp: Boolean = false)
 data class BlackjackActionRequest(val action: String = "")
 
 data class BlackjackActionResponse(
-    val ok: Boolean,
-    val error: String? = null,
+    override val ok: Boolean,
+    override val error: String? = null,
     val tableId: Long? = null,
     val resolved: Boolean? = null,
     val handNumber: Long? = null,
@@ -457,4 +441,4 @@ data class BlackjackActionResponse(
     val lossTribute: Long? = null,
     val soldTobyCoins: Long? = null,
     val newPrice: Double? = null,
-)
+) : CasinoResponseLike

--- a/web/src/main/kotlin/web/controller/BlackjackController.kt
+++ b/web/src/main/kotlin/web/controller/BlackjackController.kt
@@ -179,20 +179,31 @@ class BlackjackController(
     ): ResponseEntity<BlackjackActionResponse> = WebGuildAccess.requireMemberForJson(
         user, guildId, economyWebService, errorBuilder = { errResp(it) }
     ) { discordId ->
-        when (val outcome = blackjackService.dealSolo(discordId, guildId, request.stake)) {
-            is SoloDealOutcome.Dealt -> ResponseEntity.ok(BlackjackActionResponse(ok = true, tableId = outcome.tableId))
+        when (val outcome = blackjackService.dealSolo(discordId, guildId, request.stake, request.autoTopUp)) {
+            is SoloDealOutcome.Dealt -> ResponseEntity.ok(
+                BlackjackActionResponse(
+                    ok = true,
+                    tableId = outcome.tableId,
+                    soldTobyCoins = outcome.soldTobyCoins.takeIf { it > 0L },
+                    newPrice = outcome.newPrice
+                )
+            )
             is SoloDealOutcome.Resolved -> ResponseEntity.ok(
                 BlackjackActionResponse(
                     ok = true, tableId = outcome.tableId, resolved = true,
                     newBalance = outcome.newBalance,
                     jackpotPayout = outcome.jackpotPayout.takeIf { it > 0L },
-                    lossTribute = outcome.lossTribute.takeIf { it > 0L }
+                    lossTribute = outcome.lossTribute.takeIf { it > 0L },
+                    soldTobyCoins = outcome.soldTobyCoins.takeIf { it > 0L },
+                    newPrice = outcome.newPrice
                 )
             )
             is SoloDealOutcome.InvalidStake -> ResponseEntity.badRequest()
                 .body(BlackjackActionResponse(false, error = "Stake must be between ${outcome.min} and ${outcome.max}."))
             is SoloDealOutcome.InsufficientCredits -> ResponseEntity.badRequest()
                 .body(BlackjackActionResponse(false, error = "Need ${outcome.stake} credits, you have ${outcome.have}."))
+            is SoloDealOutcome.InsufficientCoinsForTopUp -> ResponseEntity.badRequest()
+                .body(BlackjackActionResponse(false, error = "Auto-topup needs ${outcome.needed} TOBY, you have ${outcome.have}."))
             SoloDealOutcome.UnknownUser -> ResponseEntity.badRequest()
                 .body(BlackjackActionResponse(false, error = "No user record yet — try another TobyBot command first."))
         }
@@ -266,12 +277,21 @@ class BlackjackController(
     ): ResponseEntity<BlackjackActionResponse> = WebGuildAccess.requireMemberForJson(
         user, guildId, economyWebService, errorBuilder = { errResp(it) }
     ) { discordId ->
-        when (val outcome = blackjackService.createMultiTable(discordId, guildId, request.ante)) {
-            is MultiCreateOutcome.Ok -> ResponseEntity.ok(BlackjackActionResponse(ok = true, tableId = outcome.tableId))
+        when (val outcome = blackjackService.createMultiTable(discordId, guildId, request.ante, request.autoTopUp)) {
+            is MultiCreateOutcome.Ok -> ResponseEntity.ok(
+                BlackjackActionResponse(
+                    ok = true,
+                    tableId = outcome.tableId,
+                    soldTobyCoins = outcome.soldTobyCoins.takeIf { it > 0L },
+                    newPrice = outcome.newPrice
+                )
+            )
             is MultiCreateOutcome.InvalidAnte -> ResponseEntity.badRequest()
                 .body(BlackjackActionResponse(false, error = "Ante must be between ${outcome.min} and ${outcome.max}."))
             is MultiCreateOutcome.InsufficientCredits -> ResponseEntity.badRequest()
                 .body(BlackjackActionResponse(false, error = "Need ${outcome.stake} credits, you have ${outcome.have}."))
+            is MultiCreateOutcome.InsufficientCoinsForTopUp -> ResponseEntity.badRequest()
+                .body(BlackjackActionResponse(false, error = "Auto-topup needs ${outcome.needed} TOBY, you have ${outcome.have}."))
             MultiCreateOutcome.UnknownUser -> ResponseEntity.badRequest()
                 .body(BlackjackActionResponse(false, error = "No user record yet — try another TobyBot command first."))
         }
@@ -282,13 +302,19 @@ class BlackjackController(
     fun join(
         @PathVariable guildId: Long,
         @PathVariable tableId: Long,
+        @RequestBody(required = false) request: BlackjackJoinRequest? = null,
         @AuthenticationPrincipal user: OAuth2User,
     ): ResponseEntity<BlackjackActionResponse> = WebGuildAccess.requireMemberForJson(
         user, guildId, economyWebService, errorBuilder = { errResp(it) }
     ) { discordId ->
-        when (val outcome = blackjackService.joinMultiTable(discordId, guildId, tableId)) {
+        val autoTopUp = request?.autoTopUp ?: false
+        when (val outcome = blackjackService.joinMultiTable(discordId, guildId, tableId, autoTopUp)) {
             is MultiJoinOutcome.Ok -> ResponseEntity.ok(
-                BlackjackActionResponse(ok = true, tableId = tableId, newBalance = outcome.newBalance)
+                BlackjackActionResponse(
+                    ok = true, tableId = tableId, newBalance = outcome.newBalance,
+                    soldTobyCoins = outcome.soldTobyCoins.takeIf { it > 0L },
+                    newPrice = outcome.newPrice
+                )
             )
             MultiJoinOutcome.AlreadySeated -> ResponseEntity.badRequest()
                 .body(BlackjackActionResponse(false, error = "You're already at this table."))
@@ -300,6 +326,8 @@ class BlackjackController(
                 .body(BlackjackActionResponse(false, error = "Wait for the current hand to end before joining."))
             is MultiJoinOutcome.InsufficientCredits -> ResponseEntity.badRequest()
                 .body(BlackjackActionResponse(false, error = "Need ${outcome.stake} credits, you have ${outcome.have}."))
+            is MultiJoinOutcome.InsufficientCoinsForTopUp -> ResponseEntity.badRequest()
+                .body(BlackjackActionResponse(false, error = "Auto-topup needs ${outcome.needed} TOBY, you have ${outcome.have}."))
             MultiJoinOutcome.UnknownUser -> ResponseEntity.badRequest()
                 .body(BlackjackActionResponse(false, error = "No user record yet — try another TobyBot command first."))
         }
@@ -411,8 +439,9 @@ class BlackjackController(
         )
 }
 
-data class BlackjackSoloDealRequest(val stake: Long = 0)
-data class BlackjackCreateRequest(val ante: Long = 0)
+data class BlackjackSoloDealRequest(val stake: Long = 0, val autoTopUp: Boolean = false)
+data class BlackjackCreateRequest(val ante: Long = 0, val autoTopUp: Boolean = false)
+data class BlackjackJoinRequest(val autoTopUp: Boolean = false)
 data class BlackjackActionRequest(val action: String = "")
 
 data class BlackjackActionResponse(
@@ -426,4 +455,6 @@ data class BlackjackActionResponse(
     val queued: Boolean? = null,
     val jackpotPayout: Long? = null,
     val lossTribute: Long? = null,
+    val soldTobyCoins: Long? = null,
+    val newPrice: Double? = null,
 )

--- a/web/src/main/kotlin/web/service/ModerationWebService.kt
+++ b/web/src/main/kotlin/web/service/ModerationWebService.kt
@@ -336,6 +336,43 @@ class ModerationWebService(
                 if (n !in 0..600) return "Value must be between 0 and 600 seconds."
                 n.toString()
             }
+            ConfigDto.Configurations.BLACKJACK_RAKE_PCT -> {
+                val n = rawValue.trim().toIntOrNull()
+                    ?: return "Value must be a whole number percentage (0-20)."
+                if (n !in 0..20) return "Value must be between 0 and 20 (capped server-side)."
+                n.toString()
+            }
+            ConfigDto.Configurations.BLACKJACK_MIN_ANTE,
+            ConfigDto.Configurations.BLACKJACK_MAX_ANTE -> {
+                val n = rawValue.trim().toLongOrNull()
+                    ?: return "Value must be a whole number of credits."
+                if (n < 1L) return "Value must be at least 1 credit."
+                n.toString()
+            }
+            ConfigDto.Configurations.BLACKJACK_MAX_SEATS -> {
+                val n = rawValue.trim().toIntOrNull()
+                    ?: return "Value must be a whole number."
+                if (n !in 2..7) return "Value must be between 2 and 7 seats."
+                n.toString()
+            }
+            ConfigDto.Configurations.BLACKJACK_SHOT_CLOCK_SECONDS -> {
+                val n = rawValue.trim().toIntOrNull()
+                    ?: return "Value must be a whole number of seconds."
+                if (n !in 0..600) return "Value must be between 0 and 600 seconds."
+                n.toString()
+            }
+            ConfigDto.Configurations.BLACKJACK_DEALER_HITS_SOFT_17 -> {
+                val v = rawValue.trim().lowercase()
+                if (v !in setOf("true", "false")) return "Value must be true or false."
+                v
+            }
+            ConfigDto.Configurations.BLACKJACK_BJ_PAYOUT_NUM,
+            ConfigDto.Configurations.BLACKJACK_BJ_PAYOUT_DEN -> {
+                val n = rawValue.trim().toIntOrNull()
+                    ?: return "Value must be a whole number (1-10)."
+                if (n !in 1..10) return "Value must be between 1 and 10."
+                n.toString()
+            }
             ConfigDto.Configurations.UBI_DAILY_AMOUNT -> {
                 val n = rawValue.trim().toIntOrNull()
                     ?: return "Value must be a whole number (0-1000)."


### PR DESCRIPTION
## Summary

Three follow-ups on the merged blackjack feature, bundled into one PR because they all touch `BlackjackService`.

### 1. Per-guild config (`BLACKJACK_*`)

New config keys: `BLACKJACK_RAKE_PCT`, `BLACKJACK_MIN_ANTE`, `BLACKJACK_MAX_ANTE`, `BLACKJACK_MAX_SEATS`, `BLACKJACK_SHOT_CLOCK_SECONDS`, `BLACKJACK_DEALER_HITS_SOFT_17`, `BLACKJACK_BJ_PAYOUT_NUM/DEN`. `BlackjackService.readMultiTableParams` snapshots them at table-create time so a mid-hand admin tweak can't change rules under an in-flight game. Engine refactored: `playOutDealer` now takes `hitsSoft17`, `multiplier` takes `blackjackPayoutMultiplier`; both default to the v1 hardcoded behaviour. New `BlackjackTable.TableRules` carries the per-table snapshot. Validation for the new keys lives in `ModerationWebService` so admins can tune them via the moderation web tab.

### 2. Auto-topup (TOBY → credits)

`/blackjack solo|create|join` now accept an `auto_topup:true` boolean that sells just enough TOBY at the live market price to cover any credit shortfall, mirroring the existing `/poker` / `/highlow` / `/slots` pattern via `CasinoTopUpHelper`. New `*Outcome.InsufficientCoinsForTopUp` variants surface when the player doesn't have enough TOBY either. `tradeService` + `marketService` injected as `@Autowired(required=false)` so unit tests without a Spring context still construct cleanly.

### 3. Hand history (`/blackjack history`)

New `blackjack_hand_log` table (Flyway V25) with one row per resolved hand (solo or multi). `BlackjackHandLogDto` + persistence interface + `DefaultBlackjackHandLogPersistence` mirror the poker shape. Service appends a row at every settle path (solo natural-BJ short-circuit, solo action resolution, multi `resolveMultiHand`). New `/blackjack history [table:n] [limit:m]` subcommand renders the recent rows, capped at `HISTORY_MAX_LIMIT` (25).

## Test plan

- [x] Database tests pass (existing tests still green, mocks updated for the new `multiplier(result, mult)` signature)
- [x] Web compiles (incl. `:web:compileTestKotlin`)
- [ ] CI to validate `:discord-bot:test` and `:application:test` (the latter has no new buttons/commands so its inventory tests should still match)
- [ ] Manual: set `BLACKJACK_BJ_PAYOUT_NUM=6 / _DEN=5` in a guild, play a natural BJ, confirm 6:5 payout
- [ ] Manual: `/blackjack solo stake:1000 auto_topup:true` with credits short, confirm TOBY sale and hand deal
- [ ] Manual: play a hand, then `/blackjack history` shows it; play several, scope by `table:n`

https://claude.ai/code/session_012gsr3GLkqEs449fdgLDLL6

---
_Generated by [Claude Code](https://claude.ai/code/session_012gsr3GLkqEs449fdgLDLL6)_