### PR TITLE
feat(casino web): add Rules explainers to blackjack and poker pages

### DIFF
--- a/web/src/main/resources/static/css/blackjack.css
+++ b/web/src/main/resources/static/css/blackjack.css
@@ -135,6 +135,33 @@
 }
 
 /* ------------------------------------------------------------------- */
+/* Rules / how-to-play block (mirrors .highlow-rules, .dice-rules, etc.) */
+/* ------------------------------------------------------------------- */
+
+.bj-rules {
+    margin-top: var(--space-5);
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: var(--space-4);
+}
+.bj-rules h2 {
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--text-muted);
+    margin-bottom: var(--space-3);
+}
+.bj-rules ul {
+    list-style: disc;
+    padding-left: 20px;
+    color: var(--text-muted);
+    font-size: 0.95rem;
+    line-height: 1.7;
+}
+.bj-rules strong { color: #fff; }
+
+/* ------------------------------------------------------------------- */
 /* Responsive — phones                                                  */
 /* ------------------------------------------------------------------- */
 

--- a/web/src/main/resources/static/css/poker.css
+++ b/web/src/main/resources/static/css/poker.css
@@ -146,6 +146,33 @@
 }
 
 /* ------------------------------------------------------------------- */
+/* Rules / how-to-play block (mirrors .highlow-rules, .dice-rules, etc.) */
+/* ------------------------------------------------------------------- */
+
+.poker-rules {
+    margin-top: var(--space-5);
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: var(--space-4);
+}
+.poker-rules h2 {
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--text-muted);
+    margin-bottom: var(--space-3);
+}
+.poker-rules ul {
+    list-style: disc;
+    padding-left: 20px;
+    color: var(--text-muted);
+    font-size: 0.95rem;
+    line-height: 1.7;
+}
+.poker-rules strong { color: #fff; }
+
+/* ------------------------------------------------------------------- */
 /* Responsive — phones                                                  */
 /* ------------------------------------------------------------------- */
 

--- a/web/src/main/resources/templates/blackjack-lobby.html
+++ b/web/src/main/resources/templates/blackjack-lobby.html
@@ -56,6 +56,16 @@
         </div>
         <p class="muted">Refreshes automatically.</p>
     </section>
+
+    <section class="bj-rules">
+        <h2>Rules</h2>
+        <ul>
+            <li>Pick a table to join, or create your own with the form above and an ante you choose.</li>
+            <li>Beat the dealer's hand without going over <strong>21</strong>. Natural blackjack pays <strong>3:2</strong>; any other win pays <strong>1:1</strong>; pushes refund.</li>
+            <li>The dealer stands on all 17. <strong>Double</strong>, <strong>split</strong>, and re-split (up to 4 hands) are available on every seat.</li>
+            <li>Each multiplayer hand takes a <strong>5% rake</strong> from losers' chips into the per-guild jackpot pool — somebody at the table eventually scoops it.</li>
+        </ul>
+    </section>
 </main>
 
 <div class="toast-stack" id="toast-stack" aria-live="polite"></div>

--- a/web/src/main/resources/templates/blackjack-solo.html
+++ b/web/src/main/resources/templates/blackjack-solo.html
@@ -55,6 +55,18 @@
 
         <div id="bj-result" class="bj-result muted"></div>
     </section>
+
+    <section class="bj-rules">
+        <h2>Rules</h2>
+        <ul>
+            <li>Beat the dealer's hand without going over <strong>21</strong>. Face cards count as 10; aces count as 1 or 11.</li>
+            <li><strong>Hit</strong> draws another card; <strong>Stand</strong> keeps your total. You bust at 22+ and lose your stake.</li>
+            <li>Dealer hits until 17 or higher (stands on soft 17 by default).</li>
+            <li>A two-card 21 (a "natural blackjack") pays <strong>3:2</strong>. Any other win pays <strong>1:1</strong>. Pushes refund your stake.</li>
+            <li><strong>Double down</strong> on your first two cards: doubles your stake, you draw exactly one more card.</li>
+            <li><strong>Split</strong> a matching pair (e.g. 8-8) into two hands — each plays its own ante. Up to 4 split hands; split aces auto-stand on one card.</li>
+        </ul>
+    </section>
 </main>
 
 <div class="toast-stack" id="toast-stack" aria-live="polite"></div>

--- a/web/src/main/resources/templates/blackjack-table.html
+++ b/web/src/main/resources/templates/blackjack-table.html
@@ -55,6 +55,19 @@
         <div id="bj-status" class="muted" style="margin-top: 0.75rem;"></div>
         <div id="bj-result" class="muted" style="margin-top: 0.5rem;"></div>
     </section>
+
+    <section class="bj-rules">
+        <h2>Rules</h2>
+        <ul>
+            <li>Beat the dealer's hand without going over <strong>21</strong>. Face cards count as 10; aces count as 1 or 11.</li>
+            <li><strong>Hit</strong> draws another card; <strong>Stand</strong> keeps your total. You bust at 22+ and lose your ante.</li>
+            <li>Dealer hits until 17 or higher (stands on soft 17 by default).</li>
+            <li>A two-card 21 (a "natural blackjack") pays <strong>3:2</strong>. Any other win pays <strong>1:1</strong>. Pushes refund the ante.</li>
+            <li><strong>Double down</strong> on your first two cards: doubles your stake, you draw exactly one more card.</li>
+            <li><strong>Split</strong> a matching pair (e.g. 8-8) into two hands — each plays its own ante. Up to 4 split hands; split aces auto-stand on one card.</li>
+            <li>Each hand pays a <strong>5% rake</strong> on losers' chips into the per-guild jackpot pool.</li>
+        </ul>
+    </section>
 </main>
 
 <div class="toast-stack" id="toast-stack" aria-live="polite"></div>

--- a/web/src/main/resources/templates/poker-lobby.html
+++ b/web/src/main/resources/templates/poker-lobby.html
@@ -60,6 +60,16 @@
         </div>
         <p class="muted">Refreshes automatically.</p>
     </section>
+
+    <section class="poker-rules">
+        <h2>Rules</h2>
+        <ul>
+            <li>Browse open tables or host your own — the host sets the buy-in range and blinds.</li>
+            <li>Fixed-limit Texas Hold'em: <strong>small bet</strong> pre-flop and on the flop, <strong>big bet</strong> on the turn and river, raises capped per street.</li>
+            <li>Multi-way all-ins split the pot into a main pot + side pots so everyone competes for what they could match.</li>
+            <li>Each hand pays a <strong>5% rake</strong> into the per-guild jackpot pool.</li>
+        </ul>
+    </section>
 </main>
 
 <div class="toast-stack" id="toast-stack" aria-live="polite"></div>

--- a/web/src/main/resources/templates/poker-table.html
+++ b/web/src/main/resources/templates/poker-table.html
@@ -62,6 +62,18 @@
         <div id="poker-result" class="muted" style="margin-top: 0.5rem;"></div>
         <div id="poker-pots" class="poker-pots-container" style="margin-top: 0.5rem;" hidden></div>
     </section>
+
+    <section class="poker-rules">
+        <h2>Rules</h2>
+        <ul>
+            <li>Fixed-limit Texas Hold'em: <strong>small blind</strong> and <strong>big blind</strong> are posted automatically each hand.</li>
+            <li>You're dealt 2 hole cards; 5 community cards are revealed across the flop, turn, and river.</li>
+            <li>Bet size is the table's <strong>small bet</strong> pre-flop and on the flop, <strong>big bet</strong> on the turn and river.</li>
+            <li>Raises are capped per street — once the cap is hit, only check, call, or fold are legal.</li>
+            <li>Going all-in for less than your opponents creates a <strong>side pot</strong> they fight over without you.</li>
+            <li>Each hand pays a <strong>5% rake</strong> into the per-guild jackpot pool. Best 5-card hand at showdown wins.</li>
+        </ul>
+    </section>
 </main>
 
 <div class="toast-stack" id="toast-stack" aria-live="polite"></div>


### PR DESCRIPTION
## Summary

Highlow, slots, dice, coinflip, and scratch all already render a `<section class="[game]-rules">` block at the bottom of the page so newcomers can learn the game without leaving. Blackjack (solo / table / lobby) and poker (table / lobby) didn't — this PR fills that gap.

- **Blackjack**: concise basics — hit/stand/bust, dealer S17, BJ pays 3:2 / win 1:1 / push refunds, double, split up to 4 hands (+ split-aces rule), multiplayer 5% rake → jackpot. Solo page omits the rake bullet (no pot); multi table + lobby include it.
- **Poker**: fixed-limit Texas Hold'em basics — blinds, small/big bet per street, raise cap, side pots on uneven all-ins, 5% rake → jackpot, best 5-card hand wins.

Numbers verified against the engine (`Blackjack.kt`: `BLACKJACK_MULT = 2.5`, `WIN_MULT = 2.0`, `DEALER_STAND_VALUE = 17`, `MAX_SPLIT_HANDS = 4`, `MULTI_RAKE = 0.05`; `PokerEngine.kt`: `smallBet`/`bigBet` per street, `maxRaisesPerStreet`).

Style mirrors `.highlow-rules` / `.dice-rules` / `.coinflip-rules` exactly — same surface / border / muted text / disc list. Adds parallel `.bj-rules` and `.poker-rules` blocks to `blackjack.css` and `poker.css`.

## Test plan

- [x] `:web:test` green (Thymeleaf templates parse at Spring boot; broken markup would fail the harness)
- [ ] Manual: open `/blackjack/{guild}/solo`, `/blackjack/{guild}/{tableId}`, `/blackjack/{guild}`, `/poker/{guild}/{tableId}`, `/poker/{guild}` — confirm the Rules section renders at the bottom and looks consistent with highlow/dice/etc., on desktop and at the ≤600px / ≤380px mobile breakpoints.

https://claude.ai/code/session_014ffsM6UFUh5KaMS4KUBPrf

---
_Generated by [Claude Code](https://claude.ai/code/session_014ffsM6UFUh5KaMS4KUBPrf)_