### PR TITLE
fix(casino web): unwrap ResponseEntity in JackpotPoolHeaderAdvice so the banner updates

### DIFF
--- a/web/src/main/kotlin/web/casino/JackpotPoolHeaderAdvice.kt
+++ b/web/src/main/kotlin/web/casino/JackpotPoolHeaderAdvice.kt
@@ -2,6 +2,8 @@ package web.casino
 
 import database.service.JackpotService
 import org.springframework.core.MethodParameter
+import org.springframework.core.ResolvableType
+import org.springframework.http.HttpEntity
 import org.springframework.http.MediaType
 import org.springframework.http.converter.HttpMessageConverter
 import org.springframework.http.server.ServerHttpRequest
@@ -27,10 +29,27 @@ class JackpotPoolHeaderAdvice(
     private val jackpotService: JackpotService,
 ) : ResponseBodyAdvice<CasinoResponseLike> {
 
+    /**
+     * Spring's [org.springframework.web.servlet.mvc.method.annotation.HttpEntityMethodProcessor]
+     * passes the OUTER [MethodParameter] (whose `parameterType == ResponseEntity::class.java`)
+     * into [ResponseBodyAdvice.supports]. Every casino controller returns
+     * `ResponseEntity<XxxResponse>`, so a naive `isAssignableFrom(parameterType)`
+     * check would always be `false` and the advice would never fire. Unwrap
+     * [HttpEntity] generics first so both `ResponseEntity<CasinoResponseLike>`
+     * and a direct `CasinoResponseLike` return are matched.
+     */
     override fun supports(
         returnType: MethodParameter,
         converterType: Class<out HttpMessageConverter<*>>,
-    ): Boolean = CasinoResponseLike::class.java.isAssignableFrom(returnType.parameterType)
+    ): Boolean {
+        val resolvable = ResolvableType.forMethodParameter(returnType)
+        val payload = if (HttpEntity::class.java.isAssignableFrom(resolvable.toClass())) {
+            resolvable.getGeneric(0).resolve()
+        } else {
+            resolvable.resolve()
+        } ?: return false
+        return CasinoResponseLike::class.java.isAssignableFrom(payload)
+    }
 
     override fun beforeBodyWrite(
         body: CasinoResponseLike?,

--- a/web/src/test/kotlin/web/casino/JackpotPoolHeaderAdviceMvcTest.kt
+++ b/web/src/test/kotlin/web/casino/JackpotPoolHeaderAdviceMvcTest.kt
@@ -1,0 +1,76 @@
+package web.casino
+
+import database.service.JackpotService
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import org.springframework.http.ResponseEntity
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.header
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * End-to-end slice test for [JackpotPoolHeaderAdvice]. Wires the advice
+ * through Spring's real `HttpEntityMethodProcessor` path with a tiny inline
+ * controller, so it actually exercises the case the unit test mocks away —
+ * `ResponseEntity<CasinoResponseLike>` returns where the outer
+ * `MethodParameter.parameterType` is `ResponseEntity::class.java` and the
+ * advice has to unwrap the generic itself. This is the regression guard
+ * that ensures the bug fixed in #ee98f7b's follow-up cannot silently
+ * re-introduce — the unit test alone could not have caught it.
+ */
+class JackpotPoolHeaderAdviceMvcTest {
+
+    data class StubResponse(
+        override val ok: Boolean = true,
+        override val error: String? = null,
+    ) : CasinoResponseLike
+
+    @RestController
+    class StubController {
+        @GetMapping("/casino/{guildId}/stub/wrapped")
+        fun wrapped(@PathVariable guildId: Long): ResponseEntity<StubResponse> =
+            ResponseEntity.ok(StubResponse())
+
+        @GetMapping("/casino/{guildId}/stub/direct")
+        fun direct(@PathVariable guildId: Long): StubResponse = StubResponse()
+
+        @GetMapping("/casino/{guildId}/stub/string")
+        fun plainString(@PathVariable guildId: Long): ResponseEntity<String> =
+            ResponseEntity.ok("nope")
+    }
+
+    private fun mvc(jackpotService: JackpotService): MockMvc =
+        MockMvcBuilders.standaloneSetup(StubController())
+            .setControllerAdvice(JackpotPoolHeaderAdvice(jackpotService))
+            .build()
+
+    @Test
+    fun `stamps X-Jackpot-Pool on ResponseEntity-wrapped casino response`() {
+        val svc = mockk<JackpotService>().also { every { it.getPool(42L) } returns 12_345L }
+        mvc(svc).perform(get("/casino/42/stub/wrapped"))
+            .andExpect(status().isOk)
+            .andExpect(header().string(JackpotPoolHeaderAdvice.HEADER, "12345"))
+    }
+
+    @Test
+    fun `stamps X-Jackpot-Pool on direct casino response`() {
+        val svc = mockk<JackpotService>().also { every { it.getPool(7L) } returns 99L }
+        mvc(svc).perform(get("/casino/7/stub/direct"))
+            .andExpect(status().isOk)
+            .andExpect(header().string(JackpotPoolHeaderAdvice.HEADER, "99"))
+    }
+
+    @Test
+    fun `does not stamp header on non-casino ResponseEntity`() {
+        val svc = mockk<JackpotService>(relaxed = true)
+        mvc(svc).perform(get("/casino/1/stub/string"))
+            .andExpect(status().isOk)
+            .andExpect(header().doesNotExist(JackpotPoolHeaderAdvice.HEADER))
+    }
+}

--- a/web/src/test/kotlin/web/casino/JackpotPoolHeaderAdviceTest.kt
+++ b/web/src/test/kotlin/web/casino/JackpotPoolHeaderAdviceTest.kt
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.core.MethodParameter
 import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter
 import org.springframework.http.server.ServerHttpResponse
 import org.springframework.http.server.ServletServerHttpRequest
@@ -27,6 +28,14 @@ import org.springframework.web.servlet.HandlerMapping
  * test — every CasinoResponseLike response carries the post-action
  * pool size in the X-Jackpot-Pool header, and the JS reads it from
  * api.js. Adding a new minigame can no longer regress the banner.
+ *
+ * The [methodParameter] helper resolves real reflective method handles
+ * rather than mocking [MethodParameter.parameterType]. A pure mock
+ * implementation hides the [ResponseEntity] unwrapping bug — Spring's
+ * [org.springframework.web.servlet.mvc.method.annotation.HttpEntityMethodProcessor]
+ * passes the outer ResponseEntity MethodParameter to
+ * [org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice.supports],
+ * so the advice has to unwrap the generic itself.
  */
 class JackpotPoolHeaderAdviceTest {
 
@@ -41,15 +50,23 @@ class JackpotPoolHeaderAdviceTest {
     }
 
     @Test
-    fun `supports returns true for CasinoResponseLike return types`() {
-        val param = methodParameterReturning(SampleResponse::class.java)
-        assertTrue(advice.supports(param, MappingJackson2HttpMessageConverter::class.java))
+    fun `supports returns true for direct CasinoResponseLike subtype`() {
+        assertTrue(advice.supports(methodParameter("direct"), MappingJackson2HttpMessageConverter::class.java))
     }
 
     @Test
-    fun `supports returns false for non-CasinoResponseLike return types`() {
-        val param = methodParameterReturning(String::class.java)
-        assertFalse(advice.supports(param, MappingJackson2HttpMessageConverter::class.java))
+    fun `supports returns true for ResponseEntity wrapping CasinoResponseLike`() {
+        assertTrue(advice.supports(methodParameter("wrapped"), MappingJackson2HttpMessageConverter::class.java))
+    }
+
+    @Test
+    fun `supports returns false for ResponseEntity wrapping non-CasinoResponseLike`() {
+        assertFalse(advice.supports(methodParameter("nonCasinoWrapped"), MappingJackson2HttpMessageConverter::class.java))
+    }
+
+    @Test
+    fun `supports returns false for plain non-casino return type`() {
+        assertFalse(advice.supports(methodParameter("plainString"), MappingJackson2HttpMessageConverter::class.java))
     }
 
     @Test
@@ -60,7 +77,7 @@ class JackpotPoolHeaderAdviceTest {
 
         val returned = advice.beforeBodyWrite(
             body = body,
-            returnType = methodParameterReturning(SampleResponse::class.java),
+            returnType = methodParameter("direct"),
             selectedContentType = MediaType.APPLICATION_JSON,
             selectedConverterType = MappingJackson2HttpMessageConverter::class.java,
             request = request,
@@ -76,7 +93,7 @@ class JackpotPoolHeaderAdviceTest {
         val (request, response) = exchangeWithVars(emptyMap())
         advice.beforeBodyWrite(
             body = SampleResponse(ok = true),
-            returnType = methodParameterReturning(SampleResponse::class.java),
+            returnType = methodParameter("direct"),
             selectedContentType = MediaType.APPLICATION_JSON,
             selectedConverterType = MappingJackson2HttpMessageConverter::class.java,
             request = request,
@@ -90,7 +107,7 @@ class JackpotPoolHeaderAdviceTest {
         val (request, response) = exchangeWithGuildId("not-a-long")
         advice.beforeBodyWrite(
             body = SampleResponse(ok = true),
-            returnType = methodParameterReturning(SampleResponse::class.java),
+            returnType = methodParameter("direct"),
             selectedContentType = MediaType.APPLICATION_JSON,
             selectedConverterType = MappingJackson2HttpMessageConverter::class.java,
             request = request,
@@ -107,7 +124,7 @@ class JackpotPoolHeaderAdviceTest {
 
         val returned = advice.beforeBodyWrite(
             body = body,
-            returnType = methodParameterReturning(SampleResponse::class.java),
+            returnType = methodParameter("direct"),
             selectedContentType = MediaType.APPLICATION_JSON,
             selectedConverterType = MappingJackson2HttpMessageConverter::class.java,
             request = request,
@@ -123,11 +140,16 @@ class JackpotPoolHeaderAdviceTest {
         override val error: String? = null,
     ) : CasinoResponseLike
 
-    private fun methodParameterReturning(type: Class<*>): MethodParameter {
-        val param = mockk<MethodParameter>()
-        every { param.parameterType } returns type
-        return param
+    @Suppress("unused")
+    private class Sample {
+        fun direct(): SampleResponse = SampleResponse(ok = true)
+        fun wrapped(): ResponseEntity<SampleResponse> = ResponseEntity.ok(SampleResponse(ok = true))
+        fun nonCasinoWrapped(): ResponseEntity<String> = ResponseEntity.ok("nope")
+        fun plainString(): String = "nope"
     }
+
+    private fun methodParameter(name: String): MethodParameter =
+        MethodParameter(Sample::class.java.getDeclaredMethod(name), -1)
 
     private fun exchangeWithGuildId(guildIdValue: String): Pair<ServletServerHttpRequest, ServerHttpResponse> =
         exchangeWithVars(mapOf("guildId" to guildIdValue))


### PR DESCRIPTION
## Summary

The per-guild jackpot pool banner never updated automatically after a loss in baccarat, blackjack, or any other casino game. The pool was being updated server-side correctly — `divertOnLoss` ran, the database moved, the next page reload showed the new value — but the banner stayed stale until reload.

The end-to-end pipeline was wired up correctly across three previous attempts (#362, #373, #377):

- `JackpotPoolHeaderAdvice` (`@ControllerAdvice`) was supposed to stamp `X-Jackpot-Pool: <new pool>` onto every casino JSON response.
- `api.js` reads `r.headers.get('X-Jackpot-Pool')` after every `TobyApi.postJson` and calls `TobyJackpot.updatePoolBanner({ jackpotPool })`.
- `casino-jackpot.js` writes the value into `.casino-jackpot-banner strong`.
- All casino response classes (`BlackjackActionResponse`, `BaccaratPlayResponse`, `SpinResponse`, `FlipResponse`, etc.) implement `CasinoResponseLike`.

So why didn't it work?

## Root cause

`JackpotPoolHeaderAdvice.supports()` was:

```kotlin
override fun supports(returnType: MethodParameter, …): Boolean =
    CasinoResponseLike::class.java.isAssignableFrom(returnType.parameterType)
```

Every casino controller returns `ResponseEntity<XxxResponse>`. Spring's `HttpEntityMethodProcessor` invokes `ResponseBodyAdvice.supports()` with the **outer** `MethodParameter`, where `parameterType == ResponseEntity::class.java`. `CasinoResponseLike.isAssignableFrom(ResponseEntity)` is `false`, so the advice never fired and the header was never stamped on any casino response.

The existing unit test masked this — `methodParameterReturning(...)` was a `mockk<MethodParameter>()` that stubbed `parameterType` to return the inner class directly, simulating an `@ResponseBody T` return rather than a real `ResponseEntity<T>`. The advice's mock-driven test passed; the real Spring runtime did not.

## Fix

Unwrap `HttpEntity` generics in `supports()` via `ResolvableType.forMethodParameter` so both `ResponseEntity<CasinoResponseLike>` and a direct `CasinoResponseLike` return are matched. `beforeBodyWrite` doesn't need to change — Spring already unwraps the body before calling it, so the existing `body: CasinoResponseLike?` signature stays type-safe.

```kotlin
override fun supports(returnType, converterType): Boolean {
    val resolvable = ResolvableType.forMethodParameter(returnType)
    val payload = if (HttpEntity::class.java.isAssignableFrom(resolvable.toClass())) {
        resolvable.getGeneric(0).resolve()
    } else {
        resolvable.resolve()
    } ?: return false
    return CasinoResponseLike::class.java.isAssignableFrom(payload)
}
```

## Tests

- Replaced the `mockk<MethodParameter>` helper in `JackpotPoolHeaderAdviceTest` with a reflection-based one against a real `Sample` class with `direct() / wrapped() / nonCasinoWrapped() / plainString()` methods. This is what the original test should have done — and it would have caught the bug.
- Added four new `supports` cases: direct `CasinoResponseLike`, `ResponseEntity<CasinoResponseLike>`, `ResponseEntity<String>`, plain `String`. The four pre-existing `beforeBodyWrite` cases still pass under the new helper.
- Added `JackpotPoolHeaderAdviceMvcTest` — a `MockMvcBuilders.standaloneSetup` slice that wires the advice through Spring's real `HttpEntityMethodProcessor` path with a tiny inline `@RestController`. Asserts the header is present on `ResponseEntity<CasinoResponseLike>`, present on direct `CasinoResponseLike`, and absent on `ResponseEntity<String>`. This is the regression guard that ensures this exact bug class cannot silently re-introduce.

## Test plan

- [x] `./gradlew :web:test --tests 'web.casino.JackpotPoolHeaderAdviceTest' --tests 'web.casino.JackpotPoolHeaderAdviceMvcTest'` passes.
- [x] `./gradlew :web:test` passes (no controller-test regressions).
- [ ] Manual: open `/casino/{guildId}/baccarat`, place a losing bet, confirm the banner updates without reload.
- [ ] Manual: `/blackjack/{guildId}/solo` — deal then bust on hit, confirm banner updates on the resolving POST response.
- [ ] DevTools → Network → confirm the play response carries `X-Jackpot-Pool` and the value matches the new banner contents.
- [ ] Spot-check one more game (slots / dice) for confidence in the shared mechanism.

https://claude.ai/code/session_012wCaRwkt779UuwaM6FaDgV

---
_Generated by [Claude Code](https://claude.ai/code/session_012wCaRwkt779UuwaM6FaDgV)_