### PR TITLE
fix(jackpot): premium spoke wheel with mobile sizing + click-to-spin

### DIFF
--- a/web/src/main/resources/static/css/base.css
+++ b/web/src/main/resources/static/css/base.css
@@ -588,69 +588,174 @@ td { font-size: 0.95rem; }
 }
 
 /* Spinning-payout-wheel overlay shown when a jackpot roll hits. The
-   wheel decides what fraction of the pool a winning roll pays. Sized
-   to feel like an event without consuming the whole page; absolutely
-   positioned over the page so the underlying game state is preserved
-   when the wheel closes. */
+   wheel decides what fraction of the pool a winning roll pays. The
+   wheel sits inside a felt-green panel that matches the per-game
+   `casino-felt` tables — same radial-gradient palette, same brass
+   accent vocabulary — so the overlay reads as part of the casino
+   rather than a stray dialog.
+
+   The wheel doesn't auto-spin: the player taps SPIN to start the
+   animation. Clicking the backdrop dismisses cleanly. */
 .jackpot-wheel-overlay {
     position: fixed;
     inset: 0;
-    background: rgba(0, 0, 0, 0.65);
+    background: rgba(0, 0, 0, 0.78);
     display: flex;
     align-items: center;
     justify-content: center;
     z-index: 1000;
+    padding: var(--space-3);
 }
 .jackpot-wheel-overlay[hidden] { display: none; }
