### PR TITLE
feat(excuse): subcommand rewrite + per-guild web UI

### DIFF
--- a/application/src/test/kotlin/integration/bot/ButtonManagerTest.kt
+++ b/application/src/test/kotlin/integration/bot/ButtonManagerTest.kt
@@ -74,6 +74,7 @@ class ButtonManagerTest {
             BlackjackButton::class.java,
             CasinoHoldemButton::class.java,
             DuelButton::class.java,
+            ExcuseListPageButton::class.java,
             HighlowButton::class.java,
             LotteryBuyButton::class.java,
             PausePlayButton::class.java,
@@ -84,7 +85,7 @@ class ButtonManagerTest {
         )
 
         assertTrue(availableButtons.containsAll(buttonManager.buttons.map { it.javaClass }.toList()))
-        assertEquals(11, buttonManager.buttons.size)
+        assertEquals(12, buttonManager.buttons.size)
     }
 
     @Test

--- a/application/src/test/kotlin/web/controller/ExcuseWebControllerTest.kt
+++ b/application/src/test/kotlin/web/controller/ExcuseWebControllerTest.kt
@@ -1,0 +1,232 @@
+package web.controller
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.unmockkAll
+import io.mockk.verify
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient
+import org.springframework.security.oauth2.core.OAuth2AccessToken
+import org.springframework.security.oauth2.core.user.OAuth2User
+import org.springframework.ui.Model
+import org.springframework.web.servlet.mvc.support.RedirectAttributes
+import web.service.ExcusePageViewModel
+import web.service.ExcuseWebService
+import web.service.GuildInfo
+import web.service.MemberInfo
+import web.service.RandomExcuseViewModel
+import web.service.SubmitResult
+
+class ExcuseWebControllerTest {
+
+    private lateinit var excuseWebService: ExcuseWebService
+    private lateinit var controller: ExcuseWebController
+
+    private val mockUser = mockk<OAuth2User>(relaxed = true)
+    private val mockClient = mockk<OAuth2AuthorizedClient>(relaxed = true)
+    private val mockModel = mockk<Model>(relaxed = true)
+    private val mockRa = mockk<RedirectAttributes>(relaxed = true)
+
+    private val discordId = "111"
+    private val guildId = 222L
+
+    @BeforeEach
+    fun setup() {
+        excuseWebService = mockk(relaxed = true)
+        controller = ExcuseWebController(excuseWebService, "test-client-id")
+
+        every { mockUser.getAttribute<String>("id") } returns discordId
+        every { mockUser.getAttribute<String>("username") } returns "TestUser"
+        every { mockClient.accessToken } returns mockk<OAuth2AccessToken> {
+            every { tokenValue } returns "mock-token"
+        }
+    }
+
+    @AfterEach
+    fun tearDown() = unmockkAll()
+
+    // guildList
+
+    @Test
+    fun `guildList renders the excuse-guilds template with counts`() {
+        val guilds = listOf(GuildInfo("1", "Guild One", null))
+        every { excuseWebService.getMutualGuilds("mock-token") } returns guilds
+        every { excuseWebService.getApprovedCountsForGuilds(listOf(1L)) } returns mapOf(1L to 5)
+
+        val view = controller.guildList(mockClient, mockUser, mockModel)
+
+        assertEquals("excuse-guilds", view)
+        verify { mockModel.addAttribute("guilds", guilds) }
+        verify { mockModel.addAttribute("approvedCounts", mapOf("1" to 5)) }
+        verify { mockModel.addAttribute("username", "TestUser") }
+    }
+
+    // page
+
+    @Test
+    fun `page redirects to picker when discordId is null`() {
+        every { mockUser.getAttribute<String>("id") } returns null
+
+        val view = controller.page(guildId, "approved", null, 1, mockUser, mockModel, mockRa)
+
+        assertEquals("redirect:/excuses/guilds", view)
+    }
+
+    @Test
+    fun `page redirects when guild not found`() {
+        every { excuseWebService.getGuildName(guildId) } returns null
+
+        val view = controller.page(guildId, "approved", null, 1, mockUser, mockModel, mockRa)
+
+        assertEquals("redirect:/excuses/guilds", view)
+        verify { mockRa.addFlashAttribute("error", "Bot is not in that server.") }
+    }
+
+    @Test
+    fun `page returns excuses view and populates model`() {
+        val pageVm = ExcusePageViewModel(
+            rows = emptyList(),
+            page = 1,
+            totalPages = 1,
+            totalCount = 0L,
+            isSuperUser = true,
+            requestedTab = "approved",
+            query = null,
+        )
+        every { excuseWebService.getGuildName(guildId) } returns "Test Guild"
+        every { excuseWebService.getPage(guildId, "approved", null, 1, 111L) } returns pageVm
+        every { excuseWebService.getGuildMembers(guildId) } returns listOf(MemberInfo("1", "Alice", null))
+
+        val view = controller.page(guildId, "approved", null, 1, mockUser, mockModel, mockRa)
+
+        assertEquals("excuses", view)
+        verify { mockModel.addAttribute("guildName", "Test Guild") }
+        verify { mockModel.addAttribute("isSuperUser", true) }
+        verify { mockModel.addAttribute("members", listOf(MemberInfo("1", "Alice", null))) }
+        verify { mockModel.addAttribute("totalPages", 1) }
+    }
+
+    @Test
+    fun `page skips member lookup when not superuser`() {
+        val pageVm = ExcusePageViewModel(
+            rows = emptyList(),
+            page = 1,
+            totalPages = 1,
+            totalCount = 0L,
+            isSuperUser = false,
+            requestedTab = "approved",
+            query = null,
+        )
+        every { excuseWebService.getGuildName(guildId) } returns "Test Guild"
+        every { excuseWebService.getPage(guildId, "approved", null, 1, 111L) } returns pageVm
+
+        controller.page(guildId, "approved", null, 1, mockUser, mockModel, mockRa)
+
+        verify { mockModel.addAttribute("members", emptyList<MemberInfo>()) }
+    }
+
+    // submit
+
+    @Test
+    fun `submit adds success flash on success and preserves tab+query`() {
+        every { excuseWebService.submit(guildId, "an excuse", null, 111L) } returns SubmitResult(id = 7L)
+
+        val view = controller.submit(guildId, "an excuse", null, "approved", "rain", mockUser, mockRa)
+
+        assertEquals("redirect:/excuses/$guildId?tab=approved&q=rain", view)
+        verify { mockRa.addFlashAttribute("success", "Submitted for approval (id #7).") }
+    }
+
+    @Test
+    fun `submit adds error flash on failure`() {
+        every { excuseWebService.submit(any(), any(), any(), any()) } returns SubmitResult(error = "nope")
+
+        val view = controller.submit(guildId, "x", null, null, null, mockUser, mockRa)
+
+        assertEquals("redirect:/excuses/$guildId", view)
+        verify { mockRa.addFlashAttribute("error", "nope") }
+    }
+
+    // approve
+
+    @Test
+    fun `approve returns ok on success`() {
+        every { excuseWebService.approve(5L, 111L, guildId) } returns null
+
+        val response = controller.approve(guildId, 5L, mockUser)
+
+        assertEquals(200, response.statusCode.value())
+        assertTrue(response.body?.ok == true)
+    }
+
+    @Test
+    fun `approve returns 400 with error message on failure`() {
+        every { excuseWebService.approve(5L, 111L, guildId) } returns "boom"
+
+        val response = controller.approve(guildId, 5L, mockUser)
+
+        assertEquals(400, response.statusCode.value())
+        assertEquals("boom", response.body?.error)
+    }
+
+    @Test
+    fun `approve returns 401 when not signed in`() {
+        every { mockUser.getAttribute<String>("id") } returns null
+
+        val response = controller.approve(guildId, 5L, mockUser)
+
+        assertEquals(401, response.statusCode.value())
+    }
+
+    // delete
+
+    @Test
+    fun `delete returns ok on success`() {
+        every { excuseWebService.delete(5L, 111L, guildId) } returns null
+
+        val response = controller.delete(guildId, 5L, mockUser)
+
+        assertEquals(200, response.statusCode.value())
+        assertTrue(response.body?.ok == true)
+    }
+
+    @Test
+    fun `delete returns 400 on permission failure`() {
+        every { excuseWebService.delete(5L, 111L, guildId) } returns "denied"
+
+        val response = controller.delete(guildId, 5L, mockUser)
+
+        assertEquals(400, response.statusCode.value())
+        assertEquals("denied", response.body?.error)
+    }
+
+    // random
+
+    @Test
+    fun `random returns the pick`() {
+        every { excuseWebService.getRandomApproved(guildId) } returns
+            RandomExcuseViewModel(id = 9L, text = "ate it", author = "dog")
+
+        val response = controller.random(guildId, mockUser)
+
+        assertEquals(200, response.statusCode.value())
+        assertEquals(true, response.body?.ok)
+        assertEquals(9L, response.body?.id)
+        assertEquals("ate it", response.body?.text)
+    }
+
+    @Test
+    fun `random returns ok=false with message when nothing approved yet`() {
+        every { excuseWebService.getRandomApproved(guildId) } returns null
+
+        val response = controller.random(guildId, mockUser)
+
+        assertEquals(200, response.statusCode.value())
+        assertEquals(false, response.body?.ok)
+        assertEquals("There are no approved excuses yet.", response.body?.error)
+    }
+}

--- a/application/src/test/kotlin/web/service/ExcuseWebServiceTest.kt
+++ b/application/src/test/kotlin/web/service/ExcuseWebServiceTest.kt
@@ -1,0 +1,354 @@
+package web.service
+
+import database.dto.ExcuseDto
+import database.dto.UserDto
+import database.service.ExcuseService
+import database.service.PagedExcuses
+import database.service.UserService
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.unmockkAll
+import io.mockk.verify
+import net.dv8tion.jda.api.JDA
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class ExcuseWebServiceTest {
+
+    private lateinit var excuseService: ExcuseService
+    private lateinit var userService: UserService
+    private lateinit var jda: JDA
+    private lateinit var introWebService: IntroWebService
+    private lateinit var service: ExcuseWebService
+
+    private val guildId = 999L
+    private val authorDiscordId = 111L
+    private val otherDiscordId = 222L
+
+    @BeforeEach
+    fun setup() {
+        excuseService = mockk(relaxed = true)
+        userService = mockk(relaxed = true)
+        jda = mockk(relaxed = true)
+        introWebService = mockk(relaxed = true)
+        service = ExcuseWebService(excuseService, userService, jda, introWebService)
+    }
+
+    @AfterEach
+    fun tearDown() = unmockkAll()
+
+    // getPage — tab gating
+
+    @Test
+    fun `getPage downgrades pending tab to approved for non-superusers`() {
+        every { userService.getUserById(otherDiscordId, guildId) } returns mockk<UserDto> {
+            every { superUser } returns false
+        }
+        every { excuseService.listApprovedPaged(guildId, 1, ExcuseWebService.PAGE_SIZE) } returns
+            PagedExcuses(emptyList(), 1, ExcuseWebService.PAGE_SIZE, 0L)
+
+        val result = service.getPage(guildId, "pending", null, 1, otherDiscordId)
+
+        assertEquals("approved", result.requestedTab)
+        assertFalse(result.isSuperUser)
+        verify(exactly = 0) { excuseService.listPendingPaged(any(), any(), any()) }
+        verify { excuseService.listApprovedPaged(guildId, 1, ExcuseWebService.PAGE_SIZE) }
+    }
+
+    @Test
+    fun `getPage routes pending tab to listPendingPaged when superuser`() {
+        every { userService.getUserById(authorDiscordId, guildId) } returns mockk<UserDto> {
+            every { superUser } returns true
+        }
+        every { excuseService.listPendingPaged(guildId, 1, ExcuseWebService.PAGE_SIZE) } returns
+            PagedExcuses(emptyList(), 1, ExcuseWebService.PAGE_SIZE, 0L)
+
+        val result = service.getPage(guildId, "pending", null, 1, authorDiscordId)
+
+        assertEquals("pending", result.requestedTab)
+        assertTrue(result.isSuperUser)
+        verify { excuseService.listPendingPaged(guildId, 1, ExcuseWebService.PAGE_SIZE) }
+    }
+
+    @Test
+    fun `getPage with non-blank query routes to searchApproved on approved tab`() {
+        every { userService.getUserById(authorDiscordId, guildId) } returns mockk<UserDto> {
+            every { superUser } returns false
+        }
+        every {
+            excuseService.searchApproved(guildId, "rain", 1, ExcuseWebService.PAGE_SIZE)
+        } returns PagedExcuses(emptyList(), 1, ExcuseWebService.PAGE_SIZE, 0L)
+
+        service.getPage(guildId, "approved", "rain", 1, authorDiscordId)
+
+        verify { excuseService.searchApproved(guildId, "rain", 1, ExcuseWebService.PAGE_SIZE) }
+    }
+
+    @Test
+    fun `getPage maps row view models with canDelete for own pending`() {
+        val dto = ExcuseDto(
+            id = 7L,
+            guildId = guildId,
+            author = "Author",
+            excuse = "I forgot",
+            approved = false,
+            authorDiscordId = authorDiscordId,
+        )
+        every { userService.getUserById(authorDiscordId, guildId) } returns mockk<UserDto> {
+            every { superUser } returns true
+        }
+        every {
+            excuseService.listPendingPaged(guildId, 1, ExcuseWebService.PAGE_SIZE)
+        } returns PagedExcuses(listOf(dto), 1, ExcuseWebService.PAGE_SIZE, 1L)
+
+        val result = service.getPage(guildId, "pending", null, 1, authorDiscordId)
+
+        assertEquals(1, result.rows.size)
+        val row = result.rows.first()
+        assertTrue(row.isAuthor)
+        assertTrue(row.canDelete) // superuser
+        assertTrue(row.canApprove)
+    }
+
+    @Test
+    fun `getPage marks canDelete=true for own pending even when not superuser`() {
+        val dto = ExcuseDto(
+            id = 7L,
+            guildId = guildId,
+            author = "Author",
+            excuse = "I forgot",
+            approved = false,
+            authorDiscordId = authorDiscordId,
+        )
+        every { userService.getUserById(authorDiscordId, guildId) } returns mockk<UserDto> {
+            every { superUser } returns false
+        }
+        // Non-superuser viewing pending downgrades to approved tab; reset with approved
+        // search since that is what gets called instead. Use approved tab + no query.
+        every {
+            excuseService.listApprovedPaged(guildId, 1, ExcuseWebService.PAGE_SIZE)
+        } returns PagedExcuses(listOf(dto), 1, ExcuseWebService.PAGE_SIZE, 1L)
+
+        val result = service.getPage(guildId, "approved", null, 1, authorDiscordId)
+
+        val row = result.rows.first()
+        assertTrue(row.isAuthor)
+        // Pending row owned by us is deletable
+        assertTrue(row.canDelete)
+        assertFalse(row.canApprove) // only superusers can approve
+    }
+
+    // submit
+
+    @Test
+    fun `submit rejects blank text`() {
+        val result = service.submit(guildId, "   ", null, authorDiscordId)
+        assertFalse(result.ok)
+        assertEquals("Provide some excuse text.", result.error)
+        verify(exactly = 0) { excuseService.createNewExcuse(any()) }
+    }
+
+    @Test
+    fun `submit rejects duplicates case-insensitively`() {
+        every { userService.getUserById(authorDiscordId, guildId) } returns null
+        every { excuseService.listAllGuildExcuses(guildId) } returns listOf(
+            ExcuseDto(id = 1L, guildId = guildId, author = "X", excuse = "RAIN DELAY", approved = true)
+        )
+
+        val result = service.submit(guildId, "rain delay", null, authorDiscordId)
+
+        assertFalse(result.ok)
+        assertEquals("That excuse already exists for this server.", result.error)
+        verify(exactly = 0) { excuseService.createNewExcuse(any()) }
+    }
+
+    @Test
+    fun `submit ignores author override from non-superusers`() {
+        every { userService.getUserById(authorDiscordId, guildId) } returns mockk<UserDto> {
+            every { superUser } returns false
+        }
+        every { excuseService.listAllGuildExcuses(guildId) } returns emptyList()
+        every { jda.getGuildById(guildId) } returns mockk(relaxed = true)
+        every { excuseService.createNewExcuse(any()) } returns
+            ExcuseDto(id = 1L, guildId = guildId, excuse = "rain", authorDiscordId = authorDiscordId)
+
+        val result = service.submit(guildId, "rain", otherDiscordId, authorDiscordId)
+
+        assertTrue(result.ok)
+        verify {
+            excuseService.createNewExcuse(withArg<ExcuseDto> {
+                assertEquals(authorDiscordId, it.authorDiscordId)
+            })
+        }
+    }
+
+    @Test
+    fun `submit honours author override from superusers`() {
+        every { userService.getUserById(authorDiscordId, guildId) } returns mockk<UserDto> {
+            every { superUser } returns true
+        }
+        every { excuseService.listAllGuildExcuses(guildId) } returns emptyList()
+        every { jda.getGuildById(guildId) } returns mockk(relaxed = true)
+        every { excuseService.createNewExcuse(any()) } returns
+            ExcuseDto(id = 1L, guildId = guildId, excuse = "rain", authorDiscordId = otherDiscordId)
+
+        val result = service.submit(guildId, "rain", otherDiscordId, authorDiscordId)
+
+        assertTrue(result.ok)
+        verify {
+            excuseService.createNewExcuse(withArg<ExcuseDto> {
+                assertEquals(otherDiscordId, it.authorDiscordId)
+            })
+        }
+    }
+
+    // approve
+
+    @Test
+    fun `approve fails for non-superusers`() {
+        every { userService.getUserById(authorDiscordId, guildId) } returns mockk<UserDto> {
+            every { superUser } returns false
+        }
+
+        val error = service.approve(1L, authorDiscordId, guildId)
+
+        assertEquals("You don't have permission to approve excuses.", error)
+        verify(exactly = 0) { excuseService.approveExcuse(any()) }
+    }
+
+    @Test
+    fun `approve refuses to cross guild boundaries`() {
+        every { userService.getUserById(authorDiscordId, guildId) } returns mockk<UserDto> {
+            every { superUser } returns true
+        }
+        every { excuseService.getExcuseById(1L) } returns
+            ExcuseDto(id = 1L, guildId = 555L, approved = false)
+
+        val error = service.approve(1L, authorDiscordId, guildId)
+
+        assertEquals("Excuse not found.", error)
+        verify(exactly = 0) { excuseService.approveExcuse(any()) }
+    }
+
+    @Test
+    fun `approve succeeds for superuser on matching guild`() {
+        every { userService.getUserById(authorDiscordId, guildId) } returns mockk<UserDto> {
+            every { superUser } returns true
+        }
+        every { excuseService.getExcuseById(1L) } returns
+            ExcuseDto(id = 1L, guildId = guildId, approved = false)
+        every { excuseService.approveExcuse(1L) } returns
+            ExcuseDto(id = 1L, guildId = guildId, approved = true)
+
+        val error = service.approve(1L, authorDiscordId, guildId)
+
+        assertNull(error)
+        verify { excuseService.approveExcuse(1L) }
+    }
+
+    // delete
+
+    @Test
+    fun `delete allows author of own pending excuse`() {
+        every { userService.getUserById(authorDiscordId, guildId) } returns mockk<UserDto> {
+            every { superUser } returns false
+        }
+        every { excuseService.getExcuseById(1L) } returns ExcuseDto(
+            id = 1L,
+            guildId = guildId,
+            approved = false,
+            authorDiscordId = authorDiscordId,
+        )
+        every { excuseService.deleteExcuseById(1L) } just Runs
+
+        val error = service.delete(1L, authorDiscordId, guildId)
+
+        assertNull(error)
+        verify { excuseService.deleteExcuseById(1L) }
+    }
+
+    @Test
+    fun `delete denies non-author of someone elses pending excuse`() {
+        every { userService.getUserById(otherDiscordId, guildId) } returns mockk<UserDto> {
+            every { superUser } returns false
+        }
+        every { excuseService.getExcuseById(1L) } returns ExcuseDto(
+            id = 1L,
+            guildId = guildId,
+            approved = false,
+            authorDiscordId = authorDiscordId,
+        )
+
+        val error = service.delete(1L, otherDiscordId, guildId)
+
+        assertEquals("You don't have permission to delete that excuse.", error)
+        verify(exactly = 0) { excuseService.deleteExcuseById(any()) }
+    }
+
+    @Test
+    fun `delete denies author of approved excuse unless superuser`() {
+        every { userService.getUserById(authorDiscordId, guildId) } returns mockk<UserDto> {
+            every { superUser } returns false
+        }
+        every { excuseService.getExcuseById(1L) } returns ExcuseDto(
+            id = 1L,
+            guildId = guildId,
+            approved = true,
+            authorDiscordId = authorDiscordId,
+        )
+
+        val error = service.delete(1L, authorDiscordId, guildId)
+
+        assertEquals("You don't have permission to delete that excuse.", error)
+    }
+
+    @Test
+    fun `delete allows superuser regardless of authorship`() {
+        every { userService.getUserById(otherDiscordId, guildId) } returns mockk<UserDto> {
+            every { superUser } returns true
+        }
+        every { excuseService.getExcuseById(1L) } returns ExcuseDto(
+            id = 1L,
+            guildId = guildId,
+            approved = true,
+            authorDiscordId = authorDiscordId,
+        )
+        every { excuseService.deleteExcuseById(1L) } just Runs
+
+        val error = service.delete(1L, otherDiscordId, guildId)
+
+        assertNull(error)
+        verify { excuseService.deleteExcuseById(1L) }
+    }
+
+    // random
+
+    @Test
+    fun `getRandomApproved returns a row from approved list`() {
+        val rows = listOf(
+            ExcuseDto(id = 7L, guildId = guildId, author = "A", excuse = "x", approved = true)
+        )
+        every { excuseService.listApprovedGuildExcuses(guildId) } returns rows
+
+        val pick = service.getRandomApproved(guildId)
+
+        assertNotNull(pick)
+        assertEquals(7L, pick!!.id)
+        assertEquals("x", pick.text)
+    }
+
+    @Test
+    fun `getRandomApproved returns null when nothing is approved`() {
+        every { excuseService.listApprovedGuildExcuses(guildId) } returns emptyList()
+
+        assertNull(service.getRandomApproved(guildId))
+    }
+}

