### PR TITLE
feat(web): auto-route through guild pickers when possible

### DIFF
--- a/application/src/test/kotlin/web/controller/ExcuseWebControllerTest.kt
+++ b/application/src/test/kotlin/web/controller/ExcuseWebControllerTest.kt
@@ -4,6 +4,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.unmockkAll
 import io.mockk.verify
+import jakarta.servlet.http.HttpServletRequest
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -30,6 +31,9 @@ class ExcuseWebControllerTest {
     private val mockClient = mockk<OAuth2AuthorizedClient>(relaxed = true)
     private val mockModel = mockk<Model>(relaxed = true)
     private val mockRa = mockk<RedirectAttributes>(relaxed = true)
+    private val mockRequest = mockk<HttpServletRequest>(relaxed = true).also {
+        every { it.cookies } returns null
+    }
 
     private val discordId = "111"
     private val guildId = 222L
@@ -53,11 +57,13 @@ class ExcuseWebControllerTest {
 
     @Test
     fun `guildList renders the excuse-guilds template with counts`() {
-        val guilds = listOf(GuildInfo("1", "Guild One", null))
+        // Two guilds + pick=true bypasses the auto-redirect so we can observe
+        // the full template render path (with the new pick / request params).
+        val guilds = listOf(GuildInfo("1", "Guild One", null), GuildInfo("2", "Guild Two", null))
         every { excuseWebService.getMutualGuilds("mock-token") } returns guilds
-        every { excuseWebService.getApprovedCountsForGuilds(listOf(1L)) } returns mapOf(1L to 5)
+        every { excuseWebService.getApprovedCountsForGuilds(listOf(1L, 2L)) } returns mapOf(1L to 5)
 
-        val view = controller.guildList(mockClient, mockUser, mockModel)
+        val view = controller.guildList(mockClient, mockUser, pick = true, request = mockRequest, model = mockModel)
 
         assertEquals("excuse-guilds", view)
         verify { mockModel.addAttribute("guilds", guilds) }

--- a/application/src/test/kotlin/web/controller/IntroWebControllerTest.kt
+++ b/application/src/test/kotlin/web/controller/IntroWebControllerTest.kt
@@ -5,6 +5,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.unmockkAll
 import io.mockk.verify
+import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpSession
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -30,6 +31,9 @@ class IntroWebControllerTest {
     private val mockModel = mockk<Model>(relaxed = true)
     private val mockRa = mockk<RedirectAttributes>(relaxed = true)
     private val mockSession = mockk<HttpSession>(relaxed = true)
+    private val mockRequest = mockk<HttpServletRequest>(relaxed = true).also {
+        every { it.cookies } returns null
+    }
 
     private val discordId = "111"
     private val guildId = 222L
@@ -54,10 +58,12 @@ class IntroWebControllerTest {
 
     @Test
     fun `guildList adds guilds and username to model`() {
-        val guilds = listOf(GuildInfo("1", "Guild One", null))
+        // Two guilds + pick=true bypasses the auto-redirect so the template
+        // render path stays observable here.
+        val guilds = listOf(GuildInfo("1", "Guild One", null), GuildInfo("2", "Guild Two", null))
         every { introWebService.getMutualGuilds("mock-token") } returns guilds
 
-        val view = controller.guildList(mockClient, mockUser, mockModel)
+        val view = controller.guildList(mockClient, mockUser, pick = true, request = mockRequest, model = mockModel)
 
         assertEquals("guilds", view)
         verify { mockModel.addAttribute("guilds", guilds) }

--- a/web/src/main/kotlin/web/controller/BlackjackController.kt
+++ b/web/src/main/kotlin/web/controller/BlackjackController.kt
@@ -12,6 +12,7 @@ import database.service.BlackjackService.MultiLeaveOutcome
 import database.service.BlackjackService.MultiStartOutcome
 import database.service.BlackjackService.SoloActionOutcome
 import database.service.BlackjackService.SoloDealOutcome
+import jakarta.servlet.http.HttpServletRequest
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClient
@@ -24,6 +25,7 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseBody
 import org.springframework.web.servlet.mvc.support.RedirectAttributes
 import web.casino.CasinoOutcomeMapper
@@ -33,6 +35,8 @@ import web.casino.StakeBounds
 import web.casino.renderMinigamePage
 import web.service.BlackjackWebService
 import web.service.EconomyWebService
+import web.util.DefaultGuildCookie
+import web.util.DefaultGuildRedirect
 import web.util.WebGuildAccess
 import web.util.discordIdOrNull
 import web.util.displayName
@@ -83,14 +87,25 @@ class BlackjackController(
     fun guildList(
         @RegisteredOAuth2AuthorizedClient("discord") client: OAuth2AuthorizedClient,
         @AuthenticationPrincipal user: OAuth2User,
+        @RequestParam(required = false, defaultValue = "false") pick: Boolean,
+        request: HttpServletRequest,
         model: Model,
     ): String {
         val discordId = user.discordIdOrNull()
         val guilds = if (discordId != null) {
             economyWebService.getGuildsWhereUserCanView(client.accessToken.tokenValue, discordId)
         } else emptyList()
+
+        val defaultGuildId = DefaultGuildCookie.read(request)
+        DefaultGuildRedirect.pick(
+            guildIds = guilds.mapNotNull { it.id.toLongOrNull() },
+            cookieGuildId = defaultGuildId,
+            pick = pick,
+        )?.let { return "redirect:/blackjack/$it/solo" }
+
         model.addAttribute("guilds", guilds)
         model.addAttribute("username", user.displayName())
+        model.addAttribute("defaultGuildId", defaultGuildId)
         return "blackjack-guilds"
     }
 

--- a/web/src/main/kotlin/web/controller/CasinoController.kt
+++ b/web/src/main/kotlin/web/controller/CasinoController.kt
@@ -1,5 +1,6 @@
 package web.controller
 
+import jakarta.servlet.http.HttpServletRequest
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClient
 import org.springframework.security.oauth2.client.annotation.RegisteredOAuth2AuthorizedClient
@@ -8,7 +9,10 @@ import org.springframework.stereotype.Controller
 import org.springframework.ui.Model
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import web.service.EconomyWebService
+import web.util.DefaultGuildCookie
+import web.util.DefaultGuildRedirect
 import web.util.discordIdOrNull
 import web.util.displayName
 
@@ -31,6 +35,9 @@ class CasinoController(
     fun guildList(
         @RegisteredOAuth2AuthorizedClient("discord") client: OAuth2AuthorizedClient,
         @AuthenticationPrincipal user: OAuth2User,
+        @RequestParam(required = false) game: String?,
+        @RequestParam(required = false, defaultValue = "false") pick: Boolean,
+        request: HttpServletRequest,
         model: Model
     ): String {
         val discordId = user.discordIdOrNull()
@@ -38,8 +45,43 @@ class CasinoController(
             economyWebService.getGuildsWhereUserCanView(client.accessToken.tokenValue, discordId)
         } else emptyList()
 
+        val intendedGame = game?.lowercase()?.takeIf { it in CASINO_GAME_SLUGS }
+        val defaultGuildId = DefaultGuildCookie.read(request)
+
+        // Auto-redirect only when the click carried a specific game; without
+        // intent the picker doubles as a useful index (all games per server)
+        // and isn't redundant in the single-guild case.
+        if (intendedGame != null) {
+            val targetId = DefaultGuildRedirect.pick(
+                guildIds = guilds.mapNotNull { it.id.toLongOrNull() },
+                cookieGuildId = defaultGuildId,
+                pick = pick,
+            )
+            if (targetId != null) {
+                return "redirect:${gamePath(targetId, intendedGame)}"
+            }
+        }
+
         model.addAttribute("guilds", guilds)
         model.addAttribute("username", user.displayName())
+        model.addAttribute("intendedGame", intendedGame)
+        model.addAttribute("defaultGuildId", defaultGuildId)
         return "casino-guilds"
+    }
+
+    companion object {
+        // Mirrors the game buttons rendered in casino-guilds.html. Lottery
+        // is a casino-routed entry on the same picker even though it has
+        // its own navbar item; baccarat / casino-hold'em sit under "Table
+        // games" but route through /casino/{id}/...
+        internal val CASINO_GAME_SLUGS = setOf(
+            "coinflip", "dice", "highlow", "keno", "roulette", "scratch", "slots",
+            "plinko", "horse-racing", "wheel",
+            "baccarat", "casinoholdem",
+            "lottery",
+        )
+
+        internal fun gamePath(guildId: Long, gameSlug: String): String =
+            "/casino/$guildId/$gameSlug"
     }
 }

--- a/web/src/main/kotlin/web/controller/DuelController.kt
+++ b/web/src/main/kotlin/web/controller/DuelController.kt
@@ -5,6 +5,7 @@ import database.service.DuelService
 import database.service.DuelService.AcceptOutcome
 import database.service.DuelService.StartOutcome
 import database.service.UserService
+import jakarta.servlet.http.HttpServletRequest
 import net.dv8tion.jda.api.JDA
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.http.ResponseEntity
@@ -21,6 +22,8 @@ import web.event.WebDuelOfferedEvent
 import web.service.DuelWebService
 import web.service.EconomyWebService
 import web.service.MemberLookupHelper
+import web.util.DefaultGuildCookie
+import web.util.DefaultGuildRedirect
 import web.util.WebGuildAccess
 import web.util.discordIdOrNull
 import web.util.displayName
@@ -47,14 +50,25 @@ class DuelController(
     fun guildList(
         @RegisteredOAuth2AuthorizedClient("discord") client: OAuth2AuthorizedClient,
         @AuthenticationPrincipal user: OAuth2User,
+        @RequestParam(required = false, defaultValue = "false") pick: Boolean,
+        request: HttpServletRequest,
         model: Model,
     ): String {
         val discordId = user.discordIdOrNull()
         val guilds = if (discordId != null) {
             economyWebService.getGuildsWhereUserCanView(client.accessToken.tokenValue, discordId)
         } else emptyList()
+
+        val defaultGuildId = DefaultGuildCookie.read(request)
+        DefaultGuildRedirect.pick(
+            guildIds = guilds.mapNotNull { it.id.toLongOrNull() },
+            cookieGuildId = defaultGuildId,
+            pick = pick,
+        )?.let { return "redirect:/duel/$it" }
+
         model.addAttribute("guilds", guilds)
         model.addAttribute("username", user.displayName())
+        model.addAttribute("defaultGuildId", defaultGuildId)
         return "duel-guilds"
     }
 

--- a/web/src/main/kotlin/web/controller/EconomyController.kt
+++ b/web/src/main/kotlin/web/controller/EconomyController.kt
@@ -1,5 +1,6 @@
 package web.controller
 
+import jakarta.servlet.http.HttpServletRequest
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClient
@@ -20,6 +21,8 @@ import database.service.EconomyTradeService.TradeOutcome
 import database.service.SocialCreditAwardService
 import web.service.PricePoint
 import web.service.TradeMarker
+import web.util.DefaultGuildCookie
+import web.util.DefaultGuildRedirect
 import web.util.WebGuildAccess
 import web.util.discordIdOrNull
 import web.util.displayName
@@ -40,6 +43,8 @@ class EconomyController(
     fun guildList(
         @RegisteredOAuth2AuthorizedClient("discord") client: OAuth2AuthorizedClient,
         @AuthenticationPrincipal user: OAuth2User,
+        @RequestParam(required = false, defaultValue = "false") pick: Boolean,
+        request: HttpServletRequest,
         model: Model
     ): String {
         val discordId = user.discordIdOrNull()
@@ -47,8 +52,16 @@ class EconomyController(
             economyWebService.getGuildsWhereUserCanView(client.accessToken.tokenValue, discordId)
         } else emptyList()
 
+        val defaultGuildId = DefaultGuildCookie.read(request)
+        DefaultGuildRedirect.pick(
+            guildIds = guilds.mapNotNull { it.id.toLongOrNull() },
+            cookieGuildId = defaultGuildId,
+            pick = pick,
+        )?.let { return "redirect:/economy/$it" }
+
         model.addAttribute("guilds", guilds)
         model.addAttribute("username", user.displayName())
+        model.addAttribute("defaultGuildId", defaultGuildId)
         return "economy-guilds"
     }
 

--- a/web/src/main/kotlin/web/controller/ExcuseWebController.kt
+++ b/web/src/main/kotlin/web/controller/ExcuseWebController.kt
@@ -1,5 +1,6 @@
 package web.controller
 
+import jakarta.servlet.http.HttpServletRequest
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
@@ -11,6 +12,8 @@ import org.springframework.ui.Model
 import org.springframework.web.bind.annotation.*
 import org.springframework.web.servlet.mvc.support.RedirectAttributes
 import web.service.ExcuseWebService
+import web.util.DefaultGuildCookie
+import web.util.DefaultGuildRedirect
 import web.util.WebGuildAccess
 import web.util.discordIdOrNull
 import web.util.discordIdString
@@ -30,9 +33,19 @@ class ExcuseWebController(
     fun guildList(
         @RegisteredOAuth2AuthorizedClient("discord") client: OAuth2AuthorizedClient,
         @AuthenticationPrincipal user: OAuth2User,
+        @RequestParam(required = false, defaultValue = "false") pick: Boolean,
+        request: HttpServletRequest,
         model: Model,
     ): String {
         val guilds = excuseWebService.getMutualGuilds(client.accessToken.tokenValue)
+
+        val defaultGuildId = DefaultGuildCookie.read(request)
+        DefaultGuildRedirect.pick(
+            guildIds = guilds.mapNotNull { it.id.toLongOrNull() },
+            cookieGuildId = defaultGuildId,
+            pick = pick,
+        )?.let { return "redirect:/excuses/$it" }
+
         val counts = excuseWebService.getApprovedCountsForGuilds(guilds.map { it.id.toLong() })
             .mapKeys { it.key.toString() }
 
@@ -41,6 +54,7 @@ class ExcuseWebController(
         model.addAttribute("username", user.displayName())
         model.addAttribute("discordId", user.discordIdString())
         model.addAttribute("inviteUrl", inviteUrl)
+        model.addAttribute("defaultGuildId", defaultGuildId)
         return "excuse-guilds"
     }
 

--- a/web/src/main/kotlin/web/controller/IntroWebController.kt
+++ b/web/src/main/kotlin/web/controller/IntroWebController.kt
@@ -2,6 +2,7 @@ package web.controller
 
 import database.dto.MusicDto
 import database.service.MusicFileService
+import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpSession
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.ResponseEntity
@@ -15,6 +16,8 @@ import org.springframework.web.bind.annotation.*
 import org.springframework.web.multipart.MultipartFile
 import org.springframework.web.servlet.mvc.support.RedirectAttributes
 import web.service.IntroWebService
+import web.util.DefaultGuildCookie
+import web.util.DefaultGuildRedirect
 import web.util.WebGuildAccess
 import web.util.discordIdOrNull
 import web.util.discordIdString
@@ -35,11 +38,20 @@ class IntroWebController(
     fun guildList(
         @RegisteredOAuth2AuthorizedClient("discord") client: OAuth2AuthorizedClient,
         @AuthenticationPrincipal user: OAuth2User,
+        @RequestParam(required = false, defaultValue = "false") pick: Boolean,
+        request: HttpServletRequest,
         model: Model
     ): String {
         val accessToken = client.accessToken.tokenValue
         val discordId = user.discordIdOrNull()
         val guilds = introWebService.getMutualGuilds(accessToken)
+
+        val defaultGuildId = DefaultGuildCookie.read(request)
+        DefaultGuildRedirect.pick(
+            guildIds = guilds.mapNotNull { it.id.toLongOrNull() },
+            cookieGuildId = defaultGuildId,
+            pick = pick,
+        )?.let { return "redirect:/intro/$it" }
 
         val counts: Map<String, Int> = if (discordId != null) {
             introWebService.getIntroCountsForGuilds(discordId, guilds.map { it.id.toLong() })
@@ -52,6 +64,7 @@ class IntroWebController(
         model.addAttribute("username", user.displayName())
         model.addAttribute("discordId", user.discordIdString())
         model.addAttribute("inviteUrl", inviteUrl)
+        model.addAttribute("defaultGuildId", defaultGuildId)
 
         return "guilds"
     }

--- a/web/src/main/kotlin/web/controller/LeaderboardController.kt
+++ b/web/src/main/kotlin/web/controller/LeaderboardController.kt
@@ -1,5 +1,6 @@
 package web.controller
 
+import jakarta.servlet.http.HttpServletRequest
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClient
 import org.springframework.security.oauth2.client.annotation.RegisteredOAuth2AuthorizedClient
@@ -12,6 +13,8 @@ import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.servlet.mvc.support.RedirectAttributes
 import web.service.LeaderboardSort
 import web.service.LeaderboardWebService
+import web.util.DefaultGuildCookie
+import web.util.DefaultGuildRedirect
 import web.util.WebGuildAccess
 import web.util.discordIdOrNull
 import web.util.displayName
@@ -27,6 +30,8 @@ class LeaderboardController(
     fun guildList(
         @RegisteredOAuth2AuthorizedClient("discord") client: OAuth2AuthorizedClient,
         @AuthenticationPrincipal user: OAuth2User,
+        @RequestParam(required = false, defaultValue = "false") pick: Boolean,
+        request: HttpServletRequest,
         model: Model
     ): String {
         val discordId = user.discordIdOrNull()
@@ -34,8 +39,16 @@ class LeaderboardController(
             leaderboardWebService.getGuildsWhereUserCanView(client.accessToken.tokenValue, discordId)
         } else emptyList()
 
+        val defaultGuildId = DefaultGuildCookie.read(request)
+        DefaultGuildRedirect.pick(
+            guildIds = guilds.mapNotNull { it.id.toLongOrNull() },
+            cookieGuildId = defaultGuildId,
+            pick = pick,
+        )?.let { return "redirect:/leaderboard/$it" }
+
         model.addAttribute("guilds", guilds)
         model.addAttribute("username", user.displayName())
+        model.addAttribute("defaultGuildId", defaultGuildId)
         return "leaderboards"
     }
 

--- a/web/src/main/kotlin/web/controller/LotteryGuildsController.kt
+++ b/web/src/main/kotlin/web/controller/LotteryGuildsController.kt
@@ -1,5 +1,6 @@
 package web.controller
 
+import jakarta.servlet.http.HttpServletRequest
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClient
 import org.springframework.security.oauth2.client.annotation.RegisteredOAuth2AuthorizedClient
@@ -8,7 +9,10 @@ import org.springframework.stereotype.Controller
 import org.springframework.ui.Model
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import web.service.EconomyWebService
+import web.util.DefaultGuildCookie
+import web.util.DefaultGuildRedirect
 import web.util.discordIdOrNull
 import web.util.displayName
 
@@ -34,6 +38,8 @@ class LotteryGuildsController(
     fun guildList(
         @RegisteredOAuth2AuthorizedClient("discord") client: OAuth2AuthorizedClient,
         @AuthenticationPrincipal user: OAuth2User,
+        @RequestParam(required = false, defaultValue = "false") pick: Boolean,
+        request: HttpServletRequest,
         model: Model,
     ): String {
         val discordId = user.discordIdOrNull()
@@ -41,8 +47,16 @@ class LotteryGuildsController(
             economyWebService.getGuildsWhereUserCanView(client.accessToken.tokenValue, discordId)
         } else emptyList()
 
+        val defaultGuildId = DefaultGuildCookie.read(request)
+        DefaultGuildRedirect.pick(
+            guildIds = guilds.mapNotNull { it.id.toLongOrNull() },
+            cookieGuildId = defaultGuildId,
+            pick = pick,
+        )?.let { return "redirect:/casino/$it/lottery" }
+
         model.addAttribute("guilds", guilds)
         model.addAttribute("username", user.displayName())
+        model.addAttribute("defaultGuildId", defaultGuildId)
         return "lottery-guilds"
     }
 }

--- a/web/src/main/kotlin/web/controller/ModerationController.kt
+++ b/web/src/main/kotlin/web/controller/ModerationController.kt
@@ -2,6 +2,7 @@ package web.controller
 
 import database.dto.ConfigDto
 import database.dto.UserDto
+import jakarta.servlet.http.HttpServletRequest
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
@@ -16,9 +17,12 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseBody
 import org.springframework.web.servlet.mvc.support.RedirectAttributes
 import web.service.ModerationWebService
+import web.util.DefaultGuildCookie
+import web.util.DefaultGuildRedirect
 import web.util.WebGuildAccess
 import web.util.discordIdOrNull
 import web.util.discordIdString
@@ -38,6 +42,8 @@ class ModerationController(
     fun guildList(
         @RegisteredOAuth2AuthorizedClient("discord") client: OAuth2AuthorizedClient,
         @AuthenticationPrincipal user: OAuth2User,
+        @RequestParam(required = false, defaultValue = "false") pick: Boolean,
+        request: HttpServletRequest,
         model: Model
     ): String {
         val discordId = user.discordIdOrNull()
@@ -45,10 +51,18 @@ class ModerationController(
             moderationWebService.getModeratableGuilds(client.accessToken.tokenValue, discordId)
         } else emptyList()
 
+        val defaultGuildId = DefaultGuildCookie.read(request)
+        DefaultGuildRedirect.pick(
+            guildIds = guilds.mapNotNull { it.id.toLongOrNull() },
+            cookieGuildId = defaultGuildId,
+            pick = pick,
+        )?.let { return "redirect:/moderation/$it" }
+
         model.addAttribute("guilds", guilds)
         model.addAttribute("username", user.displayName())
         model.addAttribute("discordId", user.discordIdString())
         model.addAttribute("inviteUrl", inviteUrl)
+        model.addAttribute("defaultGuildId", defaultGuildId)
         return "moderation-guilds"
     }
 

--- a/web/src/main/kotlin/web/controller/MusicWebController.kt
+++ b/web/src/main/kotlin/web/controller/MusicWebController.kt
@@ -2,6 +2,7 @@ package web.controller
 
 import core.music.MusicControlGateway
 import database.service.MusicPlaylistService.PlaylistNameTakenException
+import jakarta.servlet.http.HttpServletRequest
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClient
@@ -21,6 +22,8 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
 import org.springframework.web.servlet.mvc.support.RedirectAttributes
 import web.service.MusicSseService
 import web.service.MusicWebService
+import web.util.DefaultGuildCookie
+import web.util.DefaultGuildRedirect
 import web.util.WebGuildAccess
 import web.util.discordIdOrNull
 import web.util.discordIdString
@@ -47,14 +50,25 @@ class MusicWebController(
     fun guildList(
         @RegisteredOAuth2AuthorizedClient("discord") client: OAuth2AuthorizedClient,
         @AuthenticationPrincipal user: OAuth2User,
+        @RequestParam(required = false, defaultValue = "false") pick: Boolean,
+        request: HttpServletRequest,
         model: Model,
     ): String {
         val accessToken = client.accessToken.tokenValue
         val discordId = user.discordIdOrNull() ?: return "redirect:/login"
         val guilds = musicWebService.listGuildsForUser(accessToken, discordId)
+
+        val defaultGuildId = DefaultGuildCookie.read(request)
+        DefaultGuildRedirect.pick(
+            guildIds = guilds.mapNotNull { it.id.toLongOrNull() },
+            cookieGuildId = defaultGuildId,
+            pick = pick,
+        )?.let { return "redirect:/music-player/$it" }
+
         model.addAttribute("guilds", guilds)
         model.addAttribute("username", user.displayName())
         model.addAttribute("discordId", user.discordIdString())
+        model.addAttribute("defaultGuildId", defaultGuildId)
         return "music-guilds"
     }
 

--- a/web/src/main/kotlin/web/controller/PokerController.kt
+++ b/web/src/main/kotlin/web/controller/PokerController.kt
@@ -10,6 +10,7 @@ import database.service.JackpotService
 import database.service.PokerService.CreateOutcome
 import database.service.PokerService.StartHandOutcome
 import database.service.UserService
+import jakarta.servlet.http.HttpServletRequest
 import net.dv8tion.jda.api.JDA
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
@@ -23,10 +24,13 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseBody
 import org.springframework.web.servlet.mvc.support.RedirectAttributes
 import web.service.EconomyWebService
 import web.service.PokerWebService
+import web.util.DefaultGuildCookie
+import web.util.DefaultGuildRedirect
 import web.util.WebGuildAccess
 import web.util.discordIdOrNull
 import web.util.displayName
@@ -55,14 +59,25 @@ class PokerController(
     fun guildList(
         @RegisteredOAuth2AuthorizedClient("discord") client: OAuth2AuthorizedClient,
         @AuthenticationPrincipal user: OAuth2User,
+        @RequestParam(required = false, defaultValue = "false") pick: Boolean,
+        request: HttpServletRequest,
         model: Model,
     ): String {
         val discordId = user.discordIdOrNull()
         val guilds = if (discordId != null) {
             economyWebService.getGuildsWhereUserCanView(client.accessToken.tokenValue, discordId)
         } else emptyList()
+
+        val defaultGuildId = DefaultGuildCookie.read(request)
+        DefaultGuildRedirect.pick(
+            guildIds = guilds.mapNotNull { it.id.toLongOrNull() },
+            cookieGuildId = defaultGuildId,
+            pick = pick,
+        )?.let { return "redirect:/poker/$it" }
+
         model.addAttribute("guilds", guilds)
         model.addAttribute("username", user.displayName())
+        model.addAttribute("defaultGuildId", defaultGuildId)
         return "poker-guilds"
     }
 

--- a/web/src/main/kotlin/web/controller/PreferencesController.kt
+++ b/web/src/main/kotlin/web/controller/PreferencesController.kt
@@ -1,0 +1,87 @@
+package web.controller
+
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient
+import org.springframework.security.oauth2.client.annotation.RegisteredOAuth2AuthorizedClient
+import org.springframework.security.oauth2.core.user.OAuth2User
+import org.springframework.stereotype.Controller
+import org.springframework.ui.Model
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import web.service.IntroWebService
+import web.util.DefaultGuildCookie
+import web.util.displayName
+
+/**
+ * Toggles the [DefaultGuildCookie] from the star button rendered on
+ * the casino / leaderboard / intro picker cards. Validates the user
+ * actually shares the target guild before pinning it so a crafted
+ * POST can't anchor someone to a guild they aren't in (cookie would
+ * otherwise be silently ignored on the next picker visit, but the
+ * cleaner contract is to refuse the write).
+ */
+@Controller
+@RequestMapping("/preferences")
+class PreferencesController(
+    private val introWebService: IntroWebService,
+) {
+
+    /**
+     * Tiny management page rendered from the navbar pill. Lists the
+     * user's mutual guilds with a star button on each — same toggle
+     * the picker pages use, just collected on one page so changing the
+     * anchor doesn't require navigating to a specific feature first.
+     */
+    @GetMapping
+    fun page(
+        @RegisteredOAuth2AuthorizedClient("discord") client: OAuth2AuthorizedClient,
+        @AuthenticationPrincipal user: OAuth2User?,
+        request: HttpServletRequest,
+        model: Model,
+    ): String {
+        val guilds = if (user == null) emptyList()
+            else introWebService.getMutualGuilds(client.accessToken.tokenValue)
+        val defaultGuildId = DefaultGuildCookie.read(request)
+
+        model.addAttribute("guilds", guilds)
+        model.addAttribute("defaultGuildId", defaultGuildId)
+        model.addAttribute("username", user.displayName())
+        return "preferences"
+    }
+
+    @PostMapping("/default-guild")
+    fun setDefaultGuild(
+        @RegisteredOAuth2AuthorizedClient("discord") client: OAuth2AuthorizedClient,
+        @AuthenticationPrincipal user: OAuth2User?,
+        @RequestParam guildId: Long,
+        @RequestParam(required = false) redirect: String?,
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+    ): String {
+        val target = DefaultGuildCookie.sanitizeRedirect(redirect)
+        if (user == null) return "redirect:$target"
+
+        val isMutual = introWebService
+            .getMutualGuilds(client.accessToken.tokenValue)
+            .any { it.id.toLongOrNull() == guildId }
+        if (isMutual) {
+            DefaultGuildCookie.write(request, response, guildId)
+        }
+        return "redirect:$target"
+    }
+
+    @PostMapping("/default-guild/clear")
+    fun clearDefaultGuild(
+        @RequestParam(required = false) redirect: String?,
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+    ): String {
+        val target = DefaultGuildCookie.sanitizeRedirect(redirect)
+        DefaultGuildCookie.clear(request, response)
+        return "redirect:$target"
+    }
+}

--- a/web/src/main/kotlin/web/controller/ProfileController.kt
+++ b/web/src/main/kotlin/web/controller/ProfileController.kt
@@ -1,5 +1,6 @@
 package web.controller
 
+import jakarta.servlet.http.HttpServletRequest
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClient
 import org.springframework.security.oauth2.client.annotation.RegisteredOAuth2AuthorizedClient
@@ -9,8 +10,11 @@ import org.springframework.ui.Model
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.servlet.mvc.support.RedirectAttributes
 import web.service.ProfileWebService
+import web.util.DefaultGuildCookie
+import web.util.DefaultGuildRedirect
 import web.util.WebGuildAccess
 import web.util.discordIdOrNull
 import web.util.displayName
@@ -25,6 +29,8 @@ class ProfileController(
     fun guildList(
         @RegisteredOAuth2AuthorizedClient("discord") client: OAuth2AuthorizedClient,
         @AuthenticationPrincipal user: OAuth2User,
+        @RequestParam(required = false, defaultValue = "false") pick: Boolean,
+        request: HttpServletRequest,
         model: Model
     ): String {
         val discordId = user.discordIdOrNull()
@@ -32,8 +38,16 @@ class ProfileController(
             profileWebService.getMemberGuilds(client.accessToken.tokenValue, discordId)
         } else emptyList()
 
+        val defaultGuildId = DefaultGuildCookie.read(request)
+        DefaultGuildRedirect.pick(
+            guildIds = guilds.mapNotNull { it.id.toLongOrNull() },
+            cookieGuildId = defaultGuildId,
+            pick = pick,
+        )?.let { return "redirect:/profile/$it" }
+
         model.addAttribute("guilds", guilds)
         model.addAttribute("username", user.displayName())
+        model.addAttribute("defaultGuildId", defaultGuildId)
         return "profile-guilds"
     }
 

--- a/web/src/main/kotlin/web/controller/TeamWebController.kt
+++ b/web/src/main/kotlin/web/controller/TeamWebController.kt
@@ -1,5 +1,6 @@
 package web.controller
 
+import jakarta.servlet.http.HttpServletRequest
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
@@ -17,6 +18,8 @@ import org.springframework.web.bind.annotation.ResponseBody
 import org.springframework.web.servlet.mvc.support.RedirectAttributes
 import web.service.TeamApiResult
 import web.service.TeamWebService
+import web.util.DefaultGuildCookie
+import web.util.DefaultGuildRedirect
 import web.util.WebGuildAccess
 import web.util.discordIdString
 import web.util.displayName
@@ -35,13 +38,24 @@ class TeamWebController(
     fun guildList(
         @RegisteredOAuth2AuthorizedClient("discord") client: OAuth2AuthorizedClient,
         @AuthenticationPrincipal user: OAuth2User,
+        @RequestParam(required = false, defaultValue = "false") pick: Boolean,
+        request: HttpServletRequest,
         model: Model,
     ): String {
         val guilds = teamWebService.getMutualGuilds(client.accessToken.tokenValue)
+
+        val defaultGuildId = DefaultGuildCookie.read(request)
+        DefaultGuildRedirect.pick(
+            guildIds = guilds.mapNotNull { it.id.toLongOrNull() },
+            cookieGuildId = defaultGuildId,
+            pick = pick,
+        )?.let { return "redirect:/teams/$it" }
+
         model.addAttribute("guilds", guilds)
         model.addAttribute("username", user.displayName())
         model.addAttribute("discordId", user.discordIdString())
         model.addAttribute("inviteUrl", inviteUrl)
+        model.addAttribute("defaultGuildId", defaultGuildId)
         return "team-guilds"
     }
 

--- a/web/src/main/kotlin/web/controller/TipController.kt
+++ b/web/src/main/kotlin/web/controller/TipController.kt
@@ -3,6 +3,7 @@ package web.controller
 import database.service.TipService
 import database.service.TipService.TipOutcome
 import database.service.UserService
+import jakarta.servlet.http.HttpServletRequest
 import net.dv8tion.jda.api.JDA
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.http.ResponseEntity
@@ -17,6 +18,8 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes
 import web.event.WebTipSentEvent
 import web.service.EconomyWebService
 import web.service.TipWebService
+import web.util.DefaultGuildCookie
+import web.util.DefaultGuildRedirect
 import web.util.WebGuildAccess
 import web.util.discordIdOrNull
 import web.util.displayName
@@ -41,6 +44,8 @@ class TipController(
     fun guildList(
         @RegisteredOAuth2AuthorizedClient("discord") client: OAuth2AuthorizedClient,
         @AuthenticationPrincipal user: OAuth2User,
+        @RequestParam(required = false, defaultValue = "false") pick: Boolean,
+        request: HttpServletRequest,
         model: Model,
     ): String {
         val discordId = user.discordIdOrNull()
@@ -48,8 +53,16 @@ class TipController(
             economyWebService.getGuildsWhereUserCanView(client.accessToken.tokenValue, discordId)
         } else emptyList()
 
+        val defaultGuildId = DefaultGuildCookie.read(request)
+        DefaultGuildRedirect.pick(
+            guildIds = guilds.mapNotNull { it.id.toLongOrNull() },
+            cookieGuildId = defaultGuildId,
+            pick = pick,
+        )?.let { return "redirect:/tip/$it" }
+
         model.addAttribute("guilds", guilds)
         model.addAttribute("username", user.displayName())
+        model.addAttribute("defaultGuildId", defaultGuildId)
         return "tip-guilds"
     }
 

--- a/web/src/main/kotlin/web/controller/TitlesController.kt
+++ b/web/src/main/kotlin/web/controller/TitlesController.kt
@@ -7,15 +7,19 @@ import org.springframework.security.oauth2.client.annotation.RegisteredOAuth2Aut
 import org.springframework.security.oauth2.core.user.OAuth2User
 import org.springframework.stereotype.Controller
 import org.springframework.ui.Model
+import jakarta.servlet.http.HttpServletRequest
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseBody
 import org.springframework.web.servlet.mvc.support.RedirectAttributes
 import web.service.BuyWithTobyOutcome
 import web.service.TitlesWebService
+import web.util.DefaultGuildCookie
+import web.util.DefaultGuildRedirect
 import web.util.WebGuildAccess
 import web.util.discordIdOrNull
 import web.util.displayName
@@ -48,6 +52,8 @@ class TitlesController(
     fun guildList(
         @RegisteredOAuth2AuthorizedClient("discord") client: OAuth2AuthorizedClient,
         @AuthenticationPrincipal user: OAuth2User,
+        @RequestParam(required = false, defaultValue = "false") pick: Boolean,
+        request: HttpServletRequest,
         model: Model
     ): String {
         val discordId = user.discordIdOrNull()
@@ -55,8 +61,16 @@ class TitlesController(
             titlesWebService.getMemberGuilds(client.accessToken.tokenValue, discordId)
         } else emptyList()
 
+        val defaultGuildId = DefaultGuildCookie.read(request)
+        DefaultGuildRedirect.pick(
+            guildIds = guilds.mapNotNull { it.id.toLongOrNull() },
+            cookieGuildId = defaultGuildId,
+            pick = pick,
+        )?.let { return "redirect:/titles/$it" }
+
         model.addAttribute("guilds", guilds)
         model.addAttribute("username", user.displayName())
+        model.addAttribute("defaultGuildId", defaultGuildId)
         return "titles-guilds"
     }
 

--- a/web/src/main/kotlin/web/util/DefaultGuildCookie.kt
+++ b/web/src/main/kotlin/web/util/DefaultGuildCookie.kt
@@ -1,0 +1,68 @@
+package web.util
+
+import jakarta.servlet.http.Cookie
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+
+/**
+ * One-year browser cookie carrying the user's preferred guild id for
+ * the casino / leaderboard / intro picker pages. When set and the user
+ * is still a member of that guild, those pickers skip themselves and
+ * land on the deep link directly.
+ *
+ * Per-browser, not per-Discord-account — picked over a DB-backed setting
+ * because the feature is a navigation nicety, not durable user state.
+ * Signing in from a different device just means re-anchoring there.
+ */
+object DefaultGuildCookie {
+
+    const val COOKIE_NAME = "toby_default_guild"
+
+    private const val MAX_AGE_SECONDS = 60 * 60 * 24 * 365
+
+    /**
+     * Returns the guild id from the request cookie, or null if absent /
+     * malformed. Treat anything that doesn't parse as no preference —
+     * a corrupted cookie should never 500 the picker.
+     */
+    fun read(request: HttpServletRequest): Long? {
+        val cookie = request.cookies?.firstOrNull { it.name == COOKIE_NAME } ?: return null
+        return cookie.value?.toLongOrNull()
+    }
+
+    fun write(request: HttpServletRequest, response: HttpServletResponse, guildId: Long) {
+        val cookie = Cookie(COOKIE_NAME, guildId.toString()).apply {
+            path = "/"
+            maxAge = MAX_AGE_SECONDS
+            secure = request.isSecure
+            isHttpOnly = true
+            setAttribute("SameSite", "Lax")
+        }
+        response.addCookie(cookie)
+    }
+
+    fun clear(request: HttpServletRequest, response: HttpServletResponse) {
+        val cookie = Cookie(COOKIE_NAME, "").apply {
+            path = "/"
+            maxAge = 0
+            secure = request.isSecure
+            isHttpOnly = true
+            setAttribute("SameSite", "Lax")
+        }
+        response.addCookie(cookie)
+    }
+
+    /**
+     * Whitelist filter for the post-toggle redirect target. Accepts only
+     * in-app paths so `?redirect=https://evil.example` can't bounce the
+     * user off-site after we set the cookie. Falls back to `/` for any
+     * value that isn't a clean single-slash relative path.
+     */
+    fun sanitizeRedirect(raw: String?, fallback: String = "/"): String {
+        if (raw.isNullOrBlank()) return fallback
+        if (!raw.startsWith("/")) return fallback
+        if (raw.startsWith("//")) return fallback
+        if (raw.startsWith("/\\")) return fallback
+        return raw
+    }
+}

--- a/web/src/main/kotlin/web/util/DefaultGuildModelAdvice.kt
+++ b/web/src/main/kotlin/web/util/DefaultGuildModelAdvice.kt
@@ -1,0 +1,33 @@
+package web.util
+
+import jakarta.servlet.http.HttpServletRequest
+import net.dv8tion.jda.api.JDA
+import org.springframework.web.bind.annotation.ControllerAdvice
+import org.springframework.web.bind.annotation.ModelAttribute
+
+/**
+ * Exposes the current anchored guild id + name to every page model so
+ * the navbar can render a "Default: ServerName" pill regardless of
+ * which controller rendered the request. Without this, every picker
+ * controller would have to remember to set the attributes manually
+ * just so the shared navbar fragment renders correctly.
+ *
+ * Looking up the guild name through JDA is in-memory (no Discord API
+ * hit) — same call the picker controllers make to validate cookies.
+ * If the bot was kicked from the cookie-anchored guild, the lookup
+ * returns null and the navbar quietly hides the pill rather than
+ * showing a phantom server name.
+ */
+@ControllerAdvice
+class DefaultGuildModelAdvice(private val jda: JDA) {
+
+    @ModelAttribute("currentDefaultGuildId")
+    fun currentDefaultGuildId(request: HttpServletRequest): Long? =
+        DefaultGuildCookie.read(request)
+
+    @ModelAttribute("currentDefaultGuildName")
+    fun currentDefaultGuildName(request: HttpServletRequest): String? {
+        val id = DefaultGuildCookie.read(request) ?: return null
+        return jda.getGuildById(id)?.name
+    }
+}

--- a/web/src/main/kotlin/web/util/DefaultGuildRedirect.kt
+++ b/web/src/main/kotlin/web/util/DefaultGuildRedirect.kt
@@ -1,0 +1,31 @@
+package web.util
+
+/**
+ * Shared "skip the picker if we can" decision used by every
+ * `/{thing}/guilds` controller. Returns the guild id the picker should
+ * redirect to, or null when the picker has to render.
+ *
+ * Resolution order:
+ *   1. `pick=true` query bypass → null (render the picker)
+ *   2. No mutual guilds → null (empty-state hero renders)
+ *   3. Cookie set AND the user still shares that guild → cookie value
+ *   4. Single mutual guild → that guild's id
+ *   5. Otherwise null (multi-guild without anchor → picker)
+ *
+ * Kept as a pure function so every controller's redirect rules are
+ * trivially testable in isolation — controller tests just verify the
+ * service call wiring around it.
+ */
+object DefaultGuildRedirect {
+
+    fun pick(
+        guildIds: List<Long>,
+        cookieGuildId: Long?,
+        pick: Boolean,
+    ): Long? {
+        if (pick) return null
+        if (guildIds.isEmpty()) return null
+        if (cookieGuildId != null && cookieGuildId in guildIds) return cookieGuildId
+        return guildIds.singleOrNull()
+    }
+}

--- a/web/src/main/resources/static/css/leaderboard.css
+++ b/web/src/main/resources/static/css/leaderboard.css
@@ -118,6 +118,53 @@
 }
 .lb-top-name { font-weight: 600; display: inline-flex; gap: 6px; align-items: center; }
 
+/* -- Default-guild star button (casino-guilds, leaderboards, intro picker) -- */
+/* Wrapper card lets the whole-card link AND the star button coexist; the
+   link is `lb-guild-card-link` so the .lb-guild-card hover/border styling
+   still applies to the outer wrapper. */
+.lb-guild-card-wrap {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+    padding-bottom: 44px;
+}
+.lb-guild-card-wrap .lb-guild-card-link {
+    color: var(--text);
+    text-decoration: none;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+}
+.lb-guild-card-wrap .default-guild-form {
+    position: absolute;
+    bottom: var(--space-3);
+    left: 50%;
+    transform: translateX(-50%);
+    margin: 0;
+    z-index: 2;
+}
+.default-guild-form { margin: 0; }
+.default-guild-toggle {
+    background: transparent;
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    padding: 4px 12px;
+    font-size: 0.8rem;
+    color: var(--text-muted);
+    cursor: pointer;
+    transition: border-color 0.15s, color 0.15s, background 0.15s;
+}
+.default-guild-toggle:hover {
+    border-color: var(--accent);
+    color: var(--accent);
+}
+.default-guild-toggle.is-default {
+    border-color: var(--accent);
+    color: var(--accent);
+    background: var(--accent-soft);
+}
+
 /* -- Stats strip -- */
 .lb-stats {
     display: grid;

--- a/web/src/main/resources/static/css/nav.css
+++ b/web/src/main/resources/static/css/nav.css
@@ -36,6 +36,24 @@ nav {
     transition: border-color 0.2s, color 0.2s;
 }
 .btn-logout:hover { border-color: #e74c3c; color: #e74c3c; }
+.nav-default-guild {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    max-width: 160px;
+    padding: 4px 10px;
+    border: 1px solid #555;
+    border-radius: 999px;
+    color: #c5c5d2;
+    font-size: 0.8rem;
+    text-decoration: none;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+}
+.nav-default-guild:hover { border-color: #fff; color: #fff; }
+.nav-default-guild-empty { color: #7a7a8c; }
+.nav-default-guild-empty:hover { color: #c5c5d2; border-color: #7a7a8c; }
 .nav-toggle {
     display: none;
     background: transparent;

--- a/web/src/main/resources/templates/baccarat.html
+++ b/web/src/main/resources/templates/baccarat.html
@@ -9,7 +9,7 @@
       th:attr="data-guild-id=${guildId}, data-toby-coins=${tobyCoins}, data-market-price=${marketPrice}, data-min-stake=${minStake}, data-max-stake=${maxStake}">
 
     <div class="bac-header">
-        <a class="back-link" th:href="@{/casino/guilds}">&larr; All casino servers</a>
+        <a class="back-link" th:href="@{/casino/guilds(pick=true)}">&larr; All casino servers</a>
         <h1 th:text="'🎴 Baccarat • ' + ${guildName}">🎴 Baccarat</h1>
         <p class="muted">
             Pick a side. Both hands deal automatically per the standard Punto Banco tableau.

--- a/web/src/main/resources/templates/blackjack-guilds.html
+++ b/web/src/main/resources/templates/blackjack-guilds.html
@@ -10,6 +10,7 @@
         primaryLabel='Solo hand',
         secondaryHref='/blackjack/{id}',
         secondaryLabel='Multi tables',
+        pickerPath='/blackjack/guilds',
         emptyEmoji='🂡',
         emptyHeading='No servers to play blackjack in yet',
         emptyBody='You need to share at least one server with TobyBot to play.')}">

--- a/web/src/main/resources/templates/casino-guilds.html
+++ b/web/src/main/resources/templates/casino-guilds.html
@@ -18,6 +18,7 @@
     <div class="lb-guild-grid" th:if="${not #lists.isEmpty(guilds)}">
         <div class="lb-guild-card lb-guild-card-static" th:each="g : ${guilds}">
             <div th:replace="~{fragments/guildCard :: header(${g})}"></div>
+            <div th:replace="~{fragments/defaultGuildStar :: star(${g.id}, ${defaultGuildId}, ${intendedGame != null ? '/casino/guilds?game=' + intendedGame + '&pick=true' : '/casino/guilds?pick=true'})}"></div>
             <div class="lb-guild-top">
                 <span class="muted">Your wallet:</span>
                 <span th:text="${g.credits} + ' credits'">0 credits</span>

--- a/web/src/main/resources/templates/casinoholdem-solo.html
+++ b/web/src/main/resources/templates/casinoholdem-solo.html
@@ -9,7 +9,7 @@
       th:attr="data-guild-id=${guildId}, data-toby-coins=${tobyCoins}, data-market-price=${marketPrice}, data-min-stake=${minStake}, data-max-stake=${maxStake}, data-call-multiple=${callMultiple}, data-my-discord-id=${myDiscordId}">
 
     <div class="che-header">
-        <a class="back-link" th:href="@{/casino/guilds}">&larr; All casino servers</a>
+        <a class="back-link" th:href="@{/casino/guilds(pick=true)}">&larr; All casino servers</a>
         <h1 th:text="|🃏 Casino Hold'em • ${guildName}|">🃏 Casino Hold'em</h1>
         <p class="muted">
             Bet between <span th:text="${minStake}">10</span> and

--- a/web/src/main/resources/templates/coinflip.html
+++ b/web/src/main/resources/templates/coinflip.html
@@ -9,7 +9,7 @@
       th:attr="data-guild-id=${guildId}, data-toby-coins=${tobyCoins}, data-market-price=${marketPrice}">
 
     <div class="coinflip-header">
-        <a class="back-link" th:href="@{/casino/guilds}">&larr; All casino servers</a>
+        <a class="back-link" th:href="@{/casino/guilds(pick=true)}">&larr; All casino servers</a>
         <h1 th:text="'🪙 Coinflip • ' + ${guildName}">🪙 Coinflip</h1>
         <p class="muted">Fair 50/50 double-or-nothing. Pick a side, set a stake. Bet between
             <span th:text="${minStake}">10</span> and

--- a/web/src/main/resources/templates/dice.html
+++ b/web/src/main/resources/templates/dice.html
@@ -9,7 +9,7 @@
       th:attr="data-guild-id=${guildId}, data-toby-coins=${tobyCoins}, data-market-price=${marketPrice}">
 
     <div class="dice-header">
-        <a class="back-link" th:href="@{/casino/guilds}">&larr; All casino servers</a>
+        <a class="back-link" th:href="@{/casino/guilds(pick=true)}">&larr; All casino servers</a>
         <h1 th:text="'🎲 Dice • ' + ${guildName}">🎲 Dice</h1>
         <p class="muted">Pick a number 1-<span th:text="${sides}">6</span>, roll the die, match for
             <strong th:text="${multiplier} + '×'">5×</strong> stake. Bet

--- a/web/src/main/resources/templates/duel-guilds.html
+++ b/web/src/main/resources/templates/duel-guilds.html
@@ -8,6 +8,7 @@
         description='Challenge another user to a head-to-head 50/50 wager. Winner takes the pot (minus a small jackpot tribute).',
         actionHref='/duel/{id}',
         actionLabel='⚔️ Duel',
+        pickerPath='/duel/guilds',
         emptyEmoji='⚔️',
         emptyHeading='No servers to duel in yet',
         emptyBody='You need to share at least one server with TobyBot to challenge someone.')}">

--- a/web/src/main/resources/templates/economy-guilds.html
+++ b/web/src/main/resources/templates/economy-guilds.html
@@ -16,24 +16,26 @@
     <div th:replace="~{fragments/alerts :: error}"></div>
 
     <div class="lb-guild-grid" th:if="${not #lists.isEmpty(guilds)}">
-        <a class="lb-guild-card"
-           th:each="g : ${guilds}"
-           th:href="@{/economy/{id}(id=${g.id})}">
-            <div th:replace="~{fragments/guildCard :: header(${g})}"></div>
-            <div class="lb-guild-top">
-                <span class="muted">Price:</span>
-                <span th:if="${g.price != null}"
-                      th:text="${#numbers.formatDecimal(g.price, 1, 2)} + ' credits / coin'">—</span>
-                <span th:unless="${g.price != null}" class="muted">no market yet</span>
-            </div>
-            <div class="lb-guild-stats">
-                <span class="muted">Your holdings:</span>
-                <span>
-                    <strong th:text="${g.coins}">0</strong> TOBY ·
-                    <strong th:text="${g.credits}">0</strong> credits
-                </span>
-            </div>
-        </a>
+        <div class="lb-guild-card lb-guild-card-wrap" th:each="g : ${guilds}">
+            <a class="lb-guild-card-link"
+               th:href="@{/economy/{id}(id=${g.id})}">
+                <div th:replace="~{fragments/guildCard :: header(${g})}"></div>
+                <div class="lb-guild-top">
+                    <span class="muted">Price:</span>
+                    <span th:if="${g.price != null}"
+                          th:text="${#numbers.formatDecimal(g.price, 1, 2)} + ' credits / coin'">—</span>
+                    <span th:unless="${g.price != null}" class="muted">no market yet</span>
+                </div>
+                <div class="lb-guild-stats">
+                    <span class="muted">Your holdings:</span>
+                    <span>
+                        <strong th:text="${g.coins}">0</strong> TOBY ·
+                        <strong th:text="${g.credits}">0</strong> credits
+                    </span>
+                </div>
+            </a>
+            <div th:replace="~{fragments/defaultGuildStar :: star(${g.id}, ${defaultGuildId}, '/economy/guilds?pick=true')}"></div>
+        </div>
     </div>
 
     <div class="empty-hero" th:if="${#lists.isEmpty(guilds)}">

--- a/web/src/main/resources/templates/excuse-guilds.html
+++ b/web/src/main/resources/templates/excuse-guilds.html
@@ -18,25 +18,28 @@
     </div>
 
     <div class="guild-grid" th:if="${not #lists.isEmpty(guilds)}" id="guildGrid">
-        <a class="guild-card"
-           th:each="guild : ${guilds}"
-           th:href="@{/excuses/{id}(id=${guild.id})}"
-           th:attr="data-guild-name=${#strings.toLowerCase(guild.name)}">
-            <span class="guild-count"
-                  th:with="count=${approvedCounts[guild.id] ?: 0}"
-                  th:classappend="${count > 0 ? ' has-rows' : ''}"
-                  th:text="${count} + ' approved'">0 approved</span>
-            <img th:if="${guild.iconUrl != null}"
-                 th:src="${guild.iconUrl}"
-                 th:alt="${guild.name} + ' icon'"
-                 class="guild-icon"
-                 onerror="this.style.display='none'">
-            <div th:unless="${guild.iconUrl != null}"
-                 class="guild-icon-placeholder"
-                 aria-hidden="true"
-                 th:text="${#strings.substring(guild.name, 0, 1).toUpperCase()}">G</div>
-            <div class="guild-name" th:text="${guild.name}" th:title="${guild.name}">Guild Name</div>
-        </a>
+        <div class="guild-card-wrap"
+             th:each="guild : ${guilds}"
+             th:attr="data-guild-name=${#strings.toLowerCase(guild.name)}">
+            <a class="guild-card"
+               th:href="@{/excuses/{id}(id=${guild.id})}">
+                <span class="guild-count"
+                      th:with="count=${approvedCounts[guild.id] ?: 0}"
+                      th:classappend="${count > 0 ? ' has-rows' : ''}"
+                      th:text="${count} + ' approved'">0 approved</span>
+                <img th:if="${guild.iconUrl != null}"
+                     th:src="${guild.iconUrl}"
+                     th:alt="${guild.name} + ' icon'"
+                     class="guild-icon"
+                     onerror="this.style.display='none'">
+                <div th:unless="${guild.iconUrl != null}"
+                     class="guild-icon-placeholder"
+                     aria-hidden="true"
+                     th:text="${#strings.substring(guild.name, 0, 1).toUpperCase()}">G</div>
+                <div class="guild-name" th:text="${guild.name}" th:title="${guild.name}">Guild Name</div>
+            </a>
+            <div th:replace="~{fragments/defaultGuildStar :: star(${guild.id}, ${defaultGuildId}, '/excuses/guilds?pick=true')}"></div>
+        </div>
     </div>
 
     <p id="noResults" class="no-results">No servers match your search.</p>
@@ -58,7 +61,7 @@
         search.addEventListener('input', function () {
             const q = search.value.trim().toLowerCase();
             let visible = 0;
-            grid.querySelectorAll('.guild-card').forEach(card => {
+            grid.querySelectorAll('.guild-card-wrap').forEach(card => {
                 const name = card.dataset.guildName || '';
                 const match = !q || name.indexOf(q) !== -1;
                 card.style.display = match ? '' : 'none';

--- a/web/src/main/resources/templates/fragments/defaultGuildStar.html
+++ b/web/src/main/resources/templates/fragments/defaultGuildStar.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<body>
+<!--
+    Star button rendered on the picker pages (casino-guilds,
+    leaderboards, intro/guilds). Clicking POSTs to /preferences/...
+    which writes / clears the toby_default_guild cookie and bounces
+    back to the same picker so the user sees the state flip.
+
+    Args:
+      - guildId     : the card's guild id (String "1234..." OK)
+      - currentId   : the user's current anchored guild id (Long?)
+                      or null when nothing is anchored
+      - redirectUrl : where to bounce back to after toggle; pass the
+                      picker URL the card lives on (including ?game=…)
+                      so the auto-redirect logic re-evaluates with
+                      fresh state.
+-->
+<th:block th:fragment="star(guildId, currentId, redirectUrl)"
+          th:with="isDefault=${currentId != null and currentId.toString() == guildId.toString()}">
+    <form th:action="${isDefault} ? @{/preferences/default-guild/clear} : @{/preferences/default-guild}"
+          method="post"
+          class="default-guild-form">
+        <input type="hidden" name="redirect" th:value="${redirectUrl}">
+        <input th:unless="${isDefault}" type="hidden" name="guildId" th:value="${guildId}">
+        <button type="submit"
+                class="default-guild-toggle"
+                th:classappend="${isDefault} ? ' is-default' : ''"
+                th:aria-label="${isDefault} ? 'Unset default server' : 'Set as default server'"
+                th:title="${isDefault} ? 'Default server — click to clear' : 'Set as default server'">
+            <span aria-hidden="true" th:text="${isDefault} ? '★ Default' : '☆ Set as default'">☆ Set as default</span>
+        </button>
+    </form>
+</th:block>
+</body>
+</html>

--- a/web/src/main/resources/templates/fragments/guildListPage.html
+++ b/web/src/main/resources/templates/fragments/guildListPage.html
@@ -22,7 +22,7 @@
 -->
 <html xmlns:th="http://www.thymeleaf.org" lang="en"
       th:fragment="singleAction(pageTitle, cssPath, emoji, headingTitle, description,
-                                 actionHref, actionLabel,
+                                 actionHref, actionLabel, pickerPath,
                                  emptyEmoji, emptyHeading, emptyBody)">
 <head th:replace="~{fragments/head :: head(${pageTitle}, ${cssPath})}"></head>
 <body>
@@ -38,6 +38,7 @@
     <div class="lb-guild-grid" th:if="${not #lists.isEmpty(guilds)}">
         <div class="lb-guild-card lb-guild-card-static" th:each="g : ${guilds}">
             <div th:replace="~{fragments/guildCard :: header(${g})}"></div>
+            <div th:replace="~{fragments/defaultGuildStar :: star(${g.id}, ${defaultGuildId}, ${pickerPath + '?pick=true'})}"></div>
             <div class="lb-guild-top">
                 <span class="muted">Your wallet:</span>
                 <span th:text="${g.credits} + ' credits'">0 credits</span>
@@ -61,7 +62,7 @@
 
 <html xmlns:th="http://www.thymeleaf.org" lang="en"
       th:fragment="dualAction(pageTitle, cssPath, emoji, headingTitle, description,
-                               primaryHref, primaryLabel, secondaryHref, secondaryLabel,
+                               primaryHref, primaryLabel, secondaryHref, secondaryLabel, pickerPath,
                                emptyEmoji, emptyHeading, emptyBody)">
 <head th:replace="~{fragments/head :: head(${pageTitle}, ${cssPath})}"></head>
 <body>
@@ -77,6 +78,7 @@
     <div class="lb-guild-grid" th:if="${not #lists.isEmpty(guilds)}">
         <div class="lb-guild-card lb-guild-card-static" th:each="g : ${guilds}">
             <div th:replace="~{fragments/guildCard :: header(${g})}"></div>
+            <div th:replace="~{fragments/defaultGuildStar :: star(${g.id}, ${defaultGuildId}, ${pickerPath + '?pick=true'})}"></div>
             <div class="lb-guild-top">
                 <span class="muted">Your wallet:</span>
                 <span th:text="${g.credits} + ' credits'">0 credits</span>

--- a/web/src/main/resources/templates/fragments/navbar.html
+++ b/web/src/main/resources/templates/fragments/navbar.html
@@ -12,10 +12,11 @@
         → Tools holds reference / utility pages → Admin
         anchor sits last so the everyday traffic isn't next to it.
 
-        Anchor links inside the Play menu intentionally repeat the same
-        /casino/guilds target for the minigame entries — each row is a
-        feature index (an admin can tell that Baccarat exists from the
-        navbar alone), and the picker page handles the actual routing.
+        Each minigame entry below carries a `?game=<slug>` so the
+        /casino/guilds picker can deep-link past itself when the user
+        only shares one server with the bot (or has anchored one as a
+        default). Without the query param the picker still renders the
+        full per-guild game grid — the slug is intent, not routing.
         Poker / Blackjack / Lottery have dedicated landing routes and
         are separated by a horizontal divider so the visual grouping
         matches the routing reality.
@@ -30,18 +31,18 @@
                     aria-expanded="false"
                     onclick="toggleDropdown(this)">Play <span class="nav-dropdown-caret" aria-hidden="true">&#9662;</span></button>
             <div class="nav-dropdown-menu" role="menu">
-                <a href="/casino/guilds" role="menuitem">&#127920; Slots</a>
-                <a href="/casino/guilds" role="menuitem">&#129689; Coinflip</a>
-                <a href="/casino/guilds" role="menuitem">&#127922; Dice</a>
-                <a href="/casino/guilds" role="menuitem">&#127183; High-Low</a>
-                <a href="/casino/guilds" role="menuitem">&#127903;&#65039; Scratch</a>
-                <a href="/casino/guilds" role="menuitem">&#127919; Keno</a>
-                <a href="/casino/guilds" role="menuitem">&#127905; Roulette</a>
-                <a href="/casino/guilds" role="menuitem">&#127924; Baccarat</a>
-                <a href="/casino/guilds" role="menuitem">&#127183; Casino Hold'em</a>
-                <a href="/casino/guilds" role="menuitem">&#128994; Plinko</a>
-                <a href="/casino/guilds" role="menuitem">&#128014; Horse Racing</a>
-                <a href="/casino/guilds" role="menuitem">&#127905; Wheel</a>
+                <a href="/casino/guilds?game=slots" role="menuitem">&#127920; Slots</a>
+                <a href="/casino/guilds?game=coinflip" role="menuitem">&#129689; Coinflip</a>
+                <a href="/casino/guilds?game=dice" role="menuitem">&#127922; Dice</a>
+                <a href="/casino/guilds?game=highlow" role="menuitem">&#127183; High-Low</a>
+                <a href="/casino/guilds?game=scratch" role="menuitem">&#127903;&#65039; Scratch</a>
+                <a href="/casino/guilds?game=keno" role="menuitem">&#127919; Keno</a>
+                <a href="/casino/guilds?game=roulette" role="menuitem">&#127905; Roulette</a>
+                <a href="/casino/guilds?game=baccarat" role="menuitem">&#127924; Baccarat</a>
+                <a href="/casino/guilds?game=casinoholdem" role="menuitem">&#127183; Casino Hold'em</a>
+                <a href="/casino/guilds?game=plinko" role="menuitem">&#128994; Plinko</a>
+                <a href="/casino/guilds?game=horse-racing" role="menuitem">&#128014; Horse Racing</a>
+                <a href="/casino/guilds?game=wheel" role="menuitem">&#127905; Wheel</a>
                 <hr class="nav-dropdown-separator" aria-hidden="true">
                 <a href="/poker/guilds" role="menuitem">&#127924; Poker</a>
                 <a href="/blackjack/guilds" role="menuitem">&#127922; Blackjack</a>
@@ -88,6 +89,20 @@
         </div>
         <a href="/moderation/guilds">Admin</a>
         <span th:if="${username != null}" style="display:flex;align-items:center;gap:12px;">
+            <a th:if="${currentDefaultGuildName != null}"
+               href="/preferences"
+               class="nav-default-guild"
+               th:title="'Default server: ' + ${currentDefaultGuildName} + ' — click to change'">
+                <span aria-hidden="true">★</span>
+                <span th:text="${currentDefaultGuildName}">Server</span>
+            </a>
+            <a th:unless="${currentDefaultGuildName != null}"
+               href="/preferences"
+               class="nav-default-guild nav-default-guild-empty"
+               title="Set a default server to skip the guild picker">
+                <span aria-hidden="true">☆</span>
+                <span>Default</span>
+            </a>
             <span class="nav-user" th:text="${username}">User</span>
             <form th:action="@{/logout}" method="post" style="margin:0">
                 <button type="submit" class="btn-logout">Logout</button>

--- a/web/src/main/resources/templates/guilds.html
+++ b/web/src/main/resources/templates/guilds.html
@@ -51,6 +51,16 @@
     .guild-count.has-intros { background: var(--accent-soft); color: var(--accent); }
     .guild-count.full { background: rgba(231, 76, 60, 0.12); color: var(--danger); }
 
+    .guild-card-wrap { position: relative; display: block; }
+    .guild-card-wrap .default-guild-form {
+        position: absolute;
+        bottom: 8px; left: 50%;
+        transform: translateX(-50%);
+        margin: 0;
+        z-index: 2;
+    }
+    .guild-card-wrap .guild-card { padding-bottom: 44px; }
+
     .search-row {
         display: flex;
         gap: var(--space-3);
@@ -91,25 +101,28 @@
     </div>
 
     <div class="guild-grid" th:if="${not #lists.isEmpty(guilds)}" id="guildGrid">
-        <a class="guild-card"
-           th:each="guild : ${guilds}"
-           th:href="@{/intro/{id}(id=${guild.id})}"
-           th:attr="data-guild-name=${#strings.toLowerCase(guild.name)}">
-            <span class="guild-count"
-                  th:with="count=${introCounts[guild.id] ?: 0}"
-                  th:classappend="${count >= maxIntros ? ' full' : (count > 0 ? ' has-intros' : '')}"
-                  th:text="${count} + ' / ' + ${maxIntros}">0 / 3</span>
-            <img th:if="${guild.iconUrl != null}"
-                 th:src="${guild.iconUrl}"
-                 th:alt="${guild.name} + ' icon'"
-                 class="guild-icon"
-                 onerror="this.style.display='none'">
-            <div th:unless="${guild.iconUrl != null}"
-                 class="guild-icon-placeholder"
-                 aria-hidden="true"
-                 th:text="${#strings.substring(guild.name, 0, 1).toUpperCase()}">G</div>
-            <div class="guild-name" th:text="${guild.name}" th:title="${guild.name}">Guild Name</div>
-        </a>
+        <div class="guild-card-wrap"
+             th:each="guild : ${guilds}"
+             th:attr="data-guild-name=${#strings.toLowerCase(guild.name)}">
+            <a class="guild-card"
+               th:href="@{/intro/{id}(id=${guild.id})}">
+                <span class="guild-count"
+                      th:with="count=${introCounts[guild.id] ?: 0}"
+                      th:classappend="${count >= maxIntros ? ' full' : (count > 0 ? ' has-intros' : '')}"
+                      th:text="${count} + ' / ' + ${maxIntros}">0 / 3</span>
+                <img th:if="${guild.iconUrl != null}"
+                     th:src="${guild.iconUrl}"
+                     th:alt="${guild.name} + ' icon'"
+                     class="guild-icon"
+                     onerror="this.style.display='none'">
+                <div th:unless="${guild.iconUrl != null}"
+                     class="guild-icon-placeholder"
+                     aria-hidden="true"
+                     th:text="${#strings.substring(guild.name, 0, 1).toUpperCase()}">G</div>
+                <div class="guild-name" th:text="${guild.name}" th:title="${guild.name}">Guild Name</div>
+            </a>
+            <div th:replace="~{fragments/defaultGuildStar :: star(${guild.id}, ${defaultGuildId}, '/intro/guilds?pick=true')}"></div>
+        </div>
     </div>
 
     <p id="noResults" class="no-results">No servers match your search.</p>
@@ -131,7 +144,7 @@
         search.addEventListener('input', function () {
             const q = search.value.trim().toLowerCase();
             let visible = 0;
-            grid.querySelectorAll('.guild-card').forEach(card => {
+            grid.querySelectorAll('.guild-card-wrap').forEach(card => {
                 const name = card.dataset.guildName || '';
                 const match = !q || name.indexOf(q) !== -1;
                 card.style.display = match ? '' : 'none';

--- a/web/src/main/resources/templates/highlow.html
+++ b/web/src/main/resources/templates/highlow.html
@@ -9,7 +9,7 @@
       th:attr="data-guild-id=${guildId}, data-toby-coins=${tobyCoins}, data-market-price=${marketPrice}, data-active-anchor=${anchor}, data-active-stake=${activeStake}, data-higher-multiplier=${higherMultiplier}, data-lower-multiplier=${lowerMultiplier}">
 
     <div class="highlow-header">
-        <a class="back-link" th:href="@{/casino/guilds}">&larr; All casino servers</a>
+        <a class="back-link" th:href="@{/casino/guilds(pick=true)}">&larr; All casino servers</a>
         <h1 th:text="'🃏 High-Low • ' + ${guildName}">🃏 High-Low</h1>
         <p class="muted">Lock your stake first — the anchor is dealt only after you commit.
             Each direction's payout depends on the anchor; safer calls pay less. Tie loses.

--- a/web/src/main/resources/templates/horse-racing.html
+++ b/web/src/main/resources/templates/horse-racing.html
@@ -10,7 +10,7 @@
                data-field-size=${fieldSize}">
 
     <div class="hr-header">
-        <a class="back-link" th:href="@{/casino/guilds}">&larr; All casino servers</a>
+        <a class="back-link" th:href="@{/casino/guilds(pick=true)}">&larr; All casino servers</a>
         <h1 th:text="'🐎 Horse Racing • ' + ${guildName}">🐎 Horse Racing</h1>
         <p class="muted">Pick a horse (1–<span th:text="${fieldSize}">6</span>) and a bet type — Win (1st), Place (top 2),
             or Show (top 3). Bet <span th:text="${minStake}">10</span> to

--- a/web/src/main/resources/templates/keno.html
+++ b/web/src/main/resources/templates/keno.html
@@ -12,7 +12,7 @@
                data-pool-size=${poolSize}, data-draws=${draws}">
 
     <div class="keno-header">
-        <a class="back-link" th:href="@{/casino/guilds}">&larr; All casino servers</a>
+        <a class="back-link" th:href="@{/casino/guilds(pick=true)}">&larr; All casino servers</a>
         <h1 th:text="'🎯 Keno • ' + ${guildName}">🎯 Keno</h1>
         <p class="muted">
             Pick <span th:text="${minSpots}">1</span>-<span th:text="${maxSpots}">10</span> numbers from the

--- a/web/src/main/resources/templates/leaderboard.html
+++ b/web/src/main/resources/templates/leaderboard.html
@@ -7,7 +7,7 @@
 
 <main id="main" class="container" th:attr="data-guild-id=${guildId}">
     <div class="lb-header">
-        <a class="back-link" th:href="@{/leaderboards}">&larr; All leaderboards</a>
+        <a class="back-link" th:href="@{/leaderboards(pick=true)}">&larr; All leaderboards</a>
         <h1 th:text="${view.guildName}">Guild Name</h1>
         <p class="muted">Social credit standings &middot; current totals with this month's earnings highlighted</p>
     </div>

--- a/web/src/main/resources/templates/leaderboards.html
+++ b/web/src/main/resources/templates/leaderboards.html
@@ -15,24 +15,27 @@
     <div th:replace="~{fragments/alerts :: error}"></div>
 
     <div class="lb-guild-grid" th:if="${not #lists.isEmpty(guilds)}">
-        <a class="lb-guild-card"
-           th:each="g : ${guilds}"
-           th:href="@{/leaderboard/{id}(id=${g.id})}">
-            <div th:replace="~{fragments/guildCard :: header(${g})}"></div>
-            <div class="lb-guild-top" th:if="${g.topName != null}">
-                <span class="muted">Top this month:</span>
-                <span class="lb-top-name">
-                    <span th:if="${g.topTitle != null}" class="lb-title-pill" th:text="${g.topTitle}"></span>
-                    <span th:text="${g.topName}">Top user</span>
-                </span>
-                <span class="muted" th:text="'+' + ${g.topCreditsThisMonth} + ' credits'">+0 credits</span>
-            </div>
-            <div class="lb-guild-stats">
-                <span th:text="${g.memberCount} + ' tracked'">0 tracked</span>
-                <span>&middot;</span>
-                <span th:text="${g.totalVoiceDisplay} + ' voice this month'">0m voice this month</span>
-            </div>
-        </a>
+        <div class="lb-guild-card lb-guild-card-wrap"
+             th:each="g : ${guilds}">
+            <a class="lb-guild-card-link"
+               th:href="@{/leaderboard/{id}(id=${g.id})}">
+                <div th:replace="~{fragments/guildCard :: header(${g})}"></div>
+                <div class="lb-guild-top" th:if="${g.topName != null}">
+                    <span class="muted">Top this month:</span>
+                    <span class="lb-top-name">
+                        <span th:if="${g.topTitle != null}" class="lb-title-pill" th:text="${g.topTitle}"></span>
+                        <span th:text="${g.topName}">Top user</span>
+                    </span>
+                    <span class="muted" th:text="'+' + ${g.topCreditsThisMonth} + ' credits'">+0 credits</span>
+                </div>
+                <div class="lb-guild-stats">
+                    <span th:text="${g.memberCount} + ' tracked'">0 tracked</span>
+                    <span>&middot;</span>
+                    <span th:text="${g.totalVoiceDisplay} + ' voice this month'">0m voice this month</span>
+                </div>
+            </a>
+            <div th:replace="~{fragments/defaultGuildStar :: star(${g.id}, ${defaultGuildId}, '/leaderboards?pick=true')}"></div>
+        </div>
     </div>
 
     <div class="empty-hero" th:if="${#lists.isEmpty(guilds)}">

--- a/web/src/main/resources/templates/lottery-guilds.html
+++ b/web/src/main/resources/templates/lottery-guilds.html
@@ -8,6 +8,7 @@
         description='Daily prize draw — pick numbers in NUMBER_MATCH mode, or buy weighted tickets if your server admin opted into WEIGHTED. Every ticket also feeds the per-server jackpot pool.',
         actionHref='/casino/{id}/lottery',
         actionLabel='Play',
+        pickerPath='/lottery/guilds',
         emptyEmoji='🎟️',
         emptyHeading='No servers to play the lottery in yet',
         emptyBody='You need to share at least one server with TobyBot to play.')}">

--- a/web/src/main/resources/templates/moderation-guilds.html
+++ b/web/src/main/resources/templates/moderation-guilds.html
@@ -47,6 +47,15 @@
     }
     .empty-hero h2 { color: var(--text); margin-bottom: 10px; }
     .empty-hero .emoji { font-size: 2.4rem; display: block; margin-bottom: 12px; }
+    .guild-card-wrap { position: relative; display: block; }
+    .guild-card-wrap .default-guild-form {
+        position: absolute;
+        bottom: 8px; left: 50%;
+        transform: translateX(-50%);
+        margin: 0;
+        z-index: 2;
+    }
+    .guild-card-wrap .guild-card { padding-bottom: 44px; }
 </style>
 
 <main id="main" class="container">
@@ -58,20 +67,22 @@
     <div th:replace="~{fragments/alerts :: error}"></div>
 
     <div class="guild-grid" th:if="${not #lists.isEmpty(guilds)}">
-        <a class="guild-card"
-           th:each="guild : ${guilds}"
-           th:href="@{/moderation/{id}(id=${guild.id})}">
-            <img th:if="${guild.iconUrl != null}"
-                 th:src="${guild.iconUrl}"
-                 th:alt="${guild.name} + ' icon'"
-                 class="guild-icon"
-                 onerror="this.style.display='none'">
-            <div th:unless="${guild.iconUrl != null}"
-                 class="guild-icon-placeholder"
-                 aria-hidden="true"
-                 th:text="${#strings.substring(guild.name, 0, 1).toUpperCase()}">G</div>
-            <div class="guild-name" th:text="${guild.name}" th:title="${guild.name}">Guild Name</div>
-        </a>
+        <div class="guild-card-wrap" th:each="guild : ${guilds}">
+            <a class="guild-card"
+               th:href="@{/moderation/{id}(id=${guild.id})}">
+                <img th:if="${guild.iconUrl != null}"
+                     th:src="${guild.iconUrl}"
+                     th:alt="${guild.name} + ' icon'"
+                     class="guild-icon"
+                     onerror="this.style.display='none'">
+                <div th:unless="${guild.iconUrl != null}"
+                     class="guild-icon-placeholder"
+                     aria-hidden="true"
+                     th:text="${#strings.substring(guild.name, 0, 1).toUpperCase()}">G</div>
+                <div class="guild-name" th:text="${guild.name}" th:title="${guild.name}">Guild Name</div>
+            </a>
+            <div th:replace="~{fragments/defaultGuildStar :: star(${guild.id}, ${defaultGuildId}, '/moderation/guilds?pick=true')}"></div>
+        </div>
     </div>
 
     <div class="empty-hero" th:if="${#lists.isEmpty(guilds)}">

--- a/web/src/main/resources/templates/music-guilds.html
+++ b/web/src/main/resources/templates/music-guilds.html
@@ -35,6 +35,7 @@
 
             <div class="music-guild-actions">
                 <a class="btn-primary" th:href="@{/music-player/{id}(id=${g.id})}">🎶 Open player</a>
+                <div th:replace="~{fragments/defaultGuildStar :: star(${g.id}, ${defaultGuildId}, '/music-player/guilds?pick=true')}"></div>
             </div>
         </article>
     </div>

--- a/web/src/main/resources/templates/plinko.html
+++ b/web/src/main/resources/templates/plinko.html
@@ -10,7 +10,7 @@
                data-rows=${rows}, data-buckets=${buckets}">
 
     <div class="plinko-header">
-        <a class="back-link" th:href="@{/casino/guilds}">&larr; All casino servers</a>
+        <a class="back-link" th:href="@{/casino/guilds(pick=true)}">&larr; All casino servers</a>
         <h1 th:text="'🟢 Plinko • ' + ${guildName}">🟢 Plinko</h1>
         <p class="muted">Drop a ball through
             <span th:text="${rows}">8</span> peg rows; it lands in one of

--- a/web/src/main/resources/templates/poker-guilds.html
+++ b/web/src/main/resources/templates/poker-guilds.html
@@ -8,6 +8,7 @@
         description='Multiplayer fixed-limit Texas hold em over the social-credit economy. Buy in, deal hands, take credits from your friends. 5% rake feeds the per-server jackpot.',
         actionHref='/poker/{id}',
         actionLabel='🃏 Poker tables',
+        pickerPath='/poker/guilds',
         emptyEmoji='🃏',
         emptyHeading='No servers to play poker in yet',
         emptyBody='You need to share at least one server with TobyBot to sit down at a table.')}">

--- a/web/src/main/resources/templates/preferences.html
+++ b/web/src/main/resources/templates/preferences.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="en">
+<head th:replace="~{fragments/head :: head('TobyBot - Settings', '/css/leaderboard.css')}"></head>
+<body>
+<a href="#main" class="skip-link">Skip to content</a>
+<div th:replace="~{fragments/navbar :: navbar}"></div>
+
+<main id="main" class="container">
+    <h1 class="mb-3">Settings</h1>
+
+    <section class="lb-stat" style="text-align:left;">
+        <h2 style="margin-top:0;">Default server</h2>
+        <p class="muted">
+            Pick a default server and TobyBot will skip the "choose a server"
+            picker on every feature page — clicking <em>Slots</em>,
+            <em>Leaderboards</em>, <em>Intro Songs</em>, and so on will land
+            you straight on the destination for that server.
+        </p>
+        <p class="muted" th:if="${defaultGuildId == null}">
+            No default set yet. Click <strong>☆ Set as default</strong> on any
+            server below.
+        </p>
+        <p class="muted" th:if="${defaultGuildId != null and currentDefaultGuildName != null}">
+            Current default: <strong th:text="${currentDefaultGuildName}">Server</strong>.
+            Click <strong>★ Default</strong> below to clear it.
+        </p>
+    </section>
+
+    <div th:replace="~{fragments/alerts :: error}"></div>
+
+    <div class="lb-guild-grid" th:if="${not #lists.isEmpty(guilds)}" style="margin-top:24px;">
+        <div class="lb-guild-card lb-guild-card-static" th:each="g : ${guilds}">
+            <div th:replace="~{fragments/guildCard :: header(${g})}"></div>
+            <div th:replace="~{fragments/defaultGuildStar :: star(${g.id}, ${defaultGuildId}, '/preferences')}"></div>
+        </div>
+    </div>
+
+    <div class="empty-hero" th:if="${#lists.isEmpty(guilds)}" style="margin-top:24px;">
+        <span class="emoji" aria-hidden="true">🤖</span>
+        <h2>No servers to set as default yet</h2>
+        <p class="mb-5">
+            You need to share at least one server with TobyBot before you can
+            anchor one as your default.
+        </p>
+    </div>
+</main>
+</body>
+</html>

--- a/web/src/main/resources/templates/profile-guilds.html
+++ b/web/src/main/resources/templates/profile-guilds.html
@@ -14,15 +14,17 @@
     <div th:replace="~{fragments/alerts :: error}"></div>
 
     <div class="lb-guild-grid" th:if="${not #lists.isEmpty(guilds)}">
-        <a class="lb-guild-card"
-           th:each="g : ${guilds}"
-           th:href="@{/profile/{id}(id=${g.id})}">
-            <div th:replace="~{fragments/guildCard :: header(${g})}"></div>
-            <div class="lb-guild-top">
-                <span class="muted">Balance:</span>
-                <span th:text="${g.balance} + ' credits'">0 credits</span>
-            </div>
-        </a>
+        <div class="lb-guild-card lb-guild-card-wrap" th:each="g : ${guilds}">
+            <a class="lb-guild-card-link"
+               th:href="@{/profile/{id}(id=${g.id})}">
+                <div th:replace="~{fragments/guildCard :: header(${g})}"></div>
+                <div class="lb-guild-top">
+                    <span class="muted">Balance:</span>
+                    <span th:text="${g.balance} + ' credits'">0 credits</span>
+                </div>
+            </a>
+            <div th:replace="~{fragments/defaultGuildStar :: star(${g.id}, ${defaultGuildId}, '/profile/guilds?pick=true')}"></div>
+        </div>
     </div>
 
     <div class="empty-hero" th:if="${#lists.isEmpty(guilds)}">

--- a/web/src/main/resources/templates/roulette.html
+++ b/web/src/main/resources/templates/roulette.html
@@ -9,7 +9,7 @@
       th:attr="data-guild-id=${guildId}, data-toby-coins=${tobyCoins}, data-market-price=${marketPrice}, data-wheel-order=${#strings.listJoin(wheelOrder, ',')}">
 
     <div class="roulette-header">
-        <a class="back-link" th:href="@{/casino/guilds}">&larr; All servers</a>
+        <a class="back-link" th:href="@{/casino/guilds(pick=true)}">&larr; All servers</a>
         <h1 th:text="'🎡 Roulette • ' + ${guildName}">🎡 Roulette</h1>
         <p class="muted">European single-zero wheel. Bet between
             <span th:text="${minStake}">10</span> and

--- a/web/src/main/resources/templates/scratch.html
+++ b/web/src/main/resources/templates/scratch.html
@@ -10,7 +10,7 @@
                data-toby-coins=${tobyCoins}, data-market-price=${marketPrice}">
 
     <div class="scratch-header">
-        <a class="back-link" th:href="@{/casino/guilds}">&larr; All casino servers</a>
+        <a class="back-link" th:href="@{/casino/guilds(pick=true)}">&larr; All casino servers</a>
         <h1 th:text="'🎟️ Scratch • ' + ${guildName}">🎟️ Scratch</h1>
         <p class="muted">Buy a <span th:text="${cellCount}">9</span>-cell scratchcard. Match
             <span th:text="${matchThreshold}">5</span>+ of any symbol to win;

--- a/web/src/main/resources/templates/slots.html
+++ b/web/src/main/resources/templates/slots.html
@@ -9,7 +9,7 @@
       th:attr="data-guild-id=${guildId}, data-toby-coins=${tobyCoins}, data-market-price=${marketPrice}">
 
     <div class="slots-header">
-        <a class="back-link" th:href="@{/leaderboards}">&larr; All servers</a>
+        <a class="back-link" th:href="@{/casino/guilds(pick=true)}">&larr; All servers</a>
         <h1 th:text="'🎰 Slots • ' + ${guildName}">🎰 Slots</h1>
         <p class="muted">3-of-a-kind wins. Bet between
             <span th:text="${minStake}">10</span> and

--- a/web/src/main/resources/templates/team-guilds.html
+++ b/web/src/main/resources/templates/team-guilds.html
@@ -18,21 +18,24 @@
     </div>
 
     <div class="guild-grid" th:if="${not #lists.isEmpty(guilds)}" id="guildGrid">
-        <a class="guild-card"
-           th:each="guild : ${guilds}"
-           th:href="@{/teams/{id}(id=${guild.id})}"
-           th:attr="data-guild-name=${#strings.toLowerCase(guild.name)}">
-            <img th:if="${guild.iconUrl != null}"
-                 th:src="${guild.iconUrl}"
-                 th:alt="${guild.name} + ' icon'"
-                 class="guild-icon"
-                 onerror="this.style.display='none'">
-            <div th:unless="${guild.iconUrl != null}"
-                 class="guild-icon-placeholder"
-                 aria-hidden="true"
-                 th:text="${#strings.substring(guild.name, 0, 1).toUpperCase()}">G</div>
-            <div class="guild-name" th:text="${guild.name}" th:title="${guild.name}">Guild Name</div>
-        </a>
+        <div class="guild-card-wrap"
+             th:each="guild : ${guilds}"
+             th:attr="data-guild-name=${#strings.toLowerCase(guild.name)}">
+            <a class="guild-card"
+               th:href="@{/teams/{id}(id=${guild.id})}">
+                <img th:if="${guild.iconUrl != null}"
+                     th:src="${guild.iconUrl}"
+                     th:alt="${guild.name} + ' icon'"
+                     class="guild-icon"
+                     onerror="this.style.display='none'">
+                <div th:unless="${guild.iconUrl != null}"
+                     class="guild-icon-placeholder"
+                     aria-hidden="true"
+                     th:text="${#strings.substring(guild.name, 0, 1).toUpperCase()}">G</div>
+                <div class="guild-name" th:text="${guild.name}" th:title="${guild.name}">Guild Name</div>
+            </a>
+            <div th:replace="~{fragments/defaultGuildStar :: star(${guild.id}, ${defaultGuildId}, '/teams/guilds?pick=true')}"></div>
+        </div>
     </div>
 
     <p id="noResults" class="no-results">No servers match your search.</p>
@@ -54,7 +57,7 @@
         search.addEventListener('input', function () {
             const q = search.value.trim().toLowerCase();
             let visible = 0;
-            grid.querySelectorAll('.guild-card').forEach(card => {
+            grid.querySelectorAll('.guild-card-wrap').forEach(card => {
                 const name = card.dataset.guildName || '';
                 const match = !q || name.indexOf(q) !== -1;
                 card.style.display = match ? '' : 'none';

--- a/web/src/main/resources/templates/tip-guilds.html
+++ b/web/src/main/resources/templates/tip-guilds.html
@@ -8,6 +8,7 @@
         description='Send another user some social credit. Daily outgoing cap applies per server.',
         actionHref='/tip/{id}',
         actionLabel='💸 Send a tip',
+        pickerPath='/tip/guilds',
         emptyEmoji='💸',
         emptyHeading='No servers to tip in yet',
         emptyBody='You need to share at least one server with TobyBot to send a tip.')}">

--- a/web/src/main/resources/templates/titles-guilds.html
+++ b/web/src/main/resources/templates/titles-guilds.html
@@ -15,22 +15,24 @@
     <div th:replace="~{fragments/alerts :: error}"></div>
 
     <div class="lb-guild-grid" th:if="${not #lists.isEmpty(guilds)}">
-        <a class="lb-guild-card"
-           th:each="g : ${guilds}"
-           th:href="@{/titles/{id}(id=${g.id})}">
-            <div th:replace="~{fragments/guildCard :: header(${g})}"></div>
-            <div class="lb-guild-top">
-                <span class="muted">Balance:</span>
-                <span th:text="${g.balance} + ' credits'">0 credits</span>
-            </div>
-            <div class="lb-guild-stats" th:if="${g.equippedTitle != null}">
-                <span class="muted">Equipped:</span>
-                <span class="lb-title-pill" th:text="${g.equippedTitle}">Title</span>
-            </div>
-            <div class="lb-guild-stats" th:unless="${g.equippedTitle != null}">
-                <span class="muted">No title equipped</span>
-            </div>
-        </a>
+        <div class="lb-guild-card lb-guild-card-wrap" th:each="g : ${guilds}">
+            <a class="lb-guild-card-link"
+               th:href="@{/titles/{id}(id=${g.id})}">
+                <div th:replace="~{fragments/guildCard :: header(${g})}"></div>
+                <div class="lb-guild-top">
+                    <span class="muted">Balance:</span>
+                    <span th:text="${g.balance} + ' credits'">0 credits</span>
+                </div>
+                <div class="lb-guild-stats" th:if="${g.equippedTitle != null}">
+                    <span class="muted">Equipped:</span>
+                    <span class="lb-title-pill" th:text="${g.equippedTitle}">Title</span>
+                </div>
+                <div class="lb-guild-stats" th:unless="${g.equippedTitle != null}">
+                    <span class="muted">No title equipped</span>
+                </div>
+            </a>
+            <div th:replace="~{fragments/defaultGuildStar :: star(${g.id}, ${defaultGuildId}, '/titles/guilds?pick=true')}"></div>
+        </div>
     </div>
 
     <div class="empty-hero" th:if="${#lists.isEmpty(guilds)}">

--- a/web/src/main/resources/templates/wheel.html
+++ b/web/src/main/resources/templates/wheel.html
@@ -10,7 +10,7 @@
                data-slot-count=${slotCount}">
 
     <div class="wheel-header">
-        <a class="back-link" th:href="@{/casino/guilds}">&larr; All casino servers</a>
+        <a class="back-link" th:href="@{/casino/guilds(pick=true)}">&larr; All casino servers</a>
         <h1 th:text="'🎡 Wheel of Fortune • ' + ${guildName}">🎡 Wheel of Fortune</h1>
         <p class="muted">Pick a multiplier, spin the wheel. Land on your pick to win
             <strong>multiplier × stake</strong>. Per-pick RTPs cluster around 0.88

--- a/web/src/test/js/navbar.test.js
+++ b/web/src/test/js/navbar.test.js
@@ -69,18 +69,22 @@ describe('navbar fragment', () => {
         );
     });
 
-    test('Casino dropdown lists every minigame and points at the picker', () => {
+    test('Casino dropdown lists every minigame and points at the picker with a game query', () => {
+        // Each entry carries `?game=<slug>` so the picker can deep-link past
+        // itself when the user only shares one server with the bot (or has
+        // anchored one as default). Without the slug the picker still
+        // renders and acts as the per-guild game index.
         const casino = html.match(
             /<div class="nav-dropdown">[\s\S]*?Casino[\s\S]*?<\/div>\s*<\/div>/
         );
         expect(casino).not.toBeNull();
-        expect(casino[0]).toMatch(/href="\/casino\/guilds"[^>]*>[^<]*Slots/);
-        expect(casino[0]).toMatch(/href="\/casino\/guilds"[^>]*>[^<]*Coinflip/);
-        expect(casino[0]).toMatch(/href="\/casino\/guilds"[^>]*>[^<]*Dice/);
-        expect(casino[0]).toMatch(/href="\/casino\/guilds"[^>]*>[^<]*High-Low/);
-        expect(casino[0]).toMatch(/href="\/casino\/guilds"[^>]*>[^<]*Scratch/);
-        expect(casino[0]).toMatch(/href="\/casino\/guilds"[^>]*>[^<]*Keno/);
-        expect(casino[0]).toMatch(/href="\/casino\/guilds"[^>]*>[^<]*Baccarat/);
+        expect(casino[0]).toMatch(/href="\/casino\/guilds\?game=slots"[^>]*>[^<]*Slots/);
+        expect(casino[0]).toMatch(/href="\/casino\/guilds\?game=coinflip"[^>]*>[^<]*Coinflip/);
+        expect(casino[0]).toMatch(/href="\/casino\/guilds\?game=dice"[^>]*>[^<]*Dice/);
+        expect(casino[0]).toMatch(/href="\/casino\/guilds\?game=highlow"[^>]*>[^<]*High-Low/);
+        expect(casino[0]).toMatch(/href="\/casino\/guilds\?game=scratch"[^>]*>[^<]*Scratch/);
+        expect(casino[0]).toMatch(/href="\/casino\/guilds\?game=keno"[^>]*>[^<]*Keno/);
+        expect(casino[0]).toMatch(/href="\/casino\/guilds\?game=baccarat"[^>]*>[^<]*Baccarat/);
         // Coming-soon placeholder is gone now that the games ship.
         expect(casino[0]).not.toMatch(/coming soon/i);
     });

--- a/web/src/test/kotlin/web/controller/CasinoControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/CasinoControllerTest.kt
@@ -1,0 +1,215 @@
+package web.controller
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import jakarta.servlet.http.Cookie
+import jakarta.servlet.http.HttpServletRequest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient
+import org.springframework.security.oauth2.core.OAuth2AccessToken
+import org.springframework.security.oauth2.core.user.OAuth2User
+import org.springframework.ui.Model
+import web.service.EconomyGuildCard
+import web.service.EconomyWebService
+import web.util.DefaultGuildCookie
+
+/**
+ * The /casino/guilds picker is the navbar's landing page for every
+ * minigame. These tests pin the auto-redirect rules:
+ *
+ *   - Without `game`, never auto-redirect: the picker also acts as a
+ *     per-guild game index, so it has standalone value.
+ *   - With a valid `game` slug AND single mutual guild OR a valid cookie
+ *     anchor, redirect to `/casino/{id}/{game}` (skip the picker).
+ *   - `pick=true` forces the picker regardless (back-link bypass).
+ *   - Stale cookies (guild the user no longer shares) must be ignored,
+ *     never 4xx'd.
+ *   - Unknown game slugs are silently dropped — they're user-controlled
+ *     input from a URL query, not trusted routing data.
+ */
+internal class CasinoControllerTest {
+
+    private val discordId = 100L
+    private val tokenValue = "tkn"
+    private lateinit var economyWebService: EconomyWebService
+    private lateinit var user: OAuth2User
+    private lateinit var client: OAuth2AuthorizedClient
+    private lateinit var request: HttpServletRequest
+    private lateinit var model: Model
+    private lateinit var controller: CasinoController
+
+    @BeforeEach
+    fun setup() {
+        economyWebService = mockk(relaxed = true)
+        user = mockk {
+            every { getAttribute<String>("id") } returns discordId.toString()
+            every { getAttribute<String>("username") } returns "tester"
+        }
+        val token: OAuth2AccessToken = mockk { every { tokenValue } returns this@CasinoControllerTest.tokenValue }
+        client = mockk { every { accessToken } returns token }
+        request = mockk(relaxed = true) { every { cookies } returns null }
+        model = mockk(relaxed = true)
+        controller = CasinoController(economyWebService)
+    }
+
+    private fun card(id: Long, name: String = "g$id") = EconomyGuildCard(
+        id = id.toString(), name = name, iconUrl = null, price = null, coins = 0, credits = 0
+    )
+
+    private fun setGuilds(vararg ids: Long) {
+        every { economyWebService.getGuildsWhereUserCanView(tokenValue, discordId) } returns ids.map { card(it) }
+    }
+
+    private fun cookieFor(guildId: Long) {
+        every { request.cookies } returns arrayOf(Cookie(DefaultGuildCookie.COOKIE_NAME, guildId.toString()))
+    }
+
+    @Test
+    fun `redirects to single mutual guild's game when game param is valid and no cookie`() {
+        setGuilds(777L)
+
+        val result = controller.guildList(client, user, game = "slots", pick = false, request = request, model = model)
+
+        assertEquals("redirect:/casino/777/slots", result)
+    }
+
+    @Test
+    fun `redirects to anchored guild when cookie is set and user is still a member`() {
+        setGuilds(111L, 222L, 333L)
+        cookieFor(222L)
+
+        val result = controller.guildList(client, user, game = "roulette", pick = false, request = request, model = model)
+
+        assertEquals("redirect:/casino/222/roulette", result)
+    }
+
+    @Test
+    fun `falls back to single-guild redirect when cookie points to a guild user no longer shares`() {
+        setGuilds(111L) // user only shares one guild now
+        cookieFor(999L)  // cookie points to an unrelated/old guild
+
+        val result = controller.guildList(client, user, game = "dice", pick = false, request = request, model = model)
+
+        assertEquals("redirect:/casino/111/dice", result)
+    }
+
+    @Test
+    fun `renders picker when cookie is stale and multiple guilds without anchor match`() {
+        setGuilds(111L, 222L)
+        cookieFor(999L) // user not in 999 anymore
+
+        val result = controller.guildList(client, user, game = "slots", pick = false, request = request, model = model)
+
+        assertEquals("casino-guilds", result)
+        verify { model.addAttribute("intendedGame", "slots") }
+        verify { model.addAttribute("defaultGuildId", 999L) }
+    }
+
+    @Test
+    fun `renders picker when multiple guilds and no cookie`() {
+        setGuilds(111L, 222L)
+
+        val result = controller.guildList(client, user, game = "slots", pick = false, request = request, model = model)
+
+        assertEquals("casino-guilds", result)
+        verify { model.addAttribute("intendedGame", "slots") }
+        verify { model.addAttribute("defaultGuildId", null) }
+    }
+
+    @Test
+    fun `renders picker even with valid cookie when pick=true`() {
+        setGuilds(111L, 222L)
+        cookieFor(222L)
+
+        val result = controller.guildList(client, user, game = "slots", pick = true, request = request, model = model)
+
+        assertEquals("casino-guilds", result)
+        verify { model.addAttribute("defaultGuildId", 222L) }
+    }
+
+    @Test
+    fun `does not redirect when game param is missing — picker is the index page`() {
+        setGuilds(777L)
+
+        val result = controller.guildList(client, user, game = null, pick = false, request = request, model = model)
+
+        assertEquals("casino-guilds", result)
+    }
+
+    @Test
+    fun `does not redirect when game param is not in the whitelist`() {
+        setGuilds(777L)
+
+        val result = controller.guildList(client, user, game = "../../etc/passwd", pick = false, request = request, model = model)
+
+        assertEquals("casino-guilds", result)
+        verify { model.addAttribute("intendedGame", null) }
+    }
+
+    @Test
+    fun `game param is matched case-insensitively`() {
+        setGuilds(777L)
+
+        val result = controller.guildList(client, user, game = "SLOTS", pick = false, request = request, model = model)
+
+        assertEquals("redirect:/casino/777/slots", result)
+    }
+
+    @Test
+    fun `accepts every game slug rendered in the casino-guilds template`() {
+        // If a slug listed in the template stops resolving, the auto-redirect
+        // for that game silently falls back to "show picker" — this test is a
+        // tripwire when the template adds or renames a game.
+        val templateSlugs = listOf(
+            "coinflip", "dice", "highlow", "keno", "roulette", "scratch", "slots",
+            "plinko", "horse-racing", "wheel",
+            "baccarat", "casinoholdem",
+            "lottery",
+        )
+        setGuilds(42L)
+        for (slug in templateSlugs) {
+            val result = controller.guildList(client, user, game = slug, pick = false, request = request, model = model)
+            assertEquals("redirect:/casino/42/$slug", result, "slug `$slug` should auto-redirect")
+        }
+    }
+
+    @Test
+    fun `renders picker when user has no mutual guilds`() {
+        setGuilds() // empty
+
+        val result = controller.guildList(client, user, game = "slots", pick = false, request = request, model = model)
+
+        assertEquals("casino-guilds", result)
+    }
+
+    @Test
+    fun `picker model carries intendedGame and defaultGuildId for template`() {
+        setGuilds(111L, 222L)
+        cookieFor(222L)
+
+        controller.guildList(client, user, game = "wheel", pick = true, request = request, model = model)
+
+        verify { model.addAttribute("intendedGame", "wheel") }
+        verify { model.addAttribute("defaultGuildId", 222L) }
+        verify { model.addAttribute(eq("guilds"), any()) }
+    }
+
+    @Test
+    fun `whitelist constant matches expected slug set`() {
+        // Belt-and-braces: pins the exact slug set so a typo in a template
+        // link surfaces here too.
+        assertEquals(
+            setOf(
+                "coinflip", "dice", "highlow", "keno", "roulette", "scratch", "slots",
+                "plinko", "horse-racing", "wheel",
+                "baccarat", "casinoholdem", "lottery",
+            ),
+            CasinoController.CASINO_GAME_SLUGS
+        )
+        assertTrue(CasinoController.gamePath(7L, "slots") == "/casino/7/slots")
+    }
+}

--- a/web/src/test/kotlin/web/controller/IntroWebControllerGuildListTest.kt
+++ b/web/src/test/kotlin/web/controller/IntroWebControllerGuildListTest.kt
@@ -1,0 +1,106 @@
+package web.controller
+
+import database.service.MusicFileService
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import jakarta.servlet.http.Cookie
+import jakarta.servlet.http.HttpServletRequest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient
+import org.springframework.security.oauth2.core.OAuth2AccessToken
+import org.springframework.security.oauth2.core.user.OAuth2User
+import org.springframework.ui.Model
+import web.service.GuildInfo
+import web.service.IntroWebService
+import web.util.DefaultGuildCookie
+
+/**
+ * Coverage for the auto-redirect rules added to `/intro/guilds`. The
+ * rest of [IntroWebController] (file upload, undo, REST endpoints) has
+ * its own untouched behaviour and isn't in scope here — these tests
+ * pin only the picker redirect contract.
+ */
+internal class IntroWebControllerGuildListTest {
+
+    private val discordId = 100L
+    private val tokenValue = "tkn"
+
+    private lateinit var introWebService: IntroWebService
+    private lateinit var musicFileService: MusicFileService
+    private lateinit var user: OAuth2User
+    private lateinit var client: OAuth2AuthorizedClient
+    private lateinit var request: HttpServletRequest
+    private lateinit var controller: IntroWebController
+
+    @BeforeEach
+    fun setup() {
+        introWebService = mockk(relaxed = true)
+        musicFileService = mockk(relaxed = true)
+        user = mockk {
+            every { getAttribute<String>("id") } returns discordId.toString()
+            every { getAttribute<String>("username") } returns "tester"
+        }
+        val token: OAuth2AccessToken = mockk { every { tokenValue } returns this@IntroWebControllerGuildListTest.tokenValue }
+        client = mockk { every { accessToken } returns token }
+        request = mockk(relaxed = true) { every { cookies } returns null }
+        controller = IntroWebController(introWebService, musicFileService, "test-client-id")
+    }
+
+    private fun setMutualGuilds(vararg ids: Long) {
+        every { introWebService.getMutualGuilds(tokenValue) } returns ids.map { GuildInfo(it.toString(), "g$it", null) }
+        every { introWebService.getIntroCountsForGuilds(discordId, any()) } returns emptyMap()
+    }
+
+    private fun cookieFor(guildId: Long) {
+        every { request.cookies } returns arrayOf(Cookie(DefaultGuildCookie.COOKIE_NAME, guildId.toString()))
+    }
+
+    @Test
+    fun `guildList redirects to single mutual guild's intro page`() {
+        setMutualGuilds(777L)
+        val result = controller.guildList(client, user, pick = false, request = request, model = mockk(relaxed = true))
+        assertEquals("redirect:/intro/777", result)
+    }
+
+    @Test
+    fun `guildList redirects to anchored guild when cookie set and user still a member`() {
+        setMutualGuilds(111L, 222L)
+        cookieFor(222L)
+        val result = controller.guildList(client, user, pick = false, request = request, model = mockk(relaxed = true))
+        assertEquals("redirect:/intro/222", result)
+    }
+
+    @Test
+    fun `guildList renders picker when pick=true bypasses auto-redirect`() {
+        setMutualGuilds(111L, 222L)
+        cookieFor(222L)
+        val model: Model = mockk(relaxed = true)
+
+        val result = controller.guildList(client, user, pick = true, request = request, model = model)
+
+        assertEquals("guilds", result)
+        verify { model.addAttribute("defaultGuildId", 222L) }
+    }
+
+    @Test
+    fun `guildList ignores stale cookie pointing to a guild user no longer shares`() {
+        setMutualGuilds(111L, 222L)
+        cookieFor(999L)
+        val model: Model = mockk(relaxed = true)
+
+        val result = controller.guildList(client, user, pick = false, request = request, model = model)
+
+        assertEquals("guilds", result)
+        verify { model.addAttribute("defaultGuildId", 999L) }
+    }
+
+    @Test
+    fun `guildList renders empty picker when user has no mutual guilds`() {
+        setMutualGuilds()
+        val result = controller.guildList(client, user, pick = false, request = request, model = mockk(relaxed = true))
+        assertEquals("guilds", result)
+    }
+}

--- a/web/src/test/kotlin/web/controller/LeaderboardControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/LeaderboardControllerTest.kt
@@ -4,16 +4,22 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
+import jakarta.servlet.http.Cookie
+import jakarta.servlet.http.HttpServletRequest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient
+import org.springframework.security.oauth2.core.OAuth2AccessToken
 import org.springframework.security.oauth2.core.user.OAuth2User
 import org.springframework.ui.Model
 import org.springframework.web.servlet.mvc.support.RedirectAttributes
+import web.service.LeaderboardGuildCard
 import web.service.LeaderboardGuildView
 import web.service.LeaderboardSort
 import web.service.LeaderboardWebService
+import web.util.DefaultGuildCookie
 import java.time.LocalDate
 import java.time.ZoneOffset
 
@@ -27,9 +33,12 @@ class LeaderboardControllerTest {
 
     private val guildId = 77L
     private val discordId = 100L
+    private val tokenValue = "tkn"
 
     private lateinit var leaderboardWebService: LeaderboardWebService
     private lateinit var user: OAuth2User
+    private lateinit var client: OAuth2AuthorizedClient
+    private lateinit var request: HttpServletRequest
     private lateinit var controller: LeaderboardController
 
     @BeforeEach
@@ -39,9 +48,26 @@ class LeaderboardControllerTest {
             every { getAttribute<String>("id") } returns discordId.toString()
             every { getAttribute<String>("username") } returns "tester"
         }
+        val token: OAuth2AccessToken = mockk { every { tokenValue } returns this@LeaderboardControllerTest.tokenValue }
+        client = mockk { every { accessToken } returns token }
+        request = mockk(relaxed = true) { every { cookies } returns null }
         every { leaderboardWebService.isMember(discordId, guildId) } returns true
         every { leaderboardWebService.getGuildView(guildId, any(), any()) } returns emptyView()
         controller = LeaderboardController(leaderboardWebService)
+    }
+
+    private fun card(id: Long, name: String = "g$id") = LeaderboardGuildCard(
+        id = id.toString(), name = name, iconUrl = null,
+        topName = null, topTitle = null, topCreditsThisMonth = 0,
+        totalVoiceSeconds = 0, memberCount = 0
+    )
+
+    private fun setMutualGuilds(vararg ids: Long) {
+        every { leaderboardWebService.getGuildsWhereUserCanView(tokenValue, discordId) } returns ids.map { card(it) }
+    }
+
+    private fun cookieFor(guildId: Long) {
+        every { request.cookies } returns arrayOf(Cookie(DefaultGuildCookie.COOKIE_NAME, guildId.toString()))
     }
 
     private fun emptyView() = LeaderboardGuildView(
@@ -137,6 +163,61 @@ class LeaderboardControllerTest {
         val future = LocalDate.now(ZoneOffset.UTC).plusMonths(2)
         val futureValue = "%04d-%02d".format(future.year, future.monthValue)
         assertNull(callMonth(futureValue))
+    }
+
+    // -- Auto-redirect (guildList) tests --
+
+    @Test
+    fun `guildList redirects to single mutual guild's leaderboard`() {
+        setMutualGuilds(777L)
+        val model: Model = mockk(relaxed = true)
+        val result = controller.guildList(client, user, pick = false, request = request, model = model)
+        assertEquals("redirect:/leaderboard/777", result)
+    }
+
+    @Test
+    fun `guildList redirects to anchored guild when cookie set`() {
+        setMutualGuilds(111L, 222L, 333L)
+        cookieFor(222L)
+        val model: Model = mockk(relaxed = true)
+        val result = controller.guildList(client, user, pick = false, request = request, model = model)
+        assertEquals("redirect:/leaderboard/222", result)
+    }
+
+    @Test
+    fun `guildList renders picker for multi-guild without anchor`() {
+        setMutualGuilds(111L, 222L)
+        val model: Model = mockk(relaxed = true)
+        val result = controller.guildList(client, user, pick = false, request = request, model = model)
+        assertEquals("leaderboards", result)
+    }
+
+    @Test
+    fun `guildList renders picker when pick=true even with anchor`() {
+        setMutualGuilds(111L, 222L)
+        cookieFor(222L)
+        val model: Model = mockk(relaxed = true)
+        val result = controller.guildList(client, user, pick = true, request = request, model = model)
+        assertEquals("leaderboards", result)
+        verify { model.addAttribute("defaultGuildId", 222L) }
+    }
+
+    @Test
+    fun `guildList ignores stale cookie pointing to non-shared guild`() {
+        setMutualGuilds(111L, 222L)
+        cookieFor(999L)
+        val model: Model = mockk(relaxed = true)
+        val result = controller.guildList(client, user, pick = false, request = request, model = model)
+        assertEquals("leaderboards", result)
+        verify { model.addAttribute("defaultGuildId", 999L) }
+    }
+
+    @Test
+    fun `guildList renders empty picker when user shares no guilds`() {
+        setMutualGuilds()
+        val model: Model = mockk(relaxed = true)
+        val result = controller.guildList(client, user, pick = false, request = request, model = model)
+        assertEquals("leaderboards", result)
     }
 
     @Test

--- a/web/src/test/kotlin/web/controller/PokerControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/PokerControllerTest.kt
@@ -13,6 +13,8 @@ import database.service.UserService
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import jakarta.servlet.http.Cookie
+import jakarta.servlet.http.HttpServletRequest
 import net.dv8tion.jda.api.JDA
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -20,9 +22,14 @@ import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient
+import org.springframework.security.oauth2.core.OAuth2AccessToken
 import org.springframework.security.oauth2.core.user.OAuth2User
+import org.springframework.ui.Model
+import web.service.EconomyGuildCard
 import web.service.EconomyWebService
 import web.service.PokerWebService
+import web.util.DefaultGuildCookie
 
 class PokerControllerTest {
 
@@ -86,6 +93,51 @@ class PokerControllerTest {
         every { pokerWebService.snapshot(tableId, discordId) } returns sampleView(guildId = 999L)
         val response = controller.state(guildId, tableId, user)
         assertEquals(404, response.statusCode.value())
+    }
+
+    // -- guildList auto-redirect tests --
+
+    private fun setMutualGuilds(vararg ids: Long) {
+        every {
+            economyWebService.getGuildsWhereUserCanView(any(), discordId)
+        } returns ids.map {
+            EconomyGuildCard(id = it.toString(), name = "g$it", iconUrl = null, price = null, coins = 0, credits = 0)
+        }
+    }
+
+    private fun pokerClient(): OAuth2AuthorizedClient {
+        val token: OAuth2AccessToken = mockk { every { tokenValue } returns "tkn" }
+        return mockk { every { accessToken } returns token }
+    }
+
+    @Test
+    fun `guildList auto-redirects to single mutual guild lobby`() {
+        setMutualGuilds(777L)
+        val req: HttpServletRequest = mockk(relaxed = true) { every { cookies } returns null }
+        val result = controller.guildList(pokerClient(), user, pick = false, request = req, model = mockk(relaxed = true))
+        assertEquals("redirect:/poker/777", result)
+    }
+
+    @Test
+    fun `guildList auto-redirects to anchored guild when cookie set`() {
+        setMutualGuilds(111L, 222L)
+        val req: HttpServletRequest = mockk(relaxed = true) {
+            every { cookies } returns arrayOf(Cookie(DefaultGuildCookie.COOKIE_NAME, "222"))
+        }
+        val result = controller.guildList(pokerClient(), user, pick = false, request = req, model = mockk(relaxed = true))
+        assertEquals("redirect:/poker/222", result)
+    }
+
+    @Test
+    fun `guildList renders picker when pick=true bypasses redirect`() {
+        setMutualGuilds(111L, 222L)
+        val req: HttpServletRequest = mockk(relaxed = true) {
+            every { cookies } returns arrayOf(Cookie(DefaultGuildCookie.COOKIE_NAME, "222"))
+        }
+        val model: Model = mockk(relaxed = true)
+        val result = controller.guildList(pokerClient(), user, pick = true, request = req, model = model)
+        assertEquals("poker-guilds", result)
+        verify { model.addAttribute("defaultGuildId", 222L) }
     }
 
     @Test

--- a/web/src/test/kotlin/web/controller/PreferencesControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/PreferencesControllerTest.kt
@@ -1,0 +1,221 @@
+package web.controller
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import jakarta.servlet.http.Cookie
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient
+import org.springframework.security.oauth2.core.OAuth2AccessToken
+import org.springframework.security.oauth2.core.user.OAuth2User
+import org.springframework.ui.Model
+import web.service.GuildInfo
+import web.service.IntroWebService
+import web.util.DefaultGuildCookie
+
+/**
+ * Pins the contract of the cookie-toggle endpoints. Two non-obvious
+ * pieces of behaviour to guard:
+ *
+ *  1. **Membership check on SET** — anchoring a guild the user isn't in
+ *     would be silently ignored at the next picker visit (the auto-
+ *     redirect re-validates), but the cleaner contract is to refuse the
+ *     write outright. A crafted POST shouldn't be able to plant a cookie.
+ *
+ *  2. **Redirect sanitisation** — `redirect` is reflected into the
+ *     `Location` header. An attacker who can talk a user into clicking
+ *     a star button (CSRF-protected by Spring already) plus a poisoned
+ *     `redirect=https://evil.example` would otherwise get an open-
+ *     redirect. We funnel every value through [DefaultGuildCookie.sanitizeRedirect].
+ */
+internal class PreferencesControllerTest {
+
+    private val tokenValue = "tkn-abc"
+    private lateinit var introWebService: IntroWebService
+    private lateinit var user: OAuth2User
+    private lateinit var client: OAuth2AuthorizedClient
+    private lateinit var request: HttpServletRequest
+    private lateinit var response: HttpServletResponse
+    private lateinit var controller: PreferencesController
+
+    @BeforeEach
+    fun setup() {
+        introWebService = mockk()
+        user = mockk(relaxed = true) {
+            every { getAttribute<String>("username") } returns "tester"
+        }
+        val token: OAuth2AccessToken = mockk { every { tokenValue } returns this@PreferencesControllerTest.tokenValue }
+        client = mockk { every { accessToken } returns token }
+        request = mockk(relaxed = true) {
+            every { isSecure } returns false
+            every { cookies } returns null
+        }
+        response = mockk(relaxed = true)
+        controller = PreferencesController(introWebService)
+    }
+
+    private fun guildInfo(id: Long, name: String = "g$id") = GuildInfo(id.toString(), name, null)
+
+    @Test
+    fun `page exposes mutual guilds and current default to the model`() {
+        val cookieReq: HttpServletRequest = mockk(relaxed = true) {
+            every { isSecure } returns false
+            every { cookies } returns arrayOf(Cookie(DefaultGuildCookie.COOKIE_NAME, "222"))
+        }
+        every { introWebService.getMutualGuilds(tokenValue) } returns listOf(guildInfo(111L), guildInfo(222L))
+        val model: Model = mockk(relaxed = true)
+
+        val view = controller.page(client = client, user = user, request = cookieReq, model = model)
+
+        assertEquals("preferences", view)
+        verify { model.addAttribute("defaultGuildId", 222L) }
+        verify { model.addAttribute(eq("guilds"), any()) }
+    }
+
+    @Test
+    fun `page returns empty guild list for anonymous user`() {
+        val model: Model = mockk(relaxed = true)
+
+        val view = controller.page(client = client, user = null, request = request, model = model)
+
+        assertEquals("preferences", view)
+        verify(exactly = 0) { introWebService.getMutualGuilds(any()) }
+    }
+
+    @Test
+    fun `setDefaultGuild writes cookie when user is a member`() {
+        every { introWebService.getMutualGuilds(tokenValue) } returns listOf(guildInfo(111L), guildInfo(222L))
+        val captured = slot<Cookie>()
+        every { response.addCookie(capture(captured)) } returns Unit
+
+        val result = controller.setDefaultGuild(
+            client = client,
+            user = user,
+            guildId = 222L,
+            redirect = "/casino/guilds?game=slots&pick=true",
+            request = request,
+            response = response,
+        )
+
+        assertEquals("redirect:/casino/guilds?game=slots&pick=true", result)
+        assertEquals(DefaultGuildCookie.COOKIE_NAME, captured.captured.name)
+        assertEquals("222", captured.captured.value)
+    }
+
+    @Test
+    fun `setDefaultGuild does not write cookie when user is not a member`() {
+        every { introWebService.getMutualGuilds(tokenValue) } returns listOf(guildInfo(111L))
+
+        val result = controller.setDefaultGuild(
+            client = client,
+            user = user,
+            guildId = 999L,
+            redirect = "/leaderboards",
+            request = request,
+            response = response,
+        )
+
+        assertEquals("redirect:/leaderboards", result)
+        verify(exactly = 0) { response.addCookie(any()) }
+    }
+
+    @Test
+    fun `setDefaultGuild redirects without writing when user is anonymous`() {
+        val result = controller.setDefaultGuild(
+            client = client,
+            user = null,
+            guildId = 222L,
+            redirect = "/leaderboards",
+            request = request,
+            response = response,
+        )
+
+        assertEquals("redirect:/leaderboards", result)
+        verify(exactly = 0) { response.addCookie(any()) }
+        verify(exactly = 0) { introWebService.getMutualGuilds(any()) }
+    }
+
+    @Test
+    fun `setDefaultGuild rejects external redirect targets`() {
+        every { introWebService.getMutualGuilds(tokenValue) } returns listOf(guildInfo(111L))
+        every { response.addCookie(any()) } returns Unit
+
+        val result = controller.setDefaultGuild(
+            client = client,
+            user = user,
+            guildId = 111L,
+            redirect = "https://evil.example/path",
+            request = request,
+            response = response,
+        )
+
+        // Cookie still written (the request is otherwise valid), but the
+        // redirect target is sanitised to the safe fallback.
+        assertEquals("redirect:/", result)
+    }
+
+    @Test
+    fun `setDefaultGuild rejects protocol-relative redirect`() {
+        every { introWebService.getMutualGuilds(tokenValue) } returns listOf(guildInfo(111L))
+        every { response.addCookie(any()) } returns Unit
+
+        val result = controller.setDefaultGuild(
+            client = client,
+            user = user,
+            guildId = 111L,
+            redirect = "//evil.example",
+            request = request,
+            response = response,
+        )
+
+        assertEquals("redirect:/", result)
+    }
+
+    @Test
+    fun `clearDefaultGuild clears cookie and redirects to sanitised target`() {
+        val captured = slot<Cookie>()
+        every { response.addCookie(capture(captured)) } returns Unit
+
+        val result = controller.clearDefaultGuild(
+            redirect = "/casino/guilds?pick=true",
+            request = request,
+            response = response,
+        )
+
+        assertEquals("redirect:/casino/guilds?pick=true", result)
+        assertEquals(DefaultGuildCookie.COOKIE_NAME, captured.captured.name)
+        assertEquals(0, captured.captured.maxAge)
+    }
+
+    @Test
+    fun `clearDefaultGuild sanitises external redirect target`() {
+        every { response.addCookie(any()) } returns Unit
+
+        val result = controller.clearDefaultGuild(
+            redirect = "https://evil.example/path",
+            request = request,
+            response = response,
+        )
+
+        assertEquals("redirect:/", result)
+    }
+
+    @Test
+    fun `clearDefaultGuild redirects to fallback when redirect is null`() {
+        every { response.addCookie(any()) } returns Unit
+
+        val result = controller.clearDefaultGuild(
+            redirect = null,
+            request = request,
+            response = response,
+        )
+
+        assertEquals("redirect:/", result)
+        verify(exactly = 1) { response.addCookie(any()) }
+    }
+}

--- a/web/src/test/kotlin/web/controller/TeamWebControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/TeamWebControllerTest.kt
@@ -4,6 +4,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.unmockkAll
 import io.mockk.verify
+import jakarta.servlet.http.HttpServletRequest
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -26,6 +27,9 @@ class TeamWebControllerTest {
     private val mockClient = mockk<OAuth2AuthorizedClient>(relaxed = true)
     private val mockModel = mockk<Model>(relaxed = true)
     private val mockRa = mockk<RedirectAttributes>(relaxed = true)
+    private val mockRequest = mockk<HttpServletRequest>(relaxed = true).also {
+        every { it.cookies } returns null
+    }
 
     private val discordId = "111"
     private val guildId = 222L
@@ -47,10 +51,12 @@ class TeamWebControllerTest {
 
     @Test
     fun `guildList renders team-guilds template`() {
-        val guilds = listOf(GuildInfo("1", "Guild One", null))
+        // Multiple guilds + pick=true bypasses the auto-redirect so the
+        // template render is observable here.
+        val guilds = listOf(GuildInfo("1", "Guild One", null), GuildInfo("2", "Guild Two", null))
         every { teamWebService.getMutualGuilds("mock-token") } returns guilds
 
-        val view = controller.guildList(mockClient, mockUser, mockModel)
+        val view = controller.guildList(mockClient, mockUser, pick = true, request = mockRequest, model = mockModel)
 
         assertEquals("team-guilds", view)
         verify { mockModel.addAttribute("guilds", guilds) }

--- a/web/src/test/kotlin/web/util/DefaultGuildCookieTest.kt
+++ b/web/src/test/kotlin/web/util/DefaultGuildCookieTest.kt
@@ -1,0 +1,163 @@
+package web.util
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import jakarta.servlet.http.Cookie
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+/**
+ * Pins the cookie shape and parse rules. The cookie is the *only* source
+ * of truth for an anchored default guild, so a malformed value MUST
+ * yield null (treat as "no preference") rather than throwing — picker
+ * pages have to keep rendering even when a stale browser session sends
+ * gibberish.
+ */
+internal class DefaultGuildCookieTest {
+
+    private fun requestWith(vararg cookies: Cookie, secure: Boolean = false): HttpServletRequest =
+        mockk {
+            every { this@mockk.cookies } returns if (cookies.isEmpty()) null else cookies
+            every { isSecure } returns secure
+        }
+
+    @Test
+    fun `read returns null when no cookies present`() {
+        assertNull(DefaultGuildCookie.read(requestWith()))
+    }
+
+    @Test
+    fun `read returns null when other cookies present but ours is missing`() {
+        assertNull(DefaultGuildCookie.read(requestWith(Cookie("session", "abc"))))
+    }
+
+    @Test
+    fun `read returns guildId when cookie value is a valid long`() {
+        val req = requestWith(Cookie(DefaultGuildCookie.COOKIE_NAME, "1234567890"))
+        assertEquals(1234567890L, DefaultGuildCookie.read(req))
+    }
+
+    @Test
+    fun `read returns null when cookie value is non-numeric`() {
+        val req = requestWith(Cookie(DefaultGuildCookie.COOKIE_NAME, "not-a-number"))
+        assertNull(DefaultGuildCookie.read(req))
+    }
+
+    @Test
+    fun `read returns null when cookie value overflows Long`() {
+        val req = requestWith(Cookie(DefaultGuildCookie.COOKIE_NAME, "99999999999999999999"))
+        assertNull(DefaultGuildCookie.read(req))
+    }
+
+    @Test
+    fun `read returns null when cookie value is empty`() {
+        val req = requestWith(Cookie(DefaultGuildCookie.COOKIE_NAME, ""))
+        assertNull(DefaultGuildCookie.read(req))
+    }
+
+    @Test
+    fun `write sets cookie with 1 year max age, root path, and SameSite=Lax`() {
+        val req = requestWith(secure = false)
+        val response = mockk<HttpServletResponse>(relaxed = true)
+        val captured = slot<Cookie>()
+        every { response.addCookie(capture(captured)) } returns Unit
+
+        DefaultGuildCookie.write(req, response, 42L)
+
+        val c = captured.captured
+        assertEquals(DefaultGuildCookie.COOKIE_NAME, c.name)
+        assertEquals("42", c.value)
+        assertEquals("/", c.path)
+        assertEquals(60 * 60 * 24 * 365, c.maxAge)
+        assertEquals("Lax", c.getAttribute("SameSite"))
+    }
+
+    @Test
+    fun `write marks cookie Secure when request is HTTPS`() {
+        val response = mockk<HttpServletResponse>(relaxed = true)
+        val captured = slot<Cookie>()
+        every { response.addCookie(capture(captured)) } returns Unit
+
+        DefaultGuildCookie.write(requestWith(secure = true), response, 7L)
+
+        assertEquals(true, captured.captured.secure)
+    }
+
+    @Test
+    fun `write leaves Secure off for plain HTTP (so localhost dev works)`() {
+        val response = mockk<HttpServletResponse>(relaxed = true)
+        val captured = slot<Cookie>()
+        every { response.addCookie(capture(captured)) } returns Unit
+
+        DefaultGuildCookie.write(requestWith(secure = false), response, 7L)
+
+        assertEquals(false, captured.captured.secure)
+    }
+
+    @Test
+    fun `clear writes an expired cookie at the same path`() {
+        val response = mockk<HttpServletResponse>(relaxed = true)
+        val captured = slot<Cookie>()
+        every { response.addCookie(capture(captured)) } returns Unit
+
+        DefaultGuildCookie.clear(requestWith(), response)
+
+        val c = captured.captured
+        assertEquals(DefaultGuildCookie.COOKIE_NAME, c.name)
+        assertEquals("/", c.path)
+        assertEquals(0, c.maxAge)
+        verify(exactly = 1) { response.addCookie(any()) }
+    }
+
+    @Test
+    fun `sanitizeRedirect accepts in-app paths`() {
+        assertEquals("/casino/guilds?game=slots", DefaultGuildCookie.sanitizeRedirect("/casino/guilds?game=slots"))
+        assertEquals("/leaderboards", DefaultGuildCookie.sanitizeRedirect("/leaderboards"))
+        assertEquals("/", DefaultGuildCookie.sanitizeRedirect("/"))
+    }
+
+    @Test
+    fun `sanitizeRedirect falls back to default for external URLs`() {
+        assertEquals("/", DefaultGuildCookie.sanitizeRedirect("https://evil.example/path"))
+        assertEquals("/", DefaultGuildCookie.sanitizeRedirect("http://evil.example"))
+    }
+
+    @Test
+    fun `sanitizeRedirect falls back to default for protocol-relative URLs`() {
+        // `//evil.example` would otherwise become `https://evil.example` in the
+        // browser — the leading double-slash is the classic redirect bypass.
+        assertEquals("/", DefaultGuildCookie.sanitizeRedirect("//evil.example/path"))
+    }
+
+    @Test
+    fun `sanitizeRedirect falls back to default for backslash bypass`() {
+        // Some browsers normalise /\ to // — block that variant too.
+        assertEquals("/", DefaultGuildCookie.sanitizeRedirect("/\\evil.example"))
+    }
+
+    @Test
+    fun `sanitizeRedirect falls back to default for blank or null`() {
+        assertEquals("/", DefaultGuildCookie.sanitizeRedirect(null))
+        assertEquals("/", DefaultGuildCookie.sanitizeRedirect(""))
+        assertEquals("/", DefaultGuildCookie.sanitizeRedirect("   "))
+    }
+
+    @Test
+    fun `sanitizeRedirect falls back to default for relative paths`() {
+        // `casino/guilds` without leading slash could resolve relative to the
+        // current request — we want strict absolute-from-root only.
+        assertEquals("/", DefaultGuildCookie.sanitizeRedirect("casino/guilds"))
+        assertEquals("/", DefaultGuildCookie.sanitizeRedirect("./casino"))
+    }
+
+    @Test
+    fun `sanitizeRedirect honours custom fallback`() {
+        assertEquals("/home", DefaultGuildCookie.sanitizeRedirect(null, "/home"))
+        assertEquals("/home", DefaultGuildCookie.sanitizeRedirect("https://evil.example", "/home"))
+    }
+}

--- a/web/src/test/kotlin/web/util/DefaultGuildModelAdviceTest.kt
+++ b/web/src/test/kotlin/web/util/DefaultGuildModelAdviceTest.kt
@@ -1,0 +1,71 @@
+package web.util
+
+import io.mockk.every
+import io.mockk.mockk
+import jakarta.servlet.http.Cookie
+import jakarta.servlet.http.HttpServletRequest
+import net.dv8tion.jda.api.JDA
+import net.dv8tion.jda.api.entities.Guild
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+/**
+ * The controller advice exposes the anchored guild id + name to every
+ * model so the shared navbar fragment can render its "Default: X" pill
+ * regardless of which controller produced the page. Two important rules:
+ *
+ *  - When the cookie points to a guild the bot was kicked from, the
+ *    JDA lookup returns null and the advice must propagate that null
+ *    (navbar hides the pill) instead of crashing the render.
+ *  - When the cookie is missing or malformed, both attributes are null.
+ */
+internal class DefaultGuildModelAdviceTest {
+
+    private val jda: JDA = mockk()
+    private val advice = DefaultGuildModelAdvice(jda)
+
+    private fun requestWith(vararg cookies: Cookie): HttpServletRequest = mockk {
+        every { this@mockk.cookies } returns if (cookies.isEmpty()) null else cookies
+        every { isSecure } returns false
+    }
+
+    @Test
+    fun `currentDefaultGuildId returns cookie value when valid`() {
+        val req = requestWith(Cookie(DefaultGuildCookie.COOKIE_NAME, "555"))
+        assertEquals(555L, advice.currentDefaultGuildId(req))
+    }
+
+    @Test
+    fun `currentDefaultGuildId returns null when no cookie`() {
+        assertNull(advice.currentDefaultGuildId(requestWith()))
+    }
+
+    @Test
+    fun `currentDefaultGuildName resolves through JDA when guild exists`() {
+        val guild = mockk<Guild> { every { name } returns "My Server" }
+        every { jda.getGuildById(555L) } returns guild
+
+        val req = requestWith(Cookie(DefaultGuildCookie.COOKIE_NAME, "555"))
+        assertEquals("My Server", advice.currentDefaultGuildName(req))
+    }
+
+    @Test
+    fun `currentDefaultGuildName returns null when cookie points to a guild the bot is no longer in`() {
+        every { jda.getGuildById(555L) } returns null
+
+        val req = requestWith(Cookie(DefaultGuildCookie.COOKIE_NAME, "555"))
+        assertNull(advice.currentDefaultGuildName(req))
+    }
+
+    @Test
+    fun `currentDefaultGuildName returns null when cookie missing`() {
+        assertNull(advice.currentDefaultGuildName(requestWith()))
+    }
+
+    @Test
+    fun `currentDefaultGuildName returns null when cookie malformed`() {
+        val req = requestWith(Cookie(DefaultGuildCookie.COOKIE_NAME, "garbage"))
+        assertNull(advice.currentDefaultGuildName(req))
+    }
+}

--- a/web/src/test/kotlin/web/util/DefaultGuildRedirectTest.kt
+++ b/web/src/test/kotlin/web/util/DefaultGuildRedirectTest.kt
@@ -1,0 +1,55 @@
+package web.util
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+/**
+ * Pure-function decision table for the auto-redirect rule. Pinning each
+ * row here means every picker controller's redirect logic shrinks to
+ * "call DefaultGuildRedirect.pick and let it answer", and a regression
+ * in this rule trips one test instead of fourteen controller tests.
+ */
+internal class DefaultGuildRedirectTest {
+
+    @Test
+    fun `pick=true always returns null (force the picker)`() {
+        assertNull(DefaultGuildRedirect.pick(listOf(1L), cookieGuildId = 1L, pick = true))
+        assertNull(DefaultGuildRedirect.pick(listOf(1L, 2L), cookieGuildId = 1L, pick = true))
+        assertNull(DefaultGuildRedirect.pick(emptyList(), cookieGuildId = null, pick = true))
+    }
+
+    @Test
+    fun `empty guild list returns null (no mutual guilds — empty hero will render)`() {
+        assertNull(DefaultGuildRedirect.pick(emptyList(), cookieGuildId = 1L, pick = false))
+        assertNull(DefaultGuildRedirect.pick(emptyList(), cookieGuildId = null, pick = false))
+    }
+
+    @Test
+    fun `valid cookie wins when the user still shares that guild`() {
+        assertEquals(222L, DefaultGuildRedirect.pick(listOf(111L, 222L, 333L), cookieGuildId = 222L, pick = false))
+    }
+
+    @Test
+    fun `stale cookie falls through to the single-guild rule`() {
+        // Cookie points to a guild the user no longer shares.
+        // With only one mutual guild left, we still auto-redirect to it.
+        assertEquals(111L, DefaultGuildRedirect.pick(listOf(111L), cookieGuildId = 999L, pick = false))
+    }
+
+    @Test
+    fun `stale cookie with multi-guild returns null (picker required)`() {
+        assertNull(DefaultGuildRedirect.pick(listOf(111L, 222L), cookieGuildId = 999L, pick = false))
+    }
+
+    @Test
+    fun `single mutual guild auto-redirects even without a cookie`() {
+        assertEquals(42L, DefaultGuildRedirect.pick(listOf(42L), cookieGuildId = null, pick = false))
+    }
+
+    @Test
+    fun `multiple guilds without a cookie returns null (picker)`() {
+        assertNull(DefaultGuildRedirect.pick(listOf(1L, 2L), cookieGuildId = null, pick = false))
+        assertNull(DefaultGuildRedirect.pick(listOf(1L, 2L, 3L, 4L), cookieGuildId = null, pick = false))
+    }
+}


### PR DESCRIPTION
## Summary

- Skips the `/{thing}/guilds` picker when the user only shares one server with the bot, or has anchored a default server. Applies to every picker in the navbar (casino games, leaderboards, intros, poker, blackjack, lottery, profile, economy, titles, tip, duel, music, excuses, teams, moderation).
- Each picker card grows a `☆ Set as default` / `★ Default` toggle, the navbar shows a "★ ServerName" pill when anchored, and a new `/preferences` page lets the user manage the anchor from one place.
- `?pick=true` on any picker forces it to render — every game's `← All servers` back-link uses it so switching servers is still one click.

## How it works

- `DefaultGuildCookie` — per-browser cookie (`toby_default_guild`), 1y, `Path=/`, `HttpOnly`, `SameSite=Lax`, `Secure` when HTTPS.
- `DefaultGuildRedirect.pick(...)` — pure function: `pick=true` → null; empty guilds → null; valid cookie + still member → cookie; single mutual guild → that guild; else null.
- `PreferencesController` — POST `/preferences/default-guild` (validates membership before writing the cookie, sanitises the `redirect` target against open-redirect abuse), POST `/preferences/default-guild/clear`, GET `/preferences` (small management page).
- `DefaultGuildModelAdvice` — `@ControllerAdvice` exposing `currentDefaultGuildId` + `currentDefaultGuildName` so the shared navbar fragment can render the pill on every page.

Casino navbar links carry `?game=<slug>` (slots, coinflip, dice, …) so a single-guild user lands on the specific game; without `game` the picker still renders (it doubles as a per-guild game index). The shared `guildListPage` fragment and the individual picker templates were restructured (`<a>`-wrapped card → `<div>` wrapper containing a link + the star form) so the toggle can coexist with the per-card click target.

## Tests

Backend (JUnit 5 + MockK):
- `DefaultGuildCookieTest` — parse/write/clear, Secure flag wiring, open-redirect sanitisation.
- `DefaultGuildRedirectTest` — pure-function decision table for the auto-redirect rule.
- `DefaultGuildModelAdviceTest` — model attributes resolve via JDA, stale cookies hide the pill instead of crashing.
- `PreferencesControllerTest` — cookie writes only for members, redirect sanitisation, anonymous handling, page handler.
- `CasinoControllerTest` (new) — every redirect branch, stale cookie fallback, `pick=true` bypass, slug whitelist (including a tripwire over the template slug set), case-insensitive game param.
- `IntroWebControllerGuildListTest` (new), `LeaderboardControllerTest` extended, `PokerControllerTest` extended — same redirect contract.
- `TeamWebControllerTest` updated for the new `guildList` signature.

Frontend: no new JS introduced (the star is a plain Thymeleaf form POST). The search-filter JS in `guilds.html` / `excuse-guilds.html` / `team-guilds.html` was retargeted from `.guild-card` to `.guild-card-wrap` after the restructuring.

Full `:web:test` suite: 762 tests, 0 failures.

## Test plan

- [ ] Sign in as a user who shares exactly one server — clicking Slots / Leaderboards / Intro Songs in the navbar lands on the deep link.
- [ ] Sign in as a user sharing 2+ servers — pickers render with star buttons; click `☆` on Server B → cookie set → next nav click skips picker.
- [ ] On a game page, click `← All servers` — picker renders (anchor preserved, no auto-redirect).
- [ ] Click the "★ ServerName" pill in the navbar → land on `/preferences` and clear/re-anchor from there.
- [ ] Manually corrupt the cookie (`document.cookie='toby_default_guild=junk'`) — pickers still render, no 500.
- [ ] `POST /preferences/default-guild` with `redirect=https://evil.example` — response 302s to `/`, not the external host.

https://claude.ai/code/session_01EqHtfKMBhSrJyCZy6AcUiH

---
_Generated by [Claude Code](https://claude.ai/code/session_01EqHtfKMBhSrJyCZy6AcUiH)_