### PR TITLE
fix(casinoholdem web): escape apostrophe in title so the page renders

### DIFF
--- a/web/src/main/resources/templates/casinoholdem-guilds.html
+++ b/web/src/main/resources/templates/casinoholdem-guilds.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org" lang="en">
-<head th:replace="~{fragments/head :: head('TobyBot - Casino Hold''em', '/css/leaderboard.css')}"></head>
+<head th:replace="~{fragments/head :: head('TobyBot - Casino Hold\'em', '/css/leaderboard.css')}"></head>
 <body>
 <a href="#main" class="skip-link">Skip to content</a>
 <div th:replace="~{fragments/navbar :: navbar}"></div>

--- a/web/src/main/resources/templates/casinoholdem-solo.html
+++ b/web/src/main/resources/templates/casinoholdem-solo.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org" lang="en">
-<head th:replace="~{fragments/head :: head('TobyBot - Casino Hold''em', '/css/casinoholdem.css')}"></head>
+<head th:replace="~{fragments/head :: head('TobyBot - Casino Hold\'em', '/css/casinoholdem.css')}"></head>
 <body>
 <a href="#main" class="skip-link">Skip to content</a>
 <div th:replace="~{fragments/navbar :: navbar}"></div>


### PR DESCRIPTION
## Summary

`GET /casinoholdem/guilds` (and `/casinoholdem/{guildId}`) was returning HTTP 500 on every render. From the Heroku logs:

```
ERROR org.thymeleaf.TemplateEngine - Exception processing template "casinoholdem-guilds":
Could not parse as expression: "~{fragments/head :: head('TobyBot - Casino Hold''em', '/css/leaderboard.css')}"
(template: "casinoholdem-guilds" - line 3, col 7)
```

Both casino-hold'em templates (introduced in #392) tried to embed an apostrophe in the page title using the SQL/XML-style doubled apostrophe (`Hold''em`). Thymeleaf's SpringEL parser doesn't accept that — it sees an empty string `''` followed by stray `em',` and the whole `~{fragments/head :: head(...)}` expression fails to parse.

The other casino templates (`baccarat.html`, `dice.html`, …) all use plain titles without an apostrophe, so this template was the only one that ever needed escaping and got it wrong.

Fix: switch to backslash-escaping (`Hold\'em`), which SpringEL accepts inside a single-quoted string literal. Two-character edit per file; no controller, code, or test changes.

## Test plan

- [ ] Sign in and load `/casinoholdem/guilds` — lobby renders, browser tab shows `TobyBot - Casino Hold'em`
- [ ] Click into a guild — `/casinoholdem/{guildId}` renders with the same title and no 500
- [ ] After deploy, confirm Heroku router log no longer shows `status=500` on `path="/casinoholdem/guilds"`

https://claude.ai/code/session_011aiSwSxiTi1GDTT9J19JSu

---
_Generated by [Claude Code](https://claude.ai/code/session_011aiSwSxiTi1GDTT9J19JSu)_