### PR TITLE
feat(lottery): distinct-buyer safeguard + channel announcer

### DIFF
--- a/database/src/main/kotlin/database/dto/ConfigDto.kt
+++ b/database/src/main/kotlin/database/dto/ConfigDto.kt
@@ -229,7 +229,22 @@ class ConfigDto(
         //                    every draw guarantees a winner, predictable
         //                    drain regardless of ticket volume.
         // Defaults to "NUMBER_MATCH" so existing guilds aren't disrupted.
-        LOTTERY_DAILY_MODE("LOTTERY_DAILY_MODE");
+        LOTTERY_DAILY_MODE("LOTTERY_DAILY_MODE"),
+
+        // Whole-number minimum *distinct* buyers required for the daily
+        // draw to actually pay out. Below this count, the draw cancels:
+        // every buyer is refunded and the seed returns to the jackpot
+        // pool. Default 2 — prevents a single user sweeping the seeded
+        // pool when they're the only one who engaged. Range [1, 50];
+        // 1 disables the safeguard (matches pre-PR behaviour).
+        LOTTERY_DAILY_MIN_BUYERS("LOTTERY_DAILY_MIN_BUYERS"),
+
+        // Discord text-channel id where the daily lottery announcer
+        // posts the close+open summary (and pings winners). Optional —
+        // when blank/unset the announcer falls back to LEADERBOARD_CHANNEL,
+        // then the guild's system channel. Resolution mirrors the
+        // monthly leaderboard job's pattern.
+        LOTTERY_CHANNEL("LOTTERY_CHANNEL");
     }
 
     override fun toString(): String {

--- a/database/src/main/kotlin/database/service/JackpotLotteryService.kt
+++ b/database/src/main/kotlin/database/service/JackpotLotteryService.kt
@@ -74,6 +74,16 @@ class JackpotLotteryService(
         ) : DrawOutcome
         data object NoOpenLottery : DrawOutcome
         data object NoTickets : DrawOutcome
+
+        /**
+         * Distinct buyer count is below the per-guild
+         * `LOTTERY_DAILY_MIN_BUYERS` threshold. The caller should treat
+         * this the same as [NoTickets] — call [cancelLottery] to refund
+         * all buyers and return the seed to the jackpot pool. Distinct
+         * variant from [NoTickets] so the announcer can render the
+         * "1 buyer (need 2)" copy instead of "no tickets bought".
+         */
+        data class BelowMinBuyers(val have: Int, val need: Int) : DrawOutcome
     }
 
     sealed interface CancelOutcome {
@@ -112,6 +122,9 @@ class JackpotLotteryService(
         ) : DrawMatchOutcome
         data object NoOpenLottery : DrawMatchOutcome
         data object NoTickets : DrawMatchOutcome
+
+        /** Same semantics as [DrawOutcome.BelowMinBuyers]. */
+        data class BelowMinBuyers(val have: Int, val need: Int) : DrawMatchOutcome
     }
 
     /**
@@ -216,6 +229,17 @@ class JackpotLotteryService(
         val lotteryId = lottery.id ?: error("Open lottery has no id")
         val tickets = lotteryPersistence.ticketsByLottery(lotteryId)
         if (tickets.isEmpty() || tickets.sumOf { it.ticketCount.toLong() } == 0L) return DrawOutcome.NoTickets
+
+        // Participation safeguard: with one buyer, the top-3 weighted
+        // draw still pays them 50% of the seeded pool — effectively a
+        // free lift from the jackpot. Block payout below the configured
+        // distinct-buyer threshold so the caller can cancel + refund
+        // instead.
+        val minBuyers = LotteryHelper.dailyMinBuyers(configService, guildId)
+        val distinctBuyers = tickets.map { it.discordId }.toSet().size
+        if (distinctBuyers < minBuyers) {
+            return DrawOutcome.BelowMinBuyers(have = distinctBuyers, need = minBuyers)
+        }
 
         val winnerSlots = lottery.winnerCount.coerceAtLeast(1)
         val winners = drawWinners(tickets, winnerSlots, random)
@@ -428,6 +452,16 @@ class JackpotLotteryService(
         val lotteryId = lottery.id ?: error("Open lottery has no id")
         val tickets = lotteryPersistence.ticketsByLottery(lotteryId)
         if (tickets.isEmpty()) return DrawMatchOutcome.NoTickets
+
+        // Participation safeguard. NUMBER_MATCH is somewhat self-protecting
+        // at low counts (random rarely favours a solo buyer), but still
+        // enforce the threshold uniformly so the moderation surface
+        // means the same thing in both modes.
+        val minBuyers = LotteryHelper.dailyMinBuyers(configService, guildId)
+        val distinctBuyers = tickets.map { it.discordId }.toSet().size
+        if (distinctBuyers < minBuyers) {
+            return DrawMatchOutcome.BelowMinBuyers(have = distinctBuyers, need = minBuyers)
+        }
 
         val drawn = drawNumbers(lottery.numberMax, lottery.pickCount, random)
         val drawnSet = drawn.toSet()

--- a/database/src/main/kotlin/database/service/LotteryHelper.kt
+++ b/database/src/main/kotlin/database/service/LotteryHelper.kt
@@ -65,6 +65,15 @@ object LotteryHelper {
     const val WEIGHTED_DAILY_WINNER_COUNT: Int = 3
 
     /**
+     * Minimum *distinct* buyers required for a daily draw to pay out.
+     * Default 2: prevents a single engaged user sweeping the seeded
+     * pool when nobody else plays. 1 disables the safeguard (the draw
+     * pays out at any participation level). Range [1, 50].
+     */
+    const val DEFAULT_DAILY_MIN_BUYERS: Int = 2
+    const val MAX_DAILY_MIN_BUYERS: Int = 50
+
+    /**
      * Tier prize percentages for a match-numbers draw. Order: 5/5, 4/5,
      * 3/5, 2/5. Sum = 100; un-won tier shares roll back into the
      * per-guild jackpot pool via the remainder-handling in
@@ -131,5 +140,33 @@ object LotteryHelper {
             MODE_NUMBER_MATCH, MODE_WEIGHTED -> raw
             else -> DEFAULT_DAILY_MODE
         }
+    }
+
+    /**
+     * Live distinct-buyer threshold below which a daily draw cancels +
+     * refunds rather than paying out. Default [DEFAULT_DAILY_MIN_BUYERS],
+     * clamped to `[1, MAX_DAILY_MIN_BUYERS]` so an admin can't accidentally
+     * disable the safeguard with a 0 or negative value.
+     */
+    fun dailyMinBuyers(configService: ConfigService, guildId: Long): Int {
+        val cfg = configService.getConfigByName(
+            ConfigDto.Configurations.LOTTERY_DAILY_MIN_BUYERS.configValue,
+            guildId.toString()
+        )
+        val raw = cfg?.value?.toIntOrNull() ?: return DEFAULT_DAILY_MIN_BUYERS
+        return raw.coerceIn(1, MAX_DAILY_MIN_BUYERS)
+    }
+
+    /**
+     * Live announce-channel id for the daily lottery. Returns null when
+     * unset / unparseable so the caller can fall back through
+     * `LEADERBOARD_CHANNEL` then `guild.systemChannel`.
+     */
+    fun lotteryChannelId(configService: ConfigService, guildId: Long): Long? {
+        val cfg = configService.getConfigByName(
+            ConfigDto.Configurations.LOTTERY_CHANNEL.configValue,
+            guildId.toString()
+        )
+        return cfg?.value?.trim()?.takeIf { it.isNotEmpty() }?.toLongOrNull()
     }
 }

--- a/database/src/test/kotlin/database/service/JackpotLotteryServiceTest.kt
+++ b/database/src/test/kotlin/database/service/JackpotLotteryServiceTest.kt
@@ -39,6 +39,20 @@ class JackpotLotteryServiceTest {
                 guildId.toString()
             )
         } returns null
