### PR TITLE
fix(blackjack web): stop re-dealing the same cards into split hands every poll

### DIFF
--- a/web/src/main/resources/static/js/blackjack-solo.js
+++ b/web/src/main/resources/static/js/blackjack-solo.js
@@ -1,29 +1,10 @@
 (function () {
     "use strict";
 
-    var main = document.getElementById("main");
-    var guildId = main.dataset.guildId;
-
-    var dealForm = document.getElementById("bj-deal");
-    var stakeInput = document.getElementById("bj-stake");
-    var balanceEl = document.getElementById("bj-balance");
-    var tableEl = document.getElementById("bj-table");
-    var dealerCardsEl = document.getElementById("bj-dealer-cards");
-    var dealerTotalEl = document.getElementById("bj-dealer-total");
-    var playerCardsEl = document.getElementById("bj-player-cards");
-    var playerHandsEl = document.getElementById("bj-player-hands");
-    var playerTotalEl = document.getElementById("bj-player-total");
-    var hitBtn = document.getElementById("bj-action-hit");
-    var standBtn = document.getElementById("bj-action-stand");
-    var doubleBtn = document.getElementById("bj-action-double");
-    var splitBtn = document.getElementById("bj-action-split");
-    var resultEl = document.getElementById("bj-result");
-    var playerRowEl = document.getElementById("bj-player-row");
-
-    var pollTimer = null;
-    // Tracks the handNumber of the last result we played the chip-stack
-    // flourish on, so the 2s polling doesn't re-trigger the animation.
-    var lastFlashedHand = null;
+    // ----- DOM-agnostic helpers (defined first so jest can require the
+    // module under jsdom and exercise them via `window.TobyBlackjackSolo`
+    // even though the page-init code below early-returns when the
+    // blackjack-solo template isn't present). -----
 
     function renderCards(container, cards) {
         // Delegate to the shared casino renderer so the deal animation only
@@ -49,6 +30,91 @@
             container.appendChild(el);
         });
     }
