### PR TITLE
feat(casino web): mirror jackpot pool on every balance-mutating response

### DIFF
--- a/database/src/main/kotlin/database/service/CoinflipService.kt
+++ b/database/src/main/kotlin/database/service/CoinflipService.kt
@@ -38,7 +38,8 @@ class CoinflipService(
             val newBalance: Long,
             val jackpotPayout: Long = 0L,
             val soldTobyCoins: Long = 0L,
-            val newPrice: Double? = null
+            val newPrice: Double? = null,
+            val jackpotPool: Long = 0L
         ) : FlipOutcome
 
         data class Lose(
@@ -48,7 +49,8 @@ class CoinflipService(
             val newBalance: Long,
             val soldTobyCoins: Long = 0L,
             val newPrice: Double? = null,
-            val lossTribute: Long = 0L
+            val lossTribute: Long = 0L,
+            val jackpotPool: Long = 0L
         ) : FlipOutcome
 
         data class InsufficientCredits(val stake: Long, val have: Long) : FlipOutcome
@@ -108,7 +110,8 @@ class CoinflipService(
                 newBalance = r.newBalance + jackpot,
                 jackpotPayout = jackpot,
                 soldTobyCoins = soldCoins,
-                newPrice = newPrice
+                newPrice = newPrice,
+                jackpotPool = jackpotService.getPool(guildId)
             )
         } else {
             val tribute = JackpotHelper.divertOnLoss(jackpotService, configService, guildId, stake)
@@ -119,7 +122,8 @@ class CoinflipService(
                 newBalance = r.newBalance,
                 soldTobyCoins = soldCoins,
                 newPrice = newPrice,
-                lossTribute = tribute
+                lossTribute = tribute,
+                jackpotPool = jackpotService.getPool(guildId)
             )
         }
     }

--- a/database/src/main/kotlin/database/service/DiceService.kt
+++ b/database/src/main/kotlin/database/service/DiceService.kt
@@ -37,7 +37,8 @@ class DiceService(
             val newBalance: Long,
             val jackpotPayout: Long = 0L,
             val soldTobyCoins: Long = 0L,
-            val newPrice: Double? = null
+            val newPrice: Double? = null,
+            val jackpotPool: Long = 0L
         ) : RollOutcome
 
         data class Lose(
@@ -47,7 +48,8 @@ class DiceService(
             val newBalance: Long,
             val soldTobyCoins: Long = 0L,
             val newPrice: Double? = null,
-            val lossTribute: Long = 0L
+            val lossTribute: Long = 0L,
+            val jackpotPool: Long = 0L
         ) : RollOutcome
 
         data class InsufficientCredits(val stake: Long, val have: Long) : RollOutcome
@@ -111,7 +113,8 @@ class DiceService(
                 newBalance = r.newBalance + jackpot,
                 jackpotPayout = jackpot,
                 soldTobyCoins = soldCoins,
-                newPrice = newPrice
+                newPrice = newPrice,
+                jackpotPool = jackpotService.getPool(guildId)
             )
         } else {
             val tribute = JackpotHelper.divertOnLoss(jackpotService, configService, guildId, stake)
@@ -122,7 +125,8 @@ class DiceService(
                 newBalance = r.newBalance,
                 soldTobyCoins = soldCoins,
                 newPrice = newPrice,
-                lossTribute = tribute
+                lossTribute = tribute,
+                jackpotPool = jackpotService.getPool(guildId)
             )
         }
     }

--- a/database/src/main/kotlin/database/service/DuelService.kt
+++ b/database/src/main/kotlin/database/service/DuelService.kt
@@ -62,7 +62,8 @@ class DuelService @Autowired constructor(
             val pot: Long,
             val winnerNewBalance: Long,
             val loserNewBalance: Long,
-            val lossTribute: Long
+            val lossTribute: Long,
+            val jackpotPool: Long = 0L
         ) : AcceptOutcome
 
         data class InitiatorInsufficient(val have: Long, val needed: Long) : AcceptOutcome
