### PR TITLE
fix(push): drop broken icon asset from sw.js so macOS Firefox renders

### DIFF
--- a/web/src/main/resources/static/sw.js
+++ b/web/src/main/resources/static/sw.js
@@ -20,8 +20,12 @@ self.addEventListener('push', function (event) {
     }
     const options = {
         body: data.body || '',
-        icon: '/images/toby-icon.png',
-        badge: '/images/toby-icon.png',
+        // No icon / badge: the asset they used to point at
+        // (/images/toby-icon.png) doesn't exist, and macOS Firefox
+        // routes showNotification through the system NotificationCenter,
+        // which silently rejects the call when an icon URL 404s
+        // instead of falling back to a default. Omitting the fields
+        // lets every browser substitute its own default app glyph.
         data: { deepLink: data.deepLink || '/' }
     };
     event.waitUntil(self.registration.showNotification(data.title || 'TobyBot', options));


### PR DESCRIPTION
## Summary

macOS Firefox test push from `/api/push/test` showed the full happy path server-side:

```
WebPushAdapter: delivering to 2 endpoint(s) for 313049624636162059.
WebPushAdapter: HTTP 201 from .../wpush/v2/gAAAAABqDCEy…; marking used.
WebPushAdapter: HTTP 201 from .../wpush/v2/gAAAAABqDFP2…; marking used.
POST /api/push/test … status=200
```

…but no banner ever rendered on the laptop. The next log line is the smoking gun:

```
GET /images/toby-icon.png … status=404
```

`sw.js` sets the notification's `icon` and `badge` to `/images/toby-icon.png` — an asset that has never existed in `web/src/main/resources/static/images/` (only `favicon.svg` and `preview.svg` are there). On macOS, Firefox routes `showNotification` through the system NotificationCenter, which silently rejects the show call when an icon URL 404s instead of falling back to a default. Chrome and non-macOS Firefox gracefully degrade, which is why server-side "delivered" looked fine end-to-end.

Two lines removed from the `push` handler; every browser now substitutes its own default app glyph. When a real `toby-icon.png` ships, the lines can be restored pointing at it.

## Test plan

- [ ] Deploy, then on the macOS Firefox work laptop visit `/preferences/notifications` and hard-refresh (⌘⇧R) or DevTools → Application → Service Workers → "Update" so the new sw.js activates (our worker doesn't `skipWaiting`).
- [ ] Click **Send test push** — system banner reading "Test notification — If you see this, web push is working ✓" appears in NotificationCenter.
- [ ] If still no banner: check macOS System Settings → Notifications → Firefox is set to "Allow Notifications" (OS-level permission, separate from per-site).

## Backout

Restore the two removed lines in `sw.js` and redeploy. Notifications go back to silently dropping on macOS Firefox; no other regression, no data/env to undo.

---
_Generated by [Claude Code](https://claude.ai/code/session_019zeNrW3Q2aA9ahsRz5Xg58)_