### PR TITLE
fix(navbar): add Roulette to Casino dropdown, drop Poker from Economy

### DIFF
--- a/web/src/main/resources/templates/fragments/navbar.html
+++ b/web/src/main/resources/templates/fragments/navbar.html
@@ -23,7 +23,6 @@
                 <a href="/titles/guilds" role="menuitem">Titles</a>
                 <a href="/tip/guilds" role="menuitem">&#128184; Tip</a>
                 <a href="/duel/guilds" role="menuitem">&#9876;&#65039; Duel</a>
-                <a href="/poker/guilds" role="menuitem">&#127924; Poker</a>
             </div>
         </div>
         <div class="nav-dropdown">
@@ -39,6 +38,7 @@
                 <a href="/casino/guilds" role="menuitem">&#127183; High-Low</a>
                 <a href="/casino/guilds" role="menuitem">&#127903;&#65039; Scratch</a>
                 <a href="/casino/guilds" role="menuitem">&#127919; Keno</a>
+                <a href="/casino/guilds" role="menuitem">&#127904; Roulette</a>
                 <a href="/poker/guilds" role="menuitem">&#127924; Poker</a>
                 <a href="/blackjack/guilds" role="menuitem">&#127922; Blackjack</a>
                 <a href="/casino/guilds" role="menuitem">&#127924; Baccarat</a>


### PR DESCRIPTION
## Summary
- Add 🎡 Roulette to the navbar's **Casino** dropdown so players on any page can jump straight to it. PR #404 wired roulette into the `/casino/guilds` landing tiles but missed this dropdown, so reaching roulette took an extra hop.
- Remove Poker from the navbar's **Economy** dropdown — it was duplicated under both Economy and Casino. It stays in Casino (its natural home) and `/poker/guilds` is unchanged.

## Test plan
- [ ] Load any page and open the **Casino** dropdown — confirm 🎡 Roulette appears between Keno and Poker, click navigates to `/casino/guilds`, and from there the existing Quick play tile reaches `/casino/{guildId}/roulette`.
- [ ] Open the **Economy** dropdown — confirm only Market / Titles / 💸 Tip / ⚔️ Duel remain (no Poker).
- [ ] Confirm Poker is still listed in the Casino dropdown.

https://claude.ai/code/session_01VnFZBZ8D7dhfdtcpypnSp8

---
_Generated by [Claude Code](https://claude.ai/code/session_01VnFZBZ8D7dhfdtcpypnSp8)_