### PR TITLE
feat(jackpot): structural rebalance — payout %, gates, and lottery event

### DIFF
--- a/application/src/test/kotlin/integration/bot/CommandManagerTest.kt
+++ b/application/src/test/kotlin/integration/bot/CommandManagerTest.kt
@@ -17,6 +17,7 @@ import bot.toby.command.commands.economy.DiceCommand
 import bot.toby.command.commands.economy.DuelCommand
 import bot.toby.command.commands.economy.HighlowCommand
 import bot.toby.command.commands.economy.KenoCommand
+import bot.toby.command.commands.economy.LotteryCommand
 import bot.toby.command.commands.economy.PokerCommand
 import bot.toby.command.commands.economy.RouletteCommand
 import bot.toby.command.commands.economy.ScratchCommand
@@ -155,12 +156,13 @@ class CommandManagerTest {
             BaccaratCommand::class.java,
             KenoCommand::class.java,
             CasinoHoldemCommand::class.java,
-            RouletteCommand::class.java
+            RouletteCommand::class.java,
+            LotteryCommand::class.java,
         )
 
         Assertions.assertTrue(availableCommands.containsAll(commandManager.allCommands.map { it.javaClass }.toList()))
-        Assertions.assertEquals(60, commandManager.allCommands.size)
-        Assertions.assertEquals(60, commandManager.allSlashCommands.size)
+        Assertions.assertEquals(61, commandManager.allCommands.size)
+        Assertions.assertEquals(61, commandManager.allSlashCommands.size)
     }
 
     @Test

--- a/database/src/main/kotlin/database/dto/ConfigDto.kt
+++ b/database/src/main/kotlin/database/dto/ConfigDto.kt
@@ -150,7 +150,34 @@ class ConfigDto(
         // probability; smaller bets scale linearly as stake/anchor.
         // Decoupled from per-game max stake so admins can raise max
         // freely without shrinking jackpot odds. Default 500.
-        JACKPOT_STAKE_ANCHOR("JACKPOT_STAKE_ANCHOR");
+        JACKPOT_STAKE_ANCHOR("JACKPOT_STAKE_ANCHOR"),
+
+        // Whole-number percentage (1-100) of the per-guild jackpot pool
+        // paid out on a winning roll. Defaults to 100 when unset (current
+        // behaviour: winner banks the entire pool). Set to e.g. 30 so a
+        // single roll never sweeps the whole pool — the remainder stays
+        // in and re-seeds the next cycle, preventing one lucky bet from
+        // unbalancing the server economy.
+        JACKPOT_PAYOUT_PCT("JACKPOT_PAYOUT_PCT"),
+
+        // Whole-number days a prior jackpot winner is ineligible for
+        // another payout. 0 (default) disables the cooldown; recommended
+        // value 14. Applies to both casino-roll wins and lottery draw
+        // wins so the same player can't sweep both within the window.
+        JACKPOT_WINNER_COOLDOWN_DAYS("JACKPOT_WINNER_COOLDOWN_DAYS"),
+
+        // Whole-number trailing-day window over which the jackpot
+        // eligibility check counts the user's distinct activity days.
+        // 0 (default) disables the gate (every user is eligible);
+        // recommended 7. Activity is sourced from voice_credit_daily —
+        // any day with credit-cap-eligible earnings counts.
+        JACKPOT_ACTIVITY_WINDOW_DAYS("JACKPOT_ACTIVITY_WINDOW_DAYS"),
+
+        // Whole-number minimum count of distinct activity days within
+        // JACKPOT_ACTIVITY_WINDOW_DAYS required for the user to be
+        // jackpot-eligible. Defaults to 1; recommended 3 paired with a
+        // 7-day window. Ignored when the window is 0.
+        JACKPOT_ACTIVITY_MIN_DAYS("JACKPOT_ACTIVITY_MIN_DAYS");
     }
 
     override fun toString(): String {

--- a/database/src/main/kotlin/database/dto/JackpotLotteryDto.kt
+++ b/database/src/main/kotlin/database/dto/JackpotLotteryDto.kt
@@ -1,0 +1,67 @@
+package database.dto
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.NamedQueries
+import jakarta.persistence.NamedQuery
+import jakarta.persistence.Table
+import org.springframework.transaction.annotation.Transactional
+import java.io.Serializable
+import java.time.Instant
+
+/**
+ * Per-guild jackpot lottery event row.
+ *
+ * One OPEN row per guild at any time (enforced by a partial unique
+ * index in V27). When the admin runs `/jackpotadmin lottery_draw`, the
+ * service marks the row DRAWN and writes ticket-weighted payouts. On
+ * `lottery_cancel` the row goes CANCELLED, all ticket spend is
+ * refunded, and `pool_amount` returns to the per-guild jackpot pool.
+ */
+@NamedQueries(
+    NamedQuery(
+        name = "JackpotLotteryDto.getOpenByGuild",
+        query = "select l from JackpotLotteryDto l " +
+                "where l.guildId = :guildId and l.status = 'OPEN'"
+    )
+)
+@Entity
+@Table(name = "toby_coin_jackpot_lottery", schema = "public")
+@Transactional
+class JackpotLotteryDto(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    var id: Long? = null,
+
+    @Column(name = "guild_id", nullable = false)
+    var guildId: Long = 0,
+
+    @Column(name = "ticket_price", nullable = false)
+    var ticketPrice: Long = 0,
+
+    @Column(name = "pool_amount", nullable = false)
+    var poolAmount: Long = 0,
+
+    @Column(name = "winner_count", nullable = false)
+    var winnerCount: Int = 0,
+
+    @Column(name = "opened_at", nullable = false)
+    var openedAt: Instant = Instant.EPOCH,
+
+    @Column(name = "closes_at", nullable = false)
+    var closesAt: Instant = Instant.EPOCH,
+
+    @Column(name = "status", nullable = false, length = 16)
+    var status: String = STATUS_OPEN,
+) : Serializable {
+
+    companion object {
+        const val STATUS_OPEN = "OPEN"
+        const val STATUS_DRAWN = "DRAWN"
+        const val STATUS_CANCELLED = "CANCELLED"
+    }
+}

--- a/database/src/main/kotlin/database/dto/JackpotLotteryDto.kt
+++ b/database/src/main/kotlin/database/dto/JackpotLotteryDto.kt
@@ -56,7 +56,7 @@ class JackpotLotteryDto(
     var closesAt: Instant = Instant.EPOCH,
 
     @Column(name = "status", nullable = false, length = 16)
-    var status: String = STATUS_OPEN,
+    var status: String = "OPEN",
 ) : Serializable {
 
     companion object {

--- a/database/src/main/kotlin/database/dto/JackpotLotteryTicketDto.kt
+++ b/database/src/main/kotlin/database/dto/JackpotLotteryTicketDto.kt
@@ -1,0 +1,52 @@
+package database.dto
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.IdClass
+import jakarta.persistence.NamedQueries
+import jakarta.persistence.NamedQuery
+import jakarta.persistence.Table
+import org.springframework.transaction.annotation.Transactional
+import java.io.Serializable
+
+/**
+ * One row per (lottery, user) tracking the cumulative ticket count and
+ * total credits the user has spent on this lottery. Weighting for the
+ * draw is by `ticket_count`; `spent` is kept for refunds on cancel.
+ */
+@NamedQueries(
+    NamedQuery(
+        name = "JackpotLotteryTicketDto.get",
+        query = "select t from JackpotLotteryTicketDto t " +
+                "where t.lotteryId = :lotteryId and t.discordId = :discordId"
+    ),
+    NamedQuery(
+        name = "JackpotLotteryTicketDto.byLottery",
+        query = "select t from JackpotLotteryTicketDto t where t.lotteryId = :lotteryId"
+    )
+)
+@Entity
+@Table(name = "toby_coin_jackpot_lottery_ticket", schema = "public")
+@IdClass(JackpotLotteryTicketId::class)
+@Transactional
+class JackpotLotteryTicketDto(
+    @Id
+    @Column(name = "lottery_id")
+    var lotteryId: Long = 0,
+
+    @Id
+    @Column(name = "discord_id")
+    var discordId: Long = 0,
+
+    @Column(name = "ticket_count", nullable = false)
+    var ticketCount: Int = 0,
+
+    @Column(name = "spent", nullable = false)
+    var spent: Long = 0,
+) : Serializable
+
+data class JackpotLotteryTicketId(
+    var lotteryId: Long = 0,
+    var discordId: Long = 0,
+) : Serializable

--- a/database/src/main/kotlin/database/dto/TobyCoinJackpotWinnerDto.kt
+++ b/database/src/main/kotlin/database/dto/TobyCoinJackpotWinnerDto.kt
@@ -1,0 +1,44 @@
+package database.dto
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.IdClass
+import jakarta.persistence.NamedQueries
+import jakarta.persistence.NamedQuery
+import jakarta.persistence.Table
+import org.springframework.transaction.annotation.Transactional
+import java.io.Serializable
+import java.time.Instant
+
+@NamedQueries(
+    NamedQuery(
+        name = "TobyCoinJackpotWinnerDto.get",
+        query = "select w from TobyCoinJackpotWinnerDto w " +
+                "where w.guildId = :guildId and w.discordId = :discordId"
+    )
+)
+@Entity
+@Table(name = "toby_coin_jackpot_winner", schema = "public")
+@IdClass(TobyCoinJackpotWinnerId::class)
+@Transactional
+class TobyCoinJackpotWinnerDto(
+    @Id
+    @Column(name = "guild_id")
+    var guildId: Long = 0,
+
+    @Id
+    @Column(name = "discord_id")
+    var discordId: Long = 0,
+
+    @Column(name = "last_won_at", nullable = false)
+    var lastWonAt: Instant = Instant.EPOCH,
+
+    @Column(name = "last_won_amount", nullable = false)
+    var lastWonAmount: Long = 0
+) : Serializable
+
+data class TobyCoinJackpotWinnerId(
+    var guildId: Long = 0,
+    var discordId: Long = 0
+) : Serializable

--- a/database/src/main/kotlin/database/dto/VoiceCreditDailyDto.kt
+++ b/database/src/main/kotlin/database/dto/VoiceCreditDailyDto.kt
@@ -10,6 +10,12 @@ import java.time.LocalDate
         name = "VoiceCreditDailyDto.get",
         query = "select d from VoiceCreditDailyDto d " +
                 "where d.discordId = :discordId and d.guildId = :guildId and d.earnDate = :earnDate"
+    ),
+    NamedQuery(
+        name = "VoiceCreditDailyDto.countDaysSince",
+        query = "select count(d) from VoiceCreditDailyDto d " +
+                "where d.discordId = :discordId and d.guildId = :guildId " +
+                "and d.earnDate >= :from and d.credits > 0"
     )
 )
 @Entity

--- a/database/src/main/kotlin/database/persistence/JackpotLotteryPersistence.kt
+++ b/database/src/main/kotlin/database/persistence/JackpotLotteryPersistence.kt
@@ -1,0 +1,22 @@
+package database.persistence
+
+import database.dto.JackpotLotteryDto
+import database.dto.JackpotLotteryTicketDto
+
+interface JackpotLotteryPersistence {
+    /** Returns the single OPEN lottery row for [guildId], or null. */
+    fun getOpenByGuild(guildId: Long): JackpotLotteryDto?
+
+    /** SELECT … FOR UPDATE on the OPEN lottery row. Requires @Transactional. */
+    fun getOpenByGuildForUpdate(guildId: Long): JackpotLotteryDto?
+
+    fun upsert(lottery: JackpotLotteryDto): JackpotLotteryDto
+
+    /** SELECT … FOR UPDATE on a single ticket row, or null if absent. */
+    fun getTicketForUpdate(lotteryId: Long, discordId: Long): JackpotLotteryTicketDto?
+
+    fun upsertTicket(ticket: JackpotLotteryTicketDto): JackpotLotteryTicketDto
+
+    /** All ticket rows for [lotteryId]. Used at draw and cancel time. */
+    fun ticketsByLottery(lotteryId: Long): List<JackpotLotteryTicketDto>
+}

--- a/database/src/main/kotlin/database/persistence/TobyCoinJackpotWinnerPersistence.kt
+++ b/database/src/main/kotlin/database/persistence/TobyCoinJackpotWinnerPersistence.kt
@@ -1,0 +1,8 @@
+package database.persistence
+
+import database.dto.TobyCoinJackpotWinnerDto
+
+interface TobyCoinJackpotWinnerPersistence {
+    fun get(guildId: Long, discordId: Long): TobyCoinJackpotWinnerDto?
+    fun upsert(winner: TobyCoinJackpotWinnerDto): TobyCoinJackpotWinnerDto
+}

--- a/database/src/main/kotlin/database/persistence/VoiceCreditDailyPersistence.kt
+++ b/database/src/main/kotlin/database/persistence/VoiceCreditDailyPersistence.kt
@@ -6,4 +6,12 @@ import java.time.LocalDate
 interface VoiceCreditDailyPersistence {
     fun get(discordId: Long, guildId: Long, date: LocalDate): VoiceCreditDailyDto?
     fun upsert(row: VoiceCreditDailyDto): VoiceCreditDailyDto
+
+    /**
+     * Count distinct activity days for [discordId] in [guildId] on or after
+     * [from] where the user actually earned (credits > 0). Used by the
+     * jackpot eligibility gate to require a minimum recent-engagement
+     * footprint before paying out a roll.
+     */
+    fun countDaysSince(discordId: Long, guildId: Long, from: LocalDate): Long
 }

--- a/database/src/main/kotlin/database/persistence/impl/DefaultJackpotLotteryPersistence.kt
+++ b/database/src/main/kotlin/database/persistence/impl/DefaultJackpotLotteryPersistence.kt
@@ -1,0 +1,79 @@
+package database.persistence.impl
+
+import database.dto.JackpotLotteryDto
+import database.dto.JackpotLotteryTicketDto
+import database.dto.JackpotLotteryTicketId
+import database.persistence.JackpotLotteryPersistence
+import jakarta.persistence.EntityManager
+import jakarta.persistence.LockModeType
+import jakarta.persistence.PersistenceContext
+import jakarta.persistence.TypedQuery
+import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
+
+@Repository
+@Transactional
+class DefaultJackpotLotteryPersistence : JackpotLotteryPersistence {
+
+    @PersistenceContext
+    private lateinit var entityManager: EntityManager
+
+    override fun getOpenByGuild(guildId: Long): JackpotLotteryDto? {
+        val q: TypedQuery<JackpotLotteryDto> = entityManager.createNamedQuery(
+            "JackpotLotteryDto.getOpenByGuild", JackpotLotteryDto::class.java
+        )
+        q.setParameter("guildId", guildId)
+        return q.resultList.firstOrNull()
+    }
+
+    override fun getOpenByGuildForUpdate(guildId: Long): JackpotLotteryDto? {
+        val q: TypedQuery<JackpotLotteryDto> = entityManager.createNamedQuery(
+            "JackpotLotteryDto.getOpenByGuild", JackpotLotteryDto::class.java
+        )
+        q.setParameter("guildId", guildId)
+        q.lockMode = LockModeType.PESSIMISTIC_WRITE
+        return q.resultList.firstOrNull()
+    }
+
+    override fun upsert(lottery: JackpotLotteryDto): JackpotLotteryDto {
+        val saved = if (lottery.id == null) {
+            entityManager.persist(lottery)
+            lottery
+        } else {
+            entityManager.merge(lottery)
+        }
+        entityManager.flush()
+        return saved
+    }
+
+    override fun getTicketForUpdate(lotteryId: Long, discordId: Long): JackpotLotteryTicketDto? {
+        return entityManager.find(
+            JackpotLotteryTicketDto::class.java,
+            JackpotLotteryTicketId(lotteryId = lotteryId, discordId = discordId),
+            LockModeType.PESSIMISTIC_WRITE,
+        )
+    }
+
+    override fun upsertTicket(ticket: JackpotLotteryTicketDto): JackpotLotteryTicketDto {
+        val existing = entityManager.find(
+            JackpotLotteryTicketDto::class.java,
+            JackpotLotteryTicketId(lotteryId = ticket.lotteryId, discordId = ticket.discordId)
+        )
+        val saved = if (existing == null) {
+            entityManager.persist(ticket)
+            ticket
+        } else {
+            entityManager.merge(ticket)
+        }
+        entityManager.flush()
+        return saved
+    }
+
+    override fun ticketsByLottery(lotteryId: Long): List<JackpotLotteryTicketDto> {
+        val q: TypedQuery<JackpotLotteryTicketDto> = entityManager.createNamedQuery(
+            "JackpotLotteryTicketDto.byLottery", JackpotLotteryTicketDto::class.java
+        )
+        q.setParameter("lotteryId", lotteryId)
+        return q.resultList
+    }
+}

--- a/database/src/main/kotlin/database/persistence/impl/DefaultTobyCoinJackpotWinnerPersistence.kt
+++ b/database/src/main/kotlin/database/persistence/impl/DefaultTobyCoinJackpotWinnerPersistence.kt
@@ -1,0 +1,41 @@
+package database.persistence.impl
+
+import database.dto.TobyCoinJackpotWinnerDto
+import database.persistence.TobyCoinJackpotWinnerPersistence
+import jakarta.persistence.EntityManager
+import jakarta.persistence.PersistenceContext
+import jakarta.persistence.TypedQuery
+import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
+
+@Repository
+@Transactional
+class DefaultTobyCoinJackpotWinnerPersistence : TobyCoinJackpotWinnerPersistence {
+
+    @PersistenceContext
+    private lateinit var entityManager: EntityManager
+
+    override fun get(guildId: Long, discordId: Long): TobyCoinJackpotWinnerDto? {
+        val q: TypedQuery<TobyCoinJackpotWinnerDto> = entityManager.createNamedQuery(
+            "TobyCoinJackpotWinnerDto.get", TobyCoinJackpotWinnerDto::class.java
+        )
+        q.setParameter("guildId", guildId)
+        q.setParameter("discordId", discordId)
+        return q.resultList.firstOrNull()
+    }
+
+    override fun upsert(winner: TobyCoinJackpotWinnerDto): TobyCoinJackpotWinnerDto {
+        val existing = get(winner.guildId, winner.discordId)
+        return if (existing == null) {
+            entityManager.persist(winner)
+            entityManager.flush()
+            winner
+        } else {
+            existing.lastWonAt = winner.lastWonAt
+            existing.lastWonAmount = winner.lastWonAmount
+            entityManager.merge(existing)
+            entityManager.flush()
+            existing
+        }
+    }
+}

--- a/database/src/main/kotlin/database/persistence/impl/DefaultVoiceCreditDailyPersistence.kt
+++ b/database/src/main/kotlin/database/persistence/impl/DefaultVoiceCreditDailyPersistence.kt
@@ -40,9 +40,9 @@ class DefaultVoiceCreditDailyPersistence : VoiceCreditDailyPersistence {
     }
 
     override fun countDaysSince(discordId: Long, guildId: Long, from: LocalDate): Long {
-        val q: TypedQuery<Long> = entityManager.createNamedQuery(
-            "VoiceCreditDailyDto.countDaysSince", java.lang.Long::class.java
-        ) as TypedQuery<Long>
+        val q = entityManager.createNamedQuery(
+            "VoiceCreditDailyDto.countDaysSince", Long::class.javaObjectType
+        )
         q.setParameter("discordId", discordId)
         q.setParameter("guildId", guildId)
         q.setParameter("from", from)

--- a/database/src/main/kotlin/database/persistence/impl/DefaultVoiceCreditDailyPersistence.kt
+++ b/database/src/main/kotlin/database/persistence/impl/DefaultVoiceCreditDailyPersistence.kt
@@ -38,4 +38,14 @@ class DefaultVoiceCreditDailyPersistence : VoiceCreditDailyPersistence {
             existing
         }
     }
+
+    override fun countDaysSince(discordId: Long, guildId: Long, from: LocalDate): Long {
+        val q: TypedQuery<Long> = entityManager.createNamedQuery(
+            "VoiceCreditDailyDto.countDaysSince", java.lang.Long::class.java
+        ) as TypedQuery<Long>
+        q.setParameter("discordId", discordId)
+        q.setParameter("guildId", guildId)
+        q.setParameter("from", from)
+        return q.singleResult ?: 0L
+    }
 }