+        // Default: disable the participation gate (min buyers = 1) so the
+        // bulk of the existing tests stay focused on payout maths. The
+        // BelowMinBuyers test cases below opt in by stubbing a higher
+        // threshold per-test.
+        every {
+            configService.getConfigByName(
+                ConfigDto.Configurations.LOTTERY_DAILY_MIN_BUYERS.configValue,
+                guildId.toString()
+            )
+        } returns ConfigDto(
+            name = ConfigDto.Configurations.LOTTERY_DAILY_MIN_BUYERS.configValue,
+            value = "1",
+            guildId = guildId.toString()
+        )
         service = JackpotLotteryService(
             lotteryPersistence,
             jackpotService,
@@ -561,5 +575,120 @@ class JackpotLotteryServiceTest {
             JackpotLotteryService.DrawMatchOutcome.NoTickets,
             service.drawMatchLottery(guildId)
         )
+    }
+
+    // ===================================================================
+    // BelowMinBuyers participation gate — both modes
+    // ===================================================================
+
+    private fun stubMinBuyers(value: Int) {
+        every {
+            configService.getConfigByName(
+                ConfigDto.Configurations.LOTTERY_DAILY_MIN_BUYERS.configValue,
+                guildId.toString()
+            )
+        } returns ConfigDto(
+            name = ConfigDto.Configurations.LOTTERY_DAILY_MIN_BUYERS.configValue,
+            value = value.toString(),
+            guildId = guildId.toString()
+        )
+    }
+
+    @Test
+    fun `drawLottery returns BelowMinBuyers when distinct buyers below threshold`() {
+        stubMinBuyers(2)
+        every {
+            lotteryPersistence.getOpenByGuildAndModeForUpdate(guildId, JackpotLotteryDto.MODE_TICKET_WEIGHTED)
+        } returns JackpotLotteryDto(
+            id = 1L, guildId = guildId, ticketPrice = 50L, poolAmount = 1_000L,
+            status = JackpotLotteryDto.STATUS_OPEN, mode = JackpotLotteryDto.MODE_TICKET_WEIGHTED,
+        )
+        // Single buyer with multiple tickets — still below distinct-buyer
+        // threshold, so the gate fires regardless of ticket count.
+        every { lotteryPersistence.ticketsByLottery(1L) } returns listOf(
+            JackpotLotteryTicketDto(lotteryId = 1L, discordId = 7L, ticketCount = 5, spent = 250L),
+        )
+
+        val r = service.drawLottery(guildId)
+        assertTrue(r is JackpotLotteryService.DrawOutcome.BelowMinBuyers)
+        r as JackpotLotteryService.DrawOutcome.BelowMinBuyers
+        assertEquals(1, r.have)
+        assertEquals(2, r.need)
+        // No payouts written, pool unchanged — caller is expected to
+        // cancel + refund.
+        verify(exactly = 0) { userService.updateUser(any()) }
+    }
+
+    @Test
+    fun `drawLottery proceeds normally at threshold`() {
+        stubMinBuyers(2)
+        val lottery = JackpotLotteryDto(
+            id = 1L, guildId = guildId, ticketPrice = 50L, poolAmount = 1_000L,
+            winnerCount = 3, status = JackpotLotteryDto.STATUS_OPEN,
+            mode = JackpotLotteryDto.MODE_TICKET_WEIGHTED,
+        )
+        every {
+            lotteryPersistence.getOpenByGuildAndModeForUpdate(guildId, JackpotLotteryDto.MODE_TICKET_WEIGHTED)
+        } returns lottery
+        every { lotteryPersistence.ticketsByLottery(1L) } returns listOf(
+            JackpotLotteryTicketDto(lotteryId = 1L, discordId = 1L, ticketCount = 3, spent = 150L),
+            JackpotLotteryTicketDto(lotteryId = 1L, discordId = 2L, ticketCount = 2, spent = 100L),
+        )
+        val users = (1L..2L).associate { id ->
+            id to UserDto(discordId = id, guildId = guildId).apply { socialCredit = 0L }
+        }
+        users.forEach { (id, u) ->
+            every { userService.getUserByIdForUpdate(id, guildId) } returns u
+        }
+
+        val r = service.drawLottery(guildId)
+        assertTrue(r is JackpotLotteryService.DrawOutcome.Ok, "2 distinct buyers passes the gate")
+    }
+
+    @Test
+    fun `drawLottery threshold of 1 disables the gate (matches pre-PR behaviour)`() {
+        stubMinBuyers(1)
+        val lottery = JackpotLotteryDto(
+            id = 1L, guildId = guildId, ticketPrice = 50L, poolAmount = 1_000L,
+            winnerCount = 3, status = JackpotLotteryDto.STATUS_OPEN,
+            mode = JackpotLotteryDto.MODE_TICKET_WEIGHTED,
+        )
+        every {
+            lotteryPersistence.getOpenByGuildAndModeForUpdate(guildId, JackpotLotteryDto.MODE_TICKET_WEIGHTED)
+        } returns lottery
+        every { lotteryPersistence.ticketsByLottery(1L) } returns listOf(
+            JackpotLotteryTicketDto(lotteryId = 1L, discordId = 7L, ticketCount = 1, spent = 50L),
+        )
+        val user = UserDto(discordId = 7L, guildId = guildId).apply { socialCredit = 0L }
+        every { userService.getUserByIdForUpdate(7L, guildId) } returns user
+
+        val r = service.drawLottery(guildId)
+        assertTrue(r is JackpotLotteryService.DrawOutcome.Ok, "threshold 1 lets a single buyer through")
+    }
+
+    @Test
+    fun `drawMatchLottery returns BelowMinBuyers when distinct buyers below threshold`() {
+        stubMinBuyers(2)
+        every {
+            lotteryPersistence.getOpenByGuildAndModeForUpdate(guildId, JackpotLotteryDto.MODE_NUMBER_MATCH)
+        } returns JackpotLotteryDto(
+            id = 1L, guildId = guildId, ticketPrice = 50L, poolAmount = 1_000L,
+            status = JackpotLotteryDto.STATUS_OPEN, mode = JackpotLotteryDto.MODE_NUMBER_MATCH,
+            pickCount = 5, numberMax = 49,
+        )
+        every { lotteryPersistence.ticketsByLottery(1L) } returns listOf(
+            JackpotLotteryTicketDto(
+                lotteryId = 1L, discordId = 7L, ticketCount = 1, spent = 50L,
+                pickedNumbers = "1,2,3,4,5",
+            ),
+        )
+
+        val r = service.drawMatchLottery(guildId)
+        assertTrue(r is JackpotLotteryService.DrawMatchOutcome.BelowMinBuyers)
+        r as JackpotLotteryService.DrawMatchOutcome.BelowMinBuyers
+        assertEquals(1, r.have)
+        assertEquals(2, r.need)
+        // No drawn numbers persisted, no payouts — caller cancels + refunds.
+        verify(exactly = 0) { userService.updateUser(any()) }
     }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/moderation/JackpotAdminCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/moderation/JackpotAdminCommand.kt
@@ -169,6 +169,14 @@ class JackpotAdminCommand @Autowired constructor(
                 replyError(event, "No open lottery to draw.", deleteDelay)
             JackpotLotteryService.DrawOutcome.NoTickets ->
                 replyError(event, "Lottery has no ticket buyers — cancel instead to refund the seed.", deleteDelay)
+            is JackpotLotteryService.DrawOutcome.BelowMinBuyers ->
+                replyError(
+                    event,
+                    "Only **${result.have}** distinct buyer(s) — need **${result.need}**. " +
+                        "Cancel to refund buyers and return the seed (admins can lower " +
+                        "`LOTTERY_DAILY_MIN_BUYERS` if this threshold is too strict).",
+                    deleteDelay,
+                )
         }
     }
 

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/moderation/SetConfigCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/moderation/SetConfigCommand.kt
@@ -203,8 +203,56 @@ class SetConfigCommand @Autowired constructor(
                 ConfigDto.Configurations.LOTTERY_DAILY_MODE -> setLotteryDailyMode(
                     event, optionMapping, deleteDelay
                 )
+                ConfigDto.Configurations.LOTTERY_DAILY_MIN_BUYERS -> setRangedIntConfig(
+                    event, optionMapping, deleteDelay,
+                    config = ConfigDto.Configurations.LOTTERY_DAILY_MIN_BUYERS,
+                    gameLabel = "Daily lottery", label = "minimum distinct buyers", range = 1..50
+                )
+                ConfigDto.Configurations.LOTTERY_CHANNEL -> setLotteryChannel(
+                    event, optionMapping, deleteDelay
+                )
             }
         }
