### PR TITLE
feat(casino): Discord channel logs for anti-autoclick session activity

### DIFF
--- a/common/src/main/kotlin/common/events/AntiAutoclickEvent.kt
+++ b/common/src/main/kotlin/common/events/AntiAutoclickEvent.kt
@@ -1,0 +1,56 @@
+package common.events
+
+/**
+ * Lifecycle of a per-user, per-game anti-autoclicker suspicion session.
+ *
+ * Published via Spring's `ApplicationEventPublisher` from
+ * `database.service.CasinoBotSuspicionService` (open/close — streak transitions)
+ * and `database.service.CasinoEdgeService` (fire — forced-loss substitution).
+ *
+ * The discord-bot module owns one listener (`AntiAutoclickNotifier`) that posts
+ * a single embed when a session opens, edits it in place on every fire (with
+ * a debounce so a saturated burst can't hit per-channel edit rate limits),
+ * and finalises the message when the session closes. One session message per
+ * `(guildId, discordId, gameKey)` triple.
+ */
+sealed interface AntiAutoclickEvent {
+    val guildId: Long
+    val discordId: Long
+    val gameKey: String
+
+    /**
+     * Streak transitioned from 0 → ≥1 — the heuristic just started suspecting
+     * this `(user, guild, gameKey)`. `streak` is the new streak value (1 in
+     * practice, but typed as Int to keep the listener general).
+     */
+    data class SessionOpened(
+        override val guildId: Long,
+        override val discordId: Long,
+        override val gameKey: String,
+        val streak: Int,
+    ) : AntiAutoclickEvent
+
+    /**
+     * `CasinoEdgeService` substituted a fair outcome with a forced loss for
+     * this user. `streak` is the streak that drove the substitution; `edgePct`
+     * is the effective house-edge percentage that fired (0–50, post-cap).
+     */
+    data class BiasFired(
+        override val guildId: Long,
+        override val discordId: Long,
+        override val gameKey: String,
+        val streak: Int,
+        val edgePct: Double,
+    ) : AntiAutoclickEvent
+
+    /**
+     * Streak transitioned from ≥1 → 0 — the user supplied a non-bot-like
+     * signal (different pixel, mouse motion, or null/other-modality input).
+     * The notifier finalises the open session message with a summary.
+     */
+    data class SessionClosed(
+        override val guildId: Long,
+        override val discordId: Long,
+        override val gameKey: String,
+    ) : AntiAutoclickEvent
+}

