### PR TITLE
feat(leveling): add per-guild XP, levels, role rewards and title gates

### DIFF
--- a/application/src/test/kotlin/integration/bot/CommandManagerTest.kt
+++ b/application/src/test/kotlin/integration/bot/CommandManagerTest.kt
@@ -132,6 +132,7 @@ class CommandManagerTest {
             EditIntroCommand::class.java,
             DeleteIntroCommand::class.java,
             UserInfoCommand::class.java,
+            LevelCommand::class.java,
             RandomCommand::class.java,
             Kf2RandomMapCommand::class.java,
             DbdRandomKillerCommand::class.java,
@@ -164,8 +165,8 @@ class CommandManagerTest {
         )
 
         Assertions.assertTrue(availableCommands.containsAll(commandManager.allCommands.map { it.javaClass }.toList()))
-        Assertions.assertEquals(66, commandManager.allCommands.size)
-        Assertions.assertEquals(66, commandManager.allSlashCommands.size)
+        Assertions.assertEquals(67, commandManager.allCommands.size)
+        Assertions.assertEquals(67, commandManager.allSlashCommands.size)
     }
 
     @Test

--- a/common/src/main/kotlin/common/events/LevelUpEvent.kt
+++ b/common/src/main/kotlin/common/events/LevelUpEvent.kt
@@ -1,0 +1,21 @@
+package common.events
+
+/**
+ * Fact emitted via Spring's [org.springframework.context.ApplicationEventPublisher]
+ * whenever an XP award pushes a user past one or more level thresholds.
+ * Subscribers handle the consequences: posting an announcement in the
+ * originating channel, assigning configured role rewards, and unlocking
+ * any titles gated by `required_level`.
+ *
+ * [channelId] is the Discord text-channel id where the triggering action
+ * happened (e.g. the message that earned the XP, the slash-command channel).
+ * It is null for voice-derived awards — listeners should fall back to the
+ * configured `LEVEL_UP_CHANNEL` or the guild's system channel in that case.
+ */
+data class LevelUpEvent(
+    val discordId: Long,
+    val guildId: Long,
+    val oldLevel: Int,
+    val newLevel: Int,
+    val channelId: Long?
+)

--- a/common/src/main/kotlin/common/leveling/LevelCurve.kt
+++ b/common/src/main/kotlin/common/leveling/LevelCurve.kt
@@ -1,0 +1,72 @@
+package common.leveling
+
+/**
+ * MEE6-style level curve. The XP required to advance from level `n` to
+ * level `n+1` is `5 * n^2 + 50 * n + 100`, and the cumulative XP needed to
+ * *reach* level `n` is the sum of that polynomial for levels 0..n-1.
+ *
+ * Levels start at 0 (everyone is level 0 with 0 XP). The first level-up
+ * happens at 100 XP, the second at 255 XP (100 + 155), and so on.
+ */
+object LevelCurve {
+
+    /**
+     * XP required to go from [level] to [level] + 1.
+     */
+    fun xpForNextLevel(level: Int): Long {
+        require(level >= 0) { "level must be >= 0" }
+        val n = level.toLong()
+        return 5L * n * n + 50L * n + 100L
+    }
+
+    /**
+     * Cumulative XP needed to *reach* [level]. Reaching level 0 costs 0.
+     */
+    fun cumulativeXpForLevel(level: Int): Long {
+        require(level >= 0) { "level must be >= 0" }
+        var total = 0L
+        for (n in 0 until level) {
+            total += xpForNextLevel(n)
+        }
+        return total
+    }
+
+    /**
+     * Resolve the level a user is at given their lifetime [xp]. Negative
+     * XP is clamped to 0.
+     */
+    fun levelForXp(xp: Long): Int {
+        if (xp <= 0L) return 0
+        var level = 0
+        var cumulative = 0L
+        while (true) {
+            val next = cumulative + xpForNextLevel(level)
+            if (xp < next) return level
+            cumulative = next
+            level++
+        }
+    }
+
+    /**
+     * Progress within the current level: `(level, xpIntoLevel, xpForNextLevel)`.
+     * Useful for rendering a progress bar — `xpIntoLevel / xpForNextLevel`.
+     */
+    fun progress(xp: Long): Progress {
+        val level = levelForXp(xp)
+        val base = cumulativeXpForLevel(level)
+        val needed = xpForNextLevel(level)
+        return Progress(
+            level = level,
+            xpIntoLevel = (xp - base).coerceAtLeast(0L),
+            xpForNextLevel = needed
+        )
+    }
+
+    data class Progress(
+        val level: Int,
+        val xpIntoLevel: Long,
+        val xpForNextLevel: Long
+    ) {
+        val xpRemaining: Long get() = (xpForNextLevel - xpIntoLevel).coerceAtLeast(0L)
+    }
+}

--- a/common/src/test/kotlin/common/leveling/LevelCurveTest.kt
+++ b/common/src/test/kotlin/common/leveling/LevelCurveTest.kt
@@ -1,0 +1,74 @@
+package common.leveling
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class LevelCurveTest {
+
+    @Test
+    fun `xpForNextLevel matches the MEE6-style polynomial`() {
+        // 5n^2 + 50n + 100
+        assertEquals(100L, LevelCurve.xpForNextLevel(0))
+        assertEquals(155L, LevelCurve.xpForNextLevel(1))
+        assertEquals(220L, LevelCurve.xpForNextLevel(2))
+        assertEquals(295L, LevelCurve.xpForNextLevel(3))
+    }
+
+    @Test
+    fun `cumulativeXpForLevel sums the curve`() {
+        assertEquals(0L, LevelCurve.cumulativeXpForLevel(0))
+        assertEquals(100L, LevelCurve.cumulativeXpForLevel(1))
+        assertEquals(255L, LevelCurve.cumulativeXpForLevel(2))
+        assertEquals(475L, LevelCurve.cumulativeXpForLevel(3))
+        assertEquals(770L, LevelCurve.cumulativeXpForLevel(4))
+    }
+
+    @Test
+    fun `levelForXp returns 0 for non-positive XP`() {
+        assertEquals(0, LevelCurve.levelForXp(-1L))
+        assertEquals(0, LevelCurve.levelForXp(0L))
+        assertEquals(0, LevelCurve.levelForXp(99L))
+    }
+
+    @Test
+    fun `levelForXp transitions at exact thresholds`() {
+        // 100 XP -> level 1 starts.
+        assertEquals(1, LevelCurve.levelForXp(100L))
+        assertEquals(1, LevelCurve.levelForXp(254L))
+        // 255 XP -> level 2 starts.
+        assertEquals(2, LevelCurve.levelForXp(255L))
+        assertEquals(2, LevelCurve.levelForXp(474L))
+        // 475 XP -> level 3 starts.
+        assertEquals(3, LevelCurve.levelForXp(475L))
+    }
+
+    @Test
+    fun `progress returns the in-level offset and the curve for that level`() {
+        val p = LevelCurve.progress(300L) // level 2, 300-255 = 45 XP into level 2.
+        assertEquals(2, p.level)
+        assertEquals(45L, p.xpIntoLevel)
+        assertEquals(220L, p.xpForNextLevel)
+        assertEquals(220L - 45L, p.xpRemaining)
+    }
+
+    @Test
+    fun `progress at exact threshold puts the user at the start of the new level`() {
+        val p = LevelCurve.progress(255L)
+        assertEquals(2, p.level)
+        assertEquals(0L, p.xpIntoLevel)
+        assertEquals(220L, p.xpForNextLevel)
+    }
+
+    @Test
+    fun `levels grow but never go backwards`() {
+        var lastLevel = 0
+        var xp = 0L
+        repeat(50) {
+            xp += 1000L
+            val level = LevelCurve.levelForXp(xp)
+            assertTrue(level >= lastLevel, "level must be monotonic with xp")
+            lastLevel = level
+        }
+    }
+}

