### PR TITLE
style(web): polish notification preferences page on desktop + mobile

### DIFF
--- a/web/src/main/resources/static/css/leaderboard.css
+++ b/web/src/main/resources/static/css/leaderboard.css
@@ -677,3 +677,246 @@ details.lb-collapse[open] .lb-collapse-caret { transform: rotate(90deg); }
     border-radius: var(--radius-lg);
     margin-top: var(--space-3);
 }
+
+/* ==============================================================
+   Notification preferences matrix
+   --------------------------------------------------------------
+   Desktop: a single elevated card holds the (kind x surface) table,
+   with uppercase muted column headers, row dividers, hover tint,
+   and pill-shaped On/Off toggles keyed off .is-on / .is-off (those
+   are the classes preferences-notifications.js flips).
+   Mobile (<=600px): thead is hidden and each row collapses into its
+   own card. The first cell becomes a block header (name + desc) and
+   each surface cell becomes a flex row labelled with the surface
+   name via td.notif-cell::before { content: attr(data-label); } -
+   that's the fix for "I see 3 toggles with no idea what they do".
+   ============================================================== */
+
+.notif-matrix-wrap {
+    margin-top: var(--space-6);
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    overflow: hidden;
+}
+
+.notif-matrix {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.notif-matrix thead th {
+    text-align: center;
+    padding: var(--space-3) var(--space-4);
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--text-muted);
+    background: var(--bg);
+    border-bottom: 1px solid var(--border-strong);
+    font-weight: 600;
+}
+.notif-matrix thead th:first-child {
+    text-align: left;
+}
+
+.notif-matrix tbody tr {
+    border-top: 1px solid var(--border);
+    transition: background-color 0.12s;
+}
+.notif-matrix tbody tr:first-child {
+    border-top: 0;
+}
+.notif-matrix tbody tr:hover {
+    background: var(--accent-soft);
+}
+
+.notif-matrix td {
+    padding: var(--space-3) var(--space-4);
+    vertical-align: middle;
+}
+.notif-matrix td.notif-cell {
+    text-align: center;
+    width: 1%;
+    white-space: nowrap;
+}
+.notif-matrix td strong {
+    display: block;
+    font-size: 0.95rem;
+}
+.notif-matrix td .muted {
+    font-size: 0.85rem;
+    margin-top: 2px;
+}
+
+.notif-toggle {
+    min-width: 64px;
+    min-height: 32px;
+    padding: 4px 14px;
+    border-radius: 999px;
+    font-size: 0.8rem;
+    font-weight: 600;
+    cursor: pointer;
+    border: 1px solid var(--border-strong);
+    background: var(--border);
+    color: var(--text-muted);
+    transition: background-color 0.12s, border-color 0.12s, color 0.12s;
+}
+.notif-toggle.is-on {
+    background: var(--accent-soft);
+    border-color: var(--accent);
+    color: var(--accent);
+}
+.notif-toggle.is-off {
+    background: var(--border);
+    color: var(--text-muted);
+}
+.notif-toggle:hover:not(:disabled) {
+    border-color: var(--accent);
+}
+.notif-toggle:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+}
+.notif-toggle:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+.notif-placeholder {
+    color: var(--text-muted);
+    font-size: 1rem;
+    user-select: none;
+}
+
+.notif-push-intro {
+    margin-top: var(--space-4);
+}
+
+.push-toggle {
+    margin-top: var(--space-6);
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    padding: var(--space-5);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+}
+.push-toggle h2 {
+    margin: 0;
+    font-size: 1.1rem;
+}
+.push-toggle p {
+    margin: 0;
+}
+.push-toggle-btn {
+    align-self: flex-start;
+}
+.push-toggle-status:empty {
+    display: none;
+}
+
+@media (max-width: 600px) {
+    .notif-matrix-wrap {
+        background: transparent;
+        border: 0;
+        border-radius: 0;
+        overflow: visible;
+        margin-top: var(--space-4);
+    }
+    .notif-matrix {
+        border-collapse: separate;
+        border-spacing: 0;
+    }
+    .notif-matrix thead {
+        display: none;
+    }
+    .notif-matrix tbody,
+    .notif-matrix tr,
+    .notif-matrix td {
+        display: block;
+        width: 100%;
+    }
+    .notif-matrix tr {
+        background: var(--bg-elevated);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-md);
+        padding: var(--space-3) var(--space-4);
+        margin-bottom: var(--space-3);
+    }
+
+    .notif-matrix td {
+        padding: var(--space-2) 0;
+        text-align: left;
+        width: auto;
+        white-space: normal;
+    }
+    .notif-matrix td.notif-cell {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        gap: var(--space-3);
+        border-top: 1px solid var(--border);
+        min-height: var(--tap-min);
+        text-align: left;
+    }
+    .notif-matrix td.notif-cell::before {
+        content: attr(data-label);
+        font-size: 0.7rem;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        color: var(--text-muted);
+        font-weight: 600;
+        flex: 0 0 auto;
+    }
+
+    .notif-matrix td[data-label="Notification"] {
+        display: block;
+        border-bottom: 1px solid var(--border-strong);
+        padding-bottom: var(--space-3);
+        margin-bottom: var(--space-2);
+    }
+    .notif-matrix td[data-label="Notification"]::before {
+        display: none;
+    }
+}
+
+@media (max-width: 480px) {
+    .notif-matrix tr {
+        padding: var(--space-2) var(--space-3);
+    }
+    .notif-matrix td .muted {
+        font-size: 0.8rem;
+    }
+    .notif-toggle {
+        min-width: 56px;
+        min-height: 40px;
+        padding: 4px 12px;
+        font-size: 0.78rem;
+    }
+    .push-toggle {
+        padding: var(--space-4);
+        margin-top: var(--space-5);
+    }
+}
+
+@media (max-width: 380px) {
+    .notif-matrix tr {
+        padding: var(--space-2);
+    }
+    .notif-matrix td.notif-cell::before {
+        font-size: 0.65rem;
+    }
+    .notif-toggle {
+        min-width: 52px;
+        min-height: 40px;
+        font-size: 0.75rem;
+    }
+    .notif-matrix td strong {
+        font-size: 0.92rem;
+    }
+    .notif-matrix td .muted {
+        font-size: 0.78rem;
+    }
+}

