### PR TITLE
fix(activity): actually enable CacheFlag.ACTIVITY (PR #298 wasn't enough)

### DIFF
--- a/discord-bot/src/main/kotlin/bot/configuration/BotConfig.kt
+++ b/discord-bot/src/main/kotlin/bot/configuration/BotConfig.kt
@@ -52,7 +52,7 @@ class BotConfig {
                     CacheFlag.SCHEDULED_EVENTS
                 )
             )
-            .enableCache(CacheFlag.VOICE_STATE, CacheFlag.EMOJI)
+            .enableCache(CacheFlag.VOICE_STATE, CacheFlag.EMOJI, CacheFlag.ACTIVITY)
             .setAudioModuleConfig(AudioModuleConfig().withDaveSessionFactory(LDJDADaveSessionFactory(NativeDaveFactory())))
             .build()
     }


### PR DESCRIPTION
## Why

Game-activity tracking is **still** silently broken — `/activity me` shows nothing, no rows land in `activity_session`. PR #298 thought it had fixed exactly this symptom by removing `CacheFlag.ACTIVITY` from the explicit `disableCache(...)` set in `BotConfig`, but that change had no effect: `JDABuilder.createDefault(...)` *unconditionally* calls `disableCache(CacheFlag.getPrivileged())` (= ACTIVITY + CLIENT_STATUS + ONLINE_STATUS) inside its `applyDefault()` regardless of which intents you pass in. The flag has to be **re-enabled** via `enableCache(...)` to take effect — confirmed against [JDA v6.3.1 source](https://github.com/discord-jda/JDA/blob/v6.3.1/src/main/java/net/dv8tion/jda/api/JDABuilder.java).

With ACTIVITY disabled, JDA never delivers `UserUpdateActivitiesEvent`, so `ActivityEventHandler.onUserUpdateActivities` never fires — the rest of the pipeline (`ActivityTrackingService`, the rollup, `/activity` command) is fine; it's just never invoked.

## Fix

One line: add `CacheFlag.ACTIVITY` to the existing `enableCache(...)` call. `CLIENT_STATUS` and `ONLINE_STATUS` stay disabled — neither is read anywhere.

## Why CI didn't catch this (either time)

- `ActivityEventHandlerTest` mocks `UserUpdateActivitiesEvent` directly, bypassing JDA's gateway/cache layer entirely.
- `TestBotConfig` provides a mock `JDA` bean under the `test` profile, so the real `BotConfig` is never exercised.

A proper regression guard would need to assert against `JDABuilder`'s configured cache flags before `build()`, but JDA exposes no public getter for that — punted as out of scope.

## Test plan

- [ ] CI green (no test changes needed — JDA gateway-config flip)
- [ ] After deploy, in a guild with `ACTIVITY_TRACKING=true` and the test user not opted out:
  - [ ] Play any `Activity.ActivityType.PLAYING` game for >60s, then stop.
  - [ ] Bot logs contain `Activity change for <id> in <guild>: 'null' -> '<game>'` (open) and `'<game>' -> 'null'` (close) — from `ActivityEventHandler:37`. The presence of the open log line is the cleanest signal that ACTIVITY is now enabled.
  - [ ] `/activity me` shows the game with the recorded duration under "This month".
  - [ ] `/activity server` shows the game in the top-games list.

https://claude.ai/code/session_01MdZB2HqM39znTgmnHs2Dyw

---
_Generated by [Claude Code](https://claude.ai/code/session_01MdZB2HqM39znTgmnHs2Dyw)_