### PR TITLE
feat(leveling): award XP for web casino/poker/duel/economy actions

### DIFF
--- a/common/src/main/kotlin/common/leveling/XpAmounts.kt
+++ b/common/src/main/kotlin/common/leveling/XpAmounts.kt
@@ -1,0 +1,14 @@
+package common.leveling
+
+/**
+ * Shared XP grant constants used by every user-action XP source.
+ *
+ * Discord's [bot.toby.handler.SlashCommandEventListener] and the web
+ * surface's gameplay/economy interceptor both pay [COMMAND_XP] per
+ * user-initiated action so the two surfaces stay symmetrical. The daily
+ * cap (see [database.service.XpAwardService]) prevents either source from
+ * being farmed.
+ */
+object XpAmounts {
+    const val COMMAND_XP: Long = 5L
+}

--- a/discord-bot/src/main/kotlin/bot/toby/handler/SlashCommandEventListener.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/handler/SlashCommandEventListener.kt
@@ -1,5 +1,6 @@
 package bot.toby.handler
 
+import common.leveling.XpAmounts
 import common.logging.DiscordLogger
 import core.managers.CommandManager
 import database.service.XpAwardService
@@ -38,18 +39,11 @@ class SlashCommandEventListener @Autowired constructor(
                 xpAwardService.award(
                     discordId = event.user.idLong,
                     guildId = guildId,
-                    amount = COMMAND_XP,
+                    amount = XpAmounts.COMMAND_XP,
                     reason = "slash-command:${event.name}",
                     channelId = channelId
                 )
             }
         }
-    }
-
-    companion object {
-        // Small XP grant per slash-command invocation. The daily XP cap
-        // (default 1000) prevents spam-farming while still letting active
-        // users meaningfully progress from command usage alone.
-        const val COMMAND_XP: Long = 5L
     }
 }

--- a/web/src/main/kotlin/web/configuration/WebMvcConfig.kt
+++ b/web/src/main/kotlin/web/configuration/WebMvcConfig.kt
@@ -1,0 +1,38 @@
+package web.configuration
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+import web.util.WebGameplayXpInterceptor
+
+/**
+ * MVC pipeline wiring. Kept separate from [WebSecurityConfig] because
+ * that file's concern is the security filter chain, not the handler
+ * interceptor list.
+ *
+ * Registers [WebGameplayXpInterceptor] against every web surface that
+ * represents a user-initiated gameplay or economy action — so engaging
+ * with these features through the browser awards XP the same way running
+ * the equivalent Discord slash command does.
+ */
+@Configuration
+class WebMvcConfig(
+    private val webGameplayXpInterceptor: WebGameplayXpInterceptor,
+) : WebMvcConfigurer {
+
+    override fun addInterceptors(registry: InterceptorRegistry) {
+        registry.addInterceptor(webGameplayXpInterceptor)
+            // Casino games (12) plus lottery — all `/casino/{guildId}/**`.
+            .addPathPatterns("/casino/{guildId}/**")
+            // Blackjack lives at its own root for historical reasons.
+            .addPathPatterns("/blackjack/{guildId}/**")
+            // Poker — multi-table cash games.
+            .addPathPatterns("/poker/{guildId}/**")
+            // 1v1 duels.
+            .addPathPatterns("/duel/{guildId}/**")
+            // Toby-coin market: buy / sell.
+            .addPathPatterns("/economy/{guildId}/**")
+            // Peer tipping — `/tip/{guildId}` is a single POST.
+            .addPathPatterns("/tip/{guildId}")
+    }
+}

