### PR TITLE
feat(lottery): interactive buy button on announcement embed + modal infrastructure

### DIFF
--- a/application/src/main/resources/application.properties
+++ b/application/src/main/resources/application.properties
@@ -28,6 +28,8 @@ spring.flyway.baseline-version=0
 server.tomcat.threads.max=10
 server.tomcat.threads.min-spare=2
 
+app.base-url=${APP_BASE_URL:}
+
 # Multipart limits for intro uploads
 spring.servlet.multipart.max-file-size=600KB
 spring.servlet.multipart.max-request-size=600KB

--- a/application/src/test/kotlin/integration/bot/ButtonManagerTest.kt
+++ b/application/src/test/kotlin/integration/bot/ButtonManagerTest.kt
@@ -78,6 +78,7 @@ class ButtonManagerTest {
             InitiativeClearButton::class.java,
             InitiativeNextButton::class.java,
             InitiativePreviousButton::class.java,
+            LotteryBuyButton::class.java,
             PausePlayButton::class.java,
             PokerActionButton::class.java,
             ResendLastRequestButton::class.java,
@@ -86,7 +87,7 @@ class ButtonManagerTest {
         )
 
         assertTrue(availableButtons.containsAll(buttonManager.buttons.map { it.javaClass }.toList()))
-        assertEquals(13, buttonManager.buttons.size)
+        assertEquals(14, buttonManager.buttons.size)
     }
 
     @Test
