### PR TITLE
feat(team): modal-driven /team split with preview-confirm flow + web presets

### DIFF
--- a/application/src/test/kotlin/integration/bot/ButtonManagerTest.kt
+++ b/application/src/test/kotlin/integration/bot/ButtonManagerTest.kt
@@ -82,10 +82,13 @@ class ButtonManagerTest {
             ResendLastRequestButton::class.java,
             RollButton::class.java,
             StopButton::class.java,
+            TeamCancelButton::class.java,
+            TeamConfirmButton::class.java,
+            TeamRerollButton::class.java,
         )
 
         assertTrue(availableButtons.containsAll(buttonManager.buttons.map { it.javaClass }.toList()))
-        assertEquals(12, buttonManager.buttons.size)
+        assertEquals(15, buttonManager.buttons.size)
     }
 
     @Test

--- a/application/src/test/kotlin/integration/database/TeamPresetServiceIntegrationTest.kt
+++ b/application/src/test/kotlin/integration/database/TeamPresetServiceIntegrationTest.kt
@@ -1,0 +1,118 @@
+package integration.database
+
+import app.Application
+import bot.configuration.TestAppConfig
+import bot.configuration.TestBotConfig
+import bot.configuration.TestManagerConfig
+import common.configuration.TestCachingConfig
+import database.configuration.TestDatabaseConfig
+import database.service.TeamPresetService
+import database.service.TeamSplitSessionService
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import java.time.Duration
+
+@SpringBootTest(
+    classes = [
+        Application::class,
+        TestCachingConfig::class,
+        TestDatabaseConfig::class,
+        TestManagerConfig::class,
+        TestAppConfig::class,
+        TestBotConfig::class,
+    ]
+)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("test")
+class TeamPresetServiceIntegrationTest {
+
+    @Autowired
+    lateinit var teamPresetService: TeamPresetService
+
+    @Autowired
+    lateinit var teamSplitSessionService: TeamSplitSessionService
+
+    private val guildId = 999_001L
+
+    @BeforeEach
+    fun setUp() {
+        teamPresetService.clearCache()
+        teamPresetService.deleteAllForGuild(guildId)
+        teamSplitSessionService.purgeOlderThan(Duration.ZERO)
+    }
+
+    @Test
+    fun `upsertPreset creates a new preset and listForGuild surfaces it`() {
+        val saved = teamPresetService.upsertPreset(
+            guildId = guildId,
+            name = "friday-night",
+            memberIds = listOf(111L, 222L, 333L),
+            createdByDiscordId = 42L,
+        )
+        assertNotNull(saved.id)
+        assertEquals("friday-night", saved.name)
+        assertEquals(listOf(111L, 222L, 333L), saved.memberIdList)
+
+        teamPresetService.clearCache()
+        val listed = teamPresetService.listForGuild(guildId)
+        assertEquals(1, listed.size)
+        assertEquals("friday-night", listed[0].name)
+    }
+
+    @Test
+    fun `upsertPreset is case-insensitive and overwrites in place`() {
+        teamPresetService.upsertPreset(guildId, "Crew", listOf(111L, 222L), 42L)
+        teamPresetService.upsertPreset(guildId, "crew", listOf(333L, 444L, 555L), 42L)
+
+        teamPresetService.clearCache()
+        val all = teamPresetService.listForGuild(guildId)
+        assertEquals(1, all.size, "case-insensitive upsert should not create a second row")
+        assertEquals(listOf(333L, 444L, 555L), all[0].memberIdList)
+    }
+
+    @Test
+    fun `getByName matches case-insensitively`() {
+        teamPresetService.upsertPreset(guildId, "Squad", listOf(111L), 42L)
+        assertNotNull(teamPresetService.getByName(guildId, "squad"))
+        assertNotNull(teamPresetService.getByName(guildId, "SQUAD"))
+        assertNull(teamPresetService.getByName(guildId, "other"))
+    }
+
+    @Test
+    fun `split session roundtrips and can be marked confirmed`() {
+        val session = teamSplitSessionService.createSession(
+            guildId = guildId,
+            requesterDiscordId = 42L,
+            memberIds = listOf(111L, 222L, 333L, 444L),
+            teamCount = 2,
+            assignments = listOf(listOf(111L, 222L), listOf(333L, 444L)),
+            teamNames = listOf("Red", "Blue"),
+        )
+        val fetched = teamSplitSessionService.getSession(session.id)
+        assertNotNull(fetched)
+        assertEquals(2, fetched!!.teamCount)
+
+        val updated = teamSplitSessionService.markConfirmed(session.id)
+        assertEquals("confirmed", updated!!.lastAction)
+    }
+
+    @Test
+    fun `purgeOlderThan removes nothing when cutoff is in the past`() {
+        teamSplitSessionService.createSession(
+            guildId = guildId, requesterDiscordId = 42L,
+            memberIds = listOf(111L, 222L), teamCount = 2,
+            assignments = listOf(listOf(111L), listOf(222L)),
+            teamNames = listOf("A", "B"),
+        )
+        // A 1-hour cutoff against a row that was just inserted should be a no-op.
+        val deleted = teamSplitSessionService.purgeOlderThan(Duration.ofHours(1))
+        assertEquals(0, deleted)
+    }
+}

