### PR TITLE
fix(lottery): tab-nav layout + silent web bonus award + broken bulk-buy hint

### DIFF
--- a/database/src/test/kotlin/database/service/JackpotLotteryServiceTest.kt
+++ b/database/src/test/kotlin/database/service/JackpotLotteryServiceTest.kt
@@ -907,6 +907,33 @@ class JackpotLotteryServiceTest {
     }
 
     @Test
+    fun `buyTickets accumulates bonusTickets on the same ticket row across multiple bulk-qualifying buys`() {
+        // The user-reported "extra tickets didn't work" investigation
+        // showed the service correctly accumulates bulk bonuses on an
+        // existing ticket row, but there was no test pinning that
+        // multi-buy behaviour. This test buys twice in a row and
+        // asserts the ticket row ends with `bonusTickets = 6`, not 3
+        // (the second buy must add to bonusTickets, not overwrite).
+        stubBulkTier1(buy = 10L, bonus = 3L)
+        openWeightedLottery()
+        val user = UserDto(discordId = 7L, guildId = guildId).apply { socialCredit = 100_000L }
+        every { userService.getUserByIdForUpdate(7L, guildId) } returns user
+        val existing = JackpotLotteryTicketDto(lotteryId = 1L, discordId = 7L, ticketCount = 0, spent = 0L)
+        every { lotteryPersistence.getTicketForUpdate(1L, 7L) } returns existing
+
+        val first = service.buyTickets(guildId, discordId = 7L, ticketCount = 10)
+        assertTrue(first is JackpotLotteryService.BuyOutcome.Ok)
+        val second = service.buyTickets(guildId, discordId = 7L, ticketCount = 10)
+        assertTrue(second is JackpotLotteryService.BuyOutcome.Ok)
+        second as JackpotLotteryService.BuyOutcome.Ok
+
+        assertEquals(20, existing.ticketCount)
+        assertEquals(6L, existing.bonusTickets, "two qualifying buys → 3 + 3 = 6 bonus tickets accumulated")
+        assertEquals(3L, second.bonusTicketsGranted, "the per-buy grant on the second buy is 3, not the cumulative 6")
+        assertEquals(6L, second.totalBonusTickets, "totalBonusTickets reflects the cumulative ticket-row value")
+    }
+
+    @Test
     fun `effectiveWeight collapses to ticketCount when multiplier tiers empty`() {
         val ticket = JackpotLotteryTicketDto(lotteryId = 1L, discordId = 7L, ticketCount = 12, spent = 0L)
         assertEquals(12L, service.effectiveWeight(ticket, emptyList()))

--- a/web/src/main/kotlin/web/controller/LotteryController.kt
+++ b/web/src/main/kotlin/web/controller/LotteryController.kt
@@ -129,6 +129,11 @@ class LotteryController(
                     totalSpent = outcome.totalSpent,
                     newBalance = outcome.newBalance,
                     newPool = outcome.newPool,
+                    bonusTicketsGranted = outcome.bonusTicketsGranted.takeIf { it > 0L },
+                    totalBonusTickets = outcome.totalBonusTickets.takeIf { it > 0L },
+                    milestoneBonuses = outcome.milestoneBonuses
+                        .map { MilestoneBonusView(threshold = it.threshold, creditsAdded = it.creditsAdded) }
+                        .takeIf { it.isNotEmpty() },
                 )
             )
 
@@ -168,7 +173,37 @@ data class BuyWeightedResponse(
     val totalSpent: Long? = null,
     val newBalance: Long? = null,
     val newPool: Long? = null,
+    /**
+     * Bulk-buy bonus tickets credited on this single purchase. Null
+     * (rather than 0) when nothing was awarded so the client can
+     * cleanly skip the bonus toast without a falsy-zero check.
+     */
+    val bonusTicketsGranted: Long? = null,
+    /**
+     * Cumulative bonus tickets the buyer holds on this lottery after
+     * the purchase. Mirrors `JackpotLotteryTicketDto.bonusTickets` so
+     * the client can render the "X paid + Y bonus" breakdown without
+     * a separate snapshot round-trip.
+     */
+    val totalBonusTickets: Long? = null,
+    /**
+     * Pool-growth milestones that fired during this purchase. Each
+     * entry is `{threshold, creditsAdded}` — same shape as the
+     * service's [database.service.JackpotLotteryService.MilestoneBonus].
+     * Null when no milestones fired (the client doesn't need an empty
+     * list to know there's nothing to render).
+     */
+    val milestoneBonuses: List<MilestoneBonusView>? = null,
 ) : CasinoResponseLike
