### PR TITLE
feat(jackpot): RTP-based eligibility gate

### DIFF
--- a/database/src/main/kotlin/database/dto/ConfigDto.kt
+++ b/database/src/main/kotlin/database/dto/ConfigDto.kt
@@ -179,6 +179,18 @@ class ConfigDto(
         // 7-day window. Ignored when the window is 0.
         JACKPOT_ACTIVITY_MIN_DAYS("JACKPOT_ACTIVITY_MIN_DAYS"),
 
+        // Whole-number ceiling (0-100) on a game's canonical RTP for it
+        // to roll for the jackpot. 0 (default) disables the gate so every
+        // game stays eligible (pre-PR behaviour). Recommended 95: blocks
+        // Coinflip (1.0), Blackjack (~0.99), Baccarat (~0.99), Roulette
+        // (0.973) — games that already pay back ~all stake on their own
+        // — while keeping Slots, Scratch, Dice, Keno, and HighLow
+        // eligible. The intent is "high-RTP games don't *also* need a
+        // jackpot sweetener; jackpots compensate for house edge." A
+        // failed gate looks identical to a missed roll: no payout, pool
+        // keeps growing, no exception surfaced.
+        JACKPOT_RTP_MAX_PCT("JACKPOT_RTP_MAX_PCT"),
+
         // Whole-number percentage (0-50) — ceiling on the dynamic house
         // edge applied to web casino bets that match an autoclicker
         // signature (same screen pixel ± 2px clicked repeatedly with no

--- a/database/src/main/kotlin/database/service/BaccaratService.kt
+++ b/database/src/main/kotlin/database/service/BaccaratService.kt
@@ -132,7 +132,7 @@ class BaccaratService(
             hand.isWin -> {
                 val jackpot = JackpotHelper.rollOnWin(
                     jackpotService, configService, userService, resolved.user, guildId,
-                    stake, random,
+                    stake, JackpotGame.BACCARAT, random,
                 )
                 PlayOutcome.Win(
                     stake = stake,

--- a/database/src/main/kotlin/database/service/BlackjackService.kt
+++ b/database/src/main/kotlin/database/service/BlackjackService.kt
@@ -664,7 +664,7 @@ class BlackjackService @Autowired constructor(
                     Blackjack.Result.PLAYER_WIN, Blackjack.Result.PLAYER_BLACKJACK -> {
                         val rolled = JackpotHelper.rollOnWin(
                             jackpotService, configService, userService, user, guildId,
-                            hand.stake, random,
+                            hand.stake, JackpotGame.BLACKJACK, random,
                         )
                         if (rolled > 0L) {
                             jackpotPayout += rolled

--- a/database/src/main/kotlin/database/service/CasinoHoldemService.kt
+++ b/database/src/main/kotlin/database/service/CasinoHoldemService.kt
@@ -266,7 +266,7 @@ class CasinoHoldemService @Autowired constructor(
             CasinoHoldem.AnteResult.WIN ->
                 jackpotPayout += JackpotHelper.rollOnWin(
                     jackpotService, configService, userService, user, guildId,
-                    table.stake, random,
+                    table.stake, JackpotGame.HOLDEM, random,
                 )
             CasinoHoldem.AnteResult.LOSE ->
                 lossTribute += JackpotHelper.divertOnLoss(
@@ -285,7 +285,7 @@ class CasinoHoldemService @Autowired constructor(
             CasinoHoldem.CallResult.WIN_OTHER ->
                 jackpotPayout += JackpotHelper.rollOnWin(
                     jackpotService, configService, userService, user, guildId,
-                    callStake, random,
+                    callStake, JackpotGame.HOLDEM, random,
                 )
             CasinoHoldem.CallResult.LOSE ->
                 lossTribute += JackpotHelper.divertOnLoss(

--- a/database/src/main/kotlin/database/service/CoinflipService.kt
+++ b/database/src/main/kotlin/database/service/CoinflipService.kt
@@ -118,7 +118,7 @@ class CoinflipService(
         return if (flip.isWin) {
             val jackpot = JackpotHelper.rollOnWin(
                 jackpotService, configService, userService, resolved.user, guildId,
-                stake, random,
+                stake, JackpotGame.COINFLIP, random,
             )
             FlipOutcome.Win(
                 stake = stake,

--- a/database/src/main/kotlin/database/service/DiceService.kt
+++ b/database/src/main/kotlin/database/service/DiceService.kt
@@ -118,7 +118,7 @@ class DiceService(
         return if (roll.isWin) {
             val jackpot = JackpotHelper.rollOnWin(
                 jackpotService, configService, userService, resolved.user, guildId,
-                stake, random,
+                stake, JackpotGame.DICE, random,
             )
             RollOutcome.Win(
                 stake = stake,

--- a/database/src/main/kotlin/database/service/HighlowService.kt
+++ b/database/src/main/kotlin/database/service/HighlowService.kt
@@ -134,7 +134,7 @@ class HighlowService(
         return if (hand.isWin) {
             val jackpot = JackpotHelper.rollOnWin(
                 jackpotService, configService, userService, resolved.user, guildId,
-                stake, random,
+                stake, JackpotGame.HIGHLOW, random,
             )
             PlayOutcome.Win(
                 stake = stake,

--- a/database/src/main/kotlin/database/service/JackpotHelper.kt
+++ b/database/src/main/kotlin/database/service/JackpotHelper.kt
@@ -5,6 +5,28 @@ import database.dto.UserDto
 import kotlin.random.Random
 
 /**
+ * Casino games that feed the jackpot pool, paired with their canonical
+ * RTP. The value is the highest plausible RTP across that game's bet
+ * variants (Banker for Baccarat, basic-strategy for Blackjack, etc.) —
+ * the RTP eligibility gate uses it to decide whether a game is "too
+ * generous" to also pay a jackpot. Pinned alongside the per-game test
+ * suites in `database.economy` / `database.blackjack`; if a game's
+ * payout schedule is tuned, the value here moves with it.
+ */
+internal enum class JackpotGame(val rtp: Double) {
+    COINFLIP(1.0),     // 50/50 fair, 2× payout — no house edge by design.
+    BLACKJACK(0.99),   // Basic strategy hovers ~99-100%; conservatively 0.99.
+    BACCARAT(0.99),    // Banker ~98.94%, Player ~98.76% — pin to the higher.
+    ROULETTE(0.973),   // 36/37 European wheel — uniform across bet types.
+    HOLDEM(0.97),      // Casino Hold'em vs dealer; ~2-3% edge industry-wide.
+    HIGHLOW(0.923),    // 12/13 ≈ deckSize-1/deckSize regardless of direction.
+    KENO(0.92),        // 0.83-0.92 band; pin to the top so the gate is honest.
+    SLOTS(0.890),      // ~11% house edge; closed-form pinned by SlotMachineTest.
+    SCRATCH(0.875),    // ~12.5% edge; pinned by ScratchCard.expectedRtp().
+    DICE(0.833),       // 5/6 — 5× payout at 1/6 odds.
+}
+
+/**
  * Two casino-side feeders for the per-guild jackpot pool:
  *
  *   - [rollOnWin] — on every minigame WIN, roll a small probability
@@ -35,6 +57,19 @@ internal object JackpotHelper {
      * the `JACKPOT_WIN_PCT` config entry. Tuned alongside the trade fee.
      */
     const val DEFAULT_WIN_PROBABILITY: Double = 0.01
+
+    /**
+     * Default ceiling on a game's RTP for it to remain jackpot-eligible.
+     * Whole-number percent (0-100). 0 (default) disables the gate so
+     * unconfigured guilds keep the pre-PR behaviour — every game rolls
+     * for the jackpot. Recommended value 95: blocks Coinflip (1.0),
+     * Blackjack (~0.99), Baccarat (~0.99), Roulette (0.973) — games that
+     * already return ~all stake on their own — while keeping Slots,
+     * Scratch, Dice, Keno, and HighLow eligible. The intent is "high-RTP
+     * games don't *also* need a jackpot sweetener; jackpots compensate
+     * for house edge."
+     */
+    const val DEFAULT_RTP_MAX_PCT: Long = 0L
 
     /**
      * Default share of the pool paid on a winning roll when the server
@@ -130,6 +165,7 @@ internal object JackpotHelper {
         user: UserDto,
         guildId: Long,
         stake: Long,
+        game: JackpotGame,
         random: Random
     ): Long {
         val baseProbability = winProbability(configService, guildId)
@@ -144,6 +180,7 @@ internal object JackpotHelper {
         // growing, no payout, no exception thrown into the wager service.
         if (jackpotService.isOnCooldown(guildId, user.discordId)) return 0L
         if (!jackpotService.isActive(guildId, user.discordId)) return 0L
+        if (!isEligibleByRtp(game, configService, guildId)) return 0L
 
         val won = jackpotService.awardJackpot(guildId)
         if (won == 0L) return 0L
@@ -283,5 +320,35 @@ internal object JackpotHelper {
         )
         val days = cfg?.value?.toLongOrNull() ?: return DEFAULT_ACTIVITY_MIN_DAYS
         return days.coerceAtLeast(1L)
+    }
+
+    /**
+     * Live RTP-eligibility ceiling for [guildId] in whole-number percent
+     * (0-100), parsed from `JACKPOT_RTP_MAX_PCT`. Returns
+     * [DEFAULT_RTP_MAX_PCT] (0 = gate disabled) when unset, unparseable,
+     * or negative; clamps anything above 100 down to 100.
+     */
+    fun rtpMaxPct(configService: ConfigService, guildId: Long): Long {
+        val cfg = configService.getConfigByName(
+            ConfigDto.Configurations.JACKPOT_RTP_MAX_PCT.configValue,
+            guildId.toString()
+        )
+        val pct = cfg?.value?.toLongOrNull() ?: return DEFAULT_RTP_MAX_PCT
+        return pct.coerceIn(0L, 100L)
+    }
+
+    /**
+     * Returns `true` when [game]'s canonical RTP is at or below the
+     * configured per-guild ceiling, or when the gate is disabled
+     * (`JACKPOT_RTP_MAX_PCT` = 0). The rationale is that jackpots exist
+     * to compensate for house edge — a game already returning ~all stake
+     * to the player (Coinflip, Blackjack, Baccarat) doesn't need a
+     * jackpot bolted on top, and admins can opt out of paying one by
+     * setting a ceiling like 95.
+     */
+    fun isEligibleByRtp(game: JackpotGame, configService: ConfigService, guildId: Long): Boolean {
+        val maxPct = rtpMaxPct(configService, guildId)
+        if (maxPct == 0L) return true
+        return game.rtp * 100.0 <= maxPct.toDouble()
     }
 }

--- a/database/src/main/kotlin/database/service/JackpotHelper.kt
+++ b/database/src/main/kotlin/database/service/JackpotHelper.kt
@@ -13,7 +13,7 @@ import kotlin.random.Random
  * suites in `database.economy` / `database.blackjack`; if a game's
  * payout schedule is tuned, the value here moves with it.
  */
-internal enum class JackpotGame(val rtp: Double) {
+enum class JackpotGame(val rtp: Double) {
     COINFLIP(1.0),     // 50/50 fair, 2× payout — no house edge by design.
     BLACKJACK(0.99),   // Basic strategy hovers ~99-100%; conservatively 0.99.
     BACCARAT(0.99),    // Banker ~98.94%, Player ~98.76% — pin to the higher.

--- a/database/src/main/kotlin/database/service/JackpotService.kt
+++ b/database/src/main/kotlin/database/service/JackpotService.kt
@@ -91,6 +91,25 @@ class JackpotService(
     fun stakeAnchor(guildId: Long): Long =
         JackpotHelper.stakeAnchor(configService, guildId)
 
+    /**
+     * Live RTP-eligibility ceiling for [guildId] in whole-number percent
+     * (0-100; 0 = gate disabled). Surfaced so the casino-page banner can
+     * name the configured ceiling when explaining why a particular game
+     * isn't eligible to roll.
+     */
+    fun rtpMaxPct(guildId: Long): Long =
+        JackpotHelper.rtpMaxPct(configService, guildId)
+
+    /**
+     * Returns true when [game] is eligible to roll for the jackpot in
+     * [guildId] under the configured RTP ceiling, or when the gate is
+     * disabled (`JACKPOT_RTP_MAX_PCT` = 0). Banner-side mirror of the
+     * gate inside [JackpotHelper.rollOnWin] so the page can warn the
+     * user up front instead of only at win-time.
+     */
+    fun isEligibleByRtp(guildId: Long, game: JackpotGame): Boolean =
+        JackpotHelper.isEligibleByRtp(game, configService, guildId)
+
     companion object {
         // 4dp covers the smallest probability the saved-percent / 100
         // round-trip can express meaningfully — e.g. an admin saving

--- a/database/src/main/kotlin/database/service/KenoService.kt
+++ b/database/src/main/kotlin/database/service/KenoService.kt
@@ -134,7 +134,7 @@ class KenoService(
         return if (hand.isWin) {
             val jackpot = JackpotHelper.rollOnWin(
                 jackpotService, configService, userService, resolved.user, guildId,
-                stake, random,
+                stake, JackpotGame.KENO, random,
             )
             PlayOutcome.Win(
                 stake = stake,

--- a/database/src/main/kotlin/database/service/RouletteService.kt
+++ b/database/src/main/kotlin/database/service/RouletteService.kt
@@ -117,7 +117,7 @@ class RouletteService(
         return if (spin.isWin) {
             val jackpot = JackpotHelper.rollOnWin(
                 jackpotService, configService, userService, resolved.user, guildId,
-                stake, random,
+                stake, JackpotGame.ROULETTE, random,
             )
             SpinOutcome.Win(
                 stake = stake,

--- a/database/src/main/kotlin/database/service/ScratchService.kt
+++ b/database/src/main/kotlin/database/service/ScratchService.kt
@@ -84,7 +84,7 @@ class ScratchService(
         return if (result.isWin && result.winningSymbol != null) {
             val jackpot = JackpotHelper.rollOnWin(
                 jackpotService, configService, userService, resolved.user, guildId,
-                stake, random,
+                stake, JackpotGame.SCRATCH, random,
             )
             ScratchOutcome.Win(
                 stake = stake,

--- a/database/src/main/kotlin/database/service/SlotsService.kt
+++ b/database/src/main/kotlin/database/service/SlotsService.kt
@@ -123,7 +123,7 @@ class SlotsService(
         return if (pull.isWin) {
             val jackpot = JackpotHelper.rollOnWin(
                 jackpotService, configService, userService, resolved.user, guildId,
-                stake, random,
+                stake, JackpotGame.SLOTS, random,
             )
             SpinOutcome.Win(
                 stake = stake,

--- a/database/src/test/kotlin/database/service/JackpotHelperTest.kt
+++ b/database/src/test/kotlin/database/service/JackpotHelperTest.kt
@@ -214,7 +214,7 @@ class JackpotHelperTest {
 
         val won = JackpotHelper.rollOnWin(
             jackpotService, configService, userService, user, guildId,
-            stake = MAX_STAKE, random = stubRandom(0.001)
+            stake = MAX_STAKE, game = JackpotGame.SLOTS, random = stubRandom(0.001)
         )
 
         assertEquals(500L, won)
@@ -231,7 +231,7 @@ class JackpotHelperTest {
         // 0.5 is far above the 0.01 threshold.
         val won = JackpotHelper.rollOnWin(
             jackpotService, configService, userService, user, guildId,
-            stake = MAX_STAKE, random = stubRandom(0.5)
+            stake = MAX_STAKE, game = JackpotGame.SLOTS, random = stubRandom(0.5)
         )
 
         assertEquals(0L, won)
@@ -250,11 +250,11 @@ class JackpotHelperTest {
 
         val hit = JackpotHelper.rollOnWin(
             jackpotService, configService, userService, userHit, guildId,
-            stake = MAX_STAKE, random = stubRandom(0.004)
+            stake = MAX_STAKE, game = JackpotGame.SLOTS, random = stubRandom(0.004)
         )
         val miss = JackpotHelper.rollOnWin(
             jackpotService, configService, userService, userMiss, guildId,
-            stake = MAX_STAKE, random = stubRandom(0.006)
+            stake = MAX_STAKE, game = JackpotGame.SLOTS, random = stubRandom(0.006)
         )
 
         assertEquals(1_000L, hit, "0.004 < 0.005 should hit")
@@ -270,7 +270,7 @@ class JackpotHelperTest {
         // Even an absurdly small roll can't beat a 0.0 threshold (`< 0.0` is unreachable).
         val won = JackpotHelper.rollOnWin(
             jackpotService, configService, userService, user, guildId,
-            stake = MAX_STAKE, random = stubRandom(0.0)
+            stake = MAX_STAKE, game = JackpotGame.SLOTS, random = stubRandom(0.0)
         )
 
         assertEquals(0L, won)
@@ -287,11 +287,11 @@ class JackpotHelperTest {
 
         val hit = JackpotHelper.rollOnWin(
             jackpotService, configService, userService, userHit, guildId,
-            stake = MAX_STAKE, random = stubRandom(0.49)
+            stake = MAX_STAKE, game = JackpotGame.SLOTS, random = stubRandom(0.49)
         )
         val miss = JackpotHelper.rollOnWin(
             jackpotService, configService, userService, userMiss, guildId,
-            stake = MAX_STAKE, random = stubRandom(0.51)
+            stake = MAX_STAKE, game = JackpotGame.SLOTS, random = stubRandom(0.51)
         )
 
         assertEquals(50L, hit)
@@ -307,7 +307,7 @@ class JackpotHelperTest {
 
         val won = JackpotHelper.rollOnWin(
             jackpotService, configService, userService, user, guildId,
-            stake = MAX_STAKE, random = stubRandom(0.001)
+            stake = MAX_STAKE, game = JackpotGame.SLOTS, random = stubRandom(0.001)
         )
 
         assertEquals(0L, won)
@@ -327,11 +327,11 @@ class JackpotHelperTest {
 
         val hit = JackpotHelper.rollOnWin(
             jackpotService, configService, userService, userHit, guildId,
-            stake = 10L, random = stubRandom(0.00009)
+            stake = 10L, game = JackpotGame.SLOTS, random = stubRandom(0.00009)
         )
         val miss = JackpotHelper.rollOnWin(
             jackpotService, configService, userService, userMiss, guildId,
-            stake = 10L, random = stubRandom(0.0001)
+            stake = 10L, game = JackpotGame.SLOTS, random = stubRandom(0.0001)
         )
 
         assertEquals(1_000L, hit, "0.00009 < 0.0001 should hit")
@@ -348,11 +348,11 @@ class JackpotHelperTest {
 
         val hit = JackpotHelper.rollOnWin(
             jackpotService, configService, userService, userHit, guildId,
-            stake = 1_000L, random = stubRandom(0.009)
+            stake = 1_000L, game = JackpotGame.SLOTS, random = stubRandom(0.009)
         )
         val miss = JackpotHelper.rollOnWin(
             jackpotService, configService, userService, userMiss, guildId,
-            stake = 1_000L, random = stubRandom(0.011)
+            stake = 1_000L, game = JackpotGame.SLOTS, random = stubRandom(0.011)
         )
 
         assertEquals(1_000L, hit)
@@ -372,7 +372,7 @@ class JackpotHelperTest {
 
         val won = JackpotHelper.rollOnWin(
             jackpotService, configService, userService, user, guildId,
-            stake = 10_000L, random = stubRandom(0.009)
+            stake = 10_000L, game = JackpotGame.SLOTS, random = stubRandom(0.009)
         )
 
         assertEquals(100L, won)
@@ -388,7 +388,7 @@ class JackpotHelperTest {
         // stake/anchor = 500/500 = 1.0 → effective = 1 %; 0.009 < 0.01 hits.
         val won = JackpotHelper.rollOnWin(
             jackpotService, configService, userService, user, guildId,
-            stake = 500L, random = stubRandom(0.009)
+            stake = 500L, game = JackpotGame.SLOTS, random = stubRandom(0.009)
         )
 
         assertEquals(1L, won)
@@ -406,7 +406,7 @@ class JackpotHelperTest {
 
         val won = JackpotHelper.rollOnWin(
             jackpotService, configService, userService, user, guildId,
-            stake = 100L, random = stubRandom(0.009)
+            stake = 100L, game = JackpotGame.SLOTS, random = stubRandom(0.009)
         )
 
         assertEquals(100L, won)
@@ -423,7 +423,7 @@ class JackpotHelperTest {
 
         val won = JackpotHelper.rollOnWin(
             jackpotService, configService, userService, user, guildId,
-            stake = MAX_STAKE, random = stubRandom(0.001)
+            stake = MAX_STAKE, game = JackpotGame.SLOTS, random = stubRandom(0.001)
         )
 
         assertEquals(0L, won, "blocked by cooldown gate")
@@ -441,7 +441,7 @@ class JackpotHelperTest {
 
         val won = JackpotHelper.rollOnWin(
             jackpotService, configService, userService, user, guildId,
-            stake = MAX_STAKE, random = stubRandom(0.001)
+            stake = MAX_STAKE, game = JackpotGame.SLOTS, random = stubRandom(0.001)
         )
 
         assertEquals(0L, won, "blocked by activity gate")
@@ -458,7 +458,7 @@ class JackpotHelperTest {
 
         val won = JackpotHelper.rollOnWin(
             jackpotService, configService, userService, user, guildId,
-            stake = MAX_STAKE, random = stubRandom(0.001)
+            stake = MAX_STAKE, game = JackpotGame.SLOTS, random = stubRandom(0.001)
         )
 
         assertEquals(250L, won)
@@ -474,7 +474,7 @@ class JackpotHelperTest {
 
         JackpotHelper.rollOnWin(
             jackpotService, configService, userService, user, guildId,
-            stake = MAX_STAKE, random = stubRandom(0.001)
+            stake = MAX_STAKE, game = JackpotGame.SLOTS, random = stubRandom(0.001)
         )
 
         verify(exactly = 0) { jackpotService.recordWin(any(), any(), any(), any()) }
@@ -558,6 +558,144 @@ class JackpotHelperTest {
             )
         } returns null
         assertEquals(0L, JackpotHelper.activityWindowDays(configService, guildId))
+    }
+
+    // ---- rtpMaxPct / isEligibleByRtp / RTP gate ----
+
+    private fun rtpConfigReturns(value: String?) {
+        every {
+            configService.getConfigByName(
+                ConfigDto.Configurations.JACKPOT_RTP_MAX_PCT.configValue,
+                guildId.toString()
+            )
+        } returns value?.let { ConfigDto(name = "x", value = it, guildId = guildId.toString()) }
+    }
+
+    @Test
+    fun `rtpMaxPct returns 0 (disabled) when no config row exists`() {
+        rtpConfigReturns(null)
+
+        assertEquals(JackpotHelper.DEFAULT_RTP_MAX_PCT, JackpotHelper.rtpMaxPct(configService, guildId))
+    }
+
+    @Test
+    fun `rtpMaxPct parses a whole-number percent`() {
+        rtpConfigReturns("95")
+
+        assertEquals(95L, JackpotHelper.rtpMaxPct(configService, guildId))
+    }
+
+    @Test
+    fun `rtpMaxPct clamps above 100 and below 0`() {
+        rtpConfigReturns("250")
+        assertEquals(100L, JackpotHelper.rtpMaxPct(configService, guildId))
+
+        rtpConfigReturns("-5")
+        assertEquals(0L, JackpotHelper.rtpMaxPct(configService, guildId))
+    }
+
+    @Test
+    fun `rtpMaxPct falls back to default on unparseable values`() {
+        rtpConfigReturns("bogus")
+
+        assertEquals(JackpotHelper.DEFAULT_RTP_MAX_PCT, JackpotHelper.rtpMaxPct(configService, guildId))
+    }
+
+    @Test
+    fun `isEligibleByRtp returns true for every game when the gate is disabled`() {
+        rtpConfigReturns(null)  // 0 = disabled
+
+        for (game in JackpotGame.values()) {
+            assertEquals(
+                true,
+                JackpotHelper.isEligibleByRtp(game, configService, guildId),
+                "$game should be eligible when gate disabled"
+            )
+        }
+    }
+
+    @Test
+    fun `isEligibleByRtp blocks high-RTP games above the configured ceiling`() {
+        rtpConfigReturns("95")  // ceiling 95 % blocks Coinflip, Blackjack, Baccarat, Roulette
+
+        assertEquals(false, JackpotHelper.isEligibleByRtp(JackpotGame.COINFLIP, configService, guildId))
+        assertEquals(false, JackpotHelper.isEligibleByRtp(JackpotGame.BLACKJACK, configService, guildId))
+        assertEquals(false, JackpotHelper.isEligibleByRtp(JackpotGame.BACCARAT, configService, guildId))
+        assertEquals(false, JackpotHelper.isEligibleByRtp(JackpotGame.ROULETTE, configService, guildId))
+    }
+
+    @Test
+    fun `isEligibleByRtp keeps low-RTP games eligible at a 95 percent ceiling`() {
+        rtpConfigReturns("95")
+
+        assertEquals(true, JackpotHelper.isEligibleByRtp(JackpotGame.SLOTS, configService, guildId))
+        assertEquals(true, JackpotHelper.isEligibleByRtp(JackpotGame.SCRATCH, configService, guildId))
+        assertEquals(true, JackpotHelper.isEligibleByRtp(JackpotGame.DICE, configService, guildId))
+        assertEquals(true, JackpotHelper.isEligibleByRtp(JackpotGame.KENO, configService, guildId))
+        assertEquals(true, JackpotHelper.isEligibleByRtp(JackpotGame.HIGHLOW, configService, guildId))
+    }
+
+    @Test
+    fun `isEligibleByRtp treats RTP equal to ceiling as eligible (inclusive bound)`() {
+        // Ceiling 89 == SLOTS RTP 0.890 ⇒ SLOTS still eligible (≤, not <).
+        rtpConfigReturns("89")
+
+        assertEquals(true, JackpotHelper.isEligibleByRtp(JackpotGame.SLOTS, configService, guildId))
+        // SCRATCH (0.875) is strictly below the ceiling, also eligible.
+        assertEquals(true, JackpotHelper.isEligibleByRtp(JackpotGame.SCRATCH, configService, guildId))
+        // ROULETTE (0.973) is above the ceiling, blocked.
+        assertEquals(false, JackpotHelper.isEligibleByRtp(JackpotGame.ROULETTE, configService, guildId))
+    }
+
+    @Test
+    fun `rollOnWin blocks payout when game RTP exceeds the configured ceiling`() {
+        winConfigReturns("1")
+        anchorConfigReturns(MAX_STAKE.toString())
+        rtpConfigReturns("95")  // blocks COINFLIP (1.0)
+        val user = freshUser(initial = 100L)
+
+        // Probability roll would otherwise hit; the RTP gate is what stops it.
+        val won = JackpotHelper.rollOnWin(
+            jackpotService, configService, userService, user, guildId,
+            stake = MAX_STAKE, game = JackpotGame.COINFLIP, random = stubRandom(0.001)
+        )
+
+        assertEquals(0L, won, "blocked by RTP gate")
+        assertEquals(100L, user.socialCredit, "balance untouched on blocked gate")
+        verify(exactly = 0) { jackpotService.awardJackpot(any()) }
+        verify(exactly = 0) { jackpotService.recordWin(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `rollOnWin allows payout for low-RTP games even when ceiling is set`() {
+        winConfigReturns("1")
+        anchorConfigReturns(MAX_STAKE.toString())
+        rtpConfigReturns("95")  // SLOTS (0.890) stays eligible
+        every { jackpotService.awardJackpot(guildId) } returns 750L
+        val user = freshUser()
+
+        val won = JackpotHelper.rollOnWin(
+            jackpotService, configService, userService, user, guildId,
+            stake = MAX_STAKE, game = JackpotGame.SLOTS, random = stubRandom(0.001)
+        )
+
+        assertEquals(750L, won)
+    }
+
+    @Test
+    fun `rollOnWin preserves legacy behaviour for every game when RTP gate disabled`() {
+        winConfigReturns("1")
+        anchorConfigReturns(MAX_STAKE.toString())
+        rtpConfigReturns(null)  // 0 = disabled — even Coinflip rolls normally
+        every { jackpotService.awardJackpot(guildId) } returns 50L
+        val user = freshUser()
+
+        val won = JackpotHelper.rollOnWin(
+            jackpotService, configService, userService, user, guildId,
+            stake = MAX_STAKE, game = JackpotGame.COINFLIP, random = stubRandom(0.001)
+        )
+
+        assertEquals(50L, won, "gate disabled — Coinflip wins still roll")
     }
 
     @Test

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/moderation/SetConfigCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/moderation/SetConfigCommand.kt
@@ -168,6 +168,8 @@ class SetConfigCommand @Autowired constructor(
                     config = ConfigDto.Configurations.JACKPOT_ACTIVITY_WINDOW_DAYS, gameLabel = "Jackpot", label = "activity window days", range = 0..365)
                 ConfigDto.Configurations.JACKPOT_ACTIVITY_MIN_DAYS -> setRangedIntConfig(event, optionMapping, deleteDelay,
                     config = ConfigDto.Configurations.JACKPOT_ACTIVITY_MIN_DAYS, gameLabel = "Jackpot", label = "activity min days", range = 1..365)
+                ConfigDto.Configurations.JACKPOT_RTP_MAX_PCT -> setRangedIntConfig(event, optionMapping, deleteDelay,
+                    config = ConfigDto.Configurations.JACKPOT_RTP_MAX_PCT, gameLabel = "Jackpot", label = "max RTP percent (0 disables)", range = 0..100)
                 ConfigDto.Configurations.COINFLIP_BOT_EDGE_MAX_PCT -> setRangedIntConfig(event, optionMapping, deleteDelay,
                     config = ConfigDto.Configurations.COINFLIP_BOT_EDGE_MAX_PCT, gameLabel = "Coinflip",
                     label = "bot-suspicion max edge percent", range = 0..50)

--- a/web/src/main/kotlin/web/casino/CasinoPageContext.kt
+++ b/web/src/main/kotlin/web/casino/CasinoPageContext.kt
@@ -1,5 +1,6 @@
 package web.casino
 
+import database.service.JackpotGame
 import database.service.JackpotService
 import database.service.TobyCoinMarketService
 import database.service.UserService
@@ -39,6 +40,7 @@ class CasinoPageContext(
         guildId: Long,
         discordId: Long,
         user: OAuth2User,
+        game: JackpotGame? = null,
     ): Guild? {
         val guild = jda.getGuildById(guildId) ?: return null
         val profile = userService.getUserById(discordId, guildId)
@@ -50,6 +52,14 @@ class CasinoPageContext(
         model.addAttribute("jackpotPool", jackpotService.getPool(guildId))
         model.addAttribute("jackpotWinPct", jackpotService.winProbabilityDisplay(guildId))
         model.addAttribute("jackpotStakeAnchor", jackpotService.stakeAnchor(guildId))
+        // Per-game RTP eligibility — only set when caller declares which
+        // game this page is for. Lottery / poker pages share the banner
+        // but don't roll for the jackpot themselves, so they leave `game`
+        // null and the banner stays in its eligible-by-default form.
+        if (game != null && !jackpotService.isEligibleByRtp(guildId, game)) {
+            model.addAttribute("jackpotIneligible", true)
+            model.addAttribute("jackpotRtpMax", jackpotService.rtpMaxPct(guildId))
+        }
         model.addAttribute("username", user.displayName())
         return guild
     }
@@ -74,11 +84,12 @@ fun CasinoPageContext.renderMinigamePage(
     ra: RedirectAttributes,
     template: String,
     lobbyPath: String = "/casino/guilds",
+    game: JackpotGame? = null,
     addRulesAttributes: Model.() -> Unit,
 ): String = WebGuildAccess.requireMemberForPage(
     user, guildId, economyWebService, ra, lobbyPath = lobbyPath
 ) { discordId ->
-    populate(model, guildId, discordId, user) ?: run {
+    populate(model, guildId, discordId, user, game) ?: run {
         ra.addFlashAttribute("error", "Bot is not in that server.")
         return@requireMemberForPage "redirect:$lobbyPath"
     }

--- a/web/src/main/kotlin/web/controller/BaccaratController.kt
+++ b/web/src/main/kotlin/web/controller/BaccaratController.kt
@@ -4,6 +4,7 @@ import common.casino.CasinoCommonFailure
 import database.economy.Baccarat
 import database.service.BaccaratService
 import database.service.BaccaratService.PlayOutcome
+import database.service.JackpotGame
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.security.oauth2.core.user.OAuth2User
@@ -56,7 +57,8 @@ class BaccaratController(
         model: Model,
         ra: RedirectAttributes
     ): String = pageContext.renderMinigamePage(
-        user, guildId, economyWebService, model, ra, template = "baccarat"
+        user, guildId, economyWebService, model, ra, template = "baccarat",
+        game = JackpotGame.BACCARAT,
     ) {
         val (minStake, maxStake) = stakeBounds.baccarat(guildId)
         addAttribute("minStake", minStake)

--- a/web/src/main/kotlin/web/controller/BlackjackController.kt
+++ b/web/src/main/kotlin/web/controller/BlackjackController.kt
@@ -5,6 +5,7 @@ import database.blackjack.BlackjackTable
 import database.blackjack.BlackjackTableRegistry
 import database.service.BlackjackService
 import database.service.BlackjackService.MultiActionOutcome
+import database.service.JackpotGame
 import database.service.BlackjackService.MultiCreateOutcome
 import database.service.BlackjackService.MultiJoinOutcome
 import database.service.BlackjackService.MultiLeaveOutcome
@@ -101,7 +102,8 @@ class BlackjackController(
         ra: RedirectAttributes,
     ): String = pageContext.renderMinigamePage(
         user, guildId, economyWebService, model, ra,
-        template = "blackjack-lobby", lobbyPath = "/blackjack/guilds"
+        template = "blackjack-lobby", lobbyPath = "/blackjack/guilds",
+        game = JackpotGame.BLACKJACK,
     ) {
         val (minAnte, maxAnte) = stakeBounds.blackjackSolo(guildId)
         addAttribute("minAnte", minAnte)
@@ -119,7 +121,7 @@ class BlackjackController(
     ): String = WebGuildAccess.requireMemberForPage(
         user, guildId, economyWebService, ra, lobbyPath = "/blackjack/guilds"
     ) { discordId ->
-        pageContext.populate(model, guildId, discordId, user) ?: run {
+        pageContext.populate(model, guildId, discordId, user, game = JackpotGame.BLACKJACK) ?: run {
             ra.addFlashAttribute("error", "Bot is not in that server.")
             return@requireMemberForPage "redirect:/blackjack/guilds"
         }
@@ -145,7 +147,7 @@ class BlackjackController(
             ra.addFlashAttribute("error", "That blackjack table no longer exists.")
             return@requireMemberForPage "redirect:/blackjack/$guildId"
         }
-        pageContext.populate(model, guildId, discordId, user) ?: run {
+        pageContext.populate(model, guildId, discordId, user, game = JackpotGame.BLACKJACK) ?: run {
             ra.addFlashAttribute("error", "Bot is not in that server.")
             return@requireMemberForPage "redirect:/blackjack/guilds"
         }

--- a/web/src/main/kotlin/web/controller/CasinoHoldemController.kt
+++ b/web/src/main/kotlin/web/controller/CasinoHoldemController.kt
@@ -6,6 +6,7 @@ import database.poker.CasinoHoldemTableRegistry
 import database.service.CasinoHoldemService
 import database.service.CasinoHoldemService.ActionOutcome
 import database.service.CasinoHoldemService.DealOutcome
+import database.service.JackpotGame
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.security.oauth2.core.user.OAuth2User
@@ -71,6 +72,7 @@ class CasinoHoldemController(
     ): String = pageContext.renderMinigamePage(
         user, guildId, economyWebService, model, ra,
         template = "casinoholdem-solo",
+        game = JackpotGame.HOLDEM,
     ) {
         val discordId = user.attributes["id"].toString().toLong()
         val (minStake, maxStake) = stakeBounds.casinoHoldem(guildId)

--- a/web/src/main/kotlin/web/controller/CoinflipController.kt
+++ b/web/src/main/kotlin/web/controller/CoinflipController.kt
@@ -4,6 +4,7 @@ import common.casino.CasinoCommonFailure
 import database.economy.Coinflip
 import database.service.CoinflipService
 import database.service.CoinflipService.FlipOutcome
+import database.service.JackpotGame
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.security.oauth2.core.user.OAuth2User
@@ -52,7 +53,8 @@ class CoinflipController(
         model: Model,
         ra: RedirectAttributes
     ): String = pageContext.renderMinigamePage(
-        user, guildId, economyWebService, model, ra, template = "coinflip"
+        user, guildId, economyWebService, model, ra, template = "coinflip",
+        game = JackpotGame.COINFLIP,
     ) {
         val (minStake, maxStake) = stakeBounds.coinflip(guildId)
         addAttribute("minStake", minStake)

--- a/web/src/main/kotlin/web/controller/DiceController.kt
+++ b/web/src/main/kotlin/web/controller/DiceController.kt
@@ -4,6 +4,7 @@ import common.casino.CasinoCommonFailure
 import database.economy.Dice
 import database.service.DiceService
 import database.service.DiceService.RollOutcome
+import database.service.JackpotGame
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.security.oauth2.core.user.OAuth2User
@@ -50,7 +51,8 @@ class DiceController(
         model: Model,
         ra: RedirectAttributes
     ): String = pageContext.renderMinigamePage(
-        user, guildId, economyWebService, model, ra, template = "dice"
+        user, guildId, economyWebService, model, ra, template = "dice",
+        game = JackpotGame.DICE,
     ) {
         val (minStake, maxStake) = stakeBounds.dice(guildId)
         addAttribute("minStake", minStake)

--- a/web/src/main/kotlin/web/controller/HighlowController.kt
+++ b/web/src/main/kotlin/web/controller/HighlowController.kt
@@ -4,6 +4,7 @@ import common.casino.CasinoCommonFailure
 import database.economy.Highlow
 import database.service.HighlowService
 import database.service.HighlowService.PlayOutcome
+import database.service.JackpotGame
 import jakarta.servlet.http.HttpSession
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
@@ -46,7 +47,8 @@ class HighlowController(
         model: Model,
         ra: RedirectAttributes
     ): String = pageContext.renderMinigamePage(
-        user, guildId, economyWebService, model, ra, template = "highlow"
+        user, guildId, economyWebService, model, ra, template = "highlow",
+        game = JackpotGame.HIGHLOW,
     ) {
         // Stake commits first, anchor is dealt after the player locks it.
         // If a round is already locked in this session, surface it so the

--- a/web/src/main/kotlin/web/controller/KenoController.kt
+++ b/web/src/main/kotlin/web/controller/KenoController.kt
@@ -1,6 +1,7 @@
 package web.controller
 
 import database.economy.Keno
+import database.service.JackpotGame
 import database.service.KenoService
 import database.service.KenoService.PlayOutcome
 import org.springframework.http.ResponseEntity
@@ -55,7 +56,7 @@ class KenoController(
     ): String = WebGuildAccess.requireMemberForPage(
         user, guildId, economyWebService, ra, lobbyPath = "/casino/guilds"
     ) { discordId ->
-        pageContext.populate(model, guildId, discordId, user) ?: run {
+        pageContext.populate(model, guildId, discordId, user, game = JackpotGame.KENO) ?: run {
             ra.addFlashAttribute("error", "Bot is not in that server.")
             return@requireMemberForPage "redirect:/casino/guilds"
         }

--- a/web/src/main/kotlin/web/controller/RouletteController.kt
+++ b/web/src/main/kotlin/web/controller/RouletteController.kt
@@ -2,6 +2,7 @@ package web.controller
 
 import common.casino.CasinoCommonFailure
 import database.economy.Roulette
+import database.service.JackpotGame
 import database.service.RouletteService
 import database.service.RouletteService.SpinOutcome
 import org.springframework.http.ResponseEntity
@@ -54,6 +55,7 @@ class RouletteController(
     ): String = pageContext.renderMinigamePage(
         user, guildId, economyWebService, model, ra,
         template = "roulette", lobbyPath = "/casino/guilds",
+        game = JackpotGame.ROULETTE,
     ) {
         val (minStake, maxStake) = stakeBounds.roulette(guildId)
         addAttribute("minStake", minStake)

--- a/web/src/main/kotlin/web/controller/ScratchController.kt
+++ b/web/src/main/kotlin/web/controller/ScratchController.kt
@@ -3,6 +3,7 @@ package web.controller
 import common.casino.CasinoCommonFailure
 import database.economy.ScratchCard
 import database.economy.SlotMachine
+import database.service.JackpotGame
 import database.service.ScratchService
 import database.service.ScratchService.ScratchOutcome
 import org.springframework.http.ResponseEntity
@@ -44,7 +45,8 @@ class ScratchController(
         model: Model,
         ra: RedirectAttributes
     ): String = pageContext.renderMinigamePage(
-        user, guildId, economyWebService, model, ra, template = "scratch"
+        user, guildId, economyWebService, model, ra, template = "scratch",
+        game = JackpotGame.SCRATCH,
     ) {
         val (minStake, maxStake) = stakeBounds.scratch(guildId)
         addAttribute("minStake", minStake)

--- a/web/src/main/kotlin/web/controller/SlotsController.kt
+++ b/web/src/main/kotlin/web/controller/SlotsController.kt
@@ -2,6 +2,7 @@ package web.controller
 
 import common.casino.CasinoCommonFailure
 import database.economy.SlotMachine
+import database.service.JackpotGame
 import database.service.SlotsService
 import database.service.SlotsService.SpinOutcome
 import org.springframework.http.ResponseEntity
@@ -53,7 +54,8 @@ class SlotsController(
         ra: RedirectAttributes
     ): String = pageContext.renderMinigamePage(
         user, guildId, economyWebService, model, ra,
-        template = "slots", lobbyPath = "/leaderboards"
+        template = "slots", lobbyPath = "/leaderboards",
+        game = JackpotGame.SLOTS,
     ) {
         val (minStake, maxStake) = stakeBounds.slots(guildId)
         addAttribute("minStake", minStake)

--- a/web/src/main/kotlin/web/service/ModerationWebService.kt
+++ b/web/src/main/kotlin/web/service/ModerationWebService.kt
@@ -848,6 +848,12 @@ class ModerationWebService(
                 if (n !in 1..365) return "Value must be between 1 and 365."
                 n.toString()
             }
+            ConfigDto.Configurations.JACKPOT_RTP_MAX_PCT -> {
+                val n = rawValue.trim().toIntOrNull()
+                    ?: return "Value must be a whole number percentage (0-100; 0 disables; recommended 95)."
+                if (n !in 0..100) return "Value must be between 0 and 100 (0 disables; recommended 95)."
+                n.toString()
+            }
             ConfigDto.Configurations.COINFLIP_BOT_EDGE_MAX_PCT,
             ConfigDto.Configurations.DICE_BOT_EDGE_MAX_PCT,
             ConfigDto.Configurations.SLOTS_BOT_EDGE_MAX_PCT -> {

--- a/web/src/main/resources/templates/fragments/casino.html
+++ b/web/src/main/resources/templates/fragments/casino.html
@@ -8,15 +8,22 @@
     game in one edit.
 -->
 <div th:fragment="jackpotBanner" class="casino-jackpot-banner"
+     th:classappend="${jackpotIneligible} ? ' casino-jackpot-banner--ineligible'"
      title="Anti-cheat is on. Detected automation accrues forced losses up to a configured cap.">
     🎰 Jackpot pool:
     <strong th:text="${jackpotPool}">0</strong> credits
-    <span class="muted">
+    <span class="muted" th:unless="${jackpotIneligible}">
         — win any minigame for up to
         <span th:text="${jackpotWinPct}">1</span>%
         chance to bank the pool. The chance scales with your stake against a
         <span th:text="${jackpotStakeAnchor}">500</span>-credit reference;
         bets at or above that get the full rate, smaller bets scale linearly down.
+    </span>
+    <span class="muted" th:if="${jackpotIneligible}">
+        — this game doesn't roll for the jackpot: its RTP is above the
+        configured ceiling of
+        <span th:text="${jackpotRtpMax}">95</span>%. Wins still pay out
+        normally, but won't bank the pool.
     </span>
 </div>
 </body>

--- a/web/src/test/kotlin/web/casino/CasinoPageContextTest.kt
+++ b/web/src/test/kotlin/web/casino/CasinoPageContextTest.kt
@@ -1,0 +1,95 @@
+package web.casino
+
+import database.dto.UserDto
+import database.service.JackpotGame
+import database.service.JackpotService
+import database.service.TobyCoinMarketService
+import database.service.UserService
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import net.dv8tion.jda.api.JDA
+import net.dv8tion.jda.api.entities.Guild
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.security.oauth2.core.user.OAuth2User
+import org.springframework.ui.ConcurrentModel
+
+/**
+ * Behavioural coverage for the per-game RTP eligibility wiring in
+ * [CasinoPageContext.populate]. The banner-fragment unit test asserts
+ * the template renders the right blocks; this asserts the model arrives
+ * with the right attributes set.
+ */
+class CasinoPageContextTest {
+
+    private lateinit var userService: UserService
+    private lateinit var jackpotService: JackpotService
+    private lateinit var marketService: TobyCoinMarketService
+    private lateinit var jda: JDA
+    private lateinit var guild: Guild
+    private lateinit var user: OAuth2User
+    private lateinit var ctx: CasinoPageContext
+
+    private val guildId = 200L
+    private val discordId = 7L
+
+    @BeforeEach
+    fun setup() {
+        userService = mockk(relaxed = true)
+        jackpotService = mockk(relaxed = true)
+        marketService = mockk(relaxed = true)
+        jda = mockk(relaxed = true)
+        guild = mockk(relaxed = true)
+        user = mockk(relaxed = true)
+        every { jda.getGuildById(guildId) } returns guild
+        every { guild.name } returns "Guild"
+        every { user.getAttribute<String>("username") } returns "tester"
+        every { userService.getUserById(discordId, guildId) } returns UserDto(
+            discordId = discordId, guildId = guildId
+        )
+        every { marketService.getMarket(guildId) } returns null
+        every { jackpotService.getPool(guildId) } returns 0L
+        every { jackpotService.winProbabilityDisplay(guildId) } returns "1"
+        every { jackpotService.stakeAnchor(guildId) } returns 500L
+        ctx = CasinoPageContext(userService, jackpotService, marketService, jda)
+    }
+
+    @Test
+    fun `populate omits ineligibility attrs when game is null (lottery, poker share the banner)`() {
+        val model = ConcurrentModel()
+
+        val resolved = ctx.populate(model, guildId, discordId, user, game = null)
+
+        assertNotNull(resolved)
+        assertEquals(false, model.containsAttribute("jackpotIneligible"))
+        assertEquals(false, model.containsAttribute("jackpotRtpMax"))
+        // Eligibility was not consulted because the page didn't declare a game.
+        verify(exactly = 0) { jackpotService.isEligibleByRtp(any(), any()) }
+    }
+
+    @Test
+    fun `populate omits ineligibility attrs when the game is eligible`() {
+        every { jackpotService.isEligibleByRtp(guildId, JackpotGame.SLOTS) } returns true
+        val model = ConcurrentModel()
+
+        ctx.populate(model, guildId, discordId, user, game = JackpotGame.SLOTS)
+
+        assertEquals(false, model.containsAttribute("jackpotIneligible"))
+        assertEquals(false, model.containsAttribute("jackpotRtpMax"))
+    }
+
+    @Test
+    fun `populate stamps ineligibility attrs when the game is gated out`() {
+        every { jackpotService.isEligibleByRtp(guildId, JackpotGame.COINFLIP) } returns false
+        every { jackpotService.rtpMaxPct(guildId) } returns 95L
+        val model = ConcurrentModel()
+
+        ctx.populate(model, guildId, discordId, user, game = JackpotGame.COINFLIP)
+
+        assertEquals(true, model.getAttribute("jackpotIneligible"))
+        assertEquals(95L, model.getAttribute("jackpotRtpMax"))
+    }
+}

--- a/web/src/test/kotlin/web/controller/BlackjackControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/BlackjackControllerTest.kt
@@ -3,6 +3,7 @@ package web.controller
 import database.blackjack.BlackjackTable
 import database.blackjack.BlackjackTableRegistry
 import database.service.BlackjackService
+import database.service.JackpotGame
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -63,7 +64,7 @@ class BlackjackControllerTest {
         // casino attributes on the model so per-handler tests can assert
         // the centralised wiring fires.
         val guildStub = mockk<Guild>(relaxed = true).also { every { it.name } returns "Test Guild" }
-        every { pageContext.populate(any(), guildId, discordId, user) } answers {
+        every { pageContext.populate(any(), guildId, discordId, user, any()) } answers {
             val model = arg<Model>(0)
             model.addAttribute("guildId", guildId.toString())
             model.addAttribute("guildName", "Test Guild")
@@ -88,7 +89,7 @@ class BlackjackControllerTest {
         val view = controller.lobby(guildId, user, model, RedirectAttributesModelMap())
 
         assertEquals("blackjack-lobby", view)
-        verify { pageContext.populate(model, guildId, discordId, user) }
+        verify { pageContext.populate(model, guildId, discordId, user, JackpotGame.BLACKJACK) }
         // Centralised attributes — populated by populate(), proxied here:
         assertEquals(1234L, model.getAttribute("jackpotPool"))
         assertEquals("0.0005", model.getAttribute("jackpotWinPct"))
@@ -104,7 +105,7 @@ class BlackjackControllerTest {
         val view = controller.soloPage(guildId, user, model, RedirectAttributesModelMap())
 
         assertEquals("blackjack-solo", view)
-        verify { pageContext.populate(model, guildId, discordId, user) }
+        verify { pageContext.populate(model, guildId, discordId, user, JackpotGame.BLACKJACK) }
         assertEquals(1234L, model.getAttribute("jackpotPool"))
         assertEquals("0.0005", model.getAttribute("jackpotWinPct"))
         assertEquals(500L, model.getAttribute("jackpotStakeAnchor"))
@@ -124,7 +125,7 @@ class BlackjackControllerTest {
         )
 
         assertEquals("blackjack-table", view)
-        verify { pageContext.populate(model, guildId, discordId, user) }
+        verify { pageContext.populate(model, guildId, discordId, user, JackpotGame.BLACKJACK) }
         assertEquals(1234L, model.getAttribute("jackpotPool"))
         assertEquals("0.0005", model.getAttribute("jackpotWinPct"))
         assertEquals(500L, model.getAttribute("jackpotStakeAnchor"))

--- a/web/src/test/kotlin/web/controller/HighlowControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/HighlowControllerTest.kt
@@ -55,7 +55,7 @@ class HighlowControllerTest {
         val guild = mockk<Guild>(relaxed = true).also {
             every { it.name } returns "Test Guild"
         }
-        every { pageContext.populate(any(), guildId, discordId, user) } returns guild
+        every { pageContext.populate(any(), guildId, discordId, user, any()) } returns guild
 
         controller = HighlowController(highlowService, economyWebService, pageContext, stakeBounds)
     }

--- a/web/src/test/kotlin/web/template/CasinoJackpotBannerFragmentTest.kt
+++ b/web/src/test/kotlin/web/template/CasinoJackpotBannerFragmentTest.kt
@@ -81,6 +81,35 @@ class CasinoJackpotBannerFragmentTest {
     }
 
     @Test
+    fun `jackpot banner gates the eligible explanation behind jackpotIneligible`() {
+        // When the per-guild RTP ceiling marks this game as ineligible to
+        // roll, the banner must not still claim "win any minigame for X%
+        // chance" — that's misleading. The eligible blurb is rendered
+        // with th:unless so it's hidden whenever the model marks the
+        // game ineligible.
+        assertTrue(
+            fragmentHtml.contains("th:unless=\"\${jackpotIneligible}\""),
+            "fragment must hide the eligible-by-default blurb when jackpotIneligible is true"
+        )
+    }
+
+    @Test
+    fun `jackpot banner shows an ineligibility explanation when gated out`() {
+        // Symmetric branch — the banner explains *why* the game won't
+        // roll (RTP above the configured ceiling) instead of going
+        // silent. Includes the configured ceiling so the user can map
+        // it to the admin's setting if they ask.
+        assertTrue(
+            fragmentHtml.contains("th:if=\"\${jackpotIneligible}\""),
+            "fragment must render an ineligibility blurb when jackpotIneligible is true"
+        )
+        assertTrue(
+            fragmentHtml.contains("jackpotRtpMax"),
+            "ineligibility blurb must surface the configured RTP ceiling"
+        )
+    }
+
+    @Test
     fun `jackpot banner exposes anti-cheat tooltip via title attribute`() {
         // Hover-discoverable note about the bot-suspicion / forced-loss
         // system (see CasinoBotSuspicionService + CasinoEdgeService.applyBotEdge).


### PR DESCRIPTION
## Summary

Adds a per-guild ceiling on a game's canonical RTP for it to roll for the jackpot. The intent is **"jackpots exist to compensate for house edge — high-RTP games don't *also* need a jackpot sweetener."** A game already returning ~all stake on its own (Coinflip 1.0, Blackjack ~0.99, Baccarat ~0.99, Roulette 0.973) tips EV above 1.0 when you bolt a jackpot on top, which bleeds the casino. The new gate lets admins opt out of paying jackpots on those games while keeping Slots, Scratch, Dice, Keno, and HighLow eligible.

- New `JACKPOT_RTP_MAX_PCT` config key, whole-number percent 0-100. **0 (default) disables the gate — pre-PR behaviour preserved.** Recommended value 95: blocks the four high-RTP games above, keeps the rest eligible.
- New `JackpotGame` enum in `JackpotHelper.kt` pins each game's canonical RTP next to the eligibility logic (highest plausible variant — Banker for Baccarat, basic-strategy for Blackjack, etc., so the gate doesn't accidentally let a high-RTP variant through).
- `JackpotHelper.rollOnWin` now takes a `JackpotGame` arg; it short-circuits when the game's RTP exceeds the configured ceiling. A failed RTP gate looks identical to a missed roll (no payout, pool keeps growing, no exception surfaced) — same shape as the existing cooldown and activity gates.
- Every game-service caller updated to pass the right enum value (Coinflip, Dice, Slots, HighLow, Roulette, Keno, Scratch, Baccarat, Blackjack, Casino Hold'em).
- New config wired into the `/setconfig` Discord dispatch and the `/moderation` web tab validator (range 0-100).

## Test plan

- [x] `:database:test` passes — added 10 new tests covering `rtpMaxPct` parsing/clamping, `isEligibleByRtp` per-game eligibility, and the full `rollOnWin` flow with the gate enabled / disabled / at the inclusive bound.
- [x] `:web:test` passes — confirms the new validator branch in `ModerationWebService` doesn't break anything else.
- [ ] `:discord-bot:test` not run locally — sandbox can't resolve `moe.kyokobot.libdave` deps; the change is a single new branch in an exhaustive `when` that mirrors the existing `JACKPOT_*` patterns.
- [ ] Manual smoke: set `JACKPOT_RTP_MAX_PCT=95` on a test guild, win at `/coinflip` and verify no jackpot payout occurs even on high probability rolls; win at `/slots` and verify jackpot still rolls.

https://claude.ai/code/session_01DkruyWsC53k7nmgnyvxtw5

---
_Generated by [Claude Code](https://claude.ai/code/session_01DkruyWsC53k7nmgnyvxtw5)_