### PR TITLE
feat(web): centralised searchable user picker for every user dropdown

### DIFF
--- a/web/src/main/resources/static/css/base.css
+++ b/web/src/main/resources/static/css/base.css
@@ -966,3 +966,144 @@ td { font-size: 0.95rem; }
     .lb-rank { width: 24px; height: 24px; font-size: 0.8rem; }
     .lb-title-pill { font-size: 0.75rem; padding: 1px 6px; }
 }
+
+/* ---- Searchable user picker (templates/fragments/userPicker.html
+   + static/js/userPicker.js). Lives in base.css so every page that
+   includes the fragment gets the styling without an extra <link>. ---- */
+.user-picker { position: relative; }
+.user-picker__native {
+    position: absolute;
+    left: 0; top: 0;
+    width: 1px; height: 1px;
+    opacity: 0;
+    pointer-events: none;
+}
+.user-picker__field {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--space-2);
+    min-height: 40px;
+    background: var(--bg-input);
+    color: var(--text);
+    border: 1px solid var(--border-strong);
+    border-radius: var(--radius-md);
+    padding: var(--space-2) var(--space-3);
+    cursor: text;
+    font-size: 0.95rem;
+    transition: border-color 0.15s, box-shadow 0.15s;
+}
+.user-picker__field:hover { border-color: var(--accent); }
+.user-picker__field:focus,
+.user-picker__field[aria-expanded="true"] {
+    outline: none;
+    border-color: var(--accent);
+    box-shadow: 0 0 0 3px rgba(88, 101, 242, 0.2);
+}
+.user-picker__chips { display: contents; }
+.user-picker__chip {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-1);
+    background: var(--accent-soft);
+    color: var(--text);
+    border: 1px solid var(--border-strong);
+    border-radius: var(--radius-sm);
+    padding: 2px var(--space-2);
+    font-size: 0.85rem;
+    max-width: 220px;
+}
+.user-picker__chip > span:first-child {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.user-picker__chip-remove {
+    background: none;
+    border: none;
+    color: var(--text-muted);
+    cursor: pointer;
+    font-size: 1rem;
+    line-height: 1;
+    padding: 0 var(--space-1);
+    border-radius: var(--radius-sm);
+}
+.user-picker__chip-remove:hover { color: #fff; background: var(--accent); }
+.user-picker__value {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.user-picker__value--placeholder { color: var(--text-muted); }
+.user-picker__caret {
+    color: var(--text-muted);
+    font-size: 0.8rem;
+    margin-left: var(--space-2);
+}
+.user-picker__panel {
+    position: absolute;
+    top: calc(100% + 4px);
+    left: 0;
+    right: 0;
+    z-index: 30;
+    background: var(--bg-elevated);
+    border: 1px solid var(--border-strong);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-md);
+    max-height: 280px;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+.user-picker__panel[hidden] { display: none; }
+.user-picker__input {
+    background: var(--bg-input);
+    color: var(--text);
+    border: none;
+    border-bottom: 1px solid var(--border);
+    padding: var(--space-2) var(--space-3);
+    font-size: 0.95rem;
+    font-family: inherit;
+    width: 100%;
+}
+.user-picker__input::placeholder { color: var(--text-muted); }
+.user-picker__input:focus { outline: none; }
+.user-picker__list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    overflow-y: auto;
+    flex: 1;
+}
+.user-picker__option {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    padding: var(--space-2) var(--space-3);
+    cursor: pointer;
+}
+.user-picker__option.is-highlighted { background: var(--accent-soft); }
+.user-picker__option.is-selected { color: var(--accent); font-weight: 500; }
+.user-picker__option-label {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.user-picker__avatar {
+    width: 22px;
+    height: 22px;
+    border-radius: 50%;
+    object-fit: cover;
+    flex: 0 0 auto;
+}
+.user-picker__check { color: var(--accent); }
+.user-picker__empty {
+    padding: var(--space-3);
+    color: var(--text-muted);
+    text-align: center;
+    font-size: 0.85rem;
+}

--- a/web/src/main/resources/static/js/userPicker.js
+++ b/web/src/main/resources/static/js/userPicker.js
@@ -1,0 +1,324 @@
+// Searchable user picker. Finds every <select data-user-picker> on the
+// page and replaces it with a typeahead combobox (chips when multiple),
+// keeping the native <select> hidden in the DOM so the form posts the
+// same fields and the page still works with JavaScript disabled.
+(function () {
+    'use strict';
+
+    function init(select) {
+        if (select.dataset.userPickerReady === '1') return;
+        select.dataset.userPickerReady = '1';
+
+        const multiple = select.multiple;
+        const wrapper = select.closest('.user-picker');
+        if (!wrapper) return;
+        const placeholder = wrapper.dataset.placeholder || 'Search…';
+
+        select.classList.add('user-picker__native');
+        select.setAttribute('aria-hidden', 'true');
+        select.setAttribute('tabindex', '-1');
+
+        const fieldId = select.id || ('userPicker-' + Math.random().toString(36).slice(2));
+        const listId = fieldId + '-list';
+
+        const field = document.createElement('div');
+        field.className = 'user-picker__field';
+        field.setAttribute('role', 'combobox');
+        field.setAttribute('aria-haspopup', 'listbox');
+        field.setAttribute('aria-expanded', 'false');
+        field.setAttribute('aria-controls', listId);
+        field.tabIndex = 0;
+
+        const chipBar = document.createElement('span');
+        chipBar.className = 'user-picker__chips';
+
+        const valueLabel = document.createElement('span');
+        valueLabel.className = 'user-picker__value';
+
+        const caret = document.createElement('span');
+        caret.className = 'user-picker__caret';
+        caret.setAttribute('aria-hidden', 'true');
+        caret.textContent = '▾';
+
+        field.appendChild(chipBar);
+        field.appendChild(valueLabel);
+        field.appendChild(caret);
+
+        const panel = document.createElement('div');
+        panel.className = 'user-picker__panel';
+        panel.hidden = true;
+
+        const input = document.createElement('input');
+        input.type = 'search';
+        input.className = 'user-picker__input';
+        input.placeholder = 'Type to filter…';
+        input.autocomplete = 'off';
+        input.setAttribute('aria-controls', listId);
+
+        const list = document.createElement('ul');
+        list.className = 'user-picker__list';
+        list.id = listId;
+        list.setAttribute('role', 'listbox');
+        if (multiple) list.setAttribute('aria-multiselectable', 'true');
+
+        panel.appendChild(input);
+        panel.appendChild(list);
+        wrapper.appendChild(field);
+        wrapper.appendChild(panel);
+
+        // Cache the picker-eligible options. The empty-value option (if
+        // any) stays in the <select> for form fallback but is never
+        // shown in the combobox list — picking nothing from the list
+        // means leaving the select on its empty value.
+        const options = Array.from(select.options)
+            .filter(opt => opt.value !== '')
+            .map((opt, i) => ({
+                el: opt,
+                value: opt.value,
+                label: (opt.textContent || '').trim(),
+                labelLc: (opt.textContent || '').trim().toLowerCase(),
+                avatar: opt.dataset.avatar || '',
+                domId: listId + '-opt-' + i
+            }));
+
+        let highlightedIndex = -1;
+
+        function visibleItems() {
+            return Array.from(list.querySelectorAll('.user-picker__option'));
+        }
+
+        function updateHighlight() {
+            const items = visibleItems();
+            items.forEach((li, i) => li.classList.toggle('is-highlighted', i === highlightedIndex));
+            const active = items[highlightedIndex];
+            if (active) {
+                field.setAttribute('aria-activedescendant', active.id);
+                active.scrollIntoView({ block: 'nearest' });
+            } else {
+                field.removeAttribute('aria-activedescendant');
+            }
+        }
+
+        function renderList(query) {
+            const q = (query || '').trim().toLowerCase();
+            list.innerHTML = '';
+            let shown = 0;
+            options.forEach(o => {
+                if (q && !o.labelLc.includes(q)) return;
+                const li = document.createElement('li');
+                li.className = 'user-picker__option';
+                li.setAttribute('role', 'option');
+                li.id = o.domId;
+                li.dataset.value = o.value;
+                const isSelected = multiple ? o.el.selected : (select.value === o.value);
+                if (isSelected) {
+                    li.classList.add('is-selected');
+                    li.setAttribute('aria-selected', 'true');
+                }
+                if (o.avatar) {
+                    const img = document.createElement('img');
+                    img.className = 'user-picker__avatar';
+                    img.src = o.avatar;
+                    img.alt = '';
+                    li.appendChild(img);
+                }
+                const text = document.createElement('span');
+                text.className = 'user-picker__option-label';
+                text.textContent = o.label;
+                li.appendChild(text);
+                if (multiple && isSelected) {
+                    const check = document.createElement('span');
+                    check.className = 'user-picker__check';
+                    check.setAttribute('aria-hidden', 'true');
+                    check.textContent = '✓';
+                    li.appendChild(check);
+                }
+                list.appendChild(li);
+                shown++;
+            });
+            if (shown === 0) {
+                const empty = document.createElement('li');
+                empty.className = 'user-picker__empty';
+                empty.textContent = 'No matches';
+                list.appendChild(empty);
+            }
+            highlightedIndex = -1;
+            updateHighlight();
+        }
+
+        function renderChips() {
+            chipBar.innerHTML = '';
+            if (!multiple) {
+                const sel = select.selectedOptions[0];
+                if (sel && sel.value) {
+                    valueLabel.textContent = sel.textContent.trim();
+                    valueLabel.classList.remove('user-picker__value--placeholder');
+                } else {
+                    valueLabel.textContent = placeholder;
+                    valueLabel.classList.add('user-picker__value--placeholder');
+                }
+                return;
+            }
+            const selected = Array.from(select.selectedOptions).filter(o => o.value !== '');
+            if (selected.length === 0) {
+                valueLabel.textContent = placeholder;
+                valueLabel.classList.add('user-picker__value--placeholder');
+                return;
+            }
+            valueLabel.textContent = '';
+            valueLabel.classList.remove('user-picker__value--placeholder');
+            selected.forEach(opt => {
+                const chip = document.createElement('span');
+                chip.className = 'user-picker__chip';
+                chip.dataset.value = opt.value;
+                const lab = document.createElement('span');
+                lab.textContent = opt.textContent.trim();
+                chip.appendChild(lab);
+                const x = document.createElement('button');
+                x.type = 'button';
+                x.className = 'user-picker__chip-remove';
+                x.setAttribute('aria-label', 'Remove ' + opt.textContent.trim());
+                x.textContent = '×';
+                x.addEventListener('click', e => {
+                    e.stopPropagation();
+                    opt.selected = false;
+                    sync();
+                    if (!panel.hidden) renderList(input.value);
+                });
+                chip.appendChild(x);
+                chipBar.appendChild(chip);
+            });
+        }
+
+        function sync() {
+            renderChips();
+            select.dispatchEvent(new Event('change', { bubbles: true }));
+        }
+
+        function pick(value) {
+            const opt = Array.from(select.options).find(o => o.value === value);
+            if (!opt) return;
+            if (multiple) {
+                opt.selected = !opt.selected;
+                sync();
+                renderList(input.value);
+                input.focus();
+            } else {
+                select.value = value;
+                sync();
+                close();
+            }
+        }
+
+        function open() {
+            if (!panel.hidden) return;
+            panel.hidden = false;
+            field.setAttribute('aria-expanded', 'true');
+            input.value = '';
+            renderList('');
+            if (!multiple) {
+                const items = visibleItems();
+                highlightedIndex = items.findIndex(li => li.classList.contains('is-selected'));
+                updateHighlight();
+            }
+            requestAnimationFrame(() => input.focus());
+        }
+
+        function close() {
+            if (panel.hidden) return;
+            panel.hidden = true;
+            field.setAttribute('aria-expanded', 'false');
+            input.value = '';
+        }
+
+        field.addEventListener('click', open);
+        field.addEventListener('keydown', e => {
+            if (e.key === 'Enter' || e.key === ' ' || e.key === 'ArrowDown') {
+                e.preventDefault();
+                open();
+            }
+        });
+
+        input.addEventListener('input', () => renderList(input.value));
+        input.addEventListener('keydown', e => {
+            const items = visibleItems();
+            if (e.key === 'ArrowDown') {
+                e.preventDefault();
+                if (items.length === 0) return;
+                highlightedIndex = (highlightedIndex + 1) % items.length;
+                updateHighlight();
+            } else if (e.key === 'ArrowUp') {
+                e.preventDefault();
+                if (items.length === 0) return;
+                highlightedIndex = highlightedIndex <= 0 ? items.length - 1 : highlightedIndex - 1;
+                updateHighlight();
+            } else if (e.key === 'Enter') {
+                e.preventDefault();
+                if (highlightedIndex >= 0 && items[highlightedIndex]) {
+                    pick(items[highlightedIndex].dataset.value);
+                } else if (items.length === 1) {
+                    pick(items[0].dataset.value);
+                }
+            } else if (e.key === 'Escape') {
+                e.preventDefault();
+                close();
+                field.focus();
+            } else if (e.key === 'Backspace' && multiple && input.value === '') {
+                const sel = Array.from(select.selectedOptions).filter(o => o.value !== '');
+                if (sel.length > 0) {
+                    sel[sel.length - 1].selected = false;
+                    sync();
+                    renderList(input.value);
+                }
+            }
+        });
+
+        list.addEventListener('click', e => {
+            const li = e.target.closest('.user-picker__option');
+            if (li && li.dataset.value != null) pick(li.dataset.value);
+        });
+        list.addEventListener('mousemove', e => {
+            const li = e.target.closest('.user-picker__option');
+            if (!li) return;
+            const items = visibleItems();
+            const i = items.indexOf(li);
+            if (i !== highlightedIndex) {
+                highlightedIndex = i;
+                updateHighlight();
+            }
+        });
+
+        document.addEventListener('click', e => {
+            if (!wrapper.contains(e.target)) close();
+        });
+
+        // Redirect clicks on the associated <label for="…"> to the
+        // visible field. Without this, label clicks focus the hidden
+        // native <select> and nothing on screen reacts.
+        if (select.id) {
+            try {
+                const ownLabel = document.querySelector('label[for="' + CSS.escape(select.id) + '"]');
+                if (ownLabel) {
+                    ownLabel.addEventListener('click', e => {
+                        e.preventDefault();
+                        open();
+                    });
+                }
+            } catch (_) { /* CSS.escape unsupported; skip */ }
+        }
+
+        renderChips();
+    }
+
+    function initAll(root) {
+        (root || document).querySelectorAll('select[data-user-picker]').forEach(init);
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', () => initAll());
+    } else {
+        initAll();
+    }
+
+    window.UserPicker = { init: initAll };
+})();

--- a/web/src/main/resources/templates/duel.html
+++ b/web/src/main/resources/templates/duel.html
@@ -24,10 +24,16 @@
         <h2>Challenge someone</h2>
         <form id="duel-challenge" autocomplete="off">
             <label for="duel-opponent">Opponent</label>
-            <select id="duel-opponent" name="opponentDiscordId" required>
-                <option value="">Pick an opponent…</option>
-                <option th:each="m : ${members}" th:value="${m.id}" th:text="${m.name}"></option>
-            </select>
+            <div th:replace="~{fragments/userPicker :: userPicker(
+                    name='opponentDiscordId',
+                    id='duel-opponent',
+                    members=${members},
+                    selectedId=null,
+                    placeholder='Pick an opponent…',
+                    emptyLabel=null,
+                    required=true,
+                    multiple=false,
+                    showSocialCredit=false)}"></div>
             <p th:if="${#lists.isEmpty(members)}" class="muted">
                 No other members found in this server. Try again in a moment if the bot just connected.
             </p>
@@ -85,6 +91,7 @@
 
 <script th:src="@{/js/api.js}"></script>
 <script th:src="@{/js/toasts.js}"></script>
+<script th:src="@{/js/userPicker.js}"></script>
 <script th:src="@{/js/duel.js}"></script>
 </body>
 </html>

--- a/web/src/main/resources/templates/excuses.html
+++ b/web/src/main/resources/templates/excuses.html
@@ -144,12 +144,16 @@
             <!-- Superuser override: attribute to another member -->
             <div class="form-group" th:if="${isSuperUser}">
                 <label for="authorSelect">Attribute to (superuser only)</label>
-                <select id="authorSelect" name="authorDiscordId">
-                    <option value="">(Yourself)</option>
-                    <option th:each="m : ${members}"
-                            th:value="${m.id}"
-                            th:text="${m.name}"></option>
-                </select>
+                <div th:replace="~{fragments/userPicker :: userPicker(
+                        name='authorDiscordId',
+                        id='authorSelect',
+                        members=${members},
+                        selectedId=null,
+                        placeholder='(Yourself)',
+                        emptyLabel='(Yourself)',
+                        required=false,
+                        multiple=false,
+                        showSocialCredit=false)}"></div>
             </div>
 
             <button type="submit" class="btn">Submit for approval</button>