+
+/**
+ * View projection of a single pool-growth milestone that fired during
+ * a weighted ticket buy. Mirrors
+ * [database.service.JackpotLotteryService.MilestoneBonus] but lives in
+ * the controller layer so the response shape doesn't leak the service
+ * type into the JSON contract.
+ */
+data class MilestoneBonusView(val threshold: Long, val creditsAdded: Long)
 
 /**
  * View-friendly projection of the lottery snapshot. Strips DTO
@@ -233,22 +268,28 @@ data class LotteryViewModel(
     /**
      * What the player sees in the "Participation incentives" panel on
      * the lottery page. Only carries data that has something to render:
-     * `nextBulkHint` / `nextMultiplierHint` are null when the viewer
-     * already holds the top tier (no further "buy N more" to dangle),
-     * and `milestoneProgress` is null when no future milestone is
-     * configured (the panel just shows active rules in that case).
+     * `nextMultiplierHint` is null when the viewer already holds the
+     * top multiplier tier, and `milestoneProgress` is null when no
+     * future milestone is configured (the panel just shows active
+     * rules in that case).
+     *
+     * Note: there is intentionally no `nextBulkHint`. Bulk bonus is
+     * awarded **per-purchase** — one `/lottery buy N` call must
+     * satisfy `N >= tier.buy` on its own, regardless of how many
+     * tickets the player already holds. A previous version computed
+     * `gap = tier.buy - myTickets` and produced misleading copy like
+     * "buy 5 more in one purchase for +3 free" when the actual
+     * requirement was buy-10-or-nothing. The active-rules listing
+     * already shows every tier's threshold, which is the only
+     * information that's meaningful for a per-purchase reward.
      */
     data class WeightedIncentivesPanel(
         val bulkTiers: List<web.view.BulkBonusTierView>,
         val multiplierTiers: List<web.view.MultiplierTierView>,
         val poolMilestones: List<web.view.PoolMilestoneView>,
-        val nextBulkHint: NextBulkHint?,
         val nextMultiplierHint: NextMultiplierHint?,
         val milestoneProgress: MilestoneProgress?,
     )
-
-    /** Smallest unmatched bulk tier — "buy [gap] more in one purchase for +[bonus] free". */
-    data class NextBulkHint(val gap: Long, val bonus: Long, val threshold: Long)
 
     /** Smallest unmatched multiplier tier, with the bp pre-formatted to a human "1.25×" decimal. */
     data class NextMultiplierHint(val gap: Long, val multiplier: String, val threshold: Long)
