### PR TITLE
perf(test): normalize @SpringBootTest classes[] ordering across all 16 ITs (#365 step 1b)

### DIFF
--- a/application/src/test/kotlin/SpringApplicationTest.kt
+++ b/application/src/test/kotlin/SpringApplicationTest.kt
@@ -11,11 +11,11 @@ import org.springframework.test.context.ActiveProfiles
 @SpringBootTest(
     classes = [
         Application::class,
-        TestAppConfig::class,
-        TestBotConfig::class,
         TestCachingConfig::class,
         TestDatabaseConfig::class,
-        TestManagerConfig::class
+        TestManagerConfig::class,
+        TestAppConfig::class,
+        TestBotConfig::class,
     ]
 )
 @ActiveProfiles("test")

--- a/application/src/test/kotlin/integration/bot/AutocompleteManagerTest.kt
+++ b/application/src/test/kotlin/integration/bot/AutocompleteManagerTest.kt
@@ -22,11 +22,11 @@ import org.springframework.test.context.ActiveProfiles
 @SpringBootTest(
     classes = [
         Application::class,
-        TestAppConfig::class,
-        TestBotConfig::class,
         TestCachingConfig::class,
         TestDatabaseConfig::class,
-        TestManagerConfig::class
+        TestManagerConfig::class,
+        TestAppConfig::class,
+        TestBotConfig::class,
     ]
 )
 @ActiveProfiles("test")

--- a/application/src/test/kotlin/integration/bot/ButtonManagerTest.kt
+++ b/application/src/test/kotlin/integration/bot/ButtonManagerTest.kt
@@ -33,11 +33,11 @@ import java.util.concurrent.LinkedBlockingQueue
 @SpringBootTest(
     classes = [
         Application::class,
-        TestAppConfig::class,
-        TestBotConfig::class,
         TestCachingConfig::class,
         TestDatabaseConfig::class,
-        TestManagerConfig::class
+        TestManagerConfig::class,
+        TestAppConfig::class,
+        TestBotConfig::class,
     ]
 )
 @ActiveProfiles("test")

--- a/application/src/test/kotlin/integration/bot/CommandManagerTest.kt
+++ b/application/src/test/kotlin/integration/bot/CommandManagerTest.kt
@@ -55,11 +55,11 @@ import org.springframework.test.context.ActiveProfiles
 @SpringBootTest(
     classes = [
         Application::class,
-        TestAppConfig::class,
-        TestBotConfig::class,
         TestCachingConfig::class,
         TestDatabaseConfig::class,
-        TestManagerConfig::class
+        TestManagerConfig::class,
+        TestAppConfig::class,
+        TestBotConfig::class,
     ]
 )
 @ActiveProfiles("test")

--- a/application/src/test/kotlin/integration/bot/MenuManagerTest.kt
+++ b/application/src/test/kotlin/integration/bot/MenuManagerTest.kt
@@ -26,11 +26,11 @@ import org.springframework.test.context.ActiveProfiles
 @SpringBootTest(
     classes = [
         Application::class,
-        TestAppConfig::class,
-        TestBotConfig::class,
         TestCachingConfig::class,
         TestDatabaseConfig::class,
-        TestManagerConfig::class
+        TestManagerConfig::class,
+        TestAppConfig::class,
+        TestBotConfig::class,
     ]
 )
 @ActiveProfiles("test")


### PR DESCRIPTION
## Summary

Step 1b of issue #365: collapse the second context-cache fragmentation
in `:application` so all 16 `@SpringBootTest` classes share one cached
context.

## What was happening

The five integration tests in `integration/bot/` plus the top-level
`SpringApplicationTest` declared their `@SpringBootTest(classes = [...])`
array in one ordering:

```kotlin
classes = [
    Application::class,
    TestAppConfig::class,
    TestBotConfig::class,
    TestCachingConfig::class,
    TestDatabaseConfig::class,
    TestManagerConfig::class,
]
```

The other 11 integration tests (under `integration/database/*` and
`integration/web/*`) used a different ordering of the same six
`@Configuration` sources:

```kotlin
classes = [
    Application::class,
    TestCachingConfig::class,
    TestDatabaseConfig::class,
    TestManagerConfig::class,
    TestAppConfig::class,
    TestBotConfig::class,
]
```

Spring's `MergedContextConfiguration#equals` uses `Arrays.equals` on the
`classes` array, which is **order-sensitive** even though the set of
sources is identical. The two orderings therefore key into two separate
context-cache entries, forcing one extra Spring boot + Postgres
testcontainer Flyway-migration cycle every CI run.

Folding the five outliers into the canonical ordering used by the
larger group collapses the cache to a single entry. Combined with the
`@TestPropertySource` cleanup in #366, all 16 `@SpringBootTest` classes
now share one cached context — **three boots → one** end-to-end on
`:application:test`.

## Why it should be safe (no DB pollution)

The five group-A tests use `mockk()` for the services they exercise:

```
ButtonManagerTest.kt:55:    configService = mockk()
CommandManagerTest.kt:78:   configService = mockk()
MenuManagerTest.kt:48:      configService = mockk()
```

`grep "createNewUser\|persistence\|userService\\."` against those files
returns nothing — they don't touch the Postgres testcontainer at all.
Folding them into the shared context with the integration tests that
*do* mutate the DB (UserServiceImpl, TobyCoinTradePersistence,
EconomyTradeService, …) is therefore not a new pollution surface; the
13 DB-writing tests in `integration/database/*` + `integration/web/*`
already share one container today and pass on `main`.

If CI surfaces failures I haven't predicted, follow-up will add a
targeted `@DirtiesContext` / `@Transactional` to the offending class —
captured as remaining work in #365.

## Test plan

- [ ] CI green on `Kotlin with Gradle`
- [ ] `:application:test` log shows one `Started SpringBootApplication`
      line for the integration suite (was three before #366, two after #366)
- [ ] Total CI build duration vs the most recent `main` run

Refs #365.

https://claude.ai/code/session_01DTWCxi6KXH3nApS6mitBp4

---
_Generated by [Claude Code](https://claude.ai/code/session_01DTWCxi6KXH3nApS6mitBp4)_