### PR TITLE
fix(lottery): use runtime mode constant when refreshing announcement embed

### DIFF
--- a/discord-bot/src/main/kotlin/bot/toby/scheduling/LotteryAnnouncer.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/scheduling/LotteryAnnouncer.kt
@@ -212,7 +212,16 @@ class LotteryAnnouncer @Autowired constructor(
             ticketPrice = lottery.ticketPrice,
             poolAmount = lottery.poolAmount,
         )
-        val freshTodayBody = renderOpenSummary(lottery.mode, freshSummary)
+        // [renderOpenSummary] expects the runtime mode string from
+        // [LotteryHelper] (e.g. "WEIGHTED"), but [lottery.mode] holds
+        // the DTO column value ("TICKET_WEIGHTED" / "NUMBER_MATCH").
+        // Translate explicitly so a refreshed weighted draw doesn't
+        // fall through to the "Pick 5 of 49" else branch.
+        val runtimeMode = when (lottery.mode) {
+            JackpotLotteryDto.MODE_TICKET_WEIGHTED -> LotteryHelper.MODE_WEIGHTED
+            else -> LotteryHelper.MODE_NUMBER_MATCH
+        }
+        val freshTodayBody = renderOpenSummary(runtimeMode, freshSummary)
         previous.fields.forEach { field ->
             if (field.name == TODAYS_DRAW_FIELD) {
                 builder.addField(TODAYS_DRAW_FIELD, freshTodayBody, false)

--- a/discord-bot/src/test/kotlin/bot/toby/scheduling/LotteryAnnouncerTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/scheduling/LotteryAnnouncerTest.kt
@@ -488,6 +488,64 @@ class LotteryAnnouncerTest {
         }
 
         @Test
+        fun `weighted refresh renders the weighted mode label, not the number-match one`() {
+            // Regression: rebuildWithUpdatedTodaysDraw used to pass
+            // lottery.mode (the DTO column value "TICKET_WEIGHTED")
+            // straight to renderOpenSummary, which expects the runtime
+            // constant "WEIGHTED". The comparison fell through and
+            // emitted "Pick 5 of 49" for refreshed weighted draws.
+            every { guild.getTextChannelById(777L) } returns channel
+
+            val previousEmbed = EmbedBuilder()
+                .setTitle("🎟️ Daily Lottery — Test Guild")
+                .addField(
+                    LotteryAnnouncer.TODAYS_DRAW_FIELD,
+                    "**1000** credits in the pool · Ticket: **50** · Mode: **Top-3 weighted** · Closes 24h.",
+                    false,
+                )
+                .build()
+            val message: Message = mockk(relaxed = true)
+            every { message.embeds } returns listOf(previousEmbed)
+
+            val retrieveAction: RestAction<Message> = mockk(relaxed = true)
+            every { channel.retrieveMessageById(999L) } returns retrieveAction
+            every {
+                retrieveAction.queue(any<java.util.function.Consumer<Message>>(), any())
+            } answers {
+                firstArg<java.util.function.Consumer<Message>>().accept(message)
+            }
+
+            val editAction: MessageEditAction = mockk(relaxed = true)
+            val editedEmbedSlot = slot<MessageEmbed>()
+            every { message.editMessageEmbeds(capture(editedEmbedSlot)) } returns editAction
+            every { editAction.setComponents(any<Collection<MessageTopLevelComponent>>()) } returns editAction
+            every {
+                editAction.queue(any<java.util.function.Consumer<Message>>(), any())
+            } answers {
+                firstArg<java.util.function.Consumer<Message>>().accept(message)
+            }
+
+            val lottery = openLottery(
+                poolAmount = 2_000L,
+                announcedPoolAmount = 1_000L,
+                mode = JackpotLotteryDto.MODE_TICKET_WEIGHTED,
+            )
+            announcer.refreshAnnouncement(guild, lottery)
+
+            val todayField = editedEmbedSlot.captured.fields.first {
+                it.name == LotteryAnnouncer.TODAYS_DRAW_FIELD
+            }
+            assertTrue(
+                todayField.value!!.contains("Top-3 weighted"),
+                "weighted refresh should render the weighted label: ${todayField.value}",
+            )
+            assertFalse(
+                todayField.value!!.contains("Pick 5 of 49"),
+                "weighted refresh should not render the number-match label: ${todayField.value}",
+            )
+        }
+
+        @Test
         fun `clears announcement ref on UNKNOWN_MESSAGE error`() {
             every { guild.getTextChannelById(777L) } returns channel
 


### PR DESCRIPTION
## Summary
- The lottery refresh job has been overwriting weighted-mode announcement embeds with the wrong "Today's draw" mode label (`Pick 5 of 49`) while the footer + yesterday's recap correctly say it's a weighted draw.
- Root cause: `rebuildWithUpdatedTodaysDraw` passes `lottery.mode` (the DTO column value `"TICKET_WEIGHTED"`) straight to `renderOpenSummary`, which expects the runtime config string from `LotteryHelper.MODE_WEIGHTED` (`"WEIGHTED"`). The comparison falls through to the else branch and emits "Pick 5 of 49" for weighted draws. `NUMBER_MATCH` was unaffected because the strings happen to match on both sides.
- Fix: translate `lottery.mode` → runtime mode at the one site that mixes the two constant systems. Localised — the two constant systems exist for legitimate storage-vs-config-input reasons.
- Existing announced weighted rows in the wild will heal on the next refresh tick once the pool changes.

## Test plan
- [x] New `LotteryAnnouncerTest` case asserts a refreshed `TICKET_WEIGHTED` lottery renders **"Top-3 weighted"** and **not** "Pick 5 of 49"
- [ ] CI: `./gradlew :discord-bot:test` (couldn't compile locally — lavalink/jitpack 403s in the sandbox; CI will run)
- [ ] Manual: trigger a weighted daily roll in the dev guild, `/lottery buy 1`, wait < 5 min, confirm the refreshed embed still says "Top-3 weighted"

https://claude.ai/code/session_01UAXAiKxVAiEeMRBFRkTgZH

---
_Generated by [Claude Code](https://claude.ai/code/session_01UAXAiKxVAiEeMRBFRkTgZH)_