### PR TITLE
fix(blackjack): reject mid-hand redeal, harden splits, slow dealer reveal

### DIFF
--- a/database/src/main/kotlin/database/service/BlackjackService.kt
+++ b/database/src/main/kotlin/database/service/BlackjackService.kt
@@ -85,6 +85,12 @@ class BlackjackService @Autowired constructor(
         data class InsufficientCredits(val stake: Long, val have: Long) : SoloDealOutcome
         /** [autoTopUp] = true but the player's TOBY can't cover the credit shortfall. */
         data class InsufficientCoinsForTopUp(val needed: Long, val have: Long) : SoloDealOutcome
+        /**
+         * Caller already has an in-flight (non-RESOLVED) solo table on this
+         * guild. Reject the redeal so the wallet isn't double-debited and
+         * the previous table isn't orphaned in the registry.
+         */
+        data class HandInProgress(val tableId: Long) : SoloDealOutcome
         data object UnknownUser : SoloDealOutcome
     }
 
@@ -216,6 +222,16 @@ class BlackjackService @Autowired constructor(
         stake: Long,
         autoTopUp: Boolean = false
     ): SoloDealOutcome {
+        // Reject a redeal while the caller still has an in-flight solo
+        // table on this guild — without this guard, hitting the web Deal
+        // form mid-hand would debit the stake again, orphan the previous
+        // table in the registry, and leave the wallet wonky.
+        tableRegistry.listForGuild(guildId).firstOrNull { t ->
+            t.mode == BlackjackTable.Mode.SOLO &&
+                t.phase != BlackjackTable.Phase.RESOLVED &&
+                t.seats.any { it.discordId == discordId }
+        }?.let { return SoloDealOutcome.HandInProgress(it.id) }
+
         val params = readMultiTableParams(guildId)
         val check = WagerHelper.checkAndLock(
             userService, discordId, guildId, stake, params.minAnte, params.maxAnte
@@ -417,6 +433,13 @@ class BlackjackService @Autowired constructor(
         deck: database.card.Deck,
     ) {
         val active = seat.activeHand
+        // Defensive: a stale click + the 2s state poll could land an action
+        // here against an already-terminal slot (e.g. a split branch the
+        // player has finished). The caller's pre-flight covers DOUBLE/SPLIT,
+        // and the per-call lock serialises mutations, but a HIT/STAND from
+        // an out-of-date UI would silently mutate cards on a STANDING /
+        // BUSTED / DOUBLED / BLACKJACK slot otherwise.
+        if (active.status != BlackjackTable.SeatStatus.ACTIVE) return
         when (action) {
             Blackjack.Action.HIT -> {
                 blackjack.hit(active.cards, deck)

--- a/database/src/test/kotlin/database/service/BlackjackServiceTest.kt
+++ b/database/src/test/kotlin/database/service/BlackjackServiceTest.kt
@@ -72,6 +72,21 @@ class BlackjackServiceTest {
         Blackjack.Result.DEALER_WIN, Blackjack.Result.PLAYER_BUST -> 0.0
     }
 
+    /**
+     * Build a [Deck] whose `deal()` yields the supplied cards in order.
+     * Used by SPLIT / re-SPLIT tests to control the post-split deals
+     * (which go through `t.deck.deal()` rather than `blackjack.hit`,
+     * so the existing `every { blackjack.hit ... }` stub doesn't cover
+     * them).
+     */
+    private fun stackedDeck(vararg cards: Card): Deck {
+        val deck = mockk<Deck>()
+        val q = ArrayDeque(cards.toList())
+        every { deck.deal() } answers { q.removeFirst() }
+        every { deck.size } answers { q.size }
+        return deck
+    }
+
     // -------------------------------------------------------------------------
     // SOLO
     // -------------------------------------------------------------------------
@@ -150,6 +165,44 @@ class BlackjackServiceTest {
         // Push: -100 then +100 = 0 net.
         assertEquals(1_000L, user.socialCredit)
         assertEquals(1_000L, resolved.newBalance)
+    }
+
+    @Test
+    fun `dealSolo HandInProgress when caller already has an in-flight solo table`() {
+        val user = userWithBalance(1_000L)
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns user
+        every { blackjack.dealStartingHands(any()) } returns Blackjack.StartingDeal(
+            mutableListOf(c(Rank.EIGHT), c(Rank.NINE)),
+            mutableListOf(c(Rank.KING), c(Rank.FOUR))
+        )
+        val first = service.dealSolo(discordId, guildId, stake = 50L)
+        val firstTable = assertInstanceOf(BlackjackService.SoloDealOutcome.Dealt::class.java, first)
+        assertEquals(950L, user.socialCredit, "first ante debited")
+
+        // Re-deal mid-hand (PLAYER_TURNS) is rejected — wallet untouched,
+        // existing table still present.
+        val second = service.dealSolo(discordId, guildId, stake = 50L)
+        val inProgress = assertInstanceOf(BlackjackService.SoloDealOutcome.HandInProgress::class.java, second)
+        assertEquals(firstTable.tableId, inProgress.tableId)
+        assertEquals(950L, user.socialCredit, "no second debit on rejected redeal")
+        assertNotNull(registry.get(firstTable.tableId), "previous in-flight table preserved")
+    }
+
+    @Test
+    fun `dealSolo allows a redeal once the previous solo table is RESOLVED`() {
+        val user = userWithBalance(1_000L)
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns user
+        every { userService.getUserById(discordId, guildId) } returns user
+        every { blackjack.dealStartingHands(any()) } returns Blackjack.StartingDeal(
+            mutableListOf(c(Rank.ACE), c(Rank.KING)), // natural BJ → auto-resolves
+            mutableListOf(c(Rank.NINE), c(Rank.SEVEN))
+        )
+        every { blackjack.evaluate(any(), any()) } returns Blackjack.Result.PLAYER_BLACKJACK
+        val first = service.dealSolo(discordId, guildId, stake = 50L)
+        assertInstanceOf(BlackjackService.SoloDealOutcome.Resolved::class.java, first)
+        // First hand auto-resolved; the existing sweep should let a redeal go through.
+        val second = service.dealSolo(discordId, guildId, stake = 50L)
+        assertInstanceOf(BlackjackService.SoloDealOutcome.Resolved::class.java, second)
     }
 
     @Test
@@ -889,6 +942,209 @@ class BlackjackServiceTest {
         // Two PerHandResult entries.
         assertEquals(2, resolved.result.perHandResults.size)
         assertTrue(resolved.result.perHandResults.all { it.fromSplit })
+    }
+
+    @Test
+    fun `solo SPLIT then hit hand 0 to 21 advances to hand 1 and keeps it playable`() {
+        val user = userWithBalance(1_000L)
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns user
+        every { userService.getUserById(discordId, guildId) } returns user
+        every { blackjack.dealStartingHands(any()) } returns Blackjack.StartingDeal(
+            mutableListOf(c(Rank.EIGHT), c(Rank.EIGHT, Suit.HEARTS)),
+            mutableListOf(c(Rank.SIX), c(Rank.TEN))
+        )
+        // Stack the table's deck: SPLIT pulls one card per branch off
+        // `t.deck.deal()` directly (bypassing `blackjack.hit`), so we have
+        // to control those two cards via the deck itself.
+        every { blackjack.newDeck() } returns stackedDeck(
+            c(Rank.THREE, Suit.HEARTS), // post-split deal to hand[0] → 8+3 = 11
+            c(Rank.FIVE, Suit.HEARTS)   // post-split deal to hand[1] → 8+5 = 13
+        )
+        // The subsequent HIT goes through `blackjack.hit` (mockable).
+        every { blackjack.hit(any(), any()) } answers {
+            firstArg<MutableList<Card>>().add(c(Rank.TEN, Suit.CLUBS)) // 11 + 10 = 21
+        }
+        val deal = service.dealSolo(discordId, guildId, stake = 100L)
+        val tableId = (deal as BlackjackService.SoloDealOutcome.Dealt).tableId
+
+        service.applySoloAction(discordId, guildId, tableId, Blackjack.Action.SPLIT)
+        // After SPLIT both hands are ACTIVE and the cursor sits on hand[0].
+        val seat = registry.get(tableId)!!.seats[0]
+        assertEquals(0, seat.activeHandIndex)
+        assertEquals(BlackjackTable.SeatStatus.ACTIVE, seat.hands[0].status)
+        assertEquals(BlackjackTable.SeatStatus.ACTIVE, seat.hands[1].status)
+
+        // HIT hand[0] → 21 → auto-stands → cursor advances to hand[1].
+        val hit = service.applySoloAction(discordId, guildId, tableId, Blackjack.Action.HIT)
+        assertInstanceOf(BlackjackService.SoloActionOutcome.Continued::class.java, hit)
+        assertEquals(BlackjackTable.SeatStatus.STANDING, seat.hands[0].status)
+        assertEquals(BlackjackTable.SeatStatus.ACTIVE, seat.hands[1].status)
+        assertEquals(1, seat.activeHandIndex, "cursor advanced to second split hand")
+    }
+
+    @Test
+    fun `solo SPLIT then bust hand 0 still leaves hand 1 playable`() {
+        val user = userWithBalance(1_000L)
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns user
+        every { userService.getUserById(discordId, guildId) } returns user
+        every { blackjack.dealStartingHands(any()) } returns Blackjack.StartingDeal(
+            mutableListOf(c(Rank.NINE), c(Rank.NINE, Suit.HEARTS)),
+            mutableListOf(c(Rank.SIX), c(Rank.TEN))
+        )
+        every { blackjack.newDeck() } returns stackedDeck(
+            c(Rank.SEVEN, Suit.HEARTS), // hand[0] post-split: 9+7 = 16
+            c(Rank.SIX, Suit.HEARTS)    // hand[1] post-split: 9+6 = 15
+        )
+        every { blackjack.hit(any(), any()) } answers {
+            firstArg<MutableList<Card>>().add(c(Rank.KING, Suit.CLUBS)) // 16+10 = 26 → BUST
+        }
+
+        val deal = service.dealSolo(discordId, guildId, stake = 100L)
+        val tableId = (deal as BlackjackService.SoloDealOutcome.Dealt).tableId
+        service.applySoloAction(discordId, guildId, tableId, Blackjack.Action.SPLIT)
+        val hit = service.applySoloAction(discordId, guildId, tableId, Blackjack.Action.HIT)
+        assertInstanceOf(BlackjackService.SoloActionOutcome.Continued::class.java, hit)
+        val seat = registry.get(tableId)!!.seats[0]
+        assertEquals(BlackjackTable.SeatStatus.BUSTED, seat.hands[0].status)
+        assertEquals(BlackjackTable.SeatStatus.ACTIVE, seat.hands[1].status)
+        assertEquals(1, seat.activeHandIndex)
+    }
+
+    @Test
+    fun `solo SPLIT post-split 21 is not auto-blackjack and pays 1 to 1`() {
+        // Split 10-10, get an Ace on each split → both hands look like
+        // natural blackjack but `fromSplit` should suppress the 3:2 premium.
+        // The early-frame "looks like BJ" cards must not lock out the
+        // remaining splits — both hands stay playable, then settle as
+        // regular wins on the player's turn end.
+        val user = userWithBalance(1_000L)
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns user
+        every { userService.getUserById(discordId, guildId) } returns user
+        every { blackjack.dealStartingHands(any()) } returns Blackjack.StartingDeal(
+            mutableListOf(c(Rank.TEN), c(Rank.TEN, Suit.HEARTS)),
+            mutableListOf(c(Rank.SIX), c(Rank.TEN, Suit.DIAMONDS))
+        )
+        // Stack the deck BEFORE dealSolo so newDeck() inside dealSolo
+        // returns the controlled deck rather than the default Deck(Random(0)).
+        every { blackjack.newDeck() } returns stackedDeck(
+            c(Rank.ACE, Suit.HEARTS),    // post-split deal → hand[0] = 10+A = 21
+            c(Rank.ACE, Suit.DIAMONDS)   // post-split deal → hand[1] = 10+A = 21
+        )
+        val deal = service.dealSolo(discordId, guildId, stake = 100L)
+        val tableId = (deal as BlackjackService.SoloDealOutcome.Dealt).tableId
+
+        // Solo evaluate path: each split hand is a regular win (not BJ).
+        every { blackjack.evaluate(any(), any(), any()) } answers {
+            val fromSplit = thirdArg<Boolean>()
+            // Belt-and-braces sanity check the call site honours the flag.
+            assertTrue(fromSplit, "settleSolo must pass fromSplit=true for split slots")
+            Blackjack.Result.PLAYER_WIN
+        }
+
+        service.applySoloAction(discordId, guildId, tableId, Blackjack.Action.SPLIT)
+        var seat = registry.get(tableId)!!.seats[0]
+        // Both halves are 21 but neither is auto-marked BLACKJACK / STANDING —
+        // the player still gets to act (the explicit STAND below).
+        assertEquals(BlackjackTable.SeatStatus.ACTIVE, seat.hands[0].status)
+        assertEquals(BlackjackTable.SeatStatus.ACTIVE, seat.hands[1].status)
+        assertEquals(0, seat.activeHandIndex)
+
+        val stand1 = service.applySoloAction(discordId, guildId, tableId, Blackjack.Action.STAND)
+        assertInstanceOf(BlackjackService.SoloActionOutcome.Continued::class.java, stand1)
+        seat = registry.get(tableId)!!.seats[0]
+        assertEquals(1, seat.activeHandIndex, "STAND on hand[0] advances to hand[1]")
+        assertEquals(BlackjackTable.SeatStatus.ACTIVE, seat.hands[1].status)
+
+        val stand2 = service.applySoloAction(discordId, guildId, tableId, Blackjack.Action.STAND)
+        val resolved = assertInstanceOf(BlackjackService.SoloActionOutcome.Resolved::class.java, stand2)
+        assertEquals(2, resolved.result.perHandResults.size)
+        // Two 1:1 wins on a 100 ante: -200 then +200×2 = +200 net.
+        assertEquals(1_200L, user.socialCredit)
+        assertTrue(resolved.result.perHandResults.all { it.fromSplit })
+    }
+
+    @Test
+    fun `solo re-SPLIT plays through three hand-slots and settles each one`() {
+        val user = userWithBalance(1_000L)
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns user
+        every { userService.getUserById(discordId, guildId) } returns user
+        every { blackjack.dealStartingHands(any()) } returns Blackjack.StartingDeal(
+            mutableListOf(c(Rank.EIGHT), c(Rank.EIGHT, Suit.HEARTS)),
+            mutableListOf(c(Rank.SIX), c(Rank.TEN))
+        )
+        // Sequence (cards must be stacked BEFORE dealSolo — newDeck() is
+        // called inside dealSolo and the resulting Deck is stashed on the
+        // table; later stubs would be too late to influence t.deck):
+        //  1. SPLIT 8-8 → hand[0]=8+8 (re-split candidate), hand[1]=8+5
+        //  2. SPLIT hand[0] → hand[0]=8+4, NEW hand[1]=8+6, original hand[1] shifts to hand[2]
+        //  3. STAND through all three hands.
+        every { blackjack.newDeck() } returns stackedDeck(
+            c(Rank.EIGHT, Suit.CLUBS),   // post-split-1: hand[0] gets an 8 (now 8-8 again, splittable)
+            c(Rank.FIVE, Suit.CLUBS),    // post-split-1: hand[1] gets a 5
+            c(Rank.FOUR, Suit.HEARTS),   // post-split-2: hand[0] gets a 4 → 12
+            c(Rank.SIX, Suit.HEARTS)     // post-split-2: NEW hand[1] gets a 6 → 14
+        )
+        every { blackjack.evaluate(any(), any(), any()) } returns Blackjack.Result.PLAYER_WIN
+
+        val deal = service.dealSolo(discordId, guildId, stake = 100L)
+        val tableId = (deal as BlackjackService.SoloDealOutcome.Dealt).tableId
+
+        val first = service.applySoloAction(discordId, guildId, tableId, Blackjack.Action.SPLIT)
+        assertInstanceOf(BlackjackService.SoloActionOutcome.Continued::class.java, first)
+        val second = service.applySoloAction(discordId, guildId, tableId, Blackjack.Action.SPLIT)
+        assertInstanceOf(BlackjackService.SoloActionOutcome.Continued::class.java, second)
+        var seat = registry.get(tableId)!!.seats[0]
+        assertEquals(3, seat.hands.size, "two splits produced three slots")
+        assertEquals(0, seat.activeHandIndex)
+
+        // STAND through each slot, asserting the cursor advances each time.
+        service.applySoloAction(discordId, guildId, tableId, Blackjack.Action.STAND)
+        seat = registry.get(tableId)!!.seats[0]
+        assertEquals(1, seat.activeHandIndex)
+
+        service.applySoloAction(discordId, guildId, tableId, Blackjack.Action.STAND)
+        seat = registry.get(tableId)!!.seats[0]
+        assertEquals(2, seat.activeHandIndex)
+
+        val final = service.applySoloAction(discordId, guildId, tableId, Blackjack.Action.STAND)
+        val resolved = assertInstanceOf(BlackjackService.SoloActionOutcome.Resolved::class.java, final)
+        assertEquals(3, resolved.result.perHandResults.size)
+        assertTrue(resolved.result.perHandResults.all { it.fromSplit })
+    }
+
+    @Test
+    fun `applyActionToActiveHand is a no-op against a terminal slot`() {
+        // Defensive guard: a stale UI click that lands a HIT against a
+        // STANDING / BUSTED / DOUBLED / BLACKJACK slot must not draw a
+        // new card or call `blackjack.hit`. The pre-flight (Continued /
+        // Resolved) is fine — we just don't mutate the cards.
+        val user = userWithBalance(1_000L)
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns user
+        every { userService.getUserById(discordId, guildId) } returns user
+        every { blackjack.dealStartingHands(any()) } returns Blackjack.StartingDeal(
+            mutableListOf(c(Rank.TEN), c(Rank.NINE)),
+            mutableListOf(c(Rank.SIX), c(Rank.TEN))
+        )
+        // Settlement runs once the seat is "finished"; pin to a non-BJ
+        // result so the post-settlement status assertion doesn't get
+        // overwritten with PLAYER_BLACKJACK by the relaxed default.
+        every { blackjack.evaluate(any(), any(), any()) } returns Blackjack.Result.PLAYER_WIN
+        val deal = service.dealSolo(discordId, guildId, stake = 50L)
+        val tableId = (deal as BlackjackService.SoloDealOutcome.Dealt).tableId
+
+        // Force the active slot terminal directly (mimicking a stale UI
+        // re-submit after the player has already STOOD locally).
+        val seat = registry.get(tableId)!!.seats[0]
+        seat.activeHand.status = BlackjackTable.SeatStatus.STANDING
+        val cardsBefore = seat.activeHand.cards.toList()
+
+        // A HIT here would normally mutate the slot — verify it doesn't.
+        every { blackjack.hit(any(), any()) } answers {
+            firstArg<MutableList<Card>>().add(c(Rank.TWO, Suit.HEARTS))
+        }
+        service.applySoloAction(discordId, guildId, tableId, Blackjack.Action.HIT)
+        assertEquals(cardsBefore, seat.activeHand.cards, "no card drawn against terminal slot")
+        verify(exactly = 0) { blackjack.hit(any(), any()) }
     }
 
     @Test

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/BlackjackCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/BlackjackCommand.kt
@@ -159,6 +159,9 @@ class BlackjackCommand @Autowired constructor(
             is SoloDealOutcome.InsufficientCoinsForTopUp -> replyFailure(
                 event, WagerCommandFailure.InsufficientCoinsForTopUp(outcome.needed, outcome.have), deleteDelay
             )
+            is SoloDealOutcome.HandInProgress -> replyError(
+                event, "Finish your current hand before dealing a new one.", deleteDelay
+            )
             SoloDealOutcome.UnknownUser -> replyFailure(
                 event, WagerCommandFailure.UnknownUser, deleteDelay
             )

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/economy/BlackjackCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/economy/BlackjackCommandTest.kt
@@ -119,6 +119,22 @@ internal class BlackjackCommandTest : CommandTest {
     }
 
     @Test
+    fun `solo subcommand surfaces HandInProgress as an inline error embed`() {
+        val user = UserDto(discordId = discordId, guildId = guildId)
+        every { event.subcommandName } returns "solo"
+        every { event.getOption("stake") } returns intOpt(50L)
+        every { service.dealSolo(discordId, guildId, 50L) } returns
+            BlackjackService.SoloDealOutcome.HandInProgress(tableId = 11L)
+
+        command.handle(DefaultCommandContext(event), user, 5)
+
+        // No play embed / action row when the redeal is rejected; the user
+        // gets the standard error reply path instead.
+        verify(exactly = 1) { service.dealSolo(discordId, guildId, 50L) }
+        verify(exactly = 0) { webhookMessageCreateAction.addComponents(any<ActionRow>()) }
+    }
+
+    @Test
     fun `solo subcommand without a stake never calls the service`() {
         val user = UserDto(discordId = discordId, guildId = guildId)
         every { event.subcommandName } returns "solo"

--- a/web/src/main/kotlin/web/controller/BlackjackController.kt
+++ b/web/src/main/kotlin/web/controller/BlackjackController.kt
@@ -220,6 +220,8 @@ class BlackjackController(
             is SoloDealOutcome.InvalidStake -> errors.invalidStake(outcome.min, outcome.max)
             is SoloDealOutcome.InsufficientCredits -> errors.insufficientCredits(outcome.stake, outcome.have)
             is SoloDealOutcome.InsufficientCoinsForTopUp -> errors.insufficientCoinsForTopUp(outcome.needed, outcome.have)
+            is SoloDealOutcome.HandInProgress ->
+                errors.badRequest("Finish your current hand before dealing a new one.")
             SoloDealOutcome.UnknownUser -> errors.unknownUser()
         }
     }

--- a/web/src/main/resources/static/css/casino-table.css
+++ b/web/src/main/resources/static/css/casino-table.css
@@ -331,6 +331,28 @@
 
 .casino-card-glyph.is-dealt {
     animation: casino-deal 280ms ease-out;
+    animation-fill-mode: backwards;
+}
+
+/* Hole-card flip / dealer-draw reveal. Cards that arrive *after* the
+   first fresh card in a render get this variant — the hole card flips
+   on the spot, then subsequent draws fan in with the same flip rather
+   than the slide-from-corner used for the initial deal. */
+@keyframes casino-reveal {
+    from {
+        transform: rotateY(90deg) scale(0.95);
+        opacity: 0;
+    }
+    to {
+        transform: none;
+        opacity: 1;
+    }
+}
+
+.casino-card-glyph.is-dealt.is-revealed {
+    animation: casino-reveal 320ms ease-out;
+    animation-fill-mode: backwards;
+    backface-visibility: hidden;
 }
 
 /* ------------------------------------------------------------------- */
@@ -437,7 +459,8 @@
     .casino-seat.is-active {
         animation: none;
     }
-    .casino-card-glyph.is-dealt {
+    .casino-card-glyph.is-dealt,
+    .casino-card-glyph.is-dealt.is-revealed {
         animation: none;
     }
     .casino-chip,

--- a/web/src/main/resources/static/js/blackjack-solo.js
+++ b/web/src/main/resources/static/js/blackjack-solo.js
@@ -6,12 +6,14 @@
     // even though the page-init code below early-returns when the
     // blackjack-solo template isn't present). -----
 
-    function renderCards(container, cards) {
+    var DEALER_REVEAL_STAGGER_MS = 400;
+
+    function renderCards(container, cards, opts) {
         // Delegate to the shared casino renderer so the deal animation only
         // fires on freshly arrived cards (not every poll re-render). Falls
         // back to the legacy text glyphs if the shared module didn't load.
         if (window.CasinoRender) {
-            window.CasinoRender.renderCards(container, cards);
+            window.CasinoRender.renderCards(container, cards, opts);
             return;
         }
         container.innerHTML = "";
@@ -113,6 +115,7 @@
     var guildId = main.dataset.guildId;
 
     var dealForm = document.getElementById("bj-deal");
+    var dealButton = document.getElementById("bj-deal-button");
     var stakeInput = document.getElementById("bj-stake");
     var balanceEl = document.getElementById("bj-balance");
     var tableEl = document.getElementById("bj-table");
@@ -134,7 +137,18 @@
     function renderState(state) {
         if (!state) return;
         tableEl.hidden = false;
-        renderCards(dealerCardsEl, state.dealer);
+        // Lock the Deal button while a hand is in flight. The server enforces
+        // this too (SoloDealOutcome.HandInProgress), but disabling the
+        // control client-side avoids the "I clicked Deal twice and the
+        // wallet went weird" footgun the user reported.
+        if (dealButton) {
+            var inFlight = state.phase === "PLAYER_TURNS" || state.phase === "DEALER_TURN";
+            dealButton.disabled = inFlight;
+        }
+        // Slow the dealer's reveal/play-out so the hole card flips first
+        // and each subsequent draw arrives with a clear beat between
+        // cards, instead of everything popping in on the same frame.
+        renderCards(dealerCardsEl, state.dealer, { staggerMs: DEALER_REVEAL_STAGGER_MS });
         dealerTotalEl.textContent = state.dealer && state.dealer.length
             ? "(" + state.dealerTotalVisible + ")" : "";
 

--- a/web/src/main/resources/static/js/blackjack-table.js
+++ b/web/src/main/resources/static/js/blackjack-table.js
@@ -37,13 +37,15 @@
     // reuse where handNumber alone could collide.
     var lastFlashedKey = null;
 
-    function renderCards(container, cards) {
+    var DEALER_REVEAL_STAGGER_MS = 400;
+
+    function renderCards(container, cards, opts) {
         // Delegate to the shared renderer so the per-container deal animation
         // book-keeping is consistent with poker. The shared renderer applies
         // .casino-card-glyph and the .is-dealt animation only on freshly arrived
         // cards.
         if (window.CasinoRender) {
-            window.CasinoRender.renderCards(container, cards);
+            window.CasinoRender.renderCards(container, cards, opts);
             return;
         }
         // Fallback (loaded out of order) — keep the legacy text-glyph render.
@@ -143,7 +145,10 @@
     function renderState(state) {
         phaseEl.textContent = state.phase;
         handNumberEl.textContent = state.handNumber;
-        renderCards(dealerCardsEl, state.dealer);
+        // Slow the dealer's reveal/play-out so the hole card flips first
+        // and each subsequent draw arrives with a clear beat between
+        // cards, instead of everything popping in on the same frame.
+        renderCards(dealerCardsEl, state.dealer, { staggerMs: DEALER_REVEAL_STAGGER_MS });
         dealerTotalEl.textContent = state.dealer && state.dealer.length
             ? "(" + state.dealerTotalVisible + ")" : "";
         renderSeats(state);

--- a/web/src/main/resources/static/js/casino-render.js
+++ b/web/src/main/resources/static/js/casino-render.js
@@ -14,21 +14,30 @@
 (function () {
     "use strict";
 
-    // Per-container "previous card count" so the deal animation only fires
-    // on cards that just arrived, not on every 2-second poll re-render.
-    var dealtCounts = new WeakMap();
+    // Per-container card-state cache so the deal animation only fires on
+    // cards that just arrived (or just unmasked), not on every poll
+    // re-render. Tracks each glyph individually instead of just the count
+    // so a `"??"` → real-card transition (the dealer's hole card flipping
+    // at the end of the hand) is recognised as fresh.
+    var dealtCardsCache = new WeakMap();
+    var DEFAULT_STAGGER_MS = 90;
 
-    function renderCards(container, cards) {
+    function renderCards(container, cards, opts) {
         if (!container) return;
-        var prev = dealtCounts.get(container) || 0;
+        var staggerMs = (opts && typeof opts.staggerMs === "number") ? opts.staggerMs : DEFAULT_STAGGER_MS;
+        var prev = dealtCardsCache.get(container) || [];
         var list = cards || [];
         // Card count went DOWN — that's a fresh deal, not an in-place
         // update. Reset so every card animates in.
-        if (list.length < prev) prev = 0;
+        if (list.length < prev.length) prev = [];
         container.innerHTML = "";
-        var firstFreshIndex = prev;
+        // First index that should animate: either an entirely new index, or
+        // an existing index whose glyph just changed (hole-card reveal).
+        var firstFreshIndex = -1;
         for (var i = 0; i < list.length; i++) {
             var c = list[i];
+            var wasFresh = i >= prev.length || prev[i] !== c;
+            if (wasFresh && firstFreshIndex === -1) firstFreshIndex = i;
             var el = document.createElement("span");
             el.className = "casino-card-glyph";
             if (c === "??") {
@@ -40,27 +49,30 @@
                     el.classList.add("is-red");
                 }
             }
-            // Only animate cards that weren't there last render. Stagger
-            // each new card by 90ms so a 2-card initial deal fans in
-            // instead of arriving simultaneously.
-            if (i >= prev) {
+            // Only animate cards that just arrived or just unmasked.
+            // Stagger each fresh card by `staggerMs` so the dealer's
+            // play-out beats out instead of all landing in one frame.
+            if (wasFresh) {
                 el.classList.add("is-dealt");
-                el.style.animationDelay = ((i - firstFreshIndex) * 90) + "ms";
+                if (i > firstFreshIndex) {
+                    el.classList.add("is-revealed");
+                }
+                el.style.animationDelay = ((i - firstFreshIndex) * staggerMs) + "ms";
             }
             container.appendChild(el);
         }
-        // Notify listeners (e.g. sounds module) about how many cards
-        // just landed. Stagger the deal cue once per arriving card so
+        // Notify listeners (e.g. sounds module) about how many cards just
+        // landed/unmasked. Stagger the deal cue once per arriving card so
         // the click matches the visual.
-        var freshCount = Math.max(0, list.length - firstFreshIndex);
-        if (freshCount > 0 && window.CasinoSounds) {
+        if (firstFreshIndex >= 0 && window.CasinoSounds) {
+            var freshCount = list.length - firstFreshIndex;
             for (var k = 0; k < freshCount; k++) {
                 (function (idx) {
-                    setTimeout(function () { window.CasinoSounds.play("deal"); }, idx * 90);
+                    setTimeout(function () { window.CasinoSounds.play("deal"); }, idx * staggerMs);
                 })(k);
             }
         }
-        dealtCounts.set(container, list.length);
+        dealtCardsCache.set(container, list.slice());
     }
 
     function initialOf(name) {

--- a/web/src/main/resources/templates/blackjack-solo.html
+++ b/web/src/main/resources/templates/blackjack-solo.html
@@ -28,7 +28,7 @@
             <label for="bj-stake">Stake (credits)</label>
             <input id="bj-stake" name="stake" type="number"
                    th:attr="min=${minStake}, max=${maxStake}" th:value="${minStake}" step="1" required>
-            <button type="submit" class="btn-primary">Deal</button>
+            <button id="bj-deal-button" type="submit" class="btn-primary">Deal</button>
         </form>
         <div class="bj-balance">
             Wallet: <strong id="bj-balance" th:text="${balance}">0</strong> credits

--- a/web/src/test/js/casino-render.test.js
+++ b/web/src/test/js/casino-render.test.js
@@ -67,3 +67,65 @@ describe('CasinoRender.flashWinPayout', () => {
         expect(stacks[0].querySelector('.casino-chip-payout').textContent).toBe('+200');
     });
 });
+
+describe('CasinoRender.renderCards', () => {
+    let containerEl;
+
+    beforeEach(() => {
+        document.body.innerHTML = '<div id="cards"></div>';
+        containerEl = document.getElementById('cards');
+    });
+
+    test('flags freshly arrived cards with .is-dealt and a stagger delay', () => {
+        window.CasinoRender.renderCards(containerEl, ['A♠', 'K♥']);
+        const cards = containerEl.querySelectorAll('.casino-card-glyph');
+        expect(cards.length).toBe(2);
+        // First card animates immediately; second card carries a 90ms stagger.
+        expect(cards[0].classList.contains('is-dealt')).toBe(true);
+        expect(cards[0].style.animationDelay).toBe('0ms');
+        expect(cards[1].classList.contains('is-dealt')).toBe(true);
+        expect(cards[1].style.animationDelay).toBe('90ms');
+    });
+
+    test('does not re-animate cards that were already there last render', () => {
+        window.CasinoRender.renderCards(containerEl, ['A♠', 'K♥']);
+        // Same array on the next poll — no fresh cards.
+        window.CasinoRender.renderCards(containerEl, ['A♠', 'K♥']);
+        const cards = containerEl.querySelectorAll('.casino-card-glyph');
+        expect(cards.length).toBe(2);
+        expect(cards[0].classList.contains('is-dealt')).toBe(false);
+        expect(cards[1].classList.contains('is-dealt')).toBe(false);
+    });
+
+    test('treats a hole-card unmask (?? → real card) as a fresh arrival', () => {
+        // Initial dealer-view: upcard + masked hole card.
+        window.CasinoRender.renderCards(containerEl, ['A♠', '??']);
+        // Resolution flips the hole card to a real value.
+        window.CasinoRender.renderCards(containerEl, ['A♠', 'K♥']);
+        const cards = containerEl.querySelectorAll('.casino-card-glyph');
+        // Index 0 unchanged → no animation. Index 1 is fresh (glyph
+        // changed) → animates with .is-dealt + .is-revealed (subsequent
+        // fresh card flips, not slides in).
+        expect(cards[0].classList.contains('is-dealt')).toBe(false);
+        expect(cards[1].classList.contains('is-dealt')).toBe(true);
+    });
+
+    test('honours an explicit staggerMs override', () => {
+        // Dealer container uses a 400ms stagger so the play-out beats out.
+        window.CasinoRender.renderCards(containerEl, ['A♠', 'K♥', 'Q♣'], { staggerMs: 400 });
+        const cards = containerEl.querySelectorAll('.casino-card-glyph');
+        expect(cards[0].style.animationDelay).toBe('0ms');
+        expect(cards[1].style.animationDelay).toBe('400ms');
+        expect(cards[2].style.animationDelay).toBe('800ms');
+    });
+
+    test('count decrease (fresh deal) re-animates every card', () => {
+        window.CasinoRender.renderCards(containerEl, ['A♠', 'K♥', 'Q♣']);
+        // Next hand: fewer cards → reset baseline.
+        window.CasinoRender.renderCards(containerEl, ['T♦', 'J♥']);
+        const cards = containerEl.querySelectorAll('.casino-card-glyph');
+        expect(cards.length).toBe(2);
+        expect(cards[0].classList.contains('is-dealt')).toBe(true);
+        expect(cards[1].classList.contains('is-dealt')).toBe(true);
+    });
+});


### PR DESCRIPTION
## Summary

Three blackjack fixes wrapped in one PR because the same area is touched (and the same test file gets the new coverage):

- **Mid-hand redeal (solo web).** Pressing **Deal** again before finishing the previous hand was double-debiting the stake and orphaning the prior in-flight table in the registry until the 10-minute idle sweeper cleaned it up. `BlackjackService.dealSolo` now returns a new `SoloDealOutcome.HandInProgress(tableId)` when the caller already has a non-`RESOLVED` solo table on this guild — *before* any wallet debit. The solo web Deal button is also disabled while `phase ∈ {PLAYER_TURNS, DEALER_TURN}` as a belt-and-braces UI guard. The slash-command path surfaces the same outcome.
- **Split lock-out audit.** Couldn't pinpoint a single deterministic case from static reading, so this PR pins the contract with focused tests and adds a defensive guard in `applyActionToActiveHand` so a stale UI click against an already-terminal split slot is a no-op (no card drawn, no status change). The intentional behaviours (`fromSplit` suppresses the 3:2 natural-BJ premium, aces auto-stand and resolve immediately, hit-to-21 auto-stands and advances the cursor, re-split walks 3 slots in order) are now locked in by tests.
- **Dealer reveal pacing.** The shared renderer staggered fresh cards by 90ms but only counted "fresh" by index, so the hole-card flip (`"??"` → real card, same length) popped in instantly and any S17 draws all arrived in the same poll cycle. `casino-render.renderCards` now also detects a glyph-change-in-place as fresh, takes a `staggerMs` option, and the dealer container in both `blackjack-solo.js` and `blackjack-table.js` passes `400ms`. Hole-card reveals get a CSS flip; reduced-motion still skips animation.

## Test plan

- [x] `:database:test --tests *BlackjackServiceTest*` — passes locally (48 tests, 9 new)
- [x] `:web:test --tests *BlackjackController*` — passes locally
- [x] `npm test` (web jest) — 300 tests pass (5 new in `casino-render.test.js`)
- [ ] `:discord-bot:test --tests *BlackjackCommandTest*` — could not run locally (sandbox blocks the `moe.kyokobot.libdave` repository); the new `HandInProgress` test branch follows the existing `Insufficient*` patterns in the same file
- [ ] Manual: deal a hand, click Deal again before acting → button disabled, toast shows the in-progress error, wallet unchanged. Finish the hand, deal again → works.
- [ ] Manual: split 8-8 (or rig RNG), play both halves through to resolution; verify hand[1] never gets locked out and the cursor advances slot-by-slot.
- [ ] Manual: stand on a non-bust hand → hole card flips first, each dealer draw arrives with a clear ~400ms beat. Repeat with reduced-motion enabled.

https://claude.ai/code/session_01GuwBTHrpjrUwH1R2Yn5nYL

---
_Generated by [Claude Code](https://claude.ai/code/session_01GuwBTHrpjrUwH1R2Yn5nYL)_