### PR TITLE
feat(lottery): surface incentives on the player page + polish moderation pages

### DIFF
--- a/web/src/main/kotlin/web/controller/LotteryController.kt
+++ b/web/src/main/kotlin/web/controller/LotteryController.kt
@@ -3,6 +3,7 @@ package web.controller
 import database.dto.JackpotLotteryDto
 import database.service.JackpotLotteryService.BuyMatchOutcome
 import database.service.JackpotLotteryService.BuyOutcome
+import database.service.LotteryHelper
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.security.oauth2.core.user.OAuth2User
@@ -216,8 +217,53 @@ data class LotteryViewModel(
         val closesAtMillis: Long,
         val totalTickets: Long,
         val myTickets: Int,
+        val myBonusTickets: Long,
         val mySpent: Long,
         val topHolders: List<TopHolder>,
+        /**
+         * Resolved participation-incentive surface for the open
+         * weighted lottery: active rules + personalised next-threshold
+         * hints + next-to-fire milestone progress. Null when no
+         * incentives are configured — the player template hides the
+         * whole panel in that case.
+         */
+        val incentives: WeightedIncentivesPanel?,
+    )
+
+    /**
+     * What the player sees in the "Participation incentives" panel on
+     * the lottery page. Only carries data that has something to render:
+     * `nextBulkHint` / `nextMultiplierHint` are null when the viewer
+     * already holds the top tier (no further "buy N more" to dangle),
+     * and `milestoneProgress` is null when no future milestone is
+     * configured (the panel just shows active rules in that case).
+     */
+    data class WeightedIncentivesPanel(
+        val bulkTiers: List<web.view.BulkBonusTierView>,
+        val multiplierTiers: List<web.view.MultiplierTierView>,
+        val poolMilestones: List<web.view.PoolMilestoneView>,
+        val nextBulkHint: NextBulkHint?,
+        val nextMultiplierHint: NextMultiplierHint?,
+        val milestoneProgress: MilestoneProgress?,
+    )
+
+    /** Smallest unmatched bulk tier — "buy [gap] more in one purchase for +[bonus] free". */
+    data class NextBulkHint(val gap: Long, val bonus: Long, val threshold: Long)
+
+    /** Smallest unmatched multiplier tier, with the bp pre-formatted to a human "1.25×" decimal. */
+    data class NextMultiplierHint(val gap: Long, val multiplier: String, val threshold: Long)
+
+    /**
+     * The next-to-fire pool milestone, plus current vs threshold ticket
+     * counts so the template can render a `<progress>` bar. Already
+     * filtered by `milestonesFired`: only shows milestones strictly
+     * greater than the highest fired, so a re-render after a milestone
+     * pops never shows the just-fired one as "still ahead".
+     */
+    data class MilestoneProgress(
+        val currentTickets: Long,
+        val thresholdTickets: Long,
+        val pct: Long,
     )
 
     /** View projection of a weighted-lottery top holder — Discord
@@ -254,6 +300,9 @@ data class LotteryViewModel(
                 )
             }
             val weighted = snap.weightedOpen?.let { row ->
+                val myTickets = (snap.weightedMyTicket?.ticketCount ?: 0).toLong()
+                val myBonus = snap.weightedMyTicket?.bonusTickets ?: 0L
+                val incentives = buildIncentivesPanel(snap, row, myTickets)
                 WeightedView(
                     pool = row.poolAmount,
                     ticketPrice = row.ticketPrice,
@@ -262,10 +311,12 @@ data class LotteryViewModel(
                     closesAtMillis = row.closesAt.toEpochMilli(),
                     totalTickets = snap.weightedTotalTickets,
                     myTickets = snap.weightedMyTicket?.ticketCount ?: 0,
+                    myBonusTickets = myBonus,
                     mySpent = snap.weightedMyTicket?.spent ?: 0L,
                     topHolders = snap.weightedTopHolders.map {
                         TopHolder(it.discordId, it.ticketCount, it.name, it.avatarUrl, it.title)
                     },
+                    incentives = incentives,
                 )
             }
             return LotteryViewModel(
@@ -284,6 +335,72 @@ data class LotteryViewModel(
         private fun parseCsv(csv: String?): List<Int> {
             if (csv.isNullOrBlank()) return emptyList()
             return csv.split(',').mapNotNull { it.trim().toIntOrNull() }
+        }
+
+        /**
+         * Build the incentives panel for the viewing player on the
+         * open weighted lottery. Returns null when no incentives are
+         * configured — the template hides the whole panel rather than
+         * render an empty card.
+         *
+         * Hint derivation:
+         *  - Next bulk tier: smallest `buy` threshold strictly greater
+         *    than the viewer's current ticket count. The hint copy
+         *    "buy [gap] more in one purchase" reflects the per-purchase
+         *    nature of the bulk bonus (splitting doesn't count).
+         *  - Next multiplier tier: smallest `total` threshold strictly
+         *    greater than the viewer's total. Multiplier rendered as
+         *    a 1.25× / 1.5× decimal so the template doesn't have to.
+         *  - Milestone progress: smallest milestone whose threshold is
+         *    strictly greater than both `milestonesFired` (so we don't
+         *    show one that has already paid out) and the current
+         *    guild-wide ticket count. Pre-filtered here so the
+         *    template can just check non-null.
+         */
+        private fun buildIncentivesPanel(
+            snap: LotteryWebService.LotteryPageSnapshot,
+            lottery: JackpotLotteryDto,
+            myTickets: Long,
+        ): WeightedIncentivesPanel? {
+            val incentives = snap.weightedIncentives
+            if (incentives.isEmpty) return null
+
+            val nextBulk = incentives.bulkTiers
+                .firstOrNull { it.buy > myTickets }
+                ?.let { tier ->
+                    NextBulkHint(
+                        gap = tier.buy - myTickets,
+                        bonus = tier.bonus,
+                        threshold = tier.buy,
+                    )
+                }
+            val nextMultiplier = incentives.multiplierTiers
+                .firstOrNull { it.total > myTickets }
+                ?.let { tier ->
+                    NextMultiplierHint(
+                        gap = tier.total - myTickets,
+                        multiplier = "%.2f×".format(tier.bp / LotteryHelper.MULTIPLIER_BP_IDENTITY.toDouble()),
+                        threshold = tier.total,
+                    )
+                }
+            val nextMilestone = incentives.poolMilestones
+                .firstOrNull { it.tickets > lottery.milestonesFired && it.tickets > snap.weightedTotalTickets }
+                ?.let { tier ->
+                    MilestoneProgress(
+                        currentTickets = snap.weightedTotalTickets,
+                        thresholdTickets = tier.tickets,
+                        pct = tier.pct,
+                    )
+                }
+
+            return WeightedIncentivesPanel(
+                bulkTiers = incentives.bulkTiers,
+                multiplierTiers = incentives.multiplierTiers,
+                poolMilestones = incentives.poolMilestones,
+                nextBulkHint = nextBulk,
+                nextMultiplierHint = nextMultiplier,
+                milestoneProgress = nextMilestone,
+            )
         }
     }
 }

--- a/web/src/main/kotlin/web/service/LotteryWebService.kt
+++ b/web/src/main/kotlin/web/service/LotteryWebService.kt
@@ -8,6 +8,10 @@ import database.service.LotteryHelper
 import database.service.TitleService
 import database.service.UserService
 import org.springframework.stereotype.Service
