### PR TITLE
fix(web): revert head fragment to 2 params (500 on every 2-arg caller)

### DIFF
--- a/web/src/main/resources/static/css/blackjack.css
+++ b/web/src/main/resources/static/css/blackjack.css
@@ -1,10 +1,12 @@
 /*
  * Blackjack-specific styles. The shared "casino table" look (felt, cards,
  * seats, avatars, gold-glow active actor, deal animation) lives in
- * casino-table.css and applies to both /blackjack and /poker. Only
- * blackjack-specific bits stay here: the betting form, the lobby table
- * list rows, layout containers, and result-line variants.
+ * casino-table.css and is loaded via the @import below — that way every
+ * blackjack page picks it up without the head fragment having to juggle
+ * a second optional stylesheet parameter (which broke other 2-arg
+ * callers when the fragment signature added one).
  */
+@import url("./casino-table.css");
 
 .bj-header {
     margin-bottom: 1.5rem;

--- a/web/src/main/resources/static/css/poker.css
+++ b/web/src/main/resources/static/css/poker.css
@@ -1,10 +1,12 @@
 /*
  * Poker-specific styles. The shared "casino table" look (felt, cards,
  * seats, avatars, gold-glow active actor, deal animation) lives in
- * casino-table.css and applies to both /blackjack and /poker. Only
- * poker-specific bits stay here: the lobby form, the free-play tag, the
- * pot/side-pot panels, and layout containers.
+ * casino-table.css and is loaded via the @import below — that way every
+ * poker page picks it up without the head fragment having to juggle a
+ * second optional stylesheet parameter (which broke other 2-arg callers
+ * when the fragment signature added one).
  */
+@import url("./casino-table.css");
 
 .poker-header {
     margin-bottom: 1.5rem;

--- a/web/src/main/resources/templates/blackjack-solo.html
+++ b/web/src/main/resources/templates/blackjack-solo.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org" lang="en">
-<head th:replace="~{fragments/head :: head('TobyBot - Blackjack solo', '/css/blackjack.css', '/css/casino-table.css')}"></head>
+<head th:replace="~{fragments/head :: head('TobyBot - Blackjack solo', '/css/blackjack.css')}"></head>
 <body>
 <a href="#main" class="skip-link">Skip to content</a>
 <div th:replace="~{fragments/navbar :: navbar}"></div>

--- a/web/src/main/resources/templates/blackjack-table.html
+++ b/web/src/main/resources/templates/blackjack-table.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org" lang="en">
-<head th:replace="~{fragments/head :: head('TobyBot - Blackjack table', '/css/blackjack.css', '/css/casino-table.css')}"></head>
+<head th:replace="~{fragments/head :: head('TobyBot - Blackjack table', '/css/blackjack.css')}"></head>
 <body>
 <a href="#main" class="skip-link">Skip to content</a>
 <div th:replace="~{fragments/navbar :: navbar}"></div>

--- a/web/src/main/resources/templates/fragments/head.html
+++ b/web/src/main/resources/templates/fragments/head.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
-<head th:fragment="head(pageTitle, extraCss, extraCss2)">
+<head th:fragment="head(pageTitle, extraCss)">
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="color-scheme" content="dark">
@@ -10,10 +10,6 @@
     <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
     <link rel="stylesheet" th:href="@{/css/base.css}">
     <link rel="stylesheet" th:href="@{/css/nav.css}">
-    <!-- extraCss2 loads BEFORE extraCss so per-page overrides win on conflict
-         (e.g. blackjack/poker pull in casino-table.css as the shared base, then
-         their own stylesheet specialises). -->
-    <link rel="stylesheet" th:if="${extraCss2 != null}" th:href="@{${extraCss2}}">
     <link rel="stylesheet" th:if="${extraCss != null}" th:href="@{${extraCss}}">
 </head>
 </html>

--- a/web/src/main/resources/templates/poker-table.html
+++ b/web/src/main/resources/templates/poker-table.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org" lang="en">
-<head th:replace="~{fragments/head :: head('TobyBot - Poker table', '/css/poker.css', '/css/casino-table.css')}"></head>
+<head th:replace="~{fragments/head :: head('TobyBot - Poker table', '/css/poker.css')}"></head>
 <body>
 <a href="#main" class="skip-link">Skip to content</a>
 <div th:replace="~{fragments/navbar :: navbar}"></div>


### PR DESCRIPTION
## Summary

PR #351 expanded `fragments/head`'s signature from `head(pageTitle, extraCss)` to `head(pageTitle, extraCss, extraCss2)` so the blackjack/poker table pages could pull in `casino-table.css` as a shared base alongside their per-game stylesheet. This regressed **every other page** that called the fragment with 2 args.

Under Thymeleaf 3.1's stricter fragment-arg processing, the missing third positional argument throws a rendering exception, and the controller returns a blank-body 500.

User-visible symptom: navigating to any casino game page (`/casino/guilds`, `/casino/{g}/slots`, `/casino/{g}/coinflip`, `/casino/{g}/dice`, `/casino/{g}/highlow`, `/casino/{g}/scratch`, `/blackjack/{g}`, `/economy/{g}`, etc.) showed a completely blank page — no navbar, no content, no buttons.

Heroku log:
```
GET /casino/guilds ... status=500 bytes=33
Caused by: Thymeleaf rendering exception
```

## Fix

- Revert fragment signature to `head(pageTitle, extraCss)` so every existing 2-arg caller renders cleanly again.
- The 3 templates that previously passed `casino-table.css` as a third arg (blackjack-table, blackjack-solo, poker-table) drop it.
- `blackjack.css` and `poker.css` `@import url("./casino-table.css")` at the top, so the shared layer still loads transparently. Single source of truth for both games is preserved without any fragment-signature gymnastics.

## Test plan

- [x] `:web:test` green; no behaviour change beyond the rendering hot path.
- [ ] Manual: every previously-broken casino page renders again (`/casino/guilds`, `/blackjack/{g}`, slots/dice/coinflip/highlow/scratch, `/economy/{g}`).
- [ ] Manual: blackjack table + poker table still get the casino-felt look (now via `@import` from their per-game CSS).

https://claude.ai/code/session_012gsr3GLkqEs449fdgLDLL6

---
_Generated by [Claude Code](https://claude.ai/code/session_012gsr3GLkqEs449fdgLDLL6)_