### PR TITLE
feat(moderation web): consolidate stake/buy-in config + 0=unlimited shorthand

### DIFF
--- a/database/src/main/kotlin/database/service/BaccaratService.kt
+++ b/database/src/main/kotlin/database/service/BaccaratService.kt
@@ -110,7 +110,7 @@ class BaccaratService(
         val minStake = configService.cfgLong(
             ConfigDto.Configurations.BACCARAT_MIN_STAKE, guildId, default = Baccarat.MIN_STAKE, min = 1L
         )
-        val maxStake = configService.cfgLong(
+        val maxStake = configService.cfgLongMax(
             ConfigDto.Configurations.BACCARAT_MAX_STAKE, guildId, default = Baccarat.MAX_STAKE, min = minStake
         )
         val resolved = when (val r = WagerHelper.checkLockOrTopUp(

--- a/database/src/main/kotlin/database/service/BlackjackService.kt
+++ b/database/src/main/kotlin/database/service/BlackjackService.kt
@@ -1563,6 +1563,14 @@ class BlackjackService @Autowired constructor(
             val raw = configService.getConfigByName(key.configValue, guildId.toString())?.value
             return raw?.toLongOrNull()?.coerceAtLeast(min) ?: default
         }
+        // Sibling of cfgLong that interprets stored "0" as Long.MAX_VALUE
+        // ("no upper cap"). Used for max-cap keys like BLACKJACK_MAX_ANTE.
+        fun cfgLongMax(key: ConfigDto.Configurations, default: Long, min: Long): Long {
+            val raw = configService.getConfigByName(key.configValue, guildId.toString())
+                ?.value?.toLongOrNull() ?: return default
+            if (raw == 0L) return Long.MAX_VALUE
+            return raw.coerceAtLeast(min)
+        }
         fun cfgInt(key: ConfigDto.Configurations, default: Int, range: IntRange): Int {
             val raw = configService.getConfigByName(key.configValue, guildId.toString())?.value
             return raw?.toIntOrNull()?.coerceIn(range) ?: default
@@ -1578,7 +1586,7 @@ class BlackjackService @Autowired constructor(
             return (pct / 100.0).coerceAtMost(max)
         }
         val minAnte = cfgLong(ConfigDto.Configurations.BLACKJACK_MIN_ANTE, Blackjack.MULTI_MIN_ANTE, 1L)
-        val maxAnte = cfgLong(ConfigDto.Configurations.BLACKJACK_MAX_ANTE, Blackjack.MULTI_MAX_ANTE, minAnte)
+        val maxAnte = cfgLongMax(ConfigDto.Configurations.BLACKJACK_MAX_ANTE, Blackjack.MULTI_MAX_ANTE, minAnte)
         val maxSeats = cfgInt(ConfigDto.Configurations.BLACKJACK_MAX_SEATS, Blackjack.MULTI_MAX_SEATS, 2..7)
         val shotClock = cfgInt(
             ConfigDto.Configurations.BLACKJACK_SHOT_CLOCK_SECONDS,

--- a/database/src/main/kotlin/database/service/CasinoHoldemService.kt
+++ b/database/src/main/kotlin/database/service/CasinoHoldemService.kt
@@ -390,7 +390,7 @@ class CasinoHoldemService @Autowired constructor(
         val minStake = configService.cfgLong(
             ConfigDto.Configurations.HOLDEM_MIN_STAKE, guildId, default = CasinoHoldem.MIN_STAKE, min = 1L
         )
-        val maxStake = configService.cfgLong(
+        val maxStake = configService.cfgLongMax(
             ConfigDto.Configurations.HOLDEM_MAX_STAKE, guildId, default = CasinoHoldem.MAX_STAKE, min = minStake
         )
         val check = WagerHelper.checkAndLock(

--- a/database/src/main/kotlin/database/service/CoinflipService.kt
+++ b/database/src/main/kotlin/database/service/CoinflipService.kt
@@ -72,7 +72,7 @@ class CoinflipService(
         val minStake = configService.cfgLong(
             ConfigDto.Configurations.COINFLIP_MIN_STAKE, guildId, default = Coinflip.MIN_STAKE, min = 1L
         )
-        val maxStake = configService.cfgLong(
+        val maxStake = configService.cfgLongMax(
             ConfigDto.Configurations.COINFLIP_MAX_STAKE, guildId, default = Coinflip.MAX_STAKE, min = minStake
         )
         val resolved = when (val r = WagerHelper.checkLockOrTopUp(

--- a/database/src/main/kotlin/database/service/ConfigReaders.kt
+++ b/database/src/main/kotlin/database/service/ConfigReaders.kt
@@ -22,3 +22,27 @@ fun ConfigService.cfgLong(
     val raw = getConfigByName(key.configValue, guildId.toString())?.value
     return raw?.toLongOrNull()?.coerceAtLeast(min) ?: default
 }
+
+/**
+ * Read a per-guild Long config value where `0` is a sentinel meaning "no
+ * upper cap." For `*_MAX_STAKE` / `POKER_MAX_BUY_IN` / `BLACKJACK_MAX_ANTE`
+ * style fields admins can type `0` instead of a giant number to remove
+ * the ceiling. Returns [Long.MAX_VALUE] when stored value is exactly `0L`,
+ * [default] when missing/unparseable, otherwise coerces to be at least
+ * [min] (defensive — write-time validation already enforces this).
+ *
+ * `JACKPOT_STAKE_ANCHOR` and `*_MIN_STAKE` keys keep using [cfgLong] —
+ * they have no "unlimited" semantics (anchor is a divisor; min < 1 has
+ * no meaning).
+ */
+fun ConfigService.cfgLongMax(
+    key: ConfigDto.Configurations,
+    guildId: Long,
+    default: Long,
+    min: Long,
+): Long {
+    val raw = getConfigByName(key.configValue, guildId.toString())?.value?.toLongOrNull()
+        ?: return default
+    if (raw == 0L) return Long.MAX_VALUE
+    return raw.coerceAtLeast(min)
+}

--- a/database/src/main/kotlin/database/service/DiceService.kt
+++ b/database/src/main/kotlin/database/service/DiceService.kt
@@ -75,7 +75,7 @@ class DiceService(
         val minStake = configService.cfgLong(
             ConfigDto.Configurations.DICE_MIN_STAKE, guildId, default = Dice.MIN_STAKE, min = 1L
         )
-        val maxStake = configService.cfgLong(
+        val maxStake = configService.cfgLongMax(
             ConfigDto.Configurations.DICE_MAX_STAKE, guildId, default = Dice.MAX_STAKE, min = minStake
         )
         val resolved = when (val r = WagerHelper.checkLockOrTopUp(

--- a/database/src/main/kotlin/database/service/DuelService.kt
+++ b/database/src/main/kotlin/database/service/DuelService.kt
@@ -81,7 +81,7 @@ class DuelService @Autowired constructor(
         val minStake = configService.cfgLong(
             ConfigDto.Configurations.DUEL_MIN_STAKE, guildId, default = MIN_STAKE, min = 1L
         )
-        val maxStake = configService.cfgLong(
+        val maxStake = configService.cfgLongMax(
             ConfigDto.Configurations.DUEL_MAX_STAKE, guildId, default = MAX_STAKE, min = minStake
         )
         if (stake < minStake || stake > maxStake) {

--- a/database/src/main/kotlin/database/service/HighlowService.kt
+++ b/database/src/main/kotlin/database/service/HighlowService.kt
@@ -109,7 +109,7 @@ class HighlowService(
         val minStake = configService.cfgLong(
             ConfigDto.Configurations.HIGHLOW_MIN_STAKE, guildId, default = Highlow.MIN_STAKE, min = 1L
         )
-        val maxStake = configService.cfgLong(
+        val maxStake = configService.cfgLongMax(
             ConfigDto.Configurations.HIGHLOW_MAX_STAKE, guildId, default = Highlow.MAX_STAKE, min = minStake
         )
         val resolved = when (val r = WagerHelper.checkLockOrTopUp(

--- a/database/src/main/kotlin/database/service/KenoService.kt
+++ b/database/src/main/kotlin/database/service/KenoService.kt
@@ -105,7 +105,7 @@ class KenoService(
         val minStake = configService.cfgLong(
             ConfigDto.Configurations.KENO_MIN_STAKE, guildId, default = Keno.MIN_STAKE, min = 1L
         )
-        val maxStake = configService.cfgLong(
+        val maxStake = configService.cfgLongMax(
             ConfigDto.Configurations.KENO_MAX_STAKE, guildId, default = Keno.MAX_STAKE, min = minStake
         )
         val resolved = when (val r = WagerHelper.checkLockOrTopUp(

--- a/database/src/main/kotlin/database/service/PokerService.kt
+++ b/database/src/main/kotlin/database/service/PokerService.kt
@@ -326,6 +326,14 @@ class PokerService @Autowired constructor(
             val raw = configService.getConfigByName(key.configValue, guildId.toString())?.value
             return raw?.toLongOrNull()?.coerceAtLeast(min) ?: default
         }
+        // Sibling of cfgLong that interprets stored "0" as Long.MAX_VALUE
+        // ("no upper cap"). Used for POKER_MAX_BUY_IN.
+        fun cfgLongMax(key: ConfigDto.Configurations, default: Long, min: Long): Long {
+            val raw = configService.getConfigByName(key.configValue, guildId.toString())
+                ?.value?.toLongOrNull() ?: return default
+            if (raw == 0L) return Long.MAX_VALUE
+            return raw.coerceAtLeast(min)
+        }
         fun cfgInt(key: ConfigDto.Configurations, default: Int, range: IntRange): Int {
             val raw = configService.getConfigByName(key.configValue, guildId.toString())?.value
             return raw?.toIntOrNull()?.coerceIn(range) ?: default
@@ -336,7 +344,7 @@ class PokerService @Autowired constructor(
             smallBet = cfgLong(ConfigDto.Configurations.POKER_SMALL_BET, SMALL_BET, 1L),
             bigBet = cfgLong(ConfigDto.Configurations.POKER_BIG_BET, BIG_BET, 1L),
             minBuyIn = cfgLong(ConfigDto.Configurations.POKER_MIN_BUY_IN, MIN_BUY_IN, 1L),
-            maxBuyIn = cfgLong(ConfigDto.Configurations.POKER_MAX_BUY_IN, MAX_BUY_IN, 1L),
+            maxBuyIn = cfgLongMax(ConfigDto.Configurations.POKER_MAX_BUY_IN, MAX_BUY_IN, 1L),
             maxSeats = cfgInt(ConfigDto.Configurations.POKER_MAX_SEATS, MAX_SEATS, 2..9),
             shotClockSeconds = cfgInt(
                 ConfigDto.Configurations.POKER_SHOT_CLOCK_SECONDS,

--- a/database/src/main/kotlin/database/service/ScratchService.kt
+++ b/database/src/main/kotlin/database/service/ScratchService.kt
@@ -63,7 +63,7 @@ class ScratchService(
         val minStake = configService.cfgLong(
             ConfigDto.Configurations.SCRATCH_MIN_STAKE, guildId, default = ScratchCard.MIN_STAKE, min = 1L
         )
-        val maxStake = configService.cfgLong(
+        val maxStake = configService.cfgLongMax(
             ConfigDto.Configurations.SCRATCH_MAX_STAKE, guildId, default = ScratchCard.MAX_STAKE, min = minStake
         )
         val resolved = when (val r = WagerHelper.checkLockOrTopUp(

--- a/database/src/main/kotlin/database/service/SlotsService.kt
+++ b/database/src/main/kotlin/database/service/SlotsService.kt
@@ -75,7 +75,7 @@ class SlotsService(
         val minStake = configService.cfgLong(
             ConfigDto.Configurations.SLOTS_MIN_STAKE, guildId, default = SlotMachine.MIN_STAKE, min = 1L
         )
-        val maxStake = configService.cfgLong(
+        val maxStake = configService.cfgLongMax(
             ConfigDto.Configurations.SLOTS_MAX_STAKE, guildId, default = SlotMachine.MAX_STAKE, min = minStake
         )
         val resolved = when (val r = WagerHelper.checkLockOrTopUp(

--- a/database/src/test/kotlin/database/service/ConfigReadersTest.kt
+++ b/database/src/test/kotlin/database/service/ConfigReadersTest.kt
@@ -1,0 +1,93 @@
+package database.service
+
+import database.dto.ConfigDto
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * Read-time semantics for [cfgLong] and [cfgLongMax]. The interesting case
+ * for [cfgLongMax] is the `0 → Long.MAX_VALUE` shortcut admins use to mean
+ * "no upper cap" on a `*_MAX_STAKE` / `POKER_MAX_BUY_IN` field; if that
+ * coercion ever flips back to "0 reads as min" it silently caps every
+ * minigame at the floor and the UI's "0 = unlimited" label becomes a lie.
+ */
+class ConfigReadersTest {
+
+    private val guildId = 7L
+    private val key = ConfigDto.Configurations.DICE_MAX_STAKE
+
+    private lateinit var configService: ConfigService
+
+    @BeforeEach
+    fun setup() {
+        configService = mockk()
+    }
+
+    private fun stored(value: String?) {
+        every { configService.getConfigByName(key.configValue, guildId.toString()) } returns
+            value?.let { ConfigDto(name = key.configValue, value = it, guildId = guildId.toString()) }
+    }
+
+    // ---- cfgLong ----
+
+    @Test
+    fun `cfgLong returns default when row missing`() {
+        stored(null)
+        assertEquals(500L, configService.cfgLong(key, guildId, default = 500L, min = 1L))
+    }
+
+    @Test
+    fun `cfgLong returns default when value is unparseable`() {
+        stored("not-a-number")
+        assertEquals(500L, configService.cfgLong(key, guildId, default = 500L, min = 1L))
+    }
+
+    @Test
+    fun `cfgLong coerces stored value below min up to min`() {
+        stored("0")
+        assertEquals(1L, configService.cfgLong(key, guildId, default = 500L, min = 1L))
+    }
+
+    @Test
+    fun `cfgLong returns stored value when above min`() {
+        stored("250")
+        assertEquals(250L, configService.cfgLong(key, guildId, default = 500L, min = 1L))
+    }
+
+    // ---- cfgLongMax ----
+
+    @Test
+    fun `cfgLongMax expands stored 0 to Long_MAX_VALUE`() {
+        stored("0")
+        assertEquals(Long.MAX_VALUE, configService.cfgLongMax(key, guildId, default = 500L, min = 1L))
+    }
+
+    @Test
+    fun `cfgLongMax returns default when row missing`() {
+        stored(null)
+        assertEquals(500L, configService.cfgLongMax(key, guildId, default = 500L, min = 1L))
+    }
+
+    @Test
+    fun `cfgLongMax returns default when value is unparseable`() {
+        stored("garbage")
+        assertEquals(500L, configService.cfgLongMax(key, guildId, default = 500L, min = 1L))
+    }
+
+    @Test
+    fun `cfgLongMax coerces a positive stored value below min up to min`() {
+        // Defensive — write-time validation rejects negatives, but if a
+        // legacy row has e.g. -5 we shouldn't return a negative max either.
+        stored("-5")
+        assertEquals(1L, configService.cfgLongMax(key, guildId, default = 500L, min = 1L))
+    }
+
+    @Test
+    fun `cfgLongMax returns stored value when above min`() {
+        stored("1000")
+        assertEquals(1000L, configService.cfgLongMax(key, guildId, default = 500L, min = 1L))
+    }
+}

--- a/database/src/test/kotlin/database/service/DiceServiceTest.kt
+++ b/database/src/test/kotlin/database/service/DiceServiceTest.kt
@@ -120,6 +120,32 @@ class DiceServiceTest {
     }
 
     @Test
+    fun `DICE_MAX_STAKE = 0 means no upper cap (unlimited)`() {
+        // Per the moderation UI semantic: storing "0" in *_MAX_STAKE config
+        // means "no upper cap" — cfgLongMax expands it to Long.MAX_VALUE so
+        // the WagerHelper bounds check accepts arbitrary large stakes.
+        // Without this test, a regression in cfgLongMax (or accidentally
+        // switching the read back to cfgLong) would silently cap every
+        // game at the floor and the "0 = unlimited" UI label would be a lie.
+        val user = userWithBalance(10_000_000L)
+        every {
+            configService.getConfigByName(
+                database.dto.ConfigDto.Configurations.DICE_MAX_STAKE.configValue,
+                guildId.toString()
+            )
+        } returns database.dto.ConfigDto(name = "x", value = "0", guildId = guildId.toString())
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns user
+        every { dice.roll(4, any()) } returns Dice.Roll(landed = 4, predicted = 4, multiplier = 2L)
+        every { userService.updateUser(any()) } returns user
+
+        val outcome = service.roll(discordId, guildId, stake = 5_000_000L, predicted = 4)
+
+        // Stake of 5,000,000 is way above the default MAX_STAKE (500) but
+        // 0 = unlimited lifts the cap, so the roll completes as a Win.
+        assertInstanceOf(DiceService.RollOutcome.Win::class.java, outcome)
+    }
+
+    @Test
     fun `loss tributes 10 percent of the stake into the jackpot pool`() {
         val user = UserDto(discordId, guildId).apply { socialCredit = 500L }
         every { userService.getUserByIdForUpdate(discordId, guildId) } returns user

--- a/web/src/main/kotlin/web/casino/StakeBounds.kt
+++ b/web/src/main/kotlin/web/casino/StakeBounds.kt
@@ -13,6 +13,7 @@ import database.poker.CasinoHoldem
 import database.service.ConfigService
 import database.service.DuelService
 import database.service.cfgLong
+import database.service.cfgLongMax
 import org.springframework.stereotype.Component
 
 /**
@@ -116,7 +117,8 @@ class StakeBounds(
         defaultMax: Long,
     ): Pair<Long, Long> {
         val min = configService.cfgLong(minKey, guildId, default = defaultMin, min = 1L)
-        val max = configService.cfgLong(maxKey, guildId, default = defaultMax, min = min)
+        // Max uses cfgLongMax — stored "0" means "no upper cap" → Long.MAX_VALUE
+        val max = configService.cfgLongMax(maxKey, guildId, default = defaultMax, min = min)
         return min to max
     }
 }

--- a/web/src/main/kotlin/web/service/ModerationWebService.kt
+++ b/web/src/main/kotlin/web/service/ModerationWebService.kt
@@ -384,11 +384,16 @@ class ModerationWebService(
             ConfigDto.Configurations.POKER_BIG_BLIND,
             ConfigDto.Configurations.POKER_SMALL_BET,
             ConfigDto.Configurations.POKER_BIG_BET,
-            ConfigDto.Configurations.POKER_MIN_BUY_IN,
-            ConfigDto.Configurations.POKER_MAX_BUY_IN -> {
+            ConfigDto.Configurations.POKER_MIN_BUY_IN -> {
                 val n = rawValue.trim().toLongOrNull()
                     ?: return "Value must be a whole number of chips."
                 if (n < 1L) return "Value must be at least 1 chip."
+                n.toString()
+            }
+            ConfigDto.Configurations.POKER_MAX_BUY_IN -> {
+                val n = rawValue.trim().toLongOrNull()
+                    ?: return "Value must be a whole number of chips."
+                if (n < 0L) return "Value must be 0 (unlimited) or a positive number of chips."
                 n.toString()
             }
             ConfigDto.Configurations.POKER_MAX_SEATS -> {
@@ -409,30 +414,41 @@ class ModerationWebService(
                 if (n !in 0..20) return "Value must be between 0 and 20 (capped server-side)."
                 n.toString()
             }
+            // Min-cap stake keys + the jackpot anchor — must be >= 1.
+            // The anchor is a divisor in JackpotHelper.rollOnWin so 0 is
+            // pathological, not "unlimited"; mins below 1 have no meaning.
             ConfigDto.Configurations.BLACKJACK_MIN_ANTE,
-            ConfigDto.Configurations.BLACKJACK_MAX_ANTE,
             ConfigDto.Configurations.DICE_MIN_STAKE,
-            ConfigDto.Configurations.DICE_MAX_STAKE,
             ConfigDto.Configurations.COINFLIP_MIN_STAKE,
-            ConfigDto.Configurations.COINFLIP_MAX_STAKE,
             ConfigDto.Configurations.SLOTS_MIN_STAKE,
-            ConfigDto.Configurations.SLOTS_MAX_STAKE,
             ConfigDto.Configurations.HIGHLOW_MIN_STAKE,
-            ConfigDto.Configurations.HIGHLOW_MAX_STAKE,
             ConfigDto.Configurations.BACCARAT_MIN_STAKE,
-            ConfigDto.Configurations.BACCARAT_MAX_STAKE,
             ConfigDto.Configurations.KENO_MIN_STAKE,
-            ConfigDto.Configurations.KENO_MAX_STAKE,
             ConfigDto.Configurations.SCRATCH_MIN_STAKE,
-            ConfigDto.Configurations.SCRATCH_MAX_STAKE,
             ConfigDto.Configurations.HOLDEM_MIN_STAKE,
-            ConfigDto.Configurations.HOLDEM_MAX_STAKE,
             ConfigDto.Configurations.DUEL_MIN_STAKE,
-            ConfigDto.Configurations.DUEL_MAX_STAKE,
             ConfigDto.Configurations.JACKPOT_STAKE_ANCHOR -> {
                 val n = rawValue.trim().toLongOrNull()
                     ?: return "Value must be a whole number of credits."
                 if (n < 1L) return "Value must be at least 1 credit."
+                n.toString()
+            }
+            // Max-cap stake keys — accept 0 as "no upper cap"
+            // (cfgLongMax expands stored 0 to Long.MAX_VALUE at read time).
+            // Otherwise must be a positive whole number.
+            ConfigDto.Configurations.BLACKJACK_MAX_ANTE,
+            ConfigDto.Configurations.DICE_MAX_STAKE,
+            ConfigDto.Configurations.COINFLIP_MAX_STAKE,
+            ConfigDto.Configurations.SLOTS_MAX_STAKE,
+            ConfigDto.Configurations.HIGHLOW_MAX_STAKE,
+            ConfigDto.Configurations.BACCARAT_MAX_STAKE,
+            ConfigDto.Configurations.KENO_MAX_STAKE,
+            ConfigDto.Configurations.SCRATCH_MAX_STAKE,
+            ConfigDto.Configurations.HOLDEM_MAX_STAKE,
+            ConfigDto.Configurations.DUEL_MAX_STAKE -> {
+                val n = rawValue.trim().toLongOrNull()
+                    ?: return "Value must be a whole number of credits."
+                if (n < 0L) return "Value must be 0 (unlimited) or a positive number of credits."
                 n.toString()
             }
             ConfigDto.Configurations.BLACKJACK_MAX_SEATS -> {

--- a/web/src/main/resources/static/css/moderation.css
+++ b/web/src/main/resources/static/css/moderation.css
@@ -231,6 +231,28 @@
 }
 .config-row .save-config { grid-column: 2; }
 
+/* Config sub-groups (e.g. "Casino stakes & buy-ins" splits into Dice /
+   Coinflip / Poker / etc. sub-groups). Each `.config-group` carries a
+   small uppercase `<h4>` heading and a hairline divider between groups
+   so the card is scannable game-by-game. */
+.config-group { padding-top: var(--space-2); }
+.config-group + .config-group {
+    border-top: 1px solid var(--border);
+    margin-top: var(--space-2);
+}
+.config-group h4 {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--text-muted);
+    margin: 0 0 var(--space-2);
+}
+/* Inside a group, the per-row border-top would double up with the
+   group's own top divider on the first row. Strip it. */
+.config-section .config-group .config-row:first-child {
+    border-top: 0;
+}
+
 /* Social credit */
 .sc-adjust {
     display: flex;

--- a/web/src/main/resources/templates/moderation.html
+++ b/web/src/main/resources/templates/moderation.html
@@ -298,54 +298,6 @@
                     </span>
                     <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
                 </div>
-                <div class="config-row" data-key="POKER_SMALL_BLIND">
-                    <label>Small blind (chips posted by SB seat each hand; default 5)</label>
-                    <input type="number" min="1"
-                           th:value="${overview.config['POKER_SMALL_BLIND']}"
-                           placeholder="5"
-                           th:disabled="${!isOwner}">
-                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                </div>
-                <div class="config-row" data-key="POKER_BIG_BLIND">
-                    <label>Big blind (chips posted by BB seat each hand; default 10)</label>
-                    <input type="number" min="1"
-                           th:value="${overview.config['POKER_BIG_BLIND']}"
-                           placeholder="10"
-                           th:disabled="${!isOwner}">
-                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                </div>
-                <div class="config-row" data-key="POKER_SMALL_BET">
-                    <label>Small bet (fixed-limit bet pre-flop &amp; flop; default 10)</label>
-                    <input type="number" min="1"
-                           th:value="${overview.config['POKER_SMALL_BET']}"
-                           placeholder="10"
-                           th:disabled="${!isOwner}">
-                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                </div>
-                <div class="config-row" data-key="POKER_BIG_BET">
-                    <label>Big bet (fixed-limit bet on turn &amp; river; default 20)</label>
-                    <input type="number" min="1"
-                           th:value="${overview.config['POKER_BIG_BET']}"
-                           placeholder="20"
-                           th:disabled="${!isOwner}">
-                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                </div>
-                <div class="config-row" data-key="POKER_MIN_BUY_IN">
-                    <label>Minimum buy-in per seat (chips; default 100)</label>
-                    <input type="number" min="1"
-                           th:value="${overview.config['POKER_MIN_BUY_IN']}"
-                           placeholder="100"
-                           th:disabled="${!isOwner}">
-                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                </div>
-                <div class="config-row" data-key="POKER_MAX_BUY_IN">
-                    <label>Maximum buy-in per seat (chips; default 5000)</label>
-                    <input type="number" min="1"
-                           th:value="${overview.config['POKER_MAX_BUY_IN']}"
-                           placeholder="5000"
-                           th:disabled="${!isOwner}">
-                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                </div>
                 <div class="config-row" data-key="POKER_MAX_SEATS">
                     <label>Max seats per table (2-9; default 6)</label>
                     <input type="number" min="2" max="9"
@@ -377,22 +329,6 @@
                                th:disabled="${!isOwner}">
                         <span class="config-suffix">%</span>
                     </span>
-                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                </div>
-                <div class="config-row" data-key="BLACKJACK_MIN_ANTE">
-                    <label>Minimum stake per hand (applies to solo &amp; multi; default 10)</label>
-                    <input type="number" min="1"
-                           th:value="${overview.config['BLACKJACK_MIN_ANTE']}"
-                           placeholder="10"
-                           th:disabled="${!isOwner}">
-                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                </div>
-                <div class="config-row" data-key="BLACKJACK_MAX_ANTE">
-                    <label>Maximum stake per hand (applies to solo &amp; multi; default 500)</label>
-                    <input type="number" min="1"
-                           th:value="${overview.config['BLACKJACK_MAX_ANTE']}"
-                           placeholder="500"
-                           th:disabled="${!isOwner}">
                     <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
                 </div>
                 <div class="config-row" data-key="BLACKJACK_MAX_SEATS">
@@ -445,166 +381,266 @@
         </details>
 
         <details class="config-section">
-            <summary>Casino stake bounds</summary>
+            <summary>Casino stakes &amp; buy-ins</summary>
             <p class="muted mb-2">
-                Per-game min/max stake. No upper ceiling — set max as high as your economy can sustain.
-                Jackpot win probability scales by <code>stake / anchor</code>, so the anchor below stays a
-                stable reference even when stakes go large; bets at or above the anchor roll at the full
-                <code>JACKPOT_WIN_PCT</code> base probability. Blackjack stakes (solo and multi) are tuned
-                in the Blackjack card above via <code>BLACKJACK_MIN_ANTE</code> / <code>BLACKJACK_MAX_ANTE</code>.
+                Stake and buy-in bounds for every casino game in one place. Set any maximum to
+                <code>0</code> to remove the cap. Jackpot win probability scales by
+                <code>stake / anchor</code>, so the anchor stays a stable reference even when
+                stakes go large; bets at or above the anchor roll at the full
+                <code>JACKPOT_WIN_PCT</code> base probability.
             </p>
             <div class="config-grid">
-                <div class="config-row" data-key="JACKPOT_STAKE_ANCHOR">
-                    <label>Jackpot stake anchor (reference stake for jackpot probability scaling; default 500)</label>
-                    <input type="number" min="1"
-                           th:value="${overview.config['JACKPOT_STAKE_ANCHOR']}"
-                           placeholder="500"
-                           th:disabled="${!isOwner}">
-                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                <div class="config-group">
+                    <h4>Jackpot scaling</h4>
+                    <div class="config-row" data-key="JACKPOT_STAKE_ANCHOR">
+                        <label>Jackpot stake anchor (reference stake for jackpot probability scaling; default 500)</label>
+                        <input type="number" min="1"
+                               th:value="${overview.config['JACKPOT_STAKE_ANCHOR']}"
+                               placeholder="500"
+                               th:disabled="${!isOwner}">
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
                 </div>
-                <div class="config-row" data-key="DICE_MIN_STAKE">
-                    <label>Dice minimum stake (default 10)</label>
-                    <input type="number" min="1"
-                           th:value="${overview.config['DICE_MIN_STAKE']}"
-                           placeholder="10"
-                           th:disabled="${!isOwner}">
-                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                <div class="config-group">
+                    <h4>Dice</h4>
+                    <div class="config-row" data-key="DICE_MIN_STAKE">
+                        <label>Minimum stake (default 10)</label>
+                        <input type="number" min="1"
+                               th:value="${overview.config['DICE_MIN_STAKE']}"
+                               placeholder="10"
+                               th:disabled="${!isOwner}">
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
+                    <div class="config-row" data-key="DICE_MAX_STAKE">
+                        <label>Maximum stake (0 = unlimited; default 500)</label>
+                        <input type="number" min="0"
+                               th:value="${overview.config['DICE_MAX_STAKE']}"
+                               placeholder="500"
+                               th:disabled="${!isOwner}">
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
                 </div>
-                <div class="config-row" data-key="DICE_MAX_STAKE">
-                    <label>Dice maximum stake (default 500)</label>
-                    <input type="number" min="1"
-                           th:value="${overview.config['DICE_MAX_STAKE']}"
-                           placeholder="500"
-                           th:disabled="${!isOwner}">
-                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                <div class="config-group">
+                    <h4>Coinflip</h4>
+                    <div class="config-row" data-key="COINFLIP_MIN_STAKE">
+                        <label>Minimum stake (default 10)</label>
+                        <input type="number" min="1"
+                               th:value="${overview.config['COINFLIP_MIN_STAKE']}"
+                               placeholder="10"
+                               th:disabled="${!isOwner}">
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
+                    <div class="config-row" data-key="COINFLIP_MAX_STAKE">
+                        <label>Maximum stake (0 = unlimited; default 1000)</label>
+                        <input type="number" min="0"
+                               th:value="${overview.config['COINFLIP_MAX_STAKE']}"
+                               placeholder="1000"
+                               th:disabled="${!isOwner}">
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
                 </div>
-                <div class="config-row" data-key="COINFLIP_MIN_STAKE">
-                    <label>Coinflip minimum stake (default 10)</label>
-                    <input type="number" min="1"
-                           th:value="${overview.config['COINFLIP_MIN_STAKE']}"
-                           placeholder="10"
-                           th:disabled="${!isOwner}">
-                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                <div class="config-group">
+                    <h4>Slots</h4>
+                    <div class="config-row" data-key="SLOTS_MIN_STAKE">
+                        <label>Minimum stake (default 10)</label>
+                        <input type="number" min="1"
+                               th:value="${overview.config['SLOTS_MIN_STAKE']}"
+                               placeholder="10"
+                               th:disabled="${!isOwner}">
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
+                    <div class="config-row" data-key="SLOTS_MAX_STAKE">
+                        <label>Maximum stake (0 = unlimited; default 500)</label>
+                        <input type="number" min="0"
+                               th:value="${overview.config['SLOTS_MAX_STAKE']}"
+                               placeholder="500"
+                               th:disabled="${!isOwner}">
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
                 </div>
-                <div class="config-row" data-key="COINFLIP_MAX_STAKE">
-                    <label>Coinflip maximum stake (default 1000)</label>
-                    <input type="number" min="1"
-                           th:value="${overview.config['COINFLIP_MAX_STAKE']}"
-                           placeholder="1000"
-                           th:disabled="${!isOwner}">
-                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                <div class="config-group">
+                    <h4>Highlow</h4>
+                    <div class="config-row" data-key="HIGHLOW_MIN_STAKE">
+                        <label>Minimum stake (default 10)</label>
+                        <input type="number" min="1"
+                               th:value="${overview.config['HIGHLOW_MIN_STAKE']}"
+                               placeholder="10"
+                               th:disabled="${!isOwner}">
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
+                    <div class="config-row" data-key="HIGHLOW_MAX_STAKE">
+                        <label>Maximum stake (0 = unlimited; default 500)</label>
+                        <input type="number" min="0"
+                               th:value="${overview.config['HIGHLOW_MAX_STAKE']}"
+                               placeholder="500"
+                               th:disabled="${!isOwner}">
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
                 </div>
-                <div class="config-row" data-key="SLOTS_MIN_STAKE">
-                    <label>Slots minimum stake (default 10)</label>
-                    <input type="number" min="1"
-                           th:value="${overview.config['SLOTS_MIN_STAKE']}"
-                           placeholder="10"
-                           th:disabled="${!isOwner}">
-                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                <div class="config-group">
+                    <h4>Baccarat</h4>
+                    <div class="config-row" data-key="BACCARAT_MIN_STAKE">
+                        <label>Minimum stake (default 10)</label>
+                        <input type="number" min="1"
+                               th:value="${overview.config['BACCARAT_MIN_STAKE']}"
+                               placeholder="10"
+                               th:disabled="${!isOwner}">
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
+                    <div class="config-row" data-key="BACCARAT_MAX_STAKE">
+                        <label>Maximum stake (0 = unlimited; default 500)</label>
+                        <input type="number" min="0"
+                               th:value="${overview.config['BACCARAT_MAX_STAKE']}"
+                               placeholder="500"
+                               th:disabled="${!isOwner}">
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
                 </div>
-                <div class="config-row" data-key="SLOTS_MAX_STAKE">
-                    <label>Slots maximum stake (default 500)</label>
-                    <input type="number" min="1"
-                           th:value="${overview.config['SLOTS_MAX_STAKE']}"
-                           placeholder="500"
-                           th:disabled="${!isOwner}">
-                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                <div class="config-group">
+                    <h4>Keno</h4>
+                    <div class="config-row" data-key="KENO_MIN_STAKE">
+                        <label>Minimum stake (default 10)</label>
+                        <input type="number" min="1"
+                               th:value="${overview.config['KENO_MIN_STAKE']}"
+                               placeholder="10"
+                               th:disabled="${!isOwner}">
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
+                    <div class="config-row" data-key="KENO_MAX_STAKE">
+                        <label>Maximum stake (0 = unlimited; default 500)</label>
+                        <input type="number" min="0"
+                               th:value="${overview.config['KENO_MAX_STAKE']}"
+                               placeholder="500"
+                               th:disabled="${!isOwner}">
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
                 </div>
-                <div class="config-row" data-key="HIGHLOW_MIN_STAKE">
-                    <label>Highlow minimum stake (default 10)</label>
-                    <input type="number" min="1"
-                           th:value="${overview.config['HIGHLOW_MIN_STAKE']}"
-                           placeholder="10"
-                           th:disabled="${!isOwner}">
-                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                <div class="config-group">
+                    <h4>Scratch</h4>
+                    <div class="config-row" data-key="SCRATCH_MIN_STAKE">
+                        <label>Minimum stake (default 10)</label>
+                        <input type="number" min="1"
+                               th:value="${overview.config['SCRATCH_MIN_STAKE']}"
+                               placeholder="10"
+                               th:disabled="${!isOwner}">
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
+                    <div class="config-row" data-key="SCRATCH_MAX_STAKE">
+                        <label>Maximum stake (0 = unlimited; default 500)</label>
+                        <input type="number" min="0"
+                               th:value="${overview.config['SCRATCH_MAX_STAKE']}"
+                               placeholder="500"
+                               th:disabled="${!isOwner}">
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
                 </div>
-                <div class="config-row" data-key="HIGHLOW_MAX_STAKE">
-                    <label>Highlow maximum stake (default 500)</label>
-                    <input type="number" min="1"
-                           th:value="${overview.config['HIGHLOW_MAX_STAKE']}"
-                           placeholder="500"
-                           th:disabled="${!isOwner}">
-                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                <div class="config-group">
+                    <h4>Casino Hold'em</h4>
+                    <div class="config-row" data-key="HOLDEM_MIN_STAKE">
+                        <label>Minimum stake (default 10)</label>
+                        <input type="number" min="1"
+                               th:value="${overview.config['HOLDEM_MIN_STAKE']}"
+                               placeholder="10"
+                               th:disabled="${!isOwner}">
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
+                    <div class="config-row" data-key="HOLDEM_MAX_STAKE">
+                        <label>Maximum stake (0 = unlimited; default 500)</label>
+                        <input type="number" min="0"
+                               th:value="${overview.config['HOLDEM_MAX_STAKE']}"
+                               placeholder="500"
+                               th:disabled="${!isOwner}">
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
                 </div>
-                <div class="config-row" data-key="BACCARAT_MIN_STAKE">
-                    <label>Baccarat minimum stake (default 10)</label>
-                    <input type="number" min="1"
-                           th:value="${overview.config['BACCARAT_MIN_STAKE']}"
-                           placeholder="10"
-                           th:disabled="${!isOwner}">
-                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                <div class="config-group">
+                    <h4>Blackjack</h4>
+                    <div class="config-row" data-key="BLACKJACK_MIN_ANTE">
+                        <label>Minimum stake per hand (applies to solo &amp; multi; default 10)</label>
+                        <input type="number" min="1"
+                               th:value="${overview.config['BLACKJACK_MIN_ANTE']}"
+                               placeholder="10"
+                               th:disabled="${!isOwner}">
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
+                    <div class="config-row" data-key="BLACKJACK_MAX_ANTE">
+                        <label>Maximum stake per hand (applies to solo &amp; multi; 0 = unlimited; default 500)</label>
+                        <input type="number" min="0"
+                               th:value="${overview.config['BLACKJACK_MAX_ANTE']}"
+                               placeholder="500"
+                               th:disabled="${!isOwner}">
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
                 </div>
-                <div class="config-row" data-key="BACCARAT_MAX_STAKE">
-                    <label>Baccarat maximum stake (default 500)</label>
-                    <input type="number" min="1"
-                           th:value="${overview.config['BACCARAT_MAX_STAKE']}"
-                           placeholder="500"
-                           th:disabled="${!isOwner}">
-                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                <div class="config-group">
+                    <h4>Duel</h4>
+                    <div class="config-row" data-key="DUEL_MIN_STAKE">
+                        <label>Minimum stake (default 10)</label>
+                        <input type="number" min="1"
+                               th:value="${overview.config['DUEL_MIN_STAKE']}"
+                               placeholder="10"
+                               th:disabled="${!isOwner}">
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
+                    <div class="config-row" data-key="DUEL_MAX_STAKE">
+                        <label>Maximum stake (0 = unlimited; default 500)</label>
+                        <input type="number" min="0"
+                               th:value="${overview.config['DUEL_MAX_STAKE']}"
+                               placeholder="500"
+                               th:disabled="${!isOwner}">
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
                 </div>
-                <div class="config-row" data-key="KENO_MIN_STAKE">
-                    <label>Keno minimum stake (default 10)</label>
-                    <input type="number" min="1"
-                           th:value="${overview.config['KENO_MIN_STAKE']}"
-                           placeholder="10"
-                           th:disabled="${!isOwner}">
-                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                </div>
-                <div class="config-row" data-key="KENO_MAX_STAKE">
-                    <label>Keno maximum stake (default 500)</label>
-                    <input type="number" min="1"
-                           th:value="${overview.config['KENO_MAX_STAKE']}"
-                           placeholder="500"
-                           th:disabled="${!isOwner}">
-                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                </div>
-                <div class="config-row" data-key="SCRATCH_MIN_STAKE">
-                    <label>Scratch minimum stake (default 10)</label>
-                    <input type="number" min="1"
-                           th:value="${overview.config['SCRATCH_MIN_STAKE']}"
-                           placeholder="10"
-                           th:disabled="${!isOwner}">
-                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                </div>
-                <div class="config-row" data-key="SCRATCH_MAX_STAKE">
-                    <label>Scratch maximum stake (default 500)</label>
-                    <input type="number" min="1"
-                           th:value="${overview.config['SCRATCH_MAX_STAKE']}"
-                           placeholder="500"
-                           th:disabled="${!isOwner}">
-                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                </div>
-                <div class="config-row" data-key="HOLDEM_MIN_STAKE">
-                    <label>Casino Hold'em minimum stake (default 10)</label>
-                    <input type="number" min="1"
-                           th:value="${overview.config['HOLDEM_MIN_STAKE']}"
-                           placeholder="10"
-                           th:disabled="${!isOwner}">
-                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                </div>
-                <div class="config-row" data-key="HOLDEM_MAX_STAKE">
-                    <label>Casino Hold'em maximum stake (default 500)</label>
-                    <input type="number" min="1"
-                           th:value="${overview.config['HOLDEM_MAX_STAKE']}"
-                           placeholder="500"
-                           th:disabled="${!isOwner}">
-                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                </div>
-                <div class="config-row" data-key="DUEL_MIN_STAKE">
-                    <label>Duel minimum stake (default 10)</label>
-                    <input type="number" min="1"
-                           th:value="${overview.config['DUEL_MIN_STAKE']}"
-                           placeholder="10"
-                           th:disabled="${!isOwner}">
-                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                </div>
-                <div class="config-row" data-key="DUEL_MAX_STAKE">
-                    <label>Duel maximum stake (default 500)</label>
-                    <input type="number" min="1"
-                           th:value="${overview.config['DUEL_MAX_STAKE']}"
-                           placeholder="500"
-                           th:disabled="${!isOwner}">
-                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                <div class="config-group">
+                    <h4>Poker</h4>
+                    <div class="config-row" data-key="POKER_SMALL_BLIND">
+                        <label>Small blind (chips posted by SB seat each hand; default 5)</label>
+                        <input type="number" min="1"
+                               th:value="${overview.config['POKER_SMALL_BLIND']}"
+                               placeholder="5"
+                               th:disabled="${!isOwner}">
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
+                    <div class="config-row" data-key="POKER_BIG_BLIND">
+                        <label>Big blind (chips posted by BB seat each hand; default 10)</label>
+                        <input type="number" min="1"
+                               th:value="${overview.config['POKER_BIG_BLIND']}"
+                               placeholder="10"
+                               th:disabled="${!isOwner}">
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
+                    <div class="config-row" data-key="POKER_SMALL_BET">
+                        <label>Small bet (fixed-limit bet pre-flop &amp; flop; default 10)</label>
+                        <input type="number" min="1"
+                               th:value="${overview.config['POKER_SMALL_BET']}"
+                               placeholder="10"
+                               th:disabled="${!isOwner}">
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
+                    <div class="config-row" data-key="POKER_BIG_BET">
+                        <label>Big bet (fixed-limit bet on turn &amp; river; default 20)</label>
+                        <input type="number" min="1"
+                               th:value="${overview.config['POKER_BIG_BET']}"
+                               placeholder="20"
+                               th:disabled="${!isOwner}">
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
+                    <div class="config-row" data-key="POKER_MIN_BUY_IN">
+                        <label>Minimum buy-in per seat (chips; default 100)</label>
+                        <input type="number" min="1"
+                               th:value="${overview.config['POKER_MIN_BUY_IN']}"
+                               placeholder="100"
+                               th:disabled="${!isOwner}">
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
+                    <div class="config-row" data-key="POKER_MAX_BUY_IN">
+                        <label>Maximum buy-in per seat (chips; 0 = unlimited; default 5000)</label>
+                        <input type="number" min="0"
+                               th:value="${overview.config['POKER_MAX_BUY_IN']}"
+                               placeholder="5000"
+                               th:disabled="${!isOwner}">
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
                 </div>
             </div>
         </details>

--- a/web/src/test/kotlin/web/service/ModerationWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/ModerationWebServiceTest.kt
@@ -357,22 +357,75 @@ class ModerationWebServiceTest {
     }
 
     @Test
-    fun `updateConfig accepts BLACKJACK_MIN_ANTE and MAX_ANTE when value is a positive long`() {
+    fun `updateConfig accepts BLACKJACK_MIN_ANTE when value is a positive long and rejects 0`() {
+        // Min-ante is a floor — 0 has no meaning, so it stays rejected
+        // (unlike MAX_ANTE which now accepts 0 as "unlimited").
         mockMember(ownerId, isOwner = true)
-        val keys = listOf(
-            ConfigDto.Configurations.BLACKJACK_MIN_ANTE,
-            ConfigDto.Configurations.BLACKJACK_MAX_ANTE,
-        )
-        for (key in keys) {
-            assertNull(service.updateConfig(ownerId, guildId, key, "10"))
-            assertNull(service.updateConfig(ownerId, guildId, key, "500"))
-            verify { configService.upsertConfig(key.configValue, "10", guildId.toString()) }
-            verify { configService.upsertConfig(key.configValue, "500", guildId.toString()) }
+        val key = ConfigDto.Configurations.BLACKJACK_MIN_ANTE
 
-            assertNotNull(service.updateConfig(ownerId, guildId, key, "0"))
-            assertNotNull(service.updateConfig(ownerId, guildId, key, "-5"))
-            assertNotNull(service.updateConfig(ownerId, guildId, key, "wibble"))
+        assertNull(service.updateConfig(ownerId, guildId, key, "10"))
+        assertNull(service.updateConfig(ownerId, guildId, key, "500"))
+        verify { configService.upsertConfig(key.configValue, "10", guildId.toString()) }
+        verify { configService.upsertConfig(key.configValue, "500", guildId.toString()) }
+
+        assertNotNull(service.updateConfig(ownerId, guildId, key, "0"))
+        assertNotNull(service.updateConfig(ownerId, guildId, key, "-5"))
+        assertNotNull(service.updateConfig(ownerId, guildId, key, "wibble"))
+    }
+
+    @Test
+    fun `updateConfig accepts BLACKJACK_MAX_ANTE positive value or 0 (unlimited) and rejects negatives`() {
+        // 0 is the "no upper cap" sentinel — admins type 0 instead of a
+        // giant number. cfgLongMax expands stored 0 to Long.MAX_VALUE at
+        // read time. Negatives + non-numeric values still fail validation.
+        mockMember(ownerId, isOwner = true)
+        val key = ConfigDto.Configurations.BLACKJACK_MAX_ANTE
+
+        assertNull(service.updateConfig(ownerId, guildId, key, "500"))
+        assertNull(service.updateConfig(ownerId, guildId, key, "0"), "0 is the unlimited sentinel")
+        verify { configService.upsertConfig(key.configValue, "500", guildId.toString()) }
+        verify { configService.upsertConfig(key.configValue, "0", guildId.toString()) }
+
+        assertNotNull(service.updateConfig(ownerId, guildId, key, "-5"))
+        assertNotNull(service.updateConfig(ownerId, guildId, key, "wibble"))
+    }
+
+    @Test
+    fun `updateConfig accepts every per-game MAX_STAKE key with 0 as unlimited`() {
+        // Pin the unlimited semantic for every minigame max-cap key in
+        // one place — drift in the validation arm (e.g. someone splitting
+        // a key back into the min-cap arm) trips here immediately.
+        mockMember(ownerId, isOwner = true)
+        val maxKeys = listOf(
+            ConfigDto.Configurations.DICE_MAX_STAKE,
+            ConfigDto.Configurations.COINFLIP_MAX_STAKE,
+            ConfigDto.Configurations.SLOTS_MAX_STAKE,
+            ConfigDto.Configurations.HIGHLOW_MAX_STAKE,
+            ConfigDto.Configurations.BACCARAT_MAX_STAKE,
+            ConfigDto.Configurations.KENO_MAX_STAKE,
+            ConfigDto.Configurations.SCRATCH_MAX_STAKE,
+            ConfigDto.Configurations.HOLDEM_MAX_STAKE,
+            ConfigDto.Configurations.DUEL_MAX_STAKE,
+            ConfigDto.Configurations.POKER_MAX_BUY_IN,
+        )
+        for (key in maxKeys) {
+            assertNull(service.updateConfig(ownerId, guildId, key, "0"), "$key should accept 0 (unlimited)")
+            assertNull(service.updateConfig(ownerId, guildId, key, "1000"), "$key should accept 1000")
+            assertNotNull(service.updateConfig(ownerId, guildId, key, "-1"), "$key should reject negatives")
         }
+    }
+
+    @Test
+    fun `updateConfig keeps JACKPOT_STAKE_ANCHOR as a min-only field that rejects 0`() {
+        // The anchor is a divisor in JackpotHelper.rollOnWin (stake / anchor),
+        // so 0 isn't "unlimited" — it's pathological. Stays rejected even
+        // after the broader 0=unlimited semantic for max-stake fields.
+        mockMember(ownerId, isOwner = true)
+        val key = ConfigDto.Configurations.JACKPOT_STAKE_ANCHOR
+
+        assertNull(service.updateConfig(ownerId, guildId, key, "500"))
+        assertNotNull(service.updateConfig(ownerId, guildId, key, "0"), "anchor must reject 0")
+        assertNotNull(service.updateConfig(ownerId, guildId, key, "-1"))
     }
 
     @Test

--- a/web/src/test/kotlin/web/template/ModerationTemplateRowsTest.kt
+++ b/web/src/test/kotlin/web/template/ModerationTemplateRowsTest.kt
@@ -27,6 +27,10 @@ class ModerationTemplateRowsTest {
 
     @Test
     fun `moderation template surfaces every blackjack config key as an editable row`() {
+        // Stake-shaped keys (BLACKJACK_MIN_ANTE / BLACKJACK_MAX_ANTE) live
+        // in the consolidated "Casino stakes & buy-ins" card now, but the
+        // page still has to render rows for them — this test just asserts
+        // presence-anywhere, not which card.
         val keys = listOf(
             ConfigDto.Configurations.BLACKJACK_RAKE_PCT,
             ConfigDto.Configurations.BLACKJACK_MIN_ANTE,
@@ -50,7 +54,10 @@ class ModerationTemplateRowsTest {
         // Same regression class as blackjack — `POKER_RAKE_PCT` was the only
         // poker key with a UI row before; the per-table parameters
         // (blinds, bets, buy-in range, max seats, shot clock) were defined
-        // and validated server-side but admins had no form for them.
+        // and validated server-side but admins had no form for them. The
+        // chip-amount keys (blinds/bets/buy-ins) now live in the
+        // consolidated "Casino stakes & buy-ins" card with the rest of
+        // the stake bounds.
         val keys = listOf(
             ConfigDto.Configurations.POKER_RAKE_PCT,
             ConfigDto.Configurations.POKER_SMALL_BLIND,
@@ -91,12 +98,13 @@ class ModerationTemplateRowsTest {
     }
 
     @Test
-    fun `moderation template surfaces every per-game stake bound and the jackpot anchor as editable rows`() {
-        // Stake bounds and the jackpot scaling anchor live in their own
-        // "Casino stake bounds" card. Without this presence test, a refactor
-        // that drops or renames a row silently kills admin access to that
-        // dimension (and the service-side config quietly falls back to the
-        // hardcoded default).
+    fun `moderation template surfaces every stake or buy-in config key as an editable row`() {
+        // Every stake-shaped config — per-minigame min/max, blackjack ante
+        // bounds, the jackpot scaling anchor, and the poker chip thresholds
+        // (blinds/bets/buy-ins) — lives in the consolidated "Casino stakes
+        // & buy-ins" card. This guards against a refactor accidentally
+        // dropping a row (which would silently fall back to defaults
+        // since no UI surface remains for the admin to edit it).
         val keys = listOf(
             ConfigDto.Configurations.JACKPOT_STAKE_ANCHOR,
             ConfigDto.Configurations.DICE_MIN_STAKE,
@@ -117,6 +125,14 @@ class ModerationTemplateRowsTest {
             ConfigDto.Configurations.HOLDEM_MAX_STAKE,
             ConfigDto.Configurations.DUEL_MIN_STAKE,
             ConfigDto.Configurations.DUEL_MAX_STAKE,
+            ConfigDto.Configurations.BLACKJACK_MIN_ANTE,
+            ConfigDto.Configurations.BLACKJACK_MAX_ANTE,
+            ConfigDto.Configurations.POKER_SMALL_BLIND,
+            ConfigDto.Configurations.POKER_BIG_BLIND,
+            ConfigDto.Configurations.POKER_SMALL_BET,
+            ConfigDto.Configurations.POKER_BIG_BET,
+            ConfigDto.Configurations.POKER_MIN_BUY_IN,
+            ConfigDto.Configurations.POKER_MAX_BUY_IN,
         )
         for (key in keys) {
             assertTrue(
@@ -127,11 +143,30 @@ class ModerationTemplateRowsTest {
     }
 
     @Test
-    fun `casino stake bounds section has its own collapsed details block`() {
+    fun `casino stakes and buy-ins section has its own collapsed details block`() {
         assertTrue(
-            html.contains("<summary>Casino stake bounds</summary>"),
-            "expected a <details><summary>Casino stake bounds</summary> wrapper around the per-game stake rows"
+            html.contains("<summary>Casino stakes &amp; buy-ins</summary>"),
+            "expected a <details><summary>Casino stakes & buy-ins</summary> wrapper around the consolidated stake rows"
         )
+    }
+
+    @Test
+    fun `casino stakes card sub-groups every game with an h4 heading`() {
+        // The card is too long without sub-headings — admins scan by game.
+        // Asserting on a sample of headings so a flatten regression is
+        // obvious without making the test enumerate every group.
+        val headings = listOf(
+            "<h4>Jackpot scaling</h4>",
+            "<h4>Dice</h4>",
+            "<h4>Blackjack</h4>",
+            "<h4>Poker</h4>",
+        )
+        for (h in headings) {
+            assertTrue(
+                html.contains(h),
+                "expected $h sub-heading inside the consolidated card"
+            )
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary

Two improvements to the `/moderation` page's casino config:

1. **Consolidate** — every stake-shaped knob (per-minigame min/max, blackjack ante bounds, poker blinds/bets/buy-ins, jackpot scaling anchor) now lives in one card. The Poker and Blackjack cards keep only the *game-rules* knobs (rake %, max seats, shot clock, dealer-hits-soft-17, BJ-payout num/den). The consolidated card is renamed "Casino stakes & buy-ins" and is sub-grouped by game (`<h4>`-headed sections: Jackpot scaling / Dice / Coinflip / Slots / Highlow / Baccarat / Keno / Scratch / Casino Hold'em / Blackjack / Duel / Poker) so admins can scan game-by-game.

2. **0 = unlimited for max-cap fields** — admins can type `0` instead of a giant number to remove a maximum cap. New `ConfigService.cfgLongMax` extension expands stored `0` to `Long.MAX_VALUE` at read time; write-time validation splits the stake-config arm so max-cap keys accept `0` and min-cap keys + `JACKPOT_STAKE_ANCHOR` still require `>= 1` (the anchor is a divisor in the jackpot probability formula — `0` is pathological, not "unlimited"). UI labels reflect the semantic: max-cap rows show "(0 = unlimited; default …)" and use `min="0"` so the browser's number stepper allows 0.

## Test plan

- [x] `:database:test` — new `ConfigReadersTest` (8 cases) pins the cfgLong / cfgLongMax read-time semantics. New `DiceServiceTest` case proves end-to-end that `DICE_MAX_STAKE=0` accepts a 5,000,000 stake.
- [x] `:web:test` — `ModerationWebServiceTest` split the BLACKJACK MIN/MAX_ANTE case into two; new exhaustive max-cap-key test pins 0-as-unlimited for every `*_MAX_STAKE` + `POKER_MAX_BUY_IN`; new test pins `JACKPOT_STAKE_ANCHOR` still rejects `0`. `ModerationTemplateRowsTest` extends the consolidated-card presence list with the moved keys and asserts the new `<summary>Casino stakes &amp; buy-ins</summary>` + sub-heading regression.
- [x] `npm test` (web) — 315 JS tests pass.
- [x] `npm run lint:css` — clean.
- [ ] Manual end-to-end (CI runs `:application:test` for context-load / Spring wiring; my local sandbox can't fetch the discord-bot transitive deps but those modules are unaffected by the changes here):
  - Open `/moderation/{guildId}` → "Casino stakes & buy-ins" — confirm 12 sub-groups in the listed order, each with an `<h4>` heading.
  - Set `DICE_MAX_STAKE = 0` via the page; `/dice 1000000 6` in Discord — expected: roll accepted (no `InvalidStake`).
  - Set `JACKPOT_STAKE_ANCHOR = 0` via the page — expected: validation error "Value must be at least 1 credit." (anchor still rejects `0`).
  - Set `BLACKJACK_MAX_ANTE = 0`; `/blackjack solo 100000` — expected: hand deals.
  - Confirm Poker and Blackjack cards no longer show the moved rows but still show their game-rules controls (rake / seats / shot-clock / dealer / payout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01F1o7Dh6Sq36g4zTKWzj62D)_