### PR TITLE
fix(achievements): ratchet level/streak progress + regroup /achievements display by category

### DIFF
--- a/database/src/main/kotlin/database/service/AchievementService.kt
+++ b/database/src/main/kotlin/database/service/AchievementService.kt
@@ -36,6 +36,24 @@ interface AchievementService {
     ): ProgressResult
 
     /**
+     * Set progress to an absolute value. Use this for ratchet-style
+     * achievements where the source event carries the current absolute
+     * state (current level, current streak), not a delta. Values are
+     * clamped to `[0, threshold]`; reaching the threshold triggers the
+     * unlock path (reward + event) exactly once. Idempotent once
+     * unlocked. Unlike [progress] this accepts decreases — important
+     * for streak-broke semantics where the display should reflect the
+     * user's *current* streak, not their high-water mark.
+     */
+    fun setProgress(
+        discordId: Long,
+        guildId: Long,
+        code: String,
+        value: Long,
+        channelId: Long? = null
+    ): ProgressResult
+
+    /**
      * Snapshot for the user's profile / `/achievements` view. Includes
      * locked entries (unless hidden) so the user sees what's available.
      */

--- a/database/src/main/kotlin/database/service/impl/DefaultAchievementService.kt
+++ b/database/src/main/kotlin/database/service/impl/DefaultAchievementService.kt
@@ -97,6 +97,43 @@ class DefaultAchievementService(
         return finalizeUnlock(discordId, guildId, achievement, achievementId, achievement.threshold, channelId)
     }
 
