### PR TITLE
feat(casino): defeat min-wager autoclicker exploits on the jackpot

### DIFF
--- a/application/src/test/kotlin/integration/bot/CommandManagerTest.kt
+++ b/application/src/test/kotlin/integration/bot/CommandManagerTest.kt
@@ -132,6 +132,7 @@ class CommandManagerTest {
             DbdRandomKillerCommand::class.java,
             ExcuseCommand::class.java,
             SocialCreditCommand::class.java,
+            JackpotAdminCommand::class.java,
             TeamCommand::class.java,
             EightBallCommand::class.java,
             LinkCharacterCommand::class.java,
@@ -156,8 +157,8 @@ class CommandManagerTest {
         )
 
         Assertions.assertTrue(availableCommands.containsAll(commandManager.allCommands.map { it.javaClass }.toList()))
-        Assertions.assertEquals(58, commandManager.allCommands.size)
-        Assertions.assertEquals(58, commandManager.allSlashCommands.size)
+        Assertions.assertEquals(59, commandManager.allCommands.size)
+        Assertions.assertEquals(59, commandManager.allSlashCommands.size)
     }
 
     @Test

--- a/common/src/main/kotlin/common/casino/CasinoCommonFailure.kt
+++ b/common/src/main/kotlin/common/casino/CasinoCommonFailure.kt
@@ -35,4 +35,13 @@ sealed interface CasinoCommonFailure {
     }
 
     interface UnknownUser : CasinoCommonFailure
+
+    /**
+     * The player tried to play this minigame again before their per-user
+     * cooldown elapsed. [remainingMs] is the time left on the timer at the
+     * moment of rejection so callers can surface a "wait Xs" countdown.
+     */
+    interface OnCooldown : CasinoCommonFailure {
+        val remainingMs: Long
+    }
 }

