### PR TITLE
perf(test): enable JUnit 5 in-JVM parallel execution on :database (#365 step 3)

### DIFF
--- a/database/build.gradle
+++ b/database/build.gradle
@@ -59,6 +59,14 @@ configurations {
 tasks.register('testJar', Jar) {
     archiveClassifier = 'tests'
     from sourceSets.test.output
+    // junit-platform.properties is module-local: it tells JUnit 5 to run
+    // THIS module's tests in parallel. Without this exclude, the file
+    // would land at the root of the test jar and `:application:test`,
+    // `:web:test`, `:discord-bot:test` would all pick it up off the
+    // classpath via testArtifacts and try to parallelize their own
+    // suites — which they're not safe for (Spring TestContext + Postgres
+    // in :application, mockkStatic in :discord-bot). See #365.
+    exclude 'junit-platform.properties'
 }
 
 artifacts {

--- a/database/src/test/kotlin/database/service/impl/DefaultUserServiceCacheTest.kt
+++ b/database/src/test/kotlin/database/service/impl/DefaultUserServiceCacheTest.kt
@@ -7,6 +7,8 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.cache.CacheManager
@@ -34,6 +36,11 @@ private const val CACHE_EVICTION_TEST_PROFILE = "cache-eviction-unit-test"
 @ContextConfiguration(classes = [DefaultUserServiceCacheTest.TestContext::class])
 @ActiveProfiles(CACHE_EVICTION_TEST_PROFILE)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+// Forced serial because @DirtiesContext rebuilds the Spring context after every
+// method. Letting JUnit 5 parallelize the methods would race two reset cycles
+// against each other (and against any other test class concurrently using the
+// shared CacheManager) — issue surfaced in the audit captured under #365.
+@Execution(ExecutionMode.SAME_THREAD)
 class DefaultUserServiceCacheTest {
 
     @Autowired

--- a/database/src/test/resources/junit-platform.properties
+++ b/database/src/test/resources/junit-platform.properties
@@ -1,0 +1,5 @@
+junit.jupiter.execution.parallel.enabled=true
+junit.jupiter.execution.parallel.mode.default=concurrent
+junit.jupiter.execution.parallel.mode.classes.default=concurrent
+junit.jupiter.execution.parallel.config.strategy=dynamic
+junit.jupiter.execution.parallel.config.dynamic.factor=1


### PR DESCRIPTION
## Summary

Step 3 of #365: enable JUnit 5 in-JVM parallel execution on the
`:database` test task.

When this was attempted as part of the original PR #358 audit it hung
indefinitely at the 18-minute mark. Root cause was the
`PokerTableRegistryShotClockTest` and `PendingDuelRegistryTest` files
using `latch.await(2-3, TimeUnit.SECONDS)` against a real
`ScheduledExecutorService` — under intra-JVM parallel, the executor
thread could be starved by the concurrent runner so the await never
returned. PR #374 replaced those waits with `DeterministicScheduler`,
removing the hazard.

This PR is the unblocker the audit promised: a single
`junit-platform.properties` file enables parallel-classes +
parallel-methods, dynamic strategy.

## Why this is safe now

1. The await/sleep tests are gone (#374).
2. None of the remaining 377 `:database` tests use `mockkStatic` or
   `mockkObject` — confirmed via
   `grep -rln "mockkStatic\|mockkObject" database/src/test`.
3. The one Spring-context test in the module
   (`DefaultUserServiceCacheTest`) uses
   `@DirtiesContext(AFTER_EACH_TEST_METHOD)`, which would race two
   context-rebuild cycles against each other under parallel methods.
   This PR adds `@Execution(ExecutionMode.SAME_THREAD)` on that one
   class to keep it serial without affecting the other 376 tests.

## Local verification

```
$ ./gradlew :database:test --rerun-tasks
BUILD SUCCESSFUL in 24s
```

- 377 tests, 0 failures, 0 errors.
- Sample test-class wall times stay sub-second; the win shows up in CI
  where the 377 tests genuinely overlap across the available cores
  rather than running strictly serially on one thread.

## Test plan

- [ ] CI green on `Kotlin with Gradle`
- [ ] `:database:test` task duration on this PR vs the most recent
      `main` run (look for ~30s reduction on a 4-core runner)

Refs #365.

https://claude.ai/code/session_01DTWCxi6KXH3nApS6mitBp4

---
_Generated by [Claude Code](https://claude.ai/code/session_01DTWCxi6KXH3nApS6mitBp4)_