### PR TITLE
feat(moderation web): show a visible % suffix on every percent config row

### DIFF
--- a/web/src/main/resources/static/css/moderation.css
+++ b/web/src/main/resources/static/css/moderation.css
@@ -216,6 +216,19 @@
     border-radius: var(--radius-sm);
     grid-column: 1;
 }
+/* Wrapper for percentage inputs — keeps the input + visible "%" suffix
+   together in column 1 of the .config-row grid, so admins can see the
+   unit at a glance without hunting through the label. */
+.config-row .config-input-group {
+    grid-column: 1;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+}
+.config-row .config-input-group .config-suffix {
+    color: var(--text-muted);
+    font-size: 0.95rem;
+}
 .config-row .save-config { grid-column: 2; }
 
 /* Social credit */

--- a/web/src/main/resources/templates/moderation.html
+++ b/web/src/main/resources/templates/moderation.html
@@ -238,34 +238,46 @@
                 </div>
                 <div class="config-row" data-key="JACKPOT_LOSS_TRIBUTE_PCT">
                     <label>Jackpot loss tribute (% of every lost casino stake)</label>
-                    <input type="number" min="0" max="50"
-                           th:value="${overview.config['JACKPOT_LOSS_TRIBUTE_PCT']}"
-                           placeholder="10"
-                           th:disabled="${!isOwner}">
+                    <span class="config-input-group">
+                        <input type="number" min="0" max="50"
+                               th:value="${overview.config['JACKPOT_LOSS_TRIBUTE_PCT']}"
+                               placeholder="10"
+                               th:disabled="${!isOwner}">
+                        <span class="config-suffix">%</span>
+                    </span>
                     <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
                 </div>
                 <div class="config-row" data-key="JACKPOT_WIN_PCT">
                     <label>Jackpot win chance (% per casino-game win, decimals allowed)</label>
-                    <input type="number" min="0" max="50" step="0.01"
-                           th:value="${overview.config['JACKPOT_WIN_PCT']}"
-                           placeholder="1"
-                           th:disabled="${!isOwner}">
+                    <span class="config-input-group">
+                        <input type="number" min="0" max="50" step="0.01"
+                               th:value="${overview.config['JACKPOT_WIN_PCT']}"
+                               placeholder="1"
+                               th:disabled="${!isOwner}">
+                        <span class="config-suffix">%</span>
+                    </span>
                     <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
                 </div>
                 <div class="config-row" data-key="TRADE_BUY_FEE_PCT">
                     <label>Toby Coin BUY fee (% per leg, routed to jackpot pool)</label>
-                    <input type="number" min="0" max="25" step="0.01"
-                           th:value="${overview.config['TRADE_BUY_FEE_PCT']}"
-                           placeholder="1"
-                           th:disabled="${!isOwner}">
+                    <span class="config-input-group">
+                        <input type="number" min="0" max="25" step="0.01"
+                               th:value="${overview.config['TRADE_BUY_FEE_PCT']}"
+                               placeholder="1"
+                               th:disabled="${!isOwner}">
+                        <span class="config-suffix">%</span>
+                    </span>
                     <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
                 </div>
                 <div class="config-row" data-key="TRADE_SELL_FEE_PCT">
                     <label>Toby Coin SELL fee (% per leg, routed to jackpot pool)</label>
-                    <input type="number" min="0" max="25" step="0.01"
-                           th:value="${overview.config['TRADE_SELL_FEE_PCT']}"
-                           placeholder="1"
-                           th:disabled="${!isOwner}">
+                    <span class="config-input-group">
+                        <input type="number" min="0" max="25" step="0.01"
+                               th:value="${overview.config['TRADE_SELL_FEE_PCT']}"
+                               placeholder="1"
+                               th:disabled="${!isOwner}">
+                        <span class="config-suffix">%</span>
+                    </span>
                     <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
                 </div>
             </div>
@@ -276,10 +288,13 @@
             <div class="config-grid">
                 <div class="config-row" data-key="POKER_RAKE_PCT">
                     <label>Poker rake (% of every settled pot routed to jackpot; default 5)</label>
-                    <input type="number" min="0" max="20" step="1"
-                           th:value="${overview.config['POKER_RAKE_PCT']}"
-                           placeholder="5"
-                           th:disabled="${!isOwner}">
+                    <span class="config-input-group">
+                        <input type="number" min="0" max="20" step="1"
+                               th:value="${overview.config['POKER_RAKE_PCT']}"
+                               placeholder="5"
+                               th:disabled="${!isOwner}">
+                        <span class="config-suffix">%</span>
+                    </span>
                     <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
                 </div>
                 <div class="config-row" data-key="POKER_SMALL_BLIND">
