### PR TITLE
refactor(notify): centralise channel routing through NotificationRouter

### DIFF
--- a/common/src/main/kotlin/common/notification/ChannelRouteKey.kt
+++ b/common/src/main/kotlin/common/notification/ChannelRouteKey.kt
@@ -1,0 +1,61 @@
+package common.notification
+
+/**
+ * Per-kind channel-routing policy used by `NotificationRouter.sendChannel`.
+ * Each entry declares which per-guild config key holds the channel id
+ * (and any fallbacks) so admins control channel visibility by setting
+ * (or clearing) a single config row — not by editing code.
+ *
+ * Config-key names are stored as plain strings here so this enum stays
+ * in `common` and doesn't pull `database.dto.ConfigDto` into the
+ * downstream dependency graph. The
+ * `ChannelRouteKeyConfigKeyContractTest` (in `:database`) asserts every
+ * string resolves to a real `ConfigDto.Configurations` value at compile
+ * time of the test, so a typo here fails CI.
+ *
+ * Resolution order applied by the router for any given route:
+ *   1. `primaryConfigKey` (if set and resolvable to a writable channel)
+ *   2. each `fallbackConfigKeys` in declaration order
+ *   3. `originChannelId` (the per-call hint, e.g. "the channel that
+ *      earned the XP" for level-up announcements)
+ *   4. `guild.systemChannel` (only when [systemChannelFallback] is true)
+ *
+ * Channel routing does NOT consult `UserNotificationPrefService`. Admins
+ * disable a channel post by clearing the configured channel id; user
+ * opt-ins govern DM dispatch only.
+ */
+enum class ChannelRouteKey(
+    val primaryConfigKey: String?,
+    val fallbackConfigKeys: List<String> = emptyList(),
+    val systemChannelFallback: Boolean = true,
+) {
+    /** Level-up announcement. Falls back to the XP-earning channel, then system. */
+    LEVEL_UP(primaryConfigKey = "LEVEL_UP_CHANNEL"),
+
+    /**
+     * Daily lottery announcement. Reuses the configured leaderboard
+     * channel if no dedicated lottery channel is set — most guilds wire
+     * one announce channel and expect both to land there.
+     */
+    LOTTERY(
+        primaryConfigKey = "LOTTERY_CHANNEL",
+        fallbackConfigKeys = listOf("LEADERBOARD_CHANNEL"),
+    ),
+
+    /**
+     * Optional public shoutout when a user unlocks an achievement.
+     * No system-channel fallback: admins explicitly opt in by setting
+     * the channel; if unset, unlocks stay DM-only.
+     */
+    ACHIEVEMENT_SHOUTOUT(
+        primaryConfigKey = "ACHIEVEMENT_ANNOUNCE_CHANNEL",
+        systemChannelFallback = false,
+    ),
+
+    /**
+     * Direct-to-system-channel routing used by web-initiated flows
+     * (tip notifications, duel offers) that have no per-event channel
+     * context to fall back to.
+     */
+    SYSTEM(primaryConfigKey = null),
+}

