### PR TITLE
fix(blackjack web): serialize seat discordId as String so JS doesn't round it

### DIFF
--- a/database/src/test/kotlin/database/service/BlackjackServiceTest.kt
+++ b/database/src/test/kotlin/database/service/BlackjackServiceTest.kt
@@ -3,6 +3,7 @@ package database.service
 import database.blackjack.Blackjack
 import database.blackjack.BlackjackTable
 import database.blackjack.BlackjackTableRegistry
+import database.blackjack.bestTotal
 import database.card.Card
 import database.card.Deck
 import database.card.Rank
@@ -234,6 +235,44 @@ class BlackjackServiceTest {
         // After deal: 900. After double debit: 800. Win 2× on doubled stake (200) → +400 → 1200.
         assertEquals(1_200L, user.socialCredit)
         assertEquals(1_200L, resolved.newBalance)
+    }
+
+    @Test
+    fun `applySoloAction STAND credits player when dealer plays out and busts`() {
+        // Regression for the freeze where STAND-then-dealer-bust paid no
+        // winnings. Real evaluate() so the dealer-bust → PLAYER_WIN branch
+        // is actually exercised (the win-on-stand test above stubs evaluate
+        // and never sees the bust path).
+        val realBj = Blackjack()
+        val user = userWithBalance(1_000L)
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns user
+        every { blackjack.dealStartingHands(any()) } returns Blackjack.StartingDeal(
+            mutableListOf(c(Rank.KING), c(Rank.NINE)),                // 19
+            mutableListOf(c(Rank.SIX), c(Rank.SEVEN, Suit.HEARTS))    // 13 — must hit
+        )
+        // Dealer at 13 must hit; drop a 10 → 23 → bust.
+        every { blackjack.playOutDealer(any(), any(), any()) } answers {
+            firstArg<MutableList<Card>>().add(c(Rank.TEN, Suit.HEARTS))
+        }
+        every { blackjack.evaluate(any(), any(), any()) } answers {
+            realBj.evaluate(arg(0), arg(1), arg(2))
+        }
+
+        val deal = service.dealSolo(discordId, guildId, stake = 100L)  // -100 → 900
+        val tableId = (deal as BlackjackService.SoloDealOutcome.Dealt).tableId
+
+        val outcome = service.applySoloAction(discordId, guildId, tableId, Blackjack.Action.STAND)
+        val resolved = assertInstanceOf(BlackjackService.SoloActionOutcome.Resolved::class.java, outcome)
+
+        assertEquals(1_100L, user.socialCredit, "win pays 2× stake net +100")
+        assertEquals(1_100L, resolved.newBalance)
+        assertEquals(Blackjack.Result.PLAYER_WIN, resolved.result.seatResults[discordId])
+        assertEquals(200L, resolved.result.payouts[discordId])
+
+        val live = registry.get(tableId)!!
+        assertEquals(BlackjackTable.Phase.RESOLVED, live.phase)
+        assertNotNull(live.lastResult, "lastResult must be set so /state can render the verdict")
+        assertTrue(bestTotal(live.dealer) > 21, "sanity: dealer actually busted")
     }
 
     @Test