--- a/database/src/main/kotlin/database/service/JackpotHelper.kt
+++ b/database/src/main/kotlin/database/service/JackpotHelper.kt
@@ -37,6 +37,45 @@ internal object JackpotHelper {
     const val DEFAULT_WIN_PROBABILITY: Double = 0.01
 
     /**
+     * Default share of the pool paid on a winning roll when the server
+     * hasn't overridden the value via the `JACKPOT_PAYOUT_PCT` config
+     * entry. 100 % preserves the historic behaviour (winner banks the
+     * entire pool); guilds that have suffered a runaway pool can lower
+     * this so the remainder re-seeds the next cycle.
+     */
+    const val DEFAULT_PAYOUT_PCT: Double = 1.0
+
+    /**
+     * Default cooldown in days during which a prior jackpot winner is
+     * ineligible for another payout. 0 disables the gate (current
+     * behaviour for unconfigured guilds); recommended value is 14.
+     */
+    const val DEFAULT_WINNER_COOLDOWN_DAYS: Long = 0L
+
+    /**
+     * Hard cap on the configurable cooldown. A year is plenty — anything
+     * longer is effectively a permanent ban and should be surfaced as a
+     * separate moderation action, not a "cooldown."
+     */
+    const val MAX_WINNER_COOLDOWN_DAYS: Long = 365L
+
+    /**
+     * Default trailing-day window over which the eligibility gate counts
+     * the user's distinct activity days. 0 disables the gate (current
+     * behaviour); recommended value is 7 paired with `MIN_ACTIVITY_DAYS=3`.
+     */
+    const val DEFAULT_ACTIVITY_WINDOW_DAYS: Long = 0L
+
+    /** Hard cap on the activity window — a calendar year. */
+    const val MAX_ACTIVITY_WINDOW_DAYS: Long = 365L
+
+    /**
+     * Default minimum count of distinct activity days within the window
+     * required for jackpot eligibility. Ignored when the window is 0.
+     */
+    const val DEFAULT_ACTIVITY_MIN_DAYS: Long = 1L
+
+    /**
      * Default reference stake size for jackpot probability scaling
      * when `JACKPOT_STAKE_ANCHOR` is unset. Bets at or above this value
      * roll at the full base probability; smaller bets scale linearly.
@@ -98,8 +137,17 @@ internal object JackpotHelper {
         val scale = (stake.toDouble() / anchor.toDouble()).coerceIn(0.0, 1.0)
         val effective = baseProbability * scale
         if (random.nextDouble() >= effective) return 0L
+
+        // Post-fraud structural gates. Each defaults to "disabled" so an
+        // unconfigured guild's behaviour is unchanged. When enabled, a
+        // failed gate looks identical to a missed roll — pool keeps
+        // growing, no payout, no exception thrown into the wager service.
+        if (jackpotService.isOnCooldown(guildId, user.discordId)) return 0L
+        if (!jackpotService.isActive(guildId, user.discordId)) return 0L
+
         val won = jackpotService.awardJackpot(guildId)
         if (won == 0L) return 0L
+        jackpotService.recordWin(guildId, user.discordId, won)
         user.socialCredit = (user.socialCredit ?: 0L) + won
         userService.updateUser(user)
         return won
@@ -173,5 +221,67 @@ internal object JackpotHelper {
         )
         val pct = cfg?.value?.toDoubleOrNull() ?: return DEFAULT_LOSS_TRIBUTE
         return (pct / 100.0).coerceIn(0.0, MAX_LOSS_TRIBUTE)
+    }
+
+    /**
+     * Live payout fraction for [guildId] — admin-set whole-number percent
+     * (1-100) parsed from `JACKPOT_PAYOUT_PCT`. Returns [DEFAULT_PAYOUT_PCT]
+     * (1.0 = full pool) when unset or unparseable; clamps to (0, 1].
+     * 0 is treated as missing and falls back to the default to avoid
+     * silently disabling all jackpot payouts via a fat-fingered config row.
+     */
+    fun payoutPct(configService: ConfigService, guildId: Long): Double {
+        val cfg = configService.getConfigByName(
+            ConfigDto.Configurations.JACKPOT_PAYOUT_PCT.configValue,
+            guildId.toString()
+        )
+        val pct = cfg?.value?.toDoubleOrNull() ?: return DEFAULT_PAYOUT_PCT
+        if (pct.isNaN() || pct.isInfinite() || pct <= 0.0) return DEFAULT_PAYOUT_PCT
+        return (pct / 100.0).coerceIn(0.0, 1.0).let { if (it == 0.0) DEFAULT_PAYOUT_PCT else it }
+    }
+
+    /**
+     * Live cooldown window for [guildId] in days — admin-set whole number
+     * parsed from `JACKPOT_WINNER_COOLDOWN_DAYS`. Returns
+     * [DEFAULT_WINNER_COOLDOWN_DAYS] (0 = disabled) when unset or
+     * unparseable; clamps to `[0, MAX_WINNER_COOLDOWN_DAYS]`.
+     */
+    fun winnerCooldownDays(configService: ConfigService, guildId: Long): Long {
+        val cfg = configService.getConfigByName(
+            ConfigDto.Configurations.JACKPOT_WINNER_COOLDOWN_DAYS.configValue,
+            guildId.toString()
+        )
+        val days = cfg?.value?.toLongOrNull() ?: return DEFAULT_WINNER_COOLDOWN_DAYS
+        return days.coerceIn(0L, MAX_WINNER_COOLDOWN_DAYS)
+    }
+
+    /**
+     * Live activity-eligibility window for [guildId] in days — admin-set
+     * whole number parsed from `JACKPOT_ACTIVITY_WINDOW_DAYS`. Returns
+     * [DEFAULT_ACTIVITY_WINDOW_DAYS] (0 = gate disabled) when unset or
+     * unparseable; clamps to `[0, MAX_ACTIVITY_WINDOW_DAYS]`.
+     */
+    fun activityWindowDays(configService: ConfigService, guildId: Long): Long {
+        val cfg = configService.getConfigByName(
+            ConfigDto.Configurations.JACKPOT_ACTIVITY_WINDOW_DAYS.configValue,
+            guildId.toString()
+        )
+        val days = cfg?.value?.toLongOrNull() ?: return DEFAULT_ACTIVITY_WINDOW_DAYS
+        return days.coerceIn(0L, MAX_ACTIVITY_WINDOW_DAYS)
+    }
+
+    /**
+     * Live minimum-activity-day requirement for [guildId] — admin-set
+     * whole number parsed from `JACKPOT_ACTIVITY_MIN_DAYS`. Returns
+     * [DEFAULT_ACTIVITY_MIN_DAYS] when unset or unparseable; coerces to
+     * `>= 1L`. Only consulted when the activity window is `> 0`.
+     */
+    fun activityMinDays(configService: ConfigService, guildId: Long): Long {
+        val cfg = configService.getConfigByName(
+            ConfigDto.Configurations.JACKPOT_ACTIVITY_MIN_DAYS.configValue,
+            guildId.toString()
+        )
+        val days = cfg?.value?.toLongOrNull() ?: return DEFAULT_ACTIVITY_MIN_DAYS
+        return days.coerceAtLeast(1L)
     }
 }

