### PR TITLE
refactor(casino): unify win-settle + hoist casino-render fragment + smoke + guard tests

### DIFF
--- a/application/src/test/kotlin/integration/web/PageRenderSmokeIT.kt
+++ b/application/src/test/kotlin/integration/web/PageRenderSmokeIT.kt
@@ -93,13 +93,21 @@ class PageRenderSmokeIT {
             "/brother",
             "/config",
             "/music",
-            // Casino landing + per-guild minigame pages (the cluster that 500'd in #354)
+            // Casino landing + per-guild minigame pages. Every casino
+            // route on the navbar / picker is covered so a future
+            // template move (e.g. casinoholdem's URL move in #419)
+            // can't silently break the page without smoke catching it.
             "/casino/guilds",
             "/casino/1/slots",
             "/casino/1/dice",
             "/casino/1/coinflip",
             "/casino/1/highlow",
             "/casino/1/scratch",
+            "/casino/1/keno",
+            "/casino/1/roulette",
+            "/casino/1/baccarat",
+            "/casino/1/casinoholdem",
+            "/casino/1/lottery",
             // Poker
             "/poker/guilds",
             "/poker/1",

--- a/web/src/main/resources/static/css/base.css
+++ b/web/src/main/resources/static/css/base.css
@@ -106,19 +106,97 @@ a:hover { color: var(--accent-hover); }
 .btn:active:not(:disabled) { transform: translateY(1px); }
 .btn:disabled { opacity: 0.55; cursor: not-allowed; }
 
+/* `.btn-primary` is the semantic alias for `.btn` — game templates have
+   long used `class="btn-primary"` for action buttons (Deal, Hit, Bet)
+   and were rendering as plain unstyled browser controls because the
+   class was only defined inside home.css / campaign.css scopes. Same
+   visual + interaction as `.btn`. */
+.btn-primary {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--space-2);
+    background: var(--accent);
+    color: #fff;
+    border: 1px solid transparent;
+    padding: 10px 20px;
+    border-radius: var(--radius-md);
+    font-size: 0.95rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.15s, border-color 0.15s, color 0.15s, transform 0.05s;
+    text-decoration: none;
+    font-family: inherit;
+}
+.btn-primary:hover:not(:disabled) { background: var(--accent-hover); }
+.btn-primary:active:not(:disabled) { transform: translateY(1px); }
+.btn-primary:disabled { opacity: 0.55; cursor: not-allowed; }
+
 .btn-secondary {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--space-2);
     background: transparent;
     color: var(--text);
-    border-color: var(--border-strong);
+    border: 1px solid var(--border-strong);
+    padding: 10px 20px;
+    border-radius: var(--radius-md);
+    font-size: 0.95rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.15s, border-color 0.15s, color 0.15s, transform 0.05s;
+    text-decoration: none;
+    font-family: inherit;
 }
 .btn-secondary:hover:not(:disabled) { background: var(--accent-soft); border-color: var(--accent); color: #fff; }
+.btn-secondary:active:not(:disabled) { transform: translateY(1px); }
+.btn-secondary:disabled { opacity: 0.55; cursor: not-allowed; }
+
+/* Green accent variant for confirm-style actions (blackjack's Stand,
+   future "Lock in" / "Confirm" controls). Same shape as `.btn-primary`,
+   different colour token. */
+.btn-success {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--space-2);
+    background: var(--success-bg);
+    color: var(--success);
+    border: 1px solid var(--success-border);
+    padding: 10px 20px;
+    border-radius: var(--radius-md);
+    font-size: 0.95rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.15s, border-color 0.15s, color 0.15s, transform 0.05s;
+    text-decoration: none;
+    font-family: inherit;
+}
+.btn-success:hover:not(:disabled) { background: var(--success-border); color: #fff; }
+.btn-success:active:not(:disabled) { transform: translateY(1px); }
+.btn-success:disabled { opacity: 0.55; cursor: not-allowed; }
 
 .btn-danger {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--space-2);
     background: transparent;
     color: var(--danger);
-    border-color: var(--danger-border);
+    border: 1px solid var(--danger-border);
+    padding: 10px 20px;
+    border-radius: var(--radius-md);
+    font-size: 0.95rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.15s, border-color 0.15s, color 0.15s, transform 0.05s;
+    text-decoration: none;
+    font-family: inherit;
 }
 .btn-danger:hover:not(:disabled) { background: var(--danger-border); color: #fff; }
+.btn-danger:active:not(:disabled) { transform: translateY(1px); }
+.btn-danger:disabled { opacity: 0.55; cursor: not-allowed; }
 
 .btn-ghost {
     background: transparent;

--- a/web/src/main/resources/static/js/baccarat.js
+++ b/web/src/main/resources/static/js/baccarat.js
@@ -18,7 +18,6 @@ function renderBaccaratResult(opts) {
     var bankerTotalEl = opts.bankerTotalEl;
     var playerTotalEl = opts.playerTotalEl;
     var tableEl = opts.tableEl;
-    var flashTargetEl = opts.flashTargetEl || tableEl;
     var stagger = opts.stagger !== false;
     // Shared with blackjack/casinoholdem so every card-game felt deals
     // at the same beat-out cadence. Tests can still override via opts.
@@ -79,18 +78,10 @@ function renderBaccaratResult(opts) {
                 loseLineHtml: loseLineHtml(body, sideLabel, winnerLabel),
             });
         }
-
-        // Match the blackjack/poker payoff flourish: gold chip stack pops on
-        // wins, sound cue on either outcome. flashWinPayout picks the right
-        // payout (jackpot > net) and no-ops on losses.
-        if (typeof window !== 'undefined') {
-            if (window.CasinoRender) {
-                window.CasinoRender.flashWinPayout(flashTargetEl, body);
-            }
-            if (window.CasinoSounds) {
-                window.CasinoSounds.play(body.win ? 'win' : 'lose');
-            }
-        }
+        // Win/lose cue + chip flourish are owned by the shared
+        // casino-win-settle helper, fired by casino-game.js once this
+        // staged-deal Promise resolves. The helper checks body.push
+        // and skips both cues on a tie.
     }
 
     if (dealMs > 0) {
@@ -238,6 +229,14 @@ function loseLineHtml(body, sideLabel, winnerLabel) {
             buildPayload: function (state) {
                 return { side: selectedSide(), stake: state.stake, autoTopUp: state.autoTopUp };
             },
+            startAnimation: function () {
+                // Click cue on bet submit so baccarat has the same
+                // "round started" audio anchor as the other minigames.
+                // The deal cues themselves ride along with each
+                // freshly-arriving card via casino-render's renderCards.
+                if (window.CasinoSounds) window.CasinoSounds.play('click');
+                return null;
+            },
             renderResult: function (body) {
                 // Return the Promise so the scaffold waits for the
                 // staged deal to land before applying balance and
@@ -249,10 +248,10 @@ function loseLineHtml(body, sideLabel, winnerLabel) {
                     bankerTotalEl: bankerTotalEl,
                     playerTotalEl: playerTotalEl,
                     tableEl: tableEl,
-                    flashTargetEl: tableEl,
                     body: body,
                 });
             },
+            flashTarget: tableEl,
         });
     }
 })();

--- a/web/src/main/resources/static/js/blackjack-solo.js
+++ b/web/src/main/resources/static/js/blackjack-solo.js
@@ -359,19 +359,17 @@
         // seat.discordId is a string from the projection so the snowflake
         // survives JS Number's 53-bit precision; lookup keys match exactly.
         var seatResult = (r.seatResults || {})[seat.discordId];
-        // Fire the celebratory chip stack once per hand on a winning result.
-        // Driven off the seat's total payout, which already aggregates every
-        // split branch — so a "push hand 1, win hand 2" round still triggers
-        // the win flourish even though seatResults only carries hand 0's
-        // outcome.
-        if (shouldFlash(state) && window.CasinoRender) {
+        // Fire the celebratory chip stack + win/lose cue once per hand
+        // via the shared casino-win-settle helper. Driven off the seat's
+        // total payout, which already aggregates every split branch —
+        // so a "push hand 1, win hand 2" round still triggers the win
+        // flourish even though seatResults only carries hand 0's outcome.
+        if (shouldFlash(state) && window.TobyCasinoWinSettle) {
             var payout = (r.payouts || {})[seat.discordId];
-            if (payout && payout > 0 && playerRowEl) {
-                window.CasinoRender.flashChipsOn(playerRowEl, payout);
-            }
-            if (window.CasinoSounds) {
-                window.CasinoSounds.play(payout && payout > 0 ? "win" : "lose");
-            }
+            window.TobyCasinoWinSettle.fire({
+                win: !!(payout && payout > 0),
+                net: payout || 0,
+            }, playerRowEl);
         }
 
         // Reset the result block in case it's a re-render after a previous

--- a/web/src/main/resources/static/js/casino-game.js
+++ b/web/src/main/resources/static/js/casino-game.js
@@ -42,6 +42,20 @@
         // revealed every cell (so credits don't visibly drop before the
         // suspense beat is over). It opts out and updates manually.
         const autoApplyBalance = cfg.autoApplyBalance !== false;
+        // Win-settle: every minigame plays a win/lose cue + (on win) a
+        // chip flourish on the felt. The helper module centralises both.
+        // Pass `flashTarget` (a DOM element or `() => DOM element`) and
+        // the helper will auto-fire after renderResult settles. Passing
+        // null skips the visual half but the win/lose sound still plays
+        // (audio-only parity is the floor — every game gets the cue).
+        const flashTargetFn = (typeof cfg.flashTarget === 'function')
+            ? cfg.flashTarget
+            : (cfg.flashTarget ? () => cfg.flashTarget : () => null);
+        const chipCountFn = (typeof cfg.chipCount === 'function') ? cfg.chipCount : null;
+        // Some custom flows (scratch's user-driven reveal) drive the
+        // win-settle themselves — `autoWinSettle: false` opts out so
+        // the helper doesn't double-fire.
+        const autoWinSettle = cfg.autoWinSettle !== false;
 
         if (!form || !stakeInput || !primaryBtn) {
             return { run: function () {} };
@@ -85,6 +99,21 @@
             }
             if (typeof newBalance !== 'number') return;
             if (balanceEl) balanceEl.textContent = newBalance;
+        }
+
+        function applyWinSettle(body, override) {
+            // Plays the win/lose cue + drops a chip flourish via the
+            // shared helper. `override` lets a custom flow (scratch's
+            // reveal) supply a fresh body / target / chipCount without
+            // reaching into the helper's API directly.
+            if (!root || !root.TobyCasinoWinSettle) return;
+            var target = (override && 'flashTarget' in override)
+                ? override.flashTarget
+                : flashTargetFn(body);
+            var opts = (override && override.chipCount)
+                ? { chipCount: override.chipCount }
+                : (chipCountFn ? { chipCount: chipCountFn } : null);
+            root.TobyCasinoWinSettle.fire(body, target, opts);
         }
 
         function applyTobyDelta(body) {
@@ -172,6 +201,9 @@
                                     applyBalance(body.newBalance);
                                     applyTobyDelta(body);
                                 }