--- a/database/src/main/kotlin/database/dto/ConfigDto.kt
+++ b/database/src/main/kotlin/database/dto/ConfigDto.kt
@@ -194,6 +194,14 @@ class ConfigDto(
         DICE_BOT_EDGE_MAX_PCT("DICE_BOT_EDGE_MAX_PCT"),
         SLOTS_BOT_EDGE_MAX_PCT("SLOTS_BOT_EDGE_MAX_PCT"),
 
+        // Per-guild text-channel ID where anti-autoclicker session embeds
+        // are posted: one message per suspicion session, edited in place
+        // as forced-loss substitutions accumulate, finalised when the
+        // streak resets. Stored as a stringified Long. Falls back to the
+        // guild's system channel when unset, unparseable, or the bot has
+        // no permission on the configured channel.
+        CASINO_MODLOG_CHANNEL_ID("CASINO_MODLOG_CHANNEL_ID"),
+
         // Daily match-numbers lottery (Pick 5 of 1-49) auto-draw toggle.
         // Boolean ("true"/"false"); defaults to "false" so guilds opt in.
         // When enabled, LotteryDailyJob runs at 00:00 UTC: closes the

--- a/database/src/main/kotlin/database/service/CasinoBotSuspicionService.kt
+++ b/database/src/main/kotlin/database/service/CasinoBotSuspicionService.kt
@@ -1,5 +1,7 @@
 package database.service
 
+import common.events.AntiAutoclickEvent
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
 import java.util.concurrent.ConcurrentHashMap
 
@@ -31,7 +33,9 @@ import java.util.concurrent.ConcurrentHashMap
  * the heuristic warrants.
  */
 @Service
-class CasinoBotSuspicionService {
+class CasinoBotSuspicionService(
+    private val eventPublisher: ApplicationEventPublisher,
+) {
 
     /**
      * Maximum pixel distance between consecutive bet clicks that still
@@ -74,11 +78,17 @@ class CasinoBotSuspicionService {
         // streak so a previously suspicious user gets a clean slate when
         // they switch input modality.
         if (clickX == null || clickY == null || mouseMoved == null) {
-            states.remove(key)
+            val priorEntry = states.remove(key)
+            if ((priorEntry?.streak ?: 0) >= 1) {
+                eventPublisher.publishEvent(
+                    AntiAutoclickEvent.SessionClosed(guildId, discordId, gameKey)
+                )
+            }
             return 0
         }
 
         val prior = states[key]
+        val priorStreak = prior?.streak ?: 0
         val newStreak = if (
             prior != null &&
             !mouseMoved &&
@@ -90,6 +100,15 @@ class CasinoBotSuspicionService {
             0
         }
         states[key] = State(lastX = clickX, lastY = clickY, streak = newStreak)
+        if (priorStreak == 0 && newStreak >= 1) {
+            eventPublisher.publishEvent(
+                AntiAutoclickEvent.SessionOpened(guildId, discordId, gameKey, newStreak)
+            )
+        } else if (priorStreak >= 1 && newStreak == 0) {
+            eventPublisher.publishEvent(
+                AntiAutoclickEvent.SessionClosed(guildId, discordId, gameKey)
+            )
+        }
         return newStreak
     }
 

--- a/database/src/main/kotlin/database/service/CasinoEdgeService.kt
+++ b/database/src/main/kotlin/database/service/CasinoEdgeService.kt
@@ -1,6 +1,8 @@
 package database.service
 
+import common.events.AntiAutoclickEvent
 import database.dto.ConfigDto
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
 import kotlin.random.Random
 
@@ -27,6 +29,7 @@ import kotlin.random.Random
 class CasinoEdgeService(
     private val botSuspicionService: CasinoBotSuspicionService,
     private val configService: ConfigService,
+    private val eventPublisher: ApplicationEventPublisher,
     private val random: Random = Random.Default,
 ) {
 
@@ -67,6 +70,15 @@ class CasinoEdgeService(
         val houseEdge = (streak * EDGE_PCT_PER_STREAK / 100.0)
             .coerceIn(0.0, maxEdgePct / 100.0)
         if (houseEdge > 0.0 && random.nextDouble() < houseEdge) {
+            eventPublisher.publishEvent(
+                AntiAutoclickEvent.BiasFired(
+                    guildId = guildId,
+                    discordId = discordId,
+                    gameKey = gameKey,
+                    streak = streak,
+                    edgePct = houseEdge * 100.0,
+                )
+            )
             return asLoss()
         }
         return fairOutcome

--- a/database/src/test/kotlin/database/service/CasinoBotSuspicionServiceTest.kt
+++ b/database/src/test/kotlin/database/service/CasinoBotSuspicionServiceTest.kt
@@ -1,12 +1,17 @@
 package database.service
 
+import common.events.AntiAutoclickEvent
+import io.mockk.mockk
+import io.mockk.verify
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.springframework.context.ApplicationEventPublisher
 
 class CasinoBotSuspicionServiceTest {
 
     private lateinit var service: CasinoBotSuspicionService
+    private lateinit var eventPublisher: ApplicationEventPublisher
 
     private val discordId = 100L
     private val guildId = 200L
@@ -14,7 +19,8 @@ class CasinoBotSuspicionServiceTest {
 
     @BeforeEach
     fun setup() {
-        service = CasinoBotSuspicionService()
+        eventPublisher = mockk(relaxed = true)
+        service = CasinoBotSuspicionService(eventPublisher)
     }
 
     @Test
@@ -136,5 +142,137 @@ class CasinoBotSuspicionServiceTest {
         assertEquals(1, service.recordAndScore(discordId, guildId, "dice", 100, 200, false))
         // Slots starts fresh too.
         assertEquals(0, service.recordAndScore(discordId, guildId, "slots", 100, 200, false))
+    }
+
+    // -------- Anti-autoclick event publishing --------
+
+    @Test
+    fun `publishes SessionOpened exactly once on the 0-to-1 transition`() {
+        // First call seeds state at streak=0; second matching call transitions
+        // to streak=1 — that's the moment we want a "session opened" event.
+        service.recordAndScore(discordId, guildId, game, 100, 200, false)
+        service.recordAndScore(discordId, guildId, game, 100, 200, false)
+
+        verify(exactly = 1) {
+            eventPublisher.publishEvent(
+                AntiAutoclickEvent.SessionOpened(guildId, discordId, game, streak = 1)
+            )
+        }
+    }
+
+    @Test
+    fun `does not republish SessionOpened on subsequent streak increments`() {
+        // Streak climbs 0 → 1 → 2 → 3. Only the first transition fires
+        // SessionOpened; the rest are silent.
+        service.recordAndScore(discordId, guildId, game, 100, 200, false)
+        service.recordAndScore(discordId, guildId, game, 100, 200, false)
+        service.recordAndScore(discordId, guildId, game, 100, 200, false)
+        service.recordAndScore(discordId, guildId, game, 100, 200, false)
+
+        verify(exactly = 1) {
+            eventPublisher.publishEvent(ofType<AntiAutoclickEvent.SessionOpened>())
+        }
+        verify(exactly = 0) {
+            eventPublisher.publishEvent(ofType<AntiAutoclickEvent.SessionClosed>())
+        }
+    }
+
+    @Test
+    fun `publishes SessionClosed when streak resets via different pixel`() {
+        // Build streak 0 → 1 → 2, then jump pixel beyond epsilon → reset to 0.
+        // SessionClosed should fire on that close.
+        service.recordAndScore(discordId, guildId, game, 100, 200, false)
+        service.recordAndScore(discordId, guildId, game, 100, 200, false)
+        service.recordAndScore(discordId, guildId, game, 100, 200, false)
+        service.recordAndScore(discordId, guildId, game, 500, 600, false)
+
+        verify(exactly = 1) {
+            eventPublisher.publishEvent(
+                AntiAutoclickEvent.SessionClosed(guildId, discordId, game)
+            )
+        }
+    }
+
+    @Test
+    fun `publishes SessionClosed when streak resets via mouseMoved=true`() {
+        service.recordAndScore(discordId, guildId, game, 100, 200, false)
+        service.recordAndScore(discordId, guildId, game, 100, 200, false)
+        service.recordAndScore(discordId, guildId, game, 100, 200, mouseMoved = true)
+
+        verify(exactly = 1) {
+            eventPublisher.publishEvent(
+                AntiAutoclickEvent.SessionClosed(guildId, discordId, game)
+            )
+        }
+    }
+
+    @Test
+    fun `publishes SessionClosed when streak resets via null signal`() {
+        service.recordAndScore(discordId, guildId, game, 100, 200, false)
+        service.recordAndScore(discordId, guildId, game, 100, 200, false)
+        service.recordAndScore(discordId, guildId, game, null, 200, false)
+
+        verify(exactly = 1) {
+            eventPublisher.publishEvent(
+                AntiAutoclickEvent.SessionClosed(guildId, discordId, game)
+            )
+        }
+    }
+
+    @Test
+    fun `does not publish SessionClosed when streak was already 0`() {
+        // No streak ever opened → null signal should not fire SessionClosed.
+        // This is the Discord-bet-only path; no bogus close events.
+        service.recordAndScore(discordId, guildId, game, null, null, null)
+        service.recordAndScore(discordId, guildId, game, 100, 200, mouseMoved = true)
+        service.recordAndScore(discordId, guildId, game, 500, 600, false)
+
+        verify(exactly = 0) {
+            eventPublisher.publishEvent(ofType<AntiAutoclickEvent.SessionClosed>())
+        }
+    }
+
+    @Test
+    fun `publishes no events when streak stays at 0 across calls`() {
+        // Single bet → streak 0 → no transitions, no events at all.
+        service.recordAndScore(discordId, guildId, game, 100, 200, false)
+
+        verify(exactly = 0) { eventPublisher.publishEvent(ofType<AntiAutoclickEvent>()) }
+    }
+
+    @Test
+    fun `re-opens a fresh session after a close-then-build cycle`() {
+        // Open, close, then build back up — should fire one Open, one Close,
+        // then a second Open as the streak ramps up again.
+        service.recordAndScore(discordId, guildId, game, 100, 200, false) // 0
+        service.recordAndScore(discordId, guildId, game, 100, 200, false) // 1 → Opened
+        service.recordAndScore(discordId, guildId, game, 500, 600, false) // 0 → Closed
+        service.recordAndScore(discordId, guildId, game, 500, 600, false) // 0
+        service.recordAndScore(discordId, guildId, game, 500, 600, false) // 1 → Opened
+
+        verify(exactly = 2) {
+            eventPublisher.publishEvent(ofType<AntiAutoclickEvent.SessionOpened>())
+        }
+        verify(exactly = 1) {
+            eventPublisher.publishEvent(ofType<AntiAutoclickEvent.SessionClosed>())
+        }
+    }
+
+    @Test
+    fun `events are scoped per gameKey - independent open and close per game`() {
+        // Open dice session, then null-signal coinflip (which never opened) —
+        // must not fire SessionClosed for coinflip, only the dice open event.
+        service.recordAndScore(discordId, guildId, "dice", 100, 200, false)
+        service.recordAndScore(discordId, guildId, "dice", 100, 200, false)        // dice Opened
+        service.recordAndScore(discordId, guildId, "coinflip", null, null, null)   // no event
+
+        verify(exactly = 1) {
+            eventPublisher.publishEvent(
+                AntiAutoclickEvent.SessionOpened(guildId, discordId, "dice", streak = 1)
+            )
+        }
+        verify(exactly = 0) {
+            eventPublisher.publishEvent(ofType<AntiAutoclickEvent.SessionClosed>())
+        }
     }
 }

--- a/database/src/test/kotlin/database/service/CasinoEdgeServiceTest.kt
+++ b/database/src/test/kotlin/database/service/CasinoEdgeServiceTest.kt
@@ -1,18 +1,22 @@
 package database.service
 
+import common.events.AntiAutoclickEvent
 import database.dto.ConfigDto
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.springframework.context.ApplicationEventPublisher
 import kotlin.random.Random
 
 class CasinoEdgeServiceTest {
 
     private lateinit var botSuspicionService: CasinoBotSuspicionService
     private lateinit var configService: ConfigService
+    private lateinit var eventPublisher: ApplicationEventPublisher
     private lateinit var service: CasinoEdgeService
 
     private val discordId = 100L
@@ -24,6 +28,7 @@ class CasinoEdgeServiceTest {
     fun setup() {
         botSuspicionService = mockk(relaxed = true)
         configService = mockk(relaxed = true)
+        eventPublisher = mockk(relaxed = true)
         // relaxed=true returns 0 for Int — keeps the gate dormant unless a
         // test stubs a higher streak explicitly.
         every { botSuspicionService.recordAndScore(any(), any(), any(), any(), any(), any()) } returns 0
@@ -47,7 +52,7 @@ class CasinoEdgeServiceTest {
         // Random isn't even consulted (defensive: a misuse that boosted a
         // 0-streak bet would be a bug).
         stubStreak(0)
-        service = CasinoEdgeService(botSuspicionService, configService, mockk())
+        service = CasinoEdgeService(botSuspicionService, configService, eventPublisher, mockk())
 
         val result = service.applyBotEdge(
             discordId, guildId, gameKey, 100, 200, false, edgeMaxConfig,
@@ -64,7 +69,7 @@ class CasinoEdgeServiceTest {
         stubStreak(12)
         val random = mockk<Random>()
         every { random.nextDouble() } returns 0.0
-        service = CasinoEdgeService(botSuspicionService, configService, random)
+        service = CasinoEdgeService(botSuspicionService, configService, eventPublisher, random)
 
         val result = service.applyBotEdge(
             discordId, guildId, gameKey, 100, 200, false, edgeMaxConfig,
@@ -81,7 +86,7 @@ class CasinoEdgeServiceTest {
         stubStreak(12)
         val random = mockk<Random>()
         every { random.nextDouble() } returns 0.999
-        service = CasinoEdgeService(botSuspicionService, configService, random)
+        service = CasinoEdgeService(botSuspicionService, configService, eventPublisher, random)
 
         val result = service.applyBotEdge(
             discordId, guildId, gameKey, 100, 200, false, edgeMaxConfig,
@@ -98,7 +103,7 @@ class CasinoEdgeServiceTest {
         stubStreak(100)
         val random = mockk<Random>()
         every { random.nextDouble() } returns 0.0
-        service = CasinoEdgeService(botSuspicionService, configService, random)
+        service = CasinoEdgeService(botSuspicionService, configService, eventPublisher, random)
 
         val result = service.applyBotEdge(
             discordId, guildId, gameKey, 100, 200, false, edgeMaxConfig,
@@ -116,7 +121,7 @@ class CasinoEdgeServiceTest {
         val random = mockk<Random>()
         // 0.099 < 0.10 → substitutes. 0.11 > 0.10 → fair.
         every { random.nextDouble() } returns 0.099
-        service = CasinoEdgeService(botSuspicionService, configService, random)
+        service = CasinoEdgeService(botSuspicionService, configService, eventPublisher, random)
 
         val resultJustUnder = service.applyBotEdge(
             discordId, guildId, gameKey, 100, 200, false, edgeMaxConfig,
@@ -141,7 +146,7 @@ class CasinoEdgeServiceTest {
         stubStreak(50)
         val random = mockk<Random>()
         every { random.nextDouble() } returns 0.49
-        service = CasinoEdgeService(botSuspicionService, configService, random)
+        service = CasinoEdgeService(botSuspicionService, configService, eventPublisher, random)
 
         val withinCeiling = service.applyBotEdge(
             discordId, guildId, gameKey, 100, 200, false, edgeMaxConfig,
@@ -163,7 +168,7 @@ class CasinoEdgeServiceTest {
         // substitution fires roughly 30 % of the time. n=10k with a fixed
         // seed gives a tight enough sample that ±5pp is comfortable.
         stubStreak(12)
-        service = CasinoEdgeService(botSuspicionService, configService, Random(2026))
+        service = CasinoEdgeService(botSuspicionService, configService, eventPublisher, Random(2026))
 
         var fairCount = 0
         repeat(10_000) {
@@ -177,5 +182,100 @@ class CasinoEdgeServiceTest {
         // Expected ~70 % fair / ~30 % substituted.
         assertNotEquals(true, fairRate < 0.65 || fairRate > 0.75,
             "expected ~70 % fair (±5pp) at 30 % cap with streak=12, saw $fairRate")
+    }
+
+    // -------- BiasFired event publishing --------
+
+    @Test
+    fun `publishes BiasFired when substitution fires`() {
+        // streak=12 × 2.5pp = 30 % edge; random=0.0 < 0.30 → fires the
+        // substitution AND should publish a BiasFired event with the
+        // streak and effective edge%.
+        stubStreak(12)
+        val random = mockk<Random>()
+        every { random.nextDouble() } returns 0.0
+        service = CasinoEdgeService(botSuspicionService, configService, eventPublisher, random)
+
+        service.applyBotEdge(
+            discordId, guildId, gameKey, 100, 200, false, edgeMaxConfig,
+            fairOutcome = "fair", asLoss = { "loss" },
+        )
+
+        verify(exactly = 1) {
+            eventPublisher.publishEvent(
+                AntiAutoclickEvent.BiasFired(guildId, discordId, gameKey, streak = 12, edgePct = 30.0)
+            )
+        }
+    }
+
+    @Test
+    fun `does not publish BiasFired when streak is 0`() {
+        // No suspicion → no event, regardless of random draw.
+        stubStreak(0)
+        service = CasinoEdgeService(botSuspicionService, configService, eventPublisher, mockk(relaxed = true))
+
+        service.applyBotEdge(
+            discordId, guildId, gameKey, 100, 200, false, edgeMaxConfig,
+            fairOutcome = "fair", asLoss = { "loss" },
+        )
+
+        verify(exactly = 0) { eventPublisher.publishEvent(ofType<AntiAutoclickEvent.BiasFired>()) }
+    }
+
+    @Test
+    fun `does not publish BiasFired when random draw exceeds edge`() {
+        // Streak is suspect, but the random roll lands above the edge —
+        // the fair outcome stands and no event fires.
+        stubStreak(12)
+        val random = mockk<Random>()
+        every { random.nextDouble() } returns 0.999
+        service = CasinoEdgeService(botSuspicionService, configService, eventPublisher, random)
+
+        service.applyBotEdge(
+            discordId, guildId, gameKey, 100, 200, false, edgeMaxConfig,
+            fairOutcome = "fair", asLoss = { "loss" },
+        )
+
+        verify(exactly = 0) { eventPublisher.publishEvent(ofType<AntiAutoclickEvent.BiasFired>()) }
+    }
+
+    @Test
+    fun `does not publish BiasFired when admin cap is 0`() {
+        // Cap=0 disables the gate entirely — substitution can never fire,
+        // so no event is published either.
+        stubEdgeMaxConfig("0")
+        stubStreak(100)
+        val random = mockk<Random>()
+        every { random.nextDouble() } returns 0.0
+        service = CasinoEdgeService(botSuspicionService, configService, eventPublisher, random)
+
+        service.applyBotEdge(
+            discordId, guildId, gameKey, 100, 200, false, edgeMaxConfig,
+            fairOutcome = "fair", asLoss = { "loss" },
+        )
+
+        verify(exactly = 0) { eventPublisher.publishEvent(ofType<AntiAutoclickEvent.BiasFired>()) }
+    }
+
+    @Test
+    fun `BiasFired edgePct reflects the post-cap effective house edge`() {
+        // streak=50 raw → 125 % edge, capped to 10 % by admin override —
+        // BiasFired should report 10.0, not 125.0.
+        stubEdgeMaxConfig("10")
+        stubStreak(50)
+        val random = mockk<Random>()
+        every { random.nextDouble() } returns 0.05
+        service = CasinoEdgeService(botSuspicionService, configService, eventPublisher, random)
+
+        service.applyBotEdge(
+            discordId, guildId, gameKey, 100, 200, false, edgeMaxConfig,
+            fairOutcome = "fair", asLoss = { "loss" },
+        )
+
+        verify(exactly = 1) {
+            eventPublisher.publishEvent(
+                AntiAutoclickEvent.BiasFired(guildId, discordId, gameKey, streak = 50, edgePct = 10.0)
+            )
+        }
     }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/moderation/AntiAutoclickEmbeds.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/moderation/AntiAutoclickEmbeds.kt
@@ -1,0 +1,102 @@
+package bot.toby.command.commands.moderation
+
+import net.dv8tion.jda.api.EmbedBuilder
+import net.dv8tion.jda.api.entities.MessageEmbed
+import java.awt.Color
+import java.time.Duration
+import java.time.Instant
+
+/**
+ * Shared embed builders for the anti-autoclicker session log. One embed
+ * per `(userId, guildId, gameKey)` suspicion session, posted by
+ * `bot.toby.notify.AntiAutoclickNotifier`:
+ *
+ * - [openEmbed]   — initial post when the streak first becomes ≥1.
+ * - [activeEmbed] — edit-in-place updates as forced-loss substitutions accumulate.
+ * - [closedEmbed] — final edit when the streak resets back to 0.
+ *
+ * Colour-coded so admins can scan a channel quickly: orange = newly flagged,
+ * red = bias actively firing, grey = session ended (historical record).
+ */
+internal object AntiAutoclickEmbeds {
+
+    // Discord-blurple-adjacent palette aligned with TipEmbeds' OK/ERROR colours.
+    private val OPEN_COLOR = Color(255, 166, 0)    // amber — new suspicion
+    private val ACTIVE_COLOR = Color(237, 66, 69)  // red — bias firing
+    private val CLOSED_COLOR = Color(149, 165, 166) // grey — session ended
+
+    fun openEmbed(
+        discordId: Long,
+        gameKey: String,
+        streak: Int,
+        startedAt: Instant,
+    ): MessageEmbed = EmbedBuilder()
+        .setTitle("🤖 Autoclicker signature detected")
+        .setDescription(
+            "<@${discordId}> tripped the anti-autoclicker heuristic on **$gameKey**. " +
+                "Forced-loss bias may start firing on subsequent bets if the pattern continues."
+        )
+        .addField("Game", gameKey, true)
+        .addField("Streak", streak.toString(), true)
+        .addField("Started", "<t:${startedAt.epochSecond}:R>", true)
+        .setColor(OPEN_COLOR)
+        .build()
+
+    fun activeEmbed(
+        discordId: Long,
+        gameKey: String,
+        currentStreak: Int,
+        peakStreak: Int,
+        fireCount: Int,
+        edgePct: Double,
+        startedAt: Instant,
+        now: Instant,
+    ): MessageEmbed = EmbedBuilder()
+        .setTitle("🤖 Anti-autoclick bias active")
+        .setDescription(
+            "<@${discordId}> on **$gameKey** — bias has fired **$fireCount** time" +
+                (if (fireCount == 1) "" else "s") + "."
+        )
+        .addField("Game", gameKey, true)
+        .addField("Forced losses", fireCount.toString(), true)
+        .addField("Active for", formatDuration(Duration.between(startedAt, now)), true)
+        .addField("Current streak", currentStreak.toString(), true)
+        .addField("Peak streak", peakStreak.toString(), true)
+        .addField("Effective edge", "%.1f %%".format(edgePct), true)
+        .addField("Started", "<t:${startedAt.epochSecond}:R>", false)
+        .setColor(ACTIVE_COLOR)
+        .build()
+
+    fun closedEmbed(
+        discordId: Long,
+        gameKey: String,
+        peakStreak: Int,
+        totalFires: Int,
+        startedAt: Instant,
+        endedAt: Instant,
+    ): MessageEmbed = EmbedBuilder()
+        .setTitle("🤖 Anti-autoclick session ended")
+        .setDescription(
+            "<@${discordId}>'s autoclicker streak on **$gameKey** has reset. Final summary below."
+        )
+        .addField("Game", gameKey, true)
+        .addField("Forced losses", totalFires.toString(), true)
+        .addField("Peak streak", peakStreak.toString(), true)
+        .addField("Duration", formatDuration(Duration.between(startedAt, endedAt)), true)
+        .addField("Started", "<t:${startedAt.epochSecond}:f>", true)
+        .addField("Ended", "<t:${endedAt.epochSecond}:R>", true)
+        .setColor(CLOSED_COLOR)
+        .build()
+
+    private fun formatDuration(d: Duration): String {
+        val seconds = d.seconds.coerceAtLeast(0)
+        val h = seconds / 3600
+        val m = (seconds % 3600) / 60
+        val s = seconds % 60
+        return when {
+            h > 0 -> "${h}h ${m}m ${s}s"
+            m > 0 -> "${m}m ${s}s"
+            else -> "${s}s"
+        }
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/moderation/SetConfigCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/moderation/SetConfigCommand.kt
@@ -211,8 +211,53 @@ class SetConfigCommand @Autowired constructor(
                 ConfigDto.Configurations.LOTTERY_CHANNEL -> setLotteryChannel(
                     event, optionMapping, deleteDelay
                 )
+                // Anti-autoclicker session log channel — managed primarily
+                // via the /moderation web tab; arm stays exhaustive in case
+                // the option is registered manually.
+                ConfigDto.Configurations.CASINO_MODLOG_CHANNEL_ID -> setCasinoModlogChannel(
+                    event, optionMapping, deleteDelay
+                )
             }
         }
+    }
+
+    /**
+     * Validate + persist the per-guild text-channel id for anti-autoclick
+     * session embeds. Empty / `0` clears the override (notifier falls back
+     * to the guild's system channel). Otherwise the value must parse to a
+     * Long that resolves to a real text channel in this guild.
+     */
+    private fun setCasinoModlogChannel(
+        event: SlashCommandInteractionEvent,
+        optionMapping: OptionMapping,
+        deleteDelay: Int,
+    ) {
+        val raw = optionMapping.asString.trim()
+        val guild = event.guild ?: return
+        val resolved: String = if (raw.isEmpty() || raw == "0") {
+            ""
+        } else {
+            val id = raw.toLongOrNull() ?: run {
+                event.hook.sendMessage("Channel id must be numeric (or empty / 0 to clear).")
+                    .setEphemeral(true).queue(invokeDeleteOnMessageResponse(deleteDelay))
+                return
+            }
+            guild.getTextChannelById(id) ?: run {
+                event.hook.sendMessage("No text channel with id $id exists in this server.")
+                    .setEphemeral(true).queue(invokeDeleteOnMessageResponse(deleteDelay))
+                return
+            }
+            id.toString()
+        }
+        configService.upsertConfig(
+            ConfigDto.Configurations.CASINO_MODLOG_CHANNEL_ID.configValue, resolved, guild.id
+        )
+        val msg = if (resolved.isEmpty()) {
+            "Anti-autoclick session log channel cleared. Falling back to the guild's system channel."
+        } else {
+            "Anti-autoclick session events will post to <#$resolved>."
+        }
+        event.hook.sendMessage(msg).queue(invokeDeleteOnMessageResponse(deleteDelay))
     }
 
     /**

--- a/discord-bot/src/main/kotlin/bot/toby/notify/AntiAutoclickNotifier.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/notify/AntiAutoclickNotifier.kt
@@ -1,0 +1,241 @@
+package bot.toby.notify
+
+import bot.toby.command.commands.moderation.AntiAutoclickEmbeds
+import common.events.AntiAutoclickEvent
+import common.logging.DiscordLogger
+import database.dto.ConfigDto
+import database.service.ConfigService
+import net.dv8tion.jda.api.JDA
+import net.dv8tion.jda.api.Permission
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.Message
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
+import org.springframework.context.event.EventListener
+import org.springframework.stereotype.Component
+import java.time.Clock
+import java.time.Instant
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
+import java.util.function.Consumer
+
+/**
+ * Posts and maintains a single Discord embed per anti-autoclicker suspicion
+ * session. Listens for events from the database module:
+ *
+ * - [AntiAutoclickEvent.SessionOpened] → send a fresh embed in the configured
+ *   mod-log channel (or the guild's system channel as fallback).
+ * - [AntiAutoclickEvent.BiasFired]     → bump in-memory counters and schedule
+ *   a debounced in-place edit so a saturated burst can't spam the channel
+ *   or trip JDA's per-channel edit rate limit.
+ * - [AntiAutoclickEvent.SessionClosed] → cancel any pending edit and write
+ *   one final summary edit before discarding the session.
+ *
+ * Session state is in-memory only. A redeploy mid-session orphans the open
+ * message (it stays as the last-known state); subsequent events for the
+ * same `(user, guild, gameKey)` start a fresh session in a new message.
+ */
+@Component
+class AntiAutoclickNotifier(
+    private val jda: JDA,
+    private val configService: ConfigService,
+    private val clock: Clock = Clock.systemUTC(),
+    private val scheduler: ScheduledExecutorService = Executors.newSingleThreadScheduledExecutor { r ->
+        Thread(r, "anti-autoclick-edit-debouncer").apply { isDaemon = true }
+    },
+) {
+    private val logger = DiscordLogger.createLogger(this::class.java)
+
+    private val sessions = ConcurrentHashMap<Triple<Long, Long, String>, ActiveSession>()
+
+    private class ActiveSession(
+        val channelId: Long,
+        val startedAt: Instant,
+    ) {
+        val fireCount = AtomicInteger(0)
+        val currentStreak = AtomicInteger(0)
+        val peakStreak = AtomicInteger(0)
+        val edgePct = AtomicReference(0.0)
+        val messageId = AtomicReference<Long?>(null)
+        val pendingEdit = AtomicReference<ScheduledFuture<*>?>(null)
+    }
+
+    @EventListener
+    fun onOpened(event: AntiAutoclickEvent.SessionOpened) {
+        val key = Triple(event.discordId, event.guildId, event.gameKey)
+        val guild = jda.getGuildById(event.guildId) ?: run {
+            logger.warn("AntiAutoclickEvent.SessionOpened for guild ${event.guildId} but bot is not in that guild; skipping.")
+            return
+        }
+        val channel = resolveChannel(guild) ?: run {
+            logger.warn("No usable mod-log/system channel in guild ${event.guildId}; skipping anti-autoclick session embed.")
+            return
+        }
+        val now = Instant.now(clock)
+        val session = ActiveSession(channelId = channel.idLong, startedAt = now).also {
+            it.currentStreak.set(event.streak)
+            it.peakStreak.set(event.streak)
+        }
+        // Replace any stale orphan in the map (e.g. if a Close was missed at
+        // restart and the user re-opened) so counters don't bleed across
+        // sessions.
+        sessions[key] = session
+        runCatching {
+            channel.sendMessageEmbeds(
+                AntiAutoclickEmbeds.openEmbed(event.discordId, event.gameKey, event.streak, now)
+            ).queue(Consumer { msg: Message -> session.messageId.set(msg.idLong) })
+        }.onFailure {
+            logger.error("Could not post anti-autoclick session embed in guild ${event.guildId}: ${it.message}")
+        }
+    }
+
+    @EventListener
+    fun onFired(event: AntiAutoclickEvent.BiasFired) {
+        val key = Triple(event.discordId, event.guildId, event.gameKey)
+        val session = sessions[key] ?: run {
+            // BiasFired with no active session is normal at startup (the
+            // service restarted between the open and the first fire) — no log.
+            return
+        }
+        session.fireCount.incrementAndGet()
+        session.currentStreak.set(event.streak)
+        session.peakStreak.updateAndGet { current -> if (event.streak > current) event.streak else current }
+        session.edgePct.set(event.edgePct)
+        scheduleDebouncedEdit(event.discordId, event.gameKey, session)
+    }
+
+    @EventListener
+    fun onClosed(event: AntiAutoclickEvent.SessionClosed) {
+        val key = Triple(event.discordId, event.guildId, event.gameKey)
+        val session = sessions.remove(key) ?: return
+        session.pendingEdit.getAndSet(null)?.cancel(false)
+        val messageId = session.messageId.get() ?: run {
+            // The send hadn't yet returned the message ID before the session
+            // ended (very short streak). Nothing to edit.
+            return
+        }
+        val channel = jda.getTextChannelById(session.channelId) ?: return
+        val endedAt = Instant.now(clock)
+        runCatching {
+            channel.editMessageEmbedsById(
+                messageId,
+                AntiAutoclickEmbeds.closedEmbed(
+                    discordId = event.discordId,
+                    gameKey = event.gameKey,
+                    peakStreak = session.peakStreak.get(),
+                    totalFires = session.fireCount.get(),
+                    startedAt = session.startedAt,
+                    endedAt = endedAt,
+                ),
+            ).queue()
+        }.onFailure {
+            logger.error("Could not finalise anti-autoclick session embed ${messageId} in guild ${event.guildId}: ${it.message}")
+        }
+    }
+
+    private fun scheduleDebouncedEdit(
+        discordId: Long,
+        gameKey: String,
+        session: ActiveSession,
+    ) {
+        // If an edit is already scheduled, this fire is coalesced into it —
+        // the runnable always reads the latest counters from the session,
+        // so a single edit captures every bias-fire in the window.
+        if (session.pendingEdit.get() != null) return
+        val future: ScheduledFuture<*> = scheduler.schedule({
+            session.pendingEdit.set(null)
+            performEdit(discordId, gameKey, session)
+        }, EDIT_DEBOUNCE_MS, TimeUnit.MILLISECONDS)
+        if (!session.pendingEdit.compareAndSet(null, future)) {
+            // Another scheduling lost the race — discard ours.
+            future.cancel(false)
+        }
+    }
+
+    private fun performEdit(discordId: Long, gameKey: String, session: ActiveSession) {
+        val messageId = session.messageId.get() ?: return
+        val channel = jda.getTextChannelById(session.channelId) ?: return
+        runCatching {
+            channel.editMessageEmbedsById(
+                messageId,
+                AntiAutoclickEmbeds.activeEmbed(
+                    discordId = discordId,
+                    gameKey = gameKey,
+                    currentStreak = session.currentStreak.get(),
+                    peakStreak = session.peakStreak.get(),
+                    fireCount = session.fireCount.get(),
+                    edgePct = session.edgePct.get(),
+                    startedAt = session.startedAt,
+                    now = Instant.now(clock),
+                ),
+            ).queue()
+        }.onFailure {
+            logger.error("Could not edit anti-autoclick session embed ${messageId}: ${it.message}")
+        }
+    }
+
+    private fun resolveChannel(guild: Guild): TextChannel? {
+        val configuredId = configService.getConfigByName(
+            ConfigDto.Configurations.CASINO_MODLOG_CHANNEL_ID.configValue,
+            guild.idLong.toString(),
+        )?.value?.toLongOrNull()
+        if (configuredId != null) {
+            val configured = guild.getTextChannelById(configuredId)
+            if (configured != null && hasWritePermissions(guild, configured)) return configured
+            logger.warn("Configured CASINO_MODLOG_CHANNEL_ID=$configuredId for guild ${guild.idLong} is not usable; falling back to system channel.")
+        }
+        return guild.systemChannel?.takeIf { hasWritePermissions(guild, it) }
+    }
+
+    private fun hasWritePermissions(guild: Guild, channel: TextChannel): Boolean =
+        guild.selfMember.hasPermission(channel, Permission.MESSAGE_SEND, Permission.MESSAGE_EMBED_LINKS)
+
+    /**
+     * Test-only: force the currently-pending debounced edit to run immediately
+     * (and clears the pending future). Returns `true` if there was a pending
+     * edit to flush. Production code should never call this; the scheduler
+     * handles timing on its own.
+     */
+    internal fun flushPendingEditForTest(discordId: Long, guildId: Long, gameKey: String): Boolean {
+        val session = sessions[Triple(discordId, guildId, gameKey)] ?: return false
+        val pending = session.pendingEdit.getAndSet(null) ?: return false
+        pending.cancel(false)
+        performEdit(discordId, gameKey, session)
+        return true
+    }
+
+    /**
+     * Test-only: snapshot of current session state for the given key, or
+     * `null` if no session is active.
+     */
+    internal fun sessionSnapshotForTest(discordId: Long, guildId: Long, gameKey: String): SessionSnapshot? {
+        val s = sessions[Triple(discordId, guildId, gameKey)] ?: return null
+        return SessionSnapshot(
+            channelId = s.channelId,
+            messageId = s.messageId.get(),
+            fireCount = s.fireCount.get(),
+            currentStreak = s.currentStreak.get(),
+            peakStreak = s.peakStreak.get(),
+            edgePct = s.edgePct.get(),
+            startedAt = s.startedAt,
+        )
+    }
+
+    internal data class SessionSnapshot(
+        val channelId: Long,
+        val messageId: Long?,
+        val fireCount: Int,
+        val currentStreak: Int,
+        val peakStreak: Int,
+        val edgePct: Double,
+        val startedAt: Instant,
+    )
+
+    companion object {
+        const val EDIT_DEBOUNCE_MS: Long = 2000L
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/notify/AntiAutoclickNotifier.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/notify/AntiAutoclickNotifier.kt
@@ -146,10 +146,11 @@ class AntiAutoclickNotifier(
         // the runnable always reads the latest counters from the session,
         // so a single edit captures every bias-fire in the window.
         if (session.pendingEdit.get() != null) return
-        val future: ScheduledFuture<*> = scheduler.schedule({
+        val task = Runnable {
             session.pendingEdit.set(null)
             performEdit(discordId, gameKey, session)
-        }, EDIT_DEBOUNCE_MS, TimeUnit.MILLISECONDS)
+        }
+        val future: ScheduledFuture<*> = scheduler.schedule(task, EDIT_DEBOUNCE_MS, TimeUnit.MILLISECONDS)
         if (!session.pendingEdit.compareAndSet(null, future)) {
             // Another scheduling lost the race — discard ours.
             future.cancel(false)

--- a/discord-bot/src/test/kotlin/bot/toby/notify/AntiAutoclickNotifierTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/notify/AntiAutoclickNotifierTest.kt
@@ -4,7 +4,9 @@ import common.events.AntiAutoclickEvent
 import database.dto.ConfigDto
 import database.service.ConfigService
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
+import io.mockk.runs
 import io.mockk.slot
 import io.mockk.verify
 import net.dv8tion.jda.api.JDA
@@ -60,6 +62,11 @@ class AntiAutoclickNotifierTest {
     }
 
     private val pendingScheduledTasks = mutableListOf<Runnable>()
+    // Captures the Consumer<Message> handed to createAction.queue(...) on
+    // every send. Each open() call overwrites it; the
+    // completeOpenSendWithMessageId helper invokes the latest one to
+    // simulate JDA's REST callback firing.
+    private val openConsumerSlot = slot<Consumer<Message>>()
 
     @BeforeEach
     fun setup() {
@@ -89,11 +96,15 @@ class AntiAutoclickNotifierTest {
             )
         } returns null
 
-        // Send: capture the message-id callback so the test can synchronously
-        // simulate JDA's REST callback handing back a Message.
+        // Send: stub the queue() Consumer overload to capture the message-id
+        // callback into openConsumerSlot every time, so the test can synchronously
+        // simulate JDA's REST callback handing back a Message. Setting the
+        // capture in the stub (not in a verify) means the slot tracks the
+        // latest call and survives multiple opens within a single test.
         createAction = mockk(relaxed = true)
         every { systemChannel.sendMessageEmbeds(any<MessageEmbed>()) } returns createAction
         every { configChannel.sendMessageEmbeds(any<MessageEmbed>()) } returns createAction
+        every { createAction.queue(capture(openConsumerSlot)) } just runs
 
         editAction = mockk(relaxed = true)
         every {
@@ -119,13 +130,11 @@ class AntiAutoclickNotifierTest {
         notifier = AntiAutoclickNotifier(jda, configService, advanceableClock, scheduler)
     }
 
-    /** Simulate JDA's REST callback completing — feeds the captured Consumer
-     *  a stub Message with the given idLong. */
+    /** Simulate JDA's REST callback completing — feeds the most recently
+     *  captured Consumer a stub Message with the given idLong. */
     private fun completeOpenSendWithMessageId(id: Long) {
-        val consumerSlot = slot<Consumer<Message>>()
-        verify { createAction.queue(capture(consumerSlot)) }
         val msg = mockk<Message>(relaxed = true).also { every { it.idLong } returns id }
-        consumerSlot.captured.accept(msg)
+        openConsumerSlot.captured.accept(msg)
     }
 
     private fun openEvent(streak: Int = 1) =

--- a/discord-bot/src/test/kotlin/bot/toby/notify/AntiAutoclickNotifierTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/notify/AntiAutoclickNotifierTest.kt
@@ -1,0 +1,472 @@
+package bot.toby.notify
+
+import common.events.AntiAutoclickEvent
+import database.dto.ConfigDto
+import database.service.ConfigService
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import net.dv8tion.jda.api.JDA
+import net.dv8tion.jda.api.Permission
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.Member
+import net.dv8tion.jda.api.entities.Message
+import net.dv8tion.jda.api.entities.MessageEmbed
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
+import net.dv8tion.jda.api.requests.restaction.MessageCreateAction
+import net.dv8tion.jda.api.requests.restaction.MessageEditAction
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.TimeUnit
+import java.util.function.Consumer
+
+class AntiAutoclickNotifierTest {
+
+    private lateinit var jda: JDA
+    private lateinit var guild: Guild
+    private lateinit var selfMember: Member
+    private lateinit var systemChannel: TextChannel
+    private lateinit var configChannel: TextChannel
+    private lateinit var configService: ConfigService
+    private lateinit var scheduler: ScheduledExecutorService
+    private lateinit var notifier: AntiAutoclickNotifier
+
+    private lateinit var createAction: MessageCreateAction
+    private lateinit var editAction: MessageEditAction
+
+    private val guildId = 42L
+    private val systemChannelId = 1000L
+    private val configChannelId = 2000L
+    private val discordId = 100L
+    private val gameKey = "dice"
+    private val openMessageId = 555_000L
+
+    private val baseInstant: Instant = Instant.parse("2026-05-09T12:00:00Z")
+    private var nowOffset: Long = 0
+    private val advanceableClock = object : Clock() {
+        override fun getZone() = ZoneOffset.UTC
+        override fun withZone(zone: java.time.ZoneId) = this
+        override fun instant(): Instant = baseInstant.plusSeconds(nowOffset)
+    }
+
+    private val pendingScheduledTasks = mutableListOf<Runnable>()
+
+    @BeforeEach
+    fun setup() {
+        jda = mockk(relaxed = true)
+        guild = mockk(relaxed = true)
+        selfMember = mockk(relaxed = true)
+        systemChannel = mockk(relaxed = true)
+        configChannel = mockk(relaxed = true)
+        configService = mockk(relaxed = true)
+
+        every { jda.getGuildById(guildId) } returns guild
+        every { guild.idLong } returns guildId
+        every { guild.selfMember } returns selfMember
+        every { guild.systemChannel } returns systemChannel
+        every { guild.getTextChannelById(configChannelId) } returns configChannel
+
+        every { systemChannel.idLong } returns systemChannelId
+        every { configChannel.idLong } returns configChannelId
+        every { selfMember.hasPermission(systemChannel, *anyVararg<Permission>()) } returns true
+        every { selfMember.hasPermission(configChannel, *anyVararg<Permission>()) } returns true
+
+        // Default: no configured mod-log channel → fall back to system channel.
+        every {
+            configService.getConfigByName(
+                ConfigDto.Configurations.CASINO_MODLOG_CHANNEL_ID.configValue,
+                guildId.toString(),
+            )
+        } returns null
+
+        // Send: capture the message-id callback so the test can synchronously
+        // simulate JDA's REST callback handing back a Message.
+        createAction = mockk(relaxed = true)
+        every { systemChannel.sendMessageEmbeds(any<MessageEmbed>()) } returns createAction
+        every { configChannel.sendMessageEmbeds(any<MessageEmbed>()) } returns createAction
+
+        editAction = mockk(relaxed = true)
+        every {
+            systemChannel.editMessageEmbedsById(any<Long>(), any<MessageEmbed>())
+        } returns editAction
+        every {
+            configChannel.editMessageEmbedsById(any<Long>(), any<MessageEmbed>())
+        } returns editAction
+        every { jda.getTextChannelById(systemChannelId) } returns systemChannel
+        every { jda.getTextChannelById(configChannelId) } returns configChannel
+
+        scheduler = mockk(relaxed = true)
+        // Capture each scheduled Runnable into a list so the test can flush
+        // them deterministically. Return a relaxed ScheduledFuture so the
+        // notifier's CAS/cancel calls succeed.
+        every {
+            scheduler.schedule(any<Runnable>(), any<Long>(), any<TimeUnit>())
+        } answers {
+            val r = it.invocation.args[0] as Runnable
+            pendingScheduledTasks += r
+            mockk<ScheduledFuture<*>>(relaxed = true)
+        }
+
+        notifier = AntiAutoclickNotifier(jda, configService, advanceableClock, scheduler)
+    }
+
+    /** Simulate JDA's REST callback completing — feeds the captured Consumer
+     *  a stub Message with the given idLong. */
+    private fun completeOpenSendWithMessageId(id: Long) {
+        val consumerSlot = slot<Consumer<Message>>()
+        verify { createAction.queue(capture(consumerSlot)) }
+        val msg = mockk<Message>(relaxed = true).also { every { it.idLong } returns id }
+        consumerSlot.captured.accept(msg)
+    }
+
+    private fun openEvent(streak: Int = 1) =
+        AntiAutoclickEvent.SessionOpened(guildId, discordId, gameKey, streak)
+
+    private fun firedEvent(streak: Int, edgePct: Double = streak * 2.5) =
+        AntiAutoclickEvent.BiasFired(guildId, discordId, gameKey, streak, edgePct)
+
+    private fun closedEvent() =
+        AntiAutoclickEvent.SessionClosed(guildId, discordId, gameKey)
+
+    // -------- SessionOpened --------
+
+    @Test
+    fun `SessionOpened sends a new embed to the system channel by default`() {
+        notifier.onOpened(openEvent())
+
+        verify(exactly = 1) { systemChannel.sendMessageEmbeds(any<MessageEmbed>()) }
+        verify(exactly = 0) { configChannel.sendMessageEmbeds(any<MessageEmbed>()) }
+    }
+
+    @Test
+    fun `SessionOpened captures the message id from the queue callback into the session snapshot`() {
+        notifier.onOpened(openEvent())
+
+        completeOpenSendWithMessageId(openMessageId)
+
+        val snapshot = notifier.sessionSnapshotForTest(discordId, guildId, gameKey)
+        assertNotNull(snapshot)
+        assertEquals(openMessageId, snapshot!!.messageId)
+        assertEquals(systemChannelId, snapshot.channelId)
+        assertEquals(1, snapshot.currentStreak)
+        assertEquals(1, snapshot.peakStreak)
+        assertEquals(0, snapshot.fireCount)
+    }
+
+    @Test
+    fun `SessionOpened skips silently when bot is not in the guild`() {
+        every { jda.getGuildById(guildId) } returns null
+
+        notifier.onOpened(openEvent())
+
+        verify(exactly = 0) { systemChannel.sendMessageEmbeds(any<MessageEmbed>()) }
+        verify(exactly = 0) { configChannel.sendMessageEmbeds(any<MessageEmbed>()) }
+        assertNull(notifier.sessionSnapshotForTest(discordId, guildId, gameKey))
+    }
+
+    @Test
+    fun `SessionOpened skips when guild has no usable channel at all`() {
+        every { guild.systemChannel } returns null
+
+        notifier.onOpened(openEvent())
+
+        verify(exactly = 0) { systemChannel.sendMessageEmbeds(any<MessageEmbed>()) }
+        assertNull(notifier.sessionSnapshotForTest(discordId, guildId, gameKey))
+    }
+
+    @Test
+    fun `SessionOpened skips when bot lacks permission on the system channel`() {
+        every { selfMember.hasPermission(systemChannel, *anyVararg<Permission>()) } returns false
+
+        notifier.onOpened(openEvent())
+
+        verify(exactly = 0) { systemChannel.sendMessageEmbeds(any<MessageEmbed>()) }
+    }
+
+    // -------- Channel resolution --------
+
+    @Test
+    fun `prefers configured CASINO_MODLOG_CHANNEL_ID over the system channel`() {
+        every {
+            configService.getConfigByName(
+                ConfigDto.Configurations.CASINO_MODLOG_CHANNEL_ID.configValue,
+                guildId.toString(),
+            )
+        } returns ConfigDto(name = "x", value = configChannelId.toString(), guildId = guildId.toString())
+
+        notifier.onOpened(openEvent())
+
+        verify(exactly = 1) { configChannel.sendMessageEmbeds(any<MessageEmbed>()) }
+        verify(exactly = 0) { systemChannel.sendMessageEmbeds(any<MessageEmbed>()) }
+    }
+
+    @Test
+    fun `falls back to system channel when configured channel id is unparseable`() {
+        every {
+            configService.getConfigByName(
+                ConfigDto.Configurations.CASINO_MODLOG_CHANNEL_ID.configValue,
+                guildId.toString(),
+            )
+        } returns ConfigDto(name = "x", value = "not-a-number", guildId = guildId.toString())
+
+        notifier.onOpened(openEvent())
+
+        verify(exactly = 1) { systemChannel.sendMessageEmbeds(any<MessageEmbed>()) }
+    }
+
+    @Test
+    fun `falls back to system channel when configured channel id does not resolve to a text channel`() {
+        every {
+            configService.getConfigByName(
+                ConfigDto.Configurations.CASINO_MODLOG_CHANNEL_ID.configValue,
+                guildId.toString(),
+            )
+        } returns ConfigDto(name = "x", value = "9999", guildId = guildId.toString())
+        every { guild.getTextChannelById(9999L) } returns null
+
+        notifier.onOpened(openEvent())
+
+        verify(exactly = 1) { systemChannel.sendMessageEmbeds(any<MessageEmbed>()) }
+    }
+
+    @Test
+    fun `falls back to system channel when bot lacks permission on the configured channel`() {
+        every {
+            configService.getConfigByName(
+                ConfigDto.Configurations.CASINO_MODLOG_CHANNEL_ID.configValue,
+                guildId.toString(),
+            )
+        } returns ConfigDto(name = "x", value = configChannelId.toString(), guildId = guildId.toString())
+        every { selfMember.hasPermission(configChannel, *anyVararg<Permission>()) } returns false
+
+        notifier.onOpened(openEvent())
+
+        verify(exactly = 1) { systemChannel.sendMessageEmbeds(any<MessageEmbed>()) }
+        verify(exactly = 0) { configChannel.sendMessageEmbeds(any<MessageEmbed>()) }
+    }
+
+    // -------- BiasFired --------
+
+    @Test
+    fun `BiasFired with no active session is a silent no-op (post-restart safety)`() {
+        notifier.onFired(firedEvent(streak = 5))
+
+        verify(exactly = 0) {
+            scheduler.schedule(any<Runnable>(), any<Long>(), any<TimeUnit>())
+        }
+        verify(exactly = 0) {
+            systemChannel.editMessageEmbedsById(any<Long>(), any<MessageEmbed>())
+        }
+    }
+
+    @Test
+    fun `first BiasFired after open schedules a debounced edit and bumps counters`() {
+        notifier.onOpened(openEvent())
+        completeOpenSendWithMessageId(openMessageId)
+        nowOffset = 5
+
+        notifier.onFired(firedEvent(streak = 3, edgePct = 7.5))
+
+        verify(exactly = 1) {
+            scheduler.schedule(any<Runnable>(), AntiAutoclickNotifier.EDIT_DEBOUNCE_MS, TimeUnit.MILLISECONDS)
+        }
+        val snap = notifier.sessionSnapshotForTest(discordId, guildId, gameKey)!!
+        assertEquals(1, snap.fireCount)
+        assertEquals(3, snap.currentStreak)
+        assertEquals(3, snap.peakStreak)
+        assertEquals(7.5, snap.edgePct, 0.0001)
+    }
+
+    @Test
+    fun `multiple BiasFired events inside the debounce window coalesce into one scheduled edit`() {
+        notifier.onOpened(openEvent())
+        completeOpenSendWithMessageId(openMessageId)
+
+        notifier.onFired(firedEvent(streak = 3))
+        notifier.onFired(firedEvent(streak = 4))
+        notifier.onFired(firedEvent(streak = 5))
+
+        // Three fires, ONE scheduled edit task.
+        verify(exactly = 1) {
+            scheduler.schedule(any<Runnable>(), any<Long>(), any<TimeUnit>())
+        }
+        val snap = notifier.sessionSnapshotForTest(discordId, guildId, gameKey)!!
+        assertEquals(3, snap.fireCount)
+        assertEquals(5, snap.currentStreak)
+        assertEquals(5, snap.peakStreak)
+    }
+
+    @Test
+    fun `peak streak tracks the maximum even when current streak retreats`() {
+        notifier.onOpened(openEvent())
+        completeOpenSendWithMessageId(openMessageId)
+
+        notifier.onFired(firedEvent(streak = 8))
+        notifier.onFired(firedEvent(streak = 12))
+        notifier.onFired(firedEvent(streak = 7))
+
+        val snap = notifier.sessionSnapshotForTest(discordId, guildId, gameKey)!!
+        assertEquals(7, snap.currentStreak)
+        assertEquals(12, snap.peakStreak)
+    }
+
+    @Test
+    fun `flushing the debounced task issues exactly one edit reflecting the latest counters`() {
+        notifier.onOpened(openEvent())
+        completeOpenSendWithMessageId(openMessageId)
+
+        notifier.onFired(firedEvent(streak = 4))
+        notifier.onFired(firedEvent(streak = 6))
+        // Run the captured debouncer task — simulates the 2s window elapsing.
+        assertEquals(1, pendingScheduledTasks.size)
+        pendingScheduledTasks.first().run()
+
+        verify(exactly = 1) {
+            systemChannel.editMessageEmbedsById(openMessageId, any<MessageEmbed>())
+        }
+    }
+
+    @Test
+    fun `after the debounced edit fires, a subsequent BiasFired schedules a fresh edit (no leak)`() {
+        notifier.onOpened(openEvent())
+        completeOpenSendWithMessageId(openMessageId)
+
+        notifier.onFired(firedEvent(streak = 3))
+        pendingScheduledTasks.first().run()
+        pendingScheduledTasks.clear()
+
+        notifier.onFired(firedEvent(streak = 4))
+
+        // First scheduling + second scheduling = 2 schedule calls total.
+        verify(exactly = 2) {
+            scheduler.schedule(any<Runnable>(), any<Long>(), any<TimeUnit>())
+        }
+    }
+
+    // -------- SessionClosed --------
+
+    @Test
+    fun `SessionClosed cancels any pending edit and writes one final summary edit`() {
+        notifier.onOpened(openEvent())
+        completeOpenSendWithMessageId(openMessageId)
+        notifier.onFired(firedEvent(streak = 5))
+        nowOffset = 30
+
+        notifier.onClosed(closedEvent())
+
+        verify(exactly = 1) {
+            systemChannel.editMessageEmbedsById(openMessageId, any<MessageEmbed>())
+        }
+        // Session is removed from the map.
+        assertNull(notifier.sessionSnapshotForTest(discordId, guildId, gameKey))
+    }
+
+    @Test
+    fun `SessionClosed with no active session is a silent no-op`() {
+        notifier.onClosed(closedEvent())
+
+        verify(exactly = 0) {
+            systemChannel.editMessageEmbedsById(any<Long>(), any<MessageEmbed>())
+        }
+    }
+
+    @Test
+    fun `SessionClosed before the open send-callback returned a message id does not edit`() {
+        // Open the session but do NOT invoke the queue callback — the
+        // message id never landed. SessionClosed should not blow up; it
+        // just removes the session entry without an edit attempt.
+        notifier.onOpened(openEvent())
+
+        notifier.onClosed(closedEvent())
+
+        verify(exactly = 0) {
+            systemChannel.editMessageEmbedsById(any<Long>(), any<MessageEmbed>())
+        }
+        assertNull(notifier.sessionSnapshotForTest(discordId, guildId, gameKey))
+    }
+
+    @Test
+    fun `SessionClosed after fires posts the summary even if the debounce never flushed`() {
+        notifier.onOpened(openEvent())
+        completeOpenSendWithMessageId(openMessageId)
+        notifier.onFired(firedEvent(streak = 5))
+        // Don't run the pending scheduled task — the session closes first.
+
+        notifier.onClosed(closedEvent())
+
+        // Exactly one edit (the closed-summary), not the active-edit.
+        verify(exactly = 1) {
+            systemChannel.editMessageEmbedsById(openMessageId, any<MessageEmbed>())
+        }
+    }
+
+    // -------- Multi-session isolation --------
+
+    @Test
+    fun `two different gameKeys for the same user are independent sessions`() {
+        val openDice = AntiAutoclickEvent.SessionOpened(guildId, discordId, "dice", 1)
+        val openSlots = AntiAutoclickEvent.SessionOpened(guildId, discordId, "slots", 1)
+        val firedDice = AntiAutoclickEvent.BiasFired(guildId, discordId, "dice", 8, 20.0)
+
+        notifier.onOpened(openDice)
+        notifier.onOpened(openSlots)
+        notifier.onFired(firedDice)
+
+        // Two separate send calls (one per game) and one schedule (only dice fired).
+        verify(exactly = 2) { systemChannel.sendMessageEmbeds(any<MessageEmbed>()) }
+        verify(exactly = 1) {
+            scheduler.schedule(any<Runnable>(), any<Long>(), any<TimeUnit>())
+        }
+        val diceSnap = notifier.sessionSnapshotForTest(discordId, guildId, "dice")!!
+        val slotsSnap = notifier.sessionSnapshotForTest(discordId, guildId, "slots")!!
+        assertEquals(1, diceSnap.fireCount)
+        assertEquals(0, slotsSnap.fireCount)
+    }
+
+    @Test
+    fun `re-opening after a close starts a fresh session with cleared counters`() {
+        notifier.onOpened(openEvent())
+        completeOpenSendWithMessageId(openMessageId)
+        notifier.onFired(firedEvent(streak = 7))
+        notifier.onClosed(closedEvent())
+
+        // Second session for the same key — fresh map entry, fresh counters.
+        notifier.onOpened(openEvent())
+        completeOpenSendWithMessageId(openMessageId + 1)
+
+        val snap = notifier.sessionSnapshotForTest(discordId, guildId, gameKey)!!
+        assertEquals(openMessageId + 1, snap.messageId)
+        assertEquals(0, snap.fireCount)
+        assertEquals(1, snap.peakStreak)
+        // Two open sends total.
+        verify(exactly = 2) { systemChannel.sendMessageEmbeds(any<MessageEmbed>()) }
+    }
+
+    @Test
+    fun `flushPendingEditForTest helper runs only when there is a pending edit`() {
+        // No session yet → false.
+        assertEquals(false, notifier.flushPendingEditForTest(discordId, guildId, gameKey))
+
+        notifier.onOpened(openEvent())
+        completeOpenSendWithMessageId(openMessageId)
+        // Session but no fires → no pending edit → false.
+        assertEquals(false, notifier.flushPendingEditForTest(discordId, guildId, gameKey))
+
+        notifier.onFired(firedEvent(streak = 3))
+        // Now there is a pending edit → flush succeeds.
+        assertTrue(notifier.flushPendingEditForTest(discordId, guildId, gameKey))
+        verify(exactly = 1) {
+            systemChannel.editMessageEmbedsById(openMessageId, any<MessageEmbed>())
+        }
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/notify/AntiAutoclickNotifierTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/notify/AntiAutoclickNotifierTest.kt
@@ -10,7 +10,7 @@ import io.mockk.verify
 import net.dv8tion.jda.api.JDA
 import net.dv8tion.jda.api.Permission
 import net.dv8tion.jda.api.entities.Guild
-import net.dv8tion.jda.api.entities.Member
+import net.dv8tion.jda.api.entities.SelfMember
 import net.dv8tion.jda.api.entities.Message
 import net.dv8tion.jda.api.entities.MessageEmbed
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
@@ -34,7 +34,7 @@ class AntiAutoclickNotifierTest {
 
     private lateinit var jda: JDA
     private lateinit var guild: Guild
-    private lateinit var selfMember: Member
+    private lateinit var selfMember: SelfMember
     private lateinit var systemChannel: TextChannel
     private lateinit var configChannel: TextChannel
     private lateinit var configService: ConfigService

--- a/discord-bot/src/test/kotlin/bot/toby/notify/AntiAutoclickNotifierTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/notify/AntiAutoclickNotifierTest.kt
@@ -112,8 +112,7 @@ class AntiAutoclickNotifierTest {
         every {
             scheduler.schedule(any<Runnable>(), any<Long>(), any<TimeUnit>())
         } answers {
-            val r = it.invocation.args[0] as Runnable
-            pendingScheduledTasks += r
+            pendingScheduledTasks += firstArg<Runnable>()
             mockk<ScheduledFuture<*>>(relaxed = true)
         }
 

--- a/web/src/main/kotlin/web/service/ModerationWebService.kt
+++ b/web/src/main/kotlin/web/service/ModerationWebService.kt
@@ -892,11 +892,13 @@ class ModerationWebService(
                 if (n !in 1..50) return "Value must be between 1 and 50."
                 n.toString()
             }
-            ConfigDto.Configurations.LOTTERY_CHANNEL -> {
+            ConfigDto.Configurations.LOTTERY_CHANNEL,
+            ConfigDto.Configurations.CASINO_MODLOG_CHANNEL_ID -> {
                 val v = rawValue.trim()
                 if (v.isEmpty()) {
-                    // Empty value clears the override and falls back to
-                    // LEADERBOARD_CHANNEL → systemChannel at runtime.
+                    // Empty value clears the override. LOTTERY_CHANNEL falls
+                    // back to LEADERBOARD_CHANNEL → systemChannel at runtime;
+                    // CASINO_MODLOG_CHANNEL_ID falls back to systemChannel.
                     ""
                 } else {
                     val id = v.toLongOrNull()

--- a/web/src/test/kotlin/web/service/ModerationWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/ModerationWebServiceTest.kt
@@ -1033,6 +1033,62 @@ class ModerationWebServiceTest {
     }
 
     @Test
+    fun `updateConfig CASINO_MODLOG_CHANNEL_ID accepts a valid text channel id`() {
+        mockMember(ownerId, isOwner = true)
+        val channel = mockk<TextChannel>(relaxed = true)
+        every { channel.id } returns "12345"
+        every { guild.getTextChannelById(12345L) } returns channel
+
+        val err = service.updateConfig(
+            ownerId, guildId, ConfigDto.Configurations.CASINO_MODLOG_CHANNEL_ID, "12345"
+        )
+
+        assertNull(err)
+        verify(exactly = 1) {
+            configService.upsertConfig("CASINO_MODLOG_CHANNEL_ID", "12345", guildId.toString())
+        }
+    }
+
+    @Test
+    fun `updateConfig CASINO_MODLOG_CHANNEL_ID empty value clears the override`() {
+        mockMember(ownerId, isOwner = true)
+
+        val err = service.updateConfig(
+            ownerId, guildId, ConfigDto.Configurations.CASINO_MODLOG_CHANNEL_ID, ""
+        )
+
+        assertNull(err)
+        verify(exactly = 1) {
+            configService.upsertConfig("CASINO_MODLOG_CHANNEL_ID", "", guildId.toString())
+        }
+    }
+
+    @Test
+    fun `updateConfig CASINO_MODLOG_CHANNEL_ID rejects non-numeric value`() {
+        mockMember(ownerId, isOwner = true)
+
+        val err = service.updateConfig(
+            ownerId, guildId, ConfigDto.Configurations.CASINO_MODLOG_CHANNEL_ID, "not-a-number"
+        )
+
+        assertEquals("Channel id must be numeric.", err)
+        verify(exactly = 0) { configService.upsertConfig(any(), any(), any()) }
+    }
+
+    @Test
+    fun `updateConfig CASINO_MODLOG_CHANNEL_ID rejects unknown channel id`() {
+        mockMember(ownerId, isOwner = true)
+        every { guild.getTextChannelById(99999L) } returns null
+
+        val err = service.updateConfig(
+            ownerId, guildId, ConfigDto.Configurations.CASINO_MODLOG_CHANNEL_ID, "99999"
+        )
+
+        assertEquals("No text channel with that id exists in this server.", err)
+        verify(exactly = 0) { configService.upsertConfig(any(), any(), any()) }
+    }
+
+    @Test
     fun `getLeaderboard queries voice for the CURRENT month, not the previous one`() {
         // Regression: the old code passed [prevMonthStart, thisMonthStart),
         // which is the just-finished month — copy-paste from


### PR DESCRIPTION
## Summary

- Adds context logging for the anti-autoclicker gate so admins can see who tripped the heuristic, on which game, and how long suspicion lasted. Previously silent — false positives and per-game cap tuning were blind.
- Posts **one embed per `(user, guild, gameKey)` suspicion session** that is **edited in place** as forced-loss substitutions accumulate, then finalised with a summary when the streak resets. No per-fire spam.
- Edits are debounced 2s per session to absorb saturated bursts without hitting Discord's per-channel edit rate limit.
- Channel target is per-guild via new `CASINO_MODLOG_CHANNEL_ID` config; falls back to the guild's system channel when unset/invalid.

## Architecture

Mirrors the existing `WebTipSentEvent` → `WebTipNotifier` → `TipEmbeds` flow:

- **`common/events/AntiAutoclickEvent`** — sealed interface with `SessionOpened`, `BiasFired`, `SessionClosed` cases.
- **`CasinoBotSuspicionService`** — publishes `SessionOpened` on streak `0 → ≥1` and `SessionClosed` on streak `≥1 → 0` (incl. via null/mouse-moved/different-pixel resets).
- **`CasinoEdgeService`** — publishes `BiasFired` inside the forced-loss substitution branch with the post-cap effective edge%.
- **`AntiAutoclickNotifier`** (new, `discord-bot/notify`) — Spring `@EventListener` for all three; owns a `ConcurrentHashMap` of session state with atomic counters, a single-thread `ScheduledExecutorService` for the debounce, and CAS coalescing of pending edits.
- **`AntiAutoclickEmbeds`** (new, `discord-bot/.../moderation`) — three colour-coded embed factories (amber=opened, red=active, grey=closed) with relative timestamps and duration formatting.
- **`ConfigDto.Configurations.CASINO_MODLOG_CHANNEL_ID`** — new per-guild key.

## Test coverage

Heavy — most of the new code surface is exercised:

**Database (45 tests, all green locally)**
- `CasinoBotSuspicionServiceTest` — adds 9 new tests covering: SessionOpened fires exactly once on 0→1, never republished on later increments; SessionClosed fires on every streak reset path (different pixel, mouseMoved=true, null signals) but **not** when prior streak was already 0; per-gameKey isolation of events; full open→close→reopen cycles; no events at all when streak stays 0.
- `CasinoEdgeServiceTest` — adds 5 new tests covering: BiasFired fires when substitution fires; not when streak is 0; not when random draw exceeds edge; not when admin cap=0; `edgePct` reflects the post-cap effective edge (not the raw streak math).

**Discord-bot (`AntiAutoclickNotifierTest`, new — 22 tests)**
- SessionOpened sends a fresh embed; captures message ID from JDA's queue callback into the snapshot
- Skips silently when bot isn't in guild / no usable channel / lacks permission
- Channel resolution: prefers `CASINO_MODLOG_CHANNEL_ID`; falls back when unparseable, missing, or unauthorised
- BiasFired with no active session is a silent no-op (post-restart safety)
- First fire schedules a debounced edit and bumps counters; multiple fires inside the window **coalesce into one** scheduled edit; peak streak tracks max even when current retreats
- Flushing the debounced task issues exactly one edit reflecting latest counters
- After a flush, a subsequent fire schedules a fresh edit (no scheduler leak)
- SessionClosed cancels pending edit and writes one final summary; silent no-op if no session; doesn't edit if message ID never landed
- Two different gameKeys for the same user are independent sessions
- Re-opening after a close starts a fresh session with cleared counters

The notifier exposes `flushPendingEditForTest` and `sessionSnapshotForTest` helpers (`internal`) so tests can drive the debounce deterministically — production code never calls them.

## Test plan

- [x] `./gradlew :common:test` ✅
- [x] `./gradlew :database:test` ✅ (33 tests `CasinoBotSuspicionService`, 12 tests `CasinoEdgeService`, all green)
- [ ] `./gradlew :discord-bot:test --tests "*AntiAutoclickNotifierTest*"` — couldn't run locally (sandbox blocks lavalink/libdave Maven repos with 403); CI will validate.
- [ ] End-to-end smoke against a test guild:
  - With `CASINO_MODLOG_CHANNEL_ID` unset, spam-click the same pixel on `/casino/{guildId}/dice` until streak ≥1 → expect ONE amber "Autoclicker signature detected" embed in the system channel.
  - Continue clicking — every forced loss should *edit* that same message in place: fire count climbs, peak streak climbs, "Active for *Xm Ys*" duration ticks up. No new messages.
  - Move cursor / click a different pixel to reset → within ~2s the same message edits to the grey "Session ended" summary.
  - Trigger another suspicious streak → expect a NEW amber message (new session).
  - Set `CASINO_MODLOG_CHANNEL_ID` to a valid channel and repeat — messages route there instead.
  - Confirm no events fire on Discord-initiated bets (null click signals).


---
_Generated by [Claude Code](https://claude.ai/code/session_016qVNCQBf8iVQxH9XD6Pe5A)_