### PR TITLE
fix(intro): show clipped runtime and delete embed at clip end

### DIFF
--- a/discord-bot/src/main/kotlin/bot/toby/helpers/MusicPlayerHelper.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/helpers/MusicPlayerHelper.kt
@@ -60,7 +60,13 @@ object MusicPlayerHelper {
         }
     }
 
-    fun nowPlaying(event: IReplyCallback, playerManager: PlayerManager, deleteDelay: Int) {
+    fun nowPlaying(
+        event: IReplyCallback,
+        playerManager: PlayerManager,
+        deleteDelay: Int,
+        clipStart: Long? = null,
+        clipEnd: Long? = null
+    ) {
         logger.setGuildAndMemberContext(event.guild, event.member)
         val musicManager = playerManager.getMusicManager(event.guild!!)
         val audioPlayer = musicManager.audioPlayer
@@ -69,7 +75,7 @@ object MusicPlayerHelper {
 
         if (checkForPlayingTrack(track, hook, deleteDelay)) return
 
-        val embed = nowPlayingManager.buildNowPlayingMessageData(track, audioPlayer)
+        val embed = nowPlayingManager.buildNowPlayingMessageData(track, audioPlayer, clipStart, clipEnd)
         val (pausePlayButton, stopButton) = generateButtons()
         val guildId = event.guild!!.idLong
         val nowPlayingInfo = nowPlayingManager.getLastNowPlayingMessage(guildId)
@@ -90,7 +96,7 @@ object MusicPlayerHelper {
                     nowPlayingManager.setNowPlayingMessage(guildId, it)
                 }
         }
-        nowPlayingManager.scheduleNowPlayingUpdate(guildId, track, audioPlayer, 0L, 3L)
+        nowPlayingManager.scheduleNowPlayingUpdate(guildId, track, audioPlayer, 0L, 3L, clipStart, clipEnd)
     }
 
     private fun checkForPlayingTrack(track: AudioTrack?, hook: InteractionHook, deleteDelay: Int): Boolean {

--- a/discord-bot/src/main/kotlin/bot/toby/lavaplayer/TrackScheduler.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/lavaplayer/TrackScheduler.kt
@@ -14,6 +14,7 @@ import common.logging.DiscordLogger
 import core.command.Command.Companion.invokeDeleteOnMessageResponse
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
 import java.util.concurrent.BlockingQueue
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.LinkedBlockingQueue
 
 class TrackScheduler(val player: AudioPlayer, private val guildId: Long, var deleteDelay: Int = 5) : AudioEventAdapter() {
@@ -22,6 +23,7 @@ class TrackScheduler(val player: AudioPlayer, private val guildId: Long, var del
     var event: SlashCommandInteractionEvent? = null
     private var previousVolume: Int? = null
     private val logger: DiscordLogger = DiscordLogger.createLogger(this::class.java)
+    private val trackClipBounds = ConcurrentHashMap<AudioTrack, Pair<Long, Long>>()
 
     fun queue(track: AudioTrack, startPosition: Long, endPosition: Long?, volume: Int) {
         logger.info("Adding ${track.info.title} by ${track.info.author} to the queue for guild $guildId")
@@ -32,12 +34,14 @@ class TrackScheduler(val player: AudioPlayer, private val guildId: Long, var del
         track.position = startPosition
         track.userData = volume
         if (endPosition != null && endPosition > startPosition) {
+            trackClipBounds[track] = startPosition to endPosition
             track.setMarker(TrackMarker(endPosition) { state ->
-                // Stop the clipped track on reaching the end marker. onTrackEnd then
-                // advances the queue and restores the previous volume.
+                // Stop the clipped track on reaching the end marker via the player so
+                // onTrackEnd reliably fires; that handler tears down the now-playing
+                // embed and advances the queue / restores the previous volume.
                 if (state == TrackMarkerHandler.MarkerState.REACHED) {
                     logger.info("Clip end marker reached at $endPosition ms for ${track.info.title}, stopping track.")
-                    track.stop()
+                    player.stopTrack()
                 }
             })
         }
@@ -77,10 +81,12 @@ class TrackScheduler(val player: AudioPlayer, private val guildId: Long, var del
         logger.info { "${track.info.title} by ${track.info.author} started for guild $guildId" }
         super.onTrackStart(player, track)
         player.volume = track.userData as Int
-        event?.let { nowPlaying(it, PlayerManager.instance, deriveDeleteDelayFromTrack(track)) }
+        val (clipStart, clipEnd) = trackClipBounds[track]?.let { it.first to it.second } ?: (null to null)
+        event?.let { nowPlaying(it, PlayerManager.instance, deriveDeleteDelayFromTrack(track), clipStart, clipEnd) }
     }
 
     override fun onTrackEnd(player: AudioPlayer, track: AudioTrack, endReason: AudioTrackEndReason) {
+        trackClipBounds.remove(track)
         event?.guild?.idLong.resetMessagesForGuildId()
         logger.info("${track.info.title} by ${track.info.author} ended")
         if (endReason.mayStartNext) {

--- a/discord-bot/src/main/kotlin/bot/toby/managers/NowPlayingManager.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/managers/NowPlayingManager.kt
@@ -64,12 +64,14 @@ class NowPlayingManager {
         track: AudioTrack,
         audioPlayer: AudioPlayer,
         delay: Long,
-        period: Long
+        period: Long,
+        clipStart: Long? = null,
+        clipEnd: Long? = null
     ) {
         cancelScheduledTask(guildId)
         val scheduledTask = scheduler.scheduleAtFixedRate({
             try {
-                updateNowPlayingMessage(guildId, track, audioPlayer)
+                updateNowPlayingMessage(guildId, track, audioPlayer, clipStart, clipEnd)
             } catch (e: Exception) {
                 logger.error{ "Error occurred while updating now playing message" }
             }
@@ -78,30 +80,49 @@ class NowPlayingManager {
         scheduledTasks[guildId] = scheduledTask
     }
 
-    private fun updateNowPlayingMessage(guildId: Long, track: AudioTrack, audioPlayer: AudioPlayer) {
+    private fun updateNowPlayingMessage(
+        guildId: Long,
+        track: AudioTrack,
+        audioPlayer: AudioPlayer,
+        clipStart: Long?,
+        clipEnd: Long?
+    ) {
         lock.read {
             val message = guildLastNowPlayingMessage[guildId]
             message?.let {
-                val embed = buildNowPlayingMessageData(track, audioPlayer.volume, audioPlayer.isPaused)
+                val embed = buildNowPlayingMessageData(track, audioPlayer.volume, audioPlayer.isPaused, clipStart, clipEnd)
                 message.editMessageEmbeds(embed).queue()
                 logger.info { "Updated now playing message ${message.idLong}" }
             }
         }
     }
 
-    fun buildNowPlayingMessageData(track: AudioTrack, audioPlayer: AudioPlayer): MessageEmbed {
-        return buildNowPlayingMessageData(track, audioPlayer.volume, audioPlayer.isPaused)
+    fun buildNowPlayingMessageData(
+        track: AudioTrack,
+        audioPlayer: AudioPlayer,
+        clipStart: Long? = null,
+        clipEnd: Long? = null
+    ): MessageEmbed {
+        return buildNowPlayingMessageData(track, audioPlayer.volume, audioPlayer.isPaused, clipStart, clipEnd)
     }
 
-    private fun buildNowPlayingMessageData(track: AudioTrack, volume: Int, isPaused: Boolean): MessageEmbed {
+    private fun buildNowPlayingMessageData(
+        track: AudioTrack,
+        volume: Int,
+        isPaused: Boolean,
+        clipStart: Long? = null,
+        clipEnd: Long? = null
+    ): MessageEmbed {
         val info = track.info
         val descriptionBuilder = StringBuilder()
 
         descriptionBuilder.append("**Title**: `${info.title}`\n").append("**Author**: `${info.author}`\n")
 
         if (!info.isStream) {
-            val songPosition = formatTime(track.position)
-            val songDuration = formatTime(track.duration)
+            val effectiveStart = clipStart ?: 0L
+            val effectiveEnd = clipEnd ?: track.duration
+            val songPosition = formatTime((track.position - effectiveStart).coerceAtLeast(0L))
+            val songDuration = formatTime((effectiveEnd - effectiveStart).coerceAtLeast(0L))
             descriptionBuilder.append("**Progress**: `$songPosition / $songDuration`\n")
         } else {
             descriptionBuilder.append("**Stream**: `Live`\n")


### PR DESCRIPTION
## Summary
- Now Playing embed for a clipped intro showed the source video's full duration and lingered until that full duration elapsed. Two fixes:
  - `TrackScheduler.queue` now uses `player.stopTrack()` (instead of `track.stop()`) inside the clip-end marker handler so `onTrackEnd` reliably fires and triggers the existing `resetMessages` teardown of the embed at clip-end time.
  - Clip bounds are stored per-track in `TrackScheduler` and threaded through `MusicPlayerHelper.nowPlaying` → `NowPlayingManager.buildNowPlayingMessageData` / `scheduleNowPlayingUpdate`, so the embed's `Progress` line renders as `position-since-clip-start / clip-length` for clipped tracks. Unclipped playback is unchanged (params default to `null`).

## Test plan
- [ ] `/play intro` for a user whose intro has `clip_start_ms` / `clip_end_ms` set on a long source video — confirm the embed shows `Progress` from `00:00:00` up to `clipEnd - clipStart`, increments while audio plays, and the embed is deleted at clip end (not at full source duration).
- [ ] `/play link <url>` (no clip bounds) — confirm progress and embed lifecycle behave as before (full source duration, deleted on track end).
- [ ] Run `:discord-bot:test` (notably `TrackSchedulerTest`, `NowPlayingManagerTest`, `MusicPlayerHelperTest`) — existing call sites pass only original params; new params have default `null` so existing tests should stay green.

https://claude.ai/code/session_01DjXnQbLjpZ9HqvLJgSrevZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01DjXnQbLjpZ9HqvLJgSrevZ)_