### PR TITLE
feat(casino): per-guild stake bounds + jackpot scaling anchor

### DIFF
--- a/database/src/main/kotlin/database/dto/ConfigDto.kt
+++ b/database/src/main/kotlin/database/dto/ConfigDto.kt
@@ -119,7 +119,42 @@ class ConfigDto(
         // minigames (coinflip, slots, dice, highlow, scratch, baccarat,
         // keno, solo blackjack, duel). Defends against autoclicker spam.
         // Clamped 0-30 by CasinoCooldownService; 0 disables.
-        CASINO_COOLDOWN_SECONDS("CASINO_COOLDOWN_SECONDS");
+        CASINO_COOLDOWN_SECONDS("CASINO_COOLDOWN_SECONDS"),
+
+        // Per-game min/max stake bounds. Defaults come from each game's
+        // companion-object MIN_STAKE/MAX_STAKE constants when unset, so
+        // guilds that never touch these keys see today's behaviour.
+        // No upper ceiling — admins can raise max arbitrarily; jackpot
+        // probability scaling is anchored to JACKPOT_STAKE_ANCHOR rather
+        // than per-game maxStake so it stays sensible at any cap.
+        DICE_MIN_STAKE("DICE_MIN_STAKE"),
+        DICE_MAX_STAKE("DICE_MAX_STAKE"),
+        COINFLIP_MIN_STAKE("COINFLIP_MIN_STAKE"),
+        COINFLIP_MAX_STAKE("COINFLIP_MAX_STAKE"),
+        SLOTS_MIN_STAKE("SLOTS_MIN_STAKE"),
+        SLOTS_MAX_STAKE("SLOTS_MAX_STAKE"),
+        HIGHLOW_MIN_STAKE("HIGHLOW_MIN_STAKE"),
+        HIGHLOW_MAX_STAKE("HIGHLOW_MAX_STAKE"),
+        BACCARAT_MIN_STAKE("BACCARAT_MIN_STAKE"),
+        BACCARAT_MAX_STAKE("BACCARAT_MAX_STAKE"),
+        KENO_MIN_STAKE("KENO_MIN_STAKE"),
+        KENO_MAX_STAKE("KENO_MAX_STAKE"),
+        SCRATCH_MIN_STAKE("SCRATCH_MIN_STAKE"),
+        SCRATCH_MAX_STAKE("SCRATCH_MAX_STAKE"),
+        // Solo blackjack reuses the existing BLACKJACK_MIN_ANTE /
+        // BLACKJACK_MAX_ANTE keys — solo and multi share a single
+        // configurable stake range.
+        HOLDEM_MIN_STAKE("HOLDEM_MIN_STAKE"),
+        HOLDEM_MAX_STAKE("HOLDEM_MAX_STAKE"),
+        DUEL_MIN_STAKE("DUEL_MIN_STAKE"),
+        DUEL_MAX_STAKE("DUEL_MAX_STAKE"),
+
+        // Reference stake size for jackpot probability scaling. Bets at
+        // or above this anchor roll at the full JACKPOT_WIN_PCT base
+        // probability; smaller bets scale linearly as stake/anchor.
+        // Decoupled from per-game max stake so admins can raise max
+        // freely without shrinking jackpot odds. Default 500.
+        JACKPOT_STAKE_ANCHOR("JACKPOT_STAKE_ANCHOR");
     }
 
     override fun toString(): String {

--- a/database/src/main/kotlin/database/service/BaccaratService.kt
+++ b/database/src/main/kotlin/database/service/BaccaratService.kt
@@ -3,6 +3,7 @@ package database.service
 import common.casino.CasinoCommonFailure
 import database.card.Card
 import database.card.Deck
+import database.dto.ConfigDto
 import database.economy.Baccarat
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -109,9 +110,15 @@ class BaccaratService(
         side: Baccarat.Side,
         autoTopUp: Boolean = false
     ): PlayOutcome {
+        val minStake = configService.cfgLong(
+            ConfigDto.Configurations.BACCARAT_MIN_STAKE, guildId, default = Baccarat.MIN_STAKE, min = 1L
+        )
+        val maxStake = configService.cfgLong(
+            ConfigDto.Configurations.BACCARAT_MAX_STAKE, guildId, default = Baccarat.MAX_STAKE, min = minStake
+        )
         val resolved = when (val r = WagerHelper.checkLockOrTopUp(
             userService, tradeService, marketService,
-            discordId, guildId, stake, Baccarat.MIN_STAKE, Baccarat.MAX_STAKE, autoTopUp,
+            discordId, guildId, stake, minStake, maxStake, autoTopUp,
             cooldownService = cooldownService, game = CasinoGameKey.BACCARAT,
         )) {
             is TopUpResolution.InvalidStake -> return PlayOutcome.InvalidStake(r.min, r.max)
@@ -131,7 +138,7 @@ class BaccaratService(
             hand.isWin -> {
                 val jackpot = JackpotHelper.rollOnWin(
                     jackpotService, configService, userService, resolved.user, guildId,
-                    stake, Baccarat.MAX_STAKE, random,
+                    stake, random,
                 )
                 PlayOutcome.Win(
                     stake = stake,

--- a/database/src/main/kotlin/database/service/BlackjackService.kt
+++ b/database/src/main/kotlin/database/service/BlackjackService.kt
@@ -677,7 +677,7 @@ class BlackjackService @Autowired constructor(
                     Blackjack.Result.PLAYER_WIN, Blackjack.Result.PLAYER_BLACKJACK -> {
                         val rolled = JackpotHelper.rollOnWin(
                             jackpotService, configService, userService, user, guildId,
-                            hand.stake, Blackjack.MAX_STAKE, random,
+                            hand.stake, random,
                         )
                         if (rolled > 0L) {
                             jackpotPayout += rolled

--- a/database/src/main/kotlin/database/service/CasinoHoldemService.kt
+++ b/database/src/main/kotlin/database/service/CasinoHoldemService.kt
@@ -1,6 +1,7 @@
 package database.service
 
 import common.casino.CasinoCommonFailure
+import database.dto.ConfigDto
 import database.dto.UserDto
 import database.poker.CasinoHoldem
 import database.poker.CasinoHoldemTable
@@ -274,7 +275,7 @@ class CasinoHoldemService @Autowired constructor(
             CasinoHoldem.AnteResult.WIN ->
                 jackpotPayout += JackpotHelper.rollOnWin(
                     jackpotService, configService, userService, user, guildId,
-                    table.stake, CasinoHoldem.MAX_STAKE, random,
+                    table.stake, random,
                 )
             CasinoHoldem.AnteResult.LOSE ->
                 lossTribute += JackpotHelper.divertOnLoss(
@@ -293,7 +294,7 @@ class CasinoHoldemService @Autowired constructor(
             CasinoHoldem.CallResult.WIN_OTHER ->
                 jackpotPayout += JackpotHelper.rollOnWin(
                     jackpotService, configService, userService, user, guildId,
-                    callStake, CasinoHoldem.MAX_STAKE * 2L, random,
+                    callStake, random,
                 )
             CasinoHoldem.CallResult.LOSE ->
                 lossTribute += JackpotHelper.divertOnLoss(
@@ -395,9 +396,15 @@ class CasinoHoldemService @Autowired constructor(
         stake: Long,
         autoTopUp: Boolean,
     ): TopUpResolution {
+        val minStake = configService.cfgLong(
+            ConfigDto.Configurations.HOLDEM_MIN_STAKE, guildId, default = CasinoHoldem.MIN_STAKE, min = 1L
+        )
+        val maxStake = configService.cfgLong(
+            ConfigDto.Configurations.HOLDEM_MAX_STAKE, guildId, default = CasinoHoldem.MAX_STAKE, min = minStake
+        )
         val check = WagerHelper.checkAndLock(
             userService, discordId, guildId, stake,
-            CasinoHoldem.MIN_STAKE, CasinoHoldem.MAX_STAKE
+            minStake, maxStake
         )
         return when (check) {
             is BalanceCheck.InvalidStake -> TopUpResolution.InvalidStake(check.min, check.max)

--- a/database/src/main/kotlin/database/service/CoinflipService.kt
+++ b/database/src/main/kotlin/database/service/CoinflipService.kt
@@ -1,6 +1,7 @@
 package database.service
 
 import common.casino.CasinoCommonFailure
+import database.dto.ConfigDto
 import database.economy.Coinflip
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -71,9 +72,15 @@ class CoinflipService(
         predicted: Coinflip.Side,
         autoTopUp: Boolean = false
     ): FlipOutcome {
+        val minStake = configService.cfgLong(
+            ConfigDto.Configurations.COINFLIP_MIN_STAKE, guildId, default = Coinflip.MIN_STAKE, min = 1L
+        )
+        val maxStake = configService.cfgLong(
+            ConfigDto.Configurations.COINFLIP_MAX_STAKE, guildId, default = Coinflip.MAX_STAKE, min = minStake
+        )
         val resolved = when (val r = WagerHelper.checkLockOrTopUp(
             userService, tradeService, marketService,
-            discordId, guildId, stake, Coinflip.MIN_STAKE, Coinflip.MAX_STAKE, autoTopUp,
+            discordId, guildId, stake, minStake, maxStake, autoTopUp,
             cooldownService = cooldownService, game = CasinoGameKey.COINFLIP,
         )) {
             is TopUpResolution.InvalidStake -> return FlipOutcome.InvalidStake(r.min, r.max)
@@ -92,7 +99,7 @@ class CoinflipService(
         return if (flip.isWin) {
             val jackpot = JackpotHelper.rollOnWin(
                 jackpotService, configService, userService, resolved.user, guildId,
-                stake, Coinflip.MAX_STAKE, random,
+                stake, random,
             )
             FlipOutcome.Win(
                 stake = stake,

--- a/database/src/main/kotlin/database/service/ConfigReaders.kt
+++ b/database/src/main/kotlin/database/service/ConfigReaders.kt
@@ -1,0 +1,24 @@
+package database.service
+
+import database.dto.ConfigDto
+
+/**
+ * Read a per-guild Long config value with a default fallback and a
+ * lower-bound coercion.
+ *
+ * Mirrors the local `cfgLong` helper in `BlackjackService.readMultiTableParams`
+ * — hoisted out so every game service can read its own min/max stake config
+ * without duplicating the boilerplate. Returns [default] when the row is
+ * missing or unparseable; otherwise coerces the parsed value to be at least
+ * [min] (so an admin who sets `*_MAX_STAKE = 0` doesn't silently disable a
+ * game).
+ */
+fun ConfigService.cfgLong(
+    key: ConfigDto.Configurations,
+    guildId: Long,
+    default: Long,
+    min: Long,
+): Long {
+    val raw = getConfigByName(key.configValue, guildId.toString())?.value
+    return raw?.toLongOrNull()?.coerceAtLeast(min) ?: default
+}

--- a/database/src/main/kotlin/database/service/DiceService.kt
+++ b/database/src/main/kotlin/database/service/DiceService.kt
@@ -1,6 +1,7 @@
 package database.service
 
 import common.casino.CasinoCommonFailure
+import database.dto.ConfigDto
 import database.economy.Dice
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -74,9 +75,15 @@ class DiceService(
         if (!dice.isValidPrediction(predicted)) {
             return RollOutcome.InvalidPrediction(1, dice.sidesCount)
         }
+        val minStake = configService.cfgLong(
+            ConfigDto.Configurations.DICE_MIN_STAKE, guildId, default = Dice.MIN_STAKE, min = 1L
+        )
+        val maxStake = configService.cfgLong(
+            ConfigDto.Configurations.DICE_MAX_STAKE, guildId, default = Dice.MAX_STAKE, min = minStake
+        )
         val resolved = when (val r = WagerHelper.checkLockOrTopUp(
             userService, tradeService, marketService,
-            discordId, guildId, stake, Dice.MIN_STAKE, Dice.MAX_STAKE, autoTopUp,
+            discordId, guildId, stake, minStake, maxStake, autoTopUp,
             cooldownService = cooldownService, game = CasinoGameKey.DICE,
         )) {
             is TopUpResolution.InvalidStake -> return RollOutcome.InvalidStake(r.min, r.max)
@@ -95,7 +102,7 @@ class DiceService(
         return if (roll.isWin) {
             val jackpot = JackpotHelper.rollOnWin(
                 jackpotService, configService, userService, resolved.user, guildId,
-                stake, Dice.MAX_STAKE, random,
+                stake, random,
             )
             RollOutcome.Win(
                 stake = stake,

--- a/database/src/main/kotlin/database/service/DuelService.kt
+++ b/database/src/main/kotlin/database/service/DuelService.kt
@@ -1,5 +1,6 @@
 package database.service
 
+import database.dto.ConfigDto
 import database.dto.DuelLogDto
 import database.economy.Coinflip
 import database.persistence.DuelLogPersistence
@@ -79,8 +80,14 @@ class DuelService @Autowired constructor(
         guildId: Long,
         stake: Long,
     ): StartOutcome {
-        if (stake < MIN_STAKE || stake > MAX_STAKE) {
-            return StartOutcome.InvalidStake(MIN_STAKE, MAX_STAKE)
+        val minStake = configService.cfgLong(
+            ConfigDto.Configurations.DUEL_MIN_STAKE, guildId, default = MIN_STAKE, min = 1L
+        )
+        val maxStake = configService.cfgLong(
+            ConfigDto.Configurations.DUEL_MAX_STAKE, guildId, default = MAX_STAKE, min = minStake
+        )
+        if (stake < minStake || stake > maxStake) {
+            return StartOutcome.InvalidStake(minStake, maxStake)
         }
         if (initiatorDiscordId == opponentDiscordId) {
             return StartOutcome.InvalidOpponent(StartOutcome.InvalidOpponent.Reason.SELF)

--- a/database/src/main/kotlin/database/service/HighlowService.kt
+++ b/database/src/main/kotlin/database/service/HighlowService.kt
@@ -1,6 +1,7 @@
 package database.service
 
 import common.casino.CasinoCommonFailure
+import database.dto.ConfigDto
 import database.economy.Highlow
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -108,9 +109,15 @@ class HighlowService(
         anchor: Int?,
         autoTopUp: Boolean
     ): PlayOutcome {
+        val minStake = configService.cfgLong(
+            ConfigDto.Configurations.HIGHLOW_MIN_STAKE, guildId, default = Highlow.MIN_STAKE, min = 1L
+        )
+        val maxStake = configService.cfgLong(
+            ConfigDto.Configurations.HIGHLOW_MAX_STAKE, guildId, default = Highlow.MAX_STAKE, min = minStake
+        )
         val resolved = when (val r = WagerHelper.checkLockOrTopUp(
             userService, tradeService, marketService,
-            discordId, guildId, stake, Highlow.MIN_STAKE, Highlow.MAX_STAKE, autoTopUp,
+            discordId, guildId, stake, minStake, maxStake, autoTopUp,
             cooldownService = cooldownService, game = CasinoGameKey.HIGHLOW,
         )) {
             is TopUpResolution.InvalidStake -> return PlayOutcome.InvalidStake(r.min, r.max)
@@ -133,7 +140,7 @@ class HighlowService(
         return if (hand.isWin) {
             val jackpot = JackpotHelper.rollOnWin(
                 jackpotService, configService, userService, resolved.user, guildId,
-                stake, Highlow.MAX_STAKE, random,
+                stake, random,
             )
             PlayOutcome.Win(
                 stake = stake,

--- a/database/src/main/kotlin/database/service/JackpotHelper.kt
+++ b/database/src/main/kotlin/database/service/JackpotHelper.kt
@@ -37,6 +37,15 @@ internal object JackpotHelper {
     const val DEFAULT_WIN_PROBABILITY: Double = 0.01
 
     /**
+     * Default reference stake size for jackpot probability scaling
+     * when `JACKPOT_STAKE_ANCHOR` is unset. Bets at or above this value
+     * roll at the full base probability; smaller bets scale linearly.
+     * Matches the historical hardcoded MAX_STAKE on most minigames so
+     * behaviour is unchanged out of the box.
+     */
+    const val DEFAULT_STAKE_ANCHOR: Long = 500L
+
+    /**
      * Hard cap on the configurable win probability. 50 % keeps the
      * "growing pool" tension meaningful — without it an admin could
      * empty the pool on virtually every win.
@@ -66,11 +75,14 @@ internal object JackpotHelper {
      * is per-guild configurable via `JACKPOT_WIN_PCT`; defaults to
      * [DEFAULT_WIN_PROBABILITY].
      *
-     * The base probability is scaled linearly by `stake / maxStake`, so
-     * a min-wager autoclicker can't farm the pool — a 10/1000 coinflip
-     * rolls at 0.01 % even when the configured base is 1 %. Clamps the
-     * scale to [0,1] defensively in case a caller ever passes
-     * stake > maxStake.
+     * The base probability is scaled linearly by `stake / anchor`,
+     * where `anchor` is the per-guild `JACKPOT_STAKE_ANCHOR` config
+     * (default [DEFAULT_STAKE_ANCHOR]). A min-wager autoclicker can't
+     * farm the pool — a 10-credit play against a 500 anchor rolls at
+     * 0.02 % even when the configured base is 1 %. Bets at or above
+     * the anchor cap at full base probability. Decoupled from each
+     * game's max stake so admins can raise stakes arbitrarily without
+     * shrinking jackpot odds.
      */
     fun rollOnWin(
         jackpotService: JackpotService,
@@ -79,12 +91,11 @@ internal object JackpotHelper {
         user: UserDto,
         guildId: Long,
         stake: Long,
-        maxStake: Long,
         random: Random
     ): Long {
         val baseProbability = winProbability(configService, guildId)
-        val scale = if (maxStake <= 0L) 0.0
-            else (stake.toDouble() / maxStake.toDouble()).coerceIn(0.0, 1.0)
+        val anchor = stakeAnchor(configService, guildId)
+        val scale = (stake.toDouble() / anchor.toDouble()).coerceIn(0.0, 1.0)
         val effective = baseProbability * scale
         if (random.nextDouble() >= effective) return 0L
         val won = jackpotService.awardJackpot(guildId)
@@ -92,6 +103,20 @@ internal object JackpotHelper {
         user.socialCredit = (user.socialCredit ?: 0L) + won
         userService.updateUser(user)
         return won
+    }
+
+    /**
+     * Live jackpot stake anchor for [guildId] — admin-set whole-number
+     * credits parsed from the `JACKPOT_STAKE_ANCHOR` config entry.
+     * Returns [DEFAULT_STAKE_ANCHOR] when unset or unparseable; coerces
+     * `>= 1L` so a zero never reaches the divisor.
+     */
+    fun stakeAnchor(configService: ConfigService, guildId: Long): Long {
+        val cfg = configService.getConfigByName(
+            ConfigDto.Configurations.JACKPOT_STAKE_ANCHOR.configValue,
+            guildId.toString()
+        )
+        return cfg?.value?.toLongOrNull()?.coerceAtLeast(1L) ?: DEFAULT_STAKE_ANCHOR
     }
 
     /**

--- a/database/src/main/kotlin/database/service/KenoService.kt
+++ b/database/src/main/kotlin/database/service/KenoService.kt
@@ -1,5 +1,6 @@
 package database.service
 
+import database.dto.ConfigDto
 import database.economy.Keno
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -103,9 +104,15 @@ class KenoService(
             return PlayOutcome.InvalidPicks(Keno.MIN_SPOTS, Keno.MAX_SPOTS, Keno.POOL_SIZE)
         }
 
+        val minStake = configService.cfgLong(
+            ConfigDto.Configurations.KENO_MIN_STAKE, guildId, default = Keno.MIN_STAKE, min = 1L
+        )
+        val maxStake = configService.cfgLong(
+            ConfigDto.Configurations.KENO_MAX_STAKE, guildId, default = Keno.MAX_STAKE, min = minStake
+        )
         val resolved = when (val r = WagerHelper.checkLockOrTopUp(
             userService, tradeService, marketService,
-            discordId, guildId, stake, Keno.MIN_STAKE, Keno.MAX_STAKE, autoTopUp,
+            discordId, guildId, stake, minStake, maxStake, autoTopUp,
             cooldownService = cooldownService, game = CasinoGameKey.KENO,
         )) {
             is TopUpResolution.InvalidStake -> return PlayOutcome.InvalidStake(r.min, r.max)
@@ -132,7 +139,7 @@ class KenoService(
         return if (hand.isWin) {
             val jackpot = JackpotHelper.rollOnWin(
                 jackpotService, configService, userService, resolved.user, guildId,
-                stake, Keno.MAX_STAKE, random,
+                stake, random,
             )
             PlayOutcome.Win(
                 stake = stake,

--- a/database/src/main/kotlin/database/service/ScratchService.kt
+++ b/database/src/main/kotlin/database/service/ScratchService.kt
@@ -1,6 +1,7 @@
 package database.service
 
 import common.casino.CasinoCommonFailure
+import database.dto.ConfigDto
 import database.economy.ScratchCard
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -62,9 +63,15 @@ class ScratchService(
     }
 
     fun scratch(discordId: Long, guildId: Long, stake: Long, autoTopUp: Boolean = false): ScratchOutcome {
+        val minStake = configService.cfgLong(
+            ConfigDto.Configurations.SCRATCH_MIN_STAKE, guildId, default = ScratchCard.MIN_STAKE, min = 1L
+        )
+        val maxStake = configService.cfgLong(
+            ConfigDto.Configurations.SCRATCH_MAX_STAKE, guildId, default = ScratchCard.MAX_STAKE, min = minStake
+        )
         val resolved = when (val r = WagerHelper.checkLockOrTopUp(
             userService, tradeService, marketService,
-            discordId, guildId, stake, ScratchCard.MIN_STAKE, ScratchCard.MAX_STAKE, autoTopUp,
+            discordId, guildId, stake, minStake, maxStake, autoTopUp,
             cooldownService = cooldownService, game = CasinoGameKey.SCRATCH,
         )) {
             is TopUpResolution.InvalidStake -> return ScratchOutcome.InvalidStake(r.min, r.max)
@@ -83,7 +90,7 @@ class ScratchService(
         return if (result.isWin && result.winningSymbol != null) {
             val jackpot = JackpotHelper.rollOnWin(
                 jackpotService, configService, userService, resolved.user, guildId,
-                stake, ScratchCard.MAX_STAKE, random,
+                stake, random,
             )
             ScratchOutcome.Win(
                 stake = stake,

--- a/database/src/main/kotlin/database/service/SlotsService.kt
+++ b/database/src/main/kotlin/database/service/SlotsService.kt
@@ -1,6 +1,7 @@
 package database.service
 
 import common.casino.CasinoCommonFailure
+import database.dto.ConfigDto
 import database.economy.SlotMachine
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -74,9 +75,15 @@ class SlotsService(
     }
 
     fun spin(discordId: Long, guildId: Long, stake: Long, autoTopUp: Boolean = false): SpinOutcome {
+        val minStake = configService.cfgLong(
+            ConfigDto.Configurations.SLOTS_MIN_STAKE, guildId, default = SlotMachine.MIN_STAKE, min = 1L
+        )
+        val maxStake = configService.cfgLong(
+            ConfigDto.Configurations.SLOTS_MAX_STAKE, guildId, default = SlotMachine.MAX_STAKE, min = minStake
+        )
         val resolved = when (val r = WagerHelper.checkLockOrTopUp(
             userService, tradeService, marketService,
-            discordId, guildId, stake, SlotMachine.MIN_STAKE, SlotMachine.MAX_STAKE, autoTopUp,
+            discordId, guildId, stake, minStake, maxStake, autoTopUp,
             cooldownService = cooldownService, game = CasinoGameKey.SLOTS,
         )) {
             is TopUpResolution.InvalidStake -> return SpinOutcome.InvalidStake(r.min, r.max)
@@ -95,7 +102,7 @@ class SlotsService(
         return if (pull.isWin) {
             val jackpot = JackpotHelper.rollOnWin(
                 jackpotService, configService, userService, resolved.user, guildId,
-                stake, SlotMachine.MAX_STAKE, random,
+                stake, random,
             )
             SpinOutcome.Win(
                 stake = stake,

--- a/database/src/test/kotlin/database/service/JackpotHelperTest.kt
+++ b/database/src/test/kotlin/database/service/JackpotHelperTest.kt
@@ -45,6 +45,15 @@ class JackpotHelperTest {
         } returns value?.let { ConfigDto(name = "x", value = it, guildId = guildId.toString()) }
     }
 
+    private fun anchorConfigReturns(value: String?) {
+        every {
+            configService.getConfigByName(
+                ConfigDto.Configurations.JACKPOT_STAKE_ANCHOR.configValue,
+                guildId.toString()
+            )
+        } returns value?.let { ConfigDto(name = "x", value = it, guildId = guildId.toString()) }
+    }
+
     private fun stubRandom(value: Double): Random {
         val r = mockk<Random>()
         every { r.nextDouble() } returns value
@@ -192,12 +201,13 @@ class JackpotHelperTest {
     @Test
     fun `rollOnWin uses default 1 percent when config unset and roll lands inside threshold`() {
         winConfigReturns(null)
+        anchorConfigReturns(MAX_STAKE.toString())
         every { jackpotService.awardJackpot(guildId) } returns 500L
         val user = freshUser(initial = 100L)
 
         val won = JackpotHelper.rollOnWin(
             jackpotService, configService, userService, user, guildId,
-            stake = MAX_STAKE, maxStake = MAX_STAKE, random = stubRandom(0.001)
+            stake = MAX_STAKE, random = stubRandom(0.001)
         )
 
         assertEquals(500L, won)
@@ -208,12 +218,13 @@ class JackpotHelperTest {
     @Test
     fun `rollOnWin misses when roll equals or exceeds the configured probability`() {
         winConfigReturns(null)  // 1 % default
+        anchorConfigReturns(MAX_STAKE.toString())
         val user = freshUser(initial = 100L)
 
         // 0.5 is far above the 0.01 threshold.
         val won = JackpotHelper.rollOnWin(
             jackpotService, configService, userService, user, guildId,
-            stake = MAX_STAKE, maxStake = MAX_STAKE, random = stubRandom(0.5)
+            stake = MAX_STAKE, random = stubRandom(0.5)
         )
 
         assertEquals(0L, won)
@@ -225,17 +236,18 @@ class JackpotHelperTest {
     @Test
     fun `rollOnWin honours a sub-1 percent admin override`() {
         winConfigReturns("0.5")  // 0.005
+        anchorConfigReturns(MAX_STAKE.toString())
         every { jackpotService.awardJackpot(guildId) } returns 1_000L
         val userHit = freshUser()
         val userMiss = freshUser()
 
         val hit = JackpotHelper.rollOnWin(
             jackpotService, configService, userService, userHit, guildId,
-            stake = MAX_STAKE, maxStake = MAX_STAKE, random = stubRandom(0.004)
+            stake = MAX_STAKE, random = stubRandom(0.004)
         )
         val miss = JackpotHelper.rollOnWin(
             jackpotService, configService, userService, userMiss, guildId,
-            stake = MAX_STAKE, maxStake = MAX_STAKE, random = stubRandom(0.006)
+            stake = MAX_STAKE, random = stubRandom(0.006)
         )
 
         assertEquals(1_000L, hit, "0.004 < 0.005 should hit")
@@ -245,12 +257,13 @@ class JackpotHelperTest {
     @Test
     fun `rollOnWin disabled when admin set rate to zero`() {
         winConfigReturns("0")
+        anchorConfigReturns(MAX_STAKE.toString())
         val user = freshUser(initial = 100L)
 
         // Even an absurdly small roll can't beat a 0.0 threshold (`< 0.0` is unreachable).
         val won = JackpotHelper.rollOnWin(
             jackpotService, configService, userService, user, guildId,
-            stake = MAX_STAKE, maxStake = MAX_STAKE, random = stubRandom(0.0)
+            stake = MAX_STAKE, random = stubRandom(0.0)
         )
 
         assertEquals(0L, won)
@@ -260,17 +273,18 @@ class JackpotHelperTest {
     @Test
     fun `rollOnWin clamps above MAX_WIN_PROBABILITY`() {
         winConfigReturns("100")  // clamps to 0.50
+        anchorConfigReturns(MAX_STAKE.toString())
         every { jackpotService.awardJackpot(guildId) } returns 50L
         val userHit = freshUser()
         val userMiss = freshUser()
 
         val hit = JackpotHelper.rollOnWin(
             jackpotService, configService, userService, userHit, guildId,
-            stake = MAX_STAKE, maxStake = MAX_STAKE, random = stubRandom(0.49)
+            stake = MAX_STAKE, random = stubRandom(0.49)
         )
         val miss = JackpotHelper.rollOnWin(
             jackpotService, configService, userService, userMiss, guildId,
-            stake = MAX_STAKE, maxStake = MAX_STAKE, random = stubRandom(0.51)
+            stake = MAX_STAKE, random = stubRandom(0.51)
         )
 
         assertEquals(50L, hit)
@@ -280,12 +294,13 @@ class JackpotHelperTest {
     @Test
     fun `rollOnWin returns zero and does not credit user when pool is empty`() {
         winConfigReturns("1")
+        anchorConfigReturns(MAX_STAKE.toString())
         every { jackpotService.awardJackpot(guildId) } returns 0L
         val user = freshUser(initial = 100L)
 
         val won = JackpotHelper.rollOnWin(
             jackpotService, configService, userService, user, guildId,
-            stake = MAX_STAKE, maxStake = MAX_STAKE, random = stubRandom(0.001)
+            stake = MAX_STAKE, random = stubRandom(0.001)
         )
 
         assertEquals(0L, won)
@@ -298,17 +313,18 @@ class JackpotHelperTest {
     @Test
     fun `rollOnWin scales by stake fraction so a min-wager autoclick is effectively zero`() {
         winConfigReturns("1") // 1 % base → 10/1000 → 0.01 % effective
+        anchorConfigReturns("1000")
         every { jackpotService.awardJackpot(guildId) } returns 1_000L
         val userHit = freshUser()
         val userMiss = freshUser()
 
         val hit = JackpotHelper.rollOnWin(
             jackpotService, configService, userService, userHit, guildId,
-            stake = 10L, maxStake = 1_000L, random = stubRandom(0.00009)
+            stake = 10L, random = stubRandom(0.00009)
         )
         val miss = JackpotHelper.rollOnWin(
             jackpotService, configService, userService, userMiss, guildId,
-            stake = 10L, maxStake = 1_000L, random = stubRandom(0.0001)
+            stake = 10L, random = stubRandom(0.0001)
         )
 
         assertEquals(1_000L, hit, "0.00009 < 0.0001 should hit")
@@ -316,19 +332,20 @@ class JackpotHelperTest {
     }
 
     @Test
-    fun `rollOnWin at full max stake rolls at the unscaled base probability`() {
+    fun `rollOnWin at the anchor stake rolls at the unscaled base probability`() {
         winConfigReturns("1") // 1 % base → 1000/1000 → 1 % effective
+        anchorConfigReturns("1000")
         every { jackpotService.awardJackpot(guildId) } returns 1_000L
         val userHit = freshUser()
         val userMiss = freshUser()
 
         val hit = JackpotHelper.rollOnWin(
             jackpotService, configService, userService, userHit, guildId,
-            stake = 1_000L, maxStake = 1_000L, random = stubRandom(0.009)
+            stake = 1_000L, random = stubRandom(0.009)
         )
         val miss = JackpotHelper.rollOnWin(
             jackpotService, configService, userService, userMiss, guildId,
-            stake = 1_000L, maxStake = 1_000L, random = stubRandom(0.011)
+            stake = 1_000L, random = stubRandom(0.011)
         )
 
         assertEquals(1_000L, hit)
@@ -336,31 +353,55 @@ class JackpotHelperTest {
     }
 
     @Test
-    fun `rollOnWin clamps stake fraction to 1 when stake exceeds maxStake (defensive)`() {
+    fun `rollOnWin caps scale at 1 when stake exceeds the anchor`() {
+        // Once stake >= anchor, the anchor stops shrinking the probability —
+        // bigger bets don't get *more* than the base rate. This is the new
+        // semantics that lets admins raise per-game max stake without the
+        // probability also unbounded-scaling.
         winConfigReturns("1") // base 1 %
+        anchorConfigReturns("1000")
         every { jackpotService.awardJackpot(guildId) } returns 100L
         val user = freshUser()
 
-        // stake > maxStake would push the formula past 1.0; clamp keeps it at 1 % effective.
         val won = JackpotHelper.rollOnWin(
             jackpotService, configService, userService, user, guildId,
-            stake = 10_000L, maxStake = 1_000L, random = stubRandom(0.009)
+            stake = 10_000L, random = stubRandom(0.009)
         )
 
         assertEquals(100L, won)
     }
 
     @Test
-    fun `rollOnWin returns zero when maxStake is zero (defensive divide-by-zero guard)`() {
-        winConfigReturns("100") // would otherwise hit at the cap
+    fun `rollOnWin defaults the anchor to 500 when config row missing`() {
+        winConfigReturns("1")        // 1 % base
+        anchorConfigReturns(null)    // fall through to DEFAULT_STAKE_ANCHOR (500)
+        every { jackpotService.awardJackpot(guildId) } returns 1L
+        val user = freshUser()
+
+        // stake/anchor = 500/500 = 1.0 → effective = 1 %; 0.009 < 0.01 hits.
+        val won = JackpotHelper.rollOnWin(
+            jackpotService, configService, userService, user, guildId,
+            stake = 500L, random = stubRandom(0.009)
+        )
+
+        assertEquals(1L, won)
+    }
+
+    @Test
+    fun `rollOnWin coerces a zero anchor up to 1 (defensive divide-by-zero guard)`() {
+        // An admin who sets JACKPOT_STAKE_ANCHOR=0 shouldn't divide-by-zero
+        // the probability formula. stakeAnchor() coerces to >= 1, so any
+        // stake >= 1 trivially saturates the scale to 1.
+        winConfigReturns("1")
+        anchorConfigReturns("0")
+        every { jackpotService.awardJackpot(guildId) } returns 100L
         val user = freshUser()
 
         val won = JackpotHelper.rollOnWin(
             jackpotService, configService, userService, user, guildId,
-            stake = 100L, maxStake = 0L, random = stubRandom(0.0)
+            stake = 100L, random = stubRandom(0.009)
         )
 
-        assertEquals(0L, won)
-        verify(exactly = 0) { jackpotService.awardJackpot(any()) }
+        assertEquals(100L, won)
     }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/BaccaratCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/BaccaratCommand.kt
@@ -32,7 +32,7 @@ class BaccaratCommand @Autowired constructor(
 
     override val name: String = "baccarat"
     override val description: String =
-        "Pick Player, Banker, or Tie — both hands deal automatically. Stake bounds are per-guild (default ${Baccarat.MIN_STAKE}-${Baccarat.MAX_STAKE})."
+        "Player/Banker/Tie — both hands deal. Stake bounds per-guild (default ${Baccarat.MIN_STAKE}-${Baccarat.MAX_STAKE})."
 
     companion object {
         private const val OPT_STAKE = "stake"

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/BaccaratCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/BaccaratCommand.kt
@@ -32,16 +32,15 @@ class BaccaratCommand @Autowired constructor(
 
     override val name: String = "baccarat"
     override val description: String =
-        "Pick Player, Banker, or Tie — both hands deal automatically. Bet ${Baccarat.MIN_STAKE}-${Baccarat.MAX_STAKE} credits."
+        "Pick Player, Banker, or Tie — both hands deal automatically. Stake bounds are per-guild (default ${Baccarat.MIN_STAKE}-${Baccarat.MAX_STAKE})."
 
     companion object {
         private const val OPT_STAKE = "stake"
     }
 
     override val optionData: List<OptionData> = listOf(
-        OptionData(OptionType.INTEGER, OPT_STAKE, "Credits to wager (${Baccarat.MIN_STAKE}-${Baccarat.MAX_STAKE})", true)
-            .setMinValue(Baccarat.MIN_STAKE)
-            .setMaxValue(Baccarat.MAX_STAKE)
+        OptionData(OptionType.INTEGER, OPT_STAKE, "Credits to wager (per-guild bounds; service rejects out-of-range)", true)
+            .setMinValue(1L)
     )
 
     override fun handle(ctx: CommandContext, requestingUserDto: UserDto, deleteDelay: Int) {

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/BlackjackCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/BlackjackCommand.kt
@@ -60,16 +60,14 @@ class BlackjackCommand @Autowired constructor(
     override val subCommands: List<SubcommandData> = listOf(
         SubcommandData(SUB_SOLO, "Play one hand of blackjack against the dealer.")
             .addOptions(
-                OptionData(OptionType.INTEGER, OPT_STAKE, "Credits to wager (${Blackjack.MIN_STAKE}-${Blackjack.MAX_STAKE})", true)
-                    .setMinValue(Blackjack.MIN_STAKE)
-                    .setMaxValue(Blackjack.MAX_STAKE),
+                OptionData(OptionType.INTEGER, OPT_STAKE, "Credits to wager (per-guild bounds; service rejects out-of-range)", true)
+                    .setMinValue(1L),
                 OptionData(OptionType.BOOLEAN, OPT_AUTO_TOPUP, "Sell TOBY at market to cover any credit shortfall", false)
             ),
         SubcommandData(SUB_CREATE, "Create a multiplayer blackjack table and seat yourself.")
             .addOptions(
-                OptionData(OptionType.INTEGER, OPT_ANTE, "Per-hand ante (${Blackjack.MULTI_MIN_ANTE}-${Blackjack.MULTI_MAX_ANTE})", true)
-                    .setMinValue(Blackjack.MULTI_MIN_ANTE)
-                    .setMaxValue(Blackjack.MULTI_MAX_ANTE),
+                OptionData(OptionType.INTEGER, OPT_ANTE, "Per-hand ante (per-guild bounds; service rejects out-of-range)", true)
+                    .setMinValue(1L),
                 OptionData(OptionType.BOOLEAN, OPT_AUTO_TOPUP, "Sell TOBY at market to cover any credit shortfall", false)
             ),
         SubcommandData(SUB_JOIN, "Join an existing blackjack table at its ante.")

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/CasinoHoldemCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/CasinoHoldemCommand.kt
@@ -38,9 +38,8 @@ class CasinoHoldemCommand @Autowired constructor(
 
     override val optionData: List<OptionData> = listOf(
         OptionData(OptionType.INTEGER, OPT_STAKE,
-            "Credits to ante (${CasinoHoldem.MIN_STAKE}-${CasinoHoldem.MAX_STAKE})", true)
-            .setMinValue(CasinoHoldem.MIN_STAKE)
-            .setMaxValue(CasinoHoldem.MAX_STAKE),
+            "Credits to ante (per-guild bounds; service rejects out-of-range; default ${CasinoHoldem.MIN_STAKE}-${CasinoHoldem.MAX_STAKE})", true)
+            .setMinValue(1L),
         OptionData(OptionType.BOOLEAN, OPT_AUTO_TOPUP,
             "Sell TOBY at market to cover any credit shortfall", false),
     )

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/CoinflipCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/CoinflipCommand.kt
@@ -25,7 +25,7 @@ class CoinflipCommand @Autowired constructor(
 
     override val name: String = "coinflip"
     override val description: String =
-        "Flip a coin for double-or-nothing. Bet ${Coinflip.MIN_STAKE}-${Coinflip.MAX_STAKE} credits."
+        "Flip a coin for double-or-nothing. Stake bounds are per-guild (default ${Coinflip.MIN_STAKE}-${Coinflip.MAX_STAKE})."
 
     companion object {
         private const val OPT_SIDE = "side"
@@ -39,9 +39,8 @@ class CoinflipCommand @Autowired constructor(
         OptionData(OptionType.STRING, OPT_SIDE, "Heads or tails", true)
             .addChoice("Heads", SIDE_HEADS)
             .addChoice("Tails", SIDE_TAILS),
-        OptionData(OptionType.INTEGER, OPT_STAKE, "Credits to wager (10–1000)", true)
-            .setMinValue(Coinflip.MIN_STAKE)
-            .setMaxValue(Coinflip.MAX_STAKE)
+        OptionData(OptionType.INTEGER, OPT_STAKE, "Credits to wager (per-guild bounds; service rejects out-of-range)", true)
+            .setMinValue(1L)
     )
 
     override fun handle(ctx: CommandContext, requestingUserDto: UserDto, deleteDelay: Int) {

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/DiceCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/DiceCommand.kt
@@ -24,7 +24,7 @@ class DiceCommand @Autowired constructor(
 
     override val name: String = "dice"
     override val description: String =
-        "Pick a number 1-6, roll a die. Bet ${Dice.MIN_STAKE}-${Dice.MAX_STAKE} credits."
+        "Pick a number 1-6, roll a die. Stake bounds are per-guild (default ${Dice.MIN_STAKE}-${Dice.MAX_STAKE})."
 
     companion object {
         private const val OPT_PREDICTION = "prediction"
@@ -39,9 +39,8 @@ class DiceCommand @Autowired constructor(
         OptionData(OptionType.INTEGER, OPT_PREDICTION, "Number to predict (1-6)", true)
             .setMinValue(1L)
             .setMaxValue(Dice.DEFAULT_SIDES.toLong()),
-        OptionData(OptionType.INTEGER, OPT_STAKE, "Credits to wager (10-500)", true)
-            .setMinValue(Dice.MIN_STAKE)
-            .setMaxValue(Dice.MAX_STAKE)
+        OptionData(OptionType.INTEGER, OPT_STAKE, "Credits to wager (per-guild bounds; service rejects out-of-range)", true)
+            .setMinValue(1L)
     )
 
     override fun handle(ctx: CommandContext, requestingUserDto: UserDto, deleteDelay: Int) {

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/DuelCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/DuelCommand.kt
@@ -35,7 +35,7 @@ class DuelCommand @Autowired constructor(
 
     override val name: String = "duel"
     override val description: String =
-        "Challenge another user to a 50/50 duel. Stake ${DuelService.MIN_STAKE}-${DuelService.MAX_STAKE} credits."
+        "Challenge another user to a 50/50 duel. Stake bounds are per-guild (default ${DuelService.MIN_STAKE}-${DuelService.MAX_STAKE})."
 
     companion object {
         private const val OPT_USER = "user"
@@ -47,11 +47,10 @@ class DuelCommand @Autowired constructor(
         OptionData(
             OptionType.INTEGER,
             OPT_STAKE,
-            "Credits to wager each (${DuelService.MIN_STAKE}-${DuelService.MAX_STAKE})",
+            "Credits to wager each (per-guild bounds; service rejects out-of-range)",
             true
         )
-            .setMinValue(DuelService.MIN_STAKE)
-            .setMaxValue(DuelService.MAX_STAKE)
+            .setMinValue(1L)
     )
 
     override fun handle(ctx: CommandContext, requestingUserDto: UserDto, deleteDelay: Int) {

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/HighlowCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/HighlowCommand.kt
@@ -30,16 +30,15 @@ class HighlowCommand @Autowired constructor(
 
     override val name: String = "highlow"
     override val description: String =
-        "Predict if the next card is higher or lower than the anchor. Bet ${Highlow.MIN_STAKE}-${Highlow.MAX_STAKE} credits."
+        "Predict if the next card is higher or lower than the anchor. Stake bounds are per-guild (default ${Highlow.MIN_STAKE}-${Highlow.MAX_STAKE})."
 
     companion object {
         private const val OPT_STAKE = "stake"
     }
 
     override val optionData: List<OptionData> = listOf(
-        OptionData(OptionType.INTEGER, OPT_STAKE, "Credits to wager (${Highlow.MIN_STAKE}-${Highlow.MAX_STAKE})", true)
-            .setMinValue(Highlow.MIN_STAKE)
-            .setMaxValue(Highlow.MAX_STAKE)
+        OptionData(OptionType.INTEGER, OPT_STAKE, "Credits to wager (per-guild bounds; service rejects out-of-range)", true)
+            .setMinValue(1L)
     )
 
     override fun handle(ctx: CommandContext, requestingUserDto: UserDto, deleteDelay: Int) {

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/HighlowCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/HighlowCommand.kt
@@ -30,7 +30,7 @@ class HighlowCommand @Autowired constructor(
 
     override val name: String = "highlow"
     override val description: String =
-        "Predict if the next card is higher or lower than the anchor. Stake bounds are per-guild (default ${Highlow.MIN_STAKE}-${Highlow.MAX_STAKE})."
+        "Predict if the next card is higher or lower. Stake bounds per-guild (default ${Highlow.MIN_STAKE}-${Highlow.MAX_STAKE})."
 
     companion object {
         private const val OPT_STAKE = "stake"

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/KenoCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/KenoCommand.kt
@@ -29,7 +29,7 @@ class KenoCommand @Autowired constructor(
     override val name: String = "keno"
     override val description: String =
         "Pick ${Keno.MIN_SPOTS}-${Keno.MAX_SPOTS} numbers from 1-${Keno.POOL_SIZE}; bot draws ${Keno.DRAWS}. " +
-            "Bet ${Keno.MIN_STAKE}-${Keno.MAX_STAKE} credits."
+            "Stake bounds are per-guild (default ${Keno.MIN_STAKE}-${Keno.MAX_STAKE})."
 
     companion object {
         private const val OPT_STAKE = "stake"
@@ -42,10 +42,9 @@ class KenoCommand @Autowired constructor(
     override val optionData: List<OptionData> = listOf(
         OptionData(
             OptionType.INTEGER, OPT_STAKE,
-            "Credits to wager (${Keno.MIN_STAKE}-${Keno.MAX_STAKE})", true
+            "Credits to wager (per-guild bounds; service rejects out-of-range)", true
         )
-            .setMinValue(Keno.MIN_STAKE)
-            .setMaxValue(Keno.MAX_STAKE),
+            .setMinValue(1L),
         OptionData(
             OptionType.INTEGER, OPT_SPOTS,
             "How many numbers to pick (${Keno.MIN_SPOTS}-${Keno.MAX_SPOTS}, default $DEFAULT_SPOTS)", false

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/ScratchCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/ScratchCommand.kt
@@ -26,7 +26,7 @@ class ScratchCommand @Autowired constructor(
     override val name: String = "scratch"
     override val description: String =
         "Buy a ${ScratchCard.CELL_COUNT}-cell scratchcard. Match ${ScratchCard.MATCH_THRESHOLD}+ of any symbol. " +
-            "Bet ${ScratchCard.MIN_STAKE}-${ScratchCard.MAX_STAKE} credits."
+            "Stake bounds are per-guild (default ${ScratchCard.MIN_STAKE}-${ScratchCard.MAX_STAKE})."
 
     companion object {
         private const val OPT_STAKE = "stake"
@@ -34,9 +34,8 @@ class ScratchCommand @Autowired constructor(
     }
 
     override val optionData: List<OptionData> = listOf(
-        OptionData(OptionType.INTEGER, OPT_STAKE, "Credits to wager (10-500)", true)
-            .setMinValue(ScratchCard.MIN_STAKE)
-            .setMaxValue(ScratchCard.MAX_STAKE)
+        OptionData(OptionType.INTEGER, OPT_STAKE, "Credits to wager (per-guild bounds; service rejects out-of-range)", true)
+            .setMinValue(1L)
     )
 
     override fun handle(ctx: CommandContext, requestingUserDto: UserDto, deleteDelay: Int) {

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/SlotsCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/SlotsCommand.kt
@@ -24,7 +24,7 @@ class SlotsCommand @Autowired constructor(
 
     override val name: String = "slots"
     override val description: String =
-        "Spin a 3-reel slot machine. Bet ${SlotMachine.MIN_STAKE}-${SlotMachine.MAX_STAKE} credits per pull."
+        "Spin a 3-reel slot machine. Stake bounds are per-guild (default ${SlotMachine.MIN_STAKE}-${SlotMachine.MAX_STAKE})."
 
     companion object {
         private const val OPT_STAKE = "stake"
@@ -32,9 +32,8 @@ class SlotsCommand @Autowired constructor(
     }
 
     override val optionData: List<OptionData> = listOf(
-        OptionData(OptionType.INTEGER, OPT_STAKE, "Credits to wager (10–500)", true)
-            .setMinValue(SlotMachine.MIN_STAKE)
-            .setMaxValue(SlotMachine.MAX_STAKE)
+        OptionData(OptionType.INTEGER, OPT_STAKE, "Credits to wager (per-guild bounds; service rejects out-of-range)", true)
+            .setMinValue(1L)
     )
 
     override fun handle(ctx: CommandContext, requestingUserDto: UserDto, deleteDelay: Int) {

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/moderation/SetConfigCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/moderation/SetConfigCommand.kt
@@ -112,6 +112,50 @@ class SetConfigCommand @Autowired constructor(
                     config = ConfigDto.Configurations.CASINO_COOLDOWN_SECONDS,
                     gameLabel = "Casino", label = "cooldown seconds", range = 0..30,
                 )
+                // Per-game stake bounds + jackpot scaling anchor. Not
+                // registered as /setconfig OptionData because Discord caps
+                // the command at 25 options and these are better grouped
+                // in the /moderation web tab. Dispatch branches are kept
+                // exhaustive in case the option is registered manually
+                // (e.g. by direct API invocation).
+                ConfigDto.Configurations.DICE_MIN_STAKE -> setMinimumLongConfig(event, optionMapping, deleteDelay,
+                    config = ConfigDto.Configurations.DICE_MIN_STAKE, gameLabel = "Dice", label = "minimum stake", min = 1L, unit = "credits")
+                ConfigDto.Configurations.DICE_MAX_STAKE -> setMinimumLongConfig(event, optionMapping, deleteDelay,
+                    config = ConfigDto.Configurations.DICE_MAX_STAKE, gameLabel = "Dice", label = "maximum stake", min = 1L, unit = "credits")
+                ConfigDto.Configurations.COINFLIP_MIN_STAKE -> setMinimumLongConfig(event, optionMapping, deleteDelay,
+                    config = ConfigDto.Configurations.COINFLIP_MIN_STAKE, gameLabel = "Coinflip", label = "minimum stake", min = 1L, unit = "credits")
+                ConfigDto.Configurations.COINFLIP_MAX_STAKE -> setMinimumLongConfig(event, optionMapping, deleteDelay,
+                    config = ConfigDto.Configurations.COINFLIP_MAX_STAKE, gameLabel = "Coinflip", label = "maximum stake", min = 1L, unit = "credits")
+                ConfigDto.Configurations.SLOTS_MIN_STAKE -> setMinimumLongConfig(event, optionMapping, deleteDelay,
+                    config = ConfigDto.Configurations.SLOTS_MIN_STAKE, gameLabel = "Slots", label = "minimum stake", min = 1L, unit = "credits")
+                ConfigDto.Configurations.SLOTS_MAX_STAKE -> setMinimumLongConfig(event, optionMapping, deleteDelay,
+                    config = ConfigDto.Configurations.SLOTS_MAX_STAKE, gameLabel = "Slots", label = "maximum stake", min = 1L, unit = "credits")
+                ConfigDto.Configurations.HIGHLOW_MIN_STAKE -> setMinimumLongConfig(event, optionMapping, deleteDelay,
+                    config = ConfigDto.Configurations.HIGHLOW_MIN_STAKE, gameLabel = "Highlow", label = "minimum stake", min = 1L, unit = "credits")
+                ConfigDto.Configurations.HIGHLOW_MAX_STAKE -> setMinimumLongConfig(event, optionMapping, deleteDelay,
+                    config = ConfigDto.Configurations.HIGHLOW_MAX_STAKE, gameLabel = "Highlow", label = "maximum stake", min = 1L, unit = "credits")
+                ConfigDto.Configurations.BACCARAT_MIN_STAKE -> setMinimumLongConfig(event, optionMapping, deleteDelay,
+                    config = ConfigDto.Configurations.BACCARAT_MIN_STAKE, gameLabel = "Baccarat", label = "minimum stake", min = 1L, unit = "credits")
+                ConfigDto.Configurations.BACCARAT_MAX_STAKE -> setMinimumLongConfig(event, optionMapping, deleteDelay,
+                    config = ConfigDto.Configurations.BACCARAT_MAX_STAKE, gameLabel = "Baccarat", label = "maximum stake", min = 1L, unit = "credits")
+                ConfigDto.Configurations.KENO_MIN_STAKE -> setMinimumLongConfig(event, optionMapping, deleteDelay,
+                    config = ConfigDto.Configurations.KENO_MIN_STAKE, gameLabel = "Keno", label = "minimum stake", min = 1L, unit = "credits")
+                ConfigDto.Configurations.KENO_MAX_STAKE -> setMinimumLongConfig(event, optionMapping, deleteDelay,
+                    config = ConfigDto.Configurations.KENO_MAX_STAKE, gameLabel = "Keno", label = "maximum stake", min = 1L, unit = "credits")
+                ConfigDto.Configurations.SCRATCH_MIN_STAKE -> setMinimumLongConfig(event, optionMapping, deleteDelay,
+                    config = ConfigDto.Configurations.SCRATCH_MIN_STAKE, gameLabel = "Scratch", label = "minimum stake", min = 1L, unit = "credits")
+                ConfigDto.Configurations.SCRATCH_MAX_STAKE -> setMinimumLongConfig(event, optionMapping, deleteDelay,
+                    config = ConfigDto.Configurations.SCRATCH_MAX_STAKE, gameLabel = "Scratch", label = "maximum stake", min = 1L, unit = "credits")
+                ConfigDto.Configurations.HOLDEM_MIN_STAKE -> setMinimumLongConfig(event, optionMapping, deleteDelay,
+                    config = ConfigDto.Configurations.HOLDEM_MIN_STAKE, gameLabel = "Casino Hold'em", label = "minimum stake", min = 1L, unit = "credits")
+                ConfigDto.Configurations.HOLDEM_MAX_STAKE -> setMinimumLongConfig(event, optionMapping, deleteDelay,
+                    config = ConfigDto.Configurations.HOLDEM_MAX_STAKE, gameLabel = "Casino Hold'em", label = "maximum stake", min = 1L, unit = "credits")
+                ConfigDto.Configurations.DUEL_MIN_STAKE -> setMinimumLongConfig(event, optionMapping, deleteDelay,
+                    config = ConfigDto.Configurations.DUEL_MIN_STAKE, gameLabel = "Duel", label = "minimum stake", min = 1L, unit = "credits")
+                ConfigDto.Configurations.DUEL_MAX_STAKE -> setMinimumLongConfig(event, optionMapping, deleteDelay,
+                    config = ConfigDto.Configurations.DUEL_MAX_STAKE, gameLabel = "Duel", label = "maximum stake", min = 1L, unit = "credits")
+                ConfigDto.Configurations.JACKPOT_STAKE_ANCHOR -> setMinimumLongConfig(event, optionMapping, deleteDelay,
+                    config = ConfigDto.Configurations.JACKPOT_STAKE_ANCHOR, gameLabel = "Jackpot", label = "stake anchor", min = 1L, unit = "credits")
             }
         }
     }
@@ -519,13 +563,13 @@ class SetConfigCommand @Autowired constructor(
             OptionData(
                 OptionType.INTEGER,
                 ConfigDto.Configurations.BLACKJACK_MIN_ANTE.name.lowercase(Locale.getDefault()),
-                "Per-guild minimum blackjack ante (also the solo stake floor). Default 10.",
+                "Per-guild minimum blackjack stake (applies to both solo hands and multi-table antes). Default 10.",
                 false
             ),
             OptionData(
                 OptionType.INTEGER,
                 ConfigDto.Configurations.BLACKJACK_MAX_ANTE.name.lowercase(Locale.getDefault()),
-                "Per-guild maximum blackjack ante (also the solo stake ceiling). Default 500.",
+                "Per-guild maximum blackjack stake (applies to both solo hands and multi-table antes). Default 500.",
                 false
             ),
             OptionData(

--- a/web/src/main/kotlin/web/casino/StakeBounds.kt
+++ b/web/src/main/kotlin/web/casino/StakeBounds.kt
@@ -1,0 +1,122 @@
+package web.casino
+
+import database.dto.ConfigDto
+import database.economy.Baccarat
+import database.economy.Coinflip
+import database.economy.Dice
+import database.economy.Highlow
+import database.economy.Keno
+import database.economy.ScratchCard
+import database.economy.SlotMachine
+import database.blackjack.Blackjack
+import database.poker.CasinoHoldem
+import database.service.ConfigService
+import database.service.DuelService
+import database.service.cfgLong
+import org.springframework.stereotype.Component
+
+/**
+ * Resolves per-guild min/max stake bounds for every minigame the web
+ * surface renders. Mirrors the per-service config reads (e.g.
+ * `DiceService.roll` reading `DICE_MIN_STAKE`/`DICE_MAX_STAKE`) so the
+ * page UI shows the same effective bounds the service will enforce.
+ *
+ * Defaults fall through to each game's compile-time companion-object
+ * constant so guilds that never touch the config see today's behaviour.
+ */
+@Component
+class StakeBounds(
+    private val configService: ConfigService,
+) {
+    fun dice(guildId: Long): Pair<Long, Long> = read(
+        guildId,
+        ConfigDto.Configurations.DICE_MIN_STAKE,
+        ConfigDto.Configurations.DICE_MAX_STAKE,
+        Dice.MIN_STAKE,
+        Dice.MAX_STAKE,
+    )
+
+    fun coinflip(guildId: Long): Pair<Long, Long> = read(
+        guildId,
+        ConfigDto.Configurations.COINFLIP_MIN_STAKE,
+        ConfigDto.Configurations.COINFLIP_MAX_STAKE,
+        Coinflip.MIN_STAKE,
+        Coinflip.MAX_STAKE,
+    )
+
+    fun slots(guildId: Long): Pair<Long, Long> = read(
+        guildId,
+        ConfigDto.Configurations.SLOTS_MIN_STAKE,
+        ConfigDto.Configurations.SLOTS_MAX_STAKE,
+        SlotMachine.MIN_STAKE,
+        SlotMachine.MAX_STAKE,
+    )
+
+    fun highlow(guildId: Long): Pair<Long, Long> = read(
+        guildId,
+        ConfigDto.Configurations.HIGHLOW_MIN_STAKE,
+        ConfigDto.Configurations.HIGHLOW_MAX_STAKE,
+        Highlow.MIN_STAKE,
+        Highlow.MAX_STAKE,
+    )
+
+    fun baccarat(guildId: Long): Pair<Long, Long> = read(
+        guildId,
+        ConfigDto.Configurations.BACCARAT_MIN_STAKE,
+        ConfigDto.Configurations.BACCARAT_MAX_STAKE,
+        Baccarat.MIN_STAKE,
+        Baccarat.MAX_STAKE,
+    )
+
+    fun keno(guildId: Long): Pair<Long, Long> = read(
+        guildId,
+        ConfigDto.Configurations.KENO_MIN_STAKE,
+        ConfigDto.Configurations.KENO_MAX_STAKE,
+        Keno.MIN_STAKE,
+        Keno.MAX_STAKE,
+    )
+
+    fun scratch(guildId: Long): Pair<Long, Long> = read(
+        guildId,
+        ConfigDto.Configurations.SCRATCH_MIN_STAKE,
+        ConfigDto.Configurations.SCRATCH_MAX_STAKE,
+        ScratchCard.MIN_STAKE,
+        ScratchCard.MAX_STAKE,
+    )
+
+    fun blackjackSolo(guildId: Long): Pair<Long, Long> = read(
+        guildId,
+        ConfigDto.Configurations.BLACKJACK_MIN_ANTE,
+        ConfigDto.Configurations.BLACKJACK_MAX_ANTE,
+        Blackjack.MULTI_MIN_ANTE,
+        Blackjack.MULTI_MAX_ANTE,
+    )
+
+    fun casinoHoldem(guildId: Long): Pair<Long, Long> = read(
+        guildId,
+        ConfigDto.Configurations.HOLDEM_MIN_STAKE,
+        ConfigDto.Configurations.HOLDEM_MAX_STAKE,
+        CasinoHoldem.MIN_STAKE,
+        CasinoHoldem.MAX_STAKE,
+    )
+
+    fun duel(guildId: Long): Pair<Long, Long> = read(
+        guildId,
+        ConfigDto.Configurations.DUEL_MIN_STAKE,
+        ConfigDto.Configurations.DUEL_MAX_STAKE,
+        DuelService.MIN_STAKE,
+        DuelService.MAX_STAKE,
+    )
+
+    private fun read(
+        guildId: Long,
+        minKey: ConfigDto.Configurations,
+        maxKey: ConfigDto.Configurations,
+        defaultMin: Long,
+        defaultMax: Long,
+    ): Pair<Long, Long> {
+        val min = configService.cfgLong(minKey, guildId, default = defaultMin, min = 1L)
+        val max = configService.cfgLong(maxKey, guildId, default = defaultMax, min = min)
+        return min to max
+    }
+}

--- a/web/src/main/kotlin/web/controller/BaccaratController.kt
+++ b/web/src/main/kotlin/web/controller/BaccaratController.kt
@@ -19,6 +19,7 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes
 import web.casino.CasinoOutcomeMapper
 import web.casino.CasinoPageContext
 import web.casino.CasinoResponseLike
+import web.casino.StakeBounds
 import web.casino.renderMinigamePage
 import web.service.EconomyWebService
 import web.util.WebGuildAccess
@@ -43,6 +44,7 @@ class BaccaratController(
     private val baccaratService: BaccaratService,
     private val economyWebService: EconomyWebService,
     private val pageContext: CasinoPageContext,
+    private val stakeBounds: StakeBounds,
 ) {
 
     private val errors = CasinoOutcomeMapper { msg -> BaccaratPlayResponse(false, msg) }
@@ -56,8 +58,9 @@ class BaccaratController(
     ): String = pageContext.renderMinigamePage(
         user, guildId, economyWebService, model, ra, template = "baccarat"
     ) {
-        addAttribute("minStake", Baccarat.MIN_STAKE)
-        addAttribute("maxStake", Baccarat.MAX_STAKE)
+        val (minStake, maxStake) = stakeBounds.baccarat(guildId)
+        addAttribute("minStake", minStake)
+        addAttribute("maxStake", maxStake)
         addAttribute("playerMultiplier", Baccarat.PLAYER_WIN_MULT)
         addAttribute("bankerMultiplier", Baccarat.BANKER_WIN_MULT)
         addAttribute("tieMultiplier", Baccarat.TIE_WIN_MULT)

--- a/web/src/main/kotlin/web/controller/BlackjackController.kt
+++ b/web/src/main/kotlin/web/controller/BlackjackController.kt
@@ -30,6 +30,7 @@ import org.springframework.web.bind.annotation.ResponseBody
 import org.springframework.web.servlet.mvc.support.RedirectAttributes
 import web.casino.CasinoOutcomeMapper
 import web.casino.CasinoResponseLike
+import web.casino.StakeBounds
 import web.service.BlackjackWebService
 import web.service.EconomyWebService
 import web.util.WebGuildAccess
@@ -69,6 +70,7 @@ class BlackjackController(
     private val userService: UserService,
     private val jackpotService: JackpotService,
     private val jda: JDA,
+    private val stakeBounds: StakeBounds,
 ) {
 
     /**
@@ -113,8 +115,9 @@ class BlackjackController(
         model.addAttribute("balance", profile?.socialCredit ?: 0L)
         model.addAttribute("jackpotPool", jackpotService.getPool(guildId))
         model.addAttribute("jackpotWinPct", jackpotService.winProbabilityPct(guildId))
-        model.addAttribute("minAnte", Blackjack.MULTI_MIN_ANTE)
-        model.addAttribute("maxAnte", Blackjack.MULTI_MAX_ANTE)
+        val (minAnte, maxAnte) = stakeBounds.blackjackSolo(guildId)
+        model.addAttribute("minAnte", minAnte)
+        model.addAttribute("maxAnte", maxAnte)
         model.addAttribute("maxSeats", Blackjack.MULTI_MAX_SEATS)
         model.addAttribute("tables", blackjackWebService.listMultiTables(guildId))
         model.addAttribute("username", user.displayName())
@@ -135,8 +138,9 @@ class BlackjackController(
         model.addAttribute("balance", profile?.socialCredit ?: 0L)
         model.addAttribute("jackpotPool", jackpotService.getPool(guildId))
         model.addAttribute("jackpotWinPct", jackpotService.winProbabilityPct(guildId))
-        model.addAttribute("minStake", Blackjack.MIN_STAKE)
-        model.addAttribute("maxStake", Blackjack.MAX_STAKE)
+        val (minStake, maxStake) = stakeBounds.blackjackSolo(guildId)
+        model.addAttribute("minStake", minStake)
+        model.addAttribute("maxStake", maxStake)
         model.addAttribute("username", user.displayName())
         model.addAttribute("myDiscordId", discordId.toString())
         "blackjack-solo"

--- a/web/src/main/kotlin/web/controller/CasinoHoldemController.kt
+++ b/web/src/main/kotlin/web/controller/CasinoHoldemController.kt
@@ -25,6 +25,7 @@ import org.springframework.web.bind.annotation.ResponseBody
 import org.springframework.web.servlet.mvc.support.RedirectAttributes
 import web.casino.CasinoOutcomeMapper
 import web.casino.CasinoResponseLike
+import web.casino.StakeBounds
 import web.service.CasinoHoldemWebService
 import web.service.EconomyWebService
 import web.util.WebGuildAccess
@@ -56,6 +57,7 @@ class CasinoHoldemController(
     private val userService: UserService,
     private val jackpotService: JackpotService,
     private val jda: JDA,
+    private val stakeBounds: StakeBounds,
 ) {
 
     private val errors = CasinoOutcomeMapper { msg -> CasinoHoldemActionResponse(ok = false, error = msg) }
@@ -94,8 +96,9 @@ class CasinoHoldemController(
         model.addAttribute("balance", profile?.socialCredit ?: 0L)
         model.addAttribute("jackpotPool", jackpotService.getPool(guildId))
         model.addAttribute("jackpotWinPct", jackpotService.winProbabilityPct(guildId))
-        model.addAttribute("minStake", CasinoHoldem.MIN_STAKE)
-        model.addAttribute("maxStake", CasinoHoldem.MAX_STAKE)
+        val (minStake, maxStake) = stakeBounds.casinoHoldem(guildId)
+        model.addAttribute("minStake", minStake)
+        model.addAttribute("maxStake", maxStake)
         model.addAttribute("callMultiple", CasinoHoldem.CALL_MULTIPLE)
         model.addAttribute("username", user.displayName())
         model.addAttribute("myDiscordId", discordId.toString())

--- a/web/src/main/kotlin/web/controller/CoinflipController.kt
+++ b/web/src/main/kotlin/web/controller/CoinflipController.kt
@@ -19,6 +19,7 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes
 import web.casino.CasinoOutcomeMapper
 import web.casino.CasinoPageContext
 import web.casino.CasinoResponseLike
+import web.casino.StakeBounds
 import web.casino.renderMinigamePage
 import web.service.EconomyWebService
 import web.util.WebGuildAccess
@@ -39,6 +40,7 @@ class CoinflipController(
     private val coinflipService: CoinflipService,
     private val economyWebService: EconomyWebService,
     private val pageContext: CasinoPageContext,
+    private val stakeBounds: StakeBounds,
 ) {
 
     private val errors = CasinoOutcomeMapper { msg -> FlipResponse(false, msg) }
@@ -52,8 +54,9 @@ class CoinflipController(
     ): String = pageContext.renderMinigamePage(
         user, guildId, economyWebService, model, ra, template = "coinflip"
     ) {
-        addAttribute("minStake", Coinflip.MIN_STAKE)
-        addAttribute("maxStake", Coinflip.MAX_STAKE)
+        val (minStake, maxStake) = stakeBounds.coinflip(guildId)
+        addAttribute("minStake", minStake)
+        addAttribute("maxStake", maxStake)
         addAttribute("multiplier", Coinflip.DEFAULT_MULTIPLIER)
     }
 

--- a/web/src/main/kotlin/web/controller/DiceController.kt
+++ b/web/src/main/kotlin/web/controller/DiceController.kt
@@ -19,6 +19,7 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes
 import web.casino.CasinoOutcomeMapper
 import web.casino.CasinoPageContext
 import web.casino.CasinoResponseLike
+import web.casino.StakeBounds
 import web.casino.renderMinigamePage
 import web.service.EconomyWebService
 import web.util.WebGuildAccess
@@ -37,6 +38,7 @@ class DiceController(
     private val diceService: DiceService,
     private val economyWebService: EconomyWebService,
     private val pageContext: CasinoPageContext,
+    private val stakeBounds: StakeBounds,
 ) {
 
     private val errors = CasinoOutcomeMapper { msg -> RollResponse(false, msg) }
@@ -50,8 +52,9 @@ class DiceController(
     ): String = pageContext.renderMinigamePage(
         user, guildId, economyWebService, model, ra, template = "dice"
     ) {
-        addAttribute("minStake", Dice.MIN_STAKE)
-        addAttribute("maxStake", Dice.MAX_STAKE)
+        val (minStake, maxStake) = stakeBounds.dice(guildId)
+        addAttribute("minStake", minStake)
+        addAttribute("maxStake", maxStake)
         addAttribute("sides", Dice.DEFAULT_SIDES)
         addAttribute("multiplier", Dice.DEFAULT_MULTIPLIER)
     }

--- a/web/src/main/kotlin/web/controller/DuelController.kt
+++ b/web/src/main/kotlin/web/controller/DuelController.kt
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Controller
 import org.springframework.ui.Model
 import org.springframework.web.bind.annotation.*
 import org.springframework.web.servlet.mvc.support.RedirectAttributes
+import web.casino.StakeBounds
 import web.event.WebDuelOfferedEvent
 import web.service.DuelWebService
 import web.service.EconomyWebService
@@ -38,6 +39,7 @@ class DuelController(
     private val userService: UserService,
     private val jda: JDA,
     private val eventPublisher: ApplicationEventPublisher,
+    private val stakeBounds: StakeBounds,
 ) {
     @GetMapping("/guilds")
     fun guildList(
@@ -77,8 +79,9 @@ class DuelController(
         model.addAttribute("guildId", guildId.toString())
         model.addAttribute("guildName", guild.name)
         model.addAttribute("balance", balance)
-        model.addAttribute("minStake", DuelService.MIN_STAKE)
-        model.addAttribute("maxStake", DuelService.MAX_STAKE)
+        val (minStake, maxStake) = stakeBounds.duel(guildId)
+        model.addAttribute("minStake", minStake)
+        model.addAttribute("maxStake", maxStake)
         model.addAttribute("pending", pending)
         model.addAttribute("outgoing", outgoing)
         model.addAttribute("ttlLabel", PendingDuelRegistry.formatTtl(pendingDuelRegistry.ttl))

--- a/web/src/main/kotlin/web/controller/HighlowController.kt
+++ b/web/src/main/kotlin/web/controller/HighlowController.kt
@@ -20,6 +20,7 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes
 import web.casino.CasinoOutcomeMapper
 import web.casino.CasinoPageContext
 import web.casino.CasinoResponseLike
+import web.casino.StakeBounds
 import web.casino.renderMinigamePage
 import web.service.EconomyWebService
 import web.util.WebGuildAccess
@@ -31,6 +32,7 @@ class HighlowController(
     private val highlowService: HighlowService,
     private val economyWebService: EconomyWebService,
     private val pageContext: CasinoPageContext,
+    private val stakeBounds: StakeBounds,
 ) {
 
     private val startErrors = CasinoOutcomeMapper { msg -> StartResponse(false, msg) }
@@ -51,9 +53,10 @@ class HighlowController(
         // player isn't asked to lock again on refresh.
         val activeAnchor = activeAnchor(session, guildId)
         val activeStake = activeStake(session, guildId)
+        val (minStake, maxStake) = stakeBounds.highlow(guildId)
 
-        addAttribute("minStake", Highlow.MIN_STAKE)
-        addAttribute("maxStake", Highlow.MAX_STAKE)
+        addAttribute("minStake", minStake)
+        addAttribute("maxStake", maxStake)
         addAttribute("anchor", activeAnchor)
         addAttribute("anchorLabel", activeAnchor?.let { cardLabel(it) } ?: "?")
         addAttribute("higherMultiplier", activeAnchor?.let {
@@ -75,8 +78,9 @@ class HighlowController(
     ): ResponseEntity<StartResponse> = WebGuildAccess.requireMemberForJson(
         user, guildId, economyWebService, errorBuilder = startErrors.errorBuilder
     ) { _ ->
-        if (request.stake < Highlow.MIN_STAKE || request.stake > Highlow.MAX_STAKE) {
-            return@requireMemberForJson startErrors.invalidStake(Highlow.MIN_STAKE, Highlow.MAX_STAKE)
+        val (minStake, maxStake) = stakeBounds.highlow(guildId)
+        if (request.stake < minStake || request.stake > maxStake) {
+            return@requireMemberForJson startErrors.invalidStake(minStake, maxStake)
         }
 
         val anchor = highlowService.dealAnchor()

--- a/web/src/main/kotlin/web/controller/KenoController.kt
+++ b/web/src/main/kotlin/web/controller/KenoController.kt
@@ -18,6 +18,7 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes
 import web.casino.CasinoOutcomeMapper
 import web.casino.CasinoPageContext
 import web.casino.CasinoResponseLike
+import web.casino.StakeBounds
 import web.service.EconomyWebService
 import web.util.WebGuildAccess
 
@@ -40,6 +41,7 @@ class KenoController(
     private val kenoService: KenoService,
     private val economyWebService: EconomyWebService,
     private val pageContext: CasinoPageContext,
+    private val stakeBounds: StakeBounds,
 ) {
 
     private val errors = CasinoOutcomeMapper { msg -> KenoPlayResponse(false, msg) }
@@ -57,8 +59,9 @@ class KenoController(
             ra.addFlashAttribute("error", "Bot is not in that server.")
             return@requireMemberForPage "redirect:/casino/guilds"
         }
-        model.addAttribute("minStake", Keno.MIN_STAKE)
-        model.addAttribute("maxStake", Keno.MAX_STAKE)
+        val (minStake, maxStake) = stakeBounds.keno(guildId)
+        model.addAttribute("minStake", minStake)
+        model.addAttribute("maxStake", maxStake)
         model.addAttribute("minSpots", Keno.MIN_SPOTS)
         model.addAttribute("maxSpots", Keno.MAX_SPOTS)
         model.addAttribute("poolSize", Keno.POOL_SIZE)

--- a/web/src/main/kotlin/web/controller/ScratchController.kt
+++ b/web/src/main/kotlin/web/controller/ScratchController.kt
@@ -20,6 +20,7 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes
 import web.casino.CasinoOutcomeMapper
 import web.casino.CasinoPageContext
 import web.casino.CasinoResponseLike
+import web.casino.StakeBounds
 import web.casino.renderMinigamePage
 import web.service.EconomyWebService
 import web.util.WebGuildAccess
@@ -31,6 +32,7 @@ class ScratchController(
     private val scratchService: ScratchService,
     private val economyWebService: EconomyWebService,
     private val pageContext: CasinoPageContext,
+    private val stakeBounds: StakeBounds,
 ) {
 
     private val errors = CasinoOutcomeMapper { msg -> ScratchResponse(false, msg) }
@@ -44,8 +46,9 @@ class ScratchController(
     ): String = pageContext.renderMinigamePage(
         user, guildId, economyWebService, model, ra, template = "scratch"
     ) {
-        addAttribute("minStake", ScratchCard.MIN_STAKE)
-        addAttribute("maxStake", ScratchCard.MAX_STAKE)
+        val (minStake, maxStake) = stakeBounds.scratch(guildId)
+        addAttribute("minStake", minStake)
+        addAttribute("maxStake", maxStake)
         addAttribute("cellCount", ScratchCard.CELL_COUNT)
         addAttribute("matchThreshold", ScratchCard.MATCH_THRESHOLD)
         addAttribute("matchCounts", (ScratchCard.MATCH_THRESHOLD..ScratchCard.CELL_COUNT).toList())

--- a/web/src/main/kotlin/web/controller/SlotsController.kt
+++ b/web/src/main/kotlin/web/controller/SlotsController.kt
@@ -19,6 +19,7 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes
 import web.casino.CasinoOutcomeMapper
 import web.casino.CasinoPageContext
 import web.casino.CasinoResponseLike
+import web.casino.StakeBounds
 import web.casino.renderMinigamePage
 import web.service.EconomyWebService
 import web.util.WebGuildAccess
@@ -39,6 +40,7 @@ class SlotsController(
     private val slotsService: SlotsService,
     private val economyWebService: EconomyWebService,
     private val pageContext: CasinoPageContext,
+    private val stakeBounds: StakeBounds,
 ) {
 
     private val errors = CasinoOutcomeMapper { msg -> SpinResponse(false, msg) }
@@ -53,8 +55,9 @@ class SlotsController(
         user, guildId, economyWebService, model, ra,
         template = "slots", lobbyPath = "/leaderboards"
     ) {
-        addAttribute("minStake", SlotMachine.MIN_STAKE)
-        addAttribute("maxStake", SlotMachine.MAX_STAKE)
+        val (minStake, maxStake) = stakeBounds.slots(guildId)
+        addAttribute("minStake", minStake)
+        addAttribute("maxStake", maxStake)
         addAttribute("payoutTable", payoutRows())
     }
 

--- a/web/src/main/kotlin/web/service/ModerationWebService.kt
+++ b/web/src/main/kotlin/web/service/ModerationWebService.kt
@@ -410,7 +410,26 @@ class ModerationWebService(
                 n.toString()
             }
             ConfigDto.Configurations.BLACKJACK_MIN_ANTE,
-            ConfigDto.Configurations.BLACKJACK_MAX_ANTE -> {
+            ConfigDto.Configurations.BLACKJACK_MAX_ANTE,
+            ConfigDto.Configurations.DICE_MIN_STAKE,
+            ConfigDto.Configurations.DICE_MAX_STAKE,
+            ConfigDto.Configurations.COINFLIP_MIN_STAKE,
+            ConfigDto.Configurations.COINFLIP_MAX_STAKE,
+            ConfigDto.Configurations.SLOTS_MIN_STAKE,
+            ConfigDto.Configurations.SLOTS_MAX_STAKE,
+            ConfigDto.Configurations.HIGHLOW_MIN_STAKE,
+            ConfigDto.Configurations.HIGHLOW_MAX_STAKE,
+            ConfigDto.Configurations.BACCARAT_MIN_STAKE,
+            ConfigDto.Configurations.BACCARAT_MAX_STAKE,
+            ConfigDto.Configurations.KENO_MIN_STAKE,
+            ConfigDto.Configurations.KENO_MAX_STAKE,
+            ConfigDto.Configurations.SCRATCH_MIN_STAKE,
+            ConfigDto.Configurations.SCRATCH_MAX_STAKE,
+            ConfigDto.Configurations.HOLDEM_MIN_STAKE,
+            ConfigDto.Configurations.HOLDEM_MAX_STAKE,
+            ConfigDto.Configurations.DUEL_MIN_STAKE,
+            ConfigDto.Configurations.DUEL_MAX_STAKE,
+            ConfigDto.Configurations.JACKPOT_STAKE_ANCHOR -> {
                 val n = rawValue.trim().toLongOrNull()
                     ?: return "Value must be a whole number of credits."
                 if (n < 1L) return "Value must be at least 1 credit."

--- a/web/src/main/resources/templates/moderation.html
+++ b/web/src/main/resources/templates/moderation.html
@@ -380,7 +380,7 @@
                     <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
                 </div>
                 <div class="config-row" data-key="BLACKJACK_MIN_ANTE">
-                    <label>Minimum ante per hand (multi &amp; solo; default 10)</label>
+                    <label>Minimum stake per hand (applies to solo &amp; multi; default 10)</label>
                     <input type="number" min="1"
                            th:value="${overview.config['BLACKJACK_MIN_ANTE']}"
                            placeholder="10"
@@ -388,7 +388,7 @@
                     <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
                 </div>
                 <div class="config-row" data-key="BLACKJACK_MAX_ANTE">
-                    <label>Maximum ante per hand (multi &amp; solo; default 500)</label>
+                    <label>Maximum stake per hand (applies to solo &amp; multi; default 500)</label>
                     <input type="number" min="1"
                            th:value="${overview.config['BLACKJACK_MAX_ANTE']}"
                            placeholder="500"
@@ -438,6 +438,171 @@
                     <input type="number" min="1" max="10"
                            th:value="${overview.config['BLACKJACK_BJ_PAYOUT_DEN']}"
                            placeholder="2"
+                           th:disabled="${!isOwner}">
+                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                </div>
+            </div>
+        </details>
+
+        <details class="config-section">
+            <summary>Casino stake bounds</summary>
+            <p class="muted mb-2">
+                Per-game min/max stake. No upper ceiling — set max as high as your economy can sustain.
+                Jackpot win probability scales by <code>stake / anchor</code>, so the anchor below stays a
+                stable reference even when stakes go large; bets at or above the anchor roll at the full
+                <code>JACKPOT_WIN_PCT</code> base probability. Blackjack stakes (solo and multi) are tuned
+                in the Blackjack card above via <code>BLACKJACK_MIN_ANTE</code> / <code>BLACKJACK_MAX_ANTE</code>.
+            </p>
+            <div class="config-grid">
+                <div class="config-row" data-key="JACKPOT_STAKE_ANCHOR">
+                    <label>Jackpot stake anchor (reference stake for jackpot probability scaling; default 500)</label>
+                    <input type="number" min="1"
+                           th:value="${overview.config['JACKPOT_STAKE_ANCHOR']}"
+                           placeholder="500"
+                           th:disabled="${!isOwner}">
+                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                </div>
+                <div class="config-row" data-key="DICE_MIN_STAKE">
+                    <label>Dice minimum stake (default 10)</label>
+                    <input type="number" min="1"
+                           th:value="${overview.config['DICE_MIN_STAKE']}"
+                           placeholder="10"
+                           th:disabled="${!isOwner}">
+                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                </div>
+                <div class="config-row" data-key="DICE_MAX_STAKE">
+                    <label>Dice maximum stake (default 500)</label>
+                    <input type="number" min="1"
+                           th:value="${overview.config['DICE_MAX_STAKE']}"
+                           placeholder="500"
+                           th:disabled="${!isOwner}">
+                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                </div>
+                <div class="config-row" data-key="COINFLIP_MIN_STAKE">
+                    <label>Coinflip minimum stake (default 10)</label>
+                    <input type="number" min="1"
+                           th:value="${overview.config['COINFLIP_MIN_STAKE']}"
+                           placeholder="10"
+                           th:disabled="${!isOwner}">
+                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                </div>
+                <div class="config-row" data-key="COINFLIP_MAX_STAKE">
+                    <label>Coinflip maximum stake (default 1000)</label>
+                    <input type="number" min="1"
+                           th:value="${overview.config['COINFLIP_MAX_STAKE']}"
+                           placeholder="1000"
+                           th:disabled="${!isOwner}">
+                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                </div>
+                <div class="config-row" data-key="SLOTS_MIN_STAKE">
+                    <label>Slots minimum stake (default 10)</label>
+                    <input type="number" min="1"
+                           th:value="${overview.config['SLOTS_MIN_STAKE']}"
+                           placeholder="10"
+                           th:disabled="${!isOwner}">
+                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                </div>
+                <div class="config-row" data-key="SLOTS_MAX_STAKE">
+                    <label>Slots maximum stake (default 500)</label>
+                    <input type="number" min="1"
+                           th:value="${overview.config['SLOTS_MAX_STAKE']}"
+                           placeholder="500"
+                           th:disabled="${!isOwner}">
+                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                </div>
+                <div class="config-row" data-key="HIGHLOW_MIN_STAKE">
+                    <label>Highlow minimum stake (default 10)</label>
+                    <input type="number" min="1"
+                           th:value="${overview.config['HIGHLOW_MIN_STAKE']}"
+                           placeholder="10"
+                           th:disabled="${!isOwner}">
+                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                </div>
+                <div class="config-row" data-key="HIGHLOW_MAX_STAKE">
+                    <label>Highlow maximum stake (default 500)</label>
+                    <input type="number" min="1"
+                           th:value="${overview.config['HIGHLOW_MAX_STAKE']}"
+                           placeholder="500"
+                           th:disabled="${!isOwner}">
+                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                </div>
+                <div class="config-row" data-key="BACCARAT_MIN_STAKE">
+                    <label>Baccarat minimum stake (default 10)</label>
+                    <input type="number" min="1"
+                           th:value="${overview.config['BACCARAT_MIN_STAKE']}"
+                           placeholder="10"
+                           th:disabled="${!isOwner}">
+                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                </div>
+                <div class="config-row" data-key="BACCARAT_MAX_STAKE">
+                    <label>Baccarat maximum stake (default 500)</label>
+                    <input type="number" min="1"
+                           th:value="${overview.config['BACCARAT_MAX_STAKE']}"
+                           placeholder="500"
+                           th:disabled="${!isOwner}">
+                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                </div>
+                <div class="config-row" data-key="KENO_MIN_STAKE">
+                    <label>Keno minimum stake (default 10)</label>
+                    <input type="number" min="1"
+                           th:value="${overview.config['KENO_MIN_STAKE']}"
+                           placeholder="10"
+                           th:disabled="${!isOwner}">
+                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                </div>
+                <div class="config-row" data-key="KENO_MAX_STAKE">
+                    <label>Keno maximum stake (default 500)</label>
+                    <input type="number" min="1"
+                           th:value="${overview.config['KENO_MAX_STAKE']}"
+                           placeholder="500"
+                           th:disabled="${!isOwner}">
+                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                </div>
+                <div class="config-row" data-key="SCRATCH_MIN_STAKE">
+                    <label>Scratch minimum stake (default 10)</label>
+                    <input type="number" min="1"
+                           th:value="${overview.config['SCRATCH_MIN_STAKE']}"
+                           placeholder="10"
+                           th:disabled="${!isOwner}">
+                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                </div>
+                <div class="config-row" data-key="SCRATCH_MAX_STAKE">
+                    <label>Scratch maximum stake (default 500)</label>
+                    <input type="number" min="1"
+                           th:value="${overview.config['SCRATCH_MAX_STAKE']}"
+                           placeholder="500"
+                           th:disabled="${!isOwner}">
+                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                </div>
+                <div class="config-row" data-key="HOLDEM_MIN_STAKE">
+                    <label>Casino Hold'em minimum stake (default 10)</label>
+                    <input type="number" min="1"
+                           th:value="${overview.config['HOLDEM_MIN_STAKE']}"
+                           placeholder="10"
+                           th:disabled="${!isOwner}">
+                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                </div>
+                <div class="config-row" data-key="HOLDEM_MAX_STAKE">
+                    <label>Casino Hold'em maximum stake (default 500)</label>
+                    <input type="number" min="1"
+                           th:value="${overview.config['HOLDEM_MAX_STAKE']}"
+                           placeholder="500"
+                           th:disabled="${!isOwner}">
+                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                </div>
+                <div class="config-row" data-key="DUEL_MIN_STAKE">
+                    <label>Duel minimum stake (default 10)</label>
+                    <input type="number" min="1"
+                           th:value="${overview.config['DUEL_MIN_STAKE']}"
+                           placeholder="10"
+                           th:disabled="${!isOwner}">
+                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                </div>
+                <div class="config-row" data-key="DUEL_MAX_STAKE">
+                    <label>Duel maximum stake (default 500)</label>
+                    <input type="number" min="1"
+                           th:value="${overview.config['DUEL_MAX_STAKE']}"
+                           placeholder="500"
                            th:disabled="${!isOwner}">
                     <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
                 </div>

--- a/web/src/test/kotlin/web/controller/BaccaratControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/BaccaratControllerTest.kt
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.security.oauth2.core.user.OAuth2User
 import web.casino.CasinoPageContext
+import web.casino.StakeBounds
 import web.service.EconomyWebService
 
 class BaccaratControllerTest {
@@ -26,6 +27,7 @@ class BaccaratControllerTest {
     private lateinit var baccaratService: BaccaratService
     private lateinit var economyWebService: EconomyWebService
     private lateinit var pageContext: CasinoPageContext
+    private lateinit var stakeBounds: StakeBounds
     private lateinit var user: OAuth2User
     private lateinit var controller: BaccaratController
 
@@ -34,12 +36,13 @@ class BaccaratControllerTest {
         baccaratService = mockk(relaxed = true)
         economyWebService = mockk(relaxed = true)
         pageContext = mockk(relaxed = true)
+        stakeBounds = mockk(relaxed = true)
         user = mockk {
             every { getAttribute<String>("id") } returns discordId.toString()
             every { getAttribute<String>("username") } returns "tester"
         }
         every { economyWebService.isMember(discordId, guildId) } returns true
-        controller = BaccaratController(baccaratService, economyWebService, pageContext)
+        controller = BaccaratController(baccaratService, economyWebService, pageContext, stakeBounds)
     }
 
     private fun playerCards() = listOf(Card(Rank.FIVE, Suit.SPADES), Card(Rank.THREE, Suit.HEARTS))

--- a/web/src/test/kotlin/web/controller/BlackjackControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/BlackjackControllerTest.kt
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.security.oauth2.core.user.OAuth2User
 import org.springframework.ui.ConcurrentModel
 import org.springframework.web.servlet.mvc.support.RedirectAttributesModelMap
+import web.casino.StakeBounds
 import web.service.BlackjackWebService
 import web.service.EconomyWebService
 
@@ -39,6 +40,7 @@ class BlackjackControllerTest {
     private lateinit var userService: UserService
     private lateinit var jackpotService: JackpotService
     private lateinit var jda: JDA
+    private lateinit var stakeBounds: StakeBounds
     private lateinit var user: OAuth2User
     private lateinit var controller: BlackjackController
 
@@ -51,6 +53,9 @@ class BlackjackControllerTest {
         userService = mockk(relaxed = true)
         jackpotService = mockk(relaxed = true)
         jda = mockk(relaxed = true)
+        stakeBounds = mockk(relaxed = true) {
+            every { blackjackSolo(guildId) } returns (10L to 500L)
+        }
         user = mockk {
             every { getAttribute<String>("id") } returns discordId.toString()
             every { getAttribute<String>("username") } returns "tester"
@@ -58,7 +63,7 @@ class BlackjackControllerTest {
         every { economyWebService.isMember(discordId, guildId) } returns true
         controller = BlackjackController(
             blackjackService, blackjackWebService, tableRegistry,
-            economyWebService, userService, jackpotService, jda,
+            economyWebService, userService, jackpotService, jda, stakeBounds,
         )
     }
 

--- a/web/src/test/kotlin/web/controller/CasinoHoldemControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/CasinoHoldemControllerTest.kt
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.security.oauth2.core.user.OAuth2User
+import web.casino.StakeBounds
 import web.service.CasinoHoldemWebService
 import web.service.EconomyWebService
 import java.time.Instant
@@ -37,6 +38,7 @@ class CasinoHoldemControllerTest {
     private lateinit var userService: UserService
     private lateinit var jackpotService: JackpotService
     private lateinit var jda: JDA
+    private lateinit var stakeBounds: StakeBounds
     private lateinit var user: OAuth2User
     private lateinit var controller: CasinoHoldemController
 
@@ -49,6 +51,7 @@ class CasinoHoldemControllerTest {
         userService = mockk(relaxed = true)
         jackpotService = mockk(relaxed = true)
         jda = mockk(relaxed = true)
+        stakeBounds = mockk(relaxed = true)
         user = mockk {
             every { getAttribute<String>("id") } returns discordId.toString()
             every { getAttribute<String>("username") } returns "tester"
@@ -62,6 +65,7 @@ class CasinoHoldemControllerTest {
             userService = userService,
             jackpotService = jackpotService,
             jda = jda,
+            stakeBounds = stakeBounds,
         )
     }
 

--- a/web/src/test/kotlin/web/controller/CoinflipControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/CoinflipControllerTest.kt
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.security.oauth2.core.user.OAuth2User
 import web.casino.CasinoPageContext
+import web.casino.StakeBounds
 import web.service.EconomyWebService
 
 class CoinflipControllerTest {
@@ -22,6 +23,7 @@ class CoinflipControllerTest {
     private lateinit var coinflipService: CoinflipService
     private lateinit var economyWebService: EconomyWebService
     private lateinit var pageContext: CasinoPageContext
+    private lateinit var stakeBounds: StakeBounds
     private lateinit var user: OAuth2User
     private lateinit var controller: CoinflipController
 
@@ -30,12 +32,13 @@ class CoinflipControllerTest {
         coinflipService = mockk(relaxed = true)
         economyWebService = mockk(relaxed = true)
         pageContext = mockk(relaxed = true)
+        stakeBounds = mockk(relaxed = true)
         user = mockk {
             every { getAttribute<String>("id") } returns discordId.toString()
             every { getAttribute<String>("username") } returns "tester"
         }
         every { economyWebService.isMember(discordId, guildId) } returns true
-        controller = CoinflipController(coinflipService, economyWebService, pageContext)
+        controller = CoinflipController(coinflipService, economyWebService, pageContext, stakeBounds)
     }
 
     @Test

--- a/web/src/test/kotlin/web/controller/DiceControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/DiceControllerTest.kt
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.security.oauth2.core.user.OAuth2User
 import web.casino.CasinoPageContext
+import web.casino.StakeBounds
 import web.service.EconomyWebService
 
 class DiceControllerTest {
@@ -21,6 +22,7 @@ class DiceControllerTest {
     private lateinit var diceService: DiceService
     private lateinit var economyWebService: EconomyWebService
     private lateinit var pageContext: CasinoPageContext
+    private lateinit var stakeBounds: StakeBounds
     private lateinit var user: OAuth2User
     private lateinit var controller: DiceController
 
@@ -29,12 +31,13 @@ class DiceControllerTest {
         diceService = mockk(relaxed = true)
         economyWebService = mockk(relaxed = true)
         pageContext = mockk(relaxed = true)
+        stakeBounds = mockk(relaxed = true)
         user = mockk {
             every { getAttribute<String>("id") } returns discordId.toString()
             every { getAttribute<String>("username") } returns "tester"
         }
         every { economyWebService.isMember(discordId, guildId) } returns true
-        controller = DiceController(diceService, economyWebService, pageContext)
+        controller = DiceController(diceService, economyWebService, pageContext, stakeBounds)
     }
 
     @Test

--- a/web/src/test/kotlin/web/controller/DuelControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/DuelControllerTest.kt
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.security.oauth2.core.user.OAuth2User
+import web.casino.StakeBounds
 import web.event.WebDuelOfferedEvent
 import web.service.DuelWebService
 import web.service.EconomyWebService
@@ -33,6 +34,7 @@ class DuelControllerTest {
     private lateinit var userService: UserService
     private lateinit var jda: JDA
     private lateinit var eventPublisher: ApplicationEventPublisher
+    private lateinit var stakeBounds: StakeBounds
     private lateinit var user: OAuth2User
     private lateinit var controller: DuelController
 
@@ -45,6 +47,7 @@ class DuelControllerTest {
         userService = mockk(relaxed = true)
         jda = mockk(relaxed = true)
         eventPublisher = mockk(relaxed = true)
+        stakeBounds = mockk(relaxed = true)
         user = mockk {
             every { getAttribute<String>("id") } returns discordId.toString()
             every { getAttribute<String>("username") } returns "tester"
@@ -53,7 +56,7 @@ class DuelControllerTest {
         every { economyWebService.isMember(opponentId, guildId) } returns true
         controller = DuelController(
             duelService, duelWebService, pendingDuelRegistry,
-            economyWebService, userService, jda, eventPublisher
+            economyWebService, userService, jda, eventPublisher, stakeBounds
         )
     }
 

--- a/web/src/test/kotlin/web/controller/HighlowControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/HighlowControllerTest.kt
@@ -18,6 +18,7 @@ import org.springframework.security.oauth2.core.user.OAuth2User
 import org.springframework.ui.ConcurrentModel
 import org.springframework.web.servlet.mvc.support.RedirectAttributesModelMap
 import web.casino.CasinoPageContext
+import web.casino.StakeBounds
 import web.service.EconomyWebService
 
 class HighlowControllerTest {
@@ -31,6 +32,7 @@ class HighlowControllerTest {
     private lateinit var highlowService: HighlowService
     private lateinit var economyWebService: EconomyWebService
     private lateinit var pageContext: CasinoPageContext
+    private lateinit var stakeBounds: StakeBounds
     private lateinit var user: OAuth2User
     private lateinit var session: HttpSession
     private lateinit var controller: HighlowController
@@ -40,6 +42,9 @@ class HighlowControllerTest {
         highlowService = mockk(relaxed = true)
         economyWebService = mockk(relaxed = true)
         pageContext = mockk(relaxed = true)
+        stakeBounds = mockk(relaxed = true) {
+            every { highlow(guildId) } returns (Highlow.MIN_STAKE to Highlow.MAX_STAKE)
+        }
         user = mockk {
             every { getAttribute<String>("id") } returns discordId.toString()
             every { getAttribute<String>("username") } returns "tester"
@@ -52,7 +57,7 @@ class HighlowControllerTest {
         }
         every { pageContext.populate(any(), guildId, discordId, user) } returns guild
 
-        controller = HighlowController(highlowService, economyWebService, pageContext)
+        controller = HighlowController(highlowService, economyWebService, pageContext, stakeBounds)
     }
 
     @Test

--- a/web/src/test/kotlin/web/controller/KenoControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/KenoControllerTest.kt
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.security.oauth2.core.user.OAuth2User
 import web.casino.CasinoPageContext
+import web.casino.StakeBounds
 import web.service.EconomyWebService
 
 class KenoControllerTest {
@@ -23,6 +24,7 @@ class KenoControllerTest {
     private lateinit var kenoService: KenoService
     private lateinit var economyWebService: EconomyWebService
     private lateinit var pageContext: CasinoPageContext
+    private lateinit var stakeBounds: StakeBounds
     private lateinit var user: OAuth2User
     private lateinit var controller: KenoController
 
@@ -31,12 +33,13 @@ class KenoControllerTest {
         kenoService = mockk(relaxed = true)
         economyWebService = mockk(relaxed = true)
         pageContext = mockk(relaxed = true)
+        stakeBounds = mockk(relaxed = true)
         user = mockk {
             every { getAttribute<String>("id") } returns discordId.toString()
             every { getAttribute<String>("username") } returns "tester"
         }
         every { economyWebService.isMember(discordId, guildId) } returns true
-        controller = KenoController(kenoService, economyWebService, pageContext)
+        controller = KenoController(kenoService, economyWebService, pageContext, stakeBounds)
     }
 
     @Test

--- a/web/src/test/kotlin/web/controller/ScratchControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/ScratchControllerTest.kt
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.security.oauth2.core.user.OAuth2User
 import web.casino.CasinoPageContext
+import web.casino.StakeBounds
 import web.service.EconomyWebService
 
 class ScratchControllerTest {
@@ -22,6 +23,7 @@ class ScratchControllerTest {
     private lateinit var scratchService: ScratchService
     private lateinit var economyWebService: EconomyWebService
     private lateinit var pageContext: CasinoPageContext
+    private lateinit var stakeBounds: StakeBounds
     private lateinit var user: OAuth2User
     private lateinit var controller: ScratchController
 
@@ -30,12 +32,13 @@ class ScratchControllerTest {
         scratchService = mockk(relaxed = true)
         economyWebService = mockk(relaxed = true)
         pageContext = mockk(relaxed = true)
+        stakeBounds = mockk(relaxed = true)
         user = mockk {
             every { getAttribute<String>("id") } returns discordId.toString()
             every { getAttribute<String>("username") } returns "tester"
         }
         every { economyWebService.isMember(discordId, guildId) } returns true
-        controller = ScratchController(scratchService, economyWebService, pageContext)
+        controller = ScratchController(scratchService, economyWebService, pageContext, stakeBounds)
     }
 
     @Test

--- a/web/src/test/kotlin/web/controller/SlotsControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/SlotsControllerTest.kt
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.security.oauth2.core.user.OAuth2User
 import web.casino.CasinoPageContext
+import web.casino.StakeBounds
 import web.service.EconomyWebService
 
 /**
@@ -28,6 +29,7 @@ class SlotsControllerTest {
     private lateinit var slotsService: SlotsService
     private lateinit var economyWebService: EconomyWebService
     private lateinit var pageContext: CasinoPageContext
+    private lateinit var stakeBounds: StakeBounds
     private lateinit var user: OAuth2User
     private lateinit var controller: SlotsController
 
@@ -36,12 +38,13 @@ class SlotsControllerTest {
         slotsService = mockk(relaxed = true)
         economyWebService = mockk(relaxed = true)
         pageContext = mockk(relaxed = true)
+        stakeBounds = mockk(relaxed = true)
         user = mockk {
             every { getAttribute<String>("id") } returns discordId.toString()
             every { getAttribute<String>("username") } returns "tester"
         }
         every { economyWebService.isMember(discordId, guildId) } returns true
-        controller = SlotsController(slotsService, economyWebService, pageContext)
+        controller = SlotsController(slotsService, economyWebService, pageContext, stakeBounds)
     }
 
     @Test

--- a/web/src/test/kotlin/web/template/ModerationTemplateRowsTest.kt
+++ b/web/src/test/kotlin/web/template/ModerationTemplateRowsTest.kt
@@ -91,6 +91,50 @@ class ModerationTemplateRowsTest {
     }
 
     @Test
+    fun `moderation template surfaces every per-game stake bound and the jackpot anchor as editable rows`() {
+        // Stake bounds and the jackpot scaling anchor live in their own
+        // "Casino stake bounds" card. Without this presence test, a refactor
+        // that drops or renames a row silently kills admin access to that
+        // dimension (and the service-side config quietly falls back to the
+        // hardcoded default).
+        val keys = listOf(
+            ConfigDto.Configurations.JACKPOT_STAKE_ANCHOR,
+            ConfigDto.Configurations.DICE_MIN_STAKE,
+            ConfigDto.Configurations.DICE_MAX_STAKE,
+            ConfigDto.Configurations.COINFLIP_MIN_STAKE,
+            ConfigDto.Configurations.COINFLIP_MAX_STAKE,
+            ConfigDto.Configurations.SLOTS_MIN_STAKE,
+            ConfigDto.Configurations.SLOTS_MAX_STAKE,
+            ConfigDto.Configurations.HIGHLOW_MIN_STAKE,
+            ConfigDto.Configurations.HIGHLOW_MAX_STAKE,
+            ConfigDto.Configurations.BACCARAT_MIN_STAKE,
+            ConfigDto.Configurations.BACCARAT_MAX_STAKE,
+            ConfigDto.Configurations.KENO_MIN_STAKE,
+            ConfigDto.Configurations.KENO_MAX_STAKE,
+            ConfigDto.Configurations.SCRATCH_MIN_STAKE,
+            ConfigDto.Configurations.SCRATCH_MAX_STAKE,
+            ConfigDto.Configurations.HOLDEM_MIN_STAKE,
+            ConfigDto.Configurations.HOLDEM_MAX_STAKE,
+            ConfigDto.Configurations.DUEL_MIN_STAKE,
+            ConfigDto.Configurations.DUEL_MAX_STAKE,
+        )
+        for (key in keys) {
+            assertTrue(
+                html.contains("data-key=\"${key.name}\""),
+                "moderation.html should have a config-row for ${key.name}"
+            )
+        }
+    }
+
+    @Test
+    fun `casino stake bounds section has its own collapsed details block`() {
+        assertTrue(
+            html.contains("<summary>Casino stake bounds</summary>"),
+            "expected a <details><summary>Casino stake bounds</summary> wrapper around the per-game stake rows"
+        )
+    }
+
+    @Test
     fun `every percent config row carries a visible suffix marker`() {
         // Admins editing a percent config used to see a bare number input
         // with no unit indicator. Each *_PCT row now wraps the input in


### PR DESCRIPTION
## Summary

- Adds per-guild **min/max stake config** for every casino minigame (dice, coinflip, slots, highlow, baccarat, keno, scratch, casino-holdem, duel). Solo + multi blackjack continue to share the existing `BLACKJACK_MIN_ANTE` / `BLACKJACK_MAX_ANTE` keys — those keys were already present but the **web controller and Discord slash command surfaces were hardcoded to compile-time constants**, so admin tweaks didn't propagate. Both surfaces now read the live config.
- Adds a new global **`JACKPOT_STAKE_ANCHOR`** config (default 500) that decouples jackpot probability scaling from any individual game's max stake. Today `rollOnWin` scales by `stake / maxStake`; with this PR it scales by `stake / anchor`. Admins can raise per-game max stake arbitrarily without shrinking jackpot odds.
- Removes `setMinValue(GAME.MIN_STAKE)` / `setMaxValue(GAME.MAX_STAKE)` from every economy slash command (replaced with `setMinValue(1L)` for non-negative sanity). Discord no longer rejects out-of-default-range stakes client-side; the service is the single source of truth.
- Groups all 10 new bounds + the jackpot anchor into a dedicated **"Casino stake bounds"** card on the `/moderation` page (the new keys aren't registered as `/setconfig` slash command options because Discord caps a single command at 25 options, and the moderation tab is the cohesive UI for them).

## Implementation notes

- New `JACKPOT_STAKE_ANCHOR` config is read inside `JackpotHelper.rollOnWin` via a new `JackpotHelper.stakeAnchor()` reader (default 500, coerced ≥ 1). All 10 `rollOnWin` callsites lose their `maxStake` argument.
- New shared `ConfigService.cfgLong(...)` extension hoisted out of `BlackjackService.readMultiTableParams` so every game service reads bounds identically. Each service falls back to the existing `Game.MIN_STAKE` / `Game.MAX_STAKE` companion constants when the config row is missing — out-of-the-box behaviour is unchanged.
- New `StakeBounds` web component wraps `ConfigService` for controller use. Every minigame controller takes it as a constructor dep and renders live bounds into the page model.
- `ModerationWebService` extends the existing `BLACKJACK_MIN_ANTE / BLACKJACK_MAX_ANTE` validation arm to cover all 19 new keys (whole number, ≥ 1).

## Test plan

- [x] `:database:test` — `JackpotHelperTest` rewritten to drop the removed `maxStake` parameter and exercise the new anchor-based scaling, including: default fallback, `>= anchor` saturation, divide-by-zero guard.
- [x] `:web:test` — controller tests updated to inject the new `StakeBounds` dep; `ModerationTemplateRowsTest` extended with a presence test for every new row + the new "Casino stake bounds" `<details>` wrapper.
- [ ] Manual end-to-end:
  - In Discord: `/setconfig dice_max_stake` is exposed only via web (option-budget-capped); use `/moderation`. Set `dice_max_stake = 5000`, then `/dice 4000 6` should be accepted and `/dice 5001 6` rejected with `InvalidStake(min, max)`.
  - With `dice_max_stake` unset, the previous default cap (500) still applies.
  - Set `jackpot_stake_anchor = 1000` and `coinflip_max_stake = 500`; a 500-stake coinflip should roll the jackpot at 0.5× base probability (anchor — not the per-game max — drives the scale).
  - `/casino/{guildId}/dice` (web) shows the configured `maxStake` in the stake input's `max` attribute.
- [ ] Multi-blackjack regression: tables created via `/blackjack create` still read `BLACKJACK_MIN_ANTE` / `BLACKJACK_MAX_ANTE` (untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01F1o7Dh6Sq36g4zTKWzj62D)_