### PR TITLE
feat(music): in-browser preview of search results and queue items

### DIFF
--- a/core-api/src/main/kotlin/core/music/MusicControlGateway.kt
+++ b/core-api/src/main/kotlin/core/music/MusicControlGateway.kt
@@ -19,6 +19,12 @@ interface MusicControlGateway {
         // these themselves via TrackScheduler.getRequesterId + Guild.getMemberById.
         val requesterDisplayName: String? = null,
         val requesterAvatarUrl: String? = null,
+        // ~30s clip URL from the source's own metadata (Spotify, Apple Music,
+        // Deezer, Yandex via LavaSrc's ExtendedAudioTrack). Null for sources
+        // that don't publish a preview URL (YouTube, SoundCloud, Bandcamp,
+        // HTTP, Local). The dashboard renders a Preview button only when
+        // this is non-null.
+        val previewUrl: String? = null,
     )
 
     data class VoiceMember(

--- a/discord-bot/src/main/kotlin/bot/toby/lavaplayer/TrackInfoMapper.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/lavaplayer/TrackInfoMapper.kt
@@ -1,5 +1,6 @@
 package bot.toby.lavaplayer
 
+import com.github.topi314.lavasrc.ExtendedAudioTrack
 import com.sedmelluq.discord.lavaplayer.track.AudioTrack
 import core.music.MusicControlGateway.TrackInfo
 
@@ -7,6 +8,11 @@ object TrackInfoMapper {
     fun toTrackInfo(track: AudioTrack, requesterId: Long?): TrackInfo {
         val info = track.info
         val sourceName = runCatching { track.sourceManager?.sourceName }.getOrNull()
+        // LavaSrc-loaded tracks (Spotify, Apple Music, Deezer, Yandex) carry a
+        // ~30s preview clip URL from the source's metadata. Non-LavaSrc tracks
+        // (YouTube, SoundCloud, Bandcamp, HTTP, Local) return null and the
+        // dashboard hides the Preview button entirely.
+        val previewUrl = runCatching { (track as? ExtendedAudioTrack)?.previewUrl }.getOrNull()
         return TrackInfo(
             identifier = info.identifier,
             title = info.title,
@@ -17,6 +23,7 @@ object TrackInfoMapper {
             sourceName = sourceName,
             isStream = info.isStream,
             requesterDiscordId = requesterId,
+            previewUrl = previewUrl,
         )
     }
 }

--- a/discord-bot/src/test/kotlin/bot/toby/lavaplayer/TrackInfoMapperTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/lavaplayer/TrackInfoMapperTest.kt
@@ -1,5 +1,6 @@
 package bot.toby.lavaplayer
 
+import com.github.topi314.lavasrc.ExtendedAudioTrack
 import com.sedmelluq.discord.lavaplayer.track.AudioTrack
 import com.sedmelluq.discord.lavaplayer.track.AudioTrackInfo
 import io.mockk.every
@@ -48,5 +49,64 @@ class TrackInfoMapperTest {
 
         val info = TrackInfoMapper.toTrackInfo(track, null)
         assertNull(info.sourceName)
+    }
+
+    @Test
+    fun `previewUrl is null for non-LavaSrc tracks`() {
+        // A vanilla AudioTrack (no ExtendedAudioTrack interface, like YouTube
+        // / SoundCloud / Bandcamp loads) won't pass the cast — the dashboard
+        // hides the Preview button entirely for these.
+        val track = mockk<AudioTrack>(relaxed = true)
+        every { track.info } returns AudioTrackInfo("T", "A", 1L, "id", false, "u")
+        every { track.duration } returns 1L
+        every { track.sourceManager } returns null
+
+        val info = TrackInfoMapper.toTrackInfo(track, null)
+        assertNull(info.previewUrl)
+    }
+
+    @Test
+    fun `previewUrl is populated for ExtendedAudioTrack instances`() {
+        // LavaSrc's Spotify / Apple / Deezer / Yandex tracks all implement
+        // ExtendedAudioTrack and expose getPreviewUrl(). We hand the cast
+        // result through unchanged.
+        val track = mockk<ExtendedAudioTrack>(relaxed = true)
+        every { track.info } returns AudioTrackInfo("Spotify Track", "Artist", 200_000L, "spotify:123", false, "https://open.spotify.com/track/123")
+        every { track.duration } returns 200_000L
+        every { track.sourceManager } returns null
+        every { track.previewUrl } returns "https://p.scdn.co/mp3-preview/abc"
+
+        val info = TrackInfoMapper.toTrackInfo(track, requesterId = 7L)
+        assertEquals("https://p.scdn.co/mp3-preview/abc", info.previewUrl)
+    }
+
+    @Test
+    fun `previewUrl is null when ExtendedAudioTrack getter returns null`() {
+        // Edge: the track is an ExtendedAudioTrack but the source didn't
+        // publish a preview for this particular result (region-restricted,
+        // podcast, etc.). Same outcome as a non-LavaSrc track — no button.
+        val track = mockk<ExtendedAudioTrack>(relaxed = true)
+        every { track.info } returns AudioTrackInfo("T", "A", 1L, "id", false, "u")
+        every { track.duration } returns 1L
+        every { track.sourceManager } returns null
+        every { track.previewUrl } returns null
+
+        val info = TrackInfoMapper.toTrackInfo(track, null)
+        assertNull(info.previewUrl)
+    }
+
+    @Test
+    fun `swallows exceptions from ExtendedAudioTrack previewUrl getter`() {
+        // Defensive: if a future LavaSrc release throws inside getPreviewUrl
+        // (e.g. lazy network resolution), we don't want to bring down every
+        // track-info mapping. Fall through to null.
+        val track = mockk<ExtendedAudioTrack>(relaxed = true)
+        every { track.info } returns AudioTrackInfo("T", "A", 1L, "id", false, "u")
+        every { track.duration } returns 1L
+        every { track.sourceManager } returns null
+        every { track.previewUrl } throws RuntimeException("boom")
+
+        val info = TrackInfoMapper.toTrackInfo(track, null)
+        assertNull(info.previewUrl)
     }
 }

--- a/web/src/main/resources/static/css/music-player.css
+++ b/web/src/main/resources/static/css/music-player.css
@@ -346,6 +346,29 @@
 }
 .queue-remove:hover { color: #f25865; }
 
+/* Preview button — surfaces on search results AND queue items when the
+   source (Spotify / Apple Music / Deezer / Yandex) publishes a clip URL.
+   Distinct from .btn-transport so it can sit inline next to .btn-primary
+   (Queue) and .queue-remove (✕) without inheriting the larger transport
+   sizing. */
+.btn-preview {
+    background: rgba(88, 101, 242, 0.12);
+    color: var(--accent, #5865f2);
+    border: 1px solid rgba(88, 101, 242, 0.3);
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 0.95rem;
+    min-width: var(--tap-min);
+    min-height: var(--tap-min);
+    padding: 0 0.6rem;
+    touch-action: manipulation;
+}
+.btn-preview:hover { background: rgba(88, 101, 242, 0.2); }
+.btn-preview[aria-pressed="true"] {
+    background: var(--accent, #5865f2);
+    color: #fff;
+}
+
 /* Playlists */
 .playlist-list {
     list-style: none;

--- a/web/src/main/resources/static/js/music-player.js
+++ b/web/src/main/resources/static/js/music-player.js
@@ -199,10 +199,112 @@
         els.timeCurrent.textContent = formatMs(positionMs);
     }
 
+    // ---- Preview --------------------------------------------------------
+    // One shared <audio> drives every preview button (search results AND
+    // queue items). Clicking a button starts/resumes that track's preview;
+    // clicking it again pauses; clicking a different button stops the
+    // current preview and starts the new one. Reaching the end of the
+    // ~30s clip resets the button automatically. Button glyph always
+    // mirrors the audio element's state (`play` / `pause` / `ended` events).
+    const previewController = (() => {
+        const audio = document.getElementById('preview-audio');
+        let activeBtn = null;
+        let activeKey = null;
+
+        function setBtnPlaying(btn, playing) {
+            btn.textContent = playing ? '⏸' : '▶';
+            btn.setAttribute('aria-pressed', playing ? 'true' : 'false');
+            btn.setAttribute('aria-label', playing ? 'Pause preview' : 'Play preview');
+        }
+
+        function reset() {
+            // Stop the audio too — every caller of reset() wants playback
+            // halted (search results being wiped, the previewing track
+            // being removed from the queue, audio finishing / erroring).
+            if (audio && !audio.paused) audio.pause();
+            if (activeBtn) setBtnPlaying(activeBtn, false);
+            activeBtn = null;
+            activeKey = null;
+        }
+
+        if (audio) {
+            audio.addEventListener('play', () => { if (activeBtn) setBtnPlaying(activeBtn, true); });
+            audio.addEventListener('pause', () => { if (activeBtn) setBtnPlaying(activeBtn, false); });
+            audio.addEventListener('ended', reset);
+            audio.addEventListener('error', reset);
+        }
+
+        function trackKey(track) {
+            return track.uri || track.identifier;
+        }
+
+        function toggle(track, btn) {
+            if (!audio || !track || !track.previewUrl) return;
+            if (activeBtn === btn) {
+                if (audio.paused) audio.play().catch(reset);
+                else audio.pause();
+                return;
+            }
+            if (activeBtn) setBtnPlaying(activeBtn, false);
+            audio.src = track.previewUrl;
+            activeBtn = btn;
+            activeKey = trackKey(track);
+            setBtnPlaying(btn, true);
+            audio.play().catch(reset);
+        }
+
+        /**
+         * Called by renderQueue after an SSE queueChanged that removes
+         * tracks. If the currently-previewing track is no longer in the
+         * fresh queue, stop the audio and reset the (now-orphan) button.
+         * Search-results rerenders go through clearSearchResults which
+         * doesn't need this — the button list is wiped wholesale, and the
+         * audio element keeps its src until reused.
+         */
+        function clearIfRemoved(remainingKeys) {
+            if (!activeKey || !audio) return;
+            if (remainingKeys.indexOf(activeKey) === -1) {
+                audio.pause();
+                reset();
+            }
+        }
+
+        /**
+         * True iff the currently-active preview button is a descendant of
+         * [container]. Used by clearSearchResults to decide whether wiping
+         * the results panel should also stop the preview — wipes don't
+         * affect a queue-item preview that's playing.
+         */
+        function isActiveIn(container) {
+            return !!(activeBtn && container && container.contains(activeBtn));
+        }
+
+        return {
+            toggle: toggle,
+            clearIfRemoved: clearIfRemoved,
+            isActiveIn: isActiveIn,
+            reset: reset,
+        };
+    })();
+
+    function makePreviewBtn(track) {
+        if (!track || !track.previewUrl) return null;
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className = 'btn-preview';
+        btn.setAttribute('aria-label', 'Play preview');
+        btn.setAttribute('aria-pressed', 'false');
+        btn.title = 'Preview ~30s clip';
+        btn.textContent = '▶';
+        btn.addEventListener('click', () => previewController.toggle(track, btn));
+        return btn;
+    }
+
     function renderQueue(tracks) {
         els.queueList.innerHTML = '';
         if (!tracks || tracks.length === 0) {
             els.queueEmpty.hidden = false;
+            previewController.clearIfRemoved([]);
             return;
         }
         els.queueEmpty.hidden = true;
@@ -230,6 +332,9 @@
             meta.appendChild(authorEl);
             li.appendChild(meta);
 
+            const previewBtn = makePreviewBtn(track);
+            if (previewBtn) li.appendChild(previewBtn);
+
             const removeBtn = document.createElement('button');
             removeBtn.className = 'queue-remove';
             removeBtn.type = 'button';
@@ -248,6 +353,9 @@
         if (window.TobyMusicQueue && typeof window.TobyMusicQueue.attach === 'function') {
             window.TobyMusicQueue.attach(els.queueList, (from, to) => post('/queue/reorder', { from: from, to: to }));
         }
+
+        // After every queue re-render, drop the preview if its track is gone.
+        previewController.clearIfRemoved(tracks.map((t) => t.uri || t.identifier));
     }
 
     function renderPlaylists(playlists) {
@@ -397,6 +505,10 @@
     }
 
     function clearSearchResults() {
+        // If a preview is currently playing from a result row, stop it
+        // (otherwise the audio would keep playing against an orphaned button
+        // reference). Queue-item previews are left alone.
+        if (previewController.isActiveIn(els.searchList)) previewController.reset();
         els.searchSection.hidden = true;
         els.searchList.innerHTML = '';
         els.searchEmpty.hidden = true;
@@ -429,6 +541,9 @@
             meta.appendChild(title);
             meta.appendChild(author);
             li.appendChild(meta);
+
+            const previewBtn = makePreviewBtn(track);
+            if (previewBtn) li.appendChild(previewBtn);
 
             const queueBtn = document.createElement('button');
             queueBtn.type = 'button';

--- a/web/src/main/resources/templates/music-player.html
+++ b/web/src/main/resources/templates/music-player.html
@@ -104,6 +104,11 @@
 
 </main>
 
+<!-- Single shared audio element drives all preview buttons. Hidden because
+     we never want native controls — the buttons in the search-results / queue
+     lists drive playback, and only one preview can be active at a time. -->
+<audio id="preview-audio" preload="none" hidden></audio>
+
 <script src="/js/api.js" defer></script>
 <script src="/js/music-queue.js" defer></script>
 <script src="/js/music-player.js" defer></script>

--- a/web/src/test/js/music-preview.test.js
+++ b/web/src/test/js/music-preview.test.js
@@ -1,0 +1,402 @@
+// Tests for the in-browser preview controller — clicking ▶ next to a
+// search result or queue item plays the source's own ~30s clip via a
+// shared <audio> element. Spotify / Apple Music / Deezer / Yandex (all
+// surfaced via LavaSrc's ExtendedAudioTrack#getPreviewUrl) get a button;
+// YouTube / SoundCloud / Bandcamp / HTTP / Local don't.
+//
+// We boot the music-player.js IIFE against a hand-crafted DOM, stub
+// fetch + EventSource + HTMLMediaElement.play / .pause, then drive the
+// SSE / DOM events the production code listens to.
+
+class MockEventSource {
+    constructor(url) {
+        this.url = url;
+        this.handlers = {};
+        this.closed = false;
+        MockEventSource.instances.push(this);
+    }
+    addEventListener(name, handler) {
+        this.handlers[name] = handler;
+    }
+    close() { this.closed = true; }
+    fire(name, payload) {
+        const handler = this.handlers[name];
+        if (handler) handler({ data: JSON.stringify(payload) });
+    }
+}
+MockEventSource.instances = [];
+
+function flush() {
+    return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function setUpDashboardDom() {
+    document.head.innerHTML = '';
+    document.body.innerHTML = `
+        <div id="now-playing-empty"></div>
+        <div id="now-playing-content" hidden>
+            <img id="now-playing-art" />
+            <span id="source-badge"></span>
+            <h3 id="now-playing-title"></h3>
+            <p id="now-playing-author"></p>
+            <div id="now-playing-requester" hidden>
+                <span id="now-playing-requester-cell"></span>
+            </div>
+            <span id="time-current"></span>
+            <span id="time-total"></span>
+            <div id="progress-track"><div id="progress-fill"></div></div>
+        </div>
+        <button id="btn-pause">⏯️</button>
+        <button id="btn-skip">⏭️</button>
+        <button id="btn-stop">⏹️</button>
+        <button id="btn-loop" aria-pressed="false">🔁</button>
+        <input id="volume-slider" type="range" min="0" max="150" value="100" />
+        <span id="volume-value">100</span>
+        <form id="add-track-form"><input id="add-track-input" /><button>Search</button></form>
+        <section id="search-results-section" hidden>
+            <span id="search-results-query"></span>
+            <button id="search-results-close"></button>
+            <ol id="search-results-list"></ol>
+            <p id="search-results-empty" hidden></p>
+        </section>
+        <ol id="queue-list"></ol>
+        <p id="queue-empty"></p>
+        <ul id="playlist-list"></ul>
+        <p id="playlists-empty"></p>
+        <form id="save-playlist-form"><input id="save-playlist-name" /><button>Save</button></form>
+        <p id="voice-channel-name" hidden></p>
+        <p id="voice-channel-empty"></p>
+        <ul id="voice-member-list"></ul>
+        <audio id="preview-audio" preload="none" hidden></audio>
+    `;
+    document.body.dataset.musicPage = '1';
+    document.body.dataset.guildId = '42';
+    document.body.dataset.discordId = '100';
+}
+
+function track(overrides) {
+    return Object.assign({
+        identifier: 'abc',
+        title: 'Test Title',
+        author: 'Test Author',
+        durationMs: 200_000,
+        uri: 'https://example.com/track',
+        artworkUrl: null,
+        sourceName: 'spotify',
+        isStream: false,
+        requesterDiscordId: null,
+        previewUrl: 'https://p.scdn.co/mp3-preview/abc',
+    }, overrides);
+}
+
+function idleState() {
+    return {
+        guildId: 42,
+        nowPlaying: null,
+        positionMs: 0,
+        paused: false,
+        volume: 100,
+        looping: false,
+        queue: [],
+        voiceChannelId: null,
+        voiceChannel: null,
+    };
+}
+
+describe('music-player.js — preview controller', () => {
+    let fetchMock;
+    let visibilitySpy;
+    let playMock;
+    let pauseMock;
+    let originalPlay;
+    let originalPause;
+    // Track the current paused state ourselves — jsdom's HTMLMediaElement
+    // returns paused=true unconditionally, but the controller's toggle()
+    // branches on it, so the test mocks have to flip it to match the
+    // intended play/pause sequence.
+    let isPaused;
+
+    beforeEach(() => {
+        jest.resetModules();
+        MockEventSource.instances.length = 0;
+
+        setUpDashboardDom();
+        window.EventSource = MockEventSource;
+
+        fetchMock = jest.fn().mockImplementation((url) => {
+            if (typeof url === 'string' && url.endsWith('/state')) {
+                return Promise.resolve({
+                    ok: true,
+                    json: () => Promise.resolve({ state: idleState() }),
+                });
+            }
+            if (typeof url === 'string' && url.endsWith('/playlists')) {
+                return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+            }
+            return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+        });
+        window.fetch = fetchMock;
+
+        visibilitySpy = jest.spyOn(document, 'visibilityState', 'get');
+        visibilitySpy.mockReturnValue('visible');
+
+        // jsdom's <audio> doesn't actually play — stub play/pause so they
+        // (a) fire the corresponding events the production code listens to
+        // and (b) flip our isPaused mirror so audio.paused reflects reality
+        // when the controller branches on it.
+        originalPlay = HTMLMediaElement.prototype.play;
+        originalPause = HTMLMediaElement.prototype.pause;
+        isPaused = true;
+        playMock = jest.fn().mockImplementation(function () {
+            isPaused = false;
+            this.dispatchEvent(new Event('play'));
+            return Promise.resolve();
+        });
+        pauseMock = jest.fn().mockImplementation(function () {
+            isPaused = true;
+            this.dispatchEvent(new Event('pause'));
+        });
+        HTMLMediaElement.prototype.play = playMock;
+        HTMLMediaElement.prototype.pause = pauseMock;
+        Object.defineProperty(HTMLMediaElement.prototype, 'paused', {
+            configurable: true,
+            get: () => isPaused,
+        });
+
+        require('../../main/resources/static/js/music-player');
+    });
+
+    afterEach(() => {
+        visibilitySpy.mockRestore();
+        HTMLMediaElement.prototype.play = originalPlay;
+        HTMLMediaElement.prototype.pause = originalPause;
+        // Remove the paused override so it doesn't leak into the next file.
+        delete HTMLMediaElement.prototype.paused;
+    });
+
+    test('search result with previewUrl renders a Preview button', async () => {
+        await flush();
+        const es = MockEventSource.instances[0];
+
+        // Simulate a queueChanged so that the queue list re-renders (not
+        // strictly necessary for search but flushes the IIFE setup).
+        es.fire('queueChanged', { guildId: 42, queue: [] });
+        await flush();
+
+        // Drive the search by hand: call into renderSearchResults via the
+        // public submit flow. Stub /search to return our fixture.
+        fetchMock.mockImplementationOnce(() => Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve([track()]),
+        }));
+        document.getElementById('add-track-input').value = 'linkin park';
+        document.getElementById('add-track-form').dispatchEvent(new Event('submit', { cancelable: true }));
+        await flush();
+
+        const preview = document.querySelector('#search-results-list .btn-preview');
+        expect(preview).not.toBeNull();
+        expect(preview.textContent).toBe('▶');
+    });
+
+    test('search result without previewUrl renders no Preview button', async () => {
+        await flush();
+        fetchMock.mockImplementationOnce(() => Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve([track({ sourceName: 'youtube', previewUrl: null })]),
+        }));
+        document.getElementById('add-track-input').value = 'something youtube';
+        document.getElementById('add-track-form').dispatchEvent(new Event('submit', { cancelable: true }));
+        await flush();
+
+        expect(document.querySelector('#search-results-list .search-result')).not.toBeNull();
+        expect(document.querySelector('#search-results-list .btn-preview')).toBeNull();
+    });
+
+    test('queue item with previewUrl renders a Preview button', async () => {
+        await flush();
+        const es = MockEventSource.instances[0];
+        es.fire('queueChanged', { guildId: 42, queue: [track()] });
+        await flush();
+
+        const preview = document.querySelector('#queue-list .btn-preview');
+        expect(preview).not.toBeNull();
+    });
+
+    test('queue item without previewUrl renders no Preview button', async () => {
+        await flush();
+        const es = MockEventSource.instances[0];
+        es.fire('queueChanged', { guildId: 42, queue: [track({ sourceName: 'youtube', previewUrl: null })] });
+        await flush();
+
+        expect(document.querySelector('#queue-list .queue-item')).not.toBeNull();
+        expect(document.querySelector('#queue-list .btn-preview')).toBeNull();
+    });
+
+    test('clicking Preview plays the audio and swaps the button to ⏸', async () => {
+        await flush();
+        const es = MockEventSource.instances[0];
+        es.fire('queueChanged', { guildId: 42, queue: [track()] });
+        await flush();
+
+        const btn = document.querySelector('#queue-list .btn-preview');
+        btn.click();
+        await flush();
+
+        expect(playMock).toHaveBeenCalledTimes(1);
+        const audio = document.getElementById('preview-audio');
+        expect(audio.src).toBe('https://p.scdn.co/mp3-preview/abc');
+        expect(btn.textContent).toBe('⏸');
+        expect(btn.getAttribute('aria-pressed')).toBe('true');
+    });
+
+    test('clicking the active Preview button again pauses', async () => {
+        await flush();
+        const es = MockEventSource.instances[0];
+        es.fire('queueChanged', { guildId: 42, queue: [track()] });
+        await flush();
+
+        const btn = document.querySelector('#queue-list .btn-preview');
+        btn.click();
+        await flush();
+        btn.click();
+        await flush();
+
+        expect(pauseMock).toHaveBeenCalledTimes(1);
+        expect(btn.textContent).toBe('▶');
+        expect(btn.getAttribute('aria-pressed')).toBe('false');
+    });
+
+    test('clicking a different Preview button stops the first and starts the second', async () => {
+        await flush();
+        const es = MockEventSource.instances[0];
+        es.fire('queueChanged', {
+            guildId: 42,
+            queue: [
+                track({ identifier: 'a', uri: 'https://example.com/a', previewUrl: 'https://p.scdn.co/preview/a' }),
+                track({ identifier: 'b', uri: 'https://example.com/b', previewUrl: 'https://p.scdn.co/preview/b' }),
+            ],
+        });
+        await flush();
+
+        const btns = document.querySelectorAll('#queue-list .btn-preview');
+        expect(btns.length).toBe(2);
+
+        btns[0].click();
+        await flush();
+        expect(btns[0].textContent).toBe('⏸');
+        expect(btns[1].textContent).toBe('▶');
+
+        btns[1].click();
+        await flush();
+        // The first button reverted to ▶ (we stop-then-play on switch);
+        // the second is now active.
+        expect(btns[0].textContent).toBe('▶');
+        expect(btns[1].textContent).toBe('⏸');
+        const audio = document.getElementById('preview-audio');
+        expect(audio.src).toBe('https://p.scdn.co/preview/b');
+    });
+
+    test('SSE queueChanged that removes the previewing track resets the controller', async () => {
+        await flush();
+        const es = MockEventSource.instances[0];
+        es.fire('queueChanged', {
+            guildId: 42,
+            queue: [
+                track({ identifier: 'a', uri: 'https://example.com/a', previewUrl: 'https://p.scdn.co/preview/a' }),
+                track({ identifier: 'b', uri: 'https://example.com/b', previewUrl: 'https://p.scdn.co/preview/b' }),
+            ],
+        });
+        await flush();
+
+        const firstBtn = document.querySelectorAll('#queue-list .btn-preview')[0];
+        firstBtn.click();
+        await flush();
+        expect(firstBtn.textContent).toBe('⏸');
+
+        // Now the queue refreshes without track 'a' — the controller should
+        // pause and forget about it.
+        es.fire('queueChanged', {
+            guildId: 42,
+            queue: [track({ identifier: 'b', uri: 'https://example.com/b', previewUrl: 'https://p.scdn.co/preview/b' })],
+        });
+        await flush();
+
+        expect(pauseMock).toHaveBeenCalled();
+        // The only remaining button starts in the inactive state.
+        const remaining = document.querySelectorAll('#queue-list .btn-preview');
+        expect(remaining.length).toBe(1);
+        expect(remaining[0].textContent).toBe('▶');
+    });
+
+    test('clearing search results stops a search-row preview but not a queue-row preview', async () => {
+        await flush();
+        const es = MockEventSource.instances[0];
+
+        // Set up: one queue item + a search showing one result, both
+        // previewable.
+        es.fire('queueChanged', {
+            guildId: 42,
+            queue: [track({ identifier: 'q', uri: 'https://example.com/q', previewUrl: 'https://p.scdn.co/preview/q' })],
+        });
+        await flush();
+
+        fetchMock.mockImplementationOnce(() => Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve([track({ identifier: 's', uri: 'https://example.com/s', previewUrl: 'https://p.scdn.co/preview/s' })]),
+        }));
+        document.getElementById('add-track-input').value = 'linkin park';
+        document.getElementById('add-track-form').dispatchEvent(new Event('submit', { cancelable: true }));
+        await flush();
+
+        // Start a preview on the search row.
+        const searchBtn = document.querySelector('#search-results-list .btn-preview');
+        searchBtn.click();
+        await flush();
+        expect(searchBtn.textContent).toBe('⏸');
+        const pausesBefore = pauseMock.mock.calls.length;
+
+        // Clear results — should stop the audio since the active button is
+        // in the search list.
+        document.getElementById('search-results-close').click();
+        await flush();
+        expect(pauseMock.mock.calls.length).toBeGreaterThan(pausesBefore);
+
+        // Now flip the scenario: preview the queue row, then clear search.
+        // Re-run a search just to populate the search list (no auto-clear).
+        fetchMock.mockImplementationOnce(() => Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve([track({ identifier: 's2', uri: 'https://example.com/s2', previewUrl: 'https://p.scdn.co/preview/s2' })]),
+        }));
+        document.getElementById('add-track-input').value = 'metric';
+        document.getElementById('add-track-form').dispatchEvent(new Event('submit', { cancelable: true }));
+        await flush();
+
+        const queueBtn = document.querySelector('#queue-list .btn-preview');
+        queueBtn.click();
+        await flush();
+        const pausesBefore2 = pauseMock.mock.calls.length;
+
+        // Clearing search shouldn't touch the queue-row preview.
+        document.getElementById('search-results-close').click();
+        await flush();
+        expect(pauseMock.mock.calls.length).toBe(pausesBefore2);
+        expect(queueBtn.textContent).toBe('⏸');
+    });
+
+    test('audio "ended" event resets the active button', async () => {
+        await flush();
+        const es = MockEventSource.instances[0];
+        es.fire('queueChanged', { guildId: 42, queue: [track()] });
+        await flush();
+
+        const btn = document.querySelector('#queue-list .btn-preview');
+        btn.click();
+        await flush();
+        expect(btn.textContent).toBe('⏸');
+
+        document.getElementById('preview-audio').dispatchEvent(new Event('ended'));
+        await flush();
+        expect(btn.textContent).toBe('▶');
+        expect(btn.getAttribute('aria-pressed')).toBe('false');
+    });
+});


