### PR TITLE
style(casino web): unify all minigame UIs on the shared casino-table primitives

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Install JS dependencies
         working-directory: web
         run: npm ci
+      - name: Lint CSS
+        working-directory: web
+        run: npm run lint:css
       - name: Run JS tests
         working-directory: web
         run: npm test

--- a/web/.stylelintrc.json
+++ b/web/.stylelintrc.json
@@ -1,0 +1,6 @@
+{
+  "extends": "stylelint-config-recommended",
+  "rules": {
+    "no-descending-specificity": null
+  }
+}

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -9,7 +9,9 @@
       "version": "1.0.0",
       "devDependencies": {
         "jest": "^29.7.0",
-        "jest-environment-jsdom": "^30.2.0"
+        "jest-environment-jsdom": "^30.2.0",
+        "stylelint": "^16.26.1",
+        "stylelint-config-recommended": "^14.0.1"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -529,6 +531,30 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@cacheable/memory": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@cacheable/memory/-/memory-2.0.8.tgz",
+      "integrity": "sha512-FvEb29x5wVwu/Kf93IWwsOOEuhHh6dYCJF3vcKLzXc0KXIW181AOzv6ceT4ZpBHDvAfG60eqb+ekmrnLHIy+jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cacheable/utils": "^2.4.0",
+        "@keyv/bigmap": "^1.3.1",
+        "hookified": "^1.15.1",
+        "keyv": "^5.6.0"
+      }
+    },
+    "node_modules/@cacheable/utils": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.4.1.tgz",
+      "integrity": "sha512-eiFgzCbIneyMlLOmNG4g9xzF7Hv3Mga4LjxjcSC/ues6VYq2+gUbQI8JqNuw/ZM8tJIeIaBGpswAsqV2V7ApgA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hashery": "^1.5.1",
+        "keyv": "^5.6.0"
+      }
+    },
     "node_modules/@csstools/color-helpers": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
@@ -624,6 +650,31 @@
         "@csstools/css-tokenizer": "^3.0.4"
       }
     },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
+      "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@csstools/css-tokenizer": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
@@ -642,6 +693,64 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/media-query-list-parser": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-4.0.3.tgz",
+      "integrity": "sha512-HAYH7d3TLRHDOUQK4mZKf9k9Ph/m8Akstg66ywKR4SFAigjs3yBiUeZtFxywiTm5moZMAp/5W/ZuFnNXXYLuuQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/selector-specificity": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-5.0.0.tgz",
+      "integrity": "sha512-PCqQV3c4CoVm3kdPhyeZ07VmBRdH2EpMFA/pd9OASpOEC3aXNGoqPDAZ80D0cLpMBxnmk0+yNhGsEx31hq7Gtw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "postcss-selector-parser": "^7.0.0"
+      }
+    },
+    "node_modules/@dual-bundle/import-meta-resolve": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@dual-bundle/import-meta-resolve/-/import-meta-resolve-4.2.1.tgz",
+      "integrity": "sha512-id+7YRUgoUX6CgV0DtuhirQWodeeA7Lf4i2x71JS/vtA5pRb/hIGWlw+G6MeXvsM+MXrz0VAydTGElX1rAfgPg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/JounQin"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config": {
@@ -1259,6 +1368,68 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@keyv/bigmap": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@keyv/bigmap/-/bigmap-1.3.1.tgz",
+      "integrity": "sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hashery": "^1.4.0",
+        "hookified": "^1.15.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "keyv": "^5.6.0"
+      }
+    },
+    "node_modules/@keyv/serialize": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
+      "integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.10",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
@@ -1431,6 +1602,23 @@
         "node": ">= 14"
       }
     },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -1495,6 +1683,26 @@
       "license": "MIT",
       "dependencies": {
         "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/babel-jest": {
@@ -1708,6 +1916,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cacheable": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.3.4.tgz",
+      "integrity": "sha512-djgxybDbw9fL/ZWMI3+CE8ZilNxcwFkVtDc1gJ+IlOSSWkSMPQabhV/XCHTQ6pwwN6aivXPZ43omTooZiX06Ew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cacheable/memory": "^2.0.8",
+        "@cacheable/utils": "^2.4.0",
+        "hookified": "^1.15.0",
+        "keyv": "^5.6.0",
+        "qified": "^0.9.0"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -1852,6 +2074,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/colord": {
+      "version": "2.9.3",
+      "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
+      "integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1865,6 +2094,53 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cosmiconfig": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.1.tgz",
+      "integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "env-paths": "^2.2.1",
+        "import-fresh": "^3.3.0",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/cosmiconfig/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/cosmiconfig/node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
     },
     "node_modules/create-jest": {
       "version": "29.7.0",
@@ -1901,6 +2177,43 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-functions-list": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.3.3.tgz",
+      "integrity": "sha512-8HFEBPKhOpJPEPu70wJJetjKta86Gw9+CCyCnB3sui2qQfOvRyqBy4IKLKKAwdMpWb2lHXWk9Wb4Z6AmaUT1Pg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/cssstyle": {
@@ -2001,6 +2314,19 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.307",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.307.tgz",
@@ -2039,6 +2365,16 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/error-ex": {
@@ -2135,12 +2471,73 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fastest-levenshtein": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
+      "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.9.1"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
     },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
@@ -2150,6 +2547,16 @@
       "license": "Apache-2.0",
       "dependencies": {
         "bser": "2.1.1"
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-11.1.2.tgz",
+      "integrity": "sha512-N2WFfK12gmrK1c1GXOqiAJ1tc5YE+R53zvQ+t5P8S5XhnmKYVB5eZEiLNZKDSmoG8wqqbF9EXYBBW/nef19log==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^6.1.20"
       }
     },
     "node_modules/fill-range": {
@@ -2178,6 +2585,25 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/flat-cache": {
+      "version": "6.1.22",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.22.tgz",
+      "integrity": "sha512-N2dnzVJIphnNsjHcrxGW7DePckJ6haPrSFqpsBUhHYgwtKGVq4JrBGielEGD2fCVnsGm1zlBVZ8wGhkyuetgug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cacheable": "^2.3.4",
+        "flatted": "^3.4.2",
+        "hookified": "^1.15.0"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -2276,6 +2702,98 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/global-modules": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
+      "integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "global-prefix": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/global-prefix": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
+      "integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "^1.3.5",
+        "kind-of": "^6.0.2",
+        "which": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/global-prefix/node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
+      }
+    },
+    "node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globby/node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/globjoin": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/globjoin/-/globjoin-0.1.4.tgz",
+      "integrity": "sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -2293,6 +2811,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/hashery": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/hashery/-/hashery-1.5.1.tgz",
+      "integrity": "sha512-iZyKG96/JwPz1N55vj2Ie2vXbhu440zfUfJvSwEqEbeLluk7NnapfGqa7LH0mOsnDxTF85Mx8/dyR6HfqcbmbQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hookified": "^1.15.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -2305,6 +2836,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/hookified": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.15.1.tgz",
+      "integrity": "sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/html-encoding-sniffer": {
       "version": "4.0.0",
@@ -2325,6 +2863,19 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/html-tags": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.3.1.tgz",
+      "integrity": "sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
@@ -2377,6 +2928,43 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/import-fresh/node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/import-local": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
@@ -2426,6 +3014,13 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -2449,6 +3044,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -2469,6 +3074,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -2477,6 +3095,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -3486,6 +4114,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -3499,6 +4134,26 @@
         "node": ">=6"
       }
     },
+    "node_modules/keyv": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+      "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@keyv/serialize": "^1.1.1"
+      }
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -3508,6 +4163,13 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/known-css-properties": {
+      "version": "0.37.0",
+      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.37.0.tgz",
+      "integrity": "sha512-JCDrsP4Z1Sb9JwG0aJ8Eo2r7k4Ou5MwmThS/6lcIe1ICyb7UBJKGRIUUdqc2ASdE/42lgz6zFUnzAIhtXnBVrQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/leven": {
       "version": "3.1.0",
@@ -3538,6 +4200,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/lodash.truncate": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
+      "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -3588,12 +4257,53 @@
         "tmpl": "1.0.5"
       }
     },
+    "node_modules/mathml-tag-names": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz",
+      "integrity": "sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/meow": {
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
+      "integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -3638,6 +4348,25 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -3771,6 +4500,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -3840,6 +4582,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -3882,6 +4634,90 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.13",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
+      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-resolve-nested-selector": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.6.tgz",
+      "integrity": "sha512-0sglIs9Wmkzbr8lQwEyIzlDOOC9bGmfVKcJTaxv3vMmd3uo4o4DerC3En0bnmgceeql9BfC8hRkp7cg0fjdVqw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/postcss-safe-parser": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-7.0.1.tgz",
+      "integrity": "sha512-0AioNCJZ2DPYz5ABT6bddIqlhgwhpHZ/l65YAYo0BCIn0xiDpsnTHz0gnoTGk0OXZW0JRs+cDwL8u/teRdz+8A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss-safe-parser"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.31"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
+      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/pretty-format": {
       "version": "29.7.0",
@@ -3952,6 +4788,47 @@
       ],
       "license": "MIT"
     },
+    "node_modules/qified": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/qified/-/qified-0.9.1.tgz",
+      "integrity": "sha512-n7mar4T0xQ+39dE2vGTAlbxUEpndwPANH0kDef1/MYsB8Bba9wshkybIRx74qgcvKQPEWErf9AqAdYjhzY2Ilg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hookified": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/qified/node_modules/hookified": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/hookified/-/hookified-2.2.0.tgz",
+      "integrity": "sha512-p/LgFzRN5FeoD3DLS6bkUapeye6E4SI6yJs6KetENd18S+FBthqYq2amJUWpt5z0EQwwHemidjY5OqJGEKm5uA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
@@ -3963,6 +4840,16 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4023,12 +4910,47 @@
         "node": ">=10"
       }
     },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/rrweb-cssom": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
       "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -4107,10 +5029,38 @@
         "node": ">=8"
       }
     },
+    "node_modules/slice-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -4223,6 +5173,127 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/stylelint": {
+      "version": "16.26.1",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.26.1.tgz",
+      "integrity": "sha512-v20V59/crfc8sVTAtge0mdafI3AdnzQ2KsWe6v523L4OA1bJO02S7MO2oyXDCS6iWb9ckIPnqAFVItqSBQr7jw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/stylelint"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/stylelint"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.19",
+        "@csstools/css-tokenizer": "^3.0.4",
+        "@csstools/media-query-list-parser": "^4.0.3",
+        "@csstools/selector-specificity": "^5.0.0",
+        "@dual-bundle/import-meta-resolve": "^4.2.1",
+        "balanced-match": "^2.0.0",
+        "colord": "^2.9.3",
+        "cosmiconfig": "^9.0.0",
+        "css-functions-list": "^3.2.3",
+        "css-tree": "^3.1.0",
+        "debug": "^4.4.3",
+        "fast-glob": "^3.3.3",
+        "fastest-levenshtein": "^1.0.16",
+        "file-entry-cache": "^11.1.1",
+        "global-modules": "^2.0.0",
+        "globby": "^11.1.0",
+        "globjoin": "^0.1.4",
+        "html-tags": "^3.3.1",
+        "ignore": "^7.0.5",
+        "imurmurhash": "^0.1.4",
+        "is-plain-object": "^5.0.0",
+        "known-css-properties": "^0.37.0",
+        "mathml-tag-names": "^2.1.3",
+        "meow": "^13.2.0",
+        "micromatch": "^4.0.8",
+        "normalize-path": "^3.0.0",
+        "picocolors": "^1.1.1",
+        "postcss": "^8.5.6",
+        "postcss-resolve-nested-selector": "^0.1.6",
+        "postcss-safe-parser": "^7.0.1",
+        "postcss-selector-parser": "^7.1.0",
+        "postcss-value-parser": "^4.2.0",
+        "resolve-from": "^5.0.0",
+        "string-width": "^4.2.3",
+        "supports-hyperlinks": "^3.2.0",
+        "svg-tags": "^1.0.0",
+        "table": "^6.9.0",
+        "write-file-atomic": "^5.0.1"
+      },
+      "bin": {
+        "stylelint": "bin/stylelint.mjs"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      }
+    },
+    "node_modules/stylelint-config-recommended": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-14.0.1.tgz",
+      "integrity": "sha512-bLvc1WOz/14aPImu/cufKAZYfXs/A/owZfSMZ4N+16WGXLoX5lOir53M6odBxvhgmgdxCVnNySJmZKx73T93cg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/stylelint"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/stylelint"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12.0"
+      },
+      "peerDependencies": {
+        "stylelint": "^16.1.0"
+      }
+    },
+    "node_modules/stylelint/node_modules/balanced-match": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-2.0.0.tgz",
+      "integrity": "sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stylelint/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/stylelint/node_modules/write-file-atomic": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
+      "integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -4234,6 +5305,23 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/supports-hyperlinks": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.2.0.tgz",
+      "integrity": "sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0",
+        "supports-color": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-hyperlinks?sponsor=1"
       }
     },
     "node_modules/supports-preserve-symlinks-flag": {
@@ -4249,12 +5337,35 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/svg-tags": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
+      "integrity": "sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==",
+      "dev": true
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/table": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.9.0.tgz",
+      "integrity": "sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "ajv": "^8.0.1",
+        "lodash.truncate": "^4.4.2",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/test-exclude": {
       "version": "6.0.0",
@@ -4397,6 +5508,13 @@
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",

--- a/web/package.json
+++ b/web/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "test": "jest"
+    "test": "jest",
+    "lint:css": "stylelint \"src/main/resources/static/css/**/*.css\""
   },
   "jest": {
     "testEnvironment": "jsdom",
@@ -13,6 +14,8 @@
   },
   "devDependencies": {
     "jest": "^29.7.0",
-    "jest-environment-jsdom": "^30.2.0"
+    "jest-environment-jsdom": "^30.2.0",
+    "stylelint": "^16.26.1",
+    "stylelint-config-recommended": "^14.0.1"
   }
 }

