### PR TITLE
feat(casino): mobile usability + lobby host names + win chip-stack flourish

### DIFF
--- a/web/src/main/kotlin/web/service/BlackjackWebService.kt
+++ b/web/src/main/kotlin/web/service/BlackjackWebService.kt
@@ -24,6 +24,8 @@ class BlackjackWebService(
     data class TableSummaryView(
         val tableId: Long,
         val hostDiscordId: Long?,
+        /** Resolved Discord display name of the host, or fallback when not resolvable. */
+        val hostName: String,
         val mode: String,
         val seats: Int,
         val maxSeats: Int,
@@ -120,22 +122,30 @@ class BlackjackWebService(
         val payout: Long,
     )
 
-    fun listMultiTables(guildId: Long): List<TableSummaryView> =
-        tableRegistry.listForGuild(guildId)
+    fun listMultiTables(guildId: Long): List<TableSummaryView> {
+        val tables = tableRegistry.listForGuild(guildId)
             .filter { it.mode == BlackjackTable.Mode.MULTI }
-            .map { table ->
-                TableSummaryView(
-                    tableId = table.id,
-                    hostDiscordId = table.hostDiscordId,
-                    mode = table.mode.name,
-                    seats = table.seats.size,
-                    maxSeats = table.maxSeats,
-                    phase = table.phase.name,
-                    handNumber = table.handNumber,
-                    ante = table.ante,
-                )
-            }
-            .sortedBy { it.tableId }
+        // Batch-resolve every host's display name once so the lobby doesn't
+        // hit JDA per row.
+        val hostIds = tables.mapNotNull { it.hostDiscordId }.toSet()
+        val hosts = memberLookup.resolveAll(guildId, hostIds)
+        return tables.map { table ->
+            val host = table.hostDiscordId?.let { hosts[it] }
+            TableSummaryView(
+                tableId = table.id,
+                hostDiscordId = table.hostDiscordId,
+                hostName = host?.name
+                    ?: table.hostDiscordId?.let { memberLookup.fallbackName(it) }
+                    ?: "—",
+                mode = table.mode.name,
+                seats = table.seats.size,
+                maxSeats = table.maxSeats,
+                phase = table.phase.name,
+                handNumber = table.handNumber,
+                ante = table.ante,
+            )
+        }.sortedBy { it.tableId }
+    }
 
     fun snapshot(tableId: Long, viewerDiscordId: Long): TableStateView? {
         val table = tableRegistry.get(tableId) ?: return null

--- a/web/src/main/kotlin/web/service/PokerWebService.kt
+++ b/web/src/main/kotlin/web/service/PokerWebService.kt
@@ -22,6 +22,8 @@ class PokerWebService(
     data class TableSummaryView(
         val tableId: Long,
         val hostDiscordId: Long,
+        /** Resolved Discord display name of the host, or fallback when not resolvable. */
+        val hostName: String,
         val seats: Int,
         val maxSeats: Int,
         val phase: String,
@@ -127,20 +129,27 @@ class PokerWebService(
         val payoutByDiscordId: Map<String, Long>,
     )
 
-    fun listGuildTables(guildId: Long): List<TableSummaryView> =
-        tableRegistry.listForGuild(guildId).map {
+    fun listGuildTables(guildId: Long): List<TableSummaryView> {
+        val tables = tableRegistry.listForGuild(guildId)
+        // Batch-resolve every host's display name once so the lobby doesn't
+        // hit JDA per row.
+        val hosts = memberLookup.resolveAll(guildId, tables.map { it.hostDiscordId }.toSet())
+        return tables.map { t ->
+            val host = hosts[t.hostDiscordId]
             TableSummaryView(
-                tableId = it.id,
-                hostDiscordId = it.hostDiscordId,
-                seats = it.seats.size,
-                maxSeats = it.maxSeats,
-                phase = it.phase.name,
-                handNumber = it.handNumber,
-                minBuyIn = it.minBuyIn,
-                maxBuyIn = it.maxBuyIn,
-                isFreePlay = it.isFreePlay,
+                tableId = t.id,
+                hostDiscordId = t.hostDiscordId,
+                hostName = host?.name ?: memberLookup.fallbackName(t.hostDiscordId),
+                seats = t.seats.size,
+                maxSeats = t.maxSeats,
+                phase = t.phase.name,
+                handNumber = t.handNumber,
+                minBuyIn = t.minBuyIn,
+                maxBuyIn = t.maxBuyIn,
+                isFreePlay = t.isFreePlay,
             )
         }.sortedBy { it.tableId }
+    }
 
     fun snapshot(tableId: Long, viewerDiscordId: Long): TableStateView? {
         val table = tableRegistry.get(tableId) ?: return null

--- a/web/src/main/resources/static/css/blackjack.css
+++ b/web/src/main/resources/static/css/blackjack.css
@@ -131,3 +131,42 @@
 .bj-shot-clock {
     font-variant-numeric: tabular-nums;
 }
+
+/* ------------------------------------------------------------------- */
+/* Responsive — phones                                                  */
+/* ------------------------------------------------------------------- */
+
+@media (max-width: 600px) {
+    /* Drop the desktop-card max-width so the form fills the viewport
+       (with the page container's padding still doing the gutter work). */
+    .bj-card {
+        padding: 1rem;
+        max-width: 100%;
+    }
+    .bj-header h1 {
+        font-size: 1.4rem;
+    }
+    /* Action buttons should fill the row and be at-or-above the WCAG
+       44px touch target — bunched-up small buttons on mobile are the
+       most common Blackjack mis-tap source. */
+    .bj-actions {
+        gap: 0.4rem;
+    }
+    .bj-actions button {
+        flex: 1 1 calc(50% - 0.4rem);
+        min-height: 2.75rem;
+    }
+    .bj-info {
+        gap: 0.5rem 1rem;
+        font-size: 0.9rem;
+    }
+    .bj-table-row {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 0.5rem;
+    }
+    .bj-table-row .btn-primary {
+        width: 100%;
+        min-height: 2.75rem;
+    }
+}

--- a/web/src/main/resources/static/css/casino-table.css
+++ b/web/src/main/resources/static/css/casino-table.css
@@ -260,11 +260,131 @@
     animation: casino-deal 280ms ease-out;
 }
 
+/* ------------------------------------------------------------------- */
+/* Win chip-stack flourish                                              */
+/* ------------------------------------------------------------------- */
+
+/* Anchored to the seat so JS can drop a stack inside without leaking
+   into the page flow. The seat's other content stays untouched. */
+.casino-seat {
+    position: relative;
+}
+
+.casino-chip-stack {
+    position: absolute;
+    left: 50%;
+    bottom: 6px;
+    transform: translateX(-50%);
+    display: flex;
+    flex-direction: column-reverse;
+    align-items: center;
+    pointer-events: none;
+    z-index: 2;
+}
+
+.casino-chip {
+    width: 1.6rem;
+    height: 0.55rem;
+    border-radius: 50%;
+    background: radial-gradient(ellipse at 30% 30%, #fef08a 0%, #fcd34d 45%, #b45309 100%);
+    border: 1px solid rgba(0, 0, 0, 0.55);
+    box-shadow:
+        0 1px 0 rgba(0, 0, 0, 0.55),
+        inset 0 0 0 2px rgba(255, 255, 255, 0.15);
+    margin-top: -0.32rem;
+    animation: casino-chip-pop 520ms cubic-bezier(.18, .89, .32, 1.28) both;
+}
+
+.casino-chip-payout {
+    font-weight: 700;
+    font-size: 1.1rem;
+    color: #fde68a;
+    text-shadow: 0 0 8px rgba(252, 211, 77, 0.65);
+    margin-bottom: 0.4rem;
+    animation: casino-payout-float 1.6s ease-out both;
+}
+
+@keyframes casino-chip-pop {
+    0%   { transform: translateY(40px) scale(0.5); opacity: 0; }
+    55%  { transform: translateY(-6px) scale(1.06); opacity: 1; }
+    100% { transform: none; opacity: 1; }
+}
+
+@keyframes casino-payout-float {
+    0%   { transform: translateY(20px); opacity: 0; }
+    20%  { opacity: 1; }
+    100% { transform: translateY(-30px); opacity: 0; }
+}
+
 @media (prefers-reduced-motion: reduce) {
     .casino-seat.is-active {
         animation: none;
     }
     .casino-card-glyph.is-dealt {
         animation: none;
+    }
+    .casino-chip,
+    .casino-chip-payout {
+        animation: none;
+    }
+}
+
+/* ------------------------------------------------------------------- */
+/* Responsive — phones                                                  */
+/* ------------------------------------------------------------------- */
+
+/* Tablet / large phone — felt and cards tighten so a 5-card hand fits a
+   standard portrait viewport without horizontal scroll. */
+@media (max-width: 600px) {
+    .casino-felt {
+        padding: 1.25rem 1rem;
+        border-radius: 0.9rem;
+    }
+    .casino-card-glyph {
+        width: 2.4rem;
+        height: 3.6rem;
+        font-size: 1.1rem;
+        border-radius: 0.4rem;
+    }
+    .casino-cards {
+        gap: 0.35rem;
+        min-height: 3.8rem;
+    }
+    .casino-seat {
+        padding: 0.6rem 0.75rem;
+    }
+    .casino-actor-pill {
+        font-size: 0.82rem;
+        padding: 0.35rem 0.7rem 0.35rem 0.35rem;
+    }
+    .casino-actor-pill .casino-avatar {
+        width: 1.4rem;
+        height: 1.4rem;
+    }
+}
+
+/* Compact phone — only what's needed to keep a 5-card hand + dealer
+   visible above the fold without breaking the table metaphor. */
+@media (max-width: 380px) {
+    .casino-felt {
+        padding: 1rem 0.75rem;
+    }
+    .casino-card-glyph {
+        width: 2rem;
+        height: 3rem;
+        font-size: 0.95rem;
+    }
+    .casino-cards {
+        gap: 0.3rem;
+        min-height: 3.2rem;
+    }
+    .casino-avatar {
+        width: 1.7rem;
+        height: 1.7rem;
+    }
+    .casino-actor-pill-label {
+        /* On 320px the "Acting" tag is the first thing to drop — name +
+           avatar are still informative without it. */
+        display: none;
     }
 }

--- a/web/src/main/resources/static/css/coinflip.css
+++ b/web/src/main/resources/static/css/coinflip.css
@@ -147,4 +147,16 @@
 @media (max-width: 600px) {
     .coinflip-coin { width: 96px; height: 96px; }
     .coinflip-coin-face { font-size: 2.4rem; }
+    .coinflip-bet { max-width: 100%; }
+    /* Side picker buttons fill the row at ≥44px so they're easy to tap. */
+    .coinflip-side-picker { gap: 0.5rem; }
+    .coinflip-side-picker button {
+        flex: 1 1 0;
+        min-height: 2.75rem;
+    }
+}
+
+@media (max-width: 380px) {
+    .coinflip-coin { width: 80px; height: 80px; }
+    .coinflip-coin-face { font-size: 2rem; }
 }

--- a/web/src/main/resources/static/css/dice.css
+++ b/web/src/main/resources/static/css/dice.css
@@ -150,3 +150,15 @@
     .dice-die-face { font-size: 4rem; }
     .dice-prediction-picker { grid-template-columns: repeat(3, 1fr); }
 }
+
+/* Compact phone — die shrinks again, prediction grid keeps 3 cols
+   (going to 2 makes "predict 1-6" feel uneven). Form items stretch to
+   fill so the touch target stays at 44px+. */
+@media (max-width: 380px) {
+    .dice-bet { max-width: 100%; }
+    .dice-die { width: 80px; height: 80px; }
+    .dice-die-face { font-size: 3.2rem; }
+    .dice-prediction-picker .dice-prediction-cell {
+        min-height: 2.75rem;
+    }
+}

--- a/web/src/main/resources/static/css/highlow.css
+++ b/web/src/main/resources/static/css/highlow.css
@@ -177,4 +177,17 @@
     .highlow-card { width: 76px; height: 110px; }
     .highlow-card-face { font-size: 2rem; }
     .highlow-arrow { font-size: 1.5rem; }
+    .highlow-bet { max-width: 100%; }
+    /* Direction picker fills the row so Higher / Lower stay at ≥44px. */
+    .highlow-direction-picker { gap: 0.5rem; }
+    .highlow-direction-picker button {
+        flex: 1 1 0;
+        min-height: 2.75rem;
+    }
+}
+
+@media (max-width: 380px) {
+    .highlow-card { width: 64px; height: 92px; }
+    .highlow-card-face { font-size: 1.6rem; }
+    .highlow-arrow { font-size: 1.2rem; }
 }

--- a/web/src/main/resources/static/css/poker.css
+++ b/web/src/main/resources/static/css/poker.css
@@ -142,3 +142,52 @@
     border-radius: 0.5rem;
     background: var(--surface-2, #16181d);
 }
+
+/* ------------------------------------------------------------------- */
+/* Responsive — phones                                                  */
+/* ------------------------------------------------------------------- */
+
+@media (max-width: 600px) {
+    .poker-card {
+        padding: 1rem;
+        max-width: 100%;
+    }
+    .poker-header h1 {
+        font-size: 1.4rem;
+    }
+    /* Single-column seats on phones — the auto-fit minmax was forcing
+       seats wider than the viewport at minmax(15rem, ...). */
+    .poker-seats {
+        grid-template-columns: 1fr;
+        gap: 0.5rem;
+    }
+    .poker-info {
+        gap: 0.5rem;
+        font-size: 0.9rem;
+    }
+    .poker-info > div {
+        flex: 1 1 calc(50% - 0.5rem);
+    }
+    /* Centred-flex board still wraps; tighten spacing so 5 community
+       cards fit a portrait phone without horizontal scroll. */
+    .poker-board {
+        gap: 0.35rem;
+        min-height: 3.8rem;
+    }
+    .poker-actions {
+        gap: 0.4rem;
+    }
+    .poker-actions button {
+        flex: 1 1 calc(50% - 0.4rem);
+        min-height: 2.75rem;
+    }
+    .poker-table-row {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 0.5rem;
+    }
+    .poker-table-row .btn-primary {
+        width: 100%;
+        min-height: 2.75rem;
+    }
+}

--- a/web/src/main/resources/static/css/scratch.css
+++ b/web/src/main/resources/static/css/scratch.css
@@ -216,4 +216,13 @@
 @media (max-width: 600px) {
     .scratch-cells { max-width: 300px; }
     .scratch-cell-cover, .scratch-cell-face { font-size: 1.4rem; }
+    .scratch-bet { max-width: 100%; }
+}
+
+@media (max-width: 380px) {
+    /* Cells stay 3-wide (a 3x3 grid is the whole game), but tighten gaps
+       so the grid fits a 320px viewport. Touch targets remain large
+       enough since each cell is square-aspect. */
+    .scratch-cells { max-width: 100%; gap: 0.4rem; }
+    .scratch-cell-cover, .scratch-cell-face { font-size: 1.15rem; }
 }

--- a/web/src/main/resources/static/css/slots.css
+++ b/web/src/main/resources/static/css/slots.css
@@ -129,4 +129,13 @@
     .slots-reel { width: 72px; height: 72px; font-size: 2.4rem; }
     .slots-bet { flex-direction: column; align-items: stretch; }
     .slots-bet input[type="number"] { width: 100%; }
+    .slots-bet button { min-height: 2.75rem; }
+}
+
+@media (max-width: 380px) {
+    /* Three reels need to fit a 320px screen with a small gutter, so the
+       reels shrink again. Payouts table compresses font-size to keep
+       columns aligned without horizontal scroll. */
+    .slots-reel { width: 60px; height: 60px; font-size: 2rem; }
+    .slots-payouts { font-size: 0.85rem; }
 }

--- a/web/src/main/resources/static/js/blackjack-solo.js
+++ b/web/src/main/resources/static/js/blackjack-solo.js
@@ -21,6 +21,9 @@
     var playerRowEl = document.getElementById("bj-player-row");
 
     var pollTimer = null;
+    // Tracks the handNumber of the last result we played the chip-stack
+    // flourish on, so the 2s polling doesn't re-trigger the animation.
+    var lastFlashedHand = null;
 
     function renderCards(container, cards) {
         // Delegate to the shared casino renderer so the deal animation only
@@ -98,6 +101,14 @@
     function renderResult(state, seat) {
         var r = state.lastResult;
         var seatResult = (r.seatResults || {})[seat.discordId.toString()];
+        // Fire the celebratory chip stack once per hand on a winning result.
+        if (r.handNumber !== lastFlashedHand && window.CasinoRender) {
+            lastFlashedHand = r.handNumber;
+            var payout = (r.payouts || {})[seat.discordId.toString()];
+            if (payout && payout > 0 && playerRowEl) {
+                window.CasinoRender.flashChipsOn(playerRowEl, payout);
+            }
+        }
         var label;
         var cls = "muted";
         switch (seatResult) {

--- a/web/src/main/resources/static/js/blackjack-table.js
+++ b/web/src/main/resources/static/js/blackjack-table.js
@@ -29,6 +29,9 @@
     var pollTimer = null;
     var clockTimer = null;
     var deadlineMs = null;
+    // Tracks the handNumber of the last result we played the chip-stack
+    // flourish on, so the 2s polling doesn't re-trigger the animation.
+    var lastFlashedHand = null;
 
     function renderCards(container, cards) {
         // Delegate to the shared renderer so the per-container deal animation
@@ -81,15 +84,19 @@
                     isMe: isMe,
                     metaText: slots.length + " hands" + (seat.pendingLeave ? " · leaving" : ""),
                 });
+                groupHeader.dataset.discordId = String(seat.discordId);
                 seatsEl.appendChild(groupHeader);
                 slots.forEach(function (slot, slotIdx) {
-                    seatsEl.appendChild(renderSlot(seat, slot, slotIdx, isActorSeat && slotIdx === seat.activeHandIndex));
+                    var slotEl = renderSlot(seat, slot, slotIdx, isActorSeat && slotIdx === seat.activeHandIndex);
+                    slotEl.dataset.discordId = String(seat.discordId);
+                    seatsEl.appendChild(slotEl);
                 });
                 return;
             }
             // Single-hand path (back-compat with v1 seat shape).
             var div = document.createElement("div");
             div.className = "bj-seat casino-seat";
+            div.dataset.discordId = String(seat.discordId);
             if (isMe) div.classList.add("is-me");
             if (isActorSeat) div.classList.add("bj-seat-active", "is-active");
             if (seat.status === "BUSTED") div.classList.add("bj-seat-busted", "is-busted");
@@ -207,6 +214,19 @@
         });
         resultEl.textContent = "Hand #" + r.handNumber + " — " + lines.join(" · ") +
             ". Pot " + r.pot + " (rake " + r.rake + " → jackpot).";
+
+        // Fire the celebratory chip stack once per hand. The 2s polling
+        // would otherwise re-trigger every cycle while the result is on
+        // screen, so we key off handNumber.
+        if (r.handNumber !== lastFlashedHand && window.CasinoRender) {
+            lastFlashedHand = r.handNumber;
+            Object.keys(r.payouts || {}).forEach(function (id) {
+                var amount = r.payouts[id];
+                if (!amount || amount <= 0) return;
+                var seatEl = seatsEl.querySelector('[data-discord-id="' + id + '"]');
+                if (seatEl) window.CasinoRender.flashChipsOn(seatEl, amount);
+            });
+        }
     }
 
     function renderShotClock() {

--- a/web/src/main/resources/static/js/casino-render.js
+++ b/web/src/main/resources/static/js/casino-render.js
@@ -127,10 +127,45 @@
         }
     }
 
+    // Drop a small celebratory chip stack onto a seat element. Used by the
+    // game JS the moment a hand resolves with a positive payout — the stack
+    // animates in (one chip popping every 80ms), the payout label floats up,
+    // and the whole thing removes itself after ~1.6s so it doesn't pile up
+    // on subsequent polls.
+    function flashChipsOn(seatEl, payoutAmount, chipCount) {
+        if (!seatEl || !payoutAmount || payoutAmount <= 0) return;
+        // De-dupe: if a previous flash for the same hand is still on screen,
+        // strip it before starting a new one.
+        var existing = seatEl.querySelector(".casino-chip-stack");
+        if (existing) existing.remove();
+
+        var stack = document.createElement("div");
+        stack.className = "casino-chip-stack";
+
+        var label = document.createElement("div");
+        label.className = "casino-chip-payout";
+        label.textContent = "+" + payoutAmount;
+        stack.appendChild(label);
+
+        // Cap chip count so a "+10000" payout doesn't draw 100 chips.
+        var n = Math.max(1, Math.min(chipCount || 5, 7));
+        for (var i = 0; i < n; i++) {
+            var chip = document.createElement("span");
+            chip.className = "casino-chip";
+            chip.style.animationDelay = (i * 80) + "ms";
+            stack.appendChild(chip);
+        }
+        seatEl.appendChild(stack);
+
+        // Clean up after the longest animation (payout-float = 1.6s).
+        setTimeout(function () { if (stack.parentNode) stack.remove(); }, 1700);
+    }
+
     window.CasinoRender = {
         renderCards: renderCards,
         makeAvatar: makeAvatar,
         makeSeatHeader: makeSeatHeader,
         renderActorPill: renderActorPill,
+        flashChipsOn: flashChipsOn,
     };
 })();

