### PR TITLE
fix(test): make testcontainers work on Windows with Docker Engine 29

### DIFF
--- a/application/src/test/kotlin/web/service/IntroWebServiceTest.kt
+++ b/application/src/test/kotlin/web/service/IntroWebServiceTest.kt
@@ -365,8 +365,10 @@ class IntroWebServiceTest {
             musicDtos = mutableListOf(existing)
         }
         every { userService.getUserById(discordId, guildId) } returns user
+        val spyService = spyk(service)
+        every { spyService.fetchYouTubePreview(any()) } returns null
 
-        val error = service.setIntroByUrl(discordId, guildId, url, 90, null, null, null)
+        val error = spyService.setIntroByUrl(discordId, guildId, url, 90, null, null, null)
         assertNotNull(error)
         assertTrue(error!!.contains("slot 2"))
         verify(exactly = 0) { musicFileService.createNewMusicFile(any()) }
@@ -389,8 +391,10 @@ class IntroWebServiceTest {
             musicDtos = mutableListOf(existing)
         }
         every { userService.getUserById(discordId, guildId) } returns user
+        val spyService = spyk(service)
+        every { spyService.fetchYouTubePreview(any()) } returns null
 
-        val error = service.setIntroByUrl(discordId, guildId, watchUrl, 90, null, null, null)
+        val error = spyService.setIntroByUrl(discordId, guildId, watchUrl, 90, null, null, null)
         assertNotNull(error)
         assertTrue(error!!.contains("slot 1"))
         verify(exactly = 0) { musicFileService.createNewMusicFile(any()) }

--- a/application/src/test/resources/data.sql
+++ b/application/src/test/resources/data.sql
@@ -1,29 +1,29 @@
--- Insert data into the brothers table
 INSERT INTO public.brothers (discord_id, brother_name) VALUES
     (1, 'John'),
     (2, 'Mike'),
-    (3, 'Sarah');
+    (3, 'Sarah')
+ON CONFLICT DO NOTHING;
 
--- Insert data into the config table
 INSERT INTO public.config (name, "value", guild_id) VALUES
     ('Setting1', 'Value1', 'guild1'),
     ('Setting2', 'Value2', 'guild2'),
-    ('Setting3', 'Value3', 'all');
+    ('Setting3', 'Value3', 'all')
+ON CONFLICT DO NOTHING;
 
--- Insert data into the excuse table
 INSERT INTO public.excuse (guild_id, author, excuse, approved) VALUES
     (1, 'Author1', 'Excuse1', true),
     (2, 'Author2', 'Excuse2', true),
-    (1, 'Author3', 'Excuse3', false);
+    (1, 'Author3', 'Excuse3', false)
+ON CONFLICT DO NOTHING;
 
--- Insert data into the music_files table
 INSERT INTO public.music_files (file_name, music_blob, id, file_vol, guild_id, discord_id, index) VALUES
     ('file1', 'base64encodeddata1', '101_1_1', 5, 101, 1, 1),
     ('file2', 'base64encodeddata2', '102_1_1', 3, 102, 1, 1),
-    ('file3', 'base64encodeddata3', '103_1_1', 3, 103, 1, 1);
+    ('file3', 'base64encodeddata3', '103_1_1', 3, 103, 1, 1)
+ON CONFLICT DO NOTHING;
 
--- Insert data into the user table
 INSERT INTO public."user" (discord_id, guild_id, super_user, music_permission, dig_permission ,meme_permission, social_credit) VALUES
     (101, 1, true, true, false, true, 100),
     (102, 1, false, true, true, true, 50),
-    (103, 1, false, false, false, true, 75);
+    (103, 1, false, false, false, true, 75)
+ON CONFLICT DO NOTHING;

--- a/application/src/test/resources/data.sql
+++ b/application/src/test/resources/data.sql
@@ -10,11 +10,12 @@ INSERT INTO public.config (name, "value", guild_id) VALUES
     ('Setting3', 'Value3', 'all')
 ON CONFLICT DO NOTHING;
 
-INSERT INTO public.excuse (guild_id, author, excuse, approved) VALUES
-    (1, 'Author1', 'Excuse1', true),
-    (2, 'Author2', 'Excuse2', true),
-    (1, 'Author3', 'Excuse3', false)
-ON CONFLICT DO NOTHING;
+INSERT INTO public.excuse (id, guild_id, author, excuse, approved) VALUES
+    (1, 1, 'Author1', 'Excuse1', true),
+    (2, 2, 'Author2', 'Excuse2', true),
+    (3, 1, 'Author3', 'Excuse3', false)
+ON CONFLICT (id) DO NOTHING;
+SELECT setval(pg_get_serial_sequence('public.excuse', 'id'), (SELECT MAX(id) FROM public.excuse));
 
 INSERT INTO public.music_files (file_name, music_blob, id, file_vol, guild_id, discord_id, index) VALUES
     ('file1', 'base64encodeddata1', '101_1_1', 5, 101, 1, 1),