--- a/common/src/main/kotlin/common/configuration/CachingConfig.kt
+++ b/common/src/main/kotlin/common/configuration/CachingConfig.kt
@@ -16,7 +16,9 @@ import java.util.concurrent.TimeUnit
 class CachingConfig {
     @Bean
     fun cacheManager(): CacheManager {
-        val manager = CaffeineCacheManager("configs", "brothers", "users", "music", "excuses", "tobyCoinMarkets")
+        val manager = CaffeineCacheManager(
+            "configs", "brothers", "users", "music", "excuses", "team-presets", "tobyCoinMarkets",
+        )
         manager.setCaffeine(
             Caffeine.newBuilder()
                 .maximumSize(100)

--- a/common/src/test/kotlin/common/configuration/TestCachingConfig.kt
+++ b/common/src/test/kotlin/common/configuration/TestCachingConfig.kt
@@ -23,6 +23,7 @@ open class TestCachingConfig {
                 ConcurrentMapCache("users"),
                 ConcurrentMapCache("music"),
                 ConcurrentMapCache("excuses"),
+                ConcurrentMapCache("team-presets"),
                 ConcurrentMapCache("tobyCoinMarkets")
             )
         )

--- a/database/src/main/kotlin/database/dto/TeamPresetDto.kt
+++ b/database/src/main/kotlin/database/dto/TeamPresetDto.kt
@@ -1,0 +1,77 @@
+package database.dto
+
+import jakarta.persistence.*
+import org.springframework.transaction.annotation.Transactional
+import java.io.Serializable
+import java.time.Instant
+
+@NamedQueries(
+    NamedQuery(
+        name = "TeamPresetDto.getByGuild",
+        query = "select t from TeamPresetDto t WHERE t.guildId = :guildId ORDER BY LOWER(t.name) ASC"
+    ),
+    NamedQuery(
+        name = "TeamPresetDto.getByGuildAndName",
+        query = "select t from TeamPresetDto t WHERE t.guildId = :guildId AND LOWER(t.name) = LOWER(:name)"
+    ),
+    NamedQuery(
+        name = "TeamPresetDto.getById",
+        query = "select t from TeamPresetDto t WHERE t.id = :id"
+    ),
+    NamedQuery(
+        name = "TeamPresetDto.deleteById",
+        query = "delete from TeamPresetDto t WHERE t.id = :id"
+    ),
+    NamedQuery(
+        name = "TeamPresetDto.deleteAllByGuild",
+        query = "delete from TeamPresetDto t WHERE t.guildId = :guildId"
+    ),
+)
+@Entity
+@Table(name = "team_preset", schema = "public")
+@Transactional
+class TeamPresetDto(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    var id: Long? = null,
+
+    @Column(name = "guild_id")
+    var guildId: Long = 0L,
+
+    @Column(name = "name")
+    var name: String = "",
+
+    @Column(name = "member_ids")
+    var memberIds: String = "",
+
+    @Column(name = "created_by_discord_id")
+    var createdByDiscordId: Long = 0L,
+
+    @Column(name = "created_at")
+    var createdAt: Instant? = null,
+
+    @Column(name = "updated_at")
+    var updatedAt: Instant? = null,
+) : Serializable {
+
+    /** CSV ↔ list helper. Blank strings yield an empty list (not [""]) so
+     *  callers don't have to filter on the way out. */
+    var memberIdList: List<Long>
+        get() = memberIds.split(',').mapNotNull { it.trim().takeIf { s -> s.isNotEmpty() }?.toLongOrNull() }
+        set(value) {
+            memberIds = value.joinToString(",")
+        }
+
+    @PrePersist
+    fun onCreate() {
+        val now = Instant.now()
+        if (createdAt == null) createdAt = now
+        if (updatedAt == null) updatedAt = now
+    }
+
+    @PreUpdate
+    fun onUpdate() {
+        updatedAt = Instant.now()
+    }
+}

--- a/database/src/main/kotlin/database/dto/TeamSplitSessionDto.kt
+++ b/database/src/main/kotlin/database/dto/TeamSplitSessionDto.kt
@@ -1,0 +1,78 @@
+package database.dto
+
+import jakarta.persistence.*
+import org.springframework.transaction.annotation.Transactional
+import java.io.Serializable
+import java.time.Instant
+import java.util.UUID
+
+@NamedQueries(
+    NamedQuery(
+        name = "TeamSplitSessionDto.getById",
+        query = "select s from TeamSplitSessionDto s WHERE s.id = :id"
+    ),
+    NamedQuery(
+        name = "TeamSplitSessionDto.deleteById",
+        query = "delete from TeamSplitSessionDto s WHERE s.id = :id"
+    ),
+    NamedQuery(
+        name = "TeamSplitSessionDto.deleteOlderThan",
+        query = "delete from TeamSplitSessionDto s WHERE s.createdAt < :cutoff"
+    ),
+    NamedQuery(
+        name = "TeamSplitSessionDto.recentForGuild",
+        query = "select s from TeamSplitSessionDto s WHERE s.guildId = :guildId ORDER BY s.createdAt DESC"
+    ),
+)
+@Entity
+@Table(name = "team_split_session", schema = "public")
+@Transactional
+class TeamSplitSessionDto(
+    @Id
+    @Column(name = "id")
+    var id: UUID = UUID.randomUUID(),
+
+    @Column(name = "guild_id")
+    var guildId: Long = 0L,
+
+    @Column(name = "requester_discord_id")
+    var requesterDiscordId: Long = 0L,
+
+    /** CSV of Discord snowflakes — the source roster for the split. */
+    @Column(name = "member_ids")
+    var memberIds: String = "",
+
+    @Column(name = "team_count")
+    var teamCount: Int = 2,
+
+    /**
+     * Pipe-delimited groups of CSV ids: `1,2,3|4,5|6,7`. Lined up with
+     * [teamNames] by index. Plain text rather than JSON to keep the
+     * database module free of a Jackson dependency.
+     */
+    @Column(name = "assignments")
+    var assignments: String = "",
+
+    /** Newline-delimited (team names may contain commas). One per team. */
+    @Column(name = "team_names")
+    var teamNames: String = "",
+
+    @Column(name = "created_at")
+    var createdAt: Instant? = null,
+
+    @Column(name = "last_action")
+    var lastAction: String = ACTION_CREATED,
+) : Serializable {
+
+    @PrePersist
+    fun onCreate() {
+        if (createdAt == null) createdAt = Instant.now()
+    }
+
+    companion object {
+        const val ACTION_CREATED = "created"
+        const val ACTION_REROLLED = "rerolled"
+        const val ACTION_CONFIRMED = "confirmed"
+        const val ACTION_CANCELLED = "cancelled"
+    }
+}

--- a/database/src/main/kotlin/database/persistence/TeamPresetPersistence.kt
+++ b/database/src/main/kotlin/database/persistence/TeamPresetPersistence.kt
@@ -1,0 +1,13 @@
+package database.persistence
+
+import database.dto.TeamPresetDto
+
+interface TeamPresetPersistence {
+    fun listByGuild(guildId: Long): List<TeamPresetDto>
+    fun getByGuildAndName(guildId: Long, name: String): TeamPresetDto?
+    fun getById(id: Long): TeamPresetDto?
+    fun save(dto: TeamPresetDto): TeamPresetDto
+    fun update(dto: TeamPresetDto): TeamPresetDto
+    fun deleteById(id: Long)
+    fun deleteAllByGuild(guildId: Long)
+}

--- a/database/src/main/kotlin/database/persistence/TeamSplitSessionPersistence.kt
+++ b/database/src/main/kotlin/database/persistence/TeamSplitSessionPersistence.kt
@@ -1,0 +1,14 @@
+package database.persistence
+
+import database.dto.TeamSplitSessionDto
+import java.time.Instant
+import java.util.UUID
+
+interface TeamSplitSessionPersistence {
+    fun save(dto: TeamSplitSessionDto): TeamSplitSessionDto
+    fun getById(id: UUID): TeamSplitSessionDto?
+    fun update(dto: TeamSplitSessionDto): TeamSplitSessionDto
+    fun deleteById(id: UUID)
+    fun deleteOlderThan(cutoff: Instant): Int
+    fun recentForGuild(guildId: Long, limit: Int): List<TeamSplitSessionDto>
+}

--- a/database/src/main/kotlin/database/persistence/impl/DefaultTeamPresetPersistence.kt
+++ b/database/src/main/kotlin/database/persistence/impl/DefaultTeamPresetPersistence.kt
@@ -1,0 +1,71 @@
+package database.persistence.impl
+
+import database.dto.TeamPresetDto
+import database.persistence.TeamPresetPersistence
+import jakarta.persistence.EntityManager
+import jakarta.persistence.NoResultException
+import jakarta.persistence.PersistenceContext
+import jakarta.persistence.TypedQuery
+import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
+
+@Repository
+@Transactional
+class DefaultTeamPresetPersistence internal constructor() : TeamPresetPersistence {
+    @PersistenceContext
+    private lateinit var entityManager: EntityManager
+
+    override fun listByGuild(guildId: Long): List<TeamPresetDto> {
+        val q: TypedQuery<TeamPresetDto> =
+            entityManager.createNamedQuery("TeamPresetDto.getByGuild", TeamPresetDto::class.java)
+        q.setParameter("guildId", guildId)
+        return q.resultList
+    }
+
+    override fun getByGuildAndName(guildId: Long, name: String): TeamPresetDto? {
+        val q: TypedQuery<TeamPresetDto> =
+            entityManager.createNamedQuery("TeamPresetDto.getByGuildAndName", TeamPresetDto::class.java)
+        q.setParameter("guildId", guildId)
+        q.setParameter("name", name)
+        return try {
+            q.singleResult
+        } catch (_: NoResultException) {
+            null
+        }
+    }
+
+    override fun getById(id: Long): TeamPresetDto? {
+        val q: TypedQuery<TeamPresetDto> =
+            entityManager.createNamedQuery("TeamPresetDto.getById", TeamPresetDto::class.java)
+        q.setParameter("id", id)
+        return try {
+            q.singleResult
+        } catch (_: NoResultException) {
+            null
+        }
+    }
+
+    override fun save(dto: TeamPresetDto): TeamPresetDto {
+        entityManager.persist(dto)
+        entityManager.flush()
+        return dto
+    }
+
+    override fun update(dto: TeamPresetDto): TeamPresetDto {
+        val merged = entityManager.merge(dto)
+        entityManager.flush()
+        return merged
+    }
+
+    override fun deleteById(id: Long) {
+        val q = entityManager.createNamedQuery("TeamPresetDto.deleteById")
+        q.setParameter("id", id)
+        q.executeUpdate()
+    }
+
+    override fun deleteAllByGuild(guildId: Long) {
+        val q = entityManager.createNamedQuery("TeamPresetDto.deleteAllByGuild")
+        q.setParameter("guildId", guildId)
+        q.executeUpdate()
+    }
+}

--- a/database/src/main/kotlin/database/persistence/impl/DefaultTeamSplitSessionPersistence.kt
+++ b/database/src/main/kotlin/database/persistence/impl/DefaultTeamSplitSessionPersistence.kt
@@ -1,0 +1,62 @@
+package database.persistence.impl
+
+import database.dto.TeamSplitSessionDto
+import database.persistence.TeamSplitSessionPersistence
+import jakarta.persistence.EntityManager
+import jakarta.persistence.NoResultException
+import jakarta.persistence.PersistenceContext
+import jakarta.persistence.TypedQuery
+import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+import java.util.UUID
+
+@Repository
+@Transactional
+class DefaultTeamSplitSessionPersistence internal constructor() : TeamSplitSessionPersistence {
+    @PersistenceContext
+    private lateinit var entityManager: EntityManager
+
+    override fun save(dto: TeamSplitSessionDto): TeamSplitSessionDto {
+        entityManager.persist(dto)
+        entityManager.flush()
+        return dto
+    }
+
+    override fun getById(id: UUID): TeamSplitSessionDto? {
+        val q: TypedQuery<TeamSplitSessionDto> =
+            entityManager.createNamedQuery("TeamSplitSessionDto.getById", TeamSplitSessionDto::class.java)
+        q.setParameter("id", id)
+        return try {
+            q.singleResult
+        } catch (_: NoResultException) {
+            null
+        }
+    }
+
+    override fun update(dto: TeamSplitSessionDto): TeamSplitSessionDto {
+        val merged = entityManager.merge(dto)
+        entityManager.flush()
+        return merged
+    }
+
+    override fun deleteById(id: UUID) {
+        val q = entityManager.createNamedQuery("TeamSplitSessionDto.deleteById")
+        q.setParameter("id", id)
+        q.executeUpdate()
+    }
+
+    override fun deleteOlderThan(cutoff: Instant): Int {
+        val q = entityManager.createNamedQuery("TeamSplitSessionDto.deleteOlderThan")
+        q.setParameter("cutoff", cutoff)
+        return q.executeUpdate()
+    }
+
+    override fun recentForGuild(guildId: Long, limit: Int): List<TeamSplitSessionDto> {
+        val q: TypedQuery<TeamSplitSessionDto> =
+            entityManager.createNamedQuery("TeamSplitSessionDto.recentForGuild", TeamSplitSessionDto::class.java)
+        q.setParameter("guildId", guildId)
+        q.maxResults = limit.coerceAtLeast(1)
+        return q.resultList
+    }
+}

--- a/database/src/main/kotlin/database/service/TeamPresetService.kt
+++ b/database/src/main/kotlin/database/service/TeamPresetService.kt
@@ -1,0 +1,26 @@
+package database.service
+
+import database.dto.TeamPresetDto
+
+interface TeamPresetService {
+    fun listForGuild(guildId: Long): List<TeamPresetDto>
+    fun getByName(guildId: Long, name: String): TeamPresetDto?
+    fun getById(id: Long): TeamPresetDto?
+
+    /**
+     * Create or overwrite by `(guildId, lowercase name)`. If a preset
+     * with the same name already exists for the guild, its member list
+     * is replaced and [TeamPresetDto.updatedAt] bumps. Returns the
+     * persisted DTO.
+     */
+    fun upsertPreset(
+        guildId: Long,
+        name: String,
+        memberIds: List<Long>,
+        createdByDiscordId: Long,
+    ): TeamPresetDto
+
+    fun deletePreset(id: Long)
+    fun deleteAllForGuild(guildId: Long)
+    fun clearCache()
+}

--- a/database/src/main/kotlin/database/service/TeamSplitSessionService.kt
+++ b/database/src/main/kotlin/database/service/TeamSplitSessionService.kt
@@ -1,0 +1,57 @@
+package database.service
+
+import database.dto.TeamSplitSessionDto
+import java.time.Duration
+import java.util.UUID
+
+interface TeamSplitSessionService {
+
+    /**
+     * Persist a fresh preview session. Caller passes the resolved
+     * roster, the chosen team count, the initial assignments, and the
+     * human team names — all locked at modal-submission time. Returns
+     * the saved DTO (its `id` is the UUID embedded in button ids).
+     */
+    fun createSession(
+        guildId: Long,
+        requesterDiscordId: Long,
+        memberIds: List<Long>,
+        teamCount: Int,
+        assignments: List<List<Long>>,
+        teamNames: List<String>,
+    ): TeamSplitSessionDto
+
+    fun getSession(id: UUID): TeamSplitSessionDto?
+
+    /**
+     * Re-roll: replace assignments only. Members, team count, and names
+     * stay frozen at create time so Confirm uses the labels the user
+     * originally saw.
+     */
+    fun updateAssignments(id: UUID, assignments: List<List<Long>>): TeamSplitSessionDto?
+
+    fun markConfirmed(id: UUID): TeamSplitSessionDto?
+    fun markCancelled(id: UUID): TeamSplitSessionDto?
+
+    /** Returns the number of rows deleted. */
+    fun purgeOlderThan(maxAge: Duration): Int
+
+    fun recentForGuild(guildId: Long, limit: Int): List<TeamSplitSessionDto>
+}
+
+/** Encode `[[1,2],[3,4,5]]` as `"1,2|3,4,5"`. */
+fun encodeAssignments(assignments: List<List<Long>>): String =
+    assignments.joinToString("|") { team -> team.joinToString(",") }
+
+/** Inverse of [encodeAssignments]. Empty/blank input yields an empty list. */
+fun decodeAssignments(encoded: String): List<List<Long>> =
+    if (encoded.isBlank()) emptyList()
+    else encoded.split('|').map { group ->
+        group.split(',').mapNotNull { it.trim().takeIf { s -> s.isNotEmpty() }?.toLongOrNull() }
+    }
+
+/** Encode `["Red","Blue"]` as `"Red\nBlue"` (names may contain commas). */
+fun encodeTeamNames(names: List<String>): String = names.joinToString("\n")
+
+fun decodeTeamNames(encoded: String): List<String> =
+    if (encoded.isEmpty()) emptyList() else encoded.split('\n')

--- a/database/src/main/kotlin/database/service/impl/DefaultTeamPresetService.kt
+++ b/database/src/main/kotlin/database/service/impl/DefaultTeamPresetService.kt
@@ -1,0 +1,64 @@
+package database.service.impl
+
+import database.dto.TeamPresetDto
+import database.persistence.TeamPresetPersistence
+import database.service.TeamPresetService
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.cache.annotation.CacheEvict
+import org.springframework.cache.annotation.Cacheable
+import org.springframework.stereotype.Service
+import java.time.Instant
+
+@Service
+class DefaultTeamPresetService : TeamPresetService {
+    @Autowired
+    private lateinit var teamPresetPersistence: TeamPresetPersistence
+
+    @Cacheable(value = ["team-presets"], key = "'guild-' + #guildId")
+    override fun listForGuild(guildId: Long): List<TeamPresetDto> =
+        teamPresetPersistence.listByGuild(guildId)
+
+    override fun getByName(guildId: Long, name: String): TeamPresetDto? =
+        teamPresetPersistence.getByGuildAndName(guildId, name)
+
+    override fun getById(id: Long): TeamPresetDto? = teamPresetPersistence.getById(id)
+
+    @CacheEvict(value = ["team-presets"], allEntries = true)
+    override fun upsertPreset(
+        guildId: Long,
+        name: String,
+        memberIds: List<Long>,
+        createdByDiscordId: Long,
+    ): TeamPresetDto {
+        val trimmedName = name.trim()
+        val existing = teamPresetPersistence.getByGuildAndName(guildId, trimmedName)
+        return if (existing == null) {
+            val dto = TeamPresetDto(
+                guildId = guildId,
+                name = trimmedName,
+                createdByDiscordId = createdByDiscordId,
+            )
+            dto.memberIdList = memberIds.distinct()
+            teamPresetPersistence.save(dto)
+        } else {
+            existing.name = trimmedName
+            existing.memberIdList = memberIds.distinct()
+            existing.updatedAt = Instant.now()
+            teamPresetPersistence.update(existing)
+        }
+    }
+
+    @CacheEvict(value = ["team-presets"], allEntries = true)
+    override fun deletePreset(id: Long) {
+        teamPresetPersistence.deleteById(id)
+    }
+
+    @CacheEvict(value = ["team-presets"], allEntries = true)
+    override fun deleteAllForGuild(guildId: Long) {
+        teamPresetPersistence.deleteAllByGuild(guildId)
+    }
+
+    @CacheEvict(value = ["team-presets"], allEntries = true)
+    override fun clearCache() {
+    }
+}

--- a/database/src/main/kotlin/database/service/impl/DefaultTeamSplitSessionService.kt
+++ b/database/src/main/kotlin/database/service/impl/DefaultTeamSplitSessionService.kt
@@ -1,0 +1,67 @@
+package database.service.impl
+
+import database.dto.TeamSplitSessionDto
+import database.persistence.TeamSplitSessionPersistence
+import database.service.TeamSplitSessionService
+import database.service.encodeAssignments
+import database.service.encodeTeamNames
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Service
+import java.time.Duration
+import java.time.Instant
+import java.util.UUID
+
+@Service
+class DefaultTeamSplitSessionService : TeamSplitSessionService {
+    @Autowired
+    private lateinit var teamSplitSessionPersistence: TeamSplitSessionPersistence
+
+    override fun createSession(
+        guildId: Long,
+        requesterDiscordId: Long,
+        memberIds: List<Long>,
+        teamCount: Int,
+        assignments: List<List<Long>>,
+        teamNames: List<String>,
+    ): TeamSplitSessionDto {
+        val dto = TeamSplitSessionDto(
+            id = UUID.randomUUID(),
+            guildId = guildId,
+            requesterDiscordId = requesterDiscordId,
+            memberIds = memberIds.joinToString(","),
+            teamCount = teamCount,
+            assignments = encodeAssignments(assignments),
+            teamNames = encodeTeamNames(teamNames),
+            lastAction = TeamSplitSessionDto.ACTION_CREATED,
+        )
+        return teamSplitSessionPersistence.save(dto)
+    }
+
+    override fun getSession(id: UUID): TeamSplitSessionDto? =
+        teamSplitSessionPersistence.getById(id)
+
+    override fun updateAssignments(id: UUID, assignments: List<List<Long>>): TeamSplitSessionDto? {
+        val existing = teamSplitSessionPersistence.getById(id) ?: return null
+        existing.assignments = encodeAssignments(assignments)
+        existing.lastAction = TeamSplitSessionDto.ACTION_REROLLED
+        return teamSplitSessionPersistence.update(existing)
+    }
+
+    override fun markConfirmed(id: UUID): TeamSplitSessionDto? {
+        val existing = teamSplitSessionPersistence.getById(id) ?: return null
+        existing.lastAction = TeamSplitSessionDto.ACTION_CONFIRMED
+        return teamSplitSessionPersistence.update(existing)
+    }
+
+    override fun markCancelled(id: UUID): TeamSplitSessionDto? {
+        val existing = teamSplitSessionPersistence.getById(id) ?: return null
+        existing.lastAction = TeamSplitSessionDto.ACTION_CANCELLED
+        return teamSplitSessionPersistence.update(existing)
+    }
+
+    override fun purgeOlderThan(maxAge: Duration): Int =
+        teamSplitSessionPersistence.deleteOlderThan(Instant.now().minus(maxAge))
+
+    override fun recentForGuild(guildId: Long, limit: Int): List<TeamSplitSessionDto> =
+        teamSplitSessionPersistence.recentForGuild(guildId, limit)
+}

--- a/database/src/main/resources/db/migration/V32__team_preset_and_session.sql
+++ b/database/src/main/resources/db/migration/V32__team_preset_and_session.sql
@@ -1,0 +1,45 @@
+-- Persistence for the /team UI overhaul.
+--
+-- team_preset holds saved rosters per guild so users don't have to
+-- re-type the same group every Friday. Members are stored as a CSV of
+-- Discord snowflakes in TEXT; no other table in this repo uses
+-- bigint[], and a side-table would require cascading-delete plumbing
+-- we don't need today.
+--
+-- team_split_session is short-lived state for the preview-then-confirm
+-- flow. The /team split modal writes a row, embeds the UUID in
+-- Confirm/Reroll/Cancel button ids, and the buttons load the row back.
+-- Rerolling updates assignments in place so the same buttons keep
+-- working. There is no FK to team_preset — sessions outlive a preset
+-- rename/delete and shouldn't break when one happens.
+
+CREATE TABLE IF NOT EXISTS public.team_preset (
+    id                    BIGSERIAL                PRIMARY KEY,
+    guild_id              BIGINT                   NOT NULL,
+    name                  VARCHAR(64)              NOT NULL,
+    member_ids            TEXT                     NOT NULL,
+    created_by_discord_id BIGINT                   NOT NULL,
+    created_at            TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+    updated_at            TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_team_preset_guild_name
+    ON public.team_preset (guild_id, lower(name));
+
+CREATE INDEX IF NOT EXISTS idx_team_preset_guild
+    ON public.team_preset (guild_id);
+
+CREATE TABLE IF NOT EXISTS public.team_split_session (
+    id                   UUID                     PRIMARY KEY,
+    guild_id             BIGINT                   NOT NULL,
+    requester_discord_id BIGINT                   NOT NULL,
+    member_ids           TEXT                     NOT NULL,
+    team_count           INTEGER                  NOT NULL,
+    assignments          TEXT                     NOT NULL,
+    team_names           TEXT                     NOT NULL,
+    created_at           TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+    last_action          VARCHAR(16)              NOT NULL DEFAULT 'created'
+);
+
+CREATE INDEX IF NOT EXISTS idx_team_split_session_guild_created
+    ON public.team_split_session (guild_id, created_at DESC);

--- a/discord-bot/src/main/kotlin/bot/toby/button/buttons/TeamCancelButton.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/button/buttons/TeamCancelButton.kt
@@ -1,0 +1,39 @@
+package bot.toby.button.buttons
+
+import bot.toby.command.commands.misc.TeamCommand
+import core.button.Button
+import core.button.ButtonContext
+import database.dto.UserDto
+import database.service.TeamSplitSessionService
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+@Component
+class TeamCancelButton @Autowired constructor(
+    private val teamSplitSessionService: TeamSplitSessionService,
+) : Button {
+
+    override val name: String = TeamCommand.BUTTON_CANCEL
+    override val description: String = "Cancel a team split preview without creating any voice channels."
+    override val defersReply: Boolean = false
+
+    override fun handle(ctx: ButtonContext, requestingUserDto: UserDto, deleteDelay: Int) {
+        val event = ctx.event
+        event.deferEdit().queue()
+        val uuid = decodeUuid(event.componentId)
+        if (uuid != null) {
+            teamSplitSessionService.markCancelled(uuid)
+        }
+        event.hook.editOriginal("Team split cancelled.")
+            .setEmbeds(emptyList())
+            .setComponents()
+            .queue()
+    }
+
+    private fun decodeUuid(componentId: String): UUID? {
+        val raw = componentId.substringAfter(":", "")
+        if (raw.isEmpty()) return null
+        return runCatching { UUID.fromString(raw) }.getOrNull()
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/button/buttons/TeamConfirmButton.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/button/buttons/TeamConfirmButton.kt
@@ -61,10 +61,10 @@ class TeamConfirmButton @Autowired constructor(
                 .setBitrate(guild.maxBitrate).complete()
             memberIds.forEach { id ->
                 val target = guild.getMemberById(id) ?: return@forEach
-                guild.moveVoiceMember(target, channel as AudioChannel).queue(
-                    { /* moved */ },
-                    { /* member not in voice / left — skip silently */ },
-                )
+                // JDA's RestAction.queue() default error handler logs failures; we don't
+                // need a custom callback. A member who left voice between preview and
+                // confirm just fails silently here, which matches the legacy behavior.
+                guild.moveVoiceMember(target, channel as AudioChannel).queue()
             }
         }
 

--- a/discord-bot/src/main/kotlin/bot/toby/button/buttons/TeamConfirmButton.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/button/buttons/TeamConfirmButton.kt
@@ -1,0 +1,84 @@
+package bot.toby.button.buttons
+
+import bot.toby.command.commands.misc.TeamCommand
+import bot.toby.modal.modals.TeamSplitModal
+import core.button.Button
+import core.button.ButtonContext
+import database.dto.TeamSplitSessionDto
+import database.dto.UserDto
+import database.service.TeamSplitSessionService
+import database.service.decodeAssignments
+import database.service.decodeTeamNames
+import net.dv8tion.jda.api.entities.channel.concrete.VoiceChannel
+import net.dv8tion.jda.api.entities.channel.middleman.AudioChannel
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+@Component
+class TeamConfirmButton @Autowired constructor(
+    private val teamSplitSessionService: TeamSplitSessionService,
+) : Button {
+
+    override val name: String = TeamCommand.BUTTON_CONFIRM
+    override val description: String = "Confirm a team split preview: create voice channels and move members."
+    override val defersReply: Boolean = false
+
+    override fun handle(ctx: ButtonContext, requestingUserDto: UserDto, deleteDelay: Int) {
+        val event = ctx.event
+        event.deferEdit().queue()
+        val uuid = decodeUuid(event.componentId) ?: run {
+            event.hook.sendMessage("That preview is no longer valid.").setEphemeral(true).queue()
+            return
+        }
+        val session = teamSplitSessionService.getSession(uuid) ?: run {
+            event.hook.editOriginal("That preview expired or was cancelled.")
+                .setEmbeds(emptyList())
+                .setComponents()
+                .queue()
+            return
+        }
+
+        // Double-click protection: if a previous click already confirmed,
+        // don't create another set of channels.
+        if (session.lastAction == TeamSplitSessionDto.ACTION_CONFIRMED) {
+            event.hook.sendMessage("Teams already created for this preview.")
+                .setEphemeral(true).queue()
+            return
+        }
+        if (session.lastAction == TeamSplitSessionDto.ACTION_CANCELLED) {
+            event.hook.sendMessage("That preview was cancelled.").setEphemeral(true).queue()
+            return
+        }
+
+        val guild = ctx.guild
+        val assignments = decodeAssignments(session.assignments)
+        val teamNames = decodeTeamNames(session.teamNames)
+
+        assignments.forEachIndexed { index, memberIds ->
+            val teamName = teamNames.getOrNull(index) ?: "${TeamSplitModal.DEFAULT_PREFIX} ${index + 1}"
+            val channel: VoiceChannel = guild.createVoiceChannel(teamName)
+                .setBitrate(guild.maxBitrate).complete()
+            memberIds.forEach { id ->
+                val target = guild.getMemberById(id) ?: return@forEach
+                guild.moveVoiceMember(target, channel as AudioChannel).queue(
+                    { /* moved */ },
+                    { /* member not in voice / left — skip silently */ },
+                )
+            }
+        }
+
+        teamSplitSessionService.markConfirmed(uuid)
+
+        val resultEmbed = TeamCommand.buildResultEmbed(guild, teamNames, assignments)
+        event.hook.editOriginalEmbeds(resultEmbed)
+            .setComponents(TeamCommand.buildDisabledActionRow(uuid))
+            .queue()
+    }
+
+    private fun decodeUuid(componentId: String): UUID? {
+        val raw = componentId.substringAfter(":", "")
+        if (raw.isEmpty()) return null
+        return runCatching { UUID.fromString(raw) }.getOrNull()
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/button/buttons/TeamRerollButton.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/button/buttons/TeamRerollButton.kt
@@ -1,0 +1,70 @@
+package bot.toby.button.buttons
+
+import bot.toby.command.commands.misc.TeamCommand
+import core.button.Button
+import core.button.ButtonContext
+import database.dto.TeamSplitSessionDto
+import database.dto.UserDto
+import database.service.TeamSplitSessionService
+import database.service.decodeTeamNames
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+@Component
+class TeamRerollButton @Autowired constructor(
+    private val teamSplitSessionService: TeamSplitSessionService,
+) : Button {
+
+    override val name: String = TeamCommand.BUTTON_REROLL
+    override val description: String = "Re-shuffle a team split preview, keeping the same roster and team count."
+    override val defersReply: Boolean = false
+
+    override fun handle(ctx: ButtonContext, requestingUserDto: UserDto, deleteDelay: Int) {
+        val event = ctx.event
+        event.deferEdit().queue()
+        val uuid = decodeUuid(event.componentId) ?: run {
+            event.hook.sendMessage("That preview is no longer valid.").setEphemeral(true).queue()
+            return
+        }
+        val session = teamSplitSessionService.getSession(uuid) ?: run {
+            event.hook.editOriginal("That preview expired or was cancelled.")
+                .setEmbeds(emptyList())
+                .setComponents()
+                .queue()
+            return
+        }
+        if (session.lastAction == TeamSplitSessionDto.ACTION_CONFIRMED) {
+            event.hook.sendMessage("Already confirmed — start a new `/team split` to reroll.")
+                .setEphemeral(true).queue()
+            return
+        }
+        if (session.lastAction == TeamSplitSessionDto.ACTION_CANCELLED) {
+            event.hook.sendMessage("That preview was cancelled.").setEphemeral(true).queue()
+            return
+        }
+
+        val guild = ctx.guild
+        val memberIds = session.memberIds.split(',').mapNotNull { it.trim().toLongOrNull() }
+        val resolvedMembers = memberIds.mapNotNull { guild.getMemberById(it) }
+        val teamNames = decodeTeamNames(session.teamNames)
+
+        // Rebuild the preview with a fresh shuffle. Member list, count,
+        // and team names stay frozen from the original modal submission
+        // so Confirm still produces the labels the user agreed to.
+        val newAssignments = TeamCommand.split(resolvedMembers, session.teamCount)
+            .map { team -> team.mapNotNull { it?.idLong } }
+        teamSplitSessionService.updateAssignments(uuid, newAssignments)
+
+        val embed = TeamCommand.buildPreviewEmbed(guild, teamNames, newAssignments)
+        event.hook.editOriginalEmbeds(embed)
+            .setComponents(TeamCommand.buildActionRow(uuid))
+            .queue()
+    }
+
+    private fun decodeUuid(componentId: String): UUID? {
+        val raw = componentId.substringAfter(":", "")
+        if (raw.isEmpty()) return null
+        return runCatching { UUID.fromString(raw) }.getOrNull()
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/misc/TeamCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/misc/TeamCommand.kt
@@ -84,11 +84,19 @@ class TeamCommand : MiscCommand {
         builder.addComponents(Label.of("Load preset (optional)", presetField))
 
         val membersBuilder = TextInput.create(TeamSplitModal.FIELD_MEMBERS, TextInputStyle.PARAGRAPH)
-            .setPlaceholder("@mentions or raw IDs. Combined with preset if both are filled.")
+            .setPlaceholder("@mentions or raw IDs. Names in parentheses are decorative.")
             .setRequired(false)
             .setMaxLength(MEMBERS_FIELD_MAX)
         if (prefilledMembers.isNotEmpty()) {
-            membersBuilder.setValue(prefilledMembers.joinToString(" ") { "<@${it.idLong}>" })
+            // Modal text inputs render raw text, not Discord mentions, so a bare
+            // `<@123…>` string is unreadable. Prefix each id with the member's
+            // effective name so the user can spot wrong people / typos at a
+            // glance. The parser only looks at the `<@id>` token, so the name
+            // is decorative — users can remove a whole `Name (<@id>)` block to
+            // drop someone, and adding a new member still requires the raw id.
+            membersBuilder.setValue(
+                prefilledMembers.joinToString(", ") { "${it.effectiveName} (<@${it.idLong}>)" }
+            )
         }
         builder.addComponents(Label.of("Members", membersBuilder.build()))
 

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/misc/TeamCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/misc/TeamCommand.kt
@@ -1,77 +1,233 @@
 package bot.toby.command.commands.misc
 
+import bot.toby.modal.modals.TeamSplitModal
 import core.command.Command.Companion.replyAndDelete
 import core.command.CommandContext
 import database.dto.UserDto
+import net.dv8tion.jda.api.EmbedBuilder
+import net.dv8tion.jda.api.components.actionrow.ActionRow
+import net.dv8tion.jda.api.components.buttons.Button
+import net.dv8tion.jda.api.components.label.Label
+import net.dv8tion.jda.api.components.textinput.TextInput
+import net.dv8tion.jda.api.components.textinput.TextInputStyle
+import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.entities.Member
 import net.dv8tion.jda.api.entities.channel.middleman.GuildChannel
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
 import net.dv8tion.jda.api.interactions.commands.OptionType
 import net.dv8tion.jda.api.interactions.commands.build.OptionData
+import net.dv8tion.jda.api.interactions.commands.build.SubcommandData
+import net.dv8tion.jda.api.modals.Modal
 import org.springframework.stereotype.Component
+import java.awt.Color
+import java.util.UUID
 
 @Component
 class TeamCommand : MiscCommand {
 
-    override fun handle(ctx: CommandContext, requestingUserDto: UserDto, deleteDelay: Int) {
-        val event = ctx.event
-        event.deferReply().queue()
-        cleanupTemporaryChannels(event.guild!!.channels)
-
-        val args = event.options
-        if (args.isEmpty()) {
-            event.hook.replyAndDelete(description, deleteDelay)
-            return
-        }
-        if (event.getOption(CLEANUP)?.asBoolean == true) {
-            return
-        }
-
-        val mentionedMembers = event.getOption(TEAM_MEMBERS)?.mentions?.members ?: emptyList()
-        val listsToInitialize = minOf(event.getOption(TEAM_SIZE)?.asInt ?: 2, mentionedMembers.size)
-        val teams = split(mentionedMembers, listsToInitialize)
-        val guild = event.guild!!
-
-        val sb = StringBuilder()
-        teams.forEachIndexed { index, team ->
-            val teamName = "Team ${index + 1}"
-            sb.append("**$teamName**: ${team.joinToString { it!!.effectiveName }}\n")
-
-            val createdVoiceChannel = guild.createVoiceChannel(teamName).setBitrate(guild.maxBitrate).complete()
-            team.forEach { target -> guild.moveVoiceMember(target!!, createdVoiceChannel).queue() }
-        }
-
-        event.hook.replyAndDelete(sb.toString(), deleteDelay)
-    }
-
-    private fun cleanupTemporaryChannels(channels: List<GuildChannel>) {
-        channels.filter { it.name.matches("(?i)team\\s[0-9]+".toRegex()) }
-            .forEach { it.delete().queue() }
-    }
-
     override val name: String = "team"
-    override val description: String = "Return X teams from a list of tagged users."
-    override val optionData: List<OptionData> = listOf(
-        OptionData(OptionType.STRING, TEAM_MEMBERS, "Which discord users would you like to split into the teams?", true),
-        OptionData(OptionType.INTEGER, TEAM_SIZE, "Number of teams you want to split members into (defaults to 2)"),
-        OptionData(OptionType.BOOLEAN, CLEANUP, "Do you want to perform cleanup to reset the temporary channels in the guild?")
+    override val description: String = "Split a roster into random teams and move members into per-team voice channels."
+
+    override val subCommands: List<SubcommandData> = listOf(
+        SubcommandData(SUB_SPLIT, "Open a form to split a roster into random teams.")
+            .addOptions(
+                OptionData(
+                    OptionType.STRING,
+                    OPT_MEMBERS,
+                    "Optional: pre-fill the form with these @-mentioned members.",
+                    false,
+                )
+            ),
+        SubcommandData(SUB_CLEANUP, "Delete the temporary 'Team N' voice channels this command created."),
     )
 
-    companion object {
-        private const val TEAM_MEMBERS = "members"
-        private const val TEAM_SIZE = "size"
-        private const val CLEANUP = "cleanup"
+    override fun handle(ctx: CommandContext, requestingUserDto: UserDto, deleteDelay: Int) {
+        val event = ctx.event
+        if (event.guild == null) {
+            event.reply("This command can only be used in a server.").setEphemeral(true).queue()
+            return
+        }
 
+        when (event.subcommandName) {
+            SUB_SPLIT -> {
+                val prefill = event.getOption(OPT_MEMBERS)?.mentions?.members.orEmpty()
+                    .filter { !it.user.isBot }
+                event.replyModal(buildSplitModal(prefill)).queue()
+            }
+            SUB_CLEANUP -> {
+                event.deferReply().queue()
+                val deleted = cleanupTemporaryChannels(event.guild!!.channels)
+                event.hook.replyAndDelete(
+                    if (deleted == 0) "No temporary team channels to clean up."
+                    else "Cleaned up $deleted temporary team channel${if (deleted == 1) "" else "s"}.",
+                    deleteDelay,
+                )
+            }
+            else -> {
+                event.deferReply().queue()
+                event.hook.replyAndDelete(
+                    "Use `/team split` to open the team-split form, or `/team cleanup` to remove the temp channels.",
+                    deleteDelay,
+                )
+            }
+        }
+    }
+
+    private fun buildSplitModal(prefilledMembers: List<Member>): Modal {
+        val builder = Modal.create(TeamSplitModal.MODAL_NAME, "Split a roster into teams")
+
+        val presetField = TextInput.create(TeamSplitModal.FIELD_PRESET_NAME, TextInputStyle.SHORT)
+            .setPlaceholder("e.g. friday-night (optional)")
+            .setRequired(false)
+            .setMaxLength(PRESET_NAME_MAX)
+            .build()
+        builder.addComponents(Label.of("Load preset (optional)", presetField))
+
+        val membersBuilder = TextInput.create(TeamSplitModal.FIELD_MEMBERS, TextInputStyle.PARAGRAPH)
+            .setPlaceholder("@mentions or raw IDs. Combined with preset if both are filled.")
+            .setRequired(false)
+            .setMaxLength(MEMBERS_FIELD_MAX)
+        if (prefilledMembers.isNotEmpty()) {
+            membersBuilder.setValue(prefilledMembers.joinToString(" ") { "<@${it.idLong}>" })
+        }
+        builder.addComponents(Label.of("Members", membersBuilder.build()))
+
+        val teamCountField = TextInput.create(TeamSplitModal.FIELD_TEAM_COUNT, TextInputStyle.SHORT)
+            .setPlaceholder("2")
+            .setValue(TeamSplitModal.DEFAULT_TEAM_COUNT.toString())
+            .setRequired(true)
+            .setMaxLength(3)
+            .build()
+        builder.addComponents(Label.of("Number of teams", teamCountField))
+
+        val strategyField = TextInput.create(TeamSplitModal.FIELD_NAME_STRATEGY, TextInputStyle.SHORT)
+            .setPlaceholder("prefix or list")
+            .setValue(TeamSplitModal.STRATEGY_PREFIX)
+            .setRequired(false)
+            .setMaxLength(8)
+            .build()
+        builder.addComponents(Label.of("Name strategy: prefix | list", strategyField))
+
+        val namesField = TextInput.create(TeamSplitModal.FIELD_NAMES, TextInputStyle.SHORT)
+            .setPlaceholder("'Squad' (prefix mode) or 'Red,Blue,Green' (list mode)")
+            .setValue(TeamSplitModal.DEFAULT_PREFIX)
+            .setRequired(false)
+            .setMaxLength(NAMES_FIELD_MAX)
+            .build()
+        builder.addComponents(Label.of("Team names", namesField))
+
+        return builder.build()
+    }
+
+    private fun cleanupTemporaryChannels(channels: List<GuildChannel>): Int {
+        val matching = channels.filter { TEAM_CHANNEL_PATTERN.containsMatchIn(it.name) }
+        matching.forEach { it.delete().queue() }
+        return matching.size
+    }
+
+    companion object {
+        const val SUB_SPLIT = "split"
+        const val SUB_CLEANUP = "cleanup"
+        private const val OPT_MEMBERS = "members"
+
+        const val BUTTON_CONFIRM = "team-confirm"
+        const val BUTTON_REROLL = "team-reroll"
+        const val BUTTON_CANCEL = "team-cancel"
+
+        private const val PRESET_NAME_MAX = 64
+        private const val MEMBERS_FIELD_MAX = 4000
+        private const val NAMES_FIELD_MAX = 200
+        private const val PREVIEW_COLOR_RGB = 0x5865F2 // Discord blurple
+        private const val RESULT_COLOR_RGB = 0x57F287  // Discord green
+
+        // Match the legacy "Team N" channel format used by older invocations
+        // as well as the new "<prefix> N" channels created by Confirm. We
+        // can't enumerate every possible custom prefix, so cleanup stays
+        // conservative: match only the default "Team N" pattern. Custom-named
+        // channels stay until manually deleted (intentional — users named
+        // them, users own them).
+        private val TEAM_CHANNEL_PATTERN = Regex("(?i)^team\\s+\\d+$")
+
+        /**
+         * Legacy random-split helper. Returned by JDA `List<Member>` in
+         * the new flow, but tests still build the input out of nullable
+         * members so we keep the `List<Member?>` signature for source
+         * compatibility.
+         */
         fun split(list: List<Member?>, splitSize: Int): List<List<Member?>> {
+            if (splitSize <= 0) return emptyList()
             val shuffledList = list.shuffled()
+            val total = list.size
+            val baseSize = total / splitSize
+            val remainder = total % splitSize
             val result = mutableListOf<List<Member?>>()
-            val numberOfMembersTagged = list.size
+            var cursor = 0
             repeat(splitSize) { i ->
-                val sizeOfTeams = numberOfMembersTagged / splitSize
-                val fromIndex = i * sizeOfTeams
-                val toIndex = (i + 1) * sizeOfTeams
-                result.add(shuffledList.subList(fromIndex, toIndex))
+                // Distribute the remainder across the first `remainder` teams
+                // so we don't drop members on the floor when total %
+                // splitSize != 0 (the old impl silently truncated).
+                val take = baseSize + if (i < remainder) 1 else 0
+                result.add(shuffledList.subList(cursor, cursor + take))
+                cursor += take
             }
             return result
         }
+
+        fun buildPreviewEmbed(
+            guild: Guild,
+            teamNames: List<String>,
+            assignments: List<List<Long>>,
+        ): net.dv8tion.jda.api.entities.MessageEmbed {
+            val builder = EmbedBuilder()
+                .setTitle("Team split preview")
+                .setColor(Color(PREVIEW_COLOR_RGB))
+                .setDescription("Click **Confirm** to create voice channels and move members, **Reroll** to re-shuffle, or **Cancel**.")
+            renderTeamFields(builder, guild, teamNames, assignments)
+            builder.setFooter("Preview only — no channels created yet.")
+            return builder.build()
+        }
+
+        fun buildResultEmbed(
+            guild: Guild,
+            teamNames: List<String>,
+            assignments: List<List<Long>>,
+        ): net.dv8tion.jda.api.entities.MessageEmbed {
+            val builder = EmbedBuilder()
+                .setTitle("Teams created")
+                .setColor(Color(RESULT_COLOR_RGB))
+            renderTeamFields(builder, guild, teamNames, assignments)
+            builder.setFooter("Use /team cleanup to remove the temporary channels.")
+            return builder.build()
+        }
+
+        private fun renderTeamFields(
+            builder: EmbedBuilder,
+            guild: Guild,
+            teamNames: List<String>,
+            assignments: List<List<Long>>,
+        ) {
+            assignments.forEachIndexed { index, memberIds ->
+                val label = teamNames.getOrNull(index) ?: "Team ${index + 1}"
+                val rendered = memberIds.joinToString("\n") { id ->
+                    val name = guild.getMemberById(id)?.effectiveName
+                        ?: guild.jda.getUserById(id)?.name
+                        ?: "Unknown ($id)"
+                    "• $name"
+                }.ifEmpty { "(empty)" }
+                builder.addField("$label · ${memberIds.size}", rendered, true)
+            }
+        }
+
+        fun buildActionRow(sessionId: UUID): ActionRow = ActionRow.of(
+            Button.success("$BUTTON_CONFIRM:$sessionId", "Confirm"),
+            Button.primary("$BUTTON_REROLL:$sessionId", "Reroll"),
+            Button.danger("$BUTTON_CANCEL:$sessionId", "Cancel"),
+        )
+
+        fun buildDisabledActionRow(sessionId: UUID): ActionRow = ActionRow.of(
+            Button.success("$BUTTON_CONFIRM:$sessionId", "Confirm").withDisabled(true),
+            Button.primary("$BUTTON_REROLL:$sessionId", "Reroll").withDisabled(true),
+            Button.danger("$BUTTON_CANCEL:$sessionId", "Cancel").withDisabled(true),
+        )
     }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/modal/modals/TeamSplitModal.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/modal/modals/TeamSplitModal.kt
@@ -1,0 +1,152 @@
+package bot.toby.modal.modals
+
+import bot.toby.command.commands.misc.TeamCommand
+import core.modal.Modal
+import core.modal.ModalContext
+import database.service.TeamPresetService
+import database.service.TeamSplitSessionService
+import org.springframework.stereotype.Component
+
+/**
+ * Submission handler for the `/team split` form.
+ *
+ * Discord caps modals at 5 components, so we share one paragraph field
+ * for members across both "pasted in" and "loaded from preset" cases:
+ * the preset's roster is unioned with whatever the user typed, and the
+ * combined list is what we split.
+ *
+ * Voice channels are NOT created here — this handler only persists a
+ * preview session and posts an ephemeral embed with Confirm / Reroll /
+ * Cancel buttons. The actual side-effects happen in [TeamConfirmButton].
+ */
+@Component
+class TeamSplitModal(
+    private val teamPresetService: TeamPresetService,
+    private val teamSplitSessionService: TeamSplitSessionService,
+) : Modal {
+    override val name = MODAL_NAME
+
+    override fun handle(ctx: ModalContext, deleteDelay: Int) {
+        val event = ctx.event
+        val guild = ctx.guild
+        val guildId = guild.idLong
+
+        val presetName = event.getValue(FIELD_PRESET_NAME)?.asString?.trim().orEmpty()
+        val pastedMembersRaw = event.getValue(FIELD_MEMBERS)?.asString.orEmpty()
+        val teamCountStr = event.getValue(FIELD_TEAM_COUNT)?.asString?.trim().orEmpty()
+        val nameStrategy = event.getValue(FIELD_NAME_STRATEGY)?.asString?.trim()?.lowercase().orEmpty()
+        val namesRaw = event.getValue(FIELD_NAMES)?.asString?.trim().orEmpty()
+
+        val presetIds: List<Long> = if (presetName.isNotEmpty()) {
+            val preset = teamPresetService.getByName(guildId, presetName) ?: run {
+                event.hook.sendMessage("No preset named '$presetName' in this server.")
+                    .setEphemeral(true).queue()
+                return
+            }
+            preset.memberIdList
+        } else emptyList()
+
+        val pastedIds = parseMemberIds(pastedMembersRaw)
+        val combinedIds = (presetIds + pastedIds).distinct()
+
+        if (combinedIds.size < 2) {
+            event.hook.sendMessage("Need at least 2 members to split into teams.")
+                .setEphemeral(true).queue()
+            return
+        }
+
+        val resolvedMembers = combinedIds.mapNotNull { id -> guild.getMemberById(id) }
+            .filter { !it.user.isBot }
+        if (resolvedMembers.size < 2) {
+            event.hook.sendMessage(
+                "Could not resolve at least 2 valid members in this server from the supplied list."
+            ).setEphemeral(true).queue()
+            return
+        }
+
+        val teamCount = teamCountStr.toIntOrNull() ?: DEFAULT_TEAM_COUNT
+        if (teamCount < 2) {
+            event.hook.sendMessage("Team count must be at least 2.").setEphemeral(true).queue()
+            return
+        }
+        if (teamCount > resolvedMembers.size) {
+            event.hook.sendMessage(
+                "Team count ($teamCount) is larger than the member count (${resolvedMembers.size})."
+            ).setEphemeral(true).queue()
+            return
+        }
+
+        val teamNames = resolveTeamNames(
+            strategy = nameStrategy.ifEmpty { STRATEGY_PREFIX },
+            namesField = namesRaw,
+            teamCount = teamCount,
+        ) ?: run {
+            event.hook.sendMessage(
+                "Name list has the wrong number of entries — got ${
+                    namesRaw.split(',').count { it.isNotBlank() }
+                }, expected $teamCount."
+            ).setEphemeral(true).queue()
+            return
+        }
+
+        val resolvedMemberIds = resolvedMembers.map { it.idLong }
+        val assignments = TeamCommand.split(resolvedMembers, teamCount)
+            .map { team -> team.mapNotNull { it?.idLong } }
+
+        val session = teamSplitSessionService.createSession(
+            guildId = guildId,
+            requesterDiscordId = event.user.idLong,
+            memberIds = resolvedMemberIds,
+            teamCount = teamCount,
+            assignments = assignments,
+            teamNames = teamNames,
+        )
+
+        val embed = TeamCommand.buildPreviewEmbed(guild, teamNames, assignments)
+        event.hook.sendMessageEmbeds(embed)
+            .addComponents(TeamCommand.buildActionRow(session.id))
+            .setEphemeral(true)
+            .queue()
+    }
+
+    private fun resolveTeamNames(strategy: String, namesField: String, teamCount: Int): List<String>? {
+        return when (strategy) {
+            STRATEGY_LIST -> {
+                val parsed = namesField.split(',').map { it.trim() }.filter { it.isNotEmpty() }
+                if (parsed.size != teamCount) null else parsed
+            }
+            else -> {
+                val prefix = namesField.ifEmpty { DEFAULT_PREFIX }
+                (1..teamCount).map { "$prefix $it" }
+            }
+        }
+    }
+
+    companion object {
+        const val MODAL_NAME = "team_split"
+        const val FIELD_PRESET_NAME = "preset_name"
+        const val FIELD_MEMBERS = "members"
+        const val FIELD_TEAM_COUNT = "team_count"
+        const val FIELD_NAME_STRATEGY = "name_strategy"
+        const val FIELD_NAMES = "names"
+
+        const val STRATEGY_PREFIX = "prefix"
+        const val STRATEGY_LIST = "list"
+        const val DEFAULT_PREFIX = "Team"
+        const val DEFAULT_TEAM_COUNT = 2
+
+        // Accepts `<@123>`, `<@!123>`, and bare snowflakes.
+        // Snowflakes today are 17-20 digits; the regex tolerates the range.
+        private val MENTION_PATTERN = Regex("""<@!?(\d{15,20})>|(\b\d{15,20}\b)""")
+
+        fun parseMemberIds(raw: String): List<Long> {
+            if (raw.isBlank()) return emptyList()
+            val ids = mutableListOf<Long>()
+            for (match in MENTION_PATTERN.findAll(raw)) {
+                val id = (match.groupValues[1].ifEmpty { match.groupValues[2] }).toLongOrNull()
+                if (id != null) ids.add(id)
+            }
+            return ids.distinct()
+        }
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/button/buttons/TeamCancelButtonTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/button/buttons/TeamCancelButtonTest.kt
@@ -8,6 +8,7 @@ import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
+import net.dv8tion.jda.api.components.MessageTopLevelComponent
 import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.entities.Message
 import net.dv8tion.jda.api.entities.MessageEmbed
@@ -49,7 +50,7 @@ class TeamCancelButtonTest {
         val editAction = mockk<WebhookMessageEditAction<Message>>(relaxed = true)
         every { hook.editOriginal(any<String>()) } returns editAction
         every { editAction.setEmbeds(any<Collection<MessageEmbed>>()) } returns editAction
-        every { editAction.setComponents(*anyVararg<net.dv8tion.jda.api.components.MessageTopLevelComponent>()) } returns editAction
+        every { editAction.setComponents(*anyVararg<MessageTopLevelComponent>()) } returns editAction
         every { editAction.queue() } just Runs
     }
 

--- a/discord-bot/src/test/kotlin/bot/toby/button/buttons/TeamCancelButtonTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/button/buttons/TeamCancelButtonTest.kt
@@ -49,8 +49,7 @@ class TeamCancelButtonTest {
         val editAction = mockk<WebhookMessageEditAction<Message>>(relaxed = true)
         every { hook.editOriginal(any<String>()) } returns editAction
         every { editAction.setEmbeds(any<Collection<MessageEmbed>>()) } returns editAction
-        every { editAction.setComponents(*anyVararg()) } returns editAction
-        every { editAction.setComponents(any<Collection<*>>()) } returns editAction
+        every { editAction.setComponents(*anyVararg<net.dv8tion.jda.api.components.MessageTopLevelComponent>()) } returns editAction
         every { editAction.queue() } just Runs
     }
 

--- a/discord-bot/src/test/kotlin/bot/toby/button/buttons/TeamCancelButtonTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/button/buttons/TeamCancelButtonTest.kt
@@ -3,12 +3,17 @@ package bot.toby.button.buttons
 import bot.toby.command.commands.misc.TeamCommand
 import core.button.ButtonContext
 import database.service.TeamSplitSessionService
+import io.mockk.Runs
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
 import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.Message
+import net.dv8tion.jda.api.entities.MessageEmbed
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent
 import net.dv8tion.jda.api.interactions.InteractionHook
+import net.dv8tion.jda.api.requests.restaction.WebhookMessageEditAction
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.util.UUID
@@ -36,8 +41,17 @@ class TeamCancelButtonTest {
             every { this@mockk.event } returns this@TeamCancelButtonTest.event
             every { this@mockk.guild } returns mockk<Guild>(relaxed = true)
         }
-        // hook is relaxed = true; the editOriginal(...).setEmbeds(...).setComponents().queue()
-        // chain returns relaxed mocks automatically.
+
+        // Explicit chain stubs: relaxed mocks lose self-type on JDA's
+        // MessageEditRequest<R> chain, so each step needs to return the
+        // typed WebhookMessageEditAction mock for the next call.
+        @Suppress("UNCHECKED_CAST")
+        val editAction = mockk<WebhookMessageEditAction<Message>>(relaxed = true)
+        every { hook.editOriginal(any<String>()) } returns editAction
+        every { editAction.setEmbeds(any<Collection<MessageEmbed>>()) } returns editAction
+        every { editAction.setComponents(*anyVararg()) } returns editAction
+        every { editAction.setComponents(any<Collection<*>>()) } returns editAction
+        every { editAction.queue() } just Runs
     }
 
     @Test

--- a/discord-bot/src/test/kotlin/bot/toby/button/buttons/TeamCancelButtonTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/button/buttons/TeamCancelButtonTest.kt
@@ -1,0 +1,69 @@
+package bot.toby.button.buttons
+
+import bot.toby.command.commands.misc.TeamCommand
+import core.button.ButtonContext
+import database.dto.UserDto
+import database.service.TeamSplitSessionService
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent
+import net.dv8tion.jda.api.interactions.InteractionHook
+import net.dv8tion.jda.api.requests.restaction.WebhookMessageEditAction
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+class TeamCancelButtonTest {
+
+    private lateinit var sessionService: TeamSplitSessionService
+    private lateinit var button: TeamCancelButton
+    private lateinit var ctx: ButtonContext
+    private lateinit var event: ButtonInteractionEvent
+    private lateinit var hook: InteractionHook
+    private val sessionId = UUID.randomUUID()
+
+    @BeforeEach
+    fun setUp() {
+        sessionService = mockk(relaxed = true)
+        button = TeamCancelButton(sessionService)
+        hook = mockk(relaxed = true)
+        event = mockk(relaxed = true) {
+            every { componentId } returns "${TeamCommand.BUTTON_CANCEL}:$sessionId"
+            every { deferEdit() } returns mockk(relaxed = true)
+            every { this@mockk.hook } returns this@TeamCancelButtonTest.hook
+        }
+        ctx = mockk {
+            every { this@mockk.event } returns this@TeamCancelButtonTest.event
+            every { this@mockk.guild } returns mockk<Guild>(relaxed = true)
+        }
+
+        @Suppress("UNCHECKED_CAST")
+        val editAction = mockk<WebhookMessageEditAction<net.dv8tion.jda.api.entities.Message>>(relaxed = true)
+        every { hook.editOriginal(any<String>()) } returns editAction
+        every { editAction.setEmbeds(emptyList()) } returns editAction
+        every { editAction.setComponents() } returns editAction
+        every { editAction.queue() } just Runs
+    }
+
+    @Test
+    fun `marks the session cancelled and clears the message`() {
+        button.handle(ctx, mockk(relaxed = true), 0)
+
+        verify { sessionService.markCancelled(sessionId) }
+        verify { hook.editOriginal(any<String>()) }
+    }
+
+    @Test
+    fun `tolerates a bogus component id without throwing`() {
+        every { event.componentId } returns "${TeamCommand.BUTTON_CANCEL}:not-a-uuid"
+
+        button.handle(ctx, mockk(relaxed = true), 0)
+
+        verify(exactly = 0) { sessionService.markCancelled(any()) }
+        verify { hook.editOriginal(any<String>()) }
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/button/buttons/TeamCancelButtonTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/button/buttons/TeamCancelButtonTest.kt
@@ -2,17 +2,13 @@ package bot.toby.button.buttons
 
 import bot.toby.command.commands.misc.TeamCommand
 import core.button.ButtonContext
-import database.dto.UserDto
 import database.service.TeamSplitSessionService
-import io.mockk.Runs
 import io.mockk.every
-import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
 import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent
 import net.dv8tion.jda.api.interactions.InteractionHook
-import net.dv8tion.jda.api.requests.restaction.WebhookMessageEditAction
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.util.UUID
@@ -40,13 +36,8 @@ class TeamCancelButtonTest {
             every { this@mockk.event } returns this@TeamCancelButtonTest.event
             every { this@mockk.guild } returns mockk<Guild>(relaxed = true)
         }
-
-        @Suppress("UNCHECKED_CAST")
-        val editAction = mockk<WebhookMessageEditAction<net.dv8tion.jda.api.entities.Message>>(relaxed = true)
-        every { hook.editOriginal(any<String>()) } returns editAction
-        every { editAction.setEmbeds(emptyList()) } returns editAction
-        every { editAction.setComponents() } returns editAction
-        every { editAction.queue() } just Runs
+        // hook is relaxed = true; the editOriginal(...).setEmbeds(...).setComponents().queue()
+        // chain returns relaxed mocks automatically.
     }
 
     @Test

--- a/discord-bot/src/test/kotlin/bot/toby/button/buttons/TeamConfirmButtonTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/button/buttons/TeamConfirmButtonTest.kt
@@ -1,0 +1,172 @@
+package bot.toby.button.buttons
+
+import bot.toby.command.commands.misc.TeamCommand
+import core.button.ButtonContext
+import database.dto.TeamSplitSessionDto
+import database.dto.UserDto
+import database.service.TeamSplitSessionService
+import database.service.encodeAssignments
+import database.service.encodeTeamNames
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.Member
+import net.dv8tion.jda.api.entities.User
+import net.dv8tion.jda.api.entities.channel.concrete.VoiceChannel
+import net.dv8tion.jda.api.entities.channel.middleman.AudioChannel
+import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent
+import net.dv8tion.jda.api.interactions.InteractionHook
+import net.dv8tion.jda.api.requests.RestAction
+import net.dv8tion.jda.api.requests.restaction.ChannelAction
+import net.dv8tion.jda.api.requests.restaction.WebhookMessageEditAction
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+class TeamConfirmButtonTest {
+
+    private lateinit var sessionService: TeamSplitSessionService
+    private lateinit var button: TeamConfirmButton
+    private lateinit var ctx: ButtonContext
+    private lateinit var event: ButtonInteractionEvent
+    private lateinit var hook: InteractionHook
+    private lateinit var guild: Guild
+    private lateinit var requesterDto: UserDto
+
+    private val sessionId = UUID.randomUUID()
+
+    @BeforeEach
+    fun setUp() {
+        sessionService = mockk(relaxed = true)
+        button = TeamConfirmButton(sessionService)
+        hook = mockk(relaxed = true)
+        event = mockk(relaxed = true) {
+            every { componentId } returns "${TeamCommand.BUTTON_CONFIRM}:$sessionId"
+            every { deferEdit() } returns mockk(relaxed = true)
+            every { this@mockk.hook } returns this@TeamConfirmButtonTest.hook
+        }
+        guild = mockk(relaxed = true) {
+            every { maxBitrate } returns 96000
+        }
+        ctx = mockk {
+            every { this@mockk.event } returns this@TeamConfirmButtonTest.event
+            every { this@mockk.guild } returns this@TeamConfirmButtonTest.guild
+        }
+        requesterDto = mockk(relaxed = true)
+
+        @Suppress("UNCHECKED_CAST")
+        val editAction = mockk<WebhookMessageEditAction<net.dv8tion.jda.api.entities.Message>>(relaxed = true)
+        every { hook.editOriginalEmbeds(*anyVararg()) } returns editAction
+        every { editAction.setComponents(*anyVararg()) } returns editAction
+        every { editAction.queue() } just Runs
+    }
+
+    @Test
+    fun `name and defersReply match the contract the manager expects`() {
+        // Manager dispatches by name prefix and gates its own deferReply on this flag.
+        assertEquals(TeamCommand.BUTTON_CONFIRM, button.name)
+        assert(!button.defersReply)
+    }
+
+    @Test
+    fun `creates one voice channel per team and moves each resolved member`() {
+        val (memberA, memberB, memberC) = listOf(111L, 222L, 333L).map { memberMock(it) }
+        every { guild.getMemberById(111L) } returns memberA
+        every { guild.getMemberById(222L) } returns memberB
+        every { guild.getMemberById(333L) } returns memberC
+
+        val sessionDto = TeamSplitSessionDto(
+            id = sessionId, guildId = 100L, requesterDiscordId = 42L,
+            memberIds = "111,222,333", teamCount = 2,
+            assignments = encodeAssignments(listOf(listOf(111L, 222L), listOf(333L))),
+            teamNames = encodeTeamNames(listOf("Red", "Blue")),
+            lastAction = TeamSplitSessionDto.ACTION_CREATED,
+        )
+        every { sessionService.getSession(sessionId) } returns sessionDto
+
+        val redChannel = voiceChannelMock("Red")
+        val blueChannel = voiceChannelMock("Blue")
+        val redCreate = channelActionMock(redChannel)
+        val blueCreate = channelActionMock(blueChannel)
+        every { guild.createVoiceChannel("Red") } returns redCreate
+        every { guild.createVoiceChannel("Blue") } returns blueCreate
+
+        val moveRest = mockk<RestAction<Void>>(relaxed = true)
+        every { guild.moveVoiceMember(any(), any<AudioChannel>()) } returns moveRest
+        every { moveRest.queue(any(), any()) } just Runs
+
+        button.handle(ctx, requesterDto, 0)
+
+        verify(exactly = 1) { guild.createVoiceChannel("Red") }
+        verify(exactly = 1) { guild.createVoiceChannel("Blue") }
+        verify(exactly = 3) { guild.moveVoiceMember(any(), any<AudioChannel>()) }
+        verify(exactly = 1) { sessionService.markConfirmed(sessionId) }
+    }
+
+    @Test
+    fun `second click on already-confirmed session creates no channels`() {
+        val sessionDto = TeamSplitSessionDto(
+            id = sessionId, guildId = 100L, requesterDiscordId = 42L,
+            memberIds = "111,222", teamCount = 2,
+            assignments = encodeAssignments(listOf(listOf(111L), listOf(222L))),
+            teamNames = encodeTeamNames(listOf("A", "B")),
+            lastAction = TeamSplitSessionDto.ACTION_CONFIRMED,
+        )
+        every { sessionService.getSession(sessionId) } returns sessionDto
+
+        val warning = slot<String>()
+        @Suppress("UNCHECKED_CAST")
+        val sendAction = mockk<net.dv8tion.jda.api.requests.restaction.WebhookMessageCreateAction<net.dv8tion.jda.api.entities.Message>>(relaxed = true)
+        every { hook.sendMessage(capture(warning)) } returns sendAction
+        every { sendAction.setEphemeral(true) } returns sendAction
+        every { sendAction.queue() } just Runs
+
+        button.handle(ctx, requesterDto, 0)
+
+        verify(exactly = 0) { guild.createVoiceChannel(any<String>()) }
+        verify(exactly = 0) { sessionService.markConfirmed(any()) }
+        assert(warning.captured.contains("already created", ignoreCase = true))
+    }
+
+    @Test
+    fun `expired session edits message in place rather than creating channels`() {
+        every { sessionService.getSession(sessionId) } returns null
+
+        @Suppress("UNCHECKED_CAST")
+        val editAction = mockk<WebhookMessageEditAction<net.dv8tion.jda.api.entities.Message>>(relaxed = true)
+        every { hook.editOriginal(any<String>()) } returns editAction
+        every { editAction.setEmbeds(emptyList()) } returns editAction
+        every { editAction.setComponents() } returns editAction
+        every { editAction.queue() } just Runs
+
+        button.handle(ctx, requesterDto, 0)
+
+        verify(exactly = 0) { guild.createVoiceChannel(any<String>()) }
+        verify { hook.editOriginal(any<String>()) }
+    }
+
+    private fun memberMock(id: Long): Member {
+        val u = mockk<User>(relaxed = true) { every { isBot } returns false }
+        return mockk(relaxed = true) {
+            every { idLong } returns id
+            every { user } returns u
+            every { effectiveName } returns "Name $id"
+        }
+    }
+
+    private fun voiceChannelMock(name: String): VoiceChannel = mockk(relaxed = true) {
+        every { this@mockk.name } returns name
+    }
+
+    private fun channelActionMock(produces: VoiceChannel): ChannelAction<VoiceChannel> {
+        val action = mockk<ChannelAction<VoiceChannel>>(relaxed = true)
+        every { action.setBitrate(any()) } returns action
+        every { action.complete() } returns produces
+        return action
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/button/buttons/TeamConfirmButtonTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/button/buttons/TeamConfirmButtonTest.kt
@@ -12,6 +12,7 @@ import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
+import net.dv8tion.jda.api.components.MessageTopLevelComponent
 import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.entities.Member
 import net.dv8tion.jda.api.entities.Message
@@ -74,7 +75,7 @@ class TeamConfirmButtonTest {
         every { hook.editOriginal(any<String>()) } returns editAction
         every { hook.editOriginalEmbeds(any<MessageEmbed>(), *anyVararg<MessageEmbed>()) } returns editAction
         every { editAction.setEmbeds(any<Collection<MessageEmbed>>()) } returns editAction
-        every { editAction.setComponents(*anyVararg<net.dv8tion.jda.api.components.MessageTopLevelComponent>()) } returns editAction
+        every { editAction.setComponents(*anyVararg<MessageTopLevelComponent>()) } returns editAction
         every { editAction.queue() } just Runs
     }
 

--- a/discord-bot/src/test/kotlin/bot/toby/button/buttons/TeamConfirmButtonTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/button/buttons/TeamConfirmButtonTest.kt
@@ -11,7 +11,6 @@ import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
-import io.mockk.slot
 import io.mockk.verify
 import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.entities.Member
@@ -22,7 +21,6 @@ import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent
 import net.dv8tion.jda.api.interactions.InteractionHook
 import net.dv8tion.jda.api.requests.RestAction
 import net.dv8tion.jda.api.requests.restaction.ChannelAction
-import net.dv8tion.jda.api.requests.restaction.WebhookMessageEditAction
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -58,12 +56,8 @@ class TeamConfirmButtonTest {
             every { this@mockk.guild } returns this@TeamConfirmButtonTest.guild
         }
         requesterDto = mockk(relaxed = true)
-
-        @Suppress("UNCHECKED_CAST")
-        val editAction = mockk<WebhookMessageEditAction<net.dv8tion.jda.api.entities.Message>>(relaxed = true)
-        every { hook.editOriginalEmbeds(*anyVararg()) } returns editAction
-        every { editAction.setComponents(*anyVararg()) } returns editAction
-        every { editAction.queue() } just Runs
+        // hook is relaxed = true, so editOriginalEmbeds(...).setComponents(...).queue()
+        // and editOriginal(...)... chains return relaxed mocks automatically.
     }
 
     @Test
@@ -98,7 +92,7 @@ class TeamConfirmButtonTest {
 
         val moveRest = mockk<RestAction<Void>>(relaxed = true)
         every { guild.moveVoiceMember(any(), any<AudioChannel>()) } returns moveRest
-        every { moveRest.queue(any(), any()) } just Runs
+        every { moveRest.queue() } just Runs
 
         button.handle(ctx, requesterDto, 0)
 
@@ -119,30 +113,16 @@ class TeamConfirmButtonTest {
         )
         every { sessionService.getSession(sessionId) } returns sessionDto
 
-        val warning = slot<String>()
-        @Suppress("UNCHECKED_CAST")
-        val sendAction = mockk<net.dv8tion.jda.api.requests.restaction.WebhookMessageCreateAction<net.dv8tion.jda.api.entities.Message>>(relaxed = true)
-        every { hook.sendMessage(capture(warning)) } returns sendAction
-        every { sendAction.setEphemeral(true) } returns sendAction
-        every { sendAction.queue() } just Runs
-
         button.handle(ctx, requesterDto, 0)
 
         verify(exactly = 0) { guild.createVoiceChannel(any<String>()) }
         verify(exactly = 0) { sessionService.markConfirmed(any()) }
-        assert(warning.captured.contains("already created", ignoreCase = true))
+        verify { hook.sendMessage(match<String> { it.contains("already created", ignoreCase = true) }) }
     }
 
     @Test
     fun `expired session edits message in place rather than creating channels`() {
         every { sessionService.getSession(sessionId) } returns null
-
-        @Suppress("UNCHECKED_CAST")
-        val editAction = mockk<WebhookMessageEditAction<net.dv8tion.jda.api.entities.Message>>(relaxed = true)
-        every { hook.editOriginal(any<String>()) } returns editAction
-        every { editAction.setEmbeds(emptyList()) } returns editAction
-        every { editAction.setComponents() } returns editAction
-        every { editAction.queue() } just Runs
 
         button.handle(ctx, requesterDto, 0)
 

--- a/discord-bot/src/test/kotlin/bot/toby/button/buttons/TeamConfirmButtonTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/button/buttons/TeamConfirmButtonTest.kt
@@ -14,6 +14,8 @@ import io.mockk.mockk
 import io.mockk.verify
 import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.entities.Member
+import net.dv8tion.jda.api.entities.Message
+import net.dv8tion.jda.api.entities.MessageEmbed
 import net.dv8tion.jda.api.entities.User
 import net.dv8tion.jda.api.entities.channel.concrete.VoiceChannel
 import net.dv8tion.jda.api.entities.channel.middleman.AudioChannel
@@ -21,6 +23,7 @@ import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent
 import net.dv8tion.jda.api.interactions.InteractionHook
 import net.dv8tion.jda.api.requests.RestAction
 import net.dv8tion.jda.api.requests.restaction.ChannelAction
+import net.dv8tion.jda.api.requests.restaction.WebhookMessageEditAction
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -56,8 +59,21 @@ class TeamConfirmButtonTest {
             every { this@mockk.guild } returns this@TeamConfirmButtonTest.guild
         }
         requesterDto = mockk(relaxed = true)
-        // hook is relaxed = true, so editOriginalEmbeds(...).setComponents(...).queue()
-        // and editOriginal(...)... chains return relaxed mocks automatically.
+
+        // JDA's fluent edit chain returns the self-typed `R` from the parent
+        // interface (MessageEditRequest<R>), which is erased at runtime — mockk's
+        // relaxed mode returns the base supertype's mock and the subsequent
+        // `.setComponents` / `.queue` calls explode with a ClassCastException.
+        // Stubbing each step to return the same typed mock fixes the chain.
+        @Suppress("UNCHECKED_CAST")
+        val editAction = mockk<WebhookMessageEditAction<Message>>(relaxed = true)
+        every { hook.editOriginal(any<String>()) } returns editAction
+        every { hook.editOriginalEmbeds(any<MessageEmbed>(), *anyVararg<MessageEmbed>()) } returns editAction
+        every { hook.editOriginalEmbeds(any<Collection<MessageEmbed>>()) } returns editAction
+        every { editAction.setEmbeds(any<Collection<MessageEmbed>>()) } returns editAction
+        every { editAction.setComponents(*anyVararg()) } returns editAction
+        every { editAction.setComponents(any<Collection<*>>()) } returns editAction
+        every { editAction.queue() } just Runs
     }
 
     @Test
@@ -146,7 +162,12 @@ class TeamConfirmButtonTest {
     private fun channelActionMock(produces: VoiceChannel): ChannelAction<VoiceChannel> {
         val action = mockk<ChannelAction<VoiceChannel>>(relaxed = true)
         every { action.setBitrate(any()) } returns action
-        every { action.complete() } returns produces
+        // `complete()` is `RestAction<T>.complete()`. T is erased at runtime;
+        // mockk needs a hint to fabricate a return value of the right concrete
+        // type (otherwise it picks the base interface and the cast to
+        // VoiceChannel in production blows up). Same pattern the legacy
+        // TeamCommandTest used before the refactor.
+        every { action.hint(VoiceChannel::class).complete() } returns produces
         return action
     }
 }

--- a/discord-bot/src/test/kotlin/bot/toby/button/buttons/TeamConfirmButtonTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/button/buttons/TeamConfirmButtonTest.kt
@@ -65,14 +65,16 @@ class TeamConfirmButtonTest {
         // relaxed mode returns the base supertype's mock and the subsequent
         // `.setComponents` / `.queue` calls explode with a ClassCastException.
         // Stubbing each step to return the same typed mock fixes the chain.
+        // Production only exercises the vararg overload of setComponents (it
+        // passes a single ActionRow), so we stub just that — Kotlin can't
+        // resolve `Collection<*>` against the typed `Collection<out
+        // MessageTopLevelComponent>` overload anyway.
         @Suppress("UNCHECKED_CAST")
         val editAction = mockk<WebhookMessageEditAction<Message>>(relaxed = true)
         every { hook.editOriginal(any<String>()) } returns editAction
         every { hook.editOriginalEmbeds(any<MessageEmbed>(), *anyVararg<MessageEmbed>()) } returns editAction
-        every { hook.editOriginalEmbeds(any<Collection<MessageEmbed>>()) } returns editAction
         every { editAction.setEmbeds(any<Collection<MessageEmbed>>()) } returns editAction
-        every { editAction.setComponents(*anyVararg()) } returns editAction
-        every { editAction.setComponents(any<Collection<*>>()) } returns editAction
+        every { editAction.setComponents(*anyVararg<net.dv8tion.jda.api.components.MessageTopLevelComponent>()) } returns editAction
         every { editAction.queue() } just Runs
     }
 

--- a/discord-bot/src/test/kotlin/bot/toby/button/buttons/TeamRerollButtonTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/button/buttons/TeamRerollButtonTest.kt
@@ -22,6 +22,7 @@ import net.dv8tion.jda.api.entities.User
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent
 import net.dv8tion.jda.api.interactions.InteractionHook
 import net.dv8tion.jda.api.requests.restaction.WebhookMessageEditAction
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.util.UUID
@@ -67,8 +68,19 @@ class TeamRerollButtonTest {
 
     @Test
     fun `updates assignments and edits embed in place keeping the same buttons`() {
-        val members = listOf(111L, 222L, 333L, 444L).map { memberMock(it) }
-        members.forEach { every { guild.getMemberById(it.idLong) } returns it }
+        // Hard-code the ids on both sides — calling `member.idLong` *inside* an
+        // `every {}` block confuses mockk's call recorder (it can sometimes
+        // capture the nested invocation rather than just the arg value, so
+        // production gets 0L back from idLong and updateAssignments captures
+        // [0, 0, 0, 0]). Compute the lookup keys outside the recording block.
+        val m111 = memberMock(111L)
+        val m222 = memberMock(222L)
+        val m333 = memberMock(333L)
+        val m444 = memberMock(444L)
+        every { guild.getMemberById(111L) } returns m111
+        every { guild.getMemberById(222L) } returns m222
+        every { guild.getMemberById(333L) } returns m333
+        every { guild.getMemberById(444L) } returns m444
 
         val sessionDto = TeamSplitSessionDto(
             id = sessionId, guildId = 100L, requesterDiscordId = 42L,
@@ -86,9 +98,9 @@ class TeamRerollButtonTest {
 
         // New assignments must still total 4 members across 2 teams.
         val flat = captured.captured.flatten()
-        assert(flat.size == 4)
-        assert(flat.toSet() == setOf(111L, 222L, 333L, 444L))
-        assert(captured.captured.size == 2)
+        assertEquals(4, flat.size)
+        assertEquals(setOf(111L, 222L, 333L, 444L), flat.toSet())
+        assertEquals(2, captured.captured.size)
     }
 
     @Test

--- a/discord-bot/src/test/kotlin/bot/toby/button/buttons/TeamRerollButtonTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/button/buttons/TeamRerollButtonTest.kt
@@ -59,10 +59,8 @@ class TeamRerollButtonTest {
         val editAction = mockk<WebhookMessageEditAction<Message>>(relaxed = true)
         every { hook.editOriginal(any<String>()) } returns editAction
         every { hook.editOriginalEmbeds(any<MessageEmbed>(), *anyVararg<MessageEmbed>()) } returns editAction
-        every { hook.editOriginalEmbeds(any<Collection<MessageEmbed>>()) } returns editAction
         every { editAction.setEmbeds(any<Collection<MessageEmbed>>()) } returns editAction
-        every { editAction.setComponents(*anyVararg()) } returns editAction
-        every { editAction.setComponents(any<Collection<*>>()) } returns editAction
+        every { editAction.setComponents(*anyVararg<net.dv8tion.jda.api.components.MessageTopLevelComponent>()) } returns editAction
         every { editAction.queue() } just Runs
     }
 

--- a/discord-bot/src/test/kotlin/bot/toby/button/buttons/TeamRerollButtonTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/button/buttons/TeamRerollButtonTest.kt
@@ -13,6 +13,7 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
+import net.dv8tion.jda.api.components.MessageTopLevelComponent
 import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.entities.Member
 import net.dv8tion.jda.api.entities.Message
@@ -60,7 +61,7 @@ class TeamRerollButtonTest {
         every { hook.editOriginal(any<String>()) } returns editAction
         every { hook.editOriginalEmbeds(any<MessageEmbed>(), *anyVararg<MessageEmbed>()) } returns editAction
         every { editAction.setEmbeds(any<Collection<MessageEmbed>>()) } returns editAction
-        every { editAction.setComponents(*anyVararg<net.dv8tion.jda.api.components.MessageTopLevelComponent>()) } returns editAction
+        every { editAction.setComponents(*anyVararg<MessageTopLevelComponent>()) } returns editAction
         every { editAction.queue() } just Runs
     }
 

--- a/discord-bot/src/test/kotlin/bot/toby/button/buttons/TeamRerollButtonTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/button/buttons/TeamRerollButtonTest.kt
@@ -7,9 +7,7 @@ import database.dto.UserDto
 import database.service.TeamSplitSessionService
 import database.service.encodeAssignments
 import database.service.encodeTeamNames
-import io.mockk.Runs
 import io.mockk.every
-import io.mockk.just
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
@@ -18,7 +16,6 @@ import net.dv8tion.jda.api.entities.Member
 import net.dv8tion.jda.api.entities.User
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent
 import net.dv8tion.jda.api.interactions.InteractionHook
-import net.dv8tion.jda.api.requests.restaction.WebhookMessageEditAction
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.util.UUID
@@ -66,12 +63,6 @@ class TeamRerollButtonTest {
         )
         every { sessionService.getSession(sessionId) } returns sessionDto
 
-        @Suppress("UNCHECKED_CAST")
-        val editAction = mockk<WebhookMessageEditAction<net.dv8tion.jda.api.entities.Message>>(relaxed = true)
-        every { hook.editOriginalEmbeds(*anyVararg()) } returns editAction
-        every { editAction.setComponents(*anyVararg()) } returns editAction
-        every { editAction.queue() } just Runs
-
         val captured = slot<List<List<Long>>>()
         every { sessionService.updateAssignments(sessionId, capture(captured)) } returns sessionDto
 
@@ -82,7 +73,6 @@ class TeamRerollButtonTest {
         assert(flat.size == 4)
         assert(flat.toSet() == setOf(111L, 222L, 333L, 444L))
         assert(captured.captured.size == 2)
-        verify { hook.editOriginalEmbeds(*anyVararg()) }
     }
 
     @Test
@@ -96,17 +86,10 @@ class TeamRerollButtonTest {
         )
         every { sessionService.getSession(sessionId) } returns sessionDto
 
-        val msg = slot<String>()
-        @Suppress("UNCHECKED_CAST")
-        val sendAction = mockk<net.dv8tion.jda.api.requests.restaction.WebhookMessageCreateAction<net.dv8tion.jda.api.entities.Message>>(relaxed = true)
-        every { hook.sendMessage(capture(msg)) } returns sendAction
-        every { sendAction.setEphemeral(true) } returns sendAction
-        every { sendAction.queue() } just Runs
-
         button.handle(ctx, requesterDto, 0)
 
         verify(exactly = 0) { sessionService.updateAssignments(any(), any()) }
-        assert(msg.captured.contains("Already confirmed", ignoreCase = true))
+        verify { hook.sendMessage(match<String> { it.contains("Already confirmed", ignoreCase = true) }) }
     }
 
     private fun memberMock(id: Long): Member {

--- a/discord-bot/src/test/kotlin/bot/toby/button/buttons/TeamRerollButtonTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/button/buttons/TeamRerollButtonTest.kt
@@ -7,15 +7,20 @@ import database.dto.UserDto
 import database.service.TeamSplitSessionService
 import database.service.encodeAssignments
 import database.service.encodeTeamNames
+import io.mockk.Runs
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
 import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.entities.Member
+import net.dv8tion.jda.api.entities.Message
+import net.dv8tion.jda.api.entities.MessageEmbed
 import net.dv8tion.jda.api.entities.User
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent
 import net.dv8tion.jda.api.interactions.InteractionHook
+import net.dv8tion.jda.api.requests.restaction.WebhookMessageEditAction
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.util.UUID
@@ -47,6 +52,18 @@ class TeamRerollButtonTest {
             every { this@mockk.guild } returns this@TeamRerollButtonTest.guild
         }
         requesterDto = mockk(relaxed = true)
+
+        // Same chain-stub trick TeamConfirmButtonTest needs: relaxed mocks
+        // don't preserve the self-typed return shape of JDA's fluent edit chain.
+        @Suppress("UNCHECKED_CAST")
+        val editAction = mockk<WebhookMessageEditAction<Message>>(relaxed = true)
+        every { hook.editOriginal(any<String>()) } returns editAction
+        every { hook.editOriginalEmbeds(any<MessageEmbed>(), *anyVararg<MessageEmbed>()) } returns editAction
+        every { hook.editOriginalEmbeds(any<Collection<MessageEmbed>>()) } returns editAction
+        every { editAction.setEmbeds(any<Collection<MessageEmbed>>()) } returns editAction
+        every { editAction.setComponents(*anyVararg()) } returns editAction
+        every { editAction.setComponents(any<Collection<*>>()) } returns editAction
+        every { editAction.queue() } just Runs
     }
 
     @Test

--- a/discord-bot/src/test/kotlin/bot/toby/button/buttons/TeamRerollButtonTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/button/buttons/TeamRerollButtonTest.kt
@@ -1,0 +1,120 @@
+package bot.toby.button.buttons
+
+import bot.toby.command.commands.misc.TeamCommand
+import core.button.ButtonContext
+import database.dto.TeamSplitSessionDto
+import database.dto.UserDto
+import database.service.TeamSplitSessionService
+import database.service.encodeAssignments
+import database.service.encodeTeamNames
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.Member
+import net.dv8tion.jda.api.entities.User
+import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent
+import net.dv8tion.jda.api.interactions.InteractionHook
+import net.dv8tion.jda.api.requests.restaction.WebhookMessageEditAction
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+class TeamRerollButtonTest {
+
+    private lateinit var sessionService: TeamSplitSessionService
+    private lateinit var button: TeamRerollButton
+    private lateinit var ctx: ButtonContext
+    private lateinit var event: ButtonInteractionEvent
+    private lateinit var hook: InteractionHook
+    private lateinit var guild: Guild
+    private lateinit var requesterDto: UserDto
+    private val sessionId = UUID.randomUUID()
+
+    @BeforeEach
+    fun setUp() {
+        sessionService = mockk(relaxed = true)
+        button = TeamRerollButton(sessionService)
+        hook = mockk(relaxed = true)
+        event = mockk(relaxed = true) {
+            every { componentId } returns "${TeamCommand.BUTTON_REROLL}:$sessionId"
+            every { deferEdit() } returns mockk(relaxed = true)
+            every { this@mockk.hook } returns this@TeamRerollButtonTest.hook
+        }
+        guild = mockk(relaxed = true)
+        ctx = mockk {
+            every { this@mockk.event } returns this@TeamRerollButtonTest.event
+            every { this@mockk.guild } returns this@TeamRerollButtonTest.guild
+        }
+        requesterDto = mockk(relaxed = true)
+    }
+
+    @Test
+    fun `updates assignments and edits embed in place keeping the same buttons`() {
+        val members = listOf(111L, 222L, 333L, 444L).map { memberMock(it) }
+        members.forEach { every { guild.getMemberById(it.idLong) } returns it }
+
+        val sessionDto = TeamSplitSessionDto(
+            id = sessionId, guildId = 100L, requesterDiscordId = 42L,
+            memberIds = "111,222,333,444", teamCount = 2,
+            assignments = encodeAssignments(listOf(listOf(111L, 222L), listOf(333L, 444L))),
+            teamNames = encodeTeamNames(listOf("Red", "Blue")),
+            lastAction = TeamSplitSessionDto.ACTION_CREATED,
+        )
+        every { sessionService.getSession(sessionId) } returns sessionDto
+
+        @Suppress("UNCHECKED_CAST")
+        val editAction = mockk<WebhookMessageEditAction<net.dv8tion.jda.api.entities.Message>>(relaxed = true)
+        every { hook.editOriginalEmbeds(*anyVararg()) } returns editAction
+        every { editAction.setComponents(*anyVararg()) } returns editAction
+        every { editAction.queue() } just Runs
+
+        val captured = slot<List<List<Long>>>()
+        every { sessionService.updateAssignments(sessionId, capture(captured)) } returns sessionDto
+
+        button.handle(ctx, requesterDto, 0)
+
+        // New assignments must still total 4 members across 2 teams.
+        val flat = captured.captured.flatten()
+        assert(flat.size == 4)
+        assert(flat.toSet() == setOf(111L, 222L, 333L, 444L))
+        assert(captured.captured.size == 2)
+        verify { hook.editOriginalEmbeds(*anyVararg()) }
+    }
+
+    @Test
+    fun `confirmed session is rejected with an ephemeral message`() {
+        val sessionDto = TeamSplitSessionDto(
+            id = sessionId, guildId = 100L, requesterDiscordId = 42L,
+            memberIds = "111,222", teamCount = 2,
+            assignments = encodeAssignments(listOf(listOf(111L), listOf(222L))),
+            teamNames = encodeTeamNames(listOf("A", "B")),
+            lastAction = TeamSplitSessionDto.ACTION_CONFIRMED,
+        )
+        every { sessionService.getSession(sessionId) } returns sessionDto
+
+        val msg = slot<String>()
+        @Suppress("UNCHECKED_CAST")
+        val sendAction = mockk<net.dv8tion.jda.api.requests.restaction.WebhookMessageCreateAction<net.dv8tion.jda.api.entities.Message>>(relaxed = true)
+        every { hook.sendMessage(capture(msg)) } returns sendAction
+        every { sendAction.setEphemeral(true) } returns sendAction
+        every { sendAction.queue() } just Runs
+
+        button.handle(ctx, requesterDto, 0)
+
+        verify(exactly = 0) { sessionService.updateAssignments(any(), any()) }
+        assert(msg.captured.contains("Already confirmed", ignoreCase = true))
+    }
+
+    private fun memberMock(id: Long): Member {
+        val u = mockk<User>(relaxed = true) { every { isBot } returns false }
+        return mockk(relaxed = true) {
+            every { idLong } returns id
+            every { user } returns u
+            every { effectiveName } returns "Name $id"
+        }
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/misc/TeamCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/misc/TeamCommandTest.kt
@@ -15,7 +15,6 @@ import io.mockk.verify
 import net.dv8tion.jda.api.entities.Member
 import net.dv8tion.jda.api.entities.channel.middleman.GuildChannel
 import net.dv8tion.jda.api.modals.Modal
-import net.dv8tion.jda.api.requests.RestAction
 import net.dv8tion.jda.api.requests.restaction.AuditableRestAction
 import net.dv8tion.jda.api.requests.restaction.interactions.ModalCallbackAction
 import org.junit.jupiter.api.AfterEach
@@ -68,7 +67,7 @@ internal class TeamCommandTest : CommandTest {
         }
         val deleteAction = mockk<AuditableRestAction<Void>>(relaxed = true)
         every { teamChannel.delete() } returns deleteAction
-        every { (deleteAction as RestAction<Void>).queue() } just Runs
+        every { deleteAction.queue() } just Runs
 
         every { event.subcommandName } returns TeamCommand.SUB_CLEANUP
         every { guild.channels } returns listOf(teamChannel, unrelatedChannel)

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/misc/TeamCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/misc/TeamCommandTest.kt
@@ -5,15 +5,22 @@ import bot.toby.command.CommandTest.Companion.event
 import bot.toby.command.CommandTest.Companion.guild
 import bot.toby.command.CommandTest.Companion.requestingUserDto
 import bot.toby.command.DefaultCommandContext
-import io.mockk.*
+import bot.toby.modal.modals.TeamSplitModal
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
 import net.dv8tion.jda.api.entities.Member
-import net.dv8tion.jda.api.entities.Mentions
-import net.dv8tion.jda.api.entities.channel.concrete.VoiceChannel
-import net.dv8tion.jda.api.entities.channel.middleman.AudioChannel
-import net.dv8tion.jda.api.interactions.commands.OptionMapping
+import net.dv8tion.jda.api.entities.channel.middleman.GuildChannel
+import net.dv8tion.jda.api.modals.Modal
 import net.dv8tion.jda.api.requests.RestAction
-import net.dv8tion.jda.api.requests.restaction.ChannelAction
+import net.dv8tion.jda.api.requests.restaction.AuditableRestAction
+import net.dv8tion.jda.api.requests.restaction.interactions.ModalCallbackAction
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
@@ -22,7 +29,7 @@ internal class TeamCommandTest : CommandTest {
 
     @BeforeEach
     fun beforeEach() {
-        setUpCommonMocks() // Initialize the mocks
+        setUpCommonMocks()
         teamCommand = TeamCommand()
     }
 
@@ -32,83 +39,58 @@ internal class TeamCommandTest : CommandTest {
     }
 
     @Test
-    fun testHandle_WithNoArgs() {
-        // Set up your test scenario here, including mocking event and UserDto
-        val deleteDelay = 0
-
-        // Create a CommandContext
+    fun `split subcommand opens the team-split modal as the first response`() {
         val ctx = DefaultCommandContext(event)
+        val modalCallback = mockk<ModalCallbackAction>(relaxed = true)
+        val captured = slot<Modal>()
+        every { event.subcommandName } returns TeamCommand.SUB_SPLIT
+        every { event.getOption("members") } returns null
+        every { event.replyModal(capture(captured)) } returns modalCallback
+        every { modalCallback.queue() } just Runs
 
-        // Test the handle method
-        teamCommand.handle(ctx, requestingUserDto, deleteDelay)
+        teamCommand.handle(ctx, requestingUserDto, 0)
 
-        verify(exactly = 1) { event.deferReply() }
-        verify {
-            event.hook.sendMessage("Return X teams from a list of tagged users.")
-        }
+        // The modal must be the FIRST reply — Discord rejects replyModal
+        // after deferReply.
+        verify(exactly = 0) { event.deferReply() }
+        verify { event.replyModal(any<Modal>()) }
+        assertEquals(TeamSplitModal.MODAL_NAME, captured.captured.id)
     }
 
     @Test
-    fun testHandle_WithArgs() {
-        // Set up your test scenario here, including mocking event and UserDto
-        val membersOption = mockk<OptionMapping>()
-        val cleanupOption = mockk<OptionMapping>()
-        every { event.getOption("members") } returns membersOption
-        every { event.getOption("cleanup") } returns cleanupOption
-        every { membersOption.asString } returns "user1, user2"
-        every { cleanupOption.asBoolean } returns false
-
-        val sizeOption = mockk<OptionMapping>()
-        every { event.getOption("size") } returns sizeOption
-        every { sizeOption.asInt } returns 2
-
-        every { event.options } returns listOf(membersOption, sizeOption)
-
-        val createdVoiceChannel = mockk<VoiceChannel>()
-        val voiceChannelCreation = mockk<ChannelAction<VoiceChannel>>()
-        every { guild.createVoiceChannel(any()) } returns voiceChannelCreation
-
-        val voiceChannelModification = mockk<ChannelAction<VoiceChannel>>()
-        every { voiceChannelCreation.setBitrate(any()) } returns voiceChannelModification
-
-        every { voiceChannelModification.hint(VoiceChannel::class).complete() } returns createdVoiceChannel
-        every { createdVoiceChannel.name } returns "channelName"
-
-        val deleteDelay = 0
-
-        // Mock the guild.moveVoiceMember() method
-        val mentions = mockk<Mentions>()
-        every { event.getOption("members")?.mentions } returns mentions
-
-        val mockMember1 = mockk<Member>()
-        val mockMember2 = mockk<Member>()
-        val memberList = arrayListOf(mockMember1, mockMember2)
-        every { mockMember1.effectiveName } returns "Name 1"
-        every { mockMember2.effectiveName } returns "Name 2"
-        every { mentions.members } returns memberList
-
-        guildMoveVoiceMemberMocking(createdVoiceChannel, mockMember1)
-        guildMoveVoiceMemberMocking(createdVoiceChannel, mockMember2)
-
-        // Create a CommandContext
+    fun `cleanup subcommand deletes only matching team channels`() {
         val ctx = DefaultCommandContext(event)
+        val teamChannel: GuildChannel = mockk(relaxed = true) {
+            every { name } returns "Team 1"
+        }
+        val unrelatedChannel: GuildChannel = mockk(relaxed = true) {
+            every { name } returns "general"
+        }
+        val deleteAction = mockk<AuditableRestAction<Void>>(relaxed = true)
+        every { teamChannel.delete() } returns deleteAction
+        every { (deleteAction as RestAction<Void>).queue() } just Runs
 
-        // Test the handle method
-        teamCommand.handle(ctx, requestingUserDto, deleteDelay)
+        every { event.subcommandName } returns TeamCommand.SUB_CLEANUP
+        every { guild.channels } returns listOf(teamChannel, unrelatedChannel)
 
-        verify(exactly = 1) { event.deferReply() }
-        verify(exactly = 1) { event.hook.sendMessage(any<String>()) }
+        teamCommand.handle(ctx, requestingUserDto, 0)
+
+        verify(exactly = 1) { teamChannel.delete() }
+        verify(exactly = 0) { unrelatedChannel.delete() }
+        verify { event.deferReply() }
     }
 
-    companion object {
-        private fun guildMoveVoiceMemberMocking(createdVoiceChannel: VoiceChannel, member: Member) {
-            val restAction = mockk<RestAction<Void>>()
-            every {
-                guild.moveVoiceMember(member, createdVoiceChannel as AudioChannel)
-            } returns restAction
-
-            every { restAction.queue() } just Runs
-
-        }
+    @Test
+    fun `split helper distributes remainder across the first teams instead of dropping members`() {
+        val members = (1..7).map { mockk<Member>(relaxed = true) }
+        val groups = TeamCommand.split(members, 3)
+        // 7 members, 3 teams — expect group sizes 3, 2, 2 (no member dropped).
+        val sizes = groups.map { it.size }.sortedDescending()
+        assertEquals(listOf(3, 2, 2), sizes)
+        val total = groups.sumOf { it.size }
+        assertEquals(7, total)
+        // All inputs must appear in the output exactly once.
+        val flat = groups.flatten()
+        assertTrue(members.all { it in flat })
     }
 }

--- a/discord-bot/src/test/kotlin/bot/toby/modal/modals/TeamSplitModalTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/modal/modals/TeamSplitModalTest.kt
@@ -110,6 +110,17 @@ class TeamSplitModalTest {
     }
 
     @Test
+    fun `parseMemberIds tolerates decorative names from the prefill format`() {
+        // /team split pre-fills the modal as `Name (<@id>), Name (<@id>), …` so
+        // typos and wrong people are easier to spot. The parser must still
+        // ignore the names and pick up only the <@id> tokens.
+        val ids = TeamSplitModal.parseMemberIds(
+            "Alice (<@111111111111111111>), Bob (<@!222222222222222222>), Charlie (<@333333333333333333>)"
+        )
+        assertEquals(listOf(111111111111111111L, 222222222222222222L, 333333333333333333L), ids)
+    }
+
+    @Test
     fun `parseMemberIds yields empty on blank input`() {
         assertTrue(TeamSplitModal.parseMemberIds("").isEmpty())
         assertTrue(TeamSplitModal.parseMemberIds("   ").isEmpty())

--- a/discord-bot/src/test/kotlin/bot/toby/modal/modals/TeamSplitModalTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/modal/modals/TeamSplitModalTest.kt
@@ -11,6 +11,7 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
+import net.dv8tion.jda.api.components.MessageTopLevelComponent
 import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.entities.Member
 import net.dv8tion.jda.api.entities.Message
@@ -70,7 +71,7 @@ class TeamSplitModalTest {
         every { hook.sendMessage(capture(errorSlot)) } returns sendAction
         every { hook.sendMessageEmbeds(any<MessageEmbed>(), *anyVararg<MessageEmbed>()) } returns sendAction
         every { sendAction.setEphemeral(any()) } returns sendAction
-        every { sendAction.addComponents(*anyVararg<net.dv8tion.jda.api.components.MessageTopLevelComponent>()) } returns sendAction
+        every { sendAction.addComponents(*anyVararg<MessageTopLevelComponent>()) } returns sendAction
         every { sendAction.queue() } just Runs
 
         // Default: empty modal values; individual tests override the ones they need.

--- a/discord-bot/src/test/kotlin/bot/toby/modal/modals/TeamSplitModalTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/modal/modals/TeamSplitModalTest.kt
@@ -1,0 +1,219 @@
+package bot.toby.modal.modals
+
+import core.modal.ModalContext
+import database.dto.TeamPresetDto
+import database.dto.TeamSplitSessionDto
+import database.service.TeamPresetService
+import database.service.TeamSplitSessionService
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.Member
+import net.dv8tion.jda.api.entities.Message
+import net.dv8tion.jda.api.entities.MessageEmbed
+import net.dv8tion.jda.api.entities.User
+import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent
+import net.dv8tion.jda.api.interactions.InteractionHook
+import net.dv8tion.jda.api.interactions.modals.ModalMapping
+import net.dv8tion.jda.api.requests.restaction.WebhookMessageCreateAction
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+class TeamSplitModalTest {
+
+    private lateinit var teamPresetService: TeamPresetService
+    private lateinit var teamSplitSessionService: TeamSplitSessionService
+    private lateinit var modal: TeamSplitModal
+    private lateinit var ctx: ModalContext
+    private lateinit var event: ModalInteractionEvent
+    private lateinit var hook: InteractionHook
+    private lateinit var guild: Guild
+    private val errorSlot = slot<String>()
+
+    @BeforeEach
+    fun setup() {
+        teamPresetService = mockk(relaxed = true)
+        teamSplitSessionService = mockk(relaxed = true)
+        modal = TeamSplitModal(teamPresetService, teamSplitSessionService)
+        hook = mockk(relaxed = true)
+        event = mockk(relaxed = true)
+        guild = mockk(relaxed = true) {
+            every { idLong } returns 100L
+            every { maxBitrate } returns 96000
+        }
+
+        val user = mockk<User>(relaxed = true) {
+            every { idLong } returns 42L
+        }
+        every { event.user } returns user
+        every { event.hook } returns hook
+
+        ctx = mockk {
+            every { this@mockk.event } returns this@TeamSplitModalTest.event
+            every { this@mockk.guild } returns this@TeamSplitModalTest.guild
+        }
+
+        @Suppress("UNCHECKED_CAST")
+        val sendAction = mockk<WebhookMessageCreateAction<Message>>(relaxed = true)
+        every { hook.sendMessage(capture(errorSlot)) } returns sendAction
+        every { sendAction.setEphemeral(true) } returns sendAction
+        every { sendAction.queue() } just Runs
+
+        @Suppress("UNCHECKED_CAST")
+        val embedAction = mockk<WebhookMessageCreateAction<Message>>(relaxed = true)
+        every { hook.sendMessageEmbeds(any<MessageEmbed>(), *anyVararg<MessageEmbed>()) } returns embedAction
+        every { embedAction.addComponents(any()) } returns embedAction
+        every { embedAction.setEphemeral(true) } returns embedAction
+        every { embedAction.queue() } just Runs
+
+        // Default: empty modal values; individual tests override the ones they need.
+        every { event.getValue(TeamSplitModal.FIELD_PRESET_NAME) } returns null
+        every { event.getValue(TeamSplitModal.FIELD_MEMBERS) } returns null
+        every { event.getValue(TeamSplitModal.FIELD_TEAM_COUNT) } returns mockk { every { asString } returns "2" }
+        every { event.getValue(TeamSplitModal.FIELD_NAME_STRATEGY) } returns mockk { every { asString } returns "prefix" }
+        every { event.getValue(TeamSplitModal.FIELD_NAMES) } returns mockk { every { asString } returns "Team" }
+    }
+
+    @Test
+    fun `name is team_split`() {
+        assertEquals("team_split", modal.name)
+    }
+
+    @Test
+    fun `errors when no members provided and no preset named`() {
+        modal.handle(ctx, 0)
+        assertTrue(errorSlot.captured.contains("at least 2 members"))
+    }
+
+    @Test
+    fun `errors when preset name is unknown`() {
+        every { event.getValue(TeamSplitModal.FIELD_PRESET_NAME) } returns mockk { every { asString } returns "ghosts" }
+        every { teamPresetService.getByName(100L, "ghosts") } returns null
+
+        modal.handle(ctx, 0)
+
+        assertTrue(errorSlot.captured.contains("No preset named 'ghosts'"))
+    }
+
+    @Test
+    fun `parseMemberIds extracts mentions and bare snowflakes and dedupes`() {
+        val ids = TeamSplitModal.parseMemberIds("<@111111111111111111> <@!222222222222222222> 111111111111111111 333333333333333333")
+        assertEquals(listOf(111111111111111111L, 222222222222222222L, 333333333333333333L), ids)
+    }
+
+    @Test
+    fun `parseMemberIds yields empty on blank input`() {
+        assertTrue(TeamSplitModal.parseMemberIds("").isEmpty())
+        assertTrue(TeamSplitModal.parseMemberIds("   ").isEmpty())
+    }
+
+    @Test
+    fun `errors when team count exceeds resolved member count`() {
+        val members = listOf(memberMock(111L, "A"), memberMock(222L, "B"))
+        every { event.getValue(TeamSplitModal.FIELD_MEMBERS) } returns mockk {
+            every { asString } returns "<@111> <@222>"
+        }
+        every { event.getValue(TeamSplitModal.FIELD_TEAM_COUNT) } returns mockk { every { asString } returns "5" }
+        every { guild.getMemberById(111L) } returns members[0]
+        every { guild.getMemberById(222L) } returns members[1]
+
+        modal.handle(ctx, 0)
+
+        assertTrue(errorSlot.captured.contains("larger than the member count"))
+    }
+
+    @Test
+    fun `errors when list-strategy name count mismatches team count`() {
+        val members = listOf(memberMock(111L, "A"), memberMock(222L, "B"))
+        every { event.getValue(TeamSplitModal.FIELD_MEMBERS) } returns mockk {
+            every { asString } returns "<@111> <@222>"
+        }
+        every { event.getValue(TeamSplitModal.FIELD_NAME_STRATEGY) } returns mockk { every { asString } returns "list" }
+        every { event.getValue(TeamSplitModal.FIELD_NAMES) } returns mockk { every { asString } returns "Red,Blue,Green" }
+        every { guild.getMemberById(111L) } returns members[0]
+        every { guild.getMemberById(222L) } returns members[1]
+
+        modal.handle(ctx, 0)
+
+        assertTrue(errorSlot.captured.contains("wrong number of entries"))
+    }
+
+    @Test
+    fun `persists session before sending preview embed`() {
+        val members = listOf(memberMock(111L, "Alice"), memberMock(222L, "Bob"))
+        every { event.getValue(TeamSplitModal.FIELD_MEMBERS) } returns mockk {
+            every { asString } returns "<@111> <@222>"
+        }
+        every { guild.getMemberById(111L) } returns members[0]
+        every { guild.getMemberById(222L) } returns members[1]
+        val sessionId = UUID.randomUUID()
+        every {
+            teamSplitSessionService.createSession(
+                guildId = 100L, requesterDiscordId = 42L,
+                memberIds = any(), teamCount = 2,
+                assignments = any(), teamNames = any(),
+            )
+        } returns TeamSplitSessionDto(id = sessionId, guildId = 100L, requesterDiscordId = 42L, teamCount = 2)
+
+        modal.handle(ctx, 0)
+
+        verify {
+            teamSplitSessionService.createSession(
+                guildId = 100L, requesterDiscordId = 42L,
+                memberIds = match { it.size == 2 && it.containsAll(listOf(111L, 222L)) },
+                teamCount = 2,
+                assignments = any(),
+                teamNames = match { it == listOf("Team 1", "Team 2") },
+            )
+        }
+        verify { hook.sendMessageEmbeds(any<MessageEmbed>(), *anyVararg<MessageEmbed>()) }
+    }
+
+    @Test
+    fun `unions preset members with pasted members and dedupes`() {
+        val preset = TeamPresetDto(id = 1L, guildId = 100L, name = "core", createdByDiscordId = 42L).apply {
+            memberIdList = listOf(111L, 222L)
+        }
+        every { event.getValue(TeamSplitModal.FIELD_PRESET_NAME) } returns mockk { every { asString } returns "core" }
+        every { teamPresetService.getByName(100L, "core") } returns preset
+        every { event.getValue(TeamSplitModal.FIELD_MEMBERS) } returns mockk {
+            // 222 overlaps with preset; 333 is new
+            every { asString } returns "<@222> <@333>"
+        }
+        every { guild.getMemberById(111L) } returns memberMock(111L, "A")
+        every { guild.getMemberById(222L) } returns memberMock(222L, "B")
+        every { guild.getMemberById(333L) } returns memberMock(333L, "C")
+        val captured = slot<List<Long>>()
+        every {
+            teamSplitSessionService.createSession(
+                guildId = any(), requesterDiscordId = any(),
+                memberIds = capture(captured), teamCount = any(),
+                assignments = any(), teamNames = any(),
+            )
+        } returns TeamSplitSessionDto(guildId = 100L)
+
+        modal.handle(ctx, 0)
+
+        assertNotNull(captured.captured)
+        assertEquals(listOf(111L, 222L, 333L).sorted(), captured.captured.sorted())
+    }
+
+    private fun memberMock(id: Long, displayName: String): Member {
+        val u = mockk<User>(relaxed = true) {
+            every { isBot } returns false
+        }
+        return mockk(relaxed = true) {
+            every { idLong } returns id
+            every { user } returns u
+            every { effectiveName } returns displayName
+        }
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/modal/modals/TeamSplitModalTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/modal/modals/TeamSplitModalTest.kt
@@ -5,9 +5,7 @@ import database.dto.TeamPresetDto
 import database.dto.TeamSplitSessionDto
 import database.service.TeamPresetService
 import database.service.TeamSplitSessionService
-import io.mockk.Runs
 import io.mockk.every
-import io.mockk.just
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
@@ -18,7 +16,6 @@ import net.dv8tion.jda.api.entities.MessageEmbed
 import net.dv8tion.jda.api.entities.User
 import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent
 import net.dv8tion.jda.api.interactions.InteractionHook
-import net.dv8tion.jda.api.interactions.modals.ModalMapping
 import net.dv8tion.jda.api.requests.restaction.WebhookMessageCreateAction
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -61,18 +58,13 @@ class TeamSplitModalTest {
             every { this@mockk.guild } returns this@TeamSplitModalTest.guild
         }
 
+        // hook + the WebhookMessageCreateAction it returns are relaxed mocks,
+        // so the fluent setEphemeral / addComponents / queue chain just works.
+        // The capture-slot stub overrides the relaxed default for sendMessage(String)
+        // to record what was sent.
         @Suppress("UNCHECKED_CAST")
         val sendAction = mockk<WebhookMessageCreateAction<Message>>(relaxed = true)
         every { hook.sendMessage(capture(errorSlot)) } returns sendAction
-        every { sendAction.setEphemeral(true) } returns sendAction
-        every { sendAction.queue() } just Runs
-
-        @Suppress("UNCHECKED_CAST")
-        val embedAction = mockk<WebhookMessageCreateAction<Message>>(relaxed = true)
-        every { hook.sendMessageEmbeds(any<MessageEmbed>(), *anyVararg<MessageEmbed>()) } returns embedAction
-        every { embedAction.addComponents(any()) } returns embedAction
-        every { embedAction.setEphemeral(true) } returns embedAction
-        every { embedAction.queue() } just Runs
 
         // Default: empty modal values; individual tests override the ones they need.
         every { event.getValue(TeamSplitModal.FIELD_PRESET_NAME) } returns null

--- a/discord-bot/src/test/kotlin/bot/toby/modal/modals/TeamSplitModalTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/modal/modals/TeamSplitModalTest.kt
@@ -5,7 +5,9 @@ import database.dto.TeamPresetDto
 import database.dto.TeamSplitSessionDto
 import database.service.TeamPresetService
 import database.service.TeamSplitSessionService
+import io.mockk.Runs
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
@@ -58,13 +60,20 @@ class TeamSplitModalTest {
             every { this@mockk.guild } returns this@TeamSplitModalTest.guild
         }
 
-        // hook + the WebhookMessageCreateAction it returns are relaxed mocks,
-        // so the fluent setEphemeral / addComponents / queue chain just works.
-        // The capture-slot stub overrides the relaxed default for sendMessage(String)
-        // to record what was sent.
+        // JDA's fluent chain returns a self-type (R from MessageCreateRequest<R>)
+        // that's erased at runtime. mockk's relaxed mode then makes the chain
+        // return the erased supertype, and the next call (`addComponents`)
+        // explodes with a ClassCastException. Stub each step to return the
+        // same typed mock so the chain holds together.
         @Suppress("UNCHECKED_CAST")
         val sendAction = mockk<WebhookMessageCreateAction<Message>>(relaxed = true)
         every { hook.sendMessage(capture(errorSlot)) } returns sendAction
+        every { hook.sendMessageEmbeds(any<MessageEmbed>(), *anyVararg<MessageEmbed>()) } returns sendAction
+        every { hook.sendMessageEmbeds(any<Collection<MessageEmbed>>()) } returns sendAction
+        every { sendAction.setEphemeral(any()) } returns sendAction
+        every { sendAction.addComponents(*anyVararg()) } returns sendAction
+        every { sendAction.addComponents(any<Collection<*>>()) } returns sendAction
+        every { sendAction.queue() } just Runs
 
         // Default: empty modal values; individual tests override the ones they need.
         every { event.getValue(TeamSplitModal.FIELD_PRESET_NAME) } returns null

--- a/discord-bot/src/test/kotlin/bot/toby/modal/modals/TeamSplitModalTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/modal/modals/TeamSplitModalTest.kt
@@ -109,13 +109,13 @@ class TeamSplitModalTest {
 
     @Test
     fun `errors when team count exceeds resolved member count`() {
-        val members = listOf(memberMock(111L, "A"), memberMock(222L, "B"))
+        val members = listOf(memberMock(ID_A, "A"), memberMock(ID_B, "B"))
         every { event.getValue(TeamSplitModal.FIELD_MEMBERS) } returns mockk {
-            every { asString } returns "<@111> <@222>"
+            every { asString } returns "<@$ID_A> <@$ID_B>"
         }
         every { event.getValue(TeamSplitModal.FIELD_TEAM_COUNT) } returns mockk { every { asString } returns "5" }
-        every { guild.getMemberById(111L) } returns members[0]
-        every { guild.getMemberById(222L) } returns members[1]
+        every { guild.getMemberById(ID_A) } returns members[0]
+        every { guild.getMemberById(ID_B) } returns members[1]
 
         modal.handle(ctx, 0)
 
@@ -124,14 +124,14 @@ class TeamSplitModalTest {
 
     @Test
     fun `errors when list-strategy name count mismatches team count`() {
-        val members = listOf(memberMock(111L, "A"), memberMock(222L, "B"))
+        val members = listOf(memberMock(ID_A, "A"), memberMock(ID_B, "B"))
         every { event.getValue(TeamSplitModal.FIELD_MEMBERS) } returns mockk {
-            every { asString } returns "<@111> <@222>"
+            every { asString } returns "<@$ID_A> <@$ID_B>"
         }
         every { event.getValue(TeamSplitModal.FIELD_NAME_STRATEGY) } returns mockk { every { asString } returns "list" }
         every { event.getValue(TeamSplitModal.FIELD_NAMES) } returns mockk { every { asString } returns "Red,Blue,Green" }
-        every { guild.getMemberById(111L) } returns members[0]
-        every { guild.getMemberById(222L) } returns members[1]
+        every { guild.getMemberById(ID_A) } returns members[0]
+        every { guild.getMemberById(ID_B) } returns members[1]
 
         modal.handle(ctx, 0)
 
@@ -140,12 +140,12 @@ class TeamSplitModalTest {
 
     @Test
     fun `persists session before sending preview embed`() {
-        val members = listOf(memberMock(111L, "Alice"), memberMock(222L, "Bob"))
+        val members = listOf(memberMock(ID_A, "Alice"), memberMock(ID_B, "Bob"))
         every { event.getValue(TeamSplitModal.FIELD_MEMBERS) } returns mockk {
-            every { asString } returns "<@111> <@222>"
+            every { asString } returns "<@$ID_A> <@$ID_B>"
         }
-        every { guild.getMemberById(111L) } returns members[0]
-        every { guild.getMemberById(222L) } returns members[1]
+        every { guild.getMemberById(ID_A) } returns members[0]
+        every { guild.getMemberById(ID_B) } returns members[1]
         val sessionId = UUID.randomUUID()
         every {
             teamSplitSessionService.createSession(
@@ -160,7 +160,7 @@ class TeamSplitModalTest {
         verify {
             teamSplitSessionService.createSession(
                 guildId = 100L, requesterDiscordId = 42L,
-                memberIds = match { it.size == 2 && it.containsAll(listOf(111L, 222L)) },
+                memberIds = match { it.size == 2 && it.containsAll(listOf(ID_A, ID_B)) },
                 teamCount = 2,
                 assignments = any(),
                 teamNames = match { it == listOf("Team 1", "Team 2") },
@@ -172,17 +172,17 @@ class TeamSplitModalTest {
     @Test
     fun `unions preset members with pasted members and dedupes`() {
         val preset = TeamPresetDto(id = 1L, guildId = 100L, name = "core", createdByDiscordId = 42L).apply {
-            memberIdList = listOf(111L, 222L)
+            memberIdList = listOf(ID_A, ID_B)
         }
         every { event.getValue(TeamSplitModal.FIELD_PRESET_NAME) } returns mockk { every { asString } returns "core" }
         every { teamPresetService.getByName(100L, "core") } returns preset
         every { event.getValue(TeamSplitModal.FIELD_MEMBERS) } returns mockk {
-            // 222 overlaps with preset; 333 is new
-            every { asString } returns "<@222> <@333>"
+            // ID_B overlaps with preset; ID_C is new
+            every { asString } returns "<@$ID_B> <@$ID_C>"
         }
-        every { guild.getMemberById(111L) } returns memberMock(111L, "A")
-        every { guild.getMemberById(222L) } returns memberMock(222L, "B")
-        every { guild.getMemberById(333L) } returns memberMock(333L, "C")
+        every { guild.getMemberById(ID_A) } returns memberMock(ID_A, "A")
+        every { guild.getMemberById(ID_B) } returns memberMock(ID_B, "B")
+        every { guild.getMemberById(ID_C) } returns memberMock(ID_C, "C")
         val captured = slot<List<Long>>()
         every {
             teamSplitSessionService.createSession(
@@ -195,7 +195,7 @@ class TeamSplitModalTest {
         modal.handle(ctx, 0)
 
         assertNotNull(captured.captured)
-        assertEquals(listOf(111L, 222L, 333L).sorted(), captured.captured.sorted())
+        assertEquals(listOf(ID_A, ID_B, ID_C).sorted(), captured.captured.sorted())
     }
 
     private fun memberMock(id: Long, displayName: String): Member {
@@ -207,5 +207,14 @@ class TeamSplitModalTest {
             every { user } returns u
             every { effectiveName } returns displayName
         }
+    }
+
+    companion object {
+        // Real Discord snowflakes are 17-20 digits; the modal's mention regex
+        // enforces 15-20 to reject obvious typos. Use realistic ids in the tests
+        // so the regex actually matches.
+        private const val ID_A = 111111111111111111L
+        private const val ID_B = 222222222222222222L
+        private const val ID_C = 333333333333333333L
     }
 }

--- a/discord-bot/src/test/kotlin/bot/toby/modal/modals/TeamSplitModalTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/modal/modals/TeamSplitModalTest.kt
@@ -69,10 +69,8 @@ class TeamSplitModalTest {
         val sendAction = mockk<WebhookMessageCreateAction<Message>>(relaxed = true)
         every { hook.sendMessage(capture(errorSlot)) } returns sendAction
         every { hook.sendMessageEmbeds(any<MessageEmbed>(), *anyVararg<MessageEmbed>()) } returns sendAction
-        every { hook.sendMessageEmbeds(any<Collection<MessageEmbed>>()) } returns sendAction
         every { sendAction.setEphemeral(any()) } returns sendAction
-        every { sendAction.addComponents(*anyVararg()) } returns sendAction
-        every { sendAction.addComponents(any<Collection<*>>()) } returns sendAction
+        every { sendAction.addComponents(*anyVararg<net.dv8tion.jda.api.components.MessageTopLevelComponent>()) } returns sendAction
         every { sendAction.queue() } just Runs
 
         // Default: empty modal values; individual tests override the ones they need.

--- a/web/src/main/kotlin/web/controller/TeamWebController.kt
+++ b/web/src/main/kotlin/web/controller/TeamWebController.kt
@@ -1,0 +1,114 @@
+package web.controller
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient
+import org.springframework.security.oauth2.client.annotation.RegisteredOAuth2AuthorizedClient
+import org.springframework.security.oauth2.core.user.OAuth2User
+import org.springframework.stereotype.Controller
+import org.springframework.ui.Model
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.ResponseBody
+import org.springframework.web.servlet.mvc.support.RedirectAttributes
+import web.service.TeamApiResult
+import web.service.TeamWebService
+import web.util.WebGuildAccess
+import web.util.discordIdString
+import web.util.displayName
+
+@Controller
+@RequestMapping("/teams")
+class TeamWebController(
+    private val teamWebService: TeamWebService,
+    @param:Value($$"${spring.security.oauth2.client.registration.discord.client-id}")
+    private val discordClientId: String,
+) {
+    private val inviteUrl: String
+        get() = web.util.DiscordInvite.urlFor(discordClientId)
+
+    @GetMapping("/guilds")
+    fun guildList(
+        @RegisteredOAuth2AuthorizedClient("discord") client: OAuth2AuthorizedClient,
+        @AuthenticationPrincipal user: OAuth2User,
+        model: Model,
+    ): String {
+        val guilds = teamWebService.getMutualGuilds(client.accessToken.tokenValue)
+        model.addAttribute("guilds", guilds)
+        model.addAttribute("username", user.displayName())
+        model.addAttribute("discordId", user.discordIdString())
+        model.addAttribute("inviteUrl", inviteUrl)
+        return "team-guilds"
+    }
+
+    @GetMapping("/{guildId}")
+    fun page(
+        @PathVariable guildId: Long,
+        @AuthenticationPrincipal user: OAuth2User,
+        model: Model,
+        ra: RedirectAttributes,
+    ): String = WebGuildAccess.requireForPage(
+        user = user,
+        guildId = guildId,
+        ra = ra,
+        lobbyPath = "/teams/guilds",
+        check = teamWebService::isMember,
+    ) { _ ->
+        val guildName = teamWebService.getGuildName(guildId) ?: run {
+            ra.addFlashAttribute("error", "Bot is not in that server.")
+            return@requireForPage "redirect:/teams/guilds"
+        }
+        model.addAttribute("guildId", guildId)
+        model.addAttribute("guildName", guildName)
+        model.addAttribute("presets", teamWebService.listPresets(guildId))
+        model.addAttribute("recentSplits", teamWebService.listRecentSessions(guildId))
+        model.addAttribute("members", teamWebService.getGuildMembers(guildId))
+        model.addAttribute("maxNameLength", TeamWebService.PRESET_NAME_MAX)
+        model.addAttribute("username", user.displayName())
+        "teams"
+    }
+
+    @PostMapping("/{guildId}/presets")
+    fun createPreset(
+        @PathVariable guildId: Long,
+        @RequestParam name: String,
+        @RequestParam(name = "memberIds", required = false) memberIds: List<String>?,
+        @AuthenticationPrincipal user: OAuth2User,
+        ra: RedirectAttributes,
+    ): String = WebGuildAccess.requireForPage(
+        user = user,
+        guildId = guildId,
+        ra = ra,
+        lobbyPath = "/teams/guilds",
+        check = teamWebService::isMember,
+    ) { discordId ->
+        val error = teamWebService.upsertPreset(guildId, name, memberIds.orEmpty(), discordId)
+        if (error != null) {
+            ra.addFlashAttribute("error", error)
+        } else {
+            ra.addFlashAttribute("success", "Saved preset '${name.trim()}'.")
+        }
+        "redirect:/teams/$guildId"
+    }
+
+    @PostMapping("/{guildId}/presets/{id}/delete")
+    @ResponseBody
+    fun deletePreset(
+        @PathVariable guildId: Long,
+        @PathVariable id: Long,
+        @AuthenticationPrincipal user: OAuth2User,
+    ): ResponseEntity<TeamApiResult> = WebGuildAccess.requireForJson(
+        user = user,
+        guildId = guildId,
+        check = teamWebService::isMember,
+        errorBuilder = { status -> ResponseEntity.status(status).body(TeamApiResult(false, "Not authorized.")) },
+    ) { _ ->
+        val error = teamWebService.deletePreset(id, guildId)
+        if (error != null) ResponseEntity.badRequest().body(TeamApiResult(false, error))
+        else ResponseEntity.ok(TeamApiResult(true, null))
+    }
+}

--- a/web/src/main/kotlin/web/service/TeamWebService.kt
+++ b/web/src/main/kotlin/web/service/TeamWebService.kt
@@ -1,0 +1,164 @@
+package web.service
+
+import database.dto.TeamPresetDto
+import database.dto.TeamSplitSessionDto
+import database.service.TeamPresetService
+import database.service.TeamSplitSessionService
+import database.service.decodeAssignments
+import database.service.decodeTeamNames
+import net.dv8tion.jda.api.JDA
+import org.springframework.stereotype.Service
+import web.util.GuildMembership
+import java.time.Instant
+
+/**
+ * Backing service for the `/teams` web UI. Wraps the database service
+ * pair (presets + recent sessions) and adds the same guild-scoping
+ * checks Excuses uses, so the controller can rely on
+ * [WebGuildAccess.requireForPage]`(check = service::isMember, ...)`.
+ *
+ * Member-list and mutual-guild fetches both delegate to
+ * [IntroWebService] to share its caches and rate-limit handling.
+ */
+@Service
+class TeamWebService(
+    private val teamPresetService: TeamPresetService,
+    private val teamSplitSessionService: TeamSplitSessionService,
+    private val introWebService: IntroWebService,
+    private val guildMembership: GuildMembership,
+    private val jda: JDA,
+) {
+    companion object {
+        const val PRESET_NAME_MAX = 64
+        const val MAX_MEMBERS_PER_PRESET = 100
+        const val RECENT_SESSIONS_LIMIT = 10
+    }
+
+    fun isMember(discordId: Long, guildId: Long): Boolean =
+        guildMembership.isMember(discordId, guildId)
+
+    fun getMutualGuilds(accessToken: String): List<GuildInfo> =
+        introWebService.getMutualGuilds(accessToken)
+
+    fun getGuildName(guildId: Long): String? = jda.getGuildById(guildId)?.name
+
+    fun getGuildMembers(guildId: Long): List<MemberInfo> {
+        val guild = jda.getGuildById(guildId) ?: return emptyList()
+        return guild.members
+            .filter { !it.user.isBot }
+            .map { MemberInfo(it.id, it.effectiveName, it.effectiveAvatarUrl) }
+            .sortedBy { it.name.lowercase() }
+    }
+
+    fun listPresets(guildId: Long): List<TeamPresetViewModel> {
+        val guild = jda.getGuildById(guildId)
+        return teamPresetService.listForGuild(guildId).map { dto ->
+            val ids = dto.memberIdList
+            val resolved = ids.map { id ->
+                val name = guild?.getMemberById(id)?.effectiveName
+                    ?: jda.getUserById(id)?.name
+                    ?: "Unknown ($id)"
+                MemberPreview(id.toString(), name)
+            }
+            TeamPresetViewModel(
+                id = dto.id ?: 0L,
+                name = dto.name,
+                members = resolved,
+                memberCount = ids.size,
+                createdByDiscordId = dto.createdByDiscordId,
+                createdAt = dto.createdAt,
+                updatedAt = dto.updatedAt,
+            )
+        }
+    }
+
+    fun listRecentSessions(guildId: Long): List<RecentSplitViewModel> {
+        val guild = jda.getGuildById(guildId)
+        return teamSplitSessionService.recentForGuild(guildId, RECENT_SESSIONS_LIMIT).map { dto ->
+            val assignments = decodeAssignments(dto.assignments)
+            val names = decodeTeamNames(dto.teamNames)
+            val teams = assignments.mapIndexed { idx, ids ->
+                val label = names.getOrNull(idx) ?: "Team ${idx + 1}"
+                val resolved = ids.map { id ->
+                    guild?.getMemberById(id)?.effectiveName
+                        ?: jda.getUserById(id)?.name
+                        ?: "Unknown ($id)"
+                }
+                TeamSnapshot(label, resolved)
+            }
+            val requesterName = guild?.getMemberById(dto.requesterDiscordId)?.effectiveName
+                ?: jda.getUserById(dto.requesterDiscordId)?.name
+                ?: "Unknown"
+            RecentSplitViewModel(
+                id = dto.id.toString(),
+                createdAt = dto.createdAt,
+                status = dto.lastAction,
+                requester = requesterName,
+                teams = teams,
+            )
+        }
+    }
+
+    /**
+     * Create-or-replace a preset by name (case-insensitive). Returns
+     * `null` on success or a user-facing error string on validation
+     * failure. The requester's member-of-guild status is checked by the
+     * controller layer before this is called.
+     */
+    fun upsertPreset(
+        guildId: Long,
+        rawName: String,
+        rawMemberIds: List<String>,
+        requesterDiscordId: Long,
+    ): String? {
+        val name = rawName.trim()
+        if (name.isEmpty()) return "Preset name is required."
+        if (name.length > PRESET_NAME_MAX) {
+            return "Preset name is too long (max $PRESET_NAME_MAX characters)."
+        }
+        val memberIds = rawMemberIds.mapNotNull { it.trim().toLongOrNull() }.distinct()
+        if (memberIds.isEmpty()) return "Pick at least one member."
+        if (memberIds.size > MAX_MEMBERS_PER_PRESET) {
+            return "Too many members (max $MAX_MEMBERS_PER_PRESET per preset)."
+        }
+        val guild = jda.getGuildById(guildId) ?: return "Bot is not in that server."
+        val unknown = memberIds.filter { guild.getMemberById(it) == null }
+        if (unknown.isNotEmpty()) {
+            return "Some selected members are not in this server (${unknown.size} unknown)."
+        }
+        teamPresetService.upsertPreset(guildId, name, memberIds, requesterDiscordId)
+        return null
+    }
+
+    fun deletePreset(id: Long, guildId: Long): String? {
+        val existing = teamPresetService.getById(id) ?: return "Preset not found."
+        if (existing.guildId != guildId) return "Preset not found."
+        teamPresetService.deletePreset(id)
+        return null
+    }
+}
+
+data class TeamPresetViewModel(
+    val id: Long,
+    val name: String,
+    val members: List<MemberPreview>,
+    val memberCount: Int,
+    val createdByDiscordId: Long,
+    val createdAt: Instant?,
+    val updatedAt: Instant?,
+)
+
+data class MemberPreview(val id: String, val name: String)
+
+data class TeamSnapshot(val name: String, val members: List<String>)
+
+data class RecentSplitViewModel(
+    val id: String,
+    val createdAt: Instant?,
+    val status: String,
+    val requester: String,
+    val teams: List<TeamSnapshot>,
+)
+
+/** Used by the controller for the preset-deleted ack JSON. */
+data class TeamApiResult(val ok: Boolean, val error: String?)

--- a/web/src/main/resources/templates/fragments/navbar.html
+++ b/web/src/main/resources/templates/fragments/navbar.html
@@ -70,6 +70,7 @@
             <div class="nav-dropdown-menu" role="menu">
                 <a href="/intro/guilds" role="menuitem">Intro Songs</a>
                 <a href="/excuses/guilds" role="menuitem">Excuses</a>
+                <a href="/teams/guilds" role="menuitem">Teams</a>
             </div>
         </div>
         <div class="nav-dropdown">

--- a/web/src/main/resources/templates/team-guilds.html
+++ b/web/src/main/resources/templates/team-guilds.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="en">
+<head th:replace="~{fragments/head :: head('TobyBot - Teams', '/css/excuses.css')}"></head>
+<body>
+<a href="#main" class="skip-link">Skip to content</a>
+<div th:replace="~{fragments/navbar :: navbar}"></div>
+
+<main id="main" class="container">
+    <h1 class="mb-3">Teams</h1>
+    <p class="muted mb-5">Servers where both you and TobyBot are present. Pick one to manage saved team rosters.</p>
+
+    <div th:replace="~{fragments/alerts :: error}"></div>
+
+    <div class="search-row" th:if="${not #lists.isEmpty(guilds)}">
+        <input type="search" id="guildSearch" placeholder="Search servers…"
+               aria-label="Search servers" autocomplete="off">
+        <span class="muted" th:text="${#lists.size(guilds)} + ' server' + (${#lists.size(guilds)} == 1 ? '' : 's')">0 servers</span>
+    </div>
+
+    <div class="guild-grid" th:if="${not #lists.isEmpty(guilds)}" id="guildGrid">
+        <a class="guild-card"
+           th:each="guild : ${guilds}"
+           th:href="@{/teams/{id}(id=${guild.id})}"
+           th:attr="data-guild-name=${#strings.toLowerCase(guild.name)}">
+            <img th:if="${guild.iconUrl != null}"
+                 th:src="${guild.iconUrl}"
+                 th:alt="${guild.name} + ' icon'"
+                 class="guild-icon"
+                 onerror="this.style.display='none'">
+            <div th:unless="${guild.iconUrl != null}"
+                 class="guild-icon-placeholder"
+                 aria-hidden="true"
+                 th:text="${#strings.substring(guild.name, 0, 1).toUpperCase()}">G</div>
+            <div class="guild-name" th:text="${guild.name}" th:title="${guild.name}">Guild Name</div>
+        </a>
+    </div>
+
+    <p id="noResults" class="no-results">No servers match your search.</p>
+
+    <div class="empty-hero" th:if="${#lists.isEmpty(guilds)}">
+        <span class="emoji" aria-hidden="true">📭</span>
+        <h2>TobyBot isn't in any of your servers yet</h2>
+        <p class="mb-5">Invite the bot to get started.</p>
+        <a th:href="${inviteUrl}" class="btn" target="_blank" rel="noopener">Invite TobyBot</a>
+    </div>
+</main>
+
+<script>
+    (function () {
+        const search = document.getElementById('guildSearch');
+        const grid = document.getElementById('guildGrid');
+        const noResults = document.getElementById('noResults');
+        if (!search || !grid) return;
+        search.addEventListener('input', function () {
+            const q = search.value.trim().toLowerCase();
+            let visible = 0;
+            grid.querySelectorAll('.guild-card').forEach(card => {
+                const name = card.dataset.guildName || '';
+                const match = !q || name.indexOf(q) !== -1;
+                card.style.display = match ? '' : 'none';
+                if (match) visible++;
+            });
+            noResults.style.display = visible === 0 ? 'block' : 'none';
+        });
+    })();
+</script>
+<script th:src="@{/js/home.js}"></script>
+</body>
+</html>

--- a/web/src/main/resources/templates/teams.html
+++ b/web/src/main/resources/templates/teams.html
@@ -1,0 +1,149 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="en">
+<head th:replace="~{fragments/head :: head('TobyBot - Teams · ' + ${guildName}, '/css/excuses.css')}"></head>
+<body th:attr="data-guild-id=${guildId}">
+
+<a href="#main" class="skip-link">Skip to content</a>
+<div th:replace="~{fragments/navbar :: navbar}"></div>
+
+<!-- Flash messages rendered invisibly; toasts.js picks them up on load -->
+<div th:if="${success}" data-flash="success" class="sr-only" th:text="${success}"></div>
+<div th:if="${error}" data-flash="error" class="sr-only" th:text="${error}"></div>
+
+<main id="main" class="container">
+
+    <div class="excuse-header">
+        <h1>Teams — <span th:text="${guildName}">Server</span></h1>
+        <span class="excuse-count"
+              th:text="${#lists.size(presets)} + ' preset' + (${#lists.size(presets)} == 1 ? '' : 's')">0 presets</span>
+    </div>
+
+    <p class="muted">Save reusable rosters here, then load them in Discord via <code>/team split</code>.</p>
+
+    <!-- Existing presets -->
+    <section class="excuse-list" aria-labelledby="presets-h">
+        <h2 id="presets-h">Saved presets</h2>
+
+        <div th:if="${#lists.isEmpty(presets)}" class="empty-hero">
+            <span class="emoji" aria-hidden="true">📋</span>
+            <p>No presets yet — create one below.</p>
+        </div>
+
+        <ul th:unless="${#lists.isEmpty(presets)}" class="excuse-cards">
+            <li th:each="p : ${presets}"
+                class="excuse-card approved"
+                th:attr="data-preset-id=${p.id}">
+                <div class="excuse-text"><strong th:text="${p.name}">Preset</strong></div>
+                <div class="excuse-meta">
+                    <span class="excuse-author" th:text="${p.memberCount} + ' member' + (${p.memberCount} == 1 ? '' : 's')">0 members</span>
+                </div>
+                <ul class="muted" style="margin: 0.4em 0 0.8em 1.2em;">
+                    <li th:each="m : ${p.members}" th:text="${m.name}">Member</li>
+                </ul>
+                <div class="excuse-actions">
+                    <button type="button" class="btn btn-sm btn-danger"
+                            th:attr="data-action='delete-preset',
+                                     data-id=${p.id},
+                                     data-name=${p.name},
+                                     data-url=@{/teams/{gid}/presets/{id}/delete(gid=${guildId},id=${p.id})}">
+                        🗑 Delete
+                    </button>
+                </div>
+            </li>
+        </ul>
+    </section>
+
+    <!-- Create / replace preset -->
+    <section class="maker-card" aria-labelledby="new-preset-h">
+        <h2 id="new-preset-h">New preset</h2>
+        <p class="muted">Names are case-insensitive within a server. Submitting the same name overwrites the existing preset's roster.</p>
+        <form method="post" th:action="@{/teams/{gid}/presets(gid=${guildId})}" class="maker-form">
+
+            <div class="form-group">
+                <label for="presetName">Name</label>
+                <input id="presetName" name="name" type="text" required
+                       th:maxlength="${maxNameLength}"
+                       placeholder="e.g. Friday Night Crew">
+            </div>
+
+            <div class="form-group">
+                <label for="memberSelect">Members</label>
+                <div th:replace="~{fragments/userPicker :: userPicker(
+                        name='memberIds',
+                        id='memberSelect',
+                        members=${members},
+                        selectedId=null,
+                        placeholder='Pick members…',
+                        emptyLabel=null,
+                        required=true,
+                        multiple=true,
+                        showSocialCredit=false)}"></div>
+            </div>
+
+            <button type="submit" class="btn">Save preset</button>
+        </form>
+    </section>
+
+    <!-- Recent splits -->
+    <section class="excuse-list" aria-labelledby="recent-h" th:if="${not #lists.isEmpty(recentSplits)}">
+        <h2 id="recent-h">Recent splits</h2>
+        <ul class="excuse-cards">
+            <li th:each="s : ${recentSplits}" class="excuse-card"
+                th:classappend="${s.status == 'confirmed'} ? ' approved' : ' pending'">
+                <div class="excuse-meta">
+                    <span class="excuse-author" th:text="${s.requester}">Requester</span>
+                    <span class="excuse-state" th:text="${s.status}">status</span>
+                </div>
+                <ul style="margin: 0.4em 0 0.4em 1.2em;">
+                    <li th:each="t : ${s.teams}">
+                        <strong th:text="${t.name}">Team</strong>:
+                        <span th:text="${#strings.listJoin(t.members, ', ')}">members</span>
+                    </li>
+                </ul>
+            </li>
+        </ul>
+    </section>
+</main>
+
+<script th:src="@{/js/api.js}"></script>
+<script th:src="@{/js/toasts.js}"></script>
+<script th:src="@{/js/userPicker.js}"></script>
+<script>
+    // Wire up the delete-preset buttons via the shared api.js postJson helper.
+    document.addEventListener('DOMContentLoaded', function () {
+        document.querySelectorAll('[data-action="delete-preset"]').forEach(function (btn) {
+            btn.addEventListener('click', async function () {
+                const name = btn.dataset.name || 'this preset';
+                if (!confirm("Delete '" + name + "'?")) return;
+                btn.disabled = true;
+                try {
+                    const res = await fetch(btn.dataset.url, {
+                        method: 'POST',
+                        headers: (function () {
+                            const h = { 'Accept': 'application/json' };
+                            const tokenMeta = document.querySelector('meta[name="_csrf"]');
+                            const headerMeta = document.querySelector('meta[name="_csrf_header"]');
+                            if (tokenMeta && headerMeta) {
+                                h[headerMeta.getAttribute('content')] = tokenMeta.getAttribute('content');
+                            }
+                            return h;
+                        })(),
+                    });
+                    const body = await res.json().catch(() => ({}));
+                    if (res.ok && body.ok) {
+                        const card = btn.closest('[data-preset-id]');
+                        if (card) card.remove();
+                    } else {
+                        alert(body.error || 'Failed to delete preset.');
+                        btn.disabled = false;
+                    }
+                } catch (e) {
+                    alert('Network error.');
+                    btn.disabled = false;
+                }
+            });
+        });
+    });
+</script>
+</body>
+</html>

--- a/web/src/test/kotlin/web/controller/TeamWebControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/TeamWebControllerTest.kt
@@ -1,0 +1,129 @@
+package web.controller
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.unmockkAll
+import io.mockk.verify
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient
+import org.springframework.security.oauth2.core.OAuth2AccessToken
+import org.springframework.security.oauth2.core.user.OAuth2User
+import org.springframework.ui.Model
+import org.springframework.web.servlet.mvc.support.RedirectAttributes
+import web.service.GuildInfo
+import web.service.TeamWebService
+
+class TeamWebControllerTest {
+
+    private lateinit var teamWebService: TeamWebService
+    private lateinit var controller: TeamWebController
+
+    private val mockUser = mockk<OAuth2User>(relaxed = true)
+    private val mockClient = mockk<OAuth2AuthorizedClient>(relaxed = true)
+    private val mockModel = mockk<Model>(relaxed = true)
+    private val mockRa = mockk<RedirectAttributes>(relaxed = true)
+
+    private val discordId = "111"
+    private val guildId = 222L
+
+    @BeforeEach
+    fun setup() {
+        teamWebService = mockk(relaxed = true)
+        controller = TeamWebController(teamWebService, "test-client-id")
+
+        every { mockUser.getAttribute<String>("id") } returns discordId
+        every { mockUser.getAttribute<String>("username") } returns "TestUser"
+        every { mockClient.accessToken } returns mockk<OAuth2AccessToken> {
+            every { tokenValue } returns "mock-token"
+        }
+    }
+
+    @AfterEach
+    fun tearDown() = unmockkAll()
+
+    @Test
+    fun `guildList renders team-guilds template`() {
+        val guilds = listOf(GuildInfo("1", "Guild One", null))
+        every { teamWebService.getMutualGuilds("mock-token") } returns guilds
+
+        val view = controller.guildList(mockClient, mockUser, mockModel)
+
+        assertEquals("team-guilds", view)
+        verify { mockModel.addAttribute("guilds", guilds) }
+        verify { mockModel.addAttribute("username", "TestUser") }
+    }
+
+    @Test
+    fun `page redirects anonymous users to guild picker`() {
+        every { mockUser.getAttribute<String>("id") } returns null
+
+        val view = controller.page(guildId, mockUser, mockModel, mockRa)
+
+        assertEquals("redirect:/teams/guilds", view)
+    }
+
+    @Test
+    fun `page redirects non-members with a flash error`() {
+        every { teamWebService.isMember(discordId.toLong(), guildId) } returns false
+
+        val view = controller.page(guildId, mockUser, mockModel, mockRa)
+
+        assertEquals("redirect:/teams/guilds", view)
+    }
+
+    @Test
+    fun `page renders teams template for guild members`() {
+        every { teamWebService.isMember(discordId.toLong(), guildId) } returns true
+        every { teamWebService.getGuildName(guildId) } returns "Test Guild"
+
+        val view = controller.page(guildId, mockUser, mockModel, mockRa)
+
+        assertEquals("teams", view)
+        verify { mockModel.addAttribute("guildName", "Test Guild") }
+    }
+
+    @Test
+    fun `createPreset surfaces validation errors as flash messages`() {
+        every { teamWebService.isMember(discordId.toLong(), guildId) } returns true
+        every { teamWebService.upsertPreset(guildId, "x", any(), discordId.toLong()) } returns "Pick at least one member."
+
+        val view = controller.createPreset(guildId, "x", null, mockUser, mockRa)
+
+        assertTrue(view.startsWith("redirect:/teams/$guildId"))
+        verify { mockRa.addFlashAttribute("error", "Pick at least one member.") }
+    }
+
+    @Test
+    fun `createPreset adds a success flash on save`() {
+        every { teamWebService.isMember(discordId.toLong(), guildId) } returns true
+        every { teamWebService.upsertPreset(guildId, "Crew", listOf("111", "222"), discordId.toLong()) } returns null
+
+        controller.createPreset(guildId, "Crew", listOf("111", "222"), mockUser, mockRa)
+
+        verify { mockRa.addFlashAttribute("success", "Saved preset 'Crew'.") }
+    }
+
+    @Test
+    fun `deletePreset returns 403 to non-members`() {
+        every { teamWebService.isMember(discordId.toLong(), guildId) } returns false
+
+        val response = controller.deletePreset(guildId, 7L, mockUser)
+
+        assertEquals(403, response.statusCode.value())
+    }
+
+    @Test
+    fun `deletePreset returns ok on success`() {
+        every { teamWebService.isMember(discordId.toLong(), guildId) } returns true
+        every { teamWebService.deletePreset(7L, guildId) } returns null
+
+        val response = controller.deletePreset(guildId, 7L, mockUser)
+
+        assertEquals(200, response.statusCode.value())
+        assertTrue(response.body!!.ok)
+    }
+}

--- a/web/src/test/kotlin/web/service/TeamWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/TeamWebServiceTest.kt
@@ -1,0 +1,178 @@
+package web.service
+
+import database.dto.TeamPresetDto
+import database.dto.TeamSplitSessionDto
+import database.service.TeamPresetService
+import database.service.TeamSplitSessionService
+import database.service.encodeAssignments
+import database.service.encodeTeamNames
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.unmockkAll
+import io.mockk.verify
+import net.dv8tion.jda.api.JDA
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.Member
+import net.dv8tion.jda.api.entities.User
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import web.util.GuildMembership
+
+class TeamWebServiceTest {
+
+    private lateinit var presetService: TeamPresetService
+    private lateinit var sessionService: TeamSplitSessionService
+    private lateinit var introWebService: IntroWebService
+    private lateinit var guildMembership: GuildMembership
+    private lateinit var jda: JDA
+    private lateinit var service: TeamWebService
+
+    private val guildId = 999L
+
+    @BeforeEach
+    fun setup() {
+        presetService = mockk(relaxed = true)
+        sessionService = mockk(relaxed = true)
+        introWebService = mockk(relaxed = true)
+        guildMembership = mockk(relaxed = true)
+        jda = mockk(relaxed = true)
+        service = TeamWebService(presetService, sessionService, introWebService, guildMembership, jda)
+    }
+
+    @AfterEach
+    fun tearDown() = unmockkAll()
+
+    @Test
+    fun `isMember delegates to GuildMembership`() {
+        every { guildMembership.isMember(42L, guildId) } returns true
+        assertTrue(service.isMember(42L, guildId))
+        verify { guildMembership.isMember(42L, guildId) }
+    }
+
+    @Test
+    fun `upsertPreset rejects empty name`() {
+        val err = service.upsertPreset(guildId, "   ", listOf("111"), 42L)
+        assertEquals("Preset name is required.", err)
+        verify(exactly = 0) { presetService.upsertPreset(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `upsertPreset rejects empty member list`() {
+        val err = service.upsertPreset(guildId, "Crew", emptyList(), 42L)
+        assertEquals("Pick at least one member.", err)
+    }
+
+    @Test
+    fun `upsertPreset rejects unknown members`() {
+        val guild = guildMock {
+            every { getMemberById(111L) } returns memberMock(111L)
+            every { getMemberById(999L) } returns null
+        }
+        every { jda.getGuildById(guildId) } returns guild
+        val err = service.upsertPreset(guildId, "Crew", listOf("111", "999"), 42L)
+        assertNotNull(err)
+        assertTrue(err!!.contains("not in this server"))
+    }
+
+    @Test
+    fun `upsertPreset persists valid input and returns null on success`() {
+        val guild = guildMock {
+            every { getMemberById(any<Long>()) } answers { memberMock(it.invocation.args[0] as Long) }
+        }
+        every { jda.getGuildById(guildId) } returns guild
+
+        val err = service.upsertPreset(guildId, "Crew", listOf("111", "222"), 42L)
+
+        assertNull(err)
+        verify {
+            presetService.upsertPreset(
+                guildId = guildId,
+                name = "Crew",
+                memberIds = listOf(111L, 222L),
+                createdByDiscordId = 42L,
+            )
+        }
+    }
+
+    @Test
+    fun `deletePreset enforces guild ownership`() {
+        every { presetService.getById(7L) } returns TeamPresetDto(
+            id = 7L, guildId = 100L, name = "x", createdByDiscordId = 42L,
+        )
+        // 100L != guildId — should refuse without deleting
+        val err = service.deletePreset(7L, guildId)
+        assertEquals("Preset not found.", err)
+        verify(exactly = 0) { presetService.deletePreset(any()) }
+    }
+
+    @Test
+    fun `listRecentSessions decodes assignments and team names`() {
+        val guild = guildMock {
+            every { getMemberById(111L) } returns memberMock(111L, "Alice")
+            every { getMemberById(222L) } returns memberMock(222L, "Bob")
+        }
+        every { jda.getGuildById(guildId) } returns guild
+        val session = TeamSplitSessionDto(
+            guildId = guildId, requesterDiscordId = 111L,
+            memberIds = "111,222", teamCount = 2,
+            assignments = encodeAssignments(listOf(listOf(111L), listOf(222L))),
+            teamNames = encodeTeamNames(listOf("Red", "Blue")),
+            lastAction = TeamSplitSessionDto.ACTION_CONFIRMED,
+        )
+        every {
+            sessionService.recentForGuild(guildId, TeamWebService.RECENT_SESSIONS_LIMIT)
+        } returns listOf(session)
+
+        val out = service.listRecentSessions(guildId)
+        assertEquals(1, out.size)
+        assertEquals("confirmed", out[0].status)
+        assertEquals(listOf("Red", "Blue"), out[0].teams.map { it.name })
+        assertEquals(listOf(listOf("Alice"), listOf("Bob")), out[0].teams.map { it.members })
+    }
+
+    @Test
+    fun `getMutualGuilds delegates to IntroWebService`() {
+        val mockGuilds = listOf(GuildInfo("1", "g", null))
+        every { introWebService.getMutualGuilds("token") } returns mockGuilds
+        assertEquals(mockGuilds, service.getMutualGuilds("token"))
+    }
+
+    @Test
+    fun `getGuildMembers filters bots and sorts alphabetically`() {
+        val human = memberMock(111L, "Bob")
+        val bot = memberMock(222L, "BotName", isBot = true)
+        val anotherHuman = memberMock(333L, "alice")
+        val guild = mockk<Guild>(relaxed = true) {
+            every { members } returns listOf(human, bot, anotherHuman)
+        }
+        every { jda.getGuildById(guildId) } returns guild
+
+        val result = service.getGuildMembers(guildId)
+        assertEquals(listOf("alice", "Bob"), result.map { it.name })
+        assertFalse(result.any { it.name == "BotName" })
+    }
+
+    private fun memberMock(id: Long, displayName: String = "Name $id", isBot: Boolean = false): Member {
+        val u = mockk<User>(relaxed = true) {
+            every { this@mockk.isBot } returns isBot
+            every { name } returns displayName
+        }
+        return mockk(relaxed = true) {
+            every { idLong } returns id
+            every { this@mockk.id } returns id.toString()
+            every { user } returns u
+            every { effectiveName } returns displayName
+            every { effectiveAvatarUrl } returns "https://example/$id.png"
+        }
+    }
+
+    private fun guildMock(block: Guild.() -> Unit): Guild {
+        return mockk<Guild>(relaxed = true) { block(this) }
+    }
+}


### PR DESCRIPTION
## Summary

Rebuilds `/team` around a Discord modal, a preview-then-confirm flow, and a `/teams/{guildId}` web UI for saved rosters. Replaces the old one-shot slash command that immediately created voice channels with no chance to review.

**Discord flow**
- `/team split` opens a modal (optional `members:` slash-option pre-fills it)
- Modal collects: optional preset name, members (paragraph; `@mentions` or raw IDs), team count, naming strategy (`prefix`|`list`), names
- Submit shows an ephemeral preview embed + **Confirm / Reroll / Cancel** buttons — voice channels are NOT created yet
- **Confirm** creates the channels, moves members, disables buttons (idempotent on double-click)
- **Reroll** re-shuffles in place keeping the same buttons valid
- **Cancel** dismisses with no side effects
- `/team cleanup` is now its own subcommand (previously a boolean flag)

**Web UI** at `/teams/{guildId}`
- Preset CRUD (case-insensitive name; upsert overwrites in place)
- Recent splits panel showing the last 10 sessions per guild
- Linked from the Social navbar dropdown

**Data model** (Flyway `V32`)
- `team_preset(id, guild_id, name, member_ids, created_by_discord_id, created_at, updated_at)` — unique on `(guild_id, lower(name))`
- `team_split_session(id UUID, guild_id, requester_discord_id, member_ids, team_count, assignments, team_names, created_at, last_action)`
- Sessions are addressed by UUID embedded in button ids so a 25-member roster fits under Discord's 100-char component-id cap
- Assignments stored as pipe-delimited CSV (`1,2,3|4,5|6,7`) to keep the database module Jackson-free

## Breaking change

The old `/team members:... size:... cleanup:true` shape is gone. JDA disallows mixing top-level options with subcommands on the same slash command, so a soft deprecation isn't feasible without a parallel `/teams` (plural) command — we went with the clean cutover.

## Test plan

Automated (compiled + executed in the sandbox):
- [x] `:database:test` — green, including new DTO/persistence wiring
- [x] `:web:test` — green; new `TeamWebServiceTest` (9 tests) and `TeamWebControllerTest` (8 tests) pass
- [x] `:database:compileKotlin` and `:web:compileKotlin` clean

Automated (added; not runnable in this sandbox due to network-blocked libdave deps for `:discord-bot`):
- [ ] `TeamCommandTest` — split opens modal first, cleanup deletes only `Team N` channels, split helper distributes remainder
- [ ] `TeamSplitModalTest` — preset resolution, mention parsing, dedup, validation paths, session row written before preview
- [ ] `TeamConfirmButtonTest` / `TeamRerollButtonTest` / `TeamCancelButtonTest` — voice-channel creation, double-click safety, in-place reroll
- [ ] `TeamPresetServiceIntegrationTest` — case-insensitive upsert, session roundtrip + state transitions

Manual (post-deploy in a test guild):
- [ ] `/team split` with no slash-option → modal opens empty; type preset name → preview appears
- [ ] `/team split members:@a @b @c` → modal pre-filled; submit → preview embed; **no channels yet**
- [ ] Reroll repeatedly — assignments change, same message, same buttons
- [ ] Confirm — N voice channels created at `maxBitrate`, members moved; double-click safe
- [ ] Cancel — message clears, no channels
- [ ] `/team cleanup` deletes only `Team N`-named channels; unrelated channels untouched
- [ ] `/teams/guilds` lists mutual guilds; `/teams/{guildId}` CRUD presets; recent splits show Confirm-time entries
- [ ] Anonymous web → redirect to login; non-member of target guild → flash error + redirect

## Open follow-ups (non-blocking)

- Wire `DefaultTeamSplitSessionService.purgeOlderThan` into a `@Scheduled` nightly cleanup if session rows pile up
- Server-side member picker pagination if guilds with 5000+ members hit the `<select multiple>`
- Surface partial-success in the result embed if "member left voice between preview and Confirm" turns out noisy

https://claude.ai/code/session_01LmuHprDTKzu6Wk9J3LzgL2

---
_Generated by [Claude Code](https://claude.ai/code/session_01LmuHprDTKzu6Wk9J3LzgL2)_