@@ -163,7 +164,8 @@ class DuelService @Autowired constructor(
             pot = pot,
             winnerNewBalance = winner.socialCredit ?: 0L,
             loserNewBalance = loser.socialCredit ?: 0L,
-            lossTribute = tribute
+            lossTribute = tribute,
+            jackpotPool = jackpotService.getPool(guildId)
         )
     }
 

--- a/database/src/main/kotlin/database/service/EconomyTradeService.kt
+++ b/database/src/main/kotlin/database/service/EconomyTradeService.kt
@@ -56,7 +56,8 @@ class EconomyTradeService(
             val newPrice: Double,
             // Fee skimmed off this trade and routed to the jackpot pool.
             // Defaulted so existing test fixtures keep compiling.
-            val fee: Long = 0L
+            val fee: Long = 0L,
+            val jackpotPool: Long = 0L
         ) : TradeOutcome
 
         data class InsufficientCredits(val needed: Long, val have: Long) : TradeOutcome
@@ -118,7 +119,8 @@ class EconomyTradeService(
             newCoins = user.tobyCoins,
             newCredits = user.socialCredit ?: 0L,
             newPrice = newPrice,
-            fee = fee
+            fee = fee,
+            jackpotPool = jackpotService.getPool(guildId)
         )
     }
 
@@ -158,7 +160,8 @@ class EconomyTradeService(
             newCoins = user.tobyCoins,
             newCredits = user.socialCredit ?: 0L,
             newPrice = newPrice,
-            fee = fee
+            fee = fee,
+            jackpotPool = jackpotService.getPool(guildId)
         )
     }
 

--- a/database/src/main/kotlin/database/service/HighlowService.kt
+++ b/database/src/main/kotlin/database/service/HighlowService.kt
@@ -45,7 +45,8 @@ class HighlowService(
             val newBalance: Long,
             val jackpotPayout: Long = 0L,
             val soldTobyCoins: Long = 0L,
-            val newPrice: Double? = null
+            val newPrice: Double? = null,
+            val jackpotPool: Long = 0L
         ) : PlayOutcome
 
         data class Lose(
@@ -56,7 +57,8 @@ class HighlowService(
             val newBalance: Long,
             val soldTobyCoins: Long = 0L,
             val newPrice: Double? = null,
-            val lossTribute: Long = 0L
+            val lossTribute: Long = 0L,
+            val jackpotPool: Long = 0L
         ) : PlayOutcome
 
         data class InsufficientCredits(val stake: Long, val have: Long) : PlayOutcome
@@ -151,7 +153,8 @@ class HighlowService(
                 newBalance = r.newBalance + jackpot,
                 jackpotPayout = jackpot,
                 soldTobyCoins = soldCoins,
-                newPrice = soldNewPrice
+                newPrice = soldNewPrice,
+                jackpotPool = jackpotService.getPool(guildId)
             )
         } else {
             val tribute = JackpotHelper.divertOnLoss(jackpotService, configService, guildId, stake)
@@ -163,7 +166,8 @@ class HighlowService(
                 newBalance = r.newBalance,
                 soldTobyCoins = soldCoins,
                 newPrice = soldNewPrice,
-                lossTribute = tribute
+                lossTribute = tribute,
+                jackpotPool = jackpotService.getPool(guildId)
             )
         }
     }

