### PR TITLE
feat(casino): mode-aware lottery copy, /lottery picker, Hold'em URL move

### DIFF
--- a/web/src/main/kotlin/web/controller/CasinoHoldemController.kt
+++ b/web/src/main/kotlin/web/controller/CasinoHoldemController.kt
@@ -6,13 +6,8 @@ import database.poker.CasinoHoldemTableRegistry
 import database.service.CasinoHoldemService
 import database.service.CasinoHoldemService.ActionOutcome
 import database.service.CasinoHoldemService.DealOutcome
-import database.service.JackpotService
-import database.service.UserService
-import net.dv8tion.jda.api.JDA
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
-import org.springframework.security.oauth2.client.OAuth2AuthorizedClient
-import org.springframework.security.oauth2.client.annotation.RegisteredOAuth2AuthorizedClient
 import org.springframework.security.oauth2.core.user.OAuth2User
 import org.springframework.stereotype.Controller
 import org.springframework.ui.Model
@@ -24,88 +19,68 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseBody
 import org.springframework.web.servlet.mvc.support.RedirectAttributes
 import web.casino.CasinoOutcomeMapper
+import web.casino.CasinoPageContext
 import web.casino.CasinoResponseLike
 import web.casino.StakeBounds
+import web.casino.renderMinigamePage
 import web.service.CasinoHoldemWebService
 import web.service.EconomyWebService
 import web.util.WebGuildAccess
-import web.util.discordIdOrNull
-import web.util.displayName
 
 /**
- * Web surface for `/casinoholdem`. Same [CasinoHoldemService] the
- * Discord command uses, plus the same in-memory
- * [CasinoHoldemTableRegistry] — a hand started in Discord can also be
- * played from the web inbox, and vice versa.
+ * Web surface for the per-guild Casino Hold'em page. Same
+ * [CasinoHoldemService] the Discord command uses, plus the same
+ * in-memory [CasinoHoldemTableRegistry] — a hand started in Discord can
+ * also be played from the web, and vice versa.
+ *
+ * URL surface mirrors the rest of the casino minigame family
+ * (`/casino/{guildId}/<game>`), routed via [CasinoPageContext.
+ * renderMinigamePage] so the page model picks up `tobyCoins` /
+ * `marketPrice` / `jackpotPool` for free — same wiring as Baccarat
+ * et al. The dedicated `/casinoholdem/guilds` picker was retired in
+ * favour of the shared [CasinoController] hub at `/casino/guilds`,
+ * which already lists Hold'em alongside the other table games.
  *
  * Pages:
- *   - `GET /casinoholdem/guilds` — guild selector
- *   - `GET /casinoholdem/{guildId}` — solo play page
+ *   - `GET /casino/{guildId}/casinoholdem` — solo play page
  *
  * JSON endpoints (browser polls every ~2s for live updates):
- *   - `GET  /casinoholdem/{guildId}/state`
- *   - `POST /casinoholdem/{guildId}/deal`
- *   - `POST /casinoholdem/{guildId}/action`
+ *   - `GET  /casino/{guildId}/casinoholdem/state`
+ *   - `POST /casino/{guildId}/casinoholdem/deal`
+ *   - `POST /casino/{guildId}/casinoholdem/action`
  */
 @Controller