+import web.view.BulkBonusTierView
+import web.view.LotteryIncentivesView
+import web.view.MultiplierTierView
+import web.view.PoolMilestoneView
 
 /**
  * Thin orchestration layer around [JackpotLotteryService] for the web
@@ -52,6 +56,14 @@ class LotteryWebService(
         val revenueJackpotPct: Long,
         val dailyMode: String,
         val dailyEnabled: Boolean,
+        /**
+         * Active participation-incentive tiers for the open WEIGHTED
+         * lottery. Empty when no lottery is open, the lottery is
+         * NUMBER_MATCH-only, or no tiers are configured. Mirrors the
+         * moderation page's `lotteryIncentives` so both surfaces show
+         * the same rules verbatim.
+         */
+        val weightedIncentives: LotteryIncentivesView = LotteryIncentivesView.empty(),
     )
 
     /**
@@ -104,6 +116,20 @@ class LotteryWebService(
         }
         val weightedTotal = weightedTickets.sumOf { it.ticketCount.toLong() }
 
+        // Resolve incentives only when there's an open weighted lottery
+        // (they don't apply to NUMBER_MATCH, and an empty list when no
+        // tiers are configured means the panel won't render at all).
+        val incentives = if (weightedOpen != null) {
+            LotteryIncentivesView(
+                bulkTiers = LotteryHelper.bulkBonusTiers(configService, guildId)
+                    .map { (buy, bonus) -> BulkBonusTierView(buy = buy, bonus = bonus) },
+                multiplierTiers = LotteryHelper.volumeMultiplierTiers(configService, guildId)
+                    .map { (total, bp) -> MultiplierTierView(total = total, bp = bp) },
+                poolMilestones = LotteryHelper.poolMilestones(configService, guildId)
+                    .map { (tickets, pct) -> PoolMilestoneView(tickets = tickets, pct = pct) },
+            )
+        } else LotteryIncentivesView.empty()
+
         return LotteryPageSnapshot(
             dailyOpen = dailyOpen,
             dailyLatestDrawn = dailyLatest,
@@ -119,6 +145,7 @@ class LotteryWebService(
             revenueJackpotPct = LotteryHelper.dailyRevenueJackpotPct(configService, guildId),
             dailyMode = LotteryHelper.dailyMode(configService, guildId),
             dailyEnabled = LotteryHelper.dailyEnabled(configService, guildId),
+            weightedIncentives = incentives,
         )
     }
 

--- a/web/src/main/kotlin/web/service/ModerationWebService.kt
+++ b/web/src/main/kotlin/web/service/ModerationWebService.kt
@@ -21,6 +21,10 @@ import net.dv8tion.jda.api.entities.UserSnowflake
 import net.dv8tion.jda.api.entities.emoji.Emoji
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
+import web.view.BulkBonusTierView
+import web.view.LotteryIncentivesView
+import web.view.MultiplierTierView
+import web.view.PoolMilestoneView
 import java.time.Duration
 import java.time.Instant
 import java.time.LocalDate
@@ -1462,32 +1466,6 @@ data class GuildOverview(
     val config: Map<String, String?>,
     val lotteryIncentives: LotteryIncentivesView = LotteryIncentivesView.empty(),
 )
-
-/**
- * Resolved view of the participation-incentive config for the lottery
- * page. Each list contains only the tiers that are actually active
- * (threshold > 0) — the template uses `.size` and `.isEmpty()` to
- * render the "Active rules" summary, so unset/zero tiers vanish.
- *
- * Sourced from the same [database.service.LotteryHelper] getters that
- * [database.service.JackpotLotteryService.buyTickets] and
- * [bot.toby.scheduling.LotteryAnnouncer] read, so the web summary
- * can't drift from runtime behaviour.
- */
-data class LotteryIncentivesView(
-    val bulkTiers: List<BulkBonusTierView>,
-    val multiplierTiers: List<MultiplierTierView>,
-    val poolMilestones: List<PoolMilestoneView>,
-) {
-    companion object {
-        fun empty(): LotteryIncentivesView =
-            LotteryIncentivesView(emptyList(), emptyList(), emptyList())
-    }
-}
-
-data class BulkBonusTierView(val buy: Long, val bonus: Long)
-data class MultiplierTierView(val total: Long, val bp: Int)
-data class PoolMilestoneView(val tickets: Long, val pct: Long)
 
 data class ModeratedMember(
     val id: String,

--- a/web/src/main/kotlin/web/view/LotteryIncentivesView.kt
+++ b/web/src/main/kotlin/web/view/LotteryIncentivesView.kt
@@ -1,0 +1,27 @@
+package web.view
+
+/**
+ * Resolved view of the participation-incentive config used by both
+ * the moderation page (`overview.lotteryIncentives`) and the player
+ * lottery page (`snapshot.weighted.incentives`). Carrying only the
+ * active tiers — anything with a zero threshold is filtered out by
+ * `database.service.LotteryHelper` — so the surfaces never have to
+ * branch on "is this tier configured" themselves.
+ */
+data class LotteryIncentivesView(
+    val bulkTiers: List<BulkBonusTierView>,
+    val multiplierTiers: List<MultiplierTierView>,
+    val poolMilestones: List<PoolMilestoneView>,
+) {
+    val isEmpty: Boolean
+        get() = bulkTiers.isEmpty() && multiplierTiers.isEmpty() && poolMilestones.isEmpty()
+
+    companion object {
+        fun empty(): LotteryIncentivesView =
+            LotteryIncentivesView(emptyList(), emptyList(), emptyList())
+    }
+}
+
+data class BulkBonusTierView(val buy: Long, val bonus: Long)
+data class MultiplierTierView(val total: Long, val bp: Int)
+data class PoolMilestoneView(val tickets: Long, val pct: Long)

--- a/web/src/main/resources/static/css/lottery.css
+++ b/web/src/main/resources/static/css/lottery.css
@@ -303,6 +303,65 @@
     border-bottom-width: 2px;
 }
 
