### PR TITLE
feat(youtube): route YouTube traffic through optional rotating HTTP proxy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,9 @@ YOUTUBE_API_KEY=
 GOOGLE_REFRESH_TOKEN=
 DISCORD_CLIENT_ID=
 DISCORD_CLIENT_SECRET=
+# Optional: route YouTube traffic through an HTTP proxy to escape IP blocks
+# (use a rotating residential proxy provider such as Webshare, IPRoyal, etc.)
+YOUTUBE_PROXY_HOST=
+YOUTUBE_PROXY_PORT=
+YOUTUBE_PROXY_USER=
+YOUTUBE_PROXY_PASS=

--- a/README.md
+++ b/README.md
@@ -60,7 +60,11 @@ Requires [Docker Desktop](https://www.docker.com/products/docker-desktop/).
    | `TOKEN` | Yes | Discord bot token |
    | `DATABASE_URL` | Yes | PostgreSQL URL (`postgresql://user:pass@host:5432/db`) |
    | `YOUTUBE_API_KEY` | No | YouTube Data API key |
-   | `GOOGLE_REFRESH_TOKEN` | No | OAuth2 refresh token for YouTube playback |
+   | `GOOGLE_REFRESH_TOKEN` | No | OAuth2 refresh token for YouTube playback. See [lavaplayer-youtube OAuth2 docs](https://github.com/lavalink-devs/youtube-source#oauth-tokens) for how to mint one. Authenticated requests are far less likely to be IP-blocked. |
+   | `YOUTUBE_PROXY_HOST` | No | Hostname of an HTTP proxy to route YouTube traffic through (both lavaplayer playback and YouTube Data API). Use a rotating residential proxy provider (Webshare, IPRoyal, Bright Data, etc.) to avoid YouTube IP blocks without manually restarting the dyno. |
+   | `YOUTUBE_PROXY_PORT` | No | Port for the proxy above. Required if `YOUTUBE_PROXY_HOST` is set. |
+   | `YOUTUBE_PROXY_USER` | No | Username for proxy basic auth. Optional. |
+   | `YOUTUBE_PROXY_PASS` | No | Password for proxy basic auth. Optional. |
 
    **Option A — `.env` file** (copy the example and fill in your values):
 

--- a/discord-bot/build.gradle
+++ b/discord-bot/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.10.1'
     implementation "io.ktor:ktor-client-core:$ktor_version"
     implementation "io.ktor:ktor-client-cio:$ktor_version"
+    implementation "io.ktor:ktor-client-okhttp:$ktor_version"
     implementation "io.ktor:ktor-client-json:$ktor_version"
     implementation("io.ktor:ktor-serialization-kotlinx-json:$ktor_version")
     implementation "io.ktor:ktor-client-serialization:$ktor_version"

--- a/discord-bot/src/main/kotlin/bot/configuration/AppConfig.kt
+++ b/discord-bot/src/main/kotlin/bot/configuration/AppConfig.kt
@@ -2,14 +2,21 @@ package bot.configuration
 
 import bot.toby.handler.EventWaiter
 import bot.toby.helpers.HttpHelper
+import common.logging.DiscordLogger
 import io.ktor.client.*
-import io.ktor.client.engine.cio.*
+import io.ktor.client.engine.okhttp.*
 import io.ktor.client.plugins.contentnegotiation.*
 import io.ktor.serialization.kotlinx.json.*
 import kotlinx.serialization.json.Json
+import okhttp3.Authenticator
+import okhttp3.Credentials
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Profile
+import java.net.InetSocketAddress
+import java.net.Proxy
+
+private val logger: DiscordLogger = DiscordLogger.createLogger(AppConfig::class.java)
 
 @Profile("prod")
 @Configuration
@@ -17,9 +24,26 @@ class AppConfig {
 
     @Bean
     fun httpClient(): HttpClient {
-        return HttpClient(CIO) {
+        val proxy = YoutubeProxySettings.fromEnv()
+        return HttpClient(OkHttp) {
             install(ContentNegotiation) {
                 json(Json { ignoreUnknownKeys = true })
+            }
+            if (proxy != null) {
+                engine {
+                    config {
+                        proxy(Proxy(Proxy.Type.HTTP, InetSocketAddress(proxy.host, proxy.port)))
+                        if (proxy.hasAuth) {
+                            proxyAuthenticator(Authenticator { _, response ->
+                                val credential = Credentials.basic(proxy.user!!, proxy.pass!!)
+                                response.request.newBuilder()
+                                    .header("Proxy-Authorization", credential)
+                                    .build()
+                            })
+                        }
+                    }
+                }
+                logger.info { "Ktor HTTP proxy enabled: ${proxy.host}:${proxy.port} (auth=${proxy.hasAuth})" }
             }
         }
     }

--- a/discord-bot/src/main/kotlin/bot/configuration/YoutubeProxySettings.kt
+++ b/discord-bot/src/main/kotlin/bot/configuration/YoutubeProxySettings.kt
@@ -1,0 +1,25 @@
+package bot.configuration
+
+data class YoutubeProxySettings(
+    val host: String,
+    val port: Int,
+    val user: String?,
+    val pass: String?,
+) {
+    val hasAuth: Boolean get() = user != null && pass != null
+
+    companion object {
+        const val HOST_ENV = "YOUTUBE_PROXY_HOST"
+        const val PORT_ENV = "YOUTUBE_PROXY_PORT"
+        const val USER_ENV = "YOUTUBE_PROXY_USER"
+        const val PASS_ENV = "YOUTUBE_PROXY_PASS"
+
+        fun fromEnv(getenv: (String) -> String? = System::getenv): YoutubeProxySettings? {
+            val host = getenv(HOST_ENV)?.takeIf { it.isNotBlank() } ?: return null
+            val port = getenv(PORT_ENV)?.takeIf { it.isNotBlank() }?.toIntOrNull() ?: return null
+            val user = getenv(USER_ENV)?.takeIf { it.isNotBlank() }
+            val pass = getenv(PASS_ENV)?.takeIf { it.isNotBlank() }
+            return YoutubeProxySettings(host, port, user, pass)
+        }
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/lavaplayer/PlayerManager.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/lavaplayer/PlayerManager.kt
@@ -1,5 +1,6 @@
 package bot.toby.lavaplayer
 
+import bot.configuration.YoutubeProxySettings
 import com.sedmelluq.discord.lavaplayer.player.AudioLoadResultHandler
 import com.sedmelluq.discord.lavaplayer.player.AudioPlayerManager
 import com.sedmelluq.discord.lavaplayer.player.DefaultAudioPlayerManager
@@ -10,6 +11,7 @@ import com.sedmelluq.discord.lavaplayer.source.twitch.TwitchStreamAudioSourceMan
 import com.sedmelluq.discord.lavaplayer.tools.FriendlyException
 import com.sedmelluq.discord.lavaplayer.track.AudioPlaylist
 import com.sedmelluq.discord.lavaplayer.track.AudioTrack
+import common.logging.DiscordLogger
 import core.command.Command.Companion.replyAndDelete
 import dev.lavalink.youtube.YoutubeAudioSourceManager
 import dev.lavalink.youtube.YoutubeSourceOptions
@@ -20,10 +22,16 @@ import dev.lavalink.youtube.clients.TvHtml5Simply
 import dev.lavalink.youtube.clients.Web
 import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
+import org.apache.http.HttpHost
+import org.apache.http.auth.AuthScope
+import org.apache.http.auth.UsernamePasswordCredentials
+import org.apache.http.impl.client.BasicCredentialsProvider
 
 private const val CIPHER_API_URL = "https://cipher.kikkia.dev/api"
 
 private const val GOOGLE_REFRESH_TOKEN = "GOOGLE_REFRESH_TOKEN"
+
+private val logger: DiscordLogger = DiscordLogger.createLogger(PlayerManager::class.java)
 
 class PlayerManager(private val audioPlayerManager: AudioPlayerManager) {
     private val musicManagers: MutableMap<Long, GuildMusicManager> = HashMap()
@@ -37,6 +45,16 @@ class PlayerManager(private val audioPlayerManager: AudioPlayerManager) {
         val youtubeAudioSourceManager = YoutubeAudioSourceManager(youtubeSourceOptions, Tv(), TvHtml5Simply(), Web(), Music(), Android())
         val refreshToken = System.getenv(GOOGLE_REFRESH_TOKEN)?.takeIf { it.isNotBlank() }
         youtubeAudioSourceManager.useOauth2(refreshToken, refreshToken != null)
+        if (refreshToken != null) {
+            logger.info { "YouTube OAuth2 enabled via $GOOGLE_REFRESH_TOKEN." }
+        } else {
+            logger.warn {
+                "$GOOGLE_REFRESH_TOKEN not set — YouTube requests will be anonymous and more likely to be IP-blocked. " +
+                        "See README for how to obtain a refresh token."
+            }
+        }
+
+        configureYoutubeProxy(youtubeAudioSourceManager)
 
         audioPlayerManager.registerSourceManager(youtubeAudioSourceManager)
         audioPlayerManager.registerSourceManager(TwitchStreamAudioSourceManager())
@@ -119,6 +137,25 @@ class PlayerManager(private val audioPlayerManager: AudioPlayerManager) {
                 event?.hook?.replyAndDelete("Could not play: ${exception.message}", deleteDelay)
             }
         }
+    }
+
+    private fun configureYoutubeProxy(manager: YoutubeAudioSourceManager) {
+        val proxy = YoutubeProxySettings.fromEnv() ?: return
+        val httpHost = HttpHost(proxy.host, proxy.port)
+        val credentialsProvider = if (proxy.hasAuth) {
+            BasicCredentialsProvider().apply {
+                setCredentials(
+                    AuthScope(proxy.host, proxy.port),
+                    UsernamePasswordCredentials(proxy.user, proxy.pass)
+                )
+            }
+        } else null
+
+        manager.httpInterfaceManager.configureBuilder { builder ->
+            builder.setProxy(httpHost)
+            credentialsProvider?.let { builder.setDefaultCredentialsProvider(it) }
+        }
+        logger.info { "YouTube HTTP proxy enabled: ${proxy.host}:${proxy.port} (auth=${proxy.hasAuth})" }
     }
 
     fun destroyMusicManager(guildId: Long) {

--- a/discord-bot/src/test/kotlin/bot/configuration/YoutubeProxySettingsTest.kt
+++ b/discord-bot/src/test/kotlin/bot/configuration/YoutubeProxySettingsTest.kt
@@ -1,0 +1,98 @@
+package bot.configuration
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+internal class YoutubeProxySettingsTest {
+
+    private fun envOf(vararg pairs: Pair<String, String?>): (String) -> String? {
+        val map = pairs.toMap()
+        return { map[it] }
+    }
+
+    @Test
+    fun `returns null when host is missing`() {
+        val result = YoutubeProxySettings.fromEnv(
+            envOf(YoutubeProxySettings.PORT_ENV to "8080")
+        )
+        assertNull(result)
+    }
+
+    @Test
+    fun `returns null when host is blank`() {
+        val result = YoutubeProxySettings.fromEnv(
+            envOf(
+                YoutubeProxySettings.HOST_ENV to "  ",
+                YoutubeProxySettings.PORT_ENV to "8080",
+            )
+        )
+        assertNull(result)
+    }
+
+    @Test
+    fun `returns null when port is missing`() {
+        val result = YoutubeProxySettings.fromEnv(
+            envOf(YoutubeProxySettings.HOST_ENV to "proxy.example.com")
+        )
+        assertNull(result)
+    }
+
+    @Test
+    fun `returns null when port is not numeric`() {
+        val result = YoutubeProxySettings.fromEnv(
+            envOf(
+                YoutubeProxySettings.HOST_ENV to "proxy.example.com",
+                YoutubeProxySettings.PORT_ENV to "not-a-port",
+            )
+        )
+        assertNull(result)
+    }
+
+    @Test
+    fun `parses host and port without credentials`() {
+        val result = YoutubeProxySettings.fromEnv(
+            envOf(
+                YoutubeProxySettings.HOST_ENV to "proxy.example.com",
+                YoutubeProxySettings.PORT_ENV to "8080",
+            )
+        )!!
+        assertEquals("proxy.example.com", result.host)
+        assertEquals(8080, result.port)
+        assertNull(result.user)
+        assertNull(result.pass)
+        assertFalse(result.hasAuth)
+    }
+
+    @Test
+    fun `parses host port and credentials`() {
+        val result = YoutubeProxySettings.fromEnv(
+            envOf(
+                YoutubeProxySettings.HOST_ENV to "proxy.example.com",
+                YoutubeProxySettings.PORT_ENV to "8080",
+                YoutubeProxySettings.USER_ENV to "alice",
+                YoutubeProxySettings.PASS_ENV to "s3cret",
+            )
+        )!!
+        assertEquals("alice", result.user)
+        assertEquals("s3cret", result.pass)
+        assertTrue(result.hasAuth)
+    }
+
+    @Test
+    fun `treats blank credentials as absent`() {
+        val result = YoutubeProxySettings.fromEnv(
+            envOf(
+                YoutubeProxySettings.HOST_ENV to "proxy.example.com",
+                YoutubeProxySettings.PORT_ENV to "8080",
+                YoutubeProxySettings.USER_ENV to "  ",
+                YoutubeProxySettings.PASS_ENV to "",
+            )
+        )!!
+        assertNull(result.user)
+        assertNull(result.pass)
+        assertFalse(result.hasAuth)
+    }
+}


### PR DESCRIPTION
## Summary

YouTube intermittently IP-blocks the dyno, breaking both `/play` and intro-clip validation until the Heroku app is manually restarted in the hope of pulling a non-blocked IP. Restarting Heroku is just IP-pool roulette — this PR replaces it with two real fixes:

- **Surface OAuth2 status at startup.** Authenticated requests via `GOOGLE_REFRESH_TOKEN` (already wired in `PlayerManager`) are far less prone to anonymous-IP blocks. The bot now logs a clear WARN at boot when the token is missing, so misconfiguration is visible in Heroku logs instead of failing silently in the wild.
- **Provider-agnostic HTTP proxy support for YouTube traffic.** Setting `YOUTUBE_PROXY_HOST` / `YOUTUBE_PROXY_PORT` (plus optional `YOUTUBE_PROXY_USER` / `YOUTUBE_PROXY_PASS`) routes YouTube requests through a rotating residential proxy (Webshare's free tier works to validate; any HTTP/HTTPS proxy works). True dynamic IPs without restarting the dyno.

Coverage spans both code paths the user reported as broken:

| Flow | HTTP stack | Wired in |
|---|---|---|
| `/play` and intro **playback** | lavaplayer-youtube → Apache HTTP client | `PlayerManager.kt` (`configureYoutubeProxy`) |
| Intro **validation** (duration check via YouTube Data API) | Ktor `HttpClient` | `AppConfig.kt` (Ktor engine swap CIO → OkHttp + proxy/auth wiring) |

The Ktor engine swap (CIO → OkHttp) was needed because Ktor CIO doesn't carry proxy basic-auth credentials through to upstream proxies, and most rotating residential proxies require auth. OkHttp's `proxyAuthenticator` handles it cleanly.

All four env vars are opt-in — when unset, behavior is identical to today (apart from the new OAuth2 status log line at startup).

## Test plan

- [ ] CI: `./gradlew build` succeeds (build env here can't reach `maven.lavalink.dev` so couldn't verify locally)
- [ ] Existing `HttpHelperTest` suite still passes (uses `MockEngine`, engine-agnostic)
- [ ] New `YoutubeProxySettingsTest` covers parsing, blank handling, partial credentials
- [ ] Local sanity (post-merge or in a branch deploy): boot with no proxy env vars → log shows OAuth2 status only, behavior unchanged
- [ ] Local sanity: boot with bogus `YOUTUBE_PROXY_HOST=127.0.0.1 YOUTUBE_PROXY_PORT=1` → track loads fail with proxy connection error (proves wiring is live)
- [ ] End-to-end on Heroku: set Webshare free-tier creds, restart once, confirm `/play` works and `Ktor HTTP proxy enabled` + `YouTube HTTP proxy enabled` lines appear in logs
- [ ] End-to-end on Heroku: clip an intro from a YouTube URL, confirm validation succeeds (previously failed silently as "intro too long" when YouTube Data API was IP-blocked)

https://claude.ai/code/session_01GjpAFwFXCG3KJgz7pWev2z

---
_Generated by [Claude Code](https://claude.ai/code/session_01GjpAFwFXCG3KJgz7pWev2z)_