### PR TITLE
feat(moderation web): surface poker per-table config keys in the admin form

### DIFF
--- a/web/src/main/resources/templates/moderation.html
+++ b/web/src/main/resources/templates/moderation.html
@@ -268,11 +268,81 @@
                            th:disabled="${!isOwner}">
                     <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
                 </div>
+            </div>
+        </details>
+
+        <details class="config-section">
+            <summary>Poker</summary>
+            <div class="config-grid">
                 <div class="config-row" data-key="POKER_RAKE_PCT">
-                    <label>Poker rake (% of every settled pot)</label>
-                    <input type="number" min="0" max="20"
+                    <label>Poker rake (% of every settled pot routed to jackpot; default 5)</label>
+                    <input type="number" min="0" max="20" step="1"
                            th:value="${overview.config['POKER_RAKE_PCT']}"
                            placeholder="5"
+                           th:disabled="${!isOwner}">
+                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                </div>
+                <div class="config-row" data-key="POKER_SMALL_BLIND">
+                    <label>Small blind (chips posted by SB seat each hand; default 5)</label>
+                    <input type="number" min="1"
+                           th:value="${overview.config['POKER_SMALL_BLIND']}"
+                           placeholder="5"
+                           th:disabled="${!isOwner}">
+                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                </div>
+                <div class="config-row" data-key="POKER_BIG_BLIND">
+                    <label>Big blind (chips posted by BB seat each hand; default 10)</label>
+                    <input type="number" min="1"
+                           th:value="${overview.config['POKER_BIG_BLIND']}"
+                           placeholder="10"
+                           th:disabled="${!isOwner}">
+                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                </div>
+                <div class="config-row" data-key="POKER_SMALL_BET">
+                    <label>Small bet (fixed-limit bet pre-flop &amp; flop; default 10)</label>
+                    <input type="number" min="1"
+                           th:value="${overview.config['POKER_SMALL_BET']}"
+                           placeholder="10"
+                           th:disabled="${!isOwner}">
+                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                </div>
+                <div class="config-row" data-key="POKER_BIG_BET">
+                    <label>Big bet (fixed-limit bet on turn &amp; river; default 20)</label>
+                    <input type="number" min="1"
+                           th:value="${overview.config['POKER_BIG_BET']}"
+                           placeholder="20"
+                           th:disabled="${!isOwner}">
+                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                </div>
+                <div class="config-row" data-key="POKER_MIN_BUY_IN">
+                    <label>Minimum buy-in per seat (chips; default 100)</label>
+                    <input type="number" min="1"
+                           th:value="${overview.config['POKER_MIN_BUY_IN']}"
+                           placeholder="100"
+                           th:disabled="${!isOwner}">
+                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                </div>
+                <div class="config-row" data-key="POKER_MAX_BUY_IN">
+                    <label>Maximum buy-in per seat (chips; default 5000)</label>
+                    <input type="number" min="1"
+                           th:value="${overview.config['POKER_MAX_BUY_IN']}"
+                           placeholder="5000"
+                           th:disabled="${!isOwner}">
+                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                </div>
+                <div class="config-row" data-key="POKER_MAX_SEATS">
+                    <label>Max seats per table (2-9; default 6)</label>
+                    <input type="number" min="2" max="9"
+                           th:value="${overview.config['POKER_MAX_SEATS']}"
+                           placeholder="6"
+                           th:disabled="${!isOwner}">
+                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                </div>
+                <div class="config-row" data-key="POKER_SHOT_CLOCK_SECONDS">
+                    <label>Decision deadline per actor (seconds; 0 disables; default 30)</label>
+                    <input type="number" min="0" max="600"
+                           th:value="${overview.config['POKER_SHOT_CLOCK_SECONDS']}"
+                           placeholder="30"
                            th:disabled="${!isOwner}">
                     <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
                 </div>

--- a/web/src/test/kotlin/web/service/ModerationWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/ModerationWebServiceTest.kt
@@ -256,6 +256,22 @@ class ModerationWebServiceTest {
     }
 
     @Test