+                                if (autoWinSettle) {
+                                    applyWinSettle(body);
+                                }
                                 if (jackpot) jackpot.releasePoolBanner();
                                 busy = false;
                                 setDisabled(false);
@@ -208,6 +240,7 @@
             run: run,
             applyBalance: applyBalance,
             applyTobyDelta: applyTobyDelta,
+            applyWinSettle: applyWinSettle,
             isBusy: function () { return busy; },
         };
     }

--- a/web/src/main/resources/static/js/casino-win-settle.js
+++ b/web/src/main/resources/static/js/casino-win-settle.js
@@ -1,0 +1,66 @@
+// Shared win-settle for casino minigames. Owns the "play win or lose
+// sound + drop a chip flourish on the felt" pair that every minigame
+// used to do by hand at the end of its renderResult / stopAnimation.
+// Centralising it means a future game can't ship without the cue, and
+// a tweak to the formula (chip count, payout selection, push-vs-win
+// handling) is one edit instead of nine.
+//
+// API:
+//   TobyCasinoWinSettle.fire(body, flashTarget, options?)
+//     body         — server response. Must include either `win` (bool)
+//                    or `net` (number); push (`body.push: true`)
+//                    suppresses both sound and flash.
+//     flashTarget  — DOM element receiving the chip stack, or null to
+//                    skip the visual half (sound only).
+//     options.chipCount — optional `(body) => number` overriding the
+//                    default scaling (3–7 chips, scaling roughly by
+//                    `payout / 100`).
+//
+// Tolerant of missing dependencies — silently no-ops if `CasinoSounds`
+// or `CasinoRender` haven't been loaded yet.
+
+(function (root) {
+    'use strict';
+
+    var DEFAULT_MIN_CHIPS = 3;
+    var DEFAULT_MAX_CHIPS = 7;
+
+    function defaultChipCount(body) {
+        var payout = (typeof body.jackpotPayout === 'number' && body.jackpotPayout > 0)
+            ? body.jackpotPayout
+            : (body.net || 0);
+        return Math.min(
+            DEFAULT_MAX_CHIPS,
+            Math.max(DEFAULT_MIN_CHIPS, Math.ceil(payout / 100))
+        );
+    }
+
+    function fire(body, flashTarget, options) {
+        if (!body) return;
+        // Push (baccarat tie + future tie-able games) — refunded stake,
+        // neither outcome. Stay silent.
+        if (body.push) return;
+
+        var isWin = !!body.win || (body.net || 0) > 0;
+        if (root && root.CasinoSounds) {
+            root.CasinoSounds.play(isWin ? 'win' : 'lose');
+        }
+
+        if (!isWin || !flashTarget || !(root && root.CasinoRender)) return;
+
+        // flashWinPayout requires body.win to be truthy. Some games
+        // (highlow / scratch) don't return a `win` field — they use
+        // net > 0. Synthesise a body so the visual half lands either way.
+        var paintBody = body.win ? body : Object.assign({}, body, { win: true });
+        var fn = (options && typeof options.chipCount === 'function')
+            ? options.chipCount
+            : defaultChipCount;
+        root.CasinoRender.flashWinPayout(flashTarget, paintBody, fn(paintBody));
+    }
+
+    var api = { fire: fire, defaultChipCount: defaultChipCount };
+    if (root) root.TobyCasinoWinSettle = api;
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = api;
+    }
+})(typeof window !== 'undefined' ? window : null);

--- a/web/src/main/resources/static/js/casinoholdem-solo.js
+++ b/web/src/main/resources/static/js/casinoholdem-solo.js
@@ -139,13 +139,16 @@
         resultEl.textContent = label;
         resultEl.className = "che-result " + cls;
 
-        if (shouldFlash(state) && window.CasinoRender) {
-            if (r.totalPayout && r.totalPayout > 0 && playerRowEl) {
-                window.CasinoRender.flashChipsOn(playerRowEl, r.totalPayout);
-            }
-            if (window.CasinoSounds) {
-                window.CasinoSounds.play(r.net > 0 ? "win" : "lose");
-            }
+        // Win/lose cue + chip flourish via the shared helper. Push (net
+        // == 0) is suppressed by the helper's body.push branch below
+        // — set it explicitly so a tied hand stays silent.
+        if (shouldFlash(state) && window.TobyCasinoWinSettle) {
+            window.TobyCasinoWinSettle.fire({
+                win: r.net > 0,
+                net: r.net,
+                push: r.net === 0 && !r.folded,
+                jackpotPayout: r.jackpotPayout,
+            }, playerRowEl);
         }
     }
 
@@ -203,6 +206,9 @@
             errorToast("Enter a positive stake.");
             return;
         }
+        // Click cue on bet submit so casinoholdem has the same audio
+        // anchor as the rest of the minigames at "round started".
+        if (window.CasinoSounds) window.CasinoSounds.play("click");
         resultDefer.cancel();
         dealBusy = true;
         window.TobyApi.postJson("/casino/" + guildId + "/casinoholdem/deal", { stake: stake })

--- a/web/src/main/resources/static/js/coinflip.js
+++ b/web/src/main/resources/static/js/coinflip.js
@@ -1,6 +1,10 @@
 // Pure-DOM render for a /flip response. Hoisted out of the IIFE so the
 // jest test in `coinflip.test.js` can drive it without booting the page.
-function renderCoinflipResult(resultEl, body, flashTargetEl) {
+//
+// Win/lose sound + chip flourish are owned by the shared
+// `casino-win-settle.js` helper, fired by casino-game.js after this
+// renderResult returns (see flashTarget in init below).
+function renderCoinflipResult(resultEl, body) {
     const landedLabel = body.landed === 'HEADS' ? 'Heads' : 'Tails';
     const predictedLabel = body.predicted === 'HEADS' ? 'Heads' : 'Tails';
     if (typeof window !== 'undefined' && window.TobyCasinoResult) {
@@ -13,10 +17,6 @@ function renderCoinflipResult(resultEl, body, flashTargetEl) {
             loseLineHtml: '<strong>' + landedLabel + '.</strong> You called ' +
                 predictedLabel + ' &middot; lost <strong>' + Math.abs(body.net) + ' credits</strong>',
         });
-    }
-    // Same chip flourish blackjack uses when a hand pays out.
-    if (typeof window !== 'undefined' && window.CasinoRender) {
-        window.CasinoRender.flashWinPayout(flashTargetEl, body);
     }
 }
 
@@ -83,11 +83,10 @@ function renderCoinflipResult(resultEl, body, flashTargetEl) {
             coinFace.textContent = '🪙';
             delete coin.dataset.landed;
         }
+        // Chip-clink on landing — the win/lose cue follows from the
+        // shared win-settle helper a beat later.
         if (body && window.CasinoSounds) {
             window.CasinoSounds.play('chip');
-            setTimeout(function () {
-                window.CasinoSounds.play(body.net > 0 ? 'win' : 'lose');
-            }, 80);
         }
     }
 
@@ -123,7 +122,8 @@ function renderCoinflipResult(resultEl, body, flashTargetEl) {
         },
         startAnimation: startFlipAnimation,
         stopAnimation: stopFlipAnimation,
-        renderResult: function (body) { renderCoinflipResult(els.resultEl, body, tableEl); },
+        renderResult: function (body) { renderCoinflipResult(els.resultEl, body); },
+        flashTarget: tableEl,
     });
 })();
 

--- a/web/src/main/resources/static/js/dice.js
+++ b/web/src/main/resources/static/js/dice.js
@@ -1,6 +1,10 @@
 // Pure-DOM render for a /roll response. Hoisted out of the IIFE so the
 // jest test in `dice.test.js` can drive it without booting the page.
