### PR TITLE
fix(blackjack web): play the win chip-stack animation reliably on mobile

### DIFF
--- a/web/src/main/resources/static/css/casino-table.css
+++ b/web/src/main/resources/static/css/casino-table.css
@@ -292,6 +292,10 @@
         0 1px 0 rgba(0, 0, 0, 0.55),
         inset 0 0 0 2px rgba(255, 255, 255, 0.15);
     margin-top: -0.32rem;
+    /* Hint mobile GPUs to allocate a dedicated compositor layer per chip —
+       without it iOS Safari occasionally drops the pop animation when the
+       seat ancestor is being recomposited in the same frame. */
+    will-change: transform, opacity;
     animation: casino-chip-pop 520ms cubic-bezier(.18, .89, .32, 1.28) both;
 }
 
@@ -301,6 +305,7 @@
     color: #fde68a;
     text-shadow: 0 0 8px rgba(252, 211, 77, 0.65);
     margin-bottom: 0.4rem;
+    will-change: transform, opacity;
     animation: casino-payout-float 1.6s ease-out both;
 }
 

--- a/web/src/main/resources/static/js/blackjack-solo.js
+++ b/web/src/main/resources/static/js/blackjack-solo.js
@@ -140,6 +140,7 @@
             playerTotalEl.textContent = seat ? "(" + seat.total + ")" : "";
         }
 
+        var becomingInactive = false;
         if (state.phase === "PLAYER_TURNS" && state.isMyTurn) {
             hitBtn.disabled = false;
             standBtn.disabled = false;
@@ -155,12 +156,24 @@
             doubleBtn.disabled = true;
             splitBtn.disabled = true;
             splitBtn.hidden = true;
-            if (playerRowEl) playerRowEl.classList.remove("is-active");
+            // Defer the .is-active drop to the next frame so it doesn't tear
+            // down the seat's compositing layer in the same paint as the
+            // chip-stack flourish below — mobile WebKit drops the chip
+            // animations otherwise. The `casino-pulse` halo lingers for one
+            // extra frame, which is invisible to the eye.
+            becomingInactive = !!playerRowEl &&
+                playerRowEl.classList.contains("is-active");
         }
 
         if (state.lastResult && state.phase === "RESOLVED") {
             renderResult(state, seat);
             stopPoll();
+        }
+
+        if (becomingInactive) {
+            var raf = window.requestAnimationFrame ||
+                function (fn) { return setTimeout(fn, 0); };
+            raf(function () { playerRowEl.classList.remove("is-active"); });
         }
     }
 

--- a/web/src/main/resources/static/js/casino-render.js
+++ b/web/src/main/resources/static/js/casino-render.js
@@ -149,8 +149,18 @@
     // Drop a small celebratory chip stack onto a seat element. Used by the
     // game JS the moment a hand resolves with a positive payout — the stack
     // animates in (one chip popping every 80ms), the payout label floats up,