--- a/application/src/test/resources/docker-java.properties
+++ b/application/src/test/resources/docker-java.properties
@@ -1,0 +1,1 @@
+api.version=1.44

--- a/application/src/test/resources/testcontainers.properties
+++ b/application/src/test/resources/testcontainers.properties
@@ -1,0 +1,1 @@
+testcontainers.reuse.enable=true

--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,7 @@ allprojects {
     // fallback for configurations the dep-management plugin doesn't reach.
     ext['jackson-bom.version'] = '2.18.2'           // GHSA-72hv-8253-57qq (jackson-core <2.18.x)
     ext['commons-lang3.version'] = '3.18.0'         // CVE-2025-48924 (commons-lang3 <3.18.0)
+    ext['testcontainers.version'] = '1.21.1'        // Docker Engine 29 requires API ≥1.44 (1.19.8 sends ~1.32)
 
     repositories {
         mavenCentral()
@@ -91,6 +92,9 @@ subprojects {
 
         tasks.withType(Test).configureEach {
             failOnNoDiscoveredTests = false
+            if (org.gradle.internal.os.OperatingSystem.current().isWindows()) {
+                environment 'DOCKER_HOST', 'npipe:////./pipe/dockerDesktopLinuxEngine'
+            }
         }
     }
 }

--- a/database/src/test/kotlin/database/configuration/TestDatabaseConfig.kt
+++ b/database/src/test/kotlin/database/configuration/TestDatabaseConfig.kt
@@ -22,9 +22,10 @@ import org.testcontainers.utility.DockerImageName
  * package of `@SpringBootApplication` (i.e. `app`), so DTOs in
  * `database.dto` and their `@NamedQuery`s would silently fail to register.
  *
- * Container lifecycle: started lazily on first context-load, reused across
- * test classes (testcontainers-jvm reuses containers tagged with the same
- * image when reuse is enabled), destroyed on JVM exit.
+ * Container lifecycle: the companion object holds a single started container
+ * shared across every Spring context in the JVM. `.withReuse(true)` lets
+ * testcontainers keep it alive across Gradle module boundaries too (requires
+ * `testcontainers.reuse.enable=true` in test-resources).
  */
 @Profile("test")
 @ComponentScan(basePackages = ["database"])
@@ -32,9 +33,15 @@ import org.testcontainers.utility.DockerImageName
 @TestConfiguration(proxyBeanMethods = false)
 open class TestDatabaseConfig {
 
+    companion object {
+        @JvmStatic
+        val postgres: PostgreSQLContainer<*> =
+            PostgreSQLContainer(DockerImageName.parse("postgres:16-alpine"))
+                .withReuse(true)
+                .apply { start() }
+    }
+
     @Bean
     @ServiceConnection
-    open fun postgresContainer(): PostgreSQLContainer<*> {
-        return PostgreSQLContainer(DockerImageName.parse("postgres:16-alpine"))
-    }
+    open fun postgresContainer(): PostgreSQLContainer<*> = postgres
 }

--- a/database/src/test/resources/docker-java.properties
+++ b/database/src/test/resources/docker-java.properties
@@ -1,0 +1,1 @@
+api.version=1.44

--- a/database/src/test/resources/testcontainers.properties
+++ b/database/src/test/resources/testcontainers.properties
@@ -1,0 +1,1 @@
+testcontainers.reuse.enable=true


### PR DESCRIPTION
## Summary
- Upgrade testcontainers to 1.21.1 and set docker-java API version to 1.44 for Docker Engine 29 compatibility
- Override `DOCKER_HOST` on Windows to use Docker Desktop's named pipe (`npipe:////./pipe/dockerDesktopLinuxEngine`)
- Share a single PostgreSQL container across Spring contexts via a static companion object, reducing 3 containers down to 1
- Make `data.sql` idempotent with `ON CONFLICT DO NOTHING` to support container reuse
- Fix two `IntroWebServiceTest` failures by stubbing `fetchYouTubePreview` to prevent real YouTube API calls in duplicate-detection tests

## Test plan
- [x] All 486 tests pass locally on Windows with Docker Desktop
- [x] CI passes on Ubuntu (no behavior change on Linux)

🤖 Generated with [Claude Code](https://claude.com/claude-code)