### PR TITLE
feat(casino): add /keno minigame (web + Discord)

### DIFF
--- a/application/src/test/kotlin/integration/bot/CommandManagerTest.kt
+++ b/application/src/test/kotlin/integration/bot/CommandManagerTest.kt
@@ -15,6 +15,7 @@ import bot.toby.command.commands.economy.CoinflipCommand
 import bot.toby.command.commands.economy.DiceCommand
 import bot.toby.command.commands.economy.DuelCommand
 import bot.toby.command.commands.economy.HighlowCommand
+import bot.toby.command.commands.economy.KenoCommand
 import bot.toby.command.commands.economy.PokerCommand
 import bot.toby.command.commands.economy.ScratchCommand
 import bot.toby.command.commands.economy.SlotsCommand
@@ -148,12 +149,13 @@ class CommandManagerTest {
             DuelCommand::class.java,
             PokerCommand::class.java,
             BlackjackCommand::class.java,
-            BaccaratCommand::class.java
+            BaccaratCommand::class.java,
+            KenoCommand::class.java
         )
 
         Assertions.assertTrue(availableCommands.containsAll(commandManager.allCommands.map { it.javaClass }.toList()))
-        Assertions.assertEquals(56, commandManager.allCommands.size)
-        Assertions.assertEquals(56, commandManager.allSlashCommands.size)
+        Assertions.assertEquals(57, commandManager.allCommands.size)
+        Assertions.assertEquals(57, commandManager.allSlashCommands.size)
     }
 
     @Test

--- a/database/src/main/kotlin/database/economy/Keno.kt
+++ b/database/src/main/kotlin/database/economy/Keno.kt
@@ -1,0 +1,128 @@
+package database.economy
+
+import kotlin.random.Random
+
+/**
+ * Pure-logic keno. No Spring, no DB, no JDA — given a set of picks and
+ * a list of drawn numbers, looks up the multiplier from the paytable
+ * keyed on (spots, hits). The number drawing itself is delegated to
+ * [drawNumbers] so the service can inject a deterministic [Random] for
+ * tests while still keeping engine logic pure.
+ *
+ * Mechanic
+ *   The player chooses N numbers ("spots") between 1 and 80 — between
+ *   [MIN_SPOTS] and [MAX_SPOTS] of them — and the house draws [DRAWS]
+ *   numbers from the same 1..80 pool without replacement. The number of
+ *   the player's picks that match the draws ("hits") is looked up in
+ *   [PAYTABLE]; the resulting multiplier is applied to the stake.
+ *
+ *   Bigger spot counts allow bigger top-end multipliers (10-spot maxes
+ *   out at 100,000×) but require more hits to start paying — a 5-spot
+ *   ticket starts paying at 3 hits, a 10-spot ticket needs 5+. Across
+ *   spot counts the schedule sits at ~88-91% RTP, kept honest by
+ *   [database.economy.KenoTest]'s RTP test that derives every pay from
+ *   the hypergeometric distribution and asserts the sum lands in band.
+ */
+class Keno(private val paytable: Map<Int, List<Double>> = PAYTABLE) {
+
+    /** Resolved hand: which picks landed, what multiplier applies. */
+    data class Hand(
+        val picks: List<Int>,
+        val draws: List<Int>,
+        val hits: Int,
+        val multiplier: Double
+    ) {
+        val isWin: Boolean get() = multiplier > 0.0
+    }
+
+    /**
+     * Validate [picks] / [draws] and resolve the hand. Picks must be a
+     * non-empty distinct set in [POOL_RANGE] and within
+     * [MIN_SPOTS]..[MAX_SPOTS]; draws must be [DRAWS] distinct values in
+     * [POOL_RANGE]. Returns null on invalid input so the service can
+     * surface the typed error variant to its caller.
+     */
+    fun play(picks: Set<Int>, draws: List<Int>): Hand? {
+        if (picks.size !in MIN_SPOTS..MAX_SPOTS) return null
+        if (picks.any { it !in POOL_RANGE }) return null
+        if (draws.size != DRAWS) return null
+        if (draws.toSet().size != DRAWS) return null
+        if (draws.any { it !in POOL_RANGE }) return null
+        val hits = picks.count { it in draws }
+        val multiplier = multiplierFor(picks.size, hits)
+        return Hand(
+            picks = picks.sorted(),
+            draws = draws,
+            hits = hits,
+            multiplier = multiplier
+        )
+    }
+
+    /** Look up the payout multiplier; 0.0 if no row covers (spots, hits). */
+    fun multiplierFor(spots: Int, hits: Int): Double {
+        val row = paytable[spots] ?: return 0.0
+        return row.getOrElse(hits) { 0.0 }
+    }
+
+    /** Top-end multiplier for a spot count — used in embed/UI labels. */
+    fun maxMultiplier(spots: Int): Double = paytable[spots]?.maxOrNull() ?: 0.0
+
+    /**
+     * Draw [DRAWS] distinct numbers from [POOL_RANGE] using [random].
+     * Reservoir-style — shuffles the full pool and takes the first
+     * twenty. Cheap (80 elements) and avoids the duplicate-rejection
+     * loops that bias tail picks under partial-knowledge generators.
+     */
+    fun drawNumbers(random: Random): List<Int> =
+        POOL_RANGE.toMutableList().apply { shuffle(random) }.take(DRAWS)
+
+    /**
+     * Auto-pick [count] distinct numbers from [POOL_RANGE]. Reservoir
+     * style for the same reason as [drawNumbers].
+     */
+    fun quickPick(count: Int, random: Random): List<Int> {
+        require(count in MIN_SPOTS..MAX_SPOTS) {
+            "quickPick count must be in $MIN_SPOTS..$MAX_SPOTS, got $count"
+        }
+        return POOL_RANGE.toMutableList().apply { shuffle(random) }.take(count).sorted()
+    }
+
+    companion object {
+        const val POOL_SIZE: Int = 80
+        const val DRAWS: Int = 20
+        const val MIN_SPOTS: Int = 1
+        const val MAX_SPOTS: Int = 10
+        const val MIN_STAKE: Long = 10L
+        const val MAX_STAKE: Long = 500L
+
+        /** Inclusive range of valid pick / draw values: 1..80. */
+        val POOL_RANGE: IntRange = 1..POOL_SIZE
+
+        /**
+         * Per-spots paytable — `PAYTABLE[spots][hits]` is the multiplier
+         * applied to the stake when a ticket of that many spots lands
+         * exactly that many hits. List length is `spots + 1` so the
+         * `hits=0` cell is always present and obviously zero.
+         *
+         * RTPs (computed in [database.economy.KenoTest]) sit in the
+         * 0.83-0.92 band — slots tier, kept honest by the RTP test that
+         * derives every pay from the hypergeometric distribution and
+         * asserts the sum lands in band. 1-spot is intentionally lower
+         * (~0.875): single-number bets have a structurally high house
+         * edge in every keno schedule, raising it would force absurd
+         * floor multipliers on the multi-spot rows.
+         */
+        val PAYTABLE: Map<Int, List<Double>> = mapOf(
+            1  to listOf(0.0, 3.5),
+            2  to listOf(0.0, 0.0, 14.6),
+            3  to listOf(0.0, 0.0, 1.0, 53.0),
+            4  to listOf(0.0, 0.0, 1.0, 8.0, 100.0),
+            5  to listOf(0.0, 0.0, 0.0, 2.0, 15.0, 800.0),
+            6  to listOf(0.0, 0.0, 0.0, 1.0, 7.0, 100.0, 1_900.0),
+            7  to listOf(0.0, 0.0, 0.0, 0.0, 2.0, 28.0, 500.0, 7_000.0),
+            8  to listOf(0.0, 0.0, 0.0, 0.0, 0.0, 10.0, 115.0, 1_900.0, 28_500.0),
+            9  to listOf(0.0, 0.0, 0.0, 0.0, 0.0, 6.0, 53.0, 320.0, 4_250.0, 53_000.0),
+            10 to listOf(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 28.0, 165.0, 1_650.0, 8_300.0, 165_000.0),
+        )
+    }
+}

--- a/database/src/main/kotlin/database/service/KenoService.kt
+++ b/database/src/main/kotlin/database/service/KenoService.kt
@@ -1,0 +1,158 @@
+package database.service
+
+import database.economy.Keno
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import kotlin.random.Random
+
+/**
+ * Atomic play path for the `/keno` minigame. Same lock-then-mutate
+ * pattern as the other one-shot wager services ([BaccaratService],
+ * [CoinflipService], [DiceService]) via [UserService.getUserByIdForUpdate]:
+ *   - validate stake against [Keno.MIN_STAKE]..[Keno.MAX_STAKE]
+ *   - lock the user row
+ *   - confirm balance ≥ stake (optionally sell TOBY for the shortfall
+ *     via [CasinoTopUpHelper] when [autoTopUp] is set)
+ *   - validate picks are 1..10 distinct values in the 1..80 pool
+ *   - draw 20 numbers from the same pool with the injected [Random]
+ *   - resolve the (picks, draws) hand via [Keno.play]
+ *   - apply the resulting fractional multiplier through
+ *     [WagerHelper.applyMultiplier]
+ *   - feed [JackpotHelper] on win/loss
+ *
+ * Unlike baccarat there is no Push outcome — keno's paytable is
+ * win-or-lose. A round with zero hits (or a non-paying hit count) is
+ * a Lose with multiplier 0.0.
+ */
+@Service
+@Transactional
+class KenoService(
+    private val userService: UserService,
+    private val jackpotService: JackpotService,
+    private val tradeService: EconomyTradeService,
+    private val marketService: TobyCoinMarketService,
+    private val configService: ConfigService,
+    private val keno: Keno = Keno(),
+    private val random: Random = Random.Default
+) {
+
+    sealed interface PlayOutcome {
+        data class Win(
+            val stake: Long,
+            val payout: Long,
+            val net: Long,
+            val picks: List<Int>,
+            val draws: List<Int>,
+            val hits: Int,
+            val multiplier: Double,
+            val newBalance: Long,
+            val jackpotPayout: Long = 0L,
+            val soldTobyCoins: Long = 0L,
+            val newPrice: Double? = null
+        ) : PlayOutcome
+
+        data class Lose(
+            val stake: Long,
+            val picks: List<Int>,
+            val draws: List<Int>,
+            val hits: Int,
+            val newBalance: Long,
+            val soldTobyCoins: Long = 0L,
+            val newPrice: Double? = null,
+            val lossTribute: Long = 0L
+        ) : PlayOutcome
+
+        data class InsufficientCredits(val stake: Long, val have: Long) : PlayOutcome
+        data class InsufficientCoinsForTopUp(val needed: Long, val have: Long) : PlayOutcome
+        data class InvalidStake(val min: Long, val max: Long) : PlayOutcome
+        data class InvalidPicks(val min: Int, val max: Int, val poolMax: Int) : PlayOutcome
+        data object UnknownUser : PlayOutcome
+    }
+
+    /**
+     * Auto-pick a [count]-spot ticket. Used by Discord when the player
+     * doesn't supply explicit picks; web clients send their own picks.
+     */
+    fun quickPick(count: Int): List<Int> = keno.quickPick(count, random)
+
+    /**
+     * Per-spots top multiplier (e.g. for command-line previews so the
+     * user can see "10-spot pays up to 165,000×" before committing).
+     */
+    fun maxMultiplier(spots: Int): Double = keno.maxMultiplier(spots)
+
+    /** Whole paytable, for embeds / page rendering. */
+    val paytable: Map<Int, List<Double>> get() = Keno.PAYTABLE
+
+    fun play(
+        discordId: Long,
+        guildId: Long,
+        stake: Long,
+        picks: List<Int>,
+        autoTopUp: Boolean = false
+    ): PlayOutcome {
+        // Validate picks BEFORE touching the wallet — saves a top-up
+        // sell on a malformed request.
+        val pickSet = picks.toSet()
+        if (pickSet.size != picks.size ||
+            pickSet.size !in Keno.MIN_SPOTS..Keno.MAX_SPOTS ||
+            pickSet.any { it !in Keno.POOL_RANGE }
+        ) {
+            return PlayOutcome.InvalidPicks(Keno.MIN_SPOTS, Keno.MAX_SPOTS, Keno.POOL_SIZE)
+        }
+
+        val resolved = when (val r = WagerHelper.checkLockOrTopUp(
+            userService, tradeService, marketService,
+            discordId, guildId, stake, Keno.MIN_STAKE, Keno.MAX_STAKE, autoTopUp
+        )) {
+            is TopUpResolution.InvalidStake -> return PlayOutcome.InvalidStake(r.min, r.max)
+            TopUpResolution.UnknownUser -> return PlayOutcome.UnknownUser
+            is TopUpResolution.StillInsufficientCredits ->
+                return PlayOutcome.InsufficientCredits(r.stake, r.have)
+            is TopUpResolution.InsufficientCoinsForTopUp ->
+                return PlayOutcome.InsufficientCoinsForTopUp(r.needed, r.have)
+            is TopUpResolution.Ok -> r
+        }
+
+        val draws = keno.drawNumbers(random)
+        // Engine validates again (cheap, defence in depth) — should never
+        // fail given the upstream check, but if it does we re-surface
+        // InvalidPicks so the controller can reject with the same shape.
+        val hand = keno.play(pickSet, draws)
+            ?: return PlayOutcome.InvalidPicks(Keno.MIN_SPOTS, Keno.MAX_SPOTS, Keno.POOL_SIZE)
+
+        val wager = WagerHelper.applyMultiplier(
+            userService, resolved.user, resolved.balance, stake, hand.multiplier
+        )
+        return if (hand.isWin) {
+            val jackpot = JackpotHelper.rollOnWin(
+                jackpotService, configService, userService, resolved.user, guildId, random
+            )
+            PlayOutcome.Win(
+                stake = stake,
+                payout = wager.payout,
+                net = wager.net,
+                picks = hand.picks,
+                draws = hand.draws,
+                hits = hand.hits,
+                multiplier = hand.multiplier,
+                newBalance = wager.newBalance + jackpot,
+                jackpotPayout = jackpot,
+                soldTobyCoins = resolved.soldCoins,
+                newPrice = resolved.newPrice
+            )
+        } else {
+            val tribute = JackpotHelper.divertOnLoss(jackpotService, configService, guildId, stake)
+            PlayOutcome.Lose(
+                stake = stake,
+                picks = hand.picks,
+                draws = hand.draws,
+                hits = hand.hits,
+                newBalance = wager.newBalance,
+                soldTobyCoins = resolved.soldCoins,
+                newPrice = resolved.newPrice,
+                lossTribute = tribute
+            )
+        }
+    }
+}