@@ -159,6 +163,7 @@
 
 <script th:src="@{/js/api.js}"></script>
 <script th:src="@{/js/toasts.js}"></script>
+<script th:src="@{/js/userPicker.js}"></script>
 <script th:src="@{/js/excuses.js}"></script>
 <script th:src="@{/js/home.js}"></script>
 </body>

--- a/web/src/main/resources/templates/fragments/userPicker.html
+++ b/web/src/main/resources/templates/fragments/userPicker.html
@@ -1,0 +1,39 @@
+<!--
+  Searchable user picker. Renders a native <select> (so the form
+  still posts the same field with no JS) which userPicker.js
+  progressively enhances into a typeahead combobox — and into a
+  chip-style multi-select when `multiple=true`.
+
+  Params (use named args at the call site):
+    name             form field name (matches existing <select name=…>)
+    id               DOM id used by the <label for="…">
+    members          iterable of objects exposing .id, .name (and
+                     optional .avatarUrl, .socialCredit)
+    selectedId       pre-selected member id; pass null for none
+    placeholder      text shown when nothing is picked
+    emptyLabel       label for the empty-string option, e.g. "(Yourself)".
+                     Pass null to omit — required selects rely on that.
+    required         boolean — forwards to the <select>
+    multiple         boolean — multi-select + chip UI
+    showSocialCredit boolean — appends " — N credits" and a data-credit
+                     attribute so the casino refund picker can display
+                     and read balances without a separate template.
+-->
+<div xmlns:th="http://www.thymeleaf.org"
+     th:fragment="userPicker(name, id, members, selectedId, placeholder, emptyLabel, required, multiple, showSocialCredit)"
+     class="user-picker"
+     th:attr="data-placeholder=${placeholder}">
+    <select th:id="${id}"
+            th:name="${name}"
+            th:required="${required}"
+            th:multiple="${multiple}"
+            data-user-picker>
+        <option th:if="${emptyLabel != null}" value="" th:text="${emptyLabel}"></option>
+        <option th:each="m : ${members}"
+                th:value="${m.id}"
+                th:attr="data-avatar=${m.avatarUrl},
+                         data-credit=${showSocialCredit ? m.socialCredit : null}"
+                th:text="${showSocialCredit ? m.name + ' — ' + m.socialCredit + ' credits' : m.name}"
+                th:selected="${selectedId != null and m.id == selectedId.toString()}"></option>
+    </select>
+</div>

