### PR TITLE
feat(duel): show opponent name + avatar and per-offer expiry on web inbox

### DIFF
--- a/web/src/main/kotlin/web/controller/DuelController.kt
+++ b/web/src/main/kotlin/web/controller/DuelController.kt
@@ -85,6 +85,7 @@ class DuelController(
         model.addAttribute("pending", pending)
         model.addAttribute("outgoing", outgoing)
         model.addAttribute("ttlLabel", PendingDuelRegistry.formatTtl(pendingDuelRegistry.ttl))
+        model.addAttribute("ttlSeconds", pendingDuelRegistry.ttl.seconds)
         model.addAttribute("members", members)
         model.addAttribute("username", user.displayName())
         "duel"

--- a/web/src/main/kotlin/web/service/DuelWebService.kt
+++ b/web/src/main/kotlin/web/service/DuelWebService.kt
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Service
 class DuelWebService(
     private val pendingDuelRegistry: PendingDuelRegistry,
     private val userService: UserService,
+    private val memberLookup: MemberLookupHelper,
 ) {
     data class PendingDuelView(
         val duelId: Long,
@@ -21,23 +22,45 @@ class DuelWebService(
         // Number precision. duel.js renders these into the row text directly,
         // so a numeric round-trip would print a rounded id.
         val initiatorDiscordId: String,
+        val initiatorName: String,
+        val initiatorAvatarUrl: String?,
         val opponentDiscordId: String,
-        val stake: Long
+        val opponentName: String,
+        val opponentAvatarUrl: String?,
+        val stake: Long,
+        val createdAtEpochSeconds: Long,
     )
 
-    fun pendingForOpponent(discordId: Long, guildId: Long): List<PendingDuelView> =
-        pendingDuelRegistry.pendingForOpponent(discordId, guildId).map(::toView)
+    fun pendingForOpponent(discordId: Long, guildId: Long): List<PendingDuelView> {
+        val rows = pendingDuelRegistry.pendingForOpponent(discordId, guildId)
+        return project(rows, guildId)
+    }
 
-    fun pendingForInitiator(discordId: Long, guildId: Long): List<PendingDuelView> =
-        pendingDuelRegistry.pendingForInitiator(discordId, guildId).map(::toView)
+    fun pendingForInitiator(discordId: Long, guildId: Long): List<PendingDuelView> {
+        val rows = pendingDuelRegistry.pendingForInitiator(discordId, guildId)
+        return project(rows, guildId)
+    }
 
-    private fun toView(d: PendingDuelRegistry.PendingDuel): PendingDuelView =
-        PendingDuelView(
-            duelId = d.id,
-            initiatorDiscordId = d.initiatorDiscordId.toString(),
-            opponentDiscordId = d.opponentDiscordId.toString(),
-            stake = d.stake
-        )
+    private fun project(rows: List<PendingDuelRegistry.PendingDuel>, guildId: Long): List<PendingDuelView> {
+        if (rows.isEmpty()) return emptyList()
+        val ids = rows.flatMapTo(HashSet()) { listOf(it.initiatorDiscordId, it.opponentDiscordId) }
+        val members = memberLookup.resolveAll(guildId, ids)
+        return rows.map { d ->
+            val initiator = members[d.initiatorDiscordId]
+            val opponent = members[d.opponentDiscordId]
+            PendingDuelView(
+                duelId = d.id,
+                initiatorDiscordId = d.initiatorDiscordId.toString(),
+                initiatorName = initiator?.name ?: memberLookup.fallbackName(d.initiatorDiscordId),
+                initiatorAvatarUrl = initiator?.avatarUrl,
+                opponentDiscordId = d.opponentDiscordId.toString(),
+                opponentName = opponent?.name ?: memberLookup.fallbackName(d.opponentDiscordId),
+                opponentAvatarUrl = opponent?.avatarUrl,
+                stake = d.stake,
+                createdAtEpochSeconds = d.createdAt.epochSecond,
+            )
+        }
+    }
 
     fun ensureOpponent(opponentDiscordId: Long, guildId: Long): UserDto {
         return userService.getUserById(opponentDiscordId, guildId)

--- a/web/src/main/resources/static/css/duel.css
+++ b/web/src/main/resources/static/css/duel.css
@@ -61,6 +61,27 @@
     border-radius: 0.5rem;
 }
 
+.duel-pending-info {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    min-width: 0;
+}
+
+.duel-pending-who {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    min-width: 0;
+}
+
+.duel-pending-meta {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    font-size: 0.9rem;
+}
+
 .duel-pending-actions {
     display: flex;
     gap: 0.5rem;

--- a/web/src/main/resources/static/js/duel.js
+++ b/web/src/main/resources/static/js/duel.js
@@ -8,11 +8,99 @@
     if (!main) return;
     const guildId = main.dataset.guildId;
     if (!guildId) return;
+    const ttlSeconds = parseInt(main.dataset.ttlSeconds, 10) || 0;
 
     const balanceEl = document.getElementById('duel-balance');
     const challengeForm = document.getElementById('duel-challenge');
     const pendingList = document.getElementById('duel-pending-list');
     const outgoingList = document.getElementById('duel-outgoing-list');
+
+    function makeMemberCell(name, avatarUrl) {
+        const cell = document.createElement('div');
+        cell.className = 'member-cell';
+        if (avatarUrl) {
+            const img = document.createElement('img');
+            img.className = 'avatar';
+            img.src = avatarUrl;
+            img.alt = '';
+            img.loading = 'lazy';
+            cell.appendChild(img);
+        }
+        const nameEl = document.createElement('span');
+        nameEl.className = 'lb-name';
+        // textContent prevents nicknames like "<script>" from breaking out
+        // of the cell — duel.html relies on Thymeleaf escaping for the same
+        // reason, so the dynamic path needs the same guarantee.
+        nameEl.textContent = name || '';
+        cell.appendChild(nameEl);
+        return cell;
+    }
+
+    function formatExpiry(createdAtSeconds) {
+        if (!createdAtSeconds || !ttlSeconds) return '';
+        const expiresAtMs = (createdAtSeconds + ttlSeconds) * 1000;
+        const remaining = Math.max(0, Math.round((expiresAtMs - Date.now()) / 1000));
+        if (remaining <= 0) return 'expiring…';
+        if (remaining < 60) return 'expires in ' + remaining + 's';
+        const minutes = Math.floor(remaining / 60);
+        const seconds = remaining % 60;
+        return seconds > 0
+            ? 'expires in ' + minutes + 'm ' + seconds + 's'
+            : 'expires in ' + minutes + 'm';
+    }
+
+    function buildRow(row, opts) {
+        const node = document.createElement('div');
+        node.className = 'duel-pending-row';
+        node.dataset.duelId = String(row.duelId);
+        node.dataset.stake = String(row.stake);
+        if (row.createdAtEpochSeconds != null) {
+            node.dataset.createdAt = String(row.createdAtEpochSeconds);
+        }
+
+        const info = document.createElement('div');
+        info.className = 'duel-pending-info';
+
+        const who = document.createElement('div');
+        who.className = 'duel-pending-who';
+        const label = document.createElement('span');
+        label.className = 'muted';
+        label.textContent = opts.directionLabel;
+        who.appendChild(label);
+        who.appendChild(makeMemberCell(opts.name, opts.avatarUrl));
+        info.appendChild(who);
+
+        const meta = document.createElement('div');
+        meta.className = 'duel-pending-meta';
+        const stake = document.createElement('span');
+        stake.appendChild(document.createTextNode('for '));
+        const stakeStrong = document.createElement('strong');
+        stakeStrong.textContent = String(row.stake);
+        stake.appendChild(stakeStrong);
+        stake.appendChild(document.createTextNode(' credits'));
+        meta.appendChild(stake);
+
+        const expiry = document.createElement('span');
+        expiry.className = 'duel-expiry muted';
+        expiry.textContent = formatExpiry(row.createdAtEpochSeconds);
+        meta.appendChild(expiry);
+        info.appendChild(meta);
+
+        node.appendChild(info);
+
+        const actions = document.createElement('div');
+        actions.className = 'duel-pending-actions';
+        opts.buttons.forEach(function (b) {
+            const btn = document.createElement('button');
+            btn.type = 'button';
+            btn.className = b.className;
+            btn.textContent = b.label;
+            actions.appendChild(btn);
+        });
+        node.appendChild(actions);
+
+        return node;
+    }
 
     function renderPending(rows) {
         if (!pendingList) return;
@@ -25,18 +113,15 @@
             return;
         }
         rows.forEach(function (row) {
-            const node = document.createElement('div');
-            node.className = 'duel-pending-row';
-            node.dataset.duelId = String(row.duelId);
-            node.dataset.stake = String(row.stake);
-            node.innerHTML =
-                '<div><span>From <strong>' + row.initiatorDiscordId + '</strong></span>' +
-                '<span> for <strong>' + row.stake + '</strong> credits</span></div>' +
-                '<div class="duel-pending-actions">' +
-                '<button class="btn-primary duel-accept" type="button">Accept</button>' +
-                '<button class="btn-secondary duel-decline" type="button">Decline</button>' +
-                '</div>';
-            pendingList.appendChild(node);
+            pendingList.appendChild(buildRow(row, {
+                directionLabel: 'From',
+                name: row.initiatorName,
+                avatarUrl: row.initiatorAvatarUrl,
+                buttons: [
+                    { className: 'btn-primary duel-accept', label: 'Accept' },
+                    { className: 'btn-secondary duel-decline', label: 'Decline' },
+                ],
+            }));
         });
     }
 
@@ -58,17 +143,14 @@
             return;
         }
         rows.forEach(function (row) {
-            const node = document.createElement('div');
-            node.className = 'duel-pending-row';
-            node.dataset.duelId = String(row.duelId);
-            node.dataset.stake = String(row.stake);
-            node.innerHTML =
-                '<div><span>To <strong>' + row.opponentDiscordId + '</strong></span>' +
-                '<span> for <strong>' + row.stake + '</strong> credits</span></div>' +
-                '<div class="duel-pending-actions">' +
-                '<button class="btn-secondary duel-cancel" type="button">Cancel</button>' +
-                '</div>';
-            outgoingList.appendChild(node);
+            outgoingList.appendChild(buildRow(row, {
+                directionLabel: 'To',
+                name: row.opponentName,
+                avatarUrl: row.opponentAvatarUrl,
+                buttons: [
+                    { className: 'btn-secondary duel-cancel', label: 'Cancel' },
+                ],
+            }));
         });
     }
 
@@ -77,6 +159,19 @@
             .then(function (r) { return r.ok ? r.json() : []; })
             .then(renderOutgoing)
             .catch(function () { /* keep last known state */ });
+    }
+
+    // Tick the expiry labels on already-rendered rows without re-fetching;
+    // the 5s poll refresh would also redraw them, but a 1s tick keeps the
+    // countdown smooth between fetches.
+    function tickExpiries() {
+        const rows = document.querySelectorAll('.duel-pending-row[data-created-at]');
+        rows.forEach(function (row) {
+            const createdAt = parseInt(row.dataset.createdAt, 10);
+            if (!createdAt) return;
+            const label = row.querySelector('.duel-expiry');
+            if (label) label.textContent = formatExpiry(createdAt);
+        });
     }
 
     function refreshAll() {
@@ -168,5 +263,9 @@
         });
     }
 
