### PR TITLE
feat(lottery): WEIGHTED daily mode + polished moderation card

### DIFF
--- a/database/src/main/kotlin/database/dto/ConfigDto.kt
+++ b/database/src/main/kotlin/database/dto/ConfigDto.kt
@@ -218,7 +218,18 @@ class ConfigDto(
         // the day's prize pool. Default 30. The 30/70 split makes the
         // daily lottery a credit sink while keeping engagement-driven
         // prize growth healthy.
-        LOTTERY_DAILY_REVENUE_JACKPOT_PCT("LOTTERY_DAILY_REVENUE_JACKPOT_PCT");
+        LOTTERY_DAILY_REVENUE_JACKPOT_PCT("LOTTERY_DAILY_REVENUE_JACKPOT_PCT"),
+
+        // Which game mode the daily auto-draw uses. Two values:
+        //   "NUMBER_MATCH" — Pick 5 of 1-49 lotto-style. Best for
+        //                    high-engagement servers (≥30 tickets/day);
+        //                    relies on tier hit-rates to drain the pool.
+        //   "WEIGHTED"     — Top-3 weighted draw (50/30/20). Best for
+        //                    low-engagement servers (<30 tickets/day);
+        //                    every draw guarantees a winner, predictable
+        //                    drain regardless of ticket volume.
+        // Defaults to "NUMBER_MATCH" so existing guilds aren't disrupted.
+        LOTTERY_DAILY_MODE("LOTTERY_DAILY_MODE");
     }
 
     override fun toString(): String {

--- a/database/src/main/kotlin/database/service/LotteryHelper.kt
+++ b/database/src/main/kotlin/database/service/LotteryHelper.kt
@@ -48,6 +48,23 @@ object LotteryHelper {
     const val MAX_DAILY_REVENUE_JACKPOT_PCT: Long = 100L
 
     /**
+     * Daily-lottery game mode. NUMBER_MATCH (default) is the lotto-style
+     * Pick 5 of 49; WEIGHTED is the top-3 ticket-weighted draw better
+     * suited to low-engagement servers where match tiers can't reliably
+     * fire. Reuses the same DTO mode strings.
+     */
+    const val MODE_NUMBER_MATCH: String = "NUMBER_MATCH"
+    const val MODE_WEIGHTED: String = "WEIGHTED"
+    const val DEFAULT_DAILY_MODE: String = MODE_NUMBER_MATCH
+
+    /**
+     * For WEIGHTED daily mode: how many top winners share the pool, in
+     * 50/30/20-tier order. Hardcoded at 3 — varying this would mean a
+     * different prize-share schedule (see [JackpotLotteryService.prizeShares]).
+     */
+    const val WEIGHTED_DAILY_WINNER_COUNT: Int = 3
+
+    /**
      * Tier prize percentages for a match-numbers draw. Order: 5/5, 4/5,
      * 3/5, 2/5. Sum = 100; un-won tier shares roll back into the
      * per-guild jackpot pool via the remainder-handling in
@@ -97,5 +114,22 @@ object LotteryHelper {
         )
         val pct = cfg?.value?.toLongOrNull() ?: return DEFAULT_DAILY_REVENUE_JACKPOT_PCT
         return pct.coerceIn(0L, MAX_DAILY_REVENUE_JACKPOT_PCT)
+    }
+
+    /**
+     * Live daily-lottery game mode. Returns one of [MODE_NUMBER_MATCH]
+     * or [MODE_WEIGHTED]; falls back to [DEFAULT_DAILY_MODE] for unknown
+     * or unset values. The scheduler dispatches on this to pick the
+     * matching open/draw flow.
+     */
+    fun dailyMode(configService: ConfigService, guildId: Long): String {
+        val raw = configService.getConfigByName(
+            ConfigDto.Configurations.LOTTERY_DAILY_MODE.configValue,
+            guildId.toString()
+        )?.value?.trim()?.uppercase()
+        return when (raw) {
+            MODE_NUMBER_MATCH, MODE_WEIGHTED -> raw
+            else -> DEFAULT_DAILY_MODE
+        }
     }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/moderation/SetConfigCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/moderation/SetConfigCommand.kt
@@ -200,8 +200,34 @@ class SetConfigCommand @Autowired constructor(
                     config = ConfigDto.Configurations.LOTTERY_DAILY_REVENUE_JACKPOT_PCT,
                     gameLabel = "Daily lottery", label = "ticket revenue → jackpot percent", range = 0..100
                 )
+                ConfigDto.Configurations.LOTTERY_DAILY_MODE -> setLotteryDailyMode(
+                    event, optionMapping, deleteDelay
+                )
             }
         }
