### PR TITLE
style(web): regroup profile achievements by category with progress bars and rewards

### DIFF
--- a/web/src/main/kotlin/web/service/ProfileWebService.kt
+++ b/web/src/main/kotlin/web/service/ProfileWebService.kt
@@ -74,18 +74,8 @@ class ProfileWebService(
 
         val achievementViews = achievementService.listFor(discordId, guildId)
         val unlockedAchievements = achievementViews.filter { it.unlockedAt != null }
-        val achievementEntries = achievementViews.map { v ->
-            ProfileAchievementEntry(
-                code = v.achievement.code,
-                name = v.achievement.name,
-                description = v.achievement.description,
-                icon = v.achievement.icon,
-                category = v.achievement.category,
-                threshold = v.achievement.threshold,
-                progress = v.progress,
-                unlocked = v.unlockedAt != null,
-            )
-        }
+        val totalXpEarned = unlockedAchievements.sumOf { it.achievement.xpReward.toLong() }
+        val achievementCategories = buildAchievementCategories(achievementViews)
 
         return ProfileView(
             guildId = guild.id,
@@ -108,7 +98,59 @@ class ProfileWebService(
             streak = streakView,
             achievementsUnlocked = unlockedAchievements.size,
             achievementsTotal = achievementViews.size,
-            achievements = achievementEntries,
+            totalXpEarned = totalXpEarned,
+            achievementCategories = achievementCategories,
+        )
+    }
+
+    private fun buildAchievementCategories(
+        views: List<AchievementService.AchievementView>
+    ): List<ProfileAchievementCategory> {
+        if (views.isEmpty()) return emptyList()
+        val grouped = views.groupBy { it.achievement.category }
+        val ordered = CATEGORY_ORDER.mapNotNull { key ->
+            grouped[key]?.let { key to it }
+        } + grouped.entries
+            .filter { it.key !in CATEGORY_ORDER }
+            .sortedBy { it.key }
+            .map { it.key to it.value }
+
+        return ordered.map { (key, entries) ->
+            val sorted = entries.sortedWith(
+                compareBy<AchievementService.AchievementView> { it.unlockedAt == null }
+                    .thenByDescending { it.unlockedAt?.epochSecond ?: 0L }
+                    .thenByDescending { it.progress }
+            )
+            val display = CATEGORY_DISPLAY[key]
+            ProfileAchievementCategory(
+                key = key,
+                label = display?.first ?: key.replaceFirstChar { it.uppercase() },
+                icon = display?.second ?: "🏅",
+                unlockedCount = sorted.count { it.unlockedAt != null },
+                total = sorted.size,
+                entries = sorted.map(::toEntry),
+            )
+        }
+    }
+
+    private fun toEntry(view: AchievementService.AchievementView): ProfileAchievementEntry {
+        val a = view.achievement
+        val percent = if (a.threshold > 0)
+            ((view.progress.toDouble() / a.threshold) * 100).toInt().coerceIn(0, 100)
+        else 0
+        return ProfileAchievementEntry(
+            code = a.code,
+            name = a.name,
+            description = a.description,
+            icon = a.icon,
+            category = a.category,
+            threshold = a.threshold,
+            progress = view.progress,
+            progressPercent = percent,
+            unlocked = view.unlockedAt != null,
+            unlockedAt = view.unlockedAt?.toString(),
+            xpReward = a.xpReward,
+            creditReward = a.creditReward,
         )
     }
 
@@ -118,6 +160,20 @@ class ProfileWebService(
             ProfilePermission("Meme", user?.memePermission ?: true),
             ProfilePermission("Dig", user?.digPermission ?: true),
             ProfilePermission("Superuser", user?.superUser ?: false)
+        )
+    }
+
+    companion object {
+        private val CATEGORY_ORDER = listOf("streak", "level", "casino", "social", "music", "voice")
+
+        // Pair(label, icon)
+        private val CATEGORY_DISPLAY = mapOf(
+            "streak" to ("Streaks" to "🔥"),
+            "level" to ("Levels" to "🎖️"),
+            "casino" to ("Casino" to "🎰"),
+            "social" to ("Social" to "🤝"),
+            "music" to ("Music" to "🎵"),
+            "voice" to ("Voice" to "🎙️"),
         )
     }
 }