+    // Initial expiry pass on the server-rendered rows so the placeholder
+    // "expires soon" text is replaced immediately on page load.
+    tickExpiries();
+    setInterval(tickExpiries, 1000);
     setInterval(refreshAll, 5000);
 })();

--- a/web/src/main/resources/templates/duel.html
+++ b/web/src/main/resources/templates/duel.html
@@ -6,7 +6,7 @@
 <div th:replace="~{fragments/navbar :: navbar}"></div>
 
 <main id="main" class="container"
-      th:attr="data-guild-id=${guildId}, data-min-stake=${minStake}, data-max-stake=${maxStake}">
+      th:attr="data-guild-id=${guildId}, data-min-stake=${minStake}, data-max-stake=${maxStake}, data-ttl-seconds=${ttlSeconds}">
 
     <div class="duel-header">
         <a class="back-link" th:href="@{/duel/guilds}">&larr; All servers</a>
@@ -55,10 +55,16 @@
         <div id="duel-pending-list" class="duel-pending-list">
             <div th:if="${#lists.isEmpty(pending)}" class="muted">No pending duels right now.</div>
             <div class="duel-pending-row" th:each="p : ${pending}"
-                 th:attr="data-duel-id=${p.duelId}, data-stake=${p.stake}">
-                <div>
-                    <span>From <strong th:text="${p.initiatorDiscordId}">user</strong></span>
-                    <span> for <strong th:text="${p.stake}">100</strong> credits</span>
+                 th:attr="data-duel-id=${p.duelId}, data-stake=${p.stake}, data-created-at=${p.createdAtEpochSeconds}">
+                <div class="duel-pending-info">
+                    <div class="duel-pending-who">
+                        <span class="muted">From</span>
+                        <div th:replace="~{fragments/memberCell :: cell(${p.initiatorName}, ${p.initiatorAvatarUrl})}"></div>
+                    </div>
+                    <div class="duel-pending-meta">
+                        <span>for <strong th:text="${p.stake}">100</strong> credits</span>
+                        <span class="duel-expiry muted">expires soon</span>
+                    </div>
                 </div>
                 <div class="duel-pending-actions">
                     <button class="btn-primary duel-accept" type="button">Accept</button>
