### PR TITLE
fix(web): collapse navbar dropdown sections on mobile

### DIFF
--- a/web/src/main/resources/static/css/nav.css
+++ b/web/src/main/resources/static/css/nav.css
@@ -82,7 +82,9 @@ nav {
 .nav-dropdown-toggle:hover,
 .nav-dropdown.open > .nav-dropdown-toggle { color: #fff; }
 .nav-dropdown-caret { font-size: 0.75em; transition: transform 0.2s; }
-.nav-dropdown:hover .nav-dropdown-caret,
+@media (hover: hover) and (pointer: fine) {
+    .nav-dropdown:hover .nav-dropdown-caret { transform: rotate(180deg); }
+}
 .nav-dropdown.open .nav-dropdown-caret { transform: rotate(180deg); }
 .nav-dropdown-menu {
     display: none;
@@ -99,7 +101,9 @@ nav {
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
     flex-direction: column;
 }
-.nav-dropdown:hover .nav-dropdown-menu,
+@media (hover: hover) and (pointer: fine) {
+    .nav-dropdown:hover .nav-dropdown-menu { display: flex; }
+}
 .nav-dropdown.open .nav-dropdown-menu { display: flex; }
 .nav-dropdown-menu a,
 .nav-dropdown-menu .nav-dropdown-coming-soon {
@@ -125,15 +129,16 @@ nav {
     .nav-links a, .nav-user { padding: 10px 4px; min-height: 40px; display: flex; align-items: center; }
     .nav-links .btn-discord, .nav-links .btn-logout { align-self: flex-start; min-height: 40px; display: inline-flex; align-items: center; }
 
-    /* On mobile, dropdown items render inline under the trigger so the
-       whole menu is one vertical scroll — no second tap required. The
-       desktop hover-bridge padding is also neutralised so it doesn't
-       push items apart. */
+    /* On mobile, dropdown items inline under the trigger and toggle
+       open/closed via the .open class set by toggleDropdown() — each
+       section starts collapsed so the menu isn't one giant scroll.
+       Hover is deliberately not a trigger on touch; see the
+       @media (hover: hover) guard above. The desktop hover-bridge
+       padding is also neutralised so it doesn't push items apart. */
     .nav-dropdown { width: 100%; padding-bottom: 0; margin-bottom: 0; }
     .nav-dropdown-toggle { padding: 10px 4px; min-height: 40px; width: 100%; justify-content: flex-start; }
     .nav-dropdown-menu {
         position: static;
-        display: flex;
         margin-top: 0;
         border: none;
         padding: 0 0 0 16px;

--- a/web/src/test/e2e/fixtures/home.html
+++ b/web/src/test/e2e/fixtures/home.html
@@ -13,11 +13,38 @@
     <a class="brand" href="#">TobyBot</a>
     <button class="nav-toggle" aria-expanded="false" aria-controls="nav-menu" type="button">☰</button>
     <div class="nav-links" id="nav-menu">
-        <a href="#">Commands</a>
-        <a href="#">Casino</a>
-        <a href="#">Leaderboard</a>
-        <a href="#">Moderation</a>
         <a href="#">Profile</a>
+        <a href="#">Leaderboards</a>
+        <div class="nav-dropdown">
+            <button type="button" class="nav-dropdown-toggle" aria-haspopup="true" aria-expanded="false">Play <span class="nav-dropdown-caret" aria-hidden="true">&#9662;</span></button>
+            <div class="nav-dropdown-menu" role="menu">
+                <a href="#" role="menuitem">Slots</a>
+                <a href="#" role="menuitem">Coinflip</a>
+                <a href="#" role="menuitem">Blackjack</a>
+            </div>
+        </div>
+        <div class="nav-dropdown">
+            <button type="button" class="nav-dropdown-toggle" aria-haspopup="true" aria-expanded="false">Economy <span class="nav-dropdown-caret" aria-hidden="true">&#9662;</span></button>
+            <div class="nav-dropdown-menu" role="menu">
+                <a href="#" role="menuitem">Market</a>
+                <a href="#" role="menuitem">Titles</a>
+            </div>
+        </div>
+        <div class="nav-dropdown">
+            <button type="button" class="nav-dropdown-toggle" aria-haspopup="true" aria-expanded="false">Social <span class="nav-dropdown-caret" aria-hidden="true">&#9662;</span></button>
+            <div class="nav-dropdown-menu" role="menu">
+                <a href="#" role="menuitem">Music</a>
+                <a href="#" role="menuitem">Teams</a>
+            </div>
+        </div>
+        <div class="nav-dropdown">
+            <button type="button" class="nav-dropdown-toggle" aria-haspopup="true" aria-expanded="false">Tools <span class="nav-dropdown-caret" aria-hidden="true">&#9662;</span></button>
+            <div class="nav-dropdown-menu" role="menu">
+                <a href="#" role="menuitem">Utils</a>
+                <a href="#" role="menuitem">Commands</a>
+            </div>
+        </div>
+        <a href="#">Admin</a>
         <a class="btn-logout" href="#">Logout</a>
     </div>
 </nav>

--- a/web/src/test/e2e/responsive.spec.js
+++ b/web/src/test/e2e/responsive.spec.js
@@ -112,6 +112,125 @@ test.describe('nav hamburger toggle', () => {
     });
 });
 
+test.describe('nav dropdowns under mobile breakpoint', () => {
+    test('sections start collapsed, toggle open one at a time', async ({
+        page: browserPage,
+    }, testInfo) => {
+        // Dropdown collapse only matters on phone viewports where the
+        // hamburger menu shows. On iPad/desktop the dropdowns sit inline
+        // on the navbar and use the desktop hover/click model.
+        test.skip(
+            !PHONE_PROJECTS.has(testInfo.project.name),
+            'mobile dropdown collapse only applies under --bp-mobile',
+        );
+        await browserPage.goto('/home.html');
+        await browserPage.waitForLoadState('load');
+
+        // Fixture HTML doesn't load home.js, so inline the same handlers
+        // home.js installs in prod (matching the workaround at the
+        // hamburger toggle test above).
+        await browserPage.evaluate(() => {
+            const closeAllDropdowns = () => {
+                document.querySelectorAll('.nav-dropdown.open').forEach((d) => {
+                    d.classList.remove('open');
+                    const t = d.querySelector('.nav-dropdown-toggle');
+                    if (t) t.setAttribute('aria-expanded', 'false');
+                });
+            };
+            window.__closeAllDropdowns = closeAllDropdowns;
+            window.__toggleDropdown = (toggle) => {
+                const dropdown = toggle.closest('.nav-dropdown');
+                if (!dropdown) return false;
+                const willOpen = !dropdown.classList.contains('open');
+                closeAllDropdowns();
+                if (willOpen) {
+                    dropdown.classList.add('open');
+                    toggle.setAttribute('aria-expanded', 'true');
+                }
+                return willOpen;
+            };
+            document.querySelectorAll('.nav-dropdown-toggle').forEach((t) => {
+                t.addEventListener('click', () => window.__toggleDropdown(t));
+            });
+            const navToggle = document.querySelector('.nav-toggle');
+            const navMenu = document.getElementById('nav-menu');
+            if (navToggle && navMenu) {
+                navToggle.addEventListener('click', () => navMenu.classList.toggle('open'));
+            }
+        });
+
+        // Open the hamburger so the dropdown toggles are part of the
+        // layout and computed-style reads reflect the mobile rules.
+        await browserPage.locator('.nav-toggle').click();
+        await expect(browserPage.locator('#nav-menu')).toHaveClass(/open/);
+
+        const initialDisplays = await browserPage.$$eval(
+            '.nav-dropdown-menu',
+            (els) => els.map((el) => getComputedStyle(el).display),
+        );
+        expect(
+            initialDisplays,
+            'every dropdown menu must start collapsed (display: none) on mobile',
+        ).toEqual(initialDisplays.map(() => 'none'));
+
+        const playToggle = browserPage.locator('.nav-dropdown-toggle', { hasText: 'Play' });
+        const economyToggle = browserPage.locator('.nav-dropdown-toggle', { hasText: 'Economy' });
+
+        // Open Play: its menu becomes visible, its parent gets .open.
+        await playToggle.click();
+        const afterPlay = await browserPage.evaluate(() => {
+            const dropdowns = Array.from(document.querySelectorAll('.nav-dropdown'));
+            return dropdowns.map((d) => {
+                const label = d.querySelector('.nav-dropdown-toggle')?.textContent?.trim() || '';
+                return {
+                    label,
+                    open: d.classList.contains('open'),
+                    display: getComputedStyle(d.querySelector('.nav-dropdown-menu')).display,
+                };
+            });
+        });
+        const play = afterPlay.find((d) => d.label.startsWith('Play'));
+        expect(play.open).toBe(true);
+        expect(play.display).toBe('flex');
+        expect(afterPlay.filter((d) => d.open)).toHaveLength(1);
+
+        // Open Economy: Play must collapse (one-at-a-time contract).
+        await economyToggle.click();
+        const afterEconomy = await browserPage.evaluate(() => {
+            const dropdowns = Array.from(document.querySelectorAll('.nav-dropdown'));
+            return dropdowns.map((d) => {
+                const label = d.querySelector('.nav-dropdown-toggle')?.textContent?.trim() || '';
+                return {
+                    label,
+                    open: d.classList.contains('open'),
+                    display: getComputedStyle(d.querySelector('.nav-dropdown-menu')).display,
+                };
+            });
+        });
+        const economy = afterEconomy.find((d) => d.label.startsWith('Economy'));
+        const playAgain = afterEconomy.find((d) => d.label.startsWith('Play'));
+        expect(economy.open).toBe(true);
+        expect(economy.display).toBe('flex');
+        expect(playAgain.open).toBe(false);
+        expect(playAgain.display).toBe('none');
+        expect(afterEconomy.filter((d) => d.open)).toHaveLength(1);
+
+        // Tap Economy again: it collapses (toggle path).
+        await economyToggle.click();
+        const afterEconomyClose = await browserPage.evaluate(() => {
+            const dropdowns = Array.from(document.querySelectorAll('.nav-dropdown'));
+            return dropdowns.map((d) => ({
+                open: d.classList.contains('open'),
+                display: getComputedStyle(d.querySelector('.nav-dropdown-menu')).display,
+            }));
+        });
+        expect(afterEconomyClose.filter((d) => d.open)).toHaveLength(0);
+        expect(afterEconomyClose.map((d) => d.display)).toEqual(
+            afterEconomyClose.map(() => 'none'),
+        );
+    });
+});
+
 test.describe('mod-table card transform', () => {
     test('rows render as cards on phone with visible data-label headings', async ({
         page: browserPage,


### PR DESCRIPTION
## Summary

On a phone-width viewport (≤600px), the navbar hamburger opened a menu where all four dropdown sections (Play, Economy, Social, Tools) were already fully expanded — every link visible, scroll forever, and the section toggle buttons did nothing.

Root cause was one CSS rule in the mobile media query of `nav.css`:
`.nav-dropdown-menu { display: flex; ... }` was set unconditionally, overriding the desktop default (`display: none` unless `.open` is on the parent). The `toggleDropdown()` JS and `.open` styling were already wired correctly — only the mobile visibility gate was wrong.

- Drop the `display: flex` override inside `@media (max-width: 600px)` so the desktop default applies on phone too — sections render collapsed and only the `.nav-dropdown.open .nav-dropdown-menu { display: flex }` rule opens them.
- Gate the desktop `:hover` rules (menu visibility + caret rotation) behind `@media (hover: hover) and (pointer: fine)` so emulated `:hover` on iOS/Android can't stick a dropdown open on first tap.
- Update the explanatory comment in the mobile block to match the new behaviour.
- Add a Playwright test that opens the hamburger menu, asserts all four sections start collapsed, taps Play (opens), taps Economy (closes Play, opens Economy — one-at-a-time contract), and taps Economy again (collapses — toggle path).
- Extend the `home.html` fixture so it carries the dropdown structure the test exercises against the real `nav.css`.

No HTML template or JS handler changes — the production navbar fragment and `home.js` `toggleDropdown()` already produce/consume the `.open` class correctly.

## Test plan

- [x] `cd web && npm test` — all 509 Jest tests pass (no HTML/JS changes, no impact on `navbar.test.js`).
- [x] `cd web && npm run lint:css` — stylelint passes.
- [x] `cd web && npx playwright test --list` — new test is registered on `iphone-se` / `pixel-5` / `ipad` / `desktop` projects (skipped on non-phone viewports inside the test).
- [ ] CI runs the Playwright suite (`responsive.spec.js`) under the phone projects to exercise the new `'sections start collapsed, toggle open one at a time'` test against a real Chromium — local sandbox can't download the browser binary.
- [ ] Manual smoke once deployed: open any page that includes the navbar fragment, narrow to ≤600px, tap the hamburger → four section toggles visible with carets pointing down, no sub-items. Tap "Play" → caret rotates, sub-items appear. Tap "Economy" → Play collapses, Economy expands. Tap "Economy" again → it collapses. Re-test ≥768px to confirm hover-to-open still works.

https://claude.ai/code/session_01QRVNAPLBzccJqS1RyaGzrK

---
_Generated by [Claude Code](https://claude.ai/code/session_01QRVNAPLBzccJqS1RyaGzrK)_