### PR TITLE
feat(jackpot): structurally exclude HighLow wins from rolling

### DIFF
--- a/database/src/main/kotlin/database/service/JackpotHelper.kt
+++ b/database/src/main/kotlin/database/service/JackpotHelper.kt
@@ -6,20 +6,31 @@ import kotlin.random.Random
 
 /**
  * Casino games that feed the jackpot pool, paired with their canonical
- * RTP. The value is the highest plausible RTP across that game's bet
- * variants (Banker for Baccarat, basic-strategy for Blackjack, etc.) —
- * the RTP eligibility gate uses it to decide whether a game is "too
- * generous" to also pay a jackpot. Pinned alongside the per-game test
- * suites in `database.economy` / `database.blackjack`; if a game's
- * payout schedule is tuned, the value here moves with it.
+ * RTP and a [eligibleForJackpot] policy flag. RTP is the highest
+ * plausible value across the game's bet variants (Banker for Baccarat,
+ * basic-strategy for Blackjack, etc.) — the per-guild RTP eligibility
+ * gate uses it to decide whether a game is "too generous" to also pay
+ * a jackpot. Pinned alongside the per-game test suites in
+ * `database.economy` / `database.blackjack`; if a game's payout
+ * schedule is tuned, the value here moves with it.
+ *
+ * [eligibleForJackpot] is a global structural carve-out for games
+ * where the RTP gate isn't the right proxy. HighLow honestly returns
+ * 12/13 RTP, but the player can pick direction against an anchor
+ * dealt from 2..12 — at the extremes that wins ~85 % of the time
+ * with a tiny multiplier. `rollOnWin` fires per *win*, not per credit
+ * of house edge, so HighLow lets a player rack up free jackpot rolls
+ * while bleeding only the honest 7.7 % edge. The flag disables the
+ * win-roll while leaving `divertOnLoss` untouched — losses still feed
+ * the pool, wins just don't claim from it.
  */