+/* Participation incentives panel — appears on the WEIGHTED lottery
+ * section (and the Featured event card) when at least one tier is
+ * configured. Three sub-blocks, one per lever, each with the active
+ * rules + an optional personalised hint. Visually separated from the
+ * top-holders list above with the same elevated-card treatment as
+ * other lottery surfaces. */
+.lottery-incentives {
+    margin-top: var(--space-4);
+    padding: var(--space-4);
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+}
+.lottery-incentives > h3 {
+    margin: 0 0 var(--space-3);
+    font-size: 1rem;
+    color: var(--text);
+}
+.lottery-incentive-block {
+    padding: var(--space-3) 0;
+    border-top: 1px solid var(--border);
+}
+.lottery-incentive-block:first-of-type { border-top: 0; padding-top: 0; }
+.lottery-incentive-block > h4 {
+    margin: 0 0 var(--space-2);
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: var(--text);
+}
+.lottery-incentive-rules {
+    margin: 0 0 var(--space-2);
+    padding-left: var(--space-4);
+    color: var(--text-muted);
+    font-size: 0.9rem;
+    line-height: 1.5;
+}
+.lottery-incentive-rules > li { margin-bottom: 2px; }
+.lottery-incentive-hint {
+    margin: var(--space-2) 0 0;
+    padding: var(--space-2) var(--space-3);
+    background: var(--bg);
+    border-left: 3px solid var(--accent);
+    border-radius: 4px;
+    color: var(--text);
+    font-size: 0.9rem;
+}
+.lottery-incentive-progress { margin-top: var(--space-2); }
+.lottery-incentive-progress label {
+    display: block;
+    margin-bottom: 4px;
+    color: var(--text-muted);
+    font-size: 0.85rem;
+}
+.lottery-incentive-progress progress {
+    width: 100%;
+    height: 12px;
+    accent-color: var(--accent);
+}
+
 @media (max-width: 480px) {
     .lottery-cells { grid-template-columns: repeat(7, minmax(0, 1fr)); }
     .lottery-cell { min-width: 30px; font-size: 0.9rem; }

--- a/web/src/main/resources/static/css/moderation.css
+++ b/web/src/main/resources/static/css/moderation.css
@@ -237,6 +237,62 @@ details.config-section.is-hidden { display: none; }
 .config-section .config-subhead + p.muted {
     margin: 0 var(--space-4) var(--space-2);
 }
+/* Section lead paragraph — the short explainer that sits between the
+   <summary> and the first config-grid. Pads to align with the grid
+   columns so a long paragraph doesn't crowd the section's left edge.
+   Used by sections that need a one-paragraph orientation before the
+   dials start. */
+.config-section .config-section-lead {
+    margin: 0 var(--space-4) var(--space-3);
+}
+/* Active rules summary — small "Active: ..." readout sitting above a
+   tier's config-grid. Same gutter as config-section-lead so the row
+   visually aligns with the surrounding section copy. */
+.config-section .config-active-rules {
+    margin: 0 var(--space-4) var(--space-2);
+}
+/* Nested section inside another .config-section (e.g. the three
+   levers inside Participation incentives). Slimmer summary + thin
+   top divider so the lever boundaries read as distinct without
+   visually competing with the outer accordion. */
+.config-section .config-section.nested {
+    margin: var(--space-3) var(--space-4) 0;
+    background: var(--bg);
+}
+.config-section .config-section.nested > summary {
+    padding: var(--space-2) var(--space-3);
+    font-size: 0.9rem;
+}
+/* Small inline pill, e.g. "TICKET_WEIGHTED only" badge sitting next
+   to a section summary. Uses --accent for a subtle tint that still
+   reads against the elevated card background. */
+.config-badge {
+    display: inline-block;
+    margin-left: var(--space-2);
+    padding: 0 var(--space-2);
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    color: var(--text-muted);
+    font-size: 0.7rem;
+    font-weight: 500;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    vertical-align: middle;
+}
+/* Callout box for warnings that need to stand out — e.g. the
+   "TobyBot's role must sit above…" guidance on leveling-role rewards.
+   Yellow-tinted to distinguish it from .config-hint without needing
+   a new colour token. */
+.config-warning {
+    margin: var(--space-2) var(--space-4) var(--space-3);
+    padding: var(--space-3);
+    background: rgba(241, 196, 15, 0.08);
+    border-left: 3px solid #f1c40f;
+    border-radius: 4px;
+    color: var(--text);
+    font-size: 0.9rem;
+}
 .config-grid {
     display: grid;
     gap: var(--space-3);

--- a/web/src/main/resources/templates/lottery.html
+++ b/web/src/main/resources/templates/lottery.html
@@ -215,6 +215,78 @@
             </div>
         </form>
 
+        <!-- Participation incentives — same source of truth as the
+             admin "Active rules" line. Only renders when at least one
+             tier is configured for this guild; empty config = no panel
+             (instead of an empty-card placeholder).
+             - Active rules:  the static "buy ≥N → +M free" lines.
+             - Next bonus:    personalised "buy gap more for +M free"
+                              hint per lever; hidden when the viewer
+                              already holds the top tier.
+             - Milestone bar: live "current / threshold tickets sold"
+                              progress for the next-to-fire milestone. -->
+        <section class="lottery-incentives"
+                 th:if="${snapshot.weighted != null and snapshot.weighted.incentives != null}"
+                 th:with="inc=${snapshot.weighted.incentives}"
+                 aria-label="Participation incentives">
+            <h3>Participation incentives</h3>
+
+            <div class="lottery-incentive-block"
+                 data-incentive="bulk"
+                 th:if="${!#lists.isEmpty(inc.bulkTiers)}">
+                <h4>🎁 Bulk bonus tickets</h4>
+                <ul class="lottery-incentive-rules">
+                    <li th:each="t : ${inc.bulkTiers}"
+                        th:text="|buy at least ${t.buy} in one purchase → +${t.bonus} free tickets|">
+                        buy at least 10 in one purchase → +3 free tickets
+                    </li>
+                </ul>
+                <p class="lottery-incentive-hint"
+                   th:if="${inc.nextBulkHint != null}"
+                   th:text="|Buy ${inc.nextBulkHint.gap} more in one purchase to earn +${inc.nextBulkHint.bonus} free tickets.|">
+                    Buy 6 more in one purchase to earn +3 free tickets.
+                </p>
+            </div>
+
+            <div class="lottery-incentive-block"
+                 data-incentive="multiplier"
+                 th:if="${!#lists.isEmpty(inc.multiplierTiers)}">
+                <h4>📈 Volume weight multiplier</h4>
+                <ul class="lottery-incentive-rules">
+                    <li th:each="t : ${inc.multiplierTiers}"
+                        th:text="|hold at least ${t.total} tickets → ${#numbers.formatDecimal(t.bp / 10000.0, 1, 2)}× draw weight|">
+                        hold at least 15 tickets → 1.50× draw weight
+                    </li>
+                </ul>
+                <p class="lottery-incentive-hint"
+                   th:if="${inc.nextMultiplierHint != null}"
+                   th:text="|Hold ${inc.nextMultiplierHint.gap} more to reach ${inc.nextMultiplierHint.multiplier} draw weight.|">
+                    Hold 6 more to reach 1.50× draw weight.
+                </p>
+            </div>
+
+            <div class="lottery-incentive-block"
+                 data-incentive="milestone"
+                 th:if="${!#lists.isEmpty(inc.poolMilestones)}">
+                <h4>🚀 Pool-growth milestones</h4>
+                <ul class="lottery-incentive-rules">
+                    <li th:each="t : ${inc.poolMilestones}"
+                        th:text="|${t.tickets} tickets sold guild-wide → +${t.pct}% of jackpot top-up|">
+                        50 tickets sold guild-wide → +10% of jackpot top-up
+                    </li>
+                </ul>
+                <div class="lottery-incentive-progress"
+                     th:if="${inc.milestoneProgress != null}">
+                    <label th:text="|Next milestone: ${inc.milestoneProgress.currentTickets} / ${inc.milestoneProgress.thresholdTickets} tickets sold → +${inc.milestoneProgress.pct}% jackpot top-up|">
+                        Next milestone: 42 / 50 tickets sold → +10% jackpot top-up
+                    </label>
+                    <progress th:value="${inc.milestoneProgress.currentTickets}"
+                              th:max="${inc.milestoneProgress.thresholdTickets}">
+                    </progress>
+                </div>
+            </div>
+        </section>
+
         <div class="lottery-weighted-holders"
              th:if="${snapshot.weighted != null and !#lists.isEmpty(snapshot.weighted.topHolders)}">
             <h3>Top holders</h3>
@@ -279,6 +351,60 @@
                 Buy <span class="muted">(at <strong th:text="${snapshot.weighted.ticketPrice}">100</strong>/ticket)</span>
             </button>
         </form>
+
+        <!-- Same incentives panel as the WEIGHTED-daily section
+             above, since featured admin-fired lotteries reuse the same
+             tiers and `snapshot.weighted.incentives` projection. -->
+        <section class="lottery-incentives"
+                 th:if="${snapshot.weighted.incentives != null}"
+                 th:with="inc=${snapshot.weighted.incentives}"
+                 aria-label="Participation incentives">
+            <h3>Participation incentives</h3>
+
+            <div class="lottery-incentive-block"
+                 data-incentive="bulk"
+                 th:if="${!#lists.isEmpty(inc.bulkTiers)}">
+                <h4>🎁 Bulk bonus tickets</h4>
+                <ul class="lottery-incentive-rules">
+                    <li th:each="t : ${inc.bulkTiers}"
+                        th:text="|buy at least ${t.buy} in one purchase → +${t.bonus} free tickets|"></li>
+                </ul>
+                <p class="lottery-incentive-hint"
+                   th:if="${inc.nextBulkHint != null}"
+                   th:text="|Buy ${inc.nextBulkHint.gap} more in one purchase to earn +${inc.nextBulkHint.bonus} free tickets.|"></p>
+            </div>
+
+            <div class="lottery-incentive-block"
+                 data-incentive="multiplier"
+                 th:if="${!#lists.isEmpty(inc.multiplierTiers)}">
+                <h4>📈 Volume weight multiplier</h4>
+                <ul class="lottery-incentive-rules">
+                    <li th:each="t : ${inc.multiplierTiers}"
+                        th:text="|hold at least ${t.total} tickets → ${#numbers.formatDecimal(t.bp / 10000.0, 1, 2)}× draw weight|"></li>
+                </ul>
+                <p class="lottery-incentive-hint"
+                   th:if="${inc.nextMultiplierHint != null}"
+                   th:text="|Hold ${inc.nextMultiplierHint.gap} more to reach ${inc.nextMultiplierHint.multiplier} draw weight.|"></p>
+            </div>
+
+            <div class="lottery-incentive-block"
+                 data-incentive="milestone"
+                 th:if="${!#lists.isEmpty(inc.poolMilestones)}">
+                <h4>🚀 Pool-growth milestones</h4>
+                <ul class="lottery-incentive-rules">
+                    <li th:each="t : ${inc.poolMilestones}"
+                        th:text="|${t.tickets} tickets sold guild-wide → +${t.pct}% of jackpot top-up|"></li>
+                </ul>
+                <div class="lottery-incentive-progress"
+                     th:if="${inc.milestoneProgress != null}">
+                    <label th:text="|Next milestone: ${inc.milestoneProgress.currentTickets} / ${inc.milestoneProgress.thresholdTickets} tickets sold → +${inc.milestoneProgress.pct}% jackpot top-up|"></label>
+                    <progress th:value="${inc.milestoneProgress.currentTickets}"
+                              th:max="${inc.milestoneProgress.thresholdTickets}">
+                    </progress>
+                </div>
+            </div>
+        </section>
+
         <div class="lottery-weighted-holders" th:if="${!#lists.isEmpty(snapshot.weighted.topHolders)}">
             <h3>Top holders</h3>
             <ol class="lottery-top-holders">

--- a/web/src/main/resources/templates/moderation/leveling.html
+++ b/web/src/main/resources/templates/moderation/leveling.html
@@ -37,9 +37,7 @@
                         <label>
                             Daily XP cap
                             <span class="config-hint">
-                                Per-user ceiling on XP earned in a UTC day across all
-                                sources (messages, commands, voice intros, voice
-                                sessions). Default 1000.
+                                Per-user ceiling on XP earned in a UTC day. Default 1000.
                             </span>
                         </label>
                         <input type="number" min="0" max="100000"
@@ -143,11 +141,15 @@
 
             <details class="config-section" open>
                 <summary>Role rewards</summary>
-                <p class="muted mb-3">
+                <p class="muted config-section-lead">
                     Bind a Discord role to a level threshold — TobyBot assigns it the
-                    moment the user crosses that level. Make sure TobyBot's role sits
-                    above any role you bind here, or the assign will fail at runtime.
+                    moment the user crosses that level.
                 </p>
+                <div class="config-warning">
+                    <strong>Heads up:</strong> TobyBot's role must sit
+                    <em>above</em> any role you bind here in your server's role list, or
+                    the assign will fail at runtime.
+                </div>
 
                 <div class="leveling-rewards" id="leveling-rewards-list">
                     <p class="muted" th:if="${#lists.isEmpty(leveling.levelRewards)}">

--- a/web/src/main/resources/templates/moderation/lottery.html
+++ b/web/src/main/resources/templates/moderation/lottery.html
@@ -223,20 +223,24 @@
             </details>
 
             <details class="config-section" open>
-                <summary>Participation incentives (TICKET_WEIGHTED only)</summary>
-                <p class="muted mb-2">
-                    Rewards for buying more tickets, so a single-ticket entry isn't
-                    optimal play. Only affect TICKET_WEIGHTED lotteries — the
-                    NUMBER_MATCH daily already caps users at one ticket per draw.
-                    Set any threshold to <strong>0</strong> to disable that tier.
+                <summary>
+                    Participation incentives
+                    <span class="config-badge">TICKET_WEIGHTED only</span>
+                </summary>
+                <p class="muted config-section-lead">
+                    Reward committed buyers so a single ticket isn't optimal play.
+                    NUMBER_MATCH already caps users at one ticket per draw, so these
+                    levers only fire on TICKET_WEIGHTED lotteries. Set any
+                    threshold to <strong>0</strong> to disable that tier.
                 </p>
 
-                <h4 class="config-subhead">Bulk bonus tickets</h4>
-                <p class="muted mb-2" th:if="${overview.lotteryIncentives.bulkTiers.isEmpty()}">
+                <details class="config-section nested" open>
+                    <summary>🎁 Bulk bonus tickets</summary>
+                <p class="muted config-active-rules" th:if="${overview.lotteryIncentives.bulkTiers.isEmpty()}">
                     <em>No bulk bonus tiers active.</em> Configure at least one tier
                     below to start awarding free tickets for committed buys.
                 </p>
-                <p class="muted mb-2" th:if="${!overview.lotteryIncentives.bulkTiers.isEmpty()}">
+                <p class="muted config-active-rules" th:if="${!overview.lotteryIncentives.bulkTiers.isEmpty()}">
                     <strong>Active:</strong>
                     <span th:each="t, iter : ${overview.lotteryIncentives.bulkTiers}"
                           th:text="|buy &ge; ${t.buy} → +${t.bonus} free${iter.last ? '' : ' · '}|"></span>
@@ -300,12 +304,15 @@
                     </div>
                 </div>
 
-                <h4 class="config-subhead">Volume weight multiplier</h4>
-                <p class="muted mb-2" th:if="${overview.lotteryIncentives.multiplierTiers.isEmpty()}">
+                </details>
+
+                <details class="config-section nested" open>
+                    <summary>📈 Volume weight multiplier</summary>
+                <p class="muted config-active-rules" th:if="${overview.lotteryIncentives.multiplierTiers.isEmpty()}">
                     <em>No multiplier tiers active.</em> Configure thresholds below
                     so big-volume buyers' tickets count for more in the draw.
                 </p>
-                <p class="muted mb-2" th:if="${!overview.lotteryIncentives.multiplierTiers.isEmpty()}">
+                <p class="muted config-active-rules" th:if="${!overview.lotteryIncentives.multiplierTiers.isEmpty()}">
                     <strong>Active:</strong>
                     <span th:each="t, iter : ${overview.lotteryIncentives.multiplierTiers}"
                           th:text="|hold &ge; ${t.total} → ${#numbers.formatDecimal(t.bp / 10000.0, 1, 2)}×${iter.last ? '' : ' · '}|"></span>
@@ -373,12 +380,15 @@
                     </div>
                 </div>
 
-                <h4 class="config-subhead">Pool-growth milestones</h4>
-                <p class="muted mb-2" th:if="${overview.lotteryIncentives.poolMilestones.isEmpty()}">
+                </details>
+
+                <details class="config-section nested" open>
+                    <summary>🚀 Pool-growth milestones</summary>
+                <p class="muted config-active-rules" th:if="${overview.lotteryIncentives.poolMilestones.isEmpty()}">
                     <em>No milestones active.</em> Configure thresholds below so the
                     jackpot tops up the prize pool when collective participation hits each mark.
                 </p>
-                <p class="muted mb-2" th:if="${!overview.lotteryIncentives.poolMilestones.isEmpty()}">
+                <p class="muted config-active-rules" th:if="${!overview.lotteryIncentives.poolMilestones.isEmpty()}">
                     <strong>Active:</strong>
                     <span th:each="t, iter : ${overview.lotteryIncentives.poolMilestones}"
                           th:text="|@${t.tickets} tickets → +${t.pct}% of jackpot${iter.last ? '' : ' · '}|"></span>
@@ -452,6 +462,7 @@
                         <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
                     </div>
                 </div>
+                </details>
             </details>
 
             <div class="lottery-admin-actions">

--- a/web/src/main/resources/templates/moderation/settings.html
+++ b/web/src/main/resources/templates/moderation/settings.html
@@ -149,7 +149,10 @@
             <summary>Economy</summary>
             <div class="config-grid">
                 <div class="config-row" data-key="UBI_DAILY_AMOUNT">
-                    <label>UBI daily amount (credits granted to every user once per UTC day; 0 disables)</label>
+                    <label>
+                        UBI daily amount
+                        <span class="config-hint">Credits granted to every user once per UTC day. 0 disables.</span>
+                    </label>
                     <input type="number" min="0" max="1000"
                            th:value="${overview.config['UBI_DAILY_AMOUNT']}"
                            placeholder="0"
@@ -157,7 +160,10 @@
                     <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
                 </div>
                 <div class="config-row" data-key="DAILY_CREDIT_CAP">
-                    <label>Daily credit cap (voice/command/intro earnings ceiling; default 90)</label>
+                    <label>
+                        Daily credit cap
+                        <span class="config-hint">Voice / command / intro earnings ceiling. Default 90.</span>
+                    </label>
                     <input type="number" min="0" max="10000"
                            th:value="${overview.config['DAILY_CREDIT_CAP']}"
                            placeholder="90"
@@ -165,7 +171,10 @@
                     <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
                 </div>
                 <div class="config-row" data-key="TRADE_BUY_FEE_PCT">
-                    <label>Toby Coin BUY fee (% per leg, routed to jackpot pool)</label>
+                    <label>
+                        Toby Coin BUY fee
+                        <span class="config-hint">Charged per leg and routed to the jackpot pool.</span>
+                    </label>
                     <span class="config-input-group">
                         <input type="number" min="0" max="25" step="0.01"
                                th:value="${overview.config['TRADE_BUY_FEE_PCT']}"
@@ -176,7 +185,10 @@
                     <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
                 </div>
                 <div class="config-row" data-key="TRADE_SELL_FEE_PCT">
-                    <label>Toby Coin SELL fee (% per leg, routed to jackpot pool)</label>
+                    <label>
+                        Toby Coin SELL fee
+                        <span class="config-hint">Charged per leg and routed to the jackpot pool.</span>
+                    </label>
                     <span class="config-input-group">
                         <input type="number" min="0" max="25" step="0.01"
                                th:value="${overview.config['TRADE_SELL_FEE_PCT']}"
@@ -206,7 +218,10 @@
             </p>
             <div class="config-grid">
                 <div class="config-row" data-key="JACKPOT_LOSS_TRIBUTE_PCT">
-                    <label>Loss tribute (% of every lost casino stake routed to the pool; default 10)</label>
+                    <label>
+                        Loss tribute
+                        <span class="config-hint">% of every lost casino stake routed to the pool. Default 10.</span>
+                    </label>
                     <span class="config-input-group">
                         <input type="number" min="0" max="50"
                                th:value="${overview.config['JACKPOT_LOSS_TRIBUTE_PCT']}"
@@ -217,7 +232,10 @@
                     <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
                 </div>
                 <div class="config-row" data-key="JACKPOT_WIN_PCT">
-                    <label>Win chance (% per casino-game win; decimals allowed; 0 disables jackpots; default 1)</label>
+                    <label>
+                        Win chance
+                        <span class="config-hint">Per casino-game win; decimals allowed. 0 disables jackpots. Default 1.</span>
+                    </label>
                     <span class="config-input-group">
                         <input type="number" min="0" max="50" step="0.01"
                                th:value="${overview.config['JACKPOT_WIN_PCT']}"
@@ -254,7 +272,13 @@
                     <button type="button" class="btn jackpot-wheel-save" th:disabled="${!isOwner}">Save</button>
                 </div>
                 <div class="config-row" data-key="JACKPOT_RTP_MAX_PCT">
-                    <label>Max game RTP eligible for jackpot (0 disables the gate; recommended 95 to exclude blackjack/coinflip/baccarat/roulette)</label>
+                    <label>
+                        Max eligible game RTP
+                        <span class="config-hint">
+                            Caps which games can pay the jackpot. 0 disables the gate;
+                            recommended 95 to exclude blackjack / coinflip / baccarat / roulette.
+                        </span>
+                    </label>
                     <span class="config-input-group">
                         <input type="number" min="0" max="100"
                                th:value="${overview.config['JACKPOT_RTP_MAX_PCT']}"
@@ -265,7 +289,10 @@
                     <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
                 </div>
                 <div class="config-row" data-key="JACKPOT_WINNER_COOLDOWN_DAYS">
-                    <label>Winner cooldown (days a recent winner is ineligible; 0 disables; recommended 14)</label>
+                    <label>
+                        Winner cooldown
+                        <span class="config-hint">Days a recent winner is ineligible. 0 disables. Recommended 14.</span>
+                    </label>
                     <input type="number" min="0" max="365"
                            th:value="${overview.config['JACKPOT_WINNER_COOLDOWN_DAYS']}"
                            placeholder="0"
@@ -273,7 +300,10 @@
                     <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
                 </div>
                 <div class="config-row" data-key="JACKPOT_ACTIVITY_WINDOW_DAYS">
-                    <label>Activity window (trailing-day window for the eligibility check; 0 disables the gate; recommended 7)</label>
+                    <label>
+                        Activity window
+                        <span class="config-hint">Trailing-day window for the eligibility check. 0 disables the gate. Recommended 7.</span>
+                    </label>
                     <input type="number" min="0" max="90"
                            th:value="${overview.config['JACKPOT_ACTIVITY_WINDOW_DAYS']}"
                            placeholder="0"
@@ -281,7 +311,10 @@
                     <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
                 </div>
                 <div class="config-row" data-key="JACKPOT_ACTIVITY_MIN_DAYS">
-                    <label>Activity minimum (distinct active days required within the window; default 1; ignored when window is 0)</label>
+                    <label>
+                        Activity minimum
+                        <span class="config-hint">Distinct active days required within the window. Default 1. Ignored when window is 0.</span>
+                    </label>
                     <input type="number" min="1" max="90"
                            th:value="${overview.config['JACKPOT_ACTIVITY_MIN_DAYS']}"
                            placeholder="1"
@@ -289,7 +322,10 @@
                     <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
                 </div>
                 <div class="config-row" data-key="JACKPOT_STAKE_ANCHOR">
-                    <label>Stake anchor (reference stake for jackpot probability scaling; default 500)</label>
+                    <label>
+                        Stake anchor
+                        <span class="config-hint">Reference stake for jackpot probability scaling. Default 500.</span>
+                    </label>
                     <input type="number" min="1"
                            th:value="${overview.config['JACKPOT_STAKE_ANCHOR']}"
                            placeholder="500"
@@ -301,22 +337,22 @@
 
         <details class="config-section">
             <summary>Anti-autoclicker</summary>
-            <p class="muted mb-2">
-                Suspected autoclickers (same screen pixel clicked
-                repeatedly with no cursor motion between bets) get
-                a per-(user, guild) "streak" that ramps the house
-                edge by 2.5 percentage points per consecutive
-                bot-like click, capped per game by the values
-                below. The cap is the forced-loss probability
-                applied on top of the fair game; the suspect's
-                effective RTP becomes <code>(1 − cap/100) × fair RTP</code>.
-                Legitimate play never trips the detector. Set 0
-                to disable a game's gate entirely. Discord call
-                paths are unaffected (no mouse signal).
+            <p class="muted config-section-lead">
+                Suspected autoclickers (same screen pixel clicked repeatedly with no cursor
+                motion between bets) get a per-(user, guild) streak that ramps the house
+                edge by 2.5 percentage points per consecutive bot-like click, capped per
+                game by the values below. The cap is the forced-loss probability applied on
+                top of the fair game; the suspect's effective RTP becomes
+                <code>(1 − cap/100) × fair RTP</code>. Default cap is <strong>30 %</strong>;
+                <strong>0 disables</strong> that game's gate. Legitimate play never trips the
+                detector, and Discord call paths are unaffected (no mouse signal).
             </p>
             <div class="config-grid">
                 <div class="config-row" data-key="COINFLIP_BOT_EDGE_MAX_PCT">
-                    <label>Coinflip — max bot-suspicion house edge. Fair RTP 100 % → suspect RTP <code>100 − cap</code> %. Default 30 → suspect RTP 70 %. 0 disables.</label>
+                    <label>
+                        Coinflip
+                        <span class="config-hint">Fair RTP 100 %.</span>
+                    </label>
                     <span class="config-input-group">
                         <input type="number" min="0" max="50"
                                th:value="${overview.config['COINFLIP_BOT_EDGE_MAX_PCT']}"
@@ -327,7 +363,10 @@
                     <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
                 </div>
                 <div class="config-row" data-key="DICE_BOT_EDGE_MAX_PCT">
-                    <label>Dice — max bot-suspicion house edge. Fair RTP ≈ 83 % → suspect RTP ≈ <code>83 × (1 − cap/100)</code> %. Default 30 → suspect RTP ≈ 58 %. 0 disables.</label>
+                    <label>
+                        Dice
+                        <span class="config-hint">Fair RTP ≈ 83 %.</span>
+                    </label>
                     <span class="config-input-group">
                         <input type="number" min="0" max="50"
                                th:value="${overview.config['DICE_BOT_EDGE_MAX_PCT']}"
@@ -338,7 +377,10 @@
                     <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
                 </div>
                 <div class="config-row" data-key="SLOTS_BOT_EDGE_MAX_PCT">
-                    <label>Slots — max bot-suspicion house edge. Fair RTP ≈ 89 % → suspect RTP ≈ <code>89 × (1 − cap/100)</code> %. Default 30 → suspect RTP ≈ 62 %. 0 disables.</label>
+                    <label>
+                        Slots
+                        <span class="config-hint">Fair RTP ≈ 89 %.</span>
+                    </label>
                     <span class="config-input-group">
                         <input type="number" min="0" max="50"
                                th:value="${overview.config['SLOTS_BOT_EDGE_MAX_PCT']}"
@@ -349,7 +391,10 @@
                     <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
                 </div>
                 <div class="config-row" data-key="PLINKO_BOT_EDGE_MAX_PCT">
-                    <label>Plinko — max bot-suspicion house edge. Fair RTP ≈ 89 % → suspect RTP ≈ <code>89 × (1 − cap/100)</code> %. Default 30 → suspect RTP ≈ 62 %. 0 disables.</label>
+                    <label>
+                        Plinko
+                        <span class="config-hint">Fair RTP ≈ 89 %.</span>
+                    </label>
                     <span class="config-input-group">
                         <input type="number" min="0" max="50"
                                th:value="${overview.config['PLINKO_BOT_EDGE_MAX_PCT']}"
@@ -360,7 +405,10 @@
                     <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
                 </div>
                 <div class="config-row" data-key="WHEEL_OF_FORTUNE_BOT_EDGE_MAX_PCT">
-                    <label>Wheel of Fortune — max bot-suspicion house edge. Fair RTP ≈ 88 % → suspect RTP ≈ <code>88 × (1 − cap/100)</code> %. Default 30 → suspect RTP ≈ 62 %. 0 disables.</label>
+                    <label>
+                        Wheel of Fortune
+                        <span class="config-hint">Fair RTP ≈ 88 %.</span>
+                    </label>
                     <span class="config-input-group">
                         <input type="number" min="0" max="50"
                                th:value="${overview.config['WHEEL_OF_FORTUNE_BOT_EDGE_MAX_PCT']}"
@@ -371,7 +419,10 @@
                     <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
                 </div>
                 <div class="config-row" data-key="CASINO_MODLOG_CHANNEL_ID">
-                    <label>Casino mod-log channel (where anti-autoclicker session embeds post; falls back to system channel)</label>
+                    <label>
+                        Casino mod-log channel
+                        <span class="config-hint">Where anti-autoclicker session embeds post. Falls back to the system channel.</span>
+                    </label>
                     <select th:disabled="${!isOwner}">
                         <option value="">&mdash; system channel &mdash;</option>
                         <option th:each="tc : ${overview.textChannels}"

--- a/web/src/test/kotlin/web/controller/LotteryControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/LotteryControllerTest.kt
@@ -253,4 +253,206 @@ class LotteryControllerTest {
         assertNull(vm.daily)
         assertNull(vm.weighted)
     }
+
+    // ---- LotteryViewModel.from — Participation incentives panel ------
+
+    private fun weightedSnapshot(
+        myTickets: Int = 0,
+        myBonusTickets: Long = 0L,
+        totalTickets: Long = 0L,
+        milestonesFired: Long = 0L,
+        incentives: web.view.LotteryIncentivesView = web.view.LotteryIncentivesView.empty(),
+    ): LotteryWebService.LotteryPageSnapshot {
+        val weighted = JackpotLotteryDto(
+            id = 1L, guildId = guildId, ticketPrice = 100L, poolAmount = 1_000L,
+            winnerCount = 3, status = JackpotLotteryDto.STATUS_OPEN,
+            mode = JackpotLotteryDto.MODE_TICKET_WEIGHTED,
+            milestonesFired = milestonesFired,
+        )
+        val myTicket = if (myTickets > 0 || myBonusTickets > 0L) {
+            database.dto.JackpotLotteryTicketDto(
+                lotteryId = 1L, discordId = discordId,
+                ticketCount = myTickets, spent = myTickets * 100L,
+                bonusTickets = myBonusTickets,
+            )
+        } else null
+        return LotteryWebService.LotteryPageSnapshot(
+            dailyOpen = null,
+            dailyLatestDrawn = null,
+            dailyMyTicket = null,
+            dailyTicketBuyers = 0,
+            weightedOpen = weighted,
+            weightedMyTicket = myTicket,
+            weightedTopHolders = emptyList(),
+            weightedTotalTickets = totalTickets,
+            pickCount = 5,
+            numberMax = 49,
+            tierPercents = listOf(60, 25, 10, 5),
+            revenueJackpotPct = 30L,
+            dailyMode = "WEIGHTED",
+            dailyEnabled = true,
+            weightedIncentives = incentives,
+        )
+    }
+
+    @Test
+    fun `LotteryViewModel hides incentives panel when no tiers are configured`() {
+        // Default empty incentives → no panel rendered. The template
+        // checks `weighted.incentives != null` to decide whether to
+        // emit the section at all.
+        val vm = LotteryViewModel.from(weightedSnapshot())
+        assertNull(vm.weighted!!.incentives)
+    }
+
+    @Test
+    fun `LotteryViewModel surfaces active rules when at least one tier is configured`() {
+        val incentives = web.view.LotteryIncentivesView(
+            bulkTiers = listOf(
+                web.view.BulkBonusTierView(buy = 10L, bonus = 3L),
+                web.view.BulkBonusTierView(buy = 25L, bonus = 8L),
+            ),
+            multiplierTiers = emptyList(),
+            poolMilestones = emptyList(),
+        )
+        val vm = LotteryViewModel.from(weightedSnapshot(incentives = incentives))
+        val panel = vm.weighted!!.incentives
+        assertNotNull(panel)
+        assertEquals(2, panel!!.bulkTiers.size)
+        assertEquals(10L, panel.bulkTiers.first().buy)
+        assertTrue(panel.multiplierTiers.isEmpty())
+        assertTrue(panel.poolMilestones.isEmpty())
+    }
+
+    @Test
+    fun `LotteryViewModel computes nextBulkHint as the gap to the next unmatched tier`() {
+        // Player holds 4 tickets, lowest tier requires 10. Hint
+        // should surface "buy 6 more for +3 free". The +1 tier sits
+        // above 4 so the next-tier rule fires there.
+        val incentives = web.view.LotteryIncentivesView(
+            bulkTiers = listOf(
+                web.view.BulkBonusTierView(buy = 10L, bonus = 3L),
+                web.view.BulkBonusTierView(buy = 25L, bonus = 8L),
+            ),
+            multiplierTiers = emptyList(),
+            poolMilestones = emptyList(),
+        )
+        val vm = LotteryViewModel.from(
+            weightedSnapshot(myTickets = 4, incentives = incentives)
+        )
+        val hint = vm.weighted!!.incentives!!.nextBulkHint
+        assertNotNull(hint)
+        assertEquals(6L, hint!!.gap)
+        assertEquals(3L, hint.bonus)
+        assertEquals(10L, hint.threshold)
+    }
+
+    @Test
+    fun `LotteryViewModel returns null nextBulkHint when player already holds top tier`() {
+        // Player holds 30 tickets; tier ceiling is 25. No further
+        // "buy N more" hint to dangle — return null.
+        val incentives = web.view.LotteryIncentivesView(
+            bulkTiers = listOf(
+                web.view.BulkBonusTierView(buy = 10L, bonus = 3L),
+                web.view.BulkBonusTierView(buy = 25L, bonus = 8L),
+            ),
+            multiplierTiers = emptyList(),
+            poolMilestones = emptyList(),
+        )
+        val vm = LotteryViewModel.from(
+            weightedSnapshot(myTickets = 30, incentives = incentives)
+        )
+        assertNull(vm.weighted!!.incentives!!.nextBulkHint)
+    }
+
+    @Test
+    fun `LotteryViewModel formats nextMultiplierHint with a 2-decimal multiplier`() {
+        val incentives = web.view.LotteryIncentivesView(
+            bulkTiers = emptyList(),
+            multiplierTiers = listOf(
+                web.view.MultiplierTierView(total = 15L, bp = 15_000),
+            ),
+            poolMilestones = emptyList(),
+        )
+        val vm = LotteryViewModel.from(
+            weightedSnapshot(myTickets = 9, incentives = incentives)
+        )
+        val hint = vm.weighted!!.incentives!!.nextMultiplierHint
+        assertNotNull(hint)
+        assertEquals(6L, hint!!.gap)
+        // The hint precomputes the human "1.50×" string so the
+        // template doesn't have to massage bp at render time.
+        assertEquals("1.50×", hint.multiplier)
+    }
+
+    @Test
+    fun `LotteryViewModel reports the next-to-fire milestone with current vs threshold`() {
+        // Guild-wide 42 tickets sold; milestones at 50 and 100, none
+        // fired yet. Progress bar should show the 50 tier with
+        // current=42, threshold=50.
+        val incentives = web.view.LotteryIncentivesView(
+            bulkTiers = emptyList(),
+            multiplierTiers = emptyList(),
+            poolMilestones = listOf(
+                web.view.PoolMilestoneView(tickets = 50L, pct = 10L),
+                web.view.PoolMilestoneView(tickets = 100L, pct = 5L),
+            ),
+        )
+        val vm = LotteryViewModel.from(
+            weightedSnapshot(totalTickets = 42L, incentives = incentives)
+        )
+        val progress = vm.weighted!!.incentives!!.milestoneProgress
+        assertNotNull(progress)
+        assertEquals(42L, progress!!.currentTickets)
+        assertEquals(50L, progress.thresholdTickets)
+        assertEquals(10L, progress.pct)
+    }
+
+    @Test
+    fun `LotteryViewModel skips already-fired milestones when picking the next one`() {
+        // 50 already fired (recorded on lottery.milestonesFired);
+        // even if current ticket count is still below the 100
+        // threshold, the next-to-fire is 100, not 50.
+        val incentives = web.view.LotteryIncentivesView(
+            bulkTiers = emptyList(),
+            multiplierTiers = emptyList(),
+            poolMilestones = listOf(
+                web.view.PoolMilestoneView(tickets = 50L, pct = 10L),
+                web.view.PoolMilestoneView(tickets = 100L, pct = 5L),
+            ),
+        )
+        val vm = LotteryViewModel.from(
+            weightedSnapshot(totalTickets = 60L, milestonesFired = 50L, incentives = incentives)
+        )
+        val progress = vm.weighted!!.incentives!!.milestoneProgress
+        assertNotNull(progress)
+        assertEquals(100L, progress!!.thresholdTickets)
+    }
+
+    @Test
+    fun `LotteryViewModel returns null milestoneProgress when no future milestone exists`() {
+        // Both milestones already fired — nothing further to chase.
+        val incentives = web.view.LotteryIncentivesView(
+            bulkTiers = emptyList(),
+            multiplierTiers = emptyList(),
+            poolMilestones = listOf(
+                web.view.PoolMilestoneView(tickets = 50L, pct = 10L),
+                web.view.PoolMilestoneView(tickets = 100L, pct = 5L),
+            ),
+        )
+        val vm = LotteryViewModel.from(
+            weightedSnapshot(totalTickets = 120L, milestonesFired = 100L, incentives = incentives)
+        )
+        assertNull(vm.weighted!!.incentives!!.milestoneProgress)
+    }
+
+    @Test
+    fun `LotteryViewModel exposes the player's bonus tickets on the weighted view`() {
+        // Bonus tickets accumulated from past bulk buys must be
+        // visible to the template so the "X paid + Y bonus" copy can
+        // render. Untouched when the player has no bonus.
+        val vm = LotteryViewModel.from(
+            weightedSnapshot(myTickets = 10, myBonusTickets = 3L)
+        )
+        assertEquals(3L, vm.weighted!!.myBonusTickets)
+    }
 }

--- a/web/src/test/kotlin/web/service/LotteryWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/LotteryWebServiceTest.kt
@@ -1,0 +1,127 @@
+package web.service
+
+import database.dto.ConfigDto
+import database.dto.JackpotLotteryDto
+import database.service.ConfigService
+import database.service.JackpotLotteryService
+import database.service.TitleService
+import database.service.UserService
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * Snapshot-wiring coverage. The view-model derivation
+ * (`LotteryViewModel.from`) is already covered by `LotteryControllerTest`;
+ * here we pin that the snapshot itself surfaces the right
+ * `weightedIncentives` payload depending on whether a weighted lottery
+ * is open and whether tiers are configured for the guild. Tier
+ * filtering / clamping is the responsibility of `LotteryHelper` and
+ * is covered by `LotteryHelperTest`.
+ */
+class LotteryWebServiceTest {
+
+    private val guildId = 100L
+    private val discordId = 1L
+
+    private lateinit var jackpotLotteryService: JackpotLotteryService
+    private lateinit var configService: ConfigService
+    private lateinit var memberLookupHelper: MemberLookupHelper
+    private lateinit var userService: UserService
+    private lateinit var titleService: TitleService
+    private lateinit var service: LotteryWebService
+
+    @BeforeEach
+    fun setup() {
+        jackpotLotteryService = mockk(relaxed = true)
+        configService = mockk(relaxed = true)
+        memberLookupHelper = mockk(relaxed = true)
+        userService = mockk(relaxed = true)
+        titleService = mockk(relaxed = true)
+        service = LotteryWebService(
+            jackpotLotteryService = jackpotLotteryService,
+            configService = configService,
+            memberLookupHelper = memberLookupHelper,
+            userService = userService,
+            titleService = titleService,
+        )
+    }
+
+    private fun stubTier(key: ConfigDto.Configurations, value: String) {
+        every {
+            configService.getConfigByName(key.configValue, guildId.toString())
+        } returns ConfigDto(name = key.configValue, value = value, guildId = guildId.toString())
+    }
+
+    @Test
+    fun `snapshot returns empty incentives when no weighted lottery is open`() {
+        // No open weighted lottery → no point resolving tiers; the
+        // template should never render the panel anyway, and we save
+        // three config-table lookups per snapshot.
+        every { jackpotLotteryService.getOpenWeighted(guildId) } returns null
+
+        val snap = service.snapshot(guildId, discordId)
+
+        assertTrue(snap.weightedIncentives.bulkTiers.isEmpty())
+        assertTrue(snap.weightedIncentives.multiplierTiers.isEmpty())
+        assertTrue(snap.weightedIncentives.poolMilestones.isEmpty())
+        assertTrue(snap.weightedIncentives.isEmpty)
+    }
+
+    @Test
+    fun `snapshot returns empty incentives when a weighted lottery is open but no tiers are configured`() {
+        every { jackpotLotteryService.getOpenWeighted(guildId) } returns JackpotLotteryDto(
+            id = 1L, guildId = guildId,
+            status = JackpotLotteryDto.STATUS_OPEN,
+            mode = JackpotLotteryDto.MODE_TICKET_WEIGHTED,
+        )
+
+        val snap = service.snapshot(guildId, discordId)
+
+        // Default state — no tiers stubbed, getter returns null
+        // → LotteryHelper returns empty lists.
+        assertTrue(snap.weightedIncentives.isEmpty)
+    }
+
+    @Test
+    fun `snapshot surfaces only the active bulk tier when configured`() {
+        every { jackpotLotteryService.getOpenWeighted(guildId) } returns JackpotLotteryDto(
+            id = 1L, guildId = guildId,
+            status = JackpotLotteryDto.STATUS_OPEN,
+            mode = JackpotLotteryDto.MODE_TICKET_WEIGHTED,
+        )
+        stubTier(ConfigDto.Configurations.LOTTERY_BULK_TIER1_BUY, "10")
+        stubTier(ConfigDto.Configurations.LOTTERY_BULK_TIER1_BONUS, "3")
+        // Tier 2 / 3 left unconfigured — should not appear.
+
+        val snap = service.snapshot(guildId, discordId)
+
+        assertEquals(1, snap.weightedIncentives.bulkTiers.size)
+        assertEquals(10L, snap.weightedIncentives.bulkTiers.first().buy)
+        assertEquals(3L, snap.weightedIncentives.bulkTiers.first().bonus)
+        assertTrue(snap.weightedIncentives.multiplierTiers.isEmpty())
+        assertTrue(snap.weightedIncentives.poolMilestones.isEmpty())
+    }
+
+    @Test
+    fun `snapshot surfaces milestones when configured for an open weighted lottery`() {
+        every { jackpotLotteryService.getOpenWeighted(guildId) } returns JackpotLotteryDto(
+            id = 1L, guildId = guildId,
+            status = JackpotLotteryDto.STATUS_OPEN,
+            mode = JackpotLotteryDto.MODE_TICKET_WEIGHTED,
+        )
+        stubTier(ConfigDto.Configurations.LOTTERY_MILESTONE1_TICKETS, "50")
+        stubTier(ConfigDto.Configurations.LOTTERY_MILESTONE1_PCT, "10")
+        stubTier(ConfigDto.Configurations.LOTTERY_MILESTONE2_TICKETS, "100")
+        stubTier(ConfigDto.Configurations.LOTTERY_MILESTONE2_PCT, "5")
+
+        val snap = service.snapshot(guildId, discordId)
+
+        assertEquals(2, snap.weightedIncentives.poolMilestones.size)
+        assertEquals(50L, snap.weightedIncentives.poolMilestones.first().tickets)
+        assertEquals(10L, snap.weightedIncentives.poolMilestones.first().pct)
+    }
+}

--- a/web/src/test/kotlin/web/template/LotteryPlayerTemplateTest.kt
+++ b/web/src/test/kotlin/web/template/LotteryPlayerTemplateTest.kt
@@ -1,0 +1,92 @@
+package web.template
+
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Presence regression for the player-facing lottery template. Pins the
+ * incentives panel that surfaces participation tiers + personalised
+ * next-threshold hints + milestone progress on `/casino/{id}/lottery`.
+ *
+ * Asserts on raw HTML so a typo'd Thymeleaf expression (e.g. renaming
+ * `snapshot.weighted.incentives` without updating the template) fails
+ * CI rather than silently rendering an empty panel. The view-model
+ * derivation itself is covered by `LotteryControllerTest`.
+ */
+class LotteryPlayerTemplateTest {
+
+    private val lotteryHtml: String by lazy {
+        val url = javaClass.classLoader.getResource("templates/lottery.html")
+        assertNotNull(url, "templates/lottery.html must be on the classpath")
+        url!!.readText()
+    }
+
+    @Test
+    fun `player lottery template carries a Participation incentives section gated on incentives non-null`() {
+        // Only TICKET_WEIGHTED draws get the panel — the
+        // `snapshot.weighted != null and snapshot.weighted.incentives != null`
+        // guard hides it for NUMBER_MATCH (where incentives are inert)
+        // and for empty config (where the panel would be visually
+        // empty). Two render sites: the WEIGHTED-daily section and
+        // the admin-fired Featured event card.
+        assertTrue(
+            lotteryHtml.contains("<h3>Participation incentives</h3>"),
+            "expected the Participation incentives heading on the weighted section",
+        )
+        // The Thymeleaf guard must reference the incentives field on
+        // the weighted view model — if a refactor renames it, the
+        // assertion lights up immediately.
+        assertTrue(
+            lotteryHtml.contains("snapshot.weighted.incentives != null"),
+            "expected the panel to be gated on snapshot.weighted.incentives != null",
+        )
+    }
+
+    @Test
+    fun `player lottery template renders all three lever subsections with data-incentive markers`() {
+        // Each lever block carries a `data-incentive` attribute so the
+        // test (and any future JS) can scope to it without depending on
+        // emoji order or copy. Losing any one of these means a whole
+        // lever silently fell off the page.
+        for (lever in listOf("bulk", "multiplier", "milestone")) {
+            assertTrue(
+                lotteryHtml.contains("data-incentive=\"$lever\""),
+                "expected a `data-incentive=\"$lever\"` block in the player lottery template",
+            )
+        }
+    }
+
+    @Test
+    fun `player lottery template renders the next-threshold hint expressions per lever`() {
+        // The hint copy is computed view-side as `nextBulkHint /
+        // nextMultiplierHint`. Pin both expressions so a hint-block
+        // refactor doesn't accidentally drop one side and leave a
+        // half-rendered panel in prod.
+        for (hint in listOf(
+            "inc.nextBulkHint",
+            "inc.nextMultiplierHint",
+        )) {
+            assertTrue(
+                lotteryHtml.contains(hint),
+                "expected $hint reference in the player lottery template",
+            )
+        }
+    }
+
+    @Test
+    fun `player lottery template renders a progress bar for the next-to-fire milestone`() {
+        // The `<progress>` element drives the live FOMO bar; the
+        // `inc.milestoneProgress` view-model field carries
+        // current / threshold / pct. Verify both the element and the
+        // expression so a refactor that renames either fails fast.
+        assertTrue(
+            lotteryHtml.contains("inc.milestoneProgress"),
+            "expected inc.milestoneProgress reference for the milestone progress bar",
+        )
+        assertTrue(
+            lotteryHtml.contains("<progress"),
+            "expected a <progress> element to render the milestone progress bar",
+        )
+    }
+}