--- a/database/src/main/kotlin/database/dto/ConfigDto.kt
+++ b/database/src/main/kotlin/database/dto/ConfigDto.kt
@@ -115,6 +115,26 @@ class ConfigDto(
         // (SocialCreditAwardService.DEFAULT_DAILY_CAP) when unset or invalid.
         DAILY_CREDIT_CAP("DAILY_CREDIT_CAP"),
 
+        // Per-guild override of the daily XP cap. Falls back to 1000
+        // (XpAwardService.DEFAULT_DAILY_XP_CAP) when unset or invalid.
+        DAILY_XP_CAP("DAILY_XP_CAP"),
+
+        // Whole-number bonus added to DAILY_CREDIT_CAP per level the user
+        // has reached. Default 10. Set to 0 to disable the leveling perk
+        // for the social-credit daily cap entirely.
+        DAILY_CAP_PER_LEVEL_BONUS("DAILY_CAP_PER_LEVEL_BONUS"),
+
+        // Whole-number bonus added to UBI_DAILY_AMOUNT per level the user
+        // has reached. Default 5. Set to 0 to disable the leveling perk
+        // for UBI entirely.
+        UBI_PER_LEVEL_BONUS("UBI_PER_LEVEL_BONUS"),
+
+        // Optional Discord text-channel id where level-up announcements
+        // post. When unset (default), announcements post in the channel
+        // where the level-up was earned (message/command channel), or fall
+        // back to the system channel for voice-triggered level-ups.
+        LEVEL_UP_CHANNEL("LEVEL_UP_CHANNEL"),
+
         // Per-game min/max stake bounds. Defaults come from each game's
         // companion-object MIN_STAKE/MAX_STAKE constants when unset, so
         // guilds that never touch these keys see today's behaviour.

--- a/database/src/main/kotlin/database/dto/LevelRoleRewardDto.kt
+++ b/database/src/main/kotlin/database/dto/LevelRoleRewardDto.kt
@@ -1,0 +1,42 @@
+package database.dto
+
+import jakarta.persistence.*
+import org.springframework.transaction.annotation.Transactional
+import java.io.Serializable
+
+@NamedQueries(
+    NamedQuery(
+        name = "LevelRoleRewardDto.getGuildAll",
+        query = "select r from LevelRoleRewardDto r where r.guildId = :guildId order by r.level asc"
+    ),
+    NamedQuery(
+        name = "LevelRoleRewardDto.getByGuildAndLevel",
+        query = "select r from LevelRoleRewardDto r where r.guildId = :guildId and r.level = :level"
+    ),
+    NamedQuery(
+        name = "LevelRoleRewardDto.getInRange",
+        query = "select r from LevelRoleRewardDto r where r.guildId = :guildId " +
+                "and r.level > :fromExclusive and r.level <= :toInclusive order by r.level asc"
+    )
+)
+@Entity
+@Table(name = "level_role_reward", schema = "public")
+@IdClass(LevelRoleRewardId::class)
+@Transactional
+class LevelRoleRewardDto(
+    @Id
+    @Column(name = "guild_id")
+    var guildId: Long = 0,
+
+    @Id
+    @Column(name = "level")
+    var level: Int = 0,
+
+    @Column(name = "role_id", nullable = false)
+    var roleId: Long = 0
+) : Serializable
+
+data class LevelRoleRewardId(
+    var guildId: Long = 0,
+    var level: Int = 0
+) : Serializable

--- a/database/src/main/kotlin/database/dto/TitleDto.kt
+++ b/database/src/main/kotlin/database/dto/TitleDto.kt
@@ -30,5 +30,8 @@ class TitleDto(
     var colorHex: String? = null,
 
     @Column(name = "hoisted", nullable = false)
-    var hoisted: Boolean = false
+    var hoisted: Boolean = false,
+
+    @Column(name = "required_level", nullable = false)
+    var requiredLevel: Int = 0
 ) : Serializable

--- a/database/src/main/kotlin/database/dto/UserDto.kt
+++ b/database/src/main/kotlin/database/dto/UserDto.kt
@@ -45,6 +45,9 @@ class UserDto(
     @Column(name = "social_credit")
     var socialCredit: Long? = 0L,
 
+    @Column(name = "xp", nullable = false)
+    var xp: Long = 0L,
+
     @Column(name = "toby_coins", nullable = false)
     var tobyCoins: Long = 0L,
 

--- a/database/src/main/kotlin/database/dto/XpDailyDto.kt
+++ b/database/src/main/kotlin/database/dto/XpDailyDto.kt
@@ -1,0 +1,40 @@
+package database.dto
+
+import jakarta.persistence.*
+import org.springframework.transaction.annotation.Transactional
+import java.io.Serializable
+import java.time.LocalDate
+
+@NamedQueries(
+    NamedQuery(
+        name = "XpDailyDto.get",
+        query = "select d from XpDailyDto d " +
+                "where d.discordId = :discordId and d.guildId = :guildId and d.earnDate = :earnDate"
+    )
+)
+@Entity
+@Table(name = "xp_daily", schema = "public")
+@IdClass(XpDailyId::class)
+@Transactional
+class XpDailyDto(
+    @Id
+    @Column(name = "discord_id")
+    var discordId: Long = 0,
+
+    @Id
+    @Column(name = "guild_id")
+    var guildId: Long = 0,
+
+    @Id
+    @Column(name = "earn_date")
+    var earnDate: LocalDate = LocalDate.now(),
+
+    @Column(name = "xp_earned", nullable = false)
+    var xpEarned: Long = 0
+) : Serializable
+
+data class XpDailyId(
+    var discordId: Long = 0,
+    var guildId: Long = 0,
+    var earnDate: LocalDate = LocalDate.now()
+) : Serializable

--- a/database/src/main/kotlin/database/persistence/LevelRoleRewardPersistence.kt
+++ b/database/src/main/kotlin/database/persistence/LevelRoleRewardPersistence.kt
@@ -1,0 +1,18 @@
+package database.persistence
+
+import database.dto.LevelRoleRewardDto
+
+interface LevelRoleRewardPersistence {
+    fun listForGuild(guildId: Long): List<LevelRoleRewardDto>
+    fun get(guildId: Long, level: Int): LevelRoleRewardDto?
+
+    /**
+     * Rewards strictly above [fromExclusive] and at or below [toInclusive],
+     * ordered ascending by level. Used when a single XP grant crosses
+     * multiple level thresholds so every reward in the band gets applied.
+     */
+    fun listInRange(guildId: Long, fromExclusive: Int, toInclusive: Int): List<LevelRoleRewardDto>
+
+    fun upsert(reward: LevelRoleRewardDto): LevelRoleRewardDto
+    fun delete(guildId: Long, level: Int)
+}

--- a/database/src/main/kotlin/database/persistence/XpDailyPersistence.kt
+++ b/database/src/main/kotlin/database/persistence/XpDailyPersistence.kt
@@ -1,0 +1,9 @@
+package database.persistence
+
+import database.dto.XpDailyDto
+import java.time.LocalDate
+
+interface XpDailyPersistence {
+    fun get(discordId: Long, guildId: Long, date: LocalDate): XpDailyDto?
+    fun upsert(row: XpDailyDto): XpDailyDto
+}

--- a/database/src/main/kotlin/database/persistence/impl/DefaultLevelRoleRewardPersistence.kt
+++ b/database/src/main/kotlin/database/persistence/impl/DefaultLevelRoleRewardPersistence.kt
@@ -1,0 +1,65 @@
+package database.persistence.impl
+
+import database.dto.LevelRoleRewardDto
+import database.persistence.LevelRoleRewardPersistence
+import jakarta.persistence.EntityManager
+import jakarta.persistence.PersistenceContext
+import jakarta.persistence.TypedQuery
+import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
+
+@Repository
+@Transactional
+class DefaultLevelRoleRewardPersistence : LevelRoleRewardPersistence {
+
+    @PersistenceContext
+    private lateinit var entityManager: EntityManager
+
+    override fun listForGuild(guildId: Long): List<LevelRoleRewardDto> {
+        val q: TypedQuery<LevelRoleRewardDto> = entityManager
+            .createNamedQuery("LevelRoleRewardDto.getGuildAll", LevelRoleRewardDto::class.java)
+        q.setParameter("guildId", guildId)
+        return q.resultList
+    }
+
+    override fun get(guildId: Long, level: Int): LevelRoleRewardDto? {
+        val q: TypedQuery<LevelRoleRewardDto> = entityManager
+            .createNamedQuery("LevelRoleRewardDto.getByGuildAndLevel", LevelRoleRewardDto::class.java)
+        q.setParameter("guildId", guildId)
+        q.setParameter("level", level)
+        return q.resultList.firstOrNull()
+    }
+
+    override fun listInRange(
+        guildId: Long,
+        fromExclusive: Int,
+        toInclusive: Int
+    ): List<LevelRoleRewardDto> {
+        val q: TypedQuery<LevelRoleRewardDto> = entityManager
+            .createNamedQuery("LevelRoleRewardDto.getInRange", LevelRoleRewardDto::class.java)
+        q.setParameter("guildId", guildId)
+        q.setParameter("fromExclusive", fromExclusive)
+        q.setParameter("toInclusive", toInclusive)
+        return q.resultList
+    }
+
+    override fun upsert(reward: LevelRoleRewardDto): LevelRoleRewardDto {
+        val existing = get(reward.guildId, reward.level)
+        return if (existing == null) {
+            entityManager.persist(reward)
+            entityManager.flush()
+            reward
+        } else {
+            existing.roleId = reward.roleId
+            entityManager.merge(existing)
+            entityManager.flush()
+            existing
+        }
+    }
+
+    override fun delete(guildId: Long, level: Int) {
+        val existing = get(guildId, level) ?: return
+        entityManager.remove(existing)
+        entityManager.flush()
+    }
+}

--- a/database/src/main/kotlin/database/persistence/impl/DefaultXpDailyPersistence.kt
+++ b/database/src/main/kotlin/database/persistence/impl/DefaultXpDailyPersistence.kt
@@ -1,0 +1,41 @@
+package database.persistence.impl
+
+import database.dto.XpDailyDto
+import database.persistence.XpDailyPersistence
+import jakarta.persistence.EntityManager
+import jakarta.persistence.PersistenceContext
+import jakarta.persistence.TypedQuery
+import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+
+@Repository
+@Transactional
+class DefaultXpDailyPersistence : XpDailyPersistence {
+
+    @PersistenceContext
+    private lateinit var entityManager: EntityManager
+
+    override fun get(discordId: Long, guildId: Long, date: LocalDate): XpDailyDto? {
+        val q: TypedQuery<XpDailyDto> =
+            entityManager.createNamedQuery("XpDailyDto.get", XpDailyDto::class.java)
+        q.setParameter("discordId", discordId)
+        q.setParameter("guildId", guildId)
+        q.setParameter("earnDate", date)
+        return q.resultList.firstOrNull()
+    }
+
+    override fun upsert(row: XpDailyDto): XpDailyDto {
+        val existing = get(row.discordId, row.guildId, row.earnDate)
+        return if (existing == null) {
+            entityManager.persist(row)
+            entityManager.flush()
+            row
+        } else {
+            existing.xpEarned = row.xpEarned
+            entityManager.merge(existing)
+            entityManager.flush()
+            existing
+        }
+    }
+}

--- a/database/src/main/kotlin/database/service/LevelRoleRewardService.kt
+++ b/database/src/main/kotlin/database/service/LevelRoleRewardService.kt
@@ -1,0 +1,11 @@
+package database.service
+
+import database.dto.LevelRoleRewardDto
+
+interface LevelRoleRewardService {
+    fun listForGuild(guildId: Long): List<LevelRoleRewardDto>
+    fun get(guildId: Long, level: Int): LevelRoleRewardDto?
+    fun listInRange(guildId: Long, fromExclusive: Int, toInclusive: Int): List<LevelRoleRewardDto>
+    fun upsert(reward: LevelRoleRewardDto): LevelRoleRewardDto
+    fun delete(guildId: Long, level: Int)
+}

--- a/database/src/main/kotlin/database/service/SocialCreditAwardService.kt
+++ b/database/src/main/kotlin/database/service/SocialCreditAwardService.kt
@@ -1,5 +1,6 @@
 package database.service
 
+import common.leveling.LevelCurve
 import database.dto.ConfigDto
 import database.dto.VoiceCreditDailyDto
 import org.springframework.stereotype.Service
@@ -65,7 +66,7 @@ class SocialCreditAwardService(
         val today = LocalDate.ofInstant(at, ZoneOffset.UTC)
         val existing = voiceCreditDailyService.get(discordId, guildId, today)
         val usedToday = existing?.credits ?: 0L
-        val dailyCap = resolveDailyCap(guildId)
+        val dailyCap = resolveDailyCap(discordId, guildId)
         val headroom = (dailyCap - usedToday).coerceAtLeast(0L)
         val granted = requested.coerceAtMost(headroom)
         if (granted > 0L) {
@@ -81,7 +82,23 @@ class SocialCreditAwardService(
         return granted
     }
 
-    private fun resolveDailyCap(guildId: Long): Long {
+    /**
+     * Resolved daily cap for [discordId] in [guildId]: the per-guild
+     * configured base (or [DEFAULT_DAILY_CAP] when unset) plus the user's
+     * level bonus (`level * DAILY_CAP_PER_LEVEL_BONUS`, default +10/level).
+     * The leveling perk is config-driven so server owners can disable it
+     * by setting `DAILY_CAP_PER_LEVEL_BONUS=0`.
+     */
+    fun resolveDailyCap(discordId: Long, guildId: Long): Long {
+        val base = resolveBaseDailyCap(guildId)
+        val perLevelBonus = resolvePerLevelBonus(guildId)
+        if (perLevelBonus == 0L) return base
+        val user = userService.getUserById(discordId, guildId) ?: return base
+        val level = LevelCurve.levelForXp(user.xp)
+        return base + perLevelBonus * level
+    }
+
+    private fun resolveBaseDailyCap(guildId: Long): Long {
         val raw = configService.getConfigByName(
             ConfigDto.Configurations.DAILY_CREDIT_CAP.configValue,
             guildId.toString()
@@ -90,8 +107,20 @@ class SocialCreditAwardService(
         return if (parsed != null && parsed >= 0L) parsed else DEFAULT_DAILY_CAP
     }
 
+    private fun resolvePerLevelBonus(guildId: Long): Long {
+        val raw = configService.getConfigByName(
+            ConfigDto.Configurations.DAILY_CAP_PER_LEVEL_BONUS.configValue,
+            guildId.toString()
+        )?.value
+        val parsed = raw?.toLongOrNull()
+        return if (parsed != null && parsed >= 0L) parsed else DEFAULT_DAILY_CAP_PER_LEVEL_BONUS
+    }
+
     companion object {
         // Fallback when DAILY_CREDIT_CAP config is unset or unparseable for the guild.
         const val DEFAULT_DAILY_CAP: Long = 90L
+
+        // Fallback when DAILY_CAP_PER_LEVEL_BONUS is unset or unparseable.
+        const val DEFAULT_DAILY_CAP_PER_LEVEL_BONUS: Long = 10L
     }
 }

--- a/database/src/main/kotlin/database/service/XpAwardService.kt
+++ b/database/src/main/kotlin/database/service/XpAwardService.kt
@@ -1,0 +1,121 @@
+package database.service
+
+import common.events.LevelUpEvent
+import common.leveling.LevelCurve
+import database.dto.ConfigDto
+import database.dto.XpDailyDto
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneOffset
+
+/**
+ * Single entry point for awarding XP. Mirrors [SocialCreditAwardService]:
+ * positive [amount] only, daily-cap accounting (per-guild override via
+ * [ConfigDto.Configurations.DAILY_XP_CAP], falling back to
+ * [DEFAULT_DAILY_XP_CAP]), and a single update path so cache invalidation
+ * stays consistent.
+ *
+ * The award path computes the user's level before and after the increment;
+ * if at least one threshold is crossed, a [LevelUpEvent] is published.
+ * Listeners in the discord-bot module pick that up to announce the
+ * level-up, assign role rewards, and unlock gated titles.
+ */
+@Service
+@Transactional
+class XpAwardService(
+    private val userService: UserService,
+    private val xpDailyService: XpDailyService,
+    private val configService: ConfigService,
+    private val eventPublisher: ApplicationEventPublisher
+) {
+    /**
+     * Add [amount] XP to the user. Daily cap is enforced when
+     * [countsAgainstDailyCap] is true. Returns the XP that was actually
+     * granted (clamped to remaining daily headroom). No-ops and returns 0
+     * for non-positive [amount] or unknown users. [channelId] is forwarded
+     * to any emitted [LevelUpEvent] so listeners can post in the right
+     * channel.
+     */
+    fun award(
+        discordId: Long,
+        guildId: Long,
+        amount: Long,
+        reason: String,
+        channelId: Long? = null,
+        countsAgainstDailyCap: Boolean = true,
+        at: Instant = Instant.now(),
+    ): Long {
+        if (amount <= 0L) return 0L
+
+        val user = userService.getUserById(discordId, guildId) ?: return 0L
+
+        val granted = if (countsAgainstDailyCap) {
+            clampToDailyCap(discordId, guildId, amount, at)
+        } else {
+            amount
+        }
+        if (granted <= 0L) return 0L
+
+        val oldXp = user.xp
+        val newXp = oldXp + granted
+        val oldLevel = LevelCurve.levelForXp(oldXp)
+        val newLevel = LevelCurve.levelForXp(newXp)
+        user.xp = newXp
+        userService.updateUser(user)
+
+        if (newLevel > oldLevel) {
+            eventPublisher.publishEvent(
+                LevelUpEvent(
+                    discordId = discordId,
+                    guildId = guildId,
+                    oldLevel = oldLevel,
+                    newLevel = newLevel,
+                    channelId = channelId
+                )
+            )
+        }
+        return granted
+    }
+
+    private fun clampToDailyCap(
+        discordId: Long,
+        guildId: Long,
+        requested: Long,
+        at: Instant
+    ): Long {
+        val today = LocalDate.ofInstant(at, ZoneOffset.UTC)
+        val existing = xpDailyService.get(discordId, guildId, today)
+        val usedToday = existing?.xpEarned ?: 0L
+        val dailyCap = resolveDailyCap(guildId)
+        val headroom = (dailyCap - usedToday).coerceAtLeast(0L)
+        val granted = requested.coerceAtMost(headroom)
+        if (granted > 0L) {
+            xpDailyService.upsert(
+                XpDailyDto(
+                    discordId = discordId,
+                    guildId = guildId,
+                    earnDate = today,
+                    xpEarned = usedToday + granted
+                )
+            )
+        }
+        return granted
+    }
+
+    private fun resolveDailyCap(guildId: Long): Long {
+        val raw = configService.getConfigByName(
+            ConfigDto.Configurations.DAILY_XP_CAP.configValue,
+            guildId.toString()
+        )?.value
+        val parsed = raw?.toLongOrNull()
+        return if (parsed != null && parsed >= 0L) parsed else DEFAULT_DAILY_XP_CAP
+    }
+
+    companion object {
+        // Fallback when DAILY_XP_CAP config is unset or unparseable for the guild.
+        const val DEFAULT_DAILY_XP_CAP: Long = 1000L
+    }
+}

--- a/database/src/main/kotlin/database/service/XpDailyService.kt
+++ b/database/src/main/kotlin/database/service/XpDailyService.kt
@@ -1,0 +1,9 @@
+package database.service
+
+import database.dto.XpDailyDto
+import java.time.LocalDate
+
+interface XpDailyService {
+    fun get(discordId: Long, guildId: Long, date: LocalDate): XpDailyDto?
+    fun upsert(row: XpDailyDto): XpDailyDto
+}

--- a/database/src/main/kotlin/database/service/impl/DefaultLevelRoleRewardService.kt
+++ b/database/src/main/kotlin/database/service/impl/DefaultLevelRoleRewardService.kt
@@ -1,0 +1,28 @@
+package database.service.impl
+
+import database.dto.LevelRoleRewardDto
+import database.persistence.LevelRoleRewardPersistence
+import database.service.LevelRoleRewardService
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Service
+
+@Service
+class DefaultLevelRoleRewardService @Autowired constructor(
+    private val persistence: LevelRoleRewardPersistence
+) : LevelRoleRewardService {
+    override fun listForGuild(guildId: Long): List<LevelRoleRewardDto> =
+        persistence.listForGuild(guildId)
+
+    override fun get(guildId: Long, level: Int): LevelRoleRewardDto? =
+        persistence.get(guildId, level)
+
+    override fun listInRange(
+        guildId: Long,
+        fromExclusive: Int,
+        toInclusive: Int
+    ): List<LevelRoleRewardDto> = persistence.listInRange(guildId, fromExclusive, toInclusive)
+
+    override fun upsert(reward: LevelRoleRewardDto): LevelRoleRewardDto = persistence.upsert(reward)
+
+    override fun delete(guildId: Long, level: Int) = persistence.delete(guildId, level)
+}

--- a/database/src/main/kotlin/database/service/impl/DefaultXpDailyService.kt
+++ b/database/src/main/kotlin/database/service/impl/DefaultXpDailyService.kt
@@ -1,0 +1,18 @@
+package database.service.impl
+
+import database.dto.XpDailyDto
+import database.persistence.XpDailyPersistence
+import database.service.XpDailyService
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Service
+import java.time.LocalDate
+
+@Service
+class DefaultXpDailyService @Autowired constructor(
+    private val persistence: XpDailyPersistence
+) : XpDailyService {
+    override fun get(discordId: Long, guildId: Long, date: LocalDate): XpDailyDto? =
+        persistence.get(discordId, guildId, date)
+
+    override fun upsert(row: XpDailyDto): XpDailyDto = persistence.upsert(row)
+}

--- a/database/src/main/resources/db/migration/V34__xp_and_levels.sql
+++ b/database/src/main/resources/db/migration/V34__xp_and_levels.sql
@@ -1,0 +1,33 @@
+-- Leveling / engagement system. XP is awarded by the same engagement events
+-- that already grant social credit (intro plays, voice sessions, commands,
+-- messages), but tracked separately so spending credit at the casino does not
+-- knock a user back down a level.
+
+-- Lifetime XP per user per guild. Same primary-key shape as social_credit so
+-- the leveling system is per-guild from day one.
+ALTER TABLE public."user"
+    ADD COLUMN xp BIGINT NOT NULL DEFAULT 0;
+
+-- Daily-cap ledger for XP. Mirrors voice_credit_daily so the same anti-farm
+-- pattern (clamp award to today's headroom, upsert the row) carries over.
+CREATE TABLE xp_daily (
+    discord_id BIGINT NOT NULL,
+    guild_id   BIGINT NOT NULL,
+    earn_date  DATE   NOT NULL,
+    xp_earned  BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (discord_id, guild_id, earn_date)
+);
+
+-- Per-guild role rewards. When a user crosses `level`, the configured Discord
+-- role is assigned. Server owners manage these via the moderation web UI.
+CREATE TABLE level_role_reward (
+    guild_id BIGINT NOT NULL,
+    level    INT    NOT NULL,
+    role_id  BIGINT NOT NULL,
+    PRIMARY KEY (guild_id, level)
+);
+
+-- Optional level gate for vanity titles. Default 0 means "no gate" so every
+-- existing title stays purchasable without further migration.
+ALTER TABLE title
+    ADD COLUMN required_level INT NOT NULL DEFAULT 0;

--- a/database/src/test/kotlin/database/service/SocialCreditAwardServiceTest.kt
+++ b/database/src/test/kotlin/database/service/SocialCreditAwardServiceTest.kt
@@ -115,6 +115,46 @@ class SocialCreditAwardServiceTest {
         assertEquals(SocialCreditAwardService.DEFAULT_DAILY_CAP, granted)
     }
 
+    @Test
+    fun `daily cap gains the per-level bonus by default`() {
+        // 475 XP -> level 3, so default +10/level = +30 -> cap 120.
+        userService.seed(UserDto(discordId, guildId).apply { socialCredit = 0L; xp = 475L })
+
+        val granted = service.award(discordId, guildId, amount = 200L, reason = "test", at = now)
+
+        assertEquals(120L, granted)
+        assertEquals(120L, userService.current(discordId, guildId)?.socialCredit)
+    }
+
+    @Test
+    fun `setting DAILY_CAP_PER_LEVEL_BONUS to zero disables the leveling perk`() {
+        userService.seed(UserDto(discordId, guildId).apply { socialCredit = 0L; xp = 475L })
+        configService.set(
+            ConfigDto.Configurations.DAILY_CAP_PER_LEVEL_BONUS.configValue,
+            guildId.toString(),
+            "0"
+        )
+
+        val granted = service.award(discordId, guildId, amount = 200L, reason = "test", at = now)
+
+        assertEquals(SocialCreditAwardService.DEFAULT_DAILY_CAP, granted)
+    }
+
+    @Test
+    fun `custom DAILY_CAP_PER_LEVEL_BONUS overrides the default`() {
+        userService.seed(UserDto(discordId, guildId).apply { socialCredit = 0L; xp = 475L }) // level 3
+        configService.set(
+            ConfigDto.Configurations.DAILY_CAP_PER_LEVEL_BONUS.configValue,
+            guildId.toString(),
+            "100"
+        )
+
+        val granted = service.award(discordId, guildId, amount = 5_000L, reason = "test", at = now)
+
+        // 90 base + 100 * 3 = 390
+        assertEquals(390L, granted)
+    }
+
     private class RecordingUserService : UserService {
         private val users = mutableMapOf<Pair<Long, Long>, UserDto>()
         var updateCount: Int = 0

--- a/database/src/test/kotlin/database/service/XpAwardServiceTest.kt
+++ b/database/src/test/kotlin/database/service/XpAwardServiceTest.kt
@@ -1,0 +1,311 @@
+package database.service
+
+import common.events.LevelUpEvent
+import common.leveling.LevelCurve
+import database.dto.ConfigDto
+import database.dto.UserDto
+import database.dto.XpDailyDto
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.context.ApplicationEvent
+import org.springframework.context.ApplicationEventPublisher
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneOffset
+
+class XpAwardServiceTest {
+
+    private val discordId = 1L
+    private val guildId = 42L
+    private val now: Instant = Instant.parse("2026-04-10T10:00:00Z")
+    private val today: LocalDate = LocalDate.ofInstant(now, ZoneOffset.UTC)
+
+    private lateinit var userService: RecordingUserService
+    private lateinit var xpDailyService: InMemoryXpDailyService
+    private lateinit var configService: InMemoryConfigService
+    private lateinit var eventPublisher: RecordingEventPublisher
+    private lateinit var service: XpAwardService
+
+    @BeforeEach
+    fun setup() {
+        userService = RecordingUserService()
+        xpDailyService = InMemoryXpDailyService()
+        configService = InMemoryConfigService()
+        eventPublisher = RecordingEventPublisher()
+        service = XpAwardService(userService, xpDailyService, configService, eventPublisher)
+    }
+
+    @Test
+    fun `award adds XP and persists via updateUser`() {
+        userService.seed(UserDto(discordId, guildId).apply { xp = 10L })
+
+        val granted = service.award(discordId, guildId, amount = 5L, reason = "test", at = now)
+
+        assertEquals(5L, granted)
+        assertEquals(15L, userService.current(discordId, guildId)?.xp)
+        assertEquals(1, userService.updateCount)
+    }
+
+    @Test
+    fun `award returns zero and no-ops for non-positive amounts`() {
+        userService.seed(UserDto(discordId, guildId).apply { xp = 10L })
+
+        assertEquals(0L, service.award(discordId, guildId, amount = 0L, reason = "test", at = now))
+        assertEquals(0L, service.award(discordId, guildId, amount = -3L, reason = "test", at = now))
+
+        assertEquals(10L, userService.current(discordId, guildId)?.xp)
+        assertEquals(0, userService.updateCount)
+    }
+
+    @Test
+    fun `award respects the daily cap and consumes the remaining headroom only`() {
+        userService.seed(UserDto(discordId, guildId).apply { xp = 0L })
+        // 995/1000 already used today.
+        xpDailyService.upsert(XpDailyDto(discordId, guildId, today, xpEarned = 995L))
+
+        val granted = service.award(discordId, guildId, amount = 20L, reason = "test", at = now)
+
+        assertEquals(5L, granted, "only 5 XP of headroom remain under the default cap")
+        assertEquals(5L, userService.current(discordId, guildId)?.xp)
+        assertEquals(1000L, xpDailyService.get(discordId, guildId, today)?.xpEarned)
+    }
+
+    @Test
+    fun `award with countsAgainstDailyCap false bypasses the cap and the ledger`() {
+        userService.seed(UserDto(discordId, guildId).apply { xp = 0L })
+        xpDailyService.upsert(XpDailyDto(discordId, guildId, today, xpEarned = 1000L)) // capped
+
+        val granted = service.award(
+            discordId, guildId,
+            amount = 250L,
+            reason = "test",
+            countsAgainstDailyCap = false,
+            at = now
+        )
+
+        assertEquals(250L, granted, "uncapped award should pass through the full amount")
+        assertEquals(250L, userService.current(discordId, guildId)?.xp)
+        assertEquals(1000L, xpDailyService.get(discordId, guildId, today)?.xpEarned, "ledger untouched")
+    }
+
+    @Test
+    fun `award returns zero and does not consume the cap when user row is missing`() {
+        val granted = service.award(discordId, guildId, amount = 5L, reason = "test", at = now)
+
+        assertEquals(0L, granted)
+        assertEquals(0, userService.updateCount)
+        assertNull(xpDailyService.get(discordId, guildId, today))
+    }
+
+    @Test
+    fun `award reads the per-guild DAILY_XP_CAP override from config`() {
+        userService.seed(UserDto(discordId, guildId).apply { xp = 0L })
+        configService.set(ConfigDto.Configurations.DAILY_XP_CAP.configValue, guildId.toString(), "7")
+
+        val granted = service.award(discordId, guildId, amount = 100L, reason = "test", at = now)
+
+        assertEquals(7L, granted)
+        assertEquals(7L, userService.current(discordId, guildId)?.xp)
+        assertEquals(7L, xpDailyService.get(discordId, guildId, today)?.xpEarned)
+    }
+
+    @Test
+    fun `award falls back to DEFAULT_DAILY_XP_CAP when config value is unparseable`() {
+        userService.seed(UserDto(discordId, guildId).apply { xp = 0L })
+        configService.set(ConfigDto.Configurations.DAILY_XP_CAP.configValue, guildId.toString(), "junk")
+
+        val granted = service.award(discordId, guildId, amount = 5000L, reason = "test", at = now)
+
+        assertEquals(XpAwardService.DEFAULT_DAILY_XP_CAP, granted)
+    }
+
+    @Test
+    fun `crossing a level threshold publishes a LevelUpEvent`() {
+        // 99 XP -> level 0, add 1 -> 100 -> level 1.
+        userService.seed(UserDto(discordId, guildId).apply { xp = 99L })
+
+        service.award(
+            discordId, guildId,
+            amount = 1L,
+            reason = "test",
+            channelId = 1234L,
+            countsAgainstDailyCap = false,
+            at = now
+        )
+
+        assertEquals(1, eventPublisher.events.size)
+        val event = eventPublisher.events.single() as LevelUpEvent
+        assertEquals(discordId, event.discordId)
+        assertEquals(guildId, event.guildId)
+        assertEquals(0, event.oldLevel)
+        assertEquals(1, event.newLevel)
+        assertEquals(1234L, event.channelId)
+    }
+
+    @Test
+    fun `staying within the same level does not publish a LevelUpEvent`() {
+        userService.seed(UserDto(discordId, guildId).apply { xp = 100L }) // level 1
+
+        service.award(
+            discordId, guildId,
+            amount = 50L,
+            reason = "test",
+            countsAgainstDailyCap = false,
+            at = now
+        )
+
+        assertTrue(eventPublisher.events.isEmpty())
+    }
+
+    @Test
+    fun `a single award can cross multiple levels at once`() {
+        userService.seed(UserDto(discordId, guildId).apply { xp = 0L })
+        val target = LevelCurve.cumulativeXpForLevel(3) // 475
+
+        service.award(
+            discordId, guildId,
+            amount = target,
+            reason = "test",
+            countsAgainstDailyCap = false,
+            at = now
+        )
+
+        assertEquals(1, eventPublisher.events.size)
+        val event = eventPublisher.events.single() as LevelUpEvent
+        assertEquals(0, event.oldLevel)
+        assertEquals(3, event.newLevel)
+    }
+
+    @Test
+    fun `daily cap blocking a level-up suppresses the event`() {
+        userService.seed(UserDto(discordId, guildId).apply { xp = 0L })
+        configService.set(ConfigDto.Configurations.DAILY_XP_CAP.configValue, guildId.toString(), "50")
+
+        // Request enough to level up, but cap clamps it back below 100 XP.
+        service.award(discordId, guildId, amount = 200L, reason = "test", at = now)
+
+        assertEquals(50L, userService.current(discordId, guildId)?.xp)
+        assertTrue(eventPublisher.events.isEmpty())
+    }
+
+    @Test
+    fun `award returns zero when daily cap is already exhausted`() {
+        userService.seed(UserDto(discordId, guildId).apply { xp = 0L })
+        xpDailyService.upsert(XpDailyDto(discordId, guildId, today, xpEarned = 1000L))
+
+        val granted = service.award(discordId, guildId, amount = 50L, reason = "test", at = now)
+
+        assertEquals(0L, granted)
+        assertEquals(0L, userService.current(discordId, guildId)?.xp)
+    }
+
+    @Test
+    fun `event includes channelId when one is supplied`() {
+        userService.seed(UserDto(discordId, guildId).apply { xp = 99L })
+
+        service.award(
+            discordId, guildId,
+            amount = 200L,
+            reason = "test",
+            channelId = 7777L,
+            countsAgainstDailyCap = false,
+            at = now
+        )
+
+        assertNotNull(eventPublisher.events.firstOrNull())
+        assertEquals(7777L, (eventPublisher.events.first() as LevelUpEvent).channelId)
+    }
+
+    private class RecordingEventPublisher : ApplicationEventPublisher {
+        val events: MutableList<Any> = mutableListOf()
+        override fun publishEvent(event: ApplicationEvent) {
+            events.add(event)
+        }
+        override fun publishEvent(event: Any) {
+            events.add(event)
+        }
+    }
+
+    private class RecordingUserService : UserService {
+        private val users = mutableMapOf<Pair<Long, Long>, UserDto>()
+        var updateCount: Int = 0
+            private set
+
+        fun seed(dto: UserDto) {
+            users[dto.discordId to dto.guildId] = dto
+        }
+
+        fun current(discordId: Long, guildId: Long): UserDto? = users[discordId to guildId]
+
+        override fun listGuildUsers(guildId: Long?): List<UserDto?> =
+            users.values.filter { it.guildId == guildId }
+
+        override fun createNewUser(userDto: UserDto): UserDto = userDto.also(::seed)
+
+        override fun getUserById(discordId: Long?, guildId: Long?): UserDto? =
+            users[discordId!! to guildId!!]
+
+        override fun getUserByIdForUpdate(discordId: Long?, guildId: Long?): UserDto? =
+            getUserById(discordId, guildId)
+
+        override fun updateUser(userDto: UserDto): UserDto {
+            updateCount++
+            seed(userDto)
+            return userDto
+        }
+
+        override fun deleteUser(userDto: UserDto) { users.remove(userDto.discordId to userDto.guildId) }
+        override fun deleteUserById(discordId: Long?, guildId: Long?) { users.remove(discordId!! to guildId!!) }
+        override fun clearCache() {}
+        override fun evictUserFromCache(discordId: Long?, guildId: Long?) {}
+    }
+
+    private class InMemoryXpDailyService : XpDailyService {
+        private val rows = mutableMapOf<Triple<Long, Long, LocalDate>, XpDailyDto>()
+
+        override fun get(discordId: Long, guildId: Long, date: LocalDate): XpDailyDto? =
+            rows[Triple(discordId, guildId, date)]
+
+        override fun upsert(row: XpDailyDto): XpDailyDto {
+            rows[Triple(row.discordId, row.guildId, row.earnDate)] = row
+            return row
+        }
+    }
+
+    private class InMemoryConfigService : ConfigService {
+        private val rows = mutableMapOf<Pair<String, String>, ConfigDto>()
+
+        fun set(name: String, guildId: String, value: String) {
+            rows[name to guildId] = ConfigDto(name = name, value = value, guildId = guildId)
+        }
+
+        override fun listAllConfig(): List<ConfigDto?>? = rows.values.toList()
+        override fun listGuildConfig(guildId: String?): List<ConfigDto?>? =
+            rows.values.filter { it.guildId == guildId }
+        override fun getConfigByName(name: String?, guildId: String?): ConfigDto? =
+            rows[name to guildId] ?: rows[(name ?: "") to "all"]
+        override fun createNewConfig(configDto: ConfigDto): ConfigDto? = configDto.also {
+            rows[(it.name ?: "") to (it.guildId ?: "")] = it
+        }
+        override fun updateConfig(configDto: ConfigDto?): ConfigDto? = configDto?.also {
+            rows[(it.name ?: "") to (it.guildId ?: "")] = it
+        }
+        override fun deleteAll(guildId: String?) { rows.entries.removeIf { it.key.second == guildId } }
+        override fun deleteConfig(guildId: String?, name: String?) { rows.remove((name ?: "") to (guildId ?: "")) }
+        override fun clearCache() {}
+        override fun upsertConfig(name: String, value: String, guildId: String): ConfigService.UpsertResult {
+            val key = name to guildId
+            val existing = rows[key]
+            rows[key] = ConfigDto(name = name, value = value, guildId = guildId)
+            return if (existing == null) {
+                ConfigService.UpsertResult.Created(rows[key]!!)
+            } else {
+                ConfigService.UpsertResult.Updated(rows[key]!!, previousValue = existing.value)
+            }
+        }
+    }
+}

--- a/discord-bot/build.gradle
+++ b/discord-bot/build.gradle
@@ -29,6 +29,11 @@ dependencies {
     implementation "dev.arbjerg:lavaplayer:$lavaplayer_version"
     implementation 'org.springframework.boot:spring-boot-starter-log4j2'
     implementation 'com.google.code.gson:gson:2.10.1'
+    // Used directly for the per-user message-XP cooldown cache in
+    // MessageChatListener. common already pulls Caffeine in via Spring
+    // Boot, but as an implementation dep it isn't on this module's
+    // compile classpath unless declared here.
+    implementation 'com.github.ben-manes.caffeine:caffeine'
     implementation "io.ktor:ktor-client-core:$ktor_version"
     implementation "io.ktor:ktor-client-cio:$ktor_version"
     implementation "io.ktor:ktor-client-okhttp:$ktor_version"

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/misc/LevelCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/misc/LevelCommand.kt
@@ -1,0 +1,67 @@
+package bot.toby.command.commands.misc
+
+import bot.toby.helpers.UserDtoHelper
+import common.leveling.LevelCurve
+import core.command.Command.Companion.replyAndDelete
+import core.command.Command.Companion.replyEphemeralAndDelete
+import core.command.CommandContext
+import database.dto.UserDto
+import net.dv8tion.jda.api.entities.Member
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
+import net.dv8tion.jda.api.interactions.commands.OptionType
+import net.dv8tion.jda.api.interactions.commands.build.OptionData
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+@Component
+class LevelCommand @Autowired constructor(
+    private val userDtoHelper: UserDtoHelper
+) : MiscCommand {
+
+    override fun handle(ctx: CommandContext, requestingUserDto: UserDto, deleteDelay: Int) {
+        val event = ctx.event
+        event.deferReply().queue()
+        val target: Member? = event.getOption(USER)?.asMember ?: event.member
+        if (target == null) {
+            event.hook.replyEphemeralAndDelete("Could not resolve a member.", deleteDelay)
+            return
+        }
+        printLevel(event, target, deleteDelay)
+    }
+
+    private fun printLevel(event: SlashCommandInteractionEvent, member: Member, deleteDelay: Int) {
+        val dto = userDtoHelper.calculateUserDto(member.idLong, member.guild.idLong)
+        val progress = LevelCurve.progress(dto.xp)
+        val body = buildString {
+            append("**").append(member.effectiveName).append("** — Level ")
+            append(progress.level).append('\n')
+            append(progressBar(progress.xpIntoLevel, progress.xpForNextLevel)).append(' ')
+            append(progress.xpIntoLevel).append(" / ").append(progress.xpForNextLevel).append(" XP\n")
+            append("Total XP: ").append(dto.xp)
+            if (progress.xpRemaining > 0) {
+                append(" — ").append(progress.xpRemaining).append(" XP to next level")
+            }
+        }
+        event.hook.replyAndDelete(body, deleteDelay)
+    }
+
+    private fun progressBar(into: Long, total: Long): String {
+        if (total <= 0L) return "[" + "█".repeat(BAR_WIDTH) + "]"
+        val filled = ((into.toDouble() / total) * BAR_WIDTH)
+            .toInt()
+            .coerceIn(0, BAR_WIDTH)
+        return "[" + "█".repeat(filled) + "░".repeat(BAR_WIDTH - filled) + "]"
+    }
+
+    override val name: String = "level"
+    override val description: String =
+        "Show your level and XP progress (or another member's if mentioned)."
+    override val optionData: List<OptionData> = listOf(
+        OptionData(OptionType.USER, USER, "Member to inspect (defaults to you)", false)
+    )
+
+    companion object {
+        private const val USER = "user"
+        private const val BAR_WIDTH = 20
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/misc/UserInfoCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/misc/UserInfoCommand.kt
@@ -2,6 +2,7 @@ package bot.toby.command.commands.misc
 
 import bot.toby.helpers.UserDtoHelper
 import bot.toby.helpers.UserDtoHelper.Companion.produceMusicFileDataStringForPrinting
+import common.leveling.LevelCurve
 import core.command.Command.Companion.replyEphemeralAndDelete
 import core.command.CommandContext
 import database.dto.UserDto
@@ -52,7 +53,9 @@ class UserInfoCommand @Autowired constructor(private val userDtoHelper: UserDtoH
         val userInfoMessage = userSearched.let {
             logger.info { " Found user '$it' from lookup " }
             val introMessage = produceMusicFileDataStringForPrinting(event.member!!, userSearched)
-            "Here are the permissions for '${this.effectiveName}': '${userSearched.getPermissionsAsString()}'. \n $introMessage"
+            val progress = LevelCurve.progress(userSearched.xp)
+            val levelLine = "Level ${progress.level} (${progress.xpIntoLevel}/${progress.xpForNextLevel} XP, total ${userSearched.xp})"
+            "Here are the permissions for '${this.effectiveName}': '${userSearched.getPermissionsAsString()}'. \n $levelLine \n $introMessage"
         }
         event.hook.replyEphemeralAndDelete(userInfoMessage, deleteDelay)
     }

--- a/discord-bot/src/main/kotlin/bot/toby/handler/MessageChatListener.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/handler/MessageChatListener.kt
@@ -1,10 +1,15 @@
 package bot.toby.handler
 
 import bot.toby.emote.Emotes
+import com.github.benmanes.caffeine.cache.Caffeine
 import common.logging.DiscordLogger
+import database.service.XpAwardService
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent
 import net.dv8tion.jda.api.hooks.ListenerAdapter
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
+import java.util.concurrent.ThreadLocalRandom
+import java.util.concurrent.TimeUnit
 
 /**
  * Chat-keyword reactions on plain (non-slash) messages: the "that's not
@@ -12,11 +17,25 @@ import org.springframework.stereotype.Service
  * mention-back canned response. Split out of the old
  * `MessageEventHandler` god-class so each interaction surface has its
  * own focused listener.
+ *
+ * Also the hook where messages grant XP — every non-bot message awards a
+ * random `MESSAGE_XP_MIN..MESSAGE_XP_MAX` chunk, subject to a per-user
+ * 60s cooldown (Tatsu/MEE6-style anti-spam) and the daily XP cap.
  */
 @Service
-class MessageChatListener : ListenerAdapter() {
+class MessageChatListener @Autowired constructor(
+    private val xpAwardService: XpAwardService
+) : ListenerAdapter() {
 
     private val logger: DiscordLogger = DiscordLogger.createLogger(this::class.java)
+
+    // (guildId, discordId) -> last-award timestamp. Caffeine evicts entries
+    // older than the cooldown so the map can't grow unbounded; size is also
+    // capped as a hard ceiling.
+    private val lastAwardAt = Caffeine.newBuilder()
+        .expireAfterWrite(MESSAGE_XP_COOLDOWN_SECONDS, TimeUnit.SECONDS)
+        .maximumSize(10_000)
+        .build<Pair<Long, Long>, Long>()
 
     override fun onMessageReceived(event: MessageReceivedEvent) {
         val message = event.message
@@ -27,6 +46,8 @@ class MessageChatListener : ListenerAdapter() {
             val guild = event.guild
             val member = event.member
             if (author.isBot || event.isWebhookMessage) return
+
+            awardMessageXp(event)
 
             val messageStringLowercase = message.contentRaw.lowercase()
 
@@ -63,5 +84,36 @@ class MessageChatListener : ListenerAdapter() {
             logger.setGuildContext(null)
             logger.warn("A message was sent by '${author.name}' in a DM context.")
         }
+    }
+
+    private fun awardMessageXp(event: MessageReceivedEvent) {
+        if (!event.isFromGuild) return
+        val guildId = event.guild.idLong
+        val discordId = event.author.idLong
+        val key = guildId to discordId
+        val now = System.currentTimeMillis()
+        val previous = lastAwardAt.getIfPresent(key)
+        if (previous != null && now - previous < MESSAGE_XP_COOLDOWN_SECONDS * 1000L) return
+        lastAwardAt.put(key, now)
+        val amount = ThreadLocalRandom.current().nextLong(MESSAGE_XP_MIN, MESSAGE_XP_MAX + 1)
+        xpAwardService.award(
+            discordId = discordId,
+            guildId = guildId,
+            amount = amount,
+            reason = "message",
+            channelId = event.channel.idLong
+        )
+    }
+
+    companion object {
+        // Per-user cooldown between message-XP grants. Matches the
+        // industry-standard 60s window so chat-active users still earn
+        // XP at a reasonable clip without rewarding one-word spam.
+        const val MESSAGE_XP_COOLDOWN_SECONDS: Long = 60L
+
+        // Inclusive bounds on the per-message XP grant. Randomising in a
+        // range keeps progression less mechanical.
+        const val MESSAGE_XP_MIN: Long = 15L
+        const val MESSAGE_XP_MAX: Long = 25L
     }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/handler/SlashCommandEventListener.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/handler/SlashCommandEventListener.kt
@@ -2,6 +2,7 @@ package bot.toby.handler
 
 import common.logging.DiscordLogger
 import core.managers.CommandManager
+import database.service.XpAwardService
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -15,6 +16,7 @@ import kotlin.coroutines.CoroutineContext
 @Service
 class SlashCommandEventListener @Autowired constructor(
     private val commandManager: CommandManager,
+    private val xpAwardService: XpAwardService,
 ) : ListenerAdapter(), CoroutineScope {
 
     private val job = SupervisorJob()
@@ -25,11 +27,29 @@ class SlashCommandEventListener @Autowired constructor(
         logger.setGuildAndMemberContext(event.guild, event.member)
         logger.info { "SlashCommandInteractionEvent '${event.name}' received" }
         if (event.user.isBot) return
+        val guildId = event.guild?.idLong
+        val channelId = event.channel?.idLong
         launch {
             logger.info { "Launching coroutine for '${event.name}'" }
             commandManager.handle(event)
         }.invokeOnCompletion {
             logger.info { "Finished coroutine for '${event.name}'" }
+            if (guildId != null) {
+                xpAwardService.award(
+                    discordId = event.user.idLong,
+                    guildId = guildId,
+                    amount = COMMAND_XP,
+                    reason = "slash-command:${event.name}",
+                    channelId = channelId
+                )
+            }
         }
+    }
+
+    companion object {
+        // Small XP grant per slash-command invocation. The daily XP cap
+        // (default 1000) prevents spam-farming while still letting active
+        // users meaningfully progress from command usage alone.
+        const val COMMAND_XP: Long = 5L
     }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/handler/VoiceEventHandler.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/handler/VoiceEventHandler.kt
@@ -14,6 +14,7 @@ import database.dto.ConfigDto.Configurations.DELETE_DELAY
 import database.dto.ConfigDto.Configurations.VOLUME
 import database.service.ConfigService
 import database.service.SocialCreditAwardService
+import database.service.XpAwardService
 import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.entities.channel.concrete.VoiceChannel
 import net.dv8tion.jda.api.entities.channel.middleman.AudioChannel
@@ -35,6 +36,7 @@ class VoiceEventHandler(
     private val voiceSessionLifecycle: VoiceSessionLifecycle,
     private val lastConnectedChannelTracker: LastConnectedChannelTracker,
     private val awardService: SocialCreditAwardService,
+    private val xpAwardService: XpAwardService,
     private val nowPlayingManager: NowPlayingManager,
 ) : ListenerAdapter() {
 
@@ -230,6 +232,12 @@ class VoiceEventHandler(
                 amount = INTRO_PLAY_CREDIT,
                 reason = "intro-play"
             )
+            xpAwardService.award(
+                discordId = requestingUserDto.discordId,
+                guildId = requestingUserDto.guildId,
+                amount = INTRO_PLAY_XP,
+                reason = "intro-play"
+            )
         } else {
             logger.info { "User has no musicDto associated with them, no intro will be played" }
         }
@@ -274,5 +282,10 @@ class VoiceEventHandler(
         // Small, daily-capped reward so joining a channel with an intro set
         // feels like something without becoming farmable via rejoin spam.
         const val INTRO_PLAY_CREDIT: Long = 2L
+
+        // XP grant for the same intro-play event. Slightly larger than the
+        // credit grant since the XP daily cap is much higher; this still
+        // sits well under the cap so a few intro plays in a day stack.
+        const val INTRO_PLAY_XP: Long = 10L
     }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/leveling/LevelUpListener.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/leveling/LevelUpListener.kt
@@ -1,0 +1,125 @@
+package bot.toby.leveling
+
+import common.events.LevelUpEvent
+import common.logging.DiscordLogger
+import database.dto.ConfigDto.Configurations.LEVEL_UP_CHANNEL
+import database.dto.TitleDto
+import database.service.ConfigService
+import database.service.LevelRoleRewardService
+import database.service.TitleService
+import net.dv8tion.jda.api.JDA
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.Role
+import net.dv8tion.jda.api.entities.UserSnowflake
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.annotation.Lazy
+import org.springframework.context.event.EventListener
+import org.springframework.stereotype.Service
+
+/**
+ * Consumer of [LevelUpEvent]. On a level-up:
+ *   1. Posts a short congratulatory message in the channel where the XP
+ *      was earned (or [LEVEL_UP_CHANNEL] / system channel for voice-only
+ *      events with no originating channel).
+ *   2. Assigns every configured role reward in `(oldLevel, newLevel]`.
+ *   3. Inserts ownership rows for any titles gated at `required_level`
+ *      values in `(oldLevel, newLevel]` so the user can equip them free.
+ *
+ * All Discord-side work is dispatched non-blockingly via JDA `.queue(...)`,
+ * so the synchronous event delivery doesn't stall the XP-award caller.
+ */
+@Service
+class LevelUpListener @Autowired constructor(
+    @Lazy private val jda: JDA,
+    private val configService: ConfigService,
+    private val levelRoleRewardService: LevelRoleRewardService,
+    private val titleService: TitleService
+) {
+    private val logger: DiscordLogger = DiscordLogger.createLogger(this::class.java)
+
+    @EventListener
+    fun onLevelUp(event: LevelUpEvent) {
+        val guild = jda.getGuildById(event.guildId) ?: run {
+            logger.warn("LevelUpEvent for guild ${event.guildId} but JDA has no matching guild; skipping.")
+            return
+        }
+        logger.setGuildContext(guild)
+        logger.info {
+            "User ${event.discordId} levelled up: ${event.oldLevel} -> ${event.newLevel}"
+        }
+        announce(guild, event)
+        assignRoleRewards(guild, event)
+        unlockTitles(event)
+    }
+
+    private fun announce(guild: Guild, event: LevelUpEvent) {
+        val channel = resolveAnnouncementChannel(guild, event.channelId) ?: run {
+            logger.info { "No announcement channel resolved for guild ${guild.idLong}; skipping level-up message." }
+            return
+        }
+        val mention = "<@${event.discordId}>"
+        val body = buildString {
+            append("GG ").append(mention).append(" — you reached **Level ")
+            append(event.newLevel).append("**!")
+        }
+        runCatching {
+            channel.sendMessage(body).queue(null) { err ->
+                logger.warn("Failed to post level-up announcement in #${channel.name}: ${err.message}")
+            }
+        }.onFailure {
+            logger.warn("Level-up announcement dispatch failed: ${it.message}")
+        }
+    }
+
+    private fun resolveAnnouncementChannel(guild: Guild, originId: Long?): TextChannel? {
+        val configured = configService
+            .getConfigByName(LEVEL_UP_CHANNEL.configValue, guild.id)?.value
+            ?.toLongOrNull()
+        configured?.let { id -> guild.getTextChannelById(id)?.let { return it } }
+        originId?.let { id -> guild.getTextChannelById(id)?.let { return it } }
+        return guild.systemChannel
+    }
+
+    private fun assignRoleRewards(guild: Guild, event: LevelUpEvent) {
+        val rewards = levelRoleRewardService.listInRange(
+            guildId = event.guildId,
+            fromExclusive = event.oldLevel,
+            toInclusive = event.newLevel
+        )
+        if (rewards.isEmpty()) return
+        // UserSnowflake lets us issue the add-role REST call without
+        // pre-fetching the member; JDA handles the 404 if they've left.
+        val target = UserSnowflake.fromId(event.discordId)
+        rewards.forEach { reward ->
+            val role: Role? = guild.getRoleById(reward.roleId)
+            if (role == null) {
+                logger.warn("Configured level-${reward.level} role ${reward.roleId} missing in guild ${guild.idLong}.")
+                return@forEach
+            }
+            runCatching {
+                guild.addRoleToMember(target, role).queue(null) { err ->
+                    logger.warn("Failed to assign role ${role.name} to ${event.discordId}: ${err.message}")
+                }
+            }.onFailure {
+                logger.warn("Role assignment dispatch failed for level ${reward.level}: ${it.message}")
+            }
+        }
+    }
+
+    private fun unlockTitles(event: LevelUpEvent) {
+        val titles = titleService.listAll()
+            .filter { it.requiredLevel > event.oldLevel && it.requiredLevel <= event.newLevel }
+        if (titles.isEmpty()) return
+        titles.forEach { title -> unlockOne(event.discordId, title) }
+    }
+
+    private fun unlockOne(discordId: Long, title: TitleDto) {
+        val titleId = title.id ?: return
+        if (titleService.owns(discordId, titleId)) return
+        runCatching { titleService.recordPurchase(discordId, titleId) }
+            .onFailure {
+                logger.warn("Failed to auto-unlock title '${title.label}' for user $discordId: ${it.message}")
+            }
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/scheduling/UniversalBasicIncomeJob.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/scheduling/UniversalBasicIncomeJob.kt
@@ -1,5 +1,6 @@
 package bot.toby.scheduling
 
+import common.leveling.LevelCurve
 import common.logging.DiscordLogger
 import database.dto.ConfigDto
 import database.dto.UbiDailyDto
@@ -48,8 +49,8 @@ class UniversalBasicIncomeJob @Autowired constructor(
     }
 
     private fun grantForGuild(guild: Guild, today: LocalDate) {
-        val amount = readUbiAmount(guild.id)
-        if (amount <= 0L) {
+        val baseAmount = readUbiAmount(guild.id)
+        if (baseAmount <= 0L) {
             logger.info { "UBI disabled or unset for guild ${guild.idLong}; skipping." }
             return
         }
@@ -60,6 +61,7 @@ class UniversalBasicIncomeJob @Autowired constructor(
             return
         }
 
+        val perLevelBonus = readPerLevelBonus(guild.id)
         var granted = 0
         var skipped = 0
         users.forEach { dto ->
@@ -69,6 +71,8 @@ class UniversalBasicIncomeJob @Autowired constructor(
                 skipped++
                 return@forEach
             }
+            val level = LevelCurve.levelForXp(dto.xp)
+            val amount = baseAmount + perLevelBonus * level
             val awarded = awardService.award(
                 discordId = discordId,
                 guildId = guildId,
@@ -90,7 +94,7 @@ class UniversalBasicIncomeJob @Autowired constructor(
             }
         }
         logger.info {
-            "UBI for guild ${guild.idLong}: granted=$granted alreadyGranted=$skipped amount=$amount"
+            "UBI for guild ${guild.idLong}: granted=$granted alreadyGranted=$skipped base=$baseAmount perLevelBonus=$perLevelBonus"
         }
     }
 
@@ -100,5 +104,18 @@ class UniversalBasicIncomeJob @Autowired constructor(
             guildId
         )?.value
         return raw?.toLongOrNull()?.coerceAtLeast(0L) ?: 0L
+    }
+
+    private fun readPerLevelBonus(guildId: String): Long {
+        val raw = configService.getConfigByName(
+            ConfigDto.Configurations.UBI_PER_LEVEL_BONUS.configValue,
+            guildId
+        )?.value
+        return raw?.toLongOrNull()?.coerceAtLeast(0L) ?: DEFAULT_UBI_PER_LEVEL_BONUS
+    }
+
+    companion object {
+        // Fallback when UBI_PER_LEVEL_BONUS is unset or unparseable.
+        const val DEFAULT_UBI_PER_LEVEL_BONUS: Long = 5L
     }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/voice/VoiceCreditAwardService.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/voice/VoiceCreditAwardService.kt
@@ -4,6 +4,7 @@ import common.logging.DiscordLogger
 import database.dto.VoiceSessionDto
 import database.service.SocialCreditAwardService
 import database.service.VoiceSessionService
+import database.service.XpAwardService
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
 import java.time.Duration
@@ -12,7 +13,8 @@ import java.time.Instant
 @Service
 class VoiceCreditAwardService @Autowired constructor(
     private val voiceSessionService: VoiceSessionService,
-    private val awardService: SocialCreditAwardService
+    private val awardService: SocialCreditAwardService,
+    private val xpAwardService: XpAwardService
 ) {
     private val logger: DiscordLogger = DiscordLogger.createLogger(this::class.java)
 
@@ -29,6 +31,17 @@ class VoiceCreditAwardService @Autowired constructor(
             discordId = session.discordId,
             guildId = session.guildId,
             amount = rawCredits,
+            reason = "voice-session",
+            at = closedAt
+        )
+
+        // Voice XP scales the same way as voice credit, just at a higher
+        // rate so the leveling track moves at roughly the XP daily cap.
+        val rawXp = countedSeconds / VoiceCreditConfig.SECONDS_PER_CREDIT * VOICE_XP_PER_CREDIT
+        xpAwardService.award(
+            discordId = session.discordId,
+            guildId = session.guildId,
+            amount = rawXp,
             reason = "voice-session",
             at = closedAt
         )
@@ -72,5 +85,11 @@ class VoiceCreditAwardService @Autowired constructor(
     fun closeSessionAtShutdown(session: VoiceSessionDto, closedAt: Instant) {
         val rawSeconds = Duration.between(session.joinedAt, closedAt).seconds.coerceAtLeast(0)
         closeSessionAndAward(session, closedAt, rawSeconds)
+    }
+
+    companion object {
+        // Multiplier on the social-credit grant: every credit a voice
+        // session earns also grants this much XP.
+        const val VOICE_XP_PER_CREDIT: Long = 5L
     }
 }

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/misc/LevelCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/misc/LevelCommandTest.kt
@@ -1,0 +1,72 @@
+package bot.toby.command.commands.misc
+
+import bot.toby.command.CommandTest
+import bot.toby.command.CommandTest.Companion.event
+import bot.toby.command.CommandTest.Companion.member
+import bot.toby.command.CommandTest.Companion.webhookMessageCreateAction
+import bot.toby.command.DefaultCommandContext
+import bot.toby.helpers.UserDtoHelper
+import database.dto.UserDto
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import net.dv8tion.jda.api.interactions.commands.OptionMapping
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class LevelCommandTest : CommandTest {
+    private lateinit var userDtoHelper: UserDtoHelper
+    private lateinit var levelCommand: LevelCommand
+
+    @BeforeEach
+    fun setUp() {
+        setUpCommonMocks()
+        userDtoHelper = mockk()
+        levelCommand = LevelCommand(userDtoHelper)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        tearDownCommonMocks()
+    }
+
+    @Test
+    fun `level command renders the user's level and progress`() {
+        every { event.getOption("user") } returns null
+        val dto = UserDto(discordId = 1L, guildId = 1L).apply { xp = 300L }
+        every { userDtoHelper.calculateUserDto(any(), any()) } returns dto
+
+        val captured = slot<String>()
+        every { event.hook.sendMessage(capture(captured)) } returns webhookMessageCreateAction
+
+        levelCommand.handle(DefaultCommandContext(event), dto, 0)
+
+        verify(exactly = 1) { event.hook.sendMessage(any<String>()) }
+        // 300 XP -> level 2, 45/220 into that level.
+        assertTrue(captured.captured.contains("Level 2"))
+        assertTrue(captured.captured.contains("45 / 220 XP"))
+        assertTrue(captured.captured.contains("Total XP: 300"))
+    }
+
+    @Test
+    fun `level command inspects another member when one is mentioned`() {
+        val option = mockk<OptionMapping>()
+        every { event.getOption("user") } returns option
+        every { option.asMember } returns member
+        val dto = UserDto(discordId = 1L, guildId = 1L).apply { xp = 99L }
+        every { userDtoHelper.calculateUserDto(any(), any()) } returns dto
+
+        val captured = slot<String>()
+        every { event.hook.sendMessage(capture(captured)) } returns webhookMessageCreateAction
+
+        levelCommand.handle(DefaultCommandContext(event), dto, 0)
+
+        // Just under the first threshold (100 XP) -> still level 0 with 99/100.
+        assertTrue(captured.captured.contains("Level 0"))
+        assertTrue(captured.captured.contains("99 / 100 XP"))
+        assertTrue(captured.captured.contains("Effective Name"))
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/misc/UserInfoCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/misc/UserInfoCommandTest.kt
@@ -60,6 +60,7 @@ class UserInfoCommandTest : CommandTest {
         // Verify interactions
         verify(exactly = 1) {
             event.hook.sendMessage("Here are the permissions for 'Effective Name': 'MUSIC: true, MEME: true, DIG: true, SUPERUSER: true'. \n" +
+                    " Level 0 (0/100 XP, total 0) \n" +
                     " There is no valid intro music file associated with user Effective Name.")
         }
         verify(exactly = 1) {

--- a/discord-bot/src/test/kotlin/bot/toby/handler/MessageChatListenerTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/handler/MessageChatListenerTest.kt
@@ -1,6 +1,7 @@
 package bot.toby.handler
 
 import bot.toby.emote.Emotes
+import database.service.XpAwardService
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.spyk
@@ -19,7 +20,8 @@ import io.mockk.junit5.MockKExtension
 @ExtendWith(MockKExtension::class)
 class MessageChatListenerTest {
 
-    private val listener = spyk(MessageChatListener())
+    private val xpAwardService: XpAwardService = mockk(relaxed = true)
+    private val listener = spyk(MessageChatListener(xpAwardService))
 
     @Test
     fun `onMessageReceived should respond correctly to toby message`() {
@@ -37,6 +39,10 @@ class MessageChatListenerTest {
         every { event.member } returns member
         every { author.isBot } returns false
         every { event.isWebhookMessage } returns false
+        every { event.isFromGuild } returns true
+        every { guild.idLong } returns 1L
+        every { author.idLong } returns 2L
+        every { channel.idLong } returns 3L
         every { message.contentRaw } returns "toby"
         every { member.effectiveName } returns "Matt"
 
@@ -72,6 +78,10 @@ class MessageChatListenerTest {
         every { event.member } returns member
         every { author.isBot } returns false
         every { event.isWebhookMessage } returns false
+        every { event.isFromGuild } returns true
+        every { guild.idLong } returns 1L
+        every { author.idLong } returns 2L
+        every { channel.idLong } returns 3L
         every { message.contentRaw } returns "sigh"
         every { member.effectiveName } returns "Matt"
 
@@ -105,6 +115,10 @@ class MessageChatListenerTest {
         every { event.member } returns member
         every { author.isBot } returns false
         every { event.isWebhookMessage } returns false
+        every { event.isFromGuild } returns true
+        every { guild.idLong } returns 1L
+        every { author.idLong } returns 2L
+        every { channel.idLong } returns 3L
         every { message.contentRaw } returns "yeah"
 
         every { channel.sendMessage("YEAH????").queue() } returns mockk()

--- a/discord-bot/src/test/kotlin/bot/toby/handler/VoiceEventHandlerTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/handler/VoiceEventHandlerTest.kt
@@ -9,6 +9,7 @@ import database.dto.ConfigDto
 import database.dto.MusicDto
 import database.service.ConfigService
 import database.service.SocialCreditAwardService
+import database.service.XpAwardService
 import io.mockk.*
 import io.mockk.junit5.MockKExtension
 import net.dv8tion.jda.api.JDA
@@ -41,6 +42,7 @@ class VoiceEventHandlerTest {
     private val voiceSessionLifecycle: VoiceSessionLifecycle = mockk(relaxed = true)
     private val lastConnectedChannelTracker: LastConnectedChannelTracker = LastConnectedChannelTracker()
     private val awardService: SocialCreditAwardService = mockk(relaxed = true)
+    private val xpAwardService: XpAwardService = mockk(relaxed = true)
     private val nowPlayingManager: NowPlayingManager = mockk(relaxed = true)
 
     private val handler = spyk(
@@ -51,6 +53,7 @@ class VoiceEventHandlerTest {
             voiceSessionLifecycle,
             lastConnectedChannelTracker,
             awardService,
+            xpAwardService,
             nowPlayingManager,
         )
     )
@@ -133,6 +136,7 @@ class VoiceEventHandlerTest {
             voiceSessionLifecycle = mockk(relaxed = true),
             lastConnectedChannelTracker = LastConnectedChannelTracker(),
             awardService = mockk(relaxed = true),
+            xpAwardService = mockk(relaxed = true),
             nowPlayingManager = mockk(relaxed = true),
         )
 
@@ -179,6 +183,7 @@ class VoiceEventHandlerTest {
             voiceSessionLifecycle = voiceSessionLifecycle,
             lastConnectedChannelTracker = LastConnectedChannelTracker(),
             awardService = mockk(relaxed = true),
+            xpAwardService = mockk(relaxed = true),
             nowPlayingManager = mockk(relaxed = true),
         )
 

--- a/discord-bot/src/test/kotlin/bot/toby/leveling/LevelUpListenerTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/leveling/LevelUpListenerTest.kt
@@ -1,0 +1,191 @@
+package bot.toby.leveling
+
+import common.events.LevelUpEvent
+import database.dto.LevelRoleRewardDto
+import database.dto.TitleDto
+import database.service.ConfigService
+import database.service.LevelRoleRewardService
+import database.service.TitleService
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import net.dv8tion.jda.api.JDA
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.Role
+import net.dv8tion.jda.api.entities.UserSnowflake
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
+import net.dv8tion.jda.api.requests.restaction.AuditableRestAction
+import net.dv8tion.jda.api.requests.restaction.MessageCreateAction
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class LevelUpListenerTest {
+
+    private lateinit var jda: JDA
+    private lateinit var configService: ConfigService
+    private lateinit var levelRoleRewardService: LevelRoleRewardService
+    private lateinit var titleService: TitleService
+    private lateinit var listener: LevelUpListener
+
+    private val guildId = 7L
+    private val discordId = 100L
+
+    @BeforeEach
+    fun setUp() {
+        jda = mockk(relaxed = true)
+        configService = mockk(relaxed = true)
+        levelRoleRewardService = mockk(relaxed = true)
+        titleService = mockk(relaxed = true)
+        listener = LevelUpListener(jda, configService, levelRoleRewardService, titleService)
+    }
+
+    @Test
+    fun `onLevelUp posts announcement in the origin channel when present`() {
+        val guild = mockk<Guild>(relaxed = true)
+        val channel = mockk<TextChannel>(relaxed = true)
+        val createAction = mockk<MessageCreateAction>(relaxed = true)
+        every { jda.getGuildById(guildId) } returns guild
+        every { guild.idLong } returns guildId
+        every { guild.id } returns guildId.toString()
+        every { guild.getTextChannelById(99L) } returns channel
+        every { channel.name } returns "general"
+        every { channel.sendMessage(any<String>()) } returns createAction
+        every { configService.getConfigByName(any(), any()) } returns null
+        every { levelRoleRewardService.listInRange(any(), any(), any()) } returns emptyList()
+        every { titleService.listAll() } returns emptyList()
+
+        listener.onLevelUp(
+            LevelUpEvent(
+                discordId = discordId, guildId = guildId,
+                oldLevel = 0, newLevel = 1, channelId = 99L
+            )
+        )
+
+        val sent = slot<String>()
+        verify { channel.sendMessage(capture(sent)) }
+        assert(sent.captured.contains("Level 1"))
+        assert(sent.captured.contains("<@$discordId>"))
+    }
+
+    @Test
+    fun `onLevelUp falls back to system channel when no origin channel`() {
+        val guild = mockk<Guild>(relaxed = true)
+        val systemChannel = mockk<TextChannel>(relaxed = true)
+        val createAction = mockk<MessageCreateAction>(relaxed = true)
+        every { jda.getGuildById(guildId) } returns guild
+        every { guild.idLong } returns guildId
+        every { guild.id } returns guildId.toString()
+        every { guild.systemChannel } returns systemChannel
+        every { systemChannel.name } returns "general"
+        every { systemChannel.sendMessage(any<String>()) } returns createAction
+        every { configService.getConfigByName(any(), any()) } returns null
+        every { levelRoleRewardService.listInRange(any(), any(), any()) } returns emptyList()
+        every { titleService.listAll() } returns emptyList()
+
+        listener.onLevelUp(
+            LevelUpEvent(discordId, guildId, oldLevel = 0, newLevel = 1, channelId = null)
+        )
+
+        verify { systemChannel.sendMessage(any<String>()) }
+    }
+
+    @Test
+    fun `onLevelUp assigns every role in the level range`() {
+        val guild = mockk<Guild>(relaxed = true)
+        val channel = mockk<TextChannel>(relaxed = true)
+        val createAction = mockk<MessageCreateAction>(relaxed = true)
+        val role1 = mockk<Role>(relaxed = true)
+        val role2 = mockk<Role>(relaxed = true)
+        val addRoleAction = mockk<AuditableRestAction<Void>>(relaxed = true)
+
+        every { jda.getGuildById(guildId) } returns guild
+        every { guild.idLong } returns guildId
+        every { guild.id } returns guildId.toString()
+        every { guild.getTextChannelById(any()) } returns channel
+        every { channel.sendMessage(any<String>()) } returns createAction
+        every { configService.getConfigByName(any(), any()) } returns null
+        every { titleService.listAll() } returns emptyList()
+        every { levelRoleRewardService.listInRange(guildId, fromExclusive = 1, toInclusive = 3) } returns listOf(
+            LevelRoleRewardDto(guildId = guildId, level = 2, roleId = 201L),
+            LevelRoleRewardDto(guildId = guildId, level = 3, roleId = 202L)
+        )
+        every { guild.getRoleById(201L) } returns role1
+        every { guild.getRoleById(202L) } returns role2
+        every { role1.name } returns "Regular"
+        every { role2.name } returns "Veteran"
+        every { guild.addRoleToMember(any<UserSnowflake>(), any()) } returns addRoleAction
+
+        listener.onLevelUp(
+            LevelUpEvent(discordId, guildId, oldLevel = 1, newLevel = 3, channelId = 99L)
+        )
+
+        verify(exactly = 1) { guild.addRoleToMember(any<UserSnowflake>(), role1) }
+        verify(exactly = 1) { guild.addRoleToMember(any<UserSnowflake>(), role2) }
+    }
+
+    @Test
+    fun `onLevelUp unlocks titles whose requiredLevel falls in the range`() {
+        val guild = mockk<Guild>(relaxed = true)
+        val channel = mockk<TextChannel>(relaxed = true)
+        val createAction = mockk<MessageCreateAction>(relaxed = true)
+
+        every { jda.getGuildById(guildId) } returns guild
+        every { guild.idLong } returns guildId
+        every { guild.id } returns guildId.toString()
+        every { guild.getTextChannelById(any()) } returns channel
+        every { channel.sendMessage(any<String>()) } returns createAction
+        every { configService.getConfigByName(any(), any()) } returns null
+        every { levelRoleRewardService.listInRange(any(), any(), any()) } returns emptyList()
+
+        val gated = TitleDto(id = 10L, label = "Gated", cost = 0L).apply { requiredLevel = 2 }
+        val higher = TitleDto(id = 11L, label = "Higher", cost = 0L).apply { requiredLevel = 5 }
+        val ungated = TitleDto(id = 12L, label = "Free", cost = 0L)
+        every { titleService.listAll() } returns listOf(gated, higher, ungated)
+        every { titleService.owns(discordId, 10L) } returns false
+
+        listener.onLevelUp(
+            LevelUpEvent(discordId, guildId, oldLevel = 1, newLevel = 3, channelId = 99L)
+        )
+
+        verify(exactly = 1) { titleService.recordPurchase(discordId, 10L) }
+        verify(exactly = 0) { titleService.recordPurchase(discordId, 11L) }
+        verify(exactly = 0) { titleService.recordPurchase(discordId, 12L) }
+    }
+
+    @Test
+    fun `onLevelUp skips title unlock when the user already owns it`() {
+        val guild = mockk<Guild>(relaxed = true)
+        val channel = mockk<TextChannel>(relaxed = true)
+        val createAction = mockk<MessageCreateAction>(relaxed = true)
+
+        every { jda.getGuildById(guildId) } returns guild
+        every { guild.idLong } returns guildId
+        every { guild.id } returns guildId.toString()
+        every { guild.getTextChannelById(any()) } returns channel
+        every { channel.sendMessage(any<String>()) } returns createAction
+        every { configService.getConfigByName(any(), any()) } returns null
+        every { levelRoleRewardService.listInRange(any(), any(), any()) } returns emptyList()
+
+        val gated = TitleDto(id = 10L, label = "Gated", cost = 0L).apply { requiredLevel = 2 }
+        every { titleService.listAll() } returns listOf(gated)
+        every { titleService.owns(discordId, 10L) } returns true
+
+        listener.onLevelUp(
+            LevelUpEvent(discordId, guildId, oldLevel = 1, newLevel = 3, channelId = 99L)
+        )
+
+        verify(exactly = 0) { titleService.recordPurchase(any(), any()) }
+    }
+
+    @Test
+    fun `onLevelUp returns silently when guild is gone from JDA`() {
+        every { jda.getGuildById(guildId) } returns null
+
+        listener.onLevelUp(
+            LevelUpEvent(discordId, guildId, oldLevel = 0, newLevel = 1, channelId = 99L)
+        )
+
+        verify(exactly = 0) { titleService.recordPurchase(any(), any()) }
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/leveling/LevelUpListenerTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/leveling/LevelUpListenerTest.kt
@@ -102,7 +102,7 @@ class LevelUpListenerTest {
         every { jda.getGuildById(guildId) } returns guild
         every { guild.idLong } returns guildId
         every { guild.id } returns guildId.toString()
-        every { guild.getTextChannelById(any()) } returns channel
+        every { guild.getTextChannelById(any<Long>()) } returns channel
         every { channel.sendMessage(any<String>()) } returns createAction
         every { configService.getConfigByName(any(), any()) } returns null
         every { titleService.listAll() } returns emptyList()
@@ -133,7 +133,7 @@ class LevelUpListenerTest {
         every { jda.getGuildById(guildId) } returns guild
         every { guild.idLong } returns guildId
         every { guild.id } returns guildId.toString()
-        every { guild.getTextChannelById(any()) } returns channel
+        every { guild.getTextChannelById(any<Long>()) } returns channel
         every { channel.sendMessage(any<String>()) } returns createAction
         every { configService.getConfigByName(any(), any()) } returns null
         every { levelRoleRewardService.listInRange(any(), any(), any()) } returns emptyList()
@@ -162,7 +162,7 @@ class LevelUpListenerTest {
         every { jda.getGuildById(guildId) } returns guild
         every { guild.idLong } returns guildId
         every { guild.id } returns guildId.toString()
-        every { guild.getTextChannelById(any()) } returns channel
+        every { guild.getTextChannelById(any<Long>()) } returns channel
         every { channel.sendMessage(any<String>()) } returns createAction
         every { configService.getConfigByName(any(), any()) } returns null
         every { levelRoleRewardService.listInRange(any(), any(), any()) } returns emptyList()

--- a/discord-bot/src/test/kotlin/bot/toby/voice/VoiceCreditAwardServiceTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/voice/VoiceCreditAwardServiceTest.kt
@@ -3,6 +3,7 @@ package bot.toby.voice
 import database.dto.VoiceSessionDto
 import database.service.SocialCreditAwardService
 import database.service.VoiceSessionService
+import database.service.XpAwardService
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
@@ -17,6 +18,7 @@ class VoiceCreditAwardServiceTest {
 
     private lateinit var voiceSessionService: VoiceSessionService
     private lateinit var awardService: SocialCreditAwardService
+    private lateinit var xpAwardService: XpAwardService
     private lateinit var service: VoiceCreditAwardService
 
     private val discordId = 1L
@@ -26,7 +28,8 @@ class VoiceCreditAwardServiceTest {
     fun setup() {
         voiceSessionService = mockk(relaxed = true)
         awardService = mockk(relaxed = true)
-        service = VoiceCreditAwardService(voiceSessionService, awardService)
+        xpAwardService = mockk(relaxed = true)
+        service = VoiceCreditAwardService(voiceSessionService, awardService, xpAwardService)
     }
 
     private fun session(joinedAt: Instant): VoiceSessionDto {

--- a/web/src/main/kotlin/web/service/ModerationWebService.kt
+++ b/web/src/main/kotlin/web/service/ModerationWebService.kt
@@ -956,6 +956,34 @@ class ModerationWebService(
                 if (n !in 0..10000) return "Value must be between 0 and 10000 (default 90)."
                 n.toString()
             }
+            ConfigDto.Configurations.DAILY_XP_CAP -> {
+                val n = rawValue.trim().toIntOrNull()
+                    ?: return "Value must be a whole number (0-100000)."
+                if (n !in 0..100000) return "Value must be between 0 and 100000 (default 1000)."
+                n.toString()
+            }
+            ConfigDto.Configurations.DAILY_CAP_PER_LEVEL_BONUS -> {
+                val n = rawValue.trim().toIntOrNull()
+                    ?: return "Value must be a whole number (0-1000)."
+                if (n !in 0..1000) return "Value must be between 0 and 1000 (default 10; 0 disables the perk)."
+                n.toString()
+            }
+            ConfigDto.Configurations.UBI_PER_LEVEL_BONUS -> {
+                val n = rawValue.trim().toIntOrNull()
+                    ?: return "Value must be a whole number (0-1000)."
+                if (n !in 0..1000) return "Value must be between 0 and 1000 (default 5; 0 disables the perk)."
+                n.toString()
+            }
+            ConfigDto.Configurations.LEVEL_UP_CHANNEL -> {
+                val id = rawValue.trim()
+                if (id.isEmpty()) return "Channel id is required."
+                val idLong = id.toLongOrNull()
+                    ?: return "Channel id must be numeric."
+                if (guild.getTextChannelById(idLong) == null) {
+                    return "No text channel with that id exists in this server."
+                }
+                id
+            }
             ConfigDto.Configurations.JACKPOT_WHEEL_SEGMENTS -> {
                 // Empty resets to default. Otherwise must parse cleanly via
                 // [JackpotWheel.validateConfigString] — the live reader uses

--- a/web/src/main/kotlin/web/service/ProfileWebService.kt
+++ b/web/src/main/kotlin/web/service/ProfileWebService.kt
@@ -1,5 +1,6 @@
 package web.service
 
+import common.leveling.LevelCurve
 import database.dto.UserDto
 import database.service.TitleService
 import database.service.UserService
@@ -52,6 +53,8 @@ class ProfileWebService(
             }
             .sortedBy { it.label.lowercase() }
 
+        val xp = user?.xp ?: 0L
+        val progress = LevelCurve.progress(xp)
         return ProfileView(
             guildId = guild.id,
             guildName = guild.name,
@@ -59,6 +62,13 @@ class ProfileWebService(
             avatarUrl = member.effectiveAvatarUrl,
             isOwner = member.isOwner,
             balance = user?.socialCredit ?: 0L,
+            level = progress.level,
+            xp = xp,
+            xpIntoLevel = progress.xpIntoLevel,
+            xpForNextLevel = progress.xpForNextLevel,
+            xpProgressPercent = if (progress.xpForNextLevel > 0)
+                ((progress.xpIntoLevel.toDouble() / progress.xpForNextLevel) * 100).toInt().coerceIn(0, 100)
+            else 100,
             equippedTitleLabel = equippedTitle?.label,
             equippedTitleColorHex = equippedTitle?.colorHex,
             ownedTitles = ownedTitles,
@@ -90,6 +100,11 @@ data class ProfileView(
     val avatarUrl: String?,
     val isOwner: Boolean,
     val balance: Long,
+    val level: Int,
+    val xp: Long,
+    val xpIntoLevel: Long,
+    val xpForNextLevel: Long,
+    val xpProgressPercent: Int,
     val equippedTitleLabel: String?,
     val equippedTitleColorHex: String?,
     val ownedTitles: List<ProfileTitleEntry>,

--- a/web/src/main/resources/static/css/profile.css
+++ b/web/src/main/resources/static/css/profile.css
@@ -100,3 +100,15 @@
     background: var(--accent-soft);
     color: var(--accent);
 }
+.profile-progress {
+    margin: var(--space-2) 0;
+    background: var(--border);
+    border-radius: 999px;
+    height: 10px;
+    overflow: hidden;
+}
+.profile-progress-bar {
+    background: var(--accent);
+    height: 100%;
+    transition: width 0.3s ease;
+}

--- a/web/src/main/resources/static/css/profile.css
+++ b/web/src/main/resources/static/css/profile.css
@@ -100,15 +100,128 @@
     background: var(--accent-soft);
     color: var(--accent);
 }
-.profile-progress {
-    margin: var(--space-2) 0;
-    background: var(--border);
+/* ----- Level card ----- */
+.level-card {
+    position: relative;
+    overflow: hidden;
+    background:
+        radial-gradient(circle at top right, var(--level-tier-glow, transparent) 0%, transparent 60%),
+        var(--bg-elevated);
+    border-color: var(--level-tier-border, var(--border));
+}
+.level-tier-bronze {
+    --level-tier-from: #c9803a;
+    --level-tier-to: #e6a86b;
+    --level-tier-glow: rgba(201, 128, 58, 0.18);
+    --level-tier-border: #4a3525;
+}
+.level-tier-silver {
+    --level-tier-from: #9aa3b2;
+    --level-tier-to: #d3dae6;
+    --level-tier-glow: rgba(154, 163, 178, 0.18);
+    --level-tier-border: #3a3f4a;
+}
+.level-tier-gold {
+    --level-tier-from: #d4a017;
+    --level-tier-to: #ffd966;
+    --level-tier-glow: rgba(212, 160, 23, 0.22);
+    --level-tier-border: #4a3a15;
+}
+.level-tier-diamond {
+    --level-tier-from: #5865f2;
+    --level-tier-to: #a6b1ff;
+    --level-tier-glow: rgba(88, 101, 242, 0.28);
+    --level-tier-border: #2a3580;
+}
+
+.level-hero {
+    display: flex;
+    align-items: center;
+    gap: var(--space-4);
+}
+.level-badge {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    width: 72px;
+    height: 72px;
+    flex-shrink: 0;
+    border-radius: 50%;
+    background: linear-gradient(135deg, var(--level-tier-from) 0%, var(--level-tier-to) 100%);
+    box-shadow:
+        0 0 0 4px var(--bg-elevated),
+        0 0 0 5px var(--level-tier-border, var(--border-strong)),
+        0 8px 24px rgba(0, 0, 0, 0.35);
+    color: #1a1a2e;
+}
+.level-badge-label {
+    font-size: 0.65rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    opacity: 0.7;
+    line-height: 1;
+}
+.level-badge-value {
+    font-size: 1.6rem;
+    font-weight: 800;
+    line-height: 1;
+    margin-top: 2px;
+    font-variant-numeric: tabular-nums;
+}
+
+.level-meta {
+    flex: 1;
+    min-width: 0;
+}
+.level-progress-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    margin-bottom: var(--space-2);
+    font-size: 0.85rem;
+    font-variant-numeric: tabular-nums;
+}
+.level-current {
+    color: var(--text);
+    font-weight: 600;
+}
+.level-next {
+    color: var(--text-muted);
+}
+.level-progress {
+    background: var(--bg);
+    border: 1px solid var(--border);
     border-radius: 999px;
     height: 10px;
     overflow: hidden;
+    position: relative;
 }
-.profile-progress-bar {
-    background: var(--accent);
+.level-progress-bar {
     height: 100%;
-    transition: width 0.3s ease;
+    border-radius: 999px;
+    background: linear-gradient(90deg, var(--level-tier-from) 0%, var(--level-tier-to) 100%);
+    transition: width 0.4s cubic-bezier(0.22, 0.61, 0.36, 1);
+    box-shadow: 0 0 12px var(--level-tier-glow, transparent);
+}
+.level-footer {
+    margin-top: var(--space-3);
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    font-size: 0.85rem;
+}
+.level-total-xp {
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
+}
+
+@media (max-width: 480px) {
+    .level-badge {
+        width: 60px;
+        height: 60px;
+    }
+    .level-badge-value {
+        font-size: 1.35rem;
+    }
 }

--- a/web/src/main/resources/templates/moderation/settings.html
+++ b/web/src/main/resources/templates/moderation/settings.html
@@ -166,6 +166,37 @@
                            th:disabled="${!isOwner}">
                     <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
                 </div>
+                <div class="config-row" data-key="DAILY_XP_CAP">
+                    <label>Daily XP cap (per-user ceiling for engagement XP; default 1000)</label>
+                    <input type="number" min="0" max="100000"
+                           th:value="${overview.config['DAILY_XP_CAP']}"
+                           placeholder="1000"
+                           th:disabled="${!isOwner}">
+                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                </div>
+                <div class="config-row" data-key="DAILY_CAP_PER_LEVEL_BONUS">
+                    <label>Daily credit cap bonus per level (default +10/level; 0 disables the perk)</label>
+                    <input type="number" min="0" max="1000"
+                           th:value="${overview.config['DAILY_CAP_PER_LEVEL_BONUS']}"
+                           placeholder="10"
+                           th:disabled="${!isOwner}">
+                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                </div>
+                <div class="config-row" data-key="UBI_PER_LEVEL_BONUS">
+                    <label>UBI bonus per level (extra credits per level on each daily UBI grant; 0 disables)</label>
+                    <input type="number" min="0" max="1000"
+                           th:value="${overview.config['UBI_PER_LEVEL_BONUS']}"
+                           placeholder="5"
+                           th:disabled="${!isOwner}">
+                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                </div>
+                <div class="config-row" data-key="LEVEL_UP_CHANNEL">
+                    <label>Level-up announcement channel id (optional override; defaults to message/command channel)</label>
+                    <input type="text" th:value="${overview.config['LEVEL_UP_CHANNEL']}"
+                           placeholder="(channel id)"
+                           th:disabled="${!isOwner}">
+                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                </div>
                 <div class="config-row" data-key="TRADE_BUY_FEE_PCT">
                     <label>Toby Coin BUY fee (% per leg, routed to jackpot pool)</label>
                     <span class="config-input-group">

--- a/web/src/main/resources/templates/profile.html
+++ b/web/src/main/resources/templates/profile.html
@@ -46,6 +46,26 @@
         </section>
 
         <section class="profile-card">
+            <h2>Level</h2>
+            <div class="profile-row">
+                <span class="muted">Current level</span>
+                <strong th:text="'Level ' + ${profile.level}">Level 0</strong>
+            </div>
+            <div class="profile-row">
+                <span class="muted">XP this level</span>
+                <span th:text="${profile.xpIntoLevel} + ' / ' + ${profile.xpForNextLevel}">0 / 100</span>
+            </div>
+            <div class="profile-progress">
+                <div class="profile-progress-bar"
+                     th:style="'width: ' + ${profile.xpProgressPercent} + '%'"></div>
+            </div>
+            <div class="profile-row">
+                <span class="muted">Total XP</span>
+                <span th:text="${profile.xp}">0</span>
+            </div>
+        </section>
+
+        <section class="profile-card">
             <h2>Permissions</h2>
             <ul class="profile-perms">
                 <li th:each="p : ${profile.permissions}">

--- a/web/src/main/resources/templates/profile.html
+++ b/web/src/main/resources/templates/profile.html
@@ -45,23 +45,29 @@
             <a class="btn profile-action" th:href="@{/titles/{id}(id=${profile.guildId})}">Go to title shop &rarr;</a>
         </section>
 
-        <section class="profile-card">
+        <section class="profile-card level-card" th:classappend="'level-tier-' + (${profile.level} >= 50 ? 'diamond' : (${profile.level} >= 25 ? 'gold' : (${profile.level} >= 10 ? 'silver' : 'bronze')))">
             <h2>Level</h2>
-            <div class="profile-row">
-                <span class="muted">Current level</span>
-                <strong th:text="'Level ' + ${profile.level}">Level 0</strong>
-            </div>
-            <div class="profile-row">
-                <span class="muted">XP this level</span>
-                <span th:text="${profile.xpIntoLevel} + ' / ' + ${profile.xpForNextLevel}">0 / 100</span>
-            </div>
-            <div class="profile-progress">
-                <div class="profile-progress-bar"
-                     th:style="'width: ' + ${profile.xpProgressPercent} + '%'"></div>
-            </div>
-            <div class="profile-row">
-                <span class="muted">Total XP</span>
-                <span th:text="${profile.xp}">0</span>
+            <div class="level-hero">
+                <div class="level-badge">
+                    <span class="level-badge-label">LVL</span>
+                    <span class="level-badge-value" th:text="${profile.level}">0</span>
+                </div>
+                <div class="level-meta">
+                    <div class="level-progress-row">
+                        <span class="level-current" th:text="${profile.xpIntoLevel} + ' XP'">0 XP</span>
+                        <span class="level-next" th:text="${profile.xpForNextLevel} + ' XP'">100 XP</span>
+                    </div>
+                    <div class="level-progress" role="progressbar"
+                         th:attr="aria-valuenow=${profile.xpProgressPercent},aria-valuemin=0,aria-valuemax=100"
+                         th:attrappend="aria-label='Progress to next level'">
+                        <div class="level-progress-bar"
+                             th:style="'width: ' + ${profile.xpProgressPercent} + '%'"></div>
+                    </div>
+                    <div class="level-footer">
+                        <span class="muted">Total XP</span>
+                        <span class="level-total-xp" th:text="${profile.xp}">0</span>
+                    </div>
+                </div>
             </div>
         </section>
 


### PR DESCRIPTION
## Summary

Adds a leveling / engagement system on top of the existing social-credit
infrastructure. XP is tracked **separately** from social credit so
spending or losing credit at the casino doesn't drag a user's level
down — the long-term progression track is durable.

### XP awards (all daily-capped, default 1000 XP/day per user/guild)

- **Messages**: 15–25 XP per non-bot message with a 60s per-user
  cooldown (Tatsu/MEE6-style anti-spam), tracked in a Caffeine cache
  keyed on `(guildId, discordId)`.
- **Slash commands**: 5 XP per invocation, awarded after the command
  completes.
- **Voice intros**: 10 XP alongside the existing intro-play credit.
- **Voice sessions**: 5× the credit grant on session close.

### Level-up consequences

When `XpAwardService.award(...)` crosses one or more level thresholds it
publishes a `LevelUpEvent`. `LevelUpListener` (in the discord-bot
module) then:

1. Posts a congratulatory message in the originating channel (with
   optional `LEVEL_UP_CHANNEL` config override; falls back to system
   channel for voice-only awards).
2. Assigns every configured Discord role reward in `(oldLevel, newLevel]`
   — managed per-guild via the new `level_role_reward` table.
3. Auto-unlocks titles whose new `required_level` column falls in the
   same range — inserts a `user_owned_title` row so the user can equip
   them without paying `cost`.

### Economy feedback loop

`SocialCreditAwardService` daily cap and `UniversalBasicIncomeJob` grant
both scale with the user's level (config-tunable, defaults
`+10 cap/level` and `+5 UBI/level`; setting either to `0` disables that
perk).

### Surfaces

- New `/level [user]` slash command with progress bar.
- `/userinfo` extended with a `Level X (Y/Z XP, total N)` line.
- Web `/profile` page gains a "Level" card with a progress bar.
- Web moderation `settings.html` exposes the four new config keys:
  `DAILY_XP_CAP`, `DAILY_CAP_PER_LEVEL_BONUS`, `UBI_PER_LEVEL_BONUS`,
  `LEVEL_UP_CHANNEL`.

### Curve

Standard MEE6 polynomial: `5n² + 50n + 100` XP to advance from level
`n` to `n+1`. First level-up at 100 XP, second at 255, third at 475.

### Migration

`V34__xp_and_levels.sql` adds the `xp` column to `user`, the `xp_daily`
ledger, the `level_role_reward` table, and the `required_level` column
on `title` (default 0 = no gate, so existing titles stay purchasable).

## Test plan

- [x] `LevelCurveTest` covers exact-threshold transitions, monotonicity,
      and progress math.
- [x] `XpAwardServiceTest` mirrors `SocialCreditAwardServiceTest` plus
      `LevelUpEvent` publishing — single-threshold crossing,
      multi-threshold-in-one-grant, daily-cap suppression.
- [x] `LevelUpListenerTest` verifies announcement channel resolution,
      multi-role assignment, title unlock filter, ownership skip.
- [x] `LevelCommandTest` checks rendering against known XP values.
- [x] `SocialCreditAwardServiceTest` gains tests for the per-level cap
      bonus.
- [x] Existing `VoiceEventHandlerTest`, `VoiceCreditAwardServiceTest`,
      `MessageChatListenerTest`, `UserInfoCommandTest` updated for the
      new constructor params / output format.
- [x] Web `ModerationTemplateRowsTest` passes — every new config key has
      a `data-key` row in the moderation UI.
- [ ] Manual: confirm Flyway applies `V34` cleanly and `/level` renders
      a progress bar in a live guild.
- [ ] Manual: configure a `level_role_reward` row, push a test user past
      that level via XP grants, confirm the role lands.

> ℹ️ I could not compile `:discord-bot` in this sandbox — the maven
> repos hosting JDA / Lavalink dependencies are blocked at the network
> policy level. `:common`, `:database`, `:core-api`, and `:web` all
> compile and their test suites pass. Please run the full
> `./gradlew test` locally before merging.

https://claude.ai/code/session_01AbEuQqTA4wd5uxuc8pPqQH

---
_Generated by [Claude Code](https://claude.ai/code/session_01AbEuQqTA4wd5uxuc8pPqQH)_