### PR TITLE
fix(moderation web): snowflake ID precision loss breaks jackpot refund and other admin actions

### DIFF
--- a/database/src/main/kotlin/database/service/CasinoAdminService.kt
+++ b/database/src/main/kotlin/database/service/CasinoAdminService.kt
@@ -23,7 +23,6 @@ class CasinoAdminService(
 
     sealed interface RefundOutcome {
         data class Ok(val drained: Long, val newPool: Long, val newSourceBalance: Long) : RefundOutcome
-        data object UnknownUser : RefundOutcome
         data class Insufficient(val have: Long, val needed: Long) : RefundOutcome
         data class InvalidAmount(val amount: Long) : RefundOutcome
     }
@@ -46,10 +45,9 @@ class CasinoAdminService(
     ): RefundOutcome {
         if (amount <= 0L) return RefundOutcome.InvalidAmount(amount)
         val user = userService.getUserByIdForUpdate(sourceDiscordId, guildId)
-            ?: return RefundOutcome.UnknownUser
-        val balance = user.socialCredit ?: 0L
+        val balance = user?.socialCredit ?: 0L
         if (balance < amount) return RefundOutcome.Insufficient(balance, amount)
-        user.socialCredit = balance - amount
+        user!!.socialCredit = balance - amount
         userService.updateUser(user)
         val newPool = jackpotService.addToPool(guildId, amount)
         return RefundOutcome.Ok(

--- a/database/src/test/kotlin/database/service/CasinoAdminServiceTest.kt
+++ b/database/src/test/kotlin/database/service/CasinoAdminServiceTest.kt
@@ -1,0 +1,88 @@
+package database.service
+
+import database.dto.UserDto
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class CasinoAdminServiceTest {
+
+    private val discordId = 100L
+    private val guildId = 200L
+
+    private lateinit var userService: UserService
+    private lateinit var jackpotService: JackpotService
+    private lateinit var service: CasinoAdminService
+
+    @BeforeEach
+    fun setup() {
+        userService = mockk(relaxed = true)
+        jackpotService = mockk(relaxed = true)
+        service = CasinoAdminService(userService, jackpotService)
+    }
+
+    @Test
+    fun `refundToJackpot returns InvalidAmount for zero amount`() {
+        val result = service.refundToJackpot(discordId, guildId, 0L)
+        assertEquals(CasinoAdminService.RefundOutcome.InvalidAmount(0L), result)
+    }
+
+    @Test
+    fun `refundToJackpot returns InvalidAmount for negative amount`() {
+        val result = service.refundToJackpot(discordId, guildId, -5L)
+        assertEquals(CasinoAdminService.RefundOutcome.InvalidAmount(-5L), result)
+    }
+
+    @Test
+    fun `refundToJackpot returns Insufficient with have=0 when user record is missing`() {
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns null
+
+        val result = service.refundToJackpot(discordId, guildId, 100L)
+
+        assertEquals(CasinoAdminService.RefundOutcome.Insufficient(have = 0L, needed = 100L), result)
+        verify(exactly = 0) { userService.updateUser(any()) }
+        verify(exactly = 0) { jackpotService.addToPool(any(), any()) }
+    }
+
+    @Test
+    fun `refundToJackpot returns Insufficient when balance is less than amount`() {
+        val user = UserDto(discordId = discordId, guildId = guildId).apply { socialCredit = 50L }
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns user
+
+        val result = service.refundToJackpot(discordId, guildId, 100L)
+
+        assertEquals(CasinoAdminService.RefundOutcome.Insufficient(have = 50L, needed = 100L), result)
+        verify(exactly = 0) { userService.updateUser(any()) }
+        verify(exactly = 0) { jackpotService.addToPool(any(), any()) }
+    }
+
+    @Test
+    fun `refundToJackpot debits user and deposits to jackpot on success`() {
+        val user = UserDto(discordId = discordId, guildId = guildId).apply { socialCredit = 500L }
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns user
+        every { jackpotService.addToPool(guildId, 200L) } returns 1_200L
+
+        val result = service.refundToJackpot(discordId, guildId, 200L)
+
+        assertEquals(
+            CasinoAdminService.RefundOutcome.Ok(drained = 200L, newPool = 1_200L, newSourceBalance = 300L),
+            result,
+        )
+        assertEquals(300L, user.socialCredit)
+        verify(exactly = 1) { userService.updateUser(user) }
+        verify(exactly = 1) { jackpotService.addToPool(guildId, 200L) }
+    }
+
+    @Test
+    fun `resetJackpot delegates to JackpotService`() {
+        every { jackpotService.resetPool(guildId) } returns 5_000L
+
+        val drained = service.resetJackpot(guildId)
+
+        assertEquals(5_000L, drained)
+        verify(exactly = 1) { jackpotService.resetPool(guildId) }
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/moderation/JackpotAdminCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/moderation/JackpotAdminCommand.kt
@@ -87,8 +87,6 @@ class JackpotAdminCommand @Autowired constructor(
                 "Refunded **${result.drained}** credits from ${target.asMention} into the jackpot. " +
                     "New pool: **${result.newPool}**. New balance: **${result.newSourceBalance}**."
             ).setEphemeral(true).queue(invokeDeleteOnMessageResponse(deleteDelay))
-            CasinoAdminService.RefundOutcome.UnknownUser ->
-                replyError(event, "${target.asMention} has no record in this guild.", deleteDelay)
             is CasinoAdminService.RefundOutcome.Insufficient ->
                 replyError(
                     event,

--- a/web/src/main/kotlin/web/controller/ModerationController.kt
+++ b/web/src/main/kotlin/web/controller/ModerationController.kt
@@ -132,7 +132,9 @@ class ModerationController(
     ): ResponseEntity<ApiResult> = WebGuildAccess.requireSignedInForJson(
         user, notSignedInApi
     ) { actor ->
-        val error = moderationWebService.kickMember(actor, guildId, body.targetDiscordId, body.reason)
+        val targetId = body.targetDiscordId.toLongOrNull()
+            ?: return@requireSignedInForJson ResponseEntity.badRequest().body(ApiResult(false, "Invalid user id."))
+        val error = moderationWebService.kickMember(actor, guildId, targetId, body.reason)
         if (error != null) ResponseEntity.badRequest().body(ApiResult(false, error))
         else ResponseEntity.ok(ApiResult(true, null))
     }
@@ -146,7 +148,10 @@ class ModerationController(
     ): ResponseEntity<MoveResponse> = WebGuildAccess.requireSignedInForJson(
         user, { MoveResponse(false, "Not signed in.") }
     ) { actor ->
-        val result = moderationWebService.moveMembers(actor, guildId, body.targetChannelId, body.memberIds)
+        val channelId = body.targetChannelId.toLongOrNull()
+            ?: return@requireSignedInForJson ResponseEntity.badRequest().body(MoveResponse(false, "Invalid channel id."))
+        val memberIds = body.memberIds.mapNotNull { it.toLongOrNull() }
+        val result = moderationWebService.moveMembers(actor, guildId, channelId, memberIds)
         if (result.error != null) {
             ResponseEntity.badRequest().body(MoveResponse(false, result.error, result.moved, result.skipped))
         } else {
@@ -197,7 +202,11 @@ class ModerationController(
     ): ResponseEntity<JackpotAdminResponse> = WebGuildAccess.requireSignedInForJson(
         user, { JackpotAdminResponse(false, "Not signed in.") }
     ) { actor ->
-        val result = moderationWebService.refundJackpotFromUser(actor, guildId, body.sourceDiscordId, body.amount)
+        val sourceId = body.sourceDiscordId.toLongOrNull()
+            ?: return@requireSignedInForJson ResponseEntity.badRequest().body(
+                JackpotAdminResponse(false, "Invalid user id.")
+            )
+        val result = moderationWebService.refundJackpotFromUser(actor, guildId, sourceId, body.amount)
         if (result.error != null) {
             ResponseEntity.badRequest().body(
                 JackpotAdminResponse(false, result.error, drained = result.drained, newPool = result.newPool, newSourceBalance = result.newSourceBalance)
@@ -218,7 +227,9 @@ class ModerationController(
     ): ResponseEntity<ApiResult> = WebGuildAccess.requireSignedInForJson(
         user, notSignedInApi
     ) { actor ->
-        val error = moderationWebService.createPoll(actor, guildId, body.channelId, body.question, body.options)
+        val channelId = body.channelId.toLongOrNull()
+            ?: return@requireSignedInForJson ResponseEntity.badRequest().body(ApiResult(false, "Invalid channel id."))
+        val error = moderationWebService.createPoll(actor, guildId, channelId, body.question, body.options)
         if (error != null) ResponseEntity.badRequest().body(ApiResult(false, error))
         else ResponseEntity.ok(ApiResult(true, null))
     }
@@ -229,10 +240,10 @@ class ModerationController(
 data class PermissionRequest(val permission: String = "")
 data class SocialCreditRequest(val delta: Long = 0)
 data class ConfigRequest(val key: String = "", val value: String = "")
-data class KickRequest(val targetDiscordId: Long = 0, val reason: String? = null)
-data class MoveRequest(val targetChannelId: Long = 0, val memberIds: List<Long> = emptyList())
+data class KickRequest(val targetDiscordId: String = "", val reason: String? = null)
+data class MoveRequest(val targetChannelId: String = "", val memberIds: List<String> = emptyList())
 data class MuteRequest(val mute: Boolean = true)
-data class PollRequest(val channelId: Long = 0, val question: String = "", val options: List<String> = emptyList())
+data class PollRequest(val channelId: String = "", val question: String = "", val options: List<String> = emptyList())
 
 data class MoveResponse(
     val ok: Boolean,
@@ -249,7 +260,7 @@ data class MuteResponse(
 )
 
 data class JackpotRefundRequest(
-    val sourceDiscordId: Long = 0L,
+    val sourceDiscordId: String = "",
     val amount: Long = 0L,
 )
 

--- a/web/src/main/kotlin/web/service/ModerationWebService.kt
+++ b/web/src/main/kotlin/web/service/ModerationWebService.kt
@@ -296,8 +296,6 @@ class ModerationWebService(
                 )
                 RefundJackpotResult(null, outcome.drained, outcome.newPool, outcome.newSourceBalance)
             }
-            CasinoAdminService.RefundOutcome.UnknownUser ->
-                RefundJackpotResult("Source user has no record in this server.", 0L, jackpotService.getPool(guildId), 0L)
             is CasinoAdminService.RefundOutcome.Insufficient ->
                 RefundJackpotResult(
                     "Source user has only ${outcome.have} credits, can't refund ${outcome.needed}.",

--- a/web/src/main/resources/static/js/moderation.js
+++ b/web/src/main/resources/static/js/moderation.js
@@ -106,7 +106,7 @@
             if (reason === null) return;
             btn.disabled = true;
             postJson('/moderation/' + guildId + '/kick', {
-                targetDiscordId: Number(memberId),
+                targetDiscordId: memberId,
                 reason: reason || null
             }).then(r => {
                 btn.disabled = false;
@@ -216,7 +216,7 @@
         moveForm.addEventListener('submit', e => {
             e.preventDefault();
             const targetChannelId = moveForm.elements.targetChannelId.value;
-            const memberIds = Array.from(moveForm.elements.memberIds.selectedOptions).map(o => Number(o.value));
+            const memberIds = Array.from(moveForm.elements.memberIds.selectedOptions).map(o => o.value);
             if (!targetChannelId || memberIds.length === 0) {
                 toast('Pick a destination and at least one member.', 'error');
                 return;
@@ -224,7 +224,7 @@
             const submitBtn = moveForm.querySelector('button[type="submit"]');
             submitBtn.disabled = true;
             postJson('/moderation/' + guildId + '/voice/move', {
-                targetChannelId: Number(targetChannelId),
+                targetChannelId: targetChannelId,
                 memberIds: memberIds
             }).then(r => {
                 submitBtn.disabled = false;
@@ -256,7 +256,7 @@
             const submitBtn = pollForm.querySelector('button[type="submit"]');
             submitBtn.disabled = true;
             postJson('/moderation/' + guildId + '/poll', {
-                channelId: Number(channelId),
+                channelId: channelId,
                 question: question,
                 options: options
             }).then(r => {
@@ -324,7 +324,7 @@
             const submitBtn = jackpotRefundForm.querySelector('button[type="submit"]');
             submitBtn.disabled = true;
             postJson('/moderation/' + guildId + '/jackpot/refund', {
-                sourceDiscordId: Number(sourceDiscordId),
+                sourceDiscordId: sourceDiscordId,
                 amount: amount
             }).then(r => {
                 submitBtn.disabled = false;


### PR DESCRIPTION
## Summary

- **Root cause:** JavaScript's `Number()` silently rounds Discord snowflake IDs that exceed `Number.MAX_SAFE_INTEGER` (2^53). The moderation page was calling `Number(id)` on user/channel IDs before sending them in JSON request bodies, so the server received the wrong ID and returned "Source user has no record in this server."
- Removed all five `Number()` conversions on snowflake IDs in `moderation.js` (kick, move, poll, jackpot refund). IDs are now sent as JSON strings.
- Changed the Kotlin request DTOs (`KickRequest`, `MoveRequest`, `PollRequest`, `JackpotRefundRequest`) from `Long` to `String` with explicit `toLongOrNull()` parsing in each controller method.
- Also removed the `RefundOutcome.UnknownUser` variant from `CasinoAdminService` — a missing user now falls through as `Insufficient(have=0)`, giving a clearer error message instead of the confusing "no record" text.

## Test plan

- [x] New `CasinoAdminServiceTest` covers: missing user returns `Insufficient(0, amount)`, insufficient balance, invalid amount, and successful debit+deposit
- [x] Full compilation (`classes testClasses`) passes across all modules
- [x] Unit tests pass for `database`, `discord-bot`, and `web` modules
- [ ] Manual: open moderation page, select a user from the refund dropdown, submit — should succeed instead of erroring
- [ ] Manual: verify kick, move, poll actions also work for users with large snowflake IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)