### PR TITLE
fix(scratch): lock buy buttons through reveal + refresh TOBY button on balance changes

### DIFF
--- a/web/src/main/resources/static/js/casino-game.js
+++ b/web/src/main/resources/static/js/casino-game.js
@@ -95,10 +95,14 @@
             // load (older test paths that don't require it).
             if (root && root.TobyBalance) {
                 root.TobyBalance.update(balanceEl, newBalance);
-                return;
+            } else if (typeof newBalance === 'number' && balanceEl) {
+                balanceEl.textContent = newBalance;
             }
-            if (typeof newBalance !== 'number') return;
-            if (balanceEl) balanceEl.textContent = newBalance;
+            // The "Bet (sell TOBY)" button's visibility is driven by
+            // stake-vs-balance. Without this nudge a player who was short
+            // before a win keeps the secondary button on screen even
+            // after their balance climbs past the stake.
+            if (topUp) topUp.refresh();
         }
 
         function applyWinSettle(body, override) {
@@ -123,6 +127,11 @@
                 topUp.setTobyCoins(remaining);
             }
             if (typeof body.newPrice === 'number') topUp.setMarketPrice(body.newPrice);
+            // Belt-and-suspenders for scratch's manual flow — it calls
+            // applyTobyDelta after the balance write so the secondary
+            // button re-evaluates against the post-reveal wallet even
+            // when the response carried no soldTobyCoins/newPrice.
+            topUp.refresh();
         }
 
         function showToast(message, type) {

--- a/web/src/main/resources/static/js/scratch.js
+++ b/web/src/main/resources/static/js/scratch.js
@@ -44,6 +44,11 @@ function renderScratchResult(resultEl, body, matchThreshold, balanceEl) {
     // they hit "Reveal all") the result is shown.
     let activeCard = null;
     let game;
+    // Held across the user-driven reveal so casino-game.js keeps the buy
+    // buttons disabled until every cell is uncovered — otherwise a fast
+    // click (or autoclicker) can submit a second purchase on top of a
+    // half-revealed card. Resolved from the all-revealed branch below.
+    let revealResolve = null;
 
     function resetCells() {
         cellButtons.forEach(function (btn) {
@@ -95,6 +100,13 @@ function renderScratchResult(resultEl, body, matchThreshold, balanceEl) {
             // Card consumed — next "Buy ticket" starts a fresh one.
             activeCard = null;
             if (revealBtn) revealBtn.hidden = true;
+            // Release the busy-lock so casino-game.js can re-enable the
+            // buy buttons. Held since the renderResult Promise was issued.
+            if (revealResolve) {
+                const resolve = revealResolve;
+                revealResolve = null;
+                resolve();
+            }
         }
     }
 
@@ -169,7 +181,14 @@ function renderScratchResult(resultEl, body, matchThreshold, balanceEl) {
             }
         },
         renderResult: function () {
-            // Deliberately a no-op — see revealCell.
+            // Return a Promise so casino-game.js holds the busy-lock +
+            // setDisabled(true) across the user-driven reveal. Resolved
+            // from revealCell once the last cell is uncovered — same
+            // keno/baccarat shape covered by
+            // casino-game-lock-through-render.test.js.
+            return new Promise(function (resolve) {
+                revealResolve = resolve;
+            });
         },
     });
 })();

--- a/web/src/test/js/casino-topup.test.js
+++ b/web/src/test/js/casino-topup.test.js
@@ -175,3 +175,91 @@ describe('init', () => {
         expect(handle).toBeNull();
     });
 });