@@ -354,10 +369,13 @@
             <div class="config-grid">
                 <div class="config-row" data-key="BLACKJACK_RAKE_PCT">
                     <label>Blackjack rake (% of multi-table losers' pool routed to jackpot; default 5)</label>
-                    <input type="number" min="0" max="20" step="1"
-                           th:value="${overview.config['BLACKJACK_RAKE_PCT']}"
-                           placeholder="5"
-                           th:disabled="${!isOwner}">
+                    <span class="config-input-group">
+                        <input type="number" min="0" max="20" step="1"
+                               th:value="${overview.config['BLACKJACK_RAKE_PCT']}"
+                               placeholder="5"
+                               th:disabled="${!isOwner}">
+                        <span class="config-suffix">%</span>
+                    </span>
                     <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
                 </div>
                 <div class="config-row" data-key="BLACKJACK_MIN_ANTE">

--- a/web/src/test/kotlin/web/template/ModerationTemplateRowsTest.kt
+++ b/web/src/test/kotlin/web/template/ModerationTemplateRowsTest.kt
@@ -89,4 +89,38 @@ class ModerationTemplateRowsTest {
             "expected a <details><summary>Poker</summary> wrapper around the poker rows"
         )
     }
+
+    @Test
+    fun `every percent config row carries a visible suffix marker`() {
+        // Admins editing a percent config used to see a bare number input
+        // with no unit indicator. Each *_PCT row now wraps the input in
+        // a `.config-input-group` with a trailing `<span class="config-suffix">%</span>`
+        // so the unit is obvious without reading the label. This test
+        // pins the wiring for every percent key — losing the suffix
+        // (e.g. someone removing the wrapper during a refactor) means
+        // admins lose the visual cue again.
+        val percentKeys = listOf(
+            ConfigDto.Configurations.JACKPOT_LOSS_TRIBUTE_PCT,
+            ConfigDto.Configurations.JACKPOT_WIN_PCT,
+            ConfigDto.Configurations.TRADE_BUY_FEE_PCT,
+            ConfigDto.Configurations.TRADE_SELL_FEE_PCT,
+            ConfigDto.Configurations.POKER_RAKE_PCT,
+            ConfigDto.Configurations.BLACKJACK_RAKE_PCT,
+        )
+        for (key in percentKeys) {
+            // Slice the document at the `data-key="..."` row marker and
+            // look forward to the closing `</div>` of that row. The
+            // suffix span must appear inside that range.
+            val marker = "data-key=\"${key.name}\""
+            val rowStart = html.indexOf(marker)
+            assertTrue(rowStart >= 0, "row for ${key.name} not found")
+            val rowEnd = html.indexOf("</div>", rowStart)
+            assertTrue(rowEnd > rowStart, "row for ${key.name} not terminated")
+            val rowHtml = html.substring(rowStart, rowEnd)
+            assertTrue(
+                rowHtml.contains("config-suffix") && rowHtml.contains(">%<"),
+                "row for ${key.name} should include a `<span class=\"config-suffix\">%</span>` marker"
+            )
+        }
+    }
 }


### PR DESCRIPTION
## Summary

The percentage rows on the moderation config page render a bare `<input type="number">` with no unit indicator. The unit only appears in the label text (`(% of every lost casino stake)`), which is easy to miss when scanning the form — admins were unsure whether to enter `5` or `0.05`.

Wraps each `*_PCT` input in a `<span class="config-input-group">` flex container with a trailing `<span class="config-suffix">%</span>`, so the unit is visible at a glance right next to the number. Affects all six percent rows:

- `JACKPOT_LOSS_TRIBUTE_PCT`
- `JACKPOT_WIN_PCT`
- `TRADE_BUY_FEE_PCT`
- `TRADE_SELL_FEE_PCT`
- `POKER_RAKE_PCT`
- `BLACKJACK_RAKE_PCT`

CSS: adds a `.config-input-group` rule to `moderation.css`, sized to sit in column 1 of the existing `.config-row` grid alongside the save button. The suffix span uses `var(--text-muted)` so it reads as a secondary annotation, not part of the value.

JS: untouched. The save handler does `row.querySelector('input, select')` (descendant query), so wrapping the input in a span doesn't break value lookup.

## Tests

`ModerationTemplateRowsTest` gains a presence test that, for each percent key, slices the row HTML between the `data-key` marker and the closing `</div>`, then asserts the slice contains the `config-suffix` class and a `>%<` literal. Locks in the wiring so a future template tidy-up that drops the wrapper would fail the test rather than silently ship a unit-less input again.

## Test plan

- [x] `:web:test` green
- [ ] Manual: open `/moderation/{guildId}` and confirm each percent row shows `[ 5 ] %  [ Save ]` with the `%` immediately right of the input box.
- [ ] Manual sanity: edit any percent row, confirm the value still saves (JS lookup unchanged).

Follow-up to #367 (jackpot banner % display).

https://claude.ai/code/session_014ffsM6UFUh5KaMS4KUBPrf

---
_Generated by [Claude Code](https://claude.ai/code/session_014ffsM6UFUh5KaMS4KUBPrf)_