### PR TITLE
feat(cards): render TEN as "10" instead of "T"

### DIFF
--- a/database/src/main/kotlin/database/card/Card.kt
+++ b/database/src/main/kotlin/database/card/Card.kt
@@ -9,7 +9,7 @@ enum class Suit(val symbol: Char) {
 enum class Rank(val value: Int, val symbol: String) {
     TWO(2, "2"), THREE(3, "3"), FOUR(4, "4"), FIVE(5, "5"),
     SIX(6, "6"), SEVEN(7, "7"), EIGHT(8, "8"), NINE(9, "9"),
-    TEN(10, "T"), JACK(11, "J"), QUEEN(12, "Q"), KING(13, "K"), ACE(14, "A");
+    TEN(10, "10"), JACK(11, "J"), QUEEN(12, "Q"), KING(13, "K"), ACE(14, "A");
 
     override fun toString(): String = symbol
 }

--- a/database/src/test/kotlin/database/card/CardTest.kt
+++ b/database/src/test/kotlin/database/card/CardTest.kt
@@ -23,7 +23,7 @@ class CardTest {
     @Test
     fun `Card toString joins rank symbol and suit symbol`() {
         assertEquals("A♠", Card(Rank.ACE, Suit.SPADES).toString())
-        assertEquals("T♥", Card(Rank.TEN, Suit.HEARTS).toString())
+        assertEquals("10♥", Card(Rank.TEN, Suit.HEARTS).toString())
     }
 
     @Test

--- a/web/src/main/resources/static/js/poker-table.js
+++ b/web/src/main/resources/static/js/poker-table.js
@@ -47,7 +47,7 @@
             span.textContent = '🂠';
             return span;
         }
-        // Card strings look like "A♠", "T♥", "9♦", "K♣"
+        // Card strings look like "A♠", "10♥", "9♦", "K♣"
         const suit = c.charAt(c.length - 1);
         if (suit === '♥' || suit === '♦') span.classList.add('is-red');
         span.textContent = c;


### PR DESCRIPTION
## Summary

Switches `Rank.TEN`'s symbol from `"T"` to `"10"` in `database/src/main/kotlin/database/card/Card.kt`. "T" is poker shorthand that most casual blackjack/casino players don't recognise — every other rank already renders as a number; ten being the odd one out is a confusing surprise on a non-poker UI.

The change flows through every consumer of `Card.toString()`:
- Discord embeds (blackjack and poker hand-state messages)
- Web UI card glyphs (`.casino-card-glyph` paints whatever string the server sends)
- `blackjack_hand_log` / `poker_hand_log` `dealer` / `board` columns on rows persisted from now on

Persisted hand-log strings remain free-form text; rows are display-only and never parsed back into `Card` objects, so old `"T♥"` and new `"10♥"` rows coexist harmlessly in the audit log. The poker test helper at `HandEvaluatorTest.parse()` keeps its 2-char `"TH"` shorthand because it parses notation into `Card`, independent of `Card.toString()`.

## Mobile width

`.casino-card-glyph` is `width: 2rem` / `font-size: 0.95rem` at the 380px breakpoint; `tabular-nums` keeps "1" and "0" narrow so `"10♥"` comes in around 27px in the 32px box. Worth a real-browser eyeball on a phone before merge — if the glyph clips, the easy follow-up is bumping the width by 0.25rem at that breakpoint or shrinking the font another notch.

## Test plan

- [x] `:database:test` green — `CardTest` updated to expect `"10♥"`.
- [x] `:web:test` green.
- [x] `npm test` in `web/` — 208/208 jest cases green.
- [ ] Manual: open a blackjack hand on desktop and a phone, confirm tens render as "10" and the glyph doesn't clip.
- [ ] Manual: deal a poker hand with a ten on the board, confirm same.

https://claude.ai/code/session_014ffsM6UFUh5KaMS4KUBPrf

---
_Generated by [Claude Code](https://claude.ai/code/session_014ffsM6UFUh5KaMS4KUBPrf)_