### PR TITLE
feat(jackpot): tiered payout wheel replaces fixed-pct payout

### DIFF
--- a/database/src/main/kotlin/database/dto/ConfigDto.kt
+++ b/database/src/main/kotlin/database/dto/ConfigDto.kt
@@ -152,13 +152,15 @@ class ConfigDto(
         // freely without shrinking jackpot odds. Default 500.
         JACKPOT_STAKE_ANCHOR("JACKPOT_STAKE_ANCHOR"),
 
-        // Whole-number percentage (1-100) of the per-guild jackpot pool
-        // paid out on a winning roll. Defaults to 100 when unset (current
-        // behaviour: winner banks the entire pool). Set to e.g. 30 so a
-        // single roll never sweeps the whole pool — the remainder stays
-        // in and re-seeds the next cycle, preventing one lucky bet from
-        // unbalancing the server economy.
-        JACKPOT_PAYOUT_PCT("JACKPOT_PAYOUT_PCT"),
+        // CSV defining the per-guild jackpot payout wheel —
+        // "weight:pct,weight:pct,...". Weights are relative positive
+        // integers (frequency of the segment being landed on), payout
+        // pcts are whole-number percent of the pool (1-100) paid when
+        // the segment is picked. Default `80:1,10:5,5:10,4:20,1:50`
+        // gives 80% of jackpot wins a 1% slice and 1% a 50% slice —
+        // EV ~3.1% per win. Setting a single segment (e.g. `1:30`)
+        // expresses the historic "flat fixed-pct" payout.
+        JACKPOT_WHEEL_SEGMENTS("JACKPOT_WHEEL_SEGMENTS"),
 
         // Whole-number days a prior jackpot winner is ineligible for
         // another payout. 0 (default) disables the cooldown; recommended

--- a/database/src/main/kotlin/database/economy/JackpotWheel.kt
+++ b/database/src/main/kotlin/database/economy/JackpotWheel.kt
@@ -1,0 +1,150 @@
+package database.economy
+
+import kotlin.random.Random
+
+/**
+ * Tiered weighted-random payout wheel spun when a casino-game win
+ * rolls into the jackpot. Replaces the prior fixed-percent payout
+ * with a "compromise" mechanic: most spins give a small slice of the
+ * pool, rare spins give a bigger one. Pool growth from trade fees and
+ * loss tribute outpaces average drain, so the rare top-tier slice
+ * compounds the longer it goes unhit.
+ *
+ * Configuration travels as a single CSV string in the per-guild
+ * `config` table under [database.dto.ConfigDto.Configurations.JACKPOT_WHEEL_SEGMENTS]:
+ *
+ *     "weight:payoutPct,weight:payoutPct,..."
+ *
+ *   - weight     positive integer; relative draw frequency (not a percent)
+ *   - payoutPct  whole-number percent of the pool (1..100) paid when the
+ *                segment is picked
+ *
+ * The default ([DEFAULT_SEGMENTS]) is `80:1,10:5,5:10,4:20,1:50` — 80%
+ * of jackpot wins pay 1% of the pool (pity), 1% pay 50% (mega). EV per
+ * win is ~3.1% of the pool.
+ *
+ * To express a flat fixed-percent payout (the behaviour the deleted
+ * `JACKPOT_PAYOUT_PCT` config used to provide), set a single segment,
+ * e.g. `1:30` for "always 30% of the pool".
+ *
+ * Weighted-pick mirrors the [SlotMachine] reel pattern: weights expand
+ * into a flat list of segment indices and a single `random.nextInt`
+ * picks one. Safer than a cumulative-walk for the small segment counts
+ * (≤ [MAX_SEGMENTS]) and keeps the seeded-RNG tests reproducible.
+ */
+object JackpotWheel {
+
+    /**
+     * One wedge of the wheel. [weight] is a relative integer (the
+     * segment is picked with probability `weight / Σweights`).
+     * [payoutPct] is a fraction in `(0, 1]` of the pool — already
+     * normalised from the CSV's whole-number percent.
+     */
+    data class Segment(val weight: Int, val payoutPct: Double) {
+        init {
+            require(weight > 0) { "segment weight must be positive: $weight" }
+            require(payoutPct > 0.0 && payoutPct <= 1.0) {
+                "segment payoutPct must be in (0,1]: $payoutPct"
+            }
+        }
+    }
+
+    /**
+     * Result of [spin] — the picked index plus the segment's fraction,
+     * so callers don't have to look it up against the segment list.
+     */
+    data class Spin(val tierIndex: Int, val payoutPct: Double)
+
+    /**
+     * Hard cap on segment count. Keeps the config-row size bounded
+     * (a 12-segment wheel serialises to ~70 bytes) and keeps the
+     * expanded-pick array small.
+     */
+    const val MAX_SEGMENTS: Int = 12
+
+    /**
+     * Default wheel composition. 80% of jackpot wins pay 1% of the
+     * pool, 10% pay 5%, 5% pay 10%, 4% pay 20%, 1% pay 50%. EV per
+     * win ≈ 3.1% of the pool — well under historic 100% so the pool
+     * grows under typical traffic.
+     */
+    const val DEFAULT_SEGMENTS: String = "80:1,10:5,5:10,4:20,1:50"
+
+    private val PARSED_DEFAULT: List<Segment> = requireNotNull(tryParse(DEFAULT_SEGMENTS)) {
+        "DEFAULT_SEGMENTS must parse cleanly"
+    }
+
+    /**
+     * Parse [csv] into segments, falling back to [PARSED_DEFAULT] when
+     * [csv] is null, blank, malformed, or fails validation. Live reader
+     * path — never throws.
+     */
+    fun parse(csv: String?): List<Segment> = tryParse(csv) ?: PARSED_DEFAULT
+
+    /**
+     * Pure-validation entry point used by the moderation save path.
+     * Returns `null` when [csv] parses + validates cleanly, or a
+     * human-readable error string when it doesn't. An empty/blank value
+     * is treated as "reset to default" — also returns null.
+     */
+    fun validateConfigString(csv: String?): String? {
+        if (csv.isNullOrBlank()) return null
+        val pairs = csv.split(',').map { it.trim() }.filter { it.isNotEmpty() }
+        if (pairs.isEmpty()) return "Provide at least one weight:pct segment."
+        if (pairs.size > MAX_SEGMENTS) {
+            return "Too many segments (max $MAX_SEGMENTS); given ${pairs.size}."
+        }
+        var totalWeight = 0L
+        for ((i, pair) in pairs.withIndex()) {
+            val parts = pair.split(':').map { it.trim() }
+            if (parts.size != 2) {
+                return "Segment ${i + 1} must be 'weight:pct' (got '$pair')."
+            }
+            val w = parts[0].toIntOrNull()
+                ?: return "Segment ${i + 1} weight must be a positive integer (got '${parts[0]}')."
+            if (w <= 0) return "Segment ${i + 1} weight must be > 0 (got $w)."
+            val pct = parts[1].toIntOrNull()
+                ?: return "Segment ${i + 1} pct must be an integer 1-100 (got '${parts[1]}')."
+            if (pct !in 1..100) return "Segment ${i + 1} pct must be 1-100 (got $pct)."
+            totalWeight += w
+        }
+        if (totalWeight <= 0L) return "Total weight must be > 0."
+        return null
+    }
+
+    private fun tryParse(csv: String?): List<Segment>? {
+        if (csv.isNullOrBlank()) return null
+        val parts = csv.split(',').map { it.trim() }.filter { it.isNotEmpty() }
+        if (parts.isEmpty() || parts.size > MAX_SEGMENTS) return null
+        val out = ArrayList<Segment>(parts.size)
+        for (pair in parts) {
+            val kv = pair.split(':').map { it.trim() }
+            if (kv.size != 2) return null
+            val w = kv[0].toIntOrNull() ?: return null
+            val pct = kv[1].toIntOrNull() ?: return null
+            if (w <= 0 || pct !in 1..100) return null
+            out.add(Segment(weight = w, payoutPct = pct / 100.0))
+        }
+        return out
+    }
+
+    /**
+     * Pick one segment by weight. The expanded-list approach keeps the
+     * call to a single [Random.nextInt] for reproducibility under a
+     * seeded RNG.
+     */
+    fun spin(segments: List<Segment>, random: Random): Spin {
+        require(segments.isNotEmpty()) { "cannot spin an empty wheel" }
+        val total = segments.sumOf { it.weight }
+        require(total > 0) { "total weight must be positive" }
+        val draw = random.nextInt(total)
+        var running = 0
+        for ((index, seg) in segments.withIndex()) {
+            running += seg.weight
+            if (draw < running) return Spin(tierIndex = index, payoutPct = seg.payoutPct)
+        }
+        // Unreachable given `running` ends at `total` and `draw < total`.
+        val last = segments.lastIndex
+        return Spin(tierIndex = last, payoutPct = segments[last].payoutPct)
+    }
+}

--- a/database/src/main/kotlin/database/service/BaccaratService.kt
+++ b/database/src/main/kotlin/database/service/BaccaratService.kt
@@ -51,6 +51,8 @@ class BaccaratService(
             val multiplier: Double,
             val newBalance: Long,
             val jackpotPayout: Long = 0L,
+            val jackpotTierIndex: Int = -1,
+            val jackpotTierPayoutPct: Double = 0.0,
             val soldTobyCoins: Long = 0L,
             val newPrice: Double? = null
         ) : PlayOutcome
@@ -147,8 +149,10 @@ class BaccaratService(
                     isPlayerNatural = hand.isPlayerNatural,
                     isBankerNatural = hand.isBankerNatural,
                     multiplier = hand.multiplier,
-                    newBalance = wager.newBalance + jackpot,
-                    jackpotPayout = jackpot,
+                    newBalance = wager.newBalance + jackpot.amount,
+                    jackpotPayout = jackpot.amount,
+                    jackpotTierIndex = jackpot.tierIndex,
+                    jackpotTierPayoutPct = jackpot.tierPayoutPct,
                     soldTobyCoins = resolved.soldCoins,
                     newPrice = resolved.newPrice
                 )

--- a/database/src/main/kotlin/database/service/BlackjackService.kt
+++ b/database/src/main/kotlin/database/service/BlackjackService.kt
@@ -77,9 +77,12 @@ class BlackjackService @Autowired constructor(
             val result: BlackjackTable.HandResult,
             val newBalance: Long,
             val jackpotPayout: Long,
+            val lossTribute: Long,
+            // Tier fields are new, appended after the original positional
+            // params so existing positional callers (Discord-bot tests)
+            // keep compiling.
             val jackpotTierIndex: Int = -1,
             val jackpotTierPayoutPct: Double = 0.0,
-            val lossTribute: Long,
             val soldTobyCoins: Long = 0L,
             val newPrice: Double? = null
         ) : SoloDealOutcome
@@ -103,9 +106,11 @@ class BlackjackService @Autowired constructor(
             val result: BlackjackTable.HandResult,
             val newBalance: Long,
             val jackpotPayout: Long,
+            val lossTribute: Long,
+            // Tier fields appended so existing positional callers
+            // (Discord-bot tests) keep compiling.
             val jackpotTierIndex: Int = -1,
             val jackpotTierPayoutPct: Double = 0.0,
-            val lossTribute: Long
         ) : SoloActionOutcome
         data object HandNotFound : SoloActionOutcome
         data object NotYourHand : SoloActionOutcome

--- a/database/src/main/kotlin/database/service/BlackjackService.kt
+++ b/database/src/main/kotlin/database/service/BlackjackService.kt
@@ -77,6 +77,8 @@ class BlackjackService @Autowired constructor(
             val result: BlackjackTable.HandResult,
             val newBalance: Long,
             val jackpotPayout: Long,
+            val jackpotTierIndex: Int = -1,
+            val jackpotTierPayoutPct: Double = 0.0,
             val lossTribute: Long,
             val soldTobyCoins: Long = 0L,
             val newPrice: Double? = null
@@ -101,6 +103,8 @@ class BlackjackService @Autowired constructor(
             val result: BlackjackTable.HandResult,
             val newBalance: Long,
             val jackpotPayout: Long,
+            val jackpotTierIndex: Int = -1,
+            val jackpotTierPayoutPct: Double = 0.0,
             val lossTribute: Long
         ) : SoloActionOutcome
         data object HandNotFound : SoloActionOutcome
@@ -318,6 +322,8 @@ class BlackjackService @Autowired constructor(
                     result = settlement.handResult,
                     newBalance = settlement.newBalance,
                     jackpotPayout = settlement.jackpotPayout,
+                    jackpotTierIndex = settlement.jackpotTierIndex,
+                    jackpotTierPayoutPct = settlement.jackpotTierPayoutPct,
                     lossTribute = settlement.lossTribute,
                     soldTobyCoins = soldCoins,
                     newPrice = soldNewPrice
@@ -413,6 +419,8 @@ class BlackjackService @Autowired constructor(
                     result = settlement.handResult,
                     newBalance = settlement.newBalance,
                     jackpotPayout = settlement.jackpotPayout,
+                    jackpotTierIndex = settlement.jackpotTierIndex,
+                    jackpotTierPayoutPct = settlement.jackpotTierPayoutPct,
                     lossTribute = settlement.lossTribute
                 )
             }
@@ -605,6 +613,8 @@ class BlackjackService @Autowired constructor(
         val handResult: BlackjackTable.HandResult,
         val newBalance: Long,
         val jackpotPayout: Long,
+        val jackpotTierIndex: Int,
+        val jackpotTierPayoutPct: Double,
         val lossTribute: Long
     )
 
@@ -655,8 +665,9 @@ class BlackjackService @Autowired constructor(
 
         // One jackpot roll per winning hand-slot, one loss tribute per
         // losing hand-slot — split = more wagers, so naturally more
-        // chances at both. Pushes are no-ops on both axes.
-        var jackpotPayout = 0L
+        // chances at both. Pushes are no-ops on both axes. Multiple hits
+        // surface the higher-paying tier through [JackpotRoll.plus].
+        var jackpot = JackpotRoll.MISS
         var lossTribute = 0L
         if (user != null) {
             for (hand in perHand) {
@@ -666,8 +677,8 @@ class BlackjackService @Autowired constructor(
                             jackpotService, configService, userService, user, guildId,
                             hand.stake, JackpotGame.BLACKJACK, random,
                         )
-                        if (rolled > 0L) {
-                            jackpotPayout += rolled
+                        if (rolled.amount > 0L) {
+                            jackpot += rolled
                             newBalance = user.socialCredit ?: newBalance
                         }
                     }
@@ -698,7 +709,7 @@ class BlackjackService @Autowired constructor(
             table.lastActivityAt = Instant.now()
         }
         persistHandLog(table, handResult)
-        return SoloSettlement(handResult, newBalance, jackpotPayout, lossTribute)
+        return SoloSettlement(handResult, newBalance, jackpot.amount, jackpot.tierIndex, jackpot.tierPayoutPct, lossTribute)
     }
 
     /**

--- a/database/src/main/kotlin/database/service/CasinoHoldemService.kt
+++ b/database/src/main/kotlin/database/service/CasinoHoldemService.kt
@@ -75,6 +75,8 @@ class CasinoHoldemService @Autowired constructor(
             val result: CasinoHoldemTable.HandResult,
             val newBalance: Long,
             val jackpotPayout: Long,
+            val jackpotTierIndex: Int = -1,
+            val jackpotTierPayoutPct: Double = 0.0,
             val lossTribute: Long,
         ) : ActionOutcome
         data object HandNotFound : ActionOutcome
@@ -259,12 +261,14 @@ class CasinoHoldemService @Autowired constructor(
         // Per-leg jackpot rolls / tributes. WIN legs roll once each (so
         // a hand can produce up to two rolls); LOSE legs feed the pool
         // their own at-risk stake; PUSH legs are no-ops on both axes.
-        var jackpotPayout = 0L
+        // [JackpotRoll.plus] combines the two legs, surfacing the
+        // higher-paying tier when both hit.
+        var jackpot = JackpotRoll.MISS
         var lossTribute = 0L
 
         when (resolution.anteResult) {
             CasinoHoldem.AnteResult.WIN ->
-                jackpotPayout += JackpotHelper.rollOnWin(
+                jackpot += JackpotHelper.rollOnWin(
                     jackpotService, configService, userService, user, guildId,
                     table.stake, JackpotGame.HOLDEM, random,
                 )
@@ -283,7 +287,7 @@ class CasinoHoldemService @Autowired constructor(
             CasinoHoldem.CallResult.WIN_FLUSH,
             CasinoHoldem.CallResult.WIN_STRAIGHT,
             CasinoHoldem.CallResult.WIN_OTHER ->
-                jackpotPayout += JackpotHelper.rollOnWin(
+                jackpot += JackpotHelper.rollOnWin(
                     jackpotService, configService, userService, user, guildId,
                     callStake, JackpotGame.HOLDEM, random,
                 )
@@ -321,7 +325,9 @@ class CasinoHoldemService @Autowired constructor(
             tableId = table.id,
             result = handResult,
             newBalance = newBalance,
-            jackpotPayout = jackpotPayout,
+            jackpotPayout = jackpot.amount,
+            jackpotTierIndex = jackpot.tierIndex,
+            jackpotTierPayoutPct = jackpot.tierPayoutPct,
             lossTribute = lossTribute,
         )
     }

--- a/database/src/main/kotlin/database/service/CasinoHoldemService.kt
+++ b/database/src/main/kotlin/database/service/CasinoHoldemService.kt
@@ -75,9 +75,11 @@ class CasinoHoldemService @Autowired constructor(
             val result: CasinoHoldemTable.HandResult,
             val newBalance: Long,
             val jackpotPayout: Long,
+            val lossTribute: Long,
+            // Tier fields appended so existing positional callers keep
+            // compiling.
             val jackpotTierIndex: Int = -1,
             val jackpotTierPayoutPct: Double = 0.0,
-            val lossTribute: Long,
         ) : ActionOutcome
         data object HandNotFound : ActionOutcome
         data object NotYourHand : ActionOutcome

--- a/database/src/main/kotlin/database/service/CoinflipService.kt
+++ b/database/src/main/kotlin/database/service/CoinflipService.kt
@@ -46,6 +46,8 @@ class CoinflipService(
             val predicted: Coinflip.Side,
             val newBalance: Long,
             val jackpotPayout: Long = 0L,
+            val jackpotTierIndex: Int = -1,
+            val jackpotTierPayoutPct: Double = 0.0,
             val soldTobyCoins: Long = 0L,
             val newPrice: Double? = null,
         ) : FlipOutcome
@@ -126,8 +128,10 @@ class CoinflipService(
                 net = wager.net,
                 landed = flip.landed,
                 predicted = flip.predicted,
-                newBalance = wager.newBalance + jackpot,
-                jackpotPayout = jackpot,
+                newBalance = wager.newBalance + jackpot.amount,
+                jackpotPayout = jackpot.amount,
+                jackpotTierIndex = jackpot.tierIndex,
+                jackpotTierPayoutPct = jackpot.tierPayoutPct,
                 soldTobyCoins = resolved.soldCoins,
                 newPrice = resolved.newPrice,
             )

--- a/database/src/main/kotlin/database/service/DiceService.kt
+++ b/database/src/main/kotlin/database/service/DiceService.kt
@@ -39,6 +39,8 @@ class DiceService(
             val predicted: Int,
             val newBalance: Long,
             val jackpotPayout: Long = 0L,
+            val jackpotTierIndex: Int = -1,
+            val jackpotTierPayoutPct: Double = 0.0,
             val soldTobyCoins: Long = 0L,
             val newPrice: Double? = null,
         ) : RollOutcome
@@ -126,8 +128,10 @@ class DiceService(
                 net = wager.net,
                 landed = roll.landed,
                 predicted = roll.predicted,
-                newBalance = wager.newBalance + jackpot,
-                jackpotPayout = jackpot,
+                newBalance = wager.newBalance + jackpot.amount,
+                jackpotPayout = jackpot.amount,
+                jackpotTierIndex = jackpot.tierIndex,
+                jackpotTierPayoutPct = jackpot.tierPayoutPct,
                 soldTobyCoins = resolved.soldCoins,
                 newPrice = resolved.newPrice,
             )

--- a/database/src/main/kotlin/database/service/HighlowService.kt
+++ b/database/src/main/kotlin/database/service/HighlowService.kt
@@ -46,6 +46,8 @@ class HighlowService(
             val multiplier: Double,
             val newBalance: Long,
             val jackpotPayout: Long = 0L,
+            val jackpotTierIndex: Int = -1,
+            val jackpotTierPayoutPct: Double = 0.0,
             val soldTobyCoins: Long = 0L,
             val newPrice: Double? = null,
         ) : PlayOutcome
@@ -144,8 +146,10 @@ class HighlowService(
                 next = hand.next,
                 direction = hand.direction,
                 multiplier = hand.multiplier,
-                newBalance = wager.newBalance + jackpot,
-                jackpotPayout = jackpot,
+                newBalance = wager.newBalance + jackpot.amount,
+                jackpotPayout = jackpot.amount,
+                jackpotTierIndex = jackpot.tierIndex,
+                jackpotTierPayoutPct = jackpot.tierPayoutPct,
                 soldTobyCoins = resolved.soldCoins,
                 newPrice = resolved.newPrice,
             )

--- a/database/src/main/kotlin/database/service/JackpotHelper.kt
+++ b/database/src/main/kotlin/database/service/JackpotHelper.kt
@@ -2,7 +2,40 @@ package database.service
 
 import database.dto.ConfigDto
 import database.dto.UserDto
+import database.economy.JackpotWheel
 import kotlin.random.Random
+
+/**
+ * Outcome of a jackpot win-roll. [amount] is the credits awarded
+ * (0 on miss); [tierIndex] / [tierPayoutPct] identify which wheel
+ * segment was picked on a hit (-1 / 0.0 on miss) so the web layer can
+ * animate the wheel landing on the right wedge.
+ */
+data class JackpotRoll(
+    val amount: Long,
+    val tierIndex: Int,
+    val tierPayoutPct: Double,
+) {
+    companion object {
+        val MISS: JackpotRoll = JackpotRoll(0L, -1, 0.0)
+    }
+
+    /**
+     * Combine two rolls — used by CasinoHoldem where ante and call
+     * legs each get their own roll. Amounts sum; the tier shown is
+     * the one from the higher-paying hit (so a stacked win surfaces
+     * the bigger slice in the UI).
+     */
+    operator fun plus(other: JackpotRoll): JackpotRoll {
+        if (other.amount <= 0L) return this
+        if (this.amount <= 0L) return other
+        return if (other.amount >= this.amount) {
+            JackpotRoll(this.amount + other.amount, other.tierIndex, other.tierPayoutPct)
+        } else {
+            JackpotRoll(this.amount + other.amount, this.tierIndex, this.tierPayoutPct)
+        }
+    }
+}
 
 /**
  * Casino games that feed the jackpot pool, paired with their canonical
@@ -41,7 +74,10 @@ enum class JackpotGame(val rtp: Double, val eligibleForJackpot: Boolean = true) 
  * Two casino-side feeders for the per-guild jackpot pool:
  *
  *   - [rollOnWin] — on every minigame WIN, roll a small probability
- *     to bank the entire pool and reset it to zero.
+ *     and on a hit spin the per-guild [JackpotWheel] for a tier-based
+ *     share of the pool. Returns a [JackpotRoll] carrying the awarded
+ *     amount and the picked tier so the casino UI can animate the
+ *     wheel landing on the matching wedge.
  *   - [divertOnLoss] — on every minigame LOSS, deposit a fraction of
  *     the lost stake into the pool. The remaining fraction keeps
  *     vanishing as house edge; tribute is the visible chunk that
@@ -81,15 +117,6 @@ internal object JackpotHelper {
      * for house edge."
      */
     const val DEFAULT_RTP_MAX_PCT: Long = 0L
-
-    /**
-     * Default share of the pool paid on a winning roll when the server
-     * hasn't overridden the value via the `JACKPOT_PAYOUT_PCT` config
-     * entry. 100 % preserves the historic behaviour (winner banks the
-     * entire pool); guilds that have suffered a runaway pool can lower
-     * this so the remainder re-seeds the next cycle.
-     */
-    const val DEFAULT_PAYOUT_PCT: Double = 1.0
 
     /**
      * Default cooldown in days during which a prior jackpot winner is
@@ -153,15 +180,18 @@ internal object JackpotHelper {
     const val MAX_LOSS_TRIBUTE: Double = 0.50
 
     /**
-     * If the random roll hits and the pool is non-empty, atomically
-     * pull the entire pool, credit it to [user] (already locked by
-     * [WagerHelper.checkAndLock]), persist, and return the amount
-     * awarded. Returns `0L` on miss or empty pool. The hit probability
-     * is per-guild configurable via `JACKPOT_WIN_PCT`; defaults to
-     * [DEFAULT_WIN_PROBABILITY].
+     * If the random roll hits, spin the per-guild payout wheel (see
+     * [JackpotWheel]) for a tier and atomically credit that share of
+     * the pool to [user] (already locked by [WagerHelper.checkAndLock]).
+     * Returns [JackpotRoll.MISS] on miss / empty pool / failed gate;
+     * otherwise a [JackpotRoll] carrying the amount won, the picked
+     * segment's index, and its payout fraction so the casino UI can
+     * animate the wheel landing on the right wedge.
      *
-     * The base probability is scaled linearly by `stake / anchor`,
-     * where `anchor` is the per-guild `JACKPOT_STAKE_ANCHOR` config
+     * The hit probability is per-guild configurable via
+     * `JACKPOT_WIN_PCT`; defaults to [DEFAULT_WIN_PROBABILITY]. The
+     * base probability is scaled linearly by `stake / anchor`, where
+     * `anchor` is the per-guild `JACKPOT_STAKE_ANCHOR` config
      * (default [DEFAULT_STAKE_ANCHOR]). A min-wager autoclicker can't
      * farm the pool — a 10-credit play against a 500 anchor rolls at
      * 0.02 % even when the configured base is 1 %. Bets at or above
@@ -183,28 +213,43 @@ internal object JackpotHelper {
         stake: Long,
         game: JackpotGame,
         random: Random
-    ): Long {
-        if (!game.eligibleForJackpot) return 0L
+    ): JackpotRoll {
+        if (!game.eligibleForJackpot) return JackpotRoll.MISS
         val baseProbability = winProbability(configService, guildId)
         val anchor = stakeAnchor(configService, guildId)
         val scale = (stake.toDouble() / anchor.toDouble()).coerceIn(0.0, 1.0)
         val effective = baseProbability * scale
-        if (random.nextDouble() >= effective) return 0L
+        if (random.nextDouble() >= effective) return JackpotRoll.MISS
 
         // Post-fraud structural gates. Each defaults to "disabled" so an
         // unconfigured guild's behaviour is unchanged. When enabled, a
         // failed gate looks identical to a missed roll — pool keeps
         // growing, no payout, no exception thrown into the wager service.
-        if (jackpotService.isOnCooldown(guildId, user.discordId)) return 0L
-        if (!jackpotService.isActive(guildId, user.discordId)) return 0L
-        if (!isEligibleByRtp(game, configService, guildId)) return 0L
+        if (jackpotService.isOnCooldown(guildId, user.discordId)) return JackpotRoll.MISS
+        if (!jackpotService.isActive(guildId, user.discordId)) return JackpotRoll.MISS
+        if (!isEligibleByRtp(game, configService, guildId)) return JackpotRoll.MISS
 
-        val won = jackpotService.awardJackpot(guildId)
-        if (won == 0L) return 0L
+        val segments = JackpotWheel.parse(wheelSegmentsConfig(configService, guildId))
+        val spin = JackpotWheel.spin(segments, random)
+        val won = jackpotService.awardJackpot(guildId, spin.payoutPct)
+        if (won == 0L) return JackpotRoll.MISS
         jackpotService.recordWin(guildId, user.discordId, won)
         user.socialCredit = (user.socialCredit ?: 0L) + won
         userService.updateUser(user)
-        return won
+        return JackpotRoll(amount = won, tierIndex = spin.tierIndex, tierPayoutPct = spin.payoutPct)
+    }
+
+    /**
+     * Raw [JACKPOT_WHEEL_SEGMENTS] config value for [guildId], or null
+     * when unset. Lets [JackpotWheel.parse] handle the default-on-miss
+     * fallback in one place.
+     */
+    fun wheelSegmentsConfig(configService: ConfigService, guildId: Long): String? {
+        val cfg = configService.getConfigByName(
+            ConfigDto.Configurations.JACKPOT_WHEEL_SEGMENTS.configValue,
+            guildId.toString()
+        )
+        return cfg?.value
     }
 
     /**
@@ -275,23 +320,6 @@ internal object JackpotHelper {
         )
         val pct = cfg?.value?.toDoubleOrNull() ?: return DEFAULT_LOSS_TRIBUTE
         return (pct / 100.0).coerceIn(0.0, MAX_LOSS_TRIBUTE)
-    }
-
-    /**
-     * Live payout fraction for [guildId] — admin-set whole-number percent
-     * (1-100) parsed from `JACKPOT_PAYOUT_PCT`. Returns [DEFAULT_PAYOUT_PCT]
-     * (1.0 = full pool) when unset or unparseable; clamps to (0, 1].
-     * 0 is treated as missing and falls back to the default to avoid
-     * silently disabling all jackpot payouts via a fat-fingered config row.
-     */
-    fun payoutPct(configService: ConfigService, guildId: Long): Double {
-        val cfg = configService.getConfigByName(
-            ConfigDto.Configurations.JACKPOT_PAYOUT_PCT.configValue,
-            guildId.toString()
-        )
-        val pct = cfg?.value?.toDoubleOrNull() ?: return DEFAULT_PAYOUT_PCT
-        if (pct.isNaN() || pct.isInfinite() || pct <= 0.0) return DEFAULT_PAYOUT_PCT
-        return (pct / 100.0).coerceIn(0.0, 1.0).let { if (it == 0.0) DEFAULT_PAYOUT_PCT else it }
     }
 
     /**

--- a/database/src/main/kotlin/database/service/JackpotService.kt
+++ b/database/src/main/kotlin/database/service/JackpotService.kt
@@ -19,11 +19,11 @@ import java.time.ZoneOffset
  *
  * The pool is fed by a flat fee on every Toby Coin trade (see
  * [EconomyTradeService]). Casino minigame wins roll a small chance to
- * hit the jackpot — on a hit the player banks a configurable share of
- * the pool ([JackpotHelper.payoutPct]; default 100 %, can be lowered to
- * leave a re-seed remainder), and the pool counter drops accordingly.
+ * hit the jackpot — on a hit the per-guild [database.economy.JackpotWheel]
+ * is spun for a tier and the player banks that fraction of the pool
+ * (default tiers `80:1,10:5,5:10,4:20,1:50` — EV ~3.1% per win).
  *
- * Three structural gates layer on top of the basic roll:
+ * Two structural gates layer on top of the basic roll:
  *  - [isOnCooldown] blocks a recent winner from sweeping again within
  *    `JACKPOT_WINNER_COOLDOWN_DAYS`. Each successful win records the
  *    timestamp via [recordWin].
@@ -31,8 +31,6 @@ import java.time.ZoneOffset
  *    around in the last `JACKPOT_ACTIVITY_WINDOW_DAYS` (sourced from
  *    `voice_credit_daily`). A drive-by user with one bet can't run the
  *    pool dry.
- *  - [JackpotHelper.payoutPct] caps the share of the pool paid out on a
- *    single roll.
  *
  * All defaults match the historic single-winner-takes-all behaviour, so
  * a guild that never touches the new configs sees no change.
@@ -110,6 +108,24 @@ class JackpotService(
     fun isEligibleByRtp(guildId: Long, game: JackpotGame): Boolean =
         JackpotHelper.isEligibleByRtp(game, configService, guildId)
 
+    /**
+     * Parsed payout-wheel segments for [guildId] — reads the
+     * `JACKPOT_WHEEL_SEGMENTS` config and falls back to
+     * [database.economy.JackpotWheel.DEFAULT_SEGMENTS] when unset or
+     * malformed. Surfaced for the casino page so the wheel UI can
+     * render the same segments the server spins.
+     */
+    fun wheelSegments(guildId: Long): List<database.economy.JackpotWheel.Segment> =
+        database.economy.JackpotWheel.parse(JackpotHelper.wheelSegmentsConfig(configService, guildId))
+
+    /**
+     * Raw `JACKPOT_WHEEL_SEGMENTS` config value for [guildId] (or null
+     * when unset). Used by the moderation UI to populate the editor —
+     * a null result tells the page "show the default placeholder".
+     */
+    fun wheelSegmentsConfigValue(guildId: Long): String? =
+        JackpotHelper.wheelSegmentsConfig(configService, guildId)
+
     companion object {
         // 4dp covers the smallest probability the saved-percent / 100
         // round-trip can express meaningfully — e.g. an admin saving
@@ -132,16 +148,19 @@ class JackpotService(
     }
 
     /**
-     * Pay out a share of the pool atomically. The share is configurable
-     * via `JACKPOT_PAYOUT_PCT` (default 100 % = full pool). Returns the
-     * amount paid; caller is responsible for crediting the winner.
-     * The remainder stays in the pool and re-seeds the next cycle.
+     * Pay out a share of the pool atomically. The caller supplies
+     * [payoutFraction] in `(0, 1]` — picked by [JackpotWheel.spin] on
+     * the rolling-win path or fixed by the lottery service for draws.
+     * Returns the amount paid; the caller is responsible for crediting
+     * the winner. The remainder stays in the pool and re-seeds the
+     * next cycle.
      */
-    fun awardJackpot(guildId: Long): Long {
+    fun awardJackpot(guildId: Long, payoutFraction: Double): Long {
         val row = lockOrCreate(guildId)
         if (row.pool == 0L) return 0L
-        val pct = JackpotHelper.payoutPct(configService, guildId)
-        val won = kotlin.math.floor(row.pool * pct).toLong().coerceAtMost(row.pool).coerceAtLeast(0L)
+        val fraction = payoutFraction.coerceIn(0.0, 1.0)
+        if (fraction <= 0.0) return 0L
+        val won = kotlin.math.floor(row.pool * fraction).toLong().coerceAtMost(row.pool).coerceAtLeast(0L)
         if (won == 0L) return 0L
         row.pool -= won
         persistence.upsert(row)

--- a/database/src/main/kotlin/database/service/KenoService.kt
+++ b/database/src/main/kotlin/database/service/KenoService.kt
@@ -48,6 +48,8 @@ class KenoService(
             val multiplier: Double,
             val newBalance: Long,
             val jackpotPayout: Long = 0L,
+            val jackpotTierIndex: Int = -1,
+            val jackpotTierPayoutPct: Double = 0.0,
             val soldTobyCoins: Long = 0L,
             val newPrice: Double? = null
         ) : PlayOutcome
@@ -144,8 +146,10 @@ class KenoService(
                 draws = hand.draws,
                 hits = hand.hits,
                 multiplier = hand.multiplier,
-                newBalance = wager.newBalance + jackpot,
-                jackpotPayout = jackpot,
+                newBalance = wager.newBalance + jackpot.amount,
+                jackpotPayout = jackpot.amount,
+                jackpotTierIndex = jackpot.tierIndex,
+                jackpotTierPayoutPct = jackpot.tierPayoutPct,
                 soldTobyCoins = resolved.soldCoins,
                 newPrice = resolved.newPrice
             )

--- a/database/src/main/kotlin/database/service/RouletteService.kt
+++ b/database/src/main/kotlin/database/service/RouletteService.kt
@@ -47,6 +47,8 @@ class RouletteService(
             val net: Long,
             val newBalance: Long,
             val jackpotPayout: Long = 0L,
+            val jackpotTierIndex: Int = -1,
+            val jackpotTierPayoutPct: Double = 0.0,
             val soldTobyCoins: Long = 0L,
             val newPrice: Double? = null,
         ) : SpinOutcome
@@ -128,8 +130,10 @@ class RouletteService(
                 multiplier = spin.multiplier,
                 payout = wager.payout,
                 net = wager.net,
-                newBalance = wager.newBalance + jackpot,
-                jackpotPayout = jackpot,
+                newBalance = wager.newBalance + jackpot.amount,
+                jackpotPayout = jackpot.amount,
+                jackpotTierIndex = jackpot.tierIndex,
+                jackpotTierPayoutPct = jackpot.tierPayoutPct,
                 soldTobyCoins = resolved.soldCoins,
                 newPrice = resolved.newPrice,
             )

--- a/database/src/main/kotlin/database/service/ScratchService.kt
+++ b/database/src/main/kotlin/database/service/ScratchService.kt
@@ -37,6 +37,8 @@ class ScratchService(
             val matchCount: Int,
             val newBalance: Long,
             val jackpotPayout: Long = 0L,
+            val jackpotTierIndex: Int = -1,
+            val jackpotTierPayoutPct: Double = 0.0,
             val soldTobyCoins: Long = 0L,
             val newPrice: Double? = null,
         ) : ScratchOutcome
@@ -93,8 +95,10 @@ class ScratchService(
                 cells = result.cells,
                 winningSymbol = result.winningSymbol,
                 matchCount = result.matchCount,
-                newBalance = wager.newBalance + jackpot,
-                jackpotPayout = jackpot,
+                newBalance = wager.newBalance + jackpot.amount,
+                jackpotPayout = jackpot.amount,
+                jackpotTierIndex = jackpot.tierIndex,
+                jackpotTierPayoutPct = jackpot.tierPayoutPct,
                 soldTobyCoins = resolved.soldCoins,
                 newPrice = resolved.newPrice,
             )

--- a/database/src/main/kotlin/database/service/SlotsService.kt
+++ b/database/src/main/kotlin/database/service/SlotsService.kt
@@ -50,6 +50,8 @@ class SlotsService(
             val symbols: List<SlotMachine.Symbol>,
             val newBalance: Long,
             val jackpotPayout: Long = 0L,
+            val jackpotTierIndex: Int = -1,
+            val jackpotTierPayoutPct: Double = 0.0,
             val soldTobyCoins: Long = 0L,
             val newPrice: Double? = null,
         ) : SpinOutcome
@@ -131,8 +133,10 @@ class SlotsService(
                 payout = wager.payout,
                 net = wager.net,
                 symbols = pull.symbols,
-                newBalance = wager.newBalance + jackpot,
-                jackpotPayout = jackpot,
+                newBalance = wager.newBalance + jackpot.amount,
+                jackpotPayout = jackpot.amount,
+                jackpotTierIndex = jackpot.tierIndex,
+                jackpotTierPayoutPct = jackpot.tierPayoutPct,
                 soldTobyCoins = resolved.soldCoins,
                 newPrice = resolved.newPrice,
             )

--- a/database/src/test/kotlin/database/economy/JackpotWheelTest.kt
+++ b/database/src/test/kotlin/database/economy/JackpotWheelTest.kt
@@ -1,0 +1,129 @@
+package database.economy
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import kotlin.random.Random
+
+/**
+ * Coverage for the jackpot payout wheel — CSV parsing, weight-respecting
+ * spin distribution, and the validator used by the moderation save path.
+ * The live reader is wired into [database.service.JackpotHelper.rollOnWin];
+ * see [database.service.JackpotHelperTest] for the integration test.
+ */
+class JackpotWheelTest {
+
+    @Test
+    fun `parse handles the default segment string`() {
+        val segments = JackpotWheel.parse(JackpotWheel.DEFAULT_SEGMENTS)
+        assertEquals(5, segments.size)
+        assertEquals(JackpotWheel.Segment(80, 0.01), segments[0])
+        assertEquals(JackpotWheel.Segment(10, 0.05), segments[1])
+        assertEquals(JackpotWheel.Segment(5, 0.10), segments[2])
+        assertEquals(JackpotWheel.Segment(4, 0.20), segments[3])
+        assertEquals(JackpotWheel.Segment(1, 0.50), segments[4])
+    }
+
+    @Test
+    fun `parse falls back to defaults on null and blank`() {
+        val expected = JackpotWheel.parse(JackpotWheel.DEFAULT_SEGMENTS)
+        assertEquals(expected, JackpotWheel.parse(null))
+        assertEquals(expected, JackpotWheel.parse(""))
+        assertEquals(expected, JackpotWheel.parse("   "))
+    }
+
+    @Test
+    fun `parse falls back to defaults on malformed CSV`() {
+        val expected = JackpotWheel.parse(JackpotWheel.DEFAULT_SEGMENTS)
+        // Non-numeric weight, missing colon, out-of-range pct, zero weight,
+        // and over-MAX segment counts each fall back rather than throwing
+        // — the live reader never gets to crash the casino path.
+        listOf(
+            "abc",
+            "5,3,2",
+            "10:200",
+            "0:50",
+            "-1:50",
+            "10:0",
+            (1..(JackpotWheel.MAX_SEGMENTS + 1)).joinToString(",") { "1:1" },
+        ).forEach { bad ->
+            assertEquals(expected, JackpotWheel.parse(bad), "expected fallback for `$bad`")
+        }
+    }
+
+    @Test
+    fun `parse accepts a single fixed-pct segment`() {
+        // Equivalent of the deleted JACKPOT_PAYOUT_PCT=30 setting.
+        val segments = JackpotWheel.parse("1:30")
+        assertEquals(1, segments.size)
+        assertEquals(JackpotWheel.Segment(1, 0.30), segments[0])
+    }
+
+    @Test
+    fun `spin with seeded RNG is reproducible`() {
+        val segments = JackpotWheel.parse(JackpotWheel.DEFAULT_SEGMENTS)
+        val a = JackpotWheel.spin(segments, Random(42))
+        val b = JackpotWheel.spin(segments, Random(42))
+        assertEquals(a, b)
+    }
+
+    @Test
+    fun `spin distribution converges to the configured weights`() {
+        val segments = JackpotWheel.parse(JackpotWheel.DEFAULT_SEGMENTS)
+        val totalWeight = segments.sumOf { it.weight }.toDouble()
+        val rng = Random(0xCAFE)
+        val iterations = 200_000
+        val counts = IntArray(segments.size)
+        repeat(iterations) {
+            counts[JackpotWheel.spin(segments, rng).tierIndex]++
+        }
+        // Each segment should land within 0.7 percentage points of its
+        // configured share — generous enough to absorb sampling noise
+        // at 200k iterations, tight enough to catch a logic bug that
+        // ignores the weights.
+        segments.forEachIndexed { i, seg ->
+            val expected = seg.weight / totalWeight
+            val actual = counts[i] / iterations.toDouble()
+            assertTrue(
+                kotlin.math.abs(expected - actual) < 0.007,
+                "segment $i — expected ≈ $expected, observed $actual"
+            )
+        }
+    }
+
+    @Test
+    fun `single-tier wheel always picks index 0`() {
+        val segments = JackpotWheel.parse("1:30")
+        repeat(1_000) {
+            val spin = JackpotWheel.spin(segments, Random(it.toLong()))
+            assertEquals(0, spin.tierIndex)
+            assertEquals(0.30, spin.payoutPct, 1e-9)
+        }
+    }
+
+    @Test
+    fun `validateConfigString accepts the default and single-tier configs`() {
+        assertNull(JackpotWheel.validateConfigString(null))
+        assertNull(JackpotWheel.validateConfigString(""))
+        assertNull(JackpotWheel.validateConfigString("   "))
+        assertNull(JackpotWheel.validateConfigString(JackpotWheel.DEFAULT_SEGMENTS))
+        assertNull(JackpotWheel.validateConfigString("1:30"))
+        assertNull(JackpotWheel.validateConfigString("50:1, 50:50"))
+    }
+
+    @Test
+    fun `validateConfigString rejects bad weights, pcts, and oversized inputs`() {
+        // Each branch returns a human-readable error string the
+        // moderation UI surfaces verbatim — no exception leak.
+        assertNotNull(JackpotWheel.validateConfigString("abc"))
+        assertNotNull(JackpotWheel.validateConfigString("5,3,2"))
+        assertNotNull(JackpotWheel.validateConfigString("0:50"))
+        assertNotNull(JackpotWheel.validateConfigString("-1:50"))
+        assertNotNull(JackpotWheel.validateConfigString("10:0"))
+        assertNotNull(JackpotWheel.validateConfigString("10:101"))
+        val oversize = (1..(JackpotWheel.MAX_SEGMENTS + 1)).joinToString(",") { "1:1" }
+        assertNotNull(JackpotWheel.validateConfigString(oversize))
+    }
+}

--- a/database/src/test/kotlin/database/service/HighlowServiceTest.kt
+++ b/database/src/test/kotlin/database/service/HighlowServiceTest.kt
@@ -152,14 +152,14 @@ class HighlowServiceTest {
             anchor = 7, next = 10, direction = Highlow.Direction.HIGHER, multiplier = 2.0
         )
         every { userService.updateUser(any()) } returns user
-        every { jackpotService.awardJackpot(guildId) } returns 9_999L  // would be banked if HIGHLOW were eligible
+        every { jackpotService.awardJackpot(guildId, any()) } returns 9_999L  // would be banked if HIGHLOW were eligible
 
         val outcome = service.play(discordId, guildId, stake = 100L, direction = Highlow.Direction.HIGHER)
 
         val win = assertInstanceOf(HighlowService.PlayOutcome.Win::class.java, outcome)
         assertEquals(0L, win.jackpotPayout)
         assertEquals(1_100L, win.newBalance, "newBalance must not include any jackpot top-up")
-        verify(exactly = 0) { jackpotService.awardJackpot(any()) }
+        verify(exactly = 0) { jackpotService.awardJackpot(any(), any()) }
     }
 
     @Test

--- a/database/src/test/kotlin/database/service/JackpotHelperTest.kt
+++ b/database/src/test/kotlin/database/service/JackpotHelperTest.kt
@@ -61,9 +61,14 @@ class JackpotHelperTest {
         } returns value?.let { ConfigDto(name = "x", value = it, guildId = guildId.toString()) }
     }
 
-    private fun stubRandom(value: Double): Random {
+    private fun stubRandom(value: Double, tierPick: Int = 0): Random {
         val r = mockk<Random>()
         every { r.nextDouble() } returns value
+        // `JackpotWheel.spin` calls `random.nextInt(totalWeight)` to pick
+        // a tier on a hit. Stub it to a small value that lands in the
+        // first segment of the default wheel; tests that need a specific
+        // tier override this with their own [tierPick].
+        every { r.nextInt(any()) } returns tierPick
         return r
     }
 
@@ -209,7 +214,7 @@ class JackpotHelperTest {
     fun `rollOnWin uses default 1 percent when config unset and roll lands inside threshold`() {
         winConfigReturns(null)
         anchorConfigReturns(MAX_STAKE.toString())
-        every { jackpotService.awardJackpot(guildId) } returns 500L
+        every { jackpotService.awardJackpot(guildId, any()) } returns 500L
         val user = freshUser(initial = 100L)
 
         val won = JackpotHelper.rollOnWin(
@@ -217,7 +222,7 @@ class JackpotHelperTest {
             stake = MAX_STAKE, game = JackpotGame.SLOTS, random = stubRandom(0.001)
         )
 
-        assertEquals(500L, won)
+        assertEquals(500L, won.amount)
         assertEquals(600L, user.socialCredit)
         verify(exactly = 1) { userService.updateUser(user) }
     }
@@ -234,9 +239,9 @@ class JackpotHelperTest {
             stake = MAX_STAKE, game = JackpotGame.SLOTS, random = stubRandom(0.5)
         )
 
-        assertEquals(0L, won)
+        assertEquals(0L, won.amount)
         assertEquals(100L, user.socialCredit)
-        verify(exactly = 0) { jackpotService.awardJackpot(any()) }
+        verify(exactly = 0) { jackpotService.awardJackpot(any(), any()) }
         verify(exactly = 0) { userService.updateUser(any()) }
     }
 
@@ -244,7 +249,7 @@ class JackpotHelperTest {
     fun `rollOnWin honours a sub-1 percent admin override`() {
         winConfigReturns("0.5")  // 0.005
         anchorConfigReturns(MAX_STAKE.toString())
-        every { jackpotService.awardJackpot(guildId) } returns 1_000L
+        every { jackpotService.awardJackpot(guildId, any()) } returns 1_000L
         val userHit = freshUser()
         val userMiss = freshUser()
 
@@ -257,8 +262,8 @@ class JackpotHelperTest {
             stake = MAX_STAKE, game = JackpotGame.SLOTS, random = stubRandom(0.006)
         )
 
-        assertEquals(1_000L, hit, "0.004 < 0.005 should hit")
-        assertEquals(0L, miss, "0.006 >= 0.005 should miss")
+        assertEquals(1_000L, hit.amount, "0.004 < 0.005 should hit")
+        assertEquals(0L, miss.amount, "0.006 >= 0.005 should miss")
     }
 
     @Test
@@ -273,15 +278,15 @@ class JackpotHelperTest {
             stake = MAX_STAKE, game = JackpotGame.SLOTS, random = stubRandom(0.0)
         )
 
-        assertEquals(0L, won)
-        verify(exactly = 0) { jackpotService.awardJackpot(any()) }
+        assertEquals(0L, won.amount)
+        verify(exactly = 0) { jackpotService.awardJackpot(any(), any()) }
     }
 
     @Test
     fun `rollOnWin clamps above MAX_WIN_PROBABILITY`() {
         winConfigReturns("100")  // clamps to 0.50
         anchorConfigReturns(MAX_STAKE.toString())
-        every { jackpotService.awardJackpot(guildId) } returns 50L
+        every { jackpotService.awardJackpot(guildId, any()) } returns 50L
         val userHit = freshUser()
         val userMiss = freshUser()
 
@@ -294,15 +299,15 @@ class JackpotHelperTest {
             stake = MAX_STAKE, game = JackpotGame.SLOTS, random = stubRandom(0.51)
         )
 
-        assertEquals(50L, hit)
-        assertEquals(0L, miss)
+        assertEquals(50L, hit.amount)
+        assertEquals(0L, miss.amount)
     }
 
     @Test
     fun `rollOnWin returns zero and does not credit user when pool is empty`() {
         winConfigReturns("1")
         anchorConfigReturns(MAX_STAKE.toString())
-        every { jackpotService.awardJackpot(guildId) } returns 0L
+        every { jackpotService.awardJackpot(guildId, any()) } returns 0L
         val user = freshUser(initial = 100L)
 
         val won = JackpotHelper.rollOnWin(
@@ -310,7 +315,7 @@ class JackpotHelperTest {
             stake = MAX_STAKE, game = JackpotGame.SLOTS, random = stubRandom(0.001)
         )
 
-        assertEquals(0L, won)
+        assertEquals(0L, won.amount)
         assertEquals(100L, user.socialCredit, "balance must be untouched when pool was empty")
         verify(exactly = 0) { userService.updateUser(any()) }
     }
@@ -321,7 +326,7 @@ class JackpotHelperTest {
     fun `rollOnWin scales by stake fraction so a min-wager autoclick is effectively zero`() {
         winConfigReturns("1") // 1 % base → 10/1000 → 0.01 % effective
         anchorConfigReturns("1000")
-        every { jackpotService.awardJackpot(guildId) } returns 1_000L
+        every { jackpotService.awardJackpot(guildId, any()) } returns 1_000L
         val userHit = freshUser()
         val userMiss = freshUser()
 
@@ -334,15 +339,15 @@ class JackpotHelperTest {
             stake = 10L, game = JackpotGame.SLOTS, random = stubRandom(0.0001)
         )
 
-        assertEquals(1_000L, hit, "0.00009 < 0.0001 should hit")
-        assertEquals(0L, miss, "0.0001 >= 0.0001 should miss")
+        assertEquals(1_000L, hit.amount, "0.00009 < 0.0001 should hit")
+        assertEquals(0L, miss.amount, "0.0001 >= 0.0001 should miss")
     }
 
     @Test
     fun `rollOnWin at the anchor stake rolls at the unscaled base probability`() {
         winConfigReturns("1") // 1 % base → 1000/1000 → 1 % effective
         anchorConfigReturns("1000")
-        every { jackpotService.awardJackpot(guildId) } returns 1_000L
+        every { jackpotService.awardJackpot(guildId, any()) } returns 1_000L
         val userHit = freshUser()
         val userMiss = freshUser()
 
@@ -355,8 +360,8 @@ class JackpotHelperTest {
             stake = 1_000L, game = JackpotGame.SLOTS, random = stubRandom(0.011)
         )
 
-        assertEquals(1_000L, hit)
-        assertEquals(0L, miss)
+        assertEquals(1_000L, hit.amount)
+        assertEquals(0L, miss.amount)
     }
 
     @Test
@@ -367,7 +372,7 @@ class JackpotHelperTest {
         // probability also unbounded-scaling.
         winConfigReturns("1") // base 1 %
         anchorConfigReturns("1000")
-        every { jackpotService.awardJackpot(guildId) } returns 100L
+        every { jackpotService.awardJackpot(guildId, any()) } returns 100L
         val user = freshUser()
 
         val won = JackpotHelper.rollOnWin(
@@ -375,14 +380,14 @@ class JackpotHelperTest {
             stake = 10_000L, game = JackpotGame.SLOTS, random = stubRandom(0.009)
         )
 
-        assertEquals(100L, won)
+        assertEquals(100L, won.amount)
     }
 
     @Test
     fun `rollOnWin defaults the anchor to 500 when config row missing`() {
         winConfigReturns("1")        // 1 % base
         anchorConfigReturns(null)    // fall through to DEFAULT_STAKE_ANCHOR (500)
-        every { jackpotService.awardJackpot(guildId) } returns 1L
+        every { jackpotService.awardJackpot(guildId, any()) } returns 1L
         val user = freshUser()
 
         // stake/anchor = 500/500 = 1.0 → effective = 1 %; 0.009 < 0.01 hits.
@@ -391,7 +396,7 @@ class JackpotHelperTest {
             stake = 500L, game = JackpotGame.SLOTS, random = stubRandom(0.009)
         )
 
-        assertEquals(1L, won)
+        assertEquals(1L, won.amount)
     }
 
     @Test
@@ -401,7 +406,7 @@ class JackpotHelperTest {
         // stake >= 1 trivially saturates the scale to 1.
         winConfigReturns("1")
         anchorConfigReturns("0")
-        every { jackpotService.awardJackpot(guildId) } returns 100L
+        every { jackpotService.awardJackpot(guildId, any()) } returns 100L
         val user = freshUser()
 
         val won = JackpotHelper.rollOnWin(
@@ -409,7 +414,7 @@ class JackpotHelperTest {
             stake = 100L, game = JackpotGame.SLOTS, random = stubRandom(0.009)
         )
 
-        assertEquals(100L, won)
+        assertEquals(100L, won.amount)
     }
 
     // ---- post-fraud gates: cooldown, activity, recordWin ----
@@ -426,9 +431,9 @@ class JackpotHelperTest {
             stake = MAX_STAKE, game = JackpotGame.SLOTS, random = stubRandom(0.001)
         )
 
-        assertEquals(0L, won, "blocked by cooldown gate")
+        assertEquals(0L, won.amount, "blocked by cooldown gate")
         assertEquals(100L, user.socialCredit, "balance untouched on blocked gate")
-        verify(exactly = 0) { jackpotService.awardJackpot(any()) }
+        verify(exactly = 0) { jackpotService.awardJackpot(any(), any()) }
         verify(exactly = 0) { jackpotService.recordWin(any(), any(), any(), any()) }
     }
 
@@ -444,8 +449,8 @@ class JackpotHelperTest {
             stake = MAX_STAKE, game = JackpotGame.SLOTS, random = stubRandom(0.001)
         )
 
-        assertEquals(0L, won, "blocked by activity gate")
-        verify(exactly = 0) { jackpotService.awardJackpot(any()) }
+        assertEquals(0L, won.amount, "blocked by activity gate")
+        verify(exactly = 0) { jackpotService.awardJackpot(any(), any()) }
         verify(exactly = 0) { jackpotService.recordWin(any(), any(), any(), any()) }
     }
 
@@ -453,7 +458,7 @@ class JackpotHelperTest {
     fun `rollOnWin records the win for cooldown tracking on a successful payout`() {
         winConfigReturns("1")
         anchorConfigReturns(MAX_STAKE.toString())
-        every { jackpotService.awardJackpot(guildId) } returns 250L
+        every { jackpotService.awardJackpot(guildId, any()) } returns 250L
         val user = freshUser()
 
         val won = JackpotHelper.rollOnWin(
@@ -461,7 +466,7 @@ class JackpotHelperTest {
             stake = MAX_STAKE, game = JackpotGame.SLOTS, random = stubRandom(0.001)
         )
 
-        assertEquals(250L, won)
+        assertEquals(250L, won.amount)
         verify(exactly = 1) { jackpotService.recordWin(guildId, discordId, 250L, any()) }
     }
 
@@ -469,7 +474,7 @@ class JackpotHelperTest {
     fun `rollOnWin does not record a no-op award (empty pool)`() {
         winConfigReturns("1")
         anchorConfigReturns(MAX_STAKE.toString())
-        every { jackpotService.awardJackpot(guildId) } returns 0L
+        every { jackpotService.awardJackpot(guildId, any()) } returns 0L
         val user = freshUser()
 
         JackpotHelper.rollOnWin(
@@ -480,47 +485,32 @@ class JackpotHelperTest {
         verify(exactly = 0) { jackpotService.recordWin(any(), any(), any(), any()) }
     }
 
-    // ---- payoutPct ----
+    // ---- wheelSegmentsConfig ----
 
     @Test
-    fun `payoutPct returns the default fraction when no config row exists`() {
+    fun `wheelSegmentsConfig returns null when no config row exists`() {
         every {
             configService.getConfigByName(
-                ConfigDto.Configurations.JACKPOT_PAYOUT_PCT.configValue,
+                ConfigDto.Configurations.JACKPOT_WHEEL_SEGMENTS.configValue,
                 guildId.toString()
             )
         } returns null
-        assertEquals(JackpotHelper.DEFAULT_PAYOUT_PCT, JackpotHelper.payoutPct(configService, guildId), 1e-9)
+        // Null is the expected "use defaults" sentinel the live reader
+        // hands to [JackpotWheel.parse].
+        org.junit.jupiter.api.Assertions.assertNull(
+            JackpotHelper.wheelSegmentsConfig(configService, guildId)
+        )
     }
 
     @Test
-    fun `payoutPct parses whole-number percent and clamps to 1 at 100 percent`() {
+    fun `wheelSegmentsConfig echoes the admin-set CSV verbatim`() {
         every {
             configService.getConfigByName(
-                ConfigDto.Configurations.JACKPOT_PAYOUT_PCT.configValue,
+                ConfigDto.Configurations.JACKPOT_WHEEL_SEGMENTS.configValue,
                 guildId.toString()
             )
-        } returns ConfigDto(name = "x", value = "30", guildId = guildId.toString())
-        assertEquals(0.30, JackpotHelper.payoutPct(configService, guildId), 1e-9)
-    }
-
-    @Test
-    fun `payoutPct treats zero or negative as missing (falls back to default)`() {
-        every {
-            configService.getConfigByName(
-                ConfigDto.Configurations.JACKPOT_PAYOUT_PCT.configValue,
-                guildId.toString()
-            )
-        } returns ConfigDto(name = "x", value = "0", guildId = guildId.toString())
-        assertEquals(JackpotHelper.DEFAULT_PAYOUT_PCT, JackpotHelper.payoutPct(configService, guildId), 1e-9)
-
-        every {
-            configService.getConfigByName(
-                ConfigDto.Configurations.JACKPOT_PAYOUT_PCT.configValue,
-                guildId.toString()
-            )
-        } returns ConfigDto(name = "x", value = "-10", guildId = guildId.toString())
-        assertEquals(JackpotHelper.DEFAULT_PAYOUT_PCT, JackpotHelper.payoutPct(configService, guildId), 1e-9)
+        } returns ConfigDto(name = "x", value = "50:5,50:10", guildId = guildId.toString())
+        assertEquals("50:5,50:10", JackpotHelper.wheelSegmentsConfig(configService, guildId))
     }
 
     // ---- winnerCooldownDays ----
@@ -660,9 +650,9 @@ class JackpotHelperTest {
             stake = MAX_STAKE, game = JackpotGame.COINFLIP, random = stubRandom(0.001)
         )
 
-        assertEquals(0L, won, "blocked by RTP gate")
+        assertEquals(0L, won.amount, "blocked by RTP gate")
         assertEquals(100L, user.socialCredit, "balance untouched on blocked gate")
-        verify(exactly = 0) { jackpotService.awardJackpot(any()) }
+        verify(exactly = 0) { jackpotService.awardJackpot(any(), any()) }
         verify(exactly = 0) { jackpotService.recordWin(any(), any(), any(), any()) }
     }
 
@@ -671,7 +661,7 @@ class JackpotHelperTest {
         winConfigReturns("1")
         anchorConfigReturns(MAX_STAKE.toString())
         rtpConfigReturns("95")  // SLOTS (0.890) stays eligible
-        every { jackpotService.awardJackpot(guildId) } returns 750L
+        every { jackpotService.awardJackpot(guildId, any()) } returns 750L
         val user = freshUser()
 
         val won = JackpotHelper.rollOnWin(
@@ -679,7 +669,7 @@ class JackpotHelperTest {
             stake = MAX_STAKE, game = JackpotGame.SLOTS, random = stubRandom(0.001)
         )
 
-        assertEquals(750L, won)
+        assertEquals(750L, won.amount)
     }
 
     @Test
@@ -687,7 +677,7 @@ class JackpotHelperTest {
         winConfigReturns("1")
         anchorConfigReturns(MAX_STAKE.toString())
         rtpConfigReturns(null)  // 0 = disabled — even Coinflip rolls normally
-        every { jackpotService.awardJackpot(guildId) } returns 50L
+        every { jackpotService.awardJackpot(guildId, any()) } returns 50L
         val user = freshUser()
 
         val won = JackpotHelper.rollOnWin(
@@ -695,7 +685,7 @@ class JackpotHelperTest {
             stake = MAX_STAKE, game = JackpotGame.COINFLIP, random = stubRandom(0.001)
         )
 
-        assertEquals(50L, won, "gate disabled — Coinflip wins still roll")
+        assertEquals(50L, won.amount, "gate disabled — Coinflip wins still roll")
     }
 
     // ---- eligibleForJackpot global carve-out ----
@@ -716,9 +706,9 @@ class JackpotHelperTest {
             stake = MAX_STAKE, game = JackpotGame.HIGHLOW, random = stubRandom(0.0)
         )
 
-        assertEquals(0L, won, "HIGHLOW wins must never roll for the jackpot")
+        assertEquals(0L, won.amount, "HIGHLOW wins must never roll for the jackpot")
         assertEquals(100L, user.socialCredit, "balance untouched on carve-out")
-        verify(exactly = 0) { jackpotService.awardJackpot(any()) }
+        verify(exactly = 0) { jackpotService.awardJackpot(any(), any()) }
         verify(exactly = 0) { jackpotService.recordWin(any(), any(), any(), any()) }
         verify(exactly = 0) { userService.updateUser(any()) }
     }
@@ -731,7 +721,7 @@ class JackpotHelperTest {
         winConfigReturns("1")
         anchorConfigReturns(MAX_STAKE.toString())
         rtpConfigReturns(null)
-        every { jackpotService.awardJackpot(guildId) } returns 500L
+        every { jackpotService.awardJackpot(guildId, any()) } returns 500L
 
         val highlow = JackpotHelper.rollOnWin(
             jackpotService, configService, userService, freshUser(), guildId,
@@ -742,8 +732,8 @@ class JackpotHelperTest {
             stake = MAX_STAKE, game = JackpotGame.SLOTS, random = stubRandom(0.001)
         )
 
-        assertEquals(0L, highlow)
-        assertEquals(500L, slots)
+        assertEquals(0L, highlow.amount)
+        assertEquals(500L, slots.amount)
     }
 
     @Test

--- a/database/src/test/kotlin/database/service/JackpotServiceTest.kt
+++ b/database/src/test/kotlin/database/service/JackpotServiceTest.kt
@@ -44,14 +44,6 @@ class JackpotServiceTest {
                 guildId.toString()
             )
         } returns null
-        // Default: no `JACKPOT_PAYOUT_PCT` row → full pool payout (matches
-        // pre-rebalance behaviour for unconfigured guilds).
-        every {
-            configService.getConfigByName(
-                ConfigDto.Configurations.JACKPOT_PAYOUT_PCT.configValue,
-                guildId.toString()
-            )
-        } returns null
         // Default: cooldown / activity gates disabled.
         every {
             configService.getConfigByName(
@@ -135,30 +127,24 @@ class JackpotServiceTest {
     }
 
     @Test
-    fun `awardJackpot pays the entire pool when JACKPOT_PAYOUT_PCT is unset`() {
+    fun `awardJackpot pays the entire pool when fraction is 1`() {
         val existing = TobyCoinJackpotDto(guildId = guildId, pool = 1_500L)
         every { persistence.getByGuildForUpdate(guildId) } returns existing
         every { persistence.upsert(any()) } answers { firstArg() }
 
-        val won = service.awardJackpot(guildId)
+        val won = service.awardJackpot(guildId, 1.0)
 
-        assertEquals(1_500L, won, "default payout pct = 100% pays the entire pool")
+        assertEquals(1_500L, won, "fraction = 1.0 pays the entire pool")
         assertEquals(0L, existing.pool, "pool resets in the same transaction")
     }
 
     @Test
-    fun `awardJackpot pays a configured fraction and re-seeds the remainder`() {
-        every {
-            configService.getConfigByName(
-                ConfigDto.Configurations.JACKPOT_PAYOUT_PCT.configValue,
-                guildId.toString()
-            )
-        } returns ConfigDto(name = "x", value = "30", guildId = guildId.toString())
+    fun `awardJackpot pays the supplied fraction and re-seeds the remainder`() {
         val existing = TobyCoinJackpotDto(guildId = guildId, pool = 1_000L)
         every { persistence.getByGuildForUpdate(guildId) } returns existing
         every { persistence.upsert(any()) } answers { firstArg() }
 
-        val won = service.awardJackpot(guildId)
+        val won = service.awardJackpot(guildId, 0.30)
 
         assertEquals(300L, won, "30% of 1000 paid out")
         assertEquals(700L, existing.pool, "remainder re-seeds the next cycle")
@@ -169,8 +155,18 @@ class JackpotServiceTest {
         val empty = TobyCoinJackpotDto(guildId = guildId, pool = 0L)
         every { persistence.getByGuildForUpdate(guildId) } returns empty
 
-        assertEquals(0L, service.awardJackpot(guildId))
+        assertEquals(0L, service.awardJackpot(guildId, 1.0))
         verify(exactly = 0) { persistence.upsert(any()) }
+    }
+
+    @Test
+    fun `awardJackpot is a no-op when the supplied fraction is non-positive`() {
+        val existing = TobyCoinJackpotDto(guildId = guildId, pool = 1_000L)
+        every { persistence.getByGuildForUpdate(guildId) } returns existing
+
+        assertEquals(0L, service.awardJackpot(guildId, 0.0))
+        assertEquals(0L, service.awardJackpot(guildId, -0.5))
+        assertEquals(1_000L, existing.pool, "pool unchanged on no-op fractions")
     }
 
     @Test

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/moderation/SetConfigCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/moderation/SetConfigCommand.kt
@@ -163,8 +163,16 @@ class SetConfigCommand @Autowired constructor(
                 // (admins use the /moderation web tab) but keep the
                 // dispatch exhaustive in case the option is registered
                 // manually.
-                ConfigDto.Configurations.JACKPOT_PAYOUT_PCT -> setRangedIntConfig(event, optionMapping, deleteDelay,
-                    config = ConfigDto.Configurations.JACKPOT_PAYOUT_PCT, gameLabel = "Jackpot", label = "payout percent", range = 1..100)
+                ConfigDto.Configurations.JACKPOT_WHEEL_SEGMENTS -> {
+                    // No simple int range — admins edit the wheel via
+                    // the /moderation web tab. Surface a friendly error
+                    // if someone tries to set it via /setconfig so the
+                    // dispatch stays exhaustive but doesn't pretend to
+                    // validate the CSV here.
+                    event.hook.sendMessage(
+                        "Edit the payout wheel via the moderation web tab — the CSV format needs the dedicated editor."
+                    ).queue(invokeDeleteOnMessageResponse(deleteDelay))
+                }
                 ConfigDto.Configurations.JACKPOT_WINNER_COOLDOWN_DAYS -> setRangedIntConfig(event, optionMapping, deleteDelay,
                     config = ConfigDto.Configurations.JACKPOT_WINNER_COOLDOWN_DAYS, gameLabel = "Jackpot", label = "winner cooldown days", range = 0..365)
                 ConfigDto.Configurations.JACKPOT_ACTIVITY_WINDOW_DAYS -> setRangedIntConfig(event, optionMapping, deleteDelay,

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/moderation/SetConfigCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/moderation/SetConfigCommand.kt
@@ -169,9 +169,10 @@ class SetConfigCommand @Autowired constructor(
                     // if someone tries to set it via /setconfig so the
                     // dispatch stays exhaustive but doesn't pretend to
                     // validate the CSV here.
-                    event.hook.sendMessage(
-                        "Edit the payout wheel via the moderation web tab — the CSV format needs the dedicated editor."
-                    ).queue(invokeDeleteOnMessageResponse(deleteDelay))
+                    event.hook.replyAndDelete(
+                        "Edit the payout wheel via the moderation web tab — the CSV format needs the dedicated editor.",
+                        deleteDelay,
+                    )
                 }
                 ConfigDto.Configurations.JACKPOT_WINNER_COOLDOWN_DAYS -> setRangedIntConfig(event, optionMapping, deleteDelay,
                     config = ConfigDto.Configurations.JACKPOT_WINNER_COOLDOWN_DAYS, gameLabel = "Jackpot", label = "winner cooldown days", range = 0..365)

--- a/web/src/main/kotlin/web/casino/CasinoPageContext.kt
+++ b/web/src/main/kotlin/web/casino/CasinoPageContext.kt
@@ -52,6 +52,16 @@ class CasinoPageContext(
         model.addAttribute("jackpotPool", jackpotService.getPool(guildId))
         model.addAttribute("jackpotWinPct", jackpotService.winProbabilityDisplay(guildId))
         model.addAttribute("jackpotStakeAnchor", jackpotService.stakeAnchor(guildId))
+        // Serialised as a JSON array `[{weight, payoutPct}, ...]` for the
+        // wheel renderer. Payout fractions become whole-number percents
+        // for display; weights are positive ints already.
+        model.addAttribute(
+            "jackpotWheelSegments",
+            jackpotService.wheelSegments(guildId).map { mapOf(
+                "weight" to it.weight,
+                "payoutPct" to (it.payoutPct * 100.0).toInt(),
+            ) }
+        )
         // Per-game eligibility — only set when caller declares which game
         // this page is for. Lottery / poker pages share the banner but
         // don't roll for the jackpot themselves, so they leave `game`

--- a/web/src/main/kotlin/web/controller/BaccaratController.kt
+++ b/web/src/main/kotlin/web/controller/BaccaratController.kt
@@ -99,6 +99,8 @@ class BaccaratController(
                     win = true,
                     push = false,
                     jackpotPayout = outcome.jackpotPayout.positiveOrNull(),
+                    jackpotTierIndex = outcome.jackpotTierIndex.takeIf { it >= 0 },
+                    jackpotTierPayoutPct = outcome.jackpotTierPayoutPct.takeIf { it > 0.0 },
                     soldTobyCoins = outcome.soldTobyCoins.positiveOrNull(),
                     newPrice = outcome.newPrice,
                 )
@@ -184,6 +186,8 @@ data class BaccaratPlayResponse(
     val win: Boolean? = null,
     val push: Boolean? = null,
     val jackpotPayout: Long? = null,
+    val jackpotTierIndex: Int? = null,
+    val jackpotTierPayoutPct: Double? = null,
     val soldTobyCoins: Long? = null,
     val newPrice: Double? = null,
     val lossTribute: Long? = null,

--- a/web/src/main/kotlin/web/controller/BlackjackController.kt
+++ b/web/src/main/kotlin/web/controller/BlackjackController.kt
@@ -200,6 +200,8 @@ class BlackjackController(
                     ok = true, tableId = outcome.tableId, resolved = true,
                     newBalance = outcome.newBalance,
                     jackpotPayout = outcome.jackpotPayout.takeIf { it > 0L },
+                    jackpotTierIndex = outcome.jackpotTierIndex.takeIf { it >= 0 },
+                    jackpotTierPayoutPct = outcome.jackpotTierPayoutPct.takeIf { it > 0.0 },
                     lossTribute = outcome.lossTribute.takeIf { it > 0L },
                     soldTobyCoins = outcome.soldTobyCoins.takeIf { it > 0L },
                     newPrice = outcome.newPrice
@@ -243,6 +245,8 @@ class BlackjackController(
                         ok = true, tableId = tableId, resolved = true,
                         newBalance = outcome.newBalance,
                         jackpotPayout = outcome.jackpotPayout.takeIf { it > 0L },
+                        jackpotTierIndex = outcome.jackpotTierIndex.takeIf { it >= 0 },
+                        jackpotTierPayoutPct = outcome.jackpotTierPayoutPct.takeIf { it > 0.0 },
                         lossTribute = outcome.lossTribute.takeIf { it > 0L }
                     )
                 )
@@ -456,6 +460,8 @@ data class BlackjackActionResponse(
     val refund: Long? = null,
     val queued: Boolean? = null,
     val jackpotPayout: Long? = null,
+    val jackpotTierIndex: Int? = null,
+    val jackpotTierPayoutPct: Double? = null,
     val lossTribute: Long? = null,
     val soldTobyCoins: Long? = null,
     val newPrice: Double? = null,

--- a/web/src/main/kotlin/web/controller/CasinoHoldemController.kt
+++ b/web/src/main/kotlin/web/controller/CasinoHoldemController.kt
@@ -147,6 +147,8 @@ class CasinoHoldemController(
                         resolved = true,
                         newBalance = outcome.newBalance,
                         jackpotPayout = outcome.jackpotPayout.takeIf { it > 0L },
+                        jackpotTierIndex = outcome.jackpotTierIndex.takeIf { it >= 0 },
+                        jackpotTierPayoutPct = outcome.jackpotTierPayoutPct.takeIf { it > 0.0 },
                         lossTribute = outcome.lossTribute.takeIf { it > 0L },
                     )
                 )
@@ -179,6 +181,8 @@ data class CasinoHoldemActionResponse(
     val resolved: Boolean? = null,
     val newBalance: Long? = null,
     val jackpotPayout: Long? = null,
+    val jackpotTierIndex: Int? = null,
+    val jackpotTierPayoutPct: Double? = null,
     val lossTribute: Long? = null,
     val soldTobyCoins: Long? = null,
     val newPrice: Double? = null,

--- a/web/src/main/kotlin/web/controller/CoinflipController.kt
+++ b/web/src/main/kotlin/web/controller/CoinflipController.kt
@@ -90,6 +90,8 @@ class CoinflipController(
                     newBalance = outcome.newBalance,
                     win = true,
                     jackpotPayout = outcome.jackpotPayout.positiveOrNull(),
+                    jackpotTierIndex = outcome.jackpotTierIndex.takeIf { it >= 0 },
+                    jackpotTierPayoutPct = outcome.jackpotTierPayoutPct.takeIf { it > 0.0 },
                     soldTobyCoins = outcome.soldTobyCoins.positiveOrNull(),
                     newPrice = outcome.newPrice,
                 )
@@ -145,6 +147,8 @@ data class FlipResponse(
     val newBalance: Long? = null,
     val win: Boolean? = null,
     val jackpotPayout: Long? = null,
+    val jackpotTierIndex: Int? = null,
+    val jackpotTierPayoutPct: Double? = null,
     val soldTobyCoins: Long? = null,
     val newPrice: Double? = null,
     val lossTribute: Long? = null,

--- a/web/src/main/kotlin/web/controller/DiceController.kt
+++ b/web/src/main/kotlin/web/controller/DiceController.kt
@@ -84,6 +84,8 @@ class DiceController(
                     newBalance = outcome.newBalance,
                     win = true,
                     jackpotPayout = outcome.jackpotPayout.positiveOrNull(),
+                    jackpotTierIndex = outcome.jackpotTierIndex.takeIf { it >= 0 },
+                    jackpotTierPayoutPct = outcome.jackpotTierPayoutPct.takeIf { it > 0.0 },
                     soldTobyCoins = outcome.soldTobyCoins.positiveOrNull(),
                     newPrice = outcome.newPrice,
                 )
@@ -134,6 +136,8 @@ data class RollResponse(
     val newBalance: Long? = null,
     val win: Boolean? = null,
     val jackpotPayout: Long? = null,
+    val jackpotTierIndex: Int? = null,
+    val jackpotTierPayoutPct: Double? = null,
     val soldTobyCoins: Long? = null,
     val newPrice: Double? = null,
     val lossTribute: Long? = null,

--- a/web/src/main/kotlin/web/controller/HighlowController.kt
+++ b/web/src/main/kotlin/web/controller/HighlowController.kt
@@ -145,6 +145,8 @@ class HighlowController(
                     newBalance = outcome.newBalance,
                     win = true,
                     jackpotPayout = outcome.jackpotPayout.positiveOrNull(),
+                    jackpotTierIndex = outcome.jackpotTierIndex.takeIf { it >= 0 },
+                    jackpotTierPayoutPct = outcome.jackpotTierPayoutPct.takeIf { it > 0.0 },
                     soldTobyCoins = outcome.soldTobyCoins.positiveOrNull(),
                     newPrice = outcome.newPrice,
                 )
@@ -241,6 +243,8 @@ data class PlayResponse(
     val newBalance: Long? = null,
     val win: Boolean? = null,
     val jackpotPayout: Long? = null,
+    val jackpotTierIndex: Int? = null,
+    val jackpotTierPayoutPct: Double? = null,
     val soldTobyCoins: Long? = null,
     val newPrice: Double? = null,
     val lossTribute: Long? = null,

--- a/web/src/main/kotlin/web/controller/KenoController.kt
+++ b/web/src/main/kotlin/web/controller/KenoController.kt
@@ -107,6 +107,8 @@ class KenoController(
                     newBalance = outcome.newBalance,
                     win = true,
                     jackpotPayout = outcome.jackpotPayout.takeIf { it > 0L },
+                    jackpotTierIndex = outcome.jackpotTierIndex.takeIf { it >= 0 },
+                    jackpotTierPayoutPct = outcome.jackpotTierPayoutPct.takeIf { it > 0.0 },
                     soldTobyCoins = outcome.soldTobyCoins.takeIf { it > 0L },
                     newPrice = outcome.newPrice,
                 )
@@ -158,6 +160,8 @@ data class KenoPlayResponse(
     val newBalance: Long? = null,
     val win: Boolean? = null,
     val jackpotPayout: Long? = null,
+    val jackpotTierIndex: Int? = null,
+    val jackpotTierPayoutPct: Double? = null,
     val soldTobyCoins: Long? = null,
     val newPrice: Double? = null,
     val lossTribute: Long? = null,

--- a/web/src/main/kotlin/web/controller/RouletteController.kt
+++ b/web/src/main/kotlin/web/controller/RouletteController.kt
@@ -97,6 +97,8 @@ class RouletteController(
                     newBalance = outcome.newBalance,
                     win = true,
                     jackpotPayout = outcome.jackpotPayout.positiveOrNull(),
+                    jackpotTierIndex = outcome.jackpotTierIndex.takeIf { it >= 0 },
+                    jackpotTierPayoutPct = outcome.jackpotTierPayoutPct.takeIf { it > 0.0 },
                     soldTobyCoins = outcome.soldTobyCoins.positiveOrNull(),
                     newPrice = outcome.newPrice,
                 )
@@ -184,6 +186,8 @@ data class RouletteSpinResponse(
     val newBalance: Long? = null,
     val win: Boolean? = null,
     val jackpotPayout: Long? = null,
+    val jackpotTierIndex: Int? = null,
+    val jackpotTierPayoutPct: Double? = null,
     val soldTobyCoins: Long? = null,
     val newPrice: Double? = null,
     val lossTribute: Long? = null,

--- a/web/src/main/kotlin/web/controller/ScratchController.kt
+++ b/web/src/main/kotlin/web/controller/ScratchController.kt
@@ -92,6 +92,8 @@ class ScratchController(
                     newBalance = outcome.newBalance,
                     win = true,
                     jackpotPayout = outcome.jackpotPayout.positiveOrNull(),
+                    jackpotTierIndex = outcome.jackpotTierIndex.takeIf { it >= 0 },
+                    jackpotTierPayoutPct = outcome.jackpotTierPayoutPct.takeIf { it > 0.0 },
                     soldTobyCoins = outcome.soldTobyCoins.positiveOrNull(),
                     newPrice = outcome.newPrice,
                 )
@@ -131,6 +133,8 @@ data class ScratchResponse(
     val newBalance: Long? = null,
     val win: Boolean? = null,
     val jackpotPayout: Long? = null,
+    val jackpotTierIndex: Int? = null,
+    val jackpotTierPayoutPct: Double? = null,
     val soldTobyCoins: Long? = null,
     val newPrice: Double? = null,
     val lossTribute: Long? = null,

--- a/web/src/main/kotlin/web/controller/SlotsController.kt
+++ b/web/src/main/kotlin/web/controller/SlotsController.kt
@@ -86,6 +86,8 @@ class SlotsController(
                     newBalance = outcome.newBalance,
                     win = true,
                     jackpotPayout = outcome.jackpotPayout.positiveOrNull(),
+                    jackpotTierIndex = outcome.jackpotTierIndex.takeIf { it >= 0 },
+                    jackpotTierPayoutPct = outcome.jackpotTierPayoutPct.takeIf { it > 0.0 },
                     soldTobyCoins = outcome.soldTobyCoins.positiveOrNull(),
                     newPrice = outcome.newPrice,
                 )
@@ -146,6 +148,8 @@ data class SpinResponse(
     val newBalance: Long? = null,
     val win: Boolean? = null,
     val jackpotPayout: Long? = null,
+    val jackpotTierIndex: Int? = null,
+    val jackpotTierPayoutPct: Double? = null,
     val soldTobyCoins: Long? = null,
     val newPrice: Double? = null,
     val lossTribute: Long? = null,

--- a/web/src/main/kotlin/web/service/ModerationWebService.kt
+++ b/web/src/main/kotlin/web/service/ModerationWebService.kt
@@ -51,8 +51,8 @@ class ModerationWebService(
          * Channel-config keys eligible for the
          * [createReadOnlyChannel] flow. Hard-coded allow-list so a
          * malformed (or maliciously crafted) request can't point the
-         * `targetConfig` at, say, `JACKPOT_PAYOUT_PCT` and clobber a
-         * percentage value with a channel id.
+         * `targetConfig` at, say, `JACKPOT_WHEEL_SEGMENTS` and clobber a
+         * non-channel-id value with a channel id.
          */
         private val CHANNEL_CONFIG_ALLOWLIST: Set<ConfigDto.Configurations> = setOf(
             ConfigDto.Configurations.LOTTERY_CHANNEL,
@@ -947,11 +947,17 @@ class ModerationWebService(
                 if (n !in 0..10000) return "Value must be between 0 and 10000 (default 90)."
                 n.toString()
             }
-            ConfigDto.Configurations.JACKPOT_PAYOUT_PCT -> {
-                val n = rawValue.trim().toIntOrNull()
-                    ?: return "Value must be a whole number percentage (1-100; default 100)."
-                if (n !in 1..100) return "Value must be between 1 and 100."
-                n.toString()
+            ConfigDto.Configurations.JACKPOT_WHEEL_SEGMENTS -> {
+                // Empty resets to default. Otherwise must parse cleanly via
+                // [JackpotWheel.validateConfigString] — the live reader uses
+                // the same parser so "saved OK" implies "read OK".
+                val trimmed = rawValue.trim()
+                if (trimmed.isEmpty()) {
+                    ""
+                } else {
+                    database.economy.JackpotWheel.validateConfigString(trimmed)?.let { return it }
+                    trimmed
+                }
             }
             ConfigDto.Configurations.JACKPOT_WINNER_COOLDOWN_DAYS -> {
                 val n = rawValue.trim().toIntOrNull()

--- a/web/src/main/resources/static/css/base.css
+++ b/web/src/main/resources/static/css/base.css
@@ -587,6 +587,72 @@ td { font-size: 0.95rem; }
     font-size: 0.85rem;
 }
 
+/* Spinning-payout-wheel overlay shown when a jackpot roll hits. The
+   wheel decides what fraction of the pool a winning roll pays. Sized
+   to feel like an event without consuming the whole page; absolutely
+   positioned over the page so the underlying game state is preserved
+   when the wheel closes. */
+.jackpot-wheel-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.65);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+}
+.jackpot-wheel-overlay[hidden] { display: none; }
+.jackpot-wheel-stage {
+    position: relative;
+    width: 320px;
+    max-width: 90vw;
+    aspect-ratio: 1 / 1.15;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+.jackpot-wheel-pointer {
+    font-size: 2rem;
+    line-height: 1;
+    color: #ffe066;
+    text-shadow: 0 0 6px rgba(241, 196, 15, 0.6);
+}
+.jackpot-wheel-svg {
+    width: 100%;
+    height: auto;
+    flex: 1;
+}
+.jackpot-wheel-rotor {
+    transform-origin: 0 0;
+    transition: transform 3.2s cubic-bezier(0.18, 0.6, 0.18, 1);
+}
+.jackpot-wheel-hub {
+    fill: #ffe066;
+    stroke: rgba(0, 0, 0, 0.6);
+    stroke-width: 2;
+}
+.jackpot-wheel-segment {
+    stroke: rgba(0, 0, 0, 0.5);
+    stroke-width: 1;
+}
+.jackpot-wheel-segment-label {
+    fill: #1a1a1a;
+    font-size: 13px;
+    font-weight: 700;
+    text-anchor: middle;
+    dominant-baseline: middle;
+    pointer-events: none;
+}
+.jackpot-wheel-result {
+    margin-top: var(--space-2);
+    min-height: 1.4em;
+    text-align: center;
+    color: #ffe066;
+    font-weight: 700;
+    font-size: 1.05rem;
+    text-shadow: 0 0 6px rgba(241, 196, 15, 0.5);
+}
+
 /* Grow tap targets on any touch device without ballooning desktop buttons */
 @media (hover: none) and (pointer: coarse) {
     .btn-sm { padding: 8px 14px; min-height: 40px; }

--- a/web/src/main/resources/static/css/moderation.css
+++ b/web/src/main/resources/static/css/moderation.css
@@ -290,6 +290,75 @@ details.config-section.is-hidden { display: none; }
     .config-row .save-config { grid-column: 2; }
 }
 
+/* Wide row variant — the wheel editor needs full width for its
+   paired (weight, payout) inputs and the explainer block. */
+.config-row-wide {
+    grid-template-columns: minmax(0, 1fr) auto;
+    column-gap: var(--space-3);
+}
+.config-row-wide > label,
+.config-row-wide > .config-explainer,
+.config-row-wide > .jackpot-wheel-editor {
+    grid-column: 1 / -1;
+}
+.config-row-wide > .jackpot-wheel-save {
+    grid-column: 1 / -1;
+    justify-self: flex-start;
+}
+
+.jackpot-wheel-editor-rows {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+    margin: var(--space-2) 0;
+}
+.jackpot-wheel-editor-row {
+    display: grid;
+    grid-template-columns: 36px minmax(0, 130px) minmax(0, 160px) auto;
+    align-items: center;
+    column-gap: var(--space-3);
+}
+.jackpot-wheel-editor-row .jackpot-wheel-row-label {
+    color: var(--text-muted);
+    font-variant-numeric: tabular-nums;
+    text-align: right;
+}
+.jackpot-wheel-editor-row label {
+    grid-column: auto;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-weight: 500;
+    color: var(--text-muted);
+    font-size: 0.85rem;
+}
+.jackpot-wheel-editor-row input {
+    flex: 1 1 auto;
+    min-width: 0;
+    grid-column: auto;
+    width: 80px;
+}
+.jackpot-wheel-editor-row .config-suffix {
+    color: var(--text-muted);
+}
+.jackpot-wheel-editor-row .jw-remove {
+    padding: 2px 10px;
+}
+.jackpot-wheel-editor-actions {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    margin-top: var(--space-2);
+}
+.jackpot-wheel-ev {
+    font-size: 0.9rem;
+}
+.jackpot-wheel-error {
+    color: #ff6b6b;
+    font-size: 0.9rem;
+    margin: var(--space-2) 0 0;
+}
+
 /* Config sub-groups (e.g. "Casino stakes & buy-ins" splits into Dice /
    Coinflip / Poker / etc. sub-groups). Each `.config-group` carries a
    small uppercase `<h4>` heading and a hairline divider between groups

--- a/web/src/main/resources/static/js/blackjack-solo.js
+++ b/web/src/main/resources/static/js/blackjack-solo.js
@@ -385,10 +385,17 @@
         var jackpot = window.TobyJackpot;
         var body = (jackpot && lastResolutionBody &&
             lastResolutionBody.handNumber === r.handNumber) ? lastResolutionBody : null;
+        var jackpotPct = (body && typeof body.jackpotTierPayoutPct === "number")
+            ? body.jackpotTierPayoutPct * 100 : 0;
         var jackpotPrefixHtml = (body && jackpot)
-            ? jackpot.jackpotPrefixHtml(body.jackpotPayout) : "";
+            ? jackpot.jackpotPrefixHtml(body.jackpotPayout, jackpotPct) : "";
         var lossTributeSuffixHtml = (body && jackpot)
             ? jackpot.lossTributeSuffix(body) : "";
+        // Spin the visual wheel once per resolution if the server picked
+        // a tier. No-op when the response isn't a jackpot hit.
+        if (body && jackpot && typeof jackpot.spinWheelFor === "function") {
+            jackpot.spinWheelFor(body);
+        }
 
         // For a split round, seatResults only carries hand 0's outcome —
         // see BlackjackService.settleSolo (firstHandResult). Surface every

--- a/web/src/main/resources/static/js/casino-jackpot-wheel.js
+++ b/web/src/main/resources/static/js/casino-jackpot-wheel.js
@@ -1,0 +1,175 @@
+// Spinning-wheel renderer + animator shown when a jackpot roll hits.
+// Server picks the tier (authoritative); this JS just animates the
+// wheel landing on the matching wedge, so the player can SEE which
+// slice of the pool they're getting and why.
+//
+// Segments come from `window.__jackpotWheel` (a JSON blob the
+// `fragments/casino.html :: jackpotWheel` template inlines on every
+// casino page). Each entry is `{weight, payoutPct}` matching the
+// server-side `database.economy.JackpotWheel.Segment` row, so the
+// wheel the player sees IS the wheel the server spun.
+//
+// Coordinated with `casino-jackpot.js`'s `holdPoolBanner` /
+// `releasePoolBanner` so the live pool counter doesn't tick down to
+// the post-win value mid-spin — that would let a fast reader infer
+// the result before the wheel stops.
+
+(function (root) {
+    'use strict';
+
+    const SPIN_DURATION_MS = 3200;
+    const SPIN_ROTATIONS = 4;
+    // Palette cycles through wedges; gold, indigo, teal, pink, slate
+    // give enough contrast at 5 segments and remain readable at 12.
+    const COLOURS = ['#f1c40f', '#7c5cff', '#1abc9c', '#ff6b9d', '#5d6d7e',
+                     '#e67e22', '#3498db', '#27ae60', '#c0392b', '#8e44ad',
+                     '#d4ac0d', '#16a085'];
+
+    function readSegments() {
+        const raw = (root && root.__jackpotWheel) || [];
+        if (!Array.isArray(raw) || raw.length === 0) return [];
+        // Defensive clone + filter out malformed rows so the wheel
+        // never renders a bad wedge if the server somehow emits one.
+        return raw.filter(s =>
+            s && typeof s.weight === 'number' && s.weight > 0 &&
+            typeof s.payoutPct === 'number' && s.payoutPct > 0
+        ).map(s => ({ weight: s.weight, payoutPct: s.payoutPct }));
+    }
+
+    function buildWedgePath(startAngle, endAngle, radius) {
+        const a0 = (startAngle - 90) * Math.PI / 180;
+        const a1 = (endAngle - 90) * Math.PI / 180;
+        const x0 = Math.cos(a0) * radius;
+        const y0 = Math.sin(a0) * radius;
+        const x1 = Math.cos(a1) * radius;
+        const y1 = Math.sin(a1) * radius;
+        const largeArc = (endAngle - startAngle) > 180 ? 1 : 0;
+        return `M 0 0 L ${x0.toFixed(2)} ${y0.toFixed(2)} A ${radius} ${radius} 0 ${largeArc} 1 ${x1.toFixed(2)} ${y1.toFixed(2)} Z`;
+    }
+
+    function render(segments, rotor) {
+        rotor.innerHTML = '';
+        const totalWeight = segments.reduce((s, seg) => s + seg.weight, 0);
+        if (totalWeight <= 0) return [];
+        const radius = 100;
+        let cursor = 0;
+        const angles = [];
+        segments.forEach((seg, i) => {
+            const sweep = (seg.weight / totalWeight) * 360;
+            const start = cursor;
+            const end = cursor + sweep;
+            const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+            path.setAttribute('d', buildWedgePath(start, end, radius));
+            path.setAttribute('fill', COLOURS[i % COLOURS.length]);
+            path.setAttribute('class', 'jackpot-wheel-segment');
+            rotor.appendChild(path);
+
+            // Label at the wedge's midpoint, rotated to read radially.
+            const mid = (start + end) / 2;
+            const labelR = radius * 0.62;
+            const lx = Math.cos((mid - 90) * Math.PI / 180) * labelR;
+            const ly = Math.sin((mid - 90) * Math.PI / 180) * labelR;
+            const text = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+            text.setAttribute('x', lx.toFixed(2));
+            text.setAttribute('y', ly.toFixed(2));
+            text.setAttribute('class', 'jackpot-wheel-segment-label');
+            text.textContent = seg.payoutPct + '%';
+            rotor.appendChild(text);
+
+            angles.push({ start, end, mid });
+            cursor = end;
+        });
+        return angles;
+    }
+
+    function tierLabel(payoutPct) {
+        if (payoutPct >= 30) return '🎰 MEGA JACKPOT!';
+        if (payoutPct >= 10) return '🎰 BIG WIN!';
+        if (payoutPct >= 2)  return '💰 Nice payout!';
+        return '🎟️ Pity prize';
+    }
+
+    /**
+     * Show the overlay and spin to [tierIndex]. The wheel's rotor
+     * rotates `SPIN_ROTATIONS` full turns + the angle needed to bring
+     * the picked wedge's midpoint under the top pointer. [onSettle] is
+     * called when the CSS transition completes.
+     */
+    function spinTo(tierIndex, payoutAmount, payoutPct, onSettle) {
+        const overlay = document.getElementById('jackpot-wheel-overlay');
+        if (!overlay) {
+            // No overlay on this page (e.g. Discord-only or test
+            // harness) — fire onSettle synchronously so the calling
+            // game's renderer can paint its result line unchanged.
+            if (typeof onSettle === 'function') onSettle();
+            return;
+        }
+        const segments = readSegments();
+        const rotor = overlay.querySelector('.jackpot-wheel-rotor');
+        const resultEl = overlay.querySelector('.jackpot-wheel-result');
+        if (!rotor || segments.length === 0 || tierIndex < 0 || tierIndex >= segments.length) {
+            if (typeof onSettle === 'function') onSettle();
+            return;
+        }
+        const angles = render(segments, rotor);
+
+        // Snap rotor to 0 before animating so successive spins start
+        // from a known transform. Force a layout read between the snap
+        // and the new target to make the browser register the
+        // transition's starting point.
+        rotor.style.transition = 'none';
+        rotor.style.transform = 'rotate(0deg)';
+        // eslint-disable-next-line no-unused-expressions
+        rotor.getBoundingClientRect();
+        rotor.style.transition = '';
+
+        const target = angles[tierIndex].mid;
+        // Pointer is at the top (angle 0 in wedge coords). To bring
+        // the wedge midpoint under it we rotate by `-target`, plus
+        // full rotations for drama.
+        const finalAngle = SPIN_ROTATIONS * 360 - target;
+        overlay.hidden = false;
+        if (resultEl) resultEl.textContent = '';
+
+        // Hold the pool banner so it doesn't tick to the post-win
+        // value before the wheel lands.
+        if (root && root.TobyJackpot && typeof root.TobyJackpot.holdPoolBanner === 'function') {
+            root.TobyJackpot.holdPoolBanner();
+        }
+
+        let settled = false;
+        const settle = () => {
+            if (settled) return;
+            settled = true;
+            rotor.removeEventListener('transitionend', settle);
+            if (resultEl) resultEl.textContent = tierLabel(payoutPct) + ' +' + payoutAmount + ' credits';
+            if (root && root.TobyJackpot && typeof root.TobyJackpot.releasePoolBanner === 'function') {
+                root.TobyJackpot.releasePoolBanner();
+            }
+            // Auto-dismiss after a short read-pause so the player sees
+            // the result before returning to the table. Manual close
+            // via click also works for impatient users.
+            const close = () => { overlay.hidden = true; overlay.removeEventListener('click', close); };
+            overlay.addEventListener('click', close, { once: true });
+            setTimeout(close, 1800);
+            if (typeof onSettle === 'function') onSettle();
+        };
+        rotor.addEventListener('transitionend', settle);
+        // Belt-and-braces fallback in case transitionend doesn't fire
+        // (overlay torn down mid-spin, reduced-motion CSS, etc.).
+        setTimeout(settle, SPIN_DURATION_MS + 600);
+
+        // Schedule the spin on the next frame so the snap-to-0 above
+        // takes effect first.
+        requestAnimationFrame(() => {
+            rotor.style.transform = 'rotate(' + finalAngle.toFixed(2) + 'deg)';
+        });
+    }
+
+    const api = { readSegments, render, tierLabel, spinTo, SPIN_DURATION_MS };
+    if (root) root.TobyJackpotWheel = api;
+
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = api;
+    }
+})(typeof window !== 'undefined' ? window : null);

--- a/web/src/main/resources/static/js/casino-jackpot.js
+++ b/web/src/main/resources/static/js/casino-jackpot.js
@@ -10,9 +10,22 @@
         return !!(body && typeof body.jackpotPayout === 'number' && body.jackpotPayout > 0);
     }
 
-    function jackpotPrefixHtml(payout) {
+    /**
+     * Tier label keyed off the percentage of pool the wheel picked.
+     * Mirrors `casino-jackpot-wheel.js#tierLabel` so the result line
+     * and the wheel's settle text say the same thing.
+     */
+    function tierLabel(payoutPct) {
+        if (typeof payoutPct !== 'number' || payoutPct <= 0) return '🎰 JACKPOT!';
+        if (payoutPct >= 30) return '🎰 MEGA JACKPOT!';
+        if (payoutPct >= 10) return '🎰 BIG WIN!';
+        if (payoutPct >= 2)  return '💰 Nice payout!';
+        return '🎟️ Pity prize';
+    }
+
+    function jackpotPrefixHtml(payout, payoutPct) {
         if (typeof payout !== 'number' || payout <= 0) return '';
-        return '🎰 <strong>JACKPOT!</strong> +' + payout + ' credits<br>';
+        return tierLabel(payoutPct) + ' +' + payout + ' credits<br>';
     }
 
     // Hold/release lock used by per-game JS to keep the pool banner in
@@ -70,7 +83,35 @@
     function renderWinHtml(resultEl, body, jackpotClassName, winLineHtml) {
         if (!isJackpotHit(body)) return winLineHtml;
         if (resultEl && jackpotClassName) resultEl.classList.add(jackpotClassName);
-        return jackpotPrefixHtml(body.jackpotPayout) + winLineHtml;
+        // `jackpotTierPayoutPct` arrives as a fraction (0..1) from the
+        // backend; render the percent so it matches the wheel's labels.
+        const pct = typeof body.jackpotTierPayoutPct === 'number'
+            ? body.jackpotTierPayoutPct * 100
+            : 0;
+        return jackpotPrefixHtml(body.jackpotPayout, pct) + winLineHtml;
+    }
+
+    /**
+     * Spin the visual wheel to the server-picked tier. No-op when the
+     * response isn't a jackpot hit or the wheel module isn't loaded
+     * (e.g. test harnesses, mid-migration pages). `onSettle` fires
+     * once the wheel stops so the caller can paint its result line in
+     * sync with the wheel reveal.
+     */
+    function spinWheelFor(body, onSettle) {
+        if (!isJackpotHit(body) || typeof body.jackpotTierIndex !== 'number' || body.jackpotTierIndex < 0) {
+            if (typeof onSettle === 'function') onSettle();
+            return;
+        }
+        const wheel = root && root.TobyJackpotWheel;
+        if (!wheel || typeof wheel.spinTo !== 'function') {
+            if (typeof onSettle === 'function') onSettle();
+            return;
+        }
+        const pct = typeof body.jackpotTierPayoutPct === 'number'
+            ? Math.round(body.jackpotTierPayoutPct * 100)
+            : 0;
+        wheel.spinTo(body.jackpotTierIndex, body.jackpotPayout, pct, onSettle);
     }
 
     /**
@@ -87,7 +128,9 @@
     const api = {
         isJackpotHit,
         jackpotPrefixHtml,
+        tierLabel,
         renderWinHtml,
+        spinWheelFor,
         lossTributeSuffix,
         updatePoolBanner,
         holdPoolBanner,

--- a/web/src/main/resources/static/js/casino-result.js
+++ b/web/src/main/resources/static/js/casino-result.js
@@ -40,6 +40,14 @@
                 ? root.TobyJackpot.renderWinHtml(el, opts.body, prefix + '-result-jackpot', opts.winLineHtml)
                 : opts.winLineHtml;
             el.innerHTML = topUpPrefix + withJackpot;
+            // Fire-and-forget the wheel overlay — it does its own
+            // hold/release on the pool banner and dismisses itself
+            // after a short reveal. No-op when the response isn't a
+            // jackpot hit, so non-jackpot wins behave exactly as
+            // before.
+            if (root && root.TobyJackpot && typeof root.TobyJackpot.spinWheelFor === 'function') {
+                root.TobyJackpot.spinWheelFor(opts.body);
+            }
         } else {
             el.classList.add(prefix + '-result-lose');
             const tributeSuffix = (root && root.TobyJackpot)

--- a/web/src/main/resources/static/js/casinoholdem-solo.js
+++ b/web/src/main/resources/static/js/casinoholdem-solo.js
@@ -238,6 +238,13 @@
                 if (typeof b.newBalance === "number") {
                     window.TobyBalance.update(balanceEl, b.newBalance);
                 }
+                // Spin the wheel off the action response — the state-
+                // poll projection doesn't carry tier info, so this is
+                // the only path that can drive the animation.
+                if (b.jackpotPayout > 0 && window.TobyJackpot &&
+                    typeof window.TobyJackpot.spinWheelFor === "function") {
+                    window.TobyJackpot.spinWheelFor(b);
+                }
                 refreshState();
             })
             .catch(function () { errorToast("Network error."); })

--- a/web/src/main/resources/static/js/moderation/jackpot-wheel.js
+++ b/web/src/main/resources/static/js/moderation/jackpot-wheel.js
@@ -1,0 +1,162 @@
+// Per-tier editor for the `JACKPOT_WHEEL_SEGMENTS` config row on the
+// moderation/settings page. The config value is a CSV
+// (`80:1,10:5,5:10,4:20,1:50`) so a single `<input type="text">` would
+// be unforgiving; this widget renders one (weight, payout %) pair per
+// segment with add/remove buttons, a live EV preview, and client-side
+// validation that mirrors what `JackpotWheel.validateConfigString`
+// does on the server. Server-side validation is the source of truth —
+// these checks just keep the UX honest.
+(function () {
+    'use strict';
+
+    const DEFAULT = '80:1,10:5,5:10,4:20,1:50';
+    const MAX_SEGMENTS = 12;
+
+    function parseCsv(csv) {
+        if (!csv || typeof csv !== 'string') return [];
+        const out = [];
+        csv.split(',').forEach(pair => {
+            const trimmed = pair.trim();
+            if (!trimmed) return;
+            const parts = trimmed.split(':').map(p => p.trim());
+            if (parts.length !== 2) return;
+            const w = parseInt(parts[0], 10);
+            const p = parseInt(parts[1], 10);
+            if (!Number.isFinite(w) || !Number.isFinite(p)) return;
+            out.push({ weight: w, pct: p });
+        });
+        return out;
+    }
+
+    function serializeCsv(rows) {
+        return rows.map(r => r.weight + ':' + r.pct).join(',');
+    }
+
+    function validate(rows) {
+        if (rows.length === 0) return 'At least one segment required.';
+        if (rows.length > MAX_SEGMENTS) return 'At most ' + MAX_SEGMENTS + ' segments.';
+        let total = 0;
+        for (let i = 0; i < rows.length; i++) {
+            const r = rows[i];
+            if (!Number.isFinite(r.weight) || r.weight <= 0) {
+                return 'Segment ' + (i + 1) + ' weight must be a positive integer.';
+            }
+            if (!Number.isFinite(r.pct) || r.pct < 1 || r.pct > 100) {
+                return 'Segment ' + (i + 1) + ' payout % must be 1-100.';
+            }
+            total += r.weight;
+        }
+        if (total <= 0) return 'Total weight must be > 0.';
+        return null;
+    }
+
+    function expectedValuePct(rows) {
+        const total = rows.reduce((s, r) => s + r.weight, 0);
+        if (total <= 0) return 0;
+        return rows.reduce((s, r) => s + (r.weight / total) * r.pct, 0);
+    }
+
+    function buildEditor(editor) {
+        const rowsContainer = editor.querySelector('.jackpot-wheel-editor-rows');
+        const addBtn = editor.querySelector('.jackpot-wheel-add');
+        const evEl = editor.querySelector('.jackpot-wheel-ev');
+        const errEl = editor.querySelector('.jackpot-wheel-error');
+        const saveBtn = editor.parentElement.querySelector('.jackpot-wheel-save');
+        if (!rowsContainer || !addBtn || !saveBtn) return null;
+
+        // Seed from data-current; empty/null falls back to DEFAULT so
+        // the admin sees what would happen if they hit save with no
+        // edits (the default is also what the server uses when the row
+        // is unset).
+        let current = editor.dataset.current || '';
+        if (!current || current === 'null') current = DEFAULT;
+        let state = parseCsv(current);
+        if (state.length === 0) state = parseCsv(DEFAULT);
+
+        function render() {
+            rowsContainer.innerHTML = '';
+            state.forEach((row, idx) => {
+                const div = document.createElement('div');
+                div.className = 'jackpot-wheel-editor-row';
+                div.innerHTML =
+                    '<span class="jackpot-wheel-row-label">' + (idx + 1) + '</span>' +
+                    '<label>Weight <input type="number" min="1" step="1" class="jw-weight" value="' + row.weight + '"></label>' +
+                    '<label>Payout <input type="number" min="1" max="100" step="1" class="jw-pct" value="' + row.pct + '"><span class="config-suffix">%</span></label>' +
+                    '<button type="button" class="btn btn-sm jw-remove" aria-label="Remove segment">×</button>';
+                div.querySelector('.jw-weight').addEventListener('input', e => {
+                    state[idx].weight = parseInt(e.target.value, 10);
+                    refresh();
+                });
+                div.querySelector('.jw-pct').addEventListener('input', e => {
+                    state[idx].pct = parseInt(e.target.value, 10);
+                    refresh();
+                });
+                div.querySelector('.jw-remove').addEventListener('click', () => {
+                    if (state.length <= 1) return;
+                    state.splice(idx, 1);
+                    render();
+                    refresh();
+                });
+                rowsContainer.appendChild(div);
+            });
+            addBtn.disabled = state.length >= MAX_SEGMENTS;
+        }
+
+        function refresh() {
+            const err = validate(state);
+            if (err) {
+                errEl.hidden = false;
+                errEl.textContent = err;
+                evEl.textContent = '';
+            } else {
+                errEl.hidden = true;
+                errEl.textContent = '';
+                evEl.textContent = 'Expected payout per win: ' + expectedValuePct(state).toFixed(2) + '% of pool';
+            }
+        }
+
+        addBtn.addEventListener('click', () => {
+            if (state.length >= MAX_SEGMENTS) return;
+            state.push({ weight: 1, pct: 10 });
+            render();
+            refresh();
+        });
+
+        saveBtn.addEventListener('click', () => {
+            const err = validate(state);
+            if (err) {
+                if (window.ModerationCommon) {
+                    // No exported toast helper — reuse the error region.
+                    errEl.hidden = false;
+                    errEl.textContent = err;
+                }
+                return;
+            }
+            const csv = serializeCsv(state);
+            saveBtn.disabled = true;
+            window.ModerationCommon.postJson(
+                '/moderation/' + window.ModerationCommon.guildId + '/config',
+                { key: 'JACKPOT_WHEEL_SEGMENTS', value: csv }
+            ).then(r => {
+                saveBtn.disabled = false;
+                if (r && r.ok) {
+                    editor.dataset.current = csv;
+                    if (window.toast) window.toast('Wheel saved.', 'success');
+                } else {
+                    errEl.hidden = false;
+                    errEl.textContent = (r && r.error) || 'Could not save wheel.';
+                }
+            }).catch(() => {
+                saveBtn.disabled = false;
+                errEl.hidden = false;
+                errEl.textContent = 'Network error.';
+            });
+        });
+
+        render();
+        refresh();
+        return { state: state };
+    }
+
+    document.querySelectorAll('.jackpot-wheel-editor').forEach(buildEditor);
+})();

--- a/web/src/main/resources/templates/fragments/casino.html
+++ b/web/src/main/resources/templates/fragments/casino.html
@@ -7,7 +7,8 @@
     HTML; centralising it means a copy/styling change ripples to every
     game in one edit.
 -->
-<div th:fragment="jackpotBanner" class="casino-jackpot-banner"
+<th:block th:fragment="jackpotBanner">
+<div class="casino-jackpot-banner"
      th:classappend="${jackpotIneligible} ? ' casino-jackpot-banner--ineligible'"
      title="Anti-cheat is on. Detected automation accrues forced losses up to a configured cap.">
     🎰 Jackpot pool:
@@ -15,9 +16,11 @@
     <span class="muted" th:unless="${jackpotIneligible}">
         — win any minigame for up to
         <span th:text="${jackpotWinPct}">1</span>%
-        chance to bank the pool. The chance scales with your stake against a
+        chance to spin the payout wheel. The chance scales with your stake against a
         <span th:text="${jackpotStakeAnchor}">500</span>-credit reference;
         bets at or above that get the full rate, smaller bets scale linearly down.
+        The wheel decides what fraction of the pool you take — most spins are
+        small pity prizes, rare spins drain a meaningful share.
     </span>
     <th:block th:if="${jackpotIneligible}">
         <span class="muted" th:if="${jackpotIneligibleReason == 'rtp'}">
@@ -33,5 +36,30 @@
         </span>
     </th:block>
 </div>
+
+<!--
+    Spinning-wheel overlay shown when a jackpot roll hits. Hidden by
+    default and revealed by `casino-jackpot-wheel.js` on a winning
+    response. Segments are server-rendered as a JSON blob so the JS
+    renders the exact wheel the server spun against. Rides along with
+    every jackpotBanner include so each casino page automatically gets
+    the overlay without per-page edits.
+-->
+<div id="jackpot-wheel-overlay" class="jackpot-wheel-overlay" hidden>
+    <div class="jackpot-wheel-stage">
+        <div class="jackpot-wheel-pointer">▼</div>
+        <svg class="jackpot-wheel-svg" viewBox="-110 -110 220 220" aria-hidden="true">
+            <g class="jackpot-wheel-rotor"></g>
+            <circle cx="0" cy="0" r="14" class="jackpot-wheel-hub"></circle>
+        </svg>
+        <div class="jackpot-wheel-result" aria-live="polite"></div>
+    </div>
+    <script th:inline="javascript">
+        /*<![CDATA[*/
+        window.__jackpotWheel = /*[[${jackpotWheelSegments}]]*/ [];
+        /*]]>*/
+    </script>
+</div>
+</th:block>
 </body>
 </html>

--- a/web/src/main/resources/templates/fragments/casinoMinigame.html
+++ b/web/src/main/resources/templates/fragments/casinoMinigame.html
@@ -56,6 +56,7 @@
     <script th:src="@{/js/toasts.js}"></script>
     <script th:src="@{/js/casino-sounds.js}"></script>
     <script th:src="@{/js/casino-jackpot.js}"></script>
+    <script th:src="@{/js/casino-jackpot-wheel.js}"></script>
     <script th:src="@{/js/casino-balance.js}"></script>
     <script th:src="@{/js/casino-topup.js}"></script>
     <script th:src="@{/js/casino-result.js}"></script>

--- a/web/src/main/resources/templates/moderation/settings.html
+++ b/web/src/main/resources/templates/moderation/settings.html
@@ -227,16 +227,31 @@
                     </span>
                     <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
                 </div>
-                <div class="config-row" data-key="JACKPOT_PAYOUT_PCT">
-                    <label>Payout (% of pool paid on a winning roll; e.g. 30 leaves the rest to re-seed; default 100)</label>
-                    <span class="config-input-group">
-                        <input type="number" min="1" max="100"
-                               th:value="${overview.config['JACKPOT_PAYOUT_PCT']}"
-                               placeholder="100"
-                               th:disabled="${!isOwner}">
-                        <span class="config-suffix">%</span>
-                    </span>
-                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                <div class="config-row config-row-wide" data-key="JACKPOT_WHEEL_SEGMENTS">
+                    <label>Payout wheel segments</label>
+                    <p class="muted config-explainer">
+                        Each segment is a wedge of the spinning wheel that's
+                        spun when a player wins the jackpot. <strong>Weight</strong>
+                        is how often it's picked (positive integer; relative,
+                        not %). <strong>Payout %</strong> is how much of the pool
+                        the winner takes when the wheel lands there.
+                        Default <code>80:1,10:5,5:10,4:20,1:50</code> — most
+                        wins give a small pity prize, a rare 1-in-100 spin
+                        pays out half the pool. For a flat fixed-percent
+                        payout, set a single segment (e.g. <code>1:30</code>
+                        for "always 30% of the pool").
+                    </p>
+                    <div class="jackpot-wheel-editor"
+                         th:attr="data-current=${overview.config['JACKPOT_WHEEL_SEGMENTS']}">
+                        <div class="jackpot-wheel-editor-rows"></div>
+                        <div class="jackpot-wheel-editor-actions">
+                            <button type="button" class="btn btn-sm jackpot-wheel-add"
+                                    th:disabled="${!isOwner}">+ Add segment</button>
+                            <span class="muted jackpot-wheel-ev"></span>
+                        </div>
+                        <p class="jackpot-wheel-error error-text" hidden></p>
+                    </div>
+                    <button type="button" class="btn jackpot-wheel-save" th:disabled="${!isOwner}">Save</button>
                 </div>
                 <div class="config-row" data-key="JACKPOT_RTP_MAX_PCT">
                     <label>Max game RTP eligible for jackpot (0 disables the gate; recommended 95 to exclude blackjack/coinflip/baccarat/roulette)</label>
@@ -759,5 +774,6 @@
 <script th:src="@{/js/toasts.js}"></script>
 <script th:src="@{/js/moderationCommon.js}"></script>
 <script th:src="@{/js/moderation/settings.js}"></script>
+<script th:src="@{/js/moderation/jackpot-wheel.js}"></script>
 </body>
 </html>

--- a/web/src/test/js/casino-jackpot-wheel.test.js
+++ b/web/src/test/js/casino-jackpot-wheel.test.js
@@ -1,0 +1,179 @@
+// Coverage for the JS-side wheel renderer + spin animation. We exercise
+// the read/parse path (`readSegments`), the SVG render math, the tier
+// labelling, and the `spinTo` lifecycle (overlay show, pool-banner
+// hold, transitionend settle, dismiss). The animation timing is
+// shortcut by directly firing `transitionend` rather than waiting on
+// real CSS transitions (jsdom doesn't run them anyway).
+
+const wheel = require('../../main/resources/static/js/casino-jackpot-wheel');
+const jackpot = require('../../main/resources/static/js/casino-jackpot');
+
+const { readSegments, render, tierLabel, spinTo } = wheel;
+
+describe('readSegments', () => {
+    afterEach(() => { delete window.__jackpotWheel; });
+
+    test('returns [] when the global is unset', () => {
+        expect(readSegments()).toEqual([]);
+    });
+
+    test('returns [] when the global is empty', () => {
+        window.__jackpotWheel = [];
+        expect(readSegments()).toEqual([]);
+    });
+
+    test('passes through well-formed segments', () => {
+        window.__jackpotWheel = [
+            { weight: 80, payoutPct: 1 },
+            { weight: 10, payoutPct: 5 },
+        ];
+        expect(readSegments()).toEqual([
+            { weight: 80, payoutPct: 1 },
+            { weight: 10, payoutPct: 5 },
+        ]);
+    });
+
+    test('filters malformed rows defensively', () => {
+        window.__jackpotWheel = [
+            { weight: 10, payoutPct: 5 },
+            { weight: 0, payoutPct: 5 },       // bad weight
+            { weight: 5, payoutPct: 0 },       // bad pct
+            null,
+            { weight: 5 },                     // missing pct
+            { payoutPct: 5 },                  // missing weight
+            { weight: 'abc', payoutPct: 5 },   // wrong type
+        ];
+        expect(readSegments()).toEqual([{ weight: 10, payoutPct: 5 }]);
+    });
+});
+
+describe('tierLabel', () => {
+    test('returns increasingly louder labels by pct', () => {
+        expect(tierLabel(1)).toContain('Pity');
+        expect(tierLabel(5)).toContain('Nice');
+        expect(tierLabel(10)).toContain('BIG WIN');
+        expect(tierLabel(50)).toContain('MEGA JACKPOT');
+    });
+});
+
+describe('render', () => {
+    test('emits one path + one label per segment, sized by weight', () => {
+        const rotor = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+        const segments = [
+            { weight: 80, payoutPct: 1 },
+            { weight: 10, payoutPct: 5 },
+            { weight: 5, payoutPct: 10 },
+            { weight: 4, payoutPct: 20 },
+            { weight: 1, payoutPct: 50 },
+        ];
+        const angles = render(segments, rotor);
+        expect(rotor.querySelectorAll('path').length).toBe(5);
+        expect(rotor.querySelectorAll('text').length).toBe(5);
+        // 80/100 = 288 degrees for the first wedge.
+        expect(angles[0].end - angles[0].start).toBeCloseTo(288, 1);
+        expect(angles[4].end - angles[4].start).toBeCloseTo(3.6, 1);
+    });
+
+    test('shows the payout pct on each label', () => {
+        const rotor = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+        render([{ weight: 1, payoutPct: 30 }], rotor);
+        expect(rotor.querySelector('text').textContent).toBe('30%');
+    });
+});
+
+describe('spinTo', () => {
+    beforeEach(() => {
+        document.body.innerHTML = `
+            <div id="jackpot-wheel-overlay" hidden>
+                <svg viewBox="-110 -110 220 220">
+                    <g class="jackpot-wheel-rotor"></g>
+                </svg>
+                <div class="jackpot-wheel-result"></div>
+            </div>
+            <div class="casino-jackpot-banner"><strong>0</strong></div>
+        `;
+        window.__jackpotWheel = [
+            { weight: 80, payoutPct: 1 },
+            { weight: 10, payoutPct: 5 },
+            { weight: 5, payoutPct: 10 },
+            { weight: 4, payoutPct: 20 },
+            { weight: 1, payoutPct: 50 },
+        ];
+        // Make TobyJackpot's hold/release visible to the wheel; without
+        // it the wheel's pool-banner coordination wouldn't fire.
+        window.TobyJackpot = jackpot;
+        // Stub requestAnimationFrame to run synchronously so the
+        // rotation-set step in `spinTo` actually fires under jsdom.
+        window.requestAnimationFrame = cb => cb(0);
+    });
+
+    afterEach(() => {
+        delete window.__jackpotWheel;
+        delete window.TobyJackpot;
+        delete window.requestAnimationFrame;
+    });
+
+    test('reveals the overlay and rotates the rotor to the target wedge', () => {
+        const overlay = document.getElementById('jackpot-wheel-overlay');
+        spinTo(4, 500, 50, () => {});
+        expect(overlay.hidden).toBe(false);
+        const rotor = overlay.querySelector('.jackpot-wheel-rotor');
+        // Final angle = 4 full rotations - target midpoint angle.
+        // Tier 4 (the 1-weight 50% segment) midpoint is at ~358.2°.
+        // Rotation should therefore be around 4*360 - 358.2 = 1081.8°.
+        expect(rotor.style.transform).toMatch(/rotate\(108[0-9](\.\d+)?deg\)/);
+    });
+
+    test('paints the tier label on the result element when settled', () => {
+        const overlay = document.getElementById('jackpot-wheel-overlay');
+        const resultEl = overlay.querySelector('.jackpot-wheel-result');
+        const rotor = overlay.querySelector('.jackpot-wheel-rotor');
+        spinTo(0, 12, 1, () => {});
+        // Force the settle path manually — jsdom doesn't dispatch
+        // transitionend on its own.
+        rotor.dispatchEvent(new Event('transitionend'));
+        expect(resultEl.textContent).toContain('Pity prize');
+        expect(resultEl.textContent).toContain('+12 credits');
+    });
+
+    test('invokes onSettle exactly once on transitionend', () => {
+        const overlay = document.getElementById('jackpot-wheel-overlay');
+        const rotor = overlay.querySelector('.jackpot-wheel-rotor');
+        const settled = jest.fn();
+        spinTo(2, 100, 10, settled);
+        rotor.dispatchEvent(new Event('transitionend'));
+        // The internal fallback timeout might also call settle, but the
+        // module's `settled` guard dedupes so onSettle fires once.
+        expect(settled).toHaveBeenCalledTimes(1);
+    });
+
+    test('is a no-op (calls onSettle synchronously) when overlay is missing', () => {
+        document.getElementById('jackpot-wheel-overlay').remove();
+        const settled = jest.fn();
+        spinTo(0, 50, 1, settled);
+        expect(settled).toHaveBeenCalledTimes(1);
+    });
+
+    test('is a no-op when the tier index is out of range', () => {
+        const overlay = document.getElementById('jackpot-wheel-overlay');
+        const settled = jest.fn();
+        spinTo(99, 50, 1, settled);
+        expect(settled).toHaveBeenCalledTimes(1);
+        expect(overlay.hidden).toBe(true);
+    });
+
+    test('holds the pool banner while spinning and releases on settle', () => {
+        const overlay = document.getElementById('jackpot-wheel-overlay');
+        const rotor = overlay.querySelector('.jackpot-wheel-rotor');
+        // Force-release any prior held state.
+        jackpot.releasePoolBanner();
+        spinTo(0, 50, 1, () => {});
+        // Banner is held — an update queues, doesn't paint.
+        jackpot.updatePoolBanner({ jackpotPool: 999 });
+        const strong = document.querySelector('.casino-jackpot-banner strong');
+        expect(strong.textContent).toBe('0');
+        rotor.dispatchEvent(new Event('transitionend'));
+        // After settle the queued value is flushed.
+        expect(strong.textContent).toBe('999');
+    });
+});

--- a/web/src/test/js/casino-jackpot.test.js
+++ b/web/src/test/js/casino-jackpot.test.js
@@ -1,7 +1,9 @@
 const {
     isJackpotHit,
     jackpotPrefixHtml,
+    tierLabel,
     renderWinHtml,
+    spinWheelFor,
     lossTributeSuffix,
     updatePoolBanner,
     holdPoolBanner,
@@ -38,25 +40,92 @@ describe('isJackpotHit', () => {
 // jackpotPrefixHtml
 // ---------------------------------------------------------------------------
 
+describe('tierLabel', () => {
+    test('falls back to a generic JACKPOT label when no pct supplied', () => {
+        expect(tierLabel(undefined)).toBe('🎰 JACKPOT!');
+        expect(tierLabel(0)).toBe('🎰 JACKPOT!');
+    });
+    test('returns the pity label for sub-2% tiers', () => {
+        expect(tierLabel(1)).toContain('Pity prize');
+    });
+    test('returns the nice label for 2-9% tiers', () => {
+        expect(tierLabel(2)).toContain('Nice payout');
+        expect(tierLabel(5)).toContain('Nice payout');
+        expect(tierLabel(9)).toContain('Nice payout');
+    });
+    test('returns the big-win label for 10-29% tiers', () => {
+        expect(tierLabel(10)).toContain('BIG WIN');
+        expect(tierLabel(20)).toContain('BIG WIN');
+    });
+    test('returns the mega label for 30%+ tiers', () => {
+        expect(tierLabel(30)).toContain('MEGA JACKPOT');
+        expect(tierLabel(50)).toContain('MEGA JACKPOT');
+    });
+});
+
 describe('jackpotPrefixHtml', () => {
-    test('renders the JACKPOT banner with payout amount and a trailing <br>', () => {
-        const html = jackpotPrefixHtml(1234);
+    test('renders a tiered JACKPOT banner with the payout amount and trailing <br>', () => {
+        const html = jackpotPrefixHtml(1234, 50);
         expect(html).toContain('🎰');
-        expect(html).toContain('<strong>JACKPOT!</strong>');
+        expect(html).toContain('MEGA JACKPOT');
         expect(html).toContain('+1234 credits');
         expect(html).toContain('<br>');
     });
 
+    test('honours pity vs big tier', () => {
+        expect(jackpotPrefixHtml(50, 1)).toContain('Pity prize');
+        expect(jackpotPrefixHtml(100, 10)).toContain('BIG WIN');
+    });
+
     test('returns empty string when payout is 0', () => {
-        expect(jackpotPrefixHtml(0)).toBe('');
+        expect(jackpotPrefixHtml(0, 50)).toBe('');
     });
 
     test('returns empty string when payout is undefined', () => {
-        expect(jackpotPrefixHtml(undefined)).toBe('');
+        expect(jackpotPrefixHtml(undefined, 50)).toBe('');
     });
 
     test('returns empty string when payout is negative', () => {
-        expect(jackpotPrefixHtml(-50)).toBe('');
+        expect(jackpotPrefixHtml(-50, 50)).toBe('');
+    });
+});
+
+describe('spinWheelFor', () => {
+    let wheelCalls;
+
+    beforeEach(() => {
+        wheelCalls = [];
+        window.TobyJackpotWheel = {
+            spinTo: (idx, amount, pct, cb) => {
+                wheelCalls.push({ idx: idx, amount: amount, pct: pct });
+                if (typeof cb === 'function') cb();
+            },
+        };
+    });
+
+    afterEach(() => { delete window.TobyJackpotWheel; });
+
+    test('delegates to TobyJackpotWheel.spinTo with the picked tier and amount', () => {
+        spinWheelFor({ jackpotPayout: 500, jackpotTierIndex: 2, jackpotTierPayoutPct: 0.10 });
+        expect(wheelCalls.length).toBe(1);
+        expect(wheelCalls[0]).toEqual({ idx: 2, amount: 500, pct: 10 });
+    });
+
+    test('is a no-op when no jackpot was hit', () => {
+        spinWheelFor({ jackpotPayout: 0, jackpotTierIndex: 0, jackpotTierPayoutPct: 0.01 });
+        expect(wheelCalls.length).toBe(0);
+    });
+
+    test('is a no-op when tier index is missing', () => {
+        spinWheelFor({ jackpotPayout: 500 });
+        expect(wheelCalls.length).toBe(0);
+    });
+
+    test('calls onSettle when the wheel module is absent', () => {
+        delete window.TobyJackpotWheel;
+        const settled = jest.fn();
+        spinWheelFor({ jackpotPayout: 500, jackpotTierIndex: 0, jackpotTierPayoutPct: 0.01 }, settled);
+        expect(settled).toHaveBeenCalled();
     });
 });
 
@@ -83,15 +152,27 @@ describe('renderWinHtml', () => {
     test('prepends the jackpot prefix and adds the jackpot class on a hit', () => {
         const html = renderWinHtml(
             resultEl,
-            { jackpotPayout: 500 },
+            { jackpotPayout: 500, jackpotTierPayoutPct: 0.50 },
             'slots-result-jackpot',
             winLine,
         );
 
         expect(html.startsWith('🎰')).toBe(true);
+        expect(html).toContain('MEGA JACKPOT');
         expect(html).toContain('+500 credits');
         expect(html.endsWith(winLine)).toBe(true);
         expect(resultEl.classList.contains('slots-result-jackpot')).toBe(true);
+    });
+
+    test('renders the matching tier label for a low-pct hit', () => {
+        const html = renderWinHtml(
+            resultEl,
+            { jackpotPayout: 12, jackpotTierPayoutPct: 0.01 },
+            'slots-result-jackpot',
+            winLine,
+        );
+        expect(html).toContain('Pity prize');
+        expect(html).toContain('+12 credits');
     });
 
     test('honours per-game class names', () => {

--- a/web/src/test/kotlin/web/service/ModerationWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/ModerationWebServiceTest.kt
@@ -1202,7 +1202,7 @@ class ModerationWebServiceTest {
             guildId = guildId,
             rawName = "x",
             // Real enum entry but NOT in CHANNEL_CONFIG_ALLOWLIST.
-            targetConfigName = "JACKPOT_PAYOUT_PCT",
+            targetConfigName = "JACKPOT_WHEEL_SEGMENTS",
         )
         assertTrue(r is ModerationWebService.CreateChannelOutcome.Error)
         r as ModerationWebService.CreateChannelOutcome.Error

--- a/web/src/test/kotlin/web/template/ModerationTemplateRowsTest.kt
+++ b/web/src/test/kotlin/web/template/ModerationTemplateRowsTest.kt
@@ -184,7 +184,6 @@ class ModerationTemplateRowsTest {
         val percentKeys = listOf(
             ConfigDto.Configurations.JACKPOT_LOSS_TRIBUTE_PCT,
             ConfigDto.Configurations.JACKPOT_WIN_PCT,
-            ConfigDto.Configurations.JACKPOT_PAYOUT_PCT,
             ConfigDto.Configurations.JACKPOT_RTP_MAX_PCT,
             ConfigDto.Configurations.TRADE_BUY_FEE_PCT,
             ConfigDto.Configurations.TRADE_SELL_FEE_PCT,
@@ -221,7 +220,7 @@ class ModerationTemplateRowsTest {
         val jackpotKeys = listOf(
             ConfigDto.Configurations.JACKPOT_LOSS_TRIBUTE_PCT,
             ConfigDto.Configurations.JACKPOT_WIN_PCT,
-            ConfigDto.Configurations.JACKPOT_PAYOUT_PCT,
+            ConfigDto.Configurations.JACKPOT_WHEEL_SEGMENTS,
             ConfigDto.Configurations.JACKPOT_RTP_MAX_PCT,
             ConfigDto.Configurations.JACKPOT_WINNER_COOLDOWN_DAYS,
             ConfigDto.Configurations.JACKPOT_ACTIVITY_WINDOW_DAYS,


### PR DESCRIPTION
## Summary

A "compromise" jackpot mechanic — high win chance but small slices most of the time, rare jackpots for the big hit.

- **Backend**: `JackpotHelper.rollOnWin` returns a `JackpotRoll(amount, tierIndex, tierPayoutPct)`. On a successful trigger it spins the per-guild `JackpotWheel` for a tier and credits that fraction of the pool.
- **Default wheel** `80:1, 10:5, 5:10, 4:20, 1:50` — 80% of jackpot wins pay 1% of the pool (pity), 1% pay 50% (mega). EV per win ≈ 3.1% — well below the historic 100%, so the pool grows under typical traffic.
- **Trigger probability** stays driven entirely by `JACKPOT_WIN_PCT` (existing config, default 1%). No defaults changed — admins dial up the win chance per-guild.
- **`JACKPOT_PAYOUT_PCT` removed.** Guilds that want the old "flat fixed payout" expressed it as a single-segment wheel, e.g. `JACKPOT_WHEEL_SEGMENTS=1:30`.
- **Visual wheel**: every casino page now renders a hidden SVG wheel overlay that animates to the server-picked tier on a jackpot hit, holds the pool banner during the spin, and auto-dismisses with the tier label.
- **Moderation UI**: paired-input editor for `JACKPOT_WHEEL_SEGMENTS` in `/moderation/{guild}/settings` with live EV preview, server + client validation, and an explainer.
- **Tests**: new `JackpotWheelTest`, `casino-jackpot-wheel.test.js`; updated `JackpotHelperTest`, `JackpotServiceTest`, `casino-jackpot.test.js`, moderation template/service tests.

## Test plan

- [x] `:database:test` passes (`JackpotWheelTest`, updated `JackpotHelperTest` / `JackpotServiceTest`, `HighlowServiceTest`)
- [x] `:web:test` passes (`ModerationWebServiceTest`, `ModerationTemplateRowsTest`, `CasinoJackpotBannerFragmentTest`)
- [x] `npx jest` passes — 377/377 including new `casino-jackpot-wheel.test.js` (16 cases) and rewritten `casino-jackpot.test.js`
- [x] `npx stylelint base.css moderation.css` clean
- [ ] Manual smoke: open `/casino/{guild}/slots`, force a jackpot (raise `JACKPOT_WIN_PCT` to 50 in dev config), verify wheel reveals, animates, lands on the right wedge, banner pool ticks down by the awarded fraction
- [ ] Manual smoke: set `JACKPOT_WHEEL_SEGMENTS=1:30` via the moderation UI; wheel renders one wedge, always pays 30%
- [ ] Manual smoke: set `JACKPOT_WHEEL_SEGMENTS` to garbage in the editor — server-side validator rejects with a readable message

Note: the `:discord-bot` module couldn't be compiled in this environment (Lavalink/jitpack repos returning 403 on outbound network). Changes there are confined to a single `SetConfigCommand` branch swap (`JACKPOT_PAYOUT_PCT` → `JACKPOT_WHEEL_SEGMENTS`) and should be sanity-checked locally.

https://claude.ai/code/session_01FF6BnAEYQ76ziW7wSaW9UH

---
_Generated by [Claude Code](https://claude.ai/code/session_01FF6BnAEYQ76ziW7wSaW9UH)_