### PR TITLE
feat(casino): add /baccarat (Punto Banco) minigame

### DIFF
--- a/application/src/test/kotlin/integration/bot/ButtonManagerTest.kt
+++ b/application/src/test/kotlin/integration/bot/ButtonManagerTest.kt
@@ -70,6 +70,7 @@ class ButtonManagerTest {
     @Test
     fun testButtonManagerFindsAllButtons() {
         val availableButtons = listOf(
+            BaccaratButton::class.java,
             BlackjackButton::class.java,
             DuelButton::class.java,
             HighlowButton::class.java,
@@ -84,7 +85,7 @@ class ButtonManagerTest {
         )
 
         assertTrue(availableButtons.containsAll(buttonManager.buttons.map { it.javaClass }.toList()))
-        assertEquals(11, buttonManager.buttons.size)
+        assertEquals(12, buttonManager.buttons.size)
     }
 
     @Test

--- a/application/src/test/kotlin/integration/bot/CommandManagerTest.kt
+++ b/application/src/test/kotlin/integration/bot/CommandManagerTest.kt
@@ -9,6 +9,7 @@ import bot.toby.command.commands.dnd.InitiativeCommand
 import bot.toby.command.commands.dnd.LinkCharacterCommand
 import bot.toby.command.commands.dnd.RefreshCharacterCommand
 import bot.toby.command.commands.dnd.RollCommand
+import bot.toby.command.commands.economy.BaccaratCommand
 import bot.toby.command.commands.economy.BlackjackCommand
 import bot.toby.command.commands.economy.CoinflipCommand
 import bot.toby.command.commands.economy.DiceCommand
@@ -146,12 +147,13 @@ class CommandManagerTest {
             TipCommand::class.java,
             DuelCommand::class.java,
             PokerCommand::class.java,
-            BlackjackCommand::class.java
+            BlackjackCommand::class.java,
+            BaccaratCommand::class.java
         )
 
         Assertions.assertTrue(availableCommands.containsAll(commandManager.allCommands.map { it.javaClass }.toList()))
-        Assertions.assertEquals(55, commandManager.allCommands.size)
-        Assertions.assertEquals(55, commandManager.allSlashCommands.size)
+        Assertions.assertEquals(56, commandManager.allCommands.size)
+        Assertions.assertEquals(56, commandManager.allSlashCommands.size)
     }
 
     @Test

--- a/database/src/main/kotlin/database/economy/Baccarat.kt
+++ b/database/src/main/kotlin/database/economy/Baccarat.kt
@@ -1,0 +1,163 @@
+package database.economy
+
+import database.card.Card
+import database.card.Deck
+import database.card.Rank
+
+/**
+ * Pure-logic Punto Banco baccarat. No Spring, no DB, no JDA — deals two
+ * hands from a [Deck], follows the standard third-card "tableau" to
+ * complete each side, and resolves the player's side bet to a payout
+ * multiplier.
+ *
+ * Mechanic
+ *   The player picks one of three sides before the deal: PLAYER, BANKER,
+ *   or TIE. Card values are pip values with all tens and faces counted as
+ *   zero (A=1, 2-9=face, 10/J/Q/K=0); a hand's total is the sum mod 10.
+ *
+ *   Naturals: if either side has 8 or 9 after the first two cards, both
+ *   stand and the higher total wins (tie pushes the side bet, pays Tie).
+ *
+ *   Otherwise, the Player draws a third card on totals 0-5 and stands on
+ *   6-7. The Banker's draw rule depends on whether the Player drew, and
+ *   if so on the value of the Player's third card (the standard Punto
+ *   Banco tableau in [shouldBankerDraw]). Both sides take at most one
+ *   extra card.
+ *
+ *   Payouts on a winning side bet:
+ *     - PLAYER:  1:1            (multiplier 2.0)
+ *     - BANKER:  1:1 minus 5%   (multiplier 1.95)
+ *     - TIE:     8:1            (multiplier 9.0)
+ *   On a tied game, PLAYER and BANKER side bets push (multiplier 1.0).
+ *   Any non-winning side returns 0.0. Per-bet house edge sits between
+ *   /coinflip and /slots: ~1.24% on Player, ~1.06% on Banker, ~14.4% on
+ *   Tie at this schedule.
+ */
+class Baccarat {
+
+    enum class Side(val display: String) {
+        PLAYER("Player"),
+        BANKER("Banker"),
+        TIE("Tie")
+    }
+
+    data class Hand(
+        val side: Side,
+        val winner: Side,
+        val playerCards: List<Card>,
+        val bankerCards: List<Card>,
+        val playerTotal: Int,
+        val bankerTotal: Int,
+        val isPlayerNatural: Boolean,
+        val isBankerNatural: Boolean,
+        val multiplier: Double
+    ) {
+        val isWin: Boolean get() = multiplier > 1.0
+        val isPush: Boolean get() = multiplier == 1.0
+        val isLose: Boolean get() = multiplier == 0.0
+    }
+
+    /**
+     * Deal both hands from [deck] and resolve [side]. The deck is mutated
+     * — callers should pass a freshly seeded [Deck] per hand. Six cards
+     * worst-case (two each plus an optional third per side), which leaves
+     * the 52-card deck nowhere near exhaustion.
+     */
+    fun play(side: Side, deck: Deck): Hand {
+        val player = mutableListOf(deck.deal(), deck.deal())
+        val banker = mutableListOf(deck.deal(), deck.deal())
+
+        val pTotal0 = handTotal(player)
+        val bTotal0 = handTotal(banker)
+        val playerNatural = pTotal0 >= 8
+        val bankerNatural = bTotal0 >= 8
+
+        if (!playerNatural && !bankerNatural) {
+            val playerThird: Card? = if (pTotal0 <= 5) deck.deal().also { player.add(it) } else null
+            if (shouldBankerDraw(handTotal(banker), playerThird)) {
+                banker.add(deck.deal())
+            }
+        }
+
+        val pTotal = handTotal(player)
+        val bTotal = handTotal(banker)
+        val winner = when {
+            pTotal > bTotal -> Side.PLAYER
+            bTotal > pTotal -> Side.BANKER
+            else -> Side.TIE
+        }
+
+        return Hand(
+            side = side,
+            winner = winner,
+            playerCards = player.toList(),
+            bankerCards = banker.toList(),
+            playerTotal = pTotal,
+            bankerTotal = bTotal,
+            isPlayerNatural = playerNatural,
+            isBankerNatural = bankerNatural,
+            multiplier = multiplier(side, winner)
+        )
+    }
+
+    /**
+     * Punto Banco banker tableau. With no Player third card, Banker mirrors
+     * the Player's stand-on-six rule. With a Player third card, the table
+     * lookup below decides per Banker total.
+     */
+    private fun shouldBankerDraw(bankerTotal: Int, playerThird: Card?): Boolean {
+        if (bankerTotal >= 7) return false
+        if (playerThird == null) return bankerTotal <= 5
+        val p = playerThird.baccaratValue()
+        return when (bankerTotal) {
+            0, 1, 2 -> true
+            3 -> p != 8
+            4 -> p in 2..7
+            5 -> p in 4..7
+            6 -> p in 6..7
+            else -> false
+        }
+    }
+
+    /** Resolve the side bet given which side actually won. */
+    fun multiplier(side: Side, winner: Side): Double {
+        if (winner == Side.TIE && side != Side.TIE) return PUSH_MULT
+        if (side != winner) return LOSS_MULT
+        return previewMultiplier(side)
+    }
+
+    /** Per-side payout multiplier for embed labels and button previews. */
+    fun previewMultiplier(side: Side): Double = when (side) {
+        Side.PLAYER -> PLAYER_WIN_MULT
+        Side.BANKER -> BANKER_WIN_MULT
+        Side.TIE -> TIE_WIN_MULT
+    }
+
+    companion object {
+        const val MIN_STAKE: Long = 10L
+        const val MAX_STAKE: Long = 500L
+
+        const val PLAYER_WIN_MULT: Double = 2.0
+        const val BANKER_WIN_MULT: Double = 1.95
+        const val TIE_WIN_MULT: Double = 9.0
+        const val PUSH_MULT: Double = 1.0
+        const val LOSS_MULT: Double = 0.0
+    }
+}
+
+/** Pip value used by baccarat: A=1, 2-9=face, 10/J/Q/K=0. */
+internal fun Card.baccaratValue(): Int = when (rank) {
+    Rank.ACE -> 1
+    Rank.TWO -> 2
+    Rank.THREE -> 3
+    Rank.FOUR -> 4
+    Rank.FIVE -> 5
+    Rank.SIX -> 6
+    Rank.SEVEN -> 7
+    Rank.EIGHT -> 8
+    Rank.NINE -> 9
+    Rank.TEN, Rank.JACK, Rank.QUEEN, Rank.KING -> 0
+}
+
+/** Hand total: sum of pip values mod 10. */
+internal fun handTotal(cards: List<Card>): Int = cards.sumOf { it.baccaratValue() } % 10

--- a/database/src/main/kotlin/database/service/BaccaratService.kt
+++ b/database/src/main/kotlin/database/service/BaccaratService.kt
@@ -102,39 +102,21 @@ class BaccaratService(
         side: Baccarat.Side,
         autoTopUp: Boolean = false
     ): PlayOutcome {
-        val initial = WagerHelper.checkAndLock(
-            userService, discordId, guildId, stake, Baccarat.MIN_STAKE, Baccarat.MAX_STAKE
-        )
-        var soldCoins = 0L
-        var soldNewPrice: Double? = null
-        val resolved = when (initial) {
-            is BalanceCheck.InvalidStake -> return PlayOutcome.InvalidStake(initial.min, initial.max)
-            BalanceCheck.UnknownUser -> return PlayOutcome.UnknownUser
-            is BalanceCheck.Insufficient -> {
-                if (!autoTopUp) return PlayOutcome.InsufficientCredits(initial.stake, initial.have)
-                val user = userService.getUserByIdForUpdate(discordId, guildId)
-                    ?: return PlayOutcome.UnknownUser
-                val topUp = CasinoTopUpHelper.ensureCreditsForWager(
-                    tradeService, marketService, userService,
-                    user, guildId, currentBalance = initial.have, stake = stake
-                )
-                when (topUp) {
-                    is TopUpResult.InsufficientCoins ->
-                        return PlayOutcome.InsufficientCoinsForTopUp(topUp.needed, topUp.have)
-                    TopUpResult.MarketUnavailable ->
-                        return PlayOutcome.InsufficientCredits(initial.stake, initial.have)
-                    is TopUpResult.ToppedUp -> {
-                        soldCoins = topUp.soldCoins
-                        soldNewPrice = topUp.newPrice
-                        BalanceCheck.Ok(topUp.user, topUp.balance)
-                    }
-                }
-            }
-            is BalanceCheck.Ok -> initial
+        val resolved = when (val r = WagerHelper.checkLockOrTopUp(
+            userService, tradeService, marketService,
+            discordId, guildId, stake, Baccarat.MIN_STAKE, Baccarat.MAX_STAKE, autoTopUp
+        )) {
+            is TopUpResolution.InvalidStake -> return PlayOutcome.InvalidStake(r.min, r.max)
+            TopUpResolution.UnknownUser -> return PlayOutcome.UnknownUser
+            is TopUpResolution.StillInsufficientCredits ->
+                return PlayOutcome.InsufficientCredits(r.stake, r.have)
+            is TopUpResolution.InsufficientCoinsForTopUp ->
+                return PlayOutcome.InsufficientCoinsForTopUp(r.needed, r.have)
+            is TopUpResolution.Ok -> r
         }
 
         val hand = baccarat.play(side, Deck(random))
-        val r = WagerHelper.applyMultiplier(userService, resolved.user, resolved.balance, stake, hand.multiplier)
+        val wager = WagerHelper.applyMultiplier(userService, resolved.user, resolved.balance, stake, hand.multiplier)
         return when {
             hand.isWin -> {
                 val jackpot = JackpotHelper.rollOnWin(
@@ -142,8 +124,8 @@ class BaccaratService(
                 )
                 PlayOutcome.Win(
                     stake = stake,
-                    payout = r.payout,
-                    net = r.net,
+                    payout = wager.payout,
+                    net = wager.net,
                     side = side,
                     winner = hand.winner,
                     playerCards = hand.playerCards,
@@ -153,10 +135,10 @@ class BaccaratService(
                     isPlayerNatural = hand.isPlayerNatural,
                     isBankerNatural = hand.isBankerNatural,
                     multiplier = hand.multiplier,
-                    newBalance = r.newBalance + jackpot,
+                    newBalance = wager.newBalance + jackpot,
                     jackpotPayout = jackpot,
-                    soldTobyCoins = soldCoins,
-                    newPrice = soldNewPrice
+                    soldTobyCoins = resolved.soldCoins,
+                    newPrice = resolved.newPrice
                 )
             }
             hand.isPush -> PlayOutcome.Push(
@@ -168,9 +150,9 @@ class BaccaratService(
                 bankerTotal = hand.bankerTotal,
                 isPlayerNatural = hand.isPlayerNatural,
                 isBankerNatural = hand.isBankerNatural,
-                newBalance = r.newBalance,
-                soldTobyCoins = soldCoins,
-                newPrice = soldNewPrice
+                newBalance = wager.newBalance,
+                soldTobyCoins = resolved.soldCoins,
+                newPrice = resolved.newPrice
             )
             else -> {
                 val tribute = JackpotHelper.divertOnLoss(jackpotService, configService, guildId, stake)
@@ -184,9 +166,9 @@ class BaccaratService(
                     bankerTotal = hand.bankerTotal,
                     isPlayerNatural = hand.isPlayerNatural,
                     isBankerNatural = hand.isBankerNatural,
-                    newBalance = r.newBalance,
-                    soldTobyCoins = soldCoins,
-                    newPrice = soldNewPrice,
+                    newBalance = wager.newBalance,
+                    soldTobyCoins = resolved.soldCoins,
+                    newPrice = resolved.newPrice,
                     lossTribute = tribute
                 )
             }

--- a/database/src/main/kotlin/database/service/BaccaratService.kt
+++ b/database/src/main/kotlin/database/service/BaccaratService.kt
@@ -1,0 +1,195 @@
+package database.service
+
+import database.card.Card
+import database.card.Deck
+import database.economy.Baccarat
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import kotlin.random.Random
+
+/**
+ * Atomic play path for the `/baccarat` minigame. Same lock-then-mutate
+ * pattern as the other card-flavoured wager service ([HighlowService])
+ * via [UserService.getUserByIdForUpdate]:
+ *   - validate stake against [Baccarat.MIN_STAKE]..[Baccarat.MAX_STAKE]
+ *   - lock the user row
+ *   - confirm balance ≥ stake (optionally sell TOBY for the shortfall
+ *     via [CasinoTopUpHelper] when [autoTopUp] is set)
+ *   - deal both hands from a fresh [Deck] and resolve the side bet
+ *   - apply the resulting fractional multiplier through
+ *     [WagerHelper.applyMultiplier]
+ *   - feed [JackpotHelper] on win/loss (push is jackpot-neutral — the
+ *     stake is refunded so there's nothing to roll on or tribute)
+ */
+@Service
+@Transactional
+class BaccaratService(
+    private val userService: UserService,
+    private val jackpotService: JackpotService,
+    private val tradeService: EconomyTradeService,
+    private val marketService: TobyCoinMarketService,
+    private val configService: ConfigService,
+    private val baccarat: Baccarat = Baccarat(),
+    private val random: Random = Random.Default
+) {
+
+    sealed interface PlayOutcome {
+        data class Win(
+            val stake: Long,
+            val payout: Long,
+            val net: Long,
+            val side: Baccarat.Side,
+            val winner: Baccarat.Side,
+            val playerCards: List<Card>,
+            val bankerCards: List<Card>,
+            val playerTotal: Int,
+            val bankerTotal: Int,
+            val isPlayerNatural: Boolean,
+            val isBankerNatural: Boolean,
+            val multiplier: Double,
+            val newBalance: Long,
+            val jackpotPayout: Long = 0L,
+            val soldTobyCoins: Long = 0L,
+            val newPrice: Double? = null
+        ) : PlayOutcome
+
+        data class Push(
+            val stake: Long,
+            val side: Baccarat.Side,
+            val playerCards: List<Card>,
+            val bankerCards: List<Card>,
+            val playerTotal: Int,
+            val bankerTotal: Int,
+            val isPlayerNatural: Boolean,
+            val isBankerNatural: Boolean,
+            val newBalance: Long,
+            val soldTobyCoins: Long = 0L,
+            val newPrice: Double? = null
+        ) : PlayOutcome
+
+        data class Lose(
+            val stake: Long,
+            val side: Baccarat.Side,
+            val winner: Baccarat.Side,
+            val playerCards: List<Card>,
+            val bankerCards: List<Card>,
+            val playerTotal: Int,
+            val bankerTotal: Int,
+            val isPlayerNatural: Boolean,
+            val isBankerNatural: Boolean,
+            val newBalance: Long,
+            val soldTobyCoins: Long = 0L,
+            val newPrice: Double? = null,
+            val lossTribute: Long = 0L
+        ) : PlayOutcome
+
+        data class InsufficientCredits(val stake: Long, val have: Long) : PlayOutcome
+        data class InsufficientCoinsForTopUp(val needed: Long, val have: Long) : PlayOutcome
+        data class InvalidStake(val min: Long, val max: Long) : PlayOutcome
+        data object UnknownUser : PlayOutcome
+    }
+
+    /**
+     * Per-side payout multiplier used by the prompt embed and button
+     * labels so the player sees what each side pays before committing.
+     */
+    fun previewMultiplier(side: Baccarat.Side): Double = baccarat.previewMultiplier(side)
+
+    fun play(
+        discordId: Long,
+        guildId: Long,
+        stake: Long,
+        side: Baccarat.Side,
+        autoTopUp: Boolean = false
+    ): PlayOutcome {
+        val initial = WagerHelper.checkAndLock(
+            userService, discordId, guildId, stake, Baccarat.MIN_STAKE, Baccarat.MAX_STAKE
+        )
+        var soldCoins = 0L
+        var soldNewPrice: Double? = null
+        val resolved = when (initial) {
+            is BalanceCheck.InvalidStake -> return PlayOutcome.InvalidStake(initial.min, initial.max)
+            BalanceCheck.UnknownUser -> return PlayOutcome.UnknownUser
+            is BalanceCheck.Insufficient -> {
+                if (!autoTopUp) return PlayOutcome.InsufficientCredits(initial.stake, initial.have)
+                val user = userService.getUserByIdForUpdate(discordId, guildId)
+                    ?: return PlayOutcome.UnknownUser
+                val topUp = CasinoTopUpHelper.ensureCreditsForWager(
+                    tradeService, marketService, userService,
+                    user, guildId, currentBalance = initial.have, stake = stake
+                )
+                when (topUp) {
+                    is TopUpResult.InsufficientCoins ->
+                        return PlayOutcome.InsufficientCoinsForTopUp(topUp.needed, topUp.have)
+                    TopUpResult.MarketUnavailable ->
+                        return PlayOutcome.InsufficientCredits(initial.stake, initial.have)
+                    is TopUpResult.ToppedUp -> {
+                        soldCoins = topUp.soldCoins
+                        soldNewPrice = topUp.newPrice
+                        BalanceCheck.Ok(topUp.user, topUp.balance)
+                    }
+                }
+            }
+            is BalanceCheck.Ok -> initial
+        }
+
+        val hand = baccarat.play(side, Deck(random))
+        val r = WagerHelper.applyMultiplier(userService, resolved.user, resolved.balance, stake, hand.multiplier)
+        return when {
+            hand.isWin -> {
+                val jackpot = JackpotHelper.rollOnWin(
+                    jackpotService, configService, userService, resolved.user, guildId, random
+                )
+                PlayOutcome.Win(
+                    stake = stake,
+                    payout = r.payout,
+                    net = r.net,
+                    side = side,
+                    winner = hand.winner,
+                    playerCards = hand.playerCards,
+                    bankerCards = hand.bankerCards,
+                    playerTotal = hand.playerTotal,
+                    bankerTotal = hand.bankerTotal,
+                    isPlayerNatural = hand.isPlayerNatural,
+                    isBankerNatural = hand.isBankerNatural,
+                    multiplier = hand.multiplier,
+                    newBalance = r.newBalance + jackpot,
+                    jackpotPayout = jackpot,
+                    soldTobyCoins = soldCoins,
+                    newPrice = soldNewPrice
+                )
+            }
+            hand.isPush -> PlayOutcome.Push(
+                stake = stake,
+                side = side,
+                playerCards = hand.playerCards,
+                bankerCards = hand.bankerCards,
+                playerTotal = hand.playerTotal,
+                bankerTotal = hand.bankerTotal,
+                isPlayerNatural = hand.isPlayerNatural,
+                isBankerNatural = hand.isBankerNatural,
+                newBalance = r.newBalance,
+                soldTobyCoins = soldCoins,
+                newPrice = soldNewPrice
+            )
+            else -> {
+                val tribute = JackpotHelper.divertOnLoss(jackpotService, configService, guildId, stake)
+                PlayOutcome.Lose(
+                    stake = stake,
+                    side = side,
+                    winner = hand.winner,
+                    playerCards = hand.playerCards,
+                    bankerCards = hand.bankerCards,
+                    playerTotal = hand.playerTotal,
+                    bankerTotal = hand.bankerTotal,
+                    isPlayerNatural = hand.isPlayerNatural,
+                    isBankerNatural = hand.isBankerNatural,
+                    newBalance = r.newBalance,
+                    soldTobyCoins = soldCoins,
+                    newPrice = soldNewPrice,
+                    lossTribute = tribute
+                )
+            }
+        }
+    }
+}

--- a/database/src/main/kotlin/database/service/CoinflipService.kt
+++ b/database/src/main/kotlin/database/service/CoinflipService.kt
@@ -64,51 +64,33 @@ class CoinflipService(
         predicted: Coinflip.Side,
         autoTopUp: Boolean = false
     ): FlipOutcome {
-        val initial = WagerHelper.checkAndLock(
-            userService, discordId, guildId, stake, Coinflip.MIN_STAKE, Coinflip.MAX_STAKE
-        )
-        var soldCoins = 0L
-        var newPrice: Double? = null
-        val resolved = when (initial) {
-            is BalanceCheck.InvalidStake -> return FlipOutcome.InvalidStake(initial.min, initial.max)
-            BalanceCheck.UnknownUser -> return FlipOutcome.UnknownUser
-            is BalanceCheck.Insufficient -> {
-                if (!autoTopUp) return FlipOutcome.InsufficientCredits(initial.stake, initial.have)
-                val user = userService.getUserByIdForUpdate(discordId, guildId)
-                    ?: return FlipOutcome.UnknownUser
-                val topUp = CasinoTopUpHelper.ensureCreditsForWager(
-                    tradeService, marketService, userService,
-                    user, guildId, currentBalance = initial.have, stake = stake
-                )
-                when (topUp) {
-                    is TopUpResult.InsufficientCoins ->
-                        return FlipOutcome.InsufficientCoinsForTopUp(topUp.needed, topUp.have)
-                    TopUpResult.MarketUnavailable ->
-                        return FlipOutcome.InsufficientCredits(initial.stake, initial.have)
-                    is TopUpResult.ToppedUp -> {
-                        soldCoins = topUp.soldCoins
-                        newPrice = topUp.newPrice
-                        BalanceCheck.Ok(topUp.user, topUp.balance)
-                    }
-                }
-            }
-            is BalanceCheck.Ok -> initial
+        val resolved = when (val r = WagerHelper.checkLockOrTopUp(
+            userService, tradeService, marketService,
+            discordId, guildId, stake, Coinflip.MIN_STAKE, Coinflip.MAX_STAKE, autoTopUp
+        )) {
+            is TopUpResolution.InvalidStake -> return FlipOutcome.InvalidStake(r.min, r.max)
+            TopUpResolution.UnknownUser -> return FlipOutcome.UnknownUser
+            is TopUpResolution.StillInsufficientCredits ->
+                return FlipOutcome.InsufficientCredits(r.stake, r.have)
+            is TopUpResolution.InsufficientCoinsForTopUp ->
+                return FlipOutcome.InsufficientCoinsForTopUp(r.needed, r.have)
+            is TopUpResolution.Ok -> r
         }
 
         val flip = coinflip.flip(predicted, random)
-        val r = WagerHelper.applyMultiplier(userService, resolved.user, resolved.balance, stake, flip.multiplier)
+        val wager = WagerHelper.applyMultiplier(userService, resolved.user, resolved.balance, stake, flip.multiplier)
         return if (flip.isWin) {
             val jackpot = JackpotHelper.rollOnWin(jackpotService, configService, userService, resolved.user, guildId, random)
             FlipOutcome.Win(
                 stake = stake,
-                payout = r.payout,
-                net = r.net,
+                payout = wager.payout,
+                net = wager.net,
                 landed = flip.landed,
                 predicted = flip.predicted,
-                newBalance = r.newBalance + jackpot,
+                newBalance = wager.newBalance + jackpot,
                 jackpotPayout = jackpot,
-                soldTobyCoins = soldCoins,
-                newPrice = newPrice,
+                soldTobyCoins = resolved.soldCoins,
+                newPrice = resolved.newPrice,
             )
         } else {
             val tribute = JackpotHelper.divertOnLoss(jackpotService, configService, guildId, stake)
@@ -116,9 +98,9 @@ class CoinflipService(
                 stake = stake,
                 landed = flip.landed,
                 predicted = flip.predicted,
-                newBalance = r.newBalance,
-                soldTobyCoins = soldCoins,
-                newPrice = newPrice,
+                newBalance = wager.newBalance,
+                soldTobyCoins = resolved.soldCoins,
+                newPrice = resolved.newPrice,
                 lossTribute = tribute,
             )
         }

--- a/database/src/main/kotlin/database/service/DiceService.kt
+++ b/database/src/main/kotlin/database/service/DiceService.kt
@@ -67,51 +67,33 @@ class DiceService(
         if (!dice.isValidPrediction(predicted)) {
             return RollOutcome.InvalidPrediction(1, dice.sidesCount)
         }
-        val initial = WagerHelper.checkAndLock(
-            userService, discordId, guildId, stake, Dice.MIN_STAKE, Dice.MAX_STAKE
-        )
-        var soldCoins = 0L
-        var newPrice: Double? = null
-        val resolved = when (initial) {
-            is BalanceCheck.InvalidStake -> return RollOutcome.InvalidStake(initial.min, initial.max)
-            BalanceCheck.UnknownUser -> return RollOutcome.UnknownUser
-            is BalanceCheck.Insufficient -> {
-                if (!autoTopUp) return RollOutcome.InsufficientCredits(initial.stake, initial.have)
-                val user = userService.getUserByIdForUpdate(discordId, guildId)
-                    ?: return RollOutcome.UnknownUser
-                val topUp = CasinoTopUpHelper.ensureCreditsForWager(
-                    tradeService, marketService, userService,
-                    user, guildId, currentBalance = initial.have, stake = stake
-                )
-                when (topUp) {
-                    is TopUpResult.InsufficientCoins ->
-                        return RollOutcome.InsufficientCoinsForTopUp(topUp.needed, topUp.have)
-                    TopUpResult.MarketUnavailable ->
-                        return RollOutcome.InsufficientCredits(initial.stake, initial.have)
-                    is TopUpResult.ToppedUp -> {
-                        soldCoins = topUp.soldCoins
-                        newPrice = topUp.newPrice
-                        BalanceCheck.Ok(topUp.user, topUp.balance)
-                    }
-                }
-            }
-            is BalanceCheck.Ok -> initial
+        val resolved = when (val r = WagerHelper.checkLockOrTopUp(
+            userService, tradeService, marketService,
+            discordId, guildId, stake, Dice.MIN_STAKE, Dice.MAX_STAKE, autoTopUp
+        )) {
+            is TopUpResolution.InvalidStake -> return RollOutcome.InvalidStake(r.min, r.max)
+            TopUpResolution.UnknownUser -> return RollOutcome.UnknownUser
+            is TopUpResolution.StillInsufficientCredits ->
+                return RollOutcome.InsufficientCredits(r.stake, r.have)
+            is TopUpResolution.InsufficientCoinsForTopUp ->
+                return RollOutcome.InsufficientCoinsForTopUp(r.needed, r.have)
+            is TopUpResolution.Ok -> r
         }
 
         val roll = dice.roll(predicted, random)
-        val r = WagerHelper.applyMultiplier(userService, resolved.user, resolved.balance, stake, roll.multiplier)
+        val wager = WagerHelper.applyMultiplier(userService, resolved.user, resolved.balance, stake, roll.multiplier)
         return if (roll.isWin) {
             val jackpot = JackpotHelper.rollOnWin(jackpotService, configService, userService, resolved.user, guildId, random)
             RollOutcome.Win(
                 stake = stake,
-                payout = r.payout,
-                net = r.net,
+                payout = wager.payout,
+                net = wager.net,
                 landed = roll.landed,
                 predicted = roll.predicted,
-                newBalance = r.newBalance + jackpot,
+                newBalance = wager.newBalance + jackpot,
                 jackpotPayout = jackpot,
-                soldTobyCoins = soldCoins,
-                newPrice = newPrice,
+                soldTobyCoins = resolved.soldCoins,
+                newPrice = resolved.newPrice,
             )
         } else {
             val tribute = JackpotHelper.divertOnLoss(jackpotService, configService, guildId, stake)
@@ -119,9 +101,9 @@ class DiceService(
                 stake = stake,
                 landed = roll.landed,
                 predicted = roll.predicted,
-                newBalance = r.newBalance,
-                soldTobyCoins = soldCoins,
-                newPrice = newPrice,
+                newBalance = wager.newBalance,
+                soldTobyCoins = resolved.soldCoins,
+                newPrice = resolved.newPrice,
                 lossTribute = tribute,
             )
         }

--- a/database/src/main/kotlin/database/service/HighlowService.kt
+++ b/database/src/main/kotlin/database/service/HighlowService.kt
@@ -101,35 +101,17 @@ class HighlowService(
         anchor: Int?,
         autoTopUp: Boolean
     ): PlayOutcome {
-        val initial = WagerHelper.checkAndLock(
-            userService, discordId, guildId, stake, Highlow.MIN_STAKE, Highlow.MAX_STAKE
-        )
-        var soldCoins = 0L
-        var soldNewPrice: Double? = null
-        val resolved = when (initial) {
-            is BalanceCheck.InvalidStake -> return PlayOutcome.InvalidStake(initial.min, initial.max)
-            BalanceCheck.UnknownUser -> return PlayOutcome.UnknownUser
-            is BalanceCheck.Insufficient -> {
-                if (!autoTopUp) return PlayOutcome.InsufficientCredits(initial.stake, initial.have)
-                val user = userService.getUserByIdForUpdate(discordId, guildId)
-                    ?: return PlayOutcome.UnknownUser
-                val topUp = CasinoTopUpHelper.ensureCreditsForWager(
-                    tradeService, marketService, userService,
-                    user, guildId, currentBalance = initial.have, stake = stake
-                )
-                when (topUp) {
-                    is TopUpResult.InsufficientCoins ->
-                        return PlayOutcome.InsufficientCoinsForTopUp(topUp.needed, topUp.have)
-                    TopUpResult.MarketUnavailable ->
-                        return PlayOutcome.InsufficientCredits(initial.stake, initial.have)
-                    is TopUpResult.ToppedUp -> {
-                        soldCoins = topUp.soldCoins
-                        soldNewPrice = topUp.newPrice
-                        BalanceCheck.Ok(topUp.user, topUp.balance)
-                    }
-                }
-            }
-            is BalanceCheck.Ok -> initial
+        val resolved = when (val r = WagerHelper.checkLockOrTopUp(
+            userService, tradeService, marketService,
+            discordId, guildId, stake, Highlow.MIN_STAKE, Highlow.MAX_STAKE, autoTopUp
+        )) {
+            is TopUpResolution.InvalidStake -> return PlayOutcome.InvalidStake(r.min, r.max)
+            TopUpResolution.UnknownUser -> return PlayOutcome.UnknownUser
+            is TopUpResolution.StillInsufficientCredits ->
+                return PlayOutcome.InsufficientCredits(r.stake, r.have)
+            is TopUpResolution.InsufficientCoinsForTopUp ->
+                return PlayOutcome.InsufficientCoinsForTopUp(r.needed, r.have)
+            is TopUpResolution.Ok -> r
         }
 
         val hand = if (anchor != null) {
@@ -137,21 +119,21 @@ class HighlowService(
         } else {
             highlow.play(direction, random)
         }
-        val r = WagerHelper.applyMultiplier(userService, resolved.user, resolved.balance, stake, hand.multiplier)
+        val wager = WagerHelper.applyMultiplier(userService, resolved.user, resolved.balance, stake, hand.multiplier)
         return if (hand.isWin) {
             val jackpot = JackpotHelper.rollOnWin(jackpotService, configService, userService, resolved.user, guildId, random)
             PlayOutcome.Win(
                 stake = stake,
-                payout = r.payout,
-                net = r.net,
+                payout = wager.payout,
+                net = wager.net,
                 anchor = hand.anchor,
                 next = hand.next,
                 direction = hand.direction,
                 multiplier = hand.multiplier,
-                newBalance = r.newBalance + jackpot,
+                newBalance = wager.newBalance + jackpot,
                 jackpotPayout = jackpot,
-                soldTobyCoins = soldCoins,
-                newPrice = soldNewPrice,
+                soldTobyCoins = resolved.soldCoins,
+                newPrice = resolved.newPrice,
             )
         } else {
             val tribute = JackpotHelper.divertOnLoss(jackpotService, configService, guildId, stake)
@@ -160,9 +142,9 @@ class HighlowService(
                 anchor = hand.anchor,
                 next = hand.next,
                 direction = hand.direction,
-                newBalance = r.newBalance,
-                soldTobyCoins = soldCoins,
-                newPrice = soldNewPrice,
+                newBalance = wager.newBalance,
+                soldTobyCoins = resolved.soldCoins,
+                newPrice = resolved.newPrice,
                 lossTribute = tribute,
             )
         }

--- a/database/src/main/kotlin/database/service/ScratchService.kt
+++ b/database/src/main/kotlin/database/service/ScratchService.kt
@@ -55,61 +55,43 @@ class ScratchService(
     }
 
     fun scratch(discordId: Long, guildId: Long, stake: Long, autoTopUp: Boolean = false): ScratchOutcome {
-        val initial = WagerHelper.checkAndLock(
-            userService, discordId, guildId, stake, ScratchCard.MIN_STAKE, ScratchCard.MAX_STAKE
-        )
-        var soldCoins = 0L
-        var newPrice: Double? = null
-        val resolved = when (initial) {
-            is BalanceCheck.InvalidStake -> return ScratchOutcome.InvalidStake(initial.min, initial.max)
-            BalanceCheck.UnknownUser -> return ScratchOutcome.UnknownUser
-            is BalanceCheck.Insufficient -> {
-                if (!autoTopUp) return ScratchOutcome.InsufficientCredits(initial.stake, initial.have)
-                val user = userService.getUserByIdForUpdate(discordId, guildId)
-                    ?: return ScratchOutcome.UnknownUser
-                val topUp = CasinoTopUpHelper.ensureCreditsForWager(
-                    tradeService, marketService, userService,
-                    user, guildId, currentBalance = initial.have, stake = stake
-                )
-                when (topUp) {
-                    is TopUpResult.InsufficientCoins ->
-                        return ScratchOutcome.InsufficientCoinsForTopUp(topUp.needed, topUp.have)
-                    TopUpResult.MarketUnavailable ->
-                        return ScratchOutcome.InsufficientCredits(initial.stake, initial.have)
-                    is TopUpResult.ToppedUp -> {
-                        soldCoins = topUp.soldCoins
-                        newPrice = topUp.newPrice
-                        BalanceCheck.Ok(topUp.user, topUp.balance)
-                    }
-                }
-            }
-            is BalanceCheck.Ok -> initial
+        val resolved = when (val r = WagerHelper.checkLockOrTopUp(
+            userService, tradeService, marketService,
+            discordId, guildId, stake, ScratchCard.MIN_STAKE, ScratchCard.MAX_STAKE, autoTopUp
+        )) {
+            is TopUpResolution.InvalidStake -> return ScratchOutcome.InvalidStake(r.min, r.max)
+            TopUpResolution.UnknownUser -> return ScratchOutcome.UnknownUser
+            is TopUpResolution.StillInsufficientCredits ->
+                return ScratchOutcome.InsufficientCredits(r.stake, r.have)
+            is TopUpResolution.InsufficientCoinsForTopUp ->
+                return ScratchOutcome.InsufficientCoinsForTopUp(r.needed, r.have)
+            is TopUpResolution.Ok -> r
         }
 
         val result = card.scratch(random)
-        val r = WagerHelper.applyMultiplier(userService, resolved.user, resolved.balance, stake, result.multiplier)
+        val wager = WagerHelper.applyMultiplier(userService, resolved.user, resolved.balance, stake, result.multiplier)
         return if (result.isWin && result.winningSymbol != null) {
             val jackpot = JackpotHelper.rollOnWin(jackpotService, configService, userService, resolved.user, guildId, random)
             ScratchOutcome.Win(
                 stake = stake,
-                payout = r.payout,
-                net = r.net,
+                payout = wager.payout,
+                net = wager.net,
                 cells = result.cells,
                 winningSymbol = result.winningSymbol,
                 matchCount = result.matchCount,
-                newBalance = r.newBalance + jackpot,
+                newBalance = wager.newBalance + jackpot,
                 jackpotPayout = jackpot,
-                soldTobyCoins = soldCoins,
-                newPrice = newPrice,
+                soldTobyCoins = resolved.soldCoins,
+                newPrice = resolved.newPrice,
             )
         } else {
             val tribute = JackpotHelper.divertOnLoss(jackpotService, configService, guildId, stake)
             ScratchOutcome.Lose(
                 stake = stake,
                 cells = result.cells,
-                newBalance = r.newBalance,
-                soldTobyCoins = soldCoins,
-                newPrice = newPrice,
+                newBalance = wager.newBalance,
+                soldTobyCoins = resolved.soldCoins,
+                newPrice = resolved.newPrice,
                 lossTribute = tribute,
             )
         }

--- a/database/src/main/kotlin/database/service/SlotsService.kt
+++ b/database/src/main/kotlin/database/service/SlotsService.kt
@@ -67,62 +67,42 @@ class SlotsService(
     }
 
     fun spin(discordId: Long, guildId: Long, stake: Long, autoTopUp: Boolean = false): SpinOutcome {
-        val initial = WagerHelper.checkAndLock(
-            userService, discordId, guildId, stake, SlotMachine.MIN_STAKE, SlotMachine.MAX_STAKE
-        )
-        var soldCoins = 0L
-        var newPrice: Double? = null
-        val resolved = when (initial) {
-            is BalanceCheck.InvalidStake -> return SpinOutcome.InvalidStake(initial.min, initial.max)
-            BalanceCheck.UnknownUser -> return SpinOutcome.UnknownUser
-            is BalanceCheck.Insufficient -> {
-                if (!autoTopUp) return SpinOutcome.InsufficientCredits(initial.stake, initial.have)
-                // Lock the user row to feed the helper. WagerHelper already
-                // returned Insufficient — re-acquire to get the managed entity.
-                val user = userService.getUserByIdForUpdate(discordId, guildId)
-                    ?: return SpinOutcome.UnknownUser
-                val topUp = CasinoTopUpHelper.ensureCreditsForWager(
-                    tradeService, marketService, userService,
-                    user, guildId, currentBalance = initial.have, stake = stake
-                )
-                when (topUp) {
-                    is TopUpResult.InsufficientCoins ->
-                        return SpinOutcome.InsufficientCoinsForTopUp(topUp.needed, topUp.have)
-                    TopUpResult.MarketUnavailable ->
-                        return SpinOutcome.InsufficientCredits(initial.stake, initial.have)
-                    is TopUpResult.ToppedUp -> {
-                        soldCoins = topUp.soldCoins
-                        newPrice = topUp.newPrice
-                        BalanceCheck.Ok(topUp.user, topUp.balance)
-                    }
-                }
-            }
-            is BalanceCheck.Ok -> initial
+        val resolved = when (val r = WagerHelper.checkLockOrTopUp(
+            userService, tradeService, marketService,
+            discordId, guildId, stake, SlotMachine.MIN_STAKE, SlotMachine.MAX_STAKE, autoTopUp
+        )) {
+            is TopUpResolution.InvalidStake -> return SpinOutcome.InvalidStake(r.min, r.max)
+            TopUpResolution.UnknownUser -> return SpinOutcome.UnknownUser
+            is TopUpResolution.StillInsufficientCredits ->
+                return SpinOutcome.InsufficientCredits(r.stake, r.have)
+            is TopUpResolution.InsufficientCoinsForTopUp ->
+                return SpinOutcome.InsufficientCoinsForTopUp(r.needed, r.have)
+            is TopUpResolution.Ok -> r
         }
 
         val pull = machine.pull(random)
-        val r = WagerHelper.applyMultiplier(userService, resolved.user, resolved.balance, stake, pull.multiplier)
+        val wager = WagerHelper.applyMultiplier(userService, resolved.user, resolved.balance, stake, pull.multiplier)
         return if (pull.isWin) {
             val jackpot = JackpotHelper.rollOnWin(jackpotService, configService, userService, resolved.user, guildId, random)
             SpinOutcome.Win(
                 stake = stake,
                 multiplier = pull.multiplier,
-                payout = r.payout,
-                net = r.net,
+                payout = wager.payout,
+                net = wager.net,
                 symbols = pull.symbols,
-                newBalance = r.newBalance + jackpot,
+                newBalance = wager.newBalance + jackpot,
                 jackpotPayout = jackpot,
-                soldTobyCoins = soldCoins,
-                newPrice = newPrice,
+                soldTobyCoins = resolved.soldCoins,
+                newPrice = resolved.newPrice,
             )
         } else {
             val tribute = JackpotHelper.divertOnLoss(jackpotService, configService, guildId, stake)
             SpinOutcome.Lose(
                 stake = stake,
                 symbols = pull.symbols,
-                newBalance = r.newBalance,
-                soldTobyCoins = soldCoins,
-                newPrice = newPrice,
+                newBalance = wager.newBalance,
+                soldTobyCoins = resolved.soldCoins,
+                newPrice = resolved.newPrice,
                 lossTribute = tribute,
             )
         }

--- a/database/src/main/kotlin/database/service/WagerHelper.kt
+++ b/database/src/main/kotlin/database/service/WagerHelper.kt
@@ -28,6 +28,33 @@ internal sealed interface BalanceCheck {
 
 internal data class WagerResolution(val payout: Long, val net: Long, val newBalance: Long)
 
+/**
+ * One-call combination of [WagerHelper.checkAndLock] plus the autoTopUp
+ * follow-up branching that every casino-minigame service re-implemented
+ * verbatim. Each service maps the variants 1:1 onto its own outcome
+ * sealed type — see e.g. [BaccaratService.play] — so the per-game Win/
+ * Lose payload stays in the service while the credit-check / top-up
+ * scaffolding lives here.
+ *
+ * On `Ok`, [TopUpResolution.Ok.soldCoins] and [TopUpResolution.Ok.newPrice]
+ * carry whatever was sold to top the player up. They're `0L` and `null`
+ * respectively for a player who started with enough credits, mirroring the
+ * `var soldCoins = 0L; var newPrice: Double? = null` locals each service
+ * used to maintain.
+ */
+internal sealed interface TopUpResolution {
+    data class Ok(
+        val user: UserDto,
+        val balance: Long,
+        val soldCoins: Long,
+        val newPrice: Double?
+    ) : TopUpResolution
+    data class InvalidStake(val min: Long, val max: Long) : TopUpResolution
+    data class StillInsufficientCredits(val stake: Long, val have: Long) : TopUpResolution
+    data class InsufficientCoinsForTopUp(val needed: Long, val have: Long) : TopUpResolution
+    data object UnknownUser : TopUpResolution
+}
+
 internal object WagerHelper {
 
     /**
@@ -95,5 +122,58 @@ internal object WagerHelper {
         user.socialCredit = balance + net
         userService.updateUser(user)
         return WagerResolution(payout = payout, net = net, newBalance = user.socialCredit ?: 0L)
+    }
+
+    /**
+     * Combined check-lock-or-topup. Calls [checkAndLock]; on `Insufficient`
+     * AND [autoTopUp] = true, falls through to
+     * [CasinoTopUpHelper.ensureCreditsForWager] and re-resolves. Returns
+     * a [TopUpResolution] each minigame can map onto its own outcome
+     * sealed type with a six-branch `when`.
+     *
+     * `tradeService`/`marketService` are only used on the autoTopUp path;
+     * services that never opt in still get a clean `Ok` / `StillInsufficientCredits`
+     * shape from the helper so the call-site is uniform.
+     */
+    fun checkLockOrTopUp(
+        userService: UserService,
+        tradeService: EconomyTradeService,
+        marketService: TobyCoinMarketService,
+        discordId: Long,
+        guildId: Long,
+        stake: Long,
+        minStake: Long,
+        maxStake: Long,
+        autoTopUp: Boolean
+    ): TopUpResolution = when (val initial = checkAndLock(
+        userService, discordId, guildId, stake, minStake, maxStake
+    )) {
+        is BalanceCheck.InvalidStake -> TopUpResolution.InvalidStake(initial.min, initial.max)
+        BalanceCheck.UnknownUser -> TopUpResolution.UnknownUser
+        is BalanceCheck.Ok -> TopUpResolution.Ok(initial.user, initial.balance, soldCoins = 0L, newPrice = null)
+        is BalanceCheck.Insufficient -> {
+            if (!autoTopUp) {
+                TopUpResolution.StillInsufficientCredits(initial.stake, initial.have)
+            } else {
+                // checkAndLock already locked the row inside this transaction;
+                // re-fetching returns the same managed entity, no second DB lock.
+                val user = userService.getUserByIdForUpdate(discordId, guildId)
+                if (user == null) {
+                    TopUpResolution.UnknownUser
+                } else {
+                    when (val topUp = CasinoTopUpHelper.ensureCreditsForWager(
+                        tradeService, marketService, userService,
+                        user, guildId, currentBalance = initial.have, stake = stake
+                    )) {
+                        is TopUpResult.InsufficientCoins ->
+                            TopUpResolution.InsufficientCoinsForTopUp(topUp.needed, topUp.have)
+                        TopUpResult.MarketUnavailable ->
+                            TopUpResolution.StillInsufficientCredits(initial.stake, initial.have)
+                        is TopUpResult.ToppedUp ->
+                            TopUpResolution.Ok(topUp.user, topUp.balance, topUp.soldCoins, topUp.newPrice)
+                    }
+                }
+            }
+        }
     }
 }

--- a/database/src/test/kotlin/database/economy/BaccaratTest.kt
+++ b/database/src/test/kotlin/database/economy/BaccaratTest.kt
@@ -1,0 +1,285 @@
+package database.economy
+
+import database.card.Card
+import database.card.Deck
+import database.card.Rank
+import database.card.Suit
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import kotlin.random.Random
+
+class BaccaratTest {
+
+    private fun c(rank: Rank, suit: Suit = Suit.SPADES) = Card(rank, suit)
+
+    // --- value helpers ---
+
+    @Test
+    fun `baccaratValue maps tens and faces to zero`() {
+        assertEquals(0, c(Rank.TEN).baccaratValue())
+        assertEquals(0, c(Rank.JACK).baccaratValue())
+        assertEquals(0, c(Rank.QUEEN).baccaratValue())
+        assertEquals(0, c(Rank.KING).baccaratValue())
+    }
+
+    @Test
+    fun `baccaratValue maps ace to one and face cards 2-9 to their pip`() {
+        assertEquals(1, c(Rank.ACE).baccaratValue())
+        assertEquals(2, c(Rank.TWO).baccaratValue())
+        assertEquals(5, c(Rank.FIVE).baccaratValue())
+        assertEquals(9, c(Rank.NINE).baccaratValue())
+    }
+
+    @Test
+    fun `handTotal is the sum of pip values mod 10`() {
+        // 7 + 8 = 15 → 5
+        assertEquals(5, handTotal(listOf(c(Rank.SEVEN), c(Rank.EIGHT))))
+        // K (0) + 9 = 9
+        assertEquals(9, handTotal(listOf(c(Rank.KING), c(Rank.NINE))))
+        // 9 + 9 + 9 = 27 → 7
+        assertEquals(7, handTotal(listOf(c(Rank.NINE), c(Rank.NINE), c(Rank.NINE))))
+    }
+
+    // --- naturals ---
+
+    @Test
+    fun `player natural eight stops the deal — neither side draws a third card`() {
+        val deck = mockDeck(
+            c(Rank.FIVE), c(Rank.THREE), // player → 8 natural
+            c(Rank.TWO), c(Rank.FOUR),   // banker → 6
+            c(Rank.ACE)                  // poison: must never be drawn
+        )
+        val hand = Baccarat().play(Baccarat.Side.PLAYER, deck)
+
+        assertEquals(8, hand.playerTotal)
+        assertEquals(6, hand.bankerTotal)
+        assertEquals(2, hand.playerCards.size)
+        assertEquals(2, hand.bankerCards.size)
+        assertTrue(hand.isPlayerNatural)
+        assertFalse(hand.isBankerNatural)
+        assertEquals(Baccarat.Side.PLAYER, hand.winner)
+    }
+
+    @Test
+    fun `banker natural nine stops the deal — player does not draw even on zero`() {
+        val deck = mockDeck(
+            c(Rank.FIVE), c(Rank.FIVE), // player → 0 (would otherwise draw)
+            c(Rank.FOUR), c(Rank.FIVE), // banker → 9, natural
+            c(Rank.ACE)                  // poison
+        )
+        val hand = Baccarat().play(Baccarat.Side.PLAYER, deck)
+
+        assertEquals(0, hand.playerTotal)
+        assertEquals(9, hand.bankerTotal)
+        assertEquals(2, hand.playerCards.size)
+        assertEquals(2, hand.bankerCards.size)
+        assertTrue(hand.isBankerNatural)
+        assertEquals(Baccarat.Side.BANKER, hand.winner)
+    }
+
+    @Test
+    fun `naturals tie when both sides land on eight`() {
+        val deck = mockDeck(
+            c(Rank.FIVE), c(Rank.THREE), // player → 8
+            c(Rank.TWO), c(Rank.SIX)     // banker → 8
+        )
+        val hand = Baccarat().play(Baccarat.Side.TIE, deck)
+
+        assertEquals(Baccarat.Side.TIE, hand.winner)
+        assertTrue(hand.isPlayerNatural)
+        assertTrue(hand.isBankerNatural)
+        // Tie on TIE side bet pays at the natural multiplier.
+        assertEquals(Baccarat.TIE_WIN_MULT, hand.multiplier, 1e-9)
+    }
+
+    // --- player draw rule ---
+
+    @Test
+    fun `player draws a third card on totals 0-5`() {
+        // Player 1+3 = 4 → must draw. Banker 2+5 = 7 → stays.
+        val deck = mockDeck(
+            c(Rank.ACE), c(Rank.THREE),  // player → 4
+            c(Rank.TWO), c(Rank.FIVE),   // banker → 7
+            c(Rank.SIX)                  // player's third
+        )
+        val hand = Baccarat().play(Baccarat.Side.PLAYER, deck)
+        assertEquals(3, hand.playerCards.size)
+        // 4 + 6 = 10 → 0
+        assertEquals(0, hand.playerTotal)
+        assertEquals(2, hand.bankerCards.size)
+    }
+
+    @Test
+    fun `player stands on totals 6-7`() {
+        // Player 5+2 = 7 → stand. Banker 1+5 = 6 → would normally draw,
+        // but with no Player third card and total 6, banker stands.
+        val deck = mockDeck(
+            c(Rank.FIVE), c(Rank.TWO),   // player → 7
+            c(Rank.ACE), c(Rank.FIVE)    // banker → 6
+            // no third cards — assert by deck not being asked
+        )
+        val hand = Baccarat().play(Baccarat.Side.PLAYER, deck)
+        assertEquals(2, hand.playerCards.size)
+        assertEquals(2, hand.bankerCards.size)
+        assertEquals(7, hand.playerTotal)
+        assertEquals(6, hand.bankerTotal)
+        assertEquals(Baccarat.Side.PLAYER, hand.winner)
+    }
+
+    // --- banker tableau ---
+
+    @Test
+    fun `banker draws on total 0-5 when player did not draw a third`() {
+        // Player 4+2 = 6 → stand. Banker 2+3 = 5 → draws on no-player-third.
+        val deck = mockDeck(
+            c(Rank.FOUR), c(Rank.TWO),   // player → 6 stand
+            c(Rank.TWO), c(Rank.THREE),  // banker → 5
+            c(Rank.NINE)                 // banker's third
+        )
+        val hand = Baccarat().play(Baccarat.Side.BANKER, deck)
+        assertEquals(2, hand.playerCards.size)
+        assertEquals(3, hand.bankerCards.size)
+        // 5 + 9 = 14 → 4
+        assertEquals(4, hand.bankerTotal)
+        assertEquals(Baccarat.Side.PLAYER, hand.winner)
+    }
+
+    @Test
+    fun `banker stands on 7 even with a player third card`() {
+        // Player 1+1 = 2 → draws. Banker 5+2 = 7 → never draws.
+        val deck = mockDeck(
+            c(Rank.ACE), c(Rank.ACE),    // player → 2
+            c(Rank.FIVE), c(Rank.TWO),   // banker → 7 stand
+            c(Rank.NINE)                 // player's third → 2+9=1
+            // no banker third — banker stands on 7
+        )
+        val hand = Baccarat().play(Baccarat.Side.PLAYER, deck)
+        assertEquals(2, hand.bankerCards.size)
+        assertEquals(7, hand.bankerTotal)
+        assertEquals(1, hand.playerTotal)
+        assertEquals(Baccarat.Side.BANKER, hand.winner)
+    }
+
+    @Test
+    fun `banker on 3 stays only when player third is an 8`() {
+        // Player 5+0 = 5 → draws. Banker 2+1 = 3.
+        // Player third = 8 (rank EIGHT) → banker should NOT draw.
+        val stayDeck = mockDeck(
+            c(Rank.FIVE), c(Rank.TEN),   // player → 5
+            c(Rank.TWO), c(Rank.ACE),    // banker → 3
+            c(Rank.EIGHT)                // player third → 8 (banker stays)
+        )
+        val stayHand = Baccarat().play(Baccarat.Side.PLAYER, stayDeck)
+        assertEquals(2, stayHand.bankerCards.size)
+        assertEquals(3, stayHand.bankerTotal)
+
+        // Player third = 7 → banker should draw.
+        val drawDeck = mockDeck(
+            c(Rank.FIVE), c(Rank.TEN),   // player → 5
+            c(Rank.TWO), c(Rank.ACE),    // banker → 3
+            c(Rank.SEVEN),               // player third → 7
+            c(Rank.TWO)                  // banker third
+        )
+        val drawHand = Baccarat().play(Baccarat.Side.PLAYER, drawDeck)
+        assertEquals(3, drawHand.bankerCards.size)
+    }
+
+    @Test
+    fun `banker on 6 only draws when player third is 6 or 7`() {
+        // Banker 6 stays on player-third 5.
+        val stayDeck = mockDeck(
+            c(Rank.FIVE), c(Rank.TEN),   // player → 5
+            c(Rank.THREE), c(Rank.THREE),// banker → 6
+            c(Rank.FIVE)                 // player third → 5 → banker stays
+        )
+        val stay = Baccarat().play(Baccarat.Side.PLAYER, stayDeck)
+        assertEquals(2, stay.bankerCards.size)
+
+        // Banker 6 draws on player-third 7.
+        val drawDeck = mockDeck(
+            c(Rank.FIVE), c(Rank.TEN),   // player → 5
+            c(Rank.THREE), c(Rank.THREE),// banker → 6
+            c(Rank.SEVEN),               // player third → 7 → banker draws
+            c(Rank.TWO)                  // banker third
+        )
+        val draw = Baccarat().play(Baccarat.Side.PLAYER, drawDeck)
+        assertEquals(3, draw.bankerCards.size)
+    }
+
+    // --- multipliers ---
+
+    @Test
+    fun `multiplier returns the side payout when the chosen side wins`() {
+        val b = Baccarat()
+        assertEquals(Baccarat.PLAYER_WIN_MULT, b.multiplier(Baccarat.Side.PLAYER, Baccarat.Side.PLAYER), 1e-9)
+        assertEquals(Baccarat.BANKER_WIN_MULT, b.multiplier(Baccarat.Side.BANKER, Baccarat.Side.BANKER), 1e-9)
+        assertEquals(Baccarat.TIE_WIN_MULT, b.multiplier(Baccarat.Side.TIE, Baccarat.Side.TIE), 1e-9)
+    }
+
+    @Test
+    fun `multiplier returns zero when the chosen side loses outright`() {
+        val b = Baccarat()
+        assertEquals(0.0, b.multiplier(Baccarat.Side.PLAYER, Baccarat.Side.BANKER), 1e-9)
+        assertEquals(0.0, b.multiplier(Baccarat.Side.BANKER, Baccarat.Side.PLAYER), 1e-9)
+        // Tie loses on a non-tie game:
+        assertEquals(0.0, b.multiplier(Baccarat.Side.TIE, Baccarat.Side.PLAYER), 1e-9)
+        assertEquals(0.0, b.multiplier(Baccarat.Side.TIE, Baccarat.Side.BANKER), 1e-9)
+    }
+
+    @Test
+    fun `multiplier pushes Player and Banker side bets on a tied game`() {
+        val b = Baccarat()
+        assertEquals(Baccarat.PUSH_MULT, b.multiplier(Baccarat.Side.PLAYER, Baccarat.Side.TIE), 1e-9)
+        assertEquals(Baccarat.PUSH_MULT, b.multiplier(Baccarat.Side.BANKER, Baccarat.Side.TIE), 1e-9)
+    }
+
+    @Test
+    fun `previewMultiplier exposes the configured payouts for button labels`() {
+        val b = Baccarat()
+        assertEquals(2.0, b.previewMultiplier(Baccarat.Side.PLAYER), 1e-9)
+        assertEquals(1.95, b.previewMultiplier(Baccarat.Side.BANKER), 1e-9)
+        assertEquals(9.0, b.previewMultiplier(Baccarat.Side.TIE), 1e-9)
+    }
+
+    // --- RTP smoke ---
+
+    @Test
+    fun `RTP across 50k random hands stays close to the published edge`() {
+        val baccarat = Baccarat()
+        val rng = Random(2026)
+        val stake = 1_000L
+        val n = 50_000
+        var totalWagered = 0L
+        var totalReturned = 0.0
+        repeat(n) {
+            val side = Baccarat.Side.entries[rng.nextInt(Baccarat.Side.entries.size)]
+            val hand = baccarat.play(side, Deck(rng))
+            totalWagered += stake
+            totalReturned += hand.multiplier * stake
+        }
+        val rtp = totalReturned / totalWagered.toDouble()
+        // Mixed across all three sides — Tie's ~85% drags the average below
+        // Player/Banker's ~98%. Looser tolerance because Tie has wide
+        // variance over 50k hands.
+        assertTrue(rtp in 0.80..1.05, "expected mixed-side RTP in 0.80..1.05 but saw $rtp")
+    }
+
+    /**
+     * Test helper — a Deck whose dealt cards are the supplied [seq],
+     * in order. Calls beyond the sequence will throw via the underlying
+     * ArrayDeque. Mirrors the same reflective swap used by
+     * [database.blackjack.BlackjackTest].
+     */
+    private fun mockDeck(vararg seq: Card): Deck {
+        val deck = Deck(Random(0))
+        val field = Deck::class.java.getDeclaredField("cards")
+        field.isAccessible = true
+        @Suppress("UNCHECKED_CAST")
+        val cards = field.get(deck) as ArrayDeque<Card>
+        cards.clear()
+        cards.addAll(seq)
+        return deck
+    }
+}

--- a/database/src/test/kotlin/database/service/BaccaratServiceTest.kt
+++ b/database/src/test/kotlin/database/service/BaccaratServiceTest.kt
@@ -1,0 +1,220 @@
+package database.service
+
+import database.card.Card
+import database.card.Rank
+import database.card.Suit
+import database.dto.UserDto
+import database.economy.Baccarat
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import kotlin.random.Random
+
+class BaccaratServiceTest {
+
+    private lateinit var userService: UserService
+    private lateinit var jackpotService: JackpotService
+    private lateinit var tradeService: EconomyTradeService
+    private lateinit var marketService: TobyCoinMarketService
+    private lateinit var configService: ConfigService
+    private lateinit var baccarat: Baccarat
+    private lateinit var service: BaccaratService
+
+    private val discordId = 100L
+    private val guildId = 200L
+
+    @BeforeEach
+    fun setup() {
+        userService = mockk(relaxed = true)
+        jackpotService = mockk(relaxed = true)
+        tradeService = mockk(relaxed = true)
+        marketService = mockk(relaxed = true)
+        configService = mockk(relaxed = true)
+        baccarat = mockk(relaxed = true)
+        service = BaccaratService(
+            userService, jackpotService, tradeService, marketService, configService,
+            baccarat, Random(0)
+        )
+    }
+
+    private fun userWithBalance(balance: Long): UserDto =
+        UserDto(discordId, guildId).apply { socialCredit = balance }
+
+    private fun playerCards() = listOf(Card(Rank.FIVE, Suit.SPADES), Card(Rank.THREE, Suit.HEARTS))
+    private fun bankerCards() = listOf(Card(Rank.TWO, Suit.CLUBS), Card(Rank.FOUR, Suit.DIAMONDS))
+
+    private fun handResult(
+        side: Baccarat.Side,
+        winner: Baccarat.Side,
+        multiplier: Double
+    ): Baccarat.Hand = Baccarat.Hand(
+        side = side,
+        winner = winner,
+        playerCards = playerCards(),
+        bankerCards = bankerCards(),
+        playerTotal = 8,
+        bankerTotal = 6,
+        isPlayerNatural = true,
+        isBankerNatural = false,
+        multiplier = multiplier
+    )
+
+    @Test
+    fun `Player win debits stake and credits payout atomically`() {
+        val user = userWithBalance(1_000L)
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns user
+        every { baccarat.play(Baccarat.Side.PLAYER, any()) } returns handResult(
+            side = Baccarat.Side.PLAYER, winner = Baccarat.Side.PLAYER, multiplier = 2.0
+        )
+        val captured = slot<UserDto>()
+        every { userService.updateUser(capture(captured)) } returns user
+
+        val outcome = service.play(discordId, guildId, stake = 100L, side = Baccarat.Side.PLAYER)
+
+        val win = assertInstanceOf(BaccaratService.PlayOutcome.Win::class.java, outcome)
+        assertEquals(100L, win.stake)
+        assertEquals(200L, win.payout)
+        assertEquals(100L, win.net)
+        assertEquals(2.0, win.multiplier, 1e-9)
+        assertEquals(1_100L, win.newBalance)
+        assertEquals(Baccarat.Side.PLAYER, win.side)
+        assertEquals(Baccarat.Side.PLAYER, win.winner)
+        assertEquals(1_100L, captured.captured.socialCredit)
+    }
+
+    @Test
+    fun `Banker win pays out at the 5pct-commission multiplier`() {
+        val user = userWithBalance(1_000L)
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns user
+        every { baccarat.play(Baccarat.Side.BANKER, any()) } returns handResult(
+            side = Baccarat.Side.BANKER, winner = Baccarat.Side.BANKER, multiplier = 1.95
+        )
+        every { userService.updateUser(any()) } returns user
+
+        val outcome = service.play(discordId, guildId, stake = 100L, side = Baccarat.Side.BANKER)
+
+        val win = assertInstanceOf(BaccaratService.PlayOutcome.Win::class.java, outcome)
+        // 100 × 1.95 = 195 payout, 95 net
+        assertEquals(195L, win.payout)
+        assertEquals(95L, win.net)
+        assertEquals(1.95, win.multiplier, 1e-9)
+        assertEquals(1_095L, win.newBalance)
+    }
+
+    @Test
+    fun `loss debits stake only`() {
+        val user = userWithBalance(500L)
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns user
+        every { baccarat.play(Baccarat.Side.PLAYER, any()) } returns handResult(
+            side = Baccarat.Side.PLAYER, winner = Baccarat.Side.BANKER, multiplier = 0.0
+        )
+        every { userService.updateUser(any()) } returns user
+
+        val outcome = service.play(discordId, guildId, stake = 100L, side = Baccarat.Side.PLAYER)
+
+        val lose = assertInstanceOf(BaccaratService.PlayOutcome.Lose::class.java, outcome)
+        assertEquals(100L, lose.stake)
+        assertEquals(400L, lose.newBalance)
+        assertEquals(Baccarat.Side.BANKER, lose.winner)
+    }
+
+    @Test
+    fun `tied game pushes a Player side bet — stake is refunded`() {
+        val user = userWithBalance(500L)
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns user
+        every { baccarat.play(Baccarat.Side.PLAYER, any()) } returns handResult(
+            side = Baccarat.Side.PLAYER, winner = Baccarat.Side.TIE, multiplier = 1.0
+        )
+        every { userService.updateUser(any()) } returns user
+
+        val outcome = service.play(discordId, guildId, stake = 100L, side = Baccarat.Side.PLAYER)
+
+        val push = assertInstanceOf(BaccaratService.PlayOutcome.Push::class.java, outcome)
+        assertEquals(100L, push.stake)
+        // Push: 100×1 - 100 = net 0, balance unchanged.
+        assertEquals(500L, push.newBalance)
+        // No jackpot tribute on a push.
+        verify(exactly = 0) { jackpotService.addToPool(any(), any()) }
+    }
+
+    @Test
+    fun `Tie side bet wins at the natural multiplier on a tied game`() {
+        val user = userWithBalance(1_000L)
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns user
+        every { baccarat.play(Baccarat.Side.TIE, any()) } returns handResult(
+            side = Baccarat.Side.TIE, winner = Baccarat.Side.TIE, multiplier = 9.0
+        )
+        every { userService.updateUser(any()) } returns user
+
+        val outcome = service.play(discordId, guildId, stake = 50L, side = Baccarat.Side.TIE)
+
+        val win = assertInstanceOf(BaccaratService.PlayOutcome.Win::class.java, outcome)
+        assertEquals(450L, win.payout)
+        assertEquals(400L, win.net)
+        assertEquals(1_400L, win.newBalance)
+    }
+
+    @Test
+    fun `insufficient credits is rejected without rolling the hand`() {
+        val user = userWithBalance(50L)
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns user
+
+        val outcome = service.play(discordId, guildId, stake = 100L, side = Baccarat.Side.PLAYER)
+
+        assertInstanceOf(BaccaratService.PlayOutcome.InsufficientCredits::class.java, outcome)
+        verify(exactly = 0) { userService.updateUser(any()) }
+        verify(exactly = 0) { baccarat.play(any(), any()) }
+    }
+
+    @Test
+    fun `invalid stake is rejected before locking the user`() {
+        val outcome = service.play(
+            discordId, guildId, stake = Baccarat.MIN_STAKE - 1, side = Baccarat.Side.PLAYER
+        )
+
+        assertInstanceOf(BaccaratService.PlayOutcome.InvalidStake::class.java, outcome)
+        verify(exactly = 0) { userService.getUserByIdForUpdate(any(), any()) }
+        verify(exactly = 0) { baccarat.play(any(), any()) }
+    }
+
+    @Test
+    fun `unknown user is rejected`() {
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns null
+
+        val outcome = service.play(discordId, guildId, stake = 100L, side = Baccarat.Side.PLAYER)
+
+        assertEquals(BaccaratService.PlayOutcome.UnknownUser, outcome)
+    }
+
+    @Test
+    fun `loss tributes 10 percent of the stake into the jackpot pool`() {
+        val user = userWithBalance(500L)
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns user
+        every { baccarat.play(Baccarat.Side.PLAYER, any()) } returns handResult(
+            side = Baccarat.Side.PLAYER, winner = Baccarat.Side.BANKER, multiplier = 0.0
+        )
+        every { userService.updateUser(any()) } returns user
+
+        val outcome = service.play(discordId, guildId, stake = 100L, side = Baccarat.Side.PLAYER)
+
+        val lose = assertInstanceOf(BaccaratService.PlayOutcome.Lose::class.java, outcome)
+        assertEquals(10L, lose.lossTribute)
+        verify(exactly = 1) { jackpotService.addToPool(guildId, 10L) }
+    }
+
+    @Test
+    fun `previewMultiplier delegates to the underlying logic and does not touch the user`() {
+        every { baccarat.previewMultiplier(Baccarat.Side.BANKER) } returns 1.95
+
+        val multiplier = service.previewMultiplier(Baccarat.Side.BANKER)
+
+        assertEquals(1.95, multiplier, 1e-9)
+        verify(exactly = 0) { userService.getUserByIdForUpdate(any(), any()) }
+        verify(exactly = 0) { userService.updateUser(any()) }
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/button/buttons/BaccaratButton.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/button/buttons/BaccaratButton.kt
@@ -1,0 +1,53 @@
+package bot.toby.button.buttons
+
+import bot.toby.command.commands.economy.BaccaratEmbeds
+import core.button.Button
+import core.button.ButtonContext
+import database.dto.UserDto
+import database.service.BaccaratService
+import net.dv8tion.jda.api.components.MessageTopLevelComponent
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+/**
+ * Resolves a `/baccarat` round once the player clicks Player, Banker,
+ * or Tie. Side + stake + owning user are encoded in the component ID
+ * by [bot.toby.command.commands.economy.BaccaratCommand], so no server-
+ * side state is needed between the slash command and the click. Edits
+ * the original message in place and removes the buttons so the round
+ * can't be re-clicked.
+ */
+@Component
+class BaccaratButton @Autowired constructor(
+    private val baccaratService: BaccaratService
+) : Button {
+
+    override val name: String get() = BaccaratEmbeds.BUTTON_NAME
+    override val description: String get() = "Resolves a /baccarat round on the player's chosen side."
+
+    override fun handle(ctx: ButtonContext, requestingUserDto: UserDto, deleteDelay: Int) {
+        val event = ctx.event
+        val parsed = BaccaratEmbeds.parseButtonId(event.componentId) ?: run {
+            event.deferEdit().queue()
+            return
+        }
+
+        if (requestingUserDto.discordId != parsed.userId) {
+            event.reply("This isn't your /baccarat round — run `/baccarat` to start your own.")
+                .setEphemeral(true)
+                .queue()
+            return
+        }
+
+        val outcome = baccaratService.play(
+            requestingUserDto.discordId,
+            ctx.guild.idLong,
+            parsed.stake,
+            parsed.side
+        )
+
+        event.editMessageEmbeds(BaccaratEmbeds.outcomeEmbed(outcome))
+            .setComponents(emptyList<MessageTopLevelComponent>())
+            .queue()
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/BaccaratCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/BaccaratCommand.kt
@@ -59,7 +59,7 @@ class BaccaratCommand @Autowired constructor(
         val sideButtons = Baccarat.Side.entries.map { side ->
             Button.primary(
                 BaccaratEmbeds.sideButtonId(side, stake, userId),
-                "${side.display} (${BaccaratEmbeds.multiplierLabel(baccaratService.previewMultiplier(side))})"
+                "${side.display} (${WagerCommandEmbeds.multiplierLabel(baccaratService.previewMultiplier(side))})"
             )
         }
 

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/BaccaratCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/BaccaratCommand.kt
@@ -1,0 +1,79 @@
+package bot.toby.command.commands.economy
+
+import core.command.Command.Companion.invokeDeleteOnMessageResponse
+import core.command.CommandContext
+import database.dto.UserDto
+import database.economy.Baccarat
+import database.service.BaccaratService
+import net.dv8tion.jda.api.components.actionrow.ActionRow
+import net.dv8tion.jda.api.components.buttons.Button
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
+import net.dv8tion.jda.api.interactions.commands.OptionType
+import net.dv8tion.jda.api.interactions.commands.build.OptionData
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+/**
+ * `/baccarat stake:<int>` — posts an embed prompting the side bet
+ * (Player / Banker / Tie) and three buttons. The wager only settles
+ * when the player picks a side. No mid-hand decisions: once the side is
+ * chosen, both hands deal automatically per the Punto Banco tableau in
+ * [Baccarat.play] and the round resolves in-place. Mirrors `/highlow`'s
+ * post-then-button shape.
+ *
+ * The button click is handled by [bot.toby.button.buttons.BaccaratButton],
+ * which decodes the side + stake + owning user from the component ID
+ * and resolves via [BaccaratService.play].
+ */
+@Component
+class BaccaratCommand @Autowired constructor(
+    private val baccaratService: BaccaratService
+) : EconomyCommand {
+
+    override val name: String = "baccarat"
+    override val description: String =
+        "Pick Player, Banker, or Tie — both hands deal automatically. Bet ${Baccarat.MIN_STAKE}-${Baccarat.MAX_STAKE} credits."
+
+    companion object {
+        private const val OPT_STAKE = "stake"
+    }
+
+    override val optionData: List<OptionData> = listOf(
+        OptionData(OptionType.INTEGER, OPT_STAKE, "Credits to wager (${Baccarat.MIN_STAKE}-${Baccarat.MAX_STAKE})", true)
+            .setMinValue(Baccarat.MIN_STAKE)
+            .setMaxValue(Baccarat.MAX_STAKE)
+    )
+
+    override fun handle(ctx: CommandContext, requestingUserDto: UserDto, deleteDelay: Int) {
+        val event = ctx.event
+        event.deferReply().queue()
+
+        if (event.guild == null) {
+            replyError(event, "This command can only be used in a server.", deleteDelay); return
+        }
+        val stake = event.getOption(OPT_STAKE)?.asLong ?: run {
+            replyError(event, "You must specify a stake.", deleteDelay); return
+        }
+
+        val userId = requestingUserDto.discordId
+        val sideButtons = Baccarat.Side.entries.map { side ->
+            Button.primary(
+                BaccaratEmbeds.sideButtonId(side, stake, userId),
+                "${side.display} (${BaccaratEmbeds.multiplierLabel(baccaratService.previewMultiplier(side))})"
+            )
+        }
+
+        event.hook.sendMessageEmbeds(BaccaratEmbeds.promptEmbed(stake))
+            .addComponents(ActionRow.of(sideButtons))
+            .queue()
+    }
+
+    private fun replyError(
+        event: SlashCommandInteractionEvent,
+        message: String,
+        deleteDelay: Int
+    ) {
+        event.hook.sendMessageEmbeds(BaccaratEmbeds.errorEmbed(message))
+            .queue(invokeDeleteOnMessageResponse(deleteDelay))
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/BaccaratEmbeds.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/BaccaratEmbeds.kt
@@ -25,9 +25,6 @@ internal object BaccaratEmbeds {
     private val PROMPT_COLOR = Color(0x2C, 0x3E, 0x50)
     private val NEUTRAL_COLOR = Color(0xA0, 0xA0, 0xB0)
 
-    /** "1.95×"-style label used on side-bet buttons and prompt copy. */
-    fun multiplierLabel(multiplier: Double): String = "%.2f×".format(multiplier)
-
     fun sideButtonId(side: Baccarat.Side, stake: Long, userId: Long): String =
         listOf(BUTTON_NAME, side.name, stake.toString(), userId.toString())
             .joinToString(BUTTON_DELIM)
@@ -71,9 +68,9 @@ internal object BaccaratEmbeds {
         .setTitle("$TITLE • $stake credits")
         .setDescription(
             "Pick a side. Both hands deal automatically.\n\n" +
-                "**Player** pays **${multiplierLabel(Baccarat.PLAYER_WIN_MULT)}**, " +
-                "**Banker** pays **${multiplierLabel(Baccarat.BANKER_WIN_MULT)}** (5% commission), " +
-                "**Tie** pays **${multiplierLabel(Baccarat.TIE_WIN_MULT)}**.\n" +
+                "**Player** pays **${WagerCommandEmbeds.multiplierLabel(Baccarat.PLAYER_WIN_MULT)}**, " +
+                "**Banker** pays **${WagerCommandEmbeds.multiplierLabel(Baccarat.BANKER_WIN_MULT)}** (5% commission), " +
+                "**Tie** pays **${WagerCommandEmbeds.multiplierLabel(Baccarat.TIE_WIN_MULT)}**.\n" +
                 "On a tied game, Player and Banker bets are refunded."
         )
         .setColor(PROMPT_COLOR)
@@ -144,7 +141,7 @@ internal object BaccaratEmbeds {
             Baccarat.Side.BANKER -> "Banker wins (5% commission)"
             Baccarat.Side.TIE -> "Tie!"
         }
-        return "$emoji $flavour — won **+${win.net} credits** at ${multiplierLabel(win.multiplier)}."
+        return "$emoji $flavour — won **+${win.net} credits** at ${WagerCommandEmbeds.multiplierLabel(win.multiplier)}."
     }
 
     private fun jackpotLine(jackpotPayout: Long): String =

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/BaccaratEmbeds.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/BaccaratEmbeds.kt
@@ -1,0 +1,154 @@
+package bot.toby.command.commands.economy
+
+import database.card.Card
+import database.economy.Baccarat
+import database.service.BaccaratService.PlayOutcome
+import net.dv8tion.jda.api.EmbedBuilder
+import net.dv8tion.jda.api.entities.MessageEmbed
+import java.awt.Color
+
+/**
+ * Shared embed/component plumbing for the Discord `/baccarat` flow.
+ * The slash command uses [promptEmbed] + [sideButtonId] to post the bet
+ * prompt; [bot.toby.button.buttons.BaccaratButton] uses [outcomeEmbed]
+ * to render the resolution. Mirrors [HighlowEmbeds] one-for-one — the
+ * button-id encoding (`baccarat:<SIDE>:<stake>:<userId>`) and the
+ * win/lose colour palette are deliberately the same shape so the two
+ * flows feel consistent.
+ */
+internal object BaccaratEmbeds {
+
+    const val BUTTON_NAME = "baccarat"
+    private const val BUTTON_DELIM = ":"
+
+    private const val TITLE = "🎴 Baccarat"
+    private val PROMPT_COLOR = Color(0x2C, 0x3E, 0x50)
+
+    /** "1.95×"-style label used on side-bet buttons and prompt copy. */
+    fun multiplierLabel(multiplier: Double): String = "%.2f×".format(multiplier)
+
+    fun sideButtonId(side: Baccarat.Side, stake: Long, userId: Long): String =
+        listOf(BUTTON_NAME, side.name, stake.toString(), userId.toString())
+            .joinToString(BUTTON_DELIM)
+
+    data class ParsedButtonId(
+        val side: Baccarat.Side,
+        val stake: Long,
+        val userId: Long
+    )
+
+    fun parseButtonId(componentId: String): ParsedButtonId? {
+        val parts = componentId.split(BUTTON_DELIM)
+        if (parts.size != 4 || !parts[0].equals(BUTTON_NAME, ignoreCase = true)) return null
+        val side = runCatching { Baccarat.Side.valueOf(parts[1].uppercase()) }.getOrNull() ?: return null
+        val stake = parts[2].toLongOrNull() ?: return null
+        val userId = parts[3].toLongOrNull() ?: return null
+        return ParsedButtonId(side, stake, userId)
+    }
+
+    private fun cardLabel(card: Card): String = "`$card`"
+
+    /**
+     * Inline hand: ``A♠ 7♦`` or ``A♠ 7♦ → 5♣`` when a third card was drawn.
+     * Trailing **(total)** and an optional Natural badge mirror the
+     * blackjack handLine style.
+     */
+    fun handLine(cards: List<Card>, total: Int, isNatural: Boolean): String {
+        if (cards.isEmpty()) return "—"
+        val cardsText = if (cards.size <= 2) {
+            cards.joinToString(" ") { cardLabel(it) }
+        } else {
+            val opening = cards.subList(0, 2).joinToString(" ") { cardLabel(it) }
+            val rest = cards.subList(2, cards.size).joinToString(" ") { cardLabel(it) }
+            "$opening → $rest"
+        }
+        val suffix = if (isNatural) " — **Natural**" else ""
+        return "$cardsText **($total)**$suffix"
+    }
+
+    fun promptEmbed(stake: Long): MessageEmbed = EmbedBuilder()
+        .setTitle("$TITLE • $stake credits")
+        .setDescription(
+            "Pick a side. Both hands deal automatically.\n\n" +
+                "**Player** pays **${multiplierLabel(Baccarat.PLAYER_WIN_MULT)}**, " +
+                "**Banker** pays **${multiplierLabel(Baccarat.BANKER_WIN_MULT)}** (5% commission), " +
+                "**Tie** pays **${multiplierLabel(Baccarat.TIE_WIN_MULT)}**.\n" +
+                "On a tied game, Player and Banker bets are refunded."
+        )
+        .setColor(PROMPT_COLOR)
+        .build()
+
+    fun outcomeEmbed(outcome: PlayOutcome): MessageEmbed = when (outcome) {
+        is PlayOutcome.Win -> {
+            val verdict = winVerdict(outcome)
+            EmbedBuilder()
+                .setTitle("$TITLE • ${outcome.side.display}")
+                .setDescription(
+                    "**Player:** ${handLine(outcome.playerCards, outcome.playerTotal, outcome.isPlayerNatural)}\n" +
+                        "**Banker:** ${handLine(outcome.bankerCards, outcome.bankerTotal, outcome.isBankerNatural)}\n\n" +
+                        verdict +
+                        jackpotLine(outcome.jackpotPayout)
+                )
+                .addField("New balance", "${outcome.newBalance} credits", true)
+                .setColor(WagerCommandColors.WIN)
+                .build()
+        }
+
+        is PlayOutcome.Push -> EmbedBuilder()
+            .setTitle("$TITLE • ${outcome.side.display}")
+            .setDescription(
+                "**Player:** ${handLine(outcome.playerCards, outcome.playerTotal, outcome.isPlayerNatural)}\n" +
+                    "**Banker:** ${handLine(outcome.bankerCards, outcome.bankerTotal, outcome.isBankerNatural)}\n\n" +
+                    "🤝 Tie game — your **${outcome.side.display}** stake of " +
+                    "**${outcome.stake} credits** is refunded."
+            )
+            .addField("New balance", "${outcome.newBalance} credits", true)
+            .setColor(WagerCommandColors.LOSE)
+            .build()
+
+        is PlayOutcome.Lose -> EmbedBuilder()
+            .setTitle("$TITLE • ${outcome.side.display}")
+            .setDescription(
+                "**Player:** ${handLine(outcome.playerCards, outcome.playerTotal, outcome.isPlayerNatural)}\n" +
+                    "**Banker:** ${handLine(outcome.bankerCards, outcome.bankerTotal, outcome.isBankerNatural)}\n\n" +
+                    "❌ ${outcome.winner.display} wins. Lost **${outcome.stake} credits**." +
+                    tributeLine(outcome.lossTribute)
+            )
+            .addField("New balance", "${outcome.newBalance} credits", true)
+            .setColor(WagerCommandColors.LOSE)
+            .build()
+
+        is PlayOutcome.InsufficientCredits -> WagerCommandEmbeds.failureEmbed(
+            TITLE, WagerCommandFailure.InsufficientCredits(outcome.stake, outcome.have)
+        )
+        is PlayOutcome.InsufficientCoinsForTopUp -> WagerCommandEmbeds.failureEmbed(
+            TITLE, WagerCommandFailure.InsufficientCoinsForTopUp(outcome.needed, outcome.have)
+        )
+        is PlayOutcome.InvalidStake -> WagerCommandEmbeds.failureEmbed(
+            TITLE, WagerCommandFailure.InvalidStake(outcome.min, outcome.max)
+        )
+        PlayOutcome.UnknownUser -> WagerCommandEmbeds.failureEmbed(TITLE, WagerCommandFailure.UnknownUser)
+    }
+
+    fun errorEmbed(message: String): MessageEmbed = WagerCommandEmbeds.errorEmbed(TITLE, message)
+
+    private fun winVerdict(win: PlayOutcome.Win): String {
+        val emoji = when (win.side) {
+            Baccarat.Side.PLAYER -> "✅"
+            Baccarat.Side.BANKER -> "⚖️"
+            Baccarat.Side.TIE -> "🎉"
+        }
+        val flavour = when (win.side) {
+            Baccarat.Side.PLAYER -> "Player wins"
+            Baccarat.Side.BANKER -> "Banker wins (5% commission)"
+            Baccarat.Side.TIE -> "Tie!"
+        }
+        return "$emoji $flavour — won **+${win.net} credits** at ${multiplierLabel(win.multiplier)}."
+    }
+
+    private fun jackpotLine(jackpotPayout: Long): String =
+        if (jackpotPayout > 0L) "\n🎰 Jackpot hit! **+$jackpotPayout credits.**" else ""
+
+    private fun tributeLine(tribute: Long): String =
+        if (tribute > 0L) "\n💰 +$tribute credits to the jackpot pool." else ""
+}

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/BaccaratEmbeds.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/BaccaratEmbeds.kt
@@ -77,44 +77,35 @@ internal object BaccaratEmbeds {
         .build()
 
     fun outcomeEmbed(outcome: PlayOutcome): MessageEmbed = when (outcome) {
-        is PlayOutcome.Win -> {
-            val verdict = winVerdict(outcome)
-            EmbedBuilder()
-                .setTitle("$TITLE • ${outcome.side.display}")
-                .setDescription(
-                    "**Player:** ${handLine(outcome.playerCards, outcome.playerTotal, outcome.isPlayerNatural)}\n" +
-                        "**Banker:** ${handLine(outcome.bankerCards, outcome.bankerTotal, outcome.isBankerNatural)}\n\n" +
-                        verdict +
-                        jackpotLine(outcome.jackpotPayout)
-                )
-                .addField("New balance", "${outcome.newBalance} credits", true)
-                .setColor(WagerCommandColors.WIN)
-                .build()
-        }
+        is PlayOutcome.Win -> WagerCommandEmbeds.outcomeEmbed(
+            title = "$TITLE • ${outcome.side.display}",
+            description = "**Player:** ${handLine(outcome.playerCards, outcome.playerTotal, outcome.isPlayerNatural)}\n" +
+                "**Banker:** ${handLine(outcome.bankerCards, outcome.bankerTotal, outcome.isBankerNatural)}\n\n" +
+                winVerdict(outcome) +
+                jackpotLine(outcome.jackpotPayout),
+            newBalance = outcome.newBalance,
+            color = WagerCommandColors.WIN
+        )
 
-        is PlayOutcome.Push -> EmbedBuilder()
-            .setTitle("$TITLE • ${outcome.side.display}")
-            .setDescription(
-                "**Player:** ${handLine(outcome.playerCards, outcome.playerTotal, outcome.isPlayerNatural)}\n" +
-                    "**Banker:** ${handLine(outcome.bankerCards, outcome.bankerTotal, outcome.isBankerNatural)}\n\n" +
-                    "🤝 Tie game — your **${outcome.side.display}** stake of " +
-                    "**${outcome.stake} credits** is refunded."
-            )
-            .addField("New balance", "${outcome.newBalance} credits", true)
-            .setColor(NEUTRAL_COLOR)
-            .build()
+        is PlayOutcome.Push -> WagerCommandEmbeds.outcomeEmbed(
+            title = "$TITLE • ${outcome.side.display}",
+            description = "**Player:** ${handLine(outcome.playerCards, outcome.playerTotal, outcome.isPlayerNatural)}\n" +
+                "**Banker:** ${handLine(outcome.bankerCards, outcome.bankerTotal, outcome.isBankerNatural)}\n\n" +
+                "🤝 Tie game — your **${outcome.side.display}** stake of " +
+                "**${outcome.stake} credits** is refunded.",
+            newBalance = outcome.newBalance,
+            color = NEUTRAL_COLOR
+        )
 
-        is PlayOutcome.Lose -> EmbedBuilder()
-            .setTitle("$TITLE • ${outcome.side.display}")
-            .setDescription(
-                "**Player:** ${handLine(outcome.playerCards, outcome.playerTotal, outcome.isPlayerNatural)}\n" +
-                    "**Banker:** ${handLine(outcome.bankerCards, outcome.bankerTotal, outcome.isBankerNatural)}\n\n" +
-                    "❌ ${outcome.winner.display} wins. Lost **${outcome.stake} credits**." +
-                    tributeLine(outcome.lossTribute)
-            )
-            .addField("New balance", "${outcome.newBalance} credits", true)
-            .setColor(WagerCommandColors.LOSE)
-            .build()
+        is PlayOutcome.Lose -> WagerCommandEmbeds.outcomeEmbed(
+            title = "$TITLE • ${outcome.side.display}",
+            description = "**Player:** ${handLine(outcome.playerCards, outcome.playerTotal, outcome.isPlayerNatural)}\n" +
+                "**Banker:** ${handLine(outcome.bankerCards, outcome.bankerTotal, outcome.isBankerNatural)}\n\n" +
+                "❌ ${outcome.winner.display} wins. Lost **${outcome.stake} credits**." +
+                tributeLine(outcome.lossTribute),
+            newBalance = outcome.newBalance,
+            color = WagerCommandColors.LOSE
+        )
 
         is PlayOutcome.InsufficientCredits -> WagerCommandEmbeds.failureEmbed(
             TITLE, WagerCommandFailure.InsufficientCredits(outcome.stake, outcome.have)

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/BaccaratEmbeds.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/BaccaratEmbeds.kt
@@ -23,6 +23,7 @@ internal object BaccaratEmbeds {
 
     private const val TITLE = "🎴 Baccarat"
     private val PROMPT_COLOR = Color(0x2C, 0x3E, 0x50)
+    private val NEUTRAL_COLOR = Color(0xA0, 0xA0, 0xB0)
 
     /** "1.95×"-style label used on side-bet buttons and prompt copy. */
     fun multiplierLabel(multiplier: Double): String = "%.2f×".format(multiplier)
@@ -103,7 +104,7 @@ internal object BaccaratEmbeds {
                     "**${outcome.stake} credits** is refunded."
             )
             .addField("New balance", "${outcome.newBalance} credits", true)
-            .setColor(WagerCommandColors.LOSE)
+            .setColor(NEUTRAL_COLOR)
             .build()
 
         is PlayOutcome.Lose -> EmbedBuilder()

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/HighlowCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/HighlowCommand.kt
@@ -59,11 +59,11 @@ class HighlowCommand @Autowired constructor(
         val userId = requestingUserDto.discordId
         val higher = Button.primary(
             HighlowEmbeds.directionButtonId(Highlow.Direction.HIGHER, anchor, stake, userId),
-            "${Highlow.Direction.HIGHER.display} (${HighlowEmbeds.multiplierLabel(higherMultiplier)})"
+            "${Highlow.Direction.HIGHER.display} (${WagerCommandEmbeds.multiplierLabel(higherMultiplier)})"
         )
         val lower = Button.primary(
             HighlowEmbeds.directionButtonId(Highlow.Direction.LOWER, anchor, stake, userId),
-            "${Highlow.Direction.LOWER.display} (${HighlowEmbeds.multiplierLabel(lowerMultiplier)})"
+            "${Highlow.Direction.LOWER.display} (${WagerCommandEmbeds.multiplierLabel(lowerMultiplier)})"
         )
 
         event.hook.sendMessageEmbeds(HighlowEmbeds.anchorEmbed(anchor, stake, higherMultiplier, lowerMultiplier))

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/HighlowEmbeds.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/HighlowEmbeds.kt
@@ -28,9 +28,6 @@ internal object HighlowEmbeds {
         else -> n.toString()
     }
 
-    /** "1.50×"-style label for direction buttons / embed copy. */
-    fun multiplierLabel(multiplier: Double): String = "%.2f×".format(multiplier)
-
     fun directionButtonId(direction: Highlow.Direction, anchor: Int, stake: Long, userId: Long): String =
         listOf(BUTTON_NAME, direction.name, anchor.toString(), stake.toString(), userId.toString())
             .joinToString(BUTTON_DELIM)
@@ -57,8 +54,8 @@ internal object HighlowEmbeds {
             .setTitle("🃏 Anchor: ${cardLabel(anchor)}")
             .setDescription(
                 "Stake **$stake credits**. Will the next card be **higher** or **lower**?\n" +
-                    "Higher pays **${multiplierLabel(higherMultiplier)}**, " +
-                    "lower pays **${multiplierLabel(lowerMultiplier)}**."
+                    "Higher pays **${WagerCommandEmbeds.multiplierLabel(higherMultiplier)}**, " +
+                    "lower pays **${WagerCommandEmbeds.multiplierLabel(lowerMultiplier)}**."
             )
             .setColor(ANCHOR_COLOR)
             .build()
@@ -68,7 +65,7 @@ internal object HighlowEmbeds {
             .setTitle("🃏 ${cardLabel(outcome.anchor)} → ${cardLabel(outcome.next)}")
             .setDescription(
                 "You called **${outcome.direction.display}** at " +
-                    "**${multiplierLabel(outcome.multiplier)}** and won **+${outcome.net} credits**."
+                    "**${WagerCommandEmbeds.multiplierLabel(outcome.multiplier)}** and won **+${outcome.net} credits**."
             )
             .addField("New balance", "${outcome.newBalance} credits", true)
             .setColor(WagerCommandColors.WIN)

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/HighlowEmbeds.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/HighlowEmbeds.kt
@@ -61,22 +61,20 @@ internal object HighlowEmbeds {
             .build()
 
     fun outcomeEmbed(outcome: PlayOutcome): MessageEmbed = when (outcome) {
-        is PlayOutcome.Win -> EmbedBuilder()
-            .setTitle("🃏 ${cardLabel(outcome.anchor)} → ${cardLabel(outcome.next)}")
-            .setDescription(
-                "You called **${outcome.direction.display}** at " +
-                    "**${WagerCommandEmbeds.multiplierLabel(outcome.multiplier)}** and won **+${outcome.net} credits**."
-            )
-            .addField("New balance", "${outcome.newBalance} credits", true)
-            .setColor(WagerCommandColors.WIN)
-            .build()
+        is PlayOutcome.Win -> WagerCommandEmbeds.outcomeEmbed(
+            title = "🃏 ${cardLabel(outcome.anchor)} → ${cardLabel(outcome.next)}",
+            description = "You called **${outcome.direction.display}** at " +
+                "**${WagerCommandEmbeds.multiplierLabel(outcome.multiplier)}** and won **+${outcome.net} credits**.",
+            newBalance = outcome.newBalance,
+            color = WagerCommandColors.WIN
+        )
 
-        is PlayOutcome.Lose -> EmbedBuilder()
-            .setTitle("🃏 ${cardLabel(outcome.anchor)} → ${cardLabel(outcome.next)}")
-            .setDescription("You called **${outcome.direction.display}**. Lost **${outcome.stake} credits**.")
-            .addField("New balance", "${outcome.newBalance} credits", true)
-            .setColor(WagerCommandColors.LOSE)
-            .build()
+        is PlayOutcome.Lose -> WagerCommandEmbeds.outcomeEmbed(
+            title = "🃏 ${cardLabel(outcome.anchor)} → ${cardLabel(outcome.next)}",
+            description = "You called **${outcome.direction.display}**. Lost **${outcome.stake} credits**.",
+            newBalance = outcome.newBalance,
+            color = WagerCommandColors.LOSE
+        )
 
         is PlayOutcome.InsufficientCredits -> WagerCommandEmbeds.failureEmbed(
             TITLE, WagerCommandFailure.InsufficientCredits(outcome.stake, outcome.have)

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/WagerCommandHelper.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/WagerCommandHelper.kt
@@ -61,6 +61,15 @@ internal sealed interface WagerCommandFailure {
 internal object WagerCommandEmbeds {
 
     /**
+     * `"1.95×"`-style label used wherever a per-game payout multiplier
+     * needs to render in button copy or embed prose. Each minigame's
+     * embed file used to carry its own copy; centralised here so the
+     * format stays consistent across `/highlow`, `/baccarat`, and any
+     * future minigame that buttons-up its payout previews.
+     */
+    fun multiplierLabel(multiplier: Double): String = "%.2f×".format(multiplier)
+
+    /**
      * Build an error embed with [title] and [message]. The title is the
      * game-specific prefix (e.g. "🎰 Slots") so the player can tell at a
      * glance which command produced the error.

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/WagerCommandHelper.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/WagerCommandHelper.kt
@@ -70,6 +70,22 @@ internal object WagerCommandEmbeds {
     fun multiplierLabel(multiplier: Double): String = "%.2f×".format(multiplier)
 
     /**
+     * Win/Lose/Push outcome embed skeleton shared across the casino
+     * minigames: title + per-game body + "New balance: N credits" inline
+     * field + win/lose/neutral colour. Each game still owns its own
+     * description copy (verdict, multiplier, hand layout, etc.) — this
+     * just centralises the surrounding chrome so the field name,
+     * "credits" suffix, and inline convention stay aligned across games.
+     */
+    fun outcomeEmbed(title: String, description: String, newBalance: Long, color: Color): MessageEmbed =
+        EmbedBuilder()
+            .setTitle(title)
+            .setDescription(description)
+            .addField("New balance", "$newBalance credits", true)
+            .setColor(color)
+            .build()
+
+    /**
      * Build an error embed with [title] and [message]. The title is the
      * game-specific prefix (e.g. "🎰 Slots") so the player can tell at a
      * glance which command produced the error.

--- a/discord-bot/src/test/kotlin/bot/toby/button/buttons/BaccaratButtonTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/button/buttons/BaccaratButtonTest.kt
@@ -1,0 +1,150 @@
+package bot.toby.button.buttons
+
+import bot.toby.button.ButtonTest
+import bot.toby.button.ButtonTest.Companion.event
+import bot.toby.button.ButtonTest.Companion.mockGuild
+import bot.toby.button.DefaultButtonContext
+import database.card.Card
+import database.card.Rank
+import database.card.Suit
+import database.dto.UserDto
+import database.economy.Baccarat
+import database.service.BaccaratService
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import net.dv8tion.jda.api.components.MessageTopLevelComponent
+import net.dv8tion.jda.api.entities.MessageEmbed
+import net.dv8tion.jda.api.requests.restaction.interactions.MessageEditCallbackAction
+import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class BaccaratButtonTest : ButtonTest {
+
+    private lateinit var baccaratService: BaccaratService
+    private lateinit var button: BaccaratButton
+    private lateinit var editAction: MessageEditCallbackAction
+    private lateinit var replyAction: ReplyCallbackAction
+
+    private val ownerId = 6L
+    private val guildId = 1L
+    private val stake = 50L
+
+    @BeforeEach
+    override fun setup() {
+        super.setup()
+        every { mockGuild.idLong } returns guildId
+
+        baccaratService = mockk(relaxed = true)
+        button = BaccaratButton(baccaratService)
+
+        // F-bounded generics on JDA's MessageEditCallbackAction don't survive
+        // mockk's relaxed deep-stubs cleanly, so wire the chain manually.
+        editAction = mockk(relaxed = true)
+        every { editAction.setComponents(any<Collection<MessageTopLevelComponent>>()) } returns editAction
+        every { editAction.setComponents(*anyVararg<MessageTopLevelComponent>()) } returns editAction
+        every { editAction.queue() } just Runs
+        every { event.editMessageEmbeds(any<MessageEmbed>()) } returns editAction
+
+        replyAction = mockk(relaxed = true)
+        every { replyAction.setEphemeral(any()) } returns replyAction
+        every { replyAction.queue() } just Runs
+        every { event.reply(any<String>()) } returns replyAction
+    }
+
+    @AfterEach
+    @Throws(Exception::class)
+    override fun tearDown() {
+        super.tearDown()
+    }
+
+    private fun loseOutcome(side: Baccarat.Side) = BaccaratService.PlayOutcome.Lose(
+        stake = stake,
+        side = side,
+        winner = if (side == Baccarat.Side.BANKER) Baccarat.Side.PLAYER else Baccarat.Side.BANKER,
+        playerCards = listOf(Card(Rank.FIVE, Suit.SPADES), Card(Rank.THREE, Suit.HEARTS)),
+        bankerCards = listOf(Card(Rank.NINE, Suit.CLUBS), Card(Rank.SEVEN, Suit.DIAMONDS)),
+        playerTotal = 8,
+        bankerTotal = 6,
+        isPlayerNatural = true,
+        isBankerNatural = false,
+        newBalance = 950L
+    )
+
+    @Test
+    fun `routes click to BaccaratService with parsed side and stake`() {
+        every { event.componentId } returns "baccarat:PLAYER:$stake:$ownerId"
+        every {
+            baccaratService.play(ownerId, guildId, stake, Baccarat.Side.PLAYER)
+        } returns loseOutcome(Baccarat.Side.PLAYER)
+
+        button.handle(DefaultButtonContext(event), UserDto(ownerId, guildId), 0)
+
+        verify(exactly = 1) {
+            baccaratService.play(ownerId, guildId, stake, Baccarat.Side.PLAYER)
+        }
+        verify { event.editMessageEmbeds(any<MessageEmbed>()) }
+        verify { editAction.queue() }
+    }
+
+    @Test
+    fun `BANKER and TIE sides parse correctly`() {
+        every { event.componentId } returns "baccarat:BANKER:25:$ownerId"
+        every {
+            baccaratService.play(ownerId, guildId, 25L, Baccarat.Side.BANKER)
+        } returns loseOutcome(Baccarat.Side.BANKER)
+
+        button.handle(DefaultButtonContext(event), UserDto(ownerId, guildId), 0)
+        verify(exactly = 1) {
+            baccaratService.play(ownerId, guildId, 25L, Baccarat.Side.BANKER)
+        }
+
+        every { event.componentId } returns "baccarat:TIE:75:$ownerId"
+        every {
+            baccaratService.play(ownerId, guildId, 75L, Baccarat.Side.TIE)
+        } returns loseOutcome(Baccarat.Side.TIE)
+
+        button.handle(DefaultButtonContext(event), UserDto(ownerId, guildId), 0)
+        verify(exactly = 1) {
+            baccaratService.play(ownerId, guildId, 75L, Baccarat.Side.TIE)
+        }
+    }
+
+    @Test
+    fun `edits the original message and clears components`() {
+        every { event.componentId } returns "baccarat:PLAYER:$stake:$ownerId"
+        every {
+            baccaratService.play(ownerId, guildId, stake, Baccarat.Side.PLAYER)
+        } returns loseOutcome(Baccarat.Side.PLAYER)
+
+        button.handle(DefaultButtonContext(event), UserDto(ownerId, guildId), 0)
+
+        verify { event.editMessageEmbeds(any<MessageEmbed>()) }
+        verify { editAction.setComponents(any<Collection<MessageTopLevelComponent>>()) }
+    }
+
+    @Test
+    fun `another player clicking someone else's round is rejected ephemerally without resolving`() {
+        every { event.componentId } returns "baccarat:PLAYER:$stake:$ownerId"
+
+        button.handle(DefaultButtonContext(event), UserDto(999L, guildId), 0)
+
+        verify(exactly = 0) { baccaratService.play(any(), any(), any(), any(), any()) }
+        verify { event.reply(any<String>()) }
+        verify { replyAction.setEphemeral(true) }
+        verify { replyAction.queue() }
+    }
+
+    @Test
+    fun `malformed component id is acked without resolving`() {
+        every { event.componentId } returns "baccarat:bogus"
+
+        button.handle(DefaultButtonContext(event), UserDto(ownerId, guildId), 0)
+
+        verify(exactly = 0) { baccaratService.play(any(), any(), any(), any(), any()) }
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/economy/BaccaratCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/economy/BaccaratCommandTest.kt
@@ -1,0 +1,86 @@
+package bot.toby.command.commands.economy
+
+import bot.toby.command.CommandTest
+import bot.toby.command.CommandTest.Companion.event
+import bot.toby.command.CommandTest.Companion.guild
+import bot.toby.command.CommandTest.Companion.webhookMessageCreateAction
+import bot.toby.command.DefaultCommandContext
+import database.dto.UserDto
+import database.economy.Baccarat
+import database.service.BaccaratService
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import net.dv8tion.jda.api.components.actionrow.ActionRow
+import net.dv8tion.jda.api.entities.MessageEmbed
+import net.dv8tion.jda.api.interactions.commands.OptionMapping
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class BaccaratCommandTest : CommandTest {
+    private lateinit var baccaratService: BaccaratService
+    private lateinit var command: BaccaratCommand
+
+    private val discordId = 1L
+    private val guildId = 42L
+
+    @BeforeEach
+    fun setUp() {
+        setUpCommonMocks()
+        baccaratService = mockk(relaxed = true)
+        every { baccaratService.previewMultiplier(Baccarat.Side.PLAYER) } returns 2.0
+        every { baccaratService.previewMultiplier(Baccarat.Side.BANKER) } returns 1.95
+        every { baccaratService.previewMultiplier(Baccarat.Side.TIE) } returns 9.0
+        command = BaccaratCommand(baccaratService)
+        every { guild.idLong } returns guildId
+    }
+
+    @AfterEach
+    fun tearDown() {
+        tearDownCommonMocks()
+        clearAllMocks()
+    }
+
+    private fun intOpt(value: Long): OptionMapping = mockk<OptionMapping>(relaxed = true).also {
+        every { it.asLong } returns value
+    }
+
+    @Test
+    fun `posts the prompt embed and three side buttons without resolving the wager`() {
+        val user = UserDto(discordId = discordId, guildId = guildId)
+        every { event.getOption("stake") } returns intOpt(50L)
+
+        command.handle(DefaultCommandContext(event), user, 5)
+
+        verify(exactly = 0) { baccaratService.play(any(), any(), any(), any(), any()) }
+        verify { event.hook.sendMessageEmbeds(any<MessageEmbed>()) }
+        verify { webhookMessageCreateAction.addComponents(any<ActionRow>()) }
+    }
+
+    @Test
+    fun `encodes side stake and user into each button component id`() {
+        val stake = 50L
+        Baccarat.Side.entries.forEach { side ->
+            val id = BaccaratEmbeds.sideButtonId(side, stake, discordId)
+            val parsed = BaccaratEmbeds.parseButtonId(id)
+            assertNotNull(parsed)
+            assertEquals(side, parsed!!.side)
+            assertEquals(stake, parsed.stake)
+            assertEquals(discordId, parsed.userId)
+        }
+    }
+
+    @Test
+    fun `does not invoke the service when no stake is provided`() {
+        val user = UserDto(discordId = discordId, guildId = guildId)
+        every { event.getOption("stake") } returns null
+
+        command.handle(DefaultCommandContext(event), user, 5)
+
+        verify(exactly = 0) { baccaratService.play(any(), any(), any(), any(), any()) }
+    }
+}

--- a/web/src/main/kotlin/web/controller/BaccaratController.kt
+++ b/web/src/main/kotlin/web/controller/BaccaratController.kt
@@ -1,0 +1,190 @@
+package web.controller
+
+import database.economy.Baccarat
+import database.service.BaccaratService
+import database.service.BaccaratService.PlayOutcome
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.security.oauth2.core.user.OAuth2User
+import org.springframework.stereotype.Controller
+import org.springframework.ui.Model
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseBody
+import org.springframework.web.servlet.mvc.support.RedirectAttributes
+import web.casino.CasinoOutcomeMapper
+import web.casino.CasinoPageContext
+import web.casino.CasinoResponseLike
+import web.service.EconomyWebService
+import web.util.WebGuildAccess
+
+/**
+ * Web surface for the `/baccarat` minigame. GET renders the picker UI
+ * (Player / Banker / Tie + stake input + autoTopUp); POST runs the hand
+ * via [BaccaratService.play] and returns JSON with both hands + verdict.
+ *
+ * Same shape as [CoinflipController] — baccarat is a one-shot wager so
+ * there's no session state, no anchor-then-resolve split. The card-game
+ * polish comes from rendering both hands client-side via the shared
+ * `casino-render.js` glyph engine.
+ *
+ * Both surfaces share [BaccaratService] so Discord and web can't drift
+ * on payout maths, third-card tableau, or balance debit/credit semantics.
+ */
+@Controller
+@RequestMapping("/casino/{guildId}/baccarat")
+class BaccaratController(
+    private val baccaratService: BaccaratService,
+    private val economyWebService: EconomyWebService,
+    private val pageContext: CasinoPageContext,
+) {
+
+    private val errors = CasinoOutcomeMapper { msg -> BaccaratPlayResponse(false, msg) }
+
+    @GetMapping
+    fun page(
+        @PathVariable guildId: Long,
+        @AuthenticationPrincipal user: OAuth2User,
+        model: Model,
+        ra: RedirectAttributes
+    ): String = WebGuildAccess.requireMemberForPage(
+        user, guildId, economyWebService, ra, lobbyPath = "/casino/guilds"
+    ) { discordId ->
+        pageContext.populate(model, guildId, discordId, user) ?: run {
+            ra.addFlashAttribute("error", "Bot is not in that server.")
+            return@requireMemberForPage "redirect:/casino/guilds"
+        }
+        model.addAttribute("minStake", Baccarat.MIN_STAKE)
+        model.addAttribute("maxStake", Baccarat.MAX_STAKE)
+        model.addAttribute("playerMultiplier", Baccarat.PLAYER_WIN_MULT)
+        model.addAttribute("bankerMultiplier", Baccarat.BANKER_WIN_MULT)
+        model.addAttribute("tieMultiplier", Baccarat.TIE_WIN_MULT)
+        "baccarat"
+    }
+
+    @PostMapping("/play")
+    @ResponseBody
+    fun play(
+        @PathVariable guildId: Long,
+        @RequestBody request: BaccaratPlayRequest,
+        @AuthenticationPrincipal user: OAuth2User
+    ): ResponseEntity<BaccaratPlayResponse> = WebGuildAccess.requireMemberForJson(
+        user, guildId, economyWebService, errorBuilder = errors.errorBuilder
+    ) { discordId ->
+        val side = parseSide(request.side)
+            ?: return@requireMemberForJson errors.badRequest("Pick a side: PLAYER, BANKER, or TIE.")
+
+        when (val outcome = baccaratService.play(discordId, guildId, request.stake, side, request.autoTopUp)) {
+            is PlayOutcome.Win -> ResponseEntity.ok(
+                BaccaratPlayResponse(
+                    ok = true,
+                    side = outcome.side.name,
+                    winner = outcome.winner.name,
+                    playerCards = outcome.playerCards.map { it.toString() },
+                    bankerCards = outcome.bankerCards.map { it.toString() },
+                    playerTotal = outcome.playerTotal,
+                    bankerTotal = outcome.bankerTotal,
+                    isPlayerNatural = outcome.isPlayerNatural,
+                    isBankerNatural = outcome.isBankerNatural,
+                    multiplier = outcome.multiplier,
+                    net = outcome.net,
+                    payout = outcome.payout,
+                    newBalance = outcome.newBalance,
+                    win = true,
+                    push = false,
+                    jackpotPayout = outcome.jackpotPayout.takeIf { it > 0L },
+                    soldTobyCoins = outcome.soldTobyCoins.takeIf { it > 0L },
+                    newPrice = outcome.newPrice,
+                )
+            )
+
+            is PlayOutcome.Push -> ResponseEntity.ok(
+                BaccaratPlayResponse(
+                    ok = true,
+                    side = outcome.side.name,
+                    winner = "TIE",
+                    playerCards = outcome.playerCards.map { it.toString() },
+                    bankerCards = outcome.bankerCards.map { it.toString() },
+                    playerTotal = outcome.playerTotal,
+                    bankerTotal = outcome.bankerTotal,
+                    isPlayerNatural = outcome.isPlayerNatural,
+                    isBankerNatural = outcome.isBankerNatural,
+                    multiplier = Baccarat.PUSH_MULT,
+                    net = 0L,
+                    payout = outcome.stake,
+                    newBalance = outcome.newBalance,
+                    win = false,
+                    push = true,
+                    soldTobyCoins = outcome.soldTobyCoins.takeIf { it > 0L },
+                    newPrice = outcome.newPrice,
+                )
+            )
+
+            is PlayOutcome.Lose -> ResponseEntity.ok(
+                BaccaratPlayResponse(
+                    ok = true,
+                    side = outcome.side.name,
+                    winner = outcome.winner.name,
+                    playerCards = outcome.playerCards.map { it.toString() },
+                    bankerCards = outcome.bankerCards.map { it.toString() },
+                    playerTotal = outcome.playerTotal,
+                    bankerTotal = outcome.bankerTotal,
+                    isPlayerNatural = outcome.isPlayerNatural,
+                    isBankerNatural = outcome.isBankerNatural,
+                    net = -outcome.stake,
+                    payout = 0L,
+                    newBalance = outcome.newBalance,
+                    win = false,
+                    push = false,
+                    soldTobyCoins = outcome.soldTobyCoins.takeIf { it > 0L },
+                    newPrice = outcome.newPrice,
+                    lossTribute = outcome.lossTribute.takeIf { it > 0L },
+                )
+            )
+
+            is PlayOutcome.InsufficientCredits -> errors.insufficientCredits(outcome.stake, outcome.have)
+            is PlayOutcome.InsufficientCoinsForTopUp -> errors.insufficientCoinsForTopUp(outcome.needed, outcome.have)
+            is PlayOutcome.InvalidStake -> errors.invalidStake(outcome.min, outcome.max)
+            PlayOutcome.UnknownUser -> errors.unknownUser()
+        }
+    }
+
+    private fun parseSide(raw: String?): Baccarat.Side? = when (raw?.uppercase()) {
+        "PLAYER" -> Baccarat.Side.PLAYER
+        "BANKER" -> Baccarat.Side.BANKER
+        "TIE" -> Baccarat.Side.TIE
+        else -> null
+    }
+}
+
+data class BaccaratPlayRequest(
+    val side: String = "",
+    val stake: Long = 0,
+    val autoTopUp: Boolean = false
+)
+
+data class BaccaratPlayResponse(
+    override val ok: Boolean,
+    override val error: String? = null,
+    val side: String? = null,
+    val winner: String? = null,
+    val playerCards: List<String>? = null,
+    val bankerCards: List<String>? = null,
+    val playerTotal: Int? = null,
+    val bankerTotal: Int? = null,
+    val isPlayerNatural: Boolean? = null,
+    val isBankerNatural: Boolean? = null,
+    val multiplier: Double? = null,
+    val net: Long? = null,
+    val payout: Long? = null,
+    val newBalance: Long? = null,
+    val win: Boolean? = null,
+    val push: Boolean? = null,
+    val jackpotPayout: Long? = null,
+    val soldTobyCoins: Long? = null,
+    val newPrice: Double? = null,
+    val lossTribute: Long? = null,
+) : CasinoResponseLike

--- a/web/src/main/resources/static/css/baccarat.css
+++ b/web/src/main/resources/static/css/baccarat.css
@@ -1,0 +1,204 @@
+/*
+ * Baccarat-specific styles. The shared "casino table" look (felt, cards,
+ * deal animation) lives in casino-table.css and is loaded via the @import
+ * below — same pattern as blackjack.css.
+ *
+ * Baccarat is a one-shot wager (no mid-hand actions), so this file is
+ * smaller than blackjack.css: side picker, both-hands layout, win/push/
+ * lose result accents.
+ */
+@import url("./casino-table.css");
+
+.bac-header {
+    margin-bottom: 1.5rem;
+}
+
+.bac-header h1 {
+    margin: 0.25rem 0 0.5rem;
+}
+
+.bac-card {
+    background: var(--surface, #1f2128);
+    border-radius: 0.75rem;
+    padding: 1.5rem;
+    max-width: 56rem;
+    margin-bottom: 1.5rem;
+}
+
+.bac-card h2 {
+    margin-top: 0;
+    margin-bottom: 1rem;
+}
+
+.bac-card form {
+    display: grid;
+    gap: 0.5rem;
+    margin-bottom: 1.25rem;
+}
+
+.bac-card input[type="number"] {
+    background: var(--surface-2, #16181d);
+    color: inherit;
+    border: 1px solid var(--border, #2a2d35);
+    border-radius: 0.4rem;
+    padding: 0.5rem 0.75rem;
+    font: inherit;
+}
+
+.bac-card input[type="number"]:focus {
+    outline: 2px solid var(--accent, #5865f2);
+    outline-offset: 2px;
+}
+
+.bac-balance {
+    color: var(--muted, #a0a0b0);
+}
+
+/* Three-up side picker — Player / Banker / Tie. Each label is a
+   click-target tile that highlights when its radio is checked. */
+.bac-side-picker {
+    border: 0;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 0.5rem;
+}
+
+.bac-side-picker legend {
+    padding: 0;
+    margin-bottom: 0.5rem;
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--text-muted, #a0a0b0);
+}
+
+.bac-side {
+    background: var(--surface-2, #16181d);
+    border: 1px solid var(--border, #2a2d35);
+    border-radius: 0.5rem;
+    padding: 0.75rem;
+    cursor: pointer;
+    display: grid;
+    gap: 0.15rem;
+    transition: border-color 120ms ease, background 120ms ease;
+}
+
+.bac-side:hover {
+    border-color: var(--accent, #5865f2);
+}
+
+.bac-side input[type="radio"] {
+    position: absolute;
+    opacity: 0;
+    pointer-events: none;
+}
+
+.bac-side:has(input:checked) {
+    border-color: var(--accent, #5865f2);
+    background: rgba(88, 101, 242, 0.12);
+}
+
+.bac-side-name {
+    font-weight: 600;
+    font-size: 1rem;
+}
+
+.bac-side-mult {
+    font-variant-numeric: tabular-nums;
+    color: #57f287;
+    font-weight: 600;
+}
+
+.bac-side-note {
+    font-size: 0.78rem;
+}
+
+.bac-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-top: 0.5rem;
+}
+
+/* Two-hand table — Banker on top (dealer-zone polish from casino-table.css)
+   and Player below, each with its own card row and totals badge. */
+.bac-table .bac-row {
+    margin: 1rem 0;
+}
+
+.bac-table .bac-row h3 {
+    margin: 0 0 0.5rem;
+    font-size: 1rem;
+    font-weight: 600;
+}
+
+.bac-cards {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+    min-height: 4.5rem;
+}
+
+.bac-result {
+    margin-top: 1rem;
+    color: var(--muted, #a0a0b0);
+    line-height: 1.4;
+}
+
+.bac-result.bac-result-win {
+    color: #57f287;
+}
+
+.bac-result.bac-result-lose {
+    color: #ed4245;
+}
+
+.bac-result.bac-result-push {
+    color: #f0c040;
+}
+
+/* Same `[hidden]` override as blackjack — the explicit `display:flex` on
+   `.bac-cards` would otherwise outrank the UA `[hidden]{display:none}`,
+   leaving the previous round's hands on screen after a fresh deal. */
+.bac-cards[hidden] {
+    display: none;
+}
+
+/* Rules block — same shape as blackjack/highlow rules sections. */
+.bac-rules {
+    margin-top: var(--space-5);
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: var(--space-4);
+}
+.bac-rules h2 {
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--text-muted);
+    margin-bottom: var(--space-3);
+}
+.bac-rules ul {
+    list-style: disc;
+    padding-left: 20px;
+    color: var(--text-muted);
+    font-size: 0.95rem;
+    line-height: 1.7;
+}
+.bac-rules strong { color: #fff; }
+
+@media (max-width: 600px) {
+    .bac-card {
+        padding: 1rem;
+        max-width: 100%;
+    }
+    .bac-header h1 {
+        font-size: 1.4rem;
+    }
+    .bac-side-picker {
+        grid-template-columns: 1fr;
+    }
+}

--- a/web/src/main/resources/static/css/base.css
+++ b/web/src/main/resources/static/css/base.css
@@ -432,7 +432,8 @@ td { font-size: 0.95rem; }
 .coinflip-result-jackpot,
 .dice-result-jackpot,
 .highlow-result-jackpot,
-.scratch-result-jackpot {
+.scratch-result-jackpot,
+.bac-result-jackpot {
     color: #f1c40f;
     text-shadow: 0 0 8px rgba(241, 196, 15, 0.4);
 }

--- a/web/src/main/resources/static/js/baccarat.js
+++ b/web/src/main/resources/static/js/baccarat.js
@@ -1,0 +1,155 @@
+// Pure-DOM render for a /play response. Hoisted out of the IIFE so a
+// future jest test can drive it without booting the page. Mirrors the
+// shape of renderCoinflipResult / renderHighlowResult.
+function renderBaccaratResult(opts) {
+    var resultEl = opts.resultEl;
+    var bankerCardsEl = opts.bankerCardsEl;
+    var playerCardsEl = opts.playerCardsEl;
+    var bankerTotalEl = opts.bankerTotalEl;
+    var playerTotalEl = opts.playerTotalEl;
+    var tableEl = opts.tableEl;
+    var body = opts.body;
+
+    if (tableEl) tableEl.hidden = false;
+
+    // Card glyphs come from the shared casino-render module (red ♥/♦
+    // colouring + deal animation are automatic). Bail to plain text if
+    // the module is missing (e.g. in jsdom unit tests).
+    var render = (typeof window !== 'undefined' && window.CasinoRender)
+        ? window.CasinoRender.renderCards
+        : null;
+    if (render) {
+        if (bankerCardsEl) render(bankerCardsEl, body.bankerCards || []);
+        if (playerCardsEl) render(playerCardsEl, body.playerCards || []);
+    } else {
+        if (bankerCardsEl) bankerCardsEl.textContent = (body.bankerCards || []).join(' ');
+        if (playerCardsEl) playerCardsEl.textContent = (body.playerCards || []).join(' ');
+    }
+
+    if (bankerTotalEl) {
+        var bankerTag = body.isBankerNatural ? ' • Natural' : '';
+        bankerTotalEl.textContent = '(' + body.bankerTotal + bankerTag + ')';
+    }
+    if (playerTotalEl) {
+        var playerTag = body.isPlayerNatural ? ' • Natural' : '';
+        playerTotalEl.textContent = '(' + body.playerTotal + playerTag + ')';
+    }
+
+    if (!resultEl) return;
+    var sideLabel = sideName(body.side);
+    var winnerLabel = sideName(body.winner);
+
+    if (body.push) {
+        // Tied game on a Player/Banker bet — stake refunded, neither
+        // win nor lose. Skip the shared TobyCasinoResult helper because
+        // it only knows the win/lose dichotomy; render the push line
+        // directly so the colour and class can be -push.
+        resultEl.hidden = false;
+        resultEl.classList.remove('bac-result-win', 'bac-result-lose', 'bac-result-jackpot');
+        resultEl.classList.add('bac-result-push');
+        var topUpPrefix = (typeof window !== 'undefined' && window.TobyTopUp)
+            ? window.TobyTopUp.soldPrefixHtml(body.soldTobyCoins, body.newPrice)
+            : '';
+        resultEl.innerHTML = topUpPrefix +
+            '🤝 <strong>Tie game.</strong> Your <strong>' + sideLabel + '</strong> stake of ' +
+            '<strong>' + body.payout + ' credits</strong> is refunded.';
+        return;
+    }
+
+    if (typeof window !== 'undefined' && window.TobyCasinoResult) {
+        window.TobyCasinoResult.render({
+            resultEl: resultEl,
+            body: body,
+            classPrefix: 'bac',
+            winLineHtml: winLineHtml(body, sideLabel, winnerLabel),
+            loseLineHtml: loseLineHtml(body, sideLabel, winnerLabel),
+        });
+    }
+}
+
+function sideName(raw) {
+    if (raw === 'PLAYER') return 'Player';
+    if (raw === 'BANKER') return 'Banker';
+    if (raw === 'TIE') return 'Tie';
+    return String(raw || '');
+}
+
+function winLineHtml(body, sideLabel, winnerLabel) {
+    var multTxt = (typeof body.multiplier === 'number')
+        ? body.multiplier.toFixed(2) + '×'
+        : '';
+    var prefix = body.side === 'TIE' ? '🎉 <strong>Tie!</strong>' :
+        body.side === 'BANKER' ? '⚖️ <strong>Banker wins (5% commission).</strong>' :
+        '✅ <strong>Player wins.</strong>';
+    return prefix + ' Won <strong>+' + body.net + ' credits</strong> at ' + multTxt + '.';
+}
+
+function loseLineHtml(body, sideLabel, winnerLabel) {
+    return '❌ <strong>' + winnerLabel + ' wins.</strong> You called <strong>' +
+        sideLabel + '</strong> · lost <strong>' + Math.abs(body.net) + ' credits</strong>.';
+}
+
+(function () {
+    'use strict';
+
+    var main = document.querySelector('main[data-guild-id]');
+    if (!main) return;
+
+    var guildId = main.dataset.guildId;
+    var stakeInput = document.getElementById('bac-stake');
+    var dealBtn = document.getElementById('bac-deal');
+    var dealTobyBtn = document.getElementById('bac-deal-toby');
+    var balanceEl = document.getElementById('bac-balance');
+    var resultEl = document.getElementById('bac-result');
+    var form = document.getElementById('bac-bet');
+    var tableEl = document.getElementById('bac-table');
+    var bankerCardsEl = document.getElementById('bac-banker-cards');
+    var playerCardsEl = document.getElementById('bac-player-cards');
+    var bankerTotalEl = document.getElementById('bac-banker-total');
+    var playerTotalEl = document.getElementById('bac-player-total');
+
+    if (!form || !dealBtn || !stakeInput) return;
+
+    function selectedSide() {
+        var checked = form.querySelector('input[name="side"]:checked');
+        return checked ? checked.value : null;
+    }
+
+    if (window.TobyCasinoGame) {
+        window.TobyCasinoGame.init({
+            guildId: guildId,
+            endpoint: '/casino/' + guildId + '/baccarat/play',
+            form: form,
+            stakeInput: stakeInput,
+            primaryBtn: dealBtn,
+            tobyBtn: dealTobyBtn,
+            balanceEl: balanceEl,
+            resultEl: resultEl,
+            tobyCoins: Number(main.dataset.tobyCoins) || 0,
+            marketPrice: Number(main.dataset.marketPrice) || 0,
+            failureMessage: 'Deal failed.',
+            validate: function () {
+                if (!selectedSide()) return 'Pick a side first.';
+                return null;
+            },
+            buildPayload: function (state) {
+                return { side: selectedSide(), stake: state.stake, autoTopUp: state.autoTopUp };
+            },
+            renderResult: function (body) {
+                renderBaccaratResult({
+                    resultEl: resultEl,
+                    bankerCardsEl: bankerCardsEl,
+                    playerCardsEl: playerCardsEl,
+                    bankerTotalEl: bankerTotalEl,
+                    playerTotalEl: playerTotalEl,
+                    tableEl: tableEl,
+                    body: body,
+                });
+            },
+        });
+    }
+})();
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { renderBaccaratResult };
+}

--- a/web/src/main/resources/templates/baccarat.html
+++ b/web/src/main/resources/templates/baccarat.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="en">
+<head th:replace="~{fragments/head :: head('TobyBot - Baccarat', '/css/baccarat.css')}"></head>
+<body>
+<a href="#main" class="skip-link">Skip to content</a>
+<div th:replace="~{fragments/navbar :: navbar}"></div>
+
+<main id="main" class="container"
+      th:attr="data-guild-id=${guildId}, data-toby-coins=${tobyCoins}, data-market-price=${marketPrice}, data-min-stake=${minStake}, data-max-stake=${maxStake}">
+
+    <div class="bac-header">
+        <a class="back-link" th:href="@{/casino/guilds}">&larr; All casino servers</a>
+        <h1 th:text="'🎴 Baccarat • ' + ${guildName}">🎴 Baccarat</h1>
+        <p class="muted">
+            Pick a side. Both hands deal automatically per the standard Punto Banco tableau.
+            Bet between <span th:text="${minStake}">10</span> and
+            <span th:text="${maxStake}">500</span> credits.
+        </p>
+    </div>
+
+    <div th:replace="~{fragments/alerts :: error}"></div>
+
+    <div th:replace="~{fragments/casino :: jackpotBanner}"></div>
+
+    <section class="bac-card">
+        <h2>Place your bet</h2>
+        <form id="bac-bet" autocomplete="off">
+            <fieldset class="bac-side-picker" aria-label="Pick a side">
+                <legend>Side</legend>
+                <label class="bac-side">
+                    <input type="radio" name="side" value="PLAYER" checked>
+                    <span class="bac-side-name">Player</span>
+                    <span class="bac-side-mult"
+                          th:text="${#numbers.formatDecimal(playerMultiplier, 1, 2)} + '×'">2.00×</span>
+                </label>
+                <label class="bac-side">
+                    <input type="radio" name="side" value="BANKER">
+                    <span class="bac-side-name">Banker</span>
+                    <span class="bac-side-mult"
+                          th:text="${#numbers.formatDecimal(bankerMultiplier, 1, 2)} + '×'">1.95×</span>
+                    <span class="bac-side-note muted">5% commission</span>
+                </label>
+                <label class="bac-side">
+                    <input type="radio" name="side" value="TIE">
+                    <span class="bac-side-name">Tie</span>
+                    <span class="bac-side-mult"
+                          th:text="${#numbers.formatDecimal(tieMultiplier, 1, 2)} + '×'">9.00×</span>
+                </label>
+            </fieldset>
+            <label for="bac-stake">Stake (credits)</label>
+            <input id="bac-stake" name="stake" type="number"
+                   th:attr="min=${minStake}, max=${maxStake}" th:value="${minStake}" step="1" required>
+
+            <div class="bac-actions">
+                <button type="submit" id="bac-deal" class="btn-primary">Deal</button>
+                <button type="submit" id="bac-deal-toby" class="btn-secondary casino-bet-toby" hidden
+                        title="Sells just enough TOBY at the live market price to cover the shortfall, then deals.">
+                    Deal (sell <span class="casino-bet-toby-coins">0</span> TOBY)
+                </button>
+            </div>
+        </form>
+        <div class="bac-balance">
+            Wallet: <strong id="bac-balance" th:text="${balance}">0</strong> credits
+        </div>
+    </section>
+
+    <section class="bac-card bac-table casino-felt" id="bac-table" hidden>
+        <div class="bac-row casino-dealer-zone">
+            <h3>Banker <span class="muted" id="bac-banker-total"></span></h3>
+            <div id="bac-banker-cards" class="bac-cards casino-cards"></div>
+        </div>
+        <div class="bac-row casino-seat" id="bac-player-row">
+            <h3>Player <span class="muted" id="bac-player-total"></span></h3>
+            <div id="bac-player-cards" class="bac-cards casino-cards"></div>
+        </div>
+
+        <div id="bac-result" class="bac-result muted" hidden></div>
+    </section>
+
+    <section class="bac-rules">
+        <h2>Rules</h2>
+        <ul>
+            <li>Card values: <strong>A=1</strong>, 2–9 face value, <strong>10/J/Q/K=0</strong>. Hand total is the sum mod 10 (so 7+8=5).</li>
+            <li>Each side starts with two cards. If either has a total of 8 or 9, that's a <strong>Natural</strong> — both hands stand.</li>
+            <li>Otherwise: <strong>Player</strong> draws a third card on totals 0–5, stands on 6–7. <strong>Banker</strong>'s draw rule depends on whether Player drew and the value of Player's third card (the standard Punto Banco tableau).</li>
+            <li>Highest total after at most one extra card per side wins.</li>
+            <li>Winning bets: <strong>Player</strong> pays
+                <strong th:text="${#numbers.formatDecimal(playerMultiplier, 1, 2)} + '×'">2.00×</strong>,
+                <strong>Banker</strong> pays
+                <strong th:text="${#numbers.formatDecimal(bankerMultiplier, 1, 2)} + '×'">1.95×</strong>
+                (5% commission on the win), <strong>Tie</strong> pays
+                <strong th:text="${#numbers.formatDecimal(tieMultiplier, 1, 2)} + '×'">9.00×</strong>.</li>
+            <li>On a tied game, <strong>Player</strong> and <strong>Banker</strong> side bets are refunded.</li>
+        </ul>
+    </section>
+</main>
+
+<div class="toast-stack" id="toast-stack" aria-live="polite"></div>
+
+<script th:src="@{/js/api.js}"></script>
+<script th:src="@{/js/toasts.js}"></script>
+<script th:src="@{/js/casino-sounds.js}"></script>
+<script th:src="@{/js/casino-jackpot.js}"></script>
+<script th:src="@{/js/casino-topup.js}"></script>
+<script th:src="@{/js/casino-result.js}"></script>
+<script th:src="@{/js/casino-render.js}"></script>
+<script th:src="@{/js/casino-game.js}"></script>
+<script th:src="@{/js/baccarat.js}"></script>
+</body>
+</html>

--- a/web/src/main/resources/templates/fragments/navbar.html
+++ b/web/src/main/resources/templates/fragments/navbar.html
@@ -40,6 +40,7 @@
                 <a href="/casino/guilds" role="menuitem">&#127903;&#65039; Scratch</a>
                 <a href="/poker/guilds" role="menuitem">&#127924; Poker</a>
                 <a href="/blackjack/guilds" role="menuitem">&#127922; Blackjack</a>
+                <a href="/casino/guilds" role="menuitem">&#127924; Baccarat</a>
             </div>
         </div>
         <a href="/intro/guilds">Intro Songs</a>

--- a/web/src/test/js/baccarat.test.js
+++ b/web/src/test/js/baccarat.test.js
@@ -1,0 +1,218 @@
+const { renderBaccaratResult } = require('../../main/resources/static/js/baccarat');
+require('../../main/resources/static/js/casino-jackpot');
+require('../../main/resources/static/js/casino-result');
+
+describe('renderBaccaratResult', () => {
+    let resultEl;
+    let bankerCardsEl;
+    let playerCardsEl;
+    let bankerTotalEl;
+    let playerTotalEl;
+    let tableEl;
+
+    beforeEach(() => {
+        document.body.innerHTML = `
+            <section id="t" hidden>
+                <div id="bc"></div>
+                <div id="pc"></div>
+                <span id="bt"></span>
+                <span id="pt"></span>
+            </section>
+            <div id="r"></div>
+        `;
+        resultEl = document.getElementById('r');
+        bankerCardsEl = document.getElementById('bc');
+        playerCardsEl = document.getElementById('pc');
+        bankerTotalEl = document.getElementById('bt');
+        playerTotalEl = document.getElementById('pt');
+        tableEl = document.getElementById('t');
+    });
+
+    function renderWith(body) {
+        renderBaccaratResult({
+            resultEl, bankerCardsEl, playerCardsEl,
+            bankerTotalEl, playerTotalEl, tableEl, body,
+        });
+    }
+
+    test('Player win shows the table, paints both hand totals, and the win class', () => {
+        renderWith({
+            win: true,
+            push: false,
+            side: 'PLAYER',
+            winner: 'PLAYER',
+            playerCards: ['5♠', '3♥'],
+            bankerCards: ['2♣', '4♦'],
+            playerTotal: 8,
+            bankerTotal: 6,
+            isPlayerNatural: true,
+            isBankerNatural: false,
+            multiplier: 2.0,
+            net: 100,
+        });
+
+        expect(tableEl.hidden).toBe(false);
+        expect(resultEl.classList.contains('bac-result-win')).toBe(true);
+        expect(playerTotalEl.textContent).toBe('(8 • Natural)');
+        expect(bankerTotalEl.textContent).toBe('(6)');
+        expect(resultEl.innerHTML).toContain('Player wins');
+        expect(resultEl.innerHTML).toContain('+100 credits');
+        expect(resultEl.innerHTML).toContain('2.00×');
+    });
+
+    test('Banker win labels the 5% commission verdict', () => {
+        renderWith({
+            win: true,
+            push: false,
+            side: 'BANKER',
+            winner: 'BANKER',
+            playerCards: ['5♠', '4♥'],
+            bankerCards: ['8♣', '7♦'],
+            playerTotal: 9,
+            bankerTotal: 5,
+            isPlayerNatural: false,
+            isBankerNatural: false,
+            multiplier: 1.95,
+            net: 95,
+        });
+
+        expect(resultEl.classList.contains('bac-result-win')).toBe(true);
+        expect(resultEl.innerHTML).toContain('Banker wins');
+        expect(resultEl.innerHTML).toContain('5% commission');
+        expect(resultEl.innerHTML).toContain('1.95×');
+    });
+
+    test('Tie win calls out the tie at 9.00x', () => {
+        renderWith({
+            win: true,
+            push: false,
+            side: 'TIE',
+            winner: 'TIE',
+            playerCards: ['5♠', '3♥'],
+            bankerCards: ['4♣', '4♦'],
+            playerTotal: 8,
+            bankerTotal: 8,
+            isPlayerNatural: true,
+            isBankerNatural: true,
+            multiplier: 9.0,
+            net: 400,
+        });
+
+        expect(resultEl.classList.contains('bac-result-win')).toBe(true);
+        expect(resultEl.innerHTML).toContain('Tie!');
+        expect(resultEl.innerHTML).toContain('+400 credits');
+        expect(resultEl.innerHTML).toContain('9.00×');
+    });
+
+    test('lose path names the winning side and the lost stake', () => {
+        renderWith({
+            win: false,
+            push: false,
+            side: 'PLAYER',
+            winner: 'BANKER',
+            playerCards: ['5♠', '2♥'],
+            bankerCards: ['9♣', '8♦'],
+            playerTotal: 7,
+            bankerTotal: 7,
+            isPlayerNatural: false,
+            isBankerNatural: false,
+            net: -50,
+        });
+
+        expect(resultEl.classList.contains('bac-result-lose')).toBe(true);
+        expect(resultEl.innerHTML).toContain('Banker wins');
+        expect(resultEl.innerHTML).toContain('Player');
+        expect(resultEl.innerHTML).toContain('50 credits');
+    });
+
+    test('push (tied game on Player/Banker bet) refunds the stake and uses the push class', () => {
+        renderWith({
+            win: false,
+            push: true,
+            side: 'PLAYER',
+            winner: 'TIE',
+            playerCards: ['5♠', '2♥'],
+            bankerCards: ['3♣', '4♦'],
+            playerTotal: 7,
+            bankerTotal: 7,
+            isPlayerNatural: false,
+            isBankerNatural: false,
+            payout: 100,
+            net: 0,
+        });
+
+        expect(resultEl.classList.contains('bac-result-push')).toBe(true);
+        expect(resultEl.classList.contains('bac-result-win')).toBe(false);
+        expect(resultEl.classList.contains('bac-result-lose')).toBe(false);
+        expect(resultEl.innerHTML).toContain('Tie game');
+        expect(resultEl.innerHTML).toContain('refunded');
+        expect(resultEl.innerHTML).toContain('100 credits');
+    });
+
+    test('jackpot win prepends the JACKPOT banner', () => {
+        renderWith({
+            win: true,
+            push: false,
+            side: 'PLAYER',
+            winner: 'PLAYER',
+            playerCards: ['5♠', '3♥'],
+            bankerCards: ['2♣', '4♦'],
+            playerTotal: 8,
+            bankerTotal: 6,
+            isPlayerNatural: true,
+            isBankerNatural: false,
+            multiplier: 2.0,
+            net: 100,
+            jackpotPayout: 999,
+        });
+
+        expect(resultEl.classList.contains('bac-result-jackpot')).toBe(true);
+        expect(resultEl.innerHTML).toContain('+999 credits');
+    });
+
+    test('lose with lossTribute appends "+N to jackpot" suffix', () => {
+        renderWith({
+            win: false,
+            push: false,
+            side: 'PLAYER',
+            winner: 'BANKER',
+            playerCards: ['5♠', '2♥'],
+            bankerCards: ['9♣', '8♦'],
+            playerTotal: 7,
+            bankerTotal: 7,
+            isPlayerNatural: false,
+            isBankerNatural: false,
+            net: -50,
+            lossTribute: 5,
+        });
+
+        expect(resultEl.innerHTML).toContain('+5 to jackpot');
+    });
+
+    test('Natural badge is omitted when neither side has 8 or 9 on first two cards', () => {
+        renderWith({
+            win: true,
+            push: false,
+            side: 'PLAYER',
+            winner: 'PLAYER',
+            playerCards: ['5♠', '2♥'],
+            bankerCards: ['3♣', '3♦'],
+            playerTotal: 7,
+            bankerTotal: 6,
+            isPlayerNatural: false,
+            isBankerNatural: false,
+            multiplier: 2.0,
+            net: 100,
+        });
+
+        expect(playerTotalEl.textContent).toBe('(7)');
+        expect(bankerTotalEl.textContent).toBe('(6)');
+    });
+
+    test('returns early on missing result element', () => {
+        expect(() => renderBaccaratResult({
+            resultEl: null, bankerCardsEl: null, playerCardsEl: null,
+            tableEl: null, body: { win: true }
+        })).not.toThrow();
+    });
+});

--- a/web/src/test/js/navbar.test.js
+++ b/web/src/test/js/navbar.test.js
@@ -79,6 +79,7 @@ describe('navbar fragment', () => {
         expect(casino[0]).toMatch(/href="\/casino\/guilds"[^>]*>[^<]*Dice/);
         expect(casino[0]).toMatch(/href="\/casino\/guilds"[^>]*>[^<]*High-Low/);
         expect(casino[0]).toMatch(/href="\/casino\/guilds"[^>]*>[^<]*Scratch/);
+        expect(casino[0]).toMatch(/href="\/casino\/guilds"[^>]*>[^<]*Baccarat/);
         // Coming-soon placeholder is gone now that the games ship.
         expect(casino[0]).not.toMatch(/coming soon/i);
     });

--- a/web/src/test/kotlin/web/controller/BaccaratControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/BaccaratControllerTest.kt
@@ -1,0 +1,425 @@
+package web.controller
+
+import database.card.Card
+import database.card.Rank
+import database.card.Suit
+import database.economy.Baccarat
+import database.service.BaccaratService
+import database.service.BaccaratService.PlayOutcome
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.security.oauth2.core.user.OAuth2User
+import web.casino.CasinoPageContext
+import web.service.EconomyWebService
+
+class BaccaratControllerTest {
+
+    private val guildId = 42L
+    private val discordId = 100L
+
+    private lateinit var baccaratService: BaccaratService
+    private lateinit var economyWebService: EconomyWebService
+    private lateinit var pageContext: CasinoPageContext
+    private lateinit var user: OAuth2User
+    private lateinit var controller: BaccaratController
+
+    @BeforeEach
+    fun setup() {
+        baccaratService = mockk(relaxed = true)
+        economyWebService = mockk(relaxed = true)
+        pageContext = mockk(relaxed = true)
+        user = mockk {
+            every { getAttribute<String>("id") } returns discordId.toString()
+            every { getAttribute<String>("username") } returns "tester"
+        }
+        every { economyWebService.isMember(discordId, guildId) } returns true
+        controller = BaccaratController(baccaratService, economyWebService, pageContext)
+    }
+
+    private fun playerCards() = listOf(Card(Rank.FIVE, Suit.SPADES), Card(Rank.THREE, Suit.HEARTS))
+    private fun bankerCards() = listOf(Card(Rank.TWO, Suit.CLUBS), Card(Rank.FOUR, Suit.DIAMONDS))
+
+    @Test
+    fun `Player win returns 200 with both hands and win-shaped payload`() {
+        every {
+            baccaratService.play(discordId, guildId, 100L, Baccarat.Side.PLAYER, false)
+        } returns PlayOutcome.Win(
+            stake = 100L,
+            payout = 200L,
+            net = 100L,
+            side = Baccarat.Side.PLAYER,
+            winner = Baccarat.Side.PLAYER,
+            playerCards = playerCards(),
+            bankerCards = bankerCards(),
+            playerTotal = 8,
+            bankerTotal = 6,
+            isPlayerNatural = true,
+            isBankerNatural = false,
+            multiplier = 2.0,
+            newBalance = 1_100L
+        )
+
+        val response = controller.play(
+            guildId, BaccaratPlayRequest(side = "PLAYER", stake = 100L), user
+        )
+
+        assertTrue(response.statusCode.is2xxSuccessful)
+        val body = response.body!!
+        assertEquals(true, body.ok)
+        assertEquals(true, body.win)
+        assertEquals(false, body.push)
+        assertEquals(100L, body.net)
+        assertEquals(200L, body.payout)
+        assertEquals(1_100L, body.newBalance)
+        assertEquals("PLAYER", body.side)
+        assertEquals("PLAYER", body.winner)
+        assertEquals(2.0, body.multiplier)
+        assertEquals(8, body.playerTotal)
+        assertEquals(6, body.bankerTotal)
+        assertEquals(true, body.isPlayerNatural)
+        assertEquals(false, body.isBankerNatural)
+        // Cards are serialised as Card.toString() — e.g. "5♠".
+        assertEquals(2, body.playerCards?.size)
+        assertEquals(2, body.bankerCards?.size)
+    }
+
+    @Test
+    fun `Banker win pays at the 1_95x commission rate`() {
+        every {
+            baccaratService.play(discordId, guildId, 100L, Baccarat.Side.BANKER, false)
+        } returns PlayOutcome.Win(
+            stake = 100L,
+            payout = 195L,
+            net = 95L,
+            side = Baccarat.Side.BANKER,
+            winner = Baccarat.Side.BANKER,
+            playerCards = playerCards(),
+            bankerCards = bankerCards(),
+            playerTotal = 6,
+            bankerTotal = 8,
+            isPlayerNatural = false,
+            isBankerNatural = true,
+            multiplier = 1.95,
+            newBalance = 1_095L
+        )
+
+        val response = controller.play(
+            guildId, BaccaratPlayRequest(side = "BANKER", stake = 100L), user
+        )
+
+        val body = response.body!!
+        assertEquals(true, body.win)
+        assertEquals(195L, body.payout)
+        assertEquals(95L, body.net)
+        assertEquals(1.95, body.multiplier)
+    }
+
+    @Test
+    fun `loss returns 200 with negative net and win=false`() {
+        every {
+            baccaratService.play(discordId, guildId, 50L, Baccarat.Side.PLAYER, false)
+        } returns PlayOutcome.Lose(
+            stake = 50L,
+            side = Baccarat.Side.PLAYER,
+            winner = Baccarat.Side.BANKER,
+            playerCards = playerCards(),
+            bankerCards = bankerCards(),
+            playerTotal = 4,
+            bankerTotal = 7,
+            isPlayerNatural = false,
+            isBankerNatural = false,
+            newBalance = 950L
+        )
+
+        val response = controller.play(
+            guildId, BaccaratPlayRequest(side = "PLAYER", stake = 50L), user
+        )
+
+        assertTrue(response.statusCode.is2xxSuccessful)
+        val body = response.body!!
+        assertEquals(true, body.ok)
+        assertEquals(false, body.win)
+        assertEquals(false, body.push)
+        assertEquals(-50L, body.net)
+        assertEquals(950L, body.newBalance)
+        assertEquals("BANKER", body.winner)
+    }
+
+    @Test
+    fun `tied game pushes Player side bet — push=true and stake refunded`() {
+        every {
+            baccaratService.play(discordId, guildId, 100L, Baccarat.Side.PLAYER, false)
+        } returns PlayOutcome.Push(
+            stake = 100L,
+            side = Baccarat.Side.PLAYER,
+            playerCards = playerCards(),
+            bankerCards = bankerCards(),
+            playerTotal = 7,
+            bankerTotal = 7,
+            isPlayerNatural = false,
+            isBankerNatural = false,
+            newBalance = 1_000L
+        )
+
+        val response = controller.play(
+            guildId, BaccaratPlayRequest(side = "PLAYER", stake = 100L), user
+        )
+
+        val body = response.body!!
+        assertEquals(true, body.ok)
+        assertEquals(false, body.win)
+        assertEquals(true, body.push)
+        assertEquals("TIE", body.winner)
+        assertEquals(0L, body.net)
+        assertEquals(100L, body.payout)
+        assertEquals(1_000L, body.newBalance)
+    }
+
+    @Test
+    fun `Tie side bet wins on a tied game at the natural multiplier`() {
+        every {
+            baccaratService.play(discordId, guildId, 50L, Baccarat.Side.TIE, false)
+        } returns PlayOutcome.Win(
+            stake = 50L,
+            payout = 450L,
+            net = 400L,
+            side = Baccarat.Side.TIE,
+            winner = Baccarat.Side.TIE,
+            playerCards = playerCards(),
+            bankerCards = bankerCards(),
+            playerTotal = 8,
+            bankerTotal = 8,
+            isPlayerNatural = true,
+            isBankerNatural = true,
+            multiplier = 9.0,
+            newBalance = 1_400L
+        )
+
+        val response = controller.play(
+            guildId, BaccaratPlayRequest(side = "TIE", stake = 50L), user
+        )
+
+        val body = response.body!!
+        assertEquals(true, body.win)
+        assertEquals(false, body.push)
+        assertEquals(450L, body.payout)
+        assertEquals(400L, body.net)
+        assertEquals(9.0, body.multiplier)
+    }
+
+    @Test
+    fun `play is case-insensitive on the side parameter`() {
+        every {
+            baccaratService.play(discordId, guildId, 10L, Baccarat.Side.BANKER, false)
+        } returns PlayOutcome.Lose(
+            stake = 10L,
+            side = Baccarat.Side.BANKER,
+            winner = Baccarat.Side.PLAYER,
+            playerCards = playerCards(),
+            bankerCards = bankerCards(),
+            playerTotal = 7,
+            bankerTotal = 4,
+            isPlayerNatural = false,
+            isBankerNatural = false,
+            newBalance = 990L
+        )
+
+        val response = controller.play(
+            guildId, BaccaratPlayRequest(side = "banker", stake = 10L), user
+        )
+
+        assertTrue(response.statusCode.is2xxSuccessful)
+        verify(exactly = 1) {
+            baccaratService.play(discordId, guildId, 10L, Baccarat.Side.BANKER, false)
+        }
+    }
+
+    @Test
+    fun `play rejects unknown side with 400`() {
+        val response = controller.play(
+            guildId, BaccaratPlayRequest(side = "edge", stake = 10L), user
+        )
+
+        assertEquals(400, response.statusCode.value())
+        assertEquals(false, response.body?.ok)
+        verify(exactly = 0) { baccaratService.play(any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `play returns 400 on insufficient credits`() {
+        every {
+            baccaratService.play(discordId, guildId, 100L, Baccarat.Side.PLAYER, false)
+        } returns PlayOutcome.InsufficientCredits(stake = 100L, have = 30L)
+
+        val response = controller.play(
+            guildId, BaccaratPlayRequest(side = "PLAYER", stake = 100L), user
+        )
+
+        assertEquals(400, response.statusCode.value())
+        assertTrue(response.body?.error!!.contains("100"))
+        assertTrue(response.body?.error!!.contains("30"))
+    }
+
+    @Test
+    fun `play returns 400 on invalid stake`() {
+        every {
+            baccaratService.play(discordId, guildId, 5L, Baccarat.Side.PLAYER, false)
+        } returns PlayOutcome.InvalidStake(min = 10L, max = 500L)
+
+        val response = controller.play(
+            guildId, BaccaratPlayRequest(side = "PLAYER", stake = 5L), user
+        )
+
+        assertEquals(400, response.statusCode.value())
+        assertTrue(response.body?.error!!.contains("10"))
+        assertTrue(response.body?.error!!.contains("500"))
+    }
+
+    @Test
+    fun `play rejects with 403 when user is not a member of the guild`() {
+        every { economyWebService.isMember(discordId, guildId) } returns false
+
+        val response = controller.play(
+            guildId, BaccaratPlayRequest(side = "PLAYER", stake = 100L), user
+        )
+
+        assertEquals(403, response.statusCode.value())
+        verify(exactly = 0) { baccaratService.play(any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `jackpot win surfaces jackpotPayout in the response body`() {
+        every {
+            baccaratService.play(discordId, guildId, 100L, Baccarat.Side.PLAYER, false)
+        } returns PlayOutcome.Win(
+            stake = 100L,
+            payout = 200L,
+            net = 100L,
+            side = Baccarat.Side.PLAYER,
+            winner = Baccarat.Side.PLAYER,
+            playerCards = playerCards(),
+            bankerCards = bankerCards(),
+            playerTotal = 8,
+            bankerTotal = 5,
+            isPlayerNatural = true,
+            isBankerNatural = false,
+            multiplier = 2.0,
+            newBalance = 5_100L,
+            jackpotPayout = 4_000L
+        )
+
+        val response = controller.play(
+            guildId, BaccaratPlayRequest(side = "PLAYER", stake = 100L), user
+        )
+
+        assertEquals(4_000L, response.body!!.jackpotPayout)
+    }
+
+    @Test
+    fun `non-jackpot win does not include jackpotPayout`() {
+        every {
+            baccaratService.play(discordId, guildId, 100L, Baccarat.Side.PLAYER, false)
+        } returns PlayOutcome.Win(
+            stake = 100L,
+            payout = 200L,
+            net = 100L,
+            side = Baccarat.Side.PLAYER,
+            winner = Baccarat.Side.PLAYER,
+            playerCards = playerCards(),
+            bankerCards = bankerCards(),
+            playerTotal = 8,
+            bankerTotal = 5,
+            isPlayerNatural = true,
+            isBankerNatural = false,
+            multiplier = 2.0,
+            newBalance = 1_100L
+        )
+
+        val response = controller.play(
+            guildId, BaccaratPlayRequest(side = "PLAYER", stake = 100L), user
+        )
+
+        assertNull(response.body!!.jackpotPayout)
+    }
+
+    @Test
+    fun `lose with loss tribute surfaces lossTribute on the response`() {
+        every {
+            baccaratService.play(discordId, guildId, 100L, Baccarat.Side.PLAYER, false)
+        } returns PlayOutcome.Lose(
+            stake = 100L,
+            side = Baccarat.Side.PLAYER,
+            winner = Baccarat.Side.BANKER,
+            playerCards = playerCards(),
+            bankerCards = bankerCards(),
+            playerTotal = 4,
+            bankerTotal = 8,
+            isPlayerNatural = false,
+            isBankerNatural = true,
+            newBalance = 900L,
+            lossTribute = 10L
+        )
+
+        val response = controller.play(
+            guildId, BaccaratPlayRequest(side = "PLAYER", stake = 100L), user
+        )
+
+        assertEquals(10L, response.body!!.lossTribute)
+    }
+
+    @Test
+    fun `autoTopUp flag is forwarded to the service`() {
+        every {
+            baccaratService.play(discordId, guildId, 100L, Baccarat.Side.PLAYER, true)
+        } returns PlayOutcome.Win(
+            stake = 100L,
+            payout = 200L,
+            net = 100L,
+            side = Baccarat.Side.PLAYER,
+            winner = Baccarat.Side.PLAYER,
+            playerCards = playerCards(),
+            bankerCards = bankerCards(),
+            playerTotal = 8,
+            bankerTotal = 5,
+            isPlayerNatural = true,
+            isBankerNatural = false,
+            multiplier = 2.0,
+            newBalance = 1_100L,
+            soldTobyCoins = 25L,
+            newPrice = 4.0,
+        )
+
+        val response = controller.play(
+            guildId, BaccaratPlayRequest(side = "PLAYER", stake = 100L, autoTopUp = true), user
+        )
+
+        val body = response.body!!
+        assertEquals(true, body.win)
+        assertEquals(25L, body.soldTobyCoins)
+        assertEquals(4.0, body.newPrice)
+        verify(exactly = 1) {
+            baccaratService.play(discordId, guildId, 100L, Baccarat.Side.PLAYER, true)
+        }
+    }
+
+    @Test
+    fun `insufficient TOBY for top-up returns 400 with InsufficientCoinsForTopUp`() {
+        every {
+            baccaratService.play(discordId, guildId, 100L, Baccarat.Side.PLAYER, true)
+        } returns PlayOutcome.InsufficientCoinsForTopUp(needed = 50L, have = 5L)
+
+        val response = controller.play(
+            guildId, BaccaratPlayRequest(side = "PLAYER", stake = 100L, autoTopUp = true), user
+        )
+
+        assertEquals(400, response.statusCode.value())
+        assertTrue(response.body?.error!!.contains("50"))
+        assertTrue(response.body?.error!!.contains("5"))
+    }
+}

--- a/web/src/test/kotlin/web/static/CasinoJackpotCssRegressionTest.kt
+++ b/web/src/test/kotlin/web/static/CasinoJackpotCssRegressionTest.kt
@@ -37,7 +37,8 @@ class CasinoJackpotCssRegressionTest {
             ".coinflip-result-jackpot",
             ".dice-result-jackpot",
             ".highlow-result-jackpot",
-            ".scratch-result-jackpot"
+            ".scratch-result-jackpot",
+            ".bac-result-jackpot"
         ).forEach { selector ->
             assertTrue(
                 css.contains(selector),


### PR DESCRIPTION
## Summary
- New `/baccarat stake:<n>` slash command. Posts a bet prompt with three side buttons (Player / Banker / Tie); picking a side deals both hands automatically per the standard Punto Banco tableau and resolves in-place — no mid-hand decisions, mirrors the `/highlow` post-then-button shape.
- Payouts: **Player 2.00×**, **Banker 1.95×** (5% commission), **Tie 9.00×**. On a tied game, Player and Banker side bets push (stake refunded). Per-bet house edge sits between `/coinflip` and `/slots`: ~1.24% on Player, ~1.06% on Banker, ~14.4% on Tie.
- Stake range: `${MIN_STAKE}=10`..`${MAX_STAKE}=500` credits, matching the other casino minigames.

## Architecture
- **`Baccarat`** (`database/src/main/kotlin/database/economy/Baccarat.kt`) — pure rules: deals from a `Deck`, applies the third-card tableau, returns a `Hand` with both sides' cards/totals/naturals and the resolved multiplier. No Spring/DB/JDA.
- **`BaccaratService`** (`database/src/main/kotlin/database/service/BaccaratService.kt`) — atomic `play()` path: `WagerHelper.checkAndLock` → optional `CasinoTopUpHelper` (for a future web flow) → `Baccarat.play` → `WagerHelper.applyMultiplier` → `JackpotHelper.rollOnWin`/`divertOnLoss`. Push (tied game on Player/Banker) is jackpot-neutral. Outcomes split into `Win` / `Push` / `Lose` plus the standard rejection variants.
- **`BaccaratCommand` + `BaccaratEmbeds` + `BaccaratButton`** (`discord-bot`) — slash command posts the prompt; the button decodes `baccarat:<SIDE>:<stake>:<userId>` and routes to the service. Component-id encoding mirrors `HighlowEmbeds`. Cards render as ``A♠ 7♦`` with an arrow before any third card and a Natural badge when applicable.

Wired up automatically: `BaccaratService` via `@Service`, `BaccaratCommand` via `EconomyCommand` + `@Component` (picked up by `DefaultCommandManager`), `BaccaratButton` via `@Component` (picked up by `DefaultButtonManager` on its `name` prefix).

## Test plan
- [x] `:database:test --tests BaccaratTest --tests BaccaratServiceTest` — green locally
- [x] `BaccaratTest`: pip values, hand totals (mod 10), Player/Banker naturals stop the deal, Player draw rule, Banker tableau (B=3+P3=8 stays vs P3=7 draws, B=6+P3=5 stays vs P3=7 draws), multiplier matrix (win/lose/push), 50k random-hand RTP smoke
- [x] `BaccaratServiceTest`: Player/Banker/Tie wins debit + credit atomically; loss debits stake only; push refunds stake without jackpot tribute; insufficient credits / invalid stake / unknown user rejected before any mutation; loss tributes 10% to the jackpot pool
- [x] `BaccaratCommandTest`: posts prompt + 3 buttons, doesn't resolve until clicked; encodes side+stake+user into each button id; no-op when stake is missing
- [x] `BaccaratButtonTest`: routes to service with parsed side/stake; PLAYER/BANKER/TIE all parse; edits original message and clears components; foreign user rejected ephemerally; malformed id ack'd without resolving
- [ ] Sandbox can't reach the `moe.kyokobot.libdave` maven repo, so `:discord-bot:test` could not run locally — relying on CI to validate the discord-bot module

https://claude.ai/code/session_01SS4QMjBvYZeUTQxKdrQv4A

---
_Generated by [Claude Code](https://claude.ai/code/session_01SS4QMjBvYZeUTQxKdrQv4A)_