--- a/database/src/test/kotlin/database/notification/ChannelRouteKeyConfigKeyContractTest.kt
+++ b/database/src/test/kotlin/database/notification/ChannelRouteKeyConfigKeyContractTest.kt
@@ -1,0 +1,45 @@
+package database.notification
+
+import common.notification.ChannelRouteKey
+import database.dto.ConfigDto
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Test
+
+/**
+ * `ChannelRouteKey` lives in `:common` and carries its config-key
+ * references as plain strings (so the enum doesn't pull `database.dto`
+ * into the dependency graph). This test runs in `:database` — where
+ * `ConfigDto.Configurations` is on the classpath — and asserts every
+ * string the enum declares resolves to a real `Configurations` enum
+ * value. A typo there would otherwise only surface as silent "no
+ * channel resolved" at runtime; this guard makes it a CI failure.
+ */
+class ChannelRouteKeyConfigKeyContractTest {
+
+    @Test
+    fun `every primaryConfigKey on ChannelRouteKey resolves to a real Configurations enum value`() {
+        ChannelRouteKey.entries.forEach { route ->
+            val key = route.primaryConfigKey ?: return@forEach
+            val resolved = runCatching { ConfigDto.Configurations.valueOf(key) }.getOrNull()
+            assertNotNull(
+                resolved,
+                "ChannelRouteKey.${route.name}.primaryConfigKey='$key' does not match any " +
+                    "ConfigDto.Configurations entry. Did you typo the config-key string?",
+            )
+        }
+    }
+
+    @Test
+    fun `every fallbackConfigKeys entry resolves to a real Configurations enum value`() {
+        ChannelRouteKey.entries.forEach { route ->
+            route.fallbackConfigKeys.forEach { key ->
+                val resolved = runCatching { ConfigDto.Configurations.valueOf(key) }.getOrNull()
+                assertNotNull(
+                    resolved,
+                    "ChannelRouteKey.${route.name} fallback '$key' does not match any " +
+                        "ConfigDto.Configurations entry.",
+                )
+            }
+        }
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/handler/AchievementEventHandler.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/handler/AchievementEventHandler.kt
@@ -9,17 +9,11 @@ import common.events.LotteryWonEvent
 import common.events.StreakClaimedEvent
 import common.events.TipSentEvent
 import common.events.VoiceSessionLoggedEvent
-import common.logging.DiscordLogger
+import common.notification.ChannelRouteKey
 import common.notification.NotificationChannelKind
-import database.dto.ConfigDto.Configurations.ACHIEVEMENT_ANNOUNCE_CHANNEL
 import database.service.AchievementService
-import database.service.ConfigService
 import net.dv8tion.jda.api.EmbedBuilder
-import net.dv8tion.jda.api.JDA
-import net.dv8tion.jda.api.Permission
-import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
 import net.dv8tion.jda.api.utils.messages.MessageCreateBuilder
-import org.springframework.context.annotation.Lazy
 import org.springframework.context.event.EventListener
 import org.springframework.stereotype.Component
 import java.awt.Color
@@ -40,12 +34,9 @@ import java.awt.Color
  */
 @Component
 class AchievementEventHandler(
-    @Lazy private val jda: JDA,
     private val achievementService: AchievementService,
-    private val configService: ConfigService,
-    private val notificationRouter: NotificationRouter
+    private val notificationRouter: NotificationRouter,
 ) {
-    private val logger = DiscordLogger.createLogger(this::class.java)
 
     @EventListener
     fun onStreakClaimed(event: StreakClaimedEvent) {
@@ -171,26 +162,19 @@ class AchievementEventHandler(
     }
 
     private fun postPublicShoutout(event: AchievementUnlockedEvent) {
-        val guild = jda.getGuildById(event.guildId) ?: return
-        val configured = configService
-            .getConfigByName(ACHIEVEMENT_ANNOUNCE_CHANNEL.configValue, guild.id)?.value
-            ?.toLongOrNull()
-            ?: return
-        val channel: TextChannel = guild.getTextChannelById(configured) ?: return
-        if (!guild.selfMember.hasPermission(channel, Permission.MESSAGE_SEND, Permission.MESSAGE_EMBED_LINKS)) return
-
-        val embed = EmbedBuilder()
-            .setTitle("${event.icon ?: "🏅"} Achievement unlocked")
-            .setDescription("<@${event.discordId}> unlocked **${event.name}** — ${event.description}")
-            .setColor(Color(0xFFC857))
-            .build()
-        runCatching {
-            channel.sendMessageEmbeds(embed).queue(null) { err ->
-                logger.warn("Failed to post achievement shoutout in #${channel.name}: ${err.message}")
-            }
-        }.onFailure {
-            logger.warn("Achievement shoutout dispatch failed: ${it.message}")
-        }
+        notificationRouter.sendChannel(
+            guildId = event.guildId,
+            route = ChannelRouteKey.ACHIEVEMENT_SHOUTOUT,
+            message = {
+                MessageCreateBuilder().setEmbeds(
+                    EmbedBuilder()
+                        .setTitle("${event.icon ?: "🏅"} Achievement unlocked")
+                        .setDescription("<@${event.discordId}> unlocked **${event.name}** — ${event.description}")
+                        .setColor(Color(0xFFC857))
+                        .build()
+                ).build()
+            },
+        )
     }
 
     companion object {

--- a/discord-bot/src/main/kotlin/bot/toby/helpers/IntroHelper.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/helpers/IntroHelper.kt
@@ -13,6 +13,7 @@ import database.dto.MusicDto
 import database.dto.MusicDto.Companion.computeHash
 import database.service.ConfigService
 import database.service.MusicFileService
+import database.service.UserNotificationPrefService
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -37,10 +38,14 @@ class IntroHelper(
     private val httpHelper: HttpHelper,
     private val eventWaiter: EventWaiter,
     private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
+    // Nullable + default null so legacy positional test constructors keep
+    // compiling. Spring autowires the real bean in production.
+    private val notificationPrefService: UserNotificationPrefService? = null,
     private val validationService: IntroValidationService = IntroValidationService(httpHelper, dispatcher),
     private val mediaLoader: IntroMediaLoader = IntroMediaLoader(),
     private val notificationService: IntroNotificationService = IntroNotificationService(
-        userDtoHelper, musicFileService, httpHelper, eventWaiter, validationService, mediaLoader, dispatcher,
+        userDtoHelper, musicFileService, httpHelper, eventWaiter, validationService, mediaLoader,
+        notificationPrefService, dispatcher,
     ),
 ) {
     private val logger: DiscordLogger = DiscordLogger.createLogger(this::class.java)

--- a/discord-bot/src/main/kotlin/bot/toby/intro/IntroNotificationService.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/intro/IntroNotificationService.kt
@@ -5,9 +5,11 @@ import bot.toby.helpers.HttpHelper
 import bot.toby.helpers.InputData
 import bot.toby.util.isUrl
 import common.logging.DiscordLogger
+import common.notification.NotificationChannelKind
 import core.command.Command.Companion.invokeDeleteOnMessageResponse
 import database.dto.MusicDto
 import database.service.MusicFileService
+import database.service.UserNotificationPrefService
 import bot.toby.helpers.UserDtoHelper
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
@@ -38,6 +40,11 @@ class IntroNotificationService(
     private val eventWaiter: EventWaiter,
     private val validationService: IntroValidationService,
     private val mediaLoader: IntroMediaLoader,
+    // Nullable + default null so legacy callers / unit tests that
+    // construct this service manually keep compiling. Null = no gate
+    // (matches pre-refactor behaviour). Spring autowires the real bean
+    // in production via IntroHelper's chained construction.
+    private val notificationPrefService: UserNotificationPrefService? = null,
     private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) {
     private val logger: DiscordLogger = DiscordLogger.createLogger(this::class.java)
@@ -46,6 +53,18 @@ class IntroNotificationService(
 
     fun promptUserForMusicInfo(user: User, guild: Guild) {
         logger.setGuildAndUserContext(guild, user)
+        // Honour the per-user INTRO_PROMPT opt-out. Default is opt-in so
+        // existing servers keep nudging new members; users who don't want
+        // intro prompts run `/notify set INTRO_PROMPT off` and we silently
+        // skip the DM (no waiter is set up either). Pref service is
+        // nullable for legacy/test callers — null means "no gate".
+        val gateActive = notificationPrefService
+            ?.isOptedIn(user.idLong, guild.idLong, NotificationChannelKind.INTRO_PROMPT)
+            ?: true
+        if (!gateActive) {
+            logger.info { "User opted out of INTRO_PROMPT; skipping prompt for guild '${guild.name}'." }
+            return
+        }
         logger.info { "Prompting user to set an intro for the server that they don't have one on" }
         user.openPrivateChannel().queue { channel ->
             channel.sendMessage(

--- a/discord-bot/src/main/kotlin/bot/toby/leveling/LevelUpListener.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/leveling/LevelUpListener.kt
@@ -1,11 +1,11 @@
 package bot.toby.leveling
 
+import bot.toby.notify.NotificationRouter
 import common.events.LevelUpEvent
 import common.leveling.LevelCurve
 import common.logging.DiscordLogger
-import database.dto.ConfigDto.Configurations.LEVEL_UP_CHANNEL
+import common.notification.ChannelRouteKey
 import database.dto.TitleDto
-import database.service.ConfigService
 import database.service.LevelRoleRewardService
 import database.service.TitleService
 import net.dv8tion.jda.api.EmbedBuilder
@@ -15,7 +15,7 @@ import net.dv8tion.jda.api.entities.Member
 import net.dv8tion.jda.api.entities.MessageEmbed
 import net.dv8tion.jda.api.entities.Role
 import net.dv8tion.jda.api.entities.UserSnowflake
-import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
+import net.dv8tion.jda.api.utils.messages.MessageCreateBuilder
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Lazy
 import org.springframework.context.event.EventListener
@@ -37,9 +37,9 @@ import java.awt.Color
 @Service
 class LevelUpListener @Autowired constructor(
     @Lazy private val jda: JDA,
-    private val configService: ConfigService,
     private val levelRoleRewardService: LevelRoleRewardService,
-    private val titleService: TitleService
+    private val titleService: TitleService,
+    private val notificationRouter: NotificationRouter,
 ) {
     private val logger: DiscordLogger = DiscordLogger.createLogger(this::class.java)
 
@@ -59,19 +59,15 @@ class LevelUpListener @Autowired constructor(
     }
 
     private fun announce(guild: Guild, event: LevelUpEvent) {
-        val channel = resolveAnnouncementChannel(guild, event.channelId) ?: run {
-            logger.info { "No announcement channel resolved for guild ${guild.idLong}; skipping level-up message." }
-            return
-        }
         val member = runCatching { guild.getMemberById(event.discordId) }.getOrNull()
-        val embed = buildLevelUpEmbed(event, member)
-        runCatching {
-            channel.sendMessageEmbeds(embed).queue(null) { err ->
-                logger.warn("Failed to post level-up announcement in #${channel.name}: ${err.message}")
-            }
-        }.onFailure {
-            logger.warn("Level-up announcement dispatch failed: ${it.message}")
-        }
+        notificationRouter.sendChannel(
+            guildId = guild.idLong,
+            route = ChannelRouteKey.LEVEL_UP,
+            originChannelId = event.channelId,
+            message = {
+                MessageCreateBuilder().setEmbeds(buildLevelUpEmbed(event, member)).build()
+            },
+        )
     }
 
     private fun buildLevelUpEmbed(event: LevelUpEvent, member: Member?): MessageEmbed {
@@ -127,15 +123,6 @@ class LevelUpListener @Autowired constructor(
     }
 
     private fun formatXp(value: Long): String = String.format("%,d", value)
-
-    private fun resolveAnnouncementChannel(guild: Guild, originId: Long?): TextChannel? {
-        val configured = configService
-            .getConfigByName(LEVEL_UP_CHANNEL.configValue, guild.id)?.value
-            ?.toLongOrNull()
-        configured?.let { id -> guild.getTextChannelById(id)?.let { return it } }
-        originId?.let { id -> guild.getTextChannelById(id)?.let { return it } }
-        return guild.systemChannel
-    }
 
     private fun assignRoleRewards(guild: Guild, event: LevelUpEvent) {
         val rewards = levelRoleRewardService.listInRange(

--- a/discord-bot/src/main/kotlin/bot/toby/notify/NotificationRouter.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/notify/NotificationRouter.kt
@@ -1,30 +1,40 @@
 package bot.toby.notify
 
 import common.logging.DiscordLogger
+import common.notification.ChannelRouteKey
 import common.notification.NotificationChannelKind
+import database.service.ConfigService
 import database.service.UserNotificationPrefService
 import net.dv8tion.jda.api.JDA
+import net.dv8tion.jda.api.Permission
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.Message
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
 import net.dv8tion.jda.api.utils.messages.MessageCreateData
 import org.springframework.context.annotation.Lazy
 import org.springframework.stereotype.Component
 
 /**
- * Single DM-delivery gate for all user-targeted notifications. Every
- * notifier-style component routes through [sendDm] so the per-user
- * preference check (`user_notification_pref`) lives in one place. If
- * the user has opted out (or the default for the kind is opt-out and
- * they haven't set a row), the DM is silently dropped — the underlying
- * action (tip, duel, level-up, achievement) is unaffected.
+ * Single delivery gate for all user-targeted notifications.
  *
- * Calls are best-effort. DM dispatch can fail (closed DMs, blocked bot,
- * user left the guild); failures are logged but never propagate, so a
- * synchronous caller (e.g. a slash-command path that triggers an
- * achievement unlock) doesn't stall on Discord REST.
+ * - [sendDm] gates DM dispatch on the per-user `user_notification_pref`
+ *   row; the underlying action (tip, duel, level-up, achievement) is
+ *   unaffected when the DM is dropped.
+ * - [sendChannel] resolves the appropriate text channel for a
+ *   [ChannelRouteKey] (config-key chain + system-channel fallback) and
+ *   posts there. Channel routing does NOT consult the user pref store —
+ *   admins disable a kind by clearing the configured channel id.
+ *
+ * Both methods are best-effort. Dispatch failures (closed DMs, missing
+ * channel permissions, JDA errors) are logged but never propagate, so a
+ * synchronous caller (e.g. an event listener) never stalls or throws on
+ * Discord REST hiccups.
  */
 @Component
 class NotificationRouter(
     @Lazy private val jda: JDA,
-    private val prefService: UserNotificationPrefService
+    private val prefService: UserNotificationPrefService,
+    private val configService: ConfigService,
 ) {
     private val logger = DiscordLogger.createLogger(this::class.java)
 
@@ -69,4 +79,94 @@ class NotificationRouter(
             logger.warn("NotificationRouter dispatch failed for $discordId ($kind): ${it.message}")
         }
     }
+
+    /**
+     * Post [message] to the text channel chosen for [route] in [guildId].
+     * Resolution order (first writable wins):
+     *   1. `route.primaryConfigKey` — channel id from `ConfigService`.
+     *   2. Each `route.fallbackConfigKeys` in order.
+     *   3. [originChannelId] if supplied (e.g. the channel that earned
+     *      a level-up).
+     *   4. `guild.systemChannel` if [ChannelRouteKey.systemChannelFallback]
+     *      is true.
+     *
+     * Returns silently when no channel resolves — the caller's logic
+     * doesn't need to know. Pass [onSent] to react to the sent message
+     * (e.g. capture the message id for later edits — used by
+     * `LotteryAnnouncer.recordAnnouncement` and
+     * `WebDuelOfferNotifier.scheduleTimeoutCleanup`). [message] is built
+     * lazily so we don't pay the embed-construction cost when no channel
+     * is resolvable.
+     */
+    fun sendChannel(
+        guildId: Long,
+        route: ChannelRouteKey,
+        originChannelId: Long? = null,
+        message: () -> MessageCreateData,
+        onSent: ((Message) -> Unit)? = null,
+    ) {
+        val guild = jda.getGuildById(guildId) ?: run {
+            logger.warn("sendChannel for guild $guildId but bot is not in that guild; skipping ($route).")
+            return
+        }
+        val channel = resolveChannel(guild, route, originChannelId) ?: run {
+            logger.info {
+                "No writable channel resolved for route $route in guild ${guild.idLong}; skipping."
+            }
+            return
+        }
+
+        val payload = runCatching { message() }
+            .getOrElse { err ->
+                logger.warn("Failed to build $route payload for guild ${guild.idLong}: ${err.message}")
+                return
+            }
+
+        runCatching {
+            channel.sendMessage(payload).queue(
+                { sent -> if (onSent != null) runCatching { onSent(sent) }.onFailure {
+                    logger.warn("$route onSent callback threw: ${it.message}")
+                } },
+                { err ->
+                    logger.warn("Failed to post $route to #${channel.name}: ${err.message}")
+                },
+            )
+        }.onFailure {
+            logger.warn("$route channel dispatch failed: ${it.message}")
+        }
+    }
+
+    private fun resolveChannel(
+        guild: Guild,
+        route: ChannelRouteKey,
+        originChannelId: Long?,
+    ): TextChannel? {
+        // 1. primaryConfigKey
+        route.primaryConfigKey
+            ?.let { key -> channelFromConfig(guild, key) }
+            ?.let { return it }
+        // 2. fallbackConfigKeys in order
+        route.fallbackConfigKeys.forEach { key ->
+            channelFromConfig(guild, key)?.let { return it }
+        }
+        // 3. originChannelId
+        originChannelId?.let { id ->
+            guild.getTextChannelById(id)?.takeIf { hasSendPerms(guild, it) }?.let { return it }
+        }
+        // 4. system channel fallback (per-route opt-in)
+        if (route.systemChannelFallback) {
+            guild.systemChannel?.takeIf { hasSendPerms(guild, it) }?.let { return it }
+        }
+        return null
+    }
+
+    private fun channelFromConfig(guild: Guild, configKey: String): TextChannel? {
+        val raw = configService.getConfigByName(configKey, guild.id)?.value?.toLongOrNull()
+            ?: return null
+        val channel = guild.getTextChannelById(raw) ?: return null
+        return channel.takeIf { hasSendPerms(guild, it) }
+    }
+
+    private fun hasSendPerms(guild: Guild, channel: TextChannel): Boolean =
+        guild.selfMember.hasPermission(channel, Permission.MESSAGE_SEND, Permission.MESSAGE_EMBED_LINKS)
 }

--- a/discord-bot/src/main/kotlin/bot/toby/notify/NotificationRouter.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/notify/NotificationRouter.kt
@@ -124,9 +124,13 @@ class NotificationRouter(
 
         runCatching {
             channel.sendMessage(payload).queue(
-                { sent -> if (onSent != null) runCatching { onSent(sent) }.onFailure {
-                    logger.warn("$route onSent callback threw: ${it.message}")
-                } },
+                { sent ->
+                    onSent?.let { cb ->
+                        runCatching { cb(sent) }.onFailure {
+                            logger.warn("$route onSent callback threw: ${it.message}")
+                        }
+                    }
+                },
                 { err ->
                     logger.warn("Failed to post $route to #${channel.name}: ${err.message}")
                 },

--- a/discord-bot/src/main/kotlin/bot/toby/notify/WebDuelOfferNotifier.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/notify/WebDuelOfferNotifier.kt
@@ -2,16 +2,15 @@ package bot.toby.notify
 
 import bot.toby.command.commands.economy.DuelEmbeds
 import common.logging.DiscordLogger
+import common.notification.ChannelRouteKey
 import database.configuration.RegistryScheduler
 import database.duel.PendingDuelRegistry
-import net.dv8tion.jda.api.JDA
-import net.dv8tion.jda.api.Permission
 import net.dv8tion.jda.api.components.MessageTopLevelComponent
 import net.dv8tion.jda.api.components.actionrow.ActionRow
 import net.dv8tion.jda.api.components.buttons.Button
-import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.entities.Message
-import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
+import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel
+import net.dv8tion.jda.api.utils.messages.MessageCreateBuilder
 import org.springframework.context.event.EventListener
 import org.springframework.stereotype.Component
 import web.event.WebDuelOfferedEvent
@@ -22,8 +21,8 @@ import java.util.concurrent.TimeUnit
  * Posts a Discord channel notification when a duel is offered from
  * the web UI. The slash-command path posts inline to the channel
  * where `/duel` was invoked; web-initiated offers have no such
- * channel context, so this listener targets the guild's system
- * channel.
+ * channel context, so this listener routes through the
+ * [SYSTEM][ChannelRouteKey.SYSTEM] route via [NotificationRouter].
  *
  * Accept/Decline buttons resolve through the shared
  * [PendingDuelRegistry] regardless of which channel hosts the
@@ -31,7 +30,7 @@ import java.util.concurrent.TimeUnit
  * the registry to clean up its (ephemeral-interaction-hook-backed)
  * message when the TTL fires. For web offers there's no interaction
  * hook to edit through, so the notifier owns its own cleanup:
- * captures the sent message's id from the `queue` callback, then
+ * captures the sent message via the router's `onSent` callback, then
  * schedules a TTL-aligned task that atomically claims the offer via
  * [PendingDuelRegistry.cancel] and — if it wins the race against
  * accept/decline — edits the embed to [DuelEmbeds.timeoutEmbed] and
@@ -39,7 +38,7 @@ import java.util.concurrent.TimeUnit
  */
 @Component
 class WebDuelOfferNotifier(
-    private val jda: JDA,
+    private val notificationRouter: NotificationRouter,
     private val pendingDuelRegistry: PendingDuelRegistry,
     private val scheduler: ScheduledExecutorService = RegistryScheduler.instance,
 ) {
@@ -47,14 +46,6 @@ class WebDuelOfferNotifier(
 
     @EventListener
     fun on(event: WebDuelOfferedEvent) {
-        val guild = jda.getGuildById(event.guildId) ?: run {
-            logger.warn("WebDuelOfferedEvent for guild ${event.guildId} but bot is not in that guild; skipping.")
-            return
-        }
-        val channel = resolveChannel(guild) ?: run {
-            logger.warn("No writable system channel in guild ${event.guildId}; skipping web-duel notification.")
-            return
-        }
         val accept = Button.success(
             DuelEmbeds.acceptButtonId(event.duelId, event.opponentDiscordId),
             "Accept"
@@ -63,26 +54,31 @@ class WebDuelOfferNotifier(
             DuelEmbeds.declineButtonId(event.duelId, event.opponentDiscordId),
             "Decline"
         )
-        // addContent on the message (not the embed description) so the
-        // <@opponent> mention actually pings — embed-mention pings are silent.
-        runCatching {
-            channel.sendMessageEmbeds(
-                DuelEmbeds.offerEmbed(
-                    event.initiatorDiscordId,
-                    event.opponentDiscordId,
-                    event.stake,
-                    pendingDuelRegistry.ttl
-                )
-            )
-                .addContent("<@${event.opponentDiscordId}>")
-                .addComponents(ActionRow.of(accept, decline))
-                .queue { sent -> scheduleTimeoutCleanup(event, channel, sent) }
-        }.onFailure {
-            logger.error("Could not post web-duel notification to ${channel.id}: ${it.message}")
-        }
+        notificationRouter.sendChannel(
+            guildId = event.guildId,
+            route = ChannelRouteKey.SYSTEM,
+            message = {
+                // setContent on the message (not the embed description) so the
+                // <@opponent> mention actually pings — embed-mention pings are silent.
+                MessageCreateBuilder()
+                    .setEmbeds(
+                        DuelEmbeds.offerEmbed(
+                            event.initiatorDiscordId,
+                            event.opponentDiscordId,
+                            event.stake,
+                            pendingDuelRegistry.ttl,
+                        )
+                    )
+                    .setContent("<@${event.opponentDiscordId}>")
+                    .setComponents(ActionRow.of(accept, decline))
+                    .build()
+            },
+            onSent = { sent -> scheduleTimeoutCleanup(event, sent) },
+        )
     }
 
-    private fun scheduleTimeoutCleanup(event: WebDuelOfferedEvent, channel: TextChannel, sent: Message) {
+    private fun scheduleTimeoutCleanup(event: WebDuelOfferedEvent, sent: Message) {
+        val channel: MessageChannel = sent.channel
         scheduler.schedule({
             // Atomic claim — if cancel returns null the offer was already
             // accepted/declined and DuelButton already edited the message;
@@ -101,12 +97,5 @@ class WebDuelOfferNotifier(
                 logger.error("Could not edit expired web-duel message ${sent.id} in ${channel.id}: ${it.message}")
             }
         }, pendingDuelRegistry.ttl.toMillis(), TimeUnit.MILLISECONDS)
-    }
-
-    private fun resolveChannel(guild: Guild): TextChannel? {
-        val bot = guild.selfMember
-        return guild.systemChannel?.takeIf {
-            bot.hasPermission(it, Permission.MESSAGE_SEND, Permission.MESSAGE_EMBED_LINKS)
-        }
     }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/notify/WebTipNotifier.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/notify/WebTipNotifier.kt
@@ -1,12 +1,9 @@
 package bot.toby.notify
 
 import bot.toby.command.commands.economy.TipEmbeds
-import common.logging.DiscordLogger
+import common.notification.ChannelRouteKey
 import database.service.TipService.TipOutcome
-import net.dv8tion.jda.api.JDA
-import net.dv8tion.jda.api.Permission
-import net.dv8tion.jda.api.entities.Guild
-import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
+import net.dv8tion.jda.api.utils.messages.MessageCreateBuilder
 import org.springframework.context.event.EventListener
 import org.springframework.stereotype.Component
 import web.event.WebTipSentEvent
@@ -15,7 +12,8 @@ import web.event.WebTipSentEvent
  * Posts a Discord channel notification when a tip is initiated from
  * the web UI. The slash-command path posts inline to the channel
  * where `/tip` was invoked; web-initiated tips have no such channel
- * context, so this listener targets the guild's system channel.
+ * context, so this listener routes through the [SYSTEM][ChannelRouteKey.SYSTEM]
+ * route (system channel + permission checks live in [NotificationRouter]).
  *
  * If the bot has no writable system channel, the post is skipped (the
  * underlying transfer already happened — this is best-effort
@@ -23,20 +21,10 @@ import web.event.WebTipSentEvent
  */
 @Component
 class WebTipNotifier(
-    private val jda: JDA,
+    private val notificationRouter: NotificationRouter,
 ) {
-    private val logger = DiscordLogger.createLogger(this::class.java)
-
     @EventListener
     fun on(event: WebTipSentEvent) {
-        val guild = jda.getGuildById(event.guildId) ?: run {
-            logger.warn("WebTipSentEvent for guild ${event.guildId} but bot is not in that guild; skipping.")
-            return
-        }
-        val channel = resolveChannel(guild) ?: run {
-            logger.warn("No writable system channel in guild ${event.guildId}; skipping web-tip notification.")
-            return
-        }
         val outcome = TipOutcome.Ok(
             sender = event.senderDiscordId,
             recipient = event.recipientDiscordId,
@@ -47,21 +35,17 @@ class WebTipNotifier(
             sentTodayAfter = event.sentTodayAfter,
             dailyCap = event.dailyCap
         )
-        // addContent on the message (not the embed description) so the
-        // <@recipient> mention actually pings — embed-mention pings are silent.
-        runCatching {
-            channel.sendMessageEmbeds(TipEmbeds.okEmbed(outcome))
-                .addContent("<@${event.recipientDiscordId}>")
-                .queue()
-        }.onFailure {
-            logger.error("Could not post web-tip notification to ${channel.id}: ${it.message}")
-        }
-    }
-
-    private fun resolveChannel(guild: Guild): TextChannel? {
-        val bot = guild.selfMember
-        return guild.systemChannel?.takeIf {
-            bot.hasPermission(it, Permission.MESSAGE_SEND, Permission.MESSAGE_EMBED_LINKS)
-        }
+        notificationRouter.sendChannel(
+            guildId = event.guildId,
+            route = ChannelRouteKey.SYSTEM,
+            message = {
+                // setContent on the message (not the embed description) so the
+                // <@recipient> mention actually pings — embed-mention pings are silent.
+                MessageCreateBuilder()
+                    .setEmbeds(TipEmbeds.okEmbed(outcome))
+                    .setContent("<@${event.recipientDiscordId}>")
+                    .build()
+            },
+        )
     }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/scheduling/LotteryAnnouncer.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/scheduling/LotteryAnnouncer.kt
@@ -1,22 +1,22 @@
 package bot.toby.scheduling
 
+import bot.toby.notify.NotificationRouter
 import common.logging.DiscordLogger
-import database.dto.ConfigDto
+import common.notification.ChannelRouteKey
 import database.dto.JackpotLotteryDto
 import database.service.ConfigService
 import database.service.JackpotLotteryService
 import database.service.LotteryHelper
 import net.dv8tion.jda.api.EmbedBuilder
 import net.dv8tion.jda.api.JDA
-import net.dv8tion.jda.api.Permission
 import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.entities.Message
 import net.dv8tion.jda.api.entities.MessageEmbed
-import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
 import net.dv8tion.jda.api.exceptions.ErrorResponseException
 import net.dv8tion.jda.api.components.actionrow.ActionRow
 import net.dv8tion.jda.api.components.buttons.Button
 import net.dv8tion.jda.api.requests.ErrorResponse
+import net.dv8tion.jda.api.utils.messages.MessageCreateBuilder
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
@@ -57,6 +57,7 @@ import java.awt.Color
 class LotteryAnnouncer @Autowired constructor(
     private val configService: ConfigService,
     private val jackpotLotteryService: JackpotLotteryService,
+    private val notificationRouter: NotificationRouter,
     @Value("\${app.base-url:}") private val webBaseUrl: String = "",
 ) {
 
@@ -81,35 +82,29 @@ class LotteryAnnouncer @Autowired constructor(
         priorOutcome: PriorOutcome?,
         openOutcome: OpenSummary,
     ) {
-        val channel = resolveChannel(guild) ?: run {
-            logger.warn(
-                "No writable channel for daily lottery announcement in guild ${guild.idLong}; " +
-                    "set LOTTERY_CHANNEL or LEADERBOARD_CHANNEL, or grant the bot send-messages " +
-                    "in the system channel."
-            )
-            return
-        }
-        val embed = buildEmbed(guild, mode, priorOutcome, openOutcome)
-        val content = buildAnnouncementContent(guild, priorOutcome)
         val lotteryId = (openOutcome as? OpenSummary.Ok)?.lotteryId
         val poolAmount = (openOutcome as? OpenSummary.Ok)?.poolAmount
-        val actionRow = announcementActionRow(mode, guild.idLong)
-        runCatching {
-            val send = channel.sendMessageEmbeds(embed)
-                .setAllowedMentions(allowedMentionTypes(content))
-            if (content.isNotBlank()) {
-                send.addContent(content)
-            }
-            if (actionRow != null) {
-                send.addComponents(actionRow)
-            }
-            send.queue({ message ->
+        notificationRouter.sendChannel(
+            guildId = guild.idLong,
+            route = ChannelRouteKey.LOTTERY,
+            message = {
+                val embed = buildEmbed(guild, mode, priorOutcome, openOutcome)
+                val content = buildAnnouncementContent(guild, priorOutcome)
+                val actionRow = announcementActionRow(mode, guild.idLong)
+                val builder = MessageCreateBuilder()
+                    .setEmbeds(embed)
+                    .setAllowedMentions(allowedMentionTypes(content))
+                if (content.isNotBlank()) builder.setContent(content)
+                if (actionRow != null) builder.setComponents(actionRow)
+                builder.build()
+            },
+            onSent = { sent ->
                 if (lotteryId != null && poolAmount != null) {
                     runCatching {
                         jackpotLotteryService.recordAnnouncement(
                             lotteryId = lotteryId,
-                            channelId = channel.idLong,
-                            messageId = message.idLong,
+                            channelId = sent.channel.idLong,
+                            messageId = sent.idLong,
                             pool = poolAmount,
                         )
                     }.onFailure {
@@ -119,12 +114,8 @@ class LotteryAnnouncer @Autowired constructor(
                         )
                     }
                 }
-            }, { failure ->
-                logger.error("Could not post lottery announcement to ${channel.id}: ${failure.message}")
-            })
-        }.onFailure {
-            logger.error("Could not post lottery announcement to ${channel.id}: ${it.message}")
-        }
+            },
+        )
     }
 
     /**
@@ -302,27 +293,6 @@ class LotteryAnnouncer @Autowired constructor(
         }
     }
 
-    // ---- channel resolution ----
-
-    private fun resolveChannel(guild: Guild): TextChannel? {
-        val bot = guild.selfMember
-        // 1. LOTTERY_CHANNEL — explicit lottery channel.
-        LotteryHelper.lotteryChannelId(configService, guild.idLong)?.let { id ->
-            val channel = guild.getTextChannelById(id)
-            if (channel != null && bot.hasPermission(channel, *REQUIRED_PERMS)) return channel
-        }
-        // 2. LEADERBOARD_CHANNEL — shared announce channel fallback.
-        configService.getConfigByName(
-            ConfigDto.Configurations.LEADERBOARD_CHANNEL.configValue,
-            guild.id
-        )?.value?.toLongOrNull()?.let { id ->
-            val channel = guild.getTextChannelById(id)
-            if (channel != null && bot.hasPermission(channel, *REQUIRED_PERMS)) return channel
-        }
-        // 3. systemChannel as last resort.
-        return guild.systemChannel?.takeIf { bot.hasPermission(it, *REQUIRED_PERMS) }
-    }
-
     // ---- embed building ----
 
     private fun buildEmbed(
@@ -469,7 +439,6 @@ class LotteryAnnouncer @Autowired constructor(
     }
 
     companion object {
-        private val REQUIRED_PERMS = arrayOf(Permission.MESSAGE_SEND, Permission.MESSAGE_EMBED_LINKS)
         private const val LOTTERY_COMMAND_NAME = "lottery"
         private const val LOTTERY_BUY_SUBCOMMAND = "buy"
 

--- a/discord-bot/src/test/kotlin/bot/toby/intro/IntroNotificationServiceOptOutTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/intro/IntroNotificationServiceOptOutTest.kt
@@ -11,8 +11,6 @@ import io.mockk.mockk
 import io.mockk.verify
 import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.entities.User
-import net.dv8tion.jda.api.requests.restaction.CacheRestAction
-import net.dv8tion.jda.api.entities.channel.concrete.PrivateChannel
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
@@ -70,8 +68,10 @@ class IntroNotificationServiceOptOutTest {
         every {
             prefService.isOptedIn(discordId, guildId, NotificationChannelKind.INTRO_PROMPT)
         } returns true
-        val privateChannel: CacheRestAction<PrivateChannel> = mockk(relaxed = true)
-        every { user.openPrivateChannel() } returns privateChannel
+        // `relaxed = true` on the User mock returns a relaxed mock from
+        // openPrivateChannel() automatically — no need to over-specify
+        // the RestAction return type here, which has shifted between
+        // JDA versions.
 
         service.promptUserForMusicInfo(user, guild)
 

--- a/discord-bot/src/test/kotlin/bot/toby/intro/IntroNotificationServiceOptOutTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/intro/IntroNotificationServiceOptOutTest.kt
@@ -1,0 +1,80 @@
+package bot.toby.intro
+
+import bot.toby.handler.EventWaiter
+import bot.toby.helpers.HttpHelper
+import bot.toby.helpers.UserDtoHelper
+import common.notification.NotificationChannelKind
+import database.service.MusicFileService
+import database.service.UserNotificationPrefService
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.User
+import net.dv8tion.jda.api.requests.restaction.CacheRestAction
+import net.dv8tion.jda.api.entities.channel.concrete.PrivateChannel
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * Locks in the INTRO_PROMPT opt-out gate added when
+ * [IntroNotificationService] was wired to [UserNotificationPrefService].
+ * Pre-refactor the prompt fired unconditionally; users couldn't suppress
+ * the DM. Now `/notify set INTRO_PROMPT off` makes the bot silent.
+ */
+class IntroNotificationServiceOptOutTest {
+
+    private val discordId = 100L
+    private val guildId = 42L
+
+    private lateinit var user: User
+    private lateinit var guild: Guild
+    private lateinit var prefService: UserNotificationPrefService
+    private lateinit var service: IntroNotificationService
+
+    @BeforeEach
+    fun setup() {
+        user = mockk(relaxed = true)
+        guild = mockk(relaxed = true)
+        prefService = mockk(relaxed = true)
+        every { user.idLong } returns discordId
+        every { guild.idLong } returns guildId
+        every { guild.name } returns "Test Guild"
+
+        service = IntroNotificationService(
+            userDtoHelper = mockk<UserDtoHelper>(relaxed = true),
+            musicFileService = mockk<MusicFileService>(relaxed = true),
+            httpHelper = mockk<HttpHelper>(relaxed = true),
+            eventWaiter = mockk<EventWaiter>(relaxed = true),
+            validationService = mockk<IntroValidationService>(relaxed = true),
+            mediaLoader = mockk<IntroMediaLoader>(relaxed = true),
+            notificationPrefService = prefService,
+        )
+    }
+
+    @Test
+    fun `opted-out user gets no DM and no waiter setup`() {
+        every {
+            prefService.isOptedIn(discordId, guildId, NotificationChannelKind.INTRO_PROMPT)
+        } returns false
+
+        service.promptUserForMusicInfo(user, guild)
+
+        // openPrivateChannel is the first JDA call the prompt path makes
+        // — if the gate worked we shouldn't reach it.
+        verify(exactly = 0) { user.openPrivateChannel() }
+    }
+
+    @Test
+    fun `opted-in user reaches the prompt path`() {
+        every {
+            prefService.isOptedIn(discordId, guildId, NotificationChannelKind.INTRO_PROMPT)
+        } returns true
+        val privateChannel: CacheRestAction<PrivateChannel> = mockk(relaxed = true)
+        every { user.openPrivateChannel() } returns privateChannel
+
+        service.promptUserForMusicInfo(user, guild)
+
+        verify(exactly = 1) { user.openPrivateChannel() }
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/leveling/LevelUpListenerTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/leveling/LevelUpListenerTest.kt
@@ -1,14 +1,18 @@
 package bot.toby.leveling
 
+import bot.toby.notify.NotificationRouter
 import common.events.LevelUpEvent
 import common.leveling.LevelCurve
+import common.notification.ChannelRouteKey
 import database.dto.LevelRoleRewardDto
 import database.dto.TitleDto
-import database.service.ConfigService
 import database.service.LevelRoleRewardService
 import database.service.TitleService
+import io.mockk.CapturingSlot
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
+import io.mockk.runs
 import io.mockk.slot
 import io.mockk.verify
 import net.dv8tion.jda.api.JDA
@@ -16,16 +20,15 @@ import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.entities.MessageEmbed
 import net.dv8tion.jda.api.entities.Role
 import net.dv8tion.jda.api.entities.UserSnowflake
-import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
 import net.dv8tion.jda.api.requests.restaction.AuditableRestAction
-import net.dv8tion.jda.api.requests.restaction.MessageCreateAction
+import net.dv8tion.jda.api.utils.messages.MessageCreateData
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 class LevelUpListenerTest {
 
     private lateinit var jda: JDA
-    private lateinit var configService: ConfigService
+    private lateinit var router: NotificationRouter
     private lateinit var levelRoleRewardService: LevelRoleRewardService
     private lateinit var titleService: TitleService
     private lateinit var listener: LevelUpListener
@@ -36,26 +39,34 @@ class LevelUpListenerTest {
     @BeforeEach
     fun setUp() {
         jda = mockk(relaxed = true)
-        configService = mockk(relaxed = true)
+        router = mockk(relaxed = true)
         levelRoleRewardService = mockk(relaxed = true)
         titleService = mockk(relaxed = true)
-        listener = LevelUpListener(jda, configService, levelRoleRewardService, titleService)
+        listener = LevelUpListener(jda, levelRoleRewardService, titleService, router)
     }
 
-    @Test
-    fun `onLevelUp posts an embed in the origin channel when present`() {
+    private fun guildOnly(): Guild {
         val guild = mockk<Guild>(relaxed = true)
-        val channel = mockk<TextChannel>(relaxed = true)
-        val createAction = mockk<MessageCreateAction>(relaxed = true)
         every { jda.getGuildById(guildId) } returns guild
         every { guild.idLong } returns guildId
         every { guild.id } returns guildId.toString()
-        every { guild.getTextChannelById(99L) } returns channel
-        every { channel.name } returns "general"
-        every { channel.sendMessageEmbeds(any<MessageEmbed>()) } returns createAction
-        every { configService.getConfigByName(any(), any()) } returns null
         every { levelRoleRewardService.listInRange(any(), any(), any()) } returns emptyList()
         every { titleService.listAll() } returns emptyList()
+        return guild
+    }
+
+    private fun captureAnnouncementEmbed(): CapturingSlot<() -> MessageCreateData> {
+        val builder = slot<() -> MessageCreateData>()
+        every {
+            router.sendChannel(any(), any(), any(), capture(builder), any())
+        } just runs
+        return builder
+    }
+
+    @Test
+    fun `onLevelUp routes the announce embed via LEVEL_UP with the origin channel`() {
+        guildOnly()
+        val builder = captureAnnouncementEmbed()
 
         listener.onLevelUp(
             LevelUpEvent(
@@ -64,52 +75,48 @@ class LevelUpListenerTest {
             )
         )
 
-        val sent = slot<MessageEmbed>()
-        verify { channel.sendMessageEmbeds(capture(sent)) }
-        val embed = sent.captured
+        verify(exactly = 1) {
+            router.sendChannel(
+                guildId = guildId,
+                route = ChannelRouteKey.LEVEL_UP,
+                originChannelId = 99L,
+                message = any(),
+                onSent = null,
+            )
+        }
+        val embed = builder.captured.invoke().embeds.single()
         assert(embed.title!!.contains("LVL 1"))
         assert(embed.description!!.contains("<@$discordId>"))
         assert(embed.description!!.contains("Level 1"))
     }
 
     @Test
-    fun `onLevelUp falls back to system channel when no origin channel`() {
-        val guild = mockk<Guild>(relaxed = true)
-        val systemChannel = mockk<TextChannel>(relaxed = true)
-        val createAction = mockk<MessageCreateAction>(relaxed = true)
-        every { jda.getGuildById(guildId) } returns guild
-        every { guild.idLong } returns guildId
-        every { guild.id } returns guildId.toString()
-        every { guild.systemChannel } returns systemChannel
-        every { systemChannel.name } returns "general"
-        every { systemChannel.sendMessageEmbeds(any<MessageEmbed>()) } returns createAction
-        every { configService.getConfigByName(any(), any()) } returns null
-        every { levelRoleRewardService.listInRange(any(), any(), any()) } returns emptyList()
-        every { titleService.listAll() } returns emptyList()
+    fun `onLevelUp passes null originChannelId when the event has no channel context`() {
+        guildOnly()
+        captureAnnouncementEmbed()
 
         listener.onLevelUp(
             LevelUpEvent(discordId, guildId, oldLevel = 0, newLevel = 1, totalXp = 110L, channelId = null)
         )
 
-        verify { systemChannel.sendMessageEmbeds(any<MessageEmbed>()) }
+        verify(exactly = 1) {
+            router.sendChannel(
+                guildId = guildId,
+                route = ChannelRouteKey.LEVEL_UP,
+                originChannelId = null,
+                message = any(),
+                onSent = null,
+            )
+        }
     }
 
     @Test
     fun `onLevelUp assigns every role in the level range`() {
-        val guild = mockk<Guild>(relaxed = true)
-        val channel = mockk<TextChannel>(relaxed = true)
-        val createAction = mockk<MessageCreateAction>(relaxed = true)
+        val guild = guildOnly()
         val role1 = mockk<Role>(relaxed = true)
         val role2 = mockk<Role>(relaxed = true)
         val addRoleAction = mockk<AuditableRestAction<Void>>(relaxed = true)
 
-        every { jda.getGuildById(guildId) } returns guild
-        every { guild.idLong } returns guildId
-        every { guild.id } returns guildId.toString()
-        every { guild.getTextChannelById(any<Long>()) } returns channel
-        every { channel.sendMessageEmbeds(any<MessageEmbed>()) } returns createAction
-        every { configService.getConfigByName(any(), any()) } returns null
-        every { titleService.listAll() } returns emptyList()
         every { levelRoleRewardService.listInRange(guildId, fromExclusive = 1, toInclusive = 3) } returns listOf(
             LevelRoleRewardDto(guildId = guildId, level = 2, roleId = 201L),
             LevelRoleRewardDto(guildId = guildId, level = 3, roleId = 202L)
@@ -130,18 +137,7 @@ class LevelUpListenerTest {
 
     @Test
     fun `onLevelUp unlocks titles whose requiredLevel falls in the range`() {
-        val guild = mockk<Guild>(relaxed = true)
-        val channel = mockk<TextChannel>(relaxed = true)
-        val createAction = mockk<MessageCreateAction>(relaxed = true)
-
-        every { jda.getGuildById(guildId) } returns guild
-        every { guild.idLong } returns guildId
-        every { guild.id } returns guildId.toString()
-        every { guild.getTextChannelById(any<Long>()) } returns channel
-        every { channel.sendMessageEmbeds(any<MessageEmbed>()) } returns createAction
-        every { configService.getConfigByName(any(), any()) } returns null
-        every { levelRoleRewardService.listInRange(any(), any(), any()) } returns emptyList()
-
+        guildOnly()
         val gated = TitleDto(id = 10L, label = "Gated", cost = 0L).apply { requiredLevel = 2 }
         val higher = TitleDto(id = 11L, label = "Higher", cost = 0L).apply { requiredLevel = 5 }
         val ungated = TitleDto(id = 12L, label = "Free", cost = 0L)
@@ -159,18 +155,7 @@ class LevelUpListenerTest {
 
     @Test
     fun `onLevelUp skips title unlock when the user already owns it`() {
-        val guild = mockk<Guild>(relaxed = true)
-        val channel = mockk<TextChannel>(relaxed = true)
-        val createAction = mockk<MessageCreateAction>(relaxed = true)
-
-        every { jda.getGuildById(guildId) } returns guild
-        every { guild.idLong } returns guildId
-        every { guild.id } returns guildId.toString()
-        every { guild.getTextChannelById(any<Long>()) } returns channel
-        every { channel.sendMessageEmbeds(any<MessageEmbed>()) } returns createAction
-        every { configService.getConfigByName(any(), any()) } returns null
-        every { levelRoleRewardService.listInRange(any(), any(), any()) } returns emptyList()
-
+        guildOnly()
         val gated = TitleDto(id = 10L, label = "Gated", cost = 0L).apply { requiredLevel = 2 }
         every { titleService.listAll() } returns listOf(gated)
         every { titleService.owns(discordId, 10L) } returns true
@@ -191,22 +176,13 @@ class LevelUpListenerTest {
         )
 
         verify(exactly = 0) { titleService.recordPurchase(any(), any()) }
+        verify(exactly = 0) { router.sendChannel(any(), any(), any(), any(), any()) }
     }
 
     @Test
     fun `onLevelUp posts a tier-colored embed with progress matching LevelCurve`() {
-        val guild = mockk<Guild>(relaxed = true)
-        val channel = mockk<TextChannel>(relaxed = true)
-        val createAction = mockk<MessageCreateAction>(relaxed = true)
-        every { jda.getGuildById(guildId) } returns guild
-        every { guild.idLong } returns guildId
-        every { guild.id } returns guildId.toString()
-        every { guild.getTextChannelById(99L) } returns channel
-        every { channel.name } returns "general"
-        every { channel.sendMessageEmbeds(any<MessageEmbed>()) } returns createAction
-        every { configService.getConfigByName(any(), any()) } returns null
-        every { levelRoleRewardService.listInRange(any(), any(), any()) } returns emptyList()
-        every { titleService.listAll() } returns emptyList()
+        guildOnly()
+        val builder = captureAnnouncementEmbed()
 
         // Craft a totalXp that sits inside level 25 (Gold tier).
         val totalXp = LevelCurve.cumulativeXpForLevel(25) + 50L
@@ -219,9 +195,7 @@ class LevelUpListenerTest {
             )
         )
 
-        val sent = slot<MessageEmbed>()
-        verify { channel.sendMessageEmbeds(capture(sent)) }
-        val embed = sent.captured
+        val embed = builder.captured.invoke().embeds.single()
         assert(embed.title!!.contains("LVL 25"))
         assert((embed.colorRaw and 0xFFFFFF) == 0xD4A017) {
             "expected Gold tier color 0xD4A017, got ${(embed.colorRaw and 0xFFFFFF).toString(16)}"
@@ -241,24 +215,16 @@ class LevelUpListenerTest {
 
     @Test
     fun `onLevelUp uses extended tier names and colors from Platinum through Legendary`() {
-        val guild = mockk<Guild>(relaxed = true)
-        val channel = mockk<TextChannel>(relaxed = true)
-        val createAction = mockk<MessageCreateAction>(relaxed = true)
-        val sentEmbeds = mutableListOf<MessageEmbed>()
-        every { jda.getGuildById(guildId) } returns guild
-        every { guild.idLong } returns guildId
-        every { guild.id } returns guildId.toString()
-        every { guild.getTextChannelById(any<Long>()) } returns channel
-        every { channel.name } returns "general"
-        every { channel.sendMessageEmbeds(any<MessageEmbed>()) } answers {
-            sentEmbeds += firstArg<MessageEmbed>()
-            createAction
+        guildOnly()
+        val captured = mutableListOf<MessageCreateData>()
+        every {
+            router.sendChannel(any(), any(), any(), any(), any())
+        } answers {
+            @Suppress("UNCHECKED_CAST")
+            val build = arg<() -> MessageCreateData>(3)
+            captured += build()
         }
-        every { configService.getConfigByName(any(), any()) } returns null
-        every { levelRoleRewardService.listInRange(any(), any(), any()) } returns emptyList()
-        every { titleService.listAll() } returns emptyList()
 
-        // (newLevel, expected tier name, expected lower-24-bit color)
         val cases = listOf(
             Triple(50, "Platinum", 0xE5E4E2),
             Triple(75, "Diamond", 0x5865F2),
@@ -266,7 +232,6 @@ class LevelUpListenerTest {
             Triple(150, "Mythic", 0xFF3CAC),
             Triple(200, "Legendary", 0xFFD700),
         )
-
         cases.forEachIndexed { i, (lvl, tier, color) ->
             val totalXp = LevelCurve.cumulativeXpForLevel(lvl)
             listener.onLevelUp(
@@ -275,7 +240,7 @@ class LevelUpListenerTest {
                     oldLevel = lvl - 1, newLevel = lvl, totalXp = totalXp, channelId = 99L
                 )
             )
-            val embed = sentEmbeds[i]
+            val embed = captured[i].embeds.single()
             assert(embed.footer!!.text!!.contains(tier)) {
                 "level $lvl footer '${embed.footer!!.text}' should mention $tier"
             }
@@ -287,25 +252,16 @@ class LevelUpListenerTest {
 
     @Test
     fun `tier boundaries are off-by-one safe just below each threshold`() {
-        val guild = mockk<Guild>(relaxed = true)
-        val channel = mockk<TextChannel>(relaxed = true)
-        val createAction = mockk<MessageCreateAction>(relaxed = true)
-        val sentEmbeds = mutableListOf<MessageEmbed>()
-        every { jda.getGuildById(guildId) } returns guild
-        every { guild.idLong } returns guildId
-        every { guild.id } returns guildId.toString()
-        every { guild.getTextChannelById(any<Long>()) } returns channel
-        every { channel.name } returns "general"
-        every { channel.sendMessageEmbeds(any<MessageEmbed>()) } answers {
-            sentEmbeds += firstArg<MessageEmbed>()
-            createAction
+        guildOnly()
+        val captured = mutableListOf<MessageCreateData>()
+        every {
+            router.sendChannel(any(), any(), any(), any(), any())
+        } answers {
+            @Suppress("UNCHECKED_CAST")
+            val build = arg<() -> MessageCreateData>(3)
+            captured += build()
         }
-        every { configService.getConfigByName(any(), any()) } returns null
-        every { levelRoleRewardService.listInRange(any(), any(), any()) } returns emptyList()
-        every { titleService.listAll() } returns emptyList()
 
-        // (level just below threshold, expected lower-tier name) — guards against
-        // a `>` vs `>=` swap on the tier `when` arms.
         val boundaries = listOf(
             9 to "Bronze",     // 10 -> Silver
             24 to "Silver",    // 25 -> Gold
@@ -315,7 +271,6 @@ class LevelUpListenerTest {
             149 to "Master",   // 150 -> Mythic
             199 to "Mythic",   // 200 -> Legendary
         )
-
         boundaries.forEachIndexed { i, (lvl, expectedTier) ->
             val totalXp = LevelCurve.cumulativeXpForLevel(lvl)
             listener.onLevelUp(
@@ -324,7 +279,7 @@ class LevelUpListenerTest {
                     oldLevel = lvl - 1, newLevel = lvl, totalXp = totalXp, channelId = 99L
                 )
             )
-            val embed = sentEmbeds[i]
+            val embed = captured[i].embeds.single()
             assert(embed.footer!!.text!!.contains(expectedTier)) {
                 "level $lvl should stay on '$expectedTier' tier, got '${embed.footer!!.text}'"
             }

--- a/discord-bot/src/test/kotlin/bot/toby/notify/NotificationRouterChannelTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/notify/NotificationRouterChannelTest.kt
@@ -1,0 +1,230 @@
+package bot.toby.notify
+
+import common.notification.ChannelRouteKey
+import database.dto.ConfigDto
+import database.service.ConfigService
+import database.service.UserNotificationPrefService
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.slot
+import io.mockk.verify
+import net.dv8tion.jda.api.JDA
+import net.dv8tion.jda.api.Permission
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.Message
+import net.dv8tion.jda.api.entities.SelfMember
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
+import net.dv8tion.jda.api.requests.restaction.MessageCreateAction
+import net.dv8tion.jda.api.utils.messages.MessageCreateBuilder
+import net.dv8tion.jda.api.utils.messages.MessageCreateData
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.util.function.Consumer
+
+/**
+ * Channel-routing coverage for [NotificationRouter.sendChannel]. The
+ * DM side ([NotificationRouter.sendDm]) was previously the only
+ * behaviour and continues to live alongside this.
+ *
+ * Resolution chain the router applies:
+ *   1. primaryConfigKey
+ *   2. each fallbackConfigKeys in order
+ *   3. originChannelId
+ *   4. guild.systemChannel (if route allows)
+ *
+ * Channel posts are NOT gated by user notification prefs.
+ */
+class NotificationRouterChannelTest {
+
+    private val guildId = 100L
+    private lateinit var jda: JDA
+    private lateinit var configService: ConfigService
+    private lateinit var prefService: UserNotificationPrefService
+    private lateinit var guild: Guild
+    private lateinit var bot: SelfMember
+    private lateinit var router: NotificationRouter
+
+    private lateinit var primaryChannel: TextChannel
+    private lateinit var fallbackChannel: TextChannel
+    private lateinit var originChannel: TextChannel
+    private lateinit var systemChannel: TextChannel
+    private lateinit var createAction: MessageCreateAction
+
+    private val payload = MessageCreateBuilder().setContent("hello").build()
+    private val builder: () -> MessageCreateData = { payload }
+
+    @BeforeEach
+    fun setup() {
+        jda = mockk(relaxed = true)
+        configService = mockk(relaxed = true)
+        prefService = mockk(relaxed = true)
+        guild = mockk(relaxed = true)
+        bot = mockk(relaxed = true)
+        primaryChannel = mockk(relaxed = true)
+        fallbackChannel = mockk(relaxed = true)
+        originChannel = mockk(relaxed = true)
+        systemChannel = mockk(relaxed = true)
+        createAction = mockk(relaxed = true)
+
+        every { jda.getGuildById(guildId) } returns guild
+        every { guild.id } returns guildId.toString()
+        every { guild.idLong } returns guildId
+        every { guild.selfMember } returns bot
+        every { bot.hasPermission(any<TextChannel>(), *anyVararg<Permission>()) } returns true
+
+        every { primaryChannel.idLong } returns 1L
+        every { fallbackChannel.idLong } returns 2L
+        every { originChannel.idLong } returns 3L
+        every { systemChannel.idLong } returns 4L
+        every { primaryChannel.name } returns "primary"
+        every { fallbackChannel.name } returns "fallback"
+        every { originChannel.name } returns "origin"
+        every { systemChannel.name } returns "system"
+
+        // Each channel returns the same create-action mock (the router
+        // doesn't care which channel produced the action; we only verify
+        // which channel was asked to sendMessage).
+        every { primaryChannel.sendMessage(any<MessageCreateData>()) } returns createAction
+        every { fallbackChannel.sendMessage(any<MessageCreateData>()) } returns createAction
+        every { originChannel.sendMessage(any<MessageCreateData>()) } returns createAction
+        every { systemChannel.sendMessage(any<MessageCreateData>()) } returns createAction
+        every {
+            createAction.queue(any<Consumer<Message>>(), any<Consumer<in Throwable>>())
+        } just runs
+
+        router = NotificationRouter(jda, prefService, configService)
+    }
+
+    private fun stub(key: ConfigDto.Configurations, value: String?) {
+        every {
+            configService.getConfigByName(key.configValue, guildId.toString())
+        } returns value?.let {
+            ConfigDto(name = key.configValue, value = it, guildId = guildId.toString())
+        }
+    }
+
+    @Test
+    fun `resolves primaryConfigKey first`() {
+        stub(ConfigDto.Configurations.LEVEL_UP_CHANNEL, "1")
+        every { guild.getTextChannelById(1L) } returns primaryChannel
+
+        router.sendChannel(guildId, ChannelRouteKey.LEVEL_UP, message = builder)
+
+        verify(exactly = 1) { primaryChannel.sendMessage(payload) }
+        verify(exactly = 0) { fallbackChannel.sendMessage(any<MessageCreateData>()) }
+    }
+
+    @Test
+    fun `falls through to fallbackConfigKeys when primary is unset`() {
+        // LOTTERY route: primary=LOTTERY_CHANNEL, fallback=LEADERBOARD_CHANNEL.
+        stub(ConfigDto.Configurations.LOTTERY_CHANNEL, null)
+        stub(ConfigDto.Configurations.LEADERBOARD_CHANNEL, "2")
+        every { guild.getTextChannelById(2L) } returns fallbackChannel
+
+        router.sendChannel(guildId, ChannelRouteKey.LOTTERY, message = builder)
+
+        verify(exactly = 1) { fallbackChannel.sendMessage(payload) }
+    }
+
+    @Test
+    fun `falls through to originChannelId when configs miss`() {
+        stub(ConfigDto.Configurations.LEVEL_UP_CHANNEL, null)
+        every { guild.getTextChannelById(3L) } returns originChannel
+
+        router.sendChannel(
+            guildId, ChannelRouteKey.LEVEL_UP,
+            originChannelId = 3L,
+            message = builder,
+        )
+
+        verify(exactly = 1) { originChannel.sendMessage(payload) }
+    }
+
+    @Test
+    fun `falls through to system channel when route allows and earlier steps miss`() {
+        stub(ConfigDto.Configurations.LEVEL_UP_CHANNEL, null)
+        every { guild.systemChannel } returns systemChannel
+
+        router.sendChannel(guildId, ChannelRouteKey.LEVEL_UP, message = builder)
+
+        verify(exactly = 1) { systemChannel.sendMessage(payload) }
+    }
+
+    @Test
+    fun `ACHIEVEMENT_SHOUTOUT does not fall through to system channel`() {
+        stub(ConfigDto.Configurations.ACHIEVEMENT_ANNOUNCE_CHANNEL, null)
+        every { guild.systemChannel } returns systemChannel  // would resolve if route allowed
+
+        router.sendChannel(guildId, ChannelRouteKey.ACHIEVEMENT_SHOUTOUT, message = builder)
+
+        verify(exactly = 0) { systemChannel.sendMessage(any<MessageCreateData>()) }
+    }
+
+    @Test
+    fun `silently no-ops when nothing resolves`() {
+        stub(ConfigDto.Configurations.LEVEL_UP_CHANNEL, null)
+        every { guild.systemChannel } returns null
+
+        router.sendChannel(guildId, ChannelRouteKey.LEVEL_UP, message = builder)
+
+        verify(exactly = 0) { primaryChannel.sendMessage(any<MessageCreateData>()) }
+        verify(exactly = 0) { fallbackChannel.sendMessage(any<MessageCreateData>()) }
+        verify(exactly = 0) { systemChannel.sendMessage(any<MessageCreateData>()) }
+    }
+
+    @Test
+    fun `skips channels the bot cannot post in and continues the chain`() {
+        stub(ConfigDto.Configurations.LOTTERY_CHANNEL, "1")
+        stub(ConfigDto.Configurations.LEADERBOARD_CHANNEL, "2")
+        every { guild.getTextChannelById(1L) } returns primaryChannel
+        every { guild.getTextChannelById(2L) } returns fallbackChannel
+        every { bot.hasPermission(primaryChannel, *anyVararg<Permission>()) } returns false
+        every { bot.hasPermission(fallbackChannel, *anyVararg<Permission>()) } returns true
+
+        router.sendChannel(guildId, ChannelRouteKey.LOTTERY, message = builder)
+
+        verify(exactly = 0) { primaryChannel.sendMessage(any<MessageCreateData>()) }
+        verify(exactly = 1) { fallbackChannel.sendMessage(payload) }
+    }
+
+    @Test
+    fun `does not check user notification prefs for channel routing`() {
+        stub(ConfigDto.Configurations.LEVEL_UP_CHANNEL, "1")
+        every { guild.getTextChannelById(1L) } returns primaryChannel
+
+        router.sendChannel(guildId, ChannelRouteKey.LEVEL_UP, message = builder)
+
+        verify(exactly = 0) { prefService.isOptedIn(any(), any(), any()) }
+    }
+
+    @Test
+    fun `onSent callback receives the sent message after dispatch`() {
+        stub(ConfigDto.Configurations.LEVEL_UP_CHANNEL, "1")
+        every { guild.getTextChannelById(1L) } returns primaryChannel
+        val sent = mockk<Message>(relaxed = true)
+        val successSlot = slot<Consumer<Message>>()
+        every { createAction.queue(capture(successSlot), any<Consumer<in Throwable>>()) } just runs
+
+        var captured: Message? = null
+        router.sendChannel(
+            guildId, ChannelRouteKey.LEVEL_UP,
+            message = builder,
+            onSent = { msg -> captured = msg },
+        )
+        successSlot.captured.accept(sent)
+
+        assertSame(sent, captured)
+    }
+
+    @Test
+    fun `returns silently when guild is not in JDA`() {
+        every { jda.getGuildById(guildId) } returns null
+
+        router.sendChannel(guildId, ChannelRouteKey.LEVEL_UP, message = builder)
+
+        verify(exactly = 0) { primaryChannel.sendMessage(any<MessageCreateData>()) }
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/notify/WebDuelOfferNotifierTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/notify/WebDuelOfferNotifierTest.kt
@@ -11,7 +11,7 @@ import io.mockk.verify
 import net.dv8tion.jda.api.components.MessageTopLevelComponent
 import net.dv8tion.jda.api.entities.Message
 import net.dv8tion.jda.api.entities.MessageEmbed
-import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel
+import net.dv8tion.jda.api.entities.channel.unions.MessageChannelUnion
 import net.dv8tion.jda.api.requests.restaction.MessageEditAction
 import net.dv8tion.jda.api.utils.messages.MessageCreateData
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -114,7 +114,7 @@ class WebDuelOfferNotifierTest {
 
     @Test
     fun `cleanup edits the message with the timeout embed when the offer is still pending`() {
-        val channel: MessageChannel = mockk(relaxed = true)
+        val channel: MessageChannelUnion = mockk(relaxed = true)
         val onSent = slot<(Message) -> Unit>()
         every { router.sendChannel(any(), any(), any(), any(), capture(onSent)) } just runs
         notifier.on(event())
@@ -142,7 +142,7 @@ class WebDuelOfferNotifierTest {
 
     @Test
     fun `cleanup is a no-op when the offer was already accepted or declined`() {
-        val channel: MessageChannel = mockk(relaxed = true)
+        val channel: MessageChannelUnion = mockk(relaxed = true)
         val onSent = slot<(Message) -> Unit>()
         every { router.sendChannel(any(), any(), any(), any(), capture(onSent)) } just runs
         notifier.on(event())
@@ -158,7 +158,7 @@ class WebDuelOfferNotifierTest {
 
     @Test
     fun `cleanup swallows JDA exceptions so a failing edit does not kill the scheduler thread`() {
-        val channel: MessageChannel = mockk(relaxed = true)
+        val channel: MessageChannelUnion = mockk(relaxed = true)
         val onSent = slot<(Message) -> Unit>()
         every { router.sendChannel(any(), any(), any(), any(), capture(onSent)) } just runs
         notifier.on(event())
@@ -177,7 +177,7 @@ class WebDuelOfferNotifierTest {
         capturedTasks[0].run()
     }
 
-    private fun fakeSentMessage(channelMock: MessageChannel): Message = mockk(relaxed = true) {
+    private fun fakeSentMessage(channelMock: MessageChannelUnion): Message = mockk(relaxed = true) {
         every { id } returns sentMessageId
         every { channel } returns channelMock
     }

--- a/discord-bot/src/test/kotlin/bot/toby/notify/WebDuelOfferNotifierTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/notify/WebDuelOfferNotifierTest.kt
@@ -1,39 +1,32 @@
 package bot.toby.notify
 
+import common.notification.ChannelRouteKey
 import database.duel.PendingDuelRegistry
 import io.mockk.every
-import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
+import io.mockk.just
 import io.mockk.slot
 import io.mockk.verify
-import net.dv8tion.jda.api.JDA
-import net.dv8tion.jda.api.Permission
 import net.dv8tion.jda.api.components.MessageTopLevelComponent
-import net.dv8tion.jda.api.components.actionrow.ActionRow
-import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.entities.Message
 import net.dv8tion.jda.api.entities.MessageEmbed
-import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
-import net.dv8tion.jda.api.requests.restaction.MessageCreateAction
+import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel
 import net.dv8tion.jda.api.requests.restaction.MessageEditAction
+import net.dv8tion.jda.api.utils.messages.MessageCreateData
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.Assertions.assertEquals
 import web.event.WebDuelOfferedEvent
 import java.time.Duration
 import java.time.Instant
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
-import java.util.function.Consumer
 
 class WebDuelOfferNotifierTest {
 
-    private lateinit var jda: JDA
+    private lateinit var router: NotificationRouter
     private lateinit var pendingDuelRegistry: PendingDuelRegistry
-    private lateinit var guild: Guild
-    private lateinit var channel: TextChannel
-    private lateinit var createAction: MessageCreateAction
     private lateinit var scheduler: ScheduledExecutorService
     private lateinit var notifier: WebDuelOfferNotifier
 
@@ -52,20 +45,14 @@ class WebDuelOfferNotifierTest {
         stake = stake
     )
 
-    // Test scheduler that captures scheduled runnables so individual cases
-    // can fire (or skip) the TTL cleanup deterministically — much faster
-    // than waiting 3 minutes of wall-clock TTL.
     private val capturedTasks = mutableListOf<Runnable>()
     private val capturedDelays = mutableListOf<Long>()
 
     @BeforeEach
     fun setup() {
-        jda = mockk(relaxed = true)
+        router = mockk(relaxed = true)
         pendingDuelRegistry = mockk(relaxed = true)
         every { pendingDuelRegistry.ttl } returns Duration.ofMinutes(3)
-        guild = mockk(relaxed = true)
-        channel = mockk(relaxed = true)
-        createAction = mockk(relaxed = true)
         scheduler = mockk(relaxed = true)
         capturedTasks.clear()
         capturedDelays.clear()
@@ -76,71 +63,48 @@ class WebDuelOfferNotifierTest {
             capturedDelays.add(secondArg<Long>())
             mockk(relaxed = true)
         }
-
-        every { jda.getGuildById(guildId) } returns guild
-        every { guild.systemChannel } returns channel
-        every { guild.selfMember.hasPermission(channel, *anyVararg<Permission>()) } returns true
-        every { channel.sendMessageEmbeds(any<MessageEmbed>()) } returns createAction
-        every { createAction.addContent(any()) } returns createAction
-        every { createAction.addComponents(any<ActionRow>()) } returns createAction
-        notifier = WebDuelOfferNotifier(jda, pendingDuelRegistry, scheduler)
-    }
-
-    private fun fakeSentMessage(): Message = mockk(relaxed = true) {
-        every { id } returns sentMessageId
+        notifier = WebDuelOfferNotifier(router, pendingDuelRegistry, scheduler)
     }
 
     @Test
-    fun `happy path posts the embed and chains addContent for the opponent ping`() {
+    fun `on routes the offer to SYSTEM with an onSent callback`() {
         notifier.on(event())
 
-        verify(exactly = 1) { channel.sendMessageEmbeds(any<MessageEmbed>()) }
-        verify(exactly = 1) { createAction.addContent("<@$opponentId>") }
+        verify(exactly = 1) {
+            router.sendChannel(
+                guildId = guildId,
+                route = ChannelRouteKey.SYSTEM,
+                originChannelId = null,
+                message = any(),
+                onSent = any(),
+            )
+        }
     }
 
     @Test
-    fun `skips when bot is not in the guild`() {
-        every { jda.getGuildById(guildId) } returns null
+    fun `the built MessageCreateData carries the opponent ping in content`() {
+        val builder = slot<() -> MessageCreateData>()
+        every { router.sendChannel(any(), any(), any(), capture(builder), any()) } just runs
 
         notifier.on(event())
 
-        verify(exactly = 0) { channel.sendMessageEmbeds(any<MessageEmbed>()) }
+        val data = builder.captured.invoke()
+        assertEquals(1, data.embeds.size, "embed should be present")
+        assert(data.content.contains("<@$opponentId>")) {
+            "Opponent mention must live in setContent, not the embed"
+        }
+        assertEquals(1, data.components.size, "ActionRow with Accept/Decline must be attached")
     }
 
     @Test
-    fun `skips when guild has no system channel`() {
-        every { guild.systemChannel } returns null
+    fun `onSent callback schedules a TTL-aligned cleanup task`() {
+        val onSent = slot<(Message) -> Unit>()
+        every { router.sendChannel(any(), any(), any(), any(), capture(onSent)) } just runs
 
         notifier.on(event())
+        val sent = fakeSentMessage(channelMock = mockk(relaxed = true))
+        onSent.captured.invoke(sent)
 
-        verify(exactly = 0) { channel.sendMessageEmbeds(any<MessageEmbed>()) }
-    }
-
-    @Test
-    fun `skips when bot lacks permission on the system channel`() {
-        every { guild.selfMember.hasPermission(channel, *anyVararg<Permission>()) } returns false
-
-        notifier.on(event())
-
-        verify(exactly = 0) { channel.sendMessageEmbeds(any<MessageEmbed>()) }
-    }
-
-    // Capture the .queue { sent -> ... } callback so we can invoke it
-    // with a fake sent message and drive the cleanup branch.
-    private fun fireSendCallbackWithMessage(): Message {
-        val callback = slot<Consumer<Message>>()
-        every { createAction.queue(capture(callback)) } just runs
-        notifier.on(event())
-        val sent = fakeSentMessage()
-        callback.captured.accept(sent)
-        return sent
-    }
-
-    @Test
-    fun `schedules a TTL-aligned cleanup task once the message is sent`() {
-        fireSendCallbackWithMessage()
-
-        // One task, scheduled at the registry's configured TTL (3 minutes).
         assertEquals(1, capturedTasks.size)
         assertEquals(Duration.ofMinutes(3).toMillis(), capturedDelays[0])
         verify(exactly = 1) {
@@ -150,13 +114,18 @@ class WebDuelOfferNotifierTest {
 
     @Test
     fun `cleanup edits the message with the timeout embed when the offer is still pending`() {
-        fireSendCallbackWithMessage()
+        val channel: MessageChannel = mockk(relaxed = true)
+        val onSent = slot<(Message) -> Unit>()
+        every { router.sendChannel(any(), any(), any(), any(), capture(onSent)) } just runs
+        notifier.on(event())
+        val sent = fakeSentMessage(channelMock = channel)
+        onSent.captured.invoke(sent)
+
         val pending = PendingDuelRegistry.PendingDuel(
             id = duelId, guildId = guildId,
             initiatorDiscordId = initiatorId, opponentDiscordId = opponentId,
             stake = stake, createdAt = Instant.now()
         )
-        // Win the race — registry hands us the offer.
         every { pendingDuelRegistry.cancel(duelId) } returns pending
 
         val editAction = mockk<MessageEditAction>(relaxed = true)
@@ -173,8 +142,12 @@ class WebDuelOfferNotifierTest {
 
     @Test
     fun `cleanup is a no-op when the offer was already accepted or declined`() {
-        fireSendCallbackWithMessage()
-        // Lose the race — accept/decline already removed the offer.
+        val channel: MessageChannel = mockk(relaxed = true)
+        val onSent = slot<(Message) -> Unit>()
+        every { router.sendChannel(any(), any(), any(), any(), capture(onSent)) } just runs
+        notifier.on(event())
+        onSent.captured.invoke(fakeSentMessage(channelMock = channel))
+
         every { pendingDuelRegistry.cancel(duelId) } returns null
 
         capturedTasks[0].run()
@@ -184,21 +157,28 @@ class WebDuelOfferNotifierTest {
     }
 
     @Test
-    fun `cleanup swallows JDA exceptions so a failing edit does not propagate`() {
-        fireSendCallbackWithMessage()
-        val pending = PendingDuelRegistry.PendingDuel(
+    fun `cleanup swallows JDA exceptions so a failing edit does not kill the scheduler thread`() {
+        val channel: MessageChannel = mockk(relaxed = true)
+        val onSent = slot<(Message) -> Unit>()
+        every { router.sendChannel(any(), any(), any(), any(), capture(onSent)) } just runs
+        notifier.on(event())
+        onSent.captured.invoke(fakeSentMessage(channelMock = channel))
+
+        every { pendingDuelRegistry.cancel(duelId) } returns PendingDuelRegistry.PendingDuel(
             id = duelId, guildId = guildId,
             initiatorDiscordId = initiatorId, opponentDiscordId = opponentId,
             stake = stake, createdAt = Instant.now()
         )
-        every { pendingDuelRegistry.cancel(duelId) } returns pending
-        // editMessageEmbedsById throws — could happen if the message was
-        // deleted, the bot lost permission, or the channel went away.
         every {
             channel.editMessageEmbedsById(sentMessageId, any<MessageEmbed>())
         } throws RuntimeException("kapow")
 
-        // Should not propagate — the scheduler thread would otherwise die.
+        // Must not propagate — scheduler thread would die otherwise.
         capturedTasks[0].run()
+    }
+
+    private fun fakeSentMessage(channelMock: MessageChannel): Message = mockk(relaxed = true) {
+        every { id } returns sentMessageId
+        every { channel } returns channelMock
     }
 }

--- a/discord-bot/src/test/kotlin/bot/toby/notify/WebTipNotifierTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/notify/WebTipNotifierTest.kt
@@ -1,24 +1,22 @@
 package bot.toby.notify
 
+import common.notification.ChannelRouteKey
+import io.mockk.CapturingSlot
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
 import io.mockk.verify
-import net.dv8tion.jda.api.JDA
-import net.dv8tion.jda.api.Permission
-import net.dv8tion.jda.api.entities.Guild
-import net.dv8tion.jda.api.entities.MessageEmbed
-import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
-import net.dv8tion.jda.api.requests.restaction.MessageCreateAction
+import net.dv8tion.jda.api.utils.messages.MessageCreateData
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import web.event.WebTipSentEvent
 
 class WebTipNotifierTest {
 
-    private lateinit var jda: JDA
-    private lateinit var guild: Guild
-    private lateinit var channel: TextChannel
-    private lateinit var createAction: MessageCreateAction
+    private lateinit var router: NotificationRouter
     private lateinit var notifier: WebTipNotifier
 
     private val guildId = 42L
@@ -39,50 +37,43 @@ class WebTipNotifierTest {
 
     @BeforeEach
     fun setup() {
-        jda = mockk(relaxed = true)
-        guild = mockk(relaxed = true)
-        channel = mockk(relaxed = true)
-        createAction = mockk(relaxed = true)
-        every { jda.getGuildById(guildId) } returns guild
-        every { guild.systemChannel } returns channel
-        every { guild.selfMember.hasPermission(channel, *anyVararg<Permission>()) } returns true
-        every { channel.sendMessageEmbeds(any<MessageEmbed>()) } returns createAction
-        every { createAction.addContent(any()) } returns createAction
-        notifier = WebTipNotifier(jda)
+        router = mockk(relaxed = true)
+        notifier = WebTipNotifier(router)
     }
 
     @Test
-    fun `happy path posts the embed and chains addContent for the recipient ping`() {
+    fun `on routes to SYSTEM with the correct guildId`() {
         notifier.on(event())
 
-        verify(exactly = 1) { channel.sendMessageEmbeds(any<MessageEmbed>()) }
-        verify(exactly = 1) { createAction.addContent("<@$recipientId>") }
+        verify(exactly = 1) {
+            router.sendChannel(
+                guildId = guildId,
+                route = ChannelRouteKey.SYSTEM,
+                originChannelId = null,
+                message = any(),
+                onSent = null,
+            )
+        }
     }
 
     @Test
-    fun `skips when bot is not in the guild`() {
-        every { jda.getGuildById(guildId) } returns null
+    fun `the lazy message includes the recipient ping in content (not the embed)`() {
+        val builder = slot<() -> MessageCreateData>()
+        every {
+            router.sendChannel(any(), any(), any(), capture(builder), any())
+        } answers { }
 
         notifier.on(event())
 
-        verify(exactly = 0) { channel.sendMessageEmbeds(any<MessageEmbed>()) }
-    }
-
-    @Test
-    fun `skips when guild has no system channel`() {
-        every { guild.systemChannel } returns null
-
-        notifier.on(event())
-
-        verify(exactly = 0) { channel.sendMessageEmbeds(any<MessageEmbed>()) }
-    }
-
-    @Test
-    fun `skips when bot lacks permission on the system channel`() {
-        every { guild.selfMember.hasPermission(channel, *anyVararg<Permission>()) } returns false
-
-        notifier.on(event())
-
-        verify(exactly = 0) { channel.sendMessageEmbeds(any<MessageEmbed>()) }
+        // Force the lazy lambda; the router does this once the channel
+        // resolves. We're verifying the build output independently.
+        val data: MessageCreateData = builder.captured.invoke()
+        assertNotNull(data)
+        assertTrue(
+            data.content.contains("<@$recipientId>"),
+            "Recipient mention must live in setContent, not the embed; embed-mentions don't ping."
+        )
+        // Embed is also present.
+        assertEquals(1, data.embeds.size)
     }
 }

--- a/discord-bot/src/test/kotlin/bot/toby/scheduling/LotteryAnnouncerTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/scheduling/LotteryAnnouncerTest.kt
@@ -1,19 +1,20 @@
 package bot.toby.scheduling
 
+import bot.toby.notify.NotificationRouter
+import common.notification.ChannelRouteKey
 import database.dto.ConfigDto
 import database.dto.JackpotLotteryDto
 import database.service.ConfigService
 import database.service.JackpotLotteryService
-import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
+import io.mockk.runs
 import io.mockk.slot
 import io.mockk.verify
-import net.dv8tion.jda.api.components.MessageTopLevelComponent
 import net.dv8tion.jda.api.EmbedBuilder
 import net.dv8tion.jda.api.JDA
-import net.dv8tion.jda.api.Permission
+import net.dv8tion.jda.api.components.MessageTopLevelComponent
 import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.entities.Message
 import net.dv8tion.jda.api.entities.MessageEmbed
@@ -23,8 +24,9 @@ import net.dv8tion.jda.api.exceptions.ErrorResponseException
 import net.dv8tion.jda.api.interactions.commands.Command
 import net.dv8tion.jda.api.requests.ErrorResponse
 import net.dv8tion.jda.api.requests.RestAction
-import net.dv8tion.jda.api.requests.restaction.MessageCreateAction
 import net.dv8tion.jda.api.requests.restaction.MessageEditAction
+import net.dv8tion.jda.api.utils.messages.MessageCreateData
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
@@ -32,72 +34,59 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 /**
- * The announcer is a thin shim — most surface is channel resolution +
- * embed shape, with a single side-effect (channel.sendMessageEmbeds).
- * Tests focus on:
- *   - Resolution chain: LOTTERY_CHANNEL → LEADERBOARD_CHANNEL → system
- *   - Embed body: per-PriorOutcome variant produces distinct copy
- *   - Content: wide ping prefix from LOTTERY_PING_MODE (off / here /
- *     everyone), CTA with `/lottery buy` mention, winner pings
- *   - AllowedMentions: USER always, EVERYONE only when content has the
- *     wide ping (otherwise Discord silently strips it)
- *   - No-op when no writable channel resolves
+ * After the routing refactor, `announceCycle` delegates channel
+ * resolution + dispatch to `NotificationRouter.sendChannel`. The
+ * announcer's job shrinks to:
+ *   - building the embed
+ *   - assembling the content (wide ping prefix + CTA + winner pings)
+ *   - setting allowed-mention types so the wide ping isn't stripped
+ *   - assembling the action-row component
+ *   - capturing the sent message via the router's onSent callback so
+ *     [JackpotLotteryService.recordAnnouncement] persists the message
+ *     id for [LotteryAnnouncer.refreshAnnouncement] to edit later.
+ *
+ * Channel resolution itself (LOTTERY → LEADERBOARD → system) is now
+ * covered by `NotificationRouterChannelTest`.
  */
 class LotteryAnnouncerTest {
 
     private val guildId = 100L
     private lateinit var configService: ConfigService
     private lateinit var jackpotLotteryService: JackpotLotteryService
+    private lateinit var router: NotificationRouter
     private lateinit var guild: Guild
     private lateinit var jda: JDA
     private lateinit var bot: SelfMember
     private lateinit var channel: TextChannel
-    private lateinit var sendAction: MessageCreateAction
     private lateinit var announcer: LotteryAnnouncer
 
     @BeforeEach
     fun setup() {
         configService = mockk(relaxed = true)
         jackpotLotteryService = mockk(relaxed = true)
+        router = mockk(relaxed = true)
         guild = mockk(relaxed = true)
         jda = mockk(relaxed = true)
         bot = mockk(relaxed = true)
         channel = mockk(relaxed = true)
-        sendAction = mockk(relaxed = true)
 
         every { guild.idLong } returns guildId
         every { guild.id } returns guildId.toString()
         every { guild.name } returns "Test Guild"
         every { guild.selfMember } returns bot
         every { guild.jda } returns jda
-        // Slash-command id resolution: stub the full chain to return an
-        // empty command list so `firstOrNull { name == "lottery" }` is
-        // null and the announcer falls back to plain `/lottery buy` text.
-        // Using an explicit stub rather than `throws` because mockk's
-        // handling of default interface methods (retrieveCommands has a
-        // default impl) can vary between versions.
+        every { channel.idLong } returns 777L
+        // Slash-command id resolution: stub to empty → announcer falls
+        // back to plain `/lottery buy` text. mockk's default-interface-method
+        // handling can vary; an explicit stub is the safest.
         val restAction: RestAction<List<Command>> = mockk(relaxed = true)
         every { jda.retrieveCommands() } returns restAction
         every { restAction.complete() } returns emptyList()
-        every { bot.hasPermission(channel, *anyVararg<Permission>()) } returns true
-        every { channel.id } returns "777"
-        every { channel.idLong } returns 777L
-        every { channel.sendMessageEmbeds(any<MessageEmbed>()) } returns sendAction
-        every { sendAction.addContent(any()) } returns sendAction
-        every { sendAction.setAllowedMentions(any<Collection<Message.MentionType>>()) } returns sendAction
-        every { sendAction.queue() } just Runs
-        // The two-callback `queue(success, failure)` overload is used by
-        // [LotteryAnnouncer.announceCycle] to capture the posted message
-        // id; tests don't drive the success path so a no-op stub keeps
-        // verification on `channel.sendMessageEmbeds` working unchanged.
-        every {
-            sendAction.queue(any<java.util.function.Consumer<Message>>(), any())
-        } just Runs
 
-        announcer = LotteryAnnouncer(configService, jackpotLotteryService)
+        announcer = LotteryAnnouncer(configService, jackpotLotteryService, router)
     }
 
-    private fun stubChannelConfig(key: ConfigDto.Configurations, value: String?) {
+    private fun stubConfig(key: ConfigDto.Configurations, value: String?) {
         every {
             configService.getConfigByName(key.configValue, guildId.toString())
         } returns value?.let {
@@ -105,88 +94,87 @@ class LotteryAnnouncerTest {
         }
     }
 
-    // ---- channel resolution ----
+    /** Capture the lazy message-builder the announcer passes to the router. */
+    private fun captureMessageBuilder(): () -> MessageCreateData {
+        val builder = slot<() -> MessageCreateData>()
+        every {
+            router.sendChannel(any(), any(), any(), capture(builder), any())
+        } just runs
+        return { builder.captured.invoke() }
+    }
+
+    // ---- routing ----
 
     @Test
-    fun `resolves LOTTERY_CHANNEL first when set and writable`() {
-        stubChannelConfig(ConfigDto.Configurations.LOTTERY_CHANNEL, "777")
-        every { guild.getTextChannelById(777L) } returns channel
+    fun `announceCycle routes through the LOTTERY ChannelRouteKey`() {
+        captureMessageBuilder()
 
         announcer.announceCycle(
-            guild,
-            mode = "WEIGHTED",
-            priorOutcome = LotteryAnnouncer.PriorOutcome.NoTickets,
-            openOutcome = LotteryAnnouncer.OpenSummary.Ok(
-                seeded = 1_000L, ticketPrice = 50L, poolAmount = 1_000L,
-            ),
+            guild, mode = "WEIGHTED",
+            priorOutcome = null,
+            openOutcome = LotteryAnnouncer.OpenSummary.Skipped,
         )
 
-        verify(exactly = 1) { channel.sendMessageEmbeds(any<MessageEmbed>()) }
-        // Not even consulted — LOTTERY_CHANNEL hit.
-        verify(exactly = 0) {
-            configService.getConfigByName(
-                ConfigDto.Configurations.LEADERBOARD_CHANNEL.configValue, guildId.toString()
+        verify(exactly = 1) {
+            router.sendChannel(
+                guildId = guildId,
+                route = ChannelRouteKey.LOTTERY,
+                originChannelId = null,
+                message = any(),
+                onSent = any(),
             )
         }
     }
 
     @Test
-    fun `falls back to LEADERBOARD_CHANNEL when LOTTERY_CHANNEL is missing`() {
-        stubChannelConfig(ConfigDto.Configurations.LOTTERY_CHANNEL, null)
-        stubChannelConfig(ConfigDto.Configurations.LEADERBOARD_CHANNEL, "888")
-        every { guild.getTextChannelById(888L) } returns channel
+    fun `recordAnnouncement is called via onSent with the lottery id and sent message`() {
+        val onSent = slot<(Message) -> Unit>()
+        every { router.sendChannel(any(), any(), any(), any(), capture(onSent)) } just runs
 
         announcer.announceCycle(
-            guild, mode = "NUMBER_MATCH",
+            guild, mode = "WEIGHTED",
             priorOutcome = null,
             openOutcome = LotteryAnnouncer.OpenSummary.Ok(
-                seeded = 500L, ticketPrice = 50L, poolAmount = 500L,
+                lotteryId = 42L, seeded = 500L, ticketPrice = 50L, poolAmount = 500L,
             ),
         )
+        // Simulate the router successfully posting.
+        val sent = mockk<Message>(relaxed = true) {
+            every { idLong } returns 9999L
+            every { channel } returns mockk(relaxed = true) { every { idLong } returns 777L }
+        }
+        onSent.captured.invoke(sent)
 
-        verify(exactly = 1) { channel.sendMessageEmbeds(any<MessageEmbed>()) }
+        verify(exactly = 1) {
+            jackpotLotteryService.recordAnnouncement(
+                lotteryId = 42L,
+                channelId = 777L,
+                messageId = 9999L,
+                pool = 500L,
+            )
+        }
     }
 
     @Test
-    fun `falls back to system channel when neither config resolves`() {
-        stubChannelConfig(ConfigDto.Configurations.LOTTERY_CHANNEL, null)
-        stubChannelConfig(ConfigDto.Configurations.LEADERBOARD_CHANNEL, null)
-        every { guild.systemChannel } returns channel
+    fun `onSent skips recordAnnouncement when openOutcome is Skipped`() {
+        val onSent = slot<(Message) -> Unit>()
+        every { router.sendChannel(any(), any(), any(), any(), capture(onSent)) } just runs
 
         announcer.announceCycle(
             guild, mode = "WEIGHTED",
             priorOutcome = null,
             openOutcome = LotteryAnnouncer.OpenSummary.Skipped,
         )
+        onSent.captured.invoke(mockk(relaxed = true))
 
-        verify(exactly = 1) { channel.sendMessageEmbeds(any<MessageEmbed>()) }
-    }
-
-    @Test
-    fun `no-op when no writable channel resolves`() {
-        stubChannelConfig(ConfigDto.Configurations.LOTTERY_CHANNEL, null)
-        stubChannelConfig(ConfigDto.Configurations.LEADERBOARD_CHANNEL, null)
-        every { guild.systemChannel } returns null
-
-        announcer.announceCycle(
-            guild, mode = "WEIGHTED",
-            priorOutcome = null,
-            openOutcome = LotteryAnnouncer.OpenSummary.Skipped,
-        )
-
-        verify(exactly = 0) { channel.sendMessageEmbeds(any<MessageEmbed>()) }
+        verify(exactly = 0) { jackpotLotteryService.recordAnnouncement(any(), any(), any(), any()) }
     }
 
     // ---- embed body + pings ----
 
     @Test
-    fun `weighted draw mentions every winner and pings them in addContent`() {
-        stubChannelConfig(ConfigDto.Configurations.LOTTERY_CHANNEL, "777")
-        every { guild.getTextChannelById(777L) } returns channel
-        val embedSlot = slot<MessageEmbed>()
-        val contentSlot = slot<String>()
-        every { channel.sendMessageEmbeds(capture(embedSlot)) } returns sendAction
-        every { sendAction.addContent(capture(contentSlot)) } returns sendAction
+    fun `weighted draw mentions every winner in both embed and content`() {
+        val build = captureMessageBuilder()
 
         val payouts = listOf(
             JackpotLotteryService.WinnerPayout(discordId = 1L, ticketCount = 5, amount = 500L),
@@ -202,21 +190,17 @@ class LotteryAnnouncerTest {
             ),
         )
 
-        val embedDescription = embedSlot.captured.fields.joinToString(" ") { (it.value ?: "") }
+        val data = build()
+        val embedDescription = data.embeds.single().fields.joinToString(" ") { (it.value ?: "") }
         assertTrue(embedDescription.contains("<@1>"), "embed body mentions winner 1")
         assertTrue(embedDescription.contains("<@2>"), "embed body mentions winner 2")
-        assertTrue(contentSlot.captured.contains("<@1>"), "addContent pings winner 1")
-        assertTrue(contentSlot.captured.contains("<@2>"), "addContent pings winner 2")
+        assertTrue(data.content.contains("<@1>"), "content pings winner 1")
+        assertTrue(data.content.contains("<@2>"), "content pings winner 2")
     }
 
     @Test
     fun `BelowMinBuyers shows have-need copy and still posts CTA + wide ping`() {
-        stubChannelConfig(ConfigDto.Configurations.LOTTERY_CHANNEL, "777")
-        every { guild.getTextChannelById(777L) } returns channel
-        val embedSlot = slot<MessageEmbed>()
-        val contentSlot = slot<String>()
-        every { channel.sendMessageEmbeds(capture(embedSlot)) } returns sendAction
-        every { sendAction.addContent(capture(contentSlot)) } returns sendAction
+        val build = captureMessageBuilder()
 
         announcer.announceCycle(
             guild, mode = "WEIGHTED",
@@ -226,25 +210,19 @@ class LotteryAnnouncerTest {
             ),
         )
 
-        val embedDescription = embedSlot.captured.fields.joinToString(" ") { (it.value ?: "") }
+        val data = build()
+        val embedDescription = data.embeds.single().fields.joinToString(" ") { (it.value ?: "") }
         assertTrue(embedDescription.contains("1") && embedDescription.contains("2"))
         assertTrue(embedDescription.lowercase().contains("buyer"))
-        // Default ping mode = EVERYONE → wide ping + CTA still goes out
-        // (this is exactly the case where we want to nudge people to buy).
-        assertTrue(contentSlot.captured.contains("@everyone"))
-        assertTrue(contentSlot.captured.contains("/lottery buy"))
-        // No winners → no per-winner mention line.
-        assertFalse(contentSlot.captured.contains("Congrats:"))
+        // Default ping mode = EVERYONE.
+        assertTrue(data.content.contains("@everyone"))
+        assertTrue(data.content.contains("/lottery buy"))
+        assertFalse(data.content.contains("Congrats:"))
     }
 
     @Test
     fun `NoTickets renders a distinct copy and still posts CTA + wide ping`() {
-        stubChannelConfig(ConfigDto.Configurations.LOTTERY_CHANNEL, "777")
-        every { guild.getTextChannelById(777L) } returns channel
-        val embedSlot = slot<MessageEmbed>()
-        val contentSlot = slot<String>()
-        every { channel.sendMessageEmbeds(capture(embedSlot)) } returns sendAction
-        every { sendAction.addContent(capture(contentSlot)) } returns sendAction
+        val build = captureMessageBuilder()
 
         announcer.announceCycle(
             guild, mode = "NUMBER_MATCH",
@@ -254,22 +232,20 @@ class LotteryAnnouncerTest {
             ),
         )
 
-        val embedDescription = embedSlot.captured.fields.joinToString(" ") { (it.value ?: "") }
+        val data = build()
+        val embedDescription = data.embeds.single().fields.joinToString(" ") { (it.value ?: "") }
         assertTrue(embedDescription.lowercase().contains("no tickets"))
-        assertTrue(contentSlot.captured.contains("@everyone"))
-        assertTrue(contentSlot.captured.contains("/lottery buy"))
-        assertFalse(contentSlot.captured.contains("Congrats:"))
+        assertTrue(data.content.contains("@everyone"))
+        assertTrue(data.content.contains("/lottery buy"))
+        assertFalse(data.content.contains("Congrats:"))
     }
 
     // ---- ping-mode dispatch ----
 
     @Test
     fun `PING_MODE=HERE uses @here prefix instead of @everyone`() {
-        stubChannelConfig(ConfigDto.Configurations.LOTTERY_CHANNEL, "777")
-        stubChannelConfig(ConfigDto.Configurations.LOTTERY_PING_MODE, "HERE")
-        every { guild.getTextChannelById(777L) } returns channel
-        val contentSlot = slot<String>()
-        every { sendAction.addContent(capture(contentSlot)) } returns sendAction
+        stubConfig(ConfigDto.Configurations.LOTTERY_PING_MODE, "HERE")
+        val build = captureMessageBuilder()
 
         announcer.announceCycle(
             guild, mode = "WEIGHTED",
@@ -279,17 +255,15 @@ class LotteryAnnouncerTest {
             ),
         )
 
-        assertTrue(contentSlot.captured.contains("@here"))
-        assertFalse(contentSlot.captured.contains("@everyone"))
+        val data = build()
+        assertTrue(data.content.contains("@here"))
+        assertFalse(data.content.contains("@everyone"))
     }
 
     @Test
     fun `PING_MODE=OFF still posts CTA but no wide ping`() {
-        stubChannelConfig(ConfigDto.Configurations.LOTTERY_CHANNEL, "777")
-        stubChannelConfig(ConfigDto.Configurations.LOTTERY_PING_MODE, "OFF")
-        every { guild.getTextChannelById(777L) } returns channel
-        val contentSlot = slot<String>()
-        every { sendAction.addContent(capture(contentSlot)) } returns sendAction
+        stubConfig(ConfigDto.Configurations.LOTTERY_PING_MODE, "OFF")
+        val build = captureMessageBuilder()
 
         announcer.announceCycle(
             guild, mode = "WEIGHTED",
@@ -299,18 +273,16 @@ class LotteryAnnouncerTest {
             ),
         )
 
-        assertFalse(contentSlot.captured.contains("@everyone"))
-        assertFalse(contentSlot.captured.contains("@here"))
-        assertTrue(contentSlot.captured.contains("/lottery buy"))
+        val data = build()
+        assertFalse(data.content.contains("@everyone"))
+        assertFalse(data.content.contains("@here"))
+        assertTrue(data.content.contains("/lottery buy"))
     }
 
     @Test
     fun `allowed mentions include EVERYONE only when wide ping is in content`() {
-        stubChannelConfig(ConfigDto.Configurations.LOTTERY_CHANNEL, "777")
-        stubChannelConfig(ConfigDto.Configurations.LOTTERY_PING_MODE, "OFF")
-        every { guild.getTextChannelById(777L) } returns channel
-        val mentionsSlot = slot<Collection<Message.MentionType>>()
-        every { sendAction.setAllowedMentions(capture(mentionsSlot)) } returns sendAction
+        stubConfig(ConfigDto.Configurations.LOTTERY_PING_MODE, "OFF")
+        val build = captureMessageBuilder()
 
         announcer.announceCycle(
             guild, mode = "WEIGHTED",
@@ -320,17 +292,15 @@ class LotteryAnnouncerTest {
             ),
         )
 
-        assertTrue(mentionsSlot.captured.contains(Message.MentionType.USER))
-        assertFalse(mentionsSlot.captured.contains(Message.MentionType.EVERYONE))
+        val data = build()
+        assertTrue(data.allowedMentions.contains(Message.MentionType.USER))
+        assertFalse(data.allowedMentions.contains(Message.MentionType.EVERYONE))
     }
 
     @Test
     fun `allowed mentions include EVERYONE when @everyone is in content`() {
-        stubChannelConfig(ConfigDto.Configurations.LOTTERY_CHANNEL, "777")
-        // No PING_MODE set → default EVERYONE.
-        every { guild.getTextChannelById(777L) } returns channel
-        val mentionsSlot = slot<Collection<Message.MentionType>>()
-        every { sendAction.setAllowedMentions(capture(mentionsSlot)) } returns sendAction
+        // No PING_MODE config → default EVERYONE.
+        val build = captureMessageBuilder()
 
         announcer.announceCycle(
             guild, mode = "WEIGHTED",
@@ -340,18 +310,14 @@ class LotteryAnnouncerTest {
             ),
         )
 
-        assertTrue(mentionsSlot.captured.contains(Message.MentionType.EVERYONE))
-        assertTrue(mentionsSlot.captured.contains(Message.MentionType.USER))
+        val data = build()
+        assertTrue(data.allowedMentions.contains(Message.MentionType.EVERYONE))
+        assertTrue(data.allowedMentions.contains(Message.MentionType.USER))
     }
 
     @Test
     fun `match-numbers draw renders winning numbers and per-tier winners`() {
-        stubChannelConfig(ConfigDto.Configurations.LOTTERY_CHANNEL, "777")
-        every { guild.getTextChannelById(777L) } returns channel
-        val embedSlot = slot<MessageEmbed>()
-        val contentSlot = slot<String>()
-        every { channel.sendMessageEmbeds(capture(embedSlot)) } returns sendAction
-        every { sendAction.addContent(capture(contentSlot)) } returns sendAction
+        val build = captureMessageBuilder()
 
         announcer.announceCycle(
             guild, mode = "NUMBER_MATCH",
@@ -368,13 +334,14 @@ class LotteryAnnouncerTest {
             ),
         )
 
-        val embedDescription = embedSlot.captured.fields.joinToString(" ") { (it.value ?: "") }
+        val data = build()
+        val embedDescription = data.embeds.single().fields.joinToString(" ") { (it.value ?: "") }
         assertTrue(embedDescription.contains("3") && embedDescription.contains("42"))
         assertTrue(embedDescription.contains("<@1>"))
-        assertTrue(contentSlot.captured.contains("<@1>"))
+        assertTrue(data.content.contains("<@1>"))
     }
 
-    // ---- refreshAnnouncement ----
+    // ---- refreshAnnouncement (unchanged code path; not routed through NotificationRouter) ----
 
     private fun openLottery(
         id: Long = 1L,
@@ -489,11 +456,6 @@ class LotteryAnnouncerTest {
 
         @Test
         fun `weighted refresh renders the weighted mode label, not the number-match one`() {
-            // Regression: rebuildWithUpdatedTodaysDraw used to pass
-            // lottery.mode (the DTO column value "TICKET_WEIGHTED")
-            // straight to renderOpenSummary, which expects the runtime
-            // constant "WEIGHTED". The comparison fell through and
-            // emitted "Pick 5 of 49" for refreshed weighted draws.
             every { guild.getTextChannelById(777L) } returns channel
 
             val previousEmbed = EmbedBuilder()
@@ -544,12 +506,6 @@ class LotteryAnnouncerTest {
                 todayField.value!!.contains("Pick 5 of 49"),
                 "weighted refresh should not render the number-match label: ${todayField.value}",
             )
-            // Regression: refresh used to pass lottery.mode (the DTO
-            // column "TICKET_WEIGHTED") to announcementActionRow, which
-            // compares against LotteryHelper.MODE_WEIGHTED ("WEIGHTED").
-            // The comparison missed, fell through to the URL-button
-            // branch, and that branch returned null when webBaseUrl was
-            // blank — stripping the "Buy Tickets" button on every refresh.
             assertTrue(
                 componentsSlot.captured.isNotEmpty(),
                 "weighted refresh should preserve the Buy Tickets action row, " +


### PR DESCRIPTION
## Summary

Follow-up to #491. Pulls channel resolution + permission checks out of each notifier and into a single `NotificationRouter.sendChannel(...)` method, gated by a per-route `ChannelRouteKey` enum. Same shape as the existing `sendDm(...)` — one delivery gate per surface, two surfaces (DM, CHANNEL).

Also fixes the latent `INTRO_PROMPT` preference bypass: `IntroNotificationService.promptUserForMusicInfo` used to DM unconditionally; now it honours the per-user opt-out.

## Why

PR #491 introduced `NotificationRouter` but only for DM dispatch. Channel posts (level-up, tip, duel offer, lottery, achievement shoutout) each reimplemented channel resolution + permission checks inline. Adding a new channel-routed kind meant editing five different files. This consolidates that into one place so:

- Admins control channel visibility by setting one config key.
- Adding a new channel-routed kind is one entry in `ChannelRouteKey`.
- A typo on the config-key string fails CI via the new contract test.
- The `INTRO_PROMPT` preference users could opt out of actually does something.

## Design

**`ChannelRouteKey`** (new, in `common/notification`):

```kotlin
enum class ChannelRouteKey(
    val primaryConfigKey: String?,
    val fallbackConfigKeys: List<String> = emptyList(),
    val systemChannelFallback: Boolean = true,
) {
    LEVEL_UP("LEVEL_UP_CHANNEL"),
    LOTTERY("LOTTERY_CHANNEL", listOf("LEADERBOARD_CHANNEL")),
    ACHIEVEMENT_SHOUTOUT("ACHIEVEMENT_ANNOUNCE_CHANNEL", systemChannelFallback = false),
    SYSTEM(primaryConfigKey = null),
}
```

Strings (not enum refs) so `common` doesn't pull `database.dto`. New `:database`-side `ChannelRouteKeyConfigKeyContractTest` asserts every string resolves to a real `ConfigDto.Configurations` value.

**`NotificationRouter.sendChannel`** (new):

```kotlin
fun sendChannel(
    guildId: Long,
    route: ChannelRouteKey,
    originChannelId: Long? = null,
    message: () -> MessageCreateData,
    onSent: ((Message) -> Unit)? = null,
)
```

Resolution: `primaryConfigKey` → each `fallbackConfigKey` → `originChannelId` → `systemChannel` (if route allows). Skips channels missing `MESSAGE_SEND` + `MESSAGE_EMBED_LINKS`. Non-blocking `.queue(success, failure)`. `onSent` lets callers track the sent message (used by `LotteryAnnouncer.recordAnnouncement` and `WebDuelOfferNotifier.scheduleTimeoutCleanup`). Channel routing does **not** consult `UserNotificationPrefService` — admins disable by clearing the config key.

## Migrations

Each notifier loses inline channel-resolution and becomes a pure content-builder:

| File | Change |
|---|---|
| `LevelUpListener` | Drops `resolveAnnouncementChannel`, `ConfigService` injection. Builds embed inside the lambda. |
| `WebTipNotifier` | Drops `jda` + `resolveChannel`. Recipient ping moves to `MessageCreateBuilder.setContent`. |
| `WebDuelOfferNotifier` | Captures sent Message via `onSent` callback; TTL cleanup keeps editing the same message. Buttons + ping fold into the lambda. |
| `LotteryAnnouncer.announceCycle` | Drops `resolveChannel` + `REQUIRED_PERMS`. Wide-ping mode (`@here` / `@everyone`), per-winner pings, action row, and allowedMentions stay in the lambda. `recordAnnouncement` runs in `onSent`. `refreshAnnouncement` is unchanged — it edits the existing message via JDA directly and isn't a routing concern. |
| `AchievementEventHandler.postPublicShoutout` | Drops `jda` + `configService` + `Permission` imports. |
| `IntroNotificationService.promptUserForMusicInfo` | Injects `UserNotificationPrefService` (nullable + default-null for legacy positional test constructors). Early-returns when the user is opted out. |

## Tests

**New**:
- `NotificationRouterChannelTest` — resolution chain, permission gates, no-pref-check for channel routing, `onSent` dispatch, system-fallback toggle, silent no-op when nothing resolves.
- `IntroNotificationServiceOptOutTest` — opt-out skips both the DM and the `EventWaiter` setup.
- `ChannelRouteKeyConfigKeyContractTest` (in `:database`) — every config-key string on every route resolves to a real `ConfigDto.Configurations` entry. Typo → CI failure.

**Rewritten for the new shape**:
- `LevelUpListenerTest` — verifies `router.sendChannel` call with `LEVEL_UP` route + origin-channel passthrough; multi-case tier/colour checks capture the lazy message builder via mockk `answers`.
- `WebTipNotifierTest` — single `SYSTEM` route call + recipient ping in `setContent`.
- `WebDuelOfferNotifierTest` — `onSent` callback drives TTL cleanup; pending-still / already-resolved / JDA-throws branches preserved.
- `LotteryAnnouncerTest` — channel-resolution suite removed (now covered by `NotificationRouterChannelTest`); `announceCycle` suite rewritten to inspect the lazy message builder; `refreshAnnouncement` nested class untouched.

## Test plan

- [x] `./gradlew :common:test :database:test :web:test` — green locally.
- [ ] `:discord-bot:test` — blocked-Maven sandbox can't compile; CI will exercise it. Patterns mirror the existing notifier shape exactly.
- [ ] Manual smoke after merge:
  - Level-up announcement still posts to the configured channel (and falls back to origin / system as before).
  - `/tip` web flow still pings the recipient via system channel.
  - `/duel` web flow still ships buttons + edits to a timeout embed after TTL.
  - Daily lottery still wide-pings (`@here` / `@everyone` per `LOTTERY_PING_MODE`) and tracks announcement message id for refresh.
  - Achievement shoutout posts only when `ACHIEVEMENT_ANNOUNCE_CHANNEL` is set (no system-channel fallback).
  - First-time voice-join intro prompt is silent for users who ran `/notify set INTRO_PROMPT off`.

## Deferred

- Push surface — no interface, no stub, as agreed.
- Per-surface user opt-ins ("DM not channel for X") — `UserNotificationPrefService` rows stay per-kind; channel posts remain admin-controlled.
- `LotteryAnnouncer` wide-ping mode generalisation (move ping-mode into the router) — per-guild ping config stays in the announcer's content builder.
- `blackjack_natural` achievement hookup — separate concern, separate PR.

https://claude.ai/code/session_01P22xNb3zH5YD1na98E4cxK

---
_Generated by [Claude Code](https://claude.ai/code/session_01P22xNb3zH5YD1na98E4cxK)_