### PR TITLE
fix(push): wire WebPushAdapter via @Autowired constructor

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,9 +4,8 @@ YOUTUBE_API_KEY=
 GOOGLE_REFRESH_TOKEN=
 DISCORD_CLIENT_ID=
 DISCORD_CLIENT_SECRET=
-# Optional: route YouTube traffic through an HTTP proxy to escape IP blocks
-# (use a rotating residential proxy provider such as Webshare, IPRoyal, etc.)
-YOUTUBE_PROXY_HOST=
-YOUTUBE_PROXY_PORT=
-YOUTUBE_PROXY_USER=
-YOUTUBE_PROXY_PASS=
+# Web Push (VAPID) — generate with `npx web-push generate-vapid-keys`.
+# When unset, push notifications are silently disabled.
+TOBY_VAPID_PUBLIC_KEY=
+TOBY_VAPID_PRIVATE_KEY=
+TOBY_VAPID_SUBJECT=

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ Toby Bot is a feature-rich Discord bot built using Kotlin and powered by various
 - **Spring Boot:** Leveraging the Spring Boot framework to efficiently configure and deploy the bot.
 - **JDA:** Utilising JDA, a robust Java library for interacting with the Discord API.
 - **JPA and Hibernate:** Storing and managing data in a relational database for efficient data management.
+- **Web dashboard + OAuth2:** Companion web UI (Spring MVC + Thymeleaf) for profile, achievements, notification preferences, and admin moderation. Logs in via Discord OAuth2.
+- **Per-surface notifications:** Each notification kind (achievement unlock, level-up, duel offer, tip received, streak reminder, lottery draw) ships across three surfaces — DM, channel post, and Web Push — independently opt-in per user. The router enforces "every supported surface is wired" at dispatch time so a kind can never silently drop a surface again.
+- **Web Push (RFC 8030/8291/8292):** Browser push notifications via VAPID. A service worker handles delivery and deep-links the recipient back into the dashboard.
 
 ## Prerequisites
 
@@ -46,7 +49,7 @@ Ensure you have the following prerequisites set up before getting started:
 4. Start the bot:
 
    ```shell
-   java -jar application/build/libs/application-6.1-SNAPSHOT.jar -Dspring.profiles.active=prod
+   java -jar application/build/libs/application-7.1-SNAPSHOT.jar -Dspring.profiles.active=prod
    ```
 
 ## Running with Docker