-    // and the whole thing removes itself after ~1.6s so it doesn't pile up
-    // on subsequent polls.
+    // and the whole thing cleans itself up when the float animation ends.
+    //
+    // Mobile robustness: the chips are inserted inside a requestAnimationFrame
+    // callback so the empty stack commits to layout before the children with
+    // their staggered `animation-delay` are attached. iOS Safari and several
+    // Chromium versions drop child animations whose positioned ancestor is
+    // being recomposited in the same paint frame the children land — splitting
+    // the work across two frames sidesteps that. Cleanup keys off
+    // `animationend` on the longest-running child (payout-float = 1.6s) so a
+    // tab that was throttled mid-animation still tears the stack down at the
+    // right moment, with a 2.5s safety timer for prefers-reduced-motion (no
+    // animationend ever fires) and missed-event paranoia.
     function flashChipsOn(seatEl, payoutAmount, chipCount) {
         if (!seatEl || !payoutAmount || payoutAmount <= 0) return;
         // De-dupe: if a previous flash for the same hand is still on screen,
@@ -166,25 +176,52 @@
         label.textContent = "+" + payoutAmount;
         stack.appendChild(label);
 
-        // Cap chip count so a "+10000" payout doesn't draw 100 chips.
-        var n = Math.max(1, Math.min(chipCount || 5, 7));
-        for (var i = 0; i < n; i++) {
-            var chip = document.createElement("span");
-            chip.className = "casino-chip";
-            chip.style.animationDelay = (i * 80) + "ms";
-            stack.appendChild(chip);
-            // Synchronise the audible chip-clink with each chip's pop —
-            // gives the animation real weight.
-            if (window.CasinoSounds) {
-                (function (delay) {
-                    setTimeout(function () { window.CasinoSounds.play("chip"); }, delay);
-                })(i * 80);
-            }
-        }
         seatEl.appendChild(stack);
 
-        // Clean up after the longest animation (payout-float = 1.6s).
-        setTimeout(function () { if (stack.parentNode) stack.remove(); }, 1700);
+        // Cap chip count so a "+10000" payout doesn't draw 100 chips.
+        var n = Math.max(1, Math.min(chipCount || 5, 7));
+
+        // Idempotent removal: animationend wins the race in normal flow,
+        // safety timer covers the reduced-motion path where animationend
+        // never fires because the CSS sets `animation: none`.
+        var safetyTimer = null;
+        function cleanup() {
+            if (safetyTimer) {
+                clearTimeout(safetyTimer);
+                safetyTimer = null;
+            }
+            if (stack.parentNode) stack.remove();
+        }
+        label.addEventListener("animationend", cleanup, { once: true });
+        safetyTimer = setTimeout(cleanup, 2500);
+
+        var insertChips = function () {
+            // Bail if the stack got torn down between frames (rapid re-deal).
+            if (!stack.parentNode) return;
+            for (var i = 0; i < n; i++) {
+                var chip = document.createElement("span");
+                chip.className = "casino-chip";
+                chip.style.animationDelay = (i * 80) + "ms";
+                stack.appendChild(chip);
+                // Synchronise the audible chip-clink with each chip's pop —
+                // gives the animation real weight.
+                if (window.CasinoSounds) {
+                    (function (delay) {
+                        setTimeout(function () { window.CasinoSounds.play("chip"); }, delay);
+                    })(i * 80);
+                }
+            }
+        };
+
+        // requestAnimationFrame defers insertion to the next frame, after the
+        // empty stack has committed to layout. jsdom and very old browsers
+        // don't have rAF — fall back to a 0-ms timeout there so the unit
+        // tests still see the chips.
+        if (typeof window.requestAnimationFrame === "function") {
+            window.requestAnimationFrame(insertChips);
+        } else {
+            setTimeout(insertChips, 0);
+        }
     }
 
     window.CasinoRender = {


### PR DESCRIPTION
## Summary

The blackjack solo flow was removing `#bj-player-row`'s `.is-active` class in
the same paint frame the chip-stack flourish was being appended as a
descendant of that seat. Mobile WebKit / iOS Safari and several Chromium
versions drop descendant animations whose positioned ancestor is being
recomposited in that same frame — so the chip animation visibly skipped on
hands that resolved directly off the player's own action (stand, double,
blackjack, bust). Hands that resolved later via the polling cycle hit the
animation cleanly, which is why the bug only ever showed up on "every win on
mobile" and never on desktop.

Three small layered fixes:

- **`blackjack-solo.js`** — defer the `.is-active` drop to the next animation
  frame so the seat keeps its compositing layer while the chip stack lands.
  The gold pulse halo lingers for one frame, which is invisible to the eye.
- **`casino-render.js::flashChipsOn`** — insert chip children inside a
  `requestAnimationFrame` callback so the empty stack commits to layout
  before the staggered `animation-delay` children land. Replace the
  magic-number `setTimeout(1700)` cleanup with an `animationend` listener on
  the longest-running child (payout-float, 1.6s) plus a 2.5s safety timer for
  `prefers-reduced-motion` (where CSS sets `animation: none` so animationend
  never fires) and missed-event paranoia. jsdom fallback via `setTimeout(0)`
  keeps unit tests deterministic.
- **`casino-table.css`** — add `will-change: transform, opacity` to
  `.casino-chip` and `.casino-chip-payout` so mobile GPUs allocate a clean
  compositor layer.

The shared `flashChipsOn` is also called from `blackjack-table.js` and
`poker-table.js`, so the robustness fix benefits the multi-seat blackjack
table and poker payouts too — no per-game changes needed there.

## Test plan

- [x] `cd web && npm test` — 212/212 jest tests pass (no regressions; existing
  `blackjack-split-rerender` and `blackjack-split-cleanup` tests still cover
  the deal/poll flow that touches `casino-render.js`).
- [ ] Manual: load `/blackjack/<guildId>/solo` on a real mobile device (or
  Chrome DevTools mobile mode with 4× CPU throttle). Play 10 hands. Confirm
  the chip stack pops in and the `+<payout>` label floats up on **every** win,
  including hands that resolve directly on your own action (immediate
  blackjack on the deal, bust on hit, stand on 19/20).
- [ ] Manual: with `prefers-reduced-motion: reduce` enabled, confirm no
  animation plays and the stack is still cleaned up after ~2.5s (no DOM leak).
- [ ] Manual: spot-check `/poker/<guildId>/<tableId>` payouts to confirm the
  shared `flashChipsOn` change didn't regress poker.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BQrC1wBDzWvpfFkVPPhWid)_