--- a/web/src/main/resources/templates/preferences-notifications.html
+++ b/web/src/main/resources/templates/preferences-notifications.html
@@ -22,57 +22,59 @@
 
     <a class="back-link" th:href="@{/preferences/notifications}">&larr; Pick a different server</a>
 
-    <table class="notif-matrix" style="margin-top:24px; width:100%; border-collapse:collapse;">
-        <thead>
-            <tr>
-                <th style="text-align:left;">Notification</th>
-                <th th:each="surfaceName : ${surfaces}"
-                    style="text-align:center; padding:8px;"
-                    th:text="${surfaceName}">DM</th>
-            </tr>
-        </thead>
-        <tbody>
-            <tr th:each="row : ${matrix}"
-                class="notif-row"
-                th:attr="data-kind=${row.kind}">
-                <td style="padding:8px;">
-                    <strong th:text="${row.displayName}">Kind</strong>
-                    <div class="muted" th:text="${row.description}">desc</div>
-                </td>
-                <td th:each="cell : ${row.cells}"
-                    style="text-align:center; padding:8px;">
-                    <!-- Placeholder cell: kind doesn't support this surface. -->
-                    <span th:if="${cell.class.simpleName == 'Placeholder'}"
-                          class="notif-placeholder muted"
-                          th:attr="data-surface=${cell.surface}">—</span>
-                    <!-- Toggle cell: clickable on/off. -->
-                    <button th:if="${cell.class.simpleName == 'Toggle'}"
-                            type="button"
-                            class="notif-toggle"
-                            th:classappend="${cell.optIn} ? ' is-on' : ' is-off'"
-                            th:attr="data-kind=${row.kind},
-                                     data-surface=${cell.surface},
-                                     data-opt-in=${cell.optIn},
-                                     data-default=${cell.isDefault}"
-                            th:text="${cell.optIn} ? 'On' : 'Off'">Off</button>
-                </td>
-            </tr>
-        </tbody>
-    </table>
+    <div class="notif-matrix-wrap">
+        <table class="notif-matrix">
+            <thead>
+                <tr>
+                    <th>Notification</th>
+                    <th th:each="surfaceName : ${surfaces}"
+                        th:text="${surfaceName}">DM</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr th:each="row : ${matrix}"
+                    class="notif-row"
+                    th:attr="data-kind=${row.kind}">
+                    <td data-label="Notification">
+                        <strong th:text="${row.displayName}">Kind</strong>
+                        <div class="muted" th:text="${row.description}">desc</div>
+                    </td>
+                    <td th:each="cell : ${row.cells}"
+                        class="notif-cell"
+                        th:attr="data-label=${cell.surface}, data-surface=${cell.surface}">
+                        <!-- Placeholder cell: kind doesn't support this surface. -->
+                        <span th:if="${cell.class.simpleName == 'Placeholder'}"
+                              class="notif-placeholder muted"
+                              th:attr="data-surface=${cell.surface}">—</span>
+                        <!-- Toggle cell: clickable on/off. -->
+                        <button th:if="${cell.class.simpleName == 'Toggle'}"
+                                type="button"
+                                class="notif-toggle"
+                                th:classappend="${cell.optIn} ? ' is-on' : ' is-off'"
+                                th:attr="data-kind=${row.kind},
+                                         data-surface=${cell.surface},
+                                         data-opt-in=${cell.optIn},
+                                         data-default=${cell.isDefault}"
+                                th:text="${cell.optIn} ? 'On' : 'Off'">Off</button>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
 
