### PR TITLE
perf: reduce JVM memory footprint to fit 500MB server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,4 @@ FROM eclipse-temurin:21-jre
 RUN mkdir /app
 COPY --from=build /home/gradle/src/application/build/libs/*.jar /app/toby-bot.jar
 EXPOSE 8080
-ENTRYPOINT ["java", "-Xms64m", "-Xmx320m", "-XX:+UseZGC", "-jar", "/app/toby-bot.jar"]
+ENTRYPOINT ["java", "-Xms64m", "-Xmx320m", "-XX:+UseSerialGC", "-XX:MaxMetaspaceSize=128m", "-Xss512k", "-jar", "/app/toby-bot.jar"]

--- a/application/src/main/resources/application.properties
+++ b/application/src/main/resources/application.properties
@@ -24,6 +24,10 @@ spring.flyway.locations=classpath:db/migration
 spring.flyway.baseline-on-migrate=true
 spring.flyway.baseline-version=0
 
+# Tomcat thread pool
+server.tomcat.threads.max=10
+server.tomcat.threads.min-spare=2
+
 # Multipart limits for intro uploads
 spring.servlet.multipart.max-file-size=600KB
 spring.servlet.multipart.max-request-size=600KB

--- a/common/src/main/kotlin/common/configuration/CachingConfig.kt
+++ b/common/src/main/kotlin/common/configuration/CachingConfig.kt
@@ -19,7 +19,7 @@ class CachingConfig {
         val manager = CaffeineCacheManager("configs", "brothers", "users", "music", "excuses", "tobyCoinMarkets")
         manager.setCaffeine(
             Caffeine.newBuilder()
-                .maximumSize(500)
+                .maximumSize(100)
                 .expireAfterWrite(30, TimeUnit.MINUTES)
         )
         return manager

--- a/database/src/main/kotlin/database/blackjack/BlackjackTableRegistry.kt
+++ b/database/src/main/kotlin/database/blackjack/BlackjackTableRegistry.kt
@@ -1,11 +1,10 @@
 package database.blackjack
 
-import jakarta.annotation.PreDestroy
+import database.configuration.RegistryScheduler
 import org.springframework.stereotype.Component
 import java.time.Duration
 import java.time.Instant
 import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.TimeUnit
@@ -26,7 +25,7 @@ import java.util.concurrent.atomic.AtomicLong
 class BlackjackTableRegistry(
     private val idleTtl: Duration = DEFAULT_IDLE_TTL,
     sweepInterval: Duration = DEFAULT_SWEEP_INTERVAL,
-    private val scheduler: ScheduledExecutorService = Executors.newScheduledThreadPool(1)
+    private val scheduler: ScheduledExecutorService = RegistryScheduler.instance
 ) {
     private val tables = ConcurrentHashMap<Long, BlackjackTable>()
     private val seq = AtomicLong()
@@ -170,11 +169,6 @@ class BlackjackTableRegistry(
                 }
             }
         }
-    }
-
-    @PreDestroy
-    fun shutdown() {
-        scheduler.shutdownNow()
     }
 
     companion object {

--- a/database/src/main/kotlin/database/configuration/DatabaseConfig.kt
+++ b/database/src/main/kotlin/database/configuration/DatabaseConfig.kt
@@ -30,8 +30,9 @@ class DatabaseConfig(private val env: Environment) {
         dataSource.jdbcUrl = dbUrl
         dataSource.username = username
         dataSource.password = password
+        dataSource.maximumPoolSize = 3
+        dataSource.minimumIdle = 1
 
-        // Additional HikariCP settings can be set here if necessary
         return dataSource
     }
 

--- a/database/src/main/kotlin/database/configuration/RegistryScheduler.kt
+++ b/database/src/main/kotlin/database/configuration/RegistryScheduler.kt
@@ -1,0 +1,17 @@
+package database.configuration
+
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.ThreadFactory
+import java.util.concurrent.atomic.AtomicInteger
+
+object RegistryScheduler {
+    val instance: ScheduledExecutorService = Executors.newScheduledThreadPool(3, DaemonThreadFactory)
+
+    private object DaemonThreadFactory : ThreadFactory {
+        private val seq = AtomicInteger()
+        override fun newThread(r: Runnable) = Thread(r, "registry-scheduler-${seq.incrementAndGet()}").apply {
+            isDaemon = true
+        }
+    }
+}

--- a/database/src/main/kotlin/database/duel/PendingDuelRegistry.kt
+++ b/database/src/main/kotlin/database/duel/PendingDuelRegistry.kt
@@ -1,11 +1,10 @@
 package database.duel
 
-import jakarta.annotation.PreDestroy
+import database.configuration.RegistryScheduler
 import org.springframework.stereotype.Component
 import java.time.Duration
 import java.time.Instant
 import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicLong
@@ -23,7 +22,7 @@ import java.util.concurrent.atomic.AtomicLong
 @Component
 class PendingDuelRegistry(
     val ttl: Duration = DEFAULT_TTL,
-    private val scheduler: ScheduledExecutorService = Executors.newScheduledThreadPool(2)
+    private val scheduler: ScheduledExecutorService = RegistryScheduler.instance
 ) {
     data class PendingDuel(
         val id: Long,
@@ -86,11 +85,6 @@ class PendingDuelRegistry(
         offers.values.filter { it.initiatorDiscordId == discordId && it.guildId == guildId }
 
     fun get(id: Long): PendingDuel? = offers[id]
-
-    @PreDestroy
-    fun shutdown() {
-        scheduler.shutdownNow()
-    }
 
     companion object {
         val DEFAULT_TTL: Duration = Duration.ofMinutes(3)

--- a/database/src/main/kotlin/database/poker/CasinoHoldemTableRegistry.kt
+++ b/database/src/main/kotlin/database/poker/CasinoHoldemTableRegistry.kt
@@ -1,11 +1,10 @@
 package database.poker
 
-import jakarta.annotation.PreDestroy
+import database.configuration.RegistryScheduler
 import org.springframework.stereotype.Component
 import java.time.Duration
 import java.time.Instant
 import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicLong
@@ -25,7 +24,7 @@ import java.util.concurrent.atomic.AtomicLong
 class CasinoHoldemTableRegistry(
     private val idleTtl: Duration = DEFAULT_IDLE_TTL,
     sweepInterval: Duration = DEFAULT_SWEEP_INTERVAL,
-    private val scheduler: ScheduledExecutorService = Executors.newScheduledThreadPool(1),
+    private val scheduler: ScheduledExecutorService = RegistryScheduler.instance,
 ) {
     private val tables = ConcurrentHashMap<Long, CasinoHoldemTable>()
     private val seq = AtomicLong()
@@ -99,11 +98,6 @@ class CasinoHoldemTableRegistry(
                 }
             }
         }
-    }
-
-    @PreDestroy
-    fun shutdown() {
-        scheduler.shutdownNow()
     }
 
     companion object {

--- a/database/src/main/kotlin/database/poker/PokerTableRegistry.kt
+++ b/database/src/main/kotlin/database/poker/PokerTableRegistry.kt
@@ -1,11 +1,10 @@
 package database.poker
 
-import jakarta.annotation.PreDestroy
+import database.configuration.RegistryScheduler
 import org.springframework.stereotype.Component
 import java.time.Duration
 import java.time.Instant
 import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.TimeUnit
@@ -35,7 +34,7 @@ import java.util.concurrent.atomic.AtomicLong
 class PokerTableRegistry(
     private val idleTtl: Duration = DEFAULT_IDLE_TTL,
     sweepInterval: Duration = DEFAULT_SWEEP_INTERVAL,
-    private val scheduler: ScheduledExecutorService = Executors.newScheduledThreadPool(2)
+    private val scheduler: ScheduledExecutorService = RegistryScheduler.instance
 ) {
     private val tables = ConcurrentHashMap<Long, PokerTable>()
     private val seq = AtomicLong()
@@ -205,11 +204,6 @@ class PokerTableRegistry(
                 }
             }
         }
-    }
-
-    @PreDestroy
-    fun shutdown() {
-        scheduler.shutdownNow()
     }
 
     companion object {

--- a/discord-bot/src/main/kotlin/bot/toby/managers/NowPlayingManager.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/managers/NowPlayingManager.kt
@@ -14,7 +14,7 @@ import kotlin.concurrent.read
 import kotlin.concurrent.write
 
 class NowPlayingManager(
-    private val scheduler: ScheduledExecutorService = Executors.newScheduledThreadPool(10),
+    private val scheduler: ScheduledExecutorService = Executors.newScheduledThreadPool(2),
 ) {
     private val logger: DiscordLogger = DiscordLogger.createLogger(this::class.java)
     private val guildLastNowPlayingMessage = ConcurrentHashMap<Long, Message>()


### PR DESCRIPTION
## Summary

- **Switch ZGC → SerialGC** and add `-XX:MaxMetaspaceSize=128m -Xss512k` to Dockerfile — ZGC's multi-mapped memory overhead is excessive for a 320MB heap; SerialGC has the smallest footprint (~40–80MB savings)
- **Shrink HikariCP pool** from default 10 → 3 connections, **Caffeine caches** from 500 → 100 items per cache, and **Tomcat thread pool** from max 200 → 10
- **Consolidate 4 registry scheduler pools** (Poker, Blackjack, CasinoHoldem, PendingDuel — 6 threads across 4 pools) into a single shared 3-thread daemon pool via `RegistryScheduler`
- **Reduce NowPlayingManager** thread pool from 10 → 2

Estimated total savings: **60–120MB RSS**, bringing the bot from ~470MB down to ~350–410MB on the 500MB server.

## Test plan

- [x] All unit tests pass (`./gradlew test -x :application:test`)
- [ ] Deploy and verify RSS via `docker stats --no-stream`
- [ ] Check `/actuator/metrics/jvm.memory.used` and `/actuator/metrics/jvm.threads.live`
- [ ] Verify casino games (poker, blackjack, casino hold'em) still function with shared scheduler
- [ ] Verify duel offers still timeout correctly
- [ ] Verify music playback now-playing embeds still update
- [ ] Monitor for `StackOverflowError` (unlikely with 512k stacks, bump to 768k if seen)

🤖 Generated with [Claude Code](https://claude.com/claude-code)