--- a/web/src/main/kotlin/web/service/BlackjackWebService.kt
+++ b/web/src/main/kotlin/web/service/BlackjackWebService.kt
@@ -35,7 +35,11 @@ class BlackjackWebService(
     )
 
     data class SeatView(
-        val discordId: Long,
+        // Stringified so the 18-digit Discord snowflake survives JS's 53-bit
+        // Number precision. Numeric serialization rounds the last few digits,
+        // breaking string-keyed lookups in [HandResultView.seatResults] /
+        // [HandResultView.payouts] and the seat → "is this me?" compare.
+        val discordId: String,
         /** Discord display name (server nickname or username), or fallback when not in guild. */
         val displayName: String,
         /** CDN avatar URL, null when the bot can't resolve the member or they've left. */
@@ -78,7 +82,8 @@ class BlackjackWebService(
         val tableId: Long,
         val guildId: Long,
         val mode: String,
-        val hostDiscordId: Long?,
+        // Stringified — see [SeatView.discordId].
+        val hostDiscordId: String?,
         val phase: String,
         val handNumber: Long,
         val ante: Long,
@@ -111,7 +116,8 @@ class BlackjackWebService(
     )
 
     data class PerHandResultView(
-        val discordId: Long,
+        // Stringified — see [SeatView.discordId].
+        val discordId: String,
         val handIndex: Int,
         val cards: List<String>,
         val total: Int,
@@ -185,7 +191,7 @@ class BlackjackWebService(
                 tableId = table.id,
                 guildId = table.guildId,
                 mode = table.mode.name,
-                hostDiscordId = table.hostDiscordId,
+                hostDiscordId = table.hostDiscordId?.toString(),
                 phase = table.phase.name,
                 handNumber = table.handNumber,
                 ante = table.ante,
@@ -194,7 +200,7 @@ class BlackjackWebService(
                 seats = table.seats.map { seat ->
                     val member = members[seat.discordId]
                     SeatView(
-                        discordId = seat.discordId,
+                        discordId = seat.discordId.toString(),
                         displayName = member?.name ?: memberLookup.fallbackName(seat.discordId),
                         avatarUrl = member?.avatarUrl,
                         ante = seat.ante,
@@ -239,7 +245,7 @@ class BlackjackWebService(
                         rake = result.rake,
                         perHandResults = result.perHandResults.map { perHand ->
                             PerHandResultView(
-                                discordId = perHand.discordId,
+                                discordId = perHand.discordId.toString(),
                                 handIndex = perHand.handIndex,
                                 cards = perHand.cards.map(Card::toString),
                                 total = perHand.total,

--- a/web/src/main/resources/static/js/blackjack-solo.js
+++ b/web/src/main/resources/static/js/blackjack-solo.js
@@ -100,11 +100,13 @@
 
     function renderResult(state, seat) {
         var r = state.lastResult;
-        var seatResult = (r.seatResults || {})[seat.discordId.toString()];
+        // seat.discordId is a string from the projection so the snowflake
+        // survives JS Number's 53-bit precision; lookup keys match exactly.
+        var seatResult = (r.seatResults || {})[seat.discordId];
         // Fire the celebratory chip stack once per hand on a winning result.
         if (r.handNumber !== lastFlashedHand && window.CasinoRender) {
             lastFlashedHand = r.handNumber;
-            var payout = (r.payouts || {})[seat.discordId.toString()];
+            var payout = (r.payouts || {})[seat.discordId];
             if (payout && payout > 0 && playerRowEl) {
                 window.CasinoRender.flashChipsOn(playerRowEl, payout);
             }

--- a/web/src/main/resources/static/js/blackjack-table.js
+++ b/web/src/main/resources/static/js/blackjack-table.js
@@ -77,7 +77,7 @@
         (state.seats || []).forEach(function (seat, idx) {
             var slots = (seat.hands && seat.hands.length) ? seat.hands : null;
             var isActorSeat = idx === state.actorIndex && state.phase === "PLAYER_TURNS";
-            var isMe = seat.discordId === parseInt(myId, 10);
+            var isMe = seat.discordId === myId;
             if (slots && slots.length > 1) {
                 // Split seat: render the seat header once, then a sub-block per hand.
                 var groupHeader = window.CasinoRender.makeSeatHeader(seat, {
@@ -146,21 +146,21 @@
 
         var actorSeat = (state.seats || [])[state.actorIndex];
         toActEl.textContent = actorSeat
-            ? (actorSeat.discordId === parseInt(myId, 10) ? "You" : (actorSeat.displayName || ("@" + actorSeat.discordId)))
+            ? (actorSeat.discordId === myId ? "You" : (actorSeat.displayName || ("@" + actorSeat.discordId)))
             : "—";
 
         // Top-of-felt actor pill — only meaningful during PLAYER_TURNS.
         var pillSeat = (state.phase === "PLAYER_TURNS") ? actorSeat : null;
         if (window.CasinoRender) {
             window.CasinoRender.renderActorPill(actorPillEl, pillSeat, {
-                label: pillSeat && pillSeat.discordId === parseInt(myId, 10) ? "Your turn" : "Acting",
+                label: pillSeat && pillSeat.discordId === myId ? "Your turn" : "Acting",
             });
         }
 
         var seated = state.mySeatIndex != null;
         joinCard.hidden = seated || state.phase !== "LOBBY";
 
-        var iAmHost = state.hostDiscordId != null && state.hostDiscordId === parseInt(myId, 10);
+        var iAmHost = state.hostDiscordId != null && state.hostDiscordId === myId;
         startBtn.hidden = !(iAmHost && state.phase === "LOBBY");
         leaveBtn.hidden = !seated;
 
@@ -209,7 +209,7 @@
                 default: label = r.seatResults[id];
             }
             var payout = r.payouts && r.payouts[id] ? " (+" + r.payouts[id] + ")" : "";
-            var who = parseInt(id, 10) === parseInt(myId, 10) ? "You" : (nameById[id] || ("@" + id));
+            var who = id === myId ? "You" : (nameById[id] || ("@" + id));
             lines.push(who + ": " + label + payout);
         });
         resultEl.textContent = "Hand #" + r.handNumber + " — " + lines.join(" · ") +
@@ -226,7 +226,7 @@
                 if (!amount || amount <= 0) return;
                 var seatEl = seatsEl.querySelector('[data-discord-id="' + id + '"]');
                 if (seatEl) window.CasinoRender.flashChipsOn(seatEl, amount);
-                if (parseInt(id, 10) === parseInt(myId, 10)) myPaid = true;
+                if (id === myId) myPaid = true;
             });
             // Sound cue keyed off the viewer's outcome — winning a hand
             // should sound like a win, even if other seats lost.


### PR DESCRIPTION
## Summary

User report: solo blackjack "froze" when the dealer went bust — wallet was credited correctly, but the result line never appeared and the chip flash didn't fire, so it looked like the table was stuck. Confirmed on a dealer-win hand too (screenshot: dealer 21 vs you 19, wallet correctly debited 17→7, but no "Dealer wins" text rendered).

## Root cause

`BlackjackWebService.SeatView.discordId` is `Long`, and Jackson serializes it as a JSON number. Discord snowflakes are 18 digits (`553658039266443264` from the user's logs), well past JS `Number.MAX_SAFE_INTEGER` (2⁵³), so the browser parses them with the last few digits rounded. The `seatResults` / `payouts` maps are server-keyed by exact `Long.toString()`, so the client's `seat.discordId.toString()` lookup misses → `seatResult` is `undefined` → label falls through to `""`, no flash, wrong sound. Balance still updates (separate field `b.newBalance` on the action response), but the user has no UI signal the hand resolved.

## Changes

- **`BlackjackWebService`** projection: stringify `SeatView.discordId`, `TableStateView.hostDiscordId`, and `PerHandResultView.discordId` so they survive JS Number precision intact.
- **`blackjack-solo.js` / `blackjack-table.js`**: drop the redundant `.toString()` and replace numeric `parseInt(myId, 10)` compares with string equality. `myId` already came in as a string off `data-my-discord-id`, so this is consistent end-to-end.
- **`BlackjackServiceTest`**: new regression that exercises real `Blackjack.evaluate()` against a stub `playOutDealer` pushing the dealer past 21. The existing STAND test mocked `evaluate` to return `PLAYER_WIN` regardless, so the actual dealer-bust branch was never covered. Asserts player gets 2× stake, phase is `RESOLVED`, `lastResult` is set, and dealer really busts.

## Test plan

- [x] `:database:test` green (incl. new dealer-bust regression)
- [x] `:web:test` green
- [ ] Manual: deal a solo hand on the deployed branch, force STAND with a low total, watch dealer play out — confirm "You win." / "Dealer wins." / "Bust." text now renders, chip stack fires on a positive payout, win/lose sound matches outcome.

https://claude.ai/code/session_014ffsM6UFUh5KaMS4KUBPrf

---
_Generated by [Claude Code](https://claude.ai/code/session_014ffsM6UFUh5KaMS4KUBPrf)_