### PR TITLE
fix(casino web): style the casino tab so it stops rendering as bare boxes

### DIFF
--- a/web/src/main/resources/static/css/moderation.css
+++ b/web/src/main/resources/static/css/moderation.css
@@ -299,6 +299,84 @@
     gap: 8px;
 }
 
+/* Casino tab */
+.mod-card-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: var(--space-3);
+    max-width: 760px;
+    margin-bottom: var(--space-3);
+}
+.mod-card {
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+}
+.mod-card-wide { max-width: 560px; }
+.mod-card h3 {
+    margin: 0;
+    font-size: 0.78rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--text-muted);
+    font-weight: 600;
+}
+.mod-card p { margin: 0; }
+.mod-card .btn,
+.mod-card .btn-danger { align-self: flex-start; }
+.big-number {
+    font-size: 2rem;
+    font-weight: 700;
+    color: var(--text);
+    line-height: 1;
+    font-variant-numeric: tabular-nums;
+}
+.big-number .muted {
+    font-size: 0.85rem;
+    font-weight: 400;
+    margin-left: 4px;
+}
+
+.jackpot-refund-form {
+    display: grid;
+    gap: var(--space-3);
+    margin-top: var(--space-2);
+}
+.jackpot-refund-form label {
+    display: grid;
+    gap: 6px;
+    font-size: 0.85rem;
+    color: var(--text-muted);
+}
+.jackpot-refund-form select,
+.jackpot-refund-form input {
+    padding: 6px 10px;
+    background: var(--bg);
+    color: var(--text);
+    border: 1px solid var(--border-strong);
+    border-radius: var(--radius-sm);
+    font: inherit;
+}
+.jackpot-refund-form select:focus,
+.jackpot-refund-form input:focus {
+    outline: none;
+    border-color: var(--accent);
+    box-shadow: 0 0 0 3px var(--accent-soft);
+}
+.jackpot-refund-form button[type="submit"] { justify-self: start; }
+.jackpot-refund-balance {
+    font-size: 0.85rem;
+}
+.jackpot-refund-balance-value {
+    color: var(--text);
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
+}
+
 @media (max-width: 640px) {
     .tab-btn { padding: 8px 10px; font-size: 0.9rem; }
 

--- a/web/src/main/resources/static/js/moderation.js
+++ b/web/src/main/resources/static/js/moderation.js
@@ -296,15 +296,31 @@
     }
     const jackpotRefundForm = document.querySelector('.jackpot-refund-form');
     if (jackpotRefundForm) {
+        const sourceSelect = jackpotRefundForm.elements.sourceDiscordId;
+        const balanceHint = jackpotRefundForm.querySelector('.jackpot-refund-balance');
+        const balanceValue = jackpotRefundForm.querySelector('.jackpot-refund-balance-value');
+        const updateBalanceHint = () => {
+            const opt = sourceSelect.selectedOptions[0];
+            const credit = opt && opt.dataset.credit;
+            if (credit != null && opt.value) {
+                balanceValue.textContent = credit;
+                balanceHint.hidden = false;
+            } else {
+                balanceHint.hidden = true;
+            }
+        };
+        sourceSelect.addEventListener('change', updateBalanceHint);
         jackpotRefundForm.addEventListener('submit', e => {
             e.preventDefault();
-            const sourceDiscordId = jackpotRefundForm.elements.sourceDiscordId.value.trim();
+            const sourceDiscordId = sourceSelect.value;
             const amount = Number(jackpotRefundForm.elements.amount.value);
             if (!/^[0-9]+$/.test(sourceDiscordId) || !Number.isFinite(amount) || amount <= 0) {
-                toast('Enter a valid Discord ID and a positive amount.', 'error');
+                toast('Select a member and enter a positive amount.', 'error');
                 return;
             }
-            if (!confirm('Refund ' + amount + ' credits from user ' + sourceDiscordId + ' into the jackpot pool?')) return;
+            const selectedOpt = sourceSelect.selectedOptions[0];
+            const memberLabel = selectedOpt ? (selectedOpt.textContent.split(' — ')[0] || sourceDiscordId) : sourceDiscordId;
+            if (!confirm('Refund ' + amount + ' credits from ' + memberLabel + ' into the jackpot pool?')) return;
             const submitBtn = jackpotRefundForm.querySelector('button[type="submit"]');
             submitBtn.disabled = true;
             postJson('/moderation/' + guildId + '/jackpot/refund', {
@@ -314,11 +330,17 @@
                 submitBtn.disabled = false;
                 if (r && r.ok) {
                     if (jackpotPoolEl) jackpotPoolEl.textContent = String(r.newPool ?? 0);
+                    if (selectedOpt && r.newSourceBalance != null) {
+                        selectedOpt.dataset.credit = String(r.newSourceBalance);
+                        const name = selectedOpt.textContent.split(' — ')[0];
+                        selectedOpt.textContent = name + ' — ' + r.newSourceBalance + ' credits';
+                    }
                     toast(
                         'Refunded ' + (r.drained ?? 0) + ' credits. New pool: ' + (r.newPool ?? 0) + '.',
                         'success'
                     );
                     jackpotRefundForm.reset();
+                    updateBalanceHint();
                 } else {
                     toast(r?.error || 'Could not refund to jackpot.', 'error');
                 }

--- a/web/src/main/resources/templates/moderation.html
+++ b/web/src/main/resources/templates/moderation.html
@@ -535,21 +535,21 @@
             still drain a contaminated pool or claw an exploit refund
             back into it.
         </p>
-        <div class="mod-card">
-            <div>
+        <div class="mod-card-grid">
+            <div class="mod-card">
                 <h3>Current pool</h3>
                 <p class="big-number">
                     <span id="jackpot-pool" th:text="${jackpotPool}">0</span>
                     <span class="muted">credits</span>
                 </p>
             </div>
+            <div class="mod-card">
+                <h3>Reset jackpot pool</h3>
+                <p class="muted">Zero the pool. The drained amount is logged.</p>
+                <button id="jackpot-reset" type="button" class="btn btn-danger">Reset pool</button>
+            </div>
         </div>
-        <div class="mod-card">
-            <h3>Reset jackpot pool</h3>
-            <p class="muted">Zero the pool. The drained amount is logged.</p>
-            <button id="jackpot-reset" type="button" class="btn btn-warning">Reset pool</button>
-        </div>
-        <div class="mod-card">
+        <div class="mod-card mod-card-wide">
             <h3>Refund from user</h3>
             <p class="muted">
                 Debit a user's social credit by the given amount and

--- a/web/src/main/resources/templates/moderation.html
+++ b/web/src/main/resources/templates/moderation.html
@@ -558,9 +558,19 @@
             </p>
             <form class="jackpot-refund-form" autocomplete="off">
                 <label>
-                    User Discord ID
-                    <input type="text" name="sourceDiscordId" inputmode="numeric" pattern="[0-9]+" required>
+                    User
+                    <select name="sourceDiscordId" required>
+                        <option value="" disabled selected>Select a member…</option>
+                        <option th:each="m : ${overview.members}"
+                                th:value="${m.id}"
+                                th:attr="data-credit=${m.socialCredit}"
+                                th:text="${m.name} + ' — ' + ${m.socialCredit} + ' credits'">
+                        </option>
+                    </select>
                 </label>
+                <p class="muted jackpot-refund-balance" hidden>
+                    Current balance: <span class="jackpot-refund-balance-value">0</span> credits
+                </p>
                 <label>
                     Amount
                     <input type="number" name="amount" min="1" required>


### PR DESCRIPTION
## Summary
The casino tab on `/moderation/{guildId}` was hooked up with class names that no CSS file ever defined (`.mod-card`, `.big-number`, `.btn-warning`), so the pool counter, reset card, and refund form rendered as unstyled stacked `<div>`s with default form controls.
- Add `.mod-card` / `.mod-card-grid` / `.big-number` styles modelled on the existing `.voice-card` / `.config-section` look so the tab visually matches the rest of the page.
- Lay out the pool + reset cards side-by-side at the top (`auto-fit, minmax(260px, 1fr)`), with the refund card flowing below.
- Style `.jackpot-refund-form` with the same grid-label pattern as `.move-form` / `.poll-form`, including focus rings and a tidy "Current balance" hint row.
- Drop the orphan `.btn-warning` class — resetting the pool is destructive, so reuse the existing `.btn-danger` treatment.

## Test plan
- [ ] Open `/moderation/{guildId}` → **Casino** tab and confirm the pool + reset cards appear side-by-side on a wide viewport with proper card chrome (border, padding, elevated background).
- [ ] Confirm the "Current pool" number renders large with tabular-nums alignment.
- [ ] Confirm the "Reset pool" button uses the danger styling (red border + hover) consistent with the kick button.
- [ ] In the refund card, confirm the user dropdown, balance hint, and amount input have consistent label styling, padding, and focus ring matching the Voice/Poll forms.
- [ ] Resize to <640px and confirm the cards stack and stay readable.

https://claude.ai/code/session_01BwdEAazdYWoqpCKATrguZu

---
_Generated by [Claude Code](https://claude.ai/code/session_01BwdEAazdYWoqpCKATrguZu)_