### PR TITLE
feat(lottery): wide-ping + clickable buy CTA on daily announcement, rich top-holders on web

### DIFF
--- a/database/src/main/kotlin/database/dto/ConfigDto.kt
+++ b/database/src/main/kotlin/database/dto/ConfigDto.kt
@@ -264,7 +264,14 @@ class ConfigDto(
         // when blank/unset the announcer falls back to LEADERBOARD_CHANNEL,
         // then the guild's system channel. Resolution mirrors the
         // monthly leaderboard job's pattern.
-        LOTTERY_CHANNEL("LOTTERY_CHANNEL");
+        LOTTERY_CHANNEL("LOTTERY_CHANNEL"),
+
+        // Wide-ping mode for the daily lottery announcement. One of
+        // "OFF" (no wide ping — winners still pinged), "HERE" (@here —
+        // online members only), or "EVERYONE" (@everyone — all members).
+        // Defaults to "EVERYONE" so a fresh-install guild gets the most
+        // visible nudge to buy tickets; admins can dial it down per-server.
+        LOTTERY_PING_MODE("LOTTERY_PING_MODE");
     }
 
     override fun toString(): String {

--- a/database/src/main/kotlin/database/service/LotteryHelper.kt
+++ b/database/src/main/kotlin/database/service/LotteryHelper.kt
@@ -169,4 +169,27 @@ object LotteryHelper {
         )
         return cfg?.value?.trim()?.takeIf { it.isNotEmpty() }?.toLongOrNull()
     }
+
+    /** Wide-ping modes for the daily lottery announcement. */
+    const val PING_OFF: String = "OFF"
+    const val PING_HERE: String = "HERE"
+    const val PING_EVERYONE: String = "EVERYONE"
+    const val DEFAULT_PING_MODE: String = PING_EVERYONE
+
+    /**
+     * Live wide-ping mode for the daily lottery announcement. Returns
+     * one of [PING_OFF], [PING_HERE], [PING_EVERYONE]; unknown / unset
+     * values fall back to [DEFAULT_PING_MODE] so a fresh guild gets the
+     * loudest possible nudge.
+     */
+    fun lotteryPingMode(configService: ConfigService, guildId: Long): String {
+        val raw = configService.getConfigByName(
+            ConfigDto.Configurations.LOTTERY_PING_MODE.configValue,
+            guildId.toString()
+        )?.value?.trim()?.uppercase()
+        return when (raw) {
+            PING_OFF, PING_HERE, PING_EVERYONE -> raw
+            else -> DEFAULT_PING_MODE
+        }
+    }
 }

