### PR TITLE
fix(blackjack): load casino-win-settle.js on the bespoke web pages

### DIFF
--- a/web/src/main/resources/templates/blackjack-solo.html
+++ b/web/src/main/resources/templates/blackjack-solo.html
@@ -84,6 +84,7 @@
 <script th:src="@{/js/casino-jackpot.js}"></script>
 <script th:src="@{/js/casino-balance.js}"></script>
 <script th:src="@{/js/casino-render.js}"></script>
+<script th:src="@{/js/casino-win-settle.js}"></script>
 <script th:src="@{/js/blackjack-solo.js}"></script>
 </body>
 </html>

--- a/web/src/main/resources/templates/blackjack-table.html
+++ b/web/src/main/resources/templates/blackjack-table.html
@@ -80,6 +80,7 @@
 <script th:src="@{/js/casino-jackpot.js}"></script>
 <script th:src="@{/js/casino-balance.js}"></script>
 <script th:src="@{/js/casino-render.js}"></script>
+<script th:src="@{/js/casino-win-settle.js}"></script>
 <script th:src="@{/js/blackjack-table.js}"></script>
 </body>
 </html>

--- a/web/src/test/kotlin/web/template/CasinoMinigameTemplatesTest.kt
+++ b/web/src/test/kotlin/web/template/CasinoMinigameTemplatesTest.kt
@@ -54,6 +54,29 @@ class CasinoMinigameTemplatesTest {
         "casinoholdem-solo.html",
     )
 
+    /**
+     * Casino pages that hand-roll their script list rather than including
+     * the shared `casinoMinigame :: scripts` fragment. They have a custom
+     * page flow (their own state-poll loop, no `TobyCasinoGame.init`
+     * scaffolding, no `{prefix}-bet`/`{prefix}-stake` DOM contract) so
+     * pulling in the full fragment would load five modules they never
+     * call. The trade-off is that their script load is opt-in: the next
+     * shared module they depend on has to be wired by hand. The test
+     * below pins the two scripts the celebratory win flourish needs.
+     *
+     * Regression for "no coins visible on /blackjack/{g}/solo": the
+     * refactor that swapped `CasinoRender.flashChipsOn` for
+     * `TobyCasinoWinSettle.fire` in blackjack-solo.js hoisted
+     * casino-win-settle.js into the shared fragment but never added
+     * the matching <script> tag to blackjack-solo.html — the chip
+     * flourish silently no-op'd at runtime because the helper was
+     * undefined.
+     */
+    private val bespokeCasinoTemplates = listOf(
+        "blackjack-solo.html",
+        "blackjack-table.html",
+    )
+
     @Test
     fun `every minigame template includes the shared casinoMinigame scripts fragment`() {
         val missing = minigameTemplates.filter { name ->
@@ -136,5 +159,31 @@ class CasinoMinigameTemplatesTest {
             winSettleIdx > gameIdx,
             "casino-win-settle.js must load before casino-game.js"
         )
+    }
+
+    @Test
+    fun `bespoke casino pages load casino-render and casino-win-settle in order`() {
+        val required = listOf("/js/casino-render.js", "/js/casino-win-settle.js")
+        bespokeCasinoTemplates.forEach { name ->
+            val path = templatesRoot.resolve(name)
+            assertTrue(Files.exists(path), "missing template: $path")
+            val content = Files.readString(path)
+            required.forEach { script ->
+                assertTrue(
+                    content.contains(script),
+                    "$name does not load $script — the chip-stack flourish " +
+                        "(TobyCasinoWinSettle.fire) silently no-ops without it. " +
+                        "Add `<script th:src=\"@{$script}\"></script>` to the " +
+                        "page's script block."
+                )
+            }
+            val renderIdx = content.indexOf("casino-render.js")
+            val settleIdx = content.indexOf("casino-win-settle.js")
+            assertTrue(
+                renderIdx in 0 until settleIdx,
+                "$name must load casino-render.js before casino-win-settle.js " +
+                    "(the helper reads window.CasinoRender at fire-time)."
+            )
+        }
     }
 }


### PR DESCRIPTION
## Summary

- User report: "no coins visible" on `/blackjack/{guild}/solo` after a winning hand — the chip-stack flourish that other casino pages drop on the felt never appeared.
- Root cause: #428 swapped `blackjack-solo.js`'s `CasinoRender.flashChipsOn(...)` call for the new shared helper `TobyCasinoWinSettle.fire(...)` and hoisted `casino-win-settle.js` into the shared `casinoMinigame :: scripts` fragment. But `blackjack-solo.html` (and `blackjack-table.html`) hand-roll their `<script>` list rather than including that fragment — the new helper was never wired in, so `window.TobyCasinoWinSettle` was undefined at runtime and the chip stack silently no-op'd on every win.
- Fix: add `<script th:src="@{/js/casino-win-settle.js}"></script>` to both blackjack templates (table doesn't currently call the helper but the next refactor unifying the two pages would trip the same wire).
- Guard: extend `CasinoMinigameTemplatesTest` with a `bespokeCasinoTemplates` list so both blackjack pages must load `casino-render.js` and `casino-win-settle.js`, in that order. Other minigames stay on the shared-fragment contract that test already pinned.

The payout math itself in `BlackjackService.settleSolo` is fine — the symptom was the animation, not the credits.

## Test plan

- [x] Run `:web:test --tests web.template.CasinoMinigameTemplatesTest` → 4 tests pass, including the new `bespoke casino pages load casino-render and casino-win-settle in order`.
- [x] Delete the new `<script>` tag from `blackjack-solo.html` locally and re-run the test → fails with the actionable "$name does not load $script" message. (Restored before commit.)
- [ ] Manual: load `/blackjack/{guildId}/solo`, deal a hand, win, confirm `+N` chip stack pops on `#bj-player-row` and the win sound plays.

https://claude.ai/code/session_01XTguqDWARqsjyqYiSLVKc1

---
_Generated by [Claude Code](https://claude.ai/code/session_01XTguqDWARqsjyqYiSLVKc1)_