### PR TITLE
feat(excuse): resolve author to current Discord name at display time

### DIFF
--- a/application/src/test/kotlin/web/service/ExcuseWebServiceTest.kt
+++ b/application/src/test/kotlin/web/service/ExcuseWebServiceTest.kt
@@ -351,4 +351,115 @@ class ExcuseWebServiceTest {
 
         assertNull(service.getRandomApproved(guildId))
     }
+
+    // resolveDisplayAuthor (exercised through getRandomApproved + getPage)
+
+    @Test
+    fun `getRandomApproved resolves author to current member effective name`() {
+        val row = ExcuseDto(
+            id = 9L,
+            guildId = guildId,
+            author = "OldSnapshot",
+            excuse = "the dog ate it",
+            approved = true,
+            authorDiscordId = authorDiscordId,
+        )
+        val guild = mockk<net.dv8tion.jda.api.entities.Guild>()
+        val member = mockk<net.dv8tion.jda.api.entities.Member>()
+        every { jda.getGuildById(guildId) } returns guild
+        every { guild.getMemberById(authorDiscordId) } returns member
+        every { member.effectiveName } returns "CurrentNick"
+        every { excuseService.listApprovedGuildExcuses(guildId) } returns listOf(row)
+
+        val pick = service.getRandomApproved(guildId)
+
+        assertNotNull(pick)
+        assertEquals("CurrentNick", pick!!.author)
+    }
+
+    @Test
+    fun `getRandomApproved falls back to JDA user name when member has left`() {
+        val row = ExcuseDto(
+            id = 9L,
+            guildId = guildId,
+            author = "OldSnapshot",
+            excuse = "x",
+            approved = true,
+            authorDiscordId = authorDiscordId,
+        )
+        val guild = mockk<net.dv8tion.jda.api.entities.Guild>()
+        val user = mockk<net.dv8tion.jda.api.entities.User>()
+        every { jda.getGuildById(guildId) } returns guild
+        every { guild.getMemberById(authorDiscordId) } returns null
+        every { jda.getUserById(authorDiscordId) } returns user
+        every { user.name } returns "GlobalName"
+        every { excuseService.listApprovedGuildExcuses(guildId) } returns listOf(row)
+
+        val pick = service.getRandomApproved(guildId)
+
+        assertEquals("GlobalName", pick!!.author)
+    }
+
+    @Test
+    fun `getRandomApproved falls back to snapshot when JDA lookups all miss`() {
+        val row = ExcuseDto(
+            id = 9L,
+            guildId = guildId,
+            author = "Legacy",
+            excuse = "x",
+            approved = true,
+            authorDiscordId = authorDiscordId,
+        )
+        every { jda.getGuildById(guildId) } returns null
+        every { jda.getUserById(authorDiscordId) } returns null
+        every { excuseService.listApprovedGuildExcuses(guildId) } returns listOf(row)
+
+        val pick = service.getRandomApproved(guildId)
+
+        assertEquals("Legacy", pick!!.author)
+    }
+
+    @Test
+    fun `getRandomApproved uses snapshot for legacy rows without authorDiscordId`() {
+        val row = ExcuseDto(
+            id = 9L,
+            guildId = guildId,
+            author = "Legacy",
+            excuse = "x",
+            approved = true,
+            authorDiscordId = null,
+        )
+        every { excuseService.listApprovedGuildExcuses(guildId) } returns listOf(row)
+
+        val pick = service.getRandomApproved(guildId)
+
+        assertEquals("Legacy", pick!!.author)
+    }
+
+    @Test
+    fun `getPage row view model uses current member name when authorDiscordId resolves`() {
+        val row = ExcuseDto(
+            id = 9L,
+            guildId = guildId,
+            author = "OldSnapshot",
+            excuse = "x",
+            approved = true,
+            authorDiscordId = authorDiscordId,
+        )
+        every { userService.getUserById(authorDiscordId, guildId) } returns mockk<UserDto> {
+            every { superUser } returns false
+        }
+        every {
+            excuseService.listApprovedPaged(guildId, 1, ExcuseWebService.PAGE_SIZE)
+        } returns PagedExcuses(listOf(row), 1, ExcuseWebService.PAGE_SIZE, 1L)
+        val guild = mockk<net.dv8tion.jda.api.entities.Guild>()
+        val member = mockk<net.dv8tion.jda.api.entities.Member>()
+        every { jda.getGuildById(guildId) } returns guild
+        every { guild.getMemberById(authorDiscordId) } returns member
+        every { member.effectiveName } returns "CurrentNick"
+
+        val result = service.getPage(guildId, "approved", null, 1, authorDiscordId)
+
+        assertEquals("CurrentNick", result.rows.first().author)
+    }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/button/buttons/ExcuseListPageButton.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/button/buttons/ExcuseListPageButton.kt
@@ -53,7 +53,7 @@ class ExcuseListPageButton @Autowired constructor(
             return
         }
 
