### PR TITLE
fix(roulette web): emoji parity, fieldset shape, mid-spin lock, bet explainer

### DIFF
--- a/web/src/main/kotlin/web/controller/RouletteController.kt
+++ b/web/src/main/kotlin/web/controller/RouletteController.kt
@@ -143,10 +143,21 @@ class RouletteController(
         )
     }
 
+    // Player-facing bet menu explainer. Lives next to the controller (vs.
+    // hard-coded in the template) so a future bet-type addition only edits
+    // one place. The "covers" copy is intentionally plain English — first-
+    // time players shouldn't have to know roulette parlance.
     private fun payoutRows(): List<RoulettePayoutRow> = listOf(
-        RoulettePayoutRow("Red / Black / Odd / Even / Low / High", "1:1"),
-        RoulettePayoutRow("Dozen / Column", "2:1"),
-        RoulettePayoutRow("Straight (single number)", "35:1"),
+        RoulettePayoutRow("Red / Black", "The 18 red or 18 black pockets. Zero loses.", "1:1"),
+        RoulettePayoutRow("Odd / Even", "Odd or even between 1 and 36. Zero loses.", "1:1"),
+        RoulettePayoutRow("Low / High", "1–18 or 19–36. Zero loses.", "1:1"),
+        RoulettePayoutRow("Dozens", "1st 12, 2nd 12, or 3rd 12 — twelve numbers each.", "2:1"),
+        RoulettePayoutRow(
+            "Columns",
+            "Column 1: 1·4·7… / Column 2: 2·5·8… / Column 3: 3·6·9… — twelve numbers each.",
+            "2:1",
+        ),
+        RoulettePayoutRow("Straight", "A single number you pick (0–36).", "35:1"),
     )
 }
 
@@ -184,4 +195,4 @@ data class RouletteBetRow(
     val requiresNumber: Boolean,
 )
 
-data class RoulettePayoutRow(val label: String, val payout: String)
+data class RoulettePayoutRow(val label: String, val covers: String, val payout: String)

--- a/web/src/main/resources/static/css/roulette.css
+++ b/web/src/main/resources/static/css/roulette.css
@@ -138,13 +138,24 @@
     border-radius: 12px;
     padding: var(--space-3);
     background: rgba(0, 0, 0, 0.18);
+    /* Browsers add a user-agent margin (~2px each side) and force
+       min-inline-size: -webkit-min-content on a fieldset, which can
+       overflow the felt on small screens. Reset both so the card
+       fills its column cleanly. */
+    margin: 0;
+    min-inline-size: auto;
 }
 .roulette-bet-fieldset legend {
     color: var(--text-muted);
     text-transform: uppercase;
     font-size: 0.75rem;
     letter-spacing: 0.08em;
+    /* Reset the user-agent legend padding/margin so the "BET" label
+       sits cleanly on the top border instead of inheriting the
+       browser's asymmetric inline padding. Mirrors the pattern in
+       baccarat.css `.bac-side-picker legend`. */
     padding: 0 var(--space-2);
+    margin: 0 0 var(--space-2);
 }
 
 .roulette-bet-grid {
@@ -177,6 +188,19 @@
     border-color: var(--casino-gold);
     color: #1a1a1a;
     box-shadow: var(--casino-active-glow);
+}
+/* Disabled state used while the wheel is spinning so a player can't
+   re-pick a bet mid-animation. The hover/transform overrides keep the
+   chip looking flat (rather than lifting on hover) so the locked
+   affordance is unmistakable. */
+.roulette-chip:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+    transform: none;
+}
+.roulette-chip:disabled:hover {
+    border-color: var(--border);
+    transform: none;
 }
 .roulette-chip-label { font-size: 0.95rem; }
 .roulette-chip-odds {
@@ -288,6 +312,15 @@
     letter-spacing: 0.05em;
 }
 .roulette-payouts tr:last-child td { border-bottom: none; }
