### PR TITLE
feat(music): resume preempted audio after intro plays

### DIFF
--- a/discord-bot/src/main/kotlin/bot/toby/helpers/MusicPlayerHelper.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/helpers/MusicPlayerHelper.kt
@@ -50,8 +50,8 @@ object MusicPlayerHelper {
                 val clipStart = it.startMs?.toLong() ?: startPosition
                 val clipEnd = it.endMs?.toLong()
                 logger.info { "Url to play is: '$url' (clip ${clipStart}ms -> ${clipEnd ?: "end"})" }
-                instance.loadAndPlay(
-                    guild, event, url, true, deleteDelay, clipStart,
+                instance.loadAndPlayIntro(
+                    guild, event, url, deleteDelay, clipStart,
                     introVolume ?: currentVolume, clipEnd
                 )
             }

--- a/discord-bot/src/main/kotlin/bot/toby/lavaplayer/PlayerManager.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/lavaplayer/PlayerManager.kt
@@ -169,7 +169,7 @@ class PlayerManager(private val audioPlayerManager: AudioPlayerManager) {
         audioPlayerManager.loadItemOrdered(
             musicManager,
             trackUrl,
-            getResultHandler(event, musicManager, trackUrl, startPosition, endPosition, volume, deleteDelay)
+            getResultHandler(event, musicManager, trackUrl, startPosition, endPosition, volume, deleteDelay, isIntro = false)
         )
     }
 
@@ -186,6 +186,29 @@ class PlayerManager(private val audioPlayerManager: AudioPlayerManager) {
         volume: Int
     ) = loadAndPlay(guild, event, trackUrl, isSkippable, deleteDelay, startPosition, volume, null)
 
+    /**
+     * Load an intro track and preempt whatever is currently playing. The
+     * preempted track is restored automatically once the intro ends.
+     */
+    @Synchronized
+    fun loadAndPlayIntro(
+        guild: Guild,
+        event: SlashCommandInteractionEvent?,
+        trackUrl: String,
+        deleteDelay: Int,
+        startPosition: Long,
+        volume: Int,
+        endPosition: Long?,
+    ) {
+        val musicManager = this.getMusicManager(guild)
+        this.isCurrentlyStoppable = true
+        audioPlayerManager.loadItemOrdered(
+            musicManager,
+            trackUrl,
+            getResultHandler(event, musicManager, trackUrl, startPosition, endPosition, volume, deleteDelay, isIntro = true)
+        )
+    }
+
     private fun getResultHandler(
         event: SlashCommandInteractionEvent?,
         musicManager: GuildMusicManager,
@@ -193,7 +216,8 @@ class PlayerManager(private val audioPlayerManager: AudioPlayerManager) {
         startPosition: Long,
         endPosition: Long?,
         volume: Int,
-        deleteDelay: Int
+        deleteDelay: Int,
+        isIntro: Boolean = false,
     ): AudioLoadResultHandler {
         return object : AudioLoadResultHandler {
             private val scheduler: TrackScheduler = musicManager.scheduler
@@ -202,7 +226,11 @@ class PlayerManager(private val audioPlayerManager: AudioPlayerManager) {
             override fun trackLoaded(track: AudioTrack) {
                 scheduler.event = event
                 scheduler.deleteDelay = deleteDelay
-                scheduler.queue(track, startPosition, endPosition, volume, requesterId)
+                if (isIntro) {
+                    scheduler.queueIntro(track, startPosition, endPosition, volume, requesterId)
+                } else {
+                    scheduler.queue(track, startPosition, endPosition, volume, requesterId)
+                }
                 scheduler.setPreviousVolume(previousVolume)
             }
 

--- a/discord-bot/src/main/kotlin/bot/toby/lavaplayer/TrackScheduler.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/lavaplayer/TrackScheduler.kt
@@ -30,8 +30,14 @@ class TrackScheduler(val player: AudioPlayer, val guildId: Long, var deleteDelay
     private val logger: DiscordLogger = DiscordLogger.createLogger(this::class.java)
     private val trackClipBounds = ConcurrentHashMap<AudioTrack, Pair<Long, Long>>()
     private val trackRequesters = ConcurrentHashMap<AudioTrack, Long>()
+    private val introTracks: MutableSet<AudioTrack> = ConcurrentHashMap.newKeySet()
+    private var resumeAfterIntro: AudioTrack? = null
 
     fun getRequesterId(track: AudioTrack): Long? = trackRequesters[track]
+
+    internal fun hasResumeAfterIntro(): Boolean = resumeAfterIntro != null
+
+    internal fun isIntroTrack(track: AudioTrack): Boolean = introTracks.contains(track)
 
     fun queue(track: AudioTrack, startPosition: Long, endPosition: Long?, volume: Int, requesterId: Long? = null) {
         logger.info("Adding ${track.info.title} by ${track.info.author} to the queue for guild $guildId")
@@ -40,6 +46,65 @@ class TrackScheduler(val player: AudioPlayer, val guildId: Long, var deleteDelay
             "Adding to queue: `${track.info.title}` by `${track.info.author}` starting at '${startPosition} ms'$endNote with volume '$volume'",
             deleteDelay,
         )
+        prepareTrack(track, startPosition, endPosition, volume, requesterId)
+        synchronized(queue) {
+            if (!player.startTrack(track, true)) {
+                queue.offer(track)
+            }
+        }
+        publishQueueChanged()
+    }
+
+    /**
+     * Play an intro track immediately, preempting whatever is currently playing.
+     * The preempted track is cloned (with its live position) and stored so it
+     * resumes after the intro finishes. If nothing is playing, falls back to the
+     * regular queue path. If an intro is already in flight (resume slot already
+     * occupied), this intro is queued normally rather than overwriting the slot.
+     */
+    fun queueIntro(
+        introTrack: AudioTrack,
+        startPosition: Long,
+        endPosition: Long?,
+        volume: Int,
+        requesterId: Long? = null,
+    ) {
+        logger.info("Preparing intro ${introTrack.info.title} for guild $guildId")
+        prepareTrack(introTrack, startPosition, endPosition, volume, requesterId)
+        val currentlyPlaying = player.playingTrack
+        if (currentlyPlaying == null || resumeAfterIntro != null) {
+            // No track to preempt, or a resume slot is already occupied by an
+            // earlier intro — fall back to the standard queue-or-start path so
+            // we don't clobber the original music with a second intro.
+            synchronized(queue) {
+                if (!player.startTrack(introTrack, true)) {
+                    queue.offer(introTrack)
+                }
+            }
+            introTracks.add(introTrack)
+            publishQueueChanged()
+            return
+        }
+        // Snapshot the currently-playing track into a resume slot before the
+        // intro replaces it.
+        val clone = currentlyPlaying.makeClone()
+        clone.position = currentlyPlaying.position
+        clone.userData = currentlyPlaying.userData
+        trackClipBounds[currentlyPlaying]?.let { trackClipBounds[clone] = it }
+        trackRequesters[currentlyPlaying]?.let { trackRequesters[clone] = it }
+        resumeAfterIntro = clone
+        introTracks.add(introTrack)
+        player.startTrack(introTrack, false)
+        publishQueueChanged()
+    }
+
+    private fun prepareTrack(
+        track: AudioTrack,
+        startPosition: Long,
+        endPosition: Long?,
+        volume: Int,
+        requesterId: Long?,
+    ) {
         track.position = startPosition
         track.userData = volume
         requesterId?.let { trackRequesters[track] = it }
@@ -55,12 +120,6 @@ class TrackScheduler(val player: AudioPlayer, val guildId: Long, var deleteDelay
                 }
             })
         }
-        synchronized(queue) {
-            if (!player.startTrack(track, true)) {
-                queue.offer(track)
-            }
-        }
-        publishQueueChanged()
     }
 
     // Back-compat overload for the pre-clip call sites; currently unused but keeps
@@ -104,10 +163,22 @@ class TrackScheduler(val player: AudioPlayer, val guildId: Long, var deleteDelay
     override fun onTrackEnd(player: AudioPlayer, track: AudioTrack, endReason: AudioTrackEndReason) {
         trackClipBounds.remove(track)
         trackRequesters.remove(track)
+        val wasIntro = introTracks.remove(track)
         event?.guild?.idLong.resetMessagesForGuildId()
         logger.info("${track.info.title} by ${track.info.author} ended")
         SchedulerEvents.publish(TrackEndedEvent(guildId, endReason.name))
         if (endReason.mayStartNext) {
+            // An intro just finished and we have a preempted track waiting:
+            // restart that, do NOT advance the regular queue (so user-queued
+            // tracks added during the intro stay queued behind the resumed one).
+            if (wasIntro && resumeAfterIntro != null) {
+                val resume = resumeAfterIntro!!
+                resumeAfterIntro = null
+                player.setVolumeToPrevious()
+                logger.info("Resuming preempted track ${resume.info.title} at ${resume.position} ms")
+                player.startTrack(resume, false)
+                return
+            }
             handleNextTrack(player, track)
         }
     }
@@ -196,6 +267,10 @@ class TrackScheduler(val player: AudioPlayer, val guildId: Long, var deleteDelay
 
     fun stopTrack(isStoppable: Boolean): Boolean {
         if (!isStoppable) return false
+        // A user-initiated stop should not auto-resume a preempted track when
+        // the in-flight intro ends.
+        resumeAfterIntro = null
+        introTracks.clear()
         player.stopTrack()
         player.setVolumeToPrevious()
         return true

--- a/discord-bot/src/main/kotlin/bot/toby/lavaplayer/TrackScheduler.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/lavaplayer/TrackScheduler.kt
@@ -167,18 +167,27 @@ class TrackScheduler(val player: AudioPlayer, val guildId: Long, var deleteDelay
         event?.guild?.idLong.resetMessagesForGuildId()
         logger.info("${track.info.title} by ${track.info.author} ended")
         SchedulerEvents.publish(TrackEndedEvent(guildId, endReason.name))
+        // An intro just finished and we have a preempted track waiting: restart
+        // it (do NOT advance the regular queue so user-queued tracks added during
+        // the intro stay queued behind the resumed one). We bypass mayStartNext
+        // because clip-end markers stop the intro with STOPPED (mayStartNext is
+        // false), but we still want to resume the music that was playing before.
+        // REPLACED and CLEANUP are excluded: REPLACED means something else
+        // already took over the player; CLEANUP means the player is being
+        // destroyed (e.g. the bot is leaving the guild).
+        val shouldResumeAfterIntro = wasIntro
+                && resumeAfterIntro != null
+                && endReason != AudioTrackEndReason.REPLACED
+                && endReason != AudioTrackEndReason.CLEANUP
+        if (shouldResumeAfterIntro) {
+            val resume = resumeAfterIntro!!
+            resumeAfterIntro = null
+            player.setVolumeToPrevious()
+            logger.info("Resuming preempted track ${resume.info.title} at ${resume.position} ms")
+            player.startTrack(resume, false)
+            return
+        }
         if (endReason.mayStartNext) {
-            // An intro just finished and we have a preempted track waiting:
-            // restart that, do NOT advance the regular queue (so user-queued
-            // tracks added during the intro stay queued behind the resumed one).
-            if (wasIntro && resumeAfterIntro != null) {
-                val resume = resumeAfterIntro!!
-                resumeAfterIntro = null
-                player.setVolumeToPrevious()
-                logger.info("Resuming preempted track ${resume.info.title} at ${resume.position} ms")
-                player.startTrack(resume, false)
-                return
-            }
             handleNextTrack(player, track)
         }
     }

--- a/discord-bot/src/test/kotlin/bot/toby/handler/VoiceEventHandlerTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/handler/VoiceEventHandlerTest.kt
@@ -554,6 +554,70 @@ class VoiceEventHandlerTest {
     }
 
     @Test
+    fun `member join routes intro through loadAndPlayIntro (not loadAndPlay)`() {
+        val guild = mockk<Guild>(relaxed = true)
+        val event = mockk<GuildVoiceUpdateEvent>(relaxed = true)
+        val audioManager = mockk<AudioManager>(relaxed = true)
+        val member = mockk<Member>(relaxed = true)
+        val channel = mockk<AudioChannelUnion>(relaxed = true)
+        val audioPlayerManager = mockk<PlayerManager>(relaxed = true)
+
+        every { event.guild } returns guild
+        every { event.jda.selfUser } returns selfUser
+        every { guild.audioManager } returns audioManager
+        every { event.member } returns member
+        every { event.channelJoined } returns channel
+        every { event.channelLeft } returns null
+        every { channel.members } returns listOf(member)
+        every { member.user.isBot } returns false
+        every { member.guild } returns guild
+        every { member.isOwner } returns false
+        every { member.idLong } returns 1L
+        every { member.user.idLong } returns 1L
+        every { guild.idLong } returns 9L
+        every { guild.id } returns "9"
+        every { audioManager.isConnected } returns false
+        every { audioManager.connectedChannel } returns channel
+
+        mockkObject(PlayerManager)
+        every { PlayerManager.instance } returns audioPlayerManager
+
+        every { configService.getConfigByName(ConfigDto.Configurations.DELETE_DELAY.configValue, "9") } returns
+            ConfigDto().apply { value = "30" }
+        every { configService.getConfigByName(ConfigDto.Configurations.VOLUME.configValue, "9") } returns null
+
+        val musicDto = mockk<MusicDto>(relaxed = true) {
+            every { fileName } returns "https://example.com/intro.mp3"
+            every { musicBlob } returns null
+            every { introVolume } returns 75
+            every { startMs } returns null
+            every { endMs } returns null
+        }
+        every { userDtoHelper.calculateUserDto(1L, 9L, false) } returns mockk(relaxed = true) {
+            every { discordId } returns 1L
+            every { guildId } returns 9L
+            every { musicDtos } returns mutableListOf(musicDto)
+        }
+
+        handler.onGuildVoiceUpdate(event)
+
+        verify(atLeast = 1) {
+            audioPlayerManager.loadAndPlayIntro(
+                guild, null, "https://example.com/intro.mp3", 30, 0L, 75, null,
+            )
+        }
+        // Intros must never go through the regular loadAndPlay path now.
+        verify(exactly = 0) {
+            audioPlayerManager.loadAndPlay(any(), any(), any(), any(), any(), any(), any())
+        }
+        verify(exactly = 0) {
+            audioPlayerManager.loadAndPlay(any(), any(), any(), any(), any(), any(), any(), any())
+        }
+
+        unmockkObject(PlayerManager)
+    }
+
+    @Test
     fun `no intro award when user has no musicDto`() {
         val guild = mockk<Guild>(relaxed = true)
         val event = mockk<GuildVoiceUpdateEvent>(relaxed = true)

--- a/discord-bot/src/test/kotlin/bot/toby/helpers/MusicPlayerHelperTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/helpers/MusicPlayerHelperTest.kt
@@ -5,6 +5,8 @@ import bot.toby.lavaplayer.TrackScheduler
 import com.sedmelluq.discord.lavaplayer.player.AudioPlayer
 import com.sedmelluq.discord.lavaplayer.track.AudioTrack
 import com.sedmelluq.discord.lavaplayer.track.AudioTrackInfo
+import database.dto.MusicDto
+import database.dto.UserDto
 import io.mockk.*
 import io.mockk.impl.annotations.MockK
 import net.dv8tion.jda.api.entities.Guild
@@ -178,6 +180,109 @@ class MusicPlayerHelperTest {
                 it.title == "Title" && it.description?.contains("Author") == true
             })
             messageEditAction.setComponents(any<ActionRow>()).queue()
+        }
+    }
+
+    @Test
+    fun `playUserIntro routes through loadAndPlayIntro (not loadAndPlay) when user has musicDto`() {
+        mockkObject(PlayerManager.Companion)
+        try {
+            every { PlayerManager.instance } returns playerManager
+            every { audioPlayer.volume } returns 50
+
+            val musicDto = MusicDto().apply {
+                fileName = "https://example.com/intro.mp3"
+                introVolume = 88
+                startMs = 0
+                endMs = 2500
+            }
+            val userDto = mockk<UserDto>(relaxed = true) {
+                every { musicDtos } returns mutableListOf(musicDto)
+            }
+
+            every {
+                playerManager.loadAndPlayIntro(
+                    guildMock, null, "https://example.com/intro.mp3", 5,
+                    0L, 88, 2500L,
+                )
+            } just Runs
+            every { playerManager.setPreviousVolume(50) } just Runs
+
+            MusicPlayerHelper.playUserIntro(userDto, guildMock, null, 5)
+
+            verify(exactly = 1) {
+                playerManager.loadAndPlayIntro(
+                    guildMock, null, "https://example.com/intro.mp3", 5,
+                    0L, 88, 2500L,
+                )
+            }
+            // Crucially: the old code path must NOT be used for intros.
+            verify(exactly = 0) {
+                playerManager.loadAndPlay(any(), any(), any(), any(), any(), any(), any(), any())
+            }
+            verify(exactly = 1) { playerManager.setPreviousVolume(50) }
+        } finally {
+            unmockkObject(PlayerManager.Companion)
+        }
+    }
+
+    @Test
+    fun `playUserIntro falls back to currentVolume when musicDto introVolume is null`() {
+        mockkObject(PlayerManager.Companion)
+        try {
+            every { PlayerManager.instance } returns playerManager
+            every { audioPlayer.volume } returns 42
+
+            val musicDto = MusicDto().apply {
+                fileName = "https://example.com/intro.mp3"
+                introVolume = null
+            }
+            val userDto = mockk<UserDto>(relaxed = true) {
+                every { musicDtos } returns mutableListOf(musicDto)
+            }
+
+            every {
+                playerManager.loadAndPlayIntro(
+                    guildMock, null, "https://example.com/intro.mp3", 5,
+                    0L, 42, null,
+                )
+            } just Runs
+            every { playerManager.setPreviousVolume(42) } just Runs
+
+            MusicPlayerHelper.playUserIntro(userDto, guildMock, null, 5)
+
+            verify(exactly = 1) {
+                playerManager.loadAndPlayIntro(
+                    guildMock, null, "https://example.com/intro.mp3", 5,
+                    0L, 42, null,
+                )
+            }
+        } finally {
+            unmockkObject(PlayerManager.Companion)
+        }
+    }
+
+    @Test
+    fun `playUserIntro does nothing when user has no musicDto`() {
+        mockkObject(PlayerManager.Companion)
+        try {
+            every { PlayerManager.instance } returns playerManager
+            every { audioPlayer.volume } returns 50
+
+            val userDto = mockk<UserDto>(relaxed = true) {
+                every { musicDtos } returns mutableListOf()
+            }
+
+            MusicPlayerHelper.playUserIntro(userDto, guildMock, null, 5)
+
+            verify(exactly = 0) {
+                playerManager.loadAndPlayIntro(any(), any(), any(), any(), any(), any(), any())
+            }
+            verify(exactly = 0) {
+                playerManager.loadAndPlay(any(), any(), any(), any(), any(), any(), any(), any())
+            }
+        } finally {
+            unmockkObject(PlayerManager.Companion)
         }
     }
 

--- a/discord-bot/src/test/kotlin/bot/toby/lavaplayer/TrackSchedulerTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/lavaplayer/TrackSchedulerTest.kt
@@ -408,6 +408,23 @@ class TrackSchedulerTest {
     }
 
     @Test
+    fun `onTrackEnd does not resume preempted track when intro ends via REPLACED`() {
+        val current = mockTrack("Current")
+        val clone = mockTrack("Clone")
+        every { current.position } returns 4000L
+        every { current.userData } returns 50
+        every { current.makeClone() } returns clone
+        val intro = mockTrack("Intro")
+        every { player.playingTrack } returns current
+
+        scheduler.queueIntro(intro, 0L, null, 60)
+        // Simulate: something else took over the player (e.g. /play during intro).
+        scheduler.onTrackEnd(player, intro, AudioTrackEndReason.REPLACED)
+
+        verify(exactly = 0) { player.startTrack(clone, false) }
+    }
+
+    @Test
     fun `onTrackEnd does not resume when ended track is not an intro`() {
         val current = mockTrack("Current")
         val clone = mockTrack("Clone")

--- a/discord-bot/src/test/kotlin/bot/toby/lavaplayer/TrackSchedulerTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/lavaplayer/TrackSchedulerTest.kt
@@ -304,6 +304,205 @@ class TrackSchedulerTest {
     }
 
     @Test
+    fun `queueIntro starts intro immediately when nothing is playing`() {
+        val intro = mockTrack("Intro")
+        every { player.playingTrack } returns null
+        every { player.startTrack(intro, true) } returns true
+
+        scheduler.queueIntro(intro, 0L, null, 60)
+
+        verify(exactly = 1) { player.startTrack(intro, true) }
+        verify(exactly = 0) { player.startTrack(intro, false) }
+        assertFalse(scheduler.hasResumeAfterIntro())
+        assertTrue(scheduler.isIntroTrack(intro))
+    }
+
+    @Test
+    fun `queueIntro preempts current track and stores clone in resume slot`() {
+        val current = mockTrack("Current", volume = 40)
+        val clone = mockTrack("Current clone", volume = 40)
+        every { current.position } returns 12345L
+        every { current.userData } returns 40
+        every { current.makeClone() } returns clone
+        val intro = mockTrack("Intro")
+        every { player.playingTrack } returns current
+
+        scheduler.queueIntro(intro, 0L, null, 60)
+
+        verify(exactly = 1) { current.makeClone() }
+        verify(exactly = 1) { clone.position = 12345L }
+        verify(exactly = 1) { player.startTrack(intro, false) }
+        assertTrue(scheduler.hasResumeAfterIntro())
+        assertTrue(scheduler.isIntroTrack(intro))
+    }
+
+    @Test
+    fun `queueIntro copies volume from preempted track onto the clone`() {
+        val current = mockTrack("Current", volume = 33)
+        val clone = mockTrack("Clone")
+        every { current.position } returns 0L
+        every { current.userData } returns 33
+        every { current.makeClone() } returns clone
+        val intro = mockTrack("Intro")
+        every { player.playingTrack } returns current
+
+        scheduler.queueIntro(intro, 0L, null, 60)
+
+        verify { clone.userData = 33 }
+    }
+
+    @Test
+    fun `queueIntro preserves clip bounds and requester id of preempted track`() {
+        val current = mockTrack("Current")
+        val clone = mockTrack("Clone")
+        every { current.position } returns 500L
+        every { current.userData } returns 50
+        every { current.makeClone() } returns clone
+        every { player.startTrack(current, true) } returns true
+        scheduler.queue(current, 100L, 9000L, 50, requesterId = 777L)
+
+        val intro = mockTrack("Intro")
+        every { player.playingTrack } returns current
+        scheduler.queueIntro(intro, 0L, null, 60)
+
+        assertEquals(777L, scheduler.getRequesterId(clone))
+    }
+
+    @Test
+    fun `onTrackEnd resumes preempted track when intro ends and does not advance queue`() {
+        val current = mockTrack("Current")
+        val clone = mockTrack("Clone")
+        every { current.position } returns 4000L
+        every { current.userData } returns 50
+        every { current.makeClone() } returns clone
+        val intro = mockTrack("Intro")
+        every { player.playingTrack } returns current
+        // Pre-existing user-queued track that should NOT be advanced when the intro ends.
+        val queued = mockTrack("Queued")
+        scheduler.queue.offer(queued)
+
+        scheduler.queueIntro(intro, 0L, null, 60)
+        scheduler.onTrackEnd(player, intro, AudioTrackEndReason.FINISHED)
+
+        verify(exactly = 1) { player.startTrack(clone, false) }
+        // The queued track must remain queued — intro-resume takes priority.
+        verify(exactly = 0) { player.startTrack(queued, false) }
+        assertEquals(1, scheduler.queue.size)
+        assertFalse(scheduler.hasResumeAfterIntro())
+    }
+
+    @Test
+    fun `onTrackEnd resumes preempted track when intro ends via STOPPED (clip marker)`() {
+        val current = mockTrack("Current")
+        val clone = mockTrack("Clone")
+        every { current.position } returns 4000L
+        every { current.userData } returns 50
+        every { current.makeClone() } returns clone
+        val intro = mockTrack("Intro")
+        every { player.playingTrack } returns current
+
+        scheduler.queueIntro(intro, 0L, null, 60)
+        scheduler.onTrackEnd(player, intro, AudioTrackEndReason.STOPPED)
+
+        verify(exactly = 1) { player.startTrack(clone, false) }
+    }
+
+    @Test
+    fun `onTrackEnd does not resume when ended track is not an intro`() {
+        val current = mockTrack("Current")
+        val clone = mockTrack("Clone")
+        every { current.position } returns 1000L
+        every { current.userData } returns 50
+        every { current.makeClone() } returns clone
+        val intro = mockTrack("Intro")
+        every { player.playingTrack } returns current
+        scheduler.queueIntro(intro, 0L, null, 60)
+        // Pretend an unrelated track ends — the resume slot must stay intact.
+        val unrelated = mockTrack("Unrelated")
+
+        scheduler.onTrackEnd(player, unrelated, AudioTrackEndReason.FINISHED)
+
+        verify(exactly = 0) { player.startTrack(clone, false) }
+        assertTrue(scheduler.hasResumeAfterIntro())
+    }
+
+    @Test
+    fun `queueIntro does not overwrite resume slot when one is already occupied`() {
+        val current = mockTrack("Current")
+        val firstClone = mockTrack("First clone")
+        every { current.position } returns 1000L
+        every { current.userData } returns 50
+        every { current.makeClone() } returns firstClone
+
+        val intro1 = mockTrack("Intro 1")
+        every { player.playingTrack } returns current
+        scheduler.queueIntro(intro1, 0L, null, 60)
+        assertTrue(scheduler.hasResumeAfterIntro())
+
+        // Now another member joins; intro2 fires while intro1 is "playing".
+        val intro2 = mockTrack("Intro 2")
+        val secondClone = mockTrack("Second clone")
+        every { intro1.makeClone() } returns secondClone
+        every { player.playingTrack } returns intro1
+        every { player.startTrack(intro2, true) } returns false
+
+        scheduler.queueIntro(intro2, 0L, null, 60)
+
+        // intro1's clone must still be the one in the resume slot.
+        verify(exactly = 0) { intro1.makeClone() }
+        // intro2 should be queued (not preempt).
+        verify(exactly = 0) { player.startTrack(intro2, false) }
+        verify(exactly = 1) { player.startTrack(intro2, true) }
+        assertTrue(scheduler.queue.contains(intro2))
+        // Resuming the intro1 → preempted track still resumes firstClone, not secondClone.
+        scheduler.onTrackEnd(player, intro1, AudioTrackEndReason.FINISHED)
+        verify(exactly = 1) { player.startTrack(firstClone, false) }
+        verify(exactly = 0) { player.startTrack(secondClone, false) }
+    }
+
+    @Test
+    fun `stopTrack clears resume slot so subsequent intro end does not auto-resume`() {
+        val current = mockTrack("Current")
+        val clone = mockTrack("Clone")
+        every { current.position } returns 1000L
+        every { current.userData } returns 50
+        every { current.makeClone() } returns clone
+        val intro = mockTrack("Intro")
+        every { player.playingTrack } returns current
+
+        scheduler.queueIntro(intro, 0L, null, 60)
+        assertTrue(scheduler.hasResumeAfterIntro())
+
+        scheduler.stopTrack(true)
+        assertFalse(scheduler.hasResumeAfterIntro())
+
+        // Simulate the intro ending after stop — must NOT resume the clone.
+        scheduler.onTrackEnd(player, intro, AudioTrackEndReason.STOPPED)
+        verify(exactly = 0) { player.startTrack(clone, false) }
+    }
+
+    @Test
+    fun `intro-resume runs before loop branch — looping intro does not repeat`() {
+        scheduler.isLooping = true
+        val current = mockTrack("Current")
+        val clone = mockTrack("Clone")
+        every { current.position } returns 2000L
+        every { current.userData } returns 50
+        every { current.makeClone() } returns clone
+        val intro = mockTrack("Intro")
+        val introClone = mockTrack("Intro clone")
+        every { intro.makeClone() } returns introClone
+        every { player.playingTrack } returns current
+
+        scheduler.queueIntro(intro, 0L, null, 60)
+        scheduler.onTrackEnd(player, intro, AudioTrackEndReason.FINISHED)
+
+        verify(exactly = 1) { player.startTrack(clone, false) }
+        // The intro must NOT be re-cloned-and-restarted by the loop branch.
+        verify(exactly = 0) { player.startTrack(introClone, false) }
+    }
+
+    @Test
     fun `SchedulerEvents publisher being null does not crash event-emitting paths`() {
         // Ensure publisher is null (default in tests).
         SchedulerEvents.publisher = null


### PR DESCRIPTION
## Summary

Today, when a member joins voice while the bot is already playing audio, their intro is enqueued **behind** the currently-playing track and only plays after that track finishes — defeating the point of an intro.

This PR makes the intro preempt the currently-playing audio and resume it (from the same position) once the intro finishes.

## How

- `TrackScheduler` gains a `queueIntro(...)` path that:
  1. Captures the currently-playing track via `makeClone()` + its live `position`, plus userData/clip bounds/requester, into a resume slot.
  2. Starts the intro with `noInterrupt = false`, preempting the current track (which stops with `REPLACED` — `mayStartNext = false`, so the regular queue is **not** advanced).
  3. In `onTrackEnd`, if the ended track was an intro and a resume slot is set, restarts the cloned track and returns early — bypassing both `handleNextTrack` and the loop branch.
- `PlayerManager` gains a `loadAndPlayIntro(...)` entry point that routes through `queueIntro`.
- `MusicPlayerHelper.playUserIntro` switches from `loadAndPlay` to `loadAndPlayIntro`.

Edge cases handled:
- **Nothing currently playing** — falls back to the regular queue path; no resume slot created.
- **`/stop` during the intro** — `stopTrack` clears the resume slot and intro set, so the previous track does not zombie-resume.
- **Multiple members joining back-to-back** — if a resume slot is already occupied (first intro still in flight), subsequent intros are queued normally rather than clobbering the original music with a second intro's clone.
- **`isLooping = true`** during an intro — the new intro-resume branch runs **before** the loop branch in `onTrackEnd`, so a finished intro does not loop forever.

## Tests

- `TrackSchedulerTest`: 10 new tests — covers immediate-start, preempt-and-clone, volume/clip-bounds/requester carryover, resume on `FINISHED`/`STOPPED`, non-intro end leaves slot alone, no-overwrite when slot occupied, `stopTrack` clears slot, intro-resume beats loop branch.
- `MusicPlayerHelperTest`: 3 new tests — verifies `playUserIntro` routes through `loadAndPlayIntro` (not `loadAndPlay`), with and without `introVolume`, and that an empty `musicDtos` short-circuits.
- `VoiceEventHandlerTest`: 1 new test — end-to-end check that a member join with a configured intro invokes `loadAndPlayIntro` (and never `loadAndPlay`).

## Test plan

- [ ] CI: `./gradlew :discord-bot:test` (couldn't run locally — sandbox can't reach external Maven repos for LavaSrc/libdave).
- [ ] Manual smoke test:
  - [ ] Bot in voice, `/play <url>` a song.
  - [ ] Have a member with an intro configured leave and rejoin → the song should audibly pause, the intro plays, then the song resumes near where it stopped.
  - [ ] Repeat with `/skip` during the intro → previous song should still resume.
  - [ ] Repeat with `/stop` during the intro → playback fully stops; no auto-resume.

https://claude.ai/code/session_01MPdiGKxoWLUPbzUovXr3YW

---
_Generated by [Claude Code](https://claude.ai/code/session_01MPdiGKxoWLUPbzUovXr3YW)_