### PR TITLE
feat(leveling): render Discord level-up as a tier-colored embed

### DIFF
--- a/common/src/main/kotlin/common/events/LevelUpEvent.kt
+++ b/common/src/main/kotlin/common/events/LevelUpEvent.kt
@@ -7,6 +7,10 @@ package common.events
  * originating channel, assigning configured role rewards, and unlocking
  * any titles gated by `required_level`.
  *
+ * [totalXp] is the user's lifetime XP after the award that triggered the
+ * level-up — useful for rendering accurate progress (xp into level / xp
+ * for next level) without the listener needing to re-read the user row.
+ *
  * [channelId] is the Discord text-channel id where the triggering action
  * happened (e.g. the message that earned the XP, the slash-command channel).
  * It is null for voice-derived awards — listeners should fall back to the
@@ -17,5 +21,6 @@ data class LevelUpEvent(
     val guildId: Long,
     val oldLevel: Int,
     val newLevel: Int,
+    val totalXp: Long,
     val channelId: Long?
 )

--- a/database/src/main/kotlin/database/service/XpAwardService.kt
+++ b/database/src/main/kotlin/database/service/XpAwardService.kt
@@ -73,6 +73,7 @@ class XpAwardService(
                     guildId = guildId,
                     oldLevel = oldLevel,
                     newLevel = newLevel,
+                    totalXp = newXp,
                     channelId = channelId
                 )
             )

--- a/database/src/test/kotlin/database/service/XpAwardServiceTest.kt
+++ b/database/src/test/kotlin/database/service/XpAwardServiceTest.kt
@@ -143,6 +143,7 @@ class XpAwardServiceTest {
         assertEquals(guildId, event.guildId)
         assertEquals(0, event.oldLevel)
         assertEquals(1, event.newLevel)
+        assertEquals(100L, event.totalXp)
         assertEquals(1234L, event.channelId)
     }
 