+
+// ---------------------------------------------------------------------------
+// casino-game.js wiring — applyBalance / applyTobyDelta must trigger a
+// TobyTopUp.refresh so the "Bet (sell TOBY)" button hides itself when a
+// win pushes the player's balance past their stake. Without this nudge
+// the secondary button is stranded on screen because refresh()'s normal
+// triggers (stake-input change, setTobyCoins, setMarketPrice) don't
+// cover the post-win balance bump for a regular wager.
+// ---------------------------------------------------------------------------
+
+describe('casino-game → TobyTopUp refresh on balance updates', () => {
+    let postJsonMock;
+
+    beforeEach(() => {
+        jest.resetModules();
+        jest.useFakeTimers();
+        document.body.innerHTML = `
+            <form id="f">
+                <input id="s" type="number" value="500">
+                <button id="p" type="submit">Bet</button>
+                <button id="t" type="submit" class="casino-bet-toby" hidden>
+                    <span class="casino-bet-toby-coins">0</span>
+                </button>
+            </form>
+            <span id="bal">0</span>
+            <div id="r"></div>
+        `;
+        postJsonMock = jest.fn();
+        window.TobyApi = { postJson: postJsonMock };
+        require('../../main/resources/static/js/casino-balance');
+        require('../../main/resources/static/js/casino-jackpot');
+        require('../../main/resources/static/js/casino-topup');
+        require('../../main/resources/static/js/casino-game');
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+        delete window.TobyApi;
+        delete window.TobyCasinoGame;
+        delete window.TobyTopUp;
+        delete window.TobyBalance;
+        delete window.TobyJackpot;
+    });
+
+    function bootGame() {
+        return window.TobyCasinoGame.init({
+            guildId: 'g1',
+            endpoint: '/play',
+            form: document.getElementById('f'),
+            stakeInput: document.getElementById('s'),
+            primaryBtn: document.getElementById('p'),
+            tobyBtn: document.getElementById('t'),
+            balanceEl: document.getElementById('bal'),
+            resultEl: document.getElementById('r'),
+            tobyCoins: 1000,
+            marketPrice: 2.5,
+        });
+    }
+
+    test('applyBalance hides the TOBY button when the new balance covers the stake', () => {
+        const game = bootGame();
+        const tobyBtn = document.getElementById('t');
+        // Pre-win: stake=500 > balance=0, market+coins both healthy → button visible.
+        expect(tobyBtn.hidden).toBe(false);
+
+        // A win lands and the wallet now covers the stake outright.
+        game.applyBalance(600);
+
+        expect(document.getElementById('bal').textContent).toBe('600');
+        expect(tobyBtn.hidden).toBe(true);
+    });
+
+    test('applyTobyDelta with no soldTobyCoins still refreshes button visibility', () => {
+        const game = bootGame();
+        const tobyBtn = document.getElementById('t');
+        expect(tobyBtn.hidden).toBe(false);
+
+        // Simulate the balance moving via a different code path (e.g.
+        // scratch's renderScratchResult writes via TobyBalance.update
+        // directly), then call applyTobyDelta with a body that has
+        // neither soldTobyCoins nor newPrice — the helper still needs to
+        // refresh so the post-reveal balance hides the button.
+        document.getElementById('bal').textContent = '700';
+        game.applyTobyDelta({ newBalance: 700 });
+
+        expect(tobyBtn.hidden).toBe(true);
+    });
+});

--- a/web/src/test/js/scratch-jackpot-lock.test.js
+++ b/web/src/test/js/scratch-jackpot-lock.test.js
@@ -158,4 +158,72 @@ describe('scratch.js — pool banner lock around reveal', () => {
         expect(holdSpy).toHaveBeenCalledTimes(1);
         expect(releaseSpy).not.toHaveBeenCalled();
     });