--- a/database/src/main/kotlin/database/service/JackpotLotteryService.kt
+++ b/database/src/main/kotlin/database/service/JackpotLotteryService.kt
@@ -46,7 +46,6 @@ class JackpotLotteryService(
     private val jackpotService: JackpotService,
     private val userService: UserService,
     private val random: Random = Random.Default,
-    private val clock: () -> Instant = { Instant.now() },
 ) {
 
     sealed interface OpenOutcome {
@@ -112,7 +111,7 @@ class JackpotLotteryService(
 
         val drained = drainFromPool(guildId, seed)
 
-        val now = clock()
+        val now = Instant.now()
         val lottery = JackpotLotteryDto(
             guildId = guildId,
             ticketPrice = ticketPrice,

--- a/database/src/main/kotlin/database/service/JackpotLotteryService.kt
+++ b/database/src/main/kotlin/database/service/JackpotLotteryService.kt
@@ -1,0 +1,340 @@
+package database.service
+
+import database.dto.JackpotLotteryDto
+import database.dto.JackpotLotteryTicketDto
+import database.persistence.JackpotLotteryPersistence
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+import kotlin.math.max
+import kotlin.random.Random
+
+/**
+ * Per-guild jackpot-pool lottery events.
+ *
+ * Admins fire one of these to drain a runaway jackpot pool through a
+ * ticketed multi-winner draw rather than letting one casino-roll
+ * winner sweep the whole thing. Workflow:
+ *
+ *   1. [openLottery] — admin sets ticket price, duration, winner count
+ *      and what fraction of the current pool seeds the prize. The seed
+ *      amount is moved out of the per-guild jackpot row and parked on
+ *      the lottery row's `pool_amount`.
+ *   2. [buyTickets] — players spend credits; each purchase increments
+ *      their ticket row and adds the spend to the lottery's prize
+ *      `pool_amount` (so the prize grows with engagement).
+ *   3. [drawLottery] — admin closes the lottery: weighted draw without
+ *      replacement (probability ∝ ticket_count) picks `winner_count`
+ *      winners, prize splits 50/30/20-style across them, winners are
+ *      credited and recorded against [JackpotService.recordWin] so the
+ *      cooldown gate covers both lottery and casino-roll wins.
+ *   4. [cancelLottery] — admin cancels: every ticket buyer is refunded
+ *      what they spent, the seed `pool_amount` returns to the per-guild
+ *      jackpot row, and the lottery is marked CANCELLED.
+ *
+ * Concurrency: every mutation runs inside a `@Transactional` boundary
+ * with a pessimistic write lock on the lottery row. Per-user ticket
+ * rows are also locked on update so two simultaneous /lottery buy calls
+ * from the same user can't double-spend their balance. Only one OPEN
+ * lottery may exist per guild at a time, enforced by a partial unique
+ * index in V27.
+ */
+@Service
+@Transactional
+class JackpotLotteryService(
+    private val lotteryPersistence: JackpotLotteryPersistence,
+    private val jackpotService: JackpotService,
+    private val userService: UserService,
+    private val random: Random = Random.Default,
+    private val clock: () -> Instant = { Instant.now() },
+) {
+
+    sealed interface OpenOutcome {
+        data class Ok(val lottery: JackpotLotteryDto, val seeded: Long) : OpenOutcome
+        data object AlreadyOpen : OpenOutcome
+        data class InvalidParams(val reason: String) : OpenOutcome
+        data object EmptyPool : OpenOutcome
+    }
+
+    sealed interface BuyOutcome {
+        data class Ok(
+            val ticketCount: Int,
+            val totalSpent: Long,
+            val newBalance: Long,
+            val newPool: Long,
+        ) : BuyOutcome
+        data object NoOpenLottery : BuyOutcome
+        data class InvalidCount(val ticketCount: Int) : BuyOutcome
+        data class Insufficient(val have: Long, val need: Long) : BuyOutcome
+        data object UnknownUser : BuyOutcome
+    }
+
+    sealed interface DrawOutcome {
+        data class Ok(
+            val payouts: List<WinnerPayout>,
+            val totalPaid: Long,
+            val drained: Long,
+        ) : DrawOutcome
+        data object NoOpenLottery : DrawOutcome
+        data object NoTickets : DrawOutcome
+    }
+
+    sealed interface CancelOutcome {
+        data class Ok(val refundedUsers: Int, val refundedTotal: Long, val returnedToPool: Long) : CancelOutcome
+        data object NoOpenLottery : CancelOutcome
+    }
+
+    data class WinnerPayout(val discordId: Long, val ticketCount: Int, val amount: Long)
+
+    /**
+     * Open a new lottery for [guildId]. Pulls `floor(currentPool * drainPct)`
+     * out of the per-guild jackpot pool and parks it on the lottery row.
+     * Rejects if a lottery is already open, params are invalid, or the
+     * pool is empty (nothing to drain).
+     */
+    fun openLottery(
+        guildId: Long,
+        ticketPrice: Long,
+        durationHours: Long,
+        winnerCount: Int,
+        drainPct: Double,
+    ): OpenOutcome {
+        if (ticketPrice <= 0L) return OpenOutcome.InvalidParams("ticket price must be > 0")
+        if (durationHours <= 0L) return OpenOutcome.InvalidParams("duration must be > 0 hours")
+        if (winnerCount < 1) return OpenOutcome.InvalidParams("winner count must be >= 1")
+        if (drainPct <= 0.0 || drainPct > 1.0) return OpenOutcome.InvalidParams("drain pct must be in (0, 1]")
+
+        if (lotteryPersistence.getOpenByGuildForUpdate(guildId) != null) return OpenOutcome.AlreadyOpen
+
+        val poolBefore = jackpotService.getPool(guildId)
+        if (poolBefore == 0L) return OpenOutcome.EmptyPool
+        val seed = kotlin.math.floor(poolBefore * drainPct).toLong().coerceAtMost(poolBefore).coerceAtLeast(1L)
+
+        val drained = drainFromPool(guildId, seed)
+
+        val now = clock()
+        val lottery = JackpotLotteryDto(
+            guildId = guildId,
+            ticketPrice = ticketPrice,
+            poolAmount = drained,
+            winnerCount = winnerCount,
+            openedAt = now,
+            closesAt = now.plusSeconds(durationHours * 3600L),
+            status = JackpotLotteryDto.STATUS_OPEN,
+        )
+        return OpenOutcome.Ok(lotteryPersistence.upsert(lottery), seeded = drained)
+    }
+
+    /**
+     * Buy [ticketCount] tickets in the open lottery for [guildId].
+     * Debits the user's social_credit, increments the ticket row, and
+     * adds the spend to the lottery's prize pool.
+     */
+    fun buyTickets(guildId: Long, discordId: Long, ticketCount: Int): BuyOutcome {
+        if (ticketCount <= 0) return BuyOutcome.InvalidCount(ticketCount)
+        val lottery = lotteryPersistence.getOpenByGuildForUpdate(guildId)
+            ?: return BuyOutcome.NoOpenLottery
+
+        val cost = lottery.ticketPrice * ticketCount.toLong()
+
+        val user = userService.getUserByIdForUpdate(discordId, guildId)
+            ?: return BuyOutcome.UnknownUser
+        val balance = user.socialCredit ?: 0L
+        if (balance < cost) return BuyOutcome.Insufficient(have = balance, need = cost)
+
+        user.socialCredit = balance - cost
+        userService.updateUser(user)
+
+        val lotteryId = lottery.id ?: error("Open lottery has no id")
+        val existing = lotteryPersistence.getTicketForUpdate(lotteryId, discordId)
+        val updatedTicket = if (existing == null) {
+            JackpotLotteryTicketDto(
+                lotteryId = lotteryId,
+                discordId = discordId,
+                ticketCount = ticketCount,
+                spent = cost,
+            )
+        } else {
+            existing.ticketCount += ticketCount
+            existing.spent += cost
+            existing
+        }
+        lotteryPersistence.upsertTicket(updatedTicket)
+
+        lottery.poolAmount += cost
+        lotteryPersistence.upsert(lottery)
+
+        return BuyOutcome.Ok(
+            ticketCount = updatedTicket.ticketCount,
+            totalSpent = updatedTicket.spent,
+            newBalance = user.socialCredit ?: (balance - cost),
+            newPool = lottery.poolAmount,
+        )
+    }
+
+    /**
+     * Close the open lottery for [guildId]. Picks `winner_count` winners
+     * via weighted draw without replacement; splits `pool_amount`
+     * across them with a 50/30/20-style schedule (single winner gets
+     * 100 %); credits each, records the wins for cooldown, and marks
+     * the lottery DRAWN.
+     */
+    fun drawLottery(guildId: Long): DrawOutcome {
+        val lottery = lotteryPersistence.getOpenByGuildForUpdate(guildId)
+            ?: return DrawOutcome.NoOpenLottery
+        val lotteryId = lottery.id ?: error("Open lottery has no id")
+        val tickets = lotteryPersistence.ticketsByLottery(lotteryId)
+        if (tickets.isEmpty() || tickets.sumOf { it.ticketCount.toLong() } == 0L) return DrawOutcome.NoTickets
+
+        val winnerSlots = lottery.winnerCount.coerceAtLeast(1)
+        val winners = drawWinners(tickets, winnerSlots, random)
+        val shares = prizeShares(winnerSlots, lottery.poolAmount)
+
+        val payouts = mutableListOf<WinnerPayout>()
+        var totalPaid = 0L
+        winners.forEachIndexed { index, ticket ->
+            val amount = shares.getOrNull(index) ?: 0L
+            if (amount <= 0L) return@forEachIndexed
+            val user = userService.getUserByIdForUpdate(ticket.discordId, guildId) ?: return@forEachIndexed
+            user.socialCredit = (user.socialCredit ?: 0L) + amount
+            userService.updateUser(user)
+            jackpotService.recordWin(guildId, ticket.discordId, amount)
+            payouts += WinnerPayout(ticket.discordId, ticket.ticketCount, amount)
+            totalPaid += amount
+        }
+
+        val drained = lottery.poolAmount
+        lottery.poolAmount = 0L
+        lottery.status = JackpotLotteryDto.STATUS_DRAWN
+        lotteryPersistence.upsert(lottery)
+
+        // Any rounding remainder (e.g. odd-number split) goes back into
+        // the per-guild jackpot pool rather than vanishing.
+        val remainder = drained - totalPaid
+        if (remainder > 0L) jackpotService.addToPool(guildId, remainder)
+
+        return DrawOutcome.Ok(payouts = payouts, totalPaid = totalPaid, drained = drained)
+    }
+
+    /**
+     * Cancel the open lottery for [guildId]: refund every buyer the
+     * credits they spent, return `pool_amount` to the per-guild
+     * jackpot pool, and mark the row CANCELLED.
+     */
+    fun cancelLottery(guildId: Long): CancelOutcome {
+        val lottery = lotteryPersistence.getOpenByGuildForUpdate(guildId)
+            ?: return CancelOutcome.NoOpenLottery
+        val lotteryId = lottery.id ?: error("Open lottery has no id")
+        val tickets = lotteryPersistence.ticketsByLottery(lotteryId)
+
+        var refundedTotal = 0L
+        var refundedUsers = 0
+        for (t in tickets) {
+            if (t.spent <= 0L) continue
+            val user = userService.getUserByIdForUpdate(t.discordId, guildId) ?: continue
+            user.socialCredit = (user.socialCredit ?: 0L) + t.spent
+            userService.updateUser(user)
+            refundedTotal += t.spent
+            refundedUsers++
+        }
+
+        val seedReturn = (lottery.poolAmount - refundedTotal).coerceAtLeast(0L)
+        if (seedReturn > 0L) jackpotService.addToPool(guildId, seedReturn)
+
+        lottery.poolAmount = 0L
+        lottery.status = JackpotLotteryDto.STATUS_CANCELLED
+        lotteryPersistence.upsert(lottery)
+
+        return CancelOutcome.Ok(refundedUsers, refundedTotal, returnedToPool = seedReturn)
+    }
+
+    /** Read-only summary for `/lottery status` and the moderation tab. */
+    fun getOpen(guildId: Long): JackpotLotteryDto? = lotteryPersistence.getOpenByGuild(guildId)
+
+    fun ticketsForOpen(guildId: Long): List<JackpotLotteryTicketDto> {
+        val open = lotteryPersistence.getOpenByGuild(guildId) ?: return emptyList()
+        val id = open.id ?: return emptyList()
+        return lotteryPersistence.ticketsByLottery(id)
+    }
+
+    /**
+     * Pick [count] winners by ticket-weighted draw without replacement.
+     * The same physical ticket can never win twice; once a holder is
+     * picked, their entire ticket count is removed from the bag for the
+     * subsequent picks. If [count] exceeds the number of distinct
+     * holders, the result is shorter than [count] (the prize for the
+     * unfilled slots rolls back into the per-guild pool via the
+     * remainder-handling in [drawLottery]).
+     */
+    internal fun drawWinners(
+        tickets: List<JackpotLotteryTicketDto>,
+        count: Int,
+        random: Random,
+    ): List<JackpotLotteryTicketDto> {
+        val remaining = tickets.toMutableList()
+        val winners = mutableListOf<JackpotLotteryTicketDto>()
+        repeat(count) {
+            if (remaining.isEmpty()) return@repeat
+            val totalWeight = remaining.sumOf { it.ticketCount.toLong() }
+            if (totalWeight <= 0L) return@repeat
+            var roll = random.nextLong(totalWeight)
+            val it = remaining.iterator()
+            while (it.hasNext()) {
+                val t = it.next()
+                if (roll < t.ticketCount) {
+                    winners += t
+                    it.remove()
+                    return@repeat
+                }
+                roll -= t.ticketCount
+            }
+        }
+        return winners
+    }
+
+    /**
+     * Split [pool] across [slots] winner slots. Schedule:
+     *  - 1 winner: 100
+     *  - 2 winners: 60/40
+     *  - 3 winners: 50/30/20
+     *  - 4 winners: 40/30/20/10
+     *  - 5+ winners: linear taper that always sums to 100
+     * Floor each share to a whole credit; the rounding remainder is
+     * handled by [drawLottery] (sent back into the per-guild jackpot).
+     */
+    internal fun prizeShares(slots: Int, pool: Long): List<Long> {
+        if (slots <= 0 || pool <= 0L) return emptyList()
+        val pcts: DoubleArray = when (slots) {
+            1 -> doubleArrayOf(1.0)
+            2 -> doubleArrayOf(0.6, 0.4)
+            3 -> doubleArrayOf(0.5, 0.3, 0.2)
+            4 -> doubleArrayOf(0.4, 0.3, 0.2, 0.1)
+            else -> {
+                // Linear taper: weight i = (slots - i); normalise.
+                val raw = DoubleArray(slots) { (slots - it).toDouble() }
+                val sum = raw.sum().coerceAtLeast(1.0)
+                DoubleArray(slots) { raw[it] / sum }
+            }
+        }
+        return pcts.map { max(0L, kotlin.math.floor(pool * it).toLong()) }
+    }
+
+    /**
+     * Decrement the per-guild jackpot row by [amount]. Mirrors the lock
+     * + mutate + upsert idiom in `JackpotService.awardJackpot` so the
+     * draw doesn't leak credits and matches the same concurrency
+     * contract. Caller must already be inside a @Transactional boundary.
+     */
+    private fun drainFromPool(guildId: Long, amount: Long): Long {
+        if (amount <= 0L) return 0L
+        // We don't have a public partial-drain on JackpotService; reset
+        // and re-deposit the leftover — a single transaction so the pool
+        // never observably gaps. This matches the resetPool→addToPool
+        // sequence the moderation flow already uses.
+        val pool = jackpotService.resetPool(guildId)
+        val drained = amount.coerceAtMost(pool)
+        val leftover = pool - drained
+        if (leftover > 0L) jackpotService.addToPool(guildId, leftover)
+        return drained
+    }
+}

--- a/database/src/main/kotlin/database/service/JackpotService.kt
+++ b/database/src/main/kotlin/database/service/JackpotService.kt
@@ -1,24 +1,51 @@
 package database.service
 
 import database.dto.TobyCoinJackpotDto
+import database.dto.TobyCoinJackpotWinnerDto
 import database.persistence.TobyCoinJackpotPersistence
+import database.persistence.TobyCoinJackpotWinnerPersistence
+import database.persistence.VoiceCreditDailyPersistence
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.Duration
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneOffset
 
 /**
  * Atomic operations on the per-guild jackpot pool.
  *
  * The pool is fed by a flat fee on every Toby Coin trade (see
  * [EconomyTradeService]). Casino minigame wins roll a small chance to
- * hit the jackpot — on a hit the player banks the entire pool and the
- * counter resets to zero. All mutations go through pessimistic row
- * locks so two concurrent winners can't both bank the same pool.
+ * hit the jackpot — on a hit the player banks a configurable share of
+ * the pool ([JackpotHelper.payoutPct]; default 100 %, can be lowered to
+ * leave a re-seed remainder), and the pool counter drops accordingly.
+ *
+ * Three structural gates layer on top of the basic roll:
+ *  - [isOnCooldown] blocks a recent winner from sweeping again within
+ *    `JACKPOT_WINNER_COOLDOWN_DAYS`. Each successful win records the
+ *    timestamp via [recordWin].
+ *  - [isActive] requires the candidate winner to have actually been
+ *    around in the last `JACKPOT_ACTIVITY_WINDOW_DAYS` (sourced from
+ *    `voice_credit_daily`). A drive-by user with one bet can't run the
+ *    pool dry.
+ *  - [JackpotHelper.payoutPct] caps the share of the pool paid out on a
+ *    single roll.
+ *
+ * All defaults match the historic single-winner-takes-all behaviour, so
+ * a guild that never touches the new configs sees no change.
+ *
+ * All mutations go through pessimistic row locks so two concurrent
+ * winners can't both bank the same pool.
  */
 @Service
 @Transactional
 class JackpotService(
     private val persistence: TobyCoinJackpotPersistence,
     private val configService: ConfigService,
+    private val winnerPersistence: TobyCoinJackpotWinnerPersistence,
+    private val voiceCreditDailyPersistence: VoiceCreditDailyPersistence,
+    private val clock: () -> Instant = { Instant.now() },
 ) {
 
     /** Current pool size; 0 if no row yet for this guild. */
@@ -51,16 +78,18 @@ class JackpotService(
     }
 
     /**
-     * Pay out the entire pool atomically. Returns the amount that was
-     * in the pool at the moment of the lock; caller is responsible for
-     * crediting that amount to the winner. Pool is set to zero in the
-     * same transaction.
+     * Pay out a share of the pool atomically. The share is configurable
+     * via `JACKPOT_PAYOUT_PCT` (default 100 % = full pool). Returns the
+     * amount paid; caller is responsible for crediting the winner.
+     * The remainder stays in the pool and re-seeds the next cycle.
      */
     fun awardJackpot(guildId: Long): Long {
         val row = lockOrCreate(guildId)
-        val won = row.pool
+        if (row.pool == 0L) return 0L
+        val pct = JackpotHelper.payoutPct(configService, guildId)
+        val won = kotlin.math.floor(row.pool * pct).toLong().coerceAtMost(row.pool).coerceAtLeast(0L)
         if (won == 0L) return 0L
-        row.pool = 0L
+        row.pool -= won
         persistence.upsert(row)
         return won
     }
@@ -79,6 +108,60 @@ class JackpotService(
         row.pool = 0L
         persistence.upsert(row)
         return drained
+    }
+
+    /**
+     * Persist a jackpot win for the cooldown gate. Called after a
+     * successful payout from `JackpotHelper.rollOnWin` or from
+     * `JackpotLotteryService.drawLottery` so a single user can't sweep
+     * both a casino-roll jackpot and a lottery jackpot within the
+     * configured cooldown window.
+     */
+    fun recordWin(guildId: Long, discordId: Long, amount: Long) {
+        if (amount <= 0L) return
+        winnerPersistence.upsert(
+            TobyCoinJackpotWinnerDto(
+                guildId = guildId,
+                discordId = discordId,
+                lastWonAt = clock(),
+                lastWonAmount = amount,
+            )
+        )
+    }
+
+    /**
+     * Returns true when [discordId] won a jackpot in [guildId] within
+     * the last `JACKPOT_WINNER_COOLDOWN_DAYS` (gate disabled when the
+     * config is 0 / unset, in which case this always returns false).
+     */
+    fun isOnCooldown(guildId: Long, discordId: Long): Boolean {
+        val days = JackpotHelper.winnerCooldownDays(configService, guildId)
+        if (days <= 0L) return false
+        val row = winnerPersistence.get(guildId, discordId) ?: return false
+        val elapsed = Duration.between(row.lastWonAt, clock())
+        return elapsed < Duration.ofDays(days)
+    }
+
+    /**
+     * Returns true when [discordId] meets the per-guild activity
+     * threshold — i.e. has earned credit-cap-eligible amounts on at
+     * least `JACKPOT_ACTIVITY_MIN_DAYS` distinct days within the last
+     * `JACKPOT_ACTIVITY_WINDOW_DAYS`. Gate disabled (returns true
+     * unconditionally) when the window config is 0 / unset.
+     *
+     * `voice_credit_daily` is the activity proxy because every existing
+     * earn path (voice, commands, intros, web UI) routes through it,
+     * so a user who hasn't shown up at all won't have rows.
+     */
+    fun isActive(guildId: Long, discordId: Long): Boolean {
+        val window = JackpotHelper.activityWindowDays(configService, guildId)
+        if (window <= 0L) return true
+        val minDays = JackpotHelper.activityMinDays(configService, guildId)
+        val today = LocalDate.ofInstant(clock(), ZoneOffset.UTC)
+        // Inclusive `from` covers exactly `window` days of history including today.
+        val from = today.minusDays(window - 1L)
+        val days = voiceCreditDailyPersistence.countDaysSince(discordId, guildId, from)
+        return days >= minDays
     }
 
     private fun lockOrCreate(guildId: Long): TobyCoinJackpotDto {

--- a/database/src/main/kotlin/database/service/JackpotService.kt
+++ b/database/src/main/kotlin/database/service/JackpotService.kt
@@ -45,7 +45,6 @@ class JackpotService(
     private val configService: ConfigService,
     private val winnerPersistence: TobyCoinJackpotWinnerPersistence,
     private val voiceCreditDailyPersistence: VoiceCreditDailyPersistence,
-    private val clock: () -> Instant = { Instant.now() },
 ) {
 
     /** Current pool size; 0 if no row yet for this guild. */
@@ -117,13 +116,13 @@ class JackpotService(
      * both a casino-roll jackpot and a lottery jackpot within the
      * configured cooldown window.
      */
-    fun recordWin(guildId: Long, discordId: Long, amount: Long) {
+    fun recordWin(guildId: Long, discordId: Long, amount: Long, at: Instant = Instant.now()) {
         if (amount <= 0L) return
         winnerPersistence.upsert(
             TobyCoinJackpotWinnerDto(
                 guildId = guildId,
                 discordId = discordId,
-                lastWonAt = clock(),
+                lastWonAt = at,
                 lastWonAmount = amount,
             )
         )
@@ -134,11 +133,11 @@ class JackpotService(
      * the last `JACKPOT_WINNER_COOLDOWN_DAYS` (gate disabled when the
      * config is 0 / unset, in which case this always returns false).
      */
-    fun isOnCooldown(guildId: Long, discordId: Long): Boolean {
+    fun isOnCooldown(guildId: Long, discordId: Long, at: Instant = Instant.now()): Boolean {
         val days = JackpotHelper.winnerCooldownDays(configService, guildId)
         if (days <= 0L) return false
         val row = winnerPersistence.get(guildId, discordId) ?: return false
-        val elapsed = Duration.between(row.lastWonAt, clock())
+        val elapsed = Duration.between(row.lastWonAt, at)
         return elapsed < Duration.ofDays(days)
     }
 
@@ -153,11 +152,11 @@ class JackpotService(
      * earn path (voice, commands, intros, web UI) routes through it,
      * so a user who hasn't shown up at all won't have rows.
      */
-    fun isActive(guildId: Long, discordId: Long): Boolean {
+    fun isActive(guildId: Long, discordId: Long, at: Instant = Instant.now()): Boolean {
         val window = JackpotHelper.activityWindowDays(configService, guildId)
         if (window <= 0L) return true
         val minDays = JackpotHelper.activityMinDays(configService, guildId)
-        val today = LocalDate.ofInstant(clock(), ZoneOffset.UTC)
+        val today = LocalDate.ofInstant(at, ZoneOffset.UTC)
         // Inclusive `from` covers exactly `window` days of history including today.
         val from = today.minusDays(window - 1L)
         val days = voiceCreditDailyPersistence.countDaysSince(discordId, guildId, from)

--- a/database/src/main/resources/db/migration/V26__toby_coin_jackpot_winner.sql
+++ b/database/src/main/resources/db/migration/V26__toby_coin_jackpot_winner.sql
@@ -1,0 +1,21 @@
+-- Jackpot winner cooldown tracking. One row per (guild, user) with the
+-- timestamp of their most recent jackpot win.
+--
+-- JackpotService.isOnCooldown compares now() - last_won_at against the
+-- per-guild JACKPOT_WINNER_COOLDOWN_DAYS config to block repeat winners
+-- within the configured window. Applies to both casino-roll wins (the
+-- existing rollOnWin path in JackpotHelper) and lottery draw wins
+-- (drawLottery in JackpotLotteryService) so the same player can't sweep
+-- both within the cooldown.
+--
+-- Default cooldown is 0 days (gate disabled, current behaviour); rows
+-- still get written so admins can later flip the cooldown on without
+-- having to backfill history.
+
+CREATE TABLE toby_coin_jackpot_winner (
+    guild_id        BIGINT                   NOT NULL,
+    discord_id      BIGINT                   NOT NULL,
+    last_won_at     TIMESTAMP WITH TIME ZONE NOT NULL,
+    last_won_amount BIGINT                   NOT NULL CHECK (last_won_amount >= 0),
+    PRIMARY KEY (guild_id, discord_id)
+);

--- a/database/src/main/resources/db/migration/V27__toby_coin_jackpot_lottery.sql
+++ b/database/src/main/resources/db/migration/V27__toby_coin_jackpot_lottery.sql
@@ -1,0 +1,41 @@
+-- Per-guild jackpot lottery events.
+--
+-- Admins fire `/jackpotadmin lottery_open` to drain a runaway jackpot
+-- pool through a ticketed multi-winner draw rather than letting one
+-- casino-roll winner sweep the whole thing. The opening admin chooses
+-- ticket price, duration, winner count, and what fraction of the
+-- current pool seeds the prize. Players then `/lottery buy` tickets
+-- (credits go into the lottery's prize pool, not the jackpot row), and
+-- the admin closes via `/jackpotadmin lottery_draw` (split prize across
+-- weighted winners) or `lottery_cancel` (refund tickets, return seed
+-- pool to the jackpot).
+--
+-- A lottery is OPEN until the admin runs draw or cancel; closes_at is
+-- informational/UI only — closes are admin-driven, not auto. Only one
+-- OPEN lottery may exist per guild at a time, enforced by a partial
+-- unique index.
+
+CREATE TABLE toby_coin_jackpot_lottery (
+    id            BIGSERIAL PRIMARY KEY,
+    guild_id      BIGINT                   NOT NULL,
+    ticket_price  BIGINT                   NOT NULL CHECK (ticket_price > 0),
+    pool_amount   BIGINT                   NOT NULL CHECK (pool_amount >= 0),
+    winner_count  INT                      NOT NULL CHECK (winner_count >= 1),
+    opened_at     TIMESTAMP WITH TIME ZONE NOT NULL,
+    closes_at     TIMESTAMP WITH TIME ZONE NOT NULL,
+    status        VARCHAR(16)              NOT NULL CHECK (status IN ('OPEN','DRAWN','CANCELLED'))
+);
+
+-- Only one OPEN row per guild — partial unique index avoids two admins
+-- racing to open simultaneously and produces a clean unique-violation
+-- the service can translate to a friendly "lottery already open" error.
+CREATE UNIQUE INDEX toby_coin_jackpot_lottery_one_open_per_guild
+    ON toby_coin_jackpot_lottery (guild_id) WHERE status = 'OPEN';
+
+CREATE TABLE toby_coin_jackpot_lottery_ticket (
+    lottery_id   BIGINT NOT NULL REFERENCES toby_coin_jackpot_lottery(id) ON DELETE CASCADE,
+    discord_id   BIGINT NOT NULL,
+    ticket_count INT    NOT NULL CHECK (ticket_count > 0),
+    spent        BIGINT NOT NULL CHECK (spent >= 0),
+    PRIMARY KEY (lottery_id, discord_id)
+);

--- a/database/src/test/kotlin/database/service/JackpotHelperTest.kt
+++ b/database/src/test/kotlin/database/service/JackpotHelperTest.kt
@@ -25,6 +25,11 @@ class JackpotHelperTest {
         jackpotService = mockk(relaxed = true)
         userService = mockk(relaxed = true)
         configService = mockk(relaxed = true)
+        // Default the post-fraud gates to "pass" so the legacy probability
+        // tests below stay focused on the random-roll mechanics. Gate-
+        // specific tests override these stubs below.
+        every { jackpotService.isOnCooldown(any(), any()) } returns false
+        every { jackpotService.isActive(any(), any()) } returns true
     }
 
     private fun configReturns(value: String?) {
@@ -403,5 +408,164 @@ class JackpotHelperTest {
         )
 
         assertEquals(100L, won)
+    }
+
+    // ---- post-fraud gates: cooldown, activity, recordWin ----
+
+    @Test
+    fun `rollOnWin blocks payout when winner is on cooldown`() {
+        winConfigReturns("1")
+        anchorConfigReturns(MAX_STAKE.toString())
+        every { jackpotService.isOnCooldown(guildId, discordId) } returns true
+        val user = freshUser(initial = 100L)
+
+        val won = JackpotHelper.rollOnWin(
+            jackpotService, configService, userService, user, guildId,
+            stake = MAX_STAKE, random = stubRandom(0.001)
+        )
+
+        assertEquals(0L, won, "blocked by cooldown gate")
+        assertEquals(100L, user.socialCredit, "balance untouched on blocked gate")
+        verify(exactly = 0) { jackpotService.awardJackpot(any()) }
+        verify(exactly = 0) { jackpotService.recordWin(any(), any(), any()) }
+    }
+
+    @Test
+    fun `rollOnWin blocks payout when user is not active enough`() {
+        winConfigReturns("1")
+        anchorConfigReturns(MAX_STAKE.toString())
+        every { jackpotService.isActive(guildId, discordId) } returns false
+        val user = freshUser(initial = 100L)
+
+        val won = JackpotHelper.rollOnWin(
+            jackpotService, configService, userService, user, guildId,
+            stake = MAX_STAKE, random = stubRandom(0.001)
+        )
+
+        assertEquals(0L, won, "blocked by activity gate")
+        verify(exactly = 0) { jackpotService.awardJackpot(any()) }
+        verify(exactly = 0) { jackpotService.recordWin(any(), any(), any()) }
+    }
+
+    @Test
+    fun `rollOnWin records the win for cooldown tracking on a successful payout`() {
+        winConfigReturns("1")
+        anchorConfigReturns(MAX_STAKE.toString())
+        every { jackpotService.awardJackpot(guildId) } returns 250L
+        val user = freshUser()
+
+        val won = JackpotHelper.rollOnWin(
+            jackpotService, configService, userService, user, guildId,
+            stake = MAX_STAKE, random = stubRandom(0.001)
+        )
+
+        assertEquals(250L, won)
+        verify(exactly = 1) { jackpotService.recordWin(guildId, discordId, 250L) }
+    }
+
+    @Test
+    fun `rollOnWin does not record a no-op award (empty pool)`() {
+        winConfigReturns("1")
+        anchorConfigReturns(MAX_STAKE.toString())
+        every { jackpotService.awardJackpot(guildId) } returns 0L
+        val user = freshUser()
+
+        JackpotHelper.rollOnWin(
+            jackpotService, configService, userService, user, guildId,
+            stake = MAX_STAKE, random = stubRandom(0.001)
+        )
+
+        verify(exactly = 0) { jackpotService.recordWin(any(), any(), any()) }
+    }
+
+    // ---- payoutPct ----
+
+    @Test
+    fun `payoutPct returns the default fraction when no config row exists`() {
+        every {
+            configService.getConfigByName(
+                ConfigDto.Configurations.JACKPOT_PAYOUT_PCT.configValue,
+                guildId.toString()
+            )
+        } returns null
+        assertEquals(JackpotHelper.DEFAULT_PAYOUT_PCT, JackpotHelper.payoutPct(configService, guildId), 1e-9)
+    }
+
+    @Test
+    fun `payoutPct parses whole-number percent and clamps to 1 at 100 percent`() {
+        every {
+            configService.getConfigByName(
+                ConfigDto.Configurations.JACKPOT_PAYOUT_PCT.configValue,
+                guildId.toString()
+            )
+        } returns ConfigDto(name = "x", value = "30", guildId = guildId.toString())
+        assertEquals(0.30, JackpotHelper.payoutPct(configService, guildId), 1e-9)
+    }
+
+    @Test
+    fun `payoutPct treats zero or negative as missing (falls back to default)`() {
+        every {
+            configService.getConfigByName(
+                ConfigDto.Configurations.JACKPOT_PAYOUT_PCT.configValue,
+                guildId.toString()
+            )
+        } returns ConfigDto(name = "x", value = "0", guildId = guildId.toString())
+        assertEquals(JackpotHelper.DEFAULT_PAYOUT_PCT, JackpotHelper.payoutPct(configService, guildId), 1e-9)
+
+        every {
+            configService.getConfigByName(
+                ConfigDto.Configurations.JACKPOT_PAYOUT_PCT.configValue,
+                guildId.toString()
+            )
+        } returns ConfigDto(name = "x", value = "-10", guildId = guildId.toString())
+        assertEquals(JackpotHelper.DEFAULT_PAYOUT_PCT, JackpotHelper.payoutPct(configService, guildId), 1e-9)
+    }
+
+    // ---- winnerCooldownDays ----
+
+    @Test
+    fun `winnerCooldownDays defaults to disabled when unset`() {
+        every {
+            configService.getConfigByName(
+                ConfigDto.Configurations.JACKPOT_WINNER_COOLDOWN_DAYS.configValue,
+                guildId.toString()
+            )
+        } returns null
+        assertEquals(0L, JackpotHelper.winnerCooldownDays(configService, guildId))
+    }
+
+    @Test
+    fun `winnerCooldownDays clamps to MAX_WINNER_COOLDOWN_DAYS`() {
+        every {
+            configService.getConfigByName(
+                ConfigDto.Configurations.JACKPOT_WINNER_COOLDOWN_DAYS.configValue,
+                guildId.toString()
+            )
+        } returns ConfigDto(name = "x", value = "9999", guildId = guildId.toString())
+        assertEquals(JackpotHelper.MAX_WINNER_COOLDOWN_DAYS, JackpotHelper.winnerCooldownDays(configService, guildId))
+    }
+
+    // ---- activityWindowDays / activityMinDays ----
+
+    @Test
+    fun `activityWindowDays defaults to disabled when unset`() {
+        every {
+            configService.getConfigByName(
+                ConfigDto.Configurations.JACKPOT_ACTIVITY_WINDOW_DAYS.configValue,
+                guildId.toString()
+            )
+        } returns null
+        assertEquals(0L, JackpotHelper.activityWindowDays(configService, guildId))
+    }
+
+    @Test
+    fun `activityMinDays coerces to at least 1`() {
+        every {
+            configService.getConfigByName(
+                ConfigDto.Configurations.JACKPOT_ACTIVITY_MIN_DAYS.configValue,
+                guildId.toString()
+            )
+        } returns ConfigDto(name = "x", value = "0", guildId = guildId.toString())
+        assertEquals(1L, JackpotHelper.activityMinDays(configService, guildId))
     }
 }

--- a/database/src/test/kotlin/database/service/JackpotHelperTest.kt
+++ b/database/src/test/kotlin/database/service/JackpotHelperTest.kt
@@ -27,9 +27,11 @@ class JackpotHelperTest {
         configService = mockk(relaxed = true)
         // Default the post-fraud gates to "pass" so the legacy probability
         // tests below stay focused on the random-roll mechanics. Gate-
-        // specific tests override these stubs below.
-        every { jackpotService.isOnCooldown(any(), any()) } returns false
-        every { jackpotService.isActive(any(), any()) } returns true
+        // specific tests override these stubs below. The third matcher
+        // covers the `at: Instant = Instant.now()` default parameter — the
+        // bytecode call always has three args even when callers omit it.
+        every { jackpotService.isOnCooldown(any(), any(), any()) } returns false
+        every { jackpotService.isActive(any(), any(), any()) } returns true
     }
 
     private fun configReturns(value: String?) {
@@ -416,7 +418,7 @@ class JackpotHelperTest {
     fun `rollOnWin blocks payout when winner is on cooldown`() {
         winConfigReturns("1")
         anchorConfigReturns(MAX_STAKE.toString())
-        every { jackpotService.isOnCooldown(guildId, discordId) } returns true
+        every { jackpotService.isOnCooldown(guildId, discordId, any()) } returns true
         val user = freshUser(initial = 100L)
 
         val won = JackpotHelper.rollOnWin(
@@ -427,14 +429,14 @@ class JackpotHelperTest {
         assertEquals(0L, won, "blocked by cooldown gate")
         assertEquals(100L, user.socialCredit, "balance untouched on blocked gate")
         verify(exactly = 0) { jackpotService.awardJackpot(any()) }
-        verify(exactly = 0) { jackpotService.recordWin(any(), any(), any()) }
+        verify(exactly = 0) { jackpotService.recordWin(any(), any(), any(), any()) }
     }
 
     @Test
     fun `rollOnWin blocks payout when user is not active enough`() {
         winConfigReturns("1")
         anchorConfigReturns(MAX_STAKE.toString())
-        every { jackpotService.isActive(guildId, discordId) } returns false
+        every { jackpotService.isActive(guildId, discordId, any()) } returns false
         val user = freshUser(initial = 100L)
 
         val won = JackpotHelper.rollOnWin(
@@ -444,7 +446,7 @@ class JackpotHelperTest {
 
         assertEquals(0L, won, "blocked by activity gate")
         verify(exactly = 0) { jackpotService.awardJackpot(any()) }
-        verify(exactly = 0) { jackpotService.recordWin(any(), any(), any()) }
+        verify(exactly = 0) { jackpotService.recordWin(any(), any(), any(), any()) }
     }
 
     @Test
@@ -460,7 +462,7 @@ class JackpotHelperTest {
         )
 
         assertEquals(250L, won)
-        verify(exactly = 1) { jackpotService.recordWin(guildId, discordId, 250L) }
+        verify(exactly = 1) { jackpotService.recordWin(guildId, discordId, 250L, any()) }
     }
 
     @Test
@@ -475,7 +477,7 @@ class JackpotHelperTest {
             stake = MAX_STAKE, random = stubRandom(0.001)
         )
 
-        verify(exactly = 0) { jackpotService.recordWin(any(), any(), any()) }
+        verify(exactly = 0) { jackpotService.recordWin(any(), any(), any(), any()) }
     }
 
     // ---- payoutPct ----

--- a/database/src/test/kotlin/database/service/JackpotLotteryServiceTest.kt
+++ b/database/src/test/kotlin/database/service/JackpotLotteryServiceTest.kt
@@ -13,13 +13,11 @@ import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import java.time.Instant
 import kotlin.random.Random
 
 class JackpotLotteryServiceTest {
 
     private val guildId = 100L
-    private val now: Instant = Instant.parse("2026-05-08T12:00:00Z")
 
     private lateinit var lotteryPersistence: JackpotLotteryPersistence
     private lateinit var jackpotService: JackpotService
@@ -36,7 +34,6 @@ class JackpotLotteryServiceTest {
             jackpotService,
             userService,
             random = Random(42),
-            clock = { now },
         )
     }
 

--- a/database/src/test/kotlin/database/service/JackpotLotteryServiceTest.kt
+++ b/database/src/test/kotlin/database/service/JackpotLotteryServiceTest.kt
@@ -1,0 +1,275 @@
+package database.service
+
+import database.dto.JackpotLotteryDto
+import database.dto.JackpotLotteryTicketDto
+import database.dto.UserDto
+import database.persistence.JackpotLotteryPersistence
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import kotlin.random.Random
+
+class JackpotLotteryServiceTest {
+
+    private val guildId = 100L
+    private val now: Instant = Instant.parse("2026-05-08T12:00:00Z")
+
+    private lateinit var lotteryPersistence: JackpotLotteryPersistence
+    private lateinit var jackpotService: JackpotService
+    private lateinit var userService: UserService
+    private lateinit var service: JackpotLotteryService
+
+    @BeforeEach
+    fun setup() {
+        lotteryPersistence = mockk(relaxed = true)
+        jackpotService = mockk(relaxed = true)
+        userService = mockk(relaxed = true)
+        service = JackpotLotteryService(
+            lotteryPersistence,
+            jackpotService,
+            userService,
+            random = Random(42),
+            clock = { now },
+        )
+    }
+
+    @Test
+    fun `openLottery rejects invalid params`() {
+        val r = service.openLottery(guildId, ticketPrice = 0L, durationHours = 1, winnerCount = 1, drainPct = 1.0)
+        assertTrue(r is JackpotLotteryService.OpenOutcome.InvalidParams)
+
+        val r2 = service.openLottery(guildId, ticketPrice = 10L, durationHours = 0, winnerCount = 1, drainPct = 1.0)
+        assertTrue(r2 is JackpotLotteryService.OpenOutcome.InvalidParams)
+
+        val r3 = service.openLottery(guildId, ticketPrice = 10L, durationHours = 1, winnerCount = 0, drainPct = 1.0)
+        assertTrue(r3 is JackpotLotteryService.OpenOutcome.InvalidParams)
+
+        val r4 = service.openLottery(guildId, ticketPrice = 10L, durationHours = 1, winnerCount = 1, drainPct = 1.5)
+        assertTrue(r4 is JackpotLotteryService.OpenOutcome.InvalidParams)
+    }
+
+    @Test
+    fun `openLottery rejects when one is already open`() {
+        every { lotteryPersistence.getOpenByGuildForUpdate(guildId) } returns JackpotLotteryDto(
+            id = 1L, guildId = guildId, status = JackpotLotteryDto.STATUS_OPEN
+        )
+
+        val r = service.openLottery(guildId, ticketPrice = 100L, durationHours = 24, winnerCount = 3, drainPct = 1.0)
+        assertEquals(JackpotLotteryService.OpenOutcome.AlreadyOpen, r)
+    }
+
+    @Test
+    fun `openLottery rejects on empty pool`() {
+        every { lotteryPersistence.getOpenByGuildForUpdate(guildId) } returns null
+        every { jackpotService.getPool(guildId) } returns 0L
+
+        val r = service.openLottery(guildId, ticketPrice = 100L, durationHours = 24, winnerCount = 3, drainPct = 1.0)
+        assertEquals(JackpotLotteryService.OpenOutcome.EmptyPool, r)
+    }
+
+    @Test
+    fun `openLottery seeds the lottery from a fraction of the jackpot pool`() {
+        every { lotteryPersistence.getOpenByGuildForUpdate(guildId) } returns null
+        every { jackpotService.getPool(guildId) } returns 110_000L
+        every { jackpotService.resetPool(guildId) } returns 110_000L
+        val saved = slot<JackpotLotteryDto>()
+        every { lotteryPersistence.upsert(capture(saved)) } answers { saved.captured.also { it.id = 99L } }
+
+        val r = service.openLottery(guildId, ticketPrice = 100L, durationHours = 48, winnerCount = 3, drainPct = 0.5)
+        assertTrue(r is JackpotLotteryService.OpenOutcome.Ok)
+        r as JackpotLotteryService.OpenOutcome.Ok
+        assertEquals(55_000L, r.seeded)
+        assertEquals(JackpotLotteryDto.STATUS_OPEN, saved.captured.status)
+        assertEquals(100L, saved.captured.ticketPrice)
+        assertEquals(3, saved.captured.winnerCount)
+        // Leftover (55k) returned to the jackpot.
+        verify(exactly = 1) { jackpotService.addToPool(guildId, 55_000L) }
+    }
+
+    @Test
+    fun `buyTickets rejects when no lottery is open`() {
+        every { lotteryPersistence.getOpenByGuildForUpdate(guildId) } returns null
+
+        assertEquals(
+            JackpotLotteryService.BuyOutcome.NoOpenLottery,
+            service.buyTickets(guildId, discordId = 7L, ticketCount = 5)
+        )
+    }
+
+    @Test
+    fun `buyTickets rejects when user can't afford`() {
+        every { lotteryPersistence.getOpenByGuildForUpdate(guildId) } returns JackpotLotteryDto(
+            id = 1L, guildId = guildId, ticketPrice = 100L, status = JackpotLotteryDto.STATUS_OPEN
+        )
+        val user = UserDto(discordId = 7L, guildId = guildId).apply { socialCredit = 200L }
+        every { userService.getUserByIdForUpdate(7L, guildId) } returns user
+
+        val r = service.buyTickets(guildId, discordId = 7L, ticketCount = 5)
+        assertTrue(r is JackpotLotteryService.BuyOutcome.Insufficient)
+        r as JackpotLotteryService.BuyOutcome.Insufficient
+        assertEquals(200L, r.have)
+        assertEquals(500L, r.need)
+    }
+
+    @Test
+    fun `buyTickets debits user, increments tickets, grows pool`() {
+        val lottery = JackpotLotteryDto(
+            id = 1L, guildId = guildId, ticketPrice = 100L, poolAmount = 1000L,
+            status = JackpotLotteryDto.STATUS_OPEN
+        )
+        every { lotteryPersistence.getOpenByGuildForUpdate(guildId) } returns lottery
+        val user = UserDto(discordId = 7L, guildId = guildId).apply { socialCredit = 1_000L }
+        every { userService.getUserByIdForUpdate(7L, guildId) } returns user
+        every { lotteryPersistence.getTicketForUpdate(1L, 7L) } returns null
+
+        val r = service.buyTickets(guildId, discordId = 7L, ticketCount = 5)
+        assertTrue(r is JackpotLotteryService.BuyOutcome.Ok)
+        r as JackpotLotteryService.BuyOutcome.Ok
+        assertEquals(5, r.ticketCount)
+        assertEquals(500L, r.totalSpent)
+        assertEquals(500L, r.newBalance)
+        assertEquals(1500L, r.newPool)
+        assertEquals(500L, user.socialCredit)
+        assertEquals(1500L, lottery.poolAmount)
+    }
+
+    @Test
+    fun `drawLottery rejects when no lottery open`() {
+        every { lotteryPersistence.getOpenByGuildForUpdate(guildId) } returns null
+        assertEquals(JackpotLotteryService.DrawOutcome.NoOpenLottery, service.drawLottery(guildId))
+    }
+
+    @Test
+    fun `drawLottery rejects when no tickets sold`() {
+        every { lotteryPersistence.getOpenByGuildForUpdate(guildId) } returns JackpotLotteryDto(
+            id = 1L, guildId = guildId, status = JackpotLotteryDto.STATUS_OPEN
+        )
+        every { lotteryPersistence.ticketsByLottery(1L) } returns emptyList()
+        assertEquals(JackpotLotteryService.DrawOutcome.NoTickets, service.drawLottery(guildId))
+    }
+
+    @Test
+    fun `drawLottery splits the pool 50-30-20 across three winners`() {
+        val lottery = JackpotLotteryDto(
+            id = 1L, guildId = guildId, ticketPrice = 100L, poolAmount = 1_000L,
+            winnerCount = 3, status = JackpotLotteryDto.STATUS_OPEN
+        )
+        every { lotteryPersistence.getOpenByGuildForUpdate(guildId) } returns lottery
+        every { lotteryPersistence.ticketsByLottery(1L) } returns listOf(
+            JackpotLotteryTicketDto(lotteryId = 1L, discordId = 1L, ticketCount = 1, spent = 100L),
+            JackpotLotteryTicketDto(lotteryId = 1L, discordId = 2L, ticketCount = 1, spent = 100L),
+            JackpotLotteryTicketDto(lotteryId = 1L, discordId = 3L, ticketCount = 1, spent = 100L),
+        )
+        val users = (1L..3L).associate { id ->
+            id to UserDto(discordId = id, guildId = guildId).apply { socialCredit = 0L }
+        }
+        users.forEach { (id, u) ->
+            every { userService.getUserByIdForUpdate(id, guildId) } returns u
+        }
+
+        val r = service.drawLottery(guildId)
+        assertTrue(r is JackpotLotteryService.DrawOutcome.Ok)
+        r as JackpotLotteryService.DrawOutcome.Ok
+        assertEquals(1_000L, r.drained)
+        assertEquals(1_000L, r.totalPaid)
+        // Schedule for 3 winners is 50/30/20.
+        assertEquals(setOf(500L, 300L, 200L), r.payouts.map { it.amount }.toSet())
+        assertEquals(JackpotLotteryDto.STATUS_DRAWN, lottery.status)
+        assertEquals(0L, lottery.poolAmount)
+    }
+
+    @Test
+    fun `cancelLottery refunds buyers and returns seed to the jackpot pool`() {
+        val lottery = JackpotLotteryDto(
+            id = 1L, guildId = guildId, ticketPrice = 100L, poolAmount = 1_500L,
+            status = JackpotLotteryDto.STATUS_OPEN
+        )
+        every { lotteryPersistence.getOpenByGuildForUpdate(guildId) } returns lottery
+        every { lotteryPersistence.ticketsByLottery(1L) } returns listOf(
+            JackpotLotteryTicketDto(lotteryId = 1L, discordId = 1L, ticketCount = 5, spent = 500L),
+            JackpotLotteryTicketDto(lotteryId = 1L, discordId = 2L, ticketCount = 3, spent = 300L),
+        )
+        val users = (1L..2L).associate { id ->
+            id to UserDto(discordId = id, guildId = guildId).apply { socialCredit = 0L }
+        }
+        users.forEach { (id, u) ->
+            every { userService.getUserByIdForUpdate(id, guildId) } returns u
+        }
+
+        val r = service.cancelLottery(guildId)
+        assertTrue(r is JackpotLotteryService.CancelOutcome.Ok)
+        r as JackpotLotteryService.CancelOutcome.Ok
+        assertEquals(2, r.refundedUsers)
+        assertEquals(800L, r.refundedTotal)
+        // pool_amount=1500, refunded 800 → 700 returned to the jackpot pool.
+        assertEquals(700L, r.returnedToPool)
+        verify(exactly = 1) { jackpotService.addToPool(guildId, 700L) }
+        assertEquals(500L, users[1L]!!.socialCredit)
+        assertEquals(300L, users[2L]!!.socialCredit)
+        assertEquals(JackpotLotteryDto.STATUS_CANCELLED, lottery.status)
+    }
+
+    // ---- prizeShares (internal) ----
+
+    @Test
+    fun `prizeShares uses fixed schedules for 1 to 4 winners`() {
+        assertEquals(listOf(1000L), service.prizeShares(1, 1000L))
+        assertEquals(listOf(600L, 400L), service.prizeShares(2, 1000L))
+        assertEquals(listOf(500L, 300L, 200L), service.prizeShares(3, 1000L))
+        assertEquals(listOf(400L, 300L, 200L, 100L), service.prizeShares(4, 1000L))
+    }
+
+    @Test
+    fun `prizeShares uses linear taper for 5+ winners and remains a partition`() {
+        val shares = service.prizeShares(5, 1500L)
+        assertEquals(5, shares.size)
+        // Strictly decreasing, all positive, sum <= pool (rounding remainder
+        // returns to the pool in drawLottery).
+        assertTrue(shares.zipWithNext().all { (a, b) -> a >= b })
+        assertTrue(shares.all { it >= 0 })
+        assertTrue(shares.sum() <= 1500L)
+    }
+
+    // ---- drawWinners (weighted) ----
+
+    @Test
+    fun `drawWinners picks the same-weight users uniformly without replacement`() {
+        val tickets = listOf(
+            JackpotLotteryTicketDto(lotteryId = 1L, discordId = 1L, ticketCount = 10, spent = 0L),
+            JackpotLotteryTicketDto(lotteryId = 1L, discordId = 2L, ticketCount = 10, spent = 0L),
+            JackpotLotteryTicketDto(lotteryId = 1L, discordId = 3L, ticketCount = 10, spent = 0L),
+        )
+        val winners = service.drawWinners(tickets, count = 3, random = Random(42))
+        assertEquals(3, winners.size)
+        // No duplicates.
+        assertEquals(3, winners.map { it.discordId }.toSet().size)
+    }
+
+    @Test
+    fun `drawWinners cannot pick the same user twice`() {
+        val tickets = listOf(
+            JackpotLotteryTicketDto(lotteryId = 1L, discordId = 1L, ticketCount = 1000, spent = 0L),
+            JackpotLotteryTicketDto(lotteryId = 1L, discordId = 2L, ticketCount = 1, spent = 0L),
+        )
+        val winners = service.drawWinners(tickets, count = 2, random = Random(0))
+        assertEquals(2, winners.size)
+        assertEquals(2, winners.map { it.discordId }.toSet().size, "no duplicates even when one user dominates weight")
+    }
+
+    @Test
+    fun `drawWinners returns fewer than count when there aren't enough holders`() {
+        val tickets = listOf(
+            JackpotLotteryTicketDto(lotteryId = 1L, discordId = 1L, ticketCount = 5, spent = 0L),
+        )
+        val winners = service.drawWinners(tickets, count = 3, random = Random(1))
+        assertEquals(1, winners.size)
+        assertNotNull(winners.first())
+    }
+}

--- a/database/src/test/kotlin/database/service/JackpotServiceTest.kt
+++ b/database/src/test/kotlin/database/service/JackpotServiceTest.kt
@@ -2,29 +2,40 @@ package database.service
 
 import database.dto.ConfigDto
 import database.dto.TobyCoinJackpotDto
+import database.dto.TobyCoinJackpotWinnerDto
 import database.persistence.TobyCoinJackpotPersistence
-import io.mockk.Runs
+import database.persistence.TobyCoinJackpotWinnerPersistence
+import database.persistence.VoiceCreditDailyPersistence
 import io.mockk.every
-import io.mockk.just
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.time.Instant
 
 class JackpotServiceTest {
 
     private val guildId = 42L
+    private val discordId = 7L
+    private val now: Instant = Instant.parse("2026-05-08T12:00:00Z")
 
     private lateinit var persistence: TobyCoinJackpotPersistence
     private lateinit var configService: ConfigService
+    private lateinit var winnerPersistence: TobyCoinJackpotWinnerPersistence
+    private lateinit var voiceCreditDailyPersistence: VoiceCreditDailyPersistence
     private lateinit var service: JackpotService
 
     @BeforeEach
     fun setup() {
         persistence = mockk(relaxed = true)
         configService = mockk(relaxed = true)
+        winnerPersistence = mockk(relaxed = true)
+        voiceCreditDailyPersistence = mockk(relaxed = true)
         // Default: no `JACKPOT_WIN_PCT` row in the DB → fall through to
         // [JackpotHelper.DEFAULT_WIN_PROBABILITY] (0.01 → 1.0%).
         every {
@@ -33,7 +44,40 @@ class JackpotServiceTest {
                 guildId.toString()
             )
         } returns null
-        service = JackpotService(persistence, configService)
+        // Default: no `JACKPOT_PAYOUT_PCT` row → full pool payout (matches
+        // pre-rebalance behaviour for unconfigured guilds).
+        every {
+            configService.getConfigByName(
+                ConfigDto.Configurations.JACKPOT_PAYOUT_PCT.configValue,
+                guildId.toString()
+            )
+        } returns null
+        // Default: cooldown / activity gates disabled.
+        every {
+            configService.getConfigByName(
+                ConfigDto.Configurations.JACKPOT_WINNER_COOLDOWN_DAYS.configValue,
+                guildId.toString()
+            )
+        } returns null
+        every {
+            configService.getConfigByName(
+                ConfigDto.Configurations.JACKPOT_ACTIVITY_WINDOW_DAYS.configValue,
+                guildId.toString()
+            )
+        } returns null
+        every {
+            configService.getConfigByName(
+                ConfigDto.Configurations.JACKPOT_ACTIVITY_MIN_DAYS.configValue,
+                guildId.toString()
+            )
+        } returns null
+        service = JackpotService(
+            persistence,
+            configService,
+            winnerPersistence,
+            voiceCreditDailyPersistence,
+            clock = { now },
+        )
     }
 
     @Test
@@ -92,15 +136,33 @@ class JackpotServiceTest {
     }
 
     @Test
-    fun `awardJackpot returns the prior pool and zeroes the row`() {
+    fun `awardJackpot pays the entire pool when JACKPOT_PAYOUT_PCT is unset`() {
         val existing = TobyCoinJackpotDto(guildId = guildId, pool = 1_500L)
         every { persistence.getByGuildForUpdate(guildId) } returns existing
         every { persistence.upsert(any()) } answers { firstArg() }
 
         val won = service.awardJackpot(guildId)
 
-        assertEquals(1_500L, won, "winner banks the entire pool")
+        assertEquals(1_500L, won, "default payout pct = 100% pays the entire pool")
         assertEquals(0L, existing.pool, "pool resets in the same transaction")
+    }
+
+    @Test
+    fun `awardJackpot pays a configured fraction and re-seeds the remainder`() {
+        every {
+            configService.getConfigByName(
+                ConfigDto.Configurations.JACKPOT_PAYOUT_PCT.configValue,
+                guildId.toString()
+            )
+        } returns ConfigDto(name = "x", value = "30", guildId = guildId.toString())
+        val existing = TobyCoinJackpotDto(guildId = guildId, pool = 1_000L)
+        every { persistence.getByGuildForUpdate(guildId) } returns existing
+        every { persistence.upsert(any()) } answers { firstArg() }
+
+        val won = service.awardJackpot(guildId)
+
+        assertEquals(300L, won, "30% of 1000 paid out")
+        assertEquals(700L, existing.pool, "remainder re-seeds the next cycle")
     }
 
     @Test
@@ -173,9 +235,6 @@ class JackpotServiceTest {
 
     @Test
     fun `winProbabilityPct clamps absurd admin values to MAX_WIN_PROBABILITY`() {
-        // Validator on the moderation page should already reject anything
-        // above 50, but defend against a stale row from before the cap was
-        // tightened — JackpotHelper clamps at MAX_WIN_PROBABILITY = 0.5.
         every {
             configService.getConfigByName(
                 ConfigDto.Configurations.JACKPOT_WIN_PCT.configValue,
@@ -202,5 +261,129 @@ class JackpotServiceTest {
             guildId = guildId.toString()
         )
         assertEquals(1.0, service.winProbabilityPct(guildId), 1e-9)
+    }
+
+    // ---- recordWin / isOnCooldown ----
+
+    @Test
+    fun `recordWin upserts a winner row with the current clock timestamp`() {
+        val captured = slot<TobyCoinJackpotWinnerDto>()
+        every { winnerPersistence.upsert(capture(captured)) } answers { captured.captured }
+
+        service.recordWin(guildId, discordId, 250L)
+
+        assertEquals(guildId, captured.captured.guildId)
+        assertEquals(discordId, captured.captured.discordId)
+        assertEquals(now, captured.captured.lastWonAt)
+        assertEquals(250L, captured.captured.lastWonAmount)
+    }
+
+    @Test
+    fun `recordWin is a no-op for non-positive amounts`() {
+        service.recordWin(guildId, discordId, 0L)
+        service.recordWin(guildId, discordId, -10L)
+        verify(exactly = 0) { winnerPersistence.upsert(any()) }
+    }
+
+    @Test
+    fun `isOnCooldown returns false when the cooldown config is unset (gate disabled)`() {
+        // setup() stubs the config to null — gate disabled.
+        assertFalse(service.isOnCooldown(guildId, discordId))
+        verify(exactly = 0) { winnerPersistence.get(any(), any()) }
+    }
+
+    @Test
+    fun `isOnCooldown returns false when the user has no prior win row`() {
+        every {
+            configService.getConfigByName(
+                ConfigDto.Configurations.JACKPOT_WINNER_COOLDOWN_DAYS.configValue,
+                guildId.toString()
+            )
+        } returns ConfigDto(name = "x", value = "14", guildId = guildId.toString())
+        every { winnerPersistence.get(guildId, discordId) } returns null
+
+        assertFalse(service.isOnCooldown(guildId, discordId))
+    }
+
+    @Test
+    fun `isOnCooldown returns true when last win is within the configured window`() {
+        every {
+            configService.getConfigByName(
+                ConfigDto.Configurations.JACKPOT_WINNER_COOLDOWN_DAYS.configValue,
+                guildId.toString()
+            )
+        } returns ConfigDto(name = "x", value = "14", guildId = guildId.toString())
+        every { winnerPersistence.get(guildId, discordId) } returns TobyCoinJackpotWinnerDto(
+            guildId = guildId,
+            discordId = discordId,
+            lastWonAt = now.minus(Duration.ofDays(7)),
+            lastWonAmount = 100L,
+        )
+
+        assertTrue(service.isOnCooldown(guildId, discordId))
+    }
+
+    @Test
+    fun `isOnCooldown returns false when last win is outside the window`() {
+        every {
+            configService.getConfigByName(
+                ConfigDto.Configurations.JACKPOT_WINNER_COOLDOWN_DAYS.configValue,
+                guildId.toString()
+            )
+        } returns ConfigDto(name = "x", value = "14", guildId = guildId.toString())
+        every { winnerPersistence.get(guildId, discordId) } returns TobyCoinJackpotWinnerDto(
+            guildId = guildId,
+            discordId = discordId,
+            lastWonAt = now.minus(Duration.ofDays(20)),
+            lastWonAmount = 100L,
+        )
+
+        assertFalse(service.isOnCooldown(guildId, discordId))
+    }
+
+    // ---- isActive ----
+
+    @Test
+    fun `isActive returns true when the activity gate config is unset (disabled)`() {
+        assertTrue(service.isActive(guildId, discordId))
+        verify(exactly = 0) { voiceCreditDailyPersistence.countDaysSince(any(), any(), any()) }
+    }
+
+    @Test
+    fun `isActive returns true when activity meets the minimum threshold`() {
+        every {
+            configService.getConfigByName(
+                ConfigDto.Configurations.JACKPOT_ACTIVITY_WINDOW_DAYS.configValue,
+                guildId.toString()
+            )
+        } returns ConfigDto(name = "x", value = "7", guildId = guildId.toString())
+        every {
+            configService.getConfigByName(
+                ConfigDto.Configurations.JACKPOT_ACTIVITY_MIN_DAYS.configValue,
+                guildId.toString()
+            )
+        } returns ConfigDto(name = "x", value = "3", guildId = guildId.toString())
+        every { voiceCreditDailyPersistence.countDaysSince(eq(discordId), eq(guildId), any()) } returns 4L
+
+        assertTrue(service.isActive(guildId, discordId))
+    }
+
+    @Test
+    fun `isActive returns false when activity is below the minimum threshold`() {
+        every {
+            configService.getConfigByName(
+                ConfigDto.Configurations.JACKPOT_ACTIVITY_WINDOW_DAYS.configValue,
+                guildId.toString()
+            )
+        } returns ConfigDto(name = "x", value = "7", guildId = guildId.toString())
+        every {
+            configService.getConfigByName(
+                ConfigDto.Configurations.JACKPOT_ACTIVITY_MIN_DAYS.configValue,
+                guildId.toString()
+            )
+        } returns ConfigDto(name = "x", value = "3", guildId = guildId.toString())
+        every { voiceCreditDailyPersistence.countDaysSince(eq(discordId), eq(guildId), any()) } returns 2L
+
+        assertFalse(service.isActive(guildId, discordId))
     }
 }

--- a/database/src/test/kotlin/database/service/JackpotServiceTest.kt
+++ b/database/src/test/kotlin/database/service/JackpotServiceTest.kt
@@ -76,7 +76,6 @@ class JackpotServiceTest {
             configService,
             winnerPersistence,
             voiceCreditDailyPersistence,
-            clock = { now },
         )
     }
 
@@ -266,11 +265,11 @@ class JackpotServiceTest {
     // ---- recordWin / isOnCooldown ----
 
     @Test
-    fun `recordWin upserts a winner row with the current clock timestamp`() {
+    fun `recordWin upserts a winner row at the supplied timestamp`() {
         val captured = slot<TobyCoinJackpotWinnerDto>()
         every { winnerPersistence.upsert(capture(captured)) } answers { captured.captured }
 
-        service.recordWin(guildId, discordId, 250L)
+        service.recordWin(guildId, discordId, 250L, at = now)
 
         assertEquals(guildId, captured.captured.guildId)
         assertEquals(discordId, captured.captured.discordId)
@@ -288,7 +287,7 @@ class JackpotServiceTest {
     @Test
     fun `isOnCooldown returns false when the cooldown config is unset (gate disabled)`() {
         // setup() stubs the config to null — gate disabled.
-        assertFalse(service.isOnCooldown(guildId, discordId))
+        assertFalse(service.isOnCooldown(guildId, discordId, at = now))
         verify(exactly = 0) { winnerPersistence.get(any(), any()) }
     }
 
@@ -302,7 +301,7 @@ class JackpotServiceTest {
         } returns ConfigDto(name = "x", value = "14", guildId = guildId.toString())
         every { winnerPersistence.get(guildId, discordId) } returns null
 
-        assertFalse(service.isOnCooldown(guildId, discordId))
+        assertFalse(service.isOnCooldown(guildId, discordId, at = now))
     }
 
     @Test
@@ -320,7 +319,7 @@ class JackpotServiceTest {
             lastWonAmount = 100L,
         )
 
-        assertTrue(service.isOnCooldown(guildId, discordId))
+        assertTrue(service.isOnCooldown(guildId, discordId, at = now))
     }
 
     @Test
@@ -338,14 +337,14 @@ class JackpotServiceTest {
             lastWonAmount = 100L,
         )
 
-        assertFalse(service.isOnCooldown(guildId, discordId))
+        assertFalse(service.isOnCooldown(guildId, discordId, at = now))
     }
 
     // ---- isActive ----
 
     @Test
     fun `isActive returns true when the activity gate config is unset (disabled)`() {
-        assertTrue(service.isActive(guildId, discordId))
+        assertTrue(service.isActive(guildId, discordId, at = now))
         verify(exactly = 0) { voiceCreditDailyPersistence.countDaysSince(any(), any(), any()) }
     }
 
@@ -365,7 +364,7 @@ class JackpotServiceTest {
         } returns ConfigDto(name = "x", value = "3", guildId = guildId.toString())
         every { voiceCreditDailyPersistence.countDaysSince(eq(discordId), eq(guildId), any()) } returns 4L
 
-        assertTrue(service.isActive(guildId, discordId))
+        assertTrue(service.isActive(guildId, discordId, at = now))
     }
 
     @Test
@@ -384,6 +383,6 @@ class JackpotServiceTest {
         } returns ConfigDto(name = "x", value = "3", guildId = guildId.toString())
         every { voiceCreditDailyPersistence.countDaysSince(eq(discordId), eq(guildId), any()) } returns 2L
 
-        assertFalse(service.isActive(guildId, discordId))
+        assertFalse(service.isActive(guildId, discordId, at = now))
     }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/LotteryCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/LotteryCommand.kt
@@ -1,0 +1,139 @@
+package bot.toby.command.commands.economy
+
+import core.command.Command.Companion.invokeDeleteOnMessageResponse
+import core.command.CommandContext
+import database.dto.UserDto
+import database.service.JackpotLotteryService
+import database.service.JackpotLotteryService.BuyOutcome
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
+import net.dv8tion.jda.api.interactions.commands.OptionType
+import net.dv8tion.jda.api.interactions.commands.build.OptionData
+import net.dv8tion.jda.api.interactions.commands.build.SubcommandData
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+import java.time.Duration
+import java.time.Instant
+
+/**
+ * `/lottery buy|status` — players' surface for the per-guild jackpot
+ * lottery event opened by `/jackpotadmin lottery_open`.
+ *
+ *   - `buy <count>` debits `count × ticket_price` from the player and
+ *     adds it to the prize pool (so the prize grows with engagement).
+ *     Each ticket is a weight in the eventual draw.
+ *   - `status` shows the open lottery's prize pool, the player's own
+ *     ticket count, the top 5 holders, and time-until-close.
+ *
+ * The actual draw is admin-only (`/jackpotadmin lottery_draw`) so
+ * timing is up to whoever opened the event. There's no auto-close on
+ * `closes_at` — the timestamp is informational and used only for the
+ * "X hours remaining" hint.
+ */
+@Component
+class LotteryCommand @Autowired constructor(
+    private val jackpotLotteryService: JackpotLotteryService,
+) : EconomyCommand {
+
+    override val name: String = "lottery"
+    override val description: String = "Buy tickets in the active jackpot lottery, or check its status."
+
+    override val subCommands: List<SubcommandData> = listOf(
+        SubcommandData(SUB_BUY, "Buy tickets in the open lottery.")
+            .addOptions(
+                OptionData(OptionType.INTEGER, OPT_COUNT, "Number of tickets to buy", true)
+                    .setMinValue(1L)
+                    .setMaxValue(MAX_TICKETS_PER_BUY),
+            ),
+        SubcommandData(SUB_STATUS, "Show the open lottery (prize pool, your tickets, top holders)."),
+    )
+
+    override fun handle(ctx: CommandContext, requestingUserDto: UserDto, deleteDelay: Int) {
+        val event = ctx.event
+        event.deferReply().queue()
+
+        val guild = event.guild ?: run {
+            replyError(event, "Server only.", deleteDelay); return
+        }
+
+        when (event.subcommandName) {
+            SUB_BUY -> handleBuy(event, requestingUserDto, guild.idLong, deleteDelay)
+            SUB_STATUS -> handleStatus(event, requestingUserDto, guild.idLong, deleteDelay)
+            else -> replyError(event, "Pick a subcommand: $SUB_BUY / $SUB_STATUS.", deleteDelay)
+        }
+    }
+
+    private fun handleBuy(
+        event: SlashCommandInteractionEvent,
+        user: UserDto,
+        guildId: Long,
+        deleteDelay: Int,
+    ) {
+        val count = event.getOption(OPT_COUNT)?.asLong?.toInt() ?: run {
+            replyError(event, "Specify a ticket count.", deleteDelay); return
+        }
+        when (val r = jackpotLotteryService.buyTickets(guildId, user.discordId, count)) {
+            is BuyOutcome.Ok -> event.hook.sendMessage(
+                "Bought **$count** tickets. You now hold **${r.ticketCount}** tickets " +
+                    "(spent ${r.totalSpent} credits total). Prize pool: **${r.newPool}** credits. " +
+                    "Your balance: **${r.newBalance}** credits."
+            ).queue(invokeDeleteOnMessageResponse(deleteDelay))
+            BuyOutcome.NoOpenLottery ->
+                replyError(event, "No lottery is open right now.", deleteDelay)
+            is BuyOutcome.InvalidCount ->
+                replyError(event, "Ticket count must be positive.", deleteDelay)
+            is BuyOutcome.Insufficient ->
+                replyError(event, "You only have **${r.have}** credits, need **${r.need}**.", deleteDelay)
+            BuyOutcome.UnknownUser ->
+                replyError(event, "No user record yet. Try another TobyBot command first.", deleteDelay)
+        }
+    }
+
+    private fun handleStatus(
+        event: SlashCommandInteractionEvent,
+        user: UserDto,
+        guildId: Long,
+        deleteDelay: Int,
+    ) {
+        val lottery = jackpotLotteryService.getOpen(guildId) ?: run {
+            event.hook.sendMessage("No lottery is open right now.")
+                .queue(invokeDeleteOnMessageResponse(deleteDelay))
+            return
+        }
+        val tickets = jackpotLotteryService.ticketsForOpen(guildId)
+        val totalTickets = tickets.sumOf { it.ticketCount.toLong() }
+        val mine = tickets.firstOrNull { it.discordId == user.discordId }
+        val top = tickets.sortedByDescending { it.ticketCount }.take(5)
+            .joinToString("\n") { "<@${it.discordId}> — ${it.ticketCount} tickets" }
+            .ifEmpty { "_no buyers yet_" }
+
+        val remaining = Duration.between(Instant.now(), lottery.closesAt)
+        val remainingLabel = when {
+            remaining.isNegative -> "(past closes_at — admin must draw or cancel)"
+            remaining.toHours() >= 1 -> "${remaining.toHours()}h remaining (informational)"
+            else -> "${remaining.toMinutes().coerceAtLeast(0)}m remaining (informational)"
+        }
+
+        event.hook.sendMessage(
+            "**Lottery status**\n" +
+                "Prize pool: **${lottery.poolAmount}** credits\n" +
+                "Ticket price: **${lottery.ticketPrice}** credits each\n" +
+                "Tickets sold: **$totalTickets** (across ${tickets.size} buyers)\n" +
+                "Winners: **${lottery.winnerCount}**\n" +
+                "Your tickets: **${mine?.ticketCount ?: 0}**\n" +
+                "Closes at: $remainingLabel\n\n" +
+                "Top holders:\n$top"
+        ).queue(invokeDeleteOnMessageResponse(deleteDelay))
+    }
+
+    private fun replyError(event: SlashCommandInteractionEvent, message: String, deleteDelay: Int) {
+        event.hook.sendMessage(message).setEphemeral(true)
+            .queue(invokeDeleteOnMessageResponse(deleteDelay))
+    }
+
+    companion object {
+        private const val SUB_BUY = "buy"
+        private const val SUB_STATUS = "status"
+        private const val OPT_COUNT = "count"
+        private const val MAX_TICKETS_PER_BUY = 1_000L
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/moderation/JackpotAdminCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/moderation/JackpotAdminCommand.kt
@@ -4,6 +4,7 @@ import core.command.Command.Companion.invokeDeleteOnMessageResponse
 import core.command.CommandContext
 import database.dto.UserDto
 import database.service.CasinoAdminService
+import database.service.JackpotLotteryService
 import database.service.JackpotService
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
 import net.dv8tion.jda.api.interactions.commands.OptionType
@@ -15,7 +16,8 @@ import org.springframework.stereotype.Component
 /**
  * Owner / superuser admin command for jackpot remediation. Mirrors the
  * `/moderation` casino tab in the web UI: drain the per-guild jackpot
- * pool to zero, or claw an exploit refund back into it from a player.
+ * pool to zero, claw an exploit refund back into it from a player, or
+ * convert a runaway pool into a multi-winner ticketed lottery event.
  *
  * Permission gate matches `SetConfigCommand`: guild owner only, with
  * superuser bypass via the existing `requestingUserDto.superUser` flag.
@@ -24,10 +26,11 @@ import org.springframework.stereotype.Component
 class JackpotAdminCommand @Autowired constructor(
     private val casinoAdminService: CasinoAdminService,
     private val jackpotService: JackpotService,
+    private val jackpotLotteryService: JackpotLotteryService,
 ) : ModerationCommand {
 
     override val name: String = "jackpotadmin"
-    override val description: String = "Owner-only jackpot remediation (reset pool, refund from a user)."
+    override val description: String = "Owner-only jackpot remediation (reset pool, refund, lottery event)."
 
     override val subCommands: List<SubcommandData> = listOf(
         SubcommandData(SUB_RESET, "Drain the jackpot pool to zero."),
@@ -38,6 +41,20 @@ class JackpotAdminCommand @Autowired constructor(
                     .setMinValue(1L),
             ),
         SubcommandData(SUB_POOL, "Show the current jackpot pool size."),
+        SubcommandData(SUB_LOTTERY_OPEN, "Open a multi-winner ticketed lottery seeded from the jackpot pool.")
+            .addOptions(
+                OptionData(OptionType.INTEGER, OPT_TICKET_PRICE, "Credits per ticket", true).setMinValue(1L),
+                OptionData(OptionType.INTEGER, OPT_DURATION_HOURS, "How many hours the sale stays open", true)
+                    .setMinValue(1L),
+                OptionData(OptionType.INTEGER, OPT_WINNER_COUNT, "How many winners share the prize", true)
+                    .setMinValue(1L)
+                    .setMaxValue(10L),
+                OptionData(OptionType.INTEGER, OPT_DRAIN_PCT, "Percent of pool to seed the lottery (1-100)", true)
+                    .setMinValue(1L)
+                    .setMaxValue(100L),
+            ),
+        SubcommandData(SUB_LOTTERY_DRAW, "Close the open lottery and pay weighted winners."),
+        SubcommandData(SUB_LOTTERY_CANCEL, "Cancel the open lottery (refund tickets, return seed to pool)."),
     )
 
     override fun handle(ctx: CommandContext, requestingUserDto: UserDto, deleteDelay: Int) {
@@ -58,9 +75,13 @@ class JackpotAdminCommand @Autowired constructor(
             SUB_RESET -> handleReset(event, guildId, deleteDelay)
             SUB_REFUND -> handleRefund(event, guildId, deleteDelay)
             SUB_POOL -> handlePool(event, guildId, deleteDelay)
-            else -> event.hook.sendMessage("Pick a subcommand: $SUB_RESET / $SUB_REFUND / $SUB_POOL.")
-                .setEphemeral(true)
-                .queue(invokeDeleteOnMessageResponse(deleteDelay))
+            SUB_LOTTERY_OPEN -> handleLotteryOpen(event, guildId, deleteDelay)
+            SUB_LOTTERY_DRAW -> handleLotteryDraw(event, guildId, deleteDelay)
+            SUB_LOTTERY_CANCEL -> handleLotteryCancel(event, guildId, deleteDelay)
+            else -> event.hook.sendMessage(
+                "Pick a subcommand: $SUB_RESET / $SUB_REFUND / $SUB_POOL / " +
+                    "$SUB_LOTTERY_OPEN / $SUB_LOTTERY_DRAW / $SUB_LOTTERY_CANCEL."
+            ).setEphemeral(true).queue(invokeDeleteOnMessageResponse(deleteDelay))
         }
     }
 
@@ -105,6 +126,63 @@ class JackpotAdminCommand @Autowired constructor(
             .queue(invokeDeleteOnMessageResponse(deleteDelay))
     }
 
+    private fun handleLotteryOpen(event: SlashCommandInteractionEvent, guildId: Long, deleteDelay: Int) {
+        val ticketPrice = event.getOption(OPT_TICKET_PRICE)?.asLong
+            ?: return replyError(event, "Ticket price option missing.", deleteDelay)
+        val duration = event.getOption(OPT_DURATION_HOURS)?.asLong
+            ?: return replyError(event, "Duration option missing.", deleteDelay)
+        val winners = event.getOption(OPT_WINNER_COUNT)?.asLong?.toInt()
+            ?: return replyError(event, "Winner count option missing.", deleteDelay)
+        val drainPctRaw = event.getOption(OPT_DRAIN_PCT)?.asLong
+            ?: return replyError(event, "Drain pct option missing.", deleteDelay)
+        val drainPct = drainPctRaw.coerceIn(1L, 100L) / 100.0
+
+        when (val result = jackpotLotteryService.openLottery(
+            guildId, ticketPrice, duration, winners, drainPct
+        )) {
+            is JackpotLotteryService.OpenOutcome.Ok -> event.hook.sendMessage(
+                "Opened lottery. Seeded with **${result.seeded}** credits from the jackpot pool. " +
+                    "Tickets: **$ticketPrice** credits each. Winners: **$winners**. " +
+                    "Closes after **$duration** hours (admin must run `/jackpotadmin lottery_draw`)."
+            ).setEphemeral(true).queue(invokeDeleteOnMessageResponse(deleteDelay))
+            JackpotLotteryService.OpenOutcome.AlreadyOpen ->
+                replyError(event, "A lottery is already open for this guild. Draw or cancel it first.", deleteDelay)
+            JackpotLotteryService.OpenOutcome.EmptyPool ->
+                replyError(event, "Jackpot pool is empty — nothing to seed the lottery with.", deleteDelay)
+            is JackpotLotteryService.OpenOutcome.InvalidParams ->
+                replyError(event, "Invalid params: ${result.reason}.", deleteDelay)
+        }
+    }
+
+    private fun handleLotteryDraw(event: SlashCommandInteractionEvent, guildId: Long, deleteDelay: Int) {
+        when (val result = jackpotLotteryService.drawLottery(guildId)) {
+            is JackpotLotteryService.DrawOutcome.Ok -> {
+                val lines = result.payouts.mapIndexed { idx, p ->
+                    "${idx + 1}. <@${p.discordId}> — **${p.amount}** credits (${p.ticketCount} tickets)"
+                }
+                val body = if (lines.isEmpty()) "_No winners drawn._" else lines.joinToString("\n")
+                event.hook.sendMessage(
+                    "Lottery drawn. Total paid: **${result.totalPaid}** of **${result.drained}** credits.\n$body"
+                ).setEphemeral(false).queue(invokeDeleteOnMessageResponse(deleteDelay))
+            }
+            JackpotLotteryService.DrawOutcome.NoOpenLottery ->
+                replyError(event, "No open lottery to draw.", deleteDelay)
+            JackpotLotteryService.DrawOutcome.NoTickets ->
+                replyError(event, "Lottery has no ticket buyers — cancel instead to refund the seed.", deleteDelay)
+        }
+    }
+
+    private fun handleLotteryCancel(event: SlashCommandInteractionEvent, guildId: Long, deleteDelay: Int) {
+        when (val result = jackpotLotteryService.cancelLottery(guildId)) {
+            is JackpotLotteryService.CancelOutcome.Ok -> event.hook.sendMessage(
+                "Cancelled lottery. Refunded **${result.refundedTotal}** credits to **${result.refundedUsers}** users. " +
+                    "Returned **${result.returnedToPool}** credits to the jackpot pool."
+            ).setEphemeral(true).queue(invokeDeleteOnMessageResponse(deleteDelay))
+            JackpotLotteryService.CancelOutcome.NoOpenLottery ->
+                replyError(event, "No open lottery to cancel.", deleteDelay)
+        }
+    }
+
     private fun replyError(event: SlashCommandInteractionEvent, message: String, deleteDelay: Int) {
         event.hook.sendMessage(message).setEphemeral(true)
             .queue(invokeDeleteOnMessageResponse(deleteDelay))
@@ -114,7 +192,14 @@ class JackpotAdminCommand @Autowired constructor(
         const val SUB_RESET = "reset"
         const val SUB_REFUND = "refund"
         const val SUB_POOL = "pool"
+        const val SUB_LOTTERY_OPEN = "lottery_open"
+        const val SUB_LOTTERY_DRAW = "lottery_draw"
+        const val SUB_LOTTERY_CANCEL = "lottery_cancel"
         const val OPT_USER = "user"
         const val OPT_AMOUNT = "amount"
+        const val OPT_TICKET_PRICE = "ticket_price"
+        const val OPT_DURATION_HOURS = "duration_hours"
+        const val OPT_WINNER_COUNT = "winner_count"
+        const val OPT_DRAIN_PCT = "drain_pct"
     }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/moderation/SetConfigCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/moderation/SetConfigCommand.kt
@@ -155,6 +155,19 @@ class SetConfigCommand @Autowired constructor(
                     config = ConfigDto.Configurations.DUEL_MAX_STAKE, gameLabel = "Duel", label = "maximum stake", min = 1L, unit = "credits")
                 ConfigDto.Configurations.JACKPOT_STAKE_ANCHOR -> setMinimumLongConfig(event, optionMapping, deleteDelay,
                     config = ConfigDto.Configurations.JACKPOT_STAKE_ANCHOR, gameLabel = "Jackpot", label = "stake anchor", min = 1L, unit = "credits")
+                // Post-fraud rebalance gates. Like the per-game stake
+                // bounds above, these aren't in the /setconfig OptionData
+                // (admins use the /moderation web tab) but keep the
+                // dispatch exhaustive in case the option is registered
+                // manually.
+                ConfigDto.Configurations.JACKPOT_PAYOUT_PCT -> setRangedIntConfig(event, optionMapping, deleteDelay,
+                    config = ConfigDto.Configurations.JACKPOT_PAYOUT_PCT, gameLabel = "Jackpot", label = "payout percent", range = 1..100)
+                ConfigDto.Configurations.JACKPOT_WINNER_COOLDOWN_DAYS -> setRangedIntConfig(event, optionMapping, deleteDelay,
+                    config = ConfigDto.Configurations.JACKPOT_WINNER_COOLDOWN_DAYS, gameLabel = "Jackpot", label = "winner cooldown days", range = 0..365)
+                ConfigDto.Configurations.JACKPOT_ACTIVITY_WINDOW_DAYS -> setRangedIntConfig(event, optionMapping, deleteDelay,
+                    config = ConfigDto.Configurations.JACKPOT_ACTIVITY_WINDOW_DAYS, gameLabel = "Jackpot", label = "activity window days", range = 0..365)
+                ConfigDto.Configurations.JACKPOT_ACTIVITY_MIN_DAYS -> setRangedIntConfig(event, optionMapping, deleteDelay,
+                    config = ConfigDto.Configurations.JACKPOT_ACTIVITY_MIN_DAYS, gameLabel = "Jackpot", label = "activity min days", range = 1..365)
             }
         }
     }

--- a/web/src/main/kotlin/web/service/ModerationWebService.kt
+++ b/web/src/main/kotlin/web/service/ModerationWebService.kt
@@ -487,6 +487,30 @@ class ModerationWebService(
                 if (n !in 0..10000) return "Value must be between 0 and 10000 (default 90)."
                 n.toString()
             }
+            ConfigDto.Configurations.JACKPOT_PAYOUT_PCT -> {
+                val n = rawValue.trim().toIntOrNull()
+                    ?: return "Value must be a whole number percentage (1-100; default 100)."
+                if (n !in 1..100) return "Value must be between 1 and 100."
+                n.toString()
+            }
+            ConfigDto.Configurations.JACKPOT_WINNER_COOLDOWN_DAYS -> {
+                val n = rawValue.trim().toIntOrNull()
+                    ?: return "Value must be a whole number of days (0-365; 0 disables)."
+                if (n !in 0..365) return "Value must be between 0 and 365 days."
+                n.toString()
+            }
+            ConfigDto.Configurations.JACKPOT_ACTIVITY_WINDOW_DAYS -> {
+                val n = rawValue.trim().toIntOrNull()
+                    ?: return "Value must be a whole number of days (0-365; 0 disables)."
+                if (n !in 0..365) return "Value must be between 0 and 365 days."
+                n.toString()
+            }
+            ConfigDto.Configurations.JACKPOT_ACTIVITY_MIN_DAYS -> {
+                val n = rawValue.trim().toIntOrNull()
+                    ?: return "Value must be a whole number (1-365; default 1)."
+                if (n !in 1..365) return "Value must be between 1 and 365."
+                n.toString()
+            }
         }
 
         val guildIdString = guild.id


### PR DESCRIPTION
## Summary

Post-fraud rebalance so a runaway 110k jackpot can't be swept by a single casino-roll winner. Four composing per-guild mechanics, all defaulting to current behaviour so unconfigured guilds are unchanged.

### Mechanics

- **`JACKPOT_PAYOUT_PCT`** (G) — wins pay a configurable share of the pool; remainder re-seeds the next cycle. Default 100% preserves historic behaviour; recommended 30%. Implemented inside `JackpotService.awardJackpot` so all callers (10 wager services + holdem) get the change for free.
- **`JACKPOT_WINNER_COOLDOWN_DAYS`** (C) — past winners are jackpot-ineligible for the configured window. Tracked in new `toby_coin_jackpot_winner` table; covers both casino-roll wins and lottery draw wins so the same player can't sweep both. Default 0 (disabled); recommended 14.
- **`JACKPOT_ACTIVITY_WINDOW_DAYS` / `JACKPOT_ACTIVITY_MIN_DAYS`** (A) — eligibility gate sourced from the existing `voice_credit_daily` table — drive-by accounts with one bet can't farm the pool. Default 0 (disabled); recommended `7` window with `3` minimum days.
- **`/jackpotadmin lottery_open|draw|cancel`** + **`/lottery buy|status`** (H) — ticketed multi-winner draw to drain (full or partial) pool via an interactive event. Weighted draw without replacement; 50/30/20-style splits scaling out to a linear taper for ≥5 winners. Tickets grow the prize pool; cancel refunds buyers and returns the seed to the jackpot row.

### Gate ordering in `JackpotHelper.rollOnWin`

random roll → cooldown gate → activity gate → percentage payout → record win. Failed gates look identical to a missed roll (pool keeps growing).

### Recommended deployment for the 110k pool

```
/setconfig JACKPOT_PAYOUT_PCT 30
/setconfig JACKPOT_WINNER_COOLDOWN_DAYS 14
/setconfig JACKPOT_ACTIVITY_WINDOW_DAYS 7
/setconfig JACKPOT_ACTIVITY_MIN_DAYS 3
/jackpotadmin lottery_open ticket_price:100 duration_hours:48 winner_count:3 drain_pct:100
```

The lottery event drains the backlog via a 48-hour 3-winner draw; future runaway accumulation is structurally prevented by the percentage payout + gates.

### Database changes

- `V26__toby_coin_jackpot_winner.sql` — winner cooldown row per (guild, user)
- `V27__toby_coin_jackpot_lottery.sql` — lottery + ticket tables; partial unique index enforces one OPEN lottery per guild

## Test plan

- [ ] CI: `./gradlew build` (sandbox couldn't reach plugin repos locally; workflow validates compile + tests)
- [ ] Verify `JackpotHelperTest`, `JackpotServiceTest`, `JackpotLotteryServiceTest` all pass
- [ ] Manual smoke: set the four configs in a test guild, refund a test pool, spin slots until a hit, confirm the percentage payout and winner-row write
- [ ] Manual smoke: re-spin same user immediately, confirm cooldown blocks payout (pool grows)
- [ ] Manual smoke: open a lottery, have 3 users buy tickets, draw, confirm 50/30/20 split
- [ ] Manual smoke: cancel flow refunds buyers and returns seed to jackpot
- [ ] For live deployment: run the four `/setconfig` commands then `/jackpotadmin lottery_open 100 48 3 100` to drain the 110k

https://claude.ai/code/session_019SKJtWEuw7wSpYVHg1r3oF

---
_Generated by [Claude Code](https://claude.ai/code/session_019SKJtWEuw7wSpYVHg1r3oF)_