--- a/web/src/main/kotlin/web/util/WebGameplayXpInterceptor.kt
+++ b/web/src/main/kotlin/web/util/WebGameplayXpInterceptor.kt
@@ -1,0 +1,76 @@
+package web.util
+
+import common.leveling.XpAmounts
+import database.service.XpAwardService
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.oauth2.core.user.OAuth2User
+import org.springframework.stereotype.Component
+import org.springframework.web.servlet.HandlerInterceptor
+import org.springframework.web.servlet.HandlerMapping
+
+/**
+ * Mirrors [bot.toby.handler.SlashCommandEventListener] on the web side:
+ * after a successful POST to a gameplay/economy endpoint, award the same
+ * [XpAmounts.COMMAND_XP] grant the Discord listener pays per slash
+ * invocation. Wiring it as a [HandlerInterceptor] keeps the ~17
+ * gameplay/economy controllers free of per-method XP-award boilerplate
+ * and gives us one chokepoint to audit, the same way [WebGuildAccess]
+ * collapses the per-method membership check.
+ *
+ * Conditions for paying out (every guard short-circuits to no-op):
+ *  - `POST` only — `GET` is page render / polling, not engagement.
+ *  - Response status is 2xx — `WebGuildAccess` already 401/403's
+ *    non-members, and casino common failures map to 4xx, so a failing
+ *    "spin while broke" doesn't pay.
+ *  - The matched route has a `{guildId}` path variable that parses to a
+ *    `Long` — drops the few global gameplay surfaces (e.g. lottery guild
+ *    selector) that don't bind to a single guild.
+ *  - The authenticated principal exposes a Discord id via
+ *    [discordIdOrNull] — anonymous webhook traffic or test requests with
+ *    no security context never reach the award call.
+ *
+ * Daily cap, level-up event publishing, and unknown-user no-op all live
+ * inside [XpAwardService.award], so we don't need to re-implement any of
+ * that here.
+ */
+@Component
+class WebGameplayXpInterceptor(
+    private val xpAwardService: XpAwardService,
+) : HandlerInterceptor {
+
+    override fun afterCompletion(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        handler: Any,
+        ex: Exception?,
+    ) {
+        if (!request.method.equals("POST", ignoreCase = true)) return
+        if (response.status !in 200..299) return
+
+        val guildId = request.guildIdFromPath() ?: return
+        val discordId = request.authenticatedDiscordId() ?: return
+
+        xpAwardService.award(
+            discordId = discordId,
+            guildId = guildId,
+            amount = XpAmounts.COMMAND_XP,
+            reason = "web:${request.requestURI}",
+            channelId = null,
+        )
+    }
+
+    private fun HttpServletRequest.guildIdFromPath(): Long? {
+        @Suppress("UNCHECKED_CAST")
+        val vars = getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE)
+            as? Map<String, String> ?: return null
+        return vars["guildId"]?.toLongOrNull()
+    }
+
+    private fun HttpServletRequest.authenticatedDiscordId(): Long? {
+        val principal = SecurityContextHolder.getContext()?.authentication?.principal
+        val oAuthUser = principal as? OAuth2User ?: return null
+        return oAuthUser.discordIdOrNull()
+    }
+}

