### PR TITLE
refactor(casino web): centralize wallet-balance updates into TobyBalance.update

### DIFF
--- a/web/src/main/resources/static/js/blackjack-solo.js
+++ b/web/src/main/resources/static/js/blackjack-solo.js
@@ -262,11 +262,6 @@
             .catch(function (e) { console.warn("state poll failed", e); });
     }
 
-    function setBalance(b) {
-        if (b == null) return;
-        balanceEl.textContent = b;
-    }
-
     dealForm.addEventListener("submit", function (e) {
         e.preventDefault();
         var stake = parseInt(stakeInput.value, 10);
@@ -286,7 +281,7 @@
                 // wallet looked like it stayed full all hand and only "lost" the
                 // stake on resolution — making each subsequent action feel like
                 // it was charging stake again.
-                setBalance(b.newBalance);
+                window.TobyBalance.update(balanceEl, b.newBalance);
                 if (b.resolved) {
                     refreshState();
                 } else {
@@ -307,7 +302,7 @@
                 // live wallet on Continued too. HIT/STAND don't move the
                 // balance, but DOUBLE/SPLIT pre-debit additional stake mid-hand
                 // and the player should see that immediately.
-                setBalance(b.newBalance);
+                window.TobyBalance.update(balanceEl, b.newBalance);
                 refreshState();
             });
     }

--- a/web/src/main/resources/static/js/blackjack-table.js
+++ b/web/src/main/resources/static/js/blackjack-table.js
@@ -281,11 +281,6 @@
     // POSTs go via TobyApi.postJson so the Spring Security CSRF header
     // (read off the <meta name="_csrf"> tag in the head fragment) is
     // included — without it Spring rejects the request with 403.
-    function setBalance(b) {
-        if (b == null) return;
-        if (balanceEl) balanceEl.textContent = b;
-    }
-
     function postAction(action) {
         return window.TobyApi.postJson("/blackjack/" + guildId + "/" + tableId + "/action", { action: action })
             .then(function (b) {
@@ -297,7 +292,7 @@
                 // response — without this the multi page never updates the
                 // displayed balance, so DOUBLE/SPLIT pre-debits and end-of-hand
                 // payouts only show on a full page reload.
-                setBalance(b.newBalance);
+                window.TobyBalance.update(balanceEl, b.newBalance);
                 refreshState();
             });
     }
@@ -314,6 +309,11 @@
                     window.toasts && window.toasts.error(b.error || "Start failed.");
                     return;
                 }
+                // /start re-debits each seated player's ante for the next hand
+                // (BlackjackService.startMultiHand). Pick up whatever the
+                // server echoes — currently only present on responses that opt
+                // in via newBalance; no-ops cleanly until the backend adds it.
+                window.TobyBalance.update(balanceEl, b.newBalance);
                 refreshState();
             });
     });
@@ -325,7 +325,7 @@
                     window.toasts && window.toasts.error(b.error || "Join failed.");
                     return;
                 }
-                setBalance(b.newBalance);
+                window.TobyBalance.update(balanceEl, b.newBalance);
                 refreshState();
             });
     });
@@ -337,7 +337,7 @@
                     window.toasts && window.toasts.error(b.error || "Leave failed.");
                     return;
                 }
-                setBalance(b.newBalance);
+                window.TobyBalance.update(balanceEl, b.newBalance);
                 if (b.queued) {
                     window.toasts && window.toasts.info("Leaving — you'll auto-stand and be removed at end of hand.");
                 } else {

--- a/web/src/main/resources/static/js/casino-balance.js
+++ b/web/src/main/resources/static/js/casino-balance.js
@@ -1,0 +1,33 @@
+// Tiny shared helper for "set the displayed wallet balance" — used by
+// every casino page that updates a `*-balance` element from a server
+// response's `newBalance` field. Mirrors the TobyJackpot module shape so
+// that page-specific JS can call one canonical write site instead of
+// each file rolling its own `if (b == null) return; el.textContent = b`.
+//
+// Game-specific layout (`#bj-balance`, `#poker-balance`, `#tip-balance`,
+// the standardised `els.balanceEl` from casino-minigame-dom.js) all funnel
+// through here, so a future tweak to balance presentation (animation,
+// currency formatting, balance-flash on big swings) is one edit.
+(function (root) {
+    'use strict';
+
+    /**
+     * Write `newBalance` into [el].textContent. No-ops cleanly when the
+     * element is missing (page without a wallet readout) or when the
+     * server omitted the field — matches the existing one-shot game
+     * helper's `typeof !== 'number'` guard so a stringified number from a
+     * misbehaving backend doesn't end up as literal "[object Object]" or
+     * "undefined" in the wallet.
+     */
+    function update(el, newBalance) {
+        if (!el) return;
+        if (typeof newBalance !== 'number') return;
+        el.textContent = String(newBalance);
+    }
+
+    const api = { update };
+    if (root) root.TobyBalance = api;
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = api;
+    }
+})(typeof window !== 'undefined' ? window : null);