+
+/* Keep the "Pays" column tight so the "Covers" column gets the
+   reading width on narrow viewports. Right-align the odds for a
+   clean numeric column. */
+.roulette-payouts-pays {
+    text-align: right;
+    white-space: nowrap;
+    width: 1%;
+}
 
 @media (max-width: 600px) {
     .roulette-wheel-stage { width: 240px; height: 240px; }

--- a/web/src/main/resources/static/js/roulette.js
+++ b/web/src/main/resources/static/js/roulette.js
@@ -1,3 +1,18 @@
+// Toggle every bet chip plus the straight-number picker in lockstep so
+// neither can be re-touched mid-spin. Hoisted out of the IIFE so a jest
+// test can drive it without booting the whole page; the IIFE wires it
+// into startSpinAnimation/stopSpinAnimation.
+function setBetInputsDisabled(disabled, fieldsetEl, straightInputEl) {
+    if (!fieldsetEl) return;
+    var chips = fieldsetEl.querySelectorAll('.roulette-chip');
+    chips.forEach(function (c) {
+        c.disabled = disabled;
+        if (disabled) c.setAttribute('aria-disabled', 'true');
+        else c.removeAttribute('aria-disabled');
+    });
+    if (straightInputEl) straightInputEl.disabled = disabled;
+}
+
 // Pure-DOM render for a /spin response. Hoisted out of the IIFE so a
 // future jest test can drive it without booting the whole page (mirrors
 // renderSlotsResult). The IIFE below calls it with the live result element.
@@ -85,6 +100,10 @@ function renderRouletteResult(resultEl, body, flashTargetEl) {
         wheel.classList.remove('settling');
         spinStartedAt = performance.now();
         cancelAllTimers();
+        // Lock every bet input until the wheel actually lands. casino-game.js
+        // already disables the primary spin button while busy, but the chip
+        // radiogroup + straight-number picker would otherwise stay live.
+        setBetInputsDisabled(true, fieldset, straightInput);
 
         if (REDUCED_MOTION) {
             // Skip the live animation; we'll snap straight to the settle
@@ -119,7 +138,10 @@ function renderRouletteResult(resultEl, body, flashTargetEl) {
 
         if (!body || typeof body.landed !== 'number') {
             // Network / error path — leave the wheel where it is and skip
-            // the settle. The toast surfaces the error to the player.
+            // the settle. The toast surfaces the error to the player. Unlock
+            // the bet inputs immediately so the player can retry without
+            // re-rolling the page.
+            setBetInputsDisabled(false, fieldset, straightInput);
             return;
         }
 
@@ -146,10 +168,12 @@ function renderRouletteResult(resultEl, body, flashTargetEl) {
 
         rotation = settleDeg;
         if (REDUCED_MOTION) {
-            // Snap to the final angle without a transition.
+            // Snap to the final angle without a transition; unlock straight
+            // away since there's no settle to wait through.
             wheel.style.transform = 'rotate(' + settleDeg + 'deg)';
             paintLanded(body);
             playOutcomeCues(body);
+            setBetInputsDisabled(false, fieldset, straightInput);
             return;
         }
 
@@ -164,11 +188,13 @@ function renderRouletteResult(resultEl, body, flashTargetEl) {
         // the cadence audibly slows as the ball approaches its pocket.
         scheduleSettleTicks(SETTLE_MS, 14);
         // Finish: clean up the transition class, paint the last-landed
-        // pill, and hand off to the win/lose cue.
+        // pill, hand off to the win/lose cue, and unlock the bet inputs
+        // so the player can pick a new bet for the next spin.
         var finishId = setTimeout(function () {
             wheel.classList.remove('settling');
             paintLanded(body);
             playOutcomeCues(body);
+            setBetInputsDisabled(false, fieldset, straightInput);
         }, SETTLE_MS + 30);
         settleTimeoutIds.push(finishId);
     }
@@ -227,6 +253,10 @@ function renderRouletteResult(resultEl, body, flashTargetEl) {
     }
 
     function selectChip(chip) {
+        // Defence in depth: even though disabled buttons don't fire `click`
+        // by default, a programmatic click or a keydown firing immediately
+        // before the disabled flag flips could still slip through.
+        if (chip.disabled) return;
         var chips = fieldset.querySelectorAll('.roulette-chip');
         chips.forEach(function (c) { c.setAttribute('aria-checked', 'false'); });
         chip.setAttribute('aria-checked', 'true');
@@ -379,5 +409,5 @@ function renderRouletteResult(resultEl, body, flashTargetEl) {
 })();
 
 if (typeof module !== 'undefined' && module.exports) {
-    module.exports = { renderRouletteResult };
+    module.exports = { renderRouletteResult, setBetInputsDisabled };
 }

--- a/web/src/main/resources/templates/fragments/navbar.html
+++ b/web/src/main/resources/templates/fragments/navbar.html
@@ -38,7 +38,7 @@
                 <a href="/casino/guilds" role="menuitem">&#127183; High-Low</a>
                 <a href="/casino/guilds" role="menuitem">&#127903;&#65039; Scratch</a>
                 <a href="/casino/guilds" role="menuitem">&#127919; Keno</a>
-                <a href="/casino/guilds" role="menuitem">&#127904; Roulette</a>
+                <a href="/casino/guilds" role="menuitem">&#127905; Roulette</a>
                 <a href="/poker/guilds" role="menuitem">&#127924; Poker</a>
                 <a href="/blackjack/guilds" role="menuitem">&#127922; Blackjack</a>
                 <a href="/casino/guilds" role="menuitem">&#127924; Baccarat</a>

--- a/web/src/main/resources/templates/roulette.html
+++ b/web/src/main/resources/templates/roulette.html
@@ -86,20 +86,21 @@
     </section>
 
     <section class="roulette-payouts">
-        <h2>Payouts</h2>
+        <h2>Bet types &amp; payouts</h2>
         <table>
             <thead>
-            <tr><th>Bet</th><th>Pays</th></tr>
+            <tr><th>Bet</th><th>Covers</th><th class="roulette-payouts-pays">Pays</th></tr>
             </thead>
             <tbody>
             <tr th:each="row : ${payoutTable}">
                 <td th:text="${row.label}">Red / Black</td>
-                <td th:text="${row.payout}">1:1</td>
+                <td th:text="${row.covers}">The 18 red or 18 black pockets. Zero loses.</td>
+                <td class="roulette-payouts-pays" th:text="${row.payout}">1:1</td>
             </tr>
             </tbody>
         </table>
-        <p class="muted">European single-zero wheel. The green 0 loses every outside bet, giving the
-            house its standard 2.7% edge. Long-run RTP ≈ 97.3%.</p>
+        <p class="muted">European single-zero wheel. The green 0 loses every outside bet (red/black,
+            odd/even, low/high), giving the house its standard 2.7% edge. Long-run RTP ≈ 97.3%.</p>
     </section>
 </main>
 

--- a/web/src/test/js/roulette.test.js
+++ b/web/src/test/js/roulette.test.js
@@ -1,0 +1,179 @@
+// Smoke-test the pure render contract for the /spin response and the
+// bet-input lock helper that gates the chip radiogroup + straight-number
+// picker during the wheel animation. The IIFE in roulette.js wires the
+// form, postJson, and animation; these tests only exercise the hoisted
+// helpers so DOM mutations are deterministic.
+
+const {
+    renderRouletteResult,
+    setBetInputsDisabled,
+} = require('../../main/resources/static/js/roulette');
+require('../../main/resources/static/js/casino-jackpot');
+require('../../main/resources/static/js/casino-result');
+require('../../main/resources/static/js/casino-render');
+
+describe('renderRouletteResult', () => {
+    let resultEl;
+    let tableEl;
+
+    beforeEach(() => {
+        document.body.innerHTML =
+            '<section id="t" class="roulette-table">' +
+            '  <div id="r"></div>' +
+            '</section>';
+        tableEl = document.getElementById('t');
+        resultEl = document.getElementById('r');
+    });
+
+    test('win path includes net credits, multiplier, bet label, and pocket colour', () => {
+        renderRouletteResult(resultEl, {
+            win: true, net: 100, multiplier: 2,
+            bet: 'RED', betLabel: 'Red',
+            landed: 7, color: 'RED',
+        }, tableEl);
+
+        expect(resultEl.classList.contains('roulette-result-win')).toBe(true);
+        expect(resultEl.classList.contains('roulette-result-lose')).toBe(false);
+        expect(resultEl.innerHTML).toContain('+100 credits');
+        expect(resultEl.innerHTML).toContain('2×');
+        expect(resultEl.innerHTML).toContain('Red');
+        expect(resultEl.innerHTML).toContain('#7');
+        expect(resultEl.innerHTML).toContain('red');
+        expect(resultEl.hidden).toBe(false);
+    });
+
+    test('lose path shows the loss amount, the lose class, and the landed pocket', () => {
+        renderRouletteResult(resultEl, {
+            win: false, net: -50,
+            bet: 'BLACK', betLabel: 'Black',
+            landed: 0, color: 'GREEN',
+        }, tableEl);
+
+        expect(resultEl.classList.contains('roulette-result-lose')).toBe(true);
+        expect(resultEl.classList.contains('roulette-result-win')).toBe(false);
+        expect(resultEl.innerHTML).toContain('50 credits');
+        expect(resultEl.innerHTML).toContain('Black');
+        expect(resultEl.innerHTML).toContain('#0');
+        expect(resultEl.innerHTML).toContain('green');
+    });
+
+    test('jackpot win prepends the JACKPOT banner via TobyJackpot helper', () => {
+        renderRouletteResult(resultEl, {
+            win: true, net: 350, multiplier: 36, jackpotPayout: 5000,
+            bet: 'STRAIGHT', betLabel: 'Straight',
+            landed: 17, color: 'BLACK', straightNumber: 17,
+        }, tableEl);
+
+        expect(resultEl.classList.contains('roulette-result-jackpot')).toBe(true);
+        expect(resultEl.innerHTML).toContain('+5000 credits');
+        expect(resultEl.innerHTML).toContain('+350 credits');
+        expect(resultEl.innerHTML).toContain('36×');
+    });
+
+    test('clears prior win/lose/jackpot classes between renders', () => {
+        resultEl.classList.add('roulette-result-jackpot');
+        resultEl.classList.add('roulette-result-lose');
+
+        renderRouletteResult(resultEl, {
+            win: true, net: 100, multiplier: 2,
+            bet: 'RED', betLabel: 'Red', landed: 7, color: 'RED',
+        }, tableEl);
+
+        expect(resultEl.classList.contains('roulette-result-jackpot')).toBe(false);
+        expect(resultEl.classList.contains('roulette-result-lose')).toBe(false);
+        expect(resultEl.classList.contains('roulette-result-win')).toBe(true);
+    });
+
+    test('lose with lossTribute appends "+N to jackpot" suffix', () => {
+        renderRouletteResult(resultEl, {
+            win: false, net: -100, lossTribute: 10,
+            bet: 'RED', betLabel: 'Red', landed: 0, color: 'GREEN',
+        }, tableEl);
+
+        expect(resultEl.classList.contains('roulette-result-lose')).toBe(true);
+        expect(resultEl.innerHTML).toContain('100 credits');
+        expect(resultEl.innerHTML).toContain('+10 to jackpot');
+    });
+
+    test('returns early on missing result element', () => {
+        expect(() => renderRouletteResult(null, { win: true })).not.toThrow();
+    });
+
+    test('drops a chip stack on the table felt for a win', () => {
+        renderRouletteResult(resultEl, {
+            win: true, net: 350, multiplier: 36,
+            bet: 'STRAIGHT', betLabel: 'Straight', landed: 17, color: 'BLACK',
+        }, tableEl);
+
+        const stack = tableEl.querySelector('.casino-chip-stack');
+        expect(stack).not.toBeNull();
+        expect(stack.querySelector('.casino-chip-payout').textContent).toBe('+350');
+    });
+});
+
+describe('setBetInputsDisabled', () => {
+    let fieldset;
+    let chips;
+    let straightInput;
+
+    beforeEach(() => {
+        document.body.innerHTML =
+            '<form>' +
+            '  <fieldset id="bf">' +
+            '    <button type="button" class="roulette-chip" aria-checked="true" data-bet="RED">Red</button>' +
+            '    <button type="button" class="roulette-chip" aria-checked="false" data-bet="BLACK">Black</button>' +
+            '    <button type="button" class="roulette-chip" aria-checked="false" data-bet="STRAIGHT" data-requires-number="true">Straight</button>' +
+            '  </fieldset>' +
+            '  <input id="rn" type="number" min="0" max="36" value="0">' +
+            '</form>';
+        fieldset = document.getElementById('bf');
+        chips = Array.from(fieldset.querySelectorAll('.roulette-chip'));
+        straightInput = document.getElementById('rn');
+    });
+
+    test('flips disabled + aria-disabled on every chip and the straight input', () => {
+        setBetInputsDisabled(true, fieldset, straightInput);
+
+        chips.forEach((c) => {
+            expect(c.disabled).toBe(true);
+            expect(c.getAttribute('aria-disabled')).toBe('true');
+        });
+        expect(straightInput.disabled).toBe(true);
+    });
+
+    test('clears disabled + aria-disabled when locking is released', () => {
+        setBetInputsDisabled(true, fieldset, straightInput);
+        setBetInputsDisabled(false, fieldset, straightInput);
+
+        chips.forEach((c) => {
+            expect(c.disabled).toBe(false);
+            expect(c.hasAttribute('aria-disabled')).toBe(false);
+        });
+        expect(straightInput.disabled).toBe(false);
+    });
+
+    test('tolerates a null straightInput (picker hidden) without throwing', () => {
+        expect(() => setBetInputsDisabled(true, fieldset, null)).not.toThrow();
+        chips.forEach((c) => expect(c.disabled).toBe(true));
+    });
+
+    test('returns early without throwing on a null fieldset', () => {
+        expect(() => setBetInputsDisabled(true, null, straightInput)).not.toThrow();
+    });
+
+    test('clicking a disabled chip does not change the aria-checked selection', () => {
+        // Mid-spin lockout: the chip radiogroup must be inert until the
+        // wheel settles, otherwise a player can re-pick a bet that was
+        // never wagered. Browsers natively suppress click on disabled
+        // <button>; the assertion just nails that contract down so a
+        // future regression (e.g. swapping <button> for <div role="radio">)
+        // doesn't quietly break it.
+        setBetInputsDisabled(true, fieldset, straightInput);
+        const black = chips.find((c) => c.dataset.bet === 'BLACK');
+        black.click();
+
+        expect(black.getAttribute('aria-checked')).toBe('false');
+        const red = chips.find((c) => c.dataset.bet === 'RED');
+        expect(red.getAttribute('aria-checked')).toBe('true');
+    });
+});


### PR DESCRIPTION
## Summary
Five small follow-ups on the roulette page from a mobile screenshot of the live build.

- **Navbar emoji parity** — Casino dropdown used `&#127904;` (🎠 carousel horse) but every other surface uses 🎡 ferris wheel. One-char fix to `&#127905;`.
- **Bet `<fieldset>` shape** — reset the user-agent legend padding/margin and the fieldset's default `min-inline-size: -webkit-min-content` (mirrors baccarat.css), and added a `.roulette-chip:disabled` state for the lock fix below.
- **Mid-spin lock** — chips and the 0–36 straight picker now disable the moment the wheel starts spinning and re-enable when it actually lands (or immediately on the network-error path). Previously only the primary spin button was disabled, so a player could re-toggle a bet mid-animation and assume it "took". New hoisted `setBetInputsDisabled` helper plus a defence-in-depth guard in `selectChip`.
- **Bet-type explainer** — the bottom "Payouts" table grew a "Covers" column with plain-English copy ("Dozens — 1st 12, 2nd 12, or 3rd 12 — twelve numbers each") so first-time players don't need roulette parlance.
- **Tests** — new `web/src/test/js/roulette.test.js` (12 specs) covering both `renderRouletteResult` (win/lose/jackpot/lossTribute paths, chip-stack on a win) and `setBetInputsDisabled` (lock + unlock + null guards + a regression pin that disabled chips don't change selection on click).

## Test plan
- [x] `cd web && npm test` — 347 specs pass (12 new in `roulette.test.js`)
- [x] `cd web && npm run lint:css` — clean
- [x] `./gradlew :web:test :database:test` — all green; existing `RouletteControllerTest`/`RouletteTest`/`RouletteCommandTest` unaffected
- [ ] Open `/casino/{guildId}/roulette` and verify:
  - Page header glyph matches the navbar Casino dropdown's 🎡 Roulette entry
  - "Bet" fieldset legend sits cleanly on the top border with no asymmetric padding
  - During a spin the chip grid + straight-number input visibly disable (faded) and re-enable when the wheel lands
  - The bottom "Bet types & payouts" table has the new "Covers" column

https://claude.ai/code/session_01VnFZBZ8D7dhfdtcpypnSp8

---
_Generated by [Claude Code](https://claude.ai/code/session_01VnFZBZ8D7dhfdtcpypnSp8)_