+    }
+
+    /**
+     * Validate + persist the daily-lottery mode (NUMBER_MATCH | WEIGHTED).
+     * Stored uppercase so [LotteryHelper.dailyMode] reads cleanly.
+     */
+    private fun setLotteryDailyMode(
+        event: SlashCommandInteractionEvent,
+        optionMapping: OptionMapping,
+        deleteDelay: Int,
+    ) {
+        val raw = optionMapping.asString.trim().uppercase()
+        if (raw !in setOf("NUMBER_MATCH", "WEIGHTED")) {
+            event.hook.sendMessage("Daily lottery mode must be NUMBER_MATCH or WEIGHTED.")
+                .setEphemeral(true).queue(invokeDeleteOnMessageResponse(deleteDelay))
+            return
+        }
+        val guildId = event.guild?.id ?: return
+        configService.upsertConfig(
+            ConfigDto.Configurations.LOTTERY_DAILY_MODE.configValue, raw, guildId
+        )
+        event.hook.sendMessage("Daily lottery mode set to $raw.")
+            .queue(invokeDeleteOnMessageResponse(deleteDelay))
     }
 
     /**

--- a/discord-bot/src/main/kotlin/bot/toby/scheduling/LotteryDailyJob.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/scheduling/LotteryDailyJob.kt
@@ -17,24 +17,28 @@ import java.time.LocalDate
 import java.time.ZoneOffset
 
 /**
- * Daily match-numbers (Pick 5 of 1-49) lottery auto-draw.
+ * Daily lottery auto-draw. Runs at 00:00 UTC.
  *
- * Runs at 00:00 UTC. For each guild with `LOTTERY_DAILY_ENABLED=true`:
- *   1. Close yesterday's draw if still OPEN — runs the prize tier
- *      payouts via [JackpotLotteryService.drawMatchLottery]. If no
- *      one bought, cancels and refunds the seed via
- *      [JackpotLotteryService.cancelMatchLottery] so credits don't
- *      strand on a no-tickets row.
- *   2. Open today's draw via [JackpotLotteryService.openMatchLottery],
- *      seeding `LOTTERY_DAILY_SEED_PCT` of the per-guild jackpot pool
- *      (default 5%) into the prize pool. Ticket price comes from
- *      `LOTTERY_DAILY_TICKET_PRICE` (default 50).
- *   3. Mark the day done in [LotteryDailyService] so a mid-cron
- *      restart skips this guild on the next tick.
+ * For each guild with `LOTTERY_DAILY_ENABLED=true`, dispatches on
+ * `LOTTERY_DAILY_MODE`:
  *
- * Mirrors [UniversalBasicIncomeJob]: idempotent via composite-key
- * ledger, per-guild error isolation via runCatching, prod-profile only
- * (test profile uses manual force-draw via the moderation web tab).
+ *   - **NUMBER_MATCH** (default): Pick 5 of 1-49. Closes yesterday's
+ *     draw via [JackpotLotteryService.drawMatchLottery] (or cancels if
+ *     no tickets), opens a fresh one via
+ *     [JackpotLotteryService.openMatchLottery]. Best for high-volume
+ *     servers — match tiers (5/4/3/2 → 60/25/10/5%) need many tickets
+ *     per draw to hit reliably.
+ *
+ *   - **WEIGHTED**: top-3 weighted draw, 50/30/20 % of pool. Closes
+ *     yesterday's draw via [JackpotLotteryService.drawLottery] (or
+ *     cancels if no tickets), opens a fresh one via
+ *     [JackpotLotteryService.openLottery] with `winnerCount=3`. Best
+ *     for low-volume servers — a winner is guaranteed every draw
+ *     regardless of ticket count, so the pool drains predictably.
+ *
+ * Idempotent via composite-key ledger ([LotteryDailyService]) — a
+ * mid-cron restart skips guilds whose ledger already records today.
+ * Per-guild error isolation via `runCatching`. Prod-profile only.
  */
 @Component
 @Profile("prod")
@@ -77,56 +81,129 @@ class LotteryDailyJob @Autowired constructor(
             return
         }
 
