### PR TITLE
feat(lottery): reward buying more tickets via three configurable incentives

### DIFF
--- a/database/src/main/kotlin/database/dto/ConfigDto.kt
+++ b/database/src/main/kotlin/database/dto/ConfigDto.kt
@@ -303,6 +303,50 @@ class ConfigDto(
         // visible nudge to buy tickets; admins can dial it down per-server.
         LOTTERY_PING_MODE("LOTTERY_PING_MODE"),
 
+        // Bulk-buy bonus tiers for TICKET_WEIGHTED lotteries. Each tier
+        // is a (buy threshold, bonus tickets) pair: a single
+        // /lottery buy N call that hits the highest matching `BUY`
+        // grants `BONUS` free tickets credited to the user's
+        // bonus_tickets total. Splitting the same N across multiple
+        // smaller buys earns nothing — that's the anti-strategy hook.
+        // All zero by default → feature disabled. A tier with BUY=0 is
+        // ignored. Configurable per-guild via the web moderation page.
+        LOTTERY_BULK_TIER1_BUY("LOTTERY_BULK_TIER1_BUY"),
+        LOTTERY_BULK_TIER1_BONUS("LOTTERY_BULK_TIER1_BONUS"),
+        LOTTERY_BULK_TIER2_BUY("LOTTERY_BULK_TIER2_BUY"),
+        LOTTERY_BULK_TIER2_BONUS("LOTTERY_BULK_TIER2_BONUS"),
+        LOTTERY_BULK_TIER3_BUY("LOTTERY_BULK_TIER3_BUY"),
+        LOTTERY_BULK_TIER3_BONUS("LOTTERY_BULK_TIER3_BONUS"),
+
+        // Volume-multiplier tiers for TICKET_WEIGHTED lotteries. Each
+        // tier is a (total-tickets threshold, multiplier in basis
+        // points) pair: at draw time, a user holding >= `TOTAL` tickets
+        // has every one of their tickets weighted by `BP/10000`
+        // (10000 = 1×, 12500 = 1.25×, etc). Bonus tickets and
+        // multiplier stack. All zero by default. BP is clamped to
+        // [10000, 50000] (1× to 5×) so a typo can't catastrophise.
+        LOTTERY_MULT_TIER1_TOTAL("LOTTERY_MULT_TIER1_TOTAL"),
+        LOTTERY_MULT_TIER1_BP("LOTTERY_MULT_TIER1_BP"),
+        LOTTERY_MULT_TIER2_TOTAL("LOTTERY_MULT_TIER2_TOTAL"),
+        LOTTERY_MULT_TIER2_BP("LOTTERY_MULT_TIER2_BP"),
+        LOTTERY_MULT_TIER3_TOTAL("LOTTERY_MULT_TIER3_TOTAL"),
+        LOTTERY_MULT_TIER3_BP("LOTTERY_MULT_TIER3_BP"),
+
+        // Pool-growth milestone tiers for TICKET_WEIGHTED lotteries.
+        // Each tier is a (guild-wide ticket-count threshold, % of the
+        // current jackpot pool to absorb) pair. When the lottery's
+        // running ticket count crosses a threshold for the first time
+        // (recorded in milestones_fired), that % of the jackpot is
+        // pulled into the lottery pool. Builds shared FOMO. All zero
+        // by default. PCT is clamped to [0, 50] so a single milestone
+        // can never drain more than half the jackpot in one buy.
+        LOTTERY_MILESTONE1_TICKETS("LOTTERY_MILESTONE1_TICKETS"),
+        LOTTERY_MILESTONE1_PCT("LOTTERY_MILESTONE1_PCT"),
+        LOTTERY_MILESTONE2_TICKETS("LOTTERY_MILESTONE2_TICKETS"),
+        LOTTERY_MILESTONE2_PCT("LOTTERY_MILESTONE2_PCT"),
+        LOTTERY_MILESTONE3_TICKETS("LOTTERY_MILESTONE3_TICKETS"),
+        LOTTERY_MILESTONE3_PCT("LOTTERY_MILESTONE3_PCT"),
+
         // Daily streak XP reward shape. Computed as
         // `min(base + per_day_bonus * (streak - 1), max)` inside
         // DefaultLoginStreakService. Streak rewards bypass DAILY_XP_CAP.

--- a/database/src/main/kotlin/database/dto/JackpotLotteryDto.kt
+++ b/database/src/main/kotlin/database/dto/JackpotLotteryDto.kt
@@ -108,6 +108,15 @@ class JackpotLotteryDto(
      */
     @Column(name = "announced_pool_amount")
     var announcedPoolAmount: Long? = null,
+
+    /**
+     * Highest guild-wide ticket-count milestone that has already paid
+     * out on this lottery. Set on each `/lottery buy` to the highest
+     * threshold the new running total crossed, so each milestone fires
+     * exactly once per lottery row. 0 means no milestone has fired.
+     */
+    @Column(name = "milestones_fired", nullable = false)
+    var milestonesFired: Long = 0,
 ) : Serializable {
 
     companion object {

--- a/database/src/main/kotlin/database/dto/JackpotLotteryDto.kt
+++ b/database/src/main/kotlin/database/dto/JackpotLotteryDto.kt
@@ -110,6 +110,18 @@ class JackpotLotteryDto(
     var announcedPoolAmount: Long? = null,
 
     /**
+     * Stable digest (SHA-256 hex) of the participation-incentive tiers
+     * that were live at the most recent announce/refresh. Lets the
+     * refresh job detect a mid-lottery config edit (web UI tier
+     * change) and re-render the "Active incentives" embed field even
+     * when [announcedPoolAmount] hasn't moved. Null before the first
+     * announce; cleared together with [announcedPoolAmount] when the
+     * announcement reference is dropped.
+     */
+    @Column(name = "announced_incentives_digest", length = 64)
+    var announcedIncentivesDigest: String? = null,
+
+    /**
      * Highest guild-wide ticket-count milestone that has already paid
      * out on this lottery. Set on each `/lottery buy` to the highest
      * threshold the new running total crossed, so each milestone fires

--- a/database/src/main/kotlin/database/dto/JackpotLotteryTicketDto.kt
+++ b/database/src/main/kotlin/database/dto/JackpotLotteryTicketDto.kt
@@ -58,6 +58,16 @@ class JackpotLotteryTicketDto(
      */
     @Column(name = "picked_numbers")
     var pickedNumbers: String? = null,
+
+    /**
+     * Free tickets earned from bulk-buy bonus tiers, accumulated across
+     * every TICKET_WEIGHTED `/lottery buy N` the user makes on this
+     * lottery. Counted as additional weight in the draw alongside the
+     * volume multiplier (see [LotteryHelper] / [JackpotLotteryService.effectiveWeight]).
+     * Always 0 for NUMBER_MATCH tickets.
+     */
+    @Column(name = "bonus_tickets", nullable = false)
+    var bonusTickets: Long = 0,
 ) : Serializable
 
 data class JackpotLotteryTicketId(

--- a/database/src/main/kotlin/database/service/JackpotLotteryService.kt
+++ b/database/src/main/kotlin/database/service/JackpotLotteryService.kt
@@ -671,11 +671,18 @@ class JackpotLotteryService(
      * message ships. No-op when [lotteryId] no longer points at a row
      * (the close-then-reopen tick already moved on).
      */
-    fun recordAnnouncement(lotteryId: Long, channelId: Long, messageId: Long, pool: Long) {
+    fun recordAnnouncement(
+        lotteryId: Long,
+        channelId: Long,
+        messageId: Long,
+        pool: Long,
+        incentivesDigest: String? = null,
+    ) {
         val lottery = lotteryPersistence.findById(lotteryId) ?: return
         lottery.announcementChannelId = channelId
         lottery.announcementMessageId = messageId
         lottery.announcedPoolAmount = pool
+        lottery.announcedIncentivesDigest = incentivesDigest
         lotteryPersistence.upsert(lottery)
     }
 
@@ -689,16 +696,21 @@ class JackpotLotteryService(
         lottery.announcementChannelId = null
         lottery.announcementMessageId = null
         lottery.announcedPoolAmount = null
+        lottery.announcedIncentivesDigest = null
         lotteryPersistence.upsert(lottery)
     }
 
     /**
-     * Bump the announced-pool watermark after a successful refresh edit
-     * so subsequent ticks short-circuit until the pool grows again.
+     * Bump the announce-time watermarks (pool + incentives digest)
+     * after a successful refresh edit so subsequent ticks short-circuit
+     * until something actually changes. The digest covers the
+     * participation-incentive tiers the embed displays — a mid-lottery
+     * tier edit in the web UI bumps it even when the pool is flat.
      */
-    fun updateAnnouncedPool(lotteryId: Long, pool: Long) {
+    fun updateAnnouncementWatermarks(lotteryId: Long, pool: Long, incentivesDigest: String?) {
         val lottery = lotteryPersistence.findById(lotteryId) ?: return
         lottery.announcedPoolAmount = pool
+        lottery.announcedIncentivesDigest = incentivesDigest
         lotteryPersistence.upsert(lottery)
     }
 

--- a/database/src/main/kotlin/database/service/JackpotLotteryService.kt
+++ b/database/src/main/kotlin/database/service/JackpotLotteryService.kt
@@ -62,6 +62,12 @@ class JackpotLotteryService(
             val totalSpent: Long,
             val newBalance: Long,
             val newPool: Long,
+            /** Free tickets awarded for this single purchase (bulk-buy bonus). */
+            val bonusTicketsGranted: Long = 0L,
+            /** User's cumulative bonus tickets on this lottery after the purchase. */
+            val totalBonusTickets: Long = 0L,
+            /** Pool-growth milestones that fired during this purchase. */
+            val milestoneBonuses: List<MilestoneBonus> = emptyList(),
         ) : BuyOutcome
         data object NoOpenLottery : BuyOutcome
         data class InvalidCount(val ticketCount: Int) : BuyOutcome
@@ -69,11 +75,25 @@ class JackpotLotteryService(
         data object UnknownUser : BuyOutcome
     }
 
+    /**
+     * One pool-growth milestone that fired during a [buyTickets] call.
+     * [threshold] is the ticket-count it represents (mirrors the config
+     * row); [creditsAdded] is what landed in the lottery pool (after
+     * clamping to the jackpot's available balance — a near-empty
+     * jackpot can deliver less than the configured %).
+     */
+    data class MilestoneBonus(val threshold: Long, val creditsAdded: Long)
+
     sealed interface DrawOutcome {
         data class Ok(
             val payouts: List<WinnerPayout>,
             val totalPaid: Long,
             val drained: Long,
+            /** Sum of bulk-buy bonus tickets across every buyer at draw time. */
+            val bonusTicketsAwarded: Long = 0L,
+            /** Highest pool-growth milestone that fired during this lottery's
+             *  buy phase (0 = none). Mirrors `JackpotLotteryDto.milestonesFired`. */
+            val highestMilestoneFired: Long = 0L,
         ) : DrawOutcome
         data object NoOpenLottery : DrawOutcome
         data object NoTickets : DrawOutcome
@@ -199,6 +219,15 @@ class JackpotLotteryService(
         userService.updateUser(user)
 
         val lotteryId = lottery.id ?: error("Open lottery has no id")
+
+        // Bulk-buy bonus is computed off *this* purchase's count, so
+        // splitting the same N across multiple smaller buys earns
+        // nothing — that's the whole point of the incentive.
+        val bulkBonus = LotteryHelper.bulkBonusFor(
+            ticketCount.toLong(),
+            LotteryHelper.bulkBonusTiers(configService, guildId),
+        )
+
         val existing = lotteryPersistence.getTicketForUpdate(lotteryId, discordId)
         val updatedTicket = if (existing == null) {
             JackpotLotteryTicketDto(
@@ -206,15 +235,52 @@ class JackpotLotteryService(
                 discordId = discordId,
                 ticketCount = ticketCount,
                 spent = cost,
+                bonusTickets = bulkBonus,
             )
         } else {
             existing.ticketCount += ticketCount
             existing.spent += cost
+            existing.bonusTickets += bulkBonus
             existing
         }
         lotteryPersistence.upsertTicket(updatedTicket)
 
         lottery.poolAmount += cost
+
+        // Pool-growth milestones. The running guild-wide ticket count
+        // is the sum of (paid) ticketCount on every row of this lottery
+        // — bonus tickets don't count toward the FOMO threshold,
+        // they're a reward for crossing it. Skip the extra query when
+        // nothing is configured so a guild that doesn't use milestones
+        // pays no perf cost.
+        val firedBonuses = mutableListOf<MilestoneBonus>()
+        val milestones = LotteryHelper.poolMilestones(configService, guildId)
+        if (milestones.isNotEmpty()) {
+            val newTotalTickets = lotteryPersistence.ticketsByLottery(lotteryId)
+                .sumOf { it.ticketCount.toLong() }
+            val prevTotalTickets = newTotalTickets - ticketCount.toLong()
+            val milestonesToFire = LotteryHelper.milestonesBetween(
+                prevTotal = prevTotalTickets,
+                newTotal = newTotalTickets,
+                milestones = milestones,
+                alreadyFiredHighest = lottery.milestonesFired,
+            )
+            for ((threshold, pct) in milestonesToFire) {
+                val jackpotBefore = jackpotService.getPool(guildId)
+                if (jackpotBefore <= 0L) break  // jackpot drained; remaining milestones get nothing
+                val take = kotlin.math.floor(jackpotBefore * (pct.toDouble() / 100.0))
+                    .toLong()
+                    .coerceAtMost(jackpotBefore)
+                    .coerceAtLeast(0L)
+                if (take <= 0L) continue
+                val drained = drainFromPool(guildId, take)
+                if (drained <= 0L) continue
+                lottery.poolAmount += drained
+                lottery.milestonesFired = threshold
+                firedBonuses += MilestoneBonus(threshold = threshold, creditsAdded = drained)
+            }
+        }
+
         lotteryPersistence.upsert(lottery)
 
         return BuyOutcome.Ok(
@@ -222,6 +288,9 @@ class JackpotLotteryService(
             totalSpent = updatedTicket.spent,
             newBalance = user.socialCredit ?: (balance - cost),
             newPool = lottery.poolAmount,
+            bonusTicketsGranted = bulkBonus,
+            totalBonusTickets = updatedTicket.bonusTickets,
+            milestoneBonuses = firedBonuses,
         )
     }
 
@@ -245,7 +314,8 @@ class JackpotLotteryService(
         }
 
         val winnerSlots = lottery.winnerCount.coerceAtLeast(1)
-        val winners = drawWinners(tickets, winnerSlots, random)
+        val multiplierTiers = LotteryHelper.volumeMultiplierTiers(configService, guildId)
+        val winners = drawWinners(tickets, winnerSlots, random, multiplierTiers)
         val shares = prizeShares(winnerSlots, lottery.poolAmount)
 
         val payouts = mutableListOf<WinnerPayout>()
@@ -272,7 +342,13 @@ class JackpotLotteryService(
         val remainder = drained - totalPaid
         if (remainder > 0L) jackpotService.addToPool(guildId, remainder)
 
-        return DrawOutcome.Ok(payouts = payouts, totalPaid = totalPaid, drained = drained)
+        return DrawOutcome.Ok(
+            payouts = payouts,
+            totalPaid = totalPaid,
+            drained = drained,
+            bonusTicketsAwarded = tickets.sumOf { it.bonusTickets.coerceAtLeast(0L) },
+            highestMilestoneFired = lottery.milestonesFired,
+        )
     }
 
     fun cancelLottery(guildId: Long): CancelOutcome {
@@ -641,31 +717,58 @@ class JackpotLotteryService(
     /**
      * Pick [count] distinct winners by ticket-weighted draw without
      * replacement. Used by TICKET_WEIGHTED draws.
+     *
+     * Each ticket's draw weight is its [effectiveWeight]: paid
+     * ticket_count + accumulated bulk-buy bonus + volume-multiplier
+     * uplift (when [multiplierTiers] is non-empty). When no incentives
+     * are configured the effective weight collapses to ticket_count
+     * and the draw matches the pre-incentive behaviour exactly.
      */
     internal fun drawWinners(
         tickets: List<JackpotLotteryTicketDto>,
         count: Int,
         random: Random,
+        multiplierTiers: List<Pair<Long, Int>> = emptyList(),
     ): List<JackpotLotteryTicketDto> {
         val remaining = tickets.toMutableList()
+        val weights = remaining.map { effectiveWeight(it, multiplierTiers) }.toMutableList()
         val winners = mutableListOf<JackpotLotteryTicketDto>()
         repeat(count) {
             if (remaining.isEmpty()) return@repeat
-            val totalWeight = remaining.sumOf { it.ticketCount.toLong() }
+            val totalWeight = weights.sum()
             if (totalWeight <= 0L) return@repeat
             var roll = random.nextLong(totalWeight)
-            val it = remaining.iterator()
-            while (it.hasNext()) {
-                val t = it.next()
-                if (roll < t.ticketCount) {
-                    winners += t
-                    it.remove()
+            for (i in remaining.indices) {
+                val w = weights[i]
+                if (roll < w) {
+                    winners += remaining.removeAt(i)
+                    weights.removeAt(i)
                     return@repeat
                 }
-                roll -= t.ticketCount
+                roll -= w
             }
         }
         return winners
+    }
+
+    /**
+     * Effective draw weight for [ticket] given the guild's volume
+     * multiplier tiers. Bonus tickets are added 1:1; the multiplier
+     * scales the paid ticket count, *not* the bonus tickets (bonuses
+     * are flat rewards, not weight-stacked further on themselves).
+     * Floors fractional credit, so a 1.25× of 5 tickets is 5 + 1 = 6.
+     */
+    internal fun effectiveWeight(
+        ticket: JackpotLotteryTicketDto,
+        multiplierTiers: List<Pair<Long, Int>>,
+    ): Long {
+        val paid = ticket.ticketCount.toLong()
+        val bonus = ticket.bonusTickets.coerceAtLeast(0L)
+        if (multiplierTiers.isEmpty()) return paid + bonus
+        val bp = LotteryHelper.multiplierBpFor(paid, multiplierTiers)
+        val multiplierBonus = paid * (bp - LotteryHelper.MULTIPLIER_BP_IDENTITY) /
+            LotteryHelper.MULTIPLIER_BP_IDENTITY.toLong()
+        return paid + bonus + multiplierBonus.coerceAtLeast(0L)
     }
 
     /**

--- a/database/src/main/kotlin/database/service/LotteryHelper.kt
+++ b/database/src/main/kotlin/database/service/LotteryHelper.kt
@@ -192,4 +192,126 @@ object LotteryHelper {
             else -> DEFAULT_PING_MODE
         }
     }
+
+    // ===================================================================
+    // Participation-incentive tiers (TICKET_WEIGHTED only).
+    //
+    // Three independent levers wired through three config-pair triples.
+    // Each tier is a (threshold, payoff) pair stored as separate config
+    // rows so admins can edit and audit each value individually in the
+    // web UI. A tier with a 0/missing threshold is treated as disabled.
+    // Tiers are always returned sorted ascending so callers can iterate
+    // and pick "the highest matched tier" with a single scan.
+    // ===================================================================
+
+    /** Multiplier basis-point identity — 10000 bp = 1.0×. */
+    const val MULTIPLIER_BP_IDENTITY: Int = 10_000
+
+    /** Clamp ceiling for a multiplier tier — 5.0×. */
+    const val MULTIPLIER_BP_MAX: Int = 50_000
+
+    /** Clamp ceiling for a single milestone — half the jackpot. */
+    const val MILESTONE_PCT_MAX: Int = 50
+
+    /** Bulk-buy bonus tiers (purchase ≥ first → +second free tickets). */
+    fun bulkBonusTiers(configService: ConfigService, guildId: Long): List<Pair<Long, Long>> {
+        val pairs = listOf(
+            ConfigDto.Configurations.LOTTERY_BULK_TIER1_BUY to ConfigDto.Configurations.LOTTERY_BULK_TIER1_BONUS,
+            ConfigDto.Configurations.LOTTERY_BULK_TIER2_BUY to ConfigDto.Configurations.LOTTERY_BULK_TIER2_BONUS,
+            ConfigDto.Configurations.LOTTERY_BULK_TIER3_BUY to ConfigDto.Configurations.LOTTERY_BULK_TIER3_BONUS,
+        )
+        return pairs.mapNotNull { (buyKey, bonusKey) ->
+            val buy = readLong(configService, buyKey, guildId) ?: return@mapNotNull null
+            if (buy <= 0L) return@mapNotNull null
+            val bonus = (readLong(configService, bonusKey, guildId) ?: 0L).coerceAtLeast(0L)
+            buy to bonus
+        }.sortedBy { it.first }
+    }
+
+    /** Volume-multiplier tiers (total-tickets ≥ first → bp/10000× weight). */
+    fun volumeMultiplierTiers(configService: ConfigService, guildId: Long): List<Pair<Long, Int>> {
+        val pairs = listOf(
+            ConfigDto.Configurations.LOTTERY_MULT_TIER1_TOTAL to ConfigDto.Configurations.LOTTERY_MULT_TIER1_BP,
+            ConfigDto.Configurations.LOTTERY_MULT_TIER2_TOTAL to ConfigDto.Configurations.LOTTERY_MULT_TIER2_BP,
+            ConfigDto.Configurations.LOTTERY_MULT_TIER3_TOTAL to ConfigDto.Configurations.LOTTERY_MULT_TIER3_BP,
+        )
+        return pairs.mapNotNull { (totalKey, bpKey) ->
+            val total = readLong(configService, totalKey, guildId) ?: return@mapNotNull null
+            if (total <= 0L) return@mapNotNull null
+            val bp = (readLong(configService, bpKey, guildId)?.toInt() ?: MULTIPLIER_BP_IDENTITY)
+                .coerceIn(MULTIPLIER_BP_IDENTITY, MULTIPLIER_BP_MAX)
+            total to bp
+        }.sortedBy { it.first }
+    }
+
+    /** Pool-growth milestones (guild-wide tickets ≥ first → second % of jackpot rolled into pool). */
+    fun poolMilestones(configService: ConfigService, guildId: Long): List<Pair<Long, Long>> {
+        val pairs = listOf(
+            ConfigDto.Configurations.LOTTERY_MILESTONE1_TICKETS to ConfigDto.Configurations.LOTTERY_MILESTONE1_PCT,
+            ConfigDto.Configurations.LOTTERY_MILESTONE2_TICKETS to ConfigDto.Configurations.LOTTERY_MILESTONE2_PCT,
+            ConfigDto.Configurations.LOTTERY_MILESTONE3_TICKETS to ConfigDto.Configurations.LOTTERY_MILESTONE3_PCT,
+        )
+        return pairs.mapNotNull { (ticketsKey, pctKey) ->
+            val tickets = readLong(configService, ticketsKey, guildId) ?: return@mapNotNull null
+            if (tickets <= 0L) return@mapNotNull null
+            val pct = (readLong(configService, pctKey, guildId) ?: 0L).coerceIn(0L, MILESTONE_PCT_MAX.toLong())
+            tickets to pct
+        }.sortedBy { it.first }
+    }
+
+    private fun readLong(configService: ConfigService, key: ConfigDto.Configurations, guildId: Long): Long? =
+        configService.getConfigByName(key.configValue, guildId.toString())?.value?.trim()?.toLongOrNull()
+
+    /**
+     * Bulk bonus to award for a single `/lottery buy` of [count]
+     * tickets, given pre-sorted [tiers] (ascending by threshold). The
+     * highest tier whose threshold ≤ count wins; tiers below it are
+     * subsumed (we don't sum across tiers). Returns 0 when no tier
+     * matches or tiers is empty.
+     */
+    fun bulkBonusFor(count: Long, tiers: List<Pair<Long, Long>>): Long {
+        if (count <= 0L) return 0L
+        var bonus = 0L
+        for ((threshold, payoff) in tiers) {
+            if (count >= threshold) bonus = payoff
+            else break
+        }
+        return bonus
+    }
+
+    /**
+     * Multiplier (in basis points) for a user holding [totalTickets].
+     * Highest matching tier wins; below the smallest threshold the
+     * multiplier is [MULTIPLIER_BP_IDENTITY] (1×). Returns identity for
+     * an empty tier list.
+     */
+    fun multiplierBpFor(totalTickets: Long, tiers: List<Pair<Long, Int>>): Int {
+        if (totalTickets <= 0L) return MULTIPLIER_BP_IDENTITY
+        var bp = MULTIPLIER_BP_IDENTITY
+        for ((threshold, payoff) in tiers) {
+            if (totalTickets >= threshold) bp = payoff
+            else break
+        }
+        return bp
+    }
+
+    /**
+     * Milestones to fire on a `/lottery buy` that takes the guild-wide
+     * ticket count from [prevTotal] to [newTotal]. Returns each
+     * `(threshold, pct)` whose `threshold` is strictly greater than
+     * [alreadyFiredHighest] and is in `(prevTotal, newTotal]`. Sorted
+     * ascending so the caller can advance `milestones_fired` to the
+     * last entry's threshold.
+     */
+    fun milestonesBetween(
+        prevTotal: Long,
+        newTotal: Long,
+        milestones: List<Pair<Long, Long>>,
+        alreadyFiredHighest: Long,
+    ): List<Pair<Long, Long>> {
+        if (newTotal <= prevTotal) return emptyList()
+        return milestones.filter { (threshold, _) ->
+            threshold > alreadyFiredHighest && threshold in (prevTotal + 1)..newTotal
+        }
+    }
 }

--- a/database/src/main/resources/db/migration/V40__lottery_bonus_incentives.sql
+++ b/database/src/main/resources/db/migration/V40__lottery_bonus_incentives.sql
@@ -1,0 +1,23 @@
+-- Positive participation incentives for TICKET_WEIGHTED lotteries.
+-- Three additive levers, all default-off:
+--
+--   1. Bulk bonus tickets (per-purchase): a single /lottery buy N call
+--      grants extra free tickets when N hits configured thresholds.
+--      Tracked on the ticket row in `bonus_tickets`. Splitting into
+--      one-ticket buys earns nothing — that's the whole point.
+--
+--   2. Escalating weight multiplier (per-user-total): the more total
+--      tickets a buyer accumulates across the lottery, the more each of
+--      their tickets is worth at draw time. Read from config at draw
+--      time — no schema cost.
+--
+--   3. Pool-growth milestones (guild-wide): when total ticket count
+--      crosses configured thresholds, the lottery pool absorbs a slice
+--      of the jackpot. `milestones_fired` is the highest threshold that
+--      has already paid out so we never double-fire on the same lottery.
+
+ALTER TABLE toby_coin_jackpot_lottery_ticket
+    ADD COLUMN bonus_tickets BIGINT NOT NULL DEFAULT 0;
+
+ALTER TABLE toby_coin_jackpot_lottery
+    ADD COLUMN milestones_fired BIGINT NOT NULL DEFAULT 0;

--- a/database/src/main/resources/db/migration/V41__lottery_incentives_watermark.sql
+++ b/database/src/main/resources/db/migration/V41__lottery_incentives_watermark.sql
@@ -1,0 +1,11 @@
+-- Live the same way the pool watermark does: persist a digest of the
+-- active incentive tiers at announce/refresh time so the 5-minute
+-- LotteryRefreshJob can detect mid-lottery config edits and re-render
+-- the embed's "Active incentives" field. Without this column, the
+-- refresh short-circuit only fires when poolAmount changes, leaving
+-- the embed stale after a web-UI tier edit.
+--
+-- NULL until first announce. Cleared by clearAnnouncement alongside
+-- announced_pool_amount.
+ALTER TABLE toby_coin_jackpot_lottery
+    ADD COLUMN announced_incentives_digest VARCHAR(64);

--- a/database/src/test/kotlin/database/service/JackpotLotteryServiceTest.kt
+++ b/database/src/test/kotlin/database/service/JackpotLotteryServiceTest.kt
@@ -736,4 +736,353 @@ class JackpotLotteryServiceTest {
         // No drawn numbers persisted, no payouts — caller cancels + refunds.
         verify(exactly = 0) { userService.updateUser(any()) }
     }
+
+    // ===================================================================
+    // Participation incentives (TICKET_WEIGHTED only)
+    // ===================================================================
+
+    /** Stub a single bulk-buy bonus tier (or clear if buy <= 0). */
+    private fun stubBulkTier1(buy: Long, bonus: Long) {
+        every {
+            configService.getConfigByName(
+                ConfigDto.Configurations.LOTTERY_BULK_TIER1_BUY.configValue,
+                guildId.toString()
+            )
+        } returns ConfigDto(
+            name = ConfigDto.Configurations.LOTTERY_BULK_TIER1_BUY.configValue,
+            value = buy.toString(),
+            guildId = guildId.toString()
+        )
+        every {
+            configService.getConfigByName(
+                ConfigDto.Configurations.LOTTERY_BULK_TIER1_BONUS.configValue,
+                guildId.toString()
+            )
+        } returns ConfigDto(
+            name = ConfigDto.Configurations.LOTTERY_BULK_TIER1_BONUS.configValue,
+            value = bonus.toString(),
+            guildId = guildId.toString()
+        )
+    }
+
+    private fun stubMultTier1(total: Long, bp: Int) {
+        every {
+            configService.getConfigByName(
+                ConfigDto.Configurations.LOTTERY_MULT_TIER1_TOTAL.configValue,
+                guildId.toString()
+            )
+        } returns ConfigDto(
+            name = ConfigDto.Configurations.LOTTERY_MULT_TIER1_TOTAL.configValue,
+            value = total.toString(),
+            guildId = guildId.toString()
+        )
+        every {
+            configService.getConfigByName(
+                ConfigDto.Configurations.LOTTERY_MULT_TIER1_BP.configValue,
+                guildId.toString()
+            )
+        } returns ConfigDto(
+            name = ConfigDto.Configurations.LOTTERY_MULT_TIER1_BP.configValue,
+            value = bp.toString(),
+            guildId = guildId.toString()
+        )
+    }
+
+    private fun stubMilestone1(tickets: Long, pct: Long) {
+        every {
+            configService.getConfigByName(
+                ConfigDto.Configurations.LOTTERY_MILESTONE1_TICKETS.configValue,
+                guildId.toString()
+            )
+        } returns ConfigDto(
+            name = ConfigDto.Configurations.LOTTERY_MILESTONE1_TICKETS.configValue,
+            value = tickets.toString(),
+            guildId = guildId.toString()
+        )
+        every {
+            configService.getConfigByName(
+                ConfigDto.Configurations.LOTTERY_MILESTONE1_PCT.configValue,
+                guildId.toString()
+            )
+        } returns ConfigDto(
+            name = ConfigDto.Configurations.LOTTERY_MILESTONE1_PCT.configValue,
+            value = pct.toString(),
+            guildId = guildId.toString()
+        )
+    }
+
+    private fun openWeightedLottery(pool: Long = 0L): JackpotLotteryDto {
+        val lottery = JackpotLotteryDto(
+            id = 1L, guildId = guildId, ticketPrice = 100L, poolAmount = pool,
+            winnerCount = 3, status = JackpotLotteryDto.STATUS_OPEN,
+            mode = JackpotLotteryDto.MODE_TICKET_WEIGHTED,
+        )
+        every {
+            lotteryPersistence.getOpenByGuildAndModeForUpdate(guildId, JackpotLotteryDto.MODE_TICKET_WEIGHTED)
+        } returns lottery
+        return lottery
+    }
+
+    @Test
+    fun `buyTickets grants no bulk bonus when tiers are unset`() {
+        openWeightedLottery()
+        every { userService.getUserByIdForUpdate(7L, guildId) } returns
+            UserDto(discordId = 7L, guildId = guildId).apply { socialCredit = 10_000L }
+        every { lotteryPersistence.getTicketForUpdate(1L, 7L) } returns null
+
+        val r = service.buyTickets(guildId, discordId = 7L, ticketCount = 10)
+        assertTrue(r is JackpotLotteryService.BuyOutcome.Ok)
+        r as JackpotLotteryService.BuyOutcome.Ok
+        assertEquals(0L, r.bonusTicketsGranted)
+        assertEquals(0L, r.totalBonusTickets)
+        assertTrue(r.milestoneBonuses.isEmpty())
+    }
+
+    @Test
+    fun `buyTickets grants bulk bonus when a single purchase hits the threshold`() {
+        stubBulkTier1(buy = 10L, bonus = 3L)
+        openWeightedLottery()
+        every { userService.getUserByIdForUpdate(7L, guildId) } returns
+            UserDto(discordId = 7L, guildId = guildId).apply { socialCredit = 10_000L }
+        every { lotteryPersistence.getTicketForUpdate(1L, 7L) } returns null
+
+        val r = service.buyTickets(guildId, discordId = 7L, ticketCount = 10)
+        assertTrue(r is JackpotLotteryService.BuyOutcome.Ok)
+        r as JackpotLotteryService.BuyOutcome.Ok
+        assertEquals(3L, r.bonusTicketsGranted)
+        assertEquals(3L, r.totalBonusTickets)
+    }
+
+    @Test
+    fun `buyTickets splitting buys across 1-ticket purchases earns no bonus (anti-strategy)`() {
+        stubBulkTier1(buy = 10L, bonus = 3L)
+        openWeightedLottery()
+        val user = UserDto(discordId = 7L, guildId = guildId).apply { socialCredit = 10_000L }
+        every { userService.getUserByIdForUpdate(7L, guildId) } returns user
+        val existing = JackpotLotteryTicketDto(lotteryId = 1L, discordId = 7L, ticketCount = 0, spent = 0L)
+        every { lotteryPersistence.getTicketForUpdate(1L, 7L) } returns existing
+
+        repeat(10) {
+            val r = service.buyTickets(guildId, discordId = 7L, ticketCount = 1)
+            assertTrue(r is JackpotLotteryService.BuyOutcome.Ok)
+            r as JackpotLotteryService.BuyOutcome.Ok
+            assertEquals(0L, r.bonusTicketsGranted, "single-ticket buys never hit the bulk threshold")
+        }
+        assertEquals(10, existing.ticketCount)
+        assertEquals(0L, existing.bonusTickets)
+    }
+
+    @Test
+    fun `buyTickets picks the highest matching bulk tier`() {
+        stubBulkTier1(buy = 5L, bonus = 1L)
+        every {
+            configService.getConfigByName(
+                ConfigDto.Configurations.LOTTERY_BULK_TIER2_BUY.configValue,
+                guildId.toString()
+            )
+        } returns ConfigDto(
+            name = ConfigDto.Configurations.LOTTERY_BULK_TIER2_BUY.configValue,
+            value = "20",
+            guildId = guildId.toString()
+        )
+        every {
+            configService.getConfigByName(
+                ConfigDto.Configurations.LOTTERY_BULK_TIER2_BONUS.configValue,
+                guildId.toString()
+            )
+        } returns ConfigDto(
+            name = ConfigDto.Configurations.LOTTERY_BULK_TIER2_BONUS.configValue,
+            value = "8",
+            guildId = guildId.toString()
+        )
+        openWeightedLottery()
+        every { userService.getUserByIdForUpdate(7L, guildId) } returns
+            UserDto(discordId = 7L, guildId = guildId).apply { socialCredit = 10_000L }
+        every { lotteryPersistence.getTicketForUpdate(1L, 7L) } returns null
+
+        val r = service.buyTickets(guildId, discordId = 7L, ticketCount = 25)
+        assertTrue(r is JackpotLotteryService.BuyOutcome.Ok)
+        r as JackpotLotteryService.BuyOutcome.Ok
+        assertEquals(8L, r.bonusTicketsGranted, "tier2 wins; tier1 is subsumed")
+    }
+
+    @Test
+    fun `effectiveWeight collapses to ticketCount when multiplier tiers empty`() {
+        val ticket = JackpotLotteryTicketDto(lotteryId = 1L, discordId = 7L, ticketCount = 12, spent = 0L)
+        assertEquals(12L, service.effectiveWeight(ticket, emptyList()))
+    }
+
+    @Test
+    fun `effectiveWeight adds bonusTickets and multiplier uplift`() {
+        val ticket = JackpotLotteryTicketDto(
+            lotteryId = 1L, discordId = 7L, ticketCount = 20, spent = 0L,
+            bonusTickets = 5L,
+        )
+        // tier: hold ≥15 → 1.5× (15000 bp). 20 paid * 0.5 = +10 multiplier weight.
+        val weight = service.effectiveWeight(ticket, listOf(15L to 15_000))
+        assertEquals(20L + 5L + 10L, weight)
+    }
+
+    @Test
+    fun `drawLottery weights a high-volume buyer more than their raw ticket count`() {
+        stubMultTier1(total = 15L, bp = 15_000)  // 1.5×
+        val lottery = JackpotLotteryDto(
+            id = 1L, guildId = guildId, ticketPrice = 100L, poolAmount = 1_000L,
+            winnerCount = 1, status = JackpotLotteryDto.STATUS_OPEN,
+            mode = JackpotLotteryDto.MODE_TICKET_WEIGHTED,
+        )
+        every {
+            lotteryPersistence.getOpenByGuildAndModeForUpdate(guildId, JackpotLotteryDto.MODE_TICKET_WEIGHTED)
+        } returns lottery
+        // Buyer A holds 1 paid ticket (weight 1). Buyer B holds 20 paid
+        // tickets, qualifies for 1.5× (effective weight 30). Combined
+        // total weight 31; B should win ~30/31 of seeded RNG draws.
+        every { lotteryPersistence.ticketsByLottery(1L) } returns listOf(
+            JackpotLotteryTicketDto(lotteryId = 1L, discordId = 1L, ticketCount = 1, spent = 100L),
+            JackpotLotteryTicketDto(lotteryId = 1L, discordId = 2L, ticketCount = 20, spent = 2_000L),
+        )
+        (1L..2L).forEach { id ->
+            every { userService.getUserByIdForUpdate(id, guildId) } returns
+                UserDto(discordId = id, guildId = guildId).apply { socialCredit = 0L }
+        }
+
+        val r = service.drawLottery(guildId)
+        assertTrue(r is JackpotLotteryService.DrawOutcome.Ok)
+        r as JackpotLotteryService.DrawOutcome.Ok
+        assertEquals(1, r.payouts.size)
+        // With seed 42 and combined effective weight 31, the first roll
+        // lands inside buyer B's slice — this asserts deterministic
+        // behaviour, not just probability.
+        assertEquals(2L, r.payouts.single().discordId)
+    }
+
+    @Test
+    fun `buyTickets fires a milestone when guild-wide total crosses the threshold`() {
+        stubMilestone1(tickets = 50L, pct = 10L)
+        val lottery = openWeightedLottery(pool = 0L)
+        every { userService.getUserByIdForUpdate(7L, guildId) } returns
+            UserDto(discordId = 7L, guildId = guildId).apply { socialCredit = 100_000L }
+        every { lotteryPersistence.getTicketForUpdate(1L, 7L) } returns null
+        // After upsert, ticketsByLottery reflects this user's new row:
+        // running guild-wide ticket count = 50, prevTotal = 0.
+        every { lotteryPersistence.ticketsByLottery(1L) } returns listOf(
+            JackpotLotteryTicketDto(lotteryId = 1L, discordId = 7L, ticketCount = 50, spent = 5_000L),
+        )
+        every { jackpotService.getPool(guildId) } returns 1_000L
+        every { jackpotService.resetPool(guildId) } returns 1_000L
+
+        val r = service.buyTickets(guildId, discordId = 7L, ticketCount = 50)
+        assertTrue(r is JackpotLotteryService.BuyOutcome.Ok)
+        r as JackpotLotteryService.BuyOutcome.Ok
+        assertEquals(1, r.milestoneBonuses.size, "one milestone fires")
+        assertEquals(50L, r.milestoneBonuses.single().threshold)
+        assertEquals(100L, r.milestoneBonuses.single().creditsAdded, "10% of 1000 = 100")
+        assertEquals(50L, lottery.milestonesFired)
+        // Pool = cost (5000) + milestone (100).
+        assertEquals(5_100L, lottery.poolAmount)
+    }
+
+    @Test
+    fun `buyTickets does not refire a milestone already recorded on the lottery`() {
+        stubMilestone1(tickets = 50L, pct = 10L)
+        val lottery = JackpotLotteryDto(
+            id = 1L, guildId = guildId, ticketPrice = 100L, poolAmount = 5_100L,
+            winnerCount = 3, status = JackpotLotteryDto.STATUS_OPEN,
+            mode = JackpotLotteryDto.MODE_TICKET_WEIGHTED,
+            milestonesFired = 50L,
+        )
+        every {
+            lotteryPersistence.getOpenByGuildAndModeForUpdate(guildId, JackpotLotteryDto.MODE_TICKET_WEIGHTED)
+        } returns lottery
+        every { userService.getUserByIdForUpdate(7L, guildId) } returns
+            UserDto(discordId = 7L, guildId = guildId).apply { socialCredit = 100_000L }
+        every { lotteryPersistence.getTicketForUpdate(1L, 7L) } returns
+            JackpotLotteryTicketDto(lotteryId = 1L, discordId = 7L, ticketCount = 50, spent = 5_000L)
+        // After this buy: total = 60, well past the 50 threshold but
+        // we already fired at 50, so nothing new should trigger.
+        every { lotteryPersistence.ticketsByLottery(1L) } returns listOf(
+            JackpotLotteryTicketDto(lotteryId = 1L, discordId = 7L, ticketCount = 60, spent = 6_000L),
+        )
+
+        val r = service.buyTickets(guildId, discordId = 7L, ticketCount = 10)
+        assertTrue(r is JackpotLotteryService.BuyOutcome.Ok)
+        r as JackpotLotteryService.BuyOutcome.Ok
+        assertTrue(r.milestoneBonuses.isEmpty(), "milestone already fired earlier")
+        verify(exactly = 0) { jackpotService.resetPool(guildId) }
+    }
+
+    @Test
+    fun `buyTickets skips a milestone cleanly when jackpot is empty`() {
+        stubMilestone1(tickets = 50L, pct = 10L)
+        openWeightedLottery(pool = 0L)
+        every { userService.getUserByIdForUpdate(7L, guildId) } returns
+            UserDto(discordId = 7L, guildId = guildId).apply { socialCredit = 100_000L }
+        every { lotteryPersistence.getTicketForUpdate(1L, 7L) } returns null
+        every { lotteryPersistence.ticketsByLottery(1L) } returns listOf(
+            JackpotLotteryTicketDto(lotteryId = 1L, discordId = 7L, ticketCount = 50, spent = 5_000L),
+        )
+        every { jackpotService.getPool(guildId) } returns 0L
+
+        val r = service.buyTickets(guildId, discordId = 7L, ticketCount = 50)
+        assertTrue(r is JackpotLotteryService.BuyOutcome.Ok)
+        r as JackpotLotteryService.BuyOutcome.Ok
+        assertTrue(r.milestoneBonuses.isEmpty(), "empty jackpot delivers no top-up")
+        // Purchase itself still succeeded — only the milestone was a no-op.
+        verify(exactly = 0) { jackpotService.resetPool(guildId) }
+    }
+
+    @Test
+    fun `drawLottery still returns BelowMinBuyers when distinct buyers fall short despite bonuses`() {
+        stubMinBuyers(2)
+        stubBulkTier1(buy = 5L, bonus = 3L)  // bonus active but irrelevant
+        val lottery = JackpotLotteryDto(
+            id = 1L, guildId = guildId, ticketPrice = 100L, poolAmount = 2_000L,
+            winnerCount = 3, status = JackpotLotteryDto.STATUS_OPEN,
+            mode = JackpotLotteryDto.MODE_TICKET_WEIGHTED,
+        )
+        every {
+            lotteryPersistence.getOpenByGuildAndModeForUpdate(guildId, JackpotLotteryDto.MODE_TICKET_WEIGHTED)
+        } returns lottery
+        every { lotteryPersistence.ticketsByLottery(1L) } returns listOf(
+            JackpotLotteryTicketDto(
+                lotteryId = 1L, discordId = 7L, ticketCount = 10, spent = 1_000L,
+                bonusTickets = 3L,
+            ),
+        )
+
+        val r = service.drawLottery(guildId)
+        assertTrue(r is JackpotLotteryService.DrawOutcome.BelowMinBuyers,
+            "the participation gate is independent of the bonus path")
+    }
+
+    @Test
+    fun `drawLottery reports bonusTicketsAwarded and highestMilestoneFired in the outcome`() {
+        val lottery = JackpotLotteryDto(
+            id = 1L, guildId = guildId, ticketPrice = 100L, poolAmount = 3_000L,
+            winnerCount = 1, status = JackpotLotteryDto.STATUS_OPEN,
+            mode = JackpotLotteryDto.MODE_TICKET_WEIGHTED,
+            milestonesFired = 50L,
+        )
+        every {
+            lotteryPersistence.getOpenByGuildAndModeForUpdate(guildId, JackpotLotteryDto.MODE_TICKET_WEIGHTED)
+        } returns lottery
+        every { lotteryPersistence.ticketsByLottery(1L) } returns listOf(
+            JackpotLotteryTicketDto(
+                lotteryId = 1L, discordId = 1L, ticketCount = 30, spent = 3_000L, bonusTickets = 8L,
+            ),
+            JackpotLotteryTicketDto(
+                lotteryId = 1L, discordId = 2L, ticketCount = 20, spent = 2_000L, bonusTickets = 3L,
+            ),
+        )
+        (1L..2L).forEach { id ->
+            every { userService.getUserByIdForUpdate(id, guildId) } returns
+                UserDto(discordId = id, guildId = guildId).apply { socialCredit = 0L }
+        }
+
+        val r = service.drawLottery(guildId)
+        assertTrue(r is JackpotLotteryService.DrawOutcome.Ok)
+        r as JackpotLotteryService.DrawOutcome.Ok
+        assertEquals(11L, r.bonusTicketsAwarded, "8 + 3 across both buyers")
+        assertEquals(50L, r.highestMilestoneFired)
+    }
 }

--- a/database/src/test/kotlin/database/service/JackpotLotteryServiceTest.kt
+++ b/database/src/test/kotlin/database/service/JackpotLotteryServiceTest.kt
@@ -1031,6 +1031,69 @@ class JackpotLotteryServiceTest {
         verify(exactly = 0) { jackpotService.resetPool(guildId) }
     }
 
+    // ===================================================================
+    // Announcement watermarking (pool + incentives digest)
+    // ===================================================================
+
+    @Test
+    fun `recordAnnouncement persists the incentives digest alongside the pool`() {
+        val lottery = JackpotLotteryDto(
+            id = 99L, guildId = guildId, ticketPrice = 100L, poolAmount = 5_000L,
+            mode = JackpotLotteryDto.MODE_TICKET_WEIGHTED, status = JackpotLotteryDto.STATUS_OPEN,
+        )
+        every { lotteryPersistence.findById(99L) } returns lottery
+
+        service.recordAnnouncement(
+            lotteryId = 99L,
+            channelId = 777L,
+            messageId = 999L,
+            pool = 5_000L,
+            incentivesDigest = "deadbeef",
+        )
+
+        assertEquals(777L, lottery.announcementChannelId)
+        assertEquals(999L, lottery.announcementMessageId)
+        assertEquals(5_000L, lottery.announcedPoolAmount)
+        assertEquals("deadbeef", lottery.announcedIncentivesDigest)
+        verify(exactly = 1) { lotteryPersistence.upsert(lottery) }
+    }
+
+    @Test
+    fun `updateAnnouncementWatermarks bumps both pool and digest`() {
+        val lottery = JackpotLotteryDto(
+            id = 99L, guildId = guildId, mode = JackpotLotteryDto.MODE_TICKET_WEIGHTED,
+        ).apply {
+            announcedPoolAmount = 1_000L
+            announcedIncentivesDigest = "old"
+        }
+        every { lotteryPersistence.findById(99L) } returns lottery
+
+        service.updateAnnouncementWatermarks(99L, pool = 1_500L, incentivesDigest = "new")
+
+        assertEquals(1_500L, lottery.announcedPoolAmount)
+        assertEquals("new", lottery.announcedIncentivesDigest)
+    }
+
+    @Test
+    fun `clearAnnouncement clears the digest along with the pool and ids`() {
+        val lottery = JackpotLotteryDto(
+            id = 99L, guildId = guildId, mode = JackpotLotteryDto.MODE_TICKET_WEIGHTED,
+        ).apply {
+            announcementChannelId = 777L
+            announcementMessageId = 999L
+            announcedPoolAmount = 5_000L
+            announcedIncentivesDigest = "deadbeef"
+        }
+        every { lotteryPersistence.findById(99L) } returns lottery
+
+        service.clearAnnouncement(99L)
+
+        assertEquals(null, lottery.announcementChannelId)
+        assertEquals(null, lottery.announcementMessageId)
+        assertEquals(null, lottery.announcedPoolAmount)
+        assertEquals(null, lottery.announcedIncentivesDigest)
+    }
+
     @Test
     fun `drawLottery still returns BelowMinBuyers when distinct buyers fall short despite bonuses`() {
         stubMinBuyers(2)

--- a/database/src/test/kotlin/database/service/LotteryHelperTest.kt
+++ b/database/src/test/kotlin/database/service/LotteryHelperTest.kt
@@ -1,0 +1,135 @@
+package database.service
+
+import database.dto.ConfigDto
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Pure-helper coverage for the participation-incentive tiers added to
+ * [LotteryHelper]. [JackpotLotteryServiceTest] covers the wiring; here
+ * we pin the parsing / clamping / matching maths so a refactor of the
+ * config shape can't quietly change the rules.
+ */
+class LotteryHelperTest {
+
+    private val guildId = 100L
+
+    private fun cfg(value: String): ConfigDto =
+        ConfigDto(name = "x", value = value, guildId = guildId.toString())
+
+    private fun stub(configService: ConfigService, key: ConfigDto.Configurations, raw: String?) {
+        every {
+            configService.getConfigByName(key.configValue, guildId.toString())
+        } returns raw?.let { cfg(it) }
+    }
+
+    @Test
+    fun `bulkBonusFor returns 0 for empty tiers`() {
+        assertEquals(0L, LotteryHelper.bulkBonusFor(100L, emptyList()))
+    }
+
+    @Test
+    fun `bulkBonusFor returns 0 below the lowest threshold`() {
+        assertEquals(0L, LotteryHelper.bulkBonusFor(4L, listOf(5L to 1L, 10L to 3L)))
+    }
+
+    @Test
+    fun `bulkBonusFor picks the highest matching tier and subsumes lower ones`() {
+        val tiers = listOf(5L to 1L, 10L to 3L, 25L to 8L)
+        assertEquals(1L, LotteryHelper.bulkBonusFor(5L, tiers))
+        assertEquals(3L, LotteryHelper.bulkBonusFor(10L, tiers))
+        assertEquals(3L, LotteryHelper.bulkBonusFor(24L, tiers))
+        assertEquals(8L, LotteryHelper.bulkBonusFor(25L, tiers))
+        assertEquals(8L, LotteryHelper.bulkBonusFor(10_000L, tiers))
+    }
+
+    @Test
+    fun `multiplierBpFor returns identity below the lowest threshold or for empty tiers`() {
+        assertEquals(LotteryHelper.MULTIPLIER_BP_IDENTITY, LotteryHelper.multiplierBpFor(50L, emptyList()))
+        assertEquals(
+            LotteryHelper.MULTIPLIER_BP_IDENTITY,
+            LotteryHelper.multiplierBpFor(4L, listOf(5L to 11_000, 15L to 12_500)),
+        )
+    }
+
+    @Test
+    fun `multiplierBpFor picks the highest matching tier`() {
+        val tiers = listOf(5L to 11_000, 15L to 12_500, 40L to 15_000)
+        assertEquals(11_000, LotteryHelper.multiplierBpFor(5L, tiers))
+        assertEquals(12_500, LotteryHelper.multiplierBpFor(20L, tiers))
+        assertEquals(15_000, LotteryHelper.multiplierBpFor(40L, tiers))
+        assertEquals(15_000, LotteryHelper.multiplierBpFor(1_000L, tiers))
+    }
+
+    @Test
+    fun `milestonesBetween fires nothing when newTotal is at or below prevTotal`() {
+        val ms = listOf(50L to 5L, 100L to 5L)
+        assertTrue(LotteryHelper.milestonesBetween(100L, 100L, ms, 0L).isEmpty())
+        assertTrue(LotteryHelper.milestonesBetween(100L, 50L, ms, 0L).isEmpty())
+    }
+
+    @Test
+    fun `milestonesBetween fires multiple thresholds when one buy crosses several`() {
+        val ms = listOf(50L to 5L, 100L to 5L, 250L to 10L)
+        val fired = LotteryHelper.milestonesBetween(0L, 100L, ms, 0L)
+        assertEquals(listOf(50L to 5L, 100L to 5L), fired)
+    }
+
+    @Test
+    fun `milestonesBetween skips milestones already fired`() {
+        val ms = listOf(50L to 5L, 100L to 5L)
+        val fired = LotteryHelper.milestonesBetween(0L, 200L, ms, 50L)
+        assertEquals(listOf(100L to 5L), fired, "50 was already fired earlier; only 100 fires now")
+    }
+
+    @Test
+    fun `bulkBonusTiers ignores tiers with zero threshold and returns ascending`() {
+        val cs = mockk<ConfigService>(relaxed = true)
+        stub(cs, ConfigDto.Configurations.LOTTERY_BULK_TIER1_BUY, "25")
+        stub(cs, ConfigDto.Configurations.LOTTERY_BULK_TIER1_BONUS, "8")
+        stub(cs, ConfigDto.Configurations.LOTTERY_BULK_TIER2_BUY, "0")     // disabled
+        stub(cs, ConfigDto.Configurations.LOTTERY_BULK_TIER2_BONUS, "10")
+        stub(cs, ConfigDto.Configurations.LOTTERY_BULK_TIER3_BUY, "5")
+        stub(cs, ConfigDto.Configurations.LOTTERY_BULK_TIER3_BONUS, "1")
+
+        assertEquals(
+            listOf(5L to 1L, 25L to 8L),
+            LotteryHelper.bulkBonusTiers(cs, guildId),
+        )
+    }
+
+    @Test
+    fun `volumeMultiplierTiers clamps BP below identity up to identity`() {
+        val cs = mockk<ConfigService>(relaxed = true)
+        stub(cs, ConfigDto.Configurations.LOTTERY_MULT_TIER1_TOTAL, "10")
+        stub(cs, ConfigDto.Configurations.LOTTERY_MULT_TIER1_BP, "5000")   // < identity, clamp up
+
+        val tiers = LotteryHelper.volumeMultiplierTiers(cs, guildId)
+        assertEquals(1, tiers.size)
+        assertEquals(10L, tiers.first().first)
+        assertEquals(LotteryHelper.MULTIPLIER_BP_IDENTITY, tiers.first().second)
+    }
+
+    @Test
+    fun `volumeMultiplierTiers clamps BP above max down to max`() {
+        val cs = mockk<ConfigService>(relaxed = true)
+        stub(cs, ConfigDto.Configurations.LOTTERY_MULT_TIER1_TOTAL, "10")
+        stub(cs, ConfigDto.Configurations.LOTTERY_MULT_TIER1_BP, "999999")
+
+        val tiers = LotteryHelper.volumeMultiplierTiers(cs, guildId)
+        assertEquals(LotteryHelper.MULTIPLIER_BP_MAX, tiers.first().second)
+    }
+
+    @Test
+    fun `poolMilestones clamps pct to MILESTONE_PCT_MAX`() {
+        val cs = mockk<ConfigService>(relaxed = true)
+        stub(cs, ConfigDto.Configurations.LOTTERY_MILESTONE1_TICKETS, "100")
+        stub(cs, ConfigDto.Configurations.LOTTERY_MILESTONE1_PCT, "999")
+
+        val ms = LotteryHelper.poolMilestones(cs, guildId)
+        assertEquals(LotteryHelper.MILESTONE_PCT_MAX.toLong(), ms.first().second)
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/LotteryCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/LotteryCommand.kt
@@ -4,8 +4,10 @@ import core.command.Command.Companion.replyAndDelete
 import core.command.Command.Companion.replyEphemeralAndDelete
 import core.command.CommandContext
 import database.dto.UserDto
+import database.service.ConfigService
 import database.service.JackpotLotteryService
 import database.service.JackpotLotteryService.BuyOutcome
+import database.service.LotteryHelper
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
 import net.dv8tion.jda.api.interactions.commands.OptionType
 import net.dv8tion.jda.api.interactions.commands.build.OptionData
@@ -33,6 +35,7 @@ import java.time.Instant
 @Component
 class LotteryCommand @Autowired constructor(
     private val jackpotLotteryService: JackpotLotteryService,
+    private val configService: ConfigService,
 ) : EconomyCommand {
 
     override val name: String = "lottery"
@@ -74,9 +77,7 @@ class LotteryCommand @Autowired constructor(
         }
         when (val r = jackpotLotteryService.buyTickets(guildId, user.discordId, count)) {
             is BuyOutcome.Ok -> event.hook.replyAndDelete(
-                "Bought **$count** tickets. You now hold **${r.ticketCount}** tickets " +
-                    "(spent ${r.totalSpent} credits total). Prize pool: **${r.newPool}** credits. " +
-                    "Your balance: **${r.newBalance}** credits.",
+                buildBuyReply(count, r, guildId),
                 deleteDelay,
             )
             BuyOutcome.NoOpenLottery ->
@@ -114,17 +115,100 @@ class LotteryCommand @Autowired constructor(
             else -> "${remaining.toMinutes().coerceAtLeast(0)}m remaining (informational)"
         }
 
+        val mineCount = (mine?.ticketCount ?: 0).toLong()
+        val mineBonus = mine?.bonusTickets ?: 0L
+        val ownedLine = if (mineBonus > 0L) "**$mineCount** paid + **$mineBonus** bonus"
+        else "**$mineCount**"
+
         event.hook.replyAndDelete(
             "**Lottery status**\n" +
                 "Prize pool: **${lottery.poolAmount}** credits\n" +
                 "Ticket price: **${lottery.ticketPrice}** credits each\n" +
                 "Tickets sold: **$totalTickets** (across ${tickets.size} buyers)\n" +
                 "Winners: **${lottery.winnerCount}**\n" +
-                "Your tickets: **${mine?.ticketCount ?: 0}**\n" +
+                "Your tickets: $ownedLine\n" +
                 "Closes at: $remainingLabel\n\n" +
-                "Top holders:\n$top",
+                "Top holders:\n$top" +
+                renderIncentivesBlock(guildId, mineCount, totalTickets, lottery.milestonesFired),
             deleteDelay,
         )
+    }
+
+    /**
+     * Render the `/lottery buy` reply with bonus and milestone callouts
+     * appended only when they actually fired — a baseline buy reads
+     * exactly like the pre-incentive copy.
+     */
+    private fun buildBuyReply(count: Int, r: BuyOutcome.Ok, guildId: Long): String {
+        val lines = mutableListOf<String>()
+        val totalOwned = if (r.totalBonusTickets > 0L)
+            "**${r.ticketCount}** paid + **${r.totalBonusTickets}** bonus tickets"
+        else "**${r.ticketCount}** tickets"
+        lines += "Bought **$count** tickets. You now hold $totalOwned " +
+            "(spent ${r.totalSpent} credits total). Prize pool: **${r.newPool}** credits. " +
+            "Your balance: **${r.newBalance}** credits."
+        if (r.bonusTicketsGranted > 0L) {
+            lines += "🎁 Bulk-buy bonus: **+${r.bonusTicketsGranted}** free tickets credited."
+        }
+        if (r.milestoneBonuses.isNotEmpty()) {
+            val parts = r.milestoneBonuses.joinToString(", ") {
+                "**${it.threshold}** tickets sold → **+${it.creditsAdded}** credits"
+            }
+            lines += "🚀 Milestone reached! Jackpot top-up: $parts."
+        }
+        return lines.joinToString("\n")
+    }
+
+    /**
+     * Append a compact "Active incentives" / "Next thresholds" block to
+     * `/lottery status`. Read straight off [LotteryHelper] so the bot
+     * surface matches the web "Active rules" summary and the announcer
+     * embed without anything in between.
+     */
+    private fun renderIncentivesBlock(
+        guildId: Long,
+        userTickets: Long,
+        totalTickets: Long,
+        milestonesFired: Long,
+    ): String {
+        val bulk = LotteryHelper.bulkBonusTiers(configService, guildId)
+        val mult = LotteryHelper.volumeMultiplierTiers(configService, guildId)
+        val milestones = LotteryHelper.poolMilestones(configService, guildId)
+        if (bulk.isEmpty() && mult.isEmpty() && milestones.isEmpty()) return ""
+
+        val sb = StringBuilder("\n\n**Active incentives**")
+        if (bulk.isNotEmpty()) {
+            sb.append("\n• Bulk bonus: ")
+            sb.append(bulk.joinToString(", ") { (buy, bonus) -> "buy ≥$buy → +$bonus free" })
+            val nextBulk = bulk.firstOrNull { it.first > userTickets }
+            if (nextBulk != null) {
+                val gap = nextBulk.first - userTickets
+                sb.append(" _(next: buy $gap more in one purchase for +${nextBulk.second})_")
+            }
+        }
+        if (mult.isNotEmpty()) {
+            sb.append("\n• Volume multiplier: ")
+            sb.append(mult.joinToString(", ") { (total, bp) ->
+                "hold ≥$total → ${"%.2f".format(bp / 10000.0)}×"
+            })
+            val nextMult = mult.firstOrNull { it.first > userTickets }
+            if (nextMult != null) {
+                val gap = nextMult.first - userTickets
+                sb.append(" _(hold ${gap} more to reach ${"%.2f".format(nextMult.second / 10000.0)}×)_")
+            }
+        }
+        if (milestones.isNotEmpty()) {
+            sb.append("\n• Pool milestones: ")
+            sb.append(milestones.joinToString(", ") { (tickets, pct) -> "@$tickets tickets → +$pct% of jackpot" })
+            val nextMilestone = milestones.firstOrNull {
+                it.first > milestonesFired && it.first > totalTickets
+            }
+            if (nextMilestone != null) {
+                val gap = nextMilestone.first - totalTickets
+                sb.append(" _(next fires in $gap more tickets sold)_")
+            }
+        }
+        return sb.toString()
     }
 
     private fun replyError(event: SlashCommandInteractionEvent, message: String, deleteDelay: Int) {

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/moderation/JackpotAdminCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/moderation/JackpotAdminCommand.kt
@@ -156,8 +156,16 @@ class JackpotAdminCommand @Autowired constructor(
                     "${idx + 1}. <@${p.discordId}> — **${p.amount}** credits (${p.ticketCount} tickets)"
                 }
                 val body = if (lines.isEmpty()) "_No winners drawn._" else lines.joinToString("\n")
+                val impactBits = mutableListOf<String>()
+                if (result.bonusTicketsAwarded > 0L) {
+                    impactBits += "🎁 ${result.bonusTicketsAwarded} bulk bonus tickets awarded"
+                }
+                if (result.highestMilestoneFired > 0L) {
+                    impactBits += "🚀 milestone up to ${result.highestMilestoneFired} tickets fired"
+                }
+                val impactLine = if (impactBits.isEmpty()) "" else "\n${impactBits.joinToString(" · ")}"
                 event.hook.replyAndDelete(
-                    "Lottery drawn. Total paid: **${result.totalPaid}** of **${result.drained}** credits.\n$body",
+                    "Lottery drawn. Total paid: **${result.totalPaid}** of **${result.drained}** credits.\n$body$impactLine",
                     deleteDelay,
                 )
             }

--- a/discord-bot/src/main/kotlin/bot/toby/scheduling/LotteryAnnouncer.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/scheduling/LotteryAnnouncer.kt
@@ -24,6 +24,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 import java.awt.Color
+import java.security.MessageDigest
 
 /**
  * Posts a "yesterday's draw / today's draw" combined summary to a
@@ -102,12 +103,22 @@ class LotteryAnnouncer @Autowired constructor(
                 route = ChannelRouteKey.LOTTERY,
                 onSent = { sent ->
                     if (lotteryId != null && poolAmount != null) {
+                        // Capture the incentives digest at announce
+                        // time so the next refresh tick can detect a
+                        // tier edit without firing a redundant edit
+                        // for the unchanged baseline. Digest only
+                        // applies to TICKET_WEIGHTED — NUMBER_MATCH
+                        // embeds don't carry the field.
+                        val initialDigest = if (mode == LotteryHelper.MODE_WEIGHTED) {
+                            incentivesDigest(guild.idLong)
+                        } else null
                         runCatching {
                             jackpotLotteryService.recordAnnouncement(
                                 lotteryId = lotteryId,
                                 channelId = sent.channel.idLong,
                                 messageId = sent.idLong,
                                 pool = poolAmount,
+                                incentivesDigest = initialDigest,
                             )
                         }.onFailure {
                             logger.warn(
@@ -175,8 +186,19 @@ class LotteryAnnouncer @Autowired constructor(
         val lotteryId = lottery.id ?: return
         val messageId = lottery.announcementMessageId ?: return
         val channelId = lottery.announcementChannelId ?: return
-        val announcedPool = lottery.announcedPoolAmount
-        if (announcedPool == lottery.poolAmount) return
+        // Two reasons to refresh: the pool moved (existing trigger) or
+        // an admin edited an incentive tier in the web UI since we
+        // last announced (new trigger — covers the case where the
+        // pool is flat but the displayed tiers are stale). The digest
+        // is computed off live config so it changes the moment a tier
+        // is saved; we persist it on each successful edit to match.
+        val mode = runtimeMode(lottery.mode)
+        val freshDigest = if (mode == LotteryHelper.MODE_WEIGHTED) {
+            incentivesDigest(guild.idLong)
+        } else null
+        val poolChanged = lottery.announcedPoolAmount != lottery.poolAmount
+        val incentivesChanged = lottery.announcedIncentivesDigest != freshDigest
+        if (!poolChanged && !incentivesChanged) return
 
         val channel = guild.getTextChannelById(channelId) ?: run {
             logger.warn(
@@ -194,16 +216,22 @@ class LotteryAnnouncer @Autowired constructor(
                 runCatching { jackpotLotteryService.clearAnnouncement(lotteryId) }
                 return@queue
             }
-            val rebuilt = rebuildWithUpdatedTodaysDraw(previous, lottery)
-            val actionRow = announcementActionRow(runtimeMode(lottery.mode), guild.idLong)
+            val rebuilt = rebuildEmbed(previous, lottery, guild.idLong)
+            val actionRow = announcementActionRow(mode, guild.idLong)
             existing.editMessageEmbeds(rebuilt)
                 .setComponents(listOfNotNull(actionRow))
                 .queue({
-                runCatching { jackpotLotteryService.updateAnnouncedPool(lotteryId, lottery.poolAmount) }
+                runCatching {
+                    jackpotLotteryService.updateAnnouncementWatermarks(
+                        lotteryId = lotteryId,
+                        pool = lottery.poolAmount,
+                        incentivesDigest = freshDigest,
+                    )
+                }
                     .onFailure {
                         logger.warn(
                             "Edited lottery announcement $messageId but failed to persist new " +
-                                "pool watermark: ${it.message}"
+                                "announcement watermarks: ${it.message}"
                         )
                     }
             }, { failure ->
@@ -228,33 +256,44 @@ class LotteryAnnouncer @Autowired constructor(
     }
 
     /**
-     * Re-render the "Today's draw" field on [previous] with values from
-     * the live [lottery] row. Other fields and the embed chrome
-     * (title / colour / footer) are preserved verbatim — the only thing
-     * that should drift between announce and refresh is the pool value.
+     * Re-render the live fields on [previous] with values from the
+     * current [lottery] row and config. The "Today's draw" field always
+     * gets the fresh pool; for TICKET_WEIGHTED draws the "Active
+     * incentives" field is also re-sourced from live config so a
+     * mid-lottery tier edit propagates here. Other fields (yesterday's
+     * recap, chrome) and embed structure are preserved verbatim.
      */
-    private fun rebuildWithUpdatedTodaysDraw(
+    private fun rebuildEmbed(
         previous: MessageEmbed,
         lottery: JackpotLotteryDto,
+        guildId: Long,
     ): MessageEmbed {
         val builder = EmbedBuilder(previous).clearFields()
+        // [renderOpenSummary] expects the runtime mode string from
+        // [LotteryHelper] (e.g. "WEIGHTED"), but [lottery.mode] holds
+        // the DTO column value ("TICKET_WEIGHTED" / "NUMBER_MATCH").
+        // Translate explicitly so a refreshed weighted draw doesn't
+        // fall through to the "Pick 5 of 49" else branch.
+        val mode = runtimeMode(lottery.mode)
         val freshSummary = OpenSummary.Ok(
             lotteryId = lottery.id,
             seeded = 0L,                         // unused in renderOpenSummary
             ticketPrice = lottery.ticketPrice,
             poolAmount = lottery.poolAmount,
         )
-        // [renderOpenSummary] expects the runtime mode string from
-        // [LotteryHelper] (e.g. "WEIGHTED"), but [lottery.mode] holds
-        // the DTO column value ("TICKET_WEIGHTED" / "NUMBER_MATCH").
-        // Translate explicitly so a refreshed weighted draw doesn't
-        // fall through to the "Pick 5 of 49" else branch.
-        val freshTodayBody = renderOpenSummary(runtimeMode(lottery.mode), freshSummary)
+        val freshTodayBody = renderOpenSummary(mode, freshSummary)
+        val freshIncentives = if (mode == LotteryHelper.MODE_WEIGHTED) {
+            renderActiveIncentives(guildId)
+        } else null
         previous.fields.forEach { field ->
-            if (field.name == TODAYS_DRAW_FIELD) {
-                builder.addField(TODAYS_DRAW_FIELD, freshTodayBody, false)
-            } else {
-                builder.addField(field)
+            when (field.name) {
+                TODAYS_DRAW_FIELD -> builder.addField(TODAYS_DRAW_FIELD, freshTodayBody, false)
+                ACTIVE_INCENTIVES_FIELD -> if (freshIncentives != null) {
+                    builder.addField(ACTIVE_INCENTIVES_FIELD, freshIncentives, false)
+                } else {
+                    builder.addField(field)
+                }
+                else -> builder.addField(field)
             }
         }
         return builder.build()
@@ -375,6 +414,26 @@ class LotteryAnnouncer @Autowired constructor(
             }
         )
         return builder.build()
+    }
+
+    /**
+     * Stable digest (SHA-256 hex, 64 chars — exactly the column
+     * width) of the active incentive tiers for [guildId]. Same tiers
+     * always produce the same digest, so the refresh job can compare
+     * against the persisted watermark in O(1) and skip the Discord
+     * round-trip on quiet ticks. Cheap enough to run on every
+     * 5-minute tick.
+     */
+    internal fun incentivesDigest(guildId: Long): String {
+        val bulk = LotteryHelper.bulkBonusTiers(configService, guildId)
+        val mult = LotteryHelper.volumeMultiplierTiers(configService, guildId)
+        val ms = LotteryHelper.poolMilestones(configService, guildId)
+        val payload = "b:" + bulk.joinToString(",") { "${it.first}:${it.second}" } +
+            "|m:" + mult.joinToString(",") { "${it.first}:${it.second}" } +
+            "|p:" + ms.joinToString(",") { "${it.first}:${it.second}" }
+        return MessageDigest.getInstance("SHA-256")
+            .digest(payload.toByteArray())
+            .joinToString("") { "%02x".format(it) }
     }
 
     /**

--- a/discord-bot/src/main/kotlin/bot/toby/scheduling/LotteryAnnouncer.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/scheduling/LotteryAnnouncer.kt
@@ -279,6 +279,11 @@ class LotteryAnnouncer @Autowired constructor(
             val payouts: List<JackpotLotteryService.WinnerPayout>,
             val totalPaid: Long,
             val drained: Long,
+            /** Total bulk-buy bonus tickets awarded across all buyers this draw. */
+            val bonusTicketsAwarded: Long = 0L,
+            /** Highest pool-growth milestone threshold that fired during
+             *  this lottery (0 = no milestone fired or none configured). */
+            val highestMilestoneFired: Long = 0L,
         ) : PriorOutcome
 
         data class BelowMinBuyers(val have: Int, val need: Int) : PriorOutcome
@@ -354,6 +359,15 @@ class LotteryAnnouncer @Autowired constructor(
             )
         }
         builder.addField(TODAYS_DRAW_FIELD, renderOpenSummary(mode, openOutcome), false)
+        // Incentives apply to TICKET_WEIGHTED draws only — the daily
+        // NUMBER_MATCH already caps each user at one ticket per draw.
+        if (mode == LotteryHelper.MODE_WEIGHTED) {
+            builder.addField(
+                ACTIVE_INCENTIVES_FIELD,
+                renderActiveIncentives(guild.idLong),
+                false,
+            )
+        }
         builder.setFooter(
             when (mode) {
                 LotteryHelper.MODE_WEIGHTED -> "Top-3 weighted draw • 50/30/20 share"
@@ -361,6 +375,34 @@ class LotteryAnnouncer @Autowired constructor(
             }
         )
         return builder.build()
+    }
+
+    /**
+     * Render the per-guild "Active incentives" field body. Reads from
+     * [LotteryHelper] so the embed matches the web moderation page's
+     * "Active rules" summary one-for-one. Returns `"None"` when
+     * everything is at default — never an empty field, so an admin
+     * who's looking at the embed knows the absence is real.
+     */
+    private fun renderActiveIncentives(guildId: Long): String {
+        val bulk = LotteryHelper.bulkBonusTiers(configService, guildId)
+        val mult = LotteryHelper.volumeMultiplierTiers(configService, guildId)
+        val milestones = LotteryHelper.poolMilestones(configService, guildId)
+        if (bulk.isEmpty() && mult.isEmpty() && milestones.isEmpty()) return "None"
+        val lines = mutableListOf<String>()
+        if (bulk.isNotEmpty()) {
+            lines += "🎁 Bulk bonus: " +
+                bulk.joinToString(", ") { (buy, bonus) -> "buy ≥$buy → **+$bonus** free" }
+        }
+        if (mult.isNotEmpty()) {
+            lines += "📈 Volume multiplier: " +
+                mult.joinToString(", ") { (total, bp) -> "hold ≥$total → **${"%.2f".format(bp / 10000.0)}×**" }
+        }
+        if (milestones.isNotEmpty()) {
+            lines += "🚀 Pool milestones: " +
+                milestones.joinToString(", ") { (tickets, pct) -> "@$tickets tickets → **+$pct%** jackpot" }
+        }
+        return lines.joinToString("\n")
     }
 
     private fun renderPriorOutcome(prior: PriorOutcome): String = when (prior) {
@@ -378,7 +420,7 @@ class LotteryAnnouncer @Autowired constructor(
             "Winning numbers: **$numbers**\n$winners"
         }
         is PriorOutcome.WeightedDrawn -> {
-            if (prior.payouts.isEmpty()) {
+            val body = if (prior.payouts.isEmpty()) {
                 "No payouts — pool of **${prior.drained}** rolled back to jackpot."
             } else {
                 prior.payouts
@@ -388,6 +430,8 @@ class LotteryAnnouncer @Autowired constructor(
                     }
                     .joinToString("\n")
             }
+            val impact = renderBonusImpact(prior)
+            if (impact.isEmpty()) body else "$body\n$impact"
         }
         is PriorOutcome.BelowMinBuyers ->
             "Only **${prior.have}** buyer(s) — need **${prior.need}**. Refunded; seed returned to jackpot."
@@ -403,6 +447,24 @@ class LotteryAnnouncer @Autowired constructor(
         }
         OpenSummary.Skipped ->
             "Today's draw was not opened — see logs / moderation tab."
+    }
+
+    /**
+     * Compact "Bonus impact" line(s) for a weighted-draw result embed:
+     * total bulk bonuses awarded across all buyers, plus any pool
+     * milestones that fired with their jackpot top-ups. Empty when
+     * neither happened — caller appends a leading newline only when
+     * the body is non-empty.
+     */
+    private fun renderBonusImpact(prior: PriorOutcome.WeightedDrawn): String {
+        val lines = mutableListOf<String>()
+        if (prior.bonusTicketsAwarded > 0L) {
+            lines += "🎁 Bulk bonus impact: **${prior.bonusTicketsAwarded}** free tickets awarded across all buyers."
+        }
+        if (prior.highestMilestoneFired > 0L) {
+            lines += "🚀 Milestones fired up to **${prior.highestMilestoneFired}** tickets sold — pool topped up from the jackpot."
+        }
+        return lines.joinToString("\n")
     }
 
     private fun winnerPingIds(prior: PriorOutcome?): List<Long> = when (prior) {
@@ -489,5 +551,6 @@ class LotteryAnnouncer @Autowired constructor(
         // exactly with what [buildEmbed] writes.
         const val TODAYS_DRAW_FIELD = "Today's draw"
         const val YESTERDAYS_DRAW_FIELD = "Yesterday's draw"
+        const val ACTIVE_INCENTIVES_FIELD = "Active incentives"
     }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/scheduling/LotteryDailyJob.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/scheduling/LotteryDailyJob.kt
@@ -196,6 +196,8 @@ class LotteryDailyJob @Autowired constructor(
                     payouts = drawResult.payouts,
                     totalPaid = drawResult.totalPaid,
                     drained = drawResult.drained,
+                    bonusTicketsAwarded = drawResult.bonusTicketsAwarded,
+                    highestMilestoneFired = drawResult.highestMilestoneFired,
                 )
             }
             JackpotLotteryService.DrawOutcome.NoTickets -> {

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/economy/LotteryCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/economy/LotteryCommandTest.kt
@@ -1,0 +1,301 @@
+package bot.toby.command.commands.economy
+
+import bot.toby.command.CommandTest
+import bot.toby.command.CommandTest.Companion.event
+import bot.toby.command.CommandTest.Companion.guild
+import bot.toby.command.CommandTest.Companion.interactionHook
+import bot.toby.command.CommandTest.Companion.webhookMessageCreateAction
+import bot.toby.command.DefaultCommandContext
+import database.dto.ConfigDto
+import database.dto.JackpotLotteryDto
+import database.dto.JackpotLotteryTicketDto
+import database.dto.UserDto
+import database.service.ConfigService
+import database.service.JackpotLotteryService
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import net.dv8tion.jda.api.interactions.commands.OptionMapping
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+/**
+ * Covers the player-facing surface for the participation-incentive
+ * work: `/lottery buy` must reflect any bulk-bonus and milestone
+ * payouts in the reply text, and `/lottery status` must surface the
+ * active tiers + the user's next thresholds so they can see the rules
+ * without an admin posting them. The underlying `LotteryHelper`
+ * accessors are unit-tested in `LotteryHelperTest`; here we pin the
+ * formatting glue that turns those tuples into chat-readable text.
+ */
+internal class LotteryCommandTest : CommandTest {
+
+    private val guildId = 42L
+    private val discordId = 1L
+    private lateinit var jackpotLotteryService: JackpotLotteryService
+    private lateinit var configService: ConfigService
+    private lateinit var command: LotteryCommand
+
+    @BeforeEach
+    fun setUp() {
+        setUpCommonMocks()
+        jackpotLotteryService = mockk(relaxed = true)
+        configService = mockk(relaxed = true)
+        command = LotteryCommand(jackpotLotteryService, configService)
+        every { guild.idLong } returns guildId
+    }
+
+    @AfterEach
+    fun tearDown() {
+        tearDownCommonMocks()
+    }
+
+    private fun intOpt(value: Long): OptionMapping {
+        val o = mockk<OptionMapping>(relaxed = true)
+        every { o.asLong } returns value
+        return o
+    }
+
+    private fun stubBuySubcommand(count: Long) {
+        every { event.subcommandName } returns "buy"
+        every { event.getOption("count") } returns intOpt(count)
+    }
+
+    private fun stubStatusSubcommand() {
+        every { event.subcommandName } returns "status"
+    }
+
+    private fun stubConfig(key: ConfigDto.Configurations, value: String?) {
+        every {
+            configService.getConfigByName(key.configValue, guildId.toString())
+        } returns value?.let {
+            ConfigDto(name = key.configValue, value = it, guildId = guildId.toString())
+        }
+    }
+
+    private fun captureReply(): io.mockk.CapturingSlot<String> {
+        val slot = slot<String>()
+        every { interactionHook.sendMessage(capture(slot)) } returns webhookMessageCreateAction
+        return slot
+    }
+
+    @Test
+    fun `buy reply renders cleanly when no incentives are configured`() {
+        stubBuySubcommand(count = 5)
+        every {
+            jackpotLotteryService.buyTickets(guildId, discordId, 5)
+        } returns JackpotLotteryService.BuyOutcome.Ok(
+            ticketCount = 5,
+            totalSpent = 500L,
+            newBalance = 9_500L,
+            newPool = 1_500L,
+        )
+        val captured = captureReply()
+
+        command.handle(DefaultCommandContext(event), UserDto(discordId = discordId, guildId = guildId), 5)
+
+        val reply = captured.captured
+        assertTrue(reply.contains("Bought **5** tickets"), reply)
+        assertTrue(reply.contains("**5** tickets") || reply.contains("5** tickets"), reply)
+        assertTrue(reply.contains("1500"), "pool surfaced: $reply")
+        assertTrue(reply.contains("9500"), "balance surfaced: $reply")
+        assertFalse(reply.contains("Bulk-buy bonus"), "no bonus copy when nothing granted: $reply")
+        assertFalse(reply.contains("Milestone reached"), "no milestone copy when nothing fired: $reply")
+    }
+
+    @Test
+    fun `buy reply surfaces bulk bonus tickets when granted`() {
+        stubBuySubcommand(count = 10)
+        every {
+            jackpotLotteryService.buyTickets(guildId, discordId, 10)
+        } returns JackpotLotteryService.BuyOutcome.Ok(
+            ticketCount = 10,
+            totalSpent = 1_000L,
+            newBalance = 9_000L,
+            newPool = 2_000L,
+            bonusTicketsGranted = 3L,
+            totalBonusTickets = 3L,
+        )
+        val captured = captureReply()
+
+        command.handle(DefaultCommandContext(event), UserDto(discordId = discordId, guildId = guildId), 5)
+
+        val reply = captured.captured
+        assertTrue(reply.contains("Bulk-buy bonus"), "bonus callout present: $reply")
+        assertTrue(reply.contains("+3"), "bonus count surfaced: $reply")
+        // The total owned line should also include the bonus breakdown.
+        assertTrue(reply.contains("paid + **3** bonus"), reply)
+    }
+
+    @Test
+    fun `buy reply surfaces milestone top-up when a milestone fires`() {
+        stubBuySubcommand(count = 50)
+        every {
+            jackpotLotteryService.buyTickets(guildId, discordId, 50)
+        } returns JackpotLotteryService.BuyOutcome.Ok(
+            ticketCount = 50,
+            totalSpent = 5_000L,
+            newBalance = 5_000L,
+            newPool = 5_100L,
+            milestoneBonuses = listOf(
+                JackpotLotteryService.MilestoneBonus(threshold = 50L, creditsAdded = 100L),
+            ),
+        )
+        val captured = captureReply()
+
+        command.handle(DefaultCommandContext(event), UserDto(discordId = discordId, guildId = guildId), 5)
+
+        val reply = captured.captured
+        assertTrue(reply.contains("Milestone reached"), reply)
+        assertTrue(reply.contains("**50** tickets sold"), reply)
+        assertTrue(reply.contains("**+100** credits"), reply)
+    }
+
+    @Test
+    fun `buy reply forwards each failure outcome to an ephemeral error`() {
+        // Each failure variant should result in an ephemeral reply
+        // through `replyEphemeralAndDelete` → `sendMessage`; we capture
+        // every send and assert the variant-specific copy made it
+        // through. A regression that swallows one (e.g. `UnknownUser`)
+        // would leave that bucket silent in prod.
+        val outcomes = mapOf<JackpotLotteryService.BuyOutcome, String>(
+            JackpotLotteryService.BuyOutcome.NoOpenLottery to "No lottery is open",
+            JackpotLotteryService.BuyOutcome.InvalidCount(0) to "must be positive",
+            JackpotLotteryService.BuyOutcome.Insufficient(have = 10L, need = 100L) to
+                "only have **10** credits",
+            JackpotLotteryService.BuyOutcome.UnknownUser to "No user record",
+        )
+        for ((outcome, expected) in outcomes) {
+            stubBuySubcommand(count = 1)
+            every { jackpotLotteryService.buyTickets(guildId, discordId, 1) } returns outcome
+            val captured = captureReply()
+
+            command.handle(DefaultCommandContext(event), UserDto(discordId = discordId, guildId = guildId), 5)
+
+            assertTrue(
+                captured.captured.contains(expected, ignoreCase = true),
+                "$outcome should produce a reply containing '$expected', got: ${captured.captured}",
+            )
+        }
+    }
+
+    @Test
+    fun `status reply renders nothing-active block when no incentives configured`() {
+        stubStatusSubcommand()
+        every { jackpotLotteryService.getOpenWeighted(guildId) } returns JackpotLotteryDto(
+            id = 1L, guildId = guildId, ticketPrice = 100L, poolAmount = 1_000L,
+            winnerCount = 3, status = JackpotLotteryDto.STATUS_OPEN,
+            mode = JackpotLotteryDto.MODE_TICKET_WEIGHTED,
+            openedAt = Instant.now(), closesAt = Instant.now().plusSeconds(3_600),
+        )
+        every { jackpotLotteryService.ticketsForOpenWeighted(guildId) } returns listOf(
+            JackpotLotteryTicketDto(lotteryId = 1L, discordId = discordId, ticketCount = 5, spent = 500L),
+        )
+        val captured = captureReply()
+
+        command.handle(DefaultCommandContext(event), UserDto(discordId = discordId, guildId = guildId), 5)
+
+        val reply = captured.captured
+        assertTrue(reply.contains("Lottery status"), reply)
+        assertTrue(reply.contains("Your tickets"), reply)
+        assertFalse(
+            reply.contains("Active incentives"),
+            "no Active incentives block when nothing is configured: $reply",
+        )
+    }
+
+    @Test
+    fun `status reply surfaces active tiers and the user's next bulk threshold`() {
+        stubStatusSubcommand()
+        stubConfig(ConfigDto.Configurations.LOTTERY_BULK_TIER1_BUY, "10")
+        stubConfig(ConfigDto.Configurations.LOTTERY_BULK_TIER1_BONUS, "3")
+        every { jackpotLotteryService.getOpenWeighted(guildId) } returns JackpotLotteryDto(
+            id = 1L, guildId = guildId, ticketPrice = 100L, poolAmount = 1_000L,
+            winnerCount = 3, status = JackpotLotteryDto.STATUS_OPEN,
+            mode = JackpotLotteryDto.MODE_TICKET_WEIGHTED,
+            openedAt = Instant.now(), closesAt = Instant.now().plusSeconds(3_600),
+        )
+        // User holds 4 tickets — 6 short of the bulk threshold of 10.
+        every { jackpotLotteryService.ticketsForOpenWeighted(guildId) } returns listOf(
+            JackpotLotteryTicketDto(lotteryId = 1L, discordId = discordId, ticketCount = 4, spent = 400L),
+        )
+        val captured = captureReply()
+
+        command.handle(DefaultCommandContext(event), UserDto(discordId = discordId, guildId = guildId), 5)
+
+        val reply = captured.captured
+        assertTrue(reply.contains("Active incentives"), reply)
+        assertTrue(reply.contains("Bulk bonus"), reply)
+        assertTrue(reply.contains("buy ≥10 → +3 free"), reply)
+        // Next-threshold hint: 6 more to hit tier 1.
+        assertTrue(
+            reply.contains("buy 6 more in one purchase for +3"),
+            "next-threshold hint surfaced: $reply",
+        )
+    }
+
+    @Test
+    fun `status reply lists multiplier and milestone tiers when configured`() {
+        stubStatusSubcommand()
+        stubConfig(ConfigDto.Configurations.LOTTERY_MULT_TIER1_TOTAL, "15")
+        stubConfig(ConfigDto.Configurations.LOTTERY_MULT_TIER1_BP, "15000")
+        stubConfig(ConfigDto.Configurations.LOTTERY_MILESTONE1_TICKETS, "50")
+        stubConfig(ConfigDto.Configurations.LOTTERY_MILESTONE1_PCT, "10")
+        every { jackpotLotteryService.getOpenWeighted(guildId) } returns JackpotLotteryDto(
+            id = 1L, guildId = guildId, ticketPrice = 100L, poolAmount = 1_000L,
+            winnerCount = 3, status = JackpotLotteryDto.STATUS_OPEN,
+            mode = JackpotLotteryDto.MODE_TICKET_WEIGHTED,
+            openedAt = Instant.now(), closesAt = Instant.now().plusSeconds(3_600),
+        )
+        every { jackpotLotteryService.ticketsForOpenWeighted(guildId) } returns emptyList()
+        val captured = captureReply()
+
+        command.handle(DefaultCommandContext(event), UserDto(discordId = discordId, guildId = guildId), 5)
+
+        val reply = captured.captured
+        assertTrue(reply.contains("Volume multiplier"), reply)
+        assertTrue(reply.contains("hold ≥15 → 1.50×"), "multiplier rendered with two decimals: $reply")
+        assertTrue(reply.contains("Pool milestones"), reply)
+        assertTrue(reply.contains("@50 tickets → +10% of jackpot"), reply)
+    }
+
+    @Test
+    fun `status reply surfaces user's bonus tickets in the owned-tickets line`() {
+        stubStatusSubcommand()
+        every { jackpotLotteryService.getOpenWeighted(guildId) } returns JackpotLotteryDto(
+            id = 1L, guildId = guildId, ticketPrice = 100L, poolAmount = 1_000L,
+            winnerCount = 3, status = JackpotLotteryDto.STATUS_OPEN,
+            mode = JackpotLotteryDto.MODE_TICKET_WEIGHTED,
+            openedAt = Instant.now(), closesAt = Instant.now().plusSeconds(3_600),
+        )
+        every { jackpotLotteryService.ticketsForOpenWeighted(guildId) } returns listOf(
+            JackpotLotteryTicketDto(
+                lotteryId = 1L, discordId = discordId, ticketCount = 12, spent = 1_200L,
+                bonusTickets = 4L,
+            ),
+        )
+        val captured = captureReply()
+
+        command.handle(DefaultCommandContext(event), UserDto(discordId = discordId, guildId = guildId), 5)
+
+        val reply = captured.captured
+        assertTrue(reply.contains("**12** paid + **4** bonus"), reply)
+    }
+
+    @Test
+    fun `status reply with no open lottery returns the no-lottery copy`() {
+        stubStatusSubcommand()
+        every { jackpotLotteryService.getOpenWeighted(guildId) } returns null
+        val captured = captureReply()
+
+        command.handle(DefaultCommandContext(event), UserDto(discordId = discordId, guildId = guildId), 5)
+
+        assertTrue(captured.captured.contains("No lottery is open"))
+        verify(exactly = 0) { jackpotLotteryService.ticketsForOpenWeighted(any()) }
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/economy/LotteryCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/economy/LotteryCommandTest.kt
@@ -3,7 +3,6 @@ package bot.toby.command.commands.economy
 import bot.toby.command.CommandTest
 import bot.toby.command.CommandTest.Companion.event
 import bot.toby.command.CommandTest.Companion.guild
-import bot.toby.command.CommandTest.Companion.interactionHook
 import bot.toby.command.CommandTest.Companion.webhookMessageCreateAction
 import bot.toby.command.DefaultCommandContext
 import database.dto.ConfigDto
@@ -79,8 +78,14 @@ internal class LotteryCommandTest : CommandTest {
     }
 
     private fun captureReply(): io.mockk.CapturingSlot<String> {
+        // Mirror LevelCommandTest's working pattern: stub the chained
+        // `event.hook.sendMessage(...)` rather than going through the
+        // companion-level `interactionHook` mock. Both `replyAndDelete`
+        // and `replyEphemeralAndDelete` route through `sendMessage(...)`
+        // on the InteractionHook receiver, so a single capture covers
+        // both success and error paths.
         val slot = slot<String>()
-        every { interactionHook.sendMessage(capture(slot)) } returns webhookMessageCreateAction
+        every { event.hook.sendMessage(capture(slot)) } returns webhookMessageCreateAction
         return slot
     }
 

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/moderation/JackpotAdminCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/moderation/JackpotAdminCommandTest.kt
@@ -1,0 +1,159 @@
+package bot.toby.command.commands.moderation
+
+import bot.toby.command.CommandTest
+import bot.toby.command.CommandTest.Companion.event
+import bot.toby.command.CommandTest.Companion.guild
+import bot.toby.command.CommandTest.Companion.interactionHook
+import bot.toby.command.CommandTest.Companion.replyCallbackAction
+import bot.toby.command.CommandTest.Companion.requestingUserDto
+import bot.toby.command.CommandTest.Companion.webhookMessageCreateAction
+import bot.toby.command.DefaultCommandContext
+import database.dto.UserDto
+import database.service.CasinoAdminService
+import database.service.JackpotLotteryService
+import database.service.JackpotService
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * Focused coverage for the `/jackpotadmin lottery_draw` reply
+ * formatting after the incentives work. The handler must surface a
+ * "bonus impact" line when [JackpotLotteryService.DrawOutcome.Ok]
+ * carries non-zero [bonusTicketsAwarded] / [highestMilestoneFired]
+ * and stay clean when neither moved. Other admin subcommands are
+ * intentionally out of scope here — they're untouched by this PR.
+ */
+internal class JackpotAdminCommandTest : CommandTest {
+
+    private val guildId = 42L
+    private lateinit var casinoAdminService: CasinoAdminService
+    private lateinit var jackpotService: JackpotService
+    private lateinit var jackpotLotteryService: JackpotLotteryService
+    private lateinit var command: JackpotAdminCommand
+
+    @BeforeEach
+    fun setUp() {
+        setUpCommonMocks()
+        casinoAdminService = mockk(relaxed = true)
+        jackpotService = mockk(relaxed = true)
+        jackpotLotteryService = mockk(relaxed = true)
+        command = JackpotAdminCommand(casinoAdminService, jackpotService, jackpotLotteryService)
+        every { guild.idLong } returns guildId
+        every { event.subcommandName } returns "lottery_draw"
+        // The lottery_draw handler defers ephemerally; the base sets up
+        // deferReply() but not the boolean overload.
+        every { event.deferReply(true) } returns replyCallbackAction
+        // requestingUserDto.superUser is already stubbed true in the base.
+    }
+
+    @AfterEach
+    fun tearDown() {
+        tearDownCommonMocks()
+    }
+
+    private fun captureReply(): io.mockk.CapturingSlot<String> {
+        val slot = slot<String>()
+        every { interactionHook.sendMessage(capture(slot)) } returns webhookMessageCreateAction
+        return slot
+    }
+
+    @Test
+    fun `lottery_draw reply omits the bonus-impact line when neither bonuses nor milestones fired`() {
+        every { jackpotLotteryService.drawLottery(guildId) } returns
+            JackpotLotteryService.DrawOutcome.Ok(
+                payouts = listOf(
+                    JackpotLotteryService.WinnerPayout(discordId = 1L, ticketCount = 5, amount = 800L),
+                ),
+                totalPaid = 800L,
+                drained = 1_000L,
+            )
+        val captured = captureReply()
+
+        command.handle(DefaultCommandContext(event), requestingUserDto, 5)
+
+        val reply = captured.captured
+        assertTrue(reply.contains("Lottery drawn"), reply)
+        assertTrue(reply.contains("Total paid: **800**"), reply)
+        assertFalse(reply.contains("🎁"), "no bonus emoji when nothing granted: $reply")
+        assertFalse(reply.contains("🚀"), "no milestone emoji when nothing fired: $reply")
+    }
+
+    @Test
+    fun `lottery_draw reply surfaces bonus tickets awarded when DrawOutcome reports them`() {
+        every { jackpotLotteryService.drawLottery(guildId) } returns
+            JackpotLotteryService.DrawOutcome.Ok(
+                payouts = listOf(
+                    JackpotLotteryService.WinnerPayout(discordId = 1L, ticketCount = 30, amount = 800L),
+                ),
+                totalPaid = 800L,
+                drained = 1_000L,
+                bonusTicketsAwarded = 11L,
+            )
+        val captured = captureReply()
+
+        command.handle(DefaultCommandContext(event), requestingUserDto, 5)
+
+        val reply = captured.captured
+        assertTrue(reply.contains("🎁 11 bulk bonus tickets awarded"), reply)
+        assertFalse(reply.contains("🚀"), "milestone emoji only when one fired: $reply")
+    }
+
+    @Test
+    fun `lottery_draw reply surfaces milestone fired up to highest threshold`() {
+        every { jackpotLotteryService.drawLottery(guildId) } returns
+            JackpotLotteryService.DrawOutcome.Ok(
+                payouts = listOf(
+                    JackpotLotteryService.WinnerPayout(discordId = 1L, ticketCount = 50, amount = 1_200L),
+                ),
+                totalPaid = 1_200L,
+                drained = 1_500L,
+                highestMilestoneFired = 100L,
+            )
+        val captured = captureReply()
+
+        command.handle(DefaultCommandContext(event), requestingUserDto, 5)
+
+        val reply = captured.captured
+        assertTrue(reply.contains("🚀 milestone up to 100 tickets fired"), reply)
+    }
+
+    @Test
+    fun `lottery_draw reply combines both impact bits on one separator line`() {
+        every { jackpotLotteryService.drawLottery(guildId) } returns
+            JackpotLotteryService.DrawOutcome.Ok(
+                payouts = emptyList(),
+                totalPaid = 0L,
+                drained = 0L,
+                bonusTicketsAwarded = 7L,
+                highestMilestoneFired = 50L,
+            )
+        val captured = captureReply()
+
+        command.handle(DefaultCommandContext(event), requestingUserDto, 5)
+
+        val reply = captured.captured
+        // Both bits live on the same impact line separated by ' · ',
+        // so admins read one summary instead of two trailing lines.
+        assertTrue(reply.contains("🎁 7 bulk bonus tickets awarded · 🚀 milestone up to 50 tickets fired"), reply)
+    }
+
+    @Test
+    fun `lottery_draw reply on BelowMinBuyers surfaces the have-need counts and gate hint`() {
+        every { jackpotLotteryService.drawLottery(guildId) } returns
+            JackpotLotteryService.DrawOutcome.BelowMinBuyers(have = 1, need = 2)
+        val captured = captureReply()
+
+        command.handle(DefaultCommandContext(event), requestingUserDto, 5)
+
+        val reply = captured.captured
+        assertTrue(reply.contains("**1** distinct buyer"), reply)
+        assertTrue(reply.contains("need **2**"), reply)
+        assertTrue(reply.contains("LOTTERY_DAILY_MIN_BUYERS"), reply)
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/moderation/JackpotAdminCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/moderation/JackpotAdminCommandTest.kt
@@ -3,7 +3,6 @@ package bot.toby.command.commands.moderation
 import bot.toby.command.CommandTest
 import bot.toby.command.CommandTest.Companion.event
 import bot.toby.command.CommandTest.Companion.guild
-import bot.toby.command.CommandTest.Companion.interactionHook
 import bot.toby.command.CommandTest.Companion.replyCallbackAction
 import bot.toby.command.CommandTest.Companion.requestingUserDto
 import bot.toby.command.CommandTest.Companion.webhookMessageCreateAction
@@ -58,8 +57,13 @@ internal class JackpotAdminCommandTest : CommandTest {
     }
 
     private fun captureReply(): io.mockk.CapturingSlot<String> {
+        // Mirror LevelCommandTest's working pattern — stub the chained
+        // `event.hook.sendMessage(...)` rather than the companion-level
+        // `interactionHook` mock. Capture works for both
+        // replyAndDelete (success) and replyEphemeralAndDelete (errors)
+        // because both route through `sendMessage(message)` on the hook.
         val slot = slot<String>()
-        every { interactionHook.sendMessage(capture(slot)) } returns webhookMessageCreateAction
+        every { event.hook.sendMessage(capture(slot)) } returns webhookMessageCreateAction
         return slot
     }
 

--- a/discord-bot/src/test/kotlin/bot/toby/scheduling/LotteryAnnouncerTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/scheduling/LotteryAnnouncerTest.kt
@@ -663,6 +663,7 @@ class LotteryAnnouncerTest {
         announcementMessageId: Long? = 999L,
         announcementChannelId: Long? = 777L,
         mode: String = JackpotLotteryDto.MODE_NUMBER_MATCH,
+        announcedIncentivesDigest: String? = null,
     ) = JackpotLotteryDto(
         id = id,
         guildId = guildId,
@@ -673,6 +674,7 @@ class LotteryAnnouncerTest {
         it.announcementMessageId = announcementMessageId
         it.announcementChannelId = announcementChannelId
         it.announcedPoolAmount = announcedPoolAmount
+        it.announcedIncentivesDigest = announcedIncentivesDigest
     }
 
     @Nested
@@ -685,7 +687,7 @@ class LotteryAnnouncerTest {
             announcer.refreshAnnouncement(guild, lottery)
 
             verify(exactly = 0) { guild.getTextChannelById(any<Long>()) }
-            verify(exactly = 0) { jackpotLotteryService.updateAnnouncedPool(any(), any()) }
+            verify(exactly = 0) { jackpotLotteryService.updateAnnouncementWatermarks(any(), any(), any()) }
         }
 
         @Test
@@ -764,7 +766,9 @@ class LotteryAnnouncerTest {
             val yesterdayField = editedEmbedSlot.captured.fields.first { it.name == LotteryAnnouncer.YESTERDAYS_DRAW_FIELD }
             assertTrue(yesterdayField.value!!.contains("No tickets"), "yesterday's field should be preserved")
 
-            verify(exactly = 1) { jackpotLotteryService.updateAnnouncedPool(1L, 1_500L) }
+            verify(exactly = 1) {
+                jackpotLotteryService.updateAnnouncementWatermarks(1L, 1_500L, any())
+            }
         }
 
         @Test
@@ -827,6 +831,114 @@ class LotteryAnnouncerTest {
         }
 
         @Test
+        fun `weighted refresh fires when only the incentive config changed (pool flat)`() {
+            // Lottery already had a baseline announce with no incentives
+            // configured. Admin then enables a bulk tier via the web UI;
+            // pool didn't move but the embed must update on the next tick.
+            stubConfig(ConfigDto.Configurations.LOTTERY_BULK_TIER1_BUY, "10")
+            stubConfig(ConfigDto.Configurations.LOTTERY_BULK_TIER1_BONUS, "3")
+            every { guild.getTextChannelById(777L) } returns channel
+
+            val previousEmbed = EmbedBuilder()
+                .setTitle("🎟️ Daily Lottery — Test Guild")
+                .addField(
+                    LotteryAnnouncer.TODAYS_DRAW_FIELD,
+                    "**1000** credits in the pool · Ticket: **50** · Mode: **Top-3 weighted** · Closes 24h.",
+                    false,
+                )
+                .addField(LotteryAnnouncer.ACTIVE_INCENTIVES_FIELD, "None", false)
+                .build()
+            val message: Message = mockk(relaxed = true)
+            every { message.embeds } returns listOf(previousEmbed)
+
+            val retrieveAction: RestAction<Message> = mockk(relaxed = true)
+            every { channel.retrieveMessageById(999L) } returns retrieveAction
+            every {
+                retrieveAction.queue(any<java.util.function.Consumer<Message>>(), any())
+            } answers {
+                firstArg<java.util.function.Consumer<Message>>().accept(message)
+            }
+
+            val editAction: MessageEditAction = mockk(relaxed = true)
+            val editedEmbedSlot = slot<MessageEmbed>()
+            every { message.editMessageEmbeds(capture(editedEmbedSlot)) } returns editAction
+            every { editAction.setComponents(any<Collection<MessageTopLevelComponent>>()) } returns editAction
+            every {
+                editAction.queue(any<java.util.function.Consumer<Message>>(), any())
+            } answers {
+                firstArg<java.util.function.Consumer<Message>>().accept(message)
+            }
+
+            // Pool flat (1000 == 1000), so the only reason to refresh is
+            // the incentives digest changing. Baseline digest = null;
+            // live digest is non-null because tier 1 is now active.
+            val lottery = openLottery(
+                poolAmount = 1_000L,
+                announcedPoolAmount = 1_000L,
+                mode = JackpotLotteryDto.MODE_TICKET_WEIGHTED,
+                announcedIncentivesDigest = null,
+            )
+            announcer.refreshAnnouncement(guild, lottery)
+
+            val incentives = editedEmbedSlot.captured.fields
+                .first { it.name == LotteryAnnouncer.ACTIVE_INCENTIVES_FIELD }
+                .value!!
+            assertTrue(incentives.contains("buy ≥10"), "live tier surfaces: $incentives")
+            assertFalse(incentives == "None", "stale baseline value must be replaced")
+            verify(exactly = 1) {
+                jackpotLotteryService.updateAnnouncementWatermarks(1L, 1_000L, any())
+            }
+        }
+
+        @Test
+        fun `weighted refresh short-circuits when pool and digest both match`() {
+            // Same TICKET_WEIGHTED setup as above but the persisted
+            // digest already matches the live config — no edit needed.
+            stubConfig(ConfigDto.Configurations.LOTTERY_BULK_TIER1_BUY, "10")
+            stubConfig(ConfigDto.Configurations.LOTTERY_BULK_TIER1_BONUS, "3")
+
+            val liveDigest = announcer.incentivesDigest(guildId)
+            val lottery = openLottery(
+                poolAmount = 1_000L,
+                announcedPoolAmount = 1_000L,
+                mode = JackpotLotteryDto.MODE_TICKET_WEIGHTED,
+                announcedIncentivesDigest = liveDigest,
+            )
+            announcer.refreshAnnouncement(guild, lottery)
+
+            verify(exactly = 0) { guild.getTextChannelById(any<Long>()) }
+            verify(exactly = 0) {
+                jackpotLotteryService.updateAnnouncementWatermarks(any(), any(), any())
+            }
+        }
+
+        @Test
+        fun `incentivesDigest is deterministic for the same configured tiers`() {
+            stubConfig(ConfigDto.Configurations.LOTTERY_BULK_TIER1_BUY, "10")
+            stubConfig(ConfigDto.Configurations.LOTTERY_BULK_TIER1_BONUS, "3")
+            stubConfig(ConfigDto.Configurations.LOTTERY_MILESTONE1_TICKETS, "50")
+            stubConfig(ConfigDto.Configurations.LOTTERY_MILESTONE1_PCT, "10")
+
+            val first = announcer.incentivesDigest(guildId)
+            val second = announcer.incentivesDigest(guildId)
+            assertEquals(first, second)
+            assertTrue(first.length == 64, "SHA-256 hex is 64 chars, got ${first.length}")
+        }
+
+        @Test
+        fun `incentivesDigest changes when any tier value changes`() {
+            stubConfig(ConfigDto.Configurations.LOTTERY_BULK_TIER1_BUY, "10")
+            stubConfig(ConfigDto.Configurations.LOTTERY_BULK_TIER1_BONUS, "3")
+            val before = announcer.incentivesDigest(guildId)
+
+            // Move the bonus from 3 to 5 — different config, different digest.
+            stubConfig(ConfigDto.Configurations.LOTTERY_BULK_TIER1_BONUS, "5")
+            val after = announcer.incentivesDigest(guildId)
+
+            assertFalse(before == after, "edited tier must produce a different digest")
+        }
+
+        @Test
         fun `clears announcement ref on UNKNOWN_MESSAGE error`() {
             every { guild.getTextChannelById(777L) } returns channel
 
@@ -846,7 +958,7 @@ class LotteryAnnouncerTest {
             announcer.refreshAnnouncement(guild, lottery)
 
             verify(exactly = 1) { jackpotLotteryService.clearAnnouncement(1L) }
-            verify(exactly = 0) { jackpotLotteryService.updateAnnouncedPool(any(), any()) }
+            verify(exactly = 0) { jackpotLotteryService.updateAnnouncementWatermarks(any(), any(), any()) }
         }
     }
 }

--- a/discord-bot/src/test/kotlin/bot/toby/scheduling/LotteryAnnouncerTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/scheduling/LotteryAnnouncerTest.kt
@@ -326,12 +326,20 @@ class LotteryAnnouncerTest {
         }
         onSent.captured.invoke(sent)
 
+        // WEIGHTED mode captures a live incentives digest at announce
+        // time so the next refresh tick can detect a tier edit without
+        // a redundant edit for the unchanged baseline. With no tiers
+        // configured the digest is still non-null (SHA-256 of the
+        // empty-tier payload), and the announcer always persists it
+        // alongside the pool watermark.
+        val expectedDigest = announcer.incentivesDigest(guildId)
         verify(exactly = 1) {
             jackpotLotteryService.recordAnnouncement(
                 lotteryId = 42L,
                 channelId = 777L,
                 messageId = 9999L,
                 pool = 500L,
+                incentivesDigest = expectedDigest,
             )
         }
     }
@@ -357,7 +365,9 @@ class LotteryAnnouncerTest {
         )
         onSent.captured.invoke(mockk(relaxed = true))
 
-        verify(exactly = 0) { jackpotLotteryService.recordAnnouncement(any(), any(), any(), any()) }
+        verify(exactly = 0) {
+            jackpotLotteryService.recordAnnouncement(any(), any(), any(), any(), any())
+        }
     }
 
     // ---- embed body + pings ----

--- a/discord-bot/src/test/kotlin/bot/toby/scheduling/LotteryAnnouncerTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/scheduling/LotteryAnnouncerTest.kt
@@ -531,6 +531,129 @@ class LotteryAnnouncerTest {
         assertTrue(data.content.contains("<@1>"))
     }
 
+    // ---- participation-incentive surfacing ----
+
+    @Test
+    fun `weighted open embed renders 'None' for the active incentives field when nothing configured`() {
+        val build = captureMessageBuilder()
+
+        announcer.announceCycle(
+            guild, mode = "WEIGHTED",
+            priorOutcome = null,
+            openOutcome = LotteryAnnouncer.OpenSummary.Ok(
+                seeded = 500L, ticketPrice = 50L, poolAmount = 500L,
+            ),
+        )
+
+        val data = build()
+        val incentives = data.embeds.single().fields
+            .firstOrNull { it.name == LotteryAnnouncer.ACTIVE_INCENTIVES_FIELD }
+        assertTrue(incentives != null, "weighted embed always carries the active-incentives field")
+        assertEquals("None", incentives!!.value)
+    }
+
+    @Test
+    fun `weighted open embed lists only configured incentive tiers`() {
+        stubConfig(ConfigDto.Configurations.LOTTERY_BULK_TIER1_BUY, "10")
+        stubConfig(ConfigDto.Configurations.LOTTERY_BULK_TIER1_BONUS, "3")
+        stubConfig(ConfigDto.Configurations.LOTTERY_BULK_TIER2_BUY, "25")
+        stubConfig(ConfigDto.Configurations.LOTTERY_BULK_TIER2_BONUS, "8")
+        // Tier 3 left unset → must not appear in the embed.
+        stubConfig(ConfigDto.Configurations.LOTTERY_MILESTONE1_TICKETS, "50")
+        stubConfig(ConfigDto.Configurations.LOTTERY_MILESTONE1_PCT, "10")
+        val build = captureMessageBuilder()
+
+        announcer.announceCycle(
+            guild, mode = "WEIGHTED",
+            priorOutcome = null,
+            openOutcome = LotteryAnnouncer.OpenSummary.Ok(
+                seeded = 500L, ticketPrice = 50L, poolAmount = 500L,
+            ),
+        )
+
+        val data = build()
+        val incentives = data.embeds.single().fields
+            .first { it.name == LotteryAnnouncer.ACTIVE_INCENTIVES_FIELD }
+            .value!!
+        assertTrue(incentives.contains("buy ≥10"))
+        assertTrue(incentives.contains("buy ≥25"))
+        assertTrue(incentives.contains("@50 tickets"))
+        assertFalse(incentives.contains("Tier 3"), "unset tiers are not surfaced")
+    }
+
+    @Test
+    fun `number-match open embed omits the active incentives field`() {
+        val build = captureMessageBuilder()
+
+        announcer.announceCycle(
+            guild, mode = "NUMBER_MATCH",
+            priorOutcome = null,
+            openOutcome = LotteryAnnouncer.OpenSummary.Ok(
+                seeded = 500L, ticketPrice = 50L, poolAmount = 500L,
+            ),
+        )
+
+        val data = build()
+        val incentives = data.embeds.single().fields
+            .firstOrNull { it.name == LotteryAnnouncer.ACTIVE_INCENTIVES_FIELD }
+        assertTrue(incentives == null, "incentives apply to TICKET_WEIGHTED only")
+    }
+
+    @Test
+    fun `weighted result embed reports bonus impact and milestone fired`() {
+        val build = captureMessageBuilder()
+        val payouts = listOf(
+            JackpotLotteryService.WinnerPayout(discordId = 1L, ticketCount = 30, amount = 800L),
+        )
+
+        announcer.announceCycle(
+            guild, mode = "WEIGHTED",
+            priorOutcome = LotteryAnnouncer.PriorOutcome.WeightedDrawn(
+                payouts = payouts,
+                totalPaid = 800L,
+                drained = 1_000L,
+                bonusTicketsAwarded = 11L,
+                highestMilestoneFired = 50L,
+            ),
+            openOutcome = LotteryAnnouncer.OpenSummary.Ok(
+                seeded = 500L, ticketPrice = 50L, poolAmount = 500L,
+            ),
+        )
+
+        val data = build()
+        val yesterday = data.embeds.single().fields
+            .first { it.name == LotteryAnnouncer.YESTERDAYS_DRAW_FIELD }
+            .value!!
+        assertTrue(yesterday.contains("11"), "bonus ticket count surfaced: $yesterday")
+        assertTrue(yesterday.contains("50"), "milestone threshold surfaced: $yesterday")
+        assertTrue(yesterday.lowercase().contains("milestone"))
+    }
+
+    @Test
+    fun `weighted result embed omits bonus impact line when nothing happened`() {
+        val build = captureMessageBuilder()
+        val payouts = listOf(
+            JackpotLotteryService.WinnerPayout(discordId = 1L, ticketCount = 5, amount = 500L),
+        )
+
+        announcer.announceCycle(
+            guild, mode = "WEIGHTED",
+            priorOutcome = LotteryAnnouncer.PriorOutcome.WeightedDrawn(
+                payouts = payouts, totalPaid = 500L, drained = 500L,
+            ),
+            openOutcome = LotteryAnnouncer.OpenSummary.Ok(
+                seeded = 500L, ticketPrice = 50L, poolAmount = 500L,
+            ),
+        )
+
+        val data = build()
+        val yesterday = data.embeds.single().fields
+            .first { it.name == LotteryAnnouncer.YESTERDAYS_DRAW_FIELD }
+            .value!!
+        assertFalse(yesterday.contains("Milestones"), "no milestone fired, no line surfaced")
+        assertFalse(yesterday.contains("Bulk bonus impact"), "no bonuses awarded, no line surfaced")
+    }
+
     // ---- refreshAnnouncement (unchanged code path; not routed through NotificationRouter) ----
 
     private fun openLottery(

--- a/discord-bot/src/test/kotlin/bot/toby/scheduling/LotteryDailyJobTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/scheduling/LotteryDailyJobTest.kt
@@ -6,11 +6,16 @@ import database.service.ConfigService
 import database.service.JackpotLotteryService
 import database.service.LotteryDailyService
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.slot
 import io.mockk.verify
 import net.dv8tion.jda.api.JDA
 import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.utils.cache.SnowflakeCacheView
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.Clock
@@ -314,6 +319,49 @@ class LotteryDailyJobTest {
                 any<LotteryAnnouncer.OpenSummary.Ok>(),
             )
         }
+    }
+
+    @Test
+    fun `runDaily threads bonusTicketsAwarded and highestMilestoneFired through to WeightedDrawn`() {
+        // Regression guard for the incentives PR: the daily job is a
+        // pure pass-through for the new DrawOutcome.Ok fields, but
+        // "pure pass-through" is exactly the kind of code that
+        // silently regresses when the announcer payload shape evolves.
+        stubEnabled(true)
+        stubMode("WEIGHTED")
+        every { lotteryDailyService.alreadyRan(guildId, today) } returns false
+        every { jackpotLotteryService.getOpenWeighted(guildId) } returns JackpotLotteryDto(
+            id = 5L, guildId = guildId,
+            status = JackpotLotteryDto.STATUS_OPEN,
+            mode = JackpotLotteryDto.MODE_TICKET_WEIGHTED,
+        )
+        every { jackpotLotteryService.drawLottery(guildId) } returns
+            JackpotLotteryService.DrawOutcome.Ok(
+                payouts = listOf(
+                    JackpotLotteryService.WinnerPayout(discordId = 1L, ticketCount = 30, amount = 800L),
+                ),
+                totalPaid = 800L,
+                drained = 1_000L,
+                bonusTicketsAwarded = 11L,
+                highestMilestoneFired = 50L,
+            )
+        every { jackpotLotteryService.openLottery(guildId, any(), any(), any(), any()) } returns
+            JackpotLotteryService.OpenOutcome.Ok(
+                lottery = JackpotLotteryDto(id = 6L, guildId = guildId, poolAmount = 50L),
+                seeded = 50L,
+            )
+        val priorSlot = slot<LotteryAnnouncer.PriorOutcome>()
+        every {
+            lotteryAnnouncer.announceCycle(any(), any(), capture(priorSlot), any())
+        } just runs
+
+        job.runDaily()
+
+        val prior = priorSlot.captured
+        assertTrue(prior is LotteryAnnouncer.PriorOutcome.WeightedDrawn, "WEIGHTED cycle → WeightedDrawn")
+        prior as LotteryAnnouncer.PriorOutcome.WeightedDrawn
+        assertEquals(11L, prior.bonusTicketsAwarded)
+        assertEquals(50L, prior.highestMilestoneFired)
     }
 
     @Test

--- a/web/src/main/kotlin/web/service/ModerationWebService.kt
+++ b/web/src/main/kotlin/web/service/ModerationWebService.kt
@@ -7,6 +7,7 @@ import database.dto.UserDto
 import database.dto.LevelRoleRewardDto
 import database.service.ConfigService
 import database.service.LevelRoleRewardService
+import database.service.LotteryHelper
 import database.service.MonthlyCreditSnapshotService
 import database.service.TitleService
 import database.service.UbiDailyService
@@ -156,6 +157,22 @@ class ModerationWebService(
             cfg.name to configService.getConfigByName(cfg.configValue, guild.id)?.value
         }
 
+        // Resolve the incentive tier triples through LotteryHelper so the
+        // template, the buy-time service, and the announcer all share one
+        // definition of "active" — no risk of the web summary saying
+        // "Tier 2 is on" while the embed silently ignores it.
+        val guildIdLong = guild.id.toLongOrNull()
+        val incentives = if (guildIdLong == null) LotteryIncentivesView.empty() else {
+            LotteryIncentivesView(
+                bulkTiers = LotteryHelper.bulkBonusTiers(configService, guildIdLong)
+                    .map { (buy, bonus) -> BulkBonusTierView(buy = buy, bonus = bonus) },
+                multiplierTiers = LotteryHelper.volumeMultiplierTiers(configService, guildIdLong)
+                    .map { (total, bp) -> MultiplierTierView(total = total, bp = bp) },
+                poolMilestones = LotteryHelper.poolMilestones(configService, guildIdLong)
+                    .map { (tickets, pct) -> PoolMilestoneView(tickets = tickets, pct = pct) },
+            )
+        }
+
         return GuildOverview(
             guildId = guild.id,
             guildName = guild.name,
@@ -163,7 +180,8 @@ class ModerationWebService(
             voiceChannels = voiceChannels,
             textChannels = textChannels,
             categories = categories,
-            config = configByKey
+            config = configByKey,
+            lotteryIncentives = incentives,
         )
     }
 
@@ -989,6 +1007,69 @@ class ModerationWebService(
                 }
                 v
             }
+            // Bulk-buy bonus tiers (TICKET_WEIGHTED only). Both halves
+            // accept any non-negative whole number; 0 on `BUY` disables
+            // that tier cleanly. Capped at a generous 100k so a typo
+            // can't conjure absurd values, but big enough that a future
+            // mega-server isn't blocked.
+            ConfigDto.Configurations.LOTTERY_BULK_TIER1_BUY,
+            ConfigDto.Configurations.LOTTERY_BULK_TIER1_BONUS,
+            ConfigDto.Configurations.LOTTERY_BULK_TIER2_BUY,
+            ConfigDto.Configurations.LOTTERY_BULK_TIER2_BONUS,
+            ConfigDto.Configurations.LOTTERY_BULK_TIER3_BUY,
+            ConfigDto.Configurations.LOTTERY_BULK_TIER3_BONUS -> {
+                val n = rawValue.trim().toLongOrNull()
+                    ?: return "Value must be a whole number (0 disables this tier; max 100000)."
+                if (n !in 0L..100_000L) return "Value must be between 0 and 100,000."
+                n.toString()
+            }
+            // Volume-multiplier tier thresholds — whole-number ticket
+            // counts, 0 disables. Capped at 100k for the same reason as
+            // the bulk thresholds.
+            ConfigDto.Configurations.LOTTERY_MULT_TIER1_TOTAL,
+            ConfigDto.Configurations.LOTTERY_MULT_TIER2_TOTAL,
+            ConfigDto.Configurations.LOTTERY_MULT_TIER3_TOTAL -> {
+                val n = rawValue.trim().toLongOrNull()
+                    ?: return "Value must be a whole number (0 disables this tier; max 100000)."
+                if (n !in 0L..100_000L) return "Value must be between 0 and 100,000."
+                n.toString()
+            }
+            // Volume-multiplier basis points. 10000 = 1×, 12500 = 1.25×,
+            // 50000 = 5×. We reject sub-1× values so a tier can't
+            // *reduce* a player's weight; 0 is a special "treat as
+            // unset" sentinel the helper coerces upward to identity.
+            ConfigDto.Configurations.LOTTERY_MULT_TIER1_BP,
+            ConfigDto.Configurations.LOTTERY_MULT_TIER2_BP,
+            ConfigDto.Configurations.LOTTERY_MULT_TIER3_BP -> {
+                val n = rawValue.trim().toIntOrNull()
+                    ?: return "Value must be a whole number basis-point value (10000 = 1×, max 50000 = 5×)."
+                if (n != 0 && n !in 10_000..50_000) {
+                    return "Value must be 0 (unset) or between 10000 and 50000."
+                }
+                n.toString()
+            }
+            // Pool-milestone ticket thresholds. 0 disables. 100k cap
+            // matches the bulk thresholds.
+            ConfigDto.Configurations.LOTTERY_MILESTONE1_TICKETS,
+            ConfigDto.Configurations.LOTTERY_MILESTONE2_TICKETS,
+            ConfigDto.Configurations.LOTTERY_MILESTONE3_TICKETS -> {
+                val n = rawValue.trim().toLongOrNull()
+                    ?: return "Value must be a whole number (0 disables this tier; max 100000)."
+                if (n !in 0L..100_000L) return "Value must be between 0 and 100,000."
+                n.toString()
+            }
+            // Pool-milestone % of jackpot. Capped at 50 so a single
+            // milestone can never drain more than half the jackpot in
+            // one purchase — protects the pool from typo-shaped
+            // catastrophe.
+            ConfigDto.Configurations.LOTTERY_MILESTONE1_PCT,
+            ConfigDto.Configurations.LOTTERY_MILESTONE2_PCT,
+            ConfigDto.Configurations.LOTTERY_MILESTONE3_PCT -> {
+                val n = rawValue.trim().toIntOrNull()
+                    ?: return "Value must be a whole number percentage (0-50)."
+                if (n !in 0..50) return "Value must be between 0 and 50."
+                n.toString()
+            }
             ConfigDto.Configurations.LOTTERY_CHANNEL,
             ConfigDto.Configurations.CASINO_MODLOG_CHANNEL_ID,
             ConfigDto.Configurations.ACHIEVEMENT_ANNOUNCE_CHANNEL -> {
@@ -1378,8 +1459,35 @@ data class GuildOverview(
     val voiceChannels: List<VoiceChannelInfo>,
     val textChannels: List<TextChannelInfo>,
     val categories: List<CategoryInfo> = emptyList(),
-    val config: Map<String, String?>
+    val config: Map<String, String?>,
+    val lotteryIncentives: LotteryIncentivesView = LotteryIncentivesView.empty(),
 )
+
+/**
+ * Resolved view of the participation-incentive config for the lottery
+ * page. Each list contains only the tiers that are actually active
+ * (threshold > 0) — the template uses `.size` and `.isEmpty()` to
+ * render the "Active rules" summary, so unset/zero tiers vanish.
+ *
+ * Sourced from the same [database.service.LotteryHelper] getters that
+ * [database.service.JackpotLotteryService.buyTickets] and
+ * [bot.toby.scheduling.LotteryAnnouncer] read, so the web summary
+ * can't drift from runtime behaviour.
+ */
+data class LotteryIncentivesView(
+    val bulkTiers: List<BulkBonusTierView>,
+    val multiplierTiers: List<MultiplierTierView>,
+    val poolMilestones: List<PoolMilestoneView>,
+) {
+    companion object {
+        fun empty(): LotteryIncentivesView =
+            LotteryIncentivesView(emptyList(), emptyList(), emptyList())
+    }
+}
+
+data class BulkBonusTierView(val buy: Long, val bonus: Long)
+data class MultiplierTierView(val total: Long, val bp: Int)
+data class PoolMilestoneView(val tickets: Long, val pct: Long)
 
 data class ModeratedMember(
     val id: String,

--- a/web/src/main/resources/static/css/moderation.css
+++ b/web/src/main/resources/static/css/moderation.css
@@ -224,6 +224,19 @@ details.config-section.is-hidden { display: none; }
 .config-section .config-grid {
     padding: 0 var(--space-4) var(--space-4);
 }
+/* Sub-headings inside a .config-section that hosts more than one
+   sub-grid (e.g. the lottery incentives section with three tier
+   groups). Keeps the section visually grouped while letting each
+   sub-grid breathe vertically. */
+.config-section .config-subhead {
+    margin: var(--space-4) var(--space-4) var(--space-2);
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: var(--text);
+}
+.config-section .config-subhead + p.muted {
+    margin: 0 var(--space-4) var(--space-2);
+}
 .config-grid {
     display: grid;
     gap: var(--space-3);

--- a/web/src/main/resources/templates/moderation/lottery.html
+++ b/web/src/main/resources/templates/moderation/lottery.html
@@ -222,6 +222,238 @@
                 </div>
             </details>
 
+            <details class="config-section" open>
+                <summary>Participation incentives (TICKET_WEIGHTED only)</summary>
+                <p class="muted mb-2">
+                    Rewards for buying more tickets, so a single-ticket entry isn't
+                    optimal play. Only affect TICKET_WEIGHTED lotteries — the
+                    NUMBER_MATCH daily already caps users at one ticket per draw.
+                    Set any threshold to <strong>0</strong> to disable that tier.
+                </p>
+
+                <h4 class="config-subhead">Bulk bonus tickets</h4>
+                <p class="muted mb-2" th:if="${overview.lotteryIncentives.bulkTiers.isEmpty()}">
+                    <em>No bulk bonus tiers active.</em> Configure at least one tier
+                    below to start awarding free tickets for committed buys.
+                </p>
+                <p class="muted mb-2" th:if="${!overview.lotteryIncentives.bulkTiers.isEmpty()}">
+                    <strong>Active:</strong>
+                    <span th:each="t, iter : ${overview.lotteryIncentives.bulkTiers}"
+                          th:text="|buy &ge; ${t.buy} → +${t.bonus} free${iter.last ? '' : ' · '}|"></span>
+                </p>
+                <div class="config-grid">
+                    <div class="config-row" data-key="LOTTERY_BULK_TIER1_BUY">
+                        <label>
+                            Tier 1 — buy at least
+                            <span class="config-hint">
+                                Threshold ticket count in a single /lottery buy. 0 disables.
+                            </span>
+                        </label>
+                        <input type="number" min="0" max="100000"
+                               th:value="${overview.config['LOTTERY_BULK_TIER1_BUY']}"
+                               placeholder="0"
+                               th:disabled="${!isOwner}">
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
+                    <div class="config-row" data-key="LOTTERY_BULK_TIER1_BONUS">
+                        <label>
+                            Tier 1 — bonus tickets
+                            <span class="config-hint">Free tickets awarded when tier 1 fires.</span>
+                        </label>
+                        <input type="number" min="0" max="100000"
+                               th:value="${overview.config['LOTTERY_BULK_TIER1_BONUS']}"
+                               placeholder="0"
+                               th:disabled="${!isOwner}">
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
+                    <div class="config-row" data-key="LOTTERY_BULK_TIER2_BUY">
+                        <label>Tier 2 — buy at least</label>
+                        <input type="number" min="0" max="100000"
+                               th:value="${overview.config['LOTTERY_BULK_TIER2_BUY']}"
+                               placeholder="0"
+                               th:disabled="${!isOwner}">
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
+                    <div class="config-row" data-key="LOTTERY_BULK_TIER2_BONUS">
+                        <label>Tier 2 — bonus tickets</label>
+                        <input type="number" min="0" max="100000"
+                               th:value="${overview.config['LOTTERY_BULK_TIER2_BONUS']}"
+                               placeholder="0"
+                               th:disabled="${!isOwner}">
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
+                    <div class="config-row" data-key="LOTTERY_BULK_TIER3_BUY">
+                        <label>Tier 3 — buy at least</label>
+                        <input type="number" min="0" max="100000"
+                               th:value="${overview.config['LOTTERY_BULK_TIER3_BUY']}"
+                               placeholder="0"
+                               th:disabled="${!isOwner}">
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
+                    <div class="config-row" data-key="LOTTERY_BULK_TIER3_BONUS">
+                        <label>Tier 3 — bonus tickets</label>
+                        <input type="number" min="0" max="100000"
+                               th:value="${overview.config['LOTTERY_BULK_TIER3_BONUS']}"
+                               placeholder="0"
+                               th:disabled="${!isOwner}">
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
+                </div>
+
+                <h4 class="config-subhead">Volume weight multiplier</h4>
+                <p class="muted mb-2" th:if="${overview.lotteryIncentives.multiplierTiers.isEmpty()}">
+                    <em>No multiplier tiers active.</em> Configure thresholds below
+                    so big-volume buyers' tickets count for more in the draw.
+                </p>
+                <p class="muted mb-2" th:if="${!overview.lotteryIncentives.multiplierTiers.isEmpty()}">
+                    <strong>Active:</strong>
+                    <span th:each="t, iter : ${overview.lotteryIncentives.multiplierTiers}"
+                          th:text="|hold &ge; ${t.total} → ${#numbers.formatDecimal(t.bp / 10000.0, 1, 2)}×${iter.last ? '' : ' · '}|"></span>
+                </p>
+                <div class="config-grid">
+                    <div class="config-row" data-key="LOTTERY_MULT_TIER1_TOTAL">
+                        <label>
+                            Tier 1 — total tickets held
+                            <span class="config-hint">
+                                When a buyer's total ticket count reaches this number,
+                                every one of their tickets counts for the multiplier below.
+                                0 disables.
+                            </span>
+                        </label>
+                        <input type="number" min="0" max="100000"
+                               th:value="${overview.config['LOTTERY_MULT_TIER1_TOTAL']}"
+                               placeholder="0"
+                               th:disabled="${!isOwner}">
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
+                    <div class="config-row" data-key="LOTTERY_MULT_TIER1_BP">
+                        <label>
+                            Tier 1 — multiplier (basis points)
+                            <span class="config-hint">
+                                10000 = 1× (no boost), 12500 = 1.25×, 15000 = 1.5×, max 50000 = 5×.
+                            </span>
+                        </label>
+                        <input type="number" min="0" max="50000" step="500"
+                               th:value="${overview.config['LOTTERY_MULT_TIER1_BP']}"
+                               placeholder="10000"
+                               th:disabled="${!isOwner}">
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
+                    <div class="config-row" data-key="LOTTERY_MULT_TIER2_TOTAL">
+                        <label>Tier 2 — total tickets held</label>
+                        <input type="number" min="0" max="100000"
+                               th:value="${overview.config['LOTTERY_MULT_TIER2_TOTAL']}"
+                               placeholder="0"
+                               th:disabled="${!isOwner}">
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
+                    <div class="config-row" data-key="LOTTERY_MULT_TIER2_BP">
+                        <label>Tier 2 — multiplier (basis points)</label>
+                        <input type="number" min="0" max="50000" step="500"
+                               th:value="${overview.config['LOTTERY_MULT_TIER2_BP']}"
+                               placeholder="10000"
+                               th:disabled="${!isOwner}">
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
+                    <div class="config-row" data-key="LOTTERY_MULT_TIER3_TOTAL">
+                        <label>Tier 3 — total tickets held</label>
+                        <input type="number" min="0" max="100000"
+                               th:value="${overview.config['LOTTERY_MULT_TIER3_TOTAL']}"
+                               placeholder="0"
+                               th:disabled="${!isOwner}">
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
+                    <div class="config-row" data-key="LOTTERY_MULT_TIER3_BP">
+                        <label>Tier 3 — multiplier (basis points)</label>
+                        <input type="number" min="0" max="50000" step="500"
+                               th:value="${overview.config['LOTTERY_MULT_TIER3_BP']}"
+                               placeholder="10000"
+                               th:disabled="${!isOwner}">
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
+                </div>
+
+                <h4 class="config-subhead">Pool-growth milestones</h4>
+                <p class="muted mb-2" th:if="${overview.lotteryIncentives.poolMilestones.isEmpty()}">
+                    <em>No milestones active.</em> Configure thresholds below so the
+                    jackpot tops up the prize pool when collective participation hits each mark.
+                </p>
+                <p class="muted mb-2" th:if="${!overview.lotteryIncentives.poolMilestones.isEmpty()}">
+                    <strong>Active:</strong>
+                    <span th:each="t, iter : ${overview.lotteryIncentives.poolMilestones}"
+                          th:text="|@${t.tickets} tickets → +${t.pct}% of jackpot${iter.last ? '' : ' · '}|"></span>
+                </p>
+                <div class="config-grid">
+                    <div class="config-row" data-key="LOTTERY_MILESTONE1_TICKETS">
+                        <label>
+                            Tier 1 — guild-wide tickets sold
+                            <span class="config-hint">
+                                When total tickets bought this lottery first crosses this
+                                count, the jackpot tops up the prize pool by the % below.
+                                0 disables.
+                            </span>
+                        </label>
+                        <input type="number" min="0" max="100000"
+                               th:value="${overview.config['LOTTERY_MILESTONE1_TICKETS']}"
+                               placeholder="0"
+                               th:disabled="${!isOwner}">
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
+                    <div class="config-row" data-key="LOTTERY_MILESTONE1_PCT">
+                        <label>
+                            Tier 1 — % of jackpot
+                            <span class="config-hint">Max 50% per milestone.</span>
+                        </label>
+                        <span class="config-input-group">
+                            <input type="number" min="0" max="50"
+                                   th:value="${overview.config['LOTTERY_MILESTONE1_PCT']}"
+                                   placeholder="0"
+                                   th:disabled="${!isOwner}">
+                            <span class="config-suffix">%</span>
+                        </span>
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
+                    <div class="config-row" data-key="LOTTERY_MILESTONE2_TICKETS">
+                        <label>Tier 2 — guild-wide tickets sold</label>
+                        <input type="number" min="0" max="100000"
+                               th:value="${overview.config['LOTTERY_MILESTONE2_TICKETS']}"
+                               placeholder="0"
+                               th:disabled="${!isOwner}">
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
+                    <div class="config-row" data-key="LOTTERY_MILESTONE2_PCT">
+                        <label>Tier 2 — % of jackpot</label>
+                        <span class="config-input-group">
+                            <input type="number" min="0" max="50"
+                                   th:value="${overview.config['LOTTERY_MILESTONE2_PCT']}"
+                                   placeholder="0"
+                                   th:disabled="${!isOwner}">
+                            <span class="config-suffix">%</span>
+                        </span>
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
+                    <div class="config-row" data-key="LOTTERY_MILESTONE3_TICKETS">
+                        <label>Tier 3 — guild-wide tickets sold</label>
+                        <input type="number" min="0" max="100000"
+                               th:value="${overview.config['LOTTERY_MILESTONE3_TICKETS']}"
+                               placeholder="0"
+                               th:disabled="${!isOwner}">
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
+                    <div class="config-row" data-key="LOTTERY_MILESTONE3_PCT">
+                        <label>Tier 3 — % of jackpot</label>
+                        <span class="config-input-group">
+                            <input type="number" min="0" max="50"
+                                   th:value="${overview.config['LOTTERY_MILESTONE3_PCT']}"
+                                   placeholder="0"
+                                   th:disabled="${!isOwner}">
+                            <span class="config-suffix">%</span>
+                        </span>
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
+                </div>
+            </details>
+
             <div class="lottery-admin-actions">
                 <div class="lottery-admin-actions-text">
                     <strong>Force draw now</strong>

--- a/web/src/test/kotlin/web/service/ModerationWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/ModerationWebServiceTest.kt
@@ -1945,6 +1945,103 @@ class ModerationWebServiceTest {
         verify(exactly = 1) { titleService.updateRequiredLevel(7L, 5) }
     }
 
+    // ---- lottery participation incentives ----
+
+    @Test
+    fun `updateConfig accepts a valid bulk-buy threshold and bonus`() {
+        mockMember(ownerId, isOwner = true)
+        assertNull(service.updateConfig(ownerId, guildId, ConfigDto.Configurations.LOTTERY_BULK_TIER1_BUY, "10"))
+        assertNull(service.updateConfig(ownerId, guildId, ConfigDto.Configurations.LOTTERY_BULK_TIER1_BONUS, "3"))
+        verify { configService.upsertConfig("LOTTERY_BULK_TIER1_BUY", "10", guildId.toString()) }
+        verify { configService.upsertConfig("LOTTERY_BULK_TIER1_BONUS", "3", guildId.toString()) }
+    }
+
+    @Test
+    fun `updateConfig accepts 0 on bulk-buy threshold as 'tier disabled'`() {
+        mockMember(ownerId, isOwner = true)
+        assertNull(service.updateConfig(ownerId, guildId, ConfigDto.Configurations.LOTTERY_BULK_TIER2_BUY, "0"))
+    }
+
+    @Test
+    fun `updateConfig rejects negative or non-numeric bulk-buy values`() {
+        mockMember(ownerId, isOwner = true)
+        assertNotNull(
+            service.updateConfig(ownerId, guildId, ConfigDto.Configurations.LOTTERY_BULK_TIER1_BUY, "-1")
+        )
+        assertNotNull(
+            service.updateConfig(ownerId, guildId, ConfigDto.Configurations.LOTTERY_BULK_TIER1_BUY, "wibble")
+        )
+        verify(exactly = 0) {
+            configService.upsertConfig("LOTTERY_BULK_TIER1_BUY", any(), any())
+        }
+    }
+
+    @Test
+    fun `updateConfig clamps multiplier BP to the 10000 to 50000 range`() {
+        mockMember(ownerId, isOwner = true)
+        val key = ConfigDto.Configurations.LOTTERY_MULT_TIER1_BP
+
+        // 0 is the special unset sentinel — accepted, helper coerces upward at read time.
+        assertNull(service.updateConfig(ownerId, guildId, key, "0"))
+        assertNull(service.updateConfig(ownerId, guildId, key, "10000"))
+        assertNull(service.updateConfig(ownerId, guildId, key, "12500"))
+        assertNull(service.updateConfig(ownerId, guildId, key, "50000"))
+        // Outside the range — rejected.
+        assertNotNull(service.updateConfig(ownerId, guildId, key, "9999"))
+        assertNotNull(service.updateConfig(ownerId, guildId, key, "50001"))
+        assertNotNull(service.updateConfig(ownerId, guildId, key, "abc"))
+    }
+
+    @Test
+    fun `updateConfig rejects milestone PCT above 50`() {
+        mockMember(ownerId, isOwner = true)
+        val key = ConfigDto.Configurations.LOTTERY_MILESTONE1_PCT
+
+        assertNull(service.updateConfig(ownerId, guildId, key, "0"))
+        assertNull(service.updateConfig(ownerId, guildId, key, "10"))
+        assertNull(service.updateConfig(ownerId, guildId, key, "50"))
+        assertNotNull(service.updateConfig(ownerId, guildId, key, "51"))
+        assertNotNull(service.updateConfig(ownerId, guildId, key, "-1"))
+    }
+
+    @Test
+    fun `getGuildOverview surfaces only the active incentive tiers`() {
+        mockMember(ownerId, isOwner = true)
+        every { guild.ownerIdLong } returns ownerId
+        every { guild.members } returns emptyList()
+        every { guild.voiceChannels } returns emptyList()
+        every { guild.textChannels } returns emptyList()
+        every { guild.categories } returns emptyList()
+        every { userService.listGuildUsers(guildId) } returns emptyList()
+
+        // Tier 1 active, tier 2 left unset, tier 3 explicitly zero
+        // (should be treated as disabled). Same shape for each lever.
+        every {
+            configService.getConfigByName(
+                ConfigDto.Configurations.LOTTERY_BULK_TIER1_BUY.configValue, guildId.toString()
+            )
+        } returns ConfigDto("LOTTERY_BULK_TIER1_BUY", "10", guildId.toString())
+        every {
+            configService.getConfigByName(
+                ConfigDto.Configurations.LOTTERY_BULK_TIER1_BONUS.configValue, guildId.toString()
+            )
+        } returns ConfigDto("LOTTERY_BULK_TIER1_BONUS", "3", guildId.toString())
+        every {
+            configService.getConfigByName(
+                ConfigDto.Configurations.LOTTERY_BULK_TIER3_BUY.configValue, guildId.toString()
+            )
+        } returns ConfigDto("LOTTERY_BULK_TIER3_BUY", "0", guildId.toString())
+
+        val overview = service.getGuildOverview(guildId)
+        assertNotNull(overview)
+        val incentives = overview!!.lotteryIncentives
+        assertEquals(1, incentives.bulkTiers.size, "only tier 1 is active")
+        assertEquals(10L, incentives.bulkTiers.first().buy)
+        assertEquals(3L, incentives.bulkTiers.first().bonus)
+        assertTrue(incentives.multiplierTiers.isEmpty())
+        assertTrue(incentives.poolMilestones.isEmpty())
+    }
+
     @Test
     fun `getLevelingOverview surfaces missing-role flag for dangling rewards`() {
         every { levelRoleRewardService.listForGuild(guildId) } returns listOf(

--- a/web/src/test/kotlin/web/template/ModerationTemplateRowsTest.kt
+++ b/web/src/test/kotlin/web/template/ModerationTemplateRowsTest.kt
@@ -308,6 +308,101 @@ class ModerationTemplateRowsTest {
         )
     }
 
+    @Test
+    fun `lottery template surfaces every participation incentive tier as an editable row`() {
+        // Same regression class as the blackjack / poker / jackpot
+        // groups above: the 18 incentive keys (3 tiers × 2 fields ×
+        // 3 levers) were added to ConfigDto.Configurations to drive
+        // the new "Participation incentives" UI, and the moderation
+        // page must carry a `<input>` row for each so admins can edit
+        // them. The bidirectional guard below picks up missing rows
+        // too, but this presence check pins the wiring per-key with a
+        // clearer failure message.
+        val keys = listOf(
+            ConfigDto.Configurations.LOTTERY_BULK_TIER1_BUY,
+            ConfigDto.Configurations.LOTTERY_BULK_TIER1_BONUS,
+            ConfigDto.Configurations.LOTTERY_BULK_TIER2_BUY,
+            ConfigDto.Configurations.LOTTERY_BULK_TIER2_BONUS,
+            ConfigDto.Configurations.LOTTERY_BULK_TIER3_BUY,
+            ConfigDto.Configurations.LOTTERY_BULK_TIER3_BONUS,
+            ConfigDto.Configurations.LOTTERY_MULT_TIER1_TOTAL,
+            ConfigDto.Configurations.LOTTERY_MULT_TIER1_BP,
+            ConfigDto.Configurations.LOTTERY_MULT_TIER2_TOTAL,
+            ConfigDto.Configurations.LOTTERY_MULT_TIER2_BP,
+            ConfigDto.Configurations.LOTTERY_MULT_TIER3_TOTAL,
+            ConfigDto.Configurations.LOTTERY_MULT_TIER3_BP,
+            ConfigDto.Configurations.LOTTERY_MILESTONE1_TICKETS,
+            ConfigDto.Configurations.LOTTERY_MILESTONE1_PCT,
+            ConfigDto.Configurations.LOTTERY_MILESTONE2_TICKETS,
+            ConfigDto.Configurations.LOTTERY_MILESTONE2_PCT,
+            ConfigDto.Configurations.LOTTERY_MILESTONE3_TICKETS,
+            ConfigDto.Configurations.LOTTERY_MILESTONE3_PCT,
+        )
+        for (key in keys) {
+            assertTrue(
+                lotteryHtml.contains("data-key=\"${key.name}\""),
+                "lottery.html should have a config-row for ${key.name} in the Participation incentives section"
+            )
+        }
+    }
+
+    @Test
+    fun `lottery template has a participation incentives details block carrying all three levers`() {
+        // The new section sits inside its own collapsible block so
+        // admins can scan past it when tuning the daily prize
+        // parameters. The block's headings group the tiers by lever
+        // (bulk / multiplier / milestone) — losing any of them would
+        // flatten the section back to a wall of identical-looking
+        // numeric inputs.
+        val sectionStart = lotteryHtml.indexOf("<summary>Participation incentives")
+        assertTrue(sectionStart >= 0, "expected a Participation incentives section header")
+        val sectionEnd = lotteryHtml.indexOf("</details>", sectionStart)
+        assertTrue(sectionEnd > sectionStart, "Participation incentives section not terminated")
+        val sectionHtml = lotteryHtml.substring(sectionStart, sectionEnd)
+        for (heading in listOf(
+            "Bulk bonus tickets",
+            "Volume weight multiplier",
+            "Pool-growth milestones",
+        )) {
+            assertTrue(
+                sectionHtml.contains(heading),
+                "expected '$heading' subhead inside the Participation incentives section",
+            )
+        }
+        // All 18 tier inputs must live inside this section (not
+        // scattered across the page).
+        for (key in listOf(
+            "LOTTERY_BULK_TIER1_BUY",
+            "LOTTERY_MULT_TIER1_BP",
+            "LOTTERY_MILESTONE1_PCT",
+        )) {
+            assertTrue(
+                sectionHtml.contains("data-key=\"$key\""),
+                "$key should live inside the Participation incentives section",
+            )
+        }
+    }
+
+    @Test
+    fun `lottery template renders active rules summary backed by overview lotteryIncentives`() {
+        // The "Active rules" lines (one per lever) read the resolved
+        // tier projection off `overview.lotteryIncentives`. If the
+        // backing field is renamed or removed, every active-rules
+        // expression in the template fails at page render. Pin the
+        // three Thymeleaf expressions so a backend rename forces a
+        // matching template update.
+        for (expr in listOf(
+            "overview.lotteryIncentives.bulkTiers",
+            "overview.lotteryIncentives.multiplierTiers",
+            "overview.lotteryIncentives.poolMilestones",
+        )) {
+            assertTrue(
+                lotteryHtml.contains(expr),
+                "lottery.html should reference $expr to render the Active rules summary",
+            )
+        }
+    }
+
     /**
      * Bidirectional guard: every [ConfigDto.Configurations] enum case
      * (minus an explicit allowlist of internal keys) must appear as a


### PR DESCRIPTION
## Summary

Some users had figured out that buying a single TICKET_WEIGHTED lottery ticket was enough to satisfy `LOTTERY_DAILY_MIN_BUYERS` and be entered — making one-ticket entries the optimal play. Rather than punishing that (e.g. raising minimums), this PR adds three additive, positive incentives that make committing more attractive than splitting. Existing `LOTTERY_DAILY_MIN_BUYERS` safeguard is untouched. All three levers are default-off so nothing changes for existing guilds until an admin configures tiers.

### The three levers (TICKET_WEIGHTED only — NUMBER_MATCH caps users at one ticket per draw already)

1. **Bulk bonus tickets** — buying ≥ N in a single `/lottery buy N` call grants free bonus tickets. Splitting earns nothing.
2. **Volume weight multiplier** — once a buyer's total tickets reach a threshold, every paid ticket counts for bp/10000× (clamped 1× to 5×).
3. **Pool-growth milestones** — when guild-wide ticket count first crosses a threshold, the jackpot tops up the lottery pool by a configured % (clamped to 50%). Tracked on the lottery row so milestones never re-fire.

### Where it shows up — both surfaces always reflect the same active state

- **Web moderation page** (`/moderation/{id}/lottery`) — new "Participation incentives" section. Each tier is a discrete numeric field with its own Save button. Above each subgroup, an "Active rules" summary lists exactly the tiers that are enabled; unset/zero tiers render as inactive.
- **Discord announce embed** — TICKET_WEIGHTED open embeds carry an "Active incentives" field; renders `None` when nothing is configured (never an empty field). Result embeds add a "Bonus impact" line when bonuses or milestones fired.
- **`/lottery status`** — appends an active-incentives block with the user's next bulk/multiplier/milestone threshold.

All three surfaces read through the same `LotteryHelper` getters so they can't drift.

## Test plan

- [x] `:database:test` — full suite passes, including 12 new `JackpotLotteryServiceTest` cases (anti-split-buy assertion, multiplier weighting with seeded RNG, milestone firing/refire-skip/empty-jackpot, gate-still-fires-with-bonuses) and a new `LotteryHelperTest` pinning the parse/clamp/match maths.
- [x] `:web:test` — full suite passes, including new `ModerationWebServiceTest` cases covering 0-disables, range rejection, BP clamping, milestone cap, and the "active tiers only" overview projection.
- [ ] `:discord-bot:test` — could not run in this sandbox (external Maven hosts for `lavasrc` / `libdave` blocked); new `LotteryAnnouncerTest` cases for `Active incentives` field rendering and `Bonus impact` line in result embeds are written and shaped to compile (existing instantiations of `WeightedDrawn` use defaults for the two added fields).
- [ ] Manual on dev guild: configure tiers in the web UI, run `/jackpotadmin lottery_open`, buy from two test accounts with mixed counts, verify the embed and `/lottery status` match the web "Active rules" summary, draw and verify the result embed reports bonus impact.

## Migration

- `V40__lottery_bonus_incentives.sql` adds `bonus_tickets` (ticket row) and `milestones_fired` (lottery row). Both default to 0 — no data backfill needed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Mib78RPKH1yRW234Zwugjs)_