### PR TITLE
fix(casino web): centralize jackpot-pool mirroring so blackjack updates too

### DIFF
--- a/database/src/main/kotlin/database/service/CoinflipService.kt
+++ b/database/src/main/kotlin/database/service/CoinflipService.kt
@@ -39,7 +39,6 @@ class CoinflipService(
             val jackpotPayout: Long = 0L,
             val soldTobyCoins: Long = 0L,
             val newPrice: Double? = null,
-            val jackpotPool: Long = 0L
         ) : FlipOutcome
 
         data class Lose(
@@ -50,7 +49,6 @@ class CoinflipService(
             val soldTobyCoins: Long = 0L,
             val newPrice: Double? = null,
             val lossTribute: Long = 0L,
-            val jackpotPool: Long = 0L
         ) : FlipOutcome
 
         data class InsufficientCredits(val stake: Long, val have: Long) : FlipOutcome
@@ -111,7 +109,6 @@ class CoinflipService(
                 jackpotPayout = jackpot,
                 soldTobyCoins = soldCoins,
                 newPrice = newPrice,
-                jackpotPool = jackpotService.getPool(guildId)
             )
         } else {
             val tribute = JackpotHelper.divertOnLoss(jackpotService, configService, guildId, stake)
@@ -123,7 +120,6 @@ class CoinflipService(
                 soldTobyCoins = soldCoins,
                 newPrice = newPrice,
                 lossTribute = tribute,
-                jackpotPool = jackpotService.getPool(guildId)
             )
         }
     }

--- a/database/src/main/kotlin/database/service/DiceService.kt
+++ b/database/src/main/kotlin/database/service/DiceService.kt
@@ -38,7 +38,6 @@ class DiceService(
             val jackpotPayout: Long = 0L,
             val soldTobyCoins: Long = 0L,
             val newPrice: Double? = null,
-            val jackpotPool: Long = 0L
         ) : RollOutcome
 
         data class Lose(
@@ -49,7 +48,6 @@ class DiceService(
             val soldTobyCoins: Long = 0L,
             val newPrice: Double? = null,
             val lossTribute: Long = 0L,
-            val jackpotPool: Long = 0L
         ) : RollOutcome
 
         data class InsufficientCredits(val stake: Long, val have: Long) : RollOutcome
@@ -114,7 +112,6 @@ class DiceService(
                 jackpotPayout = jackpot,
                 soldTobyCoins = soldCoins,
                 newPrice = newPrice,
-                jackpotPool = jackpotService.getPool(guildId)
             )
         } else {
             val tribute = JackpotHelper.divertOnLoss(jackpotService, configService, guildId, stake)
@@ -126,7 +123,6 @@ class DiceService(
                 soldTobyCoins = soldCoins,
                 newPrice = newPrice,
                 lossTribute = tribute,
-                jackpotPool = jackpotService.getPool(guildId)
             )
         }
     }

--- a/database/src/main/kotlin/database/service/DuelService.kt
+++ b/database/src/main/kotlin/database/service/DuelService.kt
@@ -63,7 +63,6 @@ class DuelService @Autowired constructor(
             val winnerNewBalance: Long,
             val loserNewBalance: Long,
             val lossTribute: Long,
-            val jackpotPool: Long = 0L
         ) : AcceptOutcome
 
         data class InitiatorInsufficient(val have: Long, val needed: Long) : AcceptOutcome
@@ -165,7 +164,6 @@ class DuelService @Autowired constructor(
             winnerNewBalance = winner.socialCredit ?: 0L,
             loserNewBalance = loser.socialCredit ?: 0L,
             lossTribute = tribute,
-            jackpotPool = jackpotService.getPool(guildId)
         )
     }
 

--- a/database/src/main/kotlin/database/service/EconomyTradeService.kt
+++ b/database/src/main/kotlin/database/service/EconomyTradeService.kt
@@ -57,7 +57,6 @@ class EconomyTradeService(
             // Fee skimmed off this trade and routed to the jackpot pool.
             // Defaulted so existing test fixtures keep compiling.
             val fee: Long = 0L,
-            val jackpotPool: Long = 0L
         ) : TradeOutcome
 
         data class InsufficientCredits(val needed: Long, val have: Long) : TradeOutcome
