### PR TITLE
fix(web): add pick=true to remaining "All servers" back-links

### DIFF
--- a/web/src/main/resources/templates/blackjack-lobby.html
+++ b/web/src/main/resources/templates/blackjack-lobby.html
@@ -9,7 +9,7 @@
       th:attr="data-guild-id=${guildId}, data-min-ante=${minAnte}, data-max-ante=${maxAnte}">
 
     <div class="bj-header">
-        <a class="back-link" th:href="@{/blackjack/guilds}">&larr; All servers</a>
+        <a class="back-link" th:href="@{/blackjack/guilds(pick=true)}">&larr; All servers</a>
         <h1 th:text="'🂡 Blackjack • ' + ${guildName}">🂡 Blackjack</h1>
         <p class="muted">
             Players vs. shared dealer. Each seat antes the same amount per hand.

--- a/web/src/main/resources/templates/blackjack-solo.html
+++ b/web/src/main/resources/templates/blackjack-solo.html
@@ -9,7 +9,7 @@
       th:attr="data-guild-id=${guildId}, data-min-stake=${minStake}, data-max-stake=${maxStake}, data-my-discord-id=${myDiscordId}">
 
     <div class="bj-header">
-        <a class="back-link" th:href="@{/blackjack/guilds}">&larr; All servers</a>
+        <a class="back-link" th:href="@{/blackjack/guilds(pick=true)}">&larr; All servers</a>
         <h1>🂡 Solo blackjack</h1>
         <p class="muted">
             Bet between <span th:text="${minStake}">10</span> and

--- a/web/src/main/resources/templates/duel.html
+++ b/web/src/main/resources/templates/duel.html
@@ -15,7 +15,7 @@
                data-user-avatar=${currentUserAvatarUrl}">
 
     <div class="duel-header">
-        <a class="back-link" th:href="@{/duel/guilds}">&larr; All servers</a>
+        <a class="back-link" th:href="@{/duel/guilds(pick=true)}">&larr; All servers</a>
         <h1 th:text="'⚔️ Duel • ' + ${guildName}">⚔️ Duel</h1>
         <p class="muted">
             Stake between <span th:text="${minStake}">10</span> and

--- a/web/src/main/resources/templates/economy.html
+++ b/web/src/main/resources/templates/economy.html
@@ -16,7 +16,7 @@
 
     <div class="economy-header">
         <div>
-            <a class="back-link" th:href="@{/economy/guilds}">&larr; All markets</a>
+            <a class="back-link" th:href="@{/economy/guilds(pick=true)}">&larr; All markets</a>
             <h1 th:text="'TOBY • ' + ${view.guildName}">TOBY</h1>
         </div>
         <div class="economy-price">

--- a/web/src/main/resources/templates/excuses.html
+++ b/web/src/main/resources/templates/excuses.html
@@ -13,6 +13,7 @@
 <main id="main" class="container">
 
     <div class="excuse-header">
+        <a class="back-link" th:href="@{/excuses/guilds(pick=true)}">&larr; All servers</a>
         <h1>Excuses — <span th:text="${guildName}">Server</span></h1>
         <span class="excuse-count"
               th:text="${totalCount} + ' total'">0 total</span>

--- a/web/src/main/resources/templates/fragments/moderationHeader.html
+++ b/web/src/main/resources/templates/fragments/moderationHeader.html
@@ -12,7 +12,7 @@
 -->
 <div th:fragment="moderationHeader(overview, isOwner, active)">
     <div class="page-header mod-header">
-        <a class="back-link" th:href="@{/moderation/guilds}">&larr; All servers</a>
+        <a class="back-link" th:href="@{/moderation/guilds(pick=true)}">&larr; All servers</a>
         <h1 th:text="${overview.guildName}">Guild Name</h1>
         <p class="lede" th:if="${isOwner}">You are the server owner.</p>
         <p class="lede" th:unless="${isOwner}">You are a TobyBot superuser.</p>

--- a/web/src/main/resources/templates/intros.html
+++ b/web/src/main/resources/templates/intros.html
@@ -26,6 +26,7 @@
 <main id="main" class="container">
 
     <div class="intro-header">
+        <a class="back-link" th:href="@{/intro/guilds(pick=true)}">&larr; All servers</a>
         <h1>Intro Songs — <span th:text="${guildName}">Server</span></h1>
         <span class="slot-count"
               th:classappend="${atLimit} ? ' full'"

--- a/web/src/main/resources/templates/lottery.html
+++ b/web/src/main/resources/templates/lottery.html
@@ -14,7 +14,7 @@
                data-revenue-jackpot-pct=${snapshot.revenueJackpotPct}">
 
     <div class="lottery-header">
-        <a class="back-link" th:href="@{/lottery/guilds}">&larr; All servers</a>
+        <a class="back-link" th:href="@{/lottery/guilds(pick=true)}">&larr; All servers</a>
         <h1 th:text="'🎟️ Lottery • ' + ${guildName}">🎟️ Lottery</h1>
         <!-- Mode-aware blurb: NUMBER_MATCH (Pick-X) vs WEIGHTED (top-3
              weighted draw) reflects the guild's LOTTERY_DAILY_MODE

--- a/web/src/main/resources/templates/music-player.html
+++ b/web/src/main/resources/templates/music-player.html
@@ -9,7 +9,7 @@
 
     <header class="music-header">
         <h1>🎵 <span th:text="${guildName}">Server</span></h1>
-        <a class="btn-tertiary" href="/music-player/guilds">← All servers</a>
+        <a class="btn-tertiary" href="/music-player/guilds?pick=true">← All servers</a>
     </header>
 
     <div th:replace="~{fragments/alerts :: error}"></div>

--- a/web/src/main/resources/templates/poker-lobby.html
+++ b/web/src/main/resources/templates/poker-lobby.html
@@ -9,7 +9,7 @@
       th:attr="data-guild-id=${guildId}, data-min-buyin=${minBuyIn}, data-max-buyin=${maxBuyIn}">
 
     <div class="poker-header">
-        <a class="back-link" th:href="@{/poker/guilds}">&larr; All servers</a>
+        <a class="back-link" th:href="@{/poker/guilds(pick=true)}">&larr; All servers</a>
         <h1 th:text="'🃏 Poker • ' + ${guildName}">🃏 Poker</h1>
         <p class="muted">
             Fixed-limit Texas Hold'em.

--- a/web/src/main/resources/templates/profile.html
+++ b/web/src/main/resources/templates/profile.html
@@ -7,7 +7,7 @@
 
 <main id="main" class="container">
     <div class="profile-header">
-        <a class="back-link" th:href="@{/profile/guilds}">&larr; All servers</a>
+        <a class="back-link" th:href="@{/profile/guilds(pick=true)}">&larr; All servers</a>
         <h1 th:text="${profile.guildName}">Guild</h1>
     </div>
 

--- a/web/src/main/resources/templates/teams.html
+++ b/web/src/main/resources/templates/teams.html
@@ -13,6 +13,7 @@
 <main id="main" class="container">
 
     <div class="excuse-header">
+        <a class="back-link" th:href="@{/teams/guilds(pick=true)}">&larr; All servers</a>
         <h1>Teams — <span th:text="${guildName}">Server</span></h1>
         <span class="excuse-count"
               th:text="${#lists.size(presets)} + ' preset' + (${#lists.size(presets)} == 1 ? '' : 's')">0 presets</span>

--- a/web/src/main/resources/templates/tip.html
+++ b/web/src/main/resources/templates/tip.html
@@ -9,7 +9,7 @@
       th:attr="data-guild-id=${guildId}, data-min-tip=${minTip}, data-max-tip=${maxTip}, data-daily-cap=${dailyCap}">
 
     <div class="tip-header">
-        <a class="back-link" th:href="@{/tip/guilds}">&larr; All servers</a>
+        <a class="back-link" th:href="@{/tip/guilds(pick=true)}">&larr; All servers</a>
         <h1 th:text="'💸 Tip • ' + ${guildName}">💸 Tip</h1>
         <p class="muted">
             Send between <span th:text="${minTip}">10</span> and

--- a/web/src/main/resources/templates/titles.html
+++ b/web/src/main/resources/templates/titles.html
@@ -9,7 +9,7 @@
 
     <div class="mod-header">
         <div>
-            <a class="back-link" th:href="@{/titles/guilds}">&larr; All servers</a>
+            <a class="back-link" th:href="@{/titles/guilds(pick=true)}">&larr; All servers</a>
             <h1>Title Shop</h1>
         </div>
     </div>

--- a/web/src/test/js/back-link.test.js
+++ b/web/src/test/js/back-link.test.js
@@ -1,0 +1,99 @@
+const fs = require('fs');
+const path = require('path');
+
+// Every per-guild page renders a "← All servers" back-link to the
+// matching `/{thing}/guilds` picker. Those pickers now auto-redirect
+// to the user's anchored default server, which means a bare back-link
+// gets silently bounced right back to the page the user just left —
+// the user can never reach the picker to change their anchor.
+//
+// `?pick=true` on the picker URL bypasses the auto-redirect, so every
+// back-link MUST carry it. This test enumerates the full per-guild
+// template set so a new page added without the query param trips a
+// single, named assertion instead of shipping the same bug a third
+// time.
+
+const TEMPLATES_DIR = path.resolve(
+    __dirname,
+    '../../main/resources/templates'
+);
+
+// Each entry: [template file (relative to templates dir), picker path
+// that the back-link should target]. Grouped so the failure message
+// points at the right family if someone breaks a whole category.
+const CASES = [
+    // Casino minigames (fixed in #486; regression guard).
+    ['baccarat.html',          '/casino/guilds'],
+    ['coinflip.html',          '/casino/guilds'],
+    ['casinoholdem-solo.html', '/casino/guilds'],
+    ['dice.html',              '/casino/guilds'],
+    ['highlow.html',           '/casino/guilds'],
+    ['horse-racing.html',      '/casino/guilds'],
+    ['keno.html',              '/casino/guilds'],
+    ['plinko.html',            '/casino/guilds'],
+    ['roulette.html',          '/casino/guilds'],
+    ['scratch.html',           '/casino/guilds'],
+    ['slots.html',             '/casino/guilds'],
+    ['wheel.html',             '/casino/guilds'],
+
+    // Leaderboard.
+    ['leaderboard.html',       '/leaderboards'],
+
+    // Newly fixed by this change.
+    ['poker-lobby.html',       '/poker/guilds'],
+    ['blackjack-lobby.html',   '/blackjack/guilds'],
+    ['blackjack-solo.html',    '/blackjack/guilds'],
+    ['lottery.html',           '/lottery/guilds'],
+    ['profile.html',           '/profile/guilds'],
+    ['economy.html',           '/economy/guilds'],
+    ['titles.html',            '/titles/guilds'],
+    ['tip.html',               '/tip/guilds'],
+    ['duel.html',              '/duel/guilds'],
+    ['music-player.html',      '/music-player/guilds'],
+
+    // Shared fragment used by every /moderation/{guildId}/... page.
+    ['fragments/moderationHeader.html', '/moderation/guilds'],
+
+    // Newly added back-links on pages that previously had none.
+    ['intros.html',            '/intro/guilds'],
+    ['excuses.html',           '/excuses/guilds'],
+    ['teams.html',             '/teams/guilds'],
+];
+
+describe('per-guild back-link contract', () => {
+    test.each(CASES)(
+        '%s back-link targets %s with pick=true',
+        (templateRel, pickerPath) => {
+            const html = fs.readFileSync(
+                path.join(TEMPLATES_DIR, templateRel),
+                'utf8'
+            );
+
+            // Find the back-link anchor. Most templates use the
+            // `back-link` class; music-player.html uses `btn-tertiary`
+            // for visual reasons but the contract is the same. Inner
+            // text varies a bit ("All servers", "All casino servers",
+            // "All markets", "All leaderboards") so we don't pin it —
+            // the contract is on the href.
+            const anchorMatch = html.match(
+                /<a[^>]*class="(?:back-link|btn-tertiary)"[^>]*>[\s\S]*?<\/a>/
+            );
+            expect(anchorMatch).not.toBeNull();
+            const anchor = anchorMatch[0];
+
+            // The href must point at the matching picker — both the
+            // Thymeleaf form `@{/foo/guilds(...)}` and the literal
+            // `href="/foo/guilds..."` are valid; either way the path
+            // segment must match.
+            const escapedPath = pickerPath.replace(/\//g, '\\/');
+            expect(anchor).toMatch(
+                new RegExp(`(?:@\\{|href=")${escapedPath}`)
+            );
+
+            // The query param must be present in one of the two forms.
+            // `pick=true` — plain HTML query string.
+            // `(pick=true)` — Thymeleaf URL-expression query syntax.
+            expect(anchor).toMatch(/(?:\(pick=true\)|\?pick=true|&pick=true|&amp;pick=true)/);
+        }
+    );
+});


### PR DESCRIPTION
## Summary

- Adds `?pick=true` to the "← All servers" back-link on 11 per-guild pages (poker-lobby, blackjack-lobby/solo, lottery, profile, economy, titles, tip, duel, music-player, moderation). Without the query param the picker auto-redirect introduced in #486 bounces the user straight back to the page they just left, leaving them no way to re-anchor a different server from page chrome.
- Adds the back-link to `intros.html`, `excuses.html`, `teams.html` which had no in-page change-server affordance at all.
- Adds `web/src/test/js/back-link.test.js` enumerating every per-guild template and asserting its back-link href carries `pick=true` — so the next per-guild page added either picks up the contract or trips a single, named assertion.

## Reproduction (pre-fix)

1. Anchor Server A as default (★).
2. Open `/poker/{anyId}`.
3. Click "← All servers". Browser hits `/poker/guilds`, which auto-redirects to `/poker/{anchoredId}` — the same page. The picker is unreachable from here.

After the fix the back-link goes to `/poker/guilds?pick=true`, which the picker controller already honours by rendering the grid with the star toggle.

## Test plan

- [x] `cd web && npm test` → 536 passed (27 new in `back-link.test.js`).
- [x] `./gradlew :web:test` → green.
- [x] CSS lint clean.
- [ ] Manual: anchor a server, click each "← All servers" link on the 14 affected pages, confirm the picker renders.

https://claude.ai/code/session_01EqHtfKMBhSrJyCZy6AcUiH

---
_Generated by [Claude Code](https://claude.ai/code/session_01EqHtfKMBhSrJyCZy6AcUiH)_