### PR TITLE
feat(casino): add /casinoholdem singleplayer poker (web + Discord)

### DIFF
--- a/application/src/test/kotlin/integration/bot/ButtonManagerTest.kt
+++ b/application/src/test/kotlin/integration/bot/ButtonManagerTest.kt
@@ -72,6 +72,7 @@ class ButtonManagerTest {
         val availableButtons = listOf(
             BaccaratButton::class.java,
             BlackjackButton::class.java,
+            CasinoHoldemButton::class.java,
             DuelButton::class.java,
             HighlowButton::class.java,
             InitiativeClearButton::class.java,
@@ -85,7 +86,7 @@ class ButtonManagerTest {
         )
 
         assertTrue(availableButtons.containsAll(buttonManager.buttons.map { it.javaClass }.toList()))
-        assertEquals(12, buttonManager.buttons.size)
+        assertEquals(13, buttonManager.buttons.size)
     }
 
     @Test

--- a/application/src/test/kotlin/integration/bot/CommandManagerTest.kt
+++ b/application/src/test/kotlin/integration/bot/CommandManagerTest.kt
@@ -11,6 +11,7 @@ import bot.toby.command.commands.dnd.RefreshCharacterCommand
 import bot.toby.command.commands.dnd.RollCommand
 import bot.toby.command.commands.economy.BaccaratCommand
 import bot.toby.command.commands.economy.BlackjackCommand
+import bot.toby.command.commands.economy.CasinoHoldemCommand
 import bot.toby.command.commands.economy.CoinflipCommand
 import bot.toby.command.commands.economy.DiceCommand
 import bot.toby.command.commands.economy.DuelCommand
@@ -150,12 +151,13 @@ class CommandManagerTest {
             PokerCommand::class.java,
             BlackjackCommand::class.java,
             BaccaratCommand::class.java,
-            KenoCommand::class.java
+            KenoCommand::class.java,
+            CasinoHoldemCommand::class.java
         )
 
         Assertions.assertTrue(availableCommands.containsAll(commandManager.allCommands.map { it.javaClass }.toList()))
-        Assertions.assertEquals(57, commandManager.allCommands.size)
-        Assertions.assertEquals(57, commandManager.allSlashCommands.size)
+        Assertions.assertEquals(58, commandManager.allCommands.size)
+        Assertions.assertEquals(58, commandManager.allSlashCommands.size)
     }
 
     @Test

--- a/database/src/main/kotlin/database/poker/CasinoHoldem.kt
+++ b/database/src/main/kotlin/database/poker/CasinoHoldem.kt
@@ -1,0 +1,226 @@
+package database.poker
+
+import database.card.Card
+import database.card.Deck
+import database.card.Rank
+import kotlin.random.Random
+
+/**
+ * Pure-logic Casino Hold'em — the standard casino table variant of
+ * Texas Hold'em against the house. Player antes, sees the flop, then
+ * decides FOLD (forfeit ante) or CALL (commit `2 × stake` more) to
+ * see the turn and river. Dealer must "qualify" with at least a pair
+ * of fours for the call leg to be in play; otherwise the ante pays
+ * even and the call pushes.
+ *
+ * No Spring, no DB, no JDA — just card maths and the per-leg
+ * multiplier schedule. The owning [database.service.CasinoHoldemService]
+ * holds the actual table state under a monitor.
+ *
+ * v1 schedule (call multiplier returns include the bet — e.g. 2.0 for
+ * 1:1, 11.0 for 10:1):
+ *   - Royal Flush      → 101.0 (100:1)
+ *   - Straight Flush   →  21.0 (20:1)
+ *   - Four of a Kind   →  11.0 (10:1)
+ *   - Full House       →   4.0 (3:1)
+ *   - Flush            →   3.0 (2:1)
+ *   - Straight         →   2.0 (1:1)
+ *   - Anything else win →  2.0 (1:1)
+ *   - Push             →   1.0
+ *   - Lose / Folded    →   0.0
+ *
+ * Ante leg is even-money on a win, push on a tie or non-qualified
+ * dealer, zero on a loss / fold.
+ */
+class CasinoHoldem(private val random: Random = Random.Default) {
+
+    enum class Action { CALL, FOLD }
+
+    enum class AnteResult { WIN, PUSH, LOSE }
+
+    enum class CallResult {
+        WIN_ROYAL_FLUSH,
+        WIN_STRAIGHT_FLUSH,
+        WIN_QUADS,
+        WIN_FULL_HOUSE,
+        WIN_FLUSH,
+        WIN_STRAIGHT,
+        WIN_OTHER,
+        PUSH,
+        LOSE,
+        FOLDED,
+    }
+
+    /**
+     * Snapshot of one full deal — every card needed for showdown is
+     * peeled up-front, even though the player only sees [flop] until
+     * they CALL. This keeps the deal deterministic for tests and lets
+     * the service stash the unrevealed cards on the table for the
+     * eventual CALL path. Burn cards are skipped in v1.
+     */
+    data class Deal(
+        val playerHole: List<Card>,
+        val dealerHole: List<Card>,
+        val flop: List<Card>,
+        val turn: Card,
+        val river: Card,
+    )
+
+    /** Resolution of a CALL'd hand. Folded hands skip this. */
+    data class Resolution(
+        val playerRank: HandEvaluator.HandRank,
+        val dealerRank: HandEvaluator.HandRank,
+        val dealerQualified: Boolean,
+        val anteResult: AnteResult,
+        val callResult: CallResult,
+    )
+
+    /** Fresh shuffled 52-card deck using the engine's RNG. */
+    fun newDeck(): Deck = Deck(random)
+
+    /**
+     * Peel every card needed for showdown off [deck] in dealing order:
+     * 2 player hole, 2 dealer hole, 3 flop, 1 turn, 1 river. The deck
+     * is mutated so the caller passes a freshly seeded one per hand.
+     */
+    fun dealAll(deck: Deck): Deal {
+        val playerHole = deck.deal(2)
+        val dealerHole = deck.deal(2)
+        val flop = deck.deal(3)
+        val turn = deck.deal()
+        val river = deck.deal()
+        return Deal(playerHole, dealerHole, flop, turn, river)
+    }
+
+    /**
+     * Casino Hold'em qualification rule: dealer must hold at least a
+     * pair of fours among their best 5-of-7. Anything stronger than
+     * a pair (two pair, trips, etc.) trivially qualifies; among bare
+     * pairs, only fours-or-better counts.
+     */
+    fun dealerQualifies(rank: HandEvaluator.HandRank): Boolean {
+        if (rank.category.ordinal > HandEvaluator.Category.PAIR.ordinal) return true
+        if (rank.category != HandEvaluator.Category.PAIR) return false
+        // PAIR's tiebreakers are [pair_rank, kicker_high, kicker_mid, kicker_low].
+        val pairRank = rank.tiebreakers.firstOrNull() ?: return false
+        return pairRank >= Rank.FOUR.value
+    }
+
+    /**
+     * Run a CALL'd hand to showdown. Evaluates both sides via
+     * [HandEvaluator.bestHand] over their hole cards plus the full
+     * 5-card [board], applies dealer qualification, then maps the
+     * outcome onto per-leg [AnteResult] and [CallResult] values.
+     */
+    fun resolve(
+        playerHole: List<Card>,
+        dealerHole: List<Card>,
+        board: List<Card>,
+    ): Resolution {
+        require(board.size == 5) { "resolve needs the full 5-card board, got ${board.size}" }
+        val playerRank = HandEvaluator.bestHand(playerHole, board)
+        val dealerRank = HandEvaluator.bestHand(dealerHole, board)
+        val qualified = dealerQualifies(dealerRank)
+
+        // Dealer doesn't qualify: ante pays even, call pushes regardless
+        // of who has the better hand. (Standard Casino Hold'em rule.)
+        if (!qualified) {
+            return Resolution(
+                playerRank = playerRank,
+                dealerRank = dealerRank,
+                dealerQualified = false,
+                anteResult = AnteResult.WIN,
+                callResult = CallResult.PUSH,
+            )
+        }
+
+        val cmp = playerRank.compareTo(dealerRank)
+        return when {
+            cmp > 0 -> Resolution(
+                playerRank = playerRank,
+                dealerRank = dealerRank,
+                dealerQualified = true,
+                anteResult = AnteResult.WIN,
+                callResult = if (isRoyalFlush(playerRank)) CallResult.WIN_ROYAL_FLUSH
+                else callResultForCategory(playerRank.category),
+            )
+            cmp < 0 -> Resolution(
+                playerRank = playerRank,
+                dealerRank = dealerRank,
+                dealerQualified = true,
+                anteResult = AnteResult.LOSE,
+                callResult = CallResult.LOSE,
+            )
+            else -> Resolution(
+                playerRank = playerRank,
+                dealerRank = dealerRank,
+                dealerQualified = true,
+                anteResult = AnteResult.PUSH,
+                callResult = CallResult.PUSH,
+            )
+        }
+    }
+
+    /**
+     * Map the player's winning category to its [CallResult] so the
+     * paytable lookup is a single switch. Royal flush is ace-high
+     * straight flush — distinguished from a plain straight flush by
+     * the tiebreaker high-card value (14 = ace).
+     */
+    private fun callResultForCategory(category: HandEvaluator.Category): CallResult = when (category) {
+        HandEvaluator.Category.STRAIGHT_FLUSH -> CallResult.WIN_STRAIGHT_FLUSH
+        HandEvaluator.Category.FOUR_OF_A_KIND -> CallResult.WIN_QUADS
+        HandEvaluator.Category.FULL_HOUSE -> CallResult.WIN_FULL_HOUSE
+        HandEvaluator.Category.FLUSH -> CallResult.WIN_FLUSH
+        HandEvaluator.Category.STRAIGHT -> CallResult.WIN_STRAIGHT
+        else -> CallResult.WIN_OTHER
+    }
+
+    /**
+     * Royal-flush check: the rank's category is STRAIGHT_FLUSH and
+     * its sole tiebreaker is the ace's value. Exposed so the service
+     * can promote a generic straight-flush win to royal.
+     */
+    fun isRoyalFlush(rank: HandEvaluator.HandRank): Boolean =
+        rank.category == HandEvaluator.Category.STRAIGHT_FLUSH &&
+            rank.tiebreakers.firstOrNull() == Rank.ACE.value
+
+    /** Multiplier on the ante leg, applied to the original `stake`. */
+    fun anteMultiplier(result: AnteResult): Double = when (result) {
+        AnteResult.WIN -> ANTE_WIN_MULT
+        AnteResult.PUSH -> PUSH_MULT
+        AnteResult.LOSE -> LOSS_MULT
+    }
+
+    /** Multiplier on the call leg, applied to `2 × stake`. */
+    fun callMultiplier(result: CallResult): Double = when (result) {
+        CallResult.WIN_ROYAL_FLUSH -> ROYAL_FLUSH_MULT
+        CallResult.WIN_STRAIGHT_FLUSH -> STRAIGHT_FLUSH_MULT
+        CallResult.WIN_QUADS -> QUADS_MULT
+        CallResult.WIN_FULL_HOUSE -> FULL_HOUSE_MULT
+        CallResult.WIN_FLUSH -> FLUSH_MULT
+        CallResult.WIN_STRAIGHT -> STRAIGHT_MULT
+        CallResult.WIN_OTHER -> CALL_WIN_MULT
+        CallResult.PUSH -> PUSH_MULT
+        CallResult.LOSE, CallResult.FOLDED -> LOSS_MULT
+    }
+
+    companion object {
+        const val MIN_STAKE: Long = 10L
+        const val MAX_STAKE: Long = 500L
+
+        /** CALL costs this many times the original stake. */
+        const val CALL_MULTIPLE: Long = 2L
+
+        const val ANTE_WIN_MULT: Double = 2.0
+        const val CALL_WIN_MULT: Double = 2.0
+        const val STRAIGHT_MULT: Double = 2.0
+        const val FLUSH_MULT: Double = 3.0
+        const val FULL_HOUSE_MULT: Double = 4.0
+        const val QUADS_MULT: Double = 11.0
+        const val STRAIGHT_FLUSH_MULT: Double = 21.0
+        const val ROYAL_FLUSH_MULT: Double = 101.0
+        const val PUSH_MULT: Double = 1.0
+        const val LOSS_MULT: Double = 0.0
+    }
+}

--- a/database/src/main/kotlin/database/poker/CasinoHoldemTable.kt
+++ b/database/src/main/kotlin/database/poker/CasinoHoldemTable.kt
@@ -1,0 +1,85 @@
+package database.poker
+
+import database.card.Card
+import database.card.Deck
+import java.time.Instant
+
+/**
+ * Mutable state of a single Casino Hold'em table. One table per active
+ * hand — there's no lobby phase or multi-seat support, so the layout is
+ * deliberately flatter than [database.blackjack.BlackjackTable] /
+ * [PokerTable].
+ *
+ * All mutations happen inside a monitor on the table object (see
+ * [CasinoHoldemTableRegistry.lockTable]) so concurrent button clicks
+ * serialise around the hand state.
+ *
+ * Lifecycle:
+ *   1. `dealSolo` builds the table in [Phase.AWAIT_DECISION] with
+ *      `playerHole`, `dealerHole`, the 3-card flop on `board`, and
+ *      `pendingTurn` / `pendingRiver` stashed for the eventual CALL.
+ *      The player's `stake` has already been debited at this point.
+ *   2. On FOLD: phase → [Phase.RESOLVED], `lastResult` populated with
+ *      a folded snapshot, ante is forfeited.
+ *   3. On CALL: pending cards are appended to the board, the engine
+ *      resolves the hand, phase → [Phase.RESOLVED], `lastResult`
+ *      populated with the showdown breakdown.
+ */
+class CasinoHoldemTable(
+    val id: Long,
+    val guildId: Long,
+    val playerDiscordId: Long,
+    val stake: Long,
+    var phase: Phase = Phase.AWAIT_DECISION,
+    var deck: Deck? = null,
+    val playerHole: MutableList<Card> = mutableListOf(),
+    val dealerHole: MutableList<Card> = mutableListOf(),
+    val board: MutableList<Card> = mutableListOf(),
+    /**
+     * Turn card peeled at deal time but not exposed to the player
+     * until they CALL. Stashed on the table so the deal is fully
+     * deterministic at the deal step (the deck is consumed once,
+     * up-front) and the CALL transition is a simple appending move.
+     */
+    var pendingTurn: Card? = null,
+    var pendingRiver: Card? = null,
+    var lastResult: HandResult? = null,
+    var lastActivityAt: Instant = Instant.now(),
+) {
+
+    enum class Phase {
+        /** Cards dealt, flop visible, player owes a CALL/FOLD. */
+        AWAIT_DECISION,
+        /** Hand settled (folded or showdown). [lastResult] is populated. */
+        RESOLVED,
+    }
+
+    /**
+     * Snapshot of how a Casino Hold'em hand resolved. [resolution] is
+     * `null` on a fold (no showdown happened); otherwise it carries
+     * the ante / call breakdown produced by [CasinoHoldem.resolve].
+     *
+     * `callStake` is `0L` on a fold or a non-qualified-dealer push of
+     * the call leg (matters for the `at-risk` math the embed surfaces).
+     * Wait — non-qualified pushes still post the call stake to the
+     * pot; it just gets refunded. To keep the math uniform we record
+     * the call stake whenever the player CALL'd, regardless of whether
+     * the leg ended PUSH or LOSE; only FOLD leaves it at zero.
+     */
+    data class HandResult(
+        val playerHole: List<Card>,
+        val dealerHole: List<Card>,
+        val board: List<Card>,
+        val resolution: CasinoHoldem.Resolution?,
+        val folded: Boolean,
+        val anteStake: Long,
+        val callStake: Long,
+        val antePayout: Long,
+        val callPayout: Long,
+        val totalPayout: Long,
+        val resolvedAt: Instant,
+    ) {
+        val totalAtRisk: Long get() = anteStake + callStake
+        val net: Long get() = totalPayout - totalAtRisk
+    }
+}

