### PR TITLE
feat(support): add Ko-fi link across web, README and Discord bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ Requires [Docker Desktop](https://www.docker.com/products/docker-desktop/).
 - Invite your Toby Bot to your Discord server and grant the required permissions.
 - Interact with the bot using the commands and features provided by the project.
 
+## Support the Project
+
+TobyBot is free and open source. If you'd like to help cover hosting costs or just say thanks, you can support development on [Ko-fi](https://ko-fi.com/fratlayton).
+
 ## Acknowledgments
 
 Special thanks to the creators and maintainers of Spring Boot, JDA, JPA, Hibernate, and Spring Web for their contributions to this project.

--- a/application/src/test/kotlin/integration/bot/CommandManagerTest.kt
+++ b/application/src/test/kotlin/integration/bot/CommandManagerTest.kt
@@ -160,11 +160,12 @@ class CommandManagerTest {
             PlinkoCommand::class.java,
             WheelOfFortuneCommand::class.java,
             HorseRacingCommand::class.java,
+            SupportCommand::class.java,
         )
 
         Assertions.assertTrue(availableCommands.containsAll(commandManager.allCommands.map { it.javaClass }.toList()))
-        Assertions.assertEquals(65, commandManager.allCommands.size)
-        Assertions.assertEquals(65, commandManager.allSlashCommands.size)
+        Assertions.assertEquals(66, commandManager.allCommands.size)
+        Assertions.assertEquals(66, commandManager.allSlashCommands.size)
     }
 
     @Test

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/misc/HelpCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/misc/HelpCommand.kt
@@ -21,7 +21,8 @@ class HelpCommand @Autowired constructor(private val commands: List<core.command
         // If no specific command is provided, direct users to the general wiki page
         if (args.isEmpty()) {
             val helpMessage =
-                "For a list of all available commands, visit the [Toby Bot Commands Wiki](https://github.com/ml404/toby-bot/wiki/Commands)"
+                "For a list of all available commands, visit the [Toby Bot Commands Wiki](https://github.com/ml404/toby-bot/wiki/Commands).\n" +
+                "Enjoying the bot? You can support development on [Ko-fi](https://ko-fi.com/fratlayton)."
             event.hook.replyAndDelete(helpMessage, deleteDelay)
             return
         }

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/misc/SupportCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/misc/SupportCommand.kt
@@ -1,0 +1,38 @@
+package bot.toby.command.commands.misc
+
+import core.command.Command.Companion.invokeDeleteOnMessageResponse
+import core.command.CommandContext
+import database.dto.UserDto
+import net.dv8tion.jda.api.EmbedBuilder
+import net.dv8tion.jda.api.interactions.commands.build.OptionData
+import org.springframework.stereotype.Component
+
+@Component
+class SupportCommand : MiscCommand {
+    override fun handle(ctx: CommandContext, requestingUserDto: UserDto, deleteDelay: Int) {
+        val event = ctx.event
+        event.deferReply(true).queue()
+
+        val embed = EmbedBuilder()
+            .setTitle("Support TobyBot")
+            .setDescription(
+                "TobyBot is free and open source. If you'd like to help cover hosting " +
+                "costs or just say thanks, the links below are the best places to start."
+            )
+            .addField("Ko-fi", "[Support development](https://ko-fi.com/fratlayton)", false)
+            .addField("GitHub", "[Source & issues](https://github.com/ml404/toby-bot)", false)
+            .addField("Commands wiki", "[Browse all commands](https://github.com/ml404/toby-bot/wiki/Commands)", false)
+            .build()
+
+        event.hook.sendMessageEmbeds(embed)
+            .setEphemeral(true)
+            .queue(invokeDeleteOnMessageResponse(deleteDelay))
+    }
+
+    override val name: String
+        get() = "support"
+    override val description: String
+        get() = "Links for supporting TobyBot and finding help"
+    override val optionData: List<OptionData>
+        get() = emptyList()
+}

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/misc/SupportCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/misc/SupportCommandTest.kt
@@ -1,0 +1,31 @@
+package bot.toby.command.commands.misc
+
+import bot.toby.command.CommandTest
+import bot.toby.command.CommandTest.Companion.event
+import bot.toby.command.CommandTest.Companion.interactionHook
+import bot.toby.command.CommandTest.Companion.replyCallbackAction
+import bot.toby.command.DefaultCommandContext
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import net.dv8tion.jda.api.entities.MessageEmbed
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class SupportCommandTest : CommandTest {
+    private lateinit var supportCommand: SupportCommand
+
+    @BeforeEach
+    fun setup() {
+        setUpCommonMocks()
+        every { event.deferReply(true) } returns replyCallbackAction
+        supportCommand = SupportCommand()
+    }
+
+    @Test
+    fun testHandleSendsSupportEmbed() {
+        supportCommand.handle(DefaultCommandContext(event), mockk(), 0)
+
+        verify(exactly = 1) { interactionHook.sendMessageEmbeds(any<MessageEmbed>(), *anyVararg()) }
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/misc/SupportCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/misc/SupportCommandTest.kt
@@ -2,13 +2,12 @@ package bot.toby.command.commands.misc
 
 import bot.toby.command.CommandTest
 import bot.toby.command.CommandTest.Companion.event
-import bot.toby.command.CommandTest.Companion.interactionHook
 import bot.toby.command.CommandTest.Companion.replyCallbackAction
+import bot.toby.command.CommandTest.Companion.webhookMessageCreateAction
 import bot.toby.command.DefaultCommandContext
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
-import net.dv8tion.jda.api.entities.MessageEmbed
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
@@ -19,6 +18,7 @@ internal class SupportCommandTest : CommandTest {
     fun setup() {
         setUpCommonMocks()
         every { event.deferReply(true) } returns replyCallbackAction
+        every { event.hook.sendMessageEmbeds(any(), *anyVararg()) } returns webhookMessageCreateAction
         supportCommand = SupportCommand()
     }
 
@@ -26,6 +26,6 @@ internal class SupportCommandTest : CommandTest {
     fun testHandleSendsSupportEmbed() {
         supportCommand.handle(DefaultCommandContext(event), mockk(), 0)
 
-        verify(exactly = 1) { interactionHook.sendMessageEmbeds(any<MessageEmbed>(), *anyVararg()) }
+        verify(exactly = 1) { event.hook.sendMessageEmbeds(any(), *anyVararg()) }
     }
 }

--- a/web/src/main/resources/templates/fragments/footer.html
+++ b/web/src/main/resources/templates/fragments/footer.html
@@ -21,7 +21,8 @@
         </p>
         <p class="site-footer-line site-footer-source">
             Open source on
-            <a href="https://github.com/ml404/toby-bot" rel="noopener" target="_blank">GitHub</a>.
+            <a href="https://github.com/ml404/toby-bot" rel="noopener" target="_blank">GitHub</a> &middot;
+            <a href="https://ko-fi.com/fratlayton" rel="noopener" target="_blank">Support on Ko-fi</a>.
             <a th:href="@{/commands/wiki}">Browse all commands &rarr;</a>
         </p>
         <p class="site-footer-stack">

--- a/web/src/main/resources/templates/home.html
+++ b/web/src/main/resources/templates/home.html
@@ -183,6 +183,9 @@
         <a th:href="${inviteUrl}" class="btn-primary">Invite to Server</a>
         <a th:href="@{/commands/wiki}" class="btn-secondary">Browse all commands</a>
     </div>
+    <p class="hero-aside">
+        <a href="https://ko-fi.com/fratlayton" rel="noopener" target="_blank">Like TobyBot? Support development on Ko-fi &rarr;</a>
+    </p>
 </section>
 
 <footer th:replace="~{fragments/footer :: footer}"></footer>


### PR DESCRIPTION
## Summary

Surfaces a single Ko-fi link (`https://ko-fi.com/fratlayton`) in one spot per user-facing channel so supporters can find it without making the bot feel like a paywall:

- **Web footer** (`fragments/footer.html`) — appears on every marketing page (home, commands, terms, privacy, changelog).
- **Home page final CTA** — small `hero-aside` link under the existing Invite / Browse buttons.
- **README.md** — new "Support the Project" section above Acknowledgments.
- **`/help` no-args reply** — appends a Ko-fi sentence to the wiki pointer.
- **New `/support` slash command** — ephemeral embed with Ko-fi, GitHub and the commands wiki. Lives at `discord-bot/.../misc/SupportCommand.kt`, auto-registered via Spring's `@Component` scan (no registry edits). Test follows the `HelpCommandTest` pattern.

All edits reuse existing styles/utilities (`.site-footer a`, `.hero-aside`, `MiscCommand`, `invokeDeleteOnMessageResponse`) — no new CSS or wiring.

## Test plan

- [ ] `gradle clean build` passes locally (CI build verifies; local sandbox here blocked external Maven mirrors so a green build couldn't be produced in this session).
- [ ] Run the web app and confirm the Ko-fi link renders in the footer on `/`, `/terms`, `/privacy`, `/changelog`, `/commands/wiki`.
- [ ] Confirm the new aside line appears in the home page final CTA.
- [ ] In Discord, run `/help` with no args — Ko-fi link present in the reply.
- [ ] In Discord, run `/support` — ephemeral embed lists Ko-fi, GitHub, and the wiki.
- [ ] Preview README on GitHub to confirm the new section renders between Acknowledgments and the existing GitHub link.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lv6zWyZ93V2yxqno1xb6VS)_