+    override fun setProgress(
+        discordId: Long,
+        guildId: Long,
+        code: String,
+        value: Long,
+        channelId: Long?
+    ): ProgressResult {
+        val achievement = persistence.getByCode(code)
+            ?: return ProgressResult(null, 0L, unlocked = false, alreadyUnlocked = false)
+        val achievementId = achievement.id
+            ?: return ProgressResult(achievement, 0L, unlocked = false, alreadyUnlocked = false)
+
+        if (persistence.owns(discordId, guildId, achievementId)) {
+            return ProgressResult(achievement, achievement.threshold, unlocked = false, alreadyUnlocked = true)
+        }
+
+        val newProgress = value.coerceIn(0L, achievement.threshold)
+        val existing = persistence.getProgress(discordId, guildId, achievementId)
+        if (existing?.progress != newProgress) {
+            persistence.upsertProgress(
+                AchievementProgressDto(
+                    discordId = discordId,
+                    guildId = guildId,
+                    achievementId = achievementId,
+                    progress = newProgress,
+                    updatedAt = Instant.now()
+                )
+            )
+        }
+
+        if (newProgress < achievement.threshold) {
+            return ProgressResult(achievement, newProgress, unlocked = false, alreadyUnlocked = false)
+        }
+
+        return finalizeUnlock(discordId, guildId, achievement, achievementId, newProgress, channelId)
+    }
+
     override fun listFor(discordId: Long, guildId: Long): List<AchievementView> {
         val owned = persistence.listOwnedByUser(discordId, guildId).associateBy { it.achievementId }
         val progressByAchievement = persistence.listProgressByUser(discordId, guildId).associateBy { it.achievementId }

--- a/database/src/test/kotlin/database/service/AchievementServiceTest.kt
+++ b/database/src/test/kotlin/database/service/AchievementServiceTest.kt
@@ -140,6 +140,129 @@ class AchievementServiceTest {
         assertEquals(4L, views["p"]?.progress)
     }
 
+    // ---------- setProgress ----------
+
+    @Test
+    fun `setProgress sets absolute value and does not unlock when below threshold`() {
+        val a = persistence.save(
+            AchievementDto(code = "sp_below", name = "B", description = "d", category = "c", xpReward = 10, threshold = 10)
+        )
+
+        val result = service.setProgress(discordId, guildId, "sp_below", value = 4L)
+
+        assertFalse(result.unlocked)
+        assertEquals(4L, result.newProgress)
+        assertEquals(4L, persistence.getProgress(discordId, guildId, a.id!!)?.progress)
+        assertTrue(eventPublisher.unlockEvents.isEmpty())
+        assertFalse(persistence.owns(discordId, guildId, a.id!!))
+    }
+
+    @Test
+    fun `setProgress unlocks exactly once when value reaches the threshold`() {
+        val a = persistence.save(
+            AchievementDto(code = "sp_reach", name = "R", description = "d", category = "c", xpReward = 25, creditReward = 50, threshold = 5)
+        )
+
+        val result = service.setProgress(discordId, guildId, "sp_reach", value = 5L)
+
+        assertTrue(result.unlocked)
+        assertFalse(result.alreadyUnlocked)
+        assertEquals(5L, result.newProgress)
+        assertEquals(1, eventPublisher.unlockEvents.size)
+        assertEquals(25L, userService.current(discordId, guildId)?.xp)
+        assertEquals(50L, userService.current(discordId, guildId)?.socialCredit)
+        assertTrue(persistence.owns(discordId, guildId, a.id!!))
+    }
+
+    @Test
+    fun `setProgress clamps values above the threshold`() {
+        val a = persistence.save(
+            AchievementDto(code = "sp_clamp_high", name = "H", description = "d", category = "c", xpReward = 10, threshold = 5)
+        )
+
+        val result = service.setProgress(discordId, guildId, "sp_clamp_high", value = 99L)
+
+        assertTrue(result.unlocked)
+        assertEquals(5L, result.newProgress)
+        assertEquals(1, eventPublisher.unlockEvents.size)
+        assertEquals(10L, userService.current(discordId, guildId)?.xp)
+        assertTrue(persistence.owns(discordId, guildId, a.id!!))
+    }
+
+    @Test
+    fun `setProgress is a no-op once unlocked — streak-broke does not retract`() {
+        persistence.save(
+            AchievementDto(code = "sp_idem", name = "I", description = "d", category = "c", xpReward = 10, threshold = 3)
+        )
+        service.setProgress(discordId, guildId, "sp_idem", value = 3L)
+        val xpAfterFirst = userService.current(discordId, guildId)?.xp
+        eventPublisher.unlockEvents.clear()
+
+        val again = service.setProgress(discordId, guildId, "sp_idem", value = 1L)
+
+        assertFalse(again.unlocked)
+        assertTrue(again.alreadyUnlocked)
+        assertEquals(xpAfterFirst, userService.current(discordId, guildId)?.xp)
+        assertTrue(eventPublisher.unlockEvents.isEmpty())
+    }
+
+    @Test
+    fun `setProgress accepts a decrease for not-yet-unlocked rows`() {
+        val a = persistence.save(
+            AchievementDto(code = "sp_dec", name = "D", description = "d", category = "c", xpReward = 0, threshold = 10)
+        )
+
+        service.setProgress(discordId, guildId, "sp_dec", value = 7L)
+        assertEquals(7L, persistence.getProgress(discordId, guildId, a.id!!)?.progress)
+
+        val after = service.setProgress(discordId, guildId, "sp_dec", value = 3L)
+        assertFalse(after.unlocked)
+        assertEquals(3L, after.newProgress)
+        assertEquals(3L, persistence.getProgress(discordId, guildId, a.id!!)?.progress)
+    }
+
+    @Test
+    fun `setProgress clamps negative values to zero`() {
+        val a = persistence.save(
+            AchievementDto(code = "sp_neg", name = "N", description = "d", category = "c", threshold = 5)
+        )
+
+        val result = service.setProgress(discordId, guildId, "sp_neg", value = -5L)
+
+        assertFalse(result.unlocked)
+        assertEquals(0L, result.newProgress)
+        assertEquals(0L, persistence.getProgress(discordId, guildId, a.id!!)?.progress)
+    }
+
+    @Test
+    fun `setProgress on an unknown code is a no-op`() {
+        val result = service.setProgress(discordId, guildId, "no_such_code", value = 5L)
+        assertFalse(result.unlocked)
+        assertNull(result.achievement)
+        assertTrue(eventPublisher.unlockEvents.isEmpty())
+    }
+
+    @Test
+    fun `setProgress publishes the same AchievementUnlockedEvent payload as unlock`() {
+        persistence.save(
+            AchievementDto(
+                code = "sp_event", name = "Event", description = "desc",
+                category = "c", icon = "🎯", xpReward = 10, threshold = 2
+            )
+        )
+
+        service.setProgress(discordId, guildId, "sp_event", value = 2L, channelId = 555L)
+
+        val event = eventPublisher.unlockEvents.single()
+        assertEquals("sp_event", event.achievementCode)
+        assertEquals("Event", event.name)
+        assertEquals("desc", event.description)
+        assertEquals("🎯", event.icon)
+        assertEquals(555L, event.channelId)
+        assertEquals(discordId, event.discordId)
+        assertEquals(guildId, event.guildId)
+    }
+
     @Test
     fun `streak rewards bypass the daily cap via countsAgainstDailyCap=false`() {
         // Exhaust the user's daily XP cap.

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/misc/AchievementsCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/misc/AchievementsCommand.kt
@@ -46,54 +46,126 @@ class AchievementsCommand @Autowired constructor(
     }
 
     private fun buildEmbed(displayName: String, views: List<AchievementView>): MessageEmbed {
-        val unlocked = views.filter { it.unlockedAt != null }
-        val locked = views.filter { it.unlockedAt == null }
+        val builder = EmbedBuilder()
+            .setTitle("$displayName — Achievements")
+            .setColor(Color(0xFFC857))
 
-        val body = buildString {
-            if (views.isEmpty()) {
-                append("No achievements have been seeded yet — check back soon.")
-                return@buildString
-            }
-            append("**${unlocked.size}** / **${views.size}** unlocked\n\n")
-
-            if (unlocked.isNotEmpty()) {
-                append("__Unlocked__\n")
-                unlocked.take(MAX_LINES_PER_SECTION).forEach { v ->
-                    val icon = v.achievement.icon ?: "🏅"
-                    append("$icon **").append(v.achievement.name).append("** — ")
-                    append(v.achievement.description).append('\n')
-                }
-                if (unlocked.size > MAX_LINES_PER_SECTION) {
-                    append("…and ").append(unlocked.size - MAX_LINES_PER_SECTION).append(" more\n")
-                }
-                append('\n')
-            }
-            if (locked.isNotEmpty()) {
-                append("__In progress / locked__\n")
-                locked.take(MAX_LINES_PER_SECTION).forEach { v ->
-                    val icon = v.achievement.icon ?: "🔒"
-                    append("$icon **").append(v.achievement.name).append("** — ")
-                    append(v.achievement.description)
-                    if (v.achievement.threshold > 1) {
-                        append("  (").append(v.progress).append('/').append(v.achievement.threshold).append(')')
-                    }
-                    append('\n')
-                }
-                if (locked.size > MAX_LINES_PER_SECTION) {
-                    append("…and ").append(locked.size - MAX_LINES_PER_SECTION).append(" more\n")
-                }
-            }
+        if (views.isEmpty()) {
+            builder.setDescription("No achievements have been seeded yet — check back soon.")
+            return builder.build()
         }
 
-        return EmbedBuilder()
-            .setTitle("$displayName — Achievements")
-            .setDescription(body)
-            .setColor(Color(0xFFC857))
-            .build()
+        val unlocked = views.filter { it.unlockedAt != null }
+        val totalXp = unlocked.sumOf { it.achievement.xpReward.toLong() }
+        builder.setDescription(
+            "**${unlocked.size}** / **${views.size}** unlocked  ·  **$totalXp XP** earned"
+        )
+
+        val byCategory = views.groupBy { it.achievement.category }
+        CATEGORY_ORDER.forEach { category ->
+            val entries = byCategory[category] ?: return@forEach
+            builder.addField(renderCategoryField(category, entries))
+        }
+        // Any catalog category not in CATEGORY_ORDER (future-proofing).
+        byCategory.keys
+            .filter { it !in CATEGORY_ORDER }
+            .sorted()
+            .forEach { category ->
+                builder.addField(renderCategoryField(category, byCategory.getValue(category)))
+            }
+
+        return builder.build()
+    }
+
+    private fun renderCategoryField(category: String, entries: List<AchievementView>): MessageEmbed.Field {
+        val unlockedCount = entries.count { it.unlockedAt != null }
+        val title = "${categoryDisplay(category)}  ($unlockedCount/${entries.size})"
+
+        val sorted = entries.sortedWith(
+            compareBy<AchievementView> { it.unlockedAt == null }
+                .thenByDescending { it.unlockedAt?.epochSecond ?: 0L }
+                .thenByDescending { it.progress }
+        )
+
+        val lines = sorted.map { renderLine(it) }
+        val body = joinWithLimit(lines, FIELD_VALUE_LIMIT)
+        return MessageEmbed.Field(title, body, false)
+    }
+
+    private fun renderLine(view: AchievementView): String {
+        val a = view.achievement
+        val icon = a.icon ?: if (view.unlockedAt != null) "🏅" else "🔒"
+        val rewardSuffix = rewardSuffix(a.xpReward, a.creditReward)
+
+        return if (view.unlockedAt != null) {
+            val ts = "<t:${view.unlockedAt!!.epochSecond}:R>"
+            buildString {
+                append("✅ ").append(icon).append(" **").append(a.name).append("** — ").append(a.description)
+                append("  ·  *").append(ts).append('*')
+                if (rewardSuffix.isNotEmpty()) append("  ·  ").append(rewardSuffix)
+            }
+        } else {
+            buildString {
+                append("🔒 ").append(icon).append(" **").append(a.name).append("** — ").append(a.description)
+                if (a.threshold > 1) {
+                    append("  `[").append(progressBar(view.progress, a.threshold)).append("]` ")
+                    append(view.progress).append('/').append(a.threshold)
+                }
+                if (rewardSuffix.isNotEmpty()) append("  ·  ").append(rewardSuffix)
+            }
+        }
+    }
+
+    private fun rewardSuffix(xpReward: Int, creditReward: Long): String {
+        val parts = mutableListOf<String>()
+        if (xpReward > 0) parts.add("+$xpReward XP")
+        if (creditReward > 0L) parts.add("+${creditReward}¢")
+        return parts.joinToString(" ")
+    }
+
+    private fun progressBar(progress: Long, threshold: Long): String {
+        if (threshold <= 0L) return "░".repeat(BAR_WIDTH)
+        val ratio = (progress.toDouble() / threshold).coerceIn(0.0, 1.0)
+        val filled = (ratio * BAR_WIDTH).toInt().coerceIn(0, BAR_WIDTH)
+        return "█".repeat(filled) + "░".repeat(BAR_WIDTH - filled)
+    }
+
+    private fun categoryDisplay(category: String): String =
+        CATEGORY_DISPLAY[category] ?: category.replaceFirstChar { it.uppercase() }
+
+    private fun joinWithLimit(lines: List<String>, limit: Int): String {
+        val sb = StringBuilder()
+        var dropped = 0
+        for ((index, line) in lines.withIndex()) {
+            val candidate = if (sb.isEmpty()) line else "\n$line"
+            val remaining = lines.size - index
+            // Reserve space for a trailing "…and N more" if we'd overflow.
+            val reserved = if (remaining > 1) TRUNCATE_RESERVE else 0
+            if (sb.length + candidate.length + reserved > limit) {
+                dropped = lines.size - index
+                break
+            }
+            sb.append(candidate)
+        }
+        if (dropped > 0) sb.append("\n…and ").append(dropped).append(" more")
+        return sb.toString()
     }
 
     companion object {
         private const val OPT_USER = "user"
-        private const val MAX_LINES_PER_SECTION = 15
+        private const val BAR_WIDTH = 10
+        private const val FIELD_VALUE_LIMIT = 1024
+        private const val TRUNCATE_RESERVE = 24
+
+        private val CATEGORY_ORDER = listOf("streak", "level", "casino", "social", "music", "voice")
+
+        private val CATEGORY_DISPLAY = mapOf(
+            "streak" to "🔥 Streaks",
+            "level" to "🎖️ Levels",
+            "casino" to "🎰 Casino",
+            "social" to "🤝 Social",
+            "music" to "🎵 Music",
+            "voice" to "🎙️ Voice"
+        )
     }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/handler/AchievementEventHandler.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/handler/AchievementEventHandler.kt
@@ -49,36 +49,31 @@ class AchievementEventHandler(
             channelId = event.channelId
         )
 
-        // Counter-style streak milestones. We pass the current streak
-        // as the *absolute* value via a delta-from-current calculation
-        // would be racy across multiple guilds with shared streaks —
-        // here each is per-guild, so we just call unlock once the
-        // threshold is reached. The catalog's threshold matches the
-        // streak count, so we use `unlock` directly when the streak
-        // crosses a known milestone.
+        // Milestone streaks ratchet by absolute value so the locked
+        // /achievements display reflects the user's current streak,
+        // not zero. setProgress is idempotent post-unlock and accepts
+        // decreases (streak-broke).
         STREAK_MILESTONES.forEach { milestone ->
-            if (event.currentStreak >= milestone) {
-                achievementService.unlock(
-                    discordId = event.discordId,
-                    guildId = event.guildId,
-                    code = "streak_$milestone",
-                    channelId = event.channelId
-                )
-            }
+            achievementService.setProgress(
+                discordId = event.discordId,
+                guildId = event.guildId,
+                code = "streak_$milestone",
+                value = event.currentStreak.toLong(),
+                channelId = event.channelId
+            )
         }
     }
 
     @EventListener
     fun onLevelUp(event: LevelUpEvent) {
         LEVEL_MILESTONES.forEach { milestone ->
-            if (event.newLevel >= milestone && event.oldLevel < milestone) {
-                achievementService.unlock(
-                    discordId = event.discordId,
-                    guildId = event.guildId,
-                    code = "level_$milestone",
-                    channelId = event.channelId
-                )
-            }
+            achievementService.setProgress(
+                discordId = event.discordId,
+                guildId = event.guildId,
+                code = "level_$milestone",
+                value = event.newLevel.toLong(),
+                channelId = event.channelId
+            )
         }
     }
 

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/misc/AchievementsCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/misc/AchievementsCommandTest.kt
@@ -1,0 +1,305 @@
+package bot.toby.command.commands.misc
+
+import bot.toby.command.CommandTest
+import bot.toby.command.CommandTest.Companion.event
+import bot.toby.command.CommandTest.Companion.interactionHook
+import bot.toby.command.CommandTest.Companion.member
+import bot.toby.command.CommandTest.Companion.webhookMessageCreateAction
+import bot.toby.command.DefaultCommandContext
+import database.dto.AchievementDto
+import database.dto.UserDto
+import database.service.AchievementService
+import database.service.AchievementService.AchievementView
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import net.dv8tion.jda.api.entities.MessageEmbed
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+class AchievementsCommandTest : CommandTest {
+
+    private lateinit var achievementService: AchievementService
+    private lateinit var command: AchievementsCommand
+    private lateinit var userDto: UserDto
+
+    @BeforeEach
+    fun setUp() {
+        setUpCommonMocks()
+        achievementService = mockk(relaxed = true)
+        userDto = mockk(relaxed = true)
+        command = AchievementsCommand(achievementService)
+        every { event.getOption("user") } returns null
+        every { event.deferReply(true) } returns CommandTest.replyCallbackAction
+        every { member.effectiveName } returns "Tester"
+    }
+
+    @AfterEach
+    fun tearDown() {
+        tearDownCommonMocks()
+        clearMocks(event, interactionHook)
+    }
+
+    private fun captureEmbed(): MessageEmbed {
+        val slot = slot<MessageEmbed>()
+        verify(exactly = 1) { interactionHook.sendMessageEmbeds(capture(slot)) }
+        return slot.captured
+    }
+
+    private fun runCommand() {
+        val ctx = DefaultCommandContext(event)
+        command.handle(ctx, userDto, 0)
+    }
+
+    // ---------- empty / error paths ----------
+
+    @Test
+    fun `empty state shows seeded-soon description and no fields`() {
+        every { achievementService.listFor(any(), any()) } returns emptyList()
+
+        runCommand()
+
+        val embed = captureEmbed()
+        assertTrue(embed.description!!.contains("No achievements have been seeded yet"))
+        assertTrue(embed.fields.isEmpty())
+    }
+
+    @Test
+    fun `non-guild context returns the server-only error string`() {
+        every { event.guild } returns null
+
+        runCommand()
+
+        verify(exactly = 1) {
+            interactionHook.sendMessage("This command can only be used in a server.")
+        }
+        verify(exactly = 0) { interactionHook.sendMessageEmbeds(any<MessageEmbed>()) }
+    }
+
+    @Test
+    fun `defers reply as ephemeral`() {
+        every { achievementService.listFor(any(), any()) } returns emptyList()
+        runCommand()
+        verify(exactly = 1) { event.deferReply(true) }
+    }
+
+    // ---------- header / summary ----------
+
+    @Test
+    fun `header shows X of Y unlocked and total XP earned`() {
+        val unlocked = listOf(
+            mkView(code = "a", category = "casino", xpReward = 25, unlockedAt = Instant.now()),
+            mkView(code = "b", category = "casino", xpReward = 50, unlockedAt = Instant.now()),
+            mkView(code = "c", category = "level", xpReward = 100, unlockedAt = Instant.now()),
+        )
+        val locked = (1..5).map { mkView(code = "x$it", category = "level", xpReward = 10) }
+        every { achievementService.listFor(any(), any()) } returns unlocked + locked
+
+        runCommand()
+        val embed = captureEmbed()
+
+        assertTrue(embed.description!!.contains("**3** / **8** unlocked"), embed.description)
+        assertTrue(embed.description!!.contains("**175 XP**"), embed.description)
+    }
+
+    // ---------- grouping ----------
+
+    @Test
+    fun `achievements are grouped by category into separate fields in declared order`() {
+        val views = listOf(
+            mkView(code = "v", category = "voice", name = "VoiceA"),
+            mkView(code = "m", category = "music", name = "MusicA"),
+            mkView(code = "so", category = "social", name = "SocialA"),
+            mkView(code = "ca", category = "casino", name = "CasinoA"),
+            mkView(code = "l", category = "level", name = "LevelA"),
+            mkView(code = "s", category = "streak", name = "StreakA"),
+        )
+        every { achievementService.listFor(any(), any()) } returns views
+
+        runCommand()
+        val embed = captureEmbed()
+
+        val titles = embed.fields.map { it.name!! }
+        assertEquals(6, titles.size)
+        assertTrue(titles[0].contains("Streaks"), titles[0])
+        assertTrue(titles[1].contains("Levels"), titles[1])
+        assertTrue(titles[2].contains("Casino"), titles[2])
+        assertTrue(titles[3].contains("Social"), titles[3])
+        assertTrue(titles[4].contains("Music"), titles[4])
+        assertTrue(titles[5].contains("Voice"), titles[5])
+        titles.forEach { assertTrue(it.contains("(0/1)"), it) }
+    }
+
+    @Test
+    fun `unknown category falls back to capitalised name`() {
+        every { achievementService.listFor(any(), any()) } returns listOf(
+            mkView(code = "x", category = "experimental", name = "Exp")
+        )
+
+        runCommand()
+        val embed = captureEmbed()
+
+        val title = embed.fields.single().name!!
+        assertTrue(title.contains("Experimental"), title)
+    }
+
+    // ---------- line rendering ----------
+
+    @Test
+    fun `unlocked entry renders checkmark icon name description timestamp and rewards`() {
+        val at = Instant.parse("2024-01-01T00:00:00Z")
+        every { achievementService.listFor(any(), any()) } returns listOf(
+            mkView(
+                code = "tip_giver", category = "social", name = "Generous",
+                description = "Tip another user for the first time.", icon = "🎁",
+                xpReward = 25, creditReward = 50, threshold = 1, unlockedAt = at
+            )
+        )
+
+        runCommand()
+        val body = captureEmbed().fields.single().value!!
+
+        assertTrue(body.contains("✅"), body)
+        assertTrue(body.contains("🎁"), body)
+        assertTrue(body.contains("**Generous**"), body)
+        assertTrue(body.contains("Tip another user for the first time."), body)
+        assertTrue(body.contains("<t:${at.epochSecond}:R>"), body)
+        assertTrue(body.contains("+25 XP"), body)
+        assertTrue(body.contains("+50¢"), body)
+    }
+
+    @Test
+    fun `locked counter achievement shows progress bar with filled and empty blocks`() {
+        every { achievementService.listFor(any(), any()) } returns listOf(
+            mkView(
+                code = "p", category = "voice", name = "Counter",
+                description = "d", icon = "🎙️",
+                xpReward = 0, creditReward = 0, threshold = 10, progress = 4
+            )
+        )
+
+        runCommand()
+        val body = captureEmbed().fields.single().value!!
+
+        assertTrue(body.contains("🔒"), body)
+        assertTrue(body.contains("[████░░░░░░]"), body)
+        assertTrue(body.contains("4/10"), body)
+    }
+
+    @Test
+    fun `locked one-shot achievement (threshold 1) shows no progress bar`() {
+        every { achievementService.listFor(any(), any()) } returns listOf(
+            mkView(
+                code = "o", category = "casino", name = "OneShot",
+                description = "d", threshold = 1, progress = 0
+            )
+        )
+
+        runCommand()
+        val body = captureEmbed().fields.single().value!!
+
+        assertTrue(body.contains("🔒"), body)
+        assertFalse(body.contains("█"), body)
+        assertFalse(body.contains("░"), body)
+        assertFalse(body.contains("1/1"), body)
+    }
+
+    @Test
+    fun `level_5 with threshold 5 and progress 3 renders accurate progress — regression for the wiring bug`() {
+        every { achievementService.listFor(any(), any()) } returns listOf(
+            mkView(
+                code = "level_5", category = "level", name = "Getting Started",
+                description = "Reach level 5.", icon = "🥉",
+                xpReward = 25, threshold = 5, progress = 3
+            )
+        )
+
+        runCommand()
+        val body = captureEmbed().fields.single().value!!
+
+        // 3 of 5 ratio at 10-wide bar = 6 filled blocks.
+        assertTrue(body.contains("[██████░░░░]"), body)
+        assertTrue(body.contains("3/5"), body)
+    }
+
+    // ---------- sorting within a category ----------
+
+    @Test
+    fun `entries are sorted within a category — unlocked first newest-first then locked highest-progress-first`() {
+        val older = Instant.parse("2024-01-01T00:00:00Z")
+        val newer = Instant.parse("2024-06-01T00:00:00Z")
+        every { achievementService.listFor(any(), any()) } returns listOf(
+            mkView(code = "lo_lo", category = "casino", name = "LockedLow", threshold = 10, progress = 1),
+            mkView(code = "un_old", category = "casino", name = "UnlockedOld", unlockedAt = older),
+            mkView(code = "lo_hi", category = "casino", name = "LockedHigh", threshold = 10, progress = 8),
+            mkView(code = "un_new", category = "casino", name = "UnlockedNew", unlockedAt = newer),
+        )
+
+        runCommand()
+        val body = captureEmbed().fields.single().value!!
+
+        val iNew = body.indexOf("UnlockedNew")
+        val iOld = body.indexOf("UnlockedOld")
+        val iHi = body.indexOf("LockedHigh")
+        val iLo = body.indexOf("LockedLow")
+        assertTrue(iNew in 0 until iOld, "expected UnlockedNew before UnlockedOld in: $body")
+        assertTrue(iOld in 0 until iHi, "expected UnlockedOld before LockedHigh in: $body")
+        assertTrue(iHi in 0 until iLo, "expected LockedHigh before LockedLow in: $body")
+    }
+
+    // ---------- field truncation ----------
+
+    @Test
+    fun `field body trims with and-N-more when it would exceed the JDA 1024-char limit`() {
+        val many = (1..50).map { idx ->
+            mkView(
+                code = "big$idx",
+                category = "casino",
+                name = "Name$idx",
+                description = "x".repeat(80),
+                threshold = 1,
+            )
+        }
+        every { achievementService.listFor(any(), any()) } returns many
+
+        runCommand()
+        val body = captureEmbed().fields.single().value!!
+
+        assertTrue(body.length <= 1024, "field body length ${body.length} exceeds 1024")
+        assertTrue(body.contains("…and") && body.endsWith("more"), "expected truncation marker, got: ${body.takeLast(60)}")
+    }
+
+    private fun mkView(
+        code: String,
+        category: String,
+        name: String = "Name",
+        description: String = "desc",
+        icon: String? = "🏅",
+        xpReward: Int = 0,
+        creditReward: Long = 0L,
+        threshold: Long = 1L,
+        progress: Long = 0L,
+        unlockedAt: Instant? = null,
+    ): AchievementView = AchievementView(
+        achievement = AchievementDto(
+            id = code.hashCode().toLong(),
+            code = code,
+            name = name,
+            description = description,
+            category = category,
+            icon = icon,
+            xpReward = xpReward,
+            creditReward = creditReward,
+            threshold = threshold,
+        ),
+        unlockedAt = unlockedAt,
+        progress = progress,
+    )
+}

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/misc/AchievementsCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/misc/AchievementsCommandTest.kt
@@ -1,21 +1,20 @@
 package bot.toby.command.commands.misc
 
-import bot.toby.command.CommandTest
-import bot.toby.command.CommandTest.Companion.event
-import bot.toby.command.CommandTest.Companion.interactionHook
-import bot.toby.command.CommandTest.Companion.member
-import bot.toby.command.CommandTest.Companion.webhookMessageCreateAction
 import bot.toby.command.DefaultCommandContext
 import database.dto.AchievementDto
 import database.dto.UserDto
 import database.service.AchievementService
 import database.service.AchievementService.AchievementView
-import io.mockk.clearMocks
+import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.Member
 import net.dv8tion.jda.api.entities.MessageEmbed
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
+import net.dv8tion.jda.api.interactions.InteractionHook
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -24,32 +23,44 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.Instant
 
-class AchievementsCommandTest : CommandTest {
+class AchievementsCommandTest {
 
+    private lateinit var event: SlashCommandInteractionEvent
+    private lateinit var hook: InteractionHook
+    private lateinit var guild: Guild
+    private lateinit var member: Member
     private lateinit var achievementService: AchievementService
     private lateinit var command: AchievementsCommand
-    private lateinit var userDto: UserDto
+    private val userDto: UserDto = mockk(relaxed = true)
 
     @BeforeEach
     fun setUp() {
-        setUpCommonMocks()
+        event = mockk(relaxed = true)
+        hook = mockk(relaxed = true)
+        guild = mockk(relaxed = true)
+        member = mockk(relaxed = true)
         achievementService = mockk(relaxed = true)
-        userDto = mockk(relaxed = true)
-        command = AchievementsCommand(achievementService)
+
+        every { event.hook } returns hook
+        every { event.deferReply(true) } returns mockk(relaxed = true)
+        every { event.guild } returns guild
+        every { event.member } returns member
         every { event.getOption("user") } returns null
-        every { event.deferReply(true) } returns CommandTest.replyCallbackAction
+        every { member.idLong } returns 100L
         every { member.effectiveName } returns "Tester"
+        every { guild.idLong } returns 42L
+
+        command = AchievementsCommand(achievementService)
     }
 
     @AfterEach
     fun tearDown() {
-        tearDownCommonMocks()
-        clearMocks(event, interactionHook)
+        clearAllMocks()
     }
 
     private fun captureEmbed(): MessageEmbed {
         val slot = slot<MessageEmbed>()
-        verify(exactly = 1) { interactionHook.sendMessageEmbeds(capture(slot)) }
+        verify(exactly = 1) { hook.sendMessageEmbeds(capture(slot)) }
         return slot.captured
     }
 
@@ -77,10 +88,8 @@ class AchievementsCommandTest : CommandTest {
 
         runCommand()
 
-        verify(exactly = 1) {
-            interactionHook.sendMessage("This command can only be used in a server.")
-        }
-        verify(exactly = 0) { interactionHook.sendMessageEmbeds(any<MessageEmbed>()) }
+        verify(exactly = 1) { hook.sendMessage("This command can only be used in a server.") }
+        verify(exactly = 0) { hook.sendMessageEmbeds(any<MessageEmbed>()) }
     }
 
     @Test

--- a/discord-bot/src/test/kotlin/bot/toby/handler/AchievementEventHandlerTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/handler/AchievementEventHandlerTest.kt
@@ -60,46 +60,84 @@ class AchievementEventHandlerTest {
     }
 
     @Test
-    fun `streak claim unlocks every milestone the current streak crosses`() {
-        // currentStreak=7 → streak_first, streak_3, streak_7 (not streak_30).
+    fun `streak claim calls setProgress for every milestone with currentStreak as the value`() {
         handler.onStreakClaimed(
             StreakClaimedEvent(discordId, guildId, currentStreak = 7, longestStreak = 7, channelId = 99L)
         )
         verify(exactly = 1) { achievementService.unlock(discordId, guildId, "streak_first", 99L) }
-        verify(exactly = 1) { achievementService.unlock(discordId, guildId, "streak_3", 99L) }
-        verify(exactly = 1) { achievementService.unlock(discordId, guildId, "streak_7", 99L) }
-        verify(exactly = 0) { achievementService.unlock(discordId, guildId, "streak_30", 99L) }
+        verify(exactly = 1) { achievementService.setProgress(discordId, guildId, "streak_3", 7L, 99L) }
+        verify(exactly = 1) { achievementService.setProgress(discordId, guildId, "streak_7", 7L, 99L) }
+        verify(exactly = 1) { achievementService.setProgress(discordId, guildId, "streak_30", 7L, 99L) }
+        // Old wiring used unlock() for milestones — guard against regression.
+        verify(exactly = 0) { achievementService.unlock(discordId, guildId, "streak_3", any()) }
+        verify(exactly = 0) { achievementService.unlock(discordId, guildId, "streak_7", any()) }
+        verify(exactly = 0) { achievementService.unlock(discordId, guildId, "streak_30", any()) }
     }
 
     @Test
-    fun `30-day streak unlocks every streak milestone`() {
+    fun `30-day streak claim still ratchets all milestones via setProgress`() {
         handler.onStreakClaimed(
             StreakClaimedEvent(discordId, guildId, currentStreak = 30, longestStreak = 30, channelId = null)
         )
-        listOf("streak_first", "streak_3", "streak_7", "streak_30").forEach { code ->
-            verify(exactly = 1) { achievementService.unlock(discordId, guildId, code, null) }
+        verify(exactly = 1) { achievementService.unlock(discordId, guildId, "streak_first", null) }
+        listOf(3, 7, 30).forEach { milestone ->
+            verify(exactly = 1) {
+                achievementService.setProgress(discordId, guildId, "streak_$milestone", 30L, null)
+            }
         }
+    }
+
+    @Test
+    fun `streak claim propagates a decreased streak to setProgress (streak-broke case)`() {
+        // User had a 14-day streak, broke it, now reclaiming at day 1.
+        // The locked /achievements display should show 1/3, 1/7, 1/30 —
+        // not the high-water mark. setProgress accepts decreases.
+        handler.onStreakClaimed(
+            StreakClaimedEvent(discordId, guildId, currentStreak = 1, longestStreak = 14, channelId = 99L)
+        )
+        verify(exactly = 1) { achievementService.setProgress(discordId, guildId, "streak_3", 1L, 99L) }
+        verify(exactly = 1) { achievementService.setProgress(discordId, guildId, "streak_7", 1L, 99L) }
+        verify(exactly = 1) { achievementService.setProgress(discordId, guildId, "streak_30", 1L, 99L) }
     }
 
     // ---- level ----
 
     @Test
-    fun `level-up unlocks only milestones crossed in this jump`() {
-        // 4 → 26 crosses 5 and 25, not 50.
+    fun `level-up calls setProgress for every level milestone with newLevel as the value`() {
         handler.onLevelUp(
             LevelUpEvent(discordId, guildId, oldLevel = 4, newLevel = 26, totalXp = 0L, channelId = 99L)
         )
-        verify(exactly = 1) { achievementService.unlock(discordId, guildId, "level_5", 99L) }
-        verify(exactly = 1) { achievementService.unlock(discordId, guildId, "level_25", 99L) }
-        verify(exactly = 0) { achievementService.unlock(discordId, guildId, "level_50", any()) }
+        // Unconditional — the service short-circuits already-owned milestones.
+        verify(exactly = 1) { achievementService.setProgress(discordId, guildId, "level_5", 26L, 99L) }
+        verify(exactly = 1) { achievementService.setProgress(discordId, guildId, "level_25", 26L, 99L) }
+        verify(exactly = 1) { achievementService.setProgress(discordId, guildId, "level_50", 26L, 99L) }
+        // Old wiring used unlock() — guard against regression.
+        verify(exactly = 0) { achievementService.unlock(any(), any(), match { it.startsWith("level_") }, any()) }
     }
 
     @Test
-    fun `level-up that doesn't cross any milestone unlocks nothing`() {
+    fun `level-up forwards channelId on every setProgress call`() {
+        handler.onLevelUp(
+            LevelUpEvent(discordId, guildId, oldLevel = 0, newLevel = 1, totalXp = 0L, channelId = 12345L)
+        )
+        listOf(5, 25, 50).forEach { milestone ->
+            verify(exactly = 1) {
+                achievementService.setProgress(discordId, guildId, "level_$milestone", 1L, 12345L)
+            }
+        }
+    }
+
+    @Test
+    fun `level-up still ratchets progress on tiny single-level jumps`() {
+        // Previously this test asserted no unlock calls. New semantics:
+        // every level-up tells the service the absolute level — the
+        // service decides whether to write/unlock.
         handler.onLevelUp(
             LevelUpEvent(discordId, guildId, oldLevel = 6, newLevel = 7, totalXp = 0L, channelId = 99L)
         )
-        verify(exactly = 0) { achievementService.unlock(any(), any(), match { it.startsWith("level_") }, any()) }
+        verify(exactly = 1) { achievementService.setProgress(discordId, guildId, "level_5", 7L, 99L) }
+        verify(exactly = 1) { achievementService.setProgress(discordId, guildId, "level_25", 7L, 99L) }
+        verify(exactly = 1) { achievementService.setProgress(discordId, guildId, "level_50", 7L, 99L) }
     }
 
     // ---- tip / duel / lottery / intro / blackjack ----


### PR DESCRIPTION
## Summary

Two complaints addressed:

1. **Progress on `level_*` (and `streak_*`) achievements is wrong.** The catalog gives these milestones `threshold = 5/25/50` (and `3/7/30`), so the locked display tries to show `(progress/threshold)` — but the handler called `achievementService.unlock(...)` on milestone-cross, which skips the progress table entirely. Result: locked level/streak entries always rendered as `(0/5)`, `(0/25)`, etc., regardless of the user's actual level or streak. Counter-style achievements (`duel_wins_10`, `voice_*`) already worked correctly via `progress()`.

2. **`/achievements` was hard to read — unlock state wasn't obvious without scrolling back to Toby's DM.** Locked vs unlocked shared the same line format; the only visual difference was the section header.

## Approach

**Wiring:** added `AchievementService.setProgress(value)` — sets progress to an absolute value (clamped to threshold), unlocks exactly once on reach, idempotent thereafter, and accepts decreases (the streak-broke case `progress(delta)` couldn't express). `AchievementEventHandler.onLevelUp` / `onStreakClaimed` now call `setProgress` with `newLevel` / `currentStreak` for each milestone — the service short-circuits already-owned ones. The `streak_first` one-shot continues to use `unlock()` (threshold = 1, semantics unchanged). All other achievement wirings untouched.

No backfill — each user's next level-up / streak-claim sets their progress correctly; users who've already unlocked an achievement hit the early-return on `owns(...)`.

**Display:** rebuilt the embed in `AchievementsCommand`:
- Header: `**X** / **Y** unlocked  ·  **Z XP** earned`
- One field per category (Streaks / Levels / Casino / Social / Music / Voice) in catalog order.
- Lines: checkmark + icon + bold name + description + relative timestamp + reward suffix for unlocked; lock icon + progress bar + `progress/threshold` + reward suffix for locked counters; locked one-shots drop the bar.
- Within each category: unlocked first (newest first), then locked (closest-to-unlock first).
- 1024-char-per-field guard with truncation tail.

## Test plan

- [x] `database`: 8 new `setProgress` cases (below-threshold, reach, clamp-high, idempotent-after-unlock, accept-decrease, clamp-negative, unknown-code, event-payload-parity). All pass locally.
- [ ] `discord-bot`: rewrote 4 milestone tests in `AchievementEventHandlerTest` (now asserting `setProgress` calls + regression-guarding against the old `unlock()` path), added streak-broke and per-channel-id cases. New `AchievementsCommandTest` covers empty state, header summary, category grouping + ordering, unknown-category fallback, unlocked-line format, locked counter with bar, locked one-shot without bar, the `level_5` regression case, in-category sort order, field truncation, ephemeral defer, non-guild error path. CI-only — the discord-bot module can't compile in this sandbox (music-related dependency hosts are network-blocked).
- [ ] Live smoke after merge:
  - User between milestones (e.g. level 12): Levels field shows `level_25` at `12/25` with a bar; `level_50` reads `12/50`.
  - Earn one more level: progress increments by 1.
  - Break a streak and reclaim at day 1: `streak_3/7/30` all read `1`.
- [ ] Regression smoke: `duel_wins_10` and `voice_10h` still increment via the unchanged `progress()` path.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RBzDMkBtU6QvW87r9VoJdd)_