### PR TITLE
refactor(web): reorganize moderation settings UI into Server/Economy/Casino pillars

### DIFF
--- a/web/src/main/resources/static/css/moderation.css
+++ b/web/src/main/resources/static/css/moderation.css
@@ -169,6 +169,23 @@ details.config-section.is-hidden { display: none; }
 .btn-danger:disabled { opacity: 0.4; cursor: not-allowed; }
 
 /* Config tab */
+/* Top-level pillar headers ("Server", "Economy", "Casino") that group
+   the accordion sections beneath them. Plain <h2> siblings between
+   <details> blocks — kept out of `.config-section` so the search filter
+   in settings.js doesn't pick them up as collapsible cards. */
+.config-pillar {
+    margin: var(--space-4) 0 var(--space-2);
+    padding: 0 0 var(--space-2);
+    font-size: 0.78rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--accent);
+    border-bottom: 1px solid var(--border);
+}
+.config-pillar:first-of-type { margin-top: 0; }
+.config-pillar.is-hidden { display: none; }
+
 .config-section {
     margin-bottom: var(--space-3);
     background: var(--bg-elevated);
@@ -375,10 +392,11 @@ details.config-section.is-hidden { display: none; }
     margin: var(--space-2) 0 0;
 }
 
-/* Config sub-groups (e.g. "Casino stakes & buy-ins" splits into Dice /
-   Coinflip / Poker / etc. sub-groups). Each `.config-group` carries a
-   small uppercase `<h4>` heading and a hairline divider between groups
-   so the card is scannable game-by-game. */
+/* Config sub-groups (e.g. "Game stake limits" splits into Dice /
+   Coinflip / etc. per game; Blackjack and Poker sections split into
+   "Table rules" and stake/blind sub-groups). Each `.config-group`
+   carries a small uppercase `<h4>` heading and a hairline divider
+   between groups so the card is scannable group-by-group. */
 .config-group { padding-top: var(--space-2); }
 .config-group + .config-group {
     border-top: 1px solid var(--border);

--- a/web/src/main/resources/static/js/moderation/settings.js
+++ b/web/src/main/resources/static/js/moderation/settings.js
@@ -26,6 +26,7 @@
     const total = rows.length;
 
     const sections = Array.from(document.querySelectorAll('details.config-section'));
+    const pillars = Array.from(document.querySelectorAll('h2.config-pillar'));
     // Snapshot which sections were open before any search ran so we can
     // restore that state when the query is cleared. Force-open while
     // searching so matches deep inside collapsed sections are visible.
@@ -58,6 +59,22 @@
             const anyVisible = sectionRows.some(r => !r.classList.contains('is-hidden'));
             section.classList.toggle('is-hidden', !anyVisible && q !== '');
             if (q !== '' && anyVisible) section.open = true;
+        });
+        // Hide pillar headers whose sections are all filtered out so the
+        // page doesn't show a bare "Casino" h2 with nothing under it. A
+        // pillar "owns" every sibling .config-section up to the next
+        // pillar; walk forward from each pillar and check whether any
+        // owned section is still visible.
+        pillars.forEach((pillar, idx) => {
+            const nextPillar = pillars[idx + 1] || null;
+            let anyOwnedVisible = false;
+            for (let el = pillar.nextElementSibling; el && el !== nextPillar; el = el.nextElementSibling) {
+                if (el.classList.contains('config-section') && !el.classList.contains('is-hidden')) {
+                    anyOwnedVisible = true;
+                    break;
+                }
+            }
+            pillar.classList.toggle('is-hidden', !anyOwnedVisible && q !== '');
         });
         if (count) {
             count.textContent = q === '' ? '' : shown + ' of ' + total;

--- a/web/src/main/resources/templates/moderation/settings.html
+++ b/web/src/main/resources/templates/moderation/settings.html
@@ -32,8 +32,10 @@
             <span id="config-search-count" class="mod-search-count" aria-live="polite"></span>
         </div>
 
+        <h2 class="config-pillar">Server</h2>
+
         <details class="config-section" open>
-            <summary>Audio &amp; moves</summary>
+            <summary>Server features</summary>
             <div class="config-grid">
                 <div class="config-row" data-key="VOLUME">
                     <label>Default volume</label>
@@ -57,6 +59,24 @@
                                 th:value="${vc.name}"
                                 th:text="${vc.name}"
                                 th:selected="${overview.config['MOVE'] == vc.name}"></option>
+                    </select>
+                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                </div>
+                <!-- Saving "true" here kicks an ActivityTrackingEnabled event that
+                     fires the first-enable DM flow, matching the Discord
+                     /setconfig behaviour. Default value is "false" when no row
+                     exists yet — matches ActivityTrackingService's read default. -->
+                <div class="config-row" data-key="ACTIVITY_TRACKING">
+                    <label>Game-activity tracking</label>
+                    <select th:disabled="${!isOwner}">
+                        <option value="false"
+                                th:selected="${overview.config['ACTIVITY_TRACKING'] == null or overview.config['ACTIVITY_TRACKING'] == 'false'}">
+                            Disabled
+                        </option>
+                        <option value="true"
+                                th:selected="${overview.config['ACTIVITY_TRACKING'] == 'true'}">
+                            Enabled
+                        </option>
                     </select>
                     <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
                 </div>
@@ -123,29 +143,7 @@
             </div>
         </details>
 
-        <details class="config-section">
-            <summary>Activity tracking</summary>
-            <div class="config-grid">
-                <!-- Saving "true" here kicks an ActivityTrackingEnabled event that
-                     fires the first-enable DM flow, matching the Discord
-                     /setconfig behaviour. Default value is "false" when no row
-                     exists yet — matches ActivityTrackingService's read default. -->
-                <div class="config-row" data-key="ACTIVITY_TRACKING">
-                    <label>Game-activity tracking</label>
-                    <select th:disabled="${!isOwner}">
-                        <option value="false"
-                                th:selected="${overview.config['ACTIVITY_TRACKING'] == null or overview.config['ACTIVITY_TRACKING'] == 'false'}">
-                            Disabled
-                        </option>
-                        <option value="true"
-                                th:selected="${overview.config['ACTIVITY_TRACKING'] == 'true'}">
-                            Enabled
-                        </option>
-                    </select>
-                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                </div>
-            </div>
-        </details>
+        <h2 class="config-pillar">Economy</h2>
 
         <details class="config-section">
             <summary>Economy</summary>
@@ -190,6 +188,8 @@
                 </div>
             </div>
         </details>
+
+        <h2 class="config-pillar">Casino</h2>
 
         <details class="config-section">
             <summary>Jackpot</summary>
@@ -425,32 +425,86 @@
         <details class="config-section">
             <summary>Poker</summary>
             <div class="config-grid">
-                <div class="config-row" data-key="POKER_RAKE_PCT">
-                    <label>Poker rake (% of every settled pot routed to jackpot; default 5)</label>
-                    <span class="config-input-group">
-                        <input type="number" min="0" max="20" step="1"
-                               th:value="${overview.config['POKER_RAKE_PCT']}"
+                <div class="config-group">
+                    <h4>Table rules</h4>
+                    <div class="config-row" data-key="POKER_RAKE_PCT">
+                        <label>Poker rake (% of every settled pot routed to jackpot; default 5)</label>
+                        <span class="config-input-group">
+                            <input type="number" min="0" max="20" step="1"
+                                   th:value="${overview.config['POKER_RAKE_PCT']}"
+                                   placeholder="5"
+                                   th:disabled="${!isOwner}">
+                            <span class="config-suffix">%</span>
+                        </span>
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
+                    <div class="config-row" data-key="POKER_MAX_SEATS">
+                        <label>Max seats per table (2-9; default 6)</label>
+                        <input type="number" min="2" max="9"
+                               th:value="${overview.config['POKER_MAX_SEATS']}"
+                               placeholder="6"
+                               th:disabled="${!isOwner}">
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
+                    <div class="config-row" data-key="POKER_SHOT_CLOCK_SECONDS">
+                        <label>Decision deadline per actor (seconds; 0 disables; default 30)</label>
+                        <input type="number" min="0" max="600"
+                               th:value="${overview.config['POKER_SHOT_CLOCK_SECONDS']}"
+                               placeholder="30"
+                               th:disabled="${!isOwner}">
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
+                </div>
+                <div class="config-group">
+                    <h4>Blinds &amp; buy-ins</h4>
+                    <div class="config-row" data-key="POKER_SMALL_BLIND">
+                        <label>Small blind (chips posted by SB seat each hand; default 5)</label>
+                        <input type="number" min="1"
+                               th:value="${overview.config['POKER_SMALL_BLIND']}"
                                placeholder="5"
                                th:disabled="${!isOwner}">
-                        <span class="config-suffix">%</span>
-                    </span>
-                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                </div>
-                <div class="config-row" data-key="POKER_MAX_SEATS">
-                    <label>Max seats per table (2-9; default 6)</label>
-                    <input type="number" min="2" max="9"
-                           th:value="${overview.config['POKER_MAX_SEATS']}"
-                           placeholder="6"
-                           th:disabled="${!isOwner}">
-                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                </div>
-                <div class="config-row" data-key="POKER_SHOT_CLOCK_SECONDS">
-                    <label>Decision deadline per actor (seconds; 0 disables; default 30)</label>
-                    <input type="number" min="0" max="600"
-                           th:value="${overview.config['POKER_SHOT_CLOCK_SECONDS']}"
-                           placeholder="30"
-                           th:disabled="${!isOwner}">
-                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
+                    <div class="config-row" data-key="POKER_BIG_BLIND">
+                        <label>Big blind (chips posted by BB seat each hand; default 10)</label>
+                        <input type="number" min="1"
+                               th:value="${overview.config['POKER_BIG_BLIND']}"
+                               placeholder="10"
+                               th:disabled="${!isOwner}">
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
+                    <div class="config-row" data-key="POKER_SMALL_BET">
+                        <label>Small bet (fixed-limit bet pre-flop &amp; flop; default 10)</label>
+                        <input type="number" min="1"
+                               th:value="${overview.config['POKER_SMALL_BET']}"
+                               placeholder="10"
+                               th:disabled="${!isOwner}">
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
+                    <div class="config-row" data-key="POKER_BIG_BET">
+                        <label>Big bet (fixed-limit bet on turn &amp; river; default 20)</label>
+                        <input type="number" min="1"
+                               th:value="${overview.config['POKER_BIG_BET']}"
+                               placeholder="20"
+                               th:disabled="${!isOwner}">
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
+                    <div class="config-row" data-key="POKER_MIN_BUY_IN">
+                        <label>Minimum buy-in per seat (chips; default 100)</label>
+                        <input type="number" min="1"
+                               th:value="${overview.config['POKER_MIN_BUY_IN']}"
+                               placeholder="100"
+                               th:disabled="${!isOwner}">
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
+                    <div class="config-row" data-key="POKER_MAX_BUY_IN">
+                        <label>Maximum buy-in per seat (chips; 0 = unlimited; default 5000)</label>
+                        <input type="number" min="0"
+                               th:value="${overview.config['POKER_MAX_BUY_IN']}"
+                               placeholder="5000"
+                               th:disabled="${!isOwner}">
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
                 </div>
             </div>
         </details>
@@ -458,73 +512,95 @@
         <details class="config-section">
             <summary>Blackjack</summary>
             <div class="config-grid">
-                <div class="config-row" data-key="BLACKJACK_RAKE_PCT">
-                    <label>Blackjack rake (% of multi-table losers' pool routed to jackpot; default 5)</label>
-                    <span class="config-input-group">
-                        <input type="number" min="0" max="20" step="1"
-                               th:value="${overview.config['BLACKJACK_RAKE_PCT']}"
+                <div class="config-group">
+                    <h4>Table rules</h4>
+                    <div class="config-row" data-key="BLACKJACK_RAKE_PCT">
+                        <label>Blackjack rake (% of multi-table losers' pool routed to jackpot; default 5)</label>
+                        <span class="config-input-group">
+                            <input type="number" min="0" max="20" step="1"
+                                   th:value="${overview.config['BLACKJACK_RAKE_PCT']}"
+                                   placeholder="5"
+                                   th:disabled="${!isOwner}">
+                            <span class="config-suffix">%</span>
+                        </span>
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
+                    <div class="config-row" data-key="BLACKJACK_MAX_SEATS">
+                        <label>Max seats per multi table (2-7; default 5)</label>
+                        <input type="number" min="2" max="7"
+                               th:value="${overview.config['BLACKJACK_MAX_SEATS']}"
                                placeholder="5"
                                th:disabled="${!isOwner}">
-                        <span class="config-suffix">%</span>
-                    </span>
-                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
+                    <div class="config-row" data-key="BLACKJACK_SHOT_CLOCK_SECONDS">
+                        <label>Decision deadline per actor (seconds; 0 disables; default 30)</label>
+                        <input type="number" min="0" max="600"
+                               th:value="${overview.config['BLACKJACK_SHOT_CLOCK_SECONDS']}"
+                               placeholder="30"
+                               th:disabled="${!isOwner}">
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
+                    <div class="config-row" data-key="BLACKJACK_DEALER_HITS_SOFT_17">
+                        <label>Dealer rule on soft 17</label>
+                        <select th:disabled="${!isOwner}">
+                            <option value="false"
+                                    th:selected="${overview.config['BLACKJACK_DEALER_HITS_SOFT_17'] == null or overview.config['BLACKJACK_DEALER_HITS_SOFT_17'] == 'false'}">
+                                Stand on soft 17 (S17, default — better for the player)
+                            </option>
+                            <option value="true"
+                                    th:selected="${overview.config['BLACKJACK_DEALER_HITS_SOFT_17'] == 'true'}">
+                                Hit soft 17 (H17 — slightly worse for the player)
+                            </option>
+                        </select>
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
+                    <div class="config-row" data-key="BLACKJACK_BJ_PAYOUT_NUM">
+                        <label>Natural-blackjack payout numerator (e.g. 3 for 3:2; default 3)</label>
+                        <input type="number" min="1" max="10"
+                               th:value="${overview.config['BLACKJACK_BJ_PAYOUT_NUM']}"
+                               placeholder="3"
+                               th:disabled="${!isOwner}">
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
+                    <div class="config-row" data-key="BLACKJACK_BJ_PAYOUT_DEN">
+                        <label>Natural-blackjack payout denominator (e.g. 2 for 3:2; default 2)</label>
+                        <input type="number" min="1" max="10"
+                               th:value="${overview.config['BLACKJACK_BJ_PAYOUT_DEN']}"
+                               placeholder="2"
+                               th:disabled="${!isOwner}">
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
                 </div>
-                <div class="config-row" data-key="BLACKJACK_MAX_SEATS">
-                    <label>Max seats per multi table (2-7; default 5)</label>
-                    <input type="number" min="2" max="7"
-                           th:value="${overview.config['BLACKJACK_MAX_SEATS']}"
-                           placeholder="5"
-                           th:disabled="${!isOwner}">
-                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                </div>
-                <div class="config-row" data-key="BLACKJACK_SHOT_CLOCK_SECONDS">
-                    <label>Decision deadline per actor (seconds; 0 disables; default 30)</label>
-                    <input type="number" min="0" max="600"
-                           th:value="${overview.config['BLACKJACK_SHOT_CLOCK_SECONDS']}"
-                           placeholder="30"
-                           th:disabled="${!isOwner}">
-                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                </div>
-                <div class="config-row" data-key="BLACKJACK_DEALER_HITS_SOFT_17">
-                    <label>Dealer rule on soft 17</label>
-                    <select th:disabled="${!isOwner}">
-                        <option value="false"
-                                th:selected="${overview.config['BLACKJACK_DEALER_HITS_SOFT_17'] == null or overview.config['BLACKJACK_DEALER_HITS_SOFT_17'] == 'false'}">
-                            Stand on soft 17 (S17, default — better for the player)
-                        </option>
-                        <option value="true"
-                                th:selected="${overview.config['BLACKJACK_DEALER_HITS_SOFT_17'] == 'true'}">
-                            Hit soft 17 (H17 — slightly worse for the player)
-                        </option>
-                    </select>
-                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                </div>
-                <div class="config-row" data-key="BLACKJACK_BJ_PAYOUT_NUM">
-                    <label>Natural-blackjack payout numerator (e.g. 3 for 3:2; default 3)</label>
-                    <input type="number" min="1" max="10"
-                           th:value="${overview.config['BLACKJACK_BJ_PAYOUT_NUM']}"
-                           placeholder="3"
-                           th:disabled="${!isOwner}">
-                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                </div>
-                <div class="config-row" data-key="BLACKJACK_BJ_PAYOUT_DEN">
-                    <label>Natural-blackjack payout denominator (e.g. 2 for 3:2; default 2)</label>
-                    <input type="number" min="1" max="10"
-                           th:value="${overview.config['BLACKJACK_BJ_PAYOUT_DEN']}"
-                           placeholder="2"
-                           th:disabled="${!isOwner}">
-                    <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                <div class="config-group">
+                    <h4>Stakes per hand</h4>
+                    <div class="config-row" data-key="BLACKJACK_MIN_ANTE">
+                        <label>Minimum stake per hand (applies to solo &amp; multi; default 10)</label>
+                        <input type="number" min="1"
+                               th:value="${overview.config['BLACKJACK_MIN_ANTE']}"
+                               placeholder="10"
+                               th:disabled="${!isOwner}">
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
+                    <div class="config-row" data-key="BLACKJACK_MAX_ANTE">
+                        <label>Maximum stake per hand (applies to solo &amp; multi; 0 = unlimited; default 500)</label>
+                        <input type="number" min="0"
+                               th:value="${overview.config['BLACKJACK_MAX_ANTE']}"
+                               placeholder="500"
+                               th:disabled="${!isOwner}">
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
                 </div>
             </div>
         </details>
 
         <details class="config-section">
-            <summary>Casino stakes &amp; buy-ins</summary>
+            <summary>Game stake limits</summary>
             <p class="muted mb-2">
-                Stake and buy-in bounds for every casino game in one place. Set any maximum to
-                <code>0</code> to remove the cap. Jackpot win probability scales by
-                <code>stake / anchor</code>; the anchor lives in the
-                <strong>Jackpot</strong> section above.
+                Stake bounds for every simple casino game. Set any maximum to
+                <code>0</code> to remove the cap. Blackjack ante limits live
+                in the <strong>Blackjack</strong> section; poker blinds and
+                buy-ins live in the <strong>Poker</strong> section.
             </p>
             <div class="config-grid">
                 <div class="config-group">
@@ -756,25 +832,6 @@
                     </div>
                 </div>
                 <div class="config-group">
-                    <h4>Blackjack</h4>
-                    <div class="config-row" data-key="BLACKJACK_MIN_ANTE">
-                        <label>Minimum stake per hand (applies to solo &amp; multi; default 10)</label>
-                        <input type="number" min="1"
-                               th:value="${overview.config['BLACKJACK_MIN_ANTE']}"
-                               placeholder="10"
-                               th:disabled="${!isOwner}">
-                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                    </div>
-                    <div class="config-row" data-key="BLACKJACK_MAX_ANTE">
-                        <label>Maximum stake per hand (applies to solo &amp; multi; 0 = unlimited; default 500)</label>
-                        <input type="number" min="0"
-                               th:value="${overview.config['BLACKJACK_MAX_ANTE']}"
-                               placeholder="500"
-                               th:disabled="${!isOwner}">
-                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                    </div>
-                </div>
-                <div class="config-group">
                     <h4>Duel</h4>
                     <div class="config-row" data-key="DUEL_MIN_STAKE">
                         <label>Minimum stake (default 10)</label>
@@ -789,57 +846,6 @@
                         <input type="number" min="0"
                                th:value="${overview.config['DUEL_MAX_STAKE']}"
                                placeholder="500"
-                               th:disabled="${!isOwner}">
-                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                    </div>
-                </div>
-                <div class="config-group">
-                    <h4>Poker</h4>
-                    <div class="config-row" data-key="POKER_SMALL_BLIND">
-                        <label>Small blind (chips posted by SB seat each hand; default 5)</label>
-                        <input type="number" min="1"
-                               th:value="${overview.config['POKER_SMALL_BLIND']}"
-                               placeholder="5"
-                               th:disabled="${!isOwner}">
-                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                    </div>
-                    <div class="config-row" data-key="POKER_BIG_BLIND">
-                        <label>Big blind (chips posted by BB seat each hand; default 10)</label>
-                        <input type="number" min="1"
-                               th:value="${overview.config['POKER_BIG_BLIND']}"
-                               placeholder="10"
-                               th:disabled="${!isOwner}">
-                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                    </div>
-                    <div class="config-row" data-key="POKER_SMALL_BET">
-                        <label>Small bet (fixed-limit bet pre-flop &amp; flop; default 10)</label>
-                        <input type="number" min="1"
-                               th:value="${overview.config['POKER_SMALL_BET']}"
-                               placeholder="10"
-                               th:disabled="${!isOwner}">
-                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                    </div>
-                    <div class="config-row" data-key="POKER_BIG_BET">
-                        <label>Big bet (fixed-limit bet on turn &amp; river; default 20)</label>
-                        <input type="number" min="1"
-                               th:value="${overview.config['POKER_BIG_BET']}"
-                               placeholder="20"
-                               th:disabled="${!isOwner}">
-                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                    </div>
-                    <div class="config-row" data-key="POKER_MIN_BUY_IN">
-                        <label>Minimum buy-in per seat (chips; default 100)</label>
-                        <input type="number" min="1"
-                               th:value="${overview.config['POKER_MIN_BUY_IN']}"
-                               placeholder="100"
-                               th:disabled="${!isOwner}">
-                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
-                    </div>
-                    <div class="config-row" data-key="POKER_MAX_BUY_IN">
-                        <label>Maximum buy-in per seat (chips; 0 = unlimited; default 5000)</label>
-                        <input type="number" min="0"
-                               th:value="${overview.config['POKER_MAX_BUY_IN']}"
-                               placeholder="5000"
                                th:disabled="${!isOwner}">
                         <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
                     </div>

--- a/web/src/test/kotlin/web/template/ModerationTemplateRowsTest.kt
+++ b/web/src/test/kotlin/web/template/ModerationTemplateRowsTest.kt
@@ -35,9 +35,8 @@ class ModerationTemplateRowsTest {
 
     @Test
     fun `settings template surfaces every blackjack config key as an editable row`() {
-        // Stake-shaped keys (BLACKJACK_MIN_ANTE / BLACKJACK_MAX_ANTE) live
-        // in the consolidated "Casino stakes & buy-ins" card now, but the
-        // page still has to render rows for them — this test just asserts
+        // All Blackjack keys (table rules + ante stakes) now live together
+        // inside the Blackjack section; this test just asserts
         // presence-anywhere, not which card.
         val keys = listOf(
             ConfigDto.Configurations.BLACKJACK_RAKE_PCT,
@@ -106,10 +105,12 @@ class ModerationTemplateRowsTest {
     fun `settings template surfaces every stake or buy-in config key as an editable row`() {
         // Every stake-shaped config — per-minigame min/max, blackjack ante
         // bounds, and the poker chip thresholds (blinds/bets/buy-ins) —
-        // lives in the consolidated "Casino stakes & buy-ins" card. The
-        // jackpot stake anchor migrated up into the dedicated Jackpot
-        // section in the split refactor; it's covered by the dedicated
-        // jackpot test below.
+        // has a row somewhere on the settings page. Blackjack ante and
+        // Poker blinds/buy-ins now live inside their respective game
+        // sections; the simpler games live in the "Game stake limits"
+        // section. The jackpot stake anchor lives in the dedicated
+        // Jackpot section; it's covered by the dedicated jackpot test
+        // below.
         val keys = listOf(
             ConfigDto.Configurations.DICE_MIN_STAKE,
             ConfigDto.Configurations.DICE_MAX_STAKE,
@@ -147,27 +148,87 @@ class ModerationTemplateRowsTest {
     }
 
     @Test
-    fun `casino stakes and buy-ins section has its own collapsed details block`() {
+    fun `game stake limits section has its own collapsed details block`() {
         assertTrue(
-            settingsHtml.contains("<summary>Casino stakes &amp; buy-ins</summary>"),
-            "expected a <details><summary>Casino stakes & buy-ins</summary> wrapper around the consolidated stake rows"
+            settingsHtml.contains("<summary>Game stake limits</summary>"),
+            "expected a <details><summary>Game stake limits</summary> wrapper around the simple-game stake rows"
         )
     }
 
     @Test
-    fun `casino stakes card sub-groups every game with an h4 heading`() {
+    fun `game stake limits card sub-groups every game with an h4 heading`() {
         // The card is too long without sub-headings — admins scan by game.
         // Asserting on a sample of headings so a flatten regression is
         // obvious without making the test enumerate every group.
+        // Blackjack and Poker headings now live in their dedicated game
+        // sections under "Stakes per hand" / "Blinds & buy-ins"
+        // subgroups, so this card only carries the simple games.
         val headings = listOf(
             "<h4>Dice</h4>",
-            "<h4>Blackjack</h4>",
-            "<h4>Poker</h4>",
+            "<h4>Coinflip</h4>",
+            "<h4>Duel</h4>",
         )
         for (h in headings) {
             assertTrue(
                 settingsHtml.contains(h),
-                "expected $h sub-heading inside the consolidated card"
+                "expected $h sub-heading inside the Game stake limits card"
+            )
+        }
+    }
+
+    @Test
+    fun `blackjack section consolidates table rules and stake bounds in one place`() {
+        // Pre-pass, BLACKJACK_MIN_ANTE / MAX_ANTE lived in a separate
+        // "Casino stakes & buy-ins" card; tuning blackjack meant scrolling
+        // between two sections. Pin them inside the Blackjack section.
+        val blackjackStart = settingsHtml.indexOf("<summary>Blackjack</summary>")
+        assertTrue(blackjackStart >= 0, "Blackjack section not found")
+        val sectionEnd = settingsHtml.indexOf("</details>", blackjackStart)
+        assertTrue(sectionEnd > blackjackStart, "Blackjack section not terminated")
+        val sectionHtml = settingsHtml.substring(blackjackStart, sectionEnd)
+        for (key in listOf("BLACKJACK_MIN_ANTE", "BLACKJACK_MAX_ANTE")) {
+            assertTrue(
+                sectionHtml.contains("data-key=\"$key\""),
+                "$key should live inside the Blackjack section, not the Game stake limits card"
+            )
+        }
+    }
+
+    @Test
+    fun `poker section consolidates table rules with blinds and buy-ins in one place`() {
+        // Same regression-shape as the blackjack consolidation —
+        // POKER_SMALL_BLIND etc. used to live in the stakes mega-card.
+        val pokerStart = settingsHtml.indexOf("<summary>Poker</summary>")
+        assertTrue(pokerStart >= 0, "Poker section not found")
+        val sectionEnd = settingsHtml.indexOf("</details>", pokerStart)
+        assertTrue(sectionEnd > pokerStart, "Poker section not terminated")
+        val sectionHtml = settingsHtml.substring(pokerStart, sectionEnd)
+        val pokerStakeKeys = listOf(
+            "POKER_SMALL_BLIND",
+            "POKER_BIG_BLIND",
+            "POKER_SMALL_BET",
+            "POKER_BIG_BET",
+            "POKER_MIN_BUY_IN",
+            "POKER_MAX_BUY_IN",
+        )
+        for (key in pokerStakeKeys) {
+            assertTrue(
+                sectionHtml.contains("data-key=\"$key\""),
+                "$key should live inside the Poker section, not the Game stake limits card"
+            )
+        }
+    }
+
+    @Test
+    fun `settings template groups sections under server economy and casino pillars`() {
+        // The three top-level <h2 class="config-pillar"> headers anchor
+        // the visual grouping of the otherwise-flat accordion sections.
+        // If the pillars disappear, the page reverts to a wall of
+        // accordions and the rearrangement loses its point.
+        for (pillar in listOf("Server", "Economy", "Casino")) {
+            assertTrue(
+                settingsHtml.contains("<h2 class=\"config-pillar\">$pillar</h2>"),
+                "expected a <h2 class=\"config-pillar\">$pillar</h2> grouping header"
             )
         }
     }


### PR DESCRIPTION
## Summary

A re-arranging pass on `/moderation/{guildId}/settings` to fix two awkwardnesses without rewriting the page:

- **Blackjack and Poker each had settings split across two homes.** Table rules lived in their own section, but ante/blind/buy-in stakes were buried inside the "Casino stakes & buy-ins" mega-section — tuning either game meant scrolling between two cards. Stakes now live with their game.
- **No top-level grouping.** Three `<h2 class="config-pillar">` headers (**Server** / **Economy** / **Casino**) now anchor the otherwise-flat accordions.

Plus two small cleanups:
- Renamed `Audio & moves` → `Server features` and folded the lonely 1-item `Activity tracking` section into it.
- Renamed the thinned stakes mega-section to `Game stake limits` (now only the 13 simpler casino games).

## What moved

| Config keys | From | To |
|---|---|---|
| `BLACKJACK_MIN_ANTE`, `BLACKJACK_MAX_ANTE` | Casino stakes & buy-ins | Blackjack → *Stakes per hand* subgroup |
| `POKER_SMALL_BLIND`, `POKER_BIG_BLIND`, `POKER_SMALL_BET`, `POKER_BIG_BET`, `POKER_MIN_BUY_IN`, `POKER_MAX_BUY_IN` | Casino stakes & buy-ins | Poker → *Blinds & buy-ins* subgroup |
| `ACTIVITY_TRACKING` | Activity tracking (deleted) | Server features |

Anti-autoclicker per-game bot-edge caps intentionally stay centralized in `Anti-autoclicker` so admins tune anti-cheat together.

## Changes

- `templates/moderation/settings.html` — pillar headers, section rename, row relocations.
- `static/css/moderation.css` — `.config-pillar` rule (reuses existing variables).
- `static/js/moderation/settings.js` — search filter now hides pillar headers when none of the sections under them have visible rows, so searching for "ante" doesn't leave a bare "Casino" `<h2>` floating.
- `test/kotlin/web/template/ModerationTemplateRowsTest.kt` — updated assertions for the renamed summary, pinned the new structural invariants (Blackjack ante lives inside the Blackjack section, Poker stakes live inside the Poker section, the three pillars exist).

No backend changes: every `ConfigDto.Configurations` key still maps to exactly one `data-key` row, and the generic `.save-config` handler in `moderationCommon.js` is wired off `data-key` so DOM relocation is invisible to it.

## Test plan

- [x] `./gradlew :web:test` — passes (full web suite).
- [ ] Manual: load `/moderation/{guildId}/settings` as the guild owner.
  - [ ] Three pillar headers visible: Server, Economy, Casino.
  - [ ] 8 accordion sections in order: Server features, Messages & leaderboards, Economy, Jackpot, Anti-autoclicker, Poker, Blackjack, Game stake limits.
  - [ ] `ACTIVITY_TRACKING` toggle inside *Server features* — saving `true` still fires the first-enable DM flow.
  - [ ] Edit + save one row from each relocated group: Blackjack ante, Poker small blind.
- [ ] Manual: search filter — type `ante`, `blind`, `rake` and confirm the relocated rows surface and pillar headers above empty groups disappear; clear and confirm pillars and original open/closed snapshot restore.
- [ ] Manual: load page as a non-owner superuser — read-only alert renders, every relocated input is disabled.

https://claude.ai/code/session_017kffqu6vTMoT4yhFJKTxDJ

---
_Generated by [Claude Code](https://claude.ai/code/session_017kffqu6vTMoT4yhFJKTxDJ)_