### PR TITLE
feat(lottery): /jackpotadmin lottery_refresh_embed — manual embed rebuild trigger

### DIFF
--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/moderation/JackpotAdminCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/moderation/JackpotAdminCommand.kt
@@ -1,6 +1,7 @@
 package bot.toby.command.commands.moderation
 
 import bot.toby.modal.modals.JackpotAdminModal
+import bot.toby.scheduling.LotteryAnnouncer
 import core.command.Command.Companion.replyAndDelete
 import core.command.Command.Companion.replyEphemeralAndDelete
 import core.command.CommandContext
@@ -33,6 +34,7 @@ class JackpotAdminCommand @Autowired constructor(
     private val casinoAdminService: CasinoAdminService,
     private val jackpotService: JackpotService,
     private val jackpotLotteryService: JackpotLotteryService,
+    private val lotteryAnnouncer: LotteryAnnouncer,
 ) : ModerationCommand {
 
     override val name: String = "jackpotadmin"
@@ -50,6 +52,10 @@ class JackpotAdminCommand @Autowired constructor(
         SubcommandData(SUB_LOTTERY_OPEN, "Open a multi-winner ticketed lottery seeded from the jackpot pool (form)."),
         SubcommandData(SUB_LOTTERY_DRAW, "Close the open lottery and pay weighted winners."),
         SubcommandData(SUB_LOTTERY_CANCEL, "Cancel the open lottery (refund tickets, return seed to pool)."),
+        SubcommandData(
+            SUB_LOTTERY_REFRESH_EMBED,
+            "Re-render announce embeds for any open lottery — pick up tier edits without the 5-min wait.",
+        ),
     )
 
     override fun handle(ctx: CommandContext, requestingUserDto: UserDto, deleteDelay: Int) {
@@ -85,9 +91,11 @@ class JackpotAdminCommand @Autowired constructor(
             SUB_POOL -> handlePool(event, guildId, deleteDelay)
             SUB_LOTTERY_DRAW -> handleLotteryDraw(event, guildId, deleteDelay)
             SUB_LOTTERY_CANCEL -> handleLotteryCancel(event, guildId, deleteDelay)
+            SUB_LOTTERY_REFRESH_EMBED -> handleLotteryRefreshEmbed(event, guildId, deleteDelay)
             else -> event.hook.replyEphemeralAndDelete(
                 "Pick a subcommand: $SUB_RESET / $SUB_REFUND / $SUB_POOL / " +
-                    "$SUB_LOTTERY_OPEN / $SUB_LOTTERY_DRAW / $SUB_LOTTERY_CANCEL.",
+                    "$SUB_LOTTERY_OPEN / $SUB_LOTTERY_DRAW / $SUB_LOTTERY_CANCEL / " +
+                    "$SUB_LOTTERY_REFRESH_EMBED.",
                 deleteDelay,
             )
         }
@@ -184,6 +192,51 @@ class JackpotAdminCommand @Autowired constructor(
         }
     }
 
+    /**
+     * Force-rebuild the announce embed for every open lottery on this
+     * guild. Bypasses the 5-minute `LotteryRefreshJob` timer and its
+     * pool/digest short-circuit so admins can verify a tier edit
+     * landed without waiting (or guessing whether the digest path
+     * fired). Each call to [LotteryAnnouncer.refreshAnnouncement]
+     * runs asynchronously inside JDA's queue, so the admin's reply is
+     * "queued N", not "completed".
+     */
+    private fun handleLotteryRefreshEmbed(event: SlashCommandInteractionEvent, guildId: Long, deleteDelay: Int) {
+        val guild = event.guild ?: run {
+            replyError(event, "Guild only.", deleteDelay)
+            return
+        }
+        val openLotteries = jackpotLotteryService.getOpenLotteriesForRefresh(guildId)
+        if (openLotteries.isEmpty()) {
+            event.hook.replyEphemeralAndDelete("No open lottery to refresh.", deleteDelay)
+            return
+        }
+        var queued = 0
+        var skipped = 0
+        openLotteries.forEach { lottery ->
+            // No announcement reference means the embed was never
+            // posted (or got cleared by an UNKNOWN_MESSAGE retry).
+            // `refreshAnnouncement` would early-exit anyway, but
+            // counting up-front gives the admin a cleaner reply than
+            // "queued 1, but actually 0 happened".
+            if (lottery.announcementMessageId == null || lottery.announcementChannelId == null) {
+                skipped++
+            } else {
+                lotteryAnnouncer.refreshAnnouncement(guild, lottery, force = true)
+                queued++
+            }
+        }
+        val message = buildString {
+            append("Queued **$queued** embed refresh")
+            if (queued != 1) append("es")
+            append(".")
+            if (skipped > 0) {
+                append(" Skipped **$skipped** (no announce posted yet).")
+            }
+        }
+        event.hook.replyEphemeralAndDelete(message, deleteDelay)
+    }
+
     private fun handleLotteryCancel(event: SlashCommandInteractionEvent, guildId: Long, deleteDelay: Int) {
         when (val result = jackpotLotteryService.cancelLottery(guildId)) {
             is JackpotLotteryService.CancelOutcome.Ok -> event.hook.replyEphemeralAndDelete(
@@ -207,6 +260,7 @@ class JackpotAdminCommand @Autowired constructor(
         const val SUB_LOTTERY_OPEN = "lottery_open"
         const val SUB_LOTTERY_DRAW = "lottery_draw"
         const val SUB_LOTTERY_CANCEL = "lottery_cancel"
+        const val SUB_LOTTERY_REFRESH_EMBED = "lottery_refresh_embed"
         const val OPT_USER = "user"
         const val OPT_AMOUNT = "amount"
     }

--- a/discord-bot/src/main/kotlin/bot/toby/scheduling/LotteryAnnouncer.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/scheduling/LotteryAnnouncer.kt
@@ -181,8 +181,15 @@ class LotteryAnnouncer @Autowired constructor(
      * any other fields (e.g. yesterday's recap) are preserved as the
      * mod team last saw them. Embed layout / footer / colour stay
      * identical so the message doesn't visibly flicker on edit.
+     *
+     * [force] bypasses the pool/digest short-circuit so an admin-driven
+     * "rebuild this embed now" path
+     * (`/jackpotadmin lottery_refresh_embed`) re-renders even when
+     * nothing the watermark tracks has changed. The 5-minute
+     * [LotteryRefreshJob] never passes `force = true`, so its
+     * quiet-tick cost stays unchanged.
      */
-    fun refreshAnnouncement(guild: Guild, lottery: JackpotLotteryDto) {
+    fun refreshAnnouncement(guild: Guild, lottery: JackpotLotteryDto, force: Boolean = false) {
         val lotteryId = lottery.id ?: return
         val messageId = lottery.announcementMessageId ?: return
         val channelId = lottery.announcementChannelId ?: return
@@ -198,7 +205,7 @@ class LotteryAnnouncer @Autowired constructor(
         } else null
         val poolChanged = lottery.announcedPoolAmount != lottery.poolAmount
         val incentivesChanged = lottery.announcedIncentivesDigest != freshDigest
-        if (!poolChanged && !incentivesChanged) return
+        if (!force && !poolChanged && !incentivesChanged) return
 
         val channel = guild.getTextChannelById(channelId) ?: run {
             logger.warn(

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/moderation/JackpotAdminCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/moderation/JackpotAdminCommandTest.kt
@@ -7,6 +7,8 @@ import bot.toby.command.CommandTest.Companion.replyCallbackAction
 import bot.toby.command.CommandTest.Companion.requestingUserDto
 import bot.toby.command.CommandTest.Companion.webhookMessageCreateAction
 import bot.toby.command.DefaultCommandContext
+import bot.toby.scheduling.LotteryAnnouncer
+import database.dto.JackpotLotteryDto
 import database.dto.UserDto
 import database.service.CasinoAdminService
 import database.service.JackpotLotteryService
@@ -14,7 +16,9 @@ import database.service.JackpotService
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
+import io.mockk.verify
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
@@ -34,6 +38,7 @@ internal class JackpotAdminCommandTest : CommandTest {
     private lateinit var casinoAdminService: CasinoAdminService
     private lateinit var jackpotService: JackpotService
     private lateinit var jackpotLotteryService: JackpotLotteryService
+    private lateinit var lotteryAnnouncer: LotteryAnnouncer
     private lateinit var command: JackpotAdminCommand
 
     @BeforeEach
@@ -42,7 +47,10 @@ internal class JackpotAdminCommandTest : CommandTest {
         casinoAdminService = mockk(relaxed = true)
         jackpotService = mockk(relaxed = true)
         jackpotLotteryService = mockk(relaxed = true)
-        command = JackpotAdminCommand(casinoAdminService, jackpotService, jackpotLotteryService)
+        lotteryAnnouncer = mockk(relaxed = true)
+        command = JackpotAdminCommand(
+            casinoAdminService, jackpotService, jackpotLotteryService, lotteryAnnouncer,
+        )
         every { guild.idLong } returns guildId
         every { event.subcommandName } returns "lottery_draw"
         // The lottery_draw handler defers ephemerally; the base sets up
@@ -159,5 +167,121 @@ internal class JackpotAdminCommandTest : CommandTest {
         assertTrue(reply.contains("**1** distinct buyer"), reply)
         assertTrue(reply.contains("need **2**"), reply)
         assertTrue(reply.contains("LOTTERY_DAILY_MIN_BUYERS"), reply)
+    }
+
+    // ---- lottery_refresh_embed ----
+
+    private fun openLotteryRow(
+        id: Long = 1L,
+        messageId: Long? = 999L,
+        channelId: Long? = 777L,
+        mode: String = JackpotLotteryDto.MODE_TICKET_WEIGHTED,
+    ): JackpotLotteryDto = JackpotLotteryDto(
+        id = id,
+        guildId = guildId,
+        ticketPrice = 50L,
+        poolAmount = 1_000L,
+        mode = mode,
+    ).also {
+        it.announcementMessageId = messageId
+        it.announcementChannelId = channelId
+    }
+
+    @Test
+    fun `lottery_refresh_embed replies 'No open lottery' when nothing is open`() {
+        every { event.subcommandName } returns "lottery_refresh_embed"
+        every { jackpotLotteryService.getOpenLotteriesForRefresh(guildId) } returns emptyList()
+        val captured = captureReply()
+
+        command.handle(DefaultCommandContext(event), requestingUserDto, 5)
+
+        assertTrue(captured.captured.contains("No open lottery to refresh"), captured.captured)
+        verify(exactly = 0) { lotteryAnnouncer.refreshAnnouncement(any(), any(), any()) }
+    }
+
+    @Test
+    fun `lottery_refresh_embed calls refreshAnnouncement with force=true for each open lottery`() {
+        // Both a TICKET_WEIGHTED and a NUMBER_MATCH open lottery —
+        // the manual trigger refreshes every open row for the guild,
+        // not just weighted. (NUMBER_MATCH embeds don't carry the
+        // incentives field, but they still benefit from a forced
+        // pool refresh.)
+        every { event.subcommandName } returns "lottery_refresh_embed"
+        val weighted = openLotteryRow(id = 1L, mode = JackpotLotteryDto.MODE_TICKET_WEIGHTED)
+        val match = openLotteryRow(id = 2L, mode = JackpotLotteryDto.MODE_NUMBER_MATCH)
+        every { jackpotLotteryService.getOpenLotteriesForRefresh(guildId) } returns listOf(weighted, match)
+        val captured = captureReply()
+
+        command.handle(DefaultCommandContext(event), requestingUserDto, 5)
+
+        verify(exactly = 1) {
+            lotteryAnnouncer.refreshAnnouncement(guild, weighted, force = true)
+        }
+        verify(exactly = 1) {
+            lotteryAnnouncer.refreshAnnouncement(guild, match, force = true)
+        }
+        assertTrue(captured.captured.contains("Queued **2**"), captured.captured)
+    }
+
+    @Test
+    fun `lottery_refresh_embed counts lotteries with no announcement reference as skipped`() {
+        // One lottery has a message id; the other never announced
+        // (admin opened it but the channel resolution failed at the
+        // time, or the announce ref was cleared by UNKNOWN_MESSAGE).
+        // The reply should clearly distinguish queued vs skipped.
+        every { event.subcommandName } returns "lottery_refresh_embed"
+        val withRef = openLotteryRow(id = 1L)
+        val noRef = openLotteryRow(id = 2L, messageId = null, channelId = null)
+        every { jackpotLotteryService.getOpenLotteriesForRefresh(guildId) } returns listOf(withRef, noRef)
+        val captured = captureReply()
+
+        command.handle(DefaultCommandContext(event), requestingUserDto, 5)
+
+        verify(exactly = 1) {
+            lotteryAnnouncer.refreshAnnouncement(guild, withRef, force = true)
+        }
+        verify(exactly = 0) {
+            lotteryAnnouncer.refreshAnnouncement(guild, noRef, any())
+        }
+        val reply = captured.captured
+        assertTrue(reply.contains("Queued **1**"), reply)
+        assertTrue(reply.contains("Skipped **1**"), reply)
+        assertTrue(reply.contains("no announce posted yet"), reply)
+    }
+
+    @Test
+    fun `lottery_refresh_embed reply uses correct pluralisation for a single refresh`() {
+        // Cosmetic but visible: "Queued 1 embed refresh." not
+        // "Queued 1 embed refreshes." Pin the singular form so a
+        // future copy edit doesn't regress it.
+        every { event.subcommandName } returns "lottery_refresh_embed"
+        every { jackpotLotteryService.getOpenLotteriesForRefresh(guildId) } returns
+            listOf(openLotteryRow(id = 1L))
+        val captured = captureReply()
+
+        command.handle(DefaultCommandContext(event), requestingUserDto, 5)
+
+        val reply = captured.captured
+        assertTrue(reply.contains("Queued **1** embed refresh."), reply)
+        assertFalse(reply.contains("refreshes"), "single refresh should use the singular form: $reply")
+    }
+
+    @Test
+    fun `lottery_refresh_embed is owner-or-superuser-only`() {
+        // Mirror the existing auth-gate behaviour from the other
+        // lottery subcommands: a non-owner / non-superuser gets the
+        // ephemeral error and no service calls fire.
+        every { event.subcommandName } returns "lottery_refresh_embed"
+        val plainUser = mockk<UserDto>(relaxed = true) {
+            every { superUser } returns false
+        }
+        every { event.member?.isOwner } returns false
+        val captured = captureReply()
+
+        command.handle(DefaultCommandContext(event), plainUser, 5)
+
+        assertEquals("Server owner or superuser only.", captured.captured)
+        verify(exactly = 0) { jackpotLotteryService.getOpenLotteriesForRefresh(any()) }
+        verify(exactly = 0) { lotteryAnnouncer.refreshAnnouncement(any(), any(), any()) }
     }
 }

--- a/discord-bot/src/test/kotlin/bot/toby/scheduling/LotteryAnnouncerTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/scheduling/LotteryAnnouncerTest.kt
@@ -924,6 +924,92 @@ class LotteryAnnouncerTest {
         }
 
         @Test
+        fun `weighted refresh with force=true edits even when pool and digest both match`() {
+            // The admin manual-trigger path
+            // (`/jackpotadmin lottery_refresh_embed`) needs to bypass
+            // the short-circuit so an admin can verify config changes
+            // landed without waiting. Same setup as the short-circuit
+            // case above, but with `force = true` the embed is still
+            // edited and the watermark gets re-persisted.
+            stubConfig(ConfigDto.Configurations.LOTTERY_BULK_TIER1_BUY, "10")
+            stubConfig(ConfigDto.Configurations.LOTTERY_BULK_TIER1_BONUS, "3")
+            every { guild.getTextChannelById(777L) } returns channel
+
+            val previousEmbed = EmbedBuilder()
+                .setTitle("🎟️ Daily Lottery — Test Guild")
+                .addField(
+                    LotteryAnnouncer.TODAYS_DRAW_FIELD,
+                    "**1000** credits in the pool · Ticket: **50** · Mode: **Top-3 weighted** · Closes 24h.",
+                    false,
+                )
+                .addField(LotteryAnnouncer.ACTIVE_INCENTIVES_FIELD, "🎁 Bulk bonus: buy ≥10 → **+3** free", false)
+                .build()
+            val message: Message = mockk(relaxed = true)
+            every { message.embeds } returns listOf(previousEmbed)
+
+            val retrieveAction: RestAction<Message> = mockk(relaxed = true)
+            every { channel.retrieveMessageById(999L) } returns retrieveAction
+            every {
+                retrieveAction.queue(any<java.util.function.Consumer<Message>>(), any())
+            } answers {
+                firstArg<java.util.function.Consumer<Message>>().accept(message)
+            }
+            val editAction: MessageEditAction = mockk(relaxed = true)
+            val editedEmbedSlot = slot<MessageEmbed>()
+            every { message.editMessageEmbeds(capture(editedEmbedSlot)) } returns editAction
+            every { editAction.setComponents(any<Collection<MessageTopLevelComponent>>()) } returns editAction
+            every {
+                editAction.queue(any<java.util.function.Consumer<Message>>(), any())
+            } answers {
+                firstArg<java.util.function.Consumer<Message>>().accept(message)
+            }
+
+            val liveDigest = announcer.incentivesDigest(guildId)
+            val lottery = openLottery(
+                poolAmount = 1_000L,
+                announcedPoolAmount = 1_000L,
+                mode = JackpotLotteryDto.MODE_TICKET_WEIGHTED,
+                announcedIncentivesDigest = liveDigest,
+            )
+
+            announcer.refreshAnnouncement(guild, lottery, force = true)
+
+            // The edit fired — same path as the digest-mismatch case
+            // would have taken, just driven by `force = true`.
+            verify(exactly = 1) { message.editMessageEmbeds(any<MessageEmbed>()) }
+            // And the watermark is re-persisted (idempotent here:
+            // same digest in, same digest out, but the call still
+            // happens so a future bug that mutates state mid-refresh
+            // doesn't leave the watermark stale).
+            verify(exactly = 1) {
+                jackpotLotteryService.updateAnnouncementWatermarks(1L, 1_000L, any())
+            }
+        }
+
+        @Test
+        fun `refresh with default force=false still skips when nothing changed`() {
+            // Regression guard so the 5-minute LotteryRefreshJob keeps
+            // its cheap quiet-tick behaviour: only the new admin
+            // command should be passing force=true.
+            stubConfig(ConfigDto.Configurations.LOTTERY_BULK_TIER1_BUY, "10")
+            stubConfig(ConfigDto.Configurations.LOTTERY_BULK_TIER1_BONUS, "3")
+
+            val liveDigest = announcer.incentivesDigest(guildId)
+            val lottery = openLottery(
+                poolAmount = 1_000L,
+                announcedPoolAmount = 1_000L,
+                mode = JackpotLotteryDto.MODE_TICKET_WEIGHTED,
+                announcedIncentivesDigest = liveDigest,
+            )
+
+            // Default force=false (the explicit parameter is omitted
+            // by the refresh job).
+            announcer.refreshAnnouncement(guild, lottery)
+
+            verify(exactly = 0) { guild.getTextChannelById(any<Long>()) }
+        }
+
+        @Test
         fun `incentivesDigest is deterministic for the same configured tiers`() {
             stubConfig(ConfigDto.Configurations.LOTTERY_BULK_TIER1_BUY, "10")
             stubConfig(ConfigDto.Configurations.LOTTERY_BULK_TIER1_BONUS, "3")


### PR DESCRIPTION
## Why

PR #510 made `LotteryAnnouncer.rebuildEmbed` additive for the incentives field, but the trigger surface was still purely automatic: a 5-minute `LotteryRefreshJob` poll, with a pool/digest short-circuit. An admin tuning tiers and wanting the embed updated *now* had to wait, and a forced re-render of an unchanged-config embed wasn't possible at all.

## What

New `/jackpotadmin lottery_refresh_embed` subcommand:

- Looks up open lotteries via `getOpenLotteriesForRefresh(guildId)`.
- Calls `LotteryAnnouncer.refreshAnnouncement(guild, lottery, force = true)` for each one that has an announcement reference.
- Replies ephemerally with a breakdown: `"Queued N embed refresh(es). M skipped (no announce posted yet)."`

`LotteryAnnouncer.refreshAnnouncement` gains a `force: Boolean = false` param that bypasses the pool/digest short-circuit. The 5-minute refresh job never passes `force = true`, so quiet-tick cost is unchanged.

> Web button was considered but skipped: `web` doesn't depend on `discord-bot`, so the announcer isn't reachable from a web controller without a Spring event-bus indirection. Discord-side surface is the cleanest fit for an admin-driven trigger anyway.

## Tests

- `LotteryAnnouncerTest`:
  - `refresh with force=true edits even when pool and digest both match` — pins the bypass.
  - `refresh with default force=false still skips when nothing changed` — regression guard for the 5-minute refresh job's quiet-tick behaviour.
- `JackpotAdminCommandTest` (5 new cases):
  - `lottery_refresh_embed replies 'No open lottery' when nothing is open`
  - `lottery_refresh_embed calls refreshAnnouncement(force=true) for each open lottery`
  - `lottery_refresh_embed counts lotteries with no announcement reference as skipped`
  - `lottery_refresh_embed reply uses correct pluralisation for a single refresh`
  - `lottery_refresh_embed is owner-or-superuser-only`
  - Wired the new `LotteryAnnouncer` constructor dep into the existing test setup.

## Test plan

- [x] `./gradlew :web:test :database:test`
- [ ] `./gradlew :discord-bot:test` (CI — local sandbox blocks the bot's external Maven hosts)
- [ ] Manual: open a TICKET_WEIGHTED lottery, wait for the announce embed, configure new bulk tiers via the moderation page, run `/jackpotadmin lottery_refresh_embed` — confirm the embed updates within a second and the ephemeral reply shows "Queued 1 embed refresh".
- [ ] Manual: with no open lottery, run the command — confirm "No open lottery to refresh".
- [ ] Manual: run the command twice in a row — confirm the second call still re-renders (force bypass works even when nothing changed).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mib78RPKH1yRW234Zwugjs)_