--- a/web/src/test/kotlin/web/util/WebGameplayXpInterceptorTest.kt
+++ b/web/src/test/kotlin/web/util/WebGameplayXpInterceptorTest.kt
@@ -1,0 +1,210 @@
+package web.util
+
+import common.leveling.XpAmounts
+import database.service.XpAwardService
+import io.mockk.MockKVerificationScope
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpServletResponse
+import org.springframework.security.authentication.TestingAuthenticationToken
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.oauth2.core.user.OAuth2User
+import org.springframework.web.servlet.HandlerMapping
+
+class WebGameplayXpInterceptorTest {
+
+    private val xpAwardService: XpAwardService = mockk(relaxed = true)
+    private val interceptor = WebGameplayXpInterceptor(xpAwardService)
+
+    private val discordId = 4242L
+    private val guildId = 999L
+
+    @BeforeEach
+    fun setup() {
+        clearMocks(xpAwardService)
+        SecurityContextHolder.clearContext()
+    }
+
+    @AfterEach
+    fun teardown() {
+        SecurityContextHolder.clearContext()
+    }
+
+    private fun authenticate(discordIdAttribute: String?) {
+        val principal: OAuth2User = mockk(relaxed = true) {
+            every { getAttribute<String>("id") } returns discordIdAttribute
+        }
+        val auth = TestingAuthenticationToken(principal, null)
+        SecurityContextHolder.getContext().authentication = auth
+    }
+
+    private fun request(
+        method: String,
+        uri: String,
+        guildIdVar: String? = guildId.toString(),
+    ): MockHttpServletRequest = MockHttpServletRequest(method, uri).apply {
+        requestURI = uri
+        if (guildIdVar != null) {
+            setAttribute(
+                HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE,
+                mapOf("guildId" to guildIdVar)
+            )
+        }
+    }
+
+    private fun runAfterCompletion(
+        req: MockHttpServletRequest,
+        responseStatus: Int = 200,
+    ) {
+        val resp = MockHttpServletResponse().apply { status = responseStatus }
+        interceptor.afterCompletion(req, resp, Any(), null)
+    }
+
+    // The `at: Instant = Instant.now()` default in XpAwardService.award is
+    // evaluated at call site, so we use any() for `at` and the daily-cap
+    // flag we don't pass explicitly.
+    private fun MockKVerificationScope.awardedWithReason(reason: String) =
+        xpAwardService.award(
+            discordId = discordId,
+            guildId = guildId,
+            amount = XpAmounts.COMMAND_XP,
+            reason = reason,
+            channelId = null,
+            countsAgainstDailyCap = any(),
+            at = any(),
+        )
+
+    private fun verifyNoAward() {
+        verify(exactly = 0) {
+            xpAwardService.award(any(), any(), any(), any(), any(), any(), any())
+        }
+    }
+
+    // ---- happy paths across every gameplay/economy family ----
+
+    @Test
+    fun `casino slots POST 200 awards XP`() {
+        authenticate(discordId.toString())
+        runAfterCompletion(request("POST", "/casino/$guildId/slots/spin"))
+        verify(exactly = 1) { awardedWithReason("web:/casino/$guildId/slots/spin") }
+    }
+
+    @Test
+    fun `blackjack solo deal POST awards XP`() {
+        authenticate(discordId.toString())
+        runAfterCompletion(request("POST", "/blackjack/$guildId/solo/deal"))
+        verify(exactly = 1) { awardedWithReason("web:/blackjack/$guildId/solo/deal") }
+    }
+
+    @Test
+    fun `poker table action POST awards XP`() {
+        authenticate(discordId.toString())
+        runAfterCompletion(request("POST", "/poker/$guildId/77/action"))
+        verify(exactly = 1) { awardedWithReason("web:/poker/$guildId/77/action") }
+    }
+
+    @Test
+    fun `duel challenge POST awards XP`() {
+        authenticate(discordId.toString())
+        runAfterCompletion(request("POST", "/duel/$guildId/challenge"))
+        verify(exactly = 1) { awardedWithReason("web:/duel/$guildId/challenge") }
+    }
+
+    @Test
+    fun `economy buy POST awards XP`() {
+        authenticate(discordId.toString())
+        runAfterCompletion(request("POST", "/economy/$guildId/buy"))
+        verify(exactly = 1) { awardedWithReason("web:/economy/$guildId/buy") }
+    }
+
+    @Test
+    fun `tip POST awards XP`() {
+        authenticate(discordId.toString())
+        runAfterCompletion(request("POST", "/tip/$guildId"))
+        verify(exactly = 1) { awardedWithReason("web:/tip/$guildId") }
+    }
+
+    @Test
+    fun `lottery buy POST awards XP`() {
+        authenticate(discordId.toString())
+        runAfterCompletion(request("POST", "/casino/$guildId/lottery/match/buy"))
+        verify(exactly = 1) { awardedWithReason("web:/casino/$guildId/lottery/match/buy") }
+    }
+
+    // ---- guards ----
+
+    @Test
+    fun `GET request never awards XP`() {
+        authenticate(discordId.toString())
+        runAfterCompletion(request("GET", "/casino/$guildId/slots"))
+        verifyNoAward()
+    }
+
+    @Test
+    fun `4xx response does not award XP`() {
+        authenticate(discordId.toString())
+        runAfterCompletion(request("POST", "/casino/$guildId/slots/spin"), responseStatus = 400)
+        verifyNoAward()
+    }
+
+    @Test
+    fun `5xx response does not award XP`() {
+        authenticate(discordId.toString())
+        runAfterCompletion(request("POST", "/casino/$guildId/slots/spin"), responseStatus = 500)
+        verifyNoAward()
+    }
+
+    @Test
+    fun `missing guildId path variable does not award XP`() {
+        authenticate(discordId.toString())
+        runAfterCompletion(request("POST", "/lottery/guilds", guildIdVar = null))
+        verifyNoAward()
+    }
+
+    @Test
+    fun `unparseable guildId does not award XP`() {
+        authenticate(discordId.toString())
+        runAfterCompletion(request("POST", "/casino/foo/slots/spin", guildIdVar = "foo"))
+        verifyNoAward()
+    }
+
+    @Test
+    fun `anonymous principal does not award XP`() {
+        // No SecurityContextHolder authentication set.
+        runAfterCompletion(request("POST", "/casino/$guildId/slots/spin"))
+        verifyNoAward()
+    }
+
+    @Test
+    fun `OAuth2User missing id attribute does not award XP`() {
+        authenticate(discordIdAttribute = null)
+        runAfterCompletion(request("POST", "/casino/$guildId/slots/spin"))
+        verifyNoAward()
+    }
+
+    @Test
+    fun `OAuth2User with non-numeric id does not award XP`() {
+        authenticate(discordIdAttribute = "not-a-long")
+        runAfterCompletion(request("POST", "/casino/$guildId/slots/spin"))
+        verifyNoAward()
+    }
+
+    @Test
+    fun `non-OAuth principal does not award XP`() {
+        // A non-OAuth2 authentication (e.g. anonymous token) should be ignored.
+        // Uses TestingAuthenticationToken (purpose-built for test stubs) rather
+        // than UsernamePasswordAuthenticationToken — the latter's class name
+        // trips GitGuardian's generic-password detector when paired with a
+        // literal principal, even though the credentials slot is null.
+        val auth = TestingAuthenticationToken("not-an-oauth-user", null)
+        SecurityContextHolder.getContext().authentication = auth
+        runAfterCompletion(request("POST", "/casino/$guildId/slots/spin"))
+        verifyNoAward()
+    }
+}


