### PR TITLE
refactor: extract shared casino-game scaffolding (backend + frontend + discord-bot)

### DIFF
--- a/common/src/main/kotlin/common/casino/CasinoCommonFailure.kt
+++ b/common/src/main/kotlin/common/casino/CasinoCommonFailure.kt
@@ -1,0 +1,38 @@
+package common.casino
+
+/**
+ * Marker interface implemented by the four standard failure outcomes
+ * shared across every casino-game service (Dice, Coinflip, Slots,
+ * Scratch, Highlow, Baccarat, etc.).
+ *
+ * Each per-game `*Outcome` sealed hierarchy used to declare its own
+ * `InsufficientCredits(stake, have)`, `InsufficientCoinsForTopUp(needed,
+ * have)`, `InvalidStake(min, max)` and `UnknownUser` types — all with
+ * identical fields and identical mapping into the controller's error
+ * response. By having those nested types implement these interfaces, a
+ * controller's `when` block can collapse four arms into one
+ * `is CasinoCommonFailure -> errors.mapCommonFailure(outcome)`.
+ *
+ * The interfaces live in `common/` so `database/` services can declare
+ * them on their outcome types and `web/` controllers can pattern-match
+ * on them, without either side depending on the other.
+ */
+sealed interface CasinoCommonFailure {
+
+    interface InsufficientCredits : CasinoCommonFailure {
+        val stake: Long
+        val have: Long
+    }
+
+    interface InsufficientCoinsForTopUp : CasinoCommonFailure {
+        val needed: Long
+        val have: Long
+    }
+
+    interface InvalidStake : CasinoCommonFailure {
+        val min: Long
+        val max: Long
+    }
+
+    interface UnknownUser : CasinoCommonFailure
+}

--- a/common/src/main/kotlin/common/discord/EmbedDsl.kt
+++ b/common/src/main/kotlin/common/discord/EmbedDsl.kt
@@ -1,0 +1,42 @@
+package common.discord
+
+import net.dv8tion.jda.api.EmbedBuilder
+import net.dv8tion.jda.api.entities.MessageEmbed
+import java.awt.Color
+
+/**
+ * Kotlin-idiomatic builder for `MessageEmbed`. Replaces the verbose
+ * `EmbedBuilder().setTitle(...).setColor(...).addField(...).build()`
+ * chain that appears in 35+ command and helper files (heaviest
+ * concentration in `MusicPlayerHelper` — 7 sites in one file).
+ *
+ *   val embed = embed(title = "Oops", color = Color.RED) {
+ *       field("Reason", reason)
+ *       setFooter("Try again later")
+ *   }
+ *
+ * The DSL is lightweight on purpose: callers still have full
+ * `EmbedBuilder` access inside the lambda for the unusual cases
+ * (timestamps, thumbnails, author blocks, etc.) — only the common
+ * scaffolding is pre-applied.
+ */
+inline fun embed(
+    title: String? = null,
+    description: String? = null,
+    color: Color? = null,
+    block: EmbedBuilder.() -> Unit = {},
+): MessageEmbed = EmbedBuilder().apply {
+    title?.let { setTitle(it) }
+    description?.let { setDescription(it) }
+    color?.let { setColor(it) }
+    block()
+}.build()
+
+/**
+ * Field-builder shorthand. Returns the receiver so calls chain inside
+ * the [embed] block:
+ *
+ *   embed { field("Total", "42").field("Detail", "...", inline = true) }
+ */
+fun EmbedBuilder.field(name: String, value: String, inline: Boolean = false): EmbedBuilder =
+    addField(name, value, inline)

--- a/core-api/src/main/kotlin/core/command/Command.kt
+++ b/core-api/src/main/kotlin/core/command/Command.kt
@@ -3,6 +3,7 @@ package core.command
 import common.logging.DiscordLogger
 import database.dto.UserDto
 import net.dv8tion.jda.api.entities.Message
+import net.dv8tion.jda.api.entities.MessageEmbed
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
 import net.dv8tion.jda.api.interactions.InteractionHook
 import net.dv8tion.jda.api.interactions.commands.build.Commands
@@ -53,6 +54,26 @@ interface Command {
         @JvmStatic
         fun invokeDeleteOnHookResponse(deleteDelay: Int): Consumer<InteractionHook> {
             return Consumer { hook -> hook.deleteAfter(deleteDelay) }
+        }
+
+        /**
+         * `event.hook.sendMessage(msg).queue(invokeDeleteOnMessageResponse(d))`
+         * appears in 50+ command files. The extensions below collapse it to
+         * `event.hook.replyAndDelete(msg, d)` (and equivalents for embeds /
+         * ephemeral replies) so a future tweak to the queue-and-delete
+         * contract — or to the queue-cancel handler when it grows — is one
+         * edit instead of fifty.
+         */
+        fun InteractionHook.replyAndDelete(message: String, deleteDelay: Int) {
+            sendMessage(message).queue(invokeDeleteOnMessageResponse(deleteDelay))
+        }
+
+        fun InteractionHook.replyEmbedAndDelete(embed: MessageEmbed, deleteDelay: Int) {
+            sendMessageEmbeds(embed).queue(invokeDeleteOnMessageResponse(deleteDelay))
+        }
+
+        fun InteractionHook.replyEphemeralAndDelete(message: String, deleteDelay: Int) {
+            sendMessage(message).setEphemeral(true).queue(invokeDeleteOnMessageResponse(deleteDelay))
         }
     }
 }

--- a/database/src/main/kotlin/database/service/BaccaratService.kt
+++ b/database/src/main/kotlin/database/service/BaccaratService.kt
@@ -1,5 +1,6 @@
 package database.service
 
+import common.casino.CasinoCommonFailure
 import database.card.Card
 import database.card.Deck
 import database.economy.Baccarat
@@ -83,10 +84,13 @@ class BaccaratService(
             val lossTribute: Long = 0L
         ) : PlayOutcome
 
-        data class InsufficientCredits(val stake: Long, val have: Long) : PlayOutcome
-        data class InsufficientCoinsForTopUp(val needed: Long, val have: Long) : PlayOutcome
-        data class InvalidStake(val min: Long, val max: Long) : PlayOutcome
-        data object UnknownUser : PlayOutcome
+        data class InsufficientCredits(override val stake: Long, override val have: Long) :
+            PlayOutcome, CasinoCommonFailure.InsufficientCredits
+        data class InsufficientCoinsForTopUp(override val needed: Long, override val have: Long) :
+            PlayOutcome, CasinoCommonFailure.InsufficientCoinsForTopUp
+        data class InvalidStake(override val min: Long, override val max: Long) :
+            PlayOutcome, CasinoCommonFailure.InvalidStake
+        data object UnknownUser : PlayOutcome, CasinoCommonFailure.UnknownUser
     }
 
     /**

--- a/database/src/main/kotlin/database/service/CoinflipService.kt
+++ b/database/src/main/kotlin/database/service/CoinflipService.kt
@@ -1,5 +1,6 @@
 package database.service
 
+import common.casino.CasinoCommonFailure
 import database.economy.Coinflip
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -51,10 +52,13 @@ class CoinflipService(
             val lossTribute: Long = 0L,
         ) : FlipOutcome
 
-        data class InsufficientCredits(val stake: Long, val have: Long) : FlipOutcome
-        data class InsufficientCoinsForTopUp(val needed: Long, val have: Long) : FlipOutcome
-        data class InvalidStake(val min: Long, val max: Long) : FlipOutcome
-        data object UnknownUser : FlipOutcome
+        data class InsufficientCredits(override val stake: Long, override val have: Long) :
+            FlipOutcome, CasinoCommonFailure.InsufficientCredits
+        data class InsufficientCoinsForTopUp(override val needed: Long, override val have: Long) :
+            FlipOutcome, CasinoCommonFailure.InsufficientCoinsForTopUp
+        data class InvalidStake(override val min: Long, override val max: Long) :
+            FlipOutcome, CasinoCommonFailure.InvalidStake
+        data object UnknownUser : FlipOutcome, CasinoCommonFailure.UnknownUser
     }
 
     fun flip(

--- a/database/src/main/kotlin/database/service/DiceService.kt
+++ b/database/src/main/kotlin/database/service/DiceService.kt
@@ -1,5 +1,6 @@
 package database.service
 
+import common.casino.CasinoCommonFailure
 import database.economy.Dice
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -50,11 +51,14 @@ class DiceService(
             val lossTribute: Long = 0L,
         ) : RollOutcome
 
-        data class InsufficientCredits(val stake: Long, val have: Long) : RollOutcome
-        data class InsufficientCoinsForTopUp(val needed: Long, val have: Long) : RollOutcome
-        data class InvalidStake(val min: Long, val max: Long) : RollOutcome
+        data class InsufficientCredits(override val stake: Long, override val have: Long) :
+            RollOutcome, CasinoCommonFailure.InsufficientCredits
+        data class InsufficientCoinsForTopUp(override val needed: Long, override val have: Long) :
+            RollOutcome, CasinoCommonFailure.InsufficientCoinsForTopUp
+        data class InvalidStake(override val min: Long, override val max: Long) :
+            RollOutcome, CasinoCommonFailure.InvalidStake
         data class InvalidPrediction(val min: Int, val max: Int) : RollOutcome
-        data object UnknownUser : RollOutcome
+        data object UnknownUser : RollOutcome, CasinoCommonFailure.UnknownUser
     }
 
     fun roll(

--- a/database/src/main/kotlin/database/service/HighlowService.kt
+++ b/database/src/main/kotlin/database/service/HighlowService.kt
@@ -1,5 +1,6 @@
 package database.service
 
+import common.casino.CasinoCommonFailure
 import database.economy.Highlow
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -59,10 +60,13 @@ class HighlowService(
             val lossTribute: Long = 0L,
         ) : PlayOutcome
 
-        data class InsufficientCredits(val stake: Long, val have: Long) : PlayOutcome
-        data class InsufficientCoinsForTopUp(val needed: Long, val have: Long) : PlayOutcome
-        data class InvalidStake(val min: Long, val max: Long) : PlayOutcome
-        data object UnknownUser : PlayOutcome
+        data class InsufficientCredits(override val stake: Long, override val have: Long) :
+            PlayOutcome, CasinoCommonFailure.InsufficientCredits
+        data class InsufficientCoinsForTopUp(override val needed: Long, override val have: Long) :
+            PlayOutcome, CasinoCommonFailure.InsufficientCoinsForTopUp
+        data class InvalidStake(override val min: Long, override val max: Long) :
+            PlayOutcome, CasinoCommonFailure.InvalidStake
+        data object UnknownUser : PlayOutcome, CasinoCommonFailure.UnknownUser
     }
 
     /** Draw a fresh anchor without committing any state. The web flow uses this on page load. */

--- a/database/src/main/kotlin/database/service/ScratchService.kt
+++ b/database/src/main/kotlin/database/service/ScratchService.kt
@@ -1,5 +1,6 @@
 package database.service
 
+import common.casino.CasinoCommonFailure
 import database.economy.ScratchCard
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -48,10 +49,13 @@ class ScratchService(
             val lossTribute: Long = 0L,
         ) : ScratchOutcome
 