-        val embed = ExcuseCommand.buildPageEmbed(paged, parsed.scope, parsed.query)
+        val embed = ExcuseCommand.buildPageEmbed(event.jda, guildId, paged, parsed.scope, parsed.query)
         val prevId = ExcuseCommand.encodePageButton(parsed.scope, guildId, paged.page - 1, parsed.query)
         val nextId = ExcuseCommand.encodePageButton(parsed.scope, guildId, paged.page + 1, parsed.query)
 

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/misc/ExcuseCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/misc/ExcuseCommand.kt
@@ -8,6 +8,7 @@ import database.dto.UserDto
 import database.service.ExcuseService
 import database.service.PagedExcuses
 import net.dv8tion.jda.api.EmbedBuilder
+import net.dv8tion.jda.api.JDA
 import net.dv8tion.jda.api.components.actionrow.ActionRow
 import net.dv8tion.jda.api.components.buttons.Button
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
@@ -89,8 +90,9 @@ class ExcuseCommand @Autowired constructor(
             return
         }
         val pick = approved.random()
+        val displayAuthor = resolveDisplayAuthor(event.jda, guildId, pick)
         event.hook.replyAndDelete(
-            "Excuse #${pick.id}: '${pick.excuse}' - ${pick.author}.",
+            "Excuse #${pick.id}: '${pick.excuse}' - $displayAuthor.",
             deleteDelay,
         )
     }
@@ -240,7 +242,7 @@ class ExcuseCommand @Autowired constructor(
             return
         }
 