--- a/database/src/main/kotlin/database/dto/ExcuseDto.kt
+++ b/database/src/main/kotlin/database/dto/ExcuseDto.kt
@@ -3,11 +3,33 @@ package database.dto
 import jakarta.persistence.*
 import org.springframework.transaction.annotation.Transactional
 import java.io.Serializable
+import java.time.Instant
 
 @NamedQueries(
-    NamedQuery(name = "ExcuseDto.getAll", query = "select e from ExcuseDto e WHERE e.guildId = :guildId"),
-    NamedQuery(name = "ExcuseDto.getApproved", query = "select e from ExcuseDto e WHERE e.guildId = :guildId AND e.approved = true"),
-    NamedQuery(name = "ExcuseDto.getPending", query = "select e from ExcuseDto e WHERE e.guildId = :guildId AND e.approved = false"),
+    NamedQuery(
+        name = "ExcuseDto.getAll",
+        query = "select e from ExcuseDto e WHERE e.guildId = :guildId ORDER BY e.createdAt DESC"
+    ),
+    NamedQuery(
+        name = "ExcuseDto.getApproved",
+        query = "select e from ExcuseDto e WHERE e.guildId = :guildId AND e.approved = true ORDER BY e.createdAt DESC"
+    ),
+    NamedQuery(
+        name = "ExcuseDto.getPending",
+        query = "select e from ExcuseDto e WHERE e.guildId = :guildId AND e.approved = false ORDER BY e.createdAt DESC"
+    ),
+    NamedQuery(
+        name = "ExcuseDto.searchApproved",
+        query = "select e from ExcuseDto e WHERE e.guildId = :guildId AND e.approved = true AND LOWER(e.excuse) LIKE LOWER(CONCAT('%', :q, '%')) ORDER BY e.createdAt DESC"
+    ),
+    NamedQuery(
+        name = "ExcuseDto.countApproved",
+        query = "select count(e) from ExcuseDto e WHERE e.guildId = :guildId AND e.approved = true"
+    ),
+    NamedQuery(
+        name = "ExcuseDto.countPending",
+        query = "select count(e) from ExcuseDto e WHERE e.guildId = :guildId AND e.approved = false"
+    ),
     NamedQuery(name = "ExcuseDto.getById", query = "select e from ExcuseDto e WHERE e.id = :id"),
     NamedQuery(name = "ExcuseDto.deleteById", query = "delete from ExcuseDto e WHERE e.id = :id"),
     NamedQuery(name = "ExcuseDto.deleteAllByGuildId", query = "delete from ExcuseDto e WHERE e.guildId = :guildId")
@@ -31,5 +53,20 @@ class ExcuseDto(
     var excuse: String? = null,
 
     @Column(name = "approved")
-    var approved: Boolean = false
-) : Serializable
+    var approved: Boolean = false,
+
+    @Column(name = "created_at")
+    var createdAt: Instant? = null,
+
+    @Column(name = "approved_at")
+    var approvedAt: Instant? = null,
+
+    @Column(name = "author_discord_id")
+    var authorDiscordId: Long? = null
+) : Serializable {
+
+    @PrePersist
+    fun onCreate() {
+        if (createdAt == null) createdAt = Instant.now()
+    }
+}

--- a/database/src/main/kotlin/database/persistence/ExcusePersistence.kt
+++ b/database/src/main/kotlin/database/persistence/ExcusePersistence.kt
@@ -6,8 +6,17 @@ interface ExcusePersistence {
     fun listAllGuildExcuses(guildId: Long?): List<ExcuseDto?>
     fun listApprovedGuildExcuses(guildId: Long?): List<ExcuseDto?>
     fun listPendingGuildExcuses(guildId: Long?): List<ExcuseDto?>
+
+    fun listApprovedPaged(guildId: Long?, offset: Int, limit: Int): List<ExcuseDto>
+    fun listPendingPaged(guildId: Long?, offset: Int, limit: Int): List<ExcuseDto>
+    fun searchApproved(guildId: Long?, query: String, offset: Int, limit: Int): List<ExcuseDto>
+
+    fun countApproved(guildId: Long?): Long
+    fun countPending(guildId: Long?): Long
+    fun countSearchApproved(guildId: Long?, query: String): Long
+
     fun createNewExcuse(excuseDto: ExcuseDto?): ExcuseDto?
-    fun getExcuseById(id: Long?): ExcuseDto
+    fun getExcuseById(id: Long?): ExcuseDto?
     fun updateExcuse(excuseDto: ExcuseDto): ExcuseDto
     fun deleteAllExcusesForGuild(guildId: Long?)
     fun deleteExcuseById(id: Long?)

--- a/database/src/main/kotlin/database/persistence/impl/DefaultExcusePersistence.kt
+++ b/database/src/main/kotlin/database/persistence/impl/DefaultExcusePersistence.kt
@@ -58,13 +58,13 @@ class DefaultExcusePersistence internal constructor() : database.persistence.Exc
     }
 
     override fun countApproved(guildId: Long?): Long {
-        val q = entityManager.createNamedQuery("ExcuseDto.countApproved", java.lang.Long::class.java)
+        val q = entityManager.createNamedQuery("ExcuseDto.countApproved", Long::class.javaObjectType)
         q.setParameter("guildId", guildId)
         return q.singleResult.toLong()
     }
 
     override fun countPending(guildId: Long?): Long {
-        val q = entityManager.createNamedQuery("ExcuseDto.countPending", java.lang.Long::class.java)
+        val q = entityManager.createNamedQuery("ExcuseDto.countPending", Long::class.javaObjectType)
         q.setParameter("guildId", guildId)
         return q.singleResult.toLong()
     }
@@ -76,7 +76,7 @@ class DefaultExcusePersistence internal constructor() : database.persistence.Exc
         val q = entityManager.createQuery(
             "select count(e) from ExcuseDto e where e.guildId = :guildId and e.approved = true " +
                 "and lower(e.excuse) like lower(concat('%', :q, '%'))",
-            java.lang.Long::class.java
+            Long::class.javaObjectType
         )
         q.setParameter("guildId", guildId)
         q.setParameter("q", query)