-enum class JackpotGame(val rtp: Double) {
+enum class JackpotGame(val rtp: Double, val eligibleForJackpot: Boolean = true) {
     COINFLIP(1.0),     // 50/50 fair, 2× payout — no house edge by design.
     BLACKJACK(0.99),   // Basic strategy hovers ~99-100%; conservatively 0.99.
     BACCARAT(0.99),    // Banker ~98.94%, Player ~98.76% — pin to the higher.
     ROULETTE(0.973),   // 36/37 European wheel — uniform across bet types.
     HOLDEM(0.97),      // Casino Hold'em vs dealer; ~2-3% edge industry-wide.
-    HIGHLOW(0.923),    // 12/13 ≈ deckSize-1/deckSize regardless of direction.
+    HIGHLOW(0.923, eligibleForJackpot = false), // Honest 12/13 RTP but ~85 % win rate at extreme anchors farms rolls; loss-tribute only.
     KENO(0.92),        // 0.83-0.92 band; pin to the top so the gate is honest.
     SLOTS(0.890),      // ~11% house edge; closed-form pinned by SlotMachineTest.
     SCRATCH(0.875),    // ~12.5% edge; pinned by ScratchCard.expectedRtp().
@@ -157,6 +168,11 @@ internal object JackpotHelper {
      * the anchor cap at full base probability. Decoupled from each
      * game's max stake so admins can raise stakes arbitrarily without
      * shrinking jackpot odds.
+     *
+     * Games carrying [JackpotGame.eligibleForJackpot] = `false` skip
+     * the roll entirely — they're hard-coded ineligible regardless of
+     * RTP or any per-guild config, because the RTP gate is the wrong
+     * proxy for them (typically high-win-rate, honest-edge designs).
      */
     fun rollOnWin(
         jackpotService: JackpotService,
@@ -168,6 +184,7 @@ internal object JackpotHelper {
         game: JackpotGame,
         random: Random
     ): Long {
+        if (!game.eligibleForJackpot) return 0L
         val baseProbability = winProbability(configService, guildId)
         val anchor = stakeAnchor(configService, guildId)
         val scale = (stake.toDouble() / anchor.toDouble()).coerceIn(0.0, 1.0)

--- a/database/src/test/kotlin/database/service/HighlowServiceTest.kt
+++ b/database/src/test/kotlin/database/service/HighlowServiceTest.kt
@@ -141,6 +141,28 @@ class HighlowServiceTest {
     }
 
     @Test
+    fun `win never rolls the jackpot — HIGHLOW carries the global eligibility carve-out`() {
+        // Even with a forced-hit RNG and a non-empty pool, a HighLow win
+        // must surface jackpotPayout=0 and never touch the pool.
+        // `JackpotGame.HIGHLOW.eligibleForJackpot = false` short-circuits
+        // `JackpotHelper.rollOnWin` regardless of config.
+        val user = userWithBalance(1_000L)
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns user
+        every { highlow.play(Highlow.Direction.HIGHER, any()) } returns Highlow.Hand(
+            anchor = 7, next = 10, direction = Highlow.Direction.HIGHER, multiplier = 2.0
+        )
+        every { userService.updateUser(any()) } returns user
+        every { jackpotService.awardJackpot(guildId) } returns 9_999L  // would be banked if HIGHLOW were eligible
+
+        val outcome = service.play(discordId, guildId, stake = 100L, direction = Highlow.Direction.HIGHER)
+
+        val win = assertInstanceOf(HighlowService.PlayOutcome.Win::class.java, outcome)
+        assertEquals(0L, win.jackpotPayout)
+        assertEquals(1_100L, win.newBalance, "newBalance must not include any jackpot top-up")
+        verify(exactly = 0) { jackpotService.awardJackpot(any()) }
+    }
+
+    @Test
     fun `loss tributes 10 percent of the stake into the jackpot pool`() {
         val user = userWithBalance(500L)
         every { userService.getUserByIdForUpdate(discordId, guildId) } returns user

--- a/database/src/test/kotlin/database/service/JackpotHelperTest.kt
+++ b/database/src/test/kotlin/database/service/JackpotHelperTest.kt
@@ -698,6 +698,54 @@ class JackpotHelperTest {
         assertEquals(50L, won, "gate disabled — Coinflip wins still roll")
     }
 
+    // ---- eligibleForJackpot global carve-out ----
+
+    @Test
+    fun `rollOnWin returns zero for games carrying eligibleForJackpot=false`() {
+        // HIGHLOW is the only game with the flag today — it has an honest
+        // 12/13 RTP but the player can pick direction against an extreme
+        // anchor to win ~85 % of plays, which would farm jackpot rolls
+        // even though the RTP gate considers it eligible.
+        winConfigReturns("1")
+        anchorConfigReturns(MAX_STAKE.toString())
+        rtpConfigReturns(null)  // gate disabled — proves the carve-out is independent
+        val user = freshUser(initial = 100L)
+
+        val won = JackpotHelper.rollOnWin(
+            jackpotService, configService, userService, user, guildId,
+            stake = MAX_STAKE, game = JackpotGame.HIGHLOW, random = stubRandom(0.0)
+        )
+
+        assertEquals(0L, won, "HIGHLOW wins must never roll for the jackpot")
+        assertEquals(100L, user.socialCredit, "balance untouched on carve-out")
+        verify(exactly = 0) { jackpotService.awardJackpot(any()) }
+        verify(exactly = 0) { jackpotService.recordWin(any(), any(), any(), any()) }
+        verify(exactly = 0) { userService.updateUser(any()) }
+    }
+
+    @Test
+    fun `rollOnWin still allows other eligible games when one game is carved out`() {
+        // Sanity check that the global flag short-circuits per-game rather
+        // than per-call — a HIGHLOW play returning zero must not poison the
+        // subsequent SLOTS play.
+        winConfigReturns("1")
+        anchorConfigReturns(MAX_STAKE.toString())
+        rtpConfigReturns(null)
+        every { jackpotService.awardJackpot(guildId) } returns 500L
+
+        val highlow = JackpotHelper.rollOnWin(
+            jackpotService, configService, userService, freshUser(), guildId,
+            stake = MAX_STAKE, game = JackpotGame.HIGHLOW, random = stubRandom(0.001)
+        )
+        val slots = JackpotHelper.rollOnWin(
+            jackpotService, configService, userService, freshUser(), guildId,
+            stake = MAX_STAKE, game = JackpotGame.SLOTS, random = stubRandom(0.001)
+        )
+
+        assertEquals(0L, highlow)
+        assertEquals(500L, slots)
+    }
+
     @Test
     fun `activityMinDays coerces to at least 1`() {
         every {

--- a/web/src/main/kotlin/web/casino/CasinoPageContext.kt
+++ b/web/src/main/kotlin/web/casino/CasinoPageContext.kt
@@ -52,13 +52,28 @@ class CasinoPageContext(
         model.addAttribute("jackpotPool", jackpotService.getPool(guildId))
         model.addAttribute("jackpotWinPct", jackpotService.winProbabilityDisplay(guildId))
         model.addAttribute("jackpotStakeAnchor", jackpotService.stakeAnchor(guildId))
-        // Per-game RTP eligibility — only set when caller declares which
-        // game this page is for. Lottery / poker pages share the banner
-        // but don't roll for the jackpot themselves, so they leave `game`
+        // Per-game eligibility — only set when caller declares which game
+        // this page is for. Lottery / poker pages share the banner but
+        // don't roll for the jackpot themselves, so they leave `game`
         // null and the banner stays in its eligible-by-default form.
-        if (game != null && !jackpotService.isEligibleByRtp(guildId, game)) {
-            model.addAttribute("jackpotIneligible", true)
-            model.addAttribute("jackpotRtpMax", jackpotService.rtpMaxPct(guildId))
+        // Two ineligibility paths:
+        //   - "structural": the game is globally carved out via
+        //     `JackpotGame.eligibleForJackpot=false` (HighLow's case —
+        //     honest RTP but win-rate would farm rolls). Wins skip the
+        //     jackpot, losses still tribute.
+        //   - "rtp": the per-guild `JACKPOT_RTP_MAX_PCT` ceiling gates
+        //     this game out. Same player-facing effect, different reason.
+        // The structural reason wins when both apply, since it's the
+        // stronger (admin can't loosen it via config).
+        if (game != null) {
+            if (!game.eligibleForJackpot) {
+                model.addAttribute("jackpotIneligible", true)
+                model.addAttribute("jackpotIneligibleReason", "structural")
+            } else if (!jackpotService.isEligibleByRtp(guildId, game)) {
+                model.addAttribute("jackpotIneligible", true)
+                model.addAttribute("jackpotIneligibleReason", "rtp")
+                model.addAttribute("jackpotRtpMax", jackpotService.rtpMaxPct(guildId))
+            }
         }
         model.addAttribute("username", user.displayName())
         return guild

--- a/web/src/main/resources/templates/fragments/casino.html
+++ b/web/src/main/resources/templates/fragments/casino.html
@@ -19,11 +19,16 @@
         <span th:text="${jackpotStakeAnchor}">500</span>-credit reference;
         bets at or above that get the full rate, smaller bets scale linearly down.
     </span>
-    <span class="muted" th:if="${jackpotIneligible}">
+    <span class="muted" th:if="${jackpotIneligible and jackpotIneligibleReason == 'rtp'}">
         — this game doesn't roll for the jackpot: its RTP is above the
         configured ceiling of
         <span th:text="${jackpotRtpMax}">95</span>%. Wins still pay out
         normally, but won't bank the pool.
+    </span>
+    <span class="muted" th:if="${jackpotIneligible and jackpotIneligibleReason == 'structural'}">
+        — this game doesn't roll for the jackpot: its win rate is too
+        high to be a fair contributor. Wins still pay out normally,
+        but won't bank the pool. Losses still tribute as usual.
     </span>
 </div>
 </body>

--- a/web/src/main/resources/templates/fragments/casino.html
+++ b/web/src/main/resources/templates/fragments/casino.html
@@ -19,17 +19,19 @@
         <span th:text="${jackpotStakeAnchor}">500</span>-credit reference;
         bets at or above that get the full rate, smaller bets scale linearly down.
     </span>
-    <span class="muted" th:if="${jackpotIneligible and jackpotIneligibleReason == 'rtp'}">
-        — this game doesn't roll for the jackpot: its RTP is above the
-        configured ceiling of
-        <span th:text="${jackpotRtpMax}">95</span>%. Wins still pay out
-        normally, but won't bank the pool.
-    </span>
-    <span class="muted" th:if="${jackpotIneligible and jackpotIneligibleReason == 'structural'}">
-        — this game doesn't roll for the jackpot: its win rate is too
-        high to be a fair contributor. Wins still pay out normally,
-        but won't bank the pool. Losses still tribute as usual.
-    </span>
+    <th:block th:if="${jackpotIneligible}">
+        <span class="muted" th:if="${jackpotIneligibleReason == 'rtp'}">
+            — this game doesn't roll for the jackpot: its RTP is above the
+            configured ceiling of
+            <span th:text="${jackpotRtpMax}">95</span>%. Wins still pay out
+            normally, but won't bank the pool.
+        </span>
+        <span class="muted" th:if="${jackpotIneligibleReason == 'structural'}">
+            — this game doesn't roll for the jackpot: its win rate is too
+            high to be a fair contributor. Wins still pay out normally,
+            but won't bank the pool. Losses still tribute as usual.
+        </span>
+    </th:block>
 </div>
 </body>
 </html>

--- a/web/src/test/kotlin/web/casino/CasinoPageContextTest.kt
+++ b/web/src/test/kotlin/web/casino/CasinoPageContextTest.kt
@@ -82,7 +82,7 @@ class CasinoPageContextTest {
     }
 
     @Test
-    fun `populate stamps ineligibility attrs when the game is gated out`() {
+    fun `populate stamps RTP-reason ineligibility attrs when the per-guild RTP gate blocks the game`() {
         every { jackpotService.isEligibleByRtp(guildId, JackpotGame.COINFLIP) } returns false
         every { jackpotService.rtpMaxPct(guildId) } returns 95L
         val model = ConcurrentModel()
@@ -90,6 +90,24 @@ class CasinoPageContextTest {
         ctx.populate(model, guildId, discordId, user, game = JackpotGame.COINFLIP)
 
         assertEquals(true, model.getAttribute("jackpotIneligible"))
+        assertEquals("rtp", model.getAttribute("jackpotIneligibleReason"))
         assertEquals(95L, model.getAttribute("jackpotRtpMax"))
+    }
+
+    @Test
+    fun `populate stamps structural-reason ineligibility for HIGHLOW regardless of RTP gate`() {
+        // HIGHLOW carries JackpotGame.eligibleForJackpot=false. The RTP gate
+        // never matters for it — banner shows the win-rate reason instead.
+        val model = ConcurrentModel()
+
+        ctx.populate(model, guildId, discordId, user, game = JackpotGame.HIGHLOW)
+
+        assertEquals(true, model.getAttribute("jackpotIneligible"))
+        assertEquals("structural", model.getAttribute("jackpotIneligibleReason"))
+        assertEquals(false, model.containsAttribute("jackpotRtpMax"))
+        // The RTP gate was not even consulted — the structural carve-out
+        // short-circuits before the per-guild check.
+        verify(exactly = 0) { jackpotService.isEligibleByRtp(any(), any()) }
+        verify(exactly = 0) { jackpotService.rtpMaxPct(any()) }
     }
 }

--- a/web/src/test/kotlin/web/template/CasinoJackpotBannerFragmentTest.kt
+++ b/web/src/test/kotlin/web/template/CasinoJackpotBannerFragmentTest.kt
@@ -110,6 +110,22 @@ class CasinoJackpotBannerFragmentTest {
     }
 
     @Test
+    fun `jackpot banner does not use SpEL 'and' on the nullable jackpotIneligible attribute`() {
+        // Regression guard for the PageRenderSmokeIT failure on PR #440:
+        // `th:if="${jackpotIneligible and jackpotIneligibleReason == 'rtp'}"`
+        // throws SpelEvaluationException on every eligible-game page because
+        // `jackpotIneligible` is null there and SpEL's `and` does not
+        // short-circuit on null. The reason-branches must be guarded by a
+        // nested `th:block th:if="${jackpotIneligible}"` so they only
+        // evaluate when the attribute is truthy. Substring guard is tight:
+        // any future "${jackpotIneligible and ..." is the exact bug.
+        assertFalse(
+            fragmentHtml.contains("\${jackpotIneligible and"),
+            "fragment must not chain SpEL 'and' on the nullable jackpotIneligible — wrap inner branches in <th:block th:if=\"\${jackpotIneligible}\"> instead"
+        )
+    }
+
+    @Test
     fun `jackpot banner shows a structural-reason explanation for hard-coded carve-outs`() {
         // HighLow's RTP is honest but its win rate is so high that
         // `rollOnWin` would farm rolls; `JackpotGame.eligibleForJackpot=false`

--- a/web/src/test/kotlin/web/template/CasinoJackpotBannerFragmentTest.kt
+++ b/web/src/test/kotlin/web/template/CasinoJackpotBannerFragmentTest.kt
@@ -94,18 +94,35 @@ class CasinoJackpotBannerFragmentTest {
     }
 
     @Test
-    fun `jackpot banner shows an ineligibility explanation when gated out`() {
+    fun `jackpot banner shows an ineligibility explanation when gated out by per-guild RTP`() {
         // Symmetric branch — the banner explains *why* the game won't
         // roll (RTP above the configured ceiling) instead of going
         // silent. Includes the configured ceiling so the user can map
         // it to the admin's setting if they ask.
         assertTrue(
-            fragmentHtml.contains("th:if=\"\${jackpotIneligible}\""),
-            "fragment must render an ineligibility blurb when jackpotIneligible is true"
+            fragmentHtml.contains("jackpotIneligibleReason == 'rtp'"),
+            "fragment must guard the RTP-reason blurb on jackpotIneligibleReason"
         )
         assertTrue(
             fragmentHtml.contains("jackpotRtpMax"),
-            "ineligibility blurb must surface the configured RTP ceiling"
+            "RTP-reason blurb must surface the configured RTP ceiling"
+        )
+    }
+
+    @Test
+    fun `jackpot banner shows a structural-reason explanation for hard-coded carve-outs`() {
+        // HighLow's RTP is honest but its win rate is so high that
+        // `rollOnWin` would farm rolls; `JackpotGame.eligibleForJackpot=false`
+        // disables the win-roll regardless of per-guild config. The banner
+        // explains this with a separate, RTP-free message so the player
+        // doesn't think the admin configured a ceiling that bites HighLow.
+        assertTrue(
+            fragmentHtml.contains("jackpotIneligibleReason == 'structural'"),
+            "fragment must guard the structural-reason blurb on jackpotIneligibleReason"
+        )
+        assertTrue(
+            fragmentHtml.contains("win rate is too"),
+            "structural-reason blurb must explain it's win-rate driven, not RTP driven"
         )
     }
 


### PR DESCRIPTION
## Summary

The per-guild `JACKPOT_RTP_MAX_PCT` gate uses RTP as a proxy for "deserves a jackpot sweetener". That proxy correctly blocks Coinflip/Blackjack/Baccarat/Roulette/Holdem at the recommended ceiling of 95, but it **breaks for HighLow**: an honest 12/13 ≈ 0.923 RTP, yet the player can pick direction against an anchor dealt from 2..12 and win ~85% of plays at the extremes (anchor=12 LOWER, anchor=2 HIGHER).

`JackpotHelper.rollOnWin` fires **per winning play**, not per credit of house edge. The metric that matters for jackpot farming is `winRate / houseEdge`:

| Game | Win rate | House edge | Rolls per credit lost |
|------|---------:|-----------:|---------------------:|
| HighLow (optimal anchor) | ~85% | ~7.7% | ~1.1 |
| Slots                    | ~30% | 11.0% | ~0.27 |
| Scratch                  | ~30% | 12.5% | ~0.24 |
| Dice                     | ~17% | 16.7% | ~0.10 |
| Keno                     | ~25% | 8.0%  | ~0.31 |

HighLow gives ~**4×** more jackpot rolls per credit-lost than the next-closest eligible game. A player optimising for jackpot exposure picks an extreme anchor and grinds — bleeding the honest 7.7% edge but maximising free rolls. The RTP gate cannot fix this because the offending property is **win frequency**, not RTP.

### Changes

- **`JackpotGame` enum** (`database/.../JackpotHelper.kt`): add `eligibleForJackpot: Boolean = true`; set `HIGHLOW(0.923, eligibleForJackpot = false)`.
- **`rollOnWin`**: short-circuit to `0L` for any game with `eligibleForJackpot = false`, ahead of the RNG check. `divertOnLoss` is untouched — HighLow losses still tribute to the pool, only the win-roll is disabled.
- **Banner copy** (`fragments/casino.html` + `CasinoPageContext.kt`): add a `jackpotIneligibleReason` model attribute (`"rtp"` vs `"structural"`) and a separate "win rate is too high to be a fair contributor" blurb so the HighLow banner doesn't show a misleading RTP-ceiling message at its honest 0.923 RTP.

### Why a global flag, not per-guild config

The offending property is intrinsic to HighLow's game design (anchor range + direction choice), not a server-tunable preference. If a future game has the same shape (high win rate, honest house edge), it gets the same flag. Admins keep the RTP gate (`JACKPOT_RTP_MAX_PCT`) and all win-probability levers as before.

## Test plan

- [x] `./gradlew :common:test :core-api:test :database:test :web:test` — all pass
- [x] New `JackpotHelperTest` cases: `rollOnWin returns zero for games carrying eligibleForJackpot=false`, `rollOnWin still allows other eligible games when one game is carved out`
- [x] New `HighlowServiceTest` case: `win never rolls the jackpot — HIGHLOW carries the global eligibility carve-out`
- [x] New `CasinoPageContextTest` case: `populate stamps structural-reason ineligibility for HIGHLOW regardless of RTP gate`
- [x] Updated `CasinoJackpotBannerFragmentTest` to assert both reason-branches render
- [x] `npm test` (all 353 JS tests pass — frontend renderer stays defensively capable of displaying a jackpot result on any game)
- [ ] Manual: play HighLow on web, confirm banner shows the structural-reason copy; win never includes a `jackpotPayout`; loss still surfaces `+N to jackpot`
- [ ] Manual: smoke Slots/Dice/Scratch — wins still occasionally hit the jackpot (RNG-dependent), confirming the carve-out is per-game not global

Note: `./gradlew test` across `application` + `discord-bot` was blocked in CI sandbox by network-restricted Maven repos (`moe.kyokobot.libdave`); the four modules touched by this change all pass.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WKpfNmB3LJvB3c5tz4ATYp)_