### PR TITLE
feat(web): redesign mobile navbar as a slide-in drawer

### DIFF
--- a/web/src/main/resources/static/css/nav.css
+++ b/web/src/main/resources/static/css/nav.css
@@ -1,48 +1,107 @@
+/* ============================================================
+   Site navbar.
+
+   Desktop (≥ 601px): flat horizontal row — brand on the left, links
+   + dropdowns inline to the right. Section eyebrows, drawer chrome,
+   identity card, backdrop, and the auth footer are all
+   display: none on desktop; the hamburger is too.
+
+   Mobile (≤ 600px): the hamburger toggles a fixed-position drawer
+   that slides in from the right with a dim backdrop. The drawer
+   stacks: sticky header → identity card (signed-in) → grouped
+   sections with eyebrow labels and icons → auth footer pinned at
+   the bottom. Body scroll is locked while the drawer is open
+   (body.nav-open).
+   ============================================================ */
+
 nav {
-    background: #16213e;
+    background: var(--bg-elevated);
     padding: 14px 24px;
     display: flex;
     justify-content: space-between;
     align-items: center;
-    border-bottom: 1px solid #2a2a4a;
-    flex-wrap: wrap;
-    gap: 12px;
+    border-bottom: 1px solid var(--border);
+    gap: var(--space-3);
+    position: relative;
+    z-index: 10;
 }
-.brand { font-weight: 700; font-size: 1.2rem; color: #fff; text-decoration: none; max-width: calc(100% - 64px); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.nav-links { display: flex; align-items: center; gap: 20px; }
-.nav-links a { color: #a0a0b0; text-decoration: none; font-size: 0.9rem; transition: color 0.2s; }
-.nav-links a:hover { color: #fff; }
-.nav-user { color: #a0a0b0; font-size: 0.9rem; }
+.brand {
+    font-weight: 700;
+    font-size: 1.2rem;
+    color: #fff;
+    text-decoration: none;
+    max-width: calc(100% - 64px);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.nav-links {
+    display: flex;
+    align-items: center;
+    gap: var(--space-5);
+}
+.nav-links > .nav-section {
+    display: contents;
+}
+.nav-links > .nav-section > .nav-section-eyebrow,
+.nav-drawer-header,
+.nav-identity,
+.nav-auth {
+    display: none;
+}
+.nav-item {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2);
+    color: var(--text-muted);
+    text-decoration: none;
+    font-size: 0.9rem;
+    padding: 6px 8px;
+    border-radius: var(--radius-sm);
+    transition: color 0.15s, background 0.15s, box-shadow 0.15s;
+}
+.nav-item:hover { color: #fff; background: var(--accent-soft); }
+.nav-item-icon {
+    display: none;
+    width: 20px;
+    justify-content: center;
+    font-size: 1.05rem;
+    opacity: 0.85;
+}
+.nav-user { color: var(--text-muted); font-size: 0.9rem; }
 .btn-discord {
-    display: inline-block;
-    background: #5865F2;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--accent);
     color: #fff;
     text-decoration: none;
     padding: 8px 18px;
-    border-radius: 6px;
+    border-radius: var(--radius-sm);
     font-size: 0.9rem;
     font-weight: 600;
     transition: background 0.2s;
 }
-.btn-discord:hover { background: #4752c4; }
+.btn-discord:hover { background: var(--accent-hover); color: #fff; }
 .btn-logout {
     background: transparent;
-    border: 1px solid #555;
-    color: #a0a0b0;
+    border: 1px solid var(--border-strong);
+    color: var(--text-muted);
     padding: 8px 14px;
-    border-radius: 6px;
+    border-radius: var(--radius-sm);
     cursor: pointer;
     font-size: 0.85rem;
+    font-family: inherit;
     transition: border-color 0.2s, color 0.2s;
 }
-.btn-logout:hover { border-color: #e74c3c; color: #e74c3c; }
+.btn-logout:hover { border-color: var(--danger); color: var(--danger); }
 .nav-default-guild {
     display: inline-flex;
     align-items: center;
     gap: 4px;
     max-width: 160px;
     padding: 4px 10px;
-    border: 1px solid #555;
+    border: 1px solid var(--border-strong);
     border-radius: 999px;
     color: #c5c5d2;
     font-size: 0.8rem;
@@ -52,17 +111,60 @@ nav {
     text-overflow: ellipsis;
 }
 .nav-default-guild:hover { border-color: #fff; color: #fff; }
-.nav-default-guild-empty { color: #7a7a8c; }
-.nav-default-guild-empty:hover { color: #c5c5d2; border-color: #7a7a8c; }
+.nav-default-guild-empty { color: var(--text-dim); }
+.nav-default-guild-empty:hover { color: #c5c5d2; border-color: var(--text-dim); }
+
+/* Hamburger toggle — hidden on desktop, swap glyph via [aria-expanded]
+   so JS only flips the attribute. */
 .nav-toggle {
     display: none;
     background: transparent;
-    border: 1px solid #555;
-    color: #a0a0b0;
+    border: 1px solid var(--border-strong);
+    color: var(--text-muted);
     font-size: 1.2rem;
     padding: 4px 10px;
-    border-radius: 6px;
+    border-radius: var(--radius-sm);
     cursor: pointer;
+    line-height: 1;
+}
+.nav-toggle-icon { display: inline-block; line-height: 1; }
+.nav-toggle-icon::before { content: "\2630"; }
+.nav-toggle[aria-expanded="true"] .nav-toggle-icon::before { content: "\2715"; }
+
+/* Drawer-only chrome — surfaced inside the @media block */
+.nav-drawer-brand {
+    font-weight: 700;
+    font-size: 1.1rem;
+    color: #fff;
+}
+.nav-drawer-close {
+    width: 40px;
+    height: 40px;
+    background: transparent;
+    border: 1px solid var(--border-strong);
+    border-radius: var(--radius-sm);
+    color: var(--text);
+    font-size: 1rem;
+    cursor: pointer;
+    font-family: inherit;
+    line-height: 1;
+}
+.nav-drawer-close:hover { border-color: var(--accent); color: #fff; }
+
+.nav-identity-name {
+    font-weight: 600;
+    color: #fff;
+    font-size: 0.95rem;
+}
+
+.nav-backdrop { display: none; }
+
+/* Active-page accent. Desktop: subtle underline via box-shadow so layout
+   doesn't shift. Mobile rule below replaces this with a left-rail accent. */
+.nav-item[aria-current="page"],
+.nav-dropdown.is-active-parent > .nav-dropdown-toggle {
+    color: #fff;
+    box-shadow: inset 0 -2px 0 var(--accent);
 }
 
 /* Intermediate breakpoint — between desktop (full nav) and 600px
@@ -70,7 +172,7 @@ nav {
    wrap onto multiple rows or get clipped on iPad-portrait widths. */
 @media (max-width: 768px) {
     nav { padding: 12px 16px; }
-    .nav-links { gap: 12px; }
+    .nav-links { gap: var(--space-3); }
 }
 
 /* Dropdown menus (Economy, Casino, ...). Trigger looks like a regular nav
@@ -87,19 +189,27 @@ nav {
 .nav-dropdown-toggle {
     background: transparent;
     border: none;
-    color: #a0a0b0;
+    color: var(--text-muted);
     font-size: 0.9rem;
     cursor: pointer;
-    padding: 0;
-    transition: color 0.2s;
+    padding: 6px 8px;
+    border-radius: var(--radius-sm);
+    transition: color 0.15s, background 0.15s, box-shadow 0.15s;
     font-family: inherit;
     display: inline-flex;
     align-items: center;
     gap: 4px;
 }
 .nav-dropdown-toggle:hover,
-.nav-dropdown.open > .nav-dropdown-toggle { color: #fff; }
-.nav-dropdown-caret { font-size: 0.75em; transition: transform 0.2s; }
+.nav-dropdown.open > .nav-dropdown-toggle {
+    color: #fff;
+    background: var(--accent-soft);
+}
+.nav-dropdown-caret {
+    font-size: 0.75em;
+    transition: transform 0.2s;
+    margin-left: 2px;
+}
 @media (hover: hover) and (pointer: fine) {
     .nav-dropdown:hover .nav-dropdown-caret { transform: rotate(180deg); }
 }
@@ -110,63 +220,248 @@ nav {
     top: 100%;
     left: 0;
     margin-top: 0;
-    background: #16213e;
-    border: 1px solid #2a2a4a;
-    border-radius: 6px;
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
     padding: 6px 0;
-    min-width: 160px;
+    min-width: 180px;
     z-index: 10;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+    box-shadow: var(--shadow-md);
     flex-direction: column;
+    opacity: 0;
+    transform: translateY(-4px);
+    transition: opacity 0.12s ease-out, transform 0.12s ease-out;
 }
 @media (hover: hover) and (pointer: fine) {
-    .nav-dropdown:hover .nav-dropdown-menu { display: flex; }
+    .nav-dropdown:hover .nav-dropdown-menu {
+        display: flex;
+        opacity: 1;
+        transform: translateY(0);
+    }
 }
-.nav-dropdown.open .nav-dropdown-menu { display: flex; }
+.nav-dropdown.open .nav-dropdown-menu {
+    display: flex;
+    opacity: 1;
+    transform: translateY(0);
+}
 .nav-dropdown-menu a,
 .nav-dropdown-menu .nav-dropdown-coming-soon {
     padding: 8px 16px;
-    color: #a0a0b0;
+    color: var(--text-muted);
     text-decoration: none;
     font-size: 0.9rem;
-    transition: background 0.2s, color 0.2s;
+    transition: background 0.15s, color 0.15s;
     white-space: nowrap;
 }
-.nav-dropdown-menu a:hover { background: #2a2a4a; color: #fff; }
-.nav-dropdown-coming-soon { color: #555; cursor: default; font-style: italic; }
+.nav-dropdown-menu a:hover { background: var(--accent-soft); color: #fff; }
+.nav-dropdown-menu a[aria-current="page"] {
+    color: #fff;
+    background: var(--accent-soft);
+    box-shadow: inset 3px 0 0 var(--accent);
+}
+.nav-dropdown-coming-soon { color: var(--border-strong); cursor: default; font-style: italic; }
 .nav-dropdown-separator {
     border: 0;
-    border-top: 1px solid #2a2a4a;
+    border-top: 1px solid var(--border);
     margin: 4px 12px;
 }
 
+/* ============================================================
+   Mobile drawer (≤ 600px).
+   ============================================================ */
 @media (max-width: 600px) {
-    .nav-toggle { display: block; min-height: 40px; min-width: 40px; }
-    .nav-links { display: none; flex-direction: column; align-items: stretch; gap: 4px; width: 100%; padding: 8px 0; }
-    .nav-links.open { display: flex; }
-    .nav-links a, .nav-user { padding: 10px 4px; min-height: 40px; display: flex; align-items: center; }
-    .nav-links .btn-discord, .nav-links .btn-logout { align-self: flex-start; min-height: 40px; display: inline-flex; align-items: center; }
+    nav {
+        padding: 12px var(--space-4);
+        flex-wrap: nowrap;
+        gap: var(--space-2);
+    }
+    .brand { max-width: calc(100% - 56px); }
 
-    /* On mobile, dropdown items inline under the trigger and toggle
-       open/closed via the .open class set by toggleDropdown() — each
-       section starts collapsed so the menu isn't one giant scroll.
-       Hover is deliberately not a trigger on touch; see the
-       @media (hover: hover) guard above. The desktop hover-bridge
-       padding is also neutralised so it doesn't push items apart. */
+    .nav-toggle {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 40px;
+        min-width: 40px;
+        position: relative;
+        z-index: 60;
+    }
+
+    /* The drawer itself. Slides in from the right. */
+    .nav-links {
+        display: flex;
+        flex-direction: column;
+        align-items: stretch;
+        gap: var(--space-3);
+
+        position: fixed;
+        top: 0;
+        bottom: 0;
+        right: 0;
+        left: auto;
+        width: min(86vw, 340px);
+        max-width: 100vw;
+        padding: 0 var(--space-4) var(--space-5);
+
+        background: var(--bg-elevated);
+        border-left: 1px solid var(--border);
+        box-shadow: var(--shadow-lg);
+
+        overflow-y: auto;
+        overscroll-behavior: contain;
+
+        transform: translateX(100%);
+        transition: transform 0.22s ease-out;
+        z-index: 50;
+    }
+    .nav-links.open { transform: translateX(0); }
+
+    /* Sticky drawer header — keeps the brand + close X visible as the
+       user scrolls a long list of dropdown items. */
+    .nav-drawer-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        position: sticky;
+        top: 0;
+        background: var(--bg-elevated);
+        padding: var(--space-4) 0 var(--space-3);
+        border-bottom: 1px solid var(--border);
+        margin: 0 0 var(--space-2);
+        z-index: 2;
+    }
+
+    /* Identity card (signed-in only). */
+    .nav-identity {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: var(--space-2);
+        padding: var(--space-3);
+        background: var(--bg);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-md);
+    }
+    .nav-identity .nav-default-guild {
+        max-width: 100%;
+        align-self: stretch;
+    }
+
+    /* Sections. .nav-section was display: contents on desktop; flip it
+       to a real flex column so the eyebrow + items group together. */
+    .nav-links > .nav-section {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+    }
+    .nav-links > .nav-section > .nav-section-eyebrow {
+        display: block;
+        font-size: 0.7rem;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: var(--text-dim);
+        font-weight: 600;
+        padding: var(--space-2) var(--space-2) 4px;
+    }
+
+    /* Items + dropdown triggers as full-width tap targets. */
+    .nav-item,
+    .nav-dropdown-toggle {
+        width: 100%;
+        justify-content: flex-start;
+        padding: 10px var(--space-2);
+        min-height: var(--tap-min);
+        font-size: 0.95rem;
+        gap: var(--space-3);
+        border-radius: var(--radius-sm);
+    }
+    .nav-item-icon {
+        display: inline-flex;
+        flex-shrink: 0;
+    }
+    .nav-dropdown-toggle .nav-dropdown-label { flex: 1; text-align: left; }
+    .nav-dropdown-toggle .nav-dropdown-caret { margin-left: auto; }
+
+    /* Mobile active-pill replaces the desktop underline. */
+    .nav-item[aria-current="page"],
+    .nav-dropdown.is-active-parent > .nav-dropdown-toggle {
+        background: var(--accent-soft);
+        color: #fff;
+        box-shadow: inset 3px 0 0 var(--accent);
+    }
+
+    /* Inlined dropdowns: each section starts collapsed so the menu isn't
+       one giant scroll. Hover is deliberately not a trigger on touch (see
+       the @media (hover: hover) guard above). Desktop hover-bridge padding
+       is neutralised so it doesn't push items apart. */
     .nav-dropdown { width: 100%; padding-bottom: 0; margin-bottom: 0; }
-    .nav-dropdown-toggle { padding: 10px 4px; min-height: 40px; width: 100%; justify-content: flex-start; }
     .nav-dropdown-menu {
         position: static;
-        margin-top: 0;
+        margin: 4px 0 0 32px;
+        padding: 2px 0 2px var(--space-3);
         border: none;
-        padding: 0 0 0 16px;
+        border-left: 1px solid var(--border);
         background: transparent;
         box-shadow: none;
         min-width: 0;
+        opacity: 1;
+        transform: none;
+        transition: none;
     }
-    .nav-dropdown-menu a, .nav-dropdown-menu .nav-dropdown-coming-soon {
-        padding: 8px 4px;
-        min-height: 36px;
+    .nav-dropdown-menu a,
+    .nav-dropdown-menu .nav-dropdown-coming-soon {
+        padding: 10px 8px;
+        min-height: 40px;
         white-space: normal;
+        display: flex;
+        align-items: center;
+        border-radius: var(--radius-sm);
     }
+
+    /* Auth footer pinned to the bottom of the drawer. */
+    .nav-auth {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-2);
+        margin-top: auto;
+        padding-top: var(--space-4);
+        border-top: 1px solid var(--border);
+    }
+    .nav-auth-form { margin: 0; }
+    .nav-auth .btn-discord,
+    .nav-auth .btn-logout {
+        width: 100%;
+        justify-content: center;
+        padding: 12px 20px;
+        font-size: 0.95rem;
+        min-height: var(--tap-min);
+    }
+
+    /* Backdrop. */
+    .nav-backdrop {
+        display: block;
+        position: fixed;
+        inset: 0;
+        background: rgba(10, 10, 20, 0.55);
+        z-index: 40;
+        animation: nav-backdrop-fade-in 0.18s ease-out;
+    }
+    .nav-backdrop[hidden] { display: none; }
+
+    /* Scroll lock while the drawer is open. */
+    body.nav-open { overflow: hidden; }
+}
+
+@keyframes nav-backdrop-fade-in {
+    from { opacity: 0; }
+    to   { opacity: 1; }
+}
+
+/* Honour the user's motion preference. The drawer still opens/closes
+   instantly; only the slide + fade transitions are dropped. */
+@media (prefers-reduced-motion: reduce) {
+    .nav-links,
+    .nav-dropdown-menu,
+    .nav-backdrop,
+    .nav-dropdown-caret { transition: none; animation: none; }
 }

--- a/web/src/main/resources/static/js/home.js
+++ b/web/src/main/resources/static/js/home.js
@@ -1,7 +1,54 @@
+// Mobile nav drawer + dropdown wiring.
+//
+// toggleNav() opens/closes the right-slide drawer on mobile. On desktop the
+// .nav-links container is laid out inline and the drawer chrome (header,
+// backdrop, scroll-lock) is never visible — adding/removing the .open class
+// is harmless because the CSS rules that activate the drawer behaviour are
+// inside @media (max-width: 600px).
+//
+// The function tolerates a minimal DOM (just #nav-menu) so the existing
+// home.test.js fixtures keep working — every secondary element lookup is
+// optional.
+
+let lastFocusedBeforeNav = null;
+
 function toggleNav() {
     const menu = document.getElementById('nav-menu');
     if (!menu) return false;
-    return menu.classList.toggle('open');
+    const willOpen = !menu.classList.contains('open');
+    menu.classList.toggle('open', willOpen);
+
+    const toggle = document.getElementById('nav-toggle')
+        || document.querySelector('.nav-toggle');
+    if (toggle) toggle.setAttribute('aria-expanded', willOpen ? 'true' : 'false');
+
+    const backdrop = document.getElementById('nav-backdrop');
+    if (backdrop) {
+        if (willOpen) backdrop.removeAttribute('hidden');
+        else backdrop.setAttribute('hidden', '');
+    }
+
+    if (document.body && document.body.classList) {
+        document.body.classList.toggle('nav-open', willOpen);
+    }
+
+    if (willOpen) {
+        lastFocusedBeforeNav = document.activeElement;
+        const firstFocusable = menu.querySelector(
+            '.nav-drawer-close, a, button, [tabindex]:not([tabindex="-1"])'
+        );
+        if (firstFocusable && typeof firstFocusable.focus === 'function') {
+            try { firstFocusable.focus(); } catch (_) { /* jsdom focus may throw */ }
+        }
+    } else {
+        closeAllDropdowns();
+        if (lastFocusedBeforeNav && typeof lastFocusedBeforeNav.focus === 'function') {
+            try { lastFocusedBeforeNav.focus(); } catch (_) { /* ignore */ }
+        }
+        lastFocusedBeforeNav = null;
+    }
+
+    return willOpen;
 }
 
 // Click-toggle for navbar dropdowns. Desktop also opens on :hover via CSS;
@@ -29,20 +76,77 @@ function closeAllDropdowns() {
     });
 }
 
+// Mark the link matching the current URL with aria-current="page" and tag
+// the enclosing .nav-dropdown so the parent button picks up the same accent.
+// Longest-prefix wins so /casino/guilds?game=slots matches the Slots entry
+// over the bare /casino path. Pure DOM; CSS does the styling.
+function markActiveNavItem() {
+    const menu = document.getElementById('nav-menu');
+    if (!menu) return;
+    const path = (typeof location !== 'undefined' && location.pathname) || '/';
+    const links = menu.querySelectorAll('.nav-item, .nav-dropdown-menu a');
+    let best = null;
+    let bestLen = -1;
+    links.forEach(function (a) {
+        let href = a.getAttribute('href') || '';
+        // Strip query + hash before comparing — query params (?game=slots)
+        // are intent, not routing.
+        const q = href.indexOf('?');
+        if (q >= 0) href = href.slice(0, q);
+        const h = href.indexOf('#');
+        if (h >= 0) href = href.slice(0, h);
+        if (!href || href === '/') return;
+        const matches = path === href || path.indexOf(href + '/') === 0;
+        if (matches && href.length > bestLen) {
+            best = a;
+            bestLen = href.length;
+        }
+    });
+    if (!best) return;
+    best.setAttribute('aria-current', 'page');
+    const parentDropdown = best.closest('.nav-dropdown');
+    if (parentDropdown) parentDropdown.classList.add('is-active-parent');
+}
+
 if (typeof document !== 'undefined' && document.addEventListener) {
-    // Click outside any dropdown collapses them all. Doesn't interfere with
-    // clicks on dropdown menu items themselves — those navigate to a new
-    // page, which discards the document anyway.
+    // Click outside any dropdown collapses them all. Clicks inside the
+    // drawer container itself still bubble (so the drawer doesn't auto-close
+    // when the user reaches for a dropdown trigger), but outside-drawer
+    // clicks on the backdrop will close the drawer via the backdrop's own
+    // onclick handler.
     document.addEventListener('click', function (e) {
         if (e.target && e.target.closest && e.target.closest('.nav-dropdown')) return;
         closeAllDropdowns();
     });
-    // Esc closes any open dropdown.
+    // Esc closes any open dropdown, then the drawer if it's still open.
     document.addEventListener('keydown', function (e) {
-        if (e.key === 'Escape') closeAllDropdowns();
+        if (e.key !== 'Escape') return;
+        const anyDropdownOpen = document.querySelector('.nav-dropdown.open');
+        if (anyDropdownOpen) {
+            closeAllDropdowns();
+            return;
+        }
+        const menu = document.getElementById('nav-menu');
+        if (menu && menu.classList.contains('open')) toggleNav();
     });
+    document.addEventListener('DOMContentLoaded', markActiveNavItem);
+    // Resizing past the mobile breakpoint while the drawer is open would
+    // leave a fixed-position panel hanging over the desktop layout — close
+    // it pre-emptively. matchMedia is feature-detected for jsdom safety.
+    if (typeof window !== 'undefined' && typeof window.matchMedia === 'function') {
+        try {
+            const mq = window.matchMedia('(min-width: 601px)');
+            const handler = function (ev) {
+                if (!ev.matches) return;
+                const menu = document.getElementById('nav-menu');
+                if (menu && menu.classList.contains('open')) toggleNav();
+            };
+            if (typeof mq.addEventListener === 'function') mq.addEventListener('change', handler);
+            else if (typeof mq.addListener === 'function') mq.addListener(handler);
+        } catch (_) { /* matchMedia unavailable — ignore */ }
+    }
 }
 
 if (typeof module !== 'undefined') {
-    module.exports = { toggleNav, toggleDropdown, closeAllDropdowns };
+    module.exports = { toggleNav, toggleDropdown, closeAllDropdowns, markActiveNavItem };
 }

--- a/web/src/main/resources/templates/fragments/navbar.html
+++ b/web/src/main/resources/templates/fragments/navbar.html
@@ -4,13 +4,35 @@
 <nav th:fragment="navbar">
     <a class="brand" href="/">TobyBot</a>
     <!--
+        Toggle sits BEFORE .nav-links so it doesn't get pushed below the
+        expanded menu on mobile (nav is flex-wrap: wrap; the open drawer
+        used to take width:100% and wrap the toggle onto a new line).
+        On desktop the toggle is hidden via CSS so layout is unchanged.
+        The glyph is swapped CSS-side off [aria-expanded] — JS only flips
+        the attribute and never mutates button text.
+    -->
+    <button class="nav-toggle"
+            id="nav-toggle"
+            aria-controls="nav-menu"
+            aria-expanded="false"
+            aria-label="Toggle navigation"
+            onclick="toggleNav()">
+        <span class="nav-toggle-icon" aria-hidden="true"></span>
+    </button>
+
+    <!--
         Top-level nav grouping: personal anchors first (Profile,
         Leaderboards) → "Play" rolls every game (minigames + tables +
         lottery) into one drop-down so a new admin can find every game
         under one heading → Economy keeps the credit-flow features
         together → Social groups passive identity features (intros)
-        → Tools holds reference / utility pages → Admin
-        anchor sits last so the everyday traffic isn't next to it.
+        → Tools holds reference / utility pages → Admin sits last so
+        the everyday traffic isn't next to it.
+
+        Mobile: .nav-links becomes a fixed-position right drawer with a
+        sticky header + section eyebrows + bottom auth footer. Desktop
+        keeps the flat inline row — eyebrows + drawer chrome are
+        display:none on desktop.
 
         Each minigame entry below carries a `?game=<slug>` so the
         /casino/guilds picker can deep-link past itself when the user
@@ -21,96 +43,137 @@
         are separated by a horizontal divider so the visual grouping
         matches the routing reality.
     -->
-    <div class="nav-links" id="nav-menu">
-        <a href="/profile/guilds">Profile</a>
-        <a href="/leaderboards">Leaderboards</a>
-        <div class="nav-dropdown">
+    <div class="nav-links" id="nav-menu" aria-label="Main navigation">
+        <div class="nav-drawer-header">
+            <span class="nav-drawer-brand">TobyBot</span>
             <button type="button"
-                    class="nav-dropdown-toggle"
-                    aria-haspopup="true"
-                    aria-expanded="false"
-                    onclick="toggleDropdown(this)">Play <span class="nav-dropdown-caret" aria-hidden="true">&#9662;</span></button>
-            <div class="nav-dropdown-menu" role="menu">
-                <a href="/casino/guilds?game=slots" role="menuitem">&#127920; Slots</a>
-                <a href="/casino/guilds?game=coinflip" role="menuitem">&#129689; Coinflip</a>
-                <a href="/casino/guilds?game=dice" role="menuitem">&#127922; Dice</a>
-                <a href="/casino/guilds?game=highlow" role="menuitem">&#127183; High-Low</a>
-                <a href="/casino/guilds?game=scratch" role="menuitem">&#127903;&#65039; Scratch</a>
-                <a href="/casino/guilds?game=keno" role="menuitem">&#127919; Keno</a>
-                <a href="/casino/guilds?game=roulette" role="menuitem">&#127905; Roulette</a>
-                <a href="/casino/guilds?game=baccarat" role="menuitem">&#127924; Baccarat</a>
-                <a href="/casino/guilds?game=casinoholdem" role="menuitem">&#127183; Casino Hold'em</a>
-                <a href="/casino/guilds?game=plinko" role="menuitem">&#128994; Plinko</a>
-                <a href="/casino/guilds?game=horse-racing" role="menuitem">&#128014; Horse Racing</a>
-                <a href="/casino/guilds?game=wheel" role="menuitem">&#127905; Wheel</a>
-                <hr class="nav-dropdown-separator" aria-hidden="true">
-                <a href="/poker/guilds" role="menuitem">&#127924; Poker</a>
-                <a href="/blackjack/guilds" role="menuitem">&#127922; Blackjack</a>
-                <a href="/lottery/guilds" role="menuitem">&#127903;&#65039; Lottery</a>
-            </div>
+                    class="nav-drawer-close"
+                    aria-label="Close menu"
+                    onclick="toggleNav()">&#10005;</button>
         </div>
-        <div class="nav-dropdown">
-            <button type="button"
-                    class="nav-dropdown-toggle"
-                    aria-haspopup="true"
-                    aria-expanded="false"
-                    onclick="toggleDropdown(this)">Economy <span class="nav-dropdown-caret" aria-hidden="true">&#9662;</span></button>
-            <div class="nav-dropdown-menu" role="menu">
-                <a href="/economy/guilds" role="menuitem">Market</a>
-                <a href="/titles/guilds" role="menuitem">Titles</a>
-                <a href="/tip/guilds" role="menuitem">&#128184; Tip</a>
-                <a href="/duel/guilds" role="menuitem">&#9876;&#65039; Duel</a>
-            </div>
-        </div>
-        <div class="nav-dropdown">
-            <button type="button"
-                    class="nav-dropdown-toggle"
-                    aria-haspopup="true"
-                    aria-expanded="false"
-                    onclick="toggleDropdown(this)">Social <span class="nav-dropdown-caret" aria-hidden="true">&#9662;</span></button>
-            <div class="nav-dropdown-menu" role="menu">
-                <a href="/music-player/guilds" role="menuitem">&#127925; Music</a>
-                <a href="/intro/guilds" role="menuitem">Intro Songs</a>
-                <a href="/excuses/guilds" role="menuitem">Excuses</a>
-                <a href="/teams/guilds" role="menuitem">Teams</a>
-            </div>
-        </div>
-        <div class="nav-dropdown">
-            <button type="button"
-                    class="nav-dropdown-toggle"
-                    aria-haspopup="true"
-                    aria-expanded="false"
-                    onclick="toggleDropdown(this)">Tools <span class="nav-dropdown-caret" aria-hidden="true">&#9662;</span></button>
-            <div class="nav-dropdown-menu" role="menu">
-                <a href="/utils" role="menuitem">Utils</a>
-                <a href="/dnd" role="menuitem">D&amp;D lookups</a>
-                <a href="/commands/wiki" role="menuitem">Commands</a>
-            </div>
-        </div>
-        <a href="/moderation/guilds">Admin</a>
-        <span th:if="${username != null}" style="display:flex;align-items:center;gap:12px;">
+
+        <div class="nav-identity" th:if="${username != null}">
+            <div class="nav-identity-name" th:text="${username}">User</div>
             <a th:if="${currentDefaultGuildName != null}"
                href="/preferences"
                class="nav-default-guild"
                th:title="'Default server: ' + ${currentDefaultGuildName} + ' — click to change'">
-                <span aria-hidden="true">★</span>
+                <span aria-hidden="true">&#9733;</span>
                 <span th:text="${currentDefaultGuildName}">Server</span>
             </a>
             <a th:unless="${currentDefaultGuildName != null}"
                href="/preferences"
                class="nav-default-guild nav-default-guild-empty"
                title="Set a default server to skip the guild picker">
-                <span aria-hidden="true">☆</span>
-                <span>Default</span>
+                <span aria-hidden="true">&#9734;</span>
+                <span>Set default server</span>
             </a>
-            <span class="nav-user" th:text="${username}">User</span>
-            <form th:action="@{/logout}" method="post" style="margin:0">
-                <button type="submit" class="btn-logout">Logout</button>
+        </div>
+
+        <div class="nav-section">
+            <div class="nav-section-eyebrow">Main</div>
+            <a class="nav-item" href="/profile/guilds"><span class="nav-item-icon" aria-hidden="true">&#128100;</span><span>Profile</span></a>
+            <a class="nav-item" href="/leaderboards"><span class="nav-item-icon" aria-hidden="true">&#127942;</span><span>Leaderboards</span></a>
+        </div>
+
+        <div class="nav-section">
+            <div class="nav-section-eyebrow">Games</div>
+            <div class="nav-dropdown">
+                <button type="button"
+                        class="nav-dropdown-toggle"
+                        aria-haspopup="true"
+                        aria-expanded="false"
+                        onclick="toggleDropdown(this)"><span class="nav-item-icon" aria-hidden="true">&#127922;</span><span class="nav-dropdown-label">Play</span><span class="nav-dropdown-caret" aria-hidden="true">&#9662;</span></button>
+                <div class="nav-dropdown-menu" role="menu">
+                    <a href="/casino/guilds?game=slots" role="menuitem">&#127920; Slots</a>
+                    <a href="/casino/guilds?game=coinflip" role="menuitem">&#129689; Coinflip</a>
+                    <a href="/casino/guilds?game=dice" role="menuitem">&#127922; Dice</a>
+                    <a href="/casino/guilds?game=highlow" role="menuitem">&#127183; High-Low</a>
+                    <a href="/casino/guilds?game=scratch" role="menuitem">&#127903;&#65039; Scratch</a>
+                    <a href="/casino/guilds?game=keno" role="menuitem">&#127919; Keno</a>
+                    <a href="/casino/guilds?game=roulette" role="menuitem">&#127905; Roulette</a>
+                    <a href="/casino/guilds?game=baccarat" role="menuitem">&#127924; Baccarat</a>
+                    <a href="/casino/guilds?game=casinoholdem" role="menuitem">&#127183; Casino Hold'em</a>
+                    <a href="/casino/guilds?game=plinko" role="menuitem">&#128994; Plinko</a>
+                    <a href="/casino/guilds?game=horse-racing" role="menuitem">&#128014; Horse Racing</a>
+                    <a href="/casino/guilds?game=wheel" role="menuitem">&#127905; Wheel</a>
+                    <hr class="nav-dropdown-separator" aria-hidden="true">
+                    <a href="/poker/guilds" role="menuitem">&#127924; Poker</a>
+                    <a href="/blackjack/guilds" role="menuitem">&#127922; Blackjack</a>
+                    <a href="/lottery/guilds" role="menuitem">&#127903;&#65039; Lottery</a>
+                </div>
+            </div>
+        </div>
+
+        <div class="nav-section">
+            <div class="nav-section-eyebrow">Economy</div>
+            <div class="nav-dropdown">
+                <button type="button"
+                        class="nav-dropdown-toggle"
+                        aria-haspopup="true"
+                        aria-expanded="false"
+                        onclick="toggleDropdown(this)"><span class="nav-item-icon" aria-hidden="true">&#128176;</span><span class="nav-dropdown-label">Economy</span><span class="nav-dropdown-caret" aria-hidden="true">&#9662;</span></button>
+                <div class="nav-dropdown-menu" role="menu">
+                    <a href="/economy/guilds" role="menuitem">Market</a>
+                    <a href="/titles/guilds" role="menuitem">Titles</a>
+                    <a href="/tip/guilds" role="menuitem">&#128184; Tip</a>
+                    <a href="/duel/guilds" role="menuitem">&#9876;&#65039; Duel</a>
+                </div>
+            </div>
+        </div>
+
+        <div class="nav-section">
+            <div class="nav-section-eyebrow">Social</div>
+            <div class="nav-dropdown">
+                <button type="button"
+                        class="nav-dropdown-toggle"
+                        aria-haspopup="true"
+                        aria-expanded="false"
+                        onclick="toggleDropdown(this)"><span class="nav-item-icon" aria-hidden="true">&#127925;</span><span class="nav-dropdown-label">Social</span><span class="nav-dropdown-caret" aria-hidden="true">&#9662;</span></button>
+                <div class="nav-dropdown-menu" role="menu">
+                    <a href="/music-player/guilds" role="menuitem">&#127925; Music</a>
+                    <a href="/intro/guilds" role="menuitem">Intro Songs</a>
+                    <a href="/excuses/guilds" role="menuitem">Excuses</a>
+                    <a href="/teams/guilds" role="menuitem">Teams</a>
+                </div>
+            </div>
+        </div>
+
+        <div class="nav-section">
+            <div class="nav-section-eyebrow">Tools</div>
+            <div class="nav-dropdown">
+                <button type="button"
+                        class="nav-dropdown-toggle"
+                        aria-haspopup="true"
+                        aria-expanded="false"
+                        onclick="toggleDropdown(this)"><span class="nav-item-icon" aria-hidden="true">&#128736;&#65039;</span><span class="nav-dropdown-label">Tools</span><span class="nav-dropdown-caret" aria-hidden="true">&#9662;</span></button>
+                <div class="nav-dropdown-menu" role="menu">
+                    <a href="/utils" role="menuitem">Utils</a>
+                    <a href="/dnd" role="menuitem">D&amp;D lookups</a>
+                    <a href="/commands/wiki" role="menuitem">Commands</a>
+                </div>
+            </div>
+        </div>
+
+        <div class="nav-section">
+            <div class="nav-section-eyebrow">Moderation</div>
+            <a class="nav-item" href="/moderation/guilds"><span class="nav-item-icon" aria-hidden="true">&#128737;&#65039;</span><span>Admin</span></a>
+        </div>
+
+        <div class="nav-auth">
+            <form th:if="${username != null}"
+                  th:action="@{/logout}"
+                  method="post"
+                  class="nav-auth-form">
+                <button type="submit" class="btn-logout">Log out</button>
             </form>
-        </span>
-        <a th:if="${username == null}" href="/oauth2/authorization/discord" class="btn-discord">Login</a>
+            <a th:if="${username == null}"
+               href="/oauth2/authorization/discord"
+               class="btn-discord">Log in with Discord</a>
+        </div>
     </div>
-    <button class="nav-toggle" onclick="toggleNav()" aria-label="Toggle navigation">&#9776;</button>
+
+    <div class="nav-backdrop" id="nav-backdrop" hidden onclick="toggleNav()"></div>
     <script th:src="@{/js/home.js}"></script>
 </nav>
 </body>

--- a/web/src/test/js/home.test.js
+++ b/web/src/test/js/home.test.js
@@ -1,12 +1,13 @@
-const { toggleNav } = require('../../main/resources/static/js/home');
+const { toggleNav, markActiveNavItem } = require('../../main/resources/static/js/home');
 
 // ---------------------------------------------------------------------------
 // toggleNav
 // ---------------------------------------------------------------------------
 
-describe('toggleNav', () => {
+describe('toggleNav (minimal DOM — only #nav-menu)', () => {
     beforeEach(() => {
         document.body.innerHTML = `<div id="nav-menu"></div>`;
+        document.body.className = '';
     });
 
     test('adds "open" class and returns true when menu is closed', () => {
@@ -40,5 +41,87 @@ describe('toggleNav', () => {
         const result = toggleNav();
 
         expect(result).toBe(false);
+    });
+});
+
+describe('toggleNav (drawer DOM — toggle + backdrop + body)', () => {
+    beforeEach(() => {
+        document.body.innerHTML = `
+            <button id="nav-toggle" class="nav-toggle" aria-expanded="false"></button>
+            <div id="nav-menu" class="nav-links"></div>
+            <div id="nav-backdrop" class="nav-backdrop" hidden></div>
+        `;
+        document.body.className = '';
+    });
+
+    test('opens: flips aria-expanded, reveals backdrop, locks body scroll', () => {
+        const result = toggleNav();
+
+        expect(result).toBe(true);
+        expect(document.getElementById('nav-toggle').getAttribute('aria-expanded')).toBe('true');
+        expect(document.getElementById('nav-backdrop').hasAttribute('hidden')).toBe(false);
+        expect(document.body.classList.contains('nav-open')).toBe(true);
+    });
+
+    test('closes: restores aria-expanded, hides backdrop, unlocks body scroll', () => {
+        toggleNav(); // open
+        const result = toggleNav(); // close
+
+        expect(result).toBe(false);
+        expect(document.getElementById('nav-toggle').getAttribute('aria-expanded')).toBe('false');
+        expect(document.getElementById('nav-backdrop').hasAttribute('hidden')).toBe(true);
+        expect(document.body.classList.contains('nav-open')).toBe(false);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// markActiveNavItem
+// ---------------------------------------------------------------------------
+
+describe('markActiveNavItem', () => {
+    beforeEach(() => {
+        document.body.innerHTML = `
+            <div id="nav-menu">
+                <a class="nav-item" href="/profile/guilds">Profile</a>
+                <a class="nav-item" href="/leaderboards">Leaderboards</a>
+                <div class="nav-dropdown">
+                    <button class="nav-dropdown-toggle">Play</button>
+                    <div class="nav-dropdown-menu">
+                        <a href="/casino/guilds?game=slots">Slots</a>
+                        <a href="/poker/guilds">Poker</a>
+                    </div>
+                </div>
+            </div>
+        `;
+    });
+
+    test('marks the matching top-level nav item', () => {
+        history.pushState({}, '', '/leaderboards');
+        markActiveNavItem();
+        const links = document.querySelectorAll('.nav-item');
+        expect(links[0].hasAttribute('aria-current')).toBe(false);
+        expect(links[1].getAttribute('aria-current')).toBe('page');
+    });
+
+    test('marks the matching dropdown item and tags the parent dropdown', () => {
+        history.pushState({}, '', '/casino/guilds');
+        markActiveNavItem();
+        const slots = document.querySelector('a[href="/casino/guilds?game=slots"]');
+        expect(slots.getAttribute('aria-current')).toBe('page');
+        const parent = document.querySelector('.nav-dropdown');
+        expect(parent.classList.contains('is-active-parent')).toBe(true);
+    });
+
+    test('matches a longer path under the link (e.g. /profile/guilds/123 → Profile)', () => {
+        history.pushState({}, '', '/profile/guilds/12345');
+        markActiveNavItem();
+        const profile = document.querySelector('a[href="/profile/guilds"]');
+        expect(profile.getAttribute('aria-current')).toBe('page');
+    });
+
+    test('is a no-op when no link matches', () => {
+        history.pushState({}, '', '/totally-unrelated-page');
+        markActiveNavItem();
+        expect(document.querySelector('[aria-current="page"]')).toBeNull();
     });
 });

--- a/web/src/test/js/navbar.test.js
+++ b/web/src/test/js/navbar.test.js
@@ -14,6 +14,34 @@ const NAVBAR_FRAGMENT = path.resolve(
     '../../main/resources/templates/fragments/navbar.html'
 );
 
+// Extracts the contents of the .nav-links container by walking forward
+// from its opening tag and balancing <div>/</div> pairs. Anchoring on a
+// sibling element (like the old .nav-toggle) is brittle — the toggle now
+// sits BEFORE .nav-links in the DOM. This walker only cares about the
+// .nav-links subtree.
+function extractNavLinksInner(html) {
+    const openTag = '<div class="nav-links"';
+    const start = html.indexOf(openTag);
+    if (start < 0) return null;
+    const contentStart = html.indexOf('>', start) + 1;
+    let depth = 1;
+    let i = contentStart;
+    while (i < html.length && depth > 0) {
+        const nextOpen = html.indexOf('<div', i);
+        const nextClose = html.indexOf('</div>', i);
+        if (nextClose < 0) return null;
+        if (nextOpen >= 0 && nextOpen < nextClose) {
+            depth += 1;
+            i = nextOpen + 4;
+        } else {
+            depth -= 1;
+            if (depth === 0) return html.slice(contentStart, nextClose);
+            i = nextClose + 6;
+        }
+    }
+    return null;
+}
+
 describe('navbar fragment', () => {
     let html;
 
@@ -29,6 +57,16 @@ describe('navbar fragment', () => {
         expect(html).toMatch(
             /<button[^>]*class="[^"]*\bnav-toggle\b[^"]*"[^>]*onclick="toggleNav\(\)"/
         );
+    });
+
+    test('hamburger is exposed to assistive tech (aria-controls, aria-expanded)', () => {
+        // After the redesign the toggle drives a fixed-position drawer; the
+        // attributes let screen readers announce open/closed state and
+        // hop directly to the menu it controls.
+        const toggleMatch = html.match(/<button[^>]*class="[^"]*\bnav-toggle\b[^"]*"[^>]*>/);
+        expect(toggleMatch).not.toBeNull();
+        expect(toggleMatch[0]).toMatch(/aria-controls="nav-menu"/);
+        expect(toggleMatch[0]).toMatch(/aria-expanded="false"/);
     });
 
     test('renders the collapsible menu container with id="nav-menu"', () => {
@@ -50,6 +88,42 @@ describe('navbar fragment', () => {
         expect(fragmentMatch[0]).toMatch(
             /<script[^>]*th:src\s*=\s*"@\{\s*\/js\/home\.js\s*}"/
         );
+    });
+
+    test('renders a backdrop element wired to toggleNav()', () => {
+        // The drawer needs a dim/tap-outside-to-close backdrop on mobile.
+        // It lives outside .nav-links so it's not part of the panel itself.
+        expect(html).toMatch(
+            /<div[^>]*class="[^"]*\bnav-backdrop\b[^"]*"[^>]*id="nav-backdrop"[^>]*onclick="toggleNav\(\)"/
+        );
+    });
+
+    test('renders a drawer header with a close button wired to toggleNav()', () => {
+        expect(html).toMatch(/class="[^"]*\bnav-drawer-header\b/);
+        expect(html).toMatch(
+            /<button[^>]*class="[^"]*\bnav-drawer-close\b[^"]*"[^>]*onclick="toggleNav\(\)"/
+        );
+    });
+
+    test('groups links into labelled sections (Main / Games / Economy / Social / Tools / Moderation)', () => {
+        // Each .nav-section block carries a .nav-section-eyebrow with the
+        // section name; on desktop those eyebrows are display:none, on
+        // mobile they group the items inside the drawer.
+        const expected = ['Main', 'Games', 'Economy', 'Social', 'Tools', 'Moderation'];
+        for (const label of expected) {
+            const re = new RegExp(
+                `<div[^>]*class="[^"]*\\bnav-section-eyebrow\\b[^"]*"[^>]*>\\s*${label}\\s*</div>`
+            );
+            expect(html).toMatch(re);
+        }
+    });
+
+    test('exposes an auth footer with either Login or Logout', () => {
+        expect(html).toMatch(/class="[^"]*\bnav-auth\b/);
+        // Login link (signed-out) and Logout form (signed-in) both live in
+        // the auth footer.
+        expect(html).toMatch(/href="\/oauth2\/authorization\/discord"[^>]*class="[^"]*\bbtn-discord\b/);
+        expect(html).toMatch(/<button[^>]*type="submit"[^>]*class="[^"]*\bbtn-logout\b[^"]*"/);
     });
 
     // PR 2 (navbar dropdowns): Economy folds Market + Titles; Casino is
@@ -92,14 +166,11 @@ describe('navbar fragment', () => {
     test('Market and Titles are no longer top-level nav-links siblings', () => {
         // Regression: if someone re-introduces them at the top level the
         // navbar grows by two items and the dropdown becomes redundant.
-        const navLinks = html.match(
-            /<div class="nav-links" id="nav-menu">([\s\S]*?)<button class="nav-toggle"/
-        );
-        expect(navLinks).not.toBeNull();
-        const topLevel = navLinks[1];
+        const inner = extractNavLinksInner(html);
+        expect(inner).not.toBeNull();
         // Market / Titles links exist (inside dropdowns) but not as direct
         // children of nav-links — strip out the dropdown subtrees first.
-        const stripped = topLevel.replace(/<div class="nav-dropdown">[\s\S]*?<\/div>\s*<\/div>/g, '');
+        const stripped = inner.replace(/<div class="nav-dropdown">[\s\S]*?<\/div>\s*<\/div>/g, '');
         expect(stripped).not.toMatch(/href="\/economy\/guilds"/);
         expect(stripped).not.toMatch(/href="\/titles\/guilds"/);
     });


### PR DESCRIPTION
## Summary

The mobile navbar was broken (screenshot below): the hamburger ended up *below* the open menu because `.nav-toggle` sat after `.nav-links` in the DOM with `flex-wrap: wrap`. The drawer felt detached from the page (no backdrop, no scroll lock, no close affordance) and every link looked identical with no grouping or active-page indication.

**Mobile redesign:**
- Hamburger moved before `.nav-links` so it can no longer wrap below the open menu.
- `.nav-links` becomes a fixed-position right drawer that slides in (`transform: translateX`) over a dim backdrop.
- Sticky drawer header with brand + close `✕`.
- Identity card at the top of the drawer (signed-in only) — username + default-guild pill stretched to full width.
- Eyebrow-labelled sections: **Main / Games / Economy / Social / Tools / Moderation** — each link gets a unicode icon for fast visual scanning.
- Auth footer pinned to the bottom — Login / Logout becomes a proper full-width primary CTA instead of the tiny lonely square it was before.
- Body scroll locks while the drawer is open; Esc, backdrop tap, and the close button all close it. Focus moves into the drawer on open and restores on close. Drawer auto-closes if the viewport grows past `--bp-mobile`.
- Active link gets `aria-current="page"` + a left-rail accent; parent dropdown also picks up the accent.

**Desktop polish:**
- Hard-coded hex values replaced with `base.css` design tokens.
- Dropdown menus fade + slide in (120ms).
- Current page gets a subtle accent underline (`box-shadow: inset 0 -2px 0 var(--accent)`); no layout shift.
- Hover state on top-level items unified (`background: var(--accent-soft)`).

**A11y:**
- Hamburger now carries `aria-controls="nav-menu"` and a synced `aria-expanded`.
- Drawer marked `aria-label="Main navigation"`.
- Reduced-motion users get the open/close instantly (no slide/fade).

**JS (`home.js`):**
- `toggleNav()` extended to sync `aria-expanded`, toggle `[hidden]` on the backdrop, lock body scroll (`body.nav-open`), and manage focus.
- Existing Esc + click-outside listeners extended (no duplication).
- New `markActiveNavItem()` runs on `DOMContentLoaded`; pure DOM, no controller change.
- New `matchMedia` listener closes the drawer if the viewport grows past 600px.
- All extras are conditional on the elements existing, so the minimal `<div id="nav-menu">` test fixtures still work.

**Tests:**
- `navbar.test.js` — the `.nav-toggle`-anchored regex (which required the toggle to sit *after* `.nav-links`) is replaced with a balanced-tag walker over `.nav-links`. New tests cover the aria wiring, drawer chrome, section eyebrows, and auth footer. Existing assertions on dropdown structure preserved.
- `home.test.js` — new drawer-state assertions (`aria-expanded`, backdrop `[hidden]`, `body.nav-open`) and full `markActiveNavItem()` coverage. Original minimal-DOM assertions preserved.
- All 547 jest tests pass; stylelint clean.

## Test plan

- [x] `cd web && npx jest` — 547/547 pass
- [x] `cd web && npm run lint:css` — clean
- [ ] Manual mobile check at 375×812 + 360×640: hamburger top-right, drawer slides in from right, backdrop fades, scroll locks, close via ✕/backdrop/Esc, sections labelled, icons render, Login button full-width
- [ ] Manual desktop check ≥ 768px: flat row, no eyebrows visible, dropdowns fade in, active-page underline appears on current route
- [ ] Spot-check on `/`, `/profile/guilds`, `/leaderboards`, `/casino/guilds?game=slots`, `/moderation/guilds`, `/preferences` to confirm active highlight tracks the right item

https://claude.ai/code/session_018sfoNnBcHMJcAmzQPrg1aR

---
_Generated by [Claude Code](https://claude.ai/code/session_018sfoNnBcHMJcAmzQPrg1aR)_