@@ -148,7 +204,8 @@ data class ProfileView(
     val streak: ProfileStreakView,
     val achievementsUnlocked: Int,
     val achievementsTotal: Int,
-    val achievements: List<ProfileAchievementEntry>
+    val totalXpEarned: Long,
+    val achievementCategories: List<ProfileAchievementCategory>,
 )
 
 data class ProfileStreakView(
@@ -156,6 +213,15 @@ data class ProfileStreakView(
     val longestStreak: Int,
     val lastClaimDate: String?,
     val claimedToday: Boolean
+)
+
+data class ProfileAchievementCategory(
+    val key: String,
+    val label: String,
+    val icon: String,
+    val unlockedCount: Int,
+    val total: Int,
+    val entries: List<ProfileAchievementEntry>,
 )
 
 data class ProfileAchievementEntry(
@@ -166,7 +232,11 @@ data class ProfileAchievementEntry(
     val category: String,
     val threshold: Long,
     val progress: Long,
-    val unlocked: Boolean
+    val progressPercent: Int,
+    val unlocked: Boolean,
+    val unlockedAt: String?,
+    val xpReward: Int,
+    val creditReward: Long,
 )
 
 data class ProfileTitleEntry(

--- a/web/src/main/resources/static/css/profile.css
+++ b/web/src/main/resources/static/css/profile.css
@@ -225,3 +225,172 @@
         font-size: 1.35rem;
     }
 }
+
+/* ----- Achievements card ----- */
+.profile-achievements-header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: var(--space-2);
+}
+.profile-achievements-count {
+    font-size: 0.75rem;
+    text-transform: none;
+    letter-spacing: 0;
+    font-weight: 400;
+}
+.profile-achievements-sep {
+    margin: 0 6px;
+    opacity: 0.5;
+}
+
+.profile-achievement-groups {
+    display: grid;
+    gap: var(--space-4);
+}
+.profile-achievement-group + .profile-achievement-group {
+    border-top: 1px solid var(--border);
+    padding-top: var(--space-4);
+}
+
+.profile-achievement-group-title {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--text);
+    margin: 0 0 var(--space-3);
+    font-weight: 600;
+}
+.profile-achievement-group-icon {
+    font-size: 1.05rem;
+}
+.profile-achievement-group-count {
+    margin-left: auto;
+    text-transform: none;
+    letter-spacing: 0;
+    font-size: 0.75rem;
+    font-weight: 400;
+}
+
+.profile-achievements {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    gap: var(--space-3);
+}
+.profile-achievement {
+    display: grid;
+    grid-template-columns: auto auto 1fr;
+    grid-template-areas:
+        "marker icon body"
+        ".      .    body";
+    align-items: start;
+    gap: 10px;
+    padding: var(--space-3);
+    border-radius: var(--radius-md);
+    border: 1px solid var(--border);
+    background: var(--bg);
+    transition: border-color 0.15s, background 0.15s;
+}
+.profile-achievement.is-unlocked {
+    border-color: rgba(255, 200, 87, 0.45);
+    background: linear-gradient(135deg, rgba(255, 200, 87, 0.08), transparent 60%), var(--bg);
+}
+.profile-achievement.is-locked {
+    opacity: 0.78;
+}
+.profile-achievement.is-locked .profile-achievement-icon {
+    filter: grayscale(0.7);
+    opacity: 0.7;
+}
+
+.profile-achievement-marker {
+    grid-area: marker;
+    font-size: 1rem;
+    line-height: 1.2;
+}
+.profile-achievement-icon {
+    grid-area: icon;
+    font-size: 1.4rem;
+    line-height: 1.2;
+}
+.profile-achievement-body {
+    grid-area: body;
+    min-width: 0;
+    display: grid;
+    gap: 4px;
+}
+.profile-achievement-name {
+    font-weight: 600;
+    color: var(--text);
+    line-height: 1.25;
+}
+.profile-achievement.is-unlocked .profile-achievement-name {
+    color: #ffd87a;
+}
+.profile-achievement-desc {
+    font-size: 0.85rem;
+    line-height: 1.35;
+}
+
+.profile-achievement-progress {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-top: 4px;
+}
+.profile-achievement-progress-track {
+    flex: 1;
+    height: 6px;
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    overflow: hidden;
+    min-width: 80px;
+}
+.profile-achievement-progress-bar {
+    height: 100%;
+    background: linear-gradient(90deg, #c9803a 0%, #ffd966 100%);
+    border-radius: 999px;
+    transition: width 0.4s cubic-bezier(0.22, 0.61, 0.36, 1);
+}
+.profile-achievement-progress-text {
+    font-size: 0.75rem;
+    font-variant-numeric: tabular-nums;
+    flex-shrink: 0;
+}
+
+.profile-achievement-meta {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex-wrap: wrap;
+    font-size: 0.75rem;
+    margin-top: 2px;
+}
+.profile-achievement-rewards {
+    display: inline-flex;
+    gap: 8px;
+}
+.profile-achievement-rewards > span {
+    display: inline-block;
+    padding: 1px 6px;
+    border-radius: 4px;
+    background: var(--accent-soft);
+    color: var(--accent);
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
+}
+.profile-achievement.is-locked .profile-achievement-rewards > span {
+    background: var(--border);
+    color: var(--text-muted);
+}
+.profile-achievement-unlocked-at {
+    font-variant-numeric: tabular-nums;
+}

--- a/web/src/main/resources/templates/profile.html
+++ b/web/src/main/resources/templates/profile.html
@@ -111,30 +111,62 @@
         </section>
 
         <section class="profile-card profile-card-wide profile-achievements-card">
-            <h2>
-                Achievements
-                <span class="muted profile-achievements-count"
-                      th:text="'(' + ${profile.achievementsUnlocked} + ' / ' + ${profile.achievementsTotal} + ')'">
-                    (0 / 0)
+            <h2 class="profile-achievements-header">
+                <span>Achievements</span>
+                <span class="muted profile-achievements-count">
+                    <span th:text="${profile.achievementsUnlocked} + ' / ' + ${profile.achievementsTotal} + ' unlocked'">0 / 0 unlocked</span>
+                    <span class="profile-achievements-sep" aria-hidden="true">·</span>
+                    <span th:text="${profile.totalXpEarned} + ' XP earned'">0 XP earned</span>
                 </span>
             </h2>
             <div th:if="${profile.achievementsTotal == 0}" class="muted">
                 No achievements seeded yet — check back soon.
             </div>
-            <ul class="profile-achievements" th:if="${profile.achievementsTotal > 0}">
-                <li th:each="a : ${profile.achievements}"
-                    class="profile-achievement"
-                    th:classappend="${a.unlocked} ? ' is-unlocked' : ' is-locked'">
-                    <span class="profile-achievement-icon" th:text="${a.icon != null ? a.icon : '🏅'}">🏅</span>
-                    <div class="profile-achievement-body">
-                        <div class="profile-achievement-name" th:text="${a.name}">Name</div>
-                        <div class="muted profile-achievement-desc" th:text="${a.description}">Description</div>
-                        <div class="profile-achievement-progress muted"
-                             th:if="${not a.unlocked and a.threshold > 1}"
-                             th:text="${a.progress} + ' / ' + ${a.threshold}">0 / 1</div>
-                    </div>
-                </li>
-            </ul>
+            <div class="profile-achievement-groups" th:if="${profile.achievementsTotal > 0}">
+                <section class="profile-achievement-group" th:each="cat : ${profile.achievementCategories}">
+                    <h3 class="profile-achievement-group-title">
+                        <span class="profile-achievement-group-icon" th:text="${cat.icon}">🏅</span>
+                        <span th:text="${cat.label}">Category</span>
+                        <span class="muted profile-achievement-group-count"
+                              th:text="'(' + ${cat.unlockedCount} + ' / ' + ${cat.total} + ')'">(0 / 0)</span>
+                    </h3>
+                    <ul class="profile-achievements">
+                        <li th:each="a : ${cat.entries}"
+                            class="profile-achievement"
+                            th:classappend="${a.unlocked} ? ' is-unlocked' : ' is-locked'">
+                            <span class="profile-achievement-marker"
+                                  th:text="${a.unlocked} ? '✅' : '🔒'"
+                                  th:attr="aria-label=${a.unlocked} ? 'Unlocked' : 'Locked'">🔒</span>
+                            <span class="profile-achievement-icon" th:text="${a.icon != null ? a.icon : '🏅'}">🏅</span>
+                            <div class="profile-achievement-body">
+                                <div class="profile-achievement-name" th:text="${a.name}">Name</div>
+                                <div class="muted profile-achievement-desc" th:text="${a.description}">Description</div>
+                                <div class="profile-achievement-progress"
+                                     th:if="${not a.unlocked and a.threshold > 1}">
+                                    <div class="profile-achievement-progress-track"
+                                         role="progressbar"
+                                         th:attr="aria-valuenow=${a.progressPercent},aria-valuemin=0,aria-valuemax=100">
+                                        <div class="profile-achievement-progress-bar"
+                                             th:style="'width: ' + ${a.progressPercent} + '%'"></div>
+                                    </div>
+                                    <span class="muted profile-achievement-progress-text"
+                                          th:text="${a.progress} + ' / ' + ${a.threshold}">0 / 1</span>
+                                </div>
+                                <div class="profile-achievement-meta muted">
+                                    <span class="profile-achievement-rewards"
+                                          th:if="${a.xpReward > 0 or a.creditReward > 0}">
+                                        <span th:if="${a.xpReward > 0}" th:text="'+' + ${a.xpReward} + ' XP'">+0 XP</span>
+                                        <span th:if="${a.creditReward > 0}" th:text="'+' + ${a.creditReward} + '¢'">+0¢</span>
+                                    </span>
+                                    <span class="profile-achievement-unlocked-at"
+                                          th:if="${a.unlocked and a.unlockedAt != null}"
+                                          th:text="'Unlocked ' + ${#strings.substring(a.unlockedAt, 0, 10)}">Unlocked 2024-01-01</span>
+                                </div>
+                            </div>
+                        </li>
+                    </ul>
+                </section>
+            </div>
         </section>
 
         <section class="profile-card profile-card-wide">

--- a/web/src/test/kotlin/web/service/ProfileWebServiceEngagementTest.kt
+++ b/web/src/test/kotlin/web/service/ProfileWebServiceEngagementTest.kt
@@ -115,12 +115,14 @@ class ProfileWebServiceEngagementTest {
     }
 
     @Test
-    fun `achievements field rolls up unlocked and total counts and entries`() {
+    fun `achievements field rolls up unlocked and total counts and groups by category`() {
         val unlockedSpec = AchievementDto(
-            id = 1L, code = "u", name = "U", description = "ud", category = "level", threshold = 1
+            id = 1L, code = "u", name = "U", description = "ud", category = "level",
+            threshold = 1, xpReward = 25, creditReward = 50,
         )
         val lockedSpec = AchievementDto(
-            id = 2L, code = "l", name = "L", description = "ld", category = "level", threshold = 10
+            id = 2L, code = "l", name = "L", description = "ld", category = "level",
+            threshold = 10, xpReward = 100, creditReward = 0,
         )
         every { loginStreakService.get(discordId, guildId) } returns null
         every { achievementService.listFor(discordId, guildId) } returns listOf(
@@ -131,12 +133,107 @@ class ProfileWebServiceEngagementTest {
         val view = service.getProfile(discordId, guildId)!!
         assertEquals(1, view.achievementsUnlocked)
         assertEquals(2, view.achievementsTotal)
-        assertEquals(2, view.achievements.size)
-        val unlocked = view.achievements.first { it.code == "u" }
+        assertEquals(25L, view.totalXpEarned)
+
+        val levelCat = view.achievementCategories.single { it.key == "level" }
+        assertEquals("Levels", levelCat.label)
+        assertEquals("🎖️", levelCat.icon)
+        assertEquals(1, levelCat.unlockedCount)
+        assertEquals(2, levelCat.total)
+        // Unlocked entries sort before locked ones.
+        assertEquals(listOf("u", "l"), levelCat.entries.map { it.code })
+
+        val unlocked = levelCat.entries.first { it.code == "u" }
         assertTrue(unlocked.unlocked)
-        val locked = view.achievements.first { it.code == "l" }
+        assertEquals("2026-05-01T12:00:00Z", unlocked.unlockedAt)
+        assertEquals(25, unlocked.xpReward)
+        assertEquals(50L, unlocked.creditReward)
+
+        val locked = levelCat.entries.first { it.code == "l" }
         assertFalse(locked.unlocked)
         assertEquals(4L, locked.progress)
         assertEquals(10L, locked.threshold)
+        assertEquals(40, locked.progressPercent)  // 4/10 = 40%
+        assertEquals(100, locked.xpReward)
     }
+
+    @Test
+    fun `categories render in the canonical order (streak, level, casino, social, music, voice)`() {
+        every { loginStreakService.get(discordId, guildId) } returns null
+        every { achievementService.listFor(discordId, guildId) } returns listOf(
+            AchievementView(spec("v", "voice"), null, 0L),
+            AchievementView(spec("m", "music"), null, 0L),
+            AchievementView(spec("so", "social"), null, 0L),
+            AchievementView(spec("ca", "casino"), null, 0L),
+            AchievementView(spec("l", "level"), null, 0L),
+            AchievementView(spec("s", "streak"), null, 0L),
+        )
+
+        val view = service.getProfile(discordId, guildId)!!
+        assertEquals(
+            listOf("streak", "level", "casino", "social", "music", "voice"),
+            view.achievementCategories.map { it.key }
+        )
+    }
+
+    @Test
+    fun `unknown categories fall back to capitalised label and append after canonical ones`() {
+        every { loginStreakService.get(discordId, guildId) } returns null
+        every { achievementService.listFor(discordId, guildId) } returns listOf(
+            AchievementView(spec("e", "experimental"), null, 0L),
+            AchievementView(spec("s", "streak"), null, 0L),
+        )
+
+        val view = service.getProfile(discordId, guildId)!!
+        assertEquals(listOf("streak", "experimental"), view.achievementCategories.map { it.key })
+        val unknown = view.achievementCategories.last()
+        assertEquals("Experimental", unknown.label)
+        assertEquals("🏅", unknown.icon)
+    }
+
+    @Test
+    fun `within a category unlocked sorts newest-first then locked sorts by progress descending`() {
+        val older = Instant.parse("2024-01-01T00:00:00Z")
+        val newer = Instant.parse("2024-06-01T00:00:00Z")
+        every { loginStreakService.get(discordId, guildId) } returns null
+        every { achievementService.listFor(discordId, guildId) } returns listOf(
+            AchievementView(spec("lo", "casino", threshold = 10), null, 1L),
+            AchievementView(spec("un_old", "casino"), older, 1L),
+            AchievementView(spec("hi", "casino", threshold = 10), null, 8L),
+            AchievementView(spec("un_new", "casino"), newer, 1L),
+        )
+
+        val view = service.getProfile(discordId, guildId)!!
+        val codes = view.achievementCategories.single { it.key == "casino" }.entries.map { it.code }
+        assertEquals(listOf("un_new", "un_old", "hi", "lo"), codes)
+    }
+
+    @Test
+    fun `empty achievement list produces zero totals and no categories`() {
+        every { loginStreakService.get(discordId, guildId) } returns null
+        every { achievementService.listFor(discordId, guildId) } returns emptyList()
+
+        val view = service.getProfile(discordId, guildId)!!
+        assertEquals(0, view.achievementsTotal)
+        assertEquals(0, view.achievementsUnlocked)
+        assertEquals(0L, view.totalXpEarned)
+        assertTrue(view.achievementCategories.isEmpty())
+    }
+
+    private fun spec(
+        code: String,
+        category: String,
+        threshold: Long = 1L,
+        xpReward: Int = 0,
+        creditReward: Long = 0L,
+    ): AchievementDto = AchievementDto(
+        id = code.hashCode().toLong(),
+        code = code,
+        name = code,
+        description = "d",
+        category = category,
+        threshold = threshold,
+        xpReward = xpReward,
+        creditReward = creditReward,
+    )
 }


### PR DESCRIPTION
## Summary

Follow-up to #498 — that PR fixed the Discord `/achievements` embed but the **web profile page** (`/profile/{guildId}`) renders achievements with its own Thymeleaf template that was untouched. The screenshot user shared still showed a flat bulleted list, no checkmark/lock markers, no progress bar, and the same `0 / 5`, `0 / 25`, `0 / 50` text under level achievements.

Bring the web profile in line with the Discord layout:

- **Group by category** in the canonical order (Streaks / Levels / Casino / Social / Music / Voice), with a fallback bucket for unknown categories.
- **Marker column** — ✅ for unlocked, 🔒 for locked. Unlocked cards get a gold border + tint and a `.is-unlocked` modifier; locked cards are dimmed and their icon grayscaled.
- **Progress bar** for locked counter achievements (`threshold > 1`), rendered as a fixed-track gradient bar with `progressPercent` pre-computed in the service (no `[..]` ASCII bars in the browser).
- **Reward chips** — `+25 XP` / `+50¢` shown inline; muted styling on locked.
- **Unlock timestamp** — short `YYYY-MM-DD` form rendered on unlocked entries.
- **Summary header** now reads "X / Y unlocked · Z XP earned" instead of just "(2 / 15)".

Grouping + sorting (unlocked newest-first, then locked highest-progress-first) live in `ProfileWebService` so the template stays declarative.

## Test plan

- [x] `./gradlew :web:test --tests "web.service.ProfileWebServiceEngagementTest"` passes locally — updated the existing test for the new grouped shape and added 4 new cases covering category ordering, unknown-category fallback, in-category sort (unlocked newest-first → locked progress-desc), and empty list.
- [ ] Visual check after deploy:
  - Page renders one card per category with the right icon + label.
  - Unlocked entry shows ✅, gold border, reward chips highlighted, "Unlocked YYYY-MM-DD".
  - Locked counter (e.g. `level_25` at 12/25 after a level-up) shows 🔒, progress bar at 48%, "12 / 25" beside it.
  - Locked one-shot (e.g. `first_duel_win` while still locked) shows 🔒 with no progress bar.
  - Mobile layout: cards stack to one column, progress bar still readable.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RBzDMkBtU6QvW87r9VoJdd)_