--- a/web/src/main/resources/static/js/casino-game.js
+++ b/web/src/main/resources/static/js/casino-game.js
@@ -75,6 +75,14 @@
         }
 
         function applyBalance(newBalance) {
+            // Delegates to the shared module so every casino page funnels
+            // wallet writes through one site (animations, formatting, etc.).
+            // Falls back to the inline write if the shared module didn't
+            // load (older test paths that don't require it).
+            if (root && root.TobyBalance) {
+                root.TobyBalance.update(balanceEl, newBalance);
+                return;
+            }
             if (typeof newBalance !== 'number') return;
             if (balanceEl) balanceEl.textContent = newBalance;
         }

--- a/web/src/main/resources/static/js/poker-table.js
+++ b/web/src/main/resources/static/js/poker-table.js
@@ -306,7 +306,7 @@
                     return;
                 }
                 showToast('success', 'Cashed out ' + resp.chipsReturned + ' chips.');
-                if (balanceEl && resp.newBalance != null) balanceEl.textContent = resp.newBalance;
+                window.TobyBalance.update(balanceEl, resp.newBalance);
                 window.location.href = '/poker/' + guildId;
             })
             .catch(function () { showToast('error', 'Network error.'); });
@@ -328,7 +328,7 @@
                         return;
                     }
                     showToast('success', 'You sat down with ' + buyIn + ' chips.');
-                    if (balanceEl && resp.newBalance != null) balanceEl.textContent = resp.newBalance;
+                    window.TobyBalance.update(balanceEl, resp.newBalance);
                     refresh();
                 })
                 .catch(function () { showToast('error', 'Network error.'); });

--- a/web/src/main/resources/static/js/scratch.js
+++ b/web/src/main/resources/static/js/scratch.js
@@ -15,7 +15,9 @@ function renderScratchResult(resultEl, body, matchThreshold, balanceEl, flashTar
                 Math.abs(body.net) + ' credits</strong>',
         });
     }
-    if (typeof body.newBalance === 'number' && balanceEl) balanceEl.textContent = body.newBalance;
+    if (typeof window !== 'undefined' && window.TobyBalance) {
+        window.TobyBalance.update(balanceEl, body.newBalance);
+    }
     // Scratch's response has no `win` field — net > 0 is the win signal.
     // Bigger payouts get a taller stack (capped internally at 7).
     if (typeof window !== 'undefined' && window.CasinoRender) {

--- a/web/src/main/resources/static/js/tip.js
+++ b/web/src/main/resources/static/js/tip.js
@@ -41,7 +41,7 @@
                 return;
             }
 
