### PR TITLE
feat(moderation web): surface blackjack config keys in the admin form

### DIFF
--- a/web/src/main/resources/templates/moderation.html
+++ b/web/src/main/resources/templates/moderation.html
@@ -278,6 +278,82 @@
                 </div>
             </div>
         </details>
+
+        <details class="config-section">
+            <summary>Blackjack</summary>
+            <div class="config-grid">
+                <div class="config-row" data-key="BLACKJACK_RAKE_PCT">
+                    <label>Blackjack rake (% of multi-table losers' pool routed to jackpot; default 5)</label>
+                    <input type="number" min="0" max="20" step="1"
+                           th:value="${overview.config['BLACKJACK_RAKE_PCT']}"
+                           placeholder="5"
+                           th:disabled="${!isOwner}">
+                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                </div>
+                <div class="config-row" data-key="BLACKJACK_MIN_ANTE">
+                    <label>Minimum ante per hand (multi &amp; solo; default 10)</label>
+                    <input type="number" min="1"
+                           th:value="${overview.config['BLACKJACK_MIN_ANTE']}"
+                           placeholder="10"
+                           th:disabled="${!isOwner}">
+                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                </div>
+                <div class="config-row" data-key="BLACKJACK_MAX_ANTE">
+                    <label>Maximum ante per hand (multi &amp; solo; default 500)</label>
+                    <input type="number" min="1"
+                           th:value="${overview.config['BLACKJACK_MAX_ANTE']}"
+                           placeholder="500"
+                           th:disabled="${!isOwner}">
+                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                </div>
+                <div class="config-row" data-key="BLACKJACK_MAX_SEATS">
+                    <label>Max seats per multi table (2-7; default 5)</label>
+                    <input type="number" min="2" max="7"
+                           th:value="${overview.config['BLACKJACK_MAX_SEATS']}"
+                           placeholder="5"
+                           th:disabled="${!isOwner}">
+                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                </div>
+                <div class="config-row" data-key="BLACKJACK_SHOT_CLOCK_SECONDS">
+                    <label>Decision deadline per actor (seconds; 0 disables; default 30)</label>
+                    <input type="number" min="0" max="600"
+                           th:value="${overview.config['BLACKJACK_SHOT_CLOCK_SECONDS']}"
+                           placeholder="30"
+                           th:disabled="${!isOwner}">
+                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                </div>
+                <div class="config-row" data-key="BLACKJACK_DEALER_HITS_SOFT_17">
+                    <label>Dealer rule on soft 17</label>
+                    <select th:disabled="${!isOwner}">
+                        <option value="false"
+                                th:selected="${overview.config['BLACKJACK_DEALER_HITS_SOFT_17'] == null or overview.config['BLACKJACK_DEALER_HITS_SOFT_17'] == 'false'}">
+                            Stand on soft 17 (S17, default — better for the player)
+                        </option>
+                        <option value="true"
+                                th:selected="${overview.config['BLACKJACK_DEALER_HITS_SOFT_17'] == 'true'}">
+                            Hit soft 17 (H17 — slightly worse for the player)
+                        </option>
+                    </select>
+                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                </div>
+                <div class="config-row" data-key="BLACKJACK_BJ_PAYOUT_NUM">
+                    <label>Natural-blackjack payout numerator (e.g. 3 for 3:2; default 3)</label>
+                    <input type="number" min="1" max="10"
+                           th:value="${overview.config['BLACKJACK_BJ_PAYOUT_NUM']}"
+                           placeholder="3"
+                           th:disabled="${!isOwner}">
+                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                </div>
+                <div class="config-row" data-key="BLACKJACK_BJ_PAYOUT_DEN">
+                    <label>Natural-blackjack payout denominator (e.g. 2 for 3:2; default 2)</label>
+                    <input type="number" min="1" max="10"
+                           th:value="${overview.config['BLACKJACK_BJ_PAYOUT_DEN']}"
+                           placeholder="2"
+                           th:disabled="${!isOwner}">
+                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                </div>
+            </div>
+        </details>
     </section>
 
     <!-- VOICE TAB -->

--- a/web/src/test/kotlin/web/service/ModerationWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/ModerationWebServiceTest.kt
@@ -319,6 +319,109 @@ class ModerationWebServiceTest {
     }
 
     @Test
+    fun `updateConfig accepts BLACKJACK_RAKE_PCT in 0 to 20 inclusive`() {
+        mockMember(ownerId, isOwner = true)
+        val key = ConfigDto.Configurations.BLACKJACK_RAKE_PCT
+
+        assertNull(service.updateConfig(ownerId, guildId, key, "0"))
+        assertNull(service.updateConfig(ownerId, guildId, key, "5"))
+        assertNull(service.updateConfig(ownerId, guildId, key, "20"))
+        verify { configService.upsertConfig(key.configValue, "0", guildId.toString()) }
+        verify { configService.upsertConfig(key.configValue, "20", guildId.toString()) }
+
+        assertNotNull(service.updateConfig(ownerId, guildId, key, "-1"))
+        assertNotNull(service.updateConfig(ownerId, guildId, key, "21"))
+        assertNotNull(service.updateConfig(ownerId, guildId, key, "abc"))
+    }
+
+    @Test
+    fun `updateConfig accepts BLACKJACK_MIN_ANTE and MAX_ANTE when value is a positive long`() {
+        mockMember(ownerId, isOwner = true)
+        val keys = listOf(
+            ConfigDto.Configurations.BLACKJACK_MIN_ANTE,
+            ConfigDto.Configurations.BLACKJACK_MAX_ANTE,
+        )
+        for (key in keys) {
+            assertNull(service.updateConfig(ownerId, guildId, key, "10"))
+            assertNull(service.updateConfig(ownerId, guildId, key, "500"))
+            verify { configService.upsertConfig(key.configValue, "10", guildId.toString()) }
+            verify { configService.upsertConfig(key.configValue, "500", guildId.toString()) }
+
+            assertNotNull(service.updateConfig(ownerId, guildId, key, "0"))
+            assertNotNull(service.updateConfig(ownerId, guildId, key, "-5"))
+            assertNotNull(service.updateConfig(ownerId, guildId, key, "wibble"))
+        }
+    }
+
+    @Test
+    fun `updateConfig accepts BLACKJACK_MAX_SEATS only within 2 to 7`() {
+        mockMember(ownerId, isOwner = true)
+        val key = ConfigDto.Configurations.BLACKJACK_MAX_SEATS
+
+        assertNull(service.updateConfig(ownerId, guildId, key, "2"))
+        assertNull(service.updateConfig(ownerId, guildId, key, "7"))
+        verify { configService.upsertConfig(key.configValue, "2", guildId.toString()) }
+        verify { configService.upsertConfig(key.configValue, "7", guildId.toString()) }
+
+        assertNotNull(service.updateConfig(ownerId, guildId, key, "1"))
+        assertNotNull(service.updateConfig(ownerId, guildId, key, "8"))
+        assertNotNull(service.updateConfig(ownerId, guildId, key, "n/a"))
+    }
+
+    @Test
+    fun `updateConfig accepts BLACKJACK_SHOT_CLOCK_SECONDS in 0 to 600 (0 disables)`() {
+        mockMember(ownerId, isOwner = true)
+        val key = ConfigDto.Configurations.BLACKJACK_SHOT_CLOCK_SECONDS
+
+        assertNull(service.updateConfig(ownerId, guildId, key, "0"))
+        assertNull(service.updateConfig(ownerId, guildId, key, "30"))
+        assertNull(service.updateConfig(ownerId, guildId, key, "600"))
+        verify { configService.upsertConfig(key.configValue, "0", guildId.toString()) }
+        verify { configService.upsertConfig(key.configValue, "30", guildId.toString()) }
+
+        assertNotNull(service.updateConfig(ownerId, guildId, key, "-1"))
+        assertNotNull(service.updateConfig(ownerId, guildId, key, "601"))
+        assertNotNull(service.updateConfig(ownerId, guildId, key, "asdf"))
+    }
+
+    @Test
+    fun `updateConfig accepts BLACKJACK_DEALER_HITS_SOFT_17 only as a boolean string`() {
+        mockMember(ownerId, isOwner = true)
+        val key = ConfigDto.Configurations.BLACKJACK_DEALER_HITS_SOFT_17
+
+        assertNull(service.updateConfig(ownerId, guildId, key, "true"))
+        assertNull(service.updateConfig(ownerId, guildId, key, "false"))
+        // Validator lower-cases the input.
+        assertNull(service.updateConfig(ownerId, guildId, key, "TRUE"))
+        verify { configService.upsertConfig(key.configValue, "true", guildId.toString()) }
+        verify { configService.upsertConfig(key.configValue, "false", guildId.toString()) }
+
+        assertNotNull(service.updateConfig(ownerId, guildId, key, "yes"))
+        assertNotNull(service.updateConfig(ownerId, guildId, key, "1"))
+        assertNotNull(service.updateConfig(ownerId, guildId, key, ""))
+    }
+
+    @Test
+    fun `updateConfig accepts BLACKJACK_BJ_PAYOUT_NUM and DEN in 1 to 10`() {
+        mockMember(ownerId, isOwner = true)
+        val keys = listOf(
+            ConfigDto.Configurations.BLACKJACK_BJ_PAYOUT_NUM,
+            ConfigDto.Configurations.BLACKJACK_BJ_PAYOUT_DEN,
+        )
+        for (key in keys) {
+            assertNull(service.updateConfig(ownerId, guildId, key, "1"))
+            assertNull(service.updateConfig(ownerId, guildId, key, "3"))
+            assertNull(service.updateConfig(ownerId, guildId, key, "10"))
+            verify { configService.upsertConfig(key.configValue, "1", guildId.toString()) }
+            verify { configService.upsertConfig(key.configValue, "10", guildId.toString()) }
+
+            assertNotNull(service.updateConfig(ownerId, guildId, key, "0"))
+            assertNotNull(service.updateConfig(ownerId, guildId, key, "11"))
+            assertNotNull(service.updateConfig(ownerId, guildId, key, "abc"))
+        }
+    }
+
+    @Test
     fun `updateConfig accepts MOVE when channel name exists`() {
         mockMember(ownerId, isOwner = true)
         val vc = mockk<VoiceChannel>(relaxed = true)

--- a/web/src/test/kotlin/web/template/ModerationTemplateRowsTest.kt
+++ b/web/src/test/kotlin/web/template/ModerationTemplateRowsTest.kt
@@ -1,0 +1,59 @@
+package web.template
+
+import database.dto.ConfigDto
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Presence regression for the per-game config rows on the moderation
+ * page. The original miss was that every `BLACKJACK_*` key existed in
+ * [ConfigDto.Configurations] and the `POST /moderation/{guildId}/config`
+ * endpoint validated and persisted them, but the moderation HTML had no
+ * `<input>` row to actually drive that POST — admins had to curl.
+ *
+ * This test reads `templates/moderation.html` off the classpath and
+ * asserts each blackjack config key appears as a `data-key` attribute,
+ * which is what the page's save-config JS keys off. Catches accidental
+ * row removal during a future refactor.
+ */
+class ModerationTemplateRowsTest {
+
+    private val html: String by lazy {
+        val url = javaClass.classLoader.getResource("templates/moderation.html")
+        assertNotNull(url, "moderation.html must be on the classpath")
+        url!!.readText()
+    }
+
+    @Test
+    fun `moderation template surfaces every blackjack config key as an editable row`() {
+        val keys = listOf(
+            ConfigDto.Configurations.BLACKJACK_RAKE_PCT,
+            ConfigDto.Configurations.BLACKJACK_MIN_ANTE,
+            ConfigDto.Configurations.BLACKJACK_MAX_ANTE,
+            ConfigDto.Configurations.BLACKJACK_MAX_SEATS,
+            ConfigDto.Configurations.BLACKJACK_SHOT_CLOCK_SECONDS,
+            ConfigDto.Configurations.BLACKJACK_DEALER_HITS_SOFT_17,
+            ConfigDto.Configurations.BLACKJACK_BJ_PAYOUT_NUM,
+            ConfigDto.Configurations.BLACKJACK_BJ_PAYOUT_DEN,
+        )
+        for (key in keys) {
+            assertTrue(
+                html.contains("data-key=\"${key.name}\""),
+                "moderation.html should have a config-row for ${key.name} so admins can edit it from the UI"
+            )
+        }
+    }
+
+    @Test
+    fun `blackjack section in moderation template has its own collapsed details block`() {
+        // The page wraps each game's keys in a `<details><summary>Game</summary>`
+        // block so admins can scan to the right section. Without this wrapper
+        // the keys would be lumped into "Economy & casino" alongside trade
+        // fees and lose discoverability.
+        assertTrue(
+            html.contains("<summary>Blackjack</summary>"),
+            "expected a <details><summary>Blackjack</summary> wrapper around the blackjack rows"
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Every `BLACKJACK_*` key was already defined in `ConfigDto.Configurations` and `ModerationWebService.updateConfig` already validated and persisted them, but `templates/moderation.html` had no `<input>` rows for them — admins couldn't see or edit blackjack rules from the UI; they had to `curl POST /moderation/{guildId}/config` directly.

Adds a new `<details><summary>Blackjack</summary>` section after the existing "Economy & casino" group, with one row per key:

| Key | Range / type |
|---|---|
| `BLACKJACK_RAKE_PCT` | 0-20 |
| `BLACKJACK_MIN_ANTE` / `BLACKJACK_MAX_ANTE` | positive long |
| `BLACKJACK_MAX_SEATS` | 2-7 |
| `BLACKJACK_SHOT_CLOCK_SECONDS` | 0-600 (0 disables) |
| `BLACKJACK_DEALER_HITS_SOFT_17` | boolean `<select>` |
| `BLACKJACK_BJ_PAYOUT_NUM` / `_DEN` | 1-10 each |

Each row matches the existing JACKPOT / TRADE / POKER patterns: `th:value` from `overview.config['<KEY>']`, `th:disabled="${!isOwner}"`, and a `.save-config` button the existing JS handler already drives. The S17/H17 row uses a `<select>` like `ACTIVITY_TRACKING` since it's a true/false enum.

No backend changes — the validation paths in `ModerationWebService` already cover all eight keys.

## Tests

- **`ModerationTemplateRowsTest`** (new) — reads `templates/moderation.html` off the classpath and asserts each `BLACKJACK_*` key has a `data-key="…"` row (matches what the save-config JS reads), plus the `<summary>Blackjack</summary>` wrapper. Catches accidental row removal during a refactor.
- **`ModerationWebServiceTest`** — 6 new cases mirror the existing `POKER_*` validation tests for each blackjack key: happy paths, boundary edges, non-numeric / out-of-range rejections, boolean case-insensitivity for the soft-17 toggle.

## Test plan

- [x] `:web:test` green
- [ ] Manual: open `/moderation/{guildId}` as the owner, expand the new "Blackjack" section, edit a value (e.g. set `BLACKJACK_RAKE_PCT` to 10), Save, refresh, confirm the new value persists.
- [ ] Manual sanity: as a non-owner, confirm inputs are disabled.

## Out of scope

Poker per-table parameters (`POKER_SMALL_BLIND` / `_BIG_BLIND` / `_SMALL_BET` / `_BIG_BET` / `_MIN_BUY_IN` / `_MAX_BUY_IN` / `_MAX_SEATS` / `_SHOT_CLOCK_SECONDS`) are also missing from this form even though the validator accepts them. Same fix shape — ships separately.

https://claude.ai/code/session_014ffsM6UFUh5KaMS4KUBPrf

---
_Generated by [Claude Code](https://claude.ai/code/session_014ffsM6UFUh5KaMS4KUBPrf)_