-function renderDiceResult(resultEl, body, flashTargetEl) {
+//
+// Win/lose sound + chip flourish are owned by the shared
+// `casino-win-settle.js` helper, fired by casino-game.js after this
+// renderResult returns (see flashTarget in init below).
+function renderDiceResult(resultEl, body) {
     if (typeof window !== 'undefined' && window.TobyCasinoResult) {
         window.TobyCasinoResult.render({
             resultEl: resultEl,
@@ -11,10 +15,6 @@ function renderDiceResult(resultEl, body, flashTargetEl) {
             loseLineHtml: '<strong>' + body.landed + '.</strong> You called ' +
                 body.predicted + ' &middot; lost <strong>' + Math.abs(body.net) + ' credits</strong>',
         });
-    }
-    // Same chip flourish blackjack/poker use on a winning hand.
-    if (typeof window !== 'undefined' && window.CasinoRender) {
-        window.CasinoRender.flashWinPayout(flashTargetEl, body);
     }
 }
 
@@ -74,11 +74,10 @@ function renderDiceResult(resultEl, body, flashTargetEl) {
             dieFace.textContent = '⚀';
             delete die.dataset.landed;
         }
+        // Click on landing — the win/lose cue follows from the shared
+        // win-settle helper a beat later.
         if (body && window.CasinoSounds) {
             window.CasinoSounds.play('click');
-            setTimeout(function () {
-                window.CasinoSounds.play(body.net > 0 ? 'win' : 'lose');
-            }, 80);
         }
     }
 
@@ -114,7 +113,8 @@ function renderDiceResult(resultEl, body, flashTargetEl) {
         },
         startAnimation: startRollAnimation,
         stopAnimation: stopRollAnimation,
-        renderResult: function (body) { renderDiceResult(els.resultEl, body, tableEl); },
+        renderResult: function (body) { renderDiceResult(els.resultEl, body); },
+        flashTarget: tableEl,
     });
 })();
 