--- a/database/src/main/kotlin/database/service/ScratchService.kt
+++ b/database/src/main/kotlin/database/service/ScratchService.kt
@@ -36,7 +36,8 @@ class ScratchService(
             val newBalance: Long,
             val jackpotPayout: Long = 0L,
             val soldTobyCoins: Long = 0L,
-            val newPrice: Double? = null
+            val newPrice: Double? = null,
+            val jackpotPool: Long = 0L
         ) : ScratchOutcome
 
         data class Lose(
@@ -45,7 +46,8 @@ class ScratchService(
             val newBalance: Long,
             val soldTobyCoins: Long = 0L,
             val newPrice: Double? = null,
-            val lossTribute: Long = 0L
+            val lossTribute: Long = 0L,
+            val jackpotPool: Long = 0L
         ) : ScratchOutcome
 
         data class InsufficientCredits(val stake: Long, val have: Long) : ScratchOutcome
@@ -100,7 +102,8 @@ class ScratchService(
                 newBalance = r.newBalance + jackpot,
                 jackpotPayout = jackpot,
                 soldTobyCoins = soldCoins,
-                newPrice = newPrice
+                newPrice = newPrice,
+                jackpotPool = jackpotService.getPool(guildId)
             )
         } else {
             val tribute = JackpotHelper.divertOnLoss(jackpotService, configService, guildId, stake)
@@ -110,7 +113,8 @@ class ScratchService(
                 newBalance = r.newBalance,
                 soldTobyCoins = soldCoins,
                 newPrice = newPrice,
-                lossTribute = tribute
+                lossTribute = tribute,
+                jackpotPool = jackpotService.getPool(guildId)
             )
         }
     }

--- a/database/src/main/kotlin/database/service/SlotsService.kt
+++ b/database/src/main/kotlin/database/service/SlotsService.kt
@@ -48,7 +48,8 @@ class SlotsService(
             val newBalance: Long,
             val jackpotPayout: Long = 0L,
             val soldTobyCoins: Long = 0L,
-            val newPrice: Double? = null
+            val newPrice: Double? = null,
+            val jackpotPool: Long = 0L
         ) : SpinOutcome
 
         data class Lose(
@@ -57,7 +58,8 @@ class SlotsService(
             val newBalance: Long,
             val soldTobyCoins: Long = 0L,
             val newPrice: Double? = null,
-            val lossTribute: Long = 0L
+            val lossTribute: Long = 0L,
+            val jackpotPool: Long = 0L
         ) : SpinOutcome
 
         data class InsufficientCredits(val stake: Long, val have: Long) : SpinOutcome
@@ -113,7 +115,8 @@ class SlotsService(
                 newBalance = r.newBalance + jackpot,
                 jackpotPayout = jackpot,
                 soldTobyCoins = soldCoins,
-                newPrice = newPrice
+                newPrice = newPrice,
+                jackpotPool = jackpotService.getPool(guildId)
             )
         } else {
             val tribute = JackpotHelper.divertOnLoss(jackpotService, configService, guildId, stake)
@@ -123,7 +126,8 @@ class SlotsService(
                 newBalance = r.newBalance,
                 soldTobyCoins = soldCoins,
                 newPrice = newPrice,
-                lossTribute = tribute
+                lossTribute = tribute,
+                jackpotPool = jackpotService.getPool(guildId)
             )
         }
     }