@@ -59,12 +62,14 @@ Requires [Docker Desktop](https://www.docker.com/products/docker-desktop/).
    |---|---|---|
    | `TOKEN` | Yes | Discord bot token |
    | `DATABASE_URL` | Yes | PostgreSQL URL (`postgresql://user:pass@host:5432/db`) |
+   | `DISCORD_CLIENT_ID` | Yes (web) | Discord OAuth2 client id for the web dashboard login flow. |
+   | `DISCORD_CLIENT_SECRET` | Yes (web) | Discord OAuth2 client secret. Pair with `DISCORD_CLIENT_ID`. |
+   | `APP_BASE_URL` | No | Public base URL of the web dashboard (e.g. `https://www.toby-bot.co.uk`). Used to build deep links inside Web Push notifications and any other outbound message that needs an absolute URL. When unset, push payloads omit the deep link. |
+   | `TOBY_VAPID_PUBLIC_KEY` | No | VAPID public key (base64url) for Web Push. Generate a keypair with `npx web-push generate-vapid-keys`. The public key is served to browsers at `GET /api/push/vapid-public-key`. When unset, the `WebPushAdapter` bean is not registered and the router silently drops push (everything else keeps working). |
+   | `TOBY_VAPID_PRIVATE_KEY` | No | VAPID private key (base64url). Pair with `TOBY_VAPID_PUBLIC_KEY`; never commit. |
+   | `TOBY_VAPID_SUBJECT` | No | `mailto:` or `https://` contact URL required by RFC 8292. Defaults to `mailto:admin@example.invalid`; override in production. |
    | `YOUTUBE_API_KEY` | No | YouTube Data API key |
    | `GOOGLE_REFRESH_TOKEN` | No | OAuth2 refresh token for YouTube playback. See [lavaplayer-youtube OAuth2 docs](https://github.com/lavalink-devs/youtube-source#oauth-tokens) for how to mint one. Authenticated requests are far less likely to be IP-blocked. |
-   | `YOUTUBE_PROXY_HOST` | No | Hostname of an HTTP proxy to route YouTube traffic through (both lavaplayer playback and YouTube Data API). Use a rotating residential proxy provider (Webshare, IPRoyal, Bright Data, etc.) to avoid YouTube IP blocks without manually restarting the dyno. |
-   | `YOUTUBE_PROXY_PORT` | No | Port for the proxy above. Required if `YOUTUBE_PROXY_HOST` is set. |
-   | `YOUTUBE_PROXY_USER` | No | Username for proxy basic auth. Optional. |
-   | `YOUTUBE_PROXY_PASS` | No | Password for proxy basic auth. Optional. |
 
    **Option A — `.env` file** (copy the example and fill in your values):
 
@@ -86,6 +91,38 @@ Requires [Docker Desktop](https://www.docker.com/products/docker-desktop/).
 
 - Invite your Toby Bot to your Discord server and grant the required permissions.
 - Interact with the bot using the commands and features provided by the project.
+
+## Enabling Web Push
+
+Toby Bot ships Web Push (RFC 8030 / 8291 / 8292) for users who opt in via `/preferences/notifications` in the web dashboard.
+
+1. Generate a VAPID keypair (any P-256 ECDSA keypair will do):
+
+   ```shell
+   npx web-push generate-vapid-keys
+   ```
+
+2. Export the keys as env vars (Heroku config var, Docker secret, `.env` file, etc.):
+
+   ```
+   TOBY_VAPID_PUBLIC_KEY=<publicKey>
+   TOBY_VAPID_PRIVATE_KEY=<privateKey>
+   TOBY_VAPID_SUBJECT=mailto:admin@your-domain
+   ```
+
+   Spring's relaxed binding maps these to `toby.vapid.public-key` etc. When both keys are present the `WebPushAdapter` bean is registered and `NotificationRouter.sendPush` forwards opted-in pushes through it. When either is unset the adapter never registers — the rest of the bot keeps working unchanged.
+
+3. (Optional) set `APP_BASE_URL` so push payloads include a deep link back to the user's profile/achievements page in the dashboard.
+
+4. Smoke test after redeploy:
+
+   ```shell
+   curl -s https://your-host/api/push/vapid-public-key
+   ```
+
+   200 with the configured public key in the body means the keys are wired. 404 means the env vars aren't loaded yet.
+
+5. End-to-end: log in via Discord, toggle Push on for any event in `/preferences/notifications`, then trigger the event — a notification should land in the browser.
 
 ## Support the Project
 

--- a/application/src/test/kotlin/SpringApplicationTest.kt
+++ b/application/src/test/kotlin/SpringApplicationTest.kt
@@ -2,9 +2,12 @@ import app.Application
 import bot.configuration.TestAppConfig
 import bot.configuration.TestBotConfig
 import bot.configuration.TestManagerConfig
+import bot.toby.notify.PushAdapter
 import common.configuration.TestCachingConfig
 import database.configuration.TestDatabaseConfig
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 
@@ -20,7 +23,16 @@ import org.springframework.test.context.ActiveProfiles
 )
 @ActiveProfiles("test")
 class SpringApplicationTest {
+
+    @Autowired(required = false)
+    private var pushAdapter: PushAdapter? = null
+
     @Test
     fun contextLoads() {
+    }
+
+    @Test
+    fun `WebPushAdapter is absent when no VAPID keys are configured`() {
+        assertNull(pushAdapter)
     }
 }

--- a/application/src/test/kotlin/WebPushAdapterContextTest.kt
+++ b/application/src/test/kotlin/WebPushAdapterContextTest.kt
@@ -1,0 +1,52 @@
+import app.Application
+import bot.configuration.TestAppConfig
+import bot.configuration.TestBotConfig
+import bot.configuration.TestManagerConfig
+import bot.toby.notify.PushAdapter
+import bot.toby.notify.WebPushAdapter
+import common.configuration.TestCachingConfig
+import database.configuration.TestDatabaseConfig
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.ApplicationContext
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.TestPropertySource
+
+@SpringBootTest(
+    classes = [
+        Application::class,
+        TestCachingConfig::class,
+        TestDatabaseConfig::class,
+        TestManagerConfig::class,
+        TestAppConfig::class,
+        TestBotConfig::class,
+    ]
+)
+@ActiveProfiles("test")
+@TestPropertySource(
+    properties = [
+        "toby.vapid.public-key=test-public-key",
+        "toby.vapid.private-key=test-private-key",
+        "toby.vapid.subject=mailto:ci@example.invalid",
+    ]
+)
+class WebPushAdapterContextTest {
+
+    @Autowired
+    private lateinit var context: ApplicationContext
+
+    @Autowired(required = false)
+    private var pushAdapter: PushAdapter? = null
+
+    // Pre-fix this would fail at context refresh because Spring picked
+    // the primary constructor and couldn't find a PushTransport bean.
+    @Test
+    fun `WebPushAdapter bean is registered when VAPID keys are present`() {
+        assertNotNull(pushAdapter)
+        assertTrue(pushAdapter is WebPushAdapter)
+        assertNotNull(context.getBean(WebPushAdapter::class.java))
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ apply plugin: 'kotlin'
 
 allprojects {
     group = "com.github.ml404"
-    version = "7.0-SNAPSHOT"
+    version = "7.1-SNAPSHOT"
 
     ext['kotlin.version'] = kotlin_version
     // Override Spring Boot 3.3.4's BOM-managed versions with patched releases.

--- a/discord-bot/src/main/kotlin/bot/toby/handler/AchievementEventHandler.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/handler/AchievementEventHandler.kt
@@ -13,9 +13,11 @@ import common.events.TipSentEvent
 import common.events.VoiceSessionLoggedEvent
 import common.notification.ChannelRouteKey
 import common.notification.NotificationChannelKind
+import common.notification.PushPayload
 import database.service.AchievementService
 import net.dv8tion.jda.api.EmbedBuilder
 import net.dv8tion.jda.api.utils.messages.MessageCreateBuilder
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.event.EventListener
 import org.springframework.stereotype.Component
 import java.awt.Color
@@ -38,6 +40,7 @@ import java.awt.Color
 class AchievementEventHandler(
     private val achievementService: AchievementService,
     private val notificationRouter: NotificationRouter,
+    @Value("\${app.base-url:}") private val webBaseUrl: String = "",
 ) {
 
     @EventListener
@@ -155,27 +158,37 @@ class AchievementEventHandler(
 
     @EventListener
     fun onAchievementUnlocked(event: AchievementUnlockedEvent) {
-        notificationRouter.sendDm(
+        notificationRouter.dispatch(
+            kind = NotificationChannelKind.ACHIEVEMENT_UNLOCK,
             discordId = event.discordId,
             guildId = event.guildId,
-            kind = NotificationChannelKind.ACHIEVEMENT_UNLOCK
         ) {
-            val embed = EmbedBuilder()
-                .setTitle("${event.icon ?: "🏅"} Achievement unlocked — ${event.name}")
-                .setDescription(event.description)
-                .setColor(Color(0xFFC857))
-                .build()
-            MessageCreateBuilder().setEmbeds(embed).build()
-        }
-
-        postPublicShoutout(event)
-    }
-
-    private fun postPublicShoutout(event: AchievementUnlockedEvent) {
-        notificationRouter.sendChannel(
-            guildId = event.guildId,
-            route = ChannelRouteKey.ACHIEVEMENT_SHOUTOUT,
-            message = {
+            dm {
+                val embed = EmbedBuilder()
+                    .setTitle("${event.icon ?: "🏅"} Achievement unlocked — ${event.name}")
+                    .setDescription(event.description)
+                    .setColor(Color(0xFFC857))
+                    .build()
+                MessageCreateBuilder().setEmbeds(embed).build()
+            }
+            push {
+                PushPayload(
+                    title = "${event.icon ?: "🏅"} Achievement unlocked — ${event.name}",
+                    body = event.description,
+                    deepLink = webBaseUrl.takeIf { it.isNotBlank() }
+                        ?.let { "$it/profile/${event.guildId}" },
+                )
+            }
+            channel(
+                route = ChannelRouteKey.ACHIEVEMENT_SHOUTOUT,
+                // Router suppresses the unlocker's user-ping when they've
+                // opted out of (ACHIEVEMENT_UNLOCK, CHANNEL). The shoutout
+                // post still happens; they just don't get notified.
+                mentions = ChannelMentions(
+                    kind = NotificationChannelKind.ACHIEVEMENT_UNLOCK,
+                    userIds = listOf(event.discordId),
+                ),
+            ) {
                 // setContent on the message (not just the embed description) so the
                 // <@unlocker> mention actually pings — embed-mention pings are silent.
                 MessageCreateBuilder()
@@ -188,15 +201,8 @@ class AchievementEventHandler(
                     )
                     .setContent("<@${event.discordId}>")
                     .build()
-            },
-            // Router suppresses the unlocker's user-ping when they've
-            // opted out of (ACHIEVEMENT_UNLOCK, CHANNEL). The shoutout
-            // post still happens; they just don't get notified.
-            mentions = ChannelMentions(
-                kind = NotificationChannelKind.ACHIEVEMENT_UNLOCK,
-                userIds = listOf(event.discordId),
-            ),
-        )
+            }
+        }
     }
 
     companion object {

--- a/discord-bot/src/main/kotlin/bot/toby/leveling/LevelUpListener.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/leveling/LevelUpListener.kt
@@ -7,6 +7,7 @@ import common.leveling.LevelCurve
 import common.logging.DiscordLogger
 import common.notification.ChannelRouteKey
 import common.notification.NotificationChannelKind
+import common.notification.PushPayload
 import database.dto.TitleDto
 import database.service.LevelRoleRewardService
 import database.service.TitleService
@@ -19,6 +20,7 @@ import net.dv8tion.jda.api.entities.Role
 import net.dv8tion.jda.api.entities.UserSnowflake
 import net.dv8tion.jda.api.utils.messages.MessageCreateBuilder
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Lazy
 import org.springframework.context.event.EventListener
 import org.springframework.stereotype.Service
@@ -42,6 +44,7 @@ class LevelUpListener @Autowired constructor(
     private val levelRoleRewardService: LevelRoleRewardService,
     private val titleService: TitleService,
     private val notificationRouter: NotificationRouter,
+    @Value("\${app.base-url:}") private val webBaseUrl: String = "",
 ) {
     private val logger: DiscordLogger = DiscordLogger.createLogger(this::class.java)
 
@@ -56,42 +59,46 @@ class LevelUpListener @Autowired constructor(
             "User ${event.discordId} levelled up: ${event.oldLevel} -> ${event.newLevel}"
         }
         val member = runCatching { guild.getMemberById(event.discordId) }.getOrNull()
-        announce(guild, event, member)
-        sendLevelUpDm(event, member)
+        dispatchLevelUpNotifications(event, member)
         assignRoleRewards(guild, event)
         unlockTitles(event)
     }
 
-    private fun announce(guild: Guild, event: LevelUpEvent, member: Member?) {
-        notificationRouter.sendChannel(
-            guildId = guild.idLong,
-            route = ChannelRouteKey.LEVEL_UP,
-            originChannelId = event.channelId,
-            message = {
+    private fun dispatchLevelUpNotifications(event: LevelUpEvent, member: Member?) {
+        notificationRouter.dispatch(
+            kind = NotificationChannelKind.LEVEL_UP,
+            discordId = event.discordId,
+            guildId = event.guildId,
+        ) {
+            channel(
+                route = ChannelRouteKey.LEVEL_UP,
+                originChannelId = event.channelId,
+                // Router suppresses the leveler's user-ping when they've
+                // opted out of (LEVEL_UP, CHANNEL). Channel post still
+                // happens; they just don't get notified.
+                mentions = ChannelMentions(
+                    kind = NotificationChannelKind.LEVEL_UP,
+                    userIds = listOf(event.discordId),
+                ),
+            ) {
                 // setContent on the message (not just the embed description) so the
                 // <@leveler> mention actually pings — embed-mention pings are silent.
                 MessageCreateBuilder()
                     .setEmbeds(buildLevelUpEmbed(event, member))
                     .setContent("<@${event.discordId}>")
                     .build()
-            },
-            // Router suppresses the leveler's user-ping when they've
-            // opted out of (LEVEL_UP, CHANNEL). Channel post still
-            // happens; they just don't get notified.
-            mentions = ChannelMentions(
-                kind = NotificationChannelKind.LEVEL_UP,
-                userIds = listOf(event.discordId),
-            ),
-        )
-    }
-
-    private fun sendLevelUpDm(event: LevelUpEvent, member: Member?) {
-        notificationRouter.sendDm(
-            discordId = event.discordId,
-            guildId = event.guildId,
-            kind = NotificationChannelKind.LEVEL_UP,
-        ) {
-            MessageCreateBuilder().setEmbeds(buildLevelUpEmbed(event, member)).build()
+            }
+            dm {
+                MessageCreateBuilder().setEmbeds(buildLevelUpEmbed(event, member)).build()
+            }
+            push {
+                PushPayload(
+                    title = "Level Up — LVL ${event.newLevel}",
+                    body = "${tierName(event.newLevel)} tier — ${formatXp(event.totalXp)} total XP.",
+                    deepLink = webBaseUrl.takeIf { it.isNotBlank() }
+                        ?.let { "$it/profile/${event.guildId}" },
+                )
+            }
         }
     }
 

--- a/discord-bot/src/main/kotlin/bot/toby/notify/NotificationRouter.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/notify/NotificationRouter.kt
@@ -37,6 +37,16 @@ import java.util.concurrent.atomic.AtomicBoolean
  *   "no push adapter wired" WARN once per process so a misconfigured
  *   guild doesn't flood logs.
  *
+ * Callers should prefer [dispatch] over the surface primitives:
+ * `dispatch(kind, discordId, guildId) { dm{…}; push{…}; channel(…){…} }`
+ * fails fast at runtime when any surface the kind supports is missing
+ * a builder. The bug class that motivated this — "shipped DM + channel
+ * but forgot push, opted-in users got nothing" — becomes a CI failure
+ * instead of a silent prod drop. The surface primitives stay public
+ * for broadcast posts (e.g. [bot.toby.scheduling.LotteryAnnouncer]
+ * pinging many winners in one channel message) where there's no single
+ * recipient identity to key a dispatch on.
+ *
  * All methods are best-effort. Dispatch failures are logged but never
  * propagate, so a synchronous caller (e.g. an event listener) never
  * stalls or throws on Discord REST hiccups.
@@ -198,6 +208,147 @@ class NotificationRouter(
             }
     }
 
+    /**
+     * Single-recipient fan-out. Configure every surface [kind] supports
+     * in one place — DSL throws [IllegalStateException] if a supported
+     * surface is missing a builder, which makes "I forgot to wire push"
+     * a CI failure instead of a silent production drop.
+     *
+     * For multi-recipient broadcasts (e.g. a lottery announcement
+     * pinging many winners) use the [Collection]-overload below: the
+     * channel surface still posts once, while DM/PUSH fan out per
+     * recipient with a `(discordId) -> payload` builder.
+     *
+     * Surfaces the kind does **not** support stay optional: configuring
+     * one is a no-op (mirrors the existing `kind.supports(surface)`
+     * short-circuit in [sendDm] / [sendChannel] / [sendPush]).
+     *
+     * Example — wires all three surfaces for an achievement:
+     * ```
+     * router.dispatch(ACHIEVEMENT_UNLOCK, discordId, guildId) {
+     *     dm { buildAchievementEmbed(event) }
+     *     push { PushPayload(title, body, deepLink) }
+     *     channel(route = ACHIEVEMENT_SHOUTOUT, mentions = …) {
+     *         buildShoutoutEmbed(event)
+     *     }
+     * }
+     * ```
+     */
+    fun dispatch(
+        kind: NotificationChannelKind,
+        discordId: Long,
+        guildId: Long,
+        configure: NotificationDispatch.() -> Unit,
+    ) {
+        val plan = NotificationDispatch(kind).apply(configure)
+        enforceAllSupportedSurfacesWired(kind, plan.dmBuilder, plan.pushBuilder, plan.channelPlan)
+        // Skip surfaces the kind doesn't support even if a builder was
+        // wired — defends against typo-style misconfigurations where a
+        // caller configures `push{}` on a DM-only kind.
+        if (kind.supports(Surface.DM)) {
+            plan.dmBuilder?.let { sendDm(discordId, guildId, kind, it) }
+        }
+        if (kind.supports(Surface.PUSH)) {
+            plan.pushBuilder?.let { sendPush(discordId, guildId, kind, it) }
+        }
+        if (kind.supports(Surface.CHANNEL)) {
+            plan.channelPlan?.let { ch ->
+                sendChannel(
+                    guildId = guildId,
+                    route = ch.route,
+                    originChannelId = ch.originChannelId,
+                    message = ch.message,
+                    onSent = ch.onSent,
+                    mentions = ch.mentions,
+                )
+            }
+        }
+    }
+
+    /**
+     * Multi-recipient fan-out. Channel surface posts ONCE (the
+     * broadcast post); DM and PUSH fan out per [discordIds] entry with
+     * a `(discordId) -> payload` builder so each recipient can get a
+     * personalised message. Enforcement is identical to the
+     * single-recipient overload — every supported surface for [kind]
+     * must be wired or dispatch throws.
+     *
+     * Empty [discordIds] is valid (e.g. a lottery cycle with no
+     * winners): the channel broadcast still fires, DM/PUSH fan-out is
+     * just a zero-iteration loop.
+     *
+     * Example — lottery cycle pinging every winner in one channel post
+     * with a per-winner push:
+     * ```
+     * router.dispatch(LOTTERY_DRAW_WITH_MY_TICKET, winnerIds, guildId) {
+     *     channel(route = LOTTERY, mentions = ChannelMentions(...)) {
+     *         buildCycleAnnouncement()
+     *     }
+     *     push { winnerId -> PushPayload(...) }
+     * }
+     * ```
+     */
+    fun dispatch(
+        kind: NotificationChannelKind,
+        discordIds: Collection<Long>,
+        guildId: Long,
+        configure: MultiNotificationDispatch.() -> Unit,
+    ) {
+        val plan = MultiNotificationDispatch(kind).apply(configure)
+        enforceAllSupportedSurfacesWired(kind, plan.dmBuilder, plan.pushBuilder, plan.channelPlan)
+        // Broadcast first so per-recipient pushes don't beat the channel
+        // shoutout to the user's eyeballs.
+        if (kind.supports(Surface.CHANNEL)) {
+            plan.channelPlan?.let { ch ->
+                sendChannel(
+                    guildId = guildId,
+                    route = ch.route,
+                    originChannelId = ch.originChannelId,
+                    message = ch.message,
+                    onSent = ch.onSent,
+                    mentions = ch.mentions,
+                )
+            }
+        }
+        val dmBuilder = plan.dmBuilder.takeIf { kind.supports(Surface.DM) }
+        val pushBuilder = plan.pushBuilder.takeIf { kind.supports(Surface.PUSH) }
+        if (dmBuilder == null && pushBuilder == null) return
+        discordIds.forEach { discordId ->
+            dmBuilder?.let { builder ->
+                sendDm(discordId, guildId, kind) { builder(discordId) }
+            }
+            pushBuilder?.let { builder ->
+                sendPush(discordId, guildId, kind) { builder(discordId) }
+            }
+        }
+    }
+
+    /**
+     * Shared enforcement between single- and multi-recipient dispatch.
+     * Throws [IllegalStateException] with the list of supported
+     * surfaces the caller forgot to wire — the failure mode that
+     * shipped achievement push broken.
+     */
+    private fun enforceAllSupportedSurfacesWired(
+        kind: NotificationChannelKind,
+        dmBuilder: Any?,
+        pushBuilder: Any?,
+        channelPlan: Any?,
+    ) {
+        val missing = kind.supportedSurfaces.filter { surface ->
+            when (surface) {
+                Surface.DM -> dmBuilder == null
+                Surface.CHANNEL -> channelPlan == null
+                Surface.PUSH -> pushBuilder == null
+            }
+        }
+        check(missing.isEmpty()) {
+            "NotificationRouter.dispatch($kind) is missing builders for supported surfaces $missing. " +
+                "Wire every supported surface — silent drops are how achievement push notifications " +
+                "shipped broken in the first place."
+        }
+    }
+
     private fun resolveChannel(
         guild: Guild,
         route: ChannelRouteKey,
@@ -244,3 +395,90 @@ data class ChannelMentions(
     val kind: NotificationChannelKind,
     val userIds: List<Long>,
 )
+
+/**
+ * Builder collected by [NotificationRouter.dispatch]. One slot per
+ * surface; `dispatch` enforces that every surface [kind] supports has
+ * been wired before it fans out. Mutate only via the `dm` / `push` /
+ * `channel` helpers — direct field access is internal to the router.
+ */
+class NotificationDispatch internal constructor(
+    val kind: NotificationChannelKind,
+) {
+    internal var dmBuilder: (() -> MessageCreateData)? = null
+        private set
+    internal var pushBuilder: (() -> PushPayload)? = null
+        private set
+    internal var channelPlan: ChannelPlan? = null
+        private set
+
+    fun dm(message: () -> MessageCreateData) {
+        check(dmBuilder == null) { "dm{} configured twice for $kind dispatch" }
+        dmBuilder = message
+    }
+
+    fun push(message: () -> PushPayload) {
+        check(pushBuilder == null) { "push{} configured twice for $kind dispatch" }
+        pushBuilder = message
+    }
+
+    fun channel(
+        route: ChannelRouteKey,
+        originChannelId: Long? = null,
+        mentions: ChannelMentions? = null,
+        onSent: ((Message) -> Unit)? = null,
+        message: () -> MessageCreateData,
+    ) {
+        check(channelPlan == null) { "channel{} configured twice for $kind dispatch" }
+        channelPlan = ChannelPlan(route, originChannelId, mentions, onSent, message)
+    }
+
+    internal data class ChannelPlan(
+        val route: ChannelRouteKey,
+        val originChannelId: Long?,
+        val mentions: ChannelMentions?,
+        val onSent: ((Message) -> Unit)?,
+        val message: () -> MessageCreateData,
+    )
+}
+
+/**
+ * Multi-recipient counterpart to [NotificationDispatch]. Channel posts
+ * are broadcast (one message); DM and PUSH builders take the per-recipient
+ * `discordId` so each user can get a personalised payload (e.g. a
+ * "you won X credits" tailored to that winner's payout).
+ *
+ * Mutate only via the `dm` / `push` / `channel` helpers — direct field
+ * access is internal to the router.
+ */
+class MultiNotificationDispatch internal constructor(
+    val kind: NotificationChannelKind,
+) {
+    internal var dmBuilder: ((Long) -> MessageCreateData)? = null
+        private set
+    internal var pushBuilder: ((Long) -> PushPayload)? = null
+        private set
+    internal var channelPlan: NotificationDispatch.ChannelPlan? = null
+        private set
+
+    fun dm(message: (discordId: Long) -> MessageCreateData) {
+        check(dmBuilder == null) { "dm{} configured twice for $kind multi-dispatch" }
+        dmBuilder = message
+    }
+
+    fun push(message: (discordId: Long) -> PushPayload) {
+        check(pushBuilder == null) { "push{} configured twice for $kind multi-dispatch" }
+        pushBuilder = message
+    }
+
+    fun channel(
+        route: ChannelRouteKey,
+        originChannelId: Long? = null,
+        mentions: ChannelMentions? = null,
+        onSent: ((Message) -> Unit)? = null,
+        message: () -> MessageCreateData,
+    ) {
+        check(channelPlan == null) { "channel{} configured twice for $kind multi-dispatch" }
+        channelPlan = NotificationDispatch.ChannelPlan(route, originChannelId, mentions, onSent, message)
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/notify/WebDuelOfferNotifier.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/notify/WebDuelOfferNotifier.kt
@@ -4,6 +4,7 @@ import bot.toby.command.commands.economy.DuelEmbeds
 import common.logging.DiscordLogger
 import common.notification.ChannelRouteKey
 import common.notification.NotificationChannelKind
+import common.notification.PushPayload
 import database.configuration.RegistryScheduler
 import database.duel.PendingDuelRegistry
 import net.dv8tion.jda.api.components.MessageTopLevelComponent
@@ -12,6 +13,7 @@ import net.dv8tion.jda.api.components.buttons.Button
 import net.dv8tion.jda.api.entities.Message
 import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel
 import net.dv8tion.jda.api.utils.messages.MessageCreateBuilder
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.event.EventListener
 import org.springframework.stereotype.Component
 import web.event.WebDuelOfferedEvent
@@ -42,6 +44,7 @@ class WebDuelOfferNotifier(
     private val notificationRouter: NotificationRouter,
     private val pendingDuelRegistry: PendingDuelRegistry,
     private val scheduler: ScheduledExecutorService = RegistryScheduler.instance,
+    @Value("\${app.base-url:}") private val webBaseUrl: String = "",
 ) {
     private val logger = DiscordLogger.createLogger(this::class.java)
 
@@ -55,10 +58,22 @@ class WebDuelOfferNotifier(
             DuelEmbeds.declineButtonId(event.duelId, event.opponentDiscordId),
             "Decline"
         )
-        notificationRouter.sendChannel(
+        notificationRouter.dispatch(
+            kind = NotificationChannelKind.DUEL_OFFER,
+            discordId = event.opponentDiscordId,
             guildId = event.guildId,
-            route = ChannelRouteKey.SYSTEM,
-            message = {
+        ) {
+            channel(
+                route = ChannelRouteKey.SYSTEM,
+                onSent = { sent -> scheduleTimeoutCleanup(event, sent) },
+                // Router suppresses the opponent's user-ping when they've
+                // opted out of (DUEL_OFFER, CHANNEL). Buttons still render
+                // and the embed still shows; they just don't get notified.
+                mentions = ChannelMentions(
+                    kind = NotificationChannelKind.DUEL_OFFER,
+                    userIds = listOf(event.opponentDiscordId),
+                ),
+            ) {
                 // setContent on the message (not the embed description) so the
                 // <@opponent> mention actually pings — embed-mention pings are silent.
                 MessageCreateBuilder()
@@ -73,16 +88,16 @@ class WebDuelOfferNotifier(
                     .setContent("<@${event.opponentDiscordId}>")
                     .setComponents(ActionRow.of(accept, decline))
                     .build()
-            },
-            onSent = { sent -> scheduleTimeoutCleanup(event, sent) },
-            // Router suppresses the opponent's user-ping when they've
-            // opted out of (DUEL_OFFER, CHANNEL). Buttons still render
-            // and the embed still shows; they just don't get notified.
-            mentions = ChannelMentions(
-                kind = NotificationChannelKind.DUEL_OFFER,
-                userIds = listOf(event.opponentDiscordId),
-            ),
-        )
+            }
+            push {
+                PushPayload(
+                    title = "⚔️ Duel offer (${event.stake} credits)",
+                    body = "<@${event.initiatorDiscordId}> challenged you. Respond before it expires.",
+                    deepLink = webBaseUrl.takeIf { it.isNotBlank() }
+                        ?.let { "$it/profile/${event.guildId}" },
+                )
+            }
+        }
     }
 
     private fun scheduleTimeoutCleanup(event: WebDuelOfferedEvent, sent: Message) {

--- a/discord-bot/src/main/kotlin/bot/toby/notify/WebPushAdapter.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/notify/WebPushAdapter.kt
@@ -7,6 +7,7 @@ import database.service.PushSubscriptionService
 import nl.martijndwars.webpush.Notification
 import nl.martijndwars.webpush.PushService
 import org.bouncycastle.jce.provider.BouncyCastleProvider
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Component
@@ -55,8 +56,11 @@ class WebPushAdapter(
     /**
      * Production constructor used by Spring. Builds a [DefaultPushTransport]
      * from the VAPID env vars; tests use the primary constructor with a
-     * fake [PushTransport] directly.
+     * fake [PushTransport] directly. `@Autowired` is required so Spring
+     * picks this constructor instead of the primary (no `PushTransport`
+     * bean is published).
      */
+    @Autowired
     constructor(
         subscriptions: PushSubscriptionService,
         objectMapper: ObjectMapper,

--- a/discord-bot/src/main/kotlin/bot/toby/notify/WebTipNotifier.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/notify/WebTipNotifier.kt
@@ -3,8 +3,10 @@ package bot.toby.notify
 import bot.toby.command.commands.economy.TipEmbeds
 import common.notification.ChannelRouteKey
 import common.notification.NotificationChannelKind
+import common.notification.PushPayload
 import database.service.TipService.TipOutcome
 import net.dv8tion.jda.api.utils.messages.MessageCreateBuilder
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.event.EventListener
 import org.springframework.stereotype.Component
 import web.event.WebTipSentEvent
@@ -23,6 +25,7 @@ import web.event.WebTipSentEvent
 @Component
 class WebTipNotifier(
     private val notificationRouter: NotificationRouter,
+    @Value("\${app.base-url:}") private val webBaseUrl: String = "",
 ) {
     @EventListener
     fun on(event: WebTipSentEvent) {
@@ -36,23 +39,36 @@ class WebTipNotifier(
             sentTodayAfter = event.sentTodayAfter,
             dailyCap = event.dailyCap
         )
-        notificationRouter.sendChannel(
+        notificationRouter.dispatch(
+            kind = NotificationChannelKind.TIP_RECEIVED,
+            discordId = event.recipientDiscordId,
             guildId = event.guildId,
-            route = ChannelRouteKey.SYSTEM,
-            message = {
+        ) {
+            channel(
+                route = ChannelRouteKey.SYSTEM,
+                // Router suppresses the recipient's user-ping when they've
+                // opted out of (TIP_RECEIVED, CHANNEL). Post still happens.
+                mentions = ChannelMentions(
+                    kind = NotificationChannelKind.TIP_RECEIVED,
+                    userIds = listOf(event.recipientDiscordId),
+                ),
+            ) {
                 // setContent on the message (not the embed description) so the
                 // <@recipient> mention actually pings — embed-mention pings are silent.
                 MessageCreateBuilder()
                     .setEmbeds(TipEmbeds.okEmbed(outcome))
                     .setContent("<@${event.recipientDiscordId}>")
                     .build()
-            },
-            // Router suppresses the recipient's user-ping when they've
-            // opted out of (TIP_RECEIVED, CHANNEL). Post still happens.
-            mentions = ChannelMentions(
-                kind = NotificationChannelKind.TIP_RECEIVED,
-                userIds = listOf(event.recipientDiscordId),
-            ),
-        )
+            }
+            push {
+                val note = event.note?.takeIf { it.isNotBlank() }?.let { " — \"$it\"" } ?: ""
+                PushPayload(
+                    title = "💰 You received ${event.amount} credits",
+                    body = "<@${event.senderDiscordId}> tipped you$note.",
+                    deepLink = webBaseUrl.takeIf { it.isNotBlank() }
+                        ?.let { "$it/profile/${event.guildId}" },
+                )
+            }
+        }
     }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/scheduling/LotteryAnnouncer.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/scheduling/LotteryAnnouncer.kt
@@ -5,6 +5,7 @@ import bot.toby.notify.NotificationRouter
 import common.logging.DiscordLogger
 import common.notification.ChannelRouteKey
 import common.notification.NotificationChannelKind
+import common.notification.PushPayload
 import database.dto.JackpotLotteryDto
 import database.service.ConfigService
 import database.service.JackpotLotteryService
@@ -86,10 +87,46 @@ class LotteryAnnouncer @Autowired constructor(
     ) {
         val lotteryId = (openOutcome as? OpenSummary.Ok)?.lotteryId
         val poolAmount = (openOutcome as? OpenSummary.Ok)?.poolAmount
-        notificationRouter.sendChannel(
+        val winners = winnerPingIds(priorOutcome)
+        val payoutByWinner = payoutByWinner(priorOutcome)
+        // Multi-recipient dispatch: channel{} broadcasts one message
+        // pinging every winner; push{} fans out per-winner with each
+        // user's own payout in the body. When there are no winners the
+        // channel post still fires and the push loop is a no-op.
+        notificationRouter.dispatch(
+            kind = NotificationChannelKind.LOTTERY_DRAW_WITH_MY_TICKET,
+            discordIds = winners,
             guildId = guild.idLong,
-            route = ChannelRouteKey.LOTTERY,
-            message = {
+        ) {
+            channel(
+                route = ChannelRouteKey.LOTTERY,
+                onSent = { sent ->
+                    if (lotteryId != null && poolAmount != null) {
+                        runCatching {
+                            jackpotLotteryService.recordAnnouncement(
+                                lotteryId = lotteryId,
+                                channelId = sent.channel.idLong,
+                                messageId = sent.idLong,
+                                pool = poolAmount,
+                            )
+                        }.onFailure {
+                            logger.warn(
+                                "Could not persist lottery announcement reference for " +
+                                    "lottery $lotteryId (guild ${guild.idLong}): ${it.message}"
+                            )
+                        }
+                    }
+                },
+                // Router suppresses any winner's user-ping when they've
+                // opted out of (LOTTERY_DRAW_WITH_MY_TICKET, CHANNEL). Wide
+                // ping (@here/@everyone) is unaffected. winners is empty
+                // when there are no winners — a non-null mentions with an
+                // empty list is the correct signal.
+                mentions = ChannelMentions(
+                    kind = NotificationChannelKind.LOTTERY_DRAW_WITH_MY_TICKET,
+                    userIds = winners,
+                ),
+            ) {
                 val embed = buildEmbed(guild, mode, priorOutcome, openOutcome)
                 val content = buildAnnouncementContent(guild, priorOutcome)
                 val actionRow = announcementActionRow(mode, guild.idLong)
@@ -99,34 +136,27 @@ class LotteryAnnouncer @Autowired constructor(
                 if (content.isNotBlank()) builder.setContent(content)
                 if (actionRow != null) builder.setComponents(actionRow)
                 builder.build()
-            },
-            onSent = { sent ->
-                if (lotteryId != null && poolAmount != null) {
-                    runCatching {
-                        jackpotLotteryService.recordAnnouncement(
-                            lotteryId = lotteryId,
-                            channelId = sent.channel.idLong,
-                            messageId = sent.idLong,
-                            pool = poolAmount,
-                        )
-                    }.onFailure {
-                        logger.warn(
-                            "Could not persist lottery announcement reference for " +
-                                "lottery $lotteryId (guild ${guild.idLong}): ${it.message}"
-                        )
-                    }
-                }
-            },
-            // Router suppresses any winner's user-ping when they've
-            // opted out of (LOTTERY_DRAW_WITH_MY_TICKET, CHANNEL). Wide
-            // ping (@here/@everyone) is unaffected. winnerPingIds is
-            // empty when there are no winners — passing a non-null
-            // mentions with an empty list is the correct signal.
-            mentions = ChannelMentions(
-                kind = NotificationChannelKind.LOTTERY_DRAW_WITH_MY_TICKET,
-                userIds = winnerPingIds(priorOutcome),
-            ),
-        )
+            }
+            push { winnerId ->
+                val amount = payoutByWinner[winnerId]
+                PushPayload(
+                    title = "🎰 You won the lottery!",
+                    body = amount?.let { "Payout: $it credits" }
+                        ?: "Check the lottery channel for details.",
+                    deepLink = webBaseUrl.takeIf { it.isNotBlank() }
+                        ?.let { "$it/profile/${guild.idLong}" },
+                )
+            }
+        }
+    }
+
+    /** Flatten the prior outcome into `discordId → credit amount paid`. */
+    private fun payoutByWinner(prior: PriorOutcome?): Map<Long, Long> = when (prior) {
+        is PriorOutcome.MatchDrawn ->
+            prior.tierPayouts.associate { it.discordId to it.share }
+        is PriorOutcome.WeightedDrawn ->
+            prior.payouts.associate { it.discordId to it.amount }
+        else -> emptyMap()
     }
 
     /**

--- a/discord-bot/src/main/kotlin/bot/toby/scheduling/StreakReminderJob.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/scheduling/StreakReminderJob.kt
@@ -3,11 +3,13 @@ package bot.toby.scheduling
 import bot.toby.notify.NotificationRouter
 import common.logging.DiscordLogger
 import common.notification.NotificationChannelKind
+import common.notification.PushPayload
 import database.service.LoginStreakService
 import net.dv8tion.jda.api.EmbedBuilder
 import net.dv8tion.jda.api.JDA
 import net.dv8tion.jda.api.utils.messages.MessageCreateBuilder
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Profile
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
@@ -33,7 +35,8 @@ class StreakReminderJob @Autowired constructor(
     private val jda: JDA,
     private val loginStreakService: LoginStreakService,
     private val notificationRouter: NotificationRouter,
-    private val clock: Clock = Clock.systemUTC()
+    private val clock: Clock = Clock.systemUTC(),
+    @Value("\${app.base-url:}") private val webBaseUrl: String = "",
 ) {
     private val logger: DiscordLogger = DiscordLogger.createLogger(this::class.java)
 
@@ -59,21 +62,31 @@ class StreakReminderJob @Autowired constructor(
 
         var dispatched = 0
         due.forEach { row ->
-            notificationRouter.sendDm(
+            notificationRouter.dispatch(
+                kind = NotificationChannelKind.STREAK_REMINDER,
                 discordId = row.discordId,
                 guildId = guildId,
-                kind = NotificationChannelKind.STREAK_REMINDER
             ) {
-                MessageCreateBuilder().setEmbeds(
-                    EmbedBuilder()
-                        .setTitle("🔥 Don't lose your ${row.currentStreak}-day streak")
-                        .setDescription(
-                            "Your daily streak resets at midnight UTC. " +
-                                "Run `/daily` (or claim from the dashboard) to keep it alive."
-                        )
-                        .setColor(Color(0xF59E0B))
-                        .build()
-                ).build()
+                dm {
+                    MessageCreateBuilder().setEmbeds(
+                        EmbedBuilder()
+                            .setTitle("🔥 Don't lose your ${row.currentStreak}-day streak")
+                            .setDescription(
+                                "Your daily streak resets at midnight UTC. " +
+                                    "Run `/daily` (or claim from the dashboard) to keep it alive."
+                            )
+                            .setColor(Color(0xF59E0B))
+                            .build()
+                    ).build()
+                }
+                push {
+                    PushPayload(
+                        title = "🔥 Don't lose your ${row.currentStreak}-day streak",
+                        body = "Claim today's /daily before midnight UTC to keep it alive.",
+                        deepLink = webBaseUrl.takeIf { it.isNotBlank() }
+                            ?.let { "$it/profile/$guildId" },
+                    )
+                }
             }
             dispatched++
         }

--- a/discord-bot/src/test/kotlin/bot/toby/handler/AchievementEventHandlerTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/handler/AchievementEventHandlerTest.kt
@@ -2,6 +2,7 @@ package bot.toby.handler
 
 import bot.toby.notify.ChannelMentions
 import bot.toby.notify.NotificationRouter
+import bot.toby.notify.PushAdapter
 import common.events.AchievementUnlockedEvent
 import common.events.BlackjackNaturalEvent
 import common.events.DuelResolvedEvent
@@ -13,13 +14,21 @@ import common.events.TipSentEvent
 import common.events.VoiceSessionLoggedEvent
 import common.notification.ChannelRouteKey
 import common.notification.NotificationChannelKind
+import common.notification.PushPayload
 import database.service.AchievementService
+import database.service.ConfigService
+import database.service.UserNotificationPrefService
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.slot
+import io.mockk.spyk
 import io.mockk.verify
+import net.dv8tion.jda.api.JDA
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
@@ -46,7 +55,22 @@ class AchievementEventHandlerTest {
     @BeforeEach
     fun setup() {
         achievementService = mockk(relaxed = true)
-        router = mockk(relaxed = true)
+        // Spy on a real router so `dispatch` runs its enforcement
+        // (missing-supported-surface throws) and forwards to spied
+        // primitives we can verify. The primitives are stubbed so we
+        // don't drag in JDA REST for unit tests.
+        val jda = mockk<JDA>(relaxed = true)
+        val prefService = mockk<UserNotificationPrefService>(relaxed = true) {
+            every { isOptedIn(any(), any(), any(), any()) } returns true
+        }
+        val configService = mockk<ConfigService>(relaxed = true)
+        val pushAdapter = mockk<PushAdapter>(relaxed = true)
+        router = spyk(NotificationRouter(jda, prefService, configService, pushAdapter))
+        every { router.sendDm(any(), any(), any(), any()) } just runs
+        every { router.sendPush(any(), any(), any(), any()) } just runs
+        every {
+            router.sendChannel(any(), any(), any(), any(), any(), any())
+        } just runs
         handler = AchievementEventHandler(achievementService, router)
     }
 
@@ -268,6 +292,92 @@ class AchievementEventHandlerTest {
                     userIds = listOf(discordId),
                 ),
             )
+        }
+    }
+
+    @Test
+    fun `achievement unlock also routes a push notification via ACHIEVEMENT_UNLOCK with PUSH opt-in gating`() {
+        // Regression: pre-fix the handler only called sendDm/sendChannel,
+        // so users who opted into Surface.PUSH for ACHIEVEMENT_UNLOCK got
+        // nothing in their browser when an achievement fired.
+        val event = AchievementUnlockedEvent(
+            discordId = discordId, guildId = guildId,
+            achievementId = 1L, achievementCode = "tip_giver",
+            name = "Generous", description = "Tip another user for the first time.",
+            icon = "🎁", channelId = null,
+        )
+        handler.onAchievementUnlocked(event)
+
+        verify(exactly = 1) {
+            router.sendPush(
+                discordId = discordId,
+                guildId = guildId,
+                kind = NotificationChannelKind.ACHIEVEMENT_UNLOCK,
+                message = any(),
+            )
+        }
+    }
+
+    @Test
+    fun `achievement push payload carries the achievement name, description, and a null deep link when base url is unset`() {
+        val event = AchievementUnlockedEvent(
+            discordId = discordId, guildId = guildId,
+            achievementId = 1L, achievementCode = "tip_giver",
+            name = "Generous", description = "Tip another user for the first time.",
+            icon = "🎁", channelId = null,
+        )
+        val captured = slot<() -> PushPayload>()
+        every {
+            router.sendPush(any(), any(), any(), capture(captured))
+        } just runs
+
+        handler.onAchievementUnlocked(event)
+
+        val payload = captured.captured.invoke()
+        assertEquals("🎁 Achievement unlocked — Generous", payload.title)
+        assertEquals("Tip another user for the first time.", payload.body)
+        assertNull(payload.deepLink) // setUp uses 2-arg ctor → webBaseUrl=""
+    }
+
+    @Test
+    fun `achievement push payload sets deep link to profile page when app base url is configured`() {
+        val handlerWithBaseUrl = AchievementEventHandler(
+            achievementService = achievementService,
+            notificationRouter = router,
+            webBaseUrl = "https://www.toby-bot.co.uk",
+        )
+        val event = AchievementUnlockedEvent(
+            discordId = discordId, guildId = guildId,
+            achievementId = 1L, achievementCode = "tip_giver",
+            name = "Generous", description = "desc", icon = null, channelId = null,
+        )
+        val captured = slot<() -> PushPayload>()
+        every {
+            router.sendPush(any(), any(), any(), capture(captured))
+        } just runs
+
+        handlerWithBaseUrl.onAchievementUnlocked(event)
+
+        val payload = captured.captured.invoke()
+        assertEquals("https://www.toby-bot.co.uk/profile/$guildId", payload.deepLink)
+    }
+
+    @Test
+    fun `achievement push uses default rosette icon when event icon is null`() {
+        val event = AchievementUnlockedEvent(
+            discordId = discordId, guildId = guildId,
+            achievementId = 1L, achievementCode = "x",
+            name = "Quiet One", description = "d", icon = null, channelId = null,
+        )
+        val captured = slot<() -> PushPayload>()
+        every {
+            router.sendPush(any(), any(), any(), capture(captured))
+        } just runs
+
+        handler.onAchievementUnlocked(event)
+
+        assert(captured.captured.invoke().title.startsWith("🏅 ")) {
+            "expected default rosette icon when event.icon is null"
         }
     }
 

--- a/discord-bot/src/test/kotlin/bot/toby/leveling/LevelUpListenerTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/leveling/LevelUpListenerTest.kt
@@ -2,20 +2,25 @@ package bot.toby.leveling
 
 import bot.toby.notify.ChannelMentions
 import bot.toby.notify.NotificationRouter
+import bot.toby.notify.PushAdapter
 import common.events.LevelUpEvent
 import common.leveling.LevelCurve
 import common.notification.ChannelRouteKey
 import common.notification.NotificationChannelKind
+import common.notification.PushPayload
 import database.dto.LevelRoleRewardDto
 import database.dto.TitleDto
+import database.service.ConfigService
 import database.service.LevelRoleRewardService
 import database.service.TitleService
+import database.service.UserNotificationPrefService
 import io.mockk.CapturingSlot
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.slot
+import io.mockk.spyk
 import io.mockk.verify
 import net.dv8tion.jda.api.JDA
 import net.dv8tion.jda.api.entities.Guild
@@ -41,7 +46,21 @@ class LevelUpListenerTest {
     @BeforeEach
     fun setUp() {
         jda = mockk(relaxed = true)
-        router = mockk(relaxed = true)
+        val prefService = mockk<UserNotificationPrefService>(relaxed = true) {
+            every { isOptedIn(any(), any(), any(), any()) } returns true
+        }
+        val configService = mockk<ConfigService>(relaxed = true)
+        val pushAdapter = mockk<PushAdapter>(relaxed = true)
+        // Spy on a real router so dispatch's enforcement runs against
+        // the listener's wiring (every supported surface must be wired
+        // or dispatch throws). Surface primitives are stubbed so we
+        // don't drag in JDA REST.
+        router = spyk(NotificationRouter(jda, prefService, configService, pushAdapter))
+        every { router.sendDm(any(), any(), any(), any()) } just runs
+        every { router.sendPush(any(), any(), any(), any()) } just runs
+        every {
+            router.sendChannel(any(), any(), any(), any(), any(), any())
+        } just runs
         levelRoleRewardService = mockk(relaxed = true)
         titleService = mockk(relaxed = true)
         listener = LevelUpListener(jda, levelRoleRewardService, titleService, router)
@@ -143,6 +162,44 @@ class LevelUpListenerTest {
                 kind = NotificationChannelKind.LEVEL_UP,
                 message = any(),
             )
+        }
+    }
+
+    @Test
+    fun `onLevelUp also pushes the leveller — regression guard for forgotten push surface`() {
+        // LEVEL_UP supports DM + CHANNEL + PUSH. Dispatch enforcement
+        // requires all three; pin that the push surface fires.
+        guildOnly()
+        captureAnnouncementEmbed()
+
+        listener.onLevelUp(
+            LevelUpEvent(discordId, guildId, oldLevel = 0, newLevel = 1, totalXp = 110L, channelId = 99L)
+        )
+
+        verify(exactly = 1) {
+            router.sendPush(discordId, guildId, NotificationChannelKind.LEVEL_UP, any())
+        }
+    }
+
+    @Test
+    fun `onLevelUp push payload names the new level and total XP`() {
+        guildOnly()
+        captureAnnouncementEmbed()
+        val builder = slot<() -> PushPayload>()
+        every {
+            router.sendPush(any(), any(), any(), capture(builder))
+        } just runs
+
+        listener.onLevelUp(
+            LevelUpEvent(discordId, guildId, oldLevel = 4, newLevel = 5, totalXp = 1234L, channelId = 99L)
+        )
+
+        val payload = builder.captured.invoke()
+        assert(payload.title.contains("LVL 5")) {
+            "expected new level in push title, got: ${payload.title}"
+        }
+        assert(payload.body.contains("1,234")) {
+            "expected formatted total XP in push body, got: ${payload.body}"
         }
     }
 

--- a/discord-bot/src/test/kotlin/bot/toby/notify/NotificationRouterDispatchTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/notify/NotificationRouterDispatchTest.kt
@@ -1,0 +1,515 @@
+package bot.toby.notify
+
+import common.notification.ChannelRouteKey
+import common.notification.NotificationChannelKind
+import common.notification.PushPayload
+import common.notification.Surface
+import database.service.ConfigService
+import database.service.UserNotificationPrefService
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.verify
+import net.dv8tion.jda.api.JDA
+import net.dv8tion.jda.api.utils.messages.MessageCreateBuilder
+import net.dv8tion.jda.api.utils.messages.MessageCreateData
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * Coverage for [NotificationRouter.dispatch] — the canonical fan-out
+ * entry point that enforces "every supported surface for this kind has
+ * a builder wired" at runtime.
+ *
+ * The bug class this guards against: shipping DM + channel for a kind
+ * that supports push, forgetting to wire push, and discovering on a
+ * customer report that opted-in users never received the notification.
+ * After this refactor that mistake is a fast-failing exception during
+ * dispatch (caught by the corresponding handler test) instead of a
+ * silent production drop.
+ *
+ * Tests use a spied [NotificationRouter] so we can intercept the calls
+ * the DSL forwards to the surface primitives without exercising the
+ * JDA / push-adapter machinery (already covered by
+ * [NotificationRouterDmTest], [NotificationRouterChannelTest], and
+ * [NotificationRouterPushTest]).
+ */
+class NotificationRouterDispatchTest {
+
+    private val guildId = 100L
+    private val discordId = 200L
+
+    private lateinit var jda: JDA
+    private lateinit var prefService: UserNotificationPrefService
+    private lateinit var configService: ConfigService
+    private lateinit var pushAdapter: PushAdapter
+    private lateinit var router: NotificationRouter
+
+    @BeforeEach
+    fun setup() {
+        jda = mockk(relaxed = true)
+        prefService = mockk(relaxed = true) {
+            every { isOptedIn(any(), any(), any(), any()) } returns true
+        }
+        configService = mockk(relaxed = true)
+        pushAdapter = mockk(relaxed = true)
+        // Spy on a real router so we observe what the DSL forwards. The
+        // surface primitives are still real methods — we mock dependencies
+        // beneath them only as needed for each case.
+        router = io.mockk.spyk(
+            NotificationRouter(jda, prefService, configService, pushAdapter)
+        )
+        // Stub the surface primitives at the router level so we can
+        // assert what dispatch forwards without dragging in JDA REST.
+        every { router.sendDm(any(), any(), any(), any()) } just runs
+        every { router.sendPush(any(), any(), any(), any()) } just runs
+        every {
+            router.sendChannel(any(), any(), any(), any(), any(), any())
+        } just runs
+    }
+
+    // ---------- happy path ----------
+
+    @Test
+    fun `dispatch fans out to dm, push, and channel in one call for a kind that supports all three`() {
+        // ACHIEVEMENT_UNLOCK supports all three surfaces.
+        router.dispatch(NotificationChannelKind.ACHIEVEMENT_UNLOCK, discordId, guildId) {
+            dm { msg("dm") }
+            push { PushPayload("t", "b") }
+            channel(route = ChannelRouteKey.ACHIEVEMENT_SHOUTOUT) { msg("ch") }
+        }
+
+        verify(exactly = 1) {
+            router.sendDm(discordId, guildId, NotificationChannelKind.ACHIEVEMENT_UNLOCK, any())
+        }
+        verify(exactly = 1) {
+            router.sendPush(discordId, guildId, NotificationChannelKind.ACHIEVEMENT_UNLOCK, any())
+        }
+        verify(exactly = 1) {
+            router.sendChannel(
+                guildId = guildId,
+                route = ChannelRouteKey.ACHIEVEMENT_SHOUTOUT,
+                originChannelId = null,
+                message = any(),
+                onSent = null,
+                mentions = null,
+            )
+        }
+    }
+
+    @Test
+    fun `dispatch forwards channel originChannelId, mentions, and onSent through to sendChannel`() {
+        val mentions = ChannelMentions(
+            kind = NotificationChannelKind.ACHIEVEMENT_UNLOCK,
+            userIds = listOf(discordId),
+        )
+        val onSent: (net.dv8tion.jda.api.entities.Message) -> Unit = {}
+        router.dispatch(NotificationChannelKind.ACHIEVEMENT_UNLOCK, discordId, guildId) {
+            dm { msg("dm") }
+            push { PushPayload("t", "b") }
+            channel(
+                route = ChannelRouteKey.ACHIEVEMENT_SHOUTOUT,
+                originChannelId = 9999L,
+                mentions = mentions,
+                onSent = onSent,
+            ) { msg("ch") }
+        }
+
+        verify(exactly = 1) {
+            router.sendChannel(
+                guildId = guildId,
+                route = ChannelRouteKey.ACHIEVEMENT_SHOUTOUT,
+                originChannelId = 9999L,
+                message = any(),
+                onSent = onSent,
+                mentions = mentions,
+            )
+        }
+    }
+
+    // ---------- enforcement: missing surfaces fail fast ----------
+
+    @Test
+    fun `dispatch throws when a supported surface has no builder — the regression guard`() {
+        // ACHIEVEMENT_UNLOCK supports DM + CHANNEL + PUSH. Forgetting push
+        // is exactly the bug that shipped achievement push broken.
+        val err = assertThrows(IllegalStateException::class.java) {
+            router.dispatch(NotificationChannelKind.ACHIEVEMENT_UNLOCK, discordId, guildId) {
+                dm { msg("dm") }
+                channel(route = ChannelRouteKey.ACHIEVEMENT_SHOUTOUT) { msg("ch") }
+                // push intentionally omitted
+            }
+        }
+        assertNotNull(err.message)
+        assert(err.message!!.contains("PUSH")) {
+            "expected error to name the missing surface, got: ${err.message}"
+        }
+        // Nothing should have been forwarded — enforcement runs before fan-out.
+        verify(exactly = 0) { router.sendDm(any(), any(), any(), any()) }
+        verify(exactly = 0) { router.sendPush(any(), any(), any(), any()) }
+        verify(exactly = 0) {
+            router.sendChannel(any(), any(), any(), any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `dispatch reports every missing surface, not just the first`() {
+        val err = assertThrows(IllegalStateException::class.java) {
+            router.dispatch(NotificationChannelKind.ACHIEVEMENT_UNLOCK, discordId, guildId) {
+                // Wire nothing.
+            }
+        }
+        val msg = err.message ?: ""
+        assert(msg.contains("DM") && msg.contains("CHANNEL") && msg.contains("PUSH")) {
+            "expected all three surfaces in the error, got: $msg"
+        }
+    }
+
+    // ---------- kinds with fewer supported surfaces ----------
+
+    @Test
+    fun `dispatch accepts a single dm builder for a dm-only kind (INTRO_PROMPT)`() {
+        // INTRO_PROMPT supports DM only — push is not allowed for this
+        // kind and channel isn't either. The DSL must succeed with just
+        // dm{} and forward nothing else.
+        router.dispatch(NotificationChannelKind.INTRO_PROMPT, discordId, guildId) {
+            dm { msg("intro") }
+        }
+        verify(exactly = 1) {
+            router.sendDm(discordId, guildId, NotificationChannelKind.INTRO_PROMPT, any())
+        }
+        verify(exactly = 0) { router.sendPush(any(), any(), any(), any()) }
+        verify(exactly = 0) {
+            router.sendChannel(any(), any(), any(), any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `dispatch skips forwarding to surfaces the kind does not support, even when a builder is wired`() {
+        // INTRO_PROMPT is DM-only. Wiring push{} is a caller-side typo;
+        // the dispatch silently skips it rather than invoking sendPush
+        // and relying on its inner short-circuit. The lazy payload
+        // builder is also never invoked.
+        var pushBuilderInvoked = false
+        router.dispatch(NotificationChannelKind.INTRO_PROMPT, discordId, guildId) {
+            dm { msg("intro") }
+            push {
+                pushBuilderInvoked = true
+                PushPayload("t", "b")
+            }
+        }
+        verify(exactly = 1) {
+            router.sendDm(discordId, guildId, NotificationChannelKind.INTRO_PROMPT, any())
+        }
+        verify(exactly = 0) { router.sendPush(any(), any(), any(), any()) }
+        assert(!pushBuilderInvoked) { "push builder should not be invoked for an unsupported surface" }
+    }
+
+    @Test
+    fun `dispatch requires both surfaces for a two-surface kind (STREAK_REMINDER = DM + PUSH)`() {
+        // STREAK_REMINDER supports DM + PUSH but not CHANNEL.
+        assertThrows(IllegalStateException::class.java) {
+            router.dispatch(NotificationChannelKind.STREAK_REMINDER, discordId, guildId) {
+                dm { msg("dm") } // push missing
+            }
+        }
+        // And the happy path with both wired succeeds.
+        router.dispatch(NotificationChannelKind.STREAK_REMINDER, discordId, guildId) {
+            dm { msg("dm") }
+            push { PushPayload("t", "b") }
+        }
+        verify(exactly = 1) {
+            router.sendDm(discordId, guildId, NotificationChannelKind.STREAK_REMINDER, any())
+        }
+        verify(exactly = 1) {
+            router.sendPush(discordId, guildId, NotificationChannelKind.STREAK_REMINDER, any())
+        }
+    }
+
+    // ---------- DSL guards ----------
+
+    @Test
+    fun `dispatch rejects a duplicate dm builder so two listeners can't silently overwrite each other`() {
+        assertThrows(IllegalStateException::class.java) {
+            router.dispatch(NotificationChannelKind.ACHIEVEMENT_UNLOCK, discordId, guildId) {
+                dm { msg("a") }
+                dm { msg("b") }
+                push { PushPayload("t", "b") }
+                channel(route = ChannelRouteKey.ACHIEVEMENT_SHOUTOUT) { msg("ch") }
+            }
+        }
+    }
+
+    @Test
+    fun `dispatch rejects a duplicate push builder`() {
+        assertThrows(IllegalStateException::class.java) {
+            router.dispatch(NotificationChannelKind.ACHIEVEMENT_UNLOCK, discordId, guildId) {
+                dm { msg("dm") }
+                push { PushPayload("t", "b") }
+                push { PushPayload("t2", "b2") }
+                channel(route = ChannelRouteKey.ACHIEVEMENT_SHOUTOUT) { msg("ch") }
+            }
+        }
+    }
+
+    @Test
+    fun `dispatch rejects a duplicate channel builder`() {
+        assertThrows(IllegalStateException::class.java) {
+            router.dispatch(NotificationChannelKind.ACHIEVEMENT_UNLOCK, discordId, guildId) {
+                dm { msg("dm") }
+                push { PushPayload("t", "b") }
+                channel(route = ChannelRouteKey.ACHIEVEMENT_SHOUTOUT) { msg("ch1") }
+                channel(route = ChannelRouteKey.ACHIEVEMENT_SHOUTOUT) { msg("ch2") }
+            }
+        }
+    }
+
+    // ---------- enforcement covers every existing kind ----------
+
+    @Test
+    fun `every NotificationChannelKind declares at least one supported surface`() {
+        // Sanity guard: an empty supportedSurfaces would make dispatch a
+        // no-op that silently never fires — defeats the whole point.
+        NotificationChannelKind.entries.forEach { kind ->
+            assert(kind.supportedSurfaces.isNotEmpty()) {
+                "$kind has no supported surfaces — dispatch would no-op."
+            }
+        }
+    }
+
+    @Test
+    fun `Surface enum stays exhaustive — dispatch's when expression covers every entry`() {
+        // If a fourth surface is added, dispatch's when{} won't compile.
+        // This test pins today's set so the missing-surfaces detection
+        // logic in dispatch is exhaustive by construction.
+        assertEquals(
+            setOf(Surface.DM, Surface.CHANNEL, Surface.PUSH),
+            Surface.entries.toSet(),
+        )
+    }
+
+    // ---------- multi-recipient dispatch ----------
+
+    @Test
+    fun `multi-recipient dispatch posts the channel broadcast exactly once regardless of recipient count`() {
+        val winners = listOf(1L, 2L, 3L)
+        router.dispatch(
+            kind = NotificationChannelKind.LOTTERY_DRAW_WITH_MY_TICKET,
+            discordIds = winners,
+            guildId = guildId,
+        ) {
+            channel(route = ChannelRouteKey.LOTTERY) { msg("broadcast") }
+            push { winnerId -> PushPayload("Won", "id=$winnerId") }
+        }
+        verify(exactly = 1) {
+            router.sendChannel(
+                guildId = guildId,
+                route = ChannelRouteKey.LOTTERY,
+                originChannelId = null,
+                message = any(),
+                onSent = null,
+                mentions = null,
+            )
+        }
+    }
+
+    @Test
+    fun `multi-recipient dispatch fans push out to every recipient with the per-recipient builder`() {
+        val winners = listOf(1L, 2L, 3L)
+        router.dispatch(
+            kind = NotificationChannelKind.LOTTERY_DRAW_WITH_MY_TICKET,
+            discordIds = winners,
+            guildId = guildId,
+        ) {
+            channel(route = ChannelRouteKey.LOTTERY) { msg("broadcast") }
+            push { winnerId -> PushPayload("Won", "id=$winnerId") }
+        }
+        winners.forEach { winnerId ->
+            verify(exactly = 1) {
+                router.sendPush(
+                    winnerId, guildId, NotificationChannelKind.LOTTERY_DRAW_WITH_MY_TICKET, any()
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `multi-recipient push builder receives each recipient's discordId so payloads can personalise`() {
+        // Capture each forwarded payload-builder and invoke it to verify
+        // the body actually depends on the winner id.
+        val winners = listOf(11L, 22L)
+        val payloadBuildersByWinner = mutableMapOf<Long, () -> PushPayload>()
+        every {
+            router.sendPush(any(), any(), any(), any())
+        } answers {
+            @Suppress("UNCHECKED_CAST")
+            payloadBuildersByWinner[firstArg()] = arg<() -> PushPayload>(3)
+        }
+
+        router.dispatch(
+            kind = NotificationChannelKind.LOTTERY_DRAW_WITH_MY_TICKET,
+            discordIds = winners,
+            guildId = guildId,
+        ) {
+            channel(route = ChannelRouteKey.LOTTERY) { msg("broadcast") }
+            push { winnerId -> PushPayload("Won", "id=$winnerId") }
+        }
+
+        assertEquals("id=11", payloadBuildersByWinner.getValue(11L).invoke().body)
+        assertEquals("id=22", payloadBuildersByWinner.getValue(22L).invoke().body)
+    }
+
+    @Test
+    fun `multi-recipient dispatch enforces every supported surface — forgetting push for a many-winners cycle fails fast`() {
+        // LOTTERY_DRAW_WITH_MY_TICKET supports CHANNEL + PUSH. Wiring
+        // only channel ships the broadcast but silently drops every
+        // opted-in winner's personal notification — exactly the bug
+        // class this DSL guards against.
+        assertThrows(IllegalStateException::class.java) {
+            router.dispatch(
+                kind = NotificationChannelKind.LOTTERY_DRAW_WITH_MY_TICKET,
+                discordIds = listOf(1L, 2L),
+                guildId = guildId,
+            ) {
+                channel(route = ChannelRouteKey.LOTTERY) { msg("broadcast") }
+            }
+        }
+    }
+
+    @Test
+    fun `multi-recipient dispatch handles an empty recipient list — channel broadcast still fires, push is a no-op`() {
+        // No winners (e.g. lottery cycle with NoTickets). The channel
+        // post still announces the open draw; push fan-out is zero.
+        router.dispatch(
+            kind = NotificationChannelKind.LOTTERY_DRAW_WITH_MY_TICKET,
+            discordIds = emptyList(),
+            guildId = guildId,
+        ) {
+            channel(route = ChannelRouteKey.LOTTERY) { msg("broadcast") }
+            push { winnerId -> PushPayload("Won", "id=$winnerId") }
+        }
+        verify(exactly = 1) {
+            router.sendChannel(any(), any(), any(), any(), any(), any())
+        }
+        verify(exactly = 0) { router.sendPush(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `multi-recipient dispatch fans DM out per recipient when the kind supports DM`() {
+        // Hypothetical kind change: if LEVEL_UP were multi-recipient
+        // (e.g. "guild milestone hit, congratulate every member who
+        // contributed"), each gets a DM. Today no such caller exists,
+        // but the API has to support it — pin the behaviour.
+        router.dispatch(
+            kind = NotificationChannelKind.LEVEL_UP, // supports DM + CHANNEL + PUSH
+            discordIds = listOf(1L, 2L, 3L),
+            guildId = guildId,
+        ) {
+            channel(route = ChannelRouteKey.LEVEL_UP) { msg("broadcast") }
+            dm { id -> msg("dm-$id") }
+            push { id -> PushPayload("Level Up", "for $id") }
+        }
+        verify(exactly = 1) { router.sendDm(1L, guildId, NotificationChannelKind.LEVEL_UP, any()) }
+        verify(exactly = 1) { router.sendDm(2L, guildId, NotificationChannelKind.LEVEL_UP, any()) }
+        verify(exactly = 1) { router.sendDm(3L, guildId, NotificationChannelKind.LEVEL_UP, any()) }
+    }
+
+    @Test
+    fun `multi-recipient dispatch posts the channel broadcast BEFORE per-recipient pushes`() {
+        // Ordering matters: the user should see the public shoutout
+        // (or in-Discord context) before the push lands so a notification
+        // tap that focuses the browser doesn't beat the channel post.
+        val callOrder = mutableListOf<String>()
+        every { router.sendChannel(any(), any(), any(), any(), any(), any()) } answers {
+            callOrder += "channel"
+        }
+        every { router.sendPush(any(), any(), any(), any()) } answers {
+            callOrder += "push"
+        }
+        router.dispatch(
+            kind = NotificationChannelKind.LOTTERY_DRAW_WITH_MY_TICKET,
+            discordIds = listOf(1L, 2L),
+            guildId = guildId,
+        ) {
+            channel(route = ChannelRouteKey.LOTTERY) { msg("broadcast") }
+            push { id -> PushPayload("Won", "$id") }
+        }
+        assertEquals(listOf("channel", "push", "push"), callOrder)
+    }
+
+    @Test
+    fun `multi-recipient dispatch rejects duplicate dm builder`() {
+        assertThrows(IllegalStateException::class.java) {
+            router.dispatch(
+                kind = NotificationChannelKind.LEVEL_UP,
+                discordIds = listOf(1L),
+                guildId = guildId,
+            ) {
+                channel(route = ChannelRouteKey.LEVEL_UP) { msg("ch") }
+                dm { id -> msg("dm-$id") }
+                dm { id -> msg("dm2-$id") }
+                push { id -> PushPayload("t", "$id") }
+            }
+        }
+    }
+
+    @Test
+    fun `multi-recipient dispatch rejects duplicate push builder`() {
+        assertThrows(IllegalStateException::class.java) {
+            router.dispatch(
+                kind = NotificationChannelKind.LOTTERY_DRAW_WITH_MY_TICKET,
+                discordIds = listOf(1L),
+                guildId = guildId,
+            ) {
+                channel(route = ChannelRouteKey.LOTTERY) { msg("ch") }
+                push { id -> PushPayload("a", "$id") }
+                push { id -> PushPayload("b", "$id") }
+            }
+        }
+    }
+
+    @Test
+    fun `multi-recipient dispatch rejects duplicate channel builder`() {
+        assertThrows(IllegalStateException::class.java) {
+            router.dispatch(
+                kind = NotificationChannelKind.LOTTERY_DRAW_WITH_MY_TICKET,
+                discordIds = listOf(1L),
+                guildId = guildId,
+            ) {
+                channel(route = ChannelRouteKey.LOTTERY) { msg("ch1") }
+                channel(route = ChannelRouteKey.LOTTERY) { msg("ch2") }
+                push { id -> PushPayload("t", "$id") }
+            }
+        }
+    }
+
+    @Test
+    fun `multi-recipient dispatch ignores configured dm-or-push builders when kind does not support them`() {
+        // LOTTERY_DRAW_WITH_MY_TICKET supports CHANNEL + PUSH only.
+        // Configuring dm{} on a multi-dispatch for it should be silently
+        // skipped (no sendDm call, builder not invoked).
+        var dmBuilderInvoked = false
+        router.dispatch(
+            kind = NotificationChannelKind.LOTTERY_DRAW_WITH_MY_TICKET,
+            discordIds = listOf(1L),
+            guildId = guildId,
+        ) {
+            channel(route = ChannelRouteKey.LOTTERY) { msg("ch") }
+            push { id -> PushPayload("t", "$id") }
+            dm { _ ->
+                dmBuilderInvoked = true
+                msg("dm")
+            }
+        }
+        verify(exactly = 0) { router.sendDm(any(), any(), any(), any()) }
+        assert(!dmBuilderInvoked)
+    }
+
+    private fun msg(text: String): MessageCreateData =
+        MessageCreateBuilder().setContent(text).build()
+}

--- a/discord-bot/src/test/kotlin/bot/toby/notify/WebDuelOfferNotifierTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/notify/WebDuelOfferNotifierTest.kt
@@ -2,13 +2,18 @@ package bot.toby.notify
 
 import common.notification.ChannelRouteKey
 import common.notification.NotificationChannelKind
+import common.notification.PushPayload
 import database.duel.PendingDuelRegistry
+import database.service.ConfigService
+import database.service.UserNotificationPrefService
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.slot
+import io.mockk.spyk
 import io.mockk.verify
+import net.dv8tion.jda.api.JDA
 import net.dv8tion.jda.api.components.MessageTopLevelComponent
 import net.dv8tion.jda.api.entities.Message
 import net.dv8tion.jda.api.entities.MessageEmbed
@@ -51,7 +56,18 @@ class WebDuelOfferNotifierTest {
 
     @BeforeEach
     fun setup() {
-        router = mockk(relaxed = true)
+        val jda = mockk<JDA>(relaxed = true)
+        val prefService = mockk<UserNotificationPrefService>(relaxed = true) {
+            every { isOptedIn(any(), any(), any(), any()) } returns true
+        }
+        val configService = mockk<ConfigService>(relaxed = true)
+        val pushAdapter = mockk<PushAdapter>(relaxed = true)
+        router = spyk(NotificationRouter(jda, prefService, configService, pushAdapter))
+        every { router.sendDm(any(), any(), any(), any()) } just runs
+        every { router.sendPush(any(), any(), any(), any()) } just runs
+        every {
+            router.sendChannel(any(), any(), any(), any(), any(), any())
+        } just runs
         pendingDuelRegistry = mockk(relaxed = true)
         every { pendingDuelRegistry.ttl } returns Duration.ofMinutes(3)
         scheduler = mockk(relaxed = true)
@@ -119,6 +135,32 @@ class WebDuelOfferNotifierTest {
             "Opponent mention must live in setContent, not the embed"
         }
         assertEquals(1, data.components.size, "ActionRow with Accept/Decline must be attached")
+    }
+
+    @Test
+    fun `on also pushes the opponent — regression guard for forgotten push surface`() {
+        notifier.on(event())
+        verify(exactly = 1) {
+            router.sendPush(opponentId, guildId, NotificationChannelKind.DUEL_OFFER, any())
+        }
+    }
+
+    @Test
+    fun `push payload carries the initiator mention and stake`() {
+        val builder = slot<() -> PushPayload>()
+        every {
+            router.sendPush(any(), any(), any(), capture(builder))
+        } just runs
+
+        notifier.on(event())
+
+        val payload = builder.captured.invoke()
+        assert(payload.body.contains("<@$initiatorId>")) {
+            "expected initiator mention in push body, got: ${payload.body}"
+        }
+        assert(payload.title.contains("$stake")) {
+            "expected stake amount in push title, got: ${payload.title}"
+        }
     }
 
     @Test

--- a/discord-bot/src/test/kotlin/bot/toby/notify/WebTipNotifierTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/notify/WebTipNotifierTest.kt
@@ -2,13 +2,21 @@ package bot.toby.notify
 
 import common.notification.ChannelRouteKey
 import common.notification.NotificationChannelKind
+import common.notification.PushPayload
+import database.service.ConfigService
+import database.service.UserNotificationPrefService
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
+import io.mockk.runs
 import io.mockk.slot
+import io.mockk.spyk
 import io.mockk.verify
+import net.dv8tion.jda.api.JDA
 import net.dv8tion.jda.api.utils.messages.MessageCreateData
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -37,7 +45,18 @@ class WebTipNotifierTest {
 
     @BeforeEach
     fun setup() {
-        router = mockk(relaxed = true)
+        val jda = mockk<JDA>(relaxed = true)
+        val prefService = mockk<UserNotificationPrefService>(relaxed = true) {
+            every { isOptedIn(any(), any(), any(), any()) } returns true
+        }
+        val configService = mockk<ConfigService>(relaxed = true)
+        val pushAdapter = mockk<PushAdapter>(relaxed = true)
+        router = spyk(NotificationRouter(jda, prefService, configService, pushAdapter))
+        every { router.sendDm(any(), any(), any(), any()) } just runs
+        every { router.sendPush(any(), any(), any(), any()) } just runs
+        every {
+            router.sendChannel(any(), any(), any(), any(), any(), any())
+        } just runs
         notifier = WebTipNotifier(router)
     }
 
@@ -87,7 +106,7 @@ class WebTipNotifierTest {
                 onSent = any(),
                 mentions = any(),
             )
-        } answers { }
+        } just runs
 
         notifier.on(event())
 
@@ -98,5 +117,76 @@ class WebTipNotifierTest {
             "Recipient mention must live in setContent, not the embed; embed-mentions don't ping."
         )
         assertEquals(1, data.embeds.size)
+    }
+
+    @Test
+    fun `on also pushes the recipient — regression guard for forgotten push surface`() {
+        // TIP_RECEIVED supports CHANNEL + PUSH. Dispatch enforcement now
+        // requires both; this pins that the push surface fires alongside
+        // the channel post for opted-in recipients.
+        notifier.on(event())
+        verify(exactly = 1) {
+            router.sendPush(recipientId, guildId, NotificationChannelKind.TIP_RECEIVED, any())
+        }
+    }
+
+    @Test
+    fun `push payload carries amount and quotes the note when present`() {
+        val builder = slot<() -> PushPayload>()
+        every {
+            router.sendPush(any(), any(), any(), capture(builder))
+        } just runs
+
+        notifier.on(event())
+
+        val payload = builder.captured.invoke()
+        assertTrue(payload.title.contains("50")) {
+            "expected amount in the push title, got: ${payload.title}"
+        }
+        assertTrue(payload.body.contains("thanks")) {
+            "expected the note in the push body, got: ${payload.body}"
+        }
+    }
+
+    @Test
+    fun `push payload omits the note when blank or absent`() {
+        val noNote = event().copy(note = null)
+        val builder = slot<() -> PushPayload>()
+        every {
+            router.sendPush(any(), any(), any(), capture(builder))
+        } just runs
+
+        notifier.on(noNote)
+
+        val payload = builder.captured.invoke()
+        assertTrue(!payload.body.contains("\"")) {
+            "expected no quoted note when event.note is null, got: ${payload.body}"
+        }
+    }
+
+    @Test
+    fun `push payload has no deepLink when app base-url is unconfigured`() {
+        // Default constructor uses an empty base-url.
+        val builder = slot<() -> PushPayload>()
+        every {
+            router.sendPush(any(), any(), any(), capture(builder))
+        } just runs
+
+        notifier.on(event())
+
+        assertNull(builder.captured.invoke().deepLink)
+    }
+
+    @Test
+    fun `push payload deep-links to the profile page when app base-url is configured`() {
+        val configured = WebTipNotifier(router, webBaseUrl = "https://example.test")
+        val builder = slot<() -> PushPayload>()
+        every {
+            router.sendPush(any(), any(), any(), capture(builder))
+        } just runs
+
+        configured.on(event())
+
+        assertEquals("https://example.test/profile/$guildId", builder.captured.invoke().deepLink)
     }
 }

--- a/discord-bot/src/test/kotlin/bot/toby/scheduling/LotteryAnnouncerTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/scheduling/LotteryAnnouncerTest.kt
@@ -1,16 +1,20 @@
 package bot.toby.scheduling
 
 import bot.toby.notify.NotificationRouter
+import bot.toby.notify.PushAdapter
 import common.notification.ChannelRouteKey
+import common.notification.PushPayload
 import database.dto.ConfigDto
 import database.dto.JackpotLotteryDto
 import database.service.ConfigService
 import database.service.JackpotLotteryService
+import database.service.UserNotificationPrefService
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.slot
+import io.mockk.spyk
 import io.mockk.verify
 import net.dv8tion.jda.api.EmbedBuilder
 import net.dv8tion.jda.api.JDA
@@ -64,9 +68,21 @@ class LotteryAnnouncerTest {
     fun setup() {
         configService = mockk(relaxed = true)
         jackpotLotteryService = mockk(relaxed = true)
-        router = mockk(relaxed = true)
-        guild = mockk(relaxed = true)
+        // Spy on a real router so dispatch's enforcement runs (the
+        // LOTTERY cycle wires CHANNEL + PUSH, both required by the kind).
+        val prefService = mockk<UserNotificationPrefService>(relaxed = true) {
+            every { isOptedIn(any(), any(), any(), any()) } returns true
+        }
+        val routerConfigService = mockk<ConfigService>(relaxed = true)
+        val pushAdapter = mockk<PushAdapter>(relaxed = true)
         jda = mockk(relaxed = true)
+        router = spyk(NotificationRouter(jda, prefService, routerConfigService, pushAdapter))
+        every { router.sendDm(any(), any(), any(), any()) } just runs
+        every { router.sendPush(any(), any(), any(), any()) } just runs
+        every {
+            router.sendChannel(any(), any(), any(), any(), any(), any())
+        } just runs
+        guild = mockk(relaxed = true)
         bot = mockk(relaxed = true)
         channel = mockk(relaxed = true)
 
@@ -176,6 +192,96 @@ class LotteryAnnouncerTest {
             common.notification.NotificationChannelKind.LOTTERY_DRAW_WITH_MY_TICKET, m.kind
         )
         assertEquals(listOf(1L, 2L), m.userIds)
+    }
+
+    @Test
+    fun `WeightedDrawn cycle pushes each winner with their own payout amount in the body`() {
+        // Regression guard: LOTTERY_DRAW_WITH_MY_TICKET supports
+        // CHANNEL + PUSH, but historically only the channel post fired.
+        // Multi-recipient dispatch now also fans push out per-winner.
+        val payouts = listOf(
+            database.service.JackpotLotteryService.WinnerPayout(discordId = 1L, ticketCount = 5, amount = 500L),
+            database.service.JackpotLotteryService.WinnerPayout(discordId = 2L, ticketCount = 3, amount = 300L),
+        )
+        val pushBuilders = mutableMapOf<Long, () -> PushPayload>()
+        every {
+            router.sendPush(any(), any(), any(), any())
+        } answers {
+            @Suppress("UNCHECKED_CAST")
+            pushBuilders[firstArg()] = arg<() -> PushPayload>(3)
+        }
+
+        announcer.announceCycle(
+            guild, mode = "WEIGHTED",
+            priorOutcome = LotteryAnnouncer.PriorOutcome.WeightedDrawn(
+                payouts = payouts, totalPaid = 800L, drained = 1_000L,
+            ),
+            openOutcome = LotteryAnnouncer.OpenSummary.Ok(
+                seeded = 500L, ticketPrice = 50L, poolAmount = 500L,
+            ),
+        )
+
+        // Each winner got exactly one push targeted at their own id.
+        verify(exactly = 1) {
+            router.sendPush(1L, guildId, common.notification.NotificationChannelKind.LOTTERY_DRAW_WITH_MY_TICKET, any())
+        }
+        verify(exactly = 1) {
+            router.sendPush(2L, guildId, common.notification.NotificationChannelKind.LOTTERY_DRAW_WITH_MY_TICKET, any())
+        }
+        // Payload bodies carry each winner's own payout amount.
+        assert(pushBuilders.getValue(1L).invoke().body.contains("500"))
+        assert(pushBuilders.getValue(2L).invoke().body.contains("300"))
+    }
+
+    @Test
+    fun `MatchDrawn cycle pushes each tier winner with their tier share`() {
+        val tierPayouts = listOf(
+            database.service.JackpotLotteryService.MatchTierPayout(discordId = 7L, matches = 5, share = 600L),
+            database.service.JackpotLotteryService.MatchTierPayout(discordId = 8L, matches = 4, share = 250L),
+            database.service.JackpotLotteryService.MatchTierPayout(discordId = 9L, matches = 3, share = 100L),
+        )
+        val pushBuilders = mutableMapOf<Long, () -> PushPayload>()
+        every {
+            router.sendPush(any(), any(), any(), any())
+        } answers {
+            @Suppress("UNCHECKED_CAST")
+            pushBuilders[firstArg()] = arg<() -> PushPayload>(3)
+        }
+
+        announcer.announceCycle(
+            guild, mode = "WEIGHTED", // mode label only — outcome is MatchDrawn
+            priorOutcome = LotteryAnnouncer.PriorOutcome.MatchDrawn(
+                drawnNumbers = listOf(1, 2, 3, 4, 5),
+                tierPayouts = tierPayouts,
+                totalPaid = 950L,
+                rolledBack = 0L,
+            ),
+            openOutcome = LotteryAnnouncer.OpenSummary.Ok(
+                seeded = 500L, ticketPrice = 50L, poolAmount = 500L,
+            ),
+        )
+
+        assertEquals(setOf(7L, 8L, 9L), pushBuilders.keys)
+        assert(pushBuilders.getValue(7L).invoke().body.contains("600"))
+        assert(pushBuilders.getValue(8L).invoke().body.contains("250"))
+        assert(pushBuilders.getValue(9L).invoke().body.contains("100"))
+    }
+
+    @Test
+    fun `NoTickets cycle still fires the channel broadcast and does not push anyone`() {
+        // No winners → no push fan-out, but the open-draw announcement
+        // still ships to drive ticket purchases.
+        announcer.announceCycle(
+            guild, mode = "WEIGHTED",
+            priorOutcome = LotteryAnnouncer.PriorOutcome.NoTickets,
+            openOutcome = LotteryAnnouncer.OpenSummary.Ok(
+                seeded = 500L, ticketPrice = 50L, poolAmount = 500L,
+            ),
+        )
+        verify(exactly = 1) {
+            router.sendChannel(any(), any(), any(), any(), any(), any())
+        }
+        verify(exactly = 0) { router.sendPush(any(), any(), any(), any()) }
     }
 
     @Test

--- a/discord-bot/src/test/kotlin/bot/toby/scheduling/StreakReminderJobTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/scheduling/StreakReminderJobTest.kt
@@ -1,13 +1,17 @@
 package bot.toby.scheduling
 
 import bot.toby.notify.NotificationRouter
+import bot.toby.notify.PushAdapter
 import common.notification.NotificationChannelKind
 import database.dto.LoginStreakDto
+import database.service.ConfigService
 import database.service.LoginStreakService
+import database.service.UserNotificationPrefService
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
+import io.mockk.spyk
 import io.mockk.verify
 import net.dv8tion.jda.api.JDA
 import net.dv8tion.jda.api.entities.Guild
@@ -49,8 +53,21 @@ class StreakReminderJobTest {
     fun setup() {
         jda = mockk(relaxed = true)
         loginStreakService = mockk(relaxed = true)
-        notificationRouter = mockk(relaxed = true)
+        // Spy on a real router so `dispatch` runs its missing-surface
+        // enforcement and forwards to spied primitives we can verify.
+        val prefService = mockk<UserNotificationPrefService>(relaxed = true) {
+            every { isOptedIn(any(), any(), any(), any()) } returns true
+        }
+        val configService = mockk<ConfigService>(relaxed = true)
+        val pushAdapter = mockk<PushAdapter>(relaxed = true)
+        notificationRouter = spyk(
+            NotificationRouter(jda, prefService, configService, pushAdapter)
+        )
         every { notificationRouter.sendDm(any(), any(), any(), any()) } just runs
+        every { notificationRouter.sendPush(any(), any(), any(), any()) } just runs
+        every {
+            notificationRouter.sendChannel(any(), any(), any(), any(), any(), any())
+        } just runs
     }
 
     /** Build the job with a JDA cache containing the supplied guild ids. */
@@ -172,6 +189,32 @@ class StreakReminderJobTest {
         // grew a side-effect that bypasses the router's opt-in gate.
         verify(exactly = 1) {
             loginStreakService.findActiveStreaksDueForReminder(100L, today)
+        }
+    }
+
+    @Test
+    fun `runHourly also pushes every at-risk user — regression guard for forgotten push surface`() {
+        // STREAK_REMINDER supports DM + PUSH. Before dispatch enforcement,
+        // the job DM'd at-risk users but never pushed — opted-in browsers
+        // got nothing. Dispatch now requires both, and this test pins
+        // that the push surface fires alongside DM.
+        every {
+            loginStreakService.findActiveStreaksDueForReminder(100L, today)
+        } returns listOf(
+            LoginStreakDto(
+                discordId = 1L, guildId = 100L,
+                currentStreak = 5, longestStreak = 5,
+                lastClaimDate = today.minusDays(1), totalClaims = 5L,
+            )
+        )
+
+        buildJob(100L).runHourly()
+
+        verify(exactly = 1) {
+            notificationRouter.sendDm(1L, 100L, NotificationChannelKind.STREAK_REMINDER, any())
+        }
+        verify(exactly = 1) {
+            notificationRouter.sendPush(1L, 100L, NotificationChannelKind.STREAK_REMINDER, any())
         }
     }
 

--- a/web/src/main/resources/changelog.json
+++ b/web/src/main/resources/changelog.json
@@ -15,24 +15,10 @@
   },
   {
     "date": "May 2026",
-    "title": "Route web intro preview through proxy + surface validation errors",
-    "summary": "PR #448 already routed lavaplayer + `HttpHelper` (Ktor) through the optional YouTube proxy, but missed two paths. The **web-UI intro page preview** uses raw `java.net.HttpURLConnection` and bypasses every proxy hook from #448 — that's the symptom you actually reported. The Discord-side intro validation also swallowed its async catch silently. This PR closes both gaps.",
-    "emoji": "🎵",
-    "prNumber": 451
-  },
-  {
-    "date": "May 2026",
     "title": "Centralised searchable user picker for every user dropdown",
     "summary": "Every form that lets you pick a member — tip recipient, duel opponent, excuse attribution, intro management, voice move targets, casino jackpot refund — used a plain `<select>` populated with `${members}`. On servers with lots of members those dropdowns are a long scroll. This PR replaces all of them with a single searchable typeahead component. New fragment `templates/fragments/userPicker.html` — one signature handles single-select, multi-select with chips, optional pre-s…",
     "emoji": "🛡️",
     "prNumber": 450
-  },
-  {
-    "date": "May 2026",
-    "title": "Route YouTube traffic through optional rotating HTTP proxy",
-    "summary": "YouTube intermittently IP-blocks the dyno, breaking both `/play` and intro-clip validation until the Heroku app is manually restarted in the hope of pulling a non-blocked IP. Restarting Heroku is just IP-pool roulette — this PR replaces it with two real fixes: **Surface OAuth2 status at startup.** Authenticated requests via `GOOGLE_REFRESH_TOKEN` (already wired in `PlayerManager`) are far less prone to anonymous-IP blocks. The bot now logs a clear WARN at boot when the tok…",
-    "emoji": "🎵",
-    "prNumber": 448
   },
   {
     "date": "May 2026",


### PR DESCRIPTION
## Summary

- Setting `TOBY_VAPID_PUBLIC_KEY` + `TOBY_VAPID_PRIVATE_KEY` on Heroku crashed the dyno (`Process exited with status 1`, then `H10 App crashed` on every request).
- Root cause: `WebPushAdapter` has two constructors and neither was `@Autowired`. Spring defaults to the **primary** for Kotlin `@Component`s, which needs a `PushTransport` bean — but `PushTransport` is just an interface and `DefaultPushTransport` is a plain class with no `@Component` / `@Bean` factory. With the env vars unset, `@ConditionalOnProperty` kept the bean from being instantiated and the bug stayed latent; setting the keys triggered `NoSuchBeanDefinitionException` at context refresh.
- Fix: annotate the **secondary** (env-driven) constructor with `@Autowired` so production wires the `DefaultPushTransport` path. The primary still works for unit tests via direct instantiation, so `WebPushAdapterTest` is unaffected.
- Added a `@SpringBootTest` (`WebPushAdapterContextTest`) that sets the VAPID properties and asserts the bean is registered — pre-fix this would have failed at context refresh. Locked in the off-path with a sibling assertion in `SpringApplicationTest` that the adapter is absent when no VAPID keys are configured.
- Documented the new env vars in `.env.example`.

## Test plan

- [ ] CI: new `WebPushAdapterContextTest` passes
- [ ] CI: `SpringApplicationTest` (incl. new `WebPushAdapter is absent…` case) passes
- [ ] CI: existing `WebPushAdapterTest` unit tests still pass (primary ctor path unchanged)
- [ ] Deploy: with `TOBY_VAPID_PUBLIC_KEY` + `TOBY_VAPID_PRIVATE_KEY` set, dyno reaches `Started …Application` and stops crashing
- [ ] Manual: `curl https://www.toby-bot.co.uk/api/push/vapid-public-key` returns 200 with the configured key
- [ ] Manual: toggling Push in `/preferences/notifications` inserts a `push_subscription` row; triggering a push-eligible event renders a browser notification and bumps `last_used_at`

## Backout

`heroku config:unset TOBY_VAPID_PUBLIC_KEY TOBY_VAPID_PRIVATE_KEY` — `@ConditionalOnProperty` stops matching and the bean isn't created, reverting to the pre-VAPID warn-and-no-op behaviour.

---
_Generated by [Claude Code](https://claude.ai/code/session_019zeNrW3Q2aA9ahsRz5Xg58)_