--- a/database/src/test/kotlin/database/service/LotteryHelperPingModeTest.kt
+++ b/database/src/test/kotlin/database/service/LotteryHelperPingModeTest.kt
@@ -1,0 +1,76 @@
+package database.service
+
+import database.dto.ConfigDto
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * Read-time semantics for [LotteryHelper.lotteryPingMode]. Drives the
+ * wide-ping prefix (`@everyone` / `@here` / nothing) on the daily
+ * lottery announcement; an unknown / missing value must fall back to
+ * the loudest mode so a fresh-install guild still pings everyone — the
+ * whole point of the config is to dial that DOWN, not silently hide
+ * the announcement.
+ */
+class LotteryHelperPingModeTest {
+
+    private val guildId = 7L
+    private val key = ConfigDto.Configurations.LOTTERY_PING_MODE
+
+    private lateinit var configService: ConfigService
+
+    @BeforeEach
+    fun setup() {
+        configService = mockk()
+    }
+
+    private fun stored(value: String?) {
+        every { configService.getConfigByName(key.configValue, guildId.toString()) } returns
+            value?.let { ConfigDto(name = key.configValue, value = it, guildId = guildId.toString()) }
+    }
+
+    @Test
+    fun `defaults to EVERYONE when row is missing`() {
+        stored(null)
+        assertEquals(LotteryHelper.PING_EVERYONE, LotteryHelper.lotteryPingMode(configService, guildId))
+    }
+
+    @Test
+    fun `falls back to EVERYONE on unknown value`() {
+        stored("LOUD")
+        assertEquals(LotteryHelper.PING_EVERYONE, LotteryHelper.lotteryPingMode(configService, guildId))
+    }
+
+    @Test
+    fun `parses OFF`() {
+        stored("OFF")
+        assertEquals(LotteryHelper.PING_OFF, LotteryHelper.lotteryPingMode(configService, guildId))
+    }
+
+    @Test
+    fun `parses HERE`() {
+        stored("HERE")
+        assertEquals(LotteryHelper.PING_HERE, LotteryHelper.lotteryPingMode(configService, guildId))
+    }
+
+    @Test
+    fun `parses EVERYONE`() {
+        stored("EVERYONE")
+        assertEquals(LotteryHelper.PING_EVERYONE, LotteryHelper.lotteryPingMode(configService, guildId))
+    }
+
+    @Test
+    fun `is case-insensitive`() {
+        stored("here")
+        assertEquals(LotteryHelper.PING_HERE, LotteryHelper.lotteryPingMode(configService, guildId))
+    }
+
+    @Test
+    fun `trims whitespace`() {
+        stored("  OFF  ")
+        assertEquals(LotteryHelper.PING_OFF, LotteryHelper.lotteryPingMode(configService, guildId))
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/moderation/SetConfigCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/moderation/SetConfigCommand.kt
@@ -213,6 +213,9 @@ class SetConfigCommand @Autowired constructor(
                 ConfigDto.Configurations.LOTTERY_CHANNEL -> setLotteryChannel(
                     event, optionMapping, deleteDelay
                 )
+                ConfigDto.Configurations.LOTTERY_PING_MODE -> setLotteryPingMode(
+                    event, optionMapping, deleteDelay
+                )
                 // Anti-autoclicker session log channel — managed primarily
                 // via the /moderation web tab; arm stays exhaustive in case
                 // the option is registered manually.
@@ -322,6 +325,25 @@ class SetConfigCommand @Autowired constructor(
             ConfigDto.Configurations.LOTTERY_DAILY_MODE.configValue, raw, guildId
         )
         event.hook.sendMessage("Daily lottery mode set to $raw.")
+            .queue(invokeDeleteOnMessageResponse(deleteDelay))
+    }
+
+    private fun setLotteryPingMode(
+        event: SlashCommandInteractionEvent,
+        optionMapping: OptionMapping,
+        deleteDelay: Int,
+    ) {
+        val raw = optionMapping.asString.trim().uppercase()
+        if (raw !in setOf("OFF", "HERE", "EVERYONE")) {
+            event.hook.sendMessage("Lottery ping mode must be OFF, HERE, or EVERYONE.")
+                .setEphemeral(true).queue(invokeDeleteOnMessageResponse(deleteDelay))
+            return
+        }
+        val guildId = event.guild?.id ?: return
+        configService.upsertConfig(
+            ConfigDto.Configurations.LOTTERY_PING_MODE.configValue, raw, guildId
+        )
+        event.hook.sendMessage("Lottery announcement ping set to $raw.")
             .queue(invokeDeleteOnMessageResponse(deleteDelay))
     }
 

--- a/discord-bot/src/main/kotlin/bot/toby/scheduling/LotteryAnnouncer.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/scheduling/LotteryAnnouncer.kt
@@ -6,8 +6,10 @@ import database.service.ConfigService
 import database.service.JackpotLotteryService
 import database.service.LotteryHelper
 import net.dv8tion.jda.api.EmbedBuilder
+import net.dv8tion.jda.api.JDA
 import net.dv8tion.jda.api.Permission
 import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.Message
 import net.dv8tion.jda.api.entities.MessageEmbed
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
 import org.springframework.beans.factory.annotation.Autowired
@@ -26,16 +28,38 @@ import java.awt.Color
  *   3. `guild.systemChannel` if writable
  *   4. Skip with warn log if none
  *
- * Pings: winners' discord ids appear in the message **content** via
- * [`MessageCreateAction.addContent`] (loud notification) and again in
- * the embed body for visual context (silent there). Non-winning
- * variants (BelowMinBuyers, NoTickets) skip the addContent ping
- * entirely so a buyer-less day stays quiet.
+ * Message content layout (each line is optional except the call-to-action):
+ *   ```
+ *   @everyone | @here | (none)   ← LOTTERY_PING_MODE per guild
+ *   🎟️ A new draw is open — buy with </lottery buy:ID>
+ *   Congrats: <@winner1> <@winner2>            ← only when there are winners
+ *   ```
+ *
+ * The wide ping defaults to `@everyone` so a fresh-install guild gets
+ * the loudest possible nudge to actually buy tickets; admins dial it
+ * down via the `LOTTERY_PING_MODE` config (see [LotteryHelper.lotteryPingMode]).
+ * The slash-command mention is a clickable shortcut into `/lottery buy`;
+ * if JDA can't resolve the command id (cold start, retrieval failure)
+ * we fall back to a plain `` `/lottery buy` `` so the embed still ships.
+ *
+ * `setAllowedMentions` is set explicitly on every send: USER is always
+ * allowed (so winners get pinged), and EVERYONE is added only when the
+ * content actually contains `@everyone`/`@here`. Without that, Discord
+ * silently strips the wide ping.
  */
 @Component
 class LotteryAnnouncer @Autowired constructor(
     private val configService: ConfigService,
 ) {
+
+    /**
+     * Lazily-resolved id of the global `lottery` slash command. Cached
+     * for process lifetime — command ids only change on a fresh
+     * `updateCommands` call (i.e. another process restart). Volatile
+     * so a happens-before relationship is established between the
+     * resolver thread and any later announce-thread reader.
+     */
+    @Volatile private var cachedLotteryCommandId: Long? = null
     private val logger: DiscordLogger = DiscordLogger.createLogger(this::class.java)
 
     /**
@@ -58,11 +82,12 @@ class LotteryAnnouncer @Autowired constructor(
             return
         }
         val embed = buildEmbed(guild, mode, priorOutcome, openOutcome)
-        val pingIds = winnerPingIds(priorOutcome)
+        val content = buildAnnouncementContent(guild, priorOutcome)
         runCatching {
             val send = channel.sendMessageEmbeds(embed)
-            if (pingIds.isNotEmpty()) {
-                send.addContent(pingIds.joinToString(" ") { "<@$it>" })
+                .setAllowedMentions(allowedMentionTypes(content))
+            if (content.isNotBlank()) {
+                send.addContent(content)
             }
             send.queue()
         }.onFailure {
@@ -204,7 +229,77 @@ class LotteryAnnouncer @Autowired constructor(
         else -> emptyList()
     }
 
+    // ---- announcement content (wide ping + buy CTA + winner pings) ----
+
+    /**
+     * Assemble the message content posted alongside the embed. Always
+     * includes a call-to-action with a clickable `/lottery buy` mention;
+     * optionally prefixes a wide ping per [LotteryHelper.lotteryPingMode];
+     * appends per-winner pings on a third line when the prior outcome had
+     * winners. Newline-separated so Discord renders each on its own row.
+     */
+    private fun buildAnnouncementContent(guild: Guild, prior: PriorOutcome?): String {
+        val lines = mutableListOf<String>()
+        val cta = "🎟️ A new daily lottery is open — buy in with ${slashBuyMention(guild.jda)}!"
+        val pingPrefix = widePingPrefix(guild)
+        lines += if (pingPrefix != null) "$pingPrefix $cta" else cta
+        val winners = winnerPingIds(prior)
+        if (winners.isNotEmpty()) {
+            lines += "Congrats: " + winners.joinToString(" ") { "<@$it>" }
+        }
+        return lines.joinToString("\n")
+    }
+
+    /** `@everyone` / `@here` / `null`, per the guild's `LOTTERY_PING_MODE`. */
+    private fun widePingPrefix(guild: Guild): String? =
+        when (LotteryHelper.lotteryPingMode(configService, guild.idLong)) {
+            LotteryHelper.PING_HERE -> "@here"
+            LotteryHelper.PING_EVERYONE -> "@everyone"
+            else -> null  // PING_OFF
+        }
+
+    /**
+     * Render a clickable `</lottery buy:ID>` slash-command mention, or
+     * fall back to plain `` `/lottery buy` `` when the id is unresolvable
+     * (cold start, retrieval failure). Falling back keeps the embed
+     * shipping rather than failing the whole announce.
+     */
+    private fun slashBuyMention(jda: JDA): String {
+        val id = lotteryBuyCommandId(jda)
+        return if (id != null) "</$LOTTERY_COMMAND_NAME $LOTTERY_BUY_SUBCOMMAND:$id>" else "`/$LOTTERY_COMMAND_NAME $LOTTERY_BUY_SUBCOMMAND`"
+    }
+
+    private fun lotteryBuyCommandId(jda: JDA): Long? {
+        cachedLotteryCommandId?.let { return it }
+        val resolved = runCatching {
+            jda.retrieveCommands().complete()
+                .firstOrNull { it.name == LOTTERY_COMMAND_NAME }
+                ?.idLong
+        }.onFailure {
+            logger.warn("Could not resolve /$LOTTERY_COMMAND_NAME slash command id: ${it.message}")
+        }.getOrNull()
+        if (resolved != null) cachedLotteryCommandId = resolved
+        return resolved
+    }
+
+    /**
+     * Always allow USER mentions (winner pings); only allow EVERYONE
+     * (which covers both `@everyone` and `@here` in JDA) when the
+     * content actually contains one. JDA's default would silently strip
+     * `@everyone`/`@here` from `addContent`, so omitting this call would
+     * make `LOTTERY_PING_MODE` a no-op.
+     */
+    private fun allowedMentionTypes(content: String): Set<Message.MentionType> {
+        val types = mutableSetOf(Message.MentionType.USER)
+        if (content.contains("@everyone") || content.contains("@here")) {
+            types += Message.MentionType.EVERYONE
+        }
+        return types
+    }
+
     companion object {
         private val REQUIRED_PERMS = arrayOf(Permission.MESSAGE_SEND, Permission.MESSAGE_EMBED_LINKS)
+        private const val LOTTERY_COMMAND_NAME = "lottery"
+        private const val LOTTERY_BUY_SUBCOMMAND = "buy"
     }
 }

--- a/discord-bot/src/test/kotlin/bot/toby/scheduling/LotteryAnnouncerTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/scheduling/LotteryAnnouncerTest.kt
@@ -9,12 +9,15 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
+import net.dv8tion.jda.api.JDA
 import net.dv8tion.jda.api.Permission
 import net.dv8tion.jda.api.entities.Guild
-import net.dv8tion.jda.api.entities.SelfMember
+import net.dv8tion.jda.api.entities.Message
 import net.dv8tion.jda.api.entities.MessageEmbed
+import net.dv8tion.jda.api.entities.SelfMember
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
 import net.dv8tion.jda.api.requests.restaction.MessageCreateAction
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -25,7 +28,10 @@ import org.junit.jupiter.api.Test
  * Tests focus on:
  *   - Resolution chain: LOTTERY_CHANNEL → LEADERBOARD_CHANNEL → system
  *   - Embed body: per-PriorOutcome variant produces distinct copy
- *   - Pings: addContent only fires when there's a winner to mention
+ *   - Content: wide ping prefix from LOTTERY_PING_MODE (off / here /
+ *     everyone), CTA with `/lottery buy` mention, winner pings
+ *   - AllowedMentions: USER always, EVERYONE only when content has the
+ *     wide ping (otherwise Discord silently strips it)
  *   - No-op when no writable channel resolves
  */
 class LotteryAnnouncerTest {
@@ -33,6 +39,7 @@ class LotteryAnnouncerTest {
     private val guildId = 100L
     private lateinit var configService: ConfigService
     private lateinit var guild: Guild
+    private lateinit var jda: JDA
     private lateinit var bot: SelfMember
     private lateinit var channel: TextChannel
     private lateinit var sendAction: MessageCreateAction
@@ -42,6 +49,7 @@ class LotteryAnnouncerTest {
     fun setup() {
         configService = mockk(relaxed = true)
         guild = mockk(relaxed = true)
+        jda = mockk(relaxed = true)
         bot = mockk(relaxed = true)
         channel = mockk(relaxed = true)
         sendAction = mockk(relaxed = true)
@@ -50,10 +58,15 @@ class LotteryAnnouncerTest {
         every { guild.id } returns guildId.toString()
         every { guild.name } returns "Test Guild"
         every { guild.selfMember } returns bot
+        every { guild.jda } returns jda
+        // Slash-command id resolution falls back to plain `/lottery buy`
+        // text when retrieval fails — simplest stub for tests.
+        every { jda.retrieveCommands() } throws RuntimeException("test: skip slash mention resolution")
         every { bot.hasPermission(channel, *anyVararg<Permission>()) } returns true
         every { channel.id } returns "777"
         every { channel.sendMessageEmbeds(any<MessageEmbed>()) } returns sendAction
         every { sendAction.addContent(any()) } returns sendAction
+        every { sendAction.setAllowedMentions(any<Collection<Message.MentionType>>()) } returns sendAction
         every { sendAction.queue() } just Runs
 
         announcer = LotteryAnnouncer(configService)
@@ -172,11 +185,13 @@ class LotteryAnnouncerTest {
     }
 
     @Test
-    fun `BelowMinBuyers shows have-need copy and skips the addContent ping`() {
+    fun `BelowMinBuyers shows have-need copy and still posts CTA + wide ping`() {
         stubChannelConfig(ConfigDto.Configurations.LOTTERY_CHANNEL, "777")
         every { guild.getTextChannelById(777L) } returns channel
         val embedSlot = slot<MessageEmbed>()
+        val contentSlot = slot<String>()
         every { channel.sendMessageEmbeds(capture(embedSlot)) } returns sendAction
+        every { sendAction.addContent(capture(contentSlot)) } returns sendAction
 
         announcer.announceCycle(
             guild, mode = "WEIGHTED",
@@ -189,16 +204,22 @@ class LotteryAnnouncerTest {
         val embedDescription = embedSlot.captured.fields.joinToString(" ") { (it.value ?: "") }
         assertTrue(embedDescription.contains("1") && embedDescription.contains("2"))
         assertTrue(embedDescription.lowercase().contains("buyer"))
-        // No winners → no addContent ping at all.
-        verify(exactly = 0) { sendAction.addContent(any()) }
+        // Default ping mode = EVERYONE → wide ping + CTA still goes out
+        // (this is exactly the case where we want to nudge people to buy).
+        assertTrue(contentSlot.captured.contains("@everyone"))
+        assertTrue(contentSlot.captured.contains("/lottery buy"))
+        // No winners → no per-winner mention line.
+        assertFalse(contentSlot.captured.contains("Congrats:"))
     }
 
     @Test
-    fun `NoTickets renders a distinct copy and skips the ping`() {
+    fun `NoTickets renders a distinct copy and still posts CTA + wide ping`() {
         stubChannelConfig(ConfigDto.Configurations.LOTTERY_CHANNEL, "777")
         every { guild.getTextChannelById(777L) } returns channel
         val embedSlot = slot<MessageEmbed>()
+        val contentSlot = slot<String>()
         every { channel.sendMessageEmbeds(capture(embedSlot)) } returns sendAction
+        every { sendAction.addContent(capture(contentSlot)) } returns sendAction
 
         announcer.announceCycle(
             guild, mode = "NUMBER_MATCH",
@@ -210,7 +231,92 @@ class LotteryAnnouncerTest {
 
         val embedDescription = embedSlot.captured.fields.joinToString(" ") { (it.value ?: "") }
         assertTrue(embedDescription.lowercase().contains("no tickets"))
-        verify(exactly = 0) { sendAction.addContent(any()) }
+        assertTrue(contentSlot.captured.contains("@everyone"))
+        assertTrue(contentSlot.captured.contains("/lottery buy"))
+        assertFalse(contentSlot.captured.contains("Congrats:"))
+    }
+
+    // ---- ping-mode dispatch ----
+
+    @Test
+    fun `PING_MODE=HERE uses @here prefix instead of @everyone`() {
+        stubChannelConfig(ConfigDto.Configurations.LOTTERY_CHANNEL, "777")
+        stubChannelConfig(ConfigDto.Configurations.LOTTERY_PING_MODE, "HERE")
+        every { guild.getTextChannelById(777L) } returns channel
+        val contentSlot = slot<String>()
+        every { sendAction.addContent(capture(contentSlot)) } returns sendAction
+
+        announcer.announceCycle(
+            guild, mode = "WEIGHTED",
+            priorOutcome = LotteryAnnouncer.PriorOutcome.NoTickets,
+            openOutcome = LotteryAnnouncer.OpenSummary.Ok(
+                seeded = 500L, ticketPrice = 50L, poolAmount = 500L,
+            ),
+        )
+
+        assertTrue(contentSlot.captured.contains("@here"))
+        assertFalse(contentSlot.captured.contains("@everyone"))
+    }
+
+    @Test
+    fun `PING_MODE=OFF still posts CTA but no wide ping`() {
+        stubChannelConfig(ConfigDto.Configurations.LOTTERY_CHANNEL, "777")
+        stubChannelConfig(ConfigDto.Configurations.LOTTERY_PING_MODE, "OFF")
+        every { guild.getTextChannelById(777L) } returns channel
+        val contentSlot = slot<String>()
+        every { sendAction.addContent(capture(contentSlot)) } returns sendAction
+
+        announcer.announceCycle(
+            guild, mode = "WEIGHTED",
+            priorOutcome = LotteryAnnouncer.PriorOutcome.NoTickets,
+            openOutcome = LotteryAnnouncer.OpenSummary.Ok(
+                seeded = 500L, ticketPrice = 50L, poolAmount = 500L,
+            ),
+        )
+
+        assertFalse(contentSlot.captured.contains("@everyone"))
+        assertFalse(contentSlot.captured.contains("@here"))
+        assertTrue(contentSlot.captured.contains("/lottery buy"))
+    }
+
+    @Test
+    fun `allowed mentions include EVERYONE only when wide ping is in content`() {
+        stubChannelConfig(ConfigDto.Configurations.LOTTERY_CHANNEL, "777")
+        stubChannelConfig(ConfigDto.Configurations.LOTTERY_PING_MODE, "OFF")
+        every { guild.getTextChannelById(777L) } returns channel
+        val mentionsSlot = slot<Collection<Message.MentionType>>()
+        every { sendAction.setAllowedMentions(capture(mentionsSlot)) } returns sendAction
+
+        announcer.announceCycle(
+            guild, mode = "WEIGHTED",
+            priorOutcome = LotteryAnnouncer.PriorOutcome.NoTickets,
+            openOutcome = LotteryAnnouncer.OpenSummary.Ok(
+                seeded = 500L, ticketPrice = 50L, poolAmount = 500L,
+            ),
+        )
+
+        assertTrue(mentionsSlot.captured.contains(Message.MentionType.USER))
+        assertFalse(mentionsSlot.captured.contains(Message.MentionType.EVERYONE))
+    }
+
+    @Test
+    fun `allowed mentions include EVERYONE when @everyone is in content`() {
+        stubChannelConfig(ConfigDto.Configurations.LOTTERY_CHANNEL, "777")
+        // No PING_MODE set → default EVERYONE.
+        every { guild.getTextChannelById(777L) } returns channel
+        val mentionsSlot = slot<Collection<Message.MentionType>>()
+        every { sendAction.setAllowedMentions(capture(mentionsSlot)) } returns sendAction
+
+        announcer.announceCycle(
+            guild, mode = "WEIGHTED",
+            priorOutcome = LotteryAnnouncer.PriorOutcome.NoTickets,
+            openOutcome = LotteryAnnouncer.OpenSummary.Ok(
+                seeded = 500L, ticketPrice = 50L, poolAmount = 500L,
+            ),
+        )
+
+        assertTrue(mentionsSlot.captured.contains(Message.MentionType.EVERYONE))
+        assertTrue(mentionsSlot.captured.contains(Message.MentionType.USER))
     }
 
     @Test

--- a/discord-bot/src/test/kotlin/bot/toby/scheduling/LotteryAnnouncerTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/scheduling/LotteryAnnouncerTest.kt
@@ -16,6 +16,8 @@ import net.dv8tion.jda.api.entities.Message
 import net.dv8tion.jda.api.entities.MessageEmbed
 import net.dv8tion.jda.api.entities.SelfMember
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
+import net.dv8tion.jda.api.interactions.commands.Command
+import net.dv8tion.jda.api.requests.RestAction
 import net.dv8tion.jda.api.requests.restaction.MessageCreateAction
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -59,9 +61,15 @@ class LotteryAnnouncerTest {
         every { guild.name } returns "Test Guild"
         every { guild.selfMember } returns bot
         every { guild.jda } returns jda
-        // Slash-command id resolution falls back to plain `/lottery buy`
-        // text when retrieval fails — simplest stub for tests.
-        every { jda.retrieveCommands() } throws RuntimeException("test: skip slash mention resolution")
+        // Slash-command id resolution: stub the full chain to return an
+        // empty command list so `firstOrNull { name == "lottery" }` is
+        // null and the announcer falls back to plain `/lottery buy` text.
+        // Using an explicit stub rather than `throws` because mockk's
+        // handling of default interface methods (retrieveCommands has a
+        // default impl) can vary between versions.
+        val restAction: RestAction<List<Command>> = mockk(relaxed = true)
+        every { jda.retrieveCommands() } returns restAction
+        every { restAction.complete() } returns emptyList()
         every { bot.hasPermission(channel, *anyVararg<Permission>()) } returns true
         every { channel.id } returns "777"
         every { channel.sendMessageEmbeds(any<MessageEmbed>()) } returns sendAction

--- a/web/src/main/kotlin/web/controller/LotteryController.kt
+++ b/web/src/main/kotlin/web/controller/LotteryController.kt
@@ -1,7 +1,6 @@
 package web.controller
 
 import database.dto.JackpotLotteryDto
-import database.dto.JackpotLotteryTicketDto
 import database.service.JackpotLotteryService.BuyMatchOutcome
 import database.service.JackpotLotteryService.BuyOutcome
 import org.springframework.http.ResponseEntity
@@ -221,7 +220,17 @@ data class LotteryViewModel(
         val topHolders: List<TopHolder>,
     )
 
-    data class TopHolder(val discordId: Long, val ticketCount: Int)
+    /** View projection of a weighted-lottery top holder — Discord
+     *  display name + avatar URL come from [LotteryWebService.TopHolder]
+     *  so the lottery page renders the same member cell as the
+     *  leaderboard. Falls back to a `Player <last-4>` placeholder when
+     *  the holder has left the guild. */
+    data class TopHolder(
+        val discordId: Long,
+        val ticketCount: Int,
+        val name: String,
+        val avatarUrl: String?,
+    )
 
     companion object {
         fun from(snap: LotteryWebService.LotteryPageSnapshot): LotteryViewModel {
@@ -253,7 +262,7 @@ data class LotteryViewModel(
                     myTickets = snap.weightedMyTicket?.ticketCount ?: 0,
                     mySpent = snap.weightedMyTicket?.spent ?: 0L,
                     topHolders = snap.weightedTopHolders.map {
-                        TopHolder(it.discordId, it.ticketCount)
+                        TopHolder(it.discordId, it.ticketCount, it.name, it.avatarUrl)
                     },
                 )
             }
@@ -274,9 +283,5 @@ data class LotteryViewModel(
             if (csv.isNullOrBlank()) return emptyList()
             return csv.split(',').mapNotNull { it.trim().toIntOrNull() }
         }
-
-        // Suppress unused parameter warning — used by Thymeleaf via reflection.
-        @Suppress("unused")
-        private fun unused(t: JackpotLotteryTicketDto) = t
     }
 }

--- a/web/src/main/kotlin/web/controller/LotteryController.kt
+++ b/web/src/main/kotlin/web/controller/LotteryController.kt
@@ -221,15 +221,17 @@ data class LotteryViewModel(
     )
 
     /** View projection of a weighted-lottery top holder — Discord
-     *  display name + avatar URL come from [LotteryWebService.TopHolder]
-     *  so the lottery page renders the same member cell as the
-     *  leaderboard. Falls back to a `Player <last-4>` placeholder when
-     *  the holder has left the guild. */
+     *  display name + avatar URL + purchased title come from
+     *  [LotteryWebService.TopHolder] so the lottery page renders the
+     *  same member cell + title pill as the leaderboard. Falls back
+     *  to a `Player <last-4>` placeholder when the holder has left
+     *  the guild; `title` is null when unset / unresolvable (no pill). */
     data class TopHolder(
         val discordId: Long,
         val ticketCount: Int,
         val name: String,
         val avatarUrl: String?,
+        val title: String?,
     )
 
     companion object {
@@ -262,7 +264,7 @@ data class LotteryViewModel(
                     myTickets = snap.weightedMyTicket?.ticketCount ?: 0,
                     mySpent = snap.weightedMyTicket?.spent ?: 0L,
                     topHolders = snap.weightedTopHolders.map {
-                        TopHolder(it.discordId, it.ticketCount, it.name, it.avatarUrl)
+                        TopHolder(it.discordId, it.ticketCount, it.name, it.avatarUrl, it.title)
                     },
                 )
             }

--- a/web/src/main/kotlin/web/service/LotteryWebService.kt
+++ b/web/src/main/kotlin/web/service/LotteryWebService.kt
@@ -20,6 +20,7 @@ import org.springframework.stereotype.Service
 class LotteryWebService(
     private val jackpotLotteryService: JackpotLotteryService,
     private val configService: ConfigService,
+    private val memberLookupHelper: MemberLookupHelper,
 ) {
 
     /**
@@ -39,7 +40,7 @@ class LotteryWebService(
         val dailyTicketBuyers: Int,
         val weightedOpen: JackpotLotteryDto?,
         val weightedMyTicket: JackpotLotteryTicketDto?,
-        val weightedTopHolders: List<JackpotLotteryTicketDto>,
+        val weightedTopHolders: List<TopHolder>,
         val weightedTotalTickets: Long,
         val pickCount: Int,
         val numberMax: Int,
@@ -47,6 +48,19 @@ class LotteryWebService(
         val revenueJackpotPct: Long,
         val dailyMode: String,
         val dailyEnabled: Boolean,
+    )
+
+    /**
+     * Display projection for a single weighted-lottery top holder.
+     * Carries the Discord display name + avatar URL alongside the
+     * ticket count so the lottery page can render the same
+     * avatar-and-name member cell as the leaderboard.
+     */
+    data class TopHolder(
+        val discordId: Long,
+        val ticketCount: Int,
+        val name: String,
+        val avatarUrl: String?,
     )
 
     fun snapshot(guildId: Long, discordId: Long): LotteryPageSnapshot {
@@ -60,7 +74,17 @@ class LotteryWebService(
         val weightedOpen = jackpotLotteryService.getOpenWeighted(guildId)
         val weightedTickets = jackpotLotteryService.ticketsForOpenWeighted(guildId)
         val weightedMyTicket = weightedTickets.firstOrNull { it.discordId == discordId }
-        val weightedTop = weightedTickets.sortedByDescending { it.ticketCount }.take(5)
+        val weightedTopRaw = weightedTickets.sortedByDescending { it.ticketCount }.take(5)
+        val displays = memberLookupHelper.resolveAll(guildId, weightedTopRaw.map { it.discordId })
+        val weightedTop = weightedTopRaw.map { ticket ->
+            val display = displays[ticket.discordId]
+            TopHolder(
+                discordId = ticket.discordId,
+                ticketCount = ticket.ticketCount,
+                name = display?.name ?: memberLookupHelper.fallbackName(ticket.discordId),
+                avatarUrl = display?.avatarUrl,
+            )
+        }
         val weightedTotal = weightedTickets.sumOf { it.ticketCount.toLong() }
 
         return LotteryPageSnapshot(

--- a/web/src/main/kotlin/web/service/LotteryWebService.kt
+++ b/web/src/main/kotlin/web/service/LotteryWebService.kt
@@ -5,6 +5,8 @@ import database.dto.JackpotLotteryTicketDto
 import database.service.ConfigService
 import database.service.JackpotLotteryService
 import database.service.LotteryHelper
+import database.service.TitleService
+import database.service.UserService
 import org.springframework.stereotype.Service
 
 /**
@@ -21,6 +23,8 @@ class LotteryWebService(
     private val jackpotLotteryService: JackpotLotteryService,
     private val configService: ConfigService,
     private val memberLookupHelper: MemberLookupHelper,
+    private val userService: UserService,
+    private val titleService: TitleService,
 ) {
 
     /**
@@ -54,13 +58,16 @@ class LotteryWebService(
      * Display projection for a single weighted-lottery top holder.
      * Carries the Discord display name + avatar URL alongside the
      * ticket count so the lottery page can render the same
-     * avatar-and-name member cell as the leaderboard.
+     * avatar-and-name + title-pill member cell as the leaderboard.
+     * `title` is the user's purchased active title (same source as the
+     * leaderboard's `lb-title-pill`); null when unset or unresolvable.
      */
     data class TopHolder(
         val discordId: Long,
         val ticketCount: Int,
         val name: String,
         val avatarUrl: String?,
+        val title: String?,
     )
 
     fun snapshot(guildId: Long, discordId: Long): LotteryPageSnapshot {
@@ -78,11 +85,21 @@ class LotteryWebService(
         val displays = memberLookupHelper.resolveAll(guildId, weightedTopRaw.map { it.discordId })
         val weightedTop = weightedTopRaw.map { ticket ->
             val display = displays[ticket.discordId]
+            // Mirrors LeaderboardWebService.buildTobyCoinLeaders: a missing /
+            // stale title id must not break the snapshot, so swallow with
+            // runCatching and fall back to null (no pill rendered).
+            val title = runCatching {
+                userService.getUserById(ticket.discordId, guildId)
+                    ?.activeTitleId
+                    ?.let { titleService.getById(it) }
+                    ?.label
+            }.getOrNull()
             TopHolder(
                 discordId = ticket.discordId,
                 ticketCount = ticket.ticketCount,
                 name = display?.name ?: memberLookupHelper.fallbackName(ticket.discordId),
                 avatarUrl = display?.avatarUrl,
+                title = title,
             )
         }
         val weightedTotal = weightedTickets.sumOf { it.ticketCount.toLong() }

--- a/web/src/main/kotlin/web/service/ModerationWebService.kt
+++ b/web/src/main/kotlin/web/service/ModerationWebService.kt
@@ -1021,6 +1021,13 @@ class ModerationWebService(
                 if (n !in 1..50) return "Value must be between 1 and 50."
                 n.toString()
             }
+            ConfigDto.Configurations.LOTTERY_PING_MODE -> {
+                val v = rawValue.trim().uppercase()
+                if (v !in setOf("OFF", "HERE", "EVERYONE")) {
+                    return "Value must be OFF, HERE, or EVERYONE."
+                }
+                v
+            }
             ConfigDto.Configurations.LOTTERY_CHANNEL,
             ConfigDto.Configurations.CASINO_MODLOG_CHANNEL_ID -> {
                 val v = rawValue.trim()

--- a/web/src/main/resources/static/css/base.css
+++ b/web/src/main/resources/static/css/base.css
@@ -679,6 +679,114 @@ td { font-size: 0.95rem; }
     flex-shrink: 0;
 }
 
+/* -- Numeric value accents shared by both standings tables (credits +
+   tobycoin) on the leaderboard. Lives here so a future page that wants
+   to surface a coloured numeric pill can reuse the same set without
+   re-importing leaderboard.css. -- */
+.lb-value { font-size: 1rem; }
+.lb-value-credits { color: #FFD700; }
+.lb-value-toby { color: #57F287; }
+.lb-value-portfolio { color: var(--text-muted); font-variant-numeric: tabular-nums; }
+.lb-value-month { color: #2ECC71; font-weight: 600; }
+.lb-value-month-down { color: #ED4245; font-weight: 600; }
+
+/* ============================================================
+   Mobile: tighter standings cards.
+   The shared .mod-table mobile rules in moderation.css turn each
+   row into a card and stack each cell as its own label-left /
+   value-right flex strip. For the leaderboard's 6-column standings
+   that produced a tower of bulky rows on a phone — the user reported
+   "items not aligned, twice the size they should be".
+   This block re-lays the standings card as a 2-row grid:
+     Row 1: rank + member cell + title pill, horizontally
+     Row 2: the three numeric metrics in a 3-column grid, each as
+            a small "label / value" pair so they read as a set
+            instead of three separate stacked rows.
+   The column-area mappings reference the data-label values the
+   leaderboard template emits ("#", "Member", "Title", and the per-
+   table metric labels — Credits/TOBY/This month/Voice/Portfolio).
+   Other mod-table consumers don't carry those labels so the grid
+   override never fires for them.
+   ============================================================ */
+@media (max-width: 640px) {
+    .lb-standings-table.mod-table tr {
+        display: grid;
+        grid-template-columns: auto 1fr auto;
+        grid-template-areas:
+            "rank   member  title"
+            "m1     m2      m3";
+        align-items: center;
+        column-gap: 10px;
+        row-gap: 6px;
+        padding: 8px 10px;
+        margin-bottom: 6px;
+    }
+    .lb-standings-table.mod-table td {
+        display: block;
+        width: auto;
+        padding: 0;
+        border: 0;
+        font-size: inherit;
+    }
+    .lb-standings-table.mod-table td::before { display: none; }
+
+    .lb-standings-table.mod-table td[data-label="#"] { grid-area: rank; }
+    .lb-standings-table.mod-table td[data-label="Member"] { grid-area: member; min-width: 0; }
+    .lb-standings-table.mod-table td[data-label="Title"] { grid-area: title; justify-self: end; }
+
+    /* Each metric cell becomes a tight label/value stack — three
+       cells across the bottom row, one grid area each. The
+       align-items differs per cell so the leftmost metric
+       left-aligns under the rank/member, the centre aligns under
+       the member, and the rightmost right-aligns under the title. */
+    .lb-standings-table.mod-table td[data-label="Credits"],
+    .lb-standings-table.mod-table td[data-label="TOBY"],
+    .lb-standings-table.mod-table td[data-label="This month"],
+    .lb-standings-table.mod-table td[data-label="Voice"],
+    .lb-standings-table.mod-table td[data-label="Portfolio"] {
+        display: flex;
+        flex-direction: column;
+        gap: 1px;
+    }
+    .lb-standings-table.mod-table td[data-label="Credits"],
+    .lb-standings-table.mod-table td[data-label="TOBY"] {
+        grid-area: m1;
+        align-items: flex-start;
+    }
+    .lb-standings-table.mod-table td[data-label="This month"] {
+        grid-area: m2;
+        align-items: center;
+        text-align: center;
+    }
+    .lb-standings-table.mod-table td[data-label="Voice"],
+    .lb-standings-table.mod-table td[data-label="Portfolio"] {
+        grid-area: m3;
+        align-items: flex-end;
+        text-align: right;
+    }
+    .lb-standings-table.mod-table td[data-label="Credits"]::before,
+    .lb-standings-table.mod-table td[data-label="TOBY"]::before,
+    .lb-standings-table.mod-table td[data-label="This month"]::before,
+    .lb-standings-table.mod-table td[data-label="Voice"]::before,
+    .lb-standings-table.mod-table td[data-label="Portfolio"]::before {
+        display: block;
+        content: attr(data-label);
+        font-size: 0.6rem;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        color: var(--text-muted);
+        font-weight: 600;
+    }
+
+    /* Halve the value type weight so the bottom row reads as
+       supporting metrics, not three competing headlines. */
+    .lb-standings-table .lb-value,
+    .lb-standings-table .lb-value-month,
+    .lb-standings-table .lb-value-month-down {
+        font-size: 0.85rem;
+    }
+}
+
 @media (max-width: 480px) {
     .avatar { width: 24px; height: 24px; }
     .lb-rank { width: 24px; height: 24px; font-size: 0.8rem; }

--- a/web/src/main/resources/static/css/base.css
+++ b/web/src/main/resources/static/css/base.css
@@ -597,3 +597,90 @@ td { font-size: 0.95rem; }
     input[type=text], input[type=url], input[type=number], input[type=search],
     input[type=email], input[type=password], select { min-height: 40px; }
 }
+
+/* ============================================================
+   Rich member display primitives — avatar + name + title pill
+   + rank badge.
+   ============================================================
+   Used by the leaderboard standings tables, the moderation user
+   listing, and the lottery top-holders list. Hoisted here from
+   moderation.css/leaderboard.css so every page that loads base.css
+   (i.e. all of them) renders the same Discord-member projection
+   at the same sizes. Mobile breakpoint at 480px shrinks the
+   avatar/badge and forces ellipsis truncation on the name so a
+   long display name + medal + value pill still fits one line on
+   a 360px screen. */
+
+.member-cell {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    min-width: 0;
+}
+.avatar {
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    object-fit: cover;
+    background: var(--border);
+    flex-shrink: 0;
+}
+.lb-name {
+    font-weight: 600;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+/* Circular rank badge with optional gold/silver/bronze gradient
+   for top-3 positions. Used by leaderboard standings + lottery
+   top-holders so a "1st place" element looks the same across pages. */
+.lb-rank {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    font-weight: 700;
+    font-size: 0.9rem;
+    background: var(--bg);
+    color: var(--text-muted);
+    border: 1px solid var(--border);
+    font-variant-numeric: tabular-nums;
+    flex-shrink: 0;
+}
+.lb-rank-1 {
+    background: linear-gradient(135deg, #FFE066, #FFA500);
+    color: #1a1a1a;
+    border-color: #FFD700;
+    box-shadow: 0 0 12px rgba(255, 215, 0, 0.35);
+}
+.lb-rank-2 {
+    background: linear-gradient(135deg, #E5E7EB, #9CA3AF);
+    color: #1a1a1a;
+    border-color: #C0C0C0;
+}
+.lb-rank-3 {
+    background: linear-gradient(135deg, #CD7F32, #8B4513);
+    color: #fff;
+    border-color: #CD7F32;
+}
+
+.lb-title-pill {
+    display: inline-block;
+    padding: 2px 8px;
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    font-size: 0.8rem;
+    background: var(--bg);
+    color: var(--text);
+    flex-shrink: 0;
+}
+
+@media (max-width: 480px) {
+    .avatar { width: 24px; height: 24px; }
+    .lb-rank { width: 24px; height: 24px; font-size: 0.8rem; }
+    .lb-title-pill { font-size: 0.75rem; padding: 1px 6px; }
+}

--- a/web/src/main/resources/static/css/leaderboard.css
+++ b/web/src/main/resources/static/css/leaderboard.css
@@ -354,15 +354,8 @@ details.lb-collapse[open] .lb-collapse-caret { transform: rotate(90deg); }
 .lb-standings-table .lb-col-rank { width: 60px; text-align: left; }
 .lb-standings-table .lb-col-value { text-align: right; font-variant-numeric: tabular-nums; }
 .lb-standings-table thead th { letter-spacing: 0.02em; }
-/* `.lb-name` lives in base.css now (also used by lottery top-holders +
-   moderation user list). */
-
-/* Value accents */
-.lb-value { font-size: 1rem; }
-.lb-value-credits { color: #FFD700; }
-.lb-value-toby { color: #57F287; }
-.lb-value-portfolio { color: var(--text-muted); font-variant-numeric: tabular-nums; }
-.lb-value-month { color: #2ECC71; font-weight: 600; }
-.lb-value-month-down { color: #ED4245; font-weight: 600; }
-
-/* `.lb-title-pill` lives in base.css now (shared with lottery top-holders). */
+/* `.lb-name`, `.lb-title-pill`, and the `.lb-value*` numeric accents
+   all live in base.css now — shared with the lottery top-holders +
+   moderation user list, and with the mobile 2-row standings grid that
+   re-lays the cards as `(rank | member | title) / (m1 | m2 | m3)` so
+   the metrics read as a set rather than three stacked headlines. */

--- a/web/src/main/resources/static/css/leaderboard.css
+++ b/web/src/main/resources/static/css/leaderboard.css
@@ -230,6 +230,21 @@
     .lb-podium-1 { order: -1; }
 }
 
+/* Phone-portrait sizing for the podium — 96/72px avatars feel
+   oversized at 360px, and the larger 1st-place padding pushes the
+   card past the viewport. Shrink to 72/56px and trim the extra
+   1st-place padding so each podium card sits flush. */
+@media (max-width: 480px) {
+    .lb-podium-avatar { width: 56px; height: 56px; }
+    .lb-podium-1 .lb-podium-avatar { width: 72px; height: 72px; }
+    .lb-podium-1 {
+        padding-top: var(--space-4);
+        padding-bottom: var(--space-4);
+    }
+    .lb-podium-medal { font-size: 1.6rem; }
+    .lb-podium-1 .lb-podium-name { font-size: 1.05rem; }
+}
+
 /* -- Sort toggle (This month / Lifetime) -- */
 .lb-sort {
     display: inline-flex;
@@ -323,37 +338,8 @@ details.lb-collapse[open] .lb-collapse-caret { transform: rotate(90deg); }
 }
 .lb-collapse-body .mod-table-wrap { margin: 0; }
 
-/* -- Rank badges shared between both tables -- */
-.lb-rank {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 32px;
-    height: 32px;
-    border-radius: 50%;
-    font-weight: 700;
-    font-size: 0.9rem;
-    background: var(--bg);
-    color: var(--text-muted);
-    border: 1px solid var(--border);
-    font-variant-numeric: tabular-nums;
-}
-.lb-rank-1 {
-    background: linear-gradient(135deg, #FFE066, #FFA500);
-    color: #1a1a1a;
-    border-color: #FFD700;
-    box-shadow: 0 0 12px rgba(255, 215, 0, 0.35);
-}
-.lb-rank-2 {
-    background: linear-gradient(135deg, #E5E7EB, #9CA3AF);
-    color: #1a1a1a;
-    border-color: #C0C0C0;
-}
-.lb-rank-3 {
-    background: linear-gradient(135deg, #CD7F32, #8B4513);
-    color: #fff;
-    border-color: #CD7F32;
-}
+/* `.lb-rank` + `.lb-rank-1/2/3` live in base.css now (shared with
+   the lottery top-holders list). */
 
 /* -- Table flourish shared between both tables -- */
 .lb-standings-table tbody tr {
@@ -368,7 +354,8 @@ details.lb-collapse[open] .lb-collapse-caret { transform: rotate(90deg); }
 .lb-standings-table .lb-col-rank { width: 60px; text-align: left; }
 .lb-standings-table .lb-col-value { text-align: right; font-variant-numeric: tabular-nums; }
 .lb-standings-table thead th { letter-spacing: 0.02em; }
-.lb-standings-table .lb-name { font-weight: 600; }
+/* `.lb-name` lives in base.css now (also used by lottery top-holders +
+   moderation user list). */
 
 /* Value accents */
 .lb-value { font-size: 1rem; }
@@ -378,13 +365,4 @@ details.lb-collapse[open] .lb-collapse-caret { transform: rotate(90deg); }
 .lb-value-month { color: #2ECC71; font-weight: 600; }
 .lb-value-month-down { color: #ED4245; font-weight: 600; }
 
-/* -- Title pill -- */
-.lb-title-pill {
-    display: inline-block;
-    padding: 2px 8px;
-    border: 1px solid var(--border);
-    border-radius: 999px;
-    font-size: 0.8rem;
-    background: var(--bg);
-    color: var(--text);
-}
+/* `.lb-title-pill` lives in base.css now (shared with lottery top-holders). */

--- a/web/src/main/resources/static/css/lottery.css
+++ b/web/src/main/resources/static/css/lottery.css
@@ -212,6 +212,10 @@
     width: 120px;
 }
 
+/* Top-holders list — uses the shared `.lb-rank` / `.lb-title-pill` /
+   `.member-cell` / `.avatar` primitives from base.css for visual
+   parity with the leaderboard standings. The list-specific styling
+   (per-row card, top-1 lottery-gold ring, ticket pill) lives here. */
 .lottery-top-holders {
     list-style: none;
     padding: 0;
@@ -240,61 +244,7 @@
     box-shadow: 0 0 0 2px #f1c40f, 0 0 12px rgba(241, 196, 15, 0.55);
 }
 .lottery-top-holders .member-cell {
-    min-width: 0;
     flex: 1 1 auto;
-}
-.lottery-top-holders .member-cell .lb-name {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-}
-
-/* Rank badge — same shape + medal colours as the leaderboard's .lb-rank
-   family. Duplicated here because lottery.html only loads lottery.css; a
-   future refactor can promote both to a shared stylesheet. */
-.lottery-rank {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 28px;
-    height: 28px;
-    border-radius: 50%;
-    font-weight: 700;
-    font-size: 0.85rem;
-    background: var(--bg);
-    color: var(--text-muted);
-    border: 1px solid var(--border);
-    font-variant-numeric: tabular-nums;
-    flex-shrink: 0;
-}
-.lottery-rank.lottery-rank-1 {
-    background: linear-gradient(135deg, #FFE066, #FFA500);
-    color: #1a1a1a;
-    border-color: #FFD700;
-    box-shadow: 0 0 12px rgba(255, 215, 0, 0.35);
-}
-.lottery-rank.lottery-rank-2 {
-    background: linear-gradient(135deg, #E5E7EB, #9CA3AF);
-    color: #1a1a1a;
-    border-color: #C0C0C0;
-}
-.lottery-rank.lottery-rank-3 {
-    background: linear-gradient(135deg, #CD7F32, #8B4513);
-    color: #fff;
-    border-color: #CD7F32;
-}
-
-/* Title pill — visual match to leaderboard's .lb-title-pill (same class
-   name so the design intent is obvious). */
-.lottery-top-holders .lb-title-pill {
-    display: inline-block;
-    padding: 2px 8px;
-    border: 1px solid var(--border);
-    border-radius: 999px;
-    font-size: 0.8rem;
-    background: var(--bg);
-    color: var(--text);
-    flex-shrink: 0;
 }
 
 /* Ticket count pill — casino-card-face style + tabular-nums for column
@@ -316,21 +266,13 @@
 }
 
 /* Mobile: drop the title + ticket pills onto a second row so a long
-   display name + medal + avatar still fit on one line. Mirrors the
-   leaderboard podium's <600px stack pattern. */
+   display name + medal + avatar still fit on one line. Avatar / rank
+   badge / title pill shrinking is handled by the shared rules in
+   base.css. */
 @media (max-width: 480px) {
     .lottery-top-holders li {
         flex-wrap: wrap;
         gap: var(--space-2);
-    }
-    .lottery-top-holders .avatar {
-        width: 24px;
-        height: 24px;
-    }
-    .lottery-rank {
-        width: 24px;
-        height: 24px;
-        font-size: 0.8rem;
     }
     .lottery-ticket-pill {
         margin-left: 0;

--- a/web/src/main/resources/static/css/lottery.css
+++ b/web/src/main/resources/static/css/lottery.css
@@ -217,6 +217,16 @@
     padding-left: var(--space-5);
     margin: 0;
 }
+.lottery-top-holders li {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    padding: var(--space-1) 0;
+}
+.lottery-top-holder-tickets {
+    margin-left: auto;
+    font-variant-numeric: tabular-nums;
+}
 
 /* ============================================================ */
 /* Payout / tier schedule table                                  */

--- a/web/src/main/resources/static/css/lottery.css
+++ b/web/src/main/resources/static/css/lottery.css
@@ -213,19 +213,128 @@
 }
 
 .lottery-top-holders {
-    list-style: decimal;
-    padding-left: var(--space-5);
+    list-style: none;
+    padding: 0;
     margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
 }
 .lottery-top-holders li {
     display: flex;
     align-items: center;
     gap: var(--space-3);
-    padding: var(--space-1) 0;
+    padding: var(--space-2) var(--space-3);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    background: var(--bg-elevated);
+    min-width: 0;
 }
-.lottery-top-holder-tickets {
-    margin-left: auto;
+/* Top-1 inherits the lottery's gold palette (matches the embed colour
+   #F1C40F + the drawn-number cell glow) so the leader visually pops. */
+.lottery-top-holders li.lottery-rank-1 {
+    border-color: rgba(241, 196, 15, 0.6);
+    box-shadow: 0 0 12px rgba(241, 196, 15, 0.25);
+}
+.lottery-top-holders li.lottery-rank-1 .avatar {
+    box-shadow: 0 0 0 2px #f1c40f, 0 0 12px rgba(241, 196, 15, 0.55);
+}
+.lottery-top-holders .member-cell {
+    min-width: 0;
+    flex: 1 1 auto;
+}
+.lottery-top-holders .member-cell .lb-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+/* Rank badge — same shape + medal colours as the leaderboard's .lb-rank
+   family. Duplicated here because lottery.html only loads lottery.css; a
+   future refactor can promote both to a shared stylesheet. */
+.lottery-rank {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    font-weight: 700;
+    font-size: 0.85rem;
+    background: var(--bg);
+    color: var(--text-muted);
+    border: 1px solid var(--border);
     font-variant-numeric: tabular-nums;
+    flex-shrink: 0;
+}
+.lottery-rank.lottery-rank-1 {
+    background: linear-gradient(135deg, #FFE066, #FFA500);
+    color: #1a1a1a;
+    border-color: #FFD700;
+    box-shadow: 0 0 12px rgba(255, 215, 0, 0.35);
+}
+.lottery-rank.lottery-rank-2 {
+    background: linear-gradient(135deg, #E5E7EB, #9CA3AF);
+    color: #1a1a1a;
+    border-color: #C0C0C0;
+}
+.lottery-rank.lottery-rank-3 {
+    background: linear-gradient(135deg, #CD7F32, #8B4513);
+    color: #fff;
+    border-color: #CD7F32;
+}
+
+/* Title pill — visual match to leaderboard's .lb-title-pill (same class
+   name so the design intent is obvious). */
+.lottery-top-holders .lb-title-pill {
+    display: inline-block;
+    padding: 2px 8px;
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    font-size: 0.8rem;
+    background: var(--bg);
+    color: var(--text);
+    flex-shrink: 0;
+}
+
+/* Ticket count pill — casino-card-face style + tabular-nums for column
+   alignment across rows. */
+.lottery-ticket-pill {
+    margin-left: auto;
+    padding: 4px 10px;
+    border-radius: 999px;
+    font-variant-numeric: tabular-nums;
+    background: linear-gradient(180deg, #fdfdfd 0%, #e8e8e8 100%);
+    color: #1a1a1a;
+    border: 1px solid rgba(0, 0, 0, 0.1);
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+    font-size: 0.85rem;
+    flex-shrink: 0;
+}
+.lottery-ticket-pill .muted {
+    color: rgba(26, 26, 26, 0.6);
+}
+
+/* Mobile: drop the title + ticket pills onto a second row so a long
+   display name + medal + avatar still fit on one line. Mirrors the
+   leaderboard podium's <600px stack pattern. */
+@media (max-width: 480px) {
+    .lottery-top-holders li {
+        flex-wrap: wrap;
+        gap: var(--space-2);
+    }
+    .lottery-top-holders .avatar {
+        width: 24px;
+        height: 24px;
+    }
+    .lottery-rank {
+        width: 24px;
+        height: 24px;
+        font-size: 0.8rem;
+    }
+    .lottery-ticket-pill {
+        margin-left: 0;
+    }
 }
 
 /* ============================================================ */

--- a/web/src/main/resources/static/css/moderation.css
+++ b/web/src/main/resources/static/css/moderation.css
@@ -482,22 +482,23 @@ details.config-section.is-hidden { display: none; }
         background: var(--bg-elevated);
         border: 1px solid var(--border);
         border-radius: var(--radius-md);
-        padding: 8px 12px;
-        margin-bottom: var(--space-3);
+        padding: 6px 10px;
+        margin-bottom: var(--space-2);
     }
     .mod-table tr:last-child td { border-bottom: 1px solid var(--border); }
     .mod-table td {
         display: flex;
         justify-content: space-between;
         align-items: center;
-        gap: 12px;
+        gap: 10px;
         border-bottom: 1px solid var(--border);
-        padding: 8px 0;
+        padding: 5px 0;
+        font-size: 0.85rem;
     }
     .mod-table td:last-child { border-bottom: 0; }
     .mod-table td::before {
         content: attr(data-label);
-        font-size: 0.75rem;
+        font-size: 0.7rem;
         text-transform: uppercase;
         letter-spacing: 0.04em;
         color: var(--text-muted);

--- a/web/src/main/resources/static/css/moderation.css
+++ b/web/src/main/resources/static/css/moderation.css
@@ -117,16 +117,9 @@ details.config-section.is-hidden { display: none; }
 }
 .mod-table tr:last-child td { border-bottom: 0; }
 
-.member-cell {
-    display: flex;
-    align-items: center;
-    gap: 10px;
-}
-.avatar {
-    width: 28px; height: 28px; border-radius: 50%;
-    object-fit: cover;
-    background: var(--border);
-}
+/* `.member-cell` + `.avatar` live in base.css now (shared with the
+   leaderboard + lottery pages). Keeping the badge.owner rule here
+   since it's specific to the moderation user listing. */
 .badge.owner {
     background: var(--accent-soft);
     color: var(--accent);

--- a/web/src/main/resources/templates/fragments/memberCell.html
+++ b/web/src/main/resources/templates/fragments/memberCell.html
@@ -1,0 +1,18 @@
+<!--
+  Shared "avatar + display name" cell. Used by the leaderboard
+  standings tables and the lottery top-holders list so the two pages
+  render the same Discord-member projection.
+
+  Styling lives in static/css/moderation.css (.member-cell, .avatar)
+  and static/css/leaderboard.css (.lb-name); the fragment is a pure
+  markup refactor.
+-->
+<div xmlns:th="http://www.thymeleaf.org"
+     th:fragment="cell(name, avatarUrl)"
+     class="member-cell">
+    <img th:if="${avatarUrl != null}"
+         th:src="${avatarUrl}"
+         class="avatar"
+         alt="">
+    <span class="lb-name" th:text="${name}">Name</span>
+</div>

--- a/web/src/main/resources/templates/leaderboard.html
+++ b/web/src/main/resources/templates/leaderboard.html
@@ -169,13 +169,7 @@
                                   th:text="${row.rank}">4</span>
                         </td>
                         <td data-label="Member">
-                            <div class="member-cell">
-                                <img th:if="${row.avatarUrl != null}"
-                                     th:src="${row.avatarUrl}"
-                                     class="avatar"
-                                     alt="">
-                                <span class="lb-name" th:text="${row.name}">Name</span>
-                            </div>
+                            <div th:replace="~{fragments/memberCell :: cell(${row.name}, ${row.avatarUrl})}"></div>
                         </td>
                         <td data-label="Title">
                             <span th:if="${row.title != null}" class="lb-title-pill" th:text="${row.title}"></span>
@@ -232,13 +226,7 @@
                                   th:text="${row.rank}">1</span>
                         </td>
                         <td data-label="Member">
-                            <div class="member-cell">
-                                <img th:if="${row.avatarUrl != null}"
-                                     th:src="${row.avatarUrl}"
-                                     class="avatar"
-                                     alt="">
-                                <span class="lb-name" th:text="${row.name}">Name</span>
-                            </div>
+                            <div th:replace="~{fragments/memberCell :: cell(${row.name}, ${row.avatarUrl})}"></div>
                         </td>
                         <td data-label="Title">
                             <span th:if="${row.title != null}" class="lb-title-pill" th:text="${row.title}"></span>

--- a/web/src/main/resources/templates/lottery.html
+++ b/web/src/main/resources/templates/lottery.html
@@ -220,8 +220,10 @@
             <h3>Top holders</h3>
             <ol class="lottery-top-holders">
                 <li th:each="h : ${snapshot.weighted.topHolders}">
-                    <span class="muted">User #<span th:text="${h.discordId}">…</span></span>
-                    — <strong th:text="${h.ticketCount}">0</strong> tickets
+                    <div th:replace="~{fragments/memberCell :: cell(${h.name}, ${h.avatarUrl})}"></div>
+                    <span class="lottery-top-holder-tickets">
+                        <strong th:text="${h.ticketCount}">0</strong> tickets
+                    </span>
                 </li>
             </ol>
         </div>
@@ -275,8 +277,10 @@
             <h3>Top holders</h3>
             <ol class="lottery-top-holders">
                 <li th:each="h : ${snapshot.weighted.topHolders}">
-                    <span class="muted">User #<span th:text="${h.discordId}">…</span></span>
-                    — <strong th:text="${h.ticketCount}">0</strong> tickets
+                    <div th:replace="~{fragments/memberCell :: cell(${h.name}, ${h.avatarUrl})}"></div>
+                    <span class="lottery-top-holder-tickets">
+                        <strong th:text="${h.ticketCount}">0</strong> tickets
+                    </span>
                 </li>
             </ol>
         </div>

--- a/web/src/main/resources/templates/lottery.html
+++ b/web/src/main/resources/templates/lottery.html
@@ -219,10 +219,16 @@
              th:if="${snapshot.weighted != null and !#lists.isEmpty(snapshot.weighted.topHolders)}">
             <h3>Top holders</h3>
             <ol class="lottery-top-holders">
-                <li th:each="h : ${snapshot.weighted.topHolders}">
+                <li th:each="h, iter : ${snapshot.weighted.topHolders}"
+                    th:classappend="${'lottery-rank-' + iter.count}">
+                    <span class="lottery-rank"
+                          th:classappend="${iter.count == 1 ? 'lottery-rank-1' : (iter.count == 2 ? 'lottery-rank-2' : (iter.count == 3 ? 'lottery-rank-3' : ''))}"
+                          th:text="${iter.count}">1</span>
                     <div th:replace="~{fragments/memberCell :: cell(${h.name}, ${h.avatarUrl})}"></div>
-                    <span class="lottery-top-holder-tickets">
-                        <strong th:text="${h.ticketCount}">0</strong> tickets
+                    <span th:if="${h.title != null}" class="lb-title-pill" th:text="${h.title}"></span>
+                    <span class="lottery-ticket-pill">
+                        <strong th:text="${h.ticketCount}">0</strong>
+                        <span class="muted">tickets</span>
                     </span>
                 </li>
             </ol>
@@ -276,10 +282,16 @@
         <div class="lottery-weighted-holders" th:if="${!#lists.isEmpty(snapshot.weighted.topHolders)}">
             <h3>Top holders</h3>
             <ol class="lottery-top-holders">
-                <li th:each="h : ${snapshot.weighted.topHolders}">
+                <li th:each="h, iter : ${snapshot.weighted.topHolders}"
+                    th:classappend="${'lottery-rank-' + iter.count}">
+                    <span class="lottery-rank"
+                          th:classappend="${iter.count == 1 ? 'lottery-rank-1' : (iter.count == 2 ? 'lottery-rank-2' : (iter.count == 3 ? 'lottery-rank-3' : ''))}"
+                          th:text="${iter.count}">1</span>
                     <div th:replace="~{fragments/memberCell :: cell(${h.name}, ${h.avatarUrl})}"></div>
-                    <span class="lottery-top-holder-tickets">
-                        <strong th:text="${h.ticketCount}">0</strong> tickets
+                    <span th:if="${h.title != null}" class="lb-title-pill" th:text="${h.title}"></span>
+                    <span class="lottery-ticket-pill">
+                        <strong th:text="${h.ticketCount}">0</strong>
+                        <span class="muted">tickets</span>
                     </span>
                 </li>
             </ol>

--- a/web/src/main/resources/templates/lottery.html
+++ b/web/src/main/resources/templates/lottery.html
@@ -220,9 +220,9 @@
             <h3>Top holders</h3>
             <ol class="lottery-top-holders">
                 <li th:each="h, iter : ${snapshot.weighted.topHolders}"
-                    th:classappend="${'lottery-rank-' + iter.count}">
-                    <span class="lottery-rank"
-                          th:classappend="${iter.count == 1 ? 'lottery-rank-1' : (iter.count == 2 ? 'lottery-rank-2' : (iter.count == 3 ? 'lottery-rank-3' : ''))}"
+                    th:classappend="${iter.count == 1 ? 'lottery-rank-1' : ''}">
+                    <span class="lb-rank"
+                          th:classappend="${iter.count == 1 ? 'lb-rank-1' : (iter.count == 2 ? 'lb-rank-2' : (iter.count == 3 ? 'lb-rank-3' : ''))}"
                           th:text="${iter.count}">1</span>
                     <div th:replace="~{fragments/memberCell :: cell(${h.name}, ${h.avatarUrl})}"></div>
                     <span th:if="${h.title != null}" class="lb-title-pill" th:text="${h.title}"></span>
@@ -283,9 +283,9 @@
             <h3>Top holders</h3>
             <ol class="lottery-top-holders">
                 <li th:each="h, iter : ${snapshot.weighted.topHolders}"
-                    th:classappend="${'lottery-rank-' + iter.count}">
-                    <span class="lottery-rank"
-                          th:classappend="${iter.count == 1 ? 'lottery-rank-1' : (iter.count == 2 ? 'lottery-rank-2' : (iter.count == 3 ? 'lottery-rank-3' : ''))}"
+                    th:classappend="${iter.count == 1 ? 'lottery-rank-1' : ''}">
+                    <span class="lb-rank"
+                          th:classappend="${iter.count == 1 ? 'lb-rank-1' : (iter.count == 2 ? 'lb-rank-2' : (iter.count == 3 ? 'lb-rank-3' : ''))}"
                           th:text="${iter.count}">1</span>
                     <div th:replace="~{fragments/memberCell :: cell(${h.name}, ${h.avatarUrl})}"></div>
                     <span th:if="${h.title != null}" class="lb-title-pill" th:text="${h.title}"></span>

--- a/web/src/main/resources/templates/moderation/lottery.html
+++ b/web/src/main/resources/templates/moderation/lottery.html
@@ -133,6 +133,12 @@
                                th:disabled="${!isOwner}">
                         <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
                     </div>
+                </div>
+            </details>
+
+            <details class="config-section" open>
+                <summary>Announcements</summary>
+                <div class="config-grid">
                     <div class="config-row" data-key="LOTTERY_PING_MODE">
                         <label>
                             Announcement ping

--- a/web/src/main/resources/templates/moderation/lottery.html
+++ b/web/src/main/resources/templates/moderation/lottery.html
@@ -133,6 +133,32 @@
                                th:disabled="${!isOwner}">
                         <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
                     </div>
+                    <div class="config-row" data-key="LOTTERY_PING_MODE">
+                        <label>
+                            Announcement ping
+                            <span class="config-hint">
+                                How loudly to nudge members when the daily announcement
+                                posts. EVERYONE pings the whole server (default — most
+                                visible); HERE only pings online members; OFF skips the
+                                wide ping (winners are still pinged individually).
+                            </span>
+                        </label>
+                        <select th:disabled="${!isOwner}">
+                            <option value="EVERYONE"
+                                    th:selected="${overview.config['LOTTERY_PING_MODE'] == null or overview.config['LOTTERY_PING_MODE'] == 'EVERYONE'}">
+                                @everyone
+                            </option>
+                            <option value="HERE"
+                                    th:selected="${overview.config['LOTTERY_PING_MODE'] == 'HERE'}">
+                                @here
+                            </option>
+                            <option value="OFF"
+                                    th:selected="${overview.config['LOTTERY_PING_MODE'] == 'OFF'}">
+                                Off (winners only)
+                            </option>
+                        </select>
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
                     <div class="config-row" data-key="LOTTERY_CHANNEL">
                         <label>
                             Announce channel

--- a/web/src/test/kotlin/web/service/LotteryWebServiceTitleHydrationTest.kt
+++ b/web/src/test/kotlin/web/service/LotteryWebServiceTitleHydrationTest.kt
@@ -1,0 +1,135 @@
+package web.service
+
+import database.dto.JackpotLotteryDto
+import database.dto.JackpotLotteryTicketDto
+import database.dto.TitleDto
+import database.dto.UserDto
+import database.service.ConfigService
+import database.service.JackpotLotteryService
+import database.service.TitleService
+import database.service.UserService
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+/**
+ * Title-hydration coverage for [LotteryWebService.snapshot]. The
+ * weighted-lottery top-holder list is the lottery page's rich-info
+ * surface; failing to thread `activeTitleId → TitleService.getById ->
+ * label` would silently drop the title pill from the rendered UI even
+ * when a user has a purchased title equipped.
+ *
+ * Mirrors the defensive pattern from [LeaderboardWebService.buildTobyCoinLeaders]:
+ * a missing / stale title id must surface as `title = null` (no pill),
+ * never an exception that nukes the snapshot.
+ */
+class LotteryWebServiceTitleHydrationTest {
+
+    private val guildId = 100L
+    private val viewerId = 1L
+
+    private val jackpotLotteryService: JackpotLotteryService = mockk(relaxed = true)
+    private val configService: ConfigService = mockk(relaxed = true)
+    private val memberLookupHelper: MemberLookupHelper = mockk(relaxed = true)
+    private val userService: UserService = mockk(relaxed = true)
+    private val titleService: TitleService = mockk(relaxed = true)
+
+    private val service = LotteryWebService(
+        jackpotLotteryService,
+        configService,
+        memberLookupHelper,
+        userService,
+        titleService,
+    )
+
+    private fun stubWeightedOpenWithTickets(
+        tickets: List<JackpotLotteryTicketDto>,
+    ) {
+        val weightedOpen = JackpotLotteryDto(
+            id = 1L,
+            guildId = guildId,
+            ticketPrice = 50L,
+            poolAmount = 1_000L,
+            winnerCount = 3,
+            openedAt = Instant.now(),
+            closesAt = Instant.now().plusSeconds(3600),
+            status = JackpotLotteryDto.STATUS_OPEN,
+            mode = JackpotLotteryDto.MODE_TICKET_WEIGHTED,
+        )
+        every { jackpotLotteryService.getOpenWeighted(guildId) } returns weightedOpen
+        every { jackpotLotteryService.ticketsForOpenWeighted(guildId) } returns tickets
+        // No-op stubs so resolveAll doesn't throw when the test doesn't care.
+        every { memberLookupHelper.resolveAll(guildId, any()) } returns emptyMap()
+        every { memberLookupHelper.fallbackName(any()) } answers { "Player ${firstArg<Long>()}" }
+    }
+
+    @Test
+    fun `top holder with active title gets the title label`() {
+        val ticket = JackpotLotteryTicketDto(
+            lotteryId = 1L, discordId = 7L, ticketCount = 5, spent = 250L,
+        )
+        stubWeightedOpenWithTickets(listOf(ticket))
+
+        val user = UserDto(discordId = 7L, guildId = guildId, activeTitleId = 42L)
+        every { userService.getUserById(7L, guildId) } returns user
+        every { titleService.getById(42L) } returns TitleDto(id = 42L, label = "Lucky Roller")
+
+        val snap = service.snapshot(guildId, viewerId)
+
+        assertEquals(1, snap.weightedTopHolders.size)
+        assertEquals(7L, snap.weightedTopHolders[0].discordId)
+        assertEquals("Lucky Roller", snap.weightedTopHolders[0].title)
+    }
+
+    @Test
+    fun `top holder with no active title surfaces null title`() {
+        val ticket = JackpotLotteryTicketDto(
+            lotteryId = 1L, discordId = 8L, ticketCount = 3, spent = 150L,
+        )
+        stubWeightedOpenWithTickets(listOf(ticket))
+
+        every { userService.getUserById(8L, guildId) } returns
+            UserDto(discordId = 8L, guildId = guildId, activeTitleId = null)
+
+        val snap = service.snapshot(guildId, viewerId)
+
+        assertEquals(1, snap.weightedTopHolders.size)
+        assertNull(snap.weightedTopHolders[0].title)
+    }
+
+    @Test
+    fun `unresolvable title id swallowed - no exception, no pill`() {
+        val ticket = JackpotLotteryTicketDto(
+            lotteryId = 1L, discordId = 9L, ticketCount = 1, spent = 50L,
+        )
+        stubWeightedOpenWithTickets(listOf(ticket))
+
+        every { userService.getUserById(9L, guildId) } returns
+            UserDto(discordId = 9L, guildId = guildId, activeTitleId = 99L)
+        // Title id refers to a deleted / stale row.
+        every { titleService.getById(99L) } returns null
+
+        val snap = service.snapshot(guildId, viewerId)
+
+        assertEquals(1, snap.weightedTopHolders.size)
+        assertNull(snap.weightedTopHolders[0].title)
+    }
+
+    @Test
+    fun `userService throwing does not break the snapshot`() {
+        val ticket = JackpotLotteryTicketDto(
+            lotteryId = 1L, discordId = 10L, ticketCount = 2, spent = 100L,
+        )
+        stubWeightedOpenWithTickets(listOf(ticket))
+        every { userService.getUserById(10L, guildId) } throws RuntimeException("db down")
+
+        val snap = service.snapshot(guildId, viewerId)
+
+        // Snapshot still renders — title is null, but the holder is present.
+        assertEquals(1, snap.weightedTopHolders.size)
+        assertNull(snap.weightedTopHolders[0].title)
+    }
+}

--- a/web/src/test/kotlin/web/static/RichMemberStylingTest.kt
+++ b/web/src/test/kotlin/web/static/RichMemberStylingTest.kt
@@ -47,6 +47,13 @@ class RichMemberStylingTest {
      * pages all reference. Each must be defined as a top-level rule
      * in [baseCss] so every page picks it up via the always-loaded
      * base stylesheet.
+     *
+     * The numeric `.lb-value*` accents joined the list when the
+     * standings cards got their mobile redesign — moving them out of
+     * leaderboard.css means a future page that wants a coloured
+     * value pill can reuse them without re-importing leaderboard.css,
+     * AND the mobile shrink in the 640px standings-grid block always
+     * lines up with the right rule.
      */
     private val sharedPrimitives = listOf(
         ".member-cell",
@@ -57,6 +64,12 @@ class RichMemberStylingTest {
         ".lb-rank-2",
         ".lb-rank-3",
         ".lb-title-pill",
+        ".lb-value",
+        ".lb-value-credits",
+        ".lb-value-toby",
+        ".lb-value-portfolio",
+        ".lb-value-month",
+        ".lb-value-month-down",
     )
 
     @Test
@@ -118,6 +131,61 @@ class RichMemberStylingTest {
                     "dropping it lets a long name + medal + pill overflow the viewport on a 360px phone."
             )
         }
+    }
+
+    @Test
+    fun `standings table mobile redesign is centralised in base css`() {
+        // The standings cards used to render at 6 stacked label/value
+        // rows per row at desktop font sizes — bulky and visually
+        // disconnected on a phone. The 640px override re-lays each
+        // card as a 2-row grid (rank/member/title on top, three
+        // metrics on the bottom). The user explicitly asked for the
+        // fix to live in a shared/central location, not as a
+        // leaderboard.css one-off.
+        val mobileBlocks = extractAllMediaBlocks(baseCss, "max-width: 640px")
+        assertTrue(
+            mobileBlocks.isNotEmpty(),
+            "base.css must contain a `@media (max-width: 640px)` block " +
+                "carrying the standings 2-row grid override."
+        )
+        val combined = mobileBlocks.joinToString("\n")
+        assertTrue(
+            combined.contains(".lb-standings-table.mod-table tr") &&
+                combined.contains("display: grid") &&
+                combined.contains("grid-template-areas"),
+            "base.css 640px block must declare a CSS-grid layout for " +
+                "`.lb-standings-table.mod-table tr` so the standings cards " +
+                "show member info on top + metrics on the bottom — not a " +
+                "tower of stacked label/value strips."
+        )
+        // Each metric label that exists in the leaderboard template
+        // must be mapped to a grid area. If a future column rename
+        // (e.g. "Voice" -> "Voice (mo)") slips through, the cell will
+        // collapse onto the rank row and ruin the layout.
+        listOf(
+            "data-label=\"Credits\"",
+            "data-label=\"TOBY\"",
+            "data-label=\"This month\"",
+            "data-label=\"Voice\"",
+            "data-label=\"Portfolio\"",
+        ).forEach { selector ->
+            assertTrue(
+                combined.contains(selector),
+                "base.css 640px standings grid must map `$selector` to a " +
+                    "grid area; otherwise the metric collapses out of the " +
+                    "two-row layout when the data-label changes."
+            )
+        }
+
+        // And the leaderboard.css override should NOT exist — that's the
+        // "centralise it" half of the user's ask. Page-local overrides
+        // would defeat the point of moving the rule to base.css.
+        assertFalse(
+            leaderboardCss.contains(".lb-standings-table.mod-table tr") ||
+                leaderboardCss.contains("grid-template-areas"),
+            "leaderboard.css must NOT redefine the standings mobile grid; " +
+                "the centralised rule lives in base.css."
+        )
     }
 
     @Test

--- a/web/src/test/kotlin/web/static/RichMemberStylingTest.kt
+++ b/web/src/test/kotlin/web/static/RichMemberStylingTest.kt
@@ -1,0 +1,221 @@
+package web.static
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Pins the "rich Discord-member display" CSS contract. Three concrete
+ * bug patterns this test guards against:
+ *
+ * 1. **The leaderboard avatars regress to natural CDN size.** The
+ *    `.member-cell` + `.avatar` rules used to live in `moderation.css`,
+ *    which the leaderboard page does NOT load — so leaderboard
+ *    standings rows had no flex layout and avatars rendered at whatever
+ *    Discord returned (often 128px). Hoisted to `base.css`, the rule
+ *    applies on every page that loads the base stylesheet (i.e. all
+ *    of them).
+ *
+ * 2. **A future contributor re-defines a primitive locally.** If
+ *    `.member-cell { display: flex; ... }` reappears in `leaderboard.css`
+ *    or `lottery.css`, mobile-sizing changes in `base.css` stop
+ *    cascading — the duplicate wins on its page only and the layouts
+ *    silently drift again.
+ *
+ * 3. **The mobile shrink is dropped during a refactor.** The shared
+ *    480px breakpoint shrinks avatar + rank-badge + title-pill so a
+ *    long display name + medal + value pill fit on a 360px-wide phone.
+ *    A "tidy CSS" pass that removes the breakpoint would re-introduce
+ *    the off-screen-pill bug invisibly.
+ */
+class RichMemberStylingTest {
+
+    private val baseCss: String by lazy { readCss("static/css/base.css") }
+    private val leaderboardCss: String by lazy { readCss("static/css/leaderboard.css") }
+    private val lotteryCss: String by lazy { readCss("static/css/lottery.css") }
+    private val moderationCss: String by lazy { readCss("static/css/moderation.css") }
+
+    private fun readCss(path: String): String =
+        javaClass.classLoader
+            .getResourceAsStream(path)
+            ?.bufferedReader()
+            ?.readText()
+            ?: error("$path is not on the classpath")
+
+    /**
+     * The shared primitives the leaderboard / lottery / moderation
+     * pages all reference. Each must be defined as a top-level rule
+     * in [baseCss] so every page picks it up via the always-loaded
+     * base stylesheet.
+     */
+    private val sharedPrimitives = listOf(
+        ".member-cell",
+        ".avatar",
+        ".lb-name",
+        ".lb-rank",
+        ".lb-rank-1",
+        ".lb-rank-2",
+        ".lb-rank-3",
+        ".lb-title-pill",
+    )
+
+    @Test
+    fun `every shared rich-member primitive is defined in base css`() {
+        // Bug 1 guard: if any of these go missing from base.css the
+        // leaderboard page loses the rule entirely (it doesn't load
+        // moderation.css), and avatars regress to natural CDN size.
+        for (selector in sharedPrimitives) {
+            assertTrue(
+                baseCss.contains("$selector {") || baseCss.contains("$selector,"),
+                "base.css must declare $selector — leaderboard.html loads only " +
+                    "base.css + leaderboard.css, so a per-page CSS file can't be " +
+                    "the home for shared rich-member primitives."
+            )
+        }
+    }
+
+    @Test
+    fun `shared primitives are not redefined in per-page css`() {
+        // Bug 2 guard: a duplicate definition in a per-page file
+        // overrides the shared rule on that page, so a future mobile
+        // sizing tweak in base.css silently stops cascading.
+        val perPage = mapOf(
+            "leaderboard.css" to leaderboardCss,
+            "lottery.css" to lotteryCss,
+            "moderation.css" to moderationCss,
+        )
+        for ((file, css) in perPage) {
+            for (selector in sharedPrimitives) {
+                assertFalse(
+                    isTopLevelRule(css, selector),
+                    "$file must not redefine $selector — it lives in base.css. " +
+                        "A duplicate here will override the shared rule on that page only " +
+                        "and the rich-member layouts will drift again."
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `base css mobile shrink covers avatar + rank badge + title pill`() {
+        // Bug 3 guard: the 480px breakpoint shrinks the avatar/badge/pill
+        // so long display names don't push the value pill off-screen.
+        // base.css has multiple `@media (max-width: 480px)` blocks
+        // (modal/toast sizing predates the rich-member shrink), so look
+        // across ALL of them and assert each primitive lands in some
+        // 480px block.
+        val blocks = extractAllMediaBlocks(baseCss, "max-width: 480px")
+        assertTrue(
+            blocks.isNotEmpty(),
+            "base.css must contain at least one `@media (max-width: 480px)` block — " +
+                "without it the rich-member primitives revert to desktop sizing on phones."
+        )
+        val combined = blocks.joinToString("\n")
+        listOf(".avatar", ".lb-rank", ".lb-title-pill").forEach { sel ->
+            assertTrue(
+                isTopLevelRule(combined, sel),
+                "base.css must shrink $sel inside an `@media (max-width: 480px)` block — " +
+                    "dropping it lets a long name + medal + pill overflow the viewport on a 360px phone."
+            )
+        }
+    }
+
+    @Test
+    fun `leaderboard podium has its own phone-portrait shrink`() {
+        // Different from the shared primitive shrink because the podium
+        // uses bespoke 96/72px avatars; without a dedicated shrink the
+        // 1st-place gold-bordered card overflows a 360px viewport.
+        val combined = extractAllMediaBlocks(leaderboardCss, "max-width: 480px").joinToString("\n")
+        assertTrue(
+            isTopLevelRule(combined, ".lb-podium-avatar"),
+            "leaderboard.css must contain a `@media (max-width: 480px)` block with a " +
+                "rule for .lb-podium-avatar — the 96/72px desktop avatars overflow at 360px. " +
+                "(A renamed selector like `.lb-podium-avatar-foo` won't satisfy this test.)"
+        )
+    }
+
+    /**
+     * "Top-level rule for [selector]" means the selector starts a new
+     * rule (or is a member of a comma-separated selector list) — not a
+     * descendant in a compound selector like `.parent .member-cell`.
+     * Walks every occurrence of `selector {` or `selector,` and accepts
+     * only when the preceding non-whitespace char is `}` (previous rule
+     * ended), `,` (selector list head from a sibling), `*` (block
+     * comment close), or start-of-file. Rejects when preceded by an
+     * identifier char (`.foo-member-cell`) or by another selector
+     * (descendant combinator).
+     */
+    private fun isTopLevelRule(css: String, selector: String): Boolean {
+        val terminators = listOf('{', ',')
+        var idx = 0
+        while (idx < css.length) {
+            val hit = css.indexOf(selector, idx)
+            if (hit < 0) return false
+            idx = hit + selector.length
+
+            // Trailing char must (after optional whitespace) be { or ,.
+            var t = idx
+            while (t < css.length && css[t].isWhitespace()) t++
+            if (t >= css.length || css[t] !in terminators) continue
+
+            // Reject identifier-char prefix (`.foo-member-cell`).
+            val prev = if (hit == 0) ' ' else css[hit - 1]
+            if (prev.isLetterOrDigit() || prev == '-' || prev == '_') continue
+
+            // Walk back through whitespace; the first non-whitespace
+            // char must be a rule terminator (`}`), a selector-list
+            // separator (`,`), a block-comment close (`/`), or the
+            // start of the file. Anything else (a class char, etc.)
+            // means we're inside a compound or descendant selector.
+            var b = hit - 1
+            while (b >= 0 && css[b].isWhitespace()) b--
+            if (b >= 0 && css[b] !in setOf('}', ',', '/', '>', '+', '~').plus(';')) continue
+            // Note: `;` shouldn't appear at the top level between rules
+            // in valid CSS, but we permit it defensively. `>`, `+`, `~`
+            // suggest combinators inside a rule's selector list, which
+            // we DO want to flag — but only when our selector is the
+            // last component, not when it's `.parent > .member-cell`.
+            // Practical CSS in this repo doesn't use combinators ahead
+            // of these primitives, so this pragmatic check is fine.
+
+            return true
+        }
+        return false
+    }
+
+    /**
+     * Return the bodies of every `@media (...QUERY...) { ... }` block
+     * in [css]. Handles nested braces inside the media block.
+     */
+    private fun extractAllMediaBlocks(css: String, query: String): List<String> {
+        val out = mutableListOf<String>()
+        val anchor = "@media"
+        var idx = 0
+        while (true) {
+            val mediaStart = css.indexOf(anchor, idx)
+            if (mediaStart < 0) return out
+            val openBrace = css.indexOf('{', mediaStart)
+            if (openBrace < 0) return out
+            val header = css.substring(mediaStart, openBrace)
+            if (!header.contains(query)) {
+                idx = openBrace + 1
+                continue
+            }
+            var depth = 1
+            var i = openBrace + 1
+            while (i < css.length && depth > 0) {
+                when (css[i]) {
+                    '{' -> depth++
+                    '}' -> depth--
+                }
+                i++
+            }
+            if (depth == 0) {
+                out += css.substring(openBrace + 1, i - 1)
+                idx = i
+            } else {
+                return out
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Two improvements to the daily lottery so non-winners actually notice it and can act on it.

### Bot side — louder, clickable announcement

The daily lottery embed used to post silently and only ping winners — anyone who hadn't bought a ticket had no signal that a new draw had opened. Now the announcement carries:

- **A configurable wide ping** — new `LOTTERY_PING_MODE` config (off / here / everyone, default everyone). Surfaced on `moderation/lottery.html` next to the announce-channel row. `setAllowedMentions` is set explicitly on every send so JDA doesn't silently strip the `@everyone` / `@here` (USER mentions stay allowed so winner pings still fire).
- **A clickable `</lottery buy:id>` slash-command mention** in the call-to-action — one tap opens the buy flow. The command id is resolved lazily and cached for the process lifetime; if JDA can't resolve it (cold start, retrieval failure) we fall back to plain `` `/lottery buy` `` so the embed still ships.

The existing winner-ping line stays as a separate row when present.

### Web side — rich top-holders matching the leaderboard

The lottery page's "Top holders" list rendered raw `User #<discordId> — N tickets`. Replaced with avatar + display name + ticket count using the same Discord-member projection the leaderboard standings tables use:

- Extracted the leaderboard's inline `member-cell` markup into a shared Thymeleaf fragment `fragments/memberCell.html` (`th:fragment="cell(name, avatarUrl)"`). Both leaderboard standings tables (credits + TobyCoin) now consume the fragment, so a styling change lands in one place.
- `LotteryWebService.snapshot()` now batches a single `MemberLookupHelper.resolveAll(...)` call to enrich the top-5 holders with `name + avatarUrl` (falling back to `Player <last-4>` when a holder has left the guild — same behaviour as the leaderboard).
- Both top-holders sections in `lottery.html` (WEIGHTED daily mode + featured weighted event) consume the new fragment.

## Test plan

- [x] `:database:test --tests 'database.service.LotteryHelperPingModeTest'` — covers OFF / HERE / EVERYONE / unknown / missing / case-insensitive / whitespace-trim parsing of the new config.
- [x] `:web:test --tests 'web.controller.LotteryControllerTest'` — verifies the controller view-model maps the enriched `TopHolder` shape through cleanly.
- [x] `:web:test --tests 'web.controller.LeaderboardControllerTest'` — leaderboard fragment-extraction smoke.
- [x] `:web:test --tests 'web.template.*'` — Thymeleaf template regressions.
- [x] `:web:test --tests 'web.static.*'` — CSS regressions for the new `.lottery-top-holders li` flex rule.
- [x] `LotteryAnnouncerTest` updated for the new content layout: existing winner-ping tests still assert `<@1>` shows up; added cases for `PING_MODE=HERE`, `PING_MODE=OFF`, and that `setAllowedMentions` only includes `EVERYONE` when content actually has a wide ping. (Bot-side build can't run in this env — lavalink/libdave repos are blocked from the sandbox; tests will run on CI.)
- [ ] Smoke on a test guild after merge: from `moderation/lottery.html`, set ping mode to each value and trigger "Force draw now"; verify EVERYONE pings everyone, HERE pings only online, OFF posts the embed + clickable buy mention without a wide ping, and the `/lottery buy` mention is tappable in the Discord client.
- [ ] Browser check `/casino/{guildId}/lottery` for a guild with weighted tickets bought: top holders renders avatar + name + ticket count matching the leaderboard standings; departed members show `Player <last-4>` and no broken image.

https://claude.ai/code/session_01QWwHrVsZy3raBBQBRi8vcp

---
_Generated by [Claude Code](https://claude.ai/code/session_01QWwHrVsZy3raBBQBRi8vcp)_