+
+    function renderSplitHands(container, slots, activeIndex) {
+        // Reuse the per-slot DOM across polls so casino-render.js's
+        // WeakMap of "cards already dealt into this container" actually
+        // matches across renders. Wiping innerHTML every 1500ms made the
+        // inner .bj-cards container a new DOM node each time, so the
+        // freshly-arrived detection always saw `prev = 0` and re-animated
+        // every card with the deal sound — the table looked and sounded
+        // like cards were being dealt over and over.
+        if (container.children.length !== slots.length) {
+            container.innerHTML = "";
+        }
+        slots.forEach(function (slot, idx) {
+            var div = container.children[idx] || createSplitHandSlotEl(container);
+            div.className = "bj-seat casino-seat";
+            if (idx === activeIndex) div.classList.add("bj-seat-active", "is-active");
+            if (slot.status === "BUSTED") div.classList.add("bj-seat-busted", "is-busted");
+
+            var label = "Hand " + (idx + 1);
+            var statusBits = [];
+            if (slot.doubled) statusBits.push("Doubled");
+            switch (slot.status) {
+                case "BLACKJACK": statusBits.push("Blackjack"); break;
+                case "BUSTED": statusBits.push("Bust"); break;
+                case "STANDING": statusBits.push("Stand"); break;
+            }
+            div.querySelector(".casino-seat-name").textContent =
+                label + " — stake " + slot.stake;
+            div.querySelector(".casino-seat-meta").textContent =
+                "(" + slot.total + ")" + (statusBits.length ? " " + statusBits.join(" · ") : "");
+
+            renderCards(div.querySelector(".bj-cards"), slot.cards);
+        });
+    }
+
+    function createSplitHandSlotEl(container) {
+        var div = document.createElement("div");
+        var header = document.createElement("div");
+        header.className = "bj-seat-header casino-seat-header";
+        var nameEl = document.createElement("span");
+        nameEl.className = "casino-seat-name";
+        header.appendChild(nameEl);
+        var meta = document.createElement("span");
+        meta.className = "casino-seat-meta";
+        header.appendChild(meta);
+        div.appendChild(header);
+        var cards = document.createElement("div");
+        cards.className = "bj-cards casino-cards";
+        div.appendChild(cards);
+        container.appendChild(div);
+        return div;
+    }
+
+    if (typeof window !== "undefined") {
+        window.TobyBlackjackSolo = window.TobyBlackjackSolo || {};
+        window.TobyBlackjackSolo.renderSplitHands = renderSplitHands;
+    }
+
+    // ----- Page init. Bail out cleanly if we're loaded without the
+    // blackjack-solo template (jest tests, server error pages, etc.).
+
+    var main = document.getElementById("main");
+    if (!main) return;
+    var guildId = main.dataset.guildId;
+
+    var dealForm = document.getElementById("bj-deal");
+    var stakeInput = document.getElementById("bj-stake");
+    var balanceEl = document.getElementById("bj-balance");
+    var tableEl = document.getElementById("bj-table");
+    var dealerCardsEl = document.getElementById("bj-dealer-cards");
+    var dealerTotalEl = document.getElementById("bj-dealer-total");
+    var playerCardsEl = document.getElementById("bj-player-cards");
+    var playerHandsEl = document.getElementById("bj-player-hands");
+    var playerTotalEl = document.getElementById("bj-player-total");
+    var hitBtn = document.getElementById("bj-action-hit");
+    var standBtn = document.getElementById("bj-action-stand");
+    var doubleBtn = document.getElementById("bj-action-double");
+    var splitBtn = document.getElementById("bj-action-split");
+    var resultEl = document.getElementById("bj-result");
+    var playerRowEl = document.getElementById("bj-player-row");
+
+    var pollTimer = null;
+    // Tracks the handNumber of the last result we played the chip-stack
+    // flourish on, so the 2s polling doesn't re-trigger the animation.
+    var lastFlashedHand = null;
 
     function renderState(state) {
         if (!state) return;
@@ -216,40 +282,6 @@
     standBtn.addEventListener("click", function () { postAction("stand"); });
     doubleBtn.addEventListener("click", function () { postAction("double"); });
     splitBtn.addEventListener("click", function () { postAction("split"); });
-
-    function renderSplitHands(container, slots, activeIndex) {
-        container.innerHTML = "";
-        slots.forEach(function (slot, idx) {
-            var div = document.createElement("div");
-            div.className = "bj-seat casino-seat";
-            if (idx === activeIndex) div.classList.add("bj-seat-active", "is-active");
-            if (slot.status === "BUSTED") div.classList.add("bj-seat-busted", "is-busted");
-            var header = document.createElement("div");
-            header.className = "bj-seat-header casino-seat-header";
-            var label = "Hand " + (idx + 1);
-            var statusBits = [];
-            if (slot.doubled) statusBits.push("Doubled");
-            switch (slot.status) {
-                case "BLACKJACK": statusBits.push("Blackjack"); break;
-                case "BUSTED": statusBits.push("Bust"); break;
-                case "STANDING": statusBits.push("Stand"); break;
-            }
-            var nameEl = document.createElement("span");
-            nameEl.className = "casino-seat-name";
-            nameEl.textContent = label + " — stake " + slot.stake;
-            header.appendChild(nameEl);
-            var meta = document.createElement("span");
-            meta.className = "casino-seat-meta";
-            meta.textContent = "(" + slot.total + ")" + (statusBits.length ? " " + statusBits.join(" · ") : "");
-            header.appendChild(meta);
-            div.appendChild(header);
-            var cards = document.createElement("div");
-            cards.className = "bj-cards casino-cards";
-            renderCards(cards, slot.cards);
-            div.appendChild(cards);
-            container.appendChild(div);
-        });
-    }
 
     // On page load, see if there's an existing in-flight hand for this user.
     refreshState().then(function () {

--- a/web/src/test/js/blackjack-split-rerender.test.js
+++ b/web/src/test/js/blackjack-split-rerender.test.js
@@ -1,0 +1,84 @@
+// Regression for the "after split it just keeps dealing the same cards
+// into both hands repeatedly" bug. The old `renderSplitHands` wiped
+// `container.innerHTML` on every poll and rebuilt every sub-hand DOM
+// from scratch, so the inner `.bj-cards` container was a brand-new
+// element each render. casino-render.js's `dealtCounts` WeakMap is
+// keyed off that element — with a fresh element it always reset to 0,
+// re-animating every card with the deal sound on each poll cycle.
+//
+// The fix reuses the per-slot DOM across renders so the WeakMap entry
+// persists. This test loads `casino-render.js` and `blackjack-solo.js`
+// into jsdom, calls `renderSplitHands` twice with identical state, and
+// asserts:
+//   1. The cards container DOM nodes are identity-stable across calls.
+//   2. The cards inside aren't re-marked with `.is-dealt` (no animation).
+require('../../main/resources/static/js/casino-render');
+require('../../main/resources/static/js/blackjack-solo');
+
+describe('TobyBlackjackSolo.renderSplitHands', () => {
+    let container;
+    const slots = [
+        { cards: ['8♠', '5♣'], total: 13, stake: 100, doubled: false, status: 'ACTIVE', fromSplit: true },
+        { cards: ['8♥', 'J♦'], total: 18, stake: 100, doubled: false, status: 'ACTIVE', fromSplit: true },
+    ];
+
+    beforeEach(() => {
+        document.body.innerHTML = '<div id="hands"></div>';
+        container = document.getElementById('hands');
+    });
+
+    test('reuses the same .bj-cards DOM nodes across identical renders', () => {
+        window.TobyBlackjackSolo.renderSplitHands(container, slots, 0);
+        const firstCardEls = Array.from(container.querySelectorAll('.bj-cards'));
+        expect(firstCardEls).toHaveLength(2);
+
+        window.TobyBlackjackSolo.renderSplitHands(container, slots, 0);
+        const secondCardEls = Array.from(container.querySelectorAll('.bj-cards'));
+        expect(secondCardEls).toHaveLength(2);
+
+        // Identity check — same element references on the second render.
+        // If renderSplitHands wipes innerHTML, these would be different
+        // nodes and the deal animation would re-fire.
+        expect(secondCardEls[0]).toBe(firstCardEls[0]);
+        expect(secondCardEls[1]).toBe(firstCardEls[1]);
+    });
+
+    test('re-rendering identical state does not re-animate the cards', () => {
+        window.TobyBlackjackSolo.renderSplitHands(container, slots, 0);
+        // After the first render every card glyph carries `.is-dealt`
+        // because they were freshly arrived. Strip the marker so we can
+        // assert the second render doesn't re-add it.
+        container.querySelectorAll('.casino-card-glyph').forEach((el) => {
+            el.classList.remove('is-dealt');
+        });
+
+        window.TobyBlackjackSolo.renderSplitHands(container, slots, 0);
+        const reanimated = container.querySelectorAll('.casino-card-glyph.is-dealt');
+        expect(reanimated.length).toBe(0);
+    });
+
+    test('rebuilds when the slot count changes (split happens, or fresh deal collapses back)', () => {
+        // Render with 2 slots, then with 1 — the row count differs, so the
+        // implementation is allowed to (and should) wipe and rebuild.
+        window.TobyBlackjackSolo.renderSplitHands(container, slots, 0);
+        expect(container.querySelectorAll('.bj-cards')).toHaveLength(2);
+
+        window.TobyBlackjackSolo.renderSplitHands(container, [slots[0]], 0);
+        expect(container.querySelectorAll('.bj-cards')).toHaveLength(1);
+    });
+
+    test('updates the active-slot highlight without rebuilding the DOM', () => {
+        window.TobyBlackjackSolo.renderSplitHands(container, slots, 0);
+        const seats = container.querySelectorAll('.bj-seat');
+        expect(seats[0].classList.contains('is-active')).toBe(true);
+        expect(seats[1].classList.contains('is-active')).toBe(false);
+
+        window.TobyBlackjackSolo.renderSplitHands(container, slots, 1);
+        const seatsAfter = container.querySelectorAll('.bj-seat');
+        // Same DOM nodes, just toggled classes.
+        expect(seatsAfter[0]).toBe(seats[0]);
+        expect(seatsAfter[1]).toBe(seats[1]);
+        expect(seatsAfter[0].classList.contains('is-active')).toBe(false);
+        expect(seatsAfter[1].classList.contains('is-active')).toBe(true);
+    });
+});


### PR DESCRIPTION
## Summary

User report: after splitting a pair, the table looked and sounded like it was dealing the same two cards into both hands over and over — animation re-firing, deal sound re-playing every ~1.5s.

## Root cause

`renderSplitHands` wiped `container.innerHTML` and rebuilt every sub-hand DOM from scratch on each poll. The inner `.bj-cards` container was therefore a brand-new element each render. `casino-render.js` keys its "cards already dealt into this container" tracking off a WeakMap of those container nodes; with a fresh node every cycle, `prev` reset to 0 and every card re-fired the `.is-dealt` animation + the deal sound. Players saw and heard the same cards land into both hands on a loop.

## Fix

- **Reuse the per-slot DOM across renders.** `renderSplitHands` now only wipes `innerHTML` when the slot count changes (split just happened, or a fresh single-hand deal collapsed back). Otherwise it walks the existing `<div class="bj-seat">` nodes by index, updates classes/text, and calls `renderCards` against the same `.bj-cards` element every time. casino-render's WeakMap entry survives, so the deal animation only fires for newly-arrived cards.
- **Lifted helpers** (`renderCards`, `renderSplitHands`, `createSplitHandSlotEl`) to the top of the IIFE and exposed `window.TobyBlackjackSolo.renderSplitHands` so jest can exercise the regression in jsdom. Page-init code now early-returns when the blackjack-solo template isn't on the page (matches `poker-pots.js`), so requiring the module in tests doesn't blow up on missing DOM elements.

## Tests

New `blackjack-split-rerender.test.js` — 4 cases:
- Same-state renders preserve `.bj-cards` element identity.
- Identical re-renders don't re-add the `.is-dealt` class (no animation re-fire).
- Slot-count changes still trigger a rebuild.
- Active-slot highlight toggles in place without rebuilding the DOM.

## Test plan

- [x] `npm test` — 17 files / 212 cases green.
- [x] `:web:test` green.
- [ ] Manual: deal a pair on solo blackjack, split, leave the page idle for ~10s — confirm cards stay still, no looping deal animation, no repeating deal sound.
- [ ] Manual: hit one of the split hands — confirm only the new card animates / sounds, not the existing two.

https://claude.ai/code/session_014ffsM6UFUh5KaMS4KUBPrf

---
_Generated by [Claude Code](https://claude.ai/code/session_014ffsM6UFUh5KaMS4KUBPrf)_