-@RequestMapping("/casinoholdem")
+@RequestMapping("/casino/{guildId}/casinoholdem")
 class CasinoHoldemController(
     private val service: CasinoHoldemService,
     private val webService: CasinoHoldemWebService,
     private val tableRegistry: CasinoHoldemTableRegistry,
     private val economyWebService: EconomyWebService,
-    private val userService: UserService,
-    private val jackpotService: JackpotService,
-    private val jda: JDA,
+    private val pageContext: CasinoPageContext,
     private val stakeBounds: StakeBounds,
 ) {
 
     private val errors = CasinoOutcomeMapper { msg -> CasinoHoldemActionResponse(ok = false, error = msg) }
 
-    @GetMapping("/guilds")
-    fun guildList(
-        @RegisteredOAuth2AuthorizedClient("discord") client: OAuth2AuthorizedClient,
-        @AuthenticationPrincipal user: OAuth2User,
-        model: Model,
-    ): String {
-        val discordId = user.discordIdOrNull()
-        val guilds = if (discordId != null) {
-            economyWebService.getGuildsWhereUserCanView(client.accessToken.tokenValue, discordId)
-        } else emptyList()
-        model.addAttribute("guilds", guilds)
-        model.addAttribute("username", user.displayName())
-        return "casinoholdem-guilds"
-    }
-
-    @GetMapping("/{guildId}")
+    @GetMapping
     fun page(
         @PathVariable guildId: Long,
         @AuthenticationPrincipal user: OAuth2User,
         model: Model,
         ra: RedirectAttributes,
-    ): String = WebGuildAccess.requireMemberForPage(
-        user, guildId, economyWebService, ra, lobbyPath = "/casinoholdem/guilds"
-    ) { discordId ->
-        val guild = jda.getGuildById(guildId) ?: run {
-            ra.addFlashAttribute("error", "Bot is not in that server.")
-            return@requireMemberForPage "redirect:/casinoholdem/guilds"
-        }
-        val profile = userService.getUserById(discordId, guildId)
-        model.addAttribute("guildId", guildId.toString())
-        model.addAttribute("guildName", guild.name)
-        model.addAttribute("balance", profile?.socialCredit ?: 0L)
-        model.addAttribute("jackpotPool", jackpotService.getPool(guildId))
-        model.addAttribute("jackpotWinPct", jackpotService.winProbabilityDisplay(guildId))
+    ): String = pageContext.renderMinigamePage(
+        user, guildId, economyWebService, model, ra,
+        template = "casinoholdem-solo",
+    ) {
+        val discordId = user.attributes["id"].toString().toLong()
         val (minStake, maxStake) = stakeBounds.casinoHoldem(guildId)
-        model.addAttribute("minStake", minStake)
-        model.addAttribute("maxStake", maxStake)
-        model.addAttribute("callMultiple", CasinoHoldem.CALL_MULTIPLE)
-        model.addAttribute("username", user.displayName())
-        model.addAttribute("myDiscordId", discordId.toString())
-        "casinoholdem-solo"
+        addAttribute("minStake", minStake)
+        addAttribute("maxStake", maxStake)
+        addAttribute("callMultiple", CasinoHoldem.CALL_MULTIPLE)
+        addAttribute("myDiscordId", discordId.toString())
     }
 
-    @GetMapping("/{guildId}/state")
+    @GetMapping("/state")
     @ResponseBody
     fun state(
         @PathVariable guildId: Long,
@@ -121,7 +96,7 @@ class CasinoHoldemController(
         ResponseEntity.ok(view)
     }
 
-    @PostMapping("/{guildId}/deal")
+    @PostMapping("/deal")
     @ResponseBody
     fun deal(
         @PathVariable guildId: Long,
@@ -144,7 +119,7 @@ class CasinoHoldemController(
         }
     }
 
-    @PostMapping("/{guildId}/action")
+    @PostMapping("/action")
     @ResponseBody
     fun action(
         @PathVariable guildId: Long,

--- a/web/src/main/kotlin/web/controller/LotteryController.kt
+++ b/web/src/main/kotlin/web/controller/LotteryController.kt
@@ -183,6 +183,18 @@ data class LotteryViewModel(
     val revenueJackpotPct: Long,
     val daily: DailyView?,
     val weighted: WeightedView?,
+    /** True iff the daily lottery is enabled in moderation. When false the
+     *  page renders a paused empty-state instead of a stale picker. */
+    val dailyEnabled: Boolean,
+    /** "NUMBER_MATCH" (Pick-X picker + tier table) or "WEIGHTED" (top-3
+     *  weighted draw — shares DOM with the featured-event card and reads
+     *  from `weighted` rather than `daily`). The Featured-event card only
+     *  shows in NUMBER_MATCH mode, since a WEIGHTED daily already occupies
+     *  the single weighted-row slot. */
+    val dailyMode: String,
+    /** Convenience: true when `dailyMode == "WEIGHTED"`. Avoids string
+     *  comparisons in Thymeleaf. */
+    val isDailyWeighted: Boolean,
 ) {
     data class DailyView(
         val pool: Long,
@@ -252,6 +264,9 @@ data class LotteryViewModel(
                 revenueJackpotPct = snap.revenueJackpotPct,
                 daily = daily,
                 weighted = weighted,
+                dailyEnabled = snap.dailyEnabled,
+                dailyMode = snap.dailyMode,
+                isDailyWeighted = snap.dailyMode == database.service.LotteryHelper.MODE_WEIGHTED,
             )
         }
 

--- a/web/src/main/kotlin/web/controller/LotteryGuildsController.kt
+++ b/web/src/main/kotlin/web/controller/LotteryGuildsController.kt
@@ -1,0 +1,48 @@
+package web.controller
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient
+import org.springframework.security.oauth2.client.annotation.RegisteredOAuth2AuthorizedClient
+import org.springframework.security.oauth2.core.user.OAuth2User
+import org.springframework.stereotype.Controller
+import org.springframework.ui.Model
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import web.service.EconomyWebService
+import web.util.discordIdOrNull
+import web.util.displayName
+
+/**
+ * Dedicated lottery guild picker, mirroring the Poker / Blackjack /
+ * Casino Hold'em pattern. The casino navbar dropdown lands here so a
+ * user can pick which server they want to play in, then the per-guild
+ * page at `/casino/{guildId}/lottery` ([LotteryController]) takes over.
+ *
+ * Lives in its own controller class because [LotteryController]'s
+ * class-level `@RequestMapping("/casino/{guildId}/lottery")` is path-
+ * variable-anchored and a sibling `/lottery/guilds` `GetMapping` would
+ * fight with it. Reuses [EconomyWebService.getGuildsWhereUserCanView]
+ * for the same mutual-guild filter every other casino-game picker uses.
+ */
+@Controller
+@RequestMapping("/lottery")
+class LotteryGuildsController(
+    private val economyWebService: EconomyWebService,
+) {
+
+    @GetMapping("/guilds")
+    fun guildList(
+        @RegisteredOAuth2AuthorizedClient("discord") client: OAuth2AuthorizedClient,
+        @AuthenticationPrincipal user: OAuth2User,
+        model: Model,
+    ): String {
+        val discordId = user.discordIdOrNull()
+        val guilds = if (discordId != null) {
+            economyWebService.getGuildsWhereUserCanView(client.accessToken.tokenValue, discordId)
+        } else emptyList()
+
+        model.addAttribute("guilds", guilds)
+        model.addAttribute("username", user.displayName())
+        return "lottery-guilds"
+    }
+}

--- a/web/src/main/kotlin/web/service/LotteryWebService.kt
+++ b/web/src/main/kotlin/web/service/LotteryWebService.kt
@@ -25,6 +25,12 @@ class LotteryWebService(
     /**
      * Daily-draw + featured weighted-event snapshot for the page render.
      * Either field can be null when no lottery of that mode is open.
+     *
+     * `dailyMode` + `dailyEnabled` reflect the guild's `LOTTERY_DAILY_*`
+     * config so the page can branch its copy: a WEIGHTED-mode guild
+     * should not see the Pick-5 picker or the 5/4/3/2-match tier table,
+     * and a paused guild (`LOTTERY_DAILY_ENABLED=false`) should see an
+     * explicit empty state instead of a stale picker.
      */
     data class LotteryPageSnapshot(
         val dailyOpen: JackpotLotteryDto?,
@@ -39,6 +45,8 @@ class LotteryWebService(
         val numberMax: Int,
         val tierPercents: List<Int>,
         val revenueJackpotPct: Long,
+        val dailyMode: String,
+        val dailyEnabled: Boolean,
     )
 
     fun snapshot(guildId: Long, discordId: Long): LotteryPageSnapshot {
@@ -68,6 +76,8 @@ class LotteryWebService(
             numberMax = LotteryHelper.MATCH_NUMBER_MAX,
             tierPercents = LotteryHelper.TIER_PCTS_5_4_3_2.toList(),
             revenueJackpotPct = LotteryHelper.dailyRevenueJackpotPct(configService, guildId),
+            dailyMode = LotteryHelper.dailyMode(configService, guildId),
+            dailyEnabled = LotteryHelper.dailyEnabled(configService, guildId),
         )
     }
 

--- a/web/src/main/resources/static/js/casinoholdem-solo.js
+++ b/web/src/main/resources/static/js/casinoholdem-solo.js
@@ -179,7 +179,7 @@
     }
 
     function refreshState() {
-        return fetch("/casinoholdem/" + guildId + "/state", { credentials: "same-origin" })
+        return fetch("/casino/" + guildId + "/casinoholdem/state", { credentials: "same-origin" })
             .then(function (r) {
                 if (r.status === 404) {
                     stopPoll();
@@ -205,7 +205,7 @@
         }
         resultDefer.cancel();
         dealBusy = true;
-        window.TobyApi.postJson("/casinoholdem/" + guildId + "/deal", { stake: stake })
+        window.TobyApi.postJson("/casino/" + guildId + "/casinoholdem/deal", { stake: stake })
             .then(function (b) {
                 if (!b.ok) {
                     errorToast(b.error || "Deal failed.");
@@ -223,7 +223,7 @@
         if (actionBusy) return Promise.resolve();
         actionBusy = true;
         setActionsEnabled(false);
-        return window.TobyApi.postJson("/casinoholdem/" + guildId + "/action", { action: action })
+        return window.TobyApi.postJson("/casino/" + guildId + "/casinoholdem/action", { action: action })
             .then(function (b) {
                 if (!b.ok) {
                     errorToast(b.error || "Action failed.");

--- a/web/src/main/resources/templates/casino-guilds.html
+++ b/web/src/main/resources/templates/casino-guilds.html
@@ -50,7 +50,7 @@
                         <a class="btn-secondary"
                            th:href="@{/blackjack/{id}/solo(id=${g.id})}">🂡 Blackjack</a>
                         <a class="btn-secondary"
-                           th:href="@{/casinoholdem/{id}(id=${g.id})}">♠️ Casino Hold'em</a>
+                           th:href="@{/casino/{id}/casinoholdem(id=${g.id})}">♠️ Casino Hold'em</a>
                         <a class="btn-secondary"
                            th:href="@{/poker/{id}(id=${g.id})}">🃏 Poker</a>
                     </div>

--- a/web/src/main/resources/templates/casinoholdem-solo.html
+++ b/web/src/main/resources/templates/casinoholdem-solo.html
@@ -6,11 +6,11 @@
 <div th:replace="~{fragments/navbar :: navbar}"></div>
 
 <main id="main" class="container"
-      th:attr="data-guild-id=${guildId}, data-min-stake=${minStake}, data-max-stake=${maxStake}, data-call-multiple=${callMultiple}, data-my-discord-id=${myDiscordId}">
+      th:attr="data-guild-id=${guildId}, data-toby-coins=${tobyCoins}, data-market-price=${marketPrice}, data-min-stake=${minStake}, data-max-stake=${maxStake}, data-call-multiple=${callMultiple}, data-my-discord-id=${myDiscordId}">
 
     <div class="che-header">
-        <a class="back-link" th:href="@{/casinoholdem/guilds}">&larr; All servers</a>
-        <h1>🃏 Casino Hold'em</h1>
+        <a class="back-link" th:href="@{/casino/guilds}">&larr; All casino servers</a>
+        <h1 th:text="'🃏 Casino Hold''em • ' + ${guildName}">🃏 Casino Hold'em</h1>
         <p class="muted">
             Bet between <span th:text="${minStake}">10</span> and
             <span th:text="${maxStake}">500</span> credits per hand.
@@ -29,7 +29,13 @@
             <label for="che-stake">Ante (credits)</label>
             <input id="che-stake" name="stake" type="number"
                    th:attr="min=${minStake}, max=${maxStake}" th:value="${minStake}" step="1" required>
-            <button type="submit" class="btn-primary">Deal</button>
+            <div class="che-actions-deal">
+                <button type="submit" id="che-deal-credits" class="btn-primary">Deal</button>
+                <button type="submit" id="che-deal-toby" class="btn-secondary casino-bet-toby" hidden
+                        title="Sells just enough TOBY at the live market price to cover the shortfall, then deals.">
+                    Deal (sell <span class="casino-bet-toby-coins">0</span> TOBY)
+                </button>
+            </div>
         </form>
         <div class="che-balance">
             Wallet: <strong id="che-balance" th:text="${balance}">0</strong> credits
@@ -89,11 +95,7 @@
 
 <div class="toast-stack" id="toast-stack" aria-live="polite"></div>
 
-<script th:src="@{/js/api.js}"></script>
-<script th:src="@{/js/toasts.js}"></script>
-<script th:src="@{/js/casino-sounds.js}"></script>
-<script th:src="@{/js/casino-jackpot.js}"></script>
-<script th:src="@{/js/casino-balance.js}"></script>
+<th:block th:replace="~{fragments/casinoMinigame :: scripts}"></th:block>
 <script th:src="@{/js/casino-render.js}"></script>
 <script th:src="@{/js/casinoholdem-solo.js}"></script>
 </body>

--- a/web/src/main/resources/templates/fragments/navbar.html
+++ b/web/src/main/resources/templates/fragments/navbar.html
@@ -42,7 +42,8 @@
                 <a href="/poker/guilds" role="menuitem">&#127924; Poker</a>
                 <a href="/blackjack/guilds" role="menuitem">&#127922; Blackjack</a>
                 <a href="/casino/guilds" role="menuitem">&#127924; Baccarat</a>
-                <a href="/casinoholdem/guilds" role="menuitem">&#127183; Casino Hold'em</a>
+                <a href="/casino/guilds" role="menuitem">&#127183; Casino Hold'em</a>
+                <a href="/lottery/guilds" role="menuitem">&#127903;&#65039; Lottery</a>
             </div>
         </div>
         <a href="/intro/guilds">Intro Songs</a>

--- a/web/src/main/resources/templates/lottery-guilds.html
+++ b/web/src/main/resources/templates/lottery-guilds.html
@@ -1,17 +1,16 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org" lang="en">
-<head th:replace="~{fragments/head :: head('TobyBot - Casino Hold\'em', '/css/leaderboard.css')}"></head>
+<head th:replace="~{fragments/head :: head('TobyBot - Lottery', '/css/leaderboard.css')}"></head>
 <body>
 <a href="#main" class="skip-link">Skip to content</a>
 <div th:replace="~{fragments/navbar :: navbar}"></div>
 
 <main id="main" class="container">
-    <h1 class="mb-3">🃏 Casino Hold'em</h1>
+    <h1 class="mb-3">🎟️ Lottery</h1>
     <p class="muted mb-5">
-        Heads-up Texas Hold'em against the house. Ante, see the flop,
-        then call (2× stake) or fold. Dealer must hold a pair of fours
-        or better to qualify; standard Casino Hold'em paytable on the
-        call leg.
+        Daily prize draw — pick numbers in NUMBER_MATCH mode, or buy weighted
+        tickets if your server admin opted into WEIGHTED. Every ticket also
+        feeds the per-server jackpot pool.
     </p>
 
     <div th:replace="~{fragments/alerts :: error}"></div>
@@ -35,14 +34,14 @@
                 <span th:text="${g.credits} + ' credits'">0 credits</span>
             </div>
             <div class="lb-guild-games">
-                <a class="btn-secondary" th:href="@{/casinoholdem/{id}(id=${g.id})}">Play</a>
+                <a class="btn-secondary" th:href="@{/casino/{id}/lottery(id=${g.id})}">Play</a>
             </div>
         </div>
     </div>
 
     <div class="empty-hero" th:if="${#lists.isEmpty(guilds)}">
-        <span class="emoji" aria-hidden="true">🃏</span>
-        <h2>No servers to play Casino Hold'em in yet</h2>
+        <span class="emoji" aria-hidden="true">🎟️</span>
+        <h2>No servers to play the lottery in yet</h2>
         <p class="mb-5">
             You need to share at least one server with TobyBot to play.
         </p>

--- a/web/src/main/resources/templates/lottery.html
+++ b/web/src/main/resources/templates/lottery.html
@@ -14,14 +14,29 @@
                data-revenue-jackpot-pct=${snapshot.revenueJackpotPct}">
 
     <div class="lottery-header">
-        <a class="back-link" th:href="@{/casino/guilds}">&larr; All casino servers</a>
+        <a class="back-link" th:href="@{/lottery/guilds}">&larr; All servers</a>
         <h1 th:text="'🎟️ Lottery • ' + ${guildName}">🎟️ Lottery</h1>
-        <p class="muted">
+        <!-- Mode-aware blurb: NUMBER_MATCH (Pick-X) vs WEIGHTED (top-3
+             weighted draw) reflects the guild's LOTTERY_DAILY_MODE
+             config. Disabled guilds get a paused-state explainer that
+             tells the user to ask an admin. -->
+        <p class="muted" th:if="${!snapshot.dailyEnabled}">
+            Daily lottery is paused on this server. Ask a server admin to
+            re-enable it on the moderation page.
+        </p>
+        <p class="muted" th:if="${snapshot.dailyEnabled and !snapshot.isDailyWeighted}">
             Pick <strong th:text="${snapshot.pickCount}">5</strong> numbers from
             <strong>1–<span th:text="${snapshot.numberMax}">49</span></strong> for the daily draw.
             <strong th:text="${snapshot.revenueJackpotPct}">30</strong>% of every ticket feeds the
             per-server jackpot pool above; the remainder grows today's prize. Match more numbers,
             win bigger.
+        </p>
+        <p class="muted" th:if="${snapshot.dailyEnabled and snapshot.isDailyWeighted}">
+            Weighted daily draw — every ticket is one entry, and three winners are picked at
+            close-time weighted by ticket count, sharing the pool
+            <strong>50 / 30 / 20</strong> by tier.
+            <strong th:text="${snapshot.revenueJackpotPct}">30</strong>% of every ticket feeds the
+            per-server jackpot pool above; the remainder grows today's prize.
         </p>
     </div>
 
@@ -29,9 +44,28 @@
     <div th:replace="~{fragments/casino :: jackpotBanner}"></div>
 
     <!-- ========================================================== -->
-    <!-- Today's daily match-numbers draw                            -->
+    <!-- Daily lottery is paused — short-circuit the whole body      -->
+    <!-- with a one-card explainer; admin needs to flip ENABLED back -->
+    <!-- on in moderation. We don't render any picker/buy form so a  -->
+    <!-- stray click can't hit a buy endpoint that would 4xx anyway. -->
     <!-- ========================================================== -->
-    <section class="lottery-daily casino-felt">
+    <section class="lottery-daily casino-felt" th:if="${!snapshot.dailyEnabled}">
+        <header class="lottery-daily-header">
+            <h2>Today's draw</h2>
+            <p class="muted">
+                The daily lottery is currently disabled on this server. Check back once a
+                server admin re-enables it from the moderation page.
+            </p>
+        </header>
+    </section>
+
+    <!-- ========================================================== -->
+    <!-- NUMBER_MATCH daily — Pick X of Y picker, my-ticket panel,   -->
+    <!-- last-result panel. Reads from snapshot.daily (the open or   -->
+    <!-- last-drawn MODE_NUMBER_MATCH row).                          -->
+    <!-- ========================================================== -->
+    <section class="lottery-daily casino-felt"
+             th:if="${snapshot.dailyEnabled and !snapshot.isDailyWeighted}">
         <header class="lottery-daily-header">
             <h2>Today's draw</h2>
             <div class="lottery-daily-meta" th:if="${snapshot.daily != null}">
@@ -131,9 +165,76 @@
     </section>
 
     <!-- ========================================================== -->
-    <!-- Featured event — admin-fired weighted lottery (when open)   -->
+    <!-- WEIGHTED daily — every ticket is one entry, top-3 by weight -->
+    <!-- share 50/30/20 of the pool. Reuses snapshot.weighted (same  -->
+    <!-- DOM as the featured-event card from NUMBER_MATCH mode), but -->
+    <!-- labelled as "Today's draw" because in WEIGHTED mode this    -->
+    <!-- IS the daily, not a one-off featured event.                 -->
     <!-- ========================================================== -->
-    <section class="lottery-weighted" th:if="${snapshot.weighted != null}">
+    <section class="lottery-weighted casino-felt"
+             th:if="${snapshot.dailyEnabled and snapshot.isDailyWeighted}">
+        <header class="lottery-daily-header">
+            <h2>Today's draw</h2>
+            <div class="lottery-weighted-meta" th:if="${snapshot.weighted != null}">
+                <span class="lottery-meta-item">
+                    Prize pool:
+                    <strong id="weighted-pool" th:text="${snapshot.weighted.pool}">0</strong>
+                    <span class="muted">credits</span>
+                </span>
+                <span class="lottery-meta-item">
+                    Ticket: <strong th:text="${snapshot.weighted.ticketPrice}">50</strong>
+                    <span class="muted">credits</span>
+                </span>
+                <span class="lottery-meta-item">
+                    Tickets sold:
+                    <strong th:text="${snapshot.weighted.totalTickets}">0</strong>
+                </span>
+                <span class="lottery-meta-item">
+                    Your tickets:
+                    <strong id="weighted-my-tickets" th:text="${snapshot.weighted.myTickets}">0</strong>
+                </span>
+                <span class="lottery-meta-item lottery-countdown"
+                      th:attr="data-closes-at=${snapshot.weighted.closesAtMillis}">
+                    Closes in <strong class="lottery-countdown-value">--:--:--</strong>
+                </span>
+            </div>
+            <p class="muted" th:if="${snapshot.weighted == null}">
+                No draw is open right now — check back soon. (The cycle opens at 00:00 UTC.)
+            </p>
+        </header>
+
+        <form id="lottery-weighted-bet" autocomplete="off"
+              th:if="${snapshot.weighted != null}">
+            <label for="weighted-count">Tickets to buy</label>
+            <input id="weighted-count" name="count" type="number" min="1" value="1" required>
+            <button type="submit" id="weighted-buy" class="btn-primary">
+                Buy <span class="muted">(at <strong th:text="${snapshot.weighted.ticketPrice}">50</strong>/ticket)</span>
+            </button>
+            <div class="lottery-balance">
+                Wallet: <strong id="lottery-balance" th:text="${balance}">0</strong> credits
+            </div>
+        </form>
+
+        <div class="lottery-weighted-holders"
+             th:if="${snapshot.weighted != null and !#lists.isEmpty(snapshot.weighted.topHolders)}">
+            <h3>Top holders</h3>
+            <ol class="lottery-top-holders">
+                <li th:each="h : ${snapshot.weighted.topHolders}">
+                    <span class="muted">User #<span th:text="${h.discordId}">…</span></span>
+                    — <strong th:text="${h.ticketCount}">0</strong> tickets
+                </li>
+            </ol>
+        </div>
+    </section>
+
+    <!-- ========================================================== -->
+    <!-- Featured event — admin-fired weighted lottery (when open).  -->
+    <!-- Only shows in NUMBER_MATCH-daily mode, since a WEIGHTED     -->
+    <!-- daily already occupies the single weighted-row slot upstairs -->
+    <!-- and there can't be two opens of the same mode at once.      -->
+    <!-- ========================================================== -->
+    <section class="lottery-weighted"
+             th:if="${snapshot.dailyEnabled and !snapshot.isDailyWeighted and snapshot.weighted != null}">
         <h2>🌟 Featured event • Weighted draw</h2>
         <p class="muted">
             Special admin-fired lottery — every ticket is a weight in the draw, and
@@ -143,7 +244,7 @@
         <div class="lottery-weighted-meta">
             <span class="lottery-meta-item">
                 Prize pool:
-                <strong id="weighted-pool" th:text="${snapshot.weighted.pool}">0</strong>
+                <strong id="featured-pool" th:text="${snapshot.weighted.pool}">0</strong>
                 <span class="muted">credits</span>
             </span>
             <span class="lottery-meta-item">
@@ -156,17 +257,17 @@
             </span>
             <span class="lottery-meta-item">
                 Your tickets:
-                <strong id="weighted-my-tickets" th:text="${snapshot.weighted.myTickets}">0</strong>
+                <strong id="featured-my-tickets" th:text="${snapshot.weighted.myTickets}">0</strong>
             </span>
             <span class="lottery-meta-item lottery-countdown"
                   th:attr="data-closes-at=${snapshot.weighted.closesAtMillis}">
                 Closes in <strong class="lottery-countdown-value">--:--:--</strong>
             </span>
         </div>
-        <form id="lottery-weighted-bet" autocomplete="off">
-            <label for="weighted-count">Tickets to buy</label>
-            <input id="weighted-count" name="count" type="number" min="1" value="1" required>
-            <button type="submit" id="weighted-buy" class="btn-primary">
+        <form id="lottery-featured-bet" autocomplete="off">
+            <label for="featured-count">Tickets to buy</label>
+            <input id="featured-count" name="count" type="number" min="1" value="1" required>
+            <button type="submit" id="featured-buy" class="btn-primary">
                 Buy <span class="muted">(at <strong th:text="${snapshot.weighted.ticketPrice}">100</strong>/ticket)</span>
             </button>
         </form>
@@ -182,9 +283,12 @@
     </section>
 
     <!-- ========================================================== -->
-    <!-- Payout schedule                                             -->
+    <!-- Payout schedule — NUMBER_MATCH tier table (5/4/3/2 matches) -->
+    <!-- only renders for NUMBER_MATCH-mode dailies. WEIGHTED mode   -->
+    <!-- gets a 50/30/20 top-3 schedule instead.                     -->
     <!-- ========================================================== -->
-    <section class="lottery-payouts">
+    <section class="lottery-payouts"
+             th:if="${snapshot.dailyEnabled and !snapshot.isDailyWeighted}">
         <h2>How payouts work</h2>
         <p class="muted">
             The day's prize pool splits across match tiers. 0 or 1 matches pay nothing —
@@ -216,6 +320,33 @@
                     <td><strong>0%</strong></td>
                     <td class="muted">Lose stake — funds tomorrow's pool.</td>
                 </tr>
+            </tbody>
+        </table>
+    </section>
+
+    <section class="lottery-payouts"
+             th:if="${snapshot.dailyEnabled and snapshot.isDailyWeighted}">
+        <h2>How payouts work</h2>
+        <p class="muted">
+            Three winners are picked at close-time, weighted by how many tickets each user holds.
+            More tickets = higher chance of being drawn (and of being drawn into a higher tier).
+            Empty tiers and rounding remainders roll back into the per-server jackpot pool.
+        </p>
+        <table class="lottery-tier-table">
+            <thead>
+                <tr>
+                    <th>Tier</th>
+                    <th>Prize pool share</th>
+                    <th>Notes</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr><td><strong>1st</strong></td><td><strong>50%</strong></td>
+                    <td class="muted">Top tier — drawn first, weighted by ticket count.</td></tr>
+                <tr><td><strong>2nd</strong></td><td><strong>30%</strong></td>
+                    <td class="muted">Second tier — remaining holders re-weighted after 1st is removed.</td></tr>
+                <tr><td><strong>3rd</strong></td><td><strong>20%</strong></td>
+                    <td class="muted">Third tier — same.</td></tr>
             </tbody>
         </table>
     </section>

--- a/web/src/test/kotlin/web/controller/CasinoHoldemControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/CasinoHoldemControllerTest.kt
@@ -9,11 +9,8 @@ import database.poker.CasinoHoldemTableRegistry
 import database.service.CasinoHoldemService
 import database.service.CasinoHoldemService.ActionOutcome
 import database.service.CasinoHoldemService.DealOutcome
-import database.service.JackpotService
-import database.service.UserService
 import io.mockk.every
 import io.mockk.mockk
-import net.dv8tion.jda.api.JDA
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
@@ -21,6 +18,7 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.security.oauth2.core.user.OAuth2User
+import web.casino.CasinoPageContext
 import web.casino.StakeBounds
 import web.service.CasinoHoldemWebService
 import web.service.EconomyWebService
@@ -35,9 +33,7 @@ class CasinoHoldemControllerTest {
     private lateinit var webService: CasinoHoldemWebService
     private lateinit var registry: CasinoHoldemTableRegistry
     private lateinit var economyWebService: EconomyWebService
-    private lateinit var userService: UserService
-    private lateinit var jackpotService: JackpotService
-    private lateinit var jda: JDA
+    private lateinit var pageContext: CasinoPageContext
     private lateinit var stakeBounds: StakeBounds
     private lateinit var user: OAuth2User
     private lateinit var controller: CasinoHoldemController
@@ -48,9 +44,7 @@ class CasinoHoldemControllerTest {
         webService = mockk(relaxed = true)
         registry = mockk(relaxed = true)
         economyWebService = mockk(relaxed = true)
-        userService = mockk(relaxed = true)
-        jackpotService = mockk(relaxed = true)
-        jda = mockk(relaxed = true)
+        pageContext = mockk(relaxed = true)
         stakeBounds = mockk(relaxed = true)
         user = mockk {
             every { getAttribute<String>("id") } returns discordId.toString()
@@ -62,9 +56,7 @@ class CasinoHoldemControllerTest {
             webService = webService,
             tableRegistry = registry,
             economyWebService = economyWebService,
-            userService = userService,
-            jackpotService = jackpotService,
-            jda = jda,
+            pageContext = pageContext,
             stakeBounds = stakeBounds,
         )
     }

--- a/web/src/test/kotlin/web/controller/LotteryControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/LotteryControllerTest.kt
@@ -217,6 +217,8 @@ class LotteryControllerTest {
             numberMax = 49,
             tierPercents = listOf(60, 25, 10, 5),
             revenueJackpotPct = 30L,
+            dailyMode = "NUMBER_MATCH",
+            dailyEnabled = true,
         )
 
         val vm = LotteryViewModel.from(snap)
@@ -243,6 +245,8 @@ class LotteryControllerTest {
             numberMax = 49,
             tierPercents = listOf(60, 25, 10, 5),
             revenueJackpotPct = 30L,
+            dailyMode = "NUMBER_MATCH",
+            dailyEnabled = true,
         )
 
         val vm = LotteryViewModel.from(snap)


### PR DESCRIPTION
## Summary

Three navigation/copy fixes that share a theme — features added at different times never re-aligned with the canonical patterns the rest of the casino settled on. Tackled together because they touch the same navbar, casino hub, and minigame template family.

### 1. Mode + enabled-aware lottery copy

A guild that flipped `LOTTERY_DAILY_MODE` to `WEIGHTED` in moderation still saw the page hardcoded to "Pick 5 of 49" and a 5/4/3/2-match tier table. A guild with `LOTTERY_DAILY_ENABLED=false` saw the same Pick-5 picker with no signal that the admin paused it.

- `LotteryWebService.LotteryPageSnapshot` exposes `dailyMode` + `dailyEnabled` (existing `LotteryHelper` helpers, no new reads).
- `LotteryViewModel` adds `isDailyWeighted` so Thymeleaf doesn't string-compare.
- `lottery.html` branches three ways: paused empty-state when disabled; existing NUMBER_MATCH picker + tier table; weighted-draw "Today's draw" card (sourced from `snapshot.weighted`) + 50/30/20 top-3 payout schedule when `dailyMode=WEIGHTED`. The "Featured event" card only renders in NUMBER_MATCH mode since a WEIGHTED daily already occupies the single weighted-row slot.

### 2. Lottery in navbar + dedicated `/lottery/guilds` picker

Lottery was the only Casino dropdown game without a navbar entry. Followed the Poker/Blackjack/Hold'em pattern (own picker page) per user preference.

- New `LotteryGuildsController` → `GET /lottery/guilds`.
- New `lottery-guilds.html` cloned from the (now-retired) `casinoholdem-guilds.html`.
- `navbar.html` Casino dropdown gains `🎟️ Lottery → /lottery/guilds`.

### 3. Casino Hold'em URL + template normalization

Hold'em was the only minigame still on `/casinoholdem/*` while every other casino game lives at `/casino/{guildId}/<game>`. Its template hardcoded 7 `<script>` tags, lacked `data-toby-coins` / `data-market-price`, had no "Deal (sell TOBY)" topup button, and the controller hand-rolled model attributes.

- `@RequestMapping` moved to `/casino/{guildId}/casinoholdem`. Per-method paths drop their redundant `{guildId}` segments.
- `controller.page()` goes through `pageContext.renderMinigamePage` — same wiring as LotteryController / BlackjackController. `tobyCoins` + `marketPrice` land on the model automatically.
- Dedicated `/casinoholdem/guilds` picker retired — `casino-guilds.html` already lists Hold'em alongside other table games. `casinoholdem-guilds.html` deleted.
- `casinoholdem-solo.html`: back-link → `/casino/guilds`, data-attrs gain `data-toby-coins` + `data-market-price`, deal form gains the "Deal (sell TOBY)" topup button (verbatim shape from baccarat), scripts swap to the shared `fragments/casinoMinigame :: scripts` block, header gains `• {guildName}` to match the rest of the family.
- `casinoholdem-solo.js`: three fetch URL rewrites (state, deal, action) under the new prefix.
- `casino-guilds.html`: Hold'em link rewritten.
- `navbar.html`: "Casino Hold'em" link redirected to `/casino/guilds` since the dedicated picker is gone — matches Slots / Coinflip / Dice etc.
- `CasinoHoldemControllerTest`: constructor swap (the helper covers `userService` / `jackpotService` / `jda`).

Discord-side `/casinoholdem` slash command + button + embed are untouched — they reference the Discord command name, not web URLs.

## Test plan

- [x] `:web:test` passes locally.
- [ ] Lottery copy — NUMBER_MATCH guild renders existing Pick-5 picker + tier table.
- [ ] Lottery copy — flip `LOTTERY_DAILY_MODE=WEIGHTED` → header copy + weighted buy form + 50/30/20 schedule replace the picker / tier table; "Featured event" card no longer renders.
- [ ] Lottery copy — flip `LOTTERY_DAILY_ENABLED=false` → page shows the paused empty state, no picker, no tier table.
- [ ] `/lottery/guilds` picker reachable from the navbar dropdown; "Play" → `/casino/{id}/lottery`.
- [ ] Casino Hold'em — from `/casino/guilds` click "Casino Hold'em" → lands on `/casino/{id}/casinoholdem`. Page mirrors baccarat's structure (back-link to hub, header includes guildName, topup button visible when shortfall, jackpot banner present). Deal + call/fold flow continues to work via the live state poll.

https://claude.ai/code/session_019SKJtWEuw7wSpYVHg1r3oF

---
_Generated by [Claude Code](https://claude.ai/code/session_019SKJtWEuw7wSpYVHg1r3oF)_