-        val embed = buildPageEmbed(paged, scope, query)
+        val embed = buildPageEmbed(event.jda, guildId, paged, scope, query)
 
         if (paged.totalPages <= 1) {
             event.hook.replyEmbedAndDelete(embed, deleteDelay)
@@ -285,7 +287,13 @@ class ExcuseCommand @Autowired constructor(
         private const val OPT_QUERY = "query"
         private const val OPT_ID = "id"
 
-        fun buildPageEmbed(paged: PagedExcuses, scope: String, query: String?): net.dv8tion.jda.api.entities.MessageEmbed {
+        fun buildPageEmbed(
+            jda: JDA,
+            guildId: Long,
+            paged: PagedExcuses,
+            scope: String,
+            query: String?,
+        ): net.dv8tion.jda.api.entities.MessageEmbed {
             val title = when (scope) {
                 SCOPE_PENDING -> "Pending excuses"
                 SCOPE_SEARCH -> "Search results for '${query.orEmpty()}'"
@@ -296,13 +304,31 @@ class ExcuseCommand @Autowired constructor(
                 .setColor(Color(88, 101, 242))
             paged.rows.forEach { row ->
                 builder.addField(
-                    "#${row.id} — ${row.author ?: "Unknown"}",
+                    "#${row.id} — ${resolveDisplayAuthor(jda, guildId, row)}",
                     row.excuse.orEmpty().ifBlank { "(no text)" },
                     false,
                 )
             }
             builder.setFooter("Page ${paged.page} / ${paged.totalPages} · ${paged.totalCount} total")
             return builder.build()
+        }
+
+        /**
+         * Author rendering ladder: prefer the current guild-member effective
+         * name (picks up nickname changes), fall back to the cached Discord
+         * user name (member left the guild), then the snapshot recorded at
+         * submission (legacy rows from before authorDiscordId was a column),
+         * then a generic placeholder if everything is null.
+         */
+        fun resolveDisplayAuthor(jda: JDA, guildId: Long, row: ExcuseDto): String {
+            val authorId = row.authorDiscordId
+            if (authorId != null) {
+                val current = jda.getGuildById(guildId)?.getMemberById(authorId)
+                    ?.effectiveName?.takeIf { it.isNotBlank() }
+                    ?: jda.getUserById(authorId)?.name?.takeIf { it.isNotBlank() }
+                if (current != null) return current
+            }
+            return row.author?.takeIf { it.isNotBlank() } ?: "Unknown"
         }
 
         /**

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/misc/ExcuseCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/misc/ExcuseCommandTest.kt
@@ -356,4 +356,103 @@ internal class ExcuseCommandTest : CommandTest {
         assert(ExcuseCommand.decodePageButton("excuse-page:noop") == null)
         assert(ExcuseCommand.decodePageButton("excuse-page:approved:notanumber:1:") == null)
     }
+
+    // resolveDisplayAuthor
+
+    @Test
+    fun `resolveDisplayAuthor returns current member effective name when member exists`() {
+        val jda = mockk<net.dv8tion.jda.api.JDA>()
+        val guild = mockk<net.dv8tion.jda.api.entities.Guild>()
+        val member = mockk<net.dv8tion.jda.api.entities.Member>()
+        every { jda.getGuildById(1L) } returns guild
+        every { guild.getMemberById(42L) } returns member
+        every { member.effectiveName } returns "CurrentNick"
+
+        val row = ExcuseDto(id = 1L, guildId = 1L, author = "OldSnapshot", authorDiscordId = 42L)
+
+        val resolved = ExcuseCommand.resolveDisplayAuthor(jda, 1L, row)
+
+        assert(resolved == "CurrentNick") { "expected CurrentNick, got '$resolved'" }
+    }
+
+    @Test
+    fun `resolveDisplayAuthor falls back to user name when member has left the guild`() {
+        val jda = mockk<net.dv8tion.jda.api.JDA>()
+        val guild = mockk<net.dv8tion.jda.api.entities.Guild>()
+        val user = mockk<net.dv8tion.jda.api.entities.User>()
+        every { jda.getGuildById(1L) } returns guild
+        every { guild.getMemberById(42L) } returns null
+        every { jda.getUserById(42L) } returns user
+        every { user.name } returns "GlobalName"
+
+        val row = ExcuseDto(id = 1L, guildId = 1L, author = "OldSnapshot", authorDiscordId = 42L)
+
+        val resolved = ExcuseCommand.resolveDisplayAuthor(jda, 1L, row)
+
+        assert(resolved == "GlobalName") { "expected GlobalName, got '$resolved'" }
+    }
+
+    @Test
+    fun `resolveDisplayAuthor falls back to snapshot when both JDA lookups miss`() {
+        val jda = mockk<net.dv8tion.jda.api.JDA>()
+        every { jda.getGuildById(1L) } returns null
+        every { jda.getUserById(42L) } returns null
+
+        val row = ExcuseDto(id = 1L, guildId = 1L, author = "Legacy", authorDiscordId = 42L)
+
+        val resolved = ExcuseCommand.resolveDisplayAuthor(jda, 1L, row)
+
+        assert(resolved == "Legacy") { "expected Legacy, got '$resolved'" }
+    }
+
+    @Test
+    fun `resolveDisplayAuthor uses snapshot directly for legacy rows without authorDiscordId`() {
+        val jda = mockk<net.dv8tion.jda.api.JDA>()
+        // No JDA stubs needed — the resolver shouldn't touch JDA when authorDiscordId is null.
+
+        val row = ExcuseDto(id = 1L, guildId = 1L, author = "Legacy", authorDiscordId = null)
+
+        val resolved = ExcuseCommand.resolveDisplayAuthor(jda, 1L, row)
+
+        assert(resolved == "Legacy") { "expected Legacy, got '$resolved'" }
+    }
+
+    @Test
+    fun `resolveDisplayAuthor returns Unknown when everything is null`() {
+        val jda = mockk<net.dv8tion.jda.api.JDA>()
+        every { jda.getGuildById(any()) } returns null
+        every { jda.getUserById(any<Long>()) } returns null
+
+        val row = ExcuseDto(id = 1L, guildId = 1L, author = null, authorDiscordId = 42L)
+
+        val resolved = ExcuseCommand.resolveDisplayAuthor(jda, 1L, row)
+
+        assert(resolved == "Unknown") { "expected Unknown, got '$resolved'" }
+    }
+
+    @Test
+    fun `random uses current member name when authorDiscordId resolves`() {
+        val ctx = DefaultCommandContext(event)
+        val approved = ExcuseDto(
+            id = 5L,
+            guildId = 1L,
+            author = "OldSnapshot",
+            excuse = "the cat sat on it",
+            approved = true,
+            authorDiscordId = 99L,
+        )
+        every { event.subcommandName } returns ExcuseCommand.RANDOM
+        every { excuseService.listApprovedGuildExcuses(1L) } returns listOf(approved)
+
+        // Wire the JDA chain so resolveDisplayAuthor returns "NewNick".
+        val freshMember = mockk<net.dv8tion.jda.api.entities.Member>()
+        every { freshMember.effectiveName } returns "NewNick"
+        every { CommandTest.guild.getMemberById(99L) } returns freshMember
+        every { event.jda } returns CommandTest.jda
+        every { CommandTest.jda.getGuildById(1L) } returns CommandTest.guild
+
+        excuseCommand.handle(ctx, requestingUserDto, 0)
+
+        verify { event.hook.sendMessage("Excuse #5: 'the cat sat on it' - NewNick.") }
+    }
 }

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/misc/ExcuseCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/misc/ExcuseCommandTest.kt
@@ -420,7 +420,7 @@ internal class ExcuseCommandTest : CommandTest {
     @Test
     fun `resolveDisplayAuthor returns Unknown when everything is null`() {
         val jda = mockk<net.dv8tion.jda.api.JDA>()
-        every { jda.getGuildById(any()) } returns null
+        every { jda.getGuildById(any<Long>()) } returns null
         every { jda.getUserById(any<Long>()) } returns null
 
         val row = ExcuseDto(id = 1L, guildId = 1L, author = null, authorDiscordId = 42L)

--- a/web/src/main/kotlin/web/service/ExcuseWebService.kt
+++ b/web/src/main/kotlin/web/service/ExcuseWebService.kt
@@ -66,7 +66,7 @@ class ExcuseWebService(
             else -> excuseService.listApprovedPaged(guildId, page, PAGE_SIZE)
         }
 
-        val rows = paged.rows.map { it.toRowViewModel(requesterDiscordId, isSuper) }
+        val rows = paged.rows.map { it.toRowViewModel(guildId, requesterDiscordId, isSuper) }
 
         return ExcusePageViewModel(
             rows = rows,
@@ -85,8 +85,26 @@ class ExcuseWebService(
         return RandomExcuseViewModel(
             id = pick.id ?: 0L,
             text = pick.excuse.orEmpty(),
-            author = pick.author.orEmpty(),
+            author = resolveDisplayAuthor(guildId, pick),
         )
+    }
+
+    /**
+     * Author rendering ladder: prefer the current guild-member effective name
+     * (picks up nickname changes), fall back to the cached Discord user name
+     * (member left the guild), then the snapshot recorded at submission
+     * (legacy rows from before authorDiscordId was a column), then a generic
+     * placeholder if everything is null. Mirrors ExcuseCommand.resolveDisplayAuthor.
+     */
+    private fun resolveDisplayAuthor(guildId: Long, row: ExcuseDto): String {
+        val authorId = row.authorDiscordId
+        if (authorId != null) {
+            val current = jda.getGuildById(guildId)?.getMemberById(authorId)
+                ?.effectiveName?.takeIf { it.isNotBlank() }
+                ?: jda.getUserById(authorId)?.name?.takeIf { it.isNotBlank() }
+            if (current != null) return current
+        }
+        return row.author?.takeIf { it.isNotBlank() } ?: "Unknown"
     }
 
     /**
@@ -150,14 +168,18 @@ class ExcuseWebService(
         return null
     }
 
-    private fun ExcuseDto.toRowViewModel(requesterDiscordId: Long, isSuper: Boolean): ExcuseRowViewModel {
+    private fun ExcuseDto.toRowViewModel(
+        guildId: Long,
+        requesterDiscordId: Long,
+        isSuper: Boolean,
+    ): ExcuseRowViewModel {
         val isAuthor = authorDiscordId != null && authorDiscordId == requesterDiscordId
         val canDelete = isSuper || (!approved && isAuthor)
         val canApprove = isSuper && !approved
         return ExcuseRowViewModel(
             id = id ?: 0L,
             text = excuse.orEmpty(),
-            author = author.orEmpty(),
+            author = resolveDisplayAuthor(guildId, this),
             approved = approved,
             createdAt = createdAt,
             approvedAt = approvedAt,


### PR DESCRIPTION
## Summary

Follow-up to #443. The previous PR stored `author_discord_id` at submission but kept rendering the **snapshot** `author` string everywhere, so a user changing their server nickname left stale names attached to old excuses. This PR resolves the author through JDA at display time.

Render ladder, applied identically by `ExcuseCommand.resolveDisplayAuthor` (slash) and `ExcuseWebService.resolveDisplayAuthor` (web):

1. `guild.getMemberById(authorDiscordId)?.effectiveName` — picks up nicknames.
2. `jda.getUserById(authorDiscordId)?.name` — member left the guild but still cached as a user.
3. `row.author` — snapshot fallback for legacy rows where `authorDiscordId` is null.
4. `"Unknown"` — last-resort.

Each step also filters blanks so a member object without a usable name (or a relaxed test mock returning `""`) falls through to the next step.

### Callsites touched
- `ExcuseCommand.handleRandom` — `/excuse random` reply.
- `ExcuseCommand.buildPageEmbed` (now takes `jda, guildId`) — `/excuse list` and `/excuse search` embed field titles.
- `ExcuseListPageButton.handle` — paginator next/prev re-renders.
- `ExcuseWebService.getRandomApproved` — the web 🎲 Spin endpoint.
- `ExcuseWebService.toRowViewModel` — list/search row cards.

`handleSubmit` and the web `submit` path are untouched — they already resolve the current name to record as the snapshot, which is correct at submission time.

No schema change, no template change, no public API surface change.

## Test plan

- [ ] `./gradlew test` — new resolver tests cover all four ladder steps in both `ExcuseCommandTest` and `ExcuseWebServiceTest`; existing tests still green (`authorDiscordId = null` rows still render the snapshot).
- [ ] Dev guild: submit an excuse as a user nicknamed "Old". `/excuse random` shows "Old". Change nickname to "New". `/excuse random` now shows "New" for the same row.
- [ ] Same flow in `/excuses/{guildId}` 🎲 Spin and list cards.
- [ ] Kick the user — display falls back to JDA-cached user name.
- [ ] Manually insert a row with `author_discord_id = NULL` — display falls back to the stored snapshot.

https://claude.ai/code/session_017zT62SFU6i3HTKPf8LQQ91

---
_Generated by [Claude Code](https://claude.ai/code/session_017zT62SFU6i3HTKPf8LQQ91)_