### PR TITLE
feat(leveling-mod): dedicated tab + role-reward CRUD + title gating

### DIFF
--- a/database/src/main/kotlin/database/persistence/TitlePersistence.kt
+++ b/database/src/main/kotlin/database/persistence/TitlePersistence.kt
@@ -11,4 +11,11 @@ interface TitlePersistence {
     fun listOwned(discordId: Long): List<UserOwnedTitleDto>
     fun owns(discordId: Long, titleId: Long): Boolean
     fun recordPurchase(owned: UserOwnedTitleDto): UserOwnedTitleDto
+
+    /**
+     * Merge a mutated [TitleDto] back into the persistence context.
+     * Used by the leveling moderation page to update `required_level`
+     * on existing rows. Returns the managed instance after flush.
+     */
+    fun update(title: TitleDto): TitleDto
 }

--- a/database/src/main/kotlin/database/persistence/impl/DefaultTitlePersistence.kt
+++ b/database/src/main/kotlin/database/persistence/impl/DefaultTitlePersistence.kt
@@ -49,4 +49,10 @@ class DefaultTitlePersistence : TitlePersistence {
         entityManager.flush()
         return owned
     }
+
+    override fun update(title: TitleDto): TitleDto {
+        val merged = entityManager.merge(title)
+        entityManager.flush()
+        return merged
+    }
 }

--- a/database/src/main/kotlin/database/service/TitleService.kt
+++ b/database/src/main/kotlin/database/service/TitleService.kt
@@ -11,4 +11,12 @@ interface TitleService {
     fun listOwned(discordId: Long): List<UserOwnedTitleDto>
     fun owns(discordId: Long, titleId: Long): Boolean
     fun recordPurchase(discordId: Long, titleId: Long): UserOwnedTitleDto
+
+    /**
+     * Update the level gate on an existing title. Returns the updated
+     * row, or null if no title exists with [titleId]. [requiredLevel]
+     * must be `>= 0`; the caller is expected to validate before calling.
+     * A value of 0 means "no gate" (default).
+     */
+    fun updateRequiredLevel(titleId: Long, requiredLevel: Int): TitleDto?
 }

--- a/database/src/main/kotlin/database/service/impl/DefaultTitleService.kt
+++ b/database/src/main/kotlin/database/service/impl/DefaultTitleService.kt
@@ -27,4 +27,10 @@ class DefaultTitleService @Autowired constructor(
         )
         return persistence.recordPurchase(owned)
     }
+
+    override fun updateRequiredLevel(titleId: Long, requiredLevel: Int): TitleDto? {
+        val existing = persistence.getById(titleId) ?: return null
+        existing.requiredLevel = requiredLevel
+        return persistence.update(existing)
+    }
 }

--- a/web/src/main/kotlin/web/controller/ModerationController.kt
+++ b/web/src/main/kotlin/web/controller/ModerationController.kt
@@ -10,6 +10,7 @@ import org.springframework.security.oauth2.client.annotation.RegisteredOAuth2Aut
 import org.springframework.security.oauth2.core.user.OAuth2User
 import org.springframework.stereotype.Controller
 import org.springframework.ui.Model
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -116,6 +117,33 @@ class ModerationController(
         model: Model,
         ra: RedirectAttributes
     ): String = renderSubPage(guildId, user, model, ra, "moderation/lottery")
