### PR TITLE
fix(blackjack web): CSRF on POSTs + navbar entry

### DIFF
--- a/web/src/main/resources/static/js/blackjack-lobby.js
+++ b/web/src/main/resources/static/js/blackjack-lobby.js
@@ -18,18 +18,16 @@
     createForm.addEventListener("submit", function (e) {
         e.preventDefault();
         var ante = parseInt(anteInput.value, 10);
-        fetch("/blackjack/" + guildId + "/create", {
-            method: "POST",
-            credentials: "same-origin",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ ante: ante })
-        }).then(function (r) { return r.json().then(function (b) { return { r: r, b: b }; }); })
-          .then(function (rb) {
-              if (!rb.r.ok || !rb.b.ok) {
-                  window.toasts && window.toasts.error(rb.b.error || "Create failed.");
-                  return;
-              }
-              window.location.href = "/blackjack/" + guildId + "/" + rb.b.tableId;
-          });
+        // POSTs go via TobyApi.postJson so the Spring Security CSRF
+        // header (read off the <meta name="_csrf"> tag in the head
+        // fragment) is included — without it Spring rejects with 403.
+        window.TobyApi.postJson("/blackjack/" + guildId + "/create", { ante: ante })
+            .then(function (b) {
+                if (!b.ok) {
+                    window.toasts && window.toasts.error(b.error || "Create failed.");
+                    return;
+                }
+                window.location.href = "/blackjack/" + guildId + "/" + b.tableId;
+            });
     });
 })();

--- a/web/src/main/resources/static/js/blackjack-solo.js
+++ b/web/src/main/resources/static/js/blackjack-solo.js
@@ -133,44 +133,38 @@
         e.preventDefault();
         var stake = parseInt(stakeInput.value, 10);
         if (!stake) return;
-        fetch("/blackjack/" + guildId + "/solo/deal", {
-            method: "POST",
-            credentials: "same-origin",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ stake: stake })
-        }).then(function (r) { return r.json().then(function (b) { return { r: r, b: b }; }); })
-          .then(function (rb) {
-              if (!rb.r.ok || !rb.b.ok) {
-                  window.toasts && window.toasts.error(rb.b.error || "Deal failed.");
-                  return;
-              }
-              if (rb.b.resolved) {
-                  setBalance(rb.b.newBalance);
-                  refreshState();
-              } else {
-                  refreshState();
-                  startPoll();
-              }
-          });
+        // POSTs go via TobyApi.postJson so the Spring Security CSRF
+        // header (read off the <meta name="_csrf"> tag in the head
+        // fragment) is included — without it Spring rejects the request
+        // with 403.
+        window.TobyApi.postJson("/blackjack/" + guildId + "/solo/deal", { stake: stake })
+            .then(function (b) {
+                if (!b.ok) {
+                    window.toasts && window.toasts.error(b.error || "Deal failed.");
+                    return;
+                }
+                if (b.resolved) {
+                    setBalance(b.newBalance);
+                    refreshState();
+                } else {
+                    refreshState();
+                    startPoll();
+                }
+            });
     });
 
     function postAction(action) {
-        return fetch("/blackjack/" + guildId + "/solo/action", {
-            method: "POST",
-            credentials: "same-origin",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ action: action })
-        }).then(function (r) { return r.json().then(function (b) { return { r: r, b: b }; }); })
-          .then(function (rb) {
-              if (!rb.r.ok || !rb.b.ok) {
-                  window.toasts && window.toasts.error(rb.b.error || "Action failed.");
-                  return;
-              }
-              if (rb.b.resolved) {
-                  setBalance(rb.b.newBalance);
-              }
-              refreshState();
-          });
+        return window.TobyApi.postJson("/blackjack/" + guildId + "/solo/action", { action: action })
+            .then(function (b) {
+                if (!b.ok) {
+                    window.toasts && window.toasts.error(b.error || "Action failed.");
+                    return;
+                }
+                if (b.resolved) {
+                    setBalance(b.newBalance);
+                }
+                refreshState();
+            });
     }
 
     hitBtn.addEventListener("click", function () { postAction("hit"); });

--- a/web/src/main/resources/static/js/blackjack-table.js
+++ b/web/src/main/resources/static/js/blackjack-table.js
@@ -178,20 +178,18 @@
             .catch(function (e) { console.warn("state poll failed", e); });
     }
 
+    // POSTs go via TobyApi.postJson so the Spring Security CSRF header
+    // (read off the <meta name="_csrf"> tag in the head fragment) is
+    // included — without it Spring rejects the request with 403.
     function postAction(action) {
-        return fetch("/blackjack/" + guildId + "/" + tableId + "/action", {
-            method: "POST",
-            credentials: "same-origin",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ action: action })
-        }).then(function (r) { return r.json().then(function (b) { return { r: r, b: b }; }); })
-          .then(function (rb) {
-              if (!rb.r.ok || !rb.b.ok) {
-                  window.toasts && window.toasts.error(rb.b.error || "Action failed.");
-                  return;
-              }
-              refreshState();
-          });
+        return window.TobyApi.postJson("/blackjack/" + guildId + "/" + tableId + "/action", { action: action })
+            .then(function (b) {
+                if (!b.ok) {
+                    window.toasts && window.toasts.error(b.error || "Action failed.");
+                    return;
+                }
+                refreshState();
+            });
     }
 
     hitBtn.addEventListener("click", function () { postAction("hit"); });
