### PR TITLE
feat(lottery): web UI + daily match-numbers (Pick 5/49) auto-draw

### DIFF
--- a/database/src/main/kotlin/database/dto/ConfigDto.kt
+++ b/database/src/main/kotlin/database/dto/ConfigDto.kt
@@ -192,7 +192,33 @@ class ConfigDto(
         // games with different baseline RTPs.
         COINFLIP_BOT_EDGE_MAX_PCT("COINFLIP_BOT_EDGE_MAX_PCT"),
         DICE_BOT_EDGE_MAX_PCT("DICE_BOT_EDGE_MAX_PCT"),
-        SLOTS_BOT_EDGE_MAX_PCT("SLOTS_BOT_EDGE_MAX_PCT");
+        SLOTS_BOT_EDGE_MAX_PCT("SLOTS_BOT_EDGE_MAX_PCT"),
+
+        // Daily match-numbers lottery (Pick 5 of 1-49) auto-draw toggle.
+        // Boolean ("true"/"false"); defaults to "false" so guilds opt in.
+        // When enabled, LotteryDailyJob runs at 00:00 UTC: closes the
+        // previous day's draw if any, opens a fresh one seeded from the
+        // jackpot pool. Doubles as a credit sink — a slice of every
+        // ticket sale routes back to the jackpot.
+        LOTTERY_DAILY_ENABLED("LOTTERY_DAILY_ENABLED"),
+
+        // Whole-number credits charged per match-numbers ticket. Default
+        // 50. Range 1-1_000_000. Tickets debit `count × ticket_price`
+        // from the buyer at submission time.
+        LOTTERY_DAILY_TICKET_PRICE("LOTTERY_DAILY_TICKET_PRICE"),
+
+        // Whole-number percentage (1-100) of the live jackpot pool that
+        // seeds each day's prize pool at open. Default 5. Lower = slower
+        // drain; higher = aggressive drain. Combined with ticket
+        // revenue, this is the prize budget for that day's draw.
+        LOTTERY_DAILY_SEED_PCT("LOTTERY_DAILY_SEED_PCT"),
+
+        // Whole-number percentage (0-100) of every match-numbers ticket
+        // sale routed to the per-guild jackpot pool; the remainder feeds
+        // the day's prize pool. Default 30. The 30/70 split makes the
+        // daily lottery a credit sink while keeping engagement-driven
+        // prize growth healthy.
+        LOTTERY_DAILY_REVENUE_JACKPOT_PCT("LOTTERY_DAILY_REVENUE_JACKPOT_PCT");
     }
 
     override fun toString(): String {

--- a/database/src/main/kotlin/database/dto/JackpotLotteryDto.kt
+++ b/database/src/main/kotlin/database/dto/JackpotLotteryDto.kt
@@ -13,19 +13,31 @@ import java.io.Serializable
 import java.time.Instant
 
 /**
- * Per-guild jackpot lottery event row.
+ * Per-guild jackpot lottery event row. Two flavours coexist on the
+ * same table, distinguished by [mode]:
  *
- * One OPEN row per guild at any time (enforced by a partial unique
- * index in V27). When the admin runs `/jackpotadmin lottery_draw`, the
- * service marks the row DRAWN and writes ticket-weighted payouts. On
- * `lottery_cancel` the row goes CANCELLED, all ticket spend is
- * refunded, and `pool_amount` returns to the per-guild jackpot pool.
+ *  - `TICKET_WEIGHTED`: admin-fired one-shot. Each ticket is a weight
+ *    in a top-K winner draw. `pickCount` / `numberMax` / `drawnNumbers`
+ *    are unused.
+ *  - `NUMBER_MATCH`: daily auto-draw. Players pick 5 numbers from
+ *    1-49; the job draws 5 winning numbers; payouts tier by match
+ *    count. `winnerCount` is unused (any number of holders can match).
+ *
+ * V28 added a partial unique index on (guild_id, mode) where status =
+ * 'OPEN', so one OPEN row per (guild, mode) is allowed — both flavours
+ * can run concurrently.
  */
 @NamedQueries(
     NamedQuery(
-        name = "JackpotLotteryDto.getOpenByGuild",
+        name = "JackpotLotteryDto.getOpenByGuildAndMode",
         query = "select l from JackpotLotteryDto l " +
-                "where l.guildId = :guildId and l.status = 'OPEN'"
+                "where l.guildId = :guildId and l.mode = :mode and l.status = 'OPEN'"
+    ),
+    NamedQuery(
+        name = "JackpotLotteryDto.getLatestByGuildAndMode",
+        query = "select l from JackpotLotteryDto l " +
+                "where l.guildId = :guildId and l.mode = :mode " +
+                "order by l.openedAt desc"
     )
 )
 @Entity
@@ -57,11 +69,30 @@ class JackpotLotteryDto(
 
     @Column(name = "status", nullable = false, length = 16)
     var status: String = "OPEN",
+
+    @Column(name = "mode", nullable = false, length = 16)
+    var mode: String = MODE_TICKET_WEIGHTED,
+
+    @Column(name = "pick_count", nullable = false)
+    var pickCount: Int = 0,
+
+    @Column(name = "number_max", nullable = false)
+    var numberMax: Int = 0,
+
+    /**
+     * Comma-separated winning numbers for NUMBER_MATCH draws. Null
+     * until status flips to DRAWN. Sorted ascending for stable display.
+     */
+    @Column(name = "drawn_numbers")
+    var drawnNumbers: String? = null,
 ) : Serializable {
 
     companion object {
         const val STATUS_OPEN = "OPEN"
         const val STATUS_DRAWN = "DRAWN"
         const val STATUS_CANCELLED = "CANCELLED"
+
+        const val MODE_TICKET_WEIGHTED = "TICKET_WEIGHTED"
+        const val MODE_NUMBER_MATCH = "NUMBER_MATCH"
     }
 }

--- a/database/src/main/kotlin/database/dto/JackpotLotteryTicketDto.kt
+++ b/database/src/main/kotlin/database/dto/JackpotLotteryTicketDto.kt
@@ -12,8 +12,15 @@ import java.io.Serializable
 
 /**
  * One row per (lottery, user) tracking the cumulative ticket count and
- * total credits the user has spent on this lottery. Weighting for the
- * draw is by `ticket_count`; `spent` is kept for refunds on cancel.
+ * total credits the user has spent on this lottery.
+ *
+ * - For TICKET_WEIGHTED lotteries: weighting for the draw is by
+ *   `ticket_count`; `spent` is kept for refunds on cancel.
+ * - For NUMBER_MATCH lotteries: each ticket carries the user's picks
+ *   in `picked_numbers` (comma-separated, sorted). One row per user
+ *   per draw; buying again on the same draw replaces picks (treat
+ *   each pick set as one ticket — `ticket_count` stays at 1 for
+ *   NUMBER_MATCH).
  */
 @NamedQueries(
     NamedQuery(
@@ -44,6 +51,13 @@ class JackpotLotteryTicketDto(
 
     @Column(name = "spent", nullable = false)
     var spent: Long = 0,
+
+    /**
+     * Comma-separated picks for NUMBER_MATCH tickets, sorted ascending.
+     * Null for TICKET_WEIGHTED tickets.
+     */
+    @Column(name = "picked_numbers")
+    var pickedNumbers: String? = null,
 ) : Serializable
 
 data class JackpotLotteryTicketId(

--- a/database/src/main/kotlin/database/dto/LotteryDailyDto.kt
+++ b/database/src/main/kotlin/database/dto/LotteryDailyDto.kt
@@ -1,0 +1,48 @@
+package database.dto
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.IdClass
+import jakarta.persistence.NamedQueries
+import jakarta.persistence.NamedQuery
+import jakarta.persistence.Table
+import org.springframework.transaction.annotation.Transactional
+import java.io.Serializable
+import java.time.LocalDate
+
+/**
+ * Idempotency ledger for the daily match-numbers lottery auto-draw.
+ *
+ * Mirrors [UbiDailyDto] (V24__ubi_daily.sql): one row per
+ * (guild, draw_date). The scheduled job consults [draw_date] before
+ * touching anything for that guild — if a row exists for today, the
+ * job already ran and the close/open cycle is skipped. Survives
+ * mid-cron restarts and accidental double-firing without
+ * double-drawing or double-seeding the prize pool.
+ */
+@NamedQueries(
+    NamedQuery(
+        name = "LotteryDailyDto.get",
+        query = "select d from LotteryDailyDto d " +
+                "where d.guildId = :guildId and d.drawDate = :drawDate"
+    )
+)
+@Entity
+@Table(name = "toby_coin_jackpot_lottery_daily", schema = "public")
+@IdClass(LotteryDailyId::class)
+@Transactional
+class LotteryDailyDto(
+    @Id
+    @Column(name = "guild_id")
+    var guildId: Long = 0,
+
+    @Id
+    @Column(name = "draw_date")
+    var drawDate: LocalDate = LocalDate.now(),
+) : Serializable
+
+data class LotteryDailyId(
+    var guildId: Long = 0,
+    var drawDate: LocalDate = LocalDate.now(),
+) : Serializable

--- a/database/src/main/kotlin/database/persistence/JackpotLotteryPersistence.kt
+++ b/database/src/main/kotlin/database/persistence/JackpotLotteryPersistence.kt
@@ -4,11 +4,22 @@ import database.dto.JackpotLotteryDto
 import database.dto.JackpotLotteryTicketDto
 
 interface JackpotLotteryPersistence {
-    /** Returns the single OPEN lottery row for [guildId], or null. */
-    fun getOpenByGuild(guildId: Long): JackpotLotteryDto?
+    /**
+     * Returns the OPEN lottery row for [guildId] in [mode], or null.
+     * One OPEN per (guild, mode) is enforced by the V28 partial unique
+     * index, so this returns at most one row.
+     */
+    fun getOpenByGuildAndMode(guildId: Long, mode: String): JackpotLotteryDto?
 
     /** SELECT … FOR UPDATE on the OPEN lottery row. Requires @Transactional. */
-    fun getOpenByGuildForUpdate(guildId: Long): JackpotLotteryDto?
+    fun getOpenByGuildAndModeForUpdate(guildId: Long, mode: String): JackpotLotteryDto?
+
+    /**
+     * Most-recent lottery row for [guildId] in [mode], regardless of
+     * status. Used for the web UI's "latest result" panel — pulls the
+     * last DRAWN row by [openedAt] desc.
+     */
+    fun getLatestByGuildAndMode(guildId: Long, mode: String): JackpotLotteryDto?
 
     fun upsert(lottery: JackpotLotteryDto): JackpotLotteryDto
 

--- a/database/src/main/kotlin/database/persistence/LotteryDailyPersistence.kt
+++ b/database/src/main/kotlin/database/persistence/LotteryDailyPersistence.kt
@@ -1,0 +1,12 @@
+package database.persistence
+
+import database.dto.LotteryDailyDto
+import java.time.LocalDate
+
+interface LotteryDailyPersistence {
+    /** Returns the row for (guildId, drawDate) or null. Read-only — no lock. */
+    fun get(guildId: Long, drawDate: LocalDate): LotteryDailyDto?
+
+    /** Insert (idempotency marker). No-op if the row already exists. */
+    fun upsert(row: LotteryDailyDto): LotteryDailyDto
+}

--- a/database/src/main/kotlin/database/persistence/impl/DefaultJackpotLotteryPersistence.kt
+++ b/database/src/main/kotlin/database/persistence/impl/DefaultJackpotLotteryPersistence.kt
@@ -18,20 +18,32 @@ class DefaultJackpotLotteryPersistence : JackpotLotteryPersistence {
     @PersistenceContext
     private lateinit var entityManager: EntityManager
 
-    override fun getOpenByGuild(guildId: Long): JackpotLotteryDto? {
+    override fun getOpenByGuildAndMode(guildId: Long, mode: String): JackpotLotteryDto? {
         val q: TypedQuery<JackpotLotteryDto> = entityManager.createNamedQuery(
-            "JackpotLotteryDto.getOpenByGuild", JackpotLotteryDto::class.java
+            "JackpotLotteryDto.getOpenByGuildAndMode", JackpotLotteryDto::class.java
         )
         q.setParameter("guildId", guildId)
+        q.setParameter("mode", mode)
         return q.resultList.firstOrNull()
     }
 
-    override fun getOpenByGuildForUpdate(guildId: Long): JackpotLotteryDto? {
+    override fun getOpenByGuildAndModeForUpdate(guildId: Long, mode: String): JackpotLotteryDto? {
         val q: TypedQuery<JackpotLotteryDto> = entityManager.createNamedQuery(
-            "JackpotLotteryDto.getOpenByGuild", JackpotLotteryDto::class.java
+            "JackpotLotteryDto.getOpenByGuildAndMode", JackpotLotteryDto::class.java
         )
         q.setParameter("guildId", guildId)
+        q.setParameter("mode", mode)
         q.lockMode = LockModeType.PESSIMISTIC_WRITE
+        return q.resultList.firstOrNull()
+    }
+
+    override fun getLatestByGuildAndMode(guildId: Long, mode: String): JackpotLotteryDto? {
+        val q: TypedQuery<JackpotLotteryDto> = entityManager.createNamedQuery(
+            "JackpotLotteryDto.getLatestByGuildAndMode", JackpotLotteryDto::class.java
+        )
+        q.setParameter("guildId", guildId)
+        q.setParameter("mode", mode)
+        q.maxResults = 1
         return q.resultList.firstOrNull()
     }
 

--- a/database/src/main/kotlin/database/persistence/impl/DefaultLotteryDailyPersistence.kt
+++ b/database/src/main/kotlin/database/persistence/impl/DefaultLotteryDailyPersistence.kt
@@ -1,0 +1,37 @@
+package database.persistence.impl
+
+import database.dto.LotteryDailyDto
+import database.persistence.LotteryDailyPersistence
+import jakarta.persistence.EntityManager
+import jakarta.persistence.PersistenceContext
+import jakarta.persistence.TypedQuery
+import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+
+@Repository
+@Transactional
+class DefaultLotteryDailyPersistence : LotteryDailyPersistence {
+
+    @PersistenceContext
+    private lateinit var entityManager: EntityManager
+
+    override fun get(guildId: Long, drawDate: LocalDate): LotteryDailyDto? {
+        val q: TypedQuery<LotteryDailyDto> =
+            entityManager.createNamedQuery("LotteryDailyDto.get", LotteryDailyDto::class.java)
+        q.setParameter("guildId", guildId)
+        q.setParameter("drawDate", drawDate)
+        return q.resultList.firstOrNull()
+    }
+
+    override fun upsert(row: LotteryDailyDto): LotteryDailyDto {
+        val existing = get(row.guildId, row.drawDate)
+        return if (existing == null) {
+            entityManager.persist(row)
+            entityManager.flush()
+            row
+        } else {
+            existing
+        }
+    }
+}

--- a/database/src/main/kotlin/database/service/JackpotLotteryService.kt
+++ b/database/src/main/kotlin/database/service/JackpotLotteryService.kt
@@ -10,34 +10,27 @@ import kotlin.math.max
 import kotlin.random.Random
 
 /**
- * Per-guild jackpot-pool lottery events.
+ * Per-guild jackpot-pool lottery events. Two flavours coexist on the
+ * same DB table, distinguished by the row's `mode`:
  *
- * Admins fire one of these to drain a runaway jackpot pool through a
- * ticketed multi-winner draw rather than letting one casino-roll
- * winner sweep the whole thing. Workflow:
+ *   - **TICKET_WEIGHTED** (admin-fired one-shot drain).
+ *     [openLottery] / [buyTickets] / [drawLottery] / [cancelLottery].
+ *     Each ticket is a weight; top-K winners share the pool 50/30/20-style.
  *
- *   1. [openLottery] — admin sets ticket price, duration, winner count
- *      and what fraction of the current pool seeds the prize. The seed
- *      amount is moved out of the per-guild jackpot row and parked on
- *      the lottery row's `pool_amount`.
- *   2. [buyTickets] — players spend credits; each purchase increments
- *      their ticket row and adds the spend to the lottery's prize
- *      `pool_amount` (so the prize grows with engagement).
- *   3. [drawLottery] — admin closes the lottery: weighted draw without
- *      replacement (probability ∝ ticket_count) picks `winner_count`
- *      winners, prize splits 50/30/20-style across them, winners are
- *      credited and recorded against [JackpotService.recordWin] so the
- *      cooldown gate covers both lottery and casino-roll wins.
- *   4. [cancelLottery] — admin cancels: every ticket buyer is refunded
- *      what they spent, the seed `pool_amount` returns to the per-guild
- *      jackpot row, and the lottery is marked CANCELLED.
+ *   - **NUMBER_MATCH** (daily auto-drain — Pick 5 of 1-49).
+ *     [openMatchLottery] / [buyMatchTicket] / [drawMatchLottery].
+ *     Players pick 5 distinct numbers from 1-49; the draw produces 5
+ *     winning numbers; payouts tier by match count
+ *     (5/4/3/2 → 60/25/10/5 % of pool). 0 / 1 matches pay nothing —
+ *     those tickets are the credit sink.
+ *
+ * V28 added a partial unique index on (guild_id, mode) where status =
+ * 'OPEN'; both modes can be open simultaneously without clashing.
  *
  * Concurrency: every mutation runs inside a `@Transactional` boundary
  * with a pessimistic write lock on the lottery row. Per-user ticket
- * rows are also locked on update so two simultaneous /lottery buy calls
- * from the same user can't double-spend their balance. Only one OPEN
- * lottery may exist per guild at a time, enforced by a partial unique
- * index in V27.
+ * rows are locked individually so two simultaneous /lottery buys from
+ * the same user can't double-spend.
  */
 @Service
 @Transactional
@@ -45,8 +38,13 @@ class JackpotLotteryService(
     private val lotteryPersistence: JackpotLotteryPersistence,
     private val jackpotService: JackpotService,
     private val userService: UserService,
+    private val configService: ConfigService,
     private val random: Random = Random.Default,
 ) {
+
+    // ===================================================================
+    // TICKET_WEIGHTED outcomes (existing)
+    // ===================================================================
 
     sealed interface OpenOutcome {
         data class Ok(val lottery: JackpotLotteryDto, val seeded: Long) : OpenOutcome
@@ -85,12 +83,52 @@ class JackpotLotteryService(
 
     data class WinnerPayout(val discordId: Long, val ticketCount: Int, val amount: Long)
 
+    // ===================================================================
+    // NUMBER_MATCH outcomes (new)
+    // ===================================================================
+
+    sealed interface BuyMatchOutcome {
+        data class Ok(
+            val pickedNumbers: List<Int>,
+            val totalSpent: Long,
+            val newBalance: Long,
+            val newPool: Long,
+            val jackpotInflow: Long,
+        ) : BuyMatchOutcome
+        data object NoOpenLottery : BuyMatchOutcome
+        data class InvalidPicks(val reason: String) : BuyMatchOutcome
+        data class Insufficient(val have: Long, val need: Long) : BuyMatchOutcome
+        data object UnknownUser : BuyMatchOutcome
+        data object AlreadyBought : BuyMatchOutcome
+    }
+
+    sealed interface DrawMatchOutcome {
+        data class Ok(
+            val drawnNumbers: List<Int>,
+            val tierPayouts: List<MatchTierPayout>,
+            val totalPaid: Long,
+            val drained: Long,
+            val rolledBackToJackpot: Long,
+        ) : DrawMatchOutcome
+        data object NoOpenLottery : DrawMatchOutcome
+        data object NoTickets : DrawMatchOutcome
+    }
+
     /**
-     * Open a new lottery for [guildId]. Pulls `floor(currentPool * drainPct)`
-     * out of the per-guild jackpot pool and parks it on the lottery row.
-     * Rejects if a lottery is already open, params are invalid, or the
-     * pool is empty (nothing to drain).
+     * One winner's match-tier payout.
+     * - [matches] is how many of their 5 picks matched the draw
+     * - [share] is the *per-winner* credit amount they received
      */
+    data class MatchTierPayout(
+        val discordId: Long,
+        val matches: Int,
+        val share: Long,
+    )
+
+    // ===================================================================
+    // TICKET_WEIGHTED methods (existing)
+    // ===================================================================
+
     fun openLottery(
         guildId: Long,
         ticketPrice: Long,
@@ -103,7 +141,10 @@ class JackpotLotteryService(
         if (winnerCount < 1) return OpenOutcome.InvalidParams("winner count must be >= 1")
         if (drainPct <= 0.0 || drainPct > 1.0) return OpenOutcome.InvalidParams("drain pct must be in (0, 1]")
 
-        if (lotteryPersistence.getOpenByGuildForUpdate(guildId) != null) return OpenOutcome.AlreadyOpen
+        if (lotteryPersistence.getOpenByGuildAndModeForUpdate(
+                guildId, JackpotLotteryDto.MODE_TICKET_WEIGHTED
+            ) != null
+        ) return OpenOutcome.AlreadyOpen
 
         val poolBefore = jackpotService.getPool(guildId)
         if (poolBefore == 0L) return OpenOutcome.EmptyPool
@@ -120,19 +161,16 @@ class JackpotLotteryService(
             openedAt = now,
             closesAt = now.plusSeconds(durationHours * 3600L),
             status = JackpotLotteryDto.STATUS_OPEN,
+            mode = JackpotLotteryDto.MODE_TICKET_WEIGHTED,
         )
         return OpenOutcome.Ok(lotteryPersistence.upsert(lottery), seeded = drained)
     }
 
-    /**
-     * Buy [ticketCount] tickets in the open lottery for [guildId].
-     * Debits the user's social_credit, increments the ticket row, and
-     * adds the spend to the lottery's prize pool.
-     */
     fun buyTickets(guildId: Long, discordId: Long, ticketCount: Int): BuyOutcome {
         if (ticketCount <= 0) return BuyOutcome.InvalidCount(ticketCount)
-        val lottery = lotteryPersistence.getOpenByGuildForUpdate(guildId)
-            ?: return BuyOutcome.NoOpenLottery
+        val lottery = lotteryPersistence.getOpenByGuildAndModeForUpdate(
+            guildId, JackpotLotteryDto.MODE_TICKET_WEIGHTED
+        ) ?: return BuyOutcome.NoOpenLottery
 
         val cost = lottery.ticketPrice * ticketCount.toLong()
 
@@ -171,16 +209,10 @@ class JackpotLotteryService(
         )
     }
 
-    /**
-     * Close the open lottery for [guildId]. Picks `winner_count` winners
-     * via weighted draw without replacement; splits `pool_amount`
-     * across them with a 50/30/20-style schedule (single winner gets
-     * 100 %); credits each, records the wins for cooldown, and marks
-     * the lottery DRAWN.
-     */
     fun drawLottery(guildId: Long): DrawOutcome {
-        val lottery = lotteryPersistence.getOpenByGuildForUpdate(guildId)
-            ?: return DrawOutcome.NoOpenLottery
+        val lottery = lotteryPersistence.getOpenByGuildAndModeForUpdate(
+            guildId, JackpotLotteryDto.MODE_TICKET_WEIGHTED
+        ) ?: return DrawOutcome.NoOpenLottery
         val lotteryId = lottery.id ?: error("Open lottery has no id")
         val tickets = lotteryPersistence.ticketsByLottery(lotteryId)
         if (tickets.isEmpty() || tickets.sumOf { it.ticketCount.toLong() } == 0L) return DrawOutcome.NoTickets
@@ -215,14 +247,10 @@ class JackpotLotteryService(
         return DrawOutcome.Ok(payouts = payouts, totalPaid = totalPaid, drained = drained)
     }
 
-    /**
-     * Cancel the open lottery for [guildId]: refund every buyer the
-     * credits they spent, return `pool_amount` to the per-guild
-     * jackpot pool, and mark the row CANCELLED.
-     */
     fun cancelLottery(guildId: Long): CancelOutcome {
-        val lottery = lotteryPersistence.getOpenByGuildForUpdate(guildId)
-            ?: return CancelOutcome.NoOpenLottery
+        val lottery = lotteryPersistence.getOpenByGuildAndModeForUpdate(
+            guildId, JackpotLotteryDto.MODE_TICKET_WEIGHTED
+        ) ?: return CancelOutcome.NoOpenLottery
         val lotteryId = lottery.id ?: error("Open lottery has no id")
         val tickets = lotteryPersistence.ticketsByLottery(lotteryId)
 
@@ -248,22 +276,280 @@ class JackpotLotteryService(
     }
 
     /** Read-only summary for `/lottery status` and the moderation tab. */
-    fun getOpen(guildId: Long): JackpotLotteryDto? = lotteryPersistence.getOpenByGuild(guildId)
+    fun getOpenWeighted(guildId: Long): JackpotLotteryDto? =
+        lotteryPersistence.getOpenByGuildAndMode(guildId, JackpotLotteryDto.MODE_TICKET_WEIGHTED)
 
-    fun ticketsForOpen(guildId: Long): List<JackpotLotteryTicketDto> {
-        val open = lotteryPersistence.getOpenByGuild(guildId) ?: return emptyList()
+    fun ticketsForOpenWeighted(guildId: Long): List<JackpotLotteryTicketDto> {
+        val open = getOpenWeighted(guildId) ?: return emptyList()
         val id = open.id ?: return emptyList()
         return lotteryPersistence.ticketsByLottery(id)
     }
 
+    // ===================================================================
+    // NUMBER_MATCH methods (new)
+    // ===================================================================
+
     /**
-     * Pick [count] winners by ticket-weighted draw without replacement.
-     * The same physical ticket can never win twice; once a holder is
-     * picked, their entire ticket count is removed from the bag for the
-     * subsequent picks. If [count] exceeds the number of distinct
-     * holders, the result is shorter than [count] (the prize for the
-     * unfilled slots rolls back into the per-guild pool via the
-     * remainder-handling in [drawLottery]).
+     * Open a NUMBER_MATCH daily lottery for [guildId]. Seeds the prize
+     * pool with `floor(currentJackpot * seedPct/100)`, sets pick_count =
+     * 5 and number_max = 49 (Lotto-style), and stays open for
+     * [durationHours]. Rejects if a NUMBER_MATCH lottery is already
+     * open. Unlike weighted, an empty jackpot is OK — players' tickets
+     * still grow the prize pool.
+     */
+    fun openMatchLottery(
+        guildId: Long,
+        ticketPrice: Long,
+        seedPct: Long,
+        durationHours: Long,
+    ): OpenOutcome {
+        if (ticketPrice <= 0L) return OpenOutcome.InvalidParams("ticket price must be > 0")
+        if (durationHours <= 0L) return OpenOutcome.InvalidParams("duration must be > 0 hours")
+        if (seedPct < 0L || seedPct > 100L) return OpenOutcome.InvalidParams("seed pct must be in [0, 100]")
+
+        if (lotteryPersistence.getOpenByGuildAndModeForUpdate(
+                guildId, JackpotLotteryDto.MODE_NUMBER_MATCH
+            ) != null
+        ) return OpenOutcome.AlreadyOpen
+
+        val poolBefore = jackpotService.getPool(guildId)
+        // 0-pool is fine for NUMBER_MATCH — engagement-driven prize pool.
+        val seed = if (poolBefore <= 0L || seedPct <= 0L) 0L else
+            kotlin.math.floor(poolBefore * (seedPct.toDouble() / 100.0)).toLong().coerceAtMost(poolBefore)
+        val drained = if (seed > 0L) drainFromPool(guildId, seed) else 0L
+
+        val now = Instant.now()
+        val lottery = JackpotLotteryDto(
+            guildId = guildId,
+            ticketPrice = ticketPrice,
+            poolAmount = drained,
+            winnerCount = 0,                 // unused for NUMBER_MATCH
+            openedAt = now,
+            closesAt = now.plusSeconds(durationHours * 3600L),
+            status = JackpotLotteryDto.STATUS_OPEN,
+            mode = JackpotLotteryDto.MODE_NUMBER_MATCH,
+            pickCount = LotteryHelper.MATCH_PICK_COUNT,
+            numberMax = LotteryHelper.MATCH_NUMBER_MAX,
+        )
+        return OpenOutcome.Ok(lotteryPersistence.upsert(lottery), seeded = drained)
+    }
+
+    /**
+     * Buy a NUMBER_MATCH ticket with a specific pick set. Picks must be
+     * exactly [LotteryHelper.MATCH_PICK_COUNT] distinct ints in
+     * `[1, MATCH_NUMBER_MAX]`. Each user can buy at most one ticket per
+     * draw — repeated buys return [BuyMatchOutcome.AlreadyBought]; pick
+     * what you want, you live with it.
+     *
+     * Revenue split: the configured
+     * `LOTTERY_DAILY_REVENUE_JACKPOT_PCT` of the cost routes back to
+     * the per-guild jackpot pool; the rest feeds today's prize pool.
+     * The 30/70 default makes the daily a credit sink while letting
+     * engagement grow the prize pool.
+     */
+    fun buyMatchTicket(guildId: Long, discordId: Long, picks: List<Int>): BuyMatchOutcome {
+        val pickCount = LotteryHelper.MATCH_PICK_COUNT
+        val numberMax = LotteryHelper.MATCH_NUMBER_MAX
+        val validation = validatePicks(picks, pickCount, numberMax)
+        if (validation != null) return BuyMatchOutcome.InvalidPicks(validation)
+
+        val lottery = lotteryPersistence.getOpenByGuildAndModeForUpdate(
+            guildId, JackpotLotteryDto.MODE_NUMBER_MATCH
+        ) ?: return BuyMatchOutcome.NoOpenLottery
+
+        val lotteryId = lottery.id ?: error("Open lottery has no id")
+        if (lotteryPersistence.getTicketForUpdate(lotteryId, discordId) != null) {
+            return BuyMatchOutcome.AlreadyBought
+        }
+
+        val cost = lottery.ticketPrice
+        val user = userService.getUserByIdForUpdate(discordId, guildId)
+            ?: return BuyMatchOutcome.UnknownUser
+        val balance = user.socialCredit ?: 0L
+        if (balance < cost) return BuyMatchOutcome.Insufficient(have = balance, need = cost)
+
+        user.socialCredit = balance - cost
+        userService.updateUser(user)
+
+        val sortedPicks = picks.sorted()
+        lotteryPersistence.upsertTicket(
+            JackpotLotteryTicketDto(
+                lotteryId = lotteryId,
+                discordId = discordId,
+                ticketCount = 1,
+                spent = cost,
+                pickedNumbers = sortedPicks.joinToString(","),
+            )
+        )
+
+        val jackpotPct = LotteryHelper.dailyRevenueJackpotPct(configService, guildId)
+        val toJackpot = kotlin.math.floor(cost * (jackpotPct.toDouble() / 100.0)).toLong().coerceIn(0L, cost)
+        val toPrize = cost - toJackpot
+
+        if (toPrize > 0L) {
+            lottery.poolAmount += toPrize
+            lotteryPersistence.upsert(lottery)
+        }
+        if (toJackpot > 0L) {
+            jackpotService.addToPool(guildId, toJackpot)
+        }
+
+        return BuyMatchOutcome.Ok(
+            pickedNumbers = sortedPicks,
+            totalSpent = cost,
+            newBalance = user.socialCredit ?: (balance - cost),
+            newPool = lottery.poolAmount,
+            jackpotInflow = toJackpot,
+        )
+    }
+
+    /**
+     * Draw a NUMBER_MATCH lottery: pick 5 winning numbers, compute
+     * match counts per ticket, distribute the prize pool by tier.
+     *
+     * Tier shares (60/25/10/5 % of pool, see [LotteryHelper.TIER_PCTS_5_4_3_2]):
+     *   - 5/5 matches share 60% equally
+     *   - 4/5 share 25% equally
+     *   - 3/5 share 10% equally
+     *   - 2/5 share 5% equally
+     *   - 0/5 and 1/5 win nothing — sink for the day.
+     *
+     * Empty tiers and rounding remainders roll back into the per-guild
+     * jackpot pool so credits never vanish.
+     *
+     * Returns [DrawMatchOutcome.NoTickets] when no one bought today —
+     * the caller (scheduler) is expected to refund the seed in that
+     * case via [cancelMatchLottery].
+     */
+    fun drawMatchLottery(guildId: Long): DrawMatchOutcome {
+        val lottery = lotteryPersistence.getOpenByGuildAndModeForUpdate(
+            guildId, JackpotLotteryDto.MODE_NUMBER_MATCH
+        ) ?: return DrawMatchOutcome.NoOpenLottery
+        val lotteryId = lottery.id ?: error("Open lottery has no id")
+        val tickets = lotteryPersistence.ticketsByLottery(lotteryId)
+        if (tickets.isEmpty()) return DrawMatchOutcome.NoTickets
+
+        val drawn = drawNumbers(lottery.numberMax, lottery.pickCount, random)
+        val drawnSet = drawn.toSet()
+
+        // Group tickets by match count (0..pickCount).
+        val byMatches = (0..lottery.pickCount).associateWith { mutableListOf<JackpotLotteryTicketDto>() }
+        for (ticket in tickets) {
+            val picks = parsePicks(ticket.pickedNumbers)
+            val matches = picks.count { it in drawnSet }
+            byMatches[matches]?.add(ticket)
+        }
+
+        val totalPool = lottery.poolAmount
+        val tierShares = computeTierShares(totalPool, LotteryHelper.TIER_PCTS_5_4_3_2)
+        val payouts = mutableListOf<MatchTierPayout>()
+        var totalPaid = 0L
+
+        // Tier order: 5, 4, 3, 2 matches → indexes 0..3 in tierShares.
+        val tierMatchCounts = listOf(5, 4, 3, 2)
+        tierMatchCounts.forEachIndexed { tierIndex, matchCount ->
+            val share = tierShares[tierIndex]
+            if (share <= 0L) return@forEachIndexed
+            val winners = byMatches[matchCount].orEmpty()
+            if (winners.isEmpty()) return@forEachIndexed
+            val perWinner = share / winners.size
+            if (perWinner <= 0L) return@forEachIndexed
+            for (ticket in winners) {
+                val user = userService.getUserByIdForUpdate(ticket.discordId, guildId) ?: continue
+                user.socialCredit = (user.socialCredit ?: 0L) + perWinner
+                userService.updateUser(user)
+                jackpotService.recordWin(guildId, ticket.discordId, perWinner)
+                payouts += MatchTierPayout(ticket.discordId, matchCount, perWinner)
+                totalPaid += perWinner
+            }
+        }
+
+        lottery.drawnNumbers = drawn.joinToString(",")
+        lottery.poolAmount = 0L
+        lottery.status = JackpotLotteryDto.STATUS_DRAWN
+        lotteryPersistence.upsert(lottery)
+
+        val remainder = totalPool - totalPaid
+        val rolledBack = if (remainder > 0L) {
+            jackpotService.addToPool(guildId, remainder)
+            remainder
+        } else 0L
+
+        return DrawMatchOutcome.Ok(
+            drawnNumbers = drawn,
+            tierPayouts = payouts,
+            totalPaid = totalPaid,
+            drained = totalPool,
+            rolledBackToJackpot = rolledBack,
+        )
+    }
+
+    /**
+     * Cancel an open NUMBER_MATCH lottery: refund every buyer their
+     * spend (the prize portion of their ticket cost — the jackpot
+     * portion already left the user's wallet on buy and isn't here to
+     * refund). Returns the seed share to the per-guild jackpot pool.
+     *
+     * Used by the scheduler when a draw rolls but no tickets were
+     * bought (no one to draw against).
+     */
+    fun cancelMatchLottery(guildId: Long): CancelOutcome {
+        val lottery = lotteryPersistence.getOpenByGuildAndModeForUpdate(
+            guildId, JackpotLotteryDto.MODE_NUMBER_MATCH
+        ) ?: return CancelOutcome.NoOpenLottery
+        val lotteryId = lottery.id ?: error("Open lottery has no id")
+        val tickets = lotteryPersistence.ticketsByLottery(lotteryId)
+
+        var refundedTotal = 0L
+        var refundedUsers = 0
+        for (t in tickets) {
+            if (t.spent <= 0L) continue
+            val user = userService.getUserByIdForUpdate(t.discordId, guildId) ?: continue
+            user.socialCredit = (user.socialCredit ?: 0L) + t.spent
+            userService.updateUser(user)
+            refundedTotal += t.spent
+            refundedUsers++
+        }
+
+        val seedReturn = (lottery.poolAmount - refundedTotal).coerceAtLeast(0L)
+        if (seedReturn > 0L) jackpotService.addToPool(guildId, seedReturn)
+
+        lottery.poolAmount = 0L
+        lottery.status = JackpotLotteryDto.STATUS_CANCELLED
+        lotteryPersistence.upsert(lottery)
+
+        return CancelOutcome.Ok(refundedUsers, refundedTotal, returnedToPool = seedReturn)
+    }
+
+    /** Read-only: current open NUMBER_MATCH lottery for [guildId], if any. */
+    fun getOpenMatch(guildId: Long): JackpotLotteryDto? =
+        lotteryPersistence.getOpenByGuildAndMode(guildId, JackpotLotteryDto.MODE_NUMBER_MATCH)
+
+    /** Read-only: most-recent NUMBER_MATCH row (any status) for the result panel. */
+    fun getLatestMatch(guildId: Long): JackpotLotteryDto? =
+        lotteryPersistence.getLatestByGuildAndMode(guildId, JackpotLotteryDto.MODE_NUMBER_MATCH)
+
+    /** Read-only: tickets for the current open NUMBER_MATCH lottery. */
+    fun ticketsForOpenMatch(guildId: Long): List<JackpotLotteryTicketDto> {
+        val open = getOpenMatch(guildId) ?: return emptyList()
+        val id = open.id ?: return emptyList()
+        return lotteryPersistence.ticketsByLottery(id)
+    }
+
+    /** This user's ticket for the current open NUMBER_MATCH, if bought. */
+    fun userTicketForOpenMatch(guildId: Long, discordId: Long): JackpotLotteryTicketDto? {
+        val open = getOpenMatch(guildId) ?: return null
+        val id = open.id ?: return null
+        return lotteryPersistence.ticketsByLottery(id).firstOrNull { it.discordId == discordId }
+    }
+
+    // ===================================================================
+    // Internal helpers (testable)
+    // ===================================================================
+
+    /**
+     * Pick [count] distinct winners by ticket-weighted draw without
+     * replacement. Used by TICKET_WEIGHTED draws.
      */
     internal fun drawWinners(
         tickets: List<JackpotLotteryTicketDto>,
@@ -292,14 +578,13 @@ class JackpotLotteryService(
     }
 
     /**
-     * Split [pool] across [slots] winner slots. Schedule:
+     * Split [pool] across [slots] winner slots for TICKET_WEIGHTED.
+     * Schedule:
      *  - 1 winner: 100
      *  - 2 winners: 60/40
      *  - 3 winners: 50/30/20
      *  - 4 winners: 40/30/20/10
      *  - 5+ winners: linear taper that always sums to 100
-     * Floor each share to a whole credit; the rounding remainder is
-     * handled by [drawLottery] (sent back into the per-guild jackpot).
      */
     internal fun prizeShares(slots: Int, pool: Long): List<Long> {
         if (slots <= 0 || pool <= 0L) return emptyList()
@@ -309,7 +594,6 @@ class JackpotLotteryService(
             3 -> doubleArrayOf(0.5, 0.3, 0.2)
             4 -> doubleArrayOf(0.4, 0.3, 0.2, 0.1)
             else -> {
-                // Linear taper: weight i = (slots - i); normalise.
                 val raw = DoubleArray(slots) { (slots - it).toDouble() }
                 val sum = raw.sum().coerceAtLeast(1.0)
                 DoubleArray(slots) { raw[it] / sum }
@@ -319,17 +603,63 @@ class JackpotLotteryService(
     }
 
     /**
-     * Decrement the per-guild jackpot row by [amount]. Mirrors the lock
-     * + mutate + upsert idiom in `JackpotService.awardJackpot` so the
-     * draw doesn't leak credits and matches the same concurrency
-     * contract. Caller must already be inside a @Transactional boundary.
+     * Pick [count] distinct numbers in `[1, max]` for a NUMBER_MATCH
+     * draw. Result is sorted ascending for stable display in the
+     * `drawn_numbers` column and matched-pick UI.
+     */
+    internal fun drawNumbers(max: Int, count: Int, random: Random): List<Int> {
+        require(count in 1..max) { "count must be in 1..max ($count, $max)" }
+        val pool = (1..max).toMutableList()
+        val out = mutableListOf<Int>()
+        repeat(count) {
+            val index = random.nextInt(pool.size)
+            out += pool.removeAt(index)
+        }
+        return out.sorted()
+    }
+
+    /**
+     * Convert tier percentages [60, 25, 10, 5] to per-tier credit
+     * amounts using `floor` (rounding remainder rolls to jackpot).
+     */
+    internal fun computeTierShares(pool: Long, tierPcts: IntArray): LongArray {
+        if (pool <= 0L) return LongArray(tierPcts.size)
+        return LongArray(tierPcts.size) { i ->
+            kotlin.math.floor(pool * (tierPcts[i].toDouble() / 100.0)).toLong().coerceAtLeast(0L)
+        }
+    }
+
+    /**
+     * Validate a NUMBER_MATCH pick set. Returns null when valid; an
+     * error reason string otherwise. Centralised so the controller can
+     * surface a friendly 400 message.
+     */
+    internal fun validatePicks(picks: List<Int>, pickCount: Int, numberMax: Int): String? {
+        if (picks.size != pickCount) return "must select exactly $pickCount numbers"
+        if (picks.toSet().size != picks.size) return "picks must be distinct"
+        val outOfRange = picks.firstOrNull { it < 1 || it > numberMax }
+        if (outOfRange != null) return "picks must be in 1..$numberMax (got $outOfRange)"
+        return null
+    }
+
+    /**
+     * Parse the comma-separated `picked_numbers` column on a ticket
+     * row. Returns an empty list when null/blank — the row is
+     * effectively a non-pick (which counts as 0 matches).
+     */
+    internal fun parsePicks(csv: String?): List<Int> {
+        if (csv.isNullOrBlank()) return emptyList()
+        return csv.split(',').mapNotNull { it.trim().toIntOrNull() }
+    }
+
+    /**
+     * Decrement the per-guild jackpot row by [amount]. Mirrors the
+     * lock+mutate+upsert idiom in `JackpotService.awardJackpot`.
      */
     private fun drainFromPool(guildId: Long, amount: Long): Long {
         if (amount <= 0L) return 0L
-        // We don't have a public partial-drain on JackpotService; reset
-        // and re-deposit the leftover — a single transaction so the pool
-        // never observably gaps. This matches the resetPool→addToPool
-        // sequence the moderation flow already uses.
+        // resetPool→addToPool keeps the pool atomically non-gappy and
+        // matches the pattern used elsewhere in the codebase.
         val pool = jackpotService.resetPool(guildId)
         val drained = amount.coerceAtMost(pool)
         val leftover = pool - drained

--- a/database/src/main/kotlin/database/service/LotteryDailyService.kt
+++ b/database/src/main/kotlin/database/service/LotteryDailyService.kt
@@ -1,0 +1,36 @@
+package database.service
+
+import database.dto.LotteryDailyDto
+import database.persistence.LotteryDailyPersistence
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+
+/**
+ * Idempotency ledger for the daily match-numbers lottery auto-draw.
+ *
+ * Mirrors the [UbiDailyService] pattern: the scheduler asks
+ * [alreadyRan] before doing any work for a guild on a given date, then
+ * calls [markRan] once the open/draw work is committed. A row in the
+ * underlying ledger means "today's cycle for this guild is done";
+ * subsequent same-day invocations short-circuit.
+ */
+@Service
+@Transactional
+class LotteryDailyService(
+    private val persistence: LotteryDailyPersistence,
+) {
+
+    /** Has the daily lottery cycle already run for [guildId] on [drawDate]? */
+    fun alreadyRan(guildId: Long, drawDate: LocalDate): Boolean =
+        persistence.get(guildId, drawDate) != null
+
+    /**
+     * Record that the daily cycle ran for [guildId] on [drawDate]. Safe
+     * to call repeatedly — duplicate inserts are no-ops because the
+     * persistence layer treats the composite key as upsert-or-skip.
+     */
+    fun markRan(guildId: Long, drawDate: LocalDate) {
+        persistence.upsert(LotteryDailyDto(guildId = guildId, drawDate = drawDate))
+    }
+}

--- a/database/src/main/kotlin/database/service/LotteryHelper.kt
+++ b/database/src/main/kotlin/database/service/LotteryHelper.kt
@@ -1,0 +1,101 @@
+package database.service
+
+import database.dto.ConfigDto
+
+/**
+ * Per-guild daily match-numbers lottery configuration getters.
+ * Mirrors the shape of [JackpotHelper] config getters: read the admin
+ * config, parse, validate range, fall back to a defined default. All
+ * of these are read on every job tick / ticket buy — kept side-effect-
+ * free so they can be safely called outside a transaction.
+ *
+ * The daily flow ties into [JackpotLotteryService.openMatchLottery] /
+ * [JackpotLotteryService.buyMatchTicket] / [JackpotLotteryService.drawMatchLottery]
+ * — the values here drive the daily draw's economics.
+ */
+object LotteryHelper {
+
+    /**
+     * Pick 5 of 1-49 — Lotto-style. Hardcoded for now because the prize
+     * tier schedule was tuned to these odds; varying pick count would
+     * need a fresh schedule and is out of scope for the daily MVP.
+     */
+    const val MATCH_PICK_COUNT: Int = 5
+    const val MATCH_NUMBER_MAX: Int = 49
+
+    /** Daily auto-draw is opt-in per guild. */
+    const val DEFAULT_DAILY_ENABLED: Boolean = false
+
+    /** Default credits charged per match-numbers ticket. */
+    const val DEFAULT_DAILY_TICKET_PRICE: Long = 50L
+    const val MAX_DAILY_TICKET_PRICE: Long = 1_000_000L
+
+    /**
+     * Default % of the per-guild jackpot pool that seeds each day's
+     * prize pool at open. 5% of a 200k pool = 10k seed; combined with
+     * ticket revenue, that's the daily prize budget.
+     */
+    const val DEFAULT_DAILY_SEED_PCT: Long = 5L
+    const val MAX_DAILY_SEED_PCT: Long = 100L
+
+    /**
+     * Default % of every ticket sale that routes to the per-guild
+     * jackpot pool. The remainder (70%) feeds the day's prize pool.
+     * Higher = stronger sink; lower = bigger daily prizes from
+     * engagement.
+     */
+    const val DEFAULT_DAILY_REVENUE_JACKPOT_PCT: Long = 30L
+    const val MAX_DAILY_REVENUE_JACKPOT_PCT: Long = 100L
+
+    /**
+     * Tier prize percentages for a match-numbers draw. Order: 5/5, 4/5,
+     * 3/5, 2/5. Sum = 100; un-won tier shares roll back into the
+     * per-guild jackpot pool via the remainder-handling in
+     * [JackpotLotteryService.drawMatchLottery]. 0 / 1 matches pay
+     * nothing — those tickets are the sink.
+     */
+    val TIER_PCTS_5_4_3_2: IntArray = intArrayOf(60, 25, 10, 5)
+
+    /** Live boolean toggle for the daily auto-draw. */
+    fun dailyEnabled(configService: ConfigService, guildId: Long): Boolean {
+        val raw = configService.getConfigByName(
+            ConfigDto.Configurations.LOTTERY_DAILY_ENABLED.configValue,
+            guildId.toString()
+        )?.value?.trim()?.lowercase()
+        return when (raw) {
+            "true", "1", "yes", "on" -> true
+            null -> DEFAULT_DAILY_ENABLED
+            else -> false
+        }
+    }
+
+    /** Live ticket price for the daily lottery. */
+    fun dailyTicketPrice(configService: ConfigService, guildId: Long): Long {
+        val cfg = configService.getConfigByName(
+            ConfigDto.Configurations.LOTTERY_DAILY_TICKET_PRICE.configValue,
+            guildId.toString()
+        )
+        val price = cfg?.value?.toLongOrNull() ?: return DEFAULT_DAILY_TICKET_PRICE
+        return price.coerceIn(1L, MAX_DAILY_TICKET_PRICE)
+    }
+
+    /** Live seed % of the jackpot pool to fund the day's prize pool. */
+    fun dailySeedPct(configService: ConfigService, guildId: Long): Long {
+        val cfg = configService.getConfigByName(
+            ConfigDto.Configurations.LOTTERY_DAILY_SEED_PCT.configValue,
+            guildId.toString()
+        )
+        val pct = cfg?.value?.toLongOrNull() ?: return DEFAULT_DAILY_SEED_PCT
+        return pct.coerceIn(1L, MAX_DAILY_SEED_PCT)
+    }
+
+    /** Live % of ticket revenue routed to jackpot (rest = prize pool). */
+    fun dailyRevenueJackpotPct(configService: ConfigService, guildId: Long): Long {
+        val cfg = configService.getConfigByName(
+            ConfigDto.Configurations.LOTTERY_DAILY_REVENUE_JACKPOT_PCT.configValue,
+            guildId.toString()
+        )
+        val pct = cfg?.value?.toLongOrNull() ?: return DEFAULT_DAILY_REVENUE_JACKPOT_PCT
+        return pct.coerceIn(0L, MAX_DAILY_REVENUE_JACKPOT_PCT)
+    }
+}

--- a/database/src/main/resources/db/migration/V28__lottery_match_numbers.sql
+++ b/database/src/main/resources/db/migration/V28__lottery_match_numbers.sql
@@ -1,0 +1,48 @@
+-- Match-numbers (Pick 5 of 1-49) lottery variant + daily-draw
+-- idempotency table.
+--
+-- The existing `toby_coin_jackpot_lottery` table held only one mode of
+-- lottery: TICKET_WEIGHTED, where each ticket was a weight in the draw
+-- and top-K winners shared the prize. PR #405 shipped this for
+-- admin-fired one-shot drain events. We now add a second mode,
+-- NUMBER_MATCH, that runs DAILY: players pick 5 numbers from 1-49,
+-- the job draws 5 winning numbers at midnight UTC, and prize tiers
+-- pay by match count (5/4/3/2 matches → 60/25/10/5 % of pool).
+--
+-- Both modes coexist: one OPEN row is allowed per (guild, mode), so
+-- an admin-fired weighted lottery can run alongside the daily
+-- match-numbers draw without clashing.
+
+-- 1. Distinguish the two lottery modes on existing rows. Existing rows
+--    are TICKET_WEIGHTED by default so back-compat is automatic.
+ALTER TABLE toby_coin_jackpot_lottery
+    ADD COLUMN mode VARCHAR(16) NOT NULL DEFAULT 'TICKET_WEIGHTED'
+        CHECK (mode IN ('TICKET_WEIGHTED', 'NUMBER_MATCH'));
+
+-- 2. Match-numbers picks/draw. Fixed at 5/49 in the MVP — columns are
+--    here so a future variant can vary without another migration.
+ALTER TABLE toby_coin_jackpot_lottery
+    ADD COLUMN pick_count    INT NOT NULL DEFAULT 0,
+    ADD COLUMN number_max    INT NOT NULL DEFAULT 0,
+    ADD COLUMN drawn_numbers VARCHAR(64);  -- comma-separated, NULL until DRAWN
+
+-- 3. Per-ticket picks. NULL for TICKET_WEIGHTED tickets.
+ALTER TABLE toby_coin_jackpot_lottery_ticket
+    ADD COLUMN picked_numbers VARCHAR(64);
+
+-- 4. Replace the one-OPEN-per-guild index with one-OPEN-per-(guild, mode)
+--    so the daily match-numbers row and an admin-fired weighted row
+--    can both be OPEN simultaneously without violating uniqueness.
+DROP INDEX IF EXISTS toby_coin_jackpot_lottery_one_open_per_guild;
+
+CREATE UNIQUE INDEX toby_coin_jackpot_lottery_one_open_per_guild_mode
+    ON toby_coin_jackpot_lottery (guild_id, mode) WHERE status = 'OPEN';
+
+-- 5. Idempotency for the daily auto-draw (LotteryDailyJob).
+--    Mirrors UbiDailyDto's pattern (V24__ubi_daily.sql): one row per
+--    (guild, draw_date) so a restart mid-cron-tick can't double-draw.
+CREATE TABLE toby_coin_jackpot_lottery_daily (
+    guild_id  BIGINT NOT NULL,
+    draw_date DATE   NOT NULL,
+    PRIMARY KEY (guild_id, draw_date)
+);

--- a/database/src/test/kotlin/database/service/JackpotLotteryServiceTest.kt
+++ b/database/src/test/kotlin/database/service/JackpotLotteryServiceTest.kt
@@ -1,5 +1,6 @@
 package database.service
 
+import database.dto.ConfigDto
 import database.dto.JackpotLotteryDto
 import database.dto.JackpotLotteryTicketDto
 import database.dto.UserDto
@@ -22,6 +23,7 @@ class JackpotLotteryServiceTest {
     private lateinit var lotteryPersistence: JackpotLotteryPersistence
     private lateinit var jackpotService: JackpotService
     private lateinit var userService: UserService
+    private lateinit var configService: ConfigService
     private lateinit var service: JackpotLotteryService
 
     @BeforeEach
@@ -29,13 +31,26 @@ class JackpotLotteryServiceTest {
         lotteryPersistence = mockk(relaxed = true)
         jackpotService = mockk(relaxed = true)
         userService = mockk(relaxed = true)
+        configService = mockk(relaxed = true)
+        // Default: no LOTTERY_DAILY_REVENUE_JACKPOT_PCT row → 30% to jackpot.
+        every {
+            configService.getConfigByName(
+                ConfigDto.Configurations.LOTTERY_DAILY_REVENUE_JACKPOT_PCT.configValue,
+                guildId.toString()
+            )
+        } returns null
         service = JackpotLotteryService(
             lotteryPersistence,
             jackpotService,
             userService,
+            configService,
             random = Random(42),
         )
     }
+
+    // ===================================================================
+    // TICKET_WEIGHTED tests
+    // ===================================================================
 
     @Test
     fun `openLottery rejects invalid params`() {
@@ -54,9 +69,9 @@ class JackpotLotteryServiceTest {
 
     @Test
     fun `openLottery rejects when one is already open`() {
-        every { lotteryPersistence.getOpenByGuildForUpdate(guildId) } returns JackpotLotteryDto(
-            id = 1L, guildId = guildId, status = JackpotLotteryDto.STATUS_OPEN
-        )
+        every {
+            lotteryPersistence.getOpenByGuildAndModeForUpdate(guildId, JackpotLotteryDto.MODE_TICKET_WEIGHTED)
+        } returns JackpotLotteryDto(id = 1L, guildId = guildId, status = JackpotLotteryDto.STATUS_OPEN)
 
         val r = service.openLottery(guildId, ticketPrice = 100L, durationHours = 24, winnerCount = 3, drainPct = 1.0)
         assertEquals(JackpotLotteryService.OpenOutcome.AlreadyOpen, r)
@@ -64,7 +79,9 @@ class JackpotLotteryServiceTest {
 
     @Test
     fun `openLottery rejects on empty pool`() {
-        every { lotteryPersistence.getOpenByGuildForUpdate(guildId) } returns null
+        every {
+            lotteryPersistence.getOpenByGuildAndModeForUpdate(guildId, JackpotLotteryDto.MODE_TICKET_WEIGHTED)
+        } returns null
         every { jackpotService.getPool(guildId) } returns 0L
 
         val r = service.openLottery(guildId, ticketPrice = 100L, durationHours = 24, winnerCount = 3, drainPct = 1.0)
@@ -73,7 +90,9 @@ class JackpotLotteryServiceTest {
 
     @Test
     fun `openLottery seeds the lottery from a fraction of the jackpot pool`() {
-        every { lotteryPersistence.getOpenByGuildForUpdate(guildId) } returns null
+        every {
+            lotteryPersistence.getOpenByGuildAndModeForUpdate(guildId, JackpotLotteryDto.MODE_TICKET_WEIGHTED)
+        } returns null
         every { jackpotService.getPool(guildId) } returns 110_000L
         every { jackpotService.resetPool(guildId) } returns 110_000L
         val saved = slot<JackpotLotteryDto>()
@@ -84,15 +103,17 @@ class JackpotLotteryServiceTest {
         r as JackpotLotteryService.OpenOutcome.Ok
         assertEquals(55_000L, r.seeded)
         assertEquals(JackpotLotteryDto.STATUS_OPEN, saved.captured.status)
+        assertEquals(JackpotLotteryDto.MODE_TICKET_WEIGHTED, saved.captured.mode)
         assertEquals(100L, saved.captured.ticketPrice)
         assertEquals(3, saved.captured.winnerCount)
-        // Leftover (55k) returned to the jackpot.
         verify(exactly = 1) { jackpotService.addToPool(guildId, 55_000L) }
     }
 
     @Test
     fun `buyTickets rejects when no lottery is open`() {
-        every { lotteryPersistence.getOpenByGuildForUpdate(guildId) } returns null
+        every {
+            lotteryPersistence.getOpenByGuildAndModeForUpdate(guildId, JackpotLotteryDto.MODE_TICKET_WEIGHTED)
+        } returns null
 
         assertEquals(
             JackpotLotteryService.BuyOutcome.NoOpenLottery,
@@ -102,7 +123,9 @@ class JackpotLotteryServiceTest {
 
     @Test
     fun `buyTickets rejects when user can't afford`() {
-        every { lotteryPersistence.getOpenByGuildForUpdate(guildId) } returns JackpotLotteryDto(
+        every {
+            lotteryPersistence.getOpenByGuildAndModeForUpdate(guildId, JackpotLotteryDto.MODE_TICKET_WEIGHTED)
+        } returns JackpotLotteryDto(
             id = 1L, guildId = guildId, ticketPrice = 100L, status = JackpotLotteryDto.STATUS_OPEN
         )
         val user = UserDto(discordId = 7L, guildId = guildId).apply { socialCredit = 200L }
@@ -119,9 +142,11 @@ class JackpotLotteryServiceTest {
     fun `buyTickets debits user, increments tickets, grows pool`() {
         val lottery = JackpotLotteryDto(
             id = 1L, guildId = guildId, ticketPrice = 100L, poolAmount = 1000L,
-            status = JackpotLotteryDto.STATUS_OPEN
+            status = JackpotLotteryDto.STATUS_OPEN, mode = JackpotLotteryDto.MODE_TICKET_WEIGHTED,
         )
-        every { lotteryPersistence.getOpenByGuildForUpdate(guildId) } returns lottery
+        every {
+            lotteryPersistence.getOpenByGuildAndModeForUpdate(guildId, JackpotLotteryDto.MODE_TICKET_WEIGHTED)
+        } returns lottery
         val user = UserDto(discordId = 7L, guildId = guildId).apply { socialCredit = 1_000L }
         every { userService.getUserByIdForUpdate(7L, guildId) } returns user
         every { lotteryPersistence.getTicketForUpdate(1L, 7L) } returns null
@@ -139,13 +164,17 @@ class JackpotLotteryServiceTest {
 
     @Test
     fun `drawLottery rejects when no lottery open`() {
-        every { lotteryPersistence.getOpenByGuildForUpdate(guildId) } returns null
+        every {
+            lotteryPersistence.getOpenByGuildAndModeForUpdate(guildId, JackpotLotteryDto.MODE_TICKET_WEIGHTED)
+        } returns null
         assertEquals(JackpotLotteryService.DrawOutcome.NoOpenLottery, service.drawLottery(guildId))
     }
 
     @Test
     fun `drawLottery rejects when no tickets sold`() {
-        every { lotteryPersistence.getOpenByGuildForUpdate(guildId) } returns JackpotLotteryDto(
+        every {
+            lotteryPersistence.getOpenByGuildAndModeForUpdate(guildId, JackpotLotteryDto.MODE_TICKET_WEIGHTED)
+        } returns JackpotLotteryDto(
             id = 1L, guildId = guildId, status = JackpotLotteryDto.STATUS_OPEN
         )
         every { lotteryPersistence.ticketsByLottery(1L) } returns emptyList()
@@ -156,9 +185,12 @@ class JackpotLotteryServiceTest {
     fun `drawLottery splits the pool 50-30-20 across three winners`() {
         val lottery = JackpotLotteryDto(
             id = 1L, guildId = guildId, ticketPrice = 100L, poolAmount = 1_000L,
-            winnerCount = 3, status = JackpotLotteryDto.STATUS_OPEN
+            winnerCount = 3, status = JackpotLotteryDto.STATUS_OPEN,
+            mode = JackpotLotteryDto.MODE_TICKET_WEIGHTED,
         )
-        every { lotteryPersistence.getOpenByGuildForUpdate(guildId) } returns lottery
+        every {
+            lotteryPersistence.getOpenByGuildAndModeForUpdate(guildId, JackpotLotteryDto.MODE_TICKET_WEIGHTED)
+        } returns lottery
         every { lotteryPersistence.ticketsByLottery(1L) } returns listOf(
             JackpotLotteryTicketDto(lotteryId = 1L, discordId = 1L, ticketCount = 1, spent = 100L),
             JackpotLotteryTicketDto(lotteryId = 1L, discordId = 2L, ticketCount = 1, spent = 100L),
@@ -176,7 +208,6 @@ class JackpotLotteryServiceTest {
         r as JackpotLotteryService.DrawOutcome.Ok
         assertEquals(1_000L, r.drained)
         assertEquals(1_000L, r.totalPaid)
-        // Schedule for 3 winners is 50/30/20.
         assertEquals(setOf(500L, 300L, 200L), r.payouts.map { it.amount }.toSet())
         assertEquals(JackpotLotteryDto.STATUS_DRAWN, lottery.status)
         assertEquals(0L, lottery.poolAmount)
@@ -186,9 +217,11 @@ class JackpotLotteryServiceTest {
     fun `cancelLottery refunds buyers and returns seed to the jackpot pool`() {
         val lottery = JackpotLotteryDto(
             id = 1L, guildId = guildId, ticketPrice = 100L, poolAmount = 1_500L,
-            status = JackpotLotteryDto.STATUS_OPEN
+            status = JackpotLotteryDto.STATUS_OPEN, mode = JackpotLotteryDto.MODE_TICKET_WEIGHTED,
         )
-        every { lotteryPersistence.getOpenByGuildForUpdate(guildId) } returns lottery
+        every {
+            lotteryPersistence.getOpenByGuildAndModeForUpdate(guildId, JackpotLotteryDto.MODE_TICKET_WEIGHTED)
+        } returns lottery
         every { lotteryPersistence.ticketsByLottery(1L) } returns listOf(
             JackpotLotteryTicketDto(lotteryId = 1L, discordId = 1L, ticketCount = 5, spent = 500L),
             JackpotLotteryTicketDto(lotteryId = 1L, discordId = 2L, ticketCount = 3, spent = 300L),
@@ -205,7 +238,6 @@ class JackpotLotteryServiceTest {
         r as JackpotLotteryService.CancelOutcome.Ok
         assertEquals(2, r.refundedUsers)
         assertEquals(800L, r.refundedTotal)
-        // pool_amount=1500, refunded 800 → 700 returned to the jackpot pool.
         assertEquals(700L, r.returnedToPool)
         verify(exactly = 1) { jackpotService.addToPool(guildId, 700L) }
         assertEquals(500L, users[1L]!!.socialCredit)
@@ -227,8 +259,6 @@ class JackpotLotteryServiceTest {
     fun `prizeShares uses linear taper for 5+ winners and remains a partition`() {
         val shares = service.prizeShares(5, 1500L)
         assertEquals(5, shares.size)
-        // Strictly decreasing, all positive, sum <= pool (rounding remainder
-        // returns to the pool in drawLottery).
         assertTrue(shares.zipWithNext().all { (a, b) -> a >= b })
         assertTrue(shares.all { it >= 0 })
         assertTrue(shares.sum() <= 1500L)
@@ -245,7 +275,6 @@ class JackpotLotteryServiceTest {
         )
         val winners = service.drawWinners(tickets, count = 3, random = Random(42))
         assertEquals(3, winners.size)
-        // No duplicates.
         assertEquals(3, winners.map { it.discordId }.toSet().size)
     }
 
@@ -268,5 +297,269 @@ class JackpotLotteryServiceTest {
         val winners = service.drawWinners(tickets, count = 3, random = Random(1))
         assertEquals(1, winners.size)
         assertNotNull(winners.first())
+    }
+
+    // ===================================================================
+    // NUMBER_MATCH tests
+    // ===================================================================
+
+    @Test
+    fun `validatePicks rejects wrong-size, duplicate, or out-of-range picks`() {
+        // Wrong size
+        assertNotNull(service.validatePicks(listOf(1, 2, 3, 4), pickCount = 5, numberMax = 49))
+        // Duplicates
+        assertNotNull(service.validatePicks(listOf(1, 2, 3, 3, 5), pickCount = 5, numberMax = 49))
+        // Out of range (low)
+        assertNotNull(service.validatePicks(listOf(0, 1, 2, 3, 4), pickCount = 5, numberMax = 49))
+        // Out of range (high)
+        assertNotNull(service.validatePicks(listOf(1, 2, 3, 4, 50), pickCount = 5, numberMax = 49))
+        // Valid
+        assertEquals(null, service.validatePicks(listOf(1, 13, 27, 33, 49), pickCount = 5, numberMax = 49))
+    }
+
+    @Test
+    fun `drawNumbers returns count distinct sorted numbers in 1 to max`() {
+        val result = service.drawNumbers(max = 49, count = 5, random = Random(123))
+        assertEquals(5, result.size)
+        assertEquals(5, result.toSet().size, "all numbers must be distinct")
+        assertTrue(result.all { it in 1..49 })
+        assertEquals(result.sorted(), result, "result is sorted ascending")
+    }
+
+    @Test
+    fun `computeTierShares applies percentages with floor`() {
+        val shares = service.computeTierShares(1000L, intArrayOf(60, 25, 10, 5))
+        assertEquals(listOf(600L, 250L, 100L, 50L), shares.toList())
+        // 1001 with 60% = 600.6 → floor 600
+        val shares2 = service.computeTierShares(1001L, intArrayOf(60, 25, 10, 5))
+        assertEquals(listOf(600L, 250L, 100L, 50L), shares2.toList())
+    }
+
+    @Test
+    fun `parsePicks tolerates null, blank, and bogus entries`() {
+        assertEquals(emptyList<Int>(), service.parsePicks(null))
+        assertEquals(emptyList<Int>(), service.parsePicks(""))
+        assertEquals(emptyList<Int>(), service.parsePicks("   "))
+        assertEquals(listOf(1, 2, 3), service.parsePicks("1,2,3"))
+        assertEquals(listOf(1, 3), service.parsePicks("1,abc,3"))
+    }
+
+    @Test
+    fun `openMatchLottery seeds from configured percentage of jackpot pool`() {
+        every {
+            lotteryPersistence.getOpenByGuildAndModeForUpdate(guildId, JackpotLotteryDto.MODE_NUMBER_MATCH)
+        } returns null
+        every { jackpotService.getPool(guildId) } returns 200_000L
+        every { jackpotService.resetPool(guildId) } returns 200_000L
+        val saved = slot<JackpotLotteryDto>()
+        every { lotteryPersistence.upsert(capture(saved)) } answers { saved.captured.also { it.id = 42L } }
+
+        val r = service.openMatchLottery(guildId, ticketPrice = 50L, seedPct = 5L, durationHours = 24)
+        assertTrue(r is JackpotLotteryService.OpenOutcome.Ok)
+        r as JackpotLotteryService.OpenOutcome.Ok
+        assertEquals(10_000L, r.seeded, "5% of 200k = 10k seeded")
+        assertEquals(JackpotLotteryDto.MODE_NUMBER_MATCH, saved.captured.mode)
+        assertEquals(50L, saved.captured.ticketPrice)
+        assertEquals(LotteryHelper.MATCH_PICK_COUNT, saved.captured.pickCount)
+        assertEquals(LotteryHelper.MATCH_NUMBER_MAX, saved.captured.numberMax)
+        assertEquals(JackpotLotteryDto.STATUS_OPEN, saved.captured.status)
+        // Leftover (190k) returned to jackpot.
+        verify(exactly = 1) { jackpotService.addToPool(guildId, 190_000L) }
+    }
+
+    @Test
+    fun `openMatchLottery accepts an empty jackpot for engagement-only prize pool`() {
+        every {
+            lotteryPersistence.getOpenByGuildAndModeForUpdate(guildId, JackpotLotteryDto.MODE_NUMBER_MATCH)
+        } returns null
+        every { jackpotService.getPool(guildId) } returns 0L
+        val saved = slot<JackpotLotteryDto>()
+        every { lotteryPersistence.upsert(capture(saved)) } answers { saved.captured.also { it.id = 1L } }
+
+        val r = service.openMatchLottery(guildId, ticketPrice = 50L, seedPct = 5L, durationHours = 24)
+        assertTrue(r is JackpotLotteryService.OpenOutcome.Ok)
+        r as JackpotLotteryService.OpenOutcome.Ok
+        assertEquals(0L, r.seeded)
+    }
+
+    @Test
+    fun `buyMatchTicket rejects invalid picks`() {
+        every {
+            lotteryPersistence.getOpenByGuildAndModeForUpdate(guildId, JackpotLotteryDto.MODE_NUMBER_MATCH)
+        } returns JackpotLotteryDto(
+            id = 1L, guildId = guildId, ticketPrice = 50L, status = JackpotLotteryDto.STATUS_OPEN,
+            mode = JackpotLotteryDto.MODE_NUMBER_MATCH, pickCount = 5, numberMax = 49,
+        )
+
+        val r = service.buyMatchTicket(guildId, discordId = 7L, picks = listOf(1, 2, 3))
+        assertTrue(r is JackpotLotteryService.BuyMatchOutcome.InvalidPicks)
+    }
+
+    @Test
+    fun `buyMatchTicket rejects when no lottery open`() {
+        every {
+            lotteryPersistence.getOpenByGuildAndModeForUpdate(guildId, JackpotLotteryDto.MODE_NUMBER_MATCH)
+        } returns null
+
+        assertEquals(
+            JackpotLotteryService.BuyMatchOutcome.NoOpenLottery,
+            service.buyMatchTicket(guildId, discordId = 7L, picks = listOf(1, 2, 3, 4, 5))
+        )
+    }
+
+    @Test
+    fun `buyMatchTicket rejects double-buy by the same user`() {
+        every {
+            lotteryPersistence.getOpenByGuildAndModeForUpdate(guildId, JackpotLotteryDto.MODE_NUMBER_MATCH)
+        } returns JackpotLotteryDto(
+            id = 1L, guildId = guildId, ticketPrice = 50L, status = JackpotLotteryDto.STATUS_OPEN,
+            mode = JackpotLotteryDto.MODE_NUMBER_MATCH, pickCount = 5, numberMax = 49,
+        )
+        every { lotteryPersistence.getTicketForUpdate(1L, 7L) } returns JackpotLotteryTicketDto(
+            lotteryId = 1L, discordId = 7L, ticketCount = 1, spent = 50L, pickedNumbers = "3,7,11,21,42",
+        )
+
+        assertEquals(
+            JackpotLotteryService.BuyMatchOutcome.AlreadyBought,
+            service.buyMatchTicket(guildId, discordId = 7L, picks = listOf(1, 2, 3, 4, 5))
+        )
+    }
+
+    @Test
+    fun `buyMatchTicket splits ticket revenue 70 percent prize 30 percent jackpot`() {
+        val lottery = JackpotLotteryDto(
+            id = 1L, guildId = guildId, ticketPrice = 100L, poolAmount = 5_000L,
+            status = JackpotLotteryDto.STATUS_OPEN, mode = JackpotLotteryDto.MODE_NUMBER_MATCH,
+            pickCount = 5, numberMax = 49,
+        )
+        every {
+            lotteryPersistence.getOpenByGuildAndModeForUpdate(guildId, JackpotLotteryDto.MODE_NUMBER_MATCH)
+        } returns lottery
+        every { lotteryPersistence.getTicketForUpdate(1L, 7L) } returns null
+        val user = UserDto(discordId = 7L, guildId = guildId).apply { socialCredit = 1_000L }
+        every { userService.getUserByIdForUpdate(7L, guildId) } returns user
+
+        val r = service.buyMatchTicket(guildId, discordId = 7L, picks = listOf(1, 13, 27, 33, 49))
+        assertTrue(r is JackpotLotteryService.BuyMatchOutcome.Ok)
+        r as JackpotLotteryService.BuyMatchOutcome.Ok
+        assertEquals(listOf(1, 13, 27, 33, 49), r.pickedNumbers)
+        assertEquals(100L, r.totalSpent)
+        assertEquals(900L, r.newBalance)
+        // Default 30% to jackpot → 30 credits routed; 70 credits to prize pool.
+        assertEquals(30L, r.jackpotInflow)
+        assertEquals(5_070L, r.newPool)
+        verify(exactly = 1) { jackpotService.addToPool(guildId, 30L) }
+    }
+
+    @Test
+    fun `drawMatchLottery distributes prize pool by tier and rolls remainder back to jackpot`() {
+        val lottery = JackpotLotteryDto(
+            id = 1L, guildId = guildId, ticketPrice = 50L, poolAmount = 1_000L,
+            status = JackpotLotteryDto.STATUS_OPEN, mode = JackpotLotteryDto.MODE_NUMBER_MATCH,
+            pickCount = 5, numberMax = 49,
+        )
+        every {
+            lotteryPersistence.getOpenByGuildAndModeForUpdate(guildId, JackpotLotteryDto.MODE_NUMBER_MATCH)
+        } returns lottery
+        // Tickets crafted so we can compute matches against a controlled draw.
+        // We'll inject Random(42) — but for this test we cheat by stubbing
+        // drawNumbers via a service spy isn't easy; instead, we craft picks
+        // to span every tier and rely on the deterministic Random seed.
+        // Use service.drawNumbers(49, 5, Random(42)) once to capture the
+        // expected draw, then craft picks accordingly.
+        val expectedDraw = service.drawNumbers(49, 5, Random(42))
+
+        // Tickets:
+        //  user 1: matches all 5 (tier 5/5)
+        //  user 2: matches 4 (replace last pick with non-drawn number)
+        //  user 3: matches 3
+        //  user 4: matches 2
+        //  user 5: matches 1 (no payout)
+        val nonDrawn = (1..49).filter { it !in expectedDraw }
+        fun ticket(id: Long, picks: List<Int>) = JackpotLotteryTicketDto(
+            lotteryId = 1L, discordId = id, ticketCount = 1, spent = 50L,
+            pickedNumbers = picks.joinToString(","),
+        )
+
+        val tickets = listOf(
+            ticket(1L, expectedDraw),
+            ticket(2L, expectedDraw.take(4) + nonDrawn[0]),
+            ticket(3L, expectedDraw.take(3) + nonDrawn.subList(0, 2)),
+            ticket(4L, expectedDraw.take(2) + nonDrawn.subList(0, 3)),
+            ticket(5L, expectedDraw.take(1) + nonDrawn.subList(0, 4)),
+        )
+        every { lotteryPersistence.ticketsByLottery(1L) } returns tickets
+
+        val users = (1L..5L).associate { id ->
+            id to UserDto(discordId = id, guildId = guildId).apply { socialCredit = 0L }
+        }
+        users.forEach { (id, u) ->
+            every { userService.getUserByIdForUpdate(id, guildId) } returns u
+        }
+
+        val r = service.drawMatchLottery(guildId)
+        assertTrue(r is JackpotLotteryService.DrawMatchOutcome.Ok)
+        r as JackpotLotteryService.DrawMatchOutcome.Ok
+        assertEquals(expectedDraw, r.drawnNumbers)
+        assertEquals(1_000L, r.drained)
+
+        // Tier shares: 60 / 25 / 10 / 5 of 1000 → 600 / 250 / 100 / 50.
+        val byMatches = r.tierPayouts.associate { it.matches to it.share }
+        assertEquals(600L, byMatches[5])
+        assertEquals(250L, byMatches[4])
+        assertEquals(100L, byMatches[3])
+        assertEquals(50L, byMatches[2])
+        assertEquals(1_000L, r.totalPaid)
+        assertEquals(0L, r.rolledBackToJackpot)
+        assertEquals(JackpotLotteryDto.STATUS_DRAWN, lottery.status)
+        assertEquals(expectedDraw.joinToString(","), lottery.drawnNumbers)
+    }
+
+    @Test
+    fun `drawMatchLottery rolls empty tier shares back to jackpot`() {
+        val lottery = JackpotLotteryDto(
+            id = 1L, guildId = guildId, ticketPrice = 50L, poolAmount = 1_000L,
+            status = JackpotLotteryDto.STATUS_OPEN, mode = JackpotLotteryDto.MODE_NUMBER_MATCH,
+            pickCount = 5, numberMax = 49,
+        )
+        every {
+            lotteryPersistence.getOpenByGuildAndModeForUpdate(guildId, JackpotLotteryDto.MODE_NUMBER_MATCH)
+        } returns lottery
+
+        // Single ticket that never matches any drawn number.
+        val expectedDraw = service.drawNumbers(49, 5, Random(42))
+        val nonDrawn = (1..49).filter { it !in expectedDraw }.take(5)
+        every { lotteryPersistence.ticketsByLottery(1L) } returns listOf(
+            JackpotLotteryTicketDto(
+                lotteryId = 1L, discordId = 7L, ticketCount = 1, spent = 50L,
+                pickedNumbers = nonDrawn.joinToString(","),
+            )
+        )
+        val user = UserDto(discordId = 7L, guildId = guildId).apply { socialCredit = 0L }
+        every { userService.getUserByIdForUpdate(7L, guildId) } returns user
+
+        val r = service.drawMatchLottery(guildId)
+        assertTrue(r is JackpotLotteryService.DrawMatchOutcome.Ok)
+        r as JackpotLotteryService.DrawMatchOutcome.Ok
+        // No tier paid out — entire pool rolls back.
+        assertEquals(0L, r.totalPaid)
+        assertEquals(1_000L, r.rolledBackToJackpot)
+        verify(exactly = 1) { jackpotService.addToPool(guildId, 1_000L) }
+    }
+
+    @Test
+    fun `drawMatchLottery returns NoTickets when nobody bought today`() {
+        every {
+            lotteryPersistence.getOpenByGuildAndModeForUpdate(guildId, JackpotLotteryDto.MODE_NUMBER_MATCH)
+        } returns JackpotLotteryDto(
+            id = 1L, guildId = guildId, status = JackpotLotteryDto.STATUS_OPEN,
+            mode = JackpotLotteryDto.MODE_NUMBER_MATCH,
+        )
+        every { lotteryPersistence.ticketsByLottery(1L) } returns emptyList()
+
+        assertEquals(
+            JackpotLotteryService.DrawMatchOutcome.NoTickets,
+            service.drawMatchLottery(guildId)
+        )
     }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/LotteryCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/LotteryCommand.kt
@@ -94,12 +94,12 @@ class LotteryCommand @Autowired constructor(
         guildId: Long,
         deleteDelay: Int,
     ) {
-        val lottery = jackpotLotteryService.getOpen(guildId) ?: run {
+        val lottery = jackpotLotteryService.getOpenWeighted(guildId) ?: run {
             event.hook.sendMessage("No lottery is open right now.")
                 .queue(invokeDeleteOnMessageResponse(deleteDelay))
             return
         }
-        val tickets = jackpotLotteryService.ticketsForOpen(guildId)
+        val tickets = jackpotLotteryService.ticketsForOpenWeighted(guildId)
         val totalTickets = tickets.sumOf { it.ticketCount.toLong() }
         val mine = tickets.firstOrNull { it.discordId == user.discordId }
         val top = tickets.sortedByDescending { it.ticketCount }.take(5)

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/moderation/SetConfigCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/moderation/SetConfigCommand.kt
@@ -177,6 +177,29 @@ class SetConfigCommand @Autowired constructor(
                 ConfigDto.Configurations.SLOTS_BOT_EDGE_MAX_PCT -> setRangedIntConfig(event, optionMapping, deleteDelay,
                     config = ConfigDto.Configurations.SLOTS_BOT_EDGE_MAX_PCT, gameLabel = "Slots",
                     label = "bot-suspicion max edge percent", range = 0..50)
+                // Daily match-numbers lottery — moderation web tab is the
+                // primary surface (toggles + daily-prize parameters), but
+                // keep the dispatch arms exhaustive for direct API use.
+                ConfigDto.Configurations.LOTTERY_DAILY_ENABLED -> setBooleanConfig(
+                    event, optionMapping, deleteDelay,
+                    config = ConfigDto.Configurations.LOTTERY_DAILY_ENABLED,
+                    label = "daily lottery"
+                )
+                ConfigDto.Configurations.LOTTERY_DAILY_TICKET_PRICE -> setMinimumLongConfig(
+                    event, optionMapping, deleteDelay,
+                    config = ConfigDto.Configurations.LOTTERY_DAILY_TICKET_PRICE,
+                    gameLabel = "Daily lottery", label = "ticket price", min = 1L, unit = "credits"
+                )
+                ConfigDto.Configurations.LOTTERY_DAILY_SEED_PCT -> setRangedIntConfig(
+                    event, optionMapping, deleteDelay,
+                    config = ConfigDto.Configurations.LOTTERY_DAILY_SEED_PCT,
+                    gameLabel = "Daily lottery", label = "jackpot seed percent", range = 1..100
+                )
+                ConfigDto.Configurations.LOTTERY_DAILY_REVENUE_JACKPOT_PCT -> setRangedIntConfig(
+                    event, optionMapping, deleteDelay,
+                    config = ConfigDto.Configurations.LOTTERY_DAILY_REVENUE_JACKPOT_PCT,
+                    gameLabel = "Daily lottery", label = "ticket revenue → jackpot percent", range = 0..100
+                )
             }
         }
     }
@@ -248,6 +271,26 @@ class SetConfigCommand @Autowired constructor(
         configService.upsertConfig(configValue, value.toString(), guildId)
         val rule = if (value) "hit on soft 17 (H17)" else "stand on all 17 (S17)"
         event.hook.sendMessage("Blackjack dealer will now $rule.")
+            .queue(invokeDeleteOnMessageResponse(deleteDelay))
+    }
+
+    /**
+     * Persist a boolean config knob ("true"/"false") and reply with a
+     * uniform "$label is now enabled/disabled." message. Used by simple
+     * on/off toggles like the daily lottery.
+     */
+    private fun setBooleanConfig(
+        event: SlashCommandInteractionEvent,
+        optionMapping: OptionMapping,
+        deleteDelay: Int,
+        config: ConfigDto.Configurations,
+        label: String,
+    ) {
+        val value = optionMapping.asBoolean
+        val guildId = event.guild?.id ?: return
+        configService.upsertConfig(config.configValue, value.toString(), guildId)
+        val state = if (value) "enabled" else "disabled"
+        event.hook.sendMessage("$label is now $state.")
             .queue(invokeDeleteOnMessageResponse(deleteDelay))
     }
 

--- a/discord-bot/src/main/kotlin/bot/toby/scheduling/LotteryDailyJob.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/scheduling/LotteryDailyJob.kt
@@ -1,0 +1,136 @@
+package bot.toby.scheduling
+
+import common.logging.DiscordLogger
+import database.dto.JackpotLotteryDto
+import database.service.ConfigService
+import database.service.JackpotLotteryService
+import database.service.LotteryDailyService
+import database.service.LotteryHelper
+import net.dv8tion.jda.api.JDA
+import net.dv8tion.jda.api.entities.Guild
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.annotation.Profile
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import java.time.Clock
+import java.time.LocalDate
+import java.time.ZoneOffset
+
+/**
+ * Daily match-numbers (Pick 5 of 1-49) lottery auto-draw.
+ *
+ * Runs at 00:00 UTC. For each guild with `LOTTERY_DAILY_ENABLED=true`:
+ *   1. Close yesterday's draw if still OPEN — runs the prize tier
+ *      payouts via [JackpotLotteryService.drawMatchLottery]. If no
+ *      one bought, cancels and refunds the seed via
+ *      [JackpotLotteryService.cancelMatchLottery] so credits don't
+ *      strand on a no-tickets row.
+ *   2. Open today's draw via [JackpotLotteryService.openMatchLottery],
+ *      seeding `LOTTERY_DAILY_SEED_PCT` of the per-guild jackpot pool
+ *      (default 5%) into the prize pool. Ticket price comes from
+ *      `LOTTERY_DAILY_TICKET_PRICE` (default 50).
+ *   3. Mark the day done in [LotteryDailyService] so a mid-cron
+ *      restart skips this guild on the next tick.
+ *
+ * Mirrors [UniversalBasicIncomeJob]: idempotent via composite-key
+ * ledger, per-guild error isolation via runCatching, prod-profile only
+ * (test profile uses manual force-draw via the moderation web tab).
+ */
+@Component
+@Profile("prod")
+class LotteryDailyJob @Autowired constructor(
+    private val jda: JDA,
+    private val configService: ConfigService,
+    private val lotteryDailyService: LotteryDailyService,
+    private val jackpotLotteryService: JackpotLotteryService,
+    private val clock: Clock = Clock.systemUTC(),
+) {
+    private val logger: DiscordLogger = DiscordLogger.createLogger(this::class.java)
+
+    @Scheduled(cron = "0 0 0 * * *", zone = "UTC")
+    fun runDaily() {
+        val today = LocalDate.now(clock.withZone(ZoneOffset.UTC))
+        logger.info { "Running daily lottery job for $today" }
+
+        jda.guildCache.forEach { guild ->
+            runCatching { rollGuild(guild, today) }
+                .onFailure {
+                    logger.error("Daily lottery roll failed for guild ${guild.idLong}: ${it.message}")
+                }
+        }
+    }
+
+    /**
+     * Roll the daily draw for a single guild. Public/internal for the
+     * moderation tab's "Force draw now" button — the web service
+     * delegates here so the same close→open→mark-ran flow drives both
+     * scheduled and manual triggers.
+     */
+    fun rollGuild(guild: Guild, today: LocalDate) {
+        val guildId = guild.idLong
+        if (!LotteryHelper.dailyEnabled(configService, guildId)) {
+            logger.info { "Daily lottery disabled for guild $guildId; skipping." }
+            return
+        }
+        if (lotteryDailyService.alreadyRan(guildId, today)) {
+            logger.info { "Daily lottery already ran for guild $guildId on $today; skipping." }
+            return
+        }
+
+        // Close yesterday's draw if still open.
+        val openMatch = jackpotLotteryService.getOpenMatch(guildId)
+        if (openMatch?.status == JackpotLotteryDto.STATUS_OPEN) {
+            when (val drawResult = jackpotLotteryService.drawMatchLottery(guildId)) {
+                is JackpotLotteryService.DrawMatchOutcome.Ok -> {
+                    logger.info {
+                        "Daily lottery drew for guild $guildId: drawn=${drawResult.drawnNumbers} " +
+                            "totalPaid=${drawResult.totalPaid} rolledBack=${drawResult.rolledBackToJackpot}"
+                    }
+                }
+                JackpotLotteryService.DrawMatchOutcome.NoTickets -> {
+                    logger.info { "Daily lottery for guild $guildId had no tickets; cancelling and refunding seed." }
+                    jackpotLotteryService.cancelMatchLottery(guildId)
+                }
+                JackpotLotteryService.DrawMatchOutcome.NoOpenLottery -> {
+                    // Race with another worker — fine, just continue.
+                }
+            }
+        }
+
+        // Open today's draw.
+        val ticketPrice = LotteryHelper.dailyTicketPrice(configService, guildId)
+        val seedPct = LotteryHelper.dailySeedPct(configService, guildId)
+        when (val open = jackpotLotteryService.openMatchLottery(
+            guildId = guildId,
+            ticketPrice = ticketPrice,
+            seedPct = seedPct,
+            durationHours = DURATION_HOURS,
+        )) {
+            is JackpotLotteryService.OpenOutcome.Ok -> {
+                logger.info {
+                    "Daily lottery opened for guild $guildId: ticketPrice=$ticketPrice " +
+                        "seeded=${open.seeded} seedPct=$seedPct"
+                }
+            }
+            JackpotLotteryService.OpenOutcome.AlreadyOpen -> {
+                logger.warn { "Daily lottery for guild $guildId is already open; skipping reopen." }
+            }
+            JackpotLotteryService.OpenOutcome.EmptyPool -> {
+                // Defensive — openMatchLottery accepts empty pools, so this
+                // shouldn't fire. Log if it does and move on.
+                logger.warn { "Daily lottery for guild $guildId reported EmptyPool unexpectedly." }
+            }
+            is JackpotLotteryService.OpenOutcome.InvalidParams -> {
+                logger.warn { "Daily lottery for guild $guildId rejected params: ${open.reason}" }
+                return  // Don't mark as run so admin can fix config and retry.
+            }
+        }
+
+        lotteryDailyService.markRan(guildId, today)
+    }
+
+    companion object {
+        /** A day. The daily draw opens for 24h and closes at the next tick. */
+        private const val DURATION_HOURS: Long = 24L
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/scheduling/LotteryDailyJobTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/scheduling/LotteryDailyJobTest.kt
@@ -1,0 +1,173 @@
+package bot.toby.scheduling
+
+import database.dto.ConfigDto
+import database.dto.JackpotLotteryDto
+import database.service.ConfigService
+import database.service.JackpotLotteryService
+import database.service.LotteryDailyService
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import net.dv8tion.jda.api.JDA
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.utils.cache.SnowflakeCacheView
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.LocalDate
+import java.time.ZoneOffset
+
+class LotteryDailyJobTest {
+
+    private lateinit var jda: JDA
+    private lateinit var configService: ConfigService
+    private lateinit var lotteryDailyService: LotteryDailyService
+    private lateinit var jackpotLotteryService: JackpotLotteryService
+    private lateinit var guild: Guild
+    private lateinit var job: LotteryDailyJob
+
+    private val guildId = 100L
+    private val today: LocalDate = LocalDate.of(2026, 5, 1)
+    private val clock: Clock = Clock.fixed(today.atStartOfDay().toInstant(ZoneOffset.UTC), ZoneOffset.UTC)
+
+    @BeforeEach
+    fun setup() {
+        jda = mockk(relaxed = true)
+        configService = mockk(relaxed = true)
+        lotteryDailyService = mockk(relaxed = true)
+        jackpotLotteryService = mockk(relaxed = true)
+        guild = mockk(relaxed = true)
+
+        val cache: SnowflakeCacheView<Guild> = mockk(relaxed = true)
+        every { jda.guildCache } returns cache
+        every { cache.iterator() } returns mutableListOf(guild).iterator()
+        every { guild.idLong } returns guildId
+        every { guild.id } returns guildId.toString()
+
+        job = LotteryDailyJob(jda, configService, lotteryDailyService, jackpotLotteryService, clock)
+    }
+
+    private fun stubEnabled(enabled: Boolean) {
+        val dto = ConfigDto(
+            name = ConfigDto.Configurations.LOTTERY_DAILY_ENABLED.configValue,
+            value = enabled.toString(),
+            guildId = guildId.toString(),
+        )
+        every {
+            configService.getConfigByName(
+                ConfigDto.Configurations.LOTTERY_DAILY_ENABLED.configValue,
+                guildId.toString(),
+            )
+        } returns dto
+    }
+
+    @Test
+    fun `runDaily skips guilds with daily lottery disabled`() {
+        stubEnabled(false)
+
+        job.runDaily()
+
+        verify(exactly = 0) { jackpotLotteryService.openMatchLottery(any(), any(), any(), any()) }
+        verify(exactly = 0) { jackpotLotteryService.drawMatchLottery(any()) }
+        verify(exactly = 0) { lotteryDailyService.markRan(any(), any()) }
+    }
+
+    @Test
+    fun `runDaily skips guilds whose ledger already records a run today`() {
+        stubEnabled(true)
+        every { lotteryDailyService.alreadyRan(guildId, today) } returns true
+
+        job.runDaily()
+
+        verify(exactly = 0) { jackpotLotteryService.openMatchLottery(any(), any(), any(), any()) }
+        verify(exactly = 0) { jackpotLotteryService.drawMatchLottery(any()) }
+    }
+
+    @Test
+    fun `runDaily closes prior open draw and opens a fresh one`() {
+        stubEnabled(true)
+        every { lotteryDailyService.alreadyRan(guildId, today) } returns false
+        // Open match exists.
+        every { jackpotLotteryService.getOpenMatch(guildId) } returns JackpotLotteryDto(
+            id = 5L, guildId = guildId,
+            status = JackpotLotteryDto.STATUS_OPEN,
+            mode = JackpotLotteryDto.MODE_NUMBER_MATCH,
+        )
+        every { jackpotLotteryService.drawMatchLottery(guildId) } returns
+            JackpotLotteryService.DrawMatchOutcome.Ok(
+                drawnNumbers = listOf(1, 2, 3, 4, 5),
+                tierPayouts = emptyList(),
+                totalPaid = 0L,
+                drained = 0L,
+                rolledBackToJackpot = 0L,
+            )
+        every { jackpotLotteryService.openMatchLottery(guildId, any(), any(), any()) } returns
+            JackpotLotteryService.OpenOutcome.Ok(
+                lottery = JackpotLotteryDto(id = 6L, guildId = guildId),
+                seeded = 100L,
+            )
+
+        job.runDaily()
+
+        verify(exactly = 1) { jackpotLotteryService.drawMatchLottery(guildId) }
+        verify(exactly = 1) { jackpotLotteryService.openMatchLottery(guildId, any(), any(), 24L) }
+        verify(exactly = 1) { lotteryDailyService.markRan(guildId, today) }
+    }
+
+    @Test
+    fun `runDaily cancels the prior open draw when no tickets were bought`() {
+        stubEnabled(true)
+        every { lotteryDailyService.alreadyRan(guildId, today) } returns false
+        every { jackpotLotteryService.getOpenMatch(guildId) } returns JackpotLotteryDto(
+            id = 5L, guildId = guildId,
+            status = JackpotLotteryDto.STATUS_OPEN,
+            mode = JackpotLotteryDto.MODE_NUMBER_MATCH,
+        )
+        every { jackpotLotteryService.drawMatchLottery(guildId) } returns
+            JackpotLotteryService.DrawMatchOutcome.NoTickets
+        every { jackpotLotteryService.openMatchLottery(guildId, any(), any(), any()) } returns
+            JackpotLotteryService.OpenOutcome.Ok(
+                lottery = JackpotLotteryDto(id = 6L, guildId = guildId),
+                seeded = 100L,
+            )
+
+        job.runDaily()
+
+        verify(exactly = 1) { jackpotLotteryService.cancelMatchLottery(guildId) }
+        verify(exactly = 1) { jackpotLotteryService.openMatchLottery(guildId, any(), any(), any()) }
+        verify(exactly = 1) { lotteryDailyService.markRan(guildId, today) }
+    }
+
+    @Test
+    fun `runDaily skips draw when no prior lottery exists, just opens a new one`() {
+        stubEnabled(true)
+        every { lotteryDailyService.alreadyRan(guildId, today) } returns false
+        every { jackpotLotteryService.getOpenMatch(guildId) } returns null
+        every { jackpotLotteryService.openMatchLottery(guildId, any(), any(), any()) } returns
+            JackpotLotteryService.OpenOutcome.Ok(
+                lottery = JackpotLotteryDto(id = 6L, guildId = guildId),
+                seeded = 50L,
+            )
+
+        job.runDaily()
+
+        verify(exactly = 0) { jackpotLotteryService.drawMatchLottery(any()) }
+        verify(exactly = 1) { jackpotLotteryService.openMatchLottery(guildId, any(), any(), any()) }
+        verify(exactly = 1) { lotteryDailyService.markRan(guildId, today) }
+    }
+
+    @Test
+    fun `runDaily does not mark ran when the open call rejects with InvalidParams`() {
+        stubEnabled(true)
+        every { lotteryDailyService.alreadyRan(guildId, today) } returns false
+        every { jackpotLotteryService.getOpenMatch(guildId) } returns null
+        every { jackpotLotteryService.openMatchLottery(guildId, any(), any(), any()) } returns
+            JackpotLotteryService.OpenOutcome.InvalidParams("ticket price must be > 0")
+
+        job.runDaily()
+
+        // markRan is skipped so the next daily tick can retry once the
+        // admin fixes the offending config.
+        verify(exactly = 0) { lotteryDailyService.markRan(any(), any()) }
+    }
+}

--- a/web/src/main/kotlin/web/controller/LotteryController.kt
+++ b/web/src/main/kotlin/web/controller/LotteryController.kt
@@ -1,0 +1,267 @@
+package web.controller
+
+import database.dto.JackpotLotteryDto
+import database.dto.JackpotLotteryTicketDto
+import database.service.JackpotLotteryService.BuyMatchOutcome
+import database.service.JackpotLotteryService.BuyOutcome
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.security.oauth2.core.user.OAuth2User
+import org.springframework.stereotype.Controller
+import org.springframework.ui.Model
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseBody
+import org.springframework.web.servlet.mvc.support.RedirectAttributes
+import web.casino.CasinoPageContext
+import web.casino.CasinoResponseLike
+import web.casino.renderMinigamePage
+import web.service.EconomyWebService
+import web.service.LotteryWebService
+import web.util.WebGuildAccess
+
+/**
+ * Web surface for the per-guild lottery page.
+ *
+ * - `GET  /casino/{guildId}/lottery` — picker UI for the daily
+ *   match-numbers draw, last-result panel, and (when running) the
+ *   admin-fired weighted lottery card.
+ * - `POST /casino/{guildId}/lottery/match/buy` — submits a 5-number
+ *   pick set; debits the user; routes 30% of cost to the jackpot pool
+ *   (default) and 70% to the day's prize pool.
+ * - `POST /casino/{guildId}/lottery/weighted/buy` — buys N tickets in
+ *   the open weighted lottery, mirroring the existing /lottery buy
+ *   Discord command.
+ *
+ * Both POSTs share the same shape as other casino endpoints
+ * (`{ ok: true, ... }` on success, `{ ok: false, error: ... }` on
+ * failure) so the shared `casino-game.js` scaffold can drive them.
+ */
+@Controller
+@RequestMapping("/casino/{guildId}/lottery")
+class LotteryController(
+    private val lotteryWebService: LotteryWebService,
+    private val economyWebService: EconomyWebService,
+    private val pageContext: CasinoPageContext,
+) {
+
+    @GetMapping
+    fun page(
+        @PathVariable guildId: Long,
+        @AuthenticationPrincipal user: OAuth2User,
+        model: Model,
+        ra: RedirectAttributes,
+    ): String = pageContext.renderMinigamePage(
+        user, guildId, economyWebService, model, ra,
+        template = "lottery", lobbyPath = "/casino/guilds"
+    ) {
+        val discordId = user.attributes["id"].toString().toLong()
+        val snap = lotteryWebService.snapshot(guildId, discordId)
+        addAttribute("snapshot", LotteryViewModel.from(snap))
+    }
+
+    @PostMapping("/match/buy")
+    @ResponseBody
+    fun buyMatch(
+        @PathVariable guildId: Long,
+        @RequestBody request: BuyMatchRequest,
+        @AuthenticationPrincipal user: OAuth2User,
+    ): ResponseEntity<BuyMatchResponse> = WebGuildAccess.requireMemberForJson(
+        user, guildId, economyWebService,
+        errorBuilder = { httpStatus ->
+            val msg = if (httpStatus == 401) "Sign in first." else "You're not a member of that server."
+            ResponseEntity.status(httpStatus).body(BuyMatchResponse(ok = false, error = msg))
+        }
+    ) { discordId ->
+        when (val outcome = lotteryWebService.buyMatch(guildId, discordId, request.picks)) {
+            is BuyMatchOutcome.Ok -> ResponseEntity.ok(
+                BuyMatchResponse(
+                    ok = true,
+                    pickedNumbers = outcome.pickedNumbers,
+                    totalSpent = outcome.totalSpent,
+                    newBalance = outcome.newBalance,
+                    newPool = outcome.newPool,
+                    jackpotInflow = outcome.jackpotInflow,
+                )
+            )
+
+            is BuyMatchOutcome.InvalidPicks ->
+                ResponseEntity.badRequest().body(BuyMatchResponse(ok = false, error = outcome.reason))
+            is BuyMatchOutcome.Insufficient ->
+                ResponseEntity.badRequest().body(
+                    BuyMatchResponse(
+                        ok = false,
+                        error = "You only have ${outcome.have} credits, need ${outcome.need}.",
+                    )
+                )
+            BuyMatchOutcome.NoOpenLottery ->
+                ResponseEntity.status(404).body(BuyMatchResponse(ok = false, error = "No daily lottery is open right now."))
+            BuyMatchOutcome.AlreadyBought ->
+                ResponseEntity.badRequest().body(
+                    BuyMatchResponse(ok = false, error = "You already bought a ticket for today's draw.")
+                )
+            BuyMatchOutcome.UnknownUser ->
+                ResponseEntity.status(404).body(BuyMatchResponse(ok = false, error = "No user record found."))
+        }
+    }
+
+    @PostMapping("/weighted/buy")
+    @ResponseBody
+    fun buyWeighted(
+        @PathVariable guildId: Long,
+        @RequestBody request: BuyWeightedRequest,
+        @AuthenticationPrincipal user: OAuth2User,
+    ): ResponseEntity<BuyWeightedResponse> = WebGuildAccess.requireMemberForJson(
+        user, guildId, economyWebService,
+        errorBuilder = { httpStatus ->
+            val msg = if (httpStatus == 401) "Sign in first." else "You're not a member of that server."
+            ResponseEntity.status(httpStatus).body(BuyWeightedResponse(ok = false, error = msg))
+        }
+    ) { discordId ->
+        when (val outcome = lotteryWebService.buyWeighted(guildId, discordId, request.count)) {
+            is BuyOutcome.Ok -> ResponseEntity.ok(
+                BuyWeightedResponse(
+                    ok = true,
+                    ticketCount = outcome.ticketCount,
+                    totalSpent = outcome.totalSpent,
+                    newBalance = outcome.newBalance,
+                    newPool = outcome.newPool,
+                )
+            )
+
+            is BuyOutcome.InvalidCount ->
+                ResponseEntity.badRequest().body(BuyWeightedResponse(ok = false, error = "Ticket count must be positive."))
+            is BuyOutcome.Insufficient ->
+                ResponseEntity.badRequest().body(
+                    BuyWeightedResponse(
+                        ok = false,
+                        error = "You only have ${outcome.have} credits, need ${outcome.need}.",
+                    )
+                )
+            BuyOutcome.NoOpenLottery ->
+                ResponseEntity.status(404).body(BuyWeightedResponse(ok = false, error = "No weighted lottery is open right now."))
+            BuyOutcome.UnknownUser ->
+                ResponseEntity.status(404).body(BuyWeightedResponse(ok = false, error = "No user record found."))
+        }
+    }
+}
+
+data class BuyMatchRequest(val picks: List<Int> = emptyList())
+data class BuyMatchResponse(
+    override val ok: Boolean,
+    override val error: String? = null,
+    val pickedNumbers: List<Int>? = null,
+    val totalSpent: Long? = null,
+    val newBalance: Long? = null,
+    val newPool: Long? = null,
+    val jackpotInflow: Long? = null,
+) : CasinoResponseLike
+
+data class BuyWeightedRequest(val count: Int = 0)
+data class BuyWeightedResponse(
+    override val ok: Boolean,
+    override val error: String? = null,
+    val ticketCount: Int? = null,
+    val totalSpent: Long? = null,
+    val newBalance: Long? = null,
+    val newPool: Long? = null,
+) : CasinoResponseLike
+
+/**
+ * View-friendly projection of the lottery snapshot. Strips DTO
+ * persistence noise (id, ticketCount on NUMBER_MATCH where it's
+ * always 1) and pre-parses comma-separated numbers into List<Int> so
+ * Thymeleaf can iterate cleanly.
+ */
+data class LotteryViewModel(
+    val pickCount: Int,
+    val numberMax: Int,
+    val tierPercents: List<Int>,
+    val revenueJackpotPct: Long,
+    val daily: DailyView?,
+    val weighted: WeightedView?,
+) {
+    data class DailyView(
+        val pool: Long,
+        val ticketPrice: Long,
+        val opensAtMillis: Long,
+        val closesAtMillis: Long,
+        val status: String,
+        val isOpen: Boolean,
+        val ticketBuyers: Int,
+        val myPicks: List<Int>?,
+        val drawnNumbers: List<Int>?,
+        val myMatches: Int?,
+    )
+
+    data class WeightedView(
+        val pool: Long,
+        val ticketPrice: Long,
+        val winnerCount: Int,
+        val opensAtMillis: Long,
+        val closesAtMillis: Long,
+        val totalTickets: Long,
+        val myTickets: Int,
+        val mySpent: Long,
+        val topHolders: List<TopHolder>,
+    )
+
+    data class TopHolder(val discordId: Long, val ticketCount: Int)
+
+    companion object {
+        fun from(snap: LotteryWebService.LotteryPageSnapshot): LotteryViewModel {
+            val daily = (snap.dailyOpen ?: snap.dailyLatestDrawn)?.let { row ->
+                val drawn = parseCsv(row.drawnNumbers)
+                val mine = parseCsv(snap.dailyMyTicket?.pickedNumbers)
+                val matches = if (mine.isNotEmpty() && drawn.isNotEmpty()) mine.count { it in drawn } else null
+                DailyView(
+                    pool = row.poolAmount,
+                    ticketPrice = row.ticketPrice,
+                    opensAtMillis = row.openedAt.toEpochMilli(),
+                    closesAtMillis = row.closesAt.toEpochMilli(),
+                    status = row.status,
+                    isOpen = row.status == JackpotLotteryDto.STATUS_OPEN,
+                    ticketBuyers = snap.dailyTicketBuyers,
+                    myPicks = mine.takeIf { it.isNotEmpty() },
+                    drawnNumbers = drawn.takeIf { it.isNotEmpty() },
+                    myMatches = matches,
+                )
+            }
+            val weighted = snap.weightedOpen?.let { row ->
+                WeightedView(
+                    pool = row.poolAmount,
+                    ticketPrice = row.ticketPrice,
+                    winnerCount = row.winnerCount,
+                    opensAtMillis = row.openedAt.toEpochMilli(),
+                    closesAtMillis = row.closesAt.toEpochMilli(),
+                    totalTickets = snap.weightedTotalTickets,
+                    myTickets = snap.weightedMyTicket?.ticketCount ?: 0,
+                    mySpent = snap.weightedMyTicket?.spent ?: 0L,
+                    topHolders = snap.weightedTopHolders.map {
+                        TopHolder(it.discordId, it.ticketCount)
+                    },
+                )
+            }
+            return LotteryViewModel(
+                pickCount = snap.pickCount,
+                numberMax = snap.numberMax,
+                tierPercents = snap.tierPercents,
+                revenueJackpotPct = snap.revenueJackpotPct,
+                daily = daily,
+                weighted = weighted,
+            )
+        }
+
+        private fun parseCsv(csv: String?): List<Int> {
+            if (csv.isNullOrBlank()) return emptyList()
+            return csv.split(',').mapNotNull { it.trim().toIntOrNull() }
+        }
+
+        // Suppress unused parameter warning — used by Thymeleaf via reflection.
+        @Suppress("unused")
+        private fun unused(t: JackpotLotteryTicketDto) = t
+    }
+}

--- a/web/src/main/kotlin/web/controller/ModerationController.kt
+++ b/web/src/main/kotlin/web/controller/ModerationController.kt
@@ -218,6 +218,43 @@ class ModerationController(
         }
     }
 
+    /**
+     * Force the daily match-numbers lottery cycle to run *now* for
+     * [guildId]. Closes the current open draw (paying tier-based
+     * prizes), opens a fresh one seeded from the jackpot. Equivalent
+     * to what `LotteryDailyJob` does at 00:00 UTC, exposed manually so
+     * admins can fast-forward (testing, missed crons, demo).
+     */
+    @PostMapping("/{guildId}/lottery/draw", consumes = ["application/json"])
+    @ResponseBody
+    fun forceDailyLotteryDraw(
+        @PathVariable guildId: Long,
+        @AuthenticationPrincipal user: OAuth2User
+    ): ResponseEntity<ForceDrawLotteryResponse> = WebGuildAccess.requireSignedInForJson(
+        user, { ForceDrawLotteryResponse(false, "Not signed in.") }
+    ) { actor ->
+        val result = moderationWebService.forceDailyDraw(actor, guildId)
+        if (result.error != null) {
+            ResponseEntity.badRequest().body(
+                ForceDrawLotteryResponse(
+                    ok = false, error = result.error,
+                    drewPrior = result.drewPrior, priorTotalPaid = result.priorTotalPaid,
+                    priorRolledBack = result.priorRolledBack, priorDrawn = result.priorDrawn,
+                    openedNew = result.openedNew, newSeeded = result.newSeeded,
+                )
+            )
+        } else {
+            ResponseEntity.ok(
+                ForceDrawLotteryResponse(
+                    ok = true, error = null,
+                    drewPrior = result.drewPrior, priorTotalPaid = result.priorTotalPaid,
+                    priorRolledBack = result.priorRolledBack, priorDrawn = result.priorDrawn,
+                    openedNew = result.openedNew, newSeeded = result.newSeeded,
+                )
+            )
+        }
+    }
+
     @PostMapping("/{guildId}/poll", consumes = ["application/json"])
     @ResponseBody
     fun createPoll(
@@ -270,4 +307,15 @@ data class JackpotAdminResponse(
     val drained: Long = 0L,
     val newPool: Long = 0L,
     val newSourceBalance: Long? = null,
+)
+
+data class ForceDrawLotteryResponse(
+    val ok: Boolean,
+    val error: String?,
+    val drewPrior: Boolean = false,
+    val priorTotalPaid: Long = 0L,
+    val priorRolledBack: Long = 0L,
+    val priorDrawn: List<Int> = emptyList(),
+    val openedNew: Boolean = false,
+    val newSeeded: Long = 0L,
 )

--- a/web/src/main/kotlin/web/service/LotteryWebService.kt
+++ b/web/src/main/kotlin/web/service/LotteryWebService.kt
@@ -1,0 +1,89 @@
+package web.service
+
+import database.dto.JackpotLotteryDto
+import database.dto.JackpotLotteryTicketDto
+import database.service.ConfigService
+import database.service.JackpotLotteryService
+import database.service.LotteryHelper
+import org.springframework.stereotype.Service
+
+/**
+ * Thin orchestration layer around [JackpotLotteryService] for the web
+ * lottery page. Exposes view-friendly snapshots and ticket-buy outcome
+ * mapping; doesn't introduce new lottery semantics.
+ *
+ * Mirrors the shape of `BlackjackWebService` / `CasinoHoldemWebService`:
+ * controller passes user inputs in, service returns DTO-style data
+ * objects the controller wraps for JSON responses.
+ */
+@Service
+class LotteryWebService(
+    private val jackpotLotteryService: JackpotLotteryService,
+    private val configService: ConfigService,
+) {
+
+    /**
+     * Daily-draw + featured weighted-event snapshot for the page render.
+     * Either field can be null when no lottery of that mode is open.
+     */
+    data class LotteryPageSnapshot(
+        val dailyOpen: JackpotLotteryDto?,
+        val dailyLatestDrawn: JackpotLotteryDto?,
+        val dailyMyTicket: JackpotLotteryTicketDto?,
+        val dailyTicketBuyers: Int,
+        val weightedOpen: JackpotLotteryDto?,
+        val weightedMyTicket: JackpotLotteryTicketDto?,
+        val weightedTopHolders: List<JackpotLotteryTicketDto>,
+        val weightedTotalTickets: Long,
+        val pickCount: Int,
+        val numberMax: Int,
+        val tierPercents: List<Int>,
+        val revenueJackpotPct: Long,
+    )
+
+    fun snapshot(guildId: Long, discordId: Long): LotteryPageSnapshot {
+        val dailyOpen = jackpotLotteryService.getOpenMatch(guildId)
+        // If the open daily exists, that's "latest"; otherwise the most-
+        // recent DRAWN row (still useful to show last result).
+        val dailyLatest = dailyOpen ?: jackpotLotteryService.getLatestMatch(guildId)
+        val dailyMyTicket = jackpotLotteryService.userTicketForOpenMatch(guildId, discordId)
+        val dailyBuyers = jackpotLotteryService.ticketsForOpenMatch(guildId).size
+
+        val weightedOpen = jackpotLotteryService.getOpenWeighted(guildId)
+        val weightedTickets = jackpotLotteryService.ticketsForOpenWeighted(guildId)
+        val weightedMyTicket = weightedTickets.firstOrNull { it.discordId == discordId }
+        val weightedTop = weightedTickets.sortedByDescending { it.ticketCount }.take(5)
+        val weightedTotal = weightedTickets.sumOf { it.ticketCount.toLong() }
+
+        return LotteryPageSnapshot(
+            dailyOpen = dailyOpen,
+            dailyLatestDrawn = dailyLatest,
+            dailyMyTicket = dailyMyTicket,
+            dailyTicketBuyers = dailyBuyers,
+            weightedOpen = weightedOpen,
+            weightedMyTicket = weightedMyTicket,
+            weightedTopHolders = weightedTop,
+            weightedTotalTickets = weightedTotal,
+            pickCount = LotteryHelper.MATCH_PICK_COUNT,
+            numberMax = LotteryHelper.MATCH_NUMBER_MAX,
+            tierPercents = LotteryHelper.TIER_PCTS_5_4_3_2.toList(),
+            revenueJackpotPct = LotteryHelper.dailyRevenueJackpotPct(configService, guildId),
+        )
+    }
+
+    /** Buy a NUMBER_MATCH ticket. Wraps the underlying service 1:1. */
+    fun buyMatch(
+        guildId: Long,
+        discordId: Long,
+        picks: List<Int>,
+    ): JackpotLotteryService.BuyMatchOutcome =
+        jackpotLotteryService.buyMatchTicket(guildId, discordId, picks)
+
+    /** Buy [count] weighted tickets. Wraps the underlying service 1:1. */
+    fun buyWeighted(
+        guildId: Long,
+        discordId: Long,
+        count: Int,
+    ): JackpotLotteryService.BuyOutcome =
+        jackpotLotteryService.buyTickets(guildId, discordId, count)
+}

--- a/web/src/main/kotlin/web/service/ModerationWebService.kt
+++ b/web/src/main/kotlin/web/service/ModerationWebService.kt
@@ -6,7 +6,9 @@ import database.dto.ConfigDto
 import database.dto.UserDto
 import database.service.CasinoAdminService
 import database.service.ConfigService
+import database.service.JackpotLotteryService
 import database.service.JackpotService
+import database.service.LotteryHelper
 import database.service.MonthlyCreditSnapshotService
 import database.service.TitleService
 import database.service.UbiDailyService
@@ -34,6 +36,7 @@ class ModerationWebService(
     private val ubiDailyService: UbiDailyService,
     private val jackpotService: JackpotService,
     private val casinoAdminService: CasinoAdminService,
+    private val jackpotLotteryService: JackpotLotteryService,
     private val eventPublisher: ApplicationEventPublisher
 ) {
     companion object {
@@ -306,6 +309,98 @@ class ModerationWebService(
         }
     }
 
+    /**
+     * Force-draw the daily match-numbers lottery for [guildId]: closes
+     * the current open draw (paying tier-based prizes) and opens a
+     * fresh one seeded from the jackpot. Mirrors what
+     * [bot.toby.scheduling.LotteryDailyJob] does at 00:00 UTC, but
+     * admin-triggered for testing or when the cron missed (bot was
+     * down at midnight, etc).
+     */
+    data class ForceDrawLotteryResult(
+        val error: String?,
+        val drewPrior: Boolean,
+        val priorTotalPaid: Long,
+        val priorRolledBack: Long,
+        val priorDrawn: List<Int>,
+        val openedNew: Boolean,
+        val newSeeded: Long,
+    )
+
+    fun forceDailyDraw(actorDiscordId: Long, guildId: Long): ForceDrawLotteryResult {
+        if (!canModerate(actorDiscordId, guildId)) {
+            return ForceDrawLotteryResult(
+                error = "You are not allowed to moderate this server.",
+                drewPrior = false, priorTotalPaid = 0L, priorRolledBack = 0L,
+                priorDrawn = emptyList(), openedNew = false, newSeeded = 0L,
+            )
+        }
+        // Step 1: close open daily if present.
+        var drewPrior = false
+        var priorTotalPaid = 0L
+        var priorRolledBack = 0L
+        var priorDrawn: List<Int> = emptyList()
+        when (val drawResult = jackpotLotteryService.drawMatchLottery(guildId)) {
+            is JackpotLotteryService.DrawMatchOutcome.Ok -> {
+                drewPrior = true
+                priorTotalPaid = drawResult.totalPaid
+                priorRolledBack = drawResult.rolledBackToJackpot
+                priorDrawn = drawResult.drawnNumbers
+            }
+            JackpotLotteryService.DrawMatchOutcome.NoTickets -> {
+                jackpotLotteryService.cancelMatchLottery(guildId)
+                drewPrior = true
+            }
+            JackpotLotteryService.DrawMatchOutcome.NoOpenLottery -> {
+                // No-op; nothing to close.
+            }
+        }
+        // Step 2: open fresh daily.
+        val ticketPrice = LotteryHelper.dailyTicketPrice(configService, guildId)
+        val seedPct = LotteryHelper.dailySeedPct(configService, guildId)
+        val open = jackpotLotteryService.openMatchLottery(
+            guildId = guildId,
+            ticketPrice = ticketPrice,
+            seedPct = seedPct,
+            durationHours = 24L,
+        )
+        return when (open) {
+            is JackpotLotteryService.OpenOutcome.Ok -> {
+                logger.info(
+                    "Casino admin force-drew daily lottery: guild=$guildId actor=$actorDiscordId " +
+                        "drewPrior=$drewPrior priorTotalPaid=$priorTotalPaid newSeeded=${open.seeded}"
+                )
+                ForceDrawLotteryResult(
+                    error = null,
+                    drewPrior = drewPrior, priorTotalPaid = priorTotalPaid,
+                    priorRolledBack = priorRolledBack, priorDrawn = priorDrawn,
+                    openedNew = true, newSeeded = open.seeded,
+                )
+            }
+            JackpotLotteryService.OpenOutcome.AlreadyOpen ->
+                ForceDrawLotteryResult(
+                    error = "A daily lottery is already open — close it first.",
+                    drewPrior = drewPrior, priorTotalPaid = priorTotalPaid,
+                    priorRolledBack = priorRolledBack, priorDrawn = priorDrawn,
+                    openedNew = false, newSeeded = 0L,
+                )
+            JackpotLotteryService.OpenOutcome.EmptyPool ->
+                ForceDrawLotteryResult(
+                    error = null,
+                    drewPrior = drewPrior, priorTotalPaid = priorTotalPaid,
+                    priorRolledBack = priorRolledBack, priorDrawn = priorDrawn,
+                    openedNew = false, newSeeded = 0L,
+                )
+            is JackpotLotteryService.OpenOutcome.InvalidParams ->
+                ForceDrawLotteryResult(
+                    error = open.reason,
+                    drewPrior = drewPrior, priorTotalPaid = priorTotalPaid,
+                    priorRolledBack = priorRolledBack, priorDrawn = priorDrawn,
+                    openedNew = false, newSeeded = 0L,
+                )
+        }
+    }
+
     fun updateConfig(
         actorDiscordId: Long,
         guildId: Long,
@@ -517,6 +612,29 @@ class ModerationWebService(
                 val n = rawValue.trim().toIntOrNull()
                     ?: return "Value must be a whole number percentage (0-50; 0 disables)."
                 if (n !in 0..50) return "Value must be between 0 and 50."
+                n.toString()
+            }
+            ConfigDto.Configurations.LOTTERY_DAILY_ENABLED -> {
+                val v = rawValue.trim().lowercase()
+                if (v !in setOf("true", "false")) return "Value must be true or false."
+                v
+            }
+            ConfigDto.Configurations.LOTTERY_DAILY_TICKET_PRICE -> {
+                val n = rawValue.trim().toLongOrNull()
+                    ?: return "Value must be a whole number of credits (1-1000000)."
+                if (n !in 1L..1_000_000L) return "Value must be between 1 and 1,000,000 credits."
+                n.toString()
+            }
+            ConfigDto.Configurations.LOTTERY_DAILY_SEED_PCT -> {
+                val n = rawValue.trim().toIntOrNull()
+                    ?: return "Value must be a whole number percentage (1-100; default 5)."
+                if (n !in 1..100) return "Value must be between 1 and 100."
+                n.toString()
+            }
+            ConfigDto.Configurations.LOTTERY_DAILY_REVENUE_JACKPOT_PCT -> {
+                val n = rawValue.trim().toIntOrNull()
+                    ?: return "Value must be a whole number percentage (0-100; default 30)."
+                if (n !in 0..100) return "Value must be between 0 and 100."
                 n.toString()
             }
         }

--- a/web/src/main/resources/static/css/base.css
+++ b/web/src/main/resources/static/css/base.css
@@ -433,7 +433,8 @@ td { font-size: 0.95rem; }
 .dice-result-jackpot,
 .highlow-result-jackpot,
 .scratch-result-jackpot,
-.bac-result-jackpot {
+.bac-result-jackpot,
+.lottery-result-jackpot {
     color: #f1c40f;
     text-shadow: 0 0 8px rgba(241, 196, 15, 0.4);
 }

--- a/web/src/main/resources/static/css/lottery.css
+++ b/web/src/main/resources/static/css/lottery.css
@@ -1,0 +1,248 @@
+@import url("./casino-table.css");
+
+/* ============================================================ */
+/* Page header                                                   */
+/* ============================================================ */
+
+.lottery-header { margin-bottom: var(--space-5); }
+.lottery-header h1 { margin: var(--space-2) 0; }
+
+.lottery-daily-header {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--space-3);
+    margin-bottom: var(--space-4);
+    text-align: center;
+}
+.lottery-daily-header h2 { margin: 0; }
+
+.lottery-daily-meta,
+.lottery-weighted-meta {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: var(--space-3) var(--space-5);
+    font-size: 0.95rem;
+    font-variant-numeric: tabular-nums;
+}
+
+.lottery-meta-item {
+    background: rgba(0, 0, 0, 0.25);
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    border-radius: var(--radius-md);
+    padding: var(--space-2) var(--space-3);
+}
+
+/* Tabular-nums on the live countdown so the digits don't jiggle. */
+.lottery-countdown-value { font-variant-numeric: tabular-nums; }
+
+/* ============================================================ */
+/* Number picker grid                                            */
+/* ============================================================ */
+
+.lottery-daily { /* casino-felt owns the green-felt frame; layout only here */
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--space-4);
+    position: relative;
+}
+
+.lottery-pickbar {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--space-3);
+    justify-content: center;
+}
+.lottery-pickcount {
+    background: rgba(0, 0, 0, 0.25);
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    border-radius: var(--radius-md);
+    padding: var(--space-2) var(--space-3);
+}
+
+/* 7 columns × ceil(49/7) = 7 rows for the 1-49 grid. The grid auto-
+   wraps with auto-fit if max changes (e.g. 4-of-20 future variant). */
+.lottery-cells {
+    display: grid;
+    grid-template-columns: repeat(7, minmax(0, 1fr));
+    gap: var(--space-2);
+    width: 100%;
+    max-width: 460px;
+}
+
+.lottery-cells-readonly {
+    /* Readonly displays use auto-fit so 5 numbers don't span 7 columns. */
+    grid-template-columns: repeat(auto-fit, minmax(48px, 60px));
+    justify-content: center;
+}
+
+.lottery-cell {
+    aspect-ratio: 1 / 1;
+    /* Override casino-card-face's 3rem×4.5rem — the picker needs square
+       cells in a tight grid, not playing-card proportions. */
+    width: auto;
+    height: auto;
+    min-width: 40px;
+    border-radius: 50%;          /* round like a lotto ball */
+    cursor: pointer;
+    transition: transform 0.1s, box-shadow 0.2s;
+    user-select: none;
+    font-size: 1.05rem;
+    font-weight: 700;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+.lottery-cell:hover:not(:disabled):not(.is-drawn) {
+    transform: translateY(-2px);
+}
+.lottery-cell:active:not(:disabled) {
+    transform: translateY(0) scale(0.96);
+}
+.lottery-cell:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+}
+
+/* Pick states (user side) */
+.lottery-cell.is-picked {
+    background: var(--casino-active-tile-bg);
+    box-shadow: var(--casino-active-glow);
+    color: #1a1a1a;
+}
+
+/* Draw states (winning numbers) */
+.lottery-cell.is-drawn {
+    background: linear-gradient(180deg, #f6dc6c 0%, #d4a017 100%);
+    color: #1a1a1a;
+    cursor: default;
+    box-shadow: 0 0 12px rgba(241, 196, 15, 0.55), var(--casino-card-shadow);
+}
+
+/* Both picked AND drawn — winning match, biggest visual reward */
+.lottery-cell.is-picked.is-matched,
+.lottery-cell.is-matched {
+    background: linear-gradient(180deg, #f6dc6c 0%, #d4a017 100%);
+    box-shadow:
+        0 0 0 3px var(--casino-gold),
+        0 0 22px rgba(241, 196, 15, 0.7);
+    animation: casino-pulse 1.6s ease-in-out infinite;
+}
+
+.lottery-actions {
+    display: flex;
+    gap: var(--space-3);
+    align-items: center;
+    flex-wrap: wrap;
+    justify-content: center;
+}
+
+.lottery-balance {
+    color: var(--text-muted);
+    font-variant-numeric: tabular-nums;
+}
+
+/* ============================================================ */
+/* Result panel                                                  */
+/* ============================================================ */
+
+.lottery-result-panel {
+    width: 100%;
+    max-width: 460px;
+    text-align: center;
+}
+
+.lottery-result-panel h3 {
+    margin-top: var(--space-4);
+    margin-bottom: var(--space-2);
+}
+
+.lottery-result-summary {
+    margin-top: var(--space-3);
+    font-size: 1.05rem;
+    font-variant-numeric: tabular-nums;
+}
+
+.lottery-result {
+    min-height: 1.5em;
+    font-size: 1.05rem;
+    font-variant-numeric: tabular-nums;
+    text-align: center;
+    margin-top: var(--space-3);
+}
+
+.lottery-result-win,
+.lottery-result-summary.lottery-result-win {
+    color: #57F287;
+}
+
+.lottery-result-lose,
+.lottery-result-summary.lottery-result-lose {
+    color: var(--text-muted);
+}
+
+/* ============================================================ */
+/* Featured weighted-event card                                  */
+/* ============================================================ */
+
+.lottery-weighted {
+    margin-top: var(--space-6);
+    padding: var(--space-5);
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+}
+
+.lottery-weighted h2 { margin-top: 0; }
+
+#lottery-weighted-bet {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    flex-wrap: wrap;
+    margin: var(--space-4) 0;
+}
+#lottery-weighted-bet label {
+    color: var(--text-muted);
+}
+#lottery-weighted-bet input {
+    width: 120px;
+}
+
+.lottery-top-holders {
+    list-style: decimal;
+    padding-left: var(--space-5);
+    margin: 0;
+}
+
+/* ============================================================ */
+/* Payout / tier schedule table                                  */
+/* ============================================================ */
+
+.lottery-payouts {
+    margin-top: var(--space-6);
+}
+.lottery-tier-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-variant-numeric: tabular-nums;
+}
+.lottery-tier-table th,
+.lottery-tier-table td {
+    padding: var(--space-3);
+    border-bottom: 1px solid var(--border);
+    text-align: left;
+}
+.lottery-tier-table th {
+    color: var(--text-muted);
+    font-weight: 600;
+    border-bottom-width: 2px;
+}
+
+@media (max-width: 480px) {
+    .lottery-cells { grid-template-columns: repeat(7, minmax(0, 1fr)); }
+    .lottery-cell { min-width: 30px; font-size: 0.9rem; }
+}

--- a/web/src/main/resources/static/js/lottery.js
+++ b/web/src/main/resources/static/js/lottery.js
@@ -1,0 +1,223 @@
+/* global TobyApi, TobyBalance, toast */
+/**
+ * Web lottery page logic.
+ *
+ *  - Number picker (Pick 5 of 1-49 — read from data-pick-count /
+ *    data-number-max). Click a cell to toggle; max N picks; visual
+ *    feedback via .is-picked.
+ *  - Quick Pick + Clear helpers.
+ *  - Submit ticket via POST /casino/{guildId}/lottery/match/buy with
+ *    `{ picks: [...] }`. On success, refresh the balance and reload
+ *    the page so server-side rendering shows "Your ticket" panel.
+ *  - Live countdown to closes_at.
+ *  - Featured weighted-event card: separate buy form posting to
+ *    /casino/{guildId}/lottery/weighted/buy with `{ count: N }`.
+ *
+ * Reuses the casino-balance / api / toasts shared modules; doesn't go
+ * through the casino-game scaffold because the lottery's POST→reload
+ * shape doesn't match the spin-animate-settle scaffold (the server
+ * side tells us "you bought" — actual results land on the next draw,
+ * surfaced via the GET-page render).
+ */
+(function () {
+    'use strict';
+
+    const main = document.getElementById('main');
+    if (!main) return;
+    const guildId = main.dataset.guildId;
+    const pickCount = parseInt(main.dataset.pickCount, 10) || 5;
+    const numberMax = parseInt(main.dataset.numberMax, 10) || 49;
+
+    initDailyPicker();
+    initWeightedBet();
+    initCountdowns();
+
+    function initDailyPicker() {
+        const grid = document.getElementById('lottery-cells');
+        const form = document.getElementById('lottery-bet');
+        if (!grid || !form) return;
+        const counter = document.getElementById('lottery-pickcount-value');
+        const buyBtn = document.getElementById('lottery-buy');
+        const balanceEl = document.getElementById('lottery-balance');
+        const resultEl = document.getElementById('lottery-result');
+        const quickPickBtn = document.getElementById('lottery-quickpick');
+        const clearBtn = document.getElementById('lottery-clear');
+
+        const cells = Array.from(grid.querySelectorAll('.lottery-cell'));
+
+        function picked() {
+            return cells.filter(c => c.classList.contains('is-picked'));
+        }
+
+        function setCount() {
+            if (counter) counter.textContent = picked().length;
+        }
+
+        function togglePick(cell) {
+            if (cell.classList.contains('is-picked')) {
+                cell.classList.remove('is-picked');
+                cell.setAttribute('aria-pressed', 'false');
+            } else {
+                if (picked().length >= pickCount) {
+                    if (typeof toast === 'function') {
+                        toast(`You can only pick ${pickCount} numbers.`, 'error');
+                    }
+                    return;
+                }
+                cell.classList.add('is-picked');
+                cell.setAttribute('aria-pressed', 'true');
+            }
+            setCount();
+        }
+
+        cells.forEach(cell => {
+            cell.addEventListener('click', () => togglePick(cell));
+        });
+
+        if (quickPickBtn) {
+            quickPickBtn.addEventListener('click', () => {
+                const need = pickCount - picked().length;
+                if (need <= 0) return;
+                const candidates = cells.filter(c => !c.classList.contains('is-picked'));
+                // Fisher-Yates partial shuffle to pick `need` distinct cells.
+                for (let i = 0; i < need; i++) {
+                    const j = i + Math.floor(Math.random() * (candidates.length - i));
+                    [candidates[i], candidates[j]] = [candidates[j], candidates[i]];
+                    candidates[i].classList.add('is-picked');
+                    candidates[i].setAttribute('aria-pressed', 'true');
+                }
+                setCount();
+            });
+        }
+
+        if (clearBtn) {
+            clearBtn.addEventListener('click', () => {
+                cells.forEach(c => {
+                    c.classList.remove('is-picked');
+                    c.setAttribute('aria-pressed', 'false');
+                });
+                setCount();
+            });
+        }
+
+        form.addEventListener('submit', async (e) => {
+            e.preventDefault();
+            const selected = picked().map(c => parseInt(c.dataset.value, 10));
+            if (selected.length !== pickCount) {
+                if (typeof toast === 'function') {
+                    toast(`Pick exactly ${pickCount} numbers.`, 'error');
+                }
+                return;
+            }
+            buyBtn.disabled = true;
+            try {
+                const body = await TobyApi.postJson(
+                    `/casino/${guildId}/lottery/match/buy`,
+                    { picks: selected }
+                );
+                if (!body.ok) {
+                    if (typeof toast === 'function') {
+                        toast(body.error || 'Ticket purchase failed.', 'error');
+                    }
+                    if (resultEl) {
+                        resultEl.hidden = false;
+                        resultEl.textContent = body.error || 'Ticket purchase failed.';
+                        resultEl.classList.add('lottery-result-lose');
+                    }
+                    return;
+                }
+                if (balanceEl) TobyBalance.update(balanceEl, body.newBalance);
+                if (resultEl) {
+                    resultEl.hidden = false;
+                    resultEl.classList.remove('lottery-result-lose');
+                    resultEl.classList.add('lottery-result-win');
+                    resultEl.innerHTML =
+                        `Bought ticket • picked <strong>${selected.join(', ')}</strong>. ` +
+                        `<span class="casino-loss-tribute">+${body.jackpotInflow} to jackpot</span>`;
+                }
+                // Reload so the server-rendered "Your ticket" panel + live
+                // pool numbers appear without us having to maintain a JS
+                // shadow copy of the snapshot.
+                setTimeout(() => window.location.reload(), 1200);
+            } catch (err) {
+                if (typeof toast === 'function') {
+                    toast('Network error. Try again.', 'error');
+                }
+            } finally {
+                buyBtn.disabled = false;
+            }
+        });
+
+        setCount();
+    }
+
+    function initWeightedBet() {
+        const form = document.getElementById('lottery-weighted-bet');
+        if (!form) return;
+        const countInput = document.getElementById('weighted-count');
+        const buyBtn = document.getElementById('weighted-buy');
+        const poolEl = document.getElementById('weighted-pool');
+        const myEl = document.getElementById('weighted-my-tickets');
+        const balanceEl = document.getElementById('lottery-balance');
+
+        form.addEventListener('submit', async (e) => {
+            e.preventDefault();
+            const count = parseInt(countInput.value, 10) || 0;
+            if (count <= 0) return;
+            buyBtn.disabled = true;
+            try {
+                const body = await TobyApi.postJson(
+                    `/casino/${guildId}/lottery/weighted/buy`,
+                    { count: count }
+                );
+                if (!body.ok) {
+                    if (typeof toast === 'function') {
+                        toast(body.error || 'Buy failed.', 'error');
+                    }
+                    return;
+                }
+                if (poolEl) poolEl.textContent = body.newPool;
+                if (myEl) myEl.textContent = body.ticketCount;
+                if (balanceEl) TobyBalance.update(balanceEl, body.newBalance);
+                if (typeof toast === 'function') {
+                    toast(`Bought ${count} tickets — total ${body.ticketCount} held.`, 'success');
+                }
+            } catch (err) {
+                if (typeof toast === 'function') {
+                    toast('Network error. Try again.', 'error');
+                }
+            } finally {
+                buyBtn.disabled = false;
+            }
+        });
+    }
+
+    function initCountdowns() {
+        const targets = document.querySelectorAll('.lottery-countdown');
+        if (!targets.length) return;
+        function tick() {
+            const now = Date.now();
+            targets.forEach(el => {
+                const target = parseInt(el.dataset.closesAt, 10);
+                if (!target) return;
+                const diff = Math.max(0, target - now);
+                const valueEl = el.querySelector('.lottery-countdown-value');
+                if (!valueEl) return;
+                if (diff <= 0) {
+                    valueEl.textContent = 'closing…';
+                    return;
+                }
+                const totalSeconds = Math.floor(diff / 1000);
+                const h = Math.floor(totalSeconds / 3600);
+                const m = Math.floor((totalSeconds % 3600) / 60);
+                const s = totalSeconds % 60;
+                valueEl.textContent =
+                    String(h).padStart(2, '0') + ':' +
+                    String(m).padStart(2, '0') + ':' +
+                    String(s).padStart(2, '0');
+            });
+        }
+        tick();
+        setInterval(tick, 1000);
+    }
+}());

--- a/web/src/main/resources/static/js/moderation.js
+++ b/web/src/main/resources/static/js/moderation.js
@@ -347,4 +347,37 @@
             }).catch(() => { submitBtn.disabled = false; toast('Network error.', 'error'); });
         });
     }
+
+    // ==========================================================
+    // Daily lottery — force-draw button
+    // ==========================================================
+    const lotteryForceDrawBtn = document.getElementById('lottery-force-draw');
+    if (lotteryForceDrawBtn) {
+        lotteryForceDrawBtn.addEventListener('click', () => {
+            if (!confirm(
+                'Force the daily lottery cycle to run now? This closes any open draw ' +
+                'and pays prizes by match tier, then opens a fresh draw seeded from the jackpot.'
+            )) return;
+            lotteryForceDrawBtn.disabled = true;
+            postJson('/moderation/' + guildId + '/lottery/draw', {}).then(r => {
+                lotteryForceDrawBtn.disabled = false;
+                if (r && r.ok) {
+                    let msg = 'Lottery cycle ran.';
+                    if (r.drewPrior) {
+                        msg += ' Prior draw paid ' + (r.priorTotalPaid ?? 0) +
+                            ' credits (' + (r.priorRolledBack ?? 0) + ' rolled back to jackpot).';
+                    }
+                    if (r.openedNew) {
+                        msg += ' New draw seeded with ' + (r.newSeeded ?? 0) + ' credits.';
+                    }
+                    toast(msg, 'success');
+                } else {
+                    toast(r?.error || 'Could not run the lottery cycle.', 'error');
+                }
+            }).catch(() => {
+                lotteryForceDrawBtn.disabled = false;
+                toast('Network error.', 'error');
+            });
+        });
+    }
 })();

--- a/web/src/main/resources/templates/casino-guilds.html
+++ b/web/src/main/resources/templates/casino-guilds.html
@@ -55,6 +55,13 @@
                            th:href="@{/poker/{id}(id=${g.id})}">🃏 Poker</a>
                     </div>
                 </div>
+                <div class="lb-games-group">
+                    <h3 class="lb-games-group-title">Daily draw</h3>
+                    <div class="lb-games-row">
+                        <a class="btn-secondary"
+                           th:href="@{/casino/{id}/lottery(id=${g.id})}">🎟️ Lottery</a>
+                    </div>
+                </div>
             </div>
         </div>
     </div>

--- a/web/src/main/resources/templates/lottery.html
+++ b/web/src/main/resources/templates/lottery.html
@@ -1,0 +1,231 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="en">
+<head th:replace="~{fragments/head :: head('TobyBot - Lottery', '/css/lottery.css')}"></head>
+<body>
+<a href="#main" class="skip-link">Skip to content</a>
+<div th:replace="~{fragments/navbar :: navbar}"></div>
+
+<main id="main" class="container"
+      th:attr="data-guild-id=${guildId},
+               data-toby-coins=${tobyCoins},
+               data-market-price=${marketPrice},
+               data-pick-count=${snapshot.pickCount},
+               data-number-max=${snapshot.numberMax},
+               data-revenue-jackpot-pct=${snapshot.revenueJackpotPct}">
+
+    <div class="lottery-header">
+        <a class="back-link" th:href="@{/casino/guilds}">&larr; All casino servers</a>
+        <h1 th:text="'🎟️ Lottery • ' + ${guildName}">🎟️ Lottery</h1>
+        <p class="muted">
+            Pick <strong th:text="${snapshot.pickCount}">5</strong> numbers from
+            <strong>1–<span th:text="${snapshot.numberMax}">49</span></strong> for the daily draw.
+            <strong th:text="${snapshot.revenueJackpotPct}">30</strong>% of every ticket feeds the
+            per-server jackpot pool above; the remainder grows today's prize. Match more numbers,
+            win bigger.
+        </p>
+    </div>
+
+    <div th:replace="~{fragments/alerts :: error}"></div>
+    <div th:replace="~{fragments/casino :: jackpotBanner}"></div>
+
+    <!-- ========================================================== -->
+    <!-- Today's daily match-numbers draw                            -->
+    <!-- ========================================================== -->
+    <section class="lottery-daily casino-felt">
+        <header class="lottery-daily-header">
+            <h2>Today's draw</h2>
+            <div class="lottery-daily-meta" th:if="${snapshot.daily != null}">
+                <span class="lottery-meta-item">
+                    Prize pool:
+                    <strong id="lottery-pool" th:text="${snapshot.daily.pool}">0</strong>
+                    <span class="muted">credits</span>
+                </span>
+                <span class="lottery-meta-item">
+                    Ticket: <strong th:text="${snapshot.daily.ticketPrice}">50</strong>
+                    <span class="muted">credits</span>
+                </span>
+                <span class="lottery-meta-item">
+                    Tickets sold: <strong th:text="${snapshot.daily.ticketBuyers}">0</strong>
+                </span>
+                <span class="lottery-meta-item lottery-countdown"
+                      th:if="${snapshot.daily.isOpen}"
+                      th:attr="data-closes-at=${snapshot.daily.closesAtMillis}">
+                    Closes in <strong class="lottery-countdown-value">--:--:--</strong>
+                </span>
+                <span class="lottery-meta-item muted"
+                      th:if="${!snapshot.daily.isOpen}"
+                      th:text="${'Status: ' + snapshot.daily.status}">Status: DRAWN</span>
+            </div>
+            <p class="muted" th:if="${snapshot.daily == null}">
+                No daily draw is open right now — check back soon. (The cycle opens at 00:00 UTC.)
+            </p>
+        </header>
+
+        <!-- Number picker -->
+        <div class="lottery-picker"
+             th:if="${snapshot.daily != null and snapshot.daily.isOpen and snapshot.daily.myPicks == null}">
+            <div class="lottery-pickbar">
+                <span class="lottery-pickcount">
+                    Picks: <strong id="lottery-pickcount-value">0</strong> / <span th:text="${snapshot.pickCount}">5</span>
+                </span>
+                <button type="button" id="lottery-quickpick" class="btn-secondary"
+                        title="Auto-fill the rest of your picks at random.">Quick Pick</button>
+                <button type="button" id="lottery-clear" class="btn-secondary">Clear</button>
+            </div>
+            <form id="lottery-bet" autocomplete="off">
+                <div class="lottery-cells" id="lottery-cells" role="grid"
+                     aria-label="Lottery number picker">
+                    <button th:each="n : ${#numbers.sequence(1, snapshot.numberMax)}"
+                            type="button" class="lottery-cell casino-card-face"
+                            th:attr="data-value=${n}, aria-label='Number ' + ${n}, aria-pressed='false'"
+                            th:text="${n}">1</button>
+                </div>
+                <div class="lottery-actions">
+                    <button type="submit" id="lottery-buy" class="btn-primary">
+                        Buy ticket (<span th:text="${snapshot.daily.ticketPrice}">50</span> credits)
+                    </button>
+                </div>
+            </form>
+            <div class="lottery-balance">
+                Wallet: <strong id="lottery-balance" th:text="${balance}">0</strong> credits
+            </div>
+        </div>
+
+        <!-- User's existing ticket (already bought today) -->
+        <div class="lottery-my-ticket"
+             th:if="${snapshot.daily != null and snapshot.daily.myPicks != null}">
+            <h3>Your ticket</h3>
+            <div class="lottery-cells lottery-cells-readonly" aria-label="Your picks">
+                <span th:each="n : ${snapshot.daily.myPicks}"
+                      class="lottery-cell casino-card-face is-picked"
+                      th:classappend="${snapshot.daily.drawnNumbers != null and #lists.contains(snapshot.daily.drawnNumbers, n) ? ' is-matched' : ''}"
+                      th:text="${n}">1</span>
+            </div>
+            <p class="muted" th:if="${snapshot.daily.isOpen}">
+                One ticket per draw — come back at the next 00:00 UTC for a fresh chance.
+            </p>
+        </div>
+
+        <!-- Last result panel -->
+        <div class="lottery-result-panel"
+             th:if="${snapshot.daily != null and snapshot.daily.drawnNumbers != null}">
+            <h3>
+                Winning numbers
+                <span class="muted lottery-result-label" th:if="${!snapshot.daily.isOpen}">(latest draw)</span>
+            </h3>
+            <div class="lottery-cells lottery-cells-readonly" aria-label="Winning numbers">
+                <span th:each="n : ${snapshot.daily.drawnNumbers}"
+                      class="lottery-cell casino-card-face is-drawn"
+                      th:text="${n}">1</span>
+            </div>
+            <p class="lottery-result-summary"
+               th:if="${snapshot.daily.myMatches != null}"
+               th:classappend="${snapshot.daily.myMatches >= 2 ? ' lottery-result-win' : ' lottery-result-lose'}"
+               th:text="'You matched ' + ${snapshot.daily.myMatches} + ' / ' + ${snapshot.pickCount} + '.'">
+                You matched 0 / 5.
+            </p>
+        </div>
+
+        <!-- Live result line written by JS after a buy -->
+        <div id="lottery-result" class="lottery-result muted" hidden></div>
+    </section>
+
+    <!-- ========================================================== -->
+    <!-- Featured event — admin-fired weighted lottery (when open)   -->
+    <!-- ========================================================== -->
+    <section class="lottery-weighted" th:if="${snapshot.weighted != null}">
+        <h2>🌟 Featured event • Weighted draw</h2>
+        <p class="muted">
+            Special admin-fired lottery — every ticket is a weight in the draw, and
+            <strong th:text="${snapshot.weighted.winnerCount}">3</strong>
+            winners share the prize pool by tier.
+        </p>
+        <div class="lottery-weighted-meta">
+            <span class="lottery-meta-item">
+                Prize pool:
+                <strong id="weighted-pool" th:text="${snapshot.weighted.pool}">0</strong>
+                <span class="muted">credits</span>
+            </span>
+            <span class="lottery-meta-item">
+                Ticket: <strong th:text="${snapshot.weighted.ticketPrice}">100</strong>
+                <span class="muted">credits</span>
+            </span>
+            <span class="lottery-meta-item">
+                Tickets sold:
+                <strong th:text="${snapshot.weighted.totalTickets}">0</strong>
+            </span>
+            <span class="lottery-meta-item">
+                Your tickets:
+                <strong id="weighted-my-tickets" th:text="${snapshot.weighted.myTickets}">0</strong>
+            </span>
+            <span class="lottery-meta-item lottery-countdown"
+                  th:attr="data-closes-at=${snapshot.weighted.closesAtMillis}">
+                Closes in <strong class="lottery-countdown-value">--:--:--</strong>
+            </span>
+        </div>
+        <form id="lottery-weighted-bet" autocomplete="off">
+            <label for="weighted-count">Tickets to buy</label>
+            <input id="weighted-count" name="count" type="number" min="1" value="1" required>
+            <button type="submit" id="weighted-buy" class="btn-primary">
+                Buy <span class="muted">(at <strong th:text="${snapshot.weighted.ticketPrice}">100</strong>/ticket)</span>
+            </button>
+        </form>
+        <div class="lottery-weighted-holders" th:if="${!#lists.isEmpty(snapshot.weighted.topHolders)}">
+            <h3>Top holders</h3>
+            <ol class="lottery-top-holders">
+                <li th:each="h : ${snapshot.weighted.topHolders}">
+                    <span class="muted">User #<span th:text="${h.discordId}">…</span></span>
+                    — <strong th:text="${h.ticketCount}">0</strong> tickets
+                </li>
+            </ol>
+        </div>
+    </section>
+
+    <!-- ========================================================== -->
+    <!-- Payout schedule                                             -->
+    <!-- ========================================================== -->
+    <section class="lottery-payouts">
+        <h2>How payouts work</h2>
+        <p class="muted">
+            The day's prize pool splits across match tiers. 0 or 1 matches pay nothing —
+            those tickets fund tomorrow's prizes (and feed the jackpot via the revenue split).
+            Empty tiers and rounding remainders roll back into the per-server jackpot pool.
+        </p>
+        <table class="lottery-tier-table">
+            <thead>
+                <tr>
+                    <th>Matches</th>
+                    <th>Prize pool share</th>
+                    <th>Notes</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr th:each="i, iter : ${snapshot.tierPercents}"
+                    th:with="match=${5 - iter.index}">
+                    <td><strong th:text="${match} + ' / ' + ${snapshot.pickCount}">5 / 5</strong></td>
+                    <td><strong th:text="${snapshot.tierPercents[iter.index]} + '%'">60%</strong></td>
+                    <td class="muted">
+                        <span th:if="${match == 5}">Top tier — split equally if multiple jackpot winners.</span>
+                        <span th:if="${match == 4}">Second tier.</span>
+                        <span th:if="${match == 3}">Third tier — frequent at this odds level.</span>
+                        <span th:if="${match == 2}">Consolation tier — small return.</span>
+                    </td>
+                </tr>
+                <tr>
+                    <td><strong>0–1 / <span th:text="${snapshot.pickCount}">5</span></strong></td>
+                    <td><strong>0%</strong></td>
+                    <td class="muted">Lose stake — funds tomorrow's pool.</td>
+                </tr>
+            </tbody>
+        </table>
+    </section>
+</main>
+
+<div class="toast-stack" id="toast-stack" aria-live="polite"></div>
+
+<script th:src="@{/js/api.js}"></script>
+<script th:src="@{/js/toasts.js}"></script>
+<script th:src="@{/js/casino-balance.js}"></script>
+<script th:src="@{/js/lottery.js}"></script>
+</body>
+</html>

--- a/web/src/main/resources/templates/lottery.html
+++ b/web/src/main/resources/templates/lottery.html
@@ -223,9 +223,7 @@
 
 <div class="toast-stack" id="toast-stack" aria-live="polite"></div>
 
-<script th:src="@{/js/api.js}"></script>
-<script th:src="@{/js/toasts.js}"></script>
-<script th:src="@{/js/casino-balance.js}"></script>
+<th:block th:replace="~{fragments/casinoMinigame :: scripts}"></th:block>
 <script th:src="@{/js/lottery.js}"></script>
 </body>
 </html>

--- a/web/src/main/resources/templates/moderation.html
+++ b/web/src/main/resources/templates/moderation.html
@@ -846,6 +846,63 @@
                 <button type="submit" class="btn">Refund to jackpot</button>
             </form>
         </div>
+
+        <!-- Daily lottery: opt-in toggle + parameters + force draw -->
+        <div class="mod-card mod-card-wide">
+            <h3>Daily match-numbers lottery (Pick 5 of 1-49)</h3>
+            <p class="muted">
+                Auto-runs at 00:00 UTC. Closes the prior day's draw (paying tier prizes by
+                match count: 60/25/10/5 % of pool for 5/4/3/2 matches), then opens a new
+                day seeded from the jackpot pool. Each ticket sale routes a configurable
+                share back to the jackpot — the daily is a credit sink that drains the
+                pool steadily through many small wins instead of one big lucky roll.
+            </p>
+            <div class="config-row" data-key="LOTTERY_DAILY_ENABLED">
+                <label>
+                    Enable daily lottery
+                    <select name="LOTTERY_DAILY_ENABLED" data-key="LOTTERY_DAILY_ENABLED">
+                        <option value="true"
+                                th:selected="${overview.config['LOTTERY_DAILY_ENABLED'] == 'true'}">Enabled</option>
+                        <option value="false"
+                                th:selected="${overview.config['LOTTERY_DAILY_ENABLED'] != 'true'}">Disabled</option>
+                    </select>
+                </label>
+            </div>
+            <div class="config-row" data-key="LOTTERY_DAILY_TICKET_PRICE">
+                <label>
+                    Ticket price (credits)
+                    <input type="number" name="LOTTERY_DAILY_TICKET_PRICE"
+                           th:value="${overview.config['LOTTERY_DAILY_TICKET_PRICE']}"
+                           min="1" max="1000000" placeholder="50 (default)">
+                </label>
+            </div>
+            <div class="config-row" data-key="LOTTERY_DAILY_SEED_PCT">
+                <label>
+                    Daily seed (% of jackpot pool)
+                    <span class="config-input-group">
+                        <input type="number" name="LOTTERY_DAILY_SEED_PCT"
+                               th:value="${overview.config['LOTTERY_DAILY_SEED_PCT']}"
+                               min="1" max="100" placeholder="5 (default)">
+                        <span class="config-suffix">%</span>
+                    </span>
+                </label>
+            </div>
+            <div class="config-row" data-key="LOTTERY_DAILY_REVENUE_JACKPOT_PCT">
+                <label>
+                    Ticket revenue → jackpot
+                    <span class="config-input-group">
+                        <input type="number" name="LOTTERY_DAILY_REVENUE_JACKPOT_PCT"
+                               th:value="${overview.config['LOTTERY_DAILY_REVENUE_JACKPOT_PCT']}"
+                               min="0" max="100" placeholder="30 (default)">
+                        <span class="config-suffix">%</span>
+                    </span>
+                </label>
+            </div>
+            <p class="muted">
+                Force the cycle to run now (close any open draw, pay prizes, open the next):
+            </p>
+            <button id="lottery-force-draw" type="button" class="btn">Force draw now</button>
+        </div>
     </section>
 </main>
 

--- a/web/src/test/kotlin/web/controller/LotteryControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/LotteryControllerTest.kt
@@ -1,0 +1,252 @@
+package web.controller
+
+import database.dto.JackpotLotteryDto
+import database.service.JackpotLotteryService.BuyMatchOutcome
+import database.service.JackpotLotteryService.BuyOutcome
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.security.oauth2.core.user.OAuth2User
+import web.casino.CasinoPageContext
+import web.service.EconomyWebService
+import web.service.LotteryWebService
+
+/**
+ * Web HTTP-shape tests for the lottery controller. Mirrors the
+ * `SlotsControllerTest` style: covers each outcome's status code +
+ * response payload so refactors to the underlying service can't
+ * accidentally break the buy-flow contract.
+ */
+class LotteryControllerTest {
+
+    private val guildId = 42L
+    private val discordId = 100L
+
+    private lateinit var lotteryWebService: LotteryWebService
+    private lateinit var economyWebService: EconomyWebService
+    private lateinit var pageContext: CasinoPageContext
+    private lateinit var user: OAuth2User
+    private lateinit var controller: LotteryController
+
+    @BeforeEach
+    fun setup() {
+        lotteryWebService = mockk(relaxed = true)
+        economyWebService = mockk(relaxed = true)
+        pageContext = mockk(relaxed = true)
+        user = mockk {
+            every { getAttribute<String>("id") } returns discordId.toString()
+            every { getAttribute<String>("username") } returns "tester"
+        }
+        every { economyWebService.isMember(discordId, guildId) } returns true
+        controller = LotteryController(lotteryWebService, economyWebService, pageContext)
+    }
+
+    // ---- /match/buy -------------------------------------------
+
+    @Test
+    fun `buyMatch ok returns 200 with picks, balance, pool and jackpot inflow`() {
+        every { lotteryWebService.buyMatch(guildId, discordId, listOf(1, 13, 27, 33, 49)) } returns
+            BuyMatchOutcome.Ok(
+                pickedNumbers = listOf(1, 13, 27, 33, 49),
+                totalSpent = 50L,
+                newBalance = 950L,
+                newPool = 1_035L,
+                jackpotInflow = 15L,
+            )
+
+        val response = controller.buyMatch(
+            guildId, BuyMatchRequest(picks = listOf(1, 13, 27, 33, 49)), user
+        )
+
+        assertTrue(response.statusCode.is2xxSuccessful)
+        val body = response.body!!
+        assertEquals(true, body.ok)
+        assertNull(body.error)
+        assertEquals(listOf(1, 13, 27, 33, 49), body.pickedNumbers)
+        assertEquals(50L, body.totalSpent)
+        assertEquals(950L, body.newBalance)
+        assertEquals(1_035L, body.newPool)
+        assertEquals(15L, body.jackpotInflow)
+    }
+
+    @Test
+    fun `buyMatch invalid picks returns 400 with the validation reason`() {
+        every { lotteryWebService.buyMatch(guildId, discordId, any()) } returns
+            BuyMatchOutcome.InvalidPicks("must select exactly 5 numbers")
+
+        val response = controller.buyMatch(guildId, BuyMatchRequest(picks = listOf(1, 2, 3)), user)
+
+        assertEquals(400, response.statusCode.value())
+        val body = response.body!!
+        assertEquals(false, body.ok)
+        assertNotNull(body.error)
+        assertTrue(body.error!!.contains("must select exactly 5 numbers"))
+    }
+
+    @Test
+    fun `buyMatch insufficient credits returns 400 with the shortfall`() {
+        every { lotteryWebService.buyMatch(guildId, discordId, any()) } returns
+            BuyMatchOutcome.Insufficient(have = 30L, need = 50L)
+
+        val response = controller.buyMatch(
+            guildId, BuyMatchRequest(picks = listOf(1, 2, 3, 4, 5)), user
+        )
+
+        assertEquals(400, response.statusCode.value())
+        val body = response.body!!
+        assertEquals(false, body.ok)
+        assertTrue(body.error!!.contains("30") && body.error!!.contains("50"))
+    }
+
+    @Test
+    fun `buyMatch no open lottery returns 404`() {
+        every { lotteryWebService.buyMatch(guildId, discordId, any()) } returns
+            BuyMatchOutcome.NoOpenLottery
+
+        val response = controller.buyMatch(
+            guildId, BuyMatchRequest(picks = listOf(1, 2, 3, 4, 5)), user
+        )
+
+        assertEquals(404, response.statusCode.value())
+        val body = response.body!!
+        assertEquals(false, body.ok)
+    }
+
+    @Test
+    fun `buyMatch already-bought returns 400`() {
+        every { lotteryWebService.buyMatch(guildId, discordId, any()) } returns
+            BuyMatchOutcome.AlreadyBought
+
+        val response = controller.buyMatch(
+            guildId, BuyMatchRequest(picks = listOf(1, 2, 3, 4, 5)), user
+        )
+
+        assertEquals(400, response.statusCode.value())
+        val body = response.body!!
+        assertEquals(false, body.ok)
+        assertTrue(body.error!!.contains("already"))
+    }
+
+    // ---- /weighted/buy ----------------------------------------
+
+    @Test
+    fun `buyWeighted ok returns 200 with ticket count and pool`() {
+        every { lotteryWebService.buyWeighted(guildId, discordId, 3) } returns
+            BuyOutcome.Ok(
+                ticketCount = 3,
+                totalSpent = 300L,
+                newBalance = 700L,
+                newPool = 5_300L,
+            )
+
+        val response = controller.buyWeighted(guildId, BuyWeightedRequest(count = 3), user)
+
+        assertTrue(response.statusCode.is2xxSuccessful)
+        val body = response.body!!
+        assertEquals(true, body.ok)
+        assertEquals(3, body.ticketCount)
+        assertEquals(300L, body.totalSpent)
+        assertEquals(700L, body.newBalance)
+        assertEquals(5_300L, body.newPool)
+    }
+
+    @Test
+    fun `buyWeighted no open lottery returns 404`() {
+        every { lotteryWebService.buyWeighted(guildId, discordId, 1) } returns
+            BuyOutcome.NoOpenLottery
+
+        val response = controller.buyWeighted(guildId, BuyWeightedRequest(count = 1), user)
+
+        assertEquals(404, response.statusCode.value())
+        assertEquals(false, response.body!!.ok)
+    }
+
+    @Test
+    fun `buyWeighted invalid count returns 400`() {
+        every { lotteryWebService.buyWeighted(guildId, discordId, 0) } returns
+            BuyOutcome.InvalidCount(0)
+
+        val response = controller.buyWeighted(guildId, BuyWeightedRequest(count = 0), user)
+
+        assertEquals(400, response.statusCode.value())
+        assertEquals(false, response.body!!.ok)
+    }
+
+    @Test
+    fun `buyWeighted insufficient credits returns 400 with shortfall`() {
+        every { lotteryWebService.buyWeighted(guildId, discordId, 50) } returns
+            BuyOutcome.Insufficient(have = 100L, need = 5_000L)
+
+        val response = controller.buyWeighted(guildId, BuyWeightedRequest(count = 50), user)
+
+        assertEquals(400, response.statusCode.value())
+        val body = response.body!!
+        assertTrue(body.error!!.contains("100") && body.error!!.contains("5000"))
+    }
+
+    // ---- LotteryViewModel.from --------------------------------
+
+    @Test
+    fun `LotteryViewModel parses drawn numbers and computes my matches`() {
+        val open = JackpotLotteryDto(
+            id = 1L, guildId = guildId, ticketPrice = 50L, poolAmount = 1_000L,
+            status = JackpotLotteryDto.STATUS_DRAWN,
+            mode = JackpotLotteryDto.MODE_NUMBER_MATCH,
+            pickCount = 5, numberMax = 49,
+            drawnNumbers = "3,7,11,21,42",
+        )
+        val ticket = database.dto.JackpotLotteryTicketDto(
+            lotteryId = 1L, discordId = discordId, ticketCount = 1, spent = 50L,
+            pickedNumbers = "3,7,11,33,49",
+        )
+        val snap = LotteryWebService.LotteryPageSnapshot(
+            dailyOpen = null,
+            dailyLatestDrawn = open,
+            dailyMyTicket = ticket,
+            dailyTicketBuyers = 1,
+            weightedOpen = null,
+            weightedMyTicket = null,
+            weightedTopHolders = emptyList(),
+            weightedTotalTickets = 0L,
+            pickCount = 5,
+            numberMax = 49,
+            tierPercents = listOf(60, 25, 10, 5),
+            revenueJackpotPct = 30L,
+        )
+
+        val vm = LotteryViewModel.from(snap)
+        assertNotNull(vm.daily)
+        val daily = vm.daily!!
+        assertEquals(listOf(3, 7, 11, 21, 42), daily.drawnNumbers)
+        assertEquals(listOf(3, 7, 11, 33, 49), daily.myPicks)
+        assertEquals(3, daily.myMatches, "matched 3, 7, 11")
+        assertEquals(false, daily.isOpen)
+    }
+
+    @Test
+    fun `LotteryViewModel falls back gracefully when no daily exists`() {
+        val snap = LotteryWebService.LotteryPageSnapshot(
+            dailyOpen = null,
+            dailyLatestDrawn = null,
+            dailyMyTicket = null,
+            dailyTicketBuyers = 0,
+            weightedOpen = null,
+            weightedMyTicket = null,
+            weightedTopHolders = emptyList(),
+            weightedTotalTickets = 0L,
+            pickCount = 5,
+            numberMax = 49,
+            tierPercents = listOf(60, 25, 10, 5),
+            revenueJackpotPct = 30L,
+        )
+
+        val vm = LotteryViewModel.from(snap)
+        assertNull(vm.daily)
+        assertNull(vm.weighted)
+    }
+}

--- a/web/src/test/kotlin/web/service/ModerationWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/ModerationWebServiceTest.kt
@@ -43,6 +43,7 @@ class ModerationWebServiceTest {
     private lateinit var ubiDailyService: UbiDailyService
     private lateinit var jackpotService: database.service.JackpotService
     private lateinit var casinoAdminService: database.service.CasinoAdminService
+    private lateinit var jackpotLotteryService: database.service.JackpotLotteryService
     private lateinit var service: ModerationWebService
 
     private lateinit var guild: Guild
@@ -67,6 +68,7 @@ class ModerationWebServiceTest {
         ubiDailyService = mockk(relaxed = true)
         jackpotService = mockk(relaxed = true)
         casinoAdminService = mockk(relaxed = true)
+        jackpotLotteryService = mockk(relaxed = true)
         eventPublisher = mockk(relaxed = true)
         guild = mockk(relaxed = true)
         service = ModerationWebService(
@@ -80,6 +82,7 @@ class ModerationWebServiceTest {
             ubiDailyService,
             jackpotService,
             casinoAdminService,
+            jackpotLotteryService,
             eventPublisher
         )
 

--- a/web/src/test/kotlin/web/static/CasinoJackpotCssRegressionTest.kt
+++ b/web/src/test/kotlin/web/static/CasinoJackpotCssRegressionTest.kt
@@ -38,7 +38,8 @@ class CasinoJackpotCssRegressionTest {
             ".dice-result-jackpot",
             ".highlow-result-jackpot",
             ".scratch-result-jackpot",
-            ".bac-result-jackpot"
+            ".bac-result-jackpot",
+            ".lottery-result-jackpot"
         ).forEach { selector ->
             assertTrue(
                 css.contains(selector),

--- a/web/src/test/kotlin/web/static/LotteryCssRegressionTest.kt
+++ b/web/src/test/kotlin/web/static/LotteryCssRegressionTest.kt
@@ -1,0 +1,53 @@
+package web.static
+
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Presence regression for the daily lottery page styling. The picker
+ * grid relies on `.lottery-cell` + state classes (`is-picked`,
+ * `is-drawn`, `is-matched`) to communicate "you selected this", "this
+ * was drawn", and "you matched this drawn number". A future refactor
+ * that drops any of these would silently regress the visual feedback —
+ * the picker still works but stops glowing on matches, which is the
+ * whole point.
+ */
+class LotteryCssRegressionTest {
+
+    private val css: String by lazy {
+        javaClass.classLoader
+            .getResourceAsStream("static/css/lottery.css")
+            ?.bufferedReader()
+            ?.readText()
+            ?: error("lottery.css is not on the classpath")
+    }
+
+    @Test
+    fun `lottery css declares the cell base + state classes`() {
+        listOf(
+            ".lottery-cell",
+            ".lottery-cell.is-picked",
+            ".lottery-cell.is-drawn",
+            ".lottery-cell.is-matched",
+            ".lottery-cells",
+            ".lottery-result-win",
+            ".lottery-result-lose",
+        ).forEach { selector ->
+            assertTrue(
+                css.contains(selector),
+                "lottery.css must declare $selector so the picker UI's state-driven feedback survives refactors."
+            )
+        }
+    }
+
+    @Test
+    fun `lottery css imports the shared casino-table tokens`() {
+        // Without this import the page loses the shared --casino-gold,
+        // --casino-active-glow, etc. tokens and the picker stops looking
+        // like the rest of the casino games.
+        assertTrue(
+            css.contains("casino-table.css"),
+            "lottery.css must @import casino-table.css for the shared casino design tokens."
+        )
+    }
+}

--- a/web/src/test/kotlin/web/template/LotteryViewTemplateTest.kt
+++ b/web/src/test/kotlin/web/template/LotteryViewTemplateTest.kt
@@ -1,0 +1,96 @@
+package web.template
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Presence regression for the lottery page template. Asserts the page:
+ *  - reads the snapshot model attribute (no hardcoded numbers/copy)
+ *  - exposes the picker grid + every cell-state class the JS toggles
+ *  - reuses the shared jackpot banner fragment + casino-card-face cell base
+ *
+ * A refactor that accidentally drops any of these silently breaks
+ * either the buy flow or the result panel — both impossible to spot
+ * without playing through, hence this regression suite.
+ */
+class LotteryViewTemplateTest {
+
+    private val html: String by lazy {
+        val url = javaClass.classLoader.getResource("templates/lottery.html")
+        assertNotNull(url, "templates/lottery.html must be on the classpath")
+        url!!.readText()
+    }
+
+    @Test
+    fun `lottery page reads snapshot model attributes`() {
+        // Driven entirely by the LotteryViewModel snapshot — picking
+        // numbers, ticket price, pool, drawn numbers, my picks, etc.
+        // come from the server. Hardcoded copy here would silently
+        // ignore admin tuning.
+        listOf(
+            "snapshot.pickCount",
+            "snapshot.numberMax",
+            "snapshot.daily",
+            "snapshot.tierPercents",
+            "snapshot.revenueJackpotPct",
+        ).forEach { attr ->
+            assertTrue(
+                html.contains(attr),
+                "lottery.html must reference \${$attr} so admin-tuned values render dynamically."
+            )
+        }
+    }
+
+    @Test
+    fun `lottery page renders the number picker grid with pickable cells`() {
+        // The grid is server-rendered (progressive-enhancement safe) so
+        // even a JS-disabled visitor sees the cells; the JS hooks click
+        // handlers on the existing buttons.
+        assertTrue(
+            html.contains("class=\"lottery-cells\""),
+            "lottery.html must declare a .lottery-cells container for the picker"
+        )
+        assertTrue(
+            html.contains("class=\"lottery-cell casino-card-face\""),
+            "picker cells must use .lottery-cell + .casino-card-face for the shared card styling"
+        )
+        assertTrue(
+            html.contains("data-value="),
+            "picker cells must carry data-value so the JS knows which number is which"
+        )
+    }
+
+    @Test
+    fun `lottery page reuses the shared casino jackpot banner`() {
+        // The page's jackpot banner is the same one every minigame uses —
+        // a custom one would risk drifting from the rest of the casino.
+        assertTrue(
+            html.contains("fragments/casino :: jackpotBanner"),
+            "lottery.html must @{fragments/casino :: jackpotBanner} to share the casino styling"
+        )
+    }
+
+    @Test
+    fun `lottery page does not hardcode the pick count or number max`() {
+        // The text "Pick 5 of 1-49" must come from the snapshot, not be
+        // baked in — a future variant (Pick 4 of 20, etc.) shouldn't
+        // need a template edit.
+        assertFalse(
+            html.contains("Pick 5 of 1-49"),
+            "lottery.html should not hardcode 'Pick 5 of 1-49' — render snapshot.pickCount + snapshot.numberMax"
+        )
+    }
+
+    @Test
+    fun `lottery page references the daily countdown attribute`() {
+        // The closes_at countdown is driven by data-closes-at, not a
+        // server-rendered string — matters when the user keeps the page
+        // open across midnight.
+        assertTrue(
+            html.contains("data-closes-at="),
+            "lottery.html must expose data-closes-at so JS can run the countdown"
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Builds out the lottery feature shipped Discord-only in #405 into a full web UI and adds a **daily match-numbers (Pick 5 of 1-49) auto-draw** as a structural credit sink — chips away at the per-guild jackpot pool through many small daily wins instead of one big lucky roll.

After #405, jackpot is back at ~190k. This PR introduces a self-regulating drain: the daily seed pulls 5% of the pool into the prize pot each midnight UTC, and 30% of every ticket sale routes back to jackpot — so engagement keeps the system healthy while low-traffic days drain it faster.

### What's new

- **NUMBER_MATCH lottery mode** coexisting with the existing `TICKET_WEIGHTED` admin one-shot. V28 adds a `mode` column, picks/drawn-numbers columns, a `(guild_id, mode)` partial unique index so both modes can run simultaneously, and an idempotency ledger table.

- **`LotteryDailyJob`** — `@Scheduled(cron = "0 0 0 * * *", zone = "UTC")`, `@Profile("prod")`. Closes prior draw → pays tier prizes (60/25/10/5 % of pool for 5/4/3/2 matches; 0/1 sink) → opens fresh draw seeded from jackpot. Idempotent via composite-key ledger like `UbiDailyDto`.

- **`/casino/{guildId}/lottery` page** — number picker (7×7 grid, lotto-ball styling via `.casino-card-face`), prize-pool/closes-at countdown, last-result panel with `.is-matched` gold glow on matching picks, and a featured-event card when an admin-fired weighted lottery is open. Reuses `--casino-gold` / `--casino-active-glow` / `.casino-felt` tokens for visual consistency.

- **Moderation tab cards** for the four `LOTTERY_DAILY_*` configs (enabled / ticket-price / seed-% / revenue-jackpot-%) plus a **Force draw now** button for testing or missed-cron recovery.

- **4 new config keys** (`LOTTERY_DAILY_ENABLED`, `LOTTERY_DAILY_TICKET_PRICE`, `LOTTERY_DAILY_SEED_PCT`, `LOTTERY_DAILY_REVENUE_JACKPOT_PCT`) wired through both `ModerationWebService.updateConfig` and `SetConfigCommand` exhaustive whens.

### Drain math (200k pool, 5% seed, 30/70 split)

- Day seeds 10k from jackpot into prize pool
- Players buy say 50 tickets at 50 credits = 2.5k revenue → 750 to jackpot, 1.75k to pool
- Net jackpot delta = `-10k + 750 = -9.25k/day`
- 200k → 0 in ~22 days at low engagement, longer with more tickets sold (engagement equilibrium)

### Tests

- `JackpotLotteryServiceTest` extended with match-mode open/buy/draw (revenue split debits, tier distribution, empty-tier rollback, invalid picks, double-buy guard, no-tickets path).
- `LotteryDailyJobTest`: ledger short-circuit, prior-close → fresh-open ordering, NoTickets cancel, InvalidParams doesn't mark-ran (cron retries next day).
- `LotteryControllerTest`: every BuyMatch / BuyWeighted outcome's HTTP shape; `LotteryViewModel.from` match-count derivation.
- `LotteryViewTemplateTest`, `LotteryCssRegressionTest`: presence guards on snapshot bindings, picker grid, cell-state classes, shared casino-table tokens.
- Existing `CasinoJackpotCssRegressionTest` extended with `.lottery-result-jackpot`.

## Test plan

- [ ] CI: `./gradlew build`
- [ ] Manual smoke: enable daily on a test guild via moderation tab, refresh the lottery page, pick 5 numbers, buy a ticket → balance drops, prize pool grows, jackpot pool grows by 30% of cost
- [ ] Hit "Force draw now" → verify draw renders winning numbers, your picks highlight matched, payouts credit correctly
- [ ] Repeat-buy on same day rejected with "already bought a ticket for today's draw"
- [ ] Disable the daily and confirm the next 00:00 UTC cron skips the guild
- [ ] For the live 190k pool: enable, set seed 5%, ticket price 50; observe ~21-22 days drain horizon under typical engagement

https://claude.ai/code/session_019SKJtWEuw7wSpYVHg1r3oF

---
_Generated by [Claude Code](https://claude.ai/code/session_019SKJtWEuw7wSpYVHg1r3oF)_