@@ -120,7 +119,6 @@ class EconomyTradeService(
             newCredits = user.socialCredit ?: 0L,
             newPrice = newPrice,
             fee = fee,
-            jackpotPool = jackpotService.getPool(guildId)
         )
     }
 
@@ -161,7 +159,6 @@ class EconomyTradeService(
             newCredits = user.socialCredit ?: 0L,
             newPrice = newPrice,
             fee = fee,
-            jackpotPool = jackpotService.getPool(guildId)
         )
     }
 

--- a/database/src/main/kotlin/database/service/HighlowService.kt
+++ b/database/src/main/kotlin/database/service/HighlowService.kt
@@ -46,7 +46,6 @@ class HighlowService(
             val jackpotPayout: Long = 0L,
             val soldTobyCoins: Long = 0L,
             val newPrice: Double? = null,
-            val jackpotPool: Long = 0L
         ) : PlayOutcome
 
         data class Lose(
@@ -58,7 +57,6 @@ class HighlowService(
             val soldTobyCoins: Long = 0L,
             val newPrice: Double? = null,
             val lossTribute: Long = 0L,
-            val jackpotPool: Long = 0L
         ) : PlayOutcome
 
         data class InsufficientCredits(val stake: Long, val have: Long) : PlayOutcome
@@ -154,7 +152,6 @@ class HighlowService(
                 jackpotPayout = jackpot,
                 soldTobyCoins = soldCoins,
                 newPrice = soldNewPrice,
-                jackpotPool = jackpotService.getPool(guildId)
             )
         } else {
             val tribute = JackpotHelper.divertOnLoss(jackpotService, configService, guildId, stake)
@@ -167,7 +164,6 @@ class HighlowService(
                 soldTobyCoins = soldCoins,
                 newPrice = soldNewPrice,
                 lossTribute = tribute,
-                jackpotPool = jackpotService.getPool(guildId)
             )
         }
     }

--- a/database/src/main/kotlin/database/service/ScratchService.kt
+++ b/database/src/main/kotlin/database/service/ScratchService.kt
@@ -37,7 +37,6 @@ class ScratchService(
             val jackpotPayout: Long = 0L,
             val soldTobyCoins: Long = 0L,
             val newPrice: Double? = null,
-            val jackpotPool: Long = 0L
         ) : ScratchOutcome
 
         data class Lose(
@@ -47,7 +46,6 @@ class ScratchService(
             val soldTobyCoins: Long = 0L,
             val newPrice: Double? = null,
             val lossTribute: Long = 0L,
-            val jackpotPool: Long = 0L
         ) : ScratchOutcome
 
         data class InsufficientCredits(val stake: Long, val have: Long) : ScratchOutcome
@@ -103,7 +101,6 @@ class ScratchService(
                 jackpotPayout = jackpot,
                 soldTobyCoins = soldCoins,
                 newPrice = newPrice,
-                jackpotPool = jackpotService.getPool(guildId)
             )
         } else {
             val tribute = JackpotHelper.divertOnLoss(jackpotService, configService, guildId, stake)
@@ -114,7 +111,6 @@ class ScratchService(
                 soldTobyCoins = soldCoins,
                 newPrice = newPrice,
                 lossTribute = tribute,
-                jackpotPool = jackpotService.getPool(guildId)
             )
         }
     }

