### PR TITLE
fix(moderation): align admin poll page with /poll modal (4 options, 1 min)

### DIFF
--- a/web/src/main/kotlin/web/service/ModerationWebService.kt
+++ b/web/src/main/kotlin/web/service/ModerationWebService.kt
@@ -40,11 +40,8 @@ class ModerationWebService(
     private val eventPublisher: ApplicationEventPublisher
 ) {
     companion object {
-        const val MAX_POLL_OPTIONS = 10
-        private val POLL_EMOJI = listOf(
-            "1️⃣", "2️⃣", "3️⃣", "4️⃣", "5️⃣",
-            "6️⃣", "7️⃣", "8️⃣", "9️⃣", "🔟"
-        )
+        const val MAX_POLL_OPTIONS = 4
+        private val POLL_EMOJI = listOf("1️⃣", "2️⃣", "3️⃣", "4️⃣")
         private val logger = DiscordLogger(ModerationWebService::class.java)
 
         /**
@@ -1212,7 +1209,7 @@ class ModerationWebService(
         val cleanedQuestion = question.trim()
         if (cleanedQuestion.isEmpty()) return "Question is required."
         val cleanedOptions = options.map { it.trim() }.filter { it.isNotEmpty() }
-        if (cleanedOptions.size < 2) return "Provide at least 2 options."
+        if (cleanedOptions.isEmpty()) return "Provide at least 1 option."
         if (cleanedOptions.size > MAX_POLL_OPTIONS) return "A poll can have at most $MAX_POLL_OPTIONS options."
 
         val guild = jda.getGuildById(guildId) ?: return "Bot is not in that server."

--- a/web/src/main/resources/static/js/moderation/poll.js
+++ b/web/src/main/resources/static/js/moderation/poll.js
@@ -16,8 +16,8 @@
         const options = Array.from(pollForm.querySelectorAll('.poll-option'))
             .map(i => i.value.trim())
             .filter(v => v.length > 0);
-        if (!channelId || !question || options.length < 2) {
-            toast('Need a channel, a question, and at least 2 options.', 'error');
+        if (!channelId || !question || options.length < 1) {
+            toast('Need a channel, a question, and at least 1 option.', 'error');
             return;
         }
         const submitBtn = pollForm.querySelector('button[type="submit"]');

--- a/web/src/main/resources/templates/moderation/poll.html
+++ b/web/src/main/resources/templates/moderation/poll.html
@@ -14,7 +14,7 @@
 
     <section class="mod-panel" data-panel="poll">
         <p class="muted mb-4">
-            Post an emoji-reaction poll in a text channel. Up to 10 options.
+            Post an emoji-reaction poll in a text channel. Up to 4 options.
         </p>
         <form class="poll-form">
             <label>
@@ -28,19 +28,13 @@
             </label>
             <label>
                 Question
-                <input type="text" name="question" maxlength="256" required>
+                <textarea name="question" maxlength="500" rows="3" required></textarea>
             </label>
             <div class="poll-options">
                 <label>Option 1 <input type="text" maxlength="100" class="poll-option" required></label>
-                <label>Option 2 <input type="text" maxlength="100" class="poll-option" required></label>
+                <label>Option 2 <input type="text" maxlength="100" class="poll-option"></label>
                 <label>Option 3 <input type="text" maxlength="100" class="poll-option"></label>
                 <label>Option 4 <input type="text" maxlength="100" class="poll-option"></label>
-                <label>Option 5 <input type="text" maxlength="100" class="poll-option"></label>
-                <label>Option 6 <input type="text" maxlength="100" class="poll-option"></label>
-                <label>Option 7 <input type="text" maxlength="100" class="poll-option"></label>
-                <label>Option 8 <input type="text" maxlength="100" class="poll-option"></label>
-                <label>Option 9 <input type="text" maxlength="100" class="poll-option"></label>
-                <label>Option 10 <input type="text" maxlength="100" class="poll-option"></label>
             </div>
             <button type="submit" class="btn">Post poll</button>
         </form>

--- a/web/src/test/kotlin/web/service/ModerationWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/ModerationWebServiceTest.kt
@@ -565,19 +565,19 @@ class ModerationWebServiceTest {
     // ---- createPoll ----
 
     @Test
-    fun `createPoll rejects fewer than 2 options`() {
+    fun `createPoll rejects empty options`() {
         mockMember(ownerId, isOwner = true)
-        val err = service.createPoll(ownerId, guildId, 333L, "Yes?", listOf("only one"))
-        assertEquals("Provide at least 2 options.", err)
+        val err = service.createPoll(ownerId, guildId, 333L, "Yes?", emptyList())
+        assertEquals("Provide at least 1 option.", err)
     }
 
     @Test
-    fun `createPoll rejects more than 10 options`() {
+    fun `createPoll rejects more than 4 options`() {
         mockMember(ownerId, isOwner = true)
-        val options = (1..11).map { "opt$it" }
+        val options = (1..5).map { "opt$it" }
         val err = service.createPoll(ownerId, guildId, 333L, "Q?", options)
         assertNotNull(err)
-        assertTrue(err!!.contains("10"))
+        assertTrue(err!!.contains("4"))
     }
 
     @Test


### PR DESCRIPTION
## Summary

`/poll` was reworked into a Discord modal (`PollModal.kt`) that — bound
by Discord's 5-component modal cap — accepts a paragraph question (1–500
chars) plus up to **4** single-line options, with only option 1
required. The admin web page at `/moderation/{guildId}/poll` was still
built for the old shape (max 10 options, 2 required, 256-char single-line
question), so it was visibly out of sync and could submit polls that
needed shapes the new emoji list couldn't represent.

This PR mirrors the modal on the web side, keeping the channel selector
(the admin page's reason to exist — the modal can only post to the
channel `/poll` was invoked in).

- `ModerationWebService.kt`: `MAX_POLL_OPTIONS` 10 → 4; `POLL_EMOJI`
  trimmed to `1️⃣ 2️⃣ 3️⃣ 4️⃣` to match `PollModal.EMOJI_LIST`; minimum
  option count 2 → 1.
- `poll.html`: lede copy updated; question is now a 500-char
  `<textarea rows="3">`; options dropped from 10 to 4; only Option 1
  required.
- `poll.js`: client-side guard relaxed from `< 2` to `< 1` with matching
  toast copy.
- `ModerationWebServiceTest.kt`: the two boundary tests renamed/rewritten
  (`rejects empty options` asserts the new "Provide at least 1 option."
  message; `rejects more than 4 options` sends 5 and asserts the error
  mentions `4`). Other `createPoll` tests use 2-option lists that still
  fit and were left untouched.

## Test plan

- [x] `./gradlew :web:test --tests 'web.service.ModerationWebServiceTest'` passes
- [ ] Load `/moderation/{guildId}/poll`: question renders as a textarea, exactly 4 option rows, only "Option 1" required
- [ ] Submit channel + question + 1 option → poll posts with 1 reaction (previously blocked client-side)
- [ ] Submit with 4 options → poll posts with 4 reactions
- [ ] Run `/poll` in Discord with the same inputs and confirm the embed/reactions match the admin-page output

---
_Generated by [Claude Code](https://claude.ai/code/session_01HiVEXvdC7BZu2XBtyheBbJ)_