--- a/database/src/main/kotlin/database/service/TipService.kt
+++ b/database/src/main/kotlin/database/service/TipService.kt
@@ -28,6 +28,7 @@ class TipService @Autowired constructor(
     private val userService: UserService,
     private val tipDailyService: TipDailyService,
     private val tipLogPersistence: TipLogPersistence,
+    private val jackpotService: JackpotService,
 ) {
     sealed interface TipOutcome {
         data class Ok(
@@ -38,7 +39,8 @@ class TipService @Autowired constructor(
             val senderNewBalance: Long,
             val recipientNewBalance: Long,
             val sentTodayAfter: Long,
-            val dailyCap: Long
+            val dailyCap: Long,
+            val jackpotPool: Long = 0L
         ) : TipOutcome
 
         data class InvalidAmount(val min: Long, val max: Long) : TipOutcome
@@ -120,7 +122,8 @@ class TipService @Autowired constructor(
             senderNewBalance = senderBalance - amount,
             recipientNewBalance = recipientBalance + amount,
             sentTodayAfter = newDailyTotal,
-            dailyCap = dailyCap
+            dailyCap = dailyCap,
+            jackpotPool = jackpotService.getPool(guildId)
         )
     }
 

--- a/database/src/test/kotlin/database/service/TipServiceTest.kt
+++ b/database/src/test/kotlin/database/service/TipServiceTest.kt
@@ -4,6 +4,7 @@ import database.dto.TipDailyDto
 import database.dto.TipLogDto
 import database.dto.UserDto
 import database.persistence.TipLogPersistence
+import io.mockk.mockk
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
@@ -32,7 +33,7 @@ class TipServiceTest {
         userService = RecordingUserService()
         tipDailyService = InMemoryTipDailyService()
         tipLogPersistence = RecordingTipLogPersistence()
-        service = TipService(userService, tipDailyService, tipLogPersistence)
+        service = TipService(userService, tipDailyService, tipLogPersistence, mockk(relaxed = true))
     }
 
     @Test

--- a/web/src/main/kotlin/web/controller/CoinflipController.kt
+++ b/web/src/main/kotlin/web/controller/CoinflipController.kt
@@ -83,7 +83,8 @@ class CoinflipController(
                     win = true,
                     jackpotPayout = outcome.jackpotPayout.takeIf { it > 0L },
                     soldTobyCoins = outcome.soldTobyCoins.takeIf { it > 0L },
-                    newPrice = outcome.newPrice
+                    newPrice = outcome.newPrice,
+                    jackpotPool = outcome.jackpotPool
                 )
             )
 
@@ -98,7 +99,8 @@ class CoinflipController(
                     win = false,
                     soldTobyCoins = outcome.soldTobyCoins.takeIf { it > 0L },
                     newPrice = outcome.newPrice,
-                    lossTribute = outcome.lossTribute.takeIf { it > 0L }
+                    lossTribute = outcome.lossTribute.takeIf { it > 0L },
+                    jackpotPool = outcome.jackpotPool
                 )
             )
 
@@ -130,5 +132,6 @@ data class FlipResponse(
     val jackpotPayout: Long? = null,
     val soldTobyCoins: Long? = null,
     val newPrice: Double? = null,
-    val lossTribute: Long? = null
+    val lossTribute: Long? = null,
+    val jackpotPool: Long? = null
 ) : CasinoResponseLike

--- a/web/src/main/kotlin/web/controller/DiceController.kt
+++ b/web/src/main/kotlin/web/controller/DiceController.kt
@@ -79,7 +79,8 @@ class DiceController(
                     win = true,
                     jackpotPayout = outcome.jackpotPayout.takeIf { it > 0L },
                     soldTobyCoins = outcome.soldTobyCoins.takeIf { it > 0L },
-                    newPrice = outcome.newPrice
+                    newPrice = outcome.newPrice,
+                    jackpotPool = outcome.jackpotPool
                 )
             )
 
@@ -94,7 +95,8 @@ class DiceController(
                     win = false,
                     soldTobyCoins = outcome.soldTobyCoins.takeIf { it > 0L },
                     newPrice = outcome.newPrice,
-                    lossTribute = outcome.lossTribute.takeIf { it > 0L }
+                    lossTribute = outcome.lossTribute.takeIf { it > 0L },
+                    jackpotPool = outcome.jackpotPool
                 )
             )
 
@@ -123,5 +125,6 @@ data class RollResponse(
     val jackpotPayout: Long? = null,
     val soldTobyCoins: Long? = null,
     val newPrice: Double? = null,
-    val lossTribute: Long? = null
+    val lossTribute: Long? = null,
+    val jackpotPool: Long? = null
 ) : CasinoResponseLike

