### PR TITLE
fix(blackjack web): clear split layout after a fresh deal

### DIFF
--- a/web/src/main/resources/static/css/blackjack.css
+++ b/web/src/main/resources/static/css/blackjack.css
@@ -74,18 +74,6 @@
     min-height: 4.5rem;
 }
 
-/* Author display rules above (.bj-cards / .bj-seats) override the user-agent
-   `[hidden] { display: none }` at equal specificity, which silently breaks
-   `el.hidden = true` from JS — the element keeps its declared display value.
-   blackjack-solo.js relies on toggling `hidden` on `#bj-player-cards` /
-   `#bj-player-hands` to switch between the single-hand and split layouts;
-   without these explicit overrides, the previous round's split sub-hands
-   stay on screen after a fresh deal. Specificity (0,2,0) wins. */
-.bj-cards[hidden],
-.bj-seats[hidden] {
-    display: none;
-}
-
 .bj-info {
     display: flex;
     flex-wrap: wrap;
@@ -140,6 +128,20 @@
     display: grid;
     gap: 0.5rem;
     margin: 1rem 0;
+}
+
+/* The two class rules above (.bj-cards / .bj-seats) declare an explicit
+   `display`, which overrides the user-agent `[hidden] { display: none }` at
+   equal specificity and silently breaks `el.hidden = true` from JS — the
+   element keeps its declared display value. blackjack-solo.js relies on
+   toggling `hidden` on `#bj-player-cards` / `#bj-player-hands` to switch
+   between the single-hand and split layouts; without these overrides, the
+   previous round's split sub-hands stay on screen after a fresh deal.
+   Sits AFTER both class rules so source order also lands on it (jsdom's
+   CSS cascade is source-order-biased even when specificity should win). */
+.bj-cards[hidden],
+.bj-seats[hidden] {
+    display: none;
 }
 
 .bj-shot-clock {

--- a/web/src/main/resources/static/css/blackjack.css
+++ b/web/src/main/resources/static/css/blackjack.css
@@ -74,6 +74,18 @@
     min-height: 4.5rem;
 }
 
+/* Author display rules above (.bj-cards / .bj-seats) override the user-agent
+   `[hidden] { display: none }` at equal specificity, which silently breaks
+   `el.hidden = true` from JS — the element keeps its declared display value.
+   blackjack-solo.js relies on toggling `hidden` on `#bj-player-cards` /
+   `#bj-player-hands` to switch between the single-hand and split layouts;
+   without these explicit overrides, the previous round's split sub-hands
+   stay on screen after a fresh deal. Specificity (0,2,0) wins. */
+.bj-cards[hidden],
+.bj-seats[hidden] {
+    display: none;
+}
+
 .bj-info {
     display: flex;
     flex-wrap: wrap;

--- a/web/src/test/js/blackjack-split-cleanup.test.js
+++ b/web/src/test/js/blackjack-split-cleanup.test.js
@@ -1,0 +1,59 @@
+// Regression test for the split-layout cleanup bug. blackjack-solo.js
+// flips `hidden` on `#bj-player-cards` (.bj-cards) and `#bj-player-hands`
+// (.bj-seats) to switch between the single-hand and split layouts. The
+// `.bj-cards { display: flex }` and `.bj-seats { display: grid }` author
+// rules used to override the user-agent `[hidden] { display: none }` at
+// equal specificity, leaving the previous round's split sub-hands on
+// screen after a fresh deal. blackjack.css now carries an explicit
+// `.bj-cards[hidden], .bj-seats[hidden] { display: none; }` override at
+// specificity (0,2,0) to win the cascade. This test loads the real CSS
+// into the jsdom document and confirms the override actually applies.
+const fs = require('fs');
+const path = require('path');
+
+describe('blackjack.css — hidden actually hides .bj-cards and .bj-seats', () => {
+    let cardsEl;
+    let seatsEl;
+
+    beforeEach(() => {
+        const css = fs.readFileSync(
+            path.join(__dirname, '../../main/resources/static/css/blackjack.css'),
+            'utf8'
+        );
+        document.head.innerHTML = '';
+        const style = document.createElement('style');
+        style.textContent = css;
+        document.head.appendChild(style);
+
+        document.body.innerHTML = `
+            <div id="cards" class="bj-cards"></div>
+            <div id="seats" class="bj-seats"></div>
+        `;
+        cardsEl = document.getElementById('cards');
+        seatsEl = document.getElementById('seats');
+    });
+
+    test('.bj-cards lays out as flex when visible', () => {
+        expect(getComputedStyle(cardsEl).display).toBe('flex');
+    });
+
+    test('.bj-seats lays out as grid when visible', () => {
+        expect(getComputedStyle(seatsEl).display).toBe('grid');
+    });
+
+    test('toggling hidden on .bj-cards collapses display to none (was the bug)', () => {
+        cardsEl.hidden = true;
+        expect(getComputedStyle(cardsEl).display).toBe('none');
+    });
+
+    test('toggling hidden on .bj-seats collapses display to none (was the bug)', () => {
+        seatsEl.hidden = true;
+        expect(getComputedStyle(seatsEl).display).toBe('none');
+    });
+
+    test('clearing hidden restores the layout display', () => {
+        seatsEl.hidden = true;
+        seatsEl.hidden = false;
+        expect(getComputedStyle(seatsEl).display).toBe('grid');
+    });
+});


### PR DESCRIPTION
## Summary

Reproduce: solo-deal a splittable pair (e.g. 8-8), click Split, play out both hands, click Deal again. The new single-hand round renders **above** the previous round's two split sub-hands, which stay on screen — looks like the table never reset.

## Root cause

`blackjack-solo.js` toggles `el.hidden = true/false` on `#bj-player-cards` (`.bj-cards`) and `#bj-player-hands` (`.bj-seats`) to switch between the single-hand and split layouts. But those classes set explicit `display: flex` / `display: grid`. The user-agent `[hidden] { display: none }` rule and the author class rules collide at equal specificity (0,1,0), and the author rule wins, so `hidden` was silently a no-op for these two elements.

After a non-split deal the JS marks `bj-player-hands` hidden, but the previous round's `<div class="bj-seat">` children were still in the DOM **and** still laid out by `display: grid`.

## Fix

Add `.bj-cards[hidden], .bj-seats[hidden] { display: none; }` — specificity (0,2,0) beats both the class rules and the user-agent default, so `hidden` becomes meaningful again. `blackjack-table.js` already wipes `seatsEl.innerHTML` on every render, so the multi flow was unaffected.

## Test plan

- [x] `:web:test` green (CSS-only change, no logic touched)
- [ ] Manual: deal a solo blackjack hand of 8-8, split, play both hands to resolution, click Deal again — confirm only the new single hand renders, no leftover split sub-hands.
- [ ] Manual sanity: the multi blackjack flow still renders normally (it already wipes the seat list per poll).

https://claude.ai/code/session_014ffsM6UFUh5KaMS4KUBPrf

---
_Generated by [Claude Code](https://claude.ai/code/session_014ffsM6UFUh5KaMS4KUBPrf)_