-        // Close yesterday's draw if still open.
+        val mode = LotteryHelper.dailyMode(configService, guildId)
+        val opened = when (mode) {
+            LotteryHelper.MODE_WEIGHTED -> rollWeighted(guildId)
+            else -> rollNumberMatch(guildId)  // MODE_NUMBER_MATCH (default)
+        }
+
+        if (opened) {
+            lotteryDailyService.markRan(guildId, today)
+        }
+        // If `opened` is false the open call returned InvalidParams —
+        // don't mark ran so the next cron tick retries once admin
+        // fixes the offending config.
+    }
+
+    /**
+     * NUMBER_MATCH cycle: close (or cancel) yesterday's match lottery,
+     * open a fresh one. Returns true if the open call succeeded (or
+     * AlreadyOpen — race with another worker is treated as success).
+     */
+    private fun rollNumberMatch(guildId: Long): Boolean {
         val openMatch = jackpotLotteryService.getOpenMatch(guildId)
         if (openMatch?.status == JackpotLotteryDto.STATUS_OPEN) {
             when (val drawResult = jackpotLotteryService.drawMatchLottery(guildId)) {
-                is JackpotLotteryService.DrawMatchOutcome.Ok -> {
+                is JackpotLotteryService.DrawMatchOutcome.Ok ->
                     logger.info {
-                        "Daily lottery drew for guild $guildId: drawn=${drawResult.drawnNumbers} " +
+                        "Daily NUMBER_MATCH drew for guild $guildId: drawn=${drawResult.drawnNumbers} " +
                             "totalPaid=${drawResult.totalPaid} rolledBack=${drawResult.rolledBackToJackpot}"
                     }
-                }
                 JackpotLotteryService.DrawMatchOutcome.NoTickets -> {
-                    logger.info { "Daily lottery for guild $guildId had no tickets; cancelling and refunding seed." }
+                    logger.info { "Daily NUMBER_MATCH for guild $guildId had no tickets; cancelling and refunding seed." }
                     jackpotLotteryService.cancelMatchLottery(guildId)
                 }
-                JackpotLotteryService.DrawMatchOutcome.NoOpenLottery -> {
-                    // Race with another worker — fine, just continue.
-                }
+                JackpotLotteryService.DrawMatchOutcome.NoOpenLottery -> Unit
             }
         }
 
-        // Open today's draw.
         val ticketPrice = LotteryHelper.dailyTicketPrice(configService, guildId)
         val seedPct = LotteryHelper.dailySeedPct(configService, guildId)
-        when (val open = jackpotLotteryService.openMatchLottery(
-            guildId = guildId,
-            ticketPrice = ticketPrice,
-            seedPct = seedPct,
-            durationHours = DURATION_HOURS,
+        return when (val open = jackpotLotteryService.openMatchLottery(
+            guildId = guildId, ticketPrice = ticketPrice,
+            seedPct = seedPct, durationHours = DURATION_HOURS,
         )) {
             is JackpotLotteryService.OpenOutcome.Ok -> {
                 logger.info {
-                    "Daily lottery opened for guild $guildId: ticketPrice=$ticketPrice " +
+                    "Daily NUMBER_MATCH opened for guild $guildId: ticketPrice=$ticketPrice " +
                         "seeded=${open.seeded} seedPct=$seedPct"
                 }
+                true
             }
             JackpotLotteryService.OpenOutcome.AlreadyOpen -> {
-                logger.warn { "Daily lottery for guild $guildId is already open; skipping reopen." }
+                logger.warn { "Daily NUMBER_MATCH for guild $guildId is already open; skipping reopen." }
+                true
             }
             JackpotLotteryService.OpenOutcome.EmptyPool -> {
-                // Defensive — openMatchLottery accepts empty pools, so this
-                // shouldn't fire. Log if it does and move on.
-                logger.warn { "Daily lottery for guild $guildId reported EmptyPool unexpectedly." }
+                logger.warn { "Daily NUMBER_MATCH for guild $guildId reported EmptyPool unexpectedly." }
+                true
             }
             is JackpotLotteryService.OpenOutcome.InvalidParams -> {
-                logger.warn { "Daily lottery for guild $guildId rejected params: ${open.reason}" }
-                return  // Don't mark as run so admin can fix config and retry.
+                logger.warn { "Daily NUMBER_MATCH for guild $guildId rejected params: ${open.reason}" }
+                false
+            }
+        }
+    }
+
+    /**
+     * WEIGHTED cycle: close (or cancel) yesterday's weighted lottery,
+     * open a fresh one. Top 3 of N tickets share the pool 50/30/20 —
+     * always pays out at any ticket volume, so this is the right mode
+     * for low-engagement servers.
+     */
+    private fun rollWeighted(guildId: Long): Boolean {
+        val openWeighted = jackpotLotteryService.getOpenWeighted(guildId)
+        if (openWeighted?.status == JackpotLotteryDto.STATUS_OPEN) {
+            when (val drawResult = jackpotLotteryService.drawLottery(guildId)) {
+                is JackpotLotteryService.DrawOutcome.Ok ->
+                    logger.info {
+                        "Daily WEIGHTED drew for guild $guildId: " +
+                            "totalPaid=${drawResult.totalPaid} drained=${drawResult.drained}"
+                    }
+                JackpotLotteryService.DrawOutcome.NoTickets -> {
+                    logger.info { "Daily WEIGHTED for guild $guildId had no tickets; cancelling and refunding seed." }
+                    jackpotLotteryService.cancelLottery(guildId)
+                }
+                JackpotLotteryService.DrawOutcome.NoOpenLottery -> Unit
             }
         }
 
-        lotteryDailyService.markRan(guildId, today)
+        val ticketPrice = LotteryHelper.dailyTicketPrice(configService, guildId)
+        val seedPct = LotteryHelper.dailySeedPct(configService, guildId)
+        val drainPct = (seedPct.toDouble() / 100.0).coerceIn(0.0, 1.0)
+        return when (val open = jackpotLotteryService.openLottery(
+            guildId = guildId,
+            ticketPrice = ticketPrice,
+            durationHours = DURATION_HOURS,
+            winnerCount = LotteryHelper.WEIGHTED_DAILY_WINNER_COUNT,
+            drainPct = drainPct,
+        )) {
+            is JackpotLotteryService.OpenOutcome.Ok -> {
+                logger.info {
+                    "Daily WEIGHTED opened for guild $guildId: ticketPrice=$ticketPrice " +
+                        "seeded=${open.seeded} seedPct=$seedPct winners=${LotteryHelper.WEIGHTED_DAILY_WINNER_COUNT}"
+                }
+                true
+            }
+            JackpotLotteryService.OpenOutcome.AlreadyOpen -> {
+                logger.warn { "Daily WEIGHTED for guild $guildId is already open; skipping reopen." }
+                true
+            }
+            JackpotLotteryService.OpenOutcome.EmptyPool -> {
+                logger.info {
+                    "Daily WEIGHTED for guild $guildId skipped — jackpot empty. " +
+                        "Admin must seed the pool before the next cycle can open."
+                }
+                // Mark as ran anyway so we don't spam the log; tomorrow
+                // will retry. If the admin wants an immediate retry they
+                // can use the moderation tab's force-draw button.
+                true
+            }
+            is JackpotLotteryService.OpenOutcome.InvalidParams -> {
+                logger.warn { "Daily WEIGHTED for guild $guildId rejected params: ${open.reason}" }
+                false
+            }
+        }
     }
 
     companion object {

--- a/discord-bot/src/test/kotlin/bot/toby/scheduling/LotteryDailyJobTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/scheduling/LotteryDailyJobTest.kt
@@ -61,6 +61,19 @@ class LotteryDailyJobTest {
         } returns dto
     }
 
+    private fun stubMode(mode: String) {
+        every {
+            configService.getConfigByName(
+                ConfigDto.Configurations.LOTTERY_DAILY_MODE.configValue,
+                guildId.toString(),
+            )
+        } returns ConfigDto(
+            name = ConfigDto.Configurations.LOTTERY_DAILY_MODE.configValue,
+            value = mode,
+            guildId = guildId.toString(),
+        )
+    }
+
     @Test
     fun `runDaily skips guilds with daily lottery disabled`() {
         stubEnabled(false)
@@ -169,5 +182,93 @@ class LotteryDailyJobTest {
         // markRan is skipped so the next daily tick can retry once the
         // admin fixes the offending config.
         verify(exactly = 0) { lotteryDailyService.markRan(any(), any()) }
+    }
+
+    // ---- WEIGHTED-mode dispatch ----
+
+    @Test
+    fun `runDaily in WEIGHTED mode closes prior weighted draw and opens a fresh one`() {
+        stubEnabled(true)
+        stubMode("WEIGHTED")
+        every { lotteryDailyService.alreadyRan(guildId, today) } returns false
+        every { jackpotLotteryService.getOpenWeighted(guildId) } returns JackpotLotteryDto(
+            id = 5L, guildId = guildId,
+            status = JackpotLotteryDto.STATUS_OPEN,
+            mode = JackpotLotteryDto.MODE_TICKET_WEIGHTED,
+        )
+        every { jackpotLotteryService.drawLottery(guildId) } returns
+            JackpotLotteryService.DrawOutcome.Ok(
+                payouts = emptyList(), totalPaid = 1_000L, drained = 1_000L,
+            )
+        every { jackpotLotteryService.openLottery(guildId, any(), any(), any(), any()) } returns
+            JackpotLotteryService.OpenOutcome.Ok(
+                lottery = JackpotLotteryDto(id = 6L, guildId = guildId),
+                seeded = 5_000L,
+            )
+
+        job.runDaily()
+
+        // Weighted-path methods called, NOT match-path.
+        verify(exactly = 1) { jackpotLotteryService.drawLottery(guildId) }
+        verify(exactly = 1) { jackpotLotteryService.openLottery(guildId, any(), 24L, 3, any()) }
+        verify(exactly = 0) { jackpotLotteryService.drawMatchLottery(any()) }
+        verify(exactly = 0) { jackpotLotteryService.openMatchLottery(any(), any(), any(), any()) }
+        verify(exactly = 1) { lotteryDailyService.markRan(guildId, today) }
+    }
+
+    @Test
+    fun `runDaily in WEIGHTED mode treats EmptyPool as a soft skip and marks ran`() {
+        stubEnabled(true)
+        stubMode("WEIGHTED")
+        every { lotteryDailyService.alreadyRan(guildId, today) } returns false
+        every { jackpotLotteryService.getOpenWeighted(guildId) } returns null
+        every { jackpotLotteryService.openLottery(guildId, any(), any(), any(), any()) } returns
+            JackpotLotteryService.OpenOutcome.EmptyPool
+
+        job.runDaily()
+
+        // No spin-loop on every cron tick; admin must seed the pool.
+        verify(exactly = 1) { lotteryDailyService.markRan(guildId, today) }
+    }
+
+    @Test
+    fun `runDaily in WEIGHTED mode cancels prior draw if no tickets`() {
+        stubEnabled(true)
+        stubMode("WEIGHTED")
+        every { lotteryDailyService.alreadyRan(guildId, today) } returns false
+        every { jackpotLotteryService.getOpenWeighted(guildId) } returns JackpotLotteryDto(
+            id = 5L, guildId = guildId,
+            status = JackpotLotteryDto.STATUS_OPEN,
+            mode = JackpotLotteryDto.MODE_TICKET_WEIGHTED,
+        )
+        every { jackpotLotteryService.drawLottery(guildId) } returns
+            JackpotLotteryService.DrawOutcome.NoTickets
+        every { jackpotLotteryService.openLottery(guildId, any(), any(), any(), any()) } returns
+            JackpotLotteryService.OpenOutcome.Ok(
+                lottery = JackpotLotteryDto(id = 6L, guildId = guildId),
+                seeded = 1_000L,
+            )
+
+        job.runDaily()
+
+        verify(exactly = 1) { jackpotLotteryService.cancelLottery(guildId) }
+        verify(exactly = 1) { jackpotLotteryService.openLottery(guildId, any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `runDaily defaults to NUMBER_MATCH when mode config is missing or unknown`() {
+        stubEnabled(true)
+        // No mode stub — defaults to NUMBER_MATCH per LotteryHelper.dailyMode.
+        every { lotteryDailyService.alreadyRan(guildId, today) } returns false
+        every { jackpotLotteryService.getOpenMatch(guildId) } returns null
+        every { jackpotLotteryService.openMatchLottery(guildId, any(), any(), any()) } returns
+            JackpotLotteryService.OpenOutcome.Ok(
+                lottery = JackpotLotteryDto(id = 1L, guildId = guildId), seeded = 0L,
+            )
+
+        job.runDaily()
+
+        verify(exactly = 1) { jackpotLotteryService.openMatchLottery(guildId, any(), any(), any()) }
+        verify(exactly = 0) { jackpotLotteryService.openLottery(any(), any(), any(), any(), any()) }
     }
 }

--- a/web/src/main/kotlin/web/service/ModerationWebService.kt
+++ b/web/src/main/kotlin/web/service/ModerationWebService.kt
@@ -335,35 +335,59 @@ class ModerationWebService(
                 priorDrawn = emptyList(), openedNew = false, newSeeded = 0L,
             )
         }
-        // Step 1: close open daily if present.
+        val mode = LotteryHelper.dailyMode(configService, guildId)
+        // Step 1: close open daily if present (mode-dispatched).
         var drewPrior = false
         var priorTotalPaid = 0L
         var priorRolledBack = 0L
         var priorDrawn: List<Int> = emptyList()
-        when (val drawResult = jackpotLotteryService.drawMatchLottery(guildId)) {
-            is JackpotLotteryService.DrawMatchOutcome.Ok -> {
-                drewPrior = true
-                priorTotalPaid = drawResult.totalPaid
-                priorRolledBack = drawResult.rolledBackToJackpot
-                priorDrawn = drawResult.drawnNumbers
+        if (mode == LotteryHelper.MODE_WEIGHTED) {
+            when (val drawResult = jackpotLotteryService.drawLottery(guildId)) {
+                is JackpotLotteryService.DrawOutcome.Ok -> {
+                    drewPrior = true
+                    priorTotalPaid = drawResult.totalPaid
+                    priorRolledBack = (drawResult.drained - drawResult.totalPaid).coerceAtLeast(0L)
+                }
+                JackpotLotteryService.DrawOutcome.NoTickets -> {
+                    jackpotLotteryService.cancelLottery(guildId)
+                    drewPrior = true
+                }
+                JackpotLotteryService.DrawOutcome.NoOpenLottery -> Unit
             }
-            JackpotLotteryService.DrawMatchOutcome.NoTickets -> {
-                jackpotLotteryService.cancelMatchLottery(guildId)
-                drewPrior = true
-            }
-            JackpotLotteryService.DrawMatchOutcome.NoOpenLottery -> {
-                // No-op; nothing to close.
+        } else {
+            when (val drawResult = jackpotLotteryService.drawMatchLottery(guildId)) {
+                is JackpotLotteryService.DrawMatchOutcome.Ok -> {
+                    drewPrior = true
+                    priorTotalPaid = drawResult.totalPaid
+                    priorRolledBack = drawResult.rolledBackToJackpot
+                    priorDrawn = drawResult.drawnNumbers
+                }
+                JackpotLotteryService.DrawMatchOutcome.NoTickets -> {
+                    jackpotLotteryService.cancelMatchLottery(guildId)
+                    drewPrior = true
+                }
+                JackpotLotteryService.DrawMatchOutcome.NoOpenLottery -> Unit
             }
         }
-        // Step 2: open fresh daily.
+        // Step 2: open fresh daily (mode-dispatched).
         val ticketPrice = LotteryHelper.dailyTicketPrice(configService, guildId)
         val seedPct = LotteryHelper.dailySeedPct(configService, guildId)
-        val open = jackpotLotteryService.openMatchLottery(
-            guildId = guildId,
-            ticketPrice = ticketPrice,
-            seedPct = seedPct,
-            durationHours = 24L,
-        )
+        val open = if (mode == LotteryHelper.MODE_WEIGHTED) {
+            jackpotLotteryService.openLottery(
+                guildId = guildId,
+                ticketPrice = ticketPrice,
+                durationHours = 24L,
+                winnerCount = LotteryHelper.WEIGHTED_DAILY_WINNER_COUNT,
+                drainPct = (seedPct.toDouble() / 100.0).coerceIn(0.0, 1.0),
+            )
+        } else {
+            jackpotLotteryService.openMatchLottery(
+                guildId = guildId,
+                ticketPrice = ticketPrice,
+                seedPct = seedPct,
+                durationHours = 24L,
+            )
+        }
         return when (open) {
             is JackpotLotteryService.OpenOutcome.Ok -> {
                 logger.info(
@@ -636,6 +660,13 @@ class ModerationWebService(
                     ?: return "Value must be a whole number percentage (0-100; default 30)."
                 if (n !in 0..100) return "Value must be between 0 and 100."
                 n.toString()
+            }
+            ConfigDto.Configurations.LOTTERY_DAILY_MODE -> {
+                val v = rawValue.trim().uppercase()
+                if (v !in setOf("NUMBER_MATCH", "WEIGHTED")) {
+                    return "Value must be NUMBER_MATCH or WEIGHTED."
+                }
+                v
             }
         }
 

--- a/web/src/main/resources/static/css/moderation.css
+++ b/web/src/main/resources/static/css/moderation.css
@@ -440,3 +440,80 @@
     .mod-table td[data-label="Member"] { display: block; }
     .mod-table td[data-label="Member"]::before { display: none; }
 }
+
+/* ==============================================================
+   Daily lottery admin card — sits inside the casino tab, replaces
+   the previous flat stack of unsavable rows with a card laid out
+   in three blocks: header (title + description), two collapsible
+   `<details>` sections for Toggle/Mode and Prize parameters, and
+   a footer action area for "Force draw now". Reuses .config-grid
+   / .config-row / .config-section so the rows match the rest of
+   the moderation tab.
+   ============================================================== */
+
+.lottery-admin-card {
+    /* Override .mod-card-wide's 560px cap so the prize-parameters
+       grid + force-draw banner can breathe on wider screens. */
+    max-width: 720px;
+}
+
+.lottery-admin-header {
+    margin-bottom: var(--space-4);
+    padding-bottom: var(--space-3);
+    border-bottom: 1px solid var(--border);
+}
+.lottery-admin-header h3 {
+    margin: 0 0 var(--space-2);
+}
+.lottery-admin-header p {
+    margin: 0;
+    max-width: 60ch;
+    font-size: 0.92rem;
+    line-height: 1.5;
+}
+
+/* Optional inline hint inside a config-row label — small italic
+   secondary text that explains the field without blowing up the
+   label height. */
+.config-row label .config-hint {
+    display: block;
+    margin-top: 3px;
+    font-size: 0.78rem;
+    line-height: 1.4;
+    color: var(--text-dim);
+    font-weight: 400;
+    font-style: italic;
+}
+
+/* Force-draw footer banner — separates the dangerous-ish action
+   (mutates jackpot pool + any open draw) from the read-mostly
+   parameter rows. Text-on-left, button-on-right responsive flex. */
+.lottery-admin-actions {
+    margin-top: var(--space-4);
+    padding: var(--space-3) var(--space-4);
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    display: flex;
+    gap: var(--space-4);
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+}
+.lottery-admin-actions-text {
+    flex: 1 1 320px;
+    min-width: 240px;
+}
+.lottery-admin-actions-text strong {
+    display: block;
+    font-size: 0.95rem;
+    margin-bottom: 4px;
+}
+.lottery-admin-actions-text p {
+    margin: 0;
+    font-size: 0.85rem;
+    line-height: 1.4;
+}
+.lottery-admin-actions .btn {
+    flex: 0 0 auto;
+}

--- a/web/src/main/resources/templates/moderation.html
+++ b/web/src/main/resources/templates/moderation.html
@@ -847,61 +847,112 @@
             </form>
         </div>
 
-        <!-- Daily lottery: opt-in toggle + parameters + force draw -->
-        <div class="mod-card mod-card-wide">
-            <h3>Daily match-numbers lottery (Pick 5 of 1-49)</h3>
-            <p class="muted">
-                Auto-runs at 00:00 UTC. Closes the prior day's draw (paying tier prizes by
-                match count: 60/25/10/5 % of pool for 5/4/3/2 matches), then opens a new
-                day seeded from the jackpot pool. Each ticket sale routes a configurable
-                share back to the jackpot — the daily is a credit sink that drains the
-                pool steadily through many small wins instead of one big lucky roll.
-            </p>
-            <div class="config-row" data-key="LOTTERY_DAILY_ENABLED">
-                <label>
-                    Enable daily lottery
-                    <select name="LOTTERY_DAILY_ENABLED" data-key="LOTTERY_DAILY_ENABLED">
-                        <option value="true"
-                                th:selected="${overview.config['LOTTERY_DAILY_ENABLED'] == 'true'}">Enabled</option>
-                        <option value="false"
-                                th:selected="${overview.config['LOTTERY_DAILY_ENABLED'] != 'true'}">Disabled</option>
-                    </select>
-                </label>
+        <!--
+            Daily lottery: opt-in toggle + game mode + per-day parameters + force draw.
+
+            Each row uses the canonical .config-row pattern (label / input
+            or select / Save button) so moderation.js's existing handler
+            picks them up automatically. Without the Save button the row
+            is read-only and the admin can't actually persist anything.
+        -->
+        <div class="mod-card mod-card-wide lottery-admin-card">
+            <header class="lottery-admin-header">
+                <h3>Daily lottery</h3>
+                <p class="muted">
+                    Auto-runs at 00:00 UTC: closes the prior day's draw, pays prizes, opens a
+                    fresh one seeded from the jackpot pool. Doubles as a credit sink — a
+                    configurable slice of every ticket sale routes back to the jackpot,
+                    chipping the pool down through many small wins.
+                </p>
+            </header>
+
+            <details class="config-section" open>
+                <summary>Toggle &amp; mode</summary>
+                <div class="config-grid">
+                    <div class="config-row" data-key="LOTTERY_DAILY_ENABLED">
+                        <label>Enable daily lottery</label>
+                        <select th:disabled="${!isOwner}">
+                            <option value="false"
+                                    th:selected="${overview.config['LOTTERY_DAILY_ENABLED'] == null or overview.config['LOTTERY_DAILY_ENABLED'] != 'true'}">
+                                Disabled
+                            </option>
+                            <option value="true"
+                                    th:selected="${overview.config['LOTTERY_DAILY_ENABLED'] == 'true'}">
+                                Enabled
+                            </option>
+                        </select>
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
+                    <div class="config-row" data-key="LOTTERY_DAILY_MODE">
+                        <label>
+                            Game mode
+                            <span class="config-hint">
+                                NUMBER_MATCH for high-traffic servers (≥30 tickets/day);
+                                WEIGHTED guarantees a winner every draw — best for &lt;30 active users.
+                            </span>
+                        </label>
+                        <select th:disabled="${!isOwner}">
+                            <option value="NUMBER_MATCH"
+                                    th:selected="${overview.config['LOTTERY_DAILY_MODE'] == null or overview.config['LOTTERY_DAILY_MODE'] != 'WEIGHTED'}">
+                                Pick 5 of 49
+                            </option>
+                            <option value="WEIGHTED"
+                                    th:selected="${overview.config['LOTTERY_DAILY_MODE'] == 'WEIGHTED'}">
+                                Top-3 weighted draw
+                            </option>
+                        </select>
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
+                </div>
+            </details>
+
+            <details class="config-section" open>
+                <summary>Daily prize parameters</summary>
+                <div class="config-grid">
+                    <div class="config-row" data-key="LOTTERY_DAILY_TICKET_PRICE">
+                        <label>Ticket price (credits per ticket; default 50)</label>
+                        <input type="number" min="1" max="1000000"
+                               th:value="${overview.config['LOTTERY_DAILY_TICKET_PRICE']}"
+                               placeholder="50"
+                               th:disabled="${!isOwner}">
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
+                    <div class="config-row" data-key="LOTTERY_DAILY_SEED_PCT">
+                        <label>Daily seed (% of jackpot pool pulled into prize pool at 00:00 UTC; default 5)</label>
+                        <span class="config-input-group">
+                            <input type="number" min="1" max="100"
+                                   th:value="${overview.config['LOTTERY_DAILY_SEED_PCT']}"
+                                   placeholder="5"
+                                   th:disabled="${!isOwner}">
+                            <span class="config-suffix">%</span>
+                        </span>
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
+                    <div class="config-row" data-key="LOTTERY_DAILY_REVENUE_JACKPOT_PCT">
+                        <label>Ticket revenue → jackpot (% of every sale routed back to pool; default 30)</label>
+                        <span class="config-input-group">
+                            <input type="number" min="0" max="100"
+                                   th:value="${overview.config['LOTTERY_DAILY_REVENUE_JACKPOT_PCT']}"
+                                   placeholder="30"
+                                   th:disabled="${!isOwner}">
+                            <span class="config-suffix">%</span>
+                        </span>
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
+                </div>
+            </details>
+
+            <div class="lottery-admin-actions">
+                <div class="lottery-admin-actions-text">
+                    <strong>Force draw now</strong>
+                    <p class="muted">
+                        Closes any open draw, pays prizes, opens a fresh one — useful for
+                        testing or recovering from a missed cron.
+                    </p>
+                </div>
+                <button id="lottery-force-draw" type="button" class="btn"
+                        th:disabled="${!isOwner}">Force draw now</button>
             </div>
-            <div class="config-row" data-key="LOTTERY_DAILY_TICKET_PRICE">
-                <label>
-                    Ticket price (credits)
-                    <input type="number" name="LOTTERY_DAILY_TICKET_PRICE"
-                           th:value="${overview.config['LOTTERY_DAILY_TICKET_PRICE']}"
-                           min="1" max="1000000" placeholder="50 (default)">
-                </label>
-            </div>
-            <div class="config-row" data-key="LOTTERY_DAILY_SEED_PCT">
-                <label>
-                    Daily seed (% of jackpot pool)
-                    <span class="config-input-group">
-                        <input type="number" name="LOTTERY_DAILY_SEED_PCT"
-                               th:value="${overview.config['LOTTERY_DAILY_SEED_PCT']}"
-                               min="1" max="100" placeholder="5 (default)">
-                        <span class="config-suffix">%</span>
-                    </span>
-                </label>
-            </div>
-            <div class="config-row" data-key="LOTTERY_DAILY_REVENUE_JACKPOT_PCT">
-                <label>
-                    Ticket revenue → jackpot
-                    <span class="config-input-group">
-                        <input type="number" name="LOTTERY_DAILY_REVENUE_JACKPOT_PCT"
-                               th:value="${overview.config['LOTTERY_DAILY_REVENUE_JACKPOT_PCT']}"
-                               min="0" max="100" placeholder="30 (default)">
-                        <span class="config-suffix">%</span>
-                    </span>
-                </label>
-            </div>
-            <p class="muted">
-                Force the cycle to run now (close any open draw, pay prizes, open the next):
-            </p>
-            <button id="lottery-force-draw" type="button" class="btn">Force draw now</button>
         </div>
     </section>
 </main>


### PR DESCRIPTION
## Summary

Two follow-ups to #412 — addressing the math problem at low-traffic servers and the dishevelled moderation card.

### 1. `LOTTERY_DAILY_MODE` — pick the right game for your server

The existing daily lottery was hard-coded to NUMBER_MATCH (Pick 5 of 49). With 6 active users that doesn't drain the pool — match-tier hit rates are too low, so unwon tier shares (60% + 25% = 85% of pool) keep rolling back to jackpot. Net delta ≈ 0/day; the lottery just cycles credits without actually draining.

This adds a per-guild `LOTTERY_DAILY_MODE` config:

- **`NUMBER_MATCH`** (default): existing Pick 5 of 49. Tier-based payouts (60/25/10/5 % of pool for 5/4/3/2 matches). Needs ≥30 tickets/day to hit reliably.
- **`WEIGHTED`**: top-3 ticket-weighted draw, 50/30/20 split. Every draw pays out regardless of ticket count. Right tool for servers with <30 active users.

`LotteryDailyJob.rollGuild` now dispatches on the mode. WEIGHTED path closes via `drawLottery`/`cancelLottery` and opens via `openLottery` with `winnerCount=3`. `ModerationWebService.forceDailyDraw` does the same. Default unchanged → existing guilds aren't disrupted.

### 2. Polished moderation lottery card

The previous card had two real bugs and one cosmetic one:

- **Bug**: each `<select>`/`<input>` row was missing the canonical `<button class="save-config">`, so admins couldn't persist anything from the UI. Rebuilt every row with the standard config-row pattern.
- **Bug**: rows ignored `th:disabled="${!isOwner}"`, so non-owners saw the form as editable.
- **Cosmetic**: flat stack of rows was hard to scan. Now grouped into two collapsible `<details>` sections (Toggle/Mode and Daily prize parameters) with a footer "Force draw now" banner that has a description next to the button.

Wider max-width (720px) so the prize-parameter labels don't wrap awkwardly. Inline `.config-hint` italic secondary text under the mode dropdown explains when to pick which.

## Test plan

- [ ] CI: `./gradlew build`
- [ ] Manual: open the moderation tab → casino sub-section → verify the lottery card now shows two collapsible sections + a footer action; edit each value and click Save → toast confirms persistence
- [ ] Set `LOTTERY_DAILY_MODE=WEIGHTED` for a small test guild, fire force-draw, confirm a TICKET_WEIGHTED row gets opened with `winnerCount=3` and a top-3 split happens after tickets are bought
- [ ] Set back to `NUMBER_MATCH`, force-draw, confirm a NUMBER_MATCH row opens with `pickCount=5`/`numberMax=49`
- [ ] For the live 6-user server with the 190k pool: `LOTTERY_DAILY_MODE=WEIGHTED`, `LOTTERY_DAILY_TICKET_PRICE=50`, `LOTTERY_DAILY_SEED_PCT=5`. Force-draw to seed 9.5k into the prize pool, then let users buy. Each daily cycle drains ~9k via the top-3 split.

https://claude.ai/code/session_019SKJtWEuw7wSpYVHg1r3oF

---
_Generated by [Claude Code](https://claude.ai/code/session_019SKJtWEuw7wSpYVHg1r3oF)_