### PR TITLE
feat(web): auto-route /preferences + /preferences/notifications past the picker when anchored

### DIFF
--- a/web/src/main/kotlin/web/controller/NotificationPreferencesController.kt
+++ b/web/src/main/kotlin/web/controller/NotificationPreferencesController.kt
@@ -3,6 +3,7 @@ package web.controller
 import common.notification.NotificationChannelKind
 import common.notification.Surface
 import database.service.UserNotificationPrefService
+import jakarta.servlet.http.HttpServletRequest
 import net.dv8tion.jda.api.JDA
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.security.oauth2.core.user.OAuth2User
@@ -11,7 +12,10 @@ import org.springframework.ui.Model
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.servlet.mvc.support.RedirectAttributes
+import web.util.DefaultGuildCookie
+import web.util.DefaultGuildRedirect
 import web.util.GuildMembership
 import web.util.discordIdOrNull
 import web.util.displayName
@@ -43,11 +47,20 @@ class NotificationPreferencesController(
     @GetMapping
     fun picker(
         @AuthenticationPrincipal user: OAuth2User?,
+        @RequestParam(required = false, defaultValue = "false") pick: Boolean,
+        request: HttpServletRequest,
         model: Model,
     ): String {
         if (user == null) return "redirect:/login"
         val discordId = user.discordIdOrNull() ?: return "redirect:/login"
-        val guilds = jda.guilds.filter { it.getMemberById(discordId) != null }
+        val mutual = jda.guilds.filter { it.getMemberById(discordId) != null }
+        DefaultGuildRedirect.pick(
+            guildIds = mutual.mapNotNull { it.id.toLongOrNull() },
+            cookieGuildId = DefaultGuildCookie.read(request),
+            pick = pick,
+        )?.let { return "redirect:/preferences/notifications/$it" }
+
+        val guilds = mutual
             .map { PickerGuild(id = it.id, name = it.name, iconUrl = it.iconUrl) }
             .sortedBy { it.name.lowercase() }
         model.addAttribute("guilds", guilds)

--- a/web/src/main/kotlin/web/controller/PreferencesController.kt
+++ b/web/src/main/kotlin/web/controller/PreferencesController.kt
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import web.service.IntroWebService
 import web.util.DefaultGuildCookie
+import web.util.DefaultGuildRedirect
 import web.util.displayName
 
 /**
@@ -40,12 +41,19 @@ class PreferencesController(
     fun page(
         @RegisteredOAuth2AuthorizedClient("discord") client: OAuth2AuthorizedClient,
         @AuthenticationPrincipal user: OAuth2User?,
+        @RequestParam(required = false, defaultValue = "false") pick: Boolean,
         request: HttpServletRequest,
         model: Model,
     ): String {
         val guilds = if (user == null) emptyList()
             else introWebService.getMutualGuilds(client.accessToken.tokenValue)
         val defaultGuildId = DefaultGuildCookie.read(request)
+
+        DefaultGuildRedirect.pick(
+            guildIds = guilds.mapNotNull { it.id.toLongOrNull() },
+            cookieGuildId = defaultGuildId,
+            pick = pick,
+        )?.let { return "redirect:/preferences/notifications/$it" }
 
         model.addAttribute("guilds", guilds)
         model.addAttribute("defaultGuildId", defaultGuildId)

--- a/web/src/main/resources/templates/fragments/navbar.html
+++ b/web/src/main/resources/templates/fragments/navbar.html
@@ -55,14 +55,14 @@
         <div class="nav-identity" th:if="${username != null}">
             <div class="nav-identity-name" th:text="${username}">User</div>
             <a th:if="${currentDefaultGuildName != null}"
-               href="/preferences"
+               th:href="@{/preferences(pick=true)}"
                class="nav-default-guild"
                th:title="'Default server: ' + ${currentDefaultGuildName} + ' — click to change'">
                 <span aria-hidden="true">&#9733;</span>
                 <span th:text="${currentDefaultGuildName}">Server</span>
             </a>
             <a th:unless="${currentDefaultGuildName != null}"
-               href="/preferences"
+               th:href="@{/preferences(pick=true)}"
                class="nav-default-guild nav-default-guild-empty"
                title="Set a default server to skip the guild picker">
                 <span aria-hidden="true">&#9734;</span>

--- a/web/src/main/resources/templates/preferences-notifications.html
+++ b/web/src/main/resources/templates/preferences-notifications.html
@@ -20,7 +20,7 @@
         start using it as soon as an adapter ships.
     </p>
 
-    <a class="back-link" th:href="@{/preferences/notifications}">&larr; Pick a different server</a>
+    <a class="back-link" th:href="@{/preferences/notifications(pick=true)}">&larr; All servers</a>
 
     <div class="notif-matrix-wrap">
         <table class="notif-matrix">

--- a/web/src/test/kotlin/web/controller/NotificationPreferencesControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/NotificationPreferencesControllerTest.kt
@@ -6,6 +6,8 @@ import database.dto.UserNotificationPrefDto
 import database.service.UserNotificationPrefService
 import io.mockk.every
 import io.mockk.mockk
+import jakarta.servlet.http.Cookie
+import jakarta.servlet.http.HttpServletRequest
 import net.dv8tion.jda.api.JDA
 import net.dv8tion.jda.api.entities.Guild
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -16,6 +18,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.security.oauth2.core.user.OAuth2User
 import org.springframework.ui.ConcurrentModel
 import org.springframework.web.servlet.mvc.support.RedirectAttributesModelMap
+import web.util.DefaultGuildCookie
 import web.util.GuildMembership
 
 class NotificationPreferencesControllerTest {
@@ -29,6 +32,7 @@ class NotificationPreferencesControllerTest {
     private lateinit var controller: NotificationPreferencesController
     private lateinit var user: OAuth2User
     private lateinit var guild: Guild
+    private lateinit var request: HttpServletRequest
 
     @BeforeEach
     fun setup() {
@@ -47,6 +51,11 @@ class NotificationPreferencesControllerTest {
         }
         every { jda.getGuildById(guildId) } returns guild
         every { membership.isMember(discordId, guildId) } returns true
+        request = mockk(relaxed = true) { every { cookies } returns null }
+    }
+
+    private fun cookieFor(id: Long) {
+        every { request.cookies } returns arrayOf(Cookie(DefaultGuildCookie.COOKIE_NAME, id.toString()))
     }
 
     @Test
@@ -161,11 +170,14 @@ class NotificationPreferencesControllerTest {
 
     @Test
     fun `picker redirects to login for unauthenticated`() {
-        assertEquals("redirect:/login", controller.picker(user = null, model = ConcurrentModel()))
+        assertEquals(
+            "redirect:/login",
+            controller.picker(user = null, pick = false, request = request, model = ConcurrentModel())
+        )
     }
 
     @Test
-    fun `picker renders guild list for authenticated user`() {
+    fun `picker renders guild list for multi-guild user without anchor`() {
         val otherGuild = mockk<Guild>(relaxed = true) {
             every { id } returns "999"
             every { idLong } returns 999L
@@ -177,7 +189,7 @@ class NotificationPreferencesControllerTest {
         every { otherGuild.getMemberById(discordId) } returns mockk(relaxed = true)
 
         val model = ConcurrentModel()
-        val view = controller.picker(user, model)
+        val view = controller.picker(user, pick = false, request = request, model = model)
         assertEquals("preferences-notifications-picker", view)
 
         @Suppress("UNCHECKED_CAST")
@@ -196,15 +208,81 @@ class NotificationPreferencesControllerTest {
             every { iconUrl } returns null
             every { getMemberById(discordId) } returns null
         }
-        every { jda.guilds } returns listOf(guild, stranger)
+        // Add a third guild so the user has >1 mutual — otherwise the
+        // single-mutual-guild auto-redirect (which is intentional) fires
+        // and the picker never renders.
+        val other = mockk<Guild>(relaxed = true) {
+            every { id } returns "888"
+            every { name } returns "Other"
+            every { iconUrl } returns null
+            every { getMemberById(discordId) } returns mockk(relaxed = true)
+        }
+        every { jda.guilds } returns listOf(guild, stranger, other)
         every { guild.getMemberById(discordId) } returns mockk(relaxed = true)
 
         val model = ConcurrentModel()
-        controller.picker(user, model)
+        controller.picker(user, pick = false, request = request, model = model)
 
         @Suppress("UNCHECKED_CAST")
         val guilds = model.getAttribute("guilds") as List<NotificationPreferencesController.PickerGuild>
-        assertEquals(1, guilds.size)
-        assertEquals("Test Guild", guilds[0].name)
+        assertEquals(2, guilds.size)
+        assertTrue(guilds.none { it.name == "Stranger" })
+    }
+
+    @Test
+    fun `picker redirects to single mutual guild's matrix`() {
+        every { jda.guilds } returns listOf(guild)
+        every { guild.getMemberById(discordId) } returns mockk(relaxed = true)
+
+        val view = controller.picker(user, pick = false, request = request, model = ConcurrentModel())
+        assertEquals("redirect:/preferences/notifications/$guildId", view)
+    }
+
+    @Test
+    fun `picker redirects to anchored guild when cookie set`() {
+        val otherGuild = mockk<Guild>(relaxed = true) {
+            every { id } returns "999"
+            every { name } returns "Other"
+            every { iconUrl } returns null
+            every { getMemberById(discordId) } returns mockk(relaxed = true)
+        }
+        every { jda.guilds } returns listOf(guild, otherGuild)
+        every { guild.getMemberById(discordId) } returns mockk(relaxed = true)
+        cookieFor(999L)
+
+        val view = controller.picker(user, pick = false, request = request, model = ConcurrentModel())
+        assertEquals("redirect:/preferences/notifications/999", view)
+    }
+
+    @Test
+    fun `picker renders picker list when pick=true even with anchor`() {
+        val otherGuild = mockk<Guild>(relaxed = true) {
+            every { id } returns "999"
+            every { name } returns "Other"
+            every { iconUrl } returns null
+            every { getMemberById(discordId) } returns mockk(relaxed = true)
+        }
+        every { jda.guilds } returns listOf(guild, otherGuild)
+        every { guild.getMemberById(discordId) } returns mockk(relaxed = true)
+        cookieFor(999L)
+
+        val view = controller.picker(user, pick = true, request = request, model = ConcurrentModel())
+        assertEquals("preferences-notifications-picker", view)
+    }
+
+    @Test
+    fun `picker ignores stale cookie pointing to non-shared guild`() {
+        val otherGuild = mockk<Guild>(relaxed = true) {
+            every { id } returns "999"
+            every { name } returns "Other"
+            every { iconUrl } returns null
+            every { getMemberById(discordId) } returns mockk(relaxed = true)
+        }
+        every { jda.guilds } returns listOf(guild, otherGuild)
+        every { guild.getMemberById(discordId) } returns mockk(relaxed = true)
+        cookieFor(12345L)
+
+        val view = controller.picker(user, pick = false, request = request, model = ConcurrentModel())
+        assertEquals("preferences-notifications-picker", view)
     }
 }

--- a/web/src/test/kotlin/web/controller/PreferencesControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/PreferencesControllerTest.kt
@@ -70,7 +70,33 @@ internal class PreferencesControllerTest {
         every { introWebService.getMutualGuilds(tokenValue) } returns listOf(guildInfo(111L), guildInfo(222L))
         val model: Model = mockk(relaxed = true)
 
-        val view = controller.page(client = client, user = user, request = cookieReq, model = model)
+        val view = controller.page(client = client, user = user, pick = false, request = cookieReq, model = model)
+
+        // Cookie points at a guild the user is in → auto-redirect to that
+        // guild's notification matrix; the hub itself isn't rendered.
+        assertEquals("redirect:/preferences/notifications/222", view)
+    }
+
+    @Test
+    fun `page returns empty guild list for anonymous user`() {
+        val model: Model = mockk(relaxed = true)
+
+        val view = controller.page(client = client, user = null, pick = false, request = request, model = model)
+
+        assertEquals("preferences", view)
+        verify(exactly = 0) { introWebService.getMutualGuilds(any()) }
+    }
+
+    @Test
+    fun `page renders hub when pick=true even with anchor`() {
+        val cookieReq: HttpServletRequest = mockk(relaxed = true) {
+            every { isSecure } returns false
+            every { cookies } returns arrayOf(Cookie(DefaultGuildCookie.COOKIE_NAME, "222"))
+        }
+        every { introWebService.getMutualGuilds(tokenValue) } returns listOf(guildInfo(111L), guildInfo(222L))
+        val model: Model = mockk(relaxed = true)
+
+        val view = controller.page(client = client, user = user, pick = true, request = cookieReq, model = model)
 
         assertEquals("preferences", view)
         verify { model.addAttribute("defaultGuildId", 222L) }
@@ -78,13 +104,37 @@ internal class PreferencesControllerTest {
     }
 
     @Test
-    fun `page returns empty guild list for anonymous user`() {
+    fun `page redirects to single mutual guild's matrix when no anchor`() {
+        every { introWebService.getMutualGuilds(tokenValue) } returns listOf(guildInfo(777L))
         val model: Model = mockk(relaxed = true)
 
-        val view = controller.page(client = client, user = null, request = request, model = model)
+        val view = controller.page(client = client, user = user, pick = false, request = request, model = model)
+
+        assertEquals("redirect:/preferences/notifications/777", view)
+    }
+
+    @Test
+    fun `page renders hub for multi-guild user without anchor`() {
+        every { introWebService.getMutualGuilds(tokenValue) } returns listOf(guildInfo(111L), guildInfo(222L))
+        val model: Model = mockk(relaxed = true)
+
+        val view = controller.page(client = client, user = user, pick = false, request = request, model = model)
 
         assertEquals("preferences", view)
-        verify(exactly = 0) { introWebService.getMutualGuilds(any()) }
+    }
+
+    @Test
+    fun `page ignores stale cookie pointing to non-shared guild`() {
+        val cookieReq: HttpServletRequest = mockk(relaxed = true) {
+            every { isSecure } returns false
+            every { cookies } returns arrayOf(Cookie(DefaultGuildCookie.COOKIE_NAME, "999"))
+        }
+        every { introWebService.getMutualGuilds(tokenValue) } returns listOf(guildInfo(111L), guildInfo(222L))
+        val model: Model = mockk(relaxed = true)
+
+        val view = controller.page(client = client, user = user, pick = false, request = cookieReq, model = model)
+
+        assertEquals("preferences", view)
     }
 
     @Test


### PR DESCRIPTION
## Summary

Follow-up to #496. The Settings and Notifications navbar entries from that PR landed users on the `/preferences` hub or the notifications guild-picker even when they had already anchored a default guild via `DefaultGuildCookie`. That's an extra click vs. the rest of the app — `/leaderboards`, `/profile/guilds`, `/casino/guilds`, `/intro/guilds` etc. already skip their pickers using the shared `DefaultGuildRedirect.pick(...)` helper.

This PR applies the same helper to both preferences entry points and adds the matching back-link, with no new utilities:

- **`NotificationPreferencesController.picker()`** now reads the cookie and redirects to `/preferences/notifications/{defaultGuildId}` when anchored (or when the user only shares one mutual guild). `?pick=true` bypasses the redirect.
- **`PreferencesController.page()`** does the same — when anchored, the Settings chip skips the hub and lands directly on the notification matrix. The hub stays reachable via `?pick=true`.
- **`preferences-notifications.html`** back-link replaced with `← All servers` pointing at `/preferences/notifications?pick=true`, matching the pattern in `profile.html:10` and `intros.html:29`. The previous link omitted `pick=true`, so after the controller change it would have bounced right back to the matrix.
- **`fragments/navbar.html`** — the ★/☆ default-server chips now use `?pick=true` so they keep landing on the hub (their entire purpose is changing/clearing the anchor). The new ⚙️ Settings chip and 🔔 Notifications nav-item stay parameter-free so they trigger the auto-route.

## Test plan

- [ ] No default anchored: Settings → `/preferences` hub; Notifications → picker
- [ ] Default anchored: Settings → `/preferences/notifications/{guildId}` matrix; Notifications → same matrix
- [ ] ★ default-server chip in navbar → `/preferences` hub even when default is anchored (via `?pick=true`)
- [ ] Matrix page **← All servers** → picker page
- [ ] Toggle a preference, refresh, confirm persistence (no API change)
- [ ] Single-mutual-guild user with no anchor: auto-routes to matrix (matches existing `DefaultGuildRedirect.pick` behavior)
- [ ] Logged-out user: both pages still 401-redirect to login

https://claude.ai/code/session_01TKUtY7NB268piNfBaZ9gzF

---
_Generated by [Claude Code](https://claude.ai/code/session_01TKUtY7NB268piNfBaZ9gzF)_