--- a/web/src/main/resources/static/js/poker-table.js
+++ b/web/src/main/resources/static/js/poker-table.js
@@ -24,6 +24,9 @@
     const potsEl = document.getElementById('poker-pots');
     const shotClockEl = document.getElementById('poker-shot-clock');
     let shotClockTicker = null;
+    // Tracks the handNumber of the last result we played the chip-stack
+    // flourish on, so the 2s polling doesn't re-trigger the animation.
+    let lastFlashedHand = null;
     const balanceEl = document.getElementById('poker-balance');
     const joinCard = document.getElementById('poker-join-card');
 
@@ -69,6 +72,7 @@
         state.seats.forEach(function (s, idx) {
             const node = document.createElement('div');
             node.className = 'poker-seat casino-seat';
+            node.dataset.discordId = String(s.discordId);
             const isMe = idx === meIdx;
             if (isMe) node.classList.add('poker-seat-me', 'is-me');
             if (idx === state.actorIndex && state.phase !== 'WAITING') node.classList.add('poker-seat-active', 'is-active');
@@ -199,6 +203,21 @@
                 containerEl: potsEl,
                 pots: result.pots || [],
                 refundedByDiscordId: result.refundedByDiscordId || {},
+            });
+        }
+
+        // Fire the celebratory chip stack once per hand on each seat that
+        // received a positive payout. The 2s polling would otherwise
+        // re-trigger every cycle while the result is on screen, so we
+        // key off handNumber.
+        if (result.handNumber !== lastFlashedHand && window.CasinoRender) {
+            lastFlashedHand = result.handNumber;
+            const payouts = result.payoutByDiscordId || {};
+            Object.keys(payouts).forEach(function (id) {
+                const amount = payouts[id];
+                if (!amount || amount <= 0) return;
+                const seatEl = seatsEl.querySelector('[data-discord-id="' + id + '"]');
+                if (seatEl) window.CasinoRender.flashChipsOn(seatEl, amount);
             });
         }
     }

