### PR TITLE
fix(lottery): preserve action-row buttons on refresh for weighted mode

### DIFF
--- a/discord-bot/src/main/kotlin/bot/toby/scheduling/LotteryAnnouncer.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/scheduling/LotteryAnnouncer.kt
@@ -163,7 +163,7 @@ class LotteryAnnouncer @Autowired constructor(
                 return@queue
             }
             val rebuilt = rebuildWithUpdatedTodaysDraw(previous, lottery)
-            val actionRow = announcementActionRow(lottery.mode, guild.idLong)
+            val actionRow = announcementActionRow(runtimeMode(lottery.mode), guild.idLong)
             existing.editMessageEmbeds(rebuilt)
                 .setComponents(listOfNotNull(actionRow))
                 .queue({
@@ -217,11 +217,7 @@ class LotteryAnnouncer @Autowired constructor(
         // the DTO column value ("TICKET_WEIGHTED" / "NUMBER_MATCH").
         // Translate explicitly so a refreshed weighted draw doesn't
         // fall through to the "Pick 5 of 49" else branch.
-        val runtimeMode = when (lottery.mode) {
-            JackpotLotteryDto.MODE_TICKET_WEIGHTED -> LotteryHelper.MODE_WEIGHTED
-            else -> LotteryHelper.MODE_NUMBER_MATCH
-        }
-        val freshTodayBody = renderOpenSummary(runtimeMode, freshSummary)
+        val freshTodayBody = renderOpenSummary(runtimeMode(lottery.mode), freshSummary)
         previous.fields.forEach { field ->
             if (field.name == TODAYS_DRAW_FIELD) {
                 builder.addField(TODAYS_DRAW_FIELD, freshTodayBody, false)
@@ -282,6 +278,20 @@ class LotteryAnnouncer @Autowired constructor(
     }
 
     // ---- action row ----
+
+    /**
+     * Translate the DTO `mode` column value
+     * ([JackpotLotteryDto.MODE_TICKET_WEIGHTED] / [JackpotLotteryDto.MODE_NUMBER_MATCH])
+     * to the runtime mode string used by config + render code
+     * ([LotteryHelper.MODE_WEIGHTED] / [LotteryHelper.MODE_NUMBER_MATCH]).
+     * The two systems exist for separate reasons (storage vs admin input)
+     * and differ for the weighted case (`TICKET_WEIGHTED` vs `WEIGHTED`);
+     * the refresh path is the only place that has to bridge them.
+     */
+    private fun runtimeMode(dtoMode: String): String = when (dtoMode) {
+        JackpotLotteryDto.MODE_TICKET_WEIGHTED -> LotteryHelper.MODE_WEIGHTED
+        else -> LotteryHelper.MODE_NUMBER_MATCH
+    }
 
     private fun announcementActionRow(mode: String, guildId: Long): ActionRow? = when (mode) {
         LotteryHelper.MODE_WEIGHTED -> ActionRow.of(

--- a/discord-bot/src/test/kotlin/bot/toby/scheduling/LotteryAnnouncerTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/scheduling/LotteryAnnouncerTest.kt
@@ -517,8 +517,9 @@ class LotteryAnnouncerTest {
 
             val editAction: MessageEditAction = mockk(relaxed = true)
             val editedEmbedSlot = slot<MessageEmbed>()
+            val componentsSlot = slot<Collection<MessageTopLevelComponent>>()
             every { message.editMessageEmbeds(capture(editedEmbedSlot)) } returns editAction
-            every { editAction.setComponents(any<Collection<MessageTopLevelComponent>>()) } returns editAction
+            every { editAction.setComponents(capture(componentsSlot)) } returns editAction
             every {
                 editAction.queue(any<java.util.function.Consumer<Message>>(), any())
             } answers {
@@ -542,6 +543,17 @@ class LotteryAnnouncerTest {
             assertFalse(
                 todayField.value!!.contains("Pick 5 of 49"),
                 "weighted refresh should not render the number-match label: ${todayField.value}",
+            )
+            // Regression: refresh used to pass lottery.mode (the DTO
+            // column "TICKET_WEIGHTED") to announcementActionRow, which
+            // compares against LotteryHelper.MODE_WEIGHTED ("WEIGHTED").
+            // The comparison missed, fell through to the URL-button
+            // branch, and that branch returned null when webBaseUrl was
+            // blank — stripping the "Buy Tickets" button on every refresh.
+            assertTrue(
+                componentsSlot.captured.isNotEmpty(),
+                "weighted refresh should preserve the Buy Tickets action row, " +
+                    "got: ${componentsSlot.captured}",
             )
         }
 


### PR DESCRIPTION
## Summary
- Companion fix to #438. After that PR the **mode label** on refreshed weighted-draw embeds was right, but the **action-row buttons** still disappeared.
- Same root cause, second site: `refreshAnnouncement` at line 166 was passing `lottery.mode` (the DTO column value `"TICKET_WEIGHTED"`) to `announcementActionRow`, which compares against `LotteryHelper.MODE_WEIGHTED` (`"WEIGHTED"`). The comparison missed, fell through to the URL-button else branch, and that branch returned `null` when `webBaseUrl` was blank — so `setComponents(listOfNotNull(null))` stripped the "🎫 Buy Tickets" row on every refresh edit.
- Extracts the DTO→runtime mode mapping into a private `runtimeMode()` helper now used by both `renderOpenSummary` and `announcementActionRow` on the refresh path. Initial-announce already gets the runtime mode directly from `LotteryDailyJob` and is unaffected.
- Existing announced messages in the wild heal on the next refresh tick (next ticket buy or daily roll).

## Test plan
- [x] New assertion in the existing weighted-refresh test asserts `setComponents` is called with a non-empty collection
- [ ] CI: `./gradlew :discord-bot:test`
- [ ] Manual: in the dev guild, buy a ticket on a weighted draw, wait < 5 min, confirm the refreshed embed still has the "🎫 Buy Tickets" button attached

https://claude.ai/code/session_01UAXAiKxVAiEeMRBFRkTgZH

---
_Generated by [Claude Code](https://claude.ai/code/session_01UAXAiKxVAiEeMRBFRkTgZH)_