### PR TITLE
feat(setconfig): split into subcommand-per-category modals

### DIFF
--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/moderation/SetConfigCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/moderation/SetConfigCommand.kt
@@ -1,849 +1,152 @@
 package bot.toby.command.commands.moderation
 
-import bot.toby.activity.ActivityTrackingNotifier
-import core.command.Command.Companion.replyAndDelete
-import core.command.Command.Companion.replyEphemeralAndDelete
+import bot.toby.modal.modals.setconfig.SetConfigActivityModal
+import bot.toby.modal.modals.setconfig.SetConfigBlackjackRulesModal
+import bot.toby.modal.modals.setconfig.SetConfigBlackjackTableModal
+import bot.toby.modal.modals.setconfig.SetConfigFeesModal
+import bot.toby.modal.modals.setconfig.SetConfigGeneralModal
+import bot.toby.modal.modals.setconfig.SetConfigJackpotActivityModal
+import bot.toby.modal.modals.setconfig.SetConfigJackpotModal
+import bot.toby.modal.modals.setconfig.SetConfigLotteryBasicsModal
+import bot.toby.modal.modals.setconfig.SetConfigLotteryPoolsModal
+import bot.toby.modal.modals.setconfig.SetConfigPokerStakesModal
+import bot.toby.modal.modals.setconfig.SetConfigPokerTableModal
+import bot.toby.modal.modals.setconfig.SetConfigStakesModal
 import core.command.CommandContext
-import database.dto.ConfigDto
+import database.dto.ConfigDto.Configurations
 import database.dto.UserDto
 import database.service.ConfigService
-import net.dv8tion.jda.api.entities.channel.ChannelType
-import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
-import net.dv8tion.jda.api.interactions.commands.OptionMapping
 import net.dv8tion.jda.api.interactions.commands.OptionType
 import net.dv8tion.jda.api.interactions.commands.build.OptionData
+import net.dv8tion.jda.api.interactions.commands.build.SubcommandData
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import java.util.*
 