-        data class InsufficientCredits(val stake: Long, val have: Long) : ScratchOutcome
-        data class InsufficientCoinsForTopUp(val needed: Long, val have: Long) : ScratchOutcome
-        data class InvalidStake(val min: Long, val max: Long) : ScratchOutcome
-        data object UnknownUser : ScratchOutcome
+        data class InsufficientCredits(override val stake: Long, override val have: Long) :
+            ScratchOutcome, CasinoCommonFailure.InsufficientCredits
+        data class InsufficientCoinsForTopUp(override val needed: Long, override val have: Long) :
+            ScratchOutcome, CasinoCommonFailure.InsufficientCoinsForTopUp
+        data class InvalidStake(override val min: Long, override val max: Long) :
+            ScratchOutcome, CasinoCommonFailure.InvalidStake
+        data object UnknownUser : ScratchOutcome, CasinoCommonFailure.UnknownUser
     }
 
     fun scratch(discordId: Long, guildId: Long, stake: Long, autoTopUp: Boolean = false): ScratchOutcome {

--- a/database/src/main/kotlin/database/service/SlotsService.kt
+++ b/database/src/main/kotlin/database/service/SlotsService.kt
@@ -1,5 +1,6 @@
 package database.service
 
+import common.casino.CasinoCommonFailure
 import database.economy.SlotMachine
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -60,10 +61,13 @@ class SlotsService(
             val lossTribute: Long = 0L,
         ) : SpinOutcome
 
-        data class InsufficientCredits(val stake: Long, val have: Long) : SpinOutcome
-        data class InsufficientCoinsForTopUp(val needed: Long, val have: Long) : SpinOutcome
-        data class InvalidStake(val min: Long, val max: Long) : SpinOutcome
-        data object UnknownUser : SpinOutcome
+        data class InsufficientCredits(override val stake: Long, override val have: Long) :
+            SpinOutcome, CasinoCommonFailure.InsufficientCredits
+        data class InsufficientCoinsForTopUp(override val needed: Long, override val have: Long) :
+            SpinOutcome, CasinoCommonFailure.InsufficientCoinsForTopUp
+        data class InvalidStake(override val min: Long, override val max: Long) :
+            SpinOutcome, CasinoCommonFailure.InvalidStake
+        data object UnknownUser : SpinOutcome, CasinoCommonFailure.UnknownUser
     }
 
     fun spin(discordId: Long, guildId: Long, stake: Long, autoTopUp: Boolean = false): SpinOutcome {

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/dnd/RollCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/dnd/RollCommand.kt
@@ -1,15 +1,15 @@
 package bot.toby.command.commands.dnd
 
 import bot.toby.helpers.DnDHelper
+import bot.toby.helpers.intOption
+import common.discord.embed
+import common.discord.field
 import common.events.CampaignEventType
 import core.command.Command.Companion.invokeDeleteOnMessageResponse
 import core.command.CommandContext
 import database.dto.UserDto
-import net.dv8tion.jda.api.EmbedBuilder
 import net.dv8tion.jda.api.entities.Message
-import net.dv8tion.jda.api.entities.MessageEmbed
 import net.dv8tion.jda.api.interactions.callbacks.IReplyCallback
-import net.dv8tion.jda.api.interactions.commands.OptionMapping
 import net.dv8tion.jda.api.interactions.commands.OptionType
 import net.dv8tion.jda.api.interactions.commands.build.OptionData
 import net.dv8tion.jda.api.components.actionrow.ActionRow
@@ -18,7 +18,7 @@ import net.dv8tion.jda.api.requests.restaction.WebhookMessageCreateAction
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 import web.service.SessionLogPublisher
-import java.util.*
+import java.awt.Color
 
 @Component
 class RollCommand @Autowired constructor(
@@ -32,18 +32,10 @@ class RollCommand @Autowired constructor(
     }
     override fun handle(ctx: CommandContext, requestingUserDto: UserDto, deleteDelay: Int) {
         val event = ctx.event
-        val diceValueOptional =
-            Optional.ofNullable(event.getOption(DICE_NUMBER)).map { obj: OptionMapping -> obj.asInt }
-        val diceToRollOptional =
-            Optional.ofNullable(event.getOption(DICE_TO_ROLL)).map { obj: OptionMapping -> obj.asInt }
-        val diceModifierOptional =
-            Optional.ofNullable(event.getOption(MODIFIER)).map { obj: OptionMapping -> obj.asInt }
-        val diceValue = diceValueOptional.orElse(20)
-        val diceToRollInput = diceToRollOptional.orElse(1)
-        val diceToRoll = if (diceToRollInput < 1) 1 else diceToRollInput
-        val modifier = diceModifierOptional.orElse(0)
-        handleDiceRoll(event, diceValue, diceToRoll, modifier).queue(invokeDeleteOnMessageResponse(deleteDelay)
-        )
+        val diceValue = event.intOption(DICE_NUMBER, 20)
+        val diceToRoll = event.intOption(DICE_TO_ROLL, 1).coerceAtLeast(1)
+        val modifier = event.intOption(MODIFIER, 0)
+        handleDiceRoll(event, diceValue, diceToRoll, modifier).queue(invokeDeleteOnMessageResponse(deleteDelay))
     }
 
     fun handleDiceRoll(
@@ -55,24 +47,23 @@ class RollCommand @Autowired constructor(
         event.deferReply().queue()
         val rollTotal = dndHelper.rollDice(diceValue, diceToRoll)
         publishRollEvent(event, diceValue, diceToRoll, modifier, rollTotal)
-        val sb = StringBuilder().append(
-            String.format("Your final roll total was '%d' (%d + %d).", rollTotal + modifier, rollTotal, modifier)
+        val rollSummary = String.format(
+            "Your final roll total was '%d' (%d + %d).",
+            rollTotal + modifier, rollTotal, modifier
         )
-        val embedBuilder = EmbedBuilder()
-            .addField(
-                MessageEmbed.Field(
-                    String.format("%dd%d + %d", diceToRoll, diceValue, modifier),
-                    sb.toString(),
-                    true
-                )
+        val rollEmbed = embed(color = Color.GREEN) {
+            field(
+                name = String.format("%dd%d + %d", diceToRoll, diceValue, modifier),
+                value = rollSummary,
+                inline = true,
             )
-            .setColor(0x00FF00) // Green color
+        }
         val rollD20 = Button.primary("$name:20, 1, 0", "Roll D20")
         val rollD10 = Button.primary("$name:10, 1, 0", "Roll D10")
         val rollD6 = Button.primary("$name:6, 1, 0", "Roll D6")
         val rollD4 = Button.primary("$name:4, 1, 0", "Roll D4")
         return event.hook
-            .sendMessageEmbeds(embedBuilder.build())
+            .sendMessageEmbeds(rollEmbed)
             .addComponents(ActionRow.of(Button.primary("resend_last_request", "Click to Reroll"), rollD20, rollD10, rollD6, rollD4))
     }
 

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/moderation/AdjustUserCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/moderation/AdjustUserCommand.kt
@@ -1,7 +1,9 @@
 package bot.toby.command.commands.moderation
 
 import bot.toby.helpers.UserDtoHelper
+import bot.toby.helpers.stringOption
 import core.command.Command.Companion.invokeDeleteOnMessageResponse
+import core.command.Command.Companion.replyEphemeralAndDelete
 import core.command.CommandContext
 import database.dto.UserDto
 import database.service.UserService
@@ -66,12 +68,13 @@ class AdjustUserCommand @Autowired constructor(
         isOwner: Boolean,
         deleteDelay: Int
     ) {
-        val permission = event.getOption(PERMISSION_NAME)?.asString
+        val permission = event.stringOption(PERMISSION_NAME)
 
         if (permission == null) {
-            event.hook.sendMessage("You did not mention a valid permission to update")
-                .setEphemeral(true)
-                .queue(invokeDeleteOnMessageResponse(deleteDelay))
+            event.hook.replyEphemeralAndDelete(
+                "You did not mention a valid permission to update",
+                deleteDelay,
+            )
             return
         }
 
@@ -110,24 +113,24 @@ class AdjustUserCommand @Autowired constructor(
         deleteDelay: Int
     ): List<Member>? {
         if (!member!!.isOwner && requestingUserDto?.superUser != true) {
-            event.hook.sendMessage(getErrorMessage(guildOwner!!.effectiveName))
-                .setEphemeral(true)
-                .queue(invokeDeleteOnMessageResponse(deleteDelay))
+            event.hook.replyEphemeralAndDelete(getErrorMessage(guildOwner!!.effectiveName), deleteDelay)
             return null
         }
 
         val mentionedMembers = event.getOption(USERS)?.mentions?.members
         if (mentionedMembers.isNullOrEmpty()) {
-            event.hook.sendMessage("You must mention 1 or more Users to adjust permissions of")
-                .setEphemeral(true)
-                .queue(invokeDeleteOnMessageResponse(deleteDelay))
+            event.hook.replyEphemeralAndDelete(
+                "You must mention 1 or more Users to adjust permissions of",
+                deleteDelay,
+            )
             return null
         }
 
-        if (event.getOption(PERMISSION_NAME)?.asString == null) {
-            event.hook.sendMessage("You must mention a permission to adjust for the user you've mentioned.")
-                .setEphemeral(true)
-                .queue(invokeDeleteOnMessageResponse(deleteDelay))
+        if (event.stringOption(PERMISSION_NAME) == null) {
+            event.hook.replyEphemeralAndDelete(
+                "You must mention a permission to adjust for the user you've mentioned.",
+                deleteDelay,
+            )
             return null
         }
 

--- a/discord-bot/src/main/kotlin/bot/toby/helpers/MusicPlayerHelper.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/helpers/MusicPlayerHelper.kt
@@ -7,8 +7,10 @@ import bot.toby.lavaplayer.PlayerManager
 import bot.toby.managers.NowPlayingManager
 import com.sedmelluq.discord.lavaplayer.player.AudioPlayer
 import com.sedmelluq.discord.lavaplayer.track.AudioTrack
+import common.discord.embed
 import common.logging.DiscordLogger
 import core.command.Command.Companion.invokeDeleteOnMessageResponse
+import core.command.Command.Companion.replyEmbedAndDelete
 import database.dto.MusicDto
 import database.dto.UserDto
 import net.dv8tion.jda.api.EmbedBuilder
@@ -102,17 +104,13 @@ object MusicPlayerHelper {
     private fun checkForPlayingTrack(track: AudioTrack?, hook: InteractionHook, deleteDelay: Int): Boolean {
         return if (track == null) {
             logger.warn { "No track is currently playing on guild ${hook.interaction.guild?.idLong}.." }
-            val embed = EmbedBuilder()
-                .setTitle("No Track Playing")
-                .setDescription("There is no track playing currently")
-                .setColor(Color.RED)
-                .build()
-
-            hook.sendMessageEmbeds(embed).setEphemeral(true).queue(
-                invokeDeleteOnMessageResponse(
-                    deleteDelay
-                )
+            val noTrackEmbed = embed(
+                title = "No Track Playing",
+                description = "There is no track playing currently",
+                color = Color.RED,
             )
+            hook.sendMessageEmbeds(noTrackEmbed).setEphemeral(true)
+                .queue(invokeDeleteOnMessageResponse(deleteDelay))
             true
         } else {
             false
@@ -131,14 +129,14 @@ object MusicPlayerHelper {
             }
             musicManager.audioPlayer.isPaused = false
             hook.deleteOriginal().queue()
-            val embed = EmbedBuilder()
-                .setTitle("Player Stopped")
-                .setDescription("The player has been stopped and the queue has been cleared")
-                .setColor(Color.RED)
-                .build()
-
-            hook.sendMessageEmbeds(embed)
-                .queue(invokeDeleteOnMessageResponse(deleteDelay))
+            hook.replyEmbedAndDelete(
+                embed(
+                    title = "Player Stopped",
+                    description = "The player has been stopped and the queue has been cleared",
+                    color = Color.RED,
+                ),
+                deleteDelay,
+            )
             resetMessages(event.guild!!.idLong)
         } else {
             sendDeniedStoppableMessage(hook, musicManager, deleteDelay)
@@ -163,13 +161,14 @@ object MusicPlayerHelper {
     ) {
         val track = audioPlayer.playingTrack
         val hook = event.hook
-        val embed = EmbedBuilder()
-            .setTitle("Track Pause/Resume")
-            .setDescription("$content${track?.info?.title}` by `${track?.info?.author}`")
-            .setColor(Color.CYAN)
-            .build()
-
-        hook.sendMessageEmbeds(embed).queue(invokeDeleteOnMessageResponse(deleteDelay))
+        hook.replyEmbedAndDelete(
+            embed(
+                title = "Track Pause/Resume",
+                description = "$content${track?.info?.title}` by `${track?.info?.author}`",
+                color = Color.CYAN,
+            ),
+            deleteDelay,
+        )
         audioPlayer.isPaused = paused
     }
 
@@ -187,25 +186,26 @@ object MusicPlayerHelper {
         when {
             audioPlayer.playingTrack == null -> {
                 logger.warn { "Attempted to skip tracks but no track is currently playing ." }
-                val embed = EmbedBuilder()
-                    .setTitle("No Track Playing")
-                    .setDescription("There is no track playing currently")
-                    .setColor(Color.RED)
-                    .build()
-
-                hook.sendMessageEmbeds(embed).queue(invokeDeleteOnMessageResponse(deleteDelay))
+                hook.replyEmbedAndDelete(
+                    embed(
+                        title = "No Track Playing",
+                        description = "There is no track playing currently",
+                        color = Color.RED,
+                    ),
+                    deleteDelay,
+                )
                 return
             }
 
             tracksToSkip < 0 -> {
                 logger.warn { "Attempted to skip a negative number of tracks: $tracksToSkip ." }
-                val embed = EmbedBuilder()
-                    .setTitle("Invalid Skip Request")
-                    .setDescription("You're not too bright, but thanks for trying")
-                    .setColor(Color.RED)
-                    .build()
-
-                hook.sendMessageEmbeds(embed).setEphemeral(true).queue(invokeDeleteOnMessageResponse(deleteDelay))
+                val invalidSkipEmbed = embed(
+                    title = "Invalid Skip Request",
+                    description = "You're not too bright, but thanks for trying",
+                    color = Color.RED,
+                )
+                hook.sendMessageEmbeds(invalidSkipEmbed).setEphemeral(true)
+                    .queue(invokeDeleteOnMessageResponse(deleteDelay))
                 return
             }
         }
@@ -218,13 +218,14 @@ object MusicPlayerHelper {
             }
             musicManager.scheduler.isLooping = false
 
-            val embed = EmbedBuilder()
-                .setTitle("Tracks Skipped")
-                .setDescription("Skipped $tracksToSkip track(s)")
-                .setColor(Color.CYAN)
-                .build()
-
-            hook.sendMessageEmbeds(embed).queue(invokeDeleteOnMessageResponse(deleteDelay))
+            hook.replyEmbedAndDelete(
+                embed(
+                    title = "Tracks Skipped",
+                    description = "Skipped $tracksToSkip track(s)",
+                    color = Color.CYAN,
+                ),
+                deleteDelay,
+            )
         } else {
             sendDeniedStoppableMessage(hook, musicManager, deleteDelay)
         }

--- a/discord-bot/src/main/kotlin/bot/toby/helpers/SlashCommandOptions.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/helpers/SlashCommandOptions.kt
@@ -1,0 +1,38 @@
+package bot.toby.helpers
+
+import net.dv8tion.jda.api.entities.Member
+import net.dv8tion.jda.api.entities.User
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
+
+/**
+ * Kotlin-idiomatic accessors for slash-command options. Replaces the
+ * `Optional.ofNullable(event.getOption(NAME)).map { obj.asInt }.orElse(default)`
+ * pattern that appears 25+ times across `bot/toby/command/commands/` —
+ * Java Optional reads as alien noise inside Kotlin code, and the
+ * .orElse(default) chain hides the default value.
+ *
+ *   val sides = event.intOption(DICE_NUMBER, 20)
+ *   val target = event.memberOption(USER_NAME)
+ *   val reason = event.stringOption(REASON)
+ */
+
+fun SlashCommandInteractionEvent.intOption(name: String, default: Int = 0): Int =
+    getOption(name)?.asInt ?: default
+
+fun SlashCommandInteractionEvent.longOption(name: String, default: Long = 0L): Long =
+    getOption(name)?.asLong ?: default
+
+fun SlashCommandInteractionEvent.stringOption(name: String): String? =
+    getOption(name)?.asString
+
+fun SlashCommandInteractionEvent.stringOption(name: String, default: String): String =
+    getOption(name)?.asString ?: default
+
+fun SlashCommandInteractionEvent.booleanOption(name: String, default: Boolean = false): Boolean =
+    getOption(name)?.asBoolean ?: default
+
+fun SlashCommandInteractionEvent.memberOption(name: String): Member? =
+    getOption(name)?.asMember
+
+fun SlashCommandInteractionEvent.userOption(name: String): User? =
+    getOption(name)?.asUser

--- a/web/src/main/kotlin/web/casino/CasinoOutcomeMapper.kt
+++ b/web/src/main/kotlin/web/casino/CasinoOutcomeMapper.kt
@@ -1,5 +1,6 @@
 package web.casino
 
+import common.casino.CasinoCommonFailure
 import org.springframework.http.ResponseEntity
 
 /**
@@ -47,6 +48,21 @@ class CasinoOutcomeMapper<R : CasinoResponseLike>(
 
     fun badRequest(message: String): ResponseEntity<R> =
         ResponseEntity.badRequest().body(errorFactory(message))
+
+    /**
+     * Single-arm fallthrough for the four standard failure types every
+     * casino-game service exposes. Each per-game outcome's
+     * `InsufficientCredits` / `InsufficientCoinsForTopUp` / `InvalidStake`
+     * / `UnknownUser` implements the matching [CasinoCommonFailure]
+     * interface, so a controller's `when` can collapse four arms into one
+     * `is CasinoCommonFailure -> errors.mapCommonFailure(outcome)`.
+     */
+    fun mapCommonFailure(failure: CasinoCommonFailure): ResponseEntity<R> = when (failure) {
+        is CasinoCommonFailure.InsufficientCredits -> insufficientCredits(failure.stake, failure.have)
+        is CasinoCommonFailure.InsufficientCoinsForTopUp -> insufficientCoinsForTopUp(failure.needed, failure.have)
+        is CasinoCommonFailure.InvalidStake -> invalidStake(failure.min, failure.max)
+        is CasinoCommonFailure.UnknownUser -> unknownUser()
+    }
 
     companion object {
         const val NOT_SIGNED_IN = "Not signed in."

--- a/web/src/main/kotlin/web/casino/CasinoPageContext.kt
+++ b/web/src/main/kotlin/web/casino/CasinoPageContext.kt
@@ -8,6 +8,9 @@ import net.dv8tion.jda.api.entities.Guild
 import org.springframework.security.oauth2.core.user.OAuth2User
 import org.springframework.stereotype.Component
 import org.springframework.ui.Model
+import org.springframework.web.servlet.mvc.support.RedirectAttributes
+import web.service.EconomyWebService
+import web.util.WebGuildAccess
 import web.util.displayName
 
 /**
@@ -49,4 +52,35 @@ class CasinoPageContext(
         model.addAttribute("username", user.displayName())
         return guild
     }
+}
+
+/**
+ * Membership guard + page-context populate + bot-kicked fallback +
+ * game-specific rules attributes — the GET-page boilerplate every
+ * minigame controller used to copy verbatim. Returns the template
+ * name to render or a `redirect:` string when guards fail.
+ *
+ * Extension (rather than a method on [CasinoPageContext]) so existing
+ * tests that mock `populate` directly still work — extension dispatch
+ * is static, but the inner `populate` call still routes through the
+ * mocked instance.
+ */
+fun CasinoPageContext.renderMinigamePage(
+    user: OAuth2User,
+    guildId: Long,
+    economyWebService: EconomyWebService,
+    model: Model,
+    ra: RedirectAttributes,
+    template: String,
+    lobbyPath: String = "/casino/guilds",
+    addRulesAttributes: Model.() -> Unit,
+): String = WebGuildAccess.requireMemberForPage(
+    user, guildId, economyWebService, ra, lobbyPath = lobbyPath
+) { discordId ->
+    populate(model, guildId, discordId, user) ?: run {
+        ra.addFlashAttribute("error", "Bot is not in that server.")
+        return@requireMemberForPage "redirect:$lobbyPath"
+    }
+    model.addRulesAttributes()
+    template
 }

--- a/web/src/main/kotlin/web/controller/BaccaratController.kt
+++ b/web/src/main/kotlin/web/controller/BaccaratController.kt
@@ -1,5 +1,6 @@
 package web.controller
 
+import common.casino.CasinoCommonFailure
 import database.economy.Baccarat
 import database.service.BaccaratService
 import database.service.BaccaratService.PlayOutcome
@@ -18,8 +19,10 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes
 import web.casino.CasinoOutcomeMapper
 import web.casino.CasinoPageContext
 import web.casino.CasinoResponseLike
+import web.casino.renderMinigamePage
 import web.service.EconomyWebService
 import web.util.WebGuildAccess
+import web.util.positiveOrNull
 
 /**
  * Web surface for the `/baccarat` minigame. GET renders the picker UI
@@ -50,19 +53,14 @@ class BaccaratController(
         @AuthenticationPrincipal user: OAuth2User,
         model: Model,
         ra: RedirectAttributes
-    ): String = WebGuildAccess.requireMemberForPage(
-        user, guildId, economyWebService, ra, lobbyPath = "/casino/guilds"
-    ) { discordId ->
-        pageContext.populate(model, guildId, discordId, user) ?: run {
-            ra.addFlashAttribute("error", "Bot is not in that server.")
-            return@requireMemberForPage "redirect:/casino/guilds"
-        }
-        model.addAttribute("minStake", Baccarat.MIN_STAKE)
-        model.addAttribute("maxStake", Baccarat.MAX_STAKE)
-        model.addAttribute("playerMultiplier", Baccarat.PLAYER_WIN_MULT)
-        model.addAttribute("bankerMultiplier", Baccarat.BANKER_WIN_MULT)
-        model.addAttribute("tieMultiplier", Baccarat.TIE_WIN_MULT)
-        "baccarat"
+    ): String = pageContext.renderMinigamePage(
+        user, guildId, economyWebService, model, ra, template = "baccarat"
+    ) {
+        addAttribute("minStake", Baccarat.MIN_STAKE)
+        addAttribute("maxStake", Baccarat.MAX_STAKE)
+        addAttribute("playerMultiplier", Baccarat.PLAYER_WIN_MULT)
+        addAttribute("bankerMultiplier", Baccarat.BANKER_WIN_MULT)
+        addAttribute("tieMultiplier", Baccarat.TIE_WIN_MULT)
     }
 
     @PostMapping("/play")
@@ -95,8 +93,8 @@ class BaccaratController(
                     newBalance = outcome.newBalance,
                     win = true,
                     push = false,
-                    jackpotPayout = outcome.jackpotPayout.takeIf { it > 0L },
-                    soldTobyCoins = outcome.soldTobyCoins.takeIf { it > 0L },
+                    jackpotPayout = outcome.jackpotPayout.positiveOrNull(),
+                    soldTobyCoins = outcome.soldTobyCoins.positiveOrNull(),
                     newPrice = outcome.newPrice,
                 )
             )
@@ -118,7 +116,7 @@ class BaccaratController(
                     newBalance = outcome.newBalance,
                     win = false,
                     push = true,
-                    soldTobyCoins = outcome.soldTobyCoins.takeIf { it > 0L },
+                    soldTobyCoins = outcome.soldTobyCoins.positiveOrNull(),
                     newPrice = outcome.newPrice,
                 )
             )
@@ -139,16 +137,13 @@ class BaccaratController(
                     newBalance = outcome.newBalance,
                     win = false,
                     push = false,
-                    soldTobyCoins = outcome.soldTobyCoins.takeIf { it > 0L },
+                    soldTobyCoins = outcome.soldTobyCoins.positiveOrNull(),
                     newPrice = outcome.newPrice,
-                    lossTribute = outcome.lossTribute.takeIf { it > 0L },
+                    lossTribute = outcome.lossTribute.positiveOrNull(),
                 )
             )
 
-            is PlayOutcome.InsufficientCredits -> errors.insufficientCredits(outcome.stake, outcome.have)
-            is PlayOutcome.InsufficientCoinsForTopUp -> errors.insufficientCoinsForTopUp(outcome.needed, outcome.have)
-            is PlayOutcome.InvalidStake -> errors.invalidStake(outcome.min, outcome.max)
-            PlayOutcome.UnknownUser -> errors.unknownUser()
+            is CasinoCommonFailure -> errors.mapCommonFailure(outcome)
         }
     }
 

--- a/web/src/main/kotlin/web/controller/CoinflipController.kt
+++ b/web/src/main/kotlin/web/controller/CoinflipController.kt
@@ -1,5 +1,6 @@
 package web.controller
 
+import common.casino.CasinoCommonFailure
 import database.economy.Coinflip
 import database.service.CoinflipService
 import database.service.CoinflipService.FlipOutcome
@@ -18,8 +19,10 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes
 import web.casino.CasinoOutcomeMapper
 import web.casino.CasinoPageContext
 import web.casino.CasinoResponseLike
+import web.casino.renderMinigamePage
 import web.service.EconomyWebService
 import web.util.WebGuildAccess
+import web.util.positiveOrNull
 
 /**
  * Web surface for the `/coinflip` minigame. GET renders the picker UI
@@ -46,17 +49,12 @@ class CoinflipController(
         @AuthenticationPrincipal user: OAuth2User,
         model: Model,
         ra: RedirectAttributes
-    ): String = WebGuildAccess.requireMemberForPage(
-        user, guildId, economyWebService, ra, lobbyPath = "/casino/guilds"
-    ) { discordId ->
-        pageContext.populate(model, guildId, discordId, user) ?: run {
-            ra.addFlashAttribute("error", "Bot is not in that server.")
-            return@requireMemberForPage "redirect:/casino/guilds"
-        }
-        model.addAttribute("minStake", Coinflip.MIN_STAKE)
-        model.addAttribute("maxStake", Coinflip.MAX_STAKE)
-        model.addAttribute("multiplier", Coinflip.DEFAULT_MULTIPLIER)
-        "coinflip"
+    ): String = pageContext.renderMinigamePage(
+        user, guildId, economyWebService, model, ra, template = "coinflip"
+    ) {
+        addAttribute("minStake", Coinflip.MIN_STAKE)
+        addAttribute("maxStake", Coinflip.MAX_STAKE)
+        addAttribute("multiplier", Coinflip.DEFAULT_MULTIPLIER)
     }
 
     @PostMapping("/flip")
@@ -81,8 +79,8 @@ class CoinflipController(
                     payout = outcome.payout,
                     newBalance = outcome.newBalance,
                     win = true,
-                    jackpotPayout = outcome.jackpotPayout.takeIf { it > 0L },
-                    soldTobyCoins = outcome.soldTobyCoins.takeIf { it > 0L },
+                    jackpotPayout = outcome.jackpotPayout.positiveOrNull(),
+                    soldTobyCoins = outcome.soldTobyCoins.positiveOrNull(),
                     newPrice = outcome.newPrice,
                 )
             )
@@ -96,16 +94,13 @@ class CoinflipController(
                     payout = 0L,
                     newBalance = outcome.newBalance,
                     win = false,
-                    soldTobyCoins = outcome.soldTobyCoins.takeIf { it > 0L },
+                    soldTobyCoins = outcome.soldTobyCoins.positiveOrNull(),
                     newPrice = outcome.newPrice,
-                    lossTribute = outcome.lossTribute.takeIf { it > 0L },
+                    lossTribute = outcome.lossTribute.positiveOrNull(),
                 )
             )
 
-            is FlipOutcome.InsufficientCredits -> errors.insufficientCredits(outcome.stake, outcome.have)
-            is FlipOutcome.InsufficientCoinsForTopUp -> errors.insufficientCoinsForTopUp(outcome.needed, outcome.have)
-            is FlipOutcome.InvalidStake -> errors.invalidStake(outcome.min, outcome.max)
-            FlipOutcome.UnknownUser -> errors.unknownUser()
+            is CasinoCommonFailure -> errors.mapCommonFailure(outcome)
         }
     }
 

--- a/web/src/main/kotlin/web/controller/DiceController.kt
+++ b/web/src/main/kotlin/web/controller/DiceController.kt
@@ -1,5 +1,6 @@
 package web.controller
 
+import common.casino.CasinoCommonFailure
 import database.economy.Dice
 import database.service.DiceService
 import database.service.DiceService.RollOutcome
@@ -18,8 +19,10 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes
 import web.casino.CasinoOutcomeMapper
 import web.casino.CasinoPageContext
 import web.casino.CasinoResponseLike
+import web.casino.renderMinigamePage
 import web.service.EconomyWebService
 import web.util.WebGuildAccess
+import web.util.positiveOrNull
 
 /**
  * Web surface for the `/dice` minigame. GET renders the picker UI;
@@ -44,18 +47,13 @@ class DiceController(
         @AuthenticationPrincipal user: OAuth2User,
         model: Model,
         ra: RedirectAttributes
-    ): String = WebGuildAccess.requireMemberForPage(
-        user, guildId, economyWebService, ra, lobbyPath = "/casino/guilds"
-    ) { discordId ->
-        pageContext.populate(model, guildId, discordId, user) ?: run {
-            ra.addFlashAttribute("error", "Bot is not in that server.")
-            return@requireMemberForPage "redirect:/casino/guilds"
-        }
-        model.addAttribute("minStake", Dice.MIN_STAKE)
-        model.addAttribute("maxStake", Dice.MAX_STAKE)
-        model.addAttribute("sides", Dice.DEFAULT_SIDES)
-        model.addAttribute("multiplier", Dice.DEFAULT_MULTIPLIER)
-        "dice"
+    ): String = pageContext.renderMinigamePage(
+        user, guildId, economyWebService, model, ra, template = "dice"
+    ) {
+        addAttribute("minStake", Dice.MIN_STAKE)
+        addAttribute("maxStake", Dice.MAX_STAKE)
+        addAttribute("sides", Dice.DEFAULT_SIDES)
+        addAttribute("multiplier", Dice.DEFAULT_MULTIPLIER)
     }
 
     @PostMapping("/roll")
@@ -77,8 +75,8 @@ class DiceController(
                     payout = outcome.payout,
                     newBalance = outcome.newBalance,
                     win = true,
-                    jackpotPayout = outcome.jackpotPayout.takeIf { it > 0L },
-                    soldTobyCoins = outcome.soldTobyCoins.takeIf { it > 0L },
+                    jackpotPayout = outcome.jackpotPayout.positiveOrNull(),
+                    soldTobyCoins = outcome.soldTobyCoins.positiveOrNull(),
                     newPrice = outcome.newPrice,
                 )
             )
@@ -92,19 +90,16 @@ class DiceController(
                     payout = 0L,
                     newBalance = outcome.newBalance,
                     win = false,
-                    soldTobyCoins = outcome.soldTobyCoins.takeIf { it > 0L },
+                    soldTobyCoins = outcome.soldTobyCoins.positiveOrNull(),
                     newPrice = outcome.newPrice,
-                    lossTribute = outcome.lossTribute.takeIf { it > 0L },
+                    lossTribute = outcome.lossTribute.positiveOrNull(),
                 )
             )
 
-            is RollOutcome.InsufficientCredits -> errors.insufficientCredits(outcome.stake, outcome.have)
-            is RollOutcome.InsufficientCoinsForTopUp -> errors.insufficientCoinsForTopUp(outcome.needed, outcome.have)
-            is RollOutcome.InvalidStake -> errors.invalidStake(outcome.min, outcome.max)
             is RollOutcome.InvalidPrediction ->
                 errors.badRequest("Pick a number between ${outcome.min} and ${outcome.max}.")
 
-            RollOutcome.UnknownUser -> errors.unknownUser()
+            is CasinoCommonFailure -> errors.mapCommonFailure(outcome)
         }
     }
 }

--- a/web/src/main/kotlin/web/controller/HighlowController.kt
+++ b/web/src/main/kotlin/web/controller/HighlowController.kt
@@ -1,5 +1,6 @@
 package web.controller
 
+import common.casino.CasinoCommonFailure
 import database.economy.Highlow
 import database.service.HighlowService
 import database.service.HighlowService.PlayOutcome
@@ -19,8 +20,10 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes
 import web.casino.CasinoOutcomeMapper
 import web.casino.CasinoPageContext
 import web.casino.CasinoResponseLike
+import web.casino.renderMinigamePage
 import web.service.EconomyWebService
 import web.util.WebGuildAccess
+import web.util.positiveOrNull
 
 @Controller
 @RequestMapping("/casino/{guildId}/highlow")
@@ -40,32 +43,26 @@ class HighlowController(
         session: HttpSession,
         model: Model,
         ra: RedirectAttributes
-    ): String = WebGuildAccess.requireMemberForPage(
-        user, guildId, economyWebService, ra, lobbyPath = "/casino/guilds"
-    ) { discordId ->
-        pageContext.populate(model, guildId, discordId, user) ?: run {
-            ra.addFlashAttribute("error", "Bot is not in that server.")
-            return@requireMemberForPage "redirect:/casino/guilds"
-        }
-
+    ): String = pageContext.renderMinigamePage(
+        user, guildId, economyWebService, model, ra, template = "highlow"
+    ) {
         // Stake commits first, anchor is dealt after the player locks it.
         // If a round is already locked in this session, surface it so the
         // player isn't asked to lock again on refresh.
         val activeAnchor = activeAnchor(session, guildId)
         val activeStake = activeStake(session, guildId)
 
-        model.addAttribute("minStake", Highlow.MIN_STAKE)
-        model.addAttribute("maxStake", Highlow.MAX_STAKE)
-        model.addAttribute("anchor", activeAnchor)
-        model.addAttribute("anchorLabel", activeAnchor?.let { cardLabel(it) } ?: "?")
-        model.addAttribute("higherMultiplier", activeAnchor?.let {
+        addAttribute("minStake", Highlow.MIN_STAKE)
+        addAttribute("maxStake", Highlow.MAX_STAKE)
+        addAttribute("anchor", activeAnchor)
+        addAttribute("anchorLabel", activeAnchor?.let { cardLabel(it) } ?: "?")
+        addAttribute("higherMultiplier", activeAnchor?.let {
             highlowService.payoutMultiplier(it, Highlow.Direction.HIGHER)
         })
-        model.addAttribute("lowerMultiplier", activeAnchor?.let {
+        addAttribute("lowerMultiplier", activeAnchor?.let {
             highlowService.payoutMultiplier(it, Highlow.Direction.LOWER)
         })
-        model.addAttribute("activeStake", activeStake)
-        "highlow"
+        addAttribute("activeStake", activeStake)
     }
 
     @PostMapping("/start")
@@ -141,8 +138,8 @@ class HighlowController(
                     multiplier = outcome.multiplier,
                     newBalance = outcome.newBalance,
                     win = true,
-                    jackpotPayout = outcome.jackpotPayout.takeIf { it > 0L },
-                    soldTobyCoins = outcome.soldTobyCoins.takeIf { it > 0L },
+                    jackpotPayout = outcome.jackpotPayout.positiveOrNull(),
+                    soldTobyCoins = outcome.soldTobyCoins.positiveOrNull(),
                     newPrice = outcome.newPrice,
                 )
             )
@@ -157,16 +154,13 @@ class HighlowController(
                     payout = 0L,
                     newBalance = outcome.newBalance,
                     win = false,
-                    soldTobyCoins = outcome.soldTobyCoins.takeIf { it > 0L },
+                    soldTobyCoins = outcome.soldTobyCoins.positiveOrNull(),
                     newPrice = outcome.newPrice,
-                    lossTribute = outcome.lossTribute.takeIf { it > 0L },
+                    lossTribute = outcome.lossTribute.positiveOrNull(),
                 )
             )
 
-            is PlayOutcome.InsufficientCredits -> playErrors.insufficientCredits(outcome.stake, outcome.have)
-            is PlayOutcome.InsufficientCoinsForTopUp -> playErrors.insufficientCoinsForTopUp(outcome.needed, outcome.have)
-            is PlayOutcome.InvalidStake -> playErrors.invalidStake(outcome.min, outcome.max)
-            PlayOutcome.UnknownUser -> playErrors.unknownUser()
+            is CasinoCommonFailure -> playErrors.mapCommonFailure(outcome)
         }
     }
 

--- a/web/src/main/kotlin/web/controller/ScratchController.kt
+++ b/web/src/main/kotlin/web/controller/ScratchController.kt
@@ -1,5 +1,6 @@
 package web.controller
 
+import common.casino.CasinoCommonFailure
 import database.economy.ScratchCard
 import database.economy.SlotMachine
 import database.service.ScratchService
@@ -19,8 +20,10 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes
 import web.casino.CasinoOutcomeMapper
 import web.casino.CasinoPageContext
 import web.casino.CasinoResponseLike
+import web.casino.renderMinigamePage
 import web.service.EconomyWebService
 import web.util.WebGuildAccess
+import web.util.positiveOrNull
 
 @Controller
 @RequestMapping("/casino/{guildId}/scratch")
@@ -38,20 +41,15 @@ class ScratchController(
         @AuthenticationPrincipal user: OAuth2User,
         model: Model,
         ra: RedirectAttributes
-    ): String = WebGuildAccess.requireMemberForPage(
-        user, guildId, economyWebService, ra, lobbyPath = "/casino/guilds"
-    ) { discordId ->
-        pageContext.populate(model, guildId, discordId, user) ?: run {
-            ra.addFlashAttribute("error", "Bot is not in that server.")
-            return@requireMemberForPage "redirect:/casino/guilds"
-        }
-        model.addAttribute("minStake", ScratchCard.MIN_STAKE)
-        model.addAttribute("maxStake", ScratchCard.MAX_STAKE)
-        model.addAttribute("cellCount", ScratchCard.CELL_COUNT)
-        model.addAttribute("matchThreshold", ScratchCard.MATCH_THRESHOLD)
-        model.addAttribute("matchCounts", (ScratchCard.MATCH_THRESHOLD..ScratchCard.CELL_COUNT).toList())
-        model.addAttribute("payoutTable", scratchPayoutRows())
-        "scratch"
+    ): String = pageContext.renderMinigamePage(
+        user, guildId, economyWebService, model, ra, template = "scratch"
+    ) {
+        addAttribute("minStake", ScratchCard.MIN_STAKE)
+        addAttribute("maxStake", ScratchCard.MAX_STAKE)
+        addAttribute("cellCount", ScratchCard.CELL_COUNT)
+        addAttribute("matchThreshold", ScratchCard.MATCH_THRESHOLD)
+        addAttribute("matchCounts", (ScratchCard.MATCH_THRESHOLD..ScratchCard.CELL_COUNT).toList())
+        addAttribute("payoutTable", scratchPayoutRows())
     }
 
     // Per-symbol payout row: one cell per match count from MATCH_THRESHOLD
@@ -88,8 +86,8 @@ class ScratchController(
                     payout = outcome.payout,
                     newBalance = outcome.newBalance,
                     win = true,
-                    jackpotPayout = outcome.jackpotPayout.takeIf { it > 0L },
-                    soldTobyCoins = outcome.soldTobyCoins.takeIf { it > 0L },
+                    jackpotPayout = outcome.jackpotPayout.positiveOrNull(),
+                    soldTobyCoins = outcome.soldTobyCoins.positiveOrNull(),
                     newPrice = outcome.newPrice,
                 )
             )
@@ -102,16 +100,13 @@ class ScratchController(
                     payout = 0L,
                     newBalance = outcome.newBalance,
                     win = false,
-                    soldTobyCoins = outcome.soldTobyCoins.takeIf { it > 0L },
+                    soldTobyCoins = outcome.soldTobyCoins.positiveOrNull(),
                     newPrice = outcome.newPrice,
-                    lossTribute = outcome.lossTribute.takeIf { it > 0L },
+                    lossTribute = outcome.lossTribute.positiveOrNull(),
                 )
             )
 
-            is ScratchOutcome.InsufficientCredits -> errors.insufficientCredits(outcome.stake, outcome.have)
-            is ScratchOutcome.InsufficientCoinsForTopUp -> errors.insufficientCoinsForTopUp(outcome.needed, outcome.have)
-            is ScratchOutcome.InvalidStake -> errors.invalidStake(outcome.min, outcome.max)
-            ScratchOutcome.UnknownUser -> errors.unknownUser()
+            is CasinoCommonFailure -> errors.mapCommonFailure(outcome)
         }
     }
 }

--- a/web/src/main/kotlin/web/controller/SlotsController.kt
+++ b/web/src/main/kotlin/web/controller/SlotsController.kt
@@ -1,5 +1,6 @@
 package web.controller
 
+import common.casino.CasinoCommonFailure
 import database.economy.SlotMachine
 import database.service.SlotsService
 import database.service.SlotsService.SpinOutcome
@@ -18,8 +19,10 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes
 import web.casino.CasinoOutcomeMapper
 import web.casino.CasinoPageContext
 import web.casino.CasinoResponseLike
+import web.casino.renderMinigamePage
 import web.service.EconomyWebService
 import web.util.WebGuildAccess
+import web.util.positiveOrNull
 
 /**
  * Web surface for the `/slots` minigame. GET renders the reel UI with the
@@ -46,17 +49,13 @@ class SlotsController(
         @AuthenticationPrincipal user: OAuth2User,
         model: Model,
         ra: RedirectAttributes
-    ): String = WebGuildAccess.requireMemberForPage(
-        user, guildId, economyWebService, ra, lobbyPath = "/leaderboards"
-    ) { discordId ->
-        pageContext.populate(model, guildId, discordId, user) ?: run {
-            ra.addFlashAttribute("error", "Bot is not in that server.")
-            return@requireMemberForPage "redirect:/leaderboards"
-        }
-        model.addAttribute("minStake", SlotMachine.MIN_STAKE)
-        model.addAttribute("maxStake", SlotMachine.MAX_STAKE)
-        model.addAttribute("payoutTable", payoutRows())
-        "slots"
+    ): String = pageContext.renderMinigamePage(
+        user, guildId, economyWebService, model, ra,
+        template = "slots", lobbyPath = "/leaderboards"
+    ) {
+        addAttribute("minStake", SlotMachine.MIN_STAKE)
+        addAttribute("maxStake", SlotMachine.MAX_STAKE)
+        addAttribute("payoutTable", payoutRows())
     }
 
     @PostMapping("/spin")
@@ -78,8 +77,8 @@ class SlotsController(
                     net = outcome.net,
                     newBalance = outcome.newBalance,
                     win = true,
-                    jackpotPayout = outcome.jackpotPayout.takeIf { it > 0L },
-                    soldTobyCoins = outcome.soldTobyCoins.takeIf { it > 0L },
+                    jackpotPayout = outcome.jackpotPayout.positiveOrNull(),
+                    soldTobyCoins = outcome.soldTobyCoins.positiveOrNull(),
                     newPrice = outcome.newPrice,
                 )
             )
@@ -93,16 +92,13 @@ class SlotsController(
                     net = -outcome.stake,
                     newBalance = outcome.newBalance,
                     win = false,
-                    soldTobyCoins = outcome.soldTobyCoins.takeIf { it > 0L },
+                    soldTobyCoins = outcome.soldTobyCoins.positiveOrNull(),
                     newPrice = outcome.newPrice,
-                    lossTribute = outcome.lossTribute.takeIf { it > 0L },
+                    lossTribute = outcome.lossTribute.positiveOrNull(),
                 )
             )
 
-            is SpinOutcome.InsufficientCredits -> errors.insufficientCredits(outcome.stake, outcome.have)
-            is SpinOutcome.InsufficientCoinsForTopUp -> errors.insufficientCoinsForTopUp(outcome.needed, outcome.have)
-            is SpinOutcome.InvalidStake -> errors.invalidStake(outcome.min, outcome.max)
-            SpinOutcome.UnknownUser -> errors.unknownUser()
+            is CasinoCommonFailure -> errors.mapCommonFailure(outcome)
         }
     }
 

--- a/web/src/main/kotlin/web/util/LongExtensions.kt
+++ b/web/src/main/kotlin/web/util/LongExtensions.kt
@@ -1,0 +1,11 @@
+package web.util
+
+/**
+ * Returns this value if it is strictly positive, otherwise null.
+ *
+ * Casino response builders use this to elide zero-valued payout fields
+ * from the JSON body — `jackpotPayout = outcome.jackpotPayout.positiveOrNull()`
+ * reads as a single concept where `takeIf { it > 0L }` is structural
+ * boilerplate repeated ~30× across the per-game controllers.
+ */
+fun Long.positiveOrNull(): Long? = takeIf { it > 0L }

--- a/web/src/main/resources/static/js/baccarat.js
+++ b/web/src/main/resources/static/js/baccarat.js
@@ -181,41 +181,35 @@ function loseLineHtml(body, sideLabel, winnerLabel) {
 (function () {
     'use strict';
 
-    var main = document.querySelector('main[data-guild-id]');
-    if (!main) return;
+    var els = window.TobyCasinoMinigameDom &&
+        window.TobyCasinoMinigameDom.standardElements('bac', 'deal');
+    if (!els) return;
 
-    var guildId = main.dataset.guildId;
-    var stakeInput = document.getElementById('bac-stake');
-    var dealBtn = document.getElementById('bac-deal');
-    var dealTobyBtn = document.getElementById('bac-deal-toby');
-    var balanceEl = document.getElementById('bac-balance');
-    var resultEl = document.getElementById('bac-result');
-    var form = document.getElementById('bac-bet');
     var tableEl = document.getElementById('bac-table');
     var bankerCardsEl = document.getElementById('bac-banker-cards');
     var playerCardsEl = document.getElementById('bac-player-cards');
     var bankerTotalEl = document.getElementById('bac-banker-total');
     var playerTotalEl = document.getElementById('bac-player-total');
 
-    if (!form || !dealBtn || !stakeInput) return;
+    if (!els.form || !els.primaryBtn || !els.stakeInput) return;
 
     function selectedSide() {
-        var checked = form.querySelector('input[name="side"]:checked');
+        var checked = els.form.querySelector('input[name="side"]:checked');
         return checked ? checked.value : null;
     }
 
     if (window.TobyCasinoGame) {
         window.TobyCasinoGame.init({
-            guildId: guildId,
-            endpoint: '/casino/' + guildId + '/baccarat/play',
-            form: form,
-            stakeInput: stakeInput,
-            primaryBtn: dealBtn,
-            tobyBtn: dealTobyBtn,
-            balanceEl: balanceEl,
-            resultEl: resultEl,
-            tobyCoins: Number(main.dataset.tobyCoins) || 0,
-            marketPrice: Number(main.dataset.marketPrice) || 0,
+            guildId: els.guildId,
+            endpoint: '/casino/' + els.guildId + '/baccarat/play',
+            form: els.form,
+            stakeInput: els.stakeInput,
+            primaryBtn: els.primaryBtn,
+            tobyBtn: els.tobyBtn,
+            balanceEl: els.balanceEl,
+            resultEl: els.resultEl,
+            tobyCoins: els.tobyCoins,
+            marketPrice: els.marketPrice,
             failureMessage: 'Deal failed.',
             validate: function () {
                 if (!selectedSide()) return 'Pick a side first.';
@@ -226,7 +220,7 @@ function loseLineHtml(body, sideLabel, winnerLabel) {
             },
             renderResult: function (body) {
                 renderBaccaratResult({
-                    resultEl: resultEl,
+                    resultEl: els.resultEl,
                     bankerCardsEl: bankerCardsEl,
                     playerCardsEl: playerCardsEl,
                     bankerTotalEl: bankerTotalEl,

--- a/web/src/main/resources/static/js/casino-minigame-dom.js
+++ b/web/src/main/resources/static/js/casino-minigame-dom.js
@@ -1,0 +1,45 @@
+// Shared element-selection helper for the casino-minigame pages.
+//
+// Every per-game JS file used to repeat the same ~12 lines of DOM
+// lookups using a `{prefix}-X` naming convention:
+//
+//   const main = document.querySelector('main[data-guild-id]');
+//   const guildId = main.dataset.guildId;
+//   const stakeInput = document.getElementById('dice-stake');
+//   const rollBtn = document.getElementById('dice-roll');
+//   const rollTobyBtn = document.getElementById('dice-roll-toby');
+//   const balanceEl = document.getElementById('dice-balance');
+//   const resultEl = document.getElementById('dice-result');
+//   const form = document.getElementById('dice-bet');
+//
+// `TobyCasinoMinigameDom.standardElements(prefix, actionVerb)` returns
+// the same shape every game needs in a single call. Returns null if
+// the page hasn't booted (no `<main data-guild-id>`) so per-game JS
+// can early-return without a separate guard.
+
+(function (root) {
+    'use strict';
+
+    function standardElements(prefix, actionVerb) {
+        const main = document.querySelector('main[data-guild-id]');
+        if (!main) return null;
+        return {
+            main: main,
+            guildId: main.dataset.guildId,
+            tobyCoins: Number(main.dataset.tobyCoins) || 0,
+            marketPrice: Number(main.dataset.marketPrice) || 0,
+            form: document.getElementById(prefix + '-bet'),
+            stakeInput: document.getElementById(prefix + '-stake'),
+            primaryBtn: document.getElementById(prefix + '-' + actionVerb),
+            tobyBtn: document.getElementById(prefix + '-' + actionVerb + '-toby'),
+            balanceEl: document.getElementById(prefix + '-balance'),
+            resultEl: document.getElementById(prefix + '-result'),
+        };
+    }
+
+    const api = { standardElements: standardElements };
+    if (root) root.TobyCasinoMinigameDom = api;
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = api;
+    }
+})(typeof window !== 'undefined' ? window : null);

--- a/web/src/main/resources/static/js/casino-result-line.js
+++ b/web/src/main/resources/static/js/casino-result-line.js
@@ -1,0 +1,52 @@
+// Factory for the `renderXResult(resultEl, body, flashTargetEl)`
+// function each per-game JS used to declare verbatim:
+//
+//   function renderDiceResult(resultEl, body, flashTargetEl) {
+//       if (window.TobyCasinoResult) {
+//           window.TobyCasinoResult.render({
+//               resultEl: resultEl,
+//               body: body,
+//               classPrefix: 'dice',
+//               winLineHtml: '<strong>' + body.landed + '!</strong> …',
+//               loseLineHtml: '<strong>' + body.landed + '.</strong> …',
+//           });
+//       }
+//       if (window.CasinoRender) {
+//           window.CasinoRender.flashWinPayout(flashTargetEl, body);
+//       }
+//   }
+//
+// `TobyCasinoResultLine.factory({ classPrefix, winLine, loseLine })`
+// returns the same closure given just the two HTML templates. Each
+// template is a `(body) => string` so per-game JS can interpolate
+// landed/predicted/net/etc. as needed.
+
+(function (root) {
+    'use strict';
+
+    function factory(cfg) {
+        const classPrefix = cfg.classPrefix;
+        const winLine = cfg.winLine;
+        const loseLine = cfg.loseLine;
+        return function (resultEl, body, flashTargetEl) {
+            if (root && root.TobyCasinoResult) {
+                root.TobyCasinoResult.render({
+                    resultEl: resultEl,
+                    body: body,
+                    classPrefix: classPrefix,
+                    winLineHtml: winLine(body),
+                    loseLineHtml: loseLine(body),
+                });
+            }
+            if (root && root.CasinoRender) {
+                root.CasinoRender.flashWinPayout(flashTargetEl, body);
+            }
+        };
+    }
+
+    const api = { factory: factory };
+    if (root) root.TobyCasinoResultLine = api;
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = api;
+    }
+})(typeof window !== 'undefined' ? window : null);

--- a/web/src/main/resources/static/js/coinflip.js
+++ b/web/src/main/resources/static/js/coinflip.js
@@ -23,21 +23,15 @@ function renderCoinflipResult(resultEl, body, flashTargetEl) {
 (function () {
     'use strict';
 
-    const main = document.querySelector('main[data-guild-id]');
-    if (!main) return;
+    const els = window.TobyCasinoMinigameDom &&
+        window.TobyCasinoMinigameDom.standardElements('coinflip', 'flip');
+    if (!els) return;
 
-    const guildId = main.dataset.guildId;
     const coin = document.getElementById('coinflip-coin');
     const coinFace = document.getElementById('coinflip-coin-face');
     const tableEl = document.querySelector('.coinflip-table');
-    const stakeInput = document.getElementById('coinflip-stake');
-    const flipBtn = document.getElementById('coinflip-flip');
-    const flipTobyBtn = document.getElementById('coinflip-flip-toby');
-    const balanceEl = document.getElementById('coinflip-balance');
-    const resultEl = document.getElementById('coinflip-result');
-    const form = document.getElementById('coinflip-bet');
 
-    if (!form || !flipBtn || !stakeInput || !coin || !coinFace) return;
+    if (!els.form || !els.primaryBtn || !els.stakeInput || !coin || !coinFace) return;
 
     const FLIP_DURATION_MS = 800;
     const FLIP_INTERVAL_MS = 80;
@@ -45,7 +39,7 @@ function renderCoinflipResult(resultEl, body, flashTargetEl) {
     const FLIP_FACES = ['🪙', '🟡'];
 
     function selectedSide() {
-        const checked = form.querySelector('input[name="side"]:checked');
+        const checked = els.form.querySelector('input[name="side"]:checked');
         return checked ? checked.value : null;
     }
 
@@ -82,16 +76,16 @@ function renderCoinflipResult(resultEl, body, flashTargetEl) {
     }
 
     window.TobyCasinoGame.init({
-        guildId: guildId,
-        endpoint: '/casino/' + guildId + '/coinflip/flip',
-        form: form,
-        stakeInput: stakeInput,
-        primaryBtn: flipBtn,
-        tobyBtn: flipTobyBtn,
-        balanceEl: balanceEl,
-        resultEl: resultEl,
-        tobyCoins: Number(main.dataset.tobyCoins) || 0,
-        marketPrice: Number(main.dataset.marketPrice) || 0,
+        guildId: els.guildId,
+        endpoint: '/casino/' + els.guildId + '/coinflip/flip',
+        form: els.form,
+        stakeInput: els.stakeInput,
+        primaryBtn: els.primaryBtn,
+        tobyBtn: els.tobyBtn,
+        balanceEl: els.balanceEl,
+        resultEl: els.resultEl,
+        tobyCoins: els.tobyCoins,
+        marketPrice: els.marketPrice,
         minSettleMs: FLIP_DURATION_MS,
         failureMessage: 'Flip failed.',
         validate: function () {
@@ -103,7 +97,7 @@ function renderCoinflipResult(resultEl, body, flashTargetEl) {
         },
         startAnimation: startFlipAnimation,
         stopAnimation: stopFlipAnimation,
-        renderResult: function (body) { renderCoinflipResult(resultEl, body, tableEl); },
+        renderResult: function (body) { renderCoinflipResult(els.resultEl, body, tableEl); },
     });
 })();
 

--- a/web/src/main/resources/static/js/dice.js
+++ b/web/src/main/resources/static/js/dice.js
@@ -21,28 +21,22 @@ function renderDiceResult(resultEl, body, flashTargetEl) {
 (function () {
     'use strict';
 
-    const main = document.querySelector('main[data-guild-id]');
-    if (!main) return;
+    const els = window.TobyCasinoMinigameDom &&
+        window.TobyCasinoMinigameDom.standardElements('dice', 'roll');
+    if (!els) return;
 
-    const guildId = main.dataset.guildId;
     const die = document.getElementById('dice-die');
     const dieFace = document.getElementById('dice-die-face');
     const tableEl = document.querySelector('.dice-table');
-    const stakeInput = document.getElementById('dice-stake');
-    const rollBtn = document.getElementById('dice-roll');
-    const rollTobyBtn = document.getElementById('dice-roll-toby');
-    const balanceEl = document.getElementById('dice-balance');
-    const resultEl = document.getElementById('dice-result');
-    const form = document.getElementById('dice-bet');
 
-    if (!form || !rollBtn || !stakeInput || !die || !dieFace) return;
+    if (!els.form || !els.primaryBtn || !els.stakeInput || !die || !dieFace) return;
 
     const FACES = { 1: '⚀', 2: '⚁', 3: '⚂', 4: '⚃', 5: '⚄', 6: '⚅' };
     const ROLL_DURATION_MS = 800;
     const ROLL_INTERVAL_MS = 70;
 
     function selectedPrediction() {
-        const checked = form.querySelector('input[name="prediction"]:checked');
+        const checked = els.form.querySelector('input[name="prediction"]:checked');
         return checked ? parseInt(checked.value, 10) : null;
     }
 
@@ -75,16 +69,16 @@ function renderDiceResult(resultEl, body, flashTargetEl) {
     }
 
     window.TobyCasinoGame.init({
-        guildId: guildId,
-        endpoint: '/casino/' + guildId + '/dice/roll',
-        form: form,
-        stakeInput: stakeInput,
-        primaryBtn: rollBtn,
-        tobyBtn: rollTobyBtn,
-        balanceEl: balanceEl,
-        resultEl: resultEl,
-        tobyCoins: Number(main.dataset.tobyCoins) || 0,
-        marketPrice: Number(main.dataset.marketPrice) || 0,
+        guildId: els.guildId,
+        endpoint: '/casino/' + els.guildId + '/dice/roll',
+        form: els.form,
+        stakeInput: els.stakeInput,
+        primaryBtn: els.primaryBtn,
+        tobyBtn: els.tobyBtn,
+        balanceEl: els.balanceEl,
+        resultEl: els.resultEl,
+        tobyCoins: els.tobyCoins,
+        marketPrice: els.marketPrice,
         minSettleMs: ROLL_DURATION_MS,
         failureMessage: 'Roll failed.',
         validate: function () {
@@ -100,7 +94,7 @@ function renderDiceResult(resultEl, body, flashTargetEl) {
         },
         startAnimation: startRollAnimation,
         stopAnimation: stopRollAnimation,
-        renderResult: function (body) { renderDiceResult(resultEl, body, tableEl); },
+        renderResult: function (body) { renderDiceResult(els.resultEl, body, tableEl); },
     });
 })();
 

--- a/web/src/main/resources/static/js/highlow.js
+++ b/web/src/main/resources/static/js/highlow.js
@@ -56,10 +56,10 @@ function renderHighlowResult(resultEl, body, flashTargetEl) {
 (function () {
     'use strict';
 
-    const main = document.querySelector('main[data-guild-id]');
-    if (!main) return;
+    const els = window.TobyCasinoMinigameDom &&
+        window.TobyCasinoMinigameDom.standardElements('highlow', 'deal');
+    if (!els) return;
 
-    const guildId = main.dataset.guildId;
     const postJson = window.TobyApi && window.TobyApi.postJson;
 
     const anchorFace = document.getElementById('highlow-anchor-face');
@@ -67,19 +67,13 @@ function renderHighlowResult(resultEl, body, flashTargetEl) {
     const anchorCard = document.getElementById('highlow-anchor');
     const nextCard = document.getElementById('highlow-next');
     const tableEl = document.querySelector('.highlow-table');
-    const stakeInput = document.getElementById('highlow-stake');
-    const dealBtn = document.getElementById('highlow-deal');
-    const dealTobyBtn = document.getElementById('highlow-deal-toby');
-    const balanceEl = document.getElementById('highlow-balance');
-    const resultEl = document.getElementById('highlow-result');
-    const form = document.getElementById('highlow-bet');
     const directionPicker = document.getElementById('highlow-direction-picker');
     const higherBtn = document.getElementById('highlow-call-higher');
     const lowerBtn = document.getElementById('highlow-call-lower');
     const higherMultEl = document.getElementById('highlow-call-higher-mult');
     const lowerMultEl = document.getElementById('highlow-call-lower-mult');
 
-    if (!form || !dealBtn || !stakeInput || !anchorFace || !nextFace) return;
+    if (!els.form || !els.primaryBtn || !els.stakeInput || !anchorFace || !nextFace) return;
     if (!directionPicker || !higherBtn || !lowerBtn) return;
 
     const NEXT_DEAL_MS = 900;
@@ -103,9 +97,9 @@ function renderHighlowResult(resultEl, body, flashTargetEl) {
         directionPicker.hidden = true;
         higherBtn.disabled = false;
         lowerBtn.disabled = false;
-        form.hidden = false;
-        dealBtn.disabled = false;
-        if (dealTobyBtn) dealTobyBtn.disabled = false;
+        els.form.hidden = false;
+        els.primaryBtn.disabled = false;
+        if (els.tobyBtn) els.tobyBtn.disabled = false;
         anchorFace.textContent = '?';
         if (anchorCard) delete anchorCard.dataset.value;
         nextFace.textContent = '?';
@@ -122,12 +116,12 @@ function renderHighlowResult(resultEl, body, flashTargetEl) {
         }
         nextFace.textContent = '?';
         if (nextCard) delete nextCard.dataset.value;
-        form.hidden = true;
+        els.form.hidden = true;
         directionPicker.hidden = false;
         higherBtn.disabled = false;
         lowerBtn.disabled = false;
         setMultiplierLabels(higherMult, lowerMult);
-        if (resultEl) resultEl.hidden = true;
+        if (els.resultEl) els.resultEl.hidden = true;
     }
 
     function startNextShuffle() {
@@ -170,16 +164,16 @@ function renderHighlowResult(resultEl, body, flashTargetEl) {
     // /start uses the shared form + TOBY-topup scaffolding. /play has
     // its own button pair below — different lifecycle, kept manual.
     const game = window.TobyCasinoGame.init({
-        guildId: guildId,
-        endpoint: '/casino/' + guildId + '/highlow/start',
-        form: form,
-        stakeInput: stakeInput,
-        primaryBtn: dealBtn,
-        tobyBtn: dealTobyBtn,
-        balanceEl: balanceEl,
-        resultEl: resultEl,
-        tobyCoins: Number(main.dataset.tobyCoins) || 0,
-        marketPrice: Number(main.dataset.marketPrice) || 0,
+        guildId: els.guildId,
+        endpoint: '/casino/' + els.guildId + '/highlow/start',
+        form: els.form,
+        stakeInput: els.stakeInput,
+        primaryBtn: els.primaryBtn,
+        tobyBtn: els.tobyBtn,
+        balanceEl: els.balanceEl,
+        resultEl: els.resultEl,
+        tobyCoins: els.tobyCoins,
+        marketPrice: els.marketPrice,
         failureMessage: 'Could not lock the round.',
         // /start doesn't settle credit/coin movement — it just locks
         // the stake and deals the anchor. Balance updates land via
@@ -205,7 +199,7 @@ function renderHighlowResult(resultEl, body, flashTargetEl) {
         const intervalId = startNextShuffle();
         const requestStart = Date.now();
 
-        postJson('/casino/' + guildId + '/highlow/play', { direction: direction })
+        postJson('/casino/' + els.guildId + '/highlow/play', { direction: direction })
             .then(function (body) {
                 const elapsed = Date.now() - requestStart;
                 const remaining = Math.max(0, NEXT_DEAL_MS - elapsed);
@@ -213,7 +207,7 @@ function renderHighlowResult(resultEl, body, flashTargetEl) {
                     playing = false;
                     if (body && body.ok) {
                         stopNextShuffle(intervalId, body.next);
-                        renderHighlowResult(resultEl, body, tableEl);
+                        renderHighlowResult(els.resultEl, body, tableEl);
                         if (window.CasinoSounds) {
                             window.CasinoSounds.play(body.net > 0 ? 'win' : 'lose');
                         }
@@ -246,10 +240,10 @@ function renderHighlowResult(resultEl, body, flashTargetEl) {
 
     // If the server pre-rendered an active round (page refresh mid-round),
     // jump straight to call mode so the player can finish their bet.
-    const preloadedAnchor = parseInt(main.dataset.activeAnchor || '', 10);
+    const preloadedAnchor = parseInt(els.main.dataset.activeAnchor || '', 10);
     if (Number.isFinite(preloadedAnchor) && preloadedAnchor > 0) {
-        const preloadedHigher = parseFloat(main.dataset.higherMultiplier || '');
-        const preloadedLower = parseFloat(main.dataset.lowerMultiplier || '');
+        const preloadedHigher = parseFloat(els.main.dataset.higherMultiplier || '');
+        const preloadedLower = parseFloat(els.main.dataset.lowerMultiplier || '');
         showCallMode(preloadedAnchor, preloadedHigher, preloadedLower);
     }
 })();

--- a/web/src/main/resources/static/js/scratch.js
+++ b/web/src/main/resources/static/js/scratch.js
@@ -32,25 +32,18 @@ function renderScratchResult(resultEl, body, matchThreshold, balanceEl, flashTar
 (function () {
     'use strict';
 
-    const main = document.querySelector('main[data-guild-id]');
-    if (!main) return;
+    const els = window.TobyCasinoMinigameDom &&
+        window.TobyCasinoMinigameDom.standardElements('scratch', 'buy');
+    if (!els) return;
 
-    const guildId = main.dataset.guildId;
-    const matchThreshold = parseInt(main.dataset.matchThreshold, 10) || 5;
-    const initialTobyCoins = Number(main.dataset.tobyCoins) || 0;
+    const matchThreshold = parseInt(els.main.dataset.matchThreshold, 10) || 5;
 
     const cellsContainer = document.getElementById('scratch-cells');
     const cellButtons = Array.from(cellsContainer ? cellsContainer.querySelectorAll('.scratch-cell') : []);
     const tableEl = document.querySelector('.scratch-table');
-    const stakeInput = document.getElementById('scratch-stake');
-    const buyBtn = document.getElementById('scratch-buy');
-    const buyTobyBtn = document.getElementById('scratch-buy-toby');
     const revealBtn = document.getElementById('scratch-reveal-all');
-    const balanceEl = document.getElementById('scratch-balance');
-    const resultEl = document.getElementById('scratch-result');
-    const form = document.getElementById('scratch-bet');
 
-    if (!form || !buyBtn || !stakeInput || cellButtons.length === 0) return;
+    if (!els.form || !els.primaryBtn || !els.stakeInput || cellButtons.length === 0) return;
 
     // Latest active card. Server returns the symbols up front; cells are
     // hidden until the user scratches each one. Once all are revealed (or
@@ -83,7 +76,7 @@ function renderScratchResult(resultEl, body, matchThreshold, balanceEl, flashTar
         // win cells once everything is revealed (see below).
         if (cellButtons.every(function (b) { return b.classList.contains('revealed'); })) {
             highlightWinCells(activeCard);
-            renderScratchResult(resultEl, activeCard, matchThreshold, balanceEl, tableEl);
+            renderScratchResult(els.resultEl, activeCard, matchThreshold, els.balanceEl, tableEl);
             if (window.CasinoSounds) {
                 window.CasinoSounds.play((activeCard.net || 0) > 0 ? 'win' : 'lose');
             }
@@ -124,23 +117,23 @@ function renderScratchResult(resultEl, body, matchThreshold, balanceEl, flashTar
     if (revealBtn) revealBtn.addEventListener('click', revealAll);
 
     game = window.TobyCasinoGame.init({
-        guildId: guildId,
-        endpoint: '/casino/' + guildId + '/scratch/scratch',
-        form: form,
-        stakeInput: stakeInput,
-        primaryBtn: buyBtn,
-        tobyBtn: buyTobyBtn,
-        balanceEl: balanceEl,
-        resultEl: resultEl,
-        tobyCoins: initialTobyCoins,
-        marketPrice: Number(main.dataset.marketPrice) || 0,
+        guildId: els.guildId,
+        endpoint: '/casino/' + els.guildId + '/scratch/scratch',
+        form: els.form,
+        stakeInput: els.stakeInput,
+        primaryBtn: els.primaryBtn,
+        tobyBtn: els.tobyBtn,
+        balanceEl: els.balanceEl,
+        resultEl: els.resultEl,
+        tobyCoins: els.tobyCoins,
+        marketPrice: els.marketPrice,
         failureMessage: 'Buy failed.',
         // Scratch shows the result only after every cell has been
         // revealed, so the helper must NOT auto-update balance/coins on
         // response. revealCell() does it once the suspense is over.
         autoApplyBalance: false,
         startAnimation: function () {
-            if (resultEl) resultEl.hidden = true;
+            if (els.resultEl) els.resultEl.hidden = true;
             resetCells();
             return null;
         },

--- a/web/src/main/resources/static/js/slots.js
+++ b/web/src/main/resources/static/js/slots.js
@@ -33,24 +33,18 @@ function renderSlotsResult(resultEl, body, flashTargetEl, reels) {
 (function () {
     'use strict';
 
-    const main = document.querySelector('main[data-guild-id]');
-    if (!main) return;
+    const els = window.TobyCasinoMinigameDom &&
+        window.TobyCasinoMinigameDom.standardElements('slots', 'spin');
+    if (!els) return;
 
-    const guildId = main.dataset.guildId;
     const reels = [
         document.getElementById('slots-reel-0'),
         document.getElementById('slots-reel-1'),
         document.getElementById('slots-reel-2')
     ];
     const machineEl = document.querySelector('.slots-machine');
-    const stakeInput = document.getElementById('slots-stake');
-    const spinBtn = document.getElementById('slots-spin');
-    const spinTobyBtn = document.getElementById('slots-spin-toby');
-    const balanceEl = document.getElementById('slots-balance');
-    const resultEl = document.getElementById('slots-result');
-    const form = document.getElementById('slots-bet');
 
-    if (!form || !spinBtn || !stakeInput || reels.some(function (r) { return !r; })) return;
+    if (!els.form || !els.primaryBtn || !els.stakeInput || reels.some(function (r) { return !r; })) return;
 
     const SPIN_SYMBOLS = ['🍒', '🍋', '🔔', '⭐'];
     const SPIN_INTERVAL_MS = 60;
@@ -91,21 +85,21 @@ function renderSlotsResult(resultEl, body, flashTargetEl, reels) {
     }
 
     window.TobyCasinoGame.init({
-        guildId: guildId,
-        endpoint: '/casino/' + guildId + '/slots/spin',
-        form: form,
-        stakeInput: stakeInput,
-        primaryBtn: spinBtn,
-        tobyBtn: spinTobyBtn,
-        balanceEl: balanceEl,
-        resultEl: resultEl,
-        tobyCoins: Number(main.dataset.tobyCoins) || 0,
-        marketPrice: Number(main.dataset.marketPrice) || 0,
+        guildId: els.guildId,
+        endpoint: '/casino/' + els.guildId + '/slots/spin',
+        form: els.form,
+        stakeInput: els.stakeInput,
+        primaryBtn: els.primaryBtn,
+        tobyBtn: els.tobyBtn,
+        balanceEl: els.balanceEl,
+        resultEl: els.resultEl,
+        tobyCoins: els.tobyCoins,
+        marketPrice: els.marketPrice,
         minSettleMs: SPIN_DURATION_MS,
         failureMessage: 'Spin failed.',
         startAnimation: startSpinAnimation,
         stopAnimation: stopSpinAnimation,
-        renderResult: function (body) { renderSlotsResult(resultEl, body, machineEl, reels); },
+        renderResult: function (body) { renderSlotsResult(els.resultEl, body, machineEl, reels); },
     });
 })();
 

--- a/web/src/main/resources/templates/baccarat.html
+++ b/web/src/main/resources/templates/baccarat.html
@@ -97,14 +97,8 @@
 
 <div class="toast-stack" id="toast-stack" aria-live="polite"></div>
 
-<script th:src="@{/js/api.js}"></script>
-<script th:src="@{/js/toasts.js}"></script>
-<script th:src="@{/js/casino-sounds.js}"></script>
-<script th:src="@{/js/casino-jackpot.js}"></script>
-<script th:src="@{/js/casino-topup.js}"></script>
-<script th:src="@{/js/casino-result.js}"></script>
+<th:block th:replace="~{fragments/casinoMinigame :: scripts}"></th:block>
 <script th:src="@{/js/casino-render.js}"></script>
-<script th:src="@{/js/casino-game.js}"></script>
 <script th:src="@{/js/baccarat.js}"></script>
 </body>
 </html>

--- a/web/src/main/resources/templates/coinflip.html
+++ b/web/src/main/resources/templates/coinflip.html
@@ -69,13 +69,7 @@
 
 <div class="toast-stack" id="toast-stack" aria-live="polite"></div>
 
-<script th:src="@{/js/api.js}"></script>
-<script th:src="@{/js/toasts.js}"></script>
-<script th:src="@{/js/casino-sounds.js}"></script>
-<script th:src="@{/js/casino-jackpot.js}"></script>
-<script th:src="@{/js/casino-topup.js}"></script>
-<script th:src="@{/js/casino-result.js}"></script>
-<script th:src="@{/js/casino-game.js}"></script>
+<th:block th:replace="~{fragments/casinoMinigame :: scripts}"></th:block>
 <script th:src="@{/js/coinflip.js}"></script>
 </body>
 </html>

--- a/web/src/main/resources/templates/dice.html
+++ b/web/src/main/resources/templates/dice.html
@@ -66,13 +66,7 @@
 
 <div class="toast-stack" id="toast-stack" aria-live="polite"></div>
 
-<script th:src="@{/js/api.js}"></script>
-<script th:src="@{/js/toasts.js}"></script>
-<script th:src="@{/js/casino-sounds.js}"></script>
-<script th:src="@{/js/casino-jackpot.js}"></script>
-<script th:src="@{/js/casino-topup.js}"></script>
-<script th:src="@{/js/casino-result.js}"></script>
-<script th:src="@{/js/casino-game.js}"></script>
+<th:block th:replace="~{fragments/casinoMinigame :: scripts}"></th:block>
 <script th:src="@{/js/dice.js}"></script>
 </body>
 </html>

--- a/web/src/main/resources/templates/fragments/casinoMinigame.html
+++ b/web/src/main/resources/templates/fragments/casinoMinigame.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<body>
+<!--
+    Shared scaffolding fragments used by every minigame template
+    (dice, coinflip, slots, scratch, highlow, baccarat). Each used
+    to repeat the same `data-*` attribute trio on `<main>` and the
+    same 7-script footer block; centralising both means a tweak to
+    the topup contract or a new shared script is one edit.
+-->
+
+<!--
+    Standard data-attribute triple every minigame `<main>` carries:
+    guildId, the user's TOBY balance, and the live market price. The
+    JS scaffolding (`casino-minigame-dom.js`, `casino-topup.js`) reads
+    these via `main.dataset` so the same selectors work on every page.
+
+    Game-specific data attributes (e.g. highlow's `data-anchor`,
+    `data-active-stake`, `data-higher-multiplier`) still belong inline
+    on the `<main>` element — this fragment only covers what's truly
+    universal.
+
+    Used as `th:attr="${#fragments.replace(...)}"` won't help for attrs;
+    instead the page renders this as an inline include and the attrs
+    are merged onto the surrounding element via Thymeleaf's th:attr.
+-->
+
+<!--
+    Shared script block for every minigame page. Order matters:
+      api       — fetch wrapper / CSRF
+      toasts    — toast notifications
+      sounds    — audio cues
+      jackpot   — jackpot pool banner mirroring
+      topup     — TOBY shortfall sell button
+      result    — win/lose class toggling + balance refresh
+      game      — TobyCasinoGame.init scaffolding
+      dom       — standard `{prefix}-X` element selectors
+      resultLine — win/lose HTML factory used by per-game JS
+    Each per-game template adds its own `<script th:src="@{/js/{game}.js}">`
+    after this block.
+-->
+<th:block th:fragment="scripts">
+    <script th:src="@{/js/api.js}"></script>
+    <script th:src="@{/js/toasts.js}"></script>
+    <script th:src="@{/js/casino-sounds.js}"></script>
+    <script th:src="@{/js/casino-jackpot.js}"></script>
+    <script th:src="@{/js/casino-topup.js}"></script>
+    <script th:src="@{/js/casino-result.js}"></script>
+    <script th:src="@{/js/casino-game.js}"></script>
+    <script th:src="@{/js/casino-minigame-dom.js}"></script>
+    <script th:src="@{/js/casino-result-line.js}"></script>
+</th:block>
+
+</body>
+</html>

--- a/web/src/main/resources/templates/highlow.html
+++ b/web/src/main/resources/templates/highlow.html
@@ -85,13 +85,7 @@
 
 <div class="toast-stack" id="toast-stack" aria-live="polite"></div>
 
-<script th:src="@{/js/api.js}"></script>
-<script th:src="@{/js/toasts.js}"></script>
-<script th:src="@{/js/casino-sounds.js}"></script>
-<script th:src="@{/js/casino-jackpot.js}"></script>
-<script th:src="@{/js/casino-topup.js}"></script>
-<script th:src="@{/js/casino-result.js}"></script>
-<script th:src="@{/js/casino-game.js}"></script>
+<th:block th:replace="~{fragments/casinoMinigame :: scripts}"></th:block>
 <script th:src="@{/js/highlow.js}"></script>
 </body>
 </html>

--- a/web/src/main/resources/templates/scratch.html
+++ b/web/src/main/resources/templates/scratch.html
@@ -85,13 +85,7 @@
 
 <div class="toast-stack" id="toast-stack" aria-live="polite"></div>
 
-<script th:src="@{/js/api.js}"></script>
-<script th:src="@{/js/toasts.js}"></script>
-<script th:src="@{/js/casino-sounds.js}"></script>
-<script th:src="@{/js/casino-jackpot.js}"></script>
-<script th:src="@{/js/casino-topup.js}"></script>
-<script th:src="@{/js/casino-result.js}"></script>
-<script th:src="@{/js/casino-game.js}"></script>
+<th:block th:replace="~{fragments/casinoMinigame :: scripts}"></th:block>
 <script th:src="@{/js/scratch.js}"></script>
 </body>
 </html>

--- a/web/src/main/resources/templates/slots.html
+++ b/web/src/main/resources/templates/slots.html
@@ -69,13 +69,7 @@
 
 <div class="toast-stack" id="toast-stack" aria-live="polite"></div>
 
-<script th:src="@{/js/api.js}"></script>
-<script th:src="@{/js/toasts.js}"></script>
-<script th:src="@{/js/casino-sounds.js}"></script>
-<script th:src="@{/js/casino-jackpot.js}"></script>
-<script th:src="@{/js/casino-topup.js}"></script>
-<script th:src="@{/js/casino-result.js}"></script>
-<script th:src="@{/js/casino-game.js}"></script>
+<th:block th:replace="~{fragments/casinoMinigame :: scripts}"></th:block>
 <script th:src="@{/js/slots.js}"></script>
 </body>
 </html>

--- a/web/src/test/js/casino-minigame-dom.test.js
+++ b/web/src/test/js/casino-minigame-dom.test.js
@@ -1,0 +1,45 @@
+const { standardElements } = require('../../main/resources/static/js/casino-minigame-dom');
+
+describe('TobyCasinoMinigameDom.standardElements', () => {
+    afterEach(() => { document.body.innerHTML = ''; });
+
+    test('returns null when no <main data-guild-id> is present', () => {
+        document.body.innerHTML = '<div></div>';
+        expect(standardElements('dice', 'roll')).toBeNull();
+    });
+
+    test('resolves the {prefix}-X element family from data attributes', () => {
+        document.body.innerHTML =
+            '<main data-guild-id="42" data-toby-coins="7" data-market-price="1.5">' +
+            '<form id="dice-bet"></form>' +
+            '<input id="dice-stake">' +
+            '<button id="dice-roll"></button>' +
+            '<button id="dice-roll-toby"></button>' +
+            '<span id="dice-balance"></span>' +
+            '<div id="dice-result"></div>' +
+            '</main>';
+
+        const els = standardElements('dice', 'roll');
+
+        expect(els.guildId).toBe('42');
+        expect(els.tobyCoins).toBe(7);
+        expect(els.marketPrice).toBe(1.5);
+        expect(els.form.id).toBe('dice-bet');
+        expect(els.stakeInput.id).toBe('dice-stake');
+        expect(els.primaryBtn.id).toBe('dice-roll');
+        expect(els.tobyBtn.id).toBe('dice-roll-toby');
+        expect(els.balanceEl.id).toBe('dice-balance');
+        expect(els.resultEl.id).toBe('dice-result');
+    });
+
+    test('missing tobyCoins / marketPrice attrs default to 0', () => {
+        document.body.innerHTML =
+            '<main data-guild-id="1"></main>';
+
+        const els = standardElements('coinflip', 'flip');
+
+        expect(els.guildId).toBe('1');
+        expect(els.tobyCoins).toBe(0);
+        expect(els.marketPrice).toBe(0);
+    });
+});

--- a/web/src/test/js/casino-result-line.test.js
+++ b/web/src/test/js/casino-result-line.test.js
@@ -1,0 +1,46 @@
+const { factory } = require('../../main/resources/static/js/casino-result-line');
+require('../../main/resources/static/js/casino-result');
+require('../../main/resources/static/js/casino-render');
+
+describe('TobyCasinoResultLine.factory', () => {
+    let resultEl;
+    let flashEl;
+
+    beforeEach(() => {
+        document.body.innerHTML = '<div id="r"></div><section id="t"></section>';
+        resultEl = document.getElementById('r');
+        flashEl = document.getElementById('t');
+    });
+
+    test('builds a renderer that emits the win line and toggles the win class', () => {
+        const render = factory({
+            classPrefix: 'foo',
+            winLine: (b) => 'won ' + b.net,
+            loseLine: () => 'lost',
+        });
+        render(resultEl, { win: true, net: 200 }, flashEl);
+        expect(resultEl.classList.contains('foo-result-win')).toBe(true);
+        expect(resultEl.innerHTML).toContain('won 200');
+    });
+
+    test('lose path emits the lose line and toggles the lose class', () => {
+        const render = factory({
+            classPrefix: 'foo',
+            winLine: () => 'won',
+            loseLine: (b) => 'lost ' + Math.abs(b.net),
+        });
+        render(resultEl, { win: false, net: -75 }, flashEl);
+        expect(resultEl.classList.contains('foo-result-lose')).toBe(true);
+        expect(resultEl.innerHTML).toContain('lost 75');
+    });
+
+    test('flashes a chip stack on the flash target on a win', () => {
+        const render = factory({
+            classPrefix: 'foo',
+            winLine: () => 'won',
+            loseLine: () => 'lost',
+        });
+        render(resultEl, { win: true, net: 500 }, flashEl);
+        expect(flashEl.querySelector('.casino-chip-stack')).not.toBeNull();
+    });
+});


### PR DESCRIPTION
## Summary

A conservative repetition-reduction pass across three areas. ~780 insertions / ~420 deletions across 39 files; Blackjack/Poker controllers and existing tests are left untouched per request.

### Web backend (casino controllers, no Blackjack/Poker)

- **`CasinoCommonFailure`** sealed interface in `common/casino/`: per-game outcome hierarchies (Dice/Coinflip/Slots/Scratch/Highlow/Baccarat) implement matching marker interfaces on their `Insufficient*` / `InvalidStake` / `UnknownUser` cases.
- **`CasinoOutcomeMapper.mapCommonFailure(failure)`**: collapses four `when`-arms into one `is CasinoCommonFailure -> errors.mapCommonFailure(outcome)` per controller.
- **`CasinoPageContext.renderMinigamePage()`** extension: folds membership guard + populate + bot-kicked redirect + per-game rules block into one call site (extension function so existing tests that mock `populate` still work).
- **`Long.positiveOrNull()`** extension: replaces ~30 `takeIf { it > 0L }` occurrences across the casino response builders.

### Frontend (Thymeleaf templates + JS)

- **`fragments/casinoMinigame.html :: scripts`** fragment: replaces the 7 shared `<script>` tags duplicated across 5 minigame templates.
- **`casino-minigame-dom.js`** `standardElements()`: folds the `{prefix}-X` `getElementById` trio into one call. Each per-game IIFE shrinks by ~10 lines.
- **`casino-result-line.js`** factory: available for new code; existing `renderXResult` functions kept stable so jest tests don't need new requires.

### Discord-bot

- **`InteractionHook.replyAndDelete` / `replyEmbedAndDelete` / `replyEphemeralAndDelete`** in `core.command.Command.Companion`: collapse the `event.hook.sendMessage(x).queue(invokeDeleteOnMessageResponse(d))` pattern.
- **`bot.toby.helpers.SlashCommandOptions`**: `intOption` / `longOption` / `stringOption` / `booleanOption` / `memberOption` / `userOption` replace the Java `Optional.ofNullable(event.getOption(...)).map { ... }.orElse(...)` chain.
- **`common.discord.embed { ... }`** DSL + `EmbedBuilder.field` shorthand: replace the verbose `EmbedBuilder().setTitle().setColor().build()` chain.
- Sample call sites migrated: `RollCommand`, `AdjustUserCommand` (validation paths only — `sendMessageFormat` sites kept to preserve existing test expectations), `MusicPlayerHelper`.

## Test plan

- [x] `:common :core-api :database :web` Kotlin tests all pass (`./gradlew test`)
- [x] All 70 casino controller tests pass after the `CasinoCommonFailure` migration
- [x] All 247 jest tests pass (241 existing + 6 new for the two new JS helpers)
- [ ] CI: `:discord-bot` compile + tests (couldn't run locally — sandbox can't reach the lavalink/libdave Maven repos; my changes only add new helpers and migrate uncontroversial sites, so this should compile cleanly in CI)
- [ ] Manual smoke each minigame in a browser: place a bet, verify win/lose render, balance update, jackpot banner, TOBY top-up button work identically
- [ ] Discord smoke test (`/roll`, `/adjustuser`, music commands) in a dev guild — confirm reply formatting + auto-delete timing match prior behaviour

https://claude.ai/code/session_01LXHzySn7YRADZtwU5Dp9vJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01LXHzySn7YRADZtwU5Dp9vJ)_