--- a/web/src/main/resources/templates/blackjack-lobby.html
+++ b/web/src/main/resources/templates/blackjack-lobby.html
@@ -44,7 +44,7 @@
                 <div>
                     <div>Table #<strong th:text="${t.tableId}">1</strong>
                         — <span th:text="${t.seats}">0</span>/<span th:text="${t.maxSeats}">5</span> seats</div>
-                    <div class="muted">Host: <span th:text="${t.hostDiscordId}">000</span> ·
+                    <div class="muted">Host: <span th:text="${t.hostName}">Host</span> ·
                         Phase: <span th:text="${t.phase}">LOBBY</span> ·
                         Ante: <span th:text="${t.ante}">100</span> ·
                         Hand #<span th:text="${t.handNumber}">0</span></div>

--- a/web/src/main/resources/templates/poker-lobby.html
+++ b/web/src/main/resources/templates/poker-lobby.html
@@ -49,7 +49,7 @@
                     <div>Table #<strong th:text="${t.tableId}">1</strong>
                         — <span th:text="${t.seats}">0</span>/<span th:text="${t.maxSeats}">6</span> seats
                         <span th:if="${t.isFreePlay}" class="poker-free-tag" title="Free play — no credits, no payouts">🆓 Free</span></div>
-                    <div class="muted">Host: <span th:text="${t.hostDiscordId}">000</span> ·
+                    <div class="muted">Host: <span th:text="${t.hostName}">Host</span> ·
                         Phase: <span th:text="${t.phase}">WAITING</span> ·
                         Hand #<span th:text="${t.handNumber}">0</span></div>
                 </div>