--- a/web/src/main/resources/static/css/baccarat.css
+++ b/web/src/main/resources/static/css/baccarat.css
@@ -82,11 +82,11 @@
     cursor: pointer;
     display: grid;
     gap: 0.15rem;
-    transition: border-color 120ms ease, background 120ms ease;
+    transition: border-color 120ms ease, background 120ms ease, box-shadow 120ms ease;
 }
 
 .bac-side:hover {
-    border-color: var(--accent, #5865f2);
+    border-color: rgba(241, 196, 15, 0.6);
 }
 
 .bac-side input[type="radio"] {
@@ -95,9 +95,17 @@
     pointer-events: none;
 }
 
+/* Selected side: shared gold-ring treatment (--casino-active-glow) used
+   for the active actor on every casino game. */
 .bac-side:has(input:checked) {
-    border-color: var(--accent, #5865f2);
-    background: rgba(88, 101, 242, 0.12);
+    border-color: var(--casino-gold);
+    background: var(--casino-active-tile-bg);
+    box-shadow: var(--casino-active-glow);
+}
+
+.bac-side input[type="radio"]:focus-visible + .bac-side-name {
+    outline: 2px solid #5865F2;
+    outline-offset: 2px;
 }
 
 .bac-side-name {

--- a/web/src/main/resources/static/css/casino-table.css
+++ b/web/src/main/resources/static/css/casino-table.css
@@ -162,6 +162,10 @@
     border-radius: 0.6rem;
     padding: 0.75rem 1rem;
     transition: box-shadow 0.2s ease, filter 0.2s ease, opacity 0.2s ease;
+    /* `position: relative` so flashChipsOn can drop a chip stack inside
+       the seat (absolute-positioned overlay) without leaking into the
+       page flow. The seat's other content stays untouched. */
+    position: relative;
 }
 
 /* Active actor — gold halo + slow pulse. */
@@ -326,12 +330,6 @@
 /* ------------------------------------------------------------------- */
 /* Win chip-stack flourish                                              */
 /* ------------------------------------------------------------------- */
-
-/* Anchored to the seat so JS can drop a stack inside without leaking
-   into the page flow. The seat's other content stays untouched. */
-.casino-seat {
-    position: relative;
-}
 
 .casino-chip-stack {
     position: absolute;

--- a/web/src/main/resources/static/css/casino-table.css
+++ b/web/src/main/resources/static/css/casino-table.css
@@ -1,12 +1,64 @@
 /*
- * Shared "casino table" primitives — used by both /blackjack and /poker
- * so the two card games look like the same product. Game-specific bits
- * (split hands, side pots, betting slider, bust labels) live in their
- * per-game CSS and only override what they truly need.
+ * Shared "casino table" primitives — used by every casino minigame
+ * (blackjack, poker, baccarat, high-low, dice, slots, coinflip, scratch)
+ * so they all look like the same product. Game-specific bits (split
+ * hands, side pots, betting slider, bust labels) live in their per-game
+ * CSS and only override what they truly need.
  *
  * Class prefix: `.casino-` for components, `.is-*` modifiers.
  * Loaded before the per-game stylesheet so per-game rules win on conflict.
+ *
+ * Custom-property tokens below are the single source of truth for:
+ *   --casino-gold              : the active-actor / selected-tile colour
+ *   --casino-active-glow       : 2px ring + soft halo applied to gold
+ *                                selections (used by every game's picker)
+ *   --casino-active-tile-bg    : translucent gold wash behind selected tiles
+ *   --casino-card-bg           : white-gradient card / die / reel face
+ *   --casino-card-border       : subtle outer border on card-style faces
+ *   --casino-card-shadow       : drop shadow + inner highlight on cards
+ * Edit them here once and every game inherits the change.
+ *
+ * ---------------------------------------------------------------------
+ * Adding a new game? The polish kit is roughly:
+ *
+ *   HTML
+ *     <section class="my-game-table casino-felt">      ← green felt
+ *       <div class="my-game-card casino-card-glyph">…  ← cards
+ *       <div class="my-game-die  casino-card-face">…   ← dice/reels
+ *
+ *   per-game CSS (@import url("./casino-table.css") first)
+ *     .my-game-pick:has(input:checked) {                ← selected tile
+ *       border-color: var(--casino-gold);
+ *       background:   var(--casino-active-tile-bg);
+ *       box-shadow:   var(--casino-active-glow);
+ *     }
+ *     /* `casino-pulse` keyframe is shared too — animate any winning
+ *        cell with: animation: casino-pulse 1.6s ease-in-out infinite; */
+ *
+ *   per-game JS (load casino-render.js + casino-sounds.js + casino-result.js)
+ *     window.CasinoRender.renderCards(container, cards)         // deal animation
+ *     window.CasinoRender.flashChipsOn(feltEl, payout)          // win flourish
+ *     window.CasinoSounds.play('deal'|'win'|'lose'|'flip'|...)  // SFX
+ *     window.TobyCasinoResult.render({classPrefix:'mygame', …}) // result line
+ *
+ *   Then wire the page's <head>/<body> the same way blackjack-table.html
+ *   does — load casino-{sounds,jackpot,topup,result,render,game}.js, the
+ *   sound toggle auto-installs, and reduced-motion is already honoured.
+ * ---------------------------------------------------------------------
  */
+
+:root {
+    --casino-gold: #f1c40f;
+    --casino-active-glow:
+        0 0 0 2px var(--casino-gold),
+        0 0 18px rgba(241, 196, 15, 0.45);
+    --casino-active-tile-bg: rgba(241, 196, 15, 0.08);
+    --casino-card-bg: linear-gradient(180deg, #ffffff 0%, #f3f1ea 100%);
+    --casino-card-border: 1px solid rgba(0, 0, 0, 0.15);
+    --casino-card-shadow:
+        0 2px 6px rgba(0, 0, 0, 0.45),
+        inset 0 1px 0 rgba(255, 255, 255, 0.5);
+}
 
 /* ------------------------------------------------------------------- */
 /* Felt table                                                          */
@@ -54,23 +106,36 @@
     min-height: 4.75rem;
 }
 
+/* "Card face" recipe — the white-gradient + serif look that any game's
+   card-shaped surface should adopt (cards, dice, reels, ticket faces…).
+   Apply this class to any element to inherit the look; .casino-card-glyph
+   below extends it with the standard playing-card aspect ratio. */
+.casino-card-face {
+    background: var(--casino-card-bg);
+    color: #1a1a1a;
+    border: var(--casino-card-border);
+    border-radius: 0.5rem;
+    box-shadow: var(--casino-card-shadow);
+    font-family: "Cambria", "Georgia", serif;
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+}
+
 .casino-card-glyph {
     display: inline-flex;
     align-items: center;
     justify-content: center;
     width: 3rem;
     height: 4.5rem;
-    background: linear-gradient(180deg, #ffffff 0%, #f3f1ea 100%);
+    background: var(--casino-card-bg);
     color: #1a1a1a;
     border-radius: 0.5rem;
-    border: 1px solid rgba(0, 0, 0, 0.15);
+    border: var(--casino-card-border);
     font-family: "Cambria", "Georgia", serif;
     font-weight: 700;
     font-size: 1.35rem;
     font-variant-numeric: tabular-nums;
-    box-shadow:
-        0 2px 6px rgba(0, 0, 0, 0.45),
-        inset 0 1px 0 rgba(255, 255, 255, 0.5);
+    box-shadow: var(--casino-card-shadow);
 }
 
 .casino-card-glyph.is-red {
@@ -101,9 +166,7 @@
 
 /* Active actor — gold halo + slow pulse. */
 .casino-seat.is-active {
-    box-shadow:
-        0 0 0 2px #f1c40f,
-        0 0 18px rgba(241, 196, 15, 0.45);
+    box-shadow: var(--casino-active-glow);
     animation: casino-pulse 1.6s ease-in-out infinite;
 }
 
@@ -168,7 +231,7 @@
 }
 
 .casino-seat.is-active .casino-avatar {
-    border-color: #f1c40f;
+    border-color: var(--casino-gold);
 }
 
 /* No avatarUrl on the seat → CSS-rendered initial circle from data-initial. */
@@ -208,7 +271,7 @@
 .casino-actor-pill .casino-avatar {
     width: 1.6rem;
     height: 1.6rem;
-    border-color: #f1c40f;
+    border-color: var(--casino-gold);
 }
 
 .casino-actor-pill-label {
@@ -235,12 +298,12 @@
 @keyframes casino-pulse {
     0%, 100% {
         box-shadow:
-            0 0 0 2px #f1c40f,
+            0 0 0 2px var(--casino-gold),
             0 0 18px rgba(241, 196, 15, 0.35);
     }
     50% {
         box-shadow:
-            0 0 0 2px #f1c40f,
+            0 0 0 2px var(--casino-gold),
             0 0 28px rgba(241, 196, 15, 0.65);
     }
 }
@@ -352,7 +415,7 @@
 }
 
 .casino-sound-toggle:focus-visible {
-    outline: 2px solid #f1c40f;
+    outline: 2px solid var(--casino-gold);
     outline-offset: 2px;
 }
 

--- a/web/src/main/resources/static/css/casino-table.css
+++ b/web/src/main/resources/static/css/casino-table.css
@@ -32,8 +32,8 @@
  *       background:   var(--casino-active-tile-bg);
  *       box-shadow:   var(--casino-active-glow);
  *     }
- *     /* `casino-pulse` keyframe is shared too — animate any winning
- *        cell with: animation: casino-pulse 1.6s ease-in-out infinite; */
+ *     `casino-pulse` keyframe is shared too — animate any winning cell
+ *     with `animation: casino-pulse 1.6s ease-in-out infinite;`.
  *
  *   per-game JS (load casino-render.js + casino-sounds.js + casino-result.js)
  *     window.CasinoRender.renderCards(container, cards)         // deal animation

--- a/web/src/main/resources/static/css/casino-table.css
+++ b/web/src/main/resources/static/css/casino-table.css
@@ -65,15 +65,21 @@
 /* ------------------------------------------------------------------- */
 
 .casino-felt {
+    /* Stops brightened from the previous "almost-black green" — the old
+       gradient bottomed out at #0e2418 with a 0.55-alpha inset shadow,
+       which on phones read as black with a green tint. New stops keep
+       the dark-mode mood but stay legibly green at the edges; the inset
+       shadow is also softened so the centre actually shows the bright
+       stop. Adjust here once and every casino game inherits the change. */
     background:
-        radial-gradient(ellipse at center, #1f4a36 0%, #143324 70%, #0e2418 100%);
+        radial-gradient(ellipse at center, #2e6b4f 0%, #1f4a36 70%, #143324 100%);
     border: 1px solid rgba(255, 255, 255, 0.04);
     border-radius: 1.25rem;
     padding: 2rem;
     margin-bottom: 1.5rem;
     color: #f0f0f0;
     box-shadow:
-        inset 0 0 60px rgba(0, 0, 0, 0.55),
+        inset 0 0 60px rgba(0, 0, 0, 0.25),
         0 6px 24px rgba(0, 0, 0, 0.35);
     position: relative;
 }

--- a/web/src/main/resources/static/css/coinflip.css
+++ b/web/src/main/resources/static/css/coinflip.css
@@ -1,15 +1,16 @@
+@import url("./casino-table.css");
+
 .coinflip-header { margin-bottom: var(--space-5); }
 .coinflip-header h1 { margin: var(--space-2) 0; }
 
+/* casino-felt owns the green-felt frame; this class only owns layout. */
 .coinflip-table {
-    background: var(--surface);
-    border: 1px solid var(--border);
-    border-radius: 12px;
-    padding: var(--space-5);
     display: flex;
     flex-direction: column;
     align-items: center;
     gap: var(--space-4);
+    /* Anchor the chip flourish overlay. */
+    position: relative;
 }
 
 .coinflip-coin {
@@ -75,17 +76,19 @@
     display: block;
     text-align: center;
     padding: 12px;
-    background: #0f1830;
+    background: rgba(0, 0, 0, 0.35);
     border: 2px solid var(--border);
     border-radius: 8px;
     color: var(--text-muted);
     font-weight: 600;
-    transition: border-color 0.2s, color 0.2s, background 0.2s;
+    transition: border-color 0.2s, color 0.2s, background 0.2s, box-shadow 0.2s;
 }
+/* Selected side gets the shared gold halo (--casino-active-glow). */
 .coinflip-side input[type="radio"]:checked + span {
-    border-color: #f1c40f;
+    border-color: var(--casino-gold);
     color: #fff;
-    background: #1a2240;
+    background: var(--casino-active-tile-bg);
+    box-shadow: var(--casino-active-glow);
 }
 .coinflip-side input[type="radio"]:focus-visible + span {
     outline: 2px solid #5865F2;

--- a/web/src/main/resources/static/css/dice.css
+++ b/web/src/main/resources/static/css/dice.css
@@ -1,29 +1,30 @@
+@import url("./casino-table.css");
+
 .dice-header { margin-bottom: var(--space-5); }
 .dice-header h1 { margin: var(--space-2) 0; }
 .dice-header strong { color: #fff; }
 
+/* casino-felt owns the green table look; this class only owns layout. */
 .dice-table {
-    background: var(--surface);
-    border: 1px solid var(--border);
-    border-radius: 12px;
-    padding: var(--space-5);
     display: flex;
     flex-direction: column;
     align-items: center;
     gap: var(--space-4);
 }
 
+/* Visual recipe (white gradient, border, shadow, serif font) comes from
+   the shared `.casino-card-face` class in casino-table.css — applied
+   on the markup. Local rules only set size + interaction. */
 .dice-die {
     width: 120px;
     height: 120px;
     border-radius: 16px;
-    background: #fff;
-    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3), inset 0 -4px 8px rgba(0, 0, 0, 0.08);
     display: flex;
     align-items: center;
     justify-content: center;
     user-select: none;
     transition: transform 0.2s;
+    position: relative;
 }
 .dice-die-face {
     font-size: 5rem;
@@ -78,19 +79,21 @@
     display: block;
     text-align: center;
     padding: 12px 0;
-    background: #0f1830;
+    background: rgba(0, 0, 0, 0.35);
     border: 2px solid var(--border);
     border-radius: 8px;
     color: var(--text-muted);
     font-weight: 700;
     font-size: 1.1rem;
     font-variant-numeric: tabular-nums;
-    transition: border-color 0.2s, color 0.2s, background 0.2s;
+    transition: border-color 0.2s, color 0.2s, background 0.2s, box-shadow 0.2s;
 }
+/* Selected number gets the shared gold halo (--casino-active-glow). */
 .dice-prediction input[type="radio"]:checked + span {
-    border-color: #f1c40f;
+    border-color: var(--casino-gold);
     color: #fff;
-    background: #1a2240;
+    background: var(--casino-active-tile-bg);
+    box-shadow: var(--casino-active-glow);
 }
 .dice-prediction input[type="radio"]:focus-visible + span {
     outline: 2px solid #5865F2;

--- a/web/src/main/resources/static/css/highlow.css
+++ b/web/src/main/resources/static/css/highlow.css
@@ -1,12 +1,12 @@
+@import url("./casino-table.css");
+
 .highlow-header { margin-bottom: var(--space-5); }
 .highlow-header h1 { margin: var(--space-2) 0; }
 .highlow-header strong { color: #fff; }
 
+/* casino-felt covers the green-felt frame; this class only owns the
+   stack layout for cards + form + buttons. */
 .highlow-table {
-    background: var(--surface);
-    border: 1px solid var(--border);
-    border-radius: 12px;
-    padding: var(--space-5);
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -18,43 +18,40 @@
     align-items: center;
     gap: var(--space-3);
 }
+/* Each slot now stacks the casino card glyph above its "Anchor"/"Next"
+   label — the white card frame is gone (the glyph is the card). */
 .highlow-card {
-    width: 96px;
-    height: 134px;
-    border-radius: 12px;
-    background: linear-gradient(135deg, #fff 0%, #e8e8f0 100%);
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
     display: flex;
     flex-direction: column;
     align-items: center;
-    justify-content: center;
+    gap: 0.4rem;
     user-select: none;
-    position: relative;
 }
 .highlow-card-face {
-    font-size: 2.4rem;
-    font-weight: 700;
-    color: #1a1a2e;
-    line-height: 1;
-    font-variant-numeric: tabular-nums;
+    /* Sized larger than the default casino-card-glyph because high-low
+       has only one card per slot — there's room to make it the focal
+       point. casino-card-glyph still owns colour/shadow/typography. */
+    width: 4.5rem;
+    height: 6.4rem;
+    font-size: 2rem;
 }
 .highlow-card-label {
-    position: absolute;
-    bottom: 8px;
     font-size: 0.7rem;
     text-transform: uppercase;
     letter-spacing: 0.1em;
-    color: #666;
+    color: rgba(255, 255, 255, 0.7);
     font-weight: 600;
 }
-.highlow-card.shuffling { animation: highlow-pulse 0.4s linear infinite; }
-@keyframes highlow-pulse {
+.highlow-card.shuffling .highlow-card-face {
+    animation: highlow-shuffle 0.4s linear infinite;
+}
+@keyframes highlow-shuffle {
     0%, 100% { transform: translateY(0) scale(1); }
     50% { transform: translateY(-4px) scale(1.02); }
 }
 .highlow-arrow {
     font-size: 2rem;
-    color: var(--text-muted);
+    color: rgba(255, 255, 255, 0.6);
     user-select: none;
 }
 
@@ -119,10 +116,18 @@
     font-weight: 600;
     border-radius: 8px;
     cursor: pointer;
+    transition: box-shadow 0.15s ease, border-color 0.15s ease;
 }
 .highlow-direction-btn:disabled {
     opacity: 0.6;
     cursor: not-allowed;
+}
+/* Hover/focus reaches for the shared gold halo (--casino-active-glow). */
+.highlow-direction-btn:not(:disabled):hover,
+.highlow-direction-btn:not(:disabled):focus-visible {
+    border-color: var(--casino-gold);
+    box-shadow: var(--casino-active-glow);
+    outline: none;
 }
 
 .highlow-stake-label {
@@ -174,8 +179,7 @@
 .highlow-rules strong { color: #fff; }
 
 @media (max-width: 600px) {
-    .highlow-card { width: 76px; height: 110px; }
-    .highlow-card-face { font-size: 2rem; }
+    .highlow-card-face { width: 3.6rem; height: 5.2rem; font-size: 1.6rem; }
     .highlow-arrow { font-size: 1.5rem; }
     .highlow-bet { max-width: 100%; }
     /* Direction picker fills the row so Higher / Lower stay at ≥44px. */
@@ -187,7 +191,6 @@
 }
 
 @media (max-width: 380px) {
-    .highlow-card { width: 64px; height: 92px; }
-    .highlow-card-face { font-size: 1.6rem; }
+    .highlow-card-face { width: 3rem; height: 4.4rem; font-size: 1.3rem; }
     .highlow-arrow { font-size: 1.2rem; }
 }

--- a/web/src/main/resources/static/css/scratch.css
+++ b/web/src/main/resources/static/css/scratch.css
@@ -1,15 +1,16 @@
+@import url("./casino-table.css");
+
 .scratch-header { margin-bottom: var(--space-5); }
 .scratch-header h1 { margin: var(--space-2) 0; }
 
+/* casino-felt owns the green-felt frame; this class only owns layout. */
 .scratch-table {
-    background: var(--surface);
-    border: 1px solid var(--border);
-    border-radius: 12px;
-    padding: var(--space-5);
     display: flex;
     flex-direction: column;
     align-items: center;
     gap: var(--space-4);
+    /* Anchor the chip flourish overlay. */
+    position: relative;
 }
 
 .scratch-cells {
@@ -87,6 +88,15 @@
 .scratch-cell.win-cell .scratch-cell-face {
     background: #1a3322;
     border: 2px solid #57F287;
+}
+/* Winning cells pulse with the same gold halo blackjack/poker uses for
+   the active actor — turns the "you won" scratchcard into a celebration
+   instead of a static green border. */
+.scratch-cell.win-cell {
+    animation: casino-pulse 1.6s ease-in-out infinite;
+}
+@media (prefers-reduced-motion: reduce) {
+    .scratch-cell.win-cell { animation: none; }
 }
 
 @keyframes scratch-off {

--- a/web/src/main/resources/static/css/slots.css
+++ b/web/src/main/resources/static/css/slots.css
@@ -1,17 +1,18 @@
+@import url("./casino-table.css");
+
 .slots-header {
     margin-bottom: var(--space-5);
 }
 .slots-header h1 { margin: var(--space-2) 0; }
 
+/* casino-felt owns the green-felt frame; this class only owns layout. */
 .slots-machine {
-    background: var(--surface);
-    border: 1px solid var(--border);
-    border-radius: 12px;
-    padding: var(--space-5);
     display: flex;
     flex-direction: column;
     align-items: center;
     gap: var(--space-4);
+    /* position is needed so the chip flourish overlay anchors here. */
+    position: relative;
 }
 
 .slots-reels {
@@ -20,28 +21,43 @@
     justify-content: center;
 }
 
+/* Visual recipe comes from the shared `.casino-card-face` class —
+   applied on the markup. Local rules only set size + interaction. */
 .slots-reel {
     width: 96px;
     height: 96px;
-    background: #0f1830;
-    border: 2px solid var(--border);
     border-radius: 12px;
     display: flex;
     align-items: center;
     justify-content: center;
     font-size: 3rem;
     user-select: none;
-    transition: transform 0.1s, border-color 0.2s;
+    transition: transform 0.1s, border-color 0.2s, box-shadow 0.2s;
 }
 
 .slots-reel.spinning {
-    border-color: #57F287;
-    animation: slots-shake 0.15s linear infinite;
+    animation: slots-tumble 0.15s linear infinite;
 }
 
-@keyframes slots-shake {
+/* Per-reel stagger so the three reels stop in sequence — buys a tiny
+   "wait for it" suspense without any extra JS choreography. */
+.slots-reel.spinning:nth-child(2) { animation-delay: 60ms; }
+.slots-reel.spinning:nth-child(3) { animation-delay: 120ms; }
+
+/* Winning reel gets the same gold halo (--casino-active-glow) every
+   selected/active surface uses across all the casino games. */
+.slots-reel.win-cell {
+    border-color: var(--casino-gold);
+    box-shadow: var(--casino-active-glow);
+}
+
+@keyframes slots-tumble {
     0%, 100% { transform: translateY(0); }
-    50% { transform: translateY(-4px); }
+    50% { transform: translateY(-6px); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .slots-reel.spinning { animation: none; }
 }
 
 .slots-result {

--- a/web/src/main/resources/static/js/baccarat.js
+++ b/web/src/main/resources/static/js/baccarat.js
@@ -8,6 +8,7 @@ function renderBaccaratResult(opts) {
     var bankerTotalEl = opts.bankerTotalEl;
     var playerTotalEl = opts.playerTotalEl;
     var tableEl = opts.tableEl;
+    var flashTargetEl = opts.flashTargetEl || tableEl;
     var body = opts.body;
 
     if (tableEl) tableEl.hidden = false;
@@ -64,6 +65,18 @@ function renderBaccaratResult(opts) {
             winLineHtml: winLineHtml(body, sideLabel, winnerLabel),
             loseLineHtml: loseLineHtml(body, sideLabel, winnerLabel),
         });
+    }
+
+    // Match the blackjack/poker payoff flourish: gold chip stack pops on
+    // wins, sound cue on either outcome. flashWinPayout picks the right
+    // payout (jackpot > net) and no-ops on losses.
+    if (typeof window !== 'undefined') {
+        if (window.CasinoRender) {
+            window.CasinoRender.flashWinPayout(flashTargetEl, body);
+        }
+        if (window.CasinoSounds) {
+            window.CasinoSounds.play(body.win ? 'win' : 'lose');
+        }
     }
 }
 
@@ -143,6 +156,7 @@ function loseLineHtml(body, sideLabel, winnerLabel) {
                     bankerTotalEl: bankerTotalEl,
                     playerTotalEl: playerTotalEl,
                     tableEl: tableEl,
+                    flashTargetEl: tableEl,
                     body: body,
                 });
             },

--- a/web/src/main/resources/static/js/baccarat.js
+++ b/web/src/main/resources/static/js/baccarat.js
@@ -1,6 +1,13 @@
 // Pure-DOM render for a /play response. Hoisted out of the IIFE so a
 // future jest test can drive it without booting the page. Mirrors the
 // shape of renderCoinflipResult / renderHighlowResult.
+//
+// Staging: opts.stagger (default true) walks the cards onto the felt in
+// Punto Banco tableau order (P1 → B1 → P2 → B2 → optional P3 → B3) at
+// opts.dealMs intervals (default 400ms) so the round feels played, not
+// pre-resolved. Tests pass `stagger: false` to keep their assertions
+// synchronous. The result line / chip flourish / win-or-lose sound are
+// held until the last card lands.
 function renderBaccaratResult(opts) {
     var resultEl = opts.resultEl;
     var bankerCardsEl = opts.bankerCardsEl;
@@ -9,75 +16,144 @@ function renderBaccaratResult(opts) {
     var playerTotalEl = opts.playerTotalEl;
     var tableEl = opts.tableEl;
     var flashTargetEl = opts.flashTargetEl || tableEl;
+    var stagger = opts.stagger !== false;
+    var dealMs = stagger ? (opts.dealMs || 400) : 0;
     var body = opts.body;
 
     if (tableEl) tableEl.hidden = false;
 
-    // Card glyphs come from the shared casino-render module (red ♥/♦
-    // colouring + deal animation are automatic). Bail to plain text if
-    // the module is missing (e.g. in jsdom unit tests).
-    var render = (typeof window !== 'undefined' && window.CasinoRender)
+    // Quiet the totals while the deal is in flight — finalize() restores
+    // them with the natural tags once the last card lands. (Synchronous
+    // path keeps today's behaviour: totals are set inside finalize itself.)
+    if (dealMs > 0) {
+        if (bankerTotalEl) bankerTotalEl.textContent = '';
+        if (playerTotalEl) playerTotalEl.textContent = '';
+    }
+
+    function finalize() {
+        if (bankerTotalEl) {
+            var bankerTag = body.isBankerNatural ? ' • Natural' : '';
+            bankerTotalEl.textContent = '(' + body.bankerTotal + bankerTag + ')';
+        }
+        if (playerTotalEl) {
+            var playerTag = body.isPlayerNatural ? ' • Natural' : '';
+            playerTotalEl.textContent = '(' + body.playerTotal + playerTag + ')';
+        }
+
+        if (!resultEl) return;
+        var sideLabel = sideName(body.side);
+        var winnerLabel = sideName(body.winner);
+
+        if (body.push) {
+            // Tied game on a Player/Banker bet — stake refunded, neither
+            // win nor lose. Skip the shared TobyCasinoResult helper because
+            // it only knows the win/lose dichotomy; render the push line
+            // directly so the colour and class can be -push.
+            resultEl.hidden = false;
+            resultEl.classList.remove('bac-result-win', 'bac-result-lose', 'bac-result-jackpot');
+            resultEl.classList.add('bac-result-push');
+            var topUpPrefix = (typeof window !== 'undefined' && window.TobyTopUp)
+                ? window.TobyTopUp.soldPrefixHtml(body.soldTobyCoins, body.newPrice)
+                : '';
+            resultEl.innerHTML = topUpPrefix +
+                '🤝 <strong>Tie game.</strong> Your <strong>' + sideLabel + '</strong> stake of ' +
+                '<strong>' + body.payout + ' credits</strong> is refunded.';
+            return;
+        }
+
+        if (typeof window !== 'undefined' && window.TobyCasinoResult) {
+            window.TobyCasinoResult.render({
+                resultEl: resultEl,
+                body: body,
+                classPrefix: 'bac',
+                winLineHtml: winLineHtml(body, sideLabel, winnerLabel),
+                loseLineHtml: loseLineHtml(body, sideLabel, winnerLabel),
+            });
+        }
+
+        // Match the blackjack/poker payoff flourish: gold chip stack pops on
+        // wins, sound cue on either outcome. flashWinPayout picks the right
+        // payout (jackpot > net) and no-ops on losses.
+        if (typeof window !== 'undefined') {
+            if (window.CasinoRender) {
+                window.CasinoRender.flashWinPayout(flashTargetEl, body);
+            }
+            if (window.CasinoSounds) {
+                window.CasinoSounds.play(body.win ? 'win' : 'lose');
+            }
+        }
+    }
+
+    playBaccaratDeal({
+        playerCardsEl: playerCardsEl,
+        bankerCardsEl: bankerCardsEl,
+        body: body,
+        dealMs: dealMs,
+        onComplete: finalize,
+    });
+}
+
+// Walks the two hands onto the felt in Punto Banco tableau order. With
+// dealMs > 0 the steps are scheduled via setTimeout; with dealMs === 0
+// (or no CasinoRender available) the whole thing runs synchronously and
+// onComplete fires in the same tick.
+//
+// Relies on CasinoRender.renderCards's per-container previousCount so
+// re-rendering with a growing array animates only the freshly-arrived
+// card; the per-card 'deal' click cue rides along inside that helper.
+function playBaccaratDeal(opts) {
+    var playerCardsEl = opts.playerCardsEl;
+    var bankerCardsEl = opts.bankerCardsEl;
+    var body = opts.body;
+    var dealMs = opts.dealMs;
+    var onComplete = opts.onComplete;
+    var pCards = body.playerCards || [];
+    var bCards = body.bankerCards || [];
+
+    var renderCards = (typeof window !== 'undefined' && window.CasinoRender)
         ? window.CasinoRender.renderCards
         : null;
-    if (render) {
-        if (bankerCardsEl) render(bankerCardsEl, body.bankerCards || []);
-        if (playerCardsEl) render(playerCardsEl, body.playerCards || []);
-    } else {
-        if (bankerCardsEl) bankerCardsEl.textContent = (body.bankerCards || []).join(' ');
-        if (playerCardsEl) playerCardsEl.textContent = (body.playerCards || []).join(' ');
-    }
 
-    if (bankerTotalEl) {
-        var bankerTag = body.isBankerNatural ? ' • Natural' : '';
-        bankerTotalEl.textContent = '(' + body.bankerTotal + bankerTag + ')';
-    }
-    if (playerTotalEl) {
-        var playerTag = body.isPlayerNatural ? ' • Natural' : '';
-        playerTotalEl.textContent = '(' + body.playerTotal + playerTag + ')';
-    }
+    function done() { if (onComplete) onComplete(); }
 
-    if (!resultEl) return;
-    var sideLabel = sideName(body.side);
-    var winnerLabel = sideName(body.winner);
-
-    if (body.push) {
-        // Tied game on a Player/Banker bet — stake refunded, neither
-        // win nor lose. Skip the shared TobyCasinoResult helper because
-        // it only knows the win/lose dichotomy; render the push line
-        // directly so the colour and class can be -push.
-        resultEl.hidden = false;
-        resultEl.classList.remove('bac-result-win', 'bac-result-lose', 'bac-result-jackpot');
-        resultEl.classList.add('bac-result-push');
-        var topUpPrefix = (typeof window !== 'undefined' && window.TobyTopUp)
-            ? window.TobyTopUp.soldPrefixHtml(body.soldTobyCoins, body.newPrice)
-            : '';
-        resultEl.innerHTML = topUpPrefix +
-            '🤝 <strong>Tie game.</strong> Your <strong>' + sideLabel + '</strong> stake of ' +
-            '<strong>' + body.payout + ' credits</strong> is refunded.';
+    if (!renderCards || !dealMs || dealMs <= 0) {
+        // Synchronous path — preserves the legacy "paint everything at
+        // once" behaviour and keeps the existing jest tests trivial.
+        if (renderCards) {
+            if (bankerCardsEl) renderCards(bankerCardsEl, bCards);
+            if (playerCardsEl) renderCards(playerCardsEl, pCards);
+        } else {
+            if (bankerCardsEl) bankerCardsEl.textContent = bCards.join(' ');
+            if (playerCardsEl) playerCardsEl.textContent = pCards.join(' ');
+        }
+        done();
         return;
     }
 
-    if (typeof window !== 'undefined' && window.TobyCasinoResult) {
-        window.TobyCasinoResult.render({
-            resultEl: resultEl,
-            body: body,
-            classPrefix: 'bac',
-            winLineHtml: winLineHtml(body, sideLabel, winnerLabel),
-            loseLineHtml: loseLineHtml(body, sideLabel, winnerLabel),
-        });
+    // Build the tableau order: alternating Player / Banker, growing each
+    // side's array by one card at each step. Trailing nulls (one side
+    // ended sooner than the other) are pruned so onComplete fires the
+    // moment the last real card lands.
+    var steps = [];
+    var maxLen = Math.max(pCards.length, bCards.length);
+    for (var i = 0; i < maxLen; i++) {
+        steps.push(i < pCards.length ? { el: playerCardsEl, list: pCards.slice(0, i + 1) } : null);
+        steps.push(i < bCards.length ? { el: bankerCardsEl, list: bCards.slice(0, i + 1) } : null);
     }
+    while (steps.length && steps[steps.length - 1] === null) steps.pop();
 
-    // Match the blackjack/poker payoff flourish: gold chip stack pops on
-    // wins, sound cue on either outcome. flashWinPayout picks the right
-    // payout (jackpot > net) and no-ops on losses.
-    if (typeof window !== 'undefined') {
-        if (window.CasinoRender) {
-            window.CasinoRender.flashWinPayout(flashTargetEl, body);
-        }
-        if (window.CasinoSounds) {
-            window.CasinoSounds.play(body.win ? 'win' : 'lose');
-        }
-    }
+    // Wipe both sides up front so a fresh round starts on a clear felt.
+    // (renderCards([]) resets the previousCount tracker, so the first
+    // dealt card animates in cleanly.)
+    if (playerCardsEl) renderCards(playerCardsEl, []);
+    if (bankerCardsEl) renderCards(bankerCardsEl, []);
+
+    steps.forEach(function (step, i) {
+        setTimeout(function () {
+            if (step && step.el) renderCards(step.el, step.list);
+        }, i * dealMs);
+    });
+    setTimeout(done, steps.length * dealMs);
 }
 
 function sideName(raw) {
@@ -165,5 +241,5 @@ function loseLineHtml(body, sideLabel, winnerLabel) {
 })();
 
 if (typeof module !== 'undefined' && module.exports) {
-    module.exports = { renderBaccaratResult };
+    module.exports = { renderBaccaratResult, playBaccaratDeal };
 }

--- a/web/src/main/resources/static/js/casino-render.js
+++ b/web/src/main/resources/static/js/casino-render.js
@@ -224,11 +224,26 @@
         }
     }
 
+    // Convenience wrapper: pull the right payout off a server response
+    // body and drop a chip flourish for it. `body.jackpotPayout` (when
+    // > 0) wins over `body.net` so a jackpot reads as the bigger payout
+    // it is. No-op on losses / zero / missing seat — every game caller
+    // can pass its body straight through without guarding.
+    function flashWinPayout(seatEl, body, chipCount) {
+        if (!seatEl || !body || !body.win) return;
+        var payout = (typeof body.jackpotPayout === "number" && body.jackpotPayout > 0)
+            ? body.jackpotPayout
+            : body.net;
+        if (!payout || payout <= 0) return;
+        flashChipsOn(seatEl, payout, chipCount);
+    }
+
     window.CasinoRender = {
         renderCards: renderCards,
         makeAvatar: makeAvatar,
         makeSeatHeader: makeSeatHeader,
         renderActorPill: renderActorPill,
         flashChipsOn: flashChipsOn,
+        flashWinPayout: flashWinPayout,
     };
 })();

--- a/web/src/main/resources/static/js/coinflip.js
+++ b/web/src/main/resources/static/js/coinflip.js
@@ -1,6 +1,6 @@
 // Pure-DOM render for a /flip response. Hoisted out of the IIFE so the
 // jest test in `coinflip.test.js` can drive it without booting the page.
-function renderCoinflipResult(resultEl, body) {
+function renderCoinflipResult(resultEl, body, flashTargetEl) {
     const landedLabel = body.landed === 'HEADS' ? 'Heads' : 'Tails';
     const predictedLabel = body.predicted === 'HEADS' ? 'Heads' : 'Tails';
     if (typeof window !== 'undefined' && window.TobyCasinoResult) {
@@ -14,6 +14,10 @@ function renderCoinflipResult(resultEl, body) {
                 predictedLabel + ' &middot; lost <strong>' + Math.abs(body.net) + ' credits</strong>',
         });
     }
+    // Same chip flourish blackjack uses when a hand pays out.
+    if (typeof window !== 'undefined' && window.CasinoRender) {
+        window.CasinoRender.flashWinPayout(flashTargetEl, body);
+    }
 }
 
 (function () {
@@ -25,6 +29,7 @@ function renderCoinflipResult(resultEl, body) {
     const guildId = main.dataset.guildId;
     const coin = document.getElementById('coinflip-coin');
     const coinFace = document.getElementById('coinflip-coin-face');
+    const tableEl = document.querySelector('.coinflip-table');
     const stakeInput = document.getElementById('coinflip-stake');
     const flipBtn = document.getElementById('coinflip-flip');
     const flipTobyBtn = document.getElementById('coinflip-flip-toby');
@@ -98,7 +103,7 @@ function renderCoinflipResult(resultEl, body) {
         },
         startAnimation: startFlipAnimation,
         stopAnimation: stopFlipAnimation,
-        renderResult: function (body) { renderCoinflipResult(resultEl, body); },
+        renderResult: function (body) { renderCoinflipResult(resultEl, body, tableEl); },
     });
 })();
 

--- a/web/src/main/resources/static/js/dice.js
+++ b/web/src/main/resources/static/js/dice.js
@@ -1,6 +1,6 @@
 // Pure-DOM render for a /roll response. Hoisted out of the IIFE so the
 // jest test in `dice.test.js` can drive it without booting the page.
-function renderDiceResult(resultEl, body) {
+function renderDiceResult(resultEl, body, flashTargetEl) {
     if (typeof window !== 'undefined' && window.TobyCasinoResult) {
         window.TobyCasinoResult.render({
             resultEl: resultEl,
@@ -11,6 +11,10 @@ function renderDiceResult(resultEl, body) {
             loseLineHtml: '<strong>' + body.landed + '.</strong> You called ' +
                 body.predicted + ' &middot; lost <strong>' + Math.abs(body.net) + ' credits</strong>',
         });
+    }
+    // Same chip flourish blackjack/poker use on a winning hand.
+    if (typeof window !== 'undefined' && window.CasinoRender) {
+        window.CasinoRender.flashWinPayout(flashTargetEl, body);
     }
 }
 
@@ -23,6 +27,7 @@ function renderDiceResult(resultEl, body) {
     const guildId = main.dataset.guildId;
     const die = document.getElementById('dice-die');
     const dieFace = document.getElementById('dice-die-face');
+    const tableEl = document.querySelector('.dice-table');
     const stakeInput = document.getElementById('dice-stake');
     const rollBtn = document.getElementById('dice-roll');
     const rollTobyBtn = document.getElementById('dice-roll-toby');
@@ -95,7 +100,7 @@ function renderDiceResult(resultEl, body) {
         },
         startAnimation: startRollAnimation,
         stopAnimation: stopRollAnimation,
-        renderResult: function (body) { renderDiceResult(resultEl, body); },
+        renderResult: function (body) { renderDiceResult(resultEl, body, tableEl); },
     });
 })();
 

--- a/web/src/main/resources/static/js/highlow.js
+++ b/web/src/main/resources/static/js/highlow.js
@@ -20,7 +20,11 @@ function highlowFormatMultiplier(m) {
 
 // Pure-DOM render for a /play response. Hoisted out of the IIFE so the
 // jest test in `highlow.test.js` can drive it without booting the page.
-function renderHighlowResult(resultEl, body) {
+//
+// flashTargetEl is the felt element that gets the chip-stack flourish
+// on a win — passing it through the render fn keeps the chip flourish
+// callable from tests, instead of being trapped inside the IIFE.
+function renderHighlowResult(resultEl, body, flashTargetEl) {
     if (typeof window === 'undefined' || !window.TobyCasinoResult) return;
     const dirLabel = body.direction === 'HIGHER' ? 'Higher' : 'Lower';
     const tie = body.next === body.anchor;
@@ -39,6 +43,14 @@ function renderHighlowResult(resultEl, body) {
             ' <strong>' + highlowCardLabel(body.anchor) + '</strong> &middot; you called ' +
             dirLabel + ' &middot; lost <strong>' + Math.abs(body.net) + ' credits</strong>',
     });
+    // Highlow's response has no `win` field — net > 0 is the win signal.
+    if (window.CasinoRender) {
+        window.CasinoRender.flashWinPayout(flashTargetEl, {
+            win: (body.net || 0) > 0,
+            net: body.net,
+            jackpotPayout: body.jackpotPayout,
+        });
+    }
 }
 
 (function () {
@@ -201,20 +213,9 @@ function renderHighlowResult(resultEl, body) {
                     playing = false;
                     if (body && body.ok) {
                         stopNextShuffle(intervalId, body.next);
-                        renderHighlowResult(resultEl, body);
+                        renderHighlowResult(resultEl, body, tableEl);
                         if (window.CasinoSounds) {
                             window.CasinoSounds.play(body.net > 0 ? 'win' : 'lose');
-                        }
-                        // Drop a chip stack on the felt so a high-low win
-                        // celebrates the same way a blackjack/poker win does.
-                        // highlow uses `net > 0` as its win flag; synthesise
-                        // the field flashWinPayout expects.
-                        if (window.CasinoRender) {
-                            window.CasinoRender.flashWinPayout(tableEl, {
-                                win: body.net > 0,
-                                net: body.net,
-                                jackpotPayout: body.jackpotPayout,
-                            });
                         }
                         if (game) {
                             game.applyBalance(body.newBalance);

--- a/web/src/main/resources/static/js/highlow.js
+++ b/web/src/main/resources/static/js/highlow.js
@@ -54,6 +54,7 @@ function renderHighlowResult(resultEl, body) {
     const nextFace = document.getElementById('highlow-next-face');
     const anchorCard = document.getElementById('highlow-anchor');
     const nextCard = document.getElementById('highlow-next');
+    const tableEl = document.querySelector('.highlow-table');
     const stakeInput = document.getElementById('highlow-stake');
     const dealBtn = document.getElementById('highlow-deal');
     const dealTobyBtn = document.getElementById('highlow-deal-toby');
@@ -104,6 +105,7 @@ function renderHighlowResult(resultEl, body) {
         if (typeof anchorValue === 'number') {
             anchorFace.textContent = cardLabel(anchorValue);
             if (anchorCard) anchorCard.dataset.value = String(anchorValue);
+            replayDealAnimation(anchorFace);
             if (window.CasinoSounds) window.CasinoSounds.play('deal');
         }
         nextFace.textContent = '?';
@@ -129,12 +131,28 @@ function renderHighlowResult(resultEl, body) {
         if (typeof value === 'number') {
             nextFace.textContent = cardLabel(value);
             nextCard.dataset.value = String(value);
+            replayDealAnimation(nextFace);
             // Final card snaps into place — sounds the flip cue.
             if (window.CasinoSounds) window.CasinoSounds.play('flip');
         } else {
             nextFace.textContent = '?';
             delete nextCard.dataset.value;
         }
+    }
+
+    // Re-trigger the shared casino deal-in animation on a glyph that's
+    // already in the DOM. casino-table.css applies the keyframe via
+    // `.is-dealt`, so toggling the class restarts the 280ms ease-out.
+    function replayDealAnimation(el) {
+        if (!el) return;
+        el.classList.remove('is-dealt');
+        // Force reflow so the browser registers the class removal before
+        // re-adding it — without this the animation just keeps its current
+        // state instead of replaying.
+        // eslint-disable-next-line no-unused-expressions
+        el.offsetWidth;
+        el.classList.add('is-dealt');
+        setTimeout(function () { el.classList.remove('is-dealt'); }, 320);
     }
 
     // /start uses the shared form + TOBY-topup scaffolding. /play has
@@ -186,6 +204,17 @@ function renderHighlowResult(resultEl, body) {
                         renderHighlowResult(resultEl, body);
                         if (window.CasinoSounds) {
                             window.CasinoSounds.play(body.net > 0 ? 'win' : 'lose');
+                        }
+                        // Drop a chip stack on the felt so a high-low win
+                        // celebrates the same way a blackjack/poker win does.
+                        // highlow uses `net > 0` as its win flag; synthesise
+                        // the field flashWinPayout expects.
+                        if (window.CasinoRender) {
+                            window.CasinoRender.flashWinPayout(tableEl, {
+                                win: body.net > 0,
+                                net: body.net,
+                                jackpotPayout: body.jackpotPayout,
+                            });
                         }
                         if (game) {
                             game.applyBalance(body.newBalance);

--- a/web/src/main/resources/static/js/scratch.js
+++ b/web/src/main/resources/static/js/scratch.js
@@ -1,9 +1,9 @@
 // Pure-DOM render for a /scratch response. Hoisted out of the IIFE so
 // the jest test in `scratch.test.js` can drive it without booting the
-// page. matchThreshold and balanceEl are passed in (they live as DOM
-// attributes / element references inside the IIFE) to keep this fully
-// stateless.
-function renderScratchResult(resultEl, body, matchThreshold, balanceEl) {
+// page. matchThreshold / balanceEl / flashTargetEl are passed in (they
+// live as DOM attributes / element references inside the IIFE) to keep
+// this fully stateless.
+function renderScratchResult(resultEl, body, matchThreshold, balanceEl, flashTargetEl) {
     if (typeof window !== 'undefined' && window.TobyCasinoResult) {
         window.TobyCasinoResult.render({
             resultEl: resultEl,
@@ -16,6 +16,17 @@ function renderScratchResult(resultEl, body, matchThreshold, balanceEl) {
         });
     }
     if (typeof body.newBalance === 'number' && balanceEl) balanceEl.textContent = body.newBalance;
+    // Scratch's response has no `win` field — net > 0 is the win signal.
+    // Bigger payouts get a taller stack (capped internally at 7).
+    if (typeof window !== 'undefined' && window.CasinoRender) {
+        const payoutEstimate = (body.jackpotPayout > 0 ? body.jackpotPayout : (body.net || 0));
+        const chipCount = Math.min(7, Math.max(3, Math.ceil(payoutEstimate / 100)));
+        window.CasinoRender.flashWinPayout(flashTargetEl, {
+            win: (body.net || 0) > 0,
+            net: body.net,
+            jackpotPayout: body.jackpotPayout,
+        }, chipCount);
+    }
 }
 
 (function () {
@@ -72,24 +83,9 @@ function renderScratchResult(resultEl, body, matchThreshold, balanceEl) {
         // win cells once everything is revealed (see below).
         if (cellButtons.every(function (b) { return b.classList.contains('revealed'); })) {
             highlightWinCells(activeCard);
-            renderScratchResult(resultEl, activeCard, matchThreshold, balanceEl);
+            renderScratchResult(resultEl, activeCard, matchThreshold, balanceEl, tableEl);
             if (window.CasinoSounds) {
                 window.CasinoSounds.play((activeCard.net || 0) > 0 ? 'win' : 'lose');
-            }
-            // Drop the shared chip flourish on the felt for a win, so a
-            // scratchcard payout celebrates the same way every other
-            // casino game does. flashWinPayout treats `win: true` and a
-            // positive net as the trigger; scratch uses `net > 0` as its
-            // win flag so we synthesise that field for the helper.
-            if (window.CasinoRender) {
-                var payoutEstimate = (activeCard.jackpotPayout > 0
-                    ? activeCard.jackpotPayout
-                    : (activeCard.net || 0));
-                window.CasinoRender.flashWinPayout(tableEl, {
-                    win: (activeCard.net || 0) > 0,
-                    net: activeCard.net,
-                    jackpotPayout: activeCard.jackpotPayout,
-                }, Math.min(7, Math.max(3, Math.ceil(payoutEstimate / 100))));
             }
             // Now the credits visibly drop and the topup-coin recompute
             // catches up too — see autoApplyBalance: false in the helper.

--- a/web/src/main/resources/static/js/scratch.js
+++ b/web/src/main/resources/static/js/scratch.js
@@ -30,6 +30,7 @@ function renderScratchResult(resultEl, body, matchThreshold, balanceEl) {
 
     const cellsContainer = document.getElementById('scratch-cells');
     const cellButtons = Array.from(cellsContainer ? cellsContainer.querySelectorAll('.scratch-cell') : []);
+    const tableEl = document.querySelector('.scratch-table');
     const stakeInput = document.getElementById('scratch-stake');
     const buyBtn = document.getElementById('scratch-buy');
     const buyTobyBtn = document.getElementById('scratch-buy-toby');
@@ -74,6 +75,21 @@ function renderScratchResult(resultEl, body, matchThreshold, balanceEl) {
             renderScratchResult(resultEl, activeCard, matchThreshold, balanceEl);
             if (window.CasinoSounds) {
                 window.CasinoSounds.play((activeCard.net || 0) > 0 ? 'win' : 'lose');
+            }
+            // Drop the shared chip flourish on the felt for a win, so a
+            // scratchcard payout celebrates the same way every other
+            // casino game does. flashWinPayout treats `win: true` and a
+            // positive net as the trigger; scratch uses `net > 0` as its
+            // win flag so we synthesise that field for the helper.
+            if (window.CasinoRender) {
+                var payoutEstimate = (activeCard.jackpotPayout > 0
+                    ? activeCard.jackpotPayout
+                    : (activeCard.net || 0));
+                window.CasinoRender.flashWinPayout(tableEl, {
+                    win: (activeCard.net || 0) > 0,
+                    net: activeCard.net,
+                    jackpotPayout: activeCard.jackpotPayout,
+                }, Math.min(7, Math.max(3, Math.ceil(payoutEstimate / 100))));
             }
             // Now the credits visibly drop and the topup-coin recompute
             // catches up too — see autoApplyBalance: false in the helper.

--- a/web/src/main/resources/static/js/slots.js
+++ b/web/src/main/resources/static/js/slots.js
@@ -1,7 +1,7 @@
 // Pure-DOM render for a /spin response. Hoisted out of the IIFE so the
 // jest test in `slots.test.js` can drive it without booting the whole
 // page. The IIFE below calls it with the live result element.
-function renderSlotsResult(resultEl, body) {
+function renderSlotsResult(resultEl, body, flashTargetEl, reels) {
     if (typeof window !== 'undefined' && window.TobyCasinoResult) {
         window.TobyCasinoResult.render({
             resultEl: resultEl,
@@ -11,6 +11,22 @@ function renderSlotsResult(resultEl, body) {
                 body.multiplier + '× on a stake',
             loseLineHtml: 'Lost <strong>' + Math.abs(body.net) + ' credits</strong>',
         });
+    }
+    if (typeof window === 'undefined' || !body) return;
+    // Light up the winning reels with the gold halo used everywhere else
+    // for "this is the active payoff", and drop the shared chip flourish
+    // on the felt so a slots win celebrates like a blackjack win.
+    if (reels && reels.length) {
+        reels.forEach(function (r) { if (r) r.classList.remove('win-cell'); });
+        if (body.win) {
+            reels.forEach(function (r) { if (r) r.classList.add('win-cell'); });
+        }
+    }
+    if (window.CasinoRender) {
+        // Bigger payouts get a taller stack, capped internally at 7.
+        var payoutEstimate = (body.jackpotPayout > 0 ? body.jackpotPayout : body.net) || 0;
+        var chipCount = Math.min(7, Math.max(3, Math.ceil(payoutEstimate / 100)));
+        window.CasinoRender.flashWinPayout(flashTargetEl, body, chipCount);
     }
 }
 
@@ -26,6 +42,7 @@ function renderSlotsResult(resultEl, body) {
         document.getElementById('slots-reel-1'),
         document.getElementById('slots-reel-2')
     ];
+    const machineEl = document.querySelector('.slots-machine');
     const stakeInput = document.getElementById('slots-stake');
     const spinBtn = document.getElementById('slots-spin');
     const spinTobyBtn = document.getElementById('slots-spin-toby');
@@ -40,7 +57,12 @@ function renderSlotsResult(resultEl, body) {
     const SPIN_DURATION_MS = 800;
 
     function startSpinAnimation() {
-        reels.forEach(function (reel) { reel.classList.add('spinning'); });
+        // Strip any prior win highlight so a fresh spin doesn't wear the
+        // gold halo from the previous round while it's still tumbling.
+        reels.forEach(function (reel) {
+            reel.classList.remove('win-cell');
+            reel.classList.add('spinning');
+        });
         if (window.CasinoSounds) window.CasinoSounds.play('deal');
         return setInterval(function () {
             reels.forEach(function (reel) {
@@ -83,7 +105,7 @@ function renderSlotsResult(resultEl, body) {
         failureMessage: 'Spin failed.',
         startAnimation: startSpinAnimation,
         stopAnimation: stopSpinAnimation,
-        renderResult: function (body) { renderSlotsResult(resultEl, body); },
+        renderResult: function (body) { renderSlotsResult(resultEl, body, machineEl, reels); },
     });
 })();
 

--- a/web/src/main/resources/templates/baccarat.html
+++ b/web/src/main/resources/templates/baccarat.html
@@ -64,7 +64,7 @@
         </div>
     </section>
 
-    <section class="bac-card bac-table casino-felt" id="bac-table" hidden>
+    <section class="bac-table casino-felt" id="bac-table" hidden>
         <div class="bac-row casino-dealer-zone">
             <h3>Banker <span class="muted" id="bac-banker-total"></span></h3>
             <div id="bac-banker-cards" class="bac-cards casino-cards"></div>

--- a/web/src/main/resources/templates/blackjack-solo.html
+++ b/web/src/main/resources/templates/blackjack-solo.html
@@ -35,7 +35,7 @@
         </div>
     </section>
 
-    <section class="bj-card bj-table casino-felt" id="bj-table" hidden>
+    <section class="bj-table casino-felt" id="bj-table" hidden>
         <div class="bj-row casino-dealer-zone">
             <h3>Dealer <span class="muted" id="bj-dealer-total"></span></h3>
             <div id="bj-dealer-cards" class="bj-cards casino-cards"></div>

--- a/web/src/main/resources/templates/blackjack-table.html
+++ b/web/src/main/resources/templates/blackjack-table.html
@@ -28,7 +28,7 @@
         <button id="bj-join" class="btn-primary" type="button">Sit down</button>
     </section>
 
-    <section class="bj-card bj-table casino-felt">
+    <section class="bj-table casino-felt">
         <div id="bj-actor-pill" class="casino-actor-pill" hidden></div>
 
         <div class="bj-info">

--- a/web/src/main/resources/templates/casino-guilds.html
+++ b/web/src/main/resources/templates/casino-guilds.html
@@ -33,6 +33,8 @@
                 <a class="btn-secondary"
                    th:href="@{/casino/{id}/scratch(id=${g.id})}">🎟️ Scratch</a>
                 <a class="btn-secondary"
+                   th:href="@{/casino/{id}/baccarat(id=${g.id})}">🎴 Baccarat</a>
+                <a class="btn-secondary"
                    th:href="@{/poker/{id}(id=${g.id})}">🎴 Poker</a>
                 <a class="btn-secondary"
                    th:href="@{/blackjack/{id}/solo(id=${g.id})}">🂡 Blackjack</a>

--- a/web/src/main/resources/templates/coinflip.html
+++ b/web/src/main/resources/templates/coinflip.html
@@ -18,7 +18,7 @@
 
     <div th:replace="~{fragments/alerts :: error}"></div>
 
-    <section class="coinflip-table">
+    <section class="coinflip-table casino-felt">
         <div class="coinflip-coin" id="coinflip-coin" aria-live="polite">
             <span class="coinflip-coin-face" id="coinflip-coin-face">🪙</span>
         </div>

--- a/web/src/main/resources/templates/dice.html
+++ b/web/src/main/resources/templates/dice.html
@@ -19,8 +19,8 @@
 
     <div th:replace="~{fragments/alerts :: error}"></div>
 
-    <section class="dice-table">
-        <div class="dice-die" id="dice-die" aria-live="polite">
+    <section class="dice-table casino-felt">
+        <div class="dice-die casino-card-face" id="dice-die" aria-live="polite">
             <span class="dice-die-face" id="dice-die-face">⚀</span>
         </div>
 

--- a/web/src/main/resources/templates/highlow.html
+++ b/web/src/main/resources/templates/highlow.html
@@ -18,17 +18,17 @@
 
     <div th:replace="~{fragments/alerts :: error}"></div>
 
-    <section class="highlow-table">
+    <section class="highlow-table casino-felt">
         <div class="highlow-cards">
             <div class="highlow-card" id="highlow-anchor"
                  th:attr="data-value=${anchor}" aria-live="polite">
-                <span class="highlow-card-face" id="highlow-anchor-face"
+                <span class="highlow-card-face casino-card-glyph" id="highlow-anchor-face"
                       th:text="${anchorLabel}">?</span>
                 <span class="highlow-card-label">Anchor</span>
             </div>
             <div class="highlow-arrow" id="highlow-arrow" aria-hidden="true">→</div>
             <div class="highlow-card" id="highlow-next" aria-live="polite">
-                <span class="highlow-card-face" id="highlow-next-face">?</span>
+                <span class="highlow-card-face casino-card-glyph" id="highlow-next-face">?</span>
                 <span class="highlow-card-label">Next</span>
             </div>
         </div>

--- a/web/src/main/resources/templates/scratch.html
+++ b/web/src/main/resources/templates/scratch.html
@@ -20,7 +20,7 @@
 
     <div th:replace="~{fragments/alerts :: error}"></div>
 
-    <section class="scratch-table">
+    <section class="scratch-table casino-felt">
         <div class="scratch-cells" id="scratch-cells">
             <button th:each="i : ${#numbers.sequence(0, cellCount - 1)}"
                     type="button" class="scratch-cell"

--- a/web/src/main/resources/templates/slots.html
+++ b/web/src/main/resources/templates/slots.html
@@ -18,11 +18,11 @@
 
     <div th:replace="~{fragments/alerts :: error}"></div>
 
-    <section class="slots-machine">
+    <section class="slots-machine casino-felt">
         <div class="slots-reels" id="slots-reels" aria-live="polite">
-            <div class="slots-reel" id="slots-reel-0" data-symbol="🍒">🍒</div>
-            <div class="slots-reel" id="slots-reel-1" data-symbol="🍋">🍋</div>
-            <div class="slots-reel" id="slots-reel-2" data-symbol="🔔">🔔</div>
+            <div class="slots-reel casino-card-face" id="slots-reel-0" data-symbol="🍒">🍒</div>
+            <div class="slots-reel casino-card-face" id="slots-reel-1" data-symbol="🍋">🍋</div>
+            <div class="slots-reel casino-card-face" id="slots-reel-2" data-symbol="🔔">🔔</div>
         </div>
 
         <div class="slots-result" id="slots-result" hidden></div>

--- a/web/src/test/js/baccarat.test.js
+++ b/web/src/test/js/baccarat.test.js
@@ -1,6 +1,7 @@
 const { renderBaccaratResult } = require('../../main/resources/static/js/baccarat');
 require('../../main/resources/static/js/casino-jackpot');
 require('../../main/resources/static/js/casino-result');
+require('../../main/resources/static/js/casino-render');
 
 describe('renderBaccaratResult', () => {
     let resultEl;
@@ -214,5 +215,34 @@ describe('renderBaccaratResult', () => {
             resultEl: null, bankerCardsEl: null, playerCardsEl: null,
             tableEl: null, body: { win: true }
         })).not.toThrow();
+    });
+
+    test('win flashes a chip stack on the flash target; loss leaves it untouched', () => {
+        renderBaccaratResult({
+            resultEl, bankerCardsEl, playerCardsEl,
+            bankerTotalEl, playerTotalEl, tableEl,
+            flashTargetEl: tableEl,
+            body: {
+                win: true, push: false, side: 'PLAYER', winner: 'PLAYER',
+                playerCards: ['5♠', '3♥'], bankerCards: ['2♣', '4♦'],
+                playerTotal: 8, bankerTotal: 6, multiplier: 2.0, net: 100,
+            },
+        });
+        expect(tableEl.querySelector('.casino-chip-stack')).not.toBeNull();
+        expect(tableEl.querySelector('.casino-chip-payout').textContent).toBe('+100');
+
+        // Reset the felt for the loss check.
+        tableEl.querySelectorAll('.casino-chip-stack').forEach((el) => el.remove());
+        renderBaccaratResult({
+            resultEl, bankerCardsEl, playerCardsEl,
+            bankerTotalEl, playerTotalEl, tableEl,
+            flashTargetEl: tableEl,
+            body: {
+                win: false, push: false, side: 'PLAYER', winner: 'BANKER',
+                playerCards: ['5♠', '2♥'], bankerCards: ['9♣', '8♦'],
+                playerTotal: 7, bankerTotal: 7, net: -50,
+            },
+        });
+        expect(tableEl.querySelector('.casino-chip-stack')).toBeNull();
     });
 });

--- a/web/src/test/js/baccarat.test.js
+++ b/web/src/test/js/baccarat.test.js
@@ -32,7 +32,11 @@ describe('renderBaccaratResult', () => {
     function renderWith(body) {
         renderBaccaratResult({
             resultEl, bankerCardsEl, playerCardsEl,
-            bankerTotalEl, playerTotalEl, tableEl, body,
+            bankerTotalEl, playerTotalEl, tableEl,
+            // Keep these tests synchronous — staging is exercised by the
+            // dedicated "staged path" test below.
+            stagger: false,
+            body,
         });
     }
 
@@ -222,6 +226,7 @@ describe('renderBaccaratResult', () => {
             resultEl, bankerCardsEl, playerCardsEl,
             bankerTotalEl, playerTotalEl, tableEl,
             flashTargetEl: tableEl,
+            stagger: false,
             body: {
                 win: true, push: false, side: 'PLAYER', winner: 'PLAYER',
                 playerCards: ['5♠', '3♥'], bankerCards: ['2♣', '4♦'],
@@ -237,6 +242,7 @@ describe('renderBaccaratResult', () => {
             resultEl, bankerCardsEl, playerCardsEl,
             bankerTotalEl, playerTotalEl, tableEl,
             flashTargetEl: tableEl,
+            stagger: false,
             body: {
                 win: false, push: false, side: 'PLAYER', winner: 'BANKER',
                 playerCards: ['5♠', '2♥'], bankerCards: ['9♣', '8♦'],
@@ -244,5 +250,56 @@ describe('renderBaccaratResult', () => {
             },
         });
         expect(tableEl.querySelector('.casino-chip-stack')).toBeNull();
+    });
+
+    test('staged path holds the result line until the deal sequence completes', () => {
+        jest.useFakeTimers();
+        try {
+            renderBaccaratResult({
+                resultEl, bankerCardsEl, playerCardsEl,
+                bankerTotalEl, playerTotalEl, tableEl,
+                flashTargetEl: tableEl,
+                stagger: true,
+                dealMs: 50,
+                body: {
+                    win: true, push: false, side: 'PLAYER', winner: 'PLAYER',
+                    playerCards: ['5♠', '3♥'], bankerCards: ['2♣', '4♦'],
+                    playerTotal: 8, bankerTotal: 6,
+                    isPlayerNatural: true, isBankerNatural: false,
+                    multiplier: 2.0, net: 100,
+                },
+            });
+
+            // Synchronously after the call: cards haven't been dealt yet
+            // (only the t=0 setTimeout is queued), result line is empty,
+            // totals are blanked while the deal plays out.
+            expect(resultEl.classList.contains('bac-result-win')).toBe(false);
+            expect(resultEl.innerHTML).toBe('');
+            expect(playerTotalEl.textContent).toBe('');
+            expect(bankerTotalEl.textContent).toBe('');
+            expect(playerCardsEl.querySelectorAll('.casino-card-glyph').length).toBe(0);
+            expect(bankerCardsEl.querySelectorAll('.casino-card-glyph').length).toBe(0);
+
+            // Halfway through the first interval — only Player's first card.
+            jest.advanceTimersByTime(25);
+            expect(playerCardsEl.querySelectorAll('.casino-card-glyph').length).toBe(1);
+            expect(bankerCardsEl.querySelectorAll('.casino-card-glyph').length).toBe(0);
+            expect(resultEl.classList.contains('bac-result-win')).toBe(false);
+
+            // Advance past the deal sequence (4 * 50ms = 200ms) but stop
+            // before flashChipsOn's 2.5s safety-cleanup timer fires —
+            // otherwise runAllTimers would remove the chip stack we want
+            // to assert.
+            jest.advanceTimersByTime(250);
+            expect(playerCardsEl.querySelectorAll('.casino-card-glyph').length).toBe(2);
+            expect(bankerCardsEl.querySelectorAll('.casino-card-glyph').length).toBe(2);
+            expect(resultEl.classList.contains('bac-result-win')).toBe(true);
+            expect(resultEl.innerHTML).toContain('Player wins');
+            expect(playerTotalEl.textContent).toBe('(8 • Natural)');
+            expect(bankerTotalEl.textContent).toBe('(6)');
+            expect(tableEl.querySelector('.casino-chip-stack')).not.toBeNull();
+        } finally {
+            jest.useRealTimers();
+        }
     });
 });

--- a/web/src/test/js/casino-render.test.js
+++ b/web/src/test/js/casino-render.test.js
@@ -1,0 +1,69 @@
+// Unit tests for CasinoRender.flashWinPayout — the shared helper that
+// every casino game calls to drop a chip stack onto the felt on a win.
+// flashChipsOn (the lower-level primitive) is exercised in passing.
+
+require('../../main/resources/static/js/casino-render');
+
+describe('CasinoRender.flashWinPayout', () => {
+    let seatEl;
+
+    beforeEach(() => {
+        document.body.innerHTML = '<div id="seat"></div>';
+        seatEl = document.getElementById('seat');
+    });
+
+    test('no-ops on body.win = false', () => {
+        window.CasinoRender.flashWinPayout(seatEl, { win: false, net: 100 });
+        expect(seatEl.querySelector('.casino-chip-stack')).toBeNull();
+    });
+
+    test('no-ops on missing body', () => {
+        window.CasinoRender.flashWinPayout(seatEl, null);
+        expect(seatEl.querySelector('.casino-chip-stack')).toBeNull();
+    });
+
+    test('no-ops on missing seat element', () => {
+        expect(() => window.CasinoRender.flashWinPayout(null, { win: true, net: 100 }))
+            .not.toThrow();
+    });
+
+    test('no-ops on win with non-positive net and no jackpot', () => {
+        window.CasinoRender.flashWinPayout(seatEl, { win: true, net: 0 });
+        expect(seatEl.querySelector('.casino-chip-stack')).toBeNull();
+    });
+
+    test('drops a chip stack with the net payout when win is true', () => {
+        window.CasinoRender.flashWinPayout(seatEl, { win: true, net: 100 });
+        const stack = seatEl.querySelector('.casino-chip-stack');
+        expect(stack).not.toBeNull();
+        const label = stack.querySelector('.casino-chip-payout');
+        expect(label).not.toBeNull();
+        expect(label.textContent).toBe('+100');
+    });
+
+    test('prefers jackpotPayout over net when jackpotPayout > 0', () => {
+        window.CasinoRender.flashWinPayout(seatEl, {
+            win: true, net: 100, jackpotPayout: 999,
+        });
+        const label = seatEl.querySelector('.casino-chip-payout');
+        expect(label.textContent).toBe('+999');
+    });
+
+    test('falls back to net when jackpotPayout is zero or missing', () => {
+        window.CasinoRender.flashWinPayout(seatEl, {
+            win: true, net: 250, jackpotPayout: 0,
+        });
+        const label = seatEl.querySelector('.casino-chip-payout');
+        expect(label.textContent).toBe('+250');
+    });
+
+    test('replaces a prior chip stack instead of stacking duplicates', () => {
+        // Two consecutive wins on the same seat (e.g. two hands in a row)
+        // should not leave a ghost stack from the previous round.
+        window.CasinoRender.flashWinPayout(seatEl, { win: true, net: 100 });
+        window.CasinoRender.flashWinPayout(seatEl, { win: true, net: 200 });
+        const stacks = seatEl.querySelectorAll('.casino-chip-stack');
+        expect(stacks.length).toBe(1);
+        expect(stacks[0].querySelector('.casino-chip-payout').textContent).toBe('+200');
+    });
+});

--- a/web/src/test/js/coinflip.test.js
+++ b/web/src/test/js/coinflip.test.js
@@ -1,13 +1,16 @@
 const { renderCoinflipResult } = require('../../main/resources/static/js/coinflip');
 require('../../main/resources/static/js/casino-jackpot');
 require('../../main/resources/static/js/casino-result');
+require('../../main/resources/static/js/casino-render');
 
 describe('renderCoinflipResult', () => {
     let resultEl;
+    let tableEl;
 
     beforeEach(() => {
-        document.body.innerHTML = '<div id="r"></div>';
+        document.body.innerHTML = '<div id="r"></div><section id="t"></section>';
         resultEl = document.getElementById('r');
+        tableEl = document.getElementById('t');
     });
 
     test('renders a win line with HEADS/TAILS labels and net', () => {
@@ -50,5 +53,20 @@ describe('renderCoinflipResult', () => {
         });
 
         expect(resultEl.innerHTML).toContain('+5 to jackpot');
+    });
+
+    test('win flashes a chip stack on the table; loss leaves it untouched', () => {
+        renderCoinflipResult(resultEl, {
+            win: true, landed: 'HEADS', predicted: 'HEADS', net: 100,
+        }, tableEl);
+        const stack = tableEl.querySelector('.casino-chip-stack');
+        expect(stack).not.toBeNull();
+        expect(stack.querySelector('.casino-chip-payout').textContent).toBe('+100');
+
+        tableEl.querySelectorAll('.casino-chip-stack').forEach((el) => el.remove());
+        renderCoinflipResult(resultEl, {
+            win: false, landed: 'TAILS', predicted: 'HEADS', net: -50,
+        }, tableEl);
+        expect(tableEl.querySelector('.casino-chip-stack')).toBeNull();
     });
 });

--- a/web/src/test/js/dice.test.js
+++ b/web/src/test/js/dice.test.js
@@ -1,13 +1,16 @@
 const { renderDiceResult } = require('../../main/resources/static/js/dice');
 require('../../main/resources/static/js/casino-jackpot');
 require('../../main/resources/static/js/casino-result');
+require('../../main/resources/static/js/casino-render');
 
 describe('renderDiceResult', () => {
     let resultEl;
+    let tableEl;
 
     beforeEach(() => {
-        document.body.innerHTML = '<div id="r"></div>';
+        document.body.innerHTML = '<div id="r"></div><section id="t"></section>';
         resultEl = document.getElementById('r');
+        tableEl = document.getElementById('t');
     });
 
     test('win shows landed and predicted face plus net', () => {
@@ -40,5 +43,16 @@ describe('renderDiceResult', () => {
         });
 
         expect(resultEl.innerHTML).toContain('+10 to jackpot');
+    });
+
+    test('win flashes a chip stack on the table; loss leaves it untouched', () => {
+        renderDiceResult(resultEl, { win: true, landed: 4, predicted: 4, net: 500 }, tableEl);
+        const stack = tableEl.querySelector('.casino-chip-stack');
+        expect(stack).not.toBeNull();
+        expect(stack.querySelector('.casino-chip-payout').textContent).toBe('+500');
+
+        tableEl.querySelectorAll('.casino-chip-stack').forEach((el) => el.remove());
+        renderDiceResult(resultEl, { win: false, landed: 2, predicted: 4, net: -100 }, tableEl);
+        expect(tableEl.querySelector('.casino-chip-stack')).toBeNull();
     });
 });

--- a/web/src/test/js/highlow.test.js
+++ b/web/src/test/js/highlow.test.js
@@ -5,6 +5,7 @@ const {
 } = require('../../main/resources/static/js/highlow');
 require('../../main/resources/static/js/casino-jackpot');
 require('../../main/resources/static/js/casino-result');
+require('../../main/resources/static/js/casino-render');
 
 describe('highlowCardLabel', () => {
     test('maps face cards to letters', () => {
@@ -38,10 +39,12 @@ describe('highlowFormatMultiplier', () => {
 
 describe('renderHighlowResult', () => {
     let resultEl;
+    let tableEl;
 
     beforeEach(() => {
-        document.body.innerHTML = '<div id="r"></div>';
+        document.body.innerHTML = '<div id="r"></div><section id="t"></section>';
         resultEl = document.getElementById('r');
+        tableEl = document.getElementById('t');
     });
 
     test('win on HIGHER renders next > anchor and shows the realised multiplier', () => {
@@ -82,5 +85,22 @@ describe('renderHighlowResult', () => {
         });
 
         expect(resultEl.innerHTML).toContain('+5 to jackpot');
+    });
+
+    test('positive net flashes a chip stack on the felt; tie/loss leaves it untouched', () => {
+        // Highlow has no `win` field on the response — net > 0 is the
+        // win signal, so the render fn synthesises it for the helper.
+        renderHighlowResult(resultEl, {
+            anchor: 5, next: 11, direction: 'HIGHER', net: 100, multiplier: 1.5,
+        }, tableEl);
+        const stack = tableEl.querySelector('.casino-chip-stack');
+        expect(stack).not.toBeNull();
+        expect(stack.querySelector('.casino-chip-payout').textContent).toBe('+100');
+
+        tableEl.querySelectorAll('.casino-chip-stack').forEach((el) => el.remove());
+        renderHighlowResult(resultEl, {
+            anchor: 7, next: 7, direction: 'HIGHER', net: -50,
+        }, tableEl);
+        expect(tableEl.querySelector('.casino-chip-stack')).toBeNull();
     });
 });

--- a/web/src/test/js/scratch.test.js
+++ b/web/src/test/js/scratch.test.js
@@ -1,15 +1,19 @@
 const { renderScratchResult } = require('../../main/resources/static/js/scratch');
 require('../../main/resources/static/js/casino-jackpot');
 require('../../main/resources/static/js/casino-result');
+require('../../main/resources/static/js/casino-render');
 
 describe('renderScratchResult', () => {
     let resultEl;
     let balanceEl;
+    let tableEl;
 
     beforeEach(() => {
-        document.body.innerHTML = '<div id="r"></div><span id="b">0</span>';
+        document.body.innerHTML =
+            '<div id="r"></div><span id="b">0</span><section id="t"></section>';
         resultEl = document.getElementById('r');
         balanceEl = document.getElementById('b');
+        tableEl = document.getElementById('t');
     });
 
     test('win shows match count, winning symbol, and net', () => {
@@ -57,5 +61,22 @@ describe('renderScratchResult', () => {
         }, 5, balanceEl);
 
         expect(resultEl.innerHTML).toContain('+10 to jackpot');
+    });
+
+    test('positive net flashes a chip stack on the felt; loss leaves it untouched', () => {
+        // Scratch's response has no `win` field — net > 0 is the win
+        // signal, so the render fn synthesises it for the helper.
+        renderScratchResult(resultEl, {
+            matchCount: 5, winningSymbol: '⭐', net: 200, newBalance: 1_200,
+        }, 5, balanceEl, tableEl);
+        const stack = tableEl.querySelector('.casino-chip-stack');
+        expect(stack).not.toBeNull();
+        expect(stack.querySelector('.casino-chip-payout').textContent).toBe('+200');
+
+        tableEl.querySelectorAll('.casino-chip-stack').forEach((el) => el.remove());
+        renderScratchResult(resultEl, {
+            net: -100, newBalance: 950,
+        }, 5, balanceEl, tableEl);
+        expect(tableEl.querySelector('.casino-chip-stack')).toBeNull();
     });
 });

--- a/web/src/test/js/slots.test.js
+++ b/web/src/test/js/slots.test.js
@@ -5,13 +5,24 @@
 const { renderSlotsResult } = require('../../main/resources/static/js/slots');
 require('../../main/resources/static/js/casino-jackpot');
 require('../../main/resources/static/js/casino-result');
+require('../../main/resources/static/js/casino-render');
 
 describe('renderSlotsResult', () => {
     let resultEl;
+    let machineEl;
+    let reels;
 
     beforeEach(() => {
-        document.body.innerHTML = '<div id="r"></div>';
+        document.body.innerHTML =
+            '<div id="r"></div>' +
+            '<section id="m">' +
+            '  <div class="slots-reel" id="r0"></div>' +
+            '  <div class="slots-reel" id="r1"></div>' +
+            '  <div class="slots-reel" id="r2"></div>' +
+            '</section>';
         resultEl = document.getElementById('r');
+        machineEl = document.getElementById('m');
+        reels = ['r0', 'r1', 'r2'].map((id) => document.getElementById(id));
     });
 
     test('renders a win line with the multiplier and net', () => {
@@ -74,5 +85,27 @@ describe('renderSlotsResult', () => {
         renderSlotsResult(resultEl, { win: false, net: -100, symbols: [] });
 
         expect(resultEl.innerHTML).not.toContain('to jackpot');
+    });
+
+    test('win lights up every reel with .win-cell and drops a chip stack on the machine', () => {
+        renderSlotsResult(resultEl, {
+            win: true, multiplier: 5, net: 400, symbols: ['🍒', '🍒', '🍒']
+        }, machineEl, reels);
+
+        reels.forEach((r) => expect(r.classList.contains('win-cell')).toBe(true));
+        const stack = machineEl.querySelector('.casino-chip-stack');
+        expect(stack).not.toBeNull();
+        expect(stack.querySelector('.casino-chip-payout').textContent).toBe('+400');
+    });
+
+    test('lose strips any prior .win-cell highlight and leaves the machine clean', () => {
+        // Pretend the previous spin won — the new lose render should clear it.
+        reels.forEach((r) => r.classList.add('win-cell'));
+        renderSlotsResult(resultEl, {
+            win: false, net: -100, symbols: ['🍒', '🍋', '⭐']
+        }, machineEl, reels);
+
+        reels.forEach((r) => expect(r.classList.contains('win-cell')).toBe(false));
+        expect(machineEl.querySelector('.casino-chip-stack')).toBeNull();
     });
 });


### PR DESCRIPTION
## Summary

Brings every casino minigame's web UI up to the same visual language blackjack/poker have — green felt, gold-halo selected tiles, `casino-card-glyph` faces, chip-stack + sound flourish on wins, gold-pulse on winning cells. Affected pages: **baccarat, high-low, dice, slots, coinflip, scratch**. Blackjack & poker are unchanged but now drive their gold tone through the same shared CSS variables, so any future colour tweak lands everywhere at once.

Also: **baccarat was visible in the Casino navbar dropdown but missing from `/casino/guilds`** (the page the dropdown links to). Added the `/casino/{id}/baccarat` tile next to the other games.

### Centralisation (so future games adopt the polish for free)

- Hoisted the recurring "gold ring + soft halo" and "white card face" recipes into CSS custom properties in `casino-table.css`:
  - `--casino-gold`, `--casino-active-glow`, `--casino-active-tile-bg`
  - `--casino-card-bg`, `--casino-card-border`, `--casino-card-shadow`
- New `.casino-card-face` utility class for any card-shaped surface (dice die, slots reel) — replaces duplicated white-gradient / shadow CSS in `dice.css` and `slots.css`; applied via HTML class.
- New `CasinoRender.flashWinPayout(seatEl, body)` wrapper picks the right payout (jackpotPayout > net) and no-ops on losses, so each game's win flourish is one line instead of a 5-line guarded block.
- Per-game CSS now `@import url("./casino-table.css")` everywhere (was only blackjack/baccarat); the felt, card glyph, and pulse keyframe come from one place.
- Recipe block at the top of `casino-table.css` documents how a future game adopts the kit: which HTML classes to add, which CSS vars to reference, which JS calls to make.

### What each game gained

- **Baccarat** — gold-ring on the selected side picker (was Discord-blue); chip flourish + win/lose sound on resolve.
- **High-Low** — anchor/next now render as `.casino-card-glyph` on a felt panel; direction buttons gain the gold halo on hover/focus; chip flourish on win; deal-in animation when each card lands.
- **Dice** — felt wrapper; die uses `.casino-card-face`; gold-halo on the selected number; chip flourish on win.
- **Slots** — felt wrapper; reels use `.casino-card-face`; per-reel staggered tumble; winning reels light up with the gold halo; chip flourish scaled to payout size.
- **Coinflip** — felt wrapper; gold-halo on the selected side; chip flourish on win.
- **Scratch** — felt wrapper; winning cells pulse the shared `casino-pulse` keyframe; chip flourish on payout.

## Test plan

- [x] All 19 jest suites pass (`npm test` → 225 tests, 0 failures).
- [ ] Visit each page (`/casino/{id}/{baccarat,highlow,dice,slots,coinflip,scratch}`) and confirm:
  - [ ] Page renders on green felt with the same border-radius/shadow as blackjack & poker.
  - [ ] Selected/active tile shows the gold ring + halo.
  - [ ] On a win, a chip stack pops and `+N` floats up; the sound toggle (bottom-right) silences subsequent cues.
  - [ ] On a loss, the result line fades in muted with no chip animation.
- [ ] `prefers-reduced-motion: reduce` disables the new animations (confirmed via existing global rule).
- [ ] Mobile widths (375px, 320px) still fit each game's hero element on screen.
- [ ] `/casino/guilds` now lists Baccarat alongside the other games.

https://claude.ai/code/session_01KToQred514qQMSvQgzG8Yk

---
_Generated by [Claude Code](https://claude.ai/code/session_01KToQred514qQMSvQgzG8Yk)_