@@ -114,6 +115,7 @@ class ButtonManagerTest {
             every { channel } returns mockChannel
             every { componentId } returns "stop"
             every { hook } returns mockHook
+            every { deferReply(any<Boolean>()) } returns mockk { every { queue() } just Runs }
             every { user } returns mockk {
                 every { idLong } returns 1L
             }
@@ -175,6 +177,7 @@ class ButtonManagerTest {
             every { channel } returns mockChannel
             every { componentId } returns "pause/play"
             every { hook } returns mockHook
+            every { deferReply(any<Boolean>()) } returns mockk { every { queue() } just Runs }
             every { user } returns mockk {
                 every { idLong } returns 1L
             }

--- a/core-api/src/main/kotlin/core/button/Button.kt
+++ b/core-api/src/main/kotlin/core/button/Button.kt
@@ -6,6 +6,7 @@ import database.dto.UserDto
 interface Button {
     val name: String
     val description: String
+    val defersReply: Boolean get() = true
     val logger: DiscordLogger get() = DiscordLogger.createLogger(this::class.java)
 
     fun handle(ctx: ButtonContext, requestingUserDto: UserDto, deleteDelay: Int)

--- a/core-api/src/main/kotlin/core/managers/ModalManager.kt
+++ b/core-api/src/main/kotlin/core/managers/ModalManager.kt
@@ -1,0 +1,13 @@
+package core.managers
+
+import core.modal.Modal
+import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent
+
+interface ModalManager {
+
+    val modals: List<Modal>
+
+    fun getModal(search: String): Modal? = modals.find { it.name.equals(search, true) }
+
+    fun handle(event: ModalInteractionEvent)
+}

--- a/core-api/src/main/kotlin/core/modal/Modal.kt
+++ b/core-api/src/main/kotlin/core/modal/Modal.kt
@@ -1,0 +1,10 @@
+package core.modal
+
+import common.logging.DiscordLogger
+
+interface Modal {
+    val name: String
+    val logger: DiscordLogger get() = DiscordLogger.createLogger(this::class.java)
+
+    fun handle(ctx: ModalContext, deleteDelay: Int)
+}

--- a/core-api/src/main/kotlin/core/modal/ModalContext.kt
+++ b/core-api/src/main/kotlin/core/modal/ModalContext.kt
@@ -1,0 +1,11 @@
+package core.modal
+
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.Member
+import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent
+
+interface ModalContext {
+    val guild: Guild
+    val event: ModalInteractionEvent
+    val member: Member?
+}

--- a/database/src/main/kotlin/database/dto/JackpotLotteryDto.kt
+++ b/database/src/main/kotlin/database/dto/JackpotLotteryDto.kt
@@ -8,6 +8,7 @@ import jakarta.persistence.Id
 import jakarta.persistence.NamedQueries
 import jakarta.persistence.NamedQuery
 import jakarta.persistence.Table
+import org.hibernate.annotations.DynamicUpdate
 import org.springframework.transaction.annotation.Transactional
 import java.io.Serializable
 import java.time.Instant
@@ -41,6 +42,7 @@ import java.time.Instant
     )
 )
 @Entity
+@DynamicUpdate
 @Table(name = "toby_coin_jackpot_lottery", schema = "public")
 @Transactional
 class JackpotLotteryDto(

--- a/discord-bot/src/main/kotlin/bot/configuration/ManagerConfig.kt
+++ b/discord-bot/src/main/kotlin/bot/configuration/ManagerConfig.kt
@@ -5,13 +5,16 @@ import bot.toby.managers.DefaultAutoCompleteManager
 import bot.toby.managers.DefaultButtonManager
 import bot.toby.managers.DefaultCommandManager
 import bot.toby.managers.DefaultMenuManager
+import bot.toby.managers.DefaultModalManager
 import core.autocomplete.AutocompleteHandler
 import core.button.Button
 import core.managers.AutocompleteManager
 import core.managers.ButtonManager
 import core.managers.CommandManager
 import core.managers.MenuManager
+import core.managers.ModalManager
 import core.menu.Menu
+import core.modal.Modal
 import database.service.ConfigService
 import database.service.SocialCreditAwardService
 import org.springframework.context.annotation.Bean
@@ -52,6 +55,14 @@ class ManagerConfig {
         buttons: List<Button>
     ): ButtonManager {
         return DefaultButtonManager(configService, userDtoHelper, buttons)
+    }
+
+    @Bean
+    fun modalManager(
+        configService: ConfigService,
+        modals: List<Modal>
+    ): ModalManager {
+        return DefaultModalManager(configService, modals)
     }
 
     @Bean

--- a/discord-bot/src/main/kotlin/bot/toby/button/buttons/LotteryBuyButton.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/button/buttons/LotteryBuyButton.kt
@@ -1,0 +1,29 @@
+package bot.toby.button.buttons
+
+import core.button.Button
+import core.button.ButtonContext
+import database.dto.UserDto
+import net.dv8tion.jda.api.components.label.Label
+import net.dv8tion.jda.api.components.textinput.TextInput
+import net.dv8tion.jda.api.components.textinput.TextInputStyle
+import net.dv8tion.jda.api.modals.Modal
+import org.springframework.stereotype.Component
+
+@Component
+class LotteryBuyButton : Button {
+    override val name = "lottery_buy"
+    override val description = "Opens a modal to buy lottery tickets"
+    override val defersReply = false
+
+    override fun handle(ctx: ButtonContext, requestingUserDto: UserDto, deleteDelay: Int) {
+        val countInput = TextInput.create("count", TextInputStyle.SHORT)
+            .setPlaceholder("1")
+            .setRequiredRange(1, 4)
+            .setRequired(true)
+            .build()
+        val modal = Modal.create("lottery_buy", "Buy Lottery Tickets")
+            .addComponents(Label.of("Number of tickets", countInput))
+            .build()
+        ctx.event.replyModal(modal).queue()
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/handler/MessageEventHandler.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/handler/MessageEventHandler.kt
@@ -6,10 +6,12 @@ import core.managers.AutocompleteManager
 import core.managers.ButtonManager
 import core.managers.CommandManager
 import core.managers.MenuManager
+import core.managers.ModalManager
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
+import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent
 import net.dv8tion.jda.api.events.interaction.command.CommandAutoCompleteInteractionEvent
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent
@@ -25,6 +27,7 @@ class MessageEventHandler @Autowired constructor(
     private val commandManager: CommandManager,
     private val buttonManager: ButtonManager,
     private val menuManager: MenuManager,
+    private val modalManager: ModalManager,
     private val autocompleteManager: AutocompleteManager
 ) : ListenerAdapter(), CoroutineScope {
 
@@ -99,10 +102,18 @@ class MessageEventHandler @Autowired constructor(
     }
 
     override fun onButtonInteraction(event: ButtonInteractionEvent) {
-        event.deferReply(true).queue()
         if (!event.user.isBot) {
             launch {
                 buttonManager.handle(event)
+            }
+        }
+    }
+
+    override fun onModalInteraction(event: ModalInteractionEvent) {
+        event.deferReply(true).queue()
+        if (!event.user.isBot) {
+            launch {
+                modalManager.handle(event)
             }
         }
     }

--- a/discord-bot/src/main/kotlin/bot/toby/managers/DefaultButtonManager.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/managers/DefaultButtonManager.kt
@@ -29,13 +29,14 @@ class DefaultButtonManager @Autowired constructor(
         } ?: return
 
 
-        val btn = getButton(event.componentId.lowercase())
+        val btn = getButton(event.componentId.lowercase()) ?: return
 
-        btn?.let {
-            event.channel.sendTyping().queue()
-            val ctx = DefaultButtonContext(event)
-            requestingUserDto.let { userDto -> it.handle(ctx, userDto, deleteDelay) }
+        if (btn.defersReply) {
+            event.deferReply(true).queue()
         }
+        event.channel.sendTyping().queue()
+        val ctx = DefaultButtonContext(event)
+        btn.handle(ctx, requestingUserDto, deleteDelay)
     }
 
     // Component IDs may be stateful (e.g. "highlow:HIGHER:9:50:6", "duel:accept:1:42").

--- a/discord-bot/src/main/kotlin/bot/toby/managers/DefaultModalManager.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/managers/DefaultModalManager.kt
@@ -1,0 +1,38 @@
+package bot.toby.managers
+
+import bot.toby.modal.DefaultModalContext
+import common.logging.DiscordLogger
+import core.managers.ModalManager
+import core.modal.Modal
+import database.dto.ConfigDto
+import database.service.ConfigService
+import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Configurable
+
+@Configurable
+class DefaultModalManager @Autowired constructor(
+    private val configService: ConfigService,
+    override val modals: List<Modal>
+) : ModalManager {
+    private val logger: DiscordLogger = DiscordLogger.createLogger(this::class.java)
+
+    override fun getModal(search: String): Modal? {
+        val prefix = search.substringBefore(':').lowercase()
+        return modals.find { it.name.equals(prefix, true) }
+    }
+
+    override fun handle(event: ModalInteractionEvent) {
+        val guild = event.guild ?: return
+        val modal = getModal(event.modalId) ?: run {
+            logger.warn("No modal handler for '${event.modalId}'")
+            return
+        }
+        val deleteDelay = configService.getConfigByName(
+            ConfigDto.Configurations.DELETE_DELAY.configValue,
+            guild.id
+        )?.value?.toIntOrNull() ?: 0
+        val ctx = DefaultModalContext(event)
+        modal.handle(ctx, deleteDelay)
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/modal/DefaultModalContext.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/modal/DefaultModalContext.kt
@@ -1,0 +1,13 @@
+package bot.toby.modal
+
+import core.modal.ModalContext
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.Member
+import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent
+import net.dv8tion.jda.api.interactions.callbacks.IReplyCallback
+
+class DefaultModalContext(private val interaction: IReplyCallback) : ModalContext {
+    override val guild: Guild get() = event.guild!!
+    override val event: ModalInteractionEvent get() = interaction as ModalInteractionEvent
+    override val member: Member? get() = event.member
+}

--- a/discord-bot/src/main/kotlin/bot/toby/modal/modals/LotteryBuyModal.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/modal/modals/LotteryBuyModal.kt
@@ -1,0 +1,45 @@
+package bot.toby.modal.modals
+
+import core.modal.Modal
+import core.modal.ModalContext
+import database.service.JackpotLotteryService
+import database.service.JackpotLotteryService.BuyOutcome
+import org.springframework.stereotype.Component
+
+@Component
+class LotteryBuyModal(
+    private val jackpotLotteryService: JackpotLotteryService,
+) : Modal {
+    override val name = "lottery_buy"
+
+    override fun handle(ctx: ModalContext, deleteDelay: Int) {
+        val event = ctx.event
+        val guildId = ctx.guild.idLong
+        val userId = event.user.idLong
+
+        val count = event.getValue("count")?.asString?.toIntOrNull() ?: run {
+            event.hook.sendMessage("Enter a valid number.").setEphemeral(true).queue()
+            return
+        }
+
+        when (val r = jackpotLotteryService.buyTickets(guildId, userId, count)) {
+            is BuyOutcome.Ok -> event.hook.sendMessage(
+                "Bought **$count** ticket(s). You now hold **${r.ticketCount}** tickets " +
+                    "(spent ${r.totalSpent} credits total). Prize pool: **${r.newPool}** credits. " +
+                    "Your balance: **${r.newBalance}** credits."
+            ).setEphemeral(true).queue()
+
+            BuyOutcome.NoOpenLottery ->
+                event.hook.sendMessage("No lottery is open right now.").setEphemeral(true).queue()
+
+            is BuyOutcome.InvalidCount ->
+                event.hook.sendMessage("Ticket count must be between 1 and 1,000.").setEphemeral(true).queue()
+
+            is BuyOutcome.Insufficient ->
+                event.hook.sendMessage("You only have **${r.have}** credits, need **${r.need}**.").setEphemeral(true).queue()
+
+            BuyOutcome.UnknownUser ->
+                event.hook.sendMessage("No user record yet. Try another TobyBot command first.").setEphemeral(true).queue()
+        }
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/scheduling/LotteryAnnouncer.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/scheduling/LotteryAnnouncer.kt
@@ -14,8 +14,11 @@ import net.dv8tion.jda.api.entities.Message
 import net.dv8tion.jda.api.entities.MessageEmbed
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
 import net.dv8tion.jda.api.exceptions.ErrorResponseException
+import net.dv8tion.jda.api.components.actionrow.ActionRow
+import net.dv8tion.jda.api.components.buttons.Button
 import net.dv8tion.jda.api.requests.ErrorResponse
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 import java.awt.Color
 
@@ -54,6 +57,7 @@ import java.awt.Color
 class LotteryAnnouncer @Autowired constructor(
     private val configService: ConfigService,
     private val jackpotLotteryService: JackpotLotteryService,
+    @Value("\${app.base-url:}") private val webBaseUrl: String = "",
 ) {
 
     /**
@@ -89,11 +93,15 @@ class LotteryAnnouncer @Autowired constructor(
         val content = buildAnnouncementContent(guild, priorOutcome)
         val lotteryId = (openOutcome as? OpenSummary.Ok)?.lotteryId
         val poolAmount = (openOutcome as? OpenSummary.Ok)?.poolAmount
+        val actionRow = announcementActionRow(mode, guild.idLong)
         runCatching {
             val send = channel.sendMessageEmbeds(embed)
                 .setAllowedMentions(allowedMentionTypes(content))
             if (content.isNotBlank()) {
                 send.addContent(content)
+            }
+            if (actionRow != null) {
+                send.addComponents(actionRow)
             }
             send.queue({ message ->
                 if (lotteryId != null && poolAmount != null) {
@@ -155,7 +163,10 @@ class LotteryAnnouncer @Autowired constructor(
                 return@queue
             }
             val rebuilt = rebuildWithUpdatedTodaysDraw(previous, lottery)
-            existing.editMessageEmbeds(rebuilt).queue({
+            val actionRow = announcementActionRow(lottery.mode, guild.idLong)
+            existing.editMessageEmbeds(rebuilt)
+                .setComponents(listOfNotNull(actionRow))
+                .queue({
                 runCatching { jackpotLotteryService.updateAnnouncedPool(lotteryId, lottery.poolAmount) }
                     .onFailure {
                         logger.warn(
@@ -259,6 +270,17 @@ class LotteryAnnouncer @Autowired constructor(
             val poolAmount: Long,
         ) : OpenSummary
         data object Skipped : OpenSummary
+    }
+
+    // ---- action row ----
+
+    private fun announcementActionRow(mode: String, guildId: Long): ActionRow? = when (mode) {
+        LotteryHelper.MODE_WEIGHTED -> ActionRow.of(
+            Button.primary("lottery_buy", "🎫 Buy Tickets")
+        )
+        else -> webBaseUrl.takeIf { it.isNotBlank() }?.let { base ->
+            ActionRow.of(Button.link("$base/casino/$guildId/lottery", "🎯 Pick Numbers"))
+        }
     }
 
     // ---- channel resolution ----

--- a/discord-bot/src/test/kotlin/bot/configuration/TestManagerConfig.kt
+++ b/discord-bot/src/test/kotlin/bot/configuration/TestManagerConfig.kt
@@ -4,6 +4,7 @@ import core.managers.AutocompleteManager
 import core.managers.ButtonManager
 import core.managers.CommandManager
 import core.managers.MenuManager
+import core.managers.ModalManager
 import io.mockk.mockk
 import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.context.annotation.Bean
@@ -25,6 +26,11 @@ open class TestManagerConfig {
 
     @Bean
     open fun buttonManager(): ButtonManager {
+        return mockk(relaxed = true)
+    }
+
+    @Bean
+    open fun modalManager(): ModalManager {
         return mockk(relaxed = true)
     }
 

--- a/discord-bot/src/test/kotlin/bot/toby/button/buttons/LotteryBuyButtonTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/button/buttons/LotteryBuyButtonTest.kt
@@ -1,0 +1,59 @@
+package bot.toby.button.buttons
+
+import bot.toby.button.ButtonTest
+import bot.toby.button.ButtonTest.Companion.event
+import bot.toby.button.DefaultButtonContext
+import database.dto.UserDto
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.unmockkAll
+import io.mockk.verify
+import net.dv8tion.jda.api.modals.Modal
+import net.dv8tion.jda.api.requests.restaction.interactions.ModalCallbackAction
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class LotteryBuyButtonTest : ButtonTest {
+
+    private lateinit var button: LotteryBuyButton
+
+    @BeforeEach
+    override fun setup() {
+        super.setup()
+        button = LotteryBuyButton()
+    }
+
+    @AfterEach
+    override fun tearDown() {
+        super.tearDown()
+        unmockkAll()
+    }
+
+    @Test
+    fun `name is lottery_buy`() {
+        assertEquals("lottery_buy", button.name)
+    }
+
+    @Test
+    fun `defersReply is false`() {
+        assertFalse(button.defersReply)
+    }
+
+    @Test
+    fun `handle opens a modal with id lottery_buy`() {
+        val modalSlot = slot<Modal>()
+        val modalAction = mockk<ModalCallbackAction>(relaxed = true)
+        every { event.replyModal(capture(modalSlot)) } returns modalAction
+
+        button.handle(DefaultButtonContext(event), UserDto(1L, 1L), 0)
+
+        verify(exactly = 1) { event.replyModal(any<Modal>()) }
+        verify(exactly = 1) { modalAction.queue() }
+        assertEquals("lottery_buy", modalSlot.captured.id)
+        assertEquals("Buy Lottery Tickets", modalSlot.captured.title)
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/handler/MessageEventHandlerTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/handler/MessageEventHandlerTest.kt
@@ -5,6 +5,7 @@ import core.managers.AutocompleteManager
 import core.managers.ButtonManager
 import core.managers.CommandManager
 import core.managers.MenuManager
+import core.managers.ModalManager
 import io.mockk.*
 import io.mockk.junit5.MockKExtension
 import net.dv8tion.jda.api.entities.Guild
@@ -24,12 +25,14 @@ class MessageEventHandlerTest {
     private val commandManager: CommandManager = mockk()
     private val buttonManager: ButtonManager = mockk()
     private val menuManager: MenuManager = mockk()
+    private val modalManager: ModalManager = mockk()
     private val autocompleteManager: AutocompleteManager = mockk()
     private val handler = spyk(
         MessageEventHandler(
             commandManager,
             buttonManager,
             menuManager,
+            modalManager,
             autocompleteManager
         )
     )

--- a/discord-bot/src/test/kotlin/bot/toby/modal/modals/LotteryBuyModalTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/modal/modals/LotteryBuyModalTest.kt
@@ -1,0 +1,138 @@
+package bot.toby.modal.modals
+
+import core.modal.ModalContext
+import database.service.JackpotLotteryService
+import database.service.JackpotLotteryService.BuyOutcome
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.User
+import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent
+import net.dv8tion.jda.api.interactions.InteractionHook
+import net.dv8tion.jda.api.interactions.modals.ModalMapping
+import net.dv8tion.jda.api.entities.Message
+import net.dv8tion.jda.api.requests.restaction.WebhookMessageCreateAction
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class LotteryBuyModalTest {
+
+    private lateinit var jackpotLotteryService: JackpotLotteryService
+    private lateinit var modal: LotteryBuyModal
+    private lateinit var ctx: ModalContext
+    private lateinit var event: ModalInteractionEvent
+    private lateinit var hook: InteractionHook
+    private val messageSlot = slot<String>()
+
+    @BeforeEach
+    fun setup() {
+        jackpotLotteryService = mockk()
+        modal = LotteryBuyModal(jackpotLotteryService)
+        hook = mockk(relaxed = true)
+        event = mockk(relaxed = true)
+
+        val guild = mockk<Guild> {
+            every { idLong } returns 100L
+        }
+        val user = mockk<User> {
+            every { idLong } returns 42L
+        }
+
+        every { event.user } returns user
+        every { event.hook } returns hook
+
+        ctx = mockk {
+            every { this@mockk.event } returns this@LotteryBuyModalTest.event
+            every { this@mockk.guild } returns guild
+        }
+
+        @Suppress("UNCHECKED_CAST")
+        val sendAction = mockk<WebhookMessageCreateAction<Message>>(relaxed = true)
+        every { hook.sendMessage(capture(messageSlot)) } returns sendAction
+        every { sendAction.setEphemeral(true) } returns sendAction
+        every { sendAction.queue() } just Runs
+    }
+
+    @Test
+    fun `name is lottery_buy`() {
+        assertEquals("lottery_buy", modal.name)
+    }
+
+    @Test
+    fun `replies with error when count is not a number`() {
+        val mapping = mockk<ModalMapping> { every { asString } returns "abc" }
+        every { event.getValue("count") } returns mapping
+
+        modal.handle(ctx, 0)
+
+        assertTrue(messageSlot.captured.contains("valid number"))
+    }
+
+    @Test
+    fun `replies with success on BuyOutcome Ok`() {
+        val mapping = mockk<ModalMapping> { every { asString } returns "5" }
+        every { event.getValue("count") } returns mapping
+        every { jackpotLotteryService.buyTickets(100L, 42L, 5) } returns BuyOutcome.Ok(
+            ticketCount = 10, totalSpent = 250L, newBalance = 750L, newPool = 2_000L,
+        )
+
+        modal.handle(ctx, 0)
+
+        assertTrue(messageSlot.captured.contains("Bought **5**"))
+        assertTrue(messageSlot.captured.contains("10"))
+        assertTrue(messageSlot.captured.contains("2000"))
+    }
+
+    @Test
+    fun `replies with error on NoOpenLottery`() {
+        val mapping = mockk<ModalMapping> { every { asString } returns "1" }
+        every { event.getValue("count") } returns mapping
+        every { jackpotLotteryService.buyTickets(100L, 42L, 1) } returns BuyOutcome.NoOpenLottery
+
+        modal.handle(ctx, 0)
+
+        assertTrue(messageSlot.captured.contains("No lottery is open"))
+    }
+
+    @Test
+    fun `replies with error on Insufficient funds`() {
+        val mapping = mockk<ModalMapping> { every { asString } returns "10" }
+        every { event.getValue("count") } returns mapping
+        every { jackpotLotteryService.buyTickets(100L, 42L, 10) } returns BuyOutcome.Insufficient(
+            have = 100L, need = 500L,
+        )
+
+        modal.handle(ctx, 0)
+
+        assertTrue(messageSlot.captured.contains("100"))
+        assertTrue(messageSlot.captured.contains("500"))
+    }
+
+    @Test
+    fun `replies with error on InvalidCount`() {
+        val mapping = mockk<ModalMapping> { every { asString } returns "0" }
+        every { event.getValue("count") } returns mapping
+        every { jackpotLotteryService.buyTickets(100L, 42L, 0) } returns BuyOutcome.InvalidCount(0)
+
+        modal.handle(ctx, 0)
+
+        assertTrue(messageSlot.captured.contains("between 1 and 1,000"))
+    }
+
+    @Test
+    fun `replies with error on UnknownUser`() {
+        val mapping = mockk<ModalMapping> { every { asString } returns "1" }
+        every { event.getValue("count") } returns mapping
+        every { jackpotLotteryService.buyTickets(100L, 42L, 1) } returns BuyOutcome.UnknownUser
+
+        modal.handle(ctx, 0)
+
+        assertTrue(messageSlot.captured.contains("No user record"))
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/scheduling/LotteryAnnouncerTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/scheduling/LotteryAnnouncerTest.kt
@@ -1,6 +1,7 @@
 package bot.toby.scheduling
 
 import database.dto.ConfigDto
+import database.dto.JackpotLotteryDto
 import database.service.ConfigService
 import database.service.JackpotLotteryService
 import io.mockk.Runs
@@ -9,6 +10,8 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
+import net.dv8tion.jda.api.components.MessageTopLevelComponent
+import net.dv8tion.jda.api.EmbedBuilder
 import net.dv8tion.jda.api.JDA
 import net.dv8tion.jda.api.Permission
 import net.dv8tion.jda.api.entities.Guild
@@ -16,12 +19,16 @@ import net.dv8tion.jda.api.entities.Message
 import net.dv8tion.jda.api.entities.MessageEmbed
 import net.dv8tion.jda.api.entities.SelfMember
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
+import net.dv8tion.jda.api.exceptions.ErrorResponseException
 import net.dv8tion.jda.api.interactions.commands.Command
+import net.dv8tion.jda.api.requests.ErrorResponse
 import net.dv8tion.jda.api.requests.RestAction
 import net.dv8tion.jda.api.requests.restaction.MessageCreateAction
+import net.dv8tion.jda.api.requests.restaction.MessageEditAction
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 /**
@@ -365,5 +372,142 @@ class LotteryAnnouncerTest {
         assertTrue(embedDescription.contains("3") && embedDescription.contains("42"))
         assertTrue(embedDescription.contains("<@1>"))
         assertTrue(contentSlot.captured.contains("<@1>"))
+    }
+
+    // ---- refreshAnnouncement ----
+
+    private fun openLottery(
+        id: Long = 1L,
+        poolAmount: Long = 1_500L,
+        announcedPoolAmount: Long? = 1_000L,
+        announcementMessageId: Long? = 999L,
+        announcementChannelId: Long? = 777L,
+        mode: String = JackpotLotteryDto.MODE_NUMBER_MATCH,
+    ) = JackpotLotteryDto(
+        id = id,
+        guildId = guildId,
+        ticketPrice = 50L,
+        poolAmount = poolAmount,
+        mode = mode,
+    ).also {
+        it.announcementMessageId = announcementMessageId
+        it.announcementChannelId = announcementChannelId
+        it.announcedPoolAmount = announcedPoolAmount
+    }
+
+    @Nested
+    inner class RefreshAnnouncement {
+
+        @Test
+        fun `short-circuits when announcementMessageId is null`() {
+            val lottery = openLottery(announcementMessageId = null)
+
+            announcer.refreshAnnouncement(guild, lottery)
+
+            verify(exactly = 0) { guild.getTextChannelById(any<Long>()) }
+            verify(exactly = 0) { jackpotLotteryService.updateAnnouncedPool(any(), any()) }
+        }
+
+        @Test
+        fun `short-circuits when announcementChannelId is null`() {
+            val lottery = openLottery(announcementChannelId = null)
+
+            announcer.refreshAnnouncement(guild, lottery)
+
+            verify(exactly = 0) { guild.getTextChannelById(any<Long>()) }
+        }
+
+        @Test
+        fun `short-circuits when announcedPoolAmount equals poolAmount`() {
+            val lottery = openLottery(poolAmount = 1_000L, announcedPoolAmount = 1_000L)
+
+            announcer.refreshAnnouncement(guild, lottery)
+
+            verify(exactly = 0) { guild.getTextChannelById(any<Long>()) }
+        }
+
+        @Test
+        fun `clears announcement ref when channel vanishes`() {
+            every { guild.getTextChannelById(777L) } returns null
+            val lottery = openLottery()
+
+            announcer.refreshAnnouncement(guild, lottery)
+
+            verify(exactly = 1) { jackpotLotteryService.clearAnnouncement(1L) }
+        }
+
+        @Test
+        fun `edits embed and updates watermark when pool has grown`() {
+            every { guild.getTextChannelById(777L) } returns channel
+
+            val previousEmbed = EmbedBuilder()
+                .setTitle("🎟️ Daily Lottery — Test Guild")
+                .addField(
+                    LotteryAnnouncer.YESTERDAYS_DRAW_FIELD,
+                    "No tickets bought. Seed returned to jackpot.",
+                    false,
+                )
+                .addField(
+                    LotteryAnnouncer.TODAYS_DRAW_FIELD,
+                    "**1000** credits in the pool · Ticket: **50** · Mode: **Pick 5 of 49** · Closes 24h.",
+                    false,
+                )
+                .build()
+            val message: Message = mockk(relaxed = true)
+            every { message.embeds } returns listOf(previousEmbed)
+
+            val retrieveAction: RestAction<Message> = mockk(relaxed = true)
+            every { channel.retrieveMessageById(999L) } returns retrieveAction
+            every {
+                retrieveAction.queue(any<java.util.function.Consumer<Message>>(), any())
+            } answers {
+                firstArg<java.util.function.Consumer<Message>>().accept(message)
+            }
+
+            val editAction: MessageEditAction = mockk(relaxed = true)
+            val editedEmbedSlot = slot<MessageEmbed>()
+            every { message.editMessageEmbeds(capture(editedEmbedSlot)) } returns editAction
+            every { editAction.setComponents(any<Collection<MessageTopLevelComponent>>()) } returns editAction
+            every {
+                editAction.queue(any<java.util.function.Consumer<Message>>(), any())
+            } answers {
+                firstArg<java.util.function.Consumer<Message>>().accept(message)
+            }
+
+            val lottery = openLottery(poolAmount = 1_500L, announcedPoolAmount = 1_000L)
+            announcer.refreshAnnouncement(guild, lottery)
+
+            val todayField = editedEmbedSlot.captured.fields.first { it.name == LotteryAnnouncer.TODAYS_DRAW_FIELD }
+            assertTrue(todayField.value!!.contains("1500"), "embed should show updated pool: ${todayField.value}")
+            assertFalse(todayField.value!!.contains("1000"), "embed should not show stale pool: ${todayField.value}")
+
+            val yesterdayField = editedEmbedSlot.captured.fields.first { it.name == LotteryAnnouncer.YESTERDAYS_DRAW_FIELD }
+            assertTrue(yesterdayField.value!!.contains("No tickets"), "yesterday's field should be preserved")
+
+            verify(exactly = 1) { jackpotLotteryService.updateAnnouncedPool(1L, 1_500L) }
+        }
+
+        @Test
+        fun `clears announcement ref on UNKNOWN_MESSAGE error`() {
+            every { guild.getTextChannelById(777L) } returns channel
+
+            val retrieveAction: RestAction<Message> = mockk(relaxed = true)
+            every { channel.retrieveMessageById(999L) } returns retrieveAction
+
+            val errorResponse: ErrorResponseException = mockk(relaxed = true)
+            every { errorResponse.errorResponse } returns ErrorResponse.UNKNOWN_MESSAGE
+
+            every {
+                retrieveAction.queue(any<java.util.function.Consumer<Message>>(), any())
+            } answers {
+                secondArg<java.util.function.Consumer<Throwable>>().accept(errorResponse)
+            }
+
+            val lottery = openLottery()
+            announcer.refreshAnnouncement(guild, lottery)
+
+            verify(exactly = 1) { jackpotLotteryService.clearAnnouncement(1L) }
+            verify(exactly = 0) { jackpotLotteryService.updateAnnouncedPool(any(), any()) }
+        }
     }
 }

--- a/discord-bot/src/test/kotlin/bot/toby/scheduling/LotteryRefreshJobTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/scheduling/LotteryRefreshJobTest.kt
@@ -1,0 +1,74 @@
+package bot.toby.scheduling
+
+import database.dto.JackpotLotteryDto
+import database.service.JackpotLotteryService
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import net.dv8tion.jda.api.JDA
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.utils.cache.SnowflakeCacheView
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class LotteryRefreshJobTest {
+
+    private lateinit var jda: JDA
+    private lateinit var jackpotLotteryService: JackpotLotteryService
+    private lateinit var lotteryAnnouncer: LotteryAnnouncer
+    private lateinit var job: LotteryRefreshJob
+
+    private val guildA: Guild = mockk(relaxed = true)
+    private val guildB: Guild = mockk(relaxed = true)
+
+    @BeforeEach
+    fun setup() {
+        jda = mockk(relaxed = true)
+        jackpotLotteryService = mockk(relaxed = true)
+        lotteryAnnouncer = mockk(relaxed = true)
+
+        every { guildA.idLong } returns 100L
+        every { guildB.idLong } returns 200L
+
+        val cache: SnowflakeCacheView<Guild> = mockk(relaxed = true)
+        every { jda.guildCache } returns cache
+        every { cache.iterator() } returns mutableListOf(guildA, guildB).iterator()
+
+        job = LotteryRefreshJob(jda, jackpotLotteryService, lotteryAnnouncer)
+    }
+
+    @Test
+    fun `refreshAll fans out to each guild and each open lottery`() {
+        val lotteryA = JackpotLotteryDto(id = 1L, guildId = 100L)
+        val lotteryB1 = JackpotLotteryDto(id = 2L, guildId = 200L)
+        val lotteryB2 = JackpotLotteryDto(id = 3L, guildId = 200L)
+        every { jackpotLotteryService.getOpenLotteriesForRefresh(100L) } returns listOf(lotteryA)
+        every { jackpotLotteryService.getOpenLotteriesForRefresh(200L) } returns listOf(lotteryB1, lotteryB2)
+
+        job.refreshAll()
+
+        verify(exactly = 1) { lotteryAnnouncer.refreshAnnouncement(guildA, lotteryA) }
+        verify(exactly = 1) { lotteryAnnouncer.refreshAnnouncement(guildB, lotteryB1) }
+        verify(exactly = 1) { lotteryAnnouncer.refreshAnnouncement(guildB, lotteryB2) }
+    }
+
+    @Test
+    fun `refreshAll isolates per-guild errors`() {
+        every { jackpotLotteryService.getOpenLotteriesForRefresh(100L) } throws RuntimeException("boom")
+        val lotteryB = JackpotLotteryDto(id = 2L, guildId = 200L)
+        every { jackpotLotteryService.getOpenLotteriesForRefresh(200L) } returns listOf(lotteryB)
+
+        job.refreshAll()
+
+        verify(exactly = 1) { lotteryAnnouncer.refreshAnnouncement(guildB, lotteryB) }
+    }
+
+    @Test
+    fun `refreshAll does nothing when no guilds have open lotteries`() {
+        every { jackpotLotteryService.getOpenLotteriesForRefresh(any()) } returns emptyList()
+
+        job.refreshAll()
+
+        verify(exactly = 0) { lotteryAnnouncer.refreshAnnouncement(any(), any()) }
+    }
+}


### PR DESCRIPTION
## Summary

- **Buy Tickets button** on weighted lottery announcement embeds — opens a modal for ticket count, processes the purchase via `buyTickets` service, replies ephemeral
- **Pick Numbers link button** on number match lottery embeds — opens the web lottery page (`/casino/{guildId}/lottery`), gracefully hidden when `APP_BASE_URL` is not set
- **Buttons persist across refresh edits** — `refreshAnnouncement` re-adds the action row via `setComponents` so buttons survive the 5-minute pool update cycle
- **Lottery refresh race condition fix** — added `@DynamicUpdate` to `JackpotLotteryDto` so `updateAnnouncedPool` and `buyTickets` don't overwrite each other's columns
- **Modal infrastructure** — new `Modal`/`ModalContext`/`ModalManager` interfaces + `DefaultModalManager` (mirrors the existing menu pattern), `Button.defersReply` property so modal-triggering buttons can skip the automatic `deferReply`

## Motivation

The lottery announcement channel is read-only, making the clickable `/lottery buy` slash-command mention a dead link — users can't execute commands in a channel they can't type in. Interactive buttons solve this by letting users buy directly from the embed.

## Files changed

| Area | Files | What |
|------|-------|------|
| Core API | `Button.kt`, `Modal.kt`, `ModalContext.kt`, `ModalManager.kt` | `defersReply` property + modal interfaces |
| Discord bot | `LotteryBuyButton.kt`, `LotteryBuyModal.kt` | Button opens modal, modal processes purchase |
| Discord bot | `DefaultModalContext.kt`, `DefaultModalManager.kt` | Modal routing infrastructure |
| Discord bot | `DefaultButtonManager.kt`, `MessageEventHandler.kt`, `ManagerConfig.kt` | Wire modal handling, conditional defer |
| Discord bot | `LotteryAnnouncer.kt` | Attach buttons to embed, preserve on refresh |
| Database | `JackpotLotteryDto.kt` | `@DynamicUpdate` for race condition fix |
| Config | `application.properties` | `app.base-url` property |

## Test plan

- [x] `./gradlew :discord-bot:test` — 738 tests pass (includes 3 new button tests, 6 new modal tests, 6 new refresh tests, 3 new refresh job tests)
- [x] `./gradlew :database:test` — all pass
- [ ] Deploy, open a weighted lottery → embed shows "Buy Tickets" button → click → modal → buy → ephemeral reply
- [ ] Open a number match lottery → embed shows "Pick Numbers" link → opens web page
- [ ] Wait for refresh tick → buttons persist after embed edit
- [ ] Buy tickets from the button while a refresh is in flight → no pool overwrite (DynamicUpdate fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)