-.jackpot-wheel-stage {
-    position: relative;
-    width: 320px;
-    max-width: 90vw;
-    aspect-ratio: 1 / 1.15;
+/* Felt panel — mirrors `.casino-felt` so the wheel looks at home next
+   to the dice/blackjack/etc. tables. */
+.jackpot-wheel-panel {
+    background:
+        radial-gradient(ellipse at center, #2e6b4f 0%, #1f4a36 70%, #143324 100%);
+    border: 1px solid rgba(247, 212, 106, 0.25);
+    border-radius: 1.25rem;
+    padding: 1.5rem 1.75rem 1.25rem;
+    box-shadow:
+        inset 0 0 60px rgba(0, 0, 0, 0.45),
+        0 12px 40px rgba(0, 0, 0, 0.6),
+        0 0 0 1px rgba(0, 0, 0, 0.4);
     display: flex;
     flex-direction: column;
     align-items: center;
 }
-.jackpot-wheel-pointer {
-    font-size: 2rem;
-    line-height: 1;
-    color: #ffe066;
-    text-shadow: 0 0 6px rgba(241, 196, 15, 0.6);
+.jackpot-wheel-stage {
+    position: relative;
+    width: clamp(240px, 78vw, 360px);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.85rem;
 }
 .jackpot-wheel-svg {
     width: 100%;
     height: auto;
-    flex: 1;
+    display: block;
+    filter: drop-shadow(0 6px 14px rgba(0, 0, 0, 0.45));
 }
 .jackpot-wheel-rotor {
     transform-origin: 0 0;
     transition: transform 3.2s cubic-bezier(0.18, 0.6, 0.18, 1);
 }
-.jackpot-wheel-hub {
-    fill: #ffe066;
+/* Brass rim — gradient stroke makes it read as metal. The thin dark
+   inner ring is what gives the wedges that recessed-into-the-rim look. */
+.jackpot-wheel-rim-outer {
+    fill: url(#jackpot-wheel-rim-grad);
     stroke: rgba(0, 0, 0, 0.6);
-    stroke-width: 2;
-}
-.jackpot-wheel-segment {
-    stroke: rgba(0, 0, 0, 0.5);
     stroke-width: 1;
 }
+.jackpot-wheel-rim-inner {
+    fill: #0a1a12;
+    stroke: rgba(0, 0, 0, 0.7);
+    stroke-width: 0.5;
+}
+.jackpot-wheel-hub-outer {
+    fill: url(#jackpot-wheel-hub-grad);
+    stroke: rgba(0, 0, 0, 0.55);
+    stroke-width: 1;
+}
+.jackpot-wheel-hub-inner {
+    fill: #b07d1f;
+    stroke: rgba(255, 240, 180, 0.45);
+    stroke-width: 0.5;
+}
+.jackpot-wheel-pointer-arrow {
+    fill: url(#jackpot-wheel-pointer-grad);
+    stroke: rgba(0, 0, 0, 0.5);
+    stroke-width: 0.75;
+    stroke-linejoin: round;
+}
+.jackpot-wheel-segment {
+    stroke: rgba(0, 0, 0, 0.55);
+    stroke-width: 0.75;
+}
 .jackpot-wheel-segment-label {
-    fill: #1a1a1a;
-    font-size: 13px;
+    fill: #fff8e1;
+    font-family: "Cambria", "Georgia", serif;
+    font-size: 9px;
     font-weight: 700;
+    font-variant-numeric: tabular-nums;
     text-anchor: middle;
     dominant-baseline: middle;
+    paint-order: stroke;
+    stroke: rgba(0, 0, 0, 0.7);
+    stroke-width: 0.5;
     pointer-events: none;
 }
+.jackpot-wheel-spin-btn {
+    appearance: none;
+    border: 1px solid rgba(0, 0, 0, 0.5);
+    border-radius: 999px;
+    padding: 0.55rem 1.6rem;
+    font-family: "Cambria", "Georgia", serif;
+    font-weight: 700;
+    font-size: 1.05rem;
+    letter-spacing: 0.12em;
+    color: #2a1a04;
+    background: linear-gradient(180deg, #fff1b0 0%, #e0a93a 55%, #a87217 100%);
+    box-shadow:
+        inset 0 1px 0 rgba(255, 255, 255, 0.6),
+        inset 0 -2px 4px rgba(0, 0, 0, 0.25),
+        0 4px 10px rgba(0, 0, 0, 0.45);
+    cursor: pointer;
+    transition: transform 0.12s ease, box-shadow 0.12s ease, filter 0.2s ease;
+}
+.jackpot-wheel-spin-btn:hover:not(:disabled) {
+    transform: translateY(-1px);
+    box-shadow:
+        inset 0 1px 0 rgba(255, 255, 255, 0.7),
+        inset 0 -2px 4px rgba(0, 0, 0, 0.25),
+        0 6px 14px rgba(241, 196, 15, 0.4);
+}
+.jackpot-wheel-spin-btn:active:not(:disabled) {
+    transform: translateY(1px);
+    box-shadow:
+        inset 0 2px 4px rgba(0, 0, 0, 0.35),
+        0 2px 6px rgba(0, 0, 0, 0.4);
+}
+.jackpot-wheel-spin-btn:disabled {
+    filter: grayscale(0.5) brightness(0.7);
+    cursor: default;
+}
 .jackpot-wheel-result {
-    margin-top: var(--space-2);
     min-height: 1.4em;
     text-align: center;
     color: #ffe066;
+    font-family: "Cambria", "Georgia", serif;
     font-weight: 700;
-    font-size: 1.05rem;
-    text-shadow: 0 0 6px rgba(241, 196, 15, 0.5);
+    font-size: 1.1rem;
+    letter-spacing: 0.02em;
+    text-shadow: 0 0 8px rgba(241, 196, 15, 0.55);
+}
+
+@media (max-width: 600px) {
+    .jackpot-wheel-panel {
+        padding: 1.1rem 1.1rem 0.9rem;
+        border-radius: 1rem;
+    }
+    .jackpot-wheel-stage { gap: 0.7rem; }
+    .jackpot-wheel-spin-btn {
+        padding: 0.5rem 1.3rem;
+        font-size: 1rem;
+    }
+    .jackpot-wheel-result { font-size: 1rem; }
+}
+@media (max-width: 480px) {
+    .jackpot-wheel-stage {
+        width: clamp(220px, 84vw, 300px);
+    }
+    .jackpot-wheel-panel {
+        padding: 0.9rem 0.9rem 0.75rem;
+    }
+}
+/* Reduced-motion: kill the rotor transition. The JS still rotates to
+   the final angle (instantly) so the player can read the resting wedge. */
+@media (prefers-reduced-motion: reduce) {
+    .jackpot-wheel-rotor { transition: none; }
 }
 
 /* Grow tap targets on any touch device without ballooning desktop buttons */

--- a/web/src/main/resources/static/css/base.css
+++ b/web/src/main/resources/static/css/base.css
@@ -669,6 +669,11 @@ td { font-size: 0.95rem; }
     stroke-width: 0.75;
     stroke-linejoin: round;
 }
+.jackpot-wheel-peg {
+    fill: url(#jackpot-wheel-hub-grad);
+    stroke: rgba(0, 0, 0, 0.7);
+    stroke-width: 0.4;
+}
 .jackpot-wheel-segment {
     stroke: rgba(0, 0, 0, 0.55);
     stroke-width: 0.75;

--- a/web/src/main/resources/static/js/casino-jackpot-wheel.js
+++ b/web/src/main/resources/static/js/casino-jackpot-wheel.js
@@ -185,6 +185,22 @@
 
             spokes.push({ tierIndex, mid });
         }
+        // Brass pegs at every spoke boundary, riding inside the rotor
+        // so they spin with the wheel. The pointer's tip sits at the
+        // peg radius, so visually each peg flicks past the pointer as
+        // the wheel rotates — that's the "real wheel" cue.
+        const pegRadius = 94;
+        for (let s = 0; s < N; s++) {
+            const angle = s * sweep;
+            const px = Math.cos((angle - 90) * Math.PI / 180) * pegRadius;
+            const py = Math.sin((angle - 90) * Math.PI / 180) * pegRadius;
+            const peg = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+            peg.setAttribute('cx', px.toFixed(2));
+            peg.setAttribute('cy', py.toFixed(2));
+            peg.setAttribute('r', '2.6');
+            peg.setAttribute('class', 'jackpot-wheel-peg');
+            rotor.appendChild(peg);
+        }
         return spokes;
     }
 

--- a/web/src/main/resources/static/js/casino-jackpot-wheel.js
+++ b/web/src/main/resources/static/js/casino-jackpot-wheel.js
@@ -34,6 +34,30 @@
     const SPIN_DURATION_MS = 3200;
     const SPIN_ROTATIONS = 4;
     const SPOKE_COUNT = 24;
+    // CSS easing curve for the rotor transition. Tick scheduling
+    // inverts this so peg-pass clicks fire in lockstep with the visual
+    // — fast at first, slowing as the wheel decelerates.
+    const EASE_X1 = 0.18, EASE_Y1 = 0.6, EASE_X2 = 0.18, EASE_Y2 = 1.0;
+
+    function bezierY(u, y1, y2) {
+        const u2 = 1 - u;
+        return 3 * u2 * u2 * u * y1 + 3 * u2 * u * u * y2 + u * u * u;
+    }
+    function bezierX(u, x1, x2) {
+        const u2 = 1 - u;
+        return 3 * u2 * u2 * u * x1 + 3 * u2 * u * u * x2 + u * u * u;
+    }
+    // Find the time-fraction (X) at which the easing reaches Y =
+    // targetY. Y(u) is monotonic for our curve so binary search is
+    // safe and 24 iterations gets us well below per-frame precision.
+    function easedTimeAtValue(targetY) {
+        let lo = 0, hi = 1;
+        for (let i = 0; i < 24; i++) {
+            const mid = (lo + hi) / 2;
+            if (bezierY(mid, EASE_Y1, EASE_Y2) < targetY) lo = mid; else hi = mid;
+        }
+        return bezierX((lo + hi) / 2, EASE_X1, EASE_X2);
+    }
     // Casino-leaning palette — slightly desaturated vs the original
     // neon set so the wheel reads as "felt-and-brass" rather than
     // arcade. Cycles per tier (not per spoke) so each tier has one
@@ -267,10 +291,16 @@
 
         let settled = false;
         let spinStarted = false;
+        const tickTimeouts = [];
+
+        const clearTicks = () => {
+            while (tickTimeouts.length) clearTimeout(tickTimeouts.pop());
+        };
 
         const settle = () => {
             if (settled) return;
             settled = true;
+            clearTicks();
             rotor.removeEventListener('transitionend', settle);
             if (resultEl) resultEl.textContent = tierLabel(payoutPct) + ' +' + payoutAmount + ' credits';
             if (root && root.TobyJackpot && typeof root.TobyJackpot.releasePoolBanner === 'function') {
@@ -317,6 +347,21 @@
             // Belt-and-braces fallback in case transitionend doesn't
             // fire (overlay torn down mid-spin, GPU stalls, etc.).
             setTimeout(settle, SPIN_DURATION_MS + 600);
+            // Schedule a "tick" sound for every peg the pointer passes,
+            // timed against the same easing curve as the rotor so the
+            // clicks decelerate with the wheel. Cancelled in settle so
+            // stragglers don't fire after a fast dismiss.
+            const pegStep = 360 / SPOKE_COUNT;
+            const numTicks = Math.floor(finalAngle / pegStep);
+            for (let k = 1; k <= numTicks; k++) {
+                const eased = (k * pegStep) / finalAngle;
+                const ms = easedTimeAtValue(eased) * SPIN_DURATION_MS;
+                tickTimeouts.push(setTimeout(() => {
+                    if (root && root.CasinoSounds && typeof root.CasinoSounds.play === 'function') {
+                        root.CasinoSounds.play('tick');
+                    }
+                }, ms));
+            }
             requestAnimationFrame(() => {
                 rotor.style.transform = 'rotate(' + finalAngle.toFixed(2) + 'deg)';
             });
@@ -330,6 +375,7 @@
             if (ev.target !== overlay || spinStarted) return;
             overlay.removeEventListener('click', backdropDismiss);
             if (spinBtn) spinBtn.removeEventListener('click', startSpin);
+            clearTicks();
             overlay.hidden = true;
             if (typeof onSettle === 'function') onSettle();
         };

--- a/web/src/main/resources/static/js/casino-jackpot-wheel.js
+++ b/web/src/main/resources/static/js/casino-jackpot-wheel.js
@@ -9,21 +9,38 @@
 // server-side `database.economy.JackpotWheel.Segment` row, so the
 // wheel the player sees IS the wheel the server spun.
 //
+// Wheel layout: instead of one weight-proportional wedge per tier
+// (which renders as a giant pity arc that looks static when it spins),
+// we lay out `SPOKE_COUNT` equal-sized spokes around the rim and
+// distribute them across tiers proportionally to weight. Higher-weight
+// tiers own more spokes; the spokes are interleaved so colours
+// alternate as the wheel rotates, which is what makes the spin read
+// as motion instead of a rotating yellow blob.
+//
+// Spin is an affirmative action: the overlay reveals the wheel +
+// `SPIN` button, then nothing animates until the player clicks the
+// button. Lets the player savour the moment instead of being shown a
+// cutscene.
+//
 // Coordinated with `casino-jackpot.js`'s `holdPoolBanner` /
 // `releasePoolBanner` so the live pool counter doesn't tick down to
 // the post-win value mid-spin — that would let a fast reader infer
-// the result before the wheel stops.
+// the result before the wheel stops. Hold fires on SPIN click (not on
+// reveal) so the banner doesn't freeze while the player decides.
 
 (function (root) {
     'use strict';
 
     const SPIN_DURATION_MS = 3200;
     const SPIN_ROTATIONS = 4;
-    // Palette cycles through wedges; gold, indigo, teal, pink, slate
-    // give enough contrast at 5 segments and remain readable at 12.
-    const COLOURS = ['#f1c40f', '#7c5cff', '#1abc9c', '#ff6b9d', '#5d6d7e',
-                     '#e67e22', '#3498db', '#27ae60', '#c0392b', '#8e44ad',
-                     '#d4ac0d', '#16a085'];
+    const SPOKE_COUNT = 24;
+    // Casino-leaning palette — slightly desaturated vs the original
+    // neon set so the wheel reads as "felt-and-brass" rather than
+    // arcade. Cycles per tier (not per spoke) so each tier has one
+    // consistent colour the player can recognise across rim sectors.
+    const COLOURS = ['#e8b923', '#6b4fd6', '#16a085', '#d96089', '#4a5b6e',
+                     '#c97f24', '#2c7fbf', '#27ae60', '#a83333', '#7a3da8',
+                     '#b5901a', '#138a72'];
 
     function readSegments() {
         const raw = (root && root.__jackpotWheel) || [];
@@ -34,6 +51,88 @@
             s && typeof s.weight === 'number' && s.weight > 0 &&
             typeof s.payoutPct === 'number' && s.payoutPct > 0
         ).map(s => ({ weight: s.weight, payoutPct: s.payoutPct }));
+    }
+
+    /**
+     * Hamilton's largest-remainder method: distribute SPOKE_COUNT spokes
+     * across tiers proportional to weight. Every tier with weight > 0
+     * is guaranteed at least one spoke so rare tiers stay visible.
+     */
+    function allocateSpokes(segments) {
+        const totalWeight = segments.reduce((s, seg) => s + seg.weight, 0);
+        if (totalWeight <= 0 || segments.length === 0) return [];
+        // If there are more tiers than spokes we can't satisfy the
+        // at-least-1 guarantee for every tier; fall back to one spoke
+        // per tier, truncated.
+        if (segments.length >= SPOKE_COUNT) {
+            return segments.slice(0, SPOKE_COUNT).map(() => 1);
+        }
+        const counts = new Array(segments.length).fill(1);
+        let allocated = segments.length;
+        const ideals = segments.map(seg => (seg.weight / totalWeight) * SPOKE_COUNT);
+        const remainders = ideals.map((ideal, i) => ({ i, frac: ideal - Math.floor(ideal) }));
+        // Floor allocation on top of the reserved 1, but only the
+        // portion above 1 — we already gave each tier its base spoke.
+        for (let i = 0; i < segments.length; i++) {
+            const extra = Math.max(0, Math.floor(ideals[i]) - 1);
+            counts[i] += extra;
+            allocated += extra;
+        }
+        // Distribute leftover spokes to the tiers with the largest
+        // fractional remainders (classic Hamilton step).
+        remainders.sort((a, b) => b.frac - a.frac);
+        for (const r of remainders) {
+            if (allocated >= SPOKE_COUNT) break;
+            counts[r.i]++;
+            allocated++;
+        }
+        // If we overshot (rounding edges with at-least-1), trim from
+        // the largest count >1 until we're back at SPOKE_COUNT.
+        while (allocated > SPOKE_COUNT) {
+            let maxIdx = -1, maxCount = 1;
+            for (let i = 0; i < counts.length; i++) {
+                if (counts[i] > maxCount) { maxIdx = i; maxCount = counts[i]; }
+            }
+            if (maxIdx < 0) break;
+            counts[maxIdx]--;
+            allocated--;
+        }
+        return counts;
+    }
+
+    /**
+     * Place each tier's spokes around the rim so they're spread out
+     * (not clumped). Largest tier seeds first at evenly-spaced
+     * positions; smaller tiers fill the remaining slots, sliding
+     * forward when a slot is taken. Result is an array of length
+     * SPOKE_COUNT mapping each slot to a tier index.
+     */
+    function placeSpokes(counts) {
+        const N = counts.reduce((s, c) => s + c, 0);
+        const slots = new Array(N).fill(-1);
+        const order = counts
+            .map((c, i) => ({ i, c }))
+            .filter(t => t.c > 0)
+            .sort((a, b) => b.c - a.c);
+        let phase = 0;
+        for (const { i, c } of order) {
+            const step = N / c;
+            let pos = phase;
+            for (let j = 0; j < c; j++) {
+                let slot = Math.round(pos) % N;
+                let tries = 0;
+                while (slots[slot] !== -1 && tries < N) {
+                    slot = (slot + 1) % N;
+                    tries++;
+                }
+                slots[slot] = i;
+                pos += step;
+            }
+            // Offset the next tier's starting position so its spokes
+            // don't all collide with the previous tier's slot 0.
+            phase += step / 2;
+        }
+        return slots;
     }
 
     function buildWedgePath(startAngle, endAngle, radius) {
@@ -47,39 +146,46 @@
         return `M 0 0 L ${x0.toFixed(2)} ${y0.toFixed(2)} A ${radius} ${radius} 0 ${largeArc} 1 ${x1.toFixed(2)} ${y1.toFixed(2)} Z`;
     }
 
+    /**
+     * Render the spokes into `rotor`. Returns an array of {tierIndex,
+     * mid} per spoke so `spinTo` can pick a target angle.
+     */
     function render(segments, rotor) {
         rotor.innerHTML = '';
-        const totalWeight = segments.reduce((s, seg) => s + seg.weight, 0);
-        if (totalWeight <= 0) return [];
+        const counts = allocateSpokes(segments);
+        if (counts.length === 0) return [];
+        const slots = placeSpokes(counts);
+        const N = slots.length;
+        const sweep = 360 / N;
         const radius = 100;
-        let cursor = 0;
-        const angles = [];
-        segments.forEach((seg, i) => {
-            const sweep = (seg.weight / totalWeight) * 360;
-            const start = cursor;
-            const end = cursor + sweep;
+        const spokes = [];
+        for (let s = 0; s < N; s++) {
+            const tierIndex = slots[s];
+            const start = s * sweep;
+            const end = start + sweep;
             const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
             path.setAttribute('d', buildWedgePath(start, end, radius));
-            path.setAttribute('fill', COLOURS[i % COLOURS.length]);
+            path.setAttribute('fill', COLOURS[tierIndex % COLOURS.length]);
             path.setAttribute('class', 'jackpot-wheel-segment');
             rotor.appendChild(path);
 
-            // Label at the wedge's midpoint, rotated to read radially.
+            // Label sits near the rim so labels remain legible even when
+            // the spokes get thin. Rotate the text to read radially.
             const mid = (start + end) / 2;
-            const labelR = radius * 0.62;
+            const labelR = radius * 0.72;
             const lx = Math.cos((mid - 90) * Math.PI / 180) * labelR;
             const ly = Math.sin((mid - 90) * Math.PI / 180) * labelR;
             const text = document.createElementNS('http://www.w3.org/2000/svg', 'text');
             text.setAttribute('x', lx.toFixed(2));
             text.setAttribute('y', ly.toFixed(2));
             text.setAttribute('class', 'jackpot-wheel-segment-label');
-            text.textContent = seg.payoutPct + '%';
+            text.setAttribute('transform', `rotate(${mid.toFixed(2)} ${lx.toFixed(2)} ${ly.toFixed(2)})`);
+            text.textContent = segments[tierIndex].payoutPct + '%';
             rotor.appendChild(text);
 
-            angles.push({ start, end, mid });
-            cursor = end;
-        });
-        return angles;
+            spokes.push({ tierIndex, mid });
+        }
+        return spokes;
     }
 
     function tierLabel(payoutPct) {
@@ -89,11 +195,16 @@
         return '🎟️ Pity prize';
     }
 
+    function prefersReducedMotion() {
+        return typeof window !== 'undefined' && window.matchMedia &&
+            window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    }
+
     /**
-     * Show the overlay and spin to [tierIndex]. The wheel's rotor
-     * rotates `SPIN_ROTATIONS` full turns + the angle needed to bring
-     * the picked wedge's midpoint under the top pointer. [onSettle] is
-     * called when the CSS transition completes.
+     * Reveal the wheel overlay aimed at `tierIndex` and wait for the
+     * player to press SPIN. `onSettle` fires after the spin completes
+     * — or immediately if the player dismisses the overlay without
+     * spinning, so caller-side bookkeeping still runs deterministically.
      */
     function spinTo(tierIndex, payoutAmount, payoutPct, onSettle) {
         const overlay = document.getElementById('jackpot-wheel-overlay');
@@ -107,37 +218,40 @@
         const segments = readSegments();
         const rotor = overlay.querySelector('.jackpot-wheel-rotor');
         const resultEl = overlay.querySelector('.jackpot-wheel-result');
+        const spinBtn = overlay.querySelector('.jackpot-wheel-spin-btn');
         if (!rotor || segments.length === 0 || tierIndex < 0 || tierIndex >= segments.length) {
             if (typeof onSettle === 'function') onSettle();
             return;
         }
-        const angles = render(segments, rotor);
+        const spokes = render(segments, rotor);
+        // Pick the first spoke owned by the chosen tier. Deterministic
+        // so tests can assert a known target angle.
+        const targetSpoke = spokes.find(s => s.tierIndex === tierIndex);
+        if (!targetSpoke) {
+            if (typeof onSettle === 'function') onSettle();
+            return;
+        }
+        const target = targetSpoke.mid;
+        // Pointer is at the top (angle 0 in wedge coords). To bring
+        // the wedge midpoint under it we rotate by `-target`, plus
+        // full rotations for drama.
+        const finalAngle = SPIN_ROTATIONS * 360 - target;
 
         // Snap rotor to 0 before animating so successive spins start
-        // from a known transform. Force a layout read between the snap
-        // and the new target to make the browser register the
-        // transition's starting point.
+        // from a known transform. Force a layout read so the browser
+        // registers the transition's starting point.
         rotor.style.transition = 'none';
         rotor.style.transform = 'rotate(0deg)';
         // eslint-disable-next-line no-unused-expressions
         rotor.getBoundingClientRect();
         rotor.style.transition = '';
 
-        const target = angles[tierIndex].mid;
-        // Pointer is at the top (angle 0 in wedge coords). To bring
-        // the wedge midpoint under it we rotate by `-target`, plus
-        // full rotations for drama.
-        const finalAngle = SPIN_ROTATIONS * 360 - target;
         overlay.hidden = false;
         if (resultEl) resultEl.textContent = '';
 
-        // Hold the pool banner so it doesn't tick to the post-win
-        // value before the wheel lands.
-        if (root && root.TobyJackpot && typeof root.TobyJackpot.holdPoolBanner === 'function') {
-            root.TobyJackpot.holdPoolBanner();
-        }
-
         let settled = false;
+        let spinStarted = false;
+
         const settle = () => {
             if (settled) return;
             settled = true;
@@ -148,25 +262,75 @@
             }
             // Auto-dismiss after a short read-pause so the player sees
             // the result before returning to the table. Manual close
-            // via click also works for impatient users.
-            const close = () => { overlay.hidden = true; overlay.removeEventListener('click', close); };
-            overlay.addEventListener('click', close, { once: true });
+            // via backdrop click also works for impatient users.
+            const close = () => {
+                overlay.hidden = true;
+                overlay.removeEventListener('click', backdropAfterSettle);
+            };
+            const backdropAfterSettle = (ev) => {
+                if (ev.target === overlay) close();
+            };
+            overlay.addEventListener('click', backdropAfterSettle);
             setTimeout(close, 1800);
             if (typeof onSettle === 'function') onSettle();
         };
-        rotor.addEventListener('transitionend', settle);
-        // Belt-and-braces fallback in case transitionend doesn't fire
-        // (overlay torn down mid-spin, reduced-motion CSS, etc.).
-        setTimeout(settle, SPIN_DURATION_MS + 600);
 
-        // Schedule the spin on the next frame so the snap-to-0 above
-        // takes effect first.
-        requestAnimationFrame(() => {
-            rotor.style.transform = 'rotate(' + finalAngle.toFixed(2) + 'deg)';
-        });
+        const startSpin = () => {
+            if (spinStarted || settled) return;
+            spinStarted = true;
+            if (spinBtn) {
+                spinBtn.disabled = true;
+                spinBtn.removeEventListener('click', startSpin);
+            }
+            overlay.removeEventListener('click', backdropDismiss);
+            // Hold the pool banner once the wheel actually starts
+            // moving so the displayed pool doesn't tick down to the
+            // post-win value mid-spin.
+            if (root && root.TobyJackpot && typeof root.TobyJackpot.holdPoolBanner === 'function') {
+                root.TobyJackpot.holdPoolBanner();
+            }
+            if (prefersReducedMotion()) {
+                // Skip the 3.2s transition — the affirmative click was
+                // the moment, the rotation is just decoration.
+                rotor.style.transition = 'none';
+                rotor.style.transform = 'rotate(' + finalAngle.toFixed(2) + 'deg)';
+                settle();
+                return;
+            }
+            rotor.addEventListener('transitionend', settle);
+            // Belt-and-braces fallback in case transitionend doesn't
+            // fire (overlay torn down mid-spin, GPU stalls, etc.).
+            setTimeout(settle, SPIN_DURATION_MS + 600);
+            requestAnimationFrame(() => {
+                rotor.style.transform = 'rotate(' + finalAngle.toFixed(2) + 'deg)';
+            });
+        };
+
+        // Backdrop click before the player has chosen to spin — dismiss
+        // cleanly. The underlying game's result line is already
+        // painted, so nothing's gated on this; onSettle still fires so
+        // any caller-side bookkeeping runs.
+        const backdropDismiss = (ev) => {
+            if (ev.target !== overlay || spinStarted) return;
+            overlay.removeEventListener('click', backdropDismiss);
+            if (spinBtn) spinBtn.removeEventListener('click', startSpin);
+            overlay.hidden = true;
+            if (typeof onSettle === 'function') onSettle();
+        };
+
+        if (spinBtn) {
+            spinBtn.disabled = false;
+            spinBtn.addEventListener('click', startSpin);
+        } else {
+            // Older overlay markup with no SPIN button — preserve the
+            // auto-spin behaviour so we don't break callers/tests that
+            // haven't updated yet.
+            startSpin();
+        }
+        overlay.addEventListener('click', backdropDismiss);
     }
 
-    const api = { readSegments, render, tierLabel, spinTo, SPIN_DURATION_MS };
+    const api = { readSegments, allocateSpokes, placeSpokes, render, tierLabel, spinTo, SPIN_DURATION_MS, SPOKE_COUNT };
     if (root) root.TobyJackpotWheel = api;
 
     if (typeof module !== 'undefined' && module.exports) {

--- a/web/src/main/resources/templates/fragments/casino.html
+++ b/web/src/main/resources/templates/fragments/casino.html
@@ -89,9 +89,11 @@
                 <!-- Brass hub: outer ring + inner medallion -->
                 <circle cx="0" cy="0" r="18" class="jackpot-wheel-hub-outer"/>
                 <circle cx="0" cy="0" r="13" class="jackpot-wheel-hub-inner"/>
-                <!-- Pointer at top: gold arrow with shadow -->
+                <!-- Pointer at top: gold arrow pointing DOWN at the
+                     wheel. Apex sits at the peg radius so spinning pegs
+                     visually flick past the tip. -->
                 <path class="jackpot-wheel-pointer-arrow"
-                      d="M 0 -112 L -10 -94 L 10 -94 Z"
+                      d="M 0 -94 L -9 -116 L 9 -116 Z"
                       filter="url(#jackpot-wheel-shadow)"/>
             </svg>
             <button type="button" class="jackpot-wheel-spin-btn">SPIN</button>

--- a/web/src/main/resources/templates/fragments/casino.html
+++ b/web/src/main/resources/templates/fragments/casino.html
@@ -44,15 +44,59 @@
     renders the exact wheel the server spun against. Rides along with
     every jackpotBanner include so each casino page automatically gets
     the overlay without per-page edits.
+    The wheel doesn't auto-spin: the player presses SPIN to start the
+    rotation. Clicking the backdrop (outside the felt panel) dismisses
+    cleanly — the underlying result line is already painted on the
+    page so nothing's gated on the spin.
 -->
 <div id="jackpot-wheel-overlay" class="jackpot-wheel-overlay" hidden>
-    <div class="jackpot-wheel-stage">
-        <div class="jackpot-wheel-pointer">▼</div>
-        <svg class="jackpot-wheel-svg" viewBox="-110 -110 220 220" aria-hidden="true">
-            <g class="jackpot-wheel-rotor"></g>
-            <circle cx="0" cy="0" r="14" class="jackpot-wheel-hub"></circle>
-        </svg>
-        <div class="jackpot-wheel-result" aria-live="polite"></div>
+    <div class="jackpot-wheel-panel">
+        <div class="jackpot-wheel-stage">
+            <svg class="jackpot-wheel-svg" viewBox="-120 -120 240 240" aria-hidden="true">
+                <defs>
+                    <linearGradient id="jackpot-wheel-rim-grad" x1="0" y1="0" x2="0" y2="1">
+                        <stop offset="0%" stop-color="#f7d46a"/>
+                        <stop offset="50%" stop-color="#b07d1f"/>
+                        <stop offset="100%" stop-color="#f7d46a"/>
+                    </linearGradient>
+                    <radialGradient id="jackpot-wheel-vignette" cx="0.5" cy="0.5" r="0.5">
+                        <stop offset="60%" stop-color="rgba(0,0,0,0)"/>
+                        <stop offset="100%" stop-color="rgba(0,0,0,0.55)"/>
+                    </radialGradient>
+                    <linearGradient id="jackpot-wheel-hub-grad" x1="0" y1="0" x2="0" y2="1">
+                        <stop offset="0%" stop-color="#fff1b0"/>
+                        <stop offset="55%" stop-color="#e0a93a"/>
+                        <stop offset="100%" stop-color="#7a4f10"/>
+                    </linearGradient>
+                    <linearGradient id="jackpot-wheel-pointer-grad" x1="0" y1="0" x2="0" y2="1">
+                        <stop offset="0%" stop-color="#fff1b0"/>
+                        <stop offset="60%" stop-color="#e0a93a"/>
+                        <stop offset="100%" stop-color="#7a4f10"/>
+                    </linearGradient>
+                    <filter id="jackpot-wheel-shadow" x="-20%" y="-20%" width="140%" height="140%">
+                        <feDropShadow dx="0" dy="2" stdDeviation="2" flood-color="rgba(0,0,0,0.55)"/>
+                    </filter>
+                </defs>
+                <!-- Outer brass rim -->
+                <circle cx="0" cy="0" r="106" class="jackpot-wheel-rim-outer"/>
+                <!-- Dark seat between rim and wedges so the wedges look
+                     recessed into the brass -->
+                <circle cx="0" cy="0" r="101" class="jackpot-wheel-rim-inner"/>
+                <!-- Wedges spin inside the rim -->
+                <g class="jackpot-wheel-rotor"></g>
+                <!-- Vignette overlays the spokes for depth -->
+                <circle cx="0" cy="0" r="100" fill="url(#jackpot-wheel-vignette)" pointer-events="none"/>
+                <!-- Brass hub: outer ring + inner medallion -->
+                <circle cx="0" cy="0" r="18" class="jackpot-wheel-hub-outer"/>
+                <circle cx="0" cy="0" r="13" class="jackpot-wheel-hub-inner"/>
+                <!-- Pointer at top: gold arrow with shadow -->
+                <path class="jackpot-wheel-pointer-arrow"
+                      d="M 0 -112 L -10 -94 L 10 -94 Z"
+                      filter="url(#jackpot-wheel-shadow)"/>
+            </svg>
+            <button type="button" class="jackpot-wheel-spin-btn">SPIN</button>
+            <div class="jackpot-wheel-result" aria-live="polite"></div>
+        </div>
     </div>
     <script th:inline="javascript">
         /*<![CDATA[*/

--- a/web/src/test/js/casino-jackpot-wheel.test.js
+++ b/web/src/test/js/casino-jackpot-wheel.test.js
@@ -135,6 +135,13 @@ describe('render', () => {
         const labels = rotor.querySelectorAll('text');
         labels.forEach(t => expect(t.textContent).toBe('30%'));
     });
+
+    test('emits a brass peg at each spoke boundary so pegs spin with the wheel', () => {
+        const rotor = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+        render([{ weight: 1, payoutPct: 30 }], rotor);
+        const pegs = rotor.querySelectorAll('.jackpot-wheel-peg');
+        expect(pegs.length).toBe(SPOKE_COUNT);
+    });
 });
 
 describe('spinTo', () => {

--- a/web/src/test/js/casino-jackpot-wheel.test.js
+++ b/web/src/test/js/casino-jackpot-wheel.test.js
@@ -1,14 +1,15 @@
 // Coverage for the JS-side wheel renderer + spin animation. We exercise
-// the read/parse path (`readSegments`), the SVG render math, the tier
-// labelling, and the `spinTo` lifecycle (overlay show, pool-banner
-// hold, transitionend settle, dismiss). The animation timing is
-// shortcut by directly firing `transitionend` rather than waiting on
+// the read/parse path (`readSegments`), the spoke-allocation +
+// placement math, the tier labelling, and the `spinTo` lifecycle
+// (overlay reveal, SPIN-button gating, pool-banner hold/release on
+// click, transitionend settle, dismiss-without-spin). Animation timing
+// is shortcut by directly firing `transitionend` rather than waiting on
 // real CSS transitions (jsdom doesn't run them anyway).
 
 const wheel = require('../../main/resources/static/js/casino-jackpot-wheel');
 const jackpot = require('../../main/resources/static/js/casino-jackpot');
 
-const { readSegments, render, tierLabel, spinTo } = wheel;
+const { readSegments, allocateSpokes, placeSpokes, render, tierLabel, spinTo, SPOKE_COUNT } = wheel;
 
 describe('readSegments', () => {
     afterEach(() => { delete window.__jackpotWheel; });
@@ -56,8 +57,61 @@ describe('tierLabel', () => {
     });
 });
 
+describe('allocateSpokes', () => {
+    test('distributes the default segments to SPOKE_COUNT total spokes', () => {
+        const counts = allocateSpokes([
+            { weight: 80, payoutPct: 1 },
+            { weight: 10, payoutPct: 5 },
+            { weight: 5, payoutPct: 10 },
+            { weight: 4, payoutPct: 20 },
+            { weight: 1, payoutPct: 50 },
+        ]);
+        expect(counts.reduce((s, c) => s + c, 0)).toBe(SPOKE_COUNT);
+        // Every tier with weight > 0 gets at least one spoke so rare
+        // tiers stay visible on the rim.
+        counts.forEach(c => expect(c).toBeGreaterThanOrEqual(1));
+        // Heaviest tier gets most spokes.
+        expect(counts[0]).toBeGreaterThan(counts[1]);
+        expect(counts[0]).toBeGreaterThan(counts[4]);
+    });
+
+    test('returns [] when segments are empty or weights are zero', () => {
+        expect(allocateSpokes([])).toEqual([]);
+        expect(allocateSpokes([{ weight: 0, payoutPct: 1 }])).toEqual([]);
+    });
+
+    test('handles single-tier wheels', () => {
+        const counts = allocateSpokes([{ weight: 1, payoutPct: 30 }]);
+        expect(counts).toEqual([SPOKE_COUNT]);
+    });
+});
+
+describe('placeSpokes', () => {
+    test('places exactly the requested spoke counts', () => {
+        const slots = placeSpokes([19, 2, 1, 1, 1]);
+        expect(slots).toHaveLength(24);
+        const seen = [0, 0, 0, 0, 0];
+        slots.forEach(s => seen[s]++);
+        expect(seen).toEqual([19, 2, 1, 1, 1]);
+    });
+
+    test('interleaves small tiers so they are not adjacent', () => {
+        // Two evenly-sized tiers should alternate around the rim
+        // rather than clumping into two halves.
+        const slots = placeSpokes([12, 12]);
+        // No more than 2 adjacent slots should share the same tier.
+        let maxRun = 0, run = 0, prev = -1;
+        for (const s of slots) {
+            if (s === prev) run++; else run = 1;
+            if (run > maxRun) maxRun = run;
+            prev = s;
+        }
+        expect(maxRun).toBeLessThanOrEqual(2);
+    });
+});
+
 describe('render', () => {
-    test('emits one path + one label per segment, sized by weight', () => {
+    test('emits SPOKE_COUNT paths and labels', () => {
         const rotor = document.createElementNS('http://www.w3.org/2000/svg', 'g');
         const segments = [
             { weight: 80, payoutPct: 1 },
@@ -66,18 +120,20 @@ describe('render', () => {
             { weight: 4, payoutPct: 20 },
             { weight: 1, payoutPct: 50 },
         ];
-        const angles = render(segments, rotor);
-        expect(rotor.querySelectorAll('path').length).toBe(5);
-        expect(rotor.querySelectorAll('text').length).toBe(5);
-        // 80/100 = 288 degrees for the first wedge.
-        expect(angles[0].end - angles[0].start).toBeCloseTo(288, 1);
-        expect(angles[4].end - angles[4].start).toBeCloseTo(3.6, 1);
+        const spokes = render(segments, rotor);
+        expect(spokes).toHaveLength(SPOKE_COUNT);
+        expect(rotor.querySelectorAll('path').length).toBe(SPOKE_COUNT);
+        expect(rotor.querySelectorAll('text').length).toBe(SPOKE_COUNT);
+        // Every tier with weight > 0 must be represented at least once.
+        const tierSet = new Set(spokes.map(s => s.tierIndex));
+        expect(tierSet.size).toBe(segments.length);
     });
 
-    test('shows the payout pct on each label', () => {
+    test('labels each spoke with its tier payout pct', () => {
         const rotor = document.createElementNS('http://www.w3.org/2000/svg', 'g');
         render([{ weight: 1, payoutPct: 30 }], rotor);
-        expect(rotor.querySelector('text').textContent).toBe('30%');
+        const labels = rotor.querySelectorAll('text');
+        labels.forEach(t => expect(t.textContent).toBe('30%'));
     });
 });
 
@@ -85,10 +141,15 @@ describe('spinTo', () => {
     beforeEach(() => {
         document.body.innerHTML = `
             <div id="jackpot-wheel-overlay" hidden>
-                <svg viewBox="-110 -110 220 220">
-                    <g class="jackpot-wheel-rotor"></g>
-                </svg>
-                <div class="jackpot-wheel-result"></div>
+                <div class="jackpot-wheel-panel">
+                    <div class="jackpot-wheel-stage">
+                        <svg viewBox="-120 -120 240 240">
+                            <g class="jackpot-wheel-rotor"></g>
+                        </svg>
+                        <button type="button" class="jackpot-wheel-spin-btn">SPIN</button>
+                        <div class="jackpot-wheel-result"></div>
+                    </div>
+                </div>
             </div>
             <div class="casino-jackpot-banner"><strong>0</strong></div>
         `;
@@ -103,32 +164,63 @@ describe('spinTo', () => {
         // it the wheel's pool-banner coordination wouldn't fire.
         window.TobyJackpot = jackpot;
         // Stub requestAnimationFrame to run synchronously so the
-        // rotation-set step in `spinTo` actually fires under jsdom.
+        // rotation-set step in `startSpin` actually fires under jsdom.
         window.requestAnimationFrame = cb => cb(0);
+        // Default to no reduced-motion preference.
+        window.matchMedia = () => ({ matches: false, addEventListener() {}, removeEventListener() {} });
     });
 
     afterEach(() => {
         delete window.__jackpotWheel;
         delete window.TobyJackpot;
         delete window.requestAnimationFrame;
+        delete window.matchMedia;
     });
 
-    test('reveals the overlay and rotates the rotor to the target wedge', () => {
+    test('reveals the overlay but does not rotate before SPIN is clicked', () => {
         const overlay = document.getElementById('jackpot-wheel-overlay');
+        const rotor = overlay.querySelector('.jackpot-wheel-rotor');
+        const spinBtn = overlay.querySelector('.jackpot-wheel-spin-btn');
         spinTo(4, 500, 50, () => {});
         expect(overlay.hidden).toBe(false);
+        // Rotor snapped to 0 — no rotation applied yet.
+        expect(rotor.style.transform).toBe('rotate(0deg)');
+        // Button is enabled and ready.
+        expect(spinBtn.disabled).toBe(false);
+    });
+
+    test('rotates the rotor to a target spoke for the chosen tier after click', () => {
+        const overlay = document.getElementById('jackpot-wheel-overlay');
         const rotor = overlay.querySelector('.jackpot-wheel-rotor');
-        // Final angle = 4 full rotations - target midpoint angle.
-        // Tier 4 (the 1-weight 50% segment) midpoint is at ~358.2°.
-        // Rotation should therefore be around 4*360 - 358.2 = 1081.8°.
-        expect(rotor.style.transform).toMatch(/rotate\(108[0-9](\.\d+)?deg\)/);
+        const spinBtn = overlay.querySelector('.jackpot-wheel-spin-btn');
+        spinTo(4, 500, 50, () => {});
+        spinBtn.click();
+        // Final angle = 4 full rotations - the target spoke's midpoint.
+        // With 24 spokes the midpoint is one of (i + 0.5) * 15 = 7.5,
+        // 22.5, 37.5, … 352.5°. So the rotation should end as
+        // 1440 - one of those — i.e. 1432.5° down to 1087.5°.
+        const m = rotor.style.transform.match(/rotate\(([-\d.]+)deg\)/);
+        expect(m).not.toBeNull();
+        const angle = parseFloat(m[1]);
+        expect(angle).toBeGreaterThanOrEqual(1080);
+        expect(angle).toBeLessThanOrEqual(1440);
+    });
+
+    test('disables the SPIN button while spinning', () => {
+        const overlay = document.getElementById('jackpot-wheel-overlay');
+        const spinBtn = overlay.querySelector('.jackpot-wheel-spin-btn');
+        spinTo(0, 12, 1, () => {});
+        spinBtn.click();
+        expect(spinBtn.disabled).toBe(true);
     });
 
     test('paints the tier label on the result element when settled', () => {
         const overlay = document.getElementById('jackpot-wheel-overlay');
         const resultEl = overlay.querySelector('.jackpot-wheel-result');
         const rotor = overlay.querySelector('.jackpot-wheel-rotor');
+        const spinBtn = overlay.querySelector('.jackpot-wheel-spin-btn');
         spinTo(0, 12, 1, () => {});
+        spinBtn.click();
         // Force the settle path manually — jsdom doesn't dispatch
         // transitionend on its own.
         rotor.dispatchEvent(new Event('transitionend'));
@@ -139,8 +231,10 @@ describe('spinTo', () => {
     test('invokes onSettle exactly once on transitionend', () => {
         const overlay = document.getElementById('jackpot-wheel-overlay');
         const rotor = overlay.querySelector('.jackpot-wheel-rotor');
+        const spinBtn = overlay.querySelector('.jackpot-wheel-spin-btn');
         const settled = jest.fn();
         spinTo(2, 100, 10, settled);
+        spinBtn.click();
         rotor.dispatchEvent(new Event('transitionend'));
         // The internal fallback timeout might also call settle, but the
         // module's `settled` guard dedupes so onSettle fires once.
@@ -162,18 +256,50 @@ describe('spinTo', () => {
         expect(overlay.hidden).toBe(true);
     });
 
-    test('holds the pool banner while spinning and releases on settle', () => {
+    test('clicking the backdrop before SPIN dismisses and calls onSettle', () => {
+        const overlay = document.getElementById('jackpot-wheel-overlay');
+        const settled = jest.fn();
+        spinTo(0, 50, 1, settled);
+        // Simulate backdrop click — target must be the overlay itself.
+        const ev = new Event('click', { bubbles: true });
+        Object.defineProperty(ev, 'target', { value: overlay });
+        overlay.dispatchEvent(ev);
+        expect(overlay.hidden).toBe(true);
+        expect(settled).toHaveBeenCalledTimes(1);
+    });
+
+    test('clicking SPIN holds the pool banner; settle releases it', () => {
         const overlay = document.getElementById('jackpot-wheel-overlay');
         const rotor = overlay.querySelector('.jackpot-wheel-rotor');
-        // Force-release any prior held state.
+        const spinBtn = overlay.querySelector('.jackpot-wheel-spin-btn');
         jackpot.releasePoolBanner();
         spinTo(0, 50, 1, () => {});
-        // Banner is held — an update queues, doesn't paint.
-        jackpot.updatePoolBanner({ jackpotPool: 999 });
+        // Before the player clicks SPIN, the banner is NOT held — an
+        // update flows through normally so the page stays live.
+        jackpot.updatePoolBanner({ jackpotPool: 500 });
         const strong = document.querySelector('.casino-jackpot-banner strong');
-        expect(strong.textContent).toBe('0');
+        expect(strong.textContent).toBe('500');
+        // Once SPIN is pressed, the hold kicks in.
+        spinBtn.click();
+        jackpot.updatePoolBanner({ jackpotPool: 999 });
+        expect(strong.textContent).toBe('500'); // still held
         rotor.dispatchEvent(new Event('transitionend'));
-        // After settle the queued value is flushed.
-        expect(strong.textContent).toBe('999');
+        expect(strong.textContent).toBe('999'); // released + flushed
+    });
+
+    test('reduced-motion: SPIN click settles immediately without transition', () => {
+        window.matchMedia = (q) => ({
+            matches: q === '(prefers-reduced-motion: reduce)',
+            addEventListener() {}, removeEventListener() {}
+        });
+        const overlay = document.getElementById('jackpot-wheel-overlay');
+        const resultEl = overlay.querySelector('.jackpot-wheel-result');
+        const spinBtn = overlay.querySelector('.jackpot-wheel-spin-btn');
+        const settled = jest.fn();
+        spinTo(0, 12, 1, settled);
+        spinBtn.click();
+        // Result line is painted synchronously; no transitionend needed.
+        expect(resultEl.textContent).toContain('Pity prize');
+        expect(settled).toHaveBeenCalledTimes(1);
     });
 });

--- a/web/src/test/js/casino-jackpot-wheel.test.js
+++ b/web/src/test/js/casino-jackpot-wheel.test.js
@@ -294,6 +294,50 @@ describe('spinTo', () => {
         expect(strong.textContent).toBe('999'); // released + flushed
     });
 
+    test('schedules tick sounds during the spin, decelerating with the easing', () => {
+        jest.useFakeTimers();
+        const play = jest.fn();
+        window.CasinoSounds = { play };
+        try {
+            const spinBtn = document.querySelector('.jackpot-wheel-spin-btn');
+            spinTo(0, 12, 1, () => {});
+            spinBtn.click();
+            // Advance through the spin and let every tick timeout fire.
+            jest.advanceTimersByTime(3300);
+            const tickCalls = play.mock.calls.filter(c => c[0] === 'tick');
+            // 24 spokes × 4 turns = 96 peg passes. The exact count
+            // depends on the target spoke (extra fractional turn), but
+            // it should be roughly in that range.
+            expect(tickCalls.length).toBeGreaterThan(80);
+            expect(tickCalls.length).toBeLessThanOrEqual(96);
+        } finally {
+            delete window.CasinoSounds;
+            jest.useRealTimers();
+        }
+    });
+
+    test('cancels pending tick sounds when the overlay is dismissed mid-spin', () => {
+        jest.useFakeTimers();
+        const play = jest.fn();
+        window.CasinoSounds = { play };
+        try {
+            const overlay = document.getElementById('jackpot-wheel-overlay');
+            const rotor = overlay.querySelector('.jackpot-wheel-rotor');
+            const spinBtn = document.querySelector('.jackpot-wheel-spin-btn');
+            spinTo(0, 12, 1, () => {});
+            spinBtn.click();
+            jest.advanceTimersByTime(200);
+            rotor.dispatchEvent(new Event('transitionend')); // early settle
+            const ticksAtSettle = play.mock.calls.filter(c => c[0] === 'tick').length;
+            jest.advanceTimersByTime(3200);
+            const ticksAfterDrain = play.mock.calls.filter(c => c[0] === 'tick').length;
+            expect(ticksAfterDrain).toBe(ticksAtSettle);
+        } finally {
+            delete window.CasinoSounds;
+            jest.useRealTimers();
+        }
+    });
+
     test('reduced-motion: SPIN click settles immediately without transition', () => {
         window.matchMedia = (q) => ({
             matches: q === '(prefers-reduced-motion: reduce)',


### PR DESCRIPTION
## Summary

Three problems with the jackpot payout wheel (introduced in #442):

- **Mobile sizing.** `width: 320px; max-width: 90vw` with no responsive rules made the wheel dominate phone screens and visually crash into the stake input above and the banner description below.
- **"MS painty" visual.** Flat hex fills, a `▼` text-glyph pointer, a plain `<circle>` hub — looked nothing like the rest of the casino's `casino-felt` tables.
- **Auto-spin cutscene.** The wheel rotated the moment it appeared, with no affirmative player action.

There was also a perception issue: with weight-proportional wedges (one wedge per tier sized by weight), the default 80/10/5/4/1 distribution paints as one enormous yellow pity arc with three tiny slices. Rotating a mostly-uniform disc reads as "not moving" — the user reported the wheel "seemingly didn't spin".

## Changes

- **Wheel-of-fortune spoke layout.** 24 equal-sized spokes, allocated across tiers by Hamilton's largest-remainder method with an at-least-1-per-tier guarantee so rare tiers stay visible. Spokes are interleaved (not grouped) so colours alternate as the wheel rotates — that's what actually makes the spin look like a spin.
- **Felt-green panel + brass accents.** Matches `casino-felt` from `casino-table.css`: same radial-gradient palette, same gold/cream accent vocabulary, serif (`Cambria/Georgia`) labels matching `casino-card-face`. SVG defs for the rim gradient, hub medallion, pointer arrow with drop shadow, and a vignette overlay for depth.
- **Affirmative SPIN button.** The overlay reveals the wheel stationary with a gold `SPIN` button. Click to start the rotation; the pool-banner hold is moved to the click handler so the banner doesn't freeze while the player decides. Backdrop click before SPIN dismisses cleanly (the result line is already painted on the page, so nothing's gated on the click). Keyboard-reachable (`<button type="button">`) and honours `prefers-reduced-motion` by settling immediately on click.
- **Mobile breakpoints.** `clamp(240px, 78vw, 360px)` for fluid sizing, plus the standard 600px and 480px breakpoints used elsewhere in the casino CSS.

## Test plan

- [x] `npm test` — 386 tests pass (22 rewritten/new in `casino-jackpot-wheel.test.js`)
- [x] `npm run lint:css` clean
- [ ] On phone width (375px / 414px), the felt panel sits clear of the stake input and the banner description
- [ ] Wheel waits for SPIN — does not auto-rotate
- [ ] Clicking SPIN animates through visibly alternating coloured spokes and lands on a wedge whose `payoutPct` matches the server response
- [ ] Button disables during the spin (no double-tap restart)
- [ ] Backdrop click before SPIN closes the overlay cleanly; result line stays painted on the page
- [ ] `prefers-reduced-motion: reduce` skips the 3.2s transition

https://claude.ai/code/session_018HSqMP3tdjFb8hi6WYX8NN

---
_Generated by [Claude Code](https://claude.ai/code/session_018HSqMP3tdjFb8hi6WYX8NN)_