### PR TITLE
fix(casino web): hold lock through staggered reveals (keno, baccarat, highlow play)

### DIFF
--- a/web/src/main/resources/static/js/baccarat.js
+++ b/web/src/main/resources/static/js/baccarat.js
@@ -7,7 +7,10 @@
 // opts.dealMs intervals (default 400ms) so the round feels played, not
 // pre-resolved. Tests pass `stagger: false` to keep their assertions
 // synchronous. The result line / chip flourish / win-or-lose sound are
-// held until the last card lands.
+// held until the last card lands. Returns a Promise that resolves
+// once the deal completes (or undefined on the synchronous path) so
+// the casino-game.js scaffold can hold balance + jackpot-pool updates
+// until the reveal lands.
 function renderBaccaratResult(opts) {
     var resultEl = opts.resultEl;
     var bankerCardsEl = opts.bankerCardsEl;
@@ -84,6 +87,17 @@ function renderBaccaratResult(opts) {
         }
     }
 
+    if (dealMs > 0) {
+        return new Promise(function (resolve) {
+            playBaccaratDeal({
+                playerCardsEl: playerCardsEl,
+                bankerCardsEl: bankerCardsEl,
+                body: body,
+                dealMs: dealMs,
+                onComplete: function () { finalize(); resolve(); },
+            });
+        });
+    }
     playBaccaratDeal({
         playerCardsEl: playerCardsEl,
         bankerCardsEl: bankerCardsEl,
@@ -219,7 +233,10 @@ function loseLineHtml(body, sideLabel, winnerLabel) {
                 return { side: selectedSide(), stake: state.stake, autoTopUp: state.autoTopUp };
             },
             renderResult: function (body) {
-                renderBaccaratResult({
+                // Return the Promise so the scaffold waits for the
+                // staged deal to land before applying balance and
+                // releasing the jackpot-pool banner lock.
+                return renderBaccaratResult({
                     resultEl: els.resultEl,
                     bankerCardsEl: bankerCardsEl,
                     playerCardsEl: playerCardsEl,

--- a/web/src/main/resources/static/js/casino-game.js
+++ b/web/src/main/resources/static/js/casino-game.js
@@ -148,16 +148,34 @@
                         busy = false;
                         setDisabled(false);
                         if (body && body.ok) {
-                            renderResult(body);
-                            if (autoApplyBalance) {
-                                applyBalance(body.newBalance);
-                                applyTobyDelta(body);
+                            // renderResult may run a staggered reveal
+                            // (keno's draw, baccarat's deal) and return a
+                            // Promise that resolves once the last cell /
+                            // card lands. In that case we hold the lock,
+                            // balance, and TOBY-coin update until the
+                            // animation actually completes — otherwise
+                            // the banner / credits would tick first and
+                            // leak the outcome. Synchronous renderResults
+                            // (slots/coinflip/dice) return undefined and
+                            // settle immediately as before.
+                            const settle = renderResult(body);
+                            const finishSettle = function () {
+                                if (autoApplyBalance) {
+                                    applyBalance(body.newBalance);
+                                    applyTobyDelta(body);
+                                }
+                                if (jackpot) jackpot.releasePoolBanner();
+                            };
+                            if (settle && typeof settle.then === 'function') {
+                                settle.then(finishSettle, finishSettle);
+                            } else {
+                                finishSettle();
                             }
                         } else {
                             hideResult();
                             showToast((body && body.error) || failureMessage, 'error');
+                            if (jackpot) jackpot.releasePoolBanner();
                         }
-                        if (jackpot) jackpot.releasePoolBanner();
                     }, remaining);
                 })
                 .catch(function () {

--- a/web/src/main/resources/static/js/casino-game.js
+++ b/web/src/main/resources/static/js/casino-game.js
@@ -200,7 +200,69 @@
         };
     }
 
-    const api = { init: init };
+    // Manual lifecycle helper for casino flows that don't fit the
+    // form-submit scaffold (e.g. highlow's /play button pair). Mirrors
+    // init()'s jackpot-pool-lock + settle-delay handling so the
+    // banner can't tick before the per-flow animation lands. Caller
+    // owns the request, the per-call rendering, balance updates, and
+    // any button-disable bookkeeping.
+    //
+    // opts:
+    //   request    — () => Promise<body> (REQUIRED). Caller's fetch.
+    //   settleMs   — number (default 0). Minimum visual delay between
+    //                request start and onSettle firing, mirroring
+    //                init()'s minSettleMs.
+    //   onSettle   — (body) => void | Promise<void>. Runs once the
+    //                settle delay has elapsed, with whatever the
+    //                request resolved to (success or `{ ok: false }`).
+    //                If it returns a thenable the lock release waits
+    //                for it (parallels init()'s async-renderResult
+    //                support — keno/baccarat-shape).
+    //   onError    — (err) => void. Runs synchronously on a request
+    //                rejection (network / parse failure).
+    function runManual(opts) {
+        const request = opts.request;
+        const settleMs = (typeof opts.settleMs === 'number') ? opts.settleMs : 0;
+        const onSettle = opts.onSettle || function () {};
+        const onError = opts.onError || function () {};
+
+        const jackpot = (root && root.TobyJackpot) ? root.TobyJackpot : null;
+        if (jackpot) jackpot.holdPoolBanner();
+        const start = Date.now();
+        const release = function () {
+            if (jackpot) jackpot.releasePoolBanner();
+        };
+
+        return request().then(function (body) {
+            const remaining = Math.max(0, settleMs - (Date.now() - start));
+            setTimeout(function () {
+                let settled;
+                try {
+                    settled = onSettle(body);
+                } catch (e) {
+                    // Release the lock even if the caller's render
+                    // logic throws — otherwise the banner is stranded.
+                    // Surface the error via console so a regression
+                    // is still visible during dev.
+                    release();
+                    if (typeof console !== 'undefined' && console.error) {
+                        console.error('TobyCasinoGame.runManual onSettle threw:', e);
+                    }
+                    return;
+                }
+                if (settled && typeof settled.then === 'function') {
+                    settled.then(release, release);
+                } else {
+                    release();
+                }
+            }, remaining);
+        }, function (err) {
+            try { onError(err); }
+            finally { release(); }
+        });
+    }
+
+    const api = { init: init, runManual: runManual };
     if (root) root.TobyCasinoGame = api;
     if (typeof module !== 'undefined' && module.exports) {
         module.exports = api;

--- a/web/src/main/resources/static/js/highlow.js
+++ b/web/src/main/resources/static/js/highlow.js
@@ -197,50 +197,47 @@ function renderHighlowResult(resultEl, body, flashTargetEl) {
         higherBtn.disabled = true;
         lowerBtn.disabled = true;
         const intervalId = startNextShuffle();
-        const requestStart = Date.now();
-        // /play uses postJson directly (different lifecycle than /start)
-        // so it doesn't go through casino-game.js's hold path. Hold the
-        // jackpot-pool banner here so it can't tick before the next-card
-        // shuffle settles and leak the outcome.
-        const jackpot = (window.TobyJackpot) ? window.TobyJackpot : null;
-        if (jackpot) jackpot.holdPoolBanner();
 
-        postJson('/casino/' + els.guildId + '/highlow/play', { direction: direction })
-            .then(function (body) {
-                const elapsed = Date.now() - requestStart;
-                const remaining = Math.max(0, NEXT_DEAL_MS - elapsed);
-                setTimeout(function () {
-                    playing = false;
-                    if (body && body.ok) {
-                        stopNextShuffle(intervalId, body.next);
-                        renderHighlowResult(els.resultEl, body, tableEl);
-                        if (window.CasinoSounds) {
-                            window.CasinoSounds.play(body.net > 0 ? 'win' : 'lose');
-                        }
-                        if (game) {
-                            game.applyBalance(body.newBalance);
-                            game.applyTobyDelta(body);
-                        }
-                        // Round consumed → reset to lock mode after the
-                        // player has had a moment to read the result.
-                        setTimeout(showLockMode, ROUND_RESET_MS);
-                    } else {
-                        stopNextShuffle(intervalId);
-                        higherBtn.disabled = false;
-                        lowerBtn.disabled = false;
-                        window.toast((body && body.error) || 'Deal failed.', 'error');
+        // /play has a different lifecycle than /start (button pair, not
+        // form submit) so it goes through casino-game.js's runManual
+        // helper instead of init(). The helper handles the jackpot-pool
+        // lock + settle delay so the banner can't tick before the
+        // next-card shuffle lands.
+        window.TobyCasinoGame.runManual({
+            request: function () {
+                return postJson('/casino/' + els.guildId + '/highlow/play', { direction: direction });
+            },
+            settleMs: NEXT_DEAL_MS,
+            onSettle: function (body) {
+                playing = false;
+                if (body && body.ok) {
+                    stopNextShuffle(intervalId, body.next);
+                    renderHighlowResult(els.resultEl, body, tableEl);
+                    if (window.CasinoSounds) {
+                        window.CasinoSounds.play(body.net > 0 ? 'win' : 'lose');
                     }
-                    if (jackpot) jackpot.releasePoolBanner();
-                }, remaining);
-            })
-            .catch(function () {
+                    if (game) {
+                        game.applyBalance(body.newBalance);
+                        game.applyTobyDelta(body);
+                    }
+                    // Round consumed → reset to lock mode after the
+                    // player has had a moment to read the result.
+                    setTimeout(showLockMode, ROUND_RESET_MS);
+                } else {
+                    stopNextShuffle(intervalId);
+                    higherBtn.disabled = false;
+                    lowerBtn.disabled = false;
+                    window.toast((body && body.error) || 'Deal failed.', 'error');
+                }
+            },
+            onError: function () {
                 stopNextShuffle(intervalId);
                 playing = false;
                 higherBtn.disabled = false;
                 lowerBtn.disabled = false;
                 window.toast('Network error.', 'error');
-                if (jackpot) jackpot.releasePoolBanner();
-            });
+            },
+        });
     }
 
     higherBtn.addEventListener('click', function () { runPlay('HIGHER'); });

--- a/web/src/main/resources/static/js/highlow.js
+++ b/web/src/main/resources/static/js/highlow.js
@@ -198,6 +198,12 @@ function renderHighlowResult(resultEl, body, flashTargetEl) {
         lowerBtn.disabled = true;
         const intervalId = startNextShuffle();
         const requestStart = Date.now();
+        // /play uses postJson directly (different lifecycle than /start)
+        // so it doesn't go through casino-game.js's hold path. Hold the
+        // jackpot-pool banner here so it can't tick before the next-card
+        // shuffle settles and leak the outcome.
+        const jackpot = (window.TobyJackpot) ? window.TobyJackpot : null;
+        if (jackpot) jackpot.holdPoolBanner();
 
         postJson('/casino/' + els.guildId + '/highlow/play', { direction: direction })
             .then(function (body) {
@@ -224,6 +230,7 @@ function renderHighlowResult(resultEl, body, flashTargetEl) {
                         lowerBtn.disabled = false;
                         window.toast((body && body.error) || 'Deal failed.', 'error');
                     }
+                    if (jackpot) jackpot.releasePoolBanner();
                 }, remaining);
             })
             .catch(function () {
@@ -232,6 +239,7 @@ function renderHighlowResult(resultEl, body, flashTargetEl) {
                 higherBtn.disabled = false;
                 lowerBtn.disabled = false;
                 window.toast('Network error.', 'error');
+                if (jackpot) jackpot.releasePoolBanner();
             });
     }
 

--- a/web/src/main/resources/static/js/keno.js
+++ b/web/src/main/resources/static/js/keno.js
@@ -6,7 +6,11 @@
 // On a staged path: the cells the server drew light up one-by-one at
 // dealMs intervals (gold pulse if the draw matches a pick, dim grey
 // otherwise). The result line + chip flourish + win/lose sound hold
-// until every draw has landed.
+// until every draw has landed. Returns a Promise that resolves when
+// the last draw has landed (so the casino-game.js scaffold can hold
+// the balance / jackpot-pool refresh until the reveal completes).
+// Synchronous path (stagger: false / no grid / empty draws) returns
+// undefined, preserving the existing test contract.
 function renderKenoResult(opts) {
     var resultEl = opts.resultEl;
     var statusEl = opts.statusEl;
@@ -87,15 +91,17 @@ function renderKenoResult(opts) {
 
     // Staged path: schedule one cell-light-up per dealMs. The 'click'
     // sound rides the per-cell tick so the player can hear the deal.
-    draws.forEach(function (n, i) {
-        setTimeout(function () {
-            lightUpDraw(gridEl, n, picksSet);
-            if (typeof window !== 'undefined' && window.CasinoSounds) {
-                window.CasinoSounds.play('click');
-            }
-        }, i * dealMs);
+    return new Promise(function (resolve) {
+        draws.forEach(function (n, i) {
+            setTimeout(function () {
+                lightUpDraw(gridEl, n, picksSet);
+                if (typeof window !== 'undefined' && window.CasinoSounds) {
+                    window.CasinoSounds.play('click');
+                }
+            }, i * dealMs);
+        });
+        setTimeout(function () { finalize(); resolve(); }, draws.length * dealMs);
     });
-    setTimeout(finalize, draws.length * dealMs);
 }
 
 function lightUpDraw(gridEl, n, picksSet) {
@@ -260,7 +266,10 @@ function kenoLoseLineHtml(body) {
                 return null;
             },
             renderResult: function (body) {
-                renderKenoResult({
+                // Return the Promise — the scaffold waits for the
+                // staggered reveal to land before applying balance and
+                // releasing the jackpot-pool banner lock.
+                return renderKenoResult({
                     resultEl: resultEl,
                     statusEl: statusEl,
                     gridEl: gridEl,

--- a/web/src/test/js/baccarat.test.js
+++ b/web/src/test/js/baccarat.test.js
@@ -252,6 +252,58 @@ describe('renderBaccaratResult', () => {
         expect(tableEl.querySelector('.casino-chip-stack')).toBeNull();
     });
 
+    test('synchronous path returns undefined (no Promise)', () => {
+        const ret = renderBaccaratResult({
+            resultEl, bankerCardsEl, playerCardsEl,
+            bankerTotalEl, playerTotalEl, tableEl,
+            flashTargetEl: tableEl,
+            stagger: false,
+            body: {
+                win: true, push: false, side: 'PLAYER', winner: 'PLAYER',
+                playerCards: ['5♠', '3♥'], bankerCards: ['2♣', '4♦'],
+                playerTotal: 8, bankerTotal: 6, multiplier: 2.0, net: 100,
+            },
+        });
+        expect(ret).toBeUndefined();
+    });
+
+    test('staged path returns a Promise that resolves after the deal lands', async () => {
+        jest.useFakeTimers();
+        try {
+            const ret = renderBaccaratResult({
+                resultEl, bankerCardsEl, playerCardsEl,
+                bankerTotalEl, playerTotalEl, tableEl,
+                flashTargetEl: tableEl,
+                stagger: true, dealMs: 50,
+                body: {
+                    win: true, push: false, side: 'PLAYER', winner: 'PLAYER',
+                    playerCards: ['5♠', '3♥'], bankerCards: ['2♣', '4♦'],
+                    playerTotal: 8, bankerTotal: 6,
+                    isPlayerNatural: true, isBankerNatural: false,
+                    multiplier: 2.0, net: 100,
+                },
+            });
+            expect(ret && typeof ret.then).toBe('function');
+
+            const onSettle = jest.fn();
+            ret.then(onSettle);
+
+            // 4 cards × 50ms = 200ms total. Before the last card lands,
+            // the Promise must remain pending — that's what casino-game.js
+            // relies on to keep the banner held.
+            jest.advanceTimersByTime(199);
+            await Promise.resolve();
+            expect(onSettle).not.toHaveBeenCalled();
+
+            jest.advanceTimersByTime(1);
+            await Promise.resolve();
+            await Promise.resolve();
+            expect(onSettle).toHaveBeenCalledTimes(1);
+        } finally {
+            jest.useRealTimers();
+        }
+    });
+
     test('staged path holds the result line until the deal sequence completes', () => {
         jest.useFakeTimers();
         try {

--- a/web/src/test/js/casino-game-jackpot-lock.test.js
+++ b/web/src/test/js/casino-game-jackpot-lock.test.js
@@ -124,4 +124,78 @@ describe('casino-game.js — pool banner lock around settle', () => {
 
         expect(releaseSpy).not.toHaveBeenCalled();
     });
+
+    test('async renderResult holds the lock until its Promise resolves', async () => {
+        // Mirrors keno / baccarat: renderResult kicks off a staggered
+        // reveal that lands later via setTimeouts. The scaffold must
+        // wait for the Promise before applying balance and releasing
+        // the banner, otherwise the banner ticks before the cells /
+        // cards finish landing.
+        postJsonMock.mockResolvedValue({ ok: true, jackpotPool: 999, newBalance: 50 });
+        let resolveReveal;
+        const renderResult = jest.fn(function () {
+            return new Promise(function (r) { resolveReveal = r; });
+        });
+        const game = buildGame({ minSettleMs: 0, renderResult: renderResult });
+        game.run(false);
+
+        await Promise.resolve();
+        await Promise.resolve();
+        jest.advanceTimersByTime(0);
+
+        // settle setTimeout has fired and renderResult has been invoked,
+        // but its Promise is still pending — lock must stay held.
+        expect(renderResult).toHaveBeenCalledTimes(1);
+        expect(releaseSpy).not.toHaveBeenCalled();
+
+        // Balance must NOT have been written either — the user would
+        // see it tick before the reveal lands.
+        expect(document.getElementById('bal').textContent).toBe('100');
+
+        // Resolve the reveal — now the scaffold should flush both.
+        resolveReveal();
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(releaseSpy).toHaveBeenCalledTimes(1);
+        expect(document.getElementById('bal').textContent).toBe('50');
+    });
+
+    test('async renderResult releases the lock even on rejection', async () => {
+        // Defensive: if the per-game reveal animation throws (e.g. a
+        // rendering bug), the banner must still recover.
+        postJsonMock.mockResolvedValue({ ok: true, jackpotPool: 7, newBalance: 90 });
+        let rejectReveal;
+        const renderResult = jest.fn(function () {
+            return new Promise(function (_, rej) { rejectReveal = rej; });
+        });
+        const game = buildGame({ minSettleMs: 0, renderResult: renderResult });
+        game.run(false);
+
+        await Promise.resolve();
+        await Promise.resolve();
+        jest.advanceTimersByTime(0);
+        expect(releaseSpy).not.toHaveBeenCalled();
+
+        rejectReveal(new Error('boom'));
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(releaseSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test('synchronous renderResult (returns undefined) releases immediately', async () => {
+        postJsonMock.mockResolvedValue({ ok: true, jackpotPool: 1, newBalance: 50 });
+        const renderResult = jest.fn(function () { /* sync, no return */ });
+        const game = buildGame({ minSettleMs: 0, renderResult: renderResult });
+        game.run(false);
+
+        await Promise.resolve();
+        await Promise.resolve();
+        jest.advanceTimersByTime(0);
+
+        expect(renderResult).toHaveBeenCalledTimes(1);
+        expect(releaseSpy).toHaveBeenCalledTimes(1);
+        expect(document.getElementById('bal').textContent).toBe('50');
+    });
 });

--- a/web/src/test/js/casino-game-jackpot-lock.test.js
+++ b/web/src/test/js/casino-game-jackpot-lock.test.js
@@ -199,3 +199,172 @@ describe('casino-game.js — pool banner lock around settle', () => {
         expect(document.getElementById('bal').textContent).toBe('50');
     });
 });
+
+describe('TobyCasinoGame.runManual', () => {
+    let requestMock;
+    let onSettle;
+    let onError;
+    let holdSpy;
+    let releaseSpy;
+
+    beforeEach(() => {
+        document.body.innerHTML =
+            '<div class="casino-jackpot-banner"><strong>0</strong></div>';
+        // Reset any leaked hold from a previous test before installing
+        // spies, so the first call we observe is the one this test makes.
+        window.TobyJackpot.releasePoolBanner();
+        holdSpy = jest.spyOn(window.TobyJackpot, 'holdPoolBanner');
+        releaseSpy = jest.spyOn(window.TobyJackpot, 'releasePoolBanner');
+        requestMock = jest.fn();
+        onSettle = jest.fn();
+        onError = jest.fn();
+        jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+        holdSpy.mockRestore();
+        releaseSpy.mockRestore();
+    });
+
+    test('holds the lock before request resolves', () => {
+        requestMock.mockImplementation(() => new Promise(() => {}));
+        window.TobyCasinoGame.runManual({
+            request: requestMock,
+            settleMs: 0,
+            onSettle: onSettle,
+            onError: onError,
+        });
+        expect(holdSpy).toHaveBeenCalledTimes(1);
+        expect(releaseSpy).not.toHaveBeenCalled();
+        expect(onSettle).not.toHaveBeenCalled();
+    });
+
+    test('runs onSettle with the body and releases after settleMs', async () => {
+        const body = { ok: true, jackpotPool: 100, newBalance: 50 };
+        requestMock.mockResolvedValue(body);
+        window.TobyCasinoGame.runManual({
+            request: requestMock,
+            settleMs: 500,
+            onSettle: onSettle,
+            onError: onError,
+        });
+
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(onSettle).not.toHaveBeenCalled();
+        expect(releaseSpy).not.toHaveBeenCalled();
+
+        jest.advanceTimersByTime(499);
+        expect(onSettle).not.toHaveBeenCalled();
+        jest.advanceTimersByTime(1);
+        expect(onSettle).toHaveBeenCalledWith(body);
+        expect(releaseSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test('passes a non-ok body to onSettle (caller decides how to render)', async () => {
+        const body = { ok: false, error: 'broke' };
+        requestMock.mockResolvedValue(body);
+        window.TobyCasinoGame.runManual({
+            request: requestMock,
+            settleMs: 0,
+            onSettle: onSettle,
+        });
+
+        await Promise.resolve();
+        await Promise.resolve();
+        jest.advanceTimersByTime(0);
+
+        expect(onSettle).toHaveBeenCalledWith(body);
+        expect(releaseSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test('release waits for an async onSettle (Promise return)', async () => {
+        const body = { ok: true, jackpotPool: 1 };
+        requestMock.mockResolvedValue(body);
+        let resolveReveal;
+        const asyncSettle = jest.fn(function () {
+            return new Promise(function (r) { resolveReveal = r; });
+        });
+        window.TobyCasinoGame.runManual({
+            request: requestMock,
+            settleMs: 0,
+            onSettle: asyncSettle,
+        });
+
+        await Promise.resolve();
+        await Promise.resolve();
+        jest.advanceTimersByTime(0);
+
+        expect(asyncSettle).toHaveBeenCalledTimes(1);
+        expect(releaseSpy).not.toHaveBeenCalled();
+
+        resolveReveal();
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(releaseSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test('release fires when async onSettle rejects', async () => {
+        requestMock.mockResolvedValue({ ok: true });
+        let rejectReveal;
+        window.TobyCasinoGame.runManual({
+            request: requestMock,
+            settleMs: 0,
+            onSettle: function () {
+                return new Promise(function (_, rej) { rejectReveal = rej; });
+            },
+        });
+
+        await Promise.resolve();
+        await Promise.resolve();
+        jest.advanceTimersByTime(0);
+        expect(releaseSpy).not.toHaveBeenCalled();
+
+        rejectReveal(new Error('boom'));
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(releaseSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test('runs onError and releases when the request rejects', async () => {
+        requestMock.mockRejectedValue(new Error('network'));
+        window.TobyCasinoGame.runManual({
+            request: requestMock,
+            settleMs: 1000,
+            onSettle: onSettle,
+            onError: onError,
+        });
+
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(onError).toHaveBeenCalledTimes(1);
+        expect(onSettle).not.toHaveBeenCalled();
+        expect(releaseSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test('releases even if onSettle throws synchronously', async () => {
+        const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+        try {
+            requestMock.mockResolvedValue({ ok: true });
+            window.TobyCasinoGame.runManual({
+                request: requestMock,
+                settleMs: 0,
+                onSettle: function () { throw new Error('render bug'); },
+            });
+
+            await Promise.resolve();
+            await Promise.resolve();
+            jest.advanceTimersByTime(0);
+
+            expect(releaseSpy).toHaveBeenCalledTimes(1);
+            expect(errSpy).toHaveBeenCalled();
+        } finally {
+            errSpy.mockRestore();
+        }
+    });
+});

--- a/web/src/test/js/keno.test.js
+++ b/web/src/test/js/keno.test.js
@@ -169,6 +169,50 @@ describe('renderKenoResult (staged path)', () => {
         tableEl = document.getElementById('t');
     });
 
+    test('synchronous path returns undefined (no Promise)', () => {
+        const ret = renderKenoResult({
+            resultEl, statusEl, gridEl, flashTargetEl: tableEl,
+            stagger: false,
+            body: {
+                win: false, picks: [1], draws: [2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
+                hits: 0, net: -50,
+            },
+        });
+        expect(ret).toBeUndefined();
+    });
+
+    test('staged path returns a Promise that resolves after the deal lands', async () => {
+        jest.useFakeTimers();
+        try {
+            const ret = renderKenoResult({
+                resultEl, statusEl, gridEl, flashTargetEl: tableEl,
+                stagger: true, dealMs: 50,
+                body: {
+                    win: true, picks: [1], draws: [1, 2, 3],
+                    hits: 1, multiplier: 1, net: 100, payout: 200,
+                },
+            });
+            expect(ret && typeof ret.then).toBe('function');
+
+            const onSettle = jest.fn();
+            ret.then(onSettle);
+
+            // Before the deal sequence finishes, the Promise must not
+            // resolve — that's exactly what the casino-game.js scaffold
+            // depends on to keep the jackpot-pool banner held.
+            jest.advanceTimersByTime(149);
+            await Promise.resolve();
+            expect(onSettle).not.toHaveBeenCalled();
+
+            jest.advanceTimersByTime(1);
+            await Promise.resolve();
+            await Promise.resolve();
+            expect(onSettle).toHaveBeenCalledTimes(1);
+        } finally {
+            jest.useRealTimers();
+        }
+    });
+
     test('staged path holds the result line until the deal sequence completes', () => {
         jest.useFakeTimers();
         try {


### PR DESCRIPTION
## Summary
Follow-up to #388. Reported by user testing: keno was still leaking
the outcome via the jackpot pool banner ticking ahead of the staggered
draw. Same root cause affects baccarat and the highlow `/play` flow.

The staggered games (keno, baccarat) run their reveal animations
**inside** `renderResult` via their own internal `setTimeout`s. The
shared `casino-game.js` scaffold was releasing the lock — and writing
the new balance — the moment `renderResult` returned synchronously,
which is before any cell or card actually lands. Same outcome-leak
problem #388 fixed for slots/coinflip/dice, just on a different code
path.

- `casino-game.js`: `renderResult` may now return a thenable. The
  scaffold waits on it before applying balance, top-up coins, and
  releasing the banner lock. Synchronous returns (slots / coinflip /
  dice / highlow start / scratch) keep their previous timing.
- `keno.js` / `baccarat.js`: `renderKenoResult` and
  `renderBaccaratResult` return a Promise on the staged path that
  resolves once the last cell / card lands. The sync-path
  (`stagger: false`) returns undefined so the existing test contract
  is preserved.
- `highlow.js`: `/play` uses a hand-written `postJson` flow rather
  than the shared scaffold, so it now acquires/releases the banner
  lock manually around its `NEXT_DEAL_MS` next-card shuffle.

## Test plan
- [x] `npm test` — 26 suites, 285 tests pass (7 new)
- [x] `casino-game-jackpot-lock.test.js` — 3 new cases drive the
      scaffold with a `renderResult` that returns a Promise: lock
      held until resolution, lock released on rejection, sync
      `renderResult` (returns undefined) releases immediately.
- [x] `keno.test.js` — 2 new cases assert sync path returns undefined
      and staged path returns a Promise that only resolves after the
      full deal duration.
- [x] `baccarat.test.js` — same coverage for the staged 4-card deal.

https://claude.ai/code/session_01DyuvrdMDUrdgMnRSP3UqVK

---
_Generated by [Claude Code](https://claude.ai/code/session_01DyuvrdMDUrdgMnRSP3UqVK)_