--- a/database/src/main/kotlin/database/poker/CasinoHoldemTableRegistry.kt
+++ b/database/src/main/kotlin/database/poker/CasinoHoldemTableRegistry.kt
@@ -1,0 +1,113 @@
+package database.poker
+
+import jakarta.annotation.PreDestroy
+import org.springframework.stereotype.Component
+import java.time.Duration
+import java.time.Instant
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * In-memory book of singleplayer Casino Hold'em tables. Trimmed sibling
+ * of [database.blackjack.BlackjackTableRegistry]: solo-only, one seat
+ * per table, no shot clock — but the same idle-sweeper + per-table
+ * monitor + onIdleEvict callback shape so the rest of the casino code
+ * looks uniform.
+ *
+ * Tables vanish on bot restart. Each player's stake has already been
+ * debited from `socialCredit` at deal time; the idle sweeper would have
+ * refunded them anyway, so this is acceptable for casual play.
+ */
+@Component
+class CasinoHoldemTableRegistry(
+    private val idleTtl: Duration = DEFAULT_IDLE_TTL,
+    sweepInterval: Duration = DEFAULT_SWEEP_INTERVAL,
+    private val scheduler: ScheduledExecutorService = Executors.newScheduledThreadPool(1),
+) {
+    private val tables = ConcurrentHashMap<Long, CasinoHoldemTable>()
+    private val seq = AtomicLong()
+    private var onIdleEvict: ((CasinoHoldemTable) -> Unit)? = null
+
+    init {
+        scheduler.scheduleAtFixedRate(
+            { runCatching { sweepIdle(Instant.now()) } },
+            sweepInterval.toMillis(),
+            sweepInterval.toMillis(),
+            TimeUnit.MILLISECONDS,
+        )
+    }
+
+    fun setOnIdleEvict(callback: (CasinoHoldemTable) -> Unit) {
+        this.onIdleEvict = callback
+    }
+
+    fun create(
+        guildId: Long,
+        playerDiscordId: Long,
+        stake: Long,
+        now: Instant = Instant.now(),
+    ): CasinoHoldemTable {
+        val id = seq.incrementAndGet()
+        val table = CasinoHoldemTable(
+            id = id,
+            guildId = guildId,
+            playerDiscordId = playerDiscordId,
+            stake = stake,
+            lastActivityAt = now,
+        )
+        tables[id] = table
+        return table
+    }
+
+    fun get(tableId: Long): CasinoHoldemTable? = tables[tableId]
+
+    fun listForGuild(guildId: Long): List<CasinoHoldemTable> =
+        tables.values.filter { it.guildId == guildId }
+
+    fun remove(tableId: Long): CasinoHoldemTable? = tables.remove(tableId)
+
+    /**
+     * Run [action] under the table monitor — every state-mutating
+     * operation must go through here so concurrent button clicks
+     * serialise around a consistent view of the hand.
+     */
+    fun <T> lockTable(tableId: Long, action: (CasinoHoldemTable) -> T): T? {
+        val table = tables[tableId] ?: return null
+        synchronized(table) {
+            if (tables[tableId] == null) return null
+            return action(table)
+        }
+    }
+
+    /**
+     * Force-evict every table whose `lastActivityAt` is older than
+     * [idleTtl]. Public + parameterised so tests can drive it without
+     * waiting for the scheduler. Each evicted table is handed to
+     * [onIdleEvict] under the table monitor so the service can refund
+     * an unresolved stake.
+     */
+    fun sweepIdle(now: Instant) {
+        val cutoff = now.minus(idleTtl)
+        for ((id, table) in tables) {
+            synchronized(table) {
+                if (table.lastActivityAt.isBefore(cutoff)) {
+                    val evicted = tables.remove(id)
+                    if (evicted != null) runCatching { onIdleEvict?.invoke(evicted) }
+                }
+            }
+        }
+    }
+
+    @PreDestroy
+    fun shutdown() {
+        scheduler.shutdownNow()
+    }
+
+    companion object {
+        val DEFAULT_IDLE_TTL: Duration = Duration.ofMinutes(10)
+        val DEFAULT_SWEEP_INTERVAL: Duration = Duration.ofMinutes(1)
+    }
+}