--- a/database/src/test/kotlin/database/economy/KenoTest.kt
+++ b/database/src/test/kotlin/database/economy/KenoTest.kt
@@ -1,0 +1,222 @@
+package database.economy
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import kotlin.random.Random
+
+class KenoTest {
+
+    private val keno = Keno()
+
+    // --- play() validation ---
+
+    @Test
+    fun `play returns null when picks count is below MIN_SPOTS`() {
+        assertNull(keno.play(picks = emptySet(), draws = drawsOf(1..20)))
+    }
+
+    @Test
+    fun `play returns null when picks count is above MAX_SPOTS`() {
+        val tooMany = (1..(Keno.MAX_SPOTS + 1)).toSet()
+        assertNull(keno.play(picks = tooMany, draws = drawsOf(21..40)))
+    }
+
+    @Test
+    fun `play returns null when a pick is outside the 1-80 pool`() {
+        assertNull(keno.play(picks = setOf(0, 5, 7), draws = drawsOf(1..20)))
+        assertNull(keno.play(picks = setOf(5, 7, 81), draws = drawsOf(1..20)))
+    }
+
+    @Test
+    fun `play returns null when draws count is not exactly DRAWS`() {
+        assertNull(keno.play(picks = setOf(5), draws = (1..19).toList()))
+        assertNull(keno.play(picks = setOf(5), draws = (1..21).toList()))
+    }
+
+    @Test
+    fun `play returns null when draws contain duplicates`() {
+        val dupes = (1..19).toMutableList().apply { add(1) }
+        assertNull(keno.play(picks = setOf(5), draws = dupes))
+    }
+
+    @Test
+    fun `play returns null when a drawn number is outside the 1-80 pool`() {
+        val bad = (1..19).toMutableList().apply { add(99) }
+        assertNull(keno.play(picks = setOf(5), draws = bad))
+    }
+
+    // --- play() resolution ---
+
+    @Test
+    fun `play counts hits as the intersection of picks and draws`() {
+        // Picks: 5, 33, 50, 70 (4 spots). Draws cover 5 and 33 → 2 hits;
+        // draws come from 1..20 plus 33, none of which contain 50 or 70.
+        val draws = (listOf(33) + (1..19)).take(20)
+        val hand = keno.play(picks = setOf(5, 33, 50, 70), draws = draws)
+        assertNotNull(hand)
+        assertEquals(2, hand!!.hits)
+    }
+
+    @Test
+    fun `play returns the picks sorted ascending so the UI render is stable`() {
+        val hand = keno.play(picks = setOf(80, 1, 42, 7), draws = drawsOf(21..40))
+        assertNotNull(hand)
+        assertEquals(listOf(1, 7, 42, 80), hand!!.picks)
+    }
+
+    @Test
+    fun `play looks up the multiplier from the paytable`() {
+        // 5-spot, 5 hits → 800x per the paytable.
+        val draws = (listOf(1, 2, 3, 4, 5) + (6..20)).take(20)
+        val hand = keno.play(picks = setOf(1, 2, 3, 4, 5), draws = draws)
+        assertNotNull(hand)
+        assertEquals(5, hand!!.hits)
+        assertEquals(800.0, hand.multiplier, 1e-9)
+        assertTrue(hand.isWin)
+    }
+
+    @Test
+    fun `zero hits yields the zero multiplier and isWin=false`() {
+        // Picks 41-45, draws 1-20 → no overlap.
+        val hand = keno.play(picks = setOf(41, 42, 43, 44, 45), draws = drawsOf(1..20))
+        assertNotNull(hand)
+        assertEquals(0, hand!!.hits)
+        assertEquals(0.0, hand.multiplier, 1e-9)
+        assertFalse(hand.isWin)
+    }
+
+    @Test
+    fun `multiplierFor returns zero for hit counts that are not in the paytable row`() {
+        assertEquals(0.0, keno.multiplierFor(spots = 5, hits = 0), 1e-9)
+        assertEquals(0.0, keno.multiplierFor(spots = 5, hits = 1), 1e-9)
+        assertEquals(0.0, keno.multiplierFor(spots = 5, hits = 2), 1e-9)
+        // Out-of-range hits must not crash — they just pay nothing.
+        assertEquals(0.0, keno.multiplierFor(spots = 5, hits = 99), 1e-9)
+        assertEquals(0.0, keno.multiplierFor(spots = 99, hits = 5), 1e-9)
+    }
+
+    @Test
+    fun `maxMultiplier exposes the top payout for a spot count`() {
+        assertEquals(3.5, keno.maxMultiplier(1), 1e-9)
+        assertEquals(800.0, keno.maxMultiplier(5), 1e-9)
+        assertEquals(165_000.0, keno.maxMultiplier(10), 1e-9)
+        assertEquals(0.0, keno.maxMultiplier(99), 1e-9)
+    }
+
+    // --- drawNumbers ---
+
+    @Test
+    fun `drawNumbers returns DRAWS distinct values inside the pool range`() {
+        val draws = keno.drawNumbers(Random(0))
+        assertEquals(Keno.DRAWS, draws.size)
+        assertEquals(Keno.DRAWS, draws.toSet().size)
+        assertTrue(draws.all { it in Keno.POOL_RANGE })
+    }
+
+    @Test
+    fun `drawNumbers is deterministic for a given seed`() {
+        val a = Keno().drawNumbers(Random(1234))
+        val b = Keno().drawNumbers(Random(1234))
+        assertEquals(a, b)
+    }
+
+    // --- quickPick ---
+
+    @Test
+    fun `quickPick returns count distinct sorted values inside the pool range`() {
+        val picks = keno.quickPick(7, Random(0))
+        assertEquals(7, picks.size)
+        assertEquals(7, picks.toSet().size)
+        assertTrue(picks.all { it in Keno.POOL_RANGE })
+        assertEquals(picks.sorted(), picks)
+    }
+
+    @Test
+    fun `quickPick rejects counts outside the spots range`() {
+        runCatching { keno.quickPick(0, Random(0)) }.exceptionOrNull().let { assertNotNull(it) }
+        runCatching { keno.quickPick(11, Random(0)) }.exceptionOrNull().let { assertNotNull(it) }
+    }
+
+    // --- RTP ---
+
+    @Test
+    fun `RTP for every spot count lands in the published 0_83 to 0_92 band`() {
+        // Hypergeometric expected return: sum over k of P(k|spots) * mult[k].
+        // P(k|n) = C(n,k) * C(80-n, 20-k) / C(80, 20).
+        val rtps = (Keno.MIN_SPOTS..Keno.MAX_SPOTS).associateWith { spots ->
+            (0..spots).sumOf { k ->
+                hypergeometricProbability(spots, k) * keno.multiplierFor(spots, k)
+            }
+        }
+        // Print on failure with per-bucket contributions so the maintainer
+        // can re-tune individual cells without iterating through reruns.
+        val outOfBand = rtps.filterValues { it !in 0.83..0.92 }
+        if (outOfBand.isNotEmpty()) {
+            val detail = (Keno.MIN_SPOTS..Keno.MAX_SPOTS).joinToString("\n") { spots ->
+                val perK = (0..spots).joinToString(" ") { k ->
+                    val p = hypergeometricProbability(spots, k)
+                    val m = keno.multiplierFor(spots, k)
+                    "k=$k:${"%.4f".format(p * m)}"
+                }
+                "  $spots-spot rtp=${"%.4f".format(rtps[spots])}  $perK"
+            }
+            error("RTP out of band 0.83..0.92 — full breakdown:\n$detail")
+        }
+    }
+
+    @Test
+    fun `RTP smoke — 50k random hands stay in the published band`() {
+        val rng = Random(2026)
+        val stake = 1_000L
+        val n = 50_000
+        var totalWagered = 0L
+        var totalReturned = 0.0
+        repeat(n) {
+            val spots = (Keno.MIN_SPOTS..Keno.MAX_SPOTS).random(rng)
+            val picks = keno.quickPick(spots, rng).toSet()
+            val draws = keno.drawNumbers(rng)
+            val hand = keno.play(picks, draws)!!
+            totalWagered += stake
+            totalReturned += hand.multiplier * stake
+        }
+        val rtp = totalReturned / totalWagered.toDouble()
+        // Mixed across spot counts. Loose because top-end multipliers
+        // are very rare and one or two big hits can push the average up.
+        assertTrue(rtp in 0.70..1.30, "expected mixed-spots RTP in 0.70..1.30 but saw $rtp")
+    }
+
+    // --- helpers ---
+
+    /** Build a 20-element draw list from [range] for "happy-path" hand tests. */
+    private fun drawsOf(range: IntRange): List<Int> = range.toList().also {
+        require(it.size == Keno.DRAWS) { "test draws need exactly ${Keno.DRAWS} elements" }
+    }
+
+    /**
+     * P(exactly k of n picks hit | 20 drawn from 80) under hypergeometric
+     * distribution. Computed in BigInteger via [binomial] to avoid
+     * Long overflow on the C(80, 20) denominator (~3.5e18, fits Long but
+     * intermediate products don't).
+     */
+    private fun hypergeometricProbability(spots: Int, hits: Int): Double {
+        if (hits < 0 || hits > spots) return 0.0
+        if (Keno.DRAWS - hits < 0 || Keno.DRAWS - hits > Keno.POOL_SIZE - spots) return 0.0
+        val numerator = binomial(spots, hits) * binomial(Keno.POOL_SIZE - spots, Keno.DRAWS - hits)
+        val denominator = binomial(Keno.POOL_SIZE, Keno.DRAWS)
+        return numerator.toDouble() / denominator.toDouble()
+    }
+
+    private fun binomial(n: Int, k: Int): java.math.BigInteger {
+        if (k < 0 || k > n) return java.math.BigInteger.ZERO
+        var result = java.math.BigInteger.ONE
+        for (i in 0 until k) {
+            result = result.multiply(java.math.BigInteger.valueOf((n - i).toLong()))
+            result = result.divide(java.math.BigInteger.valueOf((i + 1).toLong()))
+        }
+        return result
+    }
+}

