### PR TITLE
fix(blackjack web): chip flourish + win/lose sound on every solo hand

### DIFF
--- a/web/src/main/resources/static/js/blackjack-solo.js
+++ b/web/src/main/resources/static/js/blackjack-solo.js
@@ -112,9 +112,13 @@
     var playerRowEl = document.getElementById("bj-player-row");
 
     var pollTimer = null;
-    // Tracks the handNumber of the last result we played the chip-stack
-    // flourish on, so the 2s polling doesn't re-trigger the animation.
-    var lastFlashedHand = null;
+    // Tracks the (tableId, handNumber) of the last result we played the
+    // chip-stack flourish on, so the 2s polling doesn't re-trigger the
+    // animation. tableId is part of the key because each solo hand spins
+    // up a fresh BlackjackTable with handNumber reset to 1 — keying on
+    // handNumber alone caused every hand after the first to be silently
+    // de-duped against the previous one.
+    var lastFlashedKey = null;
 
     function renderState(state) {
         if (!state) return;
@@ -183,8 +187,9 @@
         // survives JS Number's 53-bit precision; lookup keys match exactly.
         var seatResult = (r.seatResults || {})[seat.discordId];
         // Fire the celebratory chip stack once per hand on a winning result.
-        if (r.handNumber !== lastFlashedHand && window.CasinoRender) {
-            lastFlashedHand = r.handNumber;
+        var flashKey = state.tableId + ":" + r.handNumber;
+        if (flashKey !== lastFlashedKey && window.CasinoRender) {
+            lastFlashedKey = flashKey;
             var payout = (r.payouts || {})[seat.discordId];
             if (payout && payout > 0 && playerRowEl) {
                 window.CasinoRender.flashChipsOn(playerRowEl, payout);

--- a/web/src/main/resources/static/js/blackjack-solo.js
+++ b/web/src/main/resources/static/js/blackjack-solo.js
@@ -83,9 +83,26 @@
         return div;
     }
 
+    // Stateful dedup for the celebratory chip-stack flourish. The 1.5s
+    // poll fetches the resolved state repeatedly, so we need to fire the
+    // flourish once per hand. Keyed off (tableId, handNumber) — solo
+    // creates a fresh BlackjackTable per hand with handNumber reset to
+    // 1, so handNumber alone collides between sessions.
+    function createFlashDedup() {
+        var lastKey = null;
+        return function shouldFlash(state) {
+            if (!state || !state.lastResult) return false;
+            var key = state.tableId + ":" + state.lastResult.handNumber;
+            if (key === lastKey) return false;
+            lastKey = key;
+            return true;
+        };
+    }
+
     if (typeof window !== "undefined") {
         window.TobyBlackjackSolo = window.TobyBlackjackSolo || {};
         window.TobyBlackjackSolo.renderSplitHands = renderSplitHands;
+        window.TobyBlackjackSolo.createFlashDedup = createFlashDedup;
     }
 
     // ----- Page init. Bail out cleanly if we're loaded without the
@@ -112,13 +129,7 @@
     var playerRowEl = document.getElementById("bj-player-row");
 
     var pollTimer = null;
-    // Tracks the (tableId, handNumber) of the last result we played the
-    // chip-stack flourish on, so the 2s polling doesn't re-trigger the
-    // animation. tableId is part of the key because each solo hand spins
-    // up a fresh BlackjackTable with handNumber reset to 1 — keying on
-    // handNumber alone caused every hand after the first to be silently
-    // de-duped against the previous one.
-    var lastFlashedKey = null;
+    var shouldFlash = createFlashDedup();
 
     function renderState(state) {
         if (!state) return;
@@ -187,9 +198,7 @@
         // survives JS Number's 53-bit precision; lookup keys match exactly.
         var seatResult = (r.seatResults || {})[seat.discordId];
         // Fire the celebratory chip stack once per hand on a winning result.
-        var flashKey = state.tableId + ":" + r.handNumber;
-        if (flashKey !== lastFlashedKey && window.CasinoRender) {
-            lastFlashedKey = flashKey;
+        if (shouldFlash(state) && window.CasinoRender) {
             var payout = (r.payouts || {})[seat.discordId];
             if (payout && payout > 0 && playerRowEl) {
                 window.CasinoRender.flashChipsOn(playerRowEl, payout);

--- a/web/src/main/resources/static/js/blackjack-table.js
+++ b/web/src/main/resources/static/js/blackjack-table.js
@@ -29,9 +29,12 @@
     var pollTimer = null;
     var clockTimer = null;
     var deadlineMs = null;
-    // Tracks the handNumber of the last result we played the chip-stack
-    // flourish on, so the 2s polling doesn't re-trigger the animation.
-    var lastFlashedHand = null;
+    // Tracks the (tableId, handNumber) of the last result we played the
+    // chip-stack flourish on, so the 2s polling doesn't re-trigger the
+    // animation. Including tableId keeps us symmetric with the solo page
+    // (where handNumber resets per hand) and survives any future table
+    // reuse where handNumber alone could collide.
+    var lastFlashedKey = null;
 
     function renderCards(container, cards) {
         // Delegate to the shared renderer so the per-container deal animation
@@ -217,9 +220,10 @@
 
         // Fire the celebratory chip stack once per hand. The 2s polling
         // would otherwise re-trigger every cycle while the result is on
-        // screen, so we key off handNumber.
-        if (r.handNumber !== lastFlashedHand && window.CasinoRender) {
-            lastFlashedHand = r.handNumber;
+        // screen, so we key off (tableId, handNumber).
+        var flashKey = state.tableId + ":" + r.handNumber;
+        if (flashKey !== lastFlashedKey && window.CasinoRender) {
+            lastFlashedKey = flashKey;
             var myPaid = false;
             Object.keys(r.payouts || {}).forEach(function (id) {
                 var amount = r.payouts[id];

--- a/web/src/test/js/blackjack-flash-dedup.test.js
+++ b/web/src/test/js/blackjack-flash-dedup.test.js
@@ -1,0 +1,45 @@
+// Regression for the "celebratory chip flourish + win sound only fire on
+// the first solo hand of the session" bug. The dedup that prevents the
+// 1.5s poll loop from re-flashing the same hand used to key off
+// `lastResult.handNumber` alone, but every solo hand spins up a fresh
+// BlackjackTable with handNumber reset to 1 — so after the first win,
+// `lastFlashedHand = 1` blocked every subsequent solo hand silently.
+//
+// The fix keys the dedup on (tableId, handNumber). `createFlashDedup` is
+// the small DOM-agnostic factory that encodes the contract; it's exported
+// on `window.TobyBlackjackSolo` so this test can exercise it directly.
+require('../../main/resources/static/js/blackjack-solo');
+
+describe('TobyBlackjackSolo.createFlashDedup', () => {
+    test('fires once for a hand and dedups repeated polls of the same state', () => {
+        const shouldFlash = window.TobyBlackjackSolo.createFlashDedup();
+        const state = { tableId: 1, lastResult: { handNumber: 1 } };
+        expect(shouldFlash(state)).toBe(true);
+        expect(shouldFlash(state)).toBe(false);
+        expect(shouldFlash(state)).toBe(false);
+    });
+
+    test('fires again when tableId changes — solo hands all carry handNumber=1', () => {
+        // This is the regressed path: every new solo BlackjackTable starts
+        // at handNumber=1, so a handNumber-only dedup blocked every win
+        // after the first. tableId differs per hand and unblocks it.
+        const shouldFlash = window.TobyBlackjackSolo.createFlashDedup();
+        expect(shouldFlash({ tableId: 1, lastResult: { handNumber: 1 } })).toBe(true);
+        expect(shouldFlash({ tableId: 2, lastResult: { handNumber: 1 } })).toBe(true);
+        expect(shouldFlash({ tableId: 3, lastResult: { handNumber: 1 } })).toBe(true);
+    });
+
+    test('fires again when handNumber increments on a stable tableId (multi case)', () => {
+        const shouldFlash = window.TobyBlackjackSolo.createFlashDedup();
+        expect(shouldFlash({ tableId: 99, lastResult: { handNumber: 1 } })).toBe(true);
+        expect(shouldFlash({ tableId: 99, lastResult: { handNumber: 2 } })).toBe(true);
+        expect(shouldFlash({ tableId: 99, lastResult: { handNumber: 3 } })).toBe(true);
+    });
+
+    test('returns false when the state has no lastResult yet', () => {
+        const shouldFlash = window.TobyBlackjackSolo.createFlashDedup();
+        expect(shouldFlash({ tableId: 1, lastResult: null })).toBe(false);
+        expect(shouldFlash({ tableId: 1 })).toBe(false);
+        expect(shouldFlash(null)).toBe(false);
+    });
+});


### PR DESCRIPTION
## Summary

- The blackjack web UI's once-per-hand dedup for the celebratory chip-stack flourish (and the win/lose sound that fires alongside it) keyed off `lastResult.handNumber`. But `BlackjackService.dealSolo` creates a fresh `BlackjackTable` per solo hand and hardcodes `t.handNumber = 1L`, so every solo hand resolved with the same handNumber. After the first solo win the page-scoped `lastFlashedHand = 1` silently blocked the animation **and** the win/lose sound on every subsequent hand.
- Switch the dedup key to a `(tableId, handNumber)` composite. For solo, `tableId` changes each hand so the key is fresh. For multi, `tableId` stays but `handNumber` increments, so the key is still unique per hand. Same change applied symmetrically to `blackjack-table.js`.
- Pure client-side fix — no backend or schema changes.

## Test plan

- [x] `npx jest` in `web/` — all 16 suites / 208 tests pass
- [ ] Manual: open `/blackjack/{guildId}/solo`, win a hand → chip stack lands on `#bj-player-row`, win arpeggio plays
- [ ] Manual: deal a second hand and win again → flourish + win sound fire again (this is the regressed path)
- [ ] Manual: lose a hand → no chip stack but lose sound still plays each time
- [ ] Manual: open `/blackjack/{guildId}/{tableId}` and play multiple multi hands → flourish + sound still fire each hand (regression check)

https://claude.ai/code/session_01XbeU5DYBBBtwkDdAh5fF2k

---
_Generated by [Claude Code](https://claude.ai/code/session_01XbeU5DYBBBtwkDdAh5fF2k)_