--- a/database/src/main/kotlin/database/dto/ConfigDto.kt
+++ b/database/src/main/kotlin/database/dto/ConfigDto.kt
@@ -113,7 +113,13 @@ class ConfigDto(
         // Per-guild override of the social-credit daily cap that applies to
         // voice, command, intro, and UI-trade earnings. Falls back to 90
         // (SocialCreditAwardService.DEFAULT_DAILY_CAP) when unset or invalid.
-        DAILY_CREDIT_CAP("DAILY_CREDIT_CAP");
+        DAILY_CREDIT_CAP("DAILY_CREDIT_CAP"),
+
+        // Per-user, per-game cooldown (seconds) on single-shot casino
+        // minigames (coinflip, slots, dice, highlow, scratch, baccarat,
+        // keno, solo blackjack, duel). Defends against autoclicker spam.
+        // Clamped 0-30 by CasinoCooldownService; 0 disables.
+        CASINO_COOLDOWN_SECONDS("CASINO_COOLDOWN_SECONDS");
     }
 
     override fun toString(): String {

--- a/database/src/main/kotlin/database/service/BaccaratService.kt
+++ b/database/src/main/kotlin/database/service/BaccaratService.kt
@@ -30,6 +30,7 @@ class BaccaratService(
     private val tradeService: EconomyTradeService,
     private val marketService: TobyCoinMarketService,
     private val configService: ConfigService,
+    private val cooldownService: CasinoCooldownService,
     private val baccarat: Baccarat = Baccarat(),
     private val random: Random = Random.Default
 ) {
@@ -91,6 +92,8 @@ class BaccaratService(
         data class InvalidStake(override val min: Long, override val max: Long) :
             PlayOutcome, CasinoCommonFailure.InvalidStake
         data object UnknownUser : PlayOutcome, CasinoCommonFailure.UnknownUser
+        data class OnCooldown(override val remainingMs: Long) :
+            PlayOutcome, CasinoCommonFailure.OnCooldown
     }
 
     /**
@@ -108,7 +111,8 @@ class BaccaratService(
     ): PlayOutcome {
         val resolved = when (val r = WagerHelper.checkLockOrTopUp(
             userService, tradeService, marketService,
-            discordId, guildId, stake, Baccarat.MIN_STAKE, Baccarat.MAX_STAKE, autoTopUp
+            discordId, guildId, stake, Baccarat.MIN_STAKE, Baccarat.MAX_STAKE, autoTopUp,
+            cooldownService = cooldownService, game = CasinoGameKey.BACCARAT,
         )) {
             is TopUpResolution.InvalidStake -> return PlayOutcome.InvalidStake(r.min, r.max)
             TopUpResolution.UnknownUser -> return PlayOutcome.UnknownUser
@@ -116,15 +120,18 @@ class BaccaratService(
                 return PlayOutcome.InsufficientCredits(r.stake, r.have)
             is TopUpResolution.InsufficientCoinsForTopUp ->
                 return PlayOutcome.InsufficientCoinsForTopUp(r.needed, r.have)
+            is TopUpResolution.OnCooldown -> return PlayOutcome.OnCooldown(r.remainingMs)
             is TopUpResolution.Ok -> r
         }
 
         val hand = baccarat.play(side, Deck(random))
         val wager = WagerHelper.applyMultiplier(userService, resolved.user, resolved.balance, stake, hand.multiplier)
+        cooldownService.arm(discordId, CasinoGameKey.BACCARAT)
         return when {
             hand.isWin -> {
                 val jackpot = JackpotHelper.rollOnWin(
-                    jackpotService, configService, userService, resolved.user, guildId, random
+                    jackpotService, configService, userService, resolved.user, guildId,
+                    stake, Baccarat.MAX_STAKE, random,
                 )
                 PlayOutcome.Win(
                     stake = stake,

--- a/database/src/main/kotlin/database/service/BlackjackService.kt
+++ b/database/src/main/kotlin/database/service/BlackjackService.kt
@@ -59,6 +59,12 @@ class BlackjackService @Autowired constructor(
      * pays out correctly, the audit row just doesn't appear.
      */
     @Autowired(required = false) private val handLogPersistence: BlackjackHandLogPersistence? = null,
+    /**
+     * Optional cooldown gate. Null in test paths (no Spring context); when wired,
+     * `dealSolo` is rate-limited per user via [CasinoGameKey.BLACKJACK_SOLO]. The
+     * multi-player path is not gated — it self-throttles via the per-actor shot clock.
+     */
+    @Autowired(required = false) private val cooldownService: CasinoCooldownService? = null,
     private val random: Random = Random.Default
 ) {
 
@@ -92,6 +98,7 @@ class BlackjackService @Autowired constructor(
          */
         data class HandInProgress(val tableId: Long) : SoloDealOutcome
         data object UnknownUser : SoloDealOutcome
+        data class OnCooldown(val remainingMs: Long) : SoloDealOutcome
     }
 
     sealed interface SoloActionOutcome {
@@ -222,6 +229,11 @@ class BlackjackService @Autowired constructor(
         stake: Long,
         autoTopUp: Boolean = false
     ): SoloDealOutcome {
+        cooldownService?.tryAcquire(discordId, guildId, CasinoGameKey.BLACKJACK_SOLO)?.let { gate ->
+            if (gate is CasinoCooldownService.AcquireResult.OnCooldown) {
+                return SoloDealOutcome.OnCooldown(gate.remainingMs)
+            }
+        }
         // Reject a redeal while the caller still has an in-flight solo
         // table on this guild — without this guard, hitting the web Deal
         // form mid-hand would debit the stake again, orphan the previous
@@ -260,6 +272,7 @@ class BlackjackService @Autowired constructor(
         // Debit stake into seat escrow.
         resolved.user.socialCredit = resolved.balance - stake
         userService.updateUser(resolved.user)
+        cooldownService?.arm(discordId, CasinoGameKey.BLACKJACK_SOLO)
 
         // Sweep any resolved solo table left behind by this user's previous
         // hand — the action handler now leaves them in registry so the JS
@@ -663,7 +676,8 @@ class BlackjackService @Autowired constructor(
                 when (hand.result) {
                     Blackjack.Result.PLAYER_WIN, Blackjack.Result.PLAYER_BLACKJACK -> {
                         val rolled = JackpotHelper.rollOnWin(
-                            jackpotService, configService, userService, user, guildId, random
+                            jackpotService, configService, userService, user, guildId,
+                            hand.stake, Blackjack.MAX_STAKE, random,
                         )
                         if (rolled > 0L) {
                             jackpotPayout += rolled

--- a/database/src/main/kotlin/database/service/CasinoAdminService.kt
+++ b/database/src/main/kotlin/database/service/CasinoAdminService.kt
@@ -1,0 +1,61 @@
+package database.service
+
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * Casino remediation operations that don't have a natural home in the
+ * minigame services. Wraps `JackpotService` and `UserService` so the
+ * Discord moderation command and the web admin tab both go through one
+ * transactional path.
+ *
+ * Permission checks are the caller's responsibility — this service does
+ * the mutation only. The Discord command verifies guild owner or
+ * superuser before invoking; the web layer verifies via the moderation
+ * `canModerate` predicate.
+ */
+@Service
+@Transactional
+class CasinoAdminService(
+    private val userService: UserService,
+    private val jackpotService: JackpotService,
+) {
+
+    sealed interface RefundOutcome {
+        data class Ok(val drained: Long, val newPool: Long, val newSourceBalance: Long) : RefundOutcome
+        data object UnknownUser : RefundOutcome
+        data class Insufficient(val have: Long, val needed: Long) : RefundOutcome
+        data class InvalidAmount(val amount: Long) : RefundOutcome
+    }
+
+    /**
+     * Zero the per-guild jackpot pool. Returns the amount drained.
+     */
+    fun resetJackpot(guildId: Long): Long = jackpotService.resetPool(guildId)
+
+    /**
+     * Debit [amount] from [sourceDiscordId] and deposit the same amount
+     * into the per-guild jackpot pool. Used when a player has been
+     * clawed-back from a confirmed exploit and the credits should be
+     * returned to the pool that funded them.
+     */
+    fun refundToJackpot(
+        sourceDiscordId: Long,
+        guildId: Long,
+        amount: Long,
+    ): RefundOutcome {
+        if (amount <= 0L) return RefundOutcome.InvalidAmount(amount)
+        val user = userService.getUserByIdForUpdate(sourceDiscordId, guildId)
+            ?: return RefundOutcome.UnknownUser
+        val balance = user.socialCredit ?: 0L
+        if (balance < amount) return RefundOutcome.Insufficient(balance, amount)
+        user.socialCredit = balance - amount
+        userService.updateUser(user)
+        val newPool = jackpotService.addToPool(guildId, amount)
+        return RefundOutcome.Ok(
+            drained = amount,
+            newPool = newPool,
+            newSourceBalance = user.socialCredit ?: (balance - amount),
+        )
+    }
+}

--- a/database/src/main/kotlin/database/service/CasinoCooldownService.kt
+++ b/database/src/main/kotlin/database/service/CasinoCooldownService.kt
@@ -1,0 +1,100 @@
+package database.service
+
+import database.dto.ConfigDto
+import org.springframework.stereotype.Component
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Identifier for the spam-able single-shot casino games subject to the
+ * per-user cooldown. Multi-player table games (poker, multi-table
+ * blackjack) are turn-driven and excluded — they self-throttle through
+ * the per-actor shot clock instead.
+ */
+enum class CasinoGameKey {
+    COINFLIP, SLOTS, DICE, HIGHLOW, SCRATCH, BACCARAT, KENO, BLACKJACK_SOLO, CASINOHOLDEM, DUEL,
+}
+
+/**
+ * Per-user, per-game cooldown to defeat autoclicker spam. The user-row
+ * pessimistic lock taken by `WagerHelper.checkAndLock` only stops
+ * *concurrent* duplicate plays inside one transaction; it does nothing
+ * to throttle a script that fires sequential commands as fast as the
+ * service responds. This service plugs that gap.
+ *
+ * State is process-local, keyed `(discordId, gameKey)`. The bot is a
+ * single instance today; if/when it scales to multiple instances this
+ * needs to migrate to a shared store (Redis or a `casino_cooldown` row).
+ *
+ * The cooldown duration is admin-configurable per guild via the
+ * [ConfigDto.Configurations.CASINO_COOLDOWN_SECONDS] config key, clamped
+ * to [MIN_COOLDOWN_SECONDS]..[MAX_COOLDOWN_SECONDS]. Set to 0 to disable.
+ */
+@Component
+class CasinoCooldownService(
+    private val configService: ConfigService,
+    private val clock: () -> Long = System::currentTimeMillis,
+) {
+
+    private data class Key(val discordId: Long, val game: CasinoGameKey)
+
+    private val lastInvokes: ConcurrentHashMap<Key, Long> = ConcurrentHashMap()
+
+    sealed interface AcquireResult {
+        data object Ok : AcquireResult
+        data class OnCooldown(val remainingMs: Long) : AcquireResult
+    }
+
+    /**
+     * Check whether [discordId] may start a new wager on [game] right
+     * now. Returns [AcquireResult.OnCooldown] with the remaining time if
+     * blocked, otherwise [AcquireResult.Ok]. The caller MUST follow up
+     * with [arm] only after the wager has been successfully debited —
+     * an aborted wager (insufficient funds, invalid stake) shouldn't
+     * consume the cooldown.
+     */
+    fun tryAcquire(discordId: Long, guildId: Long, game: CasinoGameKey): AcquireResult {
+        val cooldownSeconds = cooldownSeconds(guildId)
+        if (cooldownSeconds <= 0L) return AcquireResult.Ok
+        val cooldownMs = cooldownSeconds * 1_000L
+        val now = clock()
+        val key = Key(discordId, game)
+        val last = lastInvokes[key] ?: return AcquireResult.Ok
+        val elapsed = now - last
+        if (elapsed >= cooldownMs) return AcquireResult.Ok
+        return AcquireResult.OnCooldown(remainingMs = cooldownMs - elapsed)
+    }
+
+    /**
+     * Arm the cooldown timer for [discordId] / [game]. Call this only
+     * after a successful wager debit — failed pre-checks must not
+     * trigger the timer or a typo will lock a player out.
+     */
+    fun arm(discordId: Long, game: CasinoGameKey) {
+        lastInvokes[Key(discordId, game)] = clock()
+    }
+
+    /** Test/admin hook: forget every recorded cooldown. */
+    fun reset() {
+        lastInvokes.clear()
+    }
+
+    /** Test/admin hook: forget the cooldown for a single user. */
+    fun reset(discordId: Long) {
+        lastInvokes.keys.removeIf { it.discordId == discordId }
+    }
+
+    private fun cooldownSeconds(guildId: Long): Long {
+        val cfg = configService.getConfigByName(
+            ConfigDto.Configurations.CASINO_COOLDOWN_SECONDS.configValue,
+            guildId.toString(),
+        )
+        val raw = cfg?.value?.toLongOrNull() ?: return DEFAULT_COOLDOWN_SECONDS
+        return raw.coerceIn(MIN_COOLDOWN_SECONDS, MAX_COOLDOWN_SECONDS)
+    }
+
+    companion object {
+        const val DEFAULT_COOLDOWN_SECONDS: Long = 3L
+        const val MIN_COOLDOWN_SECONDS: Long = 0L
+        const val MAX_COOLDOWN_SECONDS: Long = 30L
+    }
+}

--- a/database/src/main/kotlin/database/service/CasinoHoldemService.kt
+++ b/database/src/main/kotlin/database/service/CasinoHoldemService.kt
@@ -48,6 +48,7 @@ class CasinoHoldemService @Autowired constructor(
      */
     @Autowired(required = false) private val tradeService: EconomyTradeService? = null,
     @Autowired(required = false) private val marketService: TobyCoinMarketService? = null,
+    @Autowired(required = false) private val cooldownService: CasinoCooldownService? = null,
     private val random: Random = Random.Default,
 ) {
 
@@ -66,6 +67,8 @@ class CasinoHoldemService @Autowired constructor(
         data class InsufficientCoinsForTopUp(override val needed: Long, override val have: Long) :
             DealOutcome, CasinoCommonFailure.InsufficientCoinsForTopUp
         data object UnknownUser : DealOutcome, CasinoCommonFailure.UnknownUser
+        data class OnCooldown(override val remainingMs: Long) :
+            DealOutcome, CasinoCommonFailure.OnCooldown
     }
 
     sealed interface ActionOutcome {
@@ -105,6 +108,11 @@ class CasinoHoldemService @Autowired constructor(
         stake: Long,
         autoTopUp: Boolean = false,
     ): DealOutcome {
+        cooldownService?.tryAcquire(discordId, guildId, CasinoGameKey.CASINOHOLDEM)?.let { gate ->
+            if (gate is CasinoCooldownService.AcquireResult.OnCooldown) {
+                return DealOutcome.OnCooldown(gate.remainingMs)
+            }
+        }
         val resolved = when (val r = checkLockOrTopUp(discordId, guildId, stake, autoTopUp)) {
             is TopUpResolution.InvalidStake -> return DealOutcome.InvalidStake(r.min, r.max)
             TopUpResolution.UnknownUser -> return DealOutcome.UnknownUser
@@ -118,6 +126,7 @@ class CasinoHoldemService @Autowired constructor(
         // Debit the ante into table escrow up-front.
         resolved.user.socialCredit = resolved.balance - stake
         userService.updateUser(resolved.user)
+        cooldownService?.arm(discordId, CasinoGameKey.CASINOHOLDEM)
 
         // Sweep any RESOLVED tables this user left behind from a previous hand.
         sweepResolvedTablesFor(guildId, discordId)
@@ -264,7 +273,8 @@ class CasinoHoldemService @Autowired constructor(
         when (resolution.anteResult) {
             CasinoHoldem.AnteResult.WIN ->
                 jackpotPayout += JackpotHelper.rollOnWin(
-                    jackpotService, configService, userService, user, guildId, random
+                    jackpotService, configService, userService, user, guildId,
+                    table.stake, CasinoHoldem.MAX_STAKE, random,
                 )
             CasinoHoldem.AnteResult.LOSE ->
                 lossTribute += JackpotHelper.divertOnLoss(
@@ -282,7 +292,8 @@ class CasinoHoldemService @Autowired constructor(
             CasinoHoldem.CallResult.WIN_STRAIGHT,
             CasinoHoldem.CallResult.WIN_OTHER ->
                 jackpotPayout += JackpotHelper.rollOnWin(
-                    jackpotService, configService, userService, user, guildId, random
+                    jackpotService, configService, userService, user, guildId,
+                    callStake, CasinoHoldem.MAX_STAKE * 2L, random,
                 )
             CasinoHoldem.CallResult.LOSE ->
                 lossTribute += JackpotHelper.divertOnLoss(

--- a/database/src/main/kotlin/database/service/CoinflipService.kt
+++ b/database/src/main/kotlin/database/service/CoinflipService.kt
@@ -25,6 +25,7 @@ class CoinflipService(
     private val tradeService: EconomyTradeService,
     private val marketService: TobyCoinMarketService,
     private val configService: ConfigService,
+    private val cooldownService: CasinoCooldownService,
     private val coinflip: Coinflip = Coinflip(),
     private val random: Random = Random.Default
 ) {
@@ -59,6 +60,8 @@ class CoinflipService(
         data class InvalidStake(override val min: Long, override val max: Long) :
             FlipOutcome, CasinoCommonFailure.InvalidStake
         data object UnknownUser : FlipOutcome, CasinoCommonFailure.UnknownUser
+        data class OnCooldown(override val remainingMs: Long) :
+            FlipOutcome, CasinoCommonFailure.OnCooldown
     }
 
     fun flip(
@@ -70,7 +73,8 @@ class CoinflipService(
     ): FlipOutcome {
         val resolved = when (val r = WagerHelper.checkLockOrTopUp(
             userService, tradeService, marketService,
-            discordId, guildId, stake, Coinflip.MIN_STAKE, Coinflip.MAX_STAKE, autoTopUp
+            discordId, guildId, stake, Coinflip.MIN_STAKE, Coinflip.MAX_STAKE, autoTopUp,
+            cooldownService = cooldownService, game = CasinoGameKey.COINFLIP,
         )) {
             is TopUpResolution.InvalidStake -> return FlipOutcome.InvalidStake(r.min, r.max)
             TopUpResolution.UnknownUser -> return FlipOutcome.UnknownUser
@@ -78,13 +82,18 @@ class CoinflipService(
                 return FlipOutcome.InsufficientCredits(r.stake, r.have)
             is TopUpResolution.InsufficientCoinsForTopUp ->
                 return FlipOutcome.InsufficientCoinsForTopUp(r.needed, r.have)
+            is TopUpResolution.OnCooldown -> return FlipOutcome.OnCooldown(r.remainingMs)
             is TopUpResolution.Ok -> r
         }
 
         val flip = coinflip.flip(predicted, random)
         val wager = WagerHelper.applyMultiplier(userService, resolved.user, resolved.balance, stake, flip.multiplier)
+        cooldownService.arm(discordId, CasinoGameKey.COINFLIP)
         return if (flip.isWin) {
-            val jackpot = JackpotHelper.rollOnWin(jackpotService, configService, userService, resolved.user, guildId, random)
+            val jackpot = JackpotHelper.rollOnWin(
+                jackpotService, configService, userService, resolved.user, guildId,
+                stake, Coinflip.MAX_STAKE, random,
+            )
             FlipOutcome.Win(
                 stake = stake,
                 payout = wager.payout,

--- a/database/src/main/kotlin/database/service/DiceService.kt
+++ b/database/src/main/kotlin/database/service/DiceService.kt
@@ -24,6 +24,7 @@ class DiceService(
     private val tradeService: EconomyTradeService,
     private val marketService: TobyCoinMarketService,
     private val configService: ConfigService,
+    private val cooldownService: CasinoCooldownService,
     private val dice: Dice = Dice(),
     private val random: Random = Random.Default
 ) {
@@ -59,6 +60,8 @@ class DiceService(
             RollOutcome, CasinoCommonFailure.InvalidStake
         data class InvalidPrediction(val min: Int, val max: Int) : RollOutcome
         data object UnknownUser : RollOutcome, CasinoCommonFailure.UnknownUser
+        data class OnCooldown(override val remainingMs: Long) :
+            RollOutcome, CasinoCommonFailure.OnCooldown
     }
 
     fun roll(
@@ -73,7 +76,8 @@ class DiceService(
         }
         val resolved = when (val r = WagerHelper.checkLockOrTopUp(
             userService, tradeService, marketService,
-            discordId, guildId, stake, Dice.MIN_STAKE, Dice.MAX_STAKE, autoTopUp
+            discordId, guildId, stake, Dice.MIN_STAKE, Dice.MAX_STAKE, autoTopUp,
+            cooldownService = cooldownService, game = CasinoGameKey.DICE,
         )) {
             is TopUpResolution.InvalidStake -> return RollOutcome.InvalidStake(r.min, r.max)
             TopUpResolution.UnknownUser -> return RollOutcome.UnknownUser
@@ -81,13 +85,18 @@ class DiceService(
                 return RollOutcome.InsufficientCredits(r.stake, r.have)
             is TopUpResolution.InsufficientCoinsForTopUp ->
                 return RollOutcome.InsufficientCoinsForTopUp(r.needed, r.have)
+            is TopUpResolution.OnCooldown -> return RollOutcome.OnCooldown(r.remainingMs)
             is TopUpResolution.Ok -> r
         }
 
         val roll = dice.roll(predicted, random)
         val wager = WagerHelper.applyMultiplier(userService, resolved.user, resolved.balance, stake, roll.multiplier)
+        cooldownService.arm(discordId, CasinoGameKey.DICE)
         return if (roll.isWin) {
-            val jackpot = JackpotHelper.rollOnWin(jackpotService, configService, userService, resolved.user, guildId, random)
+            val jackpot = JackpotHelper.rollOnWin(
+                jackpotService, configService, userService, resolved.user, guildId,
+                stake, Dice.MAX_STAKE, random,
+            )
             RollOutcome.Win(
                 stake = stake,
                 payout = wager.payout,

--- a/database/src/main/kotlin/database/service/DuelService.kt
+++ b/database/src/main/kotlin/database/service/DuelService.kt
@@ -40,6 +40,7 @@ class DuelService @Autowired constructor(
     private val jackpotService: JackpotService,
     private val configService: ConfigService,
     private val duelLogPersistence: DuelLogPersistence,
+    @Autowired(required = false) private val cooldownService: CasinoCooldownService? = null,
     private val random: Random = Random.Default,
 ) {
     sealed interface StartOutcome {
@@ -52,6 +53,7 @@ class DuelService @Autowired constructor(
         data class OpponentInsufficient(val have: Long, val needed: Long) : StartOutcome
         data object UnknownInitiator : StartOutcome
         data object UnknownOpponent : StartOutcome
+        data class OnCooldown(val remainingMs: Long) : StartOutcome
     }
 
     sealed interface AcceptOutcome {
@@ -83,6 +85,11 @@ class DuelService @Autowired constructor(
         if (initiatorDiscordId == opponentDiscordId) {
             return StartOutcome.InvalidOpponent(StartOutcome.InvalidOpponent.Reason.SELF)
         }
+        cooldownService?.tryAcquire(initiatorDiscordId, guildId, CasinoGameKey.DUEL)?.let { gate ->
+            if (gate is CasinoCooldownService.AcquireResult.OnCooldown) {
+                return StartOutcome.OnCooldown(gate.remainingMs)
+            }
+        }
 
         val initiator = userService.getUserById(initiatorDiscordId, guildId)
             ?: return StartOutcome.UnknownInitiator
@@ -98,6 +105,7 @@ class DuelService @Autowired constructor(
             return StartOutcome.OpponentInsufficient(opponentBalance, stake)
         }
 
+        cooldownService?.arm(initiatorDiscordId, CasinoGameKey.DUEL)
         return StartOutcome.Ok(initiatorBalance)
     }
 

--- a/database/src/main/kotlin/database/service/HighlowService.kt
+++ b/database/src/main/kotlin/database/service/HighlowService.kt
@@ -30,6 +30,7 @@ class HighlowService(
     private val tradeService: EconomyTradeService,
     private val marketService: TobyCoinMarketService,
     private val configService: ConfigService,
+    private val cooldownService: CasinoCooldownService,
     private val highlow: Highlow = Highlow(),
     private val random: Random = Random.Default
 ) {
@@ -67,6 +68,8 @@ class HighlowService(
         data class InvalidStake(override val min: Long, override val max: Long) :
             PlayOutcome, CasinoCommonFailure.InvalidStake
         data object UnknownUser : PlayOutcome, CasinoCommonFailure.UnknownUser
+        data class OnCooldown(override val remainingMs: Long) :
+            PlayOutcome, CasinoCommonFailure.OnCooldown
     }
 
     /** Draw a fresh anchor without committing any state. The web flow uses this on page load. */
@@ -107,7 +110,8 @@ class HighlowService(
     ): PlayOutcome {
         val resolved = when (val r = WagerHelper.checkLockOrTopUp(
             userService, tradeService, marketService,
-            discordId, guildId, stake, Highlow.MIN_STAKE, Highlow.MAX_STAKE, autoTopUp
+            discordId, guildId, stake, Highlow.MIN_STAKE, Highlow.MAX_STAKE, autoTopUp,
+            cooldownService = cooldownService, game = CasinoGameKey.HIGHLOW,
         )) {
             is TopUpResolution.InvalidStake -> return PlayOutcome.InvalidStake(r.min, r.max)
             TopUpResolution.UnknownUser -> return PlayOutcome.UnknownUser
@@ -115,6 +119,7 @@ class HighlowService(
                 return PlayOutcome.InsufficientCredits(r.stake, r.have)
             is TopUpResolution.InsufficientCoinsForTopUp ->
                 return PlayOutcome.InsufficientCoinsForTopUp(r.needed, r.have)
+            is TopUpResolution.OnCooldown -> return PlayOutcome.OnCooldown(r.remainingMs)
             is TopUpResolution.Ok -> r
         }
 
@@ -124,8 +129,12 @@ class HighlowService(
             highlow.play(direction, random)
         }
         val wager = WagerHelper.applyMultiplier(userService, resolved.user, resolved.balance, stake, hand.multiplier)
+        cooldownService.arm(discordId, CasinoGameKey.HIGHLOW)
         return if (hand.isWin) {
-            val jackpot = JackpotHelper.rollOnWin(jackpotService, configService, userService, resolved.user, guildId, random)
+            val jackpot = JackpotHelper.rollOnWin(
+                jackpotService, configService, userService, resolved.user, guildId,
+                stake, Highlow.MAX_STAKE, random,
+            )
             PlayOutcome.Win(
                 stake = stake,
                 payout = wager.payout,

--- a/database/src/main/kotlin/database/service/JackpotHelper.kt
+++ b/database/src/main/kotlin/database/service/JackpotHelper.kt
@@ -65,6 +65,12 @@ internal object JackpotHelper {
      * awarded. Returns `0L` on miss or empty pool. The hit probability
      * is per-guild configurable via `JACKPOT_WIN_PCT`; defaults to
      * [DEFAULT_WIN_PROBABILITY].
+     *
+     * The base probability is scaled linearly by `stake / maxStake`, so
+     * a min-wager autoclicker can't farm the pool — a 10/1000 coinflip
+     * rolls at 0.01 % even when the configured base is 1 %. Clamps the
+     * scale to [0,1] defensively in case a caller ever passes
+     * stake > maxStake.
      */
     fun rollOnWin(
         jackpotService: JackpotService,
@@ -72,10 +78,15 @@ internal object JackpotHelper {
         userService: UserService,
         user: UserDto,
         guildId: Long,
+        stake: Long,
+        maxStake: Long,
         random: Random
     ): Long {
-        val probability = winProbability(configService, guildId)
-        if (random.nextDouble() >= probability) return 0L
+        val baseProbability = winProbability(configService, guildId)
+        val scale = if (maxStake <= 0L) 0.0
+            else (stake.toDouble() / maxStake.toDouble()).coerceIn(0.0, 1.0)
+        val effective = baseProbability * scale
+        if (random.nextDouble() >= effective) return 0L
         val won = jackpotService.awardJackpot(guildId)
         if (won == 0L) return 0L
         user.socialCredit = (user.socialCredit ?: 0L) + won

--- a/database/src/main/kotlin/database/service/JackpotService.kt
+++ b/database/src/main/kotlin/database/service/JackpotService.kt
@@ -65,6 +65,22 @@ class JackpotService(
         return won
     }
 
+    /**
+     * Admin-only: zero the pool without paying anyone. Returns the
+     * amount that was drained, so the caller can show "reset 12,345
+     * credits" in the audit response. Use when a player has
+     * pathologically inflated the pool via spam-tribute and rolling
+     * back the activity is the cleanest fix.
+     */
+    fun resetPool(guildId: Long): Long {
+        val row = lockOrCreate(guildId)
+        val drained = row.pool
+        if (drained == 0L) return 0L
+        row.pool = 0L
+        persistence.upsert(row)
+        return drained
+    }
+
     private fun lockOrCreate(guildId: Long): TobyCoinJackpotDto {
         persistence.getByGuildForUpdate(guildId)?.let { return it }
         // First fee for this guild — seed and re-read with the write lock.

--- a/database/src/main/kotlin/database/service/KenoService.kt
+++ b/database/src/main/kotlin/database/service/KenoService.kt
@@ -32,6 +32,7 @@ class KenoService(
     private val tradeService: EconomyTradeService,
     private val marketService: TobyCoinMarketService,
     private val configService: ConfigService,
+    private val cooldownService: CasinoCooldownService,
     private val keno: Keno = Keno(),
     private val random: Random = Random.Default
 ) {
@@ -67,6 +68,7 @@ class KenoService(
         data class InvalidStake(val min: Long, val max: Long) : PlayOutcome
         data class InvalidPicks(val min: Int, val max: Int, val poolMax: Int) : PlayOutcome
         data object UnknownUser : PlayOutcome
+        data class OnCooldown(val remainingMs: Long) : PlayOutcome
     }
 
     /**
@@ -103,7 +105,8 @@ class KenoService(
 
         val resolved = when (val r = WagerHelper.checkLockOrTopUp(
             userService, tradeService, marketService,
-            discordId, guildId, stake, Keno.MIN_STAKE, Keno.MAX_STAKE, autoTopUp
+            discordId, guildId, stake, Keno.MIN_STAKE, Keno.MAX_STAKE, autoTopUp,
+            cooldownService = cooldownService, game = CasinoGameKey.KENO,
         )) {
             is TopUpResolution.InvalidStake -> return PlayOutcome.InvalidStake(r.min, r.max)
             TopUpResolution.UnknownUser -> return PlayOutcome.UnknownUser
@@ -111,6 +114,7 @@ class KenoService(
                 return PlayOutcome.InsufficientCredits(r.stake, r.have)
             is TopUpResolution.InsufficientCoinsForTopUp ->
                 return PlayOutcome.InsufficientCoinsForTopUp(r.needed, r.have)
+            is TopUpResolution.OnCooldown -> return PlayOutcome.OnCooldown(r.remainingMs)
             is TopUpResolution.Ok -> r
         }
 
@@ -124,9 +128,11 @@ class KenoService(
         val wager = WagerHelper.applyMultiplier(
             userService, resolved.user, resolved.balance, stake, hand.multiplier
         )
+        cooldownService.arm(discordId, CasinoGameKey.KENO)
         return if (hand.isWin) {
             val jackpot = JackpotHelper.rollOnWin(
-                jackpotService, configService, userService, resolved.user, guildId, random
+                jackpotService, configService, userService, resolved.user, guildId,
+                stake, Keno.MAX_STAKE, random,
             )
             PlayOutcome.Win(
                 stake = stake,

--- a/database/src/main/kotlin/database/service/ScratchService.kt
+++ b/database/src/main/kotlin/database/service/ScratchService.kt
@@ -22,6 +22,7 @@ class ScratchService(
     private val tradeService: EconomyTradeService,
     private val marketService: TobyCoinMarketService,
     private val configService: ConfigService,
+    private val cooldownService: CasinoCooldownService,
     private val card: ScratchCard = ScratchCard(),
     private val random: Random = Random.Default
 ) {
@@ -56,12 +57,15 @@ class ScratchService(
         data class InvalidStake(override val min: Long, override val max: Long) :
             ScratchOutcome, CasinoCommonFailure.InvalidStake
         data object UnknownUser : ScratchOutcome, CasinoCommonFailure.UnknownUser
+        data class OnCooldown(override val remainingMs: Long) :
+            ScratchOutcome, CasinoCommonFailure.OnCooldown
     }
 
     fun scratch(discordId: Long, guildId: Long, stake: Long, autoTopUp: Boolean = false): ScratchOutcome {
         val resolved = when (val r = WagerHelper.checkLockOrTopUp(
             userService, tradeService, marketService,
-            discordId, guildId, stake, ScratchCard.MIN_STAKE, ScratchCard.MAX_STAKE, autoTopUp
+            discordId, guildId, stake, ScratchCard.MIN_STAKE, ScratchCard.MAX_STAKE, autoTopUp,
+            cooldownService = cooldownService, game = CasinoGameKey.SCRATCH,
         )) {
             is TopUpResolution.InvalidStake -> return ScratchOutcome.InvalidStake(r.min, r.max)
             TopUpResolution.UnknownUser -> return ScratchOutcome.UnknownUser
@@ -69,13 +73,18 @@ class ScratchService(
                 return ScratchOutcome.InsufficientCredits(r.stake, r.have)
             is TopUpResolution.InsufficientCoinsForTopUp ->
                 return ScratchOutcome.InsufficientCoinsForTopUp(r.needed, r.have)
+            is TopUpResolution.OnCooldown -> return ScratchOutcome.OnCooldown(r.remainingMs)
             is TopUpResolution.Ok -> r
         }
 
         val result = card.scratch(random)
         val wager = WagerHelper.applyMultiplier(userService, resolved.user, resolved.balance, stake, result.multiplier)
+        cooldownService.arm(discordId, CasinoGameKey.SCRATCH)
         return if (result.isWin && result.winningSymbol != null) {
-            val jackpot = JackpotHelper.rollOnWin(jackpotService, configService, userService, resolved.user, guildId, random)
+            val jackpot = JackpotHelper.rollOnWin(
+                jackpotService, configService, userService, resolved.user, guildId,
+                stake, ScratchCard.MAX_STAKE, random,
+            )
             ScratchOutcome.Win(
                 stake = stake,
                 payout = wager.payout,

--- a/database/src/main/kotlin/database/service/SlotsService.kt
+++ b/database/src/main/kotlin/database/service/SlotsService.kt
@@ -35,6 +35,7 @@ class SlotsService(
     private val tradeService: EconomyTradeService,
     private val marketService: TobyCoinMarketService,
     private val configService: ConfigService,
+    private val cooldownService: CasinoCooldownService,
     private val machine: SlotMachine = SlotMachine(),
     private val random: Random = Random.Default
 ) {
@@ -68,12 +69,15 @@ class SlotsService(
         data class InvalidStake(override val min: Long, override val max: Long) :
             SpinOutcome, CasinoCommonFailure.InvalidStake
         data object UnknownUser : SpinOutcome, CasinoCommonFailure.UnknownUser
+        data class OnCooldown(override val remainingMs: Long) :
+            SpinOutcome, CasinoCommonFailure.OnCooldown
     }
 
     fun spin(discordId: Long, guildId: Long, stake: Long, autoTopUp: Boolean = false): SpinOutcome {
         val resolved = when (val r = WagerHelper.checkLockOrTopUp(
             userService, tradeService, marketService,
-            discordId, guildId, stake, SlotMachine.MIN_STAKE, SlotMachine.MAX_STAKE, autoTopUp
+            discordId, guildId, stake, SlotMachine.MIN_STAKE, SlotMachine.MAX_STAKE, autoTopUp,
+            cooldownService = cooldownService, game = CasinoGameKey.SLOTS,
         )) {
             is TopUpResolution.InvalidStake -> return SpinOutcome.InvalidStake(r.min, r.max)
             TopUpResolution.UnknownUser -> return SpinOutcome.UnknownUser
@@ -81,13 +85,18 @@ class SlotsService(
                 return SpinOutcome.InsufficientCredits(r.stake, r.have)
             is TopUpResolution.InsufficientCoinsForTopUp ->
                 return SpinOutcome.InsufficientCoinsForTopUp(r.needed, r.have)
+            is TopUpResolution.OnCooldown -> return SpinOutcome.OnCooldown(r.remainingMs)
             is TopUpResolution.Ok -> r
         }
 
         val pull = machine.pull(random)
         val wager = WagerHelper.applyMultiplier(userService, resolved.user, resolved.balance, stake, pull.multiplier)
+        cooldownService.arm(discordId, CasinoGameKey.SLOTS)
         return if (pull.isWin) {
-            val jackpot = JackpotHelper.rollOnWin(jackpotService, configService, userService, resolved.user, guildId, random)
+            val jackpot = JackpotHelper.rollOnWin(
+                jackpotService, configService, userService, resolved.user, guildId,
+                stake, SlotMachine.MAX_STAKE, random,
+            )
             SpinOutcome.Win(
                 stake = stake,
                 multiplier = pull.multiplier,

--- a/database/src/main/kotlin/database/service/WagerHelper.kt
+++ b/database/src/main/kotlin/database/service/WagerHelper.kt
@@ -53,6 +53,7 @@ internal sealed interface TopUpResolution {
     data class StillInsufficientCredits(val stake: Long, val have: Long) : TopUpResolution
     data class InsufficientCoinsForTopUp(val needed: Long, val have: Long) : TopUpResolution
     data object UnknownUser : TopUpResolution
+    data class OnCooldown(val remainingMs: Long) : TopUpResolution
 }
 
 internal object WagerHelper {
@@ -136,6 +137,34 @@ internal object WagerHelper {
      * shape from the helper so the call-site is uniform.
      */
     fun checkLockOrTopUp(
+        userService: UserService,
+        tradeService: EconomyTradeService,
+        marketService: TobyCoinMarketService,
+        discordId: Long,
+        guildId: Long,
+        stake: Long,
+        minStake: Long,
+        maxStake: Long,
+        autoTopUp: Boolean,
+        cooldownService: CasinoCooldownService? = null,
+        game: CasinoGameKey? = null,
+    ): TopUpResolution {
+        // Cooldown is gated only when both collaborators are wired —
+        // existing test paths that don't pass them keep working.
+        if (cooldownService != null && game != null) {
+            when (val gate = cooldownService.tryAcquire(discordId, guildId, game)) {
+                CasinoCooldownService.AcquireResult.Ok -> Unit
+                is CasinoCooldownService.AcquireResult.OnCooldown ->
+                    return TopUpResolution.OnCooldown(gate.remainingMs)
+            }
+        }
+        return resolveCheckAndTopUp(
+            userService, tradeService, marketService,
+            discordId, guildId, stake, minStake, maxStake, autoTopUp,
+        )
+    }
+
+    private fun resolveCheckAndTopUp(
         userService: UserService,
         tradeService: EconomyTradeService,
         marketService: TobyCoinMarketService,

--- a/database/src/test/kotlin/database/service/BaccaratServiceTest.kt
+++ b/database/src/test/kotlin/database/service/BaccaratServiceTest.kt
@@ -22,6 +22,7 @@ class BaccaratServiceTest {
     private lateinit var tradeService: EconomyTradeService
     private lateinit var marketService: TobyCoinMarketService
     private lateinit var configService: ConfigService
+    private lateinit var cooldownService: CasinoCooldownService
     private lateinit var baccarat: Baccarat
     private lateinit var service: BaccaratService
 
@@ -35,9 +36,11 @@ class BaccaratServiceTest {
         tradeService = mockk(relaxed = true)
         marketService = mockk(relaxed = true)
         configService = mockk(relaxed = true)
+        cooldownService = mockk(relaxed = true)
+        every { cooldownService.tryAcquire(any(), any(), any()) } returns CasinoCooldownService.AcquireResult.Ok
         baccarat = mockk(relaxed = true)
         service = BaccaratService(
-            userService, jackpotService, tradeService, marketService, configService,
+            userService, jackpotService, tradeService, marketService, configService, cooldownService,
             baccarat, Random(0)
         )
     }

--- a/database/src/test/kotlin/database/service/CasinoCooldownServiceTest.kt
+++ b/database/src/test/kotlin/database/service/CasinoCooldownServiceTest.kt
@@ -1,0 +1,148 @@
+package database.service
+
+import database.dto.ConfigDto
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.util.concurrent.atomic.AtomicLong
+
+class CasinoCooldownServiceTest {
+
+    private val guildId = 200L
+    private val discordId = 7L
+
+    private lateinit var configService: ConfigService
+    private lateinit var nowMillis: AtomicLong
+    private lateinit var service: CasinoCooldownService
+
+    @BeforeEach
+    fun setup() {
+        configService = mockk(relaxed = true)
+        nowMillis = AtomicLong(1_000_000L)
+        service = CasinoCooldownService(configService, clock = { nowMillis.get() })
+    }
+
+    private fun configReturns(value: String?) {
+        every {
+            configService.getConfigByName(
+                ConfigDto.Configurations.CASINO_COOLDOWN_SECONDS.configValue,
+                guildId.toString(),
+            )
+        } returns value?.let { ConfigDto(name = "x", value = it, guildId = guildId.toString()) }
+    }
+
+    @Test
+    fun `tryAcquire returns Ok on the first call`() {
+        configReturns(null) // default 3 s
+        val result = service.tryAcquire(discordId, guildId, CasinoGameKey.COINFLIP)
+        assertEquals(CasinoCooldownService.AcquireResult.Ok, result)
+    }
+
+    @Test
+    fun `tryAcquire blocks until the configured cooldown elapses, then unblocks`() {
+        configReturns(null) // 3 s default
+        service.arm(discordId, CasinoGameKey.COINFLIP)
+
+        // 1 ms after arm — blocked, ~3 s remaining.
+        nowMillis.addAndGet(1L)
+        val blocked = service.tryAcquire(discordId, guildId, CasinoGameKey.COINFLIP)
+        val onCd = assertInstanceOf(CasinoCooldownService.AcquireResult.OnCooldown::class.java, blocked)
+        assertTrue(onCd.remainingMs in 2_990L..3_000L, "remaining=${onCd.remainingMs}")
+
+        // 2.999 s after arm — still blocked.
+        nowMillis.addAndGet(2_998L)
+        assertInstanceOf(
+            CasinoCooldownService.AcquireResult.OnCooldown::class.java,
+            service.tryAcquire(discordId, guildId, CasinoGameKey.COINFLIP),
+        )
+
+        // 3 s after arm — unblocked.
+        nowMillis.addAndGet(2L)
+        assertEquals(
+            CasinoCooldownService.AcquireResult.Ok,
+            service.tryAcquire(discordId, guildId, CasinoGameKey.COINFLIP),
+        )
+    }
+
+    @Test
+    fun `cooldown is per game and per user`() {
+        configReturns(null)
+        service.arm(discordId, CasinoGameKey.COINFLIP)
+
+        // Same user, different game — not blocked.
+        assertEquals(
+            CasinoCooldownService.AcquireResult.Ok,
+            service.tryAcquire(discordId, guildId, CasinoGameKey.SLOTS),
+        )
+
+        // Different user, same game — not blocked.
+        assertEquals(
+            CasinoCooldownService.AcquireResult.Ok,
+            service.tryAcquire(discordId + 1, guildId, CasinoGameKey.COINFLIP),
+        )
+    }
+
+    @Test
+    fun `cooldown of zero seconds disables gating entirely`() {
+        configReturns("0")
+        service.arm(discordId, CasinoGameKey.COINFLIP)
+
+        // Even immediately after arm, with cooldown=0 we always pass.
+        assertEquals(
+            CasinoCooldownService.AcquireResult.Ok,
+            service.tryAcquire(discordId, guildId, CasinoGameKey.COINFLIP),
+        )
+    }
+
+    @Test
+    fun `cooldown clamps above the maximum`() {
+        // Setting 999 seconds should clamp to MAX_COOLDOWN_SECONDS (30).
+        configReturns("999")
+        service.arm(discordId, CasinoGameKey.COINFLIP)
+        nowMillis.addAndGet(29_000L) // 29 s in — still blocked at 30 s clamp.
+        val res = service.tryAcquire(discordId, guildId, CasinoGameKey.COINFLIP)
+        val onCd = assertInstanceOf(CasinoCooldownService.AcquireResult.OnCooldown::class.java, res)
+        assertTrue(onCd.remainingMs in 1L..1_000L, "remaining=${onCd.remainingMs}")
+
+        nowMillis.addAndGet(2_000L) // 31 s in — past clamp, unblocked.
+        assertEquals(
+            CasinoCooldownService.AcquireResult.Ok,
+            service.tryAcquire(discordId, guildId, CasinoGameKey.COINFLIP),
+        )
+    }
+
+    @Test
+    fun `cooldown falls back to default when config value is unparseable`() {
+        configReturns("not-a-number")
+        service.arm(discordId, CasinoGameKey.COINFLIP)
+        nowMillis.addAndGet(1L)
+        // Default is 3 s — should still be blocked at 1 ms in.
+        assertNotNull(
+            (service.tryAcquire(discordId, guildId, CasinoGameKey.COINFLIP)
+                as? CasinoCooldownService.AcquireResult.OnCooldown),
+        )
+    }
+
+    @Test
+    fun `reset(discordId) forgets the user cooldown without affecting others`() {
+        configReturns(null)
+        service.arm(discordId, CasinoGameKey.COINFLIP)
+        service.arm(discordId + 1, CasinoGameKey.COINFLIP)
+
+        service.reset(discordId)
+
+        assertEquals(
+            CasinoCooldownService.AcquireResult.Ok,
+            service.tryAcquire(discordId, guildId, CasinoGameKey.COINFLIP),
+        )
+        assertInstanceOf(
+            CasinoCooldownService.AcquireResult.OnCooldown::class.java,
+            service.tryAcquire(discordId + 1, guildId, CasinoGameKey.COINFLIP),
+        )
+    }
+}

--- a/database/src/test/kotlin/database/service/CoinflipServiceTest.kt
+++ b/database/src/test/kotlin/database/service/CoinflipServiceTest.kt
@@ -19,6 +19,7 @@ class CoinflipServiceTest {
     private lateinit var tradeService: EconomyTradeService
     private lateinit var marketService: TobyCoinMarketService
     private lateinit var configService: ConfigService
+    private lateinit var cooldownService: CasinoCooldownService
     private lateinit var coinflip: Coinflip
     private lateinit var service: CoinflipService
 
@@ -32,8 +33,10 @@ class CoinflipServiceTest {
         tradeService = mockk(relaxed = true)
         marketService = mockk(relaxed = true)
         configService = mockk(relaxed = true)
+        cooldownService = mockk(relaxed = true)
+        every { cooldownService.tryAcquire(any(), any(), any()) } returns CasinoCooldownService.AcquireResult.Ok
         coinflip = mockk(relaxed = true)
-        service = CoinflipService(userService, jackpotService, tradeService, marketService, configService, coinflip, Random(0))
+        service = CoinflipService(userService, jackpotService, tradeService, marketService, configService, cooldownService, coinflip, Random(0))
     }
 
     private fun userWithBalance(balance: Long): UserDto {

--- a/database/src/test/kotlin/database/service/DiceServiceTest.kt
+++ b/database/src/test/kotlin/database/service/DiceServiceTest.kt
@@ -19,6 +19,7 @@ class DiceServiceTest {
     private lateinit var tradeService: EconomyTradeService
     private lateinit var marketService: TobyCoinMarketService
     private lateinit var configService: ConfigService
+    private lateinit var cooldownService: CasinoCooldownService
     private lateinit var dice: Dice
     private lateinit var service: DiceService
 
@@ -32,11 +33,13 @@ class DiceServiceTest {
         tradeService = mockk(relaxed = true)
         marketService = mockk(relaxed = true)
         configService = mockk(relaxed = true)
+        cooldownService = mockk(relaxed = true)
+        every { cooldownService.tryAcquire(any(), any(), any()) } returns CasinoCooldownService.AcquireResult.Ok
         dice = mockk(relaxed = true) {
             every { isValidPrediction(any()) } answers { firstArg<Int>() in 1..6 }
             every { sidesCount } returns 6
         }
-        service = DiceService(userService, jackpotService, tradeService, marketService, configService, dice, Random(0))
+        service = DiceService(userService, jackpotService, tradeService, marketService, configService, cooldownService, dice, Random(0))
     }
 
     private fun userWithBalance(balance: Long): UserDto {

--- a/database/src/test/kotlin/database/service/DuelServiceTest.kt
+++ b/database/src/test/kotlin/database/service/DuelServiceTest.kt
@@ -42,7 +42,7 @@ class DuelServiceTest {
     }
 
     private fun service(random: Random = AlwaysHeadsRandom): DuelService =
-        DuelService(userService, jackpotService, configService, duelLogPersistence, random)
+        DuelService(userService, jackpotService, configService, duelLogPersistence, cooldownService = null, random = random)
 
     @Test
     fun `startDuel returns Ok when both players have enough credits`() {

--- a/database/src/test/kotlin/database/service/HighlowServiceTest.kt
+++ b/database/src/test/kotlin/database/service/HighlowServiceTest.kt
@@ -19,6 +19,7 @@ class HighlowServiceTest {
     private lateinit var tradeService: EconomyTradeService
     private lateinit var marketService: TobyCoinMarketService
     private lateinit var configService: ConfigService
+    private lateinit var cooldownService: CasinoCooldownService
     private lateinit var highlow: Highlow
     private lateinit var service: HighlowService
 
@@ -32,8 +33,10 @@ class HighlowServiceTest {
         tradeService = mockk(relaxed = true)
         marketService = mockk(relaxed = true)
         configService = mockk(relaxed = true)
+        cooldownService = mockk(relaxed = true)
+        every { cooldownService.tryAcquire(any(), any(), any()) } returns CasinoCooldownService.AcquireResult.Ok
         highlow = mockk(relaxed = true)
-        service = HighlowService(userService, jackpotService, tradeService, marketService, configService, highlow, Random(0))
+        service = HighlowService(userService, jackpotService, tradeService, marketService, configService, cooldownService, highlow, Random(0))
     }
 
     private fun userWithBalance(balance: Long): UserDto =

--- a/database/src/test/kotlin/database/service/JackpotHelperTest.kt
+++ b/database/src/test/kotlin/database/service/JackpotHelperTest.kt
@@ -14,6 +14,7 @@ class JackpotHelperTest {
 
     private val guildId = 200L
     private val discordId = 7L
+    private val MAX_STAKE = 1_000L
 
     private lateinit var jackpotService: JackpotService
     private lateinit var userService: UserService
@@ -195,7 +196,8 @@ class JackpotHelperTest {
         val user = freshUser(initial = 100L)
 
         val won = JackpotHelper.rollOnWin(
-            jackpotService, configService, userService, user, guildId, stubRandom(0.001)
+            jackpotService, configService, userService, user, guildId,
+            stake = MAX_STAKE, maxStake = MAX_STAKE, random = stubRandom(0.001)
         )
 
         assertEquals(500L, won)
@@ -210,7 +212,8 @@ class JackpotHelperTest {
 
         // 0.5 is far above the 0.01 threshold.
         val won = JackpotHelper.rollOnWin(
-            jackpotService, configService, userService, user, guildId, stubRandom(0.5)
+            jackpotService, configService, userService, user, guildId,
+            stake = MAX_STAKE, maxStake = MAX_STAKE, random = stubRandom(0.5)
         )
 
         assertEquals(0L, won)
@@ -227,10 +230,12 @@ class JackpotHelperTest {
         val userMiss = freshUser()
 
         val hit = JackpotHelper.rollOnWin(
-            jackpotService, configService, userService, userHit, guildId, stubRandom(0.004)
+            jackpotService, configService, userService, userHit, guildId,
+            stake = MAX_STAKE, maxStake = MAX_STAKE, random = stubRandom(0.004)
         )
         val miss = JackpotHelper.rollOnWin(
-            jackpotService, configService, userService, userMiss, guildId, stubRandom(0.006)
+            jackpotService, configService, userService, userMiss, guildId,
+            stake = MAX_STAKE, maxStake = MAX_STAKE, random = stubRandom(0.006)
         )
 
         assertEquals(1_000L, hit, "0.004 < 0.005 should hit")
@@ -244,7 +249,8 @@ class JackpotHelperTest {
 
         // Even an absurdly small roll can't beat a 0.0 threshold (`< 0.0` is unreachable).
         val won = JackpotHelper.rollOnWin(
-            jackpotService, configService, userService, user, guildId, stubRandom(0.0)
+            jackpotService, configService, userService, user, guildId,
+            stake = MAX_STAKE, maxStake = MAX_STAKE, random = stubRandom(0.0)
         )
 
         assertEquals(0L, won)
@@ -259,10 +265,12 @@ class JackpotHelperTest {
         val userMiss = freshUser()
 
         val hit = JackpotHelper.rollOnWin(
-            jackpotService, configService, userService, userHit, guildId, stubRandom(0.49)
+            jackpotService, configService, userService, userHit, guildId,
+            stake = MAX_STAKE, maxStake = MAX_STAKE, random = stubRandom(0.49)
         )
         val miss = JackpotHelper.rollOnWin(
-            jackpotService, configService, userService, userMiss, guildId, stubRandom(0.51)
+            jackpotService, configService, userService, userMiss, guildId,
+            stake = MAX_STAKE, maxStake = MAX_STAKE, random = stubRandom(0.51)
         )
 
         assertEquals(50L, hit)
@@ -276,11 +284,83 @@ class JackpotHelperTest {
         val user = freshUser(initial = 100L)
 
         val won = JackpotHelper.rollOnWin(
-            jackpotService, configService, userService, user, guildId, stubRandom(0.001)
+            jackpotService, configService, userService, user, guildId,
+            stake = MAX_STAKE, maxStake = MAX_STAKE, random = stubRandom(0.001)
         )
 
         assertEquals(0L, won)
         assertEquals(100L, user.socialCredit, "balance must be untouched when pool was empty")
         verify(exactly = 0) { userService.updateUser(any()) }
+    }
+
+    // ---- stake-weighted scaling ----
+
+    @Test
+    fun `rollOnWin scales by stake fraction so a min-wager autoclick is effectively zero`() {
+        winConfigReturns("1") // 1 % base → 10/1000 → 0.01 % effective
+        every { jackpotService.awardJackpot(guildId) } returns 1_000L
+        val userHit = freshUser()
+        val userMiss = freshUser()
+
+        val hit = JackpotHelper.rollOnWin(
+            jackpotService, configService, userService, userHit, guildId,
+            stake = 10L, maxStake = 1_000L, random = stubRandom(0.00009)
+        )
+        val miss = JackpotHelper.rollOnWin(
+            jackpotService, configService, userService, userMiss, guildId,
+            stake = 10L, maxStake = 1_000L, random = stubRandom(0.0001)
+        )
+
+        assertEquals(1_000L, hit, "0.00009 < 0.0001 should hit")
+        assertEquals(0L, miss, "0.0001 >= 0.0001 should miss")
+    }
+
+    @Test
+    fun `rollOnWin at full max stake rolls at the unscaled base probability`() {
+        winConfigReturns("1") // 1 % base → 1000/1000 → 1 % effective
+        every { jackpotService.awardJackpot(guildId) } returns 1_000L
+        val userHit = freshUser()
+        val userMiss = freshUser()
+
+        val hit = JackpotHelper.rollOnWin(
+            jackpotService, configService, userService, userHit, guildId,
+            stake = 1_000L, maxStake = 1_000L, random = stubRandom(0.009)
+        )
+        val miss = JackpotHelper.rollOnWin(
+            jackpotService, configService, userService, userMiss, guildId,
+            stake = 1_000L, maxStake = 1_000L, random = stubRandom(0.011)
+        )
+
+        assertEquals(1_000L, hit)
+        assertEquals(0L, miss)
+    }
+
+    @Test
+    fun `rollOnWin clamps stake fraction to 1 when stake exceeds maxStake (defensive)`() {
+        winConfigReturns("1") // base 1 %
+        every { jackpotService.awardJackpot(guildId) } returns 100L
+        val user = freshUser()
+
+        // stake > maxStake would push the formula past 1.0; clamp keeps it at 1 % effective.
+        val won = JackpotHelper.rollOnWin(
+            jackpotService, configService, userService, user, guildId,
+            stake = 10_000L, maxStake = 1_000L, random = stubRandom(0.009)
+        )
+
+        assertEquals(100L, won)
+    }
+
+    @Test
+    fun `rollOnWin returns zero when maxStake is zero (defensive divide-by-zero guard)`() {
+        winConfigReturns("100") // would otherwise hit at the cap
+        val user = freshUser()
+
+        val won = JackpotHelper.rollOnWin(
+            jackpotService, configService, userService, user, guildId,
+            stake = 100L, maxStake = 0L, random = stubRandom(0.0)
+        )
+
+        assertEquals(0L, won)
+        verify(exactly = 0) { jackpotService.awardJackpot(any()) }
     }
 }

--- a/database/src/test/kotlin/database/service/JackpotServiceTest.kt
+++ b/database/src/test/kotlin/database/service/JackpotServiceTest.kt
@@ -113,6 +113,28 @@ class JackpotServiceTest {
     }
 
     @Test
+    fun `resetPool drains the pool to zero and returns the prior amount`() {
+        val existing = TobyCoinJackpotDto(guildId = guildId, pool = 9_999L)
+        every { persistence.getByGuildForUpdate(guildId) } returns existing
+        every { persistence.upsert(any()) } answers { firstArg() }
+
+        val drained = service.resetPool(guildId)
+
+        assertEquals(9_999L, drained)
+        assertEquals(0L, existing.pool)
+        verify(exactly = 1) { persistence.upsert(existing) }
+    }
+
+    @Test
+    fun `resetPool is a no-op when the pool is already empty`() {
+        val empty = TobyCoinJackpotDto(guildId = guildId, pool = 0L)
+        every { persistence.getByGuildForUpdate(guildId) } returns empty
+
+        assertEquals(0L, service.resetPool(guildId))
+        verify(exactly = 0) { persistence.upsert(any()) }
+    }
+
+    @Test
     fun `winProbabilityPct returns the default 1 percent when no JACKPOT_WIN_PCT row exists`() {
         // setup() already stubs configService to return null for this key.
         // [JackpotHelper.DEFAULT_WIN_PROBABILITY] = 0.01 → 1.0%.

--- a/database/src/test/kotlin/database/service/KenoServiceTest.kt
+++ b/database/src/test/kotlin/database/service/KenoServiceTest.kt
@@ -19,6 +19,7 @@ class KenoServiceTest {
     private lateinit var tradeService: EconomyTradeService
     private lateinit var marketService: TobyCoinMarketService
     private lateinit var configService: ConfigService
+    private lateinit var cooldownService: CasinoCooldownService
     private lateinit var keno: Keno
     private lateinit var service: KenoService
 
@@ -32,6 +33,8 @@ class KenoServiceTest {
         tradeService = mockk(relaxed = true)
         marketService = mockk(relaxed = true)
         configService = mockk(relaxed = true)
+        cooldownService = mockk(relaxed = true)
+        every { cooldownService.tryAcquire(any(), any(), any()) } returns CasinoCooldownService.AcquireResult.Ok
         keno = mockk(relaxed = true)
         // Defaults so the engine doesn't NPE in tests that don't override:
         every { keno.drawNumbers(any()) } returns (1..20).toList()
@@ -41,7 +44,7 @@ class KenoServiceTest {
             Keno.Hand(picks = picks.sorted(), draws = draws, hits = 0, multiplier = 0.0)
         }
         service = KenoService(
-            userService, jackpotService, tradeService, marketService, configService,
+            userService, jackpotService, tradeService, marketService, configService, cooldownService,
             keno, Random(0)
         )
     }

--- a/database/src/test/kotlin/database/service/ScratchServiceTest.kt
+++ b/database/src/test/kotlin/database/service/ScratchServiceTest.kt
@@ -20,6 +20,7 @@ class ScratchServiceTest {
     private lateinit var tradeService: EconomyTradeService
     private lateinit var marketService: TobyCoinMarketService
     private lateinit var configService: ConfigService
+    private lateinit var cooldownService: CasinoCooldownService
     private lateinit var card: ScratchCard
     private lateinit var service: ScratchService
 
@@ -33,8 +34,10 @@ class ScratchServiceTest {
         tradeService = mockk(relaxed = true)
         marketService = mockk(relaxed = true)
         configService = mockk(relaxed = true)
+        cooldownService = mockk(relaxed = true)
+        every { cooldownService.tryAcquire(any(), any(), any()) } returns CasinoCooldownService.AcquireResult.Ok
         card = mockk(relaxed = true)
-        service = ScratchService(userService, jackpotService, tradeService, marketService, configService, card, Random(0))
+        service = ScratchService(userService, jackpotService, tradeService, marketService, configService, cooldownService, card, Random(0))
     }
 
     private fun userWithBalance(balance: Long): UserDto =

--- a/database/src/test/kotlin/database/service/SlotsServiceTest.kt
+++ b/database/src/test/kotlin/database/service/SlotsServiceTest.kt
@@ -19,6 +19,7 @@ class SlotsServiceTest {
     private lateinit var tradeService: EconomyTradeService
     private lateinit var marketService: TobyCoinMarketService
     private lateinit var configService: ConfigService
+    private lateinit var cooldownService: CasinoCooldownService
     private lateinit var machine: SlotMachine
     private lateinit var service: SlotsService
 
@@ -32,8 +33,10 @@ class SlotsServiceTest {
         tradeService = mockk(relaxed = true)
         marketService = mockk(relaxed = true)
         configService = mockk(relaxed = true)
+        cooldownService = mockk(relaxed = true)
+        every { cooldownService.tryAcquire(any(), any(), any()) } returns CasinoCooldownService.AcquireResult.Ok
         machine = mockk(relaxed = true)
-        service = SlotsService(userService, jackpotService, tradeService, marketService, configService, machine, Random(0))
+        service = SlotsService(userService, jackpotService, tradeService, marketService, configService, cooldownService, machine, Random(0))
     }
 
     private fun userWithBalance(balance: Long): UserDto {

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/BaccaratEmbeds.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/BaccaratEmbeds.kt
@@ -117,6 +117,9 @@ internal object BaccaratEmbeds {
             TITLE, WagerCommandFailure.InvalidStake(outcome.min, outcome.max)
         )
         PlayOutcome.UnknownUser -> WagerCommandEmbeds.failureEmbed(TITLE, WagerCommandFailure.UnknownUser)
+        is PlayOutcome.OnCooldown -> WagerCommandEmbeds.failureEmbed(
+            TITLE, WagerCommandFailure.OnCooldown(outcome.remainingMs)
+        )
     }
 
     fun errorEmbed(message: String): MessageEmbed = WagerCommandEmbeds.errorEmbed(TITLE, message)

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/BlackjackCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/BlackjackCommand.kt
@@ -165,6 +165,9 @@ class BlackjackCommand @Autowired constructor(
             SoloDealOutcome.UnknownUser -> replyFailure(
                 event, WagerCommandFailure.UnknownUser, deleteDelay
             )
+            is SoloDealOutcome.OnCooldown -> replyFailure(
+                event, WagerCommandFailure.OnCooldown(outcome.remainingMs), deleteDelay
+            )
         }
     }
 

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/CasinoHoldemCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/CasinoHoldemCommand.kt
@@ -77,6 +77,9 @@ class CasinoHoldemCommand @Autowired constructor(
             DealOutcome.UnknownUser -> replyFailure(
                 event, WagerCommandFailure.UnknownUser, deleteDelay
             )
+            is DealOutcome.OnCooldown -> replyFailure(
+                event, WagerCommandFailure.OnCooldown(outcome.remainingMs), deleteDelay
+            )
         }
     }
 

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/CoinflipCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/CoinflipCommand.kt
@@ -93,5 +93,8 @@ class CoinflipCommand @Autowired constructor(
             TITLE, WagerCommandFailure.InvalidStake(outcome.min, outcome.max)
         )
         FlipOutcome.UnknownUser -> WagerCommandEmbeds.failureEmbed(TITLE, WagerCommandFailure.UnknownUser)
+        is FlipOutcome.OnCooldown -> WagerCommandEmbeds.failureEmbed(
+            TITLE, WagerCommandFailure.OnCooldown(outcome.remainingMs)
+        )
     }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/DiceCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/DiceCommand.kt
@@ -93,6 +93,9 @@ class DiceCommand @Autowired constructor(
             TITLE, "Pick a number between ${outcome.min} and ${outcome.max}."
         )
         RollOutcome.UnknownUser -> WagerCommandEmbeds.failureEmbed(TITLE, WagerCommandFailure.UnknownUser)
+        is RollOutcome.OnCooldown -> WagerCommandEmbeds.failureEmbed(
+            TITLE, WagerCommandFailure.OnCooldown(outcome.remainingMs)
+        )
     }
 
     // payout / stake = multiplier — derived for the "5× on" string in the win embed.

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/DuelEmbeds.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/DuelEmbeds.kt
@@ -108,6 +108,10 @@ internal object DuelEmbeds {
                 "Opponent only has ${outcome.have} credits — they can't cover a ${outcome.needed} stake."
             StartOutcome.UnknownInitiator -> "No user record yet. Try another TobyBot command first."
             StartOutcome.UnknownOpponent -> "Opponent has no user record in this guild yet."
+            is StartOutcome.OnCooldown -> {
+                val seconds = ((outcome.remainingMs + 999L) / 1000L).coerceAtLeast(1L)
+                "Slow down — wait $seconds${if (seconds == 1L) " second" else " seconds"} before duelling again."
+            }
             is StartOutcome.Ok -> "OK" // unreachable
         }
     )

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/HighlowEmbeds.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/HighlowEmbeds.kt
@@ -86,6 +86,9 @@ internal object HighlowEmbeds {
             TITLE, WagerCommandFailure.InvalidStake(outcome.min, outcome.max)
         )
         PlayOutcome.UnknownUser -> WagerCommandEmbeds.failureEmbed(TITLE, WagerCommandFailure.UnknownUser)
+        is PlayOutcome.OnCooldown -> WagerCommandEmbeds.failureEmbed(
+            TITLE, WagerCommandFailure.OnCooldown(outcome.remainingMs)
+        )
     }
 
     fun errorEmbed(message: String): MessageEmbed = WagerCommandEmbeds.errorEmbed(TITLE, message)

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/KenoEmbeds.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/KenoEmbeds.kt
@@ -79,6 +79,9 @@ internal object KenoEmbeds {
             "Pick ${outcome.min}-${outcome.max} distinct numbers between 1 and ${outcome.poolMax}."
         )
         PlayOutcome.UnknownUser -> WagerCommandEmbeds.failureEmbed(TITLE, WagerCommandFailure.UnknownUser)
+        is PlayOutcome.OnCooldown -> WagerCommandEmbeds.failureEmbed(
+            TITLE, WagerCommandFailure.OnCooldown(outcome.remainingMs)
+        )
     }
 
     fun errorEmbed(message: String): MessageEmbed = WagerCommandEmbeds.errorEmbed(TITLE, message)

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/ScratchCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/ScratchCommand.kt
@@ -85,5 +85,8 @@ class ScratchCommand @Autowired constructor(
             TITLE, WagerCommandFailure.InvalidStake(outcome.min, outcome.max)
         )
         ScratchOutcome.UnknownUser -> WagerCommandEmbeds.failureEmbed(TITLE, WagerCommandFailure.UnknownUser)
+        is ScratchOutcome.OnCooldown -> WagerCommandEmbeds.failureEmbed(
+            TITLE, WagerCommandFailure.OnCooldown(outcome.remainingMs)
+        )
     }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/SlotsCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/SlotsCommand.kt
@@ -77,6 +77,9 @@ class SlotsCommand @Autowired constructor(
             TITLE, WagerCommandFailure.InvalidStake(outcome.min, outcome.max)
         )
         SpinOutcome.UnknownUser -> WagerCommandEmbeds.failureEmbed(TITLE, WagerCommandFailure.UnknownUser)
+        is SpinOutcome.OnCooldown -> WagerCommandEmbeds.failureEmbed(
+            TITLE, WagerCommandFailure.OnCooldown(outcome.remainingMs)
+        )
     }
 
     private fun reelLine(symbols: List<SlotMachine.Symbol>): String =

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/WagerCommandHelper.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/WagerCommandHelper.kt
@@ -56,6 +56,7 @@ internal sealed interface WagerCommandFailure {
     data class InsufficientCoinsForTopUp(val needed: Long, val have: Long) : WagerCommandFailure
     data class InvalidStake(val min: Long, val max: Long) : WagerCommandFailure
     data object UnknownUser : WagerCommandFailure
+    data class OnCooldown(val remainingMs: Long) : WagerCommandFailure
 }
 
 internal object WagerCommandEmbeds {
@@ -110,6 +111,10 @@ internal object WagerCommandEmbeds {
             "Stake must be between ${failure.min} and ${failure.max} credits."
         WagerCommandFailure.UnknownUser ->
             "No user record yet. Try another TobyBot command first."
+        is WagerCommandFailure.OnCooldown -> {
+            val seconds = ((failure.remainingMs + 999L) / 1000L).coerceAtLeast(1L)
+            "Slow down — wait $seconds${if (seconds == 1L) " second" else " seconds"} before playing again."
+        }
     }
 
     /**

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/moderation/JackpotAdminCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/moderation/JackpotAdminCommand.kt
@@ -1,0 +1,122 @@
+package bot.toby.command.commands.moderation
+
+import core.command.Command.Companion.invokeDeleteOnMessageResponse
+import core.command.CommandContext
+import database.dto.UserDto
+import database.service.CasinoAdminService
+import database.service.JackpotService
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
+import net.dv8tion.jda.api.interactions.commands.OptionType
+import net.dv8tion.jda.api.interactions.commands.build.OptionData
+import net.dv8tion.jda.api.interactions.commands.build.SubcommandData
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+/**
+ * Owner / superuser admin command for jackpot remediation. Mirrors the
+ * `/moderation` casino tab in the web UI: drain the per-guild jackpot
+ * pool to zero, or claw an exploit refund back into it from a player.
+ *
+ * Permission gate matches `SetConfigCommand`: guild owner only, with
+ * superuser bypass via the existing `requestingUserDto.superUser` flag.
+ */
+@Component
+class JackpotAdminCommand @Autowired constructor(
+    private val casinoAdminService: CasinoAdminService,
+    private val jackpotService: JackpotService,
+) : ModerationCommand {
+
+    override val name: String = "jackpotadmin"
+    override val description: String = "Owner-only jackpot remediation (reset pool, refund from a user)."
+
+    override val subCommands: List<SubcommandData> = listOf(
+        SubcommandData(SUB_RESET, "Drain the jackpot pool to zero."),
+        SubcommandData(SUB_REFUND, "Debit a user and deposit the amount into the jackpot pool.")
+            .addOptions(
+                OptionData(OptionType.USER, OPT_USER, "User to debit", true),
+                OptionData(OptionType.INTEGER, OPT_AMOUNT, "Credits to move into the jackpot pool", true)
+                    .setMinValue(1L),
+            ),
+        SubcommandData(SUB_POOL, "Show the current jackpot pool size."),
+    )
+
+    override fun handle(ctx: CommandContext, requestingUserDto: UserDto, deleteDelay: Int) {
+        val event = ctx.event
+        event.deferReply(true).queue()
+        val guildId = event.guild?.idLong ?: run {
+            event.hook.sendMessage("Guild only.").setEphemeral(true)
+                .queue(invokeDeleteOnMessageResponse(deleteDelay))
+            return
+        }
+        if (!isAuthorised(ctx, requestingUserDto)) {
+            event.hook.sendMessage("Server owner or superuser only.")
+                .setEphemeral(true)
+                .queue(invokeDeleteOnMessageResponse(deleteDelay))
+            return
+        }
+        when (event.subcommandName) {
+            SUB_RESET -> handleReset(event, guildId, deleteDelay)
+            SUB_REFUND -> handleRefund(event, guildId, deleteDelay)
+            SUB_POOL -> handlePool(event, guildId, deleteDelay)
+            else -> event.hook.sendMessage("Pick a subcommand: $SUB_RESET / $SUB_REFUND / $SUB_POOL.")
+                .setEphemeral(true)
+                .queue(invokeDeleteOnMessageResponse(deleteDelay))
+        }
+    }
+
+    private fun isAuthorised(ctx: CommandContext, requestingUserDto: UserDto): Boolean =
+        ctx.member?.isOwner == true || requestingUserDto.superUser == true
+
+    private fun handleReset(event: SlashCommandInteractionEvent, guildId: Long, deleteDelay: Int) {
+        val drained = casinoAdminService.resetJackpot(guildId)
+        val message = if (drained == 0L) "Jackpot pool was already empty."
+            else "Reset jackpot pool. Drained **$drained** credits."
+        event.hook.sendMessage(message).setEphemeral(true)
+            .queue(invokeDeleteOnMessageResponse(deleteDelay))
+    }
+
+    private fun handleRefund(event: SlashCommandInteractionEvent, guildId: Long, deleteDelay: Int) {
+        val target = event.getOption(OPT_USER)?.asUser ?: run {
+            replyError(event, "User option missing.", deleteDelay); return
+        }
+        val amount = event.getOption(OPT_AMOUNT)?.asLong ?: run {
+            replyError(event, "Amount option missing.", deleteDelay); return
+        }
+        when (val result = casinoAdminService.refundToJackpot(target.idLong, guildId, amount)) {
+            is CasinoAdminService.RefundOutcome.Ok -> event.hook.sendMessage(
+                "Refunded **${result.drained}** credits from ${target.asMention} into the jackpot. " +
+                    "New pool: **${result.newPool}**. New balance: **${result.newSourceBalance}**."
+            ).setEphemeral(true).queue(invokeDeleteOnMessageResponse(deleteDelay))
+            CasinoAdminService.RefundOutcome.UnknownUser ->
+                replyError(event, "${target.asMention} has no record in this guild.", deleteDelay)
+            is CasinoAdminService.RefundOutcome.Insufficient ->
+                replyError(
+                    event,
+                    "${target.asMention} has only **${result.have}** credits, can't refund **${result.needed}**.",
+                    deleteDelay,
+                )
+            is CasinoAdminService.RefundOutcome.InvalidAmount ->
+                replyError(event, "Amount must be positive.", deleteDelay)
+        }
+    }
+
+    private fun handlePool(event: SlashCommandInteractionEvent, guildId: Long, deleteDelay: Int) {
+        val pool = jackpotService.getPool(guildId)
+        event.hook.sendMessage("Current jackpot pool: **$pool** credits.")
+            .setEphemeral(true)
+            .queue(invokeDeleteOnMessageResponse(deleteDelay))
+    }
+
+    private fun replyError(event: SlashCommandInteractionEvent, message: String, deleteDelay: Int) {
+        event.hook.sendMessage(message).setEphemeral(true)
+            .queue(invokeDeleteOnMessageResponse(deleteDelay))
+    }
+
+    companion object {
+        const val SUB_RESET = "reset"
+        const val SUB_REFUND = "refund"
+        const val SUB_POOL = "pool"
+        const val OPT_USER = "user"
+        const val OPT_AMOUNT = "amount"
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/moderation/SetConfigCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/moderation/SetConfigCommand.kt
@@ -107,6 +107,11 @@ class SetConfigCommand @Autowired constructor(
                     label = "blackjack payout denominator", range = 1..10)
                 ConfigDto.Configurations.UBI_DAILY_AMOUNT -> setUbiDailyAmount(event, optionMapping, deleteDelay)
                 ConfigDto.Configurations.DAILY_CREDIT_CAP -> setDailyCreditCap(event, optionMapping, deleteDelay)
+                ConfigDto.Configurations.CASINO_COOLDOWN_SECONDS -> setRangedIntConfig(
+                    event, optionMapping, deleteDelay,
+                    config = ConfigDto.Configurations.CASINO_COOLDOWN_SECONDS,
+                    gameLabel = "Casino", label = "cooldown seconds", range = 0..30,
+                )
             }
         }
     }
@@ -547,5 +552,8 @@ class SetConfigCommand @Autowired constructor(
                 "Override for the daily social-credit cap that applies to voice/command/intro earnings. Default 90.",
                 false
             )
+            // CASINO_COOLDOWN_SECONDS deliberately not exposed here — JDA caps slash
+            // commands at 25 options. Set it via the /moderation web admin Casino tab,
+            // or by upserting the config row directly.
         )
 }

--- a/web/src/main/kotlin/web/casino/CasinoOutcomeMapper.kt
+++ b/web/src/main/kotlin/web/casino/CasinoOutcomeMapper.kt
@@ -46,15 +46,23 @@ class CasinoOutcomeMapper<R : CasinoResponseLike>(
     fun unknownUser(): ResponseEntity<R> =
         ResponseEntity.badRequest().body(errorFactory(UNKNOWN_USER))
 
+    fun onCooldown(remainingMs: Long): ResponseEntity<R> {
+        val seconds = ((remainingMs + 999L) / 1000L).coerceAtLeast(1L)
+        return ResponseEntity.status(429)
+            .header("Retry-After", seconds.toString())
+            .body(errorFactory(onCooldownMessage(seconds)))
+    }
+
     fun badRequest(message: String): ResponseEntity<R> =
         ResponseEntity.badRequest().body(errorFactory(message))
 
     /**
-     * Single-arm fallthrough for the four standard failure types every
+     * Single-arm fallthrough for the standard failure types every
      * casino-game service exposes. Each per-game outcome's
      * `InsufficientCredits` / `InsufficientCoinsForTopUp` / `InvalidStake`
-     * / `UnknownUser` implements the matching [CasinoCommonFailure]
-     * interface, so a controller's `when` can collapse four arms into one
+     * / `UnknownUser` / `OnCooldown` implements the matching
+     * [CasinoCommonFailure] interface, so a controller's `when` can
+     * collapse multiple arms into one
      * `is CasinoCommonFailure -> errors.mapCommonFailure(outcome)`.
      */
     fun mapCommonFailure(failure: CasinoCommonFailure): ResponseEntity<R> = when (failure) {
@@ -62,6 +70,7 @@ class CasinoOutcomeMapper<R : CasinoResponseLike>(
         is CasinoCommonFailure.InsufficientCoinsForTopUp -> insufficientCoinsForTopUp(failure.needed, failure.have)
         is CasinoCommonFailure.InvalidStake -> invalidStake(failure.min, failure.max)
         is CasinoCommonFailure.UnknownUser -> unknownUser()
+        is CasinoCommonFailure.OnCooldown -> onCooldown(failure.remainingMs)
     }
 
     companion object {
@@ -80,5 +89,8 @@ class CasinoOutcomeMapper<R : CasinoResponseLike>(
 
         fun invalidStakeMessage(min: Long, max: Long): String =
             "Stake must be between $min and $max credits."
+
+        fun onCooldownMessage(seconds: Long): String =
+            "Slow down — wait $seconds${if (seconds == 1L) " second" else " seconds"} before playing again."
     }
 }

--- a/web/src/main/kotlin/web/controller/BlackjackController.kt
+++ b/web/src/main/kotlin/web/controller/BlackjackController.kt
@@ -223,6 +223,7 @@ class BlackjackController(
             is SoloDealOutcome.HandInProgress ->
                 errors.badRequest("Finish your current hand before dealing a new one.")
             SoloDealOutcome.UnknownUser -> errors.unknownUser()
+            is SoloDealOutcome.OnCooldown -> errors.onCooldown(outcome.remainingMs)
         }
     }
 

--- a/web/src/main/kotlin/web/controller/DuelController.kt
+++ b/web/src/main/kotlin/web/controller/DuelController.kt
@@ -287,6 +287,10 @@ class DuelController(
             "Opponent only has ${outcome.have} credits — they can't cover a ${outcome.needed} stake."
         StartOutcome.UnknownInitiator -> "No user record yet. Try another TobyBot command first."
         StartOutcome.UnknownOpponent -> "Opponent has no user record in this guild yet."
+        is StartOutcome.OnCooldown -> {
+            val seconds = ((outcome.remainingMs + 999L) / 1000L).coerceAtLeast(1L)
+            "Slow down — wait $seconds${if (seconds == 1L) " second" else " seconds"} before duelling again."
+        }
         is StartOutcome.Ok -> "OK"
     }
 }

--- a/web/src/main/kotlin/web/controller/KenoController.kt
+++ b/web/src/main/kotlin/web/controller/KenoController.kt
@@ -132,6 +132,7 @@ class KenoController(
                 "Pick ${outcome.min}-${outcome.max} distinct numbers between 1 and ${outcome.poolMax}."
             )
             PlayOutcome.UnknownUser -> errors.unknownUser()
+            is PlayOutcome.OnCooldown -> errors.onCooldown(outcome.remainingMs)
         }
     }
 }

--- a/web/src/main/kotlin/web/controller/ModerationController.kt
+++ b/web/src/main/kotlin/web/controller/ModerationController.kt
@@ -71,6 +71,7 @@ class ModerationController(
         model.addAttribute("isOwner", moderationWebService.isOwner(discordId, guildId))
         model.addAttribute("username", user.displayName())
         model.addAttribute("actorDiscordId", discordId.toString())
+        model.addAttribute("jackpotPool", moderationWebService.getJackpotPool(guildId))
         "moderation"
     }
 
@@ -171,6 +172,43 @@ class ModerationController(
         }
     }
 
+    @PostMapping("/{guildId}/jackpot/reset", consumes = ["application/json"])
+    @ResponseBody
+    fun resetJackpot(
+        @PathVariable guildId: Long,
+        @AuthenticationPrincipal user: OAuth2User
+    ): ResponseEntity<JackpotAdminResponse> = WebGuildAccess.requireSignedInForJson(
+        user, { JackpotAdminResponse(false, "Not signed in.") }
+    ) { actor ->
+        val result = moderationWebService.resetJackpotPool(actor, guildId)
+        if (result.error != null) {
+            ResponseEntity.badRequest().body(JackpotAdminResponse(false, result.error, drained = result.drained, newPool = result.newPool))
+        } else {
+            ResponseEntity.ok(JackpotAdminResponse(true, null, drained = result.drained, newPool = result.newPool))
+        }
+    }
+
+    @PostMapping("/{guildId}/jackpot/refund", consumes = ["application/json"])
+    @ResponseBody
+    fun refundJackpot(
+        @PathVariable guildId: Long,
+        @RequestBody body: JackpotRefundRequest,
+        @AuthenticationPrincipal user: OAuth2User
+    ): ResponseEntity<JackpotAdminResponse> = WebGuildAccess.requireSignedInForJson(
+        user, { JackpotAdminResponse(false, "Not signed in.") }
+    ) { actor ->
+        val result = moderationWebService.refundJackpotFromUser(actor, guildId, body.sourceDiscordId, body.amount)
+        if (result.error != null) {
+            ResponseEntity.badRequest().body(
+                JackpotAdminResponse(false, result.error, drained = result.drained, newPool = result.newPool, newSourceBalance = result.newSourceBalance)
+            )
+        } else {
+            ResponseEntity.ok(
+                JackpotAdminResponse(true, null, drained = result.drained, newPool = result.newPool, newSourceBalance = result.newSourceBalance)
+            )
+        }
+    }
+
     @PostMapping("/{guildId}/poll", consumes = ["application/json"])
     @ResponseBody
     fun createPoll(
@@ -208,4 +246,17 @@ data class MuteResponse(
     val error: String?,
     val changed: List<String> = emptyList(),
     val skipped: List<String> = emptyList()
+)
+
+data class JackpotRefundRequest(
+    val sourceDiscordId: Long = 0L,
+    val amount: Long = 0L,
+)
+
+data class JackpotAdminResponse(
+    val ok: Boolean,
+    val error: String?,
+    val drained: Long = 0L,
+    val newPool: Long = 0L,
+    val newSourceBalance: Long? = null,
 )

--- a/web/src/main/kotlin/web/service/ModerationWebService.kt
+++ b/web/src/main/kotlin/web/service/ModerationWebService.kt
@@ -4,7 +4,9 @@ import common.events.ActivityTrackingEnabled
 import common.logging.DiscordLogger
 import database.dto.ConfigDto
 import database.dto.UserDto
+import database.service.CasinoAdminService
 import database.service.ConfigService
+import database.service.JackpotService
 import database.service.MonthlyCreditSnapshotService
 import database.service.TitleService
 import database.service.UbiDailyService
@@ -30,6 +32,8 @@ class ModerationWebService(
     private val titleService: TitleService,
     private val snapshotService: MonthlyCreditSnapshotService,
     private val ubiDailyService: UbiDailyService,
+    private val jackpotService: JackpotService,
+    private val casinoAdminService: CasinoAdminService,
     private val eventPublisher: ApplicationEventPublisher
 ) {
     companion object {
@@ -241,6 +245,69 @@ class ModerationWebService(
         return null
     }
 
+    /** Current per-guild jackpot pool size; for the admin tab banner. */
+    fun getJackpotPool(guildId: Long): Long = jackpotService.getPool(guildId)
+
+    /**
+     * Reset (zero) the per-guild jackpot pool. Returns null on success
+     * with [drained] populated; non-null on permission failure.
+     */
+    data class ResetJackpotResult(val error: String?, val drained: Long, val newPool: Long)
+    fun resetJackpotPool(actorDiscordId: Long, guildId: Long): ResetJackpotResult {
+        if (!canModerate(actorDiscordId, guildId)) {
+            return ResetJackpotResult("You are not allowed to moderate this server.", 0L, jackpotService.getPool(guildId))
+        }
+        val drained = casinoAdminService.resetJackpot(guildId)
+        logger.info("Casino admin reset jackpot for guild=$guildId by actor=$actorDiscordId, drained=$drained")
+        return ResetJackpotResult(null, drained, 0L)
+    }
+
+    /**
+     * Debit [amount] from [sourceDiscordId] and deposit it into the
+     * per-guild jackpot pool. Used to claw back exploit gains and
+     * return them to the pool that funded them.
+     */
+    data class RefundJackpotResult(
+        val error: String?,
+        val drained: Long,
+        val newPool: Long,
+        val newSourceBalance: Long,
+    )
+    fun refundJackpotFromUser(
+        actorDiscordId: Long,
+        guildId: Long,
+        sourceDiscordId: Long,
+        amount: Long,
+    ): RefundJackpotResult {
+        if (!canModerate(actorDiscordId, guildId)) {
+            return RefundJackpotResult(
+                "You are not allowed to moderate this server.",
+                0L, jackpotService.getPool(guildId), 0L,
+            )
+        }
+        if (amount <= 0L) {
+            return RefundJackpotResult("Amount must be positive.", 0L, jackpotService.getPool(guildId), 0L)
+        }
+        return when (val outcome = casinoAdminService.refundToJackpot(sourceDiscordId, guildId, amount)) {
+            is CasinoAdminService.RefundOutcome.Ok -> {
+                logger.info(
+                    "Casino admin refund-to-jackpot guild=$guildId actor=$actorDiscordId " +
+                        "source=$sourceDiscordId amount=${outcome.drained} newPool=${outcome.newPool}"
+                )
+                RefundJackpotResult(null, outcome.drained, outcome.newPool, outcome.newSourceBalance)
+            }
+            CasinoAdminService.RefundOutcome.UnknownUser ->
+                RefundJackpotResult("Source user has no record in this server.", 0L, jackpotService.getPool(guildId), 0L)
+            is CasinoAdminService.RefundOutcome.Insufficient ->
+                RefundJackpotResult(
+                    "Source user has only ${outcome.have} credits, can't refund ${outcome.needed}.",
+                    0L, jackpotService.getPool(guildId), outcome.have,
+                )
+            is CasinoAdminService.RefundOutcome.InvalidAmount ->
+                RefundJackpotResult("Amount must be positive.", 0L, jackpotService.getPool(guildId), 0L)
+        }
+    }
+
     fun updateConfig(
         actorDiscordId: Long,
         guildId: Long,
@@ -383,6 +450,12 @@ class ModerationWebService(
                 val n = rawValue.trim().toIntOrNull()
                     ?: return "Value must be a whole number (0-10000)."
                 if (n !in 0..10000) return "Value must be between 0 and 10000 (default 90)."
+                n.toString()
+            }
+            ConfigDto.Configurations.CASINO_COOLDOWN_SECONDS -> {
+                val n = rawValue.trim().toIntOrNull()
+                    ?: return "Value must be a whole number (0-30)."
+                if (n !in 0..30) return "Value must be between 0 and 30 (0 disables cooldown)."
                 n.toString()
             }
         }

--- a/web/src/main/resources/static/js/moderation.js
+++ b/web/src/main/resources/static/js/moderation.js
@@ -270,4 +270,59 @@
             }).catch(() => { submitBtn.disabled = false; toast('Network error.', 'error'); });
         });
     }
+
+    // --- Casino tab ---
+    const jackpotPoolEl = document.getElementById('jackpot-pool');
+    const jackpotResetBtn = document.getElementById('jackpot-reset');
+    if (jackpotResetBtn) {
+        jackpotResetBtn.addEventListener('click', () => {
+            const current = Number(jackpotPoolEl?.textContent || '0');
+            if (current === 0) {
+                toast('Pool is already empty.', 'info');
+                return;
+            }
+            if (!confirm('Reset the jackpot pool to 0? This drains ' + current + ' credits.')) return;
+            jackpotResetBtn.disabled = true;
+            postJson('/moderation/' + guildId + '/jackpot/reset', {}).then(r => {
+                jackpotResetBtn.disabled = false;
+                if (r && r.ok) {
+                    if (jackpotPoolEl) jackpotPoolEl.textContent = String(r.newPool ?? 0);
+                    toast('Jackpot reset. Drained ' + (r.drained ?? 0) + ' credits.', 'success');
+                } else {
+                    toast(r?.error || 'Could not reset jackpot.', 'error');
+                }
+            }).catch(() => { jackpotResetBtn.disabled = false; toast('Network error.', 'error'); });
+        });
+    }
+    const jackpotRefundForm = document.querySelector('.jackpot-refund-form');
+    if (jackpotRefundForm) {
+        jackpotRefundForm.addEventListener('submit', e => {
+            e.preventDefault();
+            const sourceDiscordId = jackpotRefundForm.elements.sourceDiscordId.value.trim();
+            const amount = Number(jackpotRefundForm.elements.amount.value);
+            if (!/^[0-9]+$/.test(sourceDiscordId) || !Number.isFinite(amount) || amount <= 0) {
+                toast('Enter a valid Discord ID and a positive amount.', 'error');
+                return;
+            }
+            if (!confirm('Refund ' + amount + ' credits from user ' + sourceDiscordId + ' into the jackpot pool?')) return;
+            const submitBtn = jackpotRefundForm.querySelector('button[type="submit"]');
+            submitBtn.disabled = true;
+            postJson('/moderation/' + guildId + '/jackpot/refund', {
+                sourceDiscordId: Number(sourceDiscordId),
+                amount: amount
+            }).then(r => {
+                submitBtn.disabled = false;
+                if (r && r.ok) {
+                    if (jackpotPoolEl) jackpotPoolEl.textContent = String(r.newPool ?? 0);
+                    toast(
+                        'Refunded ' + (r.drained ?? 0) + ' credits. New pool: ' + (r.newPool ?? 0) + '.',
+                        'success'
+                    );
+                    jackpotRefundForm.reset();
+                } else {
+                    toast(r?.error || 'Could not refund to jackpot.', 'error');
+                }
+            }).catch(() => { submitBtn.disabled = false; toast('Network error.', 'error'); });
+        });
+    }
 })();

--- a/web/src/main/resources/templates/fragments/casino.html
+++ b/web/src/main/resources/templates/fragments/casino.html
@@ -11,9 +11,9 @@
     🎰 Jackpot pool:
     <strong th:text="${jackpotPool}">0</strong> credits
     <span class="muted">
-        — win any minigame for a
+        — win any minigame for up to
         <span th:text="${#numbers.formatDecimal(jackpotWinPct, 1, 2)}">1.00</span>%
-        chance to bank the pool.
+        chance to bank the pool, scaled by your stake ÷ that game's max.
     </span>
 </div>
 </body>

--- a/web/src/main/resources/templates/moderation.html
+++ b/web/src/main/resources/templates/moderation.html
@@ -26,6 +26,7 @@
         <button class="tab-btn" data-tab="config" role="tab" aria-selected="false">Config</button>
         <button class="tab-btn" data-tab="voice" role="tab" aria-selected="false">Voice</button>
         <button class="tab-btn" data-tab="poll" role="tab" aria-selected="false">Poll</button>
+        <button class="tab-btn" data-tab="casino" role="tab" aria-selected="false">Casino</button>
     </div>
 
     <!-- USERS TAB -->
@@ -523,6 +524,50 @@
             </div>
             <button type="submit" class="btn">Post poll</button>
         </form>
+    </section>
+
+    <!-- CASINO TAB -->
+    <section class="tab-panel" data-panel="casino">
+        <p class="muted mb-4">
+            Casino remediation. Use these when a player has farmed the
+            jackpot via spam or another exploit. Per-stake jackpot
+            scaling and per-user cooldowns are now in place, but you can
+            still drain a contaminated pool or claw an exploit refund
+            back into it.
+        </p>
+        <div class="mod-card">
+            <div>
+                <h3>Current pool</h3>
+                <p class="big-number">
+                    <span id="jackpot-pool" th:text="${jackpotPool}">0</span>
+                    <span class="muted">credits</span>
+                </p>
+            </div>
+        </div>
+        <div class="mod-card">
+            <h3>Reset jackpot pool</h3>
+            <p class="muted">Zero the pool. The drained amount is logged.</p>
+            <button id="jackpot-reset" type="button" class="btn btn-warning">Reset pool</button>
+        </div>
+        <div class="mod-card">
+            <h3>Refund from user</h3>
+            <p class="muted">
+                Debit a user's social credit by the given amount and
+                deposit it back into the jackpot pool. Use after a
+                clawback when the player profited from a spent pool.
+            </p>
+            <form class="jackpot-refund-form" autocomplete="off">
+                <label>
+                    User Discord ID
+                    <input type="text" name="sourceDiscordId" inputmode="numeric" pattern="[0-9]+" required>
+                </label>
+                <label>
+                    Amount
+                    <input type="number" name="amount" min="1" required>
+                </label>
+                <button type="submit" class="btn">Refund to jackpot</button>
+            </form>
+        </div>
     </section>
 </main>
 

--- a/web/src/test/kotlin/web/service/ModerationWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/ModerationWebServiceTest.kt
@@ -41,6 +41,8 @@ class ModerationWebServiceTest {
     private lateinit var titleService: TitleService
     private lateinit var snapshotService: MonthlyCreditSnapshotService
     private lateinit var ubiDailyService: UbiDailyService
+    private lateinit var jackpotService: database.service.JackpotService
+    private lateinit var casinoAdminService: database.service.CasinoAdminService
     private lateinit var service: ModerationWebService
 
     private lateinit var guild: Guild
@@ -63,6 +65,8 @@ class ModerationWebServiceTest {
         titleService = mockk(relaxed = true)
         snapshotService = mockk(relaxed = true)
         ubiDailyService = mockk(relaxed = true)
+        jackpotService = mockk(relaxed = true)
+        casinoAdminService = mockk(relaxed = true)
         eventPublisher = mockk(relaxed = true)
         guild = mockk(relaxed = true)
         service = ModerationWebService(
@@ -74,6 +78,8 @@ class ModerationWebServiceTest {
             titleService,
             snapshotService,
             ubiDailyService,
+            jackpotService,
+            casinoAdminService,
             eventPublisher
         )
 


### PR DESCRIPTION
## Summary

A player set up an autoclicker on `/coinflip` with the minimum wager (10 credits) and ran it all day to farm the per-guild jackpot pool. Every casino-game win rolled a flat 1 % jackpot regardless of stake size, so a 10-credit flip had identical hit odds to a 1000-credit bet — and there was no per-user cooldown to throttle the spam.

This PR adds three layers of defence (all enforced at the service layer so Discord and web inherit them together) plus admin remediation in both surfaces.

### 1. Per-user, per-game cooldown
- `CasinoCooldownService` — process-local map keyed `(discordId, gameKey)`. 3 s default, 0–30 s clamp, configurable via new `CASINO_COOLDOWN_SECONDS` config.
- Hooked into `WagerHelper.checkLockOrTopUp` so all 7 single-shot services (coinflip, slots, dice, highlow, scratch, baccarat, keno) and solo blackjack + duel pick it up uniformly.
- Cooldown arms **only on a successful debit** — typos and cap rejections don't punish the player.
- New `CasinoCommonFailure.OnCooldown` variant; `CasinoOutcomeMapper` returns HTTP 429 with `Retry-After` for web, Discord embeds get a friendly "Slow down — wait Ns" message.

### 2. Stake-weighted jackpot probability
- `JackpotHelper.rollOnWin` now scales the base probability linearly by `stake / maxStake`. A 10/1000 coinflip rolls at 0.01 % effective; a 1000/1000 coinflip rolls at the unscaled 1 % base.
- Per-game `MAX_STAKE` is read from each game's existing constant, so no new config knob.
- Kills the autoclicker math: min-wager spam yields essentially zero jackpot rolls regardless of how many spins.

### 3. Admin remediation (Discord + web)
- `JackpotService.resetPool(guildId)` drains the pool to zero atomically.
- New `CasinoAdminService.refundToJackpot` debits a user and deposits the same amount back into the pool — for clawing exploit gains back into the pool that funded them.
- **Web**: new "Casino" tab on the moderation page with pool readout, reset button, and refund-from-user form, all behind `canModerate`.
- **Discord**: new `/jackpotadmin` command with `reset` / `refund` / `pool` subcommands, owner-or-superuser gated.

The reporter's original autoclicker would now hit a 3 s cooldown between each flip *and* have its jackpot odds scaled to ~0 %, breaking the farm in two ways at once.

## Test plan

- [x] `JackpotHelperTest` — added 4 stake-weighting cases (min-wager scales to 0.01 %, full stake at base prob, clamp when stake > maxStake, divide-by-zero guard)
- [x] `CasinoCooldownServiceTest` (new) — first-call passes, blocks within window, unblocks after, per-user/per-game isolation, 0 disables, clamp at max, unparseable falls back, `reset(discordId)` is scoped
- [x] `JackpotServiceTest` — added `resetPool` drains-and-zeroes / no-op-when-empty cases
- [x] All 7 game-service tests updated to pass a relaxed-mock `CasinoCooldownService` to the constructor
- [x] `ModerationWebServiceTest` updated for the new `JackpotService` / `CasinoAdminService` collaborators
- [ ] Manual: set `CASINO_COOLDOWN_SECONDS=3`, spam `/coinflip` from one user, observe the cooldown embed between successes
- [ ] Manual: set `JACKPOT_WIN_PCT=10`, run 1000 wins at stake=10 (max=1000) → ~10 jackpot hits; rerun at stake=1000 → ~100 hits
- [ ] Manual: `/jackpotadmin reset`, then `/jackpotadmin pool` → 0
- [ ] Manual: open `/moderation/{guildId}`, switch to Casino tab, click Reset pool, refresh — pool shows 0
- [ ] Manual: open `/moderation/{guildId}`, refund N credits from user X — user balance drops by N, pool rises by N

https://claude.ai/code/session_01DEmGkVYCPgGWGGZUXXXmM1

---
_Generated by [Claude Code](https://claude.ai/code/session_01DEmGkVYCPgGWGGZUXXXmM1)_