### PR TITLE
feat(changelog): auto-append entries from merged PRs (with richer labeller)

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -41,3 +41,67 @@ Tests:
  - database/src/test/kotlin/**
  - discord-bot/src/test/kotlin/**
  - web/src/test/kotlin/**
+
+# ======================================================================
+# Feature-area labels — drive the emoji on the auto-appended changelog
+# entry (see .github/workflows/changelog.yml). A PR can pick up several;
+# the changelog action walks them in priority order and uses the first
+# match. Path globs match files anywhere in the PR's diff, so a PR
+# touching e.g. a Blackjack service + a moderation template gets both
+# labels and the priority list decides the emoji.
+# ======================================================================
+
+casino:
+ - 'discord-bot/src/main/kotlin/bot/toby/command/commands/casino/**'
+ - 'database/src/main/kotlin/database/service/{Slots,Coinflip,Dice,Highlow,Scratch,Keno,Roulette,Baccarat,CasinoHoldem}*'
+ - 'web/src/main/kotlin/web/controller/Casino*'
+ - 'web/src/main/kotlin/web/service/Casino*'
+ - 'web/src/main/resources/templates/{slots,coinflip,dice,highlow,scratch,keno,roulette,baccarat,casino-*,casinoholdem-*}.html'
+ - 'web/src/main/resources/static/{js,css}/{slots,coinflip,dice,highlow,scratch,keno,roulette,baccarat,casino*,casinoholdem*}.*'
+
+jackpot:
+ - '**/*Jackpot*'
+
+lottery:
+ - '**/*Lottery*'
+ - 'web/src/main/resources/templates/lottery*.html'
+ - 'web/src/main/resources/static/{js,css}/lottery*.*'
+
+poker:
+ - '**/*Poker*'
+ - 'web/src/main/resources/templates/poker-*.html'
+ - 'web/src/main/resources/static/{js,css}/poker*.*'
+
+blackjack:
+ - '**/*Blackjack*'
+ - 'web/src/main/resources/templates/blackjack-*.html'
+ - 'web/src/main/resources/static/{js,css}/blackjack*.*'
+
+moderation:
+ - 'discord-bot/src/main/kotlin/bot/toby/command/commands/moderation/**'
+ - 'web/src/main/kotlin/web/controller/Moderation*'
+ - 'web/src/main/kotlin/web/service/Moderation*'
+ - 'web/src/main/resources/templates/moderation/**'
+ - 'web/src/main/resources/templates/moderation*.html'
+ - 'web/src/main/resources/static/js/moderation/**'
+ - 'web/src/main/resources/static/{js,css}/moderation*.*'
+
+economy:
+ - 'discord-bot/src/main/kotlin/bot/toby/command/commands/economy/**'
+ - 'web/src/main/kotlin/web/controller/{Economy,Title,Tip,Duel}*'
+ - 'web/src/main/kotlin/web/service/{Economy,Title,Tip,Duel}*'
+ - 'web/src/main/resources/templates/{economy,titles,tip,duel}*.html'
+ - 'web/src/main/resources/static/{js,css}/{economy,titles,tip,duel}*.*'
+
+music:
+ - 'discord-bot/src/main/kotlin/bot/toby/command/commands/music/**'
+ - 'discord-bot/src/main/kotlin/bot/toby/lavaplayer/**'
+ - 'web/src/main/kotlin/web/controller/Intro*'
+ - 'web/src/main/kotlin/web/service/Intro*'
+ - 'web/src/main/resources/templates/intros.html'
+ - 'web/src/main/resources/static/{js,css}/intros*.*'
+
+dnd:
+ - 'discord-bot/src/main/kotlin/bot/toby/command/commands/dnd/**'
+ - 'web/src/main/kotlin/web/controller/{Dnd,Campaign}*'
+ - 'web/src/main/resources/templates/campaign*.html'

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,172 @@
+name: Changelog
+
+# Auto-prepend a new entry to web/src/main/resources/changelog.json when a
+# user-facing PR merges into main. Skips PRs labelled `chore`, `docs`,
+# `ci`, `build`, `style`, `dependencies`, or `skip-changelog` — the
+# label workflow auto-applies the conventional-commit prefix label, so
+# `chore: bump deps` (or a Dependabot PR) gets `chore` and silently
+# falls through here.
+#
+# The emoji is picked from the PR's feature labels (casino, jackpot,
+# lottery, etc. — see .github/labeler.yml) using a priority list. PRs
+# touching multiple feature areas pick the first match. PRs with no
+# feature label fall back to a type-based emoji (✨ feat, 🔨 fix,
+# 🧹 refactor, ⚡ perf) or a plain ✨ default.
+#
+# Pushes the change directly to main with `[skip ci]` so we don't
+# retrigger the gradle build for a docs-only commit.
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  changelog:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          # We need history so the push back to main doesn't fail with
+          # "shallow clone" weirdness on conflicting force-push attempts.
+          fetch-depth: 0
+          # Use the default GITHUB_TOKEN for the push. It can write to
+          # the repo but the resulting push doesn't trigger downstream
+          # workflow runs — exactly what we want for a changelog commit.
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Decide whether to append
+        id: gate
+        uses: actions/github-script@v7
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        with:
+          script: |
+            const labels = (context.payload.pull_request.labels || []).map(l => l.name);
+            const SKIP = ['chore', 'docs', 'ci', 'build', 'style', 'dependencies', 'skip-changelog'];
+            const skipLabel = labels.find(l => SKIP.includes(l));
+            if (skipLabel) {
+              core.info(`Skipping: PR has '${skipLabel}' label.`);
+              core.setOutput('skip', 'true');
+              return;
+            }
+
+            // Feature-label priority — first match wins. Curated rather
+            // than alphabetical so cross-cutting PRs (e.g. moderation
+            // touching jackpot configs) pick the more specific emoji.
+            const FEATURE_EMOJI = [
+              ['jackpot',    '🎰'],
+              ['lottery',    '🎟️'],
+              ['poker',      '♠️'],
+              ['blackjack',  '♠️'],
+              ['casino',     '🎲'],
+              ['moderation', '🛡️'],
+              ['economy',    '💰'],
+              ['music',      '🎵'],
+              ['dnd',        '🐉'],
+            ];
+            const TYPE_EMOJI = {
+              feat:     '✨',
+              fix:      '🔨',
+              refactor: '🧹',
+              perf:     '⚡',
+            };
+
+            const featureMatch = FEATURE_EMOJI.find(([label]) => labels.includes(label));
+            let emoji = featureMatch ? featureMatch[1] : null;
+            if (!emoji) {
+              const typeLabel = Object.keys(TYPE_EMOJI).find(t => labels.includes(t));
+              emoji = typeLabel ? TYPE_EMOJI[typeLabel] : '✨';
+            }
+
+            // Strip conventional-commit prefix from the headline.
+            // "feat(casino): roulette refresh" → "Roulette refresh".
+            // Casing: capitalise the first letter so the headline reads
+            // like a sentence regardless of how the PR author wrote it.
+            const rawTitle = process.env.PR_TITLE || '';
+            const stripped = rawTitle.replace(/^(feat|fix|chore|docs|style|refactor|perf|test|build|ci|deps|dependencies)(\([^)]*\))?!?:\s*/i, '');
+            const title = stripped.length > 0
+              ? stripped.charAt(0).toUpperCase() + stripped.slice(1)
+              : rawTitle;
+
+            // Summary: prefer the "## Summary" section of the PR body
+            // (we have a PR template that puts it there), else first
+            // non-empty paragraph. Cap at 480 chars to keep one entry
+            // visually balanced against the others.
+            const body = (process.env.PR_BODY || '').replace(/\r/g, '');
+            let summary = '';
+            const summaryMatch = body.match(/##\s+Summary\s*\n+([\s\S]+?)(\n##\s+|\n---|$)/i);
+            if (summaryMatch) {
+              summary = summaryMatch[1].trim();
+            } else {
+              const firstPara = body.split(/\n\s*\n/).find(p => p.trim().length > 0);
+              summary = (firstPara || '').trim();
+            }
+            // Strip bullet markers + the auto-appended Claude session
+            // link so it doesn't bleed into a public-facing entry.
+            summary = summary
+              .split('\n')
+              .map(line => line.replace(/^\s*[-*]\s+/, ''))
+              .filter(line => !/^https?:\/\/claude\.ai\//i.test(line.trim()))
+              .join(' ')
+              .replace(/\s+/g, ' ')
+              .trim();
+            if (summary.length > 480) summary = summary.slice(0, 477).trimEnd() + '…';
+            if (!summary) summary = title;
+
+            // Date: human-readable "Month YYYY" matching the existing
+            // seed entries.
+            const now = new Date();
+            const date = now.toLocaleString('en-GB', { month: 'long', year: 'numeric' });
+
+            const entry = {
+              date,
+              title,
+              summary,
+              emoji,
+              prNumber: parseInt(process.env.PR_NUMBER, 10),
+            };
+            core.setOutput('skip', 'false');
+            core.setOutput('entry', JSON.stringify(entry));
+            core.info(`Will prepend entry: ${JSON.stringify(entry)}`);
+
+      - name: Prepend entry to changelog.json
+        if: steps.gate.outputs.skip == 'false'
+        env:
+          ENTRY: ${{ steps.gate.outputs.entry }}
+        run: |
+          set -euo pipefail
+          FILE="web/src/main/resources/changelog.json"
+          # Idempotency: if an entry for this PR is already at the top
+          # (re-run of the workflow on the same merged PR), skip.
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          if jq -e --argjson n "$PR_NUMBER" '.[0].prNumber == $n' "$FILE" >/dev/null; then
+            echo "Entry for PR #$PR_NUMBER already at top; nothing to do."
+            exit 0
+          fi
+          tmp=$(mktemp)
+          jq --argjson entry "$ENTRY" '[$entry] + .' "$FILE" > "$tmp"
+          mv "$tmp" "$FILE"
+          echo "Prepended entry for PR #$PR_NUMBER."
+
+      - name: Commit and push
+        if: steps.gate.outputs.skip == 'false'
+        run: |
+          set -euo pipefail
+          if git diff --quiet web/src/main/resources/changelog.json; then
+            echo "No changes to commit (idempotent re-run)."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add web/src/main/resources/changelog.json
+          git commit -m "chore(changelog): add entry for #${{ github.event.pull_request.number }} [skip ci]"
+          git push origin main

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -10,6 +10,34 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      # Path-based labels (.github/labeler.yml) — area + feature labels.
       - uses: actions/labeler@v4
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      # Conventional-commit prefix → type label. Adds a single label
+      # matching the PR title prefix (chore, fix, feat, etc.) so the
+      # changelog workflow can skip non-user-facing PRs without us
+      # remembering to label them by hand. `dependabot` and `deps:`
+      # PRs both fold into the `dependencies` label so the skip rule
+      # is one entry instead of two.
+      - name: Apply title-prefix label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = context.payload.pull_request.title || '';
+            const match = title.match(/^(feat|fix|chore|docs|style|refactor|perf|test|build|ci|deps|dependencies)(\([^)]*\))?!?:/i);
+            if (!match) {
+              core.info(`PR title "${title}" has no conventional-commit prefix; skipping type label.`);
+              return;
+            }
+            let label = match[1].toLowerCase();
+            if (label === 'deps') label = 'dependencies';
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              labels: [label],
+            });
+            core.info(`Applied label: ${label}`);

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -11,6 +11,65 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Ensure every label referenced by labeler.yml + the type-prefix
+      # step + the changelog skip rules actually exists in the repo.
+      # `actions/labeler@v4` only *applies* labels — it doesn't create
+      # them — so a brand-new label rule is silently a no-op until the
+      # label exists. `gh label create --force` is idempotent (creates
+      # if missing, updates colour/description if present), runs in
+      # ~30 API calls per PR, and means a new entry in labeler.yml
+      # only needs to land in this list to start working.
+      - name: Bootstrap labels
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          sync() {
+            local name="$1" color="$2" desc="$3"
+            gh label create "$name" --color "$color" --description "$desc" --force
+          }
+
+          # Type labels (conventional-commit prefixes). The changelog
+          # workflow skips PRs carrying chore/docs/ci/build/style/dependencies.
+          sync feat         0e8a16 "User-facing feature work"
+          sync fix          d73a4a "User-facing bug fix"
+          sync refactor     7057ff "Internal refactor (may still be user-facing)"
+          sync perf         ff9f1c "Performance improvement"
+          sync chore        cccccc "Internal upkeep — skipped from changelog"
+          sync docs         0075ca "Documentation only — skipped from changelog"
+          sync style        c5def5 "Cosmetic / formatting only — skipped from changelog"
+          sync test         bfdadc "Test-only change"
+          sync build        5319e7 "Build / packaging change — skipped from changelog"
+          sync ci           1d76db "CI / Actions change — skipped from changelog"
+          sync dependencies 0366d6 "Dependency bump — skipped from changelog"
+          sync skip-changelog cccccc "Manually opt this PR out of the changelog"
+
+          # Feature labels (path-based, drive the changelog emoji).
+          sync casino       e99695 "Quick-play casino minigames"
+          sync jackpot      fbca04 "Jackpot pool tuning + payout"
+          sync lottery      f9d0c4 "Daily lottery draw"
+          sync poker        24292e "Multiplayer poker tables"
+          sync blackjack    1a1a1a "Blackjack tables (solo + multi)"
+          sync moderation   5319e7 "Server moderation web UI + commands"
+          sync economy      006b75 "TOBY market, titles, tip, duel"
+          sync music        bfd4f2 "Music playback + intro songs"
+          sync dnd          8a4baf "D&D campaign + dice tools"
+
+          # Layer labels (existing — colour-synced for consistency).
+          sync Documentation 0075ca "Markdown / docs files"
+          sync Config        c2e0c6 "Build config (gradle, properties)"
+          sync Bot           bfdadc "discord-bot module"
+          sync Buttons       c5def5 "Discord button handlers"
+          sync Commands      e4e669 "Slash command implementations"
+          sync Common        cccccc "common module"
+          sync Core-api      f9d0c4 "core-api module"
+          sync Database      d4c5f9 "database module"
+          sync Helpers       bfdadc "Bot helper utilities"
+          sync Lavaplayer    c2e0c6 "Audio / Lavaplayer integration"
+          sync Managers      ededed "Bot manager classes"
+          sync web           0e8a16 "web module"
+          sync Tests         1d76db "Test code"
+
       # Path-based labels (.github/labeler.yml) — area + feature labels.
       - uses: actions/labeler@v4
         with:

--- a/application/src/test/kotlin/web/controller/ChangelogControllerTest.kt
+++ b/application/src/test/kotlin/web/controller/ChangelogControllerTest.kt
@@ -1,13 +1,12 @@
 package web.controller
 
+import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.slot
 import io.mockk.verify
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -16,7 +15,14 @@ import org.springframework.ui.Model
 
 class ChangelogControllerTest {
 
-    private val objectMapper: ObjectMapper = jacksonObjectMapper()
+    // Plain Jackson ObjectMapper — no jackson-module-kotlin import. The
+    // kotlin module is on the runtime classpath (Spring Boot
+    // auto-registers it on the wired-in ObjectMapper) but not on the
+    // :application module's *test compile* classpath. ChangelogEntry's
+    // data class has defaults on every field so the synthetic no-arg
+    // constructor is enough for Jackson to deserialize without the
+    // kotlin module.
+    private val objectMapper: ObjectMapper = ObjectMapper()
 
     private lateinit var controller: ChangelogController
     private lateinit var model: Model
@@ -36,19 +42,9 @@ class ChangelogControllerTest {
 
     @Test
     fun `changelog adds the loaded entries onto the model`() {
-        val captured = slot<List<ChangelogController.ChangelogEntry>>()
-        every { model.addAttribute("entries", capture(captured)) } returns model
-
         controller.changelog(null, model)
 
         verify { model.addAttribute("entries", any<List<ChangelogController.ChangelogEntry>>()) }
-        assertFalse(captured.captured.isEmpty(), "changelog.json should seed at least one entry")
-        // Spot-check shape so a future schema drift surfaces here, not at
-        // template-render time.
-        val first = captured.captured.first()
-        assertTrue(first.date.isNotBlank(), "first entry should have a date")
-        assertTrue(first.title.isNotBlank(), "first entry should have a title")
-        assertTrue(first.summary.isNotBlank(), "first entry should have a summary")
     }
 
     @Test
@@ -58,8 +54,25 @@ class ChangelogControllerTest {
         // shipping unnoticed.
         assertTrue(
             controller.entryCount() > 0,
-            "ChangelogController should load entries from $RESOURCE on the classpath"
+            "ChangelogController should load entries from ${ChangelogController.CHANGELOG_RESOURCE} on the classpath"
         )
+    }
+
+    @Test
+    fun `changelog json entries have valid shape`() {
+        // Read the resource directly (independent of the controller) so a
+        // future schema drift surfaces here, not at template-render time.
+        val url = javaClass.classLoader.getResource(ChangelogController.CHANGELOG_RESOURCE)
+        assertNotNull(url, "${ChangelogController.CHANGELOG_RESOURCE} must be on the test classpath")
+        val entries: List<ChangelogController.ChangelogEntry> = objectMapper.readValue(
+            url!!.openStream(),
+            object : TypeReference<List<ChangelogController.ChangelogEntry>>() {}
+        )
+        assertTrue(entries.isNotEmpty(), "changelog.json should seed at least one entry")
+        val first = entries.first()
+        assertTrue(first.date.isNotBlank(), "first entry should have a date")
+        assertTrue(first.title.isNotBlank(), "first entry should have a title")
+        assertTrue(first.summary.isNotBlank(), "first entry should have a summary")
     }
 
     @Test
@@ -77,9 +90,5 @@ class ChangelogControllerTest {
         controller.changelog(user, model)
 
         verify { model.addAttribute("username", "TestUser") }
-    }
-
-    companion object {
-        private const val RESOURCE = ChangelogController.CHANGELOG_RESOURCE
     }
 }

--- a/application/src/test/kotlin/web/controller/ChangelogControllerTest.kt
+++ b/application/src/test/kotlin/web/controller/ChangelogControllerTest.kt
@@ -1,10 +1,14 @@
 package web.controller
 
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
 import io.mockk.verify
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.security.oauth2.core.user.OAuth2User
@@ -12,12 +16,14 @@ import org.springframework.ui.Model
 
 class ChangelogControllerTest {
 
+    private val objectMapper: ObjectMapper = jacksonObjectMapper()
+
     private lateinit var controller: ChangelogController
     private lateinit var model: Model
 
     @BeforeEach
     fun setup() {
-        controller = ChangelogController()
+        controller = ChangelogController(objectMapper)
         model = mockk(relaxed = true)
     }
 
@@ -29,19 +35,30 @@ class ChangelogControllerTest {
     }
 
     @Test
-    fun `changelog seeds entries on the model`() {
+    fun `changelog adds the loaded entries onto the model`() {
+        val captured = slot<List<ChangelogController.ChangelogEntry>>()
+        every { model.addAttribute("entries", capture(captured)) } returns model
+
         controller.changelog(null, model)
 
-        verify { model.addAttribute("entries", ChangelogController.ENTRIES) }
+        verify { model.addAttribute("entries", any<List<ChangelogController.ChangelogEntry>>()) }
+        assertFalse(captured.captured.isEmpty(), "changelog.json should seed at least one entry")
+        // Spot-check shape so a future schema drift surfaces here, not at
+        // template-render time.
+        val first = captured.captured.first()
+        assertTrue(first.date.isNotBlank(), "first entry should have a date")
+        assertTrue(first.title.isNotBlank(), "first entry should have a title")
+        assertTrue(first.summary.isNotBlank(), "first entry should have a summary")
     }
 
     @Test
-    fun `changelog has at least one entry seeded`() {
-        // Sanity check: the controller would compile with an empty list,
-        // so guard against a future regression that empties the seed.
-        assertFalse(
-            ChangelogController.ENTRIES.isEmpty(),
-            "ChangelogController.ENTRIES must contain at least one curated entry"
+    fun `controller loads at least one entry from the classpath JSON`() {
+        // Sanity check: if changelog.json is missing or malformed the
+        // controller falls back to empty silently — guard against that
+        // shipping unnoticed.
+        assertTrue(
+            controller.entryCount() > 0,
+            "ChangelogController should load entries from $RESOURCE on the classpath"
         )
     }
 
@@ -49,8 +66,6 @@ class ChangelogControllerTest {
     fun `changelog skips username when user is not authenticated`() {
         controller.changelog(null, model)
 
-        // The view is public, so anon visitors see only the entries.
-        // The navbar fragment handles the null-username case.
         verify(exactly = 0) { model.addAttribute("username", any()) }
     }
 
@@ -62,5 +77,9 @@ class ChangelogControllerTest {
         controller.changelog(user, model)
 
         verify { model.addAttribute("username", "TestUser") }
+    }
+
+    companion object {
+        private const val RESOURCE = ChangelogController.CHANGELOG_RESOURCE
     }
 }

--- a/web/src/main/kotlin/web/controller/ChangelogController.kt
+++ b/web/src/main/kotlin/web/controller/ChangelogController.kt
@@ -1,5 +1,9 @@
 package web.controller
 
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import org.slf4j.LoggerFactory
+import org.springframework.core.io.ClassPathResource
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.security.oauth2.core.user.OAuth2User
 import org.springframework.stereotype.Controller
@@ -8,138 +12,77 @@ import org.springframework.web.bind.annotation.GetMapping
 import web.util.displayName
 
 /**
- * Public changelog page. Hand-curated highlights — kept here as a static
- * list rather than scraped from `git log` because the curated framing
- * ("here's what's worth knowing") is the point. New entries go at the
- * top of [ENTRIES]. Older entries can stay until they fall off the
- * bottom or be pruned in batches; the goal isn't a full history (git
- * already has that), it's a pitch surface that shows the project is
- * alive.
+ * Public changelog page. Entries live in `resources/changelog.json` so a
+ * GitHub Action (`.github/workflows/changelog.yml`) can prepend a new
+ * entry on every merged PR without touching Kotlin. The Action picks
+ * the emoji from the PR's feature labels (casino → 🎰, moderation →
+ * 🛡️, etc.) and skips PRs labelled `chore`, `docs`, `ci`, `build`,
+ * `style`, `dependencies`, or `skip-changelog`.
  *
- * Public (no auth) so recruiters and prospective installers can scan
- * the recent activity without signing in. Endpoint matches the route
- * permitAll-listed in [web.configuration.WebSecurityConfig].
+ * The list is loaded once at controller construction. If the JSON is
+ * missing or malformed the page renders empty rather than 500-ing —
+ * losing a changelog entry is annoying but not page-fatal.
+ *
+ * Public endpoint (no auth) so recruiters and prospective installers
+ * can scan recent activity without signing in. Route is permitAll-listed
+ * in [web.configuration.WebSecurityConfig].
  */
 @Controller
-class ChangelogController {
+class ChangelogController(
+    objectMapper: ObjectMapper,
+) {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    private val entries: List<ChangelogEntry> = loadEntries(objectMapper)
 
     @GetMapping("/changelog")
     fun changelog(
         @AuthenticationPrincipal user: OAuth2User?,
         model: Model,
     ): String {
-        model.addAttribute("entries", ENTRIES)
+        model.addAttribute("entries", entries)
         if (user != null) model.addAttribute("username", user.displayName())
         return "changelog"
+    }
+
+    private fun loadEntries(objectMapper: ObjectMapper): List<ChangelogEntry> {
+        val resource = ClassPathResource(CHANGELOG_RESOURCE)
+        if (!resource.exists()) {
+            log.warn("changelog.json not found on classpath; serving empty changelog page")
+            return emptyList()
+        }
+        return runCatching {
+            resource.inputStream.use { stream ->
+                objectMapper.readValue<List<ChangelogEntry>>(stream)
+            }
+        }.onFailure { e ->
+            log.error("Failed to parse changelog.json; serving empty changelog page", e)
+        }.getOrDefault(emptyList())
     }
 
     /**
      * One row in the changelog timeline.
      *
      * @param date  human-readable, e.g. "May 2026". Sort order is the
-     *              position in the [ENTRIES] list — newest first.
+     *              position in the JSON array — newest first.
      * @param title short headline.
      * @param summary 1–2 sentences. Plain text, no markdown.
      * @param emoji optional leading glyph; null hides the icon column.
      * @param prNumber optional GitHub PR number; renders as a small link.
      */
     data class ChangelogEntry(
-        val date: String,
-        val title: String,
-        val summary: String,
+        val date: String = "",
+        val title: String = "",
+        val summary: String = "",
         val emoji: String? = null,
         val prNumber: Int? = null,
     )
 
+    /** Number of entries currently loaded. Exposed for tests. */
+    fun entryCount(): Int = entries.size
+
     companion object {
-        private const val REPO_URL = "https://github.com/ml404/toby-bot"
-
-        // Newest first. Cap to ~15 entries; older highlights can be
-        // pruned when they roll off the bottom.
-        val ENTRIES: List<ChangelogEntry> = listOf(
-            ChangelogEntry(
-                date = "May 2026",
-                title = "Moderation page split + searchable settings",
-                summary = "The single moderation page became six focused sub-pages " +
-                    "(Users, Settings, Voice, Poll, Casino, Lottery). The Settings " +
-                    "page got a sticky search box and a dedicated Jackpot section " +
-                    "exposing five eligibility/payout configs that were previously " +
-                    "backend-only. A new CI guard fails the build if a future config " +
-                    "key is added without a UI row.",
-                emoji = "🧹",
-                prNumber = 424,
-            ),
-            ChangelogEntry(
-                date = "May 2026",
-                title = "Jackpot RTP eligibility gate",
-                summary = "High-RTP games (blackjack, coinflip, baccarat, roulette) " +
-                    "can now be excluded from jackpot rolls via a configurable RTP " +
-                    "ceiling, so they don't double-dip on a sweetener they don't need.",
-                emoji = "🎰",
-                prNumber = 422,
-            ),
-            ChangelogEntry(
-                date = "May 2026",
-                title = "Anti-autoclicker channel logs",
-                summary = "Suspected-bot session embeds now post to a configurable " +
-                    "Discord channel and update in place as forced-loss substitutions " +
-                    "accumulate over the session.",
-                emoji = "🔍",
-                prNumber = 420,
-            ),
-            ChangelogEntry(
-                date = "April 2026",
-                title = "Daily lottery (Pick 5 of 49 + weighted mode)",
-                summary = "Auto-runs at 00:00 UTC: closes the prior draw, pays " +
-                    "tier-based prizes, opens a fresh one seeded from the jackpot " +
-                    "pool. NUMBER_MATCH for high-engagement servers, WEIGHTED for " +
-                    "low-traffic ones; configurable per guild from the moderation " +
-                    "Lottery sub-page.",
-                emoji = "🎟️",
-                prNumber = 412,
-            ),
-            ChangelogEntry(
-                date = "April 2026",
-                title = "Casino refresh: Roulette + Casino Hold'em",
-                summary = "Two new minigames join the quick-play roster, both " +
-                    "wired into the per-guild jackpot pool with the same loss-tribute " +
-                    "and stake-anchor rules as the rest.",
-                emoji = "🎲",
-                prNumber = 404,
-            ),
-            ChangelogEntry(
-                date = "April 2026",
-                title = "Multiplayer Blackjack tables",
-                summary = "Up to 7 seats per multi-table, configurable shot clock, " +
-                    "S17/H17 dealer rule, and 3:2 / 6:5 payout toggle. Solo blackjack " +
-                    "shares the same stake bounds.",
-                emoji = "♠️",
-            ),
-            ChangelogEntry(
-                date = "March 2026",
-                title = "Poker tables (fixed-limit Hold'em)",
-                summary = "2–9 seats, configurable blinds and bet structure, " +
-                    "per-actor shot clock with auto-fold, and rake routed to the " +
-                    "jackpot pool.",
-                emoji = "♠️",
-            ),
-            ChangelogEntry(
-                date = "March 2026",
-                title = "TOBY coin live market",
-                summary = "Per-server live market with a 5-minute price tick. Earn " +
-                    "social credit by being active, then trade it for TOBY coin.",
-                emoji = "💰",
-            ),
-            ChangelogEntry(
-                date = "February 2026",
-                title = "Web moderation admin",
-                summary = "Browser-based moderation: toggle user permissions, " +
-                    "adjust social credit, mute or move voice channels, post polls — " +
-                    "no slash commands needed.",
-                emoji = "🛡️",
-            ),
-        )
-
-        fun repoUrl(): String = REPO_URL
+        const val CHANGELOG_RESOURCE = "changelog.json"
     }
 }

--- a/web/src/main/resources/changelog.json
+++ b/web/src/main/resources/changelog.json
@@ -1,0 +1,61 @@
+[
+  {
+    "date": "May 2026",
+    "title": "Moderation page split + searchable settings",
+    "summary": "The single moderation page became six focused sub-pages (Users, Settings, Voice, Poll, Casino, Lottery). The Settings page got a sticky search box and a dedicated Jackpot section exposing five eligibility/payout configs that were previously backend-only. A new CI guard fails the build if a future config key is added without a UI row.",
+    "emoji": "🧹",
+    "prNumber": 424
+  },
+  {
+    "date": "May 2026",
+    "title": "Jackpot RTP eligibility gate",
+    "summary": "High-RTP games (blackjack, coinflip, baccarat, roulette) can now be excluded from jackpot rolls via a configurable RTP ceiling, so they don't double-dip on a sweetener they don't need.",
+    "emoji": "🎰",
+    "prNumber": 422
+  },
+  {
+    "date": "May 2026",
+    "title": "Anti-autoclicker channel logs",
+    "summary": "Suspected-bot session embeds now post to a configurable Discord channel and update in place as forced-loss substitutions accumulate over the session.",
+    "emoji": "🔍",
+    "prNumber": 420
+  },
+  {
+    "date": "April 2026",
+    "title": "Daily lottery (Pick 5 of 49 + weighted mode)",
+    "summary": "Auto-runs at 00:00 UTC: closes the prior draw, pays tier-based prizes, opens a fresh one seeded from the jackpot pool. NUMBER_MATCH for high-engagement servers, WEIGHTED for low-traffic ones; configurable per guild from the moderation Lottery sub-page.",
+    "emoji": "🎟️",
+    "prNumber": 412
+  },
+  {
+    "date": "April 2026",
+    "title": "Casino refresh: Roulette + Casino Hold'em",
+    "summary": "Two new minigames join the quick-play roster, both wired into the per-guild jackpot pool with the same loss-tribute and stake-anchor rules as the rest.",
+    "emoji": "🎲",
+    "prNumber": 404
+  },
+  {
+    "date": "April 2026",
+    "title": "Multiplayer Blackjack tables",
+    "summary": "Up to 7 seats per multi-table, configurable shot clock, S17/H17 dealer rule, and 3:2 / 6:5 payout toggle. Solo blackjack shares the same stake bounds.",
+    "emoji": "♠️"
+  },
+  {
+    "date": "March 2026",
+    "title": "Poker tables (fixed-limit Hold'em)",
+    "summary": "2-9 seats, configurable blinds and bet structure, per-actor shot clock with auto-fold, and rake routed to the jackpot pool.",
+    "emoji": "♠️"
+  },
+  {
+    "date": "March 2026",
+    "title": "TOBY coin live market",
+    "summary": "Per-server live market with a 5-minute price tick. Earn social credit by being active, then trade it for TOBY coin.",
+    "emoji": "💰"
+  },
+  {
+    "date": "February 2026",
+    "title": "Web moderation admin",
+    "summary": "Browser-based moderation: toggle user permissions, adjust social credit, mute or move voice channels, post polls — no slash commands needed.",
+    "emoji": "🛡️"
+  }
+]


### PR DESCRIPTION
## Summary

Follow-up to #425. The changelog page added there had its entries hardcoded as a `List<ChangelogEntry>` constant inside `ChangelogController.kt`, so adding one meant editing Kotlin and shipping a release. This wires it into the labeller workflow that already runs on every PR.

## What changed

**Storage move**: seed list lifted out of the controller into `web/src/main/resources/changelog.json`. Controller reads it once at startup via the Spring-injected `ObjectMapper`; if the file is missing or malformed it logs + serves an empty page rather than 500-ing.

**Labeller enrichment** (`.github/labeler.yml`): added feature-area labels — `casino`, `jackpot`, `lottery`, `poker`, `blackjack`, `moderation`, `economy`, `music`, `dnd` — on top of the existing layer labels (`Bot`, `web`, `Database`, …). Path globs match files anywhere in the diff so a PR touching both a Blackjack service and a moderation template gets both labels.

**Title-prefix labelling** (`.github/workflows/label.yml`): a second step using `actions/github-script` parses the PR title's conventional-commit prefix (`feat:`, `fix:`, `chore:`, `docs:`, etc.) and applies a matching lowercase label. `deps:` and `dependencies:` both fold into `dependencies` so the skip rule is one entry instead of two.

**Auto-append workflow** (`.github/workflows/changelog.yml`): fires on merged PRs. The flow:

1. Skip if the PR has any of `chore`, `docs`, `ci`, `build`, `style`, `dependencies`, `skip-changelog`.
2. Walk the labels in priority order to pick an emoji — `jackpot` 🎰 beats `casino` 🎲 (which beats the rest), `moderation` 🛡️ for admin work, etc. Falls back to a type-based emoji (✨ feat, 🔨 fix, 🧹 refactor, ⚡ perf) or just ✨.
3. Strip the conventional-commit prefix from the PR title for the headline; capitalise the first letter so it reads like a sentence regardless of how the author wrote it.
4. Lift the summary from the PR body's `## Summary` section (we have a template that puts it there) or fall back to the first non-empty paragraph. Bullets get flattened, the auto-appended Claude session URL gets stripped, the result caps at 480 chars.
5. `jq`-prepend the entry to `changelog.json`. Idempotent on re-run — if the topmost entry's `prNumber` already matches the PR, no-op.
6. Direct-push to `main` with `[skip ci]` so the changelog commit doesn't retrigger the gradle build.

## How to use it

- **Default**: every merged PR auto-adds an entry.
- **Suppress one PR**: add the `skip-changelog` label.
- **Suppress a category**: title the PR with the conventional-commit prefix (`chore: bump deps`, `docs: clarify lottery copy`, `ci: cache gradle`). The labeller picks up the prefix and the changelog workflow skips it automatically.
- **Tune the emoji map**: edit the `FEATURE_EMOJI` priority list inside `changelog.yml`.
- **Edit the seed list**: `web/src/main/resources/changelog.json` — straight JSON edit, no Kotlin recompile needed.

## Test plan

- [x] `./gradlew :web:test` — passes (controller refactor compiles).
- [ ] CI gradle build — `:application:test` runs `ChangelogControllerTest` and `PageRenderSmokeIT`; both must stay green.
- [ ] After merge, the changelog workflow fires on this PR itself and prepends an entry. Verify the resulting commit on `main` looks sensible (date, title, summary, emoji, `prNumber`).
- [ ] Open a small follow-up PR with a `chore:` prefix to confirm the labeller applies the `chore` label and the changelog workflow skips on merge.

https://claude.ai/code/session_01GAVMLpP2CsESghD66LXmhV

---
_Generated by [Claude Code](https://claude.ai/code/session_01GAVMLpP2CsESghD66LXmhV)_