+/**
+ * `/setconfig <subcommand>` — guild-owner-only configuration editor.
+ *
+ * Each subcommand opens a category-scoped modal that pre-populates
+ * with the current values for its fields (admins see-and-edit; blank
+ * fields skip the write). Replaced the old flat 25-option form, which
+ * was at Discord's hard limit and forced ~45 other config keys onto
+ * the web `/moderation` tab.
+ *
+ * Routing is by subcommand name → the matching modal bean's
+ * `buildModal(modalId, currentValues)`. The `stakes` subcommand is
+ * parameterised by a `game:<choice>` option whose value is encoded
+ * into the modal `customId` as `setconfig_stakes:<game>`; the modal
+ * manager routes by prefix and the modal handler parses the suffix.
+ *
+ * No `deferReply()` — the happy path is `replyModal`, which must be
+ * the first interaction response. Permission failures (non-owner)
+ * use `event.reply().setEphemeral(true)` accordingly.
+ */
 @Component
 class SetConfigCommand @Autowired constructor(
     private val configService: ConfigService,
-    private val activityTrackingNotifier: ActivityTrackingNotifier
+    private val general: SetConfigGeneralModal,
+    private val activity: SetConfigActivityModal,
+    private val fees: SetConfigFeesModal,
+    private val jackpot: SetConfigJackpotModal,
+    private val jackpotActivity: SetConfigJackpotActivityModal,
+    private val pokerStakes: SetConfigPokerStakesModal,
+    private val pokerTable: SetConfigPokerTableModal,
+    private val blackjackRules: SetConfigBlackjackRulesModal,
+    private val blackjackTable: SetConfigBlackjackTableModal,
+    private val lotteryBasics: SetConfigLotteryBasicsModal,
+    private val lotteryPools: SetConfigLotteryPoolsModal,
+    private val stakes: SetConfigStakesModal,
 ) : ModerationCommand {
+
+    override val name = "setconfig"
+    override val description =
+        "Guild-owner-only configuration. Use `/setconfig <category>` to open the matching form."
+
+    override val subCommands: List<SubcommandData> = listOf(
+        SubcommandData(SUB_GENERAL, "Audio + auto-delete + move/leaderboard channels"),
+        SubcommandData(SUB_ACTIVITY, "Game-activity tracking + UBI + daily credit cap"),
+        SubcommandData(SUB_FEES, "Loss tribute, jackpot win %, Toby Coin trade fees"),
+        SubcommandData(SUB_JACKPOT, "Jackpot stake anchor, cooldown, RTP gate, modlog channel"),
+        SubcommandData(SUB_JACKPOT_ACTIVITY, "Jackpot eligibility activity-day window"),
+        SubcommandData(SUB_POKER_STAKES, "Poker blinds/bets/rake"),
+        SubcommandData(SUB_POKER_TABLE, "Poker buy-ins, seat count, shot clock"),
+        SubcommandData(SUB_BLACKJACK_RULES, "Blackjack rake, ante, dealer rule, shot clock"),
+        SubcommandData(SUB_BLACKJACK_TABLE, "Blackjack seats + natural payout ratio"),
+        SubcommandData(SUB_LOTTERY_BASICS, "Daily lottery on/off, ticket price, mode, ping"),
+        SubcommandData(SUB_LOTTERY_POOLS, "Lottery seed/revenue split + announce channel"),
+        SubcommandData(SUB_STAKES, "Per-game stake bounds (and bot-suspicion edge cap where applicable)")
+            .addOptions(
+                OptionData(OptionType.STRING, OPT_GAME, "Which game's stake bounds to edit", true)
+                    .also { opt -> SetConfigStakesModal.Game.entries.forEach { opt.addChoice(it.label, it.token) } },
+            ),
+    )
 
     override fun handle(ctx: CommandContext, requestingUserDto: UserDto, deleteDelay: Int) {
         val event = ctx.event
-        event.deferReply(true).queue()
-        val member = ctx.member
-        if (member?.isOwner != true) {
-            event.hook.replyEphemeralAndDelete(
-                "This is currently reserved for the owner of the server only, this may change in future",
-                deleteDelay
-            )
-            return
-        }
-        validateArgumentsAndUpdateConfigs(event, deleteDelay)
-    }
 
-    private fun validateArgumentsAndUpdateConfigs(event: SlashCommandInteractionEvent, deleteDelay: Int) {
-        val options = event.options
-        if (options.isEmpty()) {
-            event.hook.replyAndDelete(description, deleteDelay)
+        if (ctx.member?.isOwner != true) {
+            event.reply(
+                "This is currently reserved for the owner of the server only, this may change in future"
+            ).setEphemeral(true).queue()
             return
         }
-        options.forEach { optionMapping ->
-            when (ConfigDto.Configurations.valueOf(optionMapping.name.uppercase(Locale.getDefault()))) {
-                ConfigDto.Configurations.MOVE -> setMove(event, deleteDelay)
-                ConfigDto.Configurations.VOLUME -> setConfigAndSendMessage(
-                    event,
-                    optionMapping,
-                    deleteDelay,
-                    "Set default volume to '${optionMapping.asInt}'"
-                )
-                ConfigDto.Configurations.DELETE_DELAY -> setConfigAndSendMessage(
-                    event,
-                    optionMapping,
-                    deleteDelay,
-                    "Set default delete message delay for TobyBot music messages to '${optionMapping.asInt}' seconds"
-                )
-                ConfigDto.Configurations.INTRO_VOLUME -> setConfigAndSendMessage(event, optionMapping, deleteDelay,
-                    "Set default intro volume to '${optionMapping.asInt}'")
-                ConfigDto.Configurations.LEADERBOARD_CHANNEL -> setLeaderboardChannel(event, deleteDelay)
-                ConfigDto.Configurations.ACTIVITY_TRACKING -> setActivityTracking(event, optionMapping, deleteDelay)
-                ConfigDto.Configurations.ACTIVITY_TRACKING_NOTIFIED -> Unit
-                ConfigDto.Configurations.JACKPOT_LOSS_TRIBUTE_PCT -> setJackpotLossTribute(event, optionMapping, deleteDelay)
-                ConfigDto.Configurations.JACKPOT_WIN_PCT -> setJackpotWinPct(event, optionMapping, deleteDelay)
-                ConfigDto.Configurations.TRADE_BUY_FEE_PCT -> setTradeFeePct(
-                    event, optionMapping, deleteDelay,
-                    config = ConfigDto.Configurations.TRADE_BUY_FEE_PCT, label = "buy"
-                )
-                ConfigDto.Configurations.TRADE_SELL_FEE_PCT -> setTradeFeePct(
-                    event, optionMapping, deleteDelay,
-                    config = ConfigDto.Configurations.TRADE_SELL_FEE_PCT, label = "sell"
-                )
-                ConfigDto.Configurations.POKER_RAKE_PCT -> setPokerRake(event, optionMapping, deleteDelay)
-                ConfigDto.Configurations.POKER_SMALL_BLIND -> setMinimumLongConfig(event, optionMapping, deleteDelay,
-                    config = ConfigDto.Configurations.POKER_SMALL_BLIND, gameLabel = "Poker", label = "small blind", min = 1L, unit = "chips")
-                ConfigDto.Configurations.POKER_BIG_BLIND -> setMinimumLongConfig(event, optionMapping, deleteDelay,
-                    config = ConfigDto.Configurations.POKER_BIG_BLIND, gameLabel = "Poker", label = "big blind", min = 1L, unit = "chips")
-                ConfigDto.Configurations.POKER_SMALL_BET -> setMinimumLongConfig(event, optionMapping, deleteDelay,
-                    config = ConfigDto.Configurations.POKER_SMALL_BET, gameLabel = "Poker", label = "small bet", min = 1L, unit = "chips")
-                ConfigDto.Configurations.POKER_BIG_BET -> setMinimumLongConfig(event, optionMapping, deleteDelay,
-                    config = ConfigDto.Configurations.POKER_BIG_BET, gameLabel = "Poker", label = "big bet", min = 1L, unit = "chips")
-                ConfigDto.Configurations.POKER_MIN_BUY_IN -> setMinimumLongConfig(event, optionMapping, deleteDelay,
-                    config = ConfigDto.Configurations.POKER_MIN_BUY_IN, gameLabel = "Poker", label = "minimum buy-in", min = 1L, unit = "chips")
-                ConfigDto.Configurations.POKER_MAX_BUY_IN -> setMinimumLongConfig(event, optionMapping, deleteDelay,
-                    config = ConfigDto.Configurations.POKER_MAX_BUY_IN, gameLabel = "Poker", label = "maximum buy-in", min = 1L, unit = "chips")
-                ConfigDto.Configurations.POKER_MAX_SEATS -> setRangedIntConfig(event, optionMapping, deleteDelay,
-                    config = ConfigDto.Configurations.POKER_MAX_SEATS, gameLabel = "Poker", label = "max seats", range = 2..9)
-                ConfigDto.Configurations.POKER_SHOT_CLOCK_SECONDS -> setRangedIntConfig(event, optionMapping, deleteDelay,
-                    config = ConfigDto.Configurations.POKER_SHOT_CLOCK_SECONDS, gameLabel = "Poker",
-                    label = "shot-clock seconds", range = 0..600)
-                ConfigDto.Configurations.BLACKJACK_RAKE_PCT -> setRangedIntConfig(event, optionMapping, deleteDelay,
-                    config = ConfigDto.Configurations.BLACKJACK_RAKE_PCT, gameLabel = "Blackjack", label = "rake percent", range = 0..20)
-                ConfigDto.Configurations.BLACKJACK_MIN_ANTE -> setMinimumLongConfig(event, optionMapping, deleteDelay,
-                    config = ConfigDto.Configurations.BLACKJACK_MIN_ANTE, gameLabel = "Blackjack", label = "minimum ante", min = 1L, unit = "credits")
-                ConfigDto.Configurations.BLACKJACK_MAX_ANTE -> setMinimumLongConfig(event, optionMapping, deleteDelay,
-                    config = ConfigDto.Configurations.BLACKJACK_MAX_ANTE, gameLabel = "Blackjack", label = "maximum ante", min = 1L, unit = "credits")
-                ConfigDto.Configurations.BLACKJACK_MAX_SEATS -> setRangedIntConfig(event, optionMapping, deleteDelay,
-                    config = ConfigDto.Configurations.BLACKJACK_MAX_SEATS, gameLabel = "Blackjack", label = "max seats", range = 2..7)
-                ConfigDto.Configurations.BLACKJACK_SHOT_CLOCK_SECONDS -> setRangedIntConfig(event, optionMapping, deleteDelay,
-                    config = ConfigDto.Configurations.BLACKJACK_SHOT_CLOCK_SECONDS, gameLabel = "Blackjack",
-                    label = "shot-clock seconds", range = 0..600)
-                ConfigDto.Configurations.BLACKJACK_DEALER_HITS_SOFT_17 -> setBlackjackBool(event, optionMapping, deleteDelay)
-                ConfigDto.Configurations.BLACKJACK_BJ_PAYOUT_NUM -> setRangedIntConfig(event, optionMapping, deleteDelay,
-                    config = ConfigDto.Configurations.BLACKJACK_BJ_PAYOUT_NUM, gameLabel = "Blackjack",
-                    label = "blackjack payout numerator", range = 1..10)
-                ConfigDto.Configurations.BLACKJACK_BJ_PAYOUT_DEN -> setRangedIntConfig(event, optionMapping, deleteDelay,
-                    config = ConfigDto.Configurations.BLACKJACK_BJ_PAYOUT_DEN, gameLabel = "Blackjack",
-                    label = "blackjack payout denominator", range = 1..10)
-                ConfigDto.Configurations.UBI_DAILY_AMOUNT -> setUbiDailyAmount(event, optionMapping, deleteDelay)
-                ConfigDto.Configurations.DAILY_CREDIT_CAP -> setDailyCreditCap(event, optionMapping, deleteDelay)
-                // Per-game stake bounds + jackpot scaling anchor. Not
-                // registered as /setconfig OptionData because Discord caps
-                // the command at 25 options and these are better grouped
-                // in the /moderation web tab. Dispatch branches are kept
-                // exhaustive in case the option is registered manually
-                // (e.g. by direct API invocation).
-                ConfigDto.Configurations.DICE_MIN_STAKE -> setMinimumLongConfig(event, optionMapping, deleteDelay,
-                    config = ConfigDto.Configurations.DICE_MIN_STAKE, gameLabel = "Dice", label = "minimum stake", min = 1L, unit = "credits")
-                ConfigDto.Configurations.DICE_MAX_STAKE -> setMinimumLongConfig(event, optionMapping, deleteDelay,
-                    config = ConfigDto.Configurations.DICE_MAX_STAKE, gameLabel = "Dice", label = "maximum stake", min = 1L, unit = "credits")
-                ConfigDto.Configurations.COINFLIP_MIN_STAKE -> setMinimumLongConfig(event, optionMapping, deleteDelay,
-                    config = ConfigDto.Configurations.COINFLIP_MIN_STAKE, gameLabel = "Coinflip", label = "minimum stake", min = 1L, unit = "credits")
-                ConfigDto.Configurations.COINFLIP_MAX_STAKE -> setMinimumLongConfig(event, optionMapping, deleteDelay,
-                    config = ConfigDto.Configurations.COINFLIP_MAX_STAKE, gameLabel = "Coinflip", label = "maximum stake", min = 1L, unit = "credits")
-                ConfigDto.Configurations.SLOTS_MIN_STAKE -> setMinimumLongConfig(event, optionMapping, deleteDelay,
-                    config = ConfigDto.Configurations.SLOTS_MIN_STAKE, gameLabel = "Slots", label = "minimum stake", min = 1L, unit = "credits")
-                ConfigDto.Configurations.SLOTS_MAX_STAKE -> setMinimumLongConfig(event, optionMapping, deleteDelay,
-                    config = ConfigDto.Configurations.SLOTS_MAX_STAKE, gameLabel = "Slots", label = "maximum stake", min = 1L, unit = "credits")
-                ConfigDto.Configurations.HIGHLOW_MIN_STAKE -> setMinimumLongConfig(event, optionMapping, deleteDelay,
-                    config = ConfigDto.Configurations.HIGHLOW_MIN_STAKE, gameLabel = "Highlow", label = "minimum stake", min = 1L, unit = "credits")
-                ConfigDto.Configurations.HIGHLOW_MAX_STAKE -> setMinimumLongConfig(event, optionMapping, deleteDelay,
-                    config = ConfigDto.Configurations.HIGHLOW_MAX_STAKE, gameLabel = "Highlow", label = "maximum stake", min = 1L, unit = "credits")
-                ConfigDto.Configurations.BACCARAT_MIN_STAKE -> setMinimumLongConfig(event, optionMapping, deleteDelay,
-                    config = ConfigDto.Configurations.BACCARAT_MIN_STAKE, gameLabel = "Baccarat", label = "minimum stake", min = 1L, unit = "credits")
-                ConfigDto.Configurations.BACCARAT_MAX_STAKE -> setMinimumLongConfig(event, optionMapping, deleteDelay,
-                    config = ConfigDto.Configurations.BACCARAT_MAX_STAKE, gameLabel = "Baccarat", label = "maximum stake", min = 1L, unit = "credits")
-                ConfigDto.Configurations.KENO_MIN_STAKE -> setMinimumLongConfig(event, optionMapping, deleteDelay,
-                    config = ConfigDto.Configurations.KENO_MIN_STAKE, gameLabel = "Keno", label = "minimum stake", min = 1L, unit = "credits")
-                ConfigDto.Configurations.KENO_MAX_STAKE -> setMinimumLongConfig(event, optionMapping, deleteDelay,
-                    config = ConfigDto.Configurations.KENO_MAX_STAKE, gameLabel = "Keno", label = "maximum stake", min = 1L, unit = "credits")
-                ConfigDto.Configurations.SCRATCH_MIN_STAKE -> setMinimumLongConfig(event, optionMapping, deleteDelay,
-                    config = ConfigDto.Configurations.SCRATCH_MIN_STAKE, gameLabel = "Scratch", label = "minimum stake", min = 1L, unit = "credits")
-                ConfigDto.Configurations.SCRATCH_MAX_STAKE -> setMinimumLongConfig(event, optionMapping, deleteDelay,
-                    config = ConfigDto.Configurations.SCRATCH_MAX_STAKE, gameLabel = "Scratch", label = "maximum stake", min = 1L, unit = "credits")
-                ConfigDto.Configurations.ROULETTE_MIN_STAKE -> setMinimumLongConfig(event, optionMapping, deleteDelay,
-                    config = ConfigDto.Configurations.ROULETTE_MIN_STAKE, gameLabel = "Roulette", label = "minimum stake", min = 1L, unit = "credits")
-                ConfigDto.Configurations.ROULETTE_MAX_STAKE -> setMinimumLongConfig(event, optionMapping, deleteDelay,
-                    config = ConfigDto.Configurations.ROULETTE_MAX_STAKE, gameLabel = "Roulette", label = "maximum stake", min = 1L, unit = "credits")
-                ConfigDto.Configurations.HOLDEM_MIN_STAKE -> setMinimumLongConfig(event, optionMapping, deleteDelay,
-                    config = ConfigDto.Configurations.HOLDEM_MIN_STAKE, gameLabel = "Casino Hold'em", label = "minimum stake", min = 1L, unit = "credits")
-                ConfigDto.Configurations.HOLDEM_MAX_STAKE -> setMinimumLongConfig(event, optionMapping, deleteDelay,
-                    config = ConfigDto.Configurations.HOLDEM_MAX_STAKE, gameLabel = "Casino Hold'em", label = "maximum stake", min = 1L, unit = "credits")
-                ConfigDto.Configurations.DUEL_MIN_STAKE -> setMinimumLongConfig(event, optionMapping, deleteDelay,
-                    config = ConfigDto.Configurations.DUEL_MIN_STAKE, gameLabel = "Duel", label = "minimum stake", min = 1L, unit = "credits")
-                ConfigDto.Configurations.DUEL_MAX_STAKE -> setMinimumLongConfig(event, optionMapping, deleteDelay,
-                    config = ConfigDto.Configurations.DUEL_MAX_STAKE, gameLabel = "Duel", label = "maximum stake", min = 1L, unit = "credits")
-                ConfigDto.Configurations.JACKPOT_STAKE_ANCHOR -> setMinimumLongConfig(event, optionMapping, deleteDelay,
-                    config = ConfigDto.Configurations.JACKPOT_STAKE_ANCHOR, gameLabel = "Jackpot", label = "stake anchor", min = 1L, unit = "credits")
-                // Post-fraud rebalance gates. Like the per-game stake
-                // bounds above, these aren't in the /setconfig OptionData
-                // (admins use the /moderation web tab) but keep the
-                // dispatch exhaustive in case the option is registered
-                // manually.
-                ConfigDto.Configurations.JACKPOT_WHEEL_SEGMENTS -> {
-                    // No simple int range — admins edit the wheel via
-                    // the /moderation web tab. Surface a friendly error
-                    // if someone tries to set it via /setconfig so the
-                    // dispatch stays exhaustive but doesn't pretend to
-                    // validate the CSV here.
-                    event.hook.replyAndDelete(
-                        "Edit the payout wheel via the moderation web tab — the CSV format needs the dedicated editor.",
-                        deleteDelay,
-                    )
+        val guild = event.guild ?: run {
+            event.reply("This command can only be used in a server.").setEphemeral(true).queue()
+            return
+        }
+        val guildId = guild.id
+        val sub = event.subcommandName
+        if (sub == null) {
+            event.reply("Pick a subcommand — see `/setconfig` autocomplete.")
+                .setEphemeral(true).queue()
+            return
+        }
+
+        val reader: (Configurations) -> String? =
+            { key -> configService.getConfigByName(key.configValue, guildId)?.value }
+
+        val modal = when (sub) {
+            SUB_GENERAL -> general.buildModal(SetConfigGeneralModal.MODAL_NAME, reader)
+            SUB_ACTIVITY -> activity.buildModal(SetConfigActivityModal.MODAL_NAME, reader)
+            SUB_FEES -> fees.buildModal(SetConfigFeesModal.MODAL_NAME, reader)
+            SUB_JACKPOT -> jackpot.buildModal(SetConfigJackpotModal.MODAL_NAME, reader)
+            SUB_JACKPOT_ACTIVITY -> jackpotActivity.buildModal(SetConfigJackpotActivityModal.MODAL_NAME, reader)
+            SUB_POKER_STAKES -> pokerStakes.buildModal(SetConfigPokerStakesModal.MODAL_NAME, reader)
+            SUB_POKER_TABLE -> pokerTable.buildModal(SetConfigPokerTableModal.MODAL_NAME, reader)
+            SUB_BLACKJACK_RULES -> blackjackRules.buildModal(SetConfigBlackjackRulesModal.MODAL_NAME, reader)
+            SUB_BLACKJACK_TABLE -> blackjackTable.buildModal(SetConfigBlackjackTableModal.MODAL_NAME, reader)
+            SUB_LOTTERY_BASICS -> lotteryBasics.buildModal(SetConfigLotteryBasicsModal.MODAL_NAME, reader)
+            SUB_LOTTERY_POOLS -> lotteryPools.buildModal(SetConfigLotteryPoolsModal.MODAL_NAME, reader)
+            SUB_STAKES -> {
+                val token = event.getOption(OPT_GAME)?.asString
+                val game = token?.let { SetConfigStakesModal.Game.byToken(it) } ?: run {
+                    event.reply("Unknown game `$token` — pick one from the autocomplete.")
+                        .setEphemeral(true).queue()
+                    return
                 }
-                ConfigDto.Configurations.JACKPOT_WINNER_COOLDOWN_DAYS -> setRangedIntConfig(event, optionMapping, deleteDelay,
-                    config = ConfigDto.Configurations.JACKPOT_WINNER_COOLDOWN_DAYS, gameLabel = "Jackpot", label = "winner cooldown days", range = 0..365)
-                ConfigDto.Configurations.JACKPOT_ACTIVITY_WINDOW_DAYS -> setRangedIntConfig(event, optionMapping, deleteDelay,
-                    config = ConfigDto.Configurations.JACKPOT_ACTIVITY_WINDOW_DAYS, gameLabel = "Jackpot", label = "activity window days", range = 0..365)
-                ConfigDto.Configurations.JACKPOT_ACTIVITY_MIN_DAYS -> setRangedIntConfig(event, optionMapping, deleteDelay,
-                    config = ConfigDto.Configurations.JACKPOT_ACTIVITY_MIN_DAYS, gameLabel = "Jackpot", label = "activity min days", range = 1..365)
-                ConfigDto.Configurations.JACKPOT_RTP_MAX_PCT -> setRangedIntConfig(event, optionMapping, deleteDelay,
-                    config = ConfigDto.Configurations.JACKPOT_RTP_MAX_PCT, gameLabel = "Jackpot", label = "max RTP percent (0 disables)", range = 0..100)
-                ConfigDto.Configurations.COINFLIP_BOT_EDGE_MAX_PCT -> setRangedIntConfig(event, optionMapping, deleteDelay,
-                    config = ConfigDto.Configurations.COINFLIP_BOT_EDGE_MAX_PCT, gameLabel = "Coinflip",
-                    label = "bot-suspicion max edge percent", range = 0..50)
-                ConfigDto.Configurations.DICE_BOT_EDGE_MAX_PCT -> setRangedIntConfig(event, optionMapping, deleteDelay,
-                    config = ConfigDto.Configurations.DICE_BOT_EDGE_MAX_PCT, gameLabel = "Dice",
-                    label = "bot-suspicion max edge percent", range = 0..50)
-                ConfigDto.Configurations.SLOTS_BOT_EDGE_MAX_PCT -> setRangedIntConfig(event, optionMapping, deleteDelay,
-                    config = ConfigDto.Configurations.SLOTS_BOT_EDGE_MAX_PCT, gameLabel = "Slots",
-                    label = "bot-suspicion max edge percent", range = 0..50)
-                // Daily match-numbers lottery — moderation web tab is the
-                // primary surface (toggles + daily-prize parameters), but
-                // keep the dispatch arms exhaustive for direct API use.
-                ConfigDto.Configurations.LOTTERY_DAILY_ENABLED -> setBooleanConfig(
-                    event, optionMapping, deleteDelay,
-                    config = ConfigDto.Configurations.LOTTERY_DAILY_ENABLED,
-                    label = "daily lottery"
-                )
-                ConfigDto.Configurations.LOTTERY_DAILY_TICKET_PRICE -> setMinimumLongConfig(
-                    event, optionMapping, deleteDelay,
-                    config = ConfigDto.Configurations.LOTTERY_DAILY_TICKET_PRICE,
-                    gameLabel = "Daily lottery", label = "ticket price", min = 1L, unit = "credits"
-                )
-                ConfigDto.Configurations.LOTTERY_DAILY_SEED_PCT -> setRangedIntConfig(
-                    event, optionMapping, deleteDelay,
-                    config = ConfigDto.Configurations.LOTTERY_DAILY_SEED_PCT,
-                    gameLabel = "Daily lottery", label = "jackpot seed percent", range = 1..100
-                )
-                ConfigDto.Configurations.LOTTERY_DAILY_REVENUE_JACKPOT_PCT -> setRangedIntConfig(
-                    event, optionMapping, deleteDelay,
-                    config = ConfigDto.Configurations.LOTTERY_DAILY_REVENUE_JACKPOT_PCT,
-                    gameLabel = "Daily lottery", label = "ticket revenue → jackpot percent", range = 0..100
-                )
-                ConfigDto.Configurations.LOTTERY_DAILY_MODE -> setLotteryDailyMode(
-                    event, optionMapping, deleteDelay
-                )
-                ConfigDto.Configurations.LOTTERY_DAILY_MIN_BUYERS -> setRangedIntConfig(
-                    event, optionMapping, deleteDelay,
-                    config = ConfigDto.Configurations.LOTTERY_DAILY_MIN_BUYERS,
-                    gameLabel = "Daily lottery", label = "minimum distinct buyers", range = 1..50
-                )
-                ConfigDto.Configurations.LOTTERY_CHANNEL -> setLotteryChannel(
-                    event, optionMapping, deleteDelay
-                )
-                ConfigDto.Configurations.LOTTERY_PING_MODE -> setLotteryPingMode(
-                    event, optionMapping, deleteDelay
-                )
-                // Anti-autoclicker session log channel — managed primarily
-                // via the /moderation web tab; arm stays exhaustive in case
-                // the option is registered manually.
-                ConfigDto.Configurations.CASINO_MODLOG_CHANNEL_ID -> setCasinoModlogChannel(
-                    event, optionMapping, deleteDelay
-                )
+                stakes.buildModal(SetConfigStakesModal.customIdFor(game), reader)
             }
-        }
-    }
-
-    /**
-     * Validate + persist the per-guild text-channel id for anti-autoclick
-     * session embeds. Empty / `0` clears the override (notifier falls back
-     * to the guild's system channel). Otherwise the value must parse to a
-     * Long that resolves to a real text channel in this guild.
-     */
-    private fun setCasinoModlogChannel(
-        event: SlashCommandInteractionEvent,
-        optionMapping: OptionMapping,
-        deleteDelay: Int,
-    ) {
-        val raw = optionMapping.asString.trim()
-        val guild = event.guild ?: return
-        val resolved: String = if (raw.isEmpty() || raw == "0") {
-            ""
-        } else {
-            val id = raw.toLongOrNull() ?: run {
-                event.hook.replyEphemeralAndDelete(
-                    "Channel id must be numeric (or empty / 0 to clear).",
-                    deleteDelay,
-                )
+            else -> {
+                event.reply("Unknown subcommand `$sub`.").setEphemeral(true).queue()
                 return
             }
-            guild.getTextChannelById(id) ?: run {
-                event.hook.replyEphemeralAndDelete(
-                    "No text channel with id $id exists in this server.",
-                    deleteDelay,
-                )
-                return
-            }
-            id.toString()
         }
-        configService.upsertConfig(
-            ConfigDto.Configurations.CASINO_MODLOG_CHANNEL_ID.configValue, resolved, guild.id
-        )
-        val msg = if (resolved.isEmpty()) {
-            "Anti-autoclick session log channel cleared. Falling back to the guild's system channel."
-        } else {
-            "Anti-autoclick session events will post to <#$resolved>."
-        }
-        event.hook.replyAndDelete(msg, deleteDelay)
+        event.replyModal(modal).queue()
     }
 
-    /**
-     * Validate + persist the daily-lottery announce channel id. Accepts
-     * a numeric channel id (or 0 / empty to clear and fall back through
-     * LEADERBOARD_CHANNEL → systemChannel). Rejects ids that don't
-     * resolve to a text channel in the current guild — admins can't
-     * usefully target someone else's channel.
-     */
-    private fun setLotteryChannel(
-        event: SlashCommandInteractionEvent,
-        optionMapping: OptionMapping,
-        deleteDelay: Int,
-    ) {
-        val raw = optionMapping.asString.trim()
-        val guild = event.guild ?: return
-        val resolved: String = if (raw.isEmpty() || raw == "0") {
-            ""
-        } else {
-            val id = raw.toLongOrNull() ?: run {
-                event.hook.replyEphemeralAndDelete(
-                    "Channel id must be numeric (or empty / 0 to clear).",
-                    deleteDelay,
-                )
-                return
-            }
-            guild.getTextChannelById(id) ?: run {
-                event.hook.replyEphemeralAndDelete(
-                    "No text channel with id $id exists in this server.",
-                    deleteDelay,
-                )
-                return
-            }
-            id.toString()
-        }
-        configService.upsertConfig(
-            ConfigDto.Configurations.LOTTERY_CHANNEL.configValue, resolved, guild.id
-        )
-        val msg = if (resolved.isEmpty()) {
-            "Daily lottery announce channel cleared. Falling back to LEADERBOARD_CHANNEL → system channel."
-        } else {
-            "Daily lottery announcements will post to <#$resolved>."
-        }
-        event.hook.replyAndDelete(msg, deleteDelay)
+    companion object {
+        const val SUB_GENERAL = "general"
+        const val SUB_ACTIVITY = "activity"
+        const val SUB_FEES = "fees"
+        const val SUB_JACKPOT = "jackpot"
+        const val SUB_JACKPOT_ACTIVITY = "jackpot_activity"
+        const val SUB_POKER_STAKES = "poker_stakes"
+        const val SUB_POKER_TABLE = "poker_table"
+        const val SUB_BLACKJACK_RULES = "blackjack_rules"
+        const val SUB_BLACKJACK_TABLE = "blackjack_table"
+        const val SUB_LOTTERY_BASICS = "lottery_basics"
+        const val SUB_LOTTERY_POOLS = "lottery_pools"
+        const val SUB_STAKES = "stakes"
+        const val OPT_GAME = "game"
     }
-
-    /**
-     * Validate + persist the daily-lottery mode (NUMBER_MATCH | WEIGHTED).
-     * Stored uppercase so [LotteryHelper.dailyMode] reads cleanly.
-     */
-    private fun setLotteryDailyMode(
-        event: SlashCommandInteractionEvent,
-        optionMapping: OptionMapping,
-        deleteDelay: Int,
-    ) {
-        val raw = optionMapping.asString.trim().uppercase()
-        if (raw !in setOf("NUMBER_MATCH", "WEIGHTED")) {
-            event.hook.replyEphemeralAndDelete(
-                "Daily lottery mode must be NUMBER_MATCH or WEIGHTED.",
-                deleteDelay,
-            )
-            return
-        }
-        val guildId = event.guild?.id ?: return
-        configService.upsertConfig(
-            ConfigDto.Configurations.LOTTERY_DAILY_MODE.configValue, raw, guildId
-        )
-        event.hook.replyAndDelete("Daily lottery mode set to $raw.", deleteDelay)
-    }
-
-    private fun setLotteryPingMode(
-        event: SlashCommandInteractionEvent,
-        optionMapping: OptionMapping,
-        deleteDelay: Int,
-    ) {
-        val raw = optionMapping.asString.trim().uppercase()
-        if (raw !in setOf("OFF", "HERE", "EVERYONE")) {
-            event.hook.replyEphemeralAndDelete(
-                "Lottery ping mode must be OFF, HERE, or EVERYONE.",
-                deleteDelay,
-            )
-            return
-        }
-        val guildId = event.guild?.id ?: return
-        configService.upsertConfig(
-            ConfigDto.Configurations.LOTTERY_PING_MODE.configValue, raw, guildId
-        )
-        event.hook.replyAndDelete("Lottery announcement ping set to $raw.", deleteDelay)
-    }
-
-    /**
-     * Validate an integer config knob within an inclusive [range],
-     * persist it, and reply with a uniform "$gameLabel $label set to $value
-     * for new tables." message. Generic across the per-game integer
-     * settings (poker max seats, poker shot clock, blackjack max seats,
-     * blackjack rake percent, blackjack BJ payout num/den, etc.).
-     */
-    private fun setRangedIntConfig(
-        event: SlashCommandInteractionEvent,
-        optionMapping: OptionMapping,
-        deleteDelay: Int,
-        config: ConfigDto.Configurations,
-        gameLabel: String,
-        label: String,
-        range: IntRange,
-    ) {
-        val value = optionMapping.asInt
-        if (value !in range) {
-            event.hook.replyEphemeralAndDelete(
-                "$gameLabel $label must be between ${range.first} and ${range.last}.",
-                deleteDelay,
-            )
-            return
-        }
-        val guildId = event.guild?.id ?: return
-        configService.upsertConfig(config.configValue, value.toString(), guildId)
-        event.hook.replyAndDelete("$gameLabel $label set to $value for new tables.", deleteDelay)
-    }
-
-    /**
-     * Validate a non-negative whole-number config knob with a floor of
-     * [min], persist it, and reply with a "$gameLabel $label set to
-     * $value $unit for new tables." message. Generic across poker chip
-     * thresholds (chips) and blackjack ante bounds (credits).
-     */
-    private fun setMinimumLongConfig(
-        event: SlashCommandInteractionEvent,
-        optionMapping: OptionMapping,
-        deleteDelay: Int,
-        config: ConfigDto.Configurations,
-        gameLabel: String,
-        label: String,
-        min: Long,
-        unit: String,
-    ) {
-        val value = optionMapping.asLong
-        if (value < min) {
-            event.hook.replyEphemeralAndDelete(
-                "$gameLabel $label must be at least $min.",
-                deleteDelay,
-            )
-            return
-        }
-        val guildId = event.guild?.id ?: return
-        configService.upsertConfig(config.configValue, value.toString(), guildId)
-        event.hook.replyAndDelete("$gameLabel $label set to $value $unit for new tables.", deleteDelay)
-    }
-
-    private fun setBlackjackBool(
-        event: SlashCommandInteractionEvent,
-        optionMapping: OptionMapping,
-        deleteDelay: Int
-    ) {
-        val value = optionMapping.asBoolean
-        val configValue = ConfigDto.Configurations.BLACKJACK_DEALER_HITS_SOFT_17.configValue
-        val guildId = event.guild?.id ?: return
-        configService.upsertConfig(configValue, value.toString(), guildId)
-        val rule = if (value) "hit on soft 17 (H17)" else "stand on all 17 (S17)"
-        event.hook.replyAndDelete("Blackjack dealer will now $rule.", deleteDelay)
-    }
-
-    /**
-     * Persist a boolean config knob ("true"/"false") and reply with a
-     * uniform "$label is now enabled/disabled." message. Used by simple
-     * on/off toggles like the daily lottery.
-     */
-    private fun setBooleanConfig(
-        event: SlashCommandInteractionEvent,
-        optionMapping: OptionMapping,
-        deleteDelay: Int,
-        config: ConfigDto.Configurations,
-        label: String,
-    ) {
-        val value = optionMapping.asBoolean
-        val guildId = event.guild?.id ?: return
-        configService.upsertConfig(config.configValue, value.toString(), guildId)
-        val state = if (value) "enabled" else "disabled"
-        event.hook.replyAndDelete("$label is now $state.", deleteDelay)
-    }
-
-    private fun setLeaderboardChannel(event: SlashCommandInteractionEvent, deleteDelay: Int) {
-        val configValue = ConfigDto.Configurations.LEADERBOARD_CHANNEL.configValue
-        val guildId = event.guild?.id ?: return
-        val channel = event.getOption(
-            ConfigDto.Configurations.LEADERBOARD_CHANNEL.name.lowercase(Locale.getDefault())
-        )?.asChannel
-        if (channel == null) {
-            event.hook.replyEphemeralAndDelete(
-                "No valid text channel was mentioned, so config was not updated",
-                deleteDelay,
-            )
-            return
-        }
-        configService.upsertConfig(configValue, channel.id, guildId)
-        event.hook.replyEphemeralAndDelete(
-            "Monthly leaderboards will now post in <#${channel.id}> on the 1st of each month.",
-            deleteDelay,
-        )
-    }
-
-    private fun setActivityTracking(
-        event: SlashCommandInteractionEvent,
-        optionMapping: OptionMapping,
-        deleteDelay: Int
-    ) {
-        val enabled = optionMapping.asBoolean
-        val configValue = ConfigDto.Configurations.ACTIVITY_TRACKING.configValue
-        val guildId = event.guild?.id ?: return
-
-        // Need to know whether tracking was previously enabled to decide
-        // whether to fire the first-enable DM flow — that's why we branch
-        // on the result instead of ignoring it.
-        val result = configService.upsertConfig(configValue, enabled.toString(), guildId)
-        val previouslyEnabled = when (result) {
-            is ConfigService.UpsertResult.Created -> false
-            is ConfigService.UpsertResult.Updated ->
-                result.previousValue?.equals("true", ignoreCase = true) == true
-        }
-
-        val message = if (enabled) {
-            "Enabled game-activity tracking for this server. Members will only be tracked while they have set " +
-                    "their Discord activity visibility to allow it. Any member can opt out with `/activity tracking-off`."
-        } else {
-            "Disabled game-activity tracking for this server. Existing rollups are retained but no new activity " +
-                    "will be recorded."
-        }
-        event.hook.replyEphemeralAndDelete(message, deleteDelay)
-
-        if (enabled && !previouslyEnabled) {
-            event.guild?.let { activityTrackingNotifier.notifyMembersOnFirstEnable(it) }
-        }
-    }
-
-    private fun setConfigAndSendMessage(
-        event: SlashCommandInteractionEvent,
-        optionMapping: OptionMapping,
-        deleteDelay: Int,
-        messageToSend: String
-    ) {
-        val newValue = optionMapping.asInt.takeIf { it >= 0 }
-        if (newValue == null) {
-            event.hook.replyEphemeralAndDelete(
-                "Value given invalid (a whole number representing percent)",
-                deleteDelay,
-            )
-            return
-        }
-
-        val configValue =
-            ConfigDto.Configurations.valueOf(optionMapping.name.uppercase(Locale.getDefault())).configValue
-        val guildId = event.guild?.id ?: return
-
-        configService.upsertConfig(configValue, newValue.toString(), guildId)
-        event.hook.replyAndDelete(messageToSend, deleteDelay)
-    }
-
-    private fun setJackpotLossTribute(
-        event: SlashCommandInteractionEvent,
-        optionMapping: OptionMapping,
-        deleteDelay: Int
-    ) {
-        val pct = optionMapping.asInt
-        if (pct !in 0..50) {
-            event.hook.replyEphemeralAndDelete(
-                "Tribute percent must be between 0 and 50 (default 10).",
-                deleteDelay,
-            )
-            return
-        }
-        val configValue = ConfigDto.Configurations.JACKPOT_LOSS_TRIBUTE_PCT.configValue
-        val guildId = event.guild?.id ?: return
-        configService.upsertConfig(configValue, pct.toString(), guildId)
-        event.hook.replyAndDelete("Jackpot loss-tribute set to $pct % of every lost casino stake.", deleteDelay)
-    }
-
-    private fun setTradeFeePct(
-        event: SlashCommandInteractionEvent,
-        optionMapping: OptionMapping,
-        deleteDelay: Int,
-        config: ConfigDto.Configurations,
-        label: String
-    ) {
-        val pct = optionMapping.asDouble
-        if (pct.isNaN() || pct.isInfinite() || pct < 0.0 || pct > 25.0) {
-            event.hook.replyEphemeralAndDelete(
-                "Trade $label fee percent must be between 0 and 25 (default 1).",
-                deleteDelay,
-            )
-            return
-        }
-        val guildId = event.guild?.id ?: return
-        configService.upsertConfig(config.configValue, pct.toString(), guildId)
-        event.hook.replyAndDelete(
-            "Toby Coin $label fee set to $pct % per leg (routed into the jackpot pool).",
-            deleteDelay,
-        )
-    }
-
-    private fun setJackpotWinPct(
-        event: SlashCommandInteractionEvent,
-        optionMapping: OptionMapping,
-        deleteDelay: Int
-    ) {
-        val pct = optionMapping.asDouble
-        if (pct.isNaN() || pct.isInfinite() || pct < 0.0 || pct > 50.0) {
-            event.hook.replyEphemeralAndDelete(
-                "Jackpot win percent must be between 0 and 50 (default 1).",
-                deleteDelay,
-            )
-            return
-        }
-        val configValue = ConfigDto.Configurations.JACKPOT_WIN_PCT.configValue
-        val guildId = event.guild?.id ?: return
-        configService.upsertConfig(configValue, pct.toString(), guildId)
-        event.hook.replyAndDelete("Jackpot win chance set to $pct % per casino-game win.", deleteDelay)
-    }
-
-    private fun setPokerRake(
-        event: SlashCommandInteractionEvent,
-        optionMapping: OptionMapping,
-        deleteDelay: Int
-    ) {
-        val pct = optionMapping.asInt
-        if (pct !in 0..20) {
-            event.hook.replyEphemeralAndDelete(
-                "Poker rake must be between 0 and 20 (default 5).",
-                deleteDelay,
-            )
-            return
-        }
-        val configValue = ConfigDto.Configurations.POKER_RAKE_PCT.configValue
-        val guildId = event.guild?.id ?: return
-        configService.upsertConfig(configValue, pct.toString(), guildId)
-        event.hook.replyAndDelete("Poker rake set to $pct % of every settled pot.", deleteDelay)
-    }
-
-    private fun setUbiDailyAmount(
-        event: SlashCommandInteractionEvent,
-        optionMapping: OptionMapping,
-        deleteDelay: Int
-    ) {
-        val amount = optionMapping.asInt
-        if (amount !in 0..1000) {
-            event.hook.replyEphemeralAndDelete(
-                "UBI daily amount must be between 0 and 1000 (0 disables UBI).",
-                deleteDelay,
-            )
-            return
-        }
-        val configValue = ConfigDto.Configurations.UBI_DAILY_AMOUNT.configValue
-        val guildId = event.guild?.id ?: return
-        configService.upsertConfig(configValue, amount.toString(), guildId)
-        val message = if (amount == 0) {
-            "UBI disabled — no automatic daily credits will be granted."
-        } else {
-            "UBI set to $amount credits per user per day. The grant runs at 00:00 UTC and bypasses the daily cap."
-        }
-        event.hook.replyAndDelete(message, deleteDelay)
-    }
-
-    private fun setDailyCreditCap(
-        event: SlashCommandInteractionEvent,
-        optionMapping: OptionMapping,
-        deleteDelay: Int
-    ) {
-        val cap = optionMapping.asInt
-        if (cap !in 0..10000) {
-            event.hook.replyEphemeralAndDelete(
-                "Daily credit cap must be between 0 and 10000 (default 90).",
-                deleteDelay,
-            )
-            return
-        }
-        val configValue = ConfigDto.Configurations.DAILY_CREDIT_CAP.configValue
-        val guildId = event.guild?.id ?: return
-        configService.upsertConfig(configValue, cap.toString(), guildId)
-        event.hook.replyAndDelete(
-            "Daily social-credit cap set to $cap credits (covers voice, command, intro, and UI-trade earnings).",
-            deleteDelay,
-        )
-    }
-
-    private fun setMove(event: SlashCommandInteractionEvent, deleteDelay: Int) {
-        val movePropertyName = ConfigDto.Configurations.MOVE.configValue
-        val guildId = event.guild?.id ?: return
-        val newDefaultMoveChannel =
-            event.getOption(ConfigDto.Configurations.MOVE.name.lowercase(Locale.getDefault()))?.asChannel
-
-        if (newDefaultMoveChannel != null) {
-            configService.upsertConfig(movePropertyName, newDefaultMoveChannel.name, guildId)
-            event.hook.replyEphemeralAndDelete(
-                "Set default move channel to '${newDefaultMoveChannel.name}'",
-                deleteDelay,
-            )
-        } else {
-            event.hook.replyEphemeralAndDelete(
-                "No valid channel was mentioned, so config was not updated",
-                deleteDelay,
-            )
-        }
-    }
-
-    override val name: String
-        get() = "setconfig"
-
-    override val description: String
-        get() = "Use this command to set the configuration used for this bot in your server"
-
-    override val optionData: List<OptionData>
-        get() = listOf(
-            OptionData(
-                OptionType.INTEGER,
-                ConfigDto.Configurations.VOLUME.name.lowercase(Locale.getDefault()),
-                "Default volume for audio player on your server (100 without an override)",
-                false
-            ),
-            OptionData(
-                OptionType.INTEGER,
-                ConfigDto.Configurations.INTRO_VOLUME.name.lowercase(Locale.getDefault()),
-                "Default volume of intros for users on your server (90 without an override)",
-                false
-            ),
-            OptionData(
-                OptionType.INTEGER,
-                ConfigDto.Configurations.DELETE_DELAY.name.lowercase(Locale.getDefault()),
-                "The length of time in seconds before your slash command messages are deleted",
-                false
-            ),
-            OptionData(
-                OptionType.CHANNEL,
-                ConfigDto.Configurations.MOVE.name.lowercase(Locale.getDefault()),
-                "Value for the default move channel you want if using move command without arguments",
-                false
-            ),
-            OptionData(
-                OptionType.CHANNEL,
-                ConfigDto.Configurations.LEADERBOARD_CHANNEL.name.lowercase(Locale.getDefault()),
-                "Text channel for the monthly social credit leaderboard post",
-                false
-            ).setChannelTypes(ChannelType.TEXT),
-            OptionData(
-                OptionType.BOOLEAN,
-                ConfigDto.Configurations.ACTIVITY_TRACKING.name.lowercase(Locale.getDefault()),
-                "Enable game-activity tracking in this server (users can opt out individually)",
-                false
-            ),
-            OptionData(
-                OptionType.INTEGER,
-                ConfigDto.Configurations.JACKPOT_LOSS_TRIBUTE_PCT.name.lowercase(Locale.getDefault()),
-                "Percent (0-50) of every lost casino stake routed into the per-guild jackpot pool. Default 10.",
-                false
-            ),
-            OptionData(
-                OptionType.NUMBER,
-                ConfigDto.Configurations.JACKPOT_WIN_PCT.name.lowercase(Locale.getDefault()),
-                "Percent (0-50, decimals e.g. 0.5) chance any casino-game win triggers the jackpot. Default 1.",
-                false
-            ),
-            OptionData(
-                OptionType.NUMBER,
-                ConfigDto.Configurations.TRADE_BUY_FEE_PCT.name.lowercase(Locale.getDefault()),
-                "Percent (0-25, decimals allowed) skimmed off every Toby Coin BUY into the jackpot pool. Default 1.",
-                false
-            ),
-            OptionData(
-                OptionType.NUMBER,
-                ConfigDto.Configurations.TRADE_SELL_FEE_PCT.name.lowercase(Locale.getDefault()),
-                "Percent (0-25, decimals allowed) skimmed off every Toby Coin SELL into the jackpot pool. Default 1.",
-                false
-            ),
-            OptionData(
-                OptionType.INTEGER,
-                ConfigDto.Configurations.POKER_RAKE_PCT.name.lowercase(Locale.getDefault()),
-                "Percent (0-20) of every settled poker pot routed into the per-guild jackpot pool. Default 5.",
-                false
-            ),
-            OptionData(
-                OptionType.INTEGER,
-                ConfigDto.Configurations.POKER_SMALL_BLIND.name.lowercase(Locale.getDefault()),
-                "Per-guild poker small blind for new tables. Default 5.",
-                false
-            ),
-            OptionData(
-                OptionType.INTEGER,
-                ConfigDto.Configurations.POKER_BIG_BLIND.name.lowercase(Locale.getDefault()),
-                "Per-guild poker big blind for new tables. Default 10.",
-                false
-            ),
-            OptionData(
-                OptionType.INTEGER,
-                ConfigDto.Configurations.POKER_SMALL_BET.name.lowercase(Locale.getDefault()),
-                "Per-guild fixed-limit small bet (pre-flop / flop). Default 10.",
-                false
-            ),
-            OptionData(
-                OptionType.INTEGER,
-                ConfigDto.Configurations.POKER_BIG_BET.name.lowercase(Locale.getDefault()),
-                "Per-guild fixed-limit big bet (turn / river). Default 20.",
-                false
-            ),
-            OptionData(
-                OptionType.INTEGER,
-                ConfigDto.Configurations.POKER_MIN_BUY_IN.name.lowercase(Locale.getDefault()),
-                "Per-guild minimum poker buy-in. Default 100.",
-                false
-            ),
-            OptionData(
-                OptionType.INTEGER,
-                ConfigDto.Configurations.POKER_MAX_BUY_IN.name.lowercase(Locale.getDefault()),
-                "Per-guild maximum poker buy-in. Default 5000.",
-                false
-            ),
-            OptionData(
-                OptionType.INTEGER,
-                ConfigDto.Configurations.POKER_MAX_SEATS.name.lowercase(Locale.getDefault()),
-                "Maximum players per poker table (2-9). Default 6.",
-                false
-            ),
-            OptionData(
-                OptionType.INTEGER,
-                ConfigDto.Configurations.POKER_SHOT_CLOCK_SECONDS.name.lowercase(Locale.getDefault()),
-                "Per-actor decision deadline in seconds (0 disables). Default 30.",
-                false
-            ),
-            OptionData(
-                OptionType.INTEGER,
-                ConfigDto.Configurations.BLACKJACK_RAKE_PCT.name.lowercase(Locale.getDefault()),
-                "Percent (0-20) of every settled blackjack pot routed into the per-guild jackpot pool. Default 5.",
-                false
-            ),
-            OptionData(
-                OptionType.INTEGER,
-                ConfigDto.Configurations.BLACKJACK_MIN_ANTE.name.lowercase(Locale.getDefault()),
-                "Per-guild minimum blackjack stake (applies to both solo hands and multi-table antes). Default 10.",
-                false
-            ),
-            OptionData(
-                OptionType.INTEGER,
-                ConfigDto.Configurations.BLACKJACK_MAX_ANTE.name.lowercase(Locale.getDefault()),
-                "Per-guild maximum blackjack stake (applies to both solo hands and multi-table antes). Default 500.",
-                false
-            ),
-            OptionData(
-                OptionType.INTEGER,
-                ConfigDto.Configurations.BLACKJACK_MAX_SEATS.name.lowercase(Locale.getDefault()),
-                "Maximum players per blackjack multi table (2-7). Default 5.",
-                false
-            ),
-            // BLACKJACK_SHOT_CLOCK_SECONDS, BLACKJACK_DEALER_HITS_SOFT_17,
-            // BLACKJACK_BJ_PAYOUT_NUM/DEN are intentionally NOT registered
-            // as /setconfig options because Discord caps a single slash
-            // command at 25 options total. They're still settable via the
-            // /moderation web tab (ModerationWebService.updateConfig) and
-            // their `when` validation in this file stays exhaustive.
-            OptionData(
-                OptionType.INTEGER,
-                ConfigDto.Configurations.UBI_DAILY_AMOUNT.name.lowercase(Locale.getDefault()),
-                "Credits granted to every known user once per UTC day, regardless of voice. 0 disables UBI.",
-                false
-            ),
-            OptionData(
-                OptionType.INTEGER,
-                ConfigDto.Configurations.DAILY_CREDIT_CAP.name.lowercase(Locale.getDefault()),
-                "Override for the daily social-credit cap that applies to voice/command/intro earnings. Default 90.",
-                false
-            )
-        )
 }

--- a/discord-bot/src/main/kotlin/bot/toby/modal/modals/setconfig/SetConfigActivityModal.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/modal/modals/setconfig/SetConfigActivityModal.kt
@@ -1,0 +1,65 @@
+package bot.toby.modal.modals.setconfig
+
+import bot.toby.activity.ActivityTrackingNotifier
+import bot.toby.modal.modals.setconfig.SetConfigFieldValidator.FieldSpec
+import core.modal.ModalContext
+import database.dto.ConfigDto.Configurations
+import database.service.ConfigService
+import database.service.ConfigService.UpsertResult
+import org.springframework.stereotype.Component
+
+/**
+ * `/setconfig activity` — game-activity tracking toggle plus daily
+ * credit knobs (UBI and the cap that applies to voice/command/intro
+ * earnings).
+ *
+ * Preserves the first-enable side effect inherited from the old
+ * monolithic `SetConfigCommand.setActivityTracking`: fires
+ * [ActivityTrackingNotifier.notifyMembersOnFirstEnable] exactly once
+ * when ACTIVITY_TRACKING transitions from disabled (or unset) to
+ * `true`. Created and Updated-with-previous-`false` both qualify as
+ * "previously disabled".
+ */
+@Component
+class SetConfigActivityModal(
+    configService: ConfigService,
+    private val activityTrackingNotifier: ActivityTrackingNotifier,
+) : SimpleSetConfigCategoryModal(configService) {
+
+    override val name = MODAL_NAME
+    override val title = "Activity & UBI"
+
+    override val specs: LinkedHashMap<Configurations, FieldSpec> = linkedMapOf(
+        Configurations.ACTIVITY_TRACKING to FieldSpec.BoolStrict("Game-activity tracking"),
+        Configurations.UBI_DAILY_AMOUNT to FieldSpec.IntRange("UBI daily amount (credits)", 0..1000),
+        Configurations.DAILY_CREDIT_CAP to FieldSpec.IntRange("Daily credit cap", 0..10000),
+    )
+
+    override val fieldIds: Map<Configurations, String> = mapOf(
+        Configurations.ACTIVITY_TRACKING to FIELD_ACTIVITY_TRACKING,
+        Configurations.UBI_DAILY_AMOUNT to FIELD_UBI_DAILY_AMOUNT,
+        Configurations.DAILY_CREDIT_CAP to FIELD_DAILY_CREDIT_CAP,
+    )
+
+    override fun afterWrites(
+        ctx: ModalContext,
+        results: List<Pair<Configurations, UpsertResult>>,
+    ) {
+        val activity = results.firstOrNull { it.first == Configurations.ACTIVITY_TRACKING } ?: return
+        if (activity.second.dto.value != "true") return
+        val previouslyEnabled = when (val r = activity.second) {
+            is UpsertResult.Created -> false
+            is UpsertResult.Updated -> r.previousValue?.equals("true", ignoreCase = true) == true
+        }
+        if (!previouslyEnabled) {
+            activityTrackingNotifier.notifyMembersOnFirstEnable(ctx.guild)
+        }
+    }
+
+    companion object {
+        const val MODAL_NAME = "setconfig_activity"
+        const val FIELD_ACTIVITY_TRACKING = "activity_tracking"
+        const val FIELD_UBI_DAILY_AMOUNT = "ubi_daily_amount"
+        const val FIELD_DAILY_CREDIT_CAP = "daily_credit_cap"
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/modal/modals/setconfig/SetConfigBlackjackRulesModal.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/modal/modals/setconfig/SetConfigBlackjackRulesModal.kt
@@ -1,0 +1,46 @@
+package bot.toby.modal.modals.setconfig
+
+import bot.toby.modal.modals.setconfig.SetConfigFieldValidator.FieldSpec
+import database.dto.ConfigDto.Configurations
+import database.service.ConfigService
+import org.springframework.stereotype.Component
+
+/**
+ * `/setconfig blackjack_rules` — the hand-rules knobs admins tweak
+ * most: rake, ante bounds, dealer-soft-17 behaviour, and the
+ * per-actor shot clock. Seat count and blackjack-natural payout
+ * ratio live in `/setconfig blackjack_table`.
+ */
+@Component
+class SetConfigBlackjackRulesModal(
+    configService: ConfigService,
+) : SimpleSetConfigCategoryModal(configService) {
+
+    override val name = MODAL_NAME
+    override val title = "Blackjack rules"
+
+    override val specs: LinkedHashMap<Configurations, FieldSpec> = linkedMapOf(
+        Configurations.BLACKJACK_RAKE_PCT to FieldSpec.IntRange("Rake %", 0..20),
+        Configurations.BLACKJACK_MIN_ANTE to FieldSpec.LongMin("Min ante", 1L),
+        Configurations.BLACKJACK_MAX_ANTE to FieldSpec.LongMin("Max ante", 1L),
+        Configurations.BLACKJACK_DEALER_HITS_SOFT_17 to FieldSpec.BoolStrict("Dealer hits soft 17"),
+        Configurations.BLACKJACK_SHOT_CLOCK_SECONDS to FieldSpec.IntRange("Shot clock (seconds)", 0..600),
+    )
+
+    override val fieldIds: Map<Configurations, String> = mapOf(
+        Configurations.BLACKJACK_RAKE_PCT to FIELD_RAKE_PCT,
+        Configurations.BLACKJACK_MIN_ANTE to FIELD_MIN_ANTE,
+        Configurations.BLACKJACK_MAX_ANTE to FIELD_MAX_ANTE,
+        Configurations.BLACKJACK_DEALER_HITS_SOFT_17 to FIELD_DEALER_HITS_SOFT_17,
+        Configurations.BLACKJACK_SHOT_CLOCK_SECONDS to FIELD_SHOT_CLOCK_SECONDS,
+    )
+
+    companion object {
+        const val MODAL_NAME = "setconfig_blackjack_rules"
+        const val FIELD_RAKE_PCT = "rake_pct"
+        const val FIELD_MIN_ANTE = "min_ante"
+        const val FIELD_MAX_ANTE = "max_ante"
+        const val FIELD_DEALER_HITS_SOFT_17 = "dealer_hits_soft_17"
+        const val FIELD_SHOT_CLOCK_SECONDS = "shot_clock_seconds"
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/modal/modals/setconfig/SetConfigBlackjackTableModal.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/modal/modals/setconfig/SetConfigBlackjackTableModal.kt
@@ -1,0 +1,39 @@
+package bot.toby.modal.modals.setconfig
+
+import bot.toby.modal.modals.setconfig.SetConfigFieldValidator.FieldSpec
+import database.dto.ConfigDto.Configurations
+import database.service.ConfigService
+import org.springframework.stereotype.Component
+
+/**
+ * `/setconfig blackjack_table` — seat count + the natural-blackjack
+ * payout ratio numerator/denominator (e.g. 3:2 → num=3, den=2). Game
+ * rules live in the paired `/setconfig blackjack_rules` modal.
+ */
+@Component
+class SetConfigBlackjackTableModal(
+    configService: ConfigService,
+) : SimpleSetConfigCategoryModal(configService) {
+
+    override val name = MODAL_NAME
+    override val title = "Blackjack table shape"
+
+    override val specs: LinkedHashMap<Configurations, FieldSpec> = linkedMapOf(
+        Configurations.BLACKJACK_MAX_SEATS to FieldSpec.IntRange("Max seats", 2..7),
+        Configurations.BLACKJACK_BJ_PAYOUT_NUM to FieldSpec.IntRange("BJ payout numerator", 1..10),
+        Configurations.BLACKJACK_BJ_PAYOUT_DEN to FieldSpec.IntRange("BJ payout denominator", 1..10),
+    )
+
+    override val fieldIds: Map<Configurations, String> = mapOf(
+        Configurations.BLACKJACK_MAX_SEATS to FIELD_MAX_SEATS,
+        Configurations.BLACKJACK_BJ_PAYOUT_NUM to FIELD_BJ_PAYOUT_NUM,
+        Configurations.BLACKJACK_BJ_PAYOUT_DEN to FIELD_BJ_PAYOUT_DEN,
+    )
+
+    companion object {
+        const val MODAL_NAME = "setconfig_blackjack_table"
+        const val FIELD_MAX_SEATS = "max_seats"
+        const val FIELD_BJ_PAYOUT_NUM = "bj_payout_num"
+        const val FIELD_BJ_PAYOUT_DEN = "bj_payout_den"
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/modal/modals/setconfig/SetConfigCategoryModal.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/modal/modals/setconfig/SetConfigCategoryModal.kt
@@ -1,0 +1,152 @@
+package bot.toby.modal.modals.setconfig
+
+import bot.toby.modal.modals.setconfig.SetConfigFieldValidator.FieldSpec
+import bot.toby.modal.modals.setconfig.SetConfigFieldValidator.ValidationOutcome
+import core.modal.Modal
+import core.modal.ModalContext
+import database.dto.ConfigDto.Configurations
+import database.service.ConfigService
+import net.dv8tion.jda.api.components.label.Label
+import net.dv8tion.jda.api.components.textinput.TextInput
+import net.dv8tion.jda.api.components.textinput.TextInputStyle
+import net.dv8tion.jda.api.modals.Modal as JdaModal
+
+/**
+ * Base for every `/setconfig <category>` modal. Owns the
+ * read-fields → validate-all → write-all-or-error flow so each
+ * concrete category just declares its spec map + field-id map.
+ *
+ * Subclasses override [afterWrites] when they need a side effect
+ * keyed off an upsert result (e.g. ACTIVITY_TRACKING's first-enable
+ * notifier).
+ */
+abstract class SetConfigCategoryModal(
+    protected val configService: ConfigService,
+) : Modal {
+
+    /**
+     * Modal title shown in the Discord client. ≤45 chars. Takes the
+     * full modal id (`<name>` for simple modals, `<name>:<suffix>`
+     * for parameterised ones like the per-game stakes modal) so
+     * subclasses can vary the title by id.
+     */
+    protected abstract fun titleFor(modalId: String): String
+
+    /**
+     * Insertion-ordered list of (config key, field spec) for the
+     * given modal id. The order is the visual order of fields and
+     * the order error messages appear in on validation failure.
+     */
+    protected abstract fun specsFor(modalId: String): LinkedHashMap<Configurations, FieldSpec>
+
+    /**
+     * Discord-side field id (TextInput component id) for each config
+     * key. Must match the lookup keys used by `event.getValue(...)`.
+     */
+    protected abstract fun fieldIdsFor(modalId: String): Map<Configurations, String>
+
+    /**
+     * Hook fired after the batch upsert completes. Receives the list
+     * of (key, UpsertResult) so subclasses can branch on Created vs
+     * Updated.previousValue. Default no-op.
+     */
+    protected open fun afterWrites(
+        ctx: ModalContext,
+        results: List<Pair<Configurations, ConfigService.UpsertResult>>,
+    ) = Unit
+
+    final override fun handle(ctx: ModalContext, deleteDelay: Int) {
+        val event = ctx.event
+        val guild = ctx.guild
+        val modalId = event.modalId
+        val specs = specsFor(modalId)
+        val fieldIds = fieldIdsFor(modalId)
+
+        val outcome = SetConfigFieldValidator.validateAll(
+            readField = { key -> event.getValue(fieldIds.getValue(key))?.asString },
+            specs = specs,
+            guild = guild,
+        )
+
+        when (outcome) {
+            is ValidationOutcome.Errors -> {
+                event.hook.sendMessage(
+                    "Couldn't save — fix these fields:\n" +
+                        outcome.messages.joinToString("\n") { "• $it" } +
+                        "\n\nNo changes were written."
+                ).setEphemeral(true).queue()
+            }
+
+            is ValidationOutcome.Writes -> {
+                if (outcome.pairs.isEmpty()) {
+                    event.hook.sendMessage("No fields filled — nothing changed.")
+                        .setEphemeral(true).queue()
+                    return
+                }
+                val results = outcome.pairs.map { (key, value) ->
+                    key to configService.upsertConfig(key.configValue, value, guild.id)
+                }
+                event.hook.sendMessage(buildSummary(outcome.pairs, specs))
+                    .setEphemeral(true).queue()
+                afterWrites(ctx, results)
+            }
+        }
+    }
+
+    /**
+     * Build the modal pre-populated with current values. The caller
+     * supplies [modalId] (e.g. `"setconfig_stakes:dice"`) so
+     * parameterised modals can vary their fields per-call; for
+     * simple modals it's the bare [name].
+     *
+     * [currentValues] is read once by the slash command and passed
+     * in as a lookup — the modal handler does no DB reads at open
+     * time.
+     */
+    fun buildModal(modalId: String, currentValues: (Configurations) -> String?): JdaModal {
+        val title = titleFor(modalId)
+        val specs = specsFor(modalId)
+        val fieldIds = fieldIdsFor(modalId)
+        val builder = JdaModal.create(modalId, title)
+        for ((key, spec) in specs) {
+            val input = TextInput.create(fieldIds.getValue(key), TextInputStyle.SHORT)
+                .setRequired(false)
+                .apply {
+                    currentValues(key)?.takeIf { it.isNotEmpty() }?.let { setValue(it) }
+                    placeholderFor(spec)?.let { setPlaceholder(it) }
+                }
+                .build()
+            builder.addComponents(Label.of(truncateLabel(spec.label), input))
+        }
+        return builder.build()
+    }
+
+    private fun buildSummary(
+        pairs: List<Pair<Configurations, String>>,
+        specs: LinkedHashMap<Configurations, FieldSpec>,
+    ): String {
+        val header = "Saved ${pairs.size} setting${if (pairs.size == 1) "" else "s"}:\n"
+        val body = pairs.joinToString("\n") { (key, value) ->
+            "• ${specs.getValue(key).label}: $value"
+        }
+        return header + body
+    }
+
+    private fun placeholderFor(spec: FieldSpec): String? = when (spec) {
+        is FieldSpec.IntRange -> "${spec.range.first}–${spec.range.last}"
+        is FieldSpec.LongMin -> "≥ ${spec.min}"
+        is FieldSpec.DoubleRange -> "${spec.range.start}–${spec.range.endInclusive}"
+        is FieldSpec.BoolStrict -> "true / false"
+        is FieldSpec.EnumChoice -> spec.allowed.joinToString(" / ")
+        is FieldSpec.ChannelByIdStoreName -> "channel id"
+        is FieldSpec.ChannelByIdStoreId -> if (spec.allowClear) "channel id (0 to clear)" else "channel id"
+    }
+
+    private fun truncateLabel(label: String): String =
+        if (label.length <= LABEL_LIMIT) label else label.take(LABEL_LIMIT - 1) + "…"
+
+    companion object {
+        /** Discord modal label cap. */
+        private const val LABEL_LIMIT = 45
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/modal/modals/setconfig/SetConfigFeesModal.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/modal/modals/setconfig/SetConfigFeesModal.kt
@@ -1,0 +1,42 @@
+package bot.toby.modal.modals.setconfig
+
+import bot.toby.modal.modals.setconfig.SetConfigFieldValidator.FieldSpec
+import database.dto.ConfigDto.Configurations
+import database.service.ConfigService
+import org.springframework.stereotype.Component
+
+/**
+ * `/setconfig fees` — the four "pool feed" percentages that route
+ * stake/trade money into the per-guild jackpot pool. All four are
+ * decimal percentages; ranges mirror the legacy command's validation.
+ */
+@Component
+class SetConfigFeesModal(
+    configService: ConfigService,
+) : SimpleSetConfigCategoryModal(configService) {
+
+    override val name = MODAL_NAME
+    override val title = "Jackpot feed % rates"
+
+    override val specs: LinkedHashMap<Configurations, FieldSpec> = linkedMapOf(
+        Configurations.JACKPOT_LOSS_TRIBUTE_PCT to FieldSpec.IntRange("Loss tribute %", 0..50),
+        Configurations.JACKPOT_WIN_PCT to FieldSpec.DoubleRange("Jackpot win %", 0.0..50.0),
+        Configurations.TRADE_BUY_FEE_PCT to FieldSpec.DoubleRange("Coin BUY fee %", 0.0..25.0),
+        Configurations.TRADE_SELL_FEE_PCT to FieldSpec.DoubleRange("Coin SELL fee %", 0.0..25.0),
+    )
+
+    override val fieldIds: Map<Configurations, String> = mapOf(
+        Configurations.JACKPOT_LOSS_TRIBUTE_PCT to FIELD_LOSS_TRIBUTE_PCT,
+        Configurations.JACKPOT_WIN_PCT to FIELD_WIN_PCT,
+        Configurations.TRADE_BUY_FEE_PCT to FIELD_TRADE_BUY_FEE_PCT,
+        Configurations.TRADE_SELL_FEE_PCT to FIELD_TRADE_SELL_FEE_PCT,
+    )
+
+    companion object {
+        const val MODAL_NAME = "setconfig_fees"
+        const val FIELD_LOSS_TRIBUTE_PCT = "loss_tribute_pct"
+        const val FIELD_WIN_PCT = "win_pct"
+        const val FIELD_TRADE_BUY_FEE_PCT = "trade_buy_fee_pct"
+        const val FIELD_TRADE_SELL_FEE_PCT = "trade_sell_fee_pct"
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/modal/modals/setconfig/SetConfigFieldValidator.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/modal/modals/setconfig/SetConfigFieldValidator.kt
@@ -1,0 +1,183 @@
+package bot.toby.modal.modals.setconfig
+
+import database.dto.ConfigDto
+import net.dv8tion.jda.api.entities.Guild
+
+/**
+ * Shared typed-field parser/validator for the `/setconfig …` modals.
+ *
+ * Each modal declares a `LinkedHashMap<Configurations, FieldSpec>`
+ * describing its fields, then calls [validateAll] with a reader that
+ * looks up the user-submitted text by config key. The validator
+ * returns either a list of (key, stringified-value) pairs to write or
+ * a list of human-readable error messages — never a mix.
+ *
+ * Three-state per-field outcome:
+ *   - `Skip`  — input was blank/whitespace → no upsert
+ *               (preserves the "blank means don't overwrite" rule)
+ *   - `Write` — parsed cleanly → upsert with the stringified value
+ *   - `Error` — failed to parse → collect the reason
+ *
+ * Modals MUST validate every field before performing any write so a
+ * single bad field doesn't leave the config half-applied.
+ */
+object SetConfigFieldValidator {
+
+    sealed interface FieldSpec {
+        val label: String
+
+        /** Whole-number integer constrained to an inclusive range. */
+        data class IntRange(override val label: String, val range: kotlin.ranges.IntRange) : FieldSpec
+
+        /** Whole-number long with a minimum (≥ [min]); no upper bound. */
+        data class LongMin(override val label: String, val min: Long) : FieldSpec
+
+        /** Decimal number constrained to an inclusive range, NaN/∞ rejected. */
+        data class DoubleRange(override val label: String, val range: ClosedFloatingPointRange<Double>) : FieldSpec
+
+        /**
+         * Boolean accepting case-insensitive `true|false|yes|no|1|0|on|off`.
+         * Always stored as `"true"` / `"false"` for downstream readers.
+         */
+        data class BoolStrict(override val label: String) : FieldSpec
+
+        /** Case-insensitive enum match; stored uppercase. */
+        data class EnumChoice(override val label: String, val allowed: Set<String>) : FieldSpec
+
+        /**
+         * Discord channel reference (raw id or `<#id>` mention) resolved
+         * against the guild; the channel's **name** is stored. Used by
+         * `MOVE`, which `MoveCommand` looks up by name — switching to id
+         * would silently break unscoped admins.
+         */
+        data class ChannelByIdStoreName(override val label: String) : FieldSpec
+
+        /**
+         * Discord channel reference resolved against the guild; the
+         * channel's **id** is stored as a string. Used for
+         * LEADERBOARD_CHANNEL, LOTTERY_CHANNEL, CASINO_MODLOG_CHANNEL_ID.
+         * `"0"` clears the override to empty string when [allowClear].
+         */
+        data class ChannelByIdStoreId(override val label: String, val allowClear: Boolean = true) : FieldSpec
+    }
+
+    sealed interface FieldResult {
+        data object Skip : FieldResult
+        data class Write(val value: String) : FieldResult
+        data class Error(val message: String) : FieldResult
+    }
+
+    /** Run a single field through its spec. Public for direct unit testing. */
+    fun validate(input: String?, spec: FieldSpec, guild: Guild? = null): FieldResult {
+        val raw = input?.trim().orEmpty()
+        if (raw.isEmpty()) return FieldResult.Skip
+
+        return when (spec) {
+            is FieldSpec.IntRange -> parseInt(raw, spec)
+            is FieldSpec.LongMin -> parseLong(raw, spec)
+            is FieldSpec.DoubleRange -> parseDouble(raw, spec)
+            is FieldSpec.BoolStrict -> parseBool(raw, spec)
+            is FieldSpec.EnumChoice -> parseEnum(raw, spec)
+            is FieldSpec.ChannelByIdStoreName -> resolveChannelName(raw, spec, guild)
+            is FieldSpec.ChannelByIdStoreId -> resolveChannelId(raw, spec, guild)
+        }
+    }
+
+    /**
+     * Run [validate] over every (key, spec) pair in insertion order.
+     * `readField(key)` returns the raw text the modal submitted for
+     * that field; pass `null` for fields the modal doesn't expose.
+     *
+     * Output preserves spec insertion order so error messages appear
+     * top-to-bottom matching the visual field order in the modal.
+     */
+    fun validateAll(
+        readField: (ConfigDto.Configurations) -> String?,
+        specs: Map<ConfigDto.Configurations, FieldSpec>,
+        guild: Guild? = null,
+    ): ValidationOutcome {
+        val writes = mutableListOf<Pair<ConfigDto.Configurations, String>>()
+        val errors = mutableListOf<String>()
+        for ((key, spec) in specs) {
+            when (val result = validate(readField(key), spec, guild)) {
+                FieldResult.Skip -> Unit
+                is FieldResult.Write -> writes += key to result.value
+                is FieldResult.Error -> errors += result.message
+            }
+        }
+        return if (errors.isNotEmpty()) ValidationOutcome.Errors(errors)
+        else ValidationOutcome.Writes(writes)
+    }
+
+    sealed interface ValidationOutcome {
+        data class Writes(val pairs: List<Pair<ConfigDto.Configurations, String>>) : ValidationOutcome
+        data class Errors(val messages: List<String>) : ValidationOutcome
+    }
+
+    // ------------------------------------------------------------------
+    // Per-type parsers (private — exposed only via `validate`)
+    // ------------------------------------------------------------------
+
+    private fun parseInt(raw: String, spec: FieldSpec.IntRange): FieldResult {
+        val parsed = raw.toIntOrNull()
+            ?: return FieldResult.Error("${spec.label}: must be a whole number")
+        return if (parsed !in spec.range) FieldResult.Error(
+            "${spec.label}: must be between ${spec.range.first} and ${spec.range.last}"
+        ) else FieldResult.Write(parsed.toString())
+    }
+
+    private fun parseLong(raw: String, spec: FieldSpec.LongMin): FieldResult {
+        val parsed = raw.toLongOrNull()
+            ?: return FieldResult.Error("${spec.label}: must be a whole number")
+        return if (parsed < spec.min) FieldResult.Error(
+            "${spec.label}: must be at least ${spec.min}"
+        ) else FieldResult.Write(parsed.toString())
+    }
+
+    private fun parseDouble(raw: String, spec: FieldSpec.DoubleRange): FieldResult {
+        val parsed = raw.toDoubleOrNull()
+            ?: return FieldResult.Error("${spec.label}: must be a number")
+        if (parsed.isNaN() || parsed.isInfinite())
+            return FieldResult.Error("${spec.label}: must be a finite number")
+        return if (parsed < spec.range.start || parsed > spec.range.endInclusive)
+            FieldResult.Error("${spec.label}: must be between ${spec.range.start} and ${spec.range.endInclusive}")
+        else FieldResult.Write(parsed.toString())
+    }
+
+    private fun parseBool(raw: String, spec: FieldSpec.BoolStrict): FieldResult {
+        return when (raw.lowercase()) {
+            "true", "yes", "1", "on", "enabled" -> FieldResult.Write("true")
+            "false", "no", "0", "off", "disabled" -> FieldResult.Write("false")
+            else -> FieldResult.Error("${spec.label}: must be true/false")
+        }
+    }
+
+    private fun parseEnum(raw: String, spec: FieldSpec.EnumChoice): FieldResult {
+        val upper = raw.uppercase()
+        return if (upper in spec.allowed) FieldResult.Write(upper)
+        else FieldResult.Error("${spec.label}: must be one of ${spec.allowed.joinToString()}")
+    }
+
+    private fun resolveChannelName(raw: String, spec: FieldSpec.ChannelByIdStoreName, guild: Guild?): FieldResult {
+        if (guild == null) return FieldResult.Error("${spec.label}: no guild context to resolve channel")
+        val id = extractChannelId(raw)
+            ?: return FieldResult.Error("${spec.label}: must be a channel id or #mention")
+        val ch = guild.getTextChannelById(id)
+            ?: guild.getVoiceChannelById(id)
+            ?: return FieldResult.Error("${spec.label}: no channel with id $id in this server")
+        return FieldResult.Write(ch.name)
+    }
+
+    private fun resolveChannelId(raw: String, spec: FieldSpec.ChannelByIdStoreId, guild: Guild?): FieldResult {
+        if (spec.allowClear && raw == "0") return FieldResult.Write("")
+        if (guild == null) return FieldResult.Error("${spec.label}: no guild context to resolve channel")
+        val id = extractChannelId(raw)
+            ?: return FieldResult.Error("${spec.label}: must be a channel id or #mention")
+        guild.getTextChannelById(id)
+            ?: return FieldResult.Error("${spec.label}: no text channel with id $id in this server")
+        return FieldResult.Write(id.toString())
+    }
+
+    private fun extractChannelId(raw: String): Long? =
+        raw.removePrefix("<#").removeSuffix(">").toLongOrNull()
+}

--- a/discord-bot/src/main/kotlin/bot/toby/modal/modals/setconfig/SetConfigGeneralModal.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/modal/modals/setconfig/SetConfigGeneralModal.kt
@@ -1,0 +1,45 @@
+package bot.toby.modal.modals.setconfig
+
+import bot.toby.modal.modals.setconfig.SetConfigFieldValidator.FieldSpec
+import database.dto.ConfigDto.Configurations
+import database.service.ConfigService
+import org.springframework.stereotype.Component
+
+/**
+ * `/setconfig general` — audio defaults + auto-delete delay + the two
+ * channel knobs every guild cares about (default move target +
+ * monthly leaderboard post location).
+ */
+@Component
+class SetConfigGeneralModal(
+    configService: ConfigService,
+) : SimpleSetConfigCategoryModal(configService) {
+
+    override val name = MODAL_NAME
+    override val title = "General settings"
+
+    override val specs: LinkedHashMap<Configurations, FieldSpec> = linkedMapOf(
+        Configurations.VOLUME to FieldSpec.IntRange("Default volume", 0..200),
+        Configurations.INTRO_VOLUME to FieldSpec.IntRange("Default intro volume", 0..200),
+        Configurations.DELETE_DELAY to FieldSpec.IntRange("Delete delay (seconds)", 0..600),
+        Configurations.MOVE to FieldSpec.ChannelByIdStoreName("Default move channel"),
+        Configurations.LEADERBOARD_CHANNEL to FieldSpec.ChannelByIdStoreId("Leaderboard channel"),
+    )
+
+    override val fieldIds: Map<Configurations, String> = mapOf(
+        Configurations.VOLUME to FIELD_VOLUME,
+        Configurations.INTRO_VOLUME to FIELD_INTRO_VOLUME,
+        Configurations.DELETE_DELAY to FIELD_DELETE_DELAY,
+        Configurations.MOVE to FIELD_MOVE,
+        Configurations.LEADERBOARD_CHANNEL to FIELD_LEADERBOARD_CHANNEL,
+    )
+
+    companion object {
+        const val MODAL_NAME = "setconfig_general"
+        const val FIELD_VOLUME = "volume"
+        const val FIELD_INTRO_VOLUME = "intro_volume"
+        const val FIELD_DELETE_DELAY = "delete_delay"
+        const val FIELD_MOVE = "move"
+        const val FIELD_LEADERBOARD_CHANNEL = "leaderboard_channel"
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/modal/modals/setconfig/SetConfigJackpotActivityModal.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/modal/modals/setconfig/SetConfigJackpotActivityModal.kt
@@ -1,0 +1,37 @@
+package bot.toby.modal.modals.setconfig
+
+import bot.toby.modal.modals.setconfig.SetConfigFieldValidator.FieldSpec
+import database.dto.ConfigDto.Configurations
+import database.service.ConfigService
+import org.springframework.stereotype.Component
+
+/**
+ * `/setconfig jackpot_activity` — the two "user must be active to win
+ * the jackpot" knobs. Both default to a permissive 0/1 (gate disabled)
+ * so the typical guild doesn't notice them; raise both to enforce a
+ * "must have voice-credit activity on N of the last M days" gate.
+ */
+@Component
+class SetConfigJackpotActivityModal(
+    configService: ConfigService,
+) : SimpleSetConfigCategoryModal(configService) {
+
+    override val name = MODAL_NAME
+    override val title = "Jackpot activity gate"
+
+    override val specs: LinkedHashMap<Configurations, FieldSpec> = linkedMapOf(
+        Configurations.JACKPOT_ACTIVITY_WINDOW_DAYS to FieldSpec.IntRange("Activity window (days)", 0..365),
+        Configurations.JACKPOT_ACTIVITY_MIN_DAYS to FieldSpec.IntRange("Min active days in window", 1..365),
+    )
+
+    override val fieldIds: Map<Configurations, String> = mapOf(
+        Configurations.JACKPOT_ACTIVITY_WINDOW_DAYS to FIELD_WINDOW_DAYS,
+        Configurations.JACKPOT_ACTIVITY_MIN_DAYS to FIELD_MIN_DAYS,
+    )
+
+    companion object {
+        const val MODAL_NAME = "setconfig_jackpot_activity"
+        const val FIELD_WINDOW_DAYS = "window_days"
+        const val FIELD_MIN_DAYS = "min_days"
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/modal/modals/setconfig/SetConfigJackpotModal.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/modal/modals/setconfig/SetConfigJackpotModal.kt
@@ -1,0 +1,44 @@
+package bot.toby.modal.modals.setconfig
+
+import bot.toby.modal.modals.setconfig.SetConfigFieldValidator.FieldSpec
+import database.dto.ConfigDto.Configurations
+import database.service.ConfigService
+import org.springframework.stereotype.Component
+
+/**
+ * `/setconfig jackpot` — jackpot eligibility-gate tunables plus the
+ * casino moderation log channel. `JACKPOT_WHEEL_SEGMENTS` stays
+ * web-only (CSV format wants the dedicated editor in the
+ * /moderation tab); the wheel-segments key is intentionally absent
+ * from this modal.
+ */
+@Component
+class SetConfigJackpotModal(
+    configService: ConfigService,
+) : SimpleSetConfigCategoryModal(configService) {
+
+    override val name = MODAL_NAME
+    override val title = "Jackpot tuning"
+
+    override val specs: LinkedHashMap<Configurations, FieldSpec> = linkedMapOf(
+        Configurations.JACKPOT_STAKE_ANCHOR to FieldSpec.LongMin("Stake anchor", 1L),
+        Configurations.JACKPOT_WINNER_COOLDOWN_DAYS to FieldSpec.IntRange("Winner cooldown (days)", 0..365),
+        Configurations.JACKPOT_RTP_MAX_PCT to FieldSpec.IntRange("RTP gate ceiling %", 0..100),
+        Configurations.CASINO_MODLOG_CHANNEL_ID to FieldSpec.ChannelByIdStoreId("Casino modlog channel"),
+    )
+
+    override val fieldIds: Map<Configurations, String> = mapOf(
+        Configurations.JACKPOT_STAKE_ANCHOR to FIELD_STAKE_ANCHOR,
+        Configurations.JACKPOT_WINNER_COOLDOWN_DAYS to FIELD_WINNER_COOLDOWN_DAYS,
+        Configurations.JACKPOT_RTP_MAX_PCT to FIELD_RTP_MAX_PCT,
+        Configurations.CASINO_MODLOG_CHANNEL_ID to FIELD_CASINO_MODLOG_CHANNEL_ID,
+    )
+
+    companion object {
+        const val MODAL_NAME = "setconfig_jackpot"
+        const val FIELD_STAKE_ANCHOR = "stake_anchor"
+        const val FIELD_WINNER_COOLDOWN_DAYS = "winner_cooldown_days"
+        const val FIELD_RTP_MAX_PCT = "rtp_max_pct"
+        const val FIELD_CASINO_MODLOG_CHANNEL_ID = "casino_modlog_channel_id"
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/modal/modals/setconfig/SetConfigLotteryBasicsModal.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/modal/modals/setconfig/SetConfigLotteryBasicsModal.kt
@@ -1,0 +1,49 @@
+package bot.toby.modal.modals.setconfig
+
+import bot.toby.modal.modals.setconfig.SetConfigFieldValidator.FieldSpec
+import database.dto.ConfigDto.Configurations
+import database.service.ConfigService
+import org.springframework.stereotype.Component
+
+/**
+ * `/setconfig lottery_basics` — daily-lottery on/off + ticket
+ * economics + draw mode + announcement ping. Pool-revenue split
+ * lives in the paired `/setconfig lottery_pools` modal.
+ */
+@Component
+class SetConfigLotteryBasicsModal(
+    configService: ConfigService,
+) : SimpleSetConfigCategoryModal(configService) {
+
+    override val name = MODAL_NAME
+    override val title = "Daily lottery basics"
+
+    override val specs: LinkedHashMap<Configurations, FieldSpec> = linkedMapOf(
+        Configurations.LOTTERY_DAILY_ENABLED to FieldSpec.BoolStrict("Daily lottery enabled"),
+        Configurations.LOTTERY_DAILY_TICKET_PRICE to FieldSpec.LongMin("Ticket price (credits)", 1L),
+        Configurations.LOTTERY_DAILY_MIN_BUYERS to FieldSpec.IntRange("Min distinct buyers", 1..50),
+        Configurations.LOTTERY_DAILY_MODE to FieldSpec.EnumChoice(
+            "Draw mode", setOf("NUMBER_MATCH", "WEIGHTED"),
+        ),
+        Configurations.LOTTERY_PING_MODE to FieldSpec.EnumChoice(
+            "Announcement ping", setOf("OFF", "HERE", "EVERYONE"),
+        ),
+    )
+
+    override val fieldIds: Map<Configurations, String> = mapOf(
+        Configurations.LOTTERY_DAILY_ENABLED to FIELD_ENABLED,
+        Configurations.LOTTERY_DAILY_TICKET_PRICE to FIELD_TICKET_PRICE,
+        Configurations.LOTTERY_DAILY_MIN_BUYERS to FIELD_MIN_BUYERS,
+        Configurations.LOTTERY_DAILY_MODE to FIELD_MODE,
+        Configurations.LOTTERY_PING_MODE to FIELD_PING_MODE,
+    )
+
+    companion object {
+        const val MODAL_NAME = "setconfig_lottery_basics"
+        const val FIELD_ENABLED = "enabled"
+        const val FIELD_TICKET_PRICE = "ticket_price"
+        const val FIELD_MIN_BUYERS = "min_buyers"
+        const val FIELD_MODE = "mode"
+        const val FIELD_PING_MODE = "ping_mode"
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/modal/modals/setconfig/SetConfigLotteryPoolsModal.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/modal/modals/setconfig/SetConfigLotteryPoolsModal.kt
@@ -1,0 +1,39 @@
+package bot.toby.modal.modals.setconfig
+
+import bot.toby.modal.modals.setconfig.SetConfigFieldValidator.FieldSpec
+import database.dto.ConfigDto.Configurations
+import database.service.ConfigService
+import org.springframework.stereotype.Component
+
+/**
+ * `/setconfig lottery_pools` — pool-seed and revenue-split percentages
+ * plus the announce channel override. Pairs with
+ * `/setconfig lottery_basics` (toggle + ticket economics).
+ */
+@Component
+class SetConfigLotteryPoolsModal(
+    configService: ConfigService,
+) : SimpleSetConfigCategoryModal(configService) {
+
+    override val name = MODAL_NAME
+    override val title = "Lottery pool routing"
+
+    override val specs: LinkedHashMap<Configurations, FieldSpec> = linkedMapOf(
+        Configurations.LOTTERY_DAILY_SEED_PCT to FieldSpec.IntRange("Pool seed %", 1..100),
+        Configurations.LOTTERY_DAILY_REVENUE_JACKPOT_PCT to FieldSpec.IntRange("Ticket revenue → jackpot %", 0..100),
+        Configurations.LOTTERY_CHANNEL to FieldSpec.ChannelByIdStoreId("Announcement channel"),
+    )
+
+    override val fieldIds: Map<Configurations, String> = mapOf(
+        Configurations.LOTTERY_DAILY_SEED_PCT to FIELD_SEED_PCT,
+        Configurations.LOTTERY_DAILY_REVENUE_JACKPOT_PCT to FIELD_REVENUE_JACKPOT_PCT,
+        Configurations.LOTTERY_CHANNEL to FIELD_CHANNEL,
+    )
+
+    companion object {
+        const val MODAL_NAME = "setconfig_lottery_pools"
+        const val FIELD_SEED_PCT = "seed_pct"
+        const val FIELD_REVENUE_JACKPOT_PCT = "revenue_jackpot_pct"
+        const val FIELD_CHANNEL = "channel"
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/modal/modals/setconfig/SetConfigPokerStakesModal.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/modal/modals/setconfig/SetConfigPokerStakesModal.kt
@@ -1,0 +1,46 @@
+package bot.toby.modal.modals.setconfig
+
+import bot.toby.modal.modals.setconfig.SetConfigFieldValidator.FieldSpec
+import database.dto.ConfigDto.Configurations
+import database.service.ConfigService
+import org.springframework.stereotype.Component
+
+/**
+ * `/setconfig poker_stakes` — money rules for new poker tables:
+ * blinds, fixed-limit bet sizes, and rake. Buy-in bounds and seat
+ * count live in `/setconfig poker_table` so each modal stays at or
+ * under Discord's 5-component cap.
+ */
+@Component
+class SetConfigPokerStakesModal(
+    configService: ConfigService,
+) : SimpleSetConfigCategoryModal(configService) {
+
+    override val name = MODAL_NAME
+    override val title = "Poker stakes"
+
+    override val specs: LinkedHashMap<Configurations, FieldSpec> = linkedMapOf(
+        Configurations.POKER_SMALL_BLIND to FieldSpec.LongMin("Small blind", 1L),
+        Configurations.POKER_BIG_BLIND to FieldSpec.LongMin("Big blind", 1L),
+        Configurations.POKER_SMALL_BET to FieldSpec.LongMin("Small bet", 1L),
+        Configurations.POKER_BIG_BET to FieldSpec.LongMin("Big bet", 1L),
+        Configurations.POKER_RAKE_PCT to FieldSpec.IntRange("Rake %", 0..20),
+    )
+
+    override val fieldIds: Map<Configurations, String> = mapOf(
+        Configurations.POKER_SMALL_BLIND to FIELD_SMALL_BLIND,
+        Configurations.POKER_BIG_BLIND to FIELD_BIG_BLIND,
+        Configurations.POKER_SMALL_BET to FIELD_SMALL_BET,
+        Configurations.POKER_BIG_BET to FIELD_BIG_BET,
+        Configurations.POKER_RAKE_PCT to FIELD_RAKE_PCT,
+    )
+
+    companion object {
+        const val MODAL_NAME = "setconfig_poker_stakes"
+        const val FIELD_SMALL_BLIND = "small_blind"
+        const val FIELD_BIG_BLIND = "big_blind"
+        const val FIELD_SMALL_BET = "small_bet"
+        const val FIELD_BIG_BET = "big_bet"
+        const val FIELD_RAKE_PCT = "rake_pct"
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/modal/modals/setconfig/SetConfigPokerTableModal.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/modal/modals/setconfig/SetConfigPokerTableModal.kt
@@ -1,0 +1,42 @@
+package bot.toby.modal.modals.setconfig
+
+import bot.toby.modal.modals.setconfig.SetConfigFieldValidator.FieldSpec
+import database.dto.ConfigDto.Configurations
+import database.service.ConfigService
+import org.springframework.stereotype.Component
+
+/**
+ * `/setconfig poker_table` — table-shape knobs: buy-in bounds, seat
+ * count, and the per-actor shot clock. Money rules live in the
+ * paired `/setconfig poker_stakes` modal.
+ */
+@Component
+class SetConfigPokerTableModal(
+    configService: ConfigService,
+) : SimpleSetConfigCategoryModal(configService) {
+
+    override val name = MODAL_NAME
+    override val title = "Poker table shape"
+
+    override val specs: LinkedHashMap<Configurations, FieldSpec> = linkedMapOf(
+        Configurations.POKER_MIN_BUY_IN to FieldSpec.LongMin("Min buy-in", 1L),
+        Configurations.POKER_MAX_BUY_IN to FieldSpec.LongMin("Max buy-in", 1L),
+        Configurations.POKER_MAX_SEATS to FieldSpec.IntRange("Max seats", 2..9),
+        Configurations.POKER_SHOT_CLOCK_SECONDS to FieldSpec.IntRange("Shot clock (seconds)", 0..600),
+    )
+
+    override val fieldIds: Map<Configurations, String> = mapOf(
+        Configurations.POKER_MIN_BUY_IN to FIELD_MIN_BUY_IN,
+        Configurations.POKER_MAX_BUY_IN to FIELD_MAX_BUY_IN,
+        Configurations.POKER_MAX_SEATS to FIELD_MAX_SEATS,
+        Configurations.POKER_SHOT_CLOCK_SECONDS to FIELD_SHOT_CLOCK_SECONDS,
+    )
+
+    companion object {
+        const val MODAL_NAME = "setconfig_poker_table"
+        const val FIELD_MIN_BUY_IN = "min_buy_in"
+        const val FIELD_MAX_BUY_IN = "max_buy_in"
+        const val FIELD_MAX_SEATS = "max_seats"
+        const val FIELD_SHOT_CLOCK_SECONDS = "shot_clock_seconds"
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/modal/modals/setconfig/SetConfigStakesModal.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/modal/modals/setconfig/SetConfigStakesModal.kt
@@ -1,0 +1,98 @@
+package bot.toby.modal.modals.setconfig
+
+import bot.toby.modal.modals.setconfig.SetConfigFieldValidator.FieldSpec
+import database.dto.ConfigDto.Configurations
+import database.service.ConfigService
+import org.springframework.stereotype.Component
+
+/**
+ * `/setconfig stakes game:<choice>` — per-game stake bounds. The
+ * slash command's `game` choice option is encoded into the modal
+ * `customId` as `setconfig_stakes:<game>` (lowercase) so the modal
+ * handler knows which `*_MIN_STAKE`/`*_MAX_STAKE` (and, where
+ * present, `*_BOT_EDGE_MAX_PCT`) keys to write.
+ *
+ * `DefaultModalManager.getModal` routes on the substring before `:`
+ * — so [MODAL_NAME] = `"setconfig_stakes"` matches every game.
+ *
+ * Adding a new game means adding a new [Game] entry — nothing else
+ * to touch.
+ */
+@Component
+class SetConfigStakesModal(
+    configService: ConfigService,
+) : SetConfigCategoryModal(configService) {
+
+    override val name = MODAL_NAME
+
+    override fun titleFor(modalId: String): String {
+        val game = parseGame(modalId)
+        return "${game.label} stakes"
+    }
+
+    override fun specsFor(modalId: String): LinkedHashMap<Configurations, FieldSpec> {
+        val game = parseGame(modalId)
+        return linkedMapOf<Configurations, FieldSpec>().apply {
+            put(game.minKey, FieldSpec.LongMin("Min stake (credits)", 1L))
+            put(game.maxKey, FieldSpec.LongMin("Max stake (credits)", 1L))
+            game.botEdgeKey?.let {
+                put(it, FieldSpec.IntRange("Bot-suspicion max edge %", 0..50))
+            }
+        }
+    }
+
+    override fun fieldIdsFor(modalId: String): Map<Configurations, String> {
+        val game = parseGame(modalId)
+        return buildMap {
+            put(game.minKey, FIELD_MIN_STAKE)
+            put(game.maxKey, FIELD_MAX_STAKE)
+            game.botEdgeKey?.let { put(it, FIELD_BOT_EDGE_PCT) }
+        }
+    }
+
+    private fun parseGame(modalId: String): Game {
+        val token = modalId.substringAfter(':', missingDelimiterValue = "")
+        return Game.byToken(token)
+            ?: error("Stakes modal customId missing or unknown game token: '$modalId'")
+    }
+
+    /**
+     * The 10 casino games exposed through `/setconfig stakes`. Each
+     * entry binds a lowercase token (used in slash-option choices and
+     * in the modal customId suffix), a human-friendly label for the
+     * modal title, and the per-game ConfigDto keys.
+     */
+    enum class Game(
+        val token: String,
+        val label: String,
+        val minKey: Configurations,
+        val maxKey: Configurations,
+        val botEdgeKey: Configurations? = null,
+    ) {
+        DICE("dice", "Dice", Configurations.DICE_MIN_STAKE, Configurations.DICE_MAX_STAKE, Configurations.DICE_BOT_EDGE_MAX_PCT),
+        COINFLIP("coinflip", "Coinflip", Configurations.COINFLIP_MIN_STAKE, Configurations.COINFLIP_MAX_STAKE, Configurations.COINFLIP_BOT_EDGE_MAX_PCT),
+        SLOTS("slots", "Slots", Configurations.SLOTS_MIN_STAKE, Configurations.SLOTS_MAX_STAKE, Configurations.SLOTS_BOT_EDGE_MAX_PCT),
+        HIGHLOW("highlow", "Highlow", Configurations.HIGHLOW_MIN_STAKE, Configurations.HIGHLOW_MAX_STAKE),
+        BACCARAT("baccarat", "Baccarat", Configurations.BACCARAT_MIN_STAKE, Configurations.BACCARAT_MAX_STAKE),
+        KENO("keno", "Keno", Configurations.KENO_MIN_STAKE, Configurations.KENO_MAX_STAKE),
+        SCRATCH("scratch", "Scratch", Configurations.SCRATCH_MIN_STAKE, Configurations.SCRATCH_MAX_STAKE),
+        ROULETTE("roulette", "Roulette", Configurations.ROULETTE_MIN_STAKE, Configurations.ROULETTE_MAX_STAKE),
+        HOLDEM("holdem", "Casino Hold'em", Configurations.HOLDEM_MIN_STAKE, Configurations.HOLDEM_MAX_STAKE),
+        DUEL("duel", "Duel", Configurations.DUEL_MIN_STAKE, Configurations.DUEL_MAX_STAKE);
+
+        companion object {
+            private val BY_TOKEN: Map<String, Game> = entries.associateBy { it.token }
+            fun byToken(token: String): Game? = BY_TOKEN[token.lowercase()]
+        }
+    }
+
+    companion object {
+        const val MODAL_NAME = "setconfig_stakes"
+        const val FIELD_MIN_STAKE = "min_stake"
+        const val FIELD_MAX_STAKE = "max_stake"
+        const val FIELD_BOT_EDGE_PCT = "bot_edge_pct"
+
+        /** Build the `customId` the slash command opens for a given game. */
+        fun customIdFor(game: Game): String = "$MODAL_NAME:${game.token}"
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/modal/modals/setconfig/SimpleSetConfigCategoryModal.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/modal/modals/setconfig/SimpleSetConfigCategoryModal.kt
@@ -1,0 +1,24 @@
+package bot.toby.modal.modals.setconfig
+
+import bot.toby.modal.modals.setconfig.SetConfigFieldValidator.FieldSpec
+import database.dto.ConfigDto.Configurations
+import database.service.ConfigService
+
+/**
+ * Sub-base for `/setconfig` modals whose title + spec list + field-id
+ * map are constant (don't vary by modal id). 10 of the 11 modals fall
+ * into this category; only [SetConfigStakesModal] needs to vary its
+ * fields per-game and so extends [SetConfigCategoryModal] directly.
+ */
+abstract class SimpleSetConfigCategoryModal(
+    configService: ConfigService,
+) : SetConfigCategoryModal(configService) {
+
+    protected abstract val title: String
+    protected abstract val specs: LinkedHashMap<Configurations, FieldSpec>
+    protected abstract val fieldIds: Map<Configurations, String>
+
+    final override fun titleFor(modalId: String): String = title
+    final override fun specsFor(modalId: String): LinkedHashMap<Configurations, FieldSpec> = specs
+    final override fun fieldIdsFor(modalId: String): Map<Configurations, String> = fieldIds
+}

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/moderation/SetConfigCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/moderation/SetConfigCommandTest.kt
@@ -1,38 +1,104 @@
 package bot.toby.command.commands.moderation
 
-import bot.toby.activity.ActivityTrackingNotifier
 import bot.toby.command.CommandTest
 import bot.toby.command.CommandTest.Companion.event
+import bot.toby.command.CommandTest.Companion.guild
 import bot.toby.command.CommandTest.Companion.member
+import bot.toby.command.CommandTest.Companion.replyCallbackAction
 import bot.toby.command.CommandTest.Companion.requestingUserDto
 import bot.toby.command.DefaultCommandContext
+import bot.toby.modal.modals.setconfig.SetConfigActivityModal
+import bot.toby.modal.modals.setconfig.SetConfigBlackjackRulesModal
+import bot.toby.modal.modals.setconfig.SetConfigBlackjackTableModal
+import bot.toby.modal.modals.setconfig.SetConfigFeesModal
+import bot.toby.modal.modals.setconfig.SetConfigGeneralModal
+import bot.toby.modal.modals.setconfig.SetConfigJackpotActivityModal
+import bot.toby.modal.modals.setconfig.SetConfigJackpotModal
+import bot.toby.modal.modals.setconfig.SetConfigLotteryBasicsModal
+import bot.toby.modal.modals.setconfig.SetConfigLotteryPoolsModal
+import bot.toby.modal.modals.setconfig.SetConfigPokerStakesModal
+import bot.toby.modal.modals.setconfig.SetConfigPokerTableModal
+import bot.toby.modal.modals.setconfig.SetConfigStakesModal
 import database.dto.ConfigDto
-import database.dto.ConfigDto.Configurations.*
+import database.dto.ConfigDto.Configurations
 import database.service.ConfigService
-import io.mockk.*
-import net.dv8tion.jda.api.entities.channel.unions.GuildChannelUnion
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.slot
+import io.mockk.verify
 import net.dv8tion.jda.api.interactions.commands.OptionMapping
+import net.dv8tion.jda.api.modals.Modal
+import net.dv8tion.jda.api.requests.restaction.interactions.ModalCallbackAction
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import java.util.*
 
+/**
+ * Routing tests for `/setconfig`. Now that the command opens a modal
+ * per subcommand (and the writes happen in the modal handlers), the
+ * old per-option upsert tests have migrated into the per-modal test
+ * classes under `bot.toby.modal.modals.setconfig`. What remains:
+ *
+ *  - Owner permission gate
+ *  - Each subcommand resolves to the right modal id
+ *  - Modal builder is called with a reader that pulls from
+ *    `configService.getConfigByName(...)` so admins see-and-edit
+ *  - Stakes subcommand encodes the `game` choice into the modal id
+ */
 internal class SetConfigCommandTest : CommandTest {
-    lateinit var setConfigCommand: SetConfigCommand
-    lateinit var configService: ConfigService
-    lateinit var activityTrackingNotifier: ActivityTrackingNotifier
+
+    private lateinit var configService: ConfigService
+    private lateinit var general: SetConfigGeneralModal
+    private lateinit var activity: SetConfigActivityModal
+    private lateinit var fees: SetConfigFeesModal
+    private lateinit var jackpot: SetConfigJackpotModal
+    private lateinit var jackpotActivity: SetConfigJackpotActivityModal
+    private lateinit var pokerStakes: SetConfigPokerStakesModal
+    private lateinit var pokerTable: SetConfigPokerTableModal
+    private lateinit var blackjackRules: SetConfigBlackjackRulesModal
+    private lateinit var blackjackTable: SetConfigBlackjackTableModal
+    private lateinit var lotteryBasics: SetConfigLotteryBasicsModal
+    private lateinit var lotteryPools: SetConfigLotteryPoolsModal
+    private lateinit var stakes: SetConfigStakesModal
+    private lateinit var command: SetConfigCommand
+
+    private val modalCallback: ModalCallbackAction = mockk(relaxed = true)
 
     @BeforeEach
     fun setUp() {
         setUpCommonMocks()
         configService = mockk(relaxed = true)
-        activityTrackingNotifier = mockk(relaxed = true)
-        // Default upsert: report Created. Tests that need Updated semantics
-        // (e.g. ACTIVITY_TRACKING first-enable) override per-test.
-        every { configService.upsertConfig(any(), any(), any()) } answers {
-            ConfigService.UpsertResult.Created(ConfigDto(firstArg(), secondArg(), thirdArg()))
-        }
-        setConfigCommand = SetConfigCommand(configService, activityTrackingNotifier)
+        general = mockk(relaxed = true)
+        activity = mockk(relaxed = true)
+        fees = mockk(relaxed = true)
+        jackpot = mockk(relaxed = true)
+        jackpotActivity = mockk(relaxed = true)
+        pokerStakes = mockk(relaxed = true)
+        pokerTable = mockk(relaxed = true)
+        blackjackRules = mockk(relaxed = true)
+        blackjackTable = mockk(relaxed = true)
+        lotteryBasics = mockk(relaxed = true)
+        lotteryPools = mockk(relaxed = true)
+        stakes = mockk(relaxed = true)
+        command = SetConfigCommand(
+            configService,
+            general, activity, fees, jackpot, jackpotActivity,
+            pokerStakes, pokerTable, blackjackRules, blackjackTable,
+            lotteryBasics, lotteryPools, stakes,
+        )
+        // CommandTest's shared stub makes `event.reply(any<String>())`
+        // suspend forever via `just awaits`. SetConfigCommand uses
+        // event.reply for early-out validation (must NOT deferReply
+        // because the happy path is replyModal). Override accordingly.
+        every { event.reply(any<String>()) } returns replyCallbackAction
+        every { event.replyModal(any<Modal>()) } returns modalCallback
+        every { modalCallback.queue() } just runs
+        every { member.isOwner } returns true
     }
 
     @AfterEach
@@ -41,189 +107,194 @@ internal class SetConfigCommandTest : CommandTest {
         clearAllMocks()
     }
 
-    @Test
-    fun testSetConfig_notAsServerOwner_sendsErrorMessage() {
-        val commandContext = DefaultCommandContext(event)
-        val volumeOptionMapping = mockk<OptionMapping>()
+    // ---- owner gate ----
 
-        every { event.getOption(VOLUME.name.lowercase(Locale.getDefault())) } returns volumeOptionMapping
-        every { volumeOptionMapping.asInt } returns 20
-        every { volumeOptionMapping.name } returns VOLUME.name
+    @Test
+    fun `non-owner gets ephemeral reply and no modal`() {
         every { member.isOwner } returns false
-        every { event.options } returns listOf(volumeOptionMapping)
+        every { event.subcommandName } returns SetConfigCommand.SUB_GENERAL
 
-        setConfigCommand.handle(commandContext, requestingUserDto, 0)
+        command.handle(DefaultCommandContext(event), requestingUserDto, 0)
 
-        verify(exactly = 0) { configService.upsertConfig(any(), any(), any()) }
         verify(exactly = 1) {
-            event.hook.sendMessage("This is currently reserved for the owner of the server only, this may change in future")
+            event.reply("This is currently reserved for the owner of the server only, this may change in future")
         }
+        verify(exactly = 0) { event.replyModal(any<Modal>()) }
     }
 
     @Test
-    fun testSetConfig_withOneConfig_writesViaUpsert() {
-        val commandContext = DefaultCommandContext(event)
-        val volumeOptionMapping = mockk<OptionMapping>()
+    fun `missing subcommand replies and does not open modal`() {
+        every { event.subcommandName } returns null
 
-        every { event.getOption(VOLUME.name.lowercase(Locale.getDefault())) } returns volumeOptionMapping
-        every { volumeOptionMapping.asInt } returns 20
-        every { volumeOptionMapping.name } returns VOLUME.name
-        every { member.isOwner } returns true
-        every { event.options } returns listOf(volumeOptionMapping)
+        command.handle(DefaultCommandContext(event), requestingUserDto, 0)
 
-        setConfigCommand.handle(commandContext, requestingUserDto, 0)
+        verify(exactly = 0) { event.replyModal(any<Modal>()) }
+        verify { event.reply(match<String> { it.contains("subcommand") }) }
+    }
 
-        verify(exactly = 1) { configService.upsertConfig(VOLUME.configValue, "20", "1") }
-        verify(exactly = 1) { event.hook.sendMessage("Set default volume to '20'") }
+    // ---- subcommand routing — one assertion per subcommand ----
+
+    @Test
+    fun `general subcommand opens the general modal`() {
+        assertOpensModal(
+            sub = SetConfigCommand.SUB_GENERAL,
+            modalIdExpected = SetConfigGeneralModal.MODAL_NAME,
+            stubReturn = { every { general.buildModal(SetConfigGeneralModal.MODAL_NAME, any()) } returns it },
+        )
     }
 
     @Test
-    fun testSetConfig_updateBranch_isInvisibleToCallers() {
-        // The whole point of upsertConfig: the caller doesn't branch on
-        // exists-vs-not-exists. Verify a single call regardless of the
-        // pre-existing row.
-        val commandContext = DefaultCommandContext(event)
-        val volumeOptionMapping = mockk<OptionMapping>()
-        every { configService.upsertConfig(VOLUME.configValue, "20", "1") } returns
-            ConfigService.UpsertResult.Updated(
-                ConfigDto(VOLUME.configValue, "20", "1"),
-                previousValue = "10"
-            )
-
-        every { event.getOption(VOLUME.name.lowercase(Locale.getDefault())) } returns volumeOptionMapping
-        every { volumeOptionMapping.asInt } returns 20
-        every { volumeOptionMapping.name } returns VOLUME.name
-        every { member.isOwner } returns true
-        every { event.options } returns listOf(volumeOptionMapping)
-
-        setConfigCommand.handle(commandContext, requestingUserDto, 0)
-
-        verify(exactly = 1) { configService.upsertConfig(VOLUME.configValue, "20", "1") }
-        verify(exactly = 1) { event.hook.sendMessage("Set default volume to '20'") }
+    fun `activity subcommand opens the activity modal`() {
+        assertOpensModal(
+            SetConfigCommand.SUB_ACTIVITY,
+            SetConfigActivityModal.MODAL_NAME,
+            { every { activity.buildModal(SetConfigActivityModal.MODAL_NAME, any()) } returns it },
+        )
     }
 
     @Test
-    fun testSetConfig_withDeleteDelay_writesViaUpsert() {
-        val commandContext = DefaultCommandContext(event)
-        val deleteDelayOptionMapping = mockk<OptionMapping>()
-
-        every { event.getOption(DELETE_DELAY.name.lowercase(Locale.getDefault())) } returns deleteDelayOptionMapping
-        every { deleteDelayOptionMapping.asInt } returns 20
-        every { deleteDelayOptionMapping.name } returns DELETE_DELAY.name
-        every { member.isOwner } returns true
-        every { event.options } returns listOf(deleteDelayOptionMapping)
-
-        setConfigCommand.handle(commandContext, requestingUserDto, 0)
-
-        verify(exactly = 1) { configService.upsertConfig(DELETE_DELAY.configValue, "20", "1") }
-        verify(exactly = 1) {
-            event.hook.sendMessage(
-                "Set default delete message delay for TobyBot music messages to '20' seconds"
-            )
-        }
+    fun `fees subcommand opens the fees modal`() {
+        assertOpensModal(
+            SetConfigCommand.SUB_FEES,
+            SetConfigFeesModal.MODAL_NAME,
+            { every { fees.buildModal(SetConfigFeesModal.MODAL_NAME, any()) } returns it },
+        )
     }
 
     @Test
-    fun testSetConfig_withMultipleSpecified_writesTwoUpserts() {
-        val commandContext = DefaultCommandContext(event)
-        val deleteDelayOptionMapping = mockk<OptionMapping>()
-        val volumeOptionMapping = mockk<OptionMapping>()
-
-        every { event.member } returns member
-        every { member.isOwner } returns true
-        every { event.options } returns listOf(deleteDelayOptionMapping, volumeOptionMapping)
-        every { deleteDelayOptionMapping.name } returns DELETE_DELAY.name.lowercase(Locale.getDefault())
-        every { deleteDelayOptionMapping.asInt } returns 20
-        every { volumeOptionMapping.name } returns VOLUME.name.lowercase(Locale.getDefault())
-        every { volumeOptionMapping.asInt } returns 20
-        every { event.guild } returns mockk {
-            every { id } returns "1"
-        }
-        every { event.hook.sendMessage(any<String>()) } returns mockk {
-            every { setEphemeral(any()) } returns this
-            every { queue(any()) } just Runs
-        }
-
-        setConfigCommand.handle(commandContext, requestingUserDto, 0)
-
-        verify(exactly = 1) { configService.upsertConfig(DELETE_DELAY.configValue, "20", "1") }
-        verify(exactly = 1) { configService.upsertConfig(VOLUME.configValue, "20", "1") }
-        verify(exactly = 2) {
-            event.hook.sendMessage(any<String>())
-        }
+    fun `jackpot subcommand opens the jackpot modal`() {
+        assertOpensModal(
+            SetConfigCommand.SUB_JACKPOT,
+            SetConfigJackpotModal.MODAL_NAME,
+            { every { jackpot.buildModal(SetConfigJackpotModal.MODAL_NAME, any()) } returns it },
+        )
     }
 
     @Test
-    fun testSetConfig_withMoveChannel_writesViaUpsert() {
-        val commandContext = DefaultCommandContext(event)
-        val moveOptionMapping = mockk<OptionMapping>()
-        val guildChannelUnion = mockk<GuildChannelUnion>()
-
-        every { event.getOption(MOVE.name.lowercase(Locale.getDefault())) } returns moveOptionMapping
-        every { moveOptionMapping.asChannel } returns guildChannelUnion
-        every { moveOptionMapping.name } returns MOVE.name.lowercase(Locale.getDefault())
-        every { guildChannelUnion.name } returns "Channel Name"
-        every { member.isOwner } returns true
-        every { event.options } returns listOf(moveOptionMapping)
-
-        setConfigCommand.handle(commandContext, requestingUserDto, 0)
-
-        verify(exactly = 1) { configService.upsertConfig(MOVE.configValue, "Channel Name", "1") }
-        verify(exactly = 1) {
-            event.hook.sendMessage("Set default move channel to 'Channel Name'")
-        }
+    fun `jackpot_activity subcommand opens the jackpot_activity modal`() {
+        assertOpensModal(
+            SetConfigCommand.SUB_JACKPOT_ACTIVITY,
+            SetConfigJackpotActivityModal.MODAL_NAME,
+            { every { jackpotActivity.buildModal(SetConfigJackpotActivityModal.MODAL_NAME, any()) } returns it },
+        )
     }
 
     @Test
-    fun testSetConfig_activityTrackingFirstEnable_firesNotifierWhenPreviouslyDisabled() {
-        // Updated outcome with previousValue="false" → notifier should fire.
-        val commandContext = DefaultCommandContext(event)
-        val optionMapping = mockk<OptionMapping>()
-        val guildMock = mockk<net.dv8tion.jda.api.entities.Guild>(relaxed = true).also {
-            every { it.id } returns "1"
-            every { it.idLong } returns 1L
-        }
-        every { event.guild } returns guildMock
-        every { event.member } returns member
-        every { member.isOwner } returns true
-        every { event.options } returns listOf(optionMapping)
-        every { optionMapping.name } returns ACTIVITY_TRACKING.name.lowercase(Locale.getDefault())
-        every { optionMapping.asBoolean } returns true
-        every { configService.upsertConfig(ACTIVITY_TRACKING.configValue, "true", "1") } returns
-            ConfigService.UpsertResult.Updated(
-                ConfigDto(ACTIVITY_TRACKING.configValue, "true", "1"),
-                previousValue = "false"
-            )
-
-        setConfigCommand.handle(commandContext, requestingUserDto, 0)
-
-        verify(exactly = 1) { activityTrackingNotifier.notifyMembersOnFirstEnable(guildMock) }
+    fun `poker_stakes subcommand opens the poker_stakes modal`() {
+        assertOpensModal(
+            SetConfigCommand.SUB_POKER_STAKES,
+            SetConfigPokerStakesModal.MODAL_NAME,
+            { every { pokerStakes.buildModal(SetConfigPokerStakesModal.MODAL_NAME, any()) } returns it },
+        )
     }
 
     @Test
-    fun testSetConfig_activityTrackingAlreadyEnabled_doesNotReFireNotifier() {
-        // Updated outcome with previousValue="true" → notifier already
-        // ran historically, so don't fire again.
-        val commandContext = DefaultCommandContext(event)
-        val optionMapping = mockk<OptionMapping>()
-        val guildMock = mockk<net.dv8tion.jda.api.entities.Guild>(relaxed = true).also {
-            every { it.id } returns "1"
-            every { it.idLong } returns 1L
-        }
-        every { event.guild } returns guildMock
-        every { event.member } returns member
-        every { member.isOwner } returns true
-        every { event.options } returns listOf(optionMapping)
-        every { optionMapping.name } returns ACTIVITY_TRACKING.name.lowercase(Locale.getDefault())
-        every { optionMapping.asBoolean } returns true
-        every { configService.upsertConfig(ACTIVITY_TRACKING.configValue, "true", "1") } returns
-            ConfigService.UpsertResult.Updated(
-                ConfigDto(ACTIVITY_TRACKING.configValue, "true", "1"),
-                previousValue = "true"
-            )
+    fun `poker_table subcommand opens the poker_table modal`() {
+        assertOpensModal(
+            SetConfigCommand.SUB_POKER_TABLE,
+            SetConfigPokerTableModal.MODAL_NAME,
+            { every { pokerTable.buildModal(SetConfigPokerTableModal.MODAL_NAME, any()) } returns it },
+        )
+    }
 
-        setConfigCommand.handle(commandContext, requestingUserDto, 0)
+    @Test
+    fun `blackjack_rules subcommand opens the blackjack_rules modal`() {
+        assertOpensModal(
+            SetConfigCommand.SUB_BLACKJACK_RULES,
+            SetConfigBlackjackRulesModal.MODAL_NAME,
+            { every { blackjackRules.buildModal(SetConfigBlackjackRulesModal.MODAL_NAME, any()) } returns it },
+        )
+    }
 
-        verify(exactly = 0) { activityTrackingNotifier.notifyMembersOnFirstEnable(any()) }
+    @Test
+    fun `blackjack_table subcommand opens the blackjack_table modal`() {
+        assertOpensModal(
+            SetConfigCommand.SUB_BLACKJACK_TABLE,
+            SetConfigBlackjackTableModal.MODAL_NAME,
+            { every { blackjackTable.buildModal(SetConfigBlackjackTableModal.MODAL_NAME, any()) } returns it },
+        )
+    }
+
+    @Test
+    fun `lottery_basics subcommand opens the lottery_basics modal`() {
+        assertOpensModal(
+            SetConfigCommand.SUB_LOTTERY_BASICS,
+            SetConfigLotteryBasicsModal.MODAL_NAME,
+            { every { lotteryBasics.buildModal(SetConfigLotteryBasicsModal.MODAL_NAME, any()) } returns it },
+        )
+    }
+
+    @Test
+    fun `lottery_pools subcommand opens the lottery_pools modal`() {
+        assertOpensModal(
+            SetConfigCommand.SUB_LOTTERY_POOLS,
+            SetConfigLotteryPoolsModal.MODAL_NAME,
+            { every { lotteryPools.buildModal(SetConfigLotteryPoolsModal.MODAL_NAME, any()) } returns it },
+        )
+    }
+
+    @Test
+    fun `stakes subcommand encodes the game choice into the modal id`() {
+        val expectedId = SetConfigStakesModal.customIdFor(SetConfigStakesModal.Game.DICE)
+        assertOpensModal(
+            sub = SetConfigCommand.SUB_STAKES,
+            modalIdExpected = expectedId,
+            stubReturn = { every { stakes.buildModal(expectedId, any()) } returns it },
+            extraEventStubs = {
+                val opt = mockk<OptionMapping> { every { asString } returns "dice" }
+                every { event.getOption(SetConfigCommand.OPT_GAME) } returns opt
+            },
+        )
+    }
+
+    @Test
+    fun `stakes subcommand with unknown game replies error and opens no modal`() {
+        every { event.subcommandName } returns SetConfigCommand.SUB_STAKES
+        val opt = mockk<OptionMapping> { every { asString } returns "bingo" }
+        every { event.getOption(SetConfigCommand.OPT_GAME) } returns opt
+
+        command.handle(DefaultCommandContext(event), requestingUserDto, 0)
+
+        verify(exactly = 0) { event.replyModal(any<Modal>()) }
+        verify { event.reply(match<String> { it.contains("bingo") }) }
+    }
+
+    // ---- modal pre-population reader ----
+
+    @Test
+    fun `buildModal reader resolves current values via configService getConfigByName`() {
+        val readerSlot = slot<(Configurations) -> String?>()
+        every { event.subcommandName } returns SetConfigCommand.SUB_GENERAL
+        val builtModal = mockk<Modal>(relaxed = true) { every { id } returns SetConfigGeneralModal.MODAL_NAME }
+        every { general.buildModal(SetConfigGeneralModal.MODAL_NAME, capture(readerSlot)) } returns builtModal
+        every {
+            configService.getConfigByName(Configurations.VOLUME.configValue, guild.id)
+        } returns ConfigDto(Configurations.VOLUME.configValue, "75", guild.id)
+
+        command.handle(DefaultCommandContext(event), requestingUserDto, 0)
+
+        assertNotNull(readerSlot.captured)
+        assertEquals("75", readerSlot.captured(Configurations.VOLUME))
+    }
+
+    // ---- helper ----
+
+    private fun assertOpensModal(
+        sub: String,
+        modalIdExpected: String,
+        stubReturn: (Modal) -> Unit,
+        extraEventStubs: () -> Unit = {},
+    ) {
+        every { event.subcommandName } returns sub
+        extraEventStubs()
+        val captured = slot<Modal>()
+        val builtModal = mockk<Modal>(relaxed = true) { every { id } returns modalIdExpected }
+        stubReturn(builtModal)
+        every { event.replyModal(capture(captured)) } returns modalCallback
+
+        command.handle(DefaultCommandContext(event), requestingUserDto, 0)
+
+        verify(exactly = 1) { event.replyModal(any<Modal>()) }
+        assertEquals(modalIdExpected, captured.captured.id)
     }
 }

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/moderation/SetConfigCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/moderation/SetConfigCommandTest.kt
@@ -267,14 +267,18 @@ internal class SetConfigCommandTest : CommandTest {
         every { event.subcommandName } returns SetConfigCommand.SUB_GENERAL
         val builtModal = mockk<Modal>(relaxed = true) { every { id } returns SetConfigGeneralModal.MODAL_NAME }
         every { general.buildModal(SetConfigGeneralModal.MODAL_NAME, capture(readerSlot)) } returns builtModal
-        every {
-            configService.getConfigByName(Configurations.VOLUME.configValue, guild.id)
-        } returns ConfigDto(Configurations.VOLUME.configValue, "75", guild.id)
+        // Use any() because a relaxed-mock ConfigService returns a default
+        // ConfigDto (value="") for unstubbed calls — the literal-arg stub
+        // matcher fights that default.
+        every { configService.getConfigByName(any(), any()) } returns
+            ConfigDto(Configurations.VOLUME.configValue, "75", "1")
 
         command.handle(DefaultCommandContext(event), requestingUserDto, 0)
 
         assertNotNull(readerSlot.captured)
         assertEquals("75", readerSlot.captured(Configurations.VOLUME))
+        // Verify the reader actually reached the service with the right key/guild.
+        verify { configService.getConfigByName(Configurations.VOLUME.configValue, "1") }
     }
 
     // ---- helper ----

--- a/discord-bot/src/test/kotlin/bot/toby/modal/modals/setconfig/SetConfigActivityModalTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/modal/modals/setconfig/SetConfigActivityModalTest.kt
@@ -45,10 +45,9 @@ class SetConfigActivityModalTest {
         }
         every { event.hook } returns hook
         every { event.modalId } returns SetConfigActivityModal.MODAL_NAME
-        ctx = mockk {
-            every { this@mockk.event } returns this@SetConfigActivityModalTest.event
-            every { this@mockk.guild } returns guild
-        }
+        ctx = mockk(relaxed = true)
+        every { ctx.event } returns event
+        every { ctx.guild } returns guild
         @Suppress("UNCHECKED_CAST")
         val send = mockk<WebhookMessageCreateAction<Message>>(relaxed = true)
         every { hook.sendMessage(capture(messageSlot)) } returns send

--- a/discord-bot/src/test/kotlin/bot/toby/modal/modals/setconfig/SetConfigActivityModalTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/modal/modals/setconfig/SetConfigActivityModalTest.kt
@@ -1,0 +1,168 @@
+package bot.toby.modal.modals.setconfig
+
+import bot.toby.activity.ActivityTrackingNotifier
+import core.modal.ModalContext
+import database.dto.ConfigDto
+import database.dto.ConfigDto.Configurations
+import database.service.ConfigService
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.Message
+import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent
+import net.dv8tion.jda.api.interactions.InteractionHook
+import net.dv8tion.jda.api.interactions.modals.ModalMapping
+import net.dv8tion.jda.api.requests.restaction.WebhookMessageCreateAction
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class SetConfigActivityModalTest {
+
+    private lateinit var configService: ConfigService
+    private lateinit var notifier: ActivityTrackingNotifier
+    private lateinit var modal: SetConfigActivityModal
+    private lateinit var ctx: ModalContext
+    private lateinit var event: ModalInteractionEvent
+    private lateinit var hook: InteractionHook
+    private lateinit var guild: Guild
+    private val messageSlot = slot<String>()
+    private val guildId = "100"
+
+    @BeforeEach
+    fun setUp() {
+        configService = mockk(relaxed = true)
+        notifier = mockk(relaxed = true)
+        modal = SetConfigActivityModal(configService, notifier)
+        hook = mockk(relaxed = true)
+        event = mockk(relaxed = true)
+        guild = mockk(relaxed = true) {
+            every { id } returns guildId
+        }
+        every { event.hook } returns hook
+        every { event.modalId } returns SetConfigActivityModal.MODAL_NAME
+        ctx = mockk {
+            every { this@mockk.event } returns this@SetConfigActivityModalTest.event
+            every { this@mockk.guild } returns guild
+        }
+        @Suppress("UNCHECKED_CAST")
+        val send = mockk<WebhookMessageCreateAction<Message>>(relaxed = true)
+        every { hook.sendMessage(capture(messageSlot)) } returns send
+        every { send.setEphemeral(true) } returns send
+        every { send.queue() } just Runs
+
+        // Default: no fields submitted
+        every { event.getValue(any()) } returns null
+    }
+
+    @Test
+    fun `first-enable from previously-disabled fires the notifier`() {
+        stub(SetConfigActivityModal.FIELD_ACTIVITY_TRACKING, "true")
+        every {
+            configService.upsertConfig(Configurations.ACTIVITY_TRACKING.configValue, "true", guildId)
+        } returns ConfigService.UpsertResult.Updated(
+            ConfigDto(Configurations.ACTIVITY_TRACKING.configValue, "true", guildId),
+            previousValue = "false",
+        )
+
+        modal.handle(ctx, 0)
+
+        verify(exactly = 1) { notifier.notifyMembersOnFirstEnable(guild) }
+    }
+
+    @Test
+    fun `first-enable from never-set (Created) also fires the notifier`() {
+        stub(SetConfigActivityModal.FIELD_ACTIVITY_TRACKING, "true")
+        every {
+            configService.upsertConfig(Configurations.ACTIVITY_TRACKING.configValue, "true", guildId)
+        } returns ConfigService.UpsertResult.Created(
+            ConfigDto(Configurations.ACTIVITY_TRACKING.configValue, "true", guildId),
+        )
+
+        modal.handle(ctx, 0)
+
+        verify(exactly = 1) { notifier.notifyMembersOnFirstEnable(guild) }
+    }
+
+    @Test
+    fun `re-enable when previously enabled does NOT re-fire the notifier`() {
+        stub(SetConfigActivityModal.FIELD_ACTIVITY_TRACKING, "true")
+        every {
+            configService.upsertConfig(Configurations.ACTIVITY_TRACKING.configValue, "true", guildId)
+        } returns ConfigService.UpsertResult.Updated(
+            ConfigDto(Configurations.ACTIVITY_TRACKING.configValue, "true", guildId),
+            previousValue = "true",
+        )
+
+        modal.handle(ctx, 0)
+
+        verify(exactly = 0) { notifier.notifyMembersOnFirstEnable(any()) }
+    }
+
+    @Test
+    fun `disabling never fires the notifier`() {
+        stub(SetConfigActivityModal.FIELD_ACTIVITY_TRACKING, "false")
+        every {
+            configService.upsertConfig(Configurations.ACTIVITY_TRACKING.configValue, "false", guildId)
+        } returns ConfigService.UpsertResult.Updated(
+            ConfigDto(Configurations.ACTIVITY_TRACKING.configValue, "false", guildId),
+            previousValue = "true",
+        )
+
+        modal.handle(ctx, 0)
+
+        verify(exactly = 0) { notifier.notifyMembersOnFirstEnable(any()) }
+    }
+
+    @Test
+    fun `blank tracking field skips both the upsert and the notifier`() {
+        // Default: all event.getValue calls return null → Skip outcome
+        modal.handle(ctx, 0)
+
+        verify(exactly = 0) { configService.upsertConfig(any(), any(), any()) }
+        verify(exactly = 0) { notifier.notifyMembersOnFirstEnable(any()) }
+        assertTrue(messageSlot.captured.contains("No fields filled"))
+    }
+
+    @Test
+    fun `numeric fields parse and upsert in order`() {
+        stub(SetConfigActivityModal.FIELD_UBI_DAILY_AMOUNT, "50")
+        stub(SetConfigActivityModal.FIELD_DAILY_CREDIT_CAP, "200")
+        every {
+            configService.upsertConfig(Configurations.UBI_DAILY_AMOUNT.configValue, "50", guildId)
+        } returns ConfigService.UpsertResult.Created(
+            ConfigDto(Configurations.UBI_DAILY_AMOUNT.configValue, "50", guildId),
+        )
+        every {
+            configService.upsertConfig(Configurations.DAILY_CREDIT_CAP.configValue, "200", guildId)
+        } returns ConfigService.UpsertResult.Created(
+            ConfigDto(Configurations.DAILY_CREDIT_CAP.configValue, "200", guildId),
+        )
+
+        modal.handle(ctx, 0)
+
+        verify(exactly = 1) { configService.upsertConfig(Configurations.UBI_DAILY_AMOUNT.configValue, "50", guildId) }
+        verify(exactly = 1) { configService.upsertConfig(Configurations.DAILY_CREDIT_CAP.configValue, "200", guildId) }
+        verify(exactly = 0) { notifier.notifyMembersOnFirstEnable(any()) }
+    }
+
+    @Test
+    fun `out-of-range UBI rejects with errors message and writes nothing`() {
+        stub(SetConfigActivityModal.FIELD_UBI_DAILY_AMOUNT, "99999")
+
+        modal.handle(ctx, 0)
+
+        verify(exactly = 0) { configService.upsertConfig(any(), any(), any()) }
+        assertTrue(messageSlot.captured.contains("Couldn't save"))
+        assertTrue(messageSlot.captured.contains("UBI daily amount"))
+    }
+
+    private fun stub(field: String, value: String) {
+        val mapping = mockk<ModalMapping> { every { asString } returns value }
+        every { event.getValue(field) } returns mapping
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/modal/modals/setconfig/SetConfigFieldValidatorTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/modal/modals/setconfig/SetConfigFieldValidatorTest.kt
@@ -1,0 +1,234 @@
+package bot.toby.modal.modals.setconfig
+
+import bot.toby.modal.modals.setconfig.SetConfigFieldValidator.FieldResult
+import bot.toby.modal.modals.setconfig.SetConfigFieldValidator.FieldSpec
+import bot.toby.modal.modals.setconfig.SetConfigFieldValidator.ValidationOutcome
+import database.dto.ConfigDto.Configurations
+import io.mockk.every
+import io.mockk.mockk
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+internal class SetConfigFieldValidatorTest {
+
+    // ----- per-type validate() coverage -----
+
+    @Test
+    fun `blank input is always Skip`() {
+        val skip = SetConfigFieldValidator.validate("", FieldSpec.IntRange("Volume", 0..200))
+        assertInstanceOf(FieldResult.Skip::class.java, skip)
+
+        val skipNull = SetConfigFieldValidator.validate(null, FieldSpec.LongMin("Stake", 1L))
+        assertInstanceOf(FieldResult.Skip::class.java, skipNull)
+
+        val skipWs = SetConfigFieldValidator.validate("   ", FieldSpec.BoolStrict("Tracking"))
+        assertInstanceOf(FieldResult.Skip::class.java, skipWs)
+    }
+
+    @Test
+    fun `IntRange parses valid value`() {
+        val r = SetConfigFieldValidator.validate("75", FieldSpec.IntRange("Volume", 0..200))
+        assertEquals(FieldResult.Write("75"), r)
+    }
+
+    @Test
+    fun `IntRange rejects non-numeric input`() {
+        val r = SetConfigFieldValidator.validate("abc", FieldSpec.IntRange("Volume", 0..200))
+        assertInstanceOf(FieldResult.Error::class.java, r)
+    }
+
+    @Test
+    fun `IntRange rejects out-of-range value`() {
+        val r = SetConfigFieldValidator.validate("250", FieldSpec.IntRange("Volume", 0..200))
+        val err = assertInstanceOf(FieldResult.Error::class.java, r)
+        assertTrue(err.message.contains("between 0 and 200"))
+    }
+
+    @Test
+    fun `LongMin parses values at the floor and above`() {
+        val rFloor = SetConfigFieldValidator.validate("1", FieldSpec.LongMin("Stake", 1L))
+        assertEquals(FieldResult.Write("1"), rFloor)
+        val rBig = SetConfigFieldValidator.validate("999999999", FieldSpec.LongMin("Stake", 1L))
+        assertEquals(FieldResult.Write("999999999"), rBig)
+    }
+
+    @Test
+    fun `LongMin rejects below floor`() {
+        val r = SetConfigFieldValidator.validate("0", FieldSpec.LongMin("Stake", 1L))
+        assertInstanceOf(FieldResult.Error::class.java, r)
+    }
+
+    @Test
+    fun `DoubleRange parses decimal`() {
+        val r = SetConfigFieldValidator.validate("12.5", FieldSpec.DoubleRange("Fee", 0.0..50.0))
+        assertEquals(FieldResult.Write("12.5"), r)
+    }
+
+    @Test
+    fun `DoubleRange rejects NaN and infinity`() {
+        val nan = SetConfigFieldValidator.validate("NaN", FieldSpec.DoubleRange("Fee", 0.0..50.0))
+        val inf = SetConfigFieldValidator.validate("Infinity", FieldSpec.DoubleRange("Fee", 0.0..50.0))
+        assertInstanceOf(FieldResult.Error::class.java, nan)
+        assertInstanceOf(FieldResult.Error::class.java, inf)
+    }
+
+    @Test
+    fun `DoubleRange rejects out of range`() {
+        val r = SetConfigFieldValidator.validate("55.0", FieldSpec.DoubleRange("Fee", 0.0..50.0))
+        assertInstanceOf(FieldResult.Error::class.java, r)
+    }
+
+    @Test
+    fun `BoolStrict normalises truthy spellings`() {
+        listOf("true", "TRUE", "yes", "Y", "1", "on", "enabled").forEach { input ->
+            if (input == "Y") return@forEach // Y not in dictionary; "yes" is
+            val r = SetConfigFieldValidator.validate(input, FieldSpec.BoolStrict("Tracking"))
+            assertEquals(FieldResult.Write("true"), r, "input=$input")
+        }
+    }
+
+    @Test
+    fun `BoolStrict normalises falsy spellings`() {
+        listOf("false", "FALSE", "no", "0", "off", "disabled").forEach { input ->
+            val r = SetConfigFieldValidator.validate(input, FieldSpec.BoolStrict("Tracking"))
+            assertEquals(FieldResult.Write("false"), r, "input=$input")
+        }
+    }
+
+    @Test
+    fun `BoolStrict rejects nonsense`() {
+        val r = SetConfigFieldValidator.validate("maybe", FieldSpec.BoolStrict("Tracking"))
+        assertInstanceOf(FieldResult.Error::class.java, r)
+    }
+
+    @Test
+    fun `EnumChoice accepts allowed value case-insensitively`() {
+        val spec = FieldSpec.EnumChoice("Mode", setOf("NUMBER_MATCH", "WEIGHTED"))
+        assertEquals(FieldResult.Write("NUMBER_MATCH"), SetConfigFieldValidator.validate("number_match", spec))
+        assertEquals(FieldResult.Write("WEIGHTED"), SetConfigFieldValidator.validate("Weighted", spec))
+    }
+
+    @Test
+    fun `EnumChoice rejects values outside the set`() {
+        val spec = FieldSpec.EnumChoice("Mode", setOf("NUMBER_MATCH", "WEIGHTED"))
+        val r = SetConfigFieldValidator.validate("RANDOM", spec)
+        assertInstanceOf(FieldResult.Error::class.java, r)
+    }
+
+    @Test
+    fun `ChannelByIdStoreName resolves to channel name`() {
+        val guild = mockk<Guild>()
+        val ch = mockk<TextChannel> { every { name } returns "general" }
+        every { guild.getTextChannelById(42L) } returns ch
+
+        val r = SetConfigFieldValidator.validate("42", FieldSpec.ChannelByIdStoreName("Move channel"), guild)
+        assertEquals(FieldResult.Write("general"), r)
+    }
+
+    @Test
+    fun `ChannelByIdStoreName accepts mention format`() {
+        val guild = mockk<Guild>()
+        val ch = mockk<TextChannel> { every { name } returns "voice-lounge" }
+        every { guild.getTextChannelById(99L) } returns ch
+
+        val r = SetConfigFieldValidator.validate("<#99>", FieldSpec.ChannelByIdStoreName("Move channel"), guild)
+        assertEquals(FieldResult.Write("voice-lounge"), r)
+    }
+
+    @Test
+    fun `ChannelByIdStoreName errors on unknown id`() {
+        val guild = mockk<Guild>()
+        every { guild.getTextChannelById(any<Long>()) } returns null
+        every { guild.getVoiceChannelById(any<Long>()) } returns null
+
+        val r = SetConfigFieldValidator.validate("123", FieldSpec.ChannelByIdStoreName("Move channel"), guild)
+        assertInstanceOf(FieldResult.Error::class.java, r)
+    }
+
+    @Test
+    fun `ChannelByIdStoreId stores numeric id`() {
+        val guild = mockk<Guild>()
+        every { guild.getTextChannelById(7L) } returns mockk<TextChannel>(relaxed = true)
+
+        val r = SetConfigFieldValidator.validate("7", FieldSpec.ChannelByIdStoreId("Leaderboard"), guild)
+        assertEquals(FieldResult.Write("7"), r)
+    }
+
+    @Test
+    fun `ChannelByIdStoreId allows 0 to clear`() {
+        val r = SetConfigFieldValidator.validate("0", FieldSpec.ChannelByIdStoreId("Lottery channel"), guild = null)
+        assertEquals(FieldResult.Write(""), r)
+    }
+
+    // ----- validateAll() collecting writes vs errors -----
+
+    @Test
+    fun `validateAll returns Writes for all-valid input`() {
+        val specs = linkedMapOf<Configurations, FieldSpec>(
+            Configurations.VOLUME to FieldSpec.IntRange("Volume", 0..200),
+            Configurations.DELETE_DELAY to FieldSpec.IntRange("Delete delay", 0..600),
+        )
+        val input = mapOf(
+            Configurations.VOLUME to "80",
+            Configurations.DELETE_DELAY to "10",
+        )
+        val out = SetConfigFieldValidator.validateAll(input::get, specs)
+        val writes = assertInstanceOf(ValidationOutcome.Writes::class.java, out)
+        assertEquals(
+            listOf(Configurations.VOLUME to "80", Configurations.DELETE_DELAY to "10"),
+            writes.pairs,
+        )
+    }
+
+    @Test
+    fun `validateAll preserves spec insertion order`() {
+        val specs = linkedMapOf<Configurations, FieldSpec>(
+            Configurations.INTRO_VOLUME to FieldSpec.IntRange("Intro volume", 0..200),
+            Configurations.VOLUME to FieldSpec.IntRange("Volume", 0..200),
+        )
+        val input = mapOf(
+            Configurations.INTRO_VOLUME to "70",
+            Configurations.VOLUME to "100",
+        )
+        val out = SetConfigFieldValidator.validateAll(input::get, specs) as ValidationOutcome.Writes
+        assertEquals(Configurations.INTRO_VOLUME, out.pairs[0].first)
+        assertEquals(Configurations.VOLUME, out.pairs[1].first)
+    }
+
+    @Test
+    fun `validateAll skips blank fields without complaining`() {
+        val specs = linkedMapOf<Configurations, FieldSpec>(
+            Configurations.VOLUME to FieldSpec.IntRange("Volume", 0..200),
+            Configurations.DELETE_DELAY to FieldSpec.IntRange("Delete delay", 0..600),
+        )
+        val input = mapOf(
+            Configurations.VOLUME to "",
+            Configurations.DELETE_DELAY to "30",
+        )
+        val out = SetConfigFieldValidator.validateAll(input::get, specs) as ValidationOutcome.Writes
+        assertEquals(listOf(Configurations.DELETE_DELAY to "30"), out.pairs)
+    }
+
+    @Test
+    fun `validateAll returns Errors when any field fails, with all errors collected`() {
+        val specs = linkedMapOf<Configurations, FieldSpec>(
+            Configurations.VOLUME to FieldSpec.IntRange("Volume", 0..200),
+            Configurations.DELETE_DELAY to FieldSpec.IntRange("Delete delay", 0..600),
+            Configurations.INTRO_VOLUME to FieldSpec.IntRange("Intro volume", 0..200),
+        )
+        val input = mapOf(
+            Configurations.VOLUME to "abc",
+            Configurations.DELETE_DELAY to "100",
+            Configurations.INTRO_VOLUME to "999",
+        )
+        val out = SetConfigFieldValidator.validateAll(input::get, specs)
+        val errors = assertInstanceOf(ValidationOutcome.Errors::class.java, out)
+        assertEquals(2, errors.messages.size)
+        assertTrue(errors.messages[0].startsWith("Volume:"))
+        assertTrue(errors.messages[1].startsWith("Intro volume:"))
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/modal/modals/setconfig/SetConfigGeneralModalTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/modal/modals/setconfig/SetConfigGeneralModalTest.kt
@@ -1,0 +1,130 @@
+package bot.toby.modal.modals.setconfig
+
+import core.modal.ModalContext
+import database.dto.ConfigDto
+import database.dto.ConfigDto.Configurations
+import database.service.ConfigService
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.Message
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
+import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent
+import net.dv8tion.jda.api.interactions.InteractionHook
+import net.dv8tion.jda.api.interactions.modals.ModalMapping
+import net.dv8tion.jda.api.requests.restaction.WebhookMessageCreateAction
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class SetConfigGeneralModalTest {
+
+    private lateinit var configService: ConfigService
+    private lateinit var modal: SetConfigGeneralModal
+    private lateinit var ctx: ModalContext
+    private lateinit var event: ModalInteractionEvent
+    private lateinit var hook: InteractionHook
+    private lateinit var guild: Guild
+    private val messageSlot = slot<String>()
+    private val guildId = "100"
+
+    @BeforeEach
+    fun setUp() {
+        configService = mockk(relaxed = true)
+        modal = SetConfigGeneralModal(configService)
+        hook = mockk(relaxed = true)
+        event = mockk(relaxed = true)
+        guild = mockk(relaxed = true) {
+            every { id } returns guildId
+        }
+        every { event.hook } returns hook
+        every { event.modalId } returns SetConfigGeneralModal.MODAL_NAME
+        ctx = mockk {
+            every { this@mockk.event } returns this@SetConfigGeneralModalTest.event
+            every { this@mockk.guild } returns guild
+        }
+        @Suppress("UNCHECKED_CAST")
+        val send = mockk<WebhookMessageCreateAction<Message>>(relaxed = true)
+        every { hook.sendMessage(capture(messageSlot)) } returns send
+        every { send.setEphemeral(true) } returns send
+        every { send.queue() } just Runs
+        every { event.getValue(any()) } returns null
+    }
+
+    @Test
+    fun `happy path writes the filled fields`() {
+        stub(SetConfigGeneralModal.FIELD_VOLUME, "120")
+        stub(SetConfigGeneralModal.FIELD_DELETE_DELAY, "10")
+        every {
+            configService.upsertConfig(Configurations.VOLUME.configValue, "120", guildId)
+        } returns ConfigService.UpsertResult.Created(ConfigDto(Configurations.VOLUME.configValue, "120", guildId))
+        every {
+            configService.upsertConfig(Configurations.DELETE_DELAY.configValue, "10", guildId)
+        } returns ConfigService.UpsertResult.Created(ConfigDto(Configurations.DELETE_DELAY.configValue, "10", guildId))
+
+        modal.handle(ctx, 0)
+
+        verify { configService.upsertConfig(Configurations.VOLUME.configValue, "120", guildId) }
+        verify { configService.upsertConfig(Configurations.DELETE_DELAY.configValue, "10", guildId) }
+        assertTrue(messageSlot.captured.startsWith("Saved 2 settings"))
+    }
+
+    @Test
+    fun `all-blank submission is a no-op with a friendly reply`() {
+        modal.handle(ctx, 0)
+
+        verify(exactly = 0) { configService.upsertConfig(any(), any(), any()) }
+        assertTrue(messageSlot.captured.contains("No fields filled"))
+    }
+
+    @Test
+    fun `MOVE resolves the channel name from a numeric id`() {
+        stub(SetConfigGeneralModal.FIELD_MOVE, "42")
+        val channel = mockk<TextChannel> { every { name } returns "general" }
+        every { guild.getTextChannelById(42L) } returns channel
+        every {
+            configService.upsertConfig(Configurations.MOVE.configValue, "general", guildId)
+        } returns ConfigService.UpsertResult.Created(ConfigDto(Configurations.MOVE.configValue, "general", guildId))
+
+        modal.handle(ctx, 0)
+
+        // Must persist the channel NAME (legacy MoveCommand contract), not the id.
+        verify(exactly = 1) { configService.upsertConfig(Configurations.MOVE.configValue, "general", guildId) }
+    }
+
+    @Test
+    fun `MOVE with unknown id fails with an error and writes nothing`() {
+        stub(SetConfigGeneralModal.FIELD_MOVE, "999")
+        every { guild.getTextChannelById(999L) } returns null
+        every { guild.getVoiceChannelById(999L) } returns null
+
+        modal.handle(ctx, 0)
+
+        verify(exactly = 0) { configService.upsertConfig(any(), any(), any()) }
+        assertTrue(messageSlot.captured.contains("Couldn't save"))
+    }
+
+    @Test
+    fun `validation errors are collected and no writes happen`() {
+        stub(SetConfigGeneralModal.FIELD_VOLUME, "9999")
+        stub(SetConfigGeneralModal.FIELD_DELETE_DELAY, "100")
+        every {
+            configService.upsertConfig(Configurations.DELETE_DELAY.configValue, "100", guildId)
+        } returns ConfigService.UpsertResult.Created(ConfigDto(Configurations.DELETE_DELAY.configValue, "100", guildId))
+
+        modal.handle(ctx, 0)
+
+        // Even though DELETE_DELAY is valid, the bad VOLUME aborts the whole batch.
+        verify(exactly = 0) { configService.upsertConfig(any(), any(), any()) }
+        assertTrue(messageSlot.captured.contains("Default volume"))
+    }
+
+    private fun stub(field: String, value: String) {
+        val mapping = mockk<ModalMapping> { every { asString } returns value }
+        every { event.getValue(field) } returns mapping
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/modal/modals/setconfig/SetConfigGeneralModalTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/modal/modals/setconfig/SetConfigGeneralModalTest.kt
@@ -43,10 +43,9 @@ class SetConfigGeneralModalTest {
         }
         every { event.hook } returns hook
         every { event.modalId } returns SetConfigGeneralModal.MODAL_NAME
-        ctx = mockk {
-            every { this@mockk.event } returns this@SetConfigGeneralModalTest.event
-            every { this@mockk.guild } returns guild
-        }
+        ctx = mockk(relaxed = true)
+        every { ctx.event } returns event
+        every { ctx.guild } returns guild
         @Suppress("UNCHECKED_CAST")
         val send = mockk<WebhookMessageCreateAction<Message>>(relaxed = true)
         every { hook.sendMessage(capture(messageSlot)) } returns send

--- a/discord-bot/src/test/kotlin/bot/toby/modal/modals/setconfig/SetConfigStakesModalTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/modal/modals/setconfig/SetConfigStakesModalTest.kt
@@ -1,0 +1,148 @@
+package bot.toby.modal.modals.setconfig
+
+import core.modal.ModalContext
+import database.dto.ConfigDto
+import database.dto.ConfigDto.Configurations
+import database.service.ConfigService
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.Message
+import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent
+import net.dv8tion.jda.api.interactions.InteractionHook
+import net.dv8tion.jda.api.interactions.modals.ModalMapping
+import net.dv8tion.jda.api.requests.restaction.WebhookMessageCreateAction
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class SetConfigStakesModalTest {
+
+    private lateinit var configService: ConfigService
+    private lateinit var modal: SetConfigStakesModal
+    private lateinit var ctx: ModalContext
+    private lateinit var event: ModalInteractionEvent
+    private lateinit var hook: InteractionHook
+    private lateinit var guild: Guild
+    private val messageSlot = slot<String>()
+    private val guildId = "100"
+
+    @BeforeEach
+    fun setUp() {
+        configService = mockk(relaxed = true)
+        modal = SetConfigStakesModal(configService)
+        hook = mockk(relaxed = true)
+        event = mockk(relaxed = true)
+        guild = mockk(relaxed = true) {
+            every { id } returns guildId
+        }
+        every { event.hook } returns hook
+        ctx = mockk {
+            every { this@mockk.event } returns this@SetConfigStakesModalTest.event
+            every { this@mockk.guild } returns guild
+        }
+        @Suppress("UNCHECKED_CAST")
+        val send = mockk<WebhookMessageCreateAction<Message>>(relaxed = true)
+        every { hook.sendMessage(capture(messageSlot)) } returns send
+        every { send.setEphemeral(true) } returns send
+        every { send.queue() } just Runs
+        every { event.getValue(any()) } returns null
+    }
+
+    // ---- customId encoding/decoding ----
+
+    @Test
+    fun `customIdFor builds the modal id with the game token`() {
+        assertEquals("setconfig_stakes:dice", SetConfigStakesModal.customIdFor(SetConfigStakesModal.Game.DICE))
+        assertEquals("setconfig_stakes:duel", SetConfigStakesModal.customIdFor(SetConfigStakesModal.Game.DUEL))
+    }
+
+    @Test
+    fun `Game byToken is case-insensitive and rejects unknown values`() {
+        assertEquals(SetConfigStakesModal.Game.HOLDEM, SetConfigStakesModal.Game.byToken("HOLDEM"))
+        assertEquals(SetConfigStakesModal.Game.HOLDEM, SetConfigStakesModal.Game.byToken("holdem"))
+        assertEquals(null, SetConfigStakesModal.Game.byToken("blackjack"))
+    }
+
+    // ---- per-game behaviour ----
+
+    @Test
+    fun `dice modal writes DICE_MIN_STAKE, DICE_MAX_STAKE and DICE_BOT_EDGE`() {
+        every { event.modalId } returns SetConfigStakesModal.customIdFor(SetConfigStakesModal.Game.DICE)
+        stub(SetConfigStakesModal.FIELD_MIN_STAKE, "5")
+        stub(SetConfigStakesModal.FIELD_MAX_STAKE, "500")
+        stub(SetConfigStakesModal.FIELD_BOT_EDGE_PCT, "30")
+        upsertCreated(Configurations.DICE_MIN_STAKE, "5")
+        upsertCreated(Configurations.DICE_MAX_STAKE, "500")
+        upsertCreated(Configurations.DICE_BOT_EDGE_MAX_PCT, "30")
+
+        modal.handle(ctx, 0)
+
+        verify { configService.upsertConfig(Configurations.DICE_MIN_STAKE.configValue, "5", guildId) }
+        verify { configService.upsertConfig(Configurations.DICE_MAX_STAKE.configValue, "500", guildId) }
+        verify { configService.upsertConfig(Configurations.DICE_BOT_EDGE_MAX_PCT.configValue, "30", guildId) }
+    }
+
+    @Test
+    fun `duel modal has no bot-edge field — fills only MIN and MAX`() {
+        every { event.modalId } returns SetConfigStakesModal.customIdFor(SetConfigStakesModal.Game.DUEL)
+        stub(SetConfigStakesModal.FIELD_MIN_STAKE, "10")
+        stub(SetConfigStakesModal.FIELD_MAX_STAKE, "1000")
+        stub(SetConfigStakesModal.FIELD_BOT_EDGE_PCT, "30") // ignored — not in specs
+        upsertCreated(Configurations.DUEL_MIN_STAKE, "10")
+        upsertCreated(Configurations.DUEL_MAX_STAKE, "1000")
+
+        modal.handle(ctx, 0)
+
+        verify { configService.upsertConfig(Configurations.DUEL_MIN_STAKE.configValue, "10", guildId) }
+        verify { configService.upsertConfig(Configurations.DUEL_MAX_STAKE.configValue, "1000", guildId) }
+        // No bot-edge key exists for DUEL → never written even though the field
+        // was submitted. The modal's specs map is the source of truth.
+        verify(exactly = 0) {
+            configService.upsertConfig(
+                match { it.contains("BOT_EDGE") }, any(), any(),
+            )
+        }
+    }
+
+    @Test
+    fun `blank min stake skips that one write, max still goes through`() {
+        every { event.modalId } returns SetConfigStakesModal.customIdFor(SetConfigStakesModal.Game.SLOTS)
+        // FIELD_MIN_STAKE remains null (blank)
+        stub(SetConfigStakesModal.FIELD_MAX_STAKE, "750")
+        upsertCreated(Configurations.SLOTS_MAX_STAKE, "750")
+
+        modal.handle(ctx, 0)
+
+        verify(exactly = 0) { configService.upsertConfig(Configurations.SLOTS_MIN_STAKE.configValue, any(), any()) }
+        verify(exactly = 1) { configService.upsertConfig(Configurations.SLOTS_MAX_STAKE.configValue, "750", guildId) }
+    }
+
+    @Test
+    fun `non-numeric min rejects without writing anything`() {
+        every { event.modalId } returns SetConfigStakesModal.customIdFor(SetConfigStakesModal.Game.KENO)
+        stub(SetConfigStakesModal.FIELD_MIN_STAKE, "abc")
+        stub(SetConfigStakesModal.FIELD_MAX_STAKE, "500")
+
+        modal.handle(ctx, 0)
+
+        verify(exactly = 0) { configService.upsertConfig(any(), any(), any()) }
+        assertTrue(messageSlot.captured.contains("Couldn't save"))
+    }
+
+    private fun stub(field: String, value: String) {
+        val mapping = mockk<ModalMapping> { every { asString } returns value }
+        every { event.getValue(field) } returns mapping
+    }
+
+    private fun upsertCreated(key: Configurations, value: String) {
+        every {
+            configService.upsertConfig(key.configValue, value, guildId)
+        } returns ConfigService.UpsertResult.Created(ConfigDto(key.configValue, value, guildId))
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/modal/modals/setconfig/SetConfigStakesModalTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/modal/modals/setconfig/SetConfigStakesModalTest.kt
@@ -42,10 +42,9 @@ class SetConfigStakesModalTest {
             every { id } returns guildId
         }
         every { event.hook } returns hook
-        ctx = mockk {
-            every { this@mockk.event } returns this@SetConfigStakesModalTest.event
-            every { this@mockk.guild } returns guild
-        }
+        ctx = mockk(relaxed = true)
+        every { ctx.event } returns event
+        every { ctx.guild } returns guild
         @Suppress("UNCHECKED_CAST")
         val send = mockk<WebhookMessageCreateAction<Message>>(relaxed = true)
         every { hook.sendMessage(capture(messageSlot)) } returns send


### PR DESCRIPTION
## Summary

Splits the monolithic `/setconfig` slash command into 12 subcommands, each opening a category-scoped modal pre-populated with the guild's current values. Replaces the previous 25-flat-option form that was hitting Discord's hard option cap and forcing ~45 other config keys to be web-only.

## Why

- **Discord's 25-option-per-command ceiling**: the old `/setconfig` was sitting on the limit. Lottery / per-game stakes / jackpot tuning / blackjack rules / anti-cheat configs (≈45 keys) were all web-only because they wouldn't fit. Slash-first admins couldn't discover them.
- **Bad UX**: 25 optional args on one line with no per-field hints and no current-value preview. Admins were guessing.
- **Modal infrastructure is already in place** from PR #456. This extends the same pattern.

## What changed

- `/setconfig <subcommand>` now routes to one of 12 modals:
  - `general`, `activity`, `fees`, `jackpot`, `jackpot_activity`
  - `poker_stakes`, `poker_table`
  - `blackjack_rules`, `blackjack_table`
  - `lottery_basics`, `lottery_pools`
  - `stakes game:<choice>` — one slash option (10-game dropdown), encoded into the modal customId so a single modal class handles every game
- New `bot/toby/modal/modals/setconfig/` package:
  - `SetConfigCategoryModal` (open base) owns the read-fields → validate-all → write-all-or-error loop
  - `SimpleSetConfigCategoryModal` sub-base removes 10× boilerplate for the non-parameterised cases
  - `SetConfigFieldValidator` centralises typed parsing (IntRange, LongMin, DoubleRange, BoolStrict, EnumChoice, ChannelByIdStoreName, ChannelByIdStoreId) and the "all-or-nothing" batch logic
- Modals **pre-populate** TextInputs with current values via `TextInput.setValue(currentValue)` so admins see-and-edit; blank fields skip the upsert (don't clobber)
- Validate-all-then-write-all — a single bad field aborts the entire batch with a field-by-field error list; no partial writes
- `ACTIVITY_TRACKING`'s first-enable notifier side effect preserved in `SetConfigActivityModal.afterWrites`, matching the exact branching the old command used
- `MOVE` still stores the channel **name** (not id) to preserve the `MoveCommand` reader contract

## Breaking change

The old flat `/setconfig vol:X intvol:Y …` syntax is gone. Discord global slash commands repopulate within ~1h of deploy; users see the new subcommand layout once their client picks up the schema. No migration needed for stored config values — the underlying `ConfigDto` rows are untouched.

## Test plan

- [ ] `./gradlew :discord-bot:test` passes — `SetConfigCommandTest` rewritten as routing-only (owner gate, per-subcommand modal-id, reader-resolves-current-value); new per-modal tests for the validator, General modal, Activity modal (notifier branches), and Stakes modal (per-game spec divergence + customId).
- [ ] `./gradlew :application:test` passes — `CommandManagerTest` still sees the same 56 commands; the SetConfigCommand bean now wires up 12 modal dependencies via Spring.
- [ ] `./gradlew build` green.
- [ ] Manual smoke in dev guild (after Discord client refresh, ~1h global propagation):
  - `/setconfig` autocomplete shows 12 subcommands; flat options are gone.
  - `/setconfig general` opens with current values; submit with one changed field → only that key upserts; blank field doesn't overwrite.
  - `/setconfig activity` toggling tracking false→true fires the notifier once; true→true doesn't.
  - `/setconfig stakes game:dice` shows 3 fields (min/max/bot edge); `game:duel` shows 2 (no bot edge).
  - Non-owner gets an ephemeral "owner only" reply, no modal.
  - Validation error (e.g. `volume=abc`) → ephemeral error listing the field, zero writes.
- [ ] `/moderation` web tab still renders + saves (regression — no web code touched).

Remaining per-modal tests (`Fees`, `Jackpot`, `JackpotActivity`, `PokerStakes`, `PokerTable`, `BlackjackRules`, `BlackjackTable`, `LotteryBasics`, `LotteryPools`) are mechanical copies of the General/Activity patterns — the shared base class and validator already have the heavy logic covered. Can land in a follow-up if reviewer prefers a smaller diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017JsBRcq9srSTaqtuyGWKCH)_