### PR TITLE
fix(leveling): render full progress bar on level-up embed

### DIFF
--- a/discord-bot/src/main/kotlin/bot/toby/leveling/LevelUpListener.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/leveling/LevelUpListener.kt
@@ -75,7 +75,7 @@ class LevelUpListener @Autowired constructor(
     }
 
     private fun buildLevelUpEmbed(event: LevelUpEvent, member: Member?): MessageEmbed {
-        val progress = LevelCurve.progress(event.totalXp)
+        val achievedXp = LevelCurve.xpForNextLevel((event.newLevel - 1).coerceAtLeast(0))
         val mention = "<@${event.discordId}>"
         val builder = EmbedBuilder()
             .setTitle("Level Up — LVL ${event.newLevel}")
@@ -83,8 +83,8 @@ class LevelUpListener @Autowired constructor(
             .setColor(Color(tierColor(event.newLevel)))
             .addField(
                 "Progress",
-                "`${progressBar(progress.xpIntoLevel, progress.xpForNextLevel)}` " +
-                    "${formatXp(progress.xpIntoLevel)} / ${formatXp(progress.xpForNextLevel)} XP",
+                "`${progressBar(achievedXp, achievedXp)}` " +
+                    "${formatXp(achievedXp)} / ${formatXp(achievedXp)} XP",
                 false
             )
             .addField("Total XP", formatXp(event.totalXp), true)

--- a/discord-bot/src/test/kotlin/bot/toby/leveling/LevelUpListenerTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/leveling/LevelUpListenerTest.kt
@@ -210,7 +210,7 @@ class LevelUpListenerTest {
 
         // Craft a totalXp that sits inside level 25 (Gold tier).
         val totalXp = LevelCurve.cumulativeXpForLevel(25) + 50L
-        val expected = LevelCurve.progress(totalXp)
+        val achieved = LevelCurve.xpForNextLevel(24)
 
         listener.onLevelUp(
             LevelUpEvent(
@@ -227,10 +227,12 @@ class LevelUpListenerTest {
             "expected Gold tier color 0xD4A017, got ${(embed.colorRaw and 0xFFFFFF).toString(16)}"
         }
         val progressField = embed.fields.single { it.name == "Progress" }.value!!
-        val formattedInto = String.format("%,d", expected.xpIntoLevel)
-        val formattedNext = String.format("%,d", expected.xpForNextLevel)
-        assert(progressField.contains("$formattedInto / $formattedNext XP")) {
-            "progress field '$progressField' should contain '$formattedInto / $formattedNext XP'"
+        val formattedAchieved = String.format("%,d", achieved)
+        assert(progressField.contains("$formattedAchieved / $formattedAchieved XP")) {
+            "progress field '$progressField' should contain '$formattedAchieved / $formattedAchieved XP'"
+        }
+        assert(progressField.contains("██████████")) {
+            "progress field '$progressField' should render a full bar on level-up"
         }
         val totalField = embed.fields.single { it.name == "Total XP" }.value!!
         assert(totalField.contains(String.format("%,d", totalXp)))


### PR DESCRIPTION
## Summary
- The Progress field on the level-up embed was computed via `LevelCurve.progress(totalXp)`, which returns `xpIntoLevel = 0` when the user lands exactly on the level threshold. That made the celebration message render an empty bar (e.g. `░░░░░░░░░░ 0 / 155 XP`) right at the moment of leveling up — the "wonky" look in the screenshot.
- Switch `buildLevelUpEmbed` to use `LevelCurve.xpForNextLevel(newLevel - 1)` as both `filled` and `total` for the bar, so the achieved level renders as full: `██████████ 100 / 100 XP` for LVL 1, `██████████ 155 / 155 XP` for LVL 2, etc.
- Total XP field (lifetime cumulative) is unchanged.

## Before / After
- Before — LVL 1 announce: `░░░░░░░░░░ 0 / 155 XP`, Total XP `100`
- After — LVL 1 announce: `██████████ 100 / 100 XP`, Total XP `100`

## Test plan
- [x] Update `LevelUpListenerTest.onLevelUp posts a tier-colored embed with progress matching LevelCurve` to assert the achieved threshold renders as `xpForNextLevel(24) / xpForNextLevel(24) XP` with a fully-filled bar.
- [ ] `./gradlew :discord-bot:test --tests "bot.toby.leveling.LevelUpListenerTest"` — not run in this environment (Maven repos for `lavasrc` / `libdave` returned 401/403 from the sandbox); please run locally / in CI.
- [ ] Manual smoke: grant enough XP to cross the level 1 and level 2 thresholds and confirm the Progress field shows a full bar.

---
_Generated by [Claude Code](https://claude.ai/code/session_01D9YyERrVMvc3koRxayJdi8)_