### PR TITLE
fix(css): honor [hidden] on .btn-primary and .btn-secondary

### DIFF
--- a/web/src/main/resources/static/css/base.css
+++ b/web/src/main/resources/static/css/base.css
@@ -151,6 +151,15 @@ a:hover { color: var(--accent-hover); }
 .btn-secondary:active:not(:disabled) { transform: translateY(1px); }
 .btn-secondary:disabled { opacity: 0.55; cursor: not-allowed; }
 
+/* `.btn-primary` and `.btn-secondary` both set explicit `display:
+   inline-flex`, which outranks the user-agent `[hidden] { display: none }`
+   and leaves any `<button class="btn-secondary" hidden>` visible until JS
+   flips it back. Casino pages rely on this for the "Bet (sell N TOBY)"
+   secondary button and per-game Reveal-all controls. Same shape as the
+   blackjack/baccarat [hidden] overrides. */
+.btn-primary[hidden],
+.btn-secondary[hidden] { display: none; }
+
 /* Green accent variant for confirm-style actions (blackjack's Stand,
    future "Lock in" / "Confirm" controls). Same shape as `.btn-primary`,
    different colour token. */


### PR DESCRIPTION
## Summary

Follow-up to #458. The user noticed the previous fix didn't actually hide the "Buy (sell N TOBY)" button on scratch even when their balance comfortably covered the stake (screenshot: balance ~100k, stake 100, button still visible reading "sell 0 TOBY"). Same story for the "Reveal all" button on initial page load.

**Root cause:** `.btn-primary` and `.btn-secondary` in `base.css:118-152` set explicit `display: inline-flex`, which outranks the user-agent stylesheet's `[hidden] { display: none }`. Any `<button class="btn-secondary" hidden>` stays visible on screen until JS toggles it. Casino-topup's `refresh()` was correctly setting `.hidden = true`, but the CSS quietly ignored the attribute.

Jest tests didn't catch this because the test DOM is built standalone and doesn't load base.css.

**Fix:** Add explicit `.btn-primary[hidden], .btn-secondary[hidden] { display: none }` in `base.css`. Same shape as the existing `[hidden]` overrides in `blackjack.css` (`.bj-cards`, `.bj-seats`) and `baccarat.css` (`.bac-cards`) that already work around their own `display: flex` collisions.

**Blast radius:** Beyond scratch's two affected buttons, this also fixes:
- All games' "Bet (sell N TOBY)" secondary button (slots, dice, coinflip, keno, roulette, etc.)
- Blackjack's hidden Split button on solo and table layouts
- Blackjack-table's "Deal next hand" / "Leave table" controls
- Poker-table's "Deal next hand" / "Cash out" controls
- Casino Hold'em's TOBY button

All these elements rely on the `hidden` attribute and have been quietly showing through. Pure CSS change — no JS, no template touch-ups, no test changes needed.

## Test plan

- [x] `npx jest` — all 423 tests pass
- [ ] Manual: load `/casino/<guild>/scratch` with balance > stake → confirm both TOBY button and Reveal-all are hidden on initial page load
- [ ] Manual: same check on slots, dice, coinflip, roulette → confirm TOBY button hidden when balance covers stake
- [ ] Manual: blackjack table → confirm "Deal next hand" / "Leave table" remain hidden until appropriate

---
_Generated by [Claude Code](https://claude.ai/code/session_019GqP342VNWv87bzxHhwN8d)_