### PR TITLE
fix(casino web): hold jackpot pool banner until reveal animation lands

### DIFF
--- a/web/src/main/resources/static/js/casino-game.js
+++ b/web/src/main/resources/static/js/casino-game.js
@@ -130,6 +130,14 @@
             setDisabled(true);
             const animationHandle = startAnimation();
             const requestStart = Date.now();
+            // Hold the central pool-banner refresh (api.js feeds it from
+            // X-Jackpot-Pool the moment the response lands, which would
+            // otherwise leak the outcome before the reels/coin/cards
+            // settle). Pages without TobyJackpot just skip silently.
+            // Scratch opts out — its lock spans the user-driven reveal
+            // and is managed inside scratch.js itself.
+            const jackpot = (autoApplyBalance && root && root.TobyJackpot) ? root.TobyJackpot : null;
+            if (jackpot) jackpot.holdPoolBanner();
 
             postJson(endpoint, payload)
                 .then(function (body) {
@@ -149,6 +157,7 @@
                             hideResult();
                             showToast((body && body.error) || failureMessage, 'error');
                         }
+                        if (jackpot) jackpot.releasePoolBanner();
                     }, remaining);
                 })
                 .catch(function () {
@@ -157,6 +166,7 @@
                     setDisabled(false);
                     hideResult();
                     showToast('Network error.', 'error');
+                    if (jackpot) jackpot.releasePoolBanner();
                 });
         }
 

--- a/web/src/main/resources/static/js/casino-jackpot.js
+++ b/web/src/main/resources/static/js/casino-jackpot.js
@@ -15,19 +15,49 @@
         return '🎰 <strong>JACKPOT!</strong> +' + payout + ' credits<br>';
     }
 
