### PR TITLE
feat(web): v2 public-site polish — themed homepage, live stats, changelog, OG/JSON-LD, footer fragment

### DIFF
--- a/application/src/test/kotlin/integration/web/PageRenderSmokeIT.kt
+++ b/application/src/test/kotlin/integration/web/PageRenderSmokeIT.kt
@@ -88,6 +88,7 @@ class PageRenderSmokeIT {
             "/login",
             "/commands",
             "/commands/wiki",
+            "/changelog",
             // Bot info pages (public)
             "/brother",
             "/config",

--- a/application/src/test/kotlin/web/controller/ChangelogControllerTest.kt
+++ b/application/src/test/kotlin/web/controller/ChangelogControllerTest.kt
@@ -1,0 +1,66 @@
+package web.controller
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.security.oauth2.core.user.OAuth2User
+import org.springframework.ui.Model
+
+class ChangelogControllerTest {
+
+    private lateinit var controller: ChangelogController
+    private lateinit var model: Model
+
+    @BeforeEach
+    fun setup() {
+        controller = ChangelogController()
+        model = mockk(relaxed = true)
+    }
+
+    @Test
+    fun `changelog returns changelog view`() {
+        val view = controller.changelog(null, model)
+
+        assertEquals("changelog", view)
+    }
+
+    @Test
+    fun `changelog seeds entries on the model`() {
+        controller.changelog(null, model)
+
+        verify { model.addAttribute("entries", ChangelogController.ENTRIES) }
+    }
+
+    @Test
+    fun `changelog has at least one entry seeded`() {
+        // Sanity check: the controller would compile with an empty list,
+        // so guard against a future regression that empties the seed.
+        assertFalse(
+            ChangelogController.ENTRIES.isEmpty(),
+            "ChangelogController.ENTRIES must contain at least one curated entry"
+        )
+    }
+
+    @Test
+    fun `changelog skips username when user is not authenticated`() {
+        controller.changelog(null, model)
+
+        // The view is public, so anon visitors see only the entries.
+        // The navbar fragment handles the null-username case.
+        verify(exactly = 0) { model.addAttribute("username", any()) }
+    }
+
+    @Test
+    fun `changelog adds username when user is authenticated`() {
+        val user = mockk<OAuth2User>(relaxed = true)
+        every { user.getAttribute<String>("username") } returns "TestUser"
+
+        controller.changelog(user, model)
+
+        verify { model.addAttribute("username", "TestUser") }
+    }
+}

--- a/application/src/test/kotlin/web/controller/HomeControllerTest.kt
+++ b/application/src/test/kotlin/web/controller/HomeControllerTest.kt
@@ -8,19 +8,28 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.security.oauth2.core.user.OAuth2User
 import org.springframework.ui.Model
+import web.service.HomeStatsService
 
 class HomeControllerTest {
 
     private lateinit var controller: HomeController
     private lateinit var model: Model
+    private lateinit var homeStatsService: HomeStatsService
 
     private val clientId = "test-client-id"
     private val expectedInviteUrl =
         "https://discord.com/api/oauth2/authorize?client_id=$clientId&permissions=8&scope=bot%20applications.commands"
+    private val sampleStats = HomeStatsService.HomeStats(
+        serverCount = 7,
+        commandCount = 42,
+        gameCount = 12,
+    )
 
     @BeforeEach
     fun setup() {
-        controller = HomeController(clientId)
+        homeStatsService = mockk(relaxed = true)
+        every { homeStatsService.get() } returns sampleStats
+        controller = HomeController(clientId, homeStatsService)
         model = mockk(relaxed = true)
     }
 
@@ -63,6 +72,14 @@ class HomeControllerTest {
         controller.home(user, model)
 
         verify { model.addAttribute("username", null) }
+    }
+
+    @Test
+    fun `home adds homeStats from the stats service`() {
+        controller.home(null, model)
+
+        verify { homeStatsService.get() }
+        verify { model.addAttribute("homeStats", sampleStats) }
     }
 
     @Test

--- a/web/src/main/kotlin/web/configuration/WebSecurityConfig.kt
+++ b/web/src/main/kotlin/web/configuration/WebSecurityConfig.kt
@@ -15,10 +15,12 @@ class WebSecurityConfig {
         http
             .authorizeHttpRequests { auth ->
                 auth.requestMatchers(
-                    "/", "/terms", "/privacy", "/brother", "/config", "/music", "/user",
+                    "/", "/terms", "/privacy", "/changelog",
+                    "/brother", "/config", "/music", "/user",
                     "/commands", "/commands/**", "/actuator/**",
                     "/v3/api-docs/**", "/swagger-ui/**", "/login", "/error",
-                    "/images/**", "/js/**", "/css/**"
+                    "/images/**", "/js/**", "/css/**",
+                    "/sitemap.xml", "/robots.txt"
                 ).permitAll()
                 auth.requestMatchers("/intro/**").authenticated()
                 auth.requestMatchers("/dnd/**").authenticated()

--- a/web/src/main/kotlin/web/controller/ChangelogController.kt
+++ b/web/src/main/kotlin/web/controller/ChangelogController.kt
@@ -1,0 +1,145 @@
+package web.controller
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.security.oauth2.core.user.OAuth2User
+import org.springframework.stereotype.Controller
+import org.springframework.ui.Model
+import org.springframework.web.bind.annotation.GetMapping
+import web.util.displayName
+
+/**
+ * Public changelog page. Hand-curated highlights — kept here as a static
+ * list rather than scraped from `git log` because the curated framing
+ * ("here's what's worth knowing") is the point. New entries go at the
+ * top of [ENTRIES]. Older entries can stay until they fall off the
+ * bottom or be pruned in batches; the goal isn't a full history (git
+ * already has that), it's a pitch surface that shows the project is
+ * alive.
+ *
+ * Public (no auth) so recruiters and prospective installers can scan
+ * the recent activity without signing in. Endpoint matches the route
+ * permitAll-listed in [web.configuration.WebSecurityConfig].
+ */
+@Controller
+class ChangelogController {
+
+    @GetMapping("/changelog")
+    fun changelog(
+        @AuthenticationPrincipal user: OAuth2User?,
+        model: Model,
+    ): String {
+        model.addAttribute("entries", ENTRIES)
+        if (user != null) model.addAttribute("username", user.displayName())
+        return "changelog"
+    }
+
+    /**
+     * One row in the changelog timeline.
+     *
+     * @param date  human-readable, e.g. "May 2026". Sort order is the
+     *              position in the [ENTRIES] list — newest first.
+     * @param title short headline.
+     * @param summary 1–2 sentences. Plain text, no markdown.
+     * @param emoji optional leading glyph; null hides the icon column.
+     * @param prNumber optional GitHub PR number; renders as a small link.
+     */
+    data class ChangelogEntry(
+        val date: String,
+        val title: String,
+        val summary: String,
+        val emoji: String? = null,
+        val prNumber: Int? = null,
+    )
+
+    companion object {
+        private const val REPO_URL = "https://github.com/ml404/toby-bot"
+
+        // Newest first. Cap to ~15 entries; older highlights can be
+        // pruned when they roll off the bottom.
+        val ENTRIES: List<ChangelogEntry> = listOf(
+            ChangelogEntry(
+                date = "May 2026",
+                title = "Moderation page split + searchable settings",
+                summary = "The single moderation page became six focused sub-pages " +
+                    "(Users, Settings, Voice, Poll, Casino, Lottery). The Settings " +
+                    "page got a sticky search box and a dedicated Jackpot section " +
+                    "exposing five eligibility/payout configs that were previously " +
+                    "backend-only. A new CI guard fails the build if a future config " +
+                    "key is added without a UI row.",
+                emoji = "🧹",
+                prNumber = 424,
+            ),
+            ChangelogEntry(
+                date = "May 2026",
+                title = "Jackpot RTP eligibility gate",
+                summary = "High-RTP games (blackjack, coinflip, baccarat, roulette) " +
+                    "can now be excluded from jackpot rolls via a configurable RTP " +
+                    "ceiling, so they don't double-dip on a sweetener they don't need.",
+                emoji = "🎰",
+                prNumber = 422,
+            ),
+            ChangelogEntry(
+                date = "May 2026",
+                title = "Anti-autoclicker channel logs",
+                summary = "Suspected-bot session embeds now post to a configurable " +
+                    "Discord channel and update in place as forced-loss substitutions " +
+                    "accumulate over the session.",
+                emoji = "🔍",
+                prNumber = 420,
+            ),
+            ChangelogEntry(
+                date = "April 2026",
+                title = "Daily lottery (Pick 5 of 49 + weighted mode)",
+                summary = "Auto-runs at 00:00 UTC: closes the prior draw, pays " +
+                    "tier-based prizes, opens a fresh one seeded from the jackpot " +
+                    "pool. NUMBER_MATCH for high-engagement servers, WEIGHTED for " +
+                    "low-traffic ones; configurable per guild from the moderation " +
+                    "Lottery sub-page.",
+                emoji = "🎟️",
+                prNumber = 412,
+            ),
+            ChangelogEntry(
+                date = "April 2026",
+                title = "Casino refresh: Roulette + Casino Hold'em",
+                summary = "Two new minigames join the quick-play roster, both " +
+                    "wired into the per-guild jackpot pool with the same loss-tribute " +
+                    "and stake-anchor rules as the rest.",
+                emoji = "🎲",
+                prNumber = 404,
+            ),
+            ChangelogEntry(
+                date = "April 2026",
+                title = "Multiplayer Blackjack tables",
+                summary = "Up to 7 seats per multi-table, configurable shot clock, " +
+                    "S17/H17 dealer rule, and 3:2 / 6:5 payout toggle. Solo blackjack " +
+                    "shares the same stake bounds.",
+                emoji = "♠️",
+            ),
+            ChangelogEntry(
+                date = "March 2026",
+                title = "Poker tables (fixed-limit Hold'em)",
+                summary = "2–9 seats, configurable blinds and bet structure, " +
+                    "per-actor shot clock with auto-fold, and rake routed to the " +
+                    "jackpot pool.",
+                emoji = "♠️",
+            ),
+            ChangelogEntry(
+                date = "March 2026",
+                title = "TOBY coin live market",
+                summary = "Per-server live market with a 5-minute price tick. Earn " +
+                    "social credit by being active, then trade it for TOBY coin.",
+                emoji = "💰",
+            ),
+            ChangelogEntry(
+                date = "February 2026",
+                title = "Web moderation admin",
+                summary = "Browser-based moderation: toggle user permissions, " +
+                    "adjust social credit, mute or move voice channels, post polls — " +
+                    "no slash commands needed.",
+                emoji = "🛡️",
+            ),
+        )
+
+        fun repoUrl(): String = REPO_URL
+    }
+}

--- a/web/src/main/kotlin/web/controller/HomeController.kt
+++ b/web/src/main/kotlin/web/controller/HomeController.kt
@@ -6,11 +6,13 @@ import org.springframework.security.oauth2.core.user.OAuth2User
 import org.springframework.stereotype.Controller
 import org.springframework.ui.Model
 import org.springframework.web.bind.annotation.GetMapping
+import web.service.HomeStatsService
 
 @Controller
 class HomeController(
     @param:Value($$"${spring.security.oauth2.client.registration.discord.client-id}")
-    private val discordClientId: String
+    private val discordClientId: String,
+    private val homeStatsService: HomeStatsService,
 ) {
 
     @GetMapping("/")
@@ -20,6 +22,7 @@ class HomeController(
             "https://discord.com/api/oauth2/authorize?client_id=$discordClientId&permissions=8&scope=bot%20applications.commands"
         )
         model.addAttribute("username", user?.getAttribute<String>("username"))
+        model.addAttribute("homeStats", homeStatsService.get())
         return "home"
     }
 

--- a/web/src/main/kotlin/web/service/HomeStatsService.kt
+++ b/web/src/main/kotlin/web/service/HomeStatsService.kt
@@ -1,0 +1,68 @@
+package web.service
+
+import core.managers.CommandManager
+import net.dv8tion.jda.api.JDA
+import org.springframework.stereotype.Service
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Live numbers for the homepage stats strip. Three counts:
+ *  - **servers**: how many guilds the bot is currently in (JDA cache size)
+ *  - **commands**: total slash-command count across every category
+ *  - **games**: hand-rolled count of standalone game UIs (9 minigames +
+ *    Poker + Blackjack + Casino Hold'em). Hardcoded because the games
+ *    list rarely changes and bumping a constant here is the cheapest
+ *    signal of "we shipped a new game" for a future PR.
+ *
+ * Memoised for 60 seconds in-process so a homepage refresh storm doesn't
+ * touch the JDA cache or sum command lists per request. We deliberately
+ * avoid `@Cacheable` here — the wider project doesn't use Spring Cache
+ * abstractions in the web module, and a tiny atomic-reference memoize
+ * keeps the dependency surface small.
+ */
+@Service
+class HomeStatsService(
+    private val jda: JDA,
+    private val commandManager: CommandManager,
+) {
+
+    data class HomeStats(
+        val serverCount: Int,
+        val commandCount: Int,
+        val gameCount: Int,
+    )
+
+    private data class Cached(val stats: HomeStats, val expiresAtNanos: Long)
+
+    private val cached = AtomicReference<Cached?>(null)
+
+    fun get(): HomeStats {
+        val now = System.nanoTime()
+        val current = cached.get()
+        if (current != null && now < current.expiresAtNanos) return current.stats
+        val fresh = compute()
+        cached.set(Cached(fresh, now + TTL_NANOS))
+        return fresh
+    }
+
+    private fun compute(): HomeStats = HomeStats(
+        serverCount = jda.guildCache.size().toInt(),
+        commandCount = commandManager.run {
+            musicCommands.size +
+                dndCommands.size +
+                moderationCommands.size +
+                economyCommands.size +
+                miscCommands.size +
+                fetchCommands.size
+        },
+        gameCount = GAME_COUNT,
+    )
+
+    companion object {
+        // 9 minigames (slots, coinflip, dice, highlow, scratch, keno,
+        // roulette, baccarat, casino hold'em) + poker + blackjack +
+        // lottery = 12. Keep in sync with the navbar Play menu.
+        private const val GAME_COUNT = 12
+        private val TTL_NANOS = 60_000_000_000L
+    }
+}

--- a/web/src/main/resources/static/css/base.css
+++ b/web/src/main/resources/static/css/base.css
@@ -245,6 +245,33 @@ input[type=range]:hover::-webkit-slider-thumb { transform: scale(1.12); }
     color: #fff;
 }
 
+/* ---- Shared "back to listing" anchor ----
+   Used on per-guild detail pages (moderation, profile, economy, casino
+   hold'em, etc.) to return to the picker. Single canonical rule here so
+   per-page CSS doesn't keep redefining it. */
+.back-link {
+    display: inline-block;
+    margin-bottom: var(--space-2);
+    font-size: 0.85rem;
+    color: var(--text-muted);
+    text-decoration: none;
+}
+.back-link:hover { color: var(--text); text-decoration: underline; }
+
+/* ---- Empty-state hero ----
+   Dashed-border centred panel for "no items yet" states. Used by the
+   intros uploader, casino guild picker, leaderboard listing, duel
+   pending list, etc. */
+.empty-hero {
+    background: var(--bg-elevated);
+    border: 1px dashed var(--border-strong);
+    border-radius: var(--radius-lg);
+    padding: 40px 24px;
+    text-align: center;
+    color: var(--text-muted);
+}
+.empty-hero .emoji { font-size: 2.2rem; display: block; margin-bottom: 10px; }
+
 /* ---- Cards ---- */
 .card {
     background: var(--bg-elevated);

--- a/web/src/main/resources/static/css/casinoholdem.css
+++ b/web/src/main/resources/static/css/casinoholdem.css
@@ -18,14 +18,6 @@
     margin: 0.25rem 0 0.5rem;
 }
 
-.back-link {
-    color: var(--muted, #a0a0b0);
-    text-decoration: none;
-    font-size: 0.9rem;
-}
-
-.back-link:hover { text-decoration: underline; }
-
 .che-card {
     background: var(--surface, #1f2128);
     border-radius: 0.75rem;

--- a/web/src/main/resources/static/css/commands.css
+++ b/web/src/main/resources/static/css/commands.css
@@ -1,0 +1,70 @@
+/* commands.css — auto-generated slash-command reference page. Tables
+   grouped by category with monospace command names + nested option
+   lists. Pulled out of an inline <style> in commands.html so the page
+   uses the same head fragment + extraCss pattern as the rest of the
+   site. */
+
+.commands-page { max-width: 960px; margin: 40px auto; padding: 0 24px 80px; }
+.commands-page h1 { font-size: 1.8rem; color: var(--text); margin-bottom: 8px; }
+.commands-page .subtitle { color: var(--text-muted); margin-bottom: 40px; }
+
+.category { margin-bottom: 48px; }
+.category h2 {
+    font-size: 0.8rem;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    margin-bottom: 12px;
+    padding-bottom: 8px;
+    border-bottom: 1px solid var(--border);
+}
+
+.table-wrap {
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    overflow: hidden;
+}
+.commands-table { width: 100%; border-collapse: collapse; }
+.commands-table th {
+    text-align: left;
+    padding: 10px 16px;
+    color: var(--text-muted);
+    font-size: 0.78rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    border-bottom: 1px solid var(--border);
+}
+.commands-table td {
+    padding: 12px 16px;
+    border-bottom: 1px solid var(--border);
+    font-size: 0.9rem;
+    vertical-align: top;
+}
+.commands-table tr:last-child td { border-bottom: none; }
+.commands-table tr:hover td { background: rgba(88, 101, 242, 0.05); }
+
+.cmd { font-family: monospace; color: var(--accent); font-size: 0.95rem; white-space: nowrap; }
+.desc { color: var(--text); }
+
+.opts { list-style: none; padding: 0; margin: 0; }
+.opt { margin-bottom: 8px; }
+.opt:last-child { margin-bottom: 0; }
+.opt-name { font-family: monospace; color: var(--text); font-size: 0.85rem; }
+.badge {
+    font-size: 0.7rem;
+    color: var(--text-muted);
+    background: var(--border);
+    padding: 1px 6px;
+    border-radius: 4px;
+    margin-left: 5px;
+    vertical-align: middle;
+}
+.opt-desc { color: var(--text-muted); font-size: 0.82rem; margin-top: 2px; }
+
+.choices { list-style: none; margin: 4px 0 0; padding-left: 10px; }
+.choice { font-size: 0.78rem; color: var(--text-muted); font-family: monospace; }
+.choice::before { content: "\2022 "; color: var(--accent); }
+
+.none { color: var(--text-muted); font-style: italic; font-size: 0.85rem; opacity: 0.6; }

--- a/web/src/main/resources/static/css/economy.css
+++ b/web/src/main/resources/static/css/economy.css
@@ -7,15 +7,6 @@
     flex-wrap: wrap;
 }
 
-.back-link {
-    display: inline-block;
-    color: var(--text-muted);
-    font-size: 0.85rem;
-    margin-bottom: var(--space-2);
-}
-
-.back-link:hover { color: var(--text); }
-
 .economy-price {
     text-align: right;
 }

--- a/web/src/main/resources/static/css/home.css
+++ b/web/src/main/resources/static/css/home.css
@@ -1,0 +1,426 @@
+/* ==========================================================================
+   home.css — public marketing pages: home, changelog (and any future page
+   that wants the themed-section / hero / footer treatment).
+   ========================================================================== */
+
+/* HERO */
+.hero {
+    text-align: center;
+    padding: 80px 24px 48px;
+}
+.hero-badge {
+    display: inline-block;
+    background: rgba(88, 101, 242, 0.15);
+    color: #7289fa;
+    border: 1px solid rgba(88, 101, 242, 0.3);
+    border-radius: 999px;
+    padding: 4px 16px;
+    font-size: 0.78rem;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    margin-bottom: 20px;
+}
+.hero h1 {
+    font-size: clamp(2rem, 5vw, 3.2rem);
+    color: #fff;
+    margin-bottom: 16px;
+    line-height: 1.2;
+}
+.hero h1 span { color: var(--accent); }
+.hero p {
+    font-size: 1.1rem;
+    color: var(--text-muted);
+    max-width: 620px;
+    margin: 0 auto 32px;
+    line-height: 1.6;
+}
+.hero-actions {
+    display: flex;
+    gap: 16px;
+    justify-content: center;
+    flex-wrap: wrap;
+    margin-bottom: 16px;
+}
+.btn-primary {
+    display: inline-block;
+    background: var(--accent);
+    color: #fff;
+    text-decoration: none;
+    padding: 14px 28px;
+    border-radius: var(--radius-md);
+    font-size: 1rem;
+    font-weight: 600;
+    transition: background 0.2s;
+}
+.btn-primary:hover { background: #4752c4; }
+.btn-secondary {
+    display: inline-block;
+    background: transparent;
+    color: var(--text);
+    text-decoration: none;
+    padding: 14px 28px;
+    border-radius: var(--radius-md);
+    border: 1px solid var(--border-strong);
+    font-size: 1rem;
+    font-weight: 600;
+    transition: border-color 0.2s, color 0.2s;
+}
+.btn-secondary:hover { border-color: var(--accent); color: #fff; }
+.hero-aside {
+    font-size: 0.85rem;
+    color: var(--text-dim);
+}
+.hero-aside a { color: #7289fa; text-decoration: none; }
+.hero-aside a:hover { text-decoration: underline; }
+
+/* LIVE STATS STRIP */
+.stats-strip {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 48px;
+    padding: 24px;
+    max-width: 720px;
+    margin: 0 auto;
+    border-top: 1px solid var(--border);
+    border-bottom: 1px solid var(--border);
+}
+.stat {
+    text-align: center;
+    min-width: 100px;
+}
+.stat-value {
+    display: block;
+    font-size: 2rem;
+    font-weight: 700;
+    color: var(--accent);
+    font-variant-numeric: tabular-nums;
+    line-height: 1.1;
+}
+.stat-label {
+    display: block;
+    font-size: 0.78rem;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    margin-top: 6px;
+}
+
+/* THEMED SECTIONS */
+.section {
+    padding: 56px 24px;
+    max-width: 1100px;
+    margin: 0 auto;
+}
+.section + .section { padding-top: 32px; }
+.section-header {
+    margin-bottom: 28px;
+    max-width: 760px;
+}
+.section-eyebrow {
+    display: inline-block;
+    font-size: 0.72rem;
+    font-weight: 600;
+    color: #7289fa;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    margin-bottom: 8px;
+}
+.section h2 {
+    font-size: 1.7rem;
+    color: #fff;
+    margin-bottom: 8px;
+    line-height: 1.25;
+}
+.section-lede {
+    color: var(--text-muted);
+    font-size: 1rem;
+    line-height: 1.55;
+    max-width: 56ch;
+}
+
+/* FEATURE CARDS — used inside .section .feature-grid */
+.feature-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+    gap: 20px;
+}
+.feature-card {
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 24px 20px;
+    transition: border-color 0.2s, transform 0.15s;
+    display: block;
+    text-decoration: none;
+    color: inherit;
+}
+.feature-card:hover { border-color: var(--accent); transform: translateY(-2px); }
+.feature-icon { font-size: 1.8rem; margin-bottom: 12px; }
+.feature-card h3 {
+    font-size: 1rem;
+    color: #fff;
+    margin-bottom: 8px;
+}
+.feature-card p {
+    font-size: 0.88rem;
+    color: var(--text-muted);
+    line-height: 1.55;
+    margin: 0;
+}
+.feature-card-tag {
+    display: inline-block;
+    margin-top: 10px;
+    font-size: 0.72rem;
+    font-weight: 600;
+    color: #7289fa;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+}
+
+/* TECH STACK STRIP */
+.tech-strip {
+    padding: 40px 24px;
+    max-width: 1100px;
+    margin: 0 auto;
+    text-align: center;
+    border-top: 1px solid var(--border);
+}
+.tech-strip-label {
+    display: block;
+    font-size: 0.74rem;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    margin-bottom: 16px;
+}
+.tech-strip-items {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 12px 28px;
+}
+.tech-strip-item {
+    color: var(--text);
+    font-size: 0.95rem;
+    font-weight: 500;
+    position: relative;
+}
+.tech-strip-item + .tech-strip-item::before {
+    content: "·";
+    color: var(--text-dim);
+    margin-right: 28px;
+    margin-left: -28px;
+    /* The negative margins keep the dot visually centred between items
+       without adding a wrapping element. Hidden on wrap by flex-gap. */
+}
+
+/* FINAL CTA — repeats hero buttons at the bottom of the page */
+.final-cta {
+    padding: 56px 24px 80px;
+    text-align: center;
+    max-width: 720px;
+    margin: 0 auto;
+}
+.final-cta h2 {
+    font-size: 1.6rem;
+    color: #fff;
+    margin-bottom: 12px;
+}
+.final-cta p {
+    color: var(--text-muted);
+    margin-bottom: 28px;
+    line-height: 1.55;
+}
+
+/* SITE FOOTER */
+.site-footer {
+    border-top: 1px solid var(--border);
+    padding: 32px 24px;
+    text-align: center;
+    color: var(--text-dim);
+    font-size: 0.82rem;
+}
+.site-footer-inner {
+    max-width: 800px;
+    margin: 0 auto;
+    display: grid;
+    gap: 8px;
+}
+.site-footer-line { margin: 0; }
+.site-footer a { color: #7289fa; text-decoration: none; }
+.site-footer a:hover { text-decoration: underline; }
+.site-footer-source { font-size: 0.85rem; }
+.site-footer-stack {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    align-items: center;
+    gap: 12px;
+    margin-top: 8px;
+    font-size: 0.78rem;
+    color: var(--text-muted);
+}
+.site-footer-stack-label {
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-dim);
+    font-weight: 600;
+}
+.site-footer-stack-item {
+    color: var(--text-muted);
+    position: relative;
+}
+.site-footer-stack-item + .site-footer-stack-item::before {
+    content: "·";
+    color: var(--text-dim);
+    margin-right: 12px;
+    margin-left: -12px;
+}
+
+/* CHANGELOG TIMELINE */
+.changelog-page {
+    max-width: 760px;
+    margin: 40px auto;
+    padding: 0 24px 64px;
+}
+.changelog-header { margin-bottom: 32px; }
+.changelog-header h1 {
+    font-size: 1.8rem;
+    color: #fff;
+    margin: 8px 0 8px;
+}
+.changelog-header .muted { color: var(--text-muted); line-height: 1.5; }
+.changelog-header a { color: #7289fa; text-decoration: none; }
+.changelog-header a:hover { text-decoration: underline; }
+.changelog-timeline {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    border-left: 2px solid var(--border);
+}
+.changelog-entry {
+    position: relative;
+    padding: 16px 0 24px 28px;
+}
+.changelog-entry::before {
+    content: "";
+    position: absolute;
+    left: -7px;
+    top: 24px;
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    background: var(--bg-elevated);
+    border: 2px solid var(--accent);
+}
+.changelog-meta {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 6px;
+    color: var(--text-muted);
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+.changelog-emoji { font-size: 1.05rem; }
+.changelog-title {
+    font-size: 1.05rem;
+    color: #fff;
+    margin: 0 0 6px;
+}
+.changelog-summary {
+    color: var(--text-muted);
+    font-size: 0.92rem;
+    line-height: 1.55;
+    margin: 0 0 8px;
+    max-width: 60ch;
+}
+.changelog-pr {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 0.78rem;
+    color: #7289fa;
+    text-decoration: none;
+}
+.changelog-pr:hover { text-decoration: underline; }
+
+/* LOGIN PAGE — centred card with feature teaser */
+.login-wrap {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: calc(100vh - 220px);
+    padding: 48px 24px;
+}
+.login-card {
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 48px 40px;
+    text-align: center;
+    max-width: 420px;
+    width: 100%;
+    box-shadow: 0 8px 32px rgba(0,0,0,0.4);
+}
+.login-card h1 { font-size: 1.8rem; margin-bottom: 8px; color: #fff; }
+.login-card .lede { color: var(--text-muted); margin-bottom: 24px; line-height: 1.55; }
+.login-card ul {
+    list-style: none;
+    text-align: left;
+    margin: 0 0 28px;
+    padding: 0;
+    display: grid;
+    gap: 8px;
+}
+.login-card li {
+    font-size: 0.9rem;
+    color: var(--text-muted);
+    padding-left: 20px;
+    position: relative;
+}
+.login-card li::before {
+    content: "\2713";
+    color: var(--accent);
+    position: absolute;
+    left: 0;
+}
+.login-card .btn-discord {
+    padding: 14px 28px;
+    border-radius: 8px;
+    font-size: 1rem;
+}
+.login-card .btn-discord:hover { background: #4752c4; }
+.login-error {
+    background: #4a1a1a;
+    border: 1px solid #c0392b;
+    color: #e74c3c;
+    padding: 10px 16px;
+    border-radius: 6px;
+    margin-bottom: 20px;
+    font-size: 0.9rem;
+}
+.login-aside {
+    margin-top: 16px;
+    font-size: 0.82rem;
+    color: var(--text-dim);
+}
+.login-aside a { color: #7289fa; text-decoration: none; }
+.login-aside a:hover { text-decoration: underline; }
+
+/* RESPONSIVE */
+@media (max-width: 600px) {
+    .stats-strip { gap: 24px; padding: 16px 12px; }
+    .stat-value { font-size: 1.6rem; }
+}
+@media (max-width: 480px) {
+    .hero { padding: 48px 16px 32px; }
+    .hero-actions { flex-direction: column; align-items: stretch; gap: 10px; }
+    .hero-actions a { width: 100%; text-align: center; }
+    .section { padding: 36px 16px; }
+    .feature-grid { gap: 16px; }
+    .feature-card { padding: 20px 16px; }
+    .final-cta { padding: 36px 16px 56px; }
+    .site-footer { padding: 24px 16px; }
+}

--- a/web/src/main/resources/static/css/intros.css
+++ b/web/src/main/resources/static/css/intros.css
@@ -121,16 +121,6 @@
     font-family: inherit;
 }
 
-.empty-hero {
-    background: var(--bg-elevated);
-    border: 1px dashed var(--border-strong);
-    border-radius: var(--radius-lg);
-    padding: 40px 24px;
-    text-align: center;
-    color: var(--text-muted);
-}
-.empty-hero .emoji { font-size: 2.2rem; display: block; margin-bottom: 10px; }
-
 /* ============================================================
    Add / replace form
    ============================================================ */

--- a/web/src/main/resources/static/css/legal.css
+++ b/web/src/main/resources/static/css/legal.css
@@ -1,0 +1,53 @@
+/* Shared styles for the Terms of Service and Privacy Policy pages.
+   These pages have the same long-form-prose layout (numbered sections,
+   muted body copy, hairline section dividers) so a tiny dedicated
+   stylesheet beats two near-identical inline <style> blocks. */
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    min-height: 100vh;
+}
+
+.legal-container {
+    max-width: 760px;
+    margin: 48px auto;
+    padding: 0 24px 80px;
+}
+
+.legal-header { margin-bottom: 40px; }
+.legal-header h1 {
+    font-size: 2rem;
+    color: #fff;
+    margin-bottom: 8px;
+}
+.legal-header .updated {
+    color: var(--text-dim);
+    font-size: 0.85rem;
+}
+
+.legal-section { margin-bottom: 36px; }
+.legal-section h2 {
+    font-size: 1rem;
+    color: #fff;
+    font-weight: 600;
+    margin-bottom: 12px;
+    padding-bottom: 8px;
+    border-bottom: 1px solid var(--border);
+}
+.legal-section p,
+.legal-section li {
+    color: var(--text-muted);
+    font-size: 0.92rem;
+    line-height: 1.7;
+}
+.legal-section p + p { margin-top: 10px; }
+.legal-section ul {
+    list-style: disc;
+    padding-left: 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+.legal-section a { color: #7289fa; }

--- a/web/src/main/resources/static/css/moderation.css
+++ b/web/src/main/resources/static/css/moderation.css
@@ -2,12 +2,6 @@
     margin-bottom: var(--space-5);
 }
 .mod-header h1 { margin-bottom: var(--space-2); }
-.back-link {
-    display: inline-block;
-    margin-bottom: var(--space-2);
-    font-size: 0.85rem;
-    color: var(--text-muted);
-}
 
 /* Member search bar on the Users tab — client-side filter. */
 .mod-search {

--- a/web/src/main/resources/static/css/profile.css
+++ b/web/src/main/resources/static/css/profile.css
@@ -2,12 +2,6 @@
     margin-bottom: var(--space-5);
 }
 .profile-header h1 { margin-bottom: var(--space-2); }
-.back-link {
-    display: inline-block;
-    margin-bottom: var(--space-2);
-    font-size: 0.85rem;
-    color: var(--text-muted);
-}
 
 .profile-grid {
     display: grid;

--- a/web/src/main/resources/static/robots.txt
+++ b/web/src/main/resources/static/robots.txt
@@ -1,0 +1,7 @@
+User-agent: *
+Allow: /
+Disallow: /oauth2/
+Disallow: /logout
+Disallow: /actuator/
+
+Sitemap: https://www.toby-bot.co.uk/sitemap.xml

--- a/web/src/main/resources/static/sitemap.xml
+++ b/web/src/main/resources/static/sitemap.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    <url>
+        <loc>https://www.toby-bot.co.uk/</loc>
+        <changefreq>weekly</changefreq>
+        <priority>1.0</priority>
+    </url>
+    <url>
+        <loc>https://www.toby-bot.co.uk/commands/wiki</loc>
+        <changefreq>weekly</changefreq>
+        <priority>0.8</priority>
+    </url>
+    <url>
+        <loc>https://www.toby-bot.co.uk/changelog</loc>
+        <changefreq>weekly</changefreq>
+        <priority>0.7</priority>
+    </url>
+    <url>
+        <loc>https://www.toby-bot.co.uk/terms</loc>
+        <changefreq>monthly</changefreq>
+        <priority>0.3</priority>
+    </url>
+    <url>
+        <loc>https://www.toby-bot.co.uk/privacy</loc>
+        <changefreq>monthly</changefreq>
+        <priority>0.3</priority>
+    </url>
+</urlset>

--- a/web/src/main/resources/templates/changelog.html
+++ b/web/src/main/resources/templates/changelog.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="en">
+<head th:replace="~{fragments/head :: headSeo(
+        'TobyBot — Changelog',
+        'Recent shipped highlights — what''s landed in TobyBot lately, in plain English.',
+        null,
+        '/css/home.css')}"></head>
+<body>
+<div th:replace="~{fragments/navbar :: navbar}"></div>
+
+<main class="changelog-page">
+    <header class="changelog-header">
+        <a class="back-link" th:href="@{/}">&larr; Home</a>
+        <h1>Changelog</h1>
+        <p class="muted">
+            Curated highlights of what&rsquo;s shipped recently. The full
+            history lives on
+            <a href="https://github.com/ml404/toby-bot" rel="noopener" target="_blank">GitHub</a>.
+        </p>
+    </header>
+
+    <ol class="changelog-timeline">
+        <li class="changelog-entry" th:each="entry : ${entries}">
+            <div class="changelog-meta">
+                <span class="changelog-emoji" th:if="${entry.emoji != null}" th:text="${entry.emoji}" aria-hidden="true">✨</span>
+                <span class="changelog-date" th:text="${entry.date}">Month YYYY</span>
+            </div>
+            <div class="changelog-body">
+                <h2 class="changelog-title" th:text="${entry.title}">Headline</h2>
+                <p class="changelog-summary" th:text="${entry.summary}">Summary text.</p>
+                <a class="changelog-pr"
+                   th:if="${entry.prNumber != null}"
+                   th:href="'https://github.com/ml404/toby-bot/pull/' + ${entry.prNumber}"
+                   th:text="'#' + ${entry.prNumber}"
+                   rel="noopener" target="_blank">#0</a>
+            </div>
+        </li>
+    </ol>
+</main>
+
+<footer th:replace="~{fragments/footer :: footer}"></footer>
+
+<script th:src="@{/js/home.js}"></script>
+</body>
+</html>

--- a/web/src/main/resources/templates/changelog.html
+++ b/web/src/main/resources/templates/changelog.html
@@ -2,7 +2,7 @@
 <html xmlns:th="http://www.thymeleaf.org" lang="en">
 <head th:replace="~{fragments/head :: headSeo(
         'TobyBot — Changelog',
-        'Recent shipped highlights — what''s landed in TobyBot lately, in plain English.',
+        'Recent shipped highlights — what just landed in TobyBot, in plain English.',
         null,
         '/css/home.css')}"></head>
 <body>

--- a/web/src/main/resources/templates/commands.html
+++ b/web/src/main/resources/templates/commands.html
@@ -1,73 +1,10 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org" lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>TobyBot &mdash; Commands</title>
-    <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
-    <link rel="stylesheet" th:href="@{/css/base.css}">
-    <link rel="stylesheet" th:href="@{/css/nav.css}">
-    <style>
-        .commands-page { max-width: 960px; margin: 40px auto; padding: 0 24px 80px; }
-        .commands-page h1 { font-size: 1.8rem; color: var(--text); margin-bottom: 8px; }
-        .commands-page .subtitle { color: var(--text-muted); margin-bottom: 40px; }
-        .category { margin-bottom: 48px; }
-        .category h2 {
-            font-size: 0.8rem;
-            color: var(--text-muted);
-            text-transform: uppercase;
-            letter-spacing: 0.08em;
-            margin-bottom: 12px;
-            padding-bottom: 8px;
-            border-bottom: 1px solid var(--border);
-        }
-        .table-wrap {
-            background: var(--bg-elevated);
-            border: 1px solid var(--border);
-            border-radius: 10px;
-            overflow: hidden;
-        }
-        .commands-table { width: 100%; border-collapse: collapse; }
-        .commands-table th {
-            text-align: left;
-            padding: 10px 16px;
-            color: var(--text-muted);
-            font-size: 0.78rem;
-            font-weight: 600;
-            text-transform: uppercase;
-            letter-spacing: 0.05em;
-            border-bottom: 1px solid var(--border);
-        }
-        .commands-table td {
-            padding: 12px 16px;
-            border-bottom: 1px solid var(--border);
-            font-size: 0.9rem;
-            vertical-align: top;
-        }
-        .commands-table tr:last-child td { border-bottom: none; }
-        .commands-table tr:hover td { background: rgba(88, 101, 242, 0.05); }
-        .cmd { font-family: monospace; color: var(--accent); font-size: 0.95rem; white-space: nowrap; }
-        .desc { color: var(--text); }
-        .opts { list-style: none; padding: 0; margin: 0; }
-        .opt { margin-bottom: 8px; }
-        .opt:last-child { margin-bottom: 0; }
-        .opt-name { font-family: monospace; color: var(--text); font-size: 0.85rem; }
-        .badge {
-            font-size: 0.7rem;
-            color: var(--text-muted);
-            background: var(--border);
-            padding: 1px 6px;
-            border-radius: 4px;
-            margin-left: 5px;
-            vertical-align: middle;
-        }
-        .opt-desc { color: var(--text-muted); font-size: 0.82rem; margin-top: 2px; }
-        .choices { list-style: none; margin: 4px 0 0; padding-left: 10px; }
-        .choice { font-size: 0.78rem; color: var(--text-muted); font-family: monospace; }
-        .choice::before { content: "• "; color: var(--accent); }
-        .none { color: var(--text-muted); font-style: italic; font-size: 0.85rem; opacity: 0.6; }
-    </style>
-</head>
+<head th:replace="~{fragments/head :: headSeo(
+        'TobyBot — Commands',
+        'Auto-generated reference for every TobyBot slash command, grouped by category (Music, D&D, Moderation, Economy, Misc, Fetch).',
+        null,
+        '/css/commands.css')}"></head>
 <body>
 
 <div th:replace="~{fragments/navbar :: navbar}"></div>
@@ -128,6 +65,8 @@
         </div>
     </section>
 </main>
+
+<footer th:replace="~{fragments/footer :: footer}"></footer>
 
 </body>
 </html>

--- a/web/src/main/resources/templates/fragments/footer.html
+++ b/web/src/main/resources/templates/fragments/footer.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<body>
+<!--
+    Shared site footer for public marketing pages (home, commands, login,
+    terms, privacy, changelog). Logged-in app pages don't include this —
+    they're working surfaces and the navbar already covers the legal
+    links via OAuth flows.
+
+    Three rows: copyright + legal, source link, tech stack. The
+    tech-stack row doubles as a craft signal for recruiters; the GitHub
+    link points at the same repo referenced from the legal pages.
+-->
+<footer th:fragment="footer" class="site-footer">
+    <div class="site-footer-inner">
+        <p class="site-footer-line">
+            &copy; 2026 TobyBot &mdash;
+            <a th:href="@{/terms}">Terms of Service</a> &middot;
+            <a th:href="@{/privacy}">Privacy Policy</a> &middot;
+            <a th:href="@{/changelog}">Changelog</a>
+        </p>
+        <p class="site-footer-line site-footer-source">
+            Open source on
+            <a href="https://github.com/ml404/toby-bot" rel="noopener" target="_blank">GitHub</a>.
+            <a th:href="@{/commands/wiki}">Browse all commands &rarr;</a>
+        </p>
+        <p class="site-footer-stack">
+            <span class="site-footer-stack-label">Built with</span>
+            <span class="site-footer-stack-item">Spring Boot</span>
+            <span class="site-footer-stack-item">Kotlin</span>
+            <span class="site-footer-stack-item">Thymeleaf</span>
+            <span class="site-footer-stack-item">Postgres</span>
+            <span class="site-footer-stack-item">JDA</span>
+            <span class="site-footer-stack-item">Lavalink</span>
+        </p>
+    </div>
+</footer>
+</body>
+</html>

--- a/web/src/main/resources/templates/fragments/head.html
+++ b/web/src/main/resources/templates/fragments/head.html
@@ -1,5 +1,16 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
+<!--
+    Shared <head> fragment. Two signatures:
+      :: head(pageTitle, extraCss)
+          — minimal: title + base CSS + optional per-page sheet. Used by
+            internal/app pages that don't need link-preview metadata.
+      :: head(pageTitle, pageDescription, ogImage, extraCss)
+          — adds <meta name="description"> + Open Graph + Twitter card so
+            shared links render rich previews. Public marketing pages
+            (home, commands, login, terms, privacy, changelog) use this.
+            Pass null for ogImage to fall back to the default preview.svg.
+-->
 <head th:fragment="head(pageTitle, extraCss)">
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -7,6 +18,29 @@
     <meta name="_csrf" th:if="${_csrf != null}" th:content="${_csrf.token}">
     <meta name="_csrf_header" th:if="${_csrf != null}" th:content="${_csrf.headerName}">
     <title th:text="${pageTitle}">TobyBot</title>
+    <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+    <link rel="stylesheet" th:href="@{/css/base.css}">
+    <link rel="stylesheet" th:href="@{/css/nav.css}">
+    <link rel="stylesheet" th:if="${extraCss != null}" th:href="@{${extraCss}}">
+</head>
+<head th:fragment="headSeo(pageTitle, pageDescription, ogImage, extraCss)">
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="color-scheme" content="dark">
+    <meta name="_csrf" th:if="${_csrf != null}" th:content="${_csrf.token}">
+    <meta name="_csrf_header" th:if="${_csrf != null}" th:content="${_csrf.headerName}">
+    <title th:text="${pageTitle}">TobyBot</title>
+    <meta name="description" th:content="${pageDescription}">
+    <meta property="og:type" content="website">
+    <meta property="og:title" th:content="${pageTitle}">
+    <meta property="og:description" th:content="${pageDescription}">
+    <meta property="og:image"
+          th:content="${ogImage != null ? ogImage : 'https://www.toby-bot.co.uk/images/preview.svg'}">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" th:content="${pageTitle}">
+    <meta name="twitter:description" th:content="${pageDescription}">
+    <meta name="twitter:image"
+          th:content="${ogImage != null ? ogImage : 'https://www.toby-bot.co.uk/images/preview.svg'}">
     <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
     <link rel="stylesheet" th:href="@{/css/base.css}">
     <link rel="stylesheet" th:href="@{/css/nav.css}">

--- a/web/src/main/resources/templates/home.html
+++ b/web/src/main/resources/templates/home.html
@@ -1,191 +1,10 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org" lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>TobyBot — Your Discord Companion</title>
-
-    <!-- SEO -->
-    <meta name="description" content="Music, moderation, DnD, a live TOBY coin market, titles to equip, and monthly leaderboards — all in one bot.">
-
-    <!-- Open Graph (WhatsApp, Facebook, etc.) -->
-    <meta property="og:type"        content="website">
-    <meta property="og:url"         content="https://www.toby-bot.co.uk/">
-    <meta property="og:title"       content="TobyBot — Your Discord Companion">
-    <meta property="og:description" content="Music, moderation, DnD, a live TOBY coin market, titles to equip, and monthly leaderboards — all in one bot.">
-    <meta property="og:image"       content="https://www.toby-bot.co.uk/images/preview.svg">
-
-    <!-- Favicon -->
-    <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
-    <link rel="stylesheet" th:href="@{/css/base.css}">
-    <link rel="stylesheet" th:href="@{/css/nav.css}">
-    <style>
-        * { box-sizing: border-box; margin: 0; padding: 0; }
-        body {
-            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-            background: #1a1a2e;
-            color: #e0e0e0;
-            min-height: 100vh;
-        }
-
-        /* HERO */
-        .hero {
-            text-align: center;
-            padding: 80px 24px 64px;
-        }
-        .hero-badge {
-            display: inline-block;
-            background: rgba(88, 101, 242, 0.15);
-            color: #7289fa;
-            border: 1px solid rgba(88, 101, 242, 0.3);
-            border-radius: 999px;
-            padding: 4px 16px;
-            font-size: 0.78rem;
-            font-weight: 600;
-            letter-spacing: 0.08em;
-            text-transform: uppercase;
-            margin-bottom: 20px;
-        }
-        .hero h1 {
-            font-size: clamp(2rem, 5vw, 3.2rem);
-            color: #fff;
-            margin-bottom: 16px;
-            line-height: 1.2;
-        }
-        .hero h1 span { color: #5865F2; }
-        .hero p {
-            font-size: 1.1rem;
-            color: #a0a0b0;
-            max-width: 540px;
-            margin: 0 auto 36px;
-            line-height: 1.6;
-        }
-        .hero-actions { display: flex; gap: 16px; justify-content: center; flex-wrap: wrap; }
-        .btn-primary {
-            display: inline-block;
-            background: #5865F2;
-            color: #fff;
-            text-decoration: none;
-            padding: 14px 28px;
-            border-radius: 8px;
-            font-size: 1rem;
-            font-weight: 600;
-            transition: background 0.2s;
-        }
-        .btn-primary:hover { background: #4752c4; }
-        .btn-secondary {
-            display: inline-block;
-            background: transparent;
-            color: #e0e0e0;
-            text-decoration: none;
-            padding: 14px 28px;
-            border-radius: 8px;
-            border: 1px solid #3a3a5a;
-            font-size: 1rem;
-            font-weight: 600;
-            transition: border-color 0.2s, color 0.2s;
-        }
-        .btn-secondary:hover { border-color: #5865F2; color: #fff; }
-
-        /* DIVIDER */
-        .divider {
-            height: 1px;
-            background: #2a2a4a;
-            max-width: 1100px;
-            margin: 0 auto;
-        }
-
-        /* FEATURES */
-        .features {
-            padding: 64px 24px;
-            max-width: 1100px;
-            margin: 0 auto;
-        }
-        .features h2 {
-            text-align: center;
-            font-size: 1.8rem;
-            color: #fff;
-            margin-bottom: 40px;
-        }
-        .feature-grid {
-            display: grid;
-            grid-template-columns: repeat(auto-fill, minmax(190px, 1fr));
-            gap: 20px;
-        }
-        .feature-card {
-            background: #16213e;
-            border: 1px solid #2a2a4a;
-            border-radius: 12px;
-            padding: 28px 20px;
-            text-align: center;
-            transition: border-color 0.2s, transform 0.15s;
-        }
-        .feature-card:hover { border-color: #5865F2; transform: translateY(-3px); }
-        .feature-icon { font-size: 2.2rem; margin-bottom: 14px; }
-        .feature-card h3 { font-size: 1rem; color: #fff; margin-bottom: 8px; }
-        .feature-card p { font-size: 0.88rem; color: #a0a0b0; line-height: 1.5; }
-        /* Linkable feature cards: no underline, full-card click target. */
-        a.feature-card { display: block; text-decoration: none; color: inherit; }
-        a.feature-card h3 { color: #fff; }
-        .commands-link {
-            text-align: center;
-            margin-top: 32px;
-        }
-        .commands-link a {
-            color: #7289fa;
-            text-decoration: none;
-            font-size: 0.95rem;
-        }
-        .commands-link a:hover { text-decoration: underline; }
-
-        /* INTRO CTA */
-        .intro-cta {
-            padding: 20px 24px 80px;
-            max-width: 800px;
-            margin: 0 auto;
-        }
-        .cta-card {
-            background: linear-gradient(135deg, #16213e 0%, #1a1a3e 100%);
-            border: 1px solid #3a3a6a;
-            border-radius: 16px;
-            padding: 48px 40px;
-            text-align: center;
-        }
-        .cta-card h2 { font-size: 1.6rem; color: #fff; margin-bottom: 12px; }
-        .cta-card p {
-            color: #a0a0b0;
-            margin-bottom: 28px;
-            max-width: 480px;
-            margin-left: auto;
-            margin-right: auto;
-            line-height: 1.6;
-        }
-
-        /* FOOTER */
-        footer {
-            border-top: 1px solid #2a2a4a;
-            padding: 24px;
-            text-align: center;
-            color: #555;
-            font-size: 0.82rem;
-        }
-        footer a { color: #7289fa; text-decoration: none; }
-        footer a:hover { text-decoration: underline; }
-
-        /* RESPONSIVE */
-        @media (max-width: 600px) {
-            .cta-card { padding: 32px 20px; }
-        }
-        @media (max-width: 480px) {
-            .hero { padding: 48px 16px 36px; }
-            .hero-actions { flex-direction: column; align-items: stretch; gap: 10px; }
-            .hero-actions .btn, .hero-actions a { width: 100%; text-align: center; }
-            .features { padding: 36px 16px; gap: 16px; }
-            .feature-card { padding: 20px 16px; }
-            .cta-card { padding: 24px 16px; }
-        }
-    </style>
-</head>
+<head th:replace="~{fragments/head :: headSeo(
+        'TobyBot — Your Discord Companion',
+        'A live per-server coin economy, a 12-game casino with a shared jackpot pool, music, polls, monthly leaderboards, and a full web admin — all in one Discord bot.',
+        'https://www.toby-bot.co.uk/images/preview.svg',
+        '/css/home.css')}"></head>
 <body>
 
 <div th:replace="~{fragments/navbar :: navbar}"></div>
@@ -193,140 +12,188 @@
 <!-- Hero -->
 <section class="hero">
     <div class="hero-badge">Discord Bot</div>
-    <h1>Your server's <span>best companion</span></h1>
-    <p>Music, moderation, DnD tools, a live TOBY coin market, titles to equip, and monthly leaderboards — all in one bot.</p>
+    <h1>Your server&rsquo;s <span>best companion</span></h1>
+    <p>A live per-server coin economy, a 12-game casino with a shared jackpot pool,
+        music and intro songs, monthly leaderboards, and a full browser-based admin —
+        all in one Discord bot.</p>
     <div class="hero-actions">
         <a th:href="${inviteUrl}" class="btn-primary">Invite to Server</a>
-        <a href="/intro/guilds" class="btn-secondary">Manage Intro Songs</a>
+        <a th:href="@{/commands/wiki}" class="btn-secondary">Browse all commands</a>
+    </div>
+    <p class="hero-aside">
+        <a th:href="@{/changelog}">What&rsquo;s new &rarr;</a>
+    </p>
+</section>
+
+<!-- Live stats -->
+<section class="stats-strip" aria-label="TobyBot at a glance">
+    <div class="stat">
+        <span class="stat-value" th:text="${homeStats.serverCount}">0</span>
+        <span class="stat-label">Servers</span>
+    </div>
+    <div class="stat">
+        <span class="stat-value" th:text="${homeStats.commandCount}">0</span>
+        <span class="stat-label">Commands</span>
+    </div>
+    <div class="stat">
+        <span class="stat-value" th:text="${homeStats.gameCount}">0</span>
+        <span class="stat-label">Games</span>
     </div>
 </section>
 
-<div class="divider"></div>
-
-<!-- Features -->
-<section class="features">
-    <h2>What can TobyBot do?</h2>
+<!-- Casino & coin -->
+<section class="section">
+    <header class="section-header">
+        <span class="section-eyebrow">Casino &amp; Coin</span>
+        <h2>A coin economy that actually loops</h2>
+        <p class="section-lede">
+            Earn social credit by hanging out, trade it for TOBY coin on a live
+            per-server market, then risk it all (or just some of it) on a
+            casino with a shared jackpot pool that grows from every loss.
+        </p>
+    </header>
     <div class="feature-grid">
-        <a class="feature-card" href="/intro/guilds">
-            <div class="feature-icon">&#127925;</div>
-            <h3>Music &amp; Intros</h3>
-            <p>Play audio and set personal intro songs that play when you join a voice channel.</p>
-        </a>
         <a class="feature-card" href="/economy/guilds">
             <div class="feature-icon">&#128176;</div>
-            <h3>TOBY Market</h3>
-            <p>Earn social credit by hanging out, then trade it for TOBY coin on a live per-server market.</p>
+            <h3>TOBY market</h3>
+            <p>Live per-server price tick every 5 minutes. Buy low, sell high — your wallet shows up on the leaderboard.</p>
+        </a>
+        <a class="feature-card" href="/casino/guilds">
+            <div class="feature-icon">&#127920;</div>
+            <h3>Casino games</h3>
+            <p>9 quick-play minigames (slots, dice, roulette, scratch, keno, high-low, baccarat, coinflip, Casino Hold&rsquo;em) plus seated Poker and Blackjack tables.</p>
+            <span class="feature-card-tag">12 games</span>
+        </a>
+        <a class="feature-card" href="/lottery/guilds">
+            <div class="feature-icon">&#127903;&#65039;</div>
+            <h3>Daily lottery</h3>
+            <p>Auto-draws at 00:00 UTC, seeded from the jackpot pool. Pick-5-of-49 or weighted-top-3, configurable per server.</p>
+        </a>
+        <a class="feature-card" href="/commands/wiki">
+            <div class="feature-icon">&#128293;</div>
+            <h3>Shared jackpot pool</h3>
+            <p>Every casino loss tributes to a per-server pool that any winning roll can claim. RTP-gated so high-RTP games don&rsquo;t double-dip.</p>
+        </a>
+        <a class="feature-card" href="/tip/guilds">
+            <div class="feature-icon">&#128184;</div>
+            <h3>Tip &amp; duel</h3>
+            <p>Send credit to a friend with a message, or stake them in a coin-flip duel — winner takes the pot.</p>
         </a>
         <a class="feature-card" href="/titles/guilds">
             <div class="feature-icon">&#127942;</div>
             <h3>Titles</h3>
-            <p>Spend credit on vanity titles that grant a matching Discord role when equipped.</p>
+            <p>Spend credit (or pay with TOBY in one click) on vanity titles that grant a matching Discord role when equipped.</p>
         </a>
-        <a class="feature-card" href="/tip/guilds">
-            <div class="feature-icon">&#128184;</div>
-            <h3>Tip A Friend</h3>
-            <p>Send some of your social credit to another user in the same server, with an optional message.</p>
-        </a>
-        <a class="feature-card" href="/duel/guilds">
-            <div class="feature-icon">&#9876;&#65039;</div>
-            <h3>Duel</h3>
-            <p>Stake credit and challenge someone to a coin-flip duel — winner takes most of the pot.</p>
-        </a>
-        <a class="feature-card" href="/poker/guilds">
-            <div class="feature-icon">&#127924;</div>
-            <h3>Poker</h3>
-            <p>Multiplayer fixed-limit Texas Hold'em with up to six seats. Buy in, deal hands, take credits from your friends.</p>
-        </a>
+    </div>
+</section>
+
+<!-- Server engagement -->
+<section class="section">
+    <header class="section-header">
+        <span class="section-eyebrow">Engagement</span>
+        <h2>Make your server worth showing up to</h2>
+        <p class="section-lede">
+            Voice-time and message activity feed monthly leaderboards, a per-user
+            profile, and personalised intro songs. Configurable daily caps,
+            UBI for non-voice users, and a 30-day rolling activity window.
+        </p>
+    </header>
+    <div class="feature-grid">
         <a class="feature-card" href="/leaderboards">
             <div class="feature-icon">&#128200;</div>
             <h3>Leaderboards</h3>
-            <p>Monthly standings and TobyCoin wallet rankings per server.</p>
+            <p>Monthly social-credit standings with a podium, TobyCoin wallet rankings, and a This-month / Total toggle.</p>
         </a>
-        <div class="feature-card">
-            <div class="feature-icon">&#127922;</div>
-            <h3>DnD Tools</h3>
-            <p>Roll dice, look up spells and monsters, and streamline your tabletop sessions.</p>
-        </div>
+        <a class="feature-card" href="/profile/guilds">
+            <div class="feature-icon">&#129489;</div>
+            <h3>Profile</h3>
+            <p>Per-server view of your social credit, equipped title, owned permissions, and recent activity.</p>
+        </a>
+        <a class="feature-card" href="/intro/guilds">
+            <div class="feature-icon">&#127925;</div>
+            <h3>Intro songs</h3>
+            <p>Set a custom track that plays whenever you join voice. YouTube links or MP3 uploads, capped per user.</p>
+        </a>
+    </div>
+</section>
+
+<!-- Server management -->
+<section class="section">
+    <header class="section-header">
+        <span class="section-eyebrow">Server Management</span>
+        <h2>Admin from the browser, not slash commands</h2>
+        <p class="section-lede">
+            A six-tab moderation web UI: search across every server config, toggle
+            user permissions, mute or move voice channels, post emoji-reaction
+            polls, and run casino remediation — without typing a single
+            <code>/setconfig</code>.
+        </p>
+    </header>
+    <div class="feature-grid">
         <a class="feature-card" href="/moderation/guilds">
             <div class="feature-icon">&#128737;</div>
-            <h3>Moderation</h3>
-            <p>Kick, mute, tweak permissions, and run polls &mdash; from your browser.</p>
+            <h3>Moderation web UI</h3>
+            <p>Search across ~58 config keys, toggle per-user permissions, adjust social credit, kick members — all in one place.</p>
+            <span class="feature-card-tag">New</span>
         </a>
-        <div class="feature-card">
-            <div class="feature-icon">&#10024;</div>
-            <h3>Miscellaneous</h3>
-            <p>Fun and utility commands for everyday use on your server.</p>
-        </div>
-        <div class="feature-card">
-            <div class="feature-icon">&#128269;</div>
-            <h3>Fetch</h3>
-            <p>Retrieve information and look things up in an instant.</p>
-        </div>
-    </div>
-    <div class="commands-link">
-        <a href="/commands/wiki">Browse all commands &#8594;</a>
+        <a class="feature-card" href="/moderation/guilds">
+            <div class="feature-icon">&#128226;</div>
+            <h3>Polls &amp; voice ops</h3>
+            <p>Post emoji-reaction polls, mass-mute or move voice-channel members, and create read-only announce channels with one click.</p>
+        </a>
+        <a class="feature-card" href="/moderation/guilds">
+            <div class="feature-icon">&#129534;</div>
+            <h3>Anti-autoclicker</h3>
+            <p>Per-pixel click-pattern detection ramps the house edge for suspect sessions; legitimate play never trips the gate.</p>
+        </a>
     </div>
 </section>
 
-<div class="divider"></div>
-
-<!-- Intro Songs CTA -->
-<section class="intro-cta">
-    <div class="cta-card">
-        <h2>&#127925; Personalise Your Entrance</h2>
-        <p>Set a custom intro song that plays whenever you join a voice channel. Supports YouTube links and MP3 uploads.</p>
-        <a href="/intro/guilds" class="btn-primary">Manage Your Intros &#8594;</a>
+<!-- Tabletop & tools -->
+<section class="section">
+    <header class="section-header">
+        <span class="section-eyebrow">Tabletop &amp; Tools</span>
+        <h2>Sundries that earn their keep</h2>
+    </header>
+    <div class="feature-grid">
+        <a class="feature-card" href="/dnd/campaign">
+            <div class="feature-icon">&#127922;</div>
+            <h3>D&amp;D campaigns</h3>
+            <p>Build encounters, drag-drop your roster, and keep initiative running — all from the browser.</p>
+        </a>
+        <a class="feature-card" href="/utils">
+            <div class="feature-icon">&#128296;</div>
+            <h3>Utilities</h3>
+            <p>Meme generator, Dead by Daylight / Killing Floor 2 random builds, and other small tools.</p>
+        </a>
     </div>
 </section>
 
-<!-- TOBY Market CTA -->
-<section class="intro-cta">
-    <div class="cta-card">
-        <h2>&#128176; Trade TOBY Coin</h2>
-        <p>Every server has its own live market with a 5-minute price tick. Earn social credit by being active, then buy low and sell high. Your wallet travels with you to the leaderboard.</p>
-        <a href="/economy/guilds" class="btn-primary">Open The Market &#8594;</a>
+<!-- Final CTA -->
+<section class="final-cta">
+    <h2>Ready to add TobyBot to your server?</h2>
+    <p>Free to install, every feature is per-server configurable, and the
+        full source is on GitHub if you want to read or fork it.</p>
+    <div class="hero-actions">
+        <a th:href="${inviteUrl}" class="btn-primary">Invite to Server</a>
+        <a th:href="@{/commands/wiki}" class="btn-secondary">Browse all commands</a>
     </div>
 </section>
 
-<!-- Titles CTA -->
-<section class="intro-cta">
-    <div class="cta-card">
-        <h2>&#127942; Wear A Title</h2>
-        <p>Spend social credit &mdash; or pay with TOBY in one click &mdash; on vanity titles that come with a matching Discord role you can equip any time.</p>
-        <a href="/titles/guilds" class="btn-primary">Browse The Title Shop &#8594;</a>
-    </div>
-</section>
+<footer th:replace="~{fragments/footer :: footer}"></footer>
 
-<!-- Leaderboards CTA -->
-<section class="intro-cta">
-    <div class="cta-card">
-        <h2>&#128200; See The Leaderboards</h2>
-        <p>Monthly social-credit standings with a podium, TobyCoin wallet rankings, and a This month / Current total toggle so the top of the list actually changes.</p>
-        <a href="/leaderboards" class="btn-primary">View Leaderboards &#8594;</a>
-    </div>
-</section>
-
-<!-- DnD Campaign CTA -->
-<section class="intro-cta">
-    <div class="cta-card">
-        <h2>&#127922; Run Your Campaign</h2>
-        <p>Build encounters, drag and drop your roster, and keep initiative running — all from the browser.</p>
-        <a href="/dnd/campaign" class="btn-primary">Open Campaign Manager &#8594;</a>
-    </div>
-</section>
-
-<!-- Moderation CTA -->
-<section class="intro-cta">
-    <div class="cta-card">
-        <h2>&#128737; Moderate From The Web</h2>
-        <p>Adjust user permissions, tweak your server config, mute a voice channel, or post a poll — no slash commands needed.</p>
-        <a href="/moderation/guilds" class="btn-primary">Open Moderation &#8594;</a>
-    </div>
-</section>
-
-<footer>
-    <p>&copy; 2026 TobyBot &mdash; <a href="/terms">Terms of Service</a> &mdash; <a href="/privacy">Privacy Policy</a></p>
-</footer>
+<!-- JSON-LD: SoftwareApplication for rich Google card on the homepage. -->
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "SoftwareApplication",
+  "name": "TobyBot",
+  "applicationCategory": "DiscordBot",
+  "operatingSystem": "Discord",
+  "url": "https://www.toby-bot.co.uk/",
+  "offers": { "@type": "Offer", "price": "0", "priceCurrency": "GBP" }
+}
+</script>
 
 <script th:src="@{/js/home.js}"></script>
 </body>

--- a/web/src/main/resources/templates/login.html
+++ b/web/src/main/resources/templates/login.html
@@ -1,70 +1,39 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org" lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>TobyBot - Login</title>
-    <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
-    <link rel="stylesheet" th:href="@{/css/base.css}">
-    <link rel="stylesheet" th:href="@{/css/nav.css}">
-    <style>
-        * { box-sizing: border-box; margin: 0; padding: 0; }
-        body {
-            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-            background: #1a1a2e;
-            color: #e0e0e0;
-            min-height: 100vh;
-        }
-        .login-wrap {
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            min-height: calc(100vh - 57px);
-        }
-        .card {
-            background: #16213e;
-            border-radius: 12px;
-            padding: 48px 40px;
-            text-align: center;
-            max-width: 400px;
-            width: 100%;
-            box-shadow: 0 8px 32px rgba(0,0,0,0.4);
-        }
-        h1 { font-size: 1.8rem; margin-bottom: 8px; color: #fff; }
-        p { color: #a0a0b0; margin-bottom: 32px; }
-        .card .btn-discord {
-            padding: 14px 28px;
-            border-radius: 8px;
-            font-size: 1rem;
-        }
-        .card .btn-discord:hover { background: #4752c4; }
-        .error {
-            background: #4a1a1a;
-            border: 1px solid #c0392b;
-            color: #e74c3c;
-            padding: 10px 16px;
-            border-radius: 6px;
-            margin-bottom: 20px;
-            font-size: 0.9rem;
-        }
-    </style>
-</head>
+<head th:replace="~{fragments/head :: headSeo(
+        'TobyBot — Login',
+        'Sign in with Discord to manage TobyBot in the servers you own or moderate.',
+        null,
+        '/css/home.css')}"></head>
 <body>
 <div th:replace="~{fragments/navbar :: navbar}"></div>
+
 <div class="login-wrap">
-<div class="card">
-    <h1>TobyBot</h1>
-    <p>Sign in with Discord to manage your server's TobyBot integration.</p>
+    <div class="login-card">
+        <h1>Sign in</h1>
+        <p class="lede">Discord OAuth — we don't ask for a password. After you sign in you can:</p>
+        <ul>
+            <li>Manage intro songs across every server you're in</li>
+            <li>Tune moderation, jackpot, and lottery settings</li>
+            <li>Trade TOBY coin from the per-server market</li>
+        </ul>
 
-    <div th:if="${loginError}" class="error">
-        Login failed. Please try again.
+        <div th:if="${loginError}" class="login-error">
+            Login failed. Please try again.
+        </div>
+
+        <a href="/oauth2/authorization/discord" class="btn-discord">
+            Login with Discord
+        </a>
+
+        <p class="login-aside">
+            New here? <a th:href="@{/}">See what TobyBot does &rarr;</a>
+        </p>
     </div>
+</div>
 
-    <a href="/oauth2/authorization/discord" class="btn-discord">
-        Login with Discord
-    </a>
-</div>
-</div>
+<footer th:replace="~{fragments/footer :: footer}"></footer>
+
 <script th:src="@{/js/home.js}"></script>
 </body>
 </html>

--- a/web/src/main/resources/templates/privacy.html
+++ b/web/src/main/resources/templates/privacy.html
@@ -1,80 +1,26 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org" lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>TobyBot — Privacy Policy</title>
-    <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
-    <link rel="stylesheet" th:href="@{/css/base.css}">
-    <link rel="stylesheet" th:href="@{/css/nav.css}">
-    <style>
-        * { box-sizing: border-box; margin: 0; padding: 0; }
-        body {
-            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-            background: #1a1a2e;
-            color: #e0e0e0;
-            min-height: 100vh;
-        }
-
-        .container {
-            max-width: 760px;
-            margin: 48px auto;
-            padding: 0 24px 80px;
-        }
-        .page-header { margin-bottom: 40px; }
-        .page-header h1 { font-size: 2rem; color: #fff; margin-bottom: 8px; }
-        .page-header .updated { color: #666; font-size: 0.85rem; }
-
-        .section { margin-bottom: 36px; }
-        .section h2 {
-            font-size: 1rem;
-            color: #fff;
-            font-weight: 600;
-            margin-bottom: 12px;
-            padding-bottom: 8px;
-            border-bottom: 1px solid #2a2a4a;
-        }
-        .section p, .section li {
-            color: #a0a0b0;
-            font-size: 0.92rem;
-            line-height: 1.7;
-        }
-        .section p + p { margin-top: 10px; }
-        .section ul {
-            list-style: disc;
-            padding-left: 20px;
-            display: flex;
-            flex-direction: column;
-            gap: 6px;
-        }
-
-        footer {
-            border-top: 1px solid #2a2a4a;
-            padding: 24px;
-            text-align: center;
-            color: #555;
-            font-size: 0.82rem;
-        }
-        footer a { color: #7289fa; text-decoration: none; }
-        footer a:hover { text-decoration: underline; }
-    </style>
-</head>
+<head th:replace="~{fragments/head :: headSeo(
+        'TobyBot — Privacy Policy',
+        'TobyBot Privacy Policy: what data we collect, how it''s used, retention windows, and how to opt out or delete your data.',
+        null,
+        '/css/legal.css')}"></head>
 <body>
 
 <div th:replace="~{fragments/navbar :: navbar}"></div>
 
-<div class="container">
-    <div class="page-header">
+<div class="legal-container">
+    <div class="legal-header">
         <h1>Privacy Policy</h1>
         <p class="updated">Last updated: April 2026</p>
     </div>
 
-    <div class="section">
+    <div class="legal-section">
         <h2>1. Introduction</h2>
         <p>This Privacy Policy explains how TobyBot ("the bot", "we", "us") collects, uses, and stores information when you use the TobyBot Discord bot or this website. By adding TobyBot to your server or using its features, you agree to the practices described here.</p>
     </div>
 
-    <div class="section">
+    <div class="legal-section">
         <h2>2. Data We Collect</h2>
         <p>TobyBot collects only the minimum data needed to operate its features:</p>
         <ul>
@@ -91,7 +37,7 @@
         <p>We do not collect passwords, email addresses, payment card numbers, or any data beyond what Discord makes available through its API.</p>
     </div>
 
-    <div class="section">
+    <div class="legal-section">
         <h2>3. How We Use Your Data</h2>
         <p>All collected data is used solely to provide and improve TobyBot's functionality:</p>
         <ul>
@@ -105,7 +51,7 @@
         <p>We do not sell, rent, or share your data with third parties for marketing or advertising purposes.</p>
     </div>
 
-    <div class="section">
+    <div class="legal-section">
         <h2>4. Game-Activity Tracking (Opt-In)</h2>
         <p>TobyBot can optionally record the names of games you are playing on Discord ("game-activity tracking") to produce per-user and per-server monthly top-games summaries. This feature is <strong>disabled by default</strong> and gated by two switches:</p>
         <ul>
@@ -118,28 +64,28 @@
         <p><strong>Not affected by tracking:</strong> game activity does not earn social credit. Tracking is observational only.</p>
     </div>
 
-    <div class="section">
+    <div class="legal-section">
         <h2>5. TOBY Coin Trade History</h2>
         <p>When you buy or sell TOBY coin via <code>/tobycoin</code> or the web Market, we record the trade (timestamp, side, quantity, price per coin, and your Discord display name) so the price chart can show markers and a "Recent trades" list to other members of the same server. This activity is visible only to members of the guild where the trade occurred. Trade records are retained for up to 12 months — long enough that the chart's 1Y view stays meaningful — and then automatically deleted; balance changes themselves persist as part of your social-credit and TOBY-coin totals.</p>
     </div>
 
-    <div class="section">
+    <div class="legal-section">
         <h2>6. Data Retention</h2>
         <p>Your data is retained for as long as TobyBot is active in your server. If you remove the bot from your server, or upon your request, we will delete all data associated with your guild. Individual user data (such as intro songs or social credit) can also be deleted on request by a server owner or the user themselves via the appropriate bot commands. Activity-tracking data is additionally governed by the retention rules described in the "Game-Activity Tracking" section above. TOBY coin trade records follow the up-to-12-month retention described in the "TOBY Coin Trade History" section above.</p>
     </div>
 
-    <div class="section">
+    <div class="legal-section">
         <h2>7. Third-Party Services</h2>
         <p>TobyBot interacts with the following external services to deliver its features:</p>
         <ul>
-            <li><strong>Discord API</strong> — all bot interactions are mediated through Discord. Discord's own <a href="https://discord.com/privacy" style="color:#7289fa;">Privacy Policy</a> applies to data held on their platform.</li>
+            <li><strong>Discord API</strong> — all bot interactions are mediated through Discord. Discord's own <a href="https://discord.com/privacy">Privacy Policy</a> applies to data held on their platform.</li>
             <li><strong>YouTube</strong> — used to search and stream music. No user data is sent to YouTube beyond the search queries you issue.</li>
             <li><strong>Reddit API</strong> — used to fetch meme images. No personally identifiable information is sent.</li>
             <li><strong>D&amp;D 5e API</strong> — used for Dungeons &amp; Dragons lookup commands. No user data is transmitted.</li>
         </ul>
     </div>
 
-    <div class="section">
+    <div class="legal-section">
         <h2>8. Your Rights</h2>
         <p>You have the right to:</p>
         <ul>
@@ -147,28 +93,26 @@
             <li>Request deletion of your personal data or your guild's data.</li>
             <li>Withdraw consent by removing TobyBot from your server at any time.</li>
         </ul>
-        <p>To exercise these rights, please open an issue on the <a href="https://github.com/ml404/toby-bot" style="color:#7289fa;">GitHub repository</a> or contact us via Discord.</p>
+        <p>To exercise these rights, please open an issue on the <a href="https://github.com/ml404/toby-bot">GitHub repository</a> or contact us via Discord.</p>
     </div>
 
-    <div class="section">
+    <div class="legal-section">
         <h2>9. Children's Privacy</h2>
         <p>TobyBot is not directed at children under the age of 13. In accordance with Discord's Terms of Service, users must be at least 13 years old. We do not knowingly collect data from anyone under this age. If you believe a minor has provided us with personal data, please contact us so we can remove it.</p>
     </div>
 
-    <div class="section">
+    <div class="legal-section">
         <h2>10. Changes to This Policy</h2>
         <p>We may update this Privacy Policy from time to time to reflect changes in the bot's features or legal requirements. We will update the "Last updated" date at the top of this page when changes are made. Continued use of TobyBot after updates are posted constitutes acceptance of the revised policy.</p>
     </div>
 
-    <div class="section">
+    <div class="legal-section">
         <h2>11. Contact</h2>
-        <p>If you have any questions or concerns about this Privacy Policy, please open an issue on the <a href="https://github.com/ml404/toby-bot" style="color:#7289fa;">GitHub repository</a> or reach out via Discord.</p>
+        <p>If you have any questions or concerns about this Privacy Policy, please open an issue on the <a href="https://github.com/ml404/toby-bot">GitHub repository</a> or reach out via Discord.</p>
     </div>
 </div>
 
-<footer>
-    <p>&copy; 2026 TobyBot &mdash; <a href="/terms">Terms of Service</a> &mdash; <a href="/privacy">Privacy Policy</a></p>
-</footer>
+<footer th:replace="~{fragments/footer :: footer}"></footer>
 
 <script th:src="@{/js/home.js}"></script>
 </body>

--- a/web/src/main/resources/templates/privacy.html
+++ b/web/src/main/resources/templates/privacy.html
@@ -2,7 +2,7 @@
 <html xmlns:th="http://www.thymeleaf.org" lang="en">
 <head th:replace="~{fragments/head :: headSeo(
         'TobyBot — Privacy Policy',
-        'TobyBot Privacy Policy: what data we collect, how it''s used, retention windows, and how to opt out or delete your data.',
+        'TobyBot Privacy Policy: what data we collect, how we use it, retention windows, and how to opt out or delete your data.',
         null,
         '/css/legal.css')}"></head>
 <body>

--- a/web/src/main/resources/templates/terms.html
+++ b/web/src/main/resources/templates/terms.html
@@ -1,90 +1,36 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org" lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>TobyBot — Terms of Service</title>
-    <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
-    <link rel="stylesheet" th:href="@{/css/base.css}">
-    <link rel="stylesheet" th:href="@{/css/nav.css}">
-    <style>
-        * { box-sizing: border-box; margin: 0; padding: 0; }
-        body {
-            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-            background: #1a1a2e;
-            color: #e0e0e0;
-            min-height: 100vh;
-        }
-
-        .container {
-            max-width: 760px;
-            margin: 48px auto;
-            padding: 0 24px 80px;
-        }
-        .page-header { margin-bottom: 40px; }
-        .page-header h1 { font-size: 2rem; color: #fff; margin-bottom: 8px; }
-        .page-header .updated { color: #666; font-size: 0.85rem; }
-
-        .section { margin-bottom: 36px; }
-        .section h2 {
-            font-size: 1rem;
-            color: #fff;
-            font-weight: 600;
-            margin-bottom: 12px;
-            padding-bottom: 8px;
-            border-bottom: 1px solid #2a2a4a;
-        }
-        .section p, .section li {
-            color: #a0a0b0;
-            font-size: 0.92rem;
-            line-height: 1.7;
-        }
-        .section p + p { margin-top: 10px; }
-        .section ul {
-            list-style: disc;
-            padding-left: 20px;
-            display: flex;
-            flex-direction: column;
-            gap: 6px;
-        }
-
-        footer {
-            border-top: 1px solid #2a2a4a;
-            padding: 24px;
-            text-align: center;
-            color: #555;
-            font-size: 0.82rem;
-        }
-        footer a { color: #7289fa; text-decoration: none; }
-        footer a:hover { text-decoration: underline; }
-    </style>
-</head>
+<head th:replace="~{fragments/head :: headSeo(
+        'TobyBot — Terms of Service',
+        'TobyBot Terms of Service: acceptable use, premium features, data handling, and contact info.',
+        null,
+        '/css/legal.css')}"></head>
 <body>
 
 <div th:replace="~{fragments/navbar :: navbar}"></div>
 
-<div class="container">
-    <div class="page-header">
+<div class="legal-container">
+    <div class="legal-header">
         <h1>Terms of Service</h1>
         <p class="updated">Last updated: March 2026</p>
     </div>
 
-    <div class="section">
+    <div class="legal-section">
         <h2>1. Acceptance of Terms</h2>
         <p>By adding TobyBot to your Discord server or using any of its features, you agree to be bound by these Terms of Service. If you do not agree to these terms, please remove the bot from your server and discontinue use.</p>
     </div>
 
-    <div class="section">
+    <div class="legal-section">
         <h2>2. Description of Service</h2>
         <p>TobyBot is a Discord bot providing music playback, intro song management, Dungeons &amp; Dragons utilities, server moderation tools, and miscellaneous commands. Features are provided as-is and may change or be discontinued at any time.</p>
     </div>
 
-    <div class="section">
+    <div class="legal-section">
         <h2>3. Eligibility</h2>
         <p>You must be at least 13 years of age to use TobyBot, in accordance with Discord's own Terms of Service. By using TobyBot you confirm that you meet this requirement and that your use complies with all applicable laws in your jurisdiction.</p>
     </div>
 
-    <div class="section">
+    <div class="legal-section">
         <h2>4. Acceptable Use</h2>
         <p>You agree to use TobyBot only for lawful purposes and in a way that does not infringe the rights of others. You must not use TobyBot to:</p>
         <ul>
@@ -96,7 +42,7 @@
         </ul>
     </div>
 
-    <div class="section">
+    <div class="legal-section">
         <h2>5. Premium Features &amp; Payments</h2>
         <p>Certain features of TobyBot may be offered under a paid tier. Where applicable:</p>
         <ul>
@@ -107,46 +53,44 @@
         </ul>
     </div>
 
-    <div class="section">
+    <div class="legal-section">
         <h2>6. Data &amp; Privacy</h2>
         <p>TobyBot stores the minimum data necessary to provide its features, including Discord user IDs, guild IDs, and user-uploaded audio files for intro songs. We do not sell your data to third parties. Audio files you upload may be deleted upon request or when you remove your intro configuration.</p>
         <p>By using this service you consent to this data being stored and processed as described.</p>
     </div>
 
-    <div class="section">
+    <div class="legal-section">
         <h2>7. Intellectual Property</h2>
         <p>All code, design, and content associated with TobyBot remain the intellectual property of the TobyBot developers. You retain ownership of any content you upload (such as audio files), but grant us a limited licence to store and serve that content as part of the service.</p>
     </div>
 
-    <div class="section">
+    <div class="legal-section">
         <h2>8. Disclaimers</h2>
         <p>TobyBot is provided "as is" without warranties of any kind, either express or implied. We do not guarantee uninterrupted availability, and the service may be subject to outages or maintenance periods.</p>
     </div>
 
-    <div class="section">
+    <div class="legal-section">
         <h2>9. Limitation of Liability</h2>
         <p>To the fullest extent permitted by law, the TobyBot developers shall not be liable for any indirect, incidental, or consequential damages arising from your use of the service, including but not limited to loss of data or server disruption.</p>
     </div>
 
-    <div class="section">
+    <div class="legal-section">
         <h2>10. Termination</h2>
         <p>We reserve the right to restrict or terminate access to TobyBot at our discretion, including in cases of abuse or violation of these terms. You may stop using the service at any time by removing the bot from your server.</p>
     </div>
 
-    <div class="section">
+    <div class="legal-section">
         <h2>11. Changes to These Terms</h2>
         <p>We may update these Terms of Service from time to time. Continued use of TobyBot after changes are posted constitutes acceptance of the revised terms. We will update the "Last updated" date at the top of this page when changes are made.</p>
     </div>
 
-    <div class="section">
+    <div class="legal-section">
         <h2>12. Contact</h2>
-        <p>If you have any questions about these terms, please open an issue on the <a href="https://github.com/ml404/toby-bot" style="color:#7289fa;">GitHub repository</a> or reach out via Discord.</p>
+        <p>If you have any questions about these terms, please open an issue on the <a href="https://github.com/ml404/toby-bot">GitHub repository</a> or reach out via Discord.</p>
     </div>
 </div>
 
-<footer>
-    <p>&copy; 2026 TobyBot &mdash; <a href="/terms">Terms of Service</a> &mdash; <a href="/privacy">Privacy Policy</a></p>
-</footer>
+<footer th:replace="~{fragments/footer :: footer}"></footer>
 
 <script th:src="@{/js/home.js}"></script>
 </body>


### PR DESCRIPTION
## Summary

Follow-up to #424. The public site had been growing feature-by-feature and the homepage had fallen behind: still pitched the bot in terms of music + D&D + market + titles + leaderboards from before the casino, jackpot, daily lottery, blackjack, anti-autoclicker, and moderation web-UI work landed. The site doubles as a portfolio piece, so this PR rewrites the public marketing surface for both purposes.

## What changed

**Homepage rewrite** (`templates/home.html`): five themed sections (Casino & Coin → Engagement → Server Management → Tabletop & Tools → Final CTA) replace the flat 11-card + 6-stacked-CTA stack. Drops two placeholder cards ("Miscellaneous", "Fetch") and the dead-link DnD card; surfaces every shipped feature including the 12 games, jackpot pool, daily lottery, anti-autoclicker, and the new moderation web UI. Inline `<style>` block lifted to `static/css/home.css`.

**Live-stats strip**: three numbers below the hero — `N servers · M commands · 12 games`. New `HomeStatsService` reads `jda.guildCache.size()` (matching the pattern in `TobyCoinPriceTickJob.kt:48`), sums `commandManager.{music,dnd,moderation,economy,misc,fetch}Commands.size`, and hardcodes the game count. Memoised 60s in-process via an `AtomicReference<Cached>` to avoid Spring Cache boilerplate that wasn't otherwise pulled into the web module.

**Changelog page** (`/changelog`): hand-curated highlights timeline. `ChangelogController.ENTRIES` seeds the recent shipped showpieces (this PR's predecessor #424, jackpot RTP gate #422, anti-autoclicker #420, daily lottery #412, Roulette #404, Blackjack tables, Poker tables, TOBY market, web moderation). Linked from the new footer + a small `What's new →` link below the homepage hero.

**Shared footer fragment** (`templates/fragments/footer.html`): copyright + Terms/Privacy/Changelog links, GitHub link, and a "Built with Spring Boot · Kotlin · Thymeleaf · Postgres · JDA · Lavalink" tech-stack strip. Reused across home, commands, login, terms, privacy, and changelog so the marketing surface finally feels cohesive instead of copy-pasted.

**SEO / link previews**: extended `head` fragment with a new `headSeo(pageTitle, pageDescription, ogImage, extraCss)` 4-arg signature so each public page can set its own description + OG/Twitter card. JSON-LD `SoftwareApplication` block on the homepage. New `static/sitemap.xml` and `static/robots.txt`. `WebSecurityConfig` updated with `/changelog`, `/sitemap.xml`, `/robots.txt` permitAll matchers.

**CSS housekeeping**: `.back-link` (previously defined identically in `moderation.css`, `profile.css`, `economy.css`, and `casinoholdem.css`) consolidated into `base.css`. `.empty-hero` (defined only in `intros.css` but used across casino/leaderboard/duel pages) also moved up. Inline `<style>` blocks on `terms.html` / `privacy.html` extracted to a shared `legal.css`; commands page styles to `commands.css`; login page styles appended to `home.css`.

## Test plan

- [x] `./gradlew :web:test` — passes (existing `ModerationTemplateRowsTest` from the prior PR still passes).
- [ ] `./gradlew :application:test --tests integration.web.PageRenderSmokeIT` — `/`, `/changelog`, `/commands/wiki`, `/login`, `/terms`, `/privacy` all return non-5xx (could not run locally; `:application` deps blocked in sandbox, will run on CI).
- [ ] Run app locally and visit `/`. Verify themed sections render, live-stats strip shows real numbers, no placeholder cards, no dead-link DnD card, footer shared with the rest.
- [ ] Visit `/changelog` — entries render as timeline; `/commands/wiki`, `/login`, `/terms`, `/privacy` — confirm shared footer appears.
- [ ] View-source the homepage — `<script type="application/ld+json">` SoftwareApplication block present; head has `og:*` and `twitter:*` meta. Run through Google's Rich Results Test or LinkedIn Post Inspector to confirm validity.
- [ ] `curl http://localhost:8080/sitemap.xml` and `/robots.txt` — both 200, sitemap lists the public routes.
- [ ] Visual sanity: scroll homepage on desktop + a 360px-wide mobile viewport. Sections collapse cleanly, stats strip wraps, tech-stack strip stays readable.

https://claude.ai/code/session_01GAVMLpP2CsESghD66LXmhV

---
_Generated by [Claude Code](https://claude.ai/code/session_01GAVMLpP2CsESghD66LXmhV)_