+    }
+
+    /**
+     * Validate + persist the daily-lottery announce channel id. Accepts
+     * a numeric channel id (or 0 / empty to clear and fall back through
+     * LEADERBOARD_CHANNEL → systemChannel). Rejects ids that don't
+     * resolve to a text channel in the current guild — admins can't
+     * usefully target someone else's channel.
+     */
+    private fun setLotteryChannel(
+        event: SlashCommandInteractionEvent,
+        optionMapping: OptionMapping,
+        deleteDelay: Int,
+    ) {
+        val raw = optionMapping.asString.trim()
+        val guild = event.guild ?: return
+        val resolved: String = if (raw.isEmpty() || raw == "0") {
+            ""
+        } else {
+            val id = raw.toLongOrNull() ?: run {
+                event.hook.sendMessage("Channel id must be numeric (or empty / 0 to clear).")
+                    .setEphemeral(true).queue(invokeDeleteOnMessageResponse(deleteDelay))
+                return
+            }
+            guild.getTextChannelById(id) ?: run {
+                event.hook.sendMessage("No text channel with id $id exists in this server.")
+                    .setEphemeral(true).queue(invokeDeleteOnMessageResponse(deleteDelay))
+                return
+            }
+            id.toString()
+        }
+        configService.upsertConfig(
+            ConfigDto.Configurations.LOTTERY_CHANNEL.configValue, resolved, guild.id
+        )
+        val msg = if (resolved.isEmpty()) {
+            "Daily lottery announce channel cleared. Falling back to LEADERBOARD_CHANNEL → system channel."
+        } else {
+            "Daily lottery announcements will post to <#$resolved>."
+        }
+        event.hook.sendMessage(msg).queue(invokeDeleteOnMessageResponse(deleteDelay))
     }
 
     /**

--- a/discord-bot/src/main/kotlin/bot/toby/scheduling/LotteryAnnouncer.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/scheduling/LotteryAnnouncer.kt
@@ -1,0 +1,210 @@
+package bot.toby.scheduling
+
+import common.logging.DiscordLogger
+import database.dto.ConfigDto
+import database.service.ConfigService
+import database.service.JackpotLotteryService
+import database.service.LotteryHelper
+import net.dv8tion.jda.api.EmbedBuilder
+import net.dv8tion.jda.api.Permission
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.MessageEmbed
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+import java.awt.Color
+
+/**
+ * Posts a "yesterday's draw / today's draw" combined summary to a
+ * per-guild lottery channel, pinging winners so they actually see the
+ * win in their notifications.
+ *
+ * Channel resolution mirrors [MonthlyLeaderboardJob.resolveChannel]:
+ *   1. `LOTTERY_CHANNEL` if set and writable
+ *   2. `LEADERBOARD_CHANNEL` fallback (so a guild with one configured
+ *      announcement channel doesn't need to set both)
+ *   3. `guild.systemChannel` if writable
+ *   4. Skip with warn log if none
+ *
+ * Pings: winners' discord ids appear in the message **content** via
+ * [`MessageCreateAction.addContent`] (loud notification) and again in
+ * the embed body for visual context (silent there). Non-winning
+ * variants (BelowMinBuyers, NoTickets) skip the addContent ping
+ * entirely so a buyer-less day stays quiet.
+ */
+@Component
+class LotteryAnnouncer @Autowired constructor(
+    private val configService: ConfigService,
+) {
+    private val logger: DiscordLogger = DiscordLogger.createLogger(this::class.java)
+
+    /**
+     * Announce one daily-cycle outcome. Posts at most one message; on
+     * any send failure logs and moves on (the cycle itself already
+     * completed — failure to announce shouldn't roll back payouts).
+     */
+    fun announceCycle(
+        guild: Guild,
+        mode: String,
+        priorOutcome: PriorOutcome?,
+        openOutcome: OpenSummary,
+    ) {
+        val channel = resolveChannel(guild) ?: run {
+            logger.warn(
+                "No writable channel for daily lottery announcement in guild ${guild.idLong}; " +
+                    "set LOTTERY_CHANNEL or LEADERBOARD_CHANNEL, or grant the bot send-messages " +
+                    "in the system channel."
+            )
+            return
+        }
+        val embed = buildEmbed(guild, mode, priorOutcome, openOutcome)
+        val pingIds = winnerPingIds(priorOutcome)
+        runCatching {
+            val send = channel.sendMessageEmbeds(embed)
+            if (pingIds.isNotEmpty()) {
+                send.addContent(pingIds.joinToString(" ") { "<@$it>" })
+            }
+            send.queue()
+        }.onFailure {
+            logger.error("Could not post lottery announcement to ${channel.id}: ${it.message}")
+        }
+    }
+
+    /**
+     * Internal-but-public sealed type so [LotteryDailyJob] and
+     * [web.service.ModerationWebService] can pass back what happened
+     * without leaning on the [JackpotLotteryService] outcome types
+     * directly (they carry persistence shapes; this carries display
+     * shapes).
+     */
+    sealed interface PriorOutcome {
+        data class MatchDrawn(
+            val drawnNumbers: List<Int>,
+            val tierPayouts: List<JackpotLotteryService.MatchTierPayout>,
+            val totalPaid: Long,
+            val rolledBack: Long,
+        ) : PriorOutcome
+
+        data class WeightedDrawn(
+            val payouts: List<JackpotLotteryService.WinnerPayout>,
+            val totalPaid: Long,
+            val drained: Long,
+        ) : PriorOutcome
+
+        data class BelowMinBuyers(val have: Int, val need: Int) : PriorOutcome
+
+        data object NoTickets : PriorOutcome
+    }
+
+    /**
+     * Open-side summary. We only need the seeded amount + ticket price
+     * for the "today's draw" line; an empty pool / skipped open
+     * collapses to a single-flag variant.
+     */
+    sealed interface OpenSummary {
+        data class Ok(val seeded: Long, val ticketPrice: Long, val poolAmount: Long) : OpenSummary
+        data object Skipped : OpenSummary
+    }
+
+    // ---- channel resolution ----
+
+    private fun resolveChannel(guild: Guild): TextChannel? {
+        val bot = guild.selfMember
+        // 1. LOTTERY_CHANNEL — explicit lottery channel.
+        LotteryHelper.lotteryChannelId(configService, guild.idLong)?.let { id ->
+            val channel = guild.getTextChannelById(id)
+            if (channel != null && bot.hasPermission(channel, *REQUIRED_PERMS)) return channel
+        }
+        // 2. LEADERBOARD_CHANNEL — shared announce channel fallback.
+        configService.getConfigByName(
+            ConfigDto.Configurations.LEADERBOARD_CHANNEL.configValue,
+            guild.id
+        )?.value?.toLongOrNull()?.let { id ->
+            val channel = guild.getTextChannelById(id)
+            if (channel != null && bot.hasPermission(channel, *REQUIRED_PERMS)) return channel
+        }
+        // 3. systemChannel as last resort.
+        return guild.systemChannel?.takeIf { bot.hasPermission(it, *REQUIRED_PERMS) }
+    }
+
+    // ---- embed building ----
+
+    private fun buildEmbed(
+        guild: Guild,
+        mode: String,
+        priorOutcome: PriorOutcome?,
+        openOutcome: OpenSummary,
+    ): MessageEmbed {
+        val builder = EmbedBuilder()
+            .setTitle("🎟️ Daily Lottery — ${guild.name}")
+            .setColor(Color(0xF1C40F))
+
+        if (priorOutcome != null) {
+            builder.addField(
+                "Yesterday's draw",
+                renderPriorOutcome(priorOutcome),
+                false
+            )
+        }
+        builder.addField("Today's draw", renderOpenSummary(mode, openOutcome), false)
+        builder.setFooter(
+            when (mode) {
+                LotteryHelper.MODE_WEIGHTED -> "Top-3 weighted draw • 50/30/20 share"
+                else -> "Pick 5 of 49 • tier payouts 60/25/10/5%"
+            }
+        )
+        return builder.build()
+    }
+
+    private fun renderPriorOutcome(prior: PriorOutcome): String = when (prior) {
+        is PriorOutcome.MatchDrawn -> {
+            val numbers = prior.drawnNumbers.joinToString(" · ")
+            val winners = if (prior.tierPayouts.isEmpty()) {
+                "No tier matched — rolled back **${prior.rolledBack}** to jackpot."
+            } else {
+                prior.tierPayouts
+                    .sortedByDescending { it.matches }
+                    .joinToString("\n") {
+                        "${it.matches}/5: <@${it.discordId}> — **${it.share}** credits"
+                    }
+            }
+            "Winning numbers: **$numbers**\n$winners"
+        }
+        is PriorOutcome.WeightedDrawn -> {
+            if (prior.payouts.isEmpty()) {
+                "No payouts — pool of **${prior.drained}** rolled back to jackpot."
+            } else {
+                prior.payouts
+                    .mapIndexed { idx, p ->
+                        val place = when (idx) { 0 -> "1st"; 1 -> "2nd"; 2 -> "3rd"; else -> "${idx + 1}th" }
+                        "$place: <@${p.discordId}> — **${p.amount}** credits"
+                    }
+                    .joinToString("\n")
+            }
+        }
+        is PriorOutcome.BelowMinBuyers ->
+            "Only **${prior.have}** buyer(s) — need **${prior.need}**. Refunded; seed returned to jackpot."
+        PriorOutcome.NoTickets ->
+            "No tickets bought. Seed returned to jackpot."
+    }
+
+    private fun renderOpenSummary(mode: String, open: OpenSummary): String = when (open) {
+        is OpenSummary.Ok -> {
+            val modeLabel = if (mode == LotteryHelper.MODE_WEIGHTED) "Top-3 weighted" else "Pick 5 of 49"
+            "**${open.poolAmount}** credits in the pool · Ticket: **${open.ticketPrice}** · " +
+                "Mode: **$modeLabel** · Closes 24h."
+        }
+        OpenSummary.Skipped ->
+            "Today's draw was not opened — see logs / moderation tab."
+    }
+
+    private fun winnerPingIds(prior: PriorOutcome?): List<Long> = when (prior) {
+        is PriorOutcome.MatchDrawn -> prior.tierPayouts.map { it.discordId }.distinct()
+        is PriorOutcome.WeightedDrawn -> prior.payouts.map { it.discordId }.distinct()
+        else -> emptyList()
+    }
+
+    companion object {
+        private val REQUIRED_PERMS = arrayOf(Permission.MESSAGE_SEND, Permission.MESSAGE_EMBED_LINKS)
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/scheduling/LotteryDailyJob.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/scheduling/LotteryDailyJob.kt
@@ -22,19 +22,15 @@ import java.time.ZoneOffset
  * For each guild with `LOTTERY_DAILY_ENABLED=true`, dispatches on
  * `LOTTERY_DAILY_MODE`:
  *
- *   - **NUMBER_MATCH** (default): Pick 5 of 1-49. Closes yesterday's
- *     draw via [JackpotLotteryService.drawMatchLottery] (or cancels if
- *     no tickets), opens a fresh one via
- *     [JackpotLotteryService.openMatchLottery]. Best for high-volume
- *     servers — match tiers (5/4/3/2 → 60/25/10/5%) need many tickets
- *     per draw to hit reliably.
+ *   - **NUMBER_MATCH** (default): Pick 5 of 1-49.
+ *   - **WEIGHTED**: top-3 weighted draw, 50/30/20 % of pool.
  *
- *   - **WEIGHTED**: top-3 weighted draw, 50/30/20 % of pool. Closes
- *     yesterday's draw via [JackpotLotteryService.drawLottery] (or
- *     cancels if no tickets), opens a fresh one via
- *     [JackpotLotteryService.openLottery] with `winnerCount=3`. Best
- *     for low-volume servers — a winner is guaranteed every draw
- *     regardless of ticket count, so the pool drains predictably.
+ * Both modes share the same outer flow: close yesterday's draw (or
+ * cancel + refund if there were no tickets, or distinct buyers were
+ * below the [LotteryHelper.dailyMinBuyers] threshold), then open a
+ * fresh one seeded from the jackpot pool. After the cycle, hand the
+ * outcome to [LotteryAnnouncer] so winners get pinged in the configured
+ * announce channel.
  *
  * Idempotent via composite-key ledger ([LotteryDailyService]) — a
  * mid-cron restart skips guilds whose ledger already records today.