+    fun `updateConfig accepts POKER_RAKE_PCT in 0 to 20 inclusive`() {
+        mockMember(ownerId, isOwner = true)
+        val key = ConfigDto.Configurations.POKER_RAKE_PCT
+
+        assertNull(service.updateConfig(ownerId, guildId, key, "0"))
+        assertNull(service.updateConfig(ownerId, guildId, key, "5"))
+        assertNull(service.updateConfig(ownerId, guildId, key, "20"))
+        verify { configService.upsertConfig(key.configValue, "0", guildId.toString()) }
+        verify { configService.upsertConfig(key.configValue, "20", guildId.toString()) }
+
+        assertNotNull(service.updateConfig(ownerId, guildId, key, "-1"))
+        assertNotNull(service.updateConfig(ownerId, guildId, key, "21"))
+        assertNotNull(service.updateConfig(ownerId, guildId, key, "wibble"))
+    }
+
+    @Test
     fun `updateConfig accepts POKER chip-amount keys when value is a positive long`() {
         mockMember(ownerId, isOwner = true)
         val keys = listOf(

--- a/web/src/test/kotlin/web/template/ModerationTemplateRowsTest.kt
+++ b/web/src/test/kotlin/web/template/ModerationTemplateRowsTest.kt
@@ -46,6 +46,31 @@ class ModerationTemplateRowsTest {
     }
 
     @Test
+    fun `moderation template surfaces every poker config key as an editable row`() {
+        // Same regression class as blackjack — `POKER_RAKE_PCT` was the only
+        // poker key with a UI row before; the per-table parameters
+        // (blinds, bets, buy-in range, max seats, shot clock) were defined
+        // and validated server-side but admins had no form for them.
+        val keys = listOf(
+            ConfigDto.Configurations.POKER_RAKE_PCT,
+            ConfigDto.Configurations.POKER_SMALL_BLIND,
+            ConfigDto.Configurations.POKER_BIG_BLIND,
+            ConfigDto.Configurations.POKER_SMALL_BET,
+            ConfigDto.Configurations.POKER_BIG_BET,
+            ConfigDto.Configurations.POKER_MIN_BUY_IN,
+            ConfigDto.Configurations.POKER_MAX_BUY_IN,
+            ConfigDto.Configurations.POKER_MAX_SEATS,
+            ConfigDto.Configurations.POKER_SHOT_CLOCK_SECONDS,
+        )
+        for (key in keys) {
+            assertTrue(
+                html.contains("data-key=\"${key.name}\""),
+                "moderation.html should have a config-row for ${key.name} so admins can edit it from the UI"
+            )
+        }
+    }
+
+    @Test
     fun `blackjack section in moderation template has its own collapsed details block`() {
         // The page wraps each game's keys in a `<details><summary>Game</summary>`
         // block so admins can scan to the right section. Without this wrapper
@@ -54,6 +79,14 @@ class ModerationTemplateRowsTest {
         assertTrue(
             html.contains("<summary>Blackjack</summary>"),
             "expected a <details><summary>Blackjack</summary> wrapper around the blackjack rows"
+        )
+    }
+
+    @Test
+    fun `poker section in moderation template has its own collapsed details block`() {
+        assertTrue(
+            html.contains("<summary>Poker</summary>"),
+            "expected a <details><summary>Poker</summary> wrapper around the poker rows"
         )
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to #363. Same gap as blackjack had: every `POKER_*` key was already defined in `ConfigDto.Configurations` and `ModerationWebService.updateConfig` already validated and persisted them, but the form only had a row for `POKER_RAKE_PCT` (sitting in the "Economy & casino" section). The eight per-table parameters had no UI, so admins had to curl `POST /moderation/{guildId}/config`.

Adds a new `<details><summary>Poker</summary>` section after Economy & casino. Moves `POKER_RAKE_PCT` into it for symmetry with the blackjack section (which already contains `BLACKJACK_RAKE_PCT` alongside the other blackjack keys). Adds rows for:

| Key | Range / type |
|---|---|
| `POKER_SMALL_BLIND` / `POKER_BIG_BLIND` | positive long |
| `POKER_SMALL_BET` / `POKER_BIG_BET` | positive long |
| `POKER_MIN_BUY_IN` / `POKER_MAX_BUY_IN` | positive long |
| `POKER_MAX_SEATS` | 2-9 |
| `POKER_SHOT_CLOCK_SECONDS` | 0-600 (0 disables) |

Each row matches the JACKPOT / TRADE / BLACKJACK pattern. No backend changes — every key already flows through the validator paths in `ModerationWebService.updateConfig` (lines 310-338).

## Tests

- **`ModerationTemplateRowsTest`** extended with a new poker-keys presence test and a `<summary>Poker</summary>` wrapper assertion, matching the blackjack pair.
- **`ModerationWebServiceTest`** gains a `POKER_RAKE_PCT` validation test (the only poker key without one — chip-amount keys, `MAX_SEATS`, and `SHOT_CLOCK_SECONDS` were already covered).

## Test plan

- [x] `:web:test` green
- [ ] Manual: open `/moderation/{guildId}` as the owner, expand the new "Poker" section, change a value (e.g. set `POKER_BIG_BLIND` to 20), Save, refresh, confirm the new value persists.
- [ ] Manual sanity: as a non-owner, confirm inputs are disabled.

This closes the casino-config admin-form gap noted as out-of-scope on #363.

https://claude.ai/code/session_014ffsM6UFUh5KaMS4KUBPrf

---
_Generated by [Claude Code](https://claude.ai/code/session_014ffsM6UFUh5KaMS4KUBPrf)_