### PR TITLE
feat(casino): add /roulette minigame (web + Discord)

### DIFF
--- a/application/src/test/kotlin/integration/bot/CommandManagerTest.kt
+++ b/application/src/test/kotlin/integration/bot/CommandManagerTest.kt
@@ -18,6 +18,7 @@ import bot.toby.command.commands.economy.DuelCommand
 import bot.toby.command.commands.economy.HighlowCommand
 import bot.toby.command.commands.economy.KenoCommand
 import bot.toby.command.commands.economy.PokerCommand
+import bot.toby.command.commands.economy.RouletteCommand
 import bot.toby.command.commands.economy.ScratchCommand
 import bot.toby.command.commands.economy.SlotsCommand
 import bot.toby.command.commands.economy.TipCommand
@@ -153,12 +154,13 @@ class CommandManagerTest {
             BlackjackCommand::class.java,
             BaccaratCommand::class.java,
             KenoCommand::class.java,
-            CasinoHoldemCommand::class.java
+            CasinoHoldemCommand::class.java,
+            RouletteCommand::class.java
         )
 
         Assertions.assertTrue(availableCommands.containsAll(commandManager.allCommands.map { it.javaClass }.toList()))
-        Assertions.assertEquals(59, commandManager.allCommands.size)
-        Assertions.assertEquals(59, commandManager.allSlashCommands.size)
+        Assertions.assertEquals(60, commandManager.allCommands.size)
+        Assertions.assertEquals(60, commandManager.allSlashCommands.size)
     }
 
     @Test