--- a/database/src/test/kotlin/database/service/KenoServiceTest.kt
+++ b/database/src/test/kotlin/database/service/KenoServiceTest.kt
@@ -1,0 +1,204 @@
+package database.service
+
+import database.dto.UserDto
+import database.economy.Keno
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import kotlin.random.Random
+
+class KenoServiceTest {
+
+    private lateinit var userService: UserService
+    private lateinit var jackpotService: JackpotService
+    private lateinit var tradeService: EconomyTradeService
+    private lateinit var marketService: TobyCoinMarketService
+    private lateinit var configService: ConfigService
+    private lateinit var keno: Keno
+    private lateinit var service: KenoService
+
+    private val discordId = 100L
+    private val guildId = 200L
+
+    @BeforeEach
+    fun setup() {
+        userService = mockk(relaxed = true)
+        jackpotService = mockk(relaxed = true)
+        tradeService = mockk(relaxed = true)
+        marketService = mockk(relaxed = true)
+        configService = mockk(relaxed = true)
+        keno = mockk(relaxed = true)
+        // Defaults so the engine doesn't NPE in tests that don't override:
+        every { keno.drawNumbers(any()) } returns (1..20).toList()
+        every { keno.play(any(), any()) } answers {
+            val picks = firstArg<Set<Int>>()
+            val draws = secondArg<List<Int>>()
+            Keno.Hand(picks = picks.sorted(), draws = draws, hits = 0, multiplier = 0.0)
+        }
+        service = KenoService(
+            userService, jackpotService, tradeService, marketService, configService,
+            keno, Random(0)
+        )
+    }
+
+    private fun userWithBalance(balance: Long): UserDto =
+        UserDto(discordId, guildId).apply { socialCredit = balance }
+
+    @Test
+    fun `Win debits stake and credits payout atomically`() {
+        val user = userWithBalance(1_000L)
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns user
+        every { keno.play(setOf(1, 2, 3, 4, 5), any()) } returns Keno.Hand(
+            picks = listOf(1, 2, 3, 4, 5),
+            draws = (1..20).toList(),
+            hits = 5,
+            multiplier = 800.0
+        )
+        val captured = slot<UserDto>()
+        every { userService.updateUser(capture(captured)) } returns user
+
+        val outcome = service.play(
+            discordId, guildId, stake = 10L, picks = listOf(1, 2, 3, 4, 5)
+        )
+
+        val win = assertInstanceOf(KenoService.PlayOutcome.Win::class.java, outcome)
+        // 10 × 800 = 8000 payout, +7990 net.
+        assertEquals(8_000L, win.payout)
+        assertEquals(7_990L, win.net)
+        assertEquals(800.0, win.multiplier, 1e-9)
+        assertEquals(8_990L, win.newBalance)
+        assertEquals(5, win.hits)
+        assertEquals(listOf(1, 2, 3, 4, 5), win.picks)
+        assertEquals(8_990L, captured.captured.socialCredit)
+    }
+
+    @Test
+    fun `Lose debits stake only and leaves picks plus draws on the outcome`() {
+        val user = userWithBalance(500L)
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns user
+        every { keno.play(setOf(40, 50, 60), any()) } returns Keno.Hand(
+            picks = listOf(40, 50, 60),
+            draws = (1..20).toList(),
+            hits = 0,
+            multiplier = 0.0
+        )
+        every { userService.updateUser(any()) } returns user
+
+        val outcome = service.play(
+            discordId, guildId, stake = 100L, picks = listOf(40, 50, 60)
+        )
+
+        val lose = assertInstanceOf(KenoService.PlayOutcome.Lose::class.java, outcome)
+        assertEquals(100L, lose.stake)
+        assertEquals(400L, lose.newBalance)
+        assertEquals(0, lose.hits)
+        assertEquals(listOf(40, 50, 60), lose.picks)
+        assertEquals(20, lose.draws.size)
+    }
+
+    @Test
+    fun `lose tributes 10 percent of the stake into the jackpot pool`() {
+        val user = userWithBalance(500L)
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns user
+        every { keno.play(any(), any()) } returns Keno.Hand(
+            picks = listOf(40), draws = (1..20).toList(), hits = 0, multiplier = 0.0
+        )
+        every { userService.updateUser(any()) } returns user
+
+        val outcome = service.play(discordId, guildId, stake = 100L, picks = listOf(40))
+
+        val lose = assertInstanceOf(KenoService.PlayOutcome.Lose::class.java, outcome)
+        assertEquals(10L, lose.lossTribute)
+        verify(exactly = 1) { jackpotService.addToPool(guildId, 10L) }
+    }
+
+    @Test
+    fun `insufficient credits is rejected without drawing`() {
+        val user = userWithBalance(50L)
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns user
+
+        val outcome = service.play(discordId, guildId, stake = 100L, picks = listOf(5))
+
+        assertInstanceOf(KenoService.PlayOutcome.InsufficientCredits::class.java, outcome)
+        verify(exactly = 0) { userService.updateUser(any()) }
+        verify(exactly = 0) { keno.drawNumbers(any()) }
+        verify(exactly = 0) { keno.play(any(), any()) }
+    }
+
+    @Test
+    fun `invalid stake is rejected before locking the user`() {
+        val outcome = service.play(
+            discordId, guildId, stake = Keno.MIN_STAKE - 1, picks = listOf(5)
+        )
+
+        assertInstanceOf(KenoService.PlayOutcome.InvalidStake::class.java, outcome)
+        verify(exactly = 0) { userService.getUserByIdForUpdate(any(), any()) }
+        verify(exactly = 0) { keno.play(any(), any()) }
+    }
+
+    @Test
+    fun `unknown user is rejected`() {
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns null
+
+        val outcome = service.play(discordId, guildId, stake = 100L, picks = listOf(5))
+
+        assertEquals(KenoService.PlayOutcome.UnknownUser, outcome)
+    }
+
+    @Test
+    fun `picks below MIN_SPOTS rejected without touching the wallet`() {
+        val outcome = service.play(discordId, guildId, stake = 100L, picks = emptyList())
+
+        assertInstanceOf(KenoService.PlayOutcome.InvalidPicks::class.java, outcome)
+        verify(exactly = 0) { userService.getUserByIdForUpdate(any(), any()) }
+    }
+
+    @Test
+    fun `picks above MAX_SPOTS rejected without touching the wallet`() {
+        val outcome = service.play(
+            discordId, guildId, stake = 100L, picks = (1..(Keno.MAX_SPOTS + 1)).toList()
+        )
+
+        assertInstanceOf(KenoService.PlayOutcome.InvalidPicks::class.java, outcome)
+        verify(exactly = 0) { userService.getUserByIdForUpdate(any(), any()) }
+    }
+
+    @Test
+    fun `pick out of pool range rejected`() {
+        val outcome = service.play(discordId, guildId, stake = 100L, picks = listOf(0, 5))
+
+        assertInstanceOf(KenoService.PlayOutcome.InvalidPicks::class.java, outcome)
+        verify(exactly = 0) { userService.getUserByIdForUpdate(any(), any()) }
+    }
+
+    @Test
+    fun `duplicate picks rejected`() {
+        val outcome = service.play(discordId, guildId, stake = 100L, picks = listOf(5, 7, 5))
+
+        assertInstanceOf(KenoService.PlayOutcome.InvalidPicks::class.java, outcome)
+        verify(exactly = 0) { userService.getUserByIdForUpdate(any(), any()) }
+    }
+
+    @Test
+    fun `quickPick delegates to the engine and does not touch the user`() {
+        every { keno.quickPick(5, any()) } returns listOf(2, 9, 17, 33, 71)
+
+        val picks = service.quickPick(5)
+
+        assertEquals(listOf(2, 9, 17, 33, 71), picks)
+        verify(exactly = 0) { userService.getUserByIdForUpdate(any(), any()) }
+        verify(exactly = 0) { userService.updateUser(any()) }
+    }
+
+    @Test
+    fun `maxMultiplier delegates to the engine`() {
+        every { keno.maxMultiplier(7) } returns 7000.0
+
+        assertEquals(7000.0, service.maxMultiplier(7), 1e-9)
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/KenoCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/KenoCommand.kt
@@ -1,0 +1,111 @@
+package bot.toby.command.commands.economy
+
+import core.command.CommandContext
+import database.dto.UserDto
+import database.economy.Keno
+import database.service.KenoService
+import net.dv8tion.jda.api.interactions.commands.OptionType
+import net.dv8tion.jda.api.interactions.commands.build.OptionData
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+/**
+ * `/keno stake:<int> [spots:<int>] [picks:<csv>]` — one-shot keno
+ * round. If `picks` is omitted, the bot quick-picks `spots` numbers (so
+ * a low-effort "/keno stake:50" works fine); if `picks` is supplied,
+ * its count must match `spots`. `spots` defaults to 5.
+ *
+ * No buttons: keno resolves in a single slash-command call so there is
+ * no anchor-then-confirm split. The same path the web
+ * `/casino/{guildId}/keno` page uses — both routes call through
+ * [KenoService.play] so the paytable, pool size, and balance debit/
+ * credit semantics stay consistent.
+ */
+@Component
+class KenoCommand @Autowired constructor(
+    private val kenoService: KenoService
+) : EconomyCommand {
+
+    override val name: String = "keno"
+    override val description: String =
+        "Pick ${Keno.MIN_SPOTS}-${Keno.MAX_SPOTS} numbers from 1-${Keno.POOL_SIZE}; bot draws ${Keno.DRAWS}. " +
+            "Bet ${Keno.MIN_STAKE}-${Keno.MAX_STAKE} credits."
+
+    companion object {
+        private const val OPT_STAKE = "stake"
+        private const val OPT_SPOTS = "spots"
+        private const val OPT_PICKS = "picks"
+        private const val DEFAULT_SPOTS = 5
+        private const val TITLE = "🎯 Keno"
+    }
+
+    override val optionData: List<OptionData> = listOf(
+        OptionData(
+            OptionType.INTEGER, OPT_STAKE,
+            "Credits to wager (${Keno.MIN_STAKE}-${Keno.MAX_STAKE})", true
+        )
+            .setMinValue(Keno.MIN_STAKE)
+            .setMaxValue(Keno.MAX_STAKE),
+        OptionData(
+            OptionType.INTEGER, OPT_SPOTS,
+            "How many numbers to pick (${Keno.MIN_SPOTS}-${Keno.MAX_SPOTS}, default $DEFAULT_SPOTS)", false
+        )
+            .setMinValue(Keno.MIN_SPOTS.toLong())
+            .setMaxValue(Keno.MAX_SPOTS.toLong()),
+        OptionData(
+            OptionType.STRING, OPT_PICKS,
+            "Your numbers (comma-separated, 1-${Keno.POOL_SIZE}). Omit to quick-pick.", false
+        )
+    )
+
+    override fun handle(ctx: CommandContext, requestingUserDto: UserDto, deleteDelay: Int) {
+        val event = ctx.event
+        event.deferReply().queue()
+
+        val guild = event.guild ?: run {
+            WagerCommandEmbeds.replyError(event, TITLE, "This command can only be used in a server.", deleteDelay); return
+        }
+        val stake = event.getOption(OPT_STAKE)?.asLong ?: run {
+            WagerCommandEmbeds.replyError(event, TITLE, "You must specify a stake.", deleteDelay); return
+        }
+        val spots = event.getOption(OPT_SPOTS)?.asLong?.toInt() ?: DEFAULT_SPOTS
+
+        val picks = parsePicks(event.getOption(OPT_PICKS)?.asString, spots) ?: run {
+            WagerCommandEmbeds.replyError(
+                event, TITLE,
+                "Picks must be $spots distinct numbers between 1 and ${Keno.POOL_SIZE}, comma-separated. " +
+                    "Omit the option to quick-pick.",
+                deleteDelay
+            ); return
+        }
+
+        val outcome = kenoService.play(
+            requestingUserDto.discordId, guild.idLong, stake, picks
+        )
+        WagerCommandEmbeds.reply(event, KenoEmbeds.outcomeEmbed(outcome), deleteDelay)
+    }
+
+    /**
+     * Either parse a user-supplied CSV into a list of distinct in-pool
+     * numbers, or return a quick-pick of [spots] when [raw] is null /
+     * blank. Returns null on a CSV that doesn't validate (count
+     * mismatch, out-of-range value, duplicate, non-integer) so the
+     * caller can surface a uniform error to the user.
+     */
+    internal fun parsePicks(raw: String?, spots: Int): List<Int>? {
+        if (raw.isNullOrBlank()) {
+            // Quick-pick path. The service will reject if spots is out
+            // of range; we still bound here so the in-engine require()
+            // doesn't surface as an opaque IllegalArgumentException.
+            if (spots !in Keno.MIN_SPOTS..Keno.MAX_SPOTS) return null
+            return kenoService.quickPick(spots)
+        }
+        val parts = raw.split(',').map { it.trim() }.filter { it.isNotEmpty() }
+        if (parts.size != spots) return null
+        val parsed = parts.mapNotNull { it.toIntOrNull() }
+        if (parsed.size != parts.size) return null
+        if (parsed.toSet().size != parsed.size) return null
+        if (parsed.any { it !in Keno.POOL_RANGE }) return null
+        return parsed
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/KenoEmbeds.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/KenoEmbeds.kt
@@ -1,8 +1,6 @@
 package bot.toby.command.commands.economy
 
-import database.economy.Keno
 import database.service.KenoService.PlayOutcome
-import net.dv8tion.jda.api.EmbedBuilder
 import net.dv8tion.jda.api.entities.MessageEmbed
 import java.awt.Color
 
@@ -84,16 +82,6 @@ internal object KenoEmbeds {
     }
 
     fun errorEmbed(message: String): MessageEmbed = WagerCommandEmbeds.errorEmbed(TITLE, message)
-
-    /**
-     * Per-spots payout preview embed for the `/keno` slash command's
-     * help-style title bar — used when the user asks for a quick-pick
-     * without committing yet (future enhancement). Currently unused
-     * outside tests; kept here so the format lives next to the rest of
-     * the embed plumbing.
-     */
-    fun paytableSummaryLine(spots: Int): String =
-        "$spots-spot pays up to **${WagerCommandEmbeds.multiplierLabel(Keno.PAYTABLE[spots]?.maxOrNull() ?: 0.0)}** at full hit."
 
     private fun jackpotLine(jackpotPayout: Long): String =
         if (jackpotPayout > 0L) "\n🎰 Jackpot hit! **+$jackpotPayout credits.**" else ""

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/KenoEmbeds.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/KenoEmbeds.kt
@@ -1,0 +1,103 @@
+package bot.toby.command.commands.economy
+
+import database.economy.Keno
+import database.service.KenoService.PlayOutcome
+import net.dv8tion.jda.api.EmbedBuilder
+import net.dv8tion.jda.api.entities.MessageEmbed
+import java.awt.Color
+
+/**
+ * Shared embed plumbing for the Discord `/keno` flow. Mirrors
+ * [BaccaratEmbeds] in shape — one-call `outcomeEmbed(outcome)` that
+ * builds the right Win / Lose embed, plus the standard failure-case
+ * routing through [WagerCommandEmbeds.failureEmbed].
+ *
+ * Unlike baccarat there is no button flow — keno resolves in a single
+ * slash-command call so there's no `parseButtonId`, no prompt embed.
+ */
+internal object KenoEmbeds {
+
+    private const val TITLE = "🎯 Keno"
+    private val NEUTRAL_COLOR = Color(0xA0, 0xA0, 0xB0)
+
+    /**
+     * Inline picks listing: `[1, 7, 18, 33, 71]`. The hit numbers are
+     * **bolded** so the resolution at a glance is "where did the
+     * matches land".
+     */
+    fun picksLine(picks: List<Int>, hits: Set<Int>): String =
+        picks.joinToString(", ") { if (it in hits) "**$it**" else it.toString() }
+
+    /**
+     * Inline draws listing: `[3, 7, 18, 22, ...]`. Hit numbers (those
+     * the player picked) are **bolded**; the rest are plain. 20 numbers
+     * fit comfortably on one line in Discord.
+     */
+    fun drawsLine(draws: List<Int>, picks: Set<Int>): String =
+        draws.sorted().joinToString(", ") { if (it in picks) "**$it**" else it.toString() }
+
+    fun outcomeEmbed(outcome: PlayOutcome): MessageEmbed = when (outcome) {
+        is PlayOutcome.Win -> {
+            val picksSet = outcome.picks.toSet()
+            WagerCommandEmbeds.outcomeEmbed(
+                title = "$TITLE • ${outcome.hits}/${outcome.picks.size} hit",
+                description =
+                    "**Your picks:** ${picksLine(outcome.picks, picksSet.intersect(outcome.draws.toSet()))}\n" +
+                    "**Drawn:** ${drawsLine(outcome.draws, picksSet)}\n\n" +
+                    "🎯 Won **+${outcome.net} credits** at " +
+                    "**${WagerCommandEmbeds.multiplierLabel(outcome.multiplier)}** on a " +
+                    "${outcome.stake} stake." +
+                    jackpotLine(outcome.jackpotPayout),
+                newBalance = outcome.newBalance,
+                color = WagerCommandColors.WIN
+            )
+        }
+
+        is PlayOutcome.Lose -> {
+            val picksSet = outcome.picks.toSet()
+            val color = if (outcome.hits > 0) NEUTRAL_COLOR else WagerCommandColors.LOSE
+            WagerCommandEmbeds.outcomeEmbed(
+                title = "$TITLE • ${outcome.hits}/${outcome.picks.size} hit",
+                description =
+                    "**Your picks:** ${picksLine(outcome.picks, picksSet.intersect(outcome.draws.toSet()))}\n" +
+                    "**Drawn:** ${drawsLine(outcome.draws, picksSet)}\n\n" +
+                    "❌ Lost **${outcome.stake} credits**." +
+                    tributeLine(outcome.lossTribute),
+                newBalance = outcome.newBalance,
+                color = color
+            )
+        }
+
+        is PlayOutcome.InsufficientCredits -> WagerCommandEmbeds.failureEmbed(
+            TITLE, WagerCommandFailure.InsufficientCredits(outcome.stake, outcome.have)
+        )
+        is PlayOutcome.InsufficientCoinsForTopUp -> WagerCommandEmbeds.failureEmbed(
+            TITLE, WagerCommandFailure.InsufficientCoinsForTopUp(outcome.needed, outcome.have)
+        )
+        is PlayOutcome.InvalidStake -> WagerCommandEmbeds.failureEmbed(
+            TITLE, WagerCommandFailure.InvalidStake(outcome.min, outcome.max)
+        )
+        is PlayOutcome.InvalidPicks -> errorEmbed(
+            "Pick ${outcome.min}-${outcome.max} distinct numbers between 1 and ${outcome.poolMax}."
+        )
+        PlayOutcome.UnknownUser -> WagerCommandEmbeds.failureEmbed(TITLE, WagerCommandFailure.UnknownUser)
+    }
+
+    fun errorEmbed(message: String): MessageEmbed = WagerCommandEmbeds.errorEmbed(TITLE, message)
+
+    /**
+     * Per-spots payout preview embed for the `/keno` slash command's
+     * help-style title bar — used when the user asks for a quick-pick
+     * without committing yet (future enhancement). Currently unused
+     * outside tests; kept here so the format lives next to the rest of
+     * the embed plumbing.
+     */
+    fun paytableSummaryLine(spots: Int): String =
+        "$spots-spot pays up to **${WagerCommandEmbeds.multiplierLabel(Keno.PAYTABLE[spots]?.maxOrNull() ?: 0.0)}** at full hit."
+
+    private fun jackpotLine(jackpotPayout: Long): String =
+        if (jackpotPayout > 0L) "\n🎰 Jackpot hit! **+$jackpotPayout credits.**" else ""
+
+    private fun tributeLine(tribute: Long): String =
+        if (tribute > 0L) "\n💰 +$tribute credits to the jackpot pool." else ""
+}

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/economy/KenoCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/economy/KenoCommandTest.kt
@@ -1,0 +1,198 @@
+package bot.toby.command.commands.economy
+
+import bot.toby.command.CommandTest
+import bot.toby.command.CommandTest.Companion.event
+import bot.toby.command.CommandTest.Companion.guild
+import bot.toby.command.DefaultCommandContext
+import database.dto.UserDto
+import database.economy.Keno
+import database.service.KenoService
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import net.dv8tion.jda.api.entities.MessageEmbed
+import net.dv8tion.jda.api.interactions.commands.OptionMapping
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class KenoCommandTest : CommandTest {
+    private lateinit var kenoService: KenoService
+    private lateinit var command: KenoCommand
+
+    private val discordId = 1L
+    private val guildId = 42L
+
+    @BeforeEach
+    fun setUp() {
+        setUpCommonMocks()
+        kenoService = mockk(relaxed = true)
+        command = KenoCommand(kenoService)
+        every { guild.idLong } returns guildId
+        every { kenoService.quickPick(any()) } answers {
+            val n = firstArg<Int>()
+            (1..n).toList()
+        }
+    }
+
+    @AfterEach
+    fun tearDown() {
+        tearDownCommonMocks()
+        clearAllMocks()
+    }
+
+    private fun intOpt(value: Long): OptionMapping = mockk<OptionMapping>(relaxed = true).also {
+        every { it.asLong } returns value
+    }
+
+    private fun stringOpt(value: String): OptionMapping = mockk<OptionMapping>(relaxed = true).also {
+        every { it.asString } returns value
+    }
+
+    @Test
+    fun `default invocation quick-picks 5 spots and resolves through the service`() {
+        val user = UserDto(discordId = discordId, guildId = guildId)
+        every { event.getOption("stake") } returns intOpt(50L)
+        every { event.getOption("spots") } returns null
+        every { event.getOption("picks") } returns null
+        every { kenoService.quickPick(5) } returns listOf(7, 12, 18, 33, 71)
+        every { kenoService.play(discordId, guildId, 50L, listOf(7, 12, 18, 33, 71)) } returns
+            KenoService.PlayOutcome.Lose(
+                stake = 50L, picks = listOf(7, 12, 18, 33, 71),
+                draws = (1..20).toList(), hits = 0, newBalance = 950L
+            )
+
+        command.handle(DefaultCommandContext(event), user, 5)
+
+        verify(exactly = 1) { kenoService.quickPick(5) }
+        verify(exactly = 1) { kenoService.play(discordId, guildId, 50L, listOf(7, 12, 18, 33, 71)) }
+        verify { event.hook.sendMessageEmbeds(any<MessageEmbed>()) }
+    }
+
+    @Test
+    fun `explicit spots option overrides the default and is forwarded to quickPick`() {
+        val user = UserDto(discordId = discordId, guildId = guildId)
+        every { event.getOption("stake") } returns intOpt(100L)
+        every { event.getOption("spots") } returns intOpt(8L)
+        every { event.getOption("picks") } returns null
+        every { kenoService.quickPick(8) } returns (1..8).toList()
+        every { kenoService.play(discordId, guildId, 100L, (1..8).toList()) } returns
+            KenoService.PlayOutcome.Lose(
+                stake = 100L, picks = (1..8).toList(),
+                draws = (50..69).toList(), hits = 0, newBalance = 900L
+            )
+
+        command.handle(DefaultCommandContext(event), user, 5)
+
+        verify(exactly = 1) { kenoService.quickPick(8) }
+    }
+
+    @Test
+    fun `user-supplied picks CSV is parsed and forwarded verbatim`() {
+        val user = UserDto(discordId = discordId, guildId = guildId)
+        every { event.getOption("stake") } returns intOpt(100L)
+        every { event.getOption("spots") } returns intOpt(5L)
+        every { event.getOption("picks") } returns stringOpt("7, 12, 18, 33, 71")
+        val capturedPicks = slot<List<Int>>()
+        every { kenoService.play(discordId, guildId, 100L, capture(capturedPicks)) } returns
+            KenoService.PlayOutcome.Win(
+                stake = 100L, payout = 1_460L, net = 1_360L,
+                picks = listOf(7, 12, 18, 33, 71),
+                draws = (1..20).toList(), hits = 2, multiplier = 14.6,
+                newBalance = 2_360L
+            )
+
+        command.handle(DefaultCommandContext(event), user, 5)
+
+        assertEquals(listOf(7, 12, 18, 33, 71), capturedPicks.captured)
+        verify(exactly = 0) { kenoService.quickPick(any()) }
+    }
+
+    @Test
+    fun `picks count mismatch surfaces an error embed and does not call the service`() {
+        val user = UserDto(discordId = discordId, guildId = guildId)
+        every { event.getOption("stake") } returns intOpt(100L)
+        every { event.getOption("spots") } returns intOpt(5L)
+        // Only 3 picks supplied for a 5-spot request.
+        every { event.getOption("picks") } returns stringOpt("7, 12, 18")
+
+        command.handle(DefaultCommandContext(event), user, 5)
+
+        verify(exactly = 0) { kenoService.play(any(), any(), any(), any(), any()) }
+        verify { event.hook.sendMessageEmbeds(any<MessageEmbed>()) }
+    }
+
+    @Test
+    fun `out-of-pool pick surfaces an error embed`() {
+        val user = UserDto(discordId = discordId, guildId = guildId)
+        every { event.getOption("stake") } returns intOpt(100L)
+        every { event.getOption("spots") } returns intOpt(2L)
+        every { event.getOption("picks") } returns stringOpt("5, 99")
+
+        command.handle(DefaultCommandContext(event), user, 5)
+
+        verify(exactly = 0) { kenoService.play(any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `duplicate picks surface an error embed`() {
+        val user = UserDto(discordId = discordId, guildId = guildId)
+        every { event.getOption("stake") } returns intOpt(100L)
+        every { event.getOption("spots") } returns intOpt(3L)
+        every { event.getOption("picks") } returns stringOpt("5, 5, 7")
+
+        command.handle(DefaultCommandContext(event), user, 5)
+
+        verify(exactly = 0) { kenoService.play(any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `non-numeric pick surfaces an error embed`() {
+        val user = UserDto(discordId = discordId, guildId = guildId)
+        every { event.getOption("stake") } returns intOpt(100L)
+        every { event.getOption("spots") } returns intOpt(2L)
+        every { event.getOption("picks") } returns stringOpt("5, abc")
+
+        command.handle(DefaultCommandContext(event), user, 5)
+
+        verify(exactly = 0) { kenoService.play(any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `does not invoke the service when no stake is provided`() {
+        val user = UserDto(discordId = discordId, guildId = guildId)
+        every { event.getOption("stake") } returns null
+
+        command.handle(DefaultCommandContext(event), user, 5)
+
+        verify(exactly = 0) { kenoService.play(any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `parsePicks helper returns null for empty parts after trimming`() {
+        // ", , , ," with spots=4 should produce 0 valid parts → mismatch.
+        assertNull(command.parsePicks(", , , ,", 4))
+    }
+
+    @Test
+    fun `parsePicks helper happy path returns the parsed list`() {
+        assertEquals(listOf(1, 2, 3), command.parsePicks("1,2,3", 3))
+    }
+
+    @Test
+    fun `parsePicks helper quick-picks when raw is blank`() {
+        every { kenoService.quickPick(5) } returns listOf(11, 22, 33, 44, 55)
+        assertEquals(listOf(11, 22, 33, 44, 55), command.parsePicks("", 5))
+        assertEquals(listOf(11, 22, 33, 44, 55), command.parsePicks(null, 5))
+    }
+
+    @Test
+    fun `parsePicks rejects spots count outside the engine range`() {
+        assertNull(command.parsePicks(null, 0))
+        assertNull(command.parsePicks(null, Keno.MAX_SPOTS + 1))
+    }
+}

--- a/web/src/main/kotlin/web/controller/KenoController.kt
+++ b/web/src/main/kotlin/web/controller/KenoController.kt
@@ -1,0 +1,160 @@
+package web.controller
+
+import database.economy.Keno
+import database.service.KenoService
+import database.service.KenoService.PlayOutcome
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.security.oauth2.core.user.OAuth2User
+import org.springframework.stereotype.Controller
+import org.springframework.ui.Model
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseBody
+import org.springframework.web.servlet.mvc.support.RedirectAttributes
+import web.casino.CasinoOutcomeMapper
+import web.casino.CasinoPageContext
+import web.casino.CasinoResponseLike
+import web.service.EconomyWebService
+import web.util.WebGuildAccess
+
+/**
+ * Web surface for the `/keno` minigame. GET renders the 8×10 picker
+ * grid + stake input + "Quick Pick N" auto-fill button; POST runs the
+ * round via [KenoService.play] and returns JSON with the player's
+ * picks, the 20 drawn numbers, hit count, multiplier, and net.
+ *
+ * Same shape as [BaccaratController] — keno is a one-shot wager so
+ * there's no session state. The "draws light up one-by-one" reveal is
+ * client-side via `keno.js` reading the body's `draws` array.
+ *
+ * Both surfaces (web + Discord) share [KenoService] so the paytable,
+ * pool size, and balance debit/credit semantics stay consistent.
+ */
+@Controller
+@RequestMapping("/casino/{guildId}/keno")
+class KenoController(
+    private val kenoService: KenoService,
+    private val economyWebService: EconomyWebService,
+    private val pageContext: CasinoPageContext,
+) {
+
+    private val errors = CasinoOutcomeMapper { msg -> KenoPlayResponse(false, msg) }
+
+    @GetMapping
+    fun page(
+        @PathVariable guildId: Long,
+        @AuthenticationPrincipal user: OAuth2User,
+        model: Model,
+        ra: RedirectAttributes
+    ): String = WebGuildAccess.requireMemberForPage(
+        user, guildId, economyWebService, ra, lobbyPath = "/casino/guilds"
+    ) { discordId ->
+        pageContext.populate(model, guildId, discordId, user) ?: run {
+            ra.addFlashAttribute("error", "Bot is not in that server.")
+            return@requireMemberForPage "redirect:/casino/guilds"
+        }
+        model.addAttribute("minStake", Keno.MIN_STAKE)
+        model.addAttribute("maxStake", Keno.MAX_STAKE)
+        model.addAttribute("minSpots", Keno.MIN_SPOTS)
+        model.addAttribute("maxSpots", Keno.MAX_SPOTS)
+        model.addAttribute("poolSize", Keno.POOL_SIZE)
+        model.addAttribute("draws", Keno.DRAWS)
+        // Render the per-spots paytable as a list of {spots, payouts}
+        // pairs so Thymeleaf can iterate with a `th:each` and the rules
+        // section / a future paytable widget can read it without
+        // hard-coding values that already live in the engine.
+        model.addAttribute(
+            "paytable",
+            (Keno.MIN_SPOTS..Keno.MAX_SPOTS).map { spots ->
+                mapOf(
+                    "spots" to spots,
+                    "payouts" to (Keno.PAYTABLE[spots] ?: emptyList())
+                )
+            }
+        )
+        "keno"
+    }
+
+    @PostMapping("/play")
+    @ResponseBody
+    fun play(
+        @PathVariable guildId: Long,
+        @RequestBody request: KenoPlayRequest,
+        @AuthenticationPrincipal user: OAuth2User
+    ): ResponseEntity<KenoPlayResponse> = WebGuildAccess.requireMemberForJson(
+        user, guildId, economyWebService, errorBuilder = errors.errorBuilder
+    ) { discordId ->
+        when (val outcome = kenoService.play(
+            discordId, guildId, request.stake, request.picks, request.autoTopUp
+        )) {
+            is PlayOutcome.Win -> ResponseEntity.ok(
+                KenoPlayResponse(
+                    ok = true,
+                    picks = outcome.picks,
+                    draws = outcome.draws,
+                    hits = outcome.hits,
+                    multiplier = outcome.multiplier,
+                    net = outcome.net,
+                    payout = outcome.payout,
+                    newBalance = outcome.newBalance,
+                    win = true,
+                    jackpotPayout = outcome.jackpotPayout.takeIf { it > 0L },
+                    soldTobyCoins = outcome.soldTobyCoins.takeIf { it > 0L },
+                    newPrice = outcome.newPrice,
+                )
+            )
+
+            is PlayOutcome.Lose -> ResponseEntity.ok(
+                KenoPlayResponse(
+                    ok = true,
+                    picks = outcome.picks,
+                    draws = outcome.draws,
+                    hits = outcome.hits,
+                    multiplier = 0.0,
+                    net = -outcome.stake,
+                    payout = 0L,
+                    newBalance = outcome.newBalance,
+                    win = false,
+                    soldTobyCoins = outcome.soldTobyCoins.takeIf { it > 0L },
+                    newPrice = outcome.newPrice,
+                    lossTribute = outcome.lossTribute.takeIf { it > 0L },
+                )
+            )
+
+            is PlayOutcome.InsufficientCredits -> errors.insufficientCredits(outcome.stake, outcome.have)
+            is PlayOutcome.InsufficientCoinsForTopUp -> errors.insufficientCoinsForTopUp(outcome.needed, outcome.have)
+            is PlayOutcome.InvalidStake -> errors.invalidStake(outcome.min, outcome.max)
+            is PlayOutcome.InvalidPicks -> errors.badRequest(
+                "Pick ${outcome.min}-${outcome.max} distinct numbers between 1 and ${outcome.poolMax}."
+            )
+            PlayOutcome.UnknownUser -> errors.unknownUser()
+        }
+    }
+}
+
+data class KenoPlayRequest(
+    val picks: List<Int> = emptyList(),
+    val stake: Long = 0,
+    val autoTopUp: Boolean = false
+)
+
+data class KenoPlayResponse(
+    override val ok: Boolean,
+    override val error: String? = null,
+    val picks: List<Int>? = null,
+    val draws: List<Int>? = null,
+    val hits: Int? = null,
+    val multiplier: Double? = null,
+    val net: Long? = null,
+    val payout: Long? = null,
+    val newBalance: Long? = null,
+    val win: Boolean? = null,
+    val jackpotPayout: Long? = null,
+    val soldTobyCoins: Long? = null,
+    val newPrice: Double? = null,
+    val lossTribute: Long? = null,
+) : CasinoResponseLike

--- a/web/src/main/resources/static/css/keno.css
+++ b/web/src/main/resources/static/css/keno.css
@@ -1,0 +1,235 @@
+@import url("./casino-table.css");
+
+.keno-header { margin-bottom: var(--space-5); }
+.keno-header h1 { margin: var(--space-2) 0; }
+.keno-header strong { color: #fff; }
+
+.keno-bet {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: var(--space-5);
+    margin-bottom: var(--space-4);
+    max-width: 56rem;
+}
+
+.keno-bet h2 { margin-top: 0; margin-bottom: var(--space-3); }
+
+.keno-bet form {
+    display: grid;
+    gap: var(--space-3);
+}
+
+.keno-pickbar {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    flex-wrap: wrap;
+}
+
+.keno-pickcount {
+    color: var(--text-muted);
+    font-variant-numeric: tabular-nums;
+}
+.keno-pickcount strong { color: #fff; }
+
+.keno-bet input[type="number"] {
+    width: 100%;
+    padding: 8px 10px;
+    background: rgba(0, 0, 0, 0.35);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    color: #fff;
+    font-size: 1rem;
+    font-variant-numeric: tabular-nums;
+    max-width: 12rem;
+}
+
+.keno-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.keno-balance {
+    color: var(--text-muted);
+    margin-top: var(--space-3);
+}
+.keno-balance strong { color: #fff; }
+
+/* casino-felt owns the green table; this class only owns layout. */
+.keno-table {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+}
+
+.keno-status {
+    color: rgba(255, 255, 255, 0.78);
+    text-align: center;
+    font-size: 0.95rem;
+    min-height: 1.4em;
+}
+
+/* 8-column board renders the 80-cell pool as 8 wide × 10 tall. The
+   shared `.casino-card-face` recipe (white gradient, inner highlight,
+   serif numerals) gives each cell the same visual language as a card
+   glyph on blackjack/poker — different shape, same product. */
+.keno-grid {
+    display: grid;
+    grid-template-columns: repeat(8, minmax(0, 1fr));
+    gap: 0.4rem;
+    width: 100%;
+}
+
+.keno-cell {
+    aspect-ratio: 1 / 1;
+    background: var(--casino-card-bg);
+    color: #1a1a1a;
+    border: var(--casino-card-border);
+    border-radius: 0.4rem;
+    box-shadow: var(--casino-card-shadow);
+    font-family: "Cambria", "Georgia", serif;
+    font-weight: 700;
+    font-size: 1rem;
+    font-variant-numeric: tabular-nums;
+    cursor: pointer;
+    user-select: none;
+    transition:
+        background 0.15s ease,
+        box-shadow 0.15s ease,
+        transform 0.1s ease,
+        border-color 0.15s ease;
+}
+
+.keno-cell:hover:not(:disabled) {
+    transform: translateY(-1px);
+    border-color: rgba(241, 196, 15, 0.5);
+}
+.keno-cell:active:not(:disabled) {
+    transform: translateY(0) scale(0.96);
+}
+.keno-cell:focus-visible {
+    outline: 2px solid #5865F2;
+    outline-offset: 2px;
+}
+.keno-cell:disabled {
+    cursor: default;
+}
+
+/* Picked but not-yet-drawn — gold ring tells the user "this is your
+   commitment", same treatment as selected sides on baccarat / coinflip. */
+.keno-cell.is-picked {
+    border-color: var(--casino-gold);
+    background: linear-gradient(180deg, #fff 0%, #fef3c7 100%);
+    box-shadow: var(--casino-active-glow);
+}
+
+/* A drawn number that the player did NOT pick — dim gray panel so the
+   cell still reads as "the round happened here" without competing for
+   attention with the hits. */
+.keno-cell.is-drawn {
+    background: linear-gradient(135deg, #2c3e50 0%, #34495e 100%);
+    color: rgba(255, 255, 255, 0.85);
+    border-color: rgba(0, 0, 0, 0.4);
+    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.45);
+}
+
+/* A drawn number the player DID pick — the hit. Pulse with the shared
+   casino-pulse keyframe so wins celebrate themselves. */
+.keno-cell.is-hit {
+    background: linear-gradient(180deg, #fde68a 0%, #fcd34d 100%);
+    color: #4a1a00;
+    border-color: var(--casino-gold);
+    box-shadow: var(--casino-active-glow);
+    animation: casino-pulse 1.6s ease-in-out infinite;
+}
+
+.keno-result {
+    min-height: 1.5em;
+    font-size: 1.05rem;
+    text-align: center;
+    font-variant-numeric: tabular-nums;
+    color: rgba(255, 255, 255, 0.85);
+}
+.keno-result.keno-result-win { color: #57F287; }
+.keno-result.keno-result-lose { color: #a0a0b0; }
+.keno-result strong { color: inherit; }
+
+.keno-rules,
+.keno-payouts {
+    margin-top: var(--space-5);
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: var(--space-4);
+}
+
+.keno-rules h2,
+.keno-payouts h2 {
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--text-muted);
+    margin-bottom: var(--space-3);
+}
+
+.keno-rules ol {
+    list-style: decimal;
+    padding-left: 22px;
+    color: var(--text-muted);
+    font-size: 0.95rem;
+    line-height: 1.7;
+}
+.keno-rules strong { color: #fff; }
+.keno-rules em { color: #fff; font-style: normal; }
+
+/* Paytable horizontal scroll: 11 columns (Spots + 0..10 hits) often
+   overflows on phones — the scroll preserves alignment and prevents
+   the table from shrinking text below readable size. */
+.keno-payouts-scroll {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+}
+.keno-payouts table {
+    width: 100%;
+    border-collapse: collapse;
+    font-variant-numeric: tabular-nums;
+    min-width: 38rem;
+}
+.keno-payouts th,
+.keno-payouts td {
+    text-align: right;
+    padding: 6px 8px;
+    border-bottom: 1px solid var(--border);
+    font-size: 0.9rem;
+}
+.keno-payouts th:first-child,
+.keno-payouts td:first-child {
+    text-align: left;
+    color: rgba(255, 255, 255, 0.85);
+}
+.keno-payouts th {
+    color: var(--text-muted);
+    font-weight: 500;
+    text-transform: uppercase;
+    font-size: 0.75rem;
+    letter-spacing: 0.05em;
+    text-align: right;
+}
+.keno-payouts td.is-pay {
+    color: var(--casino-gold);
+    font-weight: 600;
+}
+.keno-payouts tr:last-child td { border-bottom: none; }
+
+@media (max-width: 600px) {
+    .keno-cell { font-size: 0.85rem; }
+    .keno-payouts table { font-size: 0.82rem; }
+}
+
+@media (max-width: 380px) {
+    .keno-grid { gap: 0.3rem; }
+    .keno-cell { font-size: 0.75rem; }
+}

--- a/web/src/main/resources/static/js/keno.js
+++ b/web/src/main/resources/static/js/keno.js
@@ -1,0 +1,279 @@
+// Pure-DOM render for a /play response. Hoisted out of the IIFE so a
+// jest test can drive it without booting the page. Mirrors the shape of
+// renderBaccaratResult — same `stagger` / `dealMs` / synchronous-fallback
+// pattern so the staged reveal is fully test-controllable.
+//
+// On a staged path: the cells the server drew light up one-by-one at
+// dealMs intervals (gold pulse if the draw matches a pick, dim grey
+// otherwise). The result line + chip flourish + win/lose sound hold
+// until every draw has landed.
+function renderKenoResult(opts) {
+    var resultEl = opts.resultEl;
+    var statusEl = opts.statusEl;
+    var gridEl = opts.gridEl;
+    var flashTargetEl = opts.flashTargetEl;
+    var stagger = opts.stagger !== false;
+    var dealMs = stagger ? (opts.dealMs || 120) : 0;
+    var body = opts.body;
+
+    if (!body) return;
+
+    var picksSet = new Set(body.picks || []);
+    var draws = body.draws || [];
+
+    // Reset every cell on the board: drop any previous-round drawn /
+    // hit classes, restore the picked highlight for the picks the
+    // server confirmed.
+    if (gridEl) {
+        var cells = gridEl.querySelectorAll('.keno-cell');
+        for (var c = 0; c < cells.length; c++) {
+            var cell = cells[c];
+            cell.classList.remove('is-drawn', 'is-hit');
+            var n = parseInt(cell.dataset.value, 10);
+            cell.classList.toggle('is-picked', picksSet.has(n));
+        }
+    }
+
+    function finalize() {
+        if (statusEl) {
+            statusEl.textContent = body.win
+                ? 'Round complete — ' + body.hits + ' of ' + (body.picks || []).length + ' hit.'
+                : (body.hits || 0) + ' of ' + (body.picks || []).length + ' hit — no payout this round.';
+        }
+
+        if (resultEl) {
+            if (typeof window !== 'undefined' && window.TobyCasinoResult) {
+                window.TobyCasinoResult.render({
+                    resultEl: resultEl,
+                    body: body,
+                    classPrefix: 'keno',
+                    winLineHtml: kenoWinLineHtml(body),
+                    loseLineHtml: kenoLoseLineHtml(body),
+                });
+            }
+        }
+
+        if (typeof window !== 'undefined') {
+            if (window.CasinoRender) {
+                window.CasinoRender.flashWinPayout(flashTargetEl, body);
+            }
+            if (window.CasinoSounds) {
+                window.CasinoSounds.play(body.win ? 'win' : 'lose');
+            }
+        }
+    }
+
+    // Hide any prior result line while the deal plays out — it'll be
+    // re-rendered in finalize().
+    if (resultEl && dealMs > 0) {
+        resultEl.hidden = true;
+        resultEl.classList.remove('keno-result-win', 'keno-result-lose', 'keno-result-jackpot');
+        resultEl.innerHTML = '';
+    }
+    if (statusEl && dealMs > 0) {
+        statusEl.textContent = 'Drawing…';
+    }
+
+    if (!gridEl || dealMs <= 0 || draws.length === 0) {
+        // Synchronous path — light up every drawn cell at once. Tests
+        // pass `stagger: false`; production also falls through here if
+        // the grid element is missing (defensive).
+        for (var d = 0; d < draws.length; d++) {
+            lightUpDraw(gridEl, draws[d], picksSet);
+        }
+        finalize();
+        return;
+    }
+
+    // Staged path: schedule one cell-light-up per dealMs. The 'click'
+    // sound rides the per-cell tick so the player can hear the deal.
+    draws.forEach(function (n, i) {
+        setTimeout(function () {
+            lightUpDraw(gridEl, n, picksSet);
+            if (typeof window !== 'undefined' && window.CasinoSounds) {
+                window.CasinoSounds.play('click');
+            }
+        }, i * dealMs);
+    });
+    setTimeout(finalize, draws.length * dealMs);
+}
+
+function lightUpDraw(gridEl, n, picksSet) {
+    if (!gridEl) return;
+    var cell = gridEl.querySelector('.keno-cell[data-value="' + n + '"]');
+    if (!cell) return;
+    if (picksSet && picksSet.has(n)) {
+        // Hit — gold pulse via casino-pulse keyframe.
+        cell.classList.remove('is-picked', 'is-drawn');
+        cell.classList.add('is-hit');
+    } else {
+        cell.classList.remove('is-picked');
+        cell.classList.add('is-drawn');
+    }
+}
+
+function kenoWinLineHtml(body) {
+    var multTxt = (typeof body.multiplier === 'number')
+        ? body.multiplier.toFixed(body.multiplier >= 10 ? 0 : 2) + '×'
+        : '';
+    return '🎯 <strong>' + body.hits + '/' + (body.picks || []).length +
+        '</strong> hit · won <strong>+' + body.net + ' credits</strong>' +
+        (multTxt ? ' at ' + multTxt : '') + '.';
+}
+
+function kenoLoseLineHtml(body) {
+    return '❌ <strong>' + (body.hits || 0) + '/' + (body.picks || []).length +
+        '</strong> hit · lost <strong>' + Math.abs(body.net) + ' credits</strong>.';
+}
+
+(function () {
+    'use strict';
+
+    var main = document.querySelector('main[data-guild-id]');
+    if (!main) return;
+
+    var guildId = main.dataset.guildId;
+    var minSpots = parseInt(main.dataset.minSpots, 10) || 1;
+    var maxSpots = parseInt(main.dataset.maxSpots, 10) || 10;
+
+    var stakeInput = document.getElementById('keno-stake');
+    var dealBtn = document.getElementById('keno-deal');
+    var dealTobyBtn = document.getElementById('keno-deal-toby');
+    var balanceEl = document.getElementById('keno-balance');
+    var resultEl = document.getElementById('keno-result');
+    var form = document.getElementById('keno-bet-form');
+    var tableEl = document.querySelector('.keno-table');
+    var gridEl = document.getElementById('keno-grid');
+    var statusEl = document.getElementById('keno-status');
+    var pickCountEl = document.getElementById('keno-pickcount-value');
+    var quickPickBtn = document.getElementById('keno-quickpick');
+    var clearBtn = document.getElementById('keno-clear');
+
+    if (!form || !dealBtn || !stakeInput || !gridEl) return;
+
+    var picks = new Set();
+
+    function refreshPickCount() {
+        if (pickCountEl) pickCountEl.textContent = String(picks.size);
+    }
+
+    function updateCellPicked(cell, picked) {
+        cell.classList.toggle('is-picked', picked);
+        cell.setAttribute('aria-pressed', picked ? 'true' : 'false');
+    }
+
+    function clearRoundDecorations() {
+        // Strip drawn / hit decorations from the previous round so a
+        // fresh ticket starts on a clean board.
+        var marked = gridEl.querySelectorAll('.is-drawn, .is-hit');
+        for (var i = 0; i < marked.length; i++) {
+            marked[i].classList.remove('is-drawn', 'is-hit');
+        }
+    }
+
+    function togglePick(cell) {
+        var n = parseInt(cell.dataset.value, 10);
+        if (Number.isNaN(n)) return;
+        if (picks.has(n)) {
+            picks.delete(n);
+            updateCellPicked(cell, false);
+        } else {
+            if (picks.size >= maxSpots) {
+                if (window.toast) {
+                    window.toast('Maximum ' + maxSpots + ' picks per ticket.', 'info');
+                }
+                return;
+            }
+            picks.add(n);
+            updateCellPicked(cell, true);
+        }
+        refreshPickCount();
+    }
+
+    function clearPicks() {
+        var picked = gridEl.querySelectorAll('.keno-cell.is-picked');
+        for (var i = 0; i < picked.length; i++) updateCellPicked(picked[i], false);
+        picks.clear();
+        refreshPickCount();
+    }
+
+    function quickPickRest() {
+        // Auto-fill up to maxSpots from the cells the user hasn't picked.
+        var available = [];
+        var cells = gridEl.querySelectorAll('.keno-cell');
+        for (var i = 0; i < cells.length; i++) {
+            var n = parseInt(cells[i].dataset.value, 10);
+            if (!picks.has(n)) available.push(n);
+        }
+        // Fisher-Yates shuffle, but we only need maxSpots-picks.size values
+        // so partial-shuffle is plenty.
+        var need = maxSpots - picks.size;
+        if (need <= 0) return;
+        for (var k = 0; k < need && available.length > 0; k++) {
+            var idx = Math.floor(Math.random() * available.length);
+            var pick = available[idx];
+            available.splice(idx, 1);
+            picks.add(pick);
+            var cell = gridEl.querySelector('.keno-cell[data-value="' + pick + '"]');
+            if (cell) updateCellPicked(cell, true);
+        }
+        refreshPickCount();
+    }
+
+    // Wire cell clicks (delegated for cheap setup over 80 cells).
+    gridEl.addEventListener('click', function (e) {
+        var cell = e.target.closest('.keno-cell');
+        if (!cell || !gridEl.contains(cell)) return;
+        togglePick(cell);
+    });
+
+    if (quickPickBtn) quickPickBtn.addEventListener('click', quickPickRest);
+    if (clearBtn) clearBtn.addEventListener('click', clearPicks);
+
+    if (window.TobyCasinoGame) {
+        window.TobyCasinoGame.init({
+            guildId: guildId,
+            endpoint: '/casino/' + guildId + '/keno/play',
+            form: form,
+            stakeInput: stakeInput,
+            primaryBtn: dealBtn,
+            tobyBtn: dealTobyBtn,
+            balanceEl: balanceEl,
+            resultEl: resultEl,
+            tobyCoins: Number(main.dataset.tobyCoins) || 0,
+            marketPrice: Number(main.dataset.marketPrice) || 0,
+            failureMessage: 'Deal failed.',
+            validate: function () {
+                if (picks.size < minSpots) return 'Pick at least ' + minSpots + ' number' + (minSpots === 1 ? '' : 's') + '.';
+                if (picks.size > maxSpots) return 'Pick at most ' + maxSpots + ' numbers.';
+                return null;
+            },
+            buildPayload: function (state) {
+                return {
+                    picks: Array.from(picks).sort(function (a, b) { return a - b; }),
+                    stake: state.stake,
+                    autoTopUp: state.autoTopUp,
+                };
+            },
+            startAnimation: function () {
+                clearRoundDecorations();
+                return null;
+            },
+            renderResult: function (body) {
+                renderKenoResult({
+                    resultEl: resultEl,
+                    statusEl: statusEl,
+                    gridEl: gridEl,
+                    flashTargetEl: tableEl,
+                    body: body,
+                });
+            },
+        });
+    }
+
+    refreshPickCount();
+})();
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { renderKenoResult, kenoWinLineHtml, kenoLoseLineHtml };
+}

--- a/web/src/main/resources/templates/casino-guilds.html
+++ b/web/src/main/resources/templates/casino-guilds.html
@@ -33,6 +33,8 @@
                 <a class="btn-secondary"
                    th:href="@{/casino/{id}/scratch(id=${g.id})}">🎟️ Scratch</a>
                 <a class="btn-secondary"
+                   th:href="@{/casino/{id}/keno(id=${g.id})}">🎯 Keno</a>
+                <a class="btn-secondary"
                    th:href="@{/casino/{id}/baccarat(id=${g.id})}">🎴 Baccarat</a>
                 <a class="btn-secondary"
                    th:href="@{/poker/{id}(id=${g.id})}">🎴 Poker</a>

--- a/web/src/main/resources/templates/fragments/navbar.html
+++ b/web/src/main/resources/templates/fragments/navbar.html
@@ -38,6 +38,7 @@
                 <a href="/casino/guilds" role="menuitem">&#127922; Dice</a>
                 <a href="/casino/guilds" role="menuitem">&#127183; High-Low</a>
                 <a href="/casino/guilds" role="menuitem">&#127903;&#65039; Scratch</a>
+                <a href="/casino/guilds" role="menuitem">&#127919; Keno</a>
                 <a href="/poker/guilds" role="menuitem">&#127924; Poker</a>
                 <a href="/blackjack/guilds" role="menuitem">&#127922; Blackjack</a>
                 <a href="/casino/guilds" role="menuitem">&#127924; Baccarat</a>

--- a/web/src/main/resources/templates/keno.html
+++ b/web/src/main/resources/templates/keno.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="en">
+<head th:replace="~{fragments/head :: head('TobyBot - Keno', '/css/keno.css')}"></head>
+<body>
+<a href="#main" class="skip-link">Skip to content</a>
+<div th:replace="~{fragments/navbar :: navbar}"></div>
+
+<main id="main" class="container"
+      th:attr="data-guild-id=${guildId}, data-toby-coins=${tobyCoins}, data-market-price=${marketPrice},
+               data-min-stake=${minStake}, data-max-stake=${maxStake},
+               data-min-spots=${minSpots}, data-max-spots=${maxSpots},
+               data-pool-size=${poolSize}, data-draws=${draws}">
+
+    <div class="keno-header">
+        <a class="back-link" th:href="@{/casino/guilds}">&larr; All casino servers</a>
+        <h1 th:text="'🎯 Keno • ' + ${guildName}">🎯 Keno</h1>
+        <p class="muted">
+            Pick <span th:text="${minSpots}">1</span>-<span th:text="${maxSpots}">10</span> numbers from the
+            <span th:text="${poolSize}">80</span>-cell board, then watch <span th:text="${draws}">20</span>
+            numbers get drawn. Bigger spot counts unlock bigger top-end multipliers but need more hits to start paying.
+            Bet <span th:text="${minStake}">10</span>-<span th:text="${maxStake}">500</span> credits per ticket.
+        </p>
+    </div>
+
+    <div th:replace="~{fragments/alerts :: error}"></div>
+
+    <div th:replace="~{fragments/casino :: jackpotBanner}"></div>
+
+    <section class="keno-bet">
+        <h2>Place your ticket</h2>
+        <form id="keno-bet-form" autocomplete="off">
+            <div class="keno-pickbar">
+                <span class="keno-pickcount">
+                    Picks: <strong id="keno-pickcount-value">0</strong> / <span th:text="${maxSpots}">10</span>
+                </span>
+                <button type="button" id="keno-quickpick" class="btn-secondary"
+                        title="Auto-fill the rest of your picks at random.">Quick Pick</button>
+                <button type="button" id="keno-clear" class="btn-secondary">Clear</button>
+            </div>
+            <label for="keno-stake">Stake (credits)</label>
+            <input id="keno-stake" name="stake" type="number"
+                   th:attr="min=${minStake}, max=${maxStake}" th:value="${minStake}" step="1" required>
+            <div class="keno-actions">
+                <button type="submit" id="keno-deal" class="btn-primary">Deal</button>
+                <button type="submit" id="keno-deal-toby" class="btn-secondary casino-bet-toby" hidden
+                        title="Sells just enough TOBY at the live market price to cover the shortfall, then deals.">
+                    Deal (sell <span class="casino-bet-toby-coins">0</span> TOBY)
+                </button>
+            </div>
+        </form>
+        <div class="keno-balance">
+            Wallet: <strong id="keno-balance" th:text="${balance}">0</strong> credits
+        </div>
+    </section>
+
+    <section class="keno-table casino-felt" id="keno-table">
+        <div class="keno-status" id="keno-status">
+            Tap up to <span th:text="${maxSpots}">10</span> cells, then hit Deal.
+        </div>
+        <div class="keno-grid" id="keno-grid" role="grid" aria-label="Keno number board">
+            <!--/* 80 cells, generated server-side so picks are progressive-enhancement
+                   safe. JS hooks click handlers + animates draws on resolve. */-->
+            <button th:each="n : ${#numbers.sequence(1, poolSize)}"
+                    type="button" class="keno-cell"
+                    th:attr="data-value=${n}, aria-label='Number ' + ${n}, aria-pressed='false'"
+                    th:text="${n}">1</button>
+        </div>
+        <div id="keno-result" class="keno-result muted" hidden></div>
+    </section>
+
+    <section class="keno-rules">
+        <h2>How to play</h2>
+        <ol>
+            <li>
+                <strong>Pick numbers.</strong> Tap up to
+                <strong th:text="${maxSpots}">10</strong> cells on the board (1–<span th:text="${poolSize}">80</span>).
+                You can also use <strong>Quick Pick</strong> to auto-fill the rest at random.
+            </li>
+            <li>
+                <strong>Set a stake</strong> between <strong th:text="${minStake}">10</strong> and
+                <strong th:text="${maxStake}">500</strong> credits, then <strong>Deal</strong>.
+            </li>
+            <li>
+                <strong>20 numbers are drawn</strong> from the same 1–<span th:text="${poolSize}">80</span> pool.
+                They light up on the board one-by-one.
+                Cells that match your picks <em>and</em> get drawn count as <strong>hits</strong>.
+            </li>
+            <li>
+                <strong>The payout</strong> depends on how many spots you picked and how many of those got hit —
+                see the table below. Bigger spot counts unlock bigger top-end multipliers but need more hits to
+                start paying (e.g. a 10-spot ticket needs 6+ hits to pay).
+            </li>
+            <li>
+                On a winning round your stake is multiplied; on a losing round you lose the stake. A small
+                slice of every loss feeds the per-server <strong>Jackpot Pool</strong> at the top of the page —
+                any future winning round on this server has a chance to claim the entire pool on top of its payout.
+            </li>
+        </ol>
+    </section>
+
+    <section class="keno-payouts">
+        <h2>Payouts (× stake)</h2>
+        <div class="keno-payouts-scroll">
+            <table>
+                <thead>
+                <tr>
+                    <th>Spots</th>
+                    <th th:each="k : ${#numbers.sequence(0, maxSpots)}" th:text="${k}">0</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr th:each="row : ${paytable}">
+                    <td><strong th:text="${row.spots}">1</strong></td>
+                    <td th:each="k : ${#numbers.sequence(0, maxSpots)}"
+                        th:with="payouts=${row.payouts}, mult=${k < payouts.size() ? payouts[k] : null}"
+                        th:classappend="${mult != null and mult gt 0 ? 'is-pay' : ''}"
+                        th:text="${mult == null ? '' : (mult gt 0 ? mult + '×' : '—')}">—</td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+        <p class="muted">
+            Empty cells mean the spot count can't produce that hit count. RTP across the table sits in the 0.83-0.92 band.
+        </p>
+    </section>
+</main>
+
+<div class="toast-stack" id="toast-stack" aria-live="polite"></div>
+
+<script th:src="@{/js/api.js}"></script>
+<script th:src="@{/js/toasts.js}"></script>
+<script th:src="@{/js/casino-sounds.js}"></script>
+<script th:src="@{/js/casino-jackpot.js}"></script>
+<script th:src="@{/js/casino-topup.js}"></script>
+<script th:src="@{/js/casino-result.js}"></script>
+<script th:src="@{/js/casino-render.js}"></script>
+<script th:src="@{/js/casino-game.js}"></script>
+<script th:src="@{/js/keno.js}"></script>
+</body>
+</html>

--- a/web/src/test/js/keno.test.js
+++ b/web/src/test/js/keno.test.js
@@ -1,0 +1,215 @@
+const {
+    renderKenoResult,
+    kenoWinLineHtml,
+    kenoLoseLineHtml,
+} = require('../../main/resources/static/js/keno');
+require('../../main/resources/static/js/casino-jackpot');
+require('../../main/resources/static/js/casino-result');
+require('../../main/resources/static/js/casino-render');
+
+describe('kenoWinLineHtml / kenoLoseLineHtml', () => {
+    test('win line includes hits/picks ratio, net, and multiplier', () => {
+        const html = kenoWinLineHtml({
+            picks: [1, 2, 3, 4, 5], hits: 5, net: 7990, multiplier: 800,
+        });
+        expect(html).toContain('5/5');
+        expect(html).toContain('+7990 credits');
+        expect(html).toContain('800×');
+    });
+
+    test('lose line includes hits/picks ratio and abs(net)', () => {
+        const html = kenoLoseLineHtml({
+            picks: [1, 2, 3, 4, 5], hits: 1, net: -50,
+        });
+        expect(html).toContain('1/5');
+        expect(html).toContain('lost <strong>50 credits</strong>');
+    });
+});
+
+describe('renderKenoResult (synchronous path)', () => {
+    let resultEl, statusEl, gridEl, tableEl;
+
+    beforeEach(() => {
+        document.body.innerHTML =
+            '<div id="r"></div>' +
+            '<div id="s"></div>' +
+            '<section id="t">' +
+            '<div id="g">' +
+            // Just enough cells for the tests below — values 1..30.
+            Array.from({ length: 30 }, (_, i) =>
+                `<button class="keno-cell" data-value="${i + 1}">${i + 1}</button>`
+            ).join('') +
+            '</div></section>';
+        resultEl = document.getElementById('r');
+        statusEl = document.getElementById('s');
+        gridEl = document.getElementById('g');
+        tableEl = document.getElementById('t');
+    });
+
+    function findCell(n) {
+        return gridEl.querySelector(`.keno-cell[data-value="${n}"]`);
+    }
+
+    test('win lights up hit cells with .is-hit, miss cells with .is-drawn, and renders the win line', () => {
+        renderKenoResult({
+            resultEl, statusEl, gridEl, flashTargetEl: tableEl,
+            stagger: false,
+            body: {
+                win: true,
+                picks: [1, 2, 3],          // 3 picks
+                draws: [1, 2, 4, 5, 6, 7], // 1, 2 are hits; 4, 5, 6, 7 are misses
+                hits: 2,
+                multiplier: 1,
+                net: 0,                    // 3-spot, 2 hits → 1× → net 0 (push-shaped win)
+                payout: 100,
+            },
+        });
+
+        expect(findCell(1).classList.contains('is-hit')).toBe(true);
+        expect(findCell(2).classList.contains('is-hit')).toBe(true);
+        expect(findCell(3).classList.contains('is-picked')).toBe(true); // picked but not drawn
+        expect(findCell(4).classList.contains('is-drawn')).toBe(true);
+        expect(findCell(7).classList.contains('is-drawn')).toBe(true);
+
+        expect(resultEl.classList.contains('keno-result-win')).toBe(true);
+        expect(resultEl.innerHTML).toContain('2/3');
+        expect(statusEl.textContent).toContain('2 of 3 hit');
+    });
+
+    test('lose path strips draws of any prior hit class and renders the lose line', () => {
+        renderKenoResult({
+            resultEl, statusEl, gridEl, flashTargetEl: tableEl,
+            stagger: false,
+            body: {
+                win: false,
+                picks: [25, 26, 27],
+                draws: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+                hits: 0,
+                multiplier: 0,
+                net: -100,
+            },
+        });
+
+        expect(findCell(25).classList.contains('is-picked')).toBe(true);
+        expect(findCell(25).classList.contains('is-hit')).toBe(false);
+        expect(findCell(1).classList.contains('is-drawn')).toBe(true);
+        expect(resultEl.classList.contains('keno-result-lose')).toBe(true);
+        expect(resultEl.innerHTML).toContain('0/3');
+    });
+
+    test('win flashes a chip stack on the flash target; loss leaves it untouched', () => {
+        renderKenoResult({
+            resultEl, statusEl, gridEl, flashTargetEl: tableEl,
+            stagger: false,
+            body: {
+                win: true, picks: [5], draws: [5, 1, 2, 3, 4, 6, 7, 8, 9, 10],
+                hits: 1, multiplier: 3.5, net: 250, payout: 350,
+            },
+        });
+        const stack = tableEl.querySelector('.casino-chip-stack');
+        expect(stack).not.toBeNull();
+        expect(stack.querySelector('.casino-chip-payout').textContent).toBe('+250');
+
+        // Reset and re-test lose: no chip stack should be added.
+        tableEl.querySelectorAll('.casino-chip-stack').forEach((el) => el.remove());
+        renderKenoResult({
+            resultEl, statusEl, gridEl, flashTargetEl: tableEl,
+            stagger: false,
+            body: {
+                win: false, picks: [5], draws: [1, 2, 3, 4, 6, 7, 8, 9, 10, 11],
+                hits: 0, net: -50,
+            },
+        });
+        expect(tableEl.querySelector('.casino-chip-stack')).toBeNull();
+    });
+
+    test('jackpot win prepends the JACKPOT banner', () => {
+        renderKenoResult({
+            resultEl, statusEl, gridEl, flashTargetEl: tableEl,
+            stagger: false,
+            body: {
+                win: true, picks: [5], draws: [5, 1, 2, 3, 4, 6, 7, 8, 9, 10],
+                hits: 1, multiplier: 3.5, net: 250, payout: 350,
+                jackpotPayout: 4000,
+            },
+        });
+        expect(resultEl.classList.contains('keno-result-jackpot')).toBe(true);
+        expect(resultEl.innerHTML).toContain('+4000 credits');
+    });
+
+    test('lose with lossTribute appends "+N to jackpot" suffix', () => {
+        renderKenoResult({
+            resultEl, statusEl, gridEl, flashTargetEl: tableEl,
+            stagger: false,
+            body: {
+                win: false, picks: [5], draws: [1, 2, 3, 4, 6, 7, 8, 9, 10, 11],
+                hits: 0, net: -50, lossTribute: 5,
+            },
+        });
+        expect(resultEl.innerHTML).toContain('+5 to jackpot');
+    });
+});
+
+describe('renderKenoResult (staged path)', () => {
+    let resultEl, statusEl, gridEl, tableEl;
+
+    beforeEach(() => {
+        document.body.innerHTML =
+            '<div id="r"></div>' +
+            '<div id="s"></div>' +
+            '<section id="t">' +
+            '<div id="g">' +
+            Array.from({ length: 30 }, (_, i) =>
+                `<button class="keno-cell" data-value="${i + 1}">${i + 1}</button>`
+            ).join('') +
+            '</div></section>';
+        resultEl = document.getElementById('r');
+        statusEl = document.getElementById('s');
+        gridEl = document.getElementById('g');
+        tableEl = document.getElementById('t');
+    });
+
+    test('staged path holds the result line until the deal sequence completes', () => {
+        jest.useFakeTimers();
+        try {
+            renderKenoResult({
+                resultEl, statusEl, gridEl, flashTargetEl: tableEl,
+                stagger: true, dealMs: 50,
+                body: {
+                    win: true,
+                    picks: [1, 2, 3],
+                    // 3 cells get drawn — first hit at t=0, miss at t=50, hit at t=100.
+                    draws: [1, 99, 2],
+                    hits: 2,
+                    multiplier: 42,
+                    net: 4100,
+                    payout: 4200,
+                },
+            });
+
+            // Synchronously after the call: status flips to "Drawing…",
+            // result line is hidden, no draws are revealed yet.
+            expect(statusEl.textContent).toBe('Drawing…');
+            expect(resultEl.hidden).toBe(true);
+            expect(gridEl.querySelectorAll('.is-drawn, .is-hit').length).toBe(0);
+
+            // Halfway through the first interval — only the first draw landed.
+            jest.advanceTimersByTime(25);
+            expect(gridEl.querySelector('.keno-cell[data-value="1"]').classList.contains('is-hit')).toBe(true);
+            expect(gridEl.querySelectorAll('.is-drawn').length).toBe(0);
+            expect(resultEl.hidden).toBe(true);
+
+            // Past the deal sequence (3 cells × 50ms = 150ms), but before
+            // flashChipsOn's 2.5s safety-cleanup timer would remove the
+            // chip stack.
+            jest.advanceTimersByTime(200);
+            expect(gridEl.querySelector('.keno-cell[data-value="2"]').classList.contains('is-hit')).toBe(true);
+            expect(resultEl.hidden).toBe(false);
+            expect(resultEl.classList.contains('keno-result-win')).toBe(true);
+            expect(statusEl.textContent).toContain('2 of 3 hit');
+            expect(tableEl.querySelector('.casino-chip-stack')).not.toBeNull();
+        } finally {
+            jest.useRealTimers();
+        }
+    });
+});

--- a/web/src/test/js/navbar.test.js
+++ b/web/src/test/js/navbar.test.js
@@ -79,6 +79,7 @@ describe('navbar fragment', () => {
         expect(casino[0]).toMatch(/href="\/casino\/guilds"[^>]*>[^<]*Dice/);
         expect(casino[0]).toMatch(/href="\/casino\/guilds"[^>]*>[^<]*High-Low/);
         expect(casino[0]).toMatch(/href="\/casino\/guilds"[^>]*>[^<]*Scratch/);
+        expect(casino[0]).toMatch(/href="\/casino\/guilds"[^>]*>[^<]*Keno/);
         expect(casino[0]).toMatch(/href="\/casino\/guilds"[^>]*>[^<]*Baccarat/);
         // Coming-soon placeholder is gone now that the games ship.
         expect(casino[0]).not.toMatch(/coming soon/i);

--- a/web/src/test/kotlin/web/controller/KenoControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/KenoControllerTest.kt
@@ -1,0 +1,269 @@
+package web.controller
+
+import database.economy.Keno
+import database.service.KenoService
+import database.service.KenoService.PlayOutcome
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.security.oauth2.core.user.OAuth2User
+import web.casino.CasinoPageContext
+import web.service.EconomyWebService
+
+class KenoControllerTest {
+
+    private val guildId = 42L
+    private val discordId = 100L
+
+    private lateinit var kenoService: KenoService
+    private lateinit var economyWebService: EconomyWebService
+    private lateinit var pageContext: CasinoPageContext
+    private lateinit var user: OAuth2User
+    private lateinit var controller: KenoController
+
+    @BeforeEach
+    fun setup() {
+        kenoService = mockk(relaxed = true)
+        economyWebService = mockk(relaxed = true)
+        pageContext = mockk(relaxed = true)
+        user = mockk {
+            every { getAttribute<String>("id") } returns discordId.toString()
+            every { getAttribute<String>("username") } returns "tester"
+        }
+        every { economyWebService.isMember(discordId, guildId) } returns true
+        controller = KenoController(kenoService, economyWebService, pageContext)
+    }
+
+    @Test
+    fun `Win returns 200 with picks, draws, hits, and the win-shaped payload`() {
+        every {
+            kenoService.play(discordId, guildId, 100L, listOf(1, 2, 3, 4, 5), false)
+        } returns PlayOutcome.Win(
+            stake = 100L,
+            payout = 80_000L,
+            net = 79_900L,
+            picks = listOf(1, 2, 3, 4, 5),
+            draws = (1..20).toList(),
+            hits = 5,
+            multiplier = 800.0,
+            newBalance = 80_900L
+        )
+
+        val response = controller.play(
+            guildId, KenoPlayRequest(picks = listOf(1, 2, 3, 4, 5), stake = 100L), user
+        )
+
+        assertTrue(response.statusCode.is2xxSuccessful)
+        val body = response.body!!
+        assertEquals(true, body.ok)
+        assertEquals(true, body.win)
+        assertEquals(5, body.hits)
+        assertEquals(listOf(1, 2, 3, 4, 5), body.picks)
+        assertEquals((1..20).toList(), body.draws)
+        assertEquals(800.0, body.multiplier)
+        assertEquals(79_900L, body.net)
+        assertEquals(80_000L, body.payout)
+        assertEquals(80_900L, body.newBalance)
+    }
+
+    @Test
+    fun `Lose returns 200 with negative net, win=false, draws preserved`() {
+        every {
+            kenoService.play(discordId, guildId, 50L, listOf(40, 50, 60), false)
+        } returns PlayOutcome.Lose(
+            stake = 50L,
+            picks = listOf(40, 50, 60),
+            draws = (1..20).toList(),
+            hits = 0,
+            newBalance = 950L
+        )
+
+        val response = controller.play(
+            guildId, KenoPlayRequest(picks = listOf(40, 50, 60), stake = 50L), user
+        )
+
+        assertTrue(response.statusCode.is2xxSuccessful)
+        val body = response.body!!
+        assertEquals(true, body.ok)
+        assertEquals(false, body.win)
+        assertEquals(0, body.hits)
+        assertEquals(-50L, body.net)
+        assertEquals(0L, body.payout)
+        assertEquals(950L, body.newBalance)
+        assertEquals(0.0, body.multiplier)
+    }
+
+    @Test
+    fun `play returns 400 on insufficient credits`() {
+        every {
+            kenoService.play(discordId, guildId, 100L, listOf(5), false)
+        } returns PlayOutcome.InsufficientCredits(stake = 100L, have = 30L)
+
+        val response = controller.play(
+            guildId, KenoPlayRequest(picks = listOf(5), stake = 100L), user
+        )
+
+        assertEquals(400, response.statusCode.value())
+        assertTrue(response.body?.error!!.contains("100"))
+        assertTrue(response.body?.error!!.contains("30"))
+    }
+
+    @Test
+    fun `play returns 400 on invalid stake`() {
+        every {
+            kenoService.play(discordId, guildId, 5L, listOf(5), false)
+        } returns PlayOutcome.InvalidStake(min = 10L, max = 500L)
+
+        val response = controller.play(
+            guildId, KenoPlayRequest(picks = listOf(5), stake = 5L), user
+        )
+
+        assertEquals(400, response.statusCode.value())
+        assertTrue(response.body?.error!!.contains("10"))
+        assertTrue(response.body?.error!!.contains("500"))
+    }
+
+    @Test
+    fun `play returns 400 on invalid picks`() {
+        every {
+            kenoService.play(discordId, guildId, 100L, listOf(0, 99), false)
+        } returns PlayOutcome.InvalidPicks(min = 1, max = 10, poolMax = 80)
+
+        val response = controller.play(
+            guildId, KenoPlayRequest(picks = listOf(0, 99), stake = 100L), user
+        )
+
+        assertEquals(400, response.statusCode.value())
+        val msg = response.body?.error!!
+        assertTrue(msg.contains("1"))
+        assertTrue(msg.contains("10"))
+        assertTrue(msg.contains("80"))
+    }
+
+    @Test
+    fun `play rejects with 403 when user is not a member of the guild`() {
+        every { economyWebService.isMember(discordId, guildId) } returns false
+
+        val response = controller.play(
+            guildId, KenoPlayRequest(picks = listOf(5), stake = 100L), user
+        )
+
+        assertEquals(403, response.statusCode.value())
+        verify(exactly = 0) { kenoService.play(any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `jackpot win surfaces jackpotPayout in the response body`() {
+        every {
+            kenoService.play(discordId, guildId, 100L, listOf(5, 7), false)
+        } returns PlayOutcome.Win(
+            stake = 100L,
+            payout = 1_460L,
+            net = 1_360L,
+            picks = listOf(5, 7),
+            draws = (1..20).toList(),
+            hits = 2,
+            multiplier = 14.6,
+            newBalance = 6_360L,
+            jackpotPayout = 4_000L
+        )
+
+        val response = controller.play(
+            guildId, KenoPlayRequest(picks = listOf(5, 7), stake = 100L), user
+        )
+
+        assertEquals(4_000L, response.body!!.jackpotPayout)
+    }
+
+    @Test
+    fun `non-jackpot win does not include jackpotPayout`() {
+        every {
+            kenoService.play(discordId, guildId, 100L, listOf(5, 7), false)
+        } returns PlayOutcome.Win(
+            stake = 100L,
+            payout = 1_460L,
+            net = 1_360L,
+            picks = listOf(5, 7),
+            draws = (1..20).toList(),
+            hits = 2,
+            multiplier = 14.6,
+            newBalance = 2_360L
+        )
+
+        val response = controller.play(
+            guildId, KenoPlayRequest(picks = listOf(5, 7), stake = 100L), user
+        )
+
+        assertNull(response.body!!.jackpotPayout)
+    }
+
+    @Test
+    fun `lose with loss tribute surfaces lossTribute on the response`() {
+        every {
+            kenoService.play(discordId, guildId, 100L, listOf(5), false)
+        } returns PlayOutcome.Lose(
+            stake = 100L,
+            picks = listOf(5),
+            draws = (1..20).toList(),
+            hits = 0,
+            newBalance = 900L,
+            lossTribute = 10L
+        )
+
+        val response = controller.play(
+            guildId, KenoPlayRequest(picks = listOf(5), stake = 100L), user
+        )
+
+        assertEquals(10L, response.body!!.lossTribute)
+    }
+
+    @Test
+    fun `autoTopUp flag is forwarded to the service`() {
+        every {
+            kenoService.play(discordId, guildId, 100L, listOf(5), true)
+        } returns PlayOutcome.Win(
+            stake = 100L,
+            payout = 350L,
+            net = 250L,
+            picks = listOf(5),
+            draws = (1..20).toList(),
+            hits = 1,
+            multiplier = 3.5,
+            newBalance = 1_250L,
+            soldTobyCoins = 25L,
+            newPrice = 4.0,
+        )
+
+        val response = controller.play(
+            guildId, KenoPlayRequest(picks = listOf(5), stake = 100L, autoTopUp = true), user
+        )
+
+        val body = response.body!!
+        assertEquals(true, body.win)
+        assertEquals(25L, body.soldTobyCoins)
+        assertEquals(4.0, body.newPrice)
+        verify(exactly = 1) {
+            kenoService.play(discordId, guildId, 100L, listOf(5), true)
+        }
+    }
+
+    @Test
+    fun `insufficient TOBY for top-up returns 400`() {
+        every {
+            kenoService.play(discordId, guildId, 100L, listOf(5), true)
+        } returns PlayOutcome.InsufficientCoinsForTopUp(needed = 50L, have = 5L)
+
+        val response = controller.play(
+            guildId, KenoPlayRequest(picks = listOf(5), stake = 100L, autoTopUp = true), user
+        )
+
+        assertEquals(400, response.statusCode.value())
+        assertTrue(response.body?.error!!.contains("50"))
+        assertTrue(response.body?.error!!.contains("5"))
+    }
+}


### PR DESCRIPTION
## Summary

Adds **/keno** as a sibling to baccarat / coinflip / dice / etc. — same shape end-to-end (pure-logic engine, lock-then-mutate service, web controller with picker UI, Discord slash command, all new). Picks 1-10 numbers from a 1-80 pool; the bot draws 20; the per-spots paytable lookup decides the multiplier. Top end is **165,000×** on a 10/10 ticket — astronomically rare.

### Variant + paytable

- Pool 1-80, 20 drawn, picks 1-10 spots (standard Vegas keno).
- Stakes 10-500 credits (matches baccarat).
- Per-spots paytable tuned to **0.83-0.92 RTP** (slots tier).
- RTP is verified in `KenoTest` by deriving every payout from the hypergeometric distribution `P(k|spots) = C(spots,k)·C(80-spots,20-k)/C(80,20)` and asserting the sum lands in band — guards against drift if a multiplier cell is edited.

### Files

**Backend (Kotlin)**
- `database/.../economy/Keno.kt` — pure engine
- `database/.../service/KenoService.kt` — same lock-then-mutate flow as `BaccaratService` via `WagerHelper.checkLockOrTopUp` / `applyMultiplier` / `JackpotHelper`
- `web/.../controller/KenoController.kt` — `GET /casino/{guildId}/keno` page + `POST .../play` JSON; `KenoPlayResponse` implements `CasinoResponseLike` so the `X-Jackpot-Pool` header advice rides for free

**Web UI**
- `templates/keno.html` — 8×10 picker grid + Quick Pick + Clear + stake form + jackpot banner + paytable + **how-to-play rules section** (per request)
- `static/css/keno.css` — `@import casino-table.css`; cells reuse `.casino-card-face`; hits pulse gold via `casino-pulse`; misses dim grey; paytable horizontal-scrolls on phones
- `static/js/keno.js` — picks toggle, Quick Pick, **staged draw reveal** (same setTimeout-orchestration pattern as `playBaccaratDeal`)

**Discord**
- `KenoCommand.kt` — `/keno stake:<int> [spots:<int>] [picks:<csv>]`. Defaults to spots=5; auto-quick-picks if `picks` is omitted
- `KenoEmbeds.kt` — outcome embed shows picks (hits **bolded**) + sorted draws (matches **bolded**) + multiplier + net + jackpot/tribute lines

**Wiring**
- Casino dropdown navbar entry + `/casino/guilds` tile
- Navbar test extended

### Reused primitives (no new abstractions)

- `WagerHelper.checkLockOrTopUp` (stake validation + balance check + optional TOBY top-up)
- `JackpotHelper.rollOnWin` / `divertOnLoss`
- `CasinoOutcomeMapper` / `CasinoPageContext` / `CasinoResponseLike`
- `WagerCommandEmbeds` / `WagerCommandFailure` / `WagerCommandColors`
- `.casino-felt` / `.casino-card-face` / `--casino-active-glow` / `casino-pulse`
- `CasinoRender.flashWinPayout` / `CasinoSounds.play` / `TobyCasinoResult.render`

### Discord UX

```
/keno stake:50                                  → quick-picks 5 spots, resolves
/keno stake:100 spots:8                         → quick-picks 8 spots
/keno stake:200 spots:10 picks:7,12,18,23,33,42,55,61,70,77   → user picks
```

Bad picks (count mismatch, out of range, duplicates, non-numeric) surface a uniform error embed without touching the wallet.

### Web UX

Tap up to 10 cells. **Quick Pick** fills the rest. Submit → server returns picks/draws/hits/multiplier/net. JS reveals the 20 draws one-by-one at ~120 ms each (gold pulse on hits, grey panel on misses) with the per-cell click cue, then the result line + chip flourish + win/lose sound land. Rules + paytable sit underneath.

## Test plan

- [x] `:database:test` — 19 engine + 12 service tests pass; RTP test asserts the band per spot count.
- [x] `:web:test` — 12 controller tests pass.
- [x] `npm test` — 21 jest suites / **257 tests** pass (8 new for keno + 1 navbar update).
- [x] `npm run lint:css` — clean.
- [ ] CI runs `:discord-bot:test` (12 KenoCommand tests). Sandbox blocked the libdave pom fetch from `maven.lavalink.dev` so I couldn't verify locally; CI has the right network access.
- [ ] Smoke test in browser: pick 5 numbers, deal, watch the 20 draws light up, hits pulse gold, chip stack pops on a winning round.
- [ ] Smoke test in Discord: `/keno stake:50` → embed shows quick-picked numbers + draws (hits **bolded**) + verdict.

https://claude.ai/code/session_01KToQred514qQMSvQgzG8Yk

---
_Generated by [Claude Code](https://claude.ai/code/session_01KToQred514qQMSvQgzG8Yk)_