--- a/web/src/test/kotlin/web/template/ModerationTemplateRowsTest.kt
+++ b/web/src/test/kotlin/web/template/ModerationTemplateRowsTest.kt
@@ -348,17 +348,20 @@ class ModerationTemplateRowsTest {
 
     @Test
     fun `lottery template has a participation incentives details block carrying all three levers`() {
-        // The new section sits inside its own collapsible block so
-        // admins can scan past it when tuning the daily prize
-        // parameters. The block's headings group the tiers by lever
-        // (bulk / multiplier / milestone) — losing any of them would
-        // flatten the section back to a wall of identical-looking
-        // numeric inputs.
-        val sectionStart = lotteryHtml.indexOf("<summary>Participation incentives")
-        assertTrue(sectionStart >= 0, "expected a Participation incentives section header")
-        val sectionEnd = lotteryHtml.indexOf("</details>", sectionStart)
-        assertTrue(sectionEnd > sectionStart, "Participation incentives section not terminated")
-        val sectionHtml = lotteryHtml.substring(sectionStart, sectionEnd)
+        // The section sits in its own collapsible block, with three
+        // nested `<details>` levers (bulk / multiplier / milestone)
+        // for visual separation. We scope to the outer block by
+        // walking `<details>` / `</details>` pairs from the section's
+        // own opening tag, since a naive "next </details>" would
+        // terminate at the first nested closer.
+        val summaryIdx = lotteryHtml.indexOf("Participation incentives")
+        assertTrue(summaryIdx >= 0, "expected a Participation incentives section header")
+        // Walk back to the outer `<details` tag that wraps the summary.
+        val outerOpen = lotteryHtml.lastIndexOf("<details", summaryIdx)
+        assertTrue(outerOpen >= 0, "expected an outer <details> wrapping the Participation incentives summary")
+        val outerEnd = matchingCloseDetails(lotteryHtml, outerOpen)
+        assertTrue(outerEnd > outerOpen, "outer Participation incentives <details> not terminated")
+        val sectionHtml = lotteryHtml.substring(outerOpen, outerEnd)
         for (heading in listOf(
             "Bulk bonus tickets",
             "Volume weight multiplier",
@@ -381,6 +384,33 @@ class ModerationTemplateRowsTest {
                 "$key should live inside the Participation incentives section",
             )
         }
+    }
+
+    /**
+     * Find the `</details>` index that closes the `<details` opened
+     * at [openIdx], honouring nested `<details>` blocks. Returns -1
+     * if the tag is never closed (shouldn't happen on a well-formed
+     * template). Used by section-scoped assertions where a naive
+     * `indexOf("</details>", start)` would stop at the first nested
+     * closer instead of the matching outer one.
+     */
+    private fun matchingCloseDetails(html: String, openIdx: Int): Int {
+        var depth = 0
+        var i = openIdx
+        while (i < html.length) {
+            val nextOpen = html.indexOf("<details", i)
+            val nextClose = html.indexOf("</details>", i)
+            if (nextClose < 0) return -1
+            if (nextOpen in 0..<nextClose) {
+                depth++
+                i = nextOpen + "<details".length
+            } else {
+                depth--
+                if (depth == 0) return nextClose
+                i = nextClose + "</details>".length
+            }
+        }
+        return -1
     }
 
     @Test


### PR DESCRIPTION
## Why

The participation incentives shipped in #506 only appeared on the owner-only moderation page (`/moderation/{id}/lottery`) and the Discord announce embed. The player-facing `/casino/{id}/lottery` page never saw them — most members had no way to know the levers existed. Several moderation pages also had rough text/layout flagged on review: long compound labels, mixed `%` suffix patterns, awkward `<h4>` subheadings.

## What changed

### Player surface (TICKET_WEIGHTED only — NUMBER_MATCH caps users at one ticket)

- **`LotteryWebService.snapshot`** now carries the active incentive tiers via a new shared `LotteryIncentivesView` (promoted out of `ModerationWebService` into `web/view`).
- **`LotteryViewModel.WeightedView`** gains an `incentives` panel with the resolved active rules + three derived per-viewer fields:
  - `nextBulkHint` — gap + bonus + threshold; null when the player already holds the top tier
  - `nextMultiplierHint` — gap + pre-formatted `1.25×` string + threshold
  - `milestoneProgress` — current vs threshold vs % for a `<progress>` bar, skipping milestones already fired
- **`templates/lottery.html`** renders a new "Participation incentives" panel inside both the WEIGHTED-daily section and the Featured event card. Each lever block carries a `data-incentive` marker for stable test/JS scoping.
- **`lottery.css`** — minimal styling for the panel, hint callout, and progress bar.

### Moderation polish

- **`moderation/lottery.html`** — trimmed `Participation incentives (TICKET_WEIGHTED only)` into a title + `.config-badge` pill, wrapped each lever in its own nested `<details>` for visual separation.
- **`moderation/settings.html`** — split long inline labels into label + `<span class="config-hint">` across UBI, daily-cap, trade-fee, jackpot eligibility, and anti-autoclicker rows. Lifted the repetitive "Fair RTP X → suspect RTP Y" formula out of every per-game anti-autoclicker label into the section lead.
- **`moderation/leveling.html`** — shortened the daily-XP-cap hint; moved the "TobyBot's role must sit above…" warning into a `.config-warning` callout.
- **`moderation.css`** — new utility classes: `.config-section-lead`, `.config-active-rules`, `.config-section.nested`, `.config-badge`, `.config-warning`.

## Tests

- `LotteryWebServiceTest` (new) — snapshot returns empty incentives when no lottery is open / no tiers configured; surfaces only active bulk tiers and milestones when configured.
- `LotteryControllerTest` (extended, +8 cases) — view-model derivation: empty panel hides, active rules surface, `nextBulkHint` gap math, null at top tier, multiplier formatted to two decimals, milestone picks the next to fire, skips already-fired ones, exposes bonus tickets.
- `LotteryPlayerTemplateTest` (new) — pins the Participation incentives section, per-lever `data-incentive` markers, hint expressions, milestone `<progress>` element.
- `ModerationTemplateRowsTest` — the "all three levers" assertion rewired to walk balanced `<details>` nesting after the lever split.

## Test plan

- [x] `./gradlew :database:test :web:test`
- [ ] Manual: load `/moderation/{id}/lottery`, configure all three incentive levers, run `/jackpotadmin lottery_open`, load `/casino/{id}/lottery` as a non-admin — confirm the panel matches the moderation Active rules, the personalised hint reflects current ticket count, and the milestone progress bar tracks `weightedTotalTickets`.
- [ ] Manual: visit each touched moderation page and check the hints wrap cleanly, every percent row has a suffix marker, and the leveling-role rewards warning surfaces as a callout.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mib78RPKH1yRW234Zwugjs)_