--- a/web/src/main/kotlin/web/controller/DuelController.kt
+++ b/web/src/main/kotlin/web/controller/DuelController.kt
@@ -211,7 +211,8 @@ class DuelController(
                     pot = outcome.pot,
                     winnerNewBalance = outcome.winnerNewBalance,
                     loserNewBalance = outcome.loserNewBalance,
-                    lossTribute = outcome.lossTribute
+                    lossTribute = outcome.lossTribute,
+                    jackpotPool = outcome.jackpotPool
                 )
             )
             is AcceptOutcome.InitiatorInsufficient -> ResponseEntity.badRequest().body(
@@ -312,5 +313,6 @@ data class DuelActionResponse(
     val pot: Long? = null,
     val winnerNewBalance: Long? = null,
     val loserNewBalance: Long? = null,
-    val lossTribute: Long? = null
+    val lossTribute: Long? = null,
+    val jackpotPool: Long? = null
 )

--- a/web/src/main/kotlin/web/controller/EconomyController.kt
+++ b/web/src/main/kotlin/web/controller/EconomyController.kt
@@ -146,7 +146,8 @@ class EconomyController(
                         newCredits = outcome.newCredits + granted,
                         newPrice = outcome.newPrice,
                         transactedCredits = outcome.transactedCredits,
-                        fee = outcome.fee
+                        fee = outcome.fee,
+                        jackpotPool = outcome.jackpotPool
                     )
                 )
             }
@@ -175,7 +176,8 @@ data class TradeResponse(
     val newCredits: Long? = null,
     val newPrice: Double? = null,
     val transactedCredits: Long? = null,
-    val fee: Long? = null
+    val fee: Long? = null,
+    val jackpotPool: Long? = null
 )
 
 data class HistoryResponse(

--- a/web/src/main/kotlin/web/controller/HighlowController.kt
+++ b/web/src/main/kotlin/web/controller/HighlowController.kt
@@ -143,7 +143,8 @@ class HighlowController(
                     win = true,
                     jackpotPayout = outcome.jackpotPayout.takeIf { it > 0L },
                     soldTobyCoins = outcome.soldTobyCoins.takeIf { it > 0L },
-                    newPrice = outcome.newPrice
+                    newPrice = outcome.newPrice,
+                    jackpotPool = outcome.jackpotPool
                 )
             )
 
@@ -159,7 +160,8 @@ class HighlowController(
                     win = false,
                     soldTobyCoins = outcome.soldTobyCoins.takeIf { it > 0L },
                     newPrice = outcome.newPrice,
-                    lossTribute = outcome.lossTribute.takeIf { it > 0L }
+                    lossTribute = outcome.lossTribute.takeIf { it > 0L },
+                    jackpotPool = outcome.jackpotPool
                 )
             )
 
@@ -243,5 +245,6 @@ data class PlayResponse(
     val jackpotPayout: Long? = null,
     val soldTobyCoins: Long? = null,
     val newPrice: Double? = null,
-    val lossTribute: Long? = null
+    val lossTribute: Long? = null,
+    val jackpotPool: Long? = null
 ) : CasinoResponseLike

--- a/web/src/main/kotlin/web/controller/ScratchController.kt
+++ b/web/src/main/kotlin/web/controller/ScratchController.kt
@@ -90,7 +90,8 @@ class ScratchController(
                     win = true,
                     jackpotPayout = outcome.jackpotPayout.takeIf { it > 0L },
                     soldTobyCoins = outcome.soldTobyCoins.takeIf { it > 0L },
-                    newPrice = outcome.newPrice
+                    newPrice = outcome.newPrice,
+                    jackpotPool = outcome.jackpotPool
                 )
             )
 
@@ -104,7 +105,8 @@ class ScratchController(
                     win = false,
                     soldTobyCoins = outcome.soldTobyCoins.takeIf { it > 0L },
                     newPrice = outcome.newPrice,
-                    lossTribute = outcome.lossTribute.takeIf { it > 0L }
+                    lossTribute = outcome.lossTribute.takeIf { it > 0L },
+                    jackpotPool = outcome.jackpotPool
                 )
             )
 
@@ -133,5 +135,6 @@ data class ScratchResponse(
     val jackpotPayout: Long? = null,
     val soldTobyCoins: Long? = null,
     val newPrice: Double? = null,
-    val lossTribute: Long? = null
+    val lossTribute: Long? = null,
+    val jackpotPool: Long? = null
 ) : CasinoResponseLike