### PR DESCRIPTION
## Summary

Web gameplay surfaces (casino, blackjack, poker, duels, lottery, the economy market, tips) previously bypassed the XP system entirely — playing slots in Discord awarded 5 XP per slash invocation, but the same action through the browser awarded zero. This change closes the gap.

- New `WebGameplayXpInterceptor` — a Spring `HandlerInterceptor` that, after a successful (2xx) POST to a gameplay/economy route, calls `XpAwardService.award(...)` with the same 5 XP grant Discord uses per slash command.
- New `WebMvcConfig` — registers the interceptor against `/casino/{guildId}/**`, `/blackjack/{guildId}/**`, `/poker/{guildId}/**`, `/duel/{guildId}/**`, `/economy/{guildId}/**`, and `/tip/{guildId}`.
- Promotes `COMMAND_XP` from `SlashCommandEventListener` to `common.leveling.XpAmounts.COMMAND_XP` so discord-bot and web reference a single source of truth instead of two 5L literals.

Daily cap (default 1000/guild/day), level-up event publishing, and unknown-user no-op all already live inside `XpAwardService.award`, so the interceptor is just the trigger. `channelId` is passed as `null` from the web (no Discord channel context), which falls back to the guild system channel on the level-up announcement listener — already supported.

### Guards

The interceptor short-circuits to no-op unless **all** of the following are true:
- Request is a POST.
- Response status is 2xx (failed validation, 401/403/404, and casino common failures map to 4xx and don't pay).
- Matched route has a `{guildId}` path variable that parses to a `Long`.
- Authenticated principal exposes a Discord id (`OAuth2User` with an `id` attribute).

Multi-step games like blackjack and poker accrue more XP per round than slots, because each POST (deal, hit, stand, double, create, join, start, action, cashout) is its own grant — same as if you ran the equivalent sequence of Discord slash commands. The daily cap bounds farming.

## Test plan

- [x] `WebGameplayXpInterceptorTest` — 16 tests covering each gameplay/economy family's happy path plus every guard (GET, 4xx, 5xx, missing/unparseable guildId, anonymous, missing id attribute, non-numeric id, non-OAuth principal). All green locally.
- [x] `:web:test` + `:common:test` — full suites pass.
- [ ] CI build for `:discord-bot` — couldn't compile in the sandbox (libdave network restriction); CI will exercise the constant move on its side.
- [ ] Manual smoke (post-deploy): log in via Discord OAuth, spin slots once → `UserDto.xp` increases by 5; deal/hit/hit/stand a blackjack hand → +20 XP; nudge XP near a level threshold and confirm the Discord-side `LevelUpEvent` listener posts to the guild system channel.

https://claude.ai/code/session_011dh8gSJfVE61Bqz7t47QS8

---
_Generated by [Claude Code](https://claude.ai/code/session_011dh8gSJfVE61Bqz7t47QS8)_