### PR TITLE
feat(casino web): surface the jackpot pool banner on blackjack and poker pages

### DIFF
--- a/web/src/main/kotlin/web/controller/BlackjackController.kt
+++ b/web/src/main/kotlin/web/controller/BlackjackController.kt
@@ -11,6 +11,7 @@ import database.service.BlackjackService.MultiLeaveOutcome
 import database.service.BlackjackService.MultiStartOutcome
 import database.service.BlackjackService.SoloActionOutcome
 import database.service.BlackjackService.SoloDealOutcome
+import database.service.JackpotService
 import database.service.UserService
 import net.dv8tion.jda.api.JDA
 import org.springframework.http.ResponseEntity
@@ -66,6 +67,7 @@ class BlackjackController(
     private val tableRegistry: BlackjackTableRegistry,
     private val economyWebService: EconomyWebService,
     private val userService: UserService,
+    private val jackpotService: JackpotService,
     private val jda: JDA,
 ) {
 
@@ -109,6 +111,7 @@ class BlackjackController(
         model.addAttribute("guildId", guildId.toString())
         model.addAttribute("guildName", guild.name)
         model.addAttribute("balance", profile?.socialCredit ?: 0L)
+        model.addAttribute("jackpotPool", jackpotService.getPool(guildId))
         model.addAttribute("minAnte", Blackjack.MULTI_MIN_ANTE)
         model.addAttribute("maxAnte", Blackjack.MULTI_MAX_ANTE)
         model.addAttribute("maxSeats", Blackjack.MULTI_MAX_SEATS)
@@ -129,6 +132,7 @@ class BlackjackController(
         val profile = userService.getUserById(discordId, guildId)
         model.addAttribute("guildId", guildId.toString())
         model.addAttribute("balance", profile?.socialCredit ?: 0L)
+        model.addAttribute("jackpotPool", jackpotService.getPool(guildId))
         model.addAttribute("minStake", Blackjack.MIN_STAKE)
         model.addAttribute("maxStake", Blackjack.MAX_STAKE)
         model.addAttribute("username", user.displayName())
@@ -155,6 +159,7 @@ class BlackjackController(
         model.addAttribute("guildId", guildId.toString())
         model.addAttribute("tableId", tableId.toString())
         model.addAttribute("balance", profile?.socialCredit ?: 0L)
+        model.addAttribute("jackpotPool", jackpotService.getPool(guildId))
         model.addAttribute("ante", state.ante)
         model.addAttribute("username", user.displayName())
         model.addAttribute("myDiscordId", discordId.toString())

--- a/web/src/main/kotlin/web/controller/PokerController.kt
+++ b/web/src/main/kotlin/web/controller/PokerController.kt
@@ -6,6 +6,7 @@ import database.service.PokerService
 import database.service.PokerService.ActionOutcome
 import database.service.PokerService.BuyInOutcome
 import database.service.PokerService.CashOutOutcome
+import database.service.JackpotService
 import database.service.PokerService.CreateOutcome
 import database.service.PokerService.StartHandOutcome
 import database.service.UserService
@@ -47,6 +48,7 @@ class PokerController(
     private val pokerWebService: PokerWebService,
     private val economyWebService: EconomyWebService,
     private val userService: UserService,
+    private val jackpotService: JackpotService,
     private val jda: JDA,
 ) {
     @GetMapping("/guilds")
@@ -82,6 +84,7 @@ class PokerController(
         model.addAttribute("guildId", guildId.toString())
         model.addAttribute("guildName", guild.name)
         model.addAttribute("balance", profile?.socialCredit ?: 0L)
+        model.addAttribute("jackpotPool", jackpotService.getPool(guildId))
         model.addAttribute("minBuyIn", PokerService.MIN_BUY_IN)
         model.addAttribute("maxBuyIn", PokerService.MAX_BUY_IN)
         model.addAttribute("smallBlind", PokerService.SMALL_BLIND)
@@ -112,6 +115,7 @@ class PokerController(
         model.addAttribute("guildId", guildId.toString())
         model.addAttribute("tableId", tableId.toString())
         model.addAttribute("balance", profile?.socialCredit ?: 0L)
+        model.addAttribute("jackpotPool", jackpotService.getPool(guildId))
         model.addAttribute("minBuyIn", PokerService.MIN_BUY_IN)
         model.addAttribute("maxBuyIn", PokerService.MAX_BUY_IN)
         model.addAttribute("username", user.displayName())

--- a/web/src/main/resources/templates/blackjack-lobby.html
+++ b/web/src/main/resources/templates/blackjack-lobby.html
@@ -20,6 +20,8 @@
 
     <div th:replace="~{fragments/alerts :: error}"></div>
 
+    <div th:replace="~{fragments/casino :: jackpotBanner}"></div>
+
     <section class="bj-card">
         <h2>Create a new table</h2>
         <form id="bj-create" autocomplete="off">

--- a/web/src/main/resources/templates/blackjack-solo.html
+++ b/web/src/main/resources/templates/blackjack-solo.html
@@ -20,6 +20,8 @@
 
     <div th:replace="~{fragments/alerts :: error}"></div>
 
+    <div th:replace="~{fragments/casino :: jackpotBanner}"></div>
+
     <section class="bj-card">
         <h2>Place your bet</h2>
         <form id="bj-deal" autocomplete="off">

--- a/web/src/main/resources/templates/blackjack-table.html
+++ b/web/src/main/resources/templates/blackjack-table.html
@@ -20,6 +20,8 @@
         </p>
     </div>
 
+    <div th:replace="~{fragments/casino :: jackpotBanner}"></div>
+
     <section class="bj-card" id="bj-join-card" hidden>
         <h2>Join this table</h2>
         <p class="muted">First-hand ante is debited from your wallet immediately.</p>

--- a/web/src/main/resources/templates/poker-lobby.html
+++ b/web/src/main/resources/templates/poker-lobby.html
@@ -22,6 +22,8 @@
 
     <div th:replace="~{fragments/alerts :: error}"></div>
 
+    <div th:replace="~{fragments/casino :: jackpotBanner}"></div>
+
     <section class="poker-card">
         <h2>Create a new table</h2>
         <form id="poker-create" autocomplete="off">

--- a/web/src/main/resources/templates/poker-table.html
+++ b/web/src/main/resources/templates/poker-table.html
@@ -25,6 +25,8 @@
         </p>
     </div>
 
+    <div th:replace="~{fragments/casino :: jackpotBanner}"></div>
+
     <section class="poker-card" id="poker-join-card" hidden>
         <h2>Join this table</h2>
         <form id="poker-join" autocomplete="off">

--- a/web/src/test/kotlin/web/controller/BlackjackControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/BlackjackControllerTest.kt
@@ -1,0 +1,132 @@
+package web.controller
+
+import database.blackjack.BlackjackTable
+import database.blackjack.BlackjackTableRegistry
+import database.service.BlackjackService
+import database.service.JackpotService
+import database.service.UserService
+import io.mockk.every
+import io.mockk.mockk
+import net.dv8tion.jda.api.JDA
+import net.dv8tion.jda.api.entities.Guild
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.security.oauth2.core.user.OAuth2User
+import org.springframework.ui.ConcurrentModel
+import org.springframework.web.servlet.mvc.support.RedirectAttributesModelMap
+import web.service.BlackjackWebService
+import web.service.EconomyWebService
+
+/**
+ * Page-handler regression tests. The JSON endpoints (`/state`, `/deal`,
+ * `/action`, …) live in their own integration coverage; this class
+ * exists specifically to lock in the model attributes that drive the
+ * Thymeleaf templates — the original miss was that `jackpotPool` was
+ * never wired through, so the shared `~{fragments/casino :: jackpotBanner}`
+ * fragment renders blank on every blackjack page.
+ */
+class BlackjackControllerTest {
+
+    private val guildId = 42L
+    private val discordId = 100L
+    private val tableId = 7L
+
+    private lateinit var blackjackService: BlackjackService
+    private lateinit var blackjackWebService: BlackjackWebService
+    private lateinit var tableRegistry: BlackjackTableRegistry
+    private lateinit var economyWebService: EconomyWebService
+    private lateinit var userService: UserService
+    private lateinit var jackpotService: JackpotService
+    private lateinit var jda: JDA
+    private lateinit var user: OAuth2User
+    private lateinit var controller: BlackjackController
+
+    @BeforeEach
+    fun setup() {
+        blackjackService = mockk(relaxed = true)
+        blackjackWebService = mockk(relaxed = true)
+        tableRegistry = mockk(relaxed = true)
+        economyWebService = mockk(relaxed = true)
+        userService = mockk(relaxed = true)
+        jackpotService = mockk(relaxed = true)
+        jda = mockk(relaxed = true)
+        user = mockk {
+            every { getAttribute<String>("id") } returns discordId.toString()
+            every { getAttribute<String>("username") } returns "tester"
+        }
+        every { economyWebService.isMember(discordId, guildId) } returns true
+        controller = BlackjackController(
+            blackjackService, blackjackWebService, tableRegistry,
+            economyWebService, userService, jackpotService, jda,
+        )
+    }
+
+    @Test
+    fun `lobby page wires jackpotPool model attribute so the banner renders`() {
+        val guild = mockk<Guild>(relaxed = true).also {
+            every { it.name } returns "Test Guild"
+        }
+        every { jda.getGuildById(guildId) } returns guild
+        every { jackpotService.getPool(guildId) } returns 1234L
+        every { blackjackWebService.listMultiTables(guildId) } returns emptyList()
+
+        val model = ConcurrentModel()
+        val view = controller.lobby(guildId, user, model, RedirectAttributesModelMap())
+
+        assertEquals("blackjack-lobby", view)
+        assertEquals(1234L, model.getAttribute("jackpotPool"))
+    }
+
+    @Test
+    fun `soloPage wires jackpotPool model attribute so the banner renders`() {
+        every { jackpotService.getPool(guildId) } returns 5555L
+
+        val model = ConcurrentModel()
+        val view = controller.soloPage(guildId, user, model, RedirectAttributesModelMap())
+
+        assertEquals("blackjack-solo", view)
+        assertEquals(5555L, model.getAttribute("jackpotPool"))
+    }
+
+    @Test
+    fun `tablePage wires jackpotPool model attribute so the banner renders`() {
+        // Snapshot must match the requested guild and be a MULTI table or
+        // the controller short-circuits to redirect — match the production
+        // shape so we exercise the model-attribute branch.
+        val snapshot = sampleSnapshot()
+        every { blackjackWebService.snapshot(tableId, discordId) } returns snapshot
+        every { jackpotService.getPool(guildId) } returns 9876L
+
+        val model = ConcurrentModel()
+        val view = controller.tablePage(
+            guildId, tableId, user, model, RedirectAttributesModelMap()
+        )
+
+        assertEquals("blackjack-table", view)
+        assertEquals(9876L, model.getAttribute("jackpotPool"))
+    }
+
+    private fun sampleSnapshot(): BlackjackWebService.TableStateView =
+        BlackjackWebService.TableStateView(
+            tableId = tableId,
+            guildId = guildId,
+            mode = BlackjackTable.Mode.MULTI.name,
+            hostDiscordId = discordId.toString(),
+            phase = "LOBBY",
+            handNumber = 0L,
+            ante = 100L,
+            maxSeats = 5,
+            actorIndex = 0,
+            seats = emptyList(),
+            dealer = emptyList(),
+            dealerTotalVisible = 0,
+            mySeatIndex = null,
+            isMyTurn = false,
+            canDouble = false,
+            canSplit = false,
+            shotClockSeconds = 0,
+            currentActorDeadlineEpochMillis = null,
+            lastResult = null,
+        )
+}

--- a/web/src/test/kotlin/web/controller/PokerControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/PokerControllerTest.kt
@@ -2,6 +2,7 @@ package web.controller
 
 import database.poker.PokerEngine
 import database.poker.PokerTable
+import database.service.JackpotService
 import database.service.PokerService
 import database.service.PokerService.ActionOutcome
 import database.service.PokerService.BuyInOutcome
@@ -33,6 +34,7 @@ class PokerControllerTest {
     private lateinit var pokerWebService: PokerWebService
     private lateinit var economyWebService: EconomyWebService
     private lateinit var userService: UserService
+    private lateinit var jackpotService: JackpotService
     private lateinit var jda: JDA
     private lateinit var user: OAuth2User
     private lateinit var controller: PokerController
@@ -43,13 +45,16 @@ class PokerControllerTest {
         pokerWebService = mockk(relaxed = true)
         economyWebService = mockk(relaxed = true)
         userService = mockk(relaxed = true)
+        jackpotService = mockk(relaxed = true)
         jda = mockk(relaxed = true)
         user = mockk {
             every { getAttribute<String>("id") } returns discordId.toString()
             every { getAttribute<String>("username") } returns "tester"
         }
         every { economyWebService.isMember(discordId, guildId) } returns true
-        controller = PokerController(pokerService, pokerWebService, economyWebService, userService, jda)
+        controller = PokerController(
+            pokerService, pokerWebService, economyWebService, userService, jackpotService, jda
+        )
     }
 
     @Test
@@ -279,6 +284,43 @@ class PokerControllerTest {
         every { pokerService.cashOut(discordId, guildId, tableId) } returns CashOutOutcome.TableNotFound
         val response = controller.cashOut(guildId, tableId, user)
         assertEquals(404, response.statusCode.value())
+    }
+
+    @Test
+    fun `lobby page wires jackpotPool model attribute so the banner renders`() {
+        // Regression: poker lobby & table pages used to omit `jackpotPool`,
+        // so `~{fragments/casino :: jackpotBanner}` rendered "0 credits"
+        // (or 500'd in dev) — players couldn't see what the rake was
+        // contributing to or what was up for grabs.
+        val guild = mockk<net.dv8tion.jda.api.entities.Guild>(relaxed = true).also {
+            every { it.name } returns "Test Guild"
+        }
+        every { jda.getGuildById(guildId) } returns guild
+        every { jackpotService.getPool(guildId) } returns 1234L
+        every { pokerWebService.listGuildTables(guildId) } returns emptyList()
+
+        val model = org.springframework.ui.ConcurrentModel()
+        val view = controller.lobby(
+            guildId, user, model, org.springframework.web.servlet.mvc.support.RedirectAttributesModelMap()
+        )
+
+        assertEquals("poker-lobby", view)
+        assertEquals(1234L, model.getAttribute("jackpotPool"))
+    }
+
+    @Test
+    fun `tablePage wires jackpotPool model attribute so the banner renders`() {
+        every { pokerWebService.snapshot(tableId, discordId) } returns sampleView()
+        every { jackpotService.getPool(guildId) } returns 9876L
+
+        val model = org.springframework.ui.ConcurrentModel()
+        val view = controller.tablePage(
+            guildId, tableId, user, model,
+            org.springframework.web.servlet.mvc.support.RedirectAttributesModelMap()
+        )
+
+        assertEquals("poker-table", view)
+        assertEquals(9876L, model.getAttribute("jackpotPool"))
     }
 
     private fun sampleView(guildId: Long = this.guildId): PokerWebService.TableStateView =


### PR DESCRIPTION
## Summary

Highlow, slots, dice, coinflip, and scratch already render the 🎰 jackpot pool banner at the top of every game page; blackjack and poker silently dropped it, so players couldn't see what they were contributing to or what was up for grabs.

Wires `jackpotPool` into the model on every blackjack/poker page handler (`BlackjackController.{lobby, soloPage, tablePage}`, `PokerController.{lobby, tablePage}`) and drops the existing `~{fragments/casino :: jackpotBanner}` fragment near the top of all five templates. Same fragment the working casino games already use — no new HTML, no new JS.

Did *not* refactor the controllers to use `CasinoPageContext.populate()`: populate also wires `tobyCoins` / `marketPrice` which these templates don't read, so the diff would be wider than the bug warrants. One-line attribute add per handler keeps the change focused.

## Tests

- New `BlackjackControllerTest` (file didn't exist before) — `lobby` / `soloPage` / `tablePage` each assert `jackpotPool` is on the model after a successful render. Locks in the regression so a future controller refactor can't silently drop the attribute again.
- New `PokerControllerTest` cases for `lobby` and `tablePage` doing the same. The existing test class only covered the JSON endpoints, not the page handlers.

## Test plan

- [x] `:web:test` green
- [ ] Manual: visit `/blackjack/{guild}`, `/blackjack/{guild}/solo`, `/blackjack/{guild}/{tableId}`, `/poker/{guild}`, `/poker/{guild}/{tableId}` and confirm the 🎰 banner shows the live pool with the same wording as `/highlow/{guild}`.

## Out of scope (separate follow-up PRs)

- Blackjack already returns `jackpotPayout` on the action response when `JackpotHelper.rollOnWin` hits, but the JS doesn't render it yet — win-toast PR.
- Poker has no jackpot win-roll wiring at all (`PokerService` only routes rake to the pool, never calls `rollOnWin`). Bigger separate PR.

https://claude.ai/code/session_014ffsM6UFUh5KaMS4KUBPrf

---
_Generated by [Claude Code](https://claude.ai/code/session_014ffsM6UFUh5KaMS4KUBPrf)_