-    <p class="muted" style="margin-top:16px;">
+    <p class="muted notif-push-intro">
         <span class="notif-push-footnote">PUSH is delivered via web push. Enable browser push for this device below, then opt in to any kind's PUSH column above.</span>
     </p>
 
-    <section data-push-toggle class="push-toggle" style="margin-top:24px; padding:16px; border:1px solid var(--border-color, #444); border-radius:8px;">
-        <h2 style="margin-top:0;">Browser push</h2>
+    <section data-push-toggle class="push-toggle">
+        <h2>Browser push</h2>
         <p class="muted">
             Toggle web-push notifications for this device. Each device
             (laptop, phone, etc.) needs its own opt-in — your per-kind
             PUSH preferences above are shared across all your devices.
         </p>
-        <button type="button" class="push-toggle-btn">Enable browser push</button>
-        <p class="push-toggle-status muted" style="margin-top:8px;"></p>
+        <button type="button" class="btn-primary push-toggle-btn">Enable browser push</button>
+        <p class="push-toggle-status muted"></p>
     </section>
 </main>
 


### PR DESCRIPTION
## Summary

- Replace the inline-styled notification matrix with a real `.notif-matrix` design that uses the dark-theme card system (elevated wrapper, muted uppercase headers, row dividers, hover tint, pill toggles).
- **Mobile fix:** at `max-width: 600px` the table collapses to one card per notification kind. Each toggle now sits next to its surface name (`DM` / `CHANNEL` / `PUSH`) via a `td.notif-cell::before { content: attr(data-label); }` rule. Previously the column headers got squashed off-screen and users just saw "up to 3 on or offs with no indication of what they represent".
- Promote the `.push-toggle` block to an elevated card and reuse the existing `.btn-primary` for the enable/disable button.
- Further tighten spacing and shrink toggle pills at `480px` and `380px` breakpoints while keeping touch targets `>= 40px`.
- No JS or Kotlin changes — JS still keys off `.notif-toggle` + `.is-on` / `.is-off`, which are preserved.

## Test plan
- [x] `npx jest src/test/js/preferences-notifications.test.js` — 9/9 passing
- [x] `npm run lint:css` — clean
- [ ] Manual desktop check at ≥900px: elevated card wrapper, uppercase muted column headers, row hover tint, accent-tinted `On` pills, muted `Off` pills, em-dash placeholders, clicking a toggle flips state without layout shift
- [ ] Manual mobile check at 600 / 480 / 380px: `<thead>` hidden, each row is its own card with the name + description as block header followed by labelled `DM` / `CHANNEL` / `PUSH` rows, no horizontal scrolling, toggles remain tappable
- [ ] Keyboard tab: `:focus-visible` outline appears on `.notif-toggle` and `.push-toggle-btn`
- [ ] Toggle off a preference, reload page, confirm persistence (sanity-check the JS path is unchanged)

https://claude.ai/code/session_01MjEfpAeve6553Gxbk7qdY9

---
_Generated by [Claude Code](https://claude.ai/code/session_01MjEfpAeve6553Gxbk7qdY9)_