### PR TITLE
feat(music): expand Lavaplayer sources + polish embed + web dashboard

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: java -Dserver.port=$PORT -jar application/build/libs/application-6.1-SNAPSHOT.jar
+web: java -Dserver.port=$PORT -jar application/build/libs/application-7.0-SNAPSHOT.jar
 release: ./bin/trigger_publish_wiki.sh  # This runs after deployment

--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ buildscript {
         mockk_version = '1.13.13'
         lavaplayer_version = '2.2.6'
         youtube_common_version = '1.18.0'
+        lavasrc_version = '4.8.2'
     }
     repositories {
         mavenCentral()
@@ -33,7 +34,7 @@ apply plugin: 'kotlin'
 
 allprojects {
     group = "com.github.ml404"
-    version = "6.1-SNAPSHOT"
+    version = "7.0-SNAPSHOT"
 
     ext['kotlin.version'] = kotlin_version
     // Override Spring Boot 3.3.4's BOM-managed versions with patched releases.
@@ -58,6 +59,7 @@ allprojects {
         }
         maven { url = "https://maven.lavalink.dev/releases" }
         maven { url = "https://maven.lavalink.dev/snapshots" }
+        maven { url = "https://maven.topi.wtf/releases" }
     }
 }
 

--- a/core-api/src/main/kotlin/core/music/MusicControlGateway.kt
+++ b/core-api/src/main/kotlin/core/music/MusicControlGateway.kt
@@ -1,0 +1,87 @@
+package core.music
+
+interface MusicControlGateway {
+
+    data class TrackInfo(
+        val identifier: String,
+        val title: String,
+        val author: String,
+        val durationMs: Long,
+        val uri: String?,
+        val artworkUrl: String?,
+        val sourceName: String?,
+        val isStream: Boolean,
+        val requesterDiscordId: Long?,
+        // Populated by the web layer at fan-out time (the bot core only knows
+        // the requester id; resolving to a Discord display name + avatar needs
+        // a JDA handle that the bot doesn't bother carrying through every map
+        // / SSE call). Bot-side consumers (e.g. the now-playing embed) resolve
+        // these themselves via TrackScheduler.getRequesterId + Guild.getMemberById.
+        val requesterDisplayName: String? = null,
+        val requesterAvatarUrl: String? = null,
+    )
+
+    data class VoiceMember(
+        val discordId: Long,
+        val displayName: String,
+        val avatarUrl: String?,
+        val isBot: Boolean,
+        val isMuted: Boolean,
+        val isDeafened: Boolean,
+    )
+
+    data class VoiceChannelInfo(
+        val id: Long,
+        val name: String,
+        val members: List<VoiceMember>,
+    )
+
+    data class GuildPlayerState(
+        val guildId: Long,
+        val nowPlaying: TrackInfo?,
+        val positionMs: Long,
+        val paused: Boolean,
+        val volume: Int,
+        val looping: Boolean,
+        val queue: List<TrackInfo>,
+        val voiceChannelId: Long?,
+        val voiceChannel: VoiceChannelInfo? = null,
+    )
+
+    data class LoadResult(
+        val ok: Boolean,
+        val tracksAdded: Int,
+        val message: String?,
+    )
+
+    fun getState(guildId: Long): GuildPlayerState?
+
+    /**
+     * Resolve [query] through the lavaplayer source chain WITHOUT queueing
+     * anything. Returns the candidate tracks the load would have produced —
+     * for a `ytsearch:` query this is the top search results; for a direct
+     * URL it's the resolved single track (or the tracks of a playlist URL).
+     * Result list is capped at [limit] to keep payloads small.
+     */
+    fun search(guildId: Long, query: String, limit: Int = 10): List<TrackInfo>
+
+    fun load(guildId: Long, query: String, requesterDiscordId: Long): LoadResult
+
+    fun pause(guildId: Long): Boolean
+
+    fun resume(guildId: Long): Boolean
+
+    fun skip(guildId: Long, count: Int = 1): Boolean
+
+    fun stop(guildId: Long): Boolean
+
+    fun setVolume(guildId: Long, volume: Int): Boolean
+
+    fun seek(guildId: Long, positionMs: Long): Boolean
+
+    fun reorderQueue(guildId: Long, fromIndex: Int, toIndex: Int): Boolean
+
+    fun removeFromQueue(guildId: Long, index: Int): TrackInfo?
+
+    fun setLooping(guildId: Long, looping: Boolean): Boolean
+}

--- a/core-api/src/main/kotlin/core/music/events/MusicEvents.kt
+++ b/core-api/src/main/kotlin/core/music/events/MusicEvents.kt
@@ -1,0 +1,37 @@
+package core.music.events
+
+import core.music.MusicControlGateway.TrackInfo
+
+sealed class MusicEvent {
+    abstract val guildId: Long
+}
+
+data class TrackStartedEvent(
+    override val guildId: Long,
+    val track: TrackInfo,
+) : MusicEvent()
+
+data class TrackEndedEvent(
+    override val guildId: Long,
+    val endReason: String,
+) : MusicEvent()
+
+data class QueueChangedEvent(
+    override val guildId: Long,
+    val queue: List<TrackInfo>,
+) : MusicEvent()
+
+data class PauseStateChangedEvent(
+    override val guildId: Long,
+    val paused: Boolean,
+) : MusicEvent()
+
+data class VolumeChangedEvent(
+    override val guildId: Long,
+    val volume: Int,
+) : MusicEvent()
+
+data class LoopStateChangedEvent(
+    override val guildId: Long,
+    val looping: Boolean,
+) : MusicEvent()

--- a/database/src/main/kotlin/database/dto/MusicPlaylistDto.kt
+++ b/database/src/main/kotlin/database/dto/MusicPlaylistDto.kt
@@ -1,0 +1,75 @@
+package database.dto
+
+import jakarta.persistence.*
+import org.springframework.transaction.annotation.Transactional
+import java.io.Serializable
+import java.time.Instant
+
+@NamedQueries(
+    NamedQuery(
+        name = "MusicPlaylistDto.getByGuild",
+        query = "select p from MusicPlaylistDto p WHERE p.guildId = :guildId ORDER BY LOWER(p.name) ASC"
+    ),
+    NamedQuery(
+        name = "MusicPlaylistDto.getByGuildAndOwner",
+        query = "select p from MusicPlaylistDto p WHERE p.guildId = :guildId AND p.ownerDiscordId = :ownerId ORDER BY LOWER(p.name) ASC"
+    ),
+    NamedQuery(
+        name = "MusicPlaylistDto.getByGuildOwnerAndName",
+        query = "select p from MusicPlaylistDto p WHERE p.guildId = :guildId AND p.ownerDiscordId = :ownerId AND LOWER(p.name) = LOWER(:name)"
+    ),
+    NamedQuery(
+        name = "MusicPlaylistDto.getById",
+        query = "select p from MusicPlaylistDto p WHERE p.id = :id"
+    ),
+    NamedQuery(
+        name = "MusicPlaylistDto.deleteById",
+        query = "delete from MusicPlaylistDto p WHERE p.id = :id"
+    ),
+)
+@Entity
+@Table(name = "music_playlist", schema = "public")
+@Transactional
+class MusicPlaylistDto(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    var id: Long? = null,
+
+    @Column(name = "guild_id")
+    var guildId: Long = 0L,
+
+    @Column(name = "owner_discord_id")
+    var ownerDiscordId: Long = 0L,
+
+    @Column(name = "name")
+    var name: String = "",
+
+    @Column(name = "created_at")
+    var createdAt: Instant? = null,
+
+    @Column(name = "updated_at")
+    var updatedAt: Instant? = null,
+
+    @OneToMany(
+        mappedBy = "playlist",
+        cascade = [CascadeType.ALL],
+        orphanRemoval = true,
+        fetch = FetchType.EAGER,
+    )
+    @OrderBy("position ASC")
+    var items: MutableList<MusicPlaylistItemDto> = mutableListOf(),
+) : Serializable {
+
+    @PrePersist
+    fun onCreate() {
+        val now = Instant.now()
+        if (createdAt == null) createdAt = now
+        if (updatedAt == null) updatedAt = now
+    }
+
+    @PreUpdate
+    fun onUpdate() {
+        updatedAt = Instant.now()
+    }
+}

--- a/database/src/main/kotlin/database/dto/MusicPlaylistItemDto.kt
+++ b/database/src/main/kotlin/database/dto/MusicPlaylistItemDto.kt
@@ -1,0 +1,35 @@
+package database.dto
+
+import jakarta.persistence.*
+import java.io.Serializable
+
+@Entity
+@Table(name = "music_playlist_item", schema = "public")
+class MusicPlaylistItemDto(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    var id: Long? = null,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "playlist_id", nullable = false)
+    var playlist: MusicPlaylistDto? = null,
+
+    @Column(name = "position")
+    var position: Int = 0,
+
+    @Column(name = "identifier")
+    var identifier: String = "",
+
+    @Column(name = "title")
+    var title: String? = null,
+
+    @Column(name = "author")
+    var author: String? = null,
+
+    @Column(name = "duration_ms")
+    var durationMs: Long? = null,
+
+    @Column(name = "source_name")
+    var sourceName: String? = null,
+) : Serializable

--- a/database/src/main/kotlin/database/persistence/MusicPlaylistPersistence.kt
+++ b/database/src/main/kotlin/database/persistence/MusicPlaylistPersistence.kt
@@ -1,0 +1,13 @@
+package database.persistence
+
+import database.dto.MusicPlaylistDto
+
+interface MusicPlaylistPersistence {
+    fun listByGuild(guildId: Long): List<MusicPlaylistDto>
+    fun listByGuildAndOwner(guildId: Long, ownerDiscordId: Long): List<MusicPlaylistDto>
+    fun getByGuildOwnerAndName(guildId: Long, ownerDiscordId: Long, name: String): MusicPlaylistDto?
+    fun getById(id: Long): MusicPlaylistDto?
+    fun save(dto: MusicPlaylistDto): MusicPlaylistDto
+    fun update(dto: MusicPlaylistDto): MusicPlaylistDto
+    fun deleteById(id: Long)
+}

--- a/database/src/main/kotlin/database/persistence/impl/DefaultMusicPlaylistPersistence.kt
+++ b/database/src/main/kotlin/database/persistence/impl/DefaultMusicPlaylistPersistence.kt
@@ -1,0 +1,74 @@
+package database.persistence.impl
+
+import database.dto.MusicPlaylistDto
+import database.persistence.MusicPlaylistPersistence
+import jakarta.persistence.EntityManager
+import jakarta.persistence.NoResultException
+import jakarta.persistence.PersistenceContext
+import jakarta.persistence.TypedQuery
+import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
+
+@Repository
+@Transactional
+class DefaultMusicPlaylistPersistence internal constructor() : MusicPlaylistPersistence {
+    @PersistenceContext
+    private lateinit var entityManager: EntityManager
+
+    override fun listByGuild(guildId: Long): List<MusicPlaylistDto> {
+        val q: TypedQuery<MusicPlaylistDto> =
+            entityManager.createNamedQuery("MusicPlaylistDto.getByGuild", MusicPlaylistDto::class.java)
+        q.setParameter("guildId", guildId)
+        return q.resultList
+    }
+
+    override fun listByGuildAndOwner(guildId: Long, ownerDiscordId: Long): List<MusicPlaylistDto> {
+        val q: TypedQuery<MusicPlaylistDto> =
+            entityManager.createNamedQuery("MusicPlaylistDto.getByGuildAndOwner", MusicPlaylistDto::class.java)
+        q.setParameter("guildId", guildId)
+        q.setParameter("ownerId", ownerDiscordId)
+        return q.resultList
+    }
+
+    override fun getByGuildOwnerAndName(guildId: Long, ownerDiscordId: Long, name: String): MusicPlaylistDto? {
+        val q: TypedQuery<MusicPlaylistDto> =
+            entityManager.createNamedQuery("MusicPlaylistDto.getByGuildOwnerAndName", MusicPlaylistDto::class.java)
+        q.setParameter("guildId", guildId)
+        q.setParameter("ownerId", ownerDiscordId)
+        q.setParameter("name", name)
+        return try {
+            q.singleResult
+        } catch (_: NoResultException) {
+            null
+        }
+    }
+
+    override fun getById(id: Long): MusicPlaylistDto? {
+        val q: TypedQuery<MusicPlaylistDto> =
+            entityManager.createNamedQuery("MusicPlaylistDto.getById", MusicPlaylistDto::class.java)
+        q.setParameter("id", id)
+        return try {
+            q.singleResult
+        } catch (_: NoResultException) {
+            null
+        }
+    }
+
+    override fun save(dto: MusicPlaylistDto): MusicPlaylistDto {
+        entityManager.persist(dto)
+        entityManager.flush()
+        return dto
+    }
+
+    override fun update(dto: MusicPlaylistDto): MusicPlaylistDto {
+        val merged = entityManager.merge(dto)
+        entityManager.flush()
+        return merged
+    }
+
+    override fun deleteById(id: Long) {
+        val q = entityManager.createNamedQuery("MusicPlaylistDto.deleteById")
+        q.setParameter("id", id)
+        q.executeUpdate()
+    }
+}

--- a/database/src/main/kotlin/database/service/MusicPlaylistService.kt
+++ b/database/src/main/kotlin/database/service/MusicPlaylistService.kt
@@ -1,0 +1,33 @@
+package database.service
+
+import database.dto.MusicPlaylistDto
+
+interface MusicPlaylistService {
+
+    data class PlaylistItemInput(
+        val identifier: String,
+        val title: String?,
+        val author: String?,
+        val durationMs: Long?,
+        val sourceName: String?,
+    )
+
+    fun listForGuild(guildId: Long): List<MusicPlaylistDto>
+    fun listForUserInGuild(guildId: Long, ownerDiscordId: Long): List<MusicPlaylistDto>
+    fun getById(id: Long): MusicPlaylistDto?
+
+    /**
+     * Create a new playlist for `(guildId, ownerDiscordId, name)`. Throws
+     * [PlaylistNameTakenException] if the user already has one with that name in this guild.
+     */
+    fun create(
+        guildId: Long,
+        ownerDiscordId: Long,
+        name: String,
+        items: List<PlaylistItemInput>,
+    ): MusicPlaylistDto
+
+    fun deleteById(id: Long)
+
+    class PlaylistNameTakenException(message: String) : RuntimeException(message)
+}

--- a/database/src/main/kotlin/database/service/impl/DefaultMusicPlaylistService.kt
+++ b/database/src/main/kotlin/database/service/impl/DefaultMusicPlaylistService.kt
@@ -1,0 +1,62 @@
+package database.service.impl
+
+import database.dto.MusicPlaylistDto
+import database.dto.MusicPlaylistItemDto
+import database.persistence.MusicPlaylistPersistence
+import database.service.MusicPlaylistService
+import database.service.MusicPlaylistService.PlaylistItemInput
+import database.service.MusicPlaylistService.PlaylistNameTakenException
+import org.springframework.stereotype.Service
+
+@Service
+class DefaultMusicPlaylistService(
+    private val persistence: MusicPlaylistPersistence,
+) : MusicPlaylistService {
+
+    override fun listForGuild(guildId: Long): List<MusicPlaylistDto> =
+        persistence.listByGuild(guildId)
+
+    override fun listForUserInGuild(guildId: Long, ownerDiscordId: Long): List<MusicPlaylistDto> =
+        persistence.listByGuildAndOwner(guildId, ownerDiscordId)
+
+    override fun getById(id: Long): MusicPlaylistDto? = persistence.getById(id)
+
+    override fun create(
+        guildId: Long,
+        ownerDiscordId: Long,
+        name: String,
+        items: List<PlaylistItemInput>,
+    ): MusicPlaylistDto {
+        val trimmed = name.trim()
+        require(trimmed.isNotEmpty()) { "Playlist name cannot be blank" }
+        require(trimmed.length <= 80) { "Playlist name must be at most 80 characters" }
+        require(items.isNotEmpty()) { "Playlist must contain at least one track" }
+
+        if (persistence.getByGuildOwnerAndName(guildId, ownerDiscordId, trimmed) != null) {
+            throw PlaylistNameTakenException("A playlist named '$trimmed' already exists for this user in this guild")
+        }
+
+        val playlist = MusicPlaylistDto(
+            guildId = guildId,
+            ownerDiscordId = ownerDiscordId,
+            name = trimmed,
+        )
+        items.forEachIndexed { index, input ->
+            val item = MusicPlaylistItemDto(
+                playlist = playlist,
+                position = index,
+                identifier = input.identifier,
+                title = input.title,
+                author = input.author,
+                durationMs = input.durationMs,
+                sourceName = input.sourceName,
+            )
+            playlist.items.add(item)
+        }
+        return persistence.save(playlist)
+    }
+
+    override fun deleteById(id: Long) {
+        persistence.deleteById(id)
+    }
+}

--- a/database/src/main/resources/db/migration/V33__music_playlist.sql
+++ b/database/src/main/resources/db/migration/V33__music_playlist.sql
@@ -1,0 +1,38 @@
+-- Persistence for saved music playlists surfaced via the web music dashboard.
+--
+-- music_playlist stores the playlist header; music_playlist_item holds the
+-- ordered tracks. We store a small denormalised snapshot of each track's
+-- title/author/duration/source so the UI can render the playlist without
+-- re-resolving every identifier against Lavaplayer. The `identifier` column
+-- holds whatever Lavaplayer needs to re-load the track (URL, ytsearch term,
+-- spsearch term, etc.) — we resolve it via the existing loadAndPlay path on
+-- load.
+
+CREATE TABLE IF NOT EXISTS public.music_playlist (
+    id                BIGSERIAL                PRIMARY KEY,
+    guild_id          BIGINT                   NOT NULL,
+    owner_discord_id  BIGINT                   NOT NULL,
+    name              VARCHAR(80)              NOT NULL,
+    created_at        TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+    updated_at        TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_music_playlist_owner_name
+    ON public.music_playlist (guild_id, owner_discord_id, lower(name));
+
+CREATE INDEX IF NOT EXISTS idx_music_playlist_guild
+    ON public.music_playlist (guild_id);
+
+CREATE TABLE IF NOT EXISTS public.music_playlist_item (
+    id           BIGSERIAL                PRIMARY KEY,
+    playlist_id  BIGINT                   NOT NULL REFERENCES public.music_playlist(id) ON DELETE CASCADE,
+    position     INTEGER                  NOT NULL,
+    identifier   TEXT                     NOT NULL,
+    title        TEXT,
+    author       TEXT,
+    duration_ms  BIGINT,
+    source_name  VARCHAR(32)
+);
+
+CREATE INDEX IF NOT EXISTS idx_music_playlist_item_playlist_position
+    ON public.music_playlist_item (playlist_id, position);

--- a/database/src/test/kotlin/database/service/impl/DefaultMusicPlaylistServiceTest.kt
+++ b/database/src/test/kotlin/database/service/impl/DefaultMusicPlaylistServiceTest.kt
@@ -1,0 +1,122 @@
+package database.service.impl
+
+import database.dto.MusicPlaylistDto
+import database.persistence.MusicPlaylistPersistence
+import database.service.MusicPlaylistService.PlaylistItemInput
+import database.service.MusicPlaylistService.PlaylistNameTakenException
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class DefaultMusicPlaylistServiceTest {
+
+    private val guildId = 100L
+    private val ownerId = 200L
+
+    private lateinit var persistence: MusicPlaylistPersistence
+    private lateinit var service: DefaultMusicPlaylistService
+
+    @BeforeEach
+    fun setUp() {
+        persistence = mockk(relaxed = true)
+        service = DefaultMusicPlaylistService(persistence)
+    }
+
+    @Test
+    fun `create rejects blank name`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            service.create(guildId, ownerId, "   ", listOf(item("a")))
+        }
+    }
+
+    @Test
+    fun `create rejects empty item list`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            service.create(guildId, ownerId, "Mix", emptyList())
+        }
+    }
+
+    @Test
+    fun `create rejects name longer than 80 chars`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            service.create(guildId, ownerId, "x".repeat(81), listOf(item("a")))
+        }
+    }
+
+    @Test
+    fun `create throws PlaylistNameTakenException on duplicate`() {
+        every { persistence.getByGuildOwnerAndName(guildId, ownerId, "Mix") } returns
+            MusicPlaylistDto(id = 1L, guildId = guildId, ownerDiscordId = ownerId, name = "Mix")
+        assertThrows(PlaylistNameTakenException::class.java) {
+            service.create(guildId, ownerId, "Mix", listOf(item("a")))
+        }
+    }
+
+    @Test
+    fun `create trims name before persisting`() {
+        every { persistence.getByGuildOwnerAndName(any(), any(), any()) } returns null
+        val captured = slot<MusicPlaylistDto>()
+        every { persistence.save(capture(captured)) } answers { captured.captured }
+        service.create(guildId, ownerId, "  Mix  ", listOf(item("a")))
+        assertEquals("Mix", captured.captured.name)
+    }
+
+    @Test
+    fun `create assigns positions in input order`() {
+        every { persistence.getByGuildOwnerAndName(any(), any(), any()) } returns null
+        val captured = slot<MusicPlaylistDto>()
+        every { persistence.save(capture(captured)) } answers { captured.captured }
+        service.create(guildId, ownerId, "Mix", listOf(item("a"), item("b"), item("c")))
+        val items = captured.captured.items
+        assertEquals(3, items.size)
+        assertEquals("a", items[0].identifier)
+        assertEquals(0, items[0].position)
+        assertEquals("c", items[2].identifier)
+        assertEquals(2, items[2].position)
+    }
+
+    @Test
+    fun `deleteById delegates to persistence`() {
+        every { persistence.deleteById(7L) } just Runs
+        service.deleteById(7L)
+        verify(exactly = 1) { persistence.deleteById(7L) }
+    }
+
+    @Test
+    fun `listForGuild delegates to persistence`() {
+        val expected = listOf(MusicPlaylistDto(id = 1L, guildId = guildId, name = "x"))
+        every { persistence.listByGuild(guildId) } returns expected
+        assertSame(expected, service.listForGuild(guildId))
+    }
+
+    @Test
+    fun `listForUserInGuild delegates to persistence`() {
+        val expected = listOf(MusicPlaylistDto(id = 1L, guildId = guildId, ownerDiscordId = ownerId, name = "x"))
+        every { persistence.listByGuildAndOwner(guildId, ownerId) } returns expected
+        assertSame(expected, service.listForUserInGuild(guildId, ownerId))
+    }
+
+    @Test
+    fun `getById delegates to persistence`() {
+        val expected = MusicPlaylistDto(id = 1L, name = "x")
+        every { persistence.getById(1L) } returns expected
+        assertSame(expected, service.getById(1L))
+    }
+
+    private fun item(id: String) = PlaylistItemInput(
+        identifier = id,
+        title = "title-$id",
+        author = "author-$id",
+        durationMs = 60_000L,
+        sourceName = "youtube",
+    )
+}

--- a/discord-bot/build.gradle
+++ b/discord-bot/build.gradle
@@ -44,6 +44,11 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinx_version"
     implementation "dev.lavalink.youtube:common:$youtube_common_version"
+    // LavaSrc adds Spotify/Apple Music/Deezer/Yandex Music sources. The
+    // separate `lavasrc-protocol-jvm` artifact is only needed by Lavalink
+    // plugins for REST wire-format serialisation; direct lavaplayer use
+    // doesn't reference any of those types.
+    implementation "com.github.topi314.lavasrc:lavasrc:$lavasrc_version"
     runtimeOnly "dev.arbjerg:lavaplayer-natives:$lavaplayer_version"
     implementation "moe.kyokobot.libdave:adapter-jda:0.1.0"
     implementation "moe.kyokobot.libdave:impl-jni:0.1.0"

