### PR TITLE
feat(youtube): route web intro preview through proxy + surface validation errors

### DIFF
--- a/common/src/main/kotlin/common/configuration/YoutubeProxySettings.kt
+++ b/common/src/main/kotlin/common/configuration/YoutubeProxySettings.kt
@@ -1,4 +1,4 @@
-package bot.configuration
+package common.configuration
 
 data class YoutubeProxySettings(
     val host: String,

--- a/common/src/test/kotlin/common/configuration/YoutubeProxySettingsTest.kt
+++ b/common/src/test/kotlin/common/configuration/YoutubeProxySettingsTest.kt
@@ -1,4 +1,4 @@
-package bot.configuration
+package common.configuration
 
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse

--- a/discord-bot/src/main/kotlin/bot/configuration/AppConfig.kt
+++ b/discord-bot/src/main/kotlin/bot/configuration/AppConfig.kt
@@ -2,6 +2,7 @@ package bot.configuration
 
 import bot.toby.handler.EventWaiter
 import bot.toby.helpers.HttpHelper
+import common.configuration.YoutubeProxySettings
 import common.logging.DiscordLogger
 import io.ktor.client.*
 import io.ktor.client.engine.okhttp.*

--- a/discord-bot/src/main/kotlin/bot/toby/intro/IntroValidationService.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/intro/IntroValidationService.kt
@@ -53,8 +53,8 @@ class IntroValidationService(
         scope.launch {
             try {
                 onResult(checkForOverlyLongIntroDuration(url))
-            } catch (_: Exception) {
-                logger.error { "Error checking intro length for '$url'" }
+            } catch (e: Exception) {
+                logger.error { "Error checking intro length for '$url': ${e::class.simpleName}: ${e.message}" }
                 onResult(true)
             }
         }

--- a/discord-bot/src/main/kotlin/bot/toby/lavaplayer/PlayerManager.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/lavaplayer/PlayerManager.kt
@@ -1,6 +1,6 @@
 package bot.toby.lavaplayer
 
-import bot.configuration.YoutubeProxySettings
+import common.configuration.YoutubeProxySettings
 import com.sedmelluq.discord.lavaplayer.player.AudioLoadResultHandler
 import com.sedmelluq.discord.lavaplayer.player.AudioPlayerManager
 import com.sedmelluq.discord.lavaplayer.player.DefaultAudioPlayerManager

--- a/web/src/main/kotlin/web/service/IntroWebService.kt
+++ b/web/src/main/kotlin/web/service/IntroWebService.kt
@@ -2,6 +2,7 @@ package web.service
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.github.benmanes.caffeine.cache.Caffeine
+import common.configuration.YoutubeProxySettings
 import common.logging.DiscordLogger
 import database.dto.MusicDto
 import database.dto.UserDto
@@ -11,8 +12,12 @@ import net.dv8tion.jda.api.JDA
 import org.springframework.stereotype.Service
 import org.springframework.web.multipart.MultipartFile
 import java.net.HttpURLConnection
+import java.net.InetSocketAddress
+import java.net.Proxy
 import java.net.URI
 import java.net.URL
+import java.nio.charset.StandardCharsets
+import java.util.Base64
 import java.util.concurrent.TimeUnit
 
 @Service
@@ -456,8 +461,11 @@ class IntroWebService(
         return try {
             val apiUrl = "https://www.googleapis.com/youtube/v3/videos" +
                 "?id=$videoId&part=snippet,contentDetails&key=$apiKey"
-            val connection = URL(apiUrl).openConnection() as HttpURLConnection
+            val connection = openYouTubeDataApiConnection(apiUrl)
             if (connection.responseCode != 200) {
+                logger.warn {
+                    "YouTube Data API preview returned HTTP ${connection.responseCode} for videoId=$videoId"
+                }
                 return YouTubePreview(
                     videoId = videoId,
                     title = null,
@@ -475,7 +483,10 @@ class IntroWebService(
             } ?: "https://img.youtube.com/vi/$videoId/mqdefault.jpg"
             val duration = parseIsoDurationSeconds(item.path("contentDetails").path("duration").asText())
             YouTubePreview(videoId, title, thumb, duration)
-        } catch (_: Exception) {
+        } catch (e: Exception) {
+            logger.warn {
+                "fetchYouTubePreview failed for videoId=$videoId: ${e::class.simpleName}: ${e.message}"
+            }
             YouTubePreview(
                 videoId = videoId,
                 title = null,
@@ -483,6 +494,23 @@ class IntroWebService(
                 durationSeconds = null
             )
         }
+    }
+
+    private fun openYouTubeDataApiConnection(apiUrl: String): HttpURLConnection {
+        val proxy = YoutubeProxySettings.fromEnv()
+        val connection = if (proxy != null) {
+            val javaProxy = Proxy(Proxy.Type.HTTP, InetSocketAddress(proxy.host, proxy.port))
+            (URL(apiUrl).openConnection(javaProxy) as HttpURLConnection).also {
+                if (proxy.hasAuth) {
+                    val cred = Base64.getEncoder()
+                        .encodeToString("${proxy.user}:${proxy.pass}".toByteArray(StandardCharsets.UTF_8))
+                    it.setRequestProperty("Proxy-Authorization", "Basic $cred")
+                }
+            }
+        } else {
+            URL(apiUrl).openConnection() as HttpURLConnection
+        }
+        return connection
     }
 
     /**


### PR DESCRIPTION
## Summary

PR #448 already routed lavaplayer + `HttpHelper` (Ktor) through the optional YouTube proxy, but missed two paths. The **web-UI intro page preview** uses raw `java.net.HttpURLConnection` and bypasses every proxy hook from #448 — that's the symptom you actually reported. The Discord-side intro validation also swallowed its async catch silently. This PR closes both gaps.

## Changes

- **Web-UI intro preview** — `IntroWebService.fetchYouTubePreview` now honours `YOUTUBE_PROXY_HOST/PORT/USER/PASS` via `URL.openConnection(Proxy(...))` with a `Proxy-Authorization` header for basic auth. Also logs HTTP status / exception class+message in the failure paths instead of swallowing.
- **Discord intro validation** — `IntroValidationService.validateIntroLength`'s async catch no longer drops the exception detail.
- **`YoutubeProxySettings` moved** from `discord-bot.bot.configuration` to `common.configuration` so the web module can read the same env-var contract (web does not depend on discord-bot). Imports in `AppConfig` and `PlayerManager` updated.

## Test plan

- [ ] `./gradlew :common:test :discord-bot:test :web:test` — covers the relocated `YoutubeProxySettingsTest` and existing intro/preview tests.
- [ ] On Heroku with `YOUTUBE_PROXY_*` set: load the web intro page, paste a YouTube URL, hit preview. Title + duration come back from the proxy IP. Run several previews; proxy provider's dashboard should show varied exit IPs.
- [ ] With proxy unset: behaviour unchanged from main.
- [ ] When the preview does fail (e.g. invalid API key, real outage), Heroku logs should now show the HTTP status or exception class+message instead of being silent.

Related: #449, follows #448