### PR TITLE
perf(test): replace Thread.sleep + await with DeterministicScheduler (#365 step 2)

### DIFF
--- a/common/src/test/kotlin/common/testing/DeterministicScheduler.kt
+++ b/common/src/test/kotlin/common/testing/DeterministicScheduler.kt
@@ -1,0 +1,143 @@
+package common.testing
+
+import java.util.concurrent.Callable
+import java.util.concurrent.Delayed
+import java.util.concurrent.Future
+import java.util.concurrent.RejectedExecutionException
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Test-only [ScheduledExecutorService] that captures scheduled tasks but
+ * does not run them on a wall-clock timer. Tests advance work by calling
+ * [runPending], which fires every still-live task on the calling thread
+ * and clears the queue.
+ *
+ * Why this exists: the production schedulers in `NowPlayingManager`,
+ * `PokerTableRegistry`, and `PendingDuelRegistry` are normally a real
+ * `ScheduledThreadPoolExecutor`. The corresponding tests previously
+ * relied on `Thread.sleep` + `latch.await(2-3 sec)` to wait for the real
+ * scheduler to fire — that's slow (multiple seconds per file under
+ * normal load), and worse, becomes a deadlock under JUnit 5 in-JVM
+ * parallel execution because the executor thread can be starved by the
+ * concurrent runner. See the bug audit in #365.
+ *
+ * Cancelling a returned future removes the pending task so a subsequent
+ * [runPending] won't fire it. [shutdownNow] drains and returns any
+ * still-pending tasks (matching the production contract).
+ *
+ * Periodic tasks (`scheduleAtFixedRate`, `scheduleWithFixedDelay`) fire
+ * exactly once per [runPending] call, then must be re-scheduled by
+ * production code (none of our schedulers self-rearm, so this is a non-
+ * issue in practice). Tests that need multi-tick periodic behaviour can
+ * call [runPending] N times.
+ *
+ * Methods that aren't used by the production callers (`submit`,
+ * `invokeAll`, `invokeAny`, `Callable`-flavoured `schedule`) deliberately
+ * throw [UnsupportedOperationException] — if a future production change
+ * starts using them, the test will fail loudly rather than silently
+ * no-op.
+ */
+class DeterministicScheduler : ScheduledExecutorService {
+
+    private val pending = mutableListOf<PendingTask>()
+    private var shutdown = false
+
+    /**
+     * Runs every still-live pending task once on the calling thread, in
+     * the order they were scheduled. Tasks added during the run (e.g. a
+     * task that schedules another task) wait for the next [runPending]
+     * call so a self-rearming task doesn't infinite-loop the test.
+     */
+    fun runPending() {
+        val snapshot = pending.toList()
+        pending.clear()
+        for (task in snapshot) {
+            if (task.isLive()) task.command.run()
+        }
+    }
+
+    private inner class PendingTask(val command: Runnable) : ScheduledFuture<Any?> {
+        private val cancelled = AtomicBoolean(false)
+        fun isLive() = !cancelled.get()
+
+        override fun cancel(mayInterruptIfRunning: Boolean): Boolean {
+            cancelled.set(true)
+            pending.remove(this)
+            return true
+        }
+        override fun isCancelled() = cancelled.get()
+        override fun isDone() = cancelled.get()
+        override fun get(): Any? = null
+        override fun get(timeout: Long, unit: TimeUnit): Any? = null
+        override fun getDelay(unit: TimeUnit): Long = 0L
+        override fun compareTo(other: Delayed): Int = 0
+    }
+
+    override fun schedule(command: Runnable, delay: Long, unit: TimeUnit): ScheduledFuture<*> {
+        if (shutdown) throw RejectedExecutionException()
+        val task = PendingTask(command)
+        pending.add(task)
+        return task
+    }
+
+    override fun scheduleAtFixedRate(
+        command: Runnable, initialDelay: Long, period: Long, unit: TimeUnit
+    ): ScheduledFuture<*> {
+        if (shutdown) throw RejectedExecutionException()
+        val task = PendingTask(command)
+        pending.add(task)
+        return task
+    }
+
+    override fun scheduleWithFixedDelay(
+        command: Runnable, initialDelay: Long, delay: Long, unit: TimeUnit
+    ): ScheduledFuture<*> {
+        if (shutdown) throw RejectedExecutionException()
+        val task = PendingTask(command)
+        pending.add(task)
+        return task
+    }
+
+    override fun execute(command: Runnable) {
+        if (shutdown) throw RejectedExecutionException()
+        command.run()
+    }
+
+    override fun shutdown() { shutdown = true }
+
+    override fun shutdownNow(): MutableList<Runnable> {
+        shutdown = true
+        val drained = pending.map { it.command }.toMutableList()
+        pending.clear()
+        return drained
+    }
+
+    override fun isShutdown(): Boolean = shutdown
+    override fun isTerminated(): Boolean = shutdown
+    override fun awaitTermination(timeout: Long, unit: TimeUnit): Boolean = shutdown
+
+    override fun <V : Any?> schedule(callable: Callable<V>, delay: Long, unit: TimeUnit): ScheduledFuture<V> =
+        throw UnsupportedOperationException("Callable schedule() is not used by production callers")
+
+    override fun <T : Any?> submit(task: Callable<T>): Future<T> =
+        throw UnsupportedOperationException("submit is not used by production callers")
+    override fun <T : Any?> submit(task: Runnable, result: T): Future<T> =
+        throw UnsupportedOperationException("submit is not used by production callers")
+    override fun submit(task: Runnable): Future<*> =
+        throw UnsupportedOperationException("submit is not used by production callers")
+    override fun <T : Any?> invokeAll(tasks: MutableCollection<out Callable<T>>): MutableList<Future<T>> =
+        throw UnsupportedOperationException("invokeAll is not used by production callers")
+    override fun <T : Any?> invokeAll(
+        tasks: MutableCollection<out Callable<T>>, timeout: Long, unit: TimeUnit
+    ): MutableList<Future<T>> =
+        throw UnsupportedOperationException("invokeAll is not used by production callers")
+    override fun <T : Any?> invokeAny(tasks: MutableCollection<out Callable<T>>): T =
+        throw UnsupportedOperationException("invokeAny is not used by production callers")
+    override fun <T : Any?> invokeAny(
+        tasks: MutableCollection<out Callable<T>>, timeout: Long, unit: TimeUnit
+    ): T =
+        throw UnsupportedOperationException("invokeAny is not used by production callers")
+}