--- a/web/src/main/resources/static/js/highlow.js
+++ b/web/src/main/resources/static/js/highlow.js
@@ -21,10 +21,12 @@ function highlowFormatMultiplier(m) {
 // Pure-DOM render for a /play response. Hoisted out of the IIFE so the
 // jest test in `highlow.test.js` can drive it without booting the page.
 //
-// flashTargetEl is the felt element that gets the chip-stack flourish
-// on a win — passing it through the render fn keeps the chip flourish
-// callable from tests, instead of being trapped inside the IIFE.
-function renderHighlowResult(resultEl, body, flashTargetEl) {
+// Win/lose sound + chip flourish are owned by the shared
+// `casino-win-settle.js` helper (the helper synthesises a `win: true`
+// body for highlow since the response only carries `net`). Caller
+// triggers it via `game.applyWinSettle(body)` once the next-card
+// shuffle has settled.
+function renderHighlowResult(resultEl, body) {
     if (typeof window === 'undefined' || !window.TobyCasinoResult) return;
     const dirLabel = body.direction === 'HIGHER' ? 'Higher' : 'Lower';
     const tie = body.next === body.anchor;
@@ -43,14 +45,6 @@ function renderHighlowResult(resultEl, body, flashTargetEl) {
             ' <strong>' + highlowCardLabel(body.anchor) + '</strong> &middot; you called ' +
             dirLabel + ' &middot; lost <strong>' + Math.abs(body.net) + ' credits</strong>',
     });
-    // Highlow's response has no `win` field — net > 0 is the win signal.
-    if (window.CasinoRender) {
-        window.CasinoRender.flashWinPayout(flashTargetEl, {
-            win: (body.net || 0) > 0,
-            net: body.net,
-            jackpotPayout: body.jackpotPayout,
-        });
-    }
 }
 
 (function () {
@@ -177,8 +171,18 @@ function renderHighlowResult(resultEl, body, flashTargetEl) {
         failureMessage: 'Could not lock the round.',
         // /start doesn't settle credit/coin movement — it just locks
         // the stake and deals the anchor. Balance updates land via
-        // /play's response instead.
+        // /play's response instead. The shared win-settle helper
+        // would otherwise fire a 'lose' cue on the stake-lock body
+        // (no win/net field), so opt out here too — the /play onSettle
+        // path drives the cue manually via game.applyWinSettle.
         autoApplyBalance: false,
+        autoWinSettle: false,
+        startAnimation: function () {
+            // Click cue on Lock submit so highlow has the same audio
+            // anchor as the rest of the minigames at "round started".
+            if (window.CasinoSounds) window.CasinoSounds.play('click');
+            return null;
+        },
         renderResult: function (body) {
             if (typeof body.anchor === 'number') {
                 showCallMode(body.anchor, body.higherMultiplier, body.lowerMultiplier);
@@ -196,6 +200,9 @@ function renderHighlowResult(resultEl, body, flashTargetEl) {
         playing = true;
         higherBtn.disabled = true;
         lowerBtn.disabled = true;
+        // Click cue on Higher / Lower so each call has the same audio
+        // anchor as a fresh round on the form-submit minigames.
+        if (window.CasinoSounds) window.CasinoSounds.play('click');
         const intervalId = startNextShuffle();
 
         // /play has a different lifecycle than /start (button pair, not
@@ -212,11 +219,13 @@ function renderHighlowResult(resultEl, body, flashTargetEl) {
                 playing = false;
                 if (body && body.ok) {
                     stopNextShuffle(intervalId, body.next);
-                    renderHighlowResult(els.resultEl, body, tableEl);
-                    if (window.CasinoSounds) {
-                        window.CasinoSounds.play(body.net > 0 ? 'win' : 'lose');
-                    }
+                    renderHighlowResult(els.resultEl, body);
                     if (game) {
+                        // Shared win-settle: plays win/lose cue + drops
+                        // chip flourish on the felt. Helper synthesises
+                        // body.win from net since highlow's response
+                        // carries net only.
+                        game.applyWinSettle(body, { flashTarget: tableEl });
                         game.applyBalance(body.newBalance);
                         game.applyTobyDelta(body);
                     }

--- a/web/src/main/resources/static/js/keno.js
+++ b/web/src/main/resources/static/js/keno.js
@@ -15,7 +15,6 @@ function renderKenoResult(opts) {
     var resultEl = opts.resultEl;
     var statusEl = opts.statusEl;
     var gridEl = opts.gridEl;
-    var flashTargetEl = opts.flashTargetEl;
     var stagger = opts.stagger !== false;
     var dealMs = stagger ? (opts.dealMs || 120) : 0;
     var body = opts.body;
@@ -56,15 +55,11 @@ function renderKenoResult(opts) {
                 });
             }
         }
-
-        if (typeof window !== 'undefined') {
-            if (window.CasinoRender) {
-                window.CasinoRender.flashWinPayout(flashTargetEl, body);
-            }
-            if (window.CasinoSounds) {
-                window.CasinoSounds.play(body.win ? 'win' : 'lose');
-            }
-        }
+        // Win/lose cue + chip flourish are owned by the shared
+        // casino-win-settle helper, fired by casino-game.js once the
+        // staged reveal Promise resolves (i.e. after this finalize
+        // returns). The flashTarget on the keno init() is the table
+        // wrapper.
     }
 
     // Hide any prior result line while the deal plays out — it'll be
@@ -273,10 +268,10 @@ function kenoLoseLineHtml(body) {
                     resultEl: resultEl,
                     statusEl: statusEl,
                     gridEl: gridEl,
-                    flashTargetEl: tableEl,
                     body: body,
                 });
             },
+            flashTarget: tableEl,
         });
     }
 

--- a/web/src/main/resources/static/js/roulette.js
+++ b/web/src/main/resources/static/js/roulette.js
@@ -16,7 +16,11 @@ function setBetInputsDisabled(disabled, fieldsetEl, straightInputEl) {
 // Pure-DOM render for a /spin response. Hoisted out of the IIFE so a
 // future jest test can drive it without booting the whole page (mirrors
 // renderSlotsResult). The IIFE below calls it with the live result element.
-function renderRouletteResult(resultEl, body, flashTargetEl) {
+//
+// Win/lose sound + chip flourish are owned by the shared
+// `casino-win-settle.js` helper, fired by casino-game.js after this
+// renderResult returns (see flashTarget in init below).
+function renderRouletteResult(resultEl, body) {
     if (typeof window !== 'undefined' && window.TobyCasinoResult) {
         var betLabel = body.betLabel || body.bet || 'bet';
         var pocketLabel = '#' + body.landed +
@@ -32,12 +36,6 @@ function renderRouletteResult(resultEl, body, flashTargetEl) {
                 'Lost <strong>' + Math.abs(body.net) + ' credits</strong> &middot; ' +
                 betLabel + ' (landed ' + pocketLabel + ')',
         });
-    }
-    if (typeof window === 'undefined' || !body) return;
-    if (window.CasinoRender) {
-        var payoutEstimate = (body.jackpotPayout > 0 ? body.jackpotPayout : body.net) || 0;
-        var chipCount = Math.min(7, Math.max(3, Math.ceil(payoutEstimate / 100)));
-        window.CasinoRender.flashWinPayout(flashTargetEl, body, chipCount);
     }
 }
 
@@ -211,16 +209,13 @@ function renderRouletteResult(resultEl, body, flashTargetEl) {
         }
     }
 
-    function playOutcomeCues(body) {
+    function playOutcomeCues(_body) {
         if (!window.CasinoSounds) return;
+        // Ball-drop cue lands the moment the wheel settles. The win/lose
+        // arpeggio + chip flourish follow from the shared win-settle
+        // helper a beat later (fired by casino-game.js after
+        // renderResult returns).
         window.CasinoSounds.play('ball');
-        var win = body.net > 0;
-        // Slight delay so the ball-drop cue doesn't overlap the win/lose
-        // arpeggio — keeps the audio readable.
-        var id = setTimeout(function () {
-            window.CasinoSounds.play(win ? 'win' : 'lose');
-        }, 160);
-        settleTimeoutIds.push(id);
     }
 
     function paintLanded(body) {
@@ -309,8 +304,9 @@ function renderRouletteResult(resultEl, body, flashTargetEl) {
         startAnimation: startSpinAnimation,
         stopAnimation: stopSpinAnimation,
         renderResult: function (body) {
-            renderRouletteResult(els.resultEl, body, tableEl);
+            renderRouletteResult(els.resultEl, body);
         },
+        flashTarget: tableEl,
         validate: function (state) {
             var bet = selectedBet();
             if (!bet) return 'Pick a bet.';

--- a/web/src/main/resources/static/js/scratch.js
+++ b/web/src/main/resources/static/js/scratch.js
@@ -1,9 +1,13 @@
 // Pure-DOM render for a /scratch response. Hoisted out of the IIFE so
 // the jest test in `scratch.test.js` can drive it without booting the
-// page. matchThreshold / balanceEl / flashTargetEl are passed in (they
-// live as DOM attributes / element references inside the IIFE) to keep
-// this fully stateless.
-function renderScratchResult(resultEl, body, matchThreshold, balanceEl, flashTargetEl) {
+// page.
+//
+// Win/lose sound + chip flourish are now owned by the shared
+// `casino-win-settle.js` helper; the IIFE below calls
+// `game.applyWinSettle(activeCard)` from inside `revealCell` once the
+// player has finished scratching. Keeping it here would duplicate the
+// helper and risk drift if the formula changes.
+function renderScratchResult(resultEl, body, matchThreshold, balanceEl) {
     if (typeof window !== 'undefined' && window.TobyCasinoResult) {
         window.TobyCasinoResult.render({
             resultEl: resultEl,
@@ -18,17 +22,6 @@ function renderScratchResult(resultEl, body, matchThreshold, balanceEl, flashTar
     if (typeof window !== 'undefined' && window.TobyBalance) {
         window.TobyBalance.update(balanceEl, body.newBalance);
     }
-    // Scratch's response has no `win` field — net > 0 is the win signal.
-    // Bigger payouts get a taller stack (capped internally at 7).
-    if (typeof window !== 'undefined' && window.CasinoRender) {
-        const payoutEstimate = (body.jackpotPayout > 0 ? body.jackpotPayout : (body.net || 0));
-        const chipCount = Math.min(7, Math.max(3, Math.ceil(payoutEstimate / 100)));
-        window.CasinoRender.flashWinPayout(flashTargetEl, {
-            win: (body.net || 0) > 0,
-            net: body.net,
-            jackpotPayout: body.jackpotPayout,
-        }, chipCount);
-    }
 }
 
 (function () {
@@ -42,7 +35,6 @@ function renderScratchResult(resultEl, body, matchThreshold, balanceEl, flashTar
 
     const cellsContainer = document.getElementById('scratch-cells');
     const cellButtons = Array.from(cellsContainer ? cellsContainer.querySelectorAll('.scratch-cell') : []);
-    const tableEl = document.querySelector('.scratch-table');
     const revealBtn = document.getElementById('scratch-reveal-all');
 
     if (!els.form || !els.primaryBtn || !els.stakeInput || cellButtons.length === 0) return;
@@ -78,13 +70,25 @@ function renderScratchResult(resultEl, body, matchThreshold, balanceEl, flashTar
         // win cells once everything is revealed (see below).
         if (cellButtons.every(function (b) { return b.classList.contains('revealed'); })) {
             highlightWinCells(activeCard);
-            renderScratchResult(els.resultEl, activeCard, matchThreshold, els.balanceEl, tableEl);
-            if (window.CasinoSounds) {
-                window.CasinoSounds.play((activeCard.net || 0) > 0 ? 'win' : 'lose');
+            renderScratchResult(els.resultEl, activeCard, matchThreshold, els.balanceEl);
+            // Win/lose cue + chip flourish — fired AFTER the last cell
+            // reveals so the chips pop on the *cells* the player has
+            // been scratching (not the wider table). Jackpot wins get a
+            // taller stack so the celebration reads as bigger.
+            if (game) {
+                game.applyWinSettle(activeCard, {
+                    flashTarget: cellsContainer,
+                    chipCount: function (body) {
+                        var payout = body.jackpotPayout > 0 ? body.jackpotPayout : (body.net || 0);
+                        var cap = body.jackpotPayout > 0 ? 10 : 7;
+                        return Math.min(cap, Math.max(3, Math.ceil(payout / 100)));
+                    },
+                });
+                // Now the credits visibly drop and the topup-coin
+                // recompute catches up too — see autoApplyBalance: false
+                // in the helper.
+                game.applyTobyDelta(activeCard);
             }
-            // Now the credits visibly drop and the topup-coin recompute
-            // catches up too — see autoApplyBalance: false in the helper.
-            if (game) game.applyTobyDelta(activeCard);
             // And only now release the central jackpot-pool banner so it
             // doesn't tick before the suspense beat is over.
             if (window.TobyJackpot) window.TobyJackpot.releasePoolBanner();
@@ -136,7 +140,11 @@ function renderScratchResult(resultEl, body, matchThreshold, balanceEl, flashTar
         // Scratch shows the result only after every cell has been
         // revealed, so the helper must NOT auto-update balance/coins on
         // response. revealCell() does it once the suspense is over.
+        // Same reasoning for the win-settle cue + flourish — opt out
+        // of the auto-fire and call game.applyWinSettle() ourselves
+        // from inside revealCell so the chips pop with the final reveal.
         autoApplyBalance: false,
+        autoWinSettle: false,
         startAnimation: function () {
             if (els.resultEl) els.resultEl.hidden = true;
             resetCells();

--- a/web/src/main/resources/static/js/slots.js
+++ b/web/src/main/resources/static/js/slots.js
@@ -1,7 +1,12 @@
 // Pure-DOM render for a /spin response. Hoisted out of the IIFE so the
 // jest test in `slots.test.js` can drive it without booting the whole
 // page. The IIFE below calls it with the live result element.
-function renderSlotsResult(resultEl, body, flashTargetEl, reels) {
+//
+// Win/lose sound + chip flourish on the felt are owned by the shared
+// `casino-win-settle.js` helper, fired by casino-game.js after this
+// renderResult returns (see flashTarget in init below). All slots-
+// specific visuals (the gold halo on the winning reels) stay here.
+function renderSlotsResult(resultEl, body, reels) {
     if (typeof window !== 'undefined' && window.TobyCasinoResult) {
         window.TobyCasinoResult.render({
             resultEl: resultEl,
@@ -14,19 +19,12 @@ function renderSlotsResult(resultEl, body, flashTargetEl, reels) {
     }
     if (typeof window === 'undefined' || !body) return;
     // Light up the winning reels with the gold halo used everywhere else
-    // for "this is the active payoff", and drop the shared chip flourish
-    // on the felt so a slots win celebrates like a blackjack win.
+    // for "this is the active payoff".
     if (reels && reels.length) {
         reels.forEach(function (r) { if (r) r.classList.remove('win-cell'); });
         if (body.win) {
             reels.forEach(function (r) { if (r) r.classList.add('win-cell'); });
         }
-    }
-    if (window.CasinoRender) {
-        // Bigger payouts get a taller stack, capped internally at 7.
-        var payoutEstimate = (body.jackpotPayout > 0 ? body.jackpotPayout : body.net) || 0;
-        var chipCount = Math.min(7, Math.max(3, Math.ceil(payoutEstimate / 100)));
-        window.CasinoRender.flashWinPayout(flashTargetEl, body, chipCount);
     }
 }
 
@@ -82,7 +80,9 @@ function renderSlotsResult(resultEl, body, flashTargetEl, reels) {
         clearInterval(intervalId);
         const finalSymbols = body && body.symbols;
         // Stagger the reel-stop click cues so each reel locking in is
-        // audible — like a slot machine's individual reel ticks.
+        // audible — like a slot machine's individual reel ticks. The
+        // win/lose cue + chip flourish are fired by the shared
+        // win-settle helper a beat after these clicks land.
         reels.forEach(function (reel, i) {
             reel.classList.remove('spinning');
             if (finalSymbols && finalSymbols[i]) reel.textContent = finalSymbols[i];
@@ -90,11 +90,6 @@ function renderSlotsResult(resultEl, body, flashTargetEl, reels) {
                 setTimeout(function () { window.CasinoSounds.play('click'); }, i * 110);
             }
         });
-        if (body && window.CasinoSounds) {
-            setTimeout(function () {
-                window.CasinoSounds.play(body.net > 0 ? 'win' : 'lose');
-            }, reels.length * 110 + 80);
-        }
     }
 
     window.TobyCasinoGame.init({
@@ -124,7 +119,8 @@ function renderSlotsResult(resultEl, body, flashTargetEl, reels) {
         },
         startAnimation: startSpinAnimation,
         stopAnimation: stopSpinAnimation,
-        renderResult: function (body) { renderSlotsResult(els.resultEl, body, machineEl, reels); },
+        renderResult: function (body) { renderSlotsResult(els.resultEl, body, reels); },
+        flashTarget: machineEl,
     });
 })();
 

--- a/web/src/main/resources/templates/baccarat.html
+++ b/web/src/main/resources/templates/baccarat.html
@@ -98,7 +98,6 @@
 <div class="toast-stack" id="toast-stack" aria-live="polite"></div>
 
 <th:block th:replace="~{fragments/casinoMinigame :: scripts}"></th:block>
-<script th:src="@{/js/casino-render.js}"></script>
 <script th:src="@{/js/baccarat.js}"></script>
 </body>
 </html>

--- a/web/src/main/resources/templates/casinoholdem-solo.html
+++ b/web/src/main/resources/templates/casinoholdem-solo.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org" lang="en">
-<head th:replace="~{fragments/head :: head('TobyBot - Casino Hold\'em', '/css/casinoholdem.css')}"></head>
+<head th:replace="~{fragments/head :: head('TobyBot - Casino Hold''em', '/css/casinoholdem.css')}"></head>
 <body>
 <a href="#main" class="skip-link">Skip to content</a>
 <div th:replace="~{fragments/navbar :: navbar}"></div>

--- a/web/src/main/resources/templates/casinoholdem-solo.html
+++ b/web/src/main/resources/templates/casinoholdem-solo.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org" lang="en">
-<head th:replace="~{fragments/head :: head('TobyBot - Casino Hold''em', '/css/casinoholdem.css')}"></head>
+<head th:replace="~{fragments/head :: head('TobyBot - Casino Holdem', '/css/casinoholdem.css')}"></head>
 <body>
 <a href="#main" class="skip-link">Skip to content</a>
 <div th:replace="~{fragments/navbar :: navbar}"></div>
@@ -10,7 +10,7 @@
 
     <div class="che-header">
         <a class="back-link" th:href="@{/casino/guilds}">&larr; All casino servers</a>
-        <h1 th:text="'🃏 Casino Hold''em • ' + ${guildName}">🃏 Casino Hold'em</h1>
+        <h1 th:text="|🃏 Casino Hold'em • ${guildName}|">🃏 Casino Hold'em</h1>
         <p class="muted">
             Bet between <span th:text="${minStake}">10</span> and
             <span th:text="${maxStake}">500</span> credits per hand.

--- a/web/src/main/resources/templates/casinoholdem-solo.html
+++ b/web/src/main/resources/templates/casinoholdem-solo.html
@@ -96,7 +96,6 @@
 <div class="toast-stack" id="toast-stack" aria-live="polite"></div>
 
 <th:block th:replace="~{fragments/casinoMinigame :: scripts}"></th:block>
-<script th:src="@{/js/casino-render.js}"></script>
 <script th:src="@{/js/casinoholdem-solo.js}"></script>
 </body>
 </html>

--- a/web/src/main/resources/templates/fragments/casinoMinigame.html
+++ b/web/src/main/resources/templates/fragments/casinoMinigame.html
@@ -27,17 +27,29 @@
 
 <!--
     Shared script block for every minigame page. Order matters:
-      api      — fetch wrapper / CSRF
-      toasts   — toast notifications
-      sounds   — audio cues
-      jackpot  — jackpot pool banner mirroring
-      balance  — wallet balance update with flourish animation
-      topup    — TOBY shortfall sell button
-      result   — win/lose class toggling + balance refresh
-      game     — TobyCasinoGame.init scaffolding
-      dom      — standard `{prefix}-X` element selectors
+      api          — fetch wrapper / CSRF
+      toasts       — toast notifications
+      sounds       — audio cues + global mute toggle
+      jackpot      — jackpot pool banner mirroring
+      balance      — wallet balance update with flourish animation
+      topup        — TOBY shortfall sell button
+      result       — win/lose class toggling + balance refresh
+      render       — chip-stack flourish primitives (flashWinPayout etc.)
+      win-settle   — wires sounds + render into a single helper
+      game         — TobyCasinoGame.init scaffolding (calls win-settle)
+      dom          — standard `{prefix}-X` element selectors
+      bot-suspicion — anti-autoclicker telemetry tracker
     Each per-game template adds its own `<script th:src="@{/js/{game}.js}">`
     after this block.
+
+    casino-render lives here even though it's only strictly needed by
+    pages that draw chips: every minigame template historically had to
+    remember to load it explicitly, six of nine forgot, and the chip
+    flourish silently never fired (slots, coinflip, dice, highlow,
+    scratch, roulette). Hoisting it into the fragment closes that
+    forget-by-default loophole. Lobbies that never need it
+    (poker-lobby, blackjack-lobby) don't include this fragment, so
+    they still don't pay the cost.
 -->
 <th:block th:fragment="scripts">
     <script th:src="@{/js/api.js}"></script>
@@ -47,6 +59,8 @@
     <script th:src="@{/js/casino-balance.js}"></script>
     <script th:src="@{/js/casino-topup.js}"></script>
     <script th:src="@{/js/casino-result.js}"></script>
+    <script th:src="@{/js/casino-render.js}"></script>
+    <script th:src="@{/js/casino-win-settle.js}"></script>
     <script th:src="@{/js/casino-game.js}"></script>
     <script th:src="@{/js/casino-minigame-dom.js}"></script>
     <script th:src="@{/js/casino-bot-suspicion.js}"></script>

--- a/web/src/main/resources/templates/keno.html
+++ b/web/src/main/resources/templates/keno.html
@@ -127,15 +127,7 @@
 
 <div class="toast-stack" id="toast-stack" aria-live="polite"></div>
 
-<script th:src="@{/js/api.js}"></script>
-<script th:src="@{/js/toasts.js}"></script>
-<script th:src="@{/js/casino-sounds.js}"></script>
-<script th:src="@{/js/casino-jackpot.js}"></script>
-<script th:src="@{/js/casino-balance.js}"></script>
-<script th:src="@{/js/casino-topup.js}"></script>
-<script th:src="@{/js/casino-result.js}"></script>
-<script th:src="@{/js/casino-render.js}"></script>
-<script th:src="@{/js/casino-game.js}"></script>
+<th:block th:replace="~{fragments/casinoMinigame :: scripts}"></th:block>
 <script th:src="@{/js/keno.js}"></script>
 </body>
 </html>

--- a/web/src/test/js/baccarat.test.js
+++ b/web/src/test/js/baccarat.test.js
@@ -221,36 +221,9 @@ describe('renderBaccaratResult', () => {
         })).not.toThrow();
     });
 
-    test('win flashes a chip stack on the flash target; loss leaves it untouched', () => {
-        renderBaccaratResult({
-            resultEl, bankerCardsEl, playerCardsEl,
-            bankerTotalEl, playerTotalEl, tableEl,
-            flashTargetEl: tableEl,
-            stagger: false,
-            body: {
-                win: true, push: false, side: 'PLAYER', winner: 'PLAYER',
-                playerCards: ['5♠', '3♥'], bankerCards: ['2♣', '4♦'],
-                playerTotal: 8, bankerTotal: 6, multiplier: 2.0, net: 100,
-            },
-        });
-        expect(tableEl.querySelector('.casino-chip-stack')).not.toBeNull();
-        expect(tableEl.querySelector('.casino-chip-payout').textContent).toBe('+100');
-
-        // Reset the felt for the loss check.
-        tableEl.querySelectorAll('.casino-chip-stack').forEach((el) => el.remove());
-        renderBaccaratResult({
-            resultEl, bankerCardsEl, playerCardsEl,
-            bankerTotalEl, playerTotalEl, tableEl,
-            flashTargetEl: tableEl,
-            stagger: false,
-            body: {
-                win: false, push: false, side: 'PLAYER', winner: 'BANKER',
-                playerCards: ['5♠', '2♥'], bankerCards: ['9♣', '8♦'],
-                playerTotal: 7, bankerTotal: 7, net: -50,
-            },
-        });
-        expect(tableEl.querySelector('.casino-chip-stack')).toBeNull();
-    });
+    // Chip flourish has moved to casino-win-settle (the shared helper);
+    // covered in casino-win-settle.test.js. renderBaccaratResult now
+    // only owns the result line + class toggling + card layout.
 
     test('synchronous path returns undefined (no Promise)', () => {
         const ret = renderBaccaratResult({
@@ -338,10 +311,11 @@ describe('renderBaccaratResult', () => {
             expect(bankerCardsEl.querySelectorAll('.casino-card-glyph').length).toBe(0);
             expect(resultEl.classList.contains('bac-result-win')).toBe(false);
 
-            // Advance past the deal sequence (4 * 50ms = 200ms) but stop
-            // before flashChipsOn's 2.5s safety-cleanup timer fires —
-            // otherwise runAllTimers would remove the chip stack we want
-            // to assert.
+            // Advance past the deal sequence (4 * 50ms = 200ms): the
+            // result line + totals are now committed. Chip flourish
+            // is dropped by the casino-win-settle helper, fired by
+            // casino-game.js after the staged-deal Promise resolves —
+            // tested in casino-win-settle.test.js, not here.
             jest.advanceTimersByTime(250);
             expect(playerCardsEl.querySelectorAll('.casino-card-glyph').length).toBe(2);
             expect(bankerCardsEl.querySelectorAll('.casino-card-glyph').length).toBe(2);
@@ -349,7 +323,6 @@ describe('renderBaccaratResult', () => {
             expect(resultEl.innerHTML).toContain('Player wins');
             expect(playerTotalEl.textContent).toBe('(8 • Natural)');
             expect(bankerTotalEl.textContent).toBe('(6)');
-            expect(tableEl.querySelector('.casino-chip-stack')).not.toBeNull();
         } finally {
             jest.useRealTimers();
         }

--- a/web/src/test/js/casino-win-settle.test.js
+++ b/web/src/test/js/casino-win-settle.test.js
@@ -1,0 +1,155 @@
+// Pure-DOM tests for the shared casino-win-settle helper. Owns the
+// "play win-or-lose cue + drop a chip flourish on the felt" pair that
+// every minigame used to do by hand. These tests are the one place
+// chip-stack assertions still live (per-game render tests have been
+// trimmed to assert only their game-specific bits).
+//
+// Order matters: load the dependencies before the helper so its
+// `window.CasinoSounds` / `window.CasinoRender` references resolve.
+
+require('../../main/resources/static/js/casino-render');
+require('../../main/resources/static/js/casino-win-settle');
+
+describe('TobyCasinoWinSettle.fire', () => {
+    let target;
+    let playSpy;
+
+    beforeEach(() => {
+        document.body.innerHTML = '<section id="t"></section>';
+        target = document.getElementById('t');
+        // Stub the sounds module — the helper just calls .play(name).
+        playSpy = jest.fn();
+        window.CasinoSounds = { play: playSpy };
+    });
+
+    afterEach(() => {
+        delete window.CasinoSounds;
+    });
+
+    test('plays "win" + drops a chip stack on a winning body', () => {
+        window.TobyCasinoWinSettle.fire({ win: true, net: 250 }, target);
+
+        expect(playSpy).toHaveBeenCalledWith('win');
+        const stack = target.querySelector('.casino-chip-stack');
+        expect(stack).not.toBeNull();
+        expect(stack.querySelector('.casino-chip-payout').textContent).toBe('+250');
+    });
+
+    test('plays "lose" + leaves the felt clean on a losing body', () => {
+        window.TobyCasinoWinSettle.fire({ win: false, net: -100 }, target);
+
+        expect(playSpy).toHaveBeenCalledWith('lose');
+        expect(target.querySelector('.casino-chip-stack')).toBeNull();
+    });
+
+    test('synthesises win from net > 0 when body has no `win` field (highlow / scratch)', () => {
+        window.TobyCasinoWinSettle.fire({ net: 200, jackpotPayout: 0 }, target);
+
+        expect(playSpy).toHaveBeenCalledWith('win');
+        const stack = target.querySelector('.casino-chip-stack');
+        expect(stack).not.toBeNull();
+        expect(stack.querySelector('.casino-chip-payout').textContent).toBe('+200');
+    });
+
+    test('plays "lose" when net <= 0 and `win` field absent', () => {
+        window.TobyCasinoWinSettle.fire({ net: -50 }, target);
+
+        expect(playSpy).toHaveBeenCalledWith('lose');
+        expect(target.querySelector('.casino-chip-stack')).toBeNull();
+    });
+
+    test('push (baccarat tie) suppresses both sound and flash', () => {
+        window.TobyCasinoWinSettle.fire({ push: true, net: 0 }, target);
+
+        expect(playSpy).not.toHaveBeenCalled();
+        expect(target.querySelector('.casino-chip-stack')).toBeNull();
+    });
+
+    test('jackpot payout drives the chip-stack amount over net', () => {
+        // Jackpot wins — bigger stack, label reads the jackpot payout
+        // (helper picks jackpotPayout > net via flashWinPayout).
+        window.TobyCasinoWinSettle.fire(
+            { win: true, net: 500, jackpotPayout: 4000 }, target
+        );
+
+        const stack = target.querySelector('.casino-chip-stack');
+        expect(stack).not.toBeNull();
+        expect(stack.querySelector('.casino-chip-payout').textContent).toBe('+4000');
+    });
+
+    test('options.chipCount overrides the default scaling', () => {
+        // Spy on the underlying primitive — chip insertion happens in
+        // requestAnimationFrame inside flashChipsOn, so we can't assert
+        // on the rendered .casino-chip count synchronously. Verifying
+        // the helper passes the override through to flashWinPayout is
+        // the clearer contract.
+        const flashSpy = jest.spyOn(window.CasinoRender, 'flashWinPayout');
+        try {
+            window.TobyCasinoWinSettle.fire(
+                { win: true, net: 50 }, target,
+                { chipCount: () => 5 }
+            );
+            expect(flashSpy).toHaveBeenCalledTimes(1);
+            const [, , chipCountArg] = flashSpy.mock.calls[0];
+            expect(chipCountArg).toBe(5);
+        } finally {
+            flashSpy.mockRestore();
+        }
+    });
+
+    test('default scaling: 3-chip floor on tiny wins, 7-chip cap on large', () => {
+        const flashSpy = jest.spyOn(window.CasinoRender, 'flashWinPayout');
+        try {
+            // Tiny win — floor at 3 chips.
+            window.TobyCasinoWinSettle.fire({ win: true, net: 50 }, target);
+            expect(flashSpy.mock.calls[0][2]).toBe(3);
+
+            // Huge win — capped at 7 chips by the helper's default formula.
+            window.TobyCasinoWinSettle.fire({ win: true, net: 50000 }, target);
+            expect(flashSpy.mock.calls[1][2]).toBe(7);
+        } finally {
+            flashSpy.mockRestore();
+        }
+    });
+
+    test('null flashTarget skips the visual half but still plays sound', () => {
+        window.TobyCasinoWinSettle.fire({ win: true, net: 100 }, null);
+
+        expect(playSpy).toHaveBeenCalledWith('win');
+        // Nothing to assert on the DOM — no target was provided.
+    });
+
+    test('missing CasinoSounds module silently no-ops the audio half', () => {
+        delete window.CasinoSounds;
+        // No sound module loaded — should not throw.
+        expect(() => {
+            window.TobyCasinoWinSettle.fire({ win: true, net: 100 }, target);
+        }).not.toThrow();
+        // Visual half still runs (CasinoRender is still loaded).
+        expect(target.querySelector('.casino-chip-stack')).not.toBeNull();
+    });
+
+    test('null body is a silent no-op', () => {
+        expect(() => {
+            window.TobyCasinoWinSettle.fire(null, target);
+        }).not.toThrow();
+        expect(playSpy).not.toHaveBeenCalled();
+    });
+});
+
+describe('TobyCasinoWinSettle.defaultChipCount', () => {
+    test('scales with net by /100, floor 3, cap 7', () => {
+        const f = window.TobyCasinoWinSettle.defaultChipCount;
+        expect(f({ net: 50 })).toBe(3);   // floor
+        expect(f({ net: 100 })).toBe(3);  // floor
+        expect(f({ net: 300 })).toBe(3);
+        expect(f({ net: 400 })).toBe(4);
+        expect(f({ net: 700 })).toBe(7);  // cap
+        expect(f({ net: 50000 })).toBe(7); // cap holds
+    });
+
+    test('jackpot payout overrides net when present', () => {
+        const f = window.TobyCasinoWinSettle.defaultChipCount;
+        expect(f({ net: 100, jackpotPayout: 700 })).toBe(7);
+    });
+});

--- a/web/src/test/js/coinflip.test.js
+++ b/web/src/test/js/coinflip.test.js
@@ -55,18 +55,7 @@ describe('renderCoinflipResult', () => {
         expect(resultEl.innerHTML).toContain('+5 to jackpot');
     });
 
-    test('win flashes a chip stack on the table; loss leaves it untouched', () => {
-        renderCoinflipResult(resultEl, {
-            win: true, landed: 'HEADS', predicted: 'HEADS', net: 100,
-        }, tableEl);
-        const stack = tableEl.querySelector('.casino-chip-stack');
-        expect(stack).not.toBeNull();
-        expect(stack.querySelector('.casino-chip-payout').textContent).toBe('+100');
-
-        tableEl.querySelectorAll('.casino-chip-stack').forEach((el) => el.remove());
-        renderCoinflipResult(resultEl, {
-            win: false, landed: 'TAILS', predicted: 'HEADS', net: -50,
-        }, tableEl);
-        expect(tableEl.querySelector('.casino-chip-stack')).toBeNull();
-    });
+    // Chip flourish has moved to casino-win-settle (the shared helper);
+    // covered in casino-win-settle.test.js. renderCoinflipResult now
+    // only owns the result line + class toggling.
 });

--- a/web/src/test/js/dice.test.js
+++ b/web/src/test/js/dice.test.js
@@ -45,14 +45,7 @@ describe('renderDiceResult', () => {
         expect(resultEl.innerHTML).toContain('+10 to jackpot');
     });
 
-    test('win flashes a chip stack on the table; loss leaves it untouched', () => {
-        renderDiceResult(resultEl, { win: true, landed: 4, predicted: 4, net: 500 }, tableEl);
-        const stack = tableEl.querySelector('.casino-chip-stack');
-        expect(stack).not.toBeNull();
-        expect(stack.querySelector('.casino-chip-payout').textContent).toBe('+500');
-
-        tableEl.querySelectorAll('.casino-chip-stack').forEach((el) => el.remove());
-        renderDiceResult(resultEl, { win: false, landed: 2, predicted: 4, net: -100 }, tableEl);
-        expect(tableEl.querySelector('.casino-chip-stack')).toBeNull();
-    });
+    // Chip flourish has moved to casino-win-settle (the shared helper);
+    // covered in casino-win-settle.test.js. renderDiceResult now only
+    // owns the result line + class toggling.
 });

--- a/web/src/test/js/highlow.test.js
+++ b/web/src/test/js/highlow.test.js
@@ -87,20 +87,7 @@ describe('renderHighlowResult', () => {
         expect(resultEl.innerHTML).toContain('+5 to jackpot');
     });
 
-    test('positive net flashes a chip stack on the felt; tie/loss leaves it untouched', () => {
-        // Highlow has no `win` field on the response — net > 0 is the
-        // win signal, so the render fn synthesises it for the helper.
-        renderHighlowResult(resultEl, {
-            anchor: 5, next: 11, direction: 'HIGHER', net: 100, multiplier: 1.5,
-        }, tableEl);
-        const stack = tableEl.querySelector('.casino-chip-stack');
-        expect(stack).not.toBeNull();
-        expect(stack.querySelector('.casino-chip-payout').textContent).toBe('+100');
-
-        tableEl.querySelectorAll('.casino-chip-stack').forEach((el) => el.remove());
-        renderHighlowResult(resultEl, {
-            anchor: 7, next: 7, direction: 'HIGHER', net: -50,
-        }, tableEl);
-        expect(tableEl.querySelector('.casino-chip-stack')).toBeNull();
-    });
+    // Chip flourish has moved to casino-win-settle (the shared helper);
+    // covered in casino-win-settle.test.js. renderHighlowResult now
+    // only owns the result line + class toggling.
 });

--- a/web/src/test/js/keno.test.js
+++ b/web/src/test/js/keno.test.js
@@ -52,7 +52,7 @@ describe('renderKenoResult (synchronous path)', () => {
 
     test('win lights up hit cells with .is-hit, miss cells with .is-drawn, and renders the win line', () => {
         renderKenoResult({
-            resultEl, statusEl, gridEl, flashTargetEl: tableEl,
+            resultEl, statusEl, gridEl,
             stagger: false,
             body: {
                 win: true,
@@ -78,7 +78,7 @@ describe('renderKenoResult (synchronous path)', () => {
 
     test('lose path strips draws of any prior hit class and renders the lose line', () => {
         renderKenoResult({
-            resultEl, statusEl, gridEl, flashTargetEl: tableEl,
+            resultEl, statusEl, gridEl,
             stagger: false,
             body: {
                 win: false,
@@ -97,35 +97,13 @@ describe('renderKenoResult (synchronous path)', () => {
         expect(resultEl.innerHTML).toContain('0/3');
     });
 
-    test('win flashes a chip stack on the flash target; loss leaves it untouched', () => {
-        renderKenoResult({
-            resultEl, statusEl, gridEl, flashTargetEl: tableEl,
-            stagger: false,
-            body: {
-                win: true, picks: [5], draws: [5, 1, 2, 3, 4, 6, 7, 8, 9, 10],
-                hits: 1, multiplier: 3.5, net: 250, payout: 350,
-            },
-        });
-        const stack = tableEl.querySelector('.casino-chip-stack');
-        expect(stack).not.toBeNull();
-        expect(stack.querySelector('.casino-chip-payout').textContent).toBe('+250');
-
-        // Reset and re-test lose: no chip stack should be added.
-        tableEl.querySelectorAll('.casino-chip-stack').forEach((el) => el.remove());
-        renderKenoResult({
-            resultEl, statusEl, gridEl, flashTargetEl: tableEl,
-            stagger: false,
-            body: {
-                win: false, picks: [5], draws: [1, 2, 3, 4, 6, 7, 8, 9, 10, 11],
-                hits: 0, net: -50,
-            },
-        });
-        expect(tableEl.querySelector('.casino-chip-stack')).toBeNull();
-    });
+    // Chip flourish has moved to casino-win-settle (the shared helper);
+    // covered in casino-win-settle.test.js. renderKenoResult now only
+    // owns the result line + status text + grid decoration.
 
     test('jackpot win prepends the JACKPOT banner', () => {
         renderKenoResult({
-            resultEl, statusEl, gridEl, flashTargetEl: tableEl,
+            resultEl, statusEl, gridEl,
             stagger: false,
             body: {
                 win: true, picks: [5], draws: [5, 1, 2, 3, 4, 6, 7, 8, 9, 10],
@@ -139,7 +117,7 @@ describe('renderKenoResult (synchronous path)', () => {
 
     test('lose with lossTribute appends "+N to jackpot" suffix', () => {
         renderKenoResult({
-            resultEl, statusEl, gridEl, flashTargetEl: tableEl,
+            resultEl, statusEl, gridEl,
             stagger: false,
             body: {
                 win: false, picks: [5], draws: [1, 2, 3, 4, 6, 7, 8, 9, 10, 11],
@@ -171,7 +149,7 @@ describe('renderKenoResult (staged path)', () => {
 
     test('synchronous path returns undefined (no Promise)', () => {
         const ret = renderKenoResult({
-            resultEl, statusEl, gridEl, flashTargetEl: tableEl,
+            resultEl, statusEl, gridEl,
             stagger: false,
             body: {
                 win: false, picks: [1], draws: [2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
@@ -185,7 +163,7 @@ describe('renderKenoResult (staged path)', () => {
         jest.useFakeTimers();
         try {
             const ret = renderKenoResult({
-                resultEl, statusEl, gridEl, flashTargetEl: tableEl,
+                resultEl, statusEl, gridEl,
                 stagger: true, dealMs: 50,
                 body: {
                     win: true, picks: [1], draws: [1, 2, 3],
@@ -217,7 +195,7 @@ describe('renderKenoResult (staged path)', () => {
         jest.useFakeTimers();
         try {
             renderKenoResult({
-                resultEl, statusEl, gridEl, flashTargetEl: tableEl,
+                resultEl, statusEl, gridEl,
                 stagger: true, dealMs: 50,
                 body: {
                     win: true,
@@ -243,15 +221,17 @@ describe('renderKenoResult (staged path)', () => {
             expect(gridEl.querySelectorAll('.is-drawn').length).toBe(0);
             expect(resultEl.hidden).toBe(true);
 
-            // Past the deal sequence (3 cells × 50ms = 150ms), but before
-            // flashChipsOn's 2.5s safety-cleanup timer would remove the
-            // chip stack.
+            // Past the deal sequence (3 cells × 50ms = 150ms): the
+            // result line + status are now committed. The chip stack is
+            // dropped by the casino-win-settle helper, fired by
+            // casino-game.js after the staged-reveal Promise resolves
+            // — that's an integration concern for casino-game tests,
+            // not this pure-render unit.
             jest.advanceTimersByTime(200);
             expect(gridEl.querySelector('.keno-cell[data-value="2"]').classList.contains('is-hit')).toBe(true);
             expect(resultEl.hidden).toBe(false);
             expect(resultEl.classList.contains('keno-result-win')).toBe(true);
             expect(statusEl.textContent).toContain('2 of 3 hit');
-            expect(tableEl.querySelector('.casino-chip-stack')).not.toBeNull();
         } finally {
             jest.useRealTimers();
         }

--- a/web/src/test/js/roulette.test.js
+++ b/web/src/test/js/roulette.test.js
@@ -99,16 +99,9 @@ describe('renderRouletteResult', () => {
         expect(() => renderRouletteResult(null, { win: true })).not.toThrow();
     });
 
-    test('drops a chip stack on the table felt for a win', () => {
-        renderRouletteResult(resultEl, {
-            win: true, net: 350, multiplier: 36,
-            bet: 'STRAIGHT', betLabel: 'Straight', landed: 17, color: 'BLACK',
-        }, tableEl);
-
-        const stack = tableEl.querySelector('.casino-chip-stack');
-        expect(stack).not.toBeNull();
-        expect(stack.querySelector('.casino-chip-payout').textContent).toBe('+350');
-    });
+    // Chip flourish has moved to casino-win-settle (the shared helper);
+    // covered in casino-win-settle.test.js. renderRouletteResult now
+    // only owns the result line + class toggling.
 });
 
 describe('setBetInputsDisabled', () => {

--- a/web/src/test/js/scratch.test.js
+++ b/web/src/test/js/scratch.test.js
@@ -67,20 +67,7 @@ describe('renderScratchResult', () => {
         expect(resultEl.innerHTML).toContain('+10 to jackpot');
     });
 
-    test('positive net flashes a chip stack on the felt; loss leaves it untouched', () => {
-        // Scratch's response has no `win` field — net > 0 is the win
-        // signal, so the render fn synthesises it for the helper.
-        renderScratchResult(resultEl, {
-            matchCount: 5, winningSymbol: '⭐', net: 200, newBalance: 1_200,
-        }, 5, balanceEl, tableEl);
-        const stack = tableEl.querySelector('.casino-chip-stack');
-        expect(stack).not.toBeNull();
-        expect(stack.querySelector('.casino-chip-payout').textContent).toBe('+200');
-
-        tableEl.querySelectorAll('.casino-chip-stack').forEach((el) => el.remove());
-        renderScratchResult(resultEl, {
-            net: -100, newBalance: 950,
-        }, 5, balanceEl, tableEl);
-        expect(tableEl.querySelector('.casino-chip-stack')).toBeNull();
-    });
+    // Chip flourish has moved to casino-win-settle (the shared helper);
+    // covered in casino-win-settle.test.js. renderScratchResult now
+    // only owns the result line + class toggling + balance update.
 });

--- a/web/src/test/js/slots.test.js
+++ b/web/src/test/js/slots.test.js
@@ -87,25 +87,24 @@ describe('renderSlotsResult', () => {
         expect(resultEl.innerHTML).not.toContain('to jackpot');
     });
 
-    test('win lights up every reel with .win-cell and drops a chip stack on the machine', () => {
+    test('win lights up every reel with .win-cell', () => {
+        // Chip flourish is now owned by the shared casino-win-settle
+        // helper (fired from casino-game.js after renderResult). The
+        // per-reel gold halo is the slots-specific bit and stays here.
         renderSlotsResult(resultEl, {
             win: true, multiplier: 5, net: 400, symbols: ['🍒', '🍒', '🍒']
-        }, machineEl, reels);
+        }, reels);
 
         reels.forEach((r) => expect(r.classList.contains('win-cell')).toBe(true));
-        const stack = machineEl.querySelector('.casino-chip-stack');
-        expect(stack).not.toBeNull();
-        expect(stack.querySelector('.casino-chip-payout').textContent).toBe('+400');
     });
 
-    test('lose strips any prior .win-cell highlight and leaves the machine clean', () => {
+    test('lose strips any prior .win-cell highlight', () => {
         // Pretend the previous spin won — the new lose render should clear it.
         reels.forEach((r) => r.classList.add('win-cell'));
         renderSlotsResult(resultEl, {
             win: false, net: -100, symbols: ['🍒', '🍋', '⭐']
-        }, machineEl, reels);
+        }, reels);
 
         reels.forEach((r) => expect(r.classList.contains('win-cell')).toBe(false));
-        expect(machineEl.querySelector('.casino-chip-stack')).toBeNull();
     });
 });

--- a/web/src/test/kotlin/web/template/CasinoMinigameTemplatesTest.kt
+++ b/web/src/test/kotlin/web/template/CasinoMinigameTemplatesTest.kt
@@ -1,0 +1,140 @@
+package web.template
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+
+/**
+ * Guards the script-loading contract for every casino minigame page.
+ *
+ * Before this test landed, six of nine minigame templates (slots,
+ * coinflip, dice, highlow, scratch, roulette) silently never loaded
+ * `casino-render.js` — which meant the chip-stack flourish on a win
+ * never fired in production for those games. Each template was
+ * supposed to add `<script src="/js/casino-render.js">` after the
+ * shared fragment, and most authors forgot. The fix was to hoist
+ * casino-render into the shared `~{fragments/casinoMinigame ::
+ * scripts}` block; this test pins that hoist in place so the next
+ * minigame author can't accidentally reintroduce the gap.
+ *
+ * Two assertions per template:
+ *   1. The template uses the shared fragment include. A new minigame
+ *      that hand-rolls its own script block (as keno did before this
+ *      cleanup) misses every shared module added since: sounds,
+ *      jackpot pool banner, balance flourish, win-settle, dom helpers,
+ *      anti-autoclicker telemetry. The fragment is the single source
+ *      of truth for "what scripts a casino game needs".
+ *   2. The template does NOT load casino-render.js explicitly. If the
+ *      shared fragment already loads it (which it does, post-#427's
+ *      successor PR), an explicit re-load is dead weight and a
+ *      subtle hint that the author copy-pasted from a stale example.
+ *
+ * Scope is the per-game minigame templates only — lobby pages
+ * (poker-lobby, blackjack-lobby) deliberately don't include the
+ * minigame fragment because they're picker pages.
+ */
+class CasinoMinigameTemplatesTest {
+
+    private val templatesRoot: Path = Paths.get("src/main/resources/templates")
+        .takeIf { Files.exists(it) }
+        ?: Paths.get("web/src/main/resources/templates")
+
+    private val minigameTemplates = listOf(
+        "slots.html",
+        "coinflip.html",
+        "dice.html",
+        "highlow.html",
+        "scratch.html",
+        "keno.html",
+        "roulette.html",
+        "baccarat.html",
+        "casinoholdem-solo.html",
+    )
+
+    @Test
+    fun `every minigame template includes the shared casinoMinigame scripts fragment`() {
+        val missing = minigameTemplates.filter { name ->
+            val path = templatesRoot.resolve(name)
+            assertTrue(Files.exists(path), "missing template: $path")
+            !Files.readString(path).contains("fragments/casinoMinigame :: scripts")
+        }
+        assertTrue(
+            missing.isEmpty(),
+            "These minigame templates do not include the shared " +
+                "`fragments/casinoMinigame :: scripts` block, so they are " +
+                "missing every shared module added to the fragment " +
+                "(casino-sounds, casino-render, casino-win-settle, " +
+                "casino-game, casino-bot-suspicion, etc.). Replace the " +
+                "ad-hoc <script> block with " +
+                "`<th:block th:replace=\"~{fragments/casinoMinigame :: scripts}\"></th:block>`: " +
+                "$missing"
+        )
+    }
+
+    @Test
+    fun `no minigame template loads casino-render explicitly (it lives in the shared fragment)`() {
+        val redundant = minigameTemplates.filter { name ->
+            val path = templatesRoot.resolve(name)
+            Files.readString(path).contains("/js/casino-render.js")
+        }
+        assertTrue(
+            redundant.isEmpty(),
+            "These minigame templates load `casino-render.js` explicitly. " +
+                "It now lives in the shared `casinoMinigame :: scripts` fragment, so " +
+                "an explicit reload is dead weight (and a hint the template " +
+                "was copy-pasted from a pre-fix example): $redundant"
+        )
+    }
+
+    @Test
+    fun `shared fragment loads every script a minigame depends on`() {
+        // Belt-and-braces: pin the script list in the fragment so
+        // dropping one won't go unnoticed. The order matters too —
+        // win-settle reads CasinoSounds + CasinoRender, game reads
+        // win-settle, dom is read by per-game IIFEs at module load,
+        // bot-suspicion is read by the games that opt in.
+        val fragmentPath = templatesRoot.resolve("fragments/casinoMinigame.html")
+        assertTrue(Files.exists(fragmentPath), "missing fragment: $fragmentPath")
+        val content = Files.readString(fragmentPath)
+
+        val required = listOf(
+            "/js/api.js",
+            "/js/toasts.js",
+            "/js/casino-sounds.js",
+            "/js/casino-jackpot.js",
+            "/js/casino-balance.js",
+            "/js/casino-topup.js",
+            "/js/casino-result.js",
+            "/js/casino-render.js",
+            "/js/casino-win-settle.js",
+            "/js/casino-game.js",
+            "/js/casino-minigame-dom.js",
+            "/js/casino-bot-suspicion.js",
+        )
+        val missing = required.filter { !content.contains(it) }
+        assertTrue(
+            missing.isEmpty(),
+            "Shared casino-minigame fragment is missing required scripts: $missing. " +
+                "If a script was deliberately removed, update this test alongside " +
+                "the per-game expectation it implies."
+        )
+
+        // Order check: render must come before win-settle (helper reads
+        // it), win-settle before game (helper auto-fires from inside
+        // game.js's renderResult chain).
+        val renderIdx = content.indexOf("casino-render.js")
+        val winSettleIdx = content.indexOf("casino-win-settle.js")
+        val gameIdx = content.indexOf("casino-game.js")
+        assertFalse(
+            renderIdx > winSettleIdx,
+            "casino-render.js must load before casino-win-settle.js"
+        )
+        assertFalse(
+            winSettleIdx > gameIdx,
+            "casino-win-settle.js must load before casino-game.js"
+        )
+    }
+}


### PR DESCRIPTION
## Summary

The minigames were supposed to have parity on three things: win sound, loss sound, coin animation, and a global mute toggle. The JS in every game called the right APIs, but the runtime audit revealed something worse:

**Six of nine minigame templates (slots, coinflip, dice, highlow, scratch, roulette) silently never loaded `casino-render.js` in production**, so the chip-stack flourish on a win has been a no-op on those games for months. The user's "scratch lacks the animation" intuition was right — and the same was true for five other games. **Casinoholdem's URL move in #419** also deserved smoke coverage we didn't have, which is what surfaced the broader breakage.

This PR fixes the three disparities, hoists what should never have been per-template loose scripts, and adds two tests so future games can't regress.

## What changed

### 1. `casino-render.js` hoisted into the shared fragment

`~{fragments/casinoMinigame :: scripts}` now loads `casino-render.js`, `casino-win-settle.js`, and the rest of the cross-cutting modules. Every minigame gets the chip primitives by default — the forget-by-default loophole that hid this bug is closed. Stripped now-redundant explicit `casino-render.js` loads from `baccarat.html` and `casinoholdem-solo.html`. Converted `keno.html`'s hand-rolled script block to the shared fragment (it was missing five other modules too: `casino-bot-suspicion`, `casino-minigame-dom`, `casino-win-settle`, etc.).

### 2. New `casino-win-settle.js` shared helper

Owns the "play win-or-lose cue + drop a chip flourish on the felt" pair. Every minigame used to call `CasinoSounds.play('win'/'lose')` + `CasinoRender.flashWinPayout(...)` by hand. `casino-game.js` now auto-fires the helper after `renderResult` settles, driven by a new `flashTarget` opt. Per-game JS shrinks to game-specific visuals only. Push (baccarat tie) is handled — neither cue fires. Synthesises `win` from `net > 0` for games whose response lacks the field (highlow, scratch). Custom flows (scratch's user-driven reveal) opt out via `autoWinSettle: false` and call `game.applyWinSettle(body, override)` at the right moment.

### 3. Scratch win UX tuned

While we were there: chip-burst now lands on `#scratch-cells` (where the eye has been scratching) instead of the wider `.scratch-table`. Jackpot wins get a 10-chip stack vs the regular 7 cap so the "this is a big one" reads bigger. Both via the helper's `chipCount(body)` override.

### 4. Click-sound parity

Highlow, baccarat, and casinoholdem now play `'click'` at the start of a round so every minigame has the same "round started" audio anchor.

### 5. Two regression-guard tests

**`CasinoMinigameTemplatesTest`** — every per-game template must include the shared fragment, must not load `casino-render.js` explicitly (it's in the fragment), and the fragment itself must keep its required script list + the `render-before-win-settle-before-game` ordering. Catches the exact failure mode that hid this bug: a new minigame template forgetting a script.

**`PageRenderSmokeIT` expansion** — added `/casino/1/keno`, `/roulette`, `/baccarat`, `/casinoholdem`, `/lottery` to the smoke routes. Five routes that weren't smoked before; that's why casinoholdem's URL move in #419 went unnoticed. Future template moves now surface in CI.

Plus `casino-win-settle.test.js` covering the helper directly: win/lose selection (from `body.win` or synthesised from `net > 0`), push suppression, jackpot payout priority, `chipCount` override, missing-dependency tolerance.

## Test plan

- [x] `npm test` — 366 jest tests pass (existing per-game render tests trimmed to assert only their game-specific bits; chip-stack assertions migrated to the shared `casino-win-settle.test.js`).
- [x] `npm run lint:css` — clean.
- [x] `./gradlew :web:test` — passes; the new `CasinoMinigameTemplatesTest` enforces the fragment contract.
- [ ] CI `:application:test` — `PageRenderSmokeIT` will run `/casino/1/{slots,dice,coinflip,highlow,scratch,keno,roulette,baccarat,casinoholdem,lottery}` plus all the existing routes. Watch for any 5xx that comes back.
- [ ] Run the app locally; play each minigame in turn:
  - Win → win sound + chip flourish on the right surface.
  - Loss → lose sound, no chips.
  - Click the global 🔊/🔇 toggle, replay; both cues silent. Refresh the page; mute persists.
  - Highlow / baccarat / casinoholdem now play `click` on bet submit.
  - Scratch jackpot win shows a fuller chip stack on the cells (not the wider table).

https://claude.ai/code/session_01GAVMLpP2CsESghD66LXmhV

---
_Generated by [Claude Code](https://claude.ai/code/session_01GAVMLpP2CsESghD66LXmhV)_