### PR TITLE
feat(web): surface settings + notification preferences in navbar

### DIFF
--- a/web/src/main/resources/templates/fragments/navbar.html
+++ b/web/src/main/resources/templates/fragments/navbar.html
@@ -68,12 +68,19 @@
                 <span aria-hidden="true">&#9734;</span>
                 <span>Set default server</span>
             </a>
+            <a href="/preferences"
+               class="nav-default-guild"
+               title="Account settings &amp; notification preferences">
+                <span aria-hidden="true">&#9881;&#65039;</span>
+                <span>Settings</span>
+            </a>
         </div>
 
         <div class="nav-section">
             <div class="nav-section-eyebrow">Main</div>
             <a class="nav-item" href="/profile/guilds"><span class="nav-item-icon" aria-hidden="true">&#128100;</span><span>Profile</span></a>
             <a class="nav-item" href="/leaderboards"><span class="nav-item-icon" aria-hidden="true">&#127942;</span><span>Leaderboards</span></a>
+            <a th:if="${username != null}" class="nav-item" href="/preferences/notifications"><span class="nav-item-icon" aria-hidden="true">&#128276;</span><span>Notifications</span></a>
         </div>
 
         <div class="nav-section">


### PR DESCRIPTION
## Summary

The notification-preferences feature shipped end-to-end in #491/#493 (backend service, REST endpoints in `EngagementApiController`, MVC controller, templates, JS), but the only navbar path to `/preferences` was the small default-server star chip in the nav-identity block — whose label is the current default-server name and whose tooltip says "click to change default server." Nothing in the navbar said Settings, Preferences, or Notifications, so the matrix was effectively invisible to users who never thought to click that chip.

This PR adds two navbar entries, gated to logged-in users:

- A **⚙️ Settings** chip alongside the default-server chip in `.nav-identity`, linking to `/preferences` (the existing hub page, which already links onward to notifications).
- A **🔔 Notifications** entry in the Main nav section, linking directly to `/preferences/notifications` — the existing `NotificationPreferencesController` handles the no-guildId case by rendering the picker.

Only one file changed: `web/src/main/resources/templates/fragments/navbar.html` (+7 lines). No controller, route, CSS, or JS changes needed.

## Test plan

- [ ] Logged-out: navbar shows Profile, Leaderboards only — no Settings chip, no Notifications entry
- [ ] Logged-in: Settings chip appears in nav-identity, Notifications appears in Main alongside Profile/Leaderboards
- [ ] Click ⚙️ Settings → lands on `/preferences`
- [ ] Click 🔔 Notifications → lands on `/preferences/notifications` picker, then a server → matrix renders
- [ ] Toggle a notification preference on the matrix, refresh, confirm persistence (existing API path)
- [ ] Mobile drawer: hamburger opens, both new entries visible and tap-targetable in the right-side drawer

https://claude.ai/code/session_01TKUtY7NB268piNfBaZ9gzF

---
_Generated by [Claude Code](https://claude.ai/code/session_01TKUtY7NB268piNfBaZ9gzF)_