--- a/database/src/main/kotlin/database/dto/ConfigDto.kt
+++ b/database/src/main/kotlin/database/dto/ConfigDto.kt
@@ -135,6 +135,8 @@ class ConfigDto(
         KENO_MAX_STAKE("KENO_MAX_STAKE"),
         SCRATCH_MIN_STAKE("SCRATCH_MIN_STAKE"),
         SCRATCH_MAX_STAKE("SCRATCH_MAX_STAKE"),
+        ROULETTE_MIN_STAKE("ROULETTE_MIN_STAKE"),
+        ROULETTE_MAX_STAKE("ROULETTE_MAX_STAKE"),
         // Solo blackjack reuses the existing BLACKJACK_MIN_ANTE /
         // BLACKJACK_MAX_ANTE keys — solo and multi share a single
         // configurable stake range.

--- a/database/src/main/kotlin/database/economy/Roulette.kt
+++ b/database/src/main/kotlin/database/economy/Roulette.kt
@@ -1,0 +1,136 @@
+package database.economy
+
+import kotlin.random.Random
+
+/**
+ * Pure-logic European roulette wheel (single zero, 37 pockets, 2.7%
+ * house edge from the green zero). No Spring, no DB, no JDA — just a
+ * uniform pocket draw and a per-bet payout table.
+ *
+ * Bet menu (one bet per spin, mirroring `/dice` + `/coinflip` for a
+ * one-stake/one-outcome service contract):
+ *
+ *   RED / BLACK              1:1   (even-money outside; 0 loses)
+ *   ODD / EVEN               1:1   (even-money outside; 0 loses)
+ *   LOW (1-18) / HIGH (19-36)1:1   (even-money outside; 0 loses)
+ *   DOZEN_1/2/3              2:1   (1-12, 13-24, 25-36)
+ *   COLUMN_1/2/3             2:1   (1,4,7…/2,5,8…/3,6,9…)
+ *   STRAIGHT (single number) 35:1  (caller picks 0-36)
+ *
+ * [WagerHelper.applyMultiplier] computes `payout = multiplier × stake`
+ * and `net = payout − stake`, so the Bet.multiplier values below are
+ * `(odds + 1)` (e.g. 1:1 → 2×, 35:1 → 36×).
+ *
+ * RTP across every bet type works out to 36/37 ≈ 0.973 (the standard
+ * European house edge). The green zero is the entire edge — losses
+ * still feed the per-guild jackpot pool via [JackpotHelper.divertOnLoss]
+ * and wins still roll for it via [JackpotHelper.rollOnWin], identical
+ * to every other minigame.
+ *
+ * Stake bounds (`MIN_STAKE` / `MAX_STAKE`) live here so the Discord
+ * command, the web controller, and the service all agree on what's
+ * valid; per-guild admin overrides go through `ROULETTE_MIN_STAKE` /
+ * `ROULETTE_MAX_STAKE` config keys.
+ */
+class Roulette {
+
+    enum class Color { RED, BLACK, GREEN }
+
+    enum class Bet(val display: String, val multiplier: Long) {
+        RED("Red", 2L),
+        BLACK("Black", 2L),
+        ODD("Odd", 2L),
+        EVEN("Even", 2L),
+        LOW("Low (1-18)", 2L),
+        HIGH("High (19-36)", 2L),
+        DOZEN_1("1st dozen", 3L),
+        DOZEN_2("2nd dozen", 3L),
+        DOZEN_3("3rd dozen", 3L),
+        COLUMN_1("1st column", 3L),
+        COLUMN_2("2nd column", 3L),
+        COLUMN_3("3rd column", 3L),
+        STRAIGHT("Straight", 36L);
+
+        val requiresNumber: Boolean get() = this == STRAIGHT
+    }
+
+    data class Spin(
+        val landed: Int,
+        val color: Color,
+        val bet: Bet,
+        val straightNumber: Int?,
+        val multiplier: Long,
+    ) {
+        val isWin: Boolean get() = multiplier > 0L
+    }
+
+    fun spin(bet: Bet, straightNumber: Int?, random: Random): Spin {
+        val landed = random.nextInt(POCKET_COUNT)
+        val won = wins(bet, straightNumber, landed)
+        return Spin(
+            landed = landed,
+            color = colorOf(landed),
+            bet = bet,
+            straightNumber = straightNumber,
+            multiplier = if (won) bet.multiplier else 0L,
+        )
+    }
+
+    companion object {
+        const val POCKET_COUNT: Int = 37          // European: 0-36 inclusive.
+        const val MAX_NUMBER: Int = 36
+        const val MIN_STAKE: Long = 10L
+        const val MAX_STAKE: Long = 500L
+
+        /**
+         * Standard European wheel red pockets. Black is the complement
+         * within 1..36; 0 is green. Memorised verbatim from the European
+         * single-zero wheel — same set every casino uses.
+         */
+        val RED_NUMBERS: Set<Int> = setOf(
+            1, 3, 5, 7, 9, 12, 14, 16, 18,
+            19, 21, 23, 25, 27, 30, 32, 34, 36,
+        )
+
+        /**
+         * Standard European wheel pocket order (clockwise starting at 0).
+         * Used by the web UI to animate the ball decelerating across
+         * sequential pockets — pure cosmetic data, draw probability is
+         * still uniform over 0..36.
+         */
+        val WHEEL_ORDER: List<Int> = listOf(
+            0, 32, 15, 19, 4, 21, 2, 25, 17, 34, 6, 27,
+            13, 36, 11, 30, 8, 23, 10, 5, 24, 16, 33, 1,
+            20, 14, 31, 9, 22, 18, 29, 7, 28, 12, 35, 3, 26,
+        )
+
+        fun colorOf(pocket: Int): Color = when {
+            pocket == 0 -> Color.GREEN
+            pocket in RED_NUMBERS -> Color.RED
+            else -> Color.BLACK
+        }
+
+        /**
+         * Predicate over the bet menu: does [pocket] cover this [bet]?
+         * Pure function — the service uses it both inside [Roulette.spin]
+         * and (defensively) when settling Win vs. Lose so the JSON shape
+         * always agrees with the wheel position the UI is about to land
+         * the ball on. The zero pocket loses every outside bet by design.
+         */
+        fun wins(bet: Bet, straightNumber: Int?, pocket: Int): Boolean = when (bet) {
+            Bet.RED -> pocket in RED_NUMBERS
+            Bet.BLACK -> pocket != 0 && pocket !in RED_NUMBERS
+            Bet.ODD -> pocket != 0 && pocket % 2 == 1
+            Bet.EVEN -> pocket != 0 && pocket % 2 == 0
+            Bet.LOW -> pocket in 1..18
+            Bet.HIGH -> pocket in 19..36
+            Bet.DOZEN_1 -> pocket in 1..12
+            Bet.DOZEN_2 -> pocket in 13..24
+            Bet.DOZEN_3 -> pocket in 25..36
+            Bet.COLUMN_1 -> pocket != 0 && pocket % 3 == 1
+            Bet.COLUMN_2 -> pocket != 0 && pocket % 3 == 2
+            Bet.COLUMN_3 -> pocket != 0 && pocket % 3 == 0
+            Bet.STRAIGHT -> straightNumber != null && pocket == straightNumber
+        }
+    }
+}

--- a/database/src/main/kotlin/database/service/RouletteService.kt
+++ b/database/src/main/kotlin/database/service/RouletteService.kt
@@ -1,0 +1,151 @@
+package database.service
+
+import common.casino.CasinoCommonFailure
+import database.dto.ConfigDto
+import database.economy.Roulette
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import kotlin.random.Random
+
+/**
+ * Atomic spin path for the `/roulette` minigame. Both the Discord
+ * `/roulette` command and the web `/casino/{guildId}/roulette` page call
+ * through here so the debit/credit maths and the random draw only live
+ * in one place.
+ *
+ * Pattern mirrors [SlotsService] / [CoinflipService]: lock the user row
+ * via [UserService.getUserByIdForUpdate], validate inputs against the
+ * live balance, mutate, persist — all inside a single `@Transactional`
+ * boundary so concurrent `/roulette` calls from the same user (Discord
+ * + web at once, or just spam-clicking) can't double-spend the stake.
+ *
+ * Wins also roll [JackpotHelper] for a chance to bank the per-guild
+ * jackpot pool; losses divert a tribute fraction into it (same shared
+ * pool that every casino game feeds into and pays out from).
+ */
+@Service
+@Transactional
+class RouletteService(
+    private val userService: UserService,
+    private val jackpotService: JackpotService,
+    private val tradeService: EconomyTradeService,
+    private val marketService: TobyCoinMarketService,
+    private val configService: ConfigService,
+    private val roulette: Roulette = Roulette(),
+    private val random: Random = Random.Default,
+) {
+
+    sealed interface SpinOutcome {
+        data class Win(
+            val stake: Long,
+            val bet: Roulette.Bet,
+            val landed: Int,
+            val color: Roulette.Color,
+            val straightNumber: Int?,
+            val multiplier: Long,
+            val payout: Long,
+            val net: Long,
+            val newBalance: Long,
+            val jackpotPayout: Long = 0L,
+            val soldTobyCoins: Long = 0L,
+            val newPrice: Double? = null,
+        ) : SpinOutcome
+
+        data class Lose(
+            val stake: Long,
+            val bet: Roulette.Bet,
+            val landed: Int,
+            val color: Roulette.Color,
+            val straightNumber: Int?,
+            val newBalance: Long,
+            val soldTobyCoins: Long = 0L,
+            val newPrice: Double? = null,
+            val lossTribute: Long = 0L,
+        ) : SpinOutcome
+
+        data class InvalidNumber(val min: Int, val max: Int) : SpinOutcome
+
+        data class InsufficientCredits(override val stake: Long, override val have: Long) :
+            SpinOutcome, CasinoCommonFailure.InsufficientCredits
+        data class InsufficientCoinsForTopUp(override val needed: Long, override val have: Long) :
+            SpinOutcome, CasinoCommonFailure.InsufficientCoinsForTopUp
+        data class InvalidStake(override val min: Long, override val max: Long) :
+            SpinOutcome, CasinoCommonFailure.InvalidStake
+        data object UnknownUser : SpinOutcome, CasinoCommonFailure.UnknownUser
+    }
+
+    fun spin(
+        discordId: Long,
+        guildId: Long,
+        stake: Long,
+        bet: Roulette.Bet,
+        straightNumber: Int? = null,
+        autoTopUp: Boolean = false,
+    ): SpinOutcome {
+        // STRAIGHT requires a 0-36 pick; non-STRAIGHT bets ignore any value
+        // the caller passed (the Discord command and web controller both
+        // null the field for outside bets, but defending here keeps the
+        // service contract self-validating).
+        val effectiveNumber = if (bet == Roulette.Bet.STRAIGHT) straightNumber else null
+        if (bet == Roulette.Bet.STRAIGHT &&
+            (effectiveNumber == null || effectiveNumber !in 0..Roulette.MAX_NUMBER)
+        ) {
+            return SpinOutcome.InvalidNumber(0, Roulette.MAX_NUMBER)
+        }
+
+        val minStake = configService.cfgLong(
+            ConfigDto.Configurations.ROULETTE_MIN_STAKE, guildId, default = Roulette.MIN_STAKE, min = 1L
+        )
+        val maxStake = configService.cfgLongMax(
+            ConfigDto.Configurations.ROULETTE_MAX_STAKE, guildId, default = Roulette.MAX_STAKE, min = minStake
+        )
+        val resolved = when (val r = WagerHelper.checkLockOrTopUp(
+            userService, tradeService, marketService,
+            discordId, guildId, stake, minStake, maxStake, autoTopUp,
+        )) {
+            is TopUpResolution.InvalidStake -> return SpinOutcome.InvalidStake(r.min, r.max)
+            TopUpResolution.UnknownUser -> return SpinOutcome.UnknownUser
+            is TopUpResolution.StillInsufficientCredits ->
+                return SpinOutcome.InsufficientCredits(r.stake, r.have)
+            is TopUpResolution.InsufficientCoinsForTopUp ->
+                return SpinOutcome.InsufficientCoinsForTopUp(r.needed, r.have)
+            is TopUpResolution.Ok -> r
+        }
+
+        val spin = roulette.spin(bet, effectiveNumber, random)
+        val wager = WagerHelper.applyMultiplier(userService, resolved.user, resolved.balance, stake, spin.multiplier)
+        return if (spin.isWin) {
+            val jackpot = JackpotHelper.rollOnWin(
+                jackpotService, configService, userService, resolved.user, guildId,
+                stake, random,
+            )
+            SpinOutcome.Win(
+                stake = stake,
+                bet = bet,
+                landed = spin.landed,
+                color = spin.color,
+                straightNumber = effectiveNumber,
+                multiplier = spin.multiplier,
+                payout = wager.payout,
+                net = wager.net,
+                newBalance = wager.newBalance + jackpot,
+                jackpotPayout = jackpot,
+                soldTobyCoins = resolved.soldCoins,
+                newPrice = resolved.newPrice,
+            )
+        } else {
+            val tribute = JackpotHelper.divertOnLoss(jackpotService, configService, guildId, stake)
+            SpinOutcome.Lose(
+                stake = stake,
+                bet = bet,
+                landed = spin.landed,
+                color = spin.color,
+                straightNumber = effectiveNumber,
+                newBalance = wager.newBalance,
+                soldTobyCoins = resolved.soldCoins,
+                newPrice = resolved.newPrice,
+                lossTribute = tribute,
+            )
+        }
+    }
+}

--- a/database/src/test/kotlin/database/economy/RouletteTest.kt
+++ b/database/src/test/kotlin/database/economy/RouletteTest.kt
@@ -1,0 +1,180 @@
+package database.economy
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import kotlin.random.Random
+
+class RouletteTest {
+
+    private val roulette = Roulette()
+
+    @Test
+    fun `wheel has 37 pockets numbered 0 through 36 with no duplicates`() {
+        assertEquals(37, Roulette.POCKET_COUNT)
+        assertEquals(37, Roulette.WHEEL_ORDER.size)
+        assertEquals((0..36).toSet(), Roulette.WHEEL_ORDER.toSet())
+    }
+
+    @Test
+    fun `zero is green, the 18 standard reds are red, the rest are black`() {
+        assertEquals(Roulette.Color.GREEN, Roulette.colorOf(0))
+        assertEquals(18, Roulette.RED_NUMBERS.size)
+        Roulette.RED_NUMBERS.forEach { n ->
+            assertEquals(Roulette.Color.RED, Roulette.colorOf(n), "$n should be red")
+        }
+        (1..36).filterNot { it in Roulette.RED_NUMBERS }.forEach { n ->
+            assertEquals(Roulette.Color.BLACK, Roulette.colorOf(n), "$n should be black")
+        }
+    }
+
+    @Test
+    fun `even-money bets cover exactly 18 pockets (zero loses every outside bet)`() {
+        val pockets = (0..36).toList()
+        listOf(
+            Roulette.Bet.RED, Roulette.Bet.BLACK,
+            Roulette.Bet.ODD, Roulette.Bet.EVEN,
+            Roulette.Bet.LOW, Roulette.Bet.HIGH,
+        ).forEach { bet ->
+            val winning = pockets.count { Roulette.wins(bet, null, it) }
+            assertEquals(18, winning, "$bet should win on exactly 18 pockets")
+            assertFalse(Roulette.wins(bet, null, 0), "$bet must lose on the green zero")
+        }
+    }
+
+    @Test
+    fun `dozen and column bets cover exactly 12 pockets (zero loses every outside bet)`() {
+        val pockets = (0..36).toList()
+        listOf(
+            Roulette.Bet.DOZEN_1, Roulette.Bet.DOZEN_2, Roulette.Bet.DOZEN_3,
+            Roulette.Bet.COLUMN_1, Roulette.Bet.COLUMN_2, Roulette.Bet.COLUMN_3,
+        ).forEach { bet ->
+            val winning = pockets.count { Roulette.wins(bet, null, it) }
+            assertEquals(12, winning, "$bet should win on exactly 12 pockets")
+            assertFalse(Roulette.wins(bet, null, 0), "$bet must lose on the green zero")
+        }
+    }
+
+    @Test
+    fun `dozens partition 1 through 36 with no overlap and no gaps`() {
+        (1..36).forEach { n ->
+            val hits = listOf(
+                Roulette.Bet.DOZEN_1,
+                Roulette.Bet.DOZEN_2,
+                Roulette.Bet.DOZEN_3,
+            ).count { Roulette.wins(it, null, n) }
+            assertEquals(1, hits, "$n must belong to exactly one dozen")
+        }
+    }
+
+    @Test
+    fun `columns partition 1 through 36 with no overlap and no gaps`() {
+        (1..36).forEach { n ->
+            val hits = listOf(
+                Roulette.Bet.COLUMN_1,
+                Roulette.Bet.COLUMN_2,
+                Roulette.Bet.COLUMN_3,
+            ).count { Roulette.wins(it, null, n) }
+            assertEquals(1, hits, "$n must belong to exactly one column")
+        }
+    }
+
+    @Test
+    fun `straight bet wins only on the matching pocket`() {
+        (0..36).forEach { picked ->
+            (0..36).forEach { landed ->
+                val won = Roulette.wins(Roulette.Bet.STRAIGHT, picked, landed)
+                assertEquals(picked == landed, won, "STRAIGHT($picked) on $landed")
+            }
+        }
+    }
+
+    @Test
+    fun `straight bet without a number always loses`() {
+        (0..36).forEach { landed ->
+            assertFalse(
+                Roulette.wins(Roulette.Bet.STRAIGHT, null, landed),
+                "STRAIGHT with null number must always lose"
+            )
+        }
+    }
+
+    @Test
+    fun `payout multipliers are odds + 1 so applyMultiplier nets the right credits`() {
+        // applyMultiplier computes net = (multiplier × stake) - stake.
+        // 1:1 → 2× → net = stake; 2:1 → 3× → net = 2×stake; 35:1 → 36× → net = 35×stake.
+        listOf(
+            Roulette.Bet.RED, Roulette.Bet.BLACK,
+            Roulette.Bet.ODD, Roulette.Bet.EVEN,
+            Roulette.Bet.LOW, Roulette.Bet.HIGH,
+        ).forEach { assertEquals(2L, it.multiplier, "$it should pay 1:1 (multiplier 2×)") }
+
+        listOf(
+            Roulette.Bet.DOZEN_1, Roulette.Bet.DOZEN_2, Roulette.Bet.DOZEN_3,
+            Roulette.Bet.COLUMN_1, Roulette.Bet.COLUMN_2, Roulette.Bet.COLUMN_3,
+        ).forEach { assertEquals(3L, it.multiplier, "$it should pay 2:1 (multiplier 3×)") }
+
+        assertEquals(36L, Roulette.Bet.STRAIGHT.multiplier, "STRAIGHT should pay 35:1 (multiplier 36×)")
+    }
+
+    @Test
+    fun `spin returns a pocket within range and a multiplier consistent with the bet predicate`() {
+        val rng = Random(2026)
+        repeat(1_000) {
+            val bet = Roulette.Bet.entries.random(rng)
+            val number = if (bet == Roulette.Bet.STRAIGHT) rng.nextInt(0, 37) else null
+            val spin = roulette.spin(bet, number, rng)
+            assertTrue(spin.landed in 0..36, "pocket out of range: ${spin.landed}")
+            assertEquals(bet, spin.bet)
+            assertEquals(number, spin.straightNumber)
+            assertEquals(Roulette.colorOf(spin.landed), spin.color)
+
+            val expectedWin = Roulette.wins(bet, number, spin.landed)
+            assertEquals(expectedWin, spin.isWin, "isWin must agree with wins() predicate")
+            assertEquals(if (expectedWin) bet.multiplier else 0L, spin.multiplier)
+        }
+    }
+
+    @Test
+    fun `RTP across every bet type lands at the European 36 over 37 within tolerance`() {
+        // Across n spins per bet type with a fixed stake, the total
+        // returned should converge to (36/37) × totalWagered. Bigger n
+        // for the high-variance straight bet keeps the band tight.
+        val rng = Random(2026)
+        val stake = 1_000L
+        val targets = mapOf(
+            Roulette.Bet.RED to 200_000,
+            Roulette.Bet.DOZEN_1 to 200_000,
+            Roulette.Bet.STRAIGHT to 500_000,
+        )
+        targets.forEach { (bet, n) ->
+            var wagered = 0L
+            var returned = 0L
+            repeat(n) {
+                val pick = if (bet == Roulette.Bet.STRAIGHT) rng.nextInt(0, 37) else null
+                val spin = roulette.spin(bet, pick, rng)
+                wagered += stake
+                returned += spin.multiplier * stake
+            }
+            val rtp = returned.toDouble() / wagered.toDouble()
+            assertTrue(rtp in 0.94..1.00, "RTP for $bet expected ~0.973 but saw $rtp")
+        }
+    }
+
+    @Test
+    fun `requiresNumber flag identifies the only bet type that needs an explicit pick`() {
+        Roulette.Bet.entries.forEach { bet ->
+            assertEquals(bet == Roulette.Bet.STRAIGHT, bet.requiresNumber, "$bet.requiresNumber")
+        }
+    }
+
+    @Test
+    fun `every bet display label is non-empty`() {
+        Roulette.Bet.entries.forEach {
+            assertNotNull(it.display)
+            assertTrue(it.display.isNotBlank())
+        }
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/RouletteCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/RouletteCommand.kt
@@ -1,0 +1,128 @@
+package bot.toby.command.commands.economy
+
+import core.command.CommandContext
+import database.dto.UserDto
+import database.economy.Roulette
+import database.service.RouletteService
+import database.service.RouletteService.SpinOutcome
+import net.dv8tion.jda.api.EmbedBuilder
+import net.dv8tion.jda.api.interactions.commands.OptionType
+import net.dv8tion.jda.api.interactions.commands.build.OptionData
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+/**
+ * `/roulette stake:<int> bet:<choice> [number:<0-36>]` — European single-
+ * zero roulette. Calls through to [RouletteService.spin], which is the
+ * same path the web `/casino/{guildId}/roulette` page uses, so the
+ * Discord and web surfaces can't drift on payout maths or balance
+ * debit/credit semantics.
+ */
+@Component
+class RouletteCommand @Autowired constructor(
+    private val rouletteService: RouletteService,
+) : EconomyCommand {
+
+    override val name: String = "roulette"
+    override val description: String =
+        "Spin a European single-zero roulette wheel. Stake bounds are per-guild " +
+            "(default ${Roulette.MIN_STAKE}-${Roulette.MAX_STAKE})."
+
+    companion object {
+        private const val OPT_STAKE = "stake"
+        private const val OPT_BET = "bet"
+        private const val OPT_NUMBER = "number"
+        private const val TITLE = "🎡 Roulette"
+    }
+
+    override val optionData: List<OptionData> = listOf(
+        OptionData(OptionType.STRING, OPT_BET, "What to bet on", true).apply {
+            Roulette.Bet.entries.forEach { addChoice(it.display, it.name) }
+        },
+        OptionData(OptionType.INTEGER, OPT_STAKE, "Credits to wager (per-guild bounds; service rejects out-of-range)", true)
+            .setMinValue(1L),
+        OptionData(OptionType.INTEGER, OPT_NUMBER, "Pocket 0-36 (only required for a STRAIGHT bet)", false)
+            .setMinValue(0L)
+            .setMaxValue(Roulette.MAX_NUMBER.toLong()),
+    )
+
+    override fun handle(ctx: CommandContext, requestingUserDto: UserDto, deleteDelay: Int) {
+        val event = ctx.event
+        event.deferReply().queue()
+
+        val guild = event.guild ?: run {
+            WagerCommandEmbeds.replyError(event, TITLE, "This command can only be used in a server.", deleteDelay); return
+        }
+        val bet = parseBet(event.getOption(OPT_BET)?.asString) ?: run {
+            WagerCommandEmbeds.replyError(event, TITLE, "Pick a bet from the list.", deleteDelay); return
+        }
+        val stake = event.getOption(OPT_STAKE)?.asLong ?: run {
+            WagerCommandEmbeds.replyError(event, TITLE, "You must specify a stake.", deleteDelay); return
+        }
+        val number = event.getOption(OPT_NUMBER)?.asLong?.toInt()
+        if (bet == Roulette.Bet.STRAIGHT && (number == null || number !in 0..Roulette.MAX_NUMBER)) {
+            WagerCommandEmbeds.replyError(
+                event, TITLE,
+                "A straight bet needs a `number` between 0 and ${Roulette.MAX_NUMBER}.",
+                deleteDelay,
+            ); return
+        }
+
+        val outcome = rouletteService.spin(
+            requestingUserDto.discordId, guild.idLong, stake, bet, number,
+        )
+        WagerCommandEmbeds.reply(event, embedFor(outcome), deleteDelay)
+    }
+
+    private fun parseBet(raw: String?): Roulette.Bet? =
+        raw?.let { runCatching { Roulette.Bet.valueOf(it) }.getOrNull() }
+
+    private fun embedFor(outcome: SpinOutcome) = when (outcome) {
+        is SpinOutcome.Win -> EmbedBuilder()
+            .setTitle("🎡 ${pocketLine(outcome.landed, outcome.color)} — ${outcome.bet.display}")
+            .setDescription(
+                "Called **${callLabel(outcome.bet, outcome.straightNumber)}**. " +
+                    "**+${outcome.net} credits** (${outcome.multiplier}× on a ${outcome.stake} stake)."
+            )
+            .addField("New balance", "${outcome.newBalance} credits", true)
+            .setColor(WagerCommandColors.WIN)
+            .build()
+
+        is SpinOutcome.Lose -> EmbedBuilder()
+            .setTitle("🎡 ${pocketLine(outcome.landed, outcome.color)} — ${outcome.bet.display}")
+            .setDescription(
+                "Called **${callLabel(outcome.bet, outcome.straightNumber)}**. " +
+                    "Lost **${outcome.stake} credits**."
+            )
+            .addField("New balance", "${outcome.newBalance} credits", true)
+            .setColor(WagerCommandColors.LOSE)
+            .build()
+
+        is SpinOutcome.InvalidNumber -> WagerCommandEmbeds.errorEmbed(
+            TITLE, "A straight bet needs a `number` between ${outcome.min} and ${outcome.max}."
+        )
+
+        is SpinOutcome.InsufficientCredits -> WagerCommandEmbeds.failureEmbed(
+            TITLE, WagerCommandFailure.InsufficientCredits(outcome.stake, outcome.have)
+        )
+        is SpinOutcome.InsufficientCoinsForTopUp -> WagerCommandEmbeds.failureEmbed(
+            TITLE, WagerCommandFailure.InsufficientCoinsForTopUp(outcome.needed, outcome.have)
+        )
+        is SpinOutcome.InvalidStake -> WagerCommandEmbeds.failureEmbed(
+            TITLE, WagerCommandFailure.InvalidStake(outcome.min, outcome.max)
+        )
+        SpinOutcome.UnknownUser -> WagerCommandEmbeds.failureEmbed(TITLE, WagerCommandFailure.UnknownUser)
+    }
+
+    private fun pocketLine(pocket: Int, color: Roulette.Color): String =
+        "${colorEmoji(color)} $pocket"
+
+    private fun colorEmoji(color: Roulette.Color): String = when (color) {
+        Roulette.Color.RED -> "🟥"
+        Roulette.Color.BLACK -> "⬛"
+        Roulette.Color.GREEN -> "🟩"
+    }
+
+    private fun callLabel(bet: Roulette.Bet, number: Int?): String =
+        if (bet == Roulette.Bet.STRAIGHT && number != null) "${bet.display} ($number)" else bet.display
+}

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/moderation/SetConfigCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/moderation/SetConfigCommand.kt
@@ -141,6 +141,10 @@ class SetConfigCommand @Autowired constructor(
                     config = ConfigDto.Configurations.SCRATCH_MIN_STAKE, gameLabel = "Scratch", label = "minimum stake", min = 1L, unit = "credits")
                 ConfigDto.Configurations.SCRATCH_MAX_STAKE -> setMinimumLongConfig(event, optionMapping, deleteDelay,
                     config = ConfigDto.Configurations.SCRATCH_MAX_STAKE, gameLabel = "Scratch", label = "maximum stake", min = 1L, unit = "credits")
+                ConfigDto.Configurations.ROULETTE_MIN_STAKE -> setMinimumLongConfig(event, optionMapping, deleteDelay,
+                    config = ConfigDto.Configurations.ROULETTE_MIN_STAKE, gameLabel = "Roulette", label = "minimum stake", min = 1L, unit = "credits")
+                ConfigDto.Configurations.ROULETTE_MAX_STAKE -> setMinimumLongConfig(event, optionMapping, deleteDelay,
+                    config = ConfigDto.Configurations.ROULETTE_MAX_STAKE, gameLabel = "Roulette", label = "maximum stake", min = 1L, unit = "credits")
                 ConfigDto.Configurations.HOLDEM_MIN_STAKE -> setMinimumLongConfig(event, optionMapping, deleteDelay,
                     config = ConfigDto.Configurations.HOLDEM_MIN_STAKE, gameLabel = "Casino Hold'em", label = "minimum stake", min = 1L, unit = "credits")
                 ConfigDto.Configurations.HOLDEM_MAX_STAKE -> setMinimumLongConfig(event, optionMapping, deleteDelay,

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/economy/RouletteCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/economy/RouletteCommandTest.kt
@@ -1,0 +1,199 @@
+package bot.toby.command.commands.economy
+
+import bot.toby.command.CommandTest
+import bot.toby.command.CommandTest.Companion.event
+import bot.toby.command.CommandTest.Companion.guild
+import bot.toby.command.DefaultCommandContext
+import database.dto.UserDto
+import database.economy.Roulette
+import database.service.RouletteService
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import net.dv8tion.jda.api.interactions.commands.OptionMapping
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class RouletteCommandTest : CommandTest {
+    private lateinit var rouletteService: RouletteService
+    private lateinit var command: RouletteCommand
+
+    private val discordId = 1L
+    private val guildId = 42L
+
+    @BeforeEach
+    fun setUp() {
+        setUpCommonMocks()
+        rouletteService = mockk(relaxed = true)
+        command = RouletteCommand(rouletteService)
+        every { guild.idLong } returns guildId
+    }
+
+    @AfterEach
+    fun tearDown() {
+        tearDownCommonMocks()
+        clearAllMocks()
+    }
+
+    private fun strOpt(value: String): OptionMapping {
+        val o = mockk<OptionMapping>(relaxed = true)
+        every { o.asString } returns value
+        return o
+    }
+
+    private fun intOpt(value: Long): OptionMapping {
+        val o = mockk<OptionMapping>(relaxed = true)
+        every { o.asLong } returns value
+        return o
+    }
+
+    @Test
+    fun `delegates to RouletteService with parsed bet and stake (outside bet)`() {
+        val user = UserDto(discordId = discordId, guildId = guildId)
+        every { event.getOption("bet") } returns strOpt("RED")
+        every { event.getOption("stake") } returns intOpt(50L)
+        every { event.getOption("number") } returns null
+        every { rouletteService.spin(discordId, guildId, 50L, Roulette.Bet.RED, null) } returns
+            RouletteService.SpinOutcome.Lose(
+                stake = 50L,
+                bet = Roulette.Bet.RED,
+                landed = 0,
+                color = Roulette.Color.GREEN,
+                straightNumber = null,
+                newBalance = 950L,
+            )
+
+        command.handle(DefaultCommandContext(event), user, 5)
+
+        verify(exactly = 1) {
+            rouletteService.spin(discordId, guildId, 50L, Roulette.Bet.RED, null)
+        }
+    }
+
+    @Test
+    fun `delegates to RouletteService with the picked number on a STRAIGHT bet`() {
+        val user = UserDto(discordId = discordId, guildId = guildId)
+        every { event.getOption("bet") } returns strOpt("STRAIGHT")
+        every { event.getOption("stake") } returns intOpt(20L)
+        every { event.getOption("number") } returns intOpt(17L)
+        every { rouletteService.spin(discordId, guildId, 20L, Roulette.Bet.STRAIGHT, 17) } returns
+            RouletteService.SpinOutcome.Win(
+                stake = 20L,
+                bet = Roulette.Bet.STRAIGHT,
+                landed = 17,
+                color = Roulette.Color.BLACK,
+                straightNumber = 17,
+                multiplier = 36L,
+                payout = 720L,
+                net = 700L,
+                newBalance = 1_700L,
+            )
+
+        command.handle(DefaultCommandContext(event), user, 5)
+
+        verify(exactly = 1) {
+            rouletteService.spin(discordId, guildId, 20L, Roulette.Bet.STRAIGHT, 17)
+        }
+    }
+
+    @Test
+    fun `STRAIGHT without a number short-circuits without calling the service`() {
+        val user = UserDto(discordId = discordId, guildId = guildId)
+        every { event.getOption("bet") } returns strOpt("STRAIGHT")
+        every { event.getOption("stake") } returns intOpt(20L)
+        every { event.getOption("number") } returns null
+
+        command.handle(DefaultCommandContext(event), user, 5)
+
+        verify(exactly = 0) { rouletteService.spin(any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `STRAIGHT with an out-of-range number short-circuits`() {
+        val user = UserDto(discordId = discordId, guildId = guildId)
+        every { event.getOption("bet") } returns strOpt("STRAIGHT")
+        every { event.getOption("stake") } returns intOpt(20L)
+        every { event.getOption("number") } returns intOpt(99L)
+
+        command.handle(DefaultCommandContext(event), user, 5)
+
+        verify(exactly = 0) { rouletteService.spin(any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `replies with embed on each outcome variant`() {
+        val user = UserDto(discordId = discordId, guildId = guildId)
+        every { event.getOption("bet") } returns strOpt("RED")
+        every { event.getOption("stake") } returns intOpt(100L)
+        every { event.getOption("number") } returns null
+
+        val outcomes = listOf(
+            RouletteService.SpinOutcome.Win(
+                stake = 100L,
+                bet = Roulette.Bet.RED,
+                landed = 7,
+                color = Roulette.Color.RED,
+                straightNumber = null,
+                multiplier = 2L,
+                payout = 200L,
+                net = 100L,
+                newBalance = 1_100L,
+            ),
+            RouletteService.SpinOutcome.Lose(
+                stake = 100L,
+                bet = Roulette.Bet.RED,
+                landed = 0,
+                color = Roulette.Color.GREEN,
+                straightNumber = null,
+                newBalance = 900L,
+            ),
+            RouletteService.SpinOutcome.InsufficientCredits(stake = 100L, have = 50L),
+            RouletteService.SpinOutcome.InvalidStake(min = 10L, max = 500L),
+            RouletteService.SpinOutcome.InvalidNumber(min = 0, max = 36),
+            RouletteService.SpinOutcome.UnknownUser,
+        )
+        outcomes.forEach { outcome ->
+            every { rouletteService.spin(any(), any(), any(), any(), any()) } returns outcome
+            command.handle(DefaultCommandContext(event), user, 5)
+        }
+
+        verify(atLeast = outcomes.size) {
+            event.hook.sendMessageEmbeds(any<net.dv8tion.jda.api.entities.MessageEmbed>())
+        }
+    }
+
+    @Test
+    fun `missing bet option short-circuits without calling the service`() {
+        val user = UserDto(discordId = discordId, guildId = guildId)
+        every { event.getOption("bet") } returns null
+        every { event.getOption("stake") } returns intOpt(50L)
+
+        command.handle(DefaultCommandContext(event), user, 5)
+
+        verify(exactly = 0) { rouletteService.spin(any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `unknown bet string short-circuits without calling the service`() {
+        val user = UserDto(discordId = discordId, guildId = guildId)
+        every { event.getOption("bet") } returns strOpt("PURPLE")
+        every { event.getOption("stake") } returns intOpt(50L)
+
+        command.handle(DefaultCommandContext(event), user, 5)
+
+        verify(exactly = 0) { rouletteService.spin(any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `missing stake option short-circuits without calling the service`() {
+        val user = UserDto(discordId = discordId, guildId = guildId)
+        every { event.getOption("bet") } returns strOpt("RED")
+        every { event.getOption("stake") } returns null
+
+        command.handle(DefaultCommandContext(event), user, 5)
+
+        verify(exactly = 0) { rouletteService.spin(any(), any(), any(), any(), any()) }
+    }
+}

--- a/web/src/main/kotlin/web/casino/StakeBounds.kt
+++ b/web/src/main/kotlin/web/casino/StakeBounds.kt
@@ -6,6 +6,7 @@ import database.economy.Coinflip
 import database.economy.Dice
 import database.economy.Highlow
 import database.economy.Keno
+import database.economy.Roulette
 import database.economy.ScratchCard
 import database.economy.SlotMachine
 import database.blackjack.Blackjack
@@ -83,6 +84,14 @@ class StakeBounds(
         ConfigDto.Configurations.SCRATCH_MAX_STAKE,
         ScratchCard.MIN_STAKE,
         ScratchCard.MAX_STAKE,
+    )
+
+    fun roulette(guildId: Long): Pair<Long, Long> = read(
+        guildId,
+        ConfigDto.Configurations.ROULETTE_MIN_STAKE,
+        ConfigDto.Configurations.ROULETTE_MAX_STAKE,
+        Roulette.MIN_STAKE,
+        Roulette.MAX_STAKE,
     )
 
     fun blackjackSolo(guildId: Long): Pair<Long, Long> = read(

--- a/web/src/main/kotlin/web/controller/RouletteController.kt
+++ b/web/src/main/kotlin/web/controller/RouletteController.kt
@@ -1,0 +1,187 @@
+package web.controller
+
+import common.casino.CasinoCommonFailure
+import database.economy.Roulette
+import database.service.RouletteService
+import database.service.RouletteService.SpinOutcome
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.security.oauth2.core.user.OAuth2User
+import org.springframework.stereotype.Controller
+import org.springframework.ui.Model
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseBody
+import org.springframework.web.servlet.mvc.support.RedirectAttributes
+import web.casino.CasinoOutcomeMapper
+import web.casino.CasinoPageContext
+import web.casino.CasinoResponseLike
+import web.casino.StakeBounds
+import web.casino.renderMinigamePage
+import web.service.EconomyWebService
+import web.util.WebGuildAccess
+import web.util.positiveOrNull
+
+/**
+ * Web surface for the `/roulette` minigame. GET renders the wheel + bet
+ * grid with the user's current credit balance and the payout reference;
+ * POST runs the spin via [RouletteService.spin] and returns JSON for the
+ * JS animation to settle the ball onto.
+ *
+ * Both surfaces share [RouletteService] so Discord and web can't drift
+ * on payout maths, debit/credit semantics, or stake bounds.
+ */
+@Controller
+@RequestMapping("/casino/{guildId}/roulette")
+class RouletteController(
+    private val rouletteService: RouletteService,
+    private val economyWebService: EconomyWebService,
+    private val pageContext: CasinoPageContext,
+    private val stakeBounds: StakeBounds,
+) {
+
+    private val errors = CasinoOutcomeMapper { msg -> RouletteSpinResponse(false, msg) }
+
+    @GetMapping
+    fun page(
+        @PathVariable guildId: Long,
+        @AuthenticationPrincipal user: OAuth2User,
+        model: Model,
+        ra: RedirectAttributes,
+    ): String = pageContext.renderMinigamePage(
+        user, guildId, economyWebService, model, ra,
+        template = "roulette", lobbyPath = "/casino/guilds",
+    ) {
+        val (minStake, maxStake) = stakeBounds.roulette(guildId)
+        addAttribute("minStake", minStake)
+        addAttribute("maxStake", maxStake)
+        addAttribute("payoutTable", payoutRows())
+        addAttribute("redNumbers", Roulette.RED_NUMBERS)
+        addAttribute("wheelOrder", Roulette.WHEEL_ORDER)
+        addAttribute("maxPocket", Roulette.MAX_NUMBER)
+        addAttribute("bets", betRows())
+    }
+
+    @PostMapping("/spin")
+    @ResponseBody
+    fun spin(
+        @PathVariable guildId: Long,
+        @RequestBody request: RouletteSpinRequest,
+        @AuthenticationPrincipal user: OAuth2User,
+    ): ResponseEntity<RouletteSpinResponse> = WebGuildAccess.requireMemberForJson(
+        user, guildId, economyWebService, errorBuilder = errors.errorBuilder,
+    ) { discordId ->
+        val bet = parseBet(request.bet)
+            ?: return@requireMemberForJson errors.badRequest("Pick a bet from the list.")
+
+        val outcome = rouletteService.spin(
+            discordId, guildId, request.stake, bet, request.number, request.autoTopUp,
+        )
+        when (outcome) {
+            is SpinOutcome.Win -> ResponseEntity.ok(
+                RouletteSpinResponse(
+                    ok = true,
+                    bet = outcome.bet.name,
+                    betLabel = outcome.bet.display,
+                    landed = outcome.landed,
+                    color = outcome.color.name,
+                    straightNumber = outcome.straightNumber,
+                    multiplier = outcome.multiplier,
+                    payout = outcome.payout,
+                    net = outcome.net,
+                    newBalance = outcome.newBalance,
+                    win = true,
+                    jackpotPayout = outcome.jackpotPayout.positiveOrNull(),
+                    soldTobyCoins = outcome.soldTobyCoins.positiveOrNull(),
+                    newPrice = outcome.newPrice,
+                )
+            )
+
+            is SpinOutcome.Lose -> ResponseEntity.ok(
+                RouletteSpinResponse(
+                    ok = true,
+                    bet = outcome.bet.name,
+                    betLabel = outcome.bet.display,
+                    landed = outcome.landed,
+                    color = outcome.color.name,
+                    straightNumber = outcome.straightNumber,
+                    multiplier = 0L,
+                    payout = 0L,
+                    net = -outcome.stake,
+                    newBalance = outcome.newBalance,
+                    win = false,
+                    soldTobyCoins = outcome.soldTobyCoins.positiveOrNull(),
+                    newPrice = outcome.newPrice,
+                    lossTribute = outcome.lossTribute.positiveOrNull(),
+                )
+            )
+
+            is SpinOutcome.InvalidNumber -> errors.badRequest(
+                "Pick a number between ${outcome.min} and ${outcome.max} for a straight bet."
+            )
+
+            is CasinoCommonFailure -> errors.mapCommonFailure(outcome)
+        }
+    }
+
+    private fun parseBet(raw: String?): Roulette.Bet? =
+        raw?.let { runCatching { Roulette.Bet.valueOf(it) }.getOrNull() }
+
+    // Render-side projection of the bet menu. Exposed via Model so the
+    // template doesn't have to re-derive payout labels — single source
+    // of truth lives in Roulette.Bet.
+    private fun betRows(): List<RouletteBetRow> = Roulette.Bet.entries.map { bet ->
+        RouletteBetRow(
+            id = bet.name,
+            label = bet.display,
+            multiplier = bet.multiplier,
+            odds = "${bet.multiplier - 1}:1",
+            requiresNumber = bet.requiresNumber,
+        )
+    }
+
+    private fun payoutRows(): List<RoulettePayoutRow> = listOf(
+        RoulettePayoutRow("Red / Black / Odd / Even / Low / High", "1:1"),
+        RoulettePayoutRow("Dozen / Column", "2:1"),
+        RoulettePayoutRow("Straight (single number)", "35:1"),
+    )
+}
+
+data class RouletteSpinRequest(
+    val stake: Long = 0,
+    val bet: String? = null,
+    val number: Int? = null,
+    val autoTopUp: Boolean = false,
+)
+
+data class RouletteSpinResponse(
+    override val ok: Boolean,
+    override val error: String? = null,
+    val bet: String? = null,
+    val betLabel: String? = null,
+    val landed: Int? = null,
+    val color: String? = null,
+    val straightNumber: Int? = null,
+    val multiplier: Long? = null,
+    val payout: Long? = null,
+    val net: Long? = null,
+    val newBalance: Long? = null,
+    val win: Boolean? = null,
+    val jackpotPayout: Long? = null,
+    val soldTobyCoins: Long? = null,
+    val newPrice: Double? = null,
+    val lossTribute: Long? = null,
+) : CasinoResponseLike
+
+data class RouletteBetRow(
+    val id: String,
+    val label: String,
+    val multiplier: Long,
+    val odds: String,
+    val requiresNumber: Boolean,
+)
+
+data class RoulettePayoutRow(val label: String, val payout: String)

--- a/web/src/main/kotlin/web/service/ModerationWebService.kt
+++ b/web/src/main/kotlin/web/service/ModerationWebService.kt
@@ -423,6 +423,7 @@ class ModerationWebService(
             ConfigDto.Configurations.BACCARAT_MIN_STAKE,
             ConfigDto.Configurations.KENO_MIN_STAKE,
             ConfigDto.Configurations.SCRATCH_MIN_STAKE,
+            ConfigDto.Configurations.ROULETTE_MIN_STAKE,
             ConfigDto.Configurations.HOLDEM_MIN_STAKE,
             ConfigDto.Configurations.DUEL_MIN_STAKE,
             ConfigDto.Configurations.JACKPOT_STAKE_ANCHOR -> {
@@ -442,6 +443,7 @@ class ModerationWebService(
             ConfigDto.Configurations.BACCARAT_MAX_STAKE,
             ConfigDto.Configurations.KENO_MAX_STAKE,
             ConfigDto.Configurations.SCRATCH_MAX_STAKE,
+            ConfigDto.Configurations.ROULETTE_MAX_STAKE,
             ConfigDto.Configurations.HOLDEM_MAX_STAKE,
             ConfigDto.Configurations.DUEL_MAX_STAKE -> {
                 val n = rawValue.trim().toLongOrNull()

--- a/web/src/main/resources/static/css/leaderboard.css
+++ b/web/src/main/resources/static/css/leaderboard.css
@@ -33,16 +33,47 @@
 }
 .lb-guild-games {
     display: flex;
-    gap: var(--space-2);
-    flex-wrap: wrap;
+    flex-direction: column;
+    gap: var(--space-3);
     margin-top: auto;
 }
-.lb-guild-games .btn-secondary {
+/* When the casino-guilds page renders ungrouped tiles (any older template
+   that hasn't been migrated to the Quick-play / Table-games split), keep
+   the legacy flex-row behaviour intact via the bare-button selector. */
+.lb-guild-games > .btn-secondary {
     flex: 1;
+}
+.lb-games-group {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+}
+.lb-games-group-title {
+    margin: 0;
+    font-size: 0.7rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--text-muted);
+}
+.lb-games-row {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+    gap: var(--space-2);
+}
+.lb-guild-games .btn-secondary {
     text-align: center;
     text-decoration: none;
     padding: 8px 12px;
     font-size: 0.9rem;
+    /* Even widths regardless of glyph width so emoji + label align across
+       a row whether the label is "Slots" (5 chars) or "Casino Hold'em"
+       (14 chars). The grid column gives the cell its width; the link
+       fills it. */
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 4px;
 }
 .lb-guild-card-header {
     display: flex;

--- a/web/src/main/resources/static/css/roulette.css
+++ b/web/src/main/resources/static/css/roulette.css
@@ -1,0 +1,303 @@
+@import url("./casino-table.css");
+
+.roulette-header {
+    margin-bottom: var(--space-5);
+}
+.roulette-header h1 { margin: var(--space-2) 0; }
+
+/* casino-felt owns the green-felt frame; this class only owns layout. */
+.roulette-table {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--space-4);
+    /* Anchor the chip-flourish overlay to the felt so wins flash here. */
+    position: relative;
+}
+
+/* ─── Wheel stage ──────────────────────────────────────────────────────── */
+
+.roulette-wheel-stage {
+    position: relative;
+    width: 280px;
+    height: 280px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.roulette-wheel {
+    width: 100%;
+    height: 100%;
+    /* JS sets `transform: rotate(...deg)` directly during spin / settle. */
+    transform-origin: 50% 50%;
+    will-change: transform;
+    /* Ring of gold around the rim — same token every other casino card uses. */
+    filter: drop-shadow(0 0 6px rgba(0, 0, 0, 0.45));
+}
+
+.roulette-wheel.settling {
+    transition: transform 1.6s cubic-bezier(0.18, 0.78, 0.25, 1);
+}
+
+.roulette-wheel-pocket-red    { fill: #c0392b; }
+.roulette-wheel-pocket-black  { fill: #1a1a1a; }
+.roulette-wheel-pocket-green  { fill: #1f7a3a; }
+.roulette-wheel-pocket-stroke { stroke: rgba(255, 215, 0, 0.55); stroke-width: 0.4; }
+
+.roulette-wheel-rim {
+    fill: none;
+    stroke: var(--casino-gold);
+    stroke-width: 1.6;
+}
+.roulette-wheel-hub {
+    fill: #15131a;
+    stroke: var(--casino-gold);
+    stroke-width: 0.8;
+}
+.roulette-wheel-label {
+    fill: #fff;
+    font-family: inherit;
+    font-size: 6.5px;
+    font-weight: 600;
+    text-anchor: middle;
+    dominant-baseline: central;
+    pointer-events: none;
+}
+
+/* The pointer is a fixed gold triangle at the top of the stage that the
+   ball "drops past" when the wheel settles. Visually marks the winning
+   pocket without us needing to animate a separate ball element. */
+.roulette-pointer {
+    position: absolute;
+    top: -10px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 0;
+    height: 0;
+    border-left: 10px solid transparent;
+    border-right: 10px solid transparent;
+    border-top: 16px solid var(--casino-gold);
+    filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.5));
+    z-index: 2;
+}
+
+/* "Last" pill in the centre showing the most recent landed pocket. JS
+   updates the text + colour-tint after each settle. */
+.roulette-landed {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2px;
+    pointer-events: none;
+    color: #fff;
+    font-variant-numeric: tabular-nums;
+}
+.roulette-landed-label {
+    font-size: 0.65rem;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--text-muted);
+}
+.roulette-landed-pocket {
+    font-size: 1.6rem;
+    font-weight: 700;
+    min-width: 1.6rem;
+    text-align: center;
+    padding: 2px 8px;
+    border-radius: 999px;
+    background: rgba(0, 0, 0, 0.6);
+    border: 1px solid rgba(255, 215, 0, 0.4);
+}
+.roulette-landed-pocket.color-red    { background: #c0392b; border-color: #f1c40f; }
+.roulette-landed-pocket.color-black  { background: #1a1a1a; border-color: #f1c40f; }
+.roulette-landed-pocket.color-green  { background: #1f7a3a; border-color: #f1c40f; }
+
+@media (prefers-reduced-motion: reduce) {
+    /* No spinning wheel for users who asked for fewer effects — JS
+       short-circuits the spin too, so we just keep the static render. */
+    .roulette-wheel.settling { transition: none; }
+}
+
+/* ─── Bet form ─────────────────────────────────────────────────────────── */
+
+.roulette-bet {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+    width: 100%;
+    max-width: 560px;
+}
+
+.roulette-bet-fieldset {
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: var(--space-3);
+    background: rgba(0, 0, 0, 0.18);
+}
+.roulette-bet-fieldset legend {
+    color: var(--text-muted);
+    text-transform: uppercase;
+    font-size: 0.75rem;
+    letter-spacing: 0.08em;
+    padding: 0 var(--space-2);
+}
+
+.roulette-bet-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    gap: var(--space-2);
+}
+
+.roulette-chip {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 2px;
+    padding: 10px 12px;
+    background: #0f1830;
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    color: #fff;
+    font-size: 0.95rem;
+    font-weight: 500;
+    cursor: pointer;
+    user-select: none;
+    transition: transform 0.1s, border-color 0.2s, box-shadow 0.2s, background 0.2s;
+}
+.roulette-chip:hover { transform: translateY(-1px); border-color: var(--casino-gold); }
+.roulette-chip:focus-visible { outline: 2px solid var(--casino-gold); outline-offset: 2px; }
+.roulette-chip[aria-checked="true"] {
+    background: var(--casino-gold);
+    border-color: var(--casino-gold);
+    color: #1a1a1a;
+    box-shadow: var(--casino-active-glow);
+}
+.roulette-chip-label { font-size: 0.95rem; }
+.roulette-chip-odds {
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-muted);
+}
+.roulette-chip[aria-checked="true"] .roulette-chip-odds { color: rgba(0, 0, 0, 0.7); }
+
+.roulette-straight-picker {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    padding: var(--space-2) var(--space-3);
+    border: 1px dashed var(--casino-gold);
+    border-radius: 10px;
+    background: rgba(241, 196, 15, 0.08);
+}
+.roulette-straight-picker label {
+    color: var(--text-muted);
+    text-transform: uppercase;
+    font-size: 0.75rem;
+    letter-spacing: 0.08em;
+}
+.roulette-straight-picker input[type="number"] {
+    width: 80px;
+    padding: 8px 10px;
+    background: #0f1830;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    color: #fff;
+    font-size: 1rem;
+    font-variant-numeric: tabular-nums;
+}
+
+.roulette-stake-row {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    flex-wrap: wrap;
+    justify-content: center;
+}
+.roulette-stake-row label {
+    font-size: 0.85rem;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+.roulette-stake-row input[type="number"] {
+    width: 110px;
+    padding: 8px 10px;
+    background: #0f1830;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    color: #fff;
+    font-size: 1rem;
+    font-variant-numeric: tabular-nums;
+}
+
+.roulette-balance {
+    color: var(--text-muted);
+    font-variant-numeric: tabular-nums;
+}
+.roulette-balance strong { color: #fff; }
+
+.roulette-result {
+    min-height: 1.5em;
+    font-size: 1.05rem;
+    font-variant-numeric: tabular-nums;
+    text-align: center;
+}
+.roulette-result-win  { color: #57F287; }
+.roulette-result-lose { color: #a0a0b0; }
+
+/* ─── Payouts table ───────────────────────────────────────────────────── */
+
+.roulette-payouts {
+    margin-top: var(--space-5);
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: var(--space-4);
+}
+.roulette-payouts h2 {
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--text-muted);
+    margin-bottom: var(--space-3);
+}
+.roulette-payouts table {
+    width: 100%;
+    border-collapse: collapse;
+    font-variant-numeric: tabular-nums;
+}
+.roulette-payouts th,
+.roulette-payouts td {
+    text-align: left;
+    padding: 8px 4px;
+    border-bottom: 1px solid var(--border);
+    font-size: 0.95rem;
+}
+.roulette-payouts th {
+    color: var(--text-muted);
+    font-weight: 500;
+    text-transform: uppercase;
+    font-size: 0.75rem;
+    letter-spacing: 0.05em;
+}
+.roulette-payouts tr:last-child td { border-bottom: none; }
+
+@media (max-width: 600px) {
+    .roulette-wheel-stage { width: 240px; height: 240px; }
+    .roulette-stake-row { flex-direction: column; align-items: stretch; }
+    .roulette-stake-row input[type="number"] { width: 100%; }
+    .roulette-stake-row button { min-height: 2.75rem; }
+    .roulette-bet-grid { grid-template-columns: repeat(2, 1fr); }
+}
+
+@media (max-width: 380px) {
+    .roulette-wheel-stage { width: 200px; height: 200px; }
+    .roulette-payouts { font-size: 0.85rem; }
+}

--- a/web/src/main/resources/static/js/casino-sounds.js
+++ b/web/src/main/resources/static/js/casino-sounds.js
@@ -4,7 +4,7 @@
 // alongside `casino-render.js`.
 //
 // API:
-//   CasinoSounds.play('deal'|'chip'|'flip'|'win'|'lose'|'click')
+//   CasinoSounds.play('deal'|'chip'|'flip'|'win'|'lose'|'click'|'tick'|'ball')
 //   CasinoSounds.toggle()           — flip enabled/disabled, persisted
 //   CasinoSounds.isEnabled()        — current pref (default: enabled)
 //   CasinoSounds.installToggle(parentEl)  — drop a 🔊/🔇 button somewhere
@@ -114,6 +114,15 @@
         // Lose = quick descending dip. Kept short and not too dour.
         lose: function () {
             blip({ freq: function (t) { return 220 - 80 * t; }, dur: 0.30, kind: "sawtooth", peak: 0.10 });
+        },
+        // Roulette wheel tick — the rapid, high-frequency click of the
+        // ball passing a fret. Very short and quiet because it fires
+        // many times per spin.
+        tick: function () { blip({ freq: 1500, dur: 0.018, kind: "square", peak: 0.05 }); },
+        // Roulette ball settling into a pocket — a soft descending
+        // triangle blip ("plonk") that lands once per spin.
+        ball: function () {
+            blip({ freq: function (t) { return 320 - 160 * t; }, dur: 0.18, kind: "triangle", peak: 0.12 });
         },
     };
 

--- a/web/src/main/resources/static/js/roulette.js
+++ b/web/src/main/resources/static/js/roulette.js
@@ -1,0 +1,383 @@
+// Pure-DOM render for a /spin response. Hoisted out of the IIFE so a
+// future jest test can drive it without booting the whole page (mirrors
+// renderSlotsResult). The IIFE below calls it with the live result element.
+function renderRouletteResult(resultEl, body, flashTargetEl) {
+    if (typeof window !== 'undefined' && window.TobyCasinoResult) {
+        var betLabel = body.betLabel || body.bet || 'bet';
+        var pocketLabel = '#' + body.landed +
+            (body.color ? ' ' + body.color.toLowerCase() : '');
+        window.TobyCasinoResult.render({
+            resultEl: resultEl,
+            body: body,
+            classPrefix: 'roulette',
+            winLineHtml:
+                '<strong>+' + body.net + ' credits</strong> &middot; ' +
+                body.multiplier + '× on ' + betLabel + ' (landed ' + pocketLabel + ')',
+            loseLineHtml:
+                'Lost <strong>' + Math.abs(body.net) + ' credits</strong> &middot; ' +
+                betLabel + ' (landed ' + pocketLabel + ')',
+        });
+    }
+    if (typeof window === 'undefined' || !body) return;
+    if (window.CasinoRender) {
+        var payoutEstimate = (body.jackpotPayout > 0 ? body.jackpotPayout : body.net) || 0;
+        var chipCount = Math.min(7, Math.max(3, Math.ceil(payoutEstimate / 100)));
+        window.CasinoRender.flashWinPayout(flashTargetEl, body, chipCount);
+    }
+}
+
+(function () {
+    'use strict';
+
+    var els = window.TobyCasinoMinigameDom &&
+        window.TobyCasinoMinigameDom.standardElements('roulette', 'spin');
+    if (!els) return;
+
+    var wheel = document.getElementById('roulette-wheel');
+    var landedEl = document.getElementById('roulette-landed-pocket');
+    var fieldset = document.getElementById('roulette-bet-fieldset');
+    var straightPicker = document.getElementById('roulette-straight-picker');
+    var straightInput = document.getElementById('roulette-straight');
+    var tableEl = document.querySelector('.roulette-table');
+
+    if (!els.form || !els.primaryBtn || !els.stakeInput || !wheel || !fieldset) return;
+
+    var SETTLE_MS = 1600;          // wheel deceleration duration
+    var SPIN_DPS = 1080;           // degrees per second during the constant-speed spin
+    var ANIMATION_FRAME_MS = 16;   // ~60fps
+    var REDUCED_MOTION = (function () {
+        try {
+            return window.matchMedia &&
+                window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+        } catch (_) { return false; }
+    })();
+
+    // Wheel order parsed from the data attribute the controller serialises.
+    // Falls back to the standard European order if the attribute is missing
+    // (defensive — a bad parse shouldn't break the page).
+    var wheelOrder = parseWheelOrder(els.main.dataset.wheelOrder) ||
+        [0, 32, 15, 19, 4, 21, 2, 25, 17, 34, 6, 27, 13, 36, 11, 30, 8, 23,
+         10, 5, 24, 16, 33, 1, 20, 14, 31, 9, 22, 18, 29, 7, 28, 12, 35, 3, 26];
+    var POCKETS = wheelOrder.length;
+    var SLICE_DEG = 360 / POCKETS;
+    // Standard European red pockets — matches Roulette.RED_NUMBERS server-
+    // side. Used for colouring SVG slices and the centre "Last" pill.
+    var RED_NUMBERS = new Set([
+        1, 3, 5, 7, 9, 12, 14, 16, 18,
+        19, 21, 23, 25, 27, 30, 32, 34, 36,
+    ]);
+
+    renderWheel(wheel, wheelOrder);
+    bindBetChips();
+    bindStraightInput();
+
+    // ─── Spin animation state ────────────────────────────────────────────
+
+    var rafId = null;
+    var rotation = 0;
+    var spinStartedAt = 0;
+    var tickIntervalId = null;
+    var settleTimeoutIds = [];
+
+    function startSpinAnimation() {
+        // Strip any prior "settling" class so a fresh spin doesn't inherit
+        // the previous round's transition timing curve.
+        wheel.classList.remove('settling');
+        spinStartedAt = performance.now();
+        cancelAllTimers();
+
+        if (REDUCED_MOTION) {
+            // Skip the live animation; we'll snap straight to the settle
+            // angle in stopSpinAnimation. Keep a ticking sound for feedback.
+            if (window.CasinoSounds) window.CasinoSounds.play('deal');
+            return null;
+        }
+
+        function frame(now) {
+            var elapsed = (now - spinStartedAt) / 1000;
+            rotation = (rotation + SPIN_DPS * (ANIMATION_FRAME_MS / 1000)) % 360;
+            wheel.style.transform = 'rotate(' + rotation + 'deg)';
+            spinStartedAt = now;
+            rafId = requestAnimationFrame(frame);
+        }
+        rafId = requestAnimationFrame(frame);
+
+        // Constant-cadence ticks while the wheel is at full speed. Stops
+        // when the response lands and we hand off to the settle ticks.
+        if (window.CasinoSounds) {
+            window.CasinoSounds.play('deal');
+            tickIntervalId = setInterval(function () {
+                window.CasinoSounds.play('tick');
+            }, 70);
+        }
+        return rafId;
+    }
+
+    function stopSpinAnimation(_handle, body) {
+        if (rafId) { cancelAnimationFrame(rafId); rafId = null; }
+        if (tickIntervalId) { clearInterval(tickIntervalId); tickIntervalId = null; }
+
+        if (!body || typeof body.landed !== 'number') {
+            // Network / error path — leave the wheel where it is and skip
+            // the settle. The toast surfaces the error to the player.
+            return;
+        }
+
+        var idx = wheelOrder.indexOf(body.landed);
+        if (idx < 0) return;
+
+        // Pocket angle relative to the pointer at top. Wheel rotates
+        // clockwise, so target rotation needs the pocket index travelling
+        // counter-clockwise to align with the pointer.
+        var pocketAngle = -idx * SLICE_DEG;
+
+        // Build a target rotation > current rotation that ends at
+        // pocketAngle (mod 360), with a couple of extra full turns so the
+        // settle reads as "decelerating" rather than "snapping".
+        var current = rotation;
+        var extraTurns = REDUCED_MOTION ? 0 : 2;
+        var settleDeg = current + extraTurns * 360;
+        // Normalise current heading and add the offset to land on pocketAngle.
+        var currentHeading = ((current % 360) + 360) % 360;
+        var targetHeading = ((pocketAngle % 360) + 360) % 360;
+        var delta = targetHeading - currentHeading;
+        if (delta < 0) delta += 360;
+        settleDeg += delta;
+
+        rotation = settleDeg;
+        if (REDUCED_MOTION) {
+            // Snap to the final angle without a transition.
+            wheel.style.transform = 'rotate(' + settleDeg + 'deg)';
+            paintLanded(body);
+            playOutcomeCues(body);
+            return;
+        }
+
+        wheel.classList.add('settling');
+        // Force a layout flush so the browser registers the transition
+        // start point before we change the transform.
+        // eslint-disable-next-line no-unused-expressions
+        wheel.offsetHeight;
+        wheel.style.transform = 'rotate(' + settleDeg + 'deg)';
+
+        // Decelerating tick cues during the settle — quadratic falloff so
+        // the cadence audibly slows as the ball approaches its pocket.
+        scheduleSettleTicks(SETTLE_MS, 14);
+        // Finish: clean up the transition class, paint the last-landed
+        // pill, and hand off to the win/lose cue.
+        var finishId = setTimeout(function () {
+            wheel.classList.remove('settling');
+            paintLanded(body);
+            playOutcomeCues(body);
+        }, SETTLE_MS + 30);
+        settleTimeoutIds.push(finishId);
+    }
+
+    function scheduleSettleTicks(durationMs, count) {
+        for (var i = 1; i <= count; i++) {
+            var t = Math.round(durationMs * (1 - Math.pow(1 - i / count, 2.4)));
+            (function (delay) {
+                var id = setTimeout(function () {
+                    if (window.CasinoSounds) window.CasinoSounds.play('tick');
+                }, delay);
+                settleTimeoutIds.push(id);
+            })(t);
+        }
+    }
+
+    function playOutcomeCues(body) {
+        if (!window.CasinoSounds) return;
+        window.CasinoSounds.play('ball');
+        var win = body.net > 0;
+        // Slight delay so the ball-drop cue doesn't overlap the win/lose
+        // arpeggio — keeps the audio readable.
+        var id = setTimeout(function () {
+            window.CasinoSounds.play(win ? 'win' : 'lose');
+        }, 160);
+        settleTimeoutIds.push(id);
+    }
+
+    function paintLanded(body) {
+        if (!landedEl) return;
+        landedEl.textContent = body.landed;
+        landedEl.classList.remove('color-red', 'color-black', 'color-green');
+        var colorClass = 'color-' + (body.color ? body.color.toLowerCase() : 'green');
+        landedEl.classList.add(colorClass);
+    }
+
+    function cancelAllTimers() {
+        if (rafId) { cancelAnimationFrame(rafId); rafId = null; }
+        if (tickIntervalId) { clearInterval(tickIntervalId); tickIntervalId = null; }
+        settleTimeoutIds.forEach(function (id) { clearTimeout(id); });
+        settleTimeoutIds = [];
+    }
+
+    // ─── Bet selection ──────────────────────────────────────────────────
+
+    function bindBetChips() {
+        var chips = fieldset.querySelectorAll('.roulette-chip');
+        chips.forEach(function (chip) {
+            chip.addEventListener('click', function () { selectChip(chip); });
+            chip.addEventListener('keydown', function (e) {
+                if (e.key === ' ' || e.key === 'Enter') { e.preventDefault(); selectChip(chip); }
+            });
+        });
+        // Default to the first chip so a player can hit Spin immediately.
+        if (chips.length) selectChip(chips[0]);
+    }
+
+    function selectChip(chip) {
+        var chips = fieldset.querySelectorAll('.roulette-chip');
+        chips.forEach(function (c) { c.setAttribute('aria-checked', 'false'); });
+        chip.setAttribute('aria-checked', 'true');
+        var requiresNumber = chip.dataset.requiresNumber === 'true';
+        if (straightPicker) straightPicker.hidden = !requiresNumber;
+        if (window.CasinoSounds) window.CasinoSounds.play('click');
+    }
+
+    function bindStraightInput() {
+        if (!straightInput) return;
+        straightInput.addEventListener('input', function () {
+            // Clamp into [0, 36] without disrupting mid-typing — only
+            // after blur so a user can clear the field while editing.
+        });
+        straightInput.addEventListener('blur', function () {
+            var v = parseInt(straightInput.value, 10);
+            if (isNaN(v)) v = 0;
+            v = Math.max(0, Math.min(36, v));
+            straightInput.value = v;
+        });
+    }
+
+    function selectedBet() {
+        var checked = fieldset.querySelector('.roulette-chip[aria-checked="true"]');
+        return checked ? checked.dataset.bet : null;
+    }
+
+    function selectedNumber() {
+        if (!straightInput || straightPicker.hidden) return null;
+        var v = parseInt(straightInput.value, 10);
+        if (isNaN(v)) return null;
+        return Math.max(0, Math.min(36, v));
+    }
+
+    // ─── Game loop wiring ───────────────────────────────────────────────
+
+    window.TobyCasinoGame.init({
+        guildId: els.guildId,
+        endpoint: '/casino/' + els.guildId + '/roulette/spin',
+        form: els.form,
+        stakeInput: els.stakeInput,
+        primaryBtn: els.primaryBtn,
+        tobyBtn: els.tobyBtn,
+        balanceEl: els.balanceEl,
+        resultEl: els.resultEl,
+        tobyCoins: els.tobyCoins,
+        marketPrice: els.marketPrice,
+        minSettleMs: REDUCED_MOTION ? 200 : SETTLE_MS + 200,
+        failureMessage: 'Spin failed.',
+        startAnimation: startSpinAnimation,
+        stopAnimation: stopSpinAnimation,
+        renderResult: function (body) {
+            renderRouletteResult(els.resultEl, body, tableEl);
+        },
+        validate: function (state) {
+            var bet = selectedBet();
+            if (!bet) return 'Pick a bet.';
+            if (bet === 'STRAIGHT' && selectedNumber() == null) {
+                return 'Pick a number 0-36 for a straight bet.';
+            }
+            return null;
+        },
+        buildPayload: function (state) {
+            var payload = {
+                stake: state.stake,
+                autoTopUp: state.autoTopUp,
+                bet: selectedBet(),
+            };
+            if (payload.bet === 'STRAIGHT') {
+                payload.number = selectedNumber();
+            }
+            return payload;
+        },
+    });
+
+    // ─── Helpers ────────────────────────────────────────────────────────
+
+    function parseWheelOrder(raw) {
+        if (!raw) return null;
+        var parts = raw.split(',').map(function (s) { return parseInt(s.trim(), 10); });
+        if (parts.some(isNaN) || parts.length !== 37) return null;
+        return parts;
+    }
+
+    function renderWheel(svg, order) {
+        var SVG_NS = 'http://www.w3.org/2000/svg';
+        // Clear any pre-existing children (e.g. on hot reload during dev).
+        while (svg.firstChild) svg.removeChild(svg.firstChild);
+
+        // Outer rim circle.
+        var rim = document.createElementNS(SVG_NS, 'circle');
+        rim.setAttribute('cx', '0'); rim.setAttribute('cy', '0');
+        rim.setAttribute('r', '100');
+        rim.setAttribute('class', 'roulette-wheel-rim');
+        svg.appendChild(rim);
+
+        // 37 pocket sectors as donut slices between r=64 and r=100.
+        order.forEach(function (pocket, i) {
+            var startAngle = i * SLICE_DEG - 90 - SLICE_DEG / 2;
+            var endAngle   = startAngle + SLICE_DEG;
+            var path = document.createElementNS(SVG_NS, 'path');
+            path.setAttribute('d', donutSlicePath(64, 100, startAngle, endAngle));
+            var color = pocket === 0 ? 'green' :
+                (RED_NUMBERS.has(pocket) ? 'red' : 'black');
+            path.setAttribute('class',
+                'roulette-wheel-pocket-' + color + ' roulette-wheel-pocket-stroke');
+            svg.appendChild(path);
+
+            // Number label, positioned mid-slice on a smaller radius so
+            // it sits inside the coloured ring.
+            var midAngle = i * SLICE_DEG - 90;
+            var lr = 82;
+            var lx = lr * Math.cos(deg2rad(midAngle));
+            var ly = lr * Math.sin(deg2rad(midAngle));
+            var label = document.createElementNS(SVG_NS, 'text');
+            label.setAttribute('x', lx); label.setAttribute('y', ly);
+            label.setAttribute('transform',
+                'rotate(' + (midAngle + 90) + ' ' + lx + ' ' + ly + ')');
+            label.setAttribute('class', 'roulette-wheel-label');
+            label.textContent = String(pocket);
+            svg.appendChild(label);
+        });
+
+        // Centre hub.
+        var hub = document.createElementNS(SVG_NS, 'circle');
+        hub.setAttribute('cx', '0'); hub.setAttribute('cy', '0');
+        hub.setAttribute('r', '52');
+        hub.setAttribute('class', 'roulette-wheel-hub');
+        svg.appendChild(hub);
+    }
+
+    function donutSlicePath(rInner, rOuter, startDeg, endDeg) {
+        var s = deg2rad(startDeg);
+        var e = deg2rad(endDeg);
+        var x1 = rOuter * Math.cos(s), y1 = rOuter * Math.sin(s);
+        var x2 = rOuter * Math.cos(e), y2 = rOuter * Math.sin(e);
+        var x3 = rInner * Math.cos(e), y3 = rInner * Math.sin(e);
+        var x4 = rInner * Math.cos(s), y4 = rInner * Math.sin(s);
+        var largeArc = (endDeg - startDeg) > 180 ? 1 : 0;
+        return [
+            'M', x1, y1,
+            'A', rOuter, rOuter, 0, largeArc, 1, x2, y2,
+            'L', x3, y3,
+            'A', rInner, rInner, 0, largeArc, 0, x4, y4,
+            'Z',
+        ].join(' ');
+    }
+
+    function deg2rad(d) { return d * Math.PI / 180; }
+})();
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { renderRouletteResult };
+}

--- a/web/src/main/resources/templates/casino-guilds.html
+++ b/web/src/main/resources/templates/casino-guilds.html
@@ -8,8 +8,9 @@
 <main id="main" class="container">
     <h1 class="mb-3">🎰 Casino</h1>
     <p class="muted mb-5">
-        Wager social credit on the reels. Each server has its own slots room —
-        balances are per-guild. Pick a server below to spin.
+        Wager social credit on slots, roulette, dice, cards and more — every
+        server has its own room and balances are per-guild. Pick a server below
+        to play.
     </p>
 
     <div th:replace="~{fragments/alerts :: error}"></div>
@@ -22,26 +23,38 @@
                 <span th:text="${g.credits} + ' credits'">0 credits</span>
             </div>
             <div class="lb-guild-games">
-                <a class="btn-secondary"
-                   th:href="@{/casino/{id}/slots(id=${g.id})}">🎰 Slots</a>
-                <a class="btn-secondary"
-                   th:href="@{/casino/{id}/coinflip(id=${g.id})}">🪙 Coinflip</a>
-                <a class="btn-secondary"
-                   th:href="@{/casino/{id}/dice(id=${g.id})}">🎲 Dice</a>
-                <a class="btn-secondary"
-                   th:href="@{/casino/{id}/highlow(id=${g.id})}">🃏 High-Low</a>
-                <a class="btn-secondary"
-                   th:href="@{/casino/{id}/scratch(id=${g.id})}">🎟️ Scratch</a>
-                <a class="btn-secondary"
-                   th:href="@{/casino/{id}/keno(id=${g.id})}">🎯 Keno</a>
-                <a class="btn-secondary"
-                   th:href="@{/casino/{id}/baccarat(id=${g.id})}">🎴 Baccarat</a>
-                <a class="btn-secondary"
-                   th:href="@{/poker/{id}(id=${g.id})}">🎴 Poker</a>
-                <a class="btn-secondary"
-                   th:href="@{/blackjack/{id}/solo(id=${g.id})}">🂡 Blackjack</a>
-                <a class="btn-secondary"
-                   th:href="@{/casinoholdem/{id}(id=${g.id})}">🃏 Casino Hold'em</a>
+                <div class="lb-games-group">
+                    <h3 class="lb-games-group-title">Quick play</h3>
+                    <div class="lb-games-row">
+                        <a class="btn-secondary"
+                           th:href="@{/casino/{id}/coinflip(id=${g.id})}">🪙 Coinflip</a>
+                        <a class="btn-secondary"
+                           th:href="@{/casino/{id}/dice(id=${g.id})}">🎲 Dice</a>
+                        <a class="btn-secondary"
+                           th:href="@{/casino/{id}/highlow(id=${g.id})}">🃏 High-Low</a>
+                        <a class="btn-secondary"
+                           th:href="@{/casino/{id}/keno(id=${g.id})}">🎯 Keno</a>
+                        <a class="btn-secondary"
+                           th:href="@{/casino/{id}/roulette(id=${g.id})}">🎡 Roulette</a>
+                        <a class="btn-secondary"
+                           th:href="@{/casino/{id}/scratch(id=${g.id})}">🎟️ Scratch</a>
+                        <a class="btn-secondary"
+                           th:href="@{/casino/{id}/slots(id=${g.id})}">🎰 Slots</a>
+                    </div>
+                </div>
+                <div class="lb-games-group">
+                    <h3 class="lb-games-group-title">Table games</h3>
+                    <div class="lb-games-row">
+                        <a class="btn-secondary"
+                           th:href="@{/casino/{id}/baccarat(id=${g.id})}">🎴 Baccarat</a>
+                        <a class="btn-secondary"
+                           th:href="@{/blackjack/{id}/solo(id=${g.id})}">🂡 Blackjack</a>
+                        <a class="btn-secondary"
+                           th:href="@{/casinoholdem/{id}(id=${g.id})}">♠️ Casino Hold'em</a>
+                        <a class="btn-secondary"
+                           th:href="@{/poker/{id}(id=${g.id})}">🃏 Poker</a>
+                    </div>
+                </div>
             </div>
         </div>
     </div>

--- a/web/src/main/resources/templates/moderation.html
+++ b/web/src/main/resources/templates/moderation.html
@@ -535,6 +535,25 @@
                     </div>
                 </div>
                 <div class="config-group">
+                    <h4>Roulette</h4>
+                    <div class="config-row" data-key="ROULETTE_MIN_STAKE">
+                        <label>Minimum stake (default 10)</label>
+                        <input type="number" min="1"
+                               th:value="${overview.config['ROULETTE_MIN_STAKE']}"
+                               placeholder="10"
+                               th:disabled="${!isOwner}">
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
+                    <div class="config-row" data-key="ROULETTE_MAX_STAKE">
+                        <label>Maximum stake (0 = unlimited; default 500)</label>
+                        <input type="number" min="0"
+                               th:value="${overview.config['ROULETTE_MAX_STAKE']}"
+                               placeholder="500"
+                               th:disabled="${!isOwner}">
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
+                </div>
+                <div class="config-group">
                     <h4>Casino Hold'em</h4>
                     <div class="config-row" data-key="HOLDEM_MIN_STAKE">
                         <label>Minimum stake (default 10)</label>

--- a/web/src/main/resources/templates/roulette.html
+++ b/web/src/main/resources/templates/roulette.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="en">
+<head th:replace="~{fragments/head :: head('TobyBot - Roulette', '/css/roulette.css')}"></head>
+<body>
+<a href="#main" class="skip-link">Skip to content</a>
+<div th:replace="~{fragments/navbar :: navbar}"></div>
+
+<main id="main" class="container"
+      th:attr="data-guild-id=${guildId}, data-toby-coins=${tobyCoins}, data-market-price=${marketPrice}, data-wheel-order=${#strings.listJoin(wheelOrder, ',')}">
+
+    <div class="roulette-header">
+        <a class="back-link" th:href="@{/casino/guilds}">&larr; All servers</a>
+        <h1 th:text="'🎡 Roulette • ' + ${guildName}">🎡 Roulette</h1>
+        <p class="muted">European single-zero wheel. Bet between
+            <span th:text="${minStake}">10</span> and
+            <span th:text="${maxStake}">500</span> credits per spin.</p>
+    </div>
+
+    <div th:replace="~{fragments/alerts :: error}"></div>
+
+    <section class="roulette-table casino-felt">
+        <div class="roulette-wheel-stage" aria-live="polite">
+            <div class="roulette-pointer" aria-hidden="true"></div>
+            <svg class="roulette-wheel" id="roulette-wheel"
+                 viewBox="-110 -110 220 220" role="img" aria-label="Roulette wheel">
+                <!-- pocket sectors + number labels are rendered by roulette.js
+                     using the wheel order in `data-wheel-order` so the markup
+                     stays compact and the pocket geometry lives in one place. -->
+            </svg>
+            <div class="roulette-landed" id="roulette-landed" aria-hidden="true">
+                <span class="roulette-landed-label">Last</span>
+                <span class="roulette-landed-pocket" id="roulette-landed-pocket">—</span>
+            </div>
+        </div>
+
+        <div class="roulette-result" id="roulette-result" hidden></div>
+
+        <form class="roulette-bet" id="roulette-bet" autocomplete="off">
+            <fieldset class="roulette-bet-fieldset" id="roulette-bet-fieldset">
+                <legend>Bet</legend>
+                <div class="roulette-bet-grid" role="radiogroup" aria-label="Bet type">
+                    <button th:each="b : ${bets}"
+                            type="button"
+                            class="roulette-chip"
+                            th:attr="data-bet=${b.id}, data-requires-number=${b.requiresNumber}"
+                            role="radio"
+                            aria-checked="false">
+                        <span class="roulette-chip-label" th:text="${b.label}">Red</span>
+                        <span class="roulette-chip-odds" th:text="${b.odds}">1:1</span>
+                    </button>
+                </div>
+            </fieldset>
+
+            <div class="roulette-straight-picker" id="roulette-straight-picker" hidden>
+                <label for="roulette-straight">Pocket (0–<span th:text="${maxPocket}">36</span>)</label>
+                <input id="roulette-straight"
+                       name="number"
+                       type="number"
+                       min="0"
+                       th:attr="max=${maxPocket}"
+                       step="1"
+                       value="0">
+            </div>
+
+            <div class="roulette-stake-row">
+                <label for="roulette-stake">Stake (credits)</label>
+                <input id="roulette-stake"
+                       name="stake"
+                       type="number"
+                       th:attr="min=${minStake}, max=${maxStake}"
+                       th:value="${minStake}"
+                       step="1">
+                <button type="submit" id="roulette-spin" class="btn-primary">Spin</button>
+                <button type="submit" id="roulette-spin-toby" class="btn-secondary casino-bet-toby" hidden
+                        title="Sells just enough TOBY at the live market price to cover the shortfall, then spins.">
+                    Spin (sell <span class="casino-bet-toby-coins">0</span> TOBY)
+                </button>
+            </div>
+        </form>
+
+        <div class="roulette-balance">
+            Balance: <strong id="roulette-balance" th:text="${balance}">0</strong> credits
+        </div>
+
+        <div th:replace="~{fragments/casino :: jackpotBanner}"></div>
+    </section>
+
+    <section class="roulette-payouts">
+        <h2>Payouts</h2>
+        <table>
+            <thead>
+            <tr><th>Bet</th><th>Pays</th></tr>
+            </thead>
+            <tbody>
+            <tr th:each="row : ${payoutTable}">
+                <td th:text="${row.label}">Red / Black</td>
+                <td th:text="${row.payout}">1:1</td>
+            </tr>
+            </tbody>
+        </table>
+        <p class="muted">European single-zero wheel. The green 0 loses every outside bet, giving the
+            house its standard 2.7% edge. Long-run RTP ≈ 97.3%.</p>
+    </section>
+</main>
+
+<div class="toast-stack" id="toast-stack" aria-live="polite"></div>
+
+<th:block th:replace="~{fragments/casinoMinigame :: scripts}"></th:block>
+<script th:src="@{/js/roulette.js}"></script>
+</body>
+</html>

--- a/web/src/test/kotlin/web/controller/RouletteControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/RouletteControllerTest.kt
@@ -1,0 +1,301 @@
+package web.controller
+
+import database.economy.Roulette
+import database.service.RouletteService
+import database.service.RouletteService.SpinOutcome
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.security.oauth2.core.user.OAuth2User
+import web.casino.CasinoPageContext
+import web.casino.StakeBounds
+import web.service.EconomyWebService
+
+/**
+ * The /spin endpoint is the public surface for the web `/casino/{guildId}/roulette`
+ * UI. Tests cover every SpinOutcome variant's HTTP shape so a service-side
+ * outcome change can't quietly break the JSON the page JS expects.
+ */
+class RouletteControllerTest {
+
+    private val guildId = 42L
+    private val discordId = 100L
+
+    private lateinit var rouletteService: RouletteService
+    private lateinit var economyWebService: EconomyWebService
+    private lateinit var pageContext: CasinoPageContext
+    private lateinit var stakeBounds: StakeBounds
+    private lateinit var user: OAuth2User
+    private lateinit var controller: RouletteController
+
+    @BeforeEach
+    fun setup() {
+        rouletteService = mockk(relaxed = true)
+        economyWebService = mockk(relaxed = true)
+        pageContext = mockk(relaxed = true)
+        stakeBounds = mockk(relaxed = true)
+        user = mockk {
+            every { getAttribute<String>("id") } returns discordId.toString()
+            every { getAttribute<String>("username") } returns "tester"
+        }
+        every { economyWebService.isMember(discordId, guildId) } returns true
+        controller = RouletteController(rouletteService, economyWebService, pageContext, stakeBounds)
+    }
+
+    @Test
+    fun `spin win returns 200 with win-shaped payload`() {
+        every { rouletteService.spin(discordId, guildId, 100L, Roulette.Bet.RED, null, false) } returns
+            SpinOutcome.Win(
+                stake = 100L,
+                bet = Roulette.Bet.RED,
+                landed = 7,
+                color = Roulette.Color.RED,
+                straightNumber = null,
+                multiplier = 2L,
+                payout = 200L,
+                net = 100L,
+                newBalance = 1_100L,
+            )
+
+        val response = controller.spin(
+            guildId,
+            RouletteSpinRequest(stake = 100L, bet = "RED"),
+            user,
+        )
+
+        assertTrue(response.statusCode.is2xxSuccessful)
+        val body = response.body!!
+        assertEquals(true, body.ok)
+        assertEquals(true, body.win)
+        assertEquals("RED", body.bet)
+        assertEquals(7, body.landed)
+        assertEquals("RED", body.color)
+        assertEquals(2L, body.multiplier)
+        assertEquals(100L, body.net)
+        assertEquals(1_100L, body.newBalance)
+    }
+
+    @Test
+    fun `spin lose returns 200 with negative net and win=false`() {
+        every { rouletteService.spin(discordId, guildId, 50L, Roulette.Bet.BLACK, null, false) } returns
+            SpinOutcome.Lose(
+                stake = 50L,
+                bet = Roulette.Bet.BLACK,
+                landed = 0,
+                color = Roulette.Color.GREEN,
+                straightNumber = null,
+                newBalance = 950L,
+            )
+
+        val response = controller.spin(
+            guildId,
+            RouletteSpinRequest(stake = 50L, bet = "BLACK"),
+            user,
+        )
+
+        assertTrue(response.statusCode.is2xxSuccessful)
+        val body = response.body!!
+        assertEquals(true, body.ok)
+        assertEquals(false, body.win)
+        assertEquals(0, body.landed)
+        assertEquals("GREEN", body.color)
+        assertEquals(-50L, body.net)
+        assertEquals(950L, body.newBalance)
+    }
+
+    @Test
+    fun `spin straight win surfaces straightNumber on the response`() {
+        every { rouletteService.spin(discordId, guildId, 10L, Roulette.Bet.STRAIGHT, 17, false) } returns
+            SpinOutcome.Win(
+                stake = 10L,
+                bet = Roulette.Bet.STRAIGHT,
+                landed = 17,
+                color = Roulette.Color.BLACK,
+                straightNumber = 17,
+                multiplier = 36L,
+                payout = 360L,
+                net = 350L,
+                newBalance = 1_350L,
+            )
+
+        val response = controller.spin(
+            guildId,
+            RouletteSpinRequest(stake = 10L, bet = "STRAIGHT", number = 17),
+            user,
+        )
+
+        assertEquals(17, response.body!!.straightNumber)
+        assertEquals("STRAIGHT", response.body!!.bet)
+        assertEquals(36L, response.body!!.multiplier)
+    }
+
+    @Test
+    fun `spin returns 400 with error message on insufficient credits`() {
+        every { rouletteService.spin(discordId, guildId, 100L, Roulette.Bet.RED, null, false) } returns
+            SpinOutcome.InsufficientCredits(stake = 100L, have = 30L)
+
+        val response = controller.spin(
+            guildId,
+            RouletteSpinRequest(stake = 100L, bet = "RED"),
+            user,
+        )
+
+        assertEquals(400, response.statusCode.value())
+        assertEquals(false, response.body?.ok)
+        assertTrue(response.body?.error!!.contains("100"))
+        assertTrue(response.body?.error!!.contains("30"))
+    }
+
+    @Test
+    fun `spin returns 400 on invalid stake`() {
+        every { rouletteService.spin(discordId, guildId, 5L, Roulette.Bet.RED, null, false) } returns
+            SpinOutcome.InvalidStake(min = 10L, max = 500L)
+
+        val response = controller.spin(
+            guildId,
+            RouletteSpinRequest(stake = 5L, bet = "RED"),
+            user,
+        )
+
+        assertEquals(400, response.statusCode.value())
+        assertEquals(false, response.body?.ok)
+        assertTrue(response.body?.error!!.contains("10"))
+        assertTrue(response.body?.error!!.contains("500"))
+    }
+
+    @Test
+    fun `spin returns 400 on invalid straight number`() {
+        every { rouletteService.spin(discordId, guildId, 10L, Roulette.Bet.STRAIGHT, null, false) } returns
+            SpinOutcome.InvalidNumber(min = 0, max = 36)
+
+        val response = controller.spin(
+            guildId,
+            RouletteSpinRequest(stake = 10L, bet = "STRAIGHT", number = null),
+            user,
+        )
+
+        assertEquals(400, response.statusCode.value())
+        assertEquals(false, response.body?.ok)
+        assertTrue(response.body?.error!!.contains("0"))
+        assertTrue(response.body?.error!!.contains("36"))
+    }
+
+    @Test
+    fun `spin returns 400 with explanatory error when bet is unknown`() {
+        val response = controller.spin(
+            guildId,
+            RouletteSpinRequest(stake = 50L, bet = "PURPLE"),
+            user,
+        )
+
+        assertEquals(400, response.statusCode.value())
+        assertEquals(false, response.body?.ok)
+        verify(exactly = 0) { rouletteService.spin(any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `spin returns 400 on unknown user`() {
+        every { rouletteService.spin(discordId, guildId, 100L, Roulette.Bet.RED, null, false) } returns
+            SpinOutcome.UnknownUser
+
+        val response = controller.spin(
+            guildId,
+            RouletteSpinRequest(stake = 100L, bet = "RED"),
+            user,
+        )
+
+        assertEquals(400, response.statusCode.value())
+        assertEquals(false, response.body?.ok)
+    }
+
+    @Test
+    fun `spin rejects with 403 when user is not a member of the guild`() {
+        every { economyWebService.isMember(discordId, guildId) } returns false
+
+        val response = controller.spin(
+            guildId,
+            RouletteSpinRequest(stake = 100L, bet = "RED"),
+            user,
+        )
+
+        assertEquals(403, response.statusCode.value())
+        verify(exactly = 0) { rouletteService.spin(any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `jackpot win surfaces jackpotPayout in the response body`() {
+        every { rouletteService.spin(discordId, guildId, 100L, Roulette.Bet.RED, null, false) } returns
+            SpinOutcome.Win(
+                stake = 100L,
+                bet = Roulette.Bet.RED,
+                landed = 7,
+                color = Roulette.Color.RED,
+                straightNumber = null,
+                multiplier = 2L,
+                payout = 200L,
+                net = 100L,
+                newBalance = 9_100L,
+                jackpotPayout = 8_000L,
+            )
+
+        val response = controller.spin(
+            guildId,
+            RouletteSpinRequest(stake = 100L, bet = "RED"),
+            user,
+        )
+
+        assertEquals(8_000L, response.body!!.jackpotPayout)
+        assertEquals(9_100L, response.body!!.newBalance)
+    }
+
+    @Test
+    fun `non-jackpot win does not include jackpotPayout`() {
+        every { rouletteService.spin(discordId, guildId, 100L, Roulette.Bet.RED, null, false) } returns
+            SpinOutcome.Win(
+                stake = 100L,
+                bet = Roulette.Bet.RED,
+                landed = 7,
+                color = Roulette.Color.RED,
+                straightNumber = null,
+                multiplier = 2L,
+                payout = 200L,
+                net = 100L,
+                newBalance = 1_100L,
+                jackpotPayout = 0L,
+            )
+
+        val response = controller.spin(
+            guildId,
+            RouletteSpinRequest(stake = 100L, bet = "RED"),
+            user,
+        )
+
+        assertEquals(null, response.body!!.jackpotPayout)
+    }
+
+    @Test
+    fun `lose with loss tribute surfaces lossTribute on the response`() {
+        every { rouletteService.spin(discordId, guildId, 100L, Roulette.Bet.RED, null, false) } returns
+            SpinOutcome.Lose(
+                stake = 100L,
+                bet = Roulette.Bet.RED,
+                landed = 0,
+                color = Roulette.Color.GREEN,
+                straightNumber = null,
+                newBalance = 900L,
+                lossTribute = 10L,
+            )
+
+        val response = controller.spin(
+            guildId,
+            RouletteSpinRequest(stake = 100L, bet = "RED"),
+            user,
+        )
+
+        assertEquals(10L, response.body!!.lossTribute)
+    }
+}


### PR DESCRIPTION
## Summary
- New European single-zero roulette minigame following the slots/coinflip pipeline end-to-end: pure `Roulette` logic + `RouletteService` (uses `WagerHelper` + `JackpotHelper`), `/roulette` Discord command, and `/casino/{guildId}/roulette` web page with a felt-styled wheel.
- Thirteen bet types: red/black, odd/even, low/high (1:1), three dozens, three columns (2:1), and straight (35:1). Per-guild `ROULETTE_MIN_STAKE`/`ROULETTE_MAX_STAKE` config keys are wired into the moderation page; jackpot pool feeds and rolls work the same as every other minigame.
- Polished UI: SVG wheel rendered from the standard European pocket order, deceleration animation that lands the wheel on the server-returned pocket, chip-style bet selectors, dynamic 0–36 picker for straight bets, and roulette-flavoured `tick` + `ball` cues added to the shared `CasinoSounds` synth module (still no audio assets shipped). Honours `prefers-reduced-motion`.
- Casino landing cleanup: regrouped tiles into **Quick play** and **Table games** sections, sorted alphabetically; broadened the page intro copy so it no longer reads as "slots only"; gave Casino Hold'em its own ♠️ glyph so no two tiles share an emoji.

## Test plan
- [x] `./gradlew :database:test --tests 'database.economy.RouletteTest'` (13/13 pass: pocket colours, dozen/column partitions, every bet's win predicate over all 37 pockets, RTP convergence to 36/37, etc.)
- [x] `./gradlew :web:test --tests 'web.controller.RouletteControllerTest'` (12/12 pass: every `SpinOutcome` variant's HTTP shape, jackpot/loss-tribute pass-through, 403 membership guard, unknown-bet rejection)
- [x] Discord-bot module: `RouletteCommandTest` mirrors `CoinflipCommandTest` patterns (CI to validate; the lavalink/libdave deps aren't reachable from this sandbox)
- [ ] Run the bot locally and try `/roulette stake:50 bet:RED` and `/roulette stake:10 bet:STRAIGHT number:17` in a test guild; confirm embed colours/emojis and balance/jackpot updates
- [ ] Visit `/casino/{guildId}/roulette` — verify the wheel renders, bet chips select, STRAIGHT picker appears/hides, ball lands on the returned pocket, win flash + chip flourish on hit, balance/jackpot banner refresh, mute toggle silences the new tick/ball cues
- [ ] Visit `/casino/guilds` — confirm the Quick play / Table games groups render with tidy aligned tile rows on desktop and mobile widths
- [ ] Set `ROULETTE_MIN_STAKE`/`ROULETTE_MAX_STAKE` via the moderation page and verify the bot rejects out-of-range stakes

https://claude.ai/code/session_01VnFZBZ8D7dhfdtcpypnSp8

---
_Generated by [Claude Code](https://claude.ai/code/session_01VnFZBZ8D7dhfdtcpypnSp8)_