--- a/database/src/main/kotlin/database/service/CasinoHoldemService.kt
+++ b/database/src/main/kotlin/database/service/CasinoHoldemService.kt
@@ -1,0 +1,417 @@
+package database.service
+
+import common.casino.CasinoCommonFailure
+import database.dto.UserDto
+import database.poker.CasinoHoldem
+import database.poker.CasinoHoldemTable
+import database.poker.CasinoHoldemTableRegistry
+import jakarta.annotation.PostConstruct
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.annotation.Lazy
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+import kotlin.random.Random
+
+/**
+ * Atomic play path for `/casinoholdem` (Casino Hold'em vs the dealer).
+ * Mirrors the SOLO half of [BlackjackService]:
+ *   - dealSolo debits `stake` into table escrow, deals every card
+ *     up-front (player + dealer hole + flop + pending turn + river),
+ *     and posts the table in [CasinoHoldemTable.Phase.AWAIT_DECISION].
+ *   - applyAction with FOLD forfeits the ante, settles, and resolves
+ *     the table.
+ *   - applyAction with CALL pre-debits `2 × stake`, reveals turn +
+ *     river, runs [CasinoHoldem.resolve], pays out per-leg via the
+ *     standard paytable, and routes per-leg jackpot rolls / loss
+ *     tributes through [JackpotHelper].
+ *
+ * The wager is split into two legs — ante and call — each with its
+ * own multiplier. Splits feed [JackpotHelper] independently so a hand
+ * with a winning ante and a losing call leg correctly produces both
+ * a jackpot roll AND a loss tribute, the same way blackjack splits
+ * each hand-slot through [BlackjackService.settleSolo].
+ */
+@Service
+class CasinoHoldemService @Autowired constructor(
+    private val userService: UserService,
+    private val jackpotService: JackpotService,
+    private val configService: ConfigService,
+    private val tableRegistry: CasinoHoldemTableRegistry,
+    private val game: CasinoHoldem = CasinoHoldem(),
+    /**
+     * Optional sell-to-cover wiring. Mirrors [BlackjackService] —
+     * when either is null (test path with no Spring context),
+     * `autoTopUp` requests degrade gracefully to plain
+     * `InsufficientCredits` so existing constructors without these
+     * collaborators keep working.
+     */
+    @Autowired(required = false) private val tradeService: EconomyTradeService? = null,
+    @Autowired(required = false) private val marketService: TobyCoinMarketService? = null,
+    private val random: Random = Random.Default,
+) {
+
+    sealed interface DealOutcome {
+        data class Dealt(
+            val tableId: Long,
+            val snapshot: CasinoHoldemTable,
+            val newBalance: Long,
+            val soldTobyCoins: Long = 0L,
+            val newPrice: Double? = null,
+        ) : DealOutcome
+        data class InvalidStake(override val min: Long, override val max: Long) :
+            DealOutcome, CasinoCommonFailure.InvalidStake
+        data class InsufficientCredits(override val stake: Long, override val have: Long) :
+            DealOutcome, CasinoCommonFailure.InsufficientCredits
+        data class InsufficientCoinsForTopUp(override val needed: Long, override val have: Long) :
+            DealOutcome, CasinoCommonFailure.InsufficientCoinsForTopUp
+        data object UnknownUser : DealOutcome, CasinoCommonFailure.UnknownUser
+    }
+
+    sealed interface ActionOutcome {
+        data class Resolved(
+            val tableId: Long,
+            val result: CasinoHoldemTable.HandResult,
+            val newBalance: Long,
+            val jackpotPayout: Long,
+            val lossTribute: Long,
+        ) : ActionOutcome
+        data object HandNotFound : ActionOutcome
+        data object NotYourHand : ActionOutcome
+        data object IllegalAction : ActionOutcome
+        data class InsufficientCreditsForCall(val needed: Long, val have: Long) : ActionOutcome
+    }
+
+    /**
+     * Self-injection so registry callbacks (which run on the scheduler
+     * thread, not through the Spring proxy) still go through the
+     * `@Transactional` wrapper. Same pattern as [BlackjackService].
+     */
+    @Autowired
+    @Lazy
+    private var self: CasinoHoldemService? = null
+
+    private val transactionalSelf: CasinoHoldemService get() = self ?: this
+
+    @PostConstruct
+    fun wireRegistry() {
+        tableRegistry.setOnIdleEvict { table -> transactionalSelf.refundOnIdleEvict(table) }
+    }
+
+    @Transactional
+    fun dealSolo(
+        discordId: Long,
+        guildId: Long,
+        stake: Long,
+        autoTopUp: Boolean = false,
+    ): DealOutcome {
+        val resolved = when (val r = checkLockOrTopUp(discordId, guildId, stake, autoTopUp)) {
+            is TopUpResolution.InvalidStake -> return DealOutcome.InvalidStake(r.min, r.max)
+            TopUpResolution.UnknownUser -> return DealOutcome.UnknownUser
+            is TopUpResolution.StillInsufficientCredits ->
+                return DealOutcome.InsufficientCredits(r.stake, r.have)
+            is TopUpResolution.InsufficientCoinsForTopUp ->
+                return DealOutcome.InsufficientCoinsForTopUp(r.needed, r.have)
+            is TopUpResolution.Ok -> r
+        }
+
+        // Debit the ante into table escrow up-front.
+        resolved.user.socialCredit = resolved.balance - stake
+        userService.updateUser(resolved.user)
+
+        // Sweep any RESOLVED tables this user left behind from a previous hand.
+        sweepResolvedTablesFor(guildId, discordId)
+
+        val table = tableRegistry.create(
+            guildId = guildId,
+            playerDiscordId = discordId,
+            stake = stake,
+        )
+        tableRegistry.lockTable(table.id) { t ->
+            val deck = game.newDeck()
+            t.deck = deck
+            val deal = game.dealAll(deck)
+            t.playerHole.addAll(deal.playerHole)
+            t.dealerHole.addAll(deal.dealerHole)
+            t.board.addAll(deal.flop)
+            t.pendingTurn = deal.turn
+            t.pendingRiver = deal.river
+            t.phase = CasinoHoldemTable.Phase.AWAIT_DECISION
+            t.lastActivityAt = Instant.now()
+        } ?: return DealOutcome.UnknownUser
+
+        return DealOutcome.Dealt(
+            tableId = table.id,
+            snapshot = table,
+            newBalance = resolved.user.socialCredit ?: (resolved.balance - stake),
+            soldTobyCoins = resolved.soldCoins,
+            newPrice = resolved.newPrice,
+        )
+    }
+
+    @Transactional
+    fun applyAction(
+        discordId: Long,
+        guildId: Long,
+        tableId: Long,
+        action: CasinoHoldem.Action,
+    ): ActionOutcome {
+        val table = tableRegistry.get(tableId) ?: return ActionOutcome.HandNotFound
+        if (table.guildId != guildId) return ActionOutcome.HandNotFound
+        if (table.playerDiscordId != discordId) return ActionOutcome.NotYourHand
+        if (table.phase != CasinoHoldemTable.Phase.AWAIT_DECISION) return ActionOutcome.IllegalAction
+
+        return when (action) {
+            CasinoHoldem.Action.FOLD -> handleFold(table, guildId)
+            CasinoHoldem.Action.CALL -> handleCall(table, guildId, discordId)
+        }
+    }
+
+    private fun handleFold(
+        table: CasinoHoldemTable,
+        guildId: Long,
+    ): ActionOutcome {
+        val result = tableRegistry.lockTable(table.id) { t ->
+            if (t.phase != CasinoHoldemTable.Phase.AWAIT_DECISION) return@lockTable null
+            val handResult = CasinoHoldemTable.HandResult(
+                playerHole = t.playerHole.toList(),
+                dealerHole = t.dealerHole.toList(),
+                board = t.board.toList(),
+                resolution = null,
+                folded = true,
+                anteStake = t.stake,
+                callStake = 0L,
+                antePayout = 0L,
+                callPayout = 0L,
+                totalPayout = 0L,
+                resolvedAt = Instant.now(),
+            )
+            t.phase = CasinoHoldemTable.Phase.RESOLVED
+            t.lastResult = handResult
+            t.lastActivityAt = Instant.now()
+            handResult
+        } ?: return ActionOutcome.IllegalAction
+
+        // The ante was already debited at deal time; nothing further to
+        // pay out. Tribute the lost ante to the jackpot pool the same
+        // way every other game does on a loss.
+        val user = userService.getUserByIdForUpdate(table.playerDiscordId, guildId)
+        val newBalance = user?.socialCredit ?: 0L
+        val tribute = JackpotHelper.divertOnLoss(jackpotService, configService, guildId, table.stake)
+        return ActionOutcome.Resolved(
+            tableId = table.id,
+            result = result,
+            newBalance = newBalance,
+            jackpotPayout = 0L,
+            lossTribute = tribute,
+        )
+    }
+
+    private fun handleCall(
+        table: CasinoHoldemTable,
+        guildId: Long,
+        discordId: Long,
+    ): ActionOutcome {
+        val callStake = table.stake * CasinoHoldem.CALL_MULTIPLE
+
+        // Pre-debit the call leg outside the table monitor — keeps the
+        // wallet lock outside the table lock to match the ordering used
+        // by BlackjackService for DOUBLE / SPLIT.
+        val user = userService.getUserByIdForUpdate(discordId, guildId)
+            ?: return ActionOutcome.HandNotFound
+        val balance = user.socialCredit ?: 0L
+        if (balance < callStake) {
+            return ActionOutcome.InsufficientCreditsForCall(needed = callStake, have = balance)
+        }
+        user.socialCredit = balance - callStake
+        userService.updateUser(user)
+
+        val resolution = tableRegistry.lockTable(table.id) { t ->
+            if (t.phase != CasinoHoldemTable.Phase.AWAIT_DECISION) return@lockTable null
+            val turn = t.pendingTurn ?: return@lockTable null
+            val river = t.pendingRiver ?: return@lockTable null
+            t.board.add(turn)
+            t.board.add(river)
+            t.pendingTurn = null
+            t.pendingRiver = null
+            game.resolve(t.playerHole.toList(), t.dealerHole.toList(), t.board.toList())
+        }
+
+        if (resolution == null) {
+            // Table vanished or somehow re-entered while we held the wallet
+            // lock — refund the call we just debited and bail.
+            user.socialCredit = (user.socialCredit ?: 0L) + callStake
+            userService.updateUser(user)
+            return ActionOutcome.IllegalAction
+        }
+
+        val antePayout = (table.stake * game.anteMultiplier(resolution.anteResult)).toLong()
+        val callPayout = (callStake * game.callMultiplier(resolution.callResult)).toLong()
+        val totalPayout = antePayout + callPayout
+
+        // Single wallet write to credit the combined payout.
+        if (totalPayout > 0L) {
+            user.socialCredit = (user.socialCredit ?: 0L) + totalPayout
+            userService.updateUser(user)
+        }
+
+        // Per-leg jackpot rolls / tributes. WIN legs roll once each (so
+        // a hand can produce up to two rolls); LOSE legs feed the pool
+        // their own at-risk stake; PUSH legs are no-ops on both axes.
+        var jackpotPayout = 0L
+        var lossTribute = 0L
+
+        when (resolution.anteResult) {
+            CasinoHoldem.AnteResult.WIN ->
+                jackpotPayout += JackpotHelper.rollOnWin(
+                    jackpotService, configService, userService, user, guildId, random
+                )
+            CasinoHoldem.AnteResult.LOSE ->
+                lossTribute += JackpotHelper.divertOnLoss(
+                    jackpotService, configService, guildId, table.stake
+                )
+            CasinoHoldem.AnteResult.PUSH -> Unit
+        }
+
+        when (resolution.callResult) {
+            CasinoHoldem.CallResult.WIN_ROYAL_FLUSH,
+            CasinoHoldem.CallResult.WIN_STRAIGHT_FLUSH,
+            CasinoHoldem.CallResult.WIN_QUADS,
+            CasinoHoldem.CallResult.WIN_FULL_HOUSE,
+            CasinoHoldem.CallResult.WIN_FLUSH,
+            CasinoHoldem.CallResult.WIN_STRAIGHT,
+            CasinoHoldem.CallResult.WIN_OTHER ->
+                jackpotPayout += JackpotHelper.rollOnWin(
+                    jackpotService, configService, userService, user, guildId, random
+                )
+            CasinoHoldem.CallResult.LOSE ->
+                lossTribute += JackpotHelper.divertOnLoss(
+                    jackpotService, configService, guildId, callStake
+                )
+            CasinoHoldem.CallResult.PUSH, CasinoHoldem.CallResult.FOLDED -> Unit
+        }
+
+        val newBalance = user.socialCredit ?: 0L
+
+        val handResult = CasinoHoldemTable.HandResult(
+            playerHole = table.playerHole.toList(),
+            dealerHole = table.dealerHole.toList(),
+            board = table.board.toList(),
+            resolution = resolution,
+            folded = false,
+            anteStake = table.stake,
+            callStake = callStake,
+            antePayout = antePayout,
+            callPayout = callPayout,
+            totalPayout = totalPayout,
+            resolvedAt = Instant.now(),
+        )
+        // Persist the result on the table so the web poll can render
+        // the resolved state until the next deal sweeps it.
+        synchronized(table) {
+            table.phase = CasinoHoldemTable.Phase.RESOLVED
+            table.lastResult = handResult
+            table.lastActivityAt = Instant.now()
+        }
+
+        return ActionOutcome.Resolved(
+            tableId = table.id,
+            result = handResult,
+            newBalance = newBalance,
+            jackpotPayout = jackpotPayout,
+            lossTribute = lossTribute,
+        )
+    }
+
+    /** Drop a RESOLVED Casino Hold'em table after the player has read the result. */
+    fun closeSoloTable(tableId: Long) {
+        val table = tableRegistry.get(tableId) ?: return
+        if (table.phase == CasinoHoldemTable.Phase.RESOLVED) {
+            tableRegistry.remove(tableId)
+        }
+    }
+
+    /**
+     * Drop every RESOLVED table this user is still attached to in
+     * [guildId]. The action handler intentionally leaves a resolved
+     * table behind so the web JS can poll `/state` once more, render
+     * the result, and disable buttons; this method runs on the next
+     * deal to clear that residue before a fresh table is registered.
+     */
+    private fun sweepResolvedTablesFor(guildId: Long, discordId: Long) {
+        tableRegistry.listForGuild(guildId)
+            .filter { t ->
+                t.playerDiscordId == discordId &&
+                    t.phase == CasinoHoldemTable.Phase.RESOLVED
+            }
+            .forEach { tableRegistry.remove(it.id) }
+    }
+
+    /**
+     * Idle-eviction callback wired in [wireRegistry]. Refunds the
+     * ante on tables that never reached resolution (player walked
+     * away after dealing); RESOLVED tables have already been settled,
+     * so this is a no-op for them.
+     */
+    @Transactional
+    fun refundOnIdleEvict(table: CasinoHoldemTable) {
+        if (table.phase == CasinoHoldemTable.Phase.RESOLVED) return
+        val user = userService.getUserByIdForUpdate(table.playerDiscordId, table.guildId) ?: return
+        user.socialCredit = (user.socialCredit ?: 0L) + table.stake
+        userService.updateUser(user)
+    }
+
+    // -------------------------------------------------------------------------
+    // Private helpers — autoTopUp glue copied from BlackjackService's pattern.
+    // -------------------------------------------------------------------------
+
+    private sealed interface TopUpResolution {
+        data class Ok(
+            val user: UserDto,
+            val balance: Long,
+            val soldCoins: Long,
+            val newPrice: Double?,
+        ) : TopUpResolution
+        data class InvalidStake(val min: Long, val max: Long) : TopUpResolution
+        data class StillInsufficientCredits(val stake: Long, val have: Long) : TopUpResolution
+        data class InsufficientCoinsForTopUp(val needed: Long, val have: Long) : TopUpResolution
+        data object UnknownUser : TopUpResolution
+    }
+
+    private fun checkLockOrTopUp(
+        discordId: Long,
+        guildId: Long,
+        stake: Long,
+        autoTopUp: Boolean,
+    ): TopUpResolution {
+        val check = WagerHelper.checkAndLock(
+            userService, discordId, guildId, stake,
+            CasinoHoldem.MIN_STAKE, CasinoHoldem.MAX_STAKE
+        )
+        return when (check) {
+            is BalanceCheck.InvalidStake -> TopUpResolution.InvalidStake(check.min, check.max)
+            BalanceCheck.UnknownUser -> TopUpResolution.UnknownUser
+            is BalanceCheck.Ok ->
+                TopUpResolution.Ok(check.user, check.balance, soldCoins = 0L, newPrice = null)
+            is BalanceCheck.Insufficient -> {
+                if (!autoTopUp || tradeService == null || marketService == null) {
+                    TopUpResolution.StillInsufficientCredits(check.stake, check.have)
+                } else {
+                    val user = userService.getUserByIdForUpdate(discordId, guildId)
+                        ?: return TopUpResolution.UnknownUser
+                    when (val topUp = CasinoTopUpHelper.ensureCreditsForWager(
+                        tradeService, marketService, userService,
+                        user, guildId, currentBalance = check.have, stake = stake
+                    )) {
+                        is TopUpResult.InsufficientCoins ->
+                            TopUpResolution.InsufficientCoinsForTopUp(topUp.needed, topUp.have)
+                        TopUpResult.MarketUnavailable ->
+                            TopUpResolution.StillInsufficientCredits(check.stake, check.have)
+                        is TopUpResult.ToppedUp ->
+                            TopUpResolution.Ok(topUp.user, topUp.balance, topUp.soldCoins, topUp.newPrice)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/database/src/test/kotlin/database/poker/CasinoHoldemTest.kt
+++ b/database/src/test/kotlin/database/poker/CasinoHoldemTest.kt
@@ -1,0 +1,231 @@
+package database.poker
+
+import database.card.Card
+import database.card.Deck
+import database.card.Rank
+import database.card.Suit
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import kotlin.random.Random
+
+class CasinoHoldemTest {
+
+    private val game = CasinoHoldem()
+
+    private fun c(rank: Rank, suit: Suit) = Card(rank, suit)
+
+    // --- dealAll shape ---
+
+    @Test
+    fun `dealAll peels two hole cards each, a three-card flop, a turn, and a river`() {
+        val deck = Deck(Random(42))
+        val deal = game.dealAll(deck)
+
+        assertEquals(2, deal.playerHole.size)
+        assertEquals(2, deal.dealerHole.size)
+        assertEquals(3, deal.flop.size)
+        // Nine cards consumed total (52 - 9 = 43 left in the deck).
+        assertEquals(43, deck.size)
+
+        val all = deal.playerHole + deal.dealerHole + deal.flop + deal.turn + deal.river
+        // No duplicates across hands + community.
+        assertEquals(all.size, all.toSet().size)
+    }
+
+    // --- dealer qualification (Pair of Fours or better) ---
+
+    @Test
+    fun `dealer qualifies on pair of fours and on any pair stronger than fours`() {
+        val pairOfFours = HandEvaluator.HandRank(
+            HandEvaluator.Category.PAIR, listOf(Rank.FOUR.value, 13, 12, 11)
+        )
+        val pairOfFives = HandEvaluator.HandRank(
+            HandEvaluator.Category.PAIR, listOf(Rank.FIVE.value, 13, 12, 11)
+        )
+        val pairOfAces = HandEvaluator.HandRank(
+            HandEvaluator.Category.PAIR, listOf(Rank.ACE.value, 13, 12, 11)
+        )
+
+        assertTrue(game.dealerQualifies(pairOfFours))
+        assertTrue(game.dealerQualifies(pairOfFives))
+        assertTrue(game.dealerQualifies(pairOfAces))
+    }
+
+    @Test
+    fun `dealer does not qualify on pair of threes or below, or on bare high card`() {
+        val pairOfThrees = HandEvaluator.HandRank(
+            HandEvaluator.Category.PAIR, listOf(Rank.THREE.value, 13, 12, 11)
+        )
+        val pairOfTwos = HandEvaluator.HandRank(
+            HandEvaluator.Category.PAIR, listOf(Rank.TWO.value, 13, 12, 11)
+        )
+        val highCard = HandEvaluator.HandRank(
+            HandEvaluator.Category.HIGH_CARD, listOf(14, 13, 12, 11, 9)
+        )
+
+        assertFalse(game.dealerQualifies(pairOfThrees))
+        assertFalse(game.dealerQualifies(pairOfTwos))
+        assertFalse(game.dealerQualifies(highCard))
+    }
+
+    @Test
+    fun `dealer qualifies on every category above pair`() {
+        val twoPair = HandEvaluator.HandRank(
+            HandEvaluator.Category.TWO_PAIR, listOf(Rank.TWO.value, Rank.THREE.value, 5)
+        )
+        val trips = HandEvaluator.HandRank(
+            HandEvaluator.Category.THREE_OF_A_KIND, listOf(Rank.TWO.value, 5, 4)
+        )
+        val straight = HandEvaluator.HandRank(HandEvaluator.Category.STRAIGHT, listOf(5))
+        val flush = HandEvaluator.HandRank(HandEvaluator.Category.FLUSH, listOf(8, 6, 5, 3, 2))
+        val fullHouse = HandEvaluator.HandRank(HandEvaluator.Category.FULL_HOUSE, listOf(2, 3))
+        val quads = HandEvaluator.HandRank(HandEvaluator.Category.FOUR_OF_A_KIND, listOf(2, 5))
+        val sf = HandEvaluator.HandRank(HandEvaluator.Category.STRAIGHT_FLUSH, listOf(5))
+
+        for (rank in listOf(twoPair, trips, straight, flush, fullHouse, quads, sf)) {
+            assertTrue(game.dealerQualifies(rank), "expected qualify: $rank")
+        }
+    }
+
+    // --- royal flush detection ---
+
+    @Test
+    fun `royal flush is a straight flush whose top tiebreaker is the ace value`() {
+        val royal = HandEvaluator.HandRank(HandEvaluator.Category.STRAIGHT_FLUSH, listOf(Rank.ACE.value))
+        val sfTo10 = HandEvaluator.HandRank(HandEvaluator.Category.STRAIGHT_FLUSH, listOf(Rank.TEN.value))
+        val plainStraight = HandEvaluator.HandRank(HandEvaluator.Category.STRAIGHT, listOf(Rank.ACE.value))
+
+        assertTrue(game.isRoyalFlush(royal))
+        assertFalse(game.isRoyalFlush(sfTo10))
+        assertFalse(game.isRoyalFlush(plainStraight))
+    }
+
+    // --- ante / call multipliers ---
+
+    @Test
+    fun `ante multiplier returns even-money on win, refund on push, zero on loss`() {
+        assertEquals(2.0, game.anteMultiplier(CasinoHoldem.AnteResult.WIN), 1e-9)
+        assertEquals(1.0, game.anteMultiplier(CasinoHoldem.AnteResult.PUSH), 1e-9)
+        assertEquals(0.0, game.anteMultiplier(CasinoHoldem.AnteResult.LOSE), 1e-9)
+    }
+
+    @Test
+    fun `call multiplier matches the standard Casino Hold'em paytable`() {
+        // Returns are bet-inclusive (e.g. 1:1 → 2.0, 100:1 → 101.0).
+        assertEquals(101.0, game.callMultiplier(CasinoHoldem.CallResult.WIN_ROYAL_FLUSH), 1e-9)
+        assertEquals(21.0, game.callMultiplier(CasinoHoldem.CallResult.WIN_STRAIGHT_FLUSH), 1e-9)
+        assertEquals(11.0, game.callMultiplier(CasinoHoldem.CallResult.WIN_QUADS), 1e-9)
+        assertEquals(4.0, game.callMultiplier(CasinoHoldem.CallResult.WIN_FULL_HOUSE), 1e-9)
+        assertEquals(3.0, game.callMultiplier(CasinoHoldem.CallResult.WIN_FLUSH), 1e-9)
+        assertEquals(2.0, game.callMultiplier(CasinoHoldem.CallResult.WIN_STRAIGHT), 1e-9)
+        assertEquals(2.0, game.callMultiplier(CasinoHoldem.CallResult.WIN_OTHER), 1e-9)
+        assertEquals(1.0, game.callMultiplier(CasinoHoldem.CallResult.PUSH), 1e-9)
+        assertEquals(0.0, game.callMultiplier(CasinoHoldem.CallResult.LOSE), 1e-9)
+        assertEquals(0.0, game.callMultiplier(CasinoHoldem.CallResult.FOLDED), 1e-9)
+    }
+
+    // --- resolve() integration ---
+
+    @Test
+    fun `resolve returns ante WIN, call PUSH when dealer fails to qualify`() {
+        // Player: pair of kings; dealer: high card only; board: blanks that
+        // give the dealer nothing.
+        val playerHole = listOf(c(Rank.KING, Suit.SPADES), c(Rank.KING, Suit.HEARTS))
+        val dealerHole = listOf(c(Rank.SEVEN, Suit.CLUBS), c(Rank.TWO, Suit.DIAMONDS))
+        val board = listOf(
+            c(Rank.JACK, Suit.SPADES),
+            c(Rank.NINE, Suit.HEARTS),
+            c(Rank.FIVE, Suit.CLUBS),
+            c(Rank.THREE, Suit.DIAMONDS),
+            c(Rank.SIX, Suit.HEARTS),
+        )
+
+        val res = game.resolve(playerHole, dealerHole, board)
+
+        assertFalse(res.dealerQualified)
+        assertEquals(CasinoHoldem.AnteResult.WIN, res.anteResult)
+        assertEquals(CasinoHoldem.CallResult.PUSH, res.callResult)
+    }
+
+    @Test
+    fun `resolve awards player a flush win when both qualify and player out-ranks dealer`() {
+        // Player: J-10 of spades. Board: A♠ K♠ 5♠ 4♣ 2♠ — player has ace-high spade flush.
+        // Dealer: K♦ Q♣ — pair of kings (qualifies), but flush beats pair.
+        val playerHole = listOf(c(Rank.JACK, Suit.SPADES), c(Rank.TEN, Suit.SPADES))
+        val dealerHole = listOf(c(Rank.KING, Suit.DIAMONDS), c(Rank.QUEEN, Suit.CLUBS))
+        val board = listOf(
+            c(Rank.ACE, Suit.SPADES),
+            c(Rank.KING, Suit.SPADES),
+            c(Rank.FIVE, Suit.SPADES),
+            c(Rank.FOUR, Suit.CLUBS),
+            c(Rank.TWO, Suit.SPADES),
+        )
+
+        val res = game.resolve(playerHole, dealerHole, board)
+
+        assertTrue(res.dealerQualified)
+        assertEquals(CasinoHoldem.AnteResult.WIN, res.anteResult)
+        assertEquals(CasinoHoldem.CallResult.WIN_FLUSH, res.callResult)
+    }
+
+    @Test
+    fun `resolve marks royal flush when player has T-J-Q-K-A of one suit`() {
+        val playerHole = listOf(c(Rank.ACE, Suit.HEARTS), c(Rank.KING, Suit.HEARTS))
+        val dealerHole = listOf(c(Rank.SEVEN, Suit.CLUBS), c(Rank.SEVEN, Suit.DIAMONDS))
+        val board = listOf(
+            c(Rank.QUEEN, Suit.HEARTS),
+            c(Rank.JACK, Suit.HEARTS),
+            c(Rank.TEN, Suit.HEARTS),
+            c(Rank.TWO, Suit.CLUBS),
+            c(Rank.THREE, Suit.SPADES),
+        )
+
+        val res = game.resolve(playerHole, dealerHole, board)
+
+        assertTrue(res.dealerQualified)
+        assertEquals(CasinoHoldem.AnteResult.WIN, res.anteResult)
+        assertEquals(CasinoHoldem.CallResult.WIN_ROYAL_FLUSH, res.callResult)
+    }
+
+    @Test
+    fun `resolve loses both legs when dealer qualifies and out-ranks the player`() {
+        // Player: pair of fives; dealer: pair of aces. Both qualify.
+        val playerHole = listOf(c(Rank.FIVE, Suit.SPADES), c(Rank.FIVE, Suit.HEARTS))
+        val dealerHole = listOf(c(Rank.ACE, Suit.CLUBS), c(Rank.ACE, Suit.DIAMONDS))
+        val board = listOf(
+            c(Rank.JACK, Suit.SPADES),
+            c(Rank.NINE, Suit.HEARTS),
+            c(Rank.SEVEN, Suit.CLUBS),
+            c(Rank.THREE, Suit.DIAMONDS),
+            c(Rank.TWO, Suit.HEARTS),
+        )
+
+        val res = game.resolve(playerHole, dealerHole, board)
+
+        assertTrue(res.dealerQualified)
+        assertEquals(CasinoHoldem.AnteResult.LOSE, res.anteResult)
+        assertEquals(CasinoHoldem.CallResult.LOSE, res.callResult)
+    }
+
+    @Test
+    fun `resolve pushes both legs when player and dealer share the same best hand`() {
+        // Both end up using the board's straight (T-J-Q-K-A) as their best 5.
+        val playerHole = listOf(c(Rank.TWO, Suit.SPADES), c(Rank.THREE, Suit.HEARTS))
+        val dealerHole = listOf(c(Rank.FOUR, Suit.CLUBS), c(Rank.FIVE, Suit.DIAMONDS))
+        val board = listOf(
+            c(Rank.TEN, Suit.HEARTS),
+            c(Rank.JACK, Suit.SPADES),
+            c(Rank.QUEEN, Suit.CLUBS),
+            c(Rank.KING, Suit.DIAMONDS),
+            c(Rank.ACE, Suit.SPADES),
+        )
+
+        val res = game.resolve(playerHole, dealerHole, board)
+
+        assertTrue(res.dealerQualified)
+        assertEquals(CasinoHoldem.AnteResult.PUSH, res.anteResult)
+        assertEquals(CasinoHoldem.CallResult.PUSH, res.callResult)
+    }
+}

--- a/database/src/test/kotlin/database/service/CasinoHoldemServiceTest.kt
+++ b/database/src/test/kotlin/database/service/CasinoHoldemServiceTest.kt
@@ -1,0 +1,409 @@
+package database.service
+
+import database.card.Card
+import database.card.Rank
+import database.card.Suit
+import database.dto.UserDto
+import database.poker.CasinoHoldem
+import database.poker.CasinoHoldemTable
+import database.poker.CasinoHoldemTableRegistry
+import database.poker.HandEvaluator
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.time.Instant
+import java.util.concurrent.Executors
+import kotlin.random.Random
+
+class CasinoHoldemServiceTest {
+
+    private lateinit var userService: UserService
+    private lateinit var jackpotService: JackpotService
+    private lateinit var configService: ConfigService
+    private lateinit var game: CasinoHoldem
+    private lateinit var registry: CasinoHoldemTableRegistry
+    private lateinit var service: CasinoHoldemService
+
+    private val discordId = 100L
+    private val guildId = 200L
+
+    private fun userWithBalance(balance: Long): UserDto =
+        UserDto(discordId, guildId).apply { socialCredit = balance }
+
+    @BeforeEach
+    fun setup() {
+        userService = mockk(relaxed = true)
+        jackpotService = mockk(relaxed = true)
+        configService = mockk(relaxed = true)
+        game = mockk(relaxed = true)
+        // Delegate the (deterministic) per-leg multiplier lookups to a
+        // real CasinoHoldem so we don't have to spell out the paytable
+        // in every test. dealAll / resolve stay stubbed per-test.
+        val real = CasinoHoldem()
+        every { game.anteMultiplier(any()) } answers {
+            real.anteMultiplier(it.invocation.args[0] as CasinoHoldem.AnteResult)
+        }
+        every { game.callMultiplier(any()) } answers {
+            real.callMultiplier(it.invocation.args[0] as CasinoHoldem.CallResult)
+        }
+        // Real registry — its scheduler is harmless and we drive idle
+        // sweeps directly from the test.
+        registry = CasinoHoldemTableRegistry(
+            idleTtl = Duration.ofMinutes(10),
+            sweepInterval = Duration.ofHours(1),
+            scheduler = Executors.newScheduledThreadPool(1),
+        )
+        service = CasinoHoldemService(
+            userService = userService,
+            jackpotService = jackpotService,
+            configService = configService,
+            tableRegistry = registry,
+            game = game,
+            tradeService = null,
+            marketService = null,
+            random = Random(0),
+        )
+        // PostConstruct — wires the idle-evict callback.
+        service.wireRegistry()
+    }
+
+    private fun seededDeal(): CasinoHoldem.Deal = CasinoHoldem.Deal(
+        playerHole = listOf(Card(Rank.ACE, Suit.SPADES), Card(Rank.KING, Suit.SPADES)),
+        dealerHole = listOf(Card(Rank.TWO, Suit.HEARTS), Card(Rank.THREE, Suit.DIAMONDS)),
+        flop = listOf(
+            Card(Rank.QUEEN, Suit.SPADES),
+            Card(Rank.JACK, Suit.SPADES),
+            Card(Rank.TEN, Suit.SPADES),
+        ),
+        turn = Card(Rank.NINE, Suit.CLUBS),
+        river = Card(Rank.EIGHT, Suit.DIAMONDS),
+    )
+
+    private fun stubGameDealAll() {
+        every { game.newDeck() } returns mockk(relaxed = true)
+        every { game.dealAll(any()) } returns seededDeal()
+    }
+
+    // ---------- dealSolo ----------
+
+    @Test
+    fun `dealSolo InvalidStake when stake out of bounds`() {
+        val outcome = service.dealSolo(discordId, guildId, stake = CasinoHoldem.MIN_STAKE - 1)
+
+        val invalid = assertInstanceOf(CasinoHoldemService.DealOutcome.InvalidStake::class.java, outcome)
+        assertEquals(CasinoHoldem.MIN_STAKE, invalid.min)
+        assertEquals(CasinoHoldem.MAX_STAKE, invalid.max)
+        verify(exactly = 0) { userService.getUserByIdForUpdate(any(), any()) }
+    }
+
+    @Test
+    fun `dealSolo UnknownUser when no row in DB`() {
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns null
+
+        val outcome = service.dealSolo(discordId, guildId, stake = 50L)
+
+        assertEquals(CasinoHoldemService.DealOutcome.UnknownUser, outcome)
+    }
+
+    @Test
+    fun `dealSolo InsufficientCredits when balance below stake`() {
+        val user = userWithBalance(20L)
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns user
+
+        val outcome = service.dealSolo(discordId, guildId, stake = 50L)
+
+        val short = assertInstanceOf(
+            CasinoHoldemService.DealOutcome.InsufficientCredits::class.java, outcome
+        )
+        assertEquals(50L, short.stake)
+        assertEquals(20L, short.have)
+        verify(exactly = 0) { userService.updateUser(any()) }
+    }
+
+    @Test
+    fun `dealSolo happy path debits stake, registers a table in AWAIT_DECISION`() {
+        val user = userWithBalance(1_000L)
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns user
+        stubGameDealAll()
+        val captured = slot<UserDto>()
+        every { userService.updateUser(capture(captured)) } returns user
+
+        val outcome = service.dealSolo(discordId, guildId, stake = 100L)
+
+        val dealt = assertInstanceOf(CasinoHoldemService.DealOutcome.Dealt::class.java, outcome)
+        assertEquals(900L, dealt.newBalance)
+        assertEquals(900L, captured.captured.socialCredit)
+
+        val table = registry.get(dealt.tableId)
+        assertTrue(table != null)
+        table!!
+        assertEquals(CasinoHoldemTable.Phase.AWAIT_DECISION, table.phase)
+        assertEquals(2, table.playerHole.size)
+        assertEquals(2, table.dealerHole.size)
+        assertEquals(3, table.board.size)
+        assertEquals(Card(Rank.NINE, Suit.CLUBS), table.pendingTurn)
+        assertEquals(Card(Rank.EIGHT, Suit.DIAMONDS), table.pendingRiver)
+        assertEquals(100L, table.stake)
+    }
+
+    // ---------- applyAction(FOLD) ----------
+
+    @Test
+    fun `applyAction FOLD resolves the table, no payout, ante loss-tributed to jackpot`() {
+        val user = userWithBalance(1_000L)
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns user
+        stubGameDealAll()
+        every { userService.updateUser(any()) } returns user
+        // 10% of 100 stake = 10 tribute (default DEFAULT_LOSS_TRIBUTE is 10%).
+        every { configService.getConfigByName(any(), any()) } returns null
+
+        val dealt = service.dealSolo(discordId, guildId, stake = 100L)
+            as CasinoHoldemService.DealOutcome.Dealt
+
+        val outcome = service.applyAction(
+            discordId, guildId, dealt.tableId, CasinoHoldem.Action.FOLD
+        )
+
+        val resolved = assertInstanceOf(CasinoHoldemService.ActionOutcome.Resolved::class.java, outcome)
+        assertTrue(resolved.result.folded)
+        assertNull(resolved.result.resolution)
+        assertEquals(0L, resolved.result.totalPayout)
+        assertEquals(100L, resolved.result.anteStake)
+        assertEquals(0L, resolved.result.callStake)
+        assertEquals(0L, resolved.jackpotPayout)
+        assertEquals(10L, resolved.lossTribute)
+
+        val table = registry.get(dealt.tableId)!!
+        assertEquals(CasinoHoldemTable.Phase.RESOLVED, table.phase)
+        verify { jackpotService.addToPool(guildId, 10L) }
+    }
+
+    // ---------- applyAction(CALL) ----------
+
+    @Test
+    fun `applyAction CALL with insufficient credits returns InsufficientCreditsForCall`() {
+        // Wallet has just enough for the deal but not for the call (2 × stake).
+        val user = userWithBalance(120L)
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns user
+        stubGameDealAll()
+        every { userService.updateUser(any()) } returns user
+
+        val dealt = service.dealSolo(discordId, guildId, stake = 100L)
+            as CasinoHoldemService.DealOutcome.Dealt
+        // After dealing, balance = 20, callStake = 200 — short.
+
+        val outcome = service.applyAction(
+            discordId, guildId, dealt.tableId, CasinoHoldem.Action.CALL
+        )
+
+        val short = assertInstanceOf(
+            CasinoHoldemService.ActionOutcome.InsufficientCreditsForCall::class.java, outcome
+        )
+        assertEquals(200L, short.needed)
+        assertEquals(20L, short.have)
+        // Table remains in AWAIT_DECISION so the player can fold instead.
+        assertEquals(CasinoHoldemTable.Phase.AWAIT_DECISION, registry.get(dealt.tableId)!!.phase)
+    }
+
+    @Test
+    fun `applyAction CALL pays ante even-money and call 2x on a flush win`() {
+        val user = userWithBalance(1_000L)
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns user
+        stubGameDealAll()
+        every { userService.updateUser(any()) } returns user
+        every { configService.getConfigByName(any(), any()) } returns null
+
+        // Drive resolve() to a known WIN_FLUSH outcome.
+        val playerRank = HandEvaluator.HandRank(
+            HandEvaluator.Category.FLUSH, listOf(14, 13, 11, 5, 3)
+        )
+        val dealerRank = HandEvaluator.HandRank(
+            HandEvaluator.Category.PAIR, listOf(13, 12, 11, 9)
+        )
+        every { game.resolve(any(), any(), any()) } returns CasinoHoldem.Resolution(
+            playerRank = playerRank,
+            dealerRank = dealerRank,
+            dealerQualified = true,
+            anteResult = CasinoHoldem.AnteResult.WIN,
+            callResult = CasinoHoldem.CallResult.WIN_FLUSH,
+        )
+
+        val dealt = service.dealSolo(discordId, guildId, stake = 100L)
+            as CasinoHoldemService.DealOutcome.Dealt
+
+        val outcome = service.applyAction(
+            discordId, guildId, dealt.tableId, CasinoHoldem.Action.CALL
+        )
+
+        val resolved = assertInstanceOf(CasinoHoldemService.ActionOutcome.Resolved::class.java, outcome)
+        // Wallet timeline: start 1000 → -100 deal → -200 call → +200 ante (100*2.0) +600 call (200*3.0)
+        // = 700 → 500 → 700 → 1300
+        assertEquals(200L, resolved.result.antePayout)
+        assertEquals(600L, resolved.result.callPayout)
+        assertEquals(800L, resolved.result.totalPayout)
+        assertEquals(100L, resolved.result.anteStake)
+        assertEquals(200L, resolved.result.callStake)
+        // Two WIN legs roll independently against the jackpot — both miss
+        // here at the default 1% rate with a deterministic Random(0). Just
+        // assert the loss path didn't fire.
+        verify(exactly = 0) { jackpotService.addToPool(any(), any()) }
+        assertEquals(CasinoHoldemTable.Phase.RESOLVED, registry.get(dealt.tableId)!!.phase)
+    }
+
+    @Test
+    fun `applyAction CALL on dealer-no-qualify pushes the call leg`() {
+        val user = userWithBalance(1_000L)
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns user
+        stubGameDealAll()
+        every { userService.updateUser(any()) } returns user
+        every { configService.getConfigByName(any(), any()) } returns null
+
+        val anyRank = HandEvaluator.HandRank(HandEvaluator.Category.HIGH_CARD, listOf(14, 13, 11, 9, 5))
+        every { game.resolve(any(), any(), any()) } returns CasinoHoldem.Resolution(
+            playerRank = anyRank,
+            dealerRank = anyRank,
+            dealerQualified = false,
+            anteResult = CasinoHoldem.AnteResult.WIN,
+            callResult = CasinoHoldem.CallResult.PUSH,
+        )
+
+        val dealt = service.dealSolo(discordId, guildId, stake = 100L)
+            as CasinoHoldemService.DealOutcome.Dealt
+
+        val outcome = service.applyAction(
+            discordId, guildId, dealt.tableId, CasinoHoldem.Action.CALL
+        )
+
+        val resolved = assertInstanceOf(CasinoHoldemService.ActionOutcome.Resolved::class.java, outcome)
+        // Ante WIN: 100 * 2.0 = 200; call PUSH: 200 * 1.0 = 200; total = 400.
+        assertEquals(200L, resolved.result.antePayout)
+        assertEquals(200L, resolved.result.callPayout)
+        assertEquals(400L, resolved.result.totalPayout)
+    }
+
+    @Test
+    fun `applyAction CALL loses both legs when dealer qualifies and out-ranks player`() {
+        val user = userWithBalance(1_000L)
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns user
+        stubGameDealAll()
+        every { userService.updateUser(any()) } returns user
+        every { configService.getConfigByName(any(), any()) } returns null
+
+        val anyRank = HandEvaluator.HandRank(HandEvaluator.Category.PAIR, listOf(5, 14, 12, 11))
+        every { game.resolve(any(), any(), any()) } returns CasinoHoldem.Resolution(
+            playerRank = anyRank,
+            dealerRank = anyRank,
+            dealerQualified = true,
+            anteResult = CasinoHoldem.AnteResult.LOSE,
+            callResult = CasinoHoldem.CallResult.LOSE,
+        )
+
+        val dealt = service.dealSolo(discordId, guildId, stake = 100L)
+            as CasinoHoldemService.DealOutcome.Dealt
+
+        val outcome = service.applyAction(
+            discordId, guildId, dealt.tableId, CasinoHoldem.Action.CALL
+        )
+
+        val resolved = assertInstanceOf(CasinoHoldemService.ActionOutcome.Resolved::class.java, outcome)
+        assertEquals(0L, resolved.result.antePayout)
+        assertEquals(0L, resolved.result.callPayout)
+        assertEquals(0L, resolved.result.totalPayout)
+        // Default 10% loss tribute on each leg's at-risk amount: 100 * .10 + 200 * .10 = 30.
+        assertEquals(30L, resolved.lossTribute)
+        verify { jackpotService.addToPool(guildId, 10L) }
+        verify { jackpotService.addToPool(guildId, 20L) }
+    }
+
+    // ---------- HandNotFound / NotYourHand / IllegalAction ----------
+
+    @Test
+    fun `applyAction returns HandNotFound when table id is unknown`() {
+        val outcome = service.applyAction(discordId, guildId, tableId = 999L, CasinoHoldem.Action.FOLD)
+        assertEquals(CasinoHoldemService.ActionOutcome.HandNotFound, outcome)
+    }
+
+    @Test
+    fun `applyAction returns NotYourHand when caller is not the table owner`() {
+        val user = userWithBalance(1_000L)
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns user
+        stubGameDealAll()
+        every { userService.updateUser(any()) } returns user
+
+        val dealt = service.dealSolo(discordId, guildId, stake = 100L)
+            as CasinoHoldemService.DealOutcome.Dealt
+
+        val outcome = service.applyAction(
+            discordId = 999L, guildId, dealt.tableId, CasinoHoldem.Action.FOLD
+        )
+        assertEquals(CasinoHoldemService.ActionOutcome.NotYourHand, outcome)
+    }
+
+    @Test
+    fun `applyAction on a RESOLVED table is rejected as IllegalAction`() {
+        val user = userWithBalance(1_000L)
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns user
+        stubGameDealAll()
+        every { userService.updateUser(any()) } returns user
+        every { configService.getConfigByName(any(), any()) } returns null
+
+        val dealt = service.dealSolo(discordId, guildId, stake = 100L)
+            as CasinoHoldemService.DealOutcome.Dealt
+        service.applyAction(discordId, guildId, dealt.tableId, CasinoHoldem.Action.FOLD)
+
+        val second = service.applyAction(
+            discordId, guildId, dealt.tableId, CasinoHoldem.Action.FOLD
+        )
+        assertEquals(CasinoHoldemService.ActionOutcome.IllegalAction, second)
+    }
+
+    // ---------- closeSoloTable + idle eviction refund ----------
+
+    @Test
+    fun `closeSoloTable removes the table only when phase is RESOLVED`() {
+        val user = userWithBalance(1_000L)
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns user
+        stubGameDealAll()
+        every { userService.updateUser(any()) } returns user
+        every { configService.getConfigByName(any(), any()) } returns null
+
+        val dealt = service.dealSolo(discordId, guildId, stake = 100L)
+            as CasinoHoldemService.DealOutcome.Dealt
+        // Mid-hand: closeSoloTable is a no-op.
+        service.closeSoloTable(dealt.tableId)
+        assertTrue(registry.get(dealt.tableId) != null)
+
+        service.applyAction(discordId, guildId, dealt.tableId, CasinoHoldem.Action.FOLD)
+        service.closeSoloTable(dealt.tableId)
+        assertNull(registry.get(dealt.tableId))
+    }
+
+    @Test
+    fun `idle eviction refunds the stake on tables stuck in AWAIT_DECISION`() {
+        val user = userWithBalance(1_000L)
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns user
+        stubGameDealAll()
+        every { userService.updateUser(any()) } returns user
+
+        val dealt = service.dealSolo(discordId, guildId, stake = 100L)
+            as CasinoHoldemService.DealOutcome.Dealt
+        // Force the table's lastActivityAt into the past so the sweep evicts it.
+        val table = registry.get(dealt.tableId)!!
+        table.lastActivityAt = Instant.now().minus(Duration.ofHours(1))
+
+        registry.sweepIdle(Instant.now())
+
+        // The eviction callback runs with whatever the user balance was
+        // at the time of refund: it adds the stake back.
+        verify { userService.updateUser(match { it.socialCredit == 1_000L }) }
+        assertNull(registry.get(dealt.tableId))
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/button/buttons/CasinoHoldemButton.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/button/buttons/CasinoHoldemButton.kt
@@ -1,0 +1,78 @@
+package bot.toby.button.buttons
+
+import bot.toby.command.commands.economy.CasinoHoldemEmbeds
+import core.button.Button
+import core.button.ButtonContext
+import database.dto.UserDto
+import database.poker.CasinoHoldem
+import database.poker.CasinoHoldemTableRegistry
+import database.service.CasinoHoldemService
+import database.service.CasinoHoldemService.ActionOutcome
+import net.dv8tion.jda.api.components.MessageTopLevelComponent
+import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+/**
+ * Resolves a click on a `/casinoholdem` action button. The button id
+ * encodes the action and table id (`casinoholdem:CALL:<tableId>`); the
+ * actual hand state lives in [CasinoHoldemTableRegistry], which the
+ * service mutates under a per-table monitor.
+ */
+@Component
+class CasinoHoldemButton @Autowired constructor(
+    private val service: CasinoHoldemService,
+    private val tableRegistry: CasinoHoldemTableRegistry,
+) : Button {
+
+    override val name: String get() = CasinoHoldemEmbeds.BUTTON_NAME
+    override val description: String get() = "Call/Fold under a /casinoholdem hand embed."
+
+    override fun handle(ctx: ButtonContext, requestingUserDto: UserDto, deleteDelay: Int) {
+        val event = ctx.event
+        val parsed = CasinoHoldemEmbeds.parseButtonId(event.componentId) ?: run {
+            event.reply("Couldn't parse this Casino Hold'em button.").setEphemeral(true).queue()
+            return
+        }
+        val table = tableRegistry.get(parsed.tableId)
+        if (table == null || table.guildId != ctx.guild.idLong) {
+            event.reply("This Casino Hold'em hand no longer exists.").setEphemeral(true).queue()
+            return
+        }
+        if (table.playerDiscordId != requestingUserDto.discordId) {
+            event.reply("This isn't your hand — run `/casinoholdem` to start your own.")
+                .setEphemeral(true).queue()
+            return
+        }
+
+        val action = when (parsed.action) {
+            CasinoHoldemEmbeds.Action.CALL -> CasinoHoldem.Action.CALL
+            CasinoHoldemEmbeds.Action.FOLD -> CasinoHoldem.Action.FOLD
+        }
+
+        event.deferEdit().queue()
+        when (val outcome = service.applyAction(
+            requestingUserDto.discordId, table.guildId, table.id, action
+        )) {
+            is ActionOutcome.Resolved -> {
+                event.message.editMessageEmbeds(
+                    CasinoHoldemEmbeds.resolvedEmbed(
+                        table, outcome.result, outcome.newBalance,
+                        outcome.jackpotPayout, outcome.lossTribute
+                    )
+                ).setComponents(emptyList<MessageTopLevelComponent>()).queue()
+                service.closeSoloTable(table.id)
+            }
+            is ActionOutcome.InsufficientCreditsForCall -> sendError(
+                event, "Need ${outcome.needed} credits to call — you only have ${outcome.have}."
+            )
+            ActionOutcome.HandNotFound -> sendError(event, "This hand no longer exists.")
+            ActionOutcome.NotYourHand -> sendError(event, "This isn't your hand.")
+            ActionOutcome.IllegalAction -> sendError(event, "You can't do that right now.")
+        }
+    }
+
+    private fun sendError(event: ButtonInteractionEvent, message: String) {
+        event.hook.sendMessageEmbeds(CasinoHoldemEmbeds.errorEmbed(message)).setEphemeral(true).queue()
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/CasinoHoldemCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/CasinoHoldemCommand.kt
@@ -1,0 +1,111 @@
+package bot.toby.command.commands.economy
+
+import core.command.Command.Companion.invokeDeleteOnMessageResponse
+import core.command.CommandContext
+import database.dto.UserDto
+import database.poker.CasinoHoldem
+import database.poker.CasinoHoldemTableRegistry
+import database.service.CasinoHoldemService
+import database.service.CasinoHoldemService.DealOutcome
+import net.dv8tion.jda.api.components.actionrow.ActionRow
+import net.dv8tion.jda.api.components.buttons.Button
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
+import net.dv8tion.jda.api.interactions.commands.OptionType
+import net.dv8tion.jda.api.interactions.commands.build.OptionData
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+/**
+ * `/casinoholdem stake:<n>` — singleplayer Casino Hold'em vs the
+ * dealer. The flow mirrors `/blackjack solo`: stake debited at deal,
+ * one mid-hand decision (CALL or FOLD) drives settlement through
+ * [CasinoHoldemService].
+ */
+@Component
+class CasinoHoldemCommand @Autowired constructor(
+    private val service: CasinoHoldemService,
+    private val tableRegistry: CasinoHoldemTableRegistry,
+) : EconomyCommand {
+
+    override val name: String = "casinoholdem"
+    override val description: String =
+        "Play one hand of Casino Hold'em — ante, see the flop, then call or fold against the dealer."
+
+    companion object {
+        private const val OPT_STAKE = "stake"
+        private const val OPT_AUTO_TOPUP = "auto_topup"
+    }
+
+    override val optionData: List<OptionData> = listOf(
+        OptionData(OptionType.INTEGER, OPT_STAKE,
+            "Credits to ante (${CasinoHoldem.MIN_STAKE}-${CasinoHoldem.MAX_STAKE})", true)
+            .setMinValue(CasinoHoldem.MIN_STAKE)
+            .setMaxValue(CasinoHoldem.MAX_STAKE),
+        OptionData(OptionType.BOOLEAN, OPT_AUTO_TOPUP,
+            "Sell TOBY at market to cover any credit shortfall", false),
+    )
+
+    override fun handle(ctx: CommandContext, requestingUserDto: UserDto, deleteDelay: Int) {
+        val event = ctx.event
+        event.deferReply().queue()
+
+        val guild = event.guild ?: run {
+            replyError(event, "This command can only be used in a server.", deleteDelay); return
+        }
+        val stake = event.getOption(OPT_STAKE)?.asLong ?: run {
+            replyError(event, "You must specify a stake.", deleteDelay); return
+        }
+        val autoTopUp = event.getOption(OPT_AUTO_TOPUP)?.asBoolean ?: false
+
+        when (val outcome = service.dealSolo(requestingUserDto.discordId, guild.idLong, stake, autoTopUp)) {
+            is DealOutcome.Dealt -> {
+                val table = tableRegistry.get(outcome.tableId)
+                    ?: return replyError(event, "Hand vanished.", deleteDelay)
+                event.hook.sendMessageEmbeds(CasinoHoldemEmbeds.dealEmbed(table))
+                    .addComponents(actionRow(outcome.tableId))
+                    .queue()
+            }
+            is DealOutcome.InvalidStake -> replyFailure(
+                event, WagerCommandFailure.InvalidStake(outcome.min, outcome.max), deleteDelay
+            )
+            is DealOutcome.InsufficientCredits -> replyFailure(
+                event, WagerCommandFailure.InsufficientCredits(outcome.stake, outcome.have), deleteDelay
+            )
+            is DealOutcome.InsufficientCoinsForTopUp -> replyFailure(
+                event, WagerCommandFailure.InsufficientCoinsForTopUp(outcome.needed, outcome.have), deleteDelay
+            )
+            DealOutcome.UnknownUser -> replyFailure(
+                event, WagerCommandFailure.UnknownUser, deleteDelay
+            )
+        }
+    }
+
+    private fun actionRow(tableId: Long): ActionRow = ActionRow.of(
+        Button.success(
+            CasinoHoldemEmbeds.buttonId(CasinoHoldemEmbeds.Action.CALL, tableId),
+            "Call (${CasinoHoldem.CALL_MULTIPLE}× stake)"
+        ),
+        Button.danger(
+            CasinoHoldemEmbeds.buttonId(CasinoHoldemEmbeds.Action.FOLD, tableId),
+            "Fold"
+        ),
+    )
+
+    private fun replyError(
+        event: SlashCommandInteractionEvent,
+        message: String,
+        deleteDelay: Int,
+    ) {
+        event.hook.sendMessageEmbeds(CasinoHoldemEmbeds.errorEmbed(message))
+            .queue(invokeDeleteOnMessageResponse(deleteDelay))
+    }
+
+    private fun replyFailure(
+        event: SlashCommandInteractionEvent,
+        failure: WagerCommandFailure,
+        deleteDelay: Int,
+    ) {
+        event.hook.sendMessageEmbeds(WagerCommandEmbeds.failureEmbed(CasinoHoldemEmbeds.TITLE, failure))
+            .queue(invokeDeleteOnMessageResponse(deleteDelay))
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/CasinoHoldemEmbeds.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/CasinoHoldemEmbeds.kt
@@ -1,0 +1,146 @@
+package bot.toby.command.commands.economy
+
+import database.card.Card
+import database.poker.CasinoHoldem
+import database.poker.CasinoHoldemTable
+import net.dv8tion.jda.api.EmbedBuilder
+import net.dv8tion.jda.api.entities.MessageEmbed
+import java.awt.Color
+
+/**
+ * Shared embed/component plumbing for the Discord `/casinoholdem` flow.
+ *
+ * Component IDs encode the action and table id:
+ *   `casinoholdem:CALL:<tableId>`
+ * The [bot.toby.button.buttons.CasinoHoldemButton] handler parses this
+ * back out and routes to [database.service.CasinoHoldemService.applyAction].
+ */
+internal object CasinoHoldemEmbeds {
+
+    const val BUTTON_NAME = "casinoholdem"
+    private const val BUTTON_DELIM = ":"
+
+    const val TITLE = "🃏 Casino Hold'em"
+
+    private val TABLE_COLOR = Color(0x2C, 0x3E, 0x50)
+    private val NEUTRAL_COLOR = Color(0xA0, 0xA0, 0xB0)
+    private const val HIDDEN = "🂠"
+
+    enum class Action { CALL, FOLD }
+
+    fun buttonId(action: Action, tableId: Long): String =
+        listOf(BUTTON_NAME, action.name, tableId.toString()).joinToString(BUTTON_DELIM)
+
+    data class ParsedButtonId(val action: Action, val tableId: Long)
+
+    fun parseButtonId(componentId: String): ParsedButtonId? {
+        val parts = componentId.split(BUTTON_DELIM)
+        if (parts.size != 3 || !parts[0].equals(BUTTON_NAME, ignoreCase = true)) return null
+        val action = runCatching { Action.valueOf(parts[1].uppercase()) }.getOrNull() ?: return null
+        val tableId = parts[2].toLongOrNull() ?: return null
+        return ParsedButtonId(action, tableId)
+    }
+
+    private fun cardLabel(card: Card): String = "`$card`"
+
+    private fun handLine(cards: List<Card>): String =
+        if (cards.isEmpty()) "—" else cards.joinToString(" ") { cardLabel(it) }
+
+    /** Embed shown after a successful deal — flop visible, dealer hole hidden. */
+    fun dealEmbed(table: CasinoHoldemTable): MessageEmbed {
+        val callCost = table.stake * CasinoHoldem.CALL_MULTIPLE
+        val description = buildString {
+            append("**Dealer:** ").append(HIDDEN).append(' ').append(HIDDEN).append('\n')
+            append("**Board:** ").append(handLine(table.board)).append('\n')
+            append("**You:** ").append(handLine(table.playerHole)).append("\n\n")
+            append("Ante **${table.stake}** credits at risk. ")
+            append("**Call** to commit another **$callCost** credits and see the turn + river, ")
+            append("or **Fold** to forfeit the ante.")
+        }
+        return EmbedBuilder()
+            .setTitle("$TITLE • ${table.stake} credits ante")
+            .setDescription(description)
+            .setColor(TABLE_COLOR)
+            .setFooter("Dealer must hold a pair of fours or better to qualify.")
+            .build()
+    }
+
+    /** Embed shown after the hand resolves (FOLD or showdown). */
+    fun resolvedEmbed(
+        table: CasinoHoldemTable,
+        result: CasinoHoldemTable.HandResult,
+        newBalance: Long,
+        jackpotPayout: Long,
+        lossTribute: Long,
+    ): MessageEmbed {
+        val description = buildString {
+            if (result.folded) {
+                append("**Dealer:** ").append(HIDDEN).append(' ').append(HIDDEN).append('\n')
+                append("**Board:** ").append(handLine(result.board)).append('\n')
+                append("**You:** ").append(handLine(result.playerHole)).append("\n\n")
+                append("You folded. Ante of **${result.anteStake}** forfeited.")
+            } else {
+                append("**Dealer:** ").append(handLine(result.dealerHole)).append('\n')
+                append("**Board:** ").append(handLine(result.board)).append('\n')
+                append("**You:** ").append(handLine(result.playerHole)).append("\n\n")
+                val resolution = result.resolution
+                if (resolution == null) {
+                    append("Hand resolved.")
+                } else {
+                    if (!resolution.dealerQualified) {
+                        append("Dealer didn't qualify — ante pays even, call pushes.\n")
+                    }
+                    append("Ante: ").append(legLabel(resolution.anteResult, result.anteStake, result.antePayout))
+                        .append('\n')
+                    append("Call: ").append(callLegLabel(resolution.callResult, result.callStake, result.callPayout))
+                        .append('\n')
+                }
+                append('\n').append(netLine(result.net))
+            }
+            if (jackpotPayout > 0L) append("\n🎰 Jackpot hit! +$jackpotPayout credits.")
+            if (lossTribute > 0L) append("\n💰 +$lossTribute credits to the jackpot pool.")
+        }
+        return EmbedBuilder()
+            .setTitle(TITLE)
+            .setDescription(description)
+            .addField("New balance", "$newBalance credits", true)
+            .setColor(colorFor(result))
+            .build()
+    }
+
+    private fun legLabel(result: CasinoHoldem.AnteResult, stake: Long, payout: Long): String =
+        when (result) {
+            CasinoHoldem.AnteResult.WIN -> "✅ Win +${payout - stake}"
+            CasinoHoldem.AnteResult.PUSH -> "🤝 Push (refunded $stake)"
+            CasinoHoldem.AnteResult.LOSE -> "❌ Lose -$stake"
+        }
+
+    private fun callLegLabel(result: CasinoHoldem.CallResult, stake: Long, payout: Long): String =
+        when (result) {
+            CasinoHoldem.CallResult.WIN_ROYAL_FLUSH -> "🎉 Royal flush! +${payout - stake} (100:1)"
+            CasinoHoldem.CallResult.WIN_STRAIGHT_FLUSH -> "🎉 Straight flush +${payout - stake} (20:1)"
+            CasinoHoldem.CallResult.WIN_QUADS -> "🎉 Quads +${payout - stake} (10:1)"
+            CasinoHoldem.CallResult.WIN_FULL_HOUSE -> "✅ Full house +${payout - stake} (3:1)"
+            CasinoHoldem.CallResult.WIN_FLUSH -> "✅ Flush +${payout - stake} (2:1)"
+            CasinoHoldem.CallResult.WIN_STRAIGHT -> "✅ Straight +${payout - stake} (1:1)"
+            CasinoHoldem.CallResult.WIN_OTHER -> "✅ Win +${payout - stake} (1:1)"
+            CasinoHoldem.CallResult.PUSH -> "🤝 Push (refunded $stake)"
+            CasinoHoldem.CallResult.LOSE -> "❌ Lose -$stake"
+            CasinoHoldem.CallResult.FOLDED -> "—"
+        }
+
+    private fun netLine(net: Long): String = when {
+        net > 0 -> "Net **+$net credits**."
+        net < 0 -> "Net **$net credits**."
+        else -> "Broke even."
+    }
+
+    private fun colorFor(result: CasinoHoldemTable.HandResult): Color = when {
+        result.folded -> WagerCommandColors.LOSE
+        result.net > 0 -> WagerCommandColors.WIN
+        result.net < 0 -> WagerCommandColors.LOSE
+        else -> NEUTRAL_COLOR
+    }
+
+    fun errorEmbed(message: String): MessageEmbed = WagerCommandEmbeds.errorEmbed(TITLE, message)
+}

--- a/web/src/main/kotlin/web/controller/CasinoHoldemController.kt
+++ b/web/src/main/kotlin/web/controller/CasinoHoldemController.kt
@@ -1,0 +1,205 @@
+package web.controller
+
+import common.casino.CasinoCommonFailure
+import database.poker.CasinoHoldem
+import database.poker.CasinoHoldemTableRegistry
+import database.service.CasinoHoldemService
+import database.service.CasinoHoldemService.ActionOutcome
+import database.service.CasinoHoldemService.DealOutcome
+import database.service.JackpotService
+import database.service.UserService
+import net.dv8tion.jda.api.JDA
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient
+import org.springframework.security.oauth2.client.annotation.RegisteredOAuth2AuthorizedClient
+import org.springframework.security.oauth2.core.user.OAuth2User
+import org.springframework.stereotype.Controller
+import org.springframework.ui.Model
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseBody
+import org.springframework.web.servlet.mvc.support.RedirectAttributes
+import web.casino.CasinoOutcomeMapper
+import web.casino.CasinoResponseLike
+import web.service.CasinoHoldemWebService
+import web.service.EconomyWebService
+import web.util.WebGuildAccess
+import web.util.discordIdOrNull
+import web.util.displayName
+
+/**
+ * Web surface for `/casinoholdem`. Same [CasinoHoldemService] the
+ * Discord command uses, plus the same in-memory
+ * [CasinoHoldemTableRegistry] — a hand started in Discord can also be
+ * played from the web inbox, and vice versa.
+ *
+ * Pages:
+ *   - `GET /casinoholdem/guilds` — guild selector
+ *   - `GET /casinoholdem/{guildId}` — solo play page
+ *
+ * JSON endpoints (browser polls every ~2s for live updates):
+ *   - `GET  /casinoholdem/{guildId}/state`
+ *   - `POST /casinoholdem/{guildId}/deal`
+ *   - `POST /casinoholdem/{guildId}/action`
+ */
+@Controller
+@RequestMapping("/casinoholdem")
+class CasinoHoldemController(
+    private val service: CasinoHoldemService,
+    private val webService: CasinoHoldemWebService,
+    private val tableRegistry: CasinoHoldemTableRegistry,
+    private val economyWebService: EconomyWebService,
+    private val userService: UserService,
+    private val jackpotService: JackpotService,
+    private val jda: JDA,
+) {
+
+    private val errors = CasinoOutcomeMapper { msg -> CasinoHoldemActionResponse(ok = false, error = msg) }
+
+    @GetMapping("/guilds")
+    fun guildList(
+        @RegisteredOAuth2AuthorizedClient("discord") client: OAuth2AuthorizedClient,
+        @AuthenticationPrincipal user: OAuth2User,
+        model: Model,
+    ): String {
+        val discordId = user.discordIdOrNull()
+        val guilds = if (discordId != null) {
+            economyWebService.getGuildsWhereUserCanView(client.accessToken.tokenValue, discordId)
+        } else emptyList()
+        model.addAttribute("guilds", guilds)
+        model.addAttribute("username", user.displayName())
+        return "casinoholdem-guilds"
+    }
+
+    @GetMapping("/{guildId}")
+    fun page(
+        @PathVariable guildId: Long,
+        @AuthenticationPrincipal user: OAuth2User,
+        model: Model,
+        ra: RedirectAttributes,
+    ): String = WebGuildAccess.requireMemberForPage(
+        user, guildId, economyWebService, ra, lobbyPath = "/casinoholdem/guilds"
+    ) { discordId ->
+        val guild = jda.getGuildById(guildId) ?: run {
+            ra.addFlashAttribute("error", "Bot is not in that server.")
+            return@requireMemberForPage "redirect:/casinoholdem/guilds"
+        }
+        val profile = userService.getUserById(discordId, guildId)
+        model.addAttribute("guildId", guildId.toString())
+        model.addAttribute("guildName", guild.name)
+        model.addAttribute("balance", profile?.socialCredit ?: 0L)
+        model.addAttribute("jackpotPool", jackpotService.getPool(guildId))
+        model.addAttribute("jackpotWinPct", jackpotService.winProbabilityPct(guildId))
+        model.addAttribute("minStake", CasinoHoldem.MIN_STAKE)
+        model.addAttribute("maxStake", CasinoHoldem.MAX_STAKE)
+        model.addAttribute("callMultiple", CasinoHoldem.CALL_MULTIPLE)
+        model.addAttribute("username", user.displayName())
+        model.addAttribute("myDiscordId", discordId.toString())
+        "casinoholdem-solo"
+    }
+
+    @GetMapping("/{guildId}/state")
+    @ResponseBody
+    fun state(
+        @PathVariable guildId: Long,
+        @AuthenticationPrincipal user: OAuth2User,
+    ): ResponseEntity<CasinoHoldemWebService.TableStateView> = WebGuildAccess.requireMemberForJsonNoBody(
+        user, guildId, economyWebService
+    ) { discordId ->
+        val tableId = webService.findActiveTable(guildId, discordId)
+            ?: return@requireMemberForJsonNoBody ResponseEntity.status(404).build()
+        val view = webService.snapshot(tableId, discordId)
+            ?: return@requireMemberForJsonNoBody ResponseEntity.status(404).build()
+        if (view.guildId != guildId) return@requireMemberForJsonNoBody ResponseEntity.status(404).build()
+        ResponseEntity.ok(view)
+    }
+
+    @PostMapping("/{guildId}/deal")
+    @ResponseBody
+    fun deal(
+        @PathVariable guildId: Long,
+        @RequestBody request: CasinoHoldemDealRequest,
+        @AuthenticationPrincipal user: OAuth2User,
+    ): ResponseEntity<CasinoHoldemActionResponse> = WebGuildAccess.requireMemberForJson(
+        user, guildId, economyWebService, errorBuilder = errors.errorBuilder
+    ) { discordId ->
+        when (val outcome = service.dealSolo(discordId, guildId, request.stake, request.autoTopUp)) {
+            is DealOutcome.Dealt -> ResponseEntity.ok(
+                CasinoHoldemActionResponse(
+                    ok = true,
+                    tableId = outcome.tableId,
+                    newBalance = outcome.newBalance,
+                    soldTobyCoins = outcome.soldTobyCoins.takeIf { it > 0L },
+                    newPrice = outcome.newPrice,
+                )
+            )
+            is CasinoCommonFailure -> errors.mapCommonFailure(outcome)
+        }
+    }
+
+    @PostMapping("/{guildId}/action")
+    @ResponseBody
+    fun action(
+        @PathVariable guildId: Long,
+        @RequestBody request: CasinoHoldemActionRequest,
+        @AuthenticationPrincipal user: OAuth2User,
+    ): ResponseEntity<CasinoHoldemActionResponse> = WebGuildAccess.requireMemberForJson(
+        user, guildId, economyWebService, errorBuilder = errors.errorBuilder
+    ) { discordId ->
+        val tableId = webService.findActiveTable(guildId, discordId)
+            ?: return@requireMemberForJson ResponseEntity.status(404)
+                .body(CasinoHoldemActionResponse(false, error = "No active hand. Click Deal first."))
+        val action = parseAction(request.action)
+            ?: return@requireMemberForJson errors.badRequest("Unknown action: ${request.action}")
+
+        when (val outcome = service.applyAction(discordId, guildId, tableId, action)) {
+            is ActionOutcome.Resolved -> {
+                // Leave the resolved table in registry so the JS poll can read
+                // the final state and disable buttons. The next deal sweeps it.
+                ResponseEntity.ok(
+                    CasinoHoldemActionResponse(
+                        ok = true,
+                        tableId = tableId,
+                        resolved = true,
+                        newBalance = outcome.newBalance,
+                        jackpotPayout = outcome.jackpotPayout.takeIf { it > 0L },
+                        lossTribute = outcome.lossTribute.takeIf { it > 0L },
+                    )
+                )
+            }
+            is ActionOutcome.InsufficientCreditsForCall ->
+                errors.insufficientCredits(outcome.needed, outcome.have)
+            ActionOutcome.HandNotFound -> ResponseEntity.status(404)
+                .body(CasinoHoldemActionResponse(false, error = "Hand no longer exists."))
+            ActionOutcome.NotYourHand -> ResponseEntity.status(403)
+                .body(CasinoHoldemActionResponse(false, error = "This isn't your hand."))
+            ActionOutcome.IllegalAction ->
+                errors.badRequest("You can't do that right now.")
+        }
+    }
+
+    private fun parseAction(raw: String): CasinoHoldem.Action? = when (raw.lowercase()) {
+        "call" -> CasinoHoldem.Action.CALL
+        "fold" -> CasinoHoldem.Action.FOLD
+        else -> null
+    }
+}
+
+data class CasinoHoldemDealRequest(val stake: Long = 0, val autoTopUp: Boolean = false)
+data class CasinoHoldemActionRequest(val action: String = "")
+
+data class CasinoHoldemActionResponse(
+    override val ok: Boolean,
+    override val error: String? = null,
+    val tableId: Long? = null,
+    val resolved: Boolean? = null,
+    val newBalance: Long? = null,
+    val jackpotPayout: Long? = null,
+    val lossTribute: Long? = null,
+    val soldTobyCoins: Long? = null,
+    val newPrice: Double? = null,
+) : CasinoResponseLike

--- a/web/src/main/kotlin/web/service/CasinoHoldemWebService.kt
+++ b/web/src/main/kotlin/web/service/CasinoHoldemWebService.kt
@@ -1,0 +1,115 @@
+package web.service
+
+import database.card.Card
+import database.poker.CasinoHoldem
+import database.poker.CasinoHoldemTable
+import database.poker.CasinoHoldemTableRegistry
+import org.springframework.stereotype.Service
+
+/**
+ * Read-only projection of [CasinoHoldemTable] for the web UI. Crucially,
+ * the dealer's hole cards are masked server-side while the table is in
+ * [CasinoHoldemTable.Phase.AWAIT_DECISION] so a hostile client polling
+ * `/state` can't peek before showdown. Once the table is RESOLVED the
+ * dealer is fully revealed (including on a fold — the dealer reveal on
+ * a fold is intentionally suppressed for blackjack but Casino Hold'em
+ * wagers don't depend on dealer's hole on a fold either way; we keep
+ * the dealer hidden on folds to mirror the discord embed).
+ */
+@Service
+class CasinoHoldemWebService(
+    private val tableRegistry: CasinoHoldemTableRegistry,
+) {
+
+    data class TableStateView(
+        val tableId: Long,
+        val guildId: Long,
+        // Stringified for parity with [BlackjackWebService.TableStateView] —
+        // 18-digit Discord snowflakes survive JS's 53-bit Number precision.
+        val playerDiscordId: String,
+        val phase: String,
+        val stake: Long,
+        val callStake: Long,
+        val playerHole: List<String>,
+        /** Masked while AWAIT_DECISION or on a fold; full reveal on showdown. */
+        val dealerHole: List<String>,
+        val board: List<String>,
+        val lastResult: HandResultView?,
+    )
+
+    data class HandResultView(
+        val playerHole: List<String>,
+        val dealerHole: List<String>,
+        val board: List<String>,
+        val folded: Boolean,
+        val dealerQualified: Boolean,
+        val anteResult: String?,
+        val callResult: String?,
+        val anteStake: Long,
+        val callStake: Long,
+        val antePayout: Long,
+        val callPayout: Long,
+        val totalPayout: Long,
+        val net: Long,
+    )
+
+    fun snapshot(tableId: Long, viewerDiscordId: Long): TableStateView? {
+        val table = tableRegistry.get(tableId) ?: return null
+        if (table.playerDiscordId != viewerDiscordId) return null
+        synchronized(table) {
+            val masked = when (table.phase) {
+                CasinoHoldemTable.Phase.AWAIT_DECISION -> List(table.dealerHole.size) { HOLE_MASK }
+                CasinoHoldemTable.Phase.RESOLVED -> {
+                    // Hide the dealer's hole on a fold so the player can't
+                    // post-mortem the hand they walked away from.
+                    if (table.lastResult?.folded == true) List(table.dealerHole.size) { HOLE_MASK }
+                    else table.dealerHole.map(Card::toString)
+                }
+            }
+            return TableStateView(
+                tableId = table.id,
+                guildId = table.guildId,
+                playerDiscordId = table.playerDiscordId.toString(),
+                phase = table.phase.name,
+                stake = table.stake,
+                callStake = table.stake * CasinoHoldem.CALL_MULTIPLE,
+                playerHole = table.playerHole.map(Card::toString),
+                dealerHole = masked,
+                board = table.board.map(Card::toString),
+                lastResult = table.lastResult?.let { resultView(it) },
+            )
+        }
+    }
+
+    private fun resultView(result: CasinoHoldemTable.HandResult): HandResultView = HandResultView(
+        playerHole = result.playerHole.map(Card::toString),
+        dealerHole = if (result.folded) List(result.dealerHole.size) { HOLE_MASK }
+        else result.dealerHole.map(Card::toString),
+        board = result.board.map(Card::toString),
+        folded = result.folded,
+        dealerQualified = result.resolution?.dealerQualified ?: false,
+        anteResult = result.resolution?.anteResult?.name,
+        callResult = result.resolution?.callResult?.name,
+        anteStake = result.anteStake,
+        callStake = result.callStake,
+        antePayout = result.antePayout,
+        callPayout = result.callPayout,
+        totalPayout = result.totalPayout,
+        net = result.net,
+    )
+
+    /** Look up the player's currently-active table id in [guildId], if any. */
+    fun findActiveTable(guildId: Long, discordId: Long): Long? {
+        val mine = tableRegistry.listForGuild(guildId)
+            .filter { it.playerDiscordId == discordId }
+        // Prefer a still-in-flight hand. After resolution the table sticks
+        // around for one more `/state` poll so the UI can render the result;
+        // a fresh deal sweeps it.
+        return (mine.firstOrNull { it.phase != CasinoHoldemTable.Phase.RESOLVED }
+            ?: mine.firstOrNull())?.id
+    }
+
+    companion object {
+        private const val HOLE_MASK = "??"
+    }
+}

--- a/web/src/main/resources/static/css/casinoholdem.css
+++ b/web/src/main/resources/static/css/casinoholdem.css
@@ -1,0 +1,149 @@
+/*
+ * Casino Hold'em is layout-equivalent to blackjack solo: deal form,
+ * action zones, results panel, rules. The differences are mostly
+ * naming (`.che-*` vs `.bj-*`) and the addition of a paytable.
+ *
+ * To keep the visual language aligned with the rest of the casino,
+ * we import the shared casino-table felt + card glyphs and only
+ * declare the `.che-*` deltas below. Anything that's identical to
+ * blackjack uses the casino-table-* classes directly in the template.
+ */
+@import url("./casino-table.css");
+
+.che-header {
+    margin-bottom: 1.5rem;
+}
+
+.che-header h1 {
+    margin: 0.25rem 0 0.5rem;
+}
+
+.back-link {
+    color: var(--muted, #a0a0b0);
+    text-decoration: none;
+    font-size: 0.9rem;
+}
+
+.back-link:hover { text-decoration: underline; }
+
+.che-card {
+    background: var(--surface, #1f2128);
+    border-radius: 0.75rem;
+    padding: 1.5rem;
+    max-width: 56rem;
+    margin-bottom: 1.5rem;
+}
+
+.che-card h2 {
+    margin-top: 0;
+    margin-bottom: 1rem;
+}
+
+.che-card form {
+    display: grid;
+    gap: 0.5rem;
+    margin-bottom: 1.25rem;
+}
+
+.che-card input {
+    background: var(--surface-2, #16181d);
+    color: inherit;
+    border: 1px solid var(--border, #2a2d35);
+    border-radius: 0.4rem;
+    padding: 0.5rem 0.75rem;
+    font: inherit;
+}
+
+.che-card input:focus {
+    outline: 2px solid var(--accent, #5865f2);
+    outline-offset: 2px;
+}
+
+.che-balance {
+    color: var(--muted, #a0a0b0);
+}
+
+.che-table .che-row {
+    margin: 1rem 0;
+}
+
+.che-table .che-row h3 {
+    margin: 0 0 0.5rem;
+    font-size: 1rem;
+    font-weight: 600;
+}
+
+.che-cards {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+    min-height: 4.5rem;
+}
+
+.che-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin: 1rem 0 0.5rem;
+}
+
+.che-result {
+    margin-top: 0.75rem;
+    min-height: 1.4rem;
+    font-weight: 600;
+}
+
+.che-result.che-win { color: #57f287; }
+.che-result.che-lose { color: #ed4245; }
+
+.che-rules {
+    margin-top: 2rem;
+    background: var(--surface, #1f2128);
+    border-radius: 0.75rem;
+    padding: 1.25rem 1.5rem;
+    max-width: 56rem;
+}
+
+.che-rules h2 {
+    margin-top: 0;
+    margin-bottom: 0.75rem;
+    font-size: 1.1rem;
+}
+
+.che-rules ul {
+    padding-left: 1.25rem;
+    margin-bottom: 1rem;
+}
+
+.che-rules li + li {
+    margin-top: 0.4rem;
+}
+
+.che-rules strong { color: #fff; }
+
+.che-paytable {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.95rem;
+}
+
+.che-paytable th,
+.che-paytable td {
+    text-align: left;
+    padding: 0.4rem 0.5rem;
+    border-bottom: 1px solid var(--border, #2a2d35);
+}
+
+.che-paytable th {
+    color: var(--muted, #a0a0b0);
+    font-weight: 600;
+}
+
+.che-paytable tr:last-child td { border-bottom: none; }
+
+/* Match the blackjack hidden-card glyph so the dealer's masked hole
+   reads as a face-down playing card and not a literal "??". */
+.casino-card-glyph.bj-card-hidden,
+.casino-card-glyph.che-card-hidden {
+    color: #a0a0b0;
+}

--- a/web/src/main/resources/static/js/casinoholdem-solo.js
+++ b/web/src/main/resources/static/js/casinoholdem-solo.js
@@ -1,0 +1,202 @@
+(function () {
+    "use strict";
+
+    // Shared card-glyph rendering — the same path blackjack-solo uses.
+    // Falls back to inline glyphs if casino-render didn't load.
+    function renderCards(container, cards) {
+        if (window.CasinoRender) {
+            window.CasinoRender.renderCards(container, cards);
+            return;
+        }
+        container.innerHTML = "";
+        (cards || []).forEach(function (c) {
+            var el = document.createElement("span");
+            el.className = "casino-card-glyph";
+            if (c === "??") {
+                el.classList.add("che-card-hidden");
+                el.textContent = "🂠";
+            } else {
+                el.textContent = c;
+                if (c.indexOf("♥") >= 0 || c.indexOf("♦") >= 0) {
+                    el.classList.add("casino-card-red");
+                }
+            }
+            container.appendChild(el);
+        });
+    }
+
+    // Dedup the celebratory chip-stack flourish per resolved hand. Each
+    // /casinoholdem deal mints a fresh tableId, so keying on tableId is
+    // sufficient — the resolved poll arrives multiple times before the
+    // user clicks Deal again.
+    function createFlashDedup() {
+        var lastKey = null;
+        return function shouldFlash(state) {
+            if (!state || !state.lastResult) return false;
+            var key = String(state.tableId);
+            if (key === lastKey) return false;
+            lastKey = key;
+            return true;
+        };
+    }
+
+    var main = document.getElementById("main");
+    if (!main) return;
+
+    var guildId = main.dataset.guildId;
+    var callMultiple = parseInt(main.dataset.callMultiple || "2", 10);
+
+    var dealForm = document.getElementById("che-deal");
+    var stakeInput = document.getElementById("che-stake");
+    var balanceEl = document.getElementById("che-balance");
+    var tableEl = document.getElementById("che-table");
+    var dealerCardsEl = document.getElementById("che-dealer-cards");
+    var boardCardsEl = document.getElementById("che-board-cards");
+    var playerCardsEl = document.getElementById("che-player-cards");
+    var callBtn = document.getElementById("che-action-call");
+    var foldBtn = document.getElementById("che-action-fold");
+    var callCostEl = document.getElementById("che-call-cost");
+    var resultEl = document.getElementById("che-result");
+    var playerRowEl = document.getElementById("che-player-row");
+
+    var pollTimer = null;
+    var shouldFlash = createFlashDedup();
+
+    function setActionsEnabled(enabled) {
+        callBtn.disabled = !enabled;
+        foldBtn.disabled = !enabled;
+    }
+
+    function renderState(state) {
+        if (!state) return;
+        tableEl.hidden = false;
+        renderCards(dealerCardsEl, state.dealerHole);
+        renderCards(boardCardsEl, state.board);
+        renderCards(playerCardsEl, state.playerHole);
+        callCostEl.textContent = state.callStake;
+
+        if (state.phase === "AWAIT_DECISION") {
+            setActionsEnabled(true);
+            resultEl.textContent = "";
+            resultEl.className = "che-result muted";
+            if (playerRowEl) playerRowEl.classList.add("is-active");
+        } else {
+            setActionsEnabled(false);
+            if (playerRowEl) playerRowEl.classList.remove("is-active");
+            if (state.phase === "RESOLVED" && state.lastResult) {
+                renderResult(state);
+                stopPoll();
+            }
+        }
+    }
+
+    function renderResult(state) {
+        var r = state.lastResult;
+        var label;
+        var cls = "muted";
+        if (r.folded) {
+            label = "Folded — ante of " + r.anteStake + " forfeited.";
+            cls = "che-lose";
+        } else if (r.net > 0) {
+            label = winLabel(r) + " Net +" + r.net + " credits.";
+            cls = "che-win";
+        } else if (r.net < 0) {
+            label = "Dealer wins. Net " + r.net + " credits.";
+            cls = "che-lose";
+        } else {
+            label = "Push.";
+        }
+        resultEl.textContent = label;
+        resultEl.className = "che-result " + cls;
+
+        if (shouldFlash(state) && window.CasinoRender) {
+            if (r.totalPayout && r.totalPayout > 0 && playerRowEl) {
+                window.CasinoRender.flashChipsOn(playerRowEl, r.totalPayout);
+            }
+            if (window.CasinoSounds) {
+                window.CasinoSounds.play(r.net > 0 ? "win" : "lose");
+            }
+        }
+    }
+
+    function winLabel(r) {
+        switch (r.callResult) {
+            case "WIN_ROYAL_FLUSH": return "Royal flush! Paid 100:1.";
+            case "WIN_STRAIGHT_FLUSH": return "Straight flush — paid 20:1.";
+            case "WIN_QUADS": return "Four of a kind — paid 10:1.";
+            case "WIN_FULL_HOUSE": return "Full house — paid 3:1.";
+            case "WIN_FLUSH": return "Flush — paid 2:1.";
+            case "WIN_STRAIGHT": return "Straight — paid 1:1.";
+            case "WIN_OTHER": return "You win.";
+            case "PUSH":
+                return r.dealerQualified
+                    ? "Tied with the dealer."
+                    : "Dealer didn't qualify — ante pays even, call pushes.";
+            default: return "You win.";
+        }
+    }
+
+    function startPoll() {
+        stopPoll();
+        pollTimer = setInterval(refreshState, 1500);
+    }
+
+    function stopPoll() {
+        if (pollTimer) {
+            clearInterval(pollTimer);
+            pollTimer = null;
+        }
+    }
+
+    function refreshState() {
+        return fetch("/casinoholdem/" + guildId + "/state", { credentials: "same-origin" })
+            .then(function (r) {
+                if (r.status === 404) {
+                    stopPoll();
+                    return null;
+                }
+                if (!r.ok) throw new Error("state HTTP " + r.status);
+                return r.json();
+            })
+            .then(function (state) { renderState(state); })
+            .catch(function (e) { console.warn("state poll failed", e); });
+    }
+
+    dealForm.addEventListener("submit", function (e) {
+        e.preventDefault();
+        var stake = parseInt(stakeInput.value, 10);
+        if (!stake) return;
+        window.TobyApi.postJson("/casinoholdem/" + guildId + "/deal", { stake: stake })
+            .then(function (b) {
+                if (!b.ok) {
+                    window.toasts && window.toasts.error(b.error || "Deal failed.");
+                    return;
+                }
+                window.TobyBalance.update(balanceEl, b.newBalance);
+                refreshState();
+                startPoll();
+            });
+    });
+
+    function postAction(action) {
+        return window.TobyApi.postJson("/casinoholdem/" + guildId + "/action", { action: action })
+            .then(function (b) {
+                if (!b.ok) {
+                    window.toasts && window.toasts.error(b.error || "Action failed.");
+                    return;
+                }
+                if (typeof b.newBalance === "number") {
+                    window.TobyBalance.update(balanceEl, b.newBalance);
+                }
+                refreshState();
+            });
+    }
+
+    callBtn.addEventListener("click", function () { postAction("call"); });
+    foldBtn.addEventListener("click", function () { postAction("fold"); });
+
+    // On page load, see if the player already has an in-flight hand.
+    refreshState().then(function () {
+        if (!callBtn.disabled || !foldBtn.disabled) startPoll();
+    });
+})();

--- a/web/src/main/resources/templates/casino-guilds.html
+++ b/web/src/main/resources/templates/casino-guilds.html
@@ -40,6 +40,8 @@
                    th:href="@{/poker/{id}(id=${g.id})}">🎴 Poker</a>
                 <a class="btn-secondary"
                    th:href="@{/blackjack/{id}/solo(id=${g.id})}">🂡 Blackjack</a>
+                <a class="btn-secondary"
+                   th:href="@{/casinoholdem/{id}(id=${g.id})}">🃏 Casino Hold'em</a>
             </div>
         </div>
     </div>

--- a/web/src/main/resources/templates/casinoholdem-guilds.html
+++ b/web/src/main/resources/templates/casinoholdem-guilds.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="en">
+<head th:replace="~{fragments/head :: head('TobyBot - Casino Hold''em', '/css/leaderboard.css')}"></head>
+<body>
+<a href="#main" class="skip-link">Skip to content</a>
+<div th:replace="~{fragments/navbar :: navbar}"></div>
+
+<main id="main" class="container">
+    <h1 class="mb-3">🃏 Casino Hold'em</h1>
+    <p class="muted mb-5">
+        Heads-up Texas Hold'em against the house. Ante, see the flop,
+        then call (2× stake) or fold. Dealer must hold a pair of fours
+        or better to qualify; standard Casino Hold'em paytable on the
+        call leg.
+    </p>
+
+    <div th:replace="~{fragments/alerts :: error}"></div>
+
+    <div class="lb-guild-grid" th:if="${not #lists.isEmpty(guilds)}">
+        <div class="lb-guild-card lb-guild-card-static" th:each="g : ${guilds}">
+            <div class="lb-guild-card-header">
+                <img th:if="${g.iconUrl != null}"
+                     th:src="${g.iconUrl}"
+                     th:alt="${g.name} + ' icon'"
+                     class="lb-guild-icon"
+                     onerror="this.style.display='none'">
+                <div th:unless="${g.iconUrl != null}"
+                     class="lb-guild-icon-placeholder"
+                     aria-hidden="true"
+                     th:text="${#strings.substring(g.name, 0, 1).toUpperCase()}">G</div>
+                <div class="lb-guild-name" th:text="${g.name}" th:title="${g.name}">Guild</div>
+            </div>
+            <div class="lb-guild-top">
+                <span class="muted">Your wallet:</span>
+                <span th:text="${g.credits} + ' credits'">0 credits</span>
+            </div>
+            <div class="lb-guild-games">
+                <a class="btn-secondary" th:href="@{/casinoholdem/{id}(id=${g.id})}">Play</a>
+            </div>
+        </div>
+    </div>
+
+    <div class="empty-hero" th:if="${#lists.isEmpty(guilds)}">
+        <span class="emoji" aria-hidden="true">🃏</span>
+        <h2>No servers to play Casino Hold'em in yet</h2>
+        <p class="mb-5">
+            You need to share at least one server with TobyBot to play.
+        </p>
+    </div>
+</main>
+</body>
+</html>

--- a/web/src/main/resources/templates/casinoholdem-solo.html
+++ b/web/src/main/resources/templates/casinoholdem-solo.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="en">
+<head th:replace="~{fragments/head :: head('TobyBot - Casino Hold''em', '/css/casinoholdem.css')}"></head>
+<body>
+<a href="#main" class="skip-link">Skip to content</a>
+<div th:replace="~{fragments/navbar :: navbar}"></div>
+
+<main id="main" class="container"
+      th:attr="data-guild-id=${guildId}, data-min-stake=${minStake}, data-max-stake=${maxStake}, data-call-multiple=${callMultiple}, data-my-discord-id=${myDiscordId}">
+
+    <div class="che-header">
+        <a class="back-link" th:href="@{/casinoholdem/guilds}">&larr; All servers</a>
+        <h1>🃏 Casino Hold'em</h1>
+        <p class="muted">
+            Bet between <span th:text="${minStake}">10</span> and
+            <span th:text="${maxStake}">500</span> credits per hand.
+            See the flop, then call (<span th:text="${callMultiple}">2</span>× stake) or fold.
+            Dealer must hold a pair of fours or better to qualify.
+        </p>
+    </div>
+
+    <div th:replace="~{fragments/alerts :: error}"></div>
+
+    <div th:replace="~{fragments/casino :: jackpotBanner}"></div>
+
+    <section class="che-card">
+        <h2>Place your ante</h2>
+        <form id="che-deal" autocomplete="off">
+            <label for="che-stake">Ante (credits)</label>
+            <input id="che-stake" name="stake" type="number"
+                   th:attr="min=${minStake}, max=${maxStake}" th:value="${minStake}" step="1" required>
+            <button type="submit" class="btn-primary">Deal</button>
+        </form>
+        <div class="che-balance">
+            Wallet: <strong id="che-balance" th:text="${balance}">0</strong> credits
+        </div>
+    </section>
+
+    <section class="che-table casino-felt" id="che-table" hidden>
+        <div class="che-row casino-dealer-zone">
+            <h3>Dealer</h3>
+            <div id="che-dealer-cards" class="che-cards casino-cards"></div>
+        </div>
+        <div class="che-row casino-board-zone">
+            <h3>Board</h3>
+            <div id="che-board-cards" class="che-cards casino-cards"></div>
+        </div>
+        <div class="che-row casino-seat" id="che-player-row">
+            <h3>You</h3>
+            <div id="che-player-cards" class="che-cards casino-cards"></div>
+        </div>
+
+        <div class="che-actions">
+            <button id="che-action-call" class="btn-success" type="button" disabled>
+                Call (<span id="che-call-cost">0</span> credits)
+            </button>
+            <button id="che-action-fold" class="btn-danger" type="button" disabled>Fold</button>
+        </div>
+
+        <div id="che-result" class="che-result muted"></div>
+    </section>
+
+    <section class="che-rules">
+        <h2>Paytable &amp; rules</h2>
+        <ul>
+            <li>You ante <strong>stake</strong>, get 2 hole cards, see a 3-card flop.</li>
+            <li><strong>Call</strong> commits another <strong>2× stake</strong> to see the turn and river.
+                <strong>Fold</strong> forfeits your ante.</li>
+            <li>Dealer must qualify with at least a pair of fours. If they don't, the ante pays
+                <strong>1:1</strong> and the call <strong>pushes</strong> regardless of who has the better hand.</li>
+            <li>If both qualify, ante pays even on a win and the call leg pays per the schedule below.</li>
+        </ul>
+        <table class="che-paytable">
+            <thead>
+            <tr><th>Hand</th><th>Call payout</th></tr>
+            </thead>
+            <tbody>
+            <tr><td>Royal flush</td><td>100:1</td></tr>
+            <tr><td>Straight flush</td><td>20:1</td></tr>
+            <tr><td>Four of a kind</td><td>10:1</td></tr>
+            <tr><td>Full house</td><td>3:1</td></tr>
+            <tr><td>Flush</td><td>2:1</td></tr>
+            <tr><td>Straight</td><td>1:1</td></tr>
+            <tr><td>Trips, two pair, pair, high card (winning)</td><td>1:1</td></tr>
+            </tbody>
+        </table>
+    </section>
+</main>
+
+<div class="toast-stack" id="toast-stack" aria-live="polite"></div>
+
+<script th:src="@{/js/api.js}"></script>
+<script th:src="@{/js/toasts.js}"></script>
+<script th:src="@{/js/casino-sounds.js}"></script>
+<script th:src="@{/js/casino-jackpot.js}"></script>
+<script th:src="@{/js/casino-balance.js}"></script>
+<script th:src="@{/js/casino-render.js}"></script>
+<script th:src="@{/js/casinoholdem-solo.js}"></script>
+</body>
+</html>

--- a/web/src/main/resources/templates/fragments/navbar.html
+++ b/web/src/main/resources/templates/fragments/navbar.html
@@ -42,6 +42,7 @@
                 <a href="/poker/guilds" role="menuitem">&#127924; Poker</a>
                 <a href="/blackjack/guilds" role="menuitem">&#127922; Blackjack</a>
                 <a href="/casino/guilds" role="menuitem">&#127924; Baccarat</a>
+                <a href="/casinoholdem/guilds" role="menuitem">&#127183; Casino Hold'em</a>
             </div>
         </div>
         <a href="/intro/guilds">Intro Songs</a>

--- a/web/src/test/kotlin/web/controller/CasinoHoldemControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/CasinoHoldemControllerTest.kt
@@ -1,0 +1,238 @@
+package web.controller
+
+import database.card.Card
+import database.card.Rank
+import database.card.Suit
+import database.poker.CasinoHoldem
+import database.poker.CasinoHoldemTable
+import database.poker.CasinoHoldemTableRegistry
+import database.service.CasinoHoldemService
+import database.service.CasinoHoldemService.ActionOutcome
+import database.service.CasinoHoldemService.DealOutcome
+import database.service.JackpotService
+import database.service.UserService
+import io.mockk.every
+import io.mockk.mockk
+import net.dv8tion.jda.api.JDA
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.security.oauth2.core.user.OAuth2User
+import web.service.CasinoHoldemWebService
+import web.service.EconomyWebService
+import java.time.Instant
+
+class CasinoHoldemControllerTest {
+
+    private val guildId = 42L
+    private val discordId = 100L
+
+    private lateinit var service: CasinoHoldemService
+    private lateinit var webService: CasinoHoldemWebService
+    private lateinit var registry: CasinoHoldemTableRegistry
+    private lateinit var economyWebService: EconomyWebService
+    private lateinit var userService: UserService
+    private lateinit var jackpotService: JackpotService
+    private lateinit var jda: JDA
+    private lateinit var user: OAuth2User
+    private lateinit var controller: CasinoHoldemController
+
+    @BeforeEach
+    fun setup() {
+        service = mockk(relaxed = true)
+        webService = mockk(relaxed = true)
+        registry = mockk(relaxed = true)
+        economyWebService = mockk(relaxed = true)
+        userService = mockk(relaxed = true)
+        jackpotService = mockk(relaxed = true)
+        jda = mockk(relaxed = true)
+        user = mockk {
+            every { getAttribute<String>("id") } returns discordId.toString()
+            every { getAttribute<String>("username") } returns "tester"
+        }
+        every { economyWebService.isMember(discordId, guildId) } returns true
+        controller = CasinoHoldemController(
+            service = service,
+            webService = webService,
+            tableRegistry = registry,
+            economyWebService = economyWebService,
+            userService = userService,
+            jackpotService = jackpotService,
+            jda = jda,
+        )
+    }
+
+    // --- /deal ---
+
+    @Test
+    fun `deal happy path returns 200 with new tableId and balance`() {
+        val table = CasinoHoldemTable(
+            id = 7L, guildId = guildId, playerDiscordId = discordId, stake = 100L,
+        )
+        every {
+            service.dealSolo(discordId, guildId, 100L, false)
+        } returns DealOutcome.Dealt(
+            tableId = 7L,
+            snapshot = table,
+            newBalance = 900L,
+        )
+
+        val response = controller.deal(guildId, CasinoHoldemDealRequest(stake = 100L), user)
+
+        assertTrue(response.statusCode.is2xxSuccessful)
+        val body = response.body!!
+        assertEquals(true, body.ok)
+        assertEquals(7L, body.tableId)
+        assertEquals(900L, body.newBalance)
+        assertNull(body.error)
+    }
+
+    @Test
+    fun `deal InvalidStake maps to 400 with message`() {
+        every {
+            service.dealSolo(any(), any(), any(), any())
+        } returns DealOutcome.InvalidStake(
+            min = CasinoHoldem.MIN_STAKE, max = CasinoHoldem.MAX_STAKE
+        )
+
+        val response = controller.deal(guildId, CasinoHoldemDealRequest(stake = 1L), user)
+
+        assertEquals(400, response.statusCode.value())
+        assertEquals(false, response.body!!.ok)
+        assertNotNull(response.body!!.error)
+    }
+
+    @Test
+    fun `deal InsufficientCredits maps to 400`() {
+        every {
+            service.dealSolo(any(), any(), any(), any())
+        } returns DealOutcome.InsufficientCredits(stake = 100L, have = 20L)
+
+        val response = controller.deal(guildId, CasinoHoldemDealRequest(stake = 100L), user)
+
+        assertEquals(400, response.statusCode.value())
+        assertEquals(false, response.body!!.ok)
+    }
+
+    @Test
+    fun `deal returns 403 when caller is not a guild member`() {
+        every { economyWebService.isMember(discordId, guildId) } returns false
+
+        val response = controller.deal(guildId, CasinoHoldemDealRequest(stake = 100L), user)
+
+        assertEquals(403, response.statusCode.value())
+    }
+
+    // --- /action ---
+
+    @Test
+    fun `action 404 when no active table for this user`() {
+        every { webService.findActiveTable(guildId, discordId) } returns null
+
+        val response = controller.action(guildId, CasinoHoldemActionRequest(action = "fold"), user)
+
+        assertEquals(404, response.statusCode.value())
+        assertEquals(false, response.body!!.ok)
+    }
+
+    @Test
+    fun `action FOLD resolves and returns resolved=true`() {
+        every { webService.findActiveTable(guildId, discordId) } returns 7L
+        val result = CasinoHoldemTable.HandResult(
+            playerHole = listOf(Card(Rank.ACE, Suit.SPADES), Card(Rank.KING, Suit.SPADES)),
+            dealerHole = listOf(Card(Rank.TWO, Suit.HEARTS), Card(Rank.THREE, Suit.DIAMONDS)),
+            board = listOf(
+                Card(Rank.QUEEN, Suit.SPADES),
+                Card(Rank.JACK, Suit.SPADES),
+                Card(Rank.TEN, Suit.SPADES),
+            ),
+            resolution = null,
+            folded = true,
+            anteStake = 100L,
+            callStake = 0L,
+            antePayout = 0L,
+            callPayout = 0L,
+            totalPayout = 0L,
+            resolvedAt = Instant.now(),
+        )
+        every {
+            service.applyAction(discordId, guildId, 7L, CasinoHoldem.Action.FOLD)
+        } returns ActionOutcome.Resolved(
+            tableId = 7L,
+            result = result,
+            newBalance = 900L,
+            jackpotPayout = 0L,
+            lossTribute = 10L,
+        )
+
+        val response = controller.action(guildId, CasinoHoldemActionRequest(action = "fold"), user)
+
+        assertTrue(response.statusCode.is2xxSuccessful)
+        val body = response.body!!
+        assertEquals(true, body.ok)
+        assertEquals(true, body.resolved)
+        assertEquals(7L, body.tableId)
+        assertEquals(900L, body.newBalance)
+        assertEquals(10L, body.lossTribute)
+    }
+
+    @Test
+    fun `action CALL with insufficient credits returns 400`() {
+        every { webService.findActiveTable(guildId, discordId) } returns 7L
+        every {
+            service.applyAction(discordId, guildId, 7L, CasinoHoldem.Action.CALL)
+        } returns ActionOutcome.InsufficientCreditsForCall(needed = 200L, have = 20L)
+
+        val response = controller.action(guildId, CasinoHoldemActionRequest(action = "call"), user)
+
+        assertEquals(400, response.statusCode.value())
+        assertEquals(false, response.body!!.ok)
+    }
+
+    @Test
+    fun `action with unknown action string returns 400`() {
+        every { webService.findActiveTable(guildId, discordId) } returns 7L
+
+        val response = controller.action(guildId, CasinoHoldemActionRequest(action = "raise"), user)
+
+        assertEquals(400, response.statusCode.value())
+        assertEquals(false, response.body!!.ok)
+    }
+
+    // --- /state ---
+
+    @Test
+    fun `state 404 when no active table`() {
+        every { webService.findActiveTable(guildId, discordId) } returns null
+
+        val response = controller.state(guildId, user)
+
+        assertEquals(404, response.statusCode.value())
+    }
+
+    @Test
+    fun `state returns the snapshot when an active table exists`() {
+        every { webService.findActiveTable(guildId, discordId) } returns 7L
+        val view = CasinoHoldemWebService.TableStateView(
+            tableId = 7L,
+            guildId = guildId,
+            playerDiscordId = discordId.toString(),
+            phase = "AWAIT_DECISION",
+            stake = 100L,
+            callStake = 200L,
+            playerHole = listOf("A♠", "K♠"),
+            dealerHole = listOf("??", "??"),
+            board = listOf("Q♠", "J♠", "10♠"),
+            lastResult = null,
+        )
+        every { webService.snapshot(7L, discordId) } returns view
+
+        val response = controller.state(guildId, user)
+
+        assertTrue(response.statusCode.is2xxSuccessful)
+        assertEquals(view, response.body)
+    }
+}

--- a/web/src/test/kotlin/web/service/CasinoHoldemWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/CasinoHoldemWebServiceTest.kt
@@ -1,0 +1,165 @@
+package web.service
+
+import database.card.Card
+import database.card.Rank
+import database.card.Suit
+import database.poker.CasinoHoldem
+import database.poker.CasinoHoldemTable
+import database.poker.CasinoHoldemTableRegistry
+import database.poker.HandEvaluator
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.time.Instant
+import java.util.concurrent.Executors
+
+class CasinoHoldemWebServiceTest {
+
+    private lateinit var registry: CasinoHoldemTableRegistry
+    private lateinit var service: CasinoHoldemWebService
+
+    private val discordId = 100L
+    private val guildId = 200L
+
+    @BeforeEach
+    fun setup() {
+        registry = CasinoHoldemTableRegistry(
+            idleTtl = Duration.ofMinutes(10),
+            sweepInterval = Duration.ofHours(1),
+            scheduler = Executors.newScheduledThreadPool(1),
+        )
+        service = CasinoHoldemWebService(registry)
+    }
+
+    private fun seedTable(): CasinoHoldemTable {
+        val t = registry.create(guildId, discordId, stake = 100L)
+        t.playerHole.add(Card(Rank.ACE, Suit.SPADES))
+        t.playerHole.add(Card(Rank.KING, Suit.SPADES))
+        t.dealerHole.add(Card(Rank.TWO, Suit.HEARTS))
+        t.dealerHole.add(Card(Rank.THREE, Suit.DIAMONDS))
+        t.board.add(Card(Rank.QUEEN, Suit.SPADES))
+        t.board.add(Card(Rank.JACK, Suit.SPADES))
+        t.board.add(Card(Rank.TEN, Suit.SPADES))
+        t.pendingTurn = Card(Rank.NINE, Suit.CLUBS)
+        t.pendingRiver = Card(Rank.EIGHT, Suit.DIAMONDS)
+        return t
+    }
+
+    @Test
+    fun `snapshot masks dealer hole during AWAIT_DECISION`() {
+        seedTable()
+        val view = service.snapshot(tableId = 1L, viewerDiscordId = discordId)
+
+        assertNotNull(view)
+        view!!
+        assertEquals("AWAIT_DECISION", view.phase)
+        // Player + board fully visible.
+        assertEquals(listOf("A♠", "K♠"), view.playerHole)
+        assertEquals(listOf("Q♠", "J♠", "10♠"), view.board)
+        // Dealer hole masked: same length, all '??'.
+        assertEquals(2, view.dealerHole.size)
+        assertTrue(view.dealerHole.all { it == "??" })
+        assertEquals(100L, view.stake)
+        assertEquals(200L, view.callStake)
+    }
+
+    @Test
+    fun `snapshot reveals dealer hole on RESOLVED showdown (non-fold)`() {
+        val t = seedTable()
+        t.phase = CasinoHoldemTable.Phase.RESOLVED
+        val rank = HandEvaluator.HandRank(HandEvaluator.Category.PAIR, listOf(5, 14, 12, 11))
+        t.lastResult = CasinoHoldemTable.HandResult(
+            playerHole = t.playerHole.toList(),
+            dealerHole = t.dealerHole.toList(),
+            board = t.board.toList(),
+            resolution = CasinoHoldem.Resolution(
+                playerRank = rank,
+                dealerRank = rank,
+                dealerQualified = true,
+                anteResult = CasinoHoldem.AnteResult.WIN,
+                callResult = CasinoHoldem.CallResult.WIN_OTHER,
+            ),
+            folded = false,
+            anteStake = 100L,
+            callStake = 200L,
+            antePayout = 200L,
+            callPayout = 400L,
+            totalPayout = 600L,
+            resolvedAt = Instant.now(),
+        )
+
+        val view = service.snapshot(tableId = 1L, viewerDiscordId = discordId)
+
+        assertNotNull(view)
+        view!!
+        assertEquals("RESOLVED", view.phase)
+        // Both dealer cards revealed.
+        assertEquals(listOf("2♥", "3♦"), view.dealerHole)
+        // lastResult is populated.
+        val r = view.lastResult
+        assertNotNull(r)
+        r!!
+        assertFalse(r.folded)
+        assertEquals(true, r.dealerQualified)
+        assertEquals("WIN", r.anteResult)
+        assertEquals("WIN_OTHER", r.callResult)
+        assertEquals(600L, r.totalPayout)
+    }
+
+    @Test
+    fun `snapshot keeps dealer hole hidden on RESOLVED fold`() {
+        val t = seedTable()
+        t.phase = CasinoHoldemTable.Phase.RESOLVED
+        t.lastResult = CasinoHoldemTable.HandResult(
+            playerHole = t.playerHole.toList(),
+            dealerHole = t.dealerHole.toList(),
+            board = t.board.toList(),
+            resolution = null,
+            folded = true,
+            anteStake = 100L,
+            callStake = 0L,
+            antePayout = 0L,
+            callPayout = 0L,
+            totalPayout = 0L,
+            resolvedAt = Instant.now(),
+        )
+
+        val view = service.snapshot(tableId = 1L, viewerDiscordId = discordId)
+
+        assertNotNull(view)
+        view!!
+        assertEquals("RESOLVED", view.phase)
+        assertTrue(view.dealerHole.all { it == "??" })
+        assertTrue(view.lastResult!!.folded)
+        assertTrue(view.lastResult!!.dealerHole.all { it == "??" })
+        assertNull(view.lastResult!!.anteResult)
+    }
+
+    @Test
+    fun `snapshot returns null when viewer is not the table owner`() {
+        seedTable()
+        val view = service.snapshot(tableId = 1L, viewerDiscordId = 999L)
+        assertNull(view)
+    }
+
+    @Test
+    fun `findActiveTable prefers AWAIT_DECISION over a stale RESOLVED leftover`() {
+        // First create a RESOLVED leftover, then a fresh AWAIT_DECISION.
+        val stale = registry.create(guildId, discordId, stake = 100L)
+        stale.phase = CasinoHoldemTable.Phase.RESOLVED
+        registry.create(guildId, discordId, stake = 200L)
+
+        val active = service.findActiveTable(guildId, discordId)
+        assertEquals(2L, active)
+    }
+
+    @Test
+    fun `findActiveTable returns null when player has no tables in this guild`() {
+        assertNull(service.findActiveTable(guildId, discordId))
+    }
+}


### PR DESCRIPTION
## Summary

Adds **Casino Hold'em** as a singleplayer casino game alongside `/blackjack solo`. Heads-up Texas Hold'em vs the dealer with one mid-hand decision (CALL vs FOLD), the standard CHE paytable, and dealer qualification at pair-of-fours.

- New `/casinoholdem stake:<n>` slash command + button-driven CALL / FOLD
- New `/casinoholdem/{guildId}` web page with masked dealer hole, JSON polling, and the standard casino chrome (jackpot banner, balance widget, sounds)
- Pure rules engine reuses the existing `HandEvaluator` (battle-tested in multiplayer poker); wagers go through the standard `WagerHelper` + `JackpotHelper` plumbing per leg

## Game shape

1. Player antes `stake`. 2 hole cards each + 3-card flop dealt face-up.
2. Player decides: **CALL** (commits another `2 × stake`) or **FOLD** (forfeit ante).
3. Dealer must qualify (pair of fours or better) for the call leg to be in play.
4. Ante pays even-money on a win; call pays the standard CHE paytable:

| Hand | Call payout |
|---|---|
| Royal Flush | 100:1 |
| Straight Flush | 20:1 |
| Four of a Kind | 10:1 |
| Full House | 3:1 |
| Flush | 2:1 |
| Straight | 1:1 |
| Trips / Two Pair / Pair / High Card win | 1:1 |

## Files

**database** (pure logic + state + service)
- `database/poker/CasinoHoldem.kt` — rules, paytable, qualification
- `database/poker/CasinoHoldemTable.kt` — single-seat state container
- `database/poker/CasinoHoldemTableRegistry.kt` — in-memory table book + idle sweeper
- `database/service/CasinoHoldemService.kt` — `dealSolo`, `applyAction`, jackpot wiring, idle-evict refunds

**discord-bot**
- `bot/toby/command/commands/economy/CasinoHoldemCommand.kt`
- `bot/toby/command/commands/economy/CasinoHoldemEmbeds.kt`
- `bot/toby/button/buttons/CasinoHoldemButton.kt`

**web**
- `web/controller/CasinoHoldemController.kt` — `/state`, `/deal`, `/action`, page + guild selector
- `web/service/CasinoHoldemWebService.kt` — read-only projection with **server-side dealer-hole masking** during AWAIT_DECISION and on folds
- `templates/casinoholdem-guilds.html`, `templates/casinoholdem-solo.html`
- `static/css/casinoholdem.css`, `static/js/casinoholdem-solo.js`
- Casino landing tile + navbar entry

## Test plan

- [x] `./gradlew :database:test` passes (8 new `CasinoHoldemTest` cases + 12 new `CasinoHoldemServiceTest` cases)
- [x] `./gradlew :web:test` passes (5 new `CasinoHoldemWebServiceTest` cases incl. masking + 8 new `CasinoHoldemControllerTest` cases)
- [ ] `./gradlew :discord-bot:test` — could not build locally because `moe.kyokobot.libdave:impl-jni:0.1.0` returns 403 from every configured Maven repo in the sandbox. Code follows the existing BlackjackCommand / BlackjackButton patterns one-to-one; CI should pick this up cleanly.
- [ ] Manual smoke test in a dev guild covering the four resolution branches:
  - Fold → ante forfeited
  - Call, dealer doesn't qualify → ante even-money, call pushes
  - Call, dealer qualifies, player wins → per-paytable payout
  - Call, dealer qualifies, dealer wins → both legs lost
- [ ] Browser smoke test: `/casino/{guildId}` → Casino Hold'em tile → deal, fold, then deal & call. Verify `/state` JSON masks the dealer hole during AWAIT_DECISION.

https://claude.ai/code/session_01UubDYpP945DnpNfhRwkaRa

---
_Generated by [Claude Code](https://claude.ai/code/session_01UubDYpP945DnpNfhRwkaRa)_