--- a/discord-bot/src/main/kotlin/bot/toby/leveling/LevelUpListener.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/leveling/LevelUpListener.kt
@@ -91,6 +91,7 @@ class LevelUpListener @Autowired constructor(
             .setFooter("${tierName(event.newLevel)} tier")
         member?.let { m ->
             val avatar = runCatching { m.effectiveAvatarUrl }.getOrNull()
+                ?.takeIf { it.startsWith("http://") || it.startsWith("https://") }
             builder.setAuthor(m.effectiveName, null, avatar)
         }
         return builder.build()

--- a/discord-bot/src/main/kotlin/bot/toby/leveling/LevelUpListener.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/leveling/LevelUpListener.kt
@@ -1,14 +1,18 @@
 package bot.toby.leveling
 
 import common.events.LevelUpEvent
+import common.leveling.LevelCurve
 import common.logging.DiscordLogger
 import database.dto.ConfigDto.Configurations.LEVEL_UP_CHANNEL
 import database.dto.TitleDto
 import database.service.ConfigService
 import database.service.LevelRoleRewardService
 import database.service.TitleService
+import net.dv8tion.jda.api.EmbedBuilder
 import net.dv8tion.jda.api.JDA
 import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.Member
+import net.dv8tion.jda.api.entities.MessageEmbed
 import net.dv8tion.jda.api.entities.Role
 import net.dv8tion.jda.api.entities.UserSnowflake
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
@@ -16,6 +20,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Lazy
 import org.springframework.context.event.EventListener
 import org.springframework.stereotype.Service
+import java.awt.Color
 
 /**
  * Consumer of [LevelUpEvent]. On a level-up:
@@ -58,19 +63,61 @@ class LevelUpListener @Autowired constructor(
             logger.info { "No announcement channel resolved for guild ${guild.idLong}; skipping level-up message." }
             return
         }
-        val mention = "<@${event.discordId}>"
-        val body = buildString {
-            append("GG ").append(mention).append(" — you reached **Level ")
-            append(event.newLevel).append("**!")
-        }
+        val member = runCatching { guild.getMemberById(event.discordId) }.getOrNull()
+        val embed = buildLevelUpEmbed(event, member)
         runCatching {
-            channel.sendMessage(body).queue(null) { err ->
+            channel.sendMessageEmbeds(embed).queue(null) { err ->
                 logger.warn("Failed to post level-up announcement in #${channel.name}: ${err.message}")
             }
         }.onFailure {
             logger.warn("Level-up announcement dispatch failed: ${it.message}")
         }
     }
+
+    private fun buildLevelUpEmbed(event: LevelUpEvent, member: Member?): MessageEmbed {
+        val progress = LevelCurve.progress(event.totalXp)
+        val mention = "<@${event.discordId}>"
+        val builder = EmbedBuilder()
+            .setTitle("Level Up — LVL ${event.newLevel}")
+            .setDescription("GG $mention — welcome to **Level ${event.newLevel}**!")
+            .setColor(Color(tierColor(event.newLevel)))
+            .addField(
+                "Progress",
+                "`${progressBar(progress.xpIntoLevel, progress.xpForNextLevel)}` " +
+                    "${formatXp(progress.xpIntoLevel)} / ${formatXp(progress.xpForNextLevel)} XP",
+                false
+            )
+            .addField("Total XP", formatXp(event.totalXp), true)
+            .setFooter("${tierName(event.newLevel)} tier")
+        member?.let { m ->
+            val avatar = runCatching { m.effectiveAvatarUrl }.getOrNull()
+            builder.setAuthor(m.effectiveName, null, avatar)
+        }
+        return builder.build()
+    }
+
+    private fun tierColor(level: Int): Int = when {
+        level >= 50 -> 0x5865F2 // Diamond
+        level >= 25 -> 0xD4A017 // Gold
+        level >= 10 -> 0x9AA3B2 // Silver
+        else -> 0xC9803A        // Bronze
+    }
+
+    private fun tierName(level: Int): String = when {
+        level >= 50 -> "Diamond"
+        level >= 25 -> "Gold"
+        level >= 10 -> "Silver"
+        else -> "Bronze"
+    }
+
+    private fun progressBar(filled: Long, total: Long, cells: Int = 10): String {
+        if (total <= 0L) return "░".repeat(cells)
+        val ratio = (filled.toDouble() / total.toDouble()).coerceIn(0.0, 1.0)
+        val full = (ratio * cells).toInt().coerceIn(0, cells)
+        return "█".repeat(full) + "░".repeat(cells - full)
+    }
+
+    private fun formatXp(value: Long): String = String.format("%,d", value)
 
     private fun resolveAnnouncementChannel(guild: Guild, originId: Long?): TextChannel? {
         val configured = configService

--- a/discord-bot/src/test/kotlin/bot/toby/leveling/LevelUpListenerTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/leveling/LevelUpListenerTest.kt
@@ -1,6 +1,7 @@
 package bot.toby.leveling
 
 import common.events.LevelUpEvent
+import common.leveling.LevelCurve
 import database.dto.LevelRoleRewardDto
 import database.dto.TitleDto
 import database.service.ConfigService
@@ -12,6 +13,7 @@ import io.mockk.slot
 import io.mockk.verify
 import net.dv8tion.jda.api.JDA
 import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.MessageEmbed
 import net.dv8tion.jda.api.entities.Role
 import net.dv8tion.jda.api.entities.UserSnowflake
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
@@ -41,7 +43,7 @@ class LevelUpListenerTest {
     }
 
     @Test
-    fun `onLevelUp posts announcement in the origin channel when present`() {
+    fun `onLevelUp posts an embed in the origin channel when present`() {
         val guild = mockk<Guild>(relaxed = true)
         val channel = mockk<TextChannel>(relaxed = true)
         val createAction = mockk<MessageCreateAction>(relaxed = true)
@@ -50,7 +52,7 @@ class LevelUpListenerTest {
         every { guild.id } returns guildId.toString()
         every { guild.getTextChannelById(99L) } returns channel
         every { channel.name } returns "general"
-        every { channel.sendMessage(any<String>()) } returns createAction
+        every { channel.sendMessageEmbeds(any<MessageEmbed>()) } returns createAction
         every { configService.getConfigByName(any(), any()) } returns null
         every { levelRoleRewardService.listInRange(any(), any(), any()) } returns emptyList()
         every { titleService.listAll() } returns emptyList()
@@ -58,14 +60,16 @@ class LevelUpListenerTest {
         listener.onLevelUp(
             LevelUpEvent(
                 discordId = discordId, guildId = guildId,
-                oldLevel = 0, newLevel = 1, channelId = 99L
+                oldLevel = 0, newLevel = 1, totalXp = 110L, channelId = 99L
             )
         )
 
-        val sent = slot<String>()
-        verify { channel.sendMessage(capture(sent)) }
-        assert(sent.captured.contains("Level 1"))
-        assert(sent.captured.contains("<@$discordId>"))
+        val sent = slot<MessageEmbed>()
+        verify { channel.sendMessageEmbeds(capture(sent)) }
+        val embed = sent.captured
+        assert(embed.title!!.contains("LVL 1"))
+        assert(embed.description!!.contains("<@$discordId>"))
+        assert(embed.description!!.contains("Level 1"))
     }
 
     @Test
@@ -78,16 +82,16 @@ class LevelUpListenerTest {
         every { guild.id } returns guildId.toString()
         every { guild.systemChannel } returns systemChannel
         every { systemChannel.name } returns "general"
-        every { systemChannel.sendMessage(any<String>()) } returns createAction
+        every { systemChannel.sendMessageEmbeds(any<MessageEmbed>()) } returns createAction
         every { configService.getConfigByName(any(), any()) } returns null
         every { levelRoleRewardService.listInRange(any(), any(), any()) } returns emptyList()
         every { titleService.listAll() } returns emptyList()
 
         listener.onLevelUp(
-            LevelUpEvent(discordId, guildId, oldLevel = 0, newLevel = 1, channelId = null)
+            LevelUpEvent(discordId, guildId, oldLevel = 0, newLevel = 1, totalXp = 110L, channelId = null)
         )
 
-        verify { systemChannel.sendMessage(any<String>()) }
+        verify { systemChannel.sendMessageEmbeds(any<MessageEmbed>()) }
     }
 
     @Test
@@ -103,7 +107,7 @@ class LevelUpListenerTest {
         every { guild.idLong } returns guildId
         every { guild.id } returns guildId.toString()
         every { guild.getTextChannelById(any<Long>()) } returns channel
-        every { channel.sendMessage(any<String>()) } returns createAction
+        every { channel.sendMessageEmbeds(any<MessageEmbed>()) } returns createAction
         every { configService.getConfigByName(any(), any()) } returns null
         every { titleService.listAll() } returns emptyList()
         every { levelRoleRewardService.listInRange(guildId, fromExclusive = 1, toInclusive = 3) } returns listOf(
@@ -117,7 +121,7 @@ class LevelUpListenerTest {
         every { guild.addRoleToMember(any<UserSnowflake>(), any()) } returns addRoleAction
 
         listener.onLevelUp(
-            LevelUpEvent(discordId, guildId, oldLevel = 1, newLevel = 3, channelId = 99L)
+            LevelUpEvent(discordId, guildId, oldLevel = 1, newLevel = 3, totalXp = 500L, channelId = 99L)
         )
 
         verify(exactly = 1) { guild.addRoleToMember(any<UserSnowflake>(), role1) }
@@ -134,7 +138,7 @@ class LevelUpListenerTest {
         every { guild.idLong } returns guildId
         every { guild.id } returns guildId.toString()
         every { guild.getTextChannelById(any<Long>()) } returns channel
-        every { channel.sendMessage(any<String>()) } returns createAction
+        every { channel.sendMessageEmbeds(any<MessageEmbed>()) } returns createAction
         every { configService.getConfigByName(any(), any()) } returns null
         every { levelRoleRewardService.listInRange(any(), any(), any()) } returns emptyList()
 
@@ -145,7 +149,7 @@ class LevelUpListenerTest {
         every { titleService.owns(discordId, 10L) } returns false
 
         listener.onLevelUp(
-            LevelUpEvent(discordId, guildId, oldLevel = 1, newLevel = 3, channelId = 99L)
+            LevelUpEvent(discordId, guildId, oldLevel = 1, newLevel = 3, totalXp = 500L, channelId = 99L)
         )
 
         verify(exactly = 1) { titleService.recordPurchase(discordId, 10L) }
@@ -163,7 +167,7 @@ class LevelUpListenerTest {
         every { guild.idLong } returns guildId
         every { guild.id } returns guildId.toString()
         every { guild.getTextChannelById(any<Long>()) } returns channel
-        every { channel.sendMessage(any<String>()) } returns createAction
+        every { channel.sendMessageEmbeds(any<MessageEmbed>()) } returns createAction
         every { configService.getConfigByName(any(), any()) } returns null
         every { levelRoleRewardService.listInRange(any(), any(), any()) } returns emptyList()
 
@@ -172,7 +176,7 @@ class LevelUpListenerTest {
         every { titleService.owns(discordId, 10L) } returns true
 
         listener.onLevelUp(
-            LevelUpEvent(discordId, guildId, oldLevel = 1, newLevel = 3, channelId = 99L)
+            LevelUpEvent(discordId, guildId, oldLevel = 1, newLevel = 3, totalXp = 500L, channelId = 99L)
         )
 
         verify(exactly = 0) { titleService.recordPurchase(any(), any()) }
@@ -183,9 +187,53 @@ class LevelUpListenerTest {
         every { jda.getGuildById(guildId) } returns null
 
         listener.onLevelUp(
-            LevelUpEvent(discordId, guildId, oldLevel = 0, newLevel = 1, channelId = 99L)
+            LevelUpEvent(discordId, guildId, oldLevel = 0, newLevel = 1, totalXp = 110L, channelId = 99L)
         )
 
         verify(exactly = 0) { titleService.recordPurchase(any(), any()) }
+    }
+
+    @Test
+    fun `onLevelUp posts a tier-colored embed with progress matching LevelCurve`() {
+        val guild = mockk<Guild>(relaxed = true)
+        val channel = mockk<TextChannel>(relaxed = true)
+        val createAction = mockk<MessageCreateAction>(relaxed = true)
+        every { jda.getGuildById(guildId) } returns guild
+        every { guild.idLong } returns guildId
+        every { guild.id } returns guildId.toString()
+        every { guild.getTextChannelById(99L) } returns channel
+        every { channel.name } returns "general"
+        every { channel.sendMessageEmbeds(any<MessageEmbed>()) } returns createAction
+        every { configService.getConfigByName(any(), any()) } returns null
+        every { levelRoleRewardService.listInRange(any(), any(), any()) } returns emptyList()
+        every { titleService.listAll() } returns emptyList()
+
+        // Craft a totalXp that sits inside level 25 (Gold tier).
+        val totalXp = LevelCurve.cumulativeXpForLevel(25) + 50L
+        val expected = LevelCurve.progress(totalXp)
+
+        listener.onLevelUp(
+            LevelUpEvent(
+                discordId = discordId, guildId = guildId,
+                oldLevel = 24, newLevel = 25, totalXp = totalXp, channelId = 99L
+            )
+        )
+
+        val sent = slot<MessageEmbed>()
+        verify { channel.sendMessageEmbeds(capture(sent)) }
+        val embed = sent.captured
+        assert(embed.title!!.contains("LVL 25"))
+        assert((embed.colorRaw and 0xFFFFFF) == 0xD4A017) {
+            "expected Gold tier color 0xD4A017, got ${(embed.colorRaw and 0xFFFFFF).toString(16)}"
+        }
+        val progressField = embed.fields.single { it.name == "Progress" }.value!!
+        val formattedInto = String.format("%,d", expected.xpIntoLevel)
+        val formattedNext = String.format("%,d", expected.xpForNextLevel)
+        assert(progressField.contains("$formattedInto / $formattedNext XP")) {
+            "progress field '$progressField' should contain '$formattedInto / $formattedNext XP'"
+        }
+        val totalField = embed.fields.single { it.name == "Total XP" }.value!!
+        assert(totalField.contains(String.format("%,d", totalXp)))
+        assert(embed.footer!!.text!!.contains("Gold"))
     }
 }


### PR DESCRIPTION
## Summary

- Discord level-up announcement is now a tier-colored embed that mirrors the web profile card (`templates/profile.html` + `static/css/profile.css`): tier color (Bronze/Silver/Gold/Diamond), level badge in the title, an XP progress bar, and total lifetime XP.
- Numbers come from `LevelCurve.progress(totalXp)` — the same source the profile page uses — so the embed and the profile show the exact same `xpIntoLevel` / `xpForNextLevel` / total at the moment of the level-up.
- `LevelUpEvent` gained a `totalXp` field; `XpAwardService` populates it from the post-award XP it already computes.

### Before / After

Before: `GG @user — you reached **Level 5**!` (plain text)

After: an embed with title `Level Up — LVL 5`, gold/silver/etc. side color, a `Progress` field like `█████░░░░░ 145 / 525 XP`, a `Total XP` field, and a `<Tier> tier` footer. Author shows the member's display name + avatar when resolvable.

## Test plan

- [x] `:common:build` and `:database:test` pass locally (covers the `totalXp` field flowing through `XpAwardService`).
- [x] `LevelUpListenerTest` updated: existing tests now assert on `sendMessageEmbeds(...)` instead of `sendMessage(String)`. New test `onLevelUp posts a tier-colored embed with progress matching LevelCurve` fires a 24→25 event and asserts the embed's title contains `LVL 25`, side color is `0xD4A017` (Gold), `Progress` field contains the formatted `xpIntoLevel / xpForNextLevel` derived from `LevelCurve.progress(totalXp)`, `Total XP` field contains the formatted total, and the footer reads `Gold tier`.
- [ ] `:discord-bot:test` could not be run in the CI sandbox (network policy blocks the `lavasrc` / `libdave` Maven mirrors). Please confirm it passes locally / in CI before merge.
- [ ] Manual check in a dev guild: trigger a level-up across two tiers (e.g. 9→10 silver, 24→25 gold) and compare the embed's level / xpIntoLevel / xpForNextLevel / total with the same user's `/profile` page — they should match exactly.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TyhpCt7aCqVoThBKAHEC3c)_