### PR TITLE
feat(casino): add Plinko + Wheel of Fortune (low-RTP jackpot feeders)

### DIFF
--- a/application/src/test/kotlin/integration/bot/CommandManagerTest.kt
+++ b/application/src/test/kotlin/integration/bot/CommandManagerTest.kt
@@ -13,6 +13,7 @@ import bot.toby.command.commands.economy.DuelCommand
 import bot.toby.command.commands.economy.HighlowCommand
 import bot.toby.command.commands.economy.KenoCommand
 import bot.toby.command.commands.economy.LotteryCommand
+import bot.toby.command.commands.economy.PlinkoCommand
 import bot.toby.command.commands.economy.PokerCommand
 import bot.toby.command.commands.economy.RouletteCommand
 import bot.toby.command.commands.economy.ScratchCommand
@@ -20,6 +21,7 @@ import bot.toby.command.commands.economy.SlotsCommand
 import bot.toby.command.commands.economy.TipCommand
 import bot.toby.command.commands.economy.TitleCommand
 import bot.toby.command.commands.economy.TobyCoinCommand
+import bot.toby.command.commands.economy.WheelOfFortuneCommand
 import bot.toby.command.commands.fetch.DbdRandomKillerCommand
 import bot.toby.command.commands.fetch.Kf2RandomMapCommand
 import bot.toby.command.commands.fetch.MemeCommand
@@ -148,11 +150,13 @@ class CommandManagerTest {
             CasinoHoldemCommand::class.java,
             RouletteCommand::class.java,
             LotteryCommand::class.java,
+            PlinkoCommand::class.java,
+            WheelOfFortuneCommand::class.java,
         )
 
         Assertions.assertTrue(availableCommands.containsAll(commandManager.allCommands.map { it.javaClass }.toList()))
-        Assertions.assertEquals(56, commandManager.allCommands.size)
-        Assertions.assertEquals(56, commandManager.allSlashCommands.size)
+        Assertions.assertEquals(58, commandManager.allCommands.size)
+        Assertions.assertEquals(58, commandManager.allSlashCommands.size)
     }
 
     @Test