--- a/web/src/main/kotlin/web/controller/SlotsController.kt
+++ b/web/src/main/kotlin/web/controller/SlotsController.kt
@@ -80,7 +80,8 @@ class SlotsController(
                     win = true,
                     jackpotPayout = outcome.jackpotPayout.takeIf { it > 0L },
                     soldTobyCoins = outcome.soldTobyCoins.takeIf { it > 0L },
-                    newPrice = outcome.newPrice
+                    newPrice = outcome.newPrice,
+                    jackpotPool = outcome.jackpotPool
                 )
             )
 
@@ -95,7 +96,8 @@ class SlotsController(
                     win = false,
                     soldTobyCoins = outcome.soldTobyCoins.takeIf { it > 0L },
                     newPrice = outcome.newPrice,
-                    lossTribute = outcome.lossTribute.takeIf { it > 0L }
+                    lossTribute = outcome.lossTribute.takeIf { it > 0L },
+                    jackpotPool = outcome.jackpotPool
                 )
             )
 
@@ -135,7 +137,8 @@ data class SpinResponse(
     val jackpotPayout: Long? = null,
     val soldTobyCoins: Long? = null,
     val newPrice: Double? = null,
-    val lossTribute: Long? = null
+    val lossTribute: Long? = null,
+    val jackpotPool: Long? = null
 ) : CasinoResponseLike
 
 data class PayoutRow(val symbols: String, val multiplier: String)

--- a/web/src/main/kotlin/web/controller/TipController.kt
+++ b/web/src/main/kotlin/web/controller/TipController.kt
@@ -144,7 +144,8 @@ class TipController(
                         sentTodayAfter = outcome.sentTodayAfter,
                         dailyCap = outcome.dailyCap,
                         amount = outcome.amount,
-                        note = outcome.note
+                        note = outcome.note,
+                        jackpotPool = outcome.jackpotPool
                     )
                 )
             }
@@ -191,5 +192,6 @@ data class TipResponse(
     val senderNewBalance: Long? = null,
     val recipientNewBalance: Long? = null,
     val sentTodayAfter: Long? = null,
-    val dailyCap: Long? = null
+    val dailyCap: Long? = null,
+    val jackpotPool: Long? = null
 )