--- a/web/src/main/resources/templates/intros.html
+++ b/web/src/main/resources/templates/intros.html
@@ -41,13 +41,16 @@
     <section th:if="${isSuperUser}" class="member-picker-card" aria-labelledby="manage-for">
         <div class="picker-row">
             <label id="manage-for" for="memberSelect" style="margin:0;">Manage intros for</label>
-            <select id="memberSelect" name="memberSelect">
-                <option value="">(Yourself)</option>
-                <option th:each="m : ${members}"
-                        th:value="${m.id}"
-                        th:text="${m.name}"
-                        th:selected="${targetDiscordId != null and m.id == targetDiscordId.toString()}"></option>
-            </select>
+            <div th:replace="~{fragments/userPicker :: userPicker(
+                    name='memberSelect',
+                    id='memberSelect',
+                    members=${members},
+                    selectedId=${targetDiscordId},
+                    placeholder='(Yourself)',
+                    emptyLabel='(Yourself)',
+                    required=false,
+                    multiple=false,
+                    showSocialCredit=false)}"></div>
             <span th:if="${targetDiscordId != null}" class="target-badge">Super-user mode</span>
         </div>
     </section>
@@ -329,6 +332,7 @@
 
 <script th:src="@{/js/api.js}"></script>
 <script th:src="@{/js/toasts.js}"></script>