--- a/application/src/test/kotlin/integration/database/TobyCoinTradePersistenceIntegrationTest.kt
+++ b/application/src/test/kotlin/integration/database/TobyCoinTradePersistenceIntegrationTest.kt
@@ -46,7 +46,14 @@ class TobyCoinTradePersistenceIntegrationTest {
 
     companion object {
         private val seq = AtomicLong()
-        private fun freshGuildId() = 800_000L + seq.incrementAndGet()
+        // 7_800_000+ keeps this test's guildIds disjoint from
+        // TitlesBuyWithTobyCoinIntegrationTest (800_000+) and
+        // EconomyTradeServiceIntegrationTest (900_000+). Those tests insert
+        // trade rows with `executedAt = now()` against shared Postgres rows
+        // that survive `deleteOlderThan(REF - 30 days)` (cutoff is in the
+        // past relative to `now()`); without disjoint ranges, `listSince`
+        // here picks them up and the survivor count blows past 1.
+        private fun freshGuildId() = 7_800_000L + seq.incrementAndGet()
 
         // Fixed reference point for deterministic windowing math. Avoids
         // Instant.now()-based off-by-microsecond drift between the value

--- a/database/src/main/kotlin/database/dto/ConfigDto.kt
+++ b/database/src/main/kotlin/database/dto/ConfigDto.kt
@@ -137,6 +137,10 @@ class ConfigDto(
         SCRATCH_MAX_STAKE("SCRATCH_MAX_STAKE"),
         ROULETTE_MIN_STAKE("ROULETTE_MIN_STAKE"),
         ROULETTE_MAX_STAKE("ROULETTE_MAX_STAKE"),
+        PLINKO_MIN_STAKE("PLINKO_MIN_STAKE"),
+        PLINKO_MAX_STAKE("PLINKO_MAX_STAKE"),
+        WHEEL_OF_FORTUNE_MIN_STAKE("WHEEL_OF_FORTUNE_MIN_STAKE"),
+        WHEEL_OF_FORTUNE_MAX_STAKE("WHEEL_OF_FORTUNE_MAX_STAKE"),
         // Solo blackjack reuses the existing BLACKJACK_MIN_ANTE /
         // BLACKJACK_MAX_ANTE keys — solo and multi share a single
         // configurable stake range.

--- a/database/src/main/kotlin/database/dto/ConfigDto.kt
+++ b/database/src/main/kotlin/database/dto/ConfigDto.kt
@@ -211,6 +211,8 @@ class ConfigDto(
         COINFLIP_BOT_EDGE_MAX_PCT("COINFLIP_BOT_EDGE_MAX_PCT"),
         DICE_BOT_EDGE_MAX_PCT("DICE_BOT_EDGE_MAX_PCT"),
         SLOTS_BOT_EDGE_MAX_PCT("SLOTS_BOT_EDGE_MAX_PCT"),
+        PLINKO_BOT_EDGE_MAX_PCT("PLINKO_BOT_EDGE_MAX_PCT"),
+        WHEEL_OF_FORTUNE_BOT_EDGE_MAX_PCT("WHEEL_OF_FORTUNE_BOT_EDGE_MAX_PCT"),
 
         // Per-guild text-channel ID where anti-autoclicker session embeds
         // are posted: one message per suspicion session, edited in place

--- a/database/src/main/kotlin/database/economy/Plinko.kt
+++ b/database/src/main/kotlin/database/economy/Plinko.kt
@@ -1,0 +1,78 @@
+package database.economy
+
+import kotlin.random.Random
+
+/**
+ * Pure-logic Plinko: an 8-row peg board with 9 landing buckets and three
+ * risk profiles. No Spring, no DB, no JDA — just binomial drops over a
+ * fair coin per row and a multiplier table lookup at the bottom.
+ *
+ * Mechanic
+ *   Each row of pegs flips a fair coin: heads shifts the ball right, tails
+ *   left. After [ROWS] independent draws the ball lands in bucket
+ *   `k = right-count` (range `0..ROWS`). The bucket's multiplier in the
+ *   chosen [Risk]'s payout table determines the payout (`multiplier × stake`).
+ *
+ * Risk profiles (all targeting ~0.90 RTP under the binomial bucket
+ * distribution `P(k) = C(ROWS,k) / 2^ROWS`):
+ *   - LOW    — narrow range, no busts, small refund-ish center buckets.
+ *              Outer 1.9×, tapering to a 0.4× near-bust center.
+ *   - MEDIUM — wider range, single bust at the center.
+ *              Outer 12×, with 0.7× and 0× ring buckets.
+ *   - HIGH   — top-heavy, multiple busts around the center.
+ *              Outer 40×, three center 0× buckets.
+ *
+ * Each profile's RTP is the dot product of the binomial bucket probability
+ * vector and its multiplier vector; pinned in [PlinkoTest] so a tuning
+ * tweak that drifts RTP can't ship unnoticed.
+ *
+ * Stake bounds (`MIN_STAKE` / `MAX_STAKE`) live here so the Discord
+ * command, the web controller, and the service all agree on what's valid.
+ */
+class Plinko(
+    private val payouts: Map<Risk, DoubleArray> = DEFAULT_PAYOUTS
+) {
+
+    enum class Risk { LOW, MEDIUM, HIGH }
+
+    data class Drop(val bucket: Int, val multiplier: Double, val risk: Risk) {
+        val isWin: Boolean get() = multiplier > 1.0
+        val isPush: Boolean get() = multiplier == 1.0
+        val isLoss: Boolean get() = multiplier < 1.0
+    }
+
+    fun drop(risk: Risk, random: Random): Drop {
+        var rights = 0
+        repeat(ROWS) { if (random.nextBoolean()) rights += 1 }
+        val table = payouts.getValue(risk)
+        return Drop(bucket = rights, multiplier = table[rights], risk = risk)
+    }
+
+    fun payoutTable(risk: Risk): DoubleArray = payouts.getValue(risk).copyOf()
+
+    companion object {
+        const val MIN_STAKE: Long = 10L
+        const val MAX_STAKE: Long = 500L
+
+        /** 8 peg rows → 9 buckets (indices 0..8). */
+        const val ROWS: Int = 8
+        const val BUCKETS: Int = ROWS + 1
+
+        /**
+         * Risk profile payout tables. Each is a length-[BUCKETS] vector of
+         * (possibly fractional) multipliers; index `k` is the multiplier
+         * for the bucket where the ball landed after `k` right-shifts.
+         *
+         * Targets: all three profiles RTP ≈ 0.89-0.90, pinned by
+         * [database.economy.PlinkoTest].
+         */
+        val DEFAULT_PAYOUTS: Map<Risk, DoubleArray> = mapOf(
+            // Σ p(k)·m[k] / 256 = 227.8/256 ≈ 0.890
+            Risk.LOW to doubleArrayOf(1.9, 1.4, 1.1, 1.0, 0.4, 1.0, 1.1, 1.4, 1.9),
+            // 228.8/256 ≈ 0.894
+            Risk.MEDIUM to doubleArrayOf(12.0, 3.0, 1.4, 0.7, 0.0, 0.7, 1.4, 3.0, 12.0),
+            // 228.0/256 ≈ 0.891
+            Risk.HIGH to doubleArrayOf(40.0, 4.0, 1.5, 0.0, 0.0, 0.0, 1.5, 4.0, 40.0),
+        )
+    }
+}

--- a/database/src/main/kotlin/database/economy/WheelOfFortune.kt
+++ b/database/src/main/kotlin/database/economy/WheelOfFortune.kt
@@ -1,0 +1,106 @@
+package database.economy
+
+import kotlin.random.Random
+
+/**
+ * Pure-logic Wheel of Fortune: a weighted spinner where the player picks
+ * one of the marked multipliers ahead of the spin and wins
+ * `multiplier × stake` only if the wheel lands on that exact multiplier.
+ * No Spring, no DB, no JDA — just a weighted draw and an equality check.
+ *
+ * Mechanic
+ *   Player picks a multiplier from [PICKS] (2×, 3×, 5×, 10×). Wheel has
+ *   100 slots distributed as per [DEFAULT_WEIGHTS]:
+ *
+ *     2×  — 44 slots  (P=0.44, per-pick RTP = 0.88)
+ *     3×  — 29 slots  (P=0.29, per-pick RTP = 0.87)
+ *     5×  — 18 slots  (P=0.18, per-pick RTP = 0.90)
+ *    10×  —  9 slots  (P=0.09, per-pick RTP = 0.90)
+ *
+ *   Weights are roughly inversely proportional to multipliers so each
+ *   pick has RTP near the same ~0.88 target — the 2× pick is the safest
+ *   and most common, the 10× pick is the rarest and biggest. Average
+ *   per-pick RTP ≈ 0.885.
+ *
+ * Single-spin "land" is independent of the player's pick — the wheel
+ * doesn't know what was bet on. Caller compares the landed multiplier
+ * to the picked multiplier to determine a win.
+ *
+ * Stake bounds (`MIN_STAKE` / `MAX_STAKE`) live here so the Discord
+ * command, the web controller, and the service all agree on what's valid.
+ */
+class WheelOfFortune(
+    private val weights: Map<Long, Int> = DEFAULT_WEIGHTS
+) {
+
+    init {
+        require(weights.isNotEmpty()) { "wheel must have at least one slot" }
+        require(weights.keys.all { it > 1L }) {
+            "every slot multiplier must be > 1; got ${weights.keys}"
+        }
+        require(weights.values.all { it > 0 }) {
+            "every slot weight must be > 0; got ${weights.values}"
+        }
+    }
+
+    data class Spin(val landedMultiplier: Long, val pickedMultiplier: Long) {
+        val isWin: Boolean get() = landedMultiplier == pickedMultiplier
+    }
+
+    /**
+     * Spins the wheel once and compares against [pickedMultiplier].
+     * On a hit (`landed == picked`), [Spin.isWin] is true and the
+     * caller credits `picked × stake` to the player.
+     */
+    fun spin(pickedMultiplier: Long, random: Random): Spin {
+        require(isValidPick(pickedMultiplier)) {
+            "picked multiplier $pickedMultiplier is not in ${picks()}"
+        }
+        val total = weights.values.sum()
+        val draw = random.nextInt(total)
+        var running = 0
+        for ((mult, w) in weights.entries.sortedBy { it.key }) {
+            running += w
+            if (draw < running) return Spin(landedMultiplier = mult, pickedMultiplier = pickedMultiplier)
+        }
+        // Unreachable: draw < total and running ends at total.
+        val last = weights.entries.maxBy { it.key }.key
+        return Spin(landedMultiplier = last, pickedMultiplier = pickedMultiplier)
+    }
+
+    fun isValidPick(pickedMultiplier: Long): Boolean = pickedMultiplier in weights.keys
+
+    fun picks(): List<Long> = weights.keys.sorted()
+
+    fun slotCount(): Int = weights.values.sum()
+
+    fun weightFor(multiplier: Long): Int = weights[multiplier] ?: 0
+
+    companion object {
+        const val MIN_STAKE: Long = 10L
+        const val MAX_STAKE: Long = 500L
+
+        /**
+         * Wheel composition — 100 slots, sum-of-multiplier-mass ≈ 88 so
+         * average per-pick RTP ≈ 0.88. Each pick's RTP is
+         * `weight / 100 × multiplier`:
+         *
+         *   2×: 44/100 × 2  = 0.88
+         *   3×: 29/100 × 3  = 0.87
+         *   5×: 18/100 × 5  = 0.90
+         *  10×:  9/100 × 10 = 0.90
+         *
+         * Pinned in [database.economy.WheelOfFortuneTest].
+         */
+        val DEFAULT_WEIGHTS: Map<Long, Int> = linkedMapOf(
+            2L to 44,
+            3L to 29,
+            5L to 18,
+            10L to 9,
+        )
+
+        /** Sorted list of pickable multipliers, exposed for the Discord
+         *  command and web template. */
+        val PICKS: List<Long> = DEFAULT_WEIGHTS.keys.sorted()
+    }
+}

--- a/database/src/main/kotlin/database/service/JackpotHelper.kt
+++ b/database/src/main/kotlin/database/service/JackpotHelper.kt
@@ -65,7 +65,9 @@ enum class JackpotGame(val rtp: Double, val eligibleForJackpot: Boolean = true) 
     HOLDEM(0.97),      // Casino Hold'em vs dealer; ~2-3% edge industry-wide.
     HIGHLOW(0.923, eligibleForJackpot = false), // Honest 12/13 RTP but ~85 % win rate at extreme anchors farms rolls; loss-tribute only.
     KENO(0.92),        // 0.83-0.92 band; pin to the top so the gate is honest.
+    PLINKO(0.89),      // ~11% edge across LOW/MEDIUM/HIGH profiles; pinned by PlinkoTest.
     SLOTS(0.890),      // ~11% house edge; closed-form pinned by SlotMachineTest.
+    WHEEL_OF_FORTUNE(0.88), // Per-pick RTP cluster 0.87-0.90; pinned by WheelOfFortuneTest.
     SCRATCH(0.875),    // ~12.5% edge; pinned by ScratchCard.expectedRtp().
     DICE(0.833),       // 5/6 — 5× payout at 1/6 odds.
 }

--- a/database/src/main/kotlin/database/service/PlinkoService.kt
+++ b/database/src/main/kotlin/database/service/PlinkoService.kt
@@ -27,6 +27,7 @@ class PlinkoService(
     private val tradeService: EconomyTradeService,
     private val marketService: TobyCoinMarketService,
     private val configService: ConfigService,
+    private val casinoEdgeService: CasinoEdgeService,
     private val plinko: Plinko = Plinko(),
     private val random: Random = Random.Default
 ) {
@@ -84,6 +85,9 @@ class PlinkoService(
         stake: Long,
         risk: Plinko.Risk,
         autoTopUp: Boolean = false,
+        clickX: Int? = null,
+        clickY: Int? = null,
+        mouseMoved: Boolean? = null,
     ): DropOutcome {
         val minStake = configService.cfgLong(
             ConfigDto.Configurations.PLINKO_MIN_STAKE, guildId, default = Plinko.MIN_STAKE, min = 1L
@@ -104,7 +108,24 @@ class PlinkoService(
             is TopUpResolution.Ok -> r
         }
 
-        val result = plinko.drop(risk, random)
+        val fairResult = plinko.drop(risk, random)
+        // Anti-autoclicker substitution: replace the fair drop with a
+        // forced-loss landing on the worst-bucket multiplier for this
+        // risk profile. The animation still settles naturally — the
+        // player only sees the bucket index + multiplier.
+        val result = casinoEdgeService.applyBotEdge(
+            discordId = discordId,
+            guildId = guildId,
+            gameKey = "plinko",
+            clickX = clickX, clickY = clickY, mouseMoved = mouseMoved,
+            edgeMaxConfig = ConfigDto.Configurations.PLINKO_BOT_EDGE_MAX_PCT,
+            fairOutcome = fairResult,
+            asLoss = {
+                val table = plinko.payoutTable(risk)
+                val minIdx = table.indices.minBy { table[it] }
+                Plinko.Drop(bucket = minIdx, multiplier = table[minIdx], risk = risk)
+            },
+        )
         val wager = WagerHelper.applyMultiplier(
             userService, resolved.user, resolved.balance, stake, result.multiplier
         )

--- a/database/src/main/kotlin/database/service/PlinkoService.kt
+++ b/database/src/main/kotlin/database/service/PlinkoService.kt
@@ -1,0 +1,162 @@
+package database.service
+
+import common.casino.CasinoCommonFailure
+import database.dto.ConfigDto
+import database.economy.Plinko
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import kotlin.random.Random
+
+/**
+ * Atomic drop path for the `/plinko` minigame. Same lock-then-mutate
+ * pattern as [SlotsService] / [DiceService] via
+ * [UserService.getUserByIdForUpdate] so concurrent drops from the same
+ * user (Discord + web at once, or spam-clicking) can't double-spend.
+ *
+ * Wins (multiplier > 1×) roll [JackpotHelper] for a chance to bank the
+ * per-guild jackpot pool. Losses tribute the lost portion of the stake
+ * back into the pool — for partial-loss buckets (e.g. LOW profile's 0.4×
+ * center) only the net loss feeds the pool, not the whole stake. Pushes
+ * (multiplier == 1×) skip both branches: no win-roll, no tribute.
+ */
+@Service
+@Transactional
+class PlinkoService(
+    private val userService: UserService,
+    private val jackpotService: JackpotService,
+    private val tradeService: EconomyTradeService,
+    private val marketService: TobyCoinMarketService,
+    private val configService: ConfigService,
+    private val plinko: Plinko = Plinko(),
+    private val random: Random = Random.Default
+) {
+
+    sealed interface DropOutcome {
+        data class Win(
+            val stake: Long,
+            val risk: Plinko.Risk,
+            val bucket: Int,
+            val multiplier: Double,
+            val payout: Long,
+            val net: Long,
+            val newBalance: Long,
+            val jackpotPayout: Long = 0L,
+            val jackpotTierIndex: Int = -1,
+            val jackpotTierPayoutPct: Double = 0.0,
+            val soldTobyCoins: Long = 0L,
+            val newPrice: Double? = null,
+        ) : DropOutcome
+
+        data class Lose(
+            val stake: Long,
+            val risk: Plinko.Risk,
+            val bucket: Int,
+            val multiplier: Double,
+            val payout: Long,
+            val net: Long,
+            val newBalance: Long,
+            val soldTobyCoins: Long = 0L,
+            val newPrice: Double? = null,
+            val lossTribute: Long = 0L,
+        ) : DropOutcome
+
+        data class Push(
+            val stake: Long,
+            val risk: Plinko.Risk,
+            val bucket: Int,
+            val newBalance: Long,
+            val soldTobyCoins: Long = 0L,
+            val newPrice: Double? = null,
+        ) : DropOutcome
+
+        data class InsufficientCredits(override val stake: Long, override val have: Long) :
+            DropOutcome, CasinoCommonFailure.InsufficientCredits
+        data class InsufficientCoinsForTopUp(override val needed: Long, override val have: Long) :
+            DropOutcome, CasinoCommonFailure.InsufficientCoinsForTopUp
+        data class InvalidStake(override val min: Long, override val max: Long) :
+            DropOutcome, CasinoCommonFailure.InvalidStake
+        data object UnknownUser : DropOutcome, CasinoCommonFailure.UnknownUser
+    }
+
+    fun drop(
+        discordId: Long,
+        guildId: Long,
+        stake: Long,
+        risk: Plinko.Risk,
+        autoTopUp: Boolean = false,
+    ): DropOutcome {
+        val minStake = configService.cfgLong(
+            ConfigDto.Configurations.PLINKO_MIN_STAKE, guildId, default = Plinko.MIN_STAKE, min = 1L
+        )
+        val maxStake = configService.cfgLongMax(
+            ConfigDto.Configurations.PLINKO_MAX_STAKE, guildId, default = Plinko.MAX_STAKE, min = minStake
+        )
+        val resolved = when (val r = WagerHelper.checkLockOrTopUp(
+            userService, tradeService, marketService,
+            discordId, guildId, stake, minStake, maxStake, autoTopUp,
+        )) {
+            is TopUpResolution.InvalidStake -> return DropOutcome.InvalidStake(r.min, r.max)
+            TopUpResolution.UnknownUser -> return DropOutcome.UnknownUser
+            is TopUpResolution.StillInsufficientCredits ->
+                return DropOutcome.InsufficientCredits(r.stake, r.have)
+            is TopUpResolution.InsufficientCoinsForTopUp ->
+                return DropOutcome.InsufficientCoinsForTopUp(r.needed, r.have)
+            is TopUpResolution.Ok -> r
+        }
+
+        val result = plinko.drop(risk, random)
+        val wager = WagerHelper.applyMultiplier(
+            userService, resolved.user, resolved.balance, stake, result.multiplier
+        )
+        return when {
+            result.isWin -> {
+                val jackpot = JackpotHelper.rollOnWin(
+                    jackpotService, configService, userService, resolved.user, guildId,
+                    stake, JackpotGame.PLINKO, random,
+                )
+                DropOutcome.Win(
+                    stake = stake,
+                    risk = risk,
+                    bucket = result.bucket,
+                    multiplier = result.multiplier,
+                    payout = wager.payout,
+                    net = wager.net,
+                    newBalance = wager.newBalance + jackpot.amount,
+                    jackpotPayout = jackpot.amount,
+                    jackpotTierIndex = jackpot.tierIndex,
+                    jackpotTierPayoutPct = jackpot.tierPayoutPct,
+                    soldTobyCoins = resolved.soldCoins,
+                    newPrice = resolved.newPrice,
+                )
+            }
+            result.isPush -> DropOutcome.Push(
+                stake = stake,
+                risk = risk,
+                bucket = result.bucket,
+                newBalance = wager.newBalance,
+                soldTobyCoins = resolved.soldCoins,
+                newPrice = resolved.newPrice,
+            )
+            else -> {
+                // Tribute on the actual lost portion, not the full stake —
+                // a 0.4× bucket loses 0.6 × stake, not the whole stake.
+                val lossAmount = stake - wager.payout
+                val tribute = JackpotHelper.divertOnLoss(
+                    jackpotService, configService, guildId, lossAmount
+                )
+                DropOutcome.Lose(
+                    stake = stake,
+                    risk = risk,
+                    bucket = result.bucket,
+                    multiplier = result.multiplier,
+                    payout = wager.payout,
+                    net = wager.net,
+                    newBalance = wager.newBalance,
+                    soldTobyCoins = resolved.soldCoins,
+                    newPrice = resolved.newPrice,
+                    lossTribute = tribute,
+                )
+            }
+        }
+    }
+}

--- a/database/src/main/kotlin/database/service/WheelOfFortuneService.kt
+++ b/database/src/main/kotlin/database/service/WheelOfFortuneService.kt
@@ -26,6 +26,7 @@ class WheelOfFortuneService(
     private val tradeService: EconomyTradeService,
     private val marketService: TobyCoinMarketService,
     private val configService: ConfigService,
+    private val casinoEdgeService: CasinoEdgeService,
     private val wheel: WheelOfFortune = WheelOfFortune(),
     private val random: Random = Random.Default
 ) {
@@ -71,6 +72,9 @@ class WheelOfFortuneService(
         stake: Long,
         pickedMultiplier: Long,
         autoTopUp: Boolean = false,
+        clickX: Int? = null,
+        clickY: Int? = null,
+        mouseMoved: Boolean? = null,
     ): SpinOutcome {
         if (!wheel.isValidPick(pickedMultiplier)) {
             return SpinOutcome.InvalidPick(wheel.picks())
@@ -96,7 +100,22 @@ class WheelOfFortuneService(
             is TopUpResolution.Ok -> r
         }
 
-        val result = wheel.spin(pickedMultiplier, random)
+        val fairResult = wheel.spin(pickedMultiplier, random)
+        // Anti-autoclicker substitution: replace the fair spin with a
+        // landing on any non-picked multiplier (guaranteed loss for the
+        // player's pick). The wheel animation still settles naturally.
+        val result = casinoEdgeService.applyBotEdge(
+            discordId = discordId,
+            guildId = guildId,
+            gameKey = "wheel",
+            clickX = clickX, clickY = clickY, mouseMoved = mouseMoved,
+            edgeMaxConfig = ConfigDto.Configurations.WHEEL_OF_FORTUNE_BOT_EDGE_MAX_PCT,
+            fairOutcome = fairResult,
+            asLoss = {
+                val loserMult = wheel.picks().first { it != pickedMultiplier }
+                WheelOfFortune.Spin(landedMultiplier = loserMult, pickedMultiplier = pickedMultiplier)
+            },
+        )
         val multiplier = if (result.isWin) pickedMultiplier else 0L
         val wager = WagerHelper.applyMultiplier(
             userService, resolved.user, resolved.balance, stake, multiplier

--- a/database/src/main/kotlin/database/service/WheelOfFortuneService.kt
+++ b/database/src/main/kotlin/database/service/WheelOfFortuneService.kt
@@ -1,0 +1,135 @@
+package database.service
+
+import common.casino.CasinoCommonFailure
+import database.dto.ConfigDto
+import database.economy.WheelOfFortune
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import kotlin.random.Random
+
+/**
+ * Atomic spin path for the `/wheel` minigame. Same lock-then-mutate
+ * pattern as the other wager-style minigame services. The player picks
+ * one of [WheelOfFortune.PICKS] multipliers up front; the wheel spins
+ * once and the player wins `pick × stake` only if the landed multiplier
+ * equals their picked multiplier. Otherwise the stake is lost.
+ *
+ * Wins roll [JackpotHelper] for a chance to bank the per-guild jackpot
+ * pool; losses tribute the full stake into the pool (the wheel has no
+ * partial-loss buckets).
+ */
+@Service
+@Transactional
+class WheelOfFortuneService(
+    private val userService: UserService,
+    private val jackpotService: JackpotService,
+    private val tradeService: EconomyTradeService,
+    private val marketService: TobyCoinMarketService,
+    private val configService: ConfigService,
+    private val wheel: WheelOfFortune = WheelOfFortune(),
+    private val random: Random = Random.Default
+) {
+
+    sealed interface SpinOutcome {
+        data class Win(
+            val stake: Long,
+            val pickedMultiplier: Long,
+            val landedMultiplier: Long,
+            val payout: Long,
+            val net: Long,
+            val newBalance: Long,
+            val jackpotPayout: Long = 0L,
+            val jackpotTierIndex: Int = -1,
+            val jackpotTierPayoutPct: Double = 0.0,
+            val soldTobyCoins: Long = 0L,
+            val newPrice: Double? = null,
+        ) : SpinOutcome
+
+        data class Lose(
+            val stake: Long,
+            val pickedMultiplier: Long,
+            val landedMultiplier: Long,
+            val newBalance: Long,
+            val soldTobyCoins: Long = 0L,
+            val newPrice: Double? = null,
+            val lossTribute: Long = 0L,
+        ) : SpinOutcome
+
+        data class InsufficientCredits(override val stake: Long, override val have: Long) :
+            SpinOutcome, CasinoCommonFailure.InsufficientCredits
+        data class InsufficientCoinsForTopUp(override val needed: Long, override val have: Long) :
+            SpinOutcome, CasinoCommonFailure.InsufficientCoinsForTopUp
+        data class InvalidStake(override val min: Long, override val max: Long) :
+            SpinOutcome, CasinoCommonFailure.InvalidStake
+        data class InvalidPick(val picks: List<Long>) : SpinOutcome
+        data object UnknownUser : SpinOutcome, CasinoCommonFailure.UnknownUser
+    }
+
+    fun spin(
+        discordId: Long,
+        guildId: Long,
+        stake: Long,
+        pickedMultiplier: Long,
+        autoTopUp: Boolean = false,
+    ): SpinOutcome {
+        if (!wheel.isValidPick(pickedMultiplier)) {
+            return SpinOutcome.InvalidPick(wheel.picks())
+        }
+        val minStake = configService.cfgLong(
+            ConfigDto.Configurations.WHEEL_OF_FORTUNE_MIN_STAKE, guildId,
+            default = WheelOfFortune.MIN_STAKE, min = 1L
+        )
+        val maxStake = configService.cfgLongMax(
+            ConfigDto.Configurations.WHEEL_OF_FORTUNE_MAX_STAKE, guildId,
+            default = WheelOfFortune.MAX_STAKE, min = minStake
+        )
+        val resolved = when (val r = WagerHelper.checkLockOrTopUp(
+            userService, tradeService, marketService,
+            discordId, guildId, stake, minStake, maxStake, autoTopUp,
+        )) {
+            is TopUpResolution.InvalidStake -> return SpinOutcome.InvalidStake(r.min, r.max)
+            TopUpResolution.UnknownUser -> return SpinOutcome.UnknownUser
+            is TopUpResolution.StillInsufficientCredits ->
+                return SpinOutcome.InsufficientCredits(r.stake, r.have)
+            is TopUpResolution.InsufficientCoinsForTopUp ->
+                return SpinOutcome.InsufficientCoinsForTopUp(r.needed, r.have)
+            is TopUpResolution.Ok -> r
+        }
+
+        val result = wheel.spin(pickedMultiplier, random)
+        val multiplier = if (result.isWin) pickedMultiplier else 0L
+        val wager = WagerHelper.applyMultiplier(
+            userService, resolved.user, resolved.balance, stake, multiplier
+        )
+        return if (result.isWin) {
+            val jackpot = JackpotHelper.rollOnWin(
+                jackpotService, configService, userService, resolved.user, guildId,
+                stake, JackpotGame.WHEEL_OF_FORTUNE, random,
+            )
+            SpinOutcome.Win(
+                stake = stake,
+                pickedMultiplier = pickedMultiplier,
+                landedMultiplier = result.landedMultiplier,
+                payout = wager.payout,
+                net = wager.net,
+                newBalance = wager.newBalance + jackpot.amount,
+                jackpotPayout = jackpot.amount,
+                jackpotTierIndex = jackpot.tierIndex,
+                jackpotTierPayoutPct = jackpot.tierPayoutPct,
+                soldTobyCoins = resolved.soldCoins,
+                newPrice = resolved.newPrice,
+            )
+        } else {
+            val tribute = JackpotHelper.divertOnLoss(jackpotService, configService, guildId, stake)
+            SpinOutcome.Lose(
+                stake = stake,
+                pickedMultiplier = pickedMultiplier,
+                landedMultiplier = result.landedMultiplier,
+                newBalance = wager.newBalance,
+                soldTobyCoins = resolved.soldCoins,
+                newPrice = resolved.newPrice,
+                lossTribute = tribute,
+            )
+        }
+    }
+}

--- a/database/src/test/kotlin/database/economy/PlinkoTest.kt
+++ b/database/src/test/kotlin/database/economy/PlinkoTest.kt
@@ -1,0 +1,118 @@
+package database.economy
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import kotlin.random.Random
+
+class PlinkoTest {
+
+    @Test
+    fun `drop always lands in a valid bucket with the configured multiplier`() {
+        val plinko = Plinko()
+        val rng = Random(42)
+        Plinko.Risk.entries.forEach { risk ->
+            val table = plinko.payoutTable(risk)
+            repeat(1_000) {
+                val drop = plinko.drop(risk, rng)
+                assertTrue(
+                    drop.bucket in 0..Plinko.ROWS,
+                    "bucket ${drop.bucket} must be in 0..${Plinko.ROWS}"
+                )
+                assertEquals(
+                    table[drop.bucket], drop.multiplier, 1e-9,
+                    "multiplier must match the bucket's table entry"
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `default payout tables are symmetric across the center bucket`() {
+        // Symmetry guarantees an unbiased left/right walk: a tuner can't
+        // accidentally favour heads-or-tails by editing one half.
+        Plinko.Risk.entries.forEach { risk ->
+            val table = Plinko.DEFAULT_PAYOUTS.getValue(risk)
+            for (k in 0..Plinko.ROWS / 2) {
+                assertEquals(
+                    table[k], table[Plinko.ROWS - k], 1e-9,
+                    "$risk: bucket $k and ${Plinko.ROWS - k} must mirror"
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `every risk profile RTP is within 0_88 to 0_92`() {
+        // Analytic check using the binomial bucket distribution. Tighter
+        // than the Monte Carlo bound below so a typo in the payout table
+        // surfaces before the slow path runs.
+        val totalWeight = (0..Plinko.ROWS).sumOf { binomial(Plinko.ROWS, it) }
+        Plinko.Risk.entries.forEach { risk ->
+            val table = Plinko.DEFAULT_PAYOUTS.getValue(risk)
+            val ev = (0..Plinko.ROWS).sumOf { k ->
+                binomial(Plinko.ROWS, k).toDouble() * table[k]
+            } / totalWeight.toDouble()
+            assertTrue(
+                ev in 0.88..0.92,
+                "$risk profile RTP $ev must be in [0.88, 0.92]"
+            )
+        }
+    }
+
+    @Test
+    fun `RTP across 100k drops is within +- 5 percent of the analytic target`() {
+        val plinko = Plinko()
+        val rng = Random(2026)
+        val stake = 1_000L
+        Plinko.Risk.entries.forEach { risk ->
+            var totalWagered = 0L
+            var totalReturned = 0L
+            repeat(100_000) {
+                val drop = plinko.drop(risk, rng)
+                totalWagered += stake
+                totalReturned += (stake * drop.multiplier).toLong()
+            }
+            val rtp = totalReturned.toDouble() / totalWagered.toDouble()
+            assertTrue(
+                rtp in 0.84..0.94,
+                "$risk: expected RTP near 0.89 (±0.05) across 100k drops but saw $rtp"
+            )
+        }
+    }
+
+    @Test
+    fun `outer buckets always pay strictly more than the center bucket`() {
+        // Pinning the basic shape — outer buckets exist to be exciting.
+        // A retune that flattens or inverts this curve is almost certainly
+        // a bug, so block it at test time.
+        Plinko.Risk.entries.forEach { risk ->
+            val table = Plinko.DEFAULT_PAYOUTS.getValue(risk)
+            assertTrue(
+                table[0] > table[Plinko.ROWS / 2],
+                "$risk: outer bucket ${table[0]} must beat center ${table[Plinko.ROWS / 2]}"
+            )
+        }
+    }
+
+    @Test
+    fun `isWin classification matches multiplier strict-greater-than-1`() {
+        val plinko = Plinko()
+        val rng = Random(1)
+        repeat(500) {
+            val drop = plinko.drop(Plinko.Risk.MEDIUM, rng)
+            assertEquals(drop.multiplier > 1.0, drop.isWin, "isWin must match multiplier > 1.0")
+            assertEquals(drop.multiplier == 1.0, drop.isPush, "isPush must match multiplier == 1.0")
+            assertEquals(drop.multiplier < 1.0, drop.isLoss, "isLoss must match multiplier < 1.0")
+        }
+    }
+
+    private fun binomial(n: Int, k: Int): Long {
+        if (k < 0 || k > n) return 0L
+        var result = 1L
+        for (i in 0 until k) {
+            result = result * (n - i) / (i + 1)
+        }
+        return result
+    }
+}

--- a/database/src/test/kotlin/database/economy/WheelOfFortuneTest.kt
+++ b/database/src/test/kotlin/database/economy/WheelOfFortuneTest.kt
@@ -1,0 +1,109 @@
+package database.economy
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import kotlin.random.Random
+
+class WheelOfFortuneTest {
+
+    @Test
+    fun `spin always lands on one of the configured multipliers`() {
+        val wheel = WheelOfFortune()
+        val rng = Random(42)
+        val valid = WheelOfFortune.DEFAULT_WEIGHTS.keys
+        repeat(1_000) {
+            val spin = wheel.spin(pickedMultiplier = 2L, random = rng)
+            assertTrue(
+                spin.landedMultiplier in valid,
+                "landed multiplier ${spin.landedMultiplier} must be in $valid"
+            )
+        }
+    }
+
+    @Test
+    fun `pick must be one of the configured multipliers`() {
+        val wheel = WheelOfFortune()
+        assertThrows(IllegalArgumentException::class.java) {
+            wheel.spin(pickedMultiplier = 7L, random = Random(0))
+        }
+    }
+
+    @Test
+    fun `isWin matches landed equals picked`() {
+        val wheel = WheelOfFortune()
+        val rng = Random(2026)
+        repeat(500) {
+            val pick = WheelOfFortune.PICKS.random(rng)
+            val spin = wheel.spin(pick, rng)
+            assertEquals(spin.landedMultiplier == pick, spin.isWin)
+        }
+    }
+
+    @Test
+    fun `per-pick RTPs hover around 0_88 across 200k spins`() {
+        // Loose ±0.04 band — the analytic per-pick RTPs span 0.87..0.90;
+        // 200k draws keeps the CI well inside.
+        val wheel = WheelOfFortune()
+        val rng = Random(13)
+        val stake = 1_000L
+        WheelOfFortune.PICKS.forEach { pick ->
+            var totalWagered = 0L
+            var totalReturned = 0L
+            repeat(200_000) {
+                val spin = wheel.spin(pick, rng)
+                totalWagered += stake
+                if (spin.isWin) totalReturned += pick * stake
+            }
+            val rtp = totalReturned.toDouble() / totalWagered.toDouble()
+            assertTrue(
+                rtp in 0.84..0.94,
+                "pick=$pick: expected RTP near 0.88 (±0.04) across 200k spins but saw $rtp"
+            )
+        }
+    }
+
+    @Test
+    fun `analytic per-pick RTPs sit within 0_86 to 0_91`() {
+        // Closed-form check on the default weight table — drift here means
+        // a future retune slipped the canonical RTP outside the band the
+        // JackpotGame enum advertises (0.88).
+        val totalSlots = WheelOfFortune.DEFAULT_WEIGHTS.values.sum().toDouble()
+        WheelOfFortune.DEFAULT_WEIGHTS.forEach { (mult, weight) ->
+            val rtp = weight.toDouble() / totalSlots * mult.toDouble()
+            assertTrue(
+                rtp in 0.86..0.91,
+                "pick=$mult analytic RTP=$rtp must be in [0.86, 0.91]"
+            )
+        }
+    }
+
+    @Test
+    fun `larger multipliers carry strictly smaller weight than smaller multipliers`() {
+        // Wheel design principle: rarer payouts are bigger. If a retune
+        // ever inverts this, the per-pick RTPs explode (10× becoming as
+        // likely as 2× would make picking 10× a 4.4 RTP no-brainer).
+        val ordered = WheelOfFortune.DEFAULT_WEIGHTS.entries.sortedBy { it.key }
+        for (i in 1 until ordered.size) {
+            val prev = ordered[i - 1]
+            val curr = ordered[i]
+            assertTrue(
+                curr.value < prev.value,
+                "weight for ${curr.key}× (${curr.value}) must be < weight for ${prev.key}× (${prev.value})"
+            )
+        }
+    }
+
+    @Test
+    fun `seeded RNG produces deterministic landings`() {
+        val wheelA = WheelOfFortune()
+        val wheelB = WheelOfFortune()
+        val landingsA = (1..50).map { wheelA.spin(2L, Random(7)).landedMultiplier }
+        val landingsB = (1..50).map { wheelB.spin(2L, Random(7)).landedMultiplier }
+        assertEquals(landingsA, landingsB, "same seed must produce same wheel landings")
+        val landingsC = (1..50).map { wheelA.spin(2L, Random(8)).landedMultiplier }
+        assertNotEquals(landingsA, landingsC, "different seeds must diverge somewhere in 50 draws")
+    }
+}

--- a/database/src/test/kotlin/database/service/PlinkoServiceTest.kt
+++ b/database/src/test/kotlin/database/service/PlinkoServiceTest.kt
@@ -1,0 +1,185 @@
+package database.service
+
+import database.dto.UserDto
+import database.economy.Plinko
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import kotlin.random.Random
+
+class PlinkoServiceTest {
+
+    private lateinit var userService: UserService
+    private lateinit var jackpotService: JackpotService
+    private lateinit var tradeService: EconomyTradeService
+    private lateinit var marketService: TobyCoinMarketService
+    private lateinit var configService: ConfigService
+    private lateinit var plinko: Plinko
+    private lateinit var service: PlinkoService
+
+    private val discordId = 100L
+    private val guildId = 200L
+
+    @BeforeEach
+    fun setup() {
+        userService = mockk(relaxed = true)
+        jackpotService = mockk(relaxed = true)
+        tradeService = mockk(relaxed = true)
+        marketService = mockk(relaxed = true)
+        configService = mockk(relaxed = true)
+        plinko = mockk(relaxed = true)
+        service = PlinkoService(
+            userService, jackpotService, tradeService, marketService, configService,
+            plinko, Random(0)
+        )
+    }
+
+    private fun userWithBalance(balance: Long): UserDto {
+        return UserDto(discordId, guildId).apply { socialCredit = balance }
+    }
+
+    @Test
+    fun `win debits stake and credits payout atomically`() {
+        val user = userWithBalance(1_000L)
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns user
+        every { plinko.drop(Plinko.Risk.MEDIUM, any()) } returns Plinko.Drop(
+            bucket = 0, multiplier = 12.0, risk = Plinko.Risk.MEDIUM,
+        )
+        val captured = slot<UserDto>()
+        every { userService.updateUser(capture(captured)) } returns user
+
+        val outcome = service.drop(discordId, guildId, stake = 100L, risk = Plinko.Risk.MEDIUM)
+
+        val win = assertInstanceOf(PlinkoService.DropOutcome.Win::class.java, outcome)
+        assertEquals(100L, win.stake)
+        assertEquals(12.0, win.multiplier, 1e-9)
+        assertEquals(1_200L, win.payout)
+        assertEquals(1_100L, win.net, "net = payout (1200) - stake (100)")
+        assertEquals(2_100L, win.newBalance, "1000 + (1200 - 100)")
+        assertEquals(2_100L, captured.captured.socialCredit)
+    }
+
+    @Test
+    fun `full bust calls divertOnLoss with the full stake`() {
+        val user = userWithBalance(500L)
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns user
+        every { plinko.drop(Plinko.Risk.MEDIUM, any()) } returns Plinko.Drop(
+            bucket = 4, multiplier = 0.0, risk = Plinko.Risk.MEDIUM,
+        )
+        every { userService.updateUser(any()) } returns user
+        every { jackpotService.addToPool(guildId, any()) } returns 0L
+
+        val outcome = service.drop(discordId, guildId, stake = 100L, risk = Plinko.Risk.MEDIUM)
+
+        val lose = assertInstanceOf(PlinkoService.DropOutcome.Lose::class.java, outcome)
+        assertEquals(100L, lose.stake)
+        assertEquals(0L, lose.payout)
+        assertEquals(-100L, lose.net)
+        assertEquals(400L, lose.newBalance)
+        // 10% tribute applied to the full loss (= stake) → 10
+        verify(exactly = 1) { jackpotService.addToPool(guildId, 10L) }
+    }
+
+    @Test
+    fun `partial loss tributes on the actual lost portion only`() {
+        val user = userWithBalance(500L)
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns user
+        // LOW profile bucket 4: 0.4× — player keeps 40 from 100 stake,
+        // losing 60. Tribute = 10% of 60 = 6, not 10.
+        every { plinko.drop(Plinko.Risk.LOW, any()) } returns Plinko.Drop(
+            bucket = 4, multiplier = 0.4, risk = Plinko.Risk.LOW,
+        )
+        every { userService.updateUser(any()) } returns user
+        every { jackpotService.addToPool(guildId, any()) } returns 0L
+
+        val outcome = service.drop(discordId, guildId, stake = 100L, risk = Plinko.Risk.LOW)
+
+        val lose = assertInstanceOf(PlinkoService.DropOutcome.Lose::class.java, outcome)
+        assertEquals(40L, lose.payout, "0.4 × 100 = 40 retained")
+        assertEquals(-60L, lose.net, "net loss = -60")
+        assertEquals(440L, lose.newBalance)
+        verify(exactly = 1) { jackpotService.addToPool(guildId, 6L) }
+    }
+
+    @Test
+    fun `push neither tributes nor rolls jackpot`() {
+        val user = userWithBalance(500L)
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns user
+        every { plinko.drop(Plinko.Risk.LOW, any()) } returns Plinko.Drop(
+            bucket = 3, multiplier = 1.0, risk = Plinko.Risk.LOW,
+        )
+        every { userService.updateUser(any()) } returns user
+
+        val outcome = service.drop(discordId, guildId, stake = 100L, risk = Plinko.Risk.LOW)
+
+        val push = assertInstanceOf(PlinkoService.DropOutcome.Push::class.java, outcome)
+        assertEquals(100L, push.stake)
+        assertEquals(500L, push.newBalance, "stake returned in full — balance unchanged")
+        verify(exactly = 0) { jackpotService.addToPool(any(), any()) }
+        verify(exactly = 0) { jackpotService.awardJackpot(any(), any()) }
+    }
+
+    @Test
+    fun `insufficient credits is rejected without mutating balance`() {
+        val user = userWithBalance(50L)
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns user
+
+        val outcome = service.drop(discordId, guildId, stake = 100L, risk = Plinko.Risk.MEDIUM)
+
+        val rej = assertInstanceOf(PlinkoService.DropOutcome.InsufficientCredits::class.java, outcome)
+        assertEquals(100L, rej.stake)
+        assertEquals(50L, rej.have)
+        assertEquals(50L, user.socialCredit, "balance untouched on rejection")
+        verify(exactly = 0) { userService.updateUser(any()) }
+    }
+
+    @Test
+    fun `stake below MIN_STAKE is rejected before locking the user`() {
+        val outcome = service.drop(discordId, guildId, stake = Plinko.MIN_STAKE - 1, risk = Plinko.Risk.LOW)
+
+        assertInstanceOf(PlinkoService.DropOutcome.InvalidStake::class.java, outcome)
+        verify(exactly = 0) { userService.getUserByIdForUpdate(any(), any()) }
+    }
+
+    @Test
+    fun `stake above MAX_STAKE is rejected before locking the user`() {
+        val outcome = service.drop(discordId, guildId, stake = Plinko.MAX_STAKE + 1, risk = Plinko.Risk.LOW)
+
+        assertInstanceOf(PlinkoService.DropOutcome.InvalidStake::class.java, outcome)
+        verify(exactly = 0) { userService.getUserByIdForUpdate(any(), any()) }
+    }
+
+    @Test
+    fun `unknown user is rejected`() {
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns null
+
+        val outcome = service.drop(discordId, guildId, stake = 100L, risk = Plinko.Risk.LOW)
+
+        assertEquals(PlinkoService.DropOutcome.UnknownUser, outcome)
+        verify(exactly = 0) { userService.updateUser(any()) }
+    }
+
+    @Test
+    fun `win bucket on HIGH profile pays the configured 40x multiplier`() {
+        // Sanity: HIGH profile bucket 0 = 40×; a 100 stake nets +3900.
+        val user = userWithBalance(1_000L)
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns user
+        every { plinko.drop(Plinko.Risk.HIGH, any()) } returns Plinko.Drop(
+            bucket = 0, multiplier = 40.0, risk = Plinko.Risk.HIGH,
+        )
+        every { userService.updateUser(any()) } returns user
+
+        val outcome = service.drop(discordId, guildId, stake = 100L, risk = Plinko.Risk.HIGH)
+
+        val win = assertInstanceOf(PlinkoService.DropOutcome.Win::class.java, outcome)
+        assertEquals(4_000L, win.payout)
+        assertEquals(3_900L, win.net)
+        assertTrue(win.bucket == 0)
+    }
+}

--- a/database/src/test/kotlin/database/service/PlinkoServiceTest.kt
+++ b/database/src/test/kotlin/database/service/PlinkoServiceTest.kt
@@ -1,5 +1,6 @@
 package database.service
 
+import database.dto.ConfigDto
 import database.dto.UserDto
 import database.economy.Plinko
 import io.mockk.every
@@ -20,6 +21,7 @@ class PlinkoServiceTest {
     private lateinit var tradeService: EconomyTradeService
     private lateinit var marketService: TobyCoinMarketService
     private lateinit var configService: ConfigService
+    private lateinit var casinoEdgeService: CasinoEdgeService
     private lateinit var plinko: Plinko
     private lateinit var service: PlinkoService
 
@@ -33,10 +35,17 @@ class PlinkoServiceTest {
         tradeService = mockk(relaxed = true)
         marketService = mockk(relaxed = true)
         configService = mockk(relaxed = true)
+        casinoEdgeService = mockk(relaxed = true)
         plinko = mockk(relaxed = true)
+        // Default: pass the fair drop through untouched.
+        every {
+            casinoEdgeService.applyBotEdge<Plinko.Drop>(
+                any(), any(), any(), any(), any(), any(), any(), any(), any()
+            )
+        } answers { arg<Plinko.Drop>(7) }
         service = PlinkoService(
             userService, jackpotService, tradeService, marketService, configService,
-            plinko, Random(0)
+            casinoEdgeService, plinko, Random(0)
         )
     }
 
@@ -163,6 +172,58 @@ class PlinkoServiceTest {
 
         assertEquals(PlinkoService.DropOutcome.UnknownUser, outcome)
         verify(exactly = 0) { userService.updateUser(any()) }
+    }
+
+    @Test
+    fun `drop forwards bot signals + plinko gameKey + PLINKO config to CasinoEdgeService`() {
+        val user = userWithBalance(1_000L)
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns user
+        val fair = Plinko.Drop(bucket = 4, multiplier = 0.0, risk = Plinko.Risk.MEDIUM)
+        every { plinko.drop(Plinko.Risk.MEDIUM, any()) } returns fair
+
+        service.drop(
+            discordId, guildId, stake = 100L, risk = Plinko.Risk.MEDIUM,
+            clickX = 350, clickY = 220, mouseMoved = false,
+        )
+
+        verify(exactly = 1) {
+            casinoEdgeService.applyBotEdge(
+                discordId = discordId,
+                guildId = guildId,
+                gameKey = "plinko",
+                clickX = 350, clickY = 220, mouseMoved = false,
+                edgeMaxConfig = ConfigDto.Configurations.PLINKO_BOT_EDGE_MAX_PCT,
+                fairOutcome = fair,
+                asLoss = any(),
+            )
+        }
+    }
+
+    @Test
+    fun `forced-loss substitution lands on the worst-multiplier bucket for the risk profile`() {
+        // Verify the asLoss lambda invoked by the edge service produces a
+        // Drop whose multiplier is the minimum of the risk's payout table —
+        // so a forced bust is guaranteed regardless of the fair RNG.
+        val user = userWithBalance(1_000L)
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns user
+        val fairWin = Plinko.Drop(bucket = 0, multiplier = 40.0, risk = Plinko.Risk.HIGH)
+        every { plinko.drop(Plinko.Risk.HIGH, any()) } returns fairWin
+        every { plinko.payoutTable(Plinko.Risk.HIGH) } returns
+            Plinko.DEFAULT_PAYOUTS.getValue(Plinko.Risk.HIGH).copyOf()
+        val lossSlot = slot<() -> Plinko.Drop>()
+        every {
+            casinoEdgeService.applyBotEdge<Plinko.Drop>(
+                any(), any(), any(), any(), any(), any(), any(), any(),
+                asLoss = capture(lossSlot),
+            )
+        } answers { lossSlot.captured.invoke() }
+        every { userService.updateUser(any()) } returns user
+
+        val outcome = service.drop(discordId, guildId, stake = 100L, risk = Plinko.Risk.HIGH)
+
+        val lose = assertInstanceOf(PlinkoService.DropOutcome.Lose::class.java, outcome)
+        // HIGH profile min multiplier is 0.0 (buckets 3, 4, 5).
+        assertEquals(0.0, lose.multiplier, 1e-9, "forced-loss substitution must pick a 0× bucket on HIGH")
     }
 
     @Test

--- a/database/src/test/kotlin/database/service/WheelOfFortuneServiceTest.kt
+++ b/database/src/test/kotlin/database/service/WheelOfFortuneServiceTest.kt
@@ -1,0 +1,163 @@
+package database.service
+
+import database.dto.UserDto
+import database.economy.WheelOfFortune
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import kotlin.random.Random
+
+class WheelOfFortuneServiceTest {
+
+    private lateinit var userService: UserService
+    private lateinit var jackpotService: JackpotService
+    private lateinit var tradeService: EconomyTradeService
+    private lateinit var marketService: TobyCoinMarketService
+    private lateinit var configService: ConfigService
+    private lateinit var wheel: WheelOfFortune
+    private lateinit var service: WheelOfFortuneService
+
+    private val discordId = 100L
+    private val guildId = 200L
+
+    @BeforeEach
+    fun setup() {
+        userService = mockk(relaxed = true)
+        jackpotService = mockk(relaxed = true)
+        tradeService = mockk(relaxed = true)
+        marketService = mockk(relaxed = true)
+        configService = mockk(relaxed = true)
+        wheel = mockk(relaxed = true)
+        every { wheel.isValidPick(any()) } answers {
+            firstArg<Long>() in WheelOfFortune.PICKS
+        }
+        every { wheel.picks() } returns WheelOfFortune.PICKS
+        service = WheelOfFortuneService(
+            userService, jackpotService, tradeService, marketService, configService,
+            wheel, Random(0)
+        )
+    }
+
+    private fun userWithBalance(balance: Long): UserDto {
+        return UserDto(discordId, guildId).apply { socialCredit = balance }
+    }
+
+    @Test
+    fun `win debits stake and credits payout atomically`() {
+        val user = userWithBalance(1_000L)
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns user
+        every { wheel.spin(5L, any()) } returns WheelOfFortune.Spin(
+            landedMultiplier = 5L, pickedMultiplier = 5L
+        )
+        val captured = slot<UserDto>()
+        every { userService.updateUser(capture(captured)) } returns user
+
+        val outcome = service.spin(discordId, guildId, stake = 100L, pickedMultiplier = 5L)
+
+        val win = assertInstanceOf(WheelOfFortuneService.SpinOutcome.Win::class.java, outcome)
+        assertEquals(100L, win.stake)
+        assertEquals(5L, win.pickedMultiplier)
+        assertEquals(5L, win.landedMultiplier)
+        assertEquals(500L, win.payout)
+        assertEquals(400L, win.net)
+        assertEquals(1_400L, win.newBalance)
+        assertEquals(1_400L, captured.captured.socialCredit)
+    }
+
+    @Test
+    fun `loss debits stake only and tributes 10 percent into pool`() {
+        val user = userWithBalance(500L)
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns user
+        every { wheel.spin(5L, any()) } returns WheelOfFortune.Spin(
+            landedMultiplier = 2L, pickedMultiplier = 5L
+        )
+        every { userService.updateUser(any()) } returns user
+        every { jackpotService.addToPool(guildId, any()) } returns 0L
+
+        val outcome = service.spin(discordId, guildId, stake = 100L, pickedMultiplier = 5L)
+
+        val lose = assertInstanceOf(WheelOfFortuneService.SpinOutcome.Lose::class.java, outcome)
+        assertEquals(5L, lose.pickedMultiplier)
+        assertEquals(2L, lose.landedMultiplier)
+        assertEquals(400L, lose.newBalance)
+        assertEquals(10L, lose.lossTribute)
+        verify(exactly = 1) { jackpotService.addToPool(guildId, 10L) }
+    }
+
+    @Test
+    fun `invalid pick is rejected before locking the user`() {
+        every { wheel.isValidPick(7L) } returns false
+        every { wheel.picks() } returns WheelOfFortune.PICKS
+
+        val outcome = service.spin(discordId, guildId, stake = 100L, pickedMultiplier = 7L)
+
+        val rej = assertInstanceOf(WheelOfFortuneService.SpinOutcome.InvalidPick::class.java, outcome)
+        assertEquals(WheelOfFortune.PICKS, rej.picks)
+        verify(exactly = 0) { userService.getUserByIdForUpdate(any(), any()) }
+    }
+
+    @Test
+    fun `insufficient credits is rejected without mutating balance`() {
+        val user = userWithBalance(50L)
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns user
+
+        val outcome = service.spin(discordId, guildId, stake = 100L, pickedMultiplier = 2L)
+
+        val rej = assertInstanceOf(WheelOfFortuneService.SpinOutcome.InsufficientCredits::class.java, outcome)
+        assertEquals(100L, rej.stake)
+        assertEquals(50L, rej.have)
+        verify(exactly = 0) { userService.updateUser(any()) }
+    }
+
+    @Test
+    fun `stake below MIN_STAKE is rejected before locking the user`() {
+        val outcome = service.spin(
+            discordId, guildId, stake = WheelOfFortune.MIN_STAKE - 1, pickedMultiplier = 2L
+        )
+
+        assertInstanceOf(WheelOfFortuneService.SpinOutcome.InvalidStake::class.java, outcome)
+        verify(exactly = 0) { userService.getUserByIdForUpdate(any(), any()) }
+    }
+
+    @Test
+    fun `stake above MAX_STAKE is rejected before locking the user`() {
+        val outcome = service.spin(
+            discordId, guildId, stake = WheelOfFortune.MAX_STAKE + 1, pickedMultiplier = 2L
+        )
+
+        assertInstanceOf(WheelOfFortuneService.SpinOutcome.InvalidStake::class.java, outcome)
+        verify(exactly = 0) { userService.getUserByIdForUpdate(any(), any()) }
+    }
+
+    @Test
+    fun `unknown user is rejected`() {
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns null
+
+        val outcome = service.spin(discordId, guildId, stake = 100L, pickedMultiplier = 2L)
+
+        assertEquals(WheelOfFortuneService.SpinOutcome.UnknownUser, outcome)
+        verify(exactly = 0) { userService.updateUser(any()) }
+    }
+
+    @Test
+    fun `pick 10x landing 10x pays 10x stake`() {
+        val user = userWithBalance(1_000L)
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns user
+        every { wheel.spin(10L, any()) } returns WheelOfFortune.Spin(
+            landedMultiplier = 10L, pickedMultiplier = 10L
+        )
+        every { userService.updateUser(any()) } returns user
+
+        val outcome = service.spin(discordId, guildId, stake = 100L, pickedMultiplier = 10L)
+
+        val win = assertInstanceOf(WheelOfFortuneService.SpinOutcome.Win::class.java, outcome)
+        assertEquals(1_000L, win.payout)
+        assertEquals(900L, win.net)
+        assertEquals(1_900L, win.newBalance)
+    }
+}

--- a/database/src/test/kotlin/database/service/WheelOfFortuneServiceTest.kt
+++ b/database/src/test/kotlin/database/service/WheelOfFortuneServiceTest.kt
@@ -1,5 +1,6 @@
 package database.service
 
+import database.dto.ConfigDto
 import database.dto.UserDto
 import database.economy.WheelOfFortune
 import io.mockk.every
@@ -8,6 +9,7 @@ import io.mockk.slot
 import io.mockk.verify
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import kotlin.random.Random
@@ -19,6 +21,7 @@ class WheelOfFortuneServiceTest {
     private lateinit var tradeService: EconomyTradeService
     private lateinit var marketService: TobyCoinMarketService
     private lateinit var configService: ConfigService
+    private lateinit var casinoEdgeService: CasinoEdgeService
     private lateinit var wheel: WheelOfFortune
     private lateinit var service: WheelOfFortuneService
 
@@ -32,14 +35,21 @@ class WheelOfFortuneServiceTest {
         tradeService = mockk(relaxed = true)
         marketService = mockk(relaxed = true)
         configService = mockk(relaxed = true)
+        casinoEdgeService = mockk(relaxed = true)
         wheel = mockk(relaxed = true)
         every { wheel.isValidPick(any()) } answers {
             firstArg<Long>() in WheelOfFortune.PICKS
         }
         every { wheel.picks() } returns WheelOfFortune.PICKS
+        // Default: pass the fair spin through untouched.
+        every {
+            casinoEdgeService.applyBotEdge<WheelOfFortune.Spin>(
+                any(), any(), any(), any(), any(), any(), any(), any(), any()
+            )
+        } answers { arg<WheelOfFortune.Spin>(7) }
         service = WheelOfFortuneService(
             userService, jackpotService, tradeService, marketService, configService,
-            wheel, Random(0)
+            casinoEdgeService, wheel, Random(0)
         )
     }
 
@@ -142,6 +152,54 @@ class WheelOfFortuneServiceTest {
 
         assertEquals(WheelOfFortuneService.SpinOutcome.UnknownUser, outcome)
         verify(exactly = 0) { userService.updateUser(any()) }
+    }
+
+    @Test
+    fun `spin forwards bot signals + wheel gameKey + WHEEL_OF_FORTUNE config to CasinoEdgeService`() {
+        val user = userWithBalance(1_000L)
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns user
+        val fair = WheelOfFortune.Spin(landedMultiplier = 2L, pickedMultiplier = 5L)
+        every { wheel.spin(5L, any()) } returns fair
+
+        service.spin(
+            discordId, guildId, stake = 100L, pickedMultiplier = 5L,
+            clickX = 350, clickY = 220, mouseMoved = false,
+        )
+
+        verify(exactly = 1) {
+            casinoEdgeService.applyBotEdge(
+                discordId = discordId,
+                guildId = guildId,
+                gameKey = "wheel",
+                clickX = 350, clickY = 220, mouseMoved = false,
+                edgeMaxConfig = ConfigDto.Configurations.WHEEL_OF_FORTUNE_BOT_EDGE_MAX_PCT,
+                fairOutcome = fair,
+                asLoss = any(),
+            )
+        }
+    }
+
+    @Test
+    fun `forced-loss substitution lands on a non-picked multiplier`() {
+        val user = userWithBalance(1_000L)
+        every { userService.getUserByIdForUpdate(discordId, guildId) } returns user
+        // Fair RNG would win — force a substituted loss instead.
+        val fairWin = WheelOfFortune.Spin(landedMultiplier = 5L, pickedMultiplier = 5L)
+        every { wheel.spin(5L, any()) } returns fairWin
+        val lossSlot = slot<() -> WheelOfFortune.Spin>()
+        every {
+            casinoEdgeService.applyBotEdge<WheelOfFortune.Spin>(
+                any(), any(), any(), any(), any(), any(), any(), any(),
+                asLoss = capture(lossSlot),
+            )
+        } answers { lossSlot.captured.invoke() }
+        every { userService.updateUser(any()) } returns user
+
+        val outcome = service.spin(discordId, guildId, stake = 100L, pickedMultiplier = 5L)
+
+        val lose = assertInstanceOf(WheelOfFortuneService.SpinOutcome.Lose::class.java, outcome)
+        assertEquals(5L, lose.pickedMultiplier)
+        assertNotEquals(5L, lose.landedMultiplier, "forced-loss must land on a non-picked multiplier")
     }
 
     @Test

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/PlinkoCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/PlinkoCommand.kt
@@ -7,7 +7,6 @@ import database.service.PlinkoService
 import database.service.PlinkoService.DropOutcome
 import net.dv8tion.jda.api.EmbedBuilder
 import net.dv8tion.jda.api.interactions.commands.OptionType
-import net.dv8tion.jda.api.interactions.commands.build.Choice
 import net.dv8tion.jda.api.interactions.commands.build.OptionData
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
@@ -37,7 +36,7 @@ class PlinkoCommand @Autowired constructor(
 
     override val optionData: List<OptionData> = listOf(
         OptionData(OptionType.STRING, OPT_RISK, "Risk profile (LOW / MEDIUM / HIGH)", true)
-            .addChoices(Plinko.Risk.entries.map { Choice(it.name, it.name) }),
+            .also { opt -> Plinko.Risk.entries.forEach { opt.addChoice(it.name, it.name) } },
         OptionData(OptionType.INTEGER, OPT_STAKE, "Credits to wager (per-guild bounds; service rejects out-of-range)", true)
             .setMinValue(1L)
     )
@@ -67,16 +66,16 @@ class PlinkoCommand @Autowired constructor(
 
     private fun embedFor(outcome: DropOutcome) = when (outcome) {
         is DropOutcome.Win -> EmbedBuilder()
-            .setTitle("🟢 Bucket ${outcome.bucket} &middot; ${formatMult(outcome.multiplier)}")
-            .setDescription("Risk **${outcome.risk}** &middot; won **+${outcome.net} credits**.")
+            .setTitle("🟢 Bucket ${outcome.bucket} · ${formatMult(outcome.multiplier)}")
+            .setDescription("Risk **${outcome.risk}** · won **+${outcome.net} credits**.")
             .addField("New balance", "${outcome.newBalance} credits", true)
             .setColor(WagerCommandColors.WIN)
             .build()
 
         is DropOutcome.Lose -> EmbedBuilder()
-            .setTitle("🟢 Bucket ${outcome.bucket} &middot; ${formatMult(outcome.multiplier)}")
+            .setTitle("🟢 Bucket ${outcome.bucket} · ${formatMult(outcome.multiplier)}")
             .setDescription(
-                "Risk **${outcome.risk}** &middot; lost **${-outcome.net} credits**" +
+                "Risk **${outcome.risk}** · lost **${-outcome.net} credits**" +
                     if (outcome.payout > 0L) " (kept ${outcome.payout})." else "."
             )
             .addField("New balance", "${outcome.newBalance} credits", true)
@@ -84,8 +83,8 @@ class PlinkoCommand @Autowired constructor(
             .build()
 
         is DropOutcome.Push -> EmbedBuilder()
-            .setTitle("🟢 Bucket ${outcome.bucket} &middot; 1×")
-            .setDescription("Risk **${outcome.risk}** &middot; stake refunded.")
+            .setTitle("🟢 Bucket ${outcome.bucket} · 1×")
+            .setDescription("Risk **${outcome.risk}** · stake refunded.")
             .addField("New balance", "${outcome.newBalance} credits", true)
             .setColor(WagerCommandColors.LOSE)
             .build()

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/PlinkoCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/PlinkoCommand.kt
@@ -1,0 +1,110 @@
+package bot.toby.command.commands.economy
+
+import core.command.CommandContext
+import database.dto.UserDto
+import database.economy.Plinko
+import database.service.PlinkoService
+import database.service.PlinkoService.DropOutcome
+import net.dv8tion.jda.api.EmbedBuilder
+import net.dv8tion.jda.api.interactions.commands.OptionType
+import net.dv8tion.jda.api.interactions.commands.build.Choice
+import net.dv8tion.jda.api.interactions.commands.build.OptionData
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+/**
+ * `/plinko risk:<LOW|MEDIUM|HIGH> stake:<int>` — drop a ball through an
+ * 8-row peg board into one of 9 buckets. Higher risk profiles widen the
+ * outer multipliers and add bust buckets in the middle. Calls through
+ * to [PlinkoService.drop]; same path the web `/casino/{guildId}/plinko`
+ * page uses, so the two surfaces can't drift on payout maths.
+ */
+@Component
+class PlinkoCommand @Autowired constructor(
+    private val plinkoService: PlinkoService
+) : EconomyCommand {
+
+    override val name: String = "plinko"
+    override val description: String =
+        "Drop a ball through ${Plinko.ROWS} rows into one of ${Plinko.BUCKETS} buckets. " +
+            "Stake bounds are per-guild (default ${Plinko.MIN_STAKE}-${Plinko.MAX_STAKE})."
+
+    companion object {
+        private const val OPT_RISK = "risk"
+        private const val OPT_STAKE = "stake"
+        private const val TITLE = "🟢 Plinko"
+    }
+
+    override val optionData: List<OptionData> = listOf(
+        OptionData(OptionType.STRING, OPT_RISK, "Risk profile (LOW / MEDIUM / HIGH)", true)
+            .addChoices(Plinko.Risk.entries.map { Choice(it.name, it.name) }),
+        OptionData(OptionType.INTEGER, OPT_STAKE, "Credits to wager (per-guild bounds; service rejects out-of-range)", true)
+            .setMinValue(1L)
+    )
+
+    override fun handle(ctx: CommandContext, requestingUserDto: UserDto, deleteDelay: Int) {
+        val event = ctx.event
+        event.deferReply().queue()
+
+        val guild = WagerCommandEmbeds.requireGuild(event, TITLE, deleteDelay) ?: return
+        val riskName = WagerCommandEmbeds.requireOption(
+            event, TITLE, OPT_RISK, "Pick a risk profile.", deleteDelay
+        )?.asString ?: return
+        val risk = Plinko.Risk.entries.firstOrNull { it.name == riskName.uppercase() } ?: run {
+            WagerCommandEmbeds.replyError(
+                event, TITLE,
+                "Risk must be one of ${Plinko.Risk.entries.joinToString { it.name }}.",
+                deleteDelay
+            ); return
+        }
+        val stake = WagerCommandEmbeds.requireOption(
+            event, TITLE, OPT_STAKE, "You must specify a stake.", deleteDelay
+        )?.asLong ?: return
+
+        val outcome = plinkoService.drop(requestingUserDto.discordId, guild.idLong, stake, risk)
+        WagerCommandEmbeds.reply(event, embedFor(outcome), deleteDelay)
+    }
+
+    private fun embedFor(outcome: DropOutcome) = when (outcome) {
+        is DropOutcome.Win -> EmbedBuilder()
+            .setTitle("🟢 Bucket ${outcome.bucket} &middot; ${formatMult(outcome.multiplier)}")
+            .setDescription("Risk **${outcome.risk}** &middot; won **+${outcome.net} credits**.")
+            .addField("New balance", "${outcome.newBalance} credits", true)
+            .setColor(WagerCommandColors.WIN)
+            .build()
+
+        is DropOutcome.Lose -> EmbedBuilder()
+            .setTitle("🟢 Bucket ${outcome.bucket} &middot; ${formatMult(outcome.multiplier)}")
+            .setDescription(
+                "Risk **${outcome.risk}** &middot; lost **${-outcome.net} credits**" +
+                    if (outcome.payout > 0L) " (kept ${outcome.payout})." else "."
+            )
+            .addField("New balance", "${outcome.newBalance} credits", true)
+            .setColor(WagerCommandColors.LOSE)
+            .build()
+
+        is DropOutcome.Push -> EmbedBuilder()
+            .setTitle("🟢 Bucket ${outcome.bucket} &middot; 1×")
+            .setDescription("Risk **${outcome.risk}** &middot; stake refunded.")
+            .addField("New balance", "${outcome.newBalance} credits", true)
+            .setColor(WagerCommandColors.LOSE)
+            .build()
+
+        is DropOutcome.InsufficientCredits -> WagerCommandEmbeds.failureEmbed(
+            TITLE, WagerCommandFailure.InsufficientCredits(outcome.stake, outcome.have)
+        )
+        is DropOutcome.InsufficientCoinsForTopUp -> WagerCommandEmbeds.failureEmbed(
+            TITLE, WagerCommandFailure.InsufficientCoinsForTopUp(outcome.needed, outcome.have)
+        )
+        is DropOutcome.InvalidStake -> WagerCommandEmbeds.failureEmbed(
+            TITLE, WagerCommandFailure.InvalidStake(outcome.min, outcome.max)
+        )
+        DropOutcome.UnknownUser -> WagerCommandEmbeds.failureEmbed(TITLE, WagerCommandFailure.UnknownUser)
+    }
+
+    // Trim trailing zeros so 1.0× shows as "1×", 0.4× stays "0.4×".
+    private fun formatMult(m: Double): String {
+        if (m == m.toLong().toDouble()) return "${m.toLong()}×"
+        return "${"%.2f".format(m).trimEnd('0').trimEnd('.')}×"
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/PlinkoCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/PlinkoCommand.kt
@@ -25,8 +25,8 @@ class PlinkoCommand @Autowired constructor(
 
     override val name: String = "plinko"
     override val description: String =
-        "Drop a ball through ${Plinko.ROWS} rows into one of ${Plinko.BUCKETS} buckets. " +
-            "Stake bounds are per-guild (default ${Plinko.MIN_STAKE}-${Plinko.MAX_STAKE})."
+        "Drop a ball through ${Plinko.ROWS} rows into ${Plinko.BUCKETS} buckets. " +
+            "Stake bounds per-guild (default ${Plinko.MIN_STAKE}-${Plinko.MAX_STAKE})."
 
     companion object {
         private const val OPT_RISK = "risk"

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/WheelOfFortuneCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/WheelOfFortuneCommand.kt
@@ -1,0 +1,93 @@
+package bot.toby.command.commands.economy
+
+import core.command.CommandContext
+import database.dto.UserDto
+import database.economy.WheelOfFortune
+import database.service.WheelOfFortuneService
+import database.service.WheelOfFortuneService.SpinOutcome
+import net.dv8tion.jda.api.EmbedBuilder
+import net.dv8tion.jda.api.interactions.commands.OptionType
+import net.dv8tion.jda.api.interactions.commands.build.Choice
+import net.dv8tion.jda.api.interactions.commands.build.OptionData
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+/**
+ * `/wheel pick:<multiplier> stake:<int>` — pick a multiplier, spin the
+ * Wheel of Fortune. Win `pick × stake` only if the wheel lands on the
+ * chosen multiplier; otherwise the stake is lost. Calls through to
+ * [WheelOfFortuneService.spin]; same path the web
+ * `/casino/{guildId}/wheel` page uses.
+ */
+@Component
+class WheelOfFortuneCommand @Autowired constructor(
+    private val wheelService: WheelOfFortuneService
+) : EconomyCommand {
+
+    override val name: String = "wheel"
+    override val description: String =
+        "Pick a multiplier, spin the wheel. Per-pick RTPs cluster around 0.88. " +
+            "Stake bounds are per-guild (default ${WheelOfFortune.MIN_STAKE}-${WheelOfFortune.MAX_STAKE})."
+
+    companion object {
+        private const val OPT_PICK = "pick"
+        private const val OPT_STAKE = "stake"
+        private const val TITLE = "🎡 Wheel of Fortune"
+    }
+
+    override val optionData: List<OptionData> = listOf(
+        OptionData(OptionType.INTEGER, OPT_PICK, "Multiplier to bet on", true)
+            .addChoices(WheelOfFortune.PICKS.map { Choice("${it}×", it) }),
+        OptionData(OptionType.INTEGER, OPT_STAKE, "Credits to wager (per-guild bounds; service rejects out-of-range)", true)
+            .setMinValue(1L)
+    )
+
+    override fun handle(ctx: CommandContext, requestingUserDto: UserDto, deleteDelay: Int) {
+        val event = ctx.event
+        event.deferReply().queue()
+
+        val guild = WagerCommandEmbeds.requireGuild(event, TITLE, deleteDelay) ?: return
+        val pick = WagerCommandEmbeds.requireOption(
+            event, TITLE, OPT_PICK, "Pick a multiplier.", deleteDelay
+        )?.asLong ?: return
+        val stake = WagerCommandEmbeds.requireOption(
+            event, TITLE, OPT_STAKE, "You must specify a stake.", deleteDelay
+        )?.asLong ?: return
+
+        val outcome = wheelService.spin(requestingUserDto.discordId, guild.idLong, stake, pick)
+        WagerCommandEmbeds.reply(event, embedFor(outcome), deleteDelay)
+    }
+
+    private fun embedFor(outcome: SpinOutcome) = when (outcome) {
+        is SpinOutcome.Win -> EmbedBuilder()
+            .setTitle("🎡 Landed ${outcome.landedMultiplier}×")
+            .setDescription(
+                "You picked **${outcome.pickedMultiplier}×** and won " +
+                    "**+${outcome.net} credits** on a ${outcome.stake} stake."
+            )
+            .addField("New balance", "${outcome.newBalance} credits", true)
+            .setColor(WagerCommandColors.WIN)
+            .build()
+
+        is SpinOutcome.Lose -> EmbedBuilder()
+            .setTitle("🎡 Landed ${outcome.landedMultiplier}×")
+            .setDescription("You picked **${outcome.pickedMultiplier}×**. Lost **${outcome.stake} credits**.")
+            .addField("New balance", "${outcome.newBalance} credits", true)
+            .setColor(WagerCommandColors.LOSE)
+            .build()
+
+        is SpinOutcome.InsufficientCredits -> WagerCommandEmbeds.failureEmbed(
+            TITLE, WagerCommandFailure.InsufficientCredits(outcome.stake, outcome.have)
+        )
+        is SpinOutcome.InsufficientCoinsForTopUp -> WagerCommandEmbeds.failureEmbed(
+            TITLE, WagerCommandFailure.InsufficientCoinsForTopUp(outcome.needed, outcome.have)
+        )
+        is SpinOutcome.InvalidStake -> WagerCommandEmbeds.failureEmbed(
+            TITLE, WagerCommandFailure.InvalidStake(outcome.min, outcome.max)
+        )
+        is SpinOutcome.InvalidPick -> WagerCommandEmbeds.errorEmbed(
+            TITLE, "Pick must be one of ${outcome.picks.joinToString { "${it}×" }}."
+        )
+        SpinOutcome.UnknownUser -> WagerCommandEmbeds.failureEmbed(TITLE, WagerCommandFailure.UnknownUser)
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/WheelOfFortuneCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/WheelOfFortuneCommand.kt
@@ -7,7 +7,6 @@ import database.service.WheelOfFortuneService
 import database.service.WheelOfFortuneService.SpinOutcome
 import net.dv8tion.jda.api.EmbedBuilder
 import net.dv8tion.jda.api.interactions.commands.OptionType
-import net.dv8tion.jda.api.interactions.commands.build.Choice
 import net.dv8tion.jda.api.interactions.commands.build.OptionData
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
@@ -37,7 +36,7 @@ class WheelOfFortuneCommand @Autowired constructor(
 
     override val optionData: List<OptionData> = listOf(
         OptionData(OptionType.INTEGER, OPT_PICK, "Multiplier to bet on", true)
-            .addChoices(WheelOfFortune.PICKS.map { Choice("${it}×", it) }),
+            .also { opt -> WheelOfFortune.PICKS.forEach { opt.addChoice("${it}×", it) } },
         OptionData(OptionType.INTEGER, OPT_STAKE, "Credits to wager (per-guild bounds; service rejects out-of-range)", true)
             .setMinValue(1L)
     )

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/WheelOfFortuneCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/WheelOfFortuneCommand.kt
@@ -25,8 +25,8 @@ class WheelOfFortuneCommand @Autowired constructor(
 
     override val name: String = "wheel"
     override val description: String =
-        "Pick a multiplier, spin the wheel. Per-pick RTPs cluster around 0.88. " +
-            "Stake bounds are per-guild (default ${WheelOfFortune.MIN_STAKE}-${WheelOfFortune.MAX_STAKE})."
+        "Pick a multiplier, spin the wheel. Stake bounds per-guild " +
+            "(default ${WheelOfFortune.MIN_STAKE}-${WheelOfFortune.MAX_STAKE})."
 
     companion object {
         private const val OPT_PICK = "pick"

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/economy/PlinkoCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/economy/PlinkoCommandTest.kt
@@ -1,0 +1,143 @@
+package bot.toby.command.commands.economy
+
+import bot.toby.command.CommandTest
+import bot.toby.command.CommandTest.Companion.event
+import bot.toby.command.CommandTest.Companion.guild
+import bot.toby.command.DefaultCommandContext
+import database.dto.UserDto
+import database.economy.Plinko
+import database.service.PlinkoService
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import net.dv8tion.jda.api.interactions.commands.OptionMapping
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class PlinkoCommandTest : CommandTest {
+    private lateinit var plinkoService: PlinkoService
+    private lateinit var command: PlinkoCommand
+
+    private val discordId = 1L
+    private val guildId = 42L
+
+    @BeforeEach
+    fun setUp() {
+        setUpCommonMocks()
+        plinkoService = mockk(relaxed = true)
+        command = PlinkoCommand(plinkoService)
+        every { guild.idLong } returns guildId
+    }
+
+    @AfterEach
+    fun tearDown() {
+        tearDownCommonMocks()
+        clearAllMocks()
+    }
+
+    private fun longOpt(value: Long): OptionMapping = mockk<OptionMapping>(relaxed = true).also {
+        every { it.asLong } returns value
+    }
+
+    private fun stringOpt(value: String): OptionMapping = mockk<OptionMapping>(relaxed = true).also {
+        every { it.asString } returns value
+    }
+
+    @Test
+    fun `delegates to PlinkoService with risk and stake`() {
+        val user = UserDto(discordId = discordId, guildId = guildId)
+        every { event.getOption("risk") } returns stringOpt("MEDIUM")
+        every { event.getOption("stake") } returns longOpt(50L)
+        every { plinkoService.drop(discordId, guildId, 50L, Plinko.Risk.MEDIUM) } returns
+            PlinkoService.DropOutcome.Lose(
+                stake = 50L, risk = Plinko.Risk.MEDIUM, bucket = 4, multiplier = 0.0,
+                payout = 0L, net = -50L, newBalance = 950L,
+            )
+
+        command.handle(DefaultCommandContext(event), user, 5)
+
+        verify(exactly = 1) { plinkoService.drop(discordId, guildId, 50L, Plinko.Risk.MEDIUM) }
+    }
+
+    @Test
+    fun `risk is case-insensitive`() {
+        val user = UserDto(discordId = discordId, guildId = guildId)
+        every { event.getOption("risk") } returns stringOpt("high")
+        every { event.getOption("stake") } returns longOpt(100L)
+        every { plinkoService.drop(discordId, guildId, 100L, Plinko.Risk.HIGH) } returns
+            PlinkoService.DropOutcome.Push(
+                stake = 100L, risk = Plinko.Risk.HIGH, bucket = 3, newBalance = 1_000L,
+            )
+
+        command.handle(DefaultCommandContext(event), user, 5)
+
+        verify(exactly = 1) { plinkoService.drop(discordId, guildId, 100L, Plinko.Risk.HIGH) }
+    }
+
+    @Test
+    fun `unknown risk does not call the service`() {
+        val user = UserDto(discordId = discordId, guildId = guildId)
+        every { event.getOption("risk") } returns stringOpt("XTREME")
+        every { event.getOption("stake") } returns longOpt(100L)
+
+        command.handle(DefaultCommandContext(event), user, 5)
+
+        verify(exactly = 0) { plinkoService.drop(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `replies with embed on each outcome variant`() {
+        val user = UserDto(discordId = discordId, guildId = guildId)
+        every { event.getOption("risk") } returns stringOpt("LOW")
+        every { event.getOption("stake") } returns longOpt(100L)
+
+        val outcomes = listOf<PlinkoService.DropOutcome>(
+            PlinkoService.DropOutcome.Win(
+                stake = 100L, risk = Plinko.Risk.LOW, bucket = 0, multiplier = 1.9,
+                payout = 190L, net = 90L, newBalance = 1_090L,
+            ),
+            PlinkoService.DropOutcome.Lose(
+                stake = 100L, risk = Plinko.Risk.LOW, bucket = 4, multiplier = 0.4,
+                payout = 40L, net = -60L, newBalance = 940L,
+            ),
+            PlinkoService.DropOutcome.Push(
+                stake = 100L, risk = Plinko.Risk.LOW, bucket = 3, newBalance = 1_000L,
+            ),
+            PlinkoService.DropOutcome.InsufficientCredits(stake = 100L, have = 50L),
+            PlinkoService.DropOutcome.InvalidStake(min = 10L, max = 500L),
+            PlinkoService.DropOutcome.UnknownUser,
+        )
+        outcomes.forEach { outcome ->
+            every { plinkoService.drop(any(), any(), any(), any()) } returns outcome
+            command.handle(DefaultCommandContext(event), user, 5)
+        }
+
+        verify(atLeast = outcomes.size) {
+            event.hook.sendMessageEmbeds(any<net.dv8tion.jda.api.entities.MessageEmbed>())
+        }
+    }
+
+    @Test
+    fun `missing risk option short-circuits`() {
+        val user = UserDto(discordId = discordId, guildId = guildId)
+        every { event.getOption("risk") } returns null
+        every { event.getOption("stake") } returns longOpt(100L)
+
+        command.handle(DefaultCommandContext(event), user, 5)
+
+        verify(exactly = 0) { plinkoService.drop(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `missing stake option short-circuits`() {
+        val user = UserDto(discordId = discordId, guildId = guildId)
+        every { event.getOption("risk") } returns stringOpt("LOW")
+        every { event.getOption("stake") } returns null
+
+        command.handle(DefaultCommandContext(event), user, 5)
+
+        verify(exactly = 0) { plinkoService.drop(any(), any(), any(), any()) }
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/economy/WheelOfFortuneCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/economy/WheelOfFortuneCommandTest.kt
@@ -1,0 +1,111 @@
+package bot.toby.command.commands.economy
+
+import bot.toby.command.CommandTest
+import bot.toby.command.CommandTest.Companion.event
+import bot.toby.command.CommandTest.Companion.guild
+import bot.toby.command.DefaultCommandContext
+import database.dto.UserDto
+import database.economy.WheelOfFortune
+import database.service.WheelOfFortuneService
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import net.dv8tion.jda.api.interactions.commands.OptionMapping
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class WheelOfFortuneCommandTest : CommandTest {
+    private lateinit var wheelService: WheelOfFortuneService
+    private lateinit var command: WheelOfFortuneCommand
+
+    private val discordId = 1L
+    private val guildId = 42L
+
+    @BeforeEach
+    fun setUp() {
+        setUpCommonMocks()
+        wheelService = mockk(relaxed = true)
+        command = WheelOfFortuneCommand(wheelService)
+        every { guild.idLong } returns guildId
+    }
+
+    @AfterEach
+    fun tearDown() {
+        tearDownCommonMocks()
+        clearAllMocks()
+    }
+
+    private fun longOpt(value: Long): OptionMapping = mockk<OptionMapping>(relaxed = true).also {
+        every { it.asLong } returns value
+    }
+
+    @Test
+    fun `delegates to WheelOfFortuneService with pick and stake`() {
+        val user = UserDto(discordId = discordId, guildId = guildId)
+        every { event.getOption("pick") } returns longOpt(5L)
+        every { event.getOption("stake") } returns longOpt(50L)
+        every { wheelService.spin(discordId, guildId, 50L, 5L) } returns
+            WheelOfFortuneService.SpinOutcome.Lose(
+                stake = 50L, pickedMultiplier = 5L, landedMultiplier = 2L,
+                newBalance = 950L, lossTribute = 5L,
+            )
+
+        command.handle(DefaultCommandContext(event), user, 5)
+
+        verify(exactly = 1) { wheelService.spin(discordId, guildId, 50L, 5L) }
+    }
+
+    @Test
+    fun `replies with embed on each outcome variant`() {
+        val user = UserDto(discordId = discordId, guildId = guildId)
+        every { event.getOption("pick") } returns longOpt(2L)
+        every { event.getOption("stake") } returns longOpt(100L)
+
+        val outcomes = listOf<WheelOfFortuneService.SpinOutcome>(
+            WheelOfFortuneService.SpinOutcome.Win(
+                stake = 100L, pickedMultiplier = 2L, landedMultiplier = 2L,
+                payout = 200L, net = 100L, newBalance = 1_100L,
+            ),
+            WheelOfFortuneService.SpinOutcome.Lose(
+                stake = 100L, pickedMultiplier = 2L, landedMultiplier = 5L,
+                newBalance = 900L,
+            ),
+            WheelOfFortuneService.SpinOutcome.InsufficientCredits(stake = 100L, have = 50L),
+            WheelOfFortuneService.SpinOutcome.InvalidStake(min = 10L, max = 500L),
+            WheelOfFortuneService.SpinOutcome.InvalidPick(picks = WheelOfFortune.PICKS),
+            WheelOfFortuneService.SpinOutcome.UnknownUser,
+        )
+        outcomes.forEach { outcome ->
+            every { wheelService.spin(any(), any(), any(), any()) } returns outcome
+            command.handle(DefaultCommandContext(event), user, 5)
+        }
+
+        verify(atLeast = outcomes.size) {
+            event.hook.sendMessageEmbeds(any<net.dv8tion.jda.api.entities.MessageEmbed>())
+        }
+    }
+
+    @Test
+    fun `missing pick option short-circuits`() {
+        val user = UserDto(discordId = discordId, guildId = guildId)
+        every { event.getOption("pick") } returns null
+        every { event.getOption("stake") } returns longOpt(100L)
+
+        command.handle(DefaultCommandContext(event), user, 5)
+
+        verify(exactly = 0) { wheelService.spin(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `missing stake option short-circuits`() {
+        val user = UserDto(discordId = discordId, guildId = guildId)
+        every { event.getOption("pick") } returns longOpt(2L)
+        every { event.getOption("stake") } returns null
+
+        command.handle(DefaultCommandContext(event), user, 5)
+
+        verify(exactly = 0) { wheelService.spin(any(), any(), any(), any()) }
+    }
+}

--- a/web/src/main/kotlin/web/casino/StakeBounds.kt
+++ b/web/src/main/kotlin/web/casino/StakeBounds.kt
@@ -6,9 +6,11 @@ import database.economy.Coinflip
 import database.economy.Dice
 import database.economy.Highlow
 import database.economy.Keno
+import database.economy.Plinko
 import database.economy.Roulette
 import database.economy.ScratchCard
 import database.economy.SlotMachine
+import database.economy.WheelOfFortune
 import database.blackjack.Blackjack
 import database.poker.CasinoHoldem
 import database.service.ConfigService
@@ -92,6 +94,22 @@ class StakeBounds(
         ConfigDto.Configurations.ROULETTE_MAX_STAKE,
         Roulette.MIN_STAKE,
         Roulette.MAX_STAKE,
+    )
+
+    fun plinko(guildId: Long): Pair<Long, Long> = read(
+        guildId,
+        ConfigDto.Configurations.PLINKO_MIN_STAKE,
+        ConfigDto.Configurations.PLINKO_MAX_STAKE,
+        Plinko.MIN_STAKE,
+        Plinko.MAX_STAKE,
+    )
+
+    fun wheelOfFortune(guildId: Long): Pair<Long, Long> = read(
+        guildId,
+        ConfigDto.Configurations.WHEEL_OF_FORTUNE_MIN_STAKE,
+        ConfigDto.Configurations.WHEEL_OF_FORTUNE_MAX_STAKE,
+        WheelOfFortune.MIN_STAKE,
+        WheelOfFortune.MAX_STAKE,
     )
 
     fun blackjackSolo(guildId: Long): Pair<Long, Long> = read(

--- a/web/src/main/kotlin/web/controller/PlinkoController.kt
+++ b/web/src/main/kotlin/web/controller/PlinkoController.kt
@@ -1,0 +1,175 @@
+package web.controller
+
+import common.casino.CasinoCommonFailure
+import database.economy.Plinko
+import database.service.JackpotGame
+import database.service.PlinkoService
+import database.service.PlinkoService.DropOutcome
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.security.oauth2.core.user.OAuth2User
+import org.springframework.stereotype.Controller
+import org.springframework.ui.Model
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseBody
+import org.springframework.web.servlet.mvc.support.RedirectAttributes
+import web.casino.CasinoOutcomeMapper
+import web.casino.CasinoPageContext
+import web.casino.CasinoResponseLike
+import web.casino.StakeBounds
+import web.casino.renderMinigamePage
+import web.service.EconomyWebService
+import web.util.WebGuildAccess
+import web.util.positiveOrNull
+
+/**
+ * Web surface for the `/plinko` minigame. GET renders the picker UI
+ * with the three risk profiles; POST runs the drop via [PlinkoService.drop]
+ * and returns JSON for the JS animation to settle the ball.
+ *
+ * Both surfaces share [PlinkoService] so Discord and web can't drift on
+ * payout maths, debit/credit semantics, or stake bounds.
+ */
+@Controller
+@RequestMapping("/casino/{guildId}/plinko")
+class PlinkoController(
+    private val plinkoService: PlinkoService,
+    private val economyWebService: EconomyWebService,
+    private val pageContext: CasinoPageContext,
+    private val stakeBounds: StakeBounds,
+) {
+
+    private val errors = CasinoOutcomeMapper { msg -> DropResponse(false, msg) }
+
+    @GetMapping
+    fun page(
+        @PathVariable guildId: Long,
+        @AuthenticationPrincipal user: OAuth2User,
+        model: Model,
+        ra: RedirectAttributes
+    ): String = pageContext.renderMinigamePage(
+        user, guildId, economyWebService, model, ra,
+        template = "plinko",
+        game = JackpotGame.PLINKO,
+    ) {
+        val (minStake, maxStake) = stakeBounds.plinko(guildId)
+        addAttribute("minStake", minStake)
+        addAttribute("maxStake", maxStake)
+        addAttribute("rows", Plinko.ROWS)
+        addAttribute("buckets", Plinko.BUCKETS)
+        addAttribute("risks", Plinko.Risk.entries.map { it.name })
+        // Each profile's payout table, indexed by bucket left-to-right.
+        // Template renders as a small badge row per risk.
+        addAttribute(
+            "payoutTables",
+            Plinko.DEFAULT_PAYOUTS.mapValues { (_, arr) -> arr.toList() }
+                .mapKeys { it.key.name }
+        )
+    }
+
+    @PostMapping("/drop")
+    @ResponseBody
+    fun drop(
+        @PathVariable guildId: Long,
+        @RequestBody request: DropRequest,
+        @AuthenticationPrincipal user: OAuth2User
+    ): ResponseEntity<DropResponse> = WebGuildAccess.requireMemberForJson(
+        user, guildId, economyWebService, errorBuilder = errors.errorBuilder
+    ) { discordId ->
+        val risk = parseRisk(request.risk)
+            ?: return@requireMemberForJson errors.badRequest(
+                "Risk must be one of ${Plinko.Risk.entries.joinToString { it.name }}."
+            )
+        when (val outcome = plinkoService.drop(
+            discordId, guildId, request.stake, risk, request.autoTopUp,
+        )) {
+            is DropOutcome.Win -> ResponseEntity.ok(
+                DropResponse(
+                    ok = true,
+                    risk = outcome.risk.name,
+                    bucket = outcome.bucket,
+                    multiplier = outcome.multiplier,
+                    payout = outcome.payout,
+                    net = outcome.net,
+                    newBalance = outcome.newBalance,
+                    win = true,
+                    push = false,
+                    jackpotPayout = outcome.jackpotPayout.positiveOrNull(),
+                    jackpotTierIndex = outcome.jackpotTierIndex.takeIf { it >= 0 },
+                    jackpotTierPayoutPct = outcome.jackpotTierPayoutPct.takeIf { it > 0.0 },
+                    soldTobyCoins = outcome.soldTobyCoins.positiveOrNull(),
+                    newPrice = outcome.newPrice,
+                )
+            )
+
+            is DropOutcome.Lose -> ResponseEntity.ok(
+                DropResponse(
+                    ok = true,
+                    risk = outcome.risk.name,
+                    bucket = outcome.bucket,
+                    multiplier = outcome.multiplier,
+                    payout = outcome.payout,
+                    net = outcome.net,
+                    newBalance = outcome.newBalance,
+                    win = false,
+                    push = false,
+                    soldTobyCoins = outcome.soldTobyCoins.positiveOrNull(),
+                    newPrice = outcome.newPrice,
+                    lossTribute = outcome.lossTribute.positiveOrNull(),
+                )
+            )
+
+            is DropOutcome.Push -> ResponseEntity.ok(
+                DropResponse(
+                    ok = true,
+                    risk = outcome.risk.name,
+                    bucket = outcome.bucket,
+                    multiplier = 1.0,
+                    payout = outcome.stake,
+                    net = 0L,
+                    newBalance = outcome.newBalance,
+                    win = false,
+                    push = true,
+                    soldTobyCoins = outcome.soldTobyCoins.positiveOrNull(),
+                    newPrice = outcome.newPrice,
+                )
+            )
+
+            is CasinoCommonFailure -> errors.mapCommonFailure(outcome)
+        }
+    }
+
+    private fun parseRisk(value: String?): Plinko.Risk? = value
+        ?.trim()
+        ?.uppercase()
+        ?.let { name -> Plinko.Risk.entries.firstOrNull { it.name == name } }
+}
+
+data class DropRequest(
+    val stake: Long = 0,
+    val risk: String? = null,
+    val autoTopUp: Boolean = false,
+)
+
+data class DropResponse(
+    override val ok: Boolean,
+    override val error: String? = null,
+    val risk: String? = null,
+    val bucket: Int? = null,
+    val multiplier: Double? = null,
+    val payout: Long? = null,
+    val net: Long? = null,
+    val newBalance: Long? = null,
+    val win: Boolean? = null,
+    val push: Boolean? = null,
+    val jackpotPayout: Long? = null,
+    val jackpotTierIndex: Int? = null,
+    val jackpotTierPayoutPct: Double? = null,
+    val soldTobyCoins: Long? = null,
+    val newPrice: Double? = null,
+    val lossTribute: Long? = null,
+) : CasinoResponseLike

--- a/web/src/main/kotlin/web/controller/PlinkoController.kt
+++ b/web/src/main/kotlin/web/controller/PlinkoController.kt
@@ -86,6 +86,7 @@ class PlinkoController(
             )
         when (val outcome = plinkoService.drop(
             discordId, guildId, request.stake, risk, request.autoTopUp,
+            clickX = request.clickX, clickY = request.clickY, mouseMoved = request.mouseMoved,
         )) {
             is DropOutcome.Win -> ResponseEntity.ok(
                 DropResponse(
@@ -149,10 +150,16 @@ class PlinkoController(
         ?.let { name -> Plinko.Risk.entries.firstOrNull { it.name == name } }
 }
 
+// `clickX` / `clickY` / `mouseMoved` are bot-suspicion signals from
+// `plinko.js`'s tracker. All three nullable so non-browser callers (Discord,
+// keyboard submit) can omit them — backend treats nulls as non-suspicious.
 data class DropRequest(
     val stake: Long = 0,
     val risk: String? = null,
     val autoTopUp: Boolean = false,
+    val clickX: Int? = null,
+    val clickY: Int? = null,
+    val mouseMoved: Boolean? = null,
 )
 
 data class DropResponse(

--- a/web/src/main/kotlin/web/controller/WheelOfFortuneController.kt
+++ b/web/src/main/kotlin/web/controller/WheelOfFortuneController.kt
@@ -1,0 +1,146 @@
+package web.controller
+
+import common.casino.CasinoCommonFailure
+import database.economy.WheelOfFortune
+import database.service.JackpotGame
+import database.service.WheelOfFortuneService
+import database.service.WheelOfFortuneService.SpinOutcome
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.security.oauth2.core.user.OAuth2User
+import org.springframework.stereotype.Controller
+import org.springframework.ui.Model
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseBody
+import org.springframework.web.servlet.mvc.support.RedirectAttributes
+import web.casino.CasinoOutcomeMapper
+import web.casino.CasinoPageContext
+import web.casino.CasinoResponseLike
+import web.casino.StakeBounds
+import web.casino.renderMinigamePage
+import web.service.EconomyWebService
+import web.util.WebGuildAccess
+import web.util.positiveOrNull
+
+/**
+ * Web surface for the `/wheel` minigame. GET renders the picker UI;
+ * POST runs the spin via [WheelOfFortuneService.spin] and returns JSON.
+ *
+ * Both surfaces share [WheelOfFortuneService] so Discord and web can't
+ * drift on payout maths or balance debit/credit semantics.
+ */
+@Controller
+@RequestMapping("/casino/{guildId}/wheel")
+class WheelOfFortuneController(
+    private val wheelService: WheelOfFortuneService,
+    private val economyWebService: EconomyWebService,
+    private val pageContext: CasinoPageContext,
+    private val stakeBounds: StakeBounds,
+) {
+
+    private val errors = CasinoOutcomeMapper { msg -> WheelSpinResponse(false, msg) }
+
+    @GetMapping
+    fun page(
+        @PathVariable guildId: Long,
+        @AuthenticationPrincipal user: OAuth2User,
+        model: Model,
+        ra: RedirectAttributes
+    ): String = pageContext.renderMinigamePage(
+        user, guildId, economyWebService, model, ra,
+        template = "wheel",
+        game = JackpotGame.WHEEL_OF_FORTUNE,
+    ) {
+        val (minStake, maxStake) = stakeBounds.wheelOfFortune(guildId)
+        val slotCount = WheelOfFortune.DEFAULT_WEIGHTS.values.sum()
+        addAttribute("minStake", minStake)
+        addAttribute("maxStake", maxStake)
+        addAttribute("picks", WheelOfFortune.PICKS)
+        addAttribute("slotCount", slotCount)
+        // Map of multiplier → slot count for the rules panel. Sorted
+        // by multiplier so the template can iterate without re-sorting.
+        addAttribute(
+            "wheelWeights",
+            WheelOfFortune.DEFAULT_WEIGHTS.entries.sortedBy { it.key }
+                .map { mapOf("multiplier" to it.key, "slots" to it.value) }
+        )
+    }
+
+    @PostMapping("/spin")
+    @ResponseBody
+    fun spin(
+        @PathVariable guildId: Long,
+        @RequestBody request: WheelSpinRequest,
+        @AuthenticationPrincipal user: OAuth2User
+    ): ResponseEntity<WheelSpinResponse> = WebGuildAccess.requireMemberForJson(
+        user, guildId, economyWebService, errorBuilder = errors.errorBuilder
+    ) { discordId ->
+        when (val outcome = wheelService.spin(
+            discordId, guildId, request.stake, request.pick, request.autoTopUp,
+        )) {
+            is SpinOutcome.Win -> ResponseEntity.ok(
+                WheelSpinResponse(
+                    ok = true,
+                    pick = outcome.pickedMultiplier,
+                    landed = outcome.landedMultiplier,
+                    payout = outcome.payout,
+                    net = outcome.net,
+                    newBalance = outcome.newBalance,
+                    win = true,
+                    jackpotPayout = outcome.jackpotPayout.positiveOrNull(),
+                    jackpotTierIndex = outcome.jackpotTierIndex.takeIf { it >= 0 },
+                    jackpotTierPayoutPct = outcome.jackpotTierPayoutPct.takeIf { it > 0.0 },
+                    soldTobyCoins = outcome.soldTobyCoins.positiveOrNull(),
+                    newPrice = outcome.newPrice,
+                )
+            )
+
+            is SpinOutcome.Lose -> ResponseEntity.ok(
+                WheelSpinResponse(
+                    ok = true,
+                    pick = outcome.pickedMultiplier,
+                    landed = outcome.landedMultiplier,
+                    payout = 0L,
+                    net = -outcome.stake,
+                    newBalance = outcome.newBalance,
+                    win = false,
+                    soldTobyCoins = outcome.soldTobyCoins.positiveOrNull(),
+                    newPrice = outcome.newPrice,
+                    lossTribute = outcome.lossTribute.positiveOrNull(),
+                )
+            )
+
+            is SpinOutcome.InvalidPick ->
+                errors.badRequest("Pick must be one of ${outcome.picks.joinToString { "${it}×" }}.")
+
+            is CasinoCommonFailure -> errors.mapCommonFailure(outcome)
+        }
+    }
+}
+
+data class WheelSpinRequest(
+    val stake: Long = 0,
+    val pick: Long = 0,
+    val autoTopUp: Boolean = false,
+)
+
+data class WheelSpinResponse(
+    override val ok: Boolean,
+    override val error: String? = null,
+    val pick: Long? = null,
+    val landed: Long? = null,
+    val payout: Long? = null,
+    val net: Long? = null,
+    val newBalance: Long? = null,
+    val win: Boolean? = null,
+    val jackpotPayout: Long? = null,
+    val jackpotTierIndex: Int? = null,
+    val jackpotTierPayoutPct: Double? = null,
+    val soldTobyCoins: Long? = null,
+    val newPrice: Double? = null,
+    val lossTribute: Long? = null,
+) : CasinoResponseLike

--- a/web/src/main/kotlin/web/controller/WheelOfFortuneController.kt
+++ b/web/src/main/kotlin/web/controller/WheelOfFortuneController.kt
@@ -81,6 +81,7 @@ class WheelOfFortuneController(
     ) { discordId ->
         when (val outcome = wheelService.spin(
             discordId, guildId, request.stake, request.pick, request.autoTopUp,
+            clickX = request.clickX, clickY = request.clickY, mouseMoved = request.mouseMoved,
         )) {
             is SpinOutcome.Win -> ResponseEntity.ok(
                 WheelSpinResponse(
@@ -122,10 +123,16 @@ class WheelOfFortuneController(
     }
 }
 
+// `clickX` / `clickY` / `mouseMoved` are bot-suspicion signals from
+// `wheel.js`'s tracker. All three nullable so non-browser callers (Discord,
+// keyboard submit) can omit them — backend treats nulls as non-suspicious.
 data class WheelSpinRequest(
     val stake: Long = 0,
     val pick: Long = 0,
     val autoTopUp: Boolean = false,
+    val clickX: Int? = null,
+    val clickY: Int? = null,
+    val mouseMoved: Boolean? = null,
 )
 
 data class WheelSpinResponse(

--- a/web/src/main/kotlin/web/service/ModerationWebService.kt
+++ b/web/src/main/kotlin/web/service/ModerationWebService.kt
@@ -886,6 +886,8 @@ class ModerationWebService(
             ConfigDto.Configurations.ROULETTE_MIN_STAKE,
             ConfigDto.Configurations.HOLDEM_MIN_STAKE,
             ConfigDto.Configurations.DUEL_MIN_STAKE,
+            ConfigDto.Configurations.PLINKO_MIN_STAKE,
+            ConfigDto.Configurations.WHEEL_OF_FORTUNE_MIN_STAKE,
             ConfigDto.Configurations.JACKPOT_STAKE_ANCHOR -> {
                 val n = rawValue.trim().toLongOrNull()
                     ?: return "Value must be a whole number of credits."
@@ -905,7 +907,9 @@ class ModerationWebService(
             ConfigDto.Configurations.SCRATCH_MAX_STAKE,
             ConfigDto.Configurations.ROULETTE_MAX_STAKE,
             ConfigDto.Configurations.HOLDEM_MAX_STAKE,
-            ConfigDto.Configurations.DUEL_MAX_STAKE -> {
+            ConfigDto.Configurations.DUEL_MAX_STAKE,
+            ConfigDto.Configurations.PLINKO_MAX_STAKE,
+            ConfigDto.Configurations.WHEEL_OF_FORTUNE_MAX_STAKE -> {
                 val n = rawValue.trim().toLongOrNull()
                     ?: return "Value must be a whole number of credits."
                 if (n < 0L) return "Value must be 0 (unlimited) or a positive number of credits."

--- a/web/src/main/kotlin/web/service/ModerationWebService.kt
+++ b/web/src/main/kotlin/web/service/ModerationWebService.kt
@@ -989,7 +989,9 @@ class ModerationWebService(
             }
             ConfigDto.Configurations.COINFLIP_BOT_EDGE_MAX_PCT,
             ConfigDto.Configurations.DICE_BOT_EDGE_MAX_PCT,
-            ConfigDto.Configurations.SLOTS_BOT_EDGE_MAX_PCT -> {
+            ConfigDto.Configurations.SLOTS_BOT_EDGE_MAX_PCT,
+            ConfigDto.Configurations.PLINKO_BOT_EDGE_MAX_PCT,
+            ConfigDto.Configurations.WHEEL_OF_FORTUNE_BOT_EDGE_MAX_PCT -> {
                 val n = rawValue.trim().toIntOrNull()
                     ?: return "Value must be a whole number percentage (0-50; 0 disables)."
                 if (n !in 0..50) return "Value must be between 0 and 50."

--- a/web/src/main/resources/static/css/plinko.css
+++ b/web/src/main/resources/static/css/plinko.css
@@ -1,0 +1,199 @@
+@import url("./casino-table.css");
+
+.plinko-header { margin-bottom: var(--space-5); }
+.plinko-header h1 { margin: var(--space-2) 0; }
+.plinko-header strong { color: #fff; }
+
+.plinko-table {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--space-4);
+}
+
+.plinko-board {
+    position: relative;
+    width: 100%;
+    max-width: 480px;
+    height: 240px;
+    background: linear-gradient(180deg, rgba(0,0,0,0.25), rgba(0,0,0,0.05));
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    overflow: hidden;
+}
+
+.plinko-ball {
+    position: absolute;
+    top: 8px;
+    left: 50%;
+    transform: translateX(-50%);
+    font-size: 1.4rem;
+    color: var(--casino-gold);
+    line-height: 1;
+}
+.plinko-board.dropping .plinko-ball {
+    animation: plinko-drop 0.9s ease-in forwards;
+}
+@keyframes plinko-drop {
+    0%   { top: 8px;   transform: translateX(-50%) rotate(0deg); }
+    25%  { transform: translateX(calc(-50% - 30px)) rotate(120deg); }
+    50%  { transform: translateX(calc(-50% + 20px)) rotate(240deg); }
+    75%  { transform: translateX(calc(-50% - 10px)) rotate(360deg); }
+    100% { top: 200px; transform: translateX(-50%) rotate(480deg); }
+}
+
+.plinko-buckets {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    display: grid;
+    grid-template-columns: repeat(9, 1fr);
+    gap: 2px;
+    padding: 4px;
+}
+.plinko-bucket {
+    text-align: center;
+    padding: 6px 2px;
+    background: rgba(0, 0, 0, 0.35);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    color: var(--text-muted);
+    font-size: 0.8rem;
+    font-variant-numeric: tabular-nums;
+    transition: background 0.2s, color 0.2s, box-shadow 0.2s;
+}
+.plinko-bucket-landed {
+    background: var(--casino-active-tile-bg);
+    color: #fff;
+    box-shadow: var(--casino-active-glow);
+    animation: plinko-bucket-bounce 0.35s ease-out;
+}
+@keyframes plinko-bucket-bounce {
+    0%   { transform: translateY(0); }
+    50%  { transform: translateY(-6px); }
+    100% { transform: translateY(0); }
+}
+
+.plinko-result {
+    min-height: 1.5em;
+    font-size: 1.05rem;
+    text-align: center;
+    font-variant-numeric: tabular-nums;
+}
+.plinko-result-win { color: #57F287; }
+.plinko-result-lose { color: #a0a0b0; }
+
+.plinko-bet {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--space-3);
+    width: 100%;
+    max-width: 360px;
+}
+
+.plinko-risk-picker {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: var(--space-2);
+    width: 100%;
+}
+.plinko-risk {
+    cursor: pointer;
+    user-select: none;
+}
+.plinko-risk input[type="radio"] {
+    position: absolute;
+    opacity: 0;
+    pointer-events: none;
+}
+.plinko-risk span {
+    display: block;
+    text-align: center;
+    padding: 10px 0;
+    background: rgba(0, 0, 0, 0.35);
+    border: 2px solid var(--border);
+    border-radius: 8px;
+    color: var(--text-muted);
+    font-weight: 700;
+    font-size: 0.95rem;
+    letter-spacing: 0.05em;
+    transition: border-color 0.2s, color 0.2s, background 0.2s, box-shadow 0.2s;
+}
+.plinko-risk input[type="radio"]:checked + span {
+    border-color: var(--casino-gold);
+    color: #fff;
+    background: var(--casino-active-tile-bg);
+    box-shadow: var(--casino-active-glow);
+}
+.plinko-risk input[type="radio"]:focus-visible + span {
+    outline: 2px solid #5865F2;
+    outline-offset: 2px;
+}
+
+.plinko-stake-label {
+    font-size: 0.85rem;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    align-self: flex-start;
+}
+.plinko-bet input[type="number"] {
+    width: 100%;
+    padding: 8px 10px;
+    background: #0f1830;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    color: #fff;
+    font-size: 1rem;
+    font-variant-numeric: tabular-nums;
+}
+.plinko-bet button[type="submit"] { width: 100%; }
+
+.plinko-balance {
+    color: var(--text-muted);
+    font-variant-numeric: tabular-nums;
+}
+.plinko-balance strong { color: #fff; }
+
+.plinko-rules, .plinko-payouts {
+    margin-top: var(--space-5);
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: var(--space-4);
+}
+.plinko-rules h2, .plinko-payouts h2 {
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--text-muted);
+    margin-bottom: var(--space-3);
+}
+.plinko-rules ul {
+    list-style: disc;
+    padding-left: 20px;
+    color: var(--text-muted);
+    font-size: 0.95rem;
+    line-height: 1.7;
+}
+.plinko-rules strong { color: #fff; }
+.plinko-payouts table {
+    width: 100%;
+    border-collapse: collapse;
+    font-variant-numeric: tabular-nums;
+    font-size: 0.9rem;
+}
+.plinko-payouts th, .plinko-payouts td {
+    padding: 6px 8px;
+    text-align: center;
+    border-bottom: 1px solid var(--border);
+}
+.plinko-payouts th { color: var(--text-muted); font-weight: 600; }
+
+@media (max-width: 600px) {
+    .plinko-board { height: 180px; }
+    .plinko-buckets { grid-template-columns: repeat(9, 1fr); }
+    .plinko-bucket { font-size: 0.7rem; padding: 4px 1px; }
+}

--- a/web/src/main/resources/static/css/plinko.css
+++ b/web/src/main/resources/static/css/plinko.css
@@ -175,15 +175,46 @@
     line-height: 1.7;
 }
 .plinko-rules strong { color: #fff; }
-.plinko-payouts table {
+/* The transposed table is 4 columns (Bucket + LOW/MEDIUM/HIGH) — fits
+   on mobile without a horizontal scroll. The wrapper keeps a scroll
+   fallback for very narrow screens / dynamic font sizing. */
+.plinko-payouts-table-wrap {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    margin-bottom: var(--space-3);
+}
+.plinko-payouts-table {
     width: 100%;
     border-collapse: collapse;
     font-variant-numeric: tabular-nums;
     font-size: 0.9rem;
 }
-.plinko-payouts th, .plinko-payouts td {
+.plinko-payouts-table th,
+.plinko-payouts-table td {
     padding: 6px 8px;
     text-align: center;
     border-bottom: 1px solid var(--border);
+    transition: background 0.2s ease, color 0.2s ease;
 }
-.plinko-payouts th { color: var(--text-muted); font-weight: 600; }
+.plinko-payouts-table th { color: var(--text-muted); font-weight: 600; }
+/* Active risk profile gets a gold-tinted column so the player can
+   spot it at a glance. Bucket column (no data-risk) stays neutral. */
+.plinko-payouts-table th.plinko-payout-active {
+    color: var(--casino-gold);
+    text-shadow: 0 0 6px rgba(247, 212, 106, 0.4);
+}
+.plinko-payouts-table td.plinko-payout-active {
+    color: #fff;
+    font-weight: 700;
+    background: rgba(247, 212, 106, 0.08);
+}
+
+@media (max-width: 480px) {
+    .plinko-payouts-table {
+        font-size: 0.85rem;
+    }
+    .plinko-payouts-table th,
+    .plinko-payouts-table td {
+        padding: 6px 6px;
+    }
+}

--- a/web/src/main/resources/static/css/plinko.css
+++ b/web/src/main/resources/static/css/plinko.css
@@ -11,68 +11,64 @@
     gap: var(--space-4);
 }
 
-.plinko-board {
-    position: relative;
+.plinko-stage {
     width: 100%;
     max-width: 480px;
-    height: 240px;
-    background: linear-gradient(180deg, rgba(0,0,0,0.25), rgba(0,0,0,0.05));
+    padding: var(--space-3);
+    background: linear-gradient(180deg, rgba(0,0,0,0.30), rgba(0,0,0,0.08));
     border: 1px solid var(--border);
     border-radius: 12px;
-    overflow: hidden;
+    box-shadow: inset 0 0 40px rgba(0, 0, 0, 0.35);
+}
+
+.plinko-board-svg {
+    width: 100%;
+    height: auto;
+    display: block;
+    filter: drop-shadow(0 4px 10px rgba(0, 0, 0, 0.35));
+}
+
+.plinko-peg {
+    stroke: rgba(0, 0, 0, 0.55);
+    stroke-width: 0.3;
 }
 
 .plinko-ball {
-    position: absolute;
-    top: 8px;
-    left: 50%;
-    transform: translateX(-50%);
-    font-size: 1.4rem;
-    color: var(--casino-gold);
-    line-height: 1;
+    fill: url(#plinko-ball-grad);
+    stroke: rgba(0, 0, 0, 0.55);
+    stroke-width: 0.5;
 }
-.plinko-board.dropping .plinko-ball {
-    animation: plinko-drop 0.9s ease-in forwards;
+.plinko-ball[hidden] { display: none; }
+
+.plinko-bucket-rect {
+    stroke: rgba(0, 0, 0, 0.5);
+    stroke-width: 0.5;
+    transition: filter 0.25s ease, transform 0.25s ease;
+    transform-origin: center;
+    transform-box: fill-box;
 }
-@keyframes plinko-drop {
-    0%   { top: 8px;   transform: translateX(-50%) rotate(0deg); }
-    25%  { transform: translateX(calc(-50% - 30px)) rotate(120deg); }
-    50%  { transform: translateX(calc(-50% + 20px)) rotate(240deg); }
-    75%  { transform: translateX(calc(-50% - 10px)) rotate(360deg); }
-    100% { top: 200px; transform: translateX(-50%) rotate(480deg); }
+.plinko-bucket-bust    { fill: #5a2424; }
+.plinko-bucket-loss    { fill: #6b4a1f; }
+.plinko-bucket-push    { fill: #314a5e; }
+.plinko-bucket-win     { fill: #2c6b4a; }
+.plinko-bucket-jackpot { fill: #c97f24; }
+
+.plinko-bucket-landed {
+    filter: brightness(1.45) drop-shadow(0 0 6px rgba(247, 212, 106, 0.65));
+    transform: translateY(-1px);
 }
 
-.plinko-buckets {
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    display: grid;
-    grid-template-columns: repeat(9, 1fr);
-    gap: 2px;
-    padding: 4px;
-}
-.plinko-bucket {
-    text-align: center;
-    padding: 6px 2px;
-    background: rgba(0, 0, 0, 0.35);
-    border: 1px solid var(--border);
-    border-radius: 6px;
-    color: var(--text-muted);
-    font-size: 0.8rem;
+.plinko-bucket-label {
+    fill: #fff8e1;
+    font-family: "Cambria", "Georgia", serif;
+    font-size: 7px;
+    font-weight: 700;
     font-variant-numeric: tabular-nums;
-    transition: background 0.2s, color 0.2s, box-shadow 0.2s;
-}
-.plinko-bucket-landed {
-    background: var(--casino-active-tile-bg);
-    color: #fff;
-    box-shadow: var(--casino-active-glow);
-    animation: plinko-bucket-bounce 0.35s ease-out;
-}
-@keyframes plinko-bucket-bounce {
-    0%   { transform: translateY(0); }
-    50%  { transform: translateY(-6px); }
-    100% { transform: translateY(0); }
+    text-anchor: middle;
+    paint-order: stroke;
+    stroke: rgba(0, 0, 0, 0.6);
+    stroke-width: 0.4;
+    pointer-events: none;
 }
 
 .plinko-result {
@@ -191,9 +187,3 @@
     border-bottom: 1px solid var(--border);
 }
 .plinko-payouts th { color: var(--text-muted); font-weight: 600; }
-
-@media (max-width: 600px) {
-    .plinko-board { height: 180px; }
-    .plinko-buckets { grid-template-columns: repeat(9, 1fr); }
-    .plinko-bucket { font-size: 0.7rem; padding: 4px 1px; }
-}

--- a/web/src/main/resources/static/css/wheel.css
+++ b/web/src/main/resources/static/css/wheel.css
@@ -210,18 +210,49 @@
     line-height: 1.7;
 }
 .wheel-rules strong { color: #fff; }
-.wheel-weights table {
+.wheel-weights-table-wrap {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+}
+.wheel-weights-table {
     width: 100%;
     border-collapse: collapse;
     font-variant-numeric: tabular-nums;
     font-size: 0.9rem;
 }
-.wheel-weights th, .wheel-weights td {
+.wheel-weights-table th,
+.wheel-weights-table td {
     padding: 6px 8px;
     text-align: center;
     border-bottom: 1px solid var(--border);
 }
-.wheel-weights th { color: var(--text-muted); font-weight: 600; }
+.wheel-weights-table th {
+    color: var(--text-muted);
+    font-weight: 600;
+    vertical-align: bottom;
+}
+/* Allow long header labels ("Hit chance", "Per-pick RTP") to wrap onto
+   two lines on narrow viewports without overflowing the cell. */
+.wheel-weights-table th > span {
+    display: inline-block;
+    line-height: 1.2;
+    word-break: keep-all;
+    hyphens: none;
+}
+
+@media (max-width: 480px) {
+    .wheel-weights-table {
+        font-size: 0.82rem;
+    }
+    .wheel-weights-table th,
+    .wheel-weights-table td {
+        padding: 6px 4px;
+    }
+    .wheel-weights-table th {
+        font-size: 0.72rem;
+        letter-spacing: 0;
+    }
+}
 
 @media (prefers-reduced-motion: reduce) {
     .wheel-rotor { transition: none !important; }

--- a/web/src/main/resources/static/css/wheel.css
+++ b/web/src/main/resources/static/css/wheel.css
@@ -1,0 +1,171 @@
+@import url("./casino-table.css");
+
+.wheel-header { margin-bottom: var(--space-5); }
+.wheel-header h1 { margin: var(--space-2) 0; }
+.wheel-header strong { color: #fff; }
+
+.wheel-table {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--space-4);
+}
+
+.wheel-stage {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+.wheel-pointer {
+    color: var(--casino-gold);
+    font-size: 1.4rem;
+    line-height: 1;
+    margin-bottom: 4px;
+}
+.wheel-disc {
+    width: 160px;
+    height: 160px;
+    border-radius: 50%;
+    background: radial-gradient(circle at 50% 50%, #0f1830 0%, #07101e 80%);
+    border: 4px solid var(--casino-gold);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-shadow: var(--casino-active-glow);
+}
+.wheel-landed {
+    font-size: 2.5rem;
+    font-weight: 800;
+    color: #fff;
+    font-variant-numeric: tabular-nums;
+}
+.wheel-disc.spinning {
+    animation: wheel-spin 1.6s linear infinite;
+}
+@keyframes wheel-spin {
+    0%   { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+}
+
+.wheel-result {
+    min-height: 1.5em;
+    font-size: 1.05rem;
+    text-align: center;
+    font-variant-numeric: tabular-nums;
+}
+.wheel-result-win { color: #57F287; }
+.wheel-result-lose { color: #a0a0b0; }
+
+.wheel-bet {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--space-3);
+    width: 100%;
+    max-width: 360px;
+}
+
+.wheel-pick-picker {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: var(--space-2);
+    width: 100%;
+}
+.wheel-pick {
+    cursor: pointer;
+    user-select: none;
+}
+.wheel-pick input[type="radio"] {
+    position: absolute;
+    opacity: 0;
+    pointer-events: none;
+}
+.wheel-pick span {
+    display: block;
+    text-align: center;
+    padding: 12px 0;
+    background: rgba(0, 0, 0, 0.35);
+    border: 2px solid var(--border);
+    border-radius: 8px;
+    color: var(--text-muted);
+    font-weight: 700;
+    font-size: 1.1rem;
+    font-variant-numeric: tabular-nums;
+    transition: border-color 0.2s, color 0.2s, background 0.2s, box-shadow 0.2s;
+}
+.wheel-pick input[type="radio"]:checked + span {
+    border-color: var(--casino-gold);
+    color: #fff;
+    background: var(--casino-active-tile-bg);
+    box-shadow: var(--casino-active-glow);
+}
+.wheel-pick input[type="radio"]:focus-visible + span {
+    outline: 2px solid #5865F2;
+    outline-offset: 2px;
+}
+
+.wheel-stake-label {
+    font-size: 0.85rem;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    align-self: flex-start;
+}
+.wheel-bet input[type="number"] {
+    width: 100%;
+    padding: 8px 10px;
+    background: #0f1830;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    color: #fff;
+    font-size: 1rem;
+    font-variant-numeric: tabular-nums;
+}
+.wheel-bet button[type="submit"] { width: 100%; }
+
+.wheel-balance {
+    color: var(--text-muted);
+    font-variant-numeric: tabular-nums;
+}
+.wheel-balance strong { color: #fff; }
+
+.wheel-rules, .wheel-weights {
+    margin-top: var(--space-5);
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: var(--space-4);
+}
+.wheel-rules h2, .wheel-weights h2 {
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--text-muted);
+    margin-bottom: var(--space-3);
+}
+.wheel-rules ul {
+    list-style: disc;
+    padding-left: 20px;
+    color: var(--text-muted);
+    font-size: 0.95rem;
+    line-height: 1.7;
+}
+.wheel-rules strong { color: #fff; }
+.wheel-weights table {
+    width: 100%;
+    border-collapse: collapse;
+    font-variant-numeric: tabular-nums;
+    font-size: 0.9rem;
+}
+.wheel-weights th, .wheel-weights td {
+    padding: 6px 8px;
+    text-align: center;
+    border-bottom: 1px solid var(--border);
+}
+.wheel-weights th { color: var(--text-muted); font-weight: 600; }
+
+@media (max-width: 600px) {
+    .wheel-disc { width: 130px; height: 130px; }
+    .wheel-landed { font-size: 2rem; }
+}

--- a/web/src/main/resources/static/css/wheel.css
+++ b/web/src/main/resources/static/css/wheel.css
@@ -11,41 +11,84 @@
     gap: var(--space-4);
 }
 
+/* SVG wheel reuses the brass-rim/hub/pointer/peg aesthetic from
+   `.jackpot-wheel-*` in base.css. The classes here are scoped so this
+   wheel can sit inline on the page while the jackpot wheel keeps its
+   overlay-only positioning. Visual styling is intentionally a clone. */
 .wheel-stage {
     position: relative;
+    width: clamp(260px, 78vw, 360px);
     display: flex;
     flex-direction: column;
     align-items: center;
+    gap: 0.85rem;
 }
-.wheel-pointer {
-    color: var(--casino-gold);
-    font-size: 1.4rem;
-    line-height: 1;
-    margin-bottom: 4px;
+.wheel-svg {
+    width: 100%;
+    height: auto;
+    display: block;
+    filter: drop-shadow(0 6px 14px rgba(0, 0, 0, 0.45));
 }
-.wheel-disc {
-    width: 160px;
-    height: 160px;
-    border-radius: 50%;
-    background: radial-gradient(circle at 50% 50%, #0f1830 0%, #07101e 80%);
-    border: 4px solid var(--casino-gold);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    box-shadow: var(--casino-active-glow);
+.wheel-rotor {
+    transform-origin: 0 0;
+    /* Transition is added/removed via JS so we can reset between spins
+       without animating the snap-back. */
 }
-.wheel-landed {
-    font-size: 2.5rem;
-    font-weight: 800;
-    color: #fff;
+.wheel-rim-outer {
+    fill: url(#wof-wheel-rim-grad);
+    stroke: rgba(0, 0, 0, 0.6);
+    stroke-width: 1;
+}
+.wheel-rim-inner {
+    fill: #0a1a12;
+    stroke: rgba(0, 0, 0, 0.7);
+    stroke-width: 0.5;
+}
+.wheel-hub-outer {
+    fill: url(#wof-wheel-hub-grad);
+    stroke: rgba(0, 0, 0, 0.55);
+    stroke-width: 1;
+}
+.wheel-hub-inner {
+    fill: #b07d1f;
+    stroke: rgba(255, 240, 180, 0.45);
+    stroke-width: 0.5;
+}
+.wheel-pointer-arrow {
+    fill: url(#wof-wheel-pointer-grad);
+    stroke: rgba(0, 0, 0, 0.5);
+    stroke-width: 0.75;
+    stroke-linejoin: round;
+}
+.wheel-peg {
+    fill: url(#wof-wheel-hub-grad);
+    stroke: rgba(0, 0, 0, 0.7);
+    stroke-width: 0.4;
+}
+.wheel-segment {
+    stroke: rgba(0, 0, 0, 0.55);
+    stroke-width: 0.75;
+}
+.wheel-segment-label {
+    fill: #fff8e1;
+    font-family: "Cambria", "Georgia", serif;
+    font-size: 10px;
+    font-weight: 700;
     font-variant-numeric: tabular-nums;
+    text-anchor: middle;
+    dominant-baseline: middle;
+    paint-order: stroke;
+    stroke: rgba(0, 0, 0, 0.7);
+    stroke-width: 0.5;
+    pointer-events: none;
 }
-.wheel-disc.spinning {
-    animation: wheel-spin 1.6s linear infinite;
-}
-@keyframes wheel-spin {
-    0%   { transform: rotate(0deg); }
-    100% { transform: rotate(360deg); }
+
+.wheel-status {
+    text-align: center;
+    color: var(--text-muted);
+    font-size: 0.95rem;
+    font-variant-numeric: tabular-nums;
+    min-height: 1.4em;
 }
 
 .wheel-result {
@@ -82,6 +125,9 @@
     pointer-events: none;
 }
 .wheel-pick span {
+    /* `--wheel-pick-tint` is set per-chip by wheel.js to the matching
+       wedge colour, so the player sees which wedges they're betting on. */
+    --wheel-pick-tint: var(--casino-gold);
     display: block;
     text-align: center;
     padding: 12px 0;
@@ -93,12 +139,22 @@
     font-size: 1.1rem;
     font-variant-numeric: tabular-nums;
     transition: border-color 0.2s, color 0.2s, background 0.2s, box-shadow 0.2s;
+    position: relative;
+}
+.wheel-pick span::before {
+    content: '';
+    position: absolute;
+    inset: 4px auto 4px 6px;
+    width: 6px;
+    border-radius: 2px;
+    background: var(--wheel-pick-tint);
+    opacity: 0.85;
 }
 .wheel-pick input[type="radio"]:checked + span {
-    border-color: var(--casino-gold);
+    border-color: var(--wheel-pick-tint);
     color: #fff;
     background: var(--casino-active-tile-bg);
-    box-shadow: var(--casino-active-glow);
+    box-shadow: 0 0 12px var(--wheel-pick-tint, var(--casino-gold));
 }
 .wheel-pick input[type="radio"]:focus-visible + span {
     outline: 2px solid #5865F2;
@@ -165,7 +221,6 @@
 }
 .wheel-weights th { color: var(--text-muted); font-weight: 600; }
 
-@media (max-width: 600px) {
-    .wheel-disc { width: 130px; height: 130px; }
-    .wheel-landed { font-size: 2rem; }
+@media (prefers-reduced-motion: reduce) {
+    .wheel-rotor { transition: none !important; }
 }

--- a/web/src/main/resources/static/css/wheel.css
+++ b/web/src/main/resources/static/css/wheel.css
@@ -31,8 +31,10 @@
 }
 .wheel-rotor {
     transform-origin: 0 0;
-    /* Transition is added/removed via JS so we can reset between spins
-       without animating the snap-back. */
+    /* CSS owns the transition so the browser registers a stable
+       starting state for every animate. JS only overrides it with
+       inline `transition: none` for the per-spin snap-back to 0deg. */
+    transition: transform 2200ms cubic-bezier(0.18, 0.6, 0.18, 1);
 }
 .wheel-rim-outer {
     fill: url(#wof-wheel-rim-grad);

--- a/web/src/main/resources/static/js/plinko.js
+++ b/web/src/main/resources/static/js/plinko.js
@@ -1,4 +1,18 @@
-// Pure-DOM render for a /drop response. Hoisted out of the IIFE for tests.
+// Plinko renderer + animator.
+//
+// SVG board: pegs in a Galton triangle (row k has k+1 pegs), buckets
+// along the bottom labelled with the active risk profile's multipliers.
+// The ball is a separate SVG <circle> whose translate is driven by
+// requestAnimationFrame — it bounces through each row's decision point
+// and ends at the EXACT centre of the bucket the server picked.
+//
+// Risk-profile radio change re-paints the bucket labels and bucket
+// tints in place (no page reload); the active profile's payout vector
+// is read from window.__plinkoTables (server-rendered Thymeleaf blob).
+//
+// renderPlinkoResult stays as a hoisted export so the jest test in
+// `plinko.test.js` can drive it without booting the SVG board.
+
 function renderPlinkoResult(resultEl, body) {
     if (typeof window === 'undefined' || !window.TobyCasinoResult) return;
     const mult = (body && typeof body.multiplier === 'number')
@@ -33,52 +47,222 @@ function renderPlinkoResult(resultEl, body) {
     if (!els) return;
 
     const board = document.getElementById('plinko-board');
+    const pegsGroup = document.getElementById('plinko-pegs');
+    const bucketsGroup = document.getElementById('plinko-buckets');
     const ball = document.getElementById('plinko-ball');
-    const bucketsEl = document.getElementById('plinko-buckets');
     const tableEl = document.querySelector('.plinko-table');
+    if (!els.form || !els.primaryBtn || !els.stakeInput || !board || !pegsGroup || !bucketsGroup || !ball) return;
 
-    if (!els.form || !els.primaryBtn || !els.stakeInput || !board || !ball || !bucketsEl) return;
+    const SVG_NS = 'http://www.w3.org/2000/svg';
+    const ROWS = Number(window.__plinkoRows) || 8;
+    const BUCKETS = Number(window.__plinkoBuckets) || (ROWS + 1);
+    const TABLES = window.__plinkoTables || {};
 
-    const DROP_DURATION_MS = 900;
-
-    // Anti-autoclicker telemetry: same shape as dice/coinflip/slots — capture
-    // (clickX, clickY) from the bet button + a doc-level mousemove flag,
-    // forward both to the backend so CasinoBotSuspicionService can score
-    // the player's pattern. Genuine cursor motion clears the streak.
-    const botSuspicion = window.TobyCasinoBotSuspicion &&
-        window.TobyCasinoBotSuspicion.createTracker();
-    if (botSuspicion) {
-        document.addEventListener('mousemove', botSuspicion.recordMouseMove, { passive: true });
-        [els.primaryBtn, els.tobyBtn].forEach(function (btn) {
-            if (!btn) return;
-            btn.addEventListener('click', botSuspicion.recordClick, true);
-        });
-    }
+    // SVG viewBox is -100..100 horizontally so the centre lines up with
+    // x=0; buckets fill the full 200 width. Vertical layout below.
+    const BOARD_W = 200;
+    const PEG_X = BOARD_W / BUCKETS;      // horizontal peg spacing
+    const PEG_Y_TOP = 18;                  // y of row 0
+    const PEG_Y_STEP = 18;                 // y delta between rows
+    const BUCKET_Y_TOP = PEG_Y_TOP + ROWS * PEG_Y_STEP + 4;
+    const BUCKET_H = 28;
+    const BALL_R = 4;
+    const DROP_MS = 1400;
 
     function selectedRisk() {
         const checked = els.form.querySelector('input[name="risk"]:checked');
         return checked ? checked.value : null;
     }
 
-    function startDropAnimation() {
-        ball.hidden = false;
-        board.classList.add('dropping');
-        if (window.CasinoSounds) window.CasinoSounds.play('deal');
+    function bucketCenterX(k) {
+        return -BOARD_W / 2 + (k + 0.5) * PEG_X;
     }
 
-    function stopDropAnimation(_intervalId, body) {
-        board.classList.remove('dropping');
-        if (body && typeof body.bucket === 'number') {
-            // Highlight the landed bucket; CSS owns the bounce.
-            bucketsEl.querySelectorAll('.plinko-bucket').forEach(function (el) {
-                el.classList.toggle(
-                    'plinko-bucket-landed',
-                    Number(el.dataset.index) === body.bucket
-                );
-            });
-            if (window.CasinoSounds) window.CasinoSounds.play('click');
+    function formatMult(m) {
+        if (m === Math.floor(m)) return m + '×';
+        // Trim trailing zeros: 0.40 → 0.4, 1.50 → 1.5.
+        return m.toFixed(2).replace(/\.?0+$/, '') + '×';
+    }
+
+    // Tint buckets by tier: 0 (bust) muted red, <1 (partial loss) muted
+    // orange, 1 (push) neutral, >1 (win) green. Keeps the table readable
+    // at a glance without forcing the player to know the multiplier ranges.
+    function bucketClass(mult) {
+        if (mult === 0) return 'plinko-bucket-bust';
+        if (mult < 1)   return 'plinko-bucket-loss';
+        if (mult === 1) return 'plinko-bucket-push';
+        if (mult >= 10) return 'plinko-bucket-jackpot';
+        return 'plinko-bucket-win';
+    }
+
+    function renderPegs() {
+        pegsGroup.innerHTML = '';
+        // Row k has k+1 pegs centred on x=0. Offset by half-peg so the
+        // bottom row's pegs sit at the boundaries between buckets.
+        for (let row = 0; row < ROWS; row++) {
+            const y = PEG_Y_TOP + row * PEG_Y_STEP;
+            const count = row + 1;
+            const startX = -((count - 1) / 2) * PEG_X;
+            for (let i = 0; i < count; i++) {
+                const peg = document.createElementNS(SVG_NS, 'circle');
+                peg.setAttribute('cx', (startX + i * PEG_X).toFixed(2));
+                peg.setAttribute('cy', y.toFixed(2));
+                peg.setAttribute('r', '1.6');
+                peg.setAttribute('class', 'plinko-peg');
+                peg.setAttribute('fill', 'url(#plinko-peg-grad)');
+                pegsGroup.appendChild(peg);
+            }
         }
-        ball.hidden = true;
+    }
+
+    function renderBuckets(risk) {
+        bucketsGroup.innerHTML = '';
+        const table = TABLES[risk] || [];
+        const bucketW = PEG_X * 0.92;
+        for (let k = 0; k < BUCKETS; k++) {
+            const cx = bucketCenterX(k);
+            const mult = table[k];
+            const rect = document.createElementNS(SVG_NS, 'rect');
+            rect.setAttribute('x', (cx - bucketW / 2).toFixed(2));
+            rect.setAttribute('y', BUCKET_Y_TOP.toFixed(2));
+            rect.setAttribute('width', bucketW.toFixed(2));
+            rect.setAttribute('height', BUCKET_H.toFixed(2));
+            rect.setAttribute('rx', '3');
+            rect.setAttribute('class', 'plinko-bucket-rect ' + (typeof mult === 'number' ? bucketClass(mult) : ''));
+            rect.setAttribute('data-bucket', String(k));
+            bucketsGroup.appendChild(rect);
+
+            const text = document.createElementNS(SVG_NS, 'text');
+            text.setAttribute('x', cx.toFixed(2));
+            text.setAttribute('y', (BUCKET_Y_TOP + BUCKET_H / 2 + 3).toFixed(2));
+            text.setAttribute('class', 'plinko-bucket-label');
+            text.textContent = typeof mult === 'number' ? formatMult(mult) : '?';
+            bucketsGroup.appendChild(text);
+        }
+    }
+
+    function clearLandedHighlight() {
+        bucketsGroup.querySelectorAll('.plinko-bucket-landed').forEach(el => {
+            el.classList.remove('plinko-bucket-landed');
+        });
+    }
+
+    function highlightLanded(k) {
+        clearLandedHighlight();
+        const rect = bucketsGroup.querySelector('rect[data-bucket="' + k + '"]');
+        if (rect) rect.classList.add('plinko-bucket-landed');
+    }
+
+    /**
+     * Build a sequence of `ROWS` left/right decisions (-1 / +1) that
+     * sum to `K - ROWS/2` right-shifts, picking K out of ROWS as right.
+     * Shuffled with a per-drop random seed so successive drops to the
+     * same bucket don't trace the identical path.
+     */
+    function decisionPath(bucket) {
+        const rights = bucket;        // # right-shifts → bucket index
+        const lefts = ROWS - rights;
+        const seq = [];
+        for (let i = 0; i < rights; i++) seq.push(1);
+        for (let i = 0; i < lefts; i++) seq.push(-1);
+        for (let i = seq.length - 1; i > 0; i--) {
+            const j = Math.floor(Math.random() * (i + 1));
+            const tmp = seq[i]; seq[i] = seq[j]; seq[j] = tmp;
+        }
+        return seq;
+    }
+
+    // easeInOutQuad — gentle acceleration into and out of each row so
+    // the bounce reads as a real ball rather than a linear lerp.
+    function ease(t) {
+        return t < 0.5 ? 2 * t * t : 1 - Math.pow(-2 * t + 2, 2) / 2;
+    }
+
+    function animateDrop(targetBucket) {
+        const path = decisionPath(targetBucket);
+        // X waypoints — start at (0, -BALL_R), then after each row k the
+        // ball is at `cum * PEG_X / 2` where cum = sum(decisions[0..k]).
+        // Each waypoint y sits just below the row's pegs.
+        const waypoints = [{ x: 0, y: -BALL_R }];
+        let cum = 0;
+        for (let row = 0; row < ROWS; row++) {
+            cum += path[row];
+            waypoints.push({
+                x: (cum * PEG_X) / 2,
+                y: PEG_Y_TOP + row * PEG_Y_STEP + PEG_Y_STEP / 2,
+            });
+        }
+        // Final waypoint: settle into the bucket centre.
+        waypoints.push({ x: bucketCenterX(targetBucket), y: BUCKET_Y_TOP + BUCKET_H / 2 });
+
+        ball.hidden = false;
+        ball.setAttribute('cx', '0');
+        ball.setAttribute('cy', '0');
+        ball.setAttribute('transform', 'translate(' + waypoints[0].x + ',' + waypoints[0].y + ')');
+
+        const segMs = DROP_MS / (waypoints.length - 1);
+        const startedAt = performance.now();
+
+        return new Promise(resolve => {
+            function tick(now) {
+                const elapsed = now - startedAt;
+                if (elapsed >= DROP_MS) {
+                    const end = waypoints[waypoints.length - 1];
+                    ball.setAttribute('transform', 'translate(' + end.x + ',' + end.y + ')');
+                    resolve();
+                    return;
+                }
+                const segIdx = Math.min(Math.floor(elapsed / segMs), waypoints.length - 2);
+                const segStart = waypoints[segIdx];
+                const segEnd = waypoints[segIdx + 1];
+                const segT = ease((elapsed - segIdx * segMs) / segMs);
+                const x = segStart.x + (segEnd.x - segStart.x) * segT;
+                const y = segStart.y + (segEnd.y - segStart.y) * segT;
+                ball.setAttribute('transform', 'translate(' + x.toFixed(2) + ',' + y.toFixed(2) + ')');
+                requestAnimationFrame(tick);
+            }
+            requestAnimationFrame(tick);
+        });
+    }
+
+    // Initial paint.
+    renderPegs();
+    renderBuckets(selectedRisk());
+
+    // Re-paint bucket labels when the risk profile changes so the player
+    // sees the multipliers they're actually playing for before pressing Drop.
+    els.form.querySelectorAll('input[name="risk"]').forEach(input => {
+        input.addEventListener('change', () => {
+            clearLandedHighlight();
+            renderBuckets(selectedRisk());
+        });
+    });
+
+    let pendingResolve = null;
+
+    function startAnimation() {
+        clearLandedHighlight();
+        if (window.CasinoSounds) window.CasinoSounds.play('deal');
+        // The drop animation can't start until we know which bucket to
+        // aim for — we kick it off from stopAnimation once the server
+        // response arrives. Here we just clear stale state.
+        return null;
+    }
+
+    function stopAnimation(_intervalId, body) {
+        if (!body || typeof body.bucket !== 'number') {
+            ball.hidden = true;
+            return;
+        }
+        animateDrop(body.bucket).then(() => {
+            highlightLanded(body.bucket);
+            if (window.CasinoSounds) window.CasinoSounds.play('click');
+            if (pendingResolve) {
+                const r = pendingResolve;
+                pendingResolve = null;
+                r();
+            }
+        });
     }
 
     window.TobyCasinoGame.init({
@@ -92,27 +276,21 @@ function renderPlinkoResult(resultEl, body) {
         resultEl: els.resultEl,
         tobyCoins: els.tobyCoins,
         marketPrice: els.marketPrice,
-        minSettleMs: DROP_DURATION_MS,
+        minSettleMs: DROP_MS,
         failureMessage: 'Drop failed.',
         validate: function () {
             if (!selectedRisk()) return 'Pick a risk profile first.';
             return null;
         },
         buildPayload: function (state) {
-            const signals = botSuspicion ? botSuspicion.snapshotAndReset() : {
-                clickX: null, clickY: null, mouseMoved: null,
-            };
             return {
                 stake: state.stake,
                 risk: selectedRisk(),
                 autoTopUp: state.autoTopUp,
-                clickX: signals.clickX,
-                clickY: signals.clickY,
-                mouseMoved: signals.mouseMoved,
             };
         },
-        startAnimation: startDropAnimation,
-        stopAnimation: stopDropAnimation,
+        startAnimation: startAnimation,
+        stopAnimation: stopAnimation,
         renderResult: function (body) { renderPlinkoResult(els.resultEl, body); },
         flashTarget: tableEl,
     });

--- a/web/src/main/resources/static/js/plinko.js
+++ b/web/src/main/resources/static/js/plinko.js
@@ -180,10 +180,13 @@ function renderPlinkoResult(resultEl, body) {
 
     function animateDrop(targetBucket) {
         const path = decisionPath(targetBucket);
-        // X waypoints — start at (0, -BALL_R), then after each row k the
-        // ball is at `cum * PEG_X / 2` where cum = sum(decisions[0..k]).
-        // Each waypoint y sits just below the row's pegs.
-        const waypoints = [{ x: 0, y: -BALL_R }];
+        // X waypoints — start just below the top of the viewBox so the
+        // ball is visible from frame 0 (default SVG overflow clips
+        // anything outside viewBox), then after each row k the ball is
+        // at `cum * PEG_X / 2` where cum = sum(decisions[0..k]). Each
+        // waypoint y sits just below the row's pegs.
+        const START_Y = BALL_R + 4;
+        const waypoints = [{ x: 0, y: START_Y }];
         let cum = 0;
         for (let row = 0; row < ROWS; row++) {
             cum += path[row];
@@ -195,7 +198,8 @@ function renderPlinkoResult(resultEl, body) {
         // Final waypoint: settle into the bucket centre.
         waypoints.push({ x: bucketCenterX(targetBucket), y: BUCKET_Y_TOP + BUCKET_H / 2 });
 
-        ball.hidden = false;
+        // Snap to start; the ball was already visible at cy=8 on page
+        // load, so animateDrop continues from there.
         ball.setAttribute('cx', '0');
         ball.setAttribute('cy', '0');
         ball.setAttribute('transform', 'translate(' + waypoints[0].x + ',' + waypoints[0].y + ')');
@@ -250,10 +254,7 @@ function renderPlinkoResult(resultEl, body) {
     }
 
     function stopAnimation(_intervalId, body) {
-        if (!body || typeof body.bucket !== 'number') {
-            ball.hidden = true;
-            return;
-        }
+        if (!body || typeof body.bucket !== 'number') return;
         animateDrop(body.bucket).then(() => {
             highlightLanded(body.bucket);
             if (window.CasinoSounds) window.CasinoSounds.play('click');

--- a/web/src/main/resources/static/js/plinko.js
+++ b/web/src/main/resources/static/js/plinko.js
@@ -242,29 +242,21 @@ function renderPlinkoResult(resultEl, body) {
         });
     });
 
-    let pendingResolve = null;
-
     function startAnimation() {
         clearLandedHighlight();
         if (window.CasinoSounds) window.CasinoSounds.play('deal');
-        // The drop animation can't start until we know which bucket to
-        // aim for — we kick it off from stopAnimation once the server
-        // response arrives. Here we just clear stale state.
+        // The drop animation runs in renderResult so it kicks off the
+        // moment the response lands (not after a minSettleMs wait). We
+        // just clear stale state here so the previous bucket highlight
+        // goes away the instant the player presses Drop again.
         return null;
     }
 
-    function stopAnimation(_intervalId, body) {
-        if (!body || typeof body.bucket !== 'number') return;
-        animateDrop(body.bucket).then(() => {
-            highlightLanded(body.bucket);
-            if (window.CasinoSounds) window.CasinoSounds.play('click');
-            if (pendingResolve) {
-                const r = pendingResolve;
-                pendingResolve = null;
-                r();
-            }
-        });
-    }
+    // The settle / result-line paint is driven by renderResult — see
+    // the TobyCasinoGame.init config below. stopAnimation has nothing
+    // to clean up: startAnimation didn't allocate anything, and the
+    // animation is owned by the renderResult Promise.
+    function stopAnimation() {}
 
     window.TobyCasinoGame.init({
         guildId: els.guildId,
@@ -277,7 +269,14 @@ function renderPlinkoResult(resultEl, body) {
         resultEl: els.resultEl,
         tobyCoins: els.tobyCoins,
         marketPrice: els.marketPrice,
-        minSettleMs: DROP_MS,
+        // minSettleMs: 0 so casino-game.js fires renderResult the moment
+        // the response lands. The drop animation runs inside renderResult
+        // and returns a Promise that casino-game.js's finishSettle awaits
+        // before bumping the balance and dropping the chip flourish.
+        // Without this, the animation would queue behind a minSettleMs
+        // wait that sits empty (no startAnimation visuals), and the
+        // ball appears to "not move" for the first ~DROP_MS of the round.
+        minSettleMs: 0,
         failureMessage: 'Drop failed.',
         validate: function () {
             if (!selectedRisk()) return 'Pick a risk profile first.';
@@ -292,7 +291,20 @@ function renderPlinkoResult(resultEl, body) {
         },
         startAnimation: startAnimation,
         stopAnimation: stopAnimation,
-        renderResult: function (body) { renderPlinkoResult(els.resultEl, body); },
+        renderResult: function (body) {
+            // Drop, then highlight the bucket, then paint the result line.
+            // The returned Promise gates finishSettle so the chip flourish
+            // and balance bump land after the ball does — no spoiler.
+            if (!body || typeof body.bucket !== 'number') {
+                renderPlinkoResult(els.resultEl, body);
+                return undefined;
+            }
+            return animateDrop(body.bucket).then(() => {
+                highlightLanded(body.bucket);
+                if (window.CasinoSounds) window.CasinoSounds.play('click');
+                renderPlinkoResult(els.resultEl, body);
+            });
+        },
         flashTarget: tableEl,
     });
 })();

--- a/web/src/main/resources/static/js/plinko.js
+++ b/web/src/main/resources/static/js/plinko.js
@@ -41,6 +41,20 @@ function renderPlinkoResult(resultEl, body) {
 
     const DROP_DURATION_MS = 900;
 
+    // Anti-autoclicker telemetry: same shape as dice/coinflip/slots — capture
+    // (clickX, clickY) from the bet button + a doc-level mousemove flag,
+    // forward both to the backend so CasinoBotSuspicionService can score
+    // the player's pattern. Genuine cursor motion clears the streak.
+    const botSuspicion = window.TobyCasinoBotSuspicion &&
+        window.TobyCasinoBotSuspicion.createTracker();
+    if (botSuspicion) {
+        document.addEventListener('mousemove', botSuspicion.recordMouseMove, { passive: true });
+        [els.primaryBtn, els.tobyBtn].forEach(function (btn) {
+            if (!btn) return;
+            btn.addEventListener('click', botSuspicion.recordClick, true);
+        });
+    }
+
     function selectedRisk() {
         const checked = els.form.querySelector('input[name="risk"]:checked');
         return checked ? checked.value : null;
@@ -85,10 +99,16 @@ function renderPlinkoResult(resultEl, body) {
             return null;
         },
         buildPayload: function (state) {
+            const signals = botSuspicion ? botSuspicion.snapshotAndReset() : {
+                clickX: null, clickY: null, mouseMoved: null,
+            };
             return {
                 stake: state.stake,
                 risk: selectedRisk(),
                 autoTopUp: state.autoTopUp,
+                clickX: signals.clickX,
+                clickY: signals.clickY,
+                mouseMoved: signals.mouseMoved,
             };
         },
         startAnimation: startDropAnimation,

--- a/web/src/main/resources/static/js/plinko.js
+++ b/web/src/main/resources/static/js/plinko.js
@@ -153,6 +153,16 @@ function renderPlinkoResult(resultEl, body) {
         if (rect) rect.classList.add('plinko-bucket-landed');
     }
 
+    // Highlight the active risk's column in the payouts table — same
+    // info the SVG buckets show, but the table-form is the comparison
+    // view across all three profiles. Tinting the active column makes
+    // it obvious which row of multipliers the player is actually playing.
+    function highlightPayoutColumn(risk) {
+        document.querySelectorAll('.plinko-payouts-table [data-risk]').forEach(el => {
+            el.classList.toggle('plinko-payout-active', el.getAttribute('data-risk') === risk);
+        });
+    }
+
     /**
      * Build a sequence of `ROWS` left/right decisions (-1 / +1) that
      * sum to `K - ROWS/2` right-shifts, picking K out of ROWS as right.
@@ -232,6 +242,7 @@ function renderPlinkoResult(resultEl, body) {
     // Initial paint.
     renderPegs();
     renderBuckets(selectedRisk());
+    highlightPayoutColumn(selectedRisk());
 
     // Re-paint bucket labels when the risk profile changes so the player
     // sees the multipliers they're actually playing for before pressing Drop.
@@ -239,6 +250,7 @@ function renderPlinkoResult(resultEl, body) {
         input.addEventListener('change', () => {
             clearLandedHighlight();
             renderBuckets(selectedRisk());
+            highlightPayoutColumn(selectedRisk());
         });
     });
 

--- a/web/src/main/resources/static/js/plinko.js
+++ b/web/src/main/resources/static/js/plinko.js
@@ -1,0 +1,103 @@
+// Pure-DOM render for a /drop response. Hoisted out of the IIFE for tests.
+function renderPlinkoResult(resultEl, body) {
+    if (typeof window === 'undefined' || !window.TobyCasinoResult) return;
+    const mult = (body && typeof body.multiplier === 'number')
+        ? body.multiplier.toFixed(2).replace(/\.?0+$/, '') + '×'
+        : '?';
+    const bucket = (body && typeof body.bucket === 'number') ? body.bucket : '?';
+    const isPush = !!(body && body.push);
+    const winLine = '<strong>Bucket ' + bucket + ' &middot; ' + mult + '</strong>' +
+        (body && typeof body.net === 'number'
+            ? ' &middot; <strong>+' + body.net + ' credits</strong>'
+            : '');
+    let loseLine = '<strong>Bucket ' + bucket + ' &middot; ' + mult + '</strong>';
+    if (isPush) {
+        loseLine += ' &middot; <span>refund — net 0</span>';
+    } else if (body && typeof body.net === 'number') {
+        loseLine += ' &middot; lost <strong>' + Math.abs(body.net) + ' credits</strong>';
+    }
+    window.TobyCasinoResult.render({
+        resultEl: resultEl,
+        body: body,
+        classPrefix: 'plinko',
+        winLineHtml: winLine,
+        loseLineHtml: loseLine,
+    });
+}
+
+(function () {
+    'use strict';
+
+    const els = window.TobyCasinoMinigameDom &&
+        window.TobyCasinoMinigameDom.standardElements('plinko', 'drop');
+    if (!els) return;
+
+    const board = document.getElementById('plinko-board');
+    const ball = document.getElementById('plinko-ball');
+    const bucketsEl = document.getElementById('plinko-buckets');
+    const tableEl = document.querySelector('.plinko-table');
+
+    if (!els.form || !els.primaryBtn || !els.stakeInput || !board || !ball || !bucketsEl) return;
+
+    const DROP_DURATION_MS = 900;
+
+    function selectedRisk() {
+        const checked = els.form.querySelector('input[name="risk"]:checked');
+        return checked ? checked.value : null;
+    }
+
+    function startDropAnimation() {
+        ball.hidden = false;
+        board.classList.add('dropping');
+        if (window.CasinoSounds) window.CasinoSounds.play('deal');
+    }
+
+    function stopDropAnimation(_intervalId, body) {
+        board.classList.remove('dropping');
+        if (body && typeof body.bucket === 'number') {
+            // Highlight the landed bucket; CSS owns the bounce.
+            bucketsEl.querySelectorAll('.plinko-bucket').forEach(function (el) {
+                el.classList.toggle(
+                    'plinko-bucket-landed',
+                    Number(el.dataset.index) === body.bucket
+                );
+            });
+            if (window.CasinoSounds) window.CasinoSounds.play('click');
+        }
+        ball.hidden = true;
+    }
+
+    window.TobyCasinoGame.init({
+        guildId: els.guildId,
+        endpoint: '/casino/' + els.guildId + '/plinko/drop',
+        form: els.form,
+        stakeInput: els.stakeInput,
+        primaryBtn: els.primaryBtn,
+        tobyBtn: els.tobyBtn,
+        balanceEl: els.balanceEl,
+        resultEl: els.resultEl,
+        tobyCoins: els.tobyCoins,
+        marketPrice: els.marketPrice,
+        minSettleMs: DROP_DURATION_MS,
+        failureMessage: 'Drop failed.',
+        validate: function () {
+            if (!selectedRisk()) return 'Pick a risk profile first.';
+            return null;
+        },
+        buildPayload: function (state) {
+            return {
+                stake: state.stake,
+                risk: selectedRisk(),
+                autoTopUp: state.autoTopUp,
+            };
+        },
+        startAnimation: startDropAnimation,
+        stopAnimation: stopDropAnimation,
+        renderResult: function (body) { renderPlinkoResult(els.resultEl, body); },
+        flashTarget: tableEl,
+    });
+})();
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { renderPlinkoResult };
+}

--- a/web/src/main/resources/static/js/wheel.js
+++ b/web/src/main/resources/static/js/wheel.js
@@ -1,0 +1,96 @@
+// Pure-DOM render for a /spin response. Hoisted out of the IIFE for tests.
+function renderWheelResult(resultEl, body) {
+    if (typeof window === 'undefined' || !window.TobyCasinoResult) return;
+    const landed = body && body.landed != null ? body.landed + '×' : '?';
+    const pick = body && body.pick != null ? body.pick + '×' : '?';
+    const winLine = '<strong>' + landed + '</strong> &middot; you picked ' + pick +
+        ' &middot; <strong>+' + (body && typeof body.net === 'number' ? body.net : 0) + ' credits</strong>';
+    const loseLine = '<strong>' + landed + '</strong> &middot; you picked ' + pick +
+        ' &middot; lost <strong>' +
+        (body && typeof body.net === 'number' ? Math.abs(body.net) : 0) + ' credits</strong>';
+    window.TobyCasinoResult.render({
+        resultEl: resultEl,
+        body: body,
+        classPrefix: 'wheel',
+        winLineHtml: winLine,
+        loseLineHtml: loseLine,
+    });
+}
+
+(function () {
+    'use strict';
+
+    const els = window.TobyCasinoMinigameDom &&
+        window.TobyCasinoMinigameDom.standardElements('wheel', 'spin');
+    if (!els) return;
+
+    const disc = document.getElementById('wheel-disc');
+    const landedEl = document.getElementById('wheel-landed');
+    const tableEl = document.querySelector('.wheel-table');
+    if (!els.form || !els.primaryBtn || !els.stakeInput || !disc || !landedEl) return;
+
+    const SPIN_DURATION_MS = 900;
+    const SPIN_TICK_MS = 70;
+    const FACES = ['2×', '3×', '5×', '10×'];
+
+    function selectedPick() {
+        const checked = els.form.querySelector('input[name="pick"]:checked');
+        return checked ? parseInt(checked.value, 10) : null;
+    }
+
+    function startSpinAnimation() {
+        disc.classList.add('spinning');
+        if (window.CasinoSounds) window.CasinoSounds.play('deal');
+        return setInterval(function () {
+            const f = FACES[Math.floor(Math.random() * FACES.length)];
+            landedEl.textContent = f;
+        }, SPIN_TICK_MS);
+    }
+
+    function stopSpinAnimation(intervalId, body) {
+        clearInterval(intervalId);
+        disc.classList.remove('spinning');
+        if (body && body.landed != null) {
+            landedEl.textContent = body.landed + '×';
+            disc.dataset.landed = String(body.landed);
+        } else {
+            landedEl.textContent = '?';
+            delete disc.dataset.landed;
+        }
+        if (body && window.CasinoSounds) window.CasinoSounds.play('click');
+    }
+
+    window.TobyCasinoGame.init({
+        guildId: els.guildId,
+        endpoint: '/casino/' + els.guildId + '/wheel/spin',
+        form: els.form,
+        stakeInput: els.stakeInput,
+        primaryBtn: els.primaryBtn,
+        tobyBtn: els.tobyBtn,
+        balanceEl: els.balanceEl,
+        resultEl: els.resultEl,
+        tobyCoins: els.tobyCoins,
+        marketPrice: els.marketPrice,
+        minSettleMs: SPIN_DURATION_MS,
+        failureMessage: 'Spin failed.',
+        validate: function () {
+            if (!selectedPick()) return 'Pick a multiplier first.';
+            return null;
+        },
+        buildPayload: function (state) {
+            return {
+                stake: state.stake,
+                pick: selectedPick(),
+                autoTopUp: state.autoTopUp,
+            };
+        },
+        startAnimation: startSpinAnimation,
+        stopAnimation: stopSpinAnimation,
+        renderResult: function (body) { renderWheelResult(els.resultEl, body); },
+        flashTarget: tableEl,
+    });
+})();
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { renderWheelResult };
+}

--- a/web/src/main/resources/static/js/wheel.js
+++ b/web/src/main/resources/static/js/wheel.js
@@ -1,4 +1,22 @@
-// Pure-DOM render for a /spin response. Hoisted out of the IIFE for tests.
+// Wheel of Fortune renderer + animator.
+//
+// SVG layout mirrors the jackpot wheel (`fragments/casino.html :: jackpotBanner`):
+// brass rim, hub, golden pointer, spoked rotor with pegs. The rotor's
+// spokes are allocated proportional to the multiplier weights the server
+// holds, so the visible wheel IS the wheel the server spun against.
+//
+// Spoke layout: SPOKE_COUNT equal-sized wedges around the rim, allocated
+// across multiplier tiers via Hamilton's largest-remainder method —
+// same approach `casino-jackpot-wheel.js` uses so visual proportions
+// match probability proportions. Higher-weight tiers own more spokes;
+// the spokes are interleaved so colours alternate as the wheel spins.
+//
+// Spin is server-authoritative: the player presses Spin, we POST the
+// stake + pick, the server returns the landed multiplier, and the JS
+// rotates the rotor to bring a wedge of that multiplier under the
+// pointer. Pure animation — the result is decided before the wheel
+// starts moving.
+
 function renderWheelResult(resultEl, body) {
     if (typeof window === 'undefined' || !window.TobyCasinoResult) return;
     const landed = body && body.landed != null ? body.landed + '×' : '?';
@@ -24,51 +42,243 @@ function renderWheelResult(resultEl, body) {
         window.TobyCasinoMinigameDom.standardElements('wheel', 'spin');
     if (!els) return;
 
-    const disc = document.getElementById('wheel-disc');
-    const landedEl = document.getElementById('wheel-landed');
+    const rotor = document.getElementById('wheel-rotor');
+    const statusEl = document.getElementById('wheel-status');
     const tableEl = document.querySelector('.wheel-table');
-    if (!els.form || !els.primaryBtn || !els.stakeInput || !disc || !landedEl) return;
+    if (!els.form || !els.primaryBtn || !els.stakeInput || !rotor) return;
 
-    const SPIN_DURATION_MS = 900;
-    const SPIN_TICK_MS = 70;
-    const FACES = ['2×', '3×', '5×', '10×'];
+    const SVG_NS = 'http://www.w3.org/2000/svg';
+    const SPOKE_COUNT = 24;
+    const SPIN_DURATION_MS = 2200;
+    const SPIN_ROTATIONS = 4;
 
-    // Anti-autoclicker telemetry: same shape as dice/coinflip/slots.
-    const botSuspicion = window.TobyCasinoBotSuspicion &&
-        window.TobyCasinoBotSuspicion.createTracker();
-    if (botSuspicion) {
-        document.addEventListener('mousemove', botSuspicion.recordMouseMove, { passive: true });
-        [els.primaryBtn, els.tobyBtn].forEach(function (btn) {
-            if (!btn) return;
-            btn.addEventListener('click', botSuspicion.recordClick, true);
+    // One colour per multiplier tier so all spokes of the same multiplier
+    // are visually grouped — keeps the wheel readable as it spins.
+    // Order matches the picks ascending: 2× green, 3× blue, 5× purple, 10× gold.
+    const TIER_COLOURS = ['#27ae60', '#2c7fbf', '#6b4fd6', '#e8b923'];
+
+    function readWeights() {
+        const raw = (window && window.__wofWheelWeights) || [];
+        if (!Array.isArray(raw)) return [];
+        return raw
+            .filter(t => t && typeof t.multiplier === 'number' && typeof t.slots === 'number' && t.slots > 0)
+            .map(t => ({ multiplier: t.multiplier, slots: t.slots }))
+            .sort((a, b) => a.multiplier - b.multiplier);
+    }
+
+    // Hamilton's largest-remainder method, copied verbatim from
+    // casino-jackpot-wheel.js. Distributes SPOKE_COUNT spokes across
+    // tiers proportional to weight, with each tier guaranteed at least 1.
+    function allocateSpokes(tiers) {
+        const totalWeight = tiers.reduce((s, t) => s + t.slots, 0);
+        if (totalWeight <= 0 || tiers.length === 0) return [];
+        if (tiers.length >= SPOKE_COUNT) {
+            return tiers.slice(0, SPOKE_COUNT).map(() => 1);
+        }
+        const counts = new Array(tiers.length).fill(1);
+        let allocated = tiers.length;
+        const ideals = tiers.map(t => (t.slots / totalWeight) * SPOKE_COUNT);
+        const remainders = ideals.map((ideal, i) => ({ i, frac: ideal - Math.floor(ideal) }));
+        for (let i = 0; i < tiers.length; i++) {
+            const extra = Math.max(0, Math.floor(ideals[i]) - 1);
+            counts[i] += extra;
+            allocated += extra;
+        }
+        remainders.sort((a, b) => b.frac - a.frac);
+        for (const r of remainders) {
+            if (allocated >= SPOKE_COUNT) break;
+            counts[r.i]++;
+            allocated++;
+        }
+        while (allocated > SPOKE_COUNT) {
+            let maxIdx = -1, maxCount = 1;
+            for (let i = 0; i < counts.length; i++) {
+                if (counts[i] > maxCount) { maxIdx = i; maxCount = counts[i]; }
+            }
+            if (maxIdx < 0) break;
+            counts[maxIdx]--;
+            allocated--;
+        }
+        return counts;
+    }
+
+    // Spread each tier's spokes around the rim so high-weight tiers
+    // don't form one giant arc — same placement algo as the jackpot wheel.
+    function placeSpokes(counts) {
+        const N = counts.reduce((s, c) => s + c, 0);
+        const slots = new Array(N).fill(-1);
+        const order = counts.map((c, i) => ({ i, c })).filter(t => t.c > 0).sort((a, b) => b.c - a.c);
+        let phase = 0;
+        for (const { i, c } of order) {
+            const step = N / c;
+            let pos = phase;
+            for (let j = 0; j < c; j++) {
+                let slot = Math.round(pos) % N;
+                let tries = 0;
+                while (slots[slot] !== -1 && tries < N) {
+                    slot = (slot + 1) % N;
+                    tries++;
+                }
+                slots[slot] = i;
+                pos += step;
+            }
+            phase += step / 2;
+        }
+        return slots;
+    }
+
+    function buildWedgePath(startAngle, endAngle, radius) {
+        const a0 = (startAngle - 90) * Math.PI / 180;
+        const a1 = (endAngle - 90) * Math.PI / 180;
+        const x0 = Math.cos(a0) * radius;
+        const y0 = Math.sin(a0) * radius;
+        const x1 = Math.cos(a1) * radius;
+        const y1 = Math.sin(a1) * radius;
+        const largeArc = (endAngle - startAngle) > 180 ? 1 : 0;
+        return 'M 0 0 L ' + x0.toFixed(2) + ' ' + y0.toFixed(2) +
+            ' A ' + radius + ' ' + radius + ' 0 ' + largeArc + ' 1 ' +
+            x1.toFixed(2) + ' ' + y1.toFixed(2) + ' Z';
+    }
+
+    function renderWheel(tiers) {
+        rotor.innerHTML = '';
+        const counts = allocateSpokes(tiers);
+        if (counts.length === 0) return [];
+        const slots = placeSpokes(counts);
+        const N = slots.length;
+        const sweep = 360 / N;
+        const radius = 100;
+        const spokes = [];
+        for (let s = 0; s < N; s++) {
+            const tierIndex = slots[s];
+            const start = s * sweep;
+            const end = start + sweep;
+            const path = document.createElementNS(SVG_NS, 'path');
+            path.setAttribute('d', buildWedgePath(start, end, radius));
+            path.setAttribute('fill', TIER_COLOURS[tierIndex % TIER_COLOURS.length]);
+            path.setAttribute('class', 'wheel-segment');
+            rotor.appendChild(path);
+
+            const mid = (start + end) / 2;
+            const labelR = radius * 0.72;
+            const lx = Math.cos((mid - 90) * Math.PI / 180) * labelR;
+            const ly = Math.sin((mid - 90) * Math.PI / 180) * labelR;
+            const text = document.createElementNS(SVG_NS, 'text');
+            text.setAttribute('x', lx.toFixed(2));
+            text.setAttribute('y', ly.toFixed(2));
+            text.setAttribute('class', 'wheel-segment-label');
+            text.setAttribute('transform', 'rotate(' + mid.toFixed(2) + ' ' + lx.toFixed(2) + ' ' + ly.toFixed(2) + ')');
+            text.textContent = tiers[tierIndex].multiplier + '×';
+            rotor.appendChild(text);
+
+            spokes.push({ tierIndex, mid, multiplier: tiers[tierIndex].multiplier });
+        }
+        // Brass pegs at every spoke boundary, riding inside the rotor so
+        // they spin with the wheel — same visual cue the jackpot wheel uses.
+        const pegRadius = 94;
+        for (let s = 0; s < N; s++) {
+            const angle = s * sweep;
+            const px = Math.cos((angle - 90) * Math.PI / 180) * pegRadius;
+            const py = Math.sin((angle - 90) * Math.PI / 180) * pegRadius;
+            const peg = document.createElementNS(SVG_NS, 'circle');
+            peg.setAttribute('cx', px.toFixed(2));
+            peg.setAttribute('cy', py.toFixed(2));
+            peg.setAttribute('r', '2.6');
+            peg.setAttribute('class', 'wheel-peg');
+            rotor.appendChild(peg);
+        }
+        return spokes;
+    }
+
+    function prefersReducedMotion() {
+        return typeof window !== 'undefined' && window.matchMedia &&
+            window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    }
+
+    let currentSpokes = renderWheel(readWeights());
+
+    // Re-paint the picker selection's spoke colour into the picker chip
+    // so the player sees which wedges they're betting on as they
+    // toggle the pick radio.
+    function tintPickerChips() {
+        const tiers = readWeights();
+        els.form.querySelectorAll('.wheel-pick span[data-multiplier]').forEach(el => {
+            const mult = Number(el.getAttribute('data-multiplier'));
+            const idx = tiers.findIndex(t => t.multiplier === mult);
+            if (idx >= 0) {
+                el.style.setProperty('--wheel-pick-tint', TIER_COLOURS[idx % TIER_COLOURS.length]);
+            }
         });
     }
+    tintPickerChips();
 
     function selectedPick() {
         const checked = els.form.querySelector('input[name="pick"]:checked');
         return checked ? parseInt(checked.value, 10) : null;
     }
 
-    function startSpinAnimation() {
-        disc.classList.add('spinning');
+    function startAnimation() {
+        if (statusEl) statusEl.textContent = 'Spinning…';
         if (window.CasinoSounds) window.CasinoSounds.play('deal');
-        return setInterval(function () {
-            const f = FACES[Math.floor(Math.random() * FACES.length)];
-            landedEl.textContent = f;
-        }, SPIN_TICK_MS);
+        return null;
     }
 
-    function stopSpinAnimation(intervalId, body) {
-        clearInterval(intervalId);
-        disc.classList.remove('spinning');
-        if (body && body.landed != null) {
-            landedEl.textContent = body.landed + '×';
-            disc.dataset.landed = String(body.landed);
-        } else {
-            landedEl.textContent = '?';
-            delete disc.dataset.landed;
+    function spinToMultiplier(landed) {
+        if (!currentSpokes.length) return Promise.resolve();
+        const target = currentSpokes.find(s => s.multiplier === landed);
+        if (!target) return Promise.resolve();
+        // Snap rotor back to 0 before animating so successive spins
+        // start from a known transform — same pattern casino-jackpot-wheel
+        // uses to avoid accumulated-rotation drift. The pointer sits at
+        // angle 0 (top), so to bring the wedge midpoint under it we
+        // rotate by `360 - mid`, plus full rotations for drama.
+        const finalAngle = SPIN_ROTATIONS * 360 + (360 - (target.mid % 360));
+        rotor.style.transition = 'none';
+        rotor.style.transform = 'rotate(0deg)';
+        // Force a layout read so the browser registers the snap-back
+        // before the next transition kicks in. Without this, the
+        // browser collapses both transform writes into the easing curve
+        // and the wheel spins backwards from the previous resting angle.
+        // eslint-disable-next-line no-unused-expressions
+        rotor.getBoundingClientRect();
+        rotor.style.transition = '';
+        if (prefersReducedMotion()) {
+            rotor.style.transition = 'none';
+            rotor.style.transform = 'rotate(' + finalAngle + 'deg)';
+            return Promise.resolve();
         }
-        if (body && window.CasinoSounds) window.CasinoSounds.play('click');
+        return new Promise(resolve => {
+            const onEnd = () => {
+                rotor.removeEventListener('transitionend', onEnd);
+                resolve();
+            };
+            rotor.addEventListener('transitionend', onEnd);
+            // Belt-and-braces: resolve even if transitionend doesn't fire
+            // (tab switch mid-spin, GPU stalls, etc.).
+            setTimeout(() => {
+                rotor.removeEventListener('transitionend', onEnd);
+                resolve();
+            }, SPIN_DURATION_MS + 400);
+            requestAnimationFrame(() => {
+                rotor.style.transition = 'transform ' + SPIN_DURATION_MS + 'ms cubic-bezier(0.18, 0.6, 0.18, 1)';
+                rotor.style.transform = 'rotate(' + finalAngle + 'deg)';
+            });
+        });
+    }
+
+    function stopAnimation(_intervalId, body) {
+        if (!body || body.landed == null) {
+            if (statusEl) statusEl.textContent = 'Pick a multiplier and press Spin.';
+            return;
+        }
+        spinToMultiplier(body.landed).then(() => {
+            if (statusEl) {
+                statusEl.textContent = body.win
+                    ? 'Landed ' + body.landed + '× — match!'
+                    : 'Landed ' + body.landed + '× — no match.';
+            }
+            if (window.CasinoSounds) window.CasinoSounds.play('click');
+        });
     }
 
     window.TobyCasinoGame.init({
@@ -89,20 +299,14 @@ function renderWheelResult(resultEl, body) {
             return null;
         },
         buildPayload: function (state) {
-            const signals = botSuspicion ? botSuspicion.snapshotAndReset() : {
-                clickX: null, clickY: null, mouseMoved: null,
-            };
             return {
                 stake: state.stake,
                 pick: selectedPick(),
                 autoTopUp: state.autoTopUp,
-                clickX: signals.clickX,
-                clickY: signals.clickY,
-                mouseMoved: signals.mouseMoved,
             };
         },
-        startAnimation: startSpinAnimation,
-        stopAnimation: stopSpinAnimation,
+        startAnimation: startAnimation,
+        stopAnimation: stopAnimation,
         renderResult: function (body) { renderWheelResult(els.resultEl, body); },
         flashTarget: tableEl,
     });

--- a/web/src/main/resources/static/js/wheel.js
+++ b/web/src/main/resources/static/js/wheel.js
@@ -227,21 +227,23 @@ function renderWheelResult(resultEl, body) {
         if (!currentSpokes.length) return Promise.resolve();
         const target = currentSpokes.find(s => s.multiplier === landed);
         if (!target) return Promise.resolve();
-        // Snap rotor back to 0 before animating so successive spins
-        // start from a known transform — same pattern casino-jackpot-wheel
-        // uses to avoid accumulated-rotation drift. The pointer sits at
-        // angle 0 (top), so to bring the wedge midpoint under it we
-        // rotate by `360 - mid`, plus full rotations for drama.
+        // Pointer sits at angle 0 (top of the wheel). To bring the wedge
+        // midpoint under it we rotate by `360 - mid`, plus full rotations
+        // for drama. Snap rotor back to 0 first so successive spins
+        // start from a known transform — same dance casino-jackpot-wheel
+        // uses to avoid accumulated-rotation drift. The CSS transition
+        // is owned by `.wheel-rotor` (not inline) so the browser keeps a
+        // stable starting state across both the snap and the spin.
         const finalAngle = SPIN_ROTATIONS * 360 + (360 - (target.mid % 360));
         rotor.style.transition = 'none';
         rotor.style.transform = 'rotate(0deg)';
         // Force a layout read so the browser registers the snap-back
-        // before the next transition kicks in. Without this, the
-        // browser collapses both transform writes into the easing curve
-        // and the wheel spins backwards from the previous resting angle.
+        // as a discrete style change before the CSS transition kicks
+        // in. Without this, the browser collapses both transform writes
+        // into the easing curve and the wheel "spins" by zero degrees.
         // eslint-disable-next-line no-unused-expressions
         rotor.getBoundingClientRect();
-        rotor.style.transition = '';
+        rotor.style.transition = '';  // restore the CSS transition
         if (prefersReducedMotion()) {
             rotor.style.transition = 'none';
             rotor.style.transform = 'rotate(' + finalAngle + 'deg)';
@@ -260,7 +262,6 @@ function renderWheelResult(resultEl, body) {
                 resolve();
             }, SPIN_DURATION_MS + 400);
             requestAnimationFrame(() => {
-                rotor.style.transition = 'transform ' + SPIN_DURATION_MS + 'ms cubic-bezier(0.18, 0.6, 0.18, 1)';
                 rotor.style.transform = 'rotate(' + finalAngle + 'deg)';
             });
         });

--- a/web/src/main/resources/static/js/wheel.js
+++ b/web/src/main/resources/static/js/wheel.js
@@ -33,6 +33,17 @@ function renderWheelResult(resultEl, body) {
     const SPIN_TICK_MS = 70;
     const FACES = ['2×', '3×', '5×', '10×'];
 
+    // Anti-autoclicker telemetry: same shape as dice/coinflip/slots.
+    const botSuspicion = window.TobyCasinoBotSuspicion &&
+        window.TobyCasinoBotSuspicion.createTracker();
+    if (botSuspicion) {
+        document.addEventListener('mousemove', botSuspicion.recordMouseMove, { passive: true });
+        [els.primaryBtn, els.tobyBtn].forEach(function (btn) {
+            if (!btn) return;
+            btn.addEventListener('click', botSuspicion.recordClick, true);
+        });
+    }
+
     function selectedPick() {
         const checked = els.form.querySelector('input[name="pick"]:checked');
         return checked ? parseInt(checked.value, 10) : null;
@@ -78,10 +89,16 @@ function renderWheelResult(resultEl, body) {
             return null;
         },
         buildPayload: function (state) {
+            const signals = botSuspicion ? botSuspicion.snapshotAndReset() : {
+                clickX: null, clickY: null, mouseMoved: null,
+            };
             return {
                 stake: state.stake,
                 pick: selectedPick(),
                 autoTopUp: state.autoTopUp,
+                clickX: signals.clickX,
+                clickY: signals.clickY,
+                mouseMoved: signals.mouseMoved,
             };
         },
         startAnimation: startSpinAnimation,

--- a/web/src/main/resources/static/js/wheel.js
+++ b/web/src/main/resources/static/js/wheel.js
@@ -217,6 +217,13 @@ function renderWheelResult(resultEl, body) {
         return checked ? parseInt(checked.value, 10) : null;
     }
 
+    // Cumulative rotation — every spin adds SPIN_ROTATIONS full turns
+    // plus the delta to bring the target wedge under the pointer. One
+    // transform write per spin against the CSS-defined transition (no
+    // snap-back, no inline transition juggling), so browsers reliably
+    // animate the forward jump.
+    let currentRotation = 0;
+
     function startAnimation() {
         if (statusEl) statusEl.textContent = 'Spinning…';
         if (window.CasinoSounds) window.CasinoSounds.play('deal');
@@ -227,26 +234,19 @@ function renderWheelResult(resultEl, body) {
         if (!currentSpokes.length) return Promise.resolve();
         const target = currentSpokes.find(s => s.multiplier === landed);
         if (!target) return Promise.resolve();
-        // Pointer sits at angle 0 (top of the wheel). To bring the wedge
-        // midpoint under it we rotate by `360 - mid`, plus full rotations
-        // for drama. Snap rotor back to 0 first so successive spins
-        // start from a known transform — same dance casino-jackpot-wheel
-        // uses to avoid accumulated-rotation drift. The CSS transition
-        // is owned by `.wheel-rotor` (not inline) so the browser keeps a
-        // stable starting state across both the snap and the spin.
-        const finalAngle = SPIN_ROTATIONS * 360 + (360 - (target.mid % 360));
-        rotor.style.transition = 'none';
-        rotor.style.transform = 'rotate(0deg)';
-        // Force a layout read so the browser registers the snap-back
-        // as a discrete style change before the CSS transition kicks
-        // in. Without this, the browser collapses both transform writes
-        // into the easing curve and the wheel "spins" by zero degrees.
-        // eslint-disable-next-line no-unused-expressions
-        rotor.getBoundingClientRect();
-        rotor.style.transition = '';  // restore the CSS transition
+        // Where the target wedge currently sits relative to the pointer
+        // (angle 0, top of the wheel). Modulo 360 + add-360-and-mod to
+        // keep the value in [0, 360) regardless of currentRotation sign.
+        const currentWedgeAngle = ((target.mid + currentRotation) % 360 + 360) % 360;
+        // Forward rotation needed to bring the wedge to the top.
+        const deltaToTop = (360 - currentWedgeAngle) % 360;
+        currentRotation += SPIN_ROTATIONS * 360 + deltaToTop;
+
         if (prefersReducedMotion()) {
-            rotor.style.transition = 'none';
-            rotor.style.transform = 'rotate(' + finalAngle + 'deg)';
+            // Skip the easing — go straight to the resting angle. CSS's
+            // reduced-motion rule already disables the transition, so the
+            // jump is instant.
+            rotor.style.transform = 'rotate(' + currentRotation + 'deg)';
             return Promise.resolve();
         }
         return new Promise(resolve => {
@@ -262,25 +262,15 @@ function renderWheelResult(resultEl, body) {
                 resolve();
             }, SPIN_DURATION_MS + 400);
             requestAnimationFrame(() => {
-                rotor.style.transform = 'rotate(' + finalAngle + 'deg)';
+                rotor.style.transform = 'rotate(' + currentRotation + 'deg)';
             });
         });
     }
 
-    function stopAnimation(_intervalId, body) {
-        if (!body || body.landed == null) {
-            if (statusEl) statusEl.textContent = 'Pick a multiplier and press Spin.';
-            return;
-        }
-        spinToMultiplier(body.landed).then(() => {
-            if (statusEl) {
-                statusEl.textContent = body.win
-                    ? 'Landed ' + body.landed + '× — match!'
-                    : 'Landed ' + body.landed + '× — no match.';
-            }
-            if (window.CasinoSounds) window.CasinoSounds.play('click');
-        });
-    }
+    // The settle / result-line paint is driven by renderResult below;
+    // stopAnimation has nothing to clean up (startAnimation didn't
+    // allocate anything and the spin lives inside renderResult's Promise).
+    function stopAnimation() {}
 
     window.TobyCasinoGame.init({
         guildId: els.guildId,
@@ -293,7 +283,14 @@ function renderWheelResult(resultEl, body) {
         resultEl: els.resultEl,
         tobyCoins: els.tobyCoins,
         marketPrice: els.marketPrice,
-        minSettleMs: SPIN_DURATION_MS,
+        // minSettleMs: 0 so casino-game.js fires renderResult the moment
+        // the response lands. The spin animation runs inside renderResult
+        // and returns a Promise that casino-game.js's finishSettle awaits
+        // before bumping the balance and dropping the chip flourish.
+        // Without this, the wheel would queue behind a SPIN_DURATION_MS
+        // wait that sits empty, and the rotor only starts moving after
+        // the wait — exactly the "freezes and moves at the end" symptom.
+        minSettleMs: 0,
         failureMessage: 'Spin failed.',
         validate: function () {
             if (!selectedPick()) return 'Pick a multiplier first.';
@@ -308,7 +305,22 @@ function renderWheelResult(resultEl, body) {
         },
         startAnimation: startAnimation,
         stopAnimation: stopAnimation,
-        renderResult: function (body) { renderWheelResult(els.resultEl, body); },
+        renderResult: function (body) {
+            if (!body || body.landed == null) {
+                if (statusEl) statusEl.textContent = 'Pick a multiplier and press Spin.';
+                renderWheelResult(els.resultEl, body);
+                return undefined;
+            }
+            return spinToMultiplier(body.landed).then(() => {
+                if (statusEl) {
+                    statusEl.textContent = body.win
+                        ? 'Landed ' + body.landed + '× — match!'
+                        : 'Landed ' + body.landed + '× — no match.';
+                }
+                if (window.CasinoSounds) window.CasinoSounds.play('click');
+                renderWheelResult(els.resultEl, body);
+            });
+        },
         flashTarget: tableEl,
     });
 })();

--- a/web/src/main/resources/templates/casino-guilds.html
+++ b/web/src/main/resources/templates/casino-guilds.html
@@ -40,6 +40,10 @@
                            th:href="@{/casino/{id}/scratch(id=${g.id})}">🎟️ Scratch</a>
                         <a class="btn-secondary"
                            th:href="@{/casino/{id}/slots(id=${g.id})}">🎰 Slots</a>
+                        <a class="btn-secondary"
+                           th:href="@{/casino/{id}/plinko(id=${g.id})}">🟢 Plinko</a>
+                        <a class="btn-secondary"
+                           th:href="@{/casino/{id}/wheel(id=${g.id})}">🎡 Wheel</a>
                     </div>
                 </div>
                 <div class="lb-games-group">

--- a/web/src/main/resources/templates/fragments/navbar.html
+++ b/web/src/main/resources/templates/fragments/navbar.html
@@ -39,6 +39,8 @@
                 <a href="/casino/guilds" role="menuitem">&#127905; Roulette</a>
                 <a href="/casino/guilds" role="menuitem">&#127924; Baccarat</a>
                 <a href="/casino/guilds" role="menuitem">&#127183; Casino Hold'em</a>
+                <a href="/casino/guilds" role="menuitem">&#128994; Plinko</a>
+                <a href="/casino/guilds" role="menuitem">&#127905; Wheel</a>
                 <hr class="nav-dropdown-separator" aria-hidden="true">
                 <a href="/poker/guilds" role="menuitem">&#127924; Poker</a>
                 <a href="/blackjack/guilds" role="menuitem">&#127922; Blackjack</a>

--- a/web/src/main/resources/templates/home.html
+++ b/web/src/main/resources/templates/home.html
@@ -61,8 +61,8 @@
         <a class="feature-card" href="/casino/guilds">
             <div class="feature-icon">&#127920;</div>
             <h3>Casino games</h3>
-            <p>9 quick-play minigames (slots, dice, roulette, scratch, keno, high-low, baccarat, coinflip, Casino Hold&rsquo;em) plus seated Poker and Blackjack tables.</p>
-            <span class="feature-card-tag">12 games</span>
+            <p>11 quick-play minigames (slots, dice, roulette, scratch, keno, high-low, baccarat, coinflip, plinko, wheel, Casino Hold&rsquo;em) plus seated Poker and Blackjack tables.</p>
+            <span class="feature-card-tag">14 games</span>
         </a>
         <a class="feature-card" href="/lottery/guilds">
             <div class="feature-icon">&#127903;&#65039;</div>

--- a/web/src/main/resources/templates/moderation/settings.html
+++ b/web/src/main/resources/templates/moderation/settings.html
@@ -658,6 +658,44 @@
                     </div>
                 </div>
                 <div class="config-group">
+                    <h4>Plinko</h4>
+                    <div class="config-row" data-key="PLINKO_MIN_STAKE">
+                        <label>Minimum stake (default 10)</label>
+                        <input type="number" min="1"
+                               th:value="${overview.config['PLINKO_MIN_STAKE']}"
+                               placeholder="10"
+                               th:disabled="${!isOwner}">
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
+                    <div class="config-row" data-key="PLINKO_MAX_STAKE">
+                        <label>Maximum stake (0 = unlimited; default 500)</label>
+                        <input type="number" min="0"
+                               th:value="${overview.config['PLINKO_MAX_STAKE']}"
+                               placeholder="500"
+                               th:disabled="${!isOwner}">
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
+                </div>
+                <div class="config-group">
+                    <h4>Wheel of Fortune</h4>
+                    <div class="config-row" data-key="WHEEL_OF_FORTUNE_MIN_STAKE">
+                        <label>Minimum stake (default 10)</label>
+                        <input type="number" min="1"
+                               th:value="${overview.config['WHEEL_OF_FORTUNE_MIN_STAKE']}"
+                               placeholder="10"
+                               th:disabled="${!isOwner}">
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
+                    <div class="config-row" data-key="WHEEL_OF_FORTUNE_MAX_STAKE">
+                        <label>Maximum stake (0 = unlimited; default 500)</label>
+                        <input type="number" min="0"
+                               th:value="${overview.config['WHEEL_OF_FORTUNE_MAX_STAKE']}"
+                               placeholder="500"
+                               th:disabled="${!isOwner}">
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
+                </div>
+                <div class="config-group">
                     <h4>Casino Hold'em</h4>
                     <div class="config-row" data-key="HOLDEM_MIN_STAKE">
                         <label>Minimum stake (default 10)</label>

--- a/web/src/main/resources/templates/moderation/settings.html
+++ b/web/src/main/resources/templates/moderation/settings.html
@@ -348,6 +348,28 @@
                     </span>
                     <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
                 </div>
+                <div class="config-row" data-key="PLINKO_BOT_EDGE_MAX_PCT">
+                    <label>Plinko — max bot-suspicion house edge. Fair RTP ≈ 89 % → suspect RTP ≈ <code>89 × (1 − cap/100)</code> %. Default 30 → suspect RTP ≈ 62 %. 0 disables.</label>
+                    <span class="config-input-group">
+                        <input type="number" min="0" max="50"
+                               th:value="${overview.config['PLINKO_BOT_EDGE_MAX_PCT']}"
+                               placeholder="30"
+                               th:disabled="${!isOwner}">
+                        <span class="config-suffix">%</span>
+                    </span>
+                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                </div>
+                <div class="config-row" data-key="WHEEL_OF_FORTUNE_BOT_EDGE_MAX_PCT">
+                    <label>Wheel of Fortune — max bot-suspicion house edge. Fair RTP ≈ 88 % → suspect RTP ≈ <code>88 × (1 − cap/100)</code> %. Default 30 → suspect RTP ≈ 62 %. 0 disables.</label>
+                    <span class="config-input-group">
+                        <input type="number" min="0" max="50"
+                               th:value="${overview.config['WHEEL_OF_FORTUNE_BOT_EDGE_MAX_PCT']}"
+                               placeholder="30"
+                               th:disabled="${!isOwner}">
+                        <span class="config-suffix">%</span>
+                    </span>
+                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                </div>
                 <div class="config-row" data-key="CASINO_MODLOG_CHANNEL_ID">
                     <label>Casino mod-log channel (where anti-autoclicker session embeds post; falls back to system channel)</label>
                     <select th:disabled="${!isOwner}">

--- a/web/src/main/resources/templates/plinko.html
+++ b/web/src/main/resources/templates/plinko.html
@@ -57,7 +57,7 @@
                 </defs>
                 <g class="plinko-pegs" id="plinko-pegs"></g>
                 <g class="plinko-buckets-svg" id="plinko-buckets"></g>
-                <circle id="plinko-ball" class="plinko-ball" r="4" cx="0" cy="0" hidden
+                <circle id="plinko-ball" class="plinko-ball" r="5" cx="0" cy="8"
                         filter="url(#plinko-ball-shadow)"/>
             </svg>
         </div>

--- a/web/src/main/resources/templates/plinko.html
+++ b/web/src/main/resources/templates/plinko.html
@@ -104,20 +104,30 @@
 
     <section class="plinko-payouts">
         <h2>Payout tables (× stake)</h2>
-        <table>
-            <thead>
-            <tr>
-                <th>Risk</th>
-                <th th:each="i : ${#numbers.sequence(0, buckets - 1)}" th:text="${i}">0</th>
-            </tr>
-            </thead>
-            <tbody>
-            <tr th:each="r : ${risks}">
-                <td th:text="${r}">LOW</td>
-                <td th:each="m : ${payoutTables.get(r)}" th:text="${m}">1.0</td>
-            </tr>
-            </tbody>
-        </table>
+        <!--
+            Transposed: rows are buckets, columns are risk profiles.
+            On mobile that's 4 columns instead of 10, and the active risk's
+            column is highlighted by plinko.js (data-risk + .plinko-payout-active)
+            so the player can compare profiles at a glance.
+        -->
+        <div class="plinko-payouts-table-wrap">
+            <table class="plinko-payouts-table">
+                <thead>
+                <tr>
+                    <th>Bucket</th>
+                    <th th:each="r : ${risks}" th:text="${r}" th:attr="data-risk=${r}">LOW</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr th:each="i : ${#numbers.sequence(0, buckets - 1)}">
+                    <td th:text="${i}">0</td>
+                    <td th:each="r : ${risks}"
+                        th:text="${payoutTables.get(r)[i]}"
+                        th:attr="data-risk=${r}">1.9</td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
         <p class="muted">All three profiles target ~0.90 RTP. Outer buckets pay big;
             center buckets refund (×1), partially lose (×0.4–0.7), or bust (×0).</p>
     </section>

--- a/web/src/main/resources/templates/plinko.html
+++ b/web/src/main/resources/templates/plinko.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="en">
+<head th:replace="~{fragments/head :: head('TobyBot - Plinko', '/css/plinko.css')}"></head>
+<body>
+<a href="#main" class="skip-link">Skip to content</a>
+<div th:replace="~{fragments/navbar :: navbar}"></div>
+
+<main id="main" class="container"
+      th:attr="data-guild-id=${guildId}, data-toby-coins=${tobyCoins}, data-market-price=${marketPrice},
+               data-rows=${rows}, data-buckets=${buckets}">
+
+    <div class="plinko-header">
+        <a class="back-link" th:href="@{/casino/guilds}">&larr; All casino servers</a>
+        <h1 th:text="'🟢 Plinko • ' + ${guildName}">🟢 Plinko</h1>
+        <p class="muted">Drop a ball through
+            <span th:text="${rows}">8</span> peg rows; it lands in one of
+            <span th:text="${buckets}">9</span> buckets. Pick a risk profile —
+            higher risk swings the outer multipliers up and adds bust buckets
+            in the middle. Bet <span th:text="${minStake}">10</span> to
+            <span th:text="${maxStake}">500</span> credits.</p>
+    </div>
+
+    <div th:replace="~{fragments/alerts :: error}"></div>
+
+    <section class="plinko-table casino-felt">
+        <div class="plinko-board" id="plinko-board" aria-live="polite">
+            <div class="plinko-ball" id="plinko-ball" hidden>●</div>
+            <div class="plinko-buckets" id="plinko-buckets" th:attr="data-risk=${risks[0]}">
+                <span class="plinko-bucket"
+                      th:each="m, iter : ${payoutTables.get(risks[0])}"
+                      th:attr="data-index=${iter.index}"
+                      th:text="${m} + '×'">1.0×</span>
+            </div>
+        </div>
+
+        <div class="plinko-result" id="plinko-result" hidden></div>
+
+        <form class="plinko-bet" id="plinko-bet" autocomplete="off">
+            <div class="plinko-risk-picker" role="radiogroup" aria-label="Risk profile">
+                <label class="plinko-risk" th:each="r, iter : ${risks}">
+                    <input type="radio" name="risk" th:value="${r}" th:checked="${iter.index == 0}">
+                    <span th:text="${r}">LOW</span>
+                </label>
+            </div>
+            <label for="plinko-stake" class="plinko-stake-label">Stake (credits)</label>
+            <input id="plinko-stake"
+                   name="stake"
+                   type="number"
+                   th:attr="min=${minStake}, max=${maxStake}"
+                   th:value="${minStake}"
+                   step="1">
+            <button type="submit" id="plinko-drop" class="btn-primary">Drop</button>
+            <button type="submit" id="plinko-drop-toby" class="btn-secondary casino-bet-toby" hidden
+                    title="Sells just enough TOBY at the live market price to cover the shortfall, then drops.">
+                Drop (sell <span class="casino-bet-toby-coins">0</span> TOBY)
+            </button>
+        </form>
+
+        <div class="plinko-balance">
+            Balance: <strong id="plinko-balance" th:text="${balance}">0</strong> credits
+        </div>
+        <div th:replace="~{fragments/casino :: jackpotBanner}"></div>
+    </section>
+
+    <section class="plinko-payouts">
+        <h2>Payout tables (× stake)</h2>
+        <table>
+            <thead>
+            <tr>
+                <th>Risk</th>
+                <th th:each="i : ${#numbers.sequence(0, buckets - 1)}" th:text="${i}">0</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr th:each="r : ${risks}">
+                <td th:text="${r}">LOW</td>
+                <td th:each="m : ${payoutTables.get(r)}" th:text="${m}">1.0</td>
+            </tr>
+            </tbody>
+        </table>
+        <p class="muted">All three profiles target ~0.90 RTP. Outer buckets pay big;
+            center buckets refund (×1), partially lose (×0.4–0.7), or bust (×0).</p>
+    </section>
+
+    <section class="plinko-rules">
+        <h2>Rules</h2>
+        <ul>
+            <li>Pick a risk profile (LOW / MEDIUM / HIGH) and a stake.</li>
+            <li>Each of the <span th:text="${rows}">8</span> rows flips a fair coin to nudge the ball left or right.</li>
+            <li>The ball settles into one of <span th:text="${buckets}">9</span> buckets; that bucket's multiplier is your payout.</li>
+            <li>Multiplier &gt; 1 = win, = 1 = refund, &lt; 1 = partial or full loss.</li>
+            <li>Wins roll for the jackpot pool; losses tribute the lost portion of the stake.</li>
+        </ul>
+    </section>
+</main>
+
+<div class="toast-stack" id="toast-stack" aria-live="polite"></div>
+
+<th:block th:replace="~{fragments/casinoMinigame :: scripts}"></th:block>
+<script th:src="@{/js/plinko.js}"></script>
+</body>
+</html>

--- a/web/src/main/resources/templates/plinko.html
+++ b/web/src/main/resources/templates/plinko.html
@@ -22,15 +22,44 @@
 
     <div th:replace="~{fragments/alerts :: error}"></div>
 
+    <!--
+        SVG-based board: pegs are real circles laid out in the classic
+        Galton triangle (row k has k+1 pegs), buckets are wedges across
+        the bottom. The ball is an SVG <circle> whose translate transform
+        is driven by plinko.js — each row's decision picks a mid-row
+        bounce X, ending in the exact center of the landing bucket. This
+        keeps the animation aligned with the bucket the server picked.
+
+        Per-risk payout tables are stashed in `__plinkoTables` so the
+        client can render the bucket labels and tint the landing bucket
+        without round-tripping to the server.
+    -->
     <section class="plinko-table casino-felt">
-        <div class="plinko-board" id="plinko-board" aria-live="polite">
-            <div class="plinko-ball" id="plinko-ball" hidden>●</div>
-            <div class="plinko-buckets" id="plinko-buckets" th:attr="data-risk=${risks[0]}">
-                <span class="plinko-bucket"
-                      th:each="m, iter : ${payoutTables.get(risks[0])}"
-                      th:attr="data-index=${iter.index}"
-                      th:text="${m} + '×'">1.0×</span>
-            </div>
+        <div class="plinko-stage">
+            <svg class="plinko-board-svg" id="plinko-board"
+                 viewBox="-100 0 200 220"
+                 preserveAspectRatio="xMidYMid meet"
+                 aria-live="polite">
+                <defs>
+                    <radialGradient id="plinko-ball-grad" cx="0.35" cy="0.35" r="0.7">
+                        <stop offset="0%" stop-color="#fff1b0"/>
+                        <stop offset="55%" stop-color="#e0a93a"/>
+                        <stop offset="100%" stop-color="#7a4f10"/>
+                    </radialGradient>
+                    <radialGradient id="plinko-peg-grad" cx="0.4" cy="0.4" r="0.7">
+                        <stop offset="0%" stop-color="#fff8d8"/>
+                        <stop offset="60%" stop-color="#c9a04a"/>
+                        <stop offset="100%" stop-color="#5e3c0b"/>
+                    </radialGradient>
+                    <filter id="plinko-ball-shadow" x="-50%" y="-50%" width="200%" height="200%">
+                        <feDropShadow dx="0" dy="1.5" stdDeviation="1.2" flood-color="rgba(0,0,0,0.55)"/>
+                    </filter>
+                </defs>
+                <g class="plinko-pegs" id="plinko-pegs"></g>
+                <g class="plinko-buckets-svg" id="plinko-buckets"></g>
+                <circle id="plinko-ball" class="plinko-ball" r="4" cx="0" cy="0" hidden
+                        filter="url(#plinko-ball-shadow)"/>
+            </svg>
         </div>
 
         <div class="plinko-result" id="plinko-result" hidden></div>
@@ -61,6 +90,17 @@
         </div>
         <div th:replace="~{fragments/casino :: jackpotBanner}"></div>
     </section>
+
+    <script th:inline="javascript">
+        /*<![CDATA[*/
+        // {LOW: [1.9,1.4,...], MEDIUM: [...], HIGH: [...]} — payout tables
+        // per risk profile, indexed by bucket. plinko.js paints the bucket
+        // labels and tints the active risk's row of the payout table.
+        window.__plinkoTables = /*[[${payoutTables}]]*/ {};
+        window.__plinkoRows = /*[[${rows}]]*/ 8;
+        window.__plinkoBuckets = /*[[${buckets}]]*/ 9;
+        /*]]>*/
+    </script>
 
     <section class="plinko-payouts">
         <h2>Payout tables (× stake)</h2>

--- a/web/src/main/resources/templates/wheel.html
+++ b/web/src/main/resources/templates/wheel.html
@@ -20,12 +20,57 @@
 
     <div th:replace="~{fragments/alerts :: error}"></div>
 
+    <!--
+        The wheel reuses the jackpot-wheel-* SVG + CSS surface (brass rim,
+        spoked rotor, golden pointer, peg ring) that's already loaded via
+        base.css. Only the container positioning is bespoke; the wheel
+        itself looks visually identical to the jackpot payout wheel.
+
+        Spoke wedges and labels are rendered by wheel.js into `.wheel-rotor`
+        — server is authoritative for the landed multiplier; the JS just
+        animates the wheel landing on the matching wedge.
+
+        Inline JSON blob `__wofWheelWeights` carries the weight-per-
+        multiplier map so the renderer matches what the server spun.
+    -->
     <section class="wheel-table casino-felt">
         <div class="wheel-stage">
-            <div class="wheel-pointer" aria-hidden="true">▼</div>
-            <div class="wheel-disc" id="wheel-disc" aria-live="polite">
-                <span class="wheel-landed" id="wheel-landed">?</span>
-            </div>
+            <svg class="wheel-svg" viewBox="-120 -120 240 240" aria-hidden="true">
+                <defs>
+                    <linearGradient id="wof-wheel-rim-grad" x1="0" y1="0" x2="0" y2="1">
+                        <stop offset="0%" stop-color="#f7d46a"/>
+                        <stop offset="50%" stop-color="#b07d1f"/>
+                        <stop offset="100%" stop-color="#f7d46a"/>
+                    </linearGradient>
+                    <radialGradient id="wof-wheel-vignette" cx="0.5" cy="0.5" r="0.5">
+                        <stop offset="60%" stop-color="rgba(0,0,0,0)"/>
+                        <stop offset="100%" stop-color="rgba(0,0,0,0.55)"/>
+                    </radialGradient>
+                    <linearGradient id="wof-wheel-hub-grad" x1="0" y1="0" x2="0" y2="1">
+                        <stop offset="0%" stop-color="#fff1b0"/>
+                        <stop offset="55%" stop-color="#e0a93a"/>
+                        <stop offset="100%" stop-color="#7a4f10"/>
+                    </linearGradient>
+                    <linearGradient id="wof-wheel-pointer-grad" x1="0" y1="0" x2="0" y2="1">
+                        <stop offset="0%" stop-color="#fff1b0"/>
+                        <stop offset="60%" stop-color="#e0a93a"/>
+                        <stop offset="100%" stop-color="#7a4f10"/>
+                    </linearGradient>
+                    <filter id="wof-wheel-shadow" x="-20%" y="-20%" width="140%" height="140%">
+                        <feDropShadow dx="0" dy="2" stdDeviation="2" flood-color="rgba(0,0,0,0.55)"/>
+                    </filter>
+                </defs>
+                <circle cx="0" cy="0" r="106" class="wheel-rim-outer"/>
+                <circle cx="0" cy="0" r="101" class="wheel-rim-inner"/>
+                <g class="wheel-rotor" id="wheel-rotor"></g>
+                <circle cx="0" cy="0" r="100" fill="url(#wof-wheel-vignette)" pointer-events="none"/>
+                <circle cx="0" cy="0" r="18" class="wheel-hub-outer"/>
+                <circle cx="0" cy="0" r="13" class="wheel-hub-inner"/>
+                <path class="wheel-pointer-arrow"
+                      d="M 0 -94 L -9 -116 L 9 -116 Z"
+                      filter="url(#wof-wheel-shadow)"/>
+            </svg>
+            <div class="wheel-status" id="wheel-status">Pick a multiplier and press Spin.</div>
         </div>
 
         <div class="wheel-result" id="wheel-result" hidden></div>
@@ -34,7 +79,7 @@
             <div class="wheel-pick-picker" role="radiogroup" aria-label="Pick a multiplier">
                 <label class="wheel-pick" th:each="m, iter : ${picks}">
                     <input type="radio" name="pick" th:value="${m}" th:checked="${iter.index == 0}">
-                    <span th:text="${m} + '×'">2×</span>
+                    <span th:text="${m} + '×'" th:attr="data-multiplier=${m}">2×</span>
                 </label>
             </div>
             <label for="wheel-stake" class="wheel-stake-label">Stake (credits)</label>
@@ -56,6 +101,15 @@
         </div>
         <div th:replace="~{fragments/casino :: jackpotBanner}"></div>
     </section>
+
+    <script th:inline="javascript">
+        /*<![CDATA[*/
+        // [{multiplier: Long, slots: Int}], sorted by multiplier ascending.
+        // Renderer uses this to lay out spokes proportional to weight so
+        // the player sees the actual probabilities they're betting against.
+        window.__wofWheelWeights = /*[[${wheelWeights}]]*/ [];
+        /*]]>*/
+    </script>
 
     <section class="wheel-rules">
         <h2>Rules</h2>

--- a/web/src/main/resources/templates/wheel.html
+++ b/web/src/main/resources/templates/wheel.html
@@ -124,24 +124,31 @@
 
     <section class="wheel-weights">
         <h2>Wheel composition</h2>
-        <table>
-            <thead>
-            <tr>
-                <th>Multiplier</th>
-                <th>Slots</th>
-                <th>Hit chance</th>
-                <th>Per-pick RTP</th>
-            </tr>
-            </thead>
-            <tbody>
-            <tr th:each="w : ${wheelWeights}">
-                <td th:text="${w.multiplier} + '×'">2×</td>
-                <td th:text="${w.slots}">44</td>
-                <td th:text="${#numbers.formatDecimal(w.slots * 100.0 / slotCount, 1, 1)} + '%'">44.0%</td>
-                <td th:text="${#numbers.formatDecimal(w.slots * w.multiplier * 1.0 / slotCount, 1, 2)}">0.88</td>
-            </tr>
-            </tbody>
-        </table>
+        <!--
+            Two-line headers with explicit <span> wrapping so the column
+            label wraps cleanly on narrow viewports (otherwise "Hit chance"
+            and "Per-pick RTP" split awkwardly mid-word).
+        -->
+        <div class="wheel-weights-table-wrap">
+            <table class="wheel-weights-table">
+                <thead>
+                <tr>
+                    <th><span>Multiplier</span></th>
+                    <th><span>Slots</span></th>
+                    <th><span>Hit chance</span></th>
+                    <th><span>Per-pick RTP</span></th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr th:each="w : ${wheelWeights}">
+                    <td th:text="${w.multiplier} + '×'">2×</td>
+                    <td th:text="${w.slots}">44</td>
+                    <td th:text="${#numbers.formatDecimal(w.slots * 100.0 / slotCount, 1, 1)} + '%'">44.0%</td>
+                    <td th:text="${#numbers.formatDecimal(w.slots * w.multiplier * 1.0 / slotCount, 1, 2)}">0.88</td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
     </section>
 </main>
 

--- a/web/src/main/resources/templates/wheel.html
+++ b/web/src/main/resources/templates/wheel.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="en">
+<head th:replace="~{fragments/head :: head('TobyBot - Wheel of Fortune', '/css/wheel.css')}"></head>
+<body>
+<a href="#main" class="skip-link">Skip to content</a>
+<div th:replace="~{fragments/navbar :: navbar}"></div>
+
+<main id="main" class="container"
+      th:attr="data-guild-id=${guildId}, data-toby-coins=${tobyCoins}, data-market-price=${marketPrice},
+               data-slot-count=${slotCount}">
+
+    <div class="wheel-header">
+        <a class="back-link" th:href="@{/casino/guilds}">&larr; All casino servers</a>
+        <h1 th:text="'🎡 Wheel of Fortune • ' + ${guildName}">🎡 Wheel of Fortune</h1>
+        <p class="muted">Pick a multiplier, spin the wheel. Land on your pick to win
+            <strong>multiplier × stake</strong>. Per-pick RTPs cluster around 0.88
+            (rarer picks pay bigger). Bet
+            <span th:text="${minStake}">10</span>-<span th:text="${maxStake}">500</span> credits.</p>
+    </div>
+
+    <div th:replace="~{fragments/alerts :: error}"></div>
+
+    <section class="wheel-table casino-felt">
+        <div class="wheel-stage">
+            <div class="wheel-pointer" aria-hidden="true">▼</div>
+            <div class="wheel-disc" id="wheel-disc" aria-live="polite">
+                <span class="wheel-landed" id="wheel-landed">?</span>
+            </div>
+        </div>
+
+        <div class="wheel-result" id="wheel-result" hidden></div>
+
+        <form class="wheel-bet" id="wheel-bet" autocomplete="off">
+            <div class="wheel-pick-picker" role="radiogroup" aria-label="Pick a multiplier">
+                <label class="wheel-pick" th:each="m, iter : ${picks}">
+                    <input type="radio" name="pick" th:value="${m}" th:checked="${iter.index == 0}">
+                    <span th:text="${m} + '×'">2×</span>
+                </label>
+            </div>
+            <label for="wheel-stake" class="wheel-stake-label">Stake (credits)</label>
+            <input id="wheel-stake"
+                   name="stake"
+                   type="number"
+                   th:attr="min=${minStake}, max=${maxStake}"
+                   th:value="${minStake}"
+                   step="1">
+            <button type="submit" id="wheel-spin" class="btn-primary">Spin</button>
+            <button type="submit" id="wheel-spin-toby" class="btn-secondary casino-bet-toby" hidden
+                    title="Sells just enough TOBY at the live market price to cover the shortfall, then spins.">
+                Spin (sell <span class="casino-bet-toby-coins">0</span> TOBY)
+            </button>
+        </form>
+
+        <div class="wheel-balance">
+            Balance: <strong id="wheel-balance" th:text="${balance}">0</strong> credits
+        </div>
+        <div th:replace="~{fragments/casino :: jackpotBanner}"></div>
+    </section>
+
+    <section class="wheel-rules">
+        <h2>Rules</h2>
+        <ul>
+            <li>Pick one of <span th:text="${#strings.listJoin(picks, '×, ')}">2, 3, 5, 10</span>× and set a stake.</li>
+            <li>The wheel has <span th:text="${slotCount}">100</span> slots; bigger multipliers occupy fewer slots.</li>
+            <li>Win <strong>multiplier × stake</strong> only if the landed slot matches your pick.</li>
+            <li>Lose your full stake on any other landing.</li>
+            <li>Wins roll for the jackpot pool; losses tribute 10% of the stake into it.</li>
+        </ul>
+    </section>
+
+    <section class="wheel-weights">
+        <h2>Wheel composition</h2>
+        <table>
+            <thead>
+            <tr>
+                <th>Multiplier</th>
+                <th>Slots</th>
+                <th>Hit chance</th>
+                <th>Per-pick RTP</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr th:each="w : ${wheelWeights}">
+                <td th:text="${w.multiplier} + '×'">2×</td>
+                <td th:text="${w.slots}">44</td>
+                <td th:text="${#numbers.formatDecimal(w.slots * 100.0 / slotCount, 1, 1)} + '%'">44.0%</td>
+                <td th:text="${#numbers.formatDecimal(w.slots * w.multiplier * 1.0 / slotCount, 1, 2)}">0.88</td>
+            </tr>
+            </tbody>
+        </table>
+    </section>
+</main>
+
+<div class="toast-stack" id="toast-stack" aria-live="polite"></div>
+
+<th:block th:replace="~{fragments/casinoMinigame :: scripts}"></th:block>
+<script th:src="@{/js/wheel.js}"></script>
+</body>
+</html>

--- a/web/src/test/js/plinko.test.js
+++ b/web/src/test/js/plinko.test.js
@@ -1,0 +1,75 @@
+const { renderPlinkoResult } = require('../../main/resources/static/js/plinko');
+require('../../main/resources/static/js/casino-jackpot');
+require('../../main/resources/static/js/casino-result');
+require('../../main/resources/static/js/casino-render');
+
+describe('renderPlinkoResult', () => {
+    let resultEl;
+
+    beforeEach(() => {
+        document.body.innerHTML = '<div id="r"></div>';
+        resultEl = document.getElementById('r');
+    });
+
+    test('win shows bucket index, multiplier, and net credits', () => {
+        renderPlinkoResult(resultEl, {
+            win: true, push: false, bucket: 0, multiplier: 12, net: 1100
+        });
+
+        expect(resultEl.classList.contains('plinko-result-win')).toBe(true);
+        expect(resultEl.innerHTML).toContain('Bucket 0');
+        expect(resultEl.innerHTML).toContain('12×');
+        expect(resultEl.innerHTML).toContain('+1100 credits');
+    });
+
+    test('lose shows bucket, multiplier, and absolute net loss', () => {
+        renderPlinkoResult(resultEl, {
+            win: false, push: false, bucket: 4, multiplier: 0, net: -100
+        });
+
+        expect(resultEl.classList.contains('plinko-result-lose')).toBe(true);
+        expect(resultEl.innerHTML).toContain('Bucket 4');
+        expect(resultEl.innerHTML).toContain('0×');
+        expect(resultEl.innerHTML).toContain('100 credits');
+    });
+
+    test('push (multiplier 1.0) marks as lose-class with refund copy and net 0', () => {
+        // Pushes don't tribute and don't roll the jackpot, so the
+        // shared result helper treats them like lose for class purposes
+        // — but the line copy distinguishes the refund.
+        renderPlinkoResult(resultEl, {
+            win: false, push: true, bucket: 3, multiplier: 1.0, net: 0
+        });
+
+        expect(resultEl.classList.contains('plinko-result-lose')).toBe(true);
+        expect(resultEl.innerHTML).toContain('refund');
+    });
+
+    test('fractional multiplier renders without trailing zeros', () => {
+        renderPlinkoResult(resultEl, {
+            win: false, push: false, bucket: 4, multiplier: 0.4, net: -60
+        });
+
+        expect(resultEl.innerHTML).toContain('0.4×');
+        expect(resultEl.innerHTML).not.toContain('0.40×');
+    });
+
+    test('jackpot win prepends the JACKPOT banner', () => {
+        renderPlinkoResult(resultEl, {
+            win: true, push: false, bucket: 0, multiplier: 40,
+            net: 3900, jackpotPayout: 5000
+        });
+
+        expect(resultEl.classList.contains('plinko-result-jackpot')).toBe(true);
+        expect(resultEl.innerHTML).toContain('+5000 credits');
+    });
+
+    test('lose with lossTribute appends "+N to jackpot" suffix', () => {
+        renderPlinkoResult(resultEl, {
+            win: false, push: false, bucket: 4, multiplier: 0,
+            net: -100, lossTribute: 10
+        });
+
+        expect(resultEl.innerHTML).toContain('+10 to jackpot');
+    });
+});

--- a/web/src/test/js/wheel.test.js
+++ b/web/src/test/js/wheel.test.js
@@ -1,0 +1,47 @@
+const { renderWheelResult } = require('../../main/resources/static/js/wheel');
+require('../../main/resources/static/js/casino-jackpot');
+require('../../main/resources/static/js/casino-result');
+require('../../main/resources/static/js/casino-render');
+
+describe('renderWheelResult', () => {
+    let resultEl;
+
+    beforeEach(() => {
+        document.body.innerHTML = '<div id="r"></div>';
+        resultEl = document.getElementById('r');
+    });
+
+    test('win shows landed/picked multiplier and net', () => {
+        renderWheelResult(resultEl, { win: true, pick: 5, landed: 5, net: 400 });
+
+        expect(resultEl.classList.contains('wheel-result-win')).toBe(true);
+        expect(resultEl.innerHTML).toContain('5×');
+        expect(resultEl.innerHTML).toContain('+400 credits');
+    });
+
+    test('lose distinguishes landed vs picked', () => {
+        renderWheelResult(resultEl, { win: false, pick: 5, landed: 2, net: -100 });
+
+        expect(resultEl.classList.contains('wheel-result-lose')).toBe(true);
+        expect(resultEl.innerHTML).toContain('2×');
+        expect(resultEl.innerHTML).toContain('5×');
+        expect(resultEl.innerHTML).toContain('100 credits');
+    });
+
+    test('jackpot win prepends the JACKPOT banner', () => {
+        renderWheelResult(resultEl, {
+            win: true, pick: 10, landed: 10, net: 900, jackpotPayout: 2500
+        });
+
+        expect(resultEl.classList.contains('wheel-result-jackpot')).toBe(true);
+        expect(resultEl.innerHTML).toContain('+2500 credits');
+    });
+
+    test('lose with lossTribute appends "+N to jackpot" suffix', () => {
+        renderWheelResult(resultEl, {
+            win: false, pick: 5, landed: 2, net: -100, lossTribute: 10
+        });
+
+        expect(resultEl.innerHTML).toContain('+10 to jackpot');
+    });
+});

--- a/web/src/test/kotlin/web/controller/PlinkoControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/PlinkoControllerTest.kt
@@ -43,7 +43,7 @@ class PlinkoControllerTest {
 
     @Test
     fun `drop win returns 200 with win-shaped payload`() {
-        every { plinkoService.drop(discordId, guildId, 100L, Plinko.Risk.MEDIUM, any()) } returns DropOutcome.Win(
+        every { plinkoService.drop(discordId, guildId, 100L, Plinko.Risk.MEDIUM, any(), any(), any(), any()) } returns DropOutcome.Win(
             stake = 100L, risk = Plinko.Risk.MEDIUM, bucket = 0, multiplier = 12.0,
             payout = 1_200L, net = 1_100L, newBalance = 2_100L,
         )
@@ -62,7 +62,7 @@ class PlinkoControllerTest {
 
     @Test
     fun `drop lose returns 200 with win=false`() {
-        every { plinkoService.drop(discordId, guildId, 100L, Plinko.Risk.MEDIUM, any()) } returns DropOutcome.Lose(
+        every { plinkoService.drop(discordId, guildId, 100L, Plinko.Risk.MEDIUM, any(), any(), any(), any()) } returns DropOutcome.Lose(
             stake = 100L, risk = Plinko.Risk.MEDIUM, bucket = 4, multiplier = 0.0,
             payout = 0L, net = -100L, newBalance = 400L, lossTribute = 10L,
         )
@@ -79,7 +79,7 @@ class PlinkoControllerTest {
 
     @Test
     fun `drop push returns 200 with push=true and net 0`() {
-        every { plinkoService.drop(discordId, guildId, 100L, Plinko.Risk.LOW, any()) } returns DropOutcome.Push(
+        every { plinkoService.drop(discordId, guildId, 100L, Plinko.Risk.LOW, any(), any(), any(), any()) } returns DropOutcome.Push(
             stake = 100L, risk = Plinko.Risk.LOW, bucket = 3, newBalance = 500L,
         )
 
@@ -99,12 +99,12 @@ class PlinkoControllerTest {
 
         assertEquals(400, response.statusCode.value())
         assertTrue(response.body?.error!!.contains("LOW"))
-        verify(exactly = 0) { plinkoService.drop(any(), any(), any(), any(), any()) }
+        verify(exactly = 0) { plinkoService.drop(any(), any(), any(), any(), any(), any(), any(), any()) }
     }
 
     @Test
     fun `risk parsing is case-insensitive`() {
-        every { plinkoService.drop(discordId, guildId, 100L, Plinko.Risk.HIGH, any()) } returns DropOutcome.Lose(
+        every { plinkoService.drop(discordId, guildId, 100L, Plinko.Risk.HIGH, any(), any(), any(), any()) } returns DropOutcome.Lose(
             stake = 100L, risk = Plinko.Risk.HIGH, bucket = 4, multiplier = 0.0,
             payout = 0L, net = -100L, newBalance = 400L,
         )
@@ -113,13 +113,13 @@ class PlinkoControllerTest {
 
         assertEquals(200, response.statusCode.value())
         verify(exactly = 1) {
-            plinkoService.drop(discordId, guildId, 100L, Plinko.Risk.HIGH, any())
+            plinkoService.drop(discordId, guildId, 100L, Plinko.Risk.HIGH, any(), any(), any(), any())
         }
     }
 
     @Test
     fun `drop returns 400 on insufficient credits`() {
-        every { plinkoService.drop(discordId, guildId, 100L, Plinko.Risk.LOW, any()) } returns
+        every { plinkoService.drop(discordId, guildId, 100L, Plinko.Risk.LOW, any(), any(), any(), any()) } returns
             DropOutcome.InsufficientCredits(stake = 100L, have = 30L)
 
         val response = controller.drop(guildId, DropRequest(stake = 100L, risk = "LOW"), user)
@@ -129,7 +129,7 @@ class PlinkoControllerTest {
 
     @Test
     fun `drop returns 400 on invalid stake`() {
-        every { plinkoService.drop(discordId, guildId, 5L, Plinko.Risk.LOW, any()) } returns
+        every { plinkoService.drop(discordId, guildId, 5L, Plinko.Risk.LOW, any(), any(), any(), any()) } returns
             DropOutcome.InvalidStake(min = 10L, max = 500L)
 
         val response = controller.drop(guildId, DropRequest(stake = 5L, risk = "LOW"), user)
@@ -144,12 +144,53 @@ class PlinkoControllerTest {
         val response = controller.drop(guildId, DropRequest(stake = 100L, risk = "LOW"), user)
 
         assertEquals(403, response.statusCode.value())
-        verify(exactly = 0) { plinkoService.drop(any(), any(), any(), any(), any()) }
+        verify(exactly = 0) { plinkoService.drop(any(), any(), any(), any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `controller forwards bot-suspicion signals into the service`() {
+        every {
+            plinkoService.drop(any(), any(), any(), any(), any(), any(), any(), any())
+        } returns DropOutcome.Lose(
+            stake = 10L, risk = Plinko.Risk.LOW, bucket = 4, multiplier = 0.0,
+            payout = 0L, net = -10L, newBalance = 90L,
+        )
+
+        controller.drop(guildId, DropRequest(
+            stake = 10L, risk = "LOW",
+            clickX = 350, clickY = 220, mouseMoved = false,
+        ), user)
+
+        verify(exactly = 1) {
+            plinkoService.drop(
+                discordId, guildId, 10L, Plinko.Risk.LOW, false,
+                clickX = 350, clickY = 220, mouseMoved = false,
+            )
+        }
+    }
+
+    @Test
+    fun `missing bot-suspicion fields are forwarded as null (Discord-equivalent path)`() {
+        every {
+            plinkoService.drop(any(), any(), any(), any(), any(), any(), any(), any())
+        } returns DropOutcome.Lose(
+            stake = 10L, risk = Plinko.Risk.LOW, bucket = 4, multiplier = 0.0,
+            payout = 0L, net = -10L, newBalance = 90L,
+        )
+
+        controller.drop(guildId, DropRequest(stake = 10L, risk = "LOW"), user)
+
+        verify(exactly = 1) {
+            plinkoService.drop(
+                discordId, guildId, 10L, Plinko.Risk.LOW, false,
+                clickX = null, clickY = null, mouseMoved = null,
+            )
+        }
     }
 
     @Test
     fun `jackpot win surfaces jackpotPayout`() {
-        every { plinkoService.drop(discordId, guildId, 100L, Plinko.Risk.MEDIUM, any()) } returns DropOutcome.Win(
+        every { plinkoService.drop(discordId, guildId, 100L, Plinko.Risk.MEDIUM, any(), any(), any(), any()) } returns DropOutcome.Win(
             stake = 100L, risk = Plinko.Risk.MEDIUM, bucket = 0, multiplier = 12.0,
             payout = 1_200L, net = 1_100L, newBalance = 11_100L, jackpotPayout = 10_000L,
         )

--- a/web/src/test/kotlin/web/controller/PlinkoControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/PlinkoControllerTest.kt
@@ -1,0 +1,161 @@
+package web.controller
+
+import database.economy.Plinko
+import database.service.PlinkoService
+import database.service.PlinkoService.DropOutcome
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.security.oauth2.core.user.OAuth2User
+import web.casino.CasinoPageContext
+import web.casino.StakeBounds
+import web.service.EconomyWebService
+
+class PlinkoControllerTest {
+
+    private val guildId = 42L
+    private val discordId = 100L
+
+    private lateinit var plinkoService: PlinkoService
+    private lateinit var economyWebService: EconomyWebService
+    private lateinit var pageContext: CasinoPageContext
+    private lateinit var stakeBounds: StakeBounds
+    private lateinit var user: OAuth2User
+    private lateinit var controller: PlinkoController
+
+    @BeforeEach
+    fun setup() {
+        plinkoService = mockk(relaxed = true)
+        economyWebService = mockk(relaxed = true)
+        pageContext = mockk(relaxed = true)
+        stakeBounds = mockk(relaxed = true)
+        user = mockk {
+            every { getAttribute<String>("id") } returns discordId.toString()
+            every { getAttribute<String>("username") } returns "tester"
+        }
+        every { economyWebService.isMember(discordId, guildId) } returns true
+        controller = PlinkoController(plinkoService, economyWebService, pageContext, stakeBounds)
+    }
+
+    @Test
+    fun `drop win returns 200 with win-shaped payload`() {
+        every { plinkoService.drop(discordId, guildId, 100L, Plinko.Risk.MEDIUM, any()) } returns DropOutcome.Win(
+            stake = 100L, risk = Plinko.Risk.MEDIUM, bucket = 0, multiplier = 12.0,
+            payout = 1_200L, net = 1_100L, newBalance = 2_100L,
+        )
+
+        val response = controller.drop(guildId, DropRequest(stake = 100L, risk = "MEDIUM"), user)
+
+        assertTrue(response.statusCode.is2xxSuccessful)
+        val body = response.body!!
+        assertEquals(true, body.ok)
+        assertEquals(true, body.win)
+        assertEquals(false, body.push)
+        assertEquals(1_100L, body.net)
+        assertEquals(0, body.bucket)
+        assertEquals("MEDIUM", body.risk)
+    }
+
+    @Test
+    fun `drop lose returns 200 with win=false`() {
+        every { plinkoService.drop(discordId, guildId, 100L, Plinko.Risk.MEDIUM, any()) } returns DropOutcome.Lose(
+            stake = 100L, risk = Plinko.Risk.MEDIUM, bucket = 4, multiplier = 0.0,
+            payout = 0L, net = -100L, newBalance = 400L, lossTribute = 10L,
+        )
+
+        val response = controller.drop(guildId, DropRequest(stake = 100L, risk = "MEDIUM"), user)
+
+        assertTrue(response.statusCode.is2xxSuccessful)
+        val body = response.body!!
+        assertEquals(false, body.win)
+        assertEquals(false, body.push)
+        assertEquals(-100L, body.net)
+        assertEquals(10L, body.lossTribute)
+    }
+
+    @Test
+    fun `drop push returns 200 with push=true and net 0`() {
+        every { plinkoService.drop(discordId, guildId, 100L, Plinko.Risk.LOW, any()) } returns DropOutcome.Push(
+            stake = 100L, risk = Plinko.Risk.LOW, bucket = 3, newBalance = 500L,
+        )
+
+        val response = controller.drop(guildId, DropRequest(stake = 100L, risk = "LOW"), user)
+
+        assertTrue(response.statusCode.is2xxSuccessful)
+        val body = response.body!!
+        assertEquals(true, body.push)
+        assertEquals(false, body.win)
+        assertEquals(0L, body.net)
+        assertEquals(1.0, body.multiplier)
+    }
+
+    @Test
+    fun `unknown risk returns 400`() {
+        val response = controller.drop(guildId, DropRequest(stake = 100L, risk = "WAYTOOHIGH"), user)
+
+        assertEquals(400, response.statusCode.value())
+        assertTrue(response.body?.error!!.contains("LOW"))
+        verify(exactly = 0) { plinkoService.drop(any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `risk parsing is case-insensitive`() {
+        every { plinkoService.drop(discordId, guildId, 100L, Plinko.Risk.HIGH, any()) } returns DropOutcome.Lose(
+            stake = 100L, risk = Plinko.Risk.HIGH, bucket = 4, multiplier = 0.0,
+            payout = 0L, net = -100L, newBalance = 400L,
+        )
+
+        val response = controller.drop(guildId, DropRequest(stake = 100L, risk = "high"), user)
+
+        assertEquals(200, response.statusCode.value())
+        verify(exactly = 1) {
+            plinkoService.drop(discordId, guildId, 100L, Plinko.Risk.HIGH, any())
+        }
+    }
+
+    @Test
+    fun `drop returns 400 on insufficient credits`() {
+        every { plinkoService.drop(discordId, guildId, 100L, Plinko.Risk.LOW, any()) } returns
+            DropOutcome.InsufficientCredits(stake = 100L, have = 30L)
+
+        val response = controller.drop(guildId, DropRequest(stake = 100L, risk = "LOW"), user)
+
+        assertEquals(400, response.statusCode.value())
+    }
+
+    @Test
+    fun `drop returns 400 on invalid stake`() {
+        every { plinkoService.drop(discordId, guildId, 5L, Plinko.Risk.LOW, any()) } returns
+            DropOutcome.InvalidStake(min = 10L, max = 500L)
+
+        val response = controller.drop(guildId, DropRequest(stake = 5L, risk = "LOW"), user)
+
+        assertEquals(400, response.statusCode.value())
+    }
+
+    @Test
+    fun `drop rejects with 403 when user is not a member`() {
+        every { economyWebService.isMember(discordId, guildId) } returns false
+
+        val response = controller.drop(guildId, DropRequest(stake = 100L, risk = "LOW"), user)
+
+        assertEquals(403, response.statusCode.value())
+        verify(exactly = 0) { plinkoService.drop(any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `jackpot win surfaces jackpotPayout`() {
+        every { plinkoService.drop(discordId, guildId, 100L, Plinko.Risk.MEDIUM, any()) } returns DropOutcome.Win(
+            stake = 100L, risk = Plinko.Risk.MEDIUM, bucket = 0, multiplier = 12.0,
+            payout = 1_200L, net = 1_100L, newBalance = 11_100L, jackpotPayout = 10_000L,
+        )
+
+        val response = controller.drop(guildId, DropRequest(stake = 100L, risk = "MEDIUM"), user)
+
+        assertEquals(10_000L, response.body!!.jackpotPayout)
+    }
+}

--- a/web/src/test/kotlin/web/controller/WheelOfFortuneControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/WheelOfFortuneControllerTest.kt
@@ -1,0 +1,131 @@
+package web.controller
+
+import database.economy.WheelOfFortune
+import database.service.WheelOfFortuneService
+import database.service.WheelOfFortuneService.SpinOutcome
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.security.oauth2.core.user.OAuth2User
+import web.casino.CasinoPageContext
+import web.casino.StakeBounds
+import web.service.EconomyWebService
+
+class WheelOfFortuneControllerTest {
+
+    private val guildId = 42L
+    private val discordId = 100L
+
+    private lateinit var wheelService: WheelOfFortuneService
+    private lateinit var economyWebService: EconomyWebService
+    private lateinit var pageContext: CasinoPageContext
+    private lateinit var stakeBounds: StakeBounds
+    private lateinit var user: OAuth2User
+    private lateinit var controller: WheelOfFortuneController
+
+    @BeforeEach
+    fun setup() {
+        wheelService = mockk(relaxed = true)
+        economyWebService = mockk(relaxed = true)
+        pageContext = mockk(relaxed = true)
+        stakeBounds = mockk(relaxed = true)
+        user = mockk {
+            every { getAttribute<String>("id") } returns discordId.toString()
+            every { getAttribute<String>("username") } returns "tester"
+        }
+        every { economyWebService.isMember(discordId, guildId) } returns true
+        controller = WheelOfFortuneController(wheelService, economyWebService, pageContext, stakeBounds)
+    }
+
+    @Test
+    fun `spin win returns 200 with win-shaped payload`() {
+        every { wheelService.spin(discordId, guildId, 100L, 5L, any()) } returns SpinOutcome.Win(
+            stake = 100L, pickedMultiplier = 5L, landedMultiplier = 5L,
+            payout = 500L, net = 400L, newBalance = 1_400L,
+        )
+
+        val response = controller.spin(guildId, WheelSpinRequest(stake = 100L, pick = 5L), user)
+
+        assertTrue(response.statusCode.is2xxSuccessful)
+        val body = response.body!!
+        assertEquals(true, body.ok)
+        assertEquals(true, body.win)
+        assertEquals(5L, body.pick)
+        assertEquals(5L, body.landed)
+        assertEquals(400L, body.net)
+    }
+
+    @Test
+    fun `spin lose returns 200 with win=false and negative net`() {
+        every { wheelService.spin(discordId, guildId, 100L, 5L, any()) } returns SpinOutcome.Lose(
+            stake = 100L, pickedMultiplier = 5L, landedMultiplier = 2L,
+            newBalance = 400L, lossTribute = 10L,
+        )
+
+        val response = controller.spin(guildId, WheelSpinRequest(stake = 100L, pick = 5L), user)
+
+        assertTrue(response.statusCode.is2xxSuccessful)
+        val body = response.body!!
+        assertEquals(false, body.win)
+        assertEquals(-100L, body.net)
+        assertEquals(2L, body.landed)
+        assertEquals(10L, body.lossTribute)
+    }
+
+    @Test
+    fun `invalid pick returns 400`() {
+        every { wheelService.spin(discordId, guildId, 100L, 7L, any()) } returns
+            SpinOutcome.InvalidPick(picks = WheelOfFortune.PICKS)
+
+        val response = controller.spin(guildId, WheelSpinRequest(stake = 100L, pick = 7L), user)
+
+        assertEquals(400, response.statusCode.value())
+        assertTrue(response.body?.error!!.contains("2"))
+    }
+
+    @Test
+    fun `spin returns 400 on insufficient credits`() {
+        every { wheelService.spin(discordId, guildId, 100L, 2L, any()) } returns
+            SpinOutcome.InsufficientCredits(stake = 100L, have = 30L)
+
+        val response = controller.spin(guildId, WheelSpinRequest(stake = 100L, pick = 2L), user)
+
+        assertEquals(400, response.statusCode.value())
+    }
+
+    @Test
+    fun `spin returns 400 on invalid stake`() {
+        every { wheelService.spin(discordId, guildId, 5L, 2L, any()) } returns
+            SpinOutcome.InvalidStake(min = 10L, max = 500L)
+
+        val response = controller.spin(guildId, WheelSpinRequest(stake = 5L, pick = 2L), user)
+
+        assertEquals(400, response.statusCode.value())
+    }
+
+    @Test
+    fun `spin rejects with 403 when user is not a member`() {
+        every { economyWebService.isMember(discordId, guildId) } returns false
+
+        val response = controller.spin(guildId, WheelSpinRequest(stake = 100L, pick = 2L), user)
+
+        assertEquals(403, response.statusCode.value())
+        verify(exactly = 0) { wheelService.spin(any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `jackpot win surfaces jackpotPayout`() {
+        every { wheelService.spin(discordId, guildId, 100L, 10L, any()) } returns SpinOutcome.Win(
+            stake = 100L, pickedMultiplier = 10L, landedMultiplier = 10L,
+            payout = 1_000L, net = 900L, newBalance = 10_900L, jackpotPayout = 10_000L,
+        )
+
+        val response = controller.spin(guildId, WheelSpinRequest(stake = 100L, pick = 10L), user)
+
+        assertEquals(10_000L, response.body!!.jackpotPayout)
+    }
+}

--- a/web/src/test/kotlin/web/controller/WheelOfFortuneControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/WheelOfFortuneControllerTest.kt
@@ -43,7 +43,7 @@ class WheelOfFortuneControllerTest {
 
     @Test
     fun `spin win returns 200 with win-shaped payload`() {
-        every { wheelService.spin(discordId, guildId, 100L, 5L, any()) } returns SpinOutcome.Win(
+        every { wheelService.spin(discordId, guildId, 100L, 5L, any(), any(), any(), any()) } returns SpinOutcome.Win(
             stake = 100L, pickedMultiplier = 5L, landedMultiplier = 5L,
             payout = 500L, net = 400L, newBalance = 1_400L,
         )
@@ -61,7 +61,7 @@ class WheelOfFortuneControllerTest {
 
     @Test
     fun `spin lose returns 200 with win=false and negative net`() {
-        every { wheelService.spin(discordId, guildId, 100L, 5L, any()) } returns SpinOutcome.Lose(
+        every { wheelService.spin(discordId, guildId, 100L, 5L, any(), any(), any(), any()) } returns SpinOutcome.Lose(
             stake = 100L, pickedMultiplier = 5L, landedMultiplier = 2L,
             newBalance = 400L, lossTribute = 10L,
         )
@@ -78,7 +78,7 @@ class WheelOfFortuneControllerTest {
 
     @Test
     fun `invalid pick returns 400`() {
-        every { wheelService.spin(discordId, guildId, 100L, 7L, any()) } returns
+        every { wheelService.spin(discordId, guildId, 100L, 7L, any(), any(), any(), any()) } returns
             SpinOutcome.InvalidPick(picks = WheelOfFortune.PICKS)
 
         val response = controller.spin(guildId, WheelSpinRequest(stake = 100L, pick = 7L), user)
@@ -89,7 +89,7 @@ class WheelOfFortuneControllerTest {
 
     @Test
     fun `spin returns 400 on insufficient credits`() {
-        every { wheelService.spin(discordId, guildId, 100L, 2L, any()) } returns
+        every { wheelService.spin(discordId, guildId, 100L, 2L, any(), any(), any(), any()) } returns
             SpinOutcome.InsufficientCredits(stake = 100L, have = 30L)
 
         val response = controller.spin(guildId, WheelSpinRequest(stake = 100L, pick = 2L), user)
@@ -99,7 +99,7 @@ class WheelOfFortuneControllerTest {
 
     @Test
     fun `spin returns 400 on invalid stake`() {
-        every { wheelService.spin(discordId, guildId, 5L, 2L, any()) } returns
+        every { wheelService.spin(discordId, guildId, 5L, 2L, any(), any(), any(), any()) } returns
             SpinOutcome.InvalidStake(min = 10L, max = 500L)
 
         val response = controller.spin(guildId, WheelSpinRequest(stake = 5L, pick = 2L), user)
@@ -114,12 +114,33 @@ class WheelOfFortuneControllerTest {
         val response = controller.spin(guildId, WheelSpinRequest(stake = 100L, pick = 2L), user)
 
         assertEquals(403, response.statusCode.value())
-        verify(exactly = 0) { wheelService.spin(any(), any(), any(), any(), any()) }
+        verify(exactly = 0) { wheelService.spin(any(), any(), any(), any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `controller forwards bot-suspicion signals into the service`() {
+        every {
+            wheelService.spin(any(), any(), any(), any(), any(), any(), any(), any())
+        } returns SpinOutcome.Lose(
+            stake = 10L, pickedMultiplier = 2L, landedMultiplier = 5L, newBalance = 90L,
+        )
+
+        controller.spin(guildId, WheelSpinRequest(
+            stake = 10L, pick = 2L,
+            clickX = 350, clickY = 220, mouseMoved = false,
+        ), user)
+
+        verify(exactly = 1) {
+            wheelService.spin(
+                discordId, guildId, 10L, 2L, false,
+                clickX = 350, clickY = 220, mouseMoved = false,
+            )
+        }
     }
 
     @Test
     fun `jackpot win surfaces jackpotPayout`() {
-        every { wheelService.spin(discordId, guildId, 100L, 10L, any()) } returns SpinOutcome.Win(
+        every { wheelService.spin(discordId, guildId, 100L, 10L, any(), any(), any(), any()) } returns SpinOutcome.Win(
             stake = 100L, pickedMultiplier = 10L, landedMultiplier = 10L,
             payout = 1_000L, net = 900L, newBalance = 10_900L, jackpotPayout = 10_000L,
         )

--- a/web/src/test/kotlin/web/template/CasinoMinigameTemplatesTest.kt
+++ b/web/src/test/kotlin/web/template/CasinoMinigameTemplatesTest.kt
@@ -52,6 +52,8 @@ class CasinoMinigameTemplatesTest {
         "roulette.html",
         "baccarat.html",
         "casinoholdem-solo.html",
+        "plinko.html",
+        "wheel.html",
     )
 
     /**


### PR DESCRIPTION
## Summary

Two new jackpot-eligible casino games that sit in the sub-92% RTP band (where only Slots, Scratch, and Dice currently live). Both fund the per-guild jackpot pool via loss tribute and roll for it on a win — and unlike Coinflip / Blackjack / Baccarat / Roulette, they're tight enough on RTP that the `JACKPOT_RTP_MAX_PCT` gate will still let them roll when a guild dials the ceiling down.

### Plinko (canonical RTP ≈ 0.89)

- 8 peg rows, 9 buckets. Three risk profiles (`LOW`, `MEDIUM`, `HIGH`), all pinned at ~0.89-0.90 RTP analytically (and verified by Monte Carlo).
- Outer buckets pay big; center buckets refund (`×1`, push), partially lose (`×0.4`-`×0.7`), or bust (`×0`).
- Partial-loss buckets tribute on the **actual lost portion**, not the full stake — so the 0.4× LOW center routes 6 credits/100 stake to the pool, not 10.
- Pushes (`×1`) skip both the jackpot roll and the loss tribute.

### Wheel of Fortune (canonical RTP ≈ 0.88)

- 100-slot wheel; player picks one of `{2×, 3×, 5×, 10×}` and wins `pick × stake` only when the wheel lands on their pick.
- Slot weights are roughly inversely proportional to multipliers (44, 29, 18, 9), so per-pick RTPs all cluster between 0.87 and 0.90.

### What's wired up

- New `JackpotGame.PLINKO(0.89)` and `JackpotGame.WHEEL_OF_FORTUNE(0.88)` enum entries — both fully eligible for jackpot rolls.
- Engines, services, controllers, DTOs, and tests across `database/economy/`, `database/service/`, and `web/controller/`.
- `PLINKO_MIN_STAKE` / `PLINKO_MAX_STAKE` / `WHEEL_OF_FORTUNE_MIN_STAKE` / `WHEEL_OF_FORTUNE_MAX_STAKE` config keys, including `ModerationWebService` validation and `templates/moderation/settings.html` UI rows.
- `StakeBounds.plinko()` / `wheelOfFortune()` for the page handlers.
- Web pages: `plinko.html`, `wheel.html` + `plinko.js`, `wheel.js` + `plinko.css`, `wheel.css`. Both reuse the shared `TobyCasinoMinigameDom` / `TobyCasinoGame.init` / `TobyCasinoResult` scaffolding — no new infrastructure.
- Discord commands: `/plinko risk:<LOW|MEDIUM|HIGH> stake:<int>` and `/wheel pick:<multiplier> stake:<int>`.
- Casino guilds page gets two new quick-play tiles (🟢 Plinko, 🎡 Wheel).

### Notable design choices

- **Plinko partial-loss tribute** — passes the actual loss amount (`stake - payout`) to `divertOnLoss` rather than the full stake. This matches the "tribute = lost credits" mental model in the existing slots/dice services where every loss is a full-stake loss.
- **Wheel pick model** — picking is single-multiplier (not a fancy bet-type set), keeping the Discord and web UIs symmetric and the RTP math closed-form. Each per-pick RTP is pinned by `WheelOfFortuneTest`.
- **No new shared spinner util** — the plan flagged extracting `WeightedSpinner` from `JackpotWheel` as optional. `WheelOfFortune` has a different domain (single-pick winner check, not a pool fraction) and inlining the weighted-pick keeps both classes small. Skipped.

## Test plan

- [x] `:database:test` — green. New tests: `PlinkoTest`, `WheelOfFortuneTest`, `PlinkoServiceTest`, `WheelOfFortuneServiceTest`. Existing suites unchanged.
- [x] `:web:test` — green. New tests: `PlinkoControllerTest`, `WheelOfFortuneControllerTest`. `ModerationTemplateRowsTest` extended automatically (new config keys surface in `settings.html`).
- [ ] `:discord-bot:test` — could not exercise in this environment: dependency `moe.kyokobot.libdave:impl-jni:0.1.0` returns 403 from the configured Maven repos, so the discord-bot module won't resolve. The two new Discord command classes (`PlinkoCommand`, `WheelOfFortuneCommand`) follow the exact pattern of `ScratchCommand` / `DiceCommand` / `SlotsCommand`. They should compile + run identically once the dependency is reachable.
- [ ] Manual: hit `/casino/<guildId>/plinko` and `/casino/<guildId>/wheel` in a running app; confirm jackpot pool grows on losses and a forced-win (set `JACKPOT_WIN_PCT=100`) drains it.

https://claude.ai/code/session_01JL4xyTTHTFJGXEfkgsPK7v

---
_Generated by [Claude Code](https://claude.ai/code/session_01JL4xyTTHTFJGXEfkgsPK7v)_