+
+    // Buy-button stays disabled through the user-driven reveal — otherwise
+    // a fast-clicker can submit a second buy on top of a half-scratched
+    // card. Mirrors the pool-banner lock pattern above: re-enable fires
+    // only when the LAST cell flips.
+    test('buy button stays disabled across cell-by-cell reveal and re-enables on the last cell', async () => {
+        postJsonMock.mockResolvedValue(makeCard(500));
+        const buyBtn = document.getElementById('scratch-buy');
+        submitBuy();
+        // Submit handler runs synchronously: setDisabled(true) fires.
+        expect(buyBtn.disabled).toBe(true);
+
+        // Drain the response → stopAnimation → renderResult issues its
+        // Promise. Button stays disabled because the Promise is pending.
+        await Promise.resolve();
+        await Promise.resolve();
+        jest.advanceTimersByTime(0);
+        await Promise.resolve();
+        expect(buyBtn.disabled).toBe(true);
+
+        for (let i = 0; i < 8; i++) {
+            clickCell(i);
+            expect(buyBtn.disabled).toBe(true);
+        }
+        clickCell(8);
+        // revealResolve() → finishSettle → setDisabled(false). Needs a
+        // microtask flush because finishSettle is awaited via .then.
+        for (let i = 0; i < 5; i++) await Promise.resolve();
+        expect(buyBtn.disabled).toBe(false);
+    });
+
+    test('Reveal-all releases the buy-button lock after the cascade settles', async () => {
+        postJsonMock.mockResolvedValue(makeCard(500));
+        const buyBtn = document.getElementById('scratch-buy');
+        submitBuy();
+        await Promise.resolve();
+        await Promise.resolve();
+        jest.advanceTimersByTime(0);
+        await Promise.resolve();
+        expect(buyBtn.disabled).toBe(true);
+
+        document.getElementById('scratch-reveal-all').click();
+        // Mid-cascade the lock must still hold.
+        jest.advanceTimersByTime(60 * 4);
+        expect(buyBtn.disabled).toBe(true);
+
+        // Run the rest of the cascade and flush the resolution chain.
+        jest.advanceTimersByTime(60 * 5);
+        for (let i = 0; i < 5; i++) await Promise.resolve();
+        expect(buyBtn.disabled).toBe(false);
+    });
+
+    test('server error path re-enables the buy button so the user can retry', async () => {
+        postJsonMock.mockResolvedValue({ ok: false, error: 'broke' });
+        const buyBtn = document.getElementById('scratch-buy');
+        submitBuy();
+        expect(buyBtn.disabled).toBe(true);
+
+        await Promise.resolve();
+        await Promise.resolve();
+        jest.advanceTimersByTime(0);
+        for (let i = 0; i < 5; i++) await Promise.resolve();
+
+        // Scaffold's else-branch never invokes renderResult, so the
+        // Promise dance is bypassed entirely — setDisabled(false) fires
+        // from the failure path.
+        expect(buyBtn.disabled).toBe(false);
+    });
 });


### PR DESCRIPTION
## Summary

Two scratch-card UX gaps that diverged from how the other casino games (slots, dice, coinflip, keno, etc.) behave:

- **Buy buttons re-enabled mid-reveal.** The "Buy ticket" / "Buy (sell N TOBY)" buttons flipped back to enabled the moment the server returned a card — before the player had finished scratching cells. A fast-clicker (or autoclicker) could submit a second buy on top of a half-revealed card. Fix: convert scratch's `renderResult` from a no-op to a Promise resolved from the all-revealed branch in `revealCell`. The casino-game scaffold already holds `busy` + `setDisabled(true)` until the Promise resolves — same keno/baccarat shape covered by `casino-game-lock-through-render.test.js`.
- **"Bet (sell TOBY)" button stayed visible after a win lifted balance past stake.** `casino-topup.js:refresh()` already does the right thing (hides when `balance >= stake`), but its triggers — stake-input change, `setTobyCoins`, `setMarketPrice` — never fire for a regular win where the response carries only `newBalance`. Fix: call `topUp.refresh()` at the end of `applyBalance` and `applyTobyDelta` in `casino-game.js` so every balance write re-evaluates visibility (benefits all games, not just scratch).

## Test plan

- [x] `npx jest` — all 423 tests pass (5 new)
- [x] Added regression tests in `scratch-jackpot-lock.test.js`: buy button stays disabled across cell-by-cell reveal, across "Reveal all" cascade, and re-enables on server error
- [x] Added regression tests in `casino-topup.test.js`: `applyBalance` and `applyTobyDelta` (with no soldTobyCoins/newPrice) both hide the TOBY button when balance covers stake
- [ ] Manual verification on `/casino/<guild>/scratch`: confirm buttons stay disabled while scratching, re-enable after the last cell or Reveal-all completes, and the TOBY button hides itself when a win pushes the wallet past the stake

---
_Generated by [Claude Code](https://claude.ai/code/session_019GqP342VNWv87bzxHhwN8d)_