--- a/web/src/main/resources/static/js/casino-jackpot.js
+++ b/web/src/main/resources/static/js/casino-jackpot.js
@@ -16,6 +16,20 @@
     }
 
     /**
+     * Refresh the per-guild jackpot pool banner (`fragments/casino.html`)
+     * from a `body.jackpotPool` field on any balance-mutating response —
+     * casino spins, duels, trades, tips. Noop when the field is absent
+     * or the banner isn't on the current page (so duel/trade/tip pages
+     * silently skip the DOM write).
+     */
+    function updatePoolBanner(body) {
+        if (!body || typeof body.jackpotPool !== 'number') return;
+        if (typeof document === 'undefined') return;
+        const target = document.querySelector('.casino-jackpot-banner strong');
+        if (target) target.textContent = String(body.jackpotPool);
+    }
+
+    /**
      * Apply jackpot styling + prefix on top of an existing win-line HTML
      * fragment. Returns the HTML the result element should display.
      * Pass the body straight from the server response.
@@ -23,6 +37,7 @@
      *   element.innerHTML = renderWinHtml(resEl, body, 'slots-result-jackpot', winLine)
      */
     function renderWinHtml(resultEl, body, jackpotClassName, winLineHtml) {
+        updatePoolBanner(body);
         if (!isJackpotHit(body)) return winLineHtml;
         if (resultEl && jackpotClassName) resultEl.classList.add(jackpotClassName);
         return jackpotPrefixHtml(body.jackpotPayout) + winLineHtml;
@@ -34,12 +49,13 @@
      * (e.g. tiny stake floored to zero, or admin set tribute to 0 %).
      */
     function lossTributeSuffix(body) {
+        updatePoolBanner(body);
         if (!body || typeof body.lossTribute !== 'number' || body.lossTribute <= 0) return '';
         return ' &middot; <span class="casino-loss-tribute">+' +
             body.lossTribute + ' to jackpot</span>';
     }
 
-    const api = { isJackpotHit, jackpotPrefixHtml, renderWinHtml, lossTributeSuffix };
+    const api = { isJackpotHit, jackpotPrefixHtml, renderWinHtml, lossTributeSuffix, updatePoolBanner };
 
     // Browser global so each game's IIFE-style JS can reach it without
     // bundler plumbing.


### PR DESCRIPTION
## Summary

Until now the per-guild jackpot pool figure was only read on **page-render** paths (`CasinoPageContext` etc.) — none of the per-action JSON responses carried it, so the displayed pool only refreshed on a full page reload.

This PR mirrors the post-action pool value into every balance-mutating response across the casino, duels, trades, and tips, so the banner figure can update live alongside the balance.

- Adds `jackpotPool: Long` to every casino outcome (`RollOutcome.Win`/`Lose`, `SpinOutcome.Win`/`Lose`, `FlipOutcome.Win`/`Lose`, `PlayOutcome.Win`/`Lose`, `ScratchOutcome.Win`/`Lose`), to `DuelService.AcceptOutcome.Win`, to `EconomyTradeService.TradeOutcome.Ok`, and to `TipService.TipOutcome.Ok`. `TipService` and the affected services now read `jackpotService.getPool(guildId)` once after the balance write.
- Surfaces the value through every per-game and per-action response DTO (`RollResponse`, `SpinResponse`, `FlipResponse`, `PlayResponse`, `ScratchResponse`, `DuelActionResponse`, `TradeResponse`, `TipResponse`).
- `static/js/casino-jackpot.js` now refreshes `.casino-jackpot-banner strong` from `body.jackpotPool` whenever a casino response is rendered (`renderWinHtml` / `lossTributeSuffix` both call the new `updatePoolBanner` helper). Standalone `TobyJackpot.updatePoolBanner` is exported for any future caller. The DOM write silently noops when the banner isn't on the page (so duel/trade/tip pages stay unaffected).
- All new fields default to `0L` / `null` so existing test fixtures that build outcome literals keep compiling without edits. Only `TipServiceTest` needed a tweak (one extra `mockk(relaxed = true)` constructor arg) because `TipService` gained a `JackpotService` dependency.
- `SocialCreditAwardService.award()`'s return type is **not** changed — that touched ~20 test files and the user-visible win is the same. Instead, `EconomyController` reads the pool out of the existing `TradeOutcome.Ok.jackpotPool` (which is already post-fee-deposit), which gives the same end result for the trade response.

## Test plan

- [x] `./gradlew :database:compileKotlin :database:compileTestKotlin :web:compileKotlin :web:compileTestKotlin` — green
- [x] `./gradlew :database:test :web:test` — green
- [ ] Manual: in a dev guild, play one round of each minigame and confirm the casino banner updates without a page reload, and that `body.jackpotPool` appears in the response JSON.
- [ ] Manual: trade buy + sell → confirm `TradeResponse.jackpotPool` reflects the post-fee total.
- [ ] Manual: accept a duel → confirm `DuelActionResponse.jackpotPool` reflects the post-tribute total.
- [ ] Manual: send a tip → confirm `TipResponse.jackpotPool` matches the (unchanged) pool.

> Note: the `:discord-bot` module could not be compiled in the sandbox because `moe.kyokobot.libdave` repos return 401/403 from this environment. All casino/duel/tip/trade outcome additions were appended with defaults so existing literal constructions in `discord-bot` tests (e.g. `DuelButtonTest`, `TipCommandTest`, `TobyCoinCommandTest`) compile unchanged.

https://claude.ai/code/session_015616EcoQxc75PwnqwpeKHw

---
_Generated by [Claude Code](https://claude.ai/code/session_015616EcoQxc75PwnqwpeKHw)_