@@ -344,10 +385,10 @@ data class LotteryViewModel(
          * render an empty card.
          *
          * Hint derivation:
-         *  - Next bulk tier: smallest `buy` threshold strictly greater
-         *    than the viewer's current ticket count. The hint copy
-         *    "buy [gap] more in one purchase" reflects the per-purchase
-         *    nature of the bulk bonus (splitting doesn't count).
+         *  - Bulk tiers carry no personalised "next" hint. Bulk bonus
+         *    is per-purchase, so a single buy must satisfy `tier.buy`
+         *    on its own; existing holdings don't shrink the threshold.
+         *    The active-rules listing covers what the player needs.
          *  - Next multiplier tier: smallest `total` threshold strictly
          *    greater than the viewer's total. Multiplier rendered as
          *    a 1.25× / 1.5× decimal so the template doesn't have to.
@@ -365,15 +406,6 @@ data class LotteryViewModel(
             val incentives = snap.weightedIncentives
             if (incentives.isEmpty) return null
 
-            val nextBulk = incentives.bulkTiers
-                .firstOrNull { it.buy > myTickets }
-                ?.let { tier ->
-                    NextBulkHint(
-                        gap = tier.buy - myTickets,
-                        bonus = tier.bonus,
-                        threshold = tier.buy,
-                    )
-                }
             val nextMultiplier = incentives.multiplierTiers
                 .firstOrNull { it.total > myTickets }
                 ?.let { tier ->
@@ -397,7 +429,6 @@ data class LotteryViewModel(
                 bulkTiers = incentives.bulkTiers,
                 multiplierTiers = incentives.multiplierTiers,
                 poolMilestones = incentives.poolMilestones,
-                nextBulkHint = nextBulk,
                 nextMultiplierHint = nextMultiplier,
                 milestoneProgress = nextMilestone,
             )

--- a/web/src/main/resources/static/css/moderation.css
+++ b/web/src/main/resources/static/css/moderation.css
@@ -41,14 +41,38 @@ details.config-section.is-hidden { display: none; }
    styled to look like the old in-page tabs so the visual continuity is
    preserved. The .active class is set on the link matching the
    currently rendered page. */
+/* On mobile the 8-tab bar wrapped to two rows and the last tab got
+   stranded at the right edge (no `justify-content`, so tabs packed
+   left-tight on row 2 and any leftover slid against the trailing
+   border). Switching to a single horizontal strip that scrolls is the
+   standard mobile-tab pattern and sidesteps the wrap-strand artefact
+   entirely. At ≥600px we revert to wrap so a merely-narrow desktop
+   window keeps the multi-row layout. */
 .mod-subnav {
     display: flex;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
     gap: 4px;
+    overflow-x: auto;
+    overflow-y: hidden;
+    scrollbar-width: thin;
+    -webkit-overflow-scrolling: touch;
     border-bottom: 1px solid var(--border);
     margin-bottom: var(--space-5);
 }
+.mod-subnav::-webkit-scrollbar { height: 4px; }
+.mod-subnav::-webkit-scrollbar-thumb {
+    background: var(--border);
+    border-radius: 2px;
+}
+@media (min-width: 600px) {
+    .mod-subnav {
+        flex-wrap: wrap;
+        overflow-x: visible;
+    }
+}
 .mod-subnav-link {
+    flex: 0 0 auto;
+    white-space: nowrap;
     color: var(--text-muted);
     padding: var(--space-2) var(--space-4);
     text-decoration: none;

--- a/web/src/main/resources/static/js/lottery.js
+++ b/web/src/main/resources/static/js/lottery.js
@@ -177,10 +177,37 @@
                     return;
                 }
                 if (poolEl) poolEl.textContent = body.newPool;
-                if (myEl) myEl.textContent = body.ticketCount;
+                // "Your tickets" now renders "X paid + Y bonus" when
+                // the buyer has any bulk-bonus tickets — keeps parity
+                // with the moderation page and the Discord status copy.
+                if (myEl) {
+                    if (body.totalBonusTickets && body.totalBonusTickets > 0) {
+                        myEl.textContent = `${body.ticketCount} paid + ${body.totalBonusTickets} bonus`;
+                    } else {
+                        myEl.textContent = body.ticketCount;
+                    }
+                }
                 if (balanceEl) TobyBalance.update(balanceEl, body.newBalance);
                 if (typeof toast === 'function') {
-                    toast(`Bought ${count} tickets — total ${body.ticketCount} held.`, 'success');
+                    // Base success copy + optional bulk-bonus and
+                    // milestone callouts. Building the message in
+                    // pieces so a regression on the response shape
+                    // (missing field, zero bonus) silently degrades
+                    // to the base copy rather than printing
+                    // "undefined" into the toast.
+                    let msg = `Bought ${count} tickets — total ${body.ticketCount} held.`;
+                    if (body.bonusTicketsGranted && body.bonusTicketsGranted > 0) {
+                        msg += ` 🎁 +${body.bonusTicketsGranted} bonus from bulk-buy!`;
+                    }
+                    toast(msg, 'success');
+                    if (Array.isArray(body.milestoneBonuses)) {
+                        body.milestoneBonuses.forEach(m => {
+                            toast(
+                                `🚀 Milestone @${m.threshold} tickets sold → +${m.creditsAdded} credits to the pool!`,
+                                'success'
+                            );
+                        });
+                    }
                 }
             } catch (err) {
                 if (typeof toast === 'function') {

--- a/web/src/main/resources/templates/lottery.html
+++ b/web/src/main/resources/templates/lottery.html
@@ -191,7 +191,10 @@
                 </span>
                 <span class="lottery-meta-item">
                     Your tickets:
-                    <strong id="weighted-my-tickets" th:text="${snapshot.weighted.myTickets}">0</strong>
+                    <strong id="weighted-my-tickets"
+                            th:text="${snapshot.weighted.myBonusTickets > 0}
+                                     ? |${snapshot.weighted.myTickets} paid + ${snapshot.weighted.myBonusTickets} bonus|
+                                     : ${snapshot.weighted.myTickets}">0</strong>
                 </span>
                 <span class="lottery-meta-item lottery-countdown"
                       th:attr="data-closes-at=${snapshot.weighted.closesAtMillis}">
@@ -241,11 +244,11 @@
                         buy at least 10 in one purchase → +3 free tickets
                     </li>
                 </ul>
-                <p class="lottery-incentive-hint"
-                   th:if="${inc.nextBulkHint != null}"
-                   th:text="|Buy ${inc.nextBulkHint.gap} more in one purchase to earn +${inc.nextBulkHint.bonus} free tickets.|">
-                    Buy 6 more in one purchase to earn +3 free tickets.
-                </p>
+                <!-- Intentionally no personalised "buy N more" hint for
+                     bulk tiers: the bonus is per-purchase, so the
+                     active-rules list above already conveys every
+                     threshold the player needs to hit on a single buy. -->
+
             </div>
 
             <div class="lottery-incentive-block"
@@ -369,9 +372,9 @@
                     <li th:each="t : ${inc.bulkTiers}"
                         th:text="|buy at least ${t.buy} in one purchase → +${t.bonus} free tickets|"></li>
                 </ul>
-                <p class="lottery-incentive-hint"
-                   th:if="${inc.nextBulkHint != null}"
-                   th:text="|Buy ${inc.nextBulkHint.gap} more in one purchase to earn +${inc.nextBulkHint.bonus} free tickets.|"></p>
+                <!-- No personalised bulk hint — see comment on the
+                     WEIGHTED-daily section above for rationale. -->
+
             </div>
 
             <div class="lottery-incentive-block"

--- a/web/src/test/kotlin/web/controller/LotteryControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/LotteryControllerTest.kt
@@ -189,6 +189,80 @@ class LotteryControllerTest {
         assertTrue(body.error!!.contains("100") && body.error!!.contains("5000"))
     }
 
+    @Test
+    fun `buyWeighted ok surfaces bonusTicketsGranted and totalBonusTickets when service awards them`() {
+        // Regression guard for the silent-drop bug: the service already
+        // awards bonus tickets on bulk-qualifying buys, but the web
+        // response originally stripped them, leaving the client with
+        // no way to tell a +3 bonus from a +0 buy.
+        every { lotteryWebService.buyWeighted(guildId, discordId, 10) } returns
+            BuyOutcome.Ok(
+                ticketCount = 10,
+                totalSpent = 1_000L,
+                newBalance = 9_000L,
+                newPool = 2_000L,
+                bonusTicketsGranted = 3L,
+                totalBonusTickets = 3L,
+            )
+
+        val response = controller.buyWeighted(guildId, BuyWeightedRequest(count = 10), user)
+
+        assertTrue(response.statusCode.is2xxSuccessful)
+        val body = response.body!!
+        assertEquals(true, body.ok)
+        assertEquals(3L, body.bonusTicketsGranted)
+        assertEquals(3L, body.totalBonusTickets)
+        assertNull(body.milestoneBonuses, "no milestones fired → no list in the response")
+    }
+
+    @Test
+    fun `buyWeighted ok carries milestoneBonuses when the service fired any`() {
+        // Each milestone in the response carries its threshold and the
+        // credit top-up; the client toasts one per entry.
+        every { lotteryWebService.buyWeighted(guildId, discordId, 50) } returns
+            BuyOutcome.Ok(
+                ticketCount = 50,
+                totalSpent = 5_000L,
+                newBalance = 5_000L,
+                newPool = 5_100L,
+                bonusTicketsGranted = 0L,
+                totalBonusTickets = 0L,
+                milestoneBonuses = listOf(
+                    database.service.JackpotLotteryService.MilestoneBonus(threshold = 50L, creditsAdded = 100L),
+                ),
+            )
+
+        val response = controller.buyWeighted(guildId, BuyWeightedRequest(count = 50), user)
+
+        val body = response.body!!
+        assertEquals(true, body.ok)
+        assertEquals(1, body.milestoneBonuses?.size)
+        assertEquals(50L, body.milestoneBonuses?.first()?.threshold)
+        assertEquals(100L, body.milestoneBonuses?.first()?.creditsAdded)
+    }
+
+    @Test
+    fun `buyWeighted ok omits bonus fields cleanly when nothing was awarded`() {
+        // Base case: a normal buy with no bulk-tier qualification and
+        // no milestone crossings should leave all three new fields
+        // null so the JS toast falls back to its base copy without
+        // printing "+0 bonus from bulk-buy" garbage.
+        every { lotteryWebService.buyWeighted(guildId, discordId, 1) } returns
+            BuyOutcome.Ok(
+                ticketCount = 1,
+                totalSpent = 100L,
+                newBalance = 9_900L,
+                newPool = 1_100L,
+            )
+
+        val response = controller.buyWeighted(guildId, BuyWeightedRequest(count = 1), user)
+
+        val body = response.body!!
+        assertNull(body.bonusTicketsGranted, "no bulk bonus → null, not zero")
+        assertNull(body.totalBonusTickets, "no cumulative bonus → null, not zero")
+        assertNull(body.milestoneBonuses, "no milestones → null, not empty list")
+    }
+
     // ---- LotteryViewModel.from --------------------------------
 
     @Test
@@ -324,10 +398,14 @@ class LotteryControllerTest {
     }
 
     @Test
-    fun `LotteryViewModel computes nextBulkHint as the gap to the next unmatched tier`() {
-        // Player holds 4 tickets, lowest tier requires 10. Hint
-        // should surface "buy 6 more for +3 free". The +1 tier sits
-        // above 4 so the next-tier rule fires there.
+    fun `LotteryViewModel surfaces bulk tiers in the active rules list but exposes no per-viewer hint`() {
+        // Bulk bonus is per-purchase: a single buy must satisfy
+        // tier.buy on its own, so holding 4 tickets doesn't shrink
+        // the "buy at least 10" threshold to "buy 6 more". An older
+        // implementation computed gap = tier.buy - myTickets and
+        // produced misleading copy — this test pins the contract that
+        // the bulk lever exposes ONLY the active-rules list, no
+        // personalised "buy gap more" hint.
         val incentives = web.view.LotteryIncentivesView(
             bulkTiers = listOf(
                 web.view.BulkBonusTierView(buy = 10L, bonus = 3L),
@@ -339,17 +417,26 @@ class LotteryControllerTest {
         val vm = LotteryViewModel.from(
             weightedSnapshot(myTickets = 4, incentives = incentives)
         )
-        val hint = vm.weighted!!.incentives!!.nextBulkHint
-        assertNotNull(hint)
-        assertEquals(6L, hint!!.gap)
-        assertEquals(3L, hint.bonus)
-        assertEquals(10L, hint.threshold)
+        val panel = vm.weighted!!.incentives
+        assertNotNull(panel)
+        // Active rules cover the per-purchase requirement for every
+        // configured tier.
+        assertEquals(2, panel!!.bulkTiers.size)
+        assertEquals(10L, panel.bulkTiers.first().buy)
+        // The panel shape has no `nextBulkHint` field at all — Kotlin
+        // would fail compilation if a refactor re-introduced one.
+        // Multiplier / milestone hints stay correctly cumulative.
+        assertNull(panel.nextMultiplierHint, "no multiplier tiers configured → no multiplier hint")
+        assertNull(panel.milestoneProgress, "no milestones configured → no progress")
     }
 
     @Test
-    fun `LotteryViewModel returns null nextBulkHint when player already holds top tier`() {
-        // Player holds 30 tickets; tier ceiling is 25. No further
-        // "buy N more" hint to dangle — return null.
+    fun `LotteryViewModel still surfaces bulk tiers regardless of player ticket count`() {
+        // Regression guard against a future refactor that conditions
+        // bulk-tier visibility on myTickets (e.g. only showing tiers
+        // the player hasn't yet "qualified for"). All configured tiers
+        // must surface to every viewer — that's the whole point of
+        // exposing the rules.
         val incentives = web.view.LotteryIncentivesView(
             bulkTiers = listOf(
                 web.view.BulkBonusTierView(buy = 10L, bonus = 3L),
@@ -358,10 +445,10 @@ class LotteryControllerTest {
             multiplierTiers = emptyList(),
             poolMilestones = emptyList(),
         )
-        val vm = LotteryViewModel.from(
+        val panel = LotteryViewModel.from(
             weightedSnapshot(myTickets = 30, incentives = incentives)
-        )
-        assertNull(vm.weighted!!.incentives!!.nextBulkHint)
+        ).weighted!!.incentives!!
+        assertEquals(2, panel.bulkTiers.size)
     }
 
     @Test

--- a/web/src/test/kotlin/web/template/LotteryPlayerTemplateTest.kt
+++ b/web/src/test/kotlin/web/template/LotteryPlayerTemplateTest.kt
@@ -1,5 +1,6 @@
 package web.template
 
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -58,20 +59,47 @@ class LotteryPlayerTemplateTest {
     }
 
     @Test
-    fun `player lottery template renders the next-threshold hint expressions per lever`() {
-        // The hint copy is computed view-side as `nextBulkHint /
-        // nextMultiplierHint`. Pin both expressions so a hint-block
-        // refactor doesn't accidentally drop one side and leave a
-        // half-rendered panel in prod.
-        for (hint in listOf(
-            "inc.nextBulkHint",
-            "inc.nextMultiplierHint",
-        )) {
-            assertTrue(
-                lotteryHtml.contains(hint),
-                "expected $hint reference in the player lottery template",
-            )
-        }
+    fun `player lottery template renders the multiplier next-threshold hint expression`() {
+        // The multiplier lever is correctly cumulative — "hold X more
+        // tickets to reach 1.25×" — so a personalised hint there is
+        // meaningful. Pin the expression so a future hint-block
+        // refactor doesn't silently lose it.
+        assertTrue(
+            lotteryHtml.contains("inc.nextMultiplierHint"),
+            "expected inc.nextMultiplierHint reference in the player lottery template",
+        )
+    }
+
+    @Test
+    fun `player lottery template has no bulk-tier personalised hint expression`() {
+        // Bulk bonus is per-purchase, not cumulative. A previous
+        // implementation rendered "Buy N more in one purchase to earn
+        // +B free" with N = tier.buy - myTickets, which was wrong:
+        // existing holdings don't shrink the threshold. The active-
+        // rules list above already conveys what each tier requires;
+        // no personalised hint should appear anywhere in the template.
+        assertFalse(
+            lotteryHtml.contains("nextBulkHint"),
+            "bulk-tier personalised hint was removed because the gap math is " +
+                "incorrect for a per-purchase reward; do not re-introduce " +
+                "without changing the semantics first",
+        )
+    }
+
+    @Test
+    fun `player lottery template renders 'paid + bonus' breakdown when myBonusTickets is non-zero`() {
+        // The "Your tickets" line shows just `myTickets` when the
+        // player has no bulk-bonus tickets, and "X paid + Y bonus"
+        // when they do. Pin the conditional expression so a refactor
+        // can't silently lose the breakdown on initial page paint.
+        assertTrue(
+            lotteryHtml.contains("snapshot.weighted.myBonusTickets > 0"),
+            "expected the 'Your tickets' line to branch on myBonusTickets > 0",
+        )
+        assertTrue(
+            lotteryHtml.contains("paid +") && lotteryHtml.contains("bonus"),
+            "expected the 'paid + bonus' breakdown copy in the template",
+        )
     }
 
     @Test


### PR DESCRIPTION
## Three bugs reported after PR #508 merged

### 1. Moderation tab bar wrapped badly on narrow viewports

8 tabs in `.mod-subnav` with `flex-wrap: wrap` and no responsive rules → row 2 packed `Casino | Lottery` left then stranded `Leveling` at the right. Switched the bar to a single horizontal scroll strip under 600px (reverts to wrap at ≥600px). Pure CSS, no template/JS change.

### 2. Web bulk-bonus award was silent — looked like it didn't fire

The service correctly persists `bonus_tickets` and the Discord command shows the bonus, but `BuyWeightedResponse` carried only `ticketCount / totalSpent / newBalance / newPool`, and `lottery.js` ignored bonus fields anyway. So buying 10 with `LOTTERY_BULK_TIER1_BUY=10` got the +3 credited in the DB with no on-page acknowledgment — same toast as a +0 buy.

- Response now carries `bonusTicketsGranted`, `totalBonusTickets`, and `milestoneBonuses: List<MilestoneBonusView>`.
- `lottery.js` appends `🎁 +N bonus from bulk-buy!` + per-milestone toasts to the success message.
- "Your tickets" element switches to `X paid + Y bonus` on live update **and** initial page paint.

### 3. `nextBulkHint` gap math was conceptually wrong

Bulk bonus is **per-purchase** — one `/lottery buy N` call must satisfy `N >= tier.buy` on its own, regardless of existing holdings. The controller computed `gap = tier.buy - myTickets`, so a player holding 5 tickets saw "Buy 5 more in one purchase to earn +3 free" when the actual requirement was buy-10.

Dropped the bulk personalised hint entirely. The active-rules list already shows every tier's threshold, which is the only information meaningful for a per-purchase reward. Multiplier and milestone hints stay (those are correctly cumulative).

> Confirmed with the user: bulk tiers remain **highest-only** (not cumulative — buying the tier-3 amount gives only the tier-3 bonus, not tier-1+2+3 stacked). Behaviour unchanged; pinned by the existing `picks the highest matching bulk tier` test.

## Tests

- **`LotteryControllerTest`** (+3 buyWeighted-response cases)
  - surfaces `bonusTicketsGranted` / `totalBonusTickets` when the service awards them
  - carries `milestoneBonuses` when fired
  - omits the new fields cleanly (null, not zero) when nothing was awarded
- **`LotteryControllerTest`** (2 view-model tests rewritten)
  - bulk tiers surface in active-rules list but expose no per-viewer hint (Kotlin compiler now enforces — the field is gone)
  - bulk tiers stay visible regardless of viewer ticket count (regression guard)
- **`LotteryPlayerTemplateTest`**
  - removed `inc.nextBulkHint` from hint-presence list
  - new: template has NO `nextBulkHint` expression anywhere (regression guard)
  - new: `paid + bonus` conditional renders when `myBonusTickets > 0`
- **`JackpotLotteryServiceTest`** (+1 case)
  - `accumulates bonusTickets on the same ticket row across multiple bulk-qualifying buys` — two successive 10-ticket buys end at `bonusTickets = 6`, not 3 (regression guard against an overwrite refactor)

## Test plan

- [x] `./gradlew :web:test :database:test`
- [ ] Manual: resize a moderation page to ~360 px and confirm the tab strip scrolls horizontally with no orphan tab.
- [ ] Manual: configure `LOTTERY_BULK_TIER1_BUY=10` / `LOTTERY_BULK_TIER1_BONUS=3`, open a TICKET_WEIGHTED lottery, buy 10 tickets via the web form. Toast shows `🎁 +3 bonus from bulk-buy!`; "Your tickets" reads `10 paid + 3 bonus`.
- [ ] Manual: with 5 tickets held, confirm no "Buy 5 more" line on the lottery page; active rules still list the tier 1 requirement clearly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mib78RPKH1yRW234Zwugjs)_