### PR TITLE
fix(blackjack web): show every split hand's result and explain split-aces

### DIFF
--- a/web/src/main/resources/static/js/blackjack-solo.js
+++ b/web/src/main/resources/static/js/blackjack-solo.js
@@ -125,6 +125,63 @@
         return null;
     }
 
+    // Pure detector for the "active hand is a pre-split pair of aces" case.
+    // Cards on the wire are formatted by Card.toString() as
+    // `<rank-symbol><suit-symbol>` and the ACE rank symbol is the literal
+    // "A" — see database/card/Card.kt — so a leading "A" uniquely picks out
+    // an ace regardless of suit. Exposed for jest so the hint logic is
+    // testable without booting the full poll-driven page.
+    function isPairOfAces(cards) {
+        if (!cards || cards.length !== 2) return false;
+        return cards[0].charAt(0) === "A" && cards[1].charAt(0) === "A";
+    }
+
+    // Pure detector for "this resolved round had at least one split-ace
+    // hand". Used after settle to append the explainer line so a player
+    // who tapped Split before reading the pre-hint still sees why the
+    // dealer played immediately.
+    function hasSplitAceResolution(perHandResults) {
+        if (!perHandResults || !perHandResults.length) return false;
+        for (var i = 0; i < perHandResults.length; i++) {
+            var entry = perHandResults[i];
+            if (entry && entry.fromSplit && entry.cards && entry.cards.length &&
+                entry.cards[0].charAt(0) === "A") {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // Per-hand result label shared between the single-hand banner and the
+    // per-hand split lines. Returns { label, cls } so callers can pick the
+    // banner colour from the dominant outcome.
+    function labelForResult(result) {
+        switch (result) {
+            case "PLAYER_BLACKJACK": return { label: "Blackjack! Paid 3:2.", cls: "bj-win" };
+            case "PLAYER_WIN":       return { label: "You win.",             cls: "bj-win" };
+            case "PUSH":             return { label: "Push — stake refunded.", cls: "muted" };
+            case "DEALER_WIN":       return { label: "Dealer wins.",         cls: "bj-lose" };
+            case "PLAYER_BUST":      return { label: "Bust.",                cls: "bj-lose" };
+            default:                 return { label: "",                     cls: "muted" };
+        }
+    }
+
+    // Pick a single CSS class for the whole result block when split hands
+    // had mixed outcomes: any win > push > any loss. Mirrors the way the
+    // wallet actually moves — a player who pushed one and won the other
+    // ended the round up, so the banner shouldn't read as a loss.
+    function dominantResultClass(perHandResults) {
+        var sawWin = false, sawLoss = false;
+        for (var i = 0; i < perHandResults.length; i++) {
+            var r = perHandResults[i].result;
+            if (r === "PLAYER_WIN" || r === "PLAYER_BLACKJACK") sawWin = true;
+            else if (r === "DEALER_WIN" || r === "PLAYER_BUST") sawLoss = true;
+        }
+        if (sawWin) return "bj-win";
+        if (sawLoss) return "bj-lose";
+        return "muted";
+    }
+
     // Tiny factory the page uses to defer the win/lose banner until the
     // dealer's last freshly-revealed card finishes its CSS animation.
     // Hoisted so jest can drive it directly with fake timers — the
@@ -153,6 +210,10 @@
         window.TobyBlackjackSolo.validateStake = validateStake;
         window.TobyBlackjackSolo.errorToast = errorToast;
         window.TobyBlackjackSolo.createDeferredScheduler = createDeferredScheduler;
+        window.TobyBlackjackSolo.isPairOfAces = isPairOfAces;
+        window.TobyBlackjackSolo.hasSplitAceResolution = hasSplitAceResolution;
+        window.TobyBlackjackSolo.labelForResult = labelForResult;
+        window.TobyBlackjackSolo.dominantResultClass = dominantResultClass;
     }
 
     // ----- Page init. Bail out cleanly if we're loaded without the
@@ -178,6 +239,7 @@
     var splitBtn = document.getElementById("bj-action-split");
     var resultEl = document.getElementById("bj-result");
     var playerRowEl = document.getElementById("bj-player-row");
+    var splitAcesHintEl = document.getElementById("bj-split-aces-hint");
 
     var pollTimer = null;
     var resultDefer = createDeferredScheduler();
@@ -223,6 +285,18 @@
             playerTotalEl.textContent = seat ? "(" + seat.total + ")" : "";
         }
 
+        // Pre-action hint: when the active hand is a pair of aces and SPLIT
+        // is offered, surface the rule that split aces auto-stand on one
+        // card. The rules section already documents this (templates/
+        // blackjack-solo.html), but it's easy to miss in a long list — and
+        // the round visibly "skipping ahead" after the split feels like a
+        // bug at the moment it happens.
+        var activeCards = (slots && slots.length > 1)
+            ? ((slots[seat.activeHandIndex] || slots[0]).cards || [])
+            : (seat ? seat.hand : []);
+        var showAcesHint = state.phase === "PLAYER_TURNS" && state.isMyTurn &&
+            state.canSplit && isPairOfAces(activeCards);
+
         var becomingInactive = false;
         if (state.phase === "PLAYER_TURNS" && state.isMyTurn) {
             hitBtn.disabled = false;
@@ -233,12 +307,14 @@
             resultEl.textContent = "";
             resultEl.className = "bj-result muted";
             if (playerRowEl) playerRowEl.classList.add("is-active");
+            if (splitAcesHintEl) splitAcesHintEl.hidden = !showAcesHint;
         } else {
             hitBtn.disabled = true;
             standBtn.disabled = true;
             doubleBtn.disabled = true;
             splitBtn.disabled = true;
             splitBtn.hidden = true;
+            if (splitAcesHintEl) splitAcesHintEl.hidden = true;
             // Defer the .is-active drop to the next frame so it doesn't tear
             // down the seat's compositing layer in the same paint as the
             // chip-stack flourish below — mobile WebKit drops the chip
@@ -271,6 +347,10 @@
         // survives JS Number's 53-bit precision; lookup keys match exactly.
         var seatResult = (r.seatResults || {})[seat.discordId];
         // Fire the celebratory chip stack once per hand on a winning result.
+        // Driven off the seat's total payout, which already aggregates every
+        // split branch — so a "push hand 1, win hand 2" round still triggers
+        // the win flourish even though seatResults only carries hand 0's
+        // outcome.
         if (shouldFlash(state) && window.CasinoRender) {
             var payout = (r.payouts || {})[seat.discordId];
             if (payout && payout > 0 && playerRowEl) {
@@ -280,33 +360,46 @@
                 window.CasinoSounds.play(payout && payout > 0 ? "win" : "lose");
             }
         }
-        var label;
-        var cls = "muted";
-        switch (seatResult) {
-            case "PLAYER_BLACKJACK":
-                label = "Blackjack! Paid 3:2.";
-                cls = "bj-win";
-                break;
-            case "PLAYER_WIN":
-                label = "You win.";
-                cls = "bj-win";
-                break;
-            case "PUSH":
-                label = "Push — stake refunded.";
-                break;
-            case "DEALER_WIN":
-                label = "Dealer wins.";
-                cls = "bj-lose";
-                break;
-            case "PLAYER_BUST":
-                label = "Bust.";
-                cls = "bj-lose";
-                break;
-            default:
-                label = "";
+
+        // Reset the result block in case it's a re-render after a previous
+        // round (textContent assign replaces children, including any
+        // explainer/per-hand lines we appended last time).
+        resultEl.textContent = "";
+
+        // For a split round, seatResults only carries hand 0's outcome —
+        // see BlackjackService.settleSolo (firstHandResult). Surface every
+        // hand's result so a "push + win" round doesn't read as a pure
+        // push and silently drop the second hand's payout from view.
+        var seatPerHand = (r.perHandResults || []).filter(function (p) {
+            return p.discordId === seat.discordId;
+        });
+        if (seatPerHand.length > 1) {
+            resultEl.className = "bj-result " + dominantResultClass(seatPerHand);
+            seatPerHand.forEach(function (entry, idx) {
+                var line = document.createElement("div");
+                var info = labelForResult(entry.result);
+                var prefix = "Hand " + (idx + 1) + ": ";
+                var suffix = entry.payout > 0 ? " (+" + entry.payout + ")" : "";
+                line.textContent = prefix + info.label + suffix;
+                resultEl.appendChild(line);
+            });
+        } else {
+            var info = labelForResult(seatResult);
+            resultEl.textContent = info.label;
+            resultEl.className = "bj-result " + info.cls;
         }
-        resultEl.textContent = label;
-        resultEl.className = "bj-result " + cls;
+
+        // Post-resolution explainer: if any branch was a split-ace, append
+        // a small italic note explaining why the dealer played immediately.
+        // Helps a player who tapped Split before reading the pre-hint.
+        if (hasSplitAceResolution(r.perHandResults)) {
+            var note = document.createElement("small");
+            note.className = "muted";
+            note.style.display = "block";
+            note.style.fontStyle = "italic";
+            note.textContent = "Split aces auto-stood on one card by house rule.";
+            resultEl.appendChild(note);
+        }
     }
 
     function startPoll() {

--- a/web/src/main/resources/templates/blackjack-solo.html
+++ b/web/src/main/resources/templates/blackjack-solo.html
@@ -48,6 +48,11 @@
             <div id="bj-player-hands" class="bj-seats" hidden></div>
         </div>
 
+        <div id="bj-split-aces-hint" class="hint" hidden>
+            Heads up: splitting aces deals one card to each hand and auto-stands —
+            the dealer plays immediately after.
+        </div>
+
         <div class="bj-actions">
             <button id="bj-action-hit" class="btn-primary" type="button" disabled>Hit</button>
             <button id="bj-action-stand" class="btn-success" type="button" disabled>Stand</button>

--- a/web/src/test/js/blackjack-split-aces-hint.test.js
+++ b/web/src/test/js/blackjack-split-aces-hint.test.js
@@ -1,0 +1,105 @@
+// Two related fixes covered here:
+//
+// 1. Pre-action hint: the rule that split aces auto-stand on one card and
+//    the dealer plays right after is documented in the Rules list, but
+//    buried — players reported the round "skipping ahead" right after
+//    tapping Split on aces. The page now surfaces a contextual banner
+//    when the active hand is a pair of aces and SPLIT is offered.
+//
+// 2. Per-hand result display: BlackjackService.settleSolo only records
+//    hand 0's outcome in seatResults (firstHandResult), so a split round
+//    where hand 1 pushed and hand 2 won used to render only "Push —
+//    stake refunded.", silently dropping hand 2's win from the banner
+//    even though the wallet was correctly paid. renderResult now reads
+//    perHandResults and prints one line per hand whenever a seat played
+//    more than one hand.
+
+require('../../main/resources/static/js/casino-render');
+require('../../main/resources/static/js/blackjack-solo');
+
+const T = window.TobyBlackjackSolo;
+
+describe('TobyBlackjackSolo.isPairOfAces', () => {
+    test('two aces of any suits → true', () => {
+        expect(T.isPairOfAces(['A♠', 'A♥'])).toBe(true);
+        expect(T.isPairOfAces(['A♣', 'A♦'])).toBe(true);
+    });
+    test('non-aces or mixed → false', () => {
+        expect(T.isPairOfAces(['8♠', '8♥'])).toBe(false);
+        expect(T.isPairOfAces(['A♠', 'K♥'])).toBe(false);
+        expect(T.isPairOfAces(['A♠'])).toBe(false);
+        expect(T.isPairOfAces(['A♠', 'A♥', 'A♦'])).toBe(false);
+        expect(T.isPairOfAces([])).toBe(false);
+        expect(T.isPairOfAces(null)).toBe(false);
+    });
+});
+
+describe('TobyBlackjackSolo.hasSplitAceResolution', () => {
+    test('any fromSplit branch starting with an ace → true', () => {
+        expect(T.hasSplitAceResolution([
+            { fromSplit: true, cards: ['A♦', '8♣'], result: 'PUSH' },
+            { fromSplit: true, cards: ['A♣', '9♣'], result: 'PLAYER_WIN' },
+        ])).toBe(true);
+    });
+    test('non-ace splits → false', () => {
+        expect(T.hasSplitAceResolution([
+            { fromSplit: true, cards: ['8♠', '5♣'], result: 'PLAYER_WIN' },
+            { fromSplit: true, cards: ['8♥', 'J♦'], result: 'PLAYER_WIN' },
+        ])).toBe(false);
+    });
+    test('non-split aces (initial deal) → false', () => {
+        expect(T.hasSplitAceResolution([
+            { fromSplit: false, cards: ['A♠', 'K♥'], result: 'PLAYER_BLACKJACK' },
+        ])).toBe(false);
+    });
+    test('empty / missing → false', () => {
+        expect(T.hasSplitAceResolution([])).toBe(false);
+        expect(T.hasSplitAceResolution(undefined)).toBe(false);
+        expect(T.hasSplitAceResolution(null)).toBe(false);
+    });
+});
+
+describe('TobyBlackjackSolo.labelForResult', () => {
+    test('maps each enum to user-facing copy and CSS class', () => {
+        expect(T.labelForResult('PLAYER_BLACKJACK')).toEqual({ label: 'Blackjack! Paid 3:2.', cls: 'bj-win' });
+        expect(T.labelForResult('PLAYER_WIN')).toEqual({ label: 'You win.', cls: 'bj-win' });
+        expect(T.labelForResult('PUSH')).toEqual({ label: 'Push — stake refunded.', cls: 'muted' });
+        expect(T.labelForResult('DEALER_WIN')).toEqual({ label: 'Dealer wins.', cls: 'bj-lose' });
+        expect(T.labelForResult('PLAYER_BUST')).toEqual({ label: 'Bust.', cls: 'bj-lose' });
+    });
+    test('unknown result → empty muted label', () => {
+        expect(T.labelForResult('NOT_A_RESULT')).toEqual({ label: '', cls: 'muted' });
+        expect(T.labelForResult(undefined)).toEqual({ label: '', cls: 'muted' });
+    });
+});
+
+describe('TobyBlackjackSolo.dominantResultClass', () => {
+    // Mirrors the wallet's actual direction: any win shifts the banner
+    // green even if the other hand pushed or lost, because the player
+    // ended the round ahead. Push-only stays neutral. All-loss is red.
+    test('push + win → bj-win (the bug-report scenario)', () => {
+        expect(T.dominantResultClass([
+            { result: 'PUSH' }, { result: 'PLAYER_WIN' },
+        ])).toBe('bj-win');
+    });
+    test('blackjack counts as a win', () => {
+        expect(T.dominantResultClass([
+            { result: 'PLAYER_BLACKJACK' }, { result: 'DEALER_WIN' },
+        ])).toBe('bj-win');
+    });
+    test('all push → muted', () => {
+        expect(T.dominantResultClass([
+            { result: 'PUSH' }, { result: 'PUSH' },
+        ])).toBe('muted');
+    });
+    test('push + loss → bj-lose', () => {
+        expect(T.dominantResultClass([
+            { result: 'PUSH' }, { result: 'DEALER_WIN' },
+        ])).toBe('bj-lose');
+    });
+    test('all loss → bj-lose', () => {
+        expect(T.dominantResultClass([
+            { result: 'DEALER_WIN' }, { result: 'PLAYER_BUST' },
+        ])).toBe('bj-lose');
+    });
+});


### PR DESCRIPTION
## Summary

A player reported splitting two aces and seeing the dealer play out and the round resolve the instant SPLIT was tapped, with only "Push — stake refunded." in the result block — even though hand 2 actually won (A♣9♣ = 20 vs dealer 19) and the wallet was paid for it.

Two related display-only fixes here. **No backend, payout, or persistence changes** — the rule and the wallet math were correct, only the UI lagged.

- **Per-hand result display.** `BlackjackService.settleSolo` only stores hand 0's outcome in `seatResults` (`firstHandResult`), so split rounds with mixed outcomes silently dropped every hand after the first from the result banner. `renderResult` now reads `perHandResults` and prints one line per hand (with the hand's payout) whenever a seat played more than one hand, and picks the banner colour from the dominant outcome (any win → green, any loss without a win → red, otherwise neutral).
- **Split-aces explainer.** The standard rule that split aces auto-stand on one card and the dealer plays immediately is documented in the rules list, but buried — the round visibly "skipping ahead" feels like a bug at the moment it happens. Show a contextual hint above the action row when the active hand is a pair of aces, and append an italic explainer to the result block on resolution.

## Test plan

- [x] `npx jest src/test/js` — 29 suites, 328 tests pass (incl. new `blackjack-split-aces-hint.test.js` covering `isPairOfAces`, `hasSplitAceResolution`, `labelForResult`, `dominantResultClass`).
- [ ] Manual: deal until a pair of aces; confirm the hint banner shows above the action row; tap Split; confirm the result block lists `Hand 1: Push — stake refunded.` and `Hand 2: You win. (+1000)` with the italic "Split aces auto-stood on one card by house rule." line.
- [ ] Manual: deal a non-ace pair (e.g. 8-8); confirm the banner stays hidden and split flow renders one line per hand on resolution.
- [ ] Manual: deal a non-pair hand; confirm neither the banner nor the per-hand block appears.

https://claude.ai/code/session_01UfGfPAyfqJ9wN8NBtmKbo5

---
_Generated by [Claude Code](https://claude.ai/code/session_01UfGfPAyfqJ9wN8NBtmKbo5)_