### PR TITLE
fix(blackjack): keep resolved solo table around so /state can render result

### DIFF
--- a/database/src/main/kotlin/database/service/BlackjackService.kt
+++ b/database/src/main/kotlin/database/service/BlackjackService.kt
@@ -239,6 +239,11 @@ class BlackjackService @Autowired constructor(
         resolved.user.socialCredit = resolved.balance - stake
         userService.updateUser(resolved.user)
 
+        // Sweep any resolved solo table left behind by this user's previous
+        // hand — the action handler now leaves them in registry so the JS
+        // poll can render the result, but they shouldn't accumulate.
+        sweepResolvedSoloTablesFor(guildId, discordId)
+
         val table = tableRegistry.create(
             guildId = guildId,
             mode = BlackjackTable.Mode.SOLO,
@@ -548,6 +553,23 @@ class BlackjackService @Autowired constructor(
         if (table.phase == BlackjackTable.Phase.RESOLVED) {
             tableRegistry.remove(tableId)
         }
+    }
+
+    /**
+     * Drop every RESOLVED SOLO table this user is still seated at in [guildId].
+     * The action handler intentionally leaves a resolved table behind so the
+     * web JS can poll `/state` once more, render the result, and disable
+     * buttons; this method runs on the next deal to clear that residue before
+     * a fresh table is registered.
+     */
+    private fun sweepResolvedSoloTablesFor(guildId: Long, discordId: Long) {
+        tableRegistry.listForGuild(guildId)
+            .filter { t ->
+                t.mode == BlackjackTable.Mode.SOLO &&
+                    t.phase == BlackjackTable.Phase.RESOLVED &&
+                    t.seats.any { it.discordId == discordId }
+            }
+            .forEach { tableRegistry.remove(it.id) }
     }
 
     // -------------------------------------------------------------------------

--- a/web/src/main/kotlin/web/controller/BlackjackController.kt
+++ b/web/src/main/kotlin/web/controller/BlackjackController.kt
@@ -233,7 +233,10 @@ class BlackjackController(
         when (val outcome = blackjackService.applySoloAction(discordId, guildId, tableId, action)) {
             is SoloActionOutcome.Continued -> ResponseEntity.ok(BlackjackActionResponse(ok = true, tableId = tableId))
             is SoloActionOutcome.Resolved -> {
-                blackjackService.closeSoloTable(tableId)
+                // Leave the resolved table in the registry so the JS poll can read the
+                // final state (cards / dealer total / lastResult) and disable buttons.
+                // [BlackjackService.dealSolo] sweeps it on the next deal; the idle
+                // sweeper handles abandoned ones after [BlackjackTableRegistry.idleTtl].
                 ResponseEntity.ok(
                     BlackjackActionResponse(
                         ok = true, tableId = tableId, resolved = true,
@@ -407,12 +410,19 @@ class BlackjackController(
         }
     }
 
-    private fun findActiveSoloTable(guildId: Long, discordId: Long): Long? =
-        tableRegistry.listForGuild(guildId)
-            .firstOrNull { table ->
-                table.mode == BlackjackTable.Mode.SOLO &&
-                    table.seats.any { it.discordId == discordId }
-            }?.id
+    private fun findActiveSoloTable(guildId: Long, discordId: Long): Long? {
+        val mine = tableRegistry.listForGuild(guildId).filter { table ->
+            table.mode == BlackjackTable.Mode.SOLO &&
+                table.seats.any { it.discordId == discordId }
+        }
+        // Prefer a still-in-flight hand. After a hand resolves, the table now
+        // sticks around (so /state can render the result + disable buttons)
+        // until the next deal sweeps it — without this filter, an action POST
+        // arriving right after a fresh deal could land on the stale RESOLVED
+        // table instead of the new live one.
+        return (mine.firstOrNull { it.phase != BlackjackTable.Phase.RESOLVED }
+            ?: mine.firstOrNull())?.id
+    }
 
     private fun parseAction(raw: String): Blackjack.Action? = when (raw.lowercase()) {
         "hit" -> Blackjack.Action.HIT


### PR DESCRIPTION
## Summary

Production was logging bursts of `404 POST /blackjack/{guildId}/solo/action` (six in 1.2s in the user-supplied log). Root cause: the action handler called `closeSoloTable()` the moment a hand resolved, which removed the table from the in-memory registry. The web JS then polled `/state`, got a 404, returned early from `renderState` without disabling the action buttons, and any subsequent click hit `/action` with the now-missing table id and got a 404 toast.

## Fix

- `BlackjackController.soloAction`: drop the `closeSoloTable(tableId)` call on `Resolved`. The table sits in the registry as `RESOLVED` so `/state` continues to return the final cards/dealer-total/`lastResult` and the JS can render the verdict + disable buttons via its existing phase-based gating.
- `BlackjackService.dealSolo`: sweep any pre-existing `RESOLVED` solo table for the user before registering the new one, so the registry doesn't accumulate residue across multiple deals. The idle sweeper still handles tables abandoned mid-result.
- `BlackjackController.findActiveSoloTable`: prefer a non-`RESOLVED` match so an action POST arriving immediately after a fresh deal can't accidentally land on the previous (just-resolved) table.

No schema or rule changes — purely a registry-lifecycle fix.

## Test plan

- [x] `:database:test --tests "database.service.BlackjackServiceTest"` green (covers solo deal/action/resolve paths and the new `dealSolo` cleanup is exercised by the existing happy-path tests).
- [ ] Manual prod smoke: deal solo → click Stand → embed shows verdict + new balance, buttons disable, polling stops; click Deal again → fresh hand starts cleanly.

https://claude.ai/code/session_012gsr3GLkqEs449fdgLDLL6

---
_Generated by [Claude Code](https://claude.ai/code/session_012gsr3GLkqEs449fdgLDLL6)_