-            if (balanceEl) balanceEl.textContent = String(resp.senderNewBalance);
+            window.TobyBalance.update(balanceEl, resp.senderNewBalance);
             if (sentEl) sentEl.textContent = String(resp.sentTodayAfter);
 
             if (headroomEl) {

--- a/web/src/main/resources/templates/blackjack-lobby.html
+++ b/web/src/main/resources/templates/blackjack-lobby.html
@@ -75,6 +75,7 @@
 <script th:src="@{/js/api.js}"></script>
 <script th:src="@{/js/toasts.js}"></script>
 <script th:src="@{/js/casino-jackpot.js}"></script>
+<script th:src="@{/js/casino-balance.js}"></script>
 <script th:src="@{/js/blackjack-lobby.js}"></script>
 </body>
 </html>

--- a/web/src/main/resources/templates/blackjack-solo.html
+++ b/web/src/main/resources/templates/blackjack-solo.html
@@ -77,6 +77,7 @@
 <script th:src="@{/js/toasts.js}"></script>
 <script th:src="@{/js/casino-sounds.js}"></script>
 <script th:src="@{/js/casino-jackpot.js}"></script>
+<script th:src="@{/js/casino-balance.js}"></script>
 <script th:src="@{/js/casino-render.js}"></script>
 <script th:src="@{/js/blackjack-solo.js}"></script>
 </body>

--- a/web/src/main/resources/templates/blackjack-table.html
+++ b/web/src/main/resources/templates/blackjack-table.html
@@ -78,6 +78,7 @@
 <script th:src="@{/js/toasts.js}"></script>
 <script th:src="@{/js/casino-sounds.js}"></script>
 <script th:src="@{/js/casino-jackpot.js}"></script>
+<script th:src="@{/js/casino-balance.js}"></script>
 <script th:src="@{/js/casino-render.js}"></script>
 <script th:src="@{/js/blackjack-table.js}"></script>
 </body>

--- a/web/src/main/resources/templates/fragments/casinoMinigame.html
+++ b/web/src/main/resources/templates/fragments/casinoMinigame.html
@@ -44,6 +44,7 @@
     <script th:src="@{/js/toasts.js}"></script>
     <script th:src="@{/js/casino-sounds.js}"></script>
     <script th:src="@{/js/casino-jackpot.js}"></script>
+    <script th:src="@{/js/casino-balance.js}"></script>
     <script th:src="@{/js/casino-topup.js}"></script>
     <script th:src="@{/js/casino-result.js}"></script>
     <script th:src="@{/js/casino-game.js}"></script>

--- a/web/src/main/resources/templates/keno.html
+++ b/web/src/main/resources/templates/keno.html
@@ -131,6 +131,7 @@
 <script th:src="@{/js/toasts.js}"></script>
 <script th:src="@{/js/casino-sounds.js}"></script>
 <script th:src="@{/js/casino-jackpot.js}"></script>
+<script th:src="@{/js/casino-balance.js}"></script>
 <script th:src="@{/js/casino-topup.js}"></script>
 <script th:src="@{/js/casino-result.js}"></script>
 <script th:src="@{/js/casino-render.js}"></script>

--- a/web/src/main/resources/templates/poker-lobby.html
+++ b/web/src/main/resources/templates/poker-lobby.html
@@ -79,6 +79,7 @@
 <script th:src="@{/js/api.js}"></script>
 <script th:src="@{/js/toasts.js}"></script>
 <script th:src="@{/js/casino-jackpot.js}"></script>
+<script th:src="@{/js/casino-balance.js}"></script>
 <script th:src="@{/js/poker-lobby.js}"></script>
 </body>
 </html>

--- a/web/src/main/resources/templates/poker-table.html
+++ b/web/src/main/resources/templates/poker-table.html
@@ -84,6 +84,7 @@
 <script th:src="@{/js/toasts.js}"></script>
 <script th:src="@{/js/casino-sounds.js}"></script>
 <script th:src="@{/js/casino-jackpot.js}"></script>
+<script th:src="@{/js/casino-balance.js}"></script>
 <script th:src="@{/js/casino-render.js}"></script>
 <script th:src="@{/js/poker-pots.js}"></script>
 <script th:src="@{/js/poker-table.js}"></script>

--- a/web/src/main/resources/templates/tip.html
+++ b/web/src/main/resources/templates/tip.html
@@ -57,6 +57,7 @@
 
 <script th:src="@{/js/api.js}"></script>
 <script th:src="@{/js/toasts.js}"></script>
+<script th:src="@{/js/casino-balance.js}"></script>
 <script th:src="@{/js/tip.js}"></script>
 </body>
 </html>

--- a/web/src/test/js/blackjack-balance-refresh.test.js
+++ b/web/src/test/js/blackjack-balance-refresh.test.js
@@ -46,6 +46,10 @@ describe('blackjack-solo.js — wallet refresh on every action', () => {
 
         postJsonMock = jest.fn();
         window.TobyApi = { postJson: postJsonMock };
+        // blackjack-solo.js calls window.TobyBalance.update — load the
+        // shared helper into this jsdom before requiring the page IIFE
+        // so the writes go through the centralized site.
+        require('../../main/resources/static/js/casino-balance');
         // The IIFE schedules a refreshState() on load via fetch — stub it
         // out so we don't hit the network in jsdom.
         window.fetch = jest.fn().mockResolvedValue({

--- a/web/src/test/js/casino-balance.test.js
+++ b/web/src/test/js/casino-balance.test.js
@@ -1,0 +1,47 @@
+// Unit tests for the shared `TobyBalance.update` helper. The function
+// has to be defensive across every caller (one-shot games, multi-step
+// blackjack/poker, tip) so its no-op cases need to be explicit:
+//   - missing element  → no-op (page without a wallet readout)
+//   - non-number value → no-op (server omitted `newBalance`, or sent a
+//                        bad type — don't clobber the existing display)
+//   - 0                → must write '0' (regression guard against a
+//                        truthy-check that drops a legitimate zero balance)
+require('../../main/resources/static/js/casino-balance');
+
+describe('TobyBalance.update', () => {
+    let el;
+
+    beforeEach(() => {
+        document.body.innerHTML = '<strong id="bal">starting</strong>';
+        el = document.getElementById('bal');
+    });
+
+    test('writes the new balance as text when it is a number', () => {
+        window.TobyBalance.update(el, 1234);
+        expect(el.textContent).toBe('1234');
+    });
+
+    test('writes 0 — never let a truthy-check drop a real zero balance', () => {
+        window.TobyBalance.update(el, 0);
+        expect(el.textContent).toBe('0');
+    });
+
+    test('no-ops on a null element (page without a wallet readout)', () => {
+        expect(() => window.TobyBalance.update(null, 100)).not.toThrow();
+    });
+
+    test('no-ops on undefined newBalance — preserves existing display', () => {
+        window.TobyBalance.update(el, undefined);
+        expect(el.textContent).toBe('starting');
+    });
+
+    test('no-ops on null newBalance — preserves existing display', () => {
+        window.TobyBalance.update(el, null);
+        expect(el.textContent).toBe('starting');
+    });
+
+    test('no-ops on a non-number (stringly-typed bad backend) — preserves display', () => {
+        window.TobyBalance.update(el, '999');
+        expect(el.textContent).toBe('starting');
+    });
+});

--- a/web/src/test/js/scratch.test.js
+++ b/web/src/test/js/scratch.test.js
@@ -1,3 +1,7 @@
+// Order matters: load `casino-balance` *before* the scratch module so
+// `window.TobyBalance.update` is registered by the time the scratch
+// module's top-level `renderScratchResult` ends up calling it.
+require('../../main/resources/static/js/casino-balance');
 const { renderScratchResult } = require('../../main/resources/static/js/scratch');
 require('../../main/resources/static/js/casino-jackpot');
 require('../../main/resources/static/js/casino-result');


### PR DESCRIPTION
## Summary

Follow-up to #386. Every casino page that mirrors a server-side wallet was rolling its own write — two duplicated `setBalance` helpers in blackjack, three inline `balanceEl.textContent = …` writes (poker, tip, scratch), and `casino-game.js`'s private `applyBalance`. Adding a presentation tweak (animation, currency formatting, big-swing flash) would have been six edits.

- Introduces **`casino-balance.js`** exporting `TobyBalance.update(el, newBalance)` — mirrors the existing `TobyJackpot` module shape.
- Loaded next to `casino-jackpot.js` on every casino page (lobbies, tables, solo, keno, the shared `casinoMinigame.html` fragment) and on `tip.html`.
- Every existing wallet write swapped for `window.TobyBalance.update(balanceEl, body.newBalance)`. `casino-game.js#applyBalance` delegates with a defensive inline fallback.
- Also picks up the missing wallet refresh on **`blackjack-table.js`'s startBtn** — host who dealt the next hand previously saw a stale balance until first action. (Note: `BlackjackController.start` doesn't echo `newBalance` yet — the centralized call is in place; backend follow-up filed mentally.)

Considered and rejected: an "auto-update from `body.newBalance` in `api.js` against a shared CSS class". Saves ~12 LOC but creates correctness hazards — `tip.js` uses `senderNewBalance` not `newBalance`, `duel.js`'s response carries the *other* user's balance, and scratch's `autoApplyBalance: false` (suspense-reveal) would break. Explicit beats magic for a wallet write.

`duel.js` is intentionally left out — its dead-code comment at L138-141 admits the response doesn't tell the viewer which side is theirs. Backend gap, not wiring gap.

## Test plan

- [x] New `web/src/test/js/casino-balance.test.js` (6 tests) — null el, null/undefined/non-number values, the `0` regression guard, normal write.
- [x] `web/src/test/js/blackjack-balance-refresh.test.js` (4 tests) — extended setup to require the new module; same end-to-end DOM assertions still pass through the indirection.
- [x] `web/src/test/js/scratch.test.js` — extended setup to require the new module; existing tests still pass.
- [x] Full `npx jest` — 265 tests across 25 suites all green.
- [x] `./gradlew :web:test` — green.
- [x] `grep "balanceEl.textContent\\s*=\\|setBalance(" web/src/main/resources/static/js/` returns only the intentional fallback inside `casino-game.js`.
- [ ] Manual UI smoke at `/blackjack/{guildId}/solo`, `/blackjack/{guildId}/{tableId}`, `/poker/{guildId}/{tableId}`, `/tip`, plus one one-shot game (e.g. `/dice`).

https://claude.ai/code/session_01CDwxwoXNPurmJDj5sPXnGd

---
_Generated by [Claude Code](https://claude.ai/code/session_01CDwxwoXNPurmJDj5sPXnGd)_