### PR TITLE
feat(dnd): render monster and equipment images in lookups

### DIFF
--- a/discord-bot/src/main/kotlin/bot/toby/dto/web/dnd/Equipment.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/dto/web/dnd/Equipment.kt
@@ -23,6 +23,7 @@ data class Equipment(
     val strMinimum: Int?,
     val stealthDisadvantage: Boolean?,
     val desc: List<String>?,
+    val image: String?,
     val url: String?
 ) : DnDResponse {
     override fun isValidReturnObject(): Boolean =
@@ -34,6 +35,7 @@ data class Equipment(
     override fun toEmbed(): MessageEmbed {
         val embedBuilder = EmbedBuilder()
         name?.let { embedBuilder.setTitle(it) }
+        image?.let { embedBuilder.setThumbnail("https://www.dnd5eapi.co$it") }
         if (!desc.isNullOrEmpty()) {
             embedBuilder.setDescription(desc.transformListToString())
         }

--- a/discord-bot/src/main/kotlin/bot/toby/dto/web/dnd/Monster.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/dto/web/dnd/Monster.kt
@@ -33,6 +33,7 @@ data class Monster(
     val specialAbilities: List<MonsterAction>?,
     val actions: List<MonsterAction>?,
     val legendaryActions: List<MonsterAction>?,
+    val image: String?,
     val url: String?
 ) : DnDResponse {
     override fun isValidReturnObject(): Boolean =
@@ -46,6 +47,7 @@ data class Monster(
     override fun toEmbed(): MessageEmbed {
         val embedBuilder = EmbedBuilder()
         name?.let { embedBuilder.setTitle(it) }
+        image?.let { embedBuilder.setThumbnail("https://www.dnd5eapi.co$it") }
 
         val header = listOfNotNull(
             size,

--- a/discord-bot/src/test/kotlin/bot/toby/dto/web/dnd/DnDExpansionEmbedTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/dto/web/dnd/DnDExpansionEmbedTest.kt
@@ -108,6 +108,7 @@ class DnDExpansionEmbedTest {
         assertEquals("1d8 Slashing", embed.fields.first { it.name == "Damage" }.value)
         assertEquals("1d10 Slashing", embed.fields.first { it.name == "Two-Handed Damage" }.value)
         assertEquals("Versatile", embed.fields.first { it.name == "Properties" }.value)
+        assertEquals("https://www.dnd5eapi.co/api/images/equipment/longsword.png", embed.thumbnail?.url)
     }
 
     @Test
@@ -119,6 +120,7 @@ class DnDExpansionEmbedTest {
         assertEquals("18", embed.fields.first { it.name == "Armor Class" }.value)
         assertEquals("15", embed.fields.first { it.name == "Strength Min" }.value)
         assertEquals("Disadvantage", embed.fields.first { it.name == "Stealth" }.value)
+        assertNull(embed.thumbnail, "Plate fixture has no image, embed should have no thumbnail")
     }
 
     @Test
@@ -207,6 +209,16 @@ class DnDExpansionEmbedTest {
 
         val specials = embed.fields.first { it.name == "Special Abilities" }.value!!
         assertTrue(specials.contains("Nimble Escape"))
+
+        assertEquals("https://www.dnd5eapi.co/api/images/monsters/goblin.png", embed.thumbnail?.url)
+    }
+
+    @Test
+    fun `Monster embed omits thumbnail when image field is absent`() {
+        val json = DnDExpansionFixtures.MONSTER_GOBLIN.replace(""""image":"/api/images/monsters/goblin.png",""", "")
+        val m = JsonParser.parseJsonToMonster(json)!!
+        val embed = m.toEmbed()
+        assertNull(embed.thumbnail, "no image field => no thumbnail")
     }
 
     @Test

--- a/discord-bot/src/test/kotlin/bot/toby/dto/web/dnd/DnDExpansionFixtures.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/dto/web/dnd/DnDExpansionFixtures.kt
@@ -85,6 +85,7 @@ object DnDExpansionFixtures {
          "properties":[
             {"index":"versatile","name":"Versatile","url":"/api/weapon-properties/versatile"}
          ],
+         "image":"/api/images/equipment/longsword.png",
          "url":"/api/equipment/longsword"}
     """
 
@@ -167,6 +168,7 @@ object DnDExpansionFixtures {
          "actions":[{"name":"Scimitar","desc":"Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 5 (1d6 + 2) slashing damage."},
                     {"name":"Shortbow","desc":"Ranged Weapon Attack: +4 to hit, range 80/320 ft., one target. Hit: 5 (1d6 + 2) piercing damage."}],
          "legendary_actions":[],
+         "image":"/api/images/monsters/goblin.png",
          "url":"/api/monsters/goblin"}
     """
 

--- a/discord-bot/src/test/kotlin/bot/toby/helpers/JsonParserExpansionTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/helpers/JsonParserExpansionTest.kt
@@ -118,6 +118,7 @@ internal class JsonParserExpansionTest {
         assertEquals(3.0, e.weight)
         assertEquals(1, e.properties?.size)
         assertEquals("Versatile", e.properties?.first()?.name)
+        assertEquals("/api/images/equipment/longsword.png", e.image)
         assertTrue(e.isValidReturnObject())
     }
 
@@ -131,6 +132,7 @@ internal class JsonParserExpansionTest {
         assertEquals(false, e.armorClass?.dexBonus)
         assertEquals(15, e.strMinimum)
         assertEquals(true, e.stealthDisadvantage)
+        assertNull(e.image, "Plate fixture intentionally omits image; field should be null")
         assertTrue(e.isValidReturnObject())
     }
 
@@ -207,6 +209,7 @@ internal class JsonParserExpansionTest {
         assertEquals("Nimble Escape", m.specialAbilities?.first()?.name)
         assertEquals(2, m.actions?.size)
         assertEquals("Scimitar", m.actions?.first()?.name)
+        assertEquals("/api/images/monsters/goblin.png", m.image)
         assertTrue(m.isValidReturnObject())
     }
 

--- a/web/src/main/resources/static/css/dndLookup.css
+++ b/web/src/main/resources/static/css/dndLookup.css
@@ -139,3 +139,20 @@
 .lookup-result p:last-child {
     margin-bottom: 0;
 }
+
+.lookup-image {
+    float: right;
+    max-width: 180px;
+    max-height: 220px;
+    margin: 0 0 var(--space-2) var(--space-3);
+    border-radius: var(--radius-sm);
+    background: var(--bg-elevated);
+}
+
+@media (max-width: 600px) {
+    .lookup-image {
+        float: none;
+        display: block;
+        margin: 0 auto var(--space-2) auto;
+    }
+}

--- a/web/src/main/resources/static/js/dndLookup.js
+++ b/web/src/main/resources/static/js/dndLookup.js
@@ -183,6 +183,16 @@
         resultEl.appendChild(p);
     }
 
+    function appendImage(data) {
+        if (!data.image) return;
+        const img = document.createElement('img');
+        img.className = 'lookup-image';
+        img.src = `https://www.dnd5eapi.co${data.image}`;
+        img.alt = data.name || '';
+        img.loading = 'lazy';
+        resultEl.appendChild(img);
+    }
+
     function descArray(data) {
         return Array.isArray(data.desc) ? data.desc
             : Array.isArray(data.description) ? data.description
@@ -207,6 +217,7 @@
     }
 
     function renderMonster(data) {
+        appendImage(data);
         const header = [data.size, data.type, data.alignment].filter(Boolean).join(', ');
         if (header) appendMeta([header]);
 
@@ -298,6 +309,7 @@
     }
 
     function renderEquipment(data) {
+        appendImage(data);
         if (data.equipment_category?.name) appendField('Category', data.equipment_category.name);
         if (data.cost) appendField('Cost', `${data.cost.quantity} ${data.cost.unit}`);
         if (data.weight != null) appendField('Weight', `${data.weight} lb`);


### PR DESCRIPTION
## Summary

- The dnd5eapi exposes an `image` field on **monsters** (e.g. `/api/images/monsters/goblin.png`) and **equipment** (e.g. `/api/images/equipment/longsword.png`). Other endpoints don't.
- Discord embeds for those two types now set a **thumbnail** (corner image), keeping the dense HP/AC/actions fields readable.
- The web `/dnd` card now renders an **inline `<img>`** floated right on desktop, centred on mobile.
- Both fall back gracefully — many real entries omit the field, and the renderers no-op cleanly when it's null.

## Files touched

- `Monster.kt`, `Equipment.kt` — added `image: String?` field, `setThumbnail("https://www.dnd5eapi.co$it")` in `toEmbed()`.
- `dndLookup.js` — new `appendImage(data)` helper called at the top of `renderMonster` and `renderEquipment`.
- `dndLookup.css` — new `.lookup-image` rule (float right, max 180×220, mobile fallback).
- Test fixtures expanded with realistic `image` paths; embed thumbnail + parser image-field assertions; new test confirming a missing `image` produces no thumbnail.

## Test plan

- [ ] `./gradlew :discord-bot:test --tests "*DnD*" --tests "*Dnd*"` — new image assertions pass, existing tests still green
- [ ] `/dnd type:monster query:goblin` in Discord — embed has a thumbnail in the top-right corner
- [ ] `/dnd type:equipment query:longsword` — same, with a longsword icon
- [ ] `/dnd type:monster query:swarm-of-rats` (or any monster without an upstream image) — renders cleanly, no broken-image placeholder
- [ ] Visit `/dnd`, look up Goblin and Longsword — image appears floated right of the description
- [ ] Resize browser to <600px — image stacks above the text instead of floating

## ⚠️ Build verification

Same sandbox limitation as PR #444: the maven repos for `dev.lavalink.youtube` and `moe.kyokobot.libdave` return 403 here, so `:discord-bot:compileKotlin` can't run in this environment. `:web:compileKotlin`, the 389 JS tests, and CSS lint all pass locally. CI will validate the Kotlin side.

https://claude.ai/code/session_01LtrsRHef6vCutebAv6a1Ye

---
_Generated by [Claude Code](https://claude.ai/code/session_01LtrsRHef6vCutebAv6a1Ye)_