--- a/database/src/main/kotlin/database/service/SlotsService.kt
+++ b/database/src/main/kotlin/database/service/SlotsService.kt
@@ -49,7 +49,6 @@ class SlotsService(
             val jackpotPayout: Long = 0L,
             val soldTobyCoins: Long = 0L,
             val newPrice: Double? = null,
-            val jackpotPool: Long = 0L
         ) : SpinOutcome
 
         data class Lose(
@@ -59,7 +58,6 @@ class SlotsService(
             val soldTobyCoins: Long = 0L,
             val newPrice: Double? = null,
             val lossTribute: Long = 0L,
-            val jackpotPool: Long = 0L
         ) : SpinOutcome
 
         data class InsufficientCredits(val stake: Long, val have: Long) : SpinOutcome
@@ -116,7 +114,6 @@ class SlotsService(
                 jackpotPayout = jackpot,
                 soldTobyCoins = soldCoins,
                 newPrice = newPrice,
-                jackpotPool = jackpotService.getPool(guildId)
             )
         } else {
             val tribute = JackpotHelper.divertOnLoss(jackpotService, configService, guildId, stake)
@@ -127,7 +124,6 @@ class SlotsService(
                 soldTobyCoins = soldCoins,
                 newPrice = newPrice,
                 lossTribute = tribute,
-                jackpotPool = jackpotService.getPool(guildId)
             )
         }
     }

--- a/database/src/main/kotlin/database/service/TipService.kt
+++ b/database/src/main/kotlin/database/service/TipService.kt
@@ -28,7 +28,6 @@ class TipService @Autowired constructor(
     private val userService: UserService,
     private val tipDailyService: TipDailyService,
     private val tipLogPersistence: TipLogPersistence,
-    private val jackpotService: JackpotService,
 ) {
     sealed interface TipOutcome {
         data class Ok(
@@ -40,7 +39,6 @@ class TipService @Autowired constructor(
             val recipientNewBalance: Long,
             val sentTodayAfter: Long,
             val dailyCap: Long,
-            val jackpotPool: Long = 0L
         ) : TipOutcome
 
         data class InvalidAmount(val min: Long, val max: Long) : TipOutcome
@@ -123,7 +121,6 @@ class TipService @Autowired constructor(
             recipientNewBalance = recipientBalance + amount,
             sentTodayAfter = newDailyTotal,
             dailyCap = dailyCap,
-            jackpotPool = jackpotService.getPool(guildId)
         )
     }
 

--- a/database/src/test/kotlin/database/service/TipServiceTest.kt
+++ b/database/src/test/kotlin/database/service/TipServiceTest.kt
@@ -4,7 +4,6 @@ import database.dto.TipDailyDto
 import database.dto.TipLogDto
 import database.dto.UserDto
 import database.persistence.TipLogPersistence
-import io.mockk.mockk
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
@@ -33,7 +32,7 @@ class TipServiceTest {
         userService = RecordingUserService()
         tipDailyService = InMemoryTipDailyService()
         tipLogPersistence = RecordingTipLogPersistence()
-        service = TipService(userService, tipDailyService, tipLogPersistence, mockk(relaxed = true))
+        service = TipService(userService, tipDailyService, tipLogPersistence)
     }
 
     @Test

--- a/web/src/main/kotlin/web/casino/JackpotPoolHeaderAdvice.kt
+++ b/web/src/main/kotlin/web/casino/JackpotPoolHeaderAdvice.kt
@@ -1,0 +1,60 @@
+package web.casino
+
+import database.service.JackpotService
+import org.springframework.core.MethodParameter
+import org.springframework.http.MediaType
+import org.springframework.http.converter.HttpMessageConverter
+import org.springframework.http.server.ServerHttpRequest
+import org.springframework.http.server.ServerHttpResponse
+import org.springframework.http.server.ServletServerHttpRequest
+import org.springframework.web.bind.annotation.ControllerAdvice
+import org.springframework.web.servlet.HandlerMapping
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice
+
+/**
+ * Stamps the post-action per-guild jackpot pool size onto every
+ * [CasinoResponseLike] JSON response as the `X-Jackpot-Pool` header. The
+ * client-side [api.js] wrapper reads the header and refreshes the banner via
+ * [TobyJackpot.updatePoolBanner], so games never have to thread the value
+ * through their service outcome → controller arm → DTO themselves.
+ *
+ * The advice keys off [CasinoResponseLike] (the existing marker interface for
+ * the casino JSON envelope) and the `{guildId}` path variable that every
+ * casino route already declares.
+ */
+@ControllerAdvice
+class JackpotPoolHeaderAdvice(
+    private val jackpotService: JackpotService,
+) : ResponseBodyAdvice<CasinoResponseLike> {
+
+    override fun supports(
+        returnType: MethodParameter,
+        converterType: Class<out HttpMessageConverter<*>>,
+    ): Boolean = CasinoResponseLike::class.java.isAssignableFrom(returnType.parameterType)
+
+    override fun beforeBodyWrite(
+        body: CasinoResponseLike?,
+        returnType: MethodParameter,
+        selectedContentType: MediaType,
+        selectedConverterType: Class<out HttpMessageConverter<*>>,
+        request: ServerHttpRequest,
+        response: ServerHttpResponse,
+    ): CasinoResponseLike? {
+        val guildId = guildIdFrom(request) ?: return body
+        val pool = runCatching { jackpotService.getPool(guildId) }.getOrNull() ?: return body
+        response.headers.set(HEADER, pool.toString())
+        return body
+    }
+
+    private fun guildIdFrom(request: ServerHttpRequest): Long? {
+        val servlet = request as? ServletServerHttpRequest ?: return null
+        @Suppress("UNCHECKED_CAST")
+        val vars = servlet.servletRequest
+            .getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE) as? Map<String, String>
+        return vars?.get("guildId")?.toLongOrNull()
+    }
+
+    companion object {
+        const val HEADER = "X-Jackpot-Pool"
+    }
+}

--- a/web/src/main/kotlin/web/controller/CoinflipController.kt
+++ b/web/src/main/kotlin/web/controller/CoinflipController.kt
@@ -84,7 +84,6 @@ class CoinflipController(
                     jackpotPayout = outcome.jackpotPayout.takeIf { it > 0L },
                     soldTobyCoins = outcome.soldTobyCoins.takeIf { it > 0L },
                     newPrice = outcome.newPrice,
-                    jackpotPool = outcome.jackpotPool
                 )
             )
 