--- a/database/src/test/kotlin/database/duel/PendingDuelRegistryTest.kt
+++ b/database/src/test/kotlin/database/duel/PendingDuelRegistryTest.kt
@@ -1,24 +1,17 @@
 package database.duel
 
-import org.junit.jupiter.api.AfterEach
+import common.testing.DeterministicScheduler
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import java.time.Duration
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.Executors
-import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 
 class PendingDuelRegistryTest {
 
-    private val scheduler = Executors.newScheduledThreadPool(2)
-
-    @AfterEach
-    fun shutdown() {
-        scheduler.shutdownNow()
-    }
+    private val scheduler = DeterministicScheduler()
 
     private fun newRegistry(ttl: Duration = Duration.ofMillis(50)): PendingDuelRegistry =
         PendingDuelRegistry(ttl = ttl, scheduler = scheduler)
@@ -60,26 +53,28 @@ class PendingDuelRegistryTest {
     }
 
     @Test
-    fun `expiry callback fires after the configured ttl when offer still pending`() {
+    fun `expiry callback fires when the ttl task runs and offer is still pending`() {
         val registry = newRegistry(ttl = Duration.ofMillis(50))
-        val latch = CountDownLatch(1)
-        registry.register(1L, 10L, 20L, 50L) { _ -> latch.countDown() }
+        val fired = AtomicBoolean(false)
+        registry.register(1L, 10L, 20L, 50L) { _ -> fired.set(true) }
 
-        assertTrue(latch.await(2, TimeUnit.SECONDS), "timeout callback should fire within ttl + slack")
+        scheduler.runPending()
+
+        assertTrue(fired.get(), "timeout callback should fire when scheduler advances")
     }
 
     @Test
     fun `expiry is a no-op after consumeForAccept`() {
         val registry = newRegistry(ttl = Duration.ofMillis(50))
-        val callbackFired = java.util.concurrent.atomic.AtomicBoolean(false)
+        val callbackFired = AtomicBoolean(false)
         val offer = registry.register(1L, 10L, 20L, 50L) { _ -> callbackFired.set(true) }
 
-        // Consume immediately so the timer's later remove() returns null and skips the callback.
+        // Consume immediately — the still-pending timer task will run on the
+        // next scheduler advance, see the offer is already gone, and skip
+        // the callback.
         registry.consumeForAccept(offer.id)
-        Thread.sleep(150)
+        scheduler.runPending()
 
-        // Either the timer fired and saw a null offer (callback skipped), or it didn't fire yet.
-        // Either way, callback must not have fired.
         assertEquals(false, callbackFired.get(), "expiry callback must not run after consume")
     }
 

--- a/database/src/test/kotlin/database/poker/PokerTableRegistryShotClockTest.kt
+++ b/database/src/test/kotlin/database/poker/PokerTableRegistryShotClockTest.kt
@@ -1,16 +1,13 @@
 package database.poker
 
+import common.testing.DeterministicScheduler
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
-import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import java.time.Duration
 import java.time.Instant
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.Executors
-import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * Drives the per-table shot-clock plumbing in [PokerTableRegistry]
@@ -18,13 +15,19 @@ import java.util.concurrent.TimeUnit
  * path. The clock is a small piece of scheduler bookkeeping that
  * deserves coverage on its own — the production callback (auto-fold
  * via PokerService) is exercised separately by the service tests.
+ *
+ * Uses [DeterministicScheduler] so the tests don't sleep on a real
+ * wall clock waiting for the executor to fire — they advance work
+ * by calling [DeterministicScheduler.runPending].
  */
 class PokerTableRegistryShotClockTest {
+
+    private val scheduler = DeterministicScheduler()
 
     private fun newRegistry() = PokerTableRegistry(
         idleTtl = Duration.ofMinutes(10),
         sweepInterval = Duration.ofHours(1),
-        scheduler = Executors.newScheduledThreadPool(2)
+        scheduler = scheduler
     )
 
     private fun PokerTableRegistry.createTestTable(shotClockSeconds: Int = 30): PokerTable =
@@ -87,26 +90,25 @@ class PokerTableRegistryShotClockTest {
     @Test
     fun `clock fires onShotClockExpired when the actor doesn't act in time`() {
         val reg = newRegistry()
-        val fired = CountDownLatch(1)
-        var firedTable: PokerTable? = null
-        reg.setOnShotClockExpired { t -> firedTable = t; fired.countDown() }
+        val firedTable = AtomicReference<PokerTable?>(null)
+        reg.setOnShotClockExpired { t -> firedTable.set(t) }
 
         val table = reg.createTestTable(shotClockSeconds = 1)
         table.phase = PokerTable.Phase.PRE_FLOP
         table.handNumber = 1L
         reg.rearmShotClock(table.id)
 
-        val fired2sec = fired.await(3, TimeUnit.SECONDS)
-        assertTrue(fired2sec, "shot clock did not fire within 3s")
-        assertNotNull(firedTable)
-        assertEquals(table.id, firedTable!!.id)
+        scheduler.runPending()
+
+        assertNotNull(firedTable.get(), "shot clock did not fire")
+        assertEquals(table.id, firedTable.get()!!.id)
     }
 
     @Test
     fun `clock does NOT fire if the actor acted before the deadline`() {
         val reg = newRegistry()
-        val fired = CountDownLatch(1)
-        reg.setOnShotClockExpired { _ -> fired.countDown() }
+        val fireCount = java.util.concurrent.atomic.AtomicInteger(0)
+        reg.setOnShotClockExpired { _ -> fireCount.incrementAndGet() }
 
         val table = reg.createTestTable(shotClockSeconds = 1)
         table.phase = PokerTable.Phase.PRE_FLOP
@@ -114,8 +116,9 @@ class PokerTableRegistryShotClockTest {
         reg.rearmShotClock(table.id)
         reg.cancelShotClock(table.id)
 
-        val fired2sec = fired.await(2, TimeUnit.SECONDS)
-        assertFalse(fired2sec, "clock fired despite cancellation")
+        scheduler.runPending()
+
+        assertEquals(0, fireCount.get(), "clock fired despite cancellation")
     }
 
     @Test
@@ -125,8 +128,8 @@ class PokerTableRegistryShotClockTest {
         // The registry must detect the staleness and suppress the
         // callback rather than auto-folding the wrong actor.
         val reg = newRegistry()
-        var fireCount = 0
-        reg.setOnShotClockExpired { _ -> fireCount++ }
+        val fireCount = java.util.concurrent.atomic.AtomicInteger(0)
+        reg.setOnShotClockExpired { _ -> fireCount.incrementAndGet() }
 
         val table = reg.createTestTable(shotClockSeconds = 1)
         table.phase = PokerTable.Phase.PRE_FLOP
@@ -138,11 +141,9 @@ class PokerTableRegistryShotClockTest {
         // cancelling — the in-flight task should detect the change.
         table.actorIndex = 1
 
-        Thread.sleep(1500)
-        // Either the task no-ops (stale-detect path) OR has been
-        // cancelled — either way fireCount stays at 0 because the
-        // current actor is different.
-        assertEquals(0, fireCount, "stale fire was not suppressed (count=$fireCount)")
+        scheduler.runPending()
+
+        assertEquals(0, fireCount.get(), "stale fire was not suppressed (count=${fireCount.get()})")
     }
 
     @Test
@@ -150,10 +151,10 @@ class PokerTableRegistryShotClockTest {
         val reg = PokerTableRegistry(
             idleTtl = Duration.ofMillis(10),
             sweepInterval = Duration.ofHours(1),
-            scheduler = Executors.newScheduledThreadPool(2)
+            scheduler = scheduler
         )
-        val fired = CountDownLatch(1)
-        reg.setOnShotClockExpired { _ -> fired.countDown() }
+        val fireCount = java.util.concurrent.atomic.AtomicInteger(0)
+        reg.setOnShotClockExpired { _ -> fireCount.incrementAndGet() }
 
         val table = reg.create(
             guildId = 1L, hostDiscordId = 7L,
@@ -171,7 +172,8 @@ class PokerTableRegistryShotClockTest {
         // and should cancel the pending shot-clock task.
         reg.sweepIdle(Instant.now())
 
-        val firedAfterSweep = fired.await(2, TimeUnit.SECONDS)
-        assertFalse(firedAfterSweep, "shot clock fired for an evicted table")
+        scheduler.runPending()
+
+        assertEquals(0, fireCount.get(), "shot clock fired for an evicted table")
     }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/managers/NowPlayingManager.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/managers/NowPlayingManager.kt
@@ -13,12 +13,13 @@ import java.util.concurrent.locks.ReentrantReadWriteLock
 import kotlin.concurrent.read
 import kotlin.concurrent.write
 
-class NowPlayingManager {
+class NowPlayingManager(
+    private val scheduler: ScheduledExecutorService = Executors.newScheduledThreadPool(10),
+) {
     private val logger: DiscordLogger = DiscordLogger.createLogger(this::class.java)
     private val guildLastNowPlayingMessage = ConcurrentHashMap<Long, Message>()
     private val scheduledTasks = ConcurrentHashMap<Long, ScheduledFuture<*>>()
     private val lock = ReentrantReadWriteLock()
-    private val scheduler: ScheduledExecutorService = Executors.newScheduledThreadPool(10)
 
     fun setNowPlayingMessage(guildId: Long, message: Message) {
         lock.write {

--- a/discord-bot/src/test/kotlin/bot/toby/managers/NowPlayingManagerTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/managers/NowPlayingManagerTest.kt
@@ -3,6 +3,7 @@ package bot.toby.managers
 import com.sedmelluq.discord.lavaplayer.player.AudioPlayer
 import com.sedmelluq.discord.lavaplayer.track.AudioTrack
 import com.sedmelluq.discord.lavaplayer.track.AudioTrackInfo
+import common.testing.DeterministicScheduler
 import io.mockk.*
 import net.dv8tion.jda.api.entities.Message
 import net.dv8tion.jda.api.entities.MessageEmbed
@@ -17,12 +18,14 @@ import kotlin.concurrent.thread
 class NowPlayingManagerTest {
 
     private lateinit var nowPlayingManager: NowPlayingManager
+    private lateinit var scheduler: DeterministicScheduler
     private lateinit var mockMessage1: Message
     private lateinit var mockMessage2: Message
 
     @BeforeEach
     fun setUp() {
-        nowPlayingManager = NowPlayingManager()
+        scheduler = DeterministicScheduler()
+        nowPlayingManager = NowPlayingManager(scheduler = scheduler)
         mockMessage1 = mockk(relaxed = true)
         mockMessage2 = mockk(relaxed = true)
     }
@@ -185,11 +188,11 @@ class NowPlayingManagerTest {
         // When
         nowPlayingManager.scheduleNowPlayingUpdate(guildId, mockAudioTrack, mockAudioPlayer, delay, period)
 
-        // Sleep to allow the scheduled task to run
-        Thread.sleep(200)
+        // Advance the deterministic scheduler — fires the captured task once.
+        scheduler.runPending()
 
         // Then
-        coVerify(atLeast = 1) {
+        verify(exactly = 1) {
             mockMessage1.editMessageEmbeds(any<MessageEmbed>()).queue()
         }
     }
@@ -223,14 +226,13 @@ class NowPlayingManagerTest {
         nowPlayingManager.scheduleNowPlayingUpdate(guildId1, mockAudioTrack1, mockAudioPlayer1, delay, period)
         nowPlayingManager.scheduleNowPlayingUpdate(guildId2, mockAudioTrack2, mockAudioPlayer2, delay, period)
 
-        // Sleep to allow the scheduled task to run
-        Thread.sleep(200)
+        scheduler.runPending()
 
         // Then
-        coVerify(atLeast = 1) {
+        verify(exactly = 1) {
             mockMessage1.editMessageEmbeds(any<MessageEmbed>()).queue()
         }
-        coVerify(atLeast = 1) {
+        verify(exactly = 1) {
             mockMessage2.editMessageEmbeds(any<MessageEmbed>()).queue()
         }
     }
@@ -253,17 +255,17 @@ class NowPlayingManagerTest {
         nowPlayingManager.setNowPlayingMessage(guildId, mockMessage1)
         nowPlayingManager.scheduleNowPlayingUpdate(guildId, mockAudioTrack, mockAudioPlayer, delay, period)
 
-        // Sleep to allow the scheduled task to run
-        Thread.sleep(200)
+        // Run the scheduled task once before cancelling.
+        scheduler.runPending()
 
         // When
         nowPlayingManager.cancelScheduledTask(guildId)
 
-        // Sleep to allow any pending tasks to be cancelled
-        Thread.sleep(200)
+        // Any pending tasks left after cancellation must not fire.
+        scheduler.runPending()
 
         // Then
-        coVerify(atMost = 1) {
+        verify(exactly = 1) {
             mockMessage1.editMessageEmbeds(any<MessageEmbed>()).queue()
         }
     }
@@ -286,17 +288,15 @@ class NowPlayingManagerTest {
         nowPlayingManager.setNowPlayingMessage(guildId, mockMessage1)
         nowPlayingManager.scheduleNowPlayingUpdate(guildId, mockAudioTrack, mockAudioPlayer, delay, period)
 
-        // Sleep to allow the scheduled task to run
-        Thread.sleep(200)
+        scheduler.runPending()
 
         // When
         nowPlayingManager.resetNowPlayingMessage(guildId)
 
-        // Sleep to allow any pending tasks to be cancelled
-        Thread.sleep(200)
+        scheduler.runPending()
 
         // Then
-        coVerify(atMost = 1) {
+        verify(exactly = 1) {
             mockMessage1.editMessageEmbeds(any<MessageEmbed>()).queue()
         }
     }
@@ -328,20 +328,18 @@ class NowPlayingManagerTest {
         nowPlayingManager.scheduleNowPlayingUpdate(guildId1, mockAudioTrack1, mockAudioPlayer1, delay, period)
         nowPlayingManager.scheduleNowPlayingUpdate(guildId2, mockAudioTrack2, mockAudioPlayer2, delay, period)
 
-        // Sleep to allow the scheduled task to run
-        Thread.sleep(200)
+        scheduler.runPending()
 
         // When
         nowPlayingManager.clear()
 
-        // Sleep to allow any pending tasks to be cancelled
-        Thread.sleep(200)
+        scheduler.runPending()
 
         // Then
-        coVerify(atMost = 1) {
+        verify(exactly = 1) {
             mockMessage1.editMessageEmbeds(any<MessageEmbed>()).queue()
         }
-        coVerify(atMost = 1) {
+        verify(exactly = 1) {
             mockMessage2.editMessageEmbeds(any<MessageEmbed>()).queue()
         }
     }


### PR DESCRIPTION
## Summary

Step 2 of #365: replace wall-clock `Thread.sleep` / `latch.await(seconds, ...)`
in the three slowest test files with a deterministic test fake of
`ScheduledExecutorService`.

These three files were the slowest-per-method tests in the suite
because each relied on a real `ScheduledExecutorService` and waited on
the wall clock for the executor to fire:

| File | Old wall-clock waste |
|------|----------------------|
| `PendingDuelRegistryTest` | `Thread.sleep(150)` + `latch.await(2, SECONDS)` |
| `PokerTableRegistryShotClockTest` | `Thread.sleep(1500)` + 3× `latch.await(2-3, SECONDS)` |
| `NowPlayingManagerTest` | 8× `Thread.sleep(200)` (≥1.6s minimum) |

Beyond the seconds wasted on the happy path, this pattern was a
**deadlock hazard** under JUnit 5 in-JVM parallel: the executor thread
can be starved by the concurrent runner so `await` never returns.
That's exactly why step 3 of #365 (re-enable JUnit 5 parallel on
`:database`) was blocked.

## What changed

### New test utility — `common/src/test/kotlin/common/testing/DeterministicScheduler.kt`

A `ScheduledExecutorService` test fake that captures scheduled tasks
but does not run them on a wall-clock timer. Tests advance work by
calling `runPending()`, which fires every still-live captured task
once on the calling thread and clears the queue. Cancelling a
returned future removes its task from the queue. `shutdownNow()`
drains and returns any pending tasks (matching the production
contract).

Methods that aren't used by the production callers (`submit`,
`invokeAll`, `invokeAny`, `Callable`-flavoured `schedule`) deliberately
throw `UnsupportedOperationException` — a future production change
that starts using them will fail the test loudly rather than silently
no-op.

Both `:database` and `:discord-bot` already pull in `:common`
testArtifacts, so the new utility is reachable from both with no new
dependency wiring.

### Production change — `NowPlayingManager` constructor

Gains a `scheduler: ScheduledExecutorService` parameter defaulted to
the same `Executors.newScheduledThreadPool(10)` it used internally
before. The single production caller in `MusicPlayerHelper.kt:28`
(`NowPlayingManager()`) keeps working unchanged. `PokerTableRegistry`
and `PendingDuelRegistry` already exposed a `scheduler` parameter — no
production change needed there.

### Test rewrites

All three test files swap `Thread.sleep(...)` / `latch.await(seconds,
unit)` for `scheduler.runPending()`. Latches and `CountDownLatch`
imports are no longer needed.

## Local verification (`./gradlew :common:test :database:test`)

- `PendingDuelRegistryTest`: 8 tests in **24 ms** (was ~250 ms)
- `PokerTableRegistryShotClockTest`: 8 tests in **8 ms** (was ~3.5 s)
- Full `:database:test` suite: 377 tests, 0 failures
- `:common:test` (which loads the new `DeterministicScheduler` class): green

`:discord-bot:test` couldn't run in this sandbox (the
`moe.kyokobot.libdave` repo returns 403 here, same blocker as PR #358);
CI will validate `NowPlayingManagerTest`. The refactor mirrors the
database tests one-for-one — captured tasks → `runPending()` in place
of `Thread.sleep`.

## Test plan

- [ ] CI green on `Kotlin with Gradle`
- [ ] `:database:test` and `:discord-bot:test` durations both drop noticeably vs `main`
- [ ] No regression in test counts (377 in `:database:test`, ~639 in `:discord-bot:test`)

Refs #365. Unblocks step 3 (re-enabling JUnit 5 in-JVM parallel on `:database`).

https://claude.ai/code/session_01DTWCxi6KXH3nApS6mitBp4

---
_Generated by [Claude Code](https://claude.ai/code/session_01DTWCxi6KXH3nApS6mitBp4)_