### PR TITLE
fix(lottery): nav drawer stacking, additive embed rebuild, top holders include bonus tickets

### DIFF
--- a/discord-bot/src/main/kotlin/bot/toby/modal/modals/JackpotAdminModal.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/modal/modals/JackpotAdminModal.kt
@@ -1,7 +1,6 @@
 package bot.toby.modal.modals
 
 import bot.toby.scheduling.LotteryAnnouncer
-import common.logging.DiscordLogger
 import core.modal.Modal
 import core.modal.ModalContext
 import database.service.JackpotLotteryService
@@ -31,7 +30,7 @@ class JackpotAdminModal(
 ) : Modal {
     override val name = MODAL_NAME
 
-    private val logger: DiscordLogger = DiscordLogger.createLogger(this::class.java)
+    // `logger` is inherited from `Modal : Loggable`.
 
     override fun handle(ctx: ModalContext, deleteDelay: Int) {
         val event = ctx.event

--- a/discord-bot/src/main/kotlin/bot/toby/modal/modals/JackpotAdminModal.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/modal/modals/JackpotAdminModal.kt
@@ -1,9 +1,12 @@
 package bot.toby.modal.modals
 
+import bot.toby.scheduling.LotteryAnnouncer
+import common.logging.DiscordLogger
 import core.modal.Modal
 import core.modal.ModalContext
 import database.service.JackpotLotteryService
 import database.service.JackpotLotteryService.OpenOutcome
+import database.service.LotteryHelper
 import org.springframework.stereotype.Component
 
 /**
@@ -13,16 +16,27 @@ import org.springframework.stereotype.Component
  * autocomplete) with a single form. All four fields are numeric and
  * validated client-side by Discord (modal `setRequiredRange`); the
  * service still re-validates server-side via [OpenOutcome.InvalidParams].
+ *
+ * On a successful open, the modal also posts a channel announce via
+ * [LotteryAnnouncer.announceCycle] so the lottery surfaces in the
+ * configured announce channel (with the Active incentives field, the
+ * Buy Tickets action row, and the wide ping per `LOTTERY_PING_MODE`).
+ * Without this, admin-fired weighted lotteries were silent on Discord
+ * — the open went through but no embed appeared anywhere.
  */
 @Component
 class JackpotAdminModal(
     private val jackpotLotteryService: JackpotLotteryService,
+    private val lotteryAnnouncer: LotteryAnnouncer,
 ) : Modal {
     override val name = MODAL_NAME
 
+    private val logger: DiscordLogger = DiscordLogger.createLogger(this::class.java)
+
     override fun handle(ctx: ModalContext, deleteDelay: Int) {
         val event = ctx.event
-        val guildId = ctx.guild.idLong
+        val guild = ctx.guild
+        val guildId = guild.idLong
 
         val ticketPrice = event.getValue(FIELD_TICKET_PRICE)?.asString?.toLongOrNull()
         val duration = event.getValue(FIELD_DURATION_HOURS)?.asString?.toLongOrNull()
@@ -44,11 +58,33 @@ class JackpotAdminModal(
         val drainPct = drainPctRaw / 100.0
 
         when (val result = jackpotLotteryService.openLottery(guildId, ticketPrice, duration, winners, drainPct)) {
-            is OpenOutcome.Ok -> event.hook.sendMessage(
-                "Opened lottery. Seeded with **${result.seeded}** credits from the jackpot pool. " +
-                    "Tickets: **$ticketPrice** credits each. Winners: **$winners**. " +
-                    "Closes after **$duration** hours (admin must run `/jackpotadmin lottery_draw`)."
-            ).setEphemeral(true).queue()
+            is OpenOutcome.Ok -> {
+                event.hook.sendMessage(
+                    "Opened lottery. Seeded with **${result.seeded}** credits from the jackpot pool. " +
+                        "Tickets: **$ticketPrice** credits each. Winners: **$winners**. " +
+                        "Closes after **$duration** hours (admin must run `/jackpotadmin lottery_draw`)."
+                ).setEphemeral(true).queue()
+                // Post the channel announce so members actually see the
+                // lottery in Discord — without this the open is silent
+                // beyond the ephemeral confirmation to the admin.
+                runCatching {
+                    lotteryAnnouncer.announceCycle(
+                        guild = guild,
+                        mode = LotteryHelper.MODE_WEIGHTED,
+                        priorOutcome = null,
+                        openOutcome = LotteryAnnouncer.OpenSummary.Ok(
+                            lotteryId = result.lottery.id,
+                            seeded = result.seeded,
+                            ticketPrice = result.lottery.ticketPrice,
+                            poolAmount = result.lottery.poolAmount,
+                        ),
+                    )
+                }.onFailure {
+                    logger.warn(
+                        "Admin-fired lottery opened for guild $guildId but announce failed: ${it.message}"
+                    )
+                }
+            }
             OpenOutcome.AlreadyOpen ->
                 event.hook.sendMessage("A lottery is already open for this guild. Draw or cancel it first.")
                     .setEphemeral(true).queue()

--- a/discord-bot/src/main/kotlin/bot/toby/scheduling/LotteryAnnouncer.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/scheduling/LotteryAnnouncer.kt
@@ -285,16 +285,29 @@ class LotteryAnnouncer @Autowired constructor(
         val freshIncentives = if (mode == LotteryHelper.MODE_WEIGHTED) {
             renderActiveIncentives(guildId)
         } else null
+        var sawIncentivesField = false
         previous.fields.forEach { field ->
             when (field.name) {
                 TODAYS_DRAW_FIELD -> builder.addField(TODAYS_DRAW_FIELD, freshTodayBody, false)
-                ACTIVE_INCENTIVES_FIELD -> if (freshIncentives != null) {
-                    builder.addField(ACTIVE_INCENTIVES_FIELD, freshIncentives, false)
-                } else {
-                    builder.addField(field)
+                ACTIVE_INCENTIVES_FIELD -> {
+                    sawIncentivesField = true
+                    if (freshIncentives != null) {
+                        builder.addField(ACTIVE_INCENTIVES_FIELD, freshIncentives, false)
+                    } else {
+                        builder.addField(field)
+                    }
                 }
                 else -> builder.addField(field)
             }
+        }
+        // Backfill the Active incentives field on legacy embeds that
+        // were posted before the feature existed (or before tiers were
+        // configured). Without this, an old open lottery would never
+        // gain the field — the 5-minute refresh only updates what's
+        // already there. Only applies to TICKET_WEIGHTED draws since
+        // NUMBER_MATCH embeds intentionally never carry the field.
+        if (!sawIncentivesField && freshIncentives != null) {
+            builder.addField(ACTIVE_INCENTIVES_FIELD, freshIncentives, false)
         }
         return builder.build()
     }

--- a/discord-bot/src/test/kotlin/bot/toby/modal/modals/JackpotAdminModalTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/modal/modals/JackpotAdminModalTest.kt
@@ -1,0 +1,192 @@
+package bot.toby.modal.modals
+
+import bot.toby.scheduling.LotteryAnnouncer
+import core.modal.ModalContext
+import database.dto.JackpotLotteryDto
+import database.service.JackpotLotteryService
+import database.service.JackpotLotteryService.OpenOutcome
+import database.service.LotteryHelper
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.Message
+import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent
+import net.dv8tion.jda.api.interactions.InteractionHook
+import net.dv8tion.jda.api.interactions.modals.ModalMapping
+import net.dv8tion.jda.api.requests.restaction.WebhookMessageCreateAction
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * Pins the modal's announce wiring. Before this regression guard, the
+ * admin lottery-open flow opened the lottery silently — only an
+ * ephemeral "Opened" message went to the admin, and no embed reached
+ * the announce channel. Tests verify:
+ *  - Successful open routes through `LotteryAnnouncer.announceCycle`
+ *    with `mode = WEIGHTED`, no prior outcome, and the open summary
+ *    populated from the service result.
+ *  - Failure outcomes (AlreadyOpen / EmptyPool / InvalidParams) do
+ *    NOT call announceCycle — matching pre-fix behaviour for those
+ *    branches.
+ */
+class JackpotAdminModalTest {
+
+    private val guildId = 100L
+
+    private lateinit var jackpotLotteryService: JackpotLotteryService
+    private lateinit var lotteryAnnouncer: LotteryAnnouncer
+    private lateinit var modal: JackpotAdminModal
+    private lateinit var ctx: ModalContext
+    private lateinit var event: ModalInteractionEvent
+    private lateinit var hook: InteractionHook
+    private lateinit var guild: Guild
+    private val messageSlot = slot<String>()
+
+    @BeforeEach
+    fun setup() {
+        jackpotLotteryService = mockk()
+        lotteryAnnouncer = mockk(relaxed = true)
+        modal = JackpotAdminModal(jackpotLotteryService, lotteryAnnouncer)
+        hook = mockk(relaxed = true)
+        event = mockk(relaxed = true)
+        guild = mockk(relaxed = true) {
+            every { idLong } returns guildId
+        }
+
+        every { event.hook } returns hook
+
+        ctx = mockk {
+            every { this@mockk.event } returns this@JackpotAdminModalTest.event
+            every { this@mockk.guild } returns guild
+        }
+
+        @Suppress("UNCHECKED_CAST")
+        val sendAction = mockk<WebhookMessageCreateAction<Message>>(relaxed = true)
+        every { hook.sendMessage(capture(messageSlot)) } returns sendAction
+        every { sendAction.setEphemeral(true) } returns sendAction
+        every { sendAction.queue() } just Runs
+
+        // Default field stubs — happy path; individual tests override.
+        stubField(JackpotAdminModal.FIELD_TICKET_PRICE, "100")
+        stubField(JackpotAdminModal.FIELD_DURATION_HOURS, "24")
+        stubField(JackpotAdminModal.FIELD_WINNER_COUNT, "3")
+        stubField(JackpotAdminModal.FIELD_DRAIN_PCT, "10")
+    }
+
+    private fun stubField(fieldName: String, value: String) {
+        val mapping = mockk<ModalMapping> { every { asString } returns value }
+        every { event.getValue(fieldName) } returns mapping
+    }
+
+    @Test
+    fun `name is jackpot_admin_lottery_open`() {
+        assertEquals("jackpot_admin_lottery_open", modal.name)
+    }
+
+    @Test
+    fun `handle on OpenOutcome Ok calls LotteryAnnouncer announceCycle with mode=WEIGHTED`() {
+        // The lottery row carries the data the announce needs — id,
+        // ticketPrice, poolAmount — so the embed surfaces the live
+        // numbers and the watermark can be persisted via the onSent
+        // callback inside announceCycle.
+        val opened = JackpotLotteryDto(
+            id = 7L, guildId = guildId, ticketPrice = 100L, poolAmount = 1_000L,
+            winnerCount = 3, status = JackpotLotteryDto.STATUS_OPEN,
+            mode = JackpotLotteryDto.MODE_TICKET_WEIGHTED,
+        )
+        every {
+            jackpotLotteryService.openLottery(guildId, 100L, 24L, 3, 0.10)
+        } returns OpenOutcome.Ok(lottery = opened, seeded = 1_000L)
+
+        modal.handle(ctx, 0)
+
+        // Ephemeral confirmation still goes to the admin.
+        assertTrue(messageSlot.captured.contains("Opened lottery"))
+        // And announce gets posted with the right shape.
+        verify(exactly = 1) {
+            lotteryAnnouncer.announceCycle(
+                guild = guild,
+                mode = LotteryHelper.MODE_WEIGHTED,
+                priorOutcome = null,
+                openOutcome = match<LotteryAnnouncer.OpenSummary.Ok> {
+                    it.lotteryId == 7L &&
+                        it.seeded == 1_000L &&
+                        it.ticketPrice == 100L &&
+                        it.poolAmount == 1_000L
+                },
+            )
+        }
+    }
+
+    @Test
+    fun `handle on AlreadyOpen does not call announceCycle`() {
+        every {
+            jackpotLotteryService.openLottery(guildId, 100L, 24L, 3, 0.10)
+        } returns OpenOutcome.AlreadyOpen
+
+        modal.handle(ctx, 0)
+
+        assertTrue(messageSlot.captured.contains("already open"))
+        verify(exactly = 0) {
+            lotteryAnnouncer.announceCycle(any(), any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `handle on EmptyPool does not call announceCycle`() {
+        every {
+            jackpotLotteryService.openLottery(guildId, 100L, 24L, 3, 0.10)
+        } returns OpenOutcome.EmptyPool
+
+        modal.handle(ctx, 0)
+
+        assertTrue(messageSlot.captured.contains("Jackpot pool is empty"))
+        verify(exactly = 0) {
+            lotteryAnnouncer.announceCycle(any(), any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `handle on InvalidParams does not call announceCycle`() {
+        every {
+            jackpotLotteryService.openLottery(guildId, 100L, 24L, 3, 0.10)
+        } returns OpenOutcome.InvalidParams("ticket price must be > 0")
+
+        modal.handle(ctx, 0)
+
+        assertTrue(messageSlot.captured.contains("Invalid params"))
+        verify(exactly = 0) {
+            lotteryAnnouncer.announceCycle(any(), any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `handle swallows announceCycle failures so the open is not rolled back`() {
+        // The open already succeeded by the time we try to announce.
+        // If JDA throws (channel resolution failure, permission, etc),
+        // the lottery must still be considered opened — the admin
+        // gets their ephemeral confirmation and life goes on.
+        val opened = JackpotLotteryDto(
+            id = 7L, guildId = guildId, ticketPrice = 100L, poolAmount = 1_000L,
+            winnerCount = 3, status = JackpotLotteryDto.STATUS_OPEN,
+            mode = JackpotLotteryDto.MODE_TICKET_WEIGHTED,
+        )
+        every {
+            jackpotLotteryService.openLottery(guildId, 100L, 24L, 3, 0.10)
+        } returns OpenOutcome.Ok(lottery = opened, seeded = 1_000L)
+        every {
+            lotteryAnnouncer.announceCycle(any(), any(), any(), any())
+        } throws RuntimeException("channel resolution failed")
+
+        // Should not throw — the runCatching in the modal swallows.
+        modal.handle(ctx, 0)
+
+        assertTrue(messageSlot.captured.contains("Opened lottery"))
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/modal/modals/JackpotAdminModalTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/modal/modals/JackpotAdminModalTest.kt
@@ -63,7 +63,12 @@ class JackpotAdminModalTest {
 
         ctx = mockk {
             every { this@mockk.event } returns this@JackpotAdminModalTest.event
-            every { this@mockk.guild } returns guild
+            // Qualify the RHS — inside `mockk<ModalContext> { … }` the
+            // receiver is the ctx mock, which has its own `guild`
+            // property. An unqualified `guild` would resolve to the
+            // un-stubbed mock getter rather than the outer test field
+            // and blow up with "no answer provided for ModalContext.getGuild()".
+            every { this@mockk.guild } returns this@JackpotAdminModalTest.guild
         }
 
         @Suppress("UNCHECKED_CAST")

--- a/discord-bot/src/test/kotlin/bot/toby/scheduling/LotteryAnnouncerTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/scheduling/LotteryAnnouncerTest.kt
@@ -32,6 +32,7 @@ import net.dv8tion.jda.api.requests.restaction.MessageEditAction
 import net.dv8tion.jda.api.utils.messages.MessageCreateData
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -946,6 +947,130 @@ class LotteryAnnouncerTest {
             val after = announcer.incentivesDigest(guildId)
 
             assertFalse(before == after, "edited tier must produce a different digest")
+        }
+
+        @Test
+        fun `weighted refresh appends the Active incentives field when the previous embed lacks it`() {
+            // Legacy embed: posted before the incentives feature
+            // existed, so it carries only TODAYS_DRAW_FIELD. After
+            // tiers are configured the next refresh must BACKFILL the
+            // missing field, not silently drop it. Without the
+            // additive rebuild, an existing open weighted lottery
+            // would never gain the field — only fresh daily-cycle
+            // opens would.
+            stubConfig(ConfigDto.Configurations.LOTTERY_BULK_TIER1_BUY, "10")
+            stubConfig(ConfigDto.Configurations.LOTTERY_BULK_TIER1_BONUS, "3")
+            every { guild.getTextChannelById(777L) } returns channel
+
+            val previousEmbed = EmbedBuilder()
+                .setTitle("🎟️ Daily Lottery — Test Guild")
+                .addField(
+                    LotteryAnnouncer.TODAYS_DRAW_FIELD,
+                    "**1000** credits in the pool · Ticket: **50** · Mode: **Top-3 weighted** · Closes 24h.",
+                    false,
+                )
+                .build()
+            assertTrue(
+                previousEmbed.fields.none { it.name == LotteryAnnouncer.ACTIVE_INCENTIVES_FIELD },
+                "preconditions: legacy embed must NOT carry the incentives field",
+            )
+            val message: Message = mockk(relaxed = true)
+            every { message.embeds } returns listOf(previousEmbed)
+
+            val retrieveAction: RestAction<Message> = mockk(relaxed = true)
+            every { channel.retrieveMessageById(999L) } returns retrieveAction
+            every {
+                retrieveAction.queue(any<java.util.function.Consumer<Message>>(), any())
+            } answers {
+                firstArg<java.util.function.Consumer<Message>>().accept(message)
+            }
+
+            val editAction: MessageEditAction = mockk(relaxed = true)
+            val editedEmbedSlot = slot<MessageEmbed>()
+            every { message.editMessageEmbeds(capture(editedEmbedSlot)) } returns editAction
+            every { editAction.setComponents(any<Collection<MessageTopLevelComponent>>()) } returns editAction
+            every {
+                editAction.queue(any<java.util.function.Consumer<Message>>(), any())
+            } answers {
+                firstArg<java.util.function.Consumer<Message>>().accept(message)
+            }
+
+            val lottery = openLottery(
+                poolAmount = 1_000L,
+                announcedPoolAmount = 1_000L,
+                mode = JackpotLotteryDto.MODE_TICKET_WEIGHTED,
+                announcedIncentivesDigest = null,
+            )
+            announcer.refreshAnnouncement(guild, lottery)
+
+            // The rebuilt embed must now carry the field, populated
+            // from live config.
+            val incentivesField = editedEmbedSlot.captured.fields
+                .firstOrNull { it.name == LotteryAnnouncer.ACTIVE_INCENTIVES_FIELD }
+            assertNotNull(incentivesField, "legacy embed should be backfilled with the incentives field")
+            assertTrue(
+                incentivesField!!.value!!.contains("buy ≥10"),
+                "backfilled field should reflect live tier config: ${incentivesField.value}",
+            )
+            // TODAYS_DRAW field is still updated as before — backfill
+            // is additive, not replacement of the existing update path.
+            assertTrue(
+                editedEmbedSlot.captured.fields.any { it.name == LotteryAnnouncer.TODAYS_DRAW_FIELD },
+                "TODAYS_DRAW field should still be present",
+            )
+        }
+
+        @Test
+        fun `number-match refresh does not append the Active incentives field`() {
+            // Regression guard against the additive rebuild leaking
+            // into NUMBER_MATCH embeds. Those intentionally never
+            // carry the field because incentives don't apply at
+            // runtime (one ticket per user per draw).
+            stubConfig(ConfigDto.Configurations.LOTTERY_BULK_TIER1_BUY, "10")
+            stubConfig(ConfigDto.Configurations.LOTTERY_BULK_TIER1_BONUS, "3")
+            every { guild.getTextChannelById(777L) } returns channel
+
+            val previousEmbed = EmbedBuilder()
+                .setTitle("🎟️ Daily Lottery — Test Guild")
+                .addField(
+                    LotteryAnnouncer.TODAYS_DRAW_FIELD,
+                    "**500** credits in the pool · Ticket: **50** · Mode: **Pick 5 of 49** · Closes 24h.",
+                    false,
+                )
+                .build()
+            val message: Message = mockk(relaxed = true)
+            every { message.embeds } returns listOf(previousEmbed)
+
+            val retrieveAction: RestAction<Message> = mockk(relaxed = true)
+            every { channel.retrieveMessageById(999L) } returns retrieveAction
+            every {
+                retrieveAction.queue(any<java.util.function.Consumer<Message>>(), any())
+            } answers {
+                firstArg<java.util.function.Consumer<Message>>().accept(message)
+            }
+
+            val editAction: MessageEditAction = mockk(relaxed = true)
+            val editedEmbedSlot = slot<MessageEmbed>()
+            every { message.editMessageEmbeds(capture(editedEmbedSlot)) } returns editAction
+            every { editAction.setComponents(any<Collection<MessageTopLevelComponent>>()) } returns editAction
+            every {
+                editAction.queue(any<java.util.function.Consumer<Message>>(), any())
+            } answers {
+                firstArg<java.util.function.Consumer<Message>>().accept(message)
+            }
+
+            val lottery = openLottery(
+                poolAmount = 600L,
+                announcedPoolAmount = 500L,
+                mode = JackpotLotteryDto.MODE_NUMBER_MATCH,
+                announcedIncentivesDigest = null,
+            )
+            announcer.refreshAnnouncement(guild, lottery)
+
+            assertTrue(
+                editedEmbedSlot.captured.fields.none { it.name == LotteryAnnouncer.ACTIVE_INCENTIVES_FIELD },
+                "NUMBER_MATCH embeds must never carry the Active incentives field",
+            )
         }
 
         @Test

--- a/web/src/main/kotlin/web/controller/LotteryController.kt
+++ b/web/src/main/kotlin/web/controller/LotteryController.kt
@@ -316,6 +316,10 @@ data class LotteryViewModel(
     data class TopHolder(
         val discordId: Long,
         val ticketCount: Int,
+        /** Bulk-bonus tickets the holder has accumulated. The template
+         *  renders "X paid + Y bonus" when this is non-zero, matching
+         *  the "Your tickets" line treatment. */
+        val bonusTickets: Long,
         val name: String,
         val avatarUrl: String?,
         val title: String?,
@@ -355,7 +359,7 @@ data class LotteryViewModel(
                     myBonusTickets = myBonus,
                     mySpent = snap.weightedMyTicket?.spent ?: 0L,
                     topHolders = snap.weightedTopHolders.map {
-                        TopHolder(it.discordId, it.ticketCount, it.name, it.avatarUrl, it.title)
+                        TopHolder(it.discordId, it.ticketCount, it.bonusTickets, it.name, it.avatarUrl, it.title)
                     },
                     incentives = incentives,
                 )

--- a/web/src/main/kotlin/web/service/LotteryWebService.kt
+++ b/web/src/main/kotlin/web/service/LotteryWebService.kt
@@ -77,6 +77,14 @@ class LotteryWebService(
     data class TopHolder(
         val discordId: Long,
         val ticketCount: Int,
+        /**
+         * Bulk-bonus tickets the holder has accumulated on this
+         * lottery. Surfaced alongside `ticketCount` so the player
+         * page renders the same "X paid + Y bonus" breakdown the
+         * "Your tickets" line already uses, and so the leaderboard
+         * sort can use effective weight rather than just paid count.
+         */
+        val bonusTickets: Long,
         val name: String,
         val avatarUrl: String?,
         val title: String?,
@@ -93,7 +101,15 @@ class LotteryWebService(
         val weightedOpen = jackpotLotteryService.getOpenWeighted(guildId)
         val weightedTickets = jackpotLotteryService.ticketsForOpenWeighted(guildId)
         val weightedMyTicket = weightedTickets.firstOrNull { it.discordId == discordId }
-        val weightedTopRaw = weightedTickets.sortedByDescending { it.ticketCount }.take(5)
+        // Sort by effective ticket weight (paid + bonus) so a buyer who
+        // earned bulk bonuses isn't ranked below a smaller-spending
+        // holder. Mirrors the per-ticket draw weight at the conceptual
+        // level (the multiplier tier isn't applied here — top-5 is a
+        // display ordering, not the actual draw, and the multiplier
+        // gets baked into the real draw via JackpotLotteryService).
+        val weightedTopRaw = weightedTickets
+            .sortedByDescending { it.ticketCount + it.bonusTickets }
+            .take(5)
         val displays = memberLookupHelper.resolveAll(guildId, weightedTopRaw.map { it.discordId })
         val weightedTop = weightedTopRaw.map { ticket ->
             val display = displays[ticket.discordId]
@@ -109,6 +125,7 @@ class LotteryWebService(
             TopHolder(
                 discordId = ticket.discordId,
                 ticketCount = ticket.ticketCount,
+                bonusTickets = ticket.bonusTickets,
                 name = display?.name ?: memberLookupHelper.fallbackName(ticket.discordId),
                 avatarUrl = display?.avatarUrl,
                 title = title,

--- a/web/src/main/resources/static/css/nav.css
+++ b/web/src/main/resources/static/css/nav.css
@@ -335,7 +335,12 @@ nav {
 
         transform: translateX(100%);
         transition: transform 0.22s ease-out;
-        z-index: 50;
+        /* Stacking floor that beats any per-page chrome — the
+           `.mod-subnav` tab bar was visibly punching through the
+           drawer at z-index 50 because page-level rules can hit
+           higher values. 1000 leaves plenty of headroom above the
+           next-highest in-app rule (60 at line 306). */
+        z-index: 1000;
     }
     .nav-links.open { transform: translateX(0); }
 
@@ -465,13 +470,14 @@ nav {
         min-height: var(--tap-min);
     }
 
-    /* Backdrop. */
+    /* Backdrop. Sits one step below the drawer so the drawer is
+       clearly on top, but well above any per-page chrome. */
     .nav-backdrop {
         display: block;
         position: fixed;
         inset: 0;
         background: rgba(10, 10, 20, 0.55);
-        z-index: 40;
+        z-index: 999;
         animation: nav-backdrop-fade-in 0.18s ease-out;
     }
     .nav-backdrop[hidden] { display: none; }

--- a/web/src/main/resources/templates/lottery.html
+++ b/web/src/main/resources/templates/lottery.html
@@ -302,7 +302,9 @@
                     <div th:replace="~{fragments/memberCell :: cell(${h.name}, ${h.avatarUrl})}"></div>
                     <span th:if="${h.title != null}" class="lb-title-pill" th:text="${h.title}"></span>
                     <span class="lottery-ticket-pill">
-                        <strong th:text="${h.ticketCount}">0</strong>
+                        <strong th:text="${h.bonusTickets > 0}
+                                         ? |${h.ticketCount} paid + ${h.bonusTickets} bonus|
+                                         : ${h.ticketCount}">0</strong>
                         <span class="muted">tickets</span>
                     </span>
                 </li>
@@ -419,7 +421,9 @@
                     <div th:replace="~{fragments/memberCell :: cell(${h.name}, ${h.avatarUrl})}"></div>
                     <span th:if="${h.title != null}" class="lb-title-pill" th:text="${h.title}"></span>
                     <span class="lottery-ticket-pill">
-                        <strong th:text="${h.ticketCount}">0</strong>
+                        <strong th:text="${h.bonusTickets > 0}
+                                         ? |${h.ticketCount} paid + ${h.bonusTickets} bonus|
+                                         : ${h.ticketCount}">0</strong>
                         <span class="muted">tickets</span>
                     </span>
                 </li>

--- a/web/src/test/kotlin/web/controller/LotteryControllerTest.kt
+++ b/web/src/test/kotlin/web/controller/LotteryControllerTest.kt
@@ -533,6 +533,49 @@ class LotteryControllerTest {
     }
 
     @Test
+    fun `LotteryViewModel TopHolder exposes bonusTickets from the snapshot`() {
+        // The view-model layer must forward bonus tickets so the
+        // template can render the "X paid + Y bonus" breakdown on the
+        // top-holders list. Without this, the controller's TopHolder
+        // would always present 0 bonus regardless of what the service
+        // returned.
+        val snap = LotteryWebService.LotteryPageSnapshot(
+            dailyOpen = null,
+            dailyLatestDrawn = null,
+            dailyMyTicket = null,
+            dailyTicketBuyers = 0,
+            weightedOpen = JackpotLotteryDto(
+                id = 1L, guildId = guildId, ticketPrice = 100L, poolAmount = 0L,
+                winnerCount = 3, status = JackpotLotteryDto.STATUS_OPEN,
+                mode = JackpotLotteryDto.MODE_TICKET_WEIGHTED,
+            ),
+            weightedMyTicket = null,
+            weightedTopHolders = listOf(
+                LotteryWebService.TopHolder(
+                    discordId = 7L,
+                    ticketCount = 10,
+                    bonusTickets = 3L,
+                    name = "Whale",
+                    avatarUrl = null,
+                    title = null,
+                ),
+            ),
+            weightedTotalTickets = 13L,
+            pickCount = 5,
+            numberMax = 49,
+            tierPercents = listOf(60, 25, 10, 5),
+            revenueJackpotPct = 30L,
+            dailyMode = "WEIGHTED",
+            dailyEnabled = true,
+        )
+
+        val vm = LotteryViewModel.from(snap)
+        val holder = vm.weighted!!.topHolders.single()
+        assertEquals(10, holder.ticketCount)
+        assertEquals(3L, holder.bonusTickets)
+    }
+
+    @Test
     fun `LotteryViewModel exposes the player's bonus tickets on the weighted view`() {
         // Bonus tickets accumulated from past bulk buys must be
         // visible to the template so the "X paid + Y bonus" copy can

--- a/web/src/test/kotlin/web/service/LotteryWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/LotteryWebServiceTest.kt
@@ -124,4 +124,56 @@ class LotteryWebServiceTest {
         assertEquals(50L, snap.weightedIncentives.poolMilestones.first().tickets)
         assertEquals(10L, snap.weightedIncentives.poolMilestones.first().pct)
     }
+
+    @Test
+    fun `snapshot ranks top holders by ticketCount + bonusTickets so big-bonus buyers don't fall off the leaderboard`() {
+        // Three buyers: A holds 20 paid, B holds 10 paid + 15 bonus
+        // (effective 25), C holds 15 paid. Without the bonus-aware
+        // sort, B ranks third (10 < 15 < 20). With it, B is first.
+        every { jackpotLotteryService.getOpenWeighted(guildId) } returns JackpotLotteryDto(
+            id = 1L, guildId = guildId,
+            status = JackpotLotteryDto.STATUS_OPEN,
+            mode = JackpotLotteryDto.MODE_TICKET_WEIGHTED,
+        )
+        every { jackpotLotteryService.ticketsForOpenWeighted(guildId) } returns listOf(
+            database.dto.JackpotLotteryTicketDto(
+                lotteryId = 1L, discordId = 1L, ticketCount = 20, spent = 2_000L,
+                bonusTickets = 0L,
+            ),
+            database.dto.JackpotLotteryTicketDto(
+                lotteryId = 1L, discordId = 2L, ticketCount = 10, spent = 1_000L,
+                bonusTickets = 15L,
+            ),
+            database.dto.JackpotLotteryTicketDto(
+                lotteryId = 1L, discordId = 3L, ticketCount = 15, spent = 1_500L,
+                bonusTickets = 0L,
+            ),
+        )
+
+        val snap = service.snapshot(guildId, discordId)
+
+        val ranked = snap.weightedTopHolders.map { it.discordId }
+        assertEquals(listOf(2L, 1L, 3L), ranked, "effective weights: 25, 20, 15")
+    }
+
+    @Test
+    fun `snapshot TopHolder carries bonusTickets through to the view model`() {
+        every { jackpotLotteryService.getOpenWeighted(guildId) } returns JackpotLotteryDto(
+            id = 1L, guildId = guildId,
+            status = JackpotLotteryDto.STATUS_OPEN,
+            mode = JackpotLotteryDto.MODE_TICKET_WEIGHTED,
+        )
+        every { jackpotLotteryService.ticketsForOpenWeighted(guildId) } returns listOf(
+            database.dto.JackpotLotteryTicketDto(
+                lotteryId = 1L, discordId = 7L, ticketCount = 10, spent = 1_000L,
+                bonusTickets = 3L,
+            ),
+        )
+
+        val snap = service.snapshot(guildId, discordId)
+
+        val holder = snap.weightedTopHolders.single()
+        assertEquals(10, holder.ticketCount)
+        assertEquals(3L, holder.bonusTickets)
+    }
 }

--- a/web/src/test/kotlin/web/template/LotteryPlayerTemplateTest.kt
+++ b/web/src/test/kotlin/web/template/LotteryPlayerTemplateTest.kt
@@ -87,6 +87,24 @@ class LotteryPlayerTemplateTest {
     }
 
     @Test
+    fun `player lottery template renders 'paid + bonus' breakdown on top holders when h_bonusTickets is non-zero`() {
+        // Each top-holder row's ticket pill must match the "Your
+        // tickets" treatment: when the holder has bonus tickets, show
+        // "X paid + Y bonus", else just the paid count. Pin the
+        // expression in both render sites (WEIGHTED daily + Featured
+        // event card) — the conditional appears twice in the template.
+        assertTrue(
+            lotteryHtml.contains("h.bonusTickets > 0"),
+            "expected the top-holders pill to branch on h.bonusTickets > 0",
+        )
+        val occurrences = "h.bonusTickets > 0".toRegex().findAll(lotteryHtml).count()
+        assertTrue(
+            occurrences >= 2,
+            "expected the bonus-tickets conditional in both top-holder render sites; found $occurrences",
+        )
+    }
+
+    @Test
     fun `player lottery template renders 'paid + bonus' breakdown when myBonusTickets is non-zero`() {
         // The "Your tickets" line shows just `myTickets` when the
         // player has no bulk-bonus tickets, and "X paid + Y bonus"


### PR DESCRIPTION
## Three bugs reported after #509

### 1. Nav drawer bleeds through the moderation tab bar

`.nav-links` was at `z-index: 50` and the backdrop at `40` — too low to reliably cover anything a page might emit. Bumped the drawer to `1000` and the backdrop to `999`. Pure CSS.

### 2. The configured incentive settings never appeared in the lottery embed

Two parallel issues:

- **`rebuildEmbed` was replace-only.** It iterated `previous.fields` and only swapped in a fresh `ACTIVE_INCENTIVES_FIELD` value when the field already existed. Embeds posted before the feature/before tiers were configured never gained the field on the 5-minute refresh — only a fresh daily-cycle open would. Now the rebuild tracks `sawIncentivesField`; if missing and the lottery is TICKET_WEIGHTED with live incentives, the field is appended after the loop. NUMBER_MATCH stays field-free (regression-guarded).
  - **Doesn't break the existing update flow**: `TODAYS_DRAW_FIELD` still gets re-rendered, an existing `ACTIVE_INCENTIVES_FIELD` still gets replaced, other fields still get copied verbatim. The backfill only triggers when the field is missing from the previous embed.

- **`/jackpotadmin lottery_open` posted no channel announce.** The admin modal only sent the ephemeral confirmation — the lottery opened silently with no embed anywhere. Now on `OpenOutcome.Ok` the modal routes through `LotteryAnnouncer.announceCycle` with `mode = WEIGHTED, priorOutcome = null`, posting the full announce (incl. active-incentives field). `runCatching` swallows announce failures so the open isn't rolled back.

### 3. Top holders ignored bonus tickets

`weightedTopHolders` sorted by `ticketCount` only, and `TopHolder` carried no bonus field — a buyer with 10 paid + 15 bonus ranked below a 20-paid buyer, and the template rendered just `${h.ticketCount}` with no breakdown.

- `LotteryWebService.TopHolder` carries `bonusTickets`.
- Sort uses `ticketCount + bonusTickets`.
- Controller `TopHolder` view forwards the field.
- `templates/lottery.html` renders the same `X paid + Y bonus` conditional the "Your tickets" line uses, on both render sites (WEIGHTED daily + Featured event card).

## Tests

- **`LotteryAnnouncerTest`** — refresh backfills the missing field on legacy TICKET_WEIGHTED embeds; NUMBER_MATCH refresh stays field-free.
- **`JackpotAdminModalTest`** (new) — announce fires on `Ok` with `mode = WEIGHTED`; AlreadyOpen/EmptyPool/InvalidParams branches skip announce; announce failures are swallowed (open success isn't rolled back).
- **`LotteryWebServiceTest`** — top holders ranked by `ticketCount + bonusTickets` so a big-bonus buyer outranks a paid-only buyer; `TopHolder.bonusTickets` forwarded.
- **`LotteryControllerTest`** — view-model `TopHolder` exposes `bonusTickets`.
- **`LotteryPlayerTemplateTest`** — template renders the `paid + bonus` breakdown in both top-holder render sites.

## Test plan

- [x] `./gradlew :web:test :database:test`
- [ ] `./gradlew :discord-bot:test` (CI — local sandbox blocks Maven for lavasrc/libdave)
- [ ] Manual: open the nav drawer on a phone-narrow viewport, confirm `.mod-subnav` stays hidden behind it.
- [ ] Manual: `/jackpotadmin lottery_open` with `LOTTERY_BULK_TIER1_BUY=10` configured → confirm the announce channel gets a fresh embed showing the active incentives field.
- [ ] Manual: configure a tier *after* a weighted lottery is already open → confirm the next 5-minute refresh edits the embed to include the field even if it wasn't there at announce time.
- [ ] Manual: buy enough to earn bulk-bonus tickets → confirm the top-holders list ranks correctly and shows `X paid + Y bonus`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mib78RPKH1yRW234Zwugjs)_