### PR TITLE
feat(leaderboard web): show top played games of the month

### DIFF
--- a/web/src/main/kotlin/web/service/LeaderboardWebService.kt
+++ b/web/src/main/kotlin/web/service/LeaderboardWebService.kt
@@ -1,5 +1,6 @@
 package web.service
 
+import database.service.ActivityMonthlyRollupService
 import database.service.MonthlyCreditSnapshotService
 import database.service.TitleService
 import database.service.TobyCoinMarketService
@@ -21,12 +22,15 @@ class LeaderboardWebService(
     private val titleService: TitleService,
     private val snapshotService: MonthlyCreditSnapshotService,
     private val membership: GuildMembership,
+    private val rollupService: ActivityMonthlyRollupService,
 ) {
 
     companion object {
         // Keep the list tight so the leaderboard page stays scannable. Users
         // below this don't meaningfully change the story of "who owns coin".
         const val TOBY_COIN_LEADERBOARD_LIMIT = 10
+        // Matches /activity server in Discord so the web view tells the same story.
+        const val TOP_GAMES_LIMIT = 10
     }
 
     fun getGuildsWhereUserCanView(accessToken: String, discordId: Long): List<LeaderboardGuildCard> {
@@ -92,8 +96,36 @@ class LeaderboardWebService(
             mostActiveMember = mostActiveName,
             totalMembers = resorted.size,
             sort = sort,
-            tobyCoinLeaders = buildTobyCoinLeaders(guildId)
+            tobyCoinLeaders = buildTobyCoinLeaders(guildId),
+            topGames = buildTopGames(guildId)
         )
+    }
+
+    private fun buildTopGames(guildId: Long): List<TopGameRow> {
+        val thisMonth = LocalDate.now(ZoneOffset.UTC).withDayOfMonth(1)
+        // Mirror /activity server: skip rollup rows owned by users who have
+        // explicitly opted out of tracking, even though their old rows still exist.
+        val optedOut = runCatching {
+            userService.listGuildUsers(guildId)
+                .filterNotNull()
+                .filter { it.activityTrackingOptOut }
+                .map { it.discordId }
+                .toSet()
+        }.getOrDefault(emptySet())
+
+        val rollups = runCatching { rollupService.forGuildMonth(guildId, thisMonth) }
+            .getOrDefault(emptyList())
+
+        return rollups.asSequence()
+            .filter { it.discordId !in optedOut }
+            .groupBy { it.activityName }
+            .mapValues { (_, rows) -> rows.sumOf { it.seconds } }
+            .entries
+            .sortedByDescending { it.value }
+            .take(TOP_GAMES_LIMIT)
+            .mapIndexed { index, entry ->
+                TopGameRow(rank = index + 1, name = entry.key, seconds = entry.value)
+            }
     }
 
     private fun buildTobyCoinLeaders(guildId: Long): List<TobyCoinLeaderRow> {
@@ -185,7 +217,8 @@ data class LeaderboardGuildView(
     val mostActiveMember: String?,
     val totalMembers: Int,
     val sort: LeaderboardSort = LeaderboardSort.THIS_MONTH,
-    val tobyCoinLeaders: List<TobyCoinLeaderRow> = emptyList()
+    val tobyCoinLeaders: List<TobyCoinLeaderRow> = emptyList(),
+    val topGames: List<TopGameRow> = emptyList()
 ) {
     @Suppress("unused") // consumed by templates/leaderboard.html via Thymeleaf
     val totalVoiceThisMonthDisplay: String get() = formatDuration(totalVoiceThisMonth)
@@ -217,3 +250,17 @@ data class TobyCoinLeaderRow(
     val coinsThisMonth: Long = 0L,
     val portfolioCredits: Long
 )
+
+data class TopGameRow(
+    val rank: Int,
+    val name: String,
+    val seconds: Long
+) {
+    @Suppress("unused") // consumed by templates/leaderboard.html via Thymeleaf
+    val playtimeDisplay: String get() {
+        if (seconds <= 0) return "0m"
+        val hours = seconds / 3600
+        val minutes = (seconds % 3600) / 60
+        return if (hours > 0) "${hours}h ${minutes}m" else "${minutes}m"
+    }
+}

--- a/web/src/main/resources/templates/leaderboard.html
+++ b/web/src/main/resources/templates/leaderboard.html
@@ -266,6 +266,46 @@
         </div>
     </details>
 
+    <details class="lb-collapse" data-section="topgames" open
+             th:if="${not #lists.isEmpty(view.topGames)}">
+        <summary class="lb-collapse-header">
+            <span class="lb-collapse-icon" aria-hidden="true">🎮</span>
+            <span class="lb-collapse-title">Top games this month</span>
+            <span class="lb-collapse-count" th:text="${#lists.size(view.topGames)} + ' games'">0 games</span>
+            <span class="lb-collapse-caret" aria-hidden="true">
+                <svg viewBox="0 0 20 20" width="18" height="18"><path fill="currentColor" d="M6 4l8 6-8 6V4z"/></svg>
+            </span>
+        </summary>
+        <div class="lb-collapse-body">
+            <div class="mod-table-wrap">
+                <table class="mod-table lb-standings-table">
+                    <thead>
+                    <tr>
+                        <th class="lb-col-rank">#</th>
+                        <th>Game</th>
+                        <th class="lb-col-value" aria-sort="descending">🎮 Playtime</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr th:each="row : ${view.topGames}">
+                        <td data-label="#">
+                            <span class="lb-rank"
+                                  th:classappend="${row.rank == 1 ? 'lb-rank-1' : (row.rank == 2 ? 'lb-rank-2' : (row.rank == 3 ? 'lb-rank-3' : ''))}"
+                                  th:text="${row.rank}">1</span>
+                        </td>
+                        <td data-label="Game">
+                            <span class="lb-name" th:text="${row.name}">Game name</span>
+                        </td>
+                        <td data-label="Playtime" class="lb-col-value">
+                            <strong class="lb-value" th:text="${row.playtimeDisplay}">0m</strong>
+                        </td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </details>
+
     <div class="empty-hero" th:if="${#lists.isEmpty(view.podium) and #lists.isEmpty(view.standings)}">
         <span class="emoji" aria-hidden="true">🏁</span>
         <h2>No credit has been earned here yet</h2>

--- a/web/src/test/kotlin/web/service/LeaderboardWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/LeaderboardWebServiceTest.kt
@@ -39,7 +39,8 @@ class LeaderboardWebServiceTest {
         service = LeaderboardWebService(
             jda, introWebService, moderationWebService, userService, marketService,
             mockk(relaxed = true), mockk(relaxed = true),
-            GuildMembership(jda)
+            GuildMembership(jda),
+            mockk(relaxed = true)
         )
     }
 

--- a/web/src/test/kotlin/web/service/LeaderboardWebServiceTobyCoinTest.kt
+++ b/web/src/test/kotlin/web/service/LeaderboardWebServiceTobyCoinTest.kt
@@ -55,6 +55,7 @@ class LeaderboardWebServiceTobyCoinTest {
             titleService = titleService,
             snapshotService = snapshotService,
             membership = GuildMembership(jda),
+            rollupService = mockk(relaxed = true),
         )
     }
 

--- a/web/src/test/kotlin/web/service/LeaderboardWebServiceTopGamesTest.kt
+++ b/web/src/test/kotlin/web/service/LeaderboardWebServiceTopGamesTest.kt
@@ -1,0 +1,136 @@
+package web.service
+
+import database.dto.ActivityMonthlyRollupDto
+import database.dto.UserDto
+import database.service.ActivityMonthlyRollupService
+import database.service.UserService
+import io.mockk.every
+import io.mockk.mockk
+import net.dv8tion.jda.api.JDA
+import net.dv8tion.jda.api.entities.Guild
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import web.util.GuildMembership
+import java.time.LocalDate
+import java.time.ZoneOffset
+
+class LeaderboardWebServiceTopGamesTest {
+
+    private val guildId = 42L
+    private val thisMonth: LocalDate = LocalDate.now(ZoneOffset.UTC).withDayOfMonth(1)
+
+    private lateinit var jda: JDA
+    private lateinit var guild: Guild
+    private lateinit var userService: UserService
+    private lateinit var rollupService: ActivityMonthlyRollupService
+    private lateinit var service: LeaderboardWebService
+
+    @BeforeEach
+    fun setup() {
+        jda = mockk(relaxed = true)
+        guild = mockk(relaxed = true)
+        userService = mockk(relaxed = true)
+        rollupService = mockk(relaxed = true)
+        every { jda.getGuildById(guildId) } returns guild
+        every { guild.name } returns "Test Guild"
+
+        service = LeaderboardWebService(
+            jda = jda,
+            introWebService = mockk(relaxed = true),
+            moderationWebService = mockk(relaxed = true) {
+                every { getLeaderboard(guildId) } returns emptyList()
+            },
+            userService = userService,
+            marketService = mockk(relaxed = true),
+            titleService = mockk(relaxed = true),
+            snapshotService = mockk(relaxed = true),
+            membership = GuildMembership(jda),
+            rollupService = rollupService,
+        )
+    }
+
+    private fun rollup(discordId: Long, name: String, seconds: Long) =
+        ActivityMonthlyRollupDto(
+            discordId = discordId,
+            guildId = guildId,
+            monthStart = thisMonth,
+            activityName = name,
+            seconds = seconds
+        )
+
+    @Test
+    fun `topGames is empty when there are no rollups`() {
+        every { rollupService.forGuildMonth(guildId, thisMonth) } returns emptyList()
+
+        val games = checkNotNull(service.getGuildView(guildId)).topGames
+
+        assertTrue(games.isEmpty())
+    }
+
+    @Test
+    fun `topGames sums seconds across users for the same activity and ranks descending`() {
+        every { rollupService.forGuildMonth(guildId, thisMonth) } returns listOf(
+            rollup(1L, "Halo", 1_000),
+            rollup(2L, "Halo", 500),     // Halo total = 1500
+            rollup(1L, "Tetris", 4_000), // Tetris total = 4000
+            rollup(3L, "Chess", 200)
+        )
+
+        val games = checkNotNull(service.getGuildView(guildId)).topGames
+
+        assertEquals(listOf("Tetris", "Halo", "Chess"), games.map { it.name })
+        assertEquals(listOf(1, 2, 3), games.map { it.rank })
+        assertEquals(4_000L, games[0].seconds)
+        assertEquals(1_500L, games[1].seconds)
+        assertEquals(200L, games[2].seconds)
+    }
+
+    @Test
+    fun `topGames excludes rollups owned by users who opted out`() {
+        every { userService.listGuildUsers(guildId) } returns listOf(
+            UserDto(discordId = 1L, guildId = guildId).apply { activityTrackingOptOut = true },
+            UserDto(discordId = 2L, guildId = guildId).apply { activityTrackingOptOut = false }
+        )
+        every { rollupService.forGuildMonth(guildId, thisMonth) } returns listOf(
+            rollup(1L, "Halo", 9_999),  // owner opted out -> drop
+            rollup(2L, "Halo", 100)
+        )
+
+        val games = checkNotNull(service.getGuildView(guildId)).topGames
+
+        assertEquals(1, games.size)
+        assertEquals("Halo", games[0].name)
+        assertEquals(100L, games[0].seconds, "opted-out user's hours must not count toward the total")
+    }
+
+    @Test
+    fun `topGames is capped at TOP_GAMES_LIMIT entries`() {
+        val rows = (1..15).map { i -> rollup(i.toLong(), "Game $i", i * 100L) }
+        every { rollupService.forGuildMonth(guildId, thisMonth) } returns rows
+
+        val games = checkNotNull(service.getGuildView(guildId)).topGames
+
+        assertEquals(LeaderboardWebService.TOP_GAMES_LIMIT, games.size)
+        assertEquals("Game 15", games.first().name, "biggest playtime takes rank 1")
+    }
+
+    @Test
+    fun `topGames degrades to empty list when the rollup query throws`() {
+        every { rollupService.forGuildMonth(guildId, thisMonth) } throws
+            RuntimeException("activity_monthly_rollup unavailable")
+
+        val games = checkNotNull(service.getGuildView(guildId)).topGames
+
+        assertTrue(games.isEmpty(), "page must still render even if the rollup read fails")
+    }
+
+    @Test
+    fun `topGameRow formats playtime as hours and minutes`() {
+        val row = TopGameRow(rank = 1, name = "Halo", seconds = 3_660L) // 1h 1m
+        assertEquals("1h 1m", row.playtimeDisplay)
+        assertEquals("0m", TopGameRow(rank = 1, name = "Idle", seconds = 0L).playtimeDisplay)
+        assertEquals("5m", TopGameRow(rank = 1, name = "Quick", seconds = 5L * 60).playtimeDisplay)
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a new "Top games this month" collapsible table to `/leaderboard/{guildId}`, rendering the same aggregation that powers `/activity server` so the data is visible on the web without running a slash command.
- Reuses the existing `mod-table lb-standings-table` markup and `<details data-section="…">` collapsible pattern, so no new CSS or JS is needed (the table even gets the open/closed localStorage persistence for free).
- Sums `activity_monthly_rollup.seconds` per `activity_name` for the current UTC month, drops users who have opted out of tracking, sorts descending, and caps at 10 — exactly mirroring `ActivityCommand.showServer`. Hides itself when there's nothing to show or if the rollup query throws.

## Test plan
- [x] `./gradlew :web:test --tests "web.service.LeaderboardWebService*" --tests "web.controller.LeaderboardControllerTest"` (passes locally)
- [ ] Visit `/leaderboard/{guildId}` for a guild that has rollup rows for the current month and confirm the new section appears below TobyCoin wallets, lists up to 10 entries, and matches `/activity server` ordering & durations.
- [ ] Toggle the new `<details>` open/closed and reload to confirm state persistence per guild.
- [ ] Visit a guild with no rollup data (or where every user has opted out) and confirm the section is hidden and the rest of the page renders unchanged.

https://claude.ai/code/session_019v8fySXKuPWyWdaok5Di2P

---
_Generated by [Claude Code](https://claude.ai/code/session_019v8fySXKuPWyWdaok5Di2P)_