+
+    @GetMapping("/{guildId}/leveling")
+    fun levelingPage(
+        @PathVariable guildId: Long,
+        @AuthenticationPrincipal user: OAuth2User,
+        model: Model,
+        ra: RedirectAttributes
+    ): String = WebGuildAccess.requireForPage(
+        user, guildId, ra, lobbyPath = "/moderation/guilds",
+        check = moderationWebService::canModerate,
+        deniedMessage = "You are not allowed to moderate that server.",
+    ) { discordId ->
+        val overview = moderationWebService.getGuildOverview(guildId) ?: run {
+            ra.addFlashAttribute("error", "Bot is not in that server.")
+            return@requireForPage "redirect:/moderation/guilds"
+        }
+        val leveling = moderationWebService.getLevelingOverview(guildId) ?: run {
+            ra.addFlashAttribute("error", "Bot is not in that server.")
+            return@requireForPage "redirect:/moderation/guilds"
+        }
+        model.addAttribute("overview", overview)
+        model.addAttribute("leveling", leveling)
+        model.addAttribute("isOwner", moderationWebService.isOwner(discordId, guildId))
+        model.addAttribute("username", user.displayName())
+        model.addAttribute("actorDiscordId", discordId.toString())
+        "moderation/leveling"
+    }
 
     /**
      * Shared resolver for every per-tab sub-page: runs the same access
@@ -515,6 +543,63 @@ class ModerationController(
         }
     }
 
+    /**
+     * Upsert a level → role-reward binding. Owner-only. Triggered by
+     * the "Add reward" form on the leveling moderation tab.
+     */
+    @PostMapping("/{guildId}/level-reward", consumes = ["application/json"])
+    @ResponseBody
+    fun upsertLevelReward(
+        @PathVariable guildId: Long,
+        @RequestBody body: LevelRewardRequest,
+        @AuthenticationPrincipal user: OAuth2User
+    ): ResponseEntity<ApiResult> = WebGuildAccess.requireSignedInForJson(
+        user, notSignedInApi
+    ) { actor ->
+        val roleId = body.roleId.toLongOrNull()
+            ?: return@requireSignedInForJson ResponseEntity.badRequest().body(ApiResult(false, "Invalid role id."))
+        val error = moderationWebService.upsertLevelReward(actor, guildId, body.level, roleId)
+        if (error != null) ResponseEntity.badRequest().body(ApiResult(false, error))
+        else ResponseEntity.ok(ApiResult(true, null))
+    }
+
+    /**
+     * Drop a level → role-reward binding. Owner-only. Triggered by the
+     * per-row Delete button on the leveling moderation tab.
+     */
+    @DeleteMapping("/{guildId}/level-reward/{level}")
+    @ResponseBody
+    fun deleteLevelReward(
+        @PathVariable guildId: Long,
+        @PathVariable level: Int,
+        @AuthenticationPrincipal user: OAuth2User
+    ): ResponseEntity<ApiResult> = WebGuildAccess.requireSignedInForJson(
+        user, notSignedInApi
+    ) { actor ->
+        val error = moderationWebService.deleteLevelReward(actor, guildId, level)
+        if (error != null) ResponseEntity.badRequest().body(ApiResult(false, error))
+        else ResponseEntity.ok(ApiResult(true, null))
+    }
+
+    /**
+     * Set required_level on a title. Owner-only. Triggered by the
+     * per-title Save button on the leveling moderation tab.
+     */
+    @PostMapping("/{guildId}/title/{titleId}/required-level", consumes = ["application/json"])
+    @ResponseBody
+    fun setTitleRequiredLevel(
+        @PathVariable guildId: Long,
+        @PathVariable titleId: Long,
+        @RequestBody body: RequiredLevelRequest,
+        @AuthenticationPrincipal user: OAuth2User
+    ): ResponseEntity<ApiResult> = WebGuildAccess.requireSignedInForJson(
+        user, notSignedInApi
+    ) { actor ->
+        val error = moderationWebService.setTitleRequiredLevel(actor, guildId, titleId, body.requiredLevel)
+        if (error != null) ResponseEntity.badRequest().body(ApiResult(false, error))
+        else ResponseEntity.ok(ApiResult(true, null))
+    }
+
     @PostMapping("/{guildId}/poll", consumes = ["application/json"])
     @ResponseBody
     fun createPoll(
@@ -559,6 +644,8 @@ data class LockRequest(val lock: Boolean = true)
 data class SlowmodeRequest(val seconds: Int = 0)
 data class MoveRequest(val targetChannelId: String = "", val memberIds: List<String> = emptyList())
 data class PollRequest(val channelId: String = "", val question: String = "", val options: List<String> = emptyList())
+data class LevelRewardRequest(val level: Int = 0, val roleId: String = "")
+data class RequiredLevelRequest(val requiredLevel: Int = 0)
 
 data class PurgeResponse(
     val ok: Boolean,

--- a/web/src/main/kotlin/web/service/ModerationWebService.kt
+++ b/web/src/main/kotlin/web/service/ModerationWebService.kt
@@ -4,10 +4,12 @@ import common.events.ActivityTrackingEnabled
 import common.logging.DiscordLogger
 import database.dto.ConfigDto
 import database.dto.UserDto
+import database.dto.LevelRoleRewardDto
 import database.service.CasinoAdminService
 import database.service.ConfigService
 import database.service.JackpotLotteryService
 import database.service.JackpotService
+import database.service.LevelRoleRewardService
 import database.service.LotteryHelper
 import database.service.MonthlyCreditSnapshotService
 import database.service.TitleService
@@ -43,6 +45,7 @@ class ModerationWebService(
     private val jackpotService: JackpotService,
     private val casinoAdminService: CasinoAdminService,
     private val jackpotLotteryService: JackpotLotteryService,
+    private val levelRoleRewardService: LevelRoleRewardService,
     private val eventPublisher: ApplicationEventPublisher
 ) {
     companion object {
@@ -60,6 +63,7 @@ class ModerationWebService(
         private val CHANNEL_CONFIG_ALLOWLIST: Set<ConfigDto.Configurations> = setOf(
             ConfigDto.Configurations.LOTTERY_CHANNEL,
             ConfigDto.Configurations.LEADERBOARD_CHANNEL,
+            ConfigDto.Configurations.LEVEL_UP_CHANNEL,
         )
 
         /** Allow-list for the admin-only `create-admin-only-channel`
@@ -510,6 +514,107 @@ class ModerationWebService(
                     openedNew = false, newSeeded = 0L,
                 )
         }
+    }
+
+    // ---------------- Leveling moderation ----------------
+
+    /**
+     * Build the data backing the per-guild leveling moderation page: the
+     * current `(level, role)` reward bindings joined to live JDA role
+     * info (so missing/renamed roles surface clearly), and every title
+     * with its current `requiredLevel` so admins can gate purchases.
+     * Returns null if JDA can't see the guild.
+     */
+    fun getLevelingOverview(guildId: Long): LevelingOverview? {
+        val guild = jda.getGuildById(guildId) ?: return null
+        val rewards = levelRoleRewardService.listForGuild(guildId).map { dto ->
+            val role = guild.getRoleById(dto.roleId)
+            LevelRoleRewardView(
+                level = dto.level,
+                roleId = dto.roleId.toString(),
+                roleName = role?.name ?: "(deleted role)",
+                roleColorHex = role?.colorRaw?.takeIf { it != 0 }?.let { String.format("#%06x", it and 0xFFFFFF) },
+                roleMissing = role == null,
+            )
+        }
+        val roles = guild.roles
+            .filter { !it.isManaged && it.idLong != guild.idLong } // hide @everyone and integration roles
+            .sortedByDescending { it.position }
+            .map { RoleInfo(id = it.id, name = it.name) }
+        val titles = titleService.listAll().map { t ->
+            TitleGateView(
+                id = t.id ?: 0L,
+                label = t.label,
+                colorHex = t.colorHex,
+                cost = t.cost,
+                requiredLevel = t.requiredLevel,
+            )
+        }
+        return LevelingOverview(
+            guildId = guild.id,
+            guildName = guild.name,
+            levelRewards = rewards,
+            roles = roles,
+            titles = titles,
+        )
+    }
+
+    /**
+     * Upsert a `(level, roleId)` binding. Owner-only. The level must be
+     * a positive integer (level 0 is the starting state — rewards at 0
+     * would fire on every new user). The role must exist in the guild
+     * and must not be managed (integration-owned roles can't be assigned
+     * by the bot). Returns null on success, otherwise a user-facing
+     * error message.
+     */
+    fun upsertLevelReward(
+        actorDiscordId: Long,
+        guildId: Long,
+        level: Int,
+        roleId: Long,
+    ): String? {
+        if (!isOwner(actorDiscordId, guildId)) return "Only the server owner can change guild config."
+        val guild = jda.getGuildById(guildId) ?: return "Bot is not in that server."
+        if (level <= 0) return "Level must be 1 or higher."
+        val role = guild.getRoleById(roleId) ?: return "Role not found in this server."
+        if (role.isManaged) return "That role is managed by an integration and can't be assigned by the bot."
+        if (!guild.selfMember.canInteract(role)) {
+            return "The bot's highest role is below ${role.name} — move TobyBot's role above it to allow assignment."
+        }
+        levelRoleRewardService.upsert(
+            LevelRoleRewardDto(guildId = guildId, level = level, roleId = roleId)
+        )
+        return null
+    }
+
+    /**
+     * Drop the `(guildId, level)` binding. Owner-only. No-op if no row
+     * exists at that level — surfaces success either way so the UI's
+     * delete button is idempotent.
+     */
+    fun deleteLevelReward(actorDiscordId: Long, guildId: Long, level: Int): String? {
+        if (!isOwner(actorDiscordId, guildId)) return "Only the server owner can change guild config."
+        levelRoleRewardService.delete(guildId, level)
+        return null
+    }
+
+    /**
+     * Set `required_level` on a title. Owner-only. A value of 0 means
+     * "no gate" (the default). Returns null on success or a user-facing
+     * error message.
+     */
+    fun setTitleRequiredLevel(
+        actorDiscordId: Long,
+        guildId: Long,
+        titleId: Long,
+        requiredLevel: Int,
+    ): String? {
+        if (!isOwner(actorDiscordId, guildId)) return "Only the server owner can change guild config."
+        if (requiredLevel < 0) return "Required level must be zero or higher."
+        if (requiredLevel > 1000) return "Required level can't exceed 1000."
+        titleService.updateRequiredLevel(titleId, requiredLevel)
+            ?: return "Title not found."
+        return null
     }
 
     /**
@@ -975,14 +1080,19 @@ class ModerationWebService(
                 n.toString()
             }
             ConfigDto.Configurations.LEVEL_UP_CHANNEL -> {
-                val id = rawValue.trim()
-                if (id.isEmpty()) return "Channel id is required."
-                val idLong = id.toLongOrNull()
-                    ?: return "Channel id must be numeric."
-                if (guild.getTextChannelById(idLong) == null) {
-                    return "No text channel with that id exists in this server."
+                val v = rawValue.trim()
+                if (v.isEmpty()) {
+                    // Empty value clears the override. LevelUpListener falls
+                    // back to the originating channel (where the XP was
+                    // earned) and finally to the guild's system channel.
+                    ""
+                } else {
+                    val id = v.toLongOrNull()
+                        ?: return "Channel id must be numeric."
+                    val channel = guild.getTextChannelById(id)
+                        ?: return "No text channel with that id exists in this server."
+                    channel.id
                 }
-                id
             }
             ConfigDto.Configurations.JACKPOT_WHEEL_SEGMENTS -> {
                 // Empty resets to default. Otherwise must parse cleanly via
@@ -1472,6 +1582,45 @@ data class VoiceChannelInfo(
 data class TextChannelInfo(
     val id: String,
     val name: String
+)
+
+/**
+ * Subset of guild data needed to render the leveling moderation tab.
+ * Sits alongside [GuildOverview] (which the tab also pulls — config map
+ * + textChannels + categories for the channel picker / create-channel
+ * widget). This struct adds the leveling-specific projections: live
+ * level→role bindings with role display info, and titles with their
+ * current `requiredLevel` so admins can gate purchases.
+ */
+data class LevelingOverview(
+    val guildId: String,
+    val guildName: String,
+    val levelRewards: List<LevelRoleRewardView>,
+    val roles: List<RoleInfo>,
+    val titles: List<TitleGateView>,
+)
+
+data class LevelRoleRewardView(
+    val level: Int,
+    val roleId: String,
+    val roleName: String,
+    val roleColorHex: String?,
+    /** True if the role id no longer resolves in JDA — surfaced in the
+     *  UI so admins can clean up dangling rewards after a role delete. */
+    val roleMissing: Boolean,
+)
+
+data class RoleInfo(
+    val id: String,
+    val name: String,
+)
+
+data class TitleGateView(
+    val id: Long,
+    val label: String,
+    val colorHex: String?,
+    val cost: Long,
+    val requiredLevel: Int,
 )
 
 /**

--- a/web/src/main/resources/static/css/moderation.css
+++ b/web/src/main/resources/static/css/moderation.css
@@ -819,3 +819,79 @@ details.config-section.is-hidden { display: none; }
     line-height: 1.5;
     max-width: 70ch;
 }
+
+/* ==============================================================
+   Leveling moderation tab.
+   ============================================================== */
+.leveling-admin-card {
+    gap: var(--space-3);
+}
+
+.leveling-rewards-table,
+.leveling-titles-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-bottom: var(--space-3);
+}
+.leveling-rewards-table th,
+.leveling-titles-table th {
+    text-align: left;
+    padding: var(--space-2) var(--space-3);
+    font-size: 0.78rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--text-muted);
+    border-bottom: 1px solid var(--border);
+}
+.leveling-rewards-table td,
+.leveling-titles-table td {
+    padding: var(--space-2) var(--space-3);
+    border-bottom: 1px solid var(--border);
+    vertical-align: middle;
+}
+.leveling-rewards-table tr:last-of-type td,
+.leveling-titles-table tr:last-of-type td {
+    border-bottom: 0;
+}
+
+.leveling-reward-add {
+    display: flex;
+    gap: var(--space-3);
+    align-items: end;
+    padding: var(--space-3);
+    background: var(--bg-input);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    flex-wrap: wrap;
+}
+.leveling-reward-add label {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    font-size: 0.85rem;
+    color: var(--text-muted);
+    min-width: 120px;
+}
+.leveling-reward-add label > span {
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    font-size: 0.72rem;
+}
+.leveling-reward-add input,
+.leveling-reward-add select {
+    padding: 6px 10px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-strong);
+    background: var(--bg);
+    color: var(--text);
+}
+
+.leveling-title-level-input {
+    width: 80px;
+    padding: 6px 10px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-strong);
+    background: var(--bg);
+    color: var(--text);
+}

--- a/web/src/main/resources/static/js/moderation/leveling.js
+++ b/web/src/main/resources/static/js/moderation/leveling.js
@@ -1,0 +1,111 @@
+// Leveling tab: role-reward CRUD + per-title required-level save.
+// Generic config-row save + channel-create handlers live in moderationCommon.js.
+(function () {
+    'use strict';
+
+    const ctx = window.ModerationCommon;
+    if (!ctx) return;
+    const { guildId, postJson } = ctx;
+
+    // --- Add role reward ---------------------------------------------------
+    const addForm = document.getElementById('leveling-reward-add');
+    if (addForm) {
+        addForm.addEventListener('submit', (e) => {
+            e.preventDefault();
+            const levelInput = addForm.querySelector('input[name="level"]');
+            const roleSelect = addForm.querySelector('select[name="roleId"]');
+            const submitBtn = addForm.querySelector('button[type="submit"]');
+            const level = parseInt((levelInput.value || '').trim(), 10);
+            const roleId = (roleSelect.value || '').trim();
+            if (!level || level < 1) {
+                toast('Level must be 1 or higher.', 'error');
+                return;
+            }
+            if (!roleId) {
+                toast('Pick a role.', 'error');
+                return;
+            }
+            submitBtn.disabled = true;
+            postJson('/moderation/' + guildId + '/level-reward', { level: level, roleId: roleId })
+                .then(r => {
+                    submitBtn.disabled = false;
+                    if (r && r.ok) {
+                        toast('Role reward saved. Reloading…', 'success');
+                        setTimeout(() => window.location.reload(), 600);
+                    } else {
+                        toast(r?.error || 'Could not save reward.', 'error');
+                    }
+                })
+                .catch(() => {
+                    submitBtn.disabled = false;
+                    toast('Network error.', 'error');
+                });
+        });
+    }
+
+    // --- Delete role reward ------------------------------------------------
+    // fetch() is used directly here because postJson() only does POSTs;
+    // the delete endpoint is a DELETE for REST symmetry with the upsert
+    // POST. Keeps the same { ok, error } response shape.
+    function deleteReward(level, btn) {
+        if (!confirm('Delete the role reward bound to level ' + level + '?')) return;
+        btn.disabled = true;
+        fetch('/moderation/' + guildId + '/level-reward/' + level, {
+            method: 'DELETE',
+            headers: { 'Accept': 'application/json' },
+            credentials: 'same-origin',
+        }).then(r => r.json().catch(() => ({ ok: false, error: 'Bad response.' })))
+          .then(r => {
+              btn.disabled = false;
+              if (r && r.ok) {
+                  toast('Reward removed. Reloading…', 'success');
+                  setTimeout(() => window.location.reload(), 600);
+              } else {
+                  toast(r?.error || 'Could not delete reward.', 'error');
+              }
+          })
+          .catch(() => {
+              btn.disabled = false;
+              toast('Network error.', 'error');
+          });
+    }
+
+    document.querySelectorAll('.leveling-reward-delete').forEach(btn => {
+        btn.addEventListener('click', () => {
+            const level = parseInt(btn.dataset.level || '0', 10);
+            if (!level) return;
+            deleteReward(level, btn);
+        });
+    });
+
+    // --- Save title required_level ----------------------------------------
+    document.querySelectorAll('.leveling-title-save').forEach(btn => {
+        btn.addEventListener('click', () => {
+            const row = btn.closest('tr');
+            const titleId = btn.dataset.titleId;
+            const input = row?.querySelector('.leveling-title-level-input');
+            if (!titleId || !input) return;
+            const requiredLevel = parseInt((input.value || '0').trim(), 10);
+            if (Number.isNaN(requiredLevel) || requiredLevel < 0) {
+                toast('Required level must be zero or higher.', 'error');
+                return;
+            }
+            btn.disabled = true;
+            postJson('/moderation/' + guildId + '/title/' + titleId + '/required-level',
+                { requiredLevel: requiredLevel })
+                .then(r => {
+                    btn.disabled = false;
+                    if (r && r.ok) {
+                        input.defaultValue = String(requiredLevel);
+                        toast('Title gate saved.', 'success');
+                    } else {
+                        toast(r?.error || 'Could not save title gate.', 'error');
+                    }
+                })
+                .catch(() => {
+                    btn.disabled = false;
+                    toast('Network error.', 'error');
+                });
+        });
+    });
+})();

--- a/web/src/main/resources/templates/fragments/moderationHeader.html
+++ b/web/src/main/resources/templates/fragments/moderationHeader.html
@@ -49,6 +49,10 @@
            class="mod-subnav-link"
            th:classappend="${active == 'lottery'} ? ' active'"
            th:attr="aria-current=${active == 'lottery'} ? 'page'">Lottery</a>
+        <a th:href="@{/moderation/{id}/leveling(id=${overview.guildId})}"
+           class="mod-subnav-link"
+           th:classappend="${active == 'leveling'} ? ' active'"
+           th:attr="aria-current=${active == 'leveling'} ? 'page'">Leveling</a>
     </nav>
 </div>
 </body>

--- a/web/src/main/resources/templates/moderation/leveling.html
+++ b/web/src/main/resources/templates/moderation/leveling.html
@@ -1,0 +1,254 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="en">
+<head th:replace="~{fragments/head :: head('TobyBot - Moderation: Leveling', '/css/moderation.css')}"></head>
+<body>
+<a href="#main" class="skip-link">Skip to content</a>
+<div th:replace="~{fragments/navbar :: navbar}"></div>
+
+<main id="main" class="container"
+      th:attr="data-guild-id=${overview.guildId},
+               data-actor-id=${actorDiscordId},
+               data-is-owner=${isOwner}">
+
+    <div th:replace="~{fragments/moderationHeader :: moderationHeader(${overview}, ${isOwner}, 'leveling')}"></div>
+
+    <!--
+        Leveling moderation: per-guild XP tuning + level-up announcement
+        channel + level→role rewards + per-title level gating. Split into
+        four <details> sections so admins can collapse the bits they're
+        not tuning. The four config rows reuse the canonical
+        .config-row + .save-config wiring picked up by moderationCommon.js;
+        the channel picker mirrors lottery.html's LOTTERY_CHANNEL block;
+        role-reward + title-gate widgets are wired in /js/moderation/leveling.js.
+    -->
+    <section class="mod-panel" data-panel="leveling">
+        <p class="muted mb-4">
+            Engagement XP is awarded by message activity, slash commands,
+            and voice sessions, subject to a per-guild daily cap. Hitting
+            a level threshold can grant a Discord role and unlock titles
+            gated to that level. Configure all of it here.
+        </p>
+
+        <div class="mod-card mod-card-wide leveling-admin-card">
+            <details class="config-section" open>
+                <summary>XP &amp; level perks</summary>
+                <div class="config-grid">
+                    <div class="config-row" data-key="DAILY_XP_CAP">
+                        <label>
+                            Daily XP cap
+                            <span class="config-hint">
+                                Per-user ceiling on XP earned in a UTC day across all
+                                sources (messages, commands, voice intros, voice
+                                sessions). Default 1000.
+                            </span>
+                        </label>
+                        <input type="number" min="0" max="100000"
+                               th:value="${overview.config['DAILY_XP_CAP']}"
+                               placeholder="1000"
+                               th:disabled="${!isOwner}">
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
+                    <div class="config-row" data-key="DAILY_CAP_PER_LEVEL_BONUS">
+                        <label>
+                            Daily credit cap bonus per level
+                            <span class="config-hint">
+                                Extra social-credit headroom added to DAILY_CREDIT_CAP
+                                per level the user has reached. Default +10/level;
+                                0 disables the perk.
+                            </span>
+                        </label>
+                        <input type="number" min="0" max="1000"
+                               th:value="${overview.config['DAILY_CAP_PER_LEVEL_BONUS']}"
+                               placeholder="10"
+                               th:disabled="${!isOwner}">
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
+                    <div class="config-row" data-key="UBI_PER_LEVEL_BONUS">
+                        <label>
+                            UBI bonus per level
+                            <span class="config-hint">
+                                Extra credits added to each daily UBI grant per level.
+                                Default +5/level; 0 disables the perk.
+                            </span>
+                        </label>
+                        <input type="number" min="0" max="1000"
+                               th:value="${overview.config['UBI_PER_LEVEL_BONUS']}"
+                               placeholder="5"
+                               th:disabled="${!isOwner}">
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
+                </div>
+            </details>
+
+            <details class="config-section" open>
+                <summary>Level-up announcement channel</summary>
+                <div class="config-grid">
+                    <div class="config-row" data-key="LEVEL_UP_CHANNEL">
+                        <label>
+                            Announce channel
+                            <span class="config-hint">
+                                Level-up messages land here. Leave on "fall back"
+                                to post in the channel where the XP was earned
+                                (and the guild's system channel for voice-derived
+                                level-ups).
+                            </span>
+                        </label>
+                        <select th:disabled="${!isOwner}">
+                            <option value="">&mdash; fall back to message/system &mdash;</option>
+                            <option th:each="tc : ${overview.textChannels}"
+                                    th:value="${tc.id}"
+                                    th:text="'#' + ${tc.name}"
+                                    th:selected="${overview.config['LEVEL_UP_CHANNEL'] == tc.id}"></option>
+                        </select>
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
+                    <div class="config-create-channel">
+                        <div class="config-create-channel-text">
+                            <strong>Create a read-only level-up channel</strong>
+                            <p class="muted">
+                                Creates a new text channel where @everyone can read but
+                                only TobyBot can post; auto-sets the announce channel
+                                above to it. Bot needs the Manage Channels permission.
+                            </p>
+                        </div>
+                        <form class="config-create-channel-form"
+                              data-target-config="LEVEL_UP_CHANNEL"
+                              data-default-name="level-ups">
+                            <label class="config-create-channel-field">
+                                <span>Channel name</span>
+                                <input type="text" name="name" value="level-ups"
+                                       maxlength="90" th:disabled="${!isOwner}">
+                            </label>
+                            <label class="config-create-channel-field">
+                                <span>Category</span>
+                                <select name="parentCategoryId" th:disabled="${!isOwner}">
+                                    <option value="">&mdash; top-level &mdash;</option>
+                                    <option th:each="cat : ${overview.categories}"
+                                            th:value="${cat.id}"
+                                            th:text="${cat.name}"></option>
+                                </select>
+                            </label>
+                            <label class="config-create-channel-field">
+                                <span>or new category name</span>
+                                <input type="text" name="newCategoryName"
+                                       maxlength="100" placeholder="(blank = use existing)"
+                                       th:disabled="${!isOwner}">
+                            </label>
+                            <button type="submit" class="btn config-create-channel-btn"
+                                    th:disabled="${!isOwner}">Create</button>
+                        </form>
+                    </div>
+                </div>
+            </details>
+
+            <details class="config-section" open>
+                <summary>Role rewards</summary>
+                <p class="muted mb-3">
+                    Bind a Discord role to a level threshold — TobyBot assigns it the
+                    moment the user crosses that level. Make sure TobyBot's role sits
+                    above any role you bind here, or the assign will fail at runtime.
+                </p>
+
+                <div class="leveling-rewards" id="leveling-rewards-list">
+                    <p class="muted" th:if="${#lists.isEmpty(leveling.levelRewards)}">
+                        No role rewards bound yet.
+                    </p>
+                    <table class="leveling-rewards-table" th:if="${not #lists.isEmpty(leveling.levelRewards)}">
+                        <thead>
+                            <tr>
+                                <th>Level</th>
+                                <th>Role</th>
+                                <th></th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr th:each="r : ${leveling.levelRewards}" th:data-level="${r.level}">
+                                <td th:text="${r.level}">1</td>
+                                <td>
+                                    <span class="title-pill"
+                                          th:style="${r.roleColorHex != null ? 'color: ' + r.roleColorHex : ''}"
+                                          th:text="${r.roleName}">Role</span>
+                                    <span class="badge off" th:if="${r.roleMissing}">missing</span>
+                                </td>
+                                <td>
+                                    <button type="button" class="btn btn-danger leveling-reward-delete"
+                                            th:data-level="${r.level}"
+                                            th:disabled="${!isOwner}">Delete</button>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+
+                <form id="leveling-reward-add" class="leveling-reward-add">
+                    <label>
+                        <span>Level</span>
+                        <input type="number" name="level" min="1" max="1000"
+                               placeholder="10" th:disabled="${!isOwner}">
+                    </label>
+                    <label>
+                        <span>Role</span>
+                        <select name="roleId" th:disabled="${!isOwner}">
+                            <option value="">&mdash; pick a role &mdash;</option>
+                            <option th:each="role : ${leveling.roles}"
+                                    th:value="${role.id}"
+                                    th:text="${role.name}"></option>
+                        </select>
+                    </label>
+                    <button type="submit" class="btn" th:disabled="${!isOwner}">Add reward</button>
+                </form>
+            </details>
+
+            <details class="config-section">
+                <summary th:text="'Title gating (' + ${#lists.size(leveling.titles)} + ' titles)'">Title gating</summary>
+                <p class="muted mb-3">
+                    Set a minimum level a user must reach before they can buy a title.
+                    Crossing that level also auto-unlocks the title for free, so this
+                    doubles as a level-up reward path. 0 means "no gate".
+                </p>
+
+                <table class="leveling-titles-table" th:if="${not #lists.isEmpty(leveling.titles)}">
+                    <thead>
+                        <tr>
+                            <th>Title</th>
+                            <th>Cost</th>
+                            <th>Required level</th>
+                            <th></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr th:each="t : ${leveling.titles}" th:data-title-id="${t.id}">
+                            <td>
+                                <span class="title-pill"
+                                      th:style="${t.colorHex != null ? 'color: ' + t.colorHex : ''}"
+                                      th:text="${t.label}">Title</span>
+                            </td>
+                            <td th:text="${t.cost}">0</td>
+                            <td>
+                                <input type="number" class="leveling-title-level-input"
+                                       min="0" max="1000"
+                                       th:value="${t.requiredLevel}"
+                                       th:disabled="${!isOwner}">
+                            </td>
+                            <td>
+                                <button type="button" class="btn leveling-title-save"
+                                        th:data-title-id="${t.id}"
+                                        th:disabled="${!isOwner}">Save</button>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+                <p class="muted" th:if="${#lists.isEmpty(leveling.titles)}">
+                    No titles defined yet — they live in the `title` table and seed via the V13 migration.
+                </p>
+            </details>
+        </div>
+    </section>
+</main>
+
+<script th:src="@{/js/api.js}"></script>
+<script th:src="@{/js/toasts.js}"></script>
+<script th:src="@{/js/moderationCommon.js}"></script>
+<script th:src="@{/js/moderation/leveling.js}"></script>
+</body>
+</html>

--- a/web/src/main/resources/templates/moderation/settings.html
+++ b/web/src/main/resources/templates/moderation/settings.html
@@ -166,37 +166,6 @@
                            th:disabled="${!isOwner}">
                     <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
                 </div>
-                <div class="config-row" data-key="DAILY_XP_CAP">
-                    <label>Daily XP cap (per-user ceiling for engagement XP; default 1000)</label>
-                    <input type="number" min="0" max="100000"
-                           th:value="${overview.config['DAILY_XP_CAP']}"
-                           placeholder="1000"
-                           th:disabled="${!isOwner}">
-                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                </div>
-                <div class="config-row" data-key="DAILY_CAP_PER_LEVEL_BONUS">
-                    <label>Daily credit cap bonus per level (default +10/level; 0 disables the perk)</label>
-                    <input type="number" min="0" max="1000"
-                           th:value="${overview.config['DAILY_CAP_PER_LEVEL_BONUS']}"
-                           placeholder="10"
-                           th:disabled="${!isOwner}">
-                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                </div>
-                <div class="config-row" data-key="UBI_PER_LEVEL_BONUS">
-                    <label>UBI bonus per level (extra credits per level on each daily UBI grant; 0 disables)</label>
-                    <input type="number" min="0" max="1000"
-                           th:value="${overview.config['UBI_PER_LEVEL_BONUS']}"
-                           placeholder="5"
-                           th:disabled="${!isOwner}">
-                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                </div>
-                <div class="config-row" data-key="LEVEL_UP_CHANNEL">
-                    <label>Level-up announcement channel id (optional override; defaults to message/command channel)</label>
-                    <input type="text" th:value="${overview.config['LEVEL_UP_CHANNEL']}"
-                           placeholder="(channel id)"
-                           th:disabled="${!isOwner}">
-                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                </div>
                 <div class="config-row" data-key="TRADE_BUY_FEE_PCT">
                     <label>Toby Coin BUY fee (% per leg, routed to jackpot pool)</label>
                     <span class="config-input-group">

--- a/web/src/test/kotlin/web/service/ModerationWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/ModerationWebServiceTest.kt
@@ -44,6 +44,7 @@ class ModerationWebServiceTest {
     private lateinit var jackpotService: database.service.JackpotService
     private lateinit var casinoAdminService: database.service.CasinoAdminService
     private lateinit var jackpotLotteryService: database.service.JackpotLotteryService
+    private lateinit var levelRoleRewardService: database.service.LevelRoleRewardService
     private lateinit var service: ModerationWebService
 
     private lateinit var guild: Guild
@@ -69,6 +70,7 @@ class ModerationWebServiceTest {
         jackpotService = mockk(relaxed = true)
         casinoAdminService = mockk(relaxed = true)
         jackpotLotteryService = mockk(relaxed = true)
+        levelRoleRewardService = mockk(relaxed = true)
         eventPublisher = mockk(relaxed = true)
         guild = mockk(relaxed = true)
         service = ModerationWebService(
@@ -83,6 +85,7 @@ class ModerationWebServiceTest {
             jackpotService,
             casinoAdminService,
             jackpotLotteryService,
+            levelRoleRewardService,
             eventPublisher
         )
 
@@ -1792,5 +1795,184 @@ class ModerationWebServiceTest {
         val result = service.sanitizeChannelName(long)
         assertNotNull(result)
         assertEquals(90, result!!.length)
+    }
+
+    // ---- leveling moderation ----
+
+    @Test
+    fun `upsertLevelReward rejects non-owner actor`() {
+        mockMember(superUserId, isOwner = false)
+        every { introWebService.isSuperUser(superUserId, guildId) } returns true
+
+        val err = service.upsertLevelReward(superUserId, guildId, level = 2, roleId = 999L)
+
+        assertEquals("Only the server owner can change guild config.", err)
+        verify(exactly = 0) { levelRoleRewardService.upsert(any()) }
+    }
+
+    @Test
+    fun `upsertLevelReward rejects level zero`() {
+        mockMember(ownerId, isOwner = true)
+
+        val err = service.upsertLevelReward(ownerId, guildId, level = 0, roleId = 999L)
+
+        assertEquals("Level must be 1 or higher.", err)
+        verify(exactly = 0) { levelRoleRewardService.upsert(any()) }
+    }
+
+    @Test
+    fun `upsertLevelReward rejects unknown role`() {
+        mockMember(ownerId, isOwner = true)
+        every { guild.getRoleById(999L) } returns null
+
+        val err = service.upsertLevelReward(ownerId, guildId, level = 2, roleId = 999L)
+
+        assertEquals("Role not found in this server.", err)
+        verify(exactly = 0) { levelRoleRewardService.upsert(any()) }
+    }
+
+    @Test
+    fun `upsertLevelReward rejects managed role`() {
+        mockMember(ownerId, isOwner = true)
+        val role = mockk<net.dv8tion.jda.api.entities.Role>(relaxed = true).also {
+            every { it.isManaged } returns true
+        }
+        every { guild.getRoleById(999L) } returns role
+
+        val err = service.upsertLevelReward(ownerId, guildId, level = 2, roleId = 999L)
+
+        assertEquals(
+            "That role is managed by an integration and can't be assigned by the bot.",
+            err
+        )
+    }
+
+    @Test
+    fun `upsertLevelReward rejects role above bot hierarchy`() {
+        mockMember(ownerId, isOwner = true)
+        val role = mockk<net.dv8tion.jda.api.entities.Role>(relaxed = true).also {
+            every { it.isManaged } returns false
+            every { it.name } returns "Top Tier"
+        }
+        every { guild.getRoleById(999L) } returns role
+        val selfMember = mockk<SelfMember>(relaxed = true).also {
+            every { it.canInteract(role) } returns false
+        }
+        every { guild.selfMember } returns selfMember
+
+        val err = service.upsertLevelReward(ownerId, guildId, level = 2, roleId = 999L)
+
+        assertNotNull(err)
+        assertTrue(err!!.contains("Top Tier"))
+    }
+
+    @Test
+    fun `upsertLevelReward saves valid reward`() {
+        mockMember(ownerId, isOwner = true)
+        val role = mockk<net.dv8tion.jda.api.entities.Role>(relaxed = true).also {
+            every { it.isManaged } returns false
+        }
+        every { guild.getRoleById(999L) } returns role
+        val selfMember = mockk<SelfMember>(relaxed = true).also {
+            every { it.canInteract(role) } returns true
+        }
+        every { guild.selfMember } returns selfMember
+
+        val err = service.upsertLevelReward(ownerId, guildId, level = 5, roleId = 999L)
+
+        assertNull(err)
+        val captured = slot<database.dto.LevelRoleRewardDto>()
+        verify(exactly = 1) { levelRoleRewardService.upsert(capture(captured)) }
+        assertEquals(guildId, captured.captured.guildId)
+        assertEquals(5, captured.captured.level)
+        assertEquals(999L, captured.captured.roleId)
+    }
+
+    @Test
+    fun `deleteLevelReward rejects non-owner actor`() {
+        mockMember(superUserId, isOwner = false)
+        every { introWebService.isSuperUser(superUserId, guildId) } returns true
+
+        val err = service.deleteLevelReward(superUserId, guildId, level = 2)
+
+        assertEquals("Only the server owner can change guild config.", err)
+        verify(exactly = 0) { levelRoleRewardService.delete(any(), any()) }
+    }
+
+    @Test
+    fun `deleteLevelReward succeeds for owner`() {
+        mockMember(ownerId, isOwner = true)
+
+        val err = service.deleteLevelReward(ownerId, guildId, level = 5)
+
+        assertNull(err)
+        verify(exactly = 1) { levelRoleRewardService.delete(guildId, 5) }
+    }
+
+    @Test
+    fun `setTitleRequiredLevel rejects non-owner actor`() {
+        mockMember(superUserId, isOwner = false)
+        every { introWebService.isSuperUser(superUserId, guildId) } returns true
+
+        val err = service.setTitleRequiredLevel(superUserId, guildId, titleId = 7L, requiredLevel = 3)
+
+        assertEquals("Only the server owner can change guild config.", err)
+        verify(exactly = 0) { titleService.updateRequiredLevel(any(), any()) }
+    }
+
+    @Test
+    fun `setTitleRequiredLevel rejects negative level`() {
+        mockMember(ownerId, isOwner = true)
+
+        val err = service.setTitleRequiredLevel(ownerId, guildId, titleId = 7L, requiredLevel = -1)
+
+        assertEquals("Required level must be zero or higher.", err)
+    }
+
+    @Test
+    fun `setTitleRequiredLevel surfaces title-not-found`() {
+        mockMember(ownerId, isOwner = true)
+        every { titleService.updateRequiredLevel(7L, 3) } returns null
+
+        val err = service.setTitleRequiredLevel(ownerId, guildId, titleId = 7L, requiredLevel = 3)
+
+        assertEquals("Title not found.", err)
+    }
+
+    @Test
+    fun `setTitleRequiredLevel persists when valid`() {
+        mockMember(ownerId, isOwner = true)
+        val updated = TitleDto(id = 7L, label = "Speaker", cost = 500L).apply { requiredLevel = 5 }
+        every { titleService.updateRequiredLevel(7L, 5) } returns updated
+
+        val err = service.setTitleRequiredLevel(ownerId, guildId, titleId = 7L, requiredLevel = 5)
+
+        assertNull(err)
+        verify(exactly = 1) { titleService.updateRequiredLevel(7L, 5) }
+    }
+
+    @Test
+    fun `getLevelingOverview surfaces missing-role flag for dangling rewards`() {
+        every { levelRoleRewardService.listForGuild(guildId) } returns listOf(
+            database.dto.LevelRoleRewardDto(guildId = guildId, level = 5, roleId = 555L),
+            database.dto.LevelRoleRewardDto(guildId = guildId, level = 10, roleId = 666L),
+        )
+        val liveRole = mockk<net.dv8tion.jda.api.entities.Role>(relaxed = true).also {
+            every { it.name } returns "Veteran"
+            every { it.colorRaw } returns 0
+        }
+        every { guild.getRoleById(555L) } returns liveRole
+        every { guild.getRoleById(666L) } returns null
+        every { guild.roles } returns emptyList()
+        every { titleService.listAll() } returns emptyList()
+
+        val overview = service.getLevelingOverview(guildId)
+
+        assertNotNull(overview)
+        assertEquals(2, overview!!.levelRewards.size)
+        assertFalse(overview.levelRewards[0].roleMissing)
+        assertEquals("Veteran", overview.levelRewards[0].roleName)
+        assertTrue(overview.levelRewards[1].roleMissing)
+        assertEquals("(deleted role)", overview.levelRewards[1].roleName)
     }
 }

--- a/web/src/test/kotlin/web/template/ModerationTemplateRowsTest.kt
+++ b/web/src/test/kotlin/web/template/ModerationTemplateRowsTest.kt
@@ -274,6 +274,7 @@ class ModerationTemplateRowsTest {
             readTemplate("templates/moderation/poll.html"),
             readTemplate("templates/moderation/casino.html"),
             readTemplate("templates/moderation/lottery.html"),
+            readTemplate("templates/moderation/leveling.html"),
         )
         val combined = templates.joinToString("\n")
 


### PR DESCRIPTION
## Summary

Closes the moderation-UI gaps from #477. That PR shipped the leveling
backbone (XP, levels, `level_role_reward` table, `title.required_level`
column) but the admin UI was incomplete: the four config keys were
buried inside the collapsed-by-default "Economy" `<details>`, the
`level_role_reward` table had no CRUD path, and `title.required_level`
could only be set via direct DB write.

### Why this was missed

`ModerationTemplateRowsTest` only enforces that every
`ConfigDto.Configurations` entry has *some* `data-key` attribute
somewhere under `templates/moderation/`. Dropping the four leveling
rows into Economy satisfied that test — CI went green and the PR
merged. No test required "every new admin-managed table needs CRUD
UI", so the role-reward and title-gate gaps had nothing to flag them.
The test still passes (the rows live in `leveling.html` now), so the
guard rail still works at the data-key level.

### What this PR adds

- **Dedicated `/moderation/{guildId}/leveling` tab** linked from the
  moderation sub-nav (`fragments/moderationHeader.html`). Four
  `<details>` sections: XP & perks, level-up channel, role rewards,
  title gating.
- **Channel picker + create-channel widget** for `LEVEL_UP_CHANNEL`,
  reusing `wireCreateChannelForm()` from `moderationCommon.js`
  unchanged. The only backend change is adding `LEVEL_UP_CHANNEL` to
  `CHANNEL_CONFIG_ALLOWLIST` — `createTargetedChannel()` handles the
  rest. The default name is `level-ups`. Validation also relaxes to
  accept empty (fall back to message/system channel), matching
  `LOTTERY_CHANNEL` semantics.
- **`level_role_reward` CRUD**: `POST /level-reward` upsert, `DELETE
  /level-reward/{level}` removal. Guarded behind `isOwner`. Validates
  role exists, isn't managed (integration-owned), and sits below the
  bot's highest role so the assignment will actually work at runtime.
  The list view surfaces a "missing" badge if a previously bound role
  has been deleted in Discord.
- **`title.required_level` write path**: `POST
  /title/{titleId}/required-level`, backed by a new
  `TitleService.updateRequiredLevel` + `TitlePersistence.update`. Each
  row in the title-gate table has an inline number input + Save.

### Files

- New `web/src/main/resources/templates/moderation/leveling.html` —
  the new tab.
- New `web/src/main/resources/static/js/moderation/leveling.js` —
  add-reward / delete-reward / save-title-level wiring. Config rows
  and the channel-create form reuse `moderationCommon.js`.
- `web/src/main/kotlin/web/service/ModerationWebService.kt` —
  `LEVEL_UP_CHANNEL` allow-list entry, relaxed empty validation, new
  `getLevelingOverview` / `upsertLevelReward` / `deleteLevelReward` /
  `setTitleRequiredLevel` methods, new `LevelingOverview` /
  `LevelRoleRewardView` / `RoleInfo` / `TitleGateView` data classes.
- `web/src/main/kotlin/web/controller/ModerationController.kt` — new
  GET + 3 JSON endpoints.
- `database/.../TitleService` (+ interface, impl) and `TitlePersistence`
  (+ interface, impl) — new `updateRequiredLevel` /
  `update(TitleDto)`.
- `web/src/main/resources/templates/moderation/settings.html` —
  removed the four leveling config rows.
- `web/src/main/resources/templates/fragments/moderationHeader.html` —
  added the Leveling sub-nav link.
- `web/src/main/resources/static/css/moderation.css` — table + form
  styles for the new widgets.
- `web/src/test/.../ModerationWebServiceTest.kt` — 12 new tests
  covering owner-gating, role validation, level-zero rejection,
  managed-role rejection, hierarchy check, persistence, and the
  missing-role flag in `getLevelingOverview`.
- `web/src/test/.../ModerationTemplateRowsTest.kt` — scans
  `moderation/leveling.html` so the existing bidirectional config-key
  guard sees the new template.

### Known out-of-scope

The title shop (`TitlesWebService.buyTitle` /
`buyTitleWithTobyCoin`) does **not** currently enforce
`required_level` on purchase. The `LevelUpListener.unlockTitles` path
auto-grants gated titles when crossing the threshold, so the moderator
intent works for the auto-unlock case — but a user below the gate can
still buy the title manually if they have the credits. Worth filing
as a follow-up: either gate the buy path or expose this as a deliberate
"shop ignores level gate" behaviour.

## Test plan

- [x] `./gradlew :web:test` passes including 12 new
      `ModerationWebServiceTest` cases and the updated
      `ModerationTemplateRowsTest`.
- [x] `./gradlew :database:test` passes (TitleService changes
      backward-compatible).
- [x] `npm run lint:css` clean.
- [ ] Manual: hit `/moderation/{guildId}/leveling` in a live server,
      confirm the four sections render, the channel picker shows
      existing text channels, "Create level-up channel" creates a
      `#level-ups` channel and sets the config.
- [ ] Manual: add a level-2→@Regular reward, push a test user to
      level 2 via a manual XP grant, confirm the role is assigned by
      `LevelUpListener`.
- [ ] Manual: set a title's `required_level` to 5, push a user past
      level 5, confirm `user_owned_title` row inserted by the auto-
      unlock listener.

https://claude.ai/code/session_01AbEuQqTA4wd5uxuc8pPqQH

---
_Generated by [Claude Code](https://claude.ai/code/session_01AbEuQqTA4wd5uxuc8pPqQH)_