@@ -100,7 +99,6 @@ class CoinflipController(
                     soldTobyCoins = outcome.soldTobyCoins.takeIf { it > 0L },
                     newPrice = outcome.newPrice,
                     lossTribute = outcome.lossTribute.takeIf { it > 0L },
-                    jackpotPool = outcome.jackpotPool
                 )
             )
 
@@ -133,5 +131,4 @@ data class FlipResponse(
     val soldTobyCoins: Long? = null,
     val newPrice: Double? = null,
     val lossTribute: Long? = null,
-    val jackpotPool: Long? = null
 ) : CasinoResponseLike

--- a/web/src/main/kotlin/web/controller/DiceController.kt
+++ b/web/src/main/kotlin/web/controller/DiceController.kt
@@ -80,7 +80,6 @@ class DiceController(
                     jackpotPayout = outcome.jackpotPayout.takeIf { it > 0L },
                     soldTobyCoins = outcome.soldTobyCoins.takeIf { it > 0L },
                     newPrice = outcome.newPrice,
-                    jackpotPool = outcome.jackpotPool
                 )
             )
 
@@ -96,7 +95,6 @@ class DiceController(
                     soldTobyCoins = outcome.soldTobyCoins.takeIf { it > 0L },
                     newPrice = outcome.newPrice,
                     lossTribute = outcome.lossTribute.takeIf { it > 0L },
-                    jackpotPool = outcome.jackpotPool
                 )
             )
 
@@ -126,5 +124,4 @@ data class RollResponse(
     val soldTobyCoins: Long? = null,
     val newPrice: Double? = null,
     val lossTribute: Long? = null,
-    val jackpotPool: Long? = null
 ) : CasinoResponseLike

--- a/web/src/main/kotlin/web/controller/DuelController.kt
+++ b/web/src/main/kotlin/web/controller/DuelController.kt
@@ -212,7 +212,6 @@ class DuelController(
                     winnerNewBalance = outcome.winnerNewBalance,
                     loserNewBalance = outcome.loserNewBalance,
                     lossTribute = outcome.lossTribute,
-                    jackpotPool = outcome.jackpotPool
                 )
             )
             is AcceptOutcome.InitiatorInsufficient -> ResponseEntity.badRequest().body(
@@ -314,5 +313,4 @@ data class DuelActionResponse(
     val winnerNewBalance: Long? = null,
     val loserNewBalance: Long? = null,
     val lossTribute: Long? = null,
-    val jackpotPool: Long? = null
 )

--- a/web/src/main/kotlin/web/controller/EconomyController.kt
+++ b/web/src/main/kotlin/web/controller/EconomyController.kt
@@ -147,7 +147,6 @@ class EconomyController(
                         newPrice = outcome.newPrice,
                         transactedCredits = outcome.transactedCredits,
                         fee = outcome.fee,
-                        jackpotPool = outcome.jackpotPool
                     )
                 )
             }