@@ -74,10 +80,16 @@
         <div id="duel-outgoing-list" class="duel-pending-list">
             <div th:if="${#lists.isEmpty(outgoing)}" class="muted">No outgoing challenges right now.</div>
             <div class="duel-pending-row" th:each="p : ${outgoing}"
-                 th:attr="data-duel-id=${p.duelId}, data-stake=${p.stake}">
-                <div>
-                    <span>To <strong th:text="${p.opponentDiscordId}">user</strong></span>
-                    <span> for <strong th:text="${p.stake}">100</strong> credits</span>
+                 th:attr="data-duel-id=${p.duelId}, data-stake=${p.stake}, data-created-at=${p.createdAtEpochSeconds}">
+                <div class="duel-pending-info">
+                    <div class="duel-pending-who">
+                        <span class="muted">To</span>
+                        <div th:replace="~{fragments/memberCell :: cell(${p.opponentName}, ${p.opponentAvatarUrl})}"></div>
+                    </div>
+                    <div class="duel-pending-meta">
+                        <span>for <strong th:text="${p.stake}">100</strong> credits</span>
+                        <span class="duel-expiry muted">expires soon</span>
+                    </div>
                 </div>
                 <div class="duel-pending-actions">
                     <button class="btn-secondary duel-cancel" type="button">Cancel</button>

