### PR TITLE
feat(blackjack): pair split (engine + service + Discord + web UI)

### DIFF
--- a/database/src/main/kotlin/database/blackjack/Blackjack.kt
+++ b/database/src/main/kotlin/database/blackjack/Blackjack.kt
@@ -27,7 +27,7 @@ import kotlin.random.Random
  */
 class Blackjack(private val random: Random = Random.Default) {
 
-    enum class Action { HIT, STAND, DOUBLE }
+    enum class Action { HIT, STAND, DOUBLE, SPLIT }
 
     enum class Result {
         PLAYER_BLACKJACK,
@@ -89,10 +89,15 @@ class Blackjack(private val random: Random = Random.Default) {
      *   - dealer blackjack alone wins (player loses 1:1)
      *   - dealer bust → player wins 1:1
      *   - else compare totals
+     *
+     * [fromSplit] suppresses the natural-blackjack premium when the
+     * player's hand was created by splitting a pair. Standard rules:
+     * a 21 on a split hand pays 1:1, not 3:2 — even if the cards are
+     * an Ace plus a ten-value (which would otherwise be a natural).
      */
-    fun evaluate(player: List<Card>, dealer: List<Card>): Result {
+    fun evaluate(player: List<Card>, dealer: List<Card>, fromSplit: Boolean = false): Result {
         if (isBust(player)) return Result.PLAYER_BUST
-        val playerBJ = isBlackjack(player)
+        val playerBJ = !fromSplit && isBlackjack(player)
         val dealerBJ = isBlackjack(dealer)
         if (playerBJ && dealerBJ) return Result.PUSH
         if (playerBJ) return Result.PLAYER_BLACKJACK
@@ -139,6 +144,15 @@ class Blackjack(private val random: Random = Random.Default) {
 
         /** Fraction of a multiplayer pot routed to the jackpot pool. */
         const val MULTI_RAKE: Double = 0.05
+
+        /**
+         * Maximum number of hand-slots a single seat can hold after
+         * splitting. The classic blackjack cap is 4 (split → re-split
+         * → re-split again, giving at most 4 parallel hands). Split-aces
+         * specifically can't be re-split here either way; this is the
+         * absolute ceiling enforced by the SPLIT pre-check.
+         */
+        const val MAX_SPLIT_HANDS: Int = 4
 
         /**
          * Per-actor decision deadline for multi tables. Auto-stands the

--- a/database/src/main/kotlin/database/blackjack/BlackjackHand.kt
+++ b/database/src/main/kotlin/database/blackjack/BlackjackHand.kt
@@ -62,3 +62,19 @@ fun isBust(hand: List<Card>): Boolean = bestTotal(hand) > 21
  */
 fun isBlackjack(hand: List<Card>): Boolean =
     hand.size == 2 && bestTotal(hand) == 21
+
+/**
+ * True iff [hand] is a pair eligible for splitting: exactly two cards
+ * with the same blackjack value. Tens, jacks, queens and kings all
+ * count as 10, so K-J is splittable. The seat's `doubled` and split
+ * eligibility (DAS gating, re-split caps) are caller concerns —
+ * this helper is purely about the cards.
+ */
+fun canSplit(hand: List<Card>): Boolean {
+    if (hand.size != 2) return false
+    val a = hand[0]
+    val b = hand[1]
+    val av = if (a.rank == Rank.ACE) 11 else a.blackjackValues().first()
+    val bv = if (b.rank == Rank.ACE) 11 else b.blackjackValues().first()
+    return av == bv
+}

--- a/database/src/main/kotlin/database/blackjack/BlackjackTable.kt
+++ b/database/src/main/kotlin/database/blackjack/BlackjackTable.kt
@@ -93,15 +93,41 @@ class BlackjackTable(
         BLACKJACK
     }
 
-    class Seat(
-        val discordId: Long,
-        var hand: MutableList<Card> = mutableListOf(),
-        /** What the seat originally bet for this hand (pre-double). */
-        var ante: Long = 0L,
-        /** Current at-risk stake — equals [ante] unless the seat doubled. */
+    /**
+     * One hand belonging to a seat. v1 always had exactly one hand per
+     * seat; with split support a seat now holds a list of hand slots,
+     * one per split branch (so 2 after a split, 3 after re-splitting,
+     * etc.). Each slot carries its own stake, doubled flag, status, and
+     * a "from split" marker so resolution can distinguish a true natural
+     * 21 from a 21 reached by drawing onto a split.
+     */
+    class HandSlot(
+        var cards: MutableList<Card> = mutableListOf(),
+        /** Doubled-aware at-risk stake for this specific hand. */
         var stake: Long = 0L,
         var doubled: Boolean = false,
         var status: SeatStatus = SeatStatus.ACTIVE,
+        /**
+         * True if this slot was created by [database.service.BlackjackService]
+         * splitting a pair. Two-card 21s on a split hand pay 1:1, not
+         * 3:2 — the natural-blackjack premium only applies to the
+         * originally-dealt pair.
+         */
+        var fromSplit: Boolean = false,
+    )
+
+    class Seat private constructor(
+        val discordId: Long,
+        /** What the seat originally bet for this hand (pre-double, pre-split). */
+        val ante: Long,
+        /**
+         * One slot per split branch; ≥1 entry. v1 single-hand play
+         * always uses [hands][0]. After the first split there are 2;
+         * after re-splitting there can be more.
+         */
+        val hands: MutableList<HandSlot>,
+        /** Index into [hands] of which split hand is currently in play. */
+        var activeHandIndex: Int = 0,
         /**
          * Set when a seated player asks to leave during a hand (multi
          * mode only). Honoured by [database.service.BlackjackService] —
@@ -110,22 +136,106 @@ class BlackjackTable(
          * Stays `false` for between-hand `/blackjack leave`, which goes
          * through the immediate-removal path.
          */
-        var pendingLeave: Boolean = false
+        var pendingLeave: Boolean = false,
     ) {
-        /** True once the seat can no longer take an action this hand. */
+        /**
+         * Convenience constructor preserving the v1 single-hand shape so
+         * existing call sites that construct a `Seat(discordId, hand,
+         * ante, stake, doubled, status)` keep compiling. The [hand] /
+         * [stake] / [doubled] / [status] arguments populate the seat's
+         * single initial [HandSlot].
+         */
+        constructor(
+            discordId: Long,
+            hand: MutableList<Card> = mutableListOf(),
+            ante: Long = 0L,
+            stake: Long = 0L,
+            doubled: Boolean = false,
+            status: SeatStatus = SeatStatus.ACTIVE,
+            pendingLeave: Boolean = false,
+        ) : this(
+            discordId = discordId,
+            ante = ante,
+            hands = mutableListOf(
+                HandSlot(cards = hand, stake = stake, doubled = doubled, status = status)
+            ),
+            activeHandIndex = 0,
+            pendingLeave = pendingLeave,
+        )
+
+        /** The currently-active hand slot — the one accepting actions. */
+        val activeHand: HandSlot get() = hands[activeHandIndex]
+
+        // Backwards-compat accessors that delegate to [activeHand] so v1
+        // single-hand code (most of the service) can keep using
+        // `seat.hand`, `seat.stake`, etc. without spelling out the slot.
+
+        var hand: MutableList<Card>
+            get() = activeHand.cards
+            set(value) {
+                activeHand.cards = value
+            }
+
+        var stake: Long
+            get() = activeHand.stake
+            set(value) {
+                activeHand.stake = value
+            }
+
+        var doubled: Boolean
+            get() = activeHand.doubled
+            set(value) {
+                activeHand.doubled = value
+            }
+
+        var status: SeatStatus
+            get() = activeHand.status
+            set(value) {
+                activeHand.status = value
+            }
+
+        /** Sum of `stake` across every hand on this seat. */
+        val totalStake: Long
+            get() = hands.sumOf { it.stake }
+
+        /** True once every hand on this seat is in a terminal status. */
         val isFinished: Boolean
-            get() = status == SeatStatus.STANDING ||
-                status == SeatStatus.DOUBLED ||
-                status == SeatStatus.BUSTED ||
-                status == SeatStatus.BLACKJACK
+            get() = hands.all {
+                it.status == SeatStatus.STANDING ||
+                    it.status == SeatStatus.DOUBLED ||
+                    it.status == SeatStatus.BUSTED ||
+                    it.status == SeatStatus.BLACKJACK
+            }
+
+        /**
+         * Reset this seat's per-hand state for a fresh round: drop any
+         * split hands, replace with a single empty active hand, clear
+         * the leave flag. Called by [database.service.BlackjackService]
+         * on every `startMultiHand` for surviving seats.
+         */
+        fun resetForNextHand(stake: Long) {
+            hands.clear()
+            hands.add(HandSlot(stake = stake))
+            activeHandIndex = 0
+            pendingLeave = false
+        }
     }
 
     /**
      * Snapshot of how a hand resolved. For SOLO, [seatResults] /
-     * [payouts] are single-entry maps. For MULTI, [pot] is the sum of
-     * antes (after any pushed-seat refunds), [rake] is what was routed
-     * to the jackpot pool, and [payouts] is what each surviving seat
-     * was credited.
+     * [payouts] aggregate per-discordId. For MULTI, [pot] is the sum
+     * of stakes (across every hand-slot, after any pushed-stake
+     * refunds), [rake] is what was routed to the jackpot pool, and
+     * [payouts] is what each player was credited (summed across split
+     * hands if any).
+     *
+     * [perHandResults] carries the per-split-hand breakdown so embeds
+     * and the web JSON projection can render each hand individually
+     * (cards, total, doubled flag, individual outcome). For seats that
+     * never split, this list has exactly one entry per seated player.
+     * For seats that did split, there's one entry per split branch.
+     * Older callers that only need aggregate per-discordId info can
+     * stick with [seatResults] / [payouts] and ignore this field.
      */
     data class HandResult(
         val handNumber: Long,
@@ -135,6 +245,25 @@ class BlackjackTable(
         val payouts: Map<Long, Long>,
         val pot: Long,
         val rake: Long,
-        val resolvedAt: Instant
+        val resolvedAt: Instant,
+        val perHandResults: List<PerHandResult> = emptyList(),
+    )
+
+    /**
+     * Outcome of a single hand-slot — one entry per (seat, split index)
+     * pair on the resolved table. [handIndex] is 0-based within the
+     * seat's `hands` list; on a single-hand seat it's always 0. On a
+     * seat that split once it's 0 or 1; after re-splitting up to 3.
+     */
+    data class PerHandResult(
+        val discordId: Long,
+        val handIndex: Int,
+        val cards: List<Card>,
+        val total: Int,
+        val stake: Long,
+        val doubled: Boolean,
+        val fromSplit: Boolean,
+        val result: Blackjack.Result,
+        val payout: Long,
     )
 }

--- a/database/src/main/kotlin/database/service/BlackjackService.kt
+++ b/database/src/main/kotlin/database/service/BlackjackService.kt
@@ -4,6 +4,7 @@ import database.blackjack.Blackjack
 import database.blackjack.BlackjackTable
 import database.blackjack.BlackjackTableRegistry
 import database.blackjack.bestTotal
+import database.blackjack.canSplit
 import database.blackjack.isBlackjack
 import database.blackjack.isBust
 import database.dto.BlackjackHandLogDto
@@ -99,6 +100,8 @@ class BlackjackService @Autowired constructor(
         data object NotYourHand : SoloActionOutcome
         data object IllegalAction : SoloActionOutcome
         data class InsufficientCreditsForDouble(val needed: Long, val have: Long) : SoloActionOutcome
+        /** SPLIT requested but the player can't cover the second ante. */
+        data class InsufficientCreditsForSplit(val needed: Long, val have: Long) : SoloActionOutcome
     }
 
     sealed interface MultiCreateOutcome {
@@ -163,6 +166,8 @@ class BlackjackService @Autowired constructor(
         data object NoHandInProgress : MultiActionOutcome
         data object IllegalAction : MultiActionOutcome
         data class InsufficientCreditsForDouble(val needed: Long, val have: Long) : MultiActionOutcome
+        /** SPLIT requested but the player can't cover the second ante. */
+        data class InsufficientCreditsForSplit(val needed: Long, val have: Long) : MultiActionOutcome
     }
 
     /**
@@ -269,9 +274,7 @@ class BlackjackService @Autowired constructor(
             val dealerHasBJ = isBlackjack(t.dealer)
             if (playerHasBJ || dealerHasBJ) {
                 t.phase = BlackjackTable.Phase.RESOLVED
-                val result = blackjack.evaluate(seat.hand, t.dealer)
-                seat.status = statusFor(result, seat.status)
-                ResolveDecision.ResolveImmediately(seat, result)
+                ResolveDecision.ResolveImmediately(seat)
             } else {
                 t.phase = BlackjackTable.Phase.PLAYER_TURNS
                 ResolveDecision.AwaitPlayer
@@ -286,7 +289,7 @@ class BlackjackService @Autowired constructor(
                 newPrice = soldNewPrice
             )
             is ResolveDecision.ResolveImmediately -> {
-                val settlement = settleSolo(table, initial.seat, initial.result, guildId)
+                val settlement = settleSolo(table, initial.seat, guildId)
                 SoloDealOutcome.Resolved(
                     tableId = table.id,
                     result = settlement.handResult,
@@ -302,10 +305,7 @@ class BlackjackService @Autowired constructor(
 
     private sealed interface ResolveDecision {
         data object AwaitPlayer : ResolveDecision
-        data class ResolveImmediately(
-            val seat: BlackjackTable.Seat,
-            val result: Blackjack.Result
-        ) : ResolveDecision
+        data class ResolveImmediately(val seat: BlackjackTable.Seat) : ResolveDecision
     }
 
     @Transactional
@@ -319,32 +319,43 @@ class BlackjackService @Autowired constructor(
         if (table.guildId != guildId) return SoloActionOutcome.HandNotFound
         if (table.mode != BlackjackTable.Mode.SOLO) return SoloActionOutcome.HandNotFound
 
-        // For DOUBLE, debit the additional stake from the wallet BEFORE
-        // taking the table monitor — keeps the credit lock outside the
-        // table lock to match the ordering used elsewhere. The follow-up
-        // action lockTable still re-validates seat ownership and phase
-        // under the monitor before committing the draw.
-        if (action == Blackjack.Action.DOUBLE) {
-            val seatPreview = tableRegistry.lockTable(tableId) { t ->
-                val seat = t.seats.firstOrNull() ?: return@lockTable DoubleCheck.Illegal
-                if (seat.discordId != discordId) return@lockTable DoubleCheck.Illegal
-                if (t.phase != BlackjackTable.Phase.PLAYER_TURNS) return@lockTable DoubleCheck.Illegal
-                if (seat.hand.size != 2 || seat.doubled) return@lockTable DoubleCheck.Illegal
-                DoubleCheck.Ok(seat.ante)
-            } ?: return SoloActionOutcome.HandNotFound
-            when (seatPreview) {
-                is DoubleCheck.Illegal -> return SoloActionOutcome.IllegalAction
-                is DoubleCheck.Ok -> {
-                    val user = userService.getUserByIdForUpdate(discordId, guildId)
-                        ?: return SoloActionOutcome.HandNotFound
-                    val balance = user.socialCredit ?: 0L
-                    if (balance < seatPreview.amount) {
-                        return SoloActionOutcome.InsufficientCreditsForDouble(seatPreview.amount, balance)
+        // DOUBLE / SPLIT both pre-debit the additional stake from the
+        // wallet BEFORE taking the table monitor — keeps the credit lock
+        // outside the table lock to match the ordering used elsewhere.
+        // The follow-up action lockTable still re-validates seat
+        // ownership and phase under the monitor before committing.
+        when (action) {
+            Blackjack.Action.DOUBLE -> {
+                val pre = previewSoloDouble(tableId, discordId) ?: return SoloActionOutcome.HandNotFound
+                when (pre) {
+                    is StakePreCheck.Illegal -> return SoloActionOutcome.IllegalAction
+                    is StakePreCheck.Ok -> {
+                        val (user, balance) = lockUserAndBalance(discordId, guildId)
+                            ?: return SoloActionOutcome.HandNotFound
+                        if (balance < pre.amount) {
+                            return SoloActionOutcome.InsufficientCreditsForDouble(pre.amount, balance)
+                        }
+                        user.socialCredit = balance - pre.amount
+                        userService.updateUser(user)
                     }
-                    user.socialCredit = balance - seatPreview.amount
-                    userService.updateUser(user)
                 }
             }
+            Blackjack.Action.SPLIT -> {
+                val pre = previewSoloSplit(tableId, discordId) ?: return SoloActionOutcome.HandNotFound
+                when (pre) {
+                    is StakePreCheck.Illegal -> return SoloActionOutcome.IllegalAction
+                    is StakePreCheck.Ok -> {
+                        val (user, balance) = lockUserAndBalance(discordId, guildId)
+                            ?: return SoloActionOutcome.HandNotFound
+                        if (balance < pre.amount) {
+                            return SoloActionOutcome.InsufficientCreditsForSplit(pre.amount, balance)
+                        }
+                        user.socialCredit = balance - pre.amount
+                        userService.updateUser(user)
+                    }
+                }
+            }
+            else -> Unit
         }
 
         val transition = tableRegistry.lockTable(tableId) { t ->
@@ -353,41 +364,14 @@ class BlackjackService @Autowired constructor(
             if (t.phase != BlackjackTable.Phase.PLAYER_TURNS) return@lockTable SoloTransition.IllegalAction
             val deck = t.deck ?: return@lockTable SoloTransition.HandNotFound
 
-            when (action) {
-                Blackjack.Action.HIT -> {
-                    blackjack.hit(seat.hand, deck)
-                    if (isBust(seat.hand)) {
-                        seat.status = BlackjackTable.SeatStatus.BUSTED
-                        t.phase = BlackjackTable.Phase.RESOLVED
-                        SoloTransition.Resolve(seat, blackjack.evaluate(seat.hand, t.dealer))
-                    } else if (bestTotal(seat.hand) == 21) {
-                        // 21 from a hit auto-stands — no further decisions.
-                        seat.status = BlackjackTable.SeatStatus.STANDING
-                        playOutAndResolve(t, seat)
-                    } else {
-                        t.lastActivityAt = Instant.now()
-                        SoloTransition.Continue
-                    }
-                }
-                Blackjack.Action.STAND -> {
-                    seat.status = BlackjackTable.SeatStatus.STANDING
-                    playOutAndResolve(t, seat)
-                }
-                Blackjack.Action.DOUBLE -> {
-                    // The debit already happened; mark the seat doubled
-                    // and draw exactly one card, then play out dealer.
-                    seat.doubled = true
-                    seat.stake = seat.ante * 2
-                    blackjack.hit(seat.hand, deck)
-                    seat.status = if (isBust(seat.hand)) BlackjackTable.SeatStatus.BUSTED
-                    else BlackjackTable.SeatStatus.DOUBLED
-                    if (seat.status == BlackjackTable.SeatStatus.BUSTED) {
-                        t.phase = BlackjackTable.Phase.RESOLVED
-                        SoloTransition.Resolve(seat, blackjack.evaluate(seat.hand, t.dealer))
-                    } else {
-                        playOutAndResolve(t, seat)
-                    }
-                }
+            applyActionToActiveHand(t, seat, action, deck)
+            t.lastActivityAt = Instant.now()
+            advanceWithinSeat(seat)
+
+            if (seat.isFinished) {
+                runDealerAndResolve(t, seat)
+            } else {
+                SoloTransition.Continue
             }
         } ?: return SoloActionOutcome.HandNotFound
 
@@ -397,8 +381,7 @@ class BlackjackService @Autowired constructor(
             SoloTransition.IllegalAction -> SoloActionOutcome.IllegalAction
             SoloTransition.Continue -> SoloActionOutcome.Continued(table)
             is SoloTransition.Resolve -> {
-                transition.seat.status = statusFor(transition.result, transition.seat.status)
-                val settlement = settleSolo(table, transition.seat, transition.result, guildId)
+                val settlement = settleSolo(table, transition.seat, guildId)
                 SoloActionOutcome.Resolved(
                     tableId = table.id,
                     result = settlement.handResult,
@@ -411,19 +394,113 @@ class BlackjackService @Autowired constructor(
     }
 
     /**
-     * Helper invoked under the table monitor: dealer plays out then we
-     * evaluate. Mutates [t] and [seat]; returns a [SoloTransition.Resolve]
-     * the caller turns into a settlement.
+     * Apply [action] to the seat's *active* hand-slot (the one
+     * currently being played). HIT / STAND / DOUBLE only touch the
+     * active slot; SPLIT replaces it with two slots, dealing one new
+     * card to each. Caller must have already pre-debited any extra
+     * stake (DOUBLE / SPLIT) outside the table monitor.
      */
-    private fun playOutAndResolve(
+    private fun applyActionToActiveHand(
         t: BlackjackTable,
-        seat: BlackjackTable.Seat
+        seat: BlackjackTable.Seat,
+        action: Blackjack.Action,
+        deck: database.card.Deck,
+    ) {
+        val active = seat.activeHand
+        when (action) {
+            Blackjack.Action.HIT -> {
+                blackjack.hit(active.cards, deck)
+                if (isBust(active.cards)) {
+                    active.status = BlackjackTable.SeatStatus.BUSTED
+                } else if (bestTotal(active.cards) == 21) {
+                    active.status = BlackjackTable.SeatStatus.STANDING
+                }
+            }
+            Blackjack.Action.STAND -> {
+                active.status = BlackjackTable.SeatStatus.STANDING
+            }
+            Blackjack.Action.DOUBLE -> {
+                active.doubled = true
+                active.stake = active.stake * 2
+                blackjack.hit(active.cards, deck)
+                active.status = if (isBust(active.cards)) BlackjackTable.SeatStatus.BUSTED
+                else BlackjackTable.SeatStatus.DOUBLED
+            }
+            Blackjack.Action.SPLIT -> {
+                splitActiveHand(seat, active, deck)
+            }
+        }
+    }
+
+    /**
+     * Split [active] into two single-card hands, deal one card to each
+     * to bring them back to two cards, mark both as `fromSplit`. Aces
+     * additionally auto-stand: classic blackjack rule is a single card
+     * per split-ace hand, no further hits or doubles.
+     */
+    private fun splitActiveHand(
+        seat: BlackjackTable.Seat,
+        active: BlackjackTable.HandSlot,
+        deck: database.card.Deck,
+    ) {
+        val firstCard = active.cards[0]
+        val secondCard = active.cards[1]
+        val acesSplit = firstCard.rank == database.card.Rank.ACE
+        // Reuse [active] as the first split branch. Wallet was pre-debited
+        // by the same amount as the original ante, so total at-risk
+        // doubles across the two slots.
+        val splitStake = active.stake
+        active.cards = mutableListOf(firstCard, deck.deal())
+        active.fromSplit = true
+        active.status = if (acesSplit) BlackjackTable.SeatStatus.STANDING
+        else BlackjackTable.SeatStatus.ACTIVE
+        val newSlot = BlackjackTable.HandSlot(
+            cards = mutableListOf(secondCard, deck.deal()),
+            stake = splitStake,
+            doubled = false,
+            status = if (acesSplit) BlackjackTable.SeatStatus.STANDING
+            else BlackjackTable.SeatStatus.ACTIVE,
+            fromSplit = true,
+        )
+        // Insert right after the active slot so the player plays them in
+        // dealt order.
+        seat.hands.add(seat.activeHandIndex + 1, newSlot)
+    }
+
+    /**
+     * After applying an action, walk forward through [seat]'s remaining
+     * hand-slots, skipping any already-terminal slots (e.g. split aces
+     * that auto-stood on creation, or a slot whose own action just took
+     * it to STANDING/BUSTED/DOUBLED). Stops on the next ACTIVE slot, or
+     * leaves [Seat.activeHandIndex] past the end if every slot is done.
+     */
+    private fun advanceWithinSeat(seat: BlackjackTable.Seat) {
+        if (seat.activeHand.status == BlackjackTable.SeatStatus.ACTIVE) return
+        var idx = seat.activeHandIndex + 1
+        while (idx < seat.hands.size && seat.hands[idx].status != BlackjackTable.SeatStatus.ACTIVE) {
+            idx++
+        }
+        seat.activeHandIndex = idx.coerceAtMost(seat.hands.size - 1)
+    }
+
+    /**
+     * Helper invoked under the table monitor when every hand-slot on
+     * the seat is finished: dealer plays out (skipped if every slot
+     * busted) and the table phase transitions to RESOLVED. Per-hand
+     * evaluation happens in [settleSolo].
+     */
+    private fun runDealerAndResolve(
+        t: BlackjackTable,
+        seat: BlackjackTable.Seat,
     ): SoloTransition {
         val deck = t.deck ?: return SoloTransition.HandNotFound
+        val allBust = seat.hands.all { it.status == BlackjackTable.SeatStatus.BUSTED }
         t.phase = BlackjackTable.Phase.DEALER_TURN
-        blackjack.playOutDealer(t.dealer, deck, hitsSoft17 = t.rules.dealerHitsSoft17)
+        if (!allBust) {
+            blackjack.playOutDealer(t.dealer, deck, hitsSoft17 = t.rules.dealerHitsSoft17)
+        }
         t.phase = BlackjackTable.Phase.RESOLVED
-        return SoloTransition.Resolve(seat, blackjack.evaluate(seat.hand, t.dealer))
+        return SoloTransition.Resolve(seat)
     }
 
     private sealed interface SoloTransition {
@@ -431,15 +508,64 @@ class BlackjackService @Autowired constructor(
         data object NotYourHand : SoloTransition
         data object IllegalAction : SoloTransition
         data object Continue : SoloTransition
-        data class Resolve(
-            val seat: BlackjackTable.Seat,
-            val result: Blackjack.Result
-        ) : SoloTransition
+        data class Resolve(val seat: BlackjackTable.Seat) : SoloTransition
     }
 
-    private sealed interface DoubleCheck {
-        data class Ok(val amount: Long) : DoubleCheck
-        data object Illegal : DoubleCheck
+    private sealed interface StakePreCheck {
+        data class Ok(val amount: Long) : StakePreCheck
+        data object Illegal : StakePreCheck
+    }
+
+    /**
+     * Pre-flight DOUBLE under the table monitor: returns the additional
+     * stake required ([StakePreCheck.Ok]) when the active hand is
+     * exactly 2 cards on a non-doubled active slot, [StakePreCheck.Illegal]
+     * when those preconditions fail, or `null` when the table itself
+     * has vanished. Wallet check + debit happens outside the lock.
+     */
+    private fun previewSoloDouble(tableId: Long, discordId: Long): StakePreCheck? =
+        tableRegistry.lockTable(tableId) { t ->
+            val seat = t.seats.firstOrNull() ?: return@lockTable StakePreCheck.Illegal
+            if (seat.discordId != discordId) return@lockTable StakePreCheck.Illegal
+            if (t.phase != BlackjackTable.Phase.PLAYER_TURNS) return@lockTable StakePreCheck.Illegal
+            val active = seat.activeHand
+            if (active.status != BlackjackTable.SeatStatus.ACTIVE) return@lockTable StakePreCheck.Illegal
+            if (active.cards.size != 2 || active.doubled) return@lockTable StakePreCheck.Illegal
+            // The DOUBLE wallet debit equals the active hand's current
+            // stake (which is `seat.ante` for a non-split hand and
+            // `seat.ante` per split branch — split hands carry their
+            // own pre-double stake of one ante apiece).
+            StakePreCheck.Ok(active.stake)
+        }
+
+    /**
+     * Pre-flight SPLIT: the active slot must be a 2-card pair, on a
+     * non-doubled / non-already-split slot. Re-splitting is allowed up
+     * to [Blackjack.MAX_SPLIT_HANDS] total hands per seat. Split aces
+     * are valid; the resulting two hands auto-stand on creation.
+     */
+    private fun previewSoloSplit(tableId: Long, discordId: Long): StakePreCheck? =
+        tableRegistry.lockTable(tableId) { t ->
+            val seat = t.seats.firstOrNull() ?: return@lockTable StakePreCheck.Illegal
+            if (seat.discordId != discordId) return@lockTable StakePreCheck.Illegal
+            if (t.phase != BlackjackTable.Phase.PLAYER_TURNS) return@lockTable StakePreCheck.Illegal
+            val active = seat.activeHand
+            if (active.status != BlackjackTable.SeatStatus.ACTIVE) return@lockTable StakePreCheck.Illegal
+            if (active.doubled) return@lockTable StakePreCheck.Illegal
+            if (!canSplit(active.cards)) return@lockTable StakePreCheck.Illegal
+            if (seat.hands.size >= Blackjack.MAX_SPLIT_HANDS) return@lockTable StakePreCheck.Illegal
+            // Re-splitting aces is disallowed by classic rules.
+            if (active.fromSplit && active.cards[0].rank == database.card.Rank.ACE) {
+                return@lockTable StakePreCheck.Illegal
+            }
+            // Each split adds exactly one new hand at the same per-hand
+            // ante as the original — wallet must cover one more ante.
+            StakePreCheck.Ok(active.stake)
+        }
+
+    private fun lockUserAndBalance(discordId: Long, guildId: Long): Pair<database.dto.UserDto, Long>? {
+        val user = userService.getUserByIdForUpdate(discordId, guildId) ?: return null
+        return user to (user.socialCredit ?: 0L)
     }
 
     private data class SoloSettlement(
@@ -450,49 +576,88 @@ class BlackjackService @Autowired constructor(
     )
 
     /**
-     * Credit the payout (multiplier × stake) back to the player and
-     * route jackpot win-rolls / loss-tributes. Caller has already
-     * marked the seat status and put the table in RESOLVED.
+     * Iterate every hand-slot on the seat (one per split branch),
+     * evaluate each independently, sum the payouts and route the
+     * resulting jackpot rolls / loss tributes. Each hand-slot acts as
+     * its own wager — splitting effectively turns one bet into N bets.
      */
     private fun settleSolo(
         table: BlackjackTable,
         seat: BlackjackTable.Seat,
-        result: Blackjack.Result,
         guildId: Long
     ): SoloSettlement {
-        val multiplier = blackjack.multiplier(result, table.rules.blackjackPayoutMultiplier)
-        val payout = (seat.stake * multiplier).toLong()
+        val payoutMult = table.rules.blackjackPayoutMultiplier
+        val perHand = mutableListOf<BlackjackTable.PerHandResult>()
+        val firstHandResult = LinkedHashMap<Long, Blackjack.Result>()
+        var totalPayout = 0L
+        for ((idx, slot) in seat.hands.withIndex()) {
+            val result = blackjack.evaluate(slot.cards, table.dealer, fromSplit = slot.fromSplit)
+            slot.status = terminalStatusFor(result, slot.status)
+            val multiplier = blackjack.multiplier(result, payoutMult)
+            val handPayout = (slot.stake * multiplier).toLong()
+            totalPayout += handPayout
+            if (idx == 0) firstHandResult[seat.discordId] = result
+            perHand.add(
+                BlackjackTable.PerHandResult(
+                    discordId = seat.discordId,
+                    handIndex = idx,
+                    cards = slot.cards.toList(),
+                    total = bestTotal(slot.cards),
+                    stake = slot.stake,
+                    doubled = slot.doubled,
+                    fromSplit = slot.fromSplit,
+                    result = result,
+                    payout = handPayout,
+                )
+            )
+        }
 
         val user = userService.getUserByIdForUpdate(seat.discordId, guildId)
         var newBalance: Long = user?.socialCredit ?: 0L
-        if (user != null && payout > 0L) {
-            user.socialCredit = newBalance + payout
+        if (user != null && totalPayout > 0L) {
+            user.socialCredit = newBalance + totalPayout
             userService.updateUser(user)
             newBalance = user.socialCredit ?: newBalance
         }
 
+        // One jackpot roll per winning hand-slot, one loss tribute per
+        // losing hand-slot — split = more wagers, so naturally more
+        // chances at both. Pushes are no-ops on both axes.
         var jackpotPayout = 0L
         var lossTribute = 0L
-        val isWin = result == Blackjack.Result.PLAYER_WIN || result == Blackjack.Result.PLAYER_BLACKJACK
-        val isLoss = result == Blackjack.Result.DEALER_WIN || result == Blackjack.Result.PLAYER_BUST
-        if (isWin && user != null) {
-            jackpotPayout = JackpotHelper.rollOnWin(
-                jackpotService, configService, userService, user, guildId, random
-            )
-            if (jackpotPayout > 0L) newBalance = user.socialCredit ?: newBalance
-        } else if (isLoss) {
-            lossTribute = JackpotHelper.divertOnLoss(jackpotService, configService, guildId, seat.stake)
+        if (user != null) {
+            for (hand in perHand) {
+                when (hand.result) {
+                    Blackjack.Result.PLAYER_WIN, Blackjack.Result.PLAYER_BLACKJACK -> {
+                        val rolled = JackpotHelper.rollOnWin(
+                            jackpotService, configService, userService, user, guildId, random
+                        )
+                        if (rolled > 0L) {
+                            jackpotPayout += rolled
+                            newBalance = user.socialCredit ?: newBalance
+                        }
+                    }
+                    Blackjack.Result.DEALER_WIN, Blackjack.Result.PLAYER_BUST -> {
+                        lossTribute += JackpotHelper.divertOnLoss(
+                            jackpotService, configService, guildId, hand.stake
+                        )
+                    }
+                    Blackjack.Result.PUSH -> Unit
+                }
+            }
         }
 
+        val totalStake = seat.totalStake
         val handResult = BlackjackTable.HandResult(
             handNumber = table.handNumber,
             dealer = table.dealer.toList(),
             dealerTotal = bestTotal(table.dealer),
-            seatResults = mapOf(seat.discordId to result),
-            payouts = if (payout > 0L) mapOf(seat.discordId to payout) else emptyMap(),
-            pot = seat.stake,
+            seatResults = firstHandResult,
+            payouts = if (totalPayout > 0L) mapOf(seat.discordId to totalPayout) else emptyMap(),
+            pot = totalStake,
             rake = 0L,
-            resolvedAt = Instant.now()
+            resolvedAt = Instant.now(),
+            perHandResults = perHand,
         )
         synchronized(table) {
             table.lastResult = handResult
@@ -500,6 +665,27 @@ class BlackjackService @Autowired constructor(
         }
         persistHandLog(table, handResult)
         return SoloSettlement(handResult, newBalance, jackpotPayout, lossTribute)
+    }
+
+    /**
+     * Map a [Blackjack.Result] to the matching [BlackjackTable.SeatStatus]
+     * for an already-finished hand-slot. Existing terminal flags
+     * (DOUBLED, BUSTED) are preserved — only ACTIVE / STANDING get
+     * overwritten with the result-derived status.
+     */
+    private fun terminalStatusFor(
+        result: Blackjack.Result,
+        current: BlackjackTable.SeatStatus,
+    ): BlackjackTable.SeatStatus {
+        if (current == BlackjackTable.SeatStatus.DOUBLED ||
+            current == BlackjackTable.SeatStatus.BUSTED ||
+            current == BlackjackTable.SeatStatus.BLACKJACK
+        ) return current
+        return when (result) {
+            Blackjack.Result.PLAYER_BLACKJACK -> BlackjackTable.SeatStatus.BLACKJACK
+            Blackjack.Result.PLAYER_BUST -> BlackjackTable.SeatStatus.BUSTED
+            else -> current
+        }
     }
 
     /**
@@ -530,15 +716,6 @@ class BlackjackService @Autowired constructor(
                 )
             )
         }
-    }
-
-    private fun statusFor(
-        result: Blackjack.Result,
-        current: BlackjackTable.SeatStatus
-    ): BlackjackTable.SeatStatus = when (result) {
-        Blackjack.Result.PLAYER_BLACKJACK -> BlackjackTable.SeatStatus.BLACKJACK
-        Blackjack.Result.PLAYER_BUST -> BlackjackTable.SeatStatus.BUSTED
-        else -> current
     }
 
     /** Drop a SOLO table after the player has had a chance to read the result. */
@@ -867,7 +1044,6 @@ class BlackjackService @Autowired constructor(
                 seat.status = BlackjackTable.SeatStatus.ACTIVE
                 if (seat.stake == 0L) {
                     seat.stake = ante
-                    seat.ante = ante
                 }
             }
             t.dealer.clear()
@@ -914,30 +1090,43 @@ class BlackjackService @Autowired constructor(
         if (table.guildId != guildId) return MultiActionOutcome.TableNotFound
         if (table.mode != BlackjackTable.Mode.MULTI) return MultiActionOutcome.TableNotFound
 
-        // For DOUBLE we need to debit the second ante outside the table monitor.
-        if (action == Blackjack.Action.DOUBLE) {
-            val pre = tableRegistry.lockTable(tableId) { t ->
-                if (t.phase != BlackjackTable.Phase.PLAYER_TURNS) return@lockTable MultiDoublePreflight.NoHand
-                val actorSeat = t.seats.getOrNull(t.actorIndex) ?: return@lockTable MultiDoublePreflight.NoHand
-                if (actorSeat.discordId != discordId) return@lockTable MultiDoublePreflight.NotYourTurn
-                if (actorSeat.hand.size != 2 || actorSeat.doubled) return@lockTable MultiDoublePreflight.Illegal
-                MultiDoublePreflight.Ok(actorSeat.ante)
-            } ?: return MultiActionOutcome.TableNotFound
-            when (pre) {
-                MultiDoublePreflight.NoHand -> return MultiActionOutcome.NoHandInProgress
-                MultiDoublePreflight.NotYourTurn -> return MultiActionOutcome.NotYourTurn
-                MultiDoublePreflight.Illegal -> return MultiActionOutcome.IllegalAction
-                is MultiDoublePreflight.Ok -> {
-                    val user = userService.getUserByIdForUpdate(discordId, guildId)
-                        ?: return MultiActionOutcome.NotSeated
-                    val balance = user.socialCredit ?: 0L
-                    if (balance < pre.amount) {
-                        return MultiActionOutcome.InsufficientCreditsForDouble(pre.amount, balance)
+        // DOUBLE / SPLIT pre-debit happens outside the table monitor.
+        when (action) {
+            Blackjack.Action.DOUBLE -> {
+                val pre = previewMultiDouble(tableId, discordId) ?: return MultiActionOutcome.TableNotFound
+                when (pre) {
+                    MultiPreflight.NoHand -> return MultiActionOutcome.NoHandInProgress
+                    MultiPreflight.NotYourTurn -> return MultiActionOutcome.NotYourTurn
+                    MultiPreflight.Illegal -> return MultiActionOutcome.IllegalAction
+                    is MultiPreflight.Ok -> {
+                        val (user, balance) = lockUserAndBalance(discordId, guildId)
+                            ?: return MultiActionOutcome.NotSeated
+                        if (balance < pre.amount) {
+                            return MultiActionOutcome.InsufficientCreditsForDouble(pre.amount, balance)
+                        }
+                        user.socialCredit = balance - pre.amount
+                        userService.updateUser(user)
                     }
-                    user.socialCredit = balance - pre.amount
-                    userService.updateUser(user)
                 }
             }
+            Blackjack.Action.SPLIT -> {
+                val pre = previewMultiSplit(tableId, discordId) ?: return MultiActionOutcome.TableNotFound
+                when (pre) {
+                    MultiPreflight.NoHand -> return MultiActionOutcome.NoHandInProgress
+                    MultiPreflight.NotYourTurn -> return MultiActionOutcome.NotYourTurn
+                    MultiPreflight.Illegal -> return MultiActionOutcome.IllegalAction
+                    is MultiPreflight.Ok -> {
+                        val (user, balance) = lockUserAndBalance(discordId, guildId)
+                            ?: return MultiActionOutcome.NotSeated
+                        if (balance < pre.amount) {
+                            return MultiActionOutcome.InsufficientCreditsForSplit(pre.amount, balance)
+                        }
+                        user.socialCredit = balance - pre.amount
+                        userService.updateUser(user)
+                    }
+                }
+            }
+            else -> Unit
         }
 
         val transition = tableRegistry.lockTable(tableId) { t ->
@@ -947,31 +1136,15 @@ class BlackjackService @Autowired constructor(
             if (actorSeat.discordId != discordId) return@lockTable MultiTransition.NotYourTurn
             val deck = t.deck ?: return@lockTable MultiTransition.NoHand
 
-            when (action) {
-                Blackjack.Action.HIT -> {
-                    blackjack.hit(actorSeat.hand, deck)
-                    if (isBust(actorSeat.hand)) {
-                        actorSeat.status = BlackjackTable.SeatStatus.BUSTED
-                        advanceActor(t)
-                    } else if (bestTotal(actorSeat.hand) == 21) {
-                        actorSeat.status = BlackjackTable.SeatStatus.STANDING
-                        advanceActor(t)
-                    }
-                }
-                Blackjack.Action.STAND -> {
-                    actorSeat.status = BlackjackTable.SeatStatus.STANDING
-                    advanceActor(t)
-                }
-                Blackjack.Action.DOUBLE -> {
-                    actorSeat.doubled = true
-                    actorSeat.stake = actorSeat.ante * 2
-                    blackjack.hit(actorSeat.hand, deck)
-                    actorSeat.status = if (isBust(actorSeat.hand)) BlackjackTable.SeatStatus.BUSTED
-                    else BlackjackTable.SeatStatus.DOUBLED
-                    advanceActor(t)
-                }
-            }
+            applyActionToActiveHand(t, actorSeat, action, deck)
             t.lastActivityAt = Instant.now()
+            advanceWithinSeat(actorSeat)
+            // Once every hand-slot on the seat is finished, the seat
+            // itself is done — advance to the next seat (which may also
+            // get its own split flow on a future click).
+            if (actorSeat.isFinished) {
+                advanceActor(t)
+            }
 
             // Cascade past any subsequent pendingLeave seats — auto-stand
             // them on their behalf so the hand never stalls on someone
@@ -979,9 +1152,10 @@ class BlackjackService @Autowired constructor(
             while (t.phase == BlackjackTable.Phase.PLAYER_TURNS) {
                 val nextActor = t.seats.getOrNull(t.actorIndex) ?: break
                 if (!nextActor.pendingLeave) break
-                if (nextActor.status != BlackjackTable.SeatStatus.ACTIVE) break
-                nextActor.status = BlackjackTable.SeatStatus.STANDING
-                advanceActor(t)
+                if (nextActor.activeHand.status != BlackjackTable.SeatStatus.ACTIVE) break
+                nextActor.activeHand.status = BlackjackTable.SeatStatus.STANDING
+                advanceWithinSeat(nextActor)
+                if (nextActor.isFinished) advanceActor(t)
             }
 
             if (t.phase == BlackjackTable.Phase.PLAYER_TURNS) {
@@ -1009,12 +1183,45 @@ class BlackjackService @Autowired constructor(
         }
     }
 
-    private sealed interface MultiDoublePreflight {
-        data class Ok(val amount: Long) : MultiDoublePreflight
-        data object NoHand : MultiDoublePreflight
-        data object NotYourTurn : MultiDoublePreflight
-        data object Illegal : MultiDoublePreflight
+    /**
+     * Outcome of the multi-table DOUBLE / SPLIT pre-flight: tells the
+     * outer code whether the wallet debit should proceed and, if so,
+     * how much to debit. Wallet locking happens outside the table
+     * monitor (matching the ordering the rest of the service uses).
+     */
+    private sealed interface MultiPreflight {
+        data class Ok(val amount: Long) : MultiPreflight
+        data object NoHand : MultiPreflight
+        data object NotYourTurn : MultiPreflight
+        data object Illegal : MultiPreflight
     }
+
+    private fun previewMultiDouble(tableId: Long, discordId: Long): MultiPreflight? =
+        tableRegistry.lockTable(tableId) { t ->
+            if (t.phase != BlackjackTable.Phase.PLAYER_TURNS) return@lockTable MultiPreflight.NoHand
+            val actorSeat = t.seats.getOrNull(t.actorIndex) ?: return@lockTable MultiPreflight.NoHand
+            if (actorSeat.discordId != discordId) return@lockTable MultiPreflight.NotYourTurn
+            val active = actorSeat.activeHand
+            if (active.status != BlackjackTable.SeatStatus.ACTIVE) return@lockTable MultiPreflight.Illegal
+            if (active.cards.size != 2 || active.doubled) return@lockTable MultiPreflight.Illegal
+            MultiPreflight.Ok(active.stake)
+        }
+
+    private fun previewMultiSplit(tableId: Long, discordId: Long): MultiPreflight? =
+        tableRegistry.lockTable(tableId) { t ->
+            if (t.phase != BlackjackTable.Phase.PLAYER_TURNS) return@lockTable MultiPreflight.NoHand
+            val actorSeat = t.seats.getOrNull(t.actorIndex) ?: return@lockTable MultiPreflight.NoHand
+            if (actorSeat.discordId != discordId) return@lockTable MultiPreflight.NotYourTurn
+            val active = actorSeat.activeHand
+            if (active.status != BlackjackTable.SeatStatus.ACTIVE) return@lockTable MultiPreflight.Illegal
+            if (active.doubled) return@lockTable MultiPreflight.Illegal
+            if (!canSplit(active.cards)) return@lockTable MultiPreflight.Illegal
+            if (actorSeat.hands.size >= Blackjack.MAX_SPLIT_HANDS) return@lockTable MultiPreflight.Illegal
+            if (active.fromSplit && active.cards[0].rank == database.card.Rank.ACE) {
+                return@lockTable MultiPreflight.Illegal
+            }
+            MultiPreflight.Ok(active.stake)
+        }
 
     private sealed interface MultiTransition {
         data object NoHand : MultiTransition
@@ -1066,75 +1273,80 @@ class BlackjackService @Autowired constructor(
      */
     private fun resolveMultiHand(t: BlackjackTable, guildId: Long): BlackjackTable.HandResult {
         val deck = t.deck ?: error("missing deck on resolve")
-        val allBust = t.seats.all { it.status == BlackjackTable.SeatStatus.BUSTED }
+        // Flatten to a single (seat, hand-slot, hand-index) list — each
+        // split branch is its own wager and is settled independently
+        // (loss tribute / jackpot roll / pot share all happen at the
+        // hand-slot level rather than the seat level).
+        data class Entry(
+            val seat: BlackjackTable.Seat,
+            val slot: BlackjackTable.HandSlot,
+            val handIndex: Int,
+        )
+        val entries = t.seats.flatMap { seat ->
+            seat.hands.mapIndexed { idx, slot -> Entry(seat, slot, idx) }
+        }
+        val allBust = entries.all { it.slot.status == BlackjackTable.SeatStatus.BUSTED }
         if (!allBust) {
             blackjack.playOutDealer(t.dealer, deck, hitsSoft17 = t.rules.dealerHitsSoft17)
         }
         t.phase = BlackjackTable.Phase.RESOLVED
 
-        val results = LinkedHashMap<Long, Blackjack.Result>()
-        for (seat in t.seats) {
-            results[seat.discordId] = blackjack.evaluate(seat.hand, t.dealer)
+        // Evaluate each hand-slot, respecting the fromSplit flag so a
+        // split-aces 21 doesn't claim the natural-BJ premium.
+        val perSlotResult = entries.associateWith { entry ->
+            blackjack.evaluate(entry.slot.cards, t.dealer, fromSplit = entry.slot.fromSplit)
+        }
+        // Apply terminal status to each slot for downstream embed
+        // rendering (BUSTED / BLACKJACK markers).
+        for ((entry, result) in perSlotResult) {
+            entry.slot.status = terminalStatusFor(result, entry.slot.status)
         }
 
-        val totalPot = t.seats.sumOf { it.stake }
-        val pushSeats = t.seats.filter { results[it.discordId] == Blackjack.Result.PUSH }
-        val winnerSeats = t.seats.filter {
-            val r = results[it.discordId]
+        val totalPot = entries.sumOf { it.slot.stake }
+        val pushEntries = entries.filter { perSlotResult[it] == Blackjack.Result.PUSH }
+        val winnerEntries = entries.filter {
+            val r = perSlotResult[it]
             r == Blackjack.Result.PLAYER_WIN || r == Blackjack.Result.PLAYER_BLACKJACK
         }
-        val bjWinners = winnerSeats.filter { results[it.discordId] == Blackjack.Result.PLAYER_BLACKJACK }
-        val pushTotal = pushSeats.sumOf { it.stake }
-        val winnerStakeTotal = winnerSeats.sumOf { it.stake }
+        val bjEntries = winnerEntries.filter { perSlotResult[it] == Blackjack.Result.PLAYER_BLACKJACK }
+        val regularEntries = winnerEntries.filter { perSlotResult[it] == Blackjack.Result.PLAYER_WIN }
+        val pushTotal = pushEntries.sumOf { it.slot.stake }
+        val winnerStakeTotal = winnerEntries.sumOf { it.slot.stake }
         val losersPool = (totalPot - pushTotal - winnerStakeTotal).coerceAtLeast(0L)
 
-        val payouts = LinkedHashMap<Long, Long>()
-        for (seat in pushSeats) payouts[seat.discordId] = seat.stake
-        for (seat in winnerSeats) payouts.merge(seat.discordId, seat.stake) { a, b -> a + b }
+        // Per-slot payouts → aggregated per-discordId at the end. Pushed
+        // slots get their own stake refunded; winners get their own
+        // stake refunded plus a share of the losers' pool.
+        val payoutBySlot = HashMap<Entry, Long>()
+        for (e in pushEntries) payoutBySlot[e] = e.slot.stake
+        for (e in winnerEntries) payoutBySlot[e] = e.slot.stake
 
-        // Each winner is entitled to a fixed bonus on top of their stake
-        // refund: 1× their stake for a regular win, 1.5× for a natural
-        // blackjack. We pay these bonuses out of the losers' pool, after
-        // skimming 5% rake. If the pool can't cover the full bonus, we
-        // scale every bonus down proportionally so the pool is consumed
-        // exactly. Any surplus (small entitled amount, big losers' pool)
-        // also routes to the jackpot.
-        val regularWinners = winnerSeats.filter {
-            results[it.discordId] == Blackjack.Result.PLAYER_WIN
-        }
-        // BJ premium = (payoutMultiplier - 1) × stake, e.g. 3:2 → 1.5×, 6:5 → 1.2×.
         val bjPremiumFraction = (t.rules.blackjackPayoutMultiplier - 1.0).coerceAtLeast(0.0)
         var rake = 0L
-        if (winnerSeats.isEmpty()) {
-            // No winners: entire losers' pool routes to the jackpot.
+        if (winnerEntries.isEmpty()) {
             rake = losersPool
         } else if (losersPool > 0L) {
             val baseRake = (losersPool * t.rules.rakeFraction).toLong()
             val payable = losersPool - baseRake
-            val regularEntitled = regularWinners.sumOf { it.stake }
-            val bjEntitled = bjWinners.sumOf { (it.stake * bjPremiumFraction).toLong() }
+            val regularEntitled = regularEntries.sumOf { it.slot.stake }
+            val bjEntitled = bjEntries.sumOf { (it.slot.stake * bjPremiumFraction).toLong() }
             val totalEntitled = regularEntitled + bjEntitled
 
             if (totalEntitled > 0L && payable >= totalEntitled) {
-                // Full bonuses; surplus to jackpot.
-                for (seat in regularWinners) {
-                    payouts.merge(seat.discordId, seat.stake) { a, b -> a + b }
+                for (e in regularEntries) payoutBySlot.merge(e, e.slot.stake) { a, b -> a + b }
+                for (e in bjEntries) {
+                    payoutBySlot.merge(e, (e.slot.stake * bjPremiumFraction).toLong()) { a, b -> a + b }
                 }
-                for (seat in bjWinners) {
-                    payouts.merge(seat.discordId, (seat.stake * bjPremiumFraction).toLong()) { a, b -> a + b }
-                }
-                val surplus = payable - totalEntitled
-                rake = baseRake + surplus
+                rake = baseRake + (payable - totalEntitled)
             } else if (totalEntitled > 0L) {
-                // Scale down: each winner gets `(owed × payable) / totalEntitled`.
-                for (seat in regularWinners) {
-                    val share = (seat.stake * payable) / totalEntitled
-                    payouts.merge(seat.discordId, share) { a, b -> a + b }
+                for (e in regularEntries) {
+                    val share = (e.slot.stake * payable) / totalEntitled
+                    payoutBySlot.merge(e, share) { a, b -> a + b }
                 }
-                for (seat in bjWinners) {
-                    val owed = (seat.stake * bjPremiumFraction).toLong()
+                for (e in bjEntries) {
+                    val owed = (e.slot.stake * bjPremiumFraction).toLong()
                     val share = (owed * payable) / totalEntitled
-                    payouts.merge(seat.discordId, share) { a, b -> a + b }
+                    payoutBySlot.merge(e, share) { a, b -> a + b }
                 }
                 rake = baseRake
             } else {
@@ -1143,14 +1355,42 @@ class BlackjackService @Autowired constructor(
         }
         if (rake > 0L) jackpotService.addToPool(guildId, rake)
 
+        // Roll into per-discordId totals + per-slot result records.
+        val payouts = LinkedHashMap<Long, Long>()
+        for ((entry, amount) in payoutBySlot) {
+            if (amount <= 0L) continue
+            payouts.merge(entry.seat.discordId, amount) { a, b -> a + b }
+        }
         if (payouts.isNotEmpty()) {
             val locked = userService.lockUsersInAscendingOrder(payouts.keys, guildId)
             for ((id, amount) in payouts) {
-                if (amount <= 0L) continue
                 val user = locked[id] ?: continue
                 user.socialCredit = (user.socialCredit ?: 0L) + amount
                 userService.updateUser(user)
             }
+        }
+
+        val perHand = entries.map { entry ->
+            BlackjackTable.PerHandResult(
+                discordId = entry.seat.discordId,
+                handIndex = entry.handIndex,
+                cards = entry.slot.cards.toList(),
+                total = bestTotal(entry.slot.cards),
+                stake = entry.slot.stake,
+                doubled = entry.slot.doubled,
+                fromSplit = entry.slot.fromSplit,
+                result = perSlotResult[entry] ?: Blackjack.Result.PUSH,
+                payout = payoutBySlot[entry] ?: 0L,
+            )
+        }
+        // For back-compat callers reading the per-discordId map, expose
+        // each seat's first-hand result as the representative outcome
+        // (richer per-hand data lives on perHandResults).
+        val results = LinkedHashMap<Long, Blackjack.Result>()
+        for (seat in t.seats) {
+            val firstSlotResult = perSlotResult.entries.firstOrNull { it.key.seat === seat }?.value
+                ?: Blackjack.Result.PUSH
+            results[seat.discordId] = firstSlotResult
         }
 
         val handResult = BlackjackTable.HandResult(
@@ -1161,15 +1401,16 @@ class BlackjackService @Autowired constructor(
             payouts = payouts,
             pot = totalPot,
             rake = rake,
-            resolvedAt = Instant.now()
+            resolvedAt = Instant.now(),
+            perHandResults = perHand,
         )
         t.lastResult = handResult
         t.lastActivityAt = Instant.now()
         persistHandLog(t, handResult)
 
-        // Reset to LOBBY but KEEP seats. Each surviving seat needs to re-
-        // ante on the next [startMultiHand] — set stake=0 to mark "no
-        // escrow held". Drop seats that asked to leave mid-hand.
+        // Reset to LOBBY but KEEP seats. Each surviving seat needs to
+        // re-ante on the next [startMultiHand]; resetForNextHand zeroes
+        // out the per-hand state including any split branches.
         t.phase = BlackjackTable.Phase.LOBBY
         t.actorIndex = 0
         t.dealer.clear()
@@ -1177,11 +1418,7 @@ class BlackjackService @Autowired constructor(
         t.currentActorDeadline = null
         t.seats.removeAll { it.pendingLeave }
         for (seat in t.seats) {
-            seat.hand = mutableListOf()
-            seat.doubled = false
-            seat.stake = 0L
-            seat.status = BlackjackTable.SeatStatus.ACTIVE
-            seat.pendingLeave = false
+            seat.resetForNextHand(stake = 0L)
         }
         if (t.seats.isEmpty()) tableRegistry.remove(t.id)
         return handResult

--- a/database/src/test/kotlin/database/blackjack/BlackjackHandTest.kt
+++ b/database/src/test/kotlin/database/blackjack/BlackjackHandTest.kt
@@ -80,4 +80,31 @@ class BlackjackHandTest {
         assertFalse(isBlackjack(listOf(c(Rank.SEVEN), c(Rank.SEVEN, Suit.HEARTS), c(Rank.SEVEN, Suit.CLUBS))))
         assertFalse(isBlackjack(listOf(c(Rank.ACE))))
     }
+
+    @Test
+    fun `canSplit true for matching ranks`() {
+        assertTrue(canSplit(listOf(c(Rank.EIGHT), c(Rank.EIGHT, Suit.HEARTS))))
+        assertTrue(canSplit(listOf(c(Rank.ACE), c(Rank.ACE, Suit.HEARTS))))
+    }
+
+    @Test
+    fun `canSplit true for ten-value pairs across face cards`() {
+        // T-J-Q-K all count as 10 in blackjack, so any pair of them is splittable.
+        assertTrue(canSplit(listOf(c(Rank.TEN), c(Rank.JACK))))
+        assertTrue(canSplit(listOf(c(Rank.JACK), c(Rank.QUEEN))))
+        assertTrue(canSplit(listOf(c(Rank.KING), c(Rank.TEN, Suit.HEARTS))))
+    }
+
+    @Test
+    fun `canSplit false for different values`() {
+        assertFalse(canSplit(listOf(c(Rank.NINE), c(Rank.TEN))))
+        assertFalse(canSplit(listOf(c(Rank.ACE), c(Rank.KING))))
+    }
+
+    @Test
+    fun `canSplit false for non-2-card hands`() {
+        assertFalse(canSplit(emptyList()))
+        assertFalse(canSplit(listOf(c(Rank.EIGHT))))
+        assertFalse(canSplit(listOf(c(Rank.EIGHT), c(Rank.EIGHT, Suit.HEARTS), c(Rank.EIGHT, Suit.CLUBS))))
+    }
 }

--- a/database/src/test/kotlin/database/blackjack/BlackjackTest.kt
+++ b/database/src/test/kotlin/database/blackjack/BlackjackTest.kt
@@ -119,6 +119,18 @@ class BlackjackTest {
     }
 
     @Test
+    fun `evaluate fromSplit suppresses the natural-blackjack premium`() {
+        // A two-card 21 reached on a split hand counts as a regular win
+        // (1:1) — never a natural blackjack (3:2). Standard rule: split
+        // aces drawing a ten-value land at 21 but pay 1:1.
+        val bj = Blackjack()
+        val player = listOf(c(Rank.ACE), c(Rank.KING))            // would be BJ in the normal rule
+        val dealer = listOf(c(Rank.NINE), c(Rank.SEVEN))          // 16, dealer plays out
+        assertEquals(Blackjack.Result.PLAYER_BLACKJACK, bj.evaluate(player, dealer))
+        assertEquals(Blackjack.Result.PLAYER_WIN, bj.evaluate(player, dealer, fromSplit = true))
+    }
+
+    @Test
     fun `multiplier matches the documented payout schedule`() {
         val bj = Blackjack()
         assertEquals(2.5, bj.multiplier(Blackjack.Result.PLAYER_BLACKJACK))

--- a/database/src/test/kotlin/database/service/BlackjackServiceTest.kt
+++ b/database/src/test/kotlin/database/service/BlackjackServiceTest.kt
@@ -718,6 +718,106 @@ class BlackjackServiceTest {
         assertEquals(900L, host.socialCredit, "host not debited when start aborted")
     }
 
+    // -------------------------------------------------------------------------
+    // SPLIT
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `solo SPLIT debits a second ante and creates two hands`() {
+        val user = userWithBalance(1_000L)
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns user
+        // 8-8 → splittable pair. Dealer shows a 6 (will play out later).
+        every { blackjack.dealStartingHands(any()) } returns Blackjack.StartingDeal(
+            mutableListOf(c(Rank.EIGHT), c(Rank.EIGHT, Suit.HEARTS)),
+            mutableListOf(c(Rank.SIX), c(Rank.TEN))
+        )
+        val deal = service.dealSolo(discordId, guildId, stake = 100L)
+        val tableId = (deal as BlackjackService.SoloDealOutcome.Dealt).tableId
+        assertEquals(900L, user.socialCredit, "first ante debited at deal")
+
+        // SPLIT — service deals one card to each split hand. Stub hit
+        // to drop a non-bust card on each so we end up with two
+        // post-split hands the player can still hit/stand on.
+        every { blackjack.hit(any(), any()) } answers {
+            firstArg<MutableList<Card>>().add(c(Rank.THREE, Suit.HEARTS))
+        }
+        // dealStartingHands returned a fresh deck via newDeck() (relaxed
+        // mock). The split path doesn't go through newDeck(); it deals
+        // off the table's stored deck instance.
+
+        val outcome = service.applySoloAction(discordId, guildId, tableId, Blackjack.Action.SPLIT)
+        assertInstanceOf(BlackjackService.SoloActionOutcome.Continued::class.java, outcome)
+        assertEquals(800L, user.socialCredit, "second ante debited on SPLIT")
+        val live = registry.get(tableId)!!
+        val seat = live.seats[0]
+        assertEquals(2, seat.hands.size, "split produced two hand-slots")
+        assertEquals(0, seat.activeHandIndex, "first split hand active first")
+        assertTrue(seat.hands.all { it.fromSplit }, "both slots flagged fromSplit")
+    }
+
+    @Test
+    fun `solo SPLIT rejected when hand is not a pair`() {
+        val user = userWithBalance(1_000L)
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns user
+        every { blackjack.dealStartingHands(any()) } returns Blackjack.StartingDeal(
+            mutableListOf(c(Rank.EIGHT), c(Rank.NINE)),
+            mutableListOf(c(Rank.SIX), c(Rank.TEN))
+        )
+        val deal = service.dealSolo(discordId, guildId, stake = 100L)
+        val tableId = (deal as BlackjackService.SoloDealOutcome.Dealt).tableId
+
+        val outcome = service.applySoloAction(discordId, guildId, tableId, Blackjack.Action.SPLIT)
+        assertEquals(BlackjackService.SoloActionOutcome.IllegalAction, outcome)
+        assertEquals(900L, user.socialCredit, "no second-ante debit on rejected SPLIT")
+    }
+
+    @Test
+    fun `solo SPLIT rejected without funds for the second ante`() {
+        val user = userWithBalance(150L) // can pay 100 ante but not another 100
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns user
+        every { blackjack.dealStartingHands(any()) } returns Blackjack.StartingDeal(
+            mutableListOf(c(Rank.EIGHT), c(Rank.EIGHT, Suit.HEARTS)),
+            mutableListOf(c(Rank.SIX), c(Rank.TEN))
+        )
+        val deal = service.dealSolo(discordId, guildId, stake = 100L)
+        val tableId = (deal as BlackjackService.SoloDealOutcome.Dealt).tableId
+        // After deal: balance is 50.
+        val outcome = service.applySoloAction(discordId, guildId, tableId, Blackjack.Action.SPLIT)
+        val short = assertInstanceOf(
+            BlackjackService.SoloActionOutcome.InsufficientCreditsForSplit::class.java, outcome
+        )
+        assertEquals(100L, short.needed)
+        assertEquals(50L, short.have)
+    }
+
+    @Test
+    fun `solo SPLIT aces auto-stand both hands and play out the dealer`() {
+        val user = userWithBalance(1_000L)
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns user
+        every { blackjack.dealStartingHands(any()) } returns Blackjack.StartingDeal(
+            mutableListOf(c(Rank.ACE), c(Rank.ACE, Suit.HEARTS)),
+            mutableListOf(c(Rank.NINE), c(Rank.SEVEN))
+        )
+        val deal = service.dealSolo(discordId, guildId, stake = 100L)
+        val tableId = (deal as BlackjackService.SoloDealOutcome.Dealt).tableId
+
+        // Each split hand gets one card dealt (which we stub).
+        every { blackjack.hit(any(), any()) } answers {
+            firstArg<MutableList<Card>>().add(c(Rank.KING, Suit.HEARTS))
+        }
+        // Both split-hand 21s won't claim natural BJ premium; treat as regular wins.
+        every { blackjack.evaluate(any(), any(), any()) } returns Blackjack.Result.PLAYER_WIN
+
+        val outcome = service.applySoloAction(discordId, guildId, tableId, Blackjack.Action.SPLIT)
+        // Aces split auto-stands both hands → resolution happens immediately.
+        val resolved = assertInstanceOf(BlackjackService.SoloActionOutcome.Resolved::class.java, outcome)
+        // Both hands win 1× → balance: 800 (after split) + 100 stake refund * 2 + 100 win * 2 = 1200.
+        assertEquals(1_200L, user.socialCredit)
+        // Two PerHandResult entries.
+        assertEquals(2, resolved.result.perHandResults.size)
+        assertTrue(resolved.result.perHandResults.all { it.fromSplit })
+    }
+
     @Test
     fun `slot capture is harmless`() {
         val s = slot<UserDto>()

--- a/discord-bot/src/main/kotlin/bot/toby/button/buttons/BlackjackButton.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/button/buttons/BlackjackButton.kt
@@ -156,6 +156,7 @@ class BlackjackButton @Autowired constructor(
         BlackjackEmbeds.Action.HIT -> Blackjack.Action.HIT
         BlackjackEmbeds.Action.STAND -> Blackjack.Action.STAND
         BlackjackEmbeds.Action.DOUBLE -> Blackjack.Action.DOUBLE
+        BlackjackEmbeds.Action.SPLIT -> Blackjack.Action.SPLIT
         BlackjackEmbeds.Action.PEEK -> null
     }
 

--- a/discord-bot/src/main/kotlin/bot/toby/button/buttons/BlackjackButton.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/button/buttons/BlackjackButton.kt
@@ -6,6 +6,7 @@ import core.button.ButtonContext
 import database.blackjack.Blackjack
 import database.blackjack.BlackjackTable
 import database.blackjack.BlackjackTableRegistry
+import database.blackjack.canSplit
 import database.dto.UserDto
 import database.service.BlackjackService
 import database.service.BlackjackService.MultiActionOutcome
@@ -81,9 +82,14 @@ class BlackjackButton @Autowired constructor(
             is SoloActionOutcome.Continued -> {
                 val live = tableRegistry.get(table.id) ?: return
                 val liveSeat = live.seats.firstOrNull()
-                val allowDouble = liveSeat != null && liveSeat.hand.size == 2 && !liveSeat.doubled
+                val active = liveSeat?.activeHand
+                val allowDouble = active != null && active.cards.size == 2 && !active.doubled
+                val allowSplit = active != null &&
+                    !active.doubled &&
+                    canSplit(active.cards) &&
+                    liveSeat.hands.size < Blackjack.MAX_SPLIT_HANDS
                 event.message.editMessageEmbeds(BlackjackEmbeds.soloDealEmbed(live))
-                    .setComponents(soloActionRow(table.id, allowDouble))
+                    .setComponents(soloActionRow(table.id, allowDouble, allowSplit))
                     .queue()
             }
             is SoloActionOutcome.Resolved -> {
@@ -99,6 +105,9 @@ class BlackjackButton @Autowired constructor(
             SoloActionOutcome.IllegalAction -> sendError(event, "You can't do that right now.")
             is SoloActionOutcome.InsufficientCreditsForDouble -> sendError(
                 event, "Need ${outcome.needed} credits to double — you only have ${outcome.have}."
+            )
+            is SoloActionOutcome.InsufficientCreditsForSplit -> sendError(
+                event, "Need ${outcome.needed} credits to split — you only have ${outcome.have}."
             )
         }
     }
@@ -136,6 +145,9 @@ class BlackjackButton @Autowired constructor(
             is MultiActionOutcome.InsufficientCreditsForDouble -> sendError(
                 event, "Need ${outcome.needed} credits to double — you only have ${outcome.have}."
             )
+            is MultiActionOutcome.InsufficientCreditsForSplit -> sendError(
+                event, "Need ${outcome.needed} credits to split — you only have ${outcome.have}."
+            )
         }
     }
 
@@ -160,7 +172,7 @@ class BlackjackButton @Autowired constructor(
         BlackjackEmbeds.Action.PEEK -> null
     }
 
-    private fun soloActionRow(tableId: Long, allowDouble: Boolean): List<ActionRow> {
+    private fun soloActionRow(tableId: Long, allowDouble: Boolean, allowSplit: Boolean): List<ActionRow> {
         val buttons = mutableListOf(
             JdaButton.primary(BlackjackEmbeds.buttonId(BlackjackEmbeds.Action.HIT, tableId), "Hit"),
             JdaButton.success(BlackjackEmbeds.buttonId(BlackjackEmbeds.Action.STAND, tableId), "Stand"),
@@ -168,6 +180,11 @@ class BlackjackButton @Autowired constructor(
         if (allowDouble) {
             buttons.add(
                 JdaButton.secondary(BlackjackEmbeds.buttonId(BlackjackEmbeds.Action.DOUBLE, tableId), "Double Down")
+            )
+        }
+        if (allowSplit) {
+            buttons.add(
+                JdaButton.secondary(BlackjackEmbeds.buttonId(BlackjackEmbeds.Action.SPLIT, tableId), "Split")
             )
         }
         return listOf(ActionRow.of(buttons))
@@ -178,6 +195,7 @@ class BlackjackButton @Autowired constructor(
             JdaButton.primary(BlackjackEmbeds.buttonId(BlackjackEmbeds.Action.HIT, tableId), "Hit"),
             JdaButton.success(BlackjackEmbeds.buttonId(BlackjackEmbeds.Action.STAND, tableId), "Stand"),
             JdaButton.secondary(BlackjackEmbeds.buttonId(BlackjackEmbeds.Action.DOUBLE, tableId), "Double Down"),
+            JdaButton.secondary(BlackjackEmbeds.buttonId(BlackjackEmbeds.Action.SPLIT, tableId), "Split"),
             JdaButton.secondary(BlackjackEmbeds.buttonId(BlackjackEmbeds.Action.PEEK, tableId), "Peek"),
         )
     )

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/BlackjackCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/BlackjackCommand.kt
@@ -5,6 +5,7 @@ import core.command.CommandContext
 import database.blackjack.Blackjack
 import database.blackjack.BlackjackTable
 import database.blackjack.BlackjackTableRegistry
+import database.blackjack.canSplit
 import database.dto.UserDto
 import database.service.BlackjackService
 import database.service.BlackjackService.MultiCreateOutcome
@@ -133,8 +134,10 @@ class BlackjackCommand @Autowired constructor(
             is SoloDealOutcome.Dealt -> {
                 val table = tableRegistry.get(outcome.tableId)
                     ?: return replyError(event, "Hand vanished.", deleteDelay)
+                val active = table.seats.firstOrNull()?.activeHand
+                val allowSplit = active != null && canSplit(active.cards)
                 event.hook.sendMessageEmbeds(BlackjackEmbeds.soloDealEmbed(table))
-                    .addComponents(soloActionRow(outcome.tableId, allowDouble = true))
+                    .addComponents(soloActionRow(outcome.tableId, allowDouble = true, allowSplit = allowSplit))
                     .queue()
             }
             is SoloDealOutcome.Resolved -> {
@@ -355,7 +358,7 @@ class BlackjackCommand @Autowired constructor(
             .queue(invokeDeleteOnMessageResponse(deleteDelay))
     }
 
-    private fun soloActionRow(tableId: Long, allowDouble: Boolean): ActionRow {
+    private fun soloActionRow(tableId: Long, allowDouble: Boolean, allowSplit: Boolean): ActionRow {
         val buttons = mutableListOf(
             Button.primary(BlackjackEmbeds.buttonId(BlackjackEmbeds.Action.HIT, tableId), "Hit"),
             Button.success(BlackjackEmbeds.buttonId(BlackjackEmbeds.Action.STAND, tableId), "Stand"),
@@ -365,6 +368,11 @@ class BlackjackCommand @Autowired constructor(
                 Button.secondary(BlackjackEmbeds.buttonId(BlackjackEmbeds.Action.DOUBLE, tableId), "Double Down")
             )
         }
+        if (allowSplit) {
+            buttons.add(
+                Button.secondary(BlackjackEmbeds.buttonId(BlackjackEmbeds.Action.SPLIT, tableId), "Split")
+            )
+        }
         return ActionRow.of(buttons)
     }
 
@@ -372,6 +380,7 @@ class BlackjackCommand @Autowired constructor(
         Button.primary(BlackjackEmbeds.buttonId(BlackjackEmbeds.Action.HIT, tableId), "Hit"),
         Button.success(BlackjackEmbeds.buttonId(BlackjackEmbeds.Action.STAND, tableId), "Stand"),
         Button.secondary(BlackjackEmbeds.buttonId(BlackjackEmbeds.Action.DOUBLE, tableId), "Double Down"),
+        Button.secondary(BlackjackEmbeds.buttonId(BlackjackEmbeds.Action.SPLIT, tableId), "Split"),
         Button.secondary(BlackjackEmbeds.buttonId(BlackjackEmbeds.Action.PEEK, tableId), "Peek"),
     )
 

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/BlackjackEmbeds.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/BlackjackEmbeds.kt
@@ -72,18 +72,40 @@ internal object BlackjackEmbeds {
 
     fun soloDealEmbed(table: BlackjackTable): MessageEmbed {
         val seat = table.seats.firstOrNull()
-        val playerHand = seat?.hand.orEmpty()
-        val title = "$TITLE • ${seat?.stake ?: 0L} credits at risk"
+        val totalAtRisk = seat?.totalStake ?: 0L
+        val title = "$TITLE • $totalAtRisk credits at risk"
         val description = buildString {
-            append("**You:** ").append(handLine(playerHand)).append('\n')
-            append("**Dealer:** ").append(dealerUpLine(table.dealer))
+            append("**Dealer:** ").append(dealerUpLine(table.dealer)).append('\n')
+            if (seat == null || seat.hands.isEmpty()) {
+                append("**You:** —")
+            } else if (seat.hands.size == 1) {
+                append("**You:** ").append(handLine(seat.hands[0].cards))
+            } else {
+                append("**You:**\n")
+                for ((idx, slot) in seat.hands.withIndex()) {
+                    val arrow = if (idx == seat.activeHandIndex) "▶ " else "  "
+                    append("  ").append(arrow).append("Hand ${idx + 1}: ")
+                        .append(handLine(slot.cards))
+                        .append(handStatusBadge(slot.status))
+                        .append('\n')
+                }
+            }
         }
         return EmbedBuilder()
             .setTitle(title)
             .setDescription(description)
             .setColor(TABLE_COLOR)
-            .setFooter("Hit, Stand, or Double Down. Reaching 21 auto-stands.")
+            .setFooter("Hit, Stand, Double, or Split (matching pair). Reaching 21 auto-stands.")
             .build()
+    }
+
+    /** Inline status decoration appended to a hand's cards in the embed. */
+    private fun handStatusBadge(status: BlackjackTable.SeatStatus): String = when (status) {
+        BlackjackTable.SeatStatus.BLACKJACK -> " — **Blackjack!**"
+        BlackjackTable.SeatStatus.BUSTED -> " — **Bust**"
+        BlackjackTable.SeatStatus.STANDING -> " — Stand"
+        BlackjackTable.SeatStatus.DOUBLED -> " — Doubled"
+        BlackjackTable.SeatStatus.ACTIVE -> ""
     }
 
     fun soloResolvedEmbed(
@@ -93,37 +115,86 @@ internal object BlackjackEmbeds {
         jackpotPayout: Long,
         lossTribute: Long
     ): MessageEmbed {
-        val seat = table.seats.firstOrNull()
-        val playerHand = seat?.hand.orEmpty()
-        val playerResult = result.seatResults.values.firstOrNull() ?: Blackjack.Result.PUSH
-        val payout = result.payouts.values.firstOrNull() ?: 0L
-        val stake = seat?.stake ?: result.pot
-        val net = payout - stake
-        val verdict = when (playerResult) {
-            Blackjack.Result.PLAYER_BLACKJACK -> "Blackjack! +$net credits (3:2 payout)."
-            Blackjack.Result.PLAYER_WIN -> "You win! +$net credits."
-            Blackjack.Result.PUSH -> "Push — your $stake credits come back."
-            Blackjack.Result.DEALER_WIN -> "Dealer wins. -$stake credits."
-            Blackjack.Result.PLAYER_BUST -> "Bust. -$stake credits."
-        }
+        val perHand = result.perHandResults
+        val totalPayout = result.payouts.values.sum()
+        val totalStake = result.pot
+        val net = totalPayout - totalStake
         val description = buildString {
-            append("**You:** ").append(handLine(playerHand)).append('\n')
             append("**Dealer:** ").append(handLine(result.dealer)).append('\n')
-            append('\n').append(verdict)
+            if (perHand.size <= 1) {
+                // Classic single-hand flow.
+                val seat = table.seats.firstOrNull()
+                val playerHand = perHand.firstOrNull()?.cards ?: seat?.hand.orEmpty()
+                append("**You:** ").append(handLine(playerHand)).append('\n')
+            } else {
+                append("**You:**\n")
+                for (h in perHand) {
+                    append("  Hand ${h.handIndex + 1}: ").append(handLine(h.cards))
+                        .append(" — ").append(verdictLabel(h.result, h.payout, h.stake))
+                        .append('\n')
+                }
+            }
+            append('\n').append(soloOverallVerdict(perHand, totalStake, net))
             if (jackpotPayout > 0L) append("\n🎰 Jackpot hit! +$jackpotPayout credits.")
             if (lossTribute > 0L) append("\n💰 +$lossTribute credits to the jackpot pool.")
         }
-        val color = when (playerResult) {
-            Blackjack.Result.PLAYER_BLACKJACK, Blackjack.Result.PLAYER_WIN -> WagerCommandColors.WIN
-            Blackjack.Result.PUSH -> NEUTRAL_COLOR
-            Blackjack.Result.DEALER_WIN, Blackjack.Result.PLAYER_BUST -> WagerCommandColors.LOSE
-        }
+        val color = soloOverallColor(perHand, net)
         return EmbedBuilder()
             .setTitle(TITLE)
             .setDescription(description)
             .addField("New balance", "$newBalance credits", true)
             .setColor(color)
             .build()
+    }
+
+    private fun verdictLabel(result: Blackjack.Result, payout: Long, stake: Long): String = when (result) {
+        Blackjack.Result.PLAYER_BLACKJACK -> "🎉 Blackjack +${payout - stake}"
+        Blackjack.Result.PLAYER_WIN -> "✅ Win +${payout - stake}"
+        Blackjack.Result.PUSH -> "🤝 Push (refunded $stake)"
+        Blackjack.Result.DEALER_WIN -> "❌ Lose -$stake"
+        Blackjack.Result.PLAYER_BUST -> "💥 Bust -$stake"
+    }
+
+    private fun soloOverallVerdict(
+        perHand: List<BlackjackTable.PerHandResult>,
+        totalStake: Long,
+        net: Long,
+    ): String {
+        if (perHand.size <= 1) {
+            val r = perHand.firstOrNull()?.result ?: Blackjack.Result.PUSH
+            val stake = perHand.firstOrNull()?.stake ?: totalStake
+            return when (r) {
+                Blackjack.Result.PLAYER_BLACKJACK -> "Blackjack! +$net credits (3:2 payout)."
+                Blackjack.Result.PLAYER_WIN -> "You win! +$net credits."
+                Blackjack.Result.PUSH -> "Push — your $stake credits come back."
+                Blackjack.Result.DEALER_WIN -> "Dealer wins. -$stake credits."
+                Blackjack.Result.PLAYER_BUST -> "Bust. -$stake credits."
+            }
+        }
+        return when {
+            net > 0 -> "Across ${perHand.size} hands: net **+$net credits**."
+            net < 0 -> "Across ${perHand.size} hands: net **$net credits**."
+            else -> "Across ${perHand.size} hands: broke even."
+        }
+    }
+
+    private fun soloOverallColor(
+        perHand: List<BlackjackTable.PerHandResult>,
+        net: Long,
+    ): Color {
+        if (perHand.size <= 1) {
+            val r = perHand.firstOrNull()?.result ?: Blackjack.Result.PUSH
+            return when (r) {
+                Blackjack.Result.PLAYER_BLACKJACK, Blackjack.Result.PLAYER_WIN -> WagerCommandColors.WIN
+                Blackjack.Result.PUSH -> NEUTRAL_COLOR
+                Blackjack.Result.DEALER_WIN, Blackjack.Result.PLAYER_BUST -> WagerCommandColors.LOSE
+            }
+        }
+        return when {
+            net > 0 -> WagerCommandColors.WIN
+            net < 0 -> WagerCommandColors.LOSE
+            else -> NEUTRAL_COLOR
+        }
     }
 
     // --- MULTI ---
@@ -152,28 +223,39 @@ internal object BlackjackEmbeds {
         val description = buildString {
             append("**Dealer:** ").append(dealerUpLine(table.dealer)).append("\n\n")
             for ((i, seat) in table.seats.withIndex()) {
-                val arrow = if (i == table.actorIndex && table.phase == BlackjackTable.Phase.PLAYER_TURNS) "▶ " else "  "
-                val statusBadge = when (seat.status) {
-                    BlackjackTable.SeatStatus.BLACKJACK -> " — **Blackjack!**"
-                    BlackjackTable.SeatStatus.BUSTED -> " — **Bust**"
-                    BlackjackTable.SeatStatus.STANDING -> " — Stand"
-                    BlackjackTable.SeatStatus.DOUBLED -> " — Doubled"
-                    BlackjackTable.SeatStatus.ACTIVE -> ""
+                val isActorSeat = i == table.actorIndex && table.phase == BlackjackTable.Phase.PLAYER_TURNS
+                val seatArrow = if (isActorSeat) "▶ " else "  "
+                if (seat.hands.size <= 1) {
+                    val slot = seat.hands.firstOrNull()
+                    val cards = slot?.cards ?: emptyList()
+                    val status = slot?.status ?: BlackjackTable.SeatStatus.ACTIVE
+                    append(seatArrow).append("<@${seat.discordId}>: ")
+                        .append(handLine(cards))
+                        .append(handStatusBadge(status))
+                        .append('\n')
+                } else {
+                    append(seatArrow).append("<@${seat.discordId}> (${seat.hands.size} hands):\n")
+                    for ((handIdx, slot) in seat.hands.withIndex()) {
+                        val handArrow = if (isActorSeat && handIdx == seat.activeHandIndex) "▶ " else "  "
+                        append("  ").append(handArrow).append("Hand ${handIdx + 1}: ")
+                            .append(handLine(slot.cards))
+                            .append(handStatusBadge(slot.status))
+                            .append('\n')
+                    }
                 }
-                append(arrow).append("<@${seat.discordId}>: ")
-                    .append(handLine(seat.hand))
-                    .append(statusBadge)
-                    .append('\n')
             }
             val actor = table.seats.getOrNull(table.actorIndex)
             if (table.phase == BlackjackTable.Phase.PLAYER_TURNS && actor != null) {
                 append("\nTo act: <@${actor.discordId}>")
+                if (actor.hands.size > 1) {
+                    append(" (Hand ${actor.activeHandIndex + 1} of ${actor.hands.size})")
+                }
             }
         }
         return EmbedBuilder()
             .setTitle("$TITLE • Table #${table.id} • Hand #${table.handNumber}")
             .setDescription(description)
-            .setFooter("Click Hit, Stand, or Double on your turn. Peek to see your cards.")
+            .setFooter("Hit / Stand / Double / Split (matching pair) on your turn. Peek shows your cards.")
             .setColor(TABLE_COLOR)
             .build()
     }
@@ -181,16 +263,34 @@ internal object BlackjackEmbeds {
     fun multiResolvedEmbed(table: BlackjackTable, result: BlackjackTable.HandResult): MessageEmbed {
         val description = buildString {
             append("**Dealer:** ").append(handLine(result.dealer)).append("\n\n")
-            for ((id, r) in result.seatResults) {
-                val payout = result.payouts[id] ?: 0L
-                val verdict = when (r) {
-                    Blackjack.Result.PLAYER_BLACKJACK -> "🎉 Blackjack — +$payout"
-                    Blackjack.Result.PLAYER_WIN -> "✅ Win — +$payout"
-                    Blackjack.Result.PUSH -> "🤝 Push — refunded $payout"
-                    Blackjack.Result.DEALER_WIN -> "❌ Lose"
-                    Blackjack.Result.PLAYER_BUST -> "💥 Bust"
+            if (result.perHandResults.isNotEmpty()) {
+                // Group per-hand outcomes by discordId for readable output.
+                val grouped = result.perHandResults.groupBy { it.discordId }
+                for ((id, hands) in grouped) {
+                    if (hands.size == 1) {
+                        val h = hands[0]
+                        append("<@$id>: ").append(verdictLabel(h.result, h.payout, h.stake)).append('\n')
+                    } else {
+                        append("<@$id>:\n")
+                        for (h in hands) {
+                            append("  Hand ${h.handIndex + 1}: ")
+                                .append(verdictLabel(h.result, h.payout, h.stake))
+                                .append('\n')
+                        }
+                    }
                 }
-                append("<@$id>: ").append(verdict).append('\n')
+            } else {
+                for ((id, r) in result.seatResults) {
+                    val payout = result.payouts[id] ?: 0L
+                    val verdict = when (r) {
+                        Blackjack.Result.PLAYER_BLACKJACK -> "🎉 Blackjack — +$payout"
+                        Blackjack.Result.PLAYER_WIN -> "✅ Win — +$payout"
+                        Blackjack.Result.PUSH -> "🤝 Push — refunded $payout"
+                        Blackjack.Result.DEALER_WIN -> "❌ Lose"
+                        Blackjack.Result.PLAYER_BUST -> "💥 Bust"
+                    }
+                    append("<@$id>: ").append(verdict).append('\n')
+                }
             }
             append("\nPot **${result.pot}** • rake **${result.rake}** → jackpot")
         }

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/BlackjackEmbeds.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/BlackjackEmbeds.kt
@@ -32,7 +32,7 @@ internal object BlackjackEmbeds {
     private val NEUTRAL_COLOR = Color(0xA0, 0xA0, 0xB0)
     private const val HIDDEN = "🂠"
 
-    enum class Action { HIT, STAND, DOUBLE, PEEK }
+    enum class Action { HIT, STAND, DOUBLE, SPLIT, PEEK }
 
     fun buttonId(action: Action, tableId: Long): String =
         listOf(BUTTON_NAME, action.name, tableId.toString()).joinToString(BUTTON_DELIM)

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/economy/BlackjackEmbedsTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/economy/BlackjackEmbedsTest.kt
@@ -149,15 +149,31 @@ class BlackjackEmbedsTest {
         maxSeats = 5
     )
 
-    private fun result(table: BlackjackTable, r: Blackjack.Result, payout: Long): BlackjackTable.HandResult =
-        BlackjackTable.HandResult(
+    private fun result(table: BlackjackTable, r: Blackjack.Result, payout: Long): BlackjackTable.HandResult {
+        val seat = table.seats.firstOrNull()
+        val perHand = if (seat != null) listOf(
+            BlackjackTable.PerHandResult(
+                discordId = seat.discordId,
+                handIndex = 0,
+                cards = seat.hand.toList(),
+                total = 0,
+                stake = seat.stake,
+                doubled = false,
+                fromSplit = false,
+                result = r,
+                payout = payout,
+            )
+        ) else emptyList()
+        return BlackjackTable.HandResult(
             handNumber = table.handNumber,
             dealer = table.dealer.toList(),
             dealerTotal = 17,
-            seatResults = mapOf(1L to r),
-            payouts = if (payout > 0L) mapOf(1L to payout) else emptyMap(),
+            seatResults = mapOf((seat?.discordId ?: 1L) to r),
+            payouts = if (payout > 0L) mapOf((seat?.discordId ?: 1L) to payout) else emptyMap(),
             pot = 100L,
             rake = 0L,
-            resolvedAt = Instant.now()
+            resolvedAt = Instant.now(),
+            perHandResults = perHand,
         )
+    }
 }

--- a/web/src/main/kotlin/web/controller/BlackjackController.kt
+++ b/web/src/main/kotlin/web/controller/BlackjackController.kt
@@ -250,6 +250,8 @@ class BlackjackController(
             SoloActionOutcome.IllegalAction -> errors.badRequest("You can't do that right now.")
             is SoloActionOutcome.InsufficientCreditsForDouble ->
                 errors.insufficientCredits(outcome.needed, outcome.have)
+            is SoloActionOutcome.InsufficientCreditsForSplit ->
+                errors.insufficientCredits(outcome.needed, outcome.have)
         }
     }
 
@@ -404,6 +406,8 @@ class BlackjackController(
                 .body(BlackjackActionResponse(false, error = "No such table."))
             is MultiActionOutcome.InsufficientCreditsForDouble ->
                 errors.insufficientCredits(outcome.needed, outcome.have)
+            is MultiActionOutcome.InsufficientCreditsForSplit ->
+                errors.insufficientCredits(outcome.needed, outcome.have)
         }
     }
 
@@ -418,6 +422,7 @@ class BlackjackController(
         "hit" -> Blackjack.Action.HIT
         "stand" -> Blackjack.Action.STAND
         "double" -> Blackjack.Action.DOUBLE
+        "split" -> Blackjack.Action.SPLIT
         else -> null
     }
 

--- a/web/src/main/kotlin/web/service/BlackjackWebService.kt
+++ b/web/src/main/kotlin/web/service/BlackjackWebService.kt
@@ -1,8 +1,10 @@
 package web.service
 
+import database.blackjack.Blackjack
 import database.blackjack.BlackjackTable
 import database.blackjack.BlackjackTableRegistry
 import database.blackjack.bestTotal
+import database.blackjack.canSplit
 import database.blackjack.isSoft
 import database.card.Card
 import org.springframework.stereotype.Service
@@ -36,9 +38,33 @@ class BlackjackWebService(
         val doubled: Boolean,
         val status: String,
         val pendingLeave: Boolean,
+        /**
+         * The seat's currently-active hand cards. For non-split seats
+         * this is just the dealt 2-card (then hit-into-N-card) hand.
+         * For split seats it's whichever sub-hand is being played right
+         * now; the full split breakdown lives on [hands] and
+         * [activeHandIndex].
+         */
         val hand: List<String>,
         val total: Int,
         val soft: Boolean,
+        /**
+         * One entry per split branch (always ≥1). Same shape as the
+         * legacy single-hand view extended per slot, so the JS
+         * renderer can iterate this directly when [hands].size > 1.
+         */
+        val hands: List<HandSlotView> = emptyList(),
+        val activeHandIndex: Int = 0,
+    )
+
+    data class HandSlotView(
+        val cards: List<String>,
+        val total: Int,
+        val soft: Boolean,
+        val stake: Long,
+        val doubled: Boolean,
+        val status: String,
+        val fromSplit: Boolean,
     )
 
     data class TableStateView(
@@ -58,6 +84,8 @@ class BlackjackWebService(
         val mySeatIndex: Int?,
         val isMyTurn: Boolean,
         val canDouble: Boolean,
+        /** True iff the active hand is a 2-card pair the viewer can SPLIT. */
+        val canSplit: Boolean,
         val shotClockSeconds: Int,
         val currentActorDeadlineEpochMillis: Long?,
         val lastResult: HandResultView?,
@@ -71,6 +99,20 @@ class BlackjackWebService(
         val payouts: Map<String, Long>,
         val pot: Long,
         val rake: Long,
+        /** One entry per (seat, split-branch) pair. Empty for v1 callers. */
+        val perHandResults: List<PerHandResultView> = emptyList(),
+    )
+
+    data class PerHandResultView(
+        val discordId: Long,
+        val handIndex: Int,
+        val cards: List<String>,
+        val total: Int,
+        val stake: Long,
+        val doubled: Boolean,
+        val fromSplit: Boolean,
+        val result: String,
+        val payout: Long,
     )
 
     fun listMultiTables(guildId: Long): List<TableSummaryView> =
@@ -102,6 +144,10 @@ class BlackjackWebService(
                 mySeat?.status == BlackjackTable.SeatStatus.ACTIVE
             val canDouble = isMyTurn && mySeat != null &&
                 mySeat.hand.size == 2 && !mySeat.doubled
+            val canSplitNow = isMyTurn && mySeat != null &&
+                !mySeat.doubled &&
+                canSplit(mySeat.hand) &&
+                mySeat.hands.size < Blackjack.MAX_SPLIT_HANDS
 
             // Mask dealer hole card while players are still acting.
             val dealerVisible = if (table.phase == BlackjackTable.Phase.PLAYER_TURNS && table.dealer.size > 1) {
@@ -136,6 +182,18 @@ class BlackjackWebService(
                         hand = seat.hand.map(Card::toString),
                         total = bestTotal(seat.hand),
                         soft = isSoft(seat.hand),
+                        hands = seat.hands.map { slot ->
+                            HandSlotView(
+                                cards = slot.cards.map(Card::toString),
+                                total = bestTotal(slot.cards),
+                                soft = isSoft(slot.cards),
+                                stake = slot.stake,
+                                doubled = slot.doubled,
+                                status = slot.status.name,
+                                fromSplit = slot.fromSplit,
+                            )
+                        },
+                        activeHandIndex = seat.activeHandIndex,
                     )
                 },
                 dealer = dealerVisible,
@@ -143,6 +201,7 @@ class BlackjackWebService(
                 mySeatIndex = mySeatIndex,
                 isMyTurn = isMyTurn,
                 canDouble = canDouble,
+                canSplit = canSplitNow,
                 shotClockSeconds = table.shotClockSeconds,
                 currentActorDeadlineEpochMillis = table.currentActorDeadline?.toEpochMilli(),
                 lastResult = table.lastResult?.let { result ->
@@ -155,6 +214,19 @@ class BlackjackWebService(
                         payouts = result.payouts.mapKeys { it.key.toString() },
                         pot = result.pot,
                         rake = result.rake,
+                        perHandResults = result.perHandResults.map { perHand ->
+                            PerHandResultView(
+                                discordId = perHand.discordId,
+                                handIndex = perHand.handIndex,
+                                cards = perHand.cards.map(Card::toString),
+                                total = perHand.total,
+                                stake = perHand.stake,
+                                doubled = perHand.doubled,
+                                fromSplit = perHand.fromSplit,
+                                result = perHand.result.name,
+                                payout = perHand.payout,
+                            )
+                        },
                     )
                 }
             )

--- a/web/src/main/resources/static/js/blackjack-solo.js
+++ b/web/src/main/resources/static/js/blackjack-solo.js
@@ -11,10 +11,12 @@
     var dealerCardsEl = document.getElementById("bj-dealer-cards");
     var dealerTotalEl = document.getElementById("bj-dealer-total");
     var playerCardsEl = document.getElementById("bj-player-cards");
+    var playerHandsEl = document.getElementById("bj-player-hands");
     var playerTotalEl = document.getElementById("bj-player-total");
     var hitBtn = document.getElementById("bj-action-hit");
     var standBtn = document.getElementById("bj-action-stand");
     var doubleBtn = document.getElementById("bj-action-double");
+    var splitBtn = document.getElementById("bj-action-split");
     var resultEl = document.getElementById("bj-result");
 
     var pollTimer = null;
@@ -45,19 +47,36 @@
             ? "(" + state.dealerTotalVisible + ")" : "";
 
         var seat = state.seats && state.seats.length ? state.seats[0] : null;
-        renderCards(playerCardsEl, seat ? seat.hand : []);
-        playerTotalEl.textContent = seat ? "(" + seat.total + ")" : "";
+        var slots = (seat && seat.hands && seat.hands.length) ? seat.hands : null;
+        if (slots && slots.length > 1) {
+            // Split flow: render a per-hand block, hide the single-hand
+            // layout, and show the active hand's running total.
+            playerCardsEl.hidden = true;
+            playerHandsEl.hidden = false;
+            renderSplitHands(playerHandsEl, slots, seat.activeHandIndex);
+            var active = slots[seat.activeHandIndex] || slots[0];
+            playerTotalEl.textContent = active ? "(active hand: " + active.total + ")" : "";
+        } else {
+            playerHandsEl.hidden = true;
+            playerCardsEl.hidden = false;
+            renderCards(playerCardsEl, seat ? seat.hand : []);
+            playerTotalEl.textContent = seat ? "(" + seat.total + ")" : "";
+        }
 
         if (state.phase === "PLAYER_TURNS" && state.isMyTurn) {
             hitBtn.disabled = false;
             standBtn.disabled = false;
             doubleBtn.disabled = !state.canDouble;
+            splitBtn.hidden = !state.canSplit;
+            splitBtn.disabled = !state.canSplit;
             resultEl.textContent = "";
             resultEl.className = "bj-result muted";
         } else {
             hitBtn.disabled = true;
             standBtn.disabled = true;
             doubleBtn.disabled = true;
+            splitBtn.disabled = true;
+            splitBtn.hidden = true;
         }
 
         if (state.lastResult && state.phase === "RESOLVED") {
@@ -170,6 +189,36 @@
     hitBtn.addEventListener("click", function () { postAction("hit"); });
     standBtn.addEventListener("click", function () { postAction("stand"); });
     doubleBtn.addEventListener("click", function () { postAction("double"); });
+    splitBtn.addEventListener("click", function () { postAction("split"); });
+
+    function renderSplitHands(container, slots, activeIndex) {
+        container.innerHTML = "";
+        slots.forEach(function (slot, idx) {
+            var div = document.createElement("div");
+            div.className = "bj-seat";
+            if (idx === activeIndex) div.classList.add("bj-seat-active");
+            if (slot.status === "BUSTED") div.classList.add("bj-seat-busted");
+            var header = document.createElement("div");
+            header.className = "bj-seat-header";
+            var label = "Hand " + (idx + 1);
+            var statusBits = [];
+            if (slot.doubled) statusBits.push("Doubled");
+            switch (slot.status) {
+                case "BLACKJACK": statusBits.push("Blackjack"); break;
+                case "BUSTED": statusBits.push("Bust"); break;
+                case "STANDING": statusBits.push("Stand"); break;
+            }
+            header.innerHTML = "<span>" + label + " — stake " + slot.stake + "</span>" +
+                "<span class=\"bj-seat-status\">(" + slot.total + ")" +
+                (statusBits.length ? " " + statusBits.join(" · ") : "") + "</span>";
+            div.appendChild(header);
+            var cards = document.createElement("div");
+            cards.className = "bj-cards";
+            renderCards(cards, slot.cards);
+            div.appendChild(cards);
+            container.appendChild(div);
+        });
+    }
 
     // On page load, see if there's an existing in-flight hand for this user.
     refreshState().then(function () {

--- a/web/src/main/resources/static/js/blackjack-table.js
+++ b/web/src/main/resources/static/js/blackjack-table.js
@@ -16,6 +16,7 @@
     var hitBtn = document.getElementById("bj-action-hit");
     var standBtn = document.getElementById("bj-action-stand");
     var doubleBtn = document.getElementById("bj-action-double");
+    var splitBtn = document.getElementById("bj-action-split");
     var startBtn = document.getElementById("bj-action-start");
     var leaveBtn = document.getElementById("bj-action-leave");
     var statusEl = document.getElementById("bj-status");
@@ -60,11 +61,26 @@
     function renderSeats(state) {
         seatsEl.innerHTML = "";
         (state.seats || []).forEach(function (seat, idx) {
+            var slots = (seat.hands && seat.hands.length) ? seat.hands : null;
+            var isActorSeat = idx === state.actorIndex && state.phase === "PLAYER_TURNS";
+            if (slots && slots.length > 1) {
+                // Split seat: render the seat header once, then a sub-block per hand.
+                var groupHeader = document.createElement("div");
+                groupHeader.className = "bj-seat-header";
+                groupHeader.innerHTML = "<span>" +
+                    (seat.discordId === parseInt(myId, 10) ? "You" : "@" + seat.discordId) +
+                    " — " + slots.length + " hands</span>" +
+                    (seat.pendingLeave ? "<span class=\"bj-seat-status\">leaving</span>" : "");
+                seatsEl.appendChild(groupHeader);
+                slots.forEach(function (slot, slotIdx) {
+                    seatsEl.appendChild(renderSlot(seat, slot, slotIdx, isActorSeat && slotIdx === seat.activeHandIndex));
+                });
+                return;
+            }
+            // Single-hand path (back-compat with v1 seat shape).
             var div = document.createElement("div");
             div.className = "bj-seat";
-            if (idx === state.actorIndex && state.phase === "PLAYER_TURNS") {
-                div.classList.add("bj-seat-active");
-            }
+            if (isActorSeat) div.classList.add("bj-seat-active");
             if (seat.status === "BUSTED") div.classList.add("bj-seat-busted");
             var header = document.createElement("div");
             header.className = "bj-seat-header";
@@ -78,6 +94,24 @@
             div.appendChild(cards);
             seatsEl.appendChild(div);
         });
+    }
+
+    function renderSlot(seat, slot, slotIdx, isActiveSlot) {
+        var div = document.createElement("div");
+        div.className = "bj-seat";
+        if (isActiveSlot) div.classList.add("bj-seat-active");
+        if (slot.status === "BUSTED") div.classList.add("bj-seat-busted");
+        var header = document.createElement("div");
+        header.className = "bj-seat-header";
+        header.innerHTML = "<span>  Hand " + (slotIdx + 1) +
+            " — stake " + slot.stake + (slot.doubled ? " (doubled)" : "") + "</span>" +
+            "<span class=\"bj-seat-status\">(" + slot.total + ") " + statusBadge(slot.status, false) + "</span>";
+        div.appendChild(header);
+        var cards = document.createElement("div");
+        cards.className = "bj-cards";
+        renderCards(cards, slot.cards);
+        div.appendChild(cards);
+        return div;
     }
 
     function renderState(state) {
@@ -104,10 +138,14 @@
             hitBtn.disabled = false;
             standBtn.disabled = false;
             doubleBtn.disabled = !state.canDouble;
+            splitBtn.disabled = !state.canSplit;
+            splitBtn.hidden = !state.canSplit;
         } else {
             hitBtn.disabled = true;
             standBtn.disabled = true;
             doubleBtn.disabled = true;
+            splitBtn.disabled = true;
+            splitBtn.hidden = true;
         }
 
         if (state.lastResult && state.phase === "LOBBY") {
@@ -195,6 +233,7 @@
     hitBtn.addEventListener("click", function () { postAction("hit"); });
     standBtn.addEventListener("click", function () { postAction("stand"); });
     doubleBtn.addEventListener("click", function () { postAction("double"); });
+    splitBtn.addEventListener("click", function () { postAction("split"); });
 
     startBtn.addEventListener("click", function () {
         window.TobyApi.postJson("/blackjack/" + guildId + "/" + tableId + "/start", {})

--- a/web/src/main/resources/templates/blackjack-solo.html
+++ b/web/src/main/resources/templates/blackjack-solo.html
@@ -40,13 +40,17 @@
         </div>
         <div class="bj-row">
             <h3>You <span class="muted" id="bj-player-total"></span></h3>
+            <!-- Single-hand layout for the v1 case; the JS hides this and
+                 populates [bj-player-hands] once a split happens. -->
             <div id="bj-player-cards" class="bj-cards"></div>
+            <div id="bj-player-hands" class="bj-seats" hidden></div>
         </div>
 
         <div class="bj-actions">
             <button id="bj-action-hit" class="btn-primary" type="button" disabled>Hit</button>
             <button id="bj-action-stand" class="btn-success" type="button" disabled>Stand</button>
             <button id="bj-action-double" class="btn-secondary" type="button" disabled>Double down</button>
+            <button id="bj-action-split" class="btn-secondary" type="button" disabled hidden>Split</button>
         </div>
 
         <div id="bj-result" class="bj-result muted"></div>

--- a/web/src/main/resources/templates/blackjack-table.html
+++ b/web/src/main/resources/templates/blackjack-table.html
@@ -45,6 +45,7 @@
             <button id="bj-action-hit" class="btn-primary" type="button" disabled>Hit</button>
             <button id="bj-action-stand" class="btn-success" type="button" disabled>Stand</button>
             <button id="bj-action-double" class="btn-secondary" type="button" disabled>Double down</button>
+            <button id="bj-action-split" class="btn-secondary" type="button" disabled hidden>Split</button>
             <button id="bj-action-start" class="btn-secondary" type="button" hidden>Deal next hand</button>
             <button id="bj-action-leave" class="btn-secondary" type="button" hidden>Leave table</button>
         </div>


### PR DESCRIPTION
## Summary

The biggest of the original blackjack follow-up items: classic **pair split**.

Players who get dealt a matching pair can SPLIT into two parallel hands by paying a second ante. Each hand is then played to completion independently (with full HIT / STAND / DOUBLE on each, including DAS), and the dealer plays out only after every split branch finishes. Re-splitting is allowed up to a hard cap of 4 hands per seat. Split aces auto-stand (one card each, no further hits or doubles, no natural-blackjack premium on the resulting 21s).

## Data model

- New `BlackjackTable.HandSlot` — one slot per split branch, each carrying its own cards / stake / doubled flag / status / `fromSplit` marker.
- `BlackjackTable.Seat` now holds a `hands: MutableList<HandSlot>` plus `activeHandIndex`. v1 single-hand callers keep working via backwards-compat accessors (`seat.hand`, `seat.stake`, `seat.doubled`, `seat.status`) that delegate to the active slot, and via a secondary constructor preserving the old `Seat(discordId, hand, ante, stake, doubled, status)` shape so existing tests don't have to migrate.
- New `BlackjackTable.PerHandResult` for per-split-hand outcomes; the existing per-discordId aggregate maps stay around for back-compat.

## Engine + service

- `Action.SPLIT` enum case + `canSplit(hand)` helper (matching blackjack values, so K-J-Q-T are all interchangeable).
- `Blackjack.evaluate(player, dealer, fromSplit = false)` — `fromSplit = true` suppresses the natural-BJ premium so split aces drawing a ten-value pay 1:1, not 3:2.
- `BlackjackService.applySoloAction` and `applyMultiAction` handle SPLIT via the same pre-check / pre-debit / under-lock-apply pattern DOUBLE uses. The active 2-card hand is replaced by two 2-card hands (one new card dealt to each), both flagged `fromSplit`.
- HIT / STAND / DOUBLE now operate on the active hand-slot and advance through any subsequent split branches before triggering dealer playout. Dealer plays out only when every slot is finished.
- `settleSolo` and `resolveMultiHand` iterate every hand-slot, evaluate each, sum payouts per-discordId, and roll one jackpot/loss-tribute per slot.

New outcome variants: `SoloActionOutcome.InsufficientCreditsForSplit`, `MultiActionOutcome.InsufficientCreditsForSplit`.

## UI

- Discord: embeds render per-slot lines with active-hand arrow, soloResolvedEmbed and multiResolvedEmbed iterate `perHandResults`, action rows include a Split button (conditional on the active hand being a pair for solo).
- Web: `SeatView.hands` (list of `HandSlotView`), `TableStateView.canSplit`, `HandResultView.perHandResults` projections; `BlackjackController.parseAction` accepts `"split"`; templates add a hidden Split button (`#bj-action-split`); the JS swaps in a per-slot layout when `seat.hands.length > 1`.

## Tests

- `canSplit` — pair detection across face cards (T/J/Q/K all splittable).
- `evaluate` — `fromSplit` suppresses the BJ premium.
- `BlackjackServiceTest` — solo SPLIT debits a second ante, rejects non-pairs as `IllegalAction`, rejects when wallet is short with the new `InsufficientCreditsForSplit` outcome, split aces auto-stand and pay 1:1 each (not 3:2).
- All existing database/web tests still pass.

## Test plan

- [x] `:database:test` and `:web:test` pass locally
- [ ] CI to validate `:discord-bot:test` and `:application:test`
- [ ] Manual: `/blackjack solo stake:50` → deal a pair → click Split → both hands play independently
- [ ] Manual: split aces → both hands auto-stand → settled at 1:1 each
- [ ] Manual: split a pair, double down on one of the resulting hands (DAS)
- [ ] Manual: web `/blackjack/{guildId}/solo` and `/blackjack/{guildId}/{tableId}` render per-hand layout with the Split button when applicable

https://claude.ai/code/session_012gsr3GLkqEs449fdgLDLL6

---
_Generated by [Claude Code](https://claude.ai/code/session_012gsr3GLkqEs449fdgLDLL6)_