@@ -177,7 +176,6 @@ data class TradeResponse(
     val newPrice: Double? = null,
     val transactedCredits: Long? = null,
     val fee: Long? = null,
-    val jackpotPool: Long? = null
 )
 
 data class HistoryResponse(

--- a/web/src/main/kotlin/web/controller/HighlowController.kt
+++ b/web/src/main/kotlin/web/controller/HighlowController.kt
@@ -144,7 +144,6 @@ class HighlowController(
                     jackpotPayout = outcome.jackpotPayout.takeIf { it > 0L },
                     soldTobyCoins = outcome.soldTobyCoins.takeIf { it > 0L },
                     newPrice = outcome.newPrice,
-                    jackpotPool = outcome.jackpotPool
                 )
             )
 
@@ -161,7 +160,6 @@ class HighlowController(
                     soldTobyCoins = outcome.soldTobyCoins.takeIf { it > 0L },
                     newPrice = outcome.newPrice,
                     lossTribute = outcome.lossTribute.takeIf { it > 0L },
-                    jackpotPool = outcome.jackpotPool
                 )
             )
 
@@ -246,5 +244,4 @@ data class PlayResponse(
     val soldTobyCoins: Long? = null,
     val newPrice: Double? = null,
     val lossTribute: Long? = null,
-    val jackpotPool: Long? = null
 ) : CasinoResponseLike

--- a/web/src/main/kotlin/web/controller/ScratchController.kt
+++ b/web/src/main/kotlin/web/controller/ScratchController.kt
@@ -91,7 +91,6 @@ class ScratchController(
                     jackpotPayout = outcome.jackpotPayout.takeIf { it > 0L },
                     soldTobyCoins = outcome.soldTobyCoins.takeIf { it > 0L },
                     newPrice = outcome.newPrice,
-                    jackpotPool = outcome.jackpotPool
                 )
             )
 
@@ -106,7 +105,6 @@ class ScratchController(
                     soldTobyCoins = outcome.soldTobyCoins.takeIf { it > 0L },
                     newPrice = outcome.newPrice,
                     lossTribute = outcome.lossTribute.takeIf { it > 0L },
-                    jackpotPool = outcome.jackpotPool
                 )
             )
 
@@ -136,5 +134,4 @@ data class ScratchResponse(
     val soldTobyCoins: Long? = null,
     val newPrice: Double? = null,
     val lossTribute: Long? = null,
-    val jackpotPool: Long? = null
 ) : CasinoResponseLike

--- a/web/src/main/kotlin/web/controller/SlotsController.kt
+++ b/web/src/main/kotlin/web/controller/SlotsController.kt
@@ -81,7 +81,6 @@ class SlotsController(
                     jackpotPayout = outcome.jackpotPayout.takeIf { it > 0L },
                     soldTobyCoins = outcome.soldTobyCoins.takeIf { it > 0L },
                     newPrice = outcome.newPrice,
-                    jackpotPool = outcome.jackpotPool
                 )
             )
 
@@ -97,7 +96,6 @@ class SlotsController(
                     soldTobyCoins = outcome.soldTobyCoins.takeIf { it > 0L },
                     newPrice = outcome.newPrice,
                     lossTribute = outcome.lossTribute.takeIf { it > 0L },
-                    jackpotPool = outcome.jackpotPool
                 )
             )
 
@@ -138,7 +136,6 @@ data class SpinResponse(
     val soldTobyCoins: Long? = null,
     val newPrice: Double? = null,
     val lossTribute: Long? = null,
-    val jackpotPool: Long? = null
 ) : CasinoResponseLike
 
 data class PayoutRow(val symbols: String, val multiplier: String)