### PR DESCRIPTION
## Summary

The /music-player dashboard's search panel lists up to 10 results per query, but the only way to find out which "Linkin Park — Numb" is the right one is to queue it and let the bot play. Same gap on items already queued — title/author visible, no way to sanity-check before they reach the front.

This PR adds a small **▶ Preview** button next to each search result and each queue item that plays the source's own ~30s clip directly in the browser via a single shared `<audio>` element. LavaSrc's `ExtendedAudioTrack#getPreviewUrl()` surfaces a clip for **Spotify, Apple Music, Deezer, Yandex Music**; **YouTube / SoundCloud / Bandcamp / HTTP / Local** return null and the button is hidden entirely.

No bot-side audio proxying — the browser fetches the clip directly from the source's own CDN, so no DMCA tee, no Heroku CPU cost, no extra endpoints.

## UX notes

- `▶` toggles to `⏸` while playing; clicking again pauses, clicking the same button after pause resumes, clicking a *different* button switches tracks. Reaching the clip's end resets the button automatically.
- Single shared `<audio>` element — two previews can never bleed over each other.
- `aria-pressed` mirrors playing state for screen readers; tooltip explains "Preview ~30s clip".
- An SSE `queueChanged` that removes the currently-previewing track stops the audio and resets the controller.
- Clearing search results stops a search-row preview but leaves a queue-row preview untouched.