--- a/web/src/test/kotlin/web/controller/DuelControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/DuelControllerTest.kt
@@ -255,10 +255,15 @@ class DuelControllerTest {
     @Test
     fun `outgoingForMe returns the initiator's pending offers`() {
         val view = DuelWebService.PendingDuelView(
-            duelId,
-            discordId.toString(),
-            opponentId.toString(),
-            50L,
+            duelId = duelId,
+            initiatorDiscordId = discordId.toString(),
+            initiatorName = "Me",
+            initiatorAvatarUrl = null,
+            opponentDiscordId = opponentId.toString(),
+            opponentName = "Bob",
+            opponentAvatarUrl = "https://cdn/bob.png",
+            stake = 50L,
+            createdAtEpochSeconds = 1_700_000_000L,
         )
         every { duelWebService.pendingForInitiator(discordId, guildId) } returns listOf(view)
 

--- a/web/src/test/kotlin/web/service/DuelWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/DuelWebServiceTest.kt
@@ -7,6 +7,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -19,28 +20,39 @@ class DuelWebServiceTest {
 
     private lateinit var pendingDuelRegistry: PendingDuelRegistry
     private lateinit var userService: UserService
+    private lateinit var memberLookup: MemberLookupHelper
     private lateinit var service: DuelWebService
 
     @BeforeEach
     fun setup() {
         pendingDuelRegistry = mockk(relaxed = true)
         userService = mockk(relaxed = true)
-        service = DuelWebService(pendingDuelRegistry, userService)
+        memberLookup = mockk {
+            every { resolveAll(any(), any()) } returns emptyMap()
+            every { fallbackName(any()) } answers { "Player ${firstArg<Long>().toString().takeLast(4)}" }
+        }
+        service = DuelWebService(pendingDuelRegistry, userService, memberLookup)
     }
 
     @Test
     fun `pendingForOpponent projects registry entries to view DTOs`() {
+        val createdAt = Instant.ofEpochSecond(1_700_000_000L)
         every { pendingDuelRegistry.pendingForOpponent(opponentId, guildId) } returns listOf(
             PendingDuelRegistry.PendingDuel(
                 id = 1L, guildId = guildId,
                 initiatorDiscordId = 100L, opponentDiscordId = opponentId,
-                stake = 50L, createdAt = Instant.now()
+                stake = 50L, createdAt = createdAt
             ),
             PendingDuelRegistry.PendingDuel(
                 id = 2L, guildId = guildId,
                 initiatorDiscordId = 101L, opponentDiscordId = opponentId,
-                stake = 75L, createdAt = Instant.now()
+                stake = 75L, createdAt = createdAt.plusSeconds(30)
             ),
+        )
+        every { memberLookup.resolveAll(guildId, setOf(100L, opponentId, 101L)) } returns mapOf(
+            100L to MemberLookupHelper.MemberDisplay(name = "Alice", avatarUrl = "https://cdn/100.png"),
+            opponentId to MemberLookupHelper.MemberDisplay(name = "Me", avatarUrl = null),
+            // 101L intentionally omitted — should fall back to "Player …"
         )
 
         val rows = service.pendingForOpponent(opponentId, guildId)
@@ -50,9 +62,52 @@ class DuelWebServiceTest {
         // through JS (numeric serialization rounds past 2^53).
         assertTrue(rows.all { it.opponentDiscordId == opponentId.toString() })
         assertEquals("100", rows[0].initiatorDiscordId)
-        assertEquals("101", rows[1].initiatorDiscordId)
+        assertEquals("Alice", rows[0].initiatorName)
+        assertEquals("https://cdn/100.png", rows[0].initiatorAvatarUrl)
+        assertEquals("Me", rows[0].opponentName)
+        assertNull(rows[0].opponentAvatarUrl)
         assertEquals(50L, rows[0].stake)
+        assertEquals(createdAt.epochSecond, rows[0].createdAtEpochSeconds)
+
+        assertEquals("101", rows[1].initiatorDiscordId)
+        // Unresolved member falls back to the helper's "Player XXXX" form.
+        assertEquals("Player 101", rows[1].initiatorName)
+        assertNull(rows[1].initiatorAvatarUrl)
         assertEquals(75L, rows[1].stake)
+        assertEquals(createdAt.epochSecond + 30, rows[1].createdAtEpochSeconds)
+    }
+
+    @Test
+    fun `pendingForInitiator enriches opponent display`() {
+        val initiatorId = 100L
+        every { pendingDuelRegistry.pendingForInitiator(initiatorId, guildId) } returns listOf(
+            PendingDuelRegistry.PendingDuel(
+                id = 1L, guildId = guildId,
+                initiatorDiscordId = initiatorId, opponentDiscordId = opponentId,
+                stake = 50L, createdAt = Instant.ofEpochSecond(1_700_000_500L)
+            )
+        )
+        every { memberLookup.resolveAll(guildId, setOf(initiatorId, opponentId)) } returns mapOf(
+            opponentId to MemberLookupHelper.MemberDisplay(name = "Bob", avatarUrl = "https://cdn/bob.png"),
+        )
+
+        val rows = service.pendingForInitiator(initiatorId, guildId)
+
+        assertEquals(1, rows.size)
+        assertEquals("Bob", rows[0].opponentName)
+        assertEquals("https://cdn/bob.png", rows[0].opponentAvatarUrl)
+        assertEquals("Player 100", rows[0].initiatorName)
+        assertEquals(1_700_000_500L, rows[0].createdAtEpochSeconds)
+    }
+
+    @Test
+    fun `empty registry result skips JDA lookup`() {
+        every { pendingDuelRegistry.pendingForInitiator(any(), any()) } returns emptyList()
+
+        val rows = service.pendingForInitiator(opponentId, guildId)
+
+        assertTrue(rows.isEmpty())
+        verify(exactly = 0) { memberLookup.resolveAll(any(), any()) }
     }
 
     @Test


### PR DESCRIPTION
## Summary

The web `/duel/{guildId}` page previously showed each pending offer's recipient as a raw 18-digit Discord ID (e.g. `123456789012345678`) and gave no per-row expiry indication — only a static "offers expire after 3m" footer. This PR enriches `PendingDuelView` so both the outgoing and incoming offer lists render the member's server nickname and avatar and a live countdown of how long the offer has left.

- `DuelWebService` now injects `MemberLookupHelper` (same pattern Poker/Blackjack/Lottery already use) and batches name + avatar resolution per request. Unresolvable IDs fall back to the helper's `Player XXXX` form.
- `PendingDuelView` gains `initiatorName`, `initiatorAvatarUrl`, `opponentName`, `opponentAvatarUrl`, and `createdAtEpochSeconds`. `DuelController.page` also exposes `ttlSeconds` to the template.
- `duel.html` renders both sides via the existing `fragments/memberCell` (the same avatar + name cell used by leaderboards and the lottery top-holders list). The new `<span class="duel-expiry">` is filled in by the JS countdown.
- `duel.js` is rewritten to build rows via `document.createElement` rather than `innerHTML` string concatenation — Discord nicknames can contain `<` and would otherwise break out. A 1s tick refreshes the relative countdown ("expires in 2m 15s") in addition to the existing 5s poll.

## Test plan

- [ ] `./gradlew :web:test` (couldn't run locally — the sandbox can't fetch the `foojay-resolver-convention` plugin; CI will verify). Unit tests cover (a) the name + avatar projection, (b) the `Player XXXX` fallback when JDA returns no member, (c) `createdAt` epoch-seconds passthrough, and (d) the empty-list short-circuit that skips JDA.
- [ ] Manual: open `/duel/{guildId}` while signed in. From another account send a duel challenge to yourself and confirm:
  - the incoming row shows the initiator's nickname + avatar instead of the numeric ID;
  - the outgoing row (on the other side) shows the opponent's nickname + avatar;
  - both rows show "expires in 2m XXs" that counts down between refreshes and disappears when the offer is cleaned up.
- [ ] Edge case: target a user not in the bot's JDA guild cache — row should read `Player XXXX` with no avatar rather than empty.

https://claude.ai/code/session_011C54dP139iQsVefKvufcC8

---
_Generated by [Claude Code](https://claude.ai/code/session_011C54dP139iQsVefKvufcC8)_