@@ -199,48 +197,42 @@
     doubleBtn.addEventListener("click", function () { postAction("double"); });
 
     startBtn.addEventListener("click", function () {
-        fetch("/blackjack/" + guildId + "/" + tableId + "/start", {
-            method: "POST", credentials: "same-origin"
-        }).then(function (r) { return r.json().then(function (b) { return { r: r, b: b }; }); })
-          .then(function (rb) {
-              if (!rb.r.ok || !rb.b.ok) {
-                  window.toasts && window.toasts.error(rb.b.error || "Start failed.");
-                  return;
-              }
-              refreshState();
-          });
+        window.TobyApi.postJson("/blackjack/" + guildId + "/" + tableId + "/start", {})
+            .then(function (b) {
+                if (!b.ok) {
+                    window.toasts && window.toasts.error(b.error || "Start failed.");
+                    return;
+                }
+                refreshState();
+            });
     });
 
     joinBtn.addEventListener("click", function () {
-        fetch("/blackjack/" + guildId + "/" + tableId + "/join", {
-            method: "POST", credentials: "same-origin"
-        }).then(function (r) { return r.json().then(function (b) { return { r: r, b: b }; }); })
-          .then(function (rb) {
-              if (!rb.r.ok || !rb.b.ok) {
-                  window.toasts && window.toasts.error(rb.b.error || "Join failed.");
-                  return;
-              }
-              refreshState();
-          });
+        window.TobyApi.postJson("/blackjack/" + guildId + "/" + tableId + "/join", {})
+            .then(function (b) {
+                if (!b.ok) {
+                    window.toasts && window.toasts.error(b.error || "Join failed.");
+                    return;
+                }
+                refreshState();
+            });
     });
 
     leaveBtn.addEventListener("click", function () {
-        fetch("/blackjack/" + guildId + "/" + tableId + "/leave", {
-            method: "POST", credentials: "same-origin"
-        }).then(function (r) { return r.json().then(function (b) { return { r: r, b: b }; }); })
-          .then(function (rb) {
-              if (!rb.r.ok || !rb.b.ok) {
-                  window.toasts && window.toasts.error(rb.b.error || "Leave failed.");
-                  return;
-              }
-              if (rb.b.queued) {
-                  window.toasts && window.toasts.info("Leaving — you'll auto-stand and be removed at end of hand.");
-              } else {
-                  window.toasts && window.toasts.info("Cashed out " + rb.b.refund + " credits.");
-                  setTimeout(function () { window.location.href = "/blackjack/" + guildId; }, 800);
-              }
-              refreshState();
-          });
+        window.TobyApi.postJson("/blackjack/" + guildId + "/" + tableId + "/leave", {})
+            .then(function (b) {
+                if (!b.ok) {
+                    window.toasts && window.toasts.error(b.error || "Leave failed.");
+                    return;
+                }
+                if (b.queued) {
+                    window.toasts && window.toasts.info("Leaving — you'll auto-stand and be removed at end of hand.");
+                } else {
+                    window.toasts && window.toasts.info("Cashed out " + b.refund + " credits.");
+                    setTimeout(function () { window.location.href = "/blackjack/" + guildId; }, 800);
+                }
+                refreshState();
+            });
     });
 
     refreshState();

--- a/web/src/main/resources/templates/fragments/navbar.html
+++ b/web/src/main/resources/templates/fragments/navbar.html
@@ -39,6 +39,7 @@
                 <a href="/casino/guilds" role="menuitem">&#127183; High-Low</a>
                 <a href="/casino/guilds" role="menuitem">&#127903;&#65039; Scratch</a>
                 <a href="/poker/guilds" role="menuitem">&#127924; Poker</a>
+                <a href="/blackjack/guilds" role="menuitem">&#127922; Blackjack</a>
             </div>
         </div>
         <a href="/intro/guilds">Intro Songs</a>


### PR DESCRIPTION
## Summary

Hotfix for the production 403 the user just hit:

> May 02 06:39:39 toby-bot heroku/router at=info method=POST path="/blackjack/.../solo/deal" ... status=403

Spring Security has CSRF enabled for all routes except `/v3/api-docs/**` and `/swagger-ui/**`. The other casino games avoid 403s by going through the existing `TobyApi.postJson()` helper in `api.js`, which reads the CSRF token off the `<meta name="_csrf">` tag injected by the head fragment and adds the `X-CSRF-TOKEN` header. My new blackjack JS used raw `fetch()` without that, so every POST was rejected.

This PR switches all blackjack POST sites (`blackjack-solo.js`, `blackjack-table.js`, `blackjack-lobby.js`) to `TobyApi.postJson`. GET state polls stay as raw fetch (CSRF only matters for state-changing methods). Also cleans up a couple of broken `rb.b.error` / `rb.r.ok` references that pre-dated this change but were never reached because the POST never landed.

**Drive-by:** add a Blackjack entry to the Casino dropdown in the navbar fragment — it was missing, so the only way to reach `/blackjack/guilds` was via the casino-guilds card grid or a direct URL.

## Test plan

- [x] `:web:test` passes
- [ ] Manual: load `/blackjack/{guildId}/solo`, click Deal — should now succeed instead of 403
- [ ] Manual: navbar Casino dropdown shows "🎲 Blackjack" → `/blackjack/guilds`

The much-larger `/blackjack split` follow-up I started will go on its own branch — that work is paused so this CSRF fix can ship immediately.

https://claude.ai/code/session_012gsr3GLkqEs449fdgLDLL6

---
_Generated by [Claude Code](https://claude.ai/code/session_012gsr3GLkqEs449fdgLDLL6)_