### PR TITLE
perf(test): drop redundant @TestPropertySource on the two web ITs (#365 step 1a)

### DIFF
--- a/application/src/test/kotlin/integration/web/BotControllerIT.kt
+++ b/application/src/test/kotlin/integration/web/BotControllerIT.kt
@@ -11,7 +11,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.context.TestPropertySource
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
@@ -28,12 +27,6 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 )
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
-@TestPropertySource(
-    properties = [
-        "spring.security.oauth2.client.registration.discord.client-id=test-client-id",
-        "spring.security.oauth2.client.registration.discord.client-secret=test-client-secret"
-    ]
-)
 class BotControllerIT {
 
     @Autowired

--- a/application/src/test/kotlin/integration/web/PageRenderSmokeIT.kt
+++ b/application/src/test/kotlin/integration/web/PageRenderSmokeIT.kt
@@ -14,7 +14,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oauth2Login
 import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.context.TestPropertySource
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 
@@ -60,12 +59,6 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 )
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
-@TestPropertySource(
-    properties = [
-        "spring.security.oauth2.client.registration.discord.client-id=test-client-id",
-        "spring.security.oauth2.client.registration.discord.client-secret=test-client-secret",
-    ]
-)
 class PageRenderSmokeIT {
 
     @Autowired


### PR DESCRIPTION
## Summary

Smallest-blast-radius slice of issue #365 step 1: drop the redundant
`@TestPropertySource` blocks on `BotControllerIT` and `PageRenderSmokeIT`.

Both classes declare:

```kotlin
@TestPropertySource(properties = [
    "spring.security.oauth2.client.registration.discord.client-id=test-client-id",
    "spring.security.oauth2.client.registration.discord.client-secret=test-client-secret",
])
```

…but those exact values are already loaded from
`application/src/test/resources/application-test.properties:17-18` via
`@ActiveProfiles("test")`. Spring's `MergedContextConfiguration` uses
`@TestPropertySource` as part of the context-cache key, so each
redundant block forces an extra Spring context load + Postgres
testcontainer Flyway-migration cycle.

Removing them folds these two tests into the existing 11-test shared
context (the one used by every other `integration/database/*` IT and the
`integration/web/*` peers), saving 2 Spring boots — roughly 30s on CI.

## Why only these two

The other context-cache fragmentation called out in #365 step 1 — the
`classes = [...]` ordering mismatch between `integration/bot/*` and the
rest — is deliberately deferred. Folding the bot-manager tests into the
shared context exposed real test-data pollution in
`UserServiceImplIntegrationTest` and
`TobyCoinTradePersistenceIntegrationTest` under PR #358's first CI run.
Those tests need `@DirtiesContext` / `@Transactional` cleanup before
they can safely share Postgres state with the bot tests; that work
belongs in a follow-up PR.

## Test plan

- [ ] CI green on `Kotlin with Gradle` (`./gradlew build`)
- [ ] `:application:test` log shows fewer `Started SpringBootApplication`
      lines than on `main` (one shared context boot covers BotControllerIT,
      PageRenderSmokeIT, and the 11 other group-B integration tests)
- [ ] Total CI build duration vs the most recent `main` run on this PR's
      check page

Refs #365.

https://claude.ai/code/session_01DTWCxi6KXH3nApS6mitBp4

---
_Generated by [Claude Code](https://claude.ai/code/session_01DTWCxi6KXH3nApS6mitBp4)_