### PR TITLE
docs(home): surface levelling system in Engagement section

### DIFF
--- a/web/src/main/resources/templates/home.html
+++ b/web/src/main/resources/templates/home.html
@@ -93,9 +93,10 @@
         <span class="section-eyebrow">Engagement</span>
         <h2>Make your server worth showing up to</h2>
         <p class="section-lede">
-            Voice-time and message activity feed monthly leaderboards, a per-user
-            profile, and personalised intro songs. Configurable daily caps,
-            UBI for non-voice users, and a 30-day rolling activity window.
+            Voice-time and message activity earn XP and credit &mdash; feeding levels,
+            monthly leaderboards, per-user profiles, and personalised intro songs.
+            Configurable daily caps, UBI for non-voice users, and a 30-day rolling
+            activity window.
         </p>
     </header>
     <div class="feature-grid">
@@ -113,6 +114,11 @@
             <div class="feature-icon">&#127925;</div>
             <h3>Intro songs</h3>
             <p>Set a custom track that plays whenever you join voice. YouTube links or MP3 uploads, capped per user.</p>
+        </a>
+        <a class="feature-card" href="/profile/guilds">
+            <div class="feature-icon">&#11088;</div>
+            <h3>Levels &amp; XP</h3>
+            <p>Earn XP from messages, slash commands, voice intros, and voice sessions. Level up to unlock role rewards and gated vanity titles; check your progress with <code>/level</code> or on your profile.</p>
         </a>
     </div>
 </section>


### PR DESCRIPTION
## Summary
- The Engagement section on the homepage advertised Leaderboards, Profile, and Intro songs but never mentioned the full XP/levelling system that powers them — even though every profile page already renders a Level Card.
- Reworded the section lede so it names XP and levels as the engagement mechanic (kept the daily caps / UBI / 30-day window detail).
- Added a fourth `Levels & XP` feature card (⭐) linking to `/profile/guilds`, matching the existing `.feature-card` pattern and calling out role rewards, gated titles, and the `/level` slash command.

No CSS or new templates — the `.feature-grid` (`repeat(auto-fill, minmax(240px, 1fr))`) accommodates a fourth card without layout changes.

## Test plan
- [ ] Boot the web module locally and load `/`.
- [ ] Engagement section shows four cards: Leaderboards, Profile, Intro songs, **Levels & XP**.
- [ ] Section lede reads naturally and explicitly mentions XP and levels.
- [ ] Clicking the new card lands on `/profile/guilds` (same as the Profile card).
- [ ] Resize the viewport — grid wraps responsively, spacing/border/hover match the other three cards.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SEPBB636zTXWciFqgko6DK)_