### PR TITLE
fix(web): serialize remaining Discord IDs as String so JS doesn't round them

### DIFF
--- a/web/src/main/kotlin/web/controller/DuelController.kt
+++ b/web/src/main/kotlin/web/controller/DuelController.kt
@@ -205,8 +205,8 @@ class DuelController(
             is AcceptOutcome.Win -> ResponseEntity.ok(
                 DuelActionResponse(
                     ok = true,
-                    winnerDiscordId = outcome.winnerDiscordId,
-                    loserDiscordId = outcome.loserDiscordId,
+                    winnerDiscordId = outcome.winnerDiscordId.toString(),
+                    loserDiscordId = outcome.loserDiscordId.toString(),
                     stake = outcome.stake,
                     pot = outcome.pot,
                     winnerNewBalance = outcome.winnerNewBalance,
@@ -303,8 +303,11 @@ data class ChallengeResponse(
 data class DuelActionResponse(
     val ok: Boolean,
     val error: String? = null,
-    val winnerDiscordId: Long? = null,
-    val loserDiscordId: Long? = null,
+    // Stringified — JS renders [winnerDiscordId] into a `<@…>` mention, and a
+    // numeric round-trip on a 18-digit Discord snowflake would produce the
+    // wrong id (rounded past JS Number.MAX_SAFE_INTEGER).
+    val winnerDiscordId: String? = null,
+    val loserDiscordId: String? = null,
     val stake: Long? = null,
     val pot: Long? = null,
     val winnerNewBalance: Long? = null,

--- a/web/src/main/kotlin/web/service/BlackjackWebService.kt
+++ b/web/src/main/kotlin/web/service/BlackjackWebService.kt
@@ -23,7 +23,10 @@ class BlackjackWebService(
 
     data class TableSummaryView(
         val tableId: Long,
-        val hostDiscordId: Long?,
+        // Stringified — see [SeatView.discordId]. Matches the parallel field
+        // on [TableStateView] so a lobby host id and the in-table host id
+        // both round-trip through JSON without losing precision.
+        val hostDiscordId: String?,
         /** Resolved Discord display name of the host, or fallback when not resolvable. */
         val hostName: String,
         val mode: String,
@@ -139,7 +142,7 @@ class BlackjackWebService(
             val host = table.hostDiscordId?.let { hosts[it] }
             TableSummaryView(
                 tableId = table.id,
-                hostDiscordId = table.hostDiscordId,
+                hostDiscordId = table.hostDiscordId?.toString(),
                 hostName = host?.name
                     ?: table.hostDiscordId?.let { memberLookup.fallbackName(it) }
                     ?: "—",

--- a/web/src/main/kotlin/web/service/DuelWebService.kt
+++ b/web/src/main/kotlin/web/service/DuelWebService.kt
@@ -17,8 +17,11 @@ class DuelWebService(
 ) {
     data class PendingDuelView(
         val duelId: Long,
-        val initiatorDiscordId: Long,
-        val opponentDiscordId: Long,
+        // Stringified so the 18-digit Discord snowflake survives JS's 53-bit
+        // Number precision. duel.js renders these into the row text directly,
+        // so a numeric round-trip would print a rounded id.
+        val initiatorDiscordId: String,
+        val opponentDiscordId: String,
         val stake: Long
     )
 
@@ -31,8 +34,8 @@ class DuelWebService(
     private fun toView(d: PendingDuelRegistry.PendingDuel): PendingDuelView =
         PendingDuelView(
             duelId = d.id,
-            initiatorDiscordId = d.initiatorDiscordId,
-            opponentDiscordId = d.opponentDiscordId,
+            initiatorDiscordId = d.initiatorDiscordId.toString(),
+            opponentDiscordId = d.opponentDiscordId.toString(),
             stake = d.stake
         )
 

--- a/web/src/main/kotlin/web/service/PokerWebService.kt
+++ b/web/src/main/kotlin/web/service/PokerWebService.kt
@@ -21,7 +21,10 @@ class PokerWebService(
 
     data class TableSummaryView(
         val tableId: Long,
-        val hostDiscordId: Long,
+        // Stringified so the 18-digit Discord snowflake survives JS's 53-bit
+        // Number precision. Numeric serialization rounds the last few digits,
+        // breaking the "am I the host?" compare in poker-table.js.
+        val hostDiscordId: String,
         /** Resolved Discord display name of the host, or fallback when not resolvable. */
         val hostName: String,
         val seats: Int,
@@ -37,7 +40,8 @@ class PokerWebService(
     data class TableStateView(
         val tableId: Long,
         val guildId: Long,
-        val hostDiscordId: Long,
+        // Stringified — see [TableSummaryView.hostDiscordId].
+        val hostDiscordId: String,
         val phase: String,
         val handNumber: Long,
         val pot: Long,
@@ -84,7 +88,11 @@ class PokerWebService(
     )
 
     data class SeatView(
-        val discordId: Long,
+        // Stringified — see [TableSummaryView.hostDiscordId]. Used as the
+        // [data-discord-id] selector on the seat element so it must match
+        // the [HandResultView.payoutByDiscordId] keys exactly for the
+        // chip-flash flourish to find the right seat.
+        val discordId: String,
         /** Discord display name (server nickname or username), or fallback when not in guild. */
         val displayName: String,
         /** CDN avatar URL, null when the bot can't resolve the member or they've left. */
@@ -99,7 +107,10 @@ class PokerWebService(
 
     data class HandResultView(
         val handNumber: Long,
-        val winners: List<Long>,
+        // Stringified — see [SeatView.discordId]. The JS looks each winner up
+        // in the seat's `nameById` map (built from the stringified seat ids),
+        // so these have to match those exactly.
+        val winners: List<String>,
         val payoutByDiscordId: Map<String, Long>,
         val pot: Long,
         val rake: Long,
@@ -124,8 +135,9 @@ class PokerWebService(
     data class PotResultView(
         val cap: Long,
         val amount: Long,
-        val eligibleDiscordIds: List<Long>,
-        val winners: List<Long>,
+        // Stringified — see [SeatView.discordId].
+        val eligibleDiscordIds: List<String>,
+        val winners: List<String>,
         val payoutByDiscordId: Map<String, Long>,
     )
 
@@ -138,7 +150,7 @@ class PokerWebService(
             val host = hosts[t.hostDiscordId]
             TableSummaryView(
                 tableId = t.id,
-                hostDiscordId = t.hostDiscordId,
+                hostDiscordId = t.hostDiscordId.toString(),
                 hostName = host?.name ?: memberLookup.fallbackName(t.hostDiscordId),
                 seats = t.seats.size,
                 maxSeats = t.maxSeats,
@@ -181,7 +193,7 @@ class PokerWebService(
             return TableStateView(
                 tableId = table.id,
                 guildId = table.guildId,
-                hostDiscordId = table.hostDiscordId,
+                hostDiscordId = table.hostDiscordId.toString(),
                 phase = table.phase.name,
                 handNumber = table.handNumber,
                 pot = table.pot,
@@ -205,7 +217,7 @@ class PokerWebService(
                     table.seats.mapIndexed { idx, seat ->
                         val member = members[seat.discordId]
                         SeatView(
-                            discordId = seat.discordId,
+                            discordId = seat.discordId.toString(),
                             displayName = member?.name ?: memberLookup.fallbackName(seat.discordId),
                             avatarUrl = member?.avatarUrl,
                             chips = seat.chips,
@@ -231,7 +243,7 @@ class PokerWebService(
                 lastResult = table.lastResult?.let { result ->
                     HandResultView(
                         handNumber = result.handNumber,
-                        winners = result.winners,
+                        winners = result.winners.map { it.toString() },
                         payoutByDiscordId = result.payoutByDiscordId.mapKeys { it.key.toString() },
                         pot = result.pot,
                         rake = result.rake,
@@ -243,8 +255,8 @@ class PokerWebService(
                             PotResultView(
                                 cap = p.cap,
                                 amount = p.amount,
-                                eligibleDiscordIds = p.eligibleDiscordIds,
-                                winners = p.winners,
+                                eligibleDiscordIds = p.eligibleDiscordIds.map { it.toString() },
+                                winners = p.winners.map { it.toString() },
                                 payoutByDiscordId = p.payoutByDiscordId.mapKeys { it.key.toString() },
                             )
                         },

--- a/web/src/main/resources/static/js/poker-table.js
+++ b/web/src/main/resources/static/js/poker-table.js
@@ -72,7 +72,9 @@
         state.seats.forEach(function (s, idx) {
             const node = document.createElement('div');
             node.className = 'poker-seat casino-seat';
-            node.dataset.discordId = String(s.discordId);
+            // s.discordId is already a string from the server projection
+            // (Long → String in PokerWebService.SeatView); no JS rounding.
+            node.dataset.discordId = s.discordId;
             const isMe = idx === meIdx;
             if (isMe) node.classList.add('poker-seat-me', 'is-me');
             if (idx === state.actorIndex && state.phase !== 'WAITING') node.classList.add('poker-seat-active', 'is-active');
@@ -135,7 +137,9 @@
         btnRaise.textContent = 'Raise (+' + (state.raiseAmount - state.callAmount) + ')';
         btnFold.disabled = !state.isMyTurn;
 
-        const isHost = String(state.hostDiscordId) === String(myDiscordId);
+        // hostDiscordId comes through as a string (see PokerWebService);
+        // myDiscordId is read from the data-my-discord-id attribute, also a string.
+        const isHost = state.hostDiscordId === myDiscordId;
         const canStart = isHost && state.phase === 'WAITING' && state.seats.length >= 2;
         btnStart.hidden = !isHost;
         btnStart.disabled = !canStart;
@@ -185,9 +189,9 @@
         // labels show real Discord names instead of raw ids.
         const nameById = {};
         ((state && state.seats) || []).forEach(function (s) {
-            nameById[String(s.discordId)] = s.displayName || ('Player ' + s.discordId);
+            nameById[s.discordId] = s.displayName || ('Player ' + s.discordId);
         });
-        const labelFor = function (id) { return nameById[String(id)] || String(id); };
+        const labelFor = function (id) { return nameById[id] || String(id); };
         const winners = (result.winners || []).map(labelFor).join(', ');
         const reveals = result.revealedHoleCards || {};
         const lines = [];
@@ -219,7 +223,7 @@
                 if (!amount || amount <= 0) return;
                 const seatEl = seatsEl.querySelector('[data-discord-id="' + id + '"]');
                 if (seatEl) window.CasinoRender.flashChipsOn(seatEl, amount);
-                if (String(id) === String(myDiscordId)) myPaid = true;
+                if (id === myDiscordId) myPaid = true;
             });
             // Sound cue keyed off the viewer's outcome — a win is a win
             // for the player even if a side pot went elsewhere.

--- a/web/src/test/kotlin/web/controller/DuelControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/DuelControllerTest.kt
@@ -251,7 +251,12 @@ class DuelControllerTest {
 
     @Test
     fun `outgoingForMe returns the initiator's pending offers`() {
-        val view = DuelWebService.PendingDuelView(duelId, discordId, opponentId, 50L)
+        val view = DuelWebService.PendingDuelView(
+            duelId,
+            discordId.toString(),
+            opponentId.toString(),
+            50L,
+        )
         every { duelWebService.pendingForInitiator(discordId, guildId) } returns listOf(view)
 
         val response = controller.outgoingForMe(guildId, user)

--- a/web/src/test/kotlin/web/controller/PokerControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/PokerControllerTest.kt
@@ -285,7 +285,7 @@ class PokerControllerTest {
         PokerWebService.TableStateView(
             tableId = tableId,
             guildId = guildId,
-            hostDiscordId = discordId,
+            hostDiscordId = discordId.toString(),
             phase = "WAITING",
             handNumber = 0L,
             pot = 0L,

--- a/web/src/test/kotlin/web/service/BlackjackWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/BlackjackWebServiceTest.kt
@@ -95,4 +95,15 @@ class BlackjackWebServiceTest {
         assertEquals("Player 9999", view.seats[0].displayName)
         assertNull(view.seats[0].avatarUrl)
     }
+
+    @Test
+    fun `listMultiTables stringifies hostDiscordId so it survives JS Number precision`() {
+        // 18-digit Discord snowflake — past JS Number.MAX_SAFE_INTEGER (2^53).
+        // Numeric serialization would round the last few digits.
+        val snowflake = 553658039266443264L
+        makeTable(seatIds = listOf(snowflake, 2L))
+        val rows = service.listMultiTables(guildId = 42L)
+        assertEquals(1, rows.size)
+        assertEquals(snowflake.toString(), rows[0].hostDiscordId)
+    }
 }

--- a/web/src/test/kotlin/web/service/DuelWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/DuelWebServiceTest.kt
@@ -46,7 +46,11 @@ class DuelWebServiceTest {
         val rows = service.pendingForOpponent(opponentId, guildId)
 
         assertEquals(2, rows.size)
-        assertTrue(rows.all { it.opponentDiscordId == opponentId })
+        // Stringified to survive 18-digit Discord-snowflake JSON round-trips
+        // through JS (numeric serialization rounds past 2^53).
+        assertTrue(rows.all { it.opponentDiscordId == opponentId.toString() })
+        assertEquals("100", rows[0].initiatorDiscordId)
+        assertEquals("101", rows[1].initiatorDiscordId)
         assertEquals(50L, rows[0].stake)
         assertEquals(75L, rows[1].stake)
     }

--- a/web/src/test/kotlin/web/service/PokerWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/PokerWebServiceTest.kt
@@ -224,13 +224,34 @@ class PokerWebServiceTest {
         assertEquals(2, pots.size)
         assertEquals(50L, pots[0].cap)
         assertEquals(150L, pots[0].amount)
-        assertEquals(listOf(1L, 2L, 3L), pots[0].eligibleDiscordIds)
-        assertEquals(listOf(1L), pots[0].winners)
+        assertEquals(listOf("1", "2", "3"), pots[0].eligibleDiscordIds)
+        assertEquals(listOf("1"), pots[0].winners)
         assertEquals(150L, pots[0].payoutByDiscordId["1"])
         assertEquals(200L, pots[1].cap)
-        assertEquals(listOf(2L, 3L), pots[1].eligibleDiscordIds)
-        assertEquals(listOf(2L), pots[1].winners)
+        assertEquals(listOf("2", "3"), pots[1].eligibleDiscordIds)
+        assertEquals(listOf("2"), pots[1].winners)
         assertEquals(300L, pots[1].payoutByDiscordId["2"])
         assertEquals(25L, lastResult.refundedByDiscordId["3"])
+        // top-level winners are stringified too — the JS uses these to look
+        // up display names in nameById, which is keyed by the seat's
+        // (also-stringified) discordId.
+        assertEquals(listOf("1", "2"), lastResult.winners)
+    }
+
+    @Test
+    fun `seat discordId and host discordId are stringified to survive JS Number precision`() {
+        // 18-digit Discord snowflake — past JS Number.MAX_SAFE_INTEGER (2^53).
+        // Numeric serialization would round the last few digits and the JS
+        // "am I the host?" / "did I win this pot?" compares would silently
+        // miss. Lock the projection to String so JSON.parse keeps every digit.
+        val snowflake = 553658039266443264L
+        val table = makeTable(seatChips = listOf(snowflake to 1000L, 2L to 1000L))
+        val view = service.snapshot(table.id, viewerDiscordId = snowflake)!!
+        assertEquals(snowflake.toString(), view.hostDiscordId)
+        assertEquals(snowflake.toString(), view.seats[0].discordId)
+        assertEquals("2", view.seats[1].discordId)
+
+        val rows = service.listGuildTables(guildId = 42L)
+        assertEquals(snowflake.toString(), rows[0].hostDiscordId)
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to #356 — the same Long-discordId-as-JSON-Number precision-loss pattern existed in poker, duel, and the blackjack lobby summary that #356 missed. Discord snowflakes are 18 digits, past JS `Number.MAX_SAFE_INTEGER` (2^53), so any field serialized as a JSON number gets its last few digits rounded once `JSON.parse` hands it to the browser.

Concretely:

- **Poker** (`PokerWebService`): `TableSummaryView.hostDiscordId`, `TableStateView.hostDiscordId`, `SeatView.discordId`, `HandResultView.winners`, `PotResultView.eligibleDiscordIds`, `PotResultView.winners`. `poker-table.js` keys the chip-flash flourish off `[data-discord-id]` and decides "am I the host?" via `state.hostDiscordId === myDiscordId` — both relied on stringified ids being exact, so a rounded snowflake silently broke both.
- **Duel** (`DuelWebService.PendingDuelView`, `DuelController.DuelActionResponse`): `initiatorDiscordId`, `opponentDiscordId`, `winnerDiscordId`, `loserDiscordId`. `duel.js` inlines these into the row text and the resolve toast (`<@…>` mention), so a rounded id would render the wrong user.
- **Blackjack** (`BlackjackWebService.TableSummaryView.hostDiscordId`): parallel field on the lobby summary that #356 missed — fixed for consistency with the already-stringified `TableStateView.hostDiscordId`.

JS side: `poker-table.js` drops the now-redundant `String(…)` wrappers since the wire types are strings end-to-end.

## Test plan

- [x] `:web:test` green
- [x] New assertions in `PokerWebServiceTest`, `DuelWebServiceTest`, and `BlackjackWebServiceTest` use a real 18-digit snowflake (`553658039266443264`) to lock the projection — a numeric `Long` round-trip would round those.
- [ ] Manual: deal a poker hand and resolve it as host, confirm chip-flash lands on the winning seat and the "Deal" button stays enabled for the host (the `isHost` compare).
- [ ] Manual: open a duel offer between accounts whose snowflakes only differ in the lowest digits; confirm the inbox row labels the correct sender.

https://claude.ai/code/session_014ffsM6UFUh5KaMS4KUBPrf

---
_Generated by [Claude Code](https://claude.ai/code/session_014ffsM6UFUh5KaMS4KUBPrf)_