### PR DESCRIPTION
## Summary

Three follow-ups to the casino-polish PR (#351), bundled because they're all polish layers on the same surface.

### 1. Mobile usability pass across all casino games

`casino-table.css`, `blackjack.css`, and `poker.css` had **zero** responsive rules — desktop-first defaults clipped seat panels and 5-card hands on a 360px phone. Added 600px and 380px breakpoints across all casino games:

- **Shared** (`casino-table.css`): `.casino-felt` padding shrinks 2rem→1rem; `.casino-card-glyph` 3rem×4.5rem → 2rem×3rem so a 5-card hand + dealer fits 320px; actor pill drops the "Acting" tag below 380px (avatar + name remain).
- **Blackjack / Poker**: lobby/form max-widths drop to 100%; action buttons fill rows at ≥44px (WCAG); lobby table rows stack vertically; poker seats single-column on phones.
- **Dice / Coinflip / Highlow / Slots / Scratch**: added 380px tier on top of existing 600px rules; visuals shrink further; side-pickers fill the row at ≥44px touch targets.

Viewport meta confirmed already correct in `fragments/head.html`.

### 2. Lobby host name resolution

Lobbies were rendering raw Discord IDs ("Host: 540…"). Both `BlackjackWebService.TableSummaryView` and `PokerWebService.TableSummaryView` gain `hostName`, batch-resolved via the existing `MemberLookupHelper` so the lobby hits JDA once per page load, not once per row. Templates read `hostName`.

### 3. Win chip-stack flourish

When a hand resolves with a positive payout, a small stack of gold chips pops up at the winning seat with a "+200" label that floats upward. Each chip pops in on a 80ms stagger; the whole flourish runs ~1.6s and self-cleans.

- `casino-table.css` — `.casino-chip-stack` / `.casino-chip` / `.casino-chip-payout` + `casino-chip-pop` + `casino-payout-float` keyframes. Honours `prefers-reduced-motion`.
- `casino-render.js` — `CasinoRender.flashChipsOn(seatEl, payout)`.
- Game JS — keyed off `lastResult.handNumber` so 2s polling can't re-trigger; seats tagged with `data-discord-id` so the flash lands on the right seat.

## Test plan

- [x] `:web:test` green; no schema/behaviour changes outside the projection layer.
- [ ] Manual: 320px / 360px / 414px viewports across `/blackjack`, `/poker`, `/slots`, `/dice`, `/coinflip`, `/highlow`, `/scratch` — no horizontal scroll, all action buttons ≥44px tall.
- [ ] Manual: blackjack/poker lobby shows real host display names, not raw IDs.
- [ ] Manual: win a hand → gold chip stack pops up at the winning seat with `+<payout>`, animation completes in ~1.6s, doesn't re-trigger on subsequent polls.
- [ ] `prefers-reduced-motion: reduce` → no chip-pop, no payout float (CSS animations disabled).

## Out of scope

- Spectator mode, animated card dealing from a deck, sound effects.
- Migrating Moderation/Profile to `MemberLookupHelper` (uses `Member` for permission checks, not just display).

https://claude.ai/code/session_012gsr3GLkqEs449fdgLDLL6

---
_Generated by [Claude Code](https://claude.ai/code/session_012gsr3GLkqEs449fdgLDLL6)_