### PR TITLE
refactor(handlers): decompose VoiceEventHandler, MusicPlayerHelper, IntroHelper

### DIFF
--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/music/MusicCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/music/MusicCommand.kt
@@ -1,8 +1,8 @@
 package bot.toby.command.commands.music
 
-import bot.toby.helpers.MusicPlayerHelper
 import bot.toby.lavaplayer.GuildMusicManager
 import bot.toby.lavaplayer.PlayerManager
+import bot.toby.util.formatTime
 import core.command.Command
 import core.command.Command.Companion.invokeDeleteOnMessageResponse
 import core.command.CommandContext
@@ -52,7 +52,7 @@ interface MusicCommand : Command {
                     .queue(invokeDeleteOnMessageResponse(deleteDelay))
             } else {
                 val duration = musicManager.audioPlayer.playingTrack.duration
-                val songDuration = MusicPlayerHelper.formatTime(duration)
+                val songDuration = formatTime(duration)
                 interactionHook
                     .sendMessage("HEY FREAK-SHOW! YOU AIN’T GOIN’ NOWHERE. I GOTCHA’ FOR $songDuration, $songDuration OF PLAYTIME!")
                     .queue(invokeDeleteOnMessageResponse(deleteDelay))

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/music/channel/JoinCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/music/channel/JoinCommand.kt
@@ -1,8 +1,8 @@
 package bot.toby.command.commands.music.channel
 
 import bot.toby.command.commands.music.MusicCommand
-import bot.toby.handler.VoiceEventHandler.Companion.lastConnectedChannel
 import bot.toby.lavaplayer.PlayerManager
+import bot.toby.voice.LastConnectedChannelTracker
 import core.command.Command.Companion.invokeDeleteOnMessageResponse
 import core.command.CommandContext
 import database.dto.ConfigDto
@@ -14,7 +14,10 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 @Component
-class JoinCommand @Autowired constructor(private val configService: ConfigService) : MusicCommand {
+class JoinCommand @Autowired constructor(
+    private val configService: ConfigService,
+    private val lastConnectedChannelTracker: LastConnectedChannelTracker,
+) : MusicCommand {
 
     override fun handle(ctx: CommandContext, requestingUserDto: UserDto, deleteDelay: Int) {
         handleMusicCommand(ctx, PlayerManager.instance, requestingUserDto, deleteDelay)
@@ -45,7 +48,7 @@ class JoinCommand @Autowired constructor(private val configService: ConfigServic
         }
 
         memberChannel?.let { audioManager.openAudioConnection(it) }
-        lastConnectedChannel[event.guild!!.idLong] = memberChannel!!
+        lastConnectedChannelTracker.set(event.guild!!.idLong, memberChannel!!.idLong)
         val volumePropertyName = ConfigDto.Configurations.VOLUME.configValue
         val databaseConfig = configService.getConfigByName(volumePropertyName, event.guild?.id)
         val defaultVolume = databaseConfig?.value?.toInt() ?: 100

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/music/channel/JoinCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/music/channel/JoinCommand.kt
@@ -10,11 +10,10 @@ import database.dto.UserDto
 import database.service.ConfigService
 import net.dv8tion.jda.api.Permission
 import net.dv8tion.jda.api.entities.GuildVoiceState
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 @Component
-class JoinCommand @Autowired constructor(
+class JoinCommand(
     private val configService: ConfigService,
     private val lastConnectedChannelTracker: LastConnectedChannelTracker,
 ) : MusicCommand {

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/music/channel/LeaveCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/music/channel/LeaveCommand.kt
@@ -12,11 +12,10 @@ import database.service.ConfigService
 import net.dv8tion.jda.api.entities.GuildVoiceState
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
 import net.dv8tion.jda.api.managers.AudioManager
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 @Component
-class LeaveCommand @Autowired constructor(
+class LeaveCommand(
     private val configService: ConfigService,
     private val lastConnectedChannelTracker: LastConnectedChannelTracker,
 ) : MusicCommand {

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/music/channel/LeaveCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/music/channel/LeaveCommand.kt
@@ -1,9 +1,9 @@
 package bot.toby.command.commands.music.channel
 
 import bot.toby.command.commands.music.MusicCommand
-import bot.toby.handler.VoiceEventHandler.Companion.lastConnectedChannel
 import bot.toby.lavaplayer.GuildMusicManager
 import bot.toby.lavaplayer.PlayerManager
+import bot.toby.voice.LastConnectedChannelTracker
 import core.command.Command.Companion.invokeDeleteOnMessageResponse
 import core.command.CommandContext
 import database.dto.ConfigDto
@@ -16,7 +16,10 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 @Component
-class LeaveCommand @Autowired constructor(private val configService: ConfigService) : MusicCommand {
+class LeaveCommand @Autowired constructor(
+    private val configService: ConfigService,
+    private val lastConnectedChannelTracker: LastConnectedChannelTracker,
+) : MusicCommand {
 
     override fun handle(ctx: CommandContext, requestingUserDto: UserDto, deleteDelay: Int) {
         handleMusicCommand(ctx, PlayerManager.instance, requestingUserDto, deleteDelay)
@@ -70,7 +73,7 @@ class LeaveCommand @Autowired constructor(private val configService: ConfigServi
             volume = defaultVolume
         }
         audioManager.closeAudioConnection()
-        lastConnectedChannel.remove(event.guild!!.idLong)
+        lastConnectedChannelTracker.clear(event.guild!!.idLong)
 
         event.hook
             .sendMessage("Disconnecting from `\uD83D\uDD0A ${selfVoiceState?.channel?.name}`")

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/music/player/NowDigOnThisCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/music/player/NowDigOnThisCommand.kt
@@ -1,9 +1,9 @@
 package bot.toby.command.commands.music.player
 
 import bot.toby.command.commands.music.MusicCommand
-import bot.toby.helpers.MusicPlayerHelper
 import bot.toby.helpers.URLHelper
 import bot.toby.lavaplayer.PlayerManager
+import bot.toby.util.adjustTrackPlayingTimes
 import core.command.Command.Companion.invokeDeleteOnMessageResponse
 import core.command.CommandContext
 import database.dto.UserDto
@@ -53,7 +53,7 @@ class NowDigOnThisCommand : MusicCommand {
             link = "ytsearch:$link"
         }
 
-        val startPosition = MusicPlayerHelper.adjustTrackPlayingTimes(event.getOption(START_POSITION)?.asLong ?: 0L)
+        val startPosition = adjustTrackPlayingTimes(event.getOption(START_POSITION)?.asLong ?: 0L)
         val musicManager = instance.getMusicManager(ctx.guild)
         val volume = event.getOption(VOLUME)?.asInt ?: musicManager.audioPlayer.volume
 

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/music/player/PlayCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/music/player/PlayCommand.kt
@@ -3,6 +3,8 @@ package bot.toby.command.commands.music.player
 import bot.toby.command.commands.music.MusicCommand
 import bot.toby.helpers.MusicPlayerHelper
 import bot.toby.lavaplayer.PlayerManager
+import bot.toby.util.adjustTrackPlayingTimes
+import bot.toby.util.isUrl
 import core.command.CommandContext
 import database.dto.UserDto
 import net.dv8tion.jda.api.interactions.commands.OptionType
@@ -29,7 +31,7 @@ class PlayCommand : MusicCommand {
         val guild = event.guild ?: return
         val musicManager = instance.getMusicManager(guild)
 
-        val startPosition = MusicPlayerHelper.adjustTrackPlayingTimes(
+        val startPosition = adjustTrackPlayingTimes(
             event.getOption(START_POSITION)?.asLong ?: 0L
         )
         val volume = event.getOption(VOLUME)?.asInt ?: musicManager.audioPlayer.volume
@@ -41,7 +43,7 @@ class PlayCommand : MusicCommand {
 
             "link" -> {
                 var link = event.getOption(LINK)?.asString ?: ""
-                if (link.contains("youtube") && MusicPlayerHelper.isUrl(link).isEmpty()) {
+                if (link.contains("youtube") && isUrl(link).isEmpty()) {
                     link = "ytsearch:$link"
                 }
                 instance.loadAndPlay(guild, event, link, true, deleteDelay, startPosition, volume)

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/music/player/QueueCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/music/player/QueueCommand.kt
@@ -1,8 +1,8 @@
 package bot.toby.command.commands.music.player
 
 import bot.toby.command.commands.music.MusicCommand
-import bot.toby.helpers.MusicPlayerHelper
 import bot.toby.lavaplayer.PlayerManager
+import bot.toby.util.formatTime
 import com.sedmelluq.discord.lavaplayer.track.AudioTrack
 import core.command.CommandContext
 import database.dto.UserDto
@@ -49,7 +49,7 @@ class QueueCommand : MusicCommand {
                     .addContent(" by ")
                     .addContent(info?.author!!)
                     .addContent("` [`")
-                    .addContent(MusicPlayerHelper.formatTime(track.duration))
+                    .addContent(formatTime(track.duration))
                     .addContent("`]\n")
         }
         if (trackList.size > trackCount) {

--- a/discord-bot/src/main/kotlin/bot/toby/handler/VoiceEventHandler.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/handler/VoiceEventHandler.kt
@@ -1,21 +1,19 @@
 package bot.toby.handler
 
 import bot.toby.helpers.IntroHelper
+import bot.toby.helpers.MusicPlayerHelper
 import bot.toby.helpers.MusicPlayerHelper.playUserIntro
 import bot.toby.helpers.UserDtoHelper
 import bot.toby.helpers.UserDtoHelper.Companion.getRequestingUserDto
 import bot.toby.helpers.nonBots
 import bot.toby.lavaplayer.PlayerManager
-import bot.toby.voice.VoiceCompanyTracker
-import bot.toby.voice.VoiceCreditAwardService
+import bot.toby.voice.LastConnectedChannelTracker
+import bot.toby.voice.VoiceSessionLifecycle
 import common.logging.DiscordLogger
 import database.dto.ConfigDto.Configurations.DELETE_DELAY
 import database.dto.ConfigDto.Configurations.VOLUME
-import database.dto.VoiceSessionDto
 import database.service.ConfigService
 import database.service.SocialCreditAwardService
-import database.service.VoiceSessionService
-import bot.toby.helpers.MusicPlayerHelper
 import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.entities.channel.concrete.VoiceChannel
 import net.dv8tion.jda.api.entities.channel.middleman.AudioChannel
@@ -24,22 +22,19 @@ import net.dv8tion.jda.api.events.guild.voice.GuildVoiceUpdateEvent
 import net.dv8tion.jda.api.events.session.ReadyEvent
 import net.dv8tion.jda.api.hooks.ListenerAdapter
 import net.dv8tion.jda.api.managers.AudioManager
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
 import java.time.Instant
-import java.util.concurrent.ConcurrentHashMap
 
 private const val TEAM_REGEX = "(?i)team\\s[0-9]+"
 
 @Service
-class VoiceEventHandler @Autowired constructor(
+class VoiceEventHandler(
     private val configService: ConfigService,
     private val userDtoHelper: UserDtoHelper,
     private val introHelper: IntroHelper,
-    private val voiceSessionService: VoiceSessionService,
-    private val voiceCompanyTracker: VoiceCompanyTracker,
-    private val voiceCreditAwardService: VoiceCreditAwardService,
-    private val awardService: SocialCreditAwardService
+    private val voiceSessionLifecycle: VoiceSessionLifecycle,
+    private val lastConnectedChannelTracker: LastConnectedChannelTracker,
+    private val awardService: SocialCreditAwardService,
 ) : ListenerAdapter() {
 
     private val logger: DiscordLogger = DiscordLogger.createLogger(this::class.java)
@@ -51,14 +46,13 @@ class VoiceEventHandler @Autowired constructor(
             // Reconcile voice state: any non-bot member already in a voice
             // channel needs an open voice_session row, otherwise their
             // eventual leave event has nothing to close and the post-restart
-            // span gets silently dropped. The recovery hook just closed any
-            // *pre-restart* sessions; this opens fresh ones from this moment.
+            // span gets silently dropped.
             var reopened = 0
             guild.voiceChannels.forEach { channel ->
                 channel.members
                     .filter { !it.user.isBot }
                     .forEach { member ->
-                        runCatching { openSessionForUser(member.idLong, guild.idLong, channel, now) }
+                        runCatching { voiceSessionLifecycle.openSession(member.idLong, guild.idLong, channel, now) }
                             .onSuccess { reopened++ }
                             .onFailure {
                                 logger.error(
@@ -68,9 +62,6 @@ class VoiceEventHandler @Autowired constructor(
                             }
                     }
             }
-            // Always log the count, even when zero — silence is ambiguous, and
-            // we need to be able to confirm in production logs whether the
-            // reconciliation loop actually ran for this guild.
             logger.info { "Startup voice reconciliation: opened $reopened session(s) in guild ${guild.idLong}." }
             guild.connectToMostPopulatedVoiceChannel()
         }
@@ -81,6 +72,10 @@ class VoiceEventHandler @Autowired constructor(
         logger.info { "Guild $guildId left — cleaning up audio resources" }
         PlayerManager.instance.destroyMusicManager(guildId)
         MusicPlayerHelper.nowPlayingManager.resetNowPlayingMessage(guildId)
+        // The bot is no longer in this guild; the cached channel reference is
+        // dead weight (and pins a stale JDA VoiceChannel via id alone is moot
+        // here since we only kept ids — but the entry is still useless).
+        lastConnectedChannelTracker.clear(guildId)
     }
 
     private fun Guild.connectToMostPopulatedVoiceChannel() {
@@ -139,10 +134,9 @@ class VoiceEventHandler @Autowired constructor(
         val guild = event.guild
         val audioManager = guild.audioManager
 
-        // Check if the bot is being moved
         if (member.user.idLong == tobyBot.idLong) {
             logger.info { "${tobyBot.name} has been moved, checking for previous channel to rejoin..." }
-            val previousChannel = lastConnectedChannel[guild.idLong]
+            val previousChannel = lastConnectedChannelTracker.resolveChannel(guild)
             if (previousChannel != null) {
                 logger.info { "Rejoining '${previousChannel.name}'" }
                 audioManager.rejoin(previousChannel)
@@ -152,9 +146,8 @@ class VoiceEventHandler @Autowired constructor(
         } else {
             logger.info { "User '${member.effectiveName}' has moved, checking if AudioConnection should close..." }
             val now = Instant.now()
-            closeSessionForUser(member.idLong, guild.idLong, now)
-            event.channelLeft?.let { voiceCompanyTracker.reconcileChannel(it, now) }
-            event.channelJoined?.let { openSessionForUser(member.idLong, guild.idLong, it, now) }
+            voiceSessionLifecycle.closeSession(member.idLong, guild.idLong, event.channelLeft, now)
+            event.channelJoined?.let { voiceSessionLifecycle.openSession(member.idLong, guild.idLong, it, now) }
             audioManager.checkAudioManagerToCloseConnectionOnEmptyChannel()
             val defaultVolume = getConfigValue(VOLUME.configValue, guild.id)
             checkStateAndConnectToVoiceChannel(event, audioManager, guild, defaultVolume)
@@ -182,7 +175,7 @@ class VoiceEventHandler @Autowired constructor(
 
         if (event.member.user.idLong != event.jda.selfUser.idLong) {
             val now = Instant.now()
-            event.channelJoined?.let { openSessionForUser(event.member.idLong, guild.idLong, it, now) }
+            event.channelJoined?.let { voiceSessionLifecycle.openSession(event.member.idLong, guild.idLong, it, now) }
         }
 
         val requestingUserDto = event.member.getRequestingUserDto(userDtoHelper)
@@ -202,14 +195,15 @@ class VoiceEventHandler @Autowired constructor(
         guild: Guild,
         defaultVolume: Int
     ) {
-        //Ignore the bot joining voice event
         if (event.member.user.idLong != event.jda.selfUser.idLong) {
             val joinedChannelConnectedMembers = event.channelJoined?.members?.nonBots() ?: emptyList()
             if (joinedChannelConnectedMembers.isNotEmpty() && !audioManager.isConnected) {
                 logger.info { "Joining new channel '${event.channelJoined?.name}'." }
                 PlayerManager.instance.getMusicManager(guild).audioPlayer.volume = defaultVolume
-                event.channelJoined?.let { audioManager.openAudioConnection(it) }
-                lastConnectedChannel[guild.idLong] = event.channelJoined!!.asVoiceChannel()
+                event.channelJoined?.let { joined ->
+                    audioManager.openAudioConnection(joined)
+                    lastConnectedChannelTracker.set(guild.idLong, joined.idLong)
+                }
             }
         }
     }
@@ -246,37 +240,10 @@ class VoiceEventHandler @Autowired constructor(
         val member = event.member
         if (member.user.idLong != event.jda.selfUser.idLong) {
             val now = Instant.now()
-            closeSessionForUser(member.idLong, guild.idLong, now)
-            event.channelLeft?.let { voiceCompanyTracker.reconcileChannel(it, now) }
+            voiceSessionLifecycle.closeSession(member.idLong, guild.idLong, event.channelLeft, now)
         }
         audioManager.checkAudioManagerToCloseConnectionOnEmptyChannel()
         event.channelLeft?.let { deleteTemporaryChannelIfEmpty(it.members.nonBots().isEmpty(), it) }
-    }
-
-    private fun openSessionForUser(userId: Long, guildId: Long, channel: AudioChannel, now: Instant) {
-        runCatching {
-            voiceSessionService.findOpenSession(userId, guildId)?.let { stale ->
-                val companySeconds = voiceCompanyTracker.stopTracking(userId, guildId, now)
-                voiceCreditAwardService.closeSessionAndAward(stale, now, companySeconds)
-            }
-            voiceCompanyTracker.reconcileChannel(channel, now)
-            val session = VoiceSessionDto(
-                discordId = userId,
-                guildId = guildId,
-                channelId = channel.idLong,
-                joinedAt = now
-            )
-            voiceSessionService.openSession(session)
-            voiceCompanyTracker.startTracking(userId, guildId, channel, now)
-        }.onFailure { logger.error("Failed to open voice session for user $userId: ${it.message}") }
-    }
-
-    private fun closeSessionForUser(userId: Long, guildId: Long, now: Instant) {
-        runCatching {
-            val open = voiceSessionService.findOpenSession(userId, guildId) ?: return
-            val companySeconds = voiceCompanyTracker.stopTracking(userId, guildId, now)
-            voiceCreditAwardService.closeSessionAndAward(open, now, companySeconds)
-        }.onFailure { logger.error("Failed to close voice session for user $userId: ${it.message}") }
     }
 
     private fun AudioManager.checkAudioManagerToCloseConnectionOnEmptyChannel() {
@@ -285,7 +252,7 @@ class VoiceEventHandler @Autowired constructor(
             if (connectedChannel.members.nonBots().isEmpty()) {
                 this.closeAudioConnection()
                 logger.info("Audio connection closed due to empty channel.")
-                lastConnectedChannel.remove(this.guild.idLong)
+                lastConnectedChannelTracker.clear(this.guild.idLong)
             }
         }
     }
@@ -303,8 +270,6 @@ class VoiceEventHandler @Autowired constructor(
     }
 
     companion object {
-        val lastConnectedChannel = ConcurrentHashMap<Long, VoiceChannel>()
-
         // Small, daily-capped reward so joining a channel with an intro set
         // feels like something without becoming farmable via rejoin spam.
         const val INTRO_PLAY_CREDIT: Long = 2L

--- a/discord-bot/src/main/kotlin/bot/toby/handler/VoiceEventHandler.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/handler/VoiceEventHandler.kt
@@ -1,12 +1,12 @@
 package bot.toby.handler
 
 import bot.toby.helpers.IntroHelper
-import bot.toby.helpers.MusicPlayerHelper
 import bot.toby.helpers.MusicPlayerHelper.playUserIntro
 import bot.toby.helpers.UserDtoHelper
 import bot.toby.helpers.UserDtoHelper.Companion.getRequestingUserDto
 import bot.toby.helpers.nonBots
 import bot.toby.lavaplayer.PlayerManager
+import bot.toby.managers.NowPlayingManager
 import bot.toby.voice.LastConnectedChannelTracker
 import bot.toby.voice.VoiceSessionLifecycle
 import common.logging.DiscordLogger
@@ -35,6 +35,7 @@ class VoiceEventHandler(
     private val voiceSessionLifecycle: VoiceSessionLifecycle,
     private val lastConnectedChannelTracker: LastConnectedChannelTracker,
     private val awardService: SocialCreditAwardService,
+    private val nowPlayingManager: NowPlayingManager,
 ) : ListenerAdapter() {
 
     private val logger: DiscordLogger = DiscordLogger.createLogger(this::class.java)
@@ -71,7 +72,7 @@ class VoiceEventHandler(
         val guildId = event.guild.idLong
         logger.info { "Guild $guildId left — cleaning up audio resources" }
         PlayerManager.instance.destroyMusicManager(guildId)
-        MusicPlayerHelper.nowPlayingManager.resetNowPlayingMessage(guildId)
+        nowPlayingManager.resetNowPlayingMessage(guildId)
         // The bot is no longer in this guild; the cached channel reference is
         // dead weight (and pins a stale JDA VoiceChannel via id alone is moot
         // here since we only kept ids — but the entry is still useless).

--- a/discord-bot/src/main/kotlin/bot/toby/helpers/IntroHelper.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/helpers/IntroHelper.kt
@@ -20,7 +20,6 @@ import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEve
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent
 import net.dv8tion.jda.api.interactions.callbacks.IReplyCallback
 import org.jetbrains.annotations.VisibleForTesting
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
 import java.io.InputStream
 import java.net.URI
@@ -28,7 +27,7 @@ import kotlin.time.Duration.Companion.minutes
 import kotlin.time.DurationUnit
 
 @Service
-class IntroHelper @Autowired constructor(
+class IntroHelper(
     private val userDtoHelper: UserDtoHelper,
     private val musicFileService: MusicFileService,
     private val configService: ConfigService,

--- a/discord-bot/src/main/kotlin/bot/toby/helpers/IntroHelper.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/helpers/IntroHelper.kt
@@ -1,7 +1,7 @@
 package bot.toby.helpers
 
 import bot.toby.handler.EventWaiter
-import bot.toby.helpers.MusicPlayerHelper.isUrl
+import bot.toby.util.isUrl
 import common.logging.DiscordLogger
 import core.command.Command.Companion.invokeDeleteOnMessageResponse
 import database.dto.ConfigDto

--- a/discord-bot/src/main/kotlin/bot/toby/helpers/IntroHelper.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/helpers/IntroHelper.kt
@@ -1,6 +1,7 @@
 package bot.toby.helpers
 
 import bot.toby.handler.EventWaiter
+import bot.toby.intro.IntroValidationService
 import bot.toby.util.isUrl
 import common.logging.DiscordLogger
 import core.command.Command.Companion.invokeDeleteOnMessageResponse
@@ -19,21 +20,22 @@ import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEve
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent
 import net.dv8tion.jda.api.interactions.callbacks.IReplyCallback
 import org.jetbrains.annotations.VisibleForTesting
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
 import java.io.InputStream
 import java.net.URI
 import kotlin.time.Duration.Companion.minutes
-import kotlin.time.Duration.Companion.seconds
 import kotlin.time.DurationUnit
 
 @Service
-class IntroHelper(
+class IntroHelper @Autowired constructor(
     private val userDtoHelper: UserDtoHelper,
     private val musicFileService: MusicFileService,
     private val configService: ConfigService,
     private val httpHelper: HttpHelper,
     private val eventWaiter: EventWaiter,
-    private val dispatcher: CoroutineDispatcher = Dispatchers.IO
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val validationService: IntroValidationService = IntroValidationService(httpHelper, dispatcher),
 ) {
     private val logger: DiscordLogger = DiscordLogger.createLogger(this::class.java)
     private val supervisorJob = SupervisorJob()
@@ -65,8 +67,8 @@ class IntroHelper(
         when (input) {
             is InputData.Attachment -> {
                 // Validate the attachment before proceeding
-                if (!isValidAttachment(input.attachment)) {
-                    event.hook.sendMessage("Please provide a valid mp3 file under ${MAX_FILE_SIZE_KB}kb.")
+                if (!validationService.isValidAttachment(input.attachment)) {
+                    event.hook.sendMessage("Please provide a valid mp3 file under ${IntroValidationService.MAX_FILE_SIZE_KB}kb.")
                         .queue(invokeDeleteOnMessageResponse(deleteDelay))
                     return
                 }
@@ -107,11 +109,6 @@ class IntroHelper(
         }
     }
 
-    private fun isValidAttachment(attachment: Attachment): Boolean {
-        return attachment.fileExtension == "mp3" && attachment.size <= MAX_FILE_SIZE
-    }
-
-
     fun handleAttachment(
         event: IReplyCallback,
         requestingUserDto: database.dto.UserDto,
@@ -130,9 +127,9 @@ class IntroHelper(
                     .queue(invokeDeleteOnMessageResponse(deleteDelay))
             }
 
-            attachment.size > MAX_FILE_SIZE -> {
+            attachment.size > IntroValidationService.MAX_FILE_SIZE -> {
                 logger.info { "File size was too large" }
-                event.hook.sendMessage("Please keep the file size under ${MAX_FILE_SIZE_KB}kb")
+                event.hook.sendMessage("Please keep the file size under ${IntroValidationService.MAX_FILE_SIZE_KB}kb")
                     .queue(invokeDeleteOnMessageResponse(deleteDelay))
             }
 
@@ -165,7 +162,7 @@ class IntroHelper(
     ) {
         logger.setGuildAndMemberContext(event.guild, event.member)
         logger.info { "Handling URL inside intro helper..." }
-        val urlString = uri.toString().convertShortsUrls()
+        val urlString = validationService.convertShortsUrls(uri.toString())
         coroutineScope.launch {
             val title = runCatching { httpHelper.getYouTubeVideoTitle(urlString) }.getOrNull()
             persistMusicUrl(
@@ -180,8 +177,6 @@ class IntroHelper(
             )
         }
     }
-
-    fun String.convertShortsUrls() = this.replace("/shorts/", "/watch?v=" )
 
     fun findUserById(discordId: Long, guildId: Long) = userDtoHelper.calculateUserDto(guildId, discordId)
 
@@ -390,12 +385,12 @@ class IntroHelper(
         val inputData = InputData.Attachment(attachment)
         logger.info("User uploaded a music file: $inputData")
 
-        if (!isValidAttachment(attachment)) {
+        if (!validationService.isValidAttachment(attachment)) {
             handleInvalidAttachment(channel, event.author, guild)
             return
         }
 
-        val volume = parseVolume(content)
+        val volume = validationService.parseVolume(content)
         saveUserMusicDto(event.author, guild, inputData, volume)
     }
 
@@ -405,13 +400,13 @@ class IntroHelper(
         // Validate the intro length asynchronously
         coroutineScope.launch {
             try {
-                val isOverLimit = checkForOverlyLongIntroDuration(content)
+                val isOverLimit = validationService.checkForOverlyLongIntroDuration(content)
                 if (isOverLimit) {
                     handleOverLimitIntro(channel, event.author, guild)
                 } else {
                     val title = runCatching { httpHelper.getYouTubeVideoTitle(content) }.getOrNull()
                     val inputData = InputData.Url(isUrl(content))
-                    saveUserMusicDto(event.author, guild, inputData, parseVolume(content), title)
+                    saveUserMusicDto(event.author, guild, inputData, validationService.parseVolume(content), title)
                 }
             } catch (_: Exception) {
                 logger.error { "Error checking intro length for '$content'" }
@@ -429,41 +424,24 @@ class IntroHelper(
     }
 
     private fun handleOverLimitIntro(channel: PrivateChannel, author: User, guild: Guild) {
-        logger.info { "Intro was rejected for being over the specified intro limit length of ${INTRO_LIMIT.inWholeSeconds} seconds, trying again..." }
+        logger.info { "Intro was rejected for being over the specified intro limit length of ${IntroValidationService.INTRO_LIMIT.inWholeSeconds} seconds, trying again..." }
         channel
-            .sendMessage("Intro provided was over ${INTRO_LIMIT.inWholeSeconds} seconds long, out of courtesy please pick a shorter intro.")
+            .sendMessage("Intro provided was over ${IntroValidationService.INTRO_LIMIT.inWholeSeconds} seconds long, out of courtesy please pick a shorter intro.")
             .queue()
         setupWaiterForIntroMessage(author, channel, guild)
     }
 
-    fun validateIntroLength(url: String, onResult: (Boolean) -> Unit) {
-        logger.info { "Checking duration of '$url'" }
-        coroutineScope.launch {
-            try {
-                val isOverLimit = checkForOverlyLongIntroDuration(url)
-                onResult(isOverLimit)
-            } catch (_: Exception) {
-                logger.error { "Error checking intro length for '$url'" }
-                onResult(true) // You can choose to handle this differently
-            }
-        }
-    }
+    /**
+     * Public delegations preserved so existing callers/tests don't have to
+     * be rewired in the same change.
+     */
+    fun validateIntroLength(url: String, onResult: (Boolean) -> Unit) =
+        validationService.validateIntroLength(url, onResult)
 
-    suspend fun checkForOverlyLongIntroDuration(url: String): Boolean {
-        val duration = withContext(dispatcher) { httpHelper.getYouTubeVideoDuration(url) }
-        if (duration != null) {
-            logger.info { "Duration of intro is '$duration' vs limit of '$INTRO_LIMIT'" }
-            return duration > INTRO_LIMIT
-        }
-        return false
-    }
+    suspend fun checkForOverlyLongIntroDuration(url: String): Boolean =
+        validationService.checkForOverlyLongIntroDuration(url)
 
-    fun parseVolume(content: String): Int? {
-        // Try to extract a volume value (0-100) from the message content
-        val volumeRegex = """\b(\d{1,3})\b""".toRegex()
-        val volumeMatch = volumeRegex.find(content)
-        return volumeMatch?.value?.toIntOrNull()?.takeIf { it in 0..100 }
-    }
+    fun parseVolume(content: String): Int? = validationService.parseVolume(content)
 
     @VisibleForTesting
     fun saveUserMusicDto(user: User, guild: Guild, inputData: InputData, volume: Int?, displayName: String? = null) {
@@ -515,10 +493,13 @@ class IntroHelper(
 
     companion object {
         private const val VOLUME = "volume"
-        const val MAX_FILE_SIZE = 550 * 1024
-        const val MAX_FILE_SIZE_KB = "${MAX_FILE_SIZE / 1024}"
-        val INTRO_LIMIT = 15.seconds
 
+        // Backwards-compat aliases — canonical values live on
+        // [IntroValidationService.Companion]. Existing callers (SetIntroCommand,
+        // tests) still see the same constants here.
+        const val MAX_FILE_SIZE = IntroValidationService.MAX_FILE_SIZE
+        const val MAX_FILE_SIZE_KB = IntroValidationService.MAX_FILE_SIZE_KB
+        val INTRO_LIMIT = IntroValidationService.INTRO_LIMIT
     }
 }
 

--- a/discord-bot/src/main/kotlin/bot/toby/helpers/IntroHelper.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/helpers/IntroHelper.kt
@@ -1,8 +1,9 @@
 package bot.toby.helpers
 
 import bot.toby.handler.EventWaiter
+import bot.toby.intro.IntroMediaLoader
+import bot.toby.intro.IntroNotificationService
 import bot.toby.intro.IntroValidationService
-import bot.toby.util.isUrl
 import common.logging.DiscordLogger
 import core.command.Command.Companion.invokeDeleteOnMessageResponse
 import database.dto.ConfigDto
@@ -10,21 +11,21 @@ import database.dto.MusicDto
 import database.dto.MusicDto.Companion.computeHash
 import database.service.ConfigService
 import database.service.MusicFileService
-import kotlinx.coroutines.*
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.entities.Message
 import net.dv8tion.jda.api.entities.Message.Attachment
 import net.dv8tion.jda.api.entities.User
-import net.dv8tion.jda.api.entities.channel.concrete.PrivateChannel
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
-import net.dv8tion.jda.api.events.message.MessageReceivedEvent
 import net.dv8tion.jda.api.interactions.callbacks.IReplyCallback
 import org.jetbrains.annotations.VisibleForTesting
 import org.springframework.stereotype.Service
 import java.io.InputStream
 import java.net.URI
-import kotlin.time.Duration.Companion.minutes
-import kotlin.time.DurationUnit
 
 @Service
 class IntroHelper(
@@ -35,12 +36,18 @@ class IntroHelper(
     private val eventWaiter: EventWaiter,
     private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
     private val validationService: IntroValidationService = IntroValidationService(httpHelper, dispatcher),
+    private val mediaLoader: IntroMediaLoader = IntroMediaLoader(),
+    private val notificationService: IntroNotificationService = IntroNotificationService(
+        userDtoHelper, musicFileService, httpHelper, eventWaiter, validationService, mediaLoader, dispatcher,
+    ),
 ) {
     private val logger: DiscordLogger = DiscordLogger.createLogger(this::class.java)
     private val supervisorJob = SupervisorJob()
     private val coroutineScope = CoroutineScope(supervisorJob + dispatcher)
 
-    // Store the pending intro in a cache (as either an attachment or a URL string)
+    // Per-user pending intro cache, written by /setintro and read by the
+    // confirmation menu. Distinct from the DM prompt flow, which lives in
+    // IntroNotificationService.
     val pendingIntros = mutableMapOf<Long, Triple<Attachment?, String?, Int>?>()
 
     fun calculateIntroVolume(event: SlashCommandInteractionEvent): Int {
@@ -65,21 +72,12 @@ class IntroHelper(
 
         when (input) {
             is InputData.Attachment -> {
-                // Validate the attachment before proceeding
                 if (!validationService.isValidAttachment(input.attachment)) {
                     event.hook.sendMessage("Please provide a valid mp3 file under ${IntroValidationService.MAX_FILE_SIZE_KB}kb.")
                         .queue(invokeDeleteOnMessageResponse(deleteDelay))
                     return
                 }
-                handleAttachment(
-                    event,
-                    requestingUserDto,
-                    userName,
-                    deleteDelay,
-                    input.attachment,
-                    introVolume,
-                    selectedMusicDto
-                )
+                handleAttachment(event, requestingUserDto, userName, deleteDelay, input.attachment, introVolume, selectedMusicDto)
             }
 
             is InputData.Url -> {
@@ -90,15 +88,7 @@ class IntroHelper(
                     return
                 }
                 val uri = URI.create(uriString)
-                handleUrl(
-                    event,
-                    requestingUserDto,
-                    userName,
-                    deleteDelay,
-                    uri,
-                    introVolume,
-                    selectedMusicDto
-                )
+                handleUrl(event, requestingUserDto, userName, deleteDelay, uri, introVolume, selectedMusicDto)
             }
 
             else -> {
@@ -135,16 +125,7 @@ class IntroHelper(
             else -> {
                 val inputStream = downloadAttachment(attachment)
                 inputStream?.let {
-                    persistMusicFile(
-                        event,
-                        requestingUserDto,
-                        userName,
-                        deleteDelay,
-                        attachment.fileName,
-                        introVolume,
-                        it,
-                        selectedMusicDto,
-                    )
+                    persistMusicFile(event, requestingUserDto, userName, deleteDelay, attachment.fileName, introVolume, it, selectedMusicDto)
                 }
             }
         }
@@ -164,16 +145,7 @@ class IntroHelper(
         val urlString = validationService.convertShortsUrls(uri.toString())
         coroutineScope.launch {
             val title = runCatching { httpHelper.getYouTubeVideoTitle(urlString) }.getOrNull()
-            persistMusicUrl(
-                event,
-                requestingUserDto,
-                deleteDelay,
-                title ?: urlString,
-                urlString,
-                userName,
-                introVolume,
-                selectedMusicDto
-            )
+            persistMusicUrl(event, requestingUserDto, deleteDelay, title ?: urlString, urlString, userName, introVolume, selectedMusicDto)
         }
     }
 
@@ -185,15 +157,7 @@ class IntroHelper(
 
     fun deleteIntro(musicDto: MusicDto) = musicFileService.deleteMusicFileById(musicDto.id)
 
-    private fun createIntro(musicDto: MusicDto) = musicFileService.createNewMusicFile(musicDto)
-
-    fun downloadAttachment(attachment: Attachment): InputStream? {
-        return runCatching {
-            attachment.proxy.download().get()
-        }.onFailure {
-            it.printStackTrace()
-        }.getOrNull()
-    }
+    fun downloadAttachment(attachment: Attachment): InputStream? = mediaLoader.downloadAttachment(attachment)
 
     @VisibleForTesting
     fun persistMusicFile(
@@ -208,7 +172,7 @@ class IntroHelper(
     ) {
         logger.setGuildAndMemberContext(event.guild, event.member)
         logger.info { "Persisting music file" }
-        val fileContents = getFileContents(inputStream)
+        val fileContents = mediaLoader.readContents(inputStream)
             ?: return event.hook.sendMessageFormat("Unable to read file '%s'", filename)
                 .setEphemeral(true)
                 .queue(invokeDeleteOnMessageResponse(deleteDelay))
@@ -229,17 +193,12 @@ class IntroHelper(
             musicFileService.createNewMusicFile(musicDto)
                 ?.let { sendSuccessMessage(event, userName, filename, introVolume, index, deleteDelay) }
                 ?: rejectIntroForDuplication(event, userName, filename, deleteDelay)
-
         } else {
             musicFileService.updateMusicFile(musicDto)
                 ?.let { sendUpdateMessage(event, userName, filename, introVolume, musicDto.index!!, deleteDelay) }
                 ?: rejectIntroForDuplication(event, userName, filename, deleteDelay)
-
         }
     }
-
-    private fun getFileContents(inputStream: InputStream) =
-        runCatching { FileUtils.readInputStreamToByteArray(inputStream) }.getOrNull()
 
     fun persistMusicUrl(
         event: IReplyCallback,
@@ -324,116 +283,23 @@ class IntroHelper(
             .queue(invokeDeleteOnMessageResponse(deleteDelay))
     }
 
-    fun promptUserForMusicInfo(user: User, guild: Guild) {
-        logger.setGuildAndUserContext(guild, user)
-        logger.info { "Prompting user to set an intro for the server that they don't have one on" }
-        user.openPrivateChannel().queue { channel ->
-            channel.sendMessage("You don't have an intro song yet on server '${guild.name}'! Please reply with a YouTube URL or upload a music file, and optionally provide a volume level (1-100). E.g. 'https://www.youtube.com/watch?v=VIDEO_ID_HERE 90'")
-                .queue(invokeDeleteOnMessageResponse(5.minutes.toInt(DurationUnit.SECONDS)))
-
-            // Wait for a response in the user's DM
-            setupWaiterForIntroMessage(user, channel, guild)
-        }
-    }
-
-    private fun setupWaiterForIntroMessage(
-        user: User,
-        channel: PrivateChannel,
-        guild: Guild
-    ) {
-        eventWaiter.waitForMessage(
-            { event -> event.author.idLong == user.idLong && event.channel == channel },
-            { event -> handleUserMusicResponse(event, channel, guild) },
-            5.minutes,
-            {
-                logger.info { "User did not set intro for the server that they don't have one on within the timeout period" }
-                channel.sendMessage("You didn't respond in time, you can always use the '/setintro' command on server '${guild.name}'")
-                    .queue(invokeDeleteOnMessageResponse(5.minutes.toInt(DurationUnit.SECONDS)))
-            }
-        )
-    }
-
-    private fun handleUserMusicResponse(event: MessageReceivedEvent, channel: PrivateChannel, guild: Guild) {
-        val message = event.message
-        val content = message.contentRaw
-        val attachment = message.attachments.firstOrNull()
-
-        when {
-            attachment != null -> {
-                handleAttachmentInput(event, channel, guild, attachment, content)
-            }
-
-            isUrl(content).isNotEmpty() -> {
-                handleUrlInput(event, channel, guild, content)
-            }
-
-            else -> {
-                channel.sendMessage("Please provide a valid URL or upload a file.").queue()
-                setupWaiterForIntroMessage(event.author, channel, guild)
-            }
-        }
-    }
-
-    private fun handleAttachmentInput(
-        event: MessageReceivedEvent,
-        channel: PrivateChannel,
-        guild: Guild,
-        attachment: Attachment,
-        content: String
-    ) {
-        val inputData = InputData.Attachment(attachment)
-        logger.info("User uploaded a music file: $inputData")
-
-        if (!validationService.isValidAttachment(attachment)) {
-            handleInvalidAttachment(channel, event.author, guild)
-            return
-        }
-
-        val volume = validationService.parseVolume(content)
-        saveUserMusicDto(event.author, guild, inputData, volume)
-    }
-
-    private fun handleUrlInput(event: MessageReceivedEvent, channel: PrivateChannel, guild: Guild, content: String) {
-        logger.info("User provided a URL: $content")
-
-        // Validate the intro length asynchronously
-        coroutineScope.launch {
-            try {
-                val isOverLimit = validationService.checkForOverlyLongIntroDuration(content)
-                if (isOverLimit) {
-                    handleOverLimitIntro(channel, event.author, guild)
-                } else {
-                    val title = runCatching { httpHelper.getYouTubeVideoTitle(content) }.getOrNull()
-                    val inputData = InputData.Url(isUrl(content))
-                    saveUserMusicDto(event.author, guild, inputData, validationService.parseVolume(content), title)
-                }
-            } catch (_: Exception) {
-                logger.error { "Error checking intro length for '$content'" }
-                handleOverLimitIntro(channel, event.author, guild)
-            }
-        }
-    }
-
-    private fun handleInvalidAttachment(channel: PrivateChannel, author: User, guild: Guild) {
-        logger.info { "Intro was rejected for not adhering to attachment requirements, trying again..." }
-        channel
-            .sendMessage("Intro provided was either not an mp3 file or too large. Please try again.")
-            .queue()
-        setupWaiterForIntroMessage(author, channel, guild)
-    }
-
-    private fun handleOverLimitIntro(channel: PrivateChannel, author: User, guild: Guild) {
-        logger.info { "Intro was rejected for being over the specified intro limit length of ${IntroValidationService.INTRO_LIMIT.inWholeSeconds} seconds, trying again..." }
-        channel
-            .sendMessage("Intro provided was over ${IntroValidationService.INTRO_LIMIT.inWholeSeconds} seconds long, out of courtesy please pick a shorter intro.")
-            .queue()
-        setupWaiterForIntroMessage(author, channel, guild)
-    }
-
     /**
      * Public delegations preserved so existing callers/tests don't have to
      * be rewired in the same change.
      */
+    fun promptUserForMusicInfo(user: User, guild: Guild) =
+        notificationService.promptUserForMusicInfo(user, guild)
+
+    @VisibleForTesting
+    fun saveUserMusicDto(user: User, guild: Guild, inputData: InputData, volume: Int?, displayName: String? = null) =
+        notificationService.saveUserMusicDto(user, guild, inputData, volume, displayName)
+
+    @VisibleForTesting
+    fun determineMusicBlob(input: InputData): ByteArray? = notificationService.determineMusicBlob(input)
+
+    @VisibleForTesting
+    fun determineFileName(input: InputData): String = notificationService.determineFileName(input)
+
     fun validateIntroLength(url: String, onResult: (Boolean) -> Unit) =
         validationService.validateIntroLength(url, onResult)
 
@@ -441,54 +307,6 @@ class IntroHelper(
         validationService.checkForOverlyLongIntroDuration(url)
 
     fun parseVolume(content: String): Int? = validationService.parseVolume(content)
-
-    @VisibleForTesting
-    fun saveUserMusicDto(user: User, guild: Guild, inputData: InputData, volume: Int?, displayName: String? = null) {
-        // Save the musicDto for the user with the provided URL and volume
-        logger.info("Constructing musicDto from input ...")
-        val requestingUserDto = userDtoHelper.calculateUserDto(user.idLong, guild.idLong)
-        val fileName = displayName ?: determineFileName(inputData)
-        // Logic to save the musicDto in the database
-        val musicDto = MusicDto(requestingUserDto, 1, fileName, volume ?: 90, determineMusicBlob(inputData))
-        createIntro(musicDto)
-        logger.info { "User successfully uploaded intro as a result of the prompt!" }
-        user.openPrivateChannel().queue { channel ->
-            channel.sendMessage("Successfully set your intro on server '${guild.name}'")
-                .queue(invokeDeleteOnMessageResponse(1.minutes.toInt(DurationUnit.SECONDS)))
-        }
-    }
-
-    @VisibleForTesting
-    fun determineMusicBlob(input: InputData): ByteArray? {
-        return when (input) {
-            is InputData.Url -> {
-                logger.info("Processing URL input...")
-                // Logic for handling URL, e.g., downloading content, converting to blob, etc.
-                input.uri.toByteArray()  // Convert the URL to a ByteArray
-            }
-
-            is InputData.Attachment -> {
-                logger.info("Processing attachment input...")
-                val inputStream = downloadAttachment(input.attachment)
-                inputStream?.let { getFileContents(it) }  // Get the file contents as ByteArray if the input stream isn't null
-            }
-        }
-    }
-
-    @VisibleForTesting
-    fun determineFileName(input: InputData): String {
-        return when (input) {
-            is InputData.Url -> {
-                // Ensure the URL is not null or empty
-                input.uri.takeIf { it.isNotBlank() } ?: "" // Provide a default name if the URL is null or blank
-            }
-
-            is InputData.Attachment -> {
-                // Check if the attachment or its fileName is null
-                input.attachment.fileName
-            }
-        }
-    }
 
     companion object {
         private const val VOLUME = "volume"

--- a/discord-bot/src/main/kotlin/bot/toby/helpers/MusicPlayerHelper.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/helpers/MusicPlayerHelper.kt
@@ -5,6 +5,7 @@ import bot.toby.command.commands.music.MusicCommand.Companion.sendDeniedStoppabl
 import bot.toby.lavaplayer.GuildMusicManager
 import bot.toby.lavaplayer.PlayerManager
 import bot.toby.managers.NowPlayingManager
+import bot.toby.util.isUrl as utilIsUrl
 import com.sedmelluq.discord.lavaplayer.player.AudioPlayer
 import com.sedmelluq.discord.lavaplayer.track.AudioTrack
 import common.discord.embed
@@ -13,7 +14,6 @@ import core.command.Command.Companion.invokeDeleteOnMessageResponse
 import core.command.Command.Companion.replyEmbedAndDelete
 import database.dto.MusicDto
 import database.dto.UserDto
-import net.dv8tion.jda.api.EmbedBuilder
 import net.dv8tion.jda.api.components.actionrow.ActionRow
 import net.dv8tion.jda.api.components.buttons.Button
 import net.dv8tion.jda.api.entities.Guild
@@ -22,11 +22,9 @@ import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEve
 import net.dv8tion.jda.api.interactions.InteractionHook
 import net.dv8tion.jda.api.interactions.callbacks.IReplyCallback
 import java.awt.Color
-import java.util.concurrent.TimeUnit
 
 object MusicPlayerHelper {
     private val logger: DiscordLogger = DiscordLogger.createLogger(this::class.java)
-    private const val SECOND_MULTIPLIER = 1000
     val nowPlayingManager = NowPlayingManager()
 
     fun playUserIntro(
@@ -233,41 +231,12 @@ object MusicPlayerHelper {
 
     private fun determineUrlFromMusicDto(it: MusicDto): String {
         // If fileName is a URL, use it directly (backward compatibility)
-        if (isUrl(it.fileName!!).isNotEmpty()) return it.fileName!!
+        if (utilIsUrl(it.fileName!!).isNotEmpty()) return it.fileName!!
         // If musicBlob contains a URL (e.g. fileName stores the video title), use that
         val blobString = it.musicBlob?.let { bytes -> String(bytes) } ?: ""
-        if (isUrl(blobString).isNotEmpty()) return blobString
+        if (utilIsUrl(blobString).isNotEmpty()) return blobString
         // Otherwise, serve the binary data via the web endpoint
         return "$BOT_WEB_URL/music?id=${it.id}"
-    }
-
-    fun formatTime(timeInMillis: Long): String {
-        val hours = TimeUnit.MILLISECONDS.toHours(timeInMillis)
-        val minutes = TimeUnit.MILLISECONDS.toMinutes(timeInMillis) % 60
-        val seconds = TimeUnit.MILLISECONDS.toSeconds(timeInMillis) % 60
-
-        return String.format("%02d:%02d:%02d", hours, minutes, seconds)
-    }
-
-    fun adjustTrackPlayingTimes(startTime: Long): Long {
-        val adjustmentMap = mutableMapOf<String, Long>()
-        if (startTime > 0L) adjustmentMap[MusicDto.Adjustment.START.name] = startTime
-        return adjustmentMap[MusicDto.Adjustment.START.name]?.times(SECOND_MULTIPLIER) ?: 0L
-    }
-
-    // Method to extract URL using regex
-    fun isUrl(content: String): String {
-        // Regex pattern to match a URL
-        val urlRegex = Regex(
-            """\b(https?://[^\s/$.?#].\S*)\b""",
-            RegexOption.IGNORE_CASE
-        )
-        return urlRegex.find(content)?.value ?: ""
-    }
-
-    @JvmStatic
-    fun deriveDeleteDelayFromTrack(track: AudioTrack): Int {
-        return (track.duration / SECOND_MULTIPLIER).toInt()
     }
 
     fun resetMessages(guildId: Long) = nowPlayingManager.resetNowPlayingMessage(guildId)

--- a/discord-bot/src/main/kotlin/bot/toby/intro/IntroMediaLoader.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/intro/IntroMediaLoader.kt
@@ -1,0 +1,24 @@
+package bot.toby.intro
+
+import bot.toby.helpers.FileUtils
+import net.dv8tion.jda.api.entities.Message.Attachment
+import org.springframework.stereotype.Service
+import java.io.InputStream
+
+/**
+ * I/O for intro media: pulls bytes off a Discord attachment proxy and
+ * reads an InputStream into a byte array. Lifted out of IntroHelper so
+ * the persistence path doesn't have to know about Discord download
+ * mechanics, and so the notification flow can share the same loader.
+ */
+@Service
+class IntroMediaLoader {
+
+    fun downloadAttachment(attachment: Attachment): InputStream? =
+        runCatching { attachment.proxy.download().get() }
+            .onFailure { it.printStackTrace() }
+            .getOrNull()
+
+    fun readContents(inputStream: InputStream): ByteArray? =
+        runCatching { FileUtils.readInputStreamToByteArray(inputStream) }.getOrNull()
+}

--- a/discord-bot/src/main/kotlin/bot/toby/intro/IntroNotificationService.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/intro/IntroNotificationService.kt
@@ -1,0 +1,182 @@
+package bot.toby.intro
+
+import bot.toby.handler.EventWaiter
+import bot.toby.helpers.HttpHelper
+import bot.toby.helpers.InputData
+import bot.toby.util.isUrl
+import common.logging.DiscordLogger
+import core.command.Command.Companion.invokeDeleteOnMessageResponse
+import database.dto.MusicDto
+import database.service.MusicFileService
+import bot.toby.helpers.UserDtoHelper
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.Message.Attachment
+import net.dv8tion.jda.api.entities.User
+import net.dv8tion.jda.api.entities.channel.concrete.PrivateChannel
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent
+import org.springframework.stereotype.Service
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.DurationUnit
+
+/**
+ * Owns the DM-driven "you don't have an intro yet, send me one" flow:
+ * opens a private channel, prompts the user, waits for their reply via
+ * EventWaiter, validates the response, and persists the resulting
+ * musicDto. Lifted out of IntroHelper so the slash-command path doesn't
+ * have to share a class with the EventWaiter wiring.
+ */
+@Service
+class IntroNotificationService(
+    private val userDtoHelper: UserDtoHelper,
+    private val musicFileService: MusicFileService,
+    private val httpHelper: HttpHelper,
+    private val eventWaiter: EventWaiter,
+    private val validationService: IntroValidationService,
+    private val mediaLoader: IntroMediaLoader,
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
+) {
+    private val logger: DiscordLogger = DiscordLogger.createLogger(this::class.java)
+    private val supervisorJob = SupervisorJob()
+    private val coroutineScope = CoroutineScope(supervisorJob + dispatcher)
+
+    fun promptUserForMusicInfo(user: User, guild: Guild) {
+        logger.setGuildAndUserContext(guild, user)
+        logger.info { "Prompting user to set an intro for the server that they don't have one on" }
+        user.openPrivateChannel().queue { channel ->
+            channel.sendMessage(
+                "You don't have an intro song yet on server '${guild.name}'! " +
+                        "Please reply with a YouTube URL or upload a music file, " +
+                        "and optionally provide a volume level (1-100). " +
+                        "E.g. 'https://www.youtube.com/watch?v=VIDEO_ID_HERE 90'"
+            ).queue(invokeDeleteOnMessageResponse(5.minutes.toInt(DurationUnit.SECONDS)))
+
+            setupWaiterForIntroMessage(user, channel, guild)
+        }
+    }
+
+    private fun setupWaiterForIntroMessage(user: User, channel: PrivateChannel, guild: Guild) {
+        eventWaiter.waitForMessage(
+            { event -> event.author.idLong == user.idLong && event.channel == channel },
+            { event -> handleUserMusicResponse(event, channel, guild) },
+            5.minutes,
+            {
+                logger.info { "User did not set intro for the server that they don't have one on within the timeout period" }
+                channel.sendMessage(
+                    "You didn't respond in time, you can always use the '/setintro' command on server '${guild.name}'"
+                ).queue(invokeDeleteOnMessageResponse(5.minutes.toInt(DurationUnit.SECONDS)))
+            }
+        )
+    }
+
+    private fun handleUserMusicResponse(event: MessageReceivedEvent, channel: PrivateChannel, guild: Guild) {
+        val message = event.message
+        val content = message.contentRaw
+        val attachment = message.attachments.firstOrNull()
+
+        when {
+            attachment != null -> handleAttachmentInput(event, channel, guild, attachment, content)
+            isUrl(content).isNotEmpty() -> handleUrlInput(event, channel, guild, content)
+            else -> {
+                channel.sendMessage("Please provide a valid URL or upload a file.").queue()
+                setupWaiterForIntroMessage(event.author, channel, guild)
+            }
+        }
+    }
+
+    private fun handleAttachmentInput(
+        event: MessageReceivedEvent,
+        channel: PrivateChannel,
+        guild: Guild,
+        attachment: Attachment,
+        content: String,
+    ) {
+        val inputData = InputData.Attachment(attachment)
+        logger.info("User uploaded a music file: $inputData")
+
+        if (!validationService.isValidAttachment(attachment)) {
+            handleInvalidAttachment(channel, event.author, guild)
+            return
+        }
+
+        val volume = validationService.parseVolume(content)
+        saveUserMusicDto(event.author, guild, inputData, volume)
+    }
+
+    private fun handleUrlInput(event: MessageReceivedEvent, channel: PrivateChannel, guild: Guild, content: String) {
+        logger.info("User provided a URL: $content")
+
+        coroutineScope.launch {
+            try {
+                val isOverLimit = validationService.checkForOverlyLongIntroDuration(content)
+                if (isOverLimit) {
+                    handleOverLimitIntro(channel, event.author, guild)
+                } else {
+                    val title = runCatching { httpHelper.getYouTubeVideoTitle(content) }.getOrNull()
+                    val inputData = InputData.Url(isUrl(content))
+                    saveUserMusicDto(event.author, guild, inputData, validationService.parseVolume(content), title)
+                }
+            } catch (_: Exception) {
+                logger.error { "Error checking intro length for '$content'" }
+                handleOverLimitIntro(channel, event.author, guild)
+            }
+        }
+    }
+
+    private fun handleInvalidAttachment(channel: PrivateChannel, author: User, guild: Guild) {
+        logger.info { "Intro was rejected for not adhering to attachment requirements, trying again..." }
+        channel.sendMessage("Intro provided was either not an mp3 file or too large. Please try again.").queue()
+        setupWaiterForIntroMessage(author, channel, guild)
+    }
+
+    private fun handleOverLimitIntro(channel: PrivateChannel, author: User, guild: Guild) {
+        logger.info {
+            "Intro was rejected for being over the specified intro limit length of " +
+                    "${IntroValidationService.INTRO_LIMIT.inWholeSeconds} seconds, trying again..."
+        }
+        channel.sendMessage(
+            "Intro provided was over ${IntroValidationService.INTRO_LIMIT.inWholeSeconds} seconds long, " +
+                    "out of courtesy please pick a shorter intro."
+        ).queue()
+        setupWaiterForIntroMessage(author, channel, guild)
+    }
+
+    fun saveUserMusicDto(
+        user: User,
+        guild: Guild,
+        inputData: InputData,
+        volume: Int?,
+        displayName: String? = null,
+    ) {
+        logger.info("Constructing musicDto from input ...")
+        val requestingUserDto = userDtoHelper.calculateUserDto(user.idLong, guild.idLong)
+        val fileName = displayName ?: determineFileName(inputData)
+        val musicDto = MusicDto(requestingUserDto, 1, fileName, volume ?: 90, determineMusicBlob(inputData))
+        musicFileService.createNewMusicFile(musicDto)
+        logger.info { "User successfully uploaded intro as a result of the prompt!" }
+        user.openPrivateChannel().queue { channel ->
+            channel.sendMessage("Successfully set your intro on server '${guild.name}'")
+                .queue(invokeDeleteOnMessageResponse(1.minutes.toInt(DurationUnit.SECONDS)))
+        }
+    }
+
+    fun determineMusicBlob(input: InputData): ByteArray? = when (input) {
+        is InputData.Url -> {
+            logger.info("Processing URL input...")
+            input.uri.toByteArray()
+        }
+        is InputData.Attachment -> {
+            logger.info("Processing attachment input...")
+            mediaLoader.downloadAttachment(input.attachment)?.let { mediaLoader.readContents(it) }
+        }
+    }
+
+    fun determineFileName(input: InputData): String = when (input) {
+        is InputData.Url -> input.uri.takeIf { it.isNotBlank() } ?: ""
+        is InputData.Attachment -> input.attachment.fileName
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/intro/IntroValidationService.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/intro/IntroValidationService.kt
@@ -1,0 +1,68 @@
+package bot.toby.intro
+
+import bot.toby.helpers.HttpHelper
+import bot.toby.helpers.URLHelper
+import common.logging.DiscordLogger
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import net.dv8tion.jda.api.entities.Message.Attachment
+import org.springframework.stereotype.Service
+import kotlin.time.Duration.Companion.seconds
+
+@Service
+class IntroValidationService(
+    private val httpHelper: HttpHelper,
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
+) {
+    private val logger: DiscordLogger = DiscordLogger.createLogger(this::class.java)
+    private val supervisorJob = SupervisorJob()
+    private val scope = CoroutineScope(supervisorJob + dispatcher)
+
+    fun isValidAttachment(attachment: Attachment): Boolean =
+        attachment.fileExtension == "mp3" && attachment.size <= MAX_FILE_SIZE
+
+    fun isValidUrl(url: String): Boolean = URLHelper.isValidURL(url)
+
+    fun parseVolume(content: String): Int? {
+        val volumeRegex = """\b(\d{1,3})\b""".toRegex()
+        return volumeRegex.find(content)?.value?.toIntOrNull()?.takeIf { it in 0..100 }
+    }
+
+    fun convertShortsUrls(url: String): String = url.replace("/shorts/", "/watch?v=")
+
+    suspend fun checkForOverlyLongIntroDuration(url: String): Boolean {
+        val duration = withContext(dispatcher) { httpHelper.getYouTubeVideoDuration(url) }
+        if (duration != null) {
+            logger.info { "Duration of intro is '$duration' vs limit of '$INTRO_LIMIT'" }
+            return duration > INTRO_LIMIT
+        }
+        return false
+    }
+
+    /**
+     * Async wrapper around [checkForOverlyLongIntroDuration]. The async path
+     * conservatively reports "over limit" on failure so an error can't sneak
+     * a too-long intro past the check.
+     */
+    fun validateIntroLength(url: String, onResult: (Boolean) -> Unit) {
+        logger.info { "Checking duration of '$url'" }
+        scope.launch {
+            try {
+                onResult(checkForOverlyLongIntroDuration(url))
+            } catch (_: Exception) {
+                logger.error { "Error checking intro length for '$url'" }
+                onResult(true)
+            }
+        }
+    }
+
+    companion object {
+        const val MAX_FILE_SIZE = 550 * 1024
+        const val MAX_FILE_SIZE_KB = "${MAX_FILE_SIZE / 1024}"
+        val INTRO_LIMIT = 15.seconds
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/lavaplayer/TrackScheduler.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/lavaplayer/TrackScheduler.kt
@@ -1,8 +1,8 @@
 package bot.toby.lavaplayer
 
-import bot.toby.helpers.MusicPlayerHelper.deriveDeleteDelayFromTrack
 import bot.toby.helpers.MusicPlayerHelper.nowPlaying
 import bot.toby.helpers.MusicPlayerHelper.resetMessages
+import bot.toby.util.deriveDeleteDelayFromTrack
 import com.sedmelluq.discord.lavaplayer.player.AudioPlayer
 import com.sedmelluq.discord.lavaplayer.player.event.AudioEventAdapter
 import com.sedmelluq.discord.lavaplayer.track.AudioPlaylist

--- a/discord-bot/src/main/kotlin/bot/toby/managers/NowPlayingManager.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/managers/NowPlayingManager.kt
@@ -1,6 +1,6 @@
 package bot.toby.managers
 
-import bot.toby.helpers.MusicPlayerHelper.formatTime
+import bot.toby.util.formatTime
 import com.sedmelluq.discord.lavaplayer.player.AudioPlayer
 import com.sedmelluq.discord.lavaplayer.track.AudioTrack
 import common.logging.DiscordLogger

--- a/discord-bot/src/main/kotlin/bot/toby/music/MusicBeans.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/music/MusicBeans.kt
@@ -1,0 +1,19 @@
+package bot.toby.music
+
+import bot.toby.helpers.MusicPlayerHelper
+import bot.toby.managers.NowPlayingManager
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+/**
+ * MusicPlayerHelper is still a Kotlin object (commands and TrackScheduler
+ * call into it via static imports), but its embedded NowPlayingManager
+ * needs to be injectable so handlers can depend on the same instance
+ * without reaching into the helper as a hidden dependency.
+ */
+@Configuration
+class MusicBeans {
+
+    @Bean
+    fun nowPlayingManager(): NowPlayingManager = MusicPlayerHelper.nowPlayingManager
+}

--- a/discord-bot/src/main/kotlin/bot/toby/util/MusicFormat.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/util/MusicFormat.kt
@@ -1,0 +1,30 @@
+package bot.toby.util
+
+import com.sedmelluq.discord.lavaplayer.track.AudioTrack
+import database.dto.MusicDto
+import java.util.concurrent.TimeUnit
+
+private const val SECOND_MULTIPLIER = 1000
+
+private val URL_REGEX = Regex(
+    """\b(https?://[^\s/$.?#].\S*)\b""",
+    RegexOption.IGNORE_CASE,
+)
+
+fun formatTime(timeInMillis: Long): String {
+    val hours = TimeUnit.MILLISECONDS.toHours(timeInMillis)
+    val minutes = TimeUnit.MILLISECONDS.toMinutes(timeInMillis) % 60
+    val seconds = TimeUnit.MILLISECONDS.toSeconds(timeInMillis) % 60
+    return String.format("%02d:%02d:%02d", hours, minutes, seconds)
+}
+
+fun isUrl(content: String): String = URL_REGEX.find(content)?.value ?: ""
+
+fun adjustTrackPlayingTimes(startTime: Long): Long {
+    val adjustmentMap = mutableMapOf<String, Long>()
+    if (startTime > 0L) adjustmentMap[MusicDto.Adjustment.START.name] = startTime
+    return adjustmentMap[MusicDto.Adjustment.START.name]?.times(SECOND_MULTIPLIER) ?: 0L
+}
+
+fun deriveDeleteDelayFromTrack(track: AudioTrack): Int =
+    (track.duration / SECOND_MULTIPLIER).toInt()

--- a/discord-bot/src/main/kotlin/bot/toby/voice/LastConnectedChannelTracker.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/voice/LastConnectedChannelTracker.kt
@@ -1,0 +1,25 @@
+package bot.toby.voice
+
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.channel.concrete.VoiceChannel
+import org.springframework.stereotype.Service
+import java.util.concurrent.ConcurrentHashMap
+
+@Service
+class LastConnectedChannelTracker {
+
+    private val channelIdsByGuild = ConcurrentHashMap<Long, Long>()
+
+    fun set(guildId: Long, channelId: Long) {
+        channelIdsByGuild[guildId] = channelId
+    }
+
+    fun clear(guildId: Long) {
+        channelIdsByGuild.remove(guildId)
+    }
+
+    fun resolveChannel(guild: Guild): VoiceChannel? {
+        val channelId = channelIdsByGuild[guild.idLong] ?: return null
+        return guild.getVoiceChannelById(channelId)
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/voice/VoiceSessionLifecycle.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/voice/VoiceSessionLifecycle.kt
@@ -1,0 +1,49 @@
+package bot.toby.voice
+
+import common.logging.DiscordLogger
+import database.dto.VoiceSessionDto
+import database.service.VoiceSessionService
+import net.dv8tion.jda.api.entities.channel.middleman.AudioChannel
+import org.springframework.stereotype.Service
+import java.time.Instant
+
+@Service
+class VoiceSessionLifecycle(
+    private val voiceSessionService: VoiceSessionService,
+    private val voiceCompanyTracker: VoiceCompanyTracker,
+    private val voiceCreditAwardService: VoiceCreditAwardService,
+) {
+    private val logger: DiscordLogger = DiscordLogger.createLogger(this::class.java)
+
+    fun openSession(userId: Long, guildId: Long, channel: AudioChannel, now: Instant) {
+        runCatching {
+            voiceSessionService.findOpenSession(userId, guildId)?.let { stale ->
+                val companySeconds = voiceCompanyTracker.stopTracking(userId, guildId, now)
+                voiceCreditAwardService.closeSessionAndAward(stale, now, companySeconds)
+            }
+            voiceCompanyTracker.reconcileChannel(channel, now)
+            val session = VoiceSessionDto(
+                discordId = userId,
+                guildId = guildId,
+                channelId = channel.idLong,
+                joinedAt = now,
+            )
+            voiceSessionService.openSession(session)
+            voiceCompanyTracker.startTracking(userId, guildId, channel, now)
+        }.onFailure { logger.error("Failed to open voice session for user $userId: ${it.message}") }
+    }
+
+    fun closeSession(userId: Long, guildId: Long, leftChannel: AudioChannel?, now: Instant) {
+        runCatching {
+            val open = voiceSessionService.findOpenSession(userId, guildId)
+            if (open != null) {
+                val companySeconds = voiceCompanyTracker.stopTracking(userId, guildId, now)
+                voiceCreditAwardService.closeSessionAndAward(open, now, companySeconds)
+            }
+            // Other members still in the channel may have just lost company —
+            // refresh their accumulators regardless of whether the leaver had
+            // an open session.
+            leftChannel?.let { voiceCompanyTracker.reconcileChannel(it, now) }
+        }.onFailure { logger.error("Failed to close voice session for user $userId: ${it.message}") }
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/music/JoinCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/music/JoinCommandTest.kt
@@ -53,6 +53,7 @@ internal class JoinCommandTest : MusicCommandTest {
         // Setup audio channel mocks
         every { audioChannelUnion.asVoiceChannel() } returns voiceChannel
         every { voiceChannel.name } returns "Channel Name"
+        every { voiceChannel.idLong } returns 4242L
 
         // Mock behaviors for audio player and other services
         every { mockAudioPlayer.isPaused } returns false

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/music/JoinCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/music/JoinCommandTest.kt
@@ -13,6 +13,7 @@ import bot.toby.command.commands.music.MusicCommandTest.Companion.playerManager
 import bot.toby.command.commands.music.MusicCommandTest.Companion.track
 import bot.toby.command.commands.music.MusicCommandTest.Companion.trackScheduler
 import bot.toby.command.commands.music.channel.JoinCommand
+import bot.toby.voice.LastConnectedChannelTracker
 import database.dto.ConfigDto
 import database.service.ConfigService
 import io.mockk.*
@@ -31,7 +32,7 @@ internal class JoinCommandTest : MusicCommandTest {
     fun setup() {
         setupCommonMusicMocks()
         configService = mockk<ConfigService>()
-        command = JoinCommand(configService)
+        command = JoinCommand(configService, LastConnectedChannelTracker())
         every { configService.getConfigByName(any(), any()) } returns ConfigDto("", "100", "1")
     }
 

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/music/LeaveCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/music/LeaveCommandTest.kt
@@ -11,6 +11,7 @@ import bot.toby.command.commands.music.MusicCommandTest.Companion.musicManager
 import bot.toby.command.commands.music.MusicCommandTest.Companion.playerManager
 import bot.toby.command.commands.music.MusicCommandTest.Companion.trackScheduler
 import bot.toby.command.commands.music.channel.LeaveCommand
+import bot.toby.voice.LastConnectedChannelTracker
 import com.sedmelluq.discord.lavaplayer.track.AudioTrack
 import database.service.ConfigService
 import io.mockk.every
@@ -30,7 +31,7 @@ internal class LeaveCommandTest : MusicCommandTest {
     fun setup() {
         setupCommonMusicMocks()
         configService = mockk()
-        command = LeaveCommand(configService)
+        command = LeaveCommand(configService, LastConnectedChannelTracker())
     }
 
     @AfterEach

--- a/discord-bot/src/test/kotlin/bot/toby/handler/VoiceEventHandlerTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/handler/VoiceEventHandlerTest.kt
@@ -1,6 +1,5 @@
 import bot.toby.handler.VoiceEventHandler
 import bot.toby.helpers.IntroHelper
-import bot.toby.helpers.MusicPlayerHelper
 import bot.toby.helpers.UserDtoHelper
 import bot.toby.lavaplayer.PlayerManager
 import bot.toby.managers.NowPlayingManager
@@ -42,6 +41,7 @@ class VoiceEventHandlerTest {
     private val voiceSessionLifecycle: VoiceSessionLifecycle = mockk(relaxed = true)
     private val lastConnectedChannelTracker: LastConnectedChannelTracker = LastConnectedChannelTracker()
     private val awardService: SocialCreditAwardService = mockk(relaxed = true)
+    private val nowPlayingManager: NowPlayingManager = mockk(relaxed = true)
 
     private val handler = spyk(
         VoiceEventHandler(
@@ -51,6 +51,7 @@ class VoiceEventHandlerTest {
             voiceSessionLifecycle,
             lastConnectedChannelTracker,
             awardService,
+            nowPlayingManager,
         )
     )
 
@@ -132,6 +133,7 @@ class VoiceEventHandlerTest {
             voiceSessionLifecycle = mockk(relaxed = true),
             lastConnectedChannelTracker = LastConnectedChannelTracker(),
             awardService = mockk(relaxed = true),
+            nowPlayingManager = mockk(relaxed = true),
         )
 
         handler.onReady(readyEvent)
@@ -177,6 +179,7 @@ class VoiceEventHandlerTest {
             voiceSessionLifecycle = voiceSessionLifecycle,
             lastConnectedChannelTracker = LastConnectedChannelTracker(),
             awardService = mockk(relaxed = true),
+            nowPlayingManager = mockk(relaxed = true),
         )
 
         handler.onReady(readyEvent)
@@ -478,7 +481,6 @@ class VoiceEventHandlerTest {
         val guild = mockk<Guild>()
         val event = mockk<GuildLeaveEvent>()
         val playerManager = mockk<PlayerManager>(relaxed = true)
-        val nowPlayingManager = mockk<NowPlayingManager>(relaxed = true)
 
         every { event.guild } returns guild
         every { guild.idLong } returns 42L
@@ -486,9 +488,6 @@ class VoiceEventHandlerTest {
 
         mockkObject(PlayerManager)
         every { PlayerManager.instance } returns playerManager
-
-        mockkObject(MusicPlayerHelper)
-        every { MusicPlayerHelper.nowPlayingManager } returns nowPlayingManager
 
         // Pre-seed the tracker — leaving the guild should evict it.
         lastConnectedChannelTracker.set(42L, 1234L)
@@ -502,7 +501,6 @@ class VoiceEventHandlerTest {
         }
 
         unmockkObject(PlayerManager)
-        unmockkObject(MusicPlayerHelper)
     }
 
     @Test

--- a/discord-bot/src/test/kotlin/bot/toby/handler/VoiceEventHandlerTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/handler/VoiceEventHandlerTest.kt
@@ -4,13 +4,12 @@ import bot.toby.helpers.MusicPlayerHelper
 import bot.toby.helpers.UserDtoHelper
 import bot.toby.lavaplayer.PlayerManager
 import bot.toby.managers.NowPlayingManager
-import bot.toby.voice.VoiceCompanyTracker
-import bot.toby.voice.VoiceCreditAwardService
+import bot.toby.voice.LastConnectedChannelTracker
+import bot.toby.voice.VoiceSessionLifecycle
 import database.dto.ConfigDto
 import database.dto.MusicDto
 import database.service.ConfigService
 import database.service.SocialCreditAwardService
-import database.service.VoiceSessionService
 import io.mockk.*
 import io.mockk.junit5.MockKExtension
 import net.dv8tion.jda.api.JDA
@@ -40,9 +39,8 @@ class VoiceEventHandlerTest {
     private val configService: ConfigService = mockk()
     private val userDtoHelper: UserDtoHelper = mockk()
     private val introHelper: IntroHelper = mockk()
-    private val voiceSessionService: VoiceSessionService = mockk(relaxed = true)
-    private val voiceCompanyTracker: VoiceCompanyTracker = mockk(relaxed = true)
-    private val voiceCreditAwardService: VoiceCreditAwardService = mockk(relaxed = true)
+    private val voiceSessionLifecycle: VoiceSessionLifecycle = mockk(relaxed = true)
+    private val lastConnectedChannelTracker: LastConnectedChannelTracker = LastConnectedChannelTracker()
     private val awardService: SocialCreditAwardService = mockk(relaxed = true)
 
     private val handler = spyk(
@@ -50,10 +48,9 @@ class VoiceEventHandlerTest {
             configService,
             userDtoHelper,
             introHelper,
-            voiceSessionService,
-            voiceCompanyTracker,
-            voiceCreditAwardService,
-            awardService
+            voiceSessionLifecycle,
+            lastConnectedChannelTracker,
+            awardService,
         )
     )
 
@@ -132,10 +129,9 @@ class VoiceEventHandlerTest {
             configService = mockk(),
             userDtoHelper = mockk(),
             introHelper = mockk(),
-            voiceSessionService = mockk(relaxed = true),
-            voiceCompanyTracker = mockk(relaxed = true),
-            voiceCreditAwardService = mockk(relaxed = true),
-            awardService = mockk(relaxed = true)
+            voiceSessionLifecycle = mockk(relaxed = true),
+            lastConnectedChannelTracker = LastConnectedChannelTracker(),
+            awardService = mockk(relaxed = true),
         )
 
         handler.onReady(readyEvent)
@@ -157,7 +153,7 @@ class VoiceEventHandlerTest {
         val human1 = mockk<Member>(relaxed = true)
         val human2 = mockk<Member>(relaxed = true)
         val bot = mockk<Member>(relaxed = true)
-        val voiceSessionService = mockk<database.service.VoiceSessionService>(relaxed = true)
+        val voiceSessionLifecycle = mockk<VoiceSessionLifecycle>(relaxed = true)
 
         every { readyEvent.jda } returns jda
         every { jda.guildCache.iterator() } returns mutableListOf(guild).iterator()
@@ -174,31 +170,21 @@ class VoiceEventHandlerTest {
         every { human2.idLong } returns 200L
         every { bot.idLong } returns 999L  // explicit so the verify-block matcher doesn't touch the relaxed mock
 
-        // No prior session for either human — fresh insert path.
-        every { voiceSessionService.findOpenSession(any(), any()) } returns null
-
         val handler = VoiceEventHandler(
             configService = mockk(relaxed = true),
             userDtoHelper = mockk(relaxed = true),
             introHelper = mockk(relaxed = true),
-            voiceSessionService = voiceSessionService,
-            voiceCompanyTracker = mockk(relaxed = true),
-            voiceCreditAwardService = mockk(relaxed = true),
-            awardService = mockk(relaxed = true)
+            voiceSessionLifecycle = voiceSessionLifecycle,
+            lastConnectedChannelTracker = LastConnectedChannelTracker(),
+            awardService = mockk(relaxed = true),
         )
 
         handler.onReady(readyEvent)
 
         // Both humans get a session; the bot does NOT.
-        verify(exactly = 1) {
-            voiceSessionService.openSession(match { it.discordId == 100L && it.guildId == 7L && it.channelId == 99L })
-        }
-        verify(exactly = 1) {
-            voiceSessionService.openSession(match { it.discordId == 200L && it.guildId == 7L && it.channelId == 99L })
-        }
-        verify(exactly = 0) {
-            voiceSessionService.openSession(match { it.discordId == 999L })
-        }
+        verify(exactly = 1) { voiceSessionLifecycle.openSession(100L, 7L, voiceChannel, any()) }
+        verify(exactly = 1) { voiceSessionLifecycle.openSession(200L, 7L, voiceChannel, any()) }
+        verify(exactly = 0) { voiceSessionLifecycle.openSession(999L, any(), any(), any()) }
     }
 
 
@@ -390,8 +376,11 @@ class VoiceEventHandlerTest {
         every { event.channelJoined } returns newChannel
         every { event.channelLeft } returns mockk()
 
-        // Simulate previous channel in lastConnectedChannel
-        VoiceEventHandler.lastConnectedChannel[guild.idLong] = previousChannel
+        // Simulate previous channel in the tracker. The handler resolves the
+        // VoiceChannel via Guild.getVoiceChannelById at use time, so wire that.
+        every { previousChannel.idLong } returns 7777L
+        every { guild.getVoiceChannelById(7777L) } returns previousChannel
+        lastConnectedChannelTracker.set(guild.idLong, 7777L)
 
         // Mock the audioManager behavior
         every { audioManager.openAudioConnection(any()) } just Runs
@@ -433,8 +422,8 @@ class VoiceEventHandlerTest {
         every { member.effectiveName } returns "BotName"
 
 
-        // Simulate no previous channel in lastConnectedChannel
-        VoiceEventHandler.lastConnectedChannel.remove(guild.idLong)
+        // Simulate no previous channel in the tracker
+        lastConnectedChannelTracker.clear(guild.idLong)
 
         handler.onGuildVoiceUpdate(event)
 
@@ -485,12 +474,11 @@ class VoiceEventHandlerTest {
     }
 
     @Test
-    fun `onGuildLeave cleans up PlayerManager, NowPlayingManager, and lastConnectedChannel`() {
+    fun `onGuildLeave cleans up PlayerManager, NowPlayingManager, and last-connected channel`() {
         val guild = mockk<Guild>()
         val event = mockk<GuildLeaveEvent>()
         val playerManager = mockk<PlayerManager>(relaxed = true)
         val nowPlayingManager = mockk<NowPlayingManager>(relaxed = true)
-        val voiceChannel = mockk<VoiceChannel>()
 
         every { event.guild } returns guild
         every { guild.idLong } returns 42L
@@ -502,13 +490,16 @@ class VoiceEventHandlerTest {
         mockkObject(MusicPlayerHelper)
         every { MusicPlayerHelper.nowPlayingManager } returns nowPlayingManager
 
-        VoiceEventHandler.lastConnectedChannel[42L] = voiceChannel
+        // Pre-seed the tracker — leaving the guild should evict it.
+        lastConnectedChannelTracker.set(42L, 1234L)
 
         handler.onGuildLeave(event)
 
         verify(exactly = 1) { playerManager.destroyMusicManager(42L) }
         verify(exactly = 1) { nowPlayingManager.resetNowPlayingMessage(42L) }
-        assert(VoiceEventHandler.lastConnectedChannel.containsKey(42L)) { "lastConnectedChannel should be preserved for potential reconnection" }
+        assert(lastConnectedChannelTracker.resolveChannel(guild) == null) {
+            "tracker entry for the left guild should be evicted"
+        }
 
         unmockkObject(PlayerManager)
         unmockkObject(MusicPlayerHelper)

--- a/discord-bot/src/test/kotlin/bot/toby/handler/VoiceEventHandlerTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/handler/VoiceEventHandlerTest.kt
@@ -209,6 +209,7 @@ class VoiceEventHandlerTest {
         every { event.channelLeft } returns null
         every { channel.members } returns listOf(nonBotMember)
         every { channel.name } returns "voiceChannelName"
+        every { channel.idLong } returns 99L
         every { channel.asVoiceChannel() } returns mockk(relaxed = true)
         every { nonBotMember.user.isBot } returns false
         every { member.guild } returns guild
@@ -271,6 +272,7 @@ class VoiceEventHandlerTest {
         every { event.channelLeft } returns null
         every { channel.members } returns listOf(nonBotMember)
         every { channel.name } returns "voiceChannelName"
+        every { channel.idLong } returns 99L
         every { channel.asVoiceChannel() } returns mockk(relaxed = true)
         every { nonBotMember.user.isBot } returns false
         every { member.guild } returns guild


### PR DESCRIPTION
## Summary

Three focused refactors that target the most-tangled handlers/helpers in `discord-bot/`. Each commit stands on its own and keeps public command behaviour identical.

### 1. `refactor(voice): extract VoiceSessionLifecycle and LastConnectedChannelTracker`
- `VoiceEventHandler` was 312 LOC with 7 collaborators and held shared mutable state (`companion object lastConnectedChannel: ConcurrentHashMap<Long, VoiceChannel>`) that was never evicted on guild leave — a slow leak of stale JDA refs.
- Pull session open/close + the company-tracker reconcile that has to follow each one into `VoiceSessionLifecycle` (`@Service`).
- Pull the previous-channel cache into `LastConnectedChannelTracker` (`@Service`) keyed by channel id — resolves to a fresh `VoiceChannel` via `Guild.getVoiceChannelById` at use time, and is cleared in `onGuildLeave`.
- `JoinCommand` / `LeaveCommand` inject the tracker directly instead of reaching through `VoiceEventHandler.Companion`.
- The on-guild-leave test's old assertion (entry should be _preserved_) contradicted its own name; new assertion matches both name and intended eviction.

### 2. `refactor(music): extract pure music utilities and inject NowPlayingManager`
- `MusicPlayerHelper` (Kotlin `object`, 280 LOC) mixed pure utilities with stateful playback logic and embedded a `NowPlayingManager`. `VoiceEventHandler` reached into `MusicPlayerHelper.nowPlayingManager` directly as a hidden dependency.
- Move pure functions (`formatTime`, `isUrl`, `adjustTrackPlayingTimes`, `deriveDeleteDelayFromTrack`) to `bot.toby.util.MusicFormat` as top-level functions; update each call site (`MusicCommand`, `QueueCommand`, `PlayCommand`, `NowDigOnThisCommand`, `TrackScheduler`, `NowPlayingManager`, `IntroHelper`).
- Expose the helper's existing `NowPlayingManager` as a Spring `@Bean` (`MusicBeans`) so `VoiceEventHandler` can inject it directly — no more reaching through the helper.
- Stateful methods (`playUserIntro`, `skipTracks`, `stopSong`, `changePauseStatusOnTrack`, `nowPlaying`, `resetMessages`) stay on `MusicPlayerHelper` — promoting them to a managed service ripples through `TrackScheduler` and every command/button that imports them statically and is best left to a follow-up.

### 3. `refactor(intro): extract IntroValidationService`
- `IntroHelper` had grown to 528 LOC mixing HTTP fetches, validation, YouTube duration checks, persistence, and a DM-driven prompt flow.
- Lift the validation cluster (`parseVolume`, `isValidAttachment`, `convertShortsUrls`, `checkForOverlyLongIntroDuration`, `validateIntroLength`, `MAX_FILE_SIZE`, `INTRO_LIMIT`) into `bot.toby.intro.IntroValidationService` (`@Service`).
- `IntroHelper` accepts the service as a constructor dependency (with a default that constructs one from its existing `httpHelper`/`dispatcher`) and delegates its public validation API to it. Companion-object constants remain as backwards-compat aliases so `SetIntroCommand` and existing tests keep working unchanged.
- Loader/notification responsibilities (`downloadAttachment`, DM prompts, `pendingIntros`) stay in `IntroHelper` for now — extracting them would ripple into `SetIntroMenu` and the menu/button test suite.

## Test plan
- [ ] CI: `./gradlew build` (the sandbox couldn't reach `dev.lavalink.youtube` / `moe.kyokobot.libdave` repos so the build was not run locally).
- [ ] Existing handler/command/menu/button tests stay green; updated `VoiceEventHandlerTest`, `JoinCommandTest`, `LeaveCommandTest` for new constructor shapes.
- [ ] Smoke on a dev guild: join voice → bot joins → intro plays → leave → bot leaves on empty channel; rejoin path still works (`LastConnectedChannelTracker.resolveChannel`).
- [ ] Force a `GuildLeaveEvent` on dev → `LastConnectedChannelTracker` evicts.
- [ ] Set intro via URL and via attachment; both paths persist correctly.
- [ ] Casino games / now-playing message lifecycle unaffected.

## Out of scope (follow-ups)
- Drop redundant Kotlin `@Autowired` annotations on constructor parameters (low-risk cleanup).
- Promote remaining stateful `MusicPlayerHelper` methods to a managed `MusicPlaybackService`.
- Extract `IntroNotificationService` (DM/EventWaiter flow + `pendingIntros`) and `IntroMediaLoader` from `IntroHelper`.
- Add MDC-via-aspect/interceptor so handlers can't accidentally skip context (`ActivityEventHandler` has been logged about previously).

https://claude.ai/code/session_01XQsvtR3goPWAEeCfKU56pn

---
_Generated by [Claude Code](https://claude.ai/code/session_01XQsvtR3goPWAEeCfKU56pn)_