@@ -47,6 +43,7 @@ class LotteryDailyJob @Autowired constructor(
     private val configService: ConfigService,
     private val lotteryDailyService: LotteryDailyService,
     private val jackpotLotteryService: JackpotLotteryService,
+    private val lotteryAnnouncer: LotteryAnnouncer,
     private val clock: Clock = Clock.systemUTC(),
 ) {
     private val logger: DiscordLogger = DiscordLogger.createLogger(this::class.java)
@@ -65,10 +62,9 @@ class LotteryDailyJob @Autowired constructor(
     }
 
     /**
-     * Roll the daily draw for a single guild. Public/internal for the
-     * moderation tab's "Force draw now" button — the web service
-     * delegates here so the same close→open→mark-ran flow drives both
-     * scheduled and manual triggers.
+     * Roll the daily draw for a single guild. Public for the moderation
+     * tab's "Force draw now" button — both call sites share the same
+     * close→open→announce→mark-ran flow.
      */
     fun rollGuild(guild: Guild, today: LocalDate) {
         val guildId = guild.idLong
@@ -82,41 +78,68 @@ class LotteryDailyJob @Autowired constructor(
         }
 
         val mode = LotteryHelper.dailyMode(configService, guildId)
-        val opened = when (mode) {
-            LotteryHelper.MODE_WEIGHTED -> rollWeighted(guildId)
-            else -> rollNumberMatch(guildId)  // MODE_NUMBER_MATCH (default)
+        val result = when (mode) {
+            LotteryHelper.MODE_WEIGHTED -> cycleWeighted(guildId)
+            else -> cycleNumberMatch(guildId)  // MODE_NUMBER_MATCH (default)
         }
 
-        if (opened) {
+        // Always announce — even Skipped opens get a "no draw today"
+        // message so the channel reflects what actually happened.
+        lotteryAnnouncer.announceCycle(guild, mode, result.prior, result.open)
+
+        if (result.markRan) {
             lotteryDailyService.markRan(guildId, today)
         }
-        // If `opened` is false the open call returned InvalidParams —
+        // If markRan is false the open call returned InvalidParams —
         // don't mark ran so the next cron tick retries once admin
         // fixes the offending config.
     }
 
     /**
      * NUMBER_MATCH cycle: close (or cancel) yesterday's match lottery,
-     * open a fresh one. Returns true if the open call succeeded (or
-     * AlreadyOpen — race with another worker is treated as success).
+     * open a fresh one. Returns the prior + open outcomes so the
+     * announcer can render a combined message.
      */
-    private fun rollNumberMatch(guildId: Long): Boolean {
-        val openMatch = jackpotLotteryService.getOpenMatch(guildId)
-        if (openMatch?.status == JackpotLotteryDto.STATUS_OPEN) {
-            when (val drawResult = jackpotLotteryService.drawMatchLottery(guildId)) {
-                is JackpotLotteryService.DrawMatchOutcome.Ok ->
-                    logger.info {
-                        "Daily NUMBER_MATCH drew for guild $guildId: drawn=${drawResult.drawnNumbers} " +
-                            "totalPaid=${drawResult.totalPaid} rolledBack=${drawResult.rolledBackToJackpot}"
-                    }
-                JackpotLotteryService.DrawMatchOutcome.NoTickets -> {
-                    logger.info { "Daily NUMBER_MATCH for guild $guildId had no tickets; cancelling and refunding seed." }
-                    jackpotLotteryService.cancelMatchLottery(guildId)
-                }
-                JackpotLotteryService.DrawMatchOutcome.NoOpenLottery -> Unit
-            }
-        }
+    private fun cycleNumberMatch(guildId: Long): CycleResult {
+        val prior = closePriorMatch(guildId)
+        val (open, markRan) = openMatch(guildId)
+        return CycleResult(prior, open, markRan)
+    }
 
+    private fun closePriorMatch(guildId: Long): LotteryAnnouncer.PriorOutcome? {
+        val openMatch = jackpotLotteryService.getOpenMatch(guildId)
+        if (openMatch?.status != JackpotLotteryDto.STATUS_OPEN) return null
+        return when (val drawResult = jackpotLotteryService.drawMatchLottery(guildId)) {
+            is JackpotLotteryService.DrawMatchOutcome.Ok -> {
+                logger.info {
+                    "Daily NUMBER_MATCH drew for guild $guildId: drawn=${drawResult.drawnNumbers} " +
+                        "totalPaid=${drawResult.totalPaid} rolledBack=${drawResult.rolledBackToJackpot}"
+                }
+                LotteryAnnouncer.PriorOutcome.MatchDrawn(
+                    drawnNumbers = drawResult.drawnNumbers,
+                    tierPayouts = drawResult.tierPayouts,
+                    totalPaid = drawResult.totalPaid,
+                    rolledBack = drawResult.rolledBackToJackpot,
+                )
+            }
+            JackpotLotteryService.DrawMatchOutcome.NoTickets -> {
+                logger.info { "Daily NUMBER_MATCH for guild $guildId had no tickets; cancelling and refunding seed." }
+                jackpotLotteryService.cancelMatchLottery(guildId)
+                LotteryAnnouncer.PriorOutcome.NoTickets
+            }
+            is JackpotLotteryService.DrawMatchOutcome.BelowMinBuyers -> {
+                logger.info {
+                    "Daily NUMBER_MATCH for guild $guildId below buyer threshold " +
+                        "(${drawResult.have}/${drawResult.need}); cancelling and refunding."
+                }
+                jackpotLotteryService.cancelMatchLottery(guildId)
+                LotteryAnnouncer.PriorOutcome.BelowMinBuyers(drawResult.have, drawResult.need)
+            }
+            JackpotLotteryService.DrawMatchOutcome.NoOpenLottery -> null
+        }
+    }
+
+    private fun openMatch(guildId: Long): Pair<LotteryAnnouncer.OpenSummary, Boolean> {
         val ticketPrice = LotteryHelper.dailyTicketPrice(configService, guildId)
         val seedPct = LotteryHelper.dailySeedPct(configService, guildId)
         return when (val open = jackpotLotteryService.openMatchLottery(
@@ -128,46 +151,70 @@ class LotteryDailyJob @Autowired constructor(
                     "Daily NUMBER_MATCH opened for guild $guildId: ticketPrice=$ticketPrice " +
                         "seeded=${open.seeded} seedPct=$seedPct"
                 }
-                true
+                LotteryAnnouncer.OpenSummary.Ok(
+                    seeded = open.seeded,
+                    ticketPrice = ticketPrice,
+                    poolAmount = open.lottery.poolAmount,
+                ) to true
             }
             JackpotLotteryService.OpenOutcome.AlreadyOpen -> {
                 logger.warn { "Daily NUMBER_MATCH for guild $guildId is already open; skipping reopen." }
-                true
+                LotteryAnnouncer.OpenSummary.Skipped to true
             }
             JackpotLotteryService.OpenOutcome.EmptyPool -> {
                 logger.warn { "Daily NUMBER_MATCH for guild $guildId reported EmptyPool unexpectedly." }
-                true
+                LotteryAnnouncer.OpenSummary.Skipped to true
             }
             is JackpotLotteryService.OpenOutcome.InvalidParams -> {
                 logger.warn { "Daily NUMBER_MATCH for guild $guildId rejected params: ${open.reason}" }
-                false
+                LotteryAnnouncer.OpenSummary.Skipped to false
             }
         }
     }
 
     /**
      * WEIGHTED cycle: close (or cancel) yesterday's weighted lottery,
-     * open a fresh one. Top 3 of N tickets share the pool 50/30/20 —
-     * always pays out at any ticket volume, so this is the right mode
-     * for low-engagement servers.
+     * open a fresh one. Top 3 of N tickets share the pool 50/30/20.
      */
-    private fun rollWeighted(guildId: Long): Boolean {
-        val openWeighted = jackpotLotteryService.getOpenWeighted(guildId)
-        if (openWeighted?.status == JackpotLotteryDto.STATUS_OPEN) {
-            when (val drawResult = jackpotLotteryService.drawLottery(guildId)) {
-                is JackpotLotteryService.DrawOutcome.Ok ->
-                    logger.info {
-                        "Daily WEIGHTED drew for guild $guildId: " +
-                            "totalPaid=${drawResult.totalPaid} drained=${drawResult.drained}"
-                    }
-                JackpotLotteryService.DrawOutcome.NoTickets -> {
-                    logger.info { "Daily WEIGHTED for guild $guildId had no tickets; cancelling and refunding seed." }
-                    jackpotLotteryService.cancelLottery(guildId)
-                }
-                JackpotLotteryService.DrawOutcome.NoOpenLottery -> Unit
-            }
-        }
+    private fun cycleWeighted(guildId: Long): CycleResult {
+        val prior = closePriorWeighted(guildId)
+        val (open, markRan) = openWeighted(guildId)
+        return CycleResult(prior, open, markRan)
+    }
 
+    private fun closePriorWeighted(guildId: Long): LotteryAnnouncer.PriorOutcome? {
+        val openWeighted = jackpotLotteryService.getOpenWeighted(guildId)
+        if (openWeighted?.status != JackpotLotteryDto.STATUS_OPEN) return null
+        return when (val drawResult = jackpotLotteryService.drawLottery(guildId)) {
+            is JackpotLotteryService.DrawOutcome.Ok -> {
+                logger.info {
+                    "Daily WEIGHTED drew for guild $guildId: " +
+                        "totalPaid=${drawResult.totalPaid} drained=${drawResult.drained}"
+                }
+                LotteryAnnouncer.PriorOutcome.WeightedDrawn(
+                    payouts = drawResult.payouts,
+                    totalPaid = drawResult.totalPaid,
+                    drained = drawResult.drained,
+                )
+            }
+            JackpotLotteryService.DrawOutcome.NoTickets -> {
+                logger.info { "Daily WEIGHTED for guild $guildId had no tickets; cancelling and refunding seed." }
+                jackpotLotteryService.cancelLottery(guildId)
+                LotteryAnnouncer.PriorOutcome.NoTickets
+            }
+            is JackpotLotteryService.DrawOutcome.BelowMinBuyers -> {
+                logger.info {
+                    "Daily WEIGHTED for guild $guildId below buyer threshold " +
+                        "(${drawResult.have}/${drawResult.need}); cancelling and refunding."
+                }
+                jackpotLotteryService.cancelLottery(guildId)
+                LotteryAnnouncer.PriorOutcome.BelowMinBuyers(drawResult.have, drawResult.need)
+            }
+            JackpotLotteryService.DrawOutcome.NoOpenLottery -> null
+        }
+    }
+
+    private fun openWeighted(guildId: Long): Pair<LotteryAnnouncer.OpenSummary, Boolean> {
         val ticketPrice = LotteryHelper.dailyTicketPrice(configService, guildId)
         val seedPct = LotteryHelper.dailySeedPct(configService, guildId)
         val drainPct = (seedPct.toDouble() / 100.0).coerceIn(0.0, 1.0)
@@ -183,28 +230,38 @@ class LotteryDailyJob @Autowired constructor(
                     "Daily WEIGHTED opened for guild $guildId: ticketPrice=$ticketPrice " +
                         "seeded=${open.seeded} seedPct=$seedPct winners=${LotteryHelper.WEIGHTED_DAILY_WINNER_COUNT}"
                 }
-                true
+                LotteryAnnouncer.OpenSummary.Ok(
+                    seeded = open.seeded,
+                    ticketPrice = ticketPrice,
+                    poolAmount = open.lottery.poolAmount,
+                ) to true
             }
             JackpotLotteryService.OpenOutcome.AlreadyOpen -> {
                 logger.warn { "Daily WEIGHTED for guild $guildId is already open; skipping reopen." }
-                true
+                LotteryAnnouncer.OpenSummary.Skipped to true
             }
             JackpotLotteryService.OpenOutcome.EmptyPool -> {
                 logger.info {
                     "Daily WEIGHTED for guild $guildId skipped — jackpot empty. " +
                         "Admin must seed the pool before the next cycle can open."
                 }
-                // Mark as ran anyway so we don't spam the log; tomorrow
-                // will retry. If the admin wants an immediate retry they
-                // can use the moderation tab's force-draw button.
-                true
+                // Mark as ran anyway so we don't spam logs every minute;
+                // admin can use the moderation tab's force-draw button
+                // for an immediate retry once they fund the pool.
+                LotteryAnnouncer.OpenSummary.Skipped to true
             }
             is JackpotLotteryService.OpenOutcome.InvalidParams -> {
                 logger.warn { "Daily WEIGHTED for guild $guildId rejected params: ${open.reason}" }
-                false
+                LotteryAnnouncer.OpenSummary.Skipped to false
             }
         }
     }
+
+    private data class CycleResult(
+        val prior: LotteryAnnouncer.PriorOutcome?,
+        val open: LotteryAnnouncer.OpenSummary,
+        val markRan: Boolean,
+    )
 
     companion object {
         /** A day. The daily draw opens for 24h and closes at the next tick. */

--- a/discord-bot/src/test/kotlin/bot/toby/scheduling/LotteryAnnouncerTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/scheduling/LotteryAnnouncerTest.kt
@@ -1,0 +1,245 @@
+package bot.toby.scheduling
+
+import database.dto.ConfigDto
+import database.service.ConfigService
+import database.service.JackpotLotteryService
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import net.dv8tion.jda.api.Permission
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.Member
+import net.dv8tion.jda.api.entities.MessageEmbed
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
+import net.dv8tion.jda.api.requests.restaction.MessageCreateAction
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * The announcer is a thin shim — most surface is channel resolution +
+ * embed shape, with a single side-effect (channel.sendMessageEmbeds).
+ * Tests focus on:
+ *   - Resolution chain: LOTTERY_CHANNEL → LEADERBOARD_CHANNEL → system
+ *   - Embed body: per-PriorOutcome variant produces distinct copy
+ *   - Pings: addContent only fires when there's a winner to mention
+ *   - No-op when no writable channel resolves
+ */
+class LotteryAnnouncerTest {
+
+    private val guildId = 100L
+    private lateinit var configService: ConfigService
+    private lateinit var guild: Guild
+    private lateinit var bot: Member
+    private lateinit var channel: TextChannel
+    private lateinit var sendAction: MessageCreateAction
+    private lateinit var announcer: LotteryAnnouncer
+
+    @BeforeEach
+    fun setup() {
+        configService = mockk(relaxed = true)
+        guild = mockk(relaxed = true)
+        bot = mockk(relaxed = true)
+        channel = mockk(relaxed = true)
+        sendAction = mockk(relaxed = true)
+
+        every { guild.idLong } returns guildId
+        every { guild.id } returns guildId.toString()
+        every { guild.name } returns "Test Guild"
+        every { guild.selfMember } returns bot
+        every { bot.hasPermission(channel, *anyVararg<Permission>()) } returns true
+        every { channel.id } returns "777"
+        every { channel.sendMessageEmbeds(any<MessageEmbed>()) } returns sendAction
+        every { sendAction.addContent(any()) } returns sendAction
+        every { sendAction.queue() } just Runs
+
+        announcer = LotteryAnnouncer(configService)
+    }
+
+    private fun stubChannelConfig(key: ConfigDto.Configurations, value: String?) {
+        every {
+            configService.getConfigByName(key.configValue, guildId.toString())
+        } returns value?.let {
+            ConfigDto(name = key.configValue, value = it, guildId = guildId.toString())
+        }
+    }
+
+    // ---- channel resolution ----
+
+    @Test
+    fun `resolves LOTTERY_CHANNEL first when set and writable`() {
+        stubChannelConfig(ConfigDto.Configurations.LOTTERY_CHANNEL, "777")
+        every { guild.getTextChannelById(777L) } returns channel
+
+        announcer.announceCycle(
+            guild,
+            mode = "WEIGHTED",
+            priorOutcome = LotteryAnnouncer.PriorOutcome.NoTickets,
+            openOutcome = LotteryAnnouncer.OpenSummary.Ok(
+                seeded = 1_000L, ticketPrice = 50L, poolAmount = 1_000L,
+            ),
+        )
+
+        verify(exactly = 1) { channel.sendMessageEmbeds(any<MessageEmbed>()) }
+        // Not even consulted — LOTTERY_CHANNEL hit.
+        verify(exactly = 0) {
+            configService.getConfigByName(
+                ConfigDto.Configurations.LEADERBOARD_CHANNEL.configValue, guildId.toString()
+            )
+        }
+    }
+
+    @Test
+    fun `falls back to LEADERBOARD_CHANNEL when LOTTERY_CHANNEL is missing`() {
+        stubChannelConfig(ConfigDto.Configurations.LOTTERY_CHANNEL, null)
+        stubChannelConfig(ConfigDto.Configurations.LEADERBOARD_CHANNEL, "888")
+        every { guild.getTextChannelById(888L) } returns channel
+
+        announcer.announceCycle(
+            guild, mode = "NUMBER_MATCH",
+            priorOutcome = null,
+            openOutcome = LotteryAnnouncer.OpenSummary.Ok(
+                seeded = 500L, ticketPrice = 50L, poolAmount = 500L,
+            ),
+        )
+
+        verify(exactly = 1) { channel.sendMessageEmbeds(any<MessageEmbed>()) }
+    }
+
+    @Test
+    fun `falls back to system channel when neither config resolves`() {
+        stubChannelConfig(ConfigDto.Configurations.LOTTERY_CHANNEL, null)
+        stubChannelConfig(ConfigDto.Configurations.LEADERBOARD_CHANNEL, null)
+        every { guild.systemChannel } returns channel
+
+        announcer.announceCycle(
+            guild, mode = "WEIGHTED",
+            priorOutcome = null,
+            openOutcome = LotteryAnnouncer.OpenSummary.Skipped,
+        )
+
+        verify(exactly = 1) { channel.sendMessageEmbeds(any<MessageEmbed>()) }
+    }
+
+    @Test
+    fun `no-op when no writable channel resolves`() {
+        stubChannelConfig(ConfigDto.Configurations.LOTTERY_CHANNEL, null)
+        stubChannelConfig(ConfigDto.Configurations.LEADERBOARD_CHANNEL, null)
+        every { guild.systemChannel } returns null
+
+        announcer.announceCycle(
+            guild, mode = "WEIGHTED",
+            priorOutcome = null,
+            openOutcome = LotteryAnnouncer.OpenSummary.Skipped,
+        )
+
+        verify(exactly = 0) { channel.sendMessageEmbeds(any<MessageEmbed>()) }
+    }
+
+    // ---- embed body + pings ----
+
+    @Test
+    fun `weighted draw mentions every winner and pings them in addContent`() {
+        stubChannelConfig(ConfigDto.Configurations.LOTTERY_CHANNEL, "777")
+        every { guild.getTextChannelById(777L) } returns channel
+        val embedSlot = slot<MessageEmbed>()
+        val contentSlot = slot<String>()
+        every { channel.sendMessageEmbeds(capture(embedSlot)) } returns sendAction
+        every { sendAction.addContent(capture(contentSlot)) } returns sendAction
+
+        val payouts = listOf(
+            JackpotLotteryService.WinnerPayout(discordId = 1L, ticketCount = 5, amount = 500L),
+            JackpotLotteryService.WinnerPayout(discordId = 2L, ticketCount = 3, amount = 300L),
+        )
+        announcer.announceCycle(
+            guild, mode = "WEIGHTED",
+            priorOutcome = LotteryAnnouncer.PriorOutcome.WeightedDrawn(
+                payouts = payouts, totalPaid = 800L, drained = 1_000L,
+            ),
+            openOutcome = LotteryAnnouncer.OpenSummary.Ok(
+                seeded = 500L, ticketPrice = 50L, poolAmount = 500L,
+            ),
+        )
+
+        val embedDescription = embedSlot.captured.fields.joinToString(" ") { (it.value ?: "") }
+        assertTrue(embedDescription.contains("<@1>"), "embed body mentions winner 1")
+        assertTrue(embedDescription.contains("<@2>"), "embed body mentions winner 2")
+        assertTrue(contentSlot.captured.contains("<@1>"), "addContent pings winner 1")
+        assertTrue(contentSlot.captured.contains("<@2>"), "addContent pings winner 2")
+    }
+
+    @Test
+    fun `BelowMinBuyers shows have-need copy and skips the addContent ping`() {
+        stubChannelConfig(ConfigDto.Configurations.LOTTERY_CHANNEL, "777")
+        every { guild.getTextChannelById(777L) } returns channel
+        val embedSlot = slot<MessageEmbed>()
+        every { channel.sendMessageEmbeds(capture(embedSlot)) } returns sendAction
+
+        announcer.announceCycle(
+            guild, mode = "WEIGHTED",
+            priorOutcome = LotteryAnnouncer.PriorOutcome.BelowMinBuyers(have = 1, need = 2),
+            openOutcome = LotteryAnnouncer.OpenSummary.Ok(
+                seeded = 500L, ticketPrice = 50L, poolAmount = 500L,
+            ),
+        )
+
+        val embedDescription = embedSlot.captured.fields.joinToString(" ") { (it.value ?: "") }
+        assertTrue(embedDescription.contains("1") && embedDescription.contains("2"))
+        assertTrue(embedDescription.lowercase().contains("buyer"))
+        // No winners → no addContent ping at all.
+        verify(exactly = 0) { sendAction.addContent(any()) }
+    }
+
+    @Test
+    fun `NoTickets renders a distinct copy and skips the ping`() {
+        stubChannelConfig(ConfigDto.Configurations.LOTTERY_CHANNEL, "777")
+        every { guild.getTextChannelById(777L) } returns channel
+        val embedSlot = slot<MessageEmbed>()
+        every { channel.sendMessageEmbeds(capture(embedSlot)) } returns sendAction
+
+        announcer.announceCycle(
+            guild, mode = "NUMBER_MATCH",
+            priorOutcome = LotteryAnnouncer.PriorOutcome.NoTickets,
+            openOutcome = LotteryAnnouncer.OpenSummary.Ok(
+                seeded = 500L, ticketPrice = 50L, poolAmount = 500L,
+            ),
+        )
+
+        val embedDescription = embedSlot.captured.fields.joinToString(" ") { (it.value ?: "") }
+        assertTrue(embedDescription.lowercase().contains("no tickets"))
+        verify(exactly = 0) { sendAction.addContent(any()) }
+    }
+
+    @Test
+    fun `match-numbers draw renders winning numbers and per-tier winners`() {
+        stubChannelConfig(ConfigDto.Configurations.LOTTERY_CHANNEL, "777")
+        every { guild.getTextChannelById(777L) } returns channel
+        val embedSlot = slot<MessageEmbed>()
+        val contentSlot = slot<String>()
+        every { channel.sendMessageEmbeds(capture(embedSlot)) } returns sendAction
+        every { sendAction.addContent(capture(contentSlot)) } returns sendAction
+
+        announcer.announceCycle(
+            guild, mode = "NUMBER_MATCH",
+            priorOutcome = LotteryAnnouncer.PriorOutcome.MatchDrawn(
+                drawnNumbers = listOf(3, 7, 11, 21, 42),
+                tierPayouts = listOf(
+                    JackpotLotteryService.MatchTierPayout(discordId = 1L, matches = 5, share = 600L),
+                    JackpotLotteryService.MatchTierPayout(discordId = 2L, matches = 3, share = 100L),
+                ),
+                totalPaid = 700L, rolledBack = 300L,
+            ),
+            openOutcome = LotteryAnnouncer.OpenSummary.Ok(
+                seeded = 500L, ticketPrice = 50L, poolAmount = 500L,
+            ),
+        )
+
+        val embedDescription = embedSlot.captured.fields.joinToString(" ") { (it.value ?: "") }
+        assertTrue(embedDescription.contains("3") && embedDescription.contains("42"))
+        assertTrue(embedDescription.contains("<@1>"))
+        assertTrue(contentSlot.captured.contains("<@1>"))
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/scheduling/LotteryAnnouncerTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/scheduling/LotteryAnnouncerTest.kt
@@ -11,7 +11,7 @@ import io.mockk.slot
 import io.mockk.verify
 import net.dv8tion.jda.api.Permission
 import net.dv8tion.jda.api.entities.Guild
-import net.dv8tion.jda.api.entities.Member
+import net.dv8tion.jda.api.entities.SelfMember
 import net.dv8tion.jda.api.entities.MessageEmbed
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
 import net.dv8tion.jda.api.requests.restaction.MessageCreateAction
@@ -33,7 +33,7 @@ class LotteryAnnouncerTest {
     private val guildId = 100L
     private lateinit var configService: ConfigService
     private lateinit var guild: Guild
-    private lateinit var bot: Member
+    private lateinit var bot: SelfMember
     private lateinit var channel: TextChannel
     private lateinit var sendAction: MessageCreateAction
     private lateinit var announcer: LotteryAnnouncer

--- a/discord-bot/src/test/kotlin/bot/toby/scheduling/LotteryDailyJobTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/scheduling/LotteryDailyJobTest.kt
@@ -23,6 +23,7 @@ class LotteryDailyJobTest {
     private lateinit var configService: ConfigService
     private lateinit var lotteryDailyService: LotteryDailyService
     private lateinit var jackpotLotteryService: JackpotLotteryService
+    private lateinit var lotteryAnnouncer: LotteryAnnouncer
     private lateinit var guild: Guild
     private lateinit var job: LotteryDailyJob
 
@@ -36,6 +37,7 @@ class LotteryDailyJobTest {
         configService = mockk(relaxed = true)
         lotteryDailyService = mockk(relaxed = true)
         jackpotLotteryService = mockk(relaxed = true)
+        lotteryAnnouncer = mockk(relaxed = true)
         guild = mockk(relaxed = true)
 
         val cache: SnowflakeCacheView<Guild> = mockk(relaxed = true)
@@ -44,7 +46,10 @@ class LotteryDailyJobTest {
         every { guild.idLong } returns guildId
         every { guild.id } returns guildId.toString()
 
-        job = LotteryDailyJob(jda, configService, lotteryDailyService, jackpotLotteryService, clock)
+        job = LotteryDailyJob(
+            jda, configService, lotteryDailyService, jackpotLotteryService,
+            lotteryAnnouncer, clock,
+        )
     }
 
     private fun stubEnabled(enabled: Boolean) {
@@ -270,5 +275,119 @@ class LotteryDailyJobTest {
 
         verify(exactly = 1) { jackpotLotteryService.openMatchLottery(guildId, any(), any(), any()) }
         verify(exactly = 0) { jackpotLotteryService.openLottery(any(), any(), any(), any(), any()) }
+    }
+
+    // ===================================================================
+    // Announcer wiring + BelowMinBuyers path
+    // ===================================================================
+
+    @Test
+    fun `runDaily calls announcer once after a successful WEIGHTED cycle`() {
+        stubEnabled(true)
+        stubMode("WEIGHTED")
+        every { lotteryDailyService.alreadyRan(guildId, today) } returns false
+        every { jackpotLotteryService.getOpenWeighted(guildId) } returns JackpotLotteryDto(
+            id = 5L, guildId = guildId,
+            status = JackpotLotteryDto.STATUS_OPEN,
+            mode = JackpotLotteryDto.MODE_TICKET_WEIGHTED,
+        )
+        every { jackpotLotteryService.drawLottery(guildId) } returns
+            JackpotLotteryService.DrawOutcome.Ok(
+                payouts = listOf(
+                    JackpotLotteryService.WinnerPayout(discordId = 1L, ticketCount = 2, amount = 500L),
+                ),
+                totalPaid = 500L, drained = 1_000L,
+            )
+        every { jackpotLotteryService.openLottery(guildId, any(), any(), any(), any()) } returns
+            JackpotLotteryService.OpenOutcome.Ok(
+                lottery = JackpotLotteryDto(id = 6L, guildId = guildId, poolAmount = 50L),
+                seeded = 50L,
+            )
+
+        job.runDaily()
+
+        verify(exactly = 1) {
+            lotteryAnnouncer.announceCycle(
+                guild,
+                "WEIGHTED",
+                any<LotteryAnnouncer.PriorOutcome.WeightedDrawn>(),
+                any<LotteryAnnouncer.OpenSummary.Ok>(),
+            )
+        }
+    }
+
+    @Test
+    fun `runDaily handles WEIGHTED BelowMinBuyers — cancels, refunds, announces, marks ran`() {
+        stubEnabled(true)
+        stubMode("WEIGHTED")
+        every { lotteryDailyService.alreadyRan(guildId, today) } returns false
+        every { jackpotLotteryService.getOpenWeighted(guildId) } returns JackpotLotteryDto(
+            id = 5L, guildId = guildId,
+            status = JackpotLotteryDto.STATUS_OPEN,
+            mode = JackpotLotteryDto.MODE_TICKET_WEIGHTED,
+        )
+        every { jackpotLotteryService.drawLottery(guildId) } returns
+            JackpotLotteryService.DrawOutcome.BelowMinBuyers(have = 1, need = 2)
+        every { jackpotLotteryService.openLottery(guildId, any(), any(), any(), any()) } returns
+            JackpotLotteryService.OpenOutcome.Ok(
+                lottery = JackpotLotteryDto(id = 6L, guildId = guildId, poolAmount = 50L),
+                seeded = 50L,
+            )
+
+        job.runDaily()
+
+        // Refund path called.
+        verify(exactly = 1) { jackpotLotteryService.cancelLottery(guildId) }
+        // Announcer called with BelowMinBuyers prior.
+        verify(exactly = 1) {
+            lotteryAnnouncer.announceCycle(
+                guild,
+                "WEIGHTED",
+                any<LotteryAnnouncer.PriorOutcome.BelowMinBuyers>(),
+                any<LotteryAnnouncer.OpenSummary.Ok>(),
+            )
+        }
+        // Day still marked ran — the gate firing isn't a config error,
+        // just low engagement.
+        verify(exactly = 1) { lotteryDailyService.markRan(guildId, today) }
+    }
+
+    @Test
+    fun `runDaily handles NUMBER_MATCH BelowMinBuyers same way`() {
+        stubEnabled(true)
+        // Default mode is NUMBER_MATCH.
+        every { lotteryDailyService.alreadyRan(guildId, today) } returns false
+        every { jackpotLotteryService.getOpenMatch(guildId) } returns JackpotLotteryDto(
+            id = 5L, guildId = guildId,
+            status = JackpotLotteryDto.STATUS_OPEN,
+            mode = JackpotLotteryDto.MODE_NUMBER_MATCH,
+        )
+        every { jackpotLotteryService.drawMatchLottery(guildId) } returns
+            JackpotLotteryService.DrawMatchOutcome.BelowMinBuyers(have = 1, need = 3)
+        every { jackpotLotteryService.openMatchLottery(guildId, any(), any(), any()) } returns
+            JackpotLotteryService.OpenOutcome.Ok(
+                lottery = JackpotLotteryDto(id = 6L, guildId = guildId, poolAmount = 0L), seeded = 0L,
+            )
+
+        job.runDaily()
+
+        verify(exactly = 1) { jackpotLotteryService.cancelMatchLottery(guildId) }
+        verify(exactly = 1) {
+            lotteryAnnouncer.announceCycle(
+                guild,
+                "NUMBER_MATCH",
+                any<LotteryAnnouncer.PriorOutcome.BelowMinBuyers>(),
+                any<LotteryAnnouncer.OpenSummary.Ok>(),
+            )
+        }
+    }
+
+    @Test
+    fun `runDaily skips announcer entirely when daily lottery is disabled`() {
+        stubEnabled(false)
+
+        job.runDaily()
+
+        verify(exactly = 0) { lotteryAnnouncer.announceCycle(any(), any(), any(), any()) }
     }
 }

--- a/web/src/main/kotlin/web/controller/ModerationController.kt
+++ b/web/src/main/kotlin/web/controller/ModerationController.kt
@@ -240,6 +240,9 @@ class ModerationController(
                     ok = false, error = result.error,
                     drewPrior = result.drewPrior, priorTotalPaid = result.priorTotalPaid,
                     priorRolledBack = result.priorRolledBack, priorDrawn = result.priorDrawn,
+                    priorBelowMinBuyers = result.priorBelowMinBuyers,
+                    priorBuyersHave = result.priorBuyersHave,
+                    priorBuyersNeed = result.priorBuyersNeed,
                     openedNew = result.openedNew, newSeeded = result.newSeeded,
                 )
             )
@@ -249,6 +252,9 @@ class ModerationController(
                     ok = true, error = null,
                     drewPrior = result.drewPrior, priorTotalPaid = result.priorTotalPaid,
                     priorRolledBack = result.priorRolledBack, priorDrawn = result.priorDrawn,
+                    priorBelowMinBuyers = result.priorBelowMinBuyers,
+                    priorBuyersHave = result.priorBuyersHave,
+                    priorBuyersNeed = result.priorBuyersNeed,
                     openedNew = result.openedNew, newSeeded = result.newSeeded,
                 )
             )
@@ -316,6 +322,9 @@ data class ForceDrawLotteryResponse(
     val priorTotalPaid: Long = 0L,
     val priorRolledBack: Long = 0L,
     val priorDrawn: List<Int> = emptyList(),
+    val priorBelowMinBuyers: Boolean = false,
+    val priorBuyersHave: Int = 0,
+    val priorBuyersNeed: Int = 0,
     val openedNew: Boolean = false,
     val newSeeded: Long = 0L,
 )

--- a/web/src/main/kotlin/web/service/ModerationWebService.kt
+++ b/web/src/main/kotlin/web/service/ModerationWebService.kt
@@ -323,6 +323,9 @@ class ModerationWebService(
         val priorTotalPaid: Long,
         val priorRolledBack: Long,
         val priorDrawn: List<Int>,
+        val priorBelowMinBuyers: Boolean = false,
+        val priorBuyersHave: Int = 0,
+        val priorBuyersNeed: Int = 0,
         val openedNew: Boolean,
         val newSeeded: Long,
     )
@@ -337,10 +340,18 @@ class ModerationWebService(
         }
         val mode = LotteryHelper.dailyMode(configService, guildId)
         // Step 1: close open daily if present (mode-dispatched).
+        // Note: this admin-only path doesn't post the channel announcement
+        // (the announcer lives in the discord-bot module which the web
+        // module doesn't depend on; see LotteryDailyJob for the announce
+        // wiring). Force-draw is admin debug / recovery; the response
+        // payload + toast are sufficient feedback.
         var drewPrior = false
         var priorTotalPaid = 0L
         var priorRolledBack = 0L
         var priorDrawn: List<Int> = emptyList()
+        var priorBelowMinBuyers = false
+        var priorBuyersHave = 0
+        var priorBuyersNeed = 0
         if (mode == LotteryHelper.MODE_WEIGHTED) {
             when (val drawResult = jackpotLotteryService.drawLottery(guildId)) {
                 is JackpotLotteryService.DrawOutcome.Ok -> {
@@ -351,6 +362,13 @@ class ModerationWebService(
                 JackpotLotteryService.DrawOutcome.NoTickets -> {
                     jackpotLotteryService.cancelLottery(guildId)
                     drewPrior = true
+                }
+                is JackpotLotteryService.DrawOutcome.BelowMinBuyers -> {
+                    jackpotLotteryService.cancelLottery(guildId)
+                    drewPrior = true
+                    priorBelowMinBuyers = true
+                    priorBuyersHave = drawResult.have
+                    priorBuyersNeed = drawResult.need
                 }
                 JackpotLotteryService.DrawOutcome.NoOpenLottery -> Unit
             }
@@ -365,6 +383,13 @@ class ModerationWebService(
                 JackpotLotteryService.DrawMatchOutcome.NoTickets -> {
                     jackpotLotteryService.cancelMatchLottery(guildId)
                     drewPrior = true
+                }
+                is JackpotLotteryService.DrawMatchOutcome.BelowMinBuyers -> {
+                    jackpotLotteryService.cancelMatchLottery(guildId)
+                    drewPrior = true
+                    priorBelowMinBuyers = true
+                    priorBuyersHave = drawResult.have
+                    priorBuyersNeed = drawResult.need
                 }
                 JackpotLotteryService.DrawMatchOutcome.NoOpenLottery -> Unit
             }
@@ -398,6 +423,9 @@ class ModerationWebService(
                     error = null,
                     drewPrior = drewPrior, priorTotalPaid = priorTotalPaid,
                     priorRolledBack = priorRolledBack, priorDrawn = priorDrawn,
+                    priorBelowMinBuyers = priorBelowMinBuyers,
+                    priorBuyersHave = priorBuyersHave,
+                    priorBuyersNeed = priorBuyersNeed,
                     openedNew = true, newSeeded = open.seeded,
                 )
             }
@@ -406,6 +434,9 @@ class ModerationWebService(
                     error = "A daily lottery is already open — close it first.",
                     drewPrior = drewPrior, priorTotalPaid = priorTotalPaid,
                     priorRolledBack = priorRolledBack, priorDrawn = priorDrawn,
+                    priorBelowMinBuyers = priorBelowMinBuyers,
+                    priorBuyersHave = priorBuyersHave,
+                    priorBuyersNeed = priorBuyersNeed,
                     openedNew = false, newSeeded = 0L,
                 )
             JackpotLotteryService.OpenOutcome.EmptyPool ->
@@ -413,6 +444,9 @@ class ModerationWebService(
                     error = null,
                     drewPrior = drewPrior, priorTotalPaid = priorTotalPaid,
                     priorRolledBack = priorRolledBack, priorDrawn = priorDrawn,
+                    priorBelowMinBuyers = priorBelowMinBuyers,
+                    priorBuyersHave = priorBuyersHave,
+                    priorBuyersNeed = priorBuyersNeed,
                     openedNew = false, newSeeded = 0L,
                 )
             is JackpotLotteryService.OpenOutcome.InvalidParams ->
@@ -420,6 +454,9 @@ class ModerationWebService(
                     error = open.reason,
                     drewPrior = drewPrior, priorTotalPaid = priorTotalPaid,
                     priorRolledBack = priorRolledBack, priorDrawn = priorDrawn,
+                    priorBelowMinBuyers = priorBelowMinBuyers,
+                    priorBuyersHave = priorBuyersHave,
+                    priorBuyersNeed = priorBuyersNeed,
                     openedNew = false, newSeeded = 0L,
                 )
         }
@@ -667,6 +704,26 @@ class ModerationWebService(
                     return "Value must be NUMBER_MATCH or WEIGHTED."
                 }
                 v
+            }
+            ConfigDto.Configurations.LOTTERY_DAILY_MIN_BUYERS -> {
+                val n = rawValue.trim().toIntOrNull()
+                    ?: return "Value must be a whole number (1-50; default 2)."
+                if (n !in 1..50) return "Value must be between 1 and 50."
+                n.toString()
+            }
+            ConfigDto.Configurations.LOTTERY_CHANNEL -> {
+                val v = rawValue.trim()
+                if (v.isEmpty()) {
+                    // Empty value clears the override and falls back to
+                    // LEADERBOARD_CHANNEL → systemChannel at runtime.
+                    ""
+                } else {
+                    val id = v.toLongOrNull()
+                        ?: return "Channel id must be numeric."
+                    val channel = guild.getTextChannelById(id)
+                        ?: return "No text channel with that id exists in this server."
+                    channel.id
+                }
             }
         }
 

--- a/web/src/main/resources/static/js/moderation.js
+++ b/web/src/main/resources/static/js/moderation.js
@@ -364,8 +364,14 @@
                 if (r && r.ok) {
                     let msg = 'Lottery cycle ran.';
                     if (r.drewPrior) {
-                        msg += ' Prior draw paid ' + (r.priorTotalPaid ?? 0) +
-                            ' credits (' + (r.priorRolledBack ?? 0) + ' rolled back to jackpot).';
+                        if (r.priorBelowMinBuyers) {
+                            msg += ' Prior draw cancelled — only ' + (r.priorBuyersHave ?? 0) +
+                                ' distinct buyer(s), need ' + (r.priorBuyersNeed ?? 0) +
+                                '. Refunded buyer(s); seed returned to jackpot.';
+                        } else {
+                            msg += ' Prior draw paid ' + (r.priorTotalPaid ?? 0) +
+                                ' credits (' + (r.priorRolledBack ?? 0) + ' rolled back to jackpot).';
+                        }
                     }
                     if (r.openedNew) {
                         msg += ' New draw seeded with ' + (r.newSeeded ?? 0) + ' credits.';

--- a/web/src/main/resources/templates/moderation.html
+++ b/web/src/main/resources/templates/moderation.html
@@ -939,6 +939,35 @@
                         </span>
                         <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
                     </div>
+                    <div class="config-row" data-key="LOTTERY_DAILY_MIN_BUYERS">
+                        <label>
+                            Minimum distinct buyers per draw (default 2)
+                            <span class="config-hint">
+                                Below this count the daily cancels and refunds — prevents a
+                                single user sweeping the seeded pool. 1 disables the safeguard.
+                            </span>
+                        </label>
+                        <input type="number" min="1" max="50"
+                               th:value="${overview.config['LOTTERY_DAILY_MIN_BUYERS']}"
+                               placeholder="2"
+                               th:disabled="${!isOwner}">
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
+                    <div class="config-row" data-key="LOTTERY_CHANNEL">
+                        <label>
+                            Announce channel id (optional)
+                            <span class="config-hint">
+                                Channel id for the daily close+open ping. Falls back to
+                                LEADERBOARD_CHANNEL, then the guild's system channel.
+                                Leave blank to use the fallback chain.
+                            </span>
+                        </label>
+                        <input type="text"
+                               th:value="${overview.config['LOTTERY_CHANNEL']}"
+                               placeholder="(channel id)"
+                               th:disabled="${!isOwner}">
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
                 </div>
             </details>
 


### PR DESCRIPTION
## Summary

Two follow-ups to #414's WEIGHTED daily-mode option, closing the "lone engager sweeps the seeded pool" hole and adding the channel announcement / winner ping flow.

### 1. Participation safeguard (`LOTTERY_DAILY_MIN_BUYERS`)

The gap WEIGHTED mode opened: with one buyer, the top-3 weighted draw still pays them 50% of the pool. At a 5% seed off a 200k pool that's ~4.7k credits gifted to a single engaged user — exactly what we wanted to prevent.

New per-guild config `LOTTERY_DAILY_MIN_BUYERS` (default **2**, range `[1, 50]`, configurable). Below this many *distinct* `discord_id`s, the daily draw returns the new `BelowMinBuyers` outcome variant — caller's existing `NoTickets` handling (cancel + refund all buyers + return seed to jackpot) kicks in. Distinct buyers, not total tickets, so a single user buying multiple tickets can't trick the gate.

`1` disables the safeguard for guilds that explicitly want the old behaviour.

### 2. Channel announcer (`LOTTERY_CHANNEL`)

`LotteryAnnouncer` posts a combined "yesterday's draw / today's draw" embed after each daily cycle. Winners get pinged via `.addContent("<@id>")` (loud notification); non-winning variants skip the ping entirely so a buyer-less day stays quiet.

Channel resolution mirrors `MonthlyLeaderboardJob`:

1. `LOTTERY_CHANNEL` if set and writable
2. `LEADERBOARD_CHANNEL` fallback (one configured channel can carry both)
3. `guild.systemChannel` if writable
4. Skip with warn log

Per-variant embed copy:
- **MatchDrawn**: winning numbers + tier-by-tier winners (`5/5: <@1> — 600 credits`)
- **WeightedDrawn**: top-3 placements (`1st: <@1> — 500 credits`)
- **BelowMinBuyers**: "Only **1** buyer(s) — need **2**. Refunded; seed returned to jackpot."
- **NoTickets**: "No tickets bought. Seed returned to jackpot."

### Wiring choices

`LotteryDailyJob` now captures prior outcome + open summary into a `CycleResult`, hands them to the announcer, then marks-ran. The moderation **Force draw now** button preserves `BelowMinBuyers` info in its response payload (`priorBelowMinBuyers` / `priorBuyersHave` / `priorBuyersNeed`) so the admin toast explains what happened, but doesn't call the announcer — `web` module doesn't depend on `discord-bot`, and force-draw is admin debug, not a public ping. The cron is the canonical announce path.

## Test plan

- [ ] CI: `./gradlew build`
- [ ] Unit: `JackpotLotteryServiceTest` — 4 new cases (1 buyer + threshold 2 → BelowMinBuyers; threshold 1 disables; both modes)
- [ ] Unit: `LotteryAnnouncerTest` (new) — channel resolution chain, embed copy per variant, ping behaviour
- [ ] Unit: `LotteryDailyJobTest` — 4 new cases (announcer wired, BelowMinBuyers cancel-refund-announce-mark path, both modes)
- [ ] Manual on test guild:
  - Set `LOTTERY_DAILY_MIN_BUYERS=2`, `LOTTERY_CHANNEL=<channel>`, `LOTTERY_DAILY_MODE=WEIGHTED`
  - Buy 1 ticket as one user → force-draw → channel post says "1 buyer (need 2), refunded", no ping; buyer's wallet restored, jackpot back to where it was
  - Buy with 2 distinct users → force-draw → top-3 ping fires, announcement lists payouts, jackpot drains
  - Set `LOTTERY_CHANNEL=` empty → confirm fallback to `LEADERBOARD_CHANNEL`, then `systemChannel`
- [ ] For the live 6-user server: keep `MODE=WEIGHTED`, `MIN_BUYERS=2`, point `LOTTERY_CHANNEL` at the casino chat. Single-engagement days no-op cleanly. Two-or-more-engagement days drain ~9k/day with a public ping.

https://claude.ai/code/session_019SKJtWEuw7wSpYVHg1r3oF

---
_Generated by [Claude Code](https://claude.ai/code/session_019SKJtWEuw7wSpYVHg1r3oF)_