--- a/web/src/main/kotlin/web/controller/TipController.kt
+++ b/web/src/main/kotlin/web/controller/TipController.kt
@@ -145,7 +145,6 @@ class TipController(
                         dailyCap = outcome.dailyCap,
                         amount = outcome.amount,
                         note = outcome.note,
-                        jackpotPool = outcome.jackpotPool
                     )
                 )
             }
@@ -193,5 +192,4 @@ data class TipResponse(
     val recipientNewBalance: Long? = null,
     val sentTodayAfter: Long? = null,
     val dailyCap: Long? = null,
-    val jackpotPool: Long? = null
 )

--- a/web/src/main/resources/static/js/api.js
+++ b/web/src/main/resources/static/js/api.js
@@ -25,6 +25,17 @@
             headers: headers,
             body: JSON.stringify(body)
         }).then(function (r) {
+            // Centralised jackpot-pool banner refresh: every casino response
+            // carries the post-action pool size in X-Jackpot-Pool. Pages
+            // without the banner (duel/trade/tip) silently no-op inside
+            // updatePoolBanner.
+            const poolHeader = r.headers.get('X-Jackpot-Pool');
+            if (poolHeader != null && window.TobyJackpot) {
+                const pool = Number(poolHeader);
+                if (!Number.isNaN(pool)) {
+                    window.TobyJackpot.updatePoolBanner({ jackpotPool: pool });
+                }
+            }
             return r.json().catch(function () {
                 return { ok: r.ok, error: r.ok ? null : 'Request failed.' };
             });

--- a/web/src/main/resources/static/js/casino-jackpot.js
+++ b/web/src/main/resources/static/js/casino-jackpot.js
@@ -17,10 +17,11 @@
 
     /**
      * Refresh the per-guild jackpot pool banner (`fragments/casino.html`)
-     * from a `body.jackpotPool` field on any balance-mutating response —
-     * casino spins, duels, trades, tips. Noop when the field is absent
-     * or the banner isn't on the current page (so duel/trade/tip pages
-     * silently skip the DOM write).
+     * from a `body.jackpotPool` value. Called centrally by api.js after
+     * every casino POST, fed from the X-Jackpot-Pool response header — so
+     * games never have to remember to mirror the pool themselves. No-ops
+     * when the field is absent or the banner isn't on the current page (so
+     * duel/trade/tip pages silently skip the DOM write).
      */
     function updatePoolBanner(body) {
         if (!body || typeof body.jackpotPool !== 'number') return;
@@ -37,7 +38,6 @@
      *   element.innerHTML = renderWinHtml(resEl, body, 'slots-result-jackpot', winLine)
      */
     function renderWinHtml(resultEl, body, jackpotClassName, winLineHtml) {
-        updatePoolBanner(body);
         if (!isJackpotHit(body)) return winLineHtml;
         if (resultEl && jackpotClassName) resultEl.classList.add(jackpotClassName);
         return jackpotPrefixHtml(body.jackpotPayout) + winLineHtml;
@@ -49,7 +49,6 @@
      * (e.g. tiny stake floored to zero, or admin set tribute to 0 %).
      */
     function lossTributeSuffix(body) {
-        updatePoolBanner(body);
         if (!body || typeof body.lossTribute !== 'number' || body.lossTribute <= 0) return '';
         return ' &middot; <span class="casino-loss-tribute">+' +
             body.lossTribute + ' to jackpot</span>';

--- a/web/src/test/kotlin/web/casino/JackpotPoolHeaderAdviceTest.kt
+++ b/web/src/test/kotlin/web/casino/JackpotPoolHeaderAdviceTest.kt
@@ -1,0 +1,141 @@
+package web.casino
+
+import database.service.JackpotService
+import io.mockk.every
+import io.mockk.mockk
+import jakarta.servlet.http.HttpServletRequest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.core.MethodParameter
+import org.springframework.http.MediaType
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter
+import org.springframework.http.server.ServerHttpResponse
+import org.springframework.http.server.ServletServerHttpRequest
+import org.springframework.http.server.ServletServerHttpResponse
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpServletResponse
+import org.springframework.web.servlet.HandlerMapping
+
+
+/**
+ * Replaces the per-game jackpotPool body wiring that used to live in
+ * eight services and eight controllers. One advice means one place to
+ * test — every CasinoResponseLike response carries the post-action
+ * pool size in the X-Jackpot-Pool header, and the JS reads it from
+ * api.js. Adding a new minigame can no longer regress the banner.
+ */
+class JackpotPoolHeaderAdviceTest {
+
+    private val guildId = 42L
+    private lateinit var jackpotService: JackpotService
+    private lateinit var advice: JackpotPoolHeaderAdvice
+
+    @BeforeEach
+    fun setUp() {
+        jackpotService = mockk()
+        advice = JackpotPoolHeaderAdvice(jackpotService)
+    }
+
+    @Test
+    fun `supports returns true for CasinoResponseLike return types`() {
+        val param = methodParameterReturning(SampleResponse::class.java)
+        assertTrue(advice.supports(param, MappingJackson2HttpMessageConverter::class.java))
+    }
+
+    @Test
+    fun `supports returns false for non-CasinoResponseLike return types`() {
+        val param = methodParameterReturning(String::class.java)
+        assertFalse(advice.supports(param, MappingJackson2HttpMessageConverter::class.java))
+    }
+
+    @Test
+    fun `beforeBodyWrite stamps X-Jackpot-Pool header from JackpotService when guildId path var is present`() {
+        every { jackpotService.getPool(guildId) } returns 9_999L
+        val (request, response) = exchangeWithGuildId(guildId.toString())
+        val body = SampleResponse(ok = true)
+
+        val returned = advice.beforeBodyWrite(
+            body = body,
+            returnType = methodParameterReturning(SampleResponse::class.java),
+            selectedContentType = MediaType.APPLICATION_JSON,
+            selectedConverterType = MappingJackson2HttpMessageConverter::class.java,
+            request = request,
+            response = response,
+        )
+
+        assertEquals(body, returned)
+        assertEquals("9999", response.headers.getFirst(JackpotPoolHeaderAdvice.HEADER))
+    }
+
+    @Test
+    fun `beforeBodyWrite skips header when guildId path var is missing`() {
+        val (request, response) = exchangeWithVars(emptyMap())
+        advice.beforeBodyWrite(
+            body = SampleResponse(ok = true),
+            returnType = methodParameterReturning(SampleResponse::class.java),
+            selectedContentType = MediaType.APPLICATION_JSON,
+            selectedConverterType = MappingJackson2HttpMessageConverter::class.java,
+            request = request,
+            response = response,
+        )
+        assertNull(response.headers.getFirst(JackpotPoolHeaderAdvice.HEADER))
+    }
+
+    @Test
+    fun `beforeBodyWrite skips header when guildId path var is non-numeric`() {
+        val (request, response) = exchangeWithGuildId("not-a-long")
+        advice.beforeBodyWrite(
+            body = SampleResponse(ok = true),
+            returnType = methodParameterReturning(SampleResponse::class.java),
+            selectedContentType = MediaType.APPLICATION_JSON,
+            selectedConverterType = MappingJackson2HttpMessageConverter::class.java,
+            request = request,
+            response = response,
+        )
+        assertNull(response.headers.getFirst(JackpotPoolHeaderAdvice.HEADER))
+    }
+
+    @Test
+    fun `beforeBodyWrite returns body unchanged and skips header if JackpotService throws`() {
+        every { jackpotService.getPool(guildId) } throws RuntimeException("db down")
+        val (request, response) = exchangeWithGuildId(guildId.toString())
+        val body = SampleResponse(ok = true)
+
+        val returned = advice.beforeBodyWrite(
+            body = body,
+            returnType = methodParameterReturning(SampleResponse::class.java),
+            selectedContentType = MediaType.APPLICATION_JSON,
+            selectedConverterType = MappingJackson2HttpMessageConverter::class.java,
+            request = request,
+            response = response,
+        )
+
+        assertEquals(body, returned)
+        assertNull(response.headers.getFirst(JackpotPoolHeaderAdvice.HEADER))
+    }
+
+    private data class SampleResponse(
+        override val ok: Boolean,
+        override val error: String? = null,
+    ) : CasinoResponseLike
+
+    private fun methodParameterReturning(type: Class<*>): MethodParameter {
+        val param = mockk<MethodParameter>()
+        every { param.parameterType } returns type
+        return param
+    }
+
+    private fun exchangeWithGuildId(guildIdValue: String): Pair<ServletServerHttpRequest, ServerHttpResponse> =
+        exchangeWithVars(mapOf("guildId" to guildIdValue))
+
+    private fun exchangeWithVars(vars: Map<String, String>): Pair<ServletServerHttpRequest, ServerHttpResponse> {
+        val mockRequest: HttpServletRequest = MockHttpServletRequest().apply {
+            setAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE, vars)
+        }
+        return ServletServerHttpRequest(mockRequest) to ServletServerHttpResponse(MockHttpServletResponse())
+    }
+}


### PR DESCRIPTION
## Summary

PR #373 wired the post-action jackpot pool through every casino service + controller individually and missed blackjack, leaving the banner stale on every blackjack page. The duplication was the real bug — ~50 lines of identical wiring with no shared seam means any new minigame can silently regress the banner.

This PR replaces the per-game body field with a single `ResponseBodyAdvice` (`JackpotPoolHeaderAdvice`) keyed off the existing `CasinoResponseLike` marker and the `{guildId}` path variable every casino route already declares. The advice stamps `X-Jackpot-Pool` on every casino response; `api.js` reads the header inside the shared `TobyApi.postJson` wrapper and calls `TobyJackpot.updatePoolBanner`. Blackjack inherits the behaviour for free — its DTO already implements `CasinoResponseLike` — and all eight per-game outcome / DTO / controller pairs lose their `jackpotPool` plumbing.

Future minigames pick up the banner refresh automatically just by implementing `CasinoResponseLike` on a `{guildId}`-scoped route.

### Why this approach over patching blackjack alone

Per-game patching would have been a smaller diff but would have left the same brittle pattern in place — the next new minigame, or the next service rollout that forgets one game, would silently break the banner again. Centralising the mirror in one advice removes the bug class entirely.

### Files of interest

- New: `web/src/main/kotlin/web/casino/JackpotPoolHeaderAdvice.kt` — the central seam.
- New: `web/src/test/kotlin/web/casino/JackpotPoolHeaderAdviceTest.kt` — covers `supports()`, header-stamp, missing/non-numeric guildId, and JackpotService failure (silent).
- Edited: `web/src/main/resources/static/js/api.js` — reads `X-Jackpot-Pool`, calls `TobyJackpot.updatePoolBanner`.
- Edited: `web/src/main/resources/static/js/casino-jackpot.js` — drops the in-helper `updatePoolBanner(body)` calls (api.js is now the single trigger).
- Deleted: `jackpotPool` field + wiring across 8 services and 8 controller response DTOs (Coinflip, Dice, Duel, EconomyTrade, Highlow, Scratch, Slots, Tip).
- `TipService` no longer needs `JackpotService` — constructor parameter removed (test fixture updated).

## Test plan

- [x] `./gradlew :database:test :web:test` — all pass (310 tests). New `JackpotPoolHeaderAdviceTest` covers the central mechanism.
- [ ] Browser: open `/blackjack/{guildId}/solo`, deal a hand, confirm the banner number updates without a page reload and that the response carries `X-Jackpot-Pool` (DevTools → Network).
- [ ] Browser: same on `/blackjack/{guildId}/{tableId}` (multi-table).
- [ ] Browser smoke on a previously-working page (`/casino/{guildId}/slots`) — banner still updates.
- [ ] Browser smoke on a non-banner page (`/duel/{guildId}`) — header still sent, JS no-ops, no console errors.

https://claude.ai/code/session_019jHTezkFG6pwjT323c6QJv

---
_Generated by [Claude Code](https://claude.ai/code/session_019jHTezkFG6pwjT323c6QJv)_