+    // Hold/release lock used by per-game JS to keep the pool banner in
+    // sync with reveal animations. While held, updatePoolBanner queues
+    // the latest body instead of painting (last-write-wins) so a player
+    // can't read the outcome from the banner ticking before the reels
+    // stop / cards land / scratch cells reveal. release flushes the
+    // queued body. Pages without an animation never call hold so the
+    // existing immediate-paint behaviour is preserved.
+    let locked = false;
+    let pending = null;
+
+    function paintPoolBanner(body) {
+        if (typeof document === 'undefined') return;
+        const target = document.querySelector('.casino-jackpot-banner strong');
+        if (target) target.textContent = String(body.jackpotPool);
+    }
+
     /**
      * Refresh the per-guild jackpot pool banner (`fragments/casino.html`)
      * from a `body.jackpotPool` value. Called centrally by api.js after
      * every casino POST, fed from the X-Jackpot-Pool response header — so
      * games never have to remember to mirror the pool themselves. No-ops
      * when the field is absent or the banner isn't on the current page (so
-     * duel/trade/tip pages silently skip the DOM write).
+     * duel/trade/tip pages silently skip the DOM write). When the banner
+     * is held (see holdPoolBanner) the value is stashed and painted on
+     * release instead.
      */
     function updatePoolBanner(body) {
         if (!body || typeof body.jackpotPool !== 'number') return;
-        if (typeof document === 'undefined') return;
-        const target = document.querySelector('.casino-jackpot-banner strong');
-        if (target) target.textContent = String(body.jackpotPool);
+        if (locked) { pending = body; return; }
+        paintPoolBanner(body);
+    }
+
+    function holdPoolBanner() {
+        locked = true;
+    }
+
+    function releasePoolBanner() {
+        locked = false;
+        if (pending) {
+            const body = pending;
+            pending = null;
+            paintPoolBanner(body);
+        }
     }
 
     /**
@@ -54,7 +84,15 @@
             body.lossTribute + ' to jackpot</span>';
     }
 
-    const api = { isJackpotHit, jackpotPrefixHtml, renderWinHtml, lossTributeSuffix, updatePoolBanner };
+    const api = {
+        isJackpotHit,
+        jackpotPrefixHtml,
+        renderWinHtml,
+        lossTributeSuffix,
+        updatePoolBanner,
+        holdPoolBanner,
+        releasePoolBanner,
+    };
 
     // Browser global so each game's IIFE-style JS can reach it without
     // bundler plumbing.

--- a/web/src/main/resources/static/js/scratch.js
+++ b/web/src/main/resources/static/js/scratch.js
@@ -83,6 +83,9 @@ function renderScratchResult(resultEl, body, matchThreshold, balanceEl, flashTar
             // Now the credits visibly drop and the topup-coin recompute
             // catches up too — see autoApplyBalance: false in the helper.
             if (game) game.applyTobyDelta(activeCard);
+            // And only now release the central jackpot-pool banner so it
+            // doesn't tick before the suspense beat is over.
+            if (window.TobyJackpot) window.TobyJackpot.releasePoolBanner();
             // Card consumed — next "Buy ticket" starts a fresh one.
             activeCard = null;
             if (revealBtn) revealBtn.hidden = true;
@@ -135,6 +138,12 @@ function renderScratchResult(resultEl, body, matchThreshold, balanceEl, flashTar
         startAnimation: function () {
             if (els.resultEl) els.resultEl.hidden = true;
             resetCells();
+            // Hold the central jackpot-pool banner across the whole
+            // user-driven reveal — released in revealCell once every
+            // cell is uncovered (or on a server error in stopAnimation).
+            // casino-game.js skips its own hold for scratch because
+            // autoApplyBalance is false.
+            if (window.TobyJackpot) window.TobyJackpot.holdPoolBanner();
             return null;
         },
         stopAnimation: function (_handle, body) {
@@ -144,6 +153,9 @@ function renderScratchResult(resultEl, body, matchThreshold, balanceEl, flashTar
             } else {
                 activeCard = null;
                 if (revealBtn) revealBtn.hidden = true;
+                // Server errored or returned a non-ok body — there's
+                // no reveal coming, so drop the lock now.
+                if (window.TobyJackpot) window.TobyJackpot.releasePoolBanner();
             }
         },
         renderResult: function () {

--- a/web/src/test/js/casino-game-jackpot-lock.test.js
+++ b/web/src/test/js/casino-game-jackpot-lock.test.js
@@ -1,0 +1,127 @@
+// Drives `window.TobyCasinoGame.init` end-to-end with a stubbed postJson
+// to confirm that the shared scaffold acquires the central jackpot-pool
+// lock before the request and releases it on the settle tick (or on a
+// network / server error). This is what stops the per-guild "Jackpot:"
+// banner from leaking the outcome before the reveal animation lands.
+
+require('../../main/resources/static/js/casino-jackpot');
+require('../../main/resources/static/js/casino-game');
+
+describe('casino-game.js — pool banner lock around settle', () => {
+    let postJsonMock;
+    let holdSpy;
+    let releaseSpy;
+
+    beforeEach(() => {
+        document.body.innerHTML =
+            '<form id="f">' +
+            '  <input id="s" type="number" value="10">' +
+            '  <button id="p" type="submit">Spin</button>' +
+            '</form>' +
+            '<span id="bal">100</span>' +
+            '<div id="r"></div>' +
+            '<div class="casino-jackpot-banner"><strong>0</strong></div>';
+
+        postJsonMock = jest.fn();
+        window.TobyApi = { postJson: postJsonMock };
+        // Reset any leaked hold from a previous test before installing
+        // spies, so the first call we observe is the one this test makes.
+        window.TobyJackpot.releasePoolBanner();
+        holdSpy = jest.spyOn(window.TobyJackpot, 'holdPoolBanner');
+        releaseSpy = jest.spyOn(window.TobyJackpot, 'releasePoolBanner');
+        jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+        holdSpy.mockRestore();
+        releaseSpy.mockRestore();
+        delete window.TobyApi;
+    });
+
+    function buildGame(overrides) {
+        const cfg = Object.assign({
+            form: document.getElementById('f'),
+            stakeInput: document.getElementById('s'),
+            primaryBtn: document.getElementById('p'),
+            balanceEl: document.getElementById('bal'),
+            resultEl: document.getElementById('r'),
+            guildId: 'g1',
+            endpoint: '/spin',
+            minSettleMs: 800,
+        }, overrides || {});
+        return window.TobyCasinoGame.init(cfg);
+    }
+
+    test('hold acquired before postJson resolves', () => {
+        postJsonMock.mockImplementation(() => new Promise(() => {})); // never resolves
+        const game = buildGame();
+        game.run(false);
+        expect(holdSpy).toHaveBeenCalledTimes(1);
+        expect(releaseSpy).not.toHaveBeenCalled();
+    });
+
+    test('release fires only after minSettleMs has elapsed', async () => {
+        postJsonMock.mockResolvedValue({ ok: true, jackpotPool: 500, newBalance: 90 });
+        const game = buildGame({ minSettleMs: 800 });
+        game.run(false);
+
+        // Flush the .then microtask so the setTimeout is scheduled.
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(releaseSpy).not.toHaveBeenCalled();
+        jest.advanceTimersByTime(799);
+        expect(releaseSpy).not.toHaveBeenCalled();
+        jest.advanceTimersByTime(1);
+        expect(releaseSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test('release fires on network error (postJson rejects)', async () => {
+        postJsonMock.mockRejectedValue(new Error('network down'));
+        const game = buildGame();
+        game.run(false);
+
+        // Flush the .catch microtask.
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(releaseSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test('release fires on a server-side error body (ok: false)', async () => {
+        postJsonMock.mockResolvedValue({ ok: false, error: 'broke' });
+        const game = buildGame({ minSettleMs: 200 });
+        game.run(false);
+
+        await Promise.resolve();
+        await Promise.resolve();
+        jest.advanceTimersByTime(200);
+
+        expect(releaseSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test('autoApplyBalance: false skips the casino-game.js hold', () => {
+        // Scratch sets autoApplyBalance: false because its reveal beat
+        // is user-driven; it manages the lock from inside scratch.js.
+        // The shared scaffold must not also try to hold/release.
+        postJsonMock.mockImplementation(() => new Promise(() => {}));
+        const game = buildGame({ autoApplyBalance: false });
+        game.run(false);
+
+        expect(holdSpy).not.toHaveBeenCalled();
+        expect(releaseSpy).not.toHaveBeenCalled();
+    });
+
+    test('autoApplyBalance: false skips the release on settle too', async () => {
+        postJsonMock.mockResolvedValue({ ok: true, jackpotPool: 12 });
+        const game = buildGame({ autoApplyBalance: false, minSettleMs: 50 });
+        game.run(false);
+
+        await Promise.resolve();
+        await Promise.resolve();
+        jest.advanceTimersByTime(50);
+
+        expect(releaseSpy).not.toHaveBeenCalled();
+    });
+});

--- a/web/src/test/js/casino-jackpot.test.js
+++ b/web/src/test/js/casino-jackpot.test.js
@@ -3,6 +3,9 @@ const {
     jackpotPrefixHtml,
     renderWinHtml,
     lossTributeSuffix,
+    updatePoolBanner,
+    holdPoolBanner,
+    releasePoolBanner,
 } = require('../../main/resources/static/js/casino-jackpot');
 
 // ---------------------------------------------------------------------------
@@ -108,6 +111,81 @@ describe('renderWinHtml', () => {
 // ---------------------------------------------------------------------------
 // lossTributeSuffix
 // ---------------------------------------------------------------------------
+
+describe('pool banner lock', () => {
+    let strong;
+
+    beforeEach(() => {
+        document.body.innerHTML =
+            '<div class="casino-jackpot-banner"><strong>0</strong></div>';
+        strong = document.querySelector('.casino-jackpot-banner strong');
+        // Force-release in case a prior test left the lock held — the
+        // module-level state survives between tests.
+        releasePoolBanner();
+    });
+
+    test('updatePoolBanner paints immediately when no lock is held', () => {
+        updatePoolBanner({ jackpotPool: 100 });
+        expect(strong.textContent).toBe('100');
+    });
+
+    test('updatePoolBanner is a no-op while the banner is held', () => {
+        holdPoolBanner();
+        updatePoolBanner({ jackpotPool: 250 });
+        expect(strong.textContent).toBe('0');
+        releasePoolBanner();
+    });
+
+    test('releasePoolBanner flushes the latest queued value', () => {
+        holdPoolBanner();
+        updatePoolBanner({ jackpotPool: 250 });
+        expect(strong.textContent).toBe('0');
+        releasePoolBanner();
+        expect(strong.textContent).toBe('250');
+    });
+
+    test('last-write-wins under hold — only the final pool paints on release', () => {
+        holdPoolBanner();
+        updatePoolBanner({ jackpotPool: 100 });
+        updatePoolBanner({ jackpotPool: 200 });
+        updatePoolBanner({ jackpotPool: 300 });
+        expect(strong.textContent).toBe('0');
+        releasePoolBanner();
+        expect(strong.textContent).toBe('300');
+    });
+
+    test('release with no queued body leaves the DOM unchanged', () => {
+        strong.textContent = '42';
+        holdPoolBanner();
+        releasePoolBanner();
+        expect(strong.textContent).toBe('42');
+    });
+
+    test('release without a prior hold is a no-op and does not throw', () => {
+        strong.textContent = '7';
+        expect(() => releasePoolBanner()).not.toThrow();
+        expect(strong.textContent).toBe('7');
+    });
+
+    test('hold/update/release survives a missing banner element', () => {
+        document.body.innerHTML = '';
+        expect(() => {
+            holdPoolBanner();
+            updatePoolBanner({ jackpotPool: 999 });
+            releasePoolBanner();
+        }).not.toThrow();
+    });
+
+    test('updates after release paint immediately again', () => {
+        holdPoolBanner();
+        updatePoolBanner({ jackpotPool: 10 });
+        releasePoolBanner();
+        expect(strong.textContent).toBe('10');
+
+        updatePoolBanner({ jackpotPool: 20 });
+        expect(strong.textContent).toBe('20');
+    });
+});
 
 describe('lossTributeSuffix', () => {
     test('renders a "+N to jackpot" span with the casino-loss-tribute class', () => {

--- a/web/src/test/js/scratch-jackpot-lock.test.js
+++ b/web/src/test/js/scratch-jackpot-lock.test.js
@@ -1,0 +1,161 @@
+// Drives the scratch.js IIFE end-to-end to confirm the central
+// jackpot-pool banner stays held across the user-driven reveal — and
+// is only released when the player has uncovered every cell (or the
+// server returned a non-ok body). Lives in a separate file from
+// `scratch.test.js` because it needs to reload the IIFE against a
+// freshly-built scratch DOM (jest caches the require otherwise and
+// the IIFE bails on its `els` guard the first time round).
+
+function buildScratchDom() {
+    const cells = [];
+    for (let i = 0; i < 9; i++) {
+        cells.push(
+            '<button class="scratch-cell" data-index="' + i + '">' +
+            '<span class="scratch-cell-cover">?</span>' +
+            '<span class="scratch-cell-face"></span>' +
+            '</button>'
+        );
+    }
+    document.body.innerHTML =
+        '<main data-guild-id="g1" data-toby-coins="0" data-market-price="0" data-match-threshold="5">' +
+        '<div class="casino-jackpot-banner"><strong>0</strong></div>' +
+        '<form id="scratch-bet">' +
+        '<input id="scratch-stake" type="number" value="10">' +
+        '<button id="scratch-buy" type="submit">Buy</button>' +
+        '</form>' +
+        '<span id="scratch-balance">100</span>' +
+        '<div id="scratch-result"></div>' +
+        '<section class="scratch-table"></section>' +
+        '<div id="scratch-cells">' + cells.join('') + '</div>' +
+        '<button id="scratch-reveal-all">Reveal all</button>' +
+        '</main>';
+}
+
+function loadScratchIIFE() {
+    jest.isolateModules(() => {
+        require('../../main/resources/static/js/casino-jackpot');
+        require('../../main/resources/static/js/casino-minigame-dom');
+        require('../../main/resources/static/js/casino-result');
+        require('../../main/resources/static/js/casino-render');
+        require('../../main/resources/static/js/casino-game');
+        require('../../main/resources/static/js/scratch');
+    });
+}
+
+function makeCard(jackpotPool) {
+    return {
+        ok: true,
+        cells: ['⭐', '🍒', '🍋', '⭐', '🔔', '🍒', '⭐', '🍋', '🍒'],
+        winningSymbol: '⭐',
+        matchCount: 3,
+        net: -10,
+        newBalance: 90,
+        jackpotPool: jackpotPool,
+    };
+}
+
+describe('scratch.js — pool banner lock around reveal', () => {
+    let postJsonMock;
+    let holdSpy;
+    let releaseSpy;
+
+    beforeEach(() => {
+        buildScratchDom();
+        postJsonMock = jest.fn();
+        window.TobyApi = { postJson: postJsonMock };
+        jest.useFakeTimers();
+        loadScratchIIFE();
+        // Spy AFTER the IIFE re-installs window.TobyJackpot.
+        holdSpy = jest.spyOn(window.TobyJackpot, 'holdPoolBanner');
+        releaseSpy = jest.spyOn(window.TobyJackpot, 'releasePoolBanner');
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+        holdSpy.mockRestore();
+        releaseSpy.mockRestore();
+        delete window.TobyApi;
+    });
+
+    function submitBuy() {
+        const form = document.getElementById('scratch-bet');
+        form.dispatchEvent(new Event('submit', { cancelable: true }));
+    }
+
+    function clickCell(idx) {
+        document
+            .querySelector('.scratch-cell[data-index="' + idx + '"]')
+            .click();
+    }
+
+    test('holdPoolBanner fires on buy submit, before any reveal', async () => {
+        postJsonMock.mockResolvedValue(makeCard(500));
+        submitBuy();
+        await Promise.resolve();
+        await Promise.resolve();
+        // Flush the casino-game.js setTimeout(0) → calls stopAnimation
+        // which stashes the card and shows the Reveal-all button.
+        jest.advanceTimersByTime(0);
+
+        expect(holdSpy).toHaveBeenCalledTimes(1);
+        expect(releaseSpy).not.toHaveBeenCalled();
+    });
+
+    test('release fires only when the LAST cell is revealed', async () => {
+        postJsonMock.mockResolvedValue(makeCard(500));
+        submitBuy();
+        await Promise.resolve();
+        await Promise.resolve();
+        jest.advanceTimersByTime(0);
+
+        for (let i = 0; i < 8; i++) {
+            clickCell(i);
+            expect(releaseSpy).not.toHaveBeenCalled();
+        }
+        clickCell(8);
+        expect(releaseSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test('Reveal all triggers exactly one release after the cascade', async () => {
+        postJsonMock.mockResolvedValue(makeCard(500));
+        submitBuy();
+        await Promise.resolve();
+        await Promise.resolve();
+        jest.advanceTimersByTime(0);
+
+        document.getElementById('scratch-reveal-all').click();
+        // Cascade staggers cells at 60ms intervals — 9 cells * 60ms.
+        jest.advanceTimersByTime(9 * 60);
+
+        expect(releaseSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test('server error path releases the lock from stopAnimation', async () => {
+        postJsonMock.mockResolvedValue({ ok: false, error: 'broke' });
+        submitBuy();
+        await Promise.resolve();
+        await Promise.resolve();
+        jest.advanceTimersByTime(0);
+
+        // Hold acquired (startAnimation runs unconditionally), and the
+        // failure branch of stopAnimation must release it so the banner
+        // doesn't get stranded.
+        expect(holdSpy).toHaveBeenCalledTimes(1);
+        expect(releaseSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test('cell clicks before the response arrives do not release the lock', () => {
+        // postJson never resolves — activeCard stays null, so revealCell
+        // bails before reaching the all-revealed branch. The lock is
+        // still held by startAnimation.
+        postJsonMock.mockImplementation(() => new Promise(() => {}));
+        submitBuy();
+
+        for (let i = 0; i < 9; i++) {
+            clickCell(i);
+        }
+
+        expect(holdSpy).toHaveBeenCalledTimes(1);
+        expect(releaseSpy).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
## Summary
- The per-guild `Jackpot: N` banner used to repaint the instant the
  casino response arrived (`api.js` reads `X-Jackpot-Pool` straight to
  the DOM), so a player could read the outcome from the banner ticking
  before the reels stopped, the coin landed, or the scratch cells were
  uncovered. Balance/TOBY-coin updates were already gated by
  `minSettleMs`; the pool banner was the last leak.
- Added a small hold/release lock inside `casino-jackpot.js` (the
  module that already owns banner UI). While held, `updatePoolBanner`
  queues the latest body (last-write-wins) and only paints on release.
  `api.js` keeps calling `updatePoolBanner` exactly as before — the
  lock just decides whether that call paints now or later, so the
  DOM-write location stays singular.
- `casino-game.js` holds before `postJson` and releases inside the
  existing settle `setTimeout` (also from the `.catch` so a network
  error doesn't strand the banner). This automatically covers slots,
  coinflip, dice, highlow, keno, and baccarat — they share the
  scaffold.
- `scratch.js` holds in `startAnimation` and releases either when the
  player uncovers the last cell (next to the existing
  `applyTobyDelta`) or in the `stopAnimation` failure branch when the
  server returns a non-ok body.

## Test plan
- [x] `npm test` — 26 suites, 278 tests pass
- [x] `casino-jackpot.test.js` — 7 new cases for the hold/release
      primitive (immediate paint with no lock, no-op while held, flush
      on release, last-write-wins, double-release no-op,
      release-without-hold no-op, missing-banner no-throw,
      paint-resumes-after-release).
- [x] `casino-game-jackpot-lock.test.js` — 6 new integration cases
      driving `TobyCasinoGame.init()` with a stubbed `postJson`: hold
      acquired before resolve, release at `minSettleMs`, release on
      network error, release on `body.ok === false`, scratch's
      `autoApplyBalance: false` skips both the hold and the release.
- [x] `scratch-jackpot-lock.test.js` — 5 new IIFE-level cases: hold
      on buy, release only after the last cell, single release after
      the `Reveal all` 60ms cascade, server-error release from
      `stopAnimation`, no release while the response is in flight.

https://claude.ai/code/session_01DyuvrdMDUrdgMnRSP3UqVK

---
_Generated by [Claude Code](https://claude.ai/code/session_01DyuvrdMDUrdgMnRSP3UqVK)_