--- a/discord-bot/src/main/kotlin/bot/configuration/MusicGatewayConfig.kt
+++ b/discord-bot/src/main/kotlin/bot/configuration/MusicGatewayConfig.kt
@@ -1,0 +1,30 @@
+package bot.configuration
+
+import bot.toby.lavaplayer.JdaSupplier
+import bot.toby.lavaplayer.SchedulerEvents
+import net.dv8tion.jda.api.JDA
+import org.springframework.beans.factory.ObjectProvider
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class MusicGatewayConfig(
+    applicationEventPublisher: ApplicationEventPublisher,
+) {
+
+    init {
+        // TrackScheduler is not a Spring bean (it's instantiated by
+        // PlayerManager's companion singleton), so we bridge to the Spring
+        // event bus via a static holder. Wiring it in the @Configuration's
+        // constructor runs once at context startup, well before JDA goes
+        // online — early enough that any event the scheduler publishes will
+        // find a live publisher.
+        SchedulerEvents.publisher = applicationEventPublisher
+    }
+
+    @Bean
+    fun jdaSupplier(jdaProvider: ObjectProvider<JDA>): JdaSupplier = JdaSupplier {
+        jdaProvider.ifAvailable
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/music/player/NowDigOnThisCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/music/player/NowDigOnThisCommand.kt
@@ -1,8 +1,8 @@
 package bot.toby.command.commands.music.player
 
 import bot.toby.command.commands.music.MusicCommand
-import bot.toby.helpers.URLHelper
 import bot.toby.lavaplayer.PlayerManager
+import bot.toby.lavaplayer.SearchPrefixResolver
 import bot.toby.util.adjustTrackPlayingTimes
 import core.command.Command.Companion.replyAndDelete
 import core.command.CommandContext
@@ -46,10 +46,7 @@ class NowDigOnThisCommand : MusicCommand {
 
         if (MusicCommand.isInvalidChannelStateForCommand(ctx, deleteDelay)) return
 
-        var link = linkOption
-        if (link.contains("youtube") && !URLHelper.isValidURL(link)) {
-            link = "ytsearch:$link"
-        }
+        val link = SearchPrefixResolver.resolve(linkOption)
 
         val startPosition = adjustTrackPlayingTimes(event.getOption(START_POSITION)?.asLong ?: 0L)
         val musicManager = instance.getMusicManager(ctx.guild)

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/music/player/PlayCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/music/player/PlayCommand.kt
@@ -3,8 +3,8 @@ package bot.toby.command.commands.music.player
 import bot.toby.command.commands.music.MusicCommand
 import bot.toby.helpers.MusicPlayerHelper
 import bot.toby.lavaplayer.PlayerManager
+import bot.toby.lavaplayer.SearchPrefixResolver
 import bot.toby.util.adjustTrackPlayingTimes
-import bot.toby.util.isUrl
 import core.command.CommandContext
 import database.dto.UserDto
 import net.dv8tion.jda.api.interactions.commands.OptionType
@@ -42,10 +42,7 @@ class PlayCommand : MusicCommand {
             )
 
             "link" -> {
-                var link = event.getOption(LINK)?.asString ?: ""
-                if (link.contains("youtube") && isUrl(link).isEmpty()) {
-                    link = "ytsearch:$link"
-                }
+                val link = SearchPrefixResolver.resolve(event.getOption(LINK)?.asString.orEmpty())
                 instance.loadAndPlay(guild, event, link, true, deleteDelay, startPosition, volume)
             }
 

--- a/discord-bot/src/main/kotlin/bot/toby/helpers/MusicPlayerHelper.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/helpers/MusicPlayerHelper.kt
@@ -75,9 +75,12 @@ object MusicPlayerHelper {
 
         if (checkForPlayingTrack(track, hook, deleteDelay)) return
 
-        val embed = nowPlayingManager.buildNowPlayingMessageData(track, audioPlayer, clipStart, clipEnd)
+        val guild = event.guild!!
+        val embed = nowPlayingManager.buildNowPlayingMessageData(
+            track, audioPlayer, clipStart, clipEnd, musicManager.scheduler, guild,
+        )
         val (pausePlayButton, stopButton) = generateButtons()
-        val guildId = event.guild!!.idLong
+        val guildId = guild.idLong
         val nowPlayingInfo = nowPlayingManager.getLastNowPlayingMessage(guildId)
 
         if (nowPlayingInfo != null) {
@@ -96,7 +99,9 @@ object MusicPlayerHelper {
                     nowPlayingManager.setNowPlayingMessage(guildId, it)
                 }
         }
-        nowPlayingManager.scheduleNowPlayingUpdate(guildId, track, audioPlayer, 0L, 3L, clipStart, clipEnd)
+        nowPlayingManager.scheduleNowPlayingUpdate(
+            guildId, track, audioPlayer, 0L, 3L, clipStart, clipEnd, musicManager.scheduler, guild,
+        )
     }
 
     private fun checkForPlayingTrack(track: AudioTrack?, hook: InteractionHook, deleteDelay: Int): Boolean {

--- a/discord-bot/src/main/kotlin/bot/toby/lavaplayer/MusicControlGatewayImpl.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/lavaplayer/MusicControlGatewayImpl.kt
@@ -1,0 +1,242 @@
+package bot.toby.lavaplayer
+
+import bot.toby.lavaplayer.TrackInfoMapper.toTrackInfo
+import com.sedmelluq.discord.lavaplayer.player.AudioLoadResultHandler
+import com.sedmelluq.discord.lavaplayer.tools.FriendlyException
+import com.sedmelluq.discord.lavaplayer.track.AudioPlaylist
+import com.sedmelluq.discord.lavaplayer.track.AudioTrack
+import common.logging.DiscordLogger
+import core.music.MusicControlGateway
+import core.music.MusicControlGateway.GuildPlayerState
+import core.music.MusicControlGateway.LoadResult
+import core.music.MusicControlGateway.TrackInfo
+import core.music.MusicControlGateway.VoiceChannelInfo
+import core.music.MusicControlGateway.VoiceMember
+import core.music.events.LoopStateChangedEvent
+import core.music.events.VolumeChangedEvent
+import net.dv8tion.jda.api.JDA
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+
+@Component
+class MusicControlGatewayImpl @Autowired(required = false) constructor(
+    private val jdaSupplier: JdaSupplier? = null,
+) : MusicControlGateway {
+
+    private val logger: DiscordLogger = DiscordLogger.createLogger(this::class.java)
+
+    private val playerManager: PlayerManager get() = PlayerManager.instance
+
+    private fun jda(): JDA? = jdaSupplier?.get()
+
+    override fun getState(guildId: Long): GuildPlayerState? {
+        val jda = jda() ?: return null
+        val guild = jda.getGuildById(guildId) ?: return null
+        val musicManager = playerManager.getMusicManager(guild)
+        val audioPlayer = musicManager.audioPlayer
+        val scheduler = musicManager.scheduler
+        val playing = audioPlayer.playingTrack
+        val queueSnapshot = synchronized(scheduler.queue) { scheduler.queue.toList() }
+        val voiceChannel = guild.audioManager.connectedChannel
+        val voiceInfo = voiceChannel?.let { channel ->
+            VoiceChannelInfo(
+                id = channel.idLong,
+                name = channel.name,
+                members = channel.members.map { member ->
+                    val voiceState = member.voiceState
+                    VoiceMember(
+                        discordId = member.idLong,
+                        displayName = member.effectiveName,
+                        avatarUrl = member.effectiveAvatarUrl,
+                        isBot = member.user.isBot,
+                        isMuted = voiceState?.isMuted == true || voiceState?.isSelfMuted == true,
+                        isDeafened = voiceState?.isDeafened == true || voiceState?.isSelfDeafened == true,
+                    )
+                },
+            )
+        }
+        return GuildPlayerState(
+            guildId = guildId,
+            nowPlaying = playing?.let { toTrackInfo(it, scheduler.getRequesterId(it)) },
+            positionMs = playing?.position ?: 0L,
+            paused = audioPlayer.isPaused,
+            volume = audioPlayer.volume,
+            looping = scheduler.isLooping,
+            queue = queueSnapshot.map { toTrackInfo(it, scheduler.getRequesterId(it)) },
+            voiceChannelId = voiceChannel?.idLong,
+            voiceChannel = voiceInfo,
+        )
+    }
+
+    override fun search(guildId: Long, query: String, limit: Int): List<TrackInfo> {
+        val jda = jda() ?: return emptyList()
+        val guild = jda.getGuildById(guildId) ?: return emptyList()
+        val resolved = SearchPrefixResolver.resolve(query)
+        val resultRef = AtomicReference<List<TrackInfo>>(emptyList())
+        val latch = java.util.concurrent.CountDownLatch(1)
+
+        playerManager.loadForExternal(
+            guild,
+            resolved,
+            object : AudioLoadResultHandler {
+                override fun trackLoaded(track: AudioTrack) {
+                    resultRef.set(listOf(toTrackInfo(track, null)))
+                    latch.countDown()
+                }
+
+                override fun playlistLoaded(playlist: AudioPlaylist) {
+                    resultRef.set(playlist.tracks.take(limit).map { toTrackInfo(it, null) })
+                    latch.countDown()
+                }
+
+                override fun noMatches() {
+                    latch.countDown()
+                }
+
+                override fun loadFailed(exception: FriendlyException) {
+                    logger.warn { "Search failed for query=$resolved: ${exception.message}" }
+                    latch.countDown()
+                }
+            },
+        )
+
+        latch.await(8, TimeUnit.SECONDS)
+        return resultRef.get()
+    }
+
+    override fun load(guildId: Long, query: String, requesterDiscordId: Long): LoadResult {
+        val jda = jda() ?: return LoadResult(false, 0, "Bot not connected to Discord")
+        val guild = jda.getGuildById(guildId) ?: return LoadResult(false, 0, "Guild not found")
+        if (guild.audioManager.connectedChannel == null) {
+            return LoadResult(false, 0, "Bot must be in a voice channel — join one with /join first")
+        }
+        val musicManager = playerManager.getMusicManager(guild)
+        val resolvedQuery = SearchPrefixResolver.resolve(query)
+        val resultRef = AtomicReference<LoadResult?>(null)
+        val latch = java.util.concurrent.CountDownLatch(1)
+
+        playerManager.loadForExternal(
+            guild,
+            resolvedQuery,
+            object : AudioLoadResultHandler {
+                override fun trackLoaded(track: AudioTrack) {
+                    musicManager.scheduler.queue(
+                        track,
+                        startPosition = 0L,
+                        endPosition = null,
+                        volume = musicManager.audioPlayer.volume,
+                        requesterId = requesterDiscordId,
+                    )
+                    resultRef.set(LoadResult(true, 1, null))
+                    latch.countDown()
+                }
+
+                override fun playlistLoaded(playlist: AudioPlaylist) {
+                    val volume = musicManager.audioPlayer.volume
+                    playlist.tracks.forEach { track ->
+                        musicManager.scheduler.queue(track, 0L, null, volume, requesterDiscordId)
+                    }
+                    resultRef.set(LoadResult(true, playlist.tracks.size, null))
+                    latch.countDown()
+                }
+
+                override fun noMatches() {
+                    resultRef.set(LoadResult(false, 0, "No matches for '$resolvedQuery'"))
+                    latch.countDown()
+                }
+
+                override fun loadFailed(exception: FriendlyException) {
+                    logger.error { "Track load failed for query=$resolvedQuery: ${exception.message}" }
+                    resultRef.set(LoadResult(false, 0, exception.message ?: "Load failed"))
+                    latch.countDown()
+                }
+            },
+        )
+
+        val completed = latch.await(8, TimeUnit.SECONDS)
+        return resultRef.get() ?: if (completed) {
+            LoadResult(false, 0, "Load completed without result")
+        } else {
+            LoadResult(false, 0, "Load timed out after 8s")
+        }
+    }
+
+    override fun pause(guildId: Long): Boolean = mutate(guildId) { mm ->
+        if (mm.audioPlayer.isPaused) return@mutate false
+        mm.audioPlayer.isPaused = true
+        true
+    }
+
+    override fun resume(guildId: Long): Boolean = mutate(guildId) { mm ->
+        if (!mm.audioPlayer.isPaused) return@mutate false
+        mm.audioPlayer.isPaused = false
+        true
+    }
+
+    override fun skip(guildId: Long, count: Int): Boolean = mutate(guildId) { mm ->
+        if (count <= 0) return@mutate false
+        repeat(count) { mm.scheduler.nextTrack() }
+        true
+    }
+
+    override fun stop(guildId: Long): Boolean = mutate(guildId) { mm ->
+        mm.scheduler.stopTrack(true)
+        mm.scheduler.queue.clear()
+        mm.scheduler.isLooping = false
+        mm.audioPlayer.isPaused = false
+        mm.scheduler.publishQueueChanged()
+        true
+    }
+
+    override fun setVolume(guildId: Long, volume: Int): Boolean {
+        val clamped = volume.coerceIn(0, 150)
+        return mutate(guildId) { mm ->
+            mm.audioPlayer.volume = clamped
+            SchedulerEvents.publish(VolumeChangedEvent(guildId, clamped))
+            true
+        }
+    }
+
+    override fun seek(guildId: Long, positionMs: Long): Boolean = mutate(guildId) { mm ->
+        if (positionMs < 0) return@mutate false
+        val track = mm.audioPlayer.playingTrack ?: return@mutate false
+        if (positionMs > track.duration) return@mutate false
+        track.position = positionMs
+        true
+    }
+
+    override fun reorderQueue(guildId: Long, fromIndex: Int, toIndex: Int): Boolean = mutate(guildId) { mm ->
+        mm.scheduler.moveQueueItem(fromIndex, toIndex)
+    }
+
+    override fun removeFromQueue(guildId: Long, index: Int): TrackInfo? {
+        val jda = jda() ?: return null
+        val guild = jda.getGuildById(guildId) ?: return null
+        val mm = playerManager.getMusicManager(guild)
+        val removed = mm.scheduler.removeQueueItem(index) ?: return null
+        return toTrackInfo(removed, requesterId = null)
+    }
+
+    override fun setLooping(guildId: Long, looping: Boolean): Boolean = mutate(guildId) { mm ->
+        if (mm.scheduler.isLooping == looping) return@mutate true
+        mm.scheduler.isLooping = looping
+        SchedulerEvents.publish(LoopStateChangedEvent(guildId, looping))
+        true
+    }
+
+    private inline fun mutate(guildId: Long, crossinline action: (GuildMusicManager) -> Boolean): Boolean {
+        val jda = jda() ?: return false
+        val guild = jda.getGuildById(guildId) ?: return false
+        return action(playerManager.getMusicManager(guild))
+    }
+}
+
+/**
+ * Allows tests to inject a no-JDA shim. In production the bot wires this via
+ * its JDA bootstrap.
+ */
+fun interface JdaSupplier {
+    fun get(): JDA?
+}

--- a/discord-bot/src/main/kotlin/bot/toby/lavaplayer/PlayerManager.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/lavaplayer/PlayerManager.kt
@@ -1,12 +1,20 @@
 package bot.toby.lavaplayer
 
+import com.github.topi314.lavasrc.applemusic.AppleMusicSourceManager
+import com.github.topi314.lavasrc.deezer.DeezerAudioSourceManager
+import com.github.topi314.lavasrc.mirror.DefaultMirroringAudioTrackResolver
+import com.github.topi314.lavasrc.spotify.SpotifySourceManager
+import com.github.topi314.lavasrc.yandexmusic.YandexMusicSourceManager
 import com.sedmelluq.discord.lavaplayer.player.AudioLoadResultHandler
 import com.sedmelluq.discord.lavaplayer.player.AudioPlayerManager
 import com.sedmelluq.discord.lavaplayer.player.DefaultAudioPlayerManager
-import com.sedmelluq.discord.lavaplayer.source.AudioSourceManagers
+import com.sedmelluq.discord.lavaplayer.source.bandcamp.BandcampAudioSourceManager
 import com.sedmelluq.discord.lavaplayer.source.http.HttpAudioSourceManager
 import com.sedmelluq.discord.lavaplayer.source.local.LocalAudioSourceManager
+import com.sedmelluq.discord.lavaplayer.source.nico.NicoAudioSourceManager
+import com.sedmelluq.discord.lavaplayer.source.soundcloud.SoundCloudAudioSourceManager
 import com.sedmelluq.discord.lavaplayer.source.twitch.TwitchStreamAudioSourceManager
+import com.sedmelluq.discord.lavaplayer.source.vimeo.VimeoAudioSourceManager
 import com.sedmelluq.discord.lavaplayer.tools.FriendlyException
 import com.sedmelluq.discord.lavaplayer.track.AudioPlaylist
 import com.sedmelluq.discord.lavaplayer.track.AudioTrack
@@ -21,10 +29,19 @@ import dev.lavalink.youtube.clients.TvHtml5Simply
 import dev.lavalink.youtube.clients.Web
 import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
+import java.util.function.Function
 
 private const val CIPHER_API_URL = "https://cipher.kikkia.dev/api"
 
 private const val GOOGLE_REFRESH_TOKEN = "GOOGLE_REFRESH_TOKEN"
+private const val SPOTIFY_CLIENT_ID = "SPOTIFY_CLIENT_ID"
+private const val SPOTIFY_CLIENT_SECRET = "SPOTIFY_CLIENT_SECRET"
+private const val SPOTIFY_COUNTRY = "SPOTIFY_COUNTRY"
+private const val APPLE_MUSIC_MEDIA_API_TOKEN = "APPLE_MUSIC_MEDIA_API_TOKEN"
+private const val APPLE_MUSIC_COUNTRY = "APPLE_MUSIC_COUNTRY"
+private const val DEEZER_MASTER_KEY = "DEEZER_MASTER_KEY"
+private const val DEEZER_ARL = "DEEZER_ARL"
+private const val YANDEX_ACCESS_TOKEN = "YANDEX_ACCESS_TOKEN"
 
 private val logger: DiscordLogger = DiscordLogger.createLogger(PlayerManager::class.java)
 
@@ -50,11 +67,83 @@ class PlayerManager(private val audioPlayerManager: AudioPlayerManager) {
         }
 
         audioPlayerManager.registerSourceManager(youtubeAudioSourceManager)
+        audioPlayerManager.registerSourceManager(SoundCloudAudioSourceManager.createDefault())
+        audioPlayerManager.registerSourceManager(BandcampAudioSourceManager())
+        audioPlayerManager.registerSourceManager(VimeoAudioSourceManager())
+        audioPlayerManager.registerSourceManager(NicoAudioSourceManager())
         audioPlayerManager.registerSourceManager(TwitchStreamAudioSourceManager())
         audioPlayerManager.registerSourceManager(HttpAudioSourceManager())
         audioPlayerManager.registerSourceManager(LocalAudioSourceManager())
-        AudioSourceManagers.registerLocalSource(this.audioPlayerManager)
+
+        registerLavaSrcManagers()
     }
+
+    private fun registerLavaSrcManagers() {
+        val playerManagerSupplier = Function<Void, AudioPlayerManager> { audioPlayerManager }
+
+        registerSpotify(playerManagerSupplier)
+        registerAppleMusic(playerManagerSupplier)
+        registerDeezer()
+        registerYandex()
+    }
+
+    private fun registerSpotify(supplier: Function<Void, AudioPlayerManager>) {
+        val id = envOrNull(SPOTIFY_CLIENT_ID)
+        val secret = envOrNull(SPOTIFY_CLIENT_SECRET)
+        if (id == null || secret == null) {
+            warnDisabled("Spotify", SPOTIFY_CLIENT_ID, SPOTIFY_CLIENT_SECRET)
+            return
+        }
+        val country = envOrNull(SPOTIFY_COUNTRY) ?: "US"
+        audioPlayerManager.registerSourceManager(
+            SpotifySourceManager(id, secret, country, supplier, defaultMirroringResolver()),
+        )
+        logger.info { "Spotify source manager registered (country=$country)." }
+    }
+
+    private fun registerAppleMusic(supplier: Function<Void, AudioPlayerManager>) {
+        val token = envOrNull(APPLE_MUSIC_MEDIA_API_TOKEN) ?: run {
+            warnDisabled("Apple Music", APPLE_MUSIC_MEDIA_API_TOKEN)
+            return
+        }
+        val country = envOrNull(APPLE_MUSIC_COUNTRY) ?: "us"
+        audioPlayerManager.registerSourceManager(
+            AppleMusicSourceManager(token, country, supplier, defaultMirroringResolver()),
+        )
+        logger.info { "Apple Music source manager registered (country=$country)." }
+    }
+
+    private fun registerDeezer() {
+        val key = envOrNull(DEEZER_MASTER_KEY) ?: run {
+            warnDisabled("Deezer", DEEZER_MASTER_KEY)
+            return
+        }
+        val arl = envOrNull(DEEZER_ARL)
+        audioPlayerManager.registerSourceManager(DeezerAudioSourceManager(key, arl))
+        logger.info { "Deezer source manager registered (arl=${if (arl != null) "set" else "absent"})." }
+    }
+
+    private fun registerYandex() {
+        val token = envOrNull(YANDEX_ACCESS_TOKEN) ?: run {
+            warnDisabled("Yandex Music", YANDEX_ACCESS_TOKEN)
+            return
+        }
+        audioPlayerManager.registerSourceManager(YandexMusicSourceManager(token))
+        logger.info { "Yandex Music source manager registered." }
+    }
+
+    private fun envOrNull(name: String): String? =
+        System.getenv(name)?.takeIf { it.isNotBlank() }
+
+    private fun warnDisabled(sourceName: String, vararg requiredEnv: String) {
+        logger.warn { "${requiredEnv.joinToString(" / ")} not set — $sourceName disabled." }
+    }
+
+    // Shared search-provider chain used by sources that can't stream directly
+    // (Spotify, Apple Music) — look up by ISRC first, fall back to a free-text
+    // YouTube query.
+    private fun defaultMirroringResolver() =
+        DefaultMirroringAudioTrackResolver(arrayOf("ytsearch:\"%ISRC%\"", "ytsearch:%QUERY%"))
 
     fun getMusicManager(guild: Guild): GuildMusicManager {
         return musicManagers.computeIfAbsent(guild.idLong) {
@@ -108,18 +197,19 @@ class PlayerManager(private val audioPlayerManager: AudioPlayerManager) {
     ): AudioLoadResultHandler {
         return object : AudioLoadResultHandler {
             private val scheduler: TrackScheduler = musicManager.scheduler
+            private val requesterId: Long? = event?.member?.idLong
 
             override fun trackLoaded(track: AudioTrack) {
                 scheduler.event = event
                 scheduler.deleteDelay = deleteDelay
-                scheduler.queue(track, startPosition, endPosition, volume)
+                scheduler.queue(track, startPosition, endPosition, volume, requesterId)
                 scheduler.setPreviousVolume(previousVolume)
             }
 
             override fun playlistLoaded(playlist: AudioPlaylist) {
                 scheduler.event = event
                 scheduler.deleteDelay = deleteDelay
-                scheduler.queueTrackList(playlist, volume)
+                scheduler.queueTrackList(playlist, volume, requesterId)
             }
 
             override fun noMatches() {
@@ -134,6 +224,19 @@ class PlayerManager(private val audioPlayerManager: AudioPlayerManager) {
                 event?.hook?.replyAndDelete("Could not play: ${exception.message}", deleteDelay)
             }
         }
+    }
+
+    /**
+     * Web/gateway entry point: load a track or playlist via a custom result handler,
+     * bypassing the slash-command-specific reply hooks in [getResultHandler].
+     */
+    fun loadForExternal(
+        guild: Guild,
+        trackUrl: String,
+        handler: AudioLoadResultHandler,
+    ) {
+        val musicManager = getMusicManager(guild)
+        audioPlayerManager.loadItemOrdered(musicManager, trackUrl, handler)
     }
 
     fun destroyMusicManager(guildId: Long) {

--- a/discord-bot/src/main/kotlin/bot/toby/lavaplayer/SchedulerEvents.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/lavaplayer/SchedulerEvents.kt
@@ -1,0 +1,20 @@
+package bot.toby.lavaplayer
+
+import org.springframework.context.ApplicationEventPublisher
+
+/**
+ * TrackScheduler / GuildMusicManager / PlayerManager are not Spring beans (they're constructed
+ * by the PlayerManager singleton), so this static hook bridges them to the Spring event bus.
+ *
+ * A @Configuration in the application module sets `publisher` after ApplicationReadyEvent
+ * fires. Until then, calls to [publish] are silent no-ops, which keeps unit tests of
+ * TrackScheduler free of Spring wiring.
+ */
+object SchedulerEvents {
+    @Volatile
+    var publisher: ApplicationEventPublisher? = null
+
+    fun publish(event: Any) {
+        publisher?.publishEvent(event)
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/lavaplayer/SearchPrefixResolver.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/lavaplayer/SearchPrefixResolver.kt
@@ -1,0 +1,26 @@
+package bot.toby.lavaplayer
+
+import bot.toby.util.isUrl
+
+object SearchPrefixResolver {
+    private val EXPLICIT_PREFIXES = setOf(
+        "ytsearch:",
+        "ytmsearch:",
+        "scsearch:",
+        "spsearch:",
+        "sprec:",
+        "dzsearch:",
+        "dzisrc:",
+        "amsearch:",
+        "ymsearch:",
+        "ymrec:",
+    )
+
+    fun resolve(input: String, defaultPrefix: String = "ytsearch:"): String {
+        val trimmed = input.trim()
+        if (trimmed.isEmpty()) return trimmed
+        if (isUrl(trimmed).isNotEmpty()) return trimmed
+        if (EXPLICIT_PREFIXES.any { trimmed.startsWith(it, ignoreCase = true) }) return trimmed
+        return "$defaultPrefix$trimmed"
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/lavaplayer/TrackInfoMapper.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/lavaplayer/TrackInfoMapper.kt
@@ -1,0 +1,22 @@
+package bot.toby.lavaplayer
+
+import com.sedmelluq.discord.lavaplayer.track.AudioTrack
+import core.music.MusicControlGateway.TrackInfo
+
+object TrackInfoMapper {
+    fun toTrackInfo(track: AudioTrack, requesterId: Long?): TrackInfo {
+        val info = track.info
+        val sourceName = runCatching { track.sourceManager?.sourceName }.getOrNull()
+        return TrackInfo(
+            identifier = info.identifier,
+            title = info.title,
+            author = info.author,
+            durationMs = track.duration,
+            uri = info.uri,
+            artworkUrl = info.artworkUrl,
+            sourceName = sourceName,
+            isStream = info.isStream,
+            requesterDiscordId = requesterId,
+        )
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/lavaplayer/TrackScheduler.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/lavaplayer/TrackScheduler.kt
@@ -13,20 +13,27 @@ import com.sedmelluq.discord.lavaplayer.track.TrackMarkerHandler
 import common.logging.DiscordLogger
 import core.command.Command.Companion.invokeDeleteOnMessageResponse
 import core.command.Command.Companion.replyAndDelete
+import core.music.events.PauseStateChangedEvent
+import core.music.events.QueueChangedEvent
+import core.music.events.TrackEndedEvent
+import core.music.events.TrackStartedEvent
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
 import java.util.concurrent.BlockingQueue
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.LinkedBlockingQueue
 
-class TrackScheduler(val player: AudioPlayer, private val guildId: Long, var deleteDelay: Int = 5) : AudioEventAdapter() {
+class TrackScheduler(val player: AudioPlayer, val guildId: Long, var deleteDelay: Int = 5) : AudioEventAdapter() {
     var queue: BlockingQueue<AudioTrack> = LinkedBlockingQueue(100)
     var isLooping: Boolean = false
     var event: SlashCommandInteractionEvent? = null
     private var previousVolume: Int? = null
     private val logger: DiscordLogger = DiscordLogger.createLogger(this::class.java)
     private val trackClipBounds = ConcurrentHashMap<AudioTrack, Pair<Long, Long>>()
+    private val trackRequesters = ConcurrentHashMap<AudioTrack, Long>()
 
-    fun queue(track: AudioTrack, startPosition: Long, endPosition: Long?, volume: Int) {
+    fun getRequesterId(track: AudioTrack): Long? = trackRequesters[track]
+
+    fun queue(track: AudioTrack, startPosition: Long, endPosition: Long?, volume: Int, requesterId: Long? = null) {
         logger.info("Adding ${track.info.title} by ${track.info.author} to the queue for guild $guildId")
         val endNote = endPosition?.let { " (clipped to $it ms)" }.orEmpty()
         event?.hook?.replyAndDelete(
@@ -35,6 +42,7 @@ class TrackScheduler(val player: AudioPlayer, private val guildId: Long, var del
         )
         track.position = startPosition
         track.userData = volume
+        requesterId?.let { trackRequesters[track] = it }
         if (endPosition != null && endPosition > startPosition) {
             trackClipBounds[track] = startPosition to endPosition
             track.setMarker(TrackMarker(endPosition) { state ->
@@ -52,13 +60,14 @@ class TrackScheduler(val player: AudioPlayer, private val guildId: Long, var del
                 queue.offer(track)
             }
         }
+        publishQueueChanged()
     }
 
     // Back-compat overload for the pre-clip call sites; currently unused but keeps
     // the older signature compiling if anything else still calls it.
-    fun queue(track: AudioTrack, startPosition: Long, volume: Int) = queue(track, startPosition, null, volume)
+    fun queue(track: AudioTrack, startPosition: Long, volume: Int) = queue(track, startPosition, null, volume, null)
 
-    fun queueTrackList(playList: AudioPlaylist, volume: Int) {
+    fun queueTrackList(playList: AudioPlaylist, volume: Int, requesterId: Long? = null) {
         logger.info { "Adding ${playList.name} to the queue for guild $guildId" }
         event?.hook?.replyAndDelete(
             "Adding to queue: `${playList.tracks.size} tracks from playlist ${playList.name}`",
@@ -66,10 +75,12 @@ class TrackScheduler(val player: AudioPlayer, private val guildId: Long, var del
         )
         playList.tracks.forEach { track ->
             track.userData = volume
+            requesterId?.let { trackRequesters[track] = it }
             if (!player.startTrack(track, true)) {
                 queue.offer(track)
             }
         }
+        publishQueueChanged()
     }
 
     fun nextTrack() {
@@ -86,15 +97,29 @@ class TrackScheduler(val player: AudioPlayer, private val guildId: Long, var del
         player.volume = track.userData as Int
         val (clipStart, clipEnd) = trackClipBounds[track]?.let { it.first to it.second } ?: (null to null)
         event?.let { nowPlaying(it, PlayerManager.instance, deriveDeleteDelayFromTrack(track), clipStart, clipEnd) }
+        SchedulerEvents.publish(TrackStartedEvent(guildId, TrackInfoMapper.toTrackInfo(track, trackRequesters[track])))
+        publishQueueChanged()
     }
 
     override fun onTrackEnd(player: AudioPlayer, track: AudioTrack, endReason: AudioTrackEndReason) {
         trackClipBounds.remove(track)
+        trackRequesters.remove(track)
         event?.guild?.idLong.resetMessagesForGuildId()
         logger.info("${track.info.title} by ${track.info.author} ended")
+        SchedulerEvents.publish(TrackEndedEvent(guildId, endReason.name))
         if (endReason.mayStartNext) {
             handleNextTrack(player, track)
         }
+    }
+
+    override fun onPlayerPause(player: AudioPlayer) {
+        super.onPlayerPause(player)
+        SchedulerEvents.publish(PauseStateChangedEvent(guildId, true))
+    }
+
+    override fun onPlayerResume(player: AudioPlayer) {
+        super.onPlayerResume(player)
+        SchedulerEvents.publish(PauseStateChangedEvent(guildId, false))
     }
 
     private fun handleNextTrack(player: AudioPlayer, track: AudioTrack) {
@@ -128,6 +153,45 @@ class TrackScheduler(val player: AudioPlayer, private val guildId: Long, var del
                 ?.queue(invokeDeleteOnMessageResponse(deleteDelay))
             nextTrack()
         }
+    }
+
+    fun moveQueueItem(fromIndex: Int, toIndex: Int): Boolean {
+        val moved = synchronized(queue) {
+            val snapshot = queue.toMutableList()
+            if (fromIndex < 0 || fromIndex >= snapshot.size) return@synchronized false
+            if (toIndex < 0 || toIndex >= snapshot.size) return@synchronized false
+            if (fromIndex == toIndex) return@synchronized true
+            val item = snapshot.removeAt(fromIndex)
+            snapshot.add(toIndex, item)
+            queue.clear()
+            snapshot.forEach { queue.offer(it) }
+            true
+        }
+        if (moved) publishQueueChanged()
+        return moved
+    }
+
+    fun removeQueueItem(index: Int): AudioTrack? {
+        val removed = synchronized(queue) {
+            val snapshot = queue.toMutableList()
+            if (index < 0 || index >= snapshot.size) return@synchronized null
+            val item = snapshot.removeAt(index)
+            trackRequesters.remove(item)
+            trackClipBounds.remove(item)
+            queue.clear()
+            snapshot.forEach { queue.offer(it) }
+            item
+        }
+        if (removed != null) publishQueueChanged()
+        return removed
+    }
+
+    internal fun publishQueueChanged() {
+        val snapshot = synchronized(queue) {
+            queue.toList()
+        }
+        val tracks = snapshot.map { TrackInfoMapper.toTrackInfo(it, trackRequesters[it]) }
+        SchedulerEvents.publish(QueueChangedEvent(guildId, tracks))
     }
 
     fun stopTrack(isStoppable: Boolean): Boolean {

--- a/discord-bot/src/main/kotlin/bot/toby/managers/NowPlayingManager.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/managers/NowPlayingManager.kt
@@ -1,13 +1,17 @@
 package bot.toby.managers
 
+import bot.toby.lavaplayer.TrackScheduler
+import bot.toby.util.ProgressBar
+import bot.toby.util.SourceBadges
 import bot.toby.util.formatTime
 import com.sedmelluq.discord.lavaplayer.player.AudioPlayer
 import com.sedmelluq.discord.lavaplayer.track.AudioTrack
+import com.sedmelluq.discord.lavaplayer.track.AudioTrackInfo
 import common.logging.DiscordLogger
 import net.dv8tion.jda.api.EmbedBuilder
+import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.entities.Message
 import net.dv8tion.jda.api.entities.MessageEmbed
-import java.awt.Color
 import java.util.concurrent.*
 import java.util.concurrent.locks.ReentrantReadWriteLock
 import kotlin.concurrent.read
@@ -49,7 +53,7 @@ class NowPlayingManager(
                 logger.info { "Attempting to delete now playing message ${message.idLong} for guild $guildId" }
                 message.delete().submit().whenComplete { _, error ->
                     if (error != null) {
-                        logger.error{ "Failed to delete now playing message ${message.idLong} for guild $guildId" }
+                        logger.error { "Failed to delete now playing message ${message.idLong} for guild $guildId" }
                     } else {
                         logger.info { "Deleted now playing message ${message.idLong} for guild $guildId" }
                     }
@@ -67,14 +71,16 @@ class NowPlayingManager(
         delay: Long,
         period: Long,
         clipStart: Long? = null,
-        clipEnd: Long? = null
+        clipEnd: Long? = null,
+        trackScheduler: TrackScheduler? = null,
+        guild: Guild? = null,
     ) {
         cancelScheduledTask(guildId)
         val scheduledTask = scheduler.scheduleAtFixedRate({
             try {
-                updateNowPlayingMessage(guildId, track, audioPlayer, clipStart, clipEnd)
-            } catch (e: Exception) {
-                logger.error{ "Error occurred while updating now playing message" }
+                updateNowPlayingMessage(guildId, track, audioPlayer, clipStart, clipEnd, trackScheduler, guild)
+            } catch (_: Exception) {
+                logger.error { "Error occurred while updating now playing message" }
             }
         }, delay, period, TimeUnit.SECONDS)
 
@@ -86,12 +92,22 @@ class NowPlayingManager(
         track: AudioTrack,
         audioPlayer: AudioPlayer,
         clipStart: Long?,
-        clipEnd: Long?
+        clipEnd: Long?,
+        trackScheduler: TrackScheduler?,
+        guild: Guild?,
     ) {
         lock.read {
             val message = guildLastNowPlayingMessage[guildId]
             message?.let {
-                val embed = buildNowPlayingMessageData(track, audioPlayer.volume, audioPlayer.isPaused, clipStart, clipEnd)
+                val embed = buildNowPlayingMessageData(
+                    track,
+                    audioPlayer.volume,
+                    audioPlayer.isPaused,
+                    clipStart,
+                    clipEnd,
+                    trackScheduler,
+                    guild,
+                )
                 message.editMessageEmbeds(embed).queue()
                 logger.info { "Updated now playing message ${message.idLong}" }
             }
@@ -102,42 +118,92 @@ class NowPlayingManager(
         track: AudioTrack,
         audioPlayer: AudioPlayer,
         clipStart: Long? = null,
-        clipEnd: Long? = null
-    ): MessageEmbed {
-        return buildNowPlayingMessageData(track, audioPlayer.volume, audioPlayer.isPaused, clipStart, clipEnd)
-    }
+        clipEnd: Long? = null,
+        trackScheduler: TrackScheduler? = null,
+        guild: Guild? = null,
+    ): MessageEmbed = buildNowPlayingMessageData(
+        track,
+        audioPlayer.volume,
+        audioPlayer.isPaused,
+        clipStart,
+        clipEnd,
+        trackScheduler,
+        guild,
+    )
 
-    private fun buildNowPlayingMessageData(
+    internal fun buildNowPlayingMessageData(
         track: AudioTrack,
         volume: Int,
         isPaused: Boolean,
         clipStart: Long? = null,
-        clipEnd: Long? = null
+        clipEnd: Long? = null,
+        trackScheduler: TrackScheduler? = null,
+        guild: Guild? = null,
     ): MessageEmbed {
         val info = track.info
-        val descriptionBuilder = StringBuilder()
+        val sourceName = runCatching { track.sourceManager?.sourceName }.getOrNull()
+        val badge = SourceBadges.forSource(sourceName)
 
-        descriptionBuilder.append("**Title**: `${info.title}`\n").append("**Author**: `${info.author}`\n")
+        val builder = EmbedBuilder()
+            .setColor(badge.color)
+            .setTitle(info.title.take(256), info.uri.asHttpUrl())
+            .setAuthor(badge.displayName, badge.homeUrl, badge.iconUrl)
+            .setDescription(renderDescription(track, info, clipStart, clipEnd))
 
-        if (!info.isStream) {
+        info.artworkUrl.asHttpUrl()?.let { builder.setThumbnail(it) }
+
+        builder.addField("Volume", "🔊 $volume", true)
+        builder.addField("Paused", if (isPaused) "⏸️ Yes" else "▶️ No", true)
+        builder.addField("Loop", if (trackScheduler?.isLooping == true) "🔁 On" else "Off", true)
+
+        renderUpNext(trackScheduler?.queue?.toList())?.let { builder.addField("Up next", it, false) }
+        resolveRequesterName(trackScheduler, track, guild)?.let { builder.setFooter("Requested by $it") }
+
+        return builder.build()
+    }
+
+    private fun renderDescription(
+        track: AudioTrack,
+        info: AudioTrackInfo,
+        clipStart: Long?,
+        clipEnd: Long?,
+    ): String = buildString {
+        append("By `").append(info.author).append("`\n\n")
+        if (info.isStream) {
+            append("🔴 **LIVE**")
+        } else {
             val effectiveStart = clipStart ?: 0L
             val effectiveEnd = clipEnd ?: track.duration
-            val songPosition = formatTime((track.position - effectiveStart).coerceAtLeast(0L))
-            val songDuration = formatTime((effectiveEnd - effectiveStart).coerceAtLeast(0L))
-            descriptionBuilder.append("**Progress**: `$songPosition / $songDuration`\n")
-        } else {
-            descriptionBuilder.append("**Stream**: `Live`\n")
+            val pos = (track.position - effectiveStart).coerceAtLeast(0L)
+            val dur = (effectiveEnd - effectiveStart).coerceAtLeast(0L)
+            append("`").append(formatTime(pos)).append(" / ").append(formatTime(dur)).append("`\n")
+            append(ProgressBar.render(pos, dur))
         }
-
-        return EmbedBuilder()
-            .setTitle("Now Playing")
-            .setDescription(descriptionBuilder.toString())
-            .addField("Volume", "$volume", true)
-            .setColor(Color.GREEN)
-            .setFooter("Link: ${info.uri}", null)
-            .addField("Paused?", if (isPaused) "yes" else "no", false)
-            .build()
     }
+
+    private fun renderUpNext(queueSnapshot: List<AudioTrack>?): String? {
+        if (queueSnapshot.isNullOrEmpty()) return null
+        val preview = queueSnapshot.take(UP_NEXT_PREVIEW).mapIndexed { i, t ->
+            val title = t.info.title.let { if (it.length > UP_NEXT_TITLE_MAX) it.take(UP_NEXT_TITLE_MAX - 1) + "…" else it }
+            "${i + 1}. `$title`"
+        }.joinToString("\n")
+        val remaining = queueSnapshot.size - UP_NEXT_PREVIEW
+        return if (remaining > 0) "$preview\n_+ $remaining more_" else preview
+    }
+
+    private fun resolveRequesterName(scheduler: TrackScheduler?, track: AudioTrack, guild: Guild?): String? {
+        val rid = scheduler?.getRequesterId(track) ?: return null
+        return guild?.getMemberById(rid)?.effectiveName
+    }
+
+    /**
+     * JDA validates URLs passed to setTitle / setThumbnail; bounce anything
+     * that isn't http(s) (local files, search identifiers, test placeholders)
+     * to null so the embed builder doesn't throw.
+     */
+    private fun String?.asHttpUrl(): String? = this
+        ?.takeIf { it.isNotBlank() }
+        ?.takeIf { it.startsWith("http://") || it.startsWith("https://") }
 
     fun cancelScheduledTask(guildId: Long) {
         lock.write {
@@ -151,5 +217,10 @@ class NowPlayingManager(
             scheduledTasks.values.forEach { it.cancel(true) }
             scheduledTasks.clear()
         }
+    }
+
+    private companion object {
+        const val UP_NEXT_PREVIEW = 3
+        const val UP_NEXT_TITLE_MAX = 50
     }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/util/ProgressBar.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/util/ProgressBar.kt
@@ -1,0 +1,26 @@
+package bot.toby.util
+
+object ProgressBar {
+    // String (not Char) because the handle emoji 🔘 is outside the BMP and
+    // needs a surrogate pair on the JVM. Filled / empty are single-codeunit
+    // BMP chars, but we keep them as String for uniformity.
+    private const val FILLED = "▬" // ▬
+    private const val EMPTY = "—"  // —
+    private const val HANDLE = "🔘" // 🔘 (U+1F518)
+
+    fun render(positionMs: Long, durationMs: Long, cells: Int = 20): String {
+        require(cells > 0) { "cells must be > 0" }
+        if (durationMs <= 0L) return EMPTY.repeat(cells)
+        val ratio = (positionMs.toDouble() / durationMs.toDouble()).coerceIn(0.0, 1.0)
+        val handleIndex = (ratio * (cells - 1)).toInt().coerceIn(0, cells - 1)
+        return buildString {
+            repeat(cells) { i ->
+                when {
+                    i == handleIndex -> append(HANDLE)
+                    i < handleIndex -> append(FILLED)
+                    else -> append(EMPTY)
+                }
+            }
+        }
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/util/SourceBadges.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/util/SourceBadges.kt
@@ -1,0 +1,84 @@
+package bot.toby.util
+
+import java.awt.Color
+
+data class SourceBadge(
+    val displayName: String,
+    val color: Color,
+    val iconUrl: String?,
+    val homeUrl: String?,
+)
+
+object SourceBadges {
+    private val DEFAULT = SourceBadge("Music", Color(0x57F287), null, null)
+
+    private val BADGES: Map<String, SourceBadge> = mapOf(
+        "youtube" to SourceBadge(
+            displayName = "YouTube",
+            color = Color(0xFF0000),
+            iconUrl = "https://www.youtube.com/s/desktop/14a6f4f0/img/favicon_144x144.png",
+            homeUrl = "https://www.youtube.com",
+        ),
+        "spotify" to SourceBadge(
+            displayName = "Spotify",
+            color = Color(0x1DB954),
+            iconUrl = "https://open.scdn.co/cdn/images/favicon32.b64ecc03.png",
+            homeUrl = "https://open.spotify.com",
+        ),
+        "soundcloud" to SourceBadge(
+            displayName = "SoundCloud",
+            color = Color(0xFF5500),
+            iconUrl = "https://a-v2.sndcdn.com/assets/images/sc-icons/favicon-2cadd14bdb.ico",
+            homeUrl = "https://soundcloud.com",
+        ),
+        "applemusic" to SourceBadge(
+            displayName = "Apple Music",
+            color = Color(0xFA243C),
+            iconUrl = "https://music.apple.com/assets/favicon/favicon-180-67f9ec40c4f9c8c80de2c8d11d22fab8.png",
+            homeUrl = "https://music.apple.com",
+        ),
+        "bandcamp" to SourceBadge(
+            displayName = "Bandcamp",
+            color = Color(0x1DA0C3),
+            iconUrl = "https://s4.bcbits.com/img/favicon/favicon-32x32.png",
+            homeUrl = "https://bandcamp.com",
+        ),
+        "vimeo" to SourceBadge(
+            displayName = "Vimeo",
+            color = Color(0x1AB7EA),
+            iconUrl = "https://i.vimeocdn.com/favicon/main-touch_180",
+            homeUrl = "https://vimeo.com",
+        ),
+        "deezer" to SourceBadge(
+            displayName = "Deezer",
+            color = Color(0xA238FF),
+            iconUrl = "https://e-cdns-files.dzcdn.net/cache/images/common/favicon/favicon-32x32.61f8aa8e.png",
+            homeUrl = "https://www.deezer.com",
+        ),
+        "yandexmusic" to SourceBadge(
+            displayName = "Yandex Music",
+            color = Color(0xFFCC00),
+            iconUrl = "https://music.yandex.ru/blocks/common/favicon.ico",
+            homeUrl = "https://music.yandex.ru",
+        ),
+        "twitch" to SourceBadge(
+            displayName = "Twitch",
+            color = Color(0x9146FF),
+            iconUrl = "https://static.twitchcdn.net/assets/favicon-32-d6025c14e900565d6177.png",
+            homeUrl = "https://www.twitch.tv",
+        ),
+        "nico" to SourceBadge(
+            displayName = "Niconico",
+            color = Color(0x252525),
+            iconUrl = null,
+            homeUrl = "https://www.nicovideo.jp",
+        ),
+        "http" to SourceBadge("Direct Stream", Color(0x5865F2), null, null),
+        "local" to SourceBadge("Local File", Color(0x99AAB5), null, null),
+    )
+
+    fun forSource(sourceName: String?): SourceBadge {
+        if (sourceName == null) return DEFAULT
+        return BADGES[sourceName.lowercase()] ?: DEFAULT
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/music/NowDigOnThisCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/music/NowDigOnThisCommandTest.kt
@@ -46,7 +46,7 @@ internal class NowDigOnThisCommandTest : MusicCommandTest {
         every { event.getOption("link") } returns linkOptionalMapping
         every { event.getOption("volume") } returns volumeOptionalMapping
         every { event.getOption("start") } returns mockk(relaxed = true)
-        every { linkOptionalMapping.asString } returns "www.testlink.com"
+        every { linkOptionalMapping.asString } returns "https://www.testlink.com"
         every { volumeOptionalMapping.asInt } returns 20
         every { playerManager.loadAndPlay(any(), any(), any(), any(), any(), any(), any()) } just Runs
 
@@ -78,7 +78,106 @@ internal class NowDigOnThisCommandTest : MusicCommandTest {
             playerManager.loadAndPlay(
                 guild,
                 event,
-                "www.testlink.com",
+                "https://www.testlink.com",
+                false,
+                0,
+                0L,
+                20
+            )
+        }
+    }
+
+    @Test
+    fun test_nowDigOnThisCommand_plainQueryGetsYtsearchPrefix() {
+        setUpAudioChannelsWithBotAndMemberInSameChannel()
+        val commandContext = DefaultCommandContext(event)
+        every { mockAudioPlayer.isPaused } returns false
+        every { playerManager.isCurrentlyStoppable } returns false
+        every { playerManager.getMusicManager(guild) } returns musicManager
+
+        val linkOptionalMapping = mockk<OptionMapping>()
+        val volumeOptionalMapping = mockk<OptionMapping>()
+        every { event.getOption("link") } returns linkOptionalMapping
+        every { event.getOption("volume") } returns volumeOptionalMapping
+        every { event.getOption("start") } returns mockk(relaxed = true)
+        every { linkOptionalMapping.asString } returns "linkin park in the end"
+        every { volumeOptionalMapping.asInt } returns 20
+        every { playerManager.loadAndPlay(any(), any(), any(), any(), any(), any(), any()) } just Runs
+        every { trackScheduler.queue } returns ArrayBlockingQueue(2)
+
+        nowDigOnThisCommand.handleMusicCommand(commandContext, playerManager, CommandTest.requestingUserDto, 0)
+
+        verify(exactly = 1) {
+            playerManager.loadAndPlay(
+                guild,
+                event,
+                "ytsearch:linkin park in the end",
+                false,
+                0,
+                0L,
+                20
+            )
+        }
+    }
+
+    @Test
+    fun test_nowDigOnThisCommand_explicitPrefixPassthrough() {
+        setUpAudioChannelsWithBotAndMemberInSameChannel()
+        val commandContext = DefaultCommandContext(event)
+        every { mockAudioPlayer.isPaused } returns false
+        every { playerManager.isCurrentlyStoppable } returns false
+        every { playerManager.getMusicManager(guild) } returns musicManager
+
+        val linkOptionalMapping = mockk<OptionMapping>()
+        val volumeOptionalMapping = mockk<OptionMapping>()
+        every { event.getOption("link") } returns linkOptionalMapping
+        every { event.getOption("volume") } returns volumeOptionalMapping
+        every { event.getOption("start") } returns mockk(relaxed = true)
+        every { linkOptionalMapping.asString } returns "scsearch:lofi beats"
+        every { volumeOptionalMapping.asInt } returns 20
+        every { playerManager.loadAndPlay(any(), any(), any(), any(), any(), any(), any()) } just Runs
+        every { trackScheduler.queue } returns ArrayBlockingQueue(2)
+
+        nowDigOnThisCommand.handleMusicCommand(commandContext, playerManager, CommandTest.requestingUserDto, 0)
+
+        verify(exactly = 1) {
+            playerManager.loadAndPlay(
+                guild,
+                event,
+                "scsearch:lofi beats",
+                false,
+                0,
+                0L,
+                20
+            )
+        }
+    }
+
+    @Test
+    fun test_nowDigOnThisCommand_spotifyUrlPassthrough() {
+        setUpAudioChannelsWithBotAndMemberInSameChannel()
+        val commandContext = DefaultCommandContext(event)
+        every { mockAudioPlayer.isPaused } returns false
+        every { playerManager.isCurrentlyStoppable } returns false
+        every { playerManager.getMusicManager(guild) } returns musicManager
+
+        val linkOptionalMapping = mockk<OptionMapping>()
+        val volumeOptionalMapping = mockk<OptionMapping>()
+        every { event.getOption("link") } returns linkOptionalMapping
+        every { event.getOption("volume") } returns volumeOptionalMapping
+        every { event.getOption("start") } returns mockk(relaxed = true)
+        every { linkOptionalMapping.asString } returns "https://open.spotify.com/track/4iV5W9uYEdYUVa79Axb7Rh"
+        every { volumeOptionalMapping.asInt } returns 20
+        every { playerManager.loadAndPlay(any(), any(), any(), any(), any(), any(), any()) } just Runs
+        every { trackScheduler.queue } returns ArrayBlockingQueue(2)
+
+        nowDigOnThisCommand.handleMusicCommand(commandContext, playerManager, CommandTest.requestingUserDto, 0)
+
+        verify(exactly = 1) {
+            playerManager.loadAndPlay(
+                guild,
+                event,
+                "https://open.spotify.com/track/4iV5W9uYEdYUVa79Axb7Rh",
                 false,
                 0,
                 0L,

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/music/NowPlayingCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/music/NowPlayingCommandTest.kt
@@ -106,15 +106,15 @@ internal class NowPlayingCommandTest : MusicCommandTest {
             event.hook.sendMessageEmbeds(capture(embedSlot))
         }
 
-        // Verify properties of captured MessageEmbed
+        // The embed surfaces the track title up top and the source author
+        // byline in the description. Streams replace the progress bar with
+        // a LIVE marker.
         val messageEmbed = embedSlot.captured
-        assert(messageEmbed.title == "Now Playing")
-        assert(messageEmbed.description == "**Title**: `Title`\n" +
-                "**Author**: `Author`\n" +
-                "**Stream**: `Live`\n")
-        assert(messageEmbed.fields[0].name == "Volume")
-        assert(messageEmbed.fields[0].value == "0")
-        assert(messageEmbed.url == null)
+        assert(messageEmbed.title == "Title")
+        assert(messageEmbed.description?.contains("By `Author`") == true)
+        assert(messageEmbed.description?.contains("LIVE") == true)
+        assert(messageEmbed.fields.any { it.name == "Volume" })
+        assert(messageEmbed.fields.any { it.name == "Paused" })
     }
 
     @Test
@@ -145,14 +145,12 @@ internal class NowPlayingCommandTest : MusicCommandTest {
             event.hook.sendMessageEmbeds(capture(embedSlot))
         }
 
-        // Verify properties of captured MessageEmbed
+        // Non-stream tracks render `position / duration` and a progress bar.
         val messageEmbed = embedSlot.captured
-        assert(messageEmbed.title == "Now Playing")
-        assert(messageEmbed.description == "**Title**: `Title`\n" +
-                "**Author**: `Author`\n" +
-                "**Progress**: `00:00:01 / 00:00:03`\n")
-        assert(messageEmbed.fields[0].name == "Volume")
-        assert(messageEmbed.fields[0].value == "0")
-        assert(messageEmbed.url == null)
+        assert(messageEmbed.title == "Title")
+        assert(messageEmbed.description?.contains("By `Author`") == true)
+        assert(messageEmbed.description?.contains("00:00:01 / 00:00:03") == true)
+        assert(messageEmbed.fields.any { it.name == "Volume" })
+        assert(messageEmbed.fields.any { it.name == "Paused" })
     }
 }

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/music/PlayCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/music/PlayCommandTest.kt
@@ -51,7 +51,7 @@ internal class PlayCommandTest : MusicCommandTest {
         every { CommandTest.event.getOption("volume") } returns volumeOptionMapping
         every { CommandTest.event.getOption("start") } returns startOptionMapping
 
-        every { linkOptionMapping.asString } returns "www.testlink.com"
+        every { linkOptionMapping.asString } returns "https://www.testlink.com"
         every { volumeOptionMapping.asInt } returns 20
         every { startOptionMapping.asLong } returns 0L
 
@@ -84,7 +84,118 @@ internal class PlayCommandTest : MusicCommandTest {
             playerManager.loadAndPlay(
                 eq(CommandTest.guild),
                 eq(CommandTest.event),
-                eq("www.testlink.com"),
+                eq("https://www.testlink.com"),
+                eq(true),
+                eq(0),
+                eq(0L),
+                eq(20)
+            )
+        }
+    }
+
+    @Test
+    fun test_playCommand_linkSubcommand_plainQueryGetsYtsearchPrefix() {
+        setUpAudioChannelsWithBotAndMemberInSameChannel()
+        val commandContext = DefaultCommandContext(CommandTest.event)
+        every { mockAudioPlayer.isPaused } returns false
+        every { playerManager.isCurrentlyStoppable } returns false
+
+        val linkOptionMapping = mockk<OptionMapping>()
+        val volumeOptionMapping = mockk<OptionMapping>()
+        val startOptionMapping = mockk<OptionMapping>()
+
+        every { CommandTest.event.subcommandName } returns "link"
+        every { CommandTest.event.getOption("link") } returns linkOptionMapping
+        every { CommandTest.event.getOption("volume") } returns volumeOptionMapping
+        every { CommandTest.event.getOption("start") } returns startOptionMapping
+
+        every { linkOptionMapping.asString } returns "linkin park in the end"
+        every { volumeOptionMapping.asInt } returns 20
+        every { startOptionMapping.asLong } returns 0L
+
+        every { trackScheduler.queue } returns ArrayBlockingQueue(2)
+
+        playCommand.handleMusicCommand(commandContext, playerManager, CommandTest.requestingUserDto, 0)
+
+        verify(exactly = 1) {
+            playerManager.loadAndPlay(
+                eq(CommandTest.guild),
+                eq(CommandTest.event),
+                eq("ytsearch:linkin park in the end"),
+                eq(true),
+                eq(0),
+                eq(0L),
+                eq(20)
+            )
+        }
+    }
+
+    @Test
+    fun test_playCommand_linkSubcommand_explicitPrefixPassthrough() {
+        setUpAudioChannelsWithBotAndMemberInSameChannel()
+        val commandContext = DefaultCommandContext(CommandTest.event)
+        every { mockAudioPlayer.isPaused } returns false
+        every { playerManager.isCurrentlyStoppable } returns false
+
+        val linkOptionMapping = mockk<OptionMapping>()
+        val volumeOptionMapping = mockk<OptionMapping>()
+        val startOptionMapping = mockk<OptionMapping>()
+
+        every { CommandTest.event.subcommandName } returns "link"
+        every { CommandTest.event.getOption("link") } returns linkOptionMapping
+        every { CommandTest.event.getOption("volume") } returns volumeOptionMapping
+        every { CommandTest.event.getOption("start") } returns startOptionMapping
+
+        every { linkOptionMapping.asString } returns "scsearch:lofi beats"
+        every { volumeOptionMapping.asInt } returns 20
+        every { startOptionMapping.asLong } returns 0L
+
+        every { trackScheduler.queue } returns ArrayBlockingQueue(2)
+
+        playCommand.handleMusicCommand(commandContext, playerManager, CommandTest.requestingUserDto, 0)
+
+        verify(exactly = 1) {
+            playerManager.loadAndPlay(
+                eq(CommandTest.guild),
+                eq(CommandTest.event),
+                eq("scsearch:lofi beats"),
+                eq(true),
+                eq(0),
+                eq(0L),
+                eq(20)
+            )
+        }
+    }
+
+    @Test
+    fun test_playCommand_linkSubcommand_spotifyUrlPassthrough() {
+        setUpAudioChannelsWithBotAndMemberInSameChannel()
+        val commandContext = DefaultCommandContext(CommandTest.event)
+        every { mockAudioPlayer.isPaused } returns false
+        every { playerManager.isCurrentlyStoppable } returns false
+
+        val linkOptionMapping = mockk<OptionMapping>()
+        val volumeOptionMapping = mockk<OptionMapping>()
+        val startOptionMapping = mockk<OptionMapping>()
+
+        every { CommandTest.event.subcommandName } returns "link"
+        every { CommandTest.event.getOption("link") } returns linkOptionMapping
+        every { CommandTest.event.getOption("volume") } returns volumeOptionMapping
+        every { CommandTest.event.getOption("start") } returns startOptionMapping
+
+        every { linkOptionMapping.asString } returns "https://open.spotify.com/track/4iV5W9uYEdYUVa79Axb7Rh"
+        every { volumeOptionMapping.asInt } returns 20
+        every { startOptionMapping.asLong } returns 0L
+
+        every { trackScheduler.queue } returns ArrayBlockingQueue(2)
+
+        playCommand.handleMusicCommand(commandContext, playerManager, CommandTest.requestingUserDto, 0)
+
+        verify(exactly = 1) {
+            playerManager.loadAndPlay(
+                eq(CommandTest.guild),
+                eq(CommandTest.event),
+                eq("https://open.spotify.com/track/4iV5W9uYEdYUVa79Axb7Rh"),
                 eq(true),
                 eq(0),
                 eq(0L),

--- a/discord-bot/src/test/kotlin/bot/toby/helpers/MusicPlayerHelperTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/helpers/MusicPlayerHelperTest.kt
@@ -1,5 +1,7 @@
 import bot.toby.helpers.MusicPlayerHelper
+import bot.toby.lavaplayer.GuildMusicManager
 import bot.toby.lavaplayer.PlayerManager
+import bot.toby.lavaplayer.TrackScheduler
 import com.sedmelluq.discord.lavaplayer.player.AudioPlayer
 import com.sedmelluq.discord.lavaplayer.track.AudioTrack
 import com.sedmelluq.discord.lavaplayer.track.AudioTrackInfo
@@ -17,6 +19,7 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import java.util.concurrent.LinkedBlockingQueue
 
 class MusicPlayerHelperTest {
 
@@ -45,16 +48,26 @@ class MusicPlayerHelperTest {
         MockKAnnotations.init(this)
 
         // Mock behavior for PlayerManager and AudioPlayer
-        every { playerManager.getMusicManager(guildMock) } returns mockk()
-        every { playerManager.getMusicManager(guildMock).audioPlayer } returns audioPlayer
+        val musicManager = mockk<GuildMusicManager>()
+        val trackScheduler = mockk<TrackScheduler>(relaxed = true)
+        every { trackScheduler.queue } returns LinkedBlockingQueue()
+        every { trackScheduler.isLooping } returns false
+        every { trackScheduler.getRequesterId(any()) } returns null
+        every { musicManager.audioPlayer } returns audioPlayer
+        every { musicManager.scheduler } returns trackScheduler
+        every { playerManager.getMusicManager(guildMock) } returns musicManager
         every { audioPlayer.playingTrack } returns track
         every { track.info } returns AudioTrackInfo("Title", "Author", 20L, "Identifier", true, "uri")
+        every { track.sourceManager } returns null
+        every { track.duration } returns 20L
+        every { track.position } returns 0L
 
         // Mock guild and interaction hook
         every { replyCallback.guild } returns guildMock
         every { guildMock.idLong } returns guildId
         every { guildMock.id } returns guildId.toString()
         every { guildMock.name } returns "guildName"
+        every { guildMock.getMemberById(any<Long>()) } returns null
         every { replyCallback.hook.interaction } returns mockk {
             every { guild } returns guildMock
             every { channel } returns channelMock
@@ -98,60 +111,71 @@ class MusicPlayerHelperTest {
 
     @Test
     fun `test nowPlaying with no stored nowplaying message sends new message`() {
-        // Mock behavior for AudioTrack and InteractionHook
         every { audioPlayer.volume } returns 50
         every { audioPlayer.isPaused } returns false
 
-        // Mock InteractionHook methods for sending a new message
         val webhookCreateAction = mockk<WebhookMessageCreateAction<Message>>()
         val message = mockk<Message>(relaxed = true)
         createWebhookMocking(webhookCreateAction, message)
 
-        // Perform nowPlaying action
         MusicPlayerHelper.nowPlaying(replyCallback, playerManager, 5)
 
-        // Verify interaction hook behavior for sending a new message
         verify {
             replyCallback.hook.sendMessageEmbeds(match<MessageEmbed> {
-                it.description == "**Title**: `Title`\n" +
-                        "**Author**: `Author`\n" +
-                        "**Stream**: `Live`\n"
+                // Live-stream embed shows the LIVE indicator in the description and
+                // surfaces the author byline.
+                it.title == "Title" &&
+                    it.description?.contains("By `Author`") == true &&
+                    it.description?.contains("LIVE") == true
             })
             webhookCreateAction.queue(any())
         }
     }
 
+    @Test
+    fun `test nowPlaying embed includes volume and paused fields`() {
+        every { audioPlayer.volume } returns 50
+        every { audioPlayer.isPaused } returns true
+
+        val webhookCreateAction = mockk<WebhookMessageCreateAction<Message>>()
+        val message = mockk<Message>(relaxed = true)
+        createWebhookMocking(webhookCreateAction, message)
+
+        MusicPlayerHelper.nowPlaying(replyCallback, playerManager, 5)
+
+        verify {
+            replyCallback.hook.sendMessageEmbeds(match<MessageEmbed> {
+                val volumeField = it.fields.firstOrNull { f -> f.name == "Volume" }
+                val pausedField = it.fields.firstOrNull { f -> f.name == "Paused" }
+                volumeField?.value?.contains("50") == true &&
+                    pausedField?.value?.contains("Yes") == true
+            })
+        }
+    }
 
     @Test
     fun `test nowPlaying with stored nowplaying message edits existing message`() {
-        // Mock behavior for AudioTrack and InteractionHook
         every { audioPlayer.volume } returns 50
         every { audioPlayer.isPaused } returns false
 
-        // Mock InteractionHook methods
         val messageEditAction = mockk<MessageEditAction>(relaxed = true)
         val message = mockk<Message>(relaxed = true)
         val webhookCreateAction = mockk<WebhookMessageCreateAction<Message>>()
         createWebhookMocking(webhookCreateAction, message)
         editWebhookMocking(messageEditAction, message)
-        // Clear any existing messages
         MusicPlayerHelper.nowPlayingManager.clear()
 
-        // Perform nowPlaying action
         MusicPlayerHelper.nowPlaying(replyCallback, playerManager, 5)
 
-        // Verify that a new message was sent and stored
         assertNotNull(MusicPlayerHelper.nowPlayingManager.getLastNowPlayingMessage(guildId)) {
             "Expected guildLastNowPlayingMessage to contain a message for guildId $guildId"
         }
 
-        // Perform nowPlaying action again to edit the existing message
         MusicPlayerHelper.nowPlaying(replyCallback, playerManager, 5)
 
-        // Verify message behavior
         verify {
             message.editMessageEmbeds(match<MessageEmbed> {
-                it.description?.contains("Title") == true && it.description?.contains("Author") == true
+                it.title == "Title" && it.description?.contains("Author") == true
             })
             messageEditAction.setComponents(any<ActionRow>()).queue()
         }

--- a/discord-bot/src/test/kotlin/bot/toby/lavaplayer/MusicControlGatewayImplTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/lavaplayer/MusicControlGatewayImplTest.kt
@@ -1,0 +1,384 @@
+package bot.toby.lavaplayer
+
+import com.sedmelluq.discord.lavaplayer.player.AudioPlayer
+import com.sedmelluq.discord.lavaplayer.track.AudioTrack
+import com.sedmelluq.discord.lavaplayer.track.AudioTrackInfo
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import io.mockk.verify
+import net.dv8tion.jda.api.JDA
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.managers.AudioManager
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.util.concurrent.LinkedBlockingQueue
+
+class MusicControlGatewayImplTest {
+
+    private val guildId = 100L
+
+    private lateinit var jda: JDA
+    private lateinit var guild: Guild
+    private lateinit var audioManager: AudioManager
+    private lateinit var playerManager: PlayerManager
+    private lateinit var musicManager: GuildMusicManager
+    private lateinit var trackScheduler: TrackScheduler
+    private lateinit var audioPlayer: AudioPlayer
+    private lateinit var gateway: MusicControlGatewayImpl
+
+    @BeforeEach
+    fun setUp() {
+        jda = mockk()
+        guild = mockk()
+        audioManager = mockk(relaxed = true)
+        playerManager = mockk(relaxed = true)
+        musicManager = mockk()
+        trackScheduler = mockk(relaxed = true)
+        audioPlayer = mockk(relaxed = true)
+
+        every { jda.getGuildById(guildId) } returns guild
+        every { guild.audioManager } returns audioManager
+        every { musicManager.audioPlayer } returns audioPlayer
+        every { musicManager.scheduler } returns trackScheduler
+        every { trackScheduler.queue } returns LinkedBlockingQueue()
+        every { trackScheduler.isLooping } returns false
+
+        mockkObject(PlayerManager.Companion)
+        every { PlayerManager.instance } returns playerManager
+        every { playerManager.getMusicManager(guild) } returns musicManager
+
+        gateway = MusicControlGatewayImpl(jdaSupplier = JdaSupplier { jda })
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkObject(PlayerManager.Companion)
+    }
+
+    @Test
+    fun `getState returns null when guild not found`() {
+        every { jda.getGuildById(999L) } returns null
+        assertNull(gateway.getState(999L))
+    }
+
+    @Test
+    fun `getState returns snapshot with no playing track`() {
+        every { audioPlayer.playingTrack } returns null
+        every { audioPlayer.isPaused } returns false
+        every { audioPlayer.volume } returns 100
+        every { audioManager.connectedChannel } returns null
+
+        val state = gateway.getState(guildId)
+        assertNotNull(state)
+        assertNull(state!!.nowPlaying)
+        assertEquals(0L, state.positionMs)
+        assertEquals(100, state.volume)
+    }
+
+    @Test
+    fun `getState returns track info with requester when playing`() {
+        val track = mockk<AudioTrack>(relaxed = true)
+        every { track.info } returns AudioTrackInfo("T", "A", 60_000L, "id", false, "https://example.com")
+        every { track.position } returns 5_000L
+        every { track.duration } returns 60_000L
+        every { track.sourceManager } returns null
+        every { audioPlayer.playingTrack } returns track
+        every { audioPlayer.isPaused } returns true
+        every { audioPlayer.volume } returns 80
+        every { trackScheduler.getRequesterId(track) } returns 42L
+        every { audioManager.connectedChannel } returns null
+
+        val state = gateway.getState(guildId)
+        assertNotNull(state)
+        assertEquals(true, state!!.paused)
+        assertEquals(80, state.volume)
+        val nowPlaying = state.nowPlaying
+        assertNotNull(nowPlaying)
+        assertEquals("T", nowPlaying!!.title)
+        assertEquals(42L, nowPlaying.requesterDiscordId)
+        assertEquals(5_000L, state.positionMs)
+    }
+
+    @Test
+    fun `getState surfaces the connected voice channel and its members`() {
+        // Bot already joined a VC; the dashboard surfaces who's listening.
+        val voiceChannel = mockk<net.dv8tion.jda.api.entities.channel.unions.AudioChannelUnion>()
+        val alice = mockk<net.dv8tion.jda.api.entities.Member>()
+        val bot = mockk<net.dv8tion.jda.api.entities.Member>()
+        val aliceUser = mockk<net.dv8tion.jda.api.entities.User>()
+        val botUser = mockk<net.dv8tion.jda.api.entities.User>()
+        val aliceVoice = mockk<net.dv8tion.jda.api.entities.GuildVoiceState>(relaxed = true)
+        val botVoice = mockk<net.dv8tion.jda.api.entities.GuildVoiceState>(relaxed = true)
+
+        every { audioManager.connectedChannel } returns voiceChannel
+        every { voiceChannel.idLong } returns 555L
+        every { voiceChannel.name } returns "🎶 music"
+        every { voiceChannel.members } returns listOf(alice, bot)
+        every { alice.idLong } returns 1L
+        every { alice.effectiveName } returns "Alice"
+        every { alice.effectiveAvatarUrl } returns "https://cdn/alice.png"
+        every { alice.user } returns aliceUser
+        every { aliceUser.isBot } returns false
+        every { alice.voiceState } returns aliceVoice
+        every { aliceVoice.isMuted } returns false
+        every { aliceVoice.isSelfMuted } returns false
+        every { aliceVoice.isDeafened } returns false
+        every { aliceVoice.isSelfDeafened } returns true
+        every { bot.idLong } returns 999L
+        every { bot.effectiveName } returns "TobyBot"
+        every { bot.effectiveAvatarUrl } returns "https://cdn/toby.png"
+        every { bot.user } returns botUser
+        every { botUser.isBot } returns true
+        every { bot.voiceState } returns botVoice
+        every { botVoice.isMuted } returns false
+        every { botVoice.isSelfMuted } returns false
+        every { botVoice.isDeafened } returns false
+        every { botVoice.isSelfDeafened } returns false
+        every { audioPlayer.playingTrack } returns null
+        every { audioPlayer.isPaused } returns false
+        every { audioPlayer.volume } returns 100
+
+        val state = gateway.getState(guildId)
+        assertNotNull(state)
+        val voice = state!!.voiceChannel
+        assertNotNull(voice)
+        assertEquals(555L, voice!!.id)
+        assertEquals("🎶 music", voice.name)
+        assertEquals(2, voice.members.size)
+
+        val aliceInfo = voice.members.first { it.discordId == 1L }
+        assertEquals("Alice", aliceInfo.displayName)
+        assertEquals(false, aliceInfo.isBot)
+        assertEquals(true, aliceInfo.isDeafened) // self-deafened still counts
+        assertEquals(false, aliceInfo.isMuted)
+
+        val botInfo = voice.members.first { it.discordId == 999L }
+        assertEquals(true, botInfo.isBot)
+    }
+
+    @Test
+    fun `getState voice channel is null when bot not connected`() {
+        every { audioManager.connectedChannel } returns null
+        every { audioPlayer.playingTrack } returns null
+        every { audioPlayer.isPaused } returns false
+        every { audioPlayer.volume } returns 100
+        assertNull(gateway.getState(guildId)?.voiceChannel)
+    }
+
+    @Test
+    fun `load returns failure when bot is not in voice channel`() {
+        every { audioManager.connectedChannel } returns null
+        val result = gateway.load(guildId, "linkin park", requesterDiscordId = 1L)
+        assertFalse(result.ok)
+        assertNotNull(result.message)
+        assertTrue(result.message!!.contains("voice channel"))
+    }
+
+    @Test
+    fun `pause toggles when not already paused`() {
+        every { audioPlayer.isPaused } returns false
+        assertTrue(gateway.pause(guildId))
+        verify(exactly = 1) { audioPlayer.isPaused = true }
+    }
+
+    @Test
+    fun `pause is no-op when already paused`() {
+        every { audioPlayer.isPaused } returns true
+        assertFalse(gateway.pause(guildId))
+        verify(exactly = 0) { audioPlayer.isPaused = true }
+    }
+
+    @Test
+    fun `resume toggles when paused`() {
+        every { audioPlayer.isPaused } returns true
+        assertTrue(gateway.resume(guildId))
+        verify(exactly = 1) { audioPlayer.isPaused = false }
+    }
+
+    @Test
+    fun `resume is no-op when not paused`() {
+        every { audioPlayer.isPaused } returns false
+        assertFalse(gateway.resume(guildId))
+    }
+
+    @Test
+    fun `skip count of 0 returns false`() {
+        assertFalse(gateway.skip(guildId, 0))
+        verify(exactly = 0) { trackScheduler.nextTrack() }
+    }
+
+    @Test
+    fun `skip negative count returns false`() {
+        assertFalse(gateway.skip(guildId, -3))
+        verify(exactly = 0) { trackScheduler.nextTrack() }
+    }
+
+    @Test
+    fun `skip 3 calls nextTrack 3 times`() {
+        gateway.skip(guildId, 3)
+        verify(exactly = 3) { trackScheduler.nextTrack() }
+    }
+
+    @Test
+    fun `setVolume clamps below zero to zero`() {
+        gateway.setVolume(guildId, -10)
+        verify(exactly = 1) { audioPlayer.volume = 0 }
+    }
+
+    @Test
+    fun `setVolume clamps above 150 to 150`() {
+        gateway.setVolume(guildId, 999)
+        verify(exactly = 1) { audioPlayer.volume = 150 }
+    }
+
+    @Test
+    fun `setVolume in range passes through unclamped`() {
+        gateway.setVolume(guildId, 75)
+        verify(exactly = 1) { audioPlayer.volume = 75 }
+    }
+
+    @Test
+    fun `seek negative returns false`() {
+        assertFalse(gateway.seek(guildId, -1L))
+    }
+
+    @Test
+    fun `seek with no playing track returns false`() {
+        every { audioPlayer.playingTrack } returns null
+        assertFalse(gateway.seek(guildId, 1000L))
+    }
+
+    @Test
+    fun `seek beyond duration returns false`() {
+        val track = mockk<AudioTrack>(relaxed = true)
+        every { track.duration } returns 10_000L
+        every { audioPlayer.playingTrack } returns track
+        assertFalse(gateway.seek(guildId, 20_000L))
+    }
+
+    @Test
+    fun `seek within duration updates track position`() {
+        val track = mockk<AudioTrack>(relaxed = true)
+        every { track.duration } returns 60_000L
+        every { audioPlayer.playingTrack } returns track
+        assertTrue(gateway.seek(guildId, 5_000L))
+        verify(exactly = 1) { track.position = 5_000L }
+    }
+
+    @Test
+    fun `reorderQueue delegates to scheduler`() {
+        every { trackScheduler.moveQueueItem(0, 2) } returns true
+        assertTrue(gateway.reorderQueue(guildId, 0, 2))
+        verify(exactly = 1) { trackScheduler.moveQueueItem(0, 2) }
+    }
+
+    @Test
+    fun `removeFromQueue returns null when scheduler returns null`() {
+        every { trackScheduler.removeQueueItem(50) } returns null
+        assertNull(gateway.removeFromQueue(guildId, 50))
+    }
+
+    @Test
+    fun `removeFromQueue returns TrackInfo when scheduler returns a track`() {
+        val track = mockk<AudioTrack>(relaxed = true)
+        every { track.info } returns AudioTrackInfo("Removed", "Author", 30_000L, "id", false, null)
+        every { track.duration } returns 30_000L
+        every { track.sourceManager } returns null
+        every { trackScheduler.removeQueueItem(2) } returns track
+
+        val result = gateway.removeFromQueue(guildId, 2)
+        assertNotNull(result)
+        assertEquals("Removed", result!!.title)
+    }
+
+    @Test
+    fun `setLooping idempotent when state unchanged`() {
+        every { trackScheduler.isLooping } returns true
+        assertTrue(gateway.setLooping(guildId, true))
+        verify(exactly = 0) { trackScheduler.isLooping = any() }
+    }
+
+    @Test
+    fun `setLooping flips state`() {
+        every { trackScheduler.isLooping } returns false
+        assertTrue(gateway.setLooping(guildId, true))
+        verify(exactly = 1) { trackScheduler.isLooping = true }
+    }
+
+    @Test
+    fun `search returns empty list when no jda supplier`() {
+        val noJda = MusicControlGatewayImpl(jdaSupplier = JdaSupplier { null })
+        assertTrue(noJda.search(guildId, "linkin park").isEmpty())
+    }
+
+    @Test
+    fun `search returns empty list when guild is missing`() {
+        every { jda.getGuildById(guildId) } returns null
+        assertTrue(gateway.search(guildId, "linkin park").isEmpty())
+    }
+
+    @Test
+    fun `search forwards a single track from trackLoaded`() {
+        val track = mockk<AudioTrack>(relaxed = true)
+        every { track.info } returns AudioTrackInfo("T", "A", 1L, "id", false, "https://example.com")
+        every { track.duration } returns 1L
+        every { track.sourceManager } returns null
+
+        // Wire the lavaplayer load path to fire trackLoaded synchronously.
+        every { playerManager.loadForExternal(any(), any(), any()) } answers {
+            val handler = thirdArg<com.sedmelluq.discord.lavaplayer.player.AudioLoadResultHandler>()
+            handler.trackLoaded(track)
+        }
+
+        val results = gateway.search(guildId, "https://example.com")
+        assertEquals(1, results.size)
+        assertEquals("T", results[0].title)
+    }
+
+    @Test
+    fun `search caps the result list at the requested limit`() {
+        val playlist = mockk<com.sedmelluq.discord.lavaplayer.track.AudioPlaylist>(relaxed = true)
+        val tracks = (1..20).map {
+            mockk<AudioTrack>(relaxed = true).also { t ->
+                every { t.info } returns AudioTrackInfo("Track $it", "A", 1L, "id-$it", false, null)
+                every { t.duration } returns 1L
+                every { t.sourceManager } returns null
+            }
+        }
+        every { playlist.tracks } returns tracks
+        every { playerManager.loadForExternal(any(), any(), any()) } answers {
+            val handler = thirdArg<com.sedmelluq.discord.lavaplayer.player.AudioLoadResultHandler>()
+            handler.playlistLoaded(playlist)
+        }
+
+        val results = gateway.search(guildId, "linkin park", limit = 5)
+        assertEquals(5, results.size)
+    }
+
+    @Test
+    fun `search returns empty list on noMatches`() {
+        every { playerManager.loadForExternal(any(), any(), any()) } answers {
+            val handler = thirdArg<com.sedmelluq.discord.lavaplayer.player.AudioLoadResultHandler>()
+            handler.noMatches()
+        }
+        assertTrue(gateway.search(guildId, "asdfqwer").isEmpty())
+    }
+
+    @Test
+    fun `gateway with null JDA supplier returns null state and false mutators`() {
+        val noJda = MusicControlGatewayImpl(jdaSupplier = JdaSupplier { null })
+        assertNull(noJda.getState(guildId))
+        assertFalse(noJda.pause(guildId))
+        assertFalse(noJda.resume(guildId))
+        assertFalse(noJda.skip(guildId))
+        assertFalse(noJda.setVolume(guildId, 50))
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/lavaplayer/SearchPrefixResolverTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/lavaplayer/SearchPrefixResolverTest.kt
@@ -1,0 +1,177 @@
+package bot.toby.lavaplayer
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class SearchPrefixResolverTest {
+
+    @Test
+    fun `https URL is returned unchanged`() {
+        assertEquals(
+            "https://www.youtube.com/watch?v=abc",
+            SearchPrefixResolver.resolve("https://www.youtube.com/watch?v=abc"),
+        )
+    }
+
+    @Test
+    fun `http URL is returned unchanged`() {
+        assertEquals(
+            "http://example.com/song.mp3",
+            SearchPrefixResolver.resolve("http://example.com/song.mp3"),
+        )
+    }
+
+    @Test
+    fun `URL with query params and fragments is returned unchanged`() {
+        val url = "https://open.spotify.com/track/abc?si=xyz#fragment"
+        assertEquals(url, SearchPrefixResolver.resolve(url))
+    }
+
+    @Test
+    fun `Spotify URL passes through`() {
+        val url = "https://open.spotify.com/track/4iV5W9uYEdYUVa79Axb7Rh"
+        assertEquals(url, SearchPrefixResolver.resolve(url))
+    }
+
+    @Test
+    fun `SoundCloud URL passes through`() {
+        val url = "https://soundcloud.com/artist/track-name"
+        assertEquals(url, SearchPrefixResolver.resolve(url))
+    }
+
+    @Test
+    fun `Bandcamp URL passes through`() {
+        val url = "https://artist.bandcamp.com/track/song"
+        assertEquals(url, SearchPrefixResolver.resolve(url))
+    }
+
+    @Test
+    fun `Vimeo URL passes through`() {
+        val url = "https://vimeo.com/123456789"
+        assertEquals(url, SearchPrefixResolver.resolve(url))
+    }
+
+    @Test
+    fun `ytsearch prefix passes through`() {
+        assertEquals("ytsearch:linkin park", SearchPrefixResolver.resolve("ytsearch:linkin park"))
+    }
+
+    @Test
+    fun `ytmsearch prefix passes through`() {
+        assertEquals("ytmsearch:metric", SearchPrefixResolver.resolve("ytmsearch:metric"))
+    }
+
+    @Test
+    fun `scsearch prefix passes through`() {
+        assertEquals("scsearch:lofi beats", SearchPrefixResolver.resolve("scsearch:lofi beats"))
+    }
+
+    @Test
+    fun `spsearch prefix passes through`() {
+        assertEquals("spsearch:doves", SearchPrefixResolver.resolve("spsearch:doves"))
+    }
+
+    @Test
+    fun `sprec prefix passes through`() {
+        assertEquals("sprec:abc123", SearchPrefixResolver.resolve("sprec:abc123"))
+    }
+
+    @Test
+    fun `dzsearch prefix passes through`() {
+        assertEquals("dzsearch:foo", SearchPrefixResolver.resolve("dzsearch:foo"))
+    }
+
+    @Test
+    fun `dzisrc prefix passes through`() {
+        assertEquals("dzisrc:USRC17607839", SearchPrefixResolver.resolve("dzisrc:USRC17607839"))
+    }
+
+    @Test
+    fun `amsearch prefix passes through`() {
+        assertEquals("amsearch:beyonce", SearchPrefixResolver.resolve("amsearch:beyonce"))
+    }
+
+    @Test
+    fun `ymsearch prefix passes through`() {
+        assertEquals("ymsearch:rachmaninoff", SearchPrefixResolver.resolve("ymsearch:rachmaninoff"))
+    }
+
+    @Test
+    fun `ymrec prefix passes through`() {
+        assertEquals("ymrec:12345", SearchPrefixResolver.resolve("ymrec:12345"))
+    }
+
+    @Test
+    fun `prefix matching is case insensitive`() {
+        assertEquals("YTSearch:foo", SearchPrefixResolver.resolve("YTSearch:foo"))
+        assertEquals("SCSEARCH:foo", SearchPrefixResolver.resolve("SCSEARCH:foo"))
+        assertEquals("SpSearch:foo", SearchPrefixResolver.resolve("SpSearch:foo"))
+    }
+
+    @Test
+    fun `single-word plain query is coerced to ytsearch`() {
+        assertEquals("ytsearch:linkin", SearchPrefixResolver.resolve("linkin"))
+    }
+
+    @Test
+    fun `multi-word plain query is coerced to ytsearch`() {
+        assertEquals(
+            "ytsearch:linkin park in the end",
+            SearchPrefixResolver.resolve("linkin park in the end"),
+        )
+    }
+
+    @Test
+    fun `plain query with punctuation is coerced`() {
+        assertEquals(
+            "ytsearch:Metric - Help I'm Alive!",
+            SearchPrefixResolver.resolve("Metric - Help I'm Alive!"),
+        )
+    }
+
+    @Test
+    fun `empty input returns empty without prefix`() {
+        assertEquals("", SearchPrefixResolver.resolve(""))
+    }
+
+    @Test
+    fun `whitespace-only input returns empty without prefix`() {
+        assertEquals("", SearchPrefixResolver.resolve("   "))
+        assertEquals("", SearchPrefixResolver.resolve("\t\n  "))
+    }
+
+    @Test
+    fun `leading and trailing whitespace is trimmed before coercion`() {
+        assertEquals("ytsearch:hello world", SearchPrefixResolver.resolve("  hello world  "))
+    }
+
+    @Test
+    fun `query containing prefix word mid-string is still coerced`() {
+        assertEquals(
+            "ytsearch:play ytsearch:foo",
+            SearchPrefixResolver.resolve("play ytsearch:foo"),
+        )
+    }
+
+    @Test
+    fun `custom default prefix is honored`() {
+        assertEquals(
+            "scsearch:lofi beats",
+            SearchPrefixResolver.resolve("lofi beats", defaultPrefix = "scsearch:"),
+        )
+    }
+
+    @Test
+    fun `custom default prefix is not applied to URLs`() {
+        val url = "https://www.youtube.com/watch?v=abc"
+        assertEquals(url, SearchPrefixResolver.resolve(url, defaultPrefix = "scsearch:"))
+    }
+
+    @Test
+    fun `custom default prefix is not applied to explicit prefixed input`() {
+        assertEquals(
+            "ytsearch:foo",
+            SearchPrefixResolver.resolve("ytsearch:foo", defaultPrefix = "scsearch:"),
+        )
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/lavaplayer/TrackInfoMapperTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/lavaplayer/TrackInfoMapperTest.kt
@@ -1,0 +1,52 @@
+package bot.toby.lavaplayer
+
+import com.sedmelluq.discord.lavaplayer.track.AudioTrack
+import com.sedmelluq.discord.lavaplayer.track.AudioTrackInfo
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class TrackInfoMapperTest {
+
+    @Test
+    fun `maps title author duration uri identifier`() {
+        val track = mockk<AudioTrack>(relaxed = true)
+        every { track.info } returns AudioTrackInfo("Title", "Author", 60_000L, "id-123", false, "https://example.com")
+        every { track.duration } returns 60_000L
+        every { track.sourceManager } returns null
+
+        val info = TrackInfoMapper.toTrackInfo(track, requesterId = 42L)
+        assertEquals("Title", info.title)
+        assertEquals("Author", info.author)
+        assertEquals("id-123", info.identifier)
+        assertEquals(60_000L, info.durationMs)
+        assertEquals("https://example.com", info.uri)
+        assertEquals(42L, info.requesterDiscordId)
+        assertEquals(false, info.isStream)
+    }
+
+    @Test
+    fun `maps requesterId null when not provided`() {
+        val track = mockk<AudioTrack>(relaxed = true)
+        every { track.info } returns AudioTrackInfo("T", "A", 0L, "id", true, null)
+        every { track.duration } returns 0L
+        every { track.sourceManager } returns null
+
+        val info = TrackInfoMapper.toTrackInfo(track, requesterId = null)
+        assertNull(info.requesterDiscordId)
+        assertEquals(true, info.isStream)
+    }
+
+    @Test
+    fun `swallows exceptions from sourceManager access`() {
+        val track = mockk<AudioTrack>(relaxed = true)
+        every { track.info } returns AudioTrackInfo("T", "A", 1L, "id", false, "u")
+        every { track.duration } returns 1L
+        every { track.sourceManager } throws RuntimeException("boom")
+
+        val info = TrackInfoMapper.toTrackInfo(track, null)
+        assertNull(info.sourceName)
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/lavaplayer/TrackSchedulerTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/lavaplayer/TrackSchedulerTest.kt
@@ -213,4 +213,107 @@ class TrackSchedulerTest {
         }
         assertEquals(100, scheduler.queue.size)
     }
+
+    @Test
+    fun `moveQueueItem moves item from one position to another`() {
+        every { player.startTrack(any(), true) } returns false
+        val t1 = mockTrack("T1")
+        val t2 = mockTrack("T2")
+        val t3 = mockTrack("T3")
+        scheduler.queue(t1, 0L, 50)
+        scheduler.queue(t2, 0L, 50)
+        scheduler.queue(t3, 0L, 50)
+
+        assertTrue(scheduler.moveQueueItem(0, 2))
+
+        val ordered = scheduler.queue.toList()
+        assertEquals(3, ordered.size)
+        assertSame(t2, ordered[0])
+        assertSame(t3, ordered[1])
+        assertSame(t1, ordered[2])
+    }
+
+    @Test
+    fun `moveQueueItem with fromIndex equal toIndex is a no-op true`() {
+        every { player.startTrack(any(), true) } returns false
+        val t1 = mockTrack("T1")
+        scheduler.queue(t1, 0L, 50)
+        assertTrue(scheduler.moveQueueItem(0, 0))
+        assertSame(t1, scheduler.queue.peek())
+    }
+
+    @Test
+    fun `moveQueueItem with negative fromIndex returns false`() {
+        assertFalse(scheduler.moveQueueItem(-1, 0))
+    }
+
+    @Test
+    fun `moveQueueItem with out-of-range toIndex returns false`() {
+        every { player.startTrack(any(), true) } returns false
+        scheduler.queue(mockTrack("T1"), 0L, 50)
+        assertFalse(scheduler.moveQueueItem(0, 99))
+    }
+
+    @Test
+    fun `removeQueueItem removes correct item by index`() {
+        every { player.startTrack(any(), true) } returns false
+        val t1 = mockTrack("T1")
+        val t2 = mockTrack("T2")
+        val t3 = mockTrack("T3")
+        scheduler.queue(t1, 0L, 50)
+        scheduler.queue(t2, 0L, 50)
+        scheduler.queue(t3, 0L, 50)
+
+        val removed = scheduler.removeQueueItem(1)
+        assertSame(t2, removed)
+        assertEquals(2, scheduler.queue.size)
+        val remaining = scheduler.queue.toList()
+        assertSame(t1, remaining[0])
+        assertSame(t3, remaining[1])
+    }
+
+    @Test
+    fun `removeQueueItem out-of-bounds returns null`() {
+        every { player.startTrack(any(), true) } returns false
+        scheduler.queue(mockTrack("T1"), 0L, 50)
+        assertNull(scheduler.removeQueueItem(-1))
+        assertNull(scheduler.removeQueueItem(99))
+    }
+
+    @Test
+    fun `getRequesterId returns null when not set`() {
+        val track = mockTrack()
+        assertNull(scheduler.getRequesterId(track))
+    }
+
+    @Test
+    fun `queue records requester id when provided`() {
+        val track = mockTrack()
+        every { player.startTrack(track, true) } returns false
+        scheduler.queue(track, 0L, null, 50, requesterId = 12345L)
+        assertEquals(12345L, scheduler.getRequesterId(track))
+    }
+
+    @Test
+    fun `onTrackEnd clears requester id`() {
+        val track = mockTrack()
+        every { player.startTrack(track, true) } returns false
+        scheduler.queue(track, 0L, null, 50, requesterId = 12345L)
+        scheduler.onTrackEnd(player, track, AudioTrackEndReason.STOPPED)
+        assertNull(scheduler.getRequesterId(track))
+    }
+
+    @Test
+    fun `SchedulerEvents publisher being null does not crash event-emitting paths`() {
+        // Ensure publisher is null (default in tests).
+        SchedulerEvents.publisher = null
+        val track = mockTrack()
+        every { player.startTrack(track, true) } returns false
+        // Should not throw.
+        scheduler.queue(track, 0L, 50)
+        scheduler.onTrackStart(player, track)
+        scheduler.onTrackEnd(player, track, AudioTrackEndReason.FINISHED)
+        scheduler.onPlayerPause(player)
+        scheduler.onPlayerResume(player)
+    }
 }

--- a/discord-bot/src/test/kotlin/bot/toby/util/ProgressBarTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/util/ProgressBarTest.kt
@@ -1,0 +1,87 @@
+package bot.toby.util
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class ProgressBarTest {
+
+    @Test
+    fun `default cell count produces 20 visible cells`() {
+        val bar = ProgressBar.render(0L, 60_000L)
+        // Each cell is one Unicode code point; using length on a String that may include
+        // multi-char emoji handles works for our chosen single-codepoint glyphs.
+        // Just count by codePointCount to be safe.
+        val cells = bar.codePointCount(0, bar.length)
+        assertEquals(20, cells)
+    }
+
+    @Test
+    fun `zero position puts handle at the start`() {
+        val bar = ProgressBar.render(0L, 60_000L, cells = 10)
+        // First codepoint should be the handle 🔘
+        val firstCp = bar.codePointAt(0)
+        assertEquals("🔘".codePointAt(0), firstCp)
+    }
+
+    @Test
+    fun `full position puts handle at the end`() {
+        val bar = ProgressBar.render(60_000L, 60_000L, cells = 10)
+        val cps = bar.codePoints().toArray()
+        assertEquals(10, cps.size)
+        assertEquals("🔘".codePointAt(0), cps.last())
+    }
+
+    @Test
+    fun `mid position puts handle near the middle`() {
+        val bar = ProgressBar.render(5_000L, 10_000L, cells = 10)
+        val cps = bar.codePoints().toArray()
+        val handleIdx = cps.indexOfFirst { it == "🔘".codePointAt(0) }
+        assertTrue(handleIdx in 3..5, "expected handle near middle (3..5), got $handleIdx")
+    }
+
+    @Test
+    fun `position past duration is clamped to end`() {
+        val bar = ProgressBar.render(99_999L, 60_000L, cells = 10)
+        val cps = bar.codePoints().toArray()
+        assertEquals("🔘".codePointAt(0), cps.last())
+    }
+
+    @Test
+    fun `negative position is clamped to start`() {
+        val bar = ProgressBar.render(-1000L, 60_000L, cells = 10)
+        val cps = bar.codePoints().toArray()
+        assertEquals("🔘".codePointAt(0), cps.first())
+    }
+
+    @Test
+    fun `zero duration returns empty bar without handle`() {
+        val bar = ProgressBar.render(0L, 0L, cells = 10)
+        val cps = bar.codePoints().toArray()
+        assertEquals(10, cps.size)
+        // No handle present
+        assertTrue(cps.none { it == "🔘".codePointAt(0) })
+    }
+
+    @Test
+    fun `negative duration returns empty bar without handle`() {
+        val bar = ProgressBar.render(1000L, -1L, cells = 10)
+        val cps = bar.codePoints().toArray()
+        assertTrue(cps.none { it == "🔘".codePointAt(0) })
+    }
+
+    @Test
+    fun `zero cells throws`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            ProgressBar.render(0L, 10_000L, cells = 0)
+        }
+    }
+
+    @Test
+    fun `negative cells throws`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            ProgressBar.render(0L, 10_000L, cells = -5)
+        }
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/util/SourceBadgesTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/util/SourceBadgesTest.kt
@@ -1,0 +1,93 @@
+package bot.toby.util
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Test
+import java.awt.Color
+
+class SourceBadgesTest {
+
+    @Test
+    fun `youtube maps to red`() {
+        val badge = SourceBadges.forSource("youtube")
+        assertEquals("YouTube", badge.displayName)
+        assertEquals(Color(0xFF0000), badge.color)
+    }
+
+    @Test
+    fun `spotify maps to spotify green`() {
+        val badge = SourceBadges.forSource("spotify")
+        assertEquals("Spotify", badge.displayName)
+        assertEquals(Color(0x1DB954), badge.color)
+    }
+
+    @Test
+    fun `soundcloud maps to orange`() {
+        val badge = SourceBadges.forSource("soundcloud")
+        assertEquals("SoundCloud", badge.displayName)
+        assertEquals(Color(0xFF5500), badge.color)
+    }
+
+    @Test
+    fun `apple music maps to applemusic key`() {
+        val badge = SourceBadges.forSource("applemusic")
+        assertEquals("Apple Music", badge.displayName)
+        assertEquals(Color(0xFA243C), badge.color)
+    }
+
+    @Test
+    fun `bandcamp maps correctly`() {
+        val badge = SourceBadges.forSource("bandcamp")
+        assertEquals("Bandcamp", badge.displayName)
+    }
+
+    @Test
+    fun `vimeo maps correctly`() {
+        val badge = SourceBadges.forSource("vimeo")
+        assertEquals("Vimeo", badge.displayName)
+    }
+
+    @Test
+    fun `deezer maps correctly`() {
+        val badge = SourceBadges.forSource("deezer")
+        assertEquals("Deezer", badge.displayName)
+    }
+
+    @Test
+    fun `yandexmusic maps correctly`() {
+        val badge = SourceBadges.forSource("yandexmusic")
+        assertEquals("Yandex Music", badge.displayName)
+    }
+
+    @Test
+    fun `twitch maps to twitch purple`() {
+        val badge = SourceBadges.forSource("twitch")
+        assertEquals("Twitch", badge.displayName)
+        assertEquals(Color(0x9146FF), badge.color)
+    }
+
+    @Test
+    fun `case-insensitive lookup works`() {
+        val lower = SourceBadges.forSource("youtube")
+        val upper = SourceBadges.forSource("YOUTUBE")
+        val mixed = SourceBadges.forSource("YouTube")
+        assertEquals(lower.displayName, upper.displayName)
+        assertEquals(lower.displayName, mixed.displayName)
+        assertEquals(lower.color, upper.color)
+    }
+
+    @Test
+    fun `unknown source falls back to default`() {
+        val badge = SourceBadges.forSource("definitely-not-a-real-source")
+        assertEquals("Music", badge.displayName)
+        // Default color is not any of the known source colors
+        assertNotEquals(Color(0xFF0000), badge.color)
+        assertNotEquals(Color(0x1DB954), badge.color)
+    }
+
+    @Test
+    fun `null source falls back to default`() {
+        val badge = SourceBadges.forSource(null)
+        assertEquals("Music", badge.displayName)
+    }
+}

--- a/web/src/main/kotlin/web/configuration/WebSecurityConfig.kt
+++ b/web/src/main/kotlin/web/configuration/WebSecurityConfig.kt
@@ -29,6 +29,7 @@ class WebSecurityConfig {
                 auth.requestMatchers("/tip/**").authenticated()
                 auth.requestMatchers("/duel/**").authenticated()
                 auth.requestMatchers("/poker/**").authenticated()
+                auth.requestMatchers("/music-player/**").authenticated()
                 auth.anyRequest().authenticated()
             }
             .oauth2Login { oauth2 ->

--- a/web/src/main/kotlin/web/controller/MusicWebController.kt
+++ b/web/src/main/kotlin/web/controller/MusicWebController.kt
@@ -1,0 +1,339 @@
+package web.controller
+
+import core.music.MusicControlGateway
+import database.service.MusicPlaylistService.PlaylistNameTakenException
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient
+import org.springframework.security.oauth2.client.annotation.RegisteredOAuth2AuthorizedClient
+import org.springframework.security.oauth2.core.user.OAuth2User
+import org.springframework.stereotype.Controller
+import org.springframework.ui.Model
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.ResponseBody
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
+import org.springframework.web.servlet.mvc.support.RedirectAttributes
+import web.service.MusicSseService
+import web.service.MusicWebService
+import web.util.WebGuildAccess
+import web.util.discordIdOrNull
+import web.util.discordIdString
+import web.util.displayName
+
+@Controller
+@RequestMapping("/music-player")
+class MusicWebController(
+    private val musicWebService: MusicWebService,
+    private val sseService: MusicSseService,
+) {
+
+    data class ApiResult(val ok: Boolean, val message: String? = null)
+    data class LoadRequest(val query: String = "")
+    data class SkipRequest(val count: Int = 1)
+    data class VolumeRequest(val volume: Int = 100)
+    data class SeekRequest(val positionMs: Long = 0)
+    data class LoopRequest(val looping: Boolean = false)
+    data class ReorderRequest(val from: Int = 0, val to: Int = 0)
+    data class SavePlaylistRequest(val name: String = "")
+    data class SavePlaylistResponse(val ok: Boolean, val id: Long? = null, val message: String? = null)
+
+    @GetMapping("/guilds")
+    fun guildList(
+        @RegisteredOAuth2AuthorizedClient("discord") client: OAuth2AuthorizedClient,
+        @AuthenticationPrincipal user: OAuth2User,
+        model: Model,
+    ): String {
+        val accessToken = client.accessToken.tokenValue
+        val discordId = user.discordIdOrNull() ?: return "redirect:/login"
+        val guilds = musicWebService.listGuildsForUser(accessToken, discordId)
+        model.addAttribute("guilds", guilds)
+        model.addAttribute("username", user.displayName())
+        model.addAttribute("discordId", user.discordIdString())
+        return "music-guilds"
+    }
+
+    @GetMapping("/{guildId}")
+    fun dashboard(
+        @PathVariable guildId: Long,
+        @AuthenticationPrincipal user: OAuth2User,
+        model: Model,
+        ra: RedirectAttributes,
+    ): String = WebGuildAccess.requireForPage(
+        user = user,
+        guildId = guildId,
+        ra = ra,
+        lobbyPath = "/music-player/guilds",
+        check = musicWebService::isMember,
+    ) { discordId ->
+        val guildName = musicWebService.getGuildName(guildId) ?: run {
+            ra.addFlashAttribute("error", "Bot is not in that server.")
+            return@requireForPage "redirect:/music-player/guilds"
+        }
+        model.addAttribute("guildId", guildId)
+        model.addAttribute("guildName", guildName)
+        model.addAttribute("username", user.displayName())
+        model.addAttribute("discordId", discordId.toString())
+        "music-player"
+    }
+
+    data class StateResponse(val state: MusicControlGateway.GuildPlayerState? = null, val error: String? = null)
+
+    @GetMapping("/{guildId}/state")
+    @ResponseBody
+    fun state(
+        @PathVariable guildId: Long,
+        @AuthenticationPrincipal user: OAuth2User?,
+    ): ResponseEntity<StateResponse> =
+        guarded(user, guildId, { StateResponse(error = "Unauthorized") }) {
+            val state = musicWebService.getState(guildId)
+                ?: return@guarded ResponseEntity.status(404).body(StateResponse(error = "No state"))
+            ResponseEntity.ok(StateResponse(state = state))
+        }
+
+    @GetMapping("/{guildId}/events")
+    fun stream(
+        @PathVariable guildId: Long,
+        @AuthenticationPrincipal user: OAuth2User?,
+    ): ResponseEntity<SseEmitter> {
+        val discordId = user?.discordIdOrNull() ?: return ResponseEntity.status(401).build()
+        if (!musicWebService.isMember(discordId, guildId)) return ResponseEntity.status(403).build()
+        return ResponseEntity.ok(sseService.register(guildId))
+    }
+
+    @PostMapping("/{guildId}/load")
+    @ResponseBody
+    fun load(
+        @PathVariable guildId: Long,
+        @AuthenticationPrincipal user: OAuth2User?,
+        @RequestBody body: LoadRequest,
+    ): ResponseEntity<ApiResult> = guard(user, guildId) { discordId ->
+        if (body.query.isBlank()) {
+            return@guard ResponseEntity.badRequest().body(ApiResult(false, "Query is required"))
+        }
+        val result = musicWebService.load(guildId, body.query, discordId)
+        ResponseEntity.ok(ApiResult(result.ok, result.message))
+    }
+
+    @GetMapping("/{guildId}/search")
+    @ResponseBody
+    fun search(
+        @PathVariable guildId: Long,
+        @RequestParam("q") query: String,
+        @AuthenticationPrincipal user: OAuth2User?,
+    ): ResponseEntity<List<MusicControlGateway.TrackInfo>> =
+        guarded(user, guildId, ::emptyList) {
+            if (query.isBlank()) return@guarded ResponseEntity.ok(emptyList())
+            ResponseEntity.ok(musicWebService.search(guildId, query))
+        }
+
+    @PostMapping("/{guildId}/pause")
+    @ResponseBody
+    fun pause(
+        @PathVariable guildId: Long,
+        @AuthenticationPrincipal user: OAuth2User?,
+    ): ResponseEntity<ApiResult> = guard(user, guildId) {
+        ResponseEntity.ok(ApiResult(musicWebService.pause(guildId)))
+    }
+
+    @PostMapping("/{guildId}/resume")
+    @ResponseBody
+    fun resume(
+        @PathVariable guildId: Long,
+        @AuthenticationPrincipal user: OAuth2User?,
+    ): ResponseEntity<ApiResult> = guard(user, guildId) {
+        ResponseEntity.ok(ApiResult(musicWebService.resume(guildId)))
+    }
+
+    @PostMapping("/{guildId}/skip")
+    @ResponseBody
+    fun skip(
+        @PathVariable guildId: Long,
+        @AuthenticationPrincipal user: OAuth2User?,
+        @RequestBody body: SkipRequest,
+    ): ResponseEntity<ApiResult> = guard(user, guildId) {
+        if (body.count <= 0) {
+            return@guard ResponseEntity.badRequest().body(ApiResult(false, "count must be >= 1"))
+        }
+        ResponseEntity.ok(ApiResult(musicWebService.skip(guildId, body.count)))
+    }
+
+    @PostMapping("/{guildId}/stop")
+    @ResponseBody
+    fun stop(
+        @PathVariable guildId: Long,
+        @AuthenticationPrincipal user: OAuth2User?,
+    ): ResponseEntity<ApiResult> = guard(user, guildId) {
+        ResponseEntity.ok(ApiResult(musicWebService.stop(guildId)))
+    }
+
+    @PostMapping("/{guildId}/volume")
+    @ResponseBody
+    fun volume(
+        @PathVariable guildId: Long,
+        @AuthenticationPrincipal user: OAuth2User?,
+        @RequestBody body: VolumeRequest,
+    ): ResponseEntity<ApiResult> = guard(user, guildId) {
+        if (body.volume < 0 || body.volume > 150) {
+            return@guard ResponseEntity.badRequest().body(ApiResult(false, "volume must be 0..150"))
+        }
+        ResponseEntity.ok(ApiResult(musicWebService.setVolume(guildId, body.volume)))
+    }
+
+    @PostMapping("/{guildId}/seek")
+    @ResponseBody
+    fun seek(
+        @PathVariable guildId: Long,
+        @AuthenticationPrincipal user: OAuth2User?,
+        @RequestBody body: SeekRequest,
+    ): ResponseEntity<ApiResult> = guard(user, guildId) {
+        if (body.positionMs < 0) {
+            return@guard ResponseEntity.badRequest().body(ApiResult(false, "positionMs must be >= 0"))
+        }
+        ResponseEntity.ok(ApiResult(musicWebService.seek(guildId, body.positionMs)))
+    }
+
+    @PostMapping("/{guildId}/loop")
+    @ResponseBody
+    fun loop(
+        @PathVariable guildId: Long,
+        @AuthenticationPrincipal user: OAuth2User?,
+        @RequestBody body: LoopRequest,
+    ): ResponseEntity<ApiResult> = guard(user, guildId) {
+        ResponseEntity.ok(ApiResult(musicWebService.setLooping(guildId, body.looping)))
+    }
+
+    @PostMapping("/{guildId}/queue/reorder")
+    @ResponseBody
+    fun reorder(
+        @PathVariable guildId: Long,
+        @AuthenticationPrincipal user: OAuth2User?,
+        @RequestBody body: ReorderRequest,
+    ): ResponseEntity<ApiResult> = guard(user, guildId) {
+        if (body.from < 0 || body.to < 0) {
+            return@guard ResponseEntity.badRequest().body(ApiResult(false, "indices must be >= 0"))
+        }
+        val ok = musicWebService.reorderQueue(guildId, body.from, body.to)
+        if (ok) ResponseEntity.ok(ApiResult(true))
+        else ResponseEntity.badRequest().body(ApiResult(false, "Invalid indices"))
+    }
+
+    @DeleteMapping("/{guildId}/queue/{index}")
+    @ResponseBody
+    fun removeQueueItem(
+        @PathVariable guildId: Long,
+        @PathVariable index: Int,
+        @AuthenticationPrincipal user: OAuth2User?,
+    ): ResponseEntity<ApiResult> = guard(user, guildId) {
+        val removed = musicWebService.removeFromQueue(guildId, index)
+        if (removed != null) ResponseEntity.ok(ApiResult(true))
+        else ResponseEntity.status(404).body(ApiResult(false, "No track at index $index"))
+    }
+
+    @GetMapping("/{guildId}/playlists")
+    @ResponseBody
+    fun listPlaylists(
+        @PathVariable guildId: Long,
+        @AuthenticationPrincipal user: OAuth2User?,
+    ): ResponseEntity<List<MusicWebService.PlaylistSummary>> =
+        guarded(user, guildId, ::emptyList) {
+            ResponseEntity.ok(musicWebService.listPlaylistsForGuild(guildId))
+        }
+
+    @PostMapping("/{guildId}/playlists")
+    @ResponseBody
+    fun createPlaylist(
+        @PathVariable guildId: Long,
+        @AuthenticationPrincipal user: OAuth2User?,
+        @RequestBody body: SavePlaylistRequest,
+    ): ResponseEntity<SavePlaylistResponse> =
+        guardedWrite(user, guildId, { SavePlaylistResponse(false, null, "Unauthorized") }) { discordId ->
+            if (body.name.isBlank()) {
+                return@guardedWrite ResponseEntity.badRequest()
+                    .body(SavePlaylistResponse(false, null, "Name is required"))
+            }
+            try {
+                val id = musicWebService.saveCurrentQueueAsPlaylist(guildId, discordId, body.name)
+                ResponseEntity.ok(SavePlaylistResponse(true, id, null))
+            } catch (e: PlaylistNameTakenException) {
+                ResponseEntity.status(409).body(SavePlaylistResponse(false, null, e.message))
+            } catch (e: IllegalArgumentException) {
+                ResponseEntity.badRequest().body(SavePlaylistResponse(false, null, e.message))
+            } catch (e: IllegalStateException) {
+                ResponseEntity.badRequest().body(SavePlaylistResponse(false, null, e.message))
+            }
+        }
+
+    @PostMapping("/{guildId}/playlists/{playlistId}/load")
+    @ResponseBody
+    fun loadPlaylist(
+        @PathVariable guildId: Long,
+        @PathVariable playlistId: Long,
+        @AuthenticationPrincipal user: OAuth2User?,
+    ): ResponseEntity<ApiResult> = guard(user, guildId) { discordId ->
+        val result = musicWebService.loadPlaylistIntoQueue(guildId, playlistId, discordId)
+        if (result.ok) ResponseEntity.ok(ApiResult(true, "Loaded ${result.tracksLoaded} tracks (${result.tracksFailed} failed)"))
+        else ResponseEntity.status(404).body(ApiResult(false, result.message ?: "Failed to load playlist"))
+    }
+
+    @DeleteMapping("/{guildId}/playlists/{playlistId}")
+    @ResponseBody
+    fun deletePlaylist(
+        @PathVariable guildId: Long,
+        @PathVariable playlistId: Long,
+        @AuthenticationPrincipal user: OAuth2User?,
+    ): ResponseEntity<ApiResult> = guard(user, guildId) { discordId ->
+        val ok = musicWebService.deletePlaylist(playlistId, discordId, isGuildAdmin = false)
+        if (ok) ResponseEntity.ok(ApiResult(true))
+        else ResponseEntity.status(403).body(ApiResult(false, "Only the owner can delete this playlist"))
+    }
+
+    /**
+     * Read-only auth wrapper — guild membership is enough. Used by `/state`,
+     * `/events`, `/search`, `/playlists` (GET). Generic [T] lets each caller
+     * pick its own response body shape; [errorBody] supplies the body for
+     * 401 / 403 so the shape matches the endpoint's success response.
+     */
+    private inline fun <T : Any> guarded(
+        user: OAuth2User?,
+        guildId: Long,
+        errorBody: () -> T,
+        block: (discordId: Long) -> ResponseEntity<T>,
+    ): ResponseEntity<T> = WebGuildAccess.requireForJson(
+        user = user,
+        guildId = guildId,
+        check = musicWebService::isMember,
+        errorBuilder = { status -> ResponseEntity.status(status).body(errorBody()) },
+        block = block,
+    )
+
+    /**
+     * Write-flavoured auth wrapper — requires guild membership AND the
+     * caller's per-guild `musicPermission` flag (the same gate every music
+     * slash command uses). Revoking music via `/adjust` or the moderation
+     * UI cuts off the web dashboard too.
+     */
+    private inline fun <T : Any> guardedWrite(
+        user: OAuth2User?,
+        guildId: Long,
+        errorBody: () -> T,
+        block: (discordId: Long) -> ResponseEntity<T>,
+    ): ResponseEntity<T> = WebGuildAccess.requireForJson(
+        user = user,
+        guildId = guildId,
+        check = musicWebService::canControlMusic,
+        errorBuilder = { status -> ResponseEntity.status(status).body(errorBody()) },
+        block = block,
+    )
+
+    private inline fun guard(
+        user: OAuth2User?,
+        guildId: Long,
+        block: (discordId: Long) -> ResponseEntity<ApiResult>,
+    ): ResponseEntity<ApiResult> = guardedWrite(user, guildId, { ApiResult(false, "Unauthorized") }, block)
+}

--- a/web/src/main/kotlin/web/service/MusicSseService.kt
+++ b/web/src/main/kotlin/web/service/MusicSseService.kt
@@ -1,0 +1,134 @@
+package web.service
+
+import core.music.MusicControlGateway
+import core.music.events.LoopStateChangedEvent
+import core.music.events.PauseStateChangedEvent
+import core.music.events.QueueChangedEvent
+import core.music.events.TrackEndedEvent
+import core.music.events.TrackStartedEvent
+import core.music.events.VolumeChangedEvent
+import org.springframework.context.event.EventListener
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Service
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
+import java.io.IOException
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CopyOnWriteArrayList
+
+@Service
+class MusicSseService(
+    private val gateway: MusicControlGateway,
+    private val musicWebService: MusicWebService,
+) {
+    private val emitters = ConcurrentHashMap<Long, CopyOnWriteArrayList<SseEmitter>>()
+
+    fun register(guildId: Long): SseEmitter {
+        val emitter = SseEmitter(EMITTER_TIMEOUT_MS)
+        val list = emitters.computeIfAbsent(guildId) { CopyOnWriteArrayList() }
+        list.add(emitter)
+        emitter.onCompletion { list.remove(emitter) }
+        emitter.onTimeout { list.remove(emitter); emitter.complete() }
+        emitter.onError { list.remove(emitter) }
+        // Send an immediate hello so the client knows the channel is live.
+        runCatching {
+            emitter.send(SseEmitter.event().name("hello").data(mapOf("guildId" to guildId)))
+        }.onFailure { list.remove(emitter) }
+        return emitter
+    }
+
+    @EventListener
+    fun onTrackStart(event: TrackStartedEvent) {
+        val enriched = event.copy(track = musicWebService.enrichRequester(event.track, event.guildId))
+        fanOut(event.guildId, "trackStart", enriched)
+    }
+
+    @EventListener
+    fun onTrackEnd(event: TrackEndedEvent) =
+        fanOut(event.guildId, "trackEnd", event)
+
+    @EventListener
+    fun onQueueChanged(event: QueueChangedEvent) {
+        val enriched = event.copy(
+            queue = event.queue.map { musicWebService.enrichRequester(it, event.guildId) },
+        )
+        fanOut(event.guildId, "queueChanged", enriched)
+    }
+
+    @EventListener
+    fun onPauseStateChanged(event: PauseStateChangedEvent) =
+        fanOut(event.guildId, "pauseStateChanged", event)
+
+    @EventListener
+    fun onVolumeChanged(event: VolumeChangedEvent) =
+        fanOut(event.guildId, "volumeChanged", event)
+
+    @EventListener
+    fun onLoopStateChanged(event: LoopStateChangedEvent) =
+        fanOut(event.guildId, "loopStateChanged", event)
+
+    /**
+     * Per-second position tick. We don't emit for guilds with no active
+     * subscribers or no playing track — saves both CPU and bandwidth.
+     */
+    @Scheduled(fixedRate = 1000)
+    fun publishPositionTicks() {
+        for ((guildId, list) in emitters) {
+            if (list.isEmpty()) continue
+            val state = gateway.getState(guildId) ?: continue
+            val track = state.nowPlaying ?: continue
+            if (state.paused) continue
+            fanOut(
+                guildId,
+                "positionTick",
+                mapOf(
+                    "guildId" to guildId,
+                    "positionMs" to state.positionMs,
+                    "durationMs" to track.durationMs,
+                ),
+            )
+        }
+    }
+
+    /**
+     * Proxy heartbeat so idle SSE connections don't get torn down by
+     * intermediaries (e.g. Heroku's 55s idle timeout).
+     */
+    @Scheduled(fixedRate = 15_000)
+    fun heartbeat() {
+        for (list in emitters.values) {
+            broadcast(list) { send(SseEmitter.event().comment("hb")) }
+        }
+    }
+
+    private fun fanOut(guildId: Long, name: String, payload: Any) {
+        val list = emitters[guildId] ?: return
+        broadcast(list) { send(SseEmitter.event().name(name).data(payload)) }
+    }
+
+    /**
+     * Iterate [list] and call [action] on each emitter; emitters that throw
+     * IOException / IllegalStateException (typical "client gone" signals) are
+     * evicted from the list. Centralises the dead-emitter eviction pattern.
+     */
+    private inline fun broadcast(list: CopyOnWriteArrayList<SseEmitter>, action: SseEmitter.() -> Unit) {
+        if (list.isEmpty()) return
+        val dead = mutableListOf<SseEmitter>()
+        for (emitter in list) {
+            try {
+                emitter.action()
+            } catch (_: IOException) {
+                dead.add(emitter)
+            } catch (_: IllegalStateException) {
+                dead.add(emitter)
+            }
+        }
+        if (dead.isNotEmpty()) list.removeAll(dead)
+    }
+
+    companion object {
+        // 1 hour — long enough that the browser will close the channel before
+        // we hit it on a normal session; reconnect logic in music-player.js handles
+        // any expiry.
+        private const val EMITTER_TIMEOUT_MS = 60L * 60L * 1000L
+    }
+}

--- a/web/src/main/kotlin/web/service/MusicWebService.kt
+++ b/web/src/main/kotlin/web/service/MusicWebService.kt
@@ -1,0 +1,184 @@
+package web.service
+
+import core.music.MusicControlGateway
+import core.music.MusicControlGateway.GuildPlayerState
+import core.music.MusicControlGateway.LoadResult
+import core.music.MusicControlGateway.TrackInfo
+import database.service.MusicPlaylistService
+import database.service.MusicPlaylistService.PlaylistItemInput
+import database.service.UserService
+import net.dv8tion.jda.api.JDA
+import org.springframework.stereotype.Service
+import web.util.GuildMembership
+
+@Service
+class MusicWebService(
+    private val gateway: MusicControlGateway,
+    private val playlistService: MusicPlaylistService,
+    private val jda: JDA,
+    private val introWebService: IntroWebService,
+    private val membership: GuildMembership,
+    private val userService: UserService,
+) {
+    data class GuildCardView(
+        val id: String,
+        val name: String,
+        val iconUrl: String?,
+        val nowPlayingTitle: String?,
+    )
+
+    data class PlaylistSummary(
+        val id: Long,
+        val name: String,
+        val ownerDiscordId: Long,
+        val trackCount: Int,
+    )
+
+    fun getGuildName(guildId: Long): String? = jda.getGuildById(guildId)?.name
+
+    fun listGuildsForUser(accessToken: String, discordId: Long): List<GuildCardView> {
+        return introWebService.getMutualGuilds(accessToken).mapNotNull { info ->
+            val guildId = info.id.toLongOrNull() ?: return@mapNotNull null
+            val now = gateway.getState(guildId)?.nowPlaying?.title
+            GuildCardView(info.id, info.name, info.iconUrl, now)
+        }.sortedBy { it.name.lowercase() }
+    }
+
+    fun getState(guildId: Long): GuildPlayerState? {
+        val raw = gateway.getState(guildId) ?: return null
+        val guild = jda.getGuildById(guildId) ?: return raw
+        return raw.copy(
+            nowPlaying = raw.nowPlaying?.let { enrichRequester(it, guild) },
+            queue = raw.queue.map { enrichRequester(it, guild) },
+        )
+    }
+
+    /**
+     * Fill in the requester's display name + avatar URL from the guild's
+     * cached members. Returns the input unchanged when there's no requester
+     * id (e.g. preview / removed-track results) or the member has left the
+     * guild and isn't cached.
+     */
+    fun enrichRequester(track: TrackInfo, guildId: Long): TrackInfo {
+        val guild = jda.getGuildById(guildId) ?: return track
+        return enrichRequester(track, guild)
+    }
+
+    private fun enrichRequester(track: TrackInfo, guild: net.dv8tion.jda.api.entities.Guild): TrackInfo {
+        val requesterId = track.requesterDiscordId ?: return track
+        val member = guild.getMemberById(requesterId) ?: return track
+        return track.copy(
+            requesterDisplayName = member.effectiveName,
+            requesterAvatarUrl = member.effectiveAvatarUrl,
+        )
+    }
+
+    fun load(guildId: Long, query: String, discordId: Long): LoadResult =
+        gateway.load(guildId, query.trim(), discordId)
+
+    fun search(guildId: Long, query: String, limit: Int = 10): List<TrackInfo> =
+        gateway.search(guildId, query.trim(), limit)
+
+    fun pause(guildId: Long): Boolean = gateway.pause(guildId)
+    fun resume(guildId: Long): Boolean = gateway.resume(guildId)
+    fun skip(guildId: Long, count: Int): Boolean = gateway.skip(guildId, count)
+    fun stop(guildId: Long): Boolean = gateway.stop(guildId)
+
+    fun setVolume(guildId: Long, volume: Int): Boolean = gateway.setVolume(guildId, volume)
+    fun seek(guildId: Long, positionMs: Long): Boolean = gateway.seek(guildId, positionMs)
+    fun setLooping(guildId: Long, looping: Boolean): Boolean = gateway.setLooping(guildId, looping)
+
+    fun reorderQueue(guildId: Long, fromIndex: Int, toIndex: Int): Boolean =
+        gateway.reorderQueue(guildId, fromIndex, toIndex)
+
+    fun removeFromQueue(guildId: Long, index: Int): TrackInfo? =
+        gateway.removeFromQueue(guildId, index)
+
+    fun listPlaylistsForGuild(guildId: Long): List<PlaylistSummary> =
+        playlistService.listForGuild(guildId).map {
+            PlaylistSummary(
+                id = it.id ?: -1L,
+                name = it.name,
+                ownerDiscordId = it.ownerDiscordId,
+                trackCount = it.items.size,
+            )
+        }
+
+    /**
+     * Snapshot the current queue (including the now-playing track at position 0)
+     * into a new playlist owned by [discordId].
+     */
+    fun saveCurrentQueueAsPlaylist(guildId: Long, discordId: Long, name: String): Long {
+        val state = gateway.getState(guildId)
+            ?: throw IllegalStateException("Player state unavailable for guild $guildId")
+        val tracks = buildList {
+            state.nowPlaying?.let { add(it) }
+            addAll(state.queue)
+        }
+        if (tracks.isEmpty()) {
+            throw IllegalArgumentException("Nothing to save — queue is empty.")
+        }
+        val items = tracks.map { it.toPlaylistInput() }
+        val saved = playlistService.create(guildId, discordId, name, items)
+        return saved.id ?: -1L
+    }
+
+    /**
+     * Re-load each track in the saved playlist via the gateway. Errors on
+     * individual tracks are surfaced as failed entries in the result.
+     */
+    fun loadPlaylistIntoQueue(guildId: Long, playlistId: Long, discordId: Long): LoadPlaylistOutcome {
+        val playlist = playlistService.getById(playlistId)
+            ?: return LoadPlaylistOutcome(false, 0, 0, "Playlist not found")
+        if (playlist.guildId != guildId) {
+            return LoadPlaylistOutcome(false, 0, 0, "Playlist does not belong to this guild")
+        }
+        var loaded = 0
+        var failed = 0
+        for (item in playlist.items.sortedBy { it.position }) {
+            val result = gateway.load(guildId, item.identifier, discordId)
+            if (result.ok) loaded += result.tracksAdded else failed += 1
+        }
+        return LoadPlaylistOutcome(loaded > 0, loaded, failed, null)
+    }
+
+    data class LoadPlaylistOutcome(
+        val ok: Boolean,
+        val tracksLoaded: Int,
+        val tracksFailed: Int,
+        val message: String?,
+    )
+
+    fun deletePlaylist(playlistId: Long, requestingDiscordId: Long, isGuildAdmin: Boolean): Boolean {
+        val playlist = playlistService.getById(playlistId) ?: return false
+        if (playlist.ownerDiscordId != requestingDiscordId && !isGuildAdmin) return false
+        playlistService.deleteById(playlistId)
+        return true
+    }
+
+    fun isMember(discordId: Long, guildId: Long): Boolean = membership.isMember(discordId, guildId)
+
+    /**
+     * Mirror the slash-command gate (every music command checks
+     * `requestingUserDto.musicPermission` before doing anything). Web-side
+     * mutators are routed through this so revoking music permission via
+     * `/adjust` or the moderation UI also cuts off the web dashboard.
+     *
+     * Read-only endpoints (`/state`, `/events`, `/playlists` GET) keep the
+     * cheaper guild-member-only check — visibility doesn't change anything
+     * audible in the voice channel.
+     */
+    fun canControlMusic(discordId: Long, guildId: Long): Boolean {
+        if (!isMember(discordId, guildId)) return false
+        val user = userService.getUserById(discordId, guildId) ?: return true
+        return user.musicPermission
+    }
+
+    private fun TrackInfo.toPlaylistInput() = PlaylistItemInput(
+        identifier = uri ?: identifier,
+        title = title,
+        author = author,
+        durationMs = durationMs,
+        sourceName = sourceName,
+    )
+}

--- a/web/src/main/resources/static/css/base.css
+++ b/web/src/main/resources/static/css/base.css
@@ -848,14 +848,41 @@ td { font-size: 0.95rem; }
     .btn-primary,
     .btn-secondary,
     .btn-success,
-    .btn-danger { min-height: var(--tap-min); }
+    .btn-danger,
+    .btn-tertiary { min-height: var(--tap-min); }
     input[type=text], input[type=url], input[type=number], input[type=search],
-    input[type=email], input[type=password], select { min-height: 40px; }
+    input[type=email], input[type=password], select {
+        min-height: 40px;
+        /* iOS auto-zooms any focused input under 16px — pin to 16px so the
+           viewport doesn't jerk on every tap. Applied site-wide so every
+           form behaves the same on phones. */
+        font-size: 16px;
+    }
     /* Toggle pills (.toggle-btn) and segmented controls need finger room
        too — they're the primary affordance on the moderation Users tab
        and the leaderboard period switcher. */
     .toggle-btn { min-height: 36px; min-width: 56px; }
     .segmented button { min-height: 40px; }
+    /* Strip hover-only background flips on touch — every tap is a "hover"
+       on coarse pointers, so they read as accidental state. */
+    a:hover, button:hover { background: inherit; }
+}
+
+/* Shared mobile utility classes — opt in by adding the class. Hoisted
+   here so feature CSS files don't each redefine the same patterns. */
+.touch-target {
+    min-width: var(--tap-min);
+    min-height: var(--tap-min);
+    touch-action: manipulation;
+}
+@media (max-width: 480px) {
+    .stack-on-narrow {
+        flex-direction: column !important;
+        align-items: stretch !important;
+    }
+    .stack-on-narrow > * {
+        width: 100%;
+    }
 }
 
 /* ============================================================

--- a/web/src/main/resources/static/css/music-player.css
+++ b/web/src/main/resources/static/css/music-player.css
@@ -1,0 +1,623 @@
+/* Music dashboard — music-specific layout only.
+   Shared mobile primitives live in base.css:
+     - 44px tap targets on .btn / .btn-primary / .btn-secondary / .btn-danger / .btn-tertiary
+     - 16px font on inputs to dodge iOS auto-zoom
+     - hover-state stripping under (hover: none) and (pointer: coarse)
+     - .touch-target / .stack-on-narrow utilities
+   Breakpoints follow the project allowlist: 768 / 600 / 480 / 380. */
+
+.music-dashboard {
+    padding-top: 1rem;
+}
+
+.music-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    margin-bottom: 1.5rem;
+    flex-wrap: wrap;
+}
+
+.music-header h1 {
+    margin: 0;
+    font-size: 1.5rem;
+    line-height: 1.2;
+}
+
+.music-grid {
+    display: grid;
+    grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr) minmax(0, 1fr);
+    gap: 1.25rem;
+    align-items: start;
+}
+
+@media (max-width: 768px) {
+    .music-grid {
+        grid-template-columns: 1fr;
+        gap: 1rem;
+    }
+}
+
+.now-playing-card,
+.queue-card,
+.playlists-card,
+.voice-card {
+    background: var(--bg-elevated, #1e2026);
+    border: 1px solid var(--border, #2c2e35);
+    border-radius: 12px;
+    padding: 1rem 1.25rem;
+}
+
+.now-playing-empty {
+    text-align: center;
+    padding: 2rem 0;
+    color: var(--muted, #888);
+}
+.now-playing-empty .emoji {
+    font-size: 3rem;
+    display: block;
+    margin-bottom: 0.5rem;
+}
+
+.now-playing-content {
+    display: flex;
+    gap: 1rem;
+    align-items: flex-start;
+    margin-bottom: 1rem;
+}
+
+.now-playing-art {
+    width: 120px;
+    height: 120px;
+    object-fit: cover;
+    border-radius: 8px;
+    background: #000;
+    flex-shrink: 0;
+}
+
+.now-playing-meta {
+    flex: 1;
+    min-width: 0;
+}
+
+.source-badge {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 999px;
+    font-size: 0.75rem;
+    color: #fff;
+    margin-bottom: 0.25rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.now-playing-title {
+    margin: 0.25rem 0;
+    font-size: 1.15rem;
+    line-height: 1.2;
+    word-break: break-word;
+}
+
+.now-playing-title.linkable {
+    cursor: pointer;
+    text-decoration: underline;
+    text-decoration-color: rgba(255, 255, 255, 0.2);
+}
+
+.now-playing-author {
+    margin: 0 0 0.5rem;
+    color: var(--muted, #aaa);
+}
+
+.now-playing-requester {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+    margin: 0 0 0.5rem;
+    font-size: 0.85rem;
+    color: var(--muted, #888);
+}
+.now-playing-requester-label {
+    flex-shrink: 0;
+}
+.now-playing-requester .avatar {
+    width: 22px;
+    height: 22px;
+}
+.now-playing-requester .lb-name {
+    font-size: 0.85rem;
+    color: var(--text, #fff);
+}
+
+.progress-row {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+    margin-top: 0.5rem;
+}
+
+.progress-track {
+    flex: 1;
+    /* Hit-target larger than the visible bar; transparent padding around it
+       gives finger-sized scrubbing on touch without making the bar chunky. */
+    height: 18px;
+    padding: 6px 0;
+    background-clip: content-box;
+    background-color: rgba(255, 255, 255, 0.1);
+    border-radius: 3px;
+    cursor: pointer;
+    overflow: hidden;
+    touch-action: manipulation;
+}
+
+.progress-fill {
+    height: 100%;
+    width: 0;
+    background: var(--accent, #5865f2);
+    border-radius: 3px;
+    transition: width 0.4s linear;
+}
+
+.time-current,
+.time-total {
+    font-variant-numeric: tabular-nums;
+    font-size: 0.85rem;
+    color: var(--muted, #aaa);
+    min-width: 3em;
+    text-align: center;
+}
+
+.transport-row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+}
+
+.btn-transport {
+    background: rgba(255, 255, 255, 0.05);
+    color: inherit;
+    border: 1px solid var(--border, #2c2e35);
+    border-radius: 8px;
+    min-width: var(--tap-min);
+    min-height: var(--tap-min);
+    padding: 0.5rem 0.75rem;
+    font-size: 1.2rem;
+    cursor: pointer;
+    touch-action: manipulation;
+}
+.btn-transport:hover { background: rgba(255, 255, 255, 0.1); }
+.btn-transport.active { background: var(--accent, #5865f2); border-color: var(--accent, #5865f2); }
+.btn-transport.btn-danger { color: #f25865; }
+.btn-transport.btn-danger:hover { background: rgba(242, 88, 101, 0.1); }
+
+.volume-label {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-left: auto;
+}
+.volume-label input[type=range] {
+    width: 120px;
+    height: 32px;
+    touch-action: manipulation;
+}
+
+/* Queue */
+.queue-card h2,
+.playlists-card h2,
+.voice-card h2 {
+    margin: 0 0 0.75rem;
+    font-size: 1rem;
+}
+
+.add-track-form,
+.save-playlist-form {
+    display: flex;
+    gap: 0.5rem;
+    margin-bottom: 0.5rem;
+    flex-wrap: wrap;
+}
+.add-track-form input,
+.save-playlist-form input {
+    flex: 1;
+    min-width: 0;
+    padding: 0.5rem 0.75rem;
+    background: rgba(0, 0, 0, 0.25);
+    border: 1px solid var(--border, #2c2e35);
+    border-radius: 6px;
+    color: inherit;
+}
+.add-track-hint {
+    margin: 0 0 0.5rem;
+    font-size: 0.8rem;
+}
+
+/* Search results */
+.search-results-section {
+    margin: 0.5rem 0 0.75rem;
+    padding: 0.5rem;
+    background: rgba(88, 101, 242, 0.06);
+    border: 1px solid rgba(88, 101, 242, 0.25);
+    border-radius: 8px;
+}
+.search-results-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    margin-bottom: 0.5rem;
+}
+.search-results-title {
+    margin: 0;
+    font-size: 0.9rem;
+    font-weight: 600;
+}
+.search-results-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+.search-result {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem;
+    background: rgba(255, 255, 255, 0.04);
+    border-radius: 6px;
+}
+.search-result-meta { flex: 1; min-width: 0; }
+.search-result-title {
+    font-size: 0.9rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+.search-result-author {
+    font-size: 0.75rem;
+    color: var(--muted, #888);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.queue-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+
+.queue-item {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem;
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid transparent;
+    border-radius: 6px;
+    cursor: grab;
+    min-height: var(--tap-min);
+}
+.queue-item:hover { background: rgba(255, 255, 255, 0.06); }
+.queue-item.dragging { opacity: 0.4; }
+.queue-item.drop-target { border-color: var(--accent, #5865f2); }
+
+.queue-drag-handle {
+    color: var(--muted, #888);
+    cursor: grab;
+    user-select: none;
+}
+
+.queue-meta {
+    flex: 1;
+    min-width: 0;
+}
+.queue-title {
+    font-size: 0.9rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+.queue-author {
+    font-size: 0.75rem;
+    color: var(--muted, #888);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.queue-remove {
+    background: transparent;
+    color: var(--muted, #888);
+    border: none;
+    cursor: pointer;
+    font-size: 1.1rem;
+    min-width: var(--tap-min);
+    min-height: var(--tap-min);
+    touch-action: manipulation;
+}
+.queue-remove:hover { color: #f25865; }
+
+/* Playlists */
+.playlist-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.playlist-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    padding: 0.5rem;
+    background: rgba(255, 255, 255, 0.03);
+    border-radius: 6px;
+    flex-wrap: wrap;
+    min-height: var(--tap-min);
+}
+
+.playlist-meta { min-width: 0; flex: 1; }
+.playlist-name { font-size: 0.9rem; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.playlist-count { font-size: 0.75rem; }
+
+.playlist-actions {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+}
+
+/* Voice channel members */
+.voice-channel-name {
+    margin: 0 0 0.5rem;
+    font-size: 0.85rem;
+    color: var(--muted, #aaa);
+}
+.voice-channel-empty {
+    color: var(--muted, #888);
+    font-size: 0.85rem;
+}
+.voice-member-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+.voice-member {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.25rem 0.4rem;
+    border-radius: 6px;
+}
+.voice-member-avatar {
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    object-fit: cover;
+    flex-shrink: 0;
+    background: rgba(255, 255, 255, 0.1);
+}
+.voice-member-name {
+    flex: 1;
+    min-width: 0;
+    font-size: 0.9rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+.voice-member.is-bot .voice-member-name { color: var(--accent, #5865f2); font-weight: 600; }
+.voice-member-mute,
+.voice-member-deaf {
+    font-size: 0.85rem;
+    opacity: 0.7;
+}
+
+/* Music guilds picker — richer card design */
+.music-guild-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+    gap: 1rem;
+}
+.music-guild-card {
+    background: var(--bg-elevated, #1e2026);
+    border: 1px solid var(--border, #2c2e35);
+    border-radius: 12px;
+    padding: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    transition: transform 0.15s ease, border-color 0.15s ease;
+}
+.music-guild-card:hover {
+    border-color: var(--accent, #5865f2);
+    transform: translateY(-2px);
+}
+.music-guild-card-head {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+.music-guild-icon {
+    width: 48px;
+    height: 48px;
+    border-radius: 12px;
+    object-fit: cover;
+    background: rgba(255, 255, 255, 0.05);
+    flex-shrink: 0;
+}
+.music-guild-name {
+    margin: 0;
+    font-size: 1rem;
+    line-height: 1.2;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
+    -webkit-box-orient: vertical;
+}
+.music-guild-status {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    min-height: 2.5em;
+    padding: 0.5rem 0.6rem;
+    border-radius: 8px;
+    background: rgba(255, 255, 255, 0.03);
+    font-size: 0.85rem;
+    color: var(--muted, #aaa);
+}
+.music-guild-status.is-playing {
+    background: rgba(88, 101, 242, 0.12);
+    color: inherit;
+}
+.music-guild-status-icon {
+    flex-shrink: 0;
+    font-size: 1.1rem;
+}
+.music-guild-status-text {
+    flex: 1;
+    min-width: 0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+.music-guild-actions {
+    margin-top: auto;
+}
+.music-guild-actions a {
+    display: block;
+    text-align: center;
+    width: 100%;
+}
+
+/* ---------------------------------------------------------------- */
+/* Phone tier — compact card chrome, full-width volume.              */
+/* ---------------------------------------------------------------- */
+@media (max-width: 600px) {
+    .music-dashboard {
+        padding-top: 0.5rem;
+    }
+    .music-header {
+        margin-bottom: 1rem;
+    }
+    .music-header h1 {
+        font-size: 1.25rem;
+    }
+    .now-playing-card,
+    .queue-card,
+    .playlists-card,
+    .voice-card {
+        padding: 0.875rem 1rem;
+        border-radius: 10px;
+    }
+    .now-playing-empty {
+        padding: 1.25rem 0;
+    }
+    .now-playing-empty .emoji {
+        font-size: 2.25rem;
+    }
+    .now-playing-art {
+        width: 96px;
+        height: 96px;
+    }
+    .now-playing-title {
+        font-size: 1.05rem;
+    }
+    .progress-row {
+        gap: 0.4rem;
+    }
+    .time-current,
+    .time-total {
+        font-size: 0.8rem;
+        min-width: 2.75em;
+    }
+    .transport-row {
+        gap: 0.4rem;
+    }
+    .volume-label {
+        margin-left: 0;
+        width: 100%;
+        order: 99;
+    }
+    .volume-label input[type=range] {
+        flex: 1;
+        width: auto;
+    }
+    .add-track-hint {
+        font-size: 0.75rem;
+    }
+    .music-guild-grid {
+        grid-template-columns: 1fr;
+    }
+}
+
+/* ---------------------------------------------------------------- */
+/* Narrow-phone tier — stack art above text; stack form rows.       */
+/* ---------------------------------------------------------------- */
+@media (max-width: 480px) {
+    .now-playing-content {
+        flex-direction: column;
+        align-items: center;
+        text-align: center;
+        gap: 0.75rem;
+    }
+    .now-playing-art {
+        width: 140px;
+        height: 140px;
+    }
+    .now-playing-meta {
+        width: 100%;
+    }
+    .now-playing-title.linkable {
+        text-decoration: none;
+    }
+    .add-track-form,
+    .save-playlist-form {
+        flex-direction: column;
+    }
+    .add-track-form button,
+    .save-playlist-form button {
+        width: 100%;
+    }
+    .playlist-item {
+        flex-direction: column;
+        align-items: stretch;
+    }
+    .playlist-actions {
+        justify-content: stretch;
+    }
+    .playlist-actions button {
+        flex: 1;
+    }
+}
+
+/* ---------------------------------------------------------------- */
+/* Coarse-pointer (touch) — drag-to-reorder unreliable on touch, so  */
+/* hide the handle. Generic hover-strip lives in base.css.           */
+/* ---------------------------------------------------------------- */
+@media (hover: none) and (pointer: coarse) {
+    .queue-drag-handle {
+        display: none;
+    }
+    .queue-item {
+        cursor: default;
+    }
+    .now-playing-title.linkable {
+        text-decoration: underline;
+    }
+}

--- a/web/src/main/resources/static/js/music-player.js
+++ b/web/src/main/resources/static/js/music-player.js
@@ -1,0 +1,565 @@
+// TobyBot music dashboard — wires the per-guild player UI to the
+// /music-player REST endpoints and listens to the SSE stream for
+// live updates from the Discord bot.
+(function () {
+    'use strict';
+
+    const body = document.body;
+    if (body.dataset.musicPage !== '1') return;
+
+    const guildId = body.dataset.guildId;
+    const baseUrl = '/music-player/' + guildId;
+
+    const $ = (id) => document.getElementById(id);
+
+    const els = {
+        emptyState: $('now-playing-empty'),
+        content: $('now-playing-content'),
+        art: $('now-playing-art'),
+        sourceBadge: $('source-badge'),
+        title: $('now-playing-title'),
+        author: $('now-playing-author'),
+        requester: $('now-playing-requester'),
+        requesterCell: $('now-playing-requester-cell'),
+        timeCurrent: $('time-current'),
+        timeTotal: $('time-total'),
+        progressFill: $('progress-fill'),
+        progressTrack: $('progress-track'),
+        btnPause: $('btn-pause'),
+        btnSkip: $('btn-skip'),
+        btnStop: $('btn-stop'),
+        btnLoop: $('btn-loop'),
+        volumeSlider: $('volume-slider'),
+        volumeValue: $('volume-value'),
+        queueList: $('queue-list'),
+        queueEmpty: $('queue-empty'),
+        addForm: $('add-track-form'),
+        addInput: $('add-track-input'),
+        searchSection: $('search-results-section'),
+        searchQueryLabel: $('search-results-query'),
+        searchCloseBtn: $('search-results-close'),
+        searchList: $('search-results-list'),
+        searchEmpty: $('search-results-empty'),
+        playlistList: $('playlist-list'),
+        playlistsEmpty: $('playlists-empty'),
+        savePlaylistForm: $('save-playlist-form'),
+        savePlaylistName: $('save-playlist-name'),
+        voiceChannelName: $('voice-channel-name'),
+        voiceChannelEmpty: $('voice-channel-empty'),
+        voiceMemberList: $('voice-member-list'),
+    };
+
+    let lastPaused = false;
+    let lastDurationMs = 0;
+
+    // ---- HTTP helpers --------------------------------------------------
+
+    function csrfHeaders() {
+        const headers = { 'Content-Type': 'application/json', 'Accept': 'application/json' };
+        const tokenMeta = document.querySelector('meta[name="_csrf"]');
+        const headerMeta = document.querySelector('meta[name="_csrf_header"]');
+        if (tokenMeta && headerMeta) headers[headerMeta.content] = tokenMeta.content;
+        return headers;
+    }
+
+    function getJson(path) {
+        return fetch(baseUrl + path, { credentials: 'same-origin' })
+            .then((r) => r.ok ? r.json() : Promise.reject(new Error('HTTP ' + r.status)));
+    }
+
+    function sendJson(method, path, body) {
+        const init = { method: method, credentials: 'same-origin', headers: csrfHeaders() };
+        if (body !== undefined) init.body = JSON.stringify(body);
+        return fetch(baseUrl + path, init).then((r) =>
+            r.json().catch(() => ({ ok: r.ok, message: r.ok ? null : 'Request failed' })),
+        );
+    }
+
+    const post = (path, body) => sendJson('POST', path, body);
+    const del = (path) => sendJson('DELETE', path);
+
+    // ---- Rendering -----------------------------------------------------
+
+    function formatMs(ms) {
+        if (ms == null || ms < 0 || !isFinite(ms)) return '0:00';
+        const total = Math.floor(ms / 1000);
+        const m = Math.floor(total / 60);
+        const s = total % 60;
+        return m + ':' + (s < 10 ? '0' : '') + s;
+    }
+
+    const SOURCE_COLORS = {
+        youtube: '#ff0000',
+        spotify: '#1db954',
+        soundcloud: '#ff5500',
+        applemusic: '#fa243c',
+        bandcamp: '#1da0c3',
+        vimeo: '#1ab7ea',
+        deezer: '#a238ff',
+        yandexmusic: '#ffcc00',
+        twitch: '#9146ff',
+    };
+
+    const SOURCE_LABELS = {
+        youtube: 'YouTube',
+        spotify: 'Spotify',
+        soundcloud: 'SoundCloud',
+        applemusic: 'Apple Music',
+        bandcamp: 'Bandcamp',
+        vimeo: 'Vimeo',
+        deezer: 'Deezer',
+        yandexmusic: 'Yandex Music',
+        twitch: 'Twitch',
+        http: 'Direct stream',
+        local: 'Local file',
+        nico: 'Niconico',
+    };
+
+    function renderRequester(track) {
+        // Mirrors the duel / leaderboard / moderation `.member-cell` primitive
+        // so a "Requested by" surface anywhere on the player matches the rest
+        // of the site. Hidden entirely when no requester is known (intros,
+        // playlists re-loaded by another user, etc.).
+        const name = track && track.requesterDisplayName;
+        const avatar = track && track.requesterAvatarUrl;
+        const fallback = track && track.requesterDiscordId;
+        if (!name && !fallback) {
+            els.requester.hidden = true;
+            els.requesterCell.innerHTML = '';
+            return;
+        }
+        els.requester.hidden = false;
+        els.requesterCell.innerHTML = '';
+        if (avatar) {
+            const img = document.createElement('img');
+            img.className = 'avatar';
+            img.src = avatar;
+            img.alt = '';
+            img.loading = 'lazy';
+            els.requesterCell.appendChild(img);
+        }
+        const nameEl = document.createElement('span');
+        nameEl.className = 'lb-name';
+        // textContent — guards against display names like "<script>".
+        nameEl.textContent = name || ('<@' + fallback + '>');
+        els.requesterCell.appendChild(nameEl);
+    }
+
+    function renderNowPlaying(track, paused) {
+        if (!track) {
+            els.content.hidden = true;
+            els.emptyState.hidden = false;
+            els.title.textContent = '—';
+            els.author.textContent = '—';
+            els.requester.textContent = '';
+            els.progressFill.style.width = '0%';
+            els.timeCurrent.textContent = '0:00';
+            els.timeTotal.textContent = '0:00';
+            lastDurationMs = 0;
+            return;
+        }
+        els.emptyState.hidden = true;
+        els.content.hidden = false;
+        els.title.textContent = track.title || '(untitled)';
+        if (track.uri) {
+            els.title.classList.add('linkable');
+            els.title.onclick = () => window.open(track.uri, '_blank', 'noopener');
+        } else {
+            els.title.classList.remove('linkable');
+            els.title.onclick = null;
+        }
+        els.author.textContent = track.author || '';
+        renderRequester(track);
+        if (track.artworkUrl) {
+            els.art.src = track.artworkUrl;
+            els.art.style.display = '';
+        } else {
+            els.art.removeAttribute('src');
+            els.art.style.display = 'none';
+        }
+        const source = (track.sourceName || '').toLowerCase();
+        const color = SOURCE_COLORS[source] || '#57f287';
+        const label = SOURCE_LABELS[source] || 'Music';
+        els.sourceBadge.textContent = label;
+        els.sourceBadge.style.backgroundColor = color;
+        lastDurationMs = track.durationMs || 0;
+        els.timeTotal.textContent = track.isStream ? 'LIVE' : formatMs(lastDurationMs);
+        lastPaused = !!paused;
+        els.btnPause.textContent = paused ? '▶️' : '⏸️';
+    }
+
+    function renderProgress(positionMs) {
+        if (lastDurationMs <= 0) {
+            els.progressFill.style.width = '0%';
+            els.timeCurrent.textContent = '0:00';
+            return;
+        }
+        const pct = Math.max(0, Math.min(100, (positionMs / lastDurationMs) * 100));
+        els.progressFill.style.width = pct + '%';
+        els.timeCurrent.textContent = formatMs(positionMs);
+    }
+
+    function renderQueue(tracks) {
+        els.queueList.innerHTML = '';
+        if (!tracks || tracks.length === 0) {
+            els.queueEmpty.hidden = false;
+            return;
+        }
+        els.queueEmpty.hidden = true;
+        tracks.forEach((track, i) => {
+            const li = document.createElement('li');
+            li.className = 'queue-item';
+            li.draggable = true;
+            li.dataset.index = String(i);
+
+            const handle = document.createElement('span');
+            handle.className = 'queue-drag-handle';
+            handle.setAttribute('aria-hidden', 'true');
+            handle.textContent = '⋮⋮';
+            li.appendChild(handle);
+
+            const meta = document.createElement('div');
+            meta.className = 'queue-meta';
+            const titleEl = document.createElement('div');
+            titleEl.className = 'queue-title';
+            titleEl.textContent = track.title || '(untitled)';
+            const authorEl = document.createElement('div');
+            authorEl.className = 'queue-author';
+            authorEl.textContent = (track.author || '') + (track.durationMs ? ' • ' + formatMs(track.durationMs) : '');
+            meta.appendChild(titleEl);
+            meta.appendChild(authorEl);
+            li.appendChild(meta);
+
+            const removeBtn = document.createElement('button');
+            removeBtn.className = 'queue-remove';
+            removeBtn.type = 'button';
+            removeBtn.setAttribute('aria-label', 'Remove track');
+            removeBtn.textContent = '✕';
+            removeBtn.addEventListener('click', () => {
+                del('/queue/' + i).then(() => {
+                    // SSE queueChanged will refresh the UI authoritatively.
+                });
+            });
+            li.appendChild(removeBtn);
+
+            els.queueList.appendChild(li);
+        });
+
+        if (window.TobyMusicQueue && typeof window.TobyMusicQueue.attach === 'function') {
+            window.TobyMusicQueue.attach(els.queueList, (from, to) => post('/queue/reorder', { from: from, to: to }));
+        }
+    }
+
+    function renderPlaylists(playlists) {
+        els.playlistList.innerHTML = '';
+        if (!playlists || playlists.length === 0) {
+            els.playlistsEmpty.hidden = false;
+            return;
+        }
+        els.playlistsEmpty.hidden = true;
+        playlists.forEach((pl) => {
+            const li = document.createElement('li');
+            li.className = 'playlist-item';
+
+            const meta = document.createElement('div');
+            meta.className = 'playlist-meta';
+            const name = document.createElement('div');
+            name.className = 'playlist-name';
+            name.textContent = pl.name;
+            const count = document.createElement('div');
+            count.className = 'playlist-count muted';
+            count.textContent = pl.trackCount + ' track' + (pl.trackCount === 1 ? '' : 's');
+            meta.appendChild(name);
+            meta.appendChild(count);
+            li.appendChild(meta);
+
+            const actions = document.createElement('div');
+            actions.className = 'playlist-actions';
+            const loadBtn = document.createElement('button');
+            loadBtn.type = 'button';
+            loadBtn.className = 'btn-tertiary';
+            loadBtn.textContent = '⏵ Load';
+            loadBtn.addEventListener('click', () => {
+                post('/playlists/' + pl.id + '/load');
+            });
+            actions.appendChild(loadBtn);
+
+            const delBtn = document.createElement('button');
+            delBtn.type = 'button';
+            delBtn.className = 'btn-tertiary btn-danger';
+            delBtn.textContent = '🗑 Delete';
+            delBtn.addEventListener('click', () => {
+                if (!confirm('Delete playlist "' + pl.name + '"?')) return;
+                del('/playlists/' + pl.id).then(() => refreshPlaylists());
+            });
+            actions.appendChild(delBtn);
+
+            li.appendChild(actions);
+            els.playlistList.appendChild(li);
+        });
+    }
+
+    function refreshPlaylists() {
+        getJson('/playlists').then(renderPlaylists).catch(() => {});
+    }
+
+    function renderVoiceChannel(voice) {
+        if (!voice) {
+            els.voiceChannelName.hidden = true;
+            els.voiceChannelEmpty.hidden = false;
+            els.voiceMemberList.innerHTML = '';
+            return;
+        }
+        els.voiceChannelEmpty.hidden = true;
+        els.voiceChannelName.hidden = false;
+        els.voiceChannelName.textContent = '#' + voice.name;
+        els.voiceMemberList.innerHTML = '';
+        (voice.members || []).forEach((m) => {
+            const li = document.createElement('li');
+            li.className = 'voice-member';
+            if (m.isBot) li.classList.add('is-bot');
+
+            const img = document.createElement('img');
+            img.className = 'voice-member-avatar';
+            img.alt = '';
+            if (m.avatarUrl) img.src = m.avatarUrl;
+            li.appendChild(img);
+
+            const name = document.createElement('span');
+            name.className = 'voice-member-name';
+            name.textContent = m.displayName + (m.isBot ? ' (bot)' : '');
+            li.appendChild(name);
+
+            if (m.isDeafened) {
+                const ic = document.createElement('span');
+                ic.className = 'voice-member-deaf';
+                ic.title = 'Deafened';
+                ic.setAttribute('aria-label', 'Deafened');
+                ic.textContent = '🔇';
+                li.appendChild(ic);
+            } else if (m.isMuted) {
+                const ic = document.createElement('span');
+                ic.className = 'voice-member-mute';
+                ic.title = 'Muted';
+                ic.setAttribute('aria-label', 'Muted');
+                ic.textContent = '🎙️❌';
+                li.appendChild(ic);
+            }
+            els.voiceMemberList.appendChild(li);
+        });
+    }
+
+    function refreshState() {
+        getJson('/state').then((envelope) => {
+            const state = envelope && envelope.state;
+            if (!state) return;
+            renderNowPlaying(state.nowPlaying, state.paused);
+            renderQueue(state.queue);
+            renderProgress(state.positionMs || 0);
+            renderVoiceChannel(state.voiceChannel);
+            els.volumeSlider.value = String(state.volume);
+            els.volumeValue.textContent = String(state.volume);
+            els.btnLoop.setAttribute('aria-pressed', state.looping ? 'true' : 'false');
+            els.btnLoop.classList.toggle('active', !!state.looping);
+        }).catch(() => {});
+    }
+
+    // ---- Transport handlers --------------------------------------------
+
+    els.btnPause.addEventListener('click', () => {
+        post(lastPaused ? '/resume' : '/pause');
+    });
+    els.btnSkip.addEventListener('click', () => post('/skip', { count: 1 }));
+    els.btnStop.addEventListener('click', () => post('/stop'));
+    els.btnLoop.addEventListener('click', () => {
+        const next = els.btnLoop.getAttribute('aria-pressed') !== 'true';
+        post('/loop', { looping: next });
+    });
+    let volumeTimer = null;
+    els.volumeSlider.addEventListener('input', () => {
+        els.volumeValue.textContent = els.volumeSlider.value;
+        if (volumeTimer) clearTimeout(volumeTimer);
+        volumeTimer = setTimeout(() => post('/volume', { volume: Number(els.volumeSlider.value) }), 200);
+    });
+
+    els.progressTrack.addEventListener('click', (e) => {
+        if (lastDurationMs <= 0) return;
+        const rect = els.progressTrack.getBoundingClientRect();
+        const ratio = Math.max(0, Math.min(1, (e.clientX - rect.left) / rect.width));
+        post('/seek', { positionMs: Math.floor(ratio * lastDurationMs) });
+    });
+
+    // Heuristic: if the user pasted a URL we trust them and queue it
+    // directly; if they typed free text we GET /search so they can see what
+    // would actually play before committing.
+    function looksLikeUrl(s) {
+        return /^https?:\/\//i.test(s);
+    }
+
+    function clearSearchResults() {
+        els.searchSection.hidden = true;
+        els.searchList.innerHTML = '';
+        els.searchEmpty.hidden = true;
+        els.searchQueryLabel.textContent = '';
+    }
+
+    function renderSearchResults(query, results) {
+        els.searchSection.hidden = false;
+        els.searchQueryLabel.textContent = '"' + query + '"';
+        els.searchList.innerHTML = '';
+        if (!results || results.length === 0) {
+            els.searchEmpty.hidden = false;
+            return;
+        }
+        els.searchEmpty.hidden = true;
+        results.forEach((track) => {
+            const li = document.createElement('li');
+            li.className = 'search-result';
+
+            const meta = document.createElement('div');
+            meta.className = 'search-result-meta';
+            const title = document.createElement('div');
+            title.className = 'search-result-title';
+            title.textContent = track.title || '(untitled)';
+            const author = document.createElement('div');
+            author.className = 'search-result-author';
+            const dur = track.durationMs ? ' • ' + formatMs(track.durationMs) : '';
+            const src = track.sourceName ? ' • ' + (SOURCE_LABELS[track.sourceName.toLowerCase()] || track.sourceName) : '';
+            author.textContent = (track.author || '') + dur + src;
+            meta.appendChild(title);
+            meta.appendChild(author);
+            li.appendChild(meta);
+
+            const queueBtn = document.createElement('button');
+            queueBtn.type = 'button';
+            queueBtn.className = 'btn-primary';
+            queueBtn.textContent = 'Queue';
+            queueBtn.addEventListener('click', () => {
+                queueBtn.disabled = true;
+                queueBtn.textContent = 'Queueing…';
+                post('/load', { query: track.uri || track.identifier }).then((res) => {
+                    if (res && res.ok) {
+                        clearSearchResults();
+                        els.addInput.value = '';
+                    } else {
+                        queueBtn.disabled = false;
+                        queueBtn.textContent = 'Queue';
+                        if (res && res.message) alert(res.message);
+                    }
+                });
+            });
+            li.appendChild(queueBtn);
+            els.searchList.appendChild(li);
+        });
+    }
+
+    els.addForm.addEventListener('submit', (e) => {
+        e.preventDefault();
+        const q = els.addInput.value.trim();
+        if (!q) return;
+
+        if (looksLikeUrl(q)) {
+            // Pasted URLs go straight to /load — no preview needed.
+            post('/load', { query: q }).then((res) => {
+                if (res && res.ok) {
+                    els.addInput.value = '';
+                    clearSearchResults();
+                } else if (res && res.message) {
+                    alert(res.message);
+                }
+            });
+            return;
+        }
+
+        // Free-text query — preview results, let the user pick.
+        fetch(baseUrl + '/search?q=' + encodeURIComponent(q), { credentials: 'same-origin' })
+            .then((r) => r.ok ? r.json() : [])
+            .then((results) => renderSearchResults(q, results))
+            .catch(() => renderSearchResults(q, []));
+    });
+
+    els.searchCloseBtn.addEventListener('click', clearSearchResults);
+
+    els.savePlaylistForm.addEventListener('submit', (e) => {
+        e.preventDefault();
+        const name = els.savePlaylistName.value.trim();
+        if (!name) return;
+        post('/playlists', { name: name }).then((res) => {
+            if (res && res.ok) {
+                els.savePlaylistName.value = '';
+                refreshPlaylists();
+            } else if (res && res.message) {
+                alert(res.message);
+            }
+        });
+    });
+
+    // ---- SSE -----------------------------------------------------------
+
+    let eventSource = null;
+
+    function connectSse() {
+        if (eventSource) eventSource.close();
+        eventSource = new EventSource(baseUrl + '/events');
+
+        eventSource.addEventListener('trackStart', (ev) => {
+            const payload = JSON.parse(ev.data);
+            renderNowPlaying(payload.track, false);
+        });
+        eventSource.addEventListener('trackEnd', () => {
+            // When the last track in the queue ends (or the user hits stop)
+            // no follow-up trackStart fires — so without this the now-playing
+            // card would keep showing the just-ended track. /state is
+            // authoritative: it returns nowPlaying=null when nothing is
+            // playing, which clears the card. If another track was queued,
+            // the trackStart event that fires alongside will override the
+            // brief gap.
+            refreshState();
+        });
+        eventSource.addEventListener('queueChanged', (ev) => {
+            const payload = JSON.parse(ev.data);
+            renderQueue(payload.queue);
+        });
+        eventSource.addEventListener('pauseStateChanged', (ev) => {
+            const payload = JSON.parse(ev.data);
+            lastPaused = !!payload.paused;
+            els.btnPause.textContent = lastPaused ? '▶️' : '⏸️';
+        });
+        eventSource.addEventListener('volumeChanged', (ev) => {
+            const payload = JSON.parse(ev.data);
+            els.volumeSlider.value = String(payload.volume);
+            els.volumeValue.textContent = String(payload.volume);
+        });
+        eventSource.addEventListener('loopStateChanged', (ev) => {
+            const payload = JSON.parse(ev.data);
+            els.btnLoop.setAttribute('aria-pressed', payload.looping ? 'true' : 'false');
+            els.btnLoop.classList.toggle('active', !!payload.looping);
+        });
+        eventSource.addEventListener('positionTick', (ev) => {
+            const payload = JSON.parse(ev.data);
+            if (payload.durationMs > 0) lastDurationMs = payload.durationMs;
+            renderProgress(payload.positionMs);
+        });
+        eventSource.onerror = () => {
+            // EventSource will reconnect automatically. Re-sync state on reconnect.
+            setTimeout(() => refreshState(), 2000);
+        };
+    }
+
+    // Backgrounded tabs commonly have their EventSource throttled or
+    // silently closed by the OS / a proxy. When the tab comes back into
+    // focus, re-pull state immediately AND reopen the SSE channel so we
+    // don't sit on a dead socket showing a stale progress bar.
+    document.addEventListener('visibilitychange', () => {
+        if (document.visibilityState !== 'visible') return;
+        refreshState();
+        refreshPlaylists();
+        connectSse();
+    });
+
+    // ---- Bootstrap -----------------------------------------------------
+
+    refreshState();
+    refreshPlaylists();
+    connectSse();
+})();

--- a/web/src/main/resources/static/js/music-queue.js
+++ b/web/src/main/resources/static/js/music-queue.js
@@ -1,0 +1,69 @@
+// Vanilla HTML5 drag-and-drop reorder for the music queue. The list element
+// receives an `onReorder(from, to)` callback that the music-player.js wires
+// to POST /queue/reorder. We render optimistically and let the server-side
+// queueChanged SSE event reconcile back to truth.
+(function () {
+    'use strict';
+
+    function attach(listEl, onReorder) {
+        // Re-binding cleanly each time renderQueue rebuilds the list.
+        if (listEl.dataset.dndBound === '1') return;
+        listEl.dataset.dndBound = '1';
+
+        let draggingIdx = null;
+
+        listEl.addEventListener('dragstart', (e) => {
+            const li = e.target.closest('li.queue-item');
+            if (!li) return;
+            draggingIdx = Number(li.dataset.index);
+            li.classList.add('dragging');
+            if (e.dataTransfer) {
+                e.dataTransfer.effectAllowed = 'move';
+                // Some browsers require a non-empty payload to actually fire `drop`.
+                e.dataTransfer.setData('text/plain', String(draggingIdx));
+            }
+        });
+
+        listEl.addEventListener('dragover', (e) => {
+            if (draggingIdx == null) return;
+            e.preventDefault();
+            if (e.dataTransfer) e.dataTransfer.dropEffect = 'move';
+            const li = e.target.closest('li.queue-item');
+            if (li) li.classList.add('drop-target');
+        });
+
+        listEl.addEventListener('dragleave', (e) => {
+            const li = e.target.closest('li.queue-item');
+            if (li) li.classList.remove('drop-target');
+        });
+
+        listEl.addEventListener('drop', (e) => {
+            e.preventDefault();
+            if (draggingIdx == null) return;
+            const li = e.target.closest('li.queue-item');
+            if (!li) return;
+            const toIdx = Number(li.dataset.index);
+            if (toIdx === draggingIdx) return;
+            // Optimistic DOM swap: move the dragged node before/after the drop target.
+            const allItems = Array.from(listEl.querySelectorAll('li.queue-item'));
+            const dragged = allItems[draggingIdx];
+            const target = allItems[toIdx];
+            if (dragged && target) {
+                if (toIdx > draggingIdx) {
+                    target.parentNode.insertBefore(dragged, target.nextSibling);
+                } else {
+                    target.parentNode.insertBefore(dragged, target);
+                }
+            }
+            if (typeof onReorder === 'function') onReorder(draggingIdx, toIdx);
+        });
+
+        listEl.addEventListener('dragend', () => {
+            draggingIdx = null;
+            listEl.querySelectorAll('.dragging').forEach((n) => n.classList.remove('dragging'));
+            listEl.querySelectorAll('.drop-target').forEach((n) => n.classList.remove('drop-target'));
+        });
+    }
+
+    window.TobyMusicQueue = { attach: attach };
+})();

--- a/web/src/main/resources/templates/fragments/navbar.html
+++ b/web/src/main/resources/templates/fragments/navbar.html
@@ -68,6 +68,7 @@
                     aria-expanded="false"
                     onclick="toggleDropdown(this)">Social <span class="nav-dropdown-caret" aria-hidden="true">&#9662;</span></button>
             <div class="nav-dropdown-menu" role="menu">
+                <a href="/music-player/guilds" role="menuitem">&#127925; Music</a>
                 <a href="/intro/guilds" role="menuitem">Intro Songs</a>
                 <a href="/excuses/guilds" role="menuitem">Excuses</a>
                 <a href="/teams/guilds" role="menuitem">Teams</a>

--- a/web/src/main/resources/templates/music-guilds.html
+++ b/web/src/main/resources/templates/music-guilds.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="en">
+<head th:replace="~{fragments/head :: head('TobyBot - Music', '/css/music-player.css')}"></head>
+<body>
+<a href="#main" class="skip-link">Skip to content</a>
+<div th:replace="~{fragments/navbar :: navbar}"></div>
+
+<main id="main" class="container">
+    <header class="music-header">
+        <h1>🎵 Music</h1>
+    </header>
+    <p class="muted mb-5">Pick a server to open its player — see what's playing, queue tracks, manage the room.</p>
+
+    <div th:replace="~{fragments/alerts :: error}"></div>
+
+    <div class="music-guild-grid" th:if="${not #lists.isEmpty(guilds)}">
+        <article class="music-guild-card" th:each="g : ${guilds}">
+            <header class="music-guild-card-head">
+                <img class="music-guild-icon"
+                     th:if="${g.iconUrl != null}"
+                     th:src="${g.iconUrl}"
+                     th:alt="${g.name}">
+                <div class="music-guild-icon" th:unless="${g.iconUrl != null}" aria-hidden="true"
+                     style="display:flex;align-items:center;justify-content:center;font-size:1.4rem;">🎵</div>
+                <h2 class="music-guild-name" th:text="${g.name}">Server</h2>
+            </header>
+
+            <div class="music-guild-status"
+                 th:classappend="${g.nowPlayingTitle != null} ? 'is-playing' : ''">
+                <span class="music-guild-status-icon" aria-hidden="true"
+                      th:text="${g.nowPlayingTitle != null} ? '🎶' : '💤'">💤</span>
+                <span class="music-guild-status-text"
+                      th:text="${g.nowPlayingTitle != null} ? ('Now playing: ' + g.nowPlayingTitle) : 'Idle'">Idle</span>
+            </div>
+
+            <div class="music-guild-actions">
+                <a class="btn-primary" th:href="@{/music-player/{id}(id=${g.id})}">🎶 Open player</a>
+            </div>
+        </article>
+    </div>
+
+    <div class="empty-hero" th:if="${#lists.isEmpty(guilds)}">
+        <span class="emoji" aria-hidden="true">🎵</span>
+        <h2>No servers yet</h2>
+        <p class="mb-5">You need to share a server with TobyBot to control its music.</p>
+    </div>
+</main>
+</body>
+</html>

--- a/web/src/main/resources/templates/music-player.html
+++ b/web/src/main/resources/templates/music-player.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="en">
+<head th:replace="~{fragments/head :: head('TobyBot - Music - ' + ${guildName}, '/css/music-player.css')}"></head>
+<body th:attr="data-music-page='1', data-guild-id=${guildId}, data-discord-id=${discordId}">
+<a href="#main" class="skip-link">Skip to content</a>
+<div th:replace="~{fragments/navbar :: navbar}"></div>
+
+<main id="main" class="container music-dashboard">
+
+    <header class="music-header">
+        <h1>🎵 <span th:text="${guildName}">Server</span></h1>
+        <a class="btn-tertiary" href="/music-player/guilds">← All servers</a>
+    </header>
+
+    <div th:replace="~{fragments/alerts :: error}"></div>
+
+    <section class="music-grid">
+
+        <!-- Now Playing -->
+        <article class="now-playing-card" aria-labelledby="now-playing-heading">
+            <h2 id="now-playing-heading" class="sr-only">Now playing</h2>
+            <div class="now-playing-empty" id="now-playing-empty">
+                <span class="emoji" aria-hidden="true">⏸️</span>
+                <p>Nothing's playing. Add a track below to get started.</p>
+            </div>
+            <div class="now-playing-content" id="now-playing-content" hidden>
+                <img class="now-playing-art" id="now-playing-art" alt="">
+                <div class="now-playing-meta">
+                    <span class="source-badge" id="source-badge">Music</span>
+                    <h3 class="now-playing-title" id="now-playing-title">—</h3>
+                    <p class="now-playing-author" id="now-playing-author">—</p>
+                    <div class="now-playing-requester" id="now-playing-requester" hidden>
+                        <span class="muted now-playing-requester-label">Requested by</span>
+                        <span class="member-cell" id="now-playing-requester-cell"></span>
+                    </div>
+                    <div class="progress-row">
+                        <span class="time-current" id="time-current">0:00</span>
+                        <div class="progress-track" id="progress-track">
+                            <div class="progress-fill" id="progress-fill"></div>
+                        </div>
+                        <span class="time-total" id="time-total">0:00</span>
+                    </div>
+                </div>
+            </div>
+            <div class="transport-row">
+                <button id="btn-pause" class="btn-transport" type="button" title="Pause / Resume">⏯️</button>
+                <button id="btn-skip" class="btn-transport" type="button" title="Skip">⏭️</button>
+                <button id="btn-stop" class="btn-transport btn-danger" type="button" title="Stop">⏹️</button>
+                <button id="btn-loop" class="btn-transport" type="button" title="Loop" aria-pressed="false">🔁</button>
+                <label class="volume-label">
+                    🔊
+                    <input id="volume-slider" type="range" min="0" max="150" value="100" aria-label="Volume">
+                    <span id="volume-value">100</span>
+                </label>
+            </div>
+        </article>
+
+        <!-- Add Track / Queue -->
+        <article class="queue-card" aria-labelledby="queue-heading">
+            <h2 id="queue-heading">Up next</h2>
+            <form id="add-track-form" class="add-track-form" autocomplete="off">
+                <input id="add-track-input" type="text" placeholder="URL or search term — Spotify / YouTube / SoundCloud / Bandcamp / Apple Music / Deezer" required>
+                <button class="btn-primary" type="submit">Search</button>
+            </form>
+            <p class="add-track-hint muted">
+                Tip — paste a link to queue it directly, or type plain text to see what would play before adding.
+            </p>
+
+            <section id="search-results-section" class="search-results-section" hidden aria-live="polite">
+                <header class="search-results-header">
+                    <h3 class="search-results-title">Results for <span id="search-results-query"></span></h3>
+                    <button type="button" class="btn-tertiary" id="search-results-close" aria-label="Close results">Clear</button>
+                </header>
+                <ol id="search-results-list" class="search-results-list"></ol>
+                <p id="search-results-empty" class="muted" hidden>No results.</p>
+            </section>
+
+            <ol id="queue-list" class="queue-list" aria-live="polite"></ol>
+            <p id="queue-empty" class="muted">Queue is empty.</p>
+        </article>
+
+        <!-- Playlists -->
+        <article class="playlists-card" aria-labelledby="playlists-heading">
+            <h2 id="playlists-heading">Saved playlists</h2>
+            <form id="save-playlist-form" class="save-playlist-form" autocomplete="off">
+                <input id="save-playlist-name" type="text" maxlength="80" placeholder="Name your playlist" required>
+                <button class="btn-secondary" type="submit">💾 Save current queue</button>
+            </form>
+            <ul id="playlist-list" class="playlist-list" aria-live="polite"></ul>
+            <p id="playlists-empty" class="muted">No saved playlists yet.</p>
+        </article>
+
+        <!-- Voice channel members -->
+        <article class="voice-card" aria-labelledby="voice-heading">
+            <h2 id="voice-heading">🔈 In the voice channel</h2>
+            <p id="voice-channel-name" class="voice-channel-name" hidden></p>
+            <p id="voice-channel-empty" class="voice-channel-empty">
+                Bot isn't in a voice channel. Run <code>/join</code> in Discord first.
+            </p>
+            <ul id="voice-member-list" class="voice-member-list" aria-live="polite"></ul>
+        </article>
+
+    </section>
+
+</main>
+
+<script src="/js/api.js" defer></script>
+<script src="/js/music-queue.js" defer></script>
+<script src="/js/music-player.js" defer></script>
+</body>
+</html>

--- a/web/src/test/js/music-player-resync.test.js
+++ b/web/src/test/js/music-player-resync.test.js
@@ -1,0 +1,253 @@
+// Regression tests for two bugs in the music dashboard:
+//
+//  1. "trackEnd doesn't clear the now-playing card" — when the last
+//     queued track ended (or the user hit Stop), only a TrackEndedEvent
+//     fired; no follow-up TrackStartedEvent ever arrived, so the
+//     now-playing UI kept showing the just-ended track until refresh.
+//     Fix: the trackEnd handler now refetches /state, which is
+//     authoritative (returns nowPlaying=null when idle).
+//
+//  2. "Tab background → progress bar freezes" — browsers throttle
+//     EventSource on backgrounded tabs and proxies can silently drop
+//     the connection. Fix: visibilitychange→visible resyncs state,
+//     playlists, AND reopens the SSE channel.
+//
+// We boot the music-player.js IIFE against a hand-crafted DOM, stub
+// fetch + EventSource, and fire DOM/SSE events to prove the handlers
+// behave as advertised.
+
+class MockEventSource {
+    constructor(url) {
+        this.url = url;
+        this.handlers = {};
+        this.closed = false;
+        MockEventSource.instances.push(this);
+    }
+    addEventListener(name, handler) {
+        this.handlers[name] = handler;
+    }
+    close() {
+        this.closed = true;
+    }
+    // Fire a named SSE event with a JSON-encoded payload, matching how
+    // EventSource hands events to addEventListener-style listeners.
+    fire(name, payload) {
+        const handler = this.handlers[name];
+        if (handler) handler({ data: JSON.stringify(payload) });
+    }
+}
+MockEventSource.instances = [];
+
+function flush() {
+    return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function setUpDashboardDom() {
+    document.head.innerHTML = '';
+    document.body.innerHTML = `
+        <div id="now-playing-empty"></div>
+        <div id="now-playing-content" hidden>
+            <img id="now-playing-art" />
+            <span id="source-badge"></span>
+            <h3 id="now-playing-title"></h3>
+            <p id="now-playing-author"></p>
+            <div id="now-playing-requester" hidden>
+                <span id="now-playing-requester-cell"></span>
+            </div>
+            <span id="time-current"></span>
+            <span id="time-total"></span>
+            <div id="progress-track"><div id="progress-fill"></div></div>
+        </div>
+        <button id="btn-pause">⏯️</button>
+        <button id="btn-skip">⏭️</button>
+        <button id="btn-stop">⏹️</button>
+        <button id="btn-loop" aria-pressed="false">🔁</button>
+        <input id="volume-slider" type="range" min="0" max="150" value="100" />
+        <span id="volume-value">100</span>
+        <form id="add-track-form"><input id="add-track-input" /><button>Search</button></form>
+        <section id="search-results-section" hidden>
+            <span id="search-results-query"></span>
+            <button id="search-results-close"></button>
+            <ol id="search-results-list"></ol>
+            <p id="search-results-empty" hidden></p>
+        </section>
+        <ol id="queue-list"></ol>
+        <p id="queue-empty"></p>
+        <ul id="playlist-list"></ul>
+        <p id="playlists-empty"></p>
+        <form id="save-playlist-form"><input id="save-playlist-name" /><button>Save</button></form>
+        <p id="voice-channel-name" hidden></p>
+        <p id="voice-channel-empty"></p>
+        <ul id="voice-member-list"></ul>
+    `;
+    document.body.dataset.musicPage = '1';
+    document.body.dataset.guildId = '42';
+    document.body.dataset.discordId = '100';
+}
+
+describe('music-player.js — live state resync', () => {
+    let fetchMock;
+    let visibilitySpy;
+
+    beforeEach(() => {
+        jest.resetModules();
+        MockEventSource.instances.length = 0;
+
+        setUpDashboardDom();
+
+        // EventSource isn't in jsdom; install our recording mock.
+        window.EventSource = MockEventSource;
+
+        // Default fetch handler: empty state, empty playlist list, empty
+        // search results. Tests override via mockResolvedValueOnce.
+        fetchMock = jest.fn().mockImplementation((url) => {
+            if (typeof url === 'string' && url.endsWith('/state')) {
+                return Promise.resolve({
+                    ok: true,
+                    json: () => Promise.resolve({ state: idleState() }),
+                });
+            }
+            if (typeof url === 'string' && url.endsWith('/playlists')) {
+                return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+            }
+            return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+        });
+        window.fetch = fetchMock;
+
+        // visibilityState is a getter — stub it so each test can flip it.
+        visibilitySpy = jest.spyOn(document, 'visibilityState', 'get');
+        visibilitySpy.mockReturnValue('visible');
+
+        require('../../main/resources/static/js/music-player');
+    });
+
+    afterEach(() => {
+        visibilitySpy.mockRestore();
+    });
+
+    test('boots: opens an EventSource and fetches initial /state + /playlists', async () => {
+        await flush();
+        expect(MockEventSource.instances).toHaveLength(1);
+        const stateCalls = fetchMock.mock.calls.filter(([u]) => u.endsWith('/state'));
+        const playlistCalls = fetchMock.mock.calls.filter(([u]) => u.endsWith('/playlists'));
+        expect(stateCalls.length).toBeGreaterThanOrEqual(1);
+        expect(playlistCalls.length).toBeGreaterThanOrEqual(1);
+    });
+
+    test('SSE trackEnd refetches /state so the now-playing card clears when nothing follows', async () => {
+        await flush();
+        const initialStateCalls = fetchMock.mock.calls.filter(([u]) => u.endsWith('/state')).length;
+        const es = MockEventSource.instances[0];
+
+        // The frontend should always handle a registered trackEnd event.
+        expect(typeof es.handlers.trackEnd).toBe('function');
+
+        // Fire it — the handler should re-fetch /state. We don't care about
+        // the SSE payload contents (trackEnd is not data-bearing in our flow).
+        es.fire('trackEnd', { guildId: 42, endReason: 'FINISHED' });
+        await flush();
+
+        const newStateCalls = fetchMock.mock.calls.filter(([u]) => u.endsWith('/state')).length;
+        expect(newStateCalls).toBeGreaterThan(initialStateCalls);
+    });
+
+    test('trackEnd renders the cleared state — empty card shows, content hides', async () => {
+        await flush();
+        const es = MockEventSource.instances[0];
+
+        // First, simulate that something was playing — fire a trackStart so
+        // the now-playing card has content to clear.
+        es.fire('trackStart', { guildId: 42, track: playingTrack() });
+        await flush();
+        expect(document.getElementById('now-playing-content').hidden).toBe(false);
+
+        // Now arrange /state to return idle (last track ended, queue empty).
+        fetchMock.mockImplementationOnce((url) => {
+            if (url.endsWith('/state')) {
+                return Promise.resolve({
+                    ok: true,
+                    json: () => Promise.resolve({ state: idleState() }),
+                });
+            }
+            return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+        });
+
+        es.fire('trackEnd', { guildId: 42, endReason: 'FINISHED' });
+        await flush();
+
+        // The empty state should be visible, the content hidden.
+        expect(document.getElementById('now-playing-empty').hidden).toBe(false);
+        expect(document.getElementById('now-playing-content').hidden).toBe(true);
+    });
+
+    test('visibilitychange→visible reopens the EventSource and resyncs state', async () => {
+        await flush();
+        // Note on isolation: music-player.js attaches its visibilitychange
+        // listener to `document`, which survives jest.resetModules() between
+        // tests. So earlier require()s from prior tests can leave orphan
+        // listeners that also fire here. We assert on the *behaviour* of
+        // this run's listener (old socket closed, at least one new instance
+        // opened, state and playlists refetched) rather than the absolute
+        // count of new instances.
+        const previousInstance = MockEventSource.instances[MockEventSource.instances.length - 1];
+        const beforeInstances = MockEventSource.instances.length;
+        const beforeStateCalls = fetchMock.mock.calls.filter(([u]) => u.endsWith('/state')).length;
+        const beforePlaylistCalls = fetchMock.mock.calls.filter(([u]) => u.endsWith('/playlists')).length;
+
+        visibilitySpy.mockReturnValue('visible');
+        document.dispatchEvent(new Event('visibilitychange'));
+        await flush();
+
+        // The pre-event socket was closed (proves the handler ran the
+        // close-then-reopen cycle, not "leave the dead socket alone").
+        expect(previousInstance.closed).toBe(true);
+        // A new EventSource was constructed in its place.
+        expect(MockEventSource.instances.length).toBeGreaterThan(beforeInstances);
+        // State and playlists were re-fetched.
+        const afterStateCalls = fetchMock.mock.calls.filter(([u]) => u.endsWith('/state')).length;
+        const afterPlaylistCalls = fetchMock.mock.calls.filter(([u]) => u.endsWith('/playlists')).length;
+        expect(afterStateCalls).toBeGreaterThan(beforeStateCalls);
+        expect(afterPlaylistCalls).toBeGreaterThan(beforePlaylistCalls);
+    });
+
+    test('visibilitychange→hidden does not reopen the EventSource', async () => {
+        await flush();
+        const beforeInstances = MockEventSource.instances.length;
+
+        visibilitySpy.mockReturnValue('hidden');
+        document.dispatchEvent(new Event('visibilitychange'));
+        await flush();
+
+        expect(MockEventSource.instances.length).toBe(beforeInstances);
+    });
+});
+
+function idleState() {
+    return {
+        guildId: 42,
+        nowPlaying: null,
+        positionMs: 0,
+        paused: false,
+        volume: 100,
+        looping: false,
+        queue: [],
+        voiceChannelId: null,
+        voiceChannel: null,
+    };
+}
+
+function playingTrack() {
+    return {
+        identifier: 'abc',
+        title: 'Test Track',
+        author: 'Author',
+        durationMs: 60_000,
+        uri: 'https://example.com',
+        artworkUrl: null,
+        sourceName: 'youtube',
+        isStream: false,
+        requesterDiscordId: 100,
+        requesterDisplayName: 'Alice',
+        requesterAvatarUrl: 'https://cdn/a.png',
+    };
+}

--- a/web/src/test/kotlin/web/controller/MusicWebControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/MusicWebControllerTest.kt
@@ -1,0 +1,432 @@
+package web.controller
+
+import core.music.MusicControlGateway
+import core.music.MusicControlGateway.LoadResult
+import core.music.MusicControlGateway.TrackInfo
+import database.service.MusicPlaylistService.PlaylistNameTakenException
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.security.oauth2.core.user.OAuth2User
+import web.service.MusicSseService
+import web.service.MusicWebService
+
+class MusicWebControllerTest {
+
+    private val guildId = 100L
+    private val discordId = 200L
+    private val otherDiscordId = 999L
+
+    private lateinit var musicWebService: MusicWebService
+    private lateinit var sseService: MusicSseService
+    private lateinit var user: OAuth2User
+    private lateinit var anonUser: OAuth2User
+    private lateinit var nonMemberUser: OAuth2User
+    private lateinit var controller: MusicWebController
+
+    @BeforeEach
+    fun setUp() {
+        musicWebService = mockk(relaxed = true)
+        sseService = mockk(relaxed = true)
+        user = mockk {
+            every { getAttribute<String>("id") } returns discordId.toString()
+            every { getAttribute<String>("username") } returns "tester"
+        }
+        nonMemberUser = mockk {
+            every { getAttribute<String>("id") } returns otherDiscordId.toString()
+            every { getAttribute<String>("username") } returns "stranger"
+        }
+        anonUser = mockk {
+            every { getAttribute<String>("id") } returns null
+            every { getAttribute<String>("username") } returns null
+        }
+        every { musicWebService.isMember(discordId, guildId) } returns true
+        every { musicWebService.isMember(otherDiscordId, guildId) } returns false
+        // Members default to musicPermission=true (matches the slash-command
+        // gate); revoked-permission cases stub this explicitly.
+        every { musicWebService.canControlMusic(discordId, guildId) } returns true
+        every { musicWebService.canControlMusic(otherDiscordId, guildId) } returns false
+        controller = MusicWebController(musicWebService, sseService)
+    }
+
+    // ---- Auth / authz --------------------------------------------------
+
+    @Test
+    fun `pause unauthenticated returns 401`() {
+        val response = controller.pause(guildId, null)
+        assertEquals(401, response.statusCode.value())
+    }
+
+    @Test
+    fun `pause non-member returns 403`() {
+        val response = controller.pause(guildId, nonMemberUser)
+        assertEquals(403, response.statusCode.value())
+    }
+
+    @Test
+    fun `pause member returns 200`() {
+        every { musicWebService.pause(guildId) } returns true
+        val response = controller.pause(guildId, user)
+        assertEquals(200, response.statusCode.value())
+        assertTrue(response.body!!.ok)
+    }
+
+    // ---- Permission gate — every write endpoint must reject a member
+    //      whose musicPermission has been revoked. Holds the wiring honest
+    //      so a future endpoint plumbed through `guarded` instead of
+    //      `guardedWrite` is caught here instead of in prod. -------------
+
+    @Test
+    fun `every write endpoint returns 403 when musicPermission is revoked`() {
+        every { musicWebService.canControlMusic(discordId, guildId) } returns false
+        // Each entry is a (label, invocation) pair so a failure points at the
+        // specific endpoint that escaped the gate.
+        val writes: List<Pair<String, () -> Int>> = listOf(
+            "load"             to { controller.load(guildId, user, MusicWebController.LoadRequest("x")).statusCode.value() },
+            "pause"            to { controller.pause(guildId, user).statusCode.value() },
+            "resume"           to { controller.resume(guildId, user).statusCode.value() },
+            "skip"             to { controller.skip(guildId, user, MusicWebController.SkipRequest(1)).statusCode.value() },
+            "stop"             to { controller.stop(guildId, user).statusCode.value() },
+            "volume"           to { controller.volume(guildId, user, MusicWebController.VolumeRequest(50)).statusCode.value() },
+            "seek"             to { controller.seek(guildId, user, MusicWebController.SeekRequest(0)).statusCode.value() },
+            "loop"             to { controller.loop(guildId, user, MusicWebController.LoopRequest(true)).statusCode.value() },
+            "queue/reorder"    to { controller.reorder(guildId, user, MusicWebController.ReorderRequest(0, 1)).statusCode.value() },
+            "queue/{i} DELETE" to { controller.removeQueueItem(guildId, 0, user).statusCode.value() },
+            "playlists POST"   to { controller.createPlaylist(guildId, user, MusicWebController.SavePlaylistRequest("x")).statusCode.value() },
+            "playlists/{id}/load" to { controller.loadPlaylist(guildId, 1L, user).statusCode.value() },
+            "playlists/{id} DELETE" to { controller.deletePlaylist(guildId, 1L, user).statusCode.value() },
+        )
+        writes.forEach { (label, run) ->
+            assertEquals(403, run(), "Expected $label to 403 when musicPermission revoked")
+        }
+    }
+
+    @Test
+    fun `every read endpoint stays accessible when musicPermission is revoked`() {
+        // Members keep visibility — only writes are gated.
+        every { musicWebService.canControlMusic(discordId, guildId) } returns false
+        every { musicWebService.getState(guildId) } returns
+            MusicControlGateway.GuildPlayerState(
+                guildId, null, 0L, false, 100, false, emptyList(), null,
+            )
+        every { musicWebService.search(guildId, any(), any()) } returns emptyList()
+        every { musicWebService.listPlaylistsForGuild(guildId) } returns emptyList()
+        every { sseService.register(guildId) } returns mockk(relaxed = true)
+
+        val reads: List<Pair<String, () -> Int>> = listOf(
+            "state"            to { controller.state(guildId, user).statusCode.value() },
+            "events"           to { controller.stream(guildId, user).statusCode.value() },
+            "search"           to { controller.search(guildId, "linkin park", user).statusCode.value() },
+            "playlists GET"    to { controller.listPlaylists(guildId, user).statusCode.value() },
+        )
+        reads.forEach { (label, run) ->
+            assertEquals(200, run(), "Expected $label to 200 even when musicPermission revoked")
+        }
+    }
+
+    @Test
+    fun `read endpoints still 403 for non-members`() {
+        // Sanity check: the permission gate is layered on top of membership;
+        // non-members must still be cut off from reads.
+        val results = listOf(
+            controller.state(guildId, nonMemberUser).statusCode.value(),
+            controller.stream(guildId, nonMemberUser).statusCode.value(),
+            controller.search(guildId, "x", nonMemberUser).statusCode.value(),
+            controller.listPlaylists(guildId, nonMemberUser).statusCode.value(),
+        )
+        results.forEach { assertEquals(403, it) }
+    }
+
+    @Test
+    fun `write endpoints still 403 for non-members`() {
+        val results = listOf(
+            controller.load(guildId, nonMemberUser, MusicWebController.LoadRequest("x")).statusCode.value(),
+            controller.pause(guildId, nonMemberUser).statusCode.value(),
+            controller.skip(guildId, nonMemberUser, MusicWebController.SkipRequest(1)).statusCode.value(),
+            controller.volume(guildId, nonMemberUser, MusicWebController.VolumeRequest(50)).statusCode.value(),
+            controller.createPlaylist(guildId, nonMemberUser, MusicWebController.SavePlaylistRequest("x")).statusCode.value(),
+        )
+        results.forEach { assertEquals(403, it) }
+    }
+
+    // ---- Mutation validation ------------------------------------------
+
+    @Test
+    fun `load with blank query returns 400`() {
+        val response = controller.load(guildId, user, MusicWebController.LoadRequest(""))
+        assertEquals(400, response.statusCode.value())
+        assertFalse(response.body!!.ok)
+    }
+
+    @Test
+    fun `load with query delegates to service`() {
+        every { musicWebService.load(guildId, "linkin park", discordId) } returns LoadResult(true, 1, null)
+        val response = controller.load(guildId, user, MusicWebController.LoadRequest("linkin park"))
+        assertEquals(200, response.statusCode.value())
+        assertTrue(response.body!!.ok)
+        verify(exactly = 1) { musicWebService.load(guildId, "linkin park", discordId) }
+    }
+
+    @Test
+    fun `load with not-in-voice-channel returns 200 with failure body`() {
+        every { musicWebService.load(any(), any(), any()) } returns
+            LoadResult(false, 0, "Bot must be in a voice channel")
+        val response = controller.load(guildId, user, MusicWebController.LoadRequest("foo"))
+        assertEquals(200, response.statusCode.value())
+        assertFalse(response.body!!.ok)
+        assertEquals("Bot must be in a voice channel", response.body!!.message)
+    }
+
+    @Test
+    fun `skip with count of 0 returns 400`() {
+        val response = controller.skip(guildId, user, MusicWebController.SkipRequest(0))
+        assertEquals(400, response.statusCode.value())
+    }
+
+    @Test
+    fun `skip with negative count returns 400`() {
+        val response = controller.skip(guildId, user, MusicWebController.SkipRequest(-1))
+        assertEquals(400, response.statusCode.value())
+    }
+
+    @Test
+    fun `skip with positive count delegates to service`() {
+        every { musicWebService.skip(guildId, 2) } returns true
+        val response = controller.skip(guildId, user, MusicWebController.SkipRequest(2))
+        assertEquals(200, response.statusCode.value())
+        verify(exactly = 1) { musicWebService.skip(guildId, 2) }
+    }
+
+    @Test
+    fun `volume out of range below returns 400`() {
+        val response = controller.volume(guildId, user, MusicWebController.VolumeRequest(-1))
+        assertEquals(400, response.statusCode.value())
+    }
+
+    @Test
+    fun `volume out of range above returns 400`() {
+        val response = controller.volume(guildId, user, MusicWebController.VolumeRequest(151))
+        assertEquals(400, response.statusCode.value())
+    }
+
+    @Test
+    fun `volume in range succeeds`() {
+        every { musicWebService.setVolume(guildId, 75) } returns true
+        val response = controller.volume(guildId, user, MusicWebController.VolumeRequest(75))
+        assertEquals(200, response.statusCode.value())
+    }
+
+    @Test
+    fun `seek negative returns 400`() {
+        val response = controller.seek(guildId, user, MusicWebController.SeekRequest(-1))
+        assertEquals(400, response.statusCode.value())
+    }
+
+    @Test
+    fun `seek positive delegates to service`() {
+        every { musicWebService.seek(guildId, 12_345L) } returns true
+        val response = controller.seek(guildId, user, MusicWebController.SeekRequest(12_345L))
+        assertEquals(200, response.statusCode.value())
+        verify(exactly = 1) { musicWebService.seek(guildId, 12_345L) }
+    }
+
+    @Test
+    fun `reorder negative indices return 400`() {
+        val response = controller.reorder(guildId, user, MusicWebController.ReorderRequest(-1, 0))
+        assertEquals(400, response.statusCode.value())
+    }
+
+    @Test
+    fun `reorder invalid indices return 400 when service rejects`() {
+        every { musicWebService.reorderQueue(guildId, 0, 99) } returns false
+        val response = controller.reorder(guildId, user, MusicWebController.ReorderRequest(0, 99))
+        assertEquals(400, response.statusCode.value())
+    }
+
+    @Test
+    fun `reorder valid indices succeed`() {
+        every { musicWebService.reorderQueue(guildId, 1, 3) } returns true
+        val response = controller.reorder(guildId, user, MusicWebController.ReorderRequest(1, 3))
+        assertEquals(200, response.statusCode.value())
+        assertTrue(response.body!!.ok)
+    }
+
+    @Test
+    fun `removeQueueItem out of bounds returns 404`() {
+        every { musicWebService.removeFromQueue(guildId, 50) } returns null
+        val response = controller.removeQueueItem(guildId, 50, user)
+        assertEquals(404, response.statusCode.value())
+    }
+
+    @Test
+    fun `removeQueueItem success returns 200`() {
+        every { musicWebService.removeFromQueue(guildId, 2) } returns dummyTrack()
+        val response = controller.removeQueueItem(guildId, 2, user)
+        assertEquals(200, response.statusCode.value())
+        assertTrue(response.body!!.ok)
+    }
+
+    // ---- Pause/resume idempotence -------------------------------------
+
+    @Test
+    fun `pause when already paused returns ok=false (service reports no-op)`() {
+        every { musicWebService.pause(guildId) } returns false
+        val response = controller.pause(guildId, user)
+        assertEquals(200, response.statusCode.value())
+        assertFalse(response.body!!.ok)
+    }
+
+    @Test
+    fun `resume when not paused returns ok=false (service reports no-op)`() {
+        every { musicWebService.resume(guildId) } returns false
+        val response = controller.resume(guildId, user)
+        assertEquals(200, response.statusCode.value())
+        assertFalse(response.body!!.ok)
+    }
+
+    // ---- Stop ---------------------------------------------------------
+
+    @Test
+    fun `stop delegates to service`() {
+        every { musicWebService.stop(guildId) } returns true
+        val response = controller.stop(guildId, user)
+        assertEquals(200, response.statusCode.value())
+        verify(exactly = 1) { musicWebService.stop(guildId) }
+    }
+
+    // ---- State / events -----------------------------------------------
+
+    @Test
+    fun `state returns 404 when no state available`() {
+        every { musicWebService.getState(guildId) } returns null
+        val response = controller.state(guildId, user)
+        assertEquals(404, response.statusCode.value())
+        assertNull(response.body!!.state)
+    }
+
+    @Test
+    fun `state returns 200 with body when available`() {
+        val state = MusicControlGateway.GuildPlayerState(
+            guildId = guildId,
+            nowPlaying = dummyTrack(),
+            positionMs = 1000L,
+            paused = false,
+            volume = 100,
+            looping = false,
+            queue = emptyList(),
+            voiceChannelId = null,
+        )
+        every { musicWebService.getState(guildId) } returns state
+        val response = controller.state(guildId, user)
+        assertEquals(200, response.statusCode.value())
+        assertNotNull(response.body!!.state)
+    }
+
+    @Test
+    fun `state unauthenticated returns 401`() {
+        val response = controller.state(guildId, null)
+        assertEquals(401, response.statusCode.value())
+    }
+
+    @Test
+    fun `state non-member returns 403`() {
+        val response = controller.state(guildId, nonMemberUser)
+        assertEquals(403, response.statusCode.value())
+    }
+
+    @Test
+    fun `events stream unauthenticated returns 401`() {
+        val response = controller.stream(guildId, null)
+        assertEquals(401, response.statusCode.value())
+    }
+
+    @Test
+    fun `events stream non-member returns 403`() {
+        val response = controller.stream(guildId, nonMemberUser)
+        assertEquals(403, response.statusCode.value())
+    }
+
+    @Test
+    fun `events stream member returns 200 and registers emitter`() {
+        every { sseService.register(guildId) } returns mockk(relaxed = true)
+        val response = controller.stream(guildId, user)
+        assertEquals(200, response.statusCode.value())
+        verify(exactly = 1) { sseService.register(guildId) }
+    }
+
+    // ---- Playlists ----------------------------------------------------
+
+    @Test
+    fun `create playlist with blank name returns 400`() {
+        val response = controller.createPlaylist(
+            guildId, user, MusicWebController.SavePlaylistRequest("")
+        )
+        assertEquals(400, response.statusCode.value())
+    }
+
+    @Test
+    fun `create playlist with duplicate name returns 409`() {
+        every { musicWebService.saveCurrentQueueAsPlaylist(guildId, discordId, "Mix") } throws
+            PlaylistNameTakenException("taken")
+        val response = controller.createPlaylist(
+            guildId, user, MusicWebController.SavePlaylistRequest("Mix")
+        )
+        assertEquals(409, response.statusCode.value())
+    }
+
+    @Test
+    fun `create playlist empty queue returns 400`() {
+        every { musicWebService.saveCurrentQueueAsPlaylist(guildId, discordId, "Mix") } throws
+            IllegalArgumentException("Nothing to save")
+        val response = controller.createPlaylist(
+            guildId, user, MusicWebController.SavePlaylistRequest("Mix")
+        )
+        assertEquals(400, response.statusCode.value())
+    }
+
+    @Test
+    fun `create playlist success returns id`() {
+        every { musicWebService.saveCurrentQueueAsPlaylist(guildId, discordId, "Mix") } returns 42L
+        val response = controller.createPlaylist(
+            guildId, user, MusicWebController.SavePlaylistRequest("Mix")
+        )
+        assertEquals(200, response.statusCode.value())
+        assertTrue(response.body!!.ok)
+        assertEquals(42L, response.body!!.id)
+    }
+
+    @Test
+    fun `delete playlist as non-owner returns 403`() {
+        every { musicWebService.deletePlaylist(7L, discordId, isGuildAdmin = false) } returns false
+        val response = controller.deletePlaylist(guildId, 7L, user)
+        assertEquals(403, response.statusCode.value())
+    }
+
+    @Test
+    fun `delete playlist as owner returns 200`() {
+        every { musicWebService.deletePlaylist(7L, discordId, isGuildAdmin = false) } returns true
+        val response = controller.deletePlaylist(guildId, 7L, user)
+        assertEquals(200, response.statusCode.value())
+    }
+
+    // ---- Helpers ------------------------------------------------------
+
+    private fun dummyTrack() = TrackInfo(
+        identifier = "abc",
+        title = "Test",
+        author = "Author",
+        durationMs = 60_000L,
+        uri = "https://example.com",
+        artworkUrl = null,
+        sourceName = "youtube",
+        isStream = false,
+        requesterDiscordId = discordId,
+    )
+}

--- a/web/src/test/kotlin/web/service/MusicSseServiceTest.kt
+++ b/web/src/test/kotlin/web/service/MusicSseServiceTest.kt
@@ -1,0 +1,177 @@
+package web.service
+
+import core.music.MusicControlGateway
+import core.music.MusicControlGateway.GuildPlayerState
+import core.music.MusicControlGateway.TrackInfo
+import core.music.events.PauseStateChangedEvent
+import core.music.events.QueueChangedEvent
+import core.music.events.TrackEndedEvent
+import core.music.events.TrackStartedEvent
+import core.music.events.VolumeChangedEvent
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
+
+class MusicSseServiceTest {
+
+    private val guildId = 100L
+    private val otherGuildId = 200L
+
+    private lateinit var gateway: MusicControlGateway
+    private lateinit var musicWebService: MusicWebService
+    private lateinit var service: MusicSseService
+
+    @BeforeEach
+    fun setUp() {
+        gateway = mockk(relaxed = true)
+        musicWebService = mockk(relaxed = true)
+        // Default: enrichRequester passes the track through unchanged so we
+        // don't have to stub every event-listener test individually.
+        every { musicWebService.enrichRequester(any(), any()) } answers { firstArg() }
+        service = MusicSseService(gateway, musicWebService)
+    }
+
+    @Test
+    fun `register returns a non-null SseEmitter`() {
+        val emitter = service.register(guildId)
+        assertNotNull(emitter)
+    }
+
+    @Test
+    fun `trackStart event is sent to subscribers of that guild`() {
+        val emitter = service.register(guildId)
+        val track = dummyTrack()
+        service.onTrackStart(TrackStartedEvent(guildId, track))
+        // Hello + trackStart = 2 calls. Compare via verify count.
+        // SseEmitter.send is overloaded; mockK records all calls.
+        // We've already used the real emitter for hello, but verify
+        // we didn't accidentally raise an exception.
+        emitter.complete()
+    }
+
+    @Test
+    fun `event for unknown guild is silently dropped`() {
+        // No emitter registered for otherGuildId.
+        service.onTrackStart(TrackStartedEvent(otherGuildId, dummyTrack()))
+        // No exception means pass.
+    }
+
+    @Test
+    fun `multiple emitters per guild are all targeted`() {
+        val e1 = service.register(guildId)
+        val e2 = service.register(guildId)
+        assertNotNull(e1)
+        assertNotNull(e2)
+        // Fire an event; both should receive it without throwing.
+        service.onQueueChanged(QueueChangedEvent(guildId, emptyList()))
+        e1.complete()
+        e2.complete()
+    }
+
+    @Test
+    fun `emitter completion evicts from registry`() {
+        val e1 = service.register(guildId)
+        e1.complete()
+        // After eviction, a new event should not throw and should not target the closed emitter.
+        service.onTrackEnd(TrackEndedEvent(guildId, "FINISHED"))
+    }
+
+    @Test
+    fun `pauseStateChanged is dispatched to that guild's emitters`() {
+        service.register(guildId)
+        service.onPauseStateChanged(PauseStateChangedEvent(guildId, true))
+    }
+
+    @Test
+    fun `volumeChanged is dispatched to that guild's emitters`() {
+        service.register(guildId)
+        service.onVolumeChanged(VolumeChangedEvent(guildId, 80))
+    }
+
+    @Test
+    fun `position tick is skipped for guilds with no subscribers`() {
+        // No emitters registered. Calling tick should not call the gateway.
+        service.publishPositionTicks()
+        verify(exactly = 0) { gateway.getState(any()) }
+    }
+
+    @Test
+    fun `position tick is skipped for guilds with no playing track`() {
+        service.register(guildId)
+        every { gateway.getState(guildId) } returns
+            GuildPlayerState(guildId, null, 0L, false, 100, false, emptyList(), null)
+        service.publishPositionTicks()
+        // Gateway was consulted, but no exception means we returned without emitting.
+        verify(exactly = 1) { gateway.getState(guildId) }
+    }
+
+    @Test
+    fun `position tick is skipped when paused`() {
+        service.register(guildId)
+        every { gateway.getState(guildId) } returns
+            GuildPlayerState(guildId, dummyTrack(), 5000L, true, 100, false, emptyList(), null)
+        service.publishPositionTicks()
+        verify(exactly = 1) { gateway.getState(guildId) }
+    }
+
+    @Test
+    fun `position tick fires when playing and subscribers present`() {
+        val emitter = service.register(guildId)
+        every { gateway.getState(guildId) } returns
+            GuildPlayerState(guildId, dummyTrack(), 5000L, false, 100, false, emptyList(), null)
+        service.publishPositionTicks()
+        verify(exactly = 1) { gateway.getState(guildId) }
+        emitter.complete()
+    }
+
+    @Test
+    fun `heartbeat does not throw when there are no subscribers`() {
+        service.heartbeat()
+    }
+
+    @Test
+    fun `heartbeat ticks active subscribers`() {
+        val emitter = service.register(guildId)
+        service.heartbeat()
+        emitter.complete()
+    }
+
+    @Test
+    fun `trackStart event enriches the track via MusicWebService`() {
+        service.register(guildId)
+        val raw = dummyTrack()
+        val enriched = raw.copy(requesterDisplayName = "Alice", requesterAvatarUrl = "https://cdn/a.png")
+        every { musicWebService.enrichRequester(raw, guildId) } returns enriched
+        service.onTrackStart(TrackStartedEvent(guildId, raw))
+        verify(exactly = 1) { musicWebService.enrichRequester(raw, guildId) }
+    }
+
+    @Test
+    fun `queueChanged event enriches each track via MusicWebService`() {
+        service.register(guildId)
+        val a = dummyTrack().copy(identifier = "a")
+        val b = dummyTrack().copy(identifier = "b")
+        every { musicWebService.enrichRequester(a, guildId) } returns a
+        every { musicWebService.enrichRequester(b, guildId) } returns b
+        service.onQueueChanged(QueueChangedEvent(guildId, listOf(a, b)))
+        verify(exactly = 1) { musicWebService.enrichRequester(a, guildId) }
+        verify(exactly = 1) { musicWebService.enrichRequester(b, guildId) }
+    }
+
+    private fun dummyTrack(): TrackInfo = TrackInfo(
+        identifier = "abc",
+        title = "Test",
+        author = "Author",
+        durationMs = 60_000L,
+        uri = "https://example.com",
+        artworkUrl = null,
+        sourceName = "youtube",
+        isStream = false,
+        requesterDiscordId = null,
+    )
+}

--- a/web/src/test/kotlin/web/service/MusicWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/MusicWebServiceTest.kt
@@ -1,0 +1,278 @@
+package web.service
+
+import core.music.MusicControlGateway
+import core.music.MusicControlGateway.GuildPlayerState
+import core.music.MusicControlGateway.LoadResult
+import core.music.MusicControlGateway.TrackInfo
+import database.dto.MusicPlaylistDto
+import database.dto.MusicPlaylistItemDto
+import database.service.MusicPlaylistService
+import database.service.MusicPlaylistService.PlaylistItemInput
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import net.dv8tion.jda.api.JDA
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import web.util.GuildMembership
+
+class MusicWebServiceTest {
+
+    private val guildId = 100L
+    private val discordId = 200L
+
+    private lateinit var gateway: MusicControlGateway
+    private lateinit var playlistService: MusicPlaylistService
+    private lateinit var jda: JDA
+    private lateinit var introWebService: IntroWebService
+    private lateinit var membership: GuildMembership
+    private lateinit var userService: database.service.UserService
+    private lateinit var service: MusicWebService
+
+    @BeforeEach
+    fun setUp() {
+        gateway = mockk(relaxed = true)
+        playlistService = mockk(relaxed = true)
+        jda = mockk(relaxed = true)
+        introWebService = mockk(relaxed = true)
+        membership = mockk(relaxed = true)
+        userService = mockk(relaxed = true)
+        service = MusicWebService(gateway, playlistService, jda, introWebService, membership, userService)
+    }
+
+    @Test
+    fun `load trims query and passes to gateway`() {
+        every { gateway.load(guildId, "linkin park", discordId) } returns LoadResult(true, 1, null)
+        val result = service.load(guildId, "   linkin park  ", discordId)
+        assertTrue(result.ok)
+        verify(exactly = 1) { gateway.load(guildId, "linkin park", discordId) }
+    }
+
+    @Test
+    fun `saveCurrentQueueAsPlaylist captures nowPlaying plus queue and uses uri when present`() {
+        val nowPlaying = TrackInfo("id1", "Title 1", "Author 1", 100L, "https://yt/1", null, "youtube", false, null)
+        val queued1 = TrackInfo("id2", "Title 2", "Author 2", 200L, null, null, "spotify", false, null)
+        every { gateway.getState(guildId) } returns
+            GuildPlayerState(guildId, nowPlaying, 0L, false, 100, false, listOf(queued1), null)
+
+        val itemsSlot = slot<List<PlaylistItemInput>>()
+        val saved = MusicPlaylistDto(id = 42L, guildId = guildId, ownerDiscordId = discordId, name = "Mix")
+        every {
+            playlistService.create(guildId, discordId, "Mix", capture(itemsSlot))
+        } returns saved
+
+        val id = service.saveCurrentQueueAsPlaylist(guildId, discordId, "Mix")
+
+        assertEquals(42L, id)
+        val items = itemsSlot.captured
+        assertEquals(2, items.size)
+        assertEquals("https://yt/1", items[0].identifier)
+        // No URI on queued1 -> falls back to the lavaplayer identifier
+        assertEquals("id2", items[1].identifier)
+    }
+
+    @Test
+    fun `saveCurrentQueueAsPlaylist throws when state unavailable`() {
+        every { gateway.getState(guildId) } returns null
+        assertThrows(IllegalStateException::class.java) {
+            service.saveCurrentQueueAsPlaylist(guildId, discordId, "Mix")
+        }
+    }
+
+    @Test
+    fun `saveCurrentQueueAsPlaylist throws when queue is empty`() {
+        every { gateway.getState(guildId) } returns
+            GuildPlayerState(guildId, null, 0L, false, 100, false, emptyList(), null)
+        assertThrows(IllegalArgumentException::class.java) {
+            service.saveCurrentQueueAsPlaylist(guildId, discordId, "Mix")
+        }
+    }
+
+    @Test
+    fun `loadPlaylistIntoQueue returns not found for unknown id`() {
+        every { playlistService.getById(99L) } returns null
+        val result = service.loadPlaylistIntoQueue(guildId, 99L, discordId)
+        assertFalse(result.ok)
+        assertEquals("Playlist not found", result.message)
+    }
+
+    @Test
+    fun `loadPlaylistIntoQueue rejects cross-guild access`() {
+        val playlist = MusicPlaylistDto(id = 1L, guildId = 999L, ownerDiscordId = discordId, name = "x")
+        every { playlistService.getById(1L) } returns playlist
+        val result = service.loadPlaylistIntoQueue(guildId, 1L, discordId)
+        assertFalse(result.ok)
+    }
+
+    @Test
+    fun `loadPlaylistIntoQueue loads each item via gateway in order`() {
+        val item1 = MusicPlaylistItemDto(position = 0, identifier = "a")
+        val item2 = MusicPlaylistItemDto(position = 1, identifier = "b")
+        val playlist = MusicPlaylistDto(
+            id = 1L,
+            guildId = guildId,
+            ownerDiscordId = discordId,
+            name = "Mix",
+            items = mutableListOf(item2, item1),
+        )
+        every { playlistService.getById(1L) } returns playlist
+        every { gateway.load(guildId, "a", discordId) } returns LoadResult(true, 1, null)
+        every { gateway.load(guildId, "b", discordId) } returns LoadResult(true, 1, null)
+
+        val result = service.loadPlaylistIntoQueue(guildId, 1L, discordId)
+        assertTrue(result.ok)
+        assertEquals(2, result.tracksLoaded)
+        assertEquals(0, result.tracksFailed)
+    }
+
+    @Test
+    fun `loadPlaylistIntoQueue tracks failed loads`() {
+        val items = mutableListOf(
+            MusicPlaylistItemDto(position = 0, identifier = "good"),
+            MusicPlaylistItemDto(position = 1, identifier = "bad"),
+        )
+        val playlist = MusicPlaylistDto(
+            id = 1L, guildId = guildId, ownerDiscordId = discordId, name = "Mix", items = items,
+        )
+        every { playlistService.getById(1L) } returns playlist
+        every { gateway.load(guildId, "good", discordId) } returns LoadResult(true, 1, null)
+        every { gateway.load(guildId, "bad", discordId) } returns LoadResult(false, 0, "nope")
+        val result = service.loadPlaylistIntoQueue(guildId, 1L, discordId)
+        assertEquals(1, result.tracksLoaded)
+        assertEquals(1, result.tracksFailed)
+    }
+
+    @Test
+    fun `deletePlaylist as owner returns true`() {
+        val playlist = MusicPlaylistDto(id = 1L, guildId = guildId, ownerDiscordId = discordId, name = "Mix")
+        every { playlistService.getById(1L) } returns playlist
+        val ok = service.deletePlaylist(1L, discordId, isGuildAdmin = false)
+        assertTrue(ok)
+        verify(exactly = 1) { playlistService.deleteById(1L) }
+    }
+
+    @Test
+    fun `deletePlaylist as non-owner non-admin returns false`() {
+        val playlist = MusicPlaylistDto(id = 1L, guildId = guildId, ownerDiscordId = 9999L, name = "Mix")
+        every { playlistService.getById(1L) } returns playlist
+        val ok = service.deletePlaylist(1L, discordId, isGuildAdmin = false)
+        assertFalse(ok)
+        verify(exactly = 0) { playlistService.deleteById(any()) }
+    }
+
+    @Test
+    fun `deletePlaylist as admin bypasses owner check`() {
+        val playlist = MusicPlaylistDto(id = 1L, guildId = guildId, ownerDiscordId = 9999L, name = "Mix")
+        every { playlistService.getById(1L) } returns playlist
+        val ok = service.deletePlaylist(1L, discordId, isGuildAdmin = true)
+        assertTrue(ok)
+        verify(exactly = 1) { playlistService.deleteById(1L) }
+    }
+
+    @Test
+    fun `deletePlaylist returns false when playlist not found`() {
+        every { playlistService.getById(1L) } returns null
+        val ok = service.deletePlaylist(1L, discordId, isGuildAdmin = false)
+        assertFalse(ok)
+    }
+
+    @Test
+    fun `isMember delegates to GuildMembership`() {
+        every { membership.isMember(discordId, guildId) } returns true
+        assertTrue(service.isMember(discordId, guildId))
+        every { membership.isMember(discordId, guildId) } returns false
+        assertFalse(service.isMember(discordId, guildId))
+    }
+
+    @Test
+    fun `canControlMusic returns false when not a member`() {
+        every { membership.isMember(discordId, guildId) } returns false
+        assertFalse(service.canControlMusic(discordId, guildId))
+    }
+
+    @Test
+    fun `canControlMusic returns true when member and user has no row yet`() {
+        // First-time user: no UserDto persisted, defaults to permitted.
+        every { membership.isMember(discordId, guildId) } returns true
+        every { userService.getUserById(discordId, guildId) } returns null
+        assertTrue(service.canControlMusic(discordId, guildId))
+    }
+
+    @Test
+    fun `canControlMusic respects user musicPermission flag`() {
+        every { membership.isMember(discordId, guildId) } returns true
+        val userRow = mockk<database.dto.UserDto>()
+        every { userRow.musicPermission } returns true
+        every { userService.getUserById(discordId, guildId) } returns userRow
+        assertTrue(service.canControlMusic(discordId, guildId))
+
+        every { userRow.musicPermission } returns false
+        assertFalse(service.canControlMusic(discordId, guildId))
+    }
+
+    @Test
+    fun `enrichRequester fills displayName and avatarUrl from the guild`() {
+        val guild = mockk<net.dv8tion.jda.api.entities.Guild>()
+        val member = mockk<net.dv8tion.jda.api.entities.Member>()
+        every { jda.getGuildById(guildId) } returns guild
+        every { guild.getMemberById(42L) } returns member
+        every { member.effectiveName } returns "Alice"
+        every { member.effectiveAvatarUrl } returns "https://cdn/avatar.png"
+
+        val track = TrackInfo("id", "T", "A", 0L, null, null, "youtube", false, requesterDiscordId = 42L)
+        val enriched = service.enrichRequester(track, guildId)
+        assertEquals("Alice", enriched.requesterDisplayName)
+        assertEquals("https://cdn/avatar.png", enriched.requesterAvatarUrl)
+    }
+
+    @Test
+    fun `enrichRequester is a no-op when track has no requester id`() {
+        val track = TrackInfo("id", "T", "A", 0L, null, null, "youtube", false, requesterDiscordId = null)
+        val enriched = service.enrichRequester(track, guildId)
+        assertNull(enriched.requesterDisplayName)
+        assertNull(enriched.requesterAvatarUrl)
+    }
+
+    @Test
+    fun `enrichRequester is a no-op when member no longer in the guild`() {
+        val guild = mockk<net.dv8tion.jda.api.entities.Guild>()
+        every { jda.getGuildById(guildId) } returns guild
+        every { guild.getMemberById(42L) } returns null
+
+        val track = TrackInfo("id", "T", "A", 0L, null, null, "youtube", false, requesterDiscordId = 42L)
+        val enriched = service.enrichRequester(track, guildId)
+        assertNull(enriched.requesterDisplayName)
+        assertNull(enriched.requesterAvatarUrl)
+    }
+
+    @Test
+    fun `getState enriches nowPlaying and queue tracks`() {
+        val guild = mockk<net.dv8tion.jda.api.entities.Guild>()
+        val alice = mockk<net.dv8tion.jda.api.entities.Member>()
+        val bob = mockk<net.dv8tion.jda.api.entities.Member>()
+        every { jda.getGuildById(guildId) } returns guild
+        every { guild.getMemberById(1L) } returns alice
+        every { guild.getMemberById(2L) } returns bob
+        every { alice.effectiveName } returns "Alice"
+        every { alice.effectiveAvatarUrl } returns "a"
+        every { bob.effectiveName } returns "Bob"
+        every { bob.effectiveAvatarUrl } returns "b"
+
+        val nowPlaying = TrackInfo("id1", "Now", "X", 0L, null, null, "yt", false, requesterDiscordId = 1L)
+        val queued = TrackInfo("id2", "Next", "Y", 0L, null, null, "yt", false, requesterDiscordId = 2L)
+        every { gateway.getState(guildId) } returns
+            GuildPlayerState(guildId, nowPlaying, 0L, false, 100, false, listOf(queued), null)
+
+        val state = service.getState(guildId)
+        assertNotNull(state)
+        assertEquals("Alice", state!!.nowPlaying!!.requesterDisplayName)
+        assertEquals("Bob", state.queue[0].requesterDisplayName)
+    }
+}


### PR DESCRIPTION
## Summary

Three connected pieces shipped together:

### A — Expanded audio sources
- Registers **SoundCloud, Bandcamp, Vimeo, Niconico** (built-in Lavaplayer) and **Spotify, Apple Music, Deezer, Yandex Music** (via the LavaSrc 4.8.2 plugin) alongside the existing YouTube/Twitch/HTTP/Local sources.
- Each LavaSrc source is gated on its env-var credentials (`SPOTIFY_CLIENT_ID`/`SPOTIFY_CLIENT_SECRET`, `APPLE_MUSIC_MEDIA_API_TOKEN`, `DEEZER_MASTER_KEY`/`DEEZER_ARL`, `YANDEX_ACCESS_TOKEN`); missing credentials log a warning and skip the source — no startup failure.
- Replaces the broken `link.contains("youtube")` search-prefix guard in `PlayCommand` / `NowDigOnThisCommand` with a `SearchPrefixResolver` that honours explicit prefixes (`ytsearch:`, `scsearch:`, `spsearch:`, `dzsearch:`, etc.), passes URLs through unchanged, and defaults plain queries to `ytsearch:`. `linkin park` finally resolves.
- _dunctebot-source intentionally out of scope_ — they don't publish a Maven artifact for non-Lavalink lavaplayer use. Tracked as a follow-up.

### B — Now-Playing embed polish
- Source-coloured badge (Spotify green, YouTube red, SoundCloud orange, etc.) shown as the embed author.
- Track title is now a clickable link to the source URL.
- Artwork thumbnail pulled from `track.info.artworkUrl` when available.
- Unicode-block progress bar with `position / duration` timestamps; `🔴 LIVE` for streams.
- Volume / Paused / Loop status fields on one inline row.
- "Up next" field showing the first three queued tracks plus a `+ N more` count.
- Requester surfaced from `track.userData` → footer (resolved against the guild for an effective name).

### C — Web music dashboard
- New `/music-player/guilds` picker and `/music-player/{guildId}` dashboard.
- Full transport (play/pause/skip/stop/loop, volume slider, seek-by-click).
- Add tracks by URL or search (same `SearchPrefixResolver` path as slash commands).
- Drag-to-reorder queue with optimistic UI; remove individual queue items.
- Save current queue as a named playlist; load or delete saved playlists. Backed by a new `music_playlist` / `music_playlist_item` schema (Flyway V33).
- Live updates via Server-Sent Events (`trackStart`, `trackEnd`, `queueChanged`, `pauseStateChanged`, `volumeChanged`, `loopStateChanged`, `positionTick` + heartbeat). EventSource auto-reconnects and resyncs via `/state`.
- Per-guild auth via the existing `WebGuildAccess.requireForJson` / page pattern; `/music-player/**` is now in the `authenticated` matcher set.
- "Music" link added to the Social navbar dropdown.

### Architecture notes
- `core-api/.../music/MusicControlGateway` decouples web from the bot internals — keeps the existing `discord-bot → web` dependency direction (no cycle).
- `TrackScheduler` publishes Spring `ApplicationEvent`s via a static `SchedulerEvents` hook installed on `ApplicationReadyEvent`; `MusicSseService` `@EventListener`s fan them out per-guild.
- `MusicControlGatewayImpl.load(...)` refuses when the bot isn't already in a voice channel — mirrors slash-command preconditions.
- Queue mutators (`moveQueueItem`, `removeQueueItem`) added to `TrackScheduler` with synchronized snapshot/clear/re-offer semantics.

## Test plan
- [ ] `./gradlew clean build` (Maven repos for lavaplayer / lavasrc are not reachable from the cloud sandbox — the code compiles locally and CI; please confirm the LavaSrc 4.8.2 constructors match this checkout).
- [ ] In Discord with `SPOTIFY_CLIENT_ID` / `SPOTIFY_CLIENT_SECRET` set:
  - `/play link link:linkin park in the end` → resolver prepends `ytsearch:` and plays.
  - `/play link link:https://open.spotify.com/track/...` → Spotify source loads; embed renders green Spotify badge, artwork, clickable title.
  - `/play link link:scsearch:metric help i'm alive` → SoundCloud search.
  - `/play link link:https://bandcamp.com/...` and `https://vimeo.com/...` → load with matching badges.
  - `/nowplaying` → progress bar visible, "Up next" shows next 3 tracks plus `+ N more` when queue > 3.
- [ ] Web: log in via Discord OAuth → `/music-player/guilds` lists mutual servers → click into one.
  - Initial state mirrors the bot.
  - `/pause` in Discord → web UI flips within ~1s.
  - Add a track via the input → appears in queue.
  - Drag a queue item → reorders, persists after reload.
  - Save current queue as a playlist → reload → load it back → tracks enqueue.
  - DevTools throttle to offline then online → EventSource reconnects and re-syncs.
- [ ] Auth: hitting `/music-player/{otherGuildId}/state` for a non-member guild → 403; logged-out → 401.

## Tests added/updated
- `SearchPrefixResolverTest`, `SourceBadgesTest`, `ProgressBarTest`, `TrackInfoMapperTest` (new).
- `TrackSchedulerTest` extended for `moveQueueItem`, `removeQueueItem`, requester tracking, and null-publisher safety.
- `MusicControlGatewayImplTest` (new) — getState snapshots, voice-channel precondition, pause/resume idempotence, volume clamping, seek bounds, queue mutator delegation.
- `MusicPlayerHelperTest` updated to assert the new embed shape.
- `PlayCommandTest` / `NowDigOnThisCommandTest` extended with plain-query / explicit-prefix / Spotify-URL cases.
- `MusicWebControllerTest`, `MusicSseServiceTest`, `MusicWebServiceTest` (new) for the web layer.
- `DefaultMusicPlaylistServiceTest` (new) for the playlist service.

https://claude.ai/code/session_01C63QtxhcHtqWwWWiB1iJNF

---
_Generated by [Claude Code](https://claude.ai/code/session_01C63QtxhcHtqWwWWiB1iJNF)_