### PR TITLE
feat(casino web): pick jackpot refund target from member dropdown with credit shown

### DIFF
--- a/web/src/main/resources/static/js/moderation.js
+++ b/web/src/main/resources/static/js/moderation.js
@@ -296,15 +296,31 @@
     }
     const jackpotRefundForm = document.querySelector('.jackpot-refund-form');
     if (jackpotRefundForm) {
+        const sourceSelect = jackpotRefundForm.elements.sourceDiscordId;
+        const balanceHint = jackpotRefundForm.querySelector('.jackpot-refund-balance');
+        const balanceValue = jackpotRefundForm.querySelector('.jackpot-refund-balance-value');
+        const updateBalanceHint = () => {
+            const opt = sourceSelect.selectedOptions[0];
+            const credit = opt && opt.dataset.credit;
+            if (credit != null && opt.value) {
+                balanceValue.textContent = credit;
+                balanceHint.hidden = false;
+            } else {
+                balanceHint.hidden = true;
+            }
+        };
+        sourceSelect.addEventListener('change', updateBalanceHint);
         jackpotRefundForm.addEventListener('submit', e => {
             e.preventDefault();
-            const sourceDiscordId = jackpotRefundForm.elements.sourceDiscordId.value.trim();
+            const sourceDiscordId = sourceSelect.value;
             const amount = Number(jackpotRefundForm.elements.amount.value);
             if (!/^[0-9]+$/.test(sourceDiscordId) || !Number.isFinite(amount) || amount <= 0) {
-                toast('Enter a valid Discord ID and a positive amount.', 'error');
+                toast('Select a member and enter a positive amount.', 'error');
                 return;
             }
-            if (!confirm('Refund ' + amount + ' credits from user ' + sourceDiscordId + ' into the jackpot pool?')) return;
+            const selectedOpt = sourceSelect.selectedOptions[0];
+            const memberLabel = selectedOpt ? (selectedOpt.textContent.split(' — ')[0] || sourceDiscordId) : sourceDiscordId;
+            if (!confirm('Refund ' + amount + ' credits from ' + memberLabel + ' into the jackpot pool?')) return;
             const submitBtn = jackpotRefundForm.querySelector('button[type="submit"]');
             submitBtn.disabled = true;
             postJson('/moderation/' + guildId + '/jackpot/refund', {
@@ -314,11 +330,17 @@
                 submitBtn.disabled = false;
                 if (r && r.ok) {
                     if (jackpotPoolEl) jackpotPoolEl.textContent = String(r.newPool ?? 0);
+                    if (selectedOpt && r.newSourceBalance != null) {
+                        selectedOpt.dataset.credit = String(r.newSourceBalance);
+                        const name = selectedOpt.textContent.split(' — ')[0];
+                        selectedOpt.textContent = name + ' — ' + r.newSourceBalance + ' credits';
+                    }
                     toast(
                         'Refunded ' + (r.drained ?? 0) + ' credits. New pool: ' + (r.newPool ?? 0) + '.',
                         'success'
                     );
                     jackpotRefundForm.reset();
+                    updateBalanceHint();
                 } else {
                     toast(r?.error || 'Could not refund to jackpot.', 'error');
                 }

--- a/web/src/main/resources/templates/moderation.html
+++ b/web/src/main/resources/templates/moderation.html
@@ -558,9 +558,19 @@
             </p>
             <form class="jackpot-refund-form" autocomplete="off">
                 <label>
-                    User Discord ID
-                    <input type="text" name="sourceDiscordId" inputmode="numeric" pattern="[0-9]+" required>
+                    User
+                    <select name="sourceDiscordId" required>
+                        <option value="" disabled selected>Select a member…</option>
+                        <option th:each="m : ${overview.members}"
+                                th:value="${m.id}"
+                                th:attr="data-credit=${m.socialCredit}"
+                                th:text="${m.name} + ' — ' + ${m.socialCredit} + ' credits'">
+                        </option>
+                    </select>
                 </label>
+                <p class="muted jackpot-refund-balance" hidden>
+                    Current balance: <span class="jackpot-refund-balance-value">0</span> credits
+                </p>
                 <label>
                     Amount
                     <input type="number" name="amount" min="1" required>


### PR DESCRIPTION
## Summary
- Replace the raw Discord ID input on the casino tab's "Refund from user" form with a `<select>` of non-bot guild members, each option labelled with the member's current social credit (e.g. `Alice — 12,345 credits`).
- Show a "Current balance" hint next to the amount field that updates as the picked member changes, so partial refunds can be portioned at a glance.
- After a successful refund, update the chosen option's credit in place from `newSourceBalance` so the dropdown stays truthful without a page reload.
- No backend changes — `overview.members` already carries `socialCredit`, and `/moderation/{guildId}/jackpot/refund` still takes `sourceDiscordId` + `amount`.

## Test plan
- [ ] Open `/moderation/{guildId}` as a guild owner, switch to the **Casino** tab, and confirm the "User" dropdown is populated with non-bot members and each option ends with `— N credits`.
- [ ] Pick a member; confirm the "Current balance" hint appears with their credit total and disappears when the placeholder is re-selected.
- [ ] Submit a partial refund (e.g. 100 from a member with 5000) and confirm: confirm dialog shows the member name (not an ID), the pool counter at the top updates, the toast reports the drained amount, and the dropdown option for that member updates to the new balance.
- [ ] Reload the page and verify the persisted member balance matches what the dropdown showed after the refund.
- [ ] Try submitting without picking a member — should be blocked by the `required` attribute / JS guard.

https://claude.ai/code/session_01BwdEAazdYWoqpCKATrguZu

---
_Generated by [Claude Code](https://claude.ai/code/session_01BwdEAazdYWoqpCKATrguZu)_