### PR TITLE
fix(web): derive homepage game counts from a single GameCatalog

### DIFF
--- a/application/src/test/kotlin/web/controller/HomeControllerTest.kt
+++ b/application/src/test/kotlin/web/controller/HomeControllerTest.kt
@@ -27,7 +27,9 @@ class HomeControllerTest {
     private val sampleStats = HomeStatsService.HomeStats(
         serverCount = 7,
         commandCount = 42,
-        gameCount = 12,
+        gameCount = 15,
+        minigameCount = 12,
+        minigameNames = "slots, dice",
     )
 
     @BeforeEach

--- a/web/src/main/kotlin/web/catalog/GameCatalog.kt
+++ b/web/src/main/kotlin/web/catalog/GameCatalog.kt
@@ -1,0 +1,43 @@
+package web.catalog
+
+/**
+ * Single source of truth for the games listed on the homepage. Adding,
+ * removing, or renaming a game here updates every count and label
+ * rendered by `home.html` (stats strip, hero, casino feature card body,
+ * feature card tag) at once. Out of scope (still hardcoded): the navbar
+ * Play menu, `/casino/guilds` picker, the database-layer JackpotGame
+ * enum, and SetConfigStakesModal — each represents a different slice of
+ * "games" with different semantics.
+ */
+object GameCatalog {
+
+    enum class Category { MINIGAME, TABLE, DRAW }
+
+    data class Game(val displayName: String, val category: Category)
+
+    val games: List<Game> = listOf(
+        Game("slots", Category.MINIGAME),
+        Game("coinflip", Category.MINIGAME),
+        Game("dice", Category.MINIGAME),
+        Game("high-low", Category.MINIGAME),
+        Game("scratch", Category.MINIGAME),
+        Game("keno", Category.MINIGAME),
+        Game("roulette", Category.MINIGAME),
+        Game("baccarat", Category.MINIGAME),
+        Game("Casino Hold’em", Category.MINIGAME),
+        Game("plinko", Category.MINIGAME),
+        Game("horse racing", Category.MINIGAME),
+        Game("wheel", Category.MINIGAME),
+        Game("Poker", Category.TABLE),
+        Game("Blackjack", Category.TABLE),
+        Game("Lottery", Category.DRAW),
+    )
+
+    val total: Int = games.size
+
+    val minigames: List<Game> = games.filter { it.category == Category.MINIGAME }
+
+    val minigameCount: Int = minigames.size
+
+    val minigameNames: String = minigames.joinToString(", ") { it.displayName }
+}

--- a/web/src/main/kotlin/web/service/HomeStatsService.kt
+++ b/web/src/main/kotlin/web/service/HomeStatsService.kt
@@ -3,16 +3,16 @@ package web.service
 import core.managers.CommandManager
 import net.dv8tion.jda.api.JDA
 import org.springframework.stereotype.Service
+import web.catalog.GameCatalog
 import java.util.concurrent.atomic.AtomicReference
 
 /**
- * Live numbers for the homepage stats strip. Three counts:
+ * Live numbers for the homepage. Counts:
  *  - **servers**: how many guilds the bot is currently in (JDA cache size)
  *  - **commands**: total slash-command count across every category
- *  - **games**: hand-rolled count of standalone game UIs (9 minigames +
- *    Poker + Blackjack + Casino Hold'em). Hardcoded because the games
- *    list rarely changes and bumping a constant here is the cheapest
- *    signal of "we shipped a new game" for a future PR.
+ *  - **games / minigames**: derived from [GameCatalog] so the stats strip,
+ *    hero text, and casino feature card all stay in lockstep when a game
+ *    is added or removed.
  *
  * Memoised for 60 seconds in-process so a homepage refresh storm doesn't
  * touch the JDA cache or sum command lists per request. We deliberately
@@ -30,6 +30,8 @@ class HomeStatsService(
         val serverCount: Int,
         val commandCount: Int,
         val gameCount: Int,
+        val minigameCount: Int,
+        val minigameNames: String,
     )
 
     private data class Cached(val stats: HomeStats, val expiresAtNanos: Long)
@@ -55,14 +57,12 @@ class HomeStatsService(
                 miscCommands.size +
                 fetchCommands.size
         },
-        gameCount = GAME_COUNT,
+        gameCount = GameCatalog.total,
+        minigameCount = GameCatalog.minigameCount,
+        minigameNames = GameCatalog.minigameNames,
     )
 
     companion object {
-        // 9 minigames (slots, coinflip, dice, highlow, scratch, keno,
-        // roulette, baccarat, casino hold'em) + poker + blackjack +
-        // lottery = 12. Keep in sync with the navbar Play menu.
-        private const val GAME_COUNT = 12
         private val TTL_NANOS = 60_000_000_000L
     }
 }

--- a/web/src/main/resources/templates/home.html
+++ b/web/src/main/resources/templates/home.html
@@ -2,7 +2,7 @@
 <html xmlns:th="http://www.thymeleaf.org" lang="en">
 <head th:replace="~{fragments/head :: headSeo(
         'TobyBot — Your Discord Companion',
-        'A live per-server coin economy, a 13-game casino with a shared jackpot pool, music, polls, monthly leaderboards, and a full web admin — all in one Discord bot.',
+        'A live per-server coin economy, a ' + ${homeStats.gameCount} + '-game casino with a shared jackpot pool, music, polls, monthly leaderboards, and a full web admin — all in one Discord bot.',
         'https://www.toby-bot.co.uk/images/preview.svg',
         '/css/home.css')}"></head>
 <body>
@@ -13,7 +13,7 @@
 <section class="hero">
     <div class="hero-badge">Discord Bot</div>
     <h1>Your server&rsquo;s <span>best companion</span></h1>
-    <p>A live per-server coin economy, a 13-game casino with a shared jackpot pool,
+    <p>A live per-server coin economy, a [[${homeStats.gameCount}]]-game casino with a shared jackpot pool,
         music and intro songs, monthly leaderboards, and a full browser-based admin —
         all in one Discord bot.</p>
     <div class="hero-actions">
@@ -61,8 +61,8 @@
         <a class="feature-card" href="/casino/guilds">
             <div class="feature-icon">&#127920;</div>
             <h3>Casino games</h3>
-            <p>12 quick-play minigames (slots, dice, roulette, scratch, keno, high-low, baccarat, coinflip, plinko, horse racing, wheel, Casino Hold&rsquo;em) plus seated Poker and Blackjack tables.</p>
-            <span class="feature-card-tag">15 games</span>
+            <p>[[${homeStats.minigameCount}]] quick-play minigames ([[${homeStats.minigameNames}]]) plus seated Poker and Blackjack tables.</p>
+            <span class="feature-card-tag">[[${homeStats.gameCount}]] games</span>
         </a>
         <a class="feature-card" href="/lottery/guilds">
             <div class="feature-icon">&#127903;&#65039;</div>


### PR DESCRIPTION
## Summary

The homepage was rendering three different game counts because the stats strip, hero paragraph, and casino feature card each held their own hardcoded literal:

| Location | Before |
|---|---|
| Stats strip (`home.html` line 39, `homeStats.gameCount`) | `12` (from `HomeStatsService.GAME_COUNT`) |
| Hero meta description + paragraph (`home.html` lines 5, 16) | `13`-game casino |
| Casino feature card body (line 64) | `12` quick-play minigames |
| Casino feature card tag (line 65) | `15` games |

The constant in `HomeStatsService` even had a `// Keep in sync with the navbar Play menu` comment that had already gone stale. Each new game required editing four strings with nothing forcing them to agree.

### Change

- New `web/src/main/kotlin/web/catalog/GameCatalog.kt` — a single list of 15 games (matching the navbar Play menu, the most up-to-date roster) categorised as `MINIGAME` / `TABLE` / `DRAW`, exposing `total`, `minigameCount`, and a `minigameNames` joined string.
- `HomeStatsService` drops the `GAME_COUNT` constant and adds `minigameCount` + `minigameNames` to `HomeStats`, all sourced from `GameCatalog`.
- `home.html` replaces every hardcoded number/string (meta description, hero, feature card body, feature card tag) with `${homeStats.…}` references.
- `HomeControllerTest` sample stats updated to match the new `HomeStats` shape.

After the change, adding/removing a game in `GameCatalog` updates all four homepage spots in lockstep.

### Out of scope (deliberately)

The navbar Play menu (`fragments/navbar.html`), `/casino/guilds` picker, the database-layer `JackpotGame` enum, and `SetConfigStakesModal.Game` enum are unchanged — each represents a different slice of "games" with different semantics. They can be migrated to the catalog in a follow-up.

## Test plan

- [x] `./gradlew :web:compileKotlin --offline` passes
- [ ] Visit `/` and confirm:
  - Stats strip "Games" shows **15**
  - Hero says "a **15**-game casino"
  - Casino feature card body starts "**12** quick-play minigames (slots, coinflip, dice, …)"
  - Casino feature card tag shows "**15** games"
  - `<meta name="description">` (View Source) reads "15-game casino"
- [ ] `./gradlew :application:test --tests web.controller.HomeControllerTest` (couldn't run in this sandbox — `:application` pulls discord-bot deps blocked by the network policy; the edit to `sampleStats` is a mechanical two-field add matching the new constructor)

https://claude.ai/code/session_01Ls388Gm24fhQUUNgAcyZbU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ls388Gm24fhQUUNgAcyZbU)_