+<script th:src="@{/js/userPicker.js}"></script>
 <script th:src="@{/js/modal.js}"></script>
 <script th:src="@{/js/intros.js}"></script>
 <script th:src="@{/js/home.js}"></script>

--- a/web/src/main/resources/templates/moderation/casino.html
+++ b/web/src/main/resources/templates/moderation/casino.html
@@ -44,17 +44,17 @@
                 clawback when the player profited from a spent pool.
             </p>
             <form class="jackpot-refund-form" autocomplete="off">
-                <label>
-                    User
-                    <select name="sourceDiscordId" required>
-                        <option value="" disabled selected>Select a member…</option>
-                        <option th:each="m : ${overview.members}"
-                                th:value="${m.id}"
-                                th:attr="data-credit=${m.socialCredit}"
-                                th:text="${m.name} + ' — ' + ${m.socialCredit} + ' credits'">
-                        </option>
-                    </select>
-                </label>
+                <label for="jackpot-refund-user">User</label>
+                <div th:replace="~{fragments/userPicker :: userPicker(
+                        name='sourceDiscordId',
+                        id='jackpot-refund-user',
+                        members=${overview.members},
+                        selectedId=null,
+                        placeholder='Select a member…',
+                        emptyLabel=null,
+                        required=true,
+                        multiple=false,
+                        showSocialCredit=true)}"></div>
                 <p class="muted jackpot-refund-balance" hidden>
                     Current balance: <span class="jackpot-refund-balance-value">0</span> credits
                 </p>