--- a/database/src/main/kotlin/database/persistence/impl/DefaultExcusePersistence.kt
+++ b/database/src/main/kotlin/database/persistence/impl/DefaultExcusePersistence.kt
@@ -102,6 +102,16 @@ class DefaultExcusePersistence internal constructor() : database.persistence.Exc
     override fun updateExcuse(excuseDto: ExcuseDto): ExcuseDto {
         val dbExcuse = getExcuseById(excuseDto.id)
 
+        // Hibernate merge copies every field from the detached entity, including
+        // nulls — so a caller that builds a fresh ExcuseDto with only the
+        // editable fields populated would nullify created_at and trip the
+        // NOT NULL constraint. Preserve the immutable audit fields from the
+        // loaded row when the caller hasn't supplied them.
+        if (dbExcuse != null) {
+            if (excuseDto.createdAt == null) excuseDto.createdAt = dbExcuse.createdAt
+            if (excuseDto.authorDiscordId == null) excuseDto.authorDiscordId = dbExcuse.authorDiscordId
+        }
+
         if (excuseDto != dbExcuse) {
             entityManager.merge(excuseDto)
             entityManager.flush()

--- a/database/src/main/kotlin/database/persistence/impl/DefaultExcusePersistence.kt
+++ b/database/src/main/kotlin/database/persistence/impl/DefaultExcusePersistence.kt
@@ -2,6 +2,7 @@ package database.persistence.impl
 
 import database.dto.ExcuseDto
 import jakarta.persistence.EntityManager
+import jakarta.persistence.NoResultException
 import jakarta.persistence.PersistenceContext
 import jakarta.persistence.TypedQuery
 import org.springframework.stereotype.Repository
@@ -12,7 +13,6 @@ import org.springframework.transaction.annotation.Transactional
 class DefaultExcusePersistence internal constructor() : database.persistence.ExcusePersistence {
     @PersistenceContext
     private lateinit var entityManager: EntityManager
-
 
     override fun listAllGuildExcuses(guildId: Long?): List<ExcuseDto?> {
         val q: TypedQuery<ExcuseDto> = entityManager.createNamedQuery("ExcuseDto.getAll", ExcuseDto::class.java)
@@ -32,16 +32,71 @@ class DefaultExcusePersistence internal constructor() : database.persistence.Exc
         return q.resultList
     }
 
+    override fun listApprovedPaged(guildId: Long?, offset: Int, limit: Int): List<ExcuseDto> {
+        val q: TypedQuery<ExcuseDto> = entityManager.createNamedQuery("ExcuseDto.getApproved", ExcuseDto::class.java)
+        q.setParameter("guildId", guildId)
+        q.firstResult = offset.coerceAtLeast(0)
+        q.maxResults = limit.coerceAtLeast(1)
+        return q.resultList
+    }
+
+    override fun listPendingPaged(guildId: Long?, offset: Int, limit: Int): List<ExcuseDto> {
+        val q: TypedQuery<ExcuseDto> = entityManager.createNamedQuery("ExcuseDto.getPending", ExcuseDto::class.java)
+        q.setParameter("guildId", guildId)
+        q.firstResult = offset.coerceAtLeast(0)
+        q.maxResults = limit.coerceAtLeast(1)
+        return q.resultList
+    }
+
+    override fun searchApproved(guildId: Long?, query: String, offset: Int, limit: Int): List<ExcuseDto> {
+        val q: TypedQuery<ExcuseDto> = entityManager.createNamedQuery("ExcuseDto.searchApproved", ExcuseDto::class.java)
+        q.setParameter("guildId", guildId)
+        q.setParameter("q", query)
+        q.firstResult = offset.coerceAtLeast(0)
+        q.maxResults = limit.coerceAtLeast(1)
+        return q.resultList
+    }
+
+    override fun countApproved(guildId: Long?): Long {
+        val q = entityManager.createNamedQuery("ExcuseDto.countApproved", java.lang.Long::class.java)
+        q.setParameter("guildId", guildId)
+        return q.singleResult.toLong()
+    }
+
+    override fun countPending(guildId: Long?): Long {
+        val q = entityManager.createNamedQuery("ExcuseDto.countPending", java.lang.Long::class.java)
+        q.setParameter("guildId", guildId)
+        return q.singleResult.toLong()
+    }
+
+    override fun countSearchApproved(guildId: Long?, query: String): Long {
+        // No dedicated countQuery — for an in-memory page we'd usually run a parallel
+        // COUNT, but the search result set is bounded by guild and approval already.
+        // List the matching ids without fetching the full rows and count those.
+        val q = entityManager.createQuery(
+            "select count(e) from ExcuseDto e where e.guildId = :guildId and e.approved = true " +
+                "and lower(e.excuse) like lower(concat('%', :q, '%'))",
+            java.lang.Long::class.java
+        )
+        q.setParameter("guildId", guildId)
+        q.setParameter("q", query)
+        return q.singleResult.toLong()
+    }
+
     override fun createNewExcuse(excuseDto: ExcuseDto?): ExcuseDto? {
         return persistExcuseDto(excuseDto)
     }
 
-
-    override fun getExcuseById(id: Long?): ExcuseDto {
+    override fun getExcuseById(id: Long?): ExcuseDto? {
+        if (id == null) return null
         val excuseQuery: TypedQuery<ExcuseDto> =
             entityManager.createNamedQuery("ExcuseDto.getById", ExcuseDto::class.java)
         excuseQuery.setParameter("id", id)
-        return excuseQuery.singleResult
+        return try {
+            excuseQuery.singleResult
+        } catch (_: NoResultException) {
+            null
+        }
     }
 
     override fun updateExcuse(excuseDto: ExcuseDto): ExcuseDto {

--- a/database/src/main/kotlin/database/service/ExcuseService.kt
+++ b/database/src/main/kotlin/database/service/ExcuseService.kt
@@ -6,10 +6,51 @@ interface ExcuseService {
     fun listAllGuildExcuses(guildId: Long?): List<ExcuseDto?>
     fun listApprovedGuildExcuses(guildId: Long?): List<ExcuseDto?>
     fun listPendingGuildExcuses(guildId: Long?): List<ExcuseDto?>
+
+    /** Paged variants. Page numbers are 1-based. */
+    fun listApprovedPaged(guildId: Long?, page: Int, pageSize: Int): PagedExcuses
+    fun listPendingPaged(guildId: Long?, page: Int, pageSize: Int): PagedExcuses
+    fun searchApproved(guildId: Long?, query: String, page: Int, pageSize: Int): PagedExcuses
+
+    fun countApproved(guildId: Long?): Long
+    fun countPending(guildId: Long?): Long
+
     fun createNewExcuse(excuseDto: ExcuseDto?): ExcuseDto?
     fun getExcuseById(id: Long?): ExcuseDto?
     fun updateExcuse(excuseDto: ExcuseDto): ExcuseDto?
+
+    /**
+     * Approve a pending excuse. Returns the updated DTO, or null if no
+     * excuse exists with [id], or the existing DTO if it was already
+     * approved (caller can detect "no-op" by checking the returned
+     * `approved` was already true before the call).
+     */
+    fun approveExcuse(id: Long): ExcuseDto?
+
+    /**
+     * Best-effort author check used by the self-delete-own-pending rule.
+     * Returns true iff [requesterDiscordId] is recorded as the author of
+     * the row referred to by [id] AND that row is still pending. Approved
+     * rows always require superuser to delete.
+     */
+    fun canRequesterDeleteOwnPending(id: Long, requesterDiscordId: Long): Boolean
+
     fun deleteExcuseByGuildId(guildId: Long?)
     fun deleteExcuseById(id: Long?)
     fun clearCache()
+}
+
+/**
+ * 1-based page envelope. [totalPages] is at least 1 even when there are no
+ * rows so the renderer can show "Page 1 of 1" instead of "Page 1 of 0".
+ */
+data class PagedExcuses(
+    val rows: List<ExcuseDto>,
+    val page: Int,
+    val pageSize: Int,
+    val totalCount: Long,
+) {
+    val totalPages: Int get() = if (totalCount == 0L) 1 else ((totalCount + pageSize - 1) / pageSize).toInt()
+    val hasPrev: Boolean get() = page > 1
+    val hasNext: Boolean get() = page < totalPages
 }

--- a/database/src/main/kotlin/database/service/impl/DefaultExcuseService.kt
+++ b/database/src/main/kotlin/database/service/impl/DefaultExcuseService.kt
@@ -2,44 +2,106 @@ package database.service.impl
 
 import database.dto.ExcuseDto
 import database.service.ExcuseService
+import database.service.PagedExcuses
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.cache.annotation.CacheEvict
 import org.springframework.cache.annotation.CachePut
 import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Service
+import java.time.Instant
 
 @Service
 class DefaultExcuseService : ExcuseService {
     @Autowired
     private lateinit var excuseService: database.persistence.ExcusePersistence
 
-    @Cacheable(value = ["excuses"])
+    // The cache key prefixes guarantee a list lookup for guild A can't be served
+    // from a slot last written for guild B. The previous implementation omitted
+    // `key` entirely so all guilds collided on the same `excuses::<empty>` slot.
+    @Cacheable(value = ["excuses"], key = "'all-' + #guildId")
     override fun listAllGuildExcuses(guildId: Long?): List<ExcuseDto?> {
         return excuseService.listAllGuildExcuses(guildId)
     }
 
-    @Cacheable(value = ["excuses"])
+    @Cacheable(value = ["excuses"], key = "'approved-' + #guildId")
     override fun listApprovedGuildExcuses(guildId: Long?): List<ExcuseDto?> {
         return excuseService.listApprovedGuildExcuses(guildId)
     }
 
+    @Cacheable(value = ["excuses"], key = "'pending-' + #guildId")
     override fun listPendingGuildExcuses(guildId: Long?): List<ExcuseDto?> {
         return excuseService.listPendingGuildExcuses(guildId)
     }
 
-    @CachePut(value = ["excuses"], key = "#excuseDto.id")
+    // Paged + search hit the DB every time — the per-page result sets are
+    // ephemeral and not worth caching across requests.
+    override fun listApprovedPaged(guildId: Long?, page: Int, pageSize: Int): PagedExcuses {
+        val safePage = page.coerceAtLeast(1)
+        val offset = (safePage - 1) * pageSize
+        return PagedExcuses(
+            rows = excuseService.listApprovedPaged(guildId, offset, pageSize),
+            page = safePage,
+            pageSize = pageSize,
+            totalCount = excuseService.countApproved(guildId),
+        )
+    }
+
+    override fun listPendingPaged(guildId: Long?, page: Int, pageSize: Int): PagedExcuses {
+        val safePage = page.coerceAtLeast(1)
+        val offset = (safePage - 1) * pageSize
+        return PagedExcuses(
+            rows = excuseService.listPendingPaged(guildId, offset, pageSize),
+            page = safePage,
+            pageSize = pageSize,
+            totalCount = excuseService.countPending(guildId),
+        )
+    }
+
+    override fun searchApproved(guildId: Long?, query: String, page: Int, pageSize: Int): PagedExcuses {
+        val trimmed = query.trim()
+        if (trimmed.isEmpty()) return PagedExcuses(emptyList(), 1, pageSize, 0L)
+        val safePage = page.coerceAtLeast(1)
+        val offset = (safePage - 1) * pageSize
+        return PagedExcuses(
+            rows = excuseService.searchApproved(guildId, trimmed, offset, pageSize),
+            page = safePage,
+            pageSize = pageSize,
+            totalCount = excuseService.countSearchApproved(guildId, trimmed),
+        )
+    }
+
+    override fun countApproved(guildId: Long?): Long = excuseService.countApproved(guildId)
+    override fun countPending(guildId: Long?): Long = excuseService.countPending(guildId)
+
+    // A create lands in pending; only the per-guild "all" and "pending" caches
+    // need eviction. Approved-list cache stays valid until an approve runs.
+    @CacheEvict(value = ["excuses"], allEntries = true)
     override fun createNewExcuse(excuseDto: ExcuseDto?): ExcuseDto? {
         return excuseService.createNewExcuse(excuseDto)
     }
 
-    @CachePut(value = ["excuses"], key = "#id")
-    override fun getExcuseById(id: Long?): ExcuseDto {
+    override fun getExcuseById(id: Long?): ExcuseDto? {
         return excuseService.getExcuseById(id)
     }
 
-    @CachePut(value = ["excuses"], key = "#excuseDto.id")
-    override fun updateExcuse(excuseDto: ExcuseDto): ExcuseDto {
+    @CacheEvict(value = ["excuses"], allEntries = true)
+    override fun updateExcuse(excuseDto: ExcuseDto): ExcuseDto? {
         return excuseService.updateExcuse(excuseDto)
+    }
+
+    @CacheEvict(value = ["excuses"], allEntries = true)
+    override fun approveExcuse(id: Long): ExcuseDto? {
+        val dto = excuseService.getExcuseById(id) ?: return null
+        if (dto.approved) return dto
+        dto.approved = true
+        dto.approvedAt = Instant.now()
+        return excuseService.updateExcuse(dto)
+    }
+
+    override fun canRequesterDeleteOwnPending(id: Long, requesterDiscordId: Long): Boolean {
+        val dto = excuseService.getExcuseById(id) ?: return false
+        if (dto.approved) return false
+        return dto.authorDiscordId == requesterDiscordId
     }
 
     @CacheEvict(value = ["excuses"], allEntries = true)
@@ -47,7 +109,7 @@ class DefaultExcuseService : ExcuseService {
         excuseService.deleteAllExcusesForGuild(guildId)
     }
 
-    @CacheEvict(value = ["excuses"], key = "#id")
+    @CacheEvict(value = ["excuses"], allEntries = true)
     override fun deleteExcuseById(id: Long?) {
         excuseService.deleteExcuseById(id)
     }

--- a/database/src/main/resources/db/migration/V31__add_excuse_timestamps.sql
+++ b/database/src/main/resources/db/migration/V31__add_excuse_timestamps.sql
@@ -1,0 +1,20 @@
+-- Add audit timestamps and a reliable author identity column.
+--
+-- The original `author` column stores the user's effective name at submission
+-- time, which is fine for display but useless for ownership checks (it
+-- changes when someone updates their nickname, and collides between people
+-- with the same name). The new author_discord_id column lets the new self-
+-- delete-own-pending rule resolve "is this requester the author?" without
+-- string-matching display names.
+--
+-- Existing rows leave author_discord_id NULL — those excuses predate the
+-- column and can only be moderated by superusers, which matches today's
+-- behavior.
+
+ALTER TABLE public.excuse
+    ADD COLUMN IF NOT EXISTS created_at        TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+    ADD COLUMN IF NOT EXISTS approved_at       TIMESTAMP WITH TIME ZONE NULL,
+    ADD COLUMN IF NOT EXISTS author_discord_id BIGINT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_excuse_guild_approved_created
+    ON public.excuse (guild_id, approved, created_at DESC);

--- a/discord-bot/src/main/kotlin/bot/toby/button/buttons/ExcuseListPageButton.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/button/buttons/ExcuseListPageButton.kt
@@ -1,0 +1,69 @@
+package bot.toby.button.buttons
+
+import bot.toby.command.commands.misc.ExcuseCommand
+import core.button.Button
+import core.button.ButtonContext
+import database.dto.UserDto
+import database.service.ExcuseService
+import net.dv8tion.jda.api.components.actionrow.ActionRow
+import net.dv8tion.jda.api.components.buttons.Button as JdaButton
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+@Component
+class ExcuseListPageButton @Autowired constructor(
+    private val excuseService: ExcuseService
+) : Button {
+
+    override val name: String = ExcuseCommand.BUTTON_NAME
+    override val description: String = "Paginate the excuse list/search view."
+    override val defersReply: Boolean = false
+
+    override fun handle(ctx: ButtonContext, requestingUserDto: UserDto, deleteDelay: Int) {
+        val event = ctx.event
+        val componentId = event.componentId.lowercase()
+        if (componentId == "${ExcuseCommand.BUTTON_NAME}:noop") {
+            // The page indicator is disabled; this branch only exists to keep
+            // the dispatcher quiet if Discord ever sends a click for it.
+            event.deferEdit().queue()
+            return
+        }
+        val parsed = ExcuseCommand.decodePageButton(componentId) ?: run {
+            event.deferEdit().queue()
+            return
+        }
+
+        val guildId = parsed.guildId
+
+        if (parsed.scope == ExcuseCommand.SCOPE_PENDING && !requestingUserDto.superUser) {
+            event.reply("You don't have permission to view pending excuses.").setEphemeral(true).queue()
+            return
+        }
+
+        val paged = when (parsed.scope) {
+            ExcuseCommand.SCOPE_PENDING -> excuseService.listPendingPaged(guildId, parsed.page, ExcuseCommand.EXCUSES_PER_PAGE)
+            ExcuseCommand.SCOPE_SEARCH -> excuseService.searchApproved(
+                guildId, parsed.query.orEmpty(), parsed.page, ExcuseCommand.EXCUSES_PER_PAGE
+            )
+            else -> excuseService.listApprovedPaged(guildId, parsed.page, ExcuseCommand.EXCUSES_PER_PAGE)
+        }
+
+        if (paged.rows.isEmpty()) {
+            event.reply("That page is empty now — the list may have changed.").setEphemeral(true).queue()
+            return
+        }
+
+        val embed = ExcuseCommand.buildPageEmbed(paged, parsed.scope, parsed.query)
+        val prevId = ExcuseCommand.encodePageButton(parsed.scope, guildId, paged.page - 1, parsed.query)
+        val nextId = ExcuseCommand.encodePageButton(parsed.scope, guildId, paged.page + 1, parsed.query)
+
+        event.editMessageEmbeds(embed).setComponents(
+            ActionRow.of(
+                JdaButton.primary(prevId, "⬅️ Prev").withDisabled(!paged.hasPrev),
+                JdaButton.secondary("${ExcuseCommand.BUTTON_NAME}:noop", "Page ${paged.page}/${paged.totalPages}")
+                    .withDisabled(true),
+                JdaButton.primary(nextId, "Next ➡️").withDisabled(!paged.hasNext),
+            )
+        ).queue()
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/misc/ExcuseCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/misc/ExcuseCommand.kt
@@ -31,7 +31,7 @@ class ExcuseCommand @Autowired constructor(
         SubcommandData(SUBMIT, "Submit a new excuse for approval (max 200 characters).")
             .addOptions(
                 OptionData(OptionType.STRING, OPT_TEXT, "The excuse text", true)
-                    .setMaxLength(MAX_EXCUSE_LENGTH.toLong()),
+                    .setMaxLength(MAX_EXCUSE_LENGTH),
                 OptionData(
                     OptionType.USER, OPT_AUTHOR,
                     "Attribute the excuse to this user instead of yourself", false

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/misc/ExcuseCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/misc/ExcuseCommand.kt
@@ -1,171 +1,341 @@
 package bot.toby.command.commands.misc
 
 import core.command.Command.Companion.replyAndDelete
+import core.command.Command.Companion.replyEmbedAndDelete
 import core.command.CommandContext
 import database.dto.ExcuseDto
 import database.dto.UserDto
 import database.service.ExcuseService
+import database.service.PagedExcuses
+import net.dv8tion.jda.api.EmbedBuilder
+import net.dv8tion.jda.api.components.actionrow.ActionRow
+import net.dv8tion.jda.api.components.buttons.Button
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
 import net.dv8tion.jda.api.interactions.commands.OptionType
 import net.dv8tion.jda.api.interactions.commands.build.OptionData
+import net.dv8tion.jda.api.interactions.commands.build.SubcommandData
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
+import java.awt.Color
 
 @Component
-class ExcuseCommand @Autowired constructor(private val excuseService: ExcuseService) : MiscCommand {
+class ExcuseCommand @Autowired constructor(
+    private val excuseService: ExcuseService
+) : MiscCommand {
+
     override val name = "excuse"
+    override val description = "Random excuses, submissions, and moderation per server."
+
+    override val subCommands: List<SubcommandData> = listOf(
+        SubcommandData(RANDOM, "Get a random approved excuse for this server."),
+        SubcommandData(SUBMIT, "Submit a new excuse for approval (max 200 characters).")
+            .addOptions(
+                OptionData(OptionType.STRING, OPT_TEXT, "The excuse text", true)
+                    .setMaxLength(MAX_EXCUSE_LENGTH.toLong()),
+                OptionData(
+                    OptionType.USER, OPT_AUTHOR,
+                    "Attribute the excuse to this user instead of yourself", false
+                )
+            ),
+        SubcommandData(LIST, "Browse the server's excuses with pagination.")
+            .addOptions(
+                OptionData(OptionType.STRING, OPT_SCOPE, "Approved (default) or pending — pending is superuser-only")
+                    .addChoice(SCOPE_APPROVED, SCOPE_APPROVED)
+                    .addChoice(SCOPE_PENDING, SCOPE_PENDING),
+                OptionData(OptionType.INTEGER, OPT_PAGE, "Page number (default 1)")
+            ),
+        SubcommandData(SEARCH, "Find approved excuses containing the given text.")
+            .addOptions(
+                OptionData(OptionType.STRING, OPT_QUERY, "Search text (case-insensitive substring)", true),
+                OptionData(OptionType.INTEGER, OPT_PAGE, "Page number (default 1)")
+            ),
+        SubcommandData(APPROVE, "Approve a pending excuse (superuser only).")
+            .addOptions(
+                OptionData(OptionType.INTEGER, OPT_ID, "Excuse id to approve", true)
+            ),
+        SubcommandData(DELETE, "Delete an excuse (superusers, or authors deleting their own pending submission).")
+            .addOptions(
+                OptionData(OptionType.INTEGER, OPT_ID, "Excuse id to delete", true)
+            ),
+    )
 
     override fun handle(ctx: CommandContext, requestingUserDto: UserDto, deleteDelay: Int) {
         val event = ctx.event
         event.deferReply().queue()
-        val guildId = event.guild!!.idLong
-        when {
-            event.options.isEmpty() -> lookupExcuse(event, deleteDelay)
-            else -> {
-                val action = event.getOption(ACTION)?.asString
-                when (action) {
-                    PENDING -> lookupPendingExcuses(event, guildId, deleteDelay)
-                    ALL -> listAllExcuses(event, guildId, deleteDelay)
-                    APPROVE -> approveExcuse(requestingUserDto, event, deleteDelay)
-                    DELETE -> deleteExcuse(requestingUserDto, event, deleteDelay)
-                    else -> createNewExcuse(event, deleteDelay)
-                }
-            }
-        }
-    }
 
-    private fun listAllExcuses(event: SlashCommandInteractionEvent, guildId: Long, deleteDelay: Int) {
-        val excuseDtos = excuseService.listApprovedGuildExcuses(guildId)
-        if (excuseDtos.isEmpty()) {
-            event.hook.replyAndDelete("There are no approved excuses, consider submitting some.", deleteDelay)
+        val guildId = event.guild?.idLong ?: run {
+            event.hook.replyAndDelete("This command can only be used in a server.", deleteDelay)
             return
         }
-        val excusesMessage = buildExcusesMessage(excuseDtos)
-        event.hook.replyAndDelete(excusesMessage, deleteDelay)
-    }
 
-    private fun buildExcusesMessage(excuseDtos: List<ExcuseDto?>): String {
-        val builder = StringBuilder("Listing all approved excuses below: \n")
-        excuseDtos.forEachIndexed { index, excuse ->
-            builder.append("Excuse #${excuse?.id}: '${excuse?.excuse}' - ${excuse?.author}. \n")
-            if (index == MAX_EXCUSES_DISPLAYED) return@forEachIndexed
-        }
-        return builder.toString()
-    }
-
-    private fun approveExcuse(
-        requestingUserDto: UserDto?,
-        event: SlashCommandInteractionEvent,
-        deleteDelay: Int
-    ) {
-        if (requestingUserDto?.superUser == true) {
-            val excuseId = event.getOption(EXCUSE_ID)?.asLong ?: return
-            val excuseById = excuseService.getExcuseById(excuseId) ?: return
-            if (!excuseById.approved) {
-                excuseById.approved = true
-                excuseService.updateExcuse(excuseById)
-                event.hook.replyAndDelete("Approved excuse '${excuseById.excuse}'.", deleteDelay)
-            } else {
-                event.hook.replyAndDelete(EXISTING_EXCUSE_MESSAGE, deleteDelay)
-            }
-        } else {
-            sendErrorMessage(event, deleteDelay)
-        }
-    }
-
-    private fun lookupExcuse(event: SlashCommandInteractionEvent, deleteDelay: Int) {
-        val excuseDtos = excuseService.listApprovedGuildExcuses(event.guild!!.idLong)
-        if (excuseDtos.isEmpty()) {
-            event.hook.replyAndDelete("There are no approved excuses, consider submitting some.", deleteDelay)
-            return
-        }
-        val randomExcuse = excuseDtos.random()
-        event.hook.replyAndDelete(
-            "Excuse #${randomExcuse?.id}: '${randomExcuse?.excuse}' - ${randomExcuse?.author}.",
-            deleteDelay,
-        )
-    }
-
-    private fun createNewExcuse(event: SlashCommandInteractionEvent, deleteDelay: Int) {
-        val excuseMessage = event.getOption(EXCUSE)?.asString ?: return
-        val guildId = event.guild!!.idLong
-        val author = event.getOption(AUTHOR)?.asMember?.effectiveName ?: event.user.name
-        val existingExcuse = excuseService.listAllGuildExcuses(guildId).find { it?.excuse == excuseMessage }
-        if (existingExcuse != null) {
-            event.hook.replyAndDelete(EXISTING_EXCUSE_MESSAGE, deleteDelay)
-        } else {
-            val excuseDto = ExcuseDto().apply {
-                this.guildId = guildId
-                this.author = author
-                this.excuse = excuseMessage
-            }
-
-            val newExcuse = excuseService.createNewExcuse(excuseDto)
-            event.hook.replyAndDelete(
-                "Submitted new excuse '$excuseMessage' - $author with id '${newExcuse?.id}' for approval.",
+        when (event.subcommandName) {
+            RANDOM, null -> handleRandom(event, guildId, deleteDelay)
+            SUBMIT -> handleSubmit(event, guildId, requestingUserDto, deleteDelay)
+            LIST -> handleList(event, guildId, requestingUserDto, deleteDelay)
+            SEARCH -> handleSearch(event, guildId, deleteDelay)
+            APPROVE -> handleApprove(event, requestingUserDto, deleteDelay)
+            DELETE -> handleDelete(event, requestingUserDto, deleteDelay)
+            else -> event.hook.replyAndDelete(
+                "Unknown subcommand. Try `/excuse random`, `/excuse submit`, `/excuse list`, `/excuse search`.",
                 deleteDelay,
             )
         }
     }
 
-    private fun lookupPendingExcuses(event: SlashCommandInteractionEvent, guildId: Long, deleteDelay: Int) {
-        val excuseDtos = excuseService.listPendingGuildExcuses(guildId)
-        if (excuseDtos.isEmpty()) {
-            event.hook.replyAndDelete("There are no excuses pending approval, consider submitting some.", deleteDelay)
+    private fun handleRandom(event: SlashCommandInteractionEvent, guildId: Long, deleteDelay: Int) {
+        val approved = excuseService.listApprovedGuildExcuses(guildId).filterNotNull()
+        if (approved.isEmpty()) {
+            event.hook.replyAndDelete("There are no approved excuses, consider submitting some.", deleteDelay)
             return
         }
-        val excusesMessage = buildExcusesMessage(excuseDtos)
-        event.hook.replyAndDelete(excusesMessage, deleteDelay)
+        val pick = approved.random()
+        event.hook.replyAndDelete(
+            "Excuse #${pick.id}: '${pick.excuse}' - ${pick.author}.",
+            deleteDelay,
+        )
     }
 
-    private fun deleteExcuse(
-        requestingUserDto: UserDto?,
+    private fun handleSubmit(
         event: SlashCommandInteractionEvent,
-        deleteDelay: Int
+        guildId: Long,
+        requesterDto: UserDto,
+        deleteDelay: Int,
     ) {
-        if (requestingUserDto?.superUser == true) {
-            val excuseId = event.getOption(EXCUSE_ID)?.asLong ?: return
-            excuseService.deleteExcuseById(excuseId)
-            event.hook.replyAndDelete("Deleted excuse with id '$excuseId'.", deleteDelay)
-        } else {
+        val excuseText = event.getOption(OPT_TEXT)?.asString?.trim()
+        if (excuseText.isNullOrBlank()) {
+            event.hook.replyAndDelete("Provide some excuse text.", deleteDelay)
+            return
+        }
+
+        val authorMember = event.getOption(OPT_AUTHOR)?.asMember
+        val authorName = authorMember?.effectiveName ?: event.user.name
+        val authorDiscordId = authorMember?.idLong ?: event.user.idLong
+
+        val existing = excuseService.listAllGuildExcuses(guildId)
+            .filterNotNull()
+            .firstOrNull { it.excuse.equals(excuseText, ignoreCase = true) }
+        if (existing != null) {
+            event.hook.replyAndDelete(EXISTING_EXCUSE_MESSAGE, deleteDelay)
+            return
+        }
+
+        val dto = ExcuseDto(
+            guildId = guildId,
+            author = authorName,
+            excuse = excuseText,
+            authorDiscordId = authorDiscordId,
+        )
+        val saved = excuseService.createNewExcuse(dto)
+        event.hook.replyAndDelete(
+            "Submitted excuse '$excuseText' - $authorName with id '${saved?.id}' for approval.",
+            deleteDelay,
+        )
+    }
+
+    private fun handleList(
+        event: SlashCommandInteractionEvent,
+        guildId: Long,
+        requesterDto: UserDto,
+        deleteDelay: Int,
+    ) {
+        val scope = event.getOption(OPT_SCOPE)?.asString ?: SCOPE_APPROVED
+        val page = (event.getOption(OPT_PAGE)?.asInt ?: 1).coerceAtLeast(1)
+
+        if (scope == SCOPE_PENDING && !requesterDto.superUser) {
             sendErrorMessage(event, deleteDelay)
+            return
+        }
+
+        val paged = when (scope) {
+            SCOPE_PENDING -> excuseService.listPendingPaged(guildId, page, EXCUSES_PER_PAGE)
+            else -> excuseService.listApprovedPaged(guildId, page, EXCUSES_PER_PAGE)
+        }
+        sendPagedListing(
+            event = event,
+            paged = paged,
+            scope = scope,
+            query = null,
+            guildId = guildId,
+            deleteDelay = deleteDelay,
+        )
+    }
+
+    private fun handleSearch(event: SlashCommandInteractionEvent, guildId: Long, deleteDelay: Int) {
+        val query = event.getOption(OPT_QUERY)?.asString?.trim()
+        if (query.isNullOrBlank()) {
+            event.hook.replyAndDelete("Provide a search query.", deleteDelay)
+            return
+        }
+        val page = (event.getOption(OPT_PAGE)?.asInt ?: 1).coerceAtLeast(1)
+        val paged = excuseService.searchApproved(guildId, query, page, EXCUSES_PER_PAGE)
+        sendPagedListing(
+            event = event,
+            paged = paged,
+            scope = SCOPE_SEARCH,
+            query = query,
+            guildId = guildId,
+            deleteDelay = deleteDelay,
+        )
+    }
+
+    private fun handleApprove(
+        event: SlashCommandInteractionEvent,
+        requesterDto: UserDto,
+        deleteDelay: Int,
+    ) {
+        if (!requesterDto.superUser) {
+            sendErrorMessage(event, deleteDelay)
+            return
+        }
+        val id = event.getOption(OPT_ID)?.asLong ?: run {
+            event.hook.replyAndDelete("Provide the excuse id to approve.", deleteDelay)
+            return
+        }
+        val existing = excuseService.getExcuseById(id) ?: run {
+            event.hook.replyAndDelete("No excuse exists with id $id.", deleteDelay)
+            return
+        }
+        if (existing.approved) {
+            event.hook.replyAndDelete(EXISTING_EXCUSE_MESSAGE, deleteDelay)
+            return
+        }
+        val approved = excuseService.approveExcuse(id)
+        event.hook.replyAndDelete("Approved excuse '${approved?.excuse}'.", deleteDelay)
+    }
+
+    private fun handleDelete(
+        event: SlashCommandInteractionEvent,
+        requesterDto: UserDto,
+        deleteDelay: Int,
+    ) {
+        val id = event.getOption(OPT_ID)?.asLong ?: run {
+            event.hook.replyAndDelete("Provide the excuse id to delete.", deleteDelay)
+            return
+        }
+        val isSuper = requesterDto.superUser
+        val ownsPending = !isSuper && excuseService.canRequesterDeleteOwnPending(id, event.user.idLong)
+        if (!isSuper && !ownsPending) {
+            sendErrorMessage(event, deleteDelay)
+            return
+        }
+        excuseService.deleteExcuseById(id)
+        event.hook.replyAndDelete("Deleted excuse with id '$id'.", deleteDelay)
+    }
+
+    private fun sendPagedListing(
+        event: SlashCommandInteractionEvent,
+        paged: PagedExcuses,
+        scope: String,
+        query: String?,
+        guildId: Long,
+        deleteDelay: Int,
+    ) {
+        if (paged.rows.isEmpty()) {
+            val emptyMsg = when (scope) {
+                SCOPE_PENDING -> "There are no excuses pending approval, consider submitting some."
+                SCOPE_SEARCH -> "No approved excuses match '${query.orEmpty()}'."
+                else -> "There are no approved excuses, consider submitting some."
+            }
+            event.hook.replyAndDelete(emptyMsg, deleteDelay)
+            return
+        }
+
+        val embed = buildPageEmbed(paged, scope, query)
+
+        if (paged.totalPages <= 1) {
+            event.hook.replyEmbedAndDelete(embed, deleteDelay)
+            return
+        }
+
+        // Stateful pagination: button-id encodes everything the dispatcher needs
+        // to re-render the next/prev page without holding server state.
+        val prevId = encodePageButton(scope, guildId, paged.page - 1, query)
+        val nextId = encodePageButton(scope, guildId, paged.page + 1, query)
+
+        event.hook.sendMessageEmbeds(embed).addComponents(
+            ActionRow.of(
+                Button.primary(prevId, "⬅️ Prev").withDisabled(!paged.hasPrev),
+                Button.secondary("$BUTTON_NAME:noop", "Page ${paged.page}/${paged.totalPages}").withDisabled(true),
+                Button.primary(nextId, "Next ➡️").withDisabled(!paged.hasNext),
+            )
+        ).queue()
+    }
+
+    companion object {
+        const val EXISTING_EXCUSE_MESSAGE = "I've heard that one before, keep up."
+        const val MAX_EXCUSE_LENGTH = 200
+        const val EXCUSES_PER_PAGE = 10
+        const val BUTTON_NAME = "excuse-page"
+
+        const val RANDOM = "random"
+        const val SUBMIT = "submit"
+        const val LIST = "list"
+        const val SEARCH = "search"
+        const val APPROVE = "approve"
+        const val DELETE = "delete"
+
+        const val SCOPE_APPROVED = "approved"
+        const val SCOPE_PENDING = "pending"
+        const val SCOPE_SEARCH = "search"
+
+        private const val OPT_TEXT = "text"
+        private const val OPT_AUTHOR = "author"
+        private const val OPT_SCOPE = "scope"
+        private const val OPT_PAGE = "page"
+        private const val OPT_QUERY = "query"
+        private const val OPT_ID = "id"
+
+        fun buildPageEmbed(paged: PagedExcuses, scope: String, query: String?): net.dv8tion.jda.api.entities.MessageEmbed {
+            val title = when (scope) {
+                SCOPE_PENDING -> "Pending excuses"
+                SCOPE_SEARCH -> "Search results for '${query.orEmpty()}'"
+                else -> "Approved excuses"
+            }
+            val builder = EmbedBuilder()
+                .setTitle(title)
+                .setColor(Color(88, 101, 242))
+            paged.rows.forEach { row ->
+                builder.addField(
+                    "#${row.id} — ${row.author ?: "Unknown"}",
+                    row.excuse.orEmpty().ifBlank { "(no text)" },
+                    false,
+                )
+            }
+            builder.setFooter("Page ${paged.page} / ${paged.totalPages} · ${paged.totalCount} total")
+            return builder.build()
+        }
+
+        /**
+         * Encode a page button id. Query is base64'd to survive `:` separators
+         * and Discord's 100-char id limit (truncation here means the button
+         * silently rebuilds with a clipped query — better than the dispatcher
+         * mis-parsing). Decode with [decodePageButton].
+         */
+        fun encodePageButton(scope: String, guildId: Long, page: Int, query: String?): String {
+            val qPart = query?.let {
+                java.util.Base64.getUrlEncoder().withoutPadding()
+                    .encodeToString(it.toByteArray(Charsets.UTF_8))
+            }.orEmpty()
+            return "$BUTTON_NAME:$scope:$guildId:$page:$qPart"
+        }
+
+        fun decodePageButton(componentId: String): DecodedPageButton? {
+            val parts = componentId.split(":", limit = 5)
+            if (parts.size < 4 || parts[0] != BUTTON_NAME) return null
+            val scope = parts[1]
+            val guildId = parts[2].toLongOrNull() ?: return null
+            val page = parts[3].toIntOrNull() ?: return null
+            val query = parts.getOrNull(4)?.takeIf { it.isNotEmpty() }?.let {
+                runCatching { String(java.util.Base64.getUrlDecoder().decode(it), Charsets.UTF_8) }.getOrNull()
+            }
+            return DecodedPageButton(scope, guildId, page, query)
         }
     }
 
-    override val description: String
-        get() = "Let me give you a convenient excuse!"
-
-    override val optionData: List<OptionData>
-        get() = listOf(
-            OptionData(OptionType.STRING, ACTION, "Which action would you like to take?")
-                .addChoice(PENDING, PENDING)
-                .addChoice(ALL, ALL)
-                .addChoice(APPROVE, APPROVE)
-                .addChoice(DELETE, DELETE),
-            OptionData(
-                OptionType.INTEGER,
-                EXCUSE_ID,
-                "Use in combination with an approve action for pending IDs, or delete action for an approved ID"
-            ),
-            OptionData(OptionType.STRING, EXCUSE, "Use in combination with an approve being true. Max 200 characters"),
-            OptionData(
-                OptionType.USER,
-                AUTHOR,
-                "Who made this excuse? Leave blank to attribute to the user who called the command"
-            )
-        )
-
-    companion object {
-        private const val EXCUSE = "excuse"
-        private const val EXCUSE_ID = "id"
-        private const val AUTHOR = "author"
-        private const val ACTION = "action"
-        const val PENDING = "pending"
-        const val ALL = "all"
-        const val APPROVE = "approve"
-        const val DELETE = "delete"
-        const val EXISTING_EXCUSE_MESSAGE = "I've heard that one before, keep up."
-        const val MAX_EXCUSES_DISPLAYED = 5
-    }
+    data class DecodedPageButton(
+        val scope: String,
+        val guildId: Long,
+        val page: Int,
+        val query: String?,
+    )
 }
-

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/misc/ExcuseCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/misc/ExcuseCommandTest.kt
@@ -6,22 +6,21 @@ import bot.toby.command.CommandTest.Companion.requestingUserDto
 import bot.toby.command.DefaultCommandContext
 import database.dto.ExcuseDto
 import database.service.ExcuseService
+import database.service.PagedExcuses
 import io.mockk.*
-import io.mockk.InternalPlatformDsl.toStr
 import net.dv8tion.jda.api.interactions.commands.OptionMapping
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 internal class ExcuseCommandTest : CommandTest {
-    lateinit var excuseCommand: ExcuseCommand
-
-    lateinit var excuseService: ExcuseService
+    private lateinit var excuseCommand: ExcuseCommand
+    private lateinit var excuseService: ExcuseService
 
     @BeforeEach
     fun setUp() {
         setUpCommonMocks()
-        excuseService = mockk()
+        excuseService = mockk(relaxed = true)
         excuseCommand = ExcuseCommand(excuseService)
     }
 
@@ -30,305 +29,331 @@ internal class ExcuseCommandTest : CommandTest {
         tearDownCommonMocks()
     }
 
+    // /excuse random
+
     @Test
-    fun aRandomApprovedExcuse_WhenNoOptionsUsed() {
-        // Arrange
+    fun `random returns approved excuse when there is at least one`() {
         val ctx = DefaultCommandContext(event)
-        val userDto = mockk<database.dto.UserDto>()
-        val deleteDelay = 0
+        val approved = ExcuseDto(id = 1L, guildId = 1L, author = "Alice", excuse = "the dog ate it", approved = true)
+        every { event.subcommandName } returns ExcuseCommand.RANDOM
+        every { excuseService.listApprovedGuildExcuses(1L) } returns listOf(approved)
 
-        // Mock the behavior of the excuseService when listing approved guild excuses
-        val excuseDto = ExcuseDto(1, 1L, "TestAuthor", "Excuse 1", true)
-        val excuseDtos: List<ExcuseDto?> = listOf(excuseDto)
-        val optionMapping = mockk<OptionMapping>()
-        every { event.options } returns emptyList()
-        every { event.getOption("action") } returns optionMapping
-        every { optionMapping.asString } returns "all"
-        every { excuseService.listApprovedGuildExcuses(any()) } returns excuseDtos
+        excuseCommand.handle(ctx, requestingUserDto, 0)
 
-        // Act
-        excuseCommand.handle(ctx, userDto, deleteDelay)
-
-        // Assert
         verify {
-            event.hook.sendMessage(
-                "Excuse #${excuseDto.id}: '${excuseDto.excuse}' - ${excuseDto.author}."
-            )
+            event.hook.sendMessage("Excuse #1: 'the dog ate it' - Alice.")
         }
     }
 
     @Test
-    fun listAllApprovedExcuses_WithValidApprovedOnes() {
-        // Arrange
+    fun `random falls back to message when there are no approved excuses`() {
         val ctx = DefaultCommandContext(event)
-        val userDto = mockk<database.dto.UserDto>()
-        val deleteDelay = 0
+        every { event.subcommandName } returns ExcuseCommand.RANDOM
+        every { excuseService.listApprovedGuildExcuses(1L) } returns emptyList()
 
-        // Mock the behavior of the excuseService when listing approved guild excuses
-        val excuseDtos: List<ExcuseDto?> = listOf(
-            ExcuseDto(1, 1L, "TestAuthor", "Excuse 1", true),
-            ExcuseDto(2, 1L, "TestAuthor", "Excuse 2", true),
-            ExcuseDto(3, 1L, "TestAuthor", "Excuse 3", true)
-        )
-        val optionMapping = mockk<OptionMapping>()
-        every { event.options } returns listOf(optionMapping)
-        every { event.getOption("action") } returns optionMapping
-        every { optionMapping.asString } returns "all"
-        every { excuseService.listApprovedGuildExcuses(any()) } returns excuseDtos
+        excuseCommand.handle(ctx, requestingUserDto, 0)
 
-        // Act
-        excuseCommand.handle(ctx, userDto, deleteDelay)
-
-        // Assert
-        verify { event.hook.sendMessage(any<String>()) }
-    }
-
-    @Test
-    fun listAllApprovedExcuses_WithNoValidApprovedOnes() {
-        // Arrange
-        val ctx = DefaultCommandContext(event)
-        val userDto = mockk<database.dto.UserDto>()
-        val deleteDelay = 0
-
-        // Mock the behavior of the excuseService when listing approved guild excuses
-        val optionMapping = mockk<OptionMapping>()
-        every { event.options } returns emptyList()
-        every { event.getOption("action") } returns optionMapping
-        every { optionMapping.asString } returns "all"
-        every { excuseService.listApprovedGuildExcuses(any()) } returns emptyList<ExcuseDto>()
-
-        // Act
-        excuseCommand.handle(ctx, userDto, deleteDelay)
-
-        // Assert
         verify { event.hook.sendMessage("There are no approved excuses, consider submitting some.") }
     }
 
     @Test
-    fun createNewExcuse() {
-        // Arrange
+    fun `null subcommand defaults to random for muscle-memory`() {
         val ctx = DefaultCommandContext(event)
-        val userDto = mockk<database.dto.UserDto>()
-        val deleteDelay = 0
-        val excuseToCreate = ExcuseDto(1, 1L, "UserName", "Excuse 1", false)
-        val excuseMapping = mockk<OptionMapping>()
-        val actionMapping = mockk<OptionMapping>()
-        val authorMapping = mockk<OptionMapping>()
-        every { event.getOption("excuse") } returns excuseMapping
-        every { event.getOption("action") } returns actionMapping
-        every { event.getOption("author") } returns authorMapping
-        every { event.options } returns listOf(excuseMapping)
-        every { actionMapping.asString } returns null.toStr()
-        every { excuseMapping.asString } returns "Excuse 1"
-        every { authorMapping.asMember } returns null
-        every { excuseService.listAllGuildExcuses(1L) } returns emptyList<ExcuseDto>()
-        every { excuseService.createNewExcuse(any()) } returns excuseToCreate
+        val approved = ExcuseDto(id = 7L, guildId = 1L, author = "Bob", excuse = "traffic was bad", approved = true)
+        every { event.subcommandName } returns null
+        every { excuseService.listApprovedGuildExcuses(1L) } returns listOf(approved)
 
-        // Act
-        excuseCommand.handle(ctx, userDto, deleteDelay)
+        excuseCommand.handle(ctx, requestingUserDto, 0)
 
-        // Assert
+        verify { event.hook.sendMessage("Excuse #7: 'traffic was bad' - Bob.") }
+    }
+
+    // /excuse submit
+
+    @Test
+    fun `submit creates a new pending excuse with author from user`() {
+        val ctx = DefaultCommandContext(event)
+        val saved = ExcuseDto(id = 10L, guildId = 1L, author = "UserName", excuse = "I forgot", approved = false)
+        val textOption = mockk<OptionMapping> { every { asString } returns "I forgot" }
+        every { event.subcommandName } returns ExcuseCommand.SUBMIT
+        every { event.getOption("text") } returns textOption
+        every { event.getOption("author") } returns null
+        every { excuseService.listAllGuildExcuses(1L) } returns emptyList()
+        every { excuseService.createNewExcuse(any()) } returns saved
+
+        excuseCommand.handle(ctx, requestingUserDto, 0)
+
         verify {
-            excuseService.listAllGuildExcuses(1L)
-            excuseService.createNewExcuse(any())
-            event.hook.sendMessage(any<String>())
+            excuseService.createNewExcuse(withArg<ExcuseDto> {
+                assert(it.guildId == 1L)
+                assert(it.excuse == "I forgot")
+                assert(it.authorDiscordId == 1L) // from event.user.idLong in CommandTest
+                assert(!it.approved)
+            })
+            event.hook.sendMessage("Submitted excuse 'I forgot' - UserName with id '10' for approval.")
         }
     }
 
     @Test
-    fun createNewExcuse_thatExists_throwsError() {
-        // Arrange
+    fun `submit rejects duplicates case-insensitively`() {
         val ctx = DefaultCommandContext(event)
-        val userDto = mockk<database.dto.UserDto>()
-        val deleteDelay = 0
+        val existing = ExcuseDto(id = 1L, guildId = 1L, author = "Bob", excuse = "I FORGOT", approved = true)
+        val textOption = mockk<OptionMapping> { every { asString } returns "i forgot" }
+        every { event.subcommandName } returns ExcuseCommand.SUBMIT
+        every { event.getOption("text") } returns textOption
+        every { event.getOption("author") } returns null
+        every { excuseService.listAllGuildExcuses(1L) } returns listOf(existing)
 
-        val excuseToCreate = ExcuseDto(1, 1L, "UserName", "Excuse 1", false)
-        val excuseDtos: List<ExcuseDto?> = listOf(excuseToCreate)
-        val excuseMapping = mockk<OptionMapping>()
-        val actionMapping = mockk<OptionMapping>()
-        val authorMapping = mockk<OptionMapping>()
-        every { event.getOption("excuse") } returns excuseMapping
-        every { event.getOption("action") } returns actionMapping
-        every { event.getOption("author") } returns authorMapping
-        every { actionMapping.asString } returns null.toString()
-        every { authorMapping.asMember } returns null
-        every { event.options } returns listOf(excuseMapping)
-        every { excuseMapping.asString } returns "Excuse 1"
-        every { excuseService.listAllGuildExcuses(1L) } returns excuseDtos
-        every { excuseService.createNewExcuse(any()) } returns excuseToCreate
+        excuseCommand.handle(ctx, requestingUserDto, 0)
 
-        // Act
-        excuseCommand.handle(ctx, userDto, deleteDelay)
-
-        // Assert
-        verify {
-            excuseService.listAllGuildExcuses(1L)
-            event.hook.sendMessage("I've heard that one before, keep up.")
-        }
+        verify { event.hook.sendMessage(ExcuseCommand.EXISTING_EXCUSE_MESSAGE) }
         verify(exactly = 0) { excuseService.createNewExcuse(any()) }
     }
 
     @Test
-    fun approvePendingExcuse_asSuperUser() {
-        // Arrange
+    fun `submit blank text complains and does not create`() {
         val ctx = DefaultCommandContext(event)
-        val userDto = mockk<database.dto.UserDto>()
-        val deleteDelay = 0
-        val preUpdatedExcuse = ExcuseDto(1, 1L, "UserName", "Excuse 1", false)
-        val excuseToBeReturnedByUpdate = ExcuseDto(1, 1L, "UserName", "Excuse 1", true)
-        val excuseMapping = mockk<OptionMapping>()
-        val actionMapping = mockk<OptionMapping>()
-        every { event.getOption("id") } returns excuseMapping
-        every { event.getOption("action") }.returns(actionMapping)
-        every { event.options } returns listOf(excuseMapping)
-        every { userDto.superUser } returns true
-        every { excuseMapping.asInt } returns 1
-        every { excuseMapping.asLong } returns 1
-        every { actionMapping.asString } returns "approve"
-        every { excuseService.getExcuseById(1) } returns preUpdatedExcuse
-        every { excuseService.updateExcuse(any()) } returns excuseToBeReturnedByUpdate
+        val textOption = mockk<OptionMapping> { every { asString } returns "   " }
+        every { event.subcommandName } returns ExcuseCommand.SUBMIT
+        every { event.getOption("text") } returns textOption
+        every { event.getOption("author") } returns null
 
-        // Act
-        excuseCommand.handle(ctx, userDto, deleteDelay)
+        excuseCommand.handle(ctx, requestingUserDto, 0)
 
-        // Assert
+        verify { event.hook.sendMessage("Provide some excuse text.") }
+        verify(exactly = 0) { excuseService.createNewExcuse(any()) }
+    }
+
+    // /excuse approve
+
+    @Test
+    fun `approve as superuser flips approval and replies with text`() {
+        val ctx = DefaultCommandContext(event)
+        val pending = ExcuseDto(id = 5L, guildId = 1L, author = "Alice", excuse = "rain delay", approved = false)
+        val approved = ExcuseDto(id = 5L, guildId = 1L, author = "Alice", excuse = "rain delay", approved = true)
+        val idOption = mockk<OptionMapping> { every { asLong } returns 5L }
+        every { event.subcommandName } returns ExcuseCommand.APPROVE
+        every { event.getOption("id") } returns idOption
+        every { requestingUserDto.superUser } returns true
+        every { excuseService.getExcuseById(5L) } returns pending
+        every { excuseService.approveExcuse(5L) } returns approved
+
+        excuseCommand.handle(ctx, requestingUserDto, 0)
+
         verify {
-            excuseService.getExcuseById(excuseToBeReturnedByUpdate.id)
-            excuseService.updateExcuse(any())
-            event.hook.sendMessage("Approved excuse '${excuseToBeReturnedByUpdate.excuse}'.")
+            excuseService.approveExcuse(5L)
+            event.hook.sendMessage("Approved excuse 'rain delay'.")
         }
     }
 
     @Test
-    fun approvePendingExcuse_asNonAuthorisedUser() {
-        // Arrange
+    fun `approve as non-superuser is denied`() {
         val ctx = DefaultCommandContext(event)
-        val deleteDelay = 0
-        val excuseToCreate = ExcuseDto(1, 1L, "UserName", "Excuse 1", true)
-        val excuseMapping = mockk<OptionMapping>()
-        val actionMapping = mockk<OptionMapping>()
-        every { event.getOption("id") } returns excuseMapping
-        every { event.getOption("action") } returns actionMapping
-        every { event.options } returns listOf(excuseMapping)
-        every { excuseMapping.asInt } returns 1
-        every { actionMapping.asString } returns "approve"
-        every { excuseService.getExcuseById(1) } returns excuseToCreate
-        every { excuseService.updateExcuse(any()) } returns excuseToCreate
-        every { CommandTest.guild.owner } returns CommandTest.member
-        every { CommandTest.member.effectiveName } returns "Effective Name"
+        val idOption = mockk<OptionMapping> { every { asLong } returns 5L }
+        every { event.subcommandName } returns ExcuseCommand.APPROVE
+        every { event.getOption("id") } returns idOption
         every { requestingUserDto.superUser } returns false
-
-        // Act
-        excuseCommand.handle(ctx, requestingUserDto, deleteDelay)
-
-        // Assert
-        verify {
-            event.hook.sendMessageFormat("You do not have adequate permissions to use this command, if you believe this is a mistake talk to Effective Name")
-        }
-    }
-
-    @Test
-    fun listAllPendingExcuses_WithValidPendingOnes() {
-        // Arrange
-        val ctx = DefaultCommandContext(event)
-        val userDto = mockk<database.dto.UserDto>()
-        val deleteDelay = 0
-
-        // Mock the behavior of the excuseService when listing approved guild excuses
-        val excuseDtos: List<ExcuseDto?> = listOf(
-            ExcuseDto(1, 1L, "TestAuthor", "Excuse 1", true),
-            ExcuseDto(2, 1L, "TestAuthor", "Excuse 2", true),
-            ExcuseDto(3, 1L, "TestAuthor", "Excuse 3", true)
-        )
-        val optionMapping = mockk<OptionMapping>()
-        every { event.options } returns listOf(optionMapping)
-        every { event.getOption("action") } returns optionMapping
-        every { optionMapping.asString } returns "pending"
-        every { excuseService.listPendingGuildExcuses(any()) } returns excuseDtos
-
-        // Act
-        excuseCommand.handle(ctx, userDto, deleteDelay)
-
-        // Assert
-        verify { event.hook.sendMessage(any<String>()) }
-    }
-
-    @Test
-    fun listAllPendingExcuses_WithNoValidPendingOnes() {
-        // Arrange
-        val ctx = DefaultCommandContext(event)
-        val userDto = mockk<database.dto.UserDto>()
-        val deleteDelay = 0
-
-        // Mock the behavior of the excuseService when listing approved guild excuses
-        val optionMapping = mockk<OptionMapping>()
-        every { event.options } returns listOf(optionMapping)
-        every { event.getOption("action") } returns optionMapping
-        every { optionMapping.asString } returns "pending"
-        every { excuseService.listPendingGuildExcuses(any()) } returns emptyList<ExcuseDto>()
-
-        // Act
-        excuseCommand.handle(ctx, userDto, deleteDelay)
-
-        // Assert
-        verify { event.hook.sendMessage("There are no excuses pending approval, consider submitting some.") }
-    }
-
-    @Test
-    fun deleteExcuse_asValidUser() {
-        // Arrange
-        val ctx = DefaultCommandContext(event)
-        val userDto = mockk<database.dto.UserDto>()
-        val deleteDelay = 0
-        val excuseToBeReturnedByUpdate = ExcuseDto(1, 1L, "UserName", "Excuse 1", true)
-        val excuseMapping = mockk<OptionMapping>()
-        val actionMapping = mockk<OptionMapping>()
-        every { event.getOption("id") } returns excuseMapping
-        every { event.getOption("action") } returns actionMapping
-        every { event.options } returns listOf(excuseMapping)
-        every { userDto.superUser } returns true
-        every { excuseMapping.asLong } returns 1
-        every { actionMapping.asString } returns "delete"
-        every { excuseService.deleteExcuseById(1L) } just Runs
-
-        // Act
-        excuseCommand.handle(ctx, userDto, deleteDelay)
-
-        // Assert
-        verify {
-            excuseService.deleteExcuseById(any())
-            event.hook.sendMessage("Deleted excuse with id '${excuseToBeReturnedByUpdate.id}'.")
-        }
-    }
-
-    @Test
-    fun deleteExcuse_asInvalidUser() {
-        // Arrange
-        val ctx = DefaultCommandContext(event)
-        val userDto = mockk<database.dto.UserDto>()
-        val deleteDelay = 0
-        val preUpdatedExcuse = ExcuseDto(1, 1L, "UserName", "Excuse 1", false)
-        val excuseToBeReturnedByUpdate = ExcuseDto(1, 1L, "UserName", "Excuse 1", true)
-        val excuseMapping = mockk<OptionMapping>()
-        val actionMapping = mockk<OptionMapping>()
-        every { event.getOption("id") } returns excuseMapping
-        every { event.getOption("action") } returns actionMapping
-        every { event.options } returns listOf(excuseMapping)
-        every { userDto.superUser } returns false
-        every { excuseMapping.asInt } returns 1
-        every { actionMapping.asString } returns "delete"
         every { CommandTest.guild.owner } returns CommandTest.member
-        every { CommandTest.member.effectiveName } returns "Effective Name"
-        every { excuseService.getExcuseById(1) } returns preUpdatedExcuse
-        every { excuseService.updateExcuse(any()) } returns excuseToBeReturnedByUpdate
+        every { CommandTest.member.effectiveName } returns "OwnerName"
 
-        // Act
-        excuseCommand.handle(ctx, userDto, deleteDelay)
+        excuseCommand.handle(ctx, requestingUserDto, 0)
 
-        // Assert
         verify {
-            event.hook.sendMessageFormat("You do not have adequate permissions to use this command, if you believe this is a mistake talk to Effective Name")
+            event.hook.sendMessageFormat(
+                "You do not have adequate permissions to use this command, if you believe this is a mistake talk to OwnerName"
+            )
         }
-        verify(exactly = 0) { excuseService.deleteExcuseById(1) }
+        verify(exactly = 0) { excuseService.approveExcuse(any()) }
+    }
+
+    @Test
+    fun `approve of already-approved row returns the heard-it-before message`() {
+        val ctx = DefaultCommandContext(event)
+        val alreadyApproved = ExcuseDto(id = 5L, guildId = 1L, author = "Alice", excuse = "rain delay", approved = true)
+        val idOption = mockk<OptionMapping> { every { asLong } returns 5L }
+        every { event.subcommandName } returns ExcuseCommand.APPROVE
+        every { event.getOption("id") } returns idOption
+        every { requestingUserDto.superUser } returns true
+        every { excuseService.getExcuseById(5L) } returns alreadyApproved
+
+        excuseCommand.handle(ctx, requestingUserDto, 0)
+
+        verify { event.hook.sendMessage(ExcuseCommand.EXISTING_EXCUSE_MESSAGE) }
+        verify(exactly = 0) { excuseService.approveExcuse(any()) }
+    }
+
+    // /excuse delete
+
+    @Test
+    fun `delete as superuser succeeds`() {
+        val ctx = DefaultCommandContext(event)
+        val idOption = mockk<OptionMapping> { every { asLong } returns 5L }
+        every { event.subcommandName } returns ExcuseCommand.DELETE
+        every { event.getOption("id") } returns idOption
+        every { requestingUserDto.superUser } returns true
+        every { excuseService.deleteExcuseById(5L) } just Runs
+
+        excuseCommand.handle(ctx, requestingUserDto, 0)
+
+        verify {
+            excuseService.deleteExcuseById(5L)
+            event.hook.sendMessage("Deleted excuse with id '5'.")
+        }
+    }
+
+    @Test
+    fun `delete as author of own pending excuse succeeds`() {
+        val ctx = DefaultCommandContext(event)
+        val idOption = mockk<OptionMapping> { every { asLong } returns 5L }
+        every { event.subcommandName } returns ExcuseCommand.DELETE
+        every { event.getOption("id") } returns idOption
+        every { requestingUserDto.superUser } returns false
+        every { excuseService.canRequesterDeleteOwnPending(5L, 1L) } returns true
+
+        excuseCommand.handle(ctx, requestingUserDto, 0)
+
+        verify {
+            excuseService.deleteExcuseById(5L)
+            event.hook.sendMessage("Deleted excuse with id '5'.")
+        }
+    }
+
+    @Test
+    fun `delete by random user is denied`() {
+        val ctx = DefaultCommandContext(event)
+        val idOption = mockk<OptionMapping> { every { asLong } returns 5L }
+        every { event.subcommandName } returns ExcuseCommand.DELETE
+        every { event.getOption("id") } returns idOption
+        every { requestingUserDto.superUser } returns false
+        every { excuseService.canRequesterDeleteOwnPending(5L, 1L) } returns false
+        every { CommandTest.guild.owner } returns CommandTest.member
+        every { CommandTest.member.effectiveName } returns "OwnerName"
+
+        excuseCommand.handle(ctx, requestingUserDto, 0)
+
+        verify {
+            event.hook.sendMessageFormat(
+                "You do not have adequate permissions to use this command, if you believe this is a mistake talk to OwnerName"
+            )
+        }
+        verify(exactly = 0) { excuseService.deleteExcuseById(any()) }
+    }
+
+    // /excuse list
+
+    @Test
+    fun `list approved with no results sends empty message`() {
+        val ctx = DefaultCommandContext(event)
+        every { event.subcommandName } returns ExcuseCommand.LIST
+        every { event.getOption("scope") } returns null
+        every { event.getOption("page") } returns null
+        every {
+            excuseService.listApprovedPaged(1L, 1, ExcuseCommand.EXCUSES_PER_PAGE)
+        } returns PagedExcuses(emptyList(), 1, ExcuseCommand.EXCUSES_PER_PAGE, 0L)
+
+        excuseCommand.handle(ctx, requestingUserDto, 0)
+
+        verify { event.hook.sendMessage("There are no approved excuses, consider submitting some.") }
+    }
+
+    @Test
+    fun `list pending is denied for non-superusers`() {
+        val ctx = DefaultCommandContext(event)
+        val scopeOption = mockk<OptionMapping> { every { asString } returns ExcuseCommand.SCOPE_PENDING }
+        every { event.subcommandName } returns ExcuseCommand.LIST
+        every { event.getOption("scope") } returns scopeOption
+        every { event.getOption("page") } returns null
+        every { requestingUserDto.superUser } returns false
+        every { CommandTest.guild.owner } returns CommandTest.member
+        every { CommandTest.member.effectiveName } returns "OwnerName"
+
+        excuseCommand.handle(ctx, requestingUserDto, 0)
+
+        verify {
+            event.hook.sendMessageFormat(
+                "You do not have adequate permissions to use this command, if you believe this is a mistake talk to OwnerName"
+            )
+        }
+        verify(exactly = 0) { excuseService.listPendingPaged(any(), any(), any()) }
+    }
+
+    @Test
+    fun `list approved with rows sends an embed reply`() {
+        val ctx = DefaultCommandContext(event)
+        every { event.subcommandName } returns ExcuseCommand.LIST
+        every { event.getOption("scope") } returns null
+        every { event.getOption("page") } returns null
+        every {
+            excuseService.listApprovedPaged(1L, 1, ExcuseCommand.EXCUSES_PER_PAGE)
+        } returns PagedExcuses(
+            rows = listOf(
+                ExcuseDto(id = 1L, guildId = 1L, author = "Alice", excuse = "rain", approved = true),
+                ExcuseDto(id = 2L, guildId = 1L, author = "Bob", excuse = "snow", approved = true),
+            ),
+            page = 1,
+            pageSize = ExcuseCommand.EXCUSES_PER_PAGE,
+            totalCount = 2L,
+        )
+
+        excuseCommand.handle(ctx, requestingUserDto, 0)
+
+        // 2 rows fit on one page so the embed-and-delete shortcut fires.
+        verify { event.hook.sendMessageEmbeds(any<net.dv8tion.jda.api.entities.MessageEmbed>(), *anyVararg()) }
+    }
+
+    // /excuse search
+
+    @Test
+    fun `search with empty query complains`() {
+        val ctx = DefaultCommandContext(event)
+        val queryOption = mockk<OptionMapping> { every { asString } returns "   " }
+        every { event.subcommandName } returns ExcuseCommand.SEARCH
+        every { event.getOption("query") } returns queryOption
+        every { event.getOption("page") } returns null
+
+        excuseCommand.handle(ctx, requestingUserDto, 0)
+
+        verify { event.hook.sendMessage("Provide a search query.") }
+        verify(exactly = 0) { excuseService.searchApproved(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `search empty results returns query-aware message`() {
+        val ctx = DefaultCommandContext(event)
+        val queryOption = mockk<OptionMapping> { every { asString } returns "alpaca" }
+        every { event.subcommandName } returns ExcuseCommand.SEARCH
+        every { event.getOption("query") } returns queryOption
+        every { event.getOption("page") } returns null
+        every {
+            excuseService.searchApproved(1L, "alpaca", 1, ExcuseCommand.EXCUSES_PER_PAGE)
+        } returns PagedExcuses(emptyList(), 1, ExcuseCommand.EXCUSES_PER_PAGE, 0L)
+
+        excuseCommand.handle(ctx, requestingUserDto, 0)
+
+        verify { event.hook.sendMessage("No approved excuses match 'alpaca'.") }
+    }
+
+    // round-trip on the page-button id encoder/decoder
+
+    @Test
+    fun `encodePageButton round-trips through decodePageButton`() {
+        val encoded = ExcuseCommand.encodePageButton(
+            scope = ExcuseCommand.SCOPE_SEARCH,
+            guildId = 42L,
+            page = 3,
+            query = "tricky:value with spaces",
+        )
+        val decoded = ExcuseCommand.decodePageButton(encoded)!!
+        assert(decoded.scope == ExcuseCommand.SCOPE_SEARCH)
+        assert(decoded.guildId == 42L)
+        assert(decoded.page == 3)
+        assert(decoded.query == "tricky:value with spaces")
+    }
+
+    @Test
+    fun `decodePageButton returns null for unrelated component ids`() {
+        assert(ExcuseCommand.decodePageButton("init:next") == null)
+        assert(ExcuseCommand.decodePageButton("excuse-page:noop") == null)
+        assert(ExcuseCommand.decodePageButton("excuse-page:approved:notanumber:1:") == null)
     }
 }

--- a/web/src/main/kotlin/web/controller/ExcuseWebController.kt
+++ b/web/src/main/kotlin/web/controller/ExcuseWebController.kt
@@ -1,0 +1,167 @@
+package web.controller
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient
+import org.springframework.security.oauth2.client.annotation.RegisteredOAuth2AuthorizedClient
+import org.springframework.security.oauth2.core.user.OAuth2User
+import org.springframework.stereotype.Controller
+import org.springframework.ui.Model
+import org.springframework.web.bind.annotation.*
+import org.springframework.web.servlet.mvc.support.RedirectAttributes
+import web.service.ExcuseWebService
+import web.util.WebGuildAccess
+import web.util.discordIdOrNull
+import web.util.discordIdString
+import web.util.displayName
+
+@Controller
+@RequestMapping("/excuses")
+class ExcuseWebController(
+    private val excuseWebService: ExcuseWebService,
+    @param:Value($$"${spring.security.oauth2.client.registration.discord.client-id}")
+    private val discordClientId: String,
+) {
+    private val inviteUrl: String
+        get() = web.util.DiscordInvite.urlFor(discordClientId)
+
+    @GetMapping("/guilds")
+    fun guildList(
+        @RegisteredOAuth2AuthorizedClient("discord") client: OAuth2AuthorizedClient,
+        @AuthenticationPrincipal user: OAuth2User,
+        model: Model,
+    ): String {
+        val guilds = excuseWebService.getMutualGuilds(client.accessToken.tokenValue)
+        val counts = excuseWebService.getApprovedCountsForGuilds(guilds.map { it.id.toLong() })
+            .mapKeys { it.key.toString() }
+
+        model.addAttribute("guilds", guilds)
+        model.addAttribute("approvedCounts", counts)
+        model.addAttribute("username", user.displayName())
+        model.addAttribute("discordId", user.discordIdString())
+        model.addAttribute("inviteUrl", inviteUrl)
+        return "excuse-guilds"
+    }
+
+    @GetMapping("/{guildId}")
+    fun page(
+        @PathVariable guildId: Long,
+        @RequestParam(required = false, defaultValue = ExcuseWebService.TAB_APPROVED) tab: String,
+        @RequestParam(required = false) q: String?,
+        @RequestParam(required = false, defaultValue = "1") page: Int,
+        @AuthenticationPrincipal user: OAuth2User,
+        model: Model,
+        ra: RedirectAttributes,
+    ): String = WebGuildAccess.requireSignedInForPage(user, "/excuses/guilds") { authDiscordId ->
+        val guildName = excuseWebService.getGuildName(guildId) ?: run {
+            ra.addFlashAttribute("error", "Bot is not in that server.")
+            return@requireSignedInForPage "redirect:/excuses/guilds"
+        }
+
+        val view = excuseWebService.getPage(guildId, tab, q, page, authDiscordId)
+        val members = if (view.isSuperUser) excuseWebService.getGuildMembers(guildId) else emptyList()
+
+        model.addAttribute("guildId", guildId)
+        model.addAttribute("guildName", guildName)
+        model.addAttribute("rows", view.rows)
+        model.addAttribute("page", view.page)
+        model.addAttribute("totalPages", view.totalPages)
+        model.addAttribute("totalCount", view.totalCount)
+        model.addAttribute("hasPrev", view.hasPrev)
+        model.addAttribute("hasNext", view.hasNext)
+        model.addAttribute("activeTab", view.requestedTab)
+        model.addAttribute("query", view.query)
+        model.addAttribute("isSuperUser", view.isSuperUser)
+        model.addAttribute("members", members)
+        model.addAttribute("maxLength", ExcuseWebService.MAX_EXCUSE_LENGTH)
+        model.addAttribute("username", user.displayName())
+        "excuses"
+    }
+
+    @GetMapping("/{guildId}/random")
+    @ResponseBody
+    fun random(
+        @PathVariable guildId: Long,
+        @AuthenticationPrincipal user: OAuth2User,
+    ): ResponseEntity<RandomResponse> = WebGuildAccess.requireSignedInForJson(
+        user, notSignedInRandom,
+    ) { _ ->
+        val pick = excuseWebService.getRandomApproved(guildId)
+        if (pick == null) {
+            ResponseEntity.ok(RandomResponse(ok = false, error = "There are no approved excuses yet."))
+        } else {
+            ResponseEntity.ok(RandomResponse(ok = true, id = pick.id, text = pick.text, author = pick.author))
+        }
+    }
+
+    @PostMapping("/{guildId}/submit")
+    fun submit(
+        @PathVariable guildId: Long,
+        @RequestParam text: String,
+        @RequestParam(required = false) authorDiscordId: Long?,
+        @RequestParam(required = false) tab: String?,
+        @RequestParam(required = false) q: String?,
+        @AuthenticationPrincipal user: OAuth2User,
+        ra: RedirectAttributes,
+    ): String = WebGuildAccess.requireSignedInForPage(user, "/excuses/guilds") { authDiscordId2 ->
+        val result = excuseWebService.submit(guildId, text, authorDiscordId, authDiscordId2)
+        if (result.ok) {
+            ra.addFlashAttribute("success", "Submitted for approval (id #${result.id}).")
+        } else {
+            ra.addFlashAttribute("error", result.error)
+        }
+        redirectToPage(guildId, tab, q)
+    }
+
+    @PostMapping("/{guildId}/{id}/approve")
+    @ResponseBody
+    fun approve(
+        @PathVariable guildId: Long,
+        @PathVariable id: Long,
+        @AuthenticationPrincipal user: OAuth2User,
+    ): ResponseEntity<ExcuseApiResult> = WebGuildAccess.requireSignedInForJson(
+        user, notSignedInApi,
+    ) { authDiscordId ->
+        val error = excuseWebService.approve(id, authDiscordId, guildId)
+        if (error != null) ResponseEntity.badRequest().body(ExcuseApiResult(false, error))
+        else ResponseEntity.ok(ExcuseApiResult(true, null))
+    }
+
+    @PostMapping("/{guildId}/{id}/delete")
+    @ResponseBody
+    fun delete(
+        @PathVariable guildId: Long,
+        @PathVariable id: Long,
+        @AuthenticationPrincipal user: OAuth2User,
+    ): ResponseEntity<ExcuseApiResult> = WebGuildAccess.requireSignedInForJson(
+        user, notSignedInApi,
+    ) { authDiscordId ->
+        val error = excuseWebService.delete(id, authDiscordId, guildId)
+        if (error != null) ResponseEntity.badRequest().body(ExcuseApiResult(false, error))
+        else ResponseEntity.ok(ExcuseApiResult(true, null))
+    }
+
+    private val notSignedInApi: () -> ExcuseApiResult = { ExcuseApiResult(false, "Not signed in.") }
+    private val notSignedInRandom: () -> RandomResponse = {
+        RandomResponse(ok = false, error = "Not signed in.")
+    }
+
+    private fun redirectToPage(guildId: Long, tab: String?, q: String?): String {
+        val params = mutableListOf<String>()
+        if (!tab.isNullOrBlank()) params += "tab=$tab"
+        if (!q.isNullOrBlank()) params += "q=${java.net.URLEncoder.encode(q, Charsets.UTF_8)}"
+        val suffix = if (params.isEmpty()) "" else "?" + params.joinToString("&")
+        return "redirect:/excuses/$guildId$suffix"
+    }
+}
+
+data class ExcuseApiResult(val ok: Boolean, val error: String?)
+
+data class RandomResponse(
+    val ok: Boolean,
+    val id: Long? = null,
+    val text: String? = null,
+    val author: String? = null,
+    val error: String? = null,
+)

--- a/web/src/main/kotlin/web/service/ExcuseWebService.kt
+++ b/web/src/main/kotlin/web/service/ExcuseWebService.kt
@@ -1,0 +1,201 @@
+package web.service
+
+import database.dto.ExcuseDto
+import database.service.ExcuseService
+import database.service.PagedExcuses
+import database.service.UserService
+import net.dv8tion.jda.api.JDA
+import org.springframework.stereotype.Service
+import java.time.Instant
+
+@Service
+class ExcuseWebService(
+    private val excuseService: ExcuseService,
+    private val userService: UserService,
+    private val jda: JDA,
+    private val introWebService: IntroWebService,
+) {
+    companion object {
+        const val PAGE_SIZE = 12
+        const val MAX_EXCUSE_LENGTH = 200
+        const val TAB_APPROVED = "approved"
+        const val TAB_PENDING = "pending"
+    }
+
+    // Reuse Intros' Discord-API guild fetch — both pages need the same
+    // /users/@me/guilds → mutual-guild filter and the same 60s cache.
+    fun getMutualGuilds(accessToken: String): List<GuildInfo> =
+        introWebService.getMutualGuilds(accessToken)
+
+    fun getGuildName(guildId: Long): String? = jda.getGuildById(guildId)?.name
+
+    fun isSuperUser(discordId: Long, guildId: Long): Boolean =
+        userService.getUserById(discordId, guildId)?.superUser == true
+
+    fun getGuildMembers(guildId: Long): List<MemberInfo> {
+        val guild = jda.getGuildById(guildId) ?: return emptyList()
+        return guild.members
+            .filter { !it.user.isBot }
+            .map { MemberInfo(it.id, it.effectiveName, it.effectiveAvatarUrl) }
+            .sortedBy { it.name.lowercase() }
+    }
+
+    fun getApprovedCountsForGuilds(guildIds: List<Long>): Map<Long, Int> =
+        guildIds.associateWith { excuseService.countApproved(it).toInt() }
+
+    /**
+     * Return a page of excuses for the given guild + tab + (optional) query.
+     * The pending tab is gated to superusers; non-superusers asking for
+     * pending are silently downgraded to the approved tab, with
+     * [ExcusePageViewModel.requestedTab] set to "approved" so the template
+     * doesn't show stale tab state.
+     */
+    fun getPage(
+        guildId: Long,
+        tab: String,
+        query: String?,
+        page: Int,
+        requesterDiscordId: Long,
+    ): ExcusePageViewModel {
+        val isSuper = isSuperUser(requesterDiscordId, guildId)
+        val effectiveTab = if (tab == TAB_PENDING && !isSuper) TAB_APPROVED else tab
+
+        val paged: PagedExcuses = when {
+            effectiveTab == TAB_PENDING -> excuseService.listPendingPaged(guildId, page, PAGE_SIZE)
+            !query.isNullOrBlank() -> excuseService.searchApproved(guildId, query.trim(), page, PAGE_SIZE)
+            else -> excuseService.listApprovedPaged(guildId, page, PAGE_SIZE)
+        }
+
+        val rows = paged.rows.map { it.toRowViewModel(requesterDiscordId, isSuper) }
+
+        return ExcusePageViewModel(
+            rows = rows,
+            page = paged.page,
+            totalPages = paged.totalPages,
+            totalCount = paged.totalCount,
+            isSuperUser = isSuper,
+            requestedTab = effectiveTab,
+            query = query?.trim(),
+        )
+    }
+
+    fun getRandomApproved(guildId: Long): RandomExcuseViewModel? {
+        val pick = excuseService.listApprovedGuildExcuses(guildId).filterNotNull().randomOrNull()
+            ?: return null
+        return RandomExcuseViewModel(
+            id = pick.id ?: 0L,
+            text = pick.excuse.orEmpty(),
+            author = pick.author.orEmpty(),
+        )
+    }
+
+    /**
+     * Submit a new pending excuse. Author override is honoured only when
+     * the requester is a superuser.
+     */
+    fun submit(
+        guildId: Long,
+        text: String,
+        authorOverrideDiscordId: Long?,
+        requesterDiscordId: Long,
+    ): SubmitResult {
+        val trimmed = text.trim()
+        if (trimmed.isEmpty()) return SubmitResult(error = "Provide some excuse text.")
+        if (trimmed.length > MAX_EXCUSE_LENGTH) {
+            return SubmitResult(error = "Excuse is too long (max $MAX_EXCUSE_LENGTH characters).")
+        }
+
+        val isSuper = isSuperUser(requesterDiscordId, guildId)
+        val authorDiscordId = if (isSuper) authorOverrideDiscordId ?: requesterDiscordId else requesterDiscordId
+        val guild = jda.getGuildById(guildId)
+        val authorName = guild?.getMemberById(authorDiscordId)?.effectiveName
+            ?: jda.getUserById(authorDiscordId)?.name
+            ?: "Unknown"
+
+        val existing = excuseService.listAllGuildExcuses(guildId)
+            .filterNotNull()
+            .firstOrNull { it.excuse.equals(trimmed, ignoreCase = true) }
+        if (existing != null) return SubmitResult(error = "That excuse already exists for this server.")
+
+        val saved = excuseService.createNewExcuse(
+            ExcuseDto(
+                guildId = guildId,
+                author = authorName,
+                excuse = trimmed,
+                approved = false,
+                authorDiscordId = authorDiscordId,
+            )
+        )
+        return SubmitResult(id = saved?.id)
+    }
+
+    fun approve(id: Long, requesterDiscordId: Long, guildId: Long): String? {
+        if (!isSuperUser(requesterDiscordId, guildId)) return "You don't have permission to approve excuses."
+        val existing = excuseService.getExcuseById(id) ?: return "Excuse not found."
+        if (existing.guildId != guildId) return "Excuse not found."
+        if (existing.approved) return null
+        excuseService.approveExcuse(id) ?: return "Excuse not found."
+        return null
+    }
+
+    fun delete(id: Long, requesterDiscordId: Long, guildId: Long): String? {
+        val existing = excuseService.getExcuseById(id) ?: return "Excuse not found."
+        if (existing.guildId != guildId) return "Excuse not found."
+
+        val isSuper = isSuperUser(requesterDiscordId, guildId)
+        val ownsPending = !existing.approved && existing.authorDiscordId == requesterDiscordId
+        if (!isSuper && !ownsPending) return "You don't have permission to delete that excuse."
+
+        excuseService.deleteExcuseById(id)
+        return null
+    }
+
+    private fun ExcuseDto.toRowViewModel(requesterDiscordId: Long, isSuper: Boolean): ExcuseRowViewModel {
+        val isAuthor = authorDiscordId != null && authorDiscordId == requesterDiscordId
+        val canDelete = isSuper || (!approved && isAuthor)
+        val canApprove = isSuper && !approved
+        return ExcuseRowViewModel(
+            id = id ?: 0L,
+            text = excuse.orEmpty(),
+            author = author.orEmpty(),
+            approved = approved,
+            createdAt = createdAt,
+            approvedAt = approvedAt,
+            isAuthor = isAuthor,
+            canDelete = canDelete,
+            canApprove = canApprove,
+        )
+    }
+
+}
+
+data class ExcuseRowViewModel(
+    val id: Long,
+    val text: String,
+    val author: String,
+    val approved: Boolean,
+    val createdAt: Instant?,
+    val approvedAt: Instant?,
+    val isAuthor: Boolean,
+    val canDelete: Boolean,
+    val canApprove: Boolean,
+)
+
+data class ExcusePageViewModel(
+    val rows: List<ExcuseRowViewModel>,
+    val page: Int,
+    val totalPages: Int,
+    val totalCount: Long,
+    val isSuperUser: Boolean,
+    val requestedTab: String,
+    val query: String?,
+) {
+    val hasPrev: Boolean get() = page > 1
+    val hasNext: Boolean get() = page < totalPages
+}
+
+data class RandomExcuseViewModel(val id: Long, val text: String, val author: String)
+
+data class SubmitResult(val id: Long? = null, val error: String? = null) {
+    val ok: Boolean get() = error == null
+}

--- a/web/src/main/resources/static/css/excuses.css
+++ b/web/src/main/resources/static/css/excuses.css
@@ -1,0 +1,281 @@
+/* Excuses page — finder, list, maker. Built on the same CSS variables
+   as the rest of the site so theme tweaks propagate automatically. */
+
+/* ------------------------------ Guild picker ------------------------------ */
+/* Re-use the shared guild grid layout from guilds.html — these styles are
+   the per-page tweaks (different count badge color than the intro page). */
+.guild-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(210px, 1fr));
+    gap: var(--space-4);
+}
+.guild-card {
+    position: relative;
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    padding: var(--space-5);
+    text-align: center;
+    text-decoration: none;
+    color: var(--text);
+    transition: border-color 0.15s, transform 0.1s;
+    display: block;
+}
+.guild-card:hover { border-color: var(--accent); transform: translateY(-2px); color: var(--text); }
+.guild-icon, .guild-icon-placeholder {
+    width: 64px; height: 64px; border-radius: 50%;
+    margin: 0 auto 12px; display: block;
+}
+.guild-icon-placeholder {
+    background: var(--accent);
+    color: #fff;
+    font-size: 1.5rem; font-weight: 700;
+    display: flex; align-items: center; justify-content: center;
+}
+.guild-name {
+    font-weight: 600; font-size: 0.95rem;
+    overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.guild-count {
+    position: absolute;
+    top: 10px; right: 10px;
+    background: var(--border);
+    color: var(--text-muted);
+    font-size: 0.7rem;
+    padding: 3px 8px;
+    border-radius: 999px;
+    font-weight: 600;
+}
+.guild-count.has-rows { background: var(--accent-soft); color: var(--accent); }
+
+.search-row {
+    display: flex;
+    gap: var(--space-3);
+    margin-bottom: var(--space-5);
+    align-items: center;
+}
+.search-row input { flex: 1; max-width: 420px; }
+.no-results { color: var(--text-muted); padding: 24px; text-align: center; display: none; }
+
+/* ------------------------------ Header ------------------------------ */
+.excuse-header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: var(--space-4);
+    margin-bottom: var(--space-5);
+    flex-wrap: wrap;
+}
+.excuse-count {
+    background: var(--accent-soft);
+    color: var(--accent);
+    padding: 4px 12px;
+    border-radius: 999px;
+    font-size: 0.85rem;
+    font-weight: 600;
+}
+
+/* ------------------------------ Finder card ------------------------------ */
+.finder-card {
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    padding: var(--space-6);
+    margin-bottom: var(--space-6);
+}
+.finder-card h2 { margin-top: 0; }
+.finder-controls {
+    display: flex;
+    gap: var(--space-3);
+    align-items: center;
+    flex-wrap: wrap;
+    margin-top: var(--space-4);
+}
+.btn-spin {
+    font-size: 1rem;
+    padding: 10px 20px;
+    background: var(--accent);
+    color: #fff;
+    border: 0;
+    border-radius: var(--radius-md);
+    cursor: pointer;
+    transition: background 0.15s, transform 0.05s;
+}
+.btn-spin:hover { background: var(--accent-hover); }
+.btn-spin:active { transform: scale(0.97); }
+.btn-spin.spinning { opacity: 0.7; pointer-events: none; }
+.finder-search {
+    display: flex;
+    gap: var(--space-2);
+    align-items: center;
+    flex: 1;
+    min-width: 260px;
+}
+.finder-search input[type="search"] { flex: 1; min-width: 0; }
+.random-result {
+    margin-top: var(--space-5);
+    background: var(--accent-soft);
+    border-left: 3px solid var(--accent);
+    padding: var(--space-4) var(--space-5);
+    border-radius: var(--radius-md);
+}
+.random-quote { margin: 0; }
+.quote-text {
+    display: block;
+    font-size: 1.15rem;
+    font-style: italic;
+    margin-bottom: var(--space-2);
+}
+.random-quote footer { color: var(--text-muted); font-size: 0.9rem; }
+
+/* ------------------------------ Tabs ------------------------------ */
+.tabs-row {
+    display: flex;
+    gap: var(--space-2);
+    margin-bottom: var(--space-4);
+    border-bottom: 1px solid var(--border);
+}
+.tab {
+    padding: 10px 18px;
+    text-decoration: none;
+    color: var(--text-muted);
+    font-weight: 600;
+    border-bottom: 2px solid transparent;
+    margin-bottom: -1px;
+    transition: color 0.12s, border-color 0.12s;
+}
+.tab:hover { color: var(--text); }
+.tab.active {
+    color: var(--accent);
+    border-bottom-color: var(--accent);
+}
+
+/* ------------------------------ Excuse list ------------------------------ */
+.excuse-list { margin-bottom: var(--space-6); }
+.excuse-cards {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: var(--space-3);
+}
+.excuse-card {
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    padding: var(--space-4) var(--space-5);
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: var(--space-2) var(--space-4);
+    align-items: start;
+    transition: border-color 0.15s, opacity 0.3s;
+}
+.excuse-card.removing { opacity: 0; transform: translateX(20px); }
+.excuse-card.pending { border-left: 3px solid var(--accent); }
+.excuse-text {
+    grid-column: 1 / 2;
+    font-size: 1rem;
+    line-height: 1.4;
+    color: var(--text);
+}
+.excuse-meta {
+    grid-column: 1 / 2;
+    display: flex;
+    gap: var(--space-3);
+    align-items: center;
+    flex-wrap: wrap;
+    color: var(--text-muted);
+    font-size: 0.85rem;
+}
+.excuse-author { color: var(--text); font-weight: 600; }
+.excuse-id { color: var(--text-dim); }
+.excuse-state {
+    background: var(--success-bg);
+    color: var(--success);
+    padding: 2px 8px;
+    border-radius: 999px;
+    font-size: 0.75rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+.excuse-state.pending {
+    background: var(--accent-soft);
+    color: var(--accent);
+}
+.excuse-actions {
+    grid-column: 2 / 3;
+    grid-row: 1 / 3;
+    display: flex;
+    gap: var(--space-2);
+    align-items: flex-start;
+}
+
+/* ------------------------------ Pager ------------------------------ */
+.pager {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: var(--space-4);
+    margin-top: var(--space-5);
+}
+.pager .disabled {
+    pointer-events: none;
+    opacity: 0.45;
+}
+.pager-info {
+    color: var(--text-muted);
+    font-size: 0.9rem;
+    min-width: 120px;
+    text-align: center;
+}
+
+/* ------------------------------ Maker card ------------------------------ */
+.maker-card {
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    padding: var(--space-6);
+}
+.maker-card h2 { margin-top: 0; }
+.maker-form {
+    display: grid;
+    gap: var(--space-4);
+    margin-top: var(--space-4);
+}
+.maker-form textarea {
+    resize: vertical;
+    min-height: 56px;
+    font-family: inherit;
+    line-height: 1.4;
+}
+.char-counter {
+    font-size: 0.8rem;
+    color: var(--text-dim);
+    margin-top: 4px;
+}
+.char-counter.over { color: var(--danger); font-weight: 600; }
+
+/* ------------------------------ Empty state ------------------------------ */
+.empty-hero {
+    background: var(--bg-elevated);
+    border: 1px dashed var(--border-strong);
+    border-radius: var(--radius-lg);
+    padding: 48px 24px;
+    text-align: center;
+    color: var(--text-muted);
+}
+.empty-hero .emoji { font-size: 2.4rem; display: block; margin-bottom: 12px; }
+.empty-hero h2 { color: var(--text); margin-bottom: 10px; }
+
+/* ------------------------------ Responsive ------------------------------ */
+@media (max-width: 600px) {
+    .guild-grid { grid-template-columns: 1fr; gap: 12px; }
+    .guild-card { padding: 14px 16px; }
+    .excuse-header { flex-direction: column; align-items: stretch; }
+    .finder-controls { flex-direction: column; align-items: stretch; }
+    .btn-spin { width: 100%; }
+    .finder-search { width: 100%; }
+    .excuse-card { grid-template-columns: 1fr; }
+    .excuse-actions { grid-column: 1 / 2; grid-row: auto; }
+}

--- a/web/src/main/resources/static/js/excuses.js
+++ b/web/src/main/resources/static/js/excuses.js
@@ -1,0 +1,110 @@
+// Excuses page interactivity — spin, approve, delete, char-counter.
+// Mutating actions go through TobyApi.postJson (CSRF-aware); the spin
+// endpoint is a GET so it uses plain fetch.
+
+(function () {
+    'use strict';
+
+    function $(sel, el) { return (el || document).querySelector(sel); }
+
+    // ---- Char counter on the maker textarea ----
+    const textarea = $('#excuseText');
+    const counter = $('#charCount');
+    if (textarea && counter) {
+        const max = parseInt(textarea.getAttribute('maxlength') || '200', 10);
+        function refresh() {
+            const len = textarea.value.length;
+            counter.textContent = String(len);
+            counter.parentElement.classList.toggle('over', len > max);
+        }
+        textarea.addEventListener('input', refresh);
+        refresh();
+    }
+
+    // ---- Spin random excuse ----
+    const spinBtn = $('#spinBtn');
+    if (spinBtn) {
+        const result = $('#randomResult');
+        const textEl = $('#randomText');
+        const authorEl = $('#randomAuthor');
+        const idEl = $('#randomId');
+        spinBtn.addEventListener('click', function () {
+            const url = spinBtn.dataset.randomUrl;
+            if (!url) return;
+            spinBtn.classList.add('spinning');
+            fetch(url, { credentials: 'same-origin', headers: { 'Accept': 'application/json' } })
+                .then(r => r.json())
+                .then(json => {
+                    if (json && json.ok) {
+                        textEl.textContent = json.text || '';
+                        authorEl.textContent = json.author || '';
+                        idEl.textContent = (json.id != null) ? String(json.id) : '';
+                        result.hidden = false;
+                    } else {
+                        const msg = (json && json.error) || 'No excuses available.';
+                        if (window.TobyToasts) window.TobyToasts.info(msg);
+                        result.hidden = true;
+                    }
+                })
+                .catch(() => {
+                    if (window.TobyToasts) window.TobyToasts.error('Could not fetch an excuse.');
+                })
+                .finally(() => spinBtn.classList.remove('spinning'));
+        });
+    }
+
+    // ---- Approve / Delete buttons on each row ----
+    document.addEventListener('click', function (ev) {
+        const btn = ev.target.closest('button[data-action]');
+        if (!btn) return;
+        const action = btn.dataset.action;
+        const url = btn.dataset.url;
+        if (!url) return;
+
+        if (action === 'delete') {
+            const confirmed = window.confirm('Delete this excuse?');
+            if (!confirmed) return;
+        }
+
+        btn.disabled = true;
+        const promise = window.TobyApi
+            ? window.TobyApi.postJson(url, {})
+            : fetch(url, { method: 'POST', credentials: 'same-origin' }).then(r => r.json());
+
+        promise.then(json => {
+            if (json && json.ok) {
+                const card = btn.closest('.excuse-card');
+                if (action === 'delete' && card) {
+                    card.classList.add('removing');
+                    setTimeout(() => card.remove(), 250);
+                    if (window.TobyToasts) window.TobyToasts.success('Deleted.');
+                } else if (action === 'approve' && card) {
+                    if (window.TobyToasts) window.TobyToasts.success('Approved.');
+                    // The card's state (pending vs approved) depends on the
+                    // current tab, so reload the page rather than mutate
+                    // in-place — the approved version may need to move tabs.
+                    setTimeout(() => window.location.reload(), 400);
+                }
+            } else {
+                const msg = (json && json.error) || 'That action failed.';
+                if (window.TobyToasts) window.TobyToasts.error(msg);
+                btn.disabled = false;
+            }
+        }).catch(() => {
+            if (window.TobyToasts) window.TobyToasts.error('Request failed.');
+            btn.disabled = false;
+        });
+    });
+
+    // ---- Replay flash messages as toasts (mirrors intros.js behavior) ----
+    document.addEventListener('DOMContentLoaded', function () {
+        document.querySelectorAll('[data-flash]').forEach(function (node) {
+            const kind = node.dataset.flash;
+            const msg = node.textContent.trim();
+            if (!msg || !window.TobyToasts) return;
+            if (kind === 'success') window.TobyToasts.success(msg);
+            else if (kind === 'error') window.TobyToasts.error(msg);
+            else window.TobyToasts.info(msg);
+        });
+    });
+})();

--- a/web/src/main/resources/templates/excuse-guilds.html
+++ b/web/src/main/resources/templates/excuse-guilds.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="en">
+<head th:replace="~{fragments/head :: head('TobyBot - Excuses', '/css/excuses.css')}"></head>
+<body>
+<a href="#main" class="skip-link">Skip to content</a>
+<div th:replace="~{fragments/navbar :: navbar}"></div>
+
+<main id="main" class="container">
+    <h1 class="mb-3">Excuses</h1>
+    <p class="muted mb-5">Servers where both you and TobyBot are present. Pick one to browse or submit excuses.</p>
+
+    <div th:replace="~{fragments/alerts :: error}"></div>
+
+    <div class="search-row" th:if="${not #lists.isEmpty(guilds)}">
+        <input type="search" id="guildSearch" placeholder="Search servers…"
+               aria-label="Search servers" autocomplete="off">
+        <span class="muted" th:text="${#lists.size(guilds)} + ' server' + (${#lists.size(guilds)} == 1 ? '' : 's')">0 servers</span>
+    </div>
+
+    <div class="guild-grid" th:if="${not #lists.isEmpty(guilds)}" id="guildGrid">
+        <a class="guild-card"
+           th:each="guild : ${guilds}"
+           th:href="@{/excuses/{id}(id=${guild.id})}"
+           th:attr="data-guild-name=${#strings.toLowerCase(guild.name)}">
+            <span class="guild-count"
+                  th:with="count=${approvedCounts[guild.id] ?: 0}"
+                  th:classappend="${count > 0 ? ' has-rows' : ''}"
+                  th:text="${count} + ' approved'">0 approved</span>
+            <img th:if="${guild.iconUrl != null}"
+                 th:src="${guild.iconUrl}"
+                 th:alt="${guild.name} + ' icon'"
+                 class="guild-icon"
+                 onerror="this.style.display='none'">
+            <div th:unless="${guild.iconUrl != null}"
+                 class="guild-icon-placeholder"
+                 aria-hidden="true"
+                 th:text="${#strings.substring(guild.name, 0, 1).toUpperCase()}">G</div>
+            <div class="guild-name" th:text="${guild.name}" th:title="${guild.name}">Guild Name</div>
+        </a>
+    </div>
+
+    <p id="noResults" class="no-results">No servers match your search.</p>
+
+    <div class="empty-hero" th:if="${#lists.isEmpty(guilds)}">
+        <span class="emoji" aria-hidden="true">📭</span>
+        <h2>TobyBot isn't in any of your servers yet</h2>
+        <p class="mb-5">Invite the bot to get started.</p>
+        <a th:href="${inviteUrl}" class="btn" target="_blank" rel="noopener">Invite TobyBot</a>
+    </div>
+</main>
+
+<script>
+    (function () {
+        const search = document.getElementById('guildSearch');
+        const grid = document.getElementById('guildGrid');
+        const noResults = document.getElementById('noResults');
+        if (!search || !grid) return;
+        search.addEventListener('input', function () {
+            const q = search.value.trim().toLowerCase();
+            let visible = 0;
+            grid.querySelectorAll('.guild-card').forEach(card => {
+                const name = card.dataset.guildName || '';
+                const match = !q || name.indexOf(q) !== -1;
+                card.style.display = match ? '' : 'none';
+                if (match) visible++;
+            });
+            noResults.style.display = visible === 0 ? 'block' : 'none';
+        });
+    })();
+</script>
+<script th:src="@{/js/home.js}"></script>
+</body>
+</html>

--- a/web/src/main/resources/templates/excuses.html
+++ b/web/src/main/resources/templates/excuses.html
@@ -1,0 +1,165 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="en">
+<head th:replace="~{fragments/head :: head('TobyBot - Excuses · ' + ${guildName}, '/css/excuses.css')}"></head>
+<body th:attr="data-guild-id=${guildId}">
+
+<a href="#main" class="skip-link">Skip to content</a>
+<div th:replace="~{fragments/navbar :: navbar}"></div>
+
+<!-- Flash messages rendered invisibly; toasts.js picks them up on load -->
+<div th:if="${success}" data-flash="success" class="sr-only" th:text="${success}"></div>
+<div th:if="${error}" data-flash="error" class="sr-only" th:text="${error}"></div>
+
+<main id="main" class="container">
+
+    <div class="excuse-header">
+        <h1>Excuses — <span th:text="${guildName}">Server</span></h1>
+        <span class="excuse-count"
+              th:text="${totalCount} + ' total'">0 total</span>
+    </div>
+
+    <!-- Finder: spin a random approved excuse without reloading -->
+    <section class="finder-card" aria-labelledby="finder-h">
+        <h2 id="finder-h">Finder</h2>
+        <p class="muted">Spin for a random approved excuse, or search for something specific.</p>
+        <div class="finder-controls">
+            <button type="button" id="spinBtn" class="btn btn-spin"
+                    th:attr="data-random-url=@{/excuses/{gid}/random(gid=${guildId})}">🎲 Spin</button>
+            <form method="get" th:action="@{/excuses/{gid}(gid=${guildId})}" class="finder-search">
+                <input type="hidden" name="tab" th:value="${activeTab}">
+                <input type="search" name="q" th:value="${query}"
+                       placeholder="Search approved excuses…" aria-label="Search excuses">
+                <button type="submit" class="btn btn-sm">Search</button>
+                <a th:if="${query != null and query != ''}"
+                   th:href="@{/excuses/{gid}(gid=${guildId},tab=${activeTab})}"
+                   class="btn btn-sm btn-secondary">Clear</a>
+            </form>
+        </div>
+        <div id="randomResult" class="random-result" aria-live="polite" hidden>
+            <blockquote class="random-quote">
+                <span class="quote-text" id="randomText"></span>
+                <footer>— <span id="randomAuthor"></span> · <span class="muted">#<span id="randomId"></span></span></footer>
+            </blockquote>
+        </div>
+    </section>
+
+    <!-- Tabs: Approved / Pending (pending only when superuser) -->
+    <section class="tabs-row" aria-label="Filter by approval state">
+        <a class="tab"
+           th:href="@{/excuses/{gid}(gid=${guildId},tab='approved',q=${query})}"
+           th:classappend="${activeTab == 'approved'} ? ' active'"
+           aria-current="${activeTab == 'approved'} ? 'page'">
+            Approved
+        </a>
+        <a class="tab"
+           th:if="${isSuperUser}"
+           th:href="@{/excuses/{gid}(gid=${guildId},tab='pending')}"
+           th:classappend="${activeTab == 'pending'} ? ' active'"
+           aria-current="${activeTab == 'pending'} ? 'page'">
+            Pending
+        </a>
+    </section>
+
+    <!-- Rows -->
+    <section class="excuse-list" aria-labelledby="list-h">
+        <h2 id="list-h" class="sr-only">Excuses</h2>
+
+        <div th:if="${#lists.isEmpty(rows)}" class="empty-hero">
+            <span class="emoji" aria-hidden="true">🤷</span>
+            <p th:if="${query != null and query != ''}">
+                No approved excuses match '<span th:text="${query}"></span>'.
+            </p>
+            <p th:if="${query == null or query == ''}"
+               th:text="${activeTab == 'pending'}
+                        ? 'Nothing pending right now.'
+                        : 'No approved excuses yet — submit one below to get started.'">
+                No excuses.
+            </p>
+        </div>
+
+        <ul th:unless="${#lists.isEmpty(rows)}" class="excuse-cards">
+            <li th:each="row : ${rows}"
+                class="excuse-card"
+                th:classappend="${row.approved} ? ' approved' : ' pending'"
+                th:attr="data-excuse-id=${row.id}">
+                <div class="excuse-text" th:text="${row.text}">Excuse text</div>
+                <div class="excuse-meta">
+                    <span class="excuse-author" th:text="${row.author}">Author</span>
+                    <span class="excuse-id" th:text="'#' + ${row.id}">#1</span>
+                    <span class="excuse-state" th:if="${row.approved}">Approved</span>
+                    <span class="excuse-state pending" th:unless="${row.approved}">Pending</span>
+                </div>
+                <div class="excuse-actions">
+                    <button type="button" class="btn btn-sm"
+                            th:if="${row.canApprove}"
+                            th:attr="data-action='approve',
+                                     data-id=${row.id},
+                                     data-url=@{/excuses/{gid}/{id}/approve(gid=${guildId},id=${row.id})}">
+                        ✓ Approve
+                    </button>
+                    <button type="button" class="btn btn-sm btn-danger"
+                            th:if="${row.canDelete}"
+                            th:attr="data-action='delete',
+                                     data-id=${row.id},
+                                     data-url=@{/excuses/{gid}/{id}/delete(gid=${guildId},id=${row.id})}">
+                        🗑 Delete
+                    </button>
+                </div>
+            </li>
+        </ul>
+
+        <!-- Pager -->
+        <nav class="pager" th:if="${totalPages > 1}" aria-label="Pagination">
+            <a class="btn btn-sm"
+               th:href="@{/excuses/{gid}(gid=${guildId},tab=${activeTab},q=${query},page=${page - 1})}"
+               th:classappend="${not hasPrev} ? ' disabled'"
+               th:attr="aria-disabled=${not hasPrev}">⬅️ Prev</a>
+            <span class="pager-info" th:text="'Page ' + ${page} + ' / ' + ${totalPages}">Page 1 / 1</span>
+            <a class="btn btn-sm"
+               th:href="@{/excuses/{gid}(gid=${guildId},tab=${activeTab},q=${query},page=${page + 1})}"
+               th:classappend="${not hasNext} ? ' disabled'"
+               th:attr="aria-disabled=${not hasNext}">Next ➡️</a>
+        </nav>
+    </section>
+
+    <!-- Maker: submit form -->
+    <section class="maker-card" aria-labelledby="maker-h">
+        <h2 id="maker-h">Maker</h2>
+        <p class="muted">Submit a new excuse for approval. Max <span th:text="${maxLength}">200</span> characters.</p>
+        <form method="post" th:action="@{/excuses/{gid}/submit(gid=${guildId})}" class="maker-form">
+            <input type="hidden" name="tab" th:value="${activeTab}">
+            <input type="hidden" name="q" th:value="${query}">
+
+            <div class="form-group">
+                <label for="excuseText">Excuse</label>
+                <textarea id="excuseText" name="text" required
+                          th:maxlength="${maxLength}"
+                          rows="2"
+                          placeholder="e.g. The dog ate my homework."></textarea>
+                <div class="char-counter">
+                    <span id="charCount">0</span> / <span th:text="${maxLength}">200</span>
+                </div>
+            </div>
+
+            <!-- Superuser override: attribute to another member -->
+            <div class="form-group" th:if="${isSuperUser}">
+                <label for="authorSelect">Attribute to (superuser only)</label>
+                <select id="authorSelect" name="authorDiscordId">
+                    <option value="">(Yourself)</option>
+                    <option th:each="m : ${members}"
+                            th:value="${m.id}"
+                            th:text="${m.name}"></option>
+                </select>
+            </div>
+
+            <button type="submit" class="btn">Submit for approval</button>
+        </form>
+    </section>
+</main>
+
+<script th:src="@{/js/api.js}"></script>
+<script th:src="@{/js/toasts.js}"></script>
+<script th:src="@{/js/excuses.js}"></script>
+<script th:src="@{/js/home.js}"></script>
+</body>
+</html>

--- a/web/src/main/resources/templates/fragments/navbar.html
+++ b/web/src/main/resources/templates/fragments/navbar.html
@@ -66,6 +66,7 @@
                     onclick="toggleDropdown(this)">Social <span class="nav-dropdown-caret" aria-hidden="true">&#9662;</span></button>
             <div class="nav-dropdown-menu" role="menu">
                 <a href="/intro/guilds" role="menuitem">Intro Songs</a>
+                <a href="/excuses/guilds" role="menuitem">Excuses</a>
             </div>
         </div>
         <div class="nav-dropdown">


### PR DESCRIPTION
## Summary

Polishes the excuse service end-to-end:

- **`/excuse` rewrite** to real Discord subcommands: `random`, `submit`, `list`, `search`, `approve`, `delete`. Replaces the previous free-form `action` option that silently fell through to "create" when no known action was matched.
- **Per-guild web UI** at `/excuses` — the "excuse maker and finder":
  - Finder card with a 🎲 Spin button (AJAX) and search box.
  - Approved / Pending tabs (pending superuser-only).
  - Per-row Approve/Delete buttons; submission form with author override for superusers.
  - Server-side pagination (12/page).
  - Mirrors the existing `IntroWebController` + `WebGuildAccess` + OAuth2 pattern; navbar gains an `Excuses` entry alongside Intro Songs.
- **Slash list/search pagination**: 10/page embeds with prev/next button paginator (`ExcuseListPageButton`, state encoded in the component id).
- **Service/persistence**:
  - New paged + count + case-insensitive search methods.
  - `approveExcuse(id)` and `canRequesterDeleteOwnPending(id, requesterDiscordId)` helpers so the same self-delete rule (authors can delete their own pending submissions) applies from the slash command and the web UI.
  - **Fix latent cache bug** — `@Cacheable` on `listAllGuildExcuses` / `listApprovedGuildExcuses` omitted `key`, so all guilds collided on one slot. Keys now include the `guildId`.
- **Flyway migration `V31__add_excuse_timestamps.sql`** adds `created_at`, `approved_at`, and `author_discord_id`. Existing rows leave `author_discord_id` NULL — those predate the column and remain superuser-only as today.
- **Tests** for the rewritten command, the new web controller, and the new web service.

## Test plan

- [ ] Migration applies cleanly (Flyway picks up `V31` after `V30__drop_dnd_campaign_tables`).
- [ ] `/excuse random`, `/excuse submit`, `/excuse list scope:pending` (superuser-only), `/excuse search query:…`, `/excuse approve id:N`, `/excuse delete id:N` all work in a dev guild; page paginator advances correctly.
- [ ] `/excuses/guilds` shows mutual servers with approved counts.
- [ ] On a per-guild page: Spin returns a random approved excuse without reload; search filters; approve/delete buttons update in place; superuser can submit on behalf of a chosen member; non-superusers can delete their own pending submissions but not others'.
- [ ] `./gradlew test` — new command/service/controller tests pass; existing `ExcuseServiceImplIntegrationTest` still green (data.sql fixtures unaffected by the new nullable columns).

https://claude.ai/code/session_017zT62SFU6i3HTKPf8LQQ91

---
_Generated by [Claude Code](https://claude.ai/code/session_017zT62SFU6i3HTKPf8LQQ91)_