## Architecture

- `TrackInfo.previewUrl: String? = null` added to `core.music.MusicControlGateway` (same default-null pattern used for `requesterDisplayName` / `requesterAvatarUrl`). No schema migration.
- `TrackInfoMapper.toTrackInfo(...)` extracts via `(track as? ExtendedAudioTrack)?.previewUrl` — runCatching-wrapped so a future LavaSrc release throwing inside the getter can't bring down the whole map.
- Frontend `previewController` IIFE encapsulates the single audio element, the active button reference, and the play/pause/end/error event wiring.

## Test plan
- [x] `./gradlew :discord-bot:test` — `TrackInfoMapperTest` covers four new cases: non-LavaSrc → null, ExtendedAudioTrack happy path, ExtendedAudioTrack null preview, getter throws → null.
- [x] `cd web && npm test` — new `music-preview.test.js` covers 10 cases (search + queue rendering with/without `previewUrl`, play / pause / switch / end / removed-track / clear-search isolation). All 509 Jest tests pass.
- [ ] Manual smoke (requires `SPOTIFY_CLIENT_ID` / `SPOTIFY_CLIENT_SECRET` in env):
  - Open `/music-player/{guildId}`.
  - Search `linkin park numb` — Spotify hits show ▶ Preview; YouTube hits don't.
  - Click ▶ on result 1 → plays, glyph becomes ⏸.
  - Click ▶ on result 3 → result 1 stops, result 3 plays.
  - Click ⏸ on the active button → pauses.
  - Let one play out → button resets to ▶ automatically.
  - Queue a Spotify track → it appears in queue with its own ▶ button.
  - Queue a YouTube track → it appears in queue with **no** ▶ button.

## Out of scope

- Streaming the bot's actual voice-channel audio to the browser (the "listen along" feature) — covered in scoping but carries DMCA exposure and Heroku CPU concerns. Tracked separately.
- Previewing tracks *inside* saved playlists — the playlists card shows only `{ name, trackCount }` today; expanding it to per-track UI is a separate change.

https://claude.ai/code/session_01C63QtxhcHtqWwWWiB1iJNF

---
_Generated by [Claude Code](https://claude.ai/code/session_01C63QtxhcHtqWwWWiB1iJNF)_