@@ -70,6 +70,7 @@
 
 <script th:src="@{/js/api.js}"></script>
 <script th:src="@{/js/toasts.js}"></script>
+<script th:src="@{/js/userPicker.js}"></script>
 <script th:src="@{/js/moderationCommon.js}"></script>
 <script th:src="@{/js/moderation/casino.js}"></script>
 </body>

--- a/web/src/main/resources/templates/moderation/voice.html
+++ b/web/src/main/resources/templates/moderation/voice.html
@@ -44,15 +44,17 @@
                             th:text="${vc.name}"></option>
                 </select>
             </label>
-            <label>
-                Members (ctrl+click for multi)
-                <select name="memberIds" multiple size="6" required>
-                    <option th:each="m : ${overview.members}"
-                            th:if="${!m.isBot}"
-                            th:value="${m.id}"
-                            th:text="${m.name}"></option>
-                </select>
-            </label>
+            <label for="move-members">Members</label>
+            <div th:replace="~{fragments/userPicker :: userPicker(
+                    name='memberIds',
+                    id='move-members',
+                    members=${overview.members},
+                    selectedId=null,
+                    placeholder='Pick members to move…',
+                    emptyLabel=null,
+                    required=true,
+                    multiple=true,
+                    showSocialCredit=false)}"></div>
             <button type="submit" class="btn">Move</button>
         </form>
     </section>
@@ -60,6 +62,7 @@
 
 <script th:src="@{/js/api.js}"></script>
 <script th:src="@{/js/toasts.js}"></script>
+<script th:src="@{/js/userPicker.js}"></script>
 <script th:src="@{/js/moderationCommon.js}"></script>
 <script th:src="@{/js/moderation/voice.js}"></script>
 </body>

--- a/web/src/main/resources/templates/tip.html
+++ b/web/src/main/resources/templates/tip.html
@@ -23,10 +23,16 @@
     <section class="tip-card">
         <form id="tip-form" autocomplete="off">
             <label for="tip-recipient">Recipient</label>
-            <select id="tip-recipient" name="recipientDiscordId" required>
-                <option value="">Pick a recipient…</option>
-                <option th:each="m : ${members}" th:value="${m.id}" th:text="${m.name}"></option>
-            </select>
+            <div th:replace="~{fragments/userPicker :: userPicker(
+                    name='recipientDiscordId',
+                    id='tip-recipient',
+                    members=${members},
+                    selectedId=null,
+                    placeholder='Pick a recipient…',
+                    emptyLabel=null,
+                    required=true,
+                    multiple=false,
+                    showSocialCredit=false)}"></div>
             <p th:if="${#lists.isEmpty(members)}" class="muted">
                 No other members found in this server. Try again in a moment if the bot just connected.
             </p>
@@ -57,6 +63,7 @@
 
 <script th:src="@{/js/api.js}"></script>
 <script th:src="@{/js/toasts.js}"></script>
+<script th:src="@{/js/userPicker.js}"></script>
 <script th:src="@{/js/casino-balance.js}"></script>
 <script th:src="@{/js/tip.js}"></script>
 </body>


### PR DESCRIPTION
## Summary

Every form that lets you pick a member — tip recipient, duel opponent, excuse attribution, intro management, voice move targets, casino jackpot refund — used a plain `<select>` populated with `${members}`. On servers with lots of members those dropdowns are a long scroll. This PR replaces all of them with a single searchable typeahead component.

- New fragment `templates/fragments/userPicker.html` — one signature handles single-select, multi-select with chips, optional pre-selection, optional `(Yourself)` empty option, and the casino refund's `name — N credits` formatting.
- New `static/js/userPicker.js` — progressive enhancement: the fragment still renders a real `<select>` (so the form posts the same fields and the page works with JS off), and the script hides it and builds a combobox UI in its place. Existing page JS keeps working because the underlying `<select>` stays in the DOM and a `change` event fires on every pick.
- Styles appended to `static/css/base.css` so every page that uses the fragment picks them up automatically (no per-page link tag needed).

Pages migrated: `tip.html`, `duel.html`, `excuses.html`, `intros.html`, `moderation/voice.html` (multi-select with chips), `moderation/casino.html` (keeps the `data-credit` data attr so `casino.js`'s live balance hint still works). The `moderation/users.html` config page already has a search-and-filter table and is left alone.

## Test plan
- [x] `./gradlew :web:test` passes (`FragmentSignatureTest` confirms every call site matches the fragment's 9-param signature)
- [ ] Manual: open each migrated page, type to filter, pick a member, submit the form — confirm the right id reaches the controller
- [ ] Manual: voice move — pick two members, remove one with the chip × and one with Backspace; submit; confirm both `memberIds` were sent before removal and just one after
- [ ] Manual: casino refund — pick a member and confirm the "Current balance: …" hint still updates (proves the `change` event still fires)
- [ ] Manual: intros — load `?targetDiscordId=…` and confirm the picker shows the target as the initial value
- [ ] Manual (regression): disable JS and confirm each page still renders a usable native `<select>` and submits correctly
- [ ] Manual (a11y): keyboard-only — Tab to picker, Enter to open, type, ↓/↑ to navigate, Enter to pick, Esc to close

https://claude.ai/code/session_011DTrWRm1qPXDzkjTgiUNyL

---
_Generated by [Claude Code](https://claude.ai/code/session_011DTrWRm1qPXDzkjTgiUNyL)_