### PR TITLE
fix(web): restore desktop navbar identity/auth + dedupe drawer close ✕

### DIFF
--- a/web/src/main/kotlin/web/configuration/WebSecurityConfig.kt
+++ b/web/src/main/kotlin/web/configuration/WebSecurityConfig.kt
@@ -35,7 +35,7 @@ class WebSecurityConfig {
             .oauth2Login { oauth2 ->
                 oauth2
                     .loginPage("/login")
-                    .defaultSuccessUrl("/intro/guilds", false)
+                    .defaultSuccessUrl("/", false)
                     .failureUrl("/login?error=true")
             }
             .logout { logout ->

--- a/web/src/main/resources/static/css/nav.css
+++ b/web/src/main/resources/static/css/nav.css
@@ -44,11 +44,36 @@ nav {
     display: contents;
 }
 .nav-links > .nav-section > .nav-section-eyebrow,
-.nav-drawer-header,
-.nav-identity,
-.nav-auth {
+.nav-drawer-header {
     display: none;
 }
+
+/* Identity (default-guild pill + username) and auth (Login / Logout)
+   live inline on desktop and restyle into card + footer inside the
+   drawer via the @media (max-width: 600px) block below. */
+.nav-identity {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-3);
+    background: transparent;
+    border: none;
+    padding: 0;
+    border-radius: 0;
+}
+.nav-identity-name {
+    font-weight: 500;
+    color: var(--text-muted);
+    font-size: 0.9rem;
+}
+.nav-auth {
+    display: inline-flex;
+    align-items: center;
+    margin: 0;
+    padding: 0;
+    border: none;
+    gap: 0;
+}
+.nav-auth-form { margin: 0; }
 .nav-item {
     display: inline-flex;
     align-items: center;
@@ -150,12 +175,6 @@ nav {
     line-height: 1;
 }
 .nav-drawer-close:hover { border-color: var(--accent); color: #fff; }
-
-.nav-identity-name {
-    font-weight: 600;
-    color: #fff;
-    font-size: 0.95rem;
-}
 
 .nav-backdrop { display: none; }
 
@@ -286,6 +305,10 @@ nav {
         position: relative;
         z-index: 60;
     }
+    /* Once the drawer is open, the drawer's own sticky-header ✕ is the
+       single dismissal affordance — hide the hamburger so it doesn't
+       render a second overlapping ✕ glyph on top of the drawer. */
+    body.nav-open .nav-toggle { display: none; }
 
     /* The drawer itself. Slides in from the right. */
     .nav-links {
@@ -341,6 +364,11 @@ nav {
         background: var(--bg);
         border: 1px solid var(--border);
         border-radius: var(--radius-md);
+    }
+    .nav-identity-name {
+        font-weight: 600;
+        color: #fff;
+        font-size: 0.95rem;
     }
     .nav-identity .nav-default-guild {
         max-width: 100%;

--- a/web/src/test/js/navbar.test.js
+++ b/web/src/test/js/navbar.test.js
@@ -13,6 +13,33 @@ const NAVBAR_FRAGMENT = path.resolve(
     __dirname,
     '../../main/resources/templates/fragments/navbar.html'
 );
+const NAV_CSS = path.resolve(
+    __dirname,
+    '../../main/resources/static/css/nav.css'
+);
+
+// Extracts a CSS rule body (everything between `selector {` and the
+// matching closing brace) so we can assert on the declarations without
+// being brittle about whitespace or sibling rule order. Returns null if
+// the selector isn't found.
+function extractRuleBody(css, selectorPrefix) {
+    const start = css.indexOf(selectorPrefix);
+    if (start < 0) return null;
+    const braceOpen = css.indexOf('{', start);
+    if (braceOpen < 0) return null;
+    let depth = 1;
+    let i = braceOpen + 1;
+    while (i < css.length && depth > 0) {
+        const ch = css[i];
+        if (ch === '{') depth += 1;
+        else if (ch === '}') {
+            depth -= 1;
+            if (depth === 0) return css.slice(braceOpen + 1, i);
+        }
+        i += 1;
+    }
+    return null;
+}
 
 // Extracts the contents of the .nav-links container by walking forward
 // from its opening tag and balancing <div>/</div> pairs. Anchoring on a
@@ -173,5 +200,91 @@ describe('navbar fragment', () => {
         const stripped = inner.replace(/<div class="nav-dropdown">[\s\S]*?<\/div>\s*<\/div>/g, '');
         expect(stripped).not.toMatch(/href="\/economy\/guilds"/);
         expect(stripped).not.toMatch(/href="\/titles\/guilds"/);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// CSS regression tests
+//
+// The follow-up fix in this PR restored desktop visibility of the Login
+// button + default-guild pill, and de-duplicated the close-✕ glyph that
+// rendered on top of the hamburger when the mobile drawer was open. These
+// tests pin those contracts so a future restyle can't silently revert
+// either regression.
+// ---------------------------------------------------------------------------
+
+describe('nav.css desktop visibility', () => {
+    let css;
+
+    beforeAll(() => {
+        css = fs.readFileSync(NAV_CSS, 'utf8');
+    });
+
+    test('.nav-identity is not display:none at top level', () => {
+        // Locate the top-level .nav-identity rule body and assert it's
+        // not hidden. The mobile drawer rule lives inside @media and is
+        // a different rule body.
+        const body = extractRuleBody(css, '\n.nav-identity {');
+        expect(body).not.toBeNull();
+        expect(body).not.toMatch(/display:\s*none/);
+    });
+
+    test('.nav-auth is not display:none at top level', () => {
+        const body = extractRuleBody(css, '\n.nav-auth {');
+        expect(body).not.toBeNull();
+        expect(body).not.toMatch(/display:\s*none/);
+    });
+
+    test('.nav-identity and .nav-auth are not bundled into the desktop hide list', () => {
+        // The original regression was a single rule like
+        //   .nav-drawer-header, .nav-identity, .nav-auth { display: none; }
+        // that hid all three on desktop. Catch it by name — the drawer
+        // header is allowed (mobile-only), the other two must not appear.
+        const hideListPattern = /\.nav-drawer-header[\s\S]{0,200}?display:\s*none/;
+        const hideListMatch = css.match(hideListPattern);
+        if (hideListMatch) {
+            expect(hideListMatch[0]).not.toMatch(/\.nav-identity\b/);
+            expect(hideListMatch[0]).not.toMatch(/\.nav-auth\b/);
+        }
+    });
+
+    test('drawer-only chrome (.nav-drawer-header) stays hidden on desktop', () => {
+        // Companion to the rule above: the drawer header *should* be
+        // hidden on desktop. Asserts the dedupe didn't accidentally
+        // unhide it.
+        expect(css).toMatch(/\.nav-drawer-header[\s\S]{0,80}?display:\s*none/);
+    });
+});
+
+describe('nav.css mobile drawer-close dedupe', () => {
+    let css;
+
+    beforeAll(() => {
+        css = fs.readFileSync(NAV_CSS, 'utf8');
+    });
+
+    test('hides the hamburger while the drawer is open', () => {
+        // Without this rule the hamburger swaps glyph to ✕ via
+        // [aria-expanded="true"] and stacks visually on top of the
+        // drawer's own sticky-header close button — two ✕ marks
+        // overlapping. The drawer's ✕ is the canonical dismissal
+        // affordance once open.
+        expect(css).toMatch(
+            /body\.nav-open\s+\.nav-toggle\s*\{\s*display:\s*none\s*;?\s*\}/
+        );
+    });
+
+    test('hamburger remains visible by default (no global hide)', () => {
+        // Defensive check: the hide rule must be scoped to body.nav-open,
+        // not applied unconditionally. A naked `.nav-toggle { display: none }`
+        // would leave the closed-state navbar with no way to open the menu.
+        const mobileBlockStart = css.indexOf('@media (max-width: 600px)');
+        expect(mobileBlockStart).toBeGreaterThan(-1);
+        const mobileBlock = css.slice(mobileBlockStart);
+        // The mobile rule for .nav-toggle should set display: inline-flex
+        // (or block / flex) — anything but `none`.
+        expect(mobileBlock).toMatch(
+            /\n\s*\.nav-toggle\s*\{[^}]*display:\s*(?:inline-flex|flex|block|inline-block)/
+        );
     });
 });

--- a/web/src/test/kotlin/web/configuration/WebSecurityConfigOAuthRedirectTest.kt
+++ b/web/src/test/kotlin/web/configuration/WebSecurityConfigOAuthRedirectTest.kt
@@ -1,0 +1,64 @@
+package web.configuration
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.io.File
+
+/**
+ * The post-OAuth landing URL is configured via `defaultSuccessUrl(...)`
+ * inside [WebSecurityConfig]. Before this fix the value was
+ * `/intro/guilds`, which meant tapping the navbar's "Log in with Discord"
+ * button from any non-protected page (homepage, leaderboard, casino
+ * picker) always dumped the user on the Intro Songs guild picker.
+ *
+ * The contract: the default success URL is `/` (homepage). Spring's
+ * saved-request behaviour still works because the second argument to
+ * `defaultSuccessUrl` stays `false` — a user bounced to login from a
+ * protected page still lands back on the protected page after OAuth.
+ *
+ * Source-text assertion (no @SpringBootTest) matches the existing
+ * pattern under `web/src/test/kotlin/web/static/` (the
+ * `CssRegressionTest` files) — cheap, fast, and catches the exact
+ * mistake that regressed.
+ */
+internal class WebSecurityConfigOAuthRedirectTest {
+
+    private val source: String by lazy {
+        File("src/main/kotlin/web/configuration/WebSecurityConfig.kt")
+            .takeIf { it.exists() }
+            ?.readText()
+            ?: error("WebSecurityConfig.kt not found relative to web module root")
+    }
+
+    @Test
+    fun `post-OAuth default landing URL is the homepage`() {
+        val expected = ".defaultSuccessUrl(\"/\", false)"
+        assertTrue(
+            source.replace(" ", "").contains(expected.replace(" ", "")),
+            "WebSecurityConfig.kt must set $expected so users who tap Login from any non-protected page land on the homepage."
+        )
+    }
+
+    @Test
+    fun `post-OAuth default landing URL is no longer the intro picker`() {
+        assertFalse(
+            source.contains("\"/intro/guilds\""),
+            "WebSecurityConfig.kt must not hard-code the intro guild picker as the default landing — that was the surprising behaviour the navbar redesign was reporting."
+        )
+    }
+
+    @Test
+    fun `saved-request behaviour stays enabled (alwaysUseDefaultUrl=false)`() {
+        // The `false` flag preserves Spring's saved-request handling: a
+        // user bounced to login from a protected page lands back there
+        // after OAuth instead of the default URL. If someone flips it to
+        // true the user always gets dumped on the default URL — the
+        // regression this test catches.
+        val flipped = ".defaultSuccessUrl(\"/\", true)"
+        assertFalse(
+            source.replace(" ", "").contains(flipped.replace(" ", "")),
+            "WebSecurityConfig.kt must keep alwaysUseDefaultUrl=false so saved-request redirects work."
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Three follow-ups to the navbar redesign in #488 (now on `main`):

**1. Desktop regression — Login + default-guild pill were invisible.**
The redesign moved Login into `.nav-auth` and the username + default-guild pill into `.nav-identity`, then set both to `display: none` on desktop. Result: logged-out users couldn't see the Login button; logged-in users couldn't see their default-server pill or Logout button on desktop.

Removed both from the desktop hide-list and gave them inline default styling. The mobile drawer card/footer styling still wins inside the `@media (max-width: 600px)` block.

**2. Mobile drawer rendered two ✕ glyphs on top of each other.**
When the drawer opens, the hamburger swaps to ✕ via `aria-expanded` (z-index 60) — and the drawer also has its own sticky-header close button ✕ (inside the drawer at z-index 50). Both glyphs occupied roughly the same screen space in the top-right corner.

Hide the hamburger when `body.nav-open` is set. The drawer's own ✕ becomes the single visual close affordance; Esc and backdrop-tap still close as before. The hamburger reappears as ☰ once the drawer closes.

**3. Post-OAuth landing page hard-coded to `/intro/guilds`.**
`WebSecurityConfig.kt:38` had `.defaultSuccessUrl("/intro/guilds", false)`, so anyone clicking the Login button from any non-protected page landed on the Intro Songs guild picker — surprising behaviour now that Login is a more prominent navbar CTA.

Changed the default URL to `/` (homepage). The `alwaysUseDefaultUrl=false` flag is preserved, so Spring's saved-request behaviour still works: a user bounced to login from a protected page (e.g. `/profile/guilds`) still lands back there after OAuth.

## Test plan

- [x] `cd web && npx jest` — 547/547 pass
- [x] `cd web && npm run lint:css` — clean
- [ ] Desktop ≥ 768px logged-out: Login button visible at right of nav, click → Discord OAuth → returns to `/`
- [ ] Desktop ≥ 768px logged-in: ★ default-server pill + username + Logout visible at right of nav
- [ ] Mobile ≤ 600px: tap ☰ → drawer slides in, hamburger disappears, only the drawer's ✕ visible; tap ✕ → drawer closes, ☰ returns
- [ ] OAuth saved-request: visit `/profile/guilds` logged out → bounced to `/login` → Discord OAuth → returns to `/profile/guilds`

Refs #488.

https://claude.ai/code/session_018sfoNnBcHMJcAmzQPrg1aR

---
_Generated by [Claude Code](https://claude.ai/code/session_018sfoNnBcHMJcAmzQPrg1aR)_