### PR TITLE
feat(pricealert): /pricealert auto-trade triggers with PRICE_ALERT receipt DM

### DIFF
--- a/application/src/test/kotlin/integration/bot/CommandManagerTest.kt
+++ b/application/src/test/kotlin/integration/bot/CommandManagerTest.kt
@@ -16,6 +16,7 @@ import bot.toby.command.commands.economy.KenoCommand
 import bot.toby.command.commands.economy.LotteryCommand
 import bot.toby.command.commands.economy.PlinkoCommand
 import bot.toby.command.commands.economy.PokerCommand
+import bot.toby.command.commands.economy.PriceAlertCommand
 import bot.toby.command.commands.economy.RouletteCommand
 import bot.toby.command.commands.economy.ScratchCommand
 import bot.toby.command.commands.economy.SlotsCommand
@@ -137,6 +138,7 @@ class CommandManagerTest {
             EightBallCommand::class.java,
             TitleCommand::class.java,
             TobyCoinCommand::class.java,
+            PriceAlertCommand::class.java,
             SlotsCommand::class.java,
             CoinflipCommand::class.java,
             DiceCommand::class.java,
@@ -162,8 +164,8 @@ class CommandManagerTest {
         )
 
         Assertions.assertTrue(availableCommands.containsAll(commandManager.allCommands.map { it.javaClass }.toList()))
-        Assertions.assertEquals(66, commandManager.allCommands.size)
-        Assertions.assertEquals(66, commandManager.allSlashCommands.size)
+        Assertions.assertEquals(67, commandManager.allCommands.size)
+        Assertions.assertEquals(67, commandManager.allSlashCommands.size)
     }
 
     @Test

--- a/common/src/main/kotlin/common/notification/NotificationChannelKind.kt
+++ b/common/src/main/kotlin/common/notification/NotificationChannelKind.kt
@@ -55,7 +55,7 @@ enum class NotificationChannelKind(
     ),
     PRICE_ALERT(
         displayName = "TobyCoin price alert",
-        description = "Off by default — DM on large TobyCoin price moves.",
+        description = "Off by default — DM receipts when a /pricealert trigger auto-executes a buy or sell on your behalf.",
         perSurfaceDefaults = mapOf(Surface.DM to false, Surface.PUSH to false),
     ),
     INTRO_PROMPT(

--- a/common/src/test/kotlin/common/notification/NotificationChannelKindTest.kt
+++ b/common/src/test/kotlin/common/notification/NotificationChannelKindTest.kt
@@ -34,6 +34,28 @@ class NotificationChannelKindTest {
         }
     }
 
+    @Test
+    fun `PRICE_ALERT description tells the user it's an auto-trade receipt`() {
+        // The string surfaces in /notify, the web API, and the
+        // notification-preferences page — all three rely on the enum's
+        // description as their source of truth. A stale "DM on large
+        // price moves" copy misleads the user into thinking PRICE_ALERT
+        // is a heads-up rather than a receipt of a trade the bot just
+        // ran on their behalf.
+        val desc = NotificationChannelKind.PRICE_ALERT.description.lowercase()
+        assertTrue(
+            desc.contains("/pricealert") || desc.contains("pricealert"),
+            "PRICE_ALERT description must point users at the /pricealert " +
+                    "command source: ${NotificationChannelKind.PRICE_ALERT.description}"
+        )
+        assertTrue(
+            desc.contains("buy") && desc.contains("sell"),
+            "PRICE_ALERT description must mention both buy and sell so " +
+                    "the user understands the receipt scope: " +
+                    NotificationChannelKind.PRICE_ALERT.description
+        )
+    }
+
     // ---- per-surface defaults (new shape) ----
 
     @Test

--- a/database/src/main/kotlin/database/dto/UserPriceTriggerDto.kt
+++ b/database/src/main/kotlin/database/dto/UserPriceTriggerDto.kt
@@ -1,0 +1,78 @@
+package database.dto
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.NamedQueries
+import jakarta.persistence.NamedQuery
+import jakarta.persistence.Table
+import org.hibernate.annotations.DynamicUpdate
+import org.springframework.transaction.annotation.Transactional
+import java.io.Serializable
+import java.time.Instant
+
+/**
+ * A user-defined TobyCoin price trigger. When the market tick crosses
+ * [thresholdPrice] from the side the price was on at creation
+ * ([priceAtCreation]), the scheduler auto-executes the declared trade
+ * ([side] of [amount] coins) and DMs a receipt.
+ *
+ * One-shot: the scheduler stamps [firedAt] and flips [enabled] false
+ * on fire, so a price oscillating around the threshold can't replay
+ * the trade. The user re-arms by re-running `/pricealert add`.
+ */
+@NamedQueries(
+    NamedQuery(
+        name = "UserPriceTriggerDto.listEnabledByGuild",
+        query = "select t from UserPriceTriggerDto t " +
+                "where t.guildId = :guildId and t.enabled = true"
+    ),
+    NamedQuery(
+        name = "UserPriceTriggerDto.listByUser",
+        query = "select t from UserPriceTriggerDto t " +
+                "where t.discordId = :discordId and t.guildId = :guildId " +
+                "order by t.id"
+    )
+)
+@Entity
+@DynamicUpdate
+@Table(name = "user_price_trigger", schema = "public")
+@Transactional
+class UserPriceTriggerDto(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    var id: Long? = null,
+
+    @Column(name = "discord_id", nullable = false)
+    var discordId: Long = 0,
+
+    @Column(name = "guild_id", nullable = false)
+    var guildId: Long = 0,
+
+    @Column(name = "threshold_price", nullable = false)
+    var thresholdPrice: Double = 0.0,
+
+    @Column(name = "price_at_creation", nullable = false)
+    var priceAtCreation: Double = 0.0,
+
+    @Column(name = "side", nullable = false, length = 8)
+    var side: String = Side.BUY.name,
+
+    @Column(name = "amount", nullable = false)
+    var amount: Long = 0,
+
+    @Column(name = "enabled", nullable = false)
+    var enabled: Boolean = true,
+
+    @Column(name = "fired_at")
+    var firedAt: Instant? = null,
+
+    @Column(name = "created_at", nullable = false)
+    var createdAt: Instant = Instant.now(),
+) : Serializable {
+
+    enum class Side { BUY, SELL }
+}

--- a/database/src/main/kotlin/database/dto/UserPriceTriggerDto.kt
+++ b/database/src/main/kotlin/database/dto/UserPriceTriggerDto.kt
@@ -75,4 +75,17 @@ class UserPriceTriggerDto(
 ) : Serializable {
 
     enum class Side { BUY, SELL }
+
+    /**
+     * Typed accessor over the stringly-typed [side] column. Reading
+     * throws [IllegalArgumentException] when the column holds a value
+     * that doesn't map to a [Side] enum constant — callers in the
+     * scheduler hot-path wrap this in a `runCatching` guard so a
+     * corrupted row disables itself instead of crashing the whole
+     * tick. Writes go through the enum's `name` so the column never
+     * holds anything but valid identifiers.
+     */
+    var sideEnum: Side
+        get() = Side.valueOf(side)
+        set(value) { side = value.name }
 }

--- a/database/src/main/kotlin/database/persistence/UserPriceTriggerPersistence.kt
+++ b/database/src/main/kotlin/database/persistence/UserPriceTriggerPersistence.kt
@@ -1,0 +1,15 @@
+package database.persistence
+
+import database.dto.UserPriceTriggerDto
+
+interface UserPriceTriggerPersistence {
+    fun save(trigger: UserPriceTriggerDto): UserPriceTriggerDto
+
+    fun findById(id: Long): UserPriceTriggerDto?
+
+    fun listEnabledByGuild(guildId: Long): List<UserPriceTriggerDto>
+
+    fun listByUser(discordId: Long, guildId: Long): List<UserPriceTriggerDto>
+
+    fun deleteById(id: Long): Boolean
+}

--- a/database/src/main/kotlin/database/persistence/impl/DefaultUserPriceTriggerPersistence.kt
+++ b/database/src/main/kotlin/database/persistence/impl/DefaultUserPriceTriggerPersistence.kt
@@ -1,0 +1,47 @@
+package database.persistence.impl
+
+import database.dto.UserPriceTriggerDto
+import database.persistence.UserPriceTriggerPersistence
+import jakarta.persistence.EntityManager
+import jakarta.persistence.PersistenceContext
+import jakarta.persistence.TypedQuery
+import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
+
+@Repository
+@Transactional
+class DefaultUserPriceTriggerPersistence : UserPriceTriggerPersistence {
+
+    @PersistenceContext
+    private lateinit var entityManager: EntityManager
+
+    override fun save(trigger: UserPriceTriggerDto): UserPriceTriggerDto =
+        entityManager.saveOrMerge(trigger, isNew = { it.id == null })
+
+    override fun findById(id: Long): UserPriceTriggerDto? =
+        entityManager.find(UserPriceTriggerDto::class.java, id)
+
+    override fun listEnabledByGuild(guildId: Long): List<UserPriceTriggerDto> {
+        val q: TypedQuery<UserPriceTriggerDto> = entityManager.createNamedQuery(
+            "UserPriceTriggerDto.listEnabledByGuild", UserPriceTriggerDto::class.java
+        )
+        q.setParameter("guildId", guildId)
+        return q.resultList
+    }
+
+    override fun listByUser(discordId: Long, guildId: Long): List<UserPriceTriggerDto> {
+        val q: TypedQuery<UserPriceTriggerDto> = entityManager.createNamedQuery(
+            "UserPriceTriggerDto.listByUser", UserPriceTriggerDto::class.java
+        )
+        q.setParameter("discordId", discordId)
+        q.setParameter("guildId", guildId)
+        return q.resultList
+    }
+
+    override fun deleteById(id: Long): Boolean {
+        val existing = entityManager.find(UserPriceTriggerDto::class.java, id) ?: return false
+        entityManager.remove(existing)
+        entityManager.flush()
+        return true
+    }
+}

--- a/database/src/main/kotlin/database/service/UserPriceTriggerService.kt
+++ b/database/src/main/kotlin/database/service/UserPriceTriggerService.kt
@@ -1,0 +1,34 @@
+package database.service
+
+import database.dto.UserPriceTriggerDto
+import java.time.Instant
+
+interface UserPriceTriggerService {
+    fun create(
+        discordId: Long,
+        guildId: Long,
+        threshold: Double,
+        priceAtCreation: Double,
+        side: UserPriceTriggerDto.Side,
+        amount: Long,
+    ): UserPriceTriggerDto
+
+    fun listForUser(discordId: Long, guildId: Long): List<UserPriceTriggerDto>
+
+    /**
+     * Delete trigger [id] only if it belongs to [requestingDiscordId]
+     * — guards against one user removing another's row.
+     */
+    fun remove(id: Long, requestingDiscordId: Long): Boolean
+
+    /**
+     * Returns every enabled trigger in [guildId] whose target was
+     * reached by [newPrice] from the side the price was on at the
+     * trigger's creation. Direction is implicit:
+     *   (priceAtCreation - threshold) * (newPrice - threshold) <= 0.
+     */
+    fun findTriggered(guildId: Long, newPrice: Double): List<UserPriceTriggerDto>
+
+    /** Mark [id] fired at [firedAt] and disable it. */
+    fun markFired(id: Long, firedAt: Instant)
+}

--- a/database/src/main/kotlin/database/service/impl/DefaultUserPriceTriggerService.kt
+++ b/database/src/main/kotlin/database/service/impl/DefaultUserPriceTriggerService.kt
@@ -1,0 +1,67 @@
+package database.service.impl
+
+import database.dto.UserPriceTriggerDto
+import database.persistence.UserPriceTriggerPersistence
+import database.service.UserPriceTriggerService
+import org.springframework.stereotype.Service
+import java.time.Instant
+
+@Service
+class DefaultUserPriceTriggerService(
+    private val persistence: UserPriceTriggerPersistence,
+) : UserPriceTriggerService {
+
+    override fun create(
+        discordId: Long,
+        guildId: Long,
+        threshold: Double,
+        priceAtCreation: Double,
+        side: UserPriceTriggerDto.Side,
+        amount: Long,
+    ): UserPriceTriggerDto {
+        require(amount > 0L) { "amount must be positive (was $amount)" }
+        require(threshold > 0.0) { "threshold must be positive (was $threshold)" }
+        return persistence.save(
+            UserPriceTriggerDto(
+                discordId = discordId,
+                guildId = guildId,
+                thresholdPrice = threshold,
+                priceAtCreation = priceAtCreation,
+                side = side.name,
+                amount = amount,
+                enabled = true,
+                createdAt = Instant.now(),
+            )
+        )
+    }
+
+    override fun listForUser(discordId: Long, guildId: Long): List<UserPriceTriggerDto> =
+        persistence.listByUser(discordId, guildId)
+
+    override fun remove(id: Long, requestingDiscordId: Long): Boolean {
+        val row = persistence.findById(id) ?: return false
+        if (row.discordId != requestingDiscordId) return false
+        return persistence.deleteById(id)
+    }
+
+    override fun findTriggered(guildId: Long, newPrice: Double): List<UserPriceTriggerDto> {
+        return persistence.listEnabledByGuild(guildId).filter { row ->
+            // Target reached from the original side: equivalent to
+            //   (priceAtCreation > threshold && newPrice <= threshold) ||
+            //   (priceAtCreation < threshold && newPrice >= threshold).
+            // The single-line product check below collapses both cases
+            // and stays well-behaved at the equality boundary because
+            // we reject `threshold == priceAtCreation` upstream in the
+            // slash command.
+            (row.priceAtCreation - row.thresholdPrice) *
+                (newPrice - row.thresholdPrice) <= 0.0
+        }
+    }
+
+    override fun markFired(id: Long, firedAt: Instant) {
+        val row = persistence.findById(id) ?: return
+        row.firedAt = firedAt
+        row.enabled = false
+        persistence.save(row)
+    }
+}

--- a/database/src/main/resources/db/migration/V42__user_price_trigger.sql
+++ b/database/src/main/resources/db/migration/V42__user_price_trigger.sql
@@ -1,0 +1,33 @@
+-- Per-user predefined TobyCoin price triggers. When the price tick
+-- crosses a user's target threshold, the bot auto-executes the
+-- declared trade (BUY/SELL of `amount` coins) and DMs a receipt via
+-- the existing PRICE_ALERT notification kind.
+--
+-- Fire-direction is implicit: at /pricealert add time the slash
+-- command captures the current market price into `price_at_creation`.
+-- The fire condition is "newPrice has reached the target from the
+-- side it was on at creation", i.e.
+--   (price_at_creation - threshold_price) * (newPrice - threshold_price) <= 0
+-- One-shot: on fire, the row gets `fired_at` stamped and `enabled`
+-- flipped false so a price that oscillates around the threshold can't
+-- re-fire the same trade. To re-arm, the user re-runs /pricealert add.
+CREATE TABLE user_price_trigger (
+    id                  BIGSERIAL PRIMARY KEY,
+    discord_id          BIGINT        NOT NULL,
+    guild_id            BIGINT        NOT NULL,
+    threshold_price     NUMERIC(20,6) NOT NULL,
+    price_at_creation   NUMERIC(20,6) NOT NULL,
+    side                VARCHAR(8)    NOT NULL,
+    amount              BIGINT        NOT NULL,
+    enabled             BOOLEAN       NOT NULL DEFAULT TRUE,
+    fired_at            TIMESTAMPTZ,
+    created_at          TIMESTAMPTZ   NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Hot path: every price tick scans this index per guild.
+CREATE INDEX idx_user_price_trigger_guild_enabled
+    ON user_price_trigger (guild_id) WHERE enabled;
+
+-- /pricealert list lookup.
+CREATE INDEX idx_user_price_trigger_user
+    ON user_price_trigger (discord_id, guild_id);

--- a/database/src/test/kotlin/database/service/UserPriceTriggerServiceTest.kt
+++ b/database/src/test/kotlin/database/service/UserPriceTriggerServiceTest.kt
@@ -5,13 +5,17 @@ import database.persistence.UserPriceTriggerPersistence
 import database.service.impl.DefaultUserPriceTriggerService
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import java.time.Instant
 
-class UserPriceTriggerTargetReachedTest {
+class UserPriceTriggerServiceTest {
 
     private val guildId = 100L
     private val discordId = 42L
@@ -154,5 +158,88 @@ class UserPriceTriggerTargetReachedTest {
         assertFalse(service.remove(7L, requestingDiscordId = 9999L))
         // Correct owner — proceeds.
         assertTrue(service.remove(7L, requestingDiscordId = discordId))
+    }
+
+    @Test
+    fun `remove returns false when no row exists`() {
+        every { persistence.findById(404L) } returns null
+
+        assertFalse(service.remove(404L, requestingDiscordId = discordId))
+        verify(exactly = 0) { persistence.deleteById(any()) }
+    }
+
+    @Test
+    fun `create persists a row with the enum stored as its name and enabled=true`() {
+        val saved = slot<UserPriceTriggerDto>()
+        every { persistence.save(capture(saved)) } answers { firstArg() }
+
+        val result = service.create(
+            discordId, guildId,
+            threshold = 90.0, priceAtCreation = 120.0,
+            side = UserPriceTriggerDto.Side.SELL, amount = 7L,
+        )
+
+        assertEquals("SELL", saved.captured.side)
+        assertEquals(7L, saved.captured.amount)
+        assertEquals(90.0, saved.captured.thresholdPrice)
+        assertEquals(120.0, saved.captured.priceAtCreation)
+        assertTrue(saved.captured.enabled)
+        assertNotNull(result)
+        // Sanity-check the typed accessor — refactor R1.
+        assertEquals(UserPriceTriggerDto.Side.SELL, saved.captured.sideEnum)
+    }
+
+    @Test
+    fun `listForUser delegates straight to persistence`() {
+        val rows = listOf(row(id = 1, threshold = 50.0, priceAtCreation = 100.0))
+        every { persistence.listByUser(discordId, guildId) } returns rows
+
+        assertEquals(rows, service.listForUser(discordId, guildId))
+        verify(exactly = 1) { persistence.listByUser(discordId, guildId) }
+    }
+
+    @Test
+    fun `markFired stamps firedAt and disables, then saves`() {
+        val row = row(id = 5, threshold = 100.0, priceAtCreation = 120.0)
+        every { persistence.findById(5L) } returns row
+        val saved = slot<UserPriceTriggerDto>()
+        every { persistence.save(capture(saved)) } answers { firstArg() }
+
+        val now = Instant.parse("2026-05-19T12:00:00Z")
+        service.markFired(5L, now)
+
+        assertEquals(now, saved.captured.firedAt)
+        assertFalse(saved.captured.enabled)
+    }
+
+    @Test
+    fun `markFired on missing id is a silent no-op`() {
+        every { persistence.findById(404L) } returns null
+
+        service.markFired(404L, Instant.now())
+
+        verify(exactly = 0) { persistence.save(any()) }
+    }
+
+    @Test
+    fun `sideEnum accessor round-trips through the string column`() {
+        // R1 refactor: verify the typed accessor reads what setter wrote.
+        val dto = UserPriceTriggerDto(
+            discordId = discordId, guildId = guildId,
+            thresholdPrice = 100.0, priceAtCreation = 120.0,
+            side = UserPriceTriggerDto.Side.BUY.name, amount = 1L,
+        )
+        assertEquals(UserPriceTriggerDto.Side.BUY, dto.sideEnum)
+
+        dto.sideEnum = UserPriceTriggerDto.Side.SELL
+        assertEquals("SELL", dto.side)
+        assertEquals(UserPriceTriggerDto.Side.SELL, dto.sideEnum)
+    }
+
+    @Test
+    fun `sideEnum getter throws when column holds garbage`() {
+        val dto = UserPriceTriggerDto(side = "WOBBLE")
+        val ex = runCatching { dto.sideEnum }.exceptionOrNull()
+        assertTrue(ex is IllegalArgumentException, "expected IAE, got $ex")
     }
 }

--- a/database/src/test/kotlin/database/service/UserPriceTriggerTargetReachedTest.kt
+++ b/database/src/test/kotlin/database/service/UserPriceTriggerTargetReachedTest.kt
@@ -1,0 +1,158 @@
+package database.service
+
+import database.dto.UserPriceTriggerDto
+import database.persistence.UserPriceTriggerPersistence
+import database.service.impl.DefaultUserPriceTriggerService
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class UserPriceTriggerTargetReachedTest {
+
+    private val guildId = 100L
+    private val discordId = 42L
+    private lateinit var persistence: UserPriceTriggerPersistence
+    private lateinit var service: DefaultUserPriceTriggerService
+
+    @BeforeEach
+    fun setUp() {
+        persistence = mockk(relaxed = true)
+        service = DefaultUserPriceTriggerService(persistence)
+    }
+
+    private fun row(
+        id: Long,
+        threshold: Double,
+        priceAtCreation: Double,
+        side: UserPriceTriggerDto.Side = UserPriceTriggerDto.Side.BUY,
+        amount: Long = 10,
+    ) = UserPriceTriggerDto(
+        id = id,
+        discordId = discordId,
+        guildId = guildId,
+        thresholdPrice = threshold,
+        priceAtCreation = priceAtCreation,
+        side = side.name,
+        amount = amount,
+        enabled = true,
+    )
+
+    @Test
+    fun `downward target fires when newPrice reaches or passes through threshold`() {
+        // Buy at 100 when price was 120 — fires the first time price hits 100 or below.
+        val trigger = row(id = 1, threshold = 100.0, priceAtCreation = 120.0)
+        every { persistence.listEnabledByGuild(guildId) } returns listOf(trigger)
+
+        assertTrue(service.findTriggered(guildId, newPrice = 100.0).isNotEmpty())
+        assertTrue(service.findTriggered(guildId, newPrice = 99.5).isNotEmpty())
+        assertTrue(service.findTriggered(guildId, newPrice = 50.0).isNotEmpty())
+    }
+
+    @Test
+    fun `downward target does not fire while price stays above threshold`() {
+        val trigger = row(id = 1, threshold = 100.0, priceAtCreation = 120.0)
+        every { persistence.listEnabledByGuild(guildId) } returns listOf(trigger)
+
+        assertTrue(service.findTriggered(guildId, newPrice = 110.0).isEmpty())
+        assertTrue(service.findTriggered(guildId, newPrice = 120.0).isEmpty())
+        assertTrue(service.findTriggered(guildId, newPrice = 200.0).isEmpty())
+    }
+
+    @Test
+    fun `upward target fires when newPrice reaches or passes through threshold`() {
+        // Sell at 150 when price was 120 — fires the first time price hits 150 or above.
+        val trigger = row(
+            id = 2,
+            threshold = 150.0,
+            priceAtCreation = 120.0,
+            side = UserPriceTriggerDto.Side.SELL,
+        )
+        every { persistence.listEnabledByGuild(guildId) } returns listOf(trigger)
+
+        assertTrue(service.findTriggered(guildId, newPrice = 150.0).isNotEmpty())
+        assertTrue(service.findTriggered(guildId, newPrice = 151.0).isNotEmpty())
+        assertTrue(service.findTriggered(guildId, newPrice = 999.0).isNotEmpty())
+    }
+
+    @Test
+    fun `upward target does not fire while price stays below threshold`() {
+        val trigger = row(
+            id = 2,
+            threshold = 150.0,
+            priceAtCreation = 120.0,
+            side = UserPriceTriggerDto.Side.SELL,
+        )
+        every { persistence.listEnabledByGuild(guildId) } returns listOf(trigger)
+
+        assertTrue(service.findTriggered(guildId, newPrice = 149.99).isEmpty())
+        assertTrue(service.findTriggered(guildId, newPrice = 120.0).isEmpty())
+        assertTrue(service.findTriggered(guildId, newPrice = 50.0).isEmpty())
+    }
+
+    @Test
+    fun `price gap past threshold in a single tick still fires`() {
+        // Created when price was 120; tick goes 120 → 95 (gaps past 100).
+        val trigger = row(id = 3, threshold = 100.0, priceAtCreation = 120.0)
+        every { persistence.listEnabledByGuild(guildId) } returns listOf(trigger)
+
+        assertTrue(service.findTriggered(guildId, newPrice = 95.0).isNotEmpty())
+    }
+
+    @Test
+    fun `enabled rows from listEnabledByGuild are the only candidates`() {
+        // Service delegates to listEnabledByGuild — disabled rows are
+        // never returned by that query, so we just verify both rows
+        // returned by the mock get evaluated against the crossing check.
+        val armed = row(id = 1, threshold = 100.0, priceAtCreation = 120.0)
+        val notReached = row(id = 2, threshold = 50.0, priceAtCreation = 120.0)
+        every { persistence.listEnabledByGuild(guildId) } returns listOf(armed, notReached)
+
+        val fired = service.findTriggered(guildId, newPrice = 99.0)
+        assertEquals(listOf(1L), fired.map { it.id })
+    }
+
+    @Test
+    fun `multiple triggers for same user can fire on same tick`() {
+        val a = row(id = 1, threshold = 100.0, priceAtCreation = 120.0)
+        val b = row(id = 2, threshold = 110.0, priceAtCreation = 120.0)
+        every { persistence.listEnabledByGuild(guildId) } returns listOf(a, b)
+
+        val fired = service.findTriggered(guildId, newPrice = 99.0)
+        assertEquals(listOf(1L, 2L), fired.map { it.id })
+    }
+
+    @Test
+    fun `create rejects non-positive amount and threshold`() {
+        val ex1 = runCatching {
+            service.create(
+                discordId, guildId, threshold = 100.0, priceAtCreation = 120.0,
+                side = UserPriceTriggerDto.Side.BUY, amount = 0L
+            )
+        }.exceptionOrNull()
+        assertTrue(ex1 is IllegalArgumentException)
+
+        val ex2 = runCatching {
+            service.create(
+                discordId, guildId, threshold = 0.0, priceAtCreation = 120.0,
+                side = UserPriceTriggerDto.Side.BUY, amount = 1L
+            )
+        }.exceptionOrNull()
+        assertTrue(ex2 is IllegalArgumentException)
+    }
+
+    @Test
+    fun `remove enforces ownership`() {
+        val row = row(id = 7, threshold = 100.0, priceAtCreation = 120.0)
+        every { persistence.findById(7L) } returns row
+        every { persistence.deleteById(7L) } returns true
+
+        // Wrong owner — must not delete.
+        assertFalse(service.remove(7L, requestingDiscordId = 9999L))
+        // Correct owner — proceeds.
+        assertTrue(service.remove(7L, requestingDiscordId = discordId))
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/PriceAlertCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/economy/PriceAlertCommand.kt
@@ -1,0 +1,219 @@
+package bot.toby.command.commands.economy
+
+import common.notification.NotificationChannelKind
+import common.notification.Surface
+import core.command.Command.Companion.replyEphemeralAndDelete
+import core.command.Command.Companion.replyEphemeralEmbedAndDelete
+import core.command.CommandContext
+import database.dto.UserDto
+import database.dto.UserPriceTriggerDto
+import database.service.EconomyTradeService
+import database.service.UserNotificationPrefService
+import database.service.UserPriceTriggerService
+import net.dv8tion.jda.api.EmbedBuilder
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
+import net.dv8tion.jda.api.interactions.commands.OptionType
+import net.dv8tion.jda.api.interactions.commands.build.OptionData
+import net.dv8tion.jda.api.interactions.commands.build.SubcommandData
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+import java.awt.Color
+import kotlin.math.abs
+
+@Component
+class PriceAlertCommand @Autowired constructor(
+    private val triggerService: UserPriceTriggerService,
+    private val tradeService: EconomyTradeService,
+    private val prefService: UserNotificationPrefService,
+) : EconomyCommand {
+
+    override val name: String = "pricealert"
+    override val description: String =
+        "Set a TobyCoin price target that auto-executes a buy/sell when reached."
+
+    companion object {
+        private const val OPT_PRICE = "price"
+        private const val OPT_SIDE = "side"
+        private const val OPT_AMOUNT = "amount"
+        private const val OPT_ID = "id"
+
+        // Same precision as the threshold column (NUMERIC(20,6)).
+        // Rejecting threshold == currentPrice (rounded to 4dp) avoids
+        // the "armed at parity" edge case where any next-tick movement
+        // satisfies the target.
+        private const val PARITY_EPSILON = 1e-4
+    }
+
+    override val subCommands: List<SubcommandData> = listOf(
+        SubcommandData("add", "Register a target-price auto-trade.")
+            .addOptions(
+                OptionData(OptionType.NUMBER, OPT_PRICE, "Target price (credits per coin)", true)
+                    .setMinValue(0.01),
+                OptionData(OptionType.STRING, OPT_SIDE, "BUY or SELL when target is reached", true)
+                    .addChoice("BUY", UserPriceTriggerDto.Side.BUY.name)
+                    .addChoice("SELL", UserPriceTriggerDto.Side.SELL.name),
+                OptionData(OptionType.INTEGER, OPT_AMOUNT, "Coins to trade", true)
+                    .setMinValue(1)
+            ),
+        SubcommandData("list", "Show your active price-alert triggers."),
+        SubcommandData("remove", "Delete one of your triggers.")
+            .addOptions(
+                OptionData(OptionType.INTEGER, OPT_ID, "Trigger id (from /pricealert list)", true)
+                    .setMinValue(1)
+            )
+    )
+
+    override fun handle(ctx: CommandContext, requestingUserDto: UserDto, deleteDelay: Int) {
+        val event = ctx.event
+        event.deferReply(true).queue()
+
+        val guild = event.guild ?: run {
+            event.hook.replyEphemeralAndDelete(
+                "This command can only be used in a server.", deleteDelay
+            ); return
+        }
+        val guildId = guild.idLong
+        val discordId = event.user.idLong
+
+        when (event.subcommandName) {
+            "add" -> handleAdd(event, discordId, guildId, deleteDelay)
+            "list" -> handleList(event, discordId, guildId, deleteDelay)
+            "remove" -> handleRemove(event, discordId, deleteDelay)
+            else -> event.hook.replyEphemeralAndDelete("Unknown subcommand.", deleteDelay)
+        }
+    }
+
+    private fun handleAdd(
+        event: SlashCommandInteractionEvent,
+        discordId: Long,
+        guildId: Long,
+        deleteDelay: Int,
+    ) {
+        val threshold = event.getOption(OPT_PRICE)?.asDouble ?: run {
+            event.hook.replyEphemeralAndDelete("Missing price.", deleteDelay); return
+        }
+        val sideName = event.getOption(OPT_SIDE)?.asString ?: run {
+            event.hook.replyEphemeralAndDelete("Missing side.", deleteDelay); return
+        }
+        val amount = event.getOption(OPT_AMOUNT)?.asLong ?: run {
+            event.hook.replyEphemeralAndDelete("Missing amount.", deleteDelay); return
+        }
+        val side = runCatching { UserPriceTriggerDto.Side.valueOf(sideName) }
+            .getOrElse {
+                event.hook.replyEphemeralAndDelete(
+                    "Side must be BUY or SELL.", deleteDelay
+                ); return
+            }
+
+        val market = tradeService.loadOrCreateMarket(guildId)
+        val currentPrice = market.price
+
+        if (abs(threshold - currentPrice) < PARITY_EPSILON) {
+            event.hook.replyEphemeralAndDelete(
+                "Threshold (${"%.4f".format(threshold)}) is essentially the current price " +
+                        "(${"%.4f".format(currentPrice)}). Pick a target meaningfully above or " +
+                        "below the current price so the direction is unambiguous.",
+                deleteDelay
+            )
+            return
+        }
+
+        val trigger = triggerService.create(
+            discordId = discordId,
+            guildId = guildId,
+            threshold = threshold,
+            priceAtCreation = currentPrice,
+            side = side,
+            amount = amount,
+        )
+
+        // Auto-enable PRICE_ALERT DM so the receipt is actually
+        // delivered. Per the approved plan: convenience beats silent
+        // dropping. The user can flip it off later via /notify.
+        val wasOptedIn = prefService.isOptedIn(
+            discordId, guildId, NotificationChannelKind.PRICE_ALERT, Surface.DM
+        )
+        if (!wasOptedIn) {
+            prefService.setPref(
+                discordId, guildId,
+                NotificationChannelKind.PRICE_ALERT, Surface.DM, optIn = true,
+            )
+        }
+
+        val direction = if (threshold < currentPrice) "drop" else "rise"
+        val movePct = abs(threshold - currentPrice) / currentPrice * 100.0
+        val description = buildString {
+            append("Trigger **#${trigger.id}** set. Current price ")
+            append("**${"%.4f".format(currentPrice)}**; when TobyCoin reaches ")
+            append("**${"%.4f".format(threshold)}** (a $direction of ")
+            append("${"%.2f".format(movePct)}%) you'll auto-**${side.name} ${amount}** ")
+            append("and get a DM receipt.")
+            if (!wasOptedIn) {
+                append("\n\n_PRICE_ALERT DMs were off; I enabled them for you so the " +
+                        "receipt can reach you._")
+            }
+        }
+
+        val embed = EmbedBuilder()
+            .setTitle("Price alert created")
+            .setDescription(description)
+            .setColor(Color(0x57, 0xF2, 0x87))
+            .build()
+        event.hook.replyEphemeralEmbedAndDelete(embed, deleteDelay)
+    }
+
+    private fun handleList(
+        event: SlashCommandInteractionEvent,
+        discordId: Long,
+        guildId: Long,
+        deleteDelay: Int,
+    ) {
+        val triggers = triggerService.listForUser(discordId, guildId)
+        if (triggers.isEmpty()) {
+            event.hook.replyEphemeralAndDelete(
+                "You have no price-alert triggers. Use `/pricealert add` to create one.",
+                deleteDelay
+            )
+            return
+        }
+
+        val currentPrice = tradeService.loadOrCreateMarket(guildId).price
+        val embed = EmbedBuilder()
+            .setTitle("Your price-alert triggers")
+            .setDescription("Current TobyCoin price: **${"%.4f".format(currentPrice)}**")
+
+        triggers.forEach { t ->
+            val status = when {
+                !t.enabled && t.firedAt != null -> "fired <t:${t.firedAt!!.epochSecond}:R>"
+                !t.enabled -> "disabled"
+                else -> "armed (waiting)"
+            }
+            val direction = if (t.thresholdPrice < t.priceAtCreation) "↓ drop to" else "↑ rise to"
+            embed.addField(
+                "#${t.id} • ${t.side} ${t.amount}",
+                "$direction **${"%.4f".format(t.thresholdPrice)}** " +
+                        "(created at ${"%.4f".format(t.priceAtCreation)}) — $status",
+                false
+            )
+        }
+        event.hook.replyEphemeralEmbedAndDelete(embed.build(), deleteDelay)
+    }
+
+    private fun handleRemove(
+        event: SlashCommandInteractionEvent,
+        discordId: Long,
+        deleteDelay: Int,
+    ) {
+        val id = event.getOption(OPT_ID)?.asLong ?: run {
+            event.hook.replyEphemeralAndDelete("Missing id.", deleteDelay); return
+        }
+        val removed = triggerService.remove(id, discordId)
+        if (removed) {
+            event.hook.replyEphemeralAndDelete("Trigger #$id removed.", deleteDelay)
+        } else {
+            event.hook.replyEphemeralAndDelete(
+                "No trigger #$id found that you own.", deleteDelay
+            )
+        }
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/notify/PriceAlertReceiptBuilder.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/notify/PriceAlertReceiptBuilder.kt
@@ -1,0 +1,174 @@
+package bot.toby.notify
+
+import common.notification.PushPayload
+import database.dto.UserPriceTriggerDto
+import database.service.EconomyTradeService.TradeOutcome
+import net.dv8tion.jda.api.EmbedBuilder
+import net.dv8tion.jda.api.utils.messages.MessageCreateBuilder
+import net.dv8tion.jda.api.utils.messages.MessageCreateData
+import java.awt.Color
+
+/**
+ * Renders the DM and push payloads for an auto-executed price-alert
+ * trade. The trade has already happened by the time we get here —
+ * we're a receipt, not a confirmation. No interactive components.
+ *
+ * Fee handling mirrors the canonical wording in
+ * `TobyCoinCommand.describe` so users see the same "X gross + Y fee"
+ * breakdown they'd get from a manual `/tobycoin buy|sell`. The fee
+ * routes to the per-guild jackpot pool — surfacing that in the embed
+ * makes the deduction obvious instead of a mystery line.
+ */
+object PriceAlertReceiptBuilder {
+
+    private val SUCCESS_COLOR = Color(0x57, 0xF2, 0x87)
+    private val FAILURE_COLOR = Color(0xED, 0x42, 0x45)
+
+    fun buildDm(
+        trigger: UserPriceTriggerDto,
+        outcome: TradeOutcome,
+    ): MessageCreateData {
+        val side = trigger.side
+        val embed = when (outcome) {
+            is TradeOutcome.Ok -> okEmbed(trigger, outcome, side)
+            is TradeOutcome.InsufficientCredits -> insufficientCreditsEmbed(trigger, outcome)
+            is TradeOutcome.InsufficientCoins -> insufficientCoinsEmbed(trigger, outcome)
+            TradeOutcome.InvalidAmount -> failureEmbed(
+                trigger,
+                "the trade was rejected as invalid (amount ${trigger.amount}). " +
+                        "This shouldn't normally happen — please report it."
+            )
+            TradeOutcome.UnknownUser -> failureEmbed(
+                trigger,
+                "I couldn't find your wallet in this guild. The trigger has been disabled."
+            )
+        }
+        return MessageCreateBuilder().setEmbeds(embed).build()
+    }
+
+    fun buildPush(
+        trigger: UserPriceTriggerDto,
+        outcome: TradeOutcome,
+    ): PushPayload {
+        val title = "TobyCoin price alert"
+        val body = when (outcome) {
+            is TradeOutcome.Ok ->
+                "${pastTense(trigger.side)} ${outcome.amount} TOBY at ${"%.4f".format(outcome.newPrice)}."
+            is TradeOutcome.InsufficientCredits ->
+                "Trigger #${trigger.id} fired but you lacked credits to BUY."
+            is TradeOutcome.InsufficientCoins ->
+                "Trigger #${trigger.id} fired but you lacked TOBY to SELL."
+            TradeOutcome.InvalidAmount ->
+                "Trigger #${trigger.id} fired but the trade was rejected as invalid."
+            TradeOutcome.UnknownUser ->
+                "Trigger #${trigger.id} fired but your wallet wasn't found."
+        }
+        return PushPayload(title = title, body = body)
+    }
+
+    private fun okEmbed(
+        trigger: UserPriceTriggerDto,
+        ok: TradeOutcome.Ok,
+        side: String,
+    ): net.dv8tion.jda.api.entities.MessageEmbed {
+        val verb = pastTense(side)
+        val executionPrice = if (ok.amount > 0L) {
+            // Reconstruct from the canonical gross. Both BUY and SELL
+            // round the gross at trade time (ceil for BUY, floor for
+            // SELL) — re-deriving an "execution price" from
+            // gross/amount is a small lie at the sub-credit level, but
+            // matches what `/tobycoin buy|sell` users already see and
+            // keeps the receipt free of a separate price-per-coin
+            // field that would have to be plumbed through TradeOutcome.
+            val isBuy = side == UserPriceTriggerDto.Side.BUY.name
+            val gross = if (isBuy) ok.transactedCredits - ok.fee
+                        else ok.transactedCredits + ok.fee
+            gross.toDouble() / ok.amount
+        } else 0.0
+
+        val embed = EmbedBuilder()
+            .setTitle("Auto-trade executed — Trigger #${trigger.id}")
+            .setColor(SUCCESS_COLOR)
+            .addField(
+                "Target",
+                "${"%.4f".format(trigger.thresholdPrice)} (reached, new price " +
+                        "${"%.4f".format(ok.newPrice)})",
+                false
+            )
+            .addField(
+                "Trade",
+                "**$verb ${ok.amount} TOBY** @ ${"%.4f".format(executionPrice)}",
+                false
+            )
+
+        if (side == UserPriceTriggerDto.Side.BUY.name) {
+            val gross = ok.transactedCredits - ok.fee
+            val feePart = if (ok.fee > 0L) " + **${ok.fee}** fee (to jackpot)" else ""
+            embed.addField(
+                "Cost",
+                "**${gross}** credits subtotal$feePart = **${ok.transactedCredits}** credits total",
+                false
+            )
+        } else {
+            val gross = ok.transactedCredits + ok.fee
+            val feePart = if (ok.fee > 0L) " − **${ok.fee}** fee (to jackpot)" else ""
+            embed.addField(
+                "Proceeds",
+                "**${gross}** credits gross$feePart = **${ok.transactedCredits}** credits received",
+                false
+            )
+        }
+
+        embed.addField(
+            "New balance",
+            "**${ok.newCoins}** TOBY • **${ok.newCredits}** credits",
+            false
+        )
+        embed.setFooter("Trigger one-shot — use /pricealert add to set another.")
+        return embed.build()
+    }
+
+    private fun insufficientCreditsEmbed(
+        trigger: UserPriceTriggerDto,
+        outcome: TradeOutcome.InsufficientCredits,
+    ) = EmbedBuilder()
+        .setTitle("Auto-trade skipped — Trigger #${trigger.id}")
+        .setColor(FAILURE_COLOR)
+        .setDescription(
+            "Target ${"%.4f".format(trigger.thresholdPrice)} was reached, but you didn't " +
+                    "have enough credits to BUY ${trigger.amount} TOBY: needed " +
+                    "**${outcome.needed}** credits (price + fee), had **${outcome.have}**. " +
+                    "No trade made. Trigger disabled."
+        )
+        .build()
+
+    private fun insufficientCoinsEmbed(
+        trigger: UserPriceTriggerDto,
+        outcome: TradeOutcome.InsufficientCoins,
+    ) = EmbedBuilder()
+        .setTitle("Auto-trade skipped — Trigger #${trigger.id}")
+        .setColor(FAILURE_COLOR)
+        .setDescription(
+            "Target ${"%.4f".format(trigger.thresholdPrice)} was reached, but you didn't " +
+                    "have enough TOBY to SELL ${trigger.amount}: needed **${outcome.needed}** " +
+                    "coins, had **${outcome.have}**. No trade made. Trigger disabled."
+        )
+        .build()
+
+    private fun failureEmbed(
+        trigger: UserPriceTriggerDto,
+        reason: String,
+    ) = EmbedBuilder()
+        .setTitle("Auto-trade failed — Trigger #${trigger.id}")
+        .setColor(FAILURE_COLOR)
+        .setDescription(
+            "Target ${"%.4f".format(trigger.thresholdPrice)} was reached but $reason"
+        )
+        .build()
+
+    private fun pastTense(side: String): String = when (side) {
+        UserPriceTriggerDto.Side.BUY.name -> "Bought"
+        UserPriceTriggerDto.Side.SELL.name -> "Sold"
+        else -> side
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/notify/PriceAlertReceiptBuilder.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/notify/PriceAlertReceiptBuilder.kt
@@ -2,6 +2,7 @@ package bot.toby.notify
 
 import common.notification.PushPayload
 import database.dto.UserPriceTriggerDto
+import database.dto.UserPriceTriggerDto.Side
 import database.service.EconomyTradeService.TradeOutcome
 import net.dv8tion.jda.api.EmbedBuilder
 import net.dv8tion.jda.api.utils.messages.MessageCreateBuilder
@@ -28,7 +29,7 @@ object PriceAlertReceiptBuilder {
         trigger: UserPriceTriggerDto,
         outcome: TradeOutcome,
     ): MessageCreateData {
-        val side = trigger.side
+        val side = trigger.sideEnum
         val embed = when (outcome) {
             is TradeOutcome.Ok -> okEmbed(trigger, outcome, side)
             is TradeOutcome.InsufficientCredits -> insufficientCreditsEmbed(trigger, outcome)
@@ -53,7 +54,7 @@ object PriceAlertReceiptBuilder {
         val title = "TobyCoin price alert"
         val body = when (outcome) {
             is TradeOutcome.Ok ->
-                "${pastTense(trigger.side)} ${outcome.amount} TOBY at ${"%.4f".format(outcome.newPrice)}."
+                "${pastTense(trigger.sideEnum)} ${outcome.amount} TOBY at ${"%.4f".format(outcome.newPrice)}."
             is TradeOutcome.InsufficientCredits ->
                 "Trigger #${trigger.id} fired but you lacked credits to BUY."
             is TradeOutcome.InsufficientCoins ->
@@ -69,8 +70,9 @@ object PriceAlertReceiptBuilder {
     private fun okEmbed(
         trigger: UserPriceTriggerDto,
         ok: TradeOutcome.Ok,
-        side: String,
+        side: Side,
     ): net.dv8tion.jda.api.entities.MessageEmbed {
+        val isBuy = side == Side.BUY
         val verb = pastTense(side)
         val executionPrice = if (ok.amount > 0L) {
             // Reconstruct from the canonical gross. Both BUY and SELL
@@ -80,7 +82,6 @@ object PriceAlertReceiptBuilder {
             // matches what `/tobycoin buy|sell` users already see and
             // keeps the receipt free of a separate price-per-coin
             // field that would have to be plumbed through TradeOutcome.
-            val isBuy = side == UserPriceTriggerDto.Side.BUY.name
             val gross = if (isBuy) ok.transactedCredits - ok.fee
                         else ok.transactedCredits + ok.fee
             gross.toDouble() / ok.amount
@@ -101,7 +102,7 @@ object PriceAlertReceiptBuilder {
                 false
             )
 
-        if (side == UserPriceTriggerDto.Side.BUY.name) {
+        if (isBuy) {
             val gross = ok.transactedCredits - ok.fee
             val feePart = if (ok.fee > 0L) " + **${ok.fee}** fee (to jackpot)" else ""
             embed.addField(
@@ -166,9 +167,8 @@ object PriceAlertReceiptBuilder {
         )
         .build()
 
-    private fun pastTense(side: String): String = when (side) {
-        UserPriceTriggerDto.Side.BUY.name -> "Bought"
-        UserPriceTriggerDto.Side.SELL.name -> "Sold"
-        else -> side
+    private fun pastTense(side: Side): String = when (side) {
+        Side.BUY -> "Bought"
+        Side.SELL -> "Sold"
     }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/scheduling/TobyCoinPriceTickJob.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/scheduling/TobyCoinPriceTickJob.kt
@@ -1,10 +1,16 @@
 package bot.toby.scheduling
 
-import database.economy.TobyCoinEngine
+import bot.toby.notify.NotificationRouter
+import bot.toby.notify.PriceAlertReceiptBuilder
 import common.logging.DiscordLogger
+import common.notification.NotificationChannelKind
 import database.dto.TobyCoinMarketDto
 import database.dto.TobyCoinPricePointDto
+import database.dto.UserPriceTriggerDto
+import database.economy.TobyCoinEngine
+import database.service.EconomyTradeService
 import database.service.TobyCoinMarketService
+import database.service.UserPriceTriggerService
 import net.dv8tion.jda.api.JDA
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Profile
@@ -20,12 +26,22 @@ import kotlin.random.Random
  * Each tick applies a GBM random-walk step (so the chart keeps moving even
  * when nobody trades) and appends a sample to the price history so the
  * chart has fresh data. Old history rows are pruned after each pass.
+ *
+ * After persisting the new price, [handleTriggered] scans
+ * `user_price_trigger` rows whose target was reached by the tick and
+ * auto-executes the user's declared BUY/SELL via [EconomyTradeService],
+ * DM'ing a receipt via [NotificationRouter]. Triggers are one-shot —
+ * fired rows are disabled so an oscillation around the threshold can't
+ * replay the trade.
  */
 @Component
 @Profile("prod")
 class TobyCoinPriceTickJob @Autowired constructor(
     private val jda: JDA,
-    private val marketService: TobyCoinMarketService
+    private val marketService: TobyCoinMarketService,
+    private val triggerService: UserPriceTriggerService,
+    private val tradeService: EconomyTradeService,
+    private val notificationRouter: NotificationRouter,
 ) {
     private val logger: DiscordLogger = DiscordLogger.createLogger(this::class.java)
 
@@ -71,5 +87,42 @@ class TobyCoinPriceTickJob @Autowired constructor(
         marketService.appendPricePoint(
             TobyCoinPricePointDto(guildId = guildId, sampledAt = now, price = newPrice)
         )
+        handleTriggered(guildId, newPrice, now)
+    }
+
+    private fun handleTriggered(guildId: Long, newPrice: Double, now: Instant) {
+        val rows = triggerService.findTriggered(guildId, newPrice)
+        if (rows.isEmpty()) return
+        rows.forEach { row ->
+            runCatching { executeTrigger(row, guildId, now) }
+                .onFailure { err ->
+                    logger.warn(
+                        "Price-alert auto-trade failed trigger=${row.id} " +
+                                "user=${row.discordId} guild=$guildId: ${err.message}"
+                    )
+                    // Disable the row anyway so a broken trigger doesn't
+                    // re-fire every 5 minutes for the next 24 hours.
+                    runCatching { triggerService.markFired(row.id!!, now) }
+                }
+        }
+    }
+
+    private fun executeTrigger(row: UserPriceTriggerDto, guildId: Long, now: Instant) {
+        val outcome = when (row.side) {
+            UserPriceTriggerDto.Side.BUY.name ->
+                tradeService.buy(row.discordId, guildId, row.amount)
+            UserPriceTriggerDto.Side.SELL.name ->
+                tradeService.sell(row.discordId, guildId, row.amount)
+            else -> {
+                logger.warn("Unknown side ${row.side} on trigger ${row.id}; disabling.")
+                triggerService.markFired(row.id!!, now)
+                return
+            }
+        }
+        notificationRouter.dispatch(NotificationChannelKind.PRICE_ALERT, row.discordId, guildId) {
+            dm { PriceAlertReceiptBuilder.buildDm(row, outcome) }
+            push { PriceAlertReceiptBuilder.buildPush(row, outcome) }
+        }
+        triggerService.markFired(row.id!!, now)
     }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/scheduling/TobyCoinPriceTickJob.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/scheduling/TobyCoinPriceTickJob.kt
@@ -101,23 +101,29 @@ class TobyCoinPriceTickJob @Autowired constructor(
                                 "user=${row.discordId} guild=$guildId: ${err.message}"
                     )
                     // Disable the row anyway so a broken trigger doesn't
-                    // re-fire every 5 minutes for the next 24 hours.
+                    // re-fire every 5 minutes for the next 24 hours. A
+                    // second failure here would otherwise be silent —
+                    // log it so the operator sees both halves.
                     runCatching { triggerService.markFired(row.id!!, now) }
+                        .onFailure { markErr ->
+                            logger.warn(
+                                "Also failed to disable broken trigger=${row.id} " +
+                                        "after trade-execution failure: ${markErr.message}"
+                            )
+                        }
                 }
         }
     }
 
     private fun executeTrigger(row: UserPriceTriggerDto, guildId: Long, now: Instant) {
-        val outcome = when (row.side) {
-            UserPriceTriggerDto.Side.BUY.name ->
-                tradeService.buy(row.discordId, guildId, row.amount)
-            UserPriceTriggerDto.Side.SELL.name ->
-                tradeService.sell(row.discordId, guildId, row.amount)
-            else -> {
-                logger.warn("Unknown side ${row.side} on trigger ${row.id}; disabling.")
-                triggerService.markFired(row.id!!, now)
-                return
-            }
+        val side = runCatching { row.sideEnum }.getOrElse {
+            logger.warn("Unknown side ${row.side} on trigger ${row.id}; disabling.")
+            triggerService.markFired(row.id!!, now)
+            return
+        }
+        val outcome = when (side) {
+            UserPriceTriggerDto.Side.BUY -> tradeService.buy(row.discordId, guildId, row.amount)
+            UserPriceTriggerDto.Side.SELL -> tradeService.sell(row.discordId, guildId, row.amount)
         }
         notificationRouter.dispatch(NotificationChannelKind.PRICE_ALERT, row.discordId, guildId) {
             dm { PriceAlertReceiptBuilder.buildDm(row, outcome) }

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/economy/PriceAlertCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/economy/PriceAlertCommandTest.kt
@@ -1,0 +1,162 @@
+package bot.toby.command.commands.economy
+
+import bot.toby.command.CommandTest
+import bot.toby.command.CommandTest.Companion.event
+import bot.toby.command.CommandTest.Companion.interactionHook
+import bot.toby.command.DefaultCommandContext
+import common.notification.NotificationChannelKind
+import common.notification.Surface
+import database.dto.TobyCoinMarketDto
+import database.dto.UserDto
+import database.dto.UserPriceTriggerDto
+import database.service.EconomyTradeService
+import database.service.UserNotificationPrefService
+import database.service.UserPriceTriggerService
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import net.dv8tion.jda.api.entities.MessageEmbed
+import net.dv8tion.jda.api.interactions.commands.OptionMapping
+import net.dv8tion.jda.api.requests.restaction.WebhookMessageCreateAction
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+internal class PriceAlertCommandTest : CommandTest {
+
+    private lateinit var triggerService: UserPriceTriggerService
+    private lateinit var tradeService: EconomyTradeService
+    private lateinit var prefService: UserNotificationPrefService
+    private lateinit var command: PriceAlertCommand
+
+    private val discordId = 1L
+    private val guildId = 1L
+
+    @BeforeEach
+    fun setUp() {
+        setUpCommonMocks()
+        triggerService = mockk(relaxed = true)
+        tradeService = mockk(relaxed = true)
+        prefService = mockk(relaxed = true)
+        command = PriceAlertCommand(triggerService, tradeService, prefService)
+
+        every { event.deferReply(true) } returns CommandTest.replyCallbackAction
+        every { tradeService.loadOrCreateMarket(guildId) } returns
+                TobyCoinMarketDto(guildId = guildId, price = 100.0, lastTickAt = Instant.now())
+    }
+
+    @AfterEach
+    fun tearDown() {
+        tearDownCommonMocks()
+        clearAllMocks()
+    }
+
+    private fun stringOpt(value: String): OptionMapping {
+        val o = mockk<OptionMapping>(relaxed = true)
+        every { o.asString } returns value
+        return o
+    }
+
+    private fun longOpt(value: Long): OptionMapping {
+        val o = mockk<OptionMapping>(relaxed = true)
+        every { o.asLong } returns value
+        return o
+    }
+
+    private fun doubleOpt(value: Double): OptionMapping {
+        val o = mockk<OptionMapping>(relaxed = true)
+        every { o.asDouble } returns value
+        return o
+    }
+
+    @Test
+    fun `add rejects threshold equal to current price`() {
+        every { event.subcommandName } returns "add"
+        every { event.getOption("price") } returns doubleOpt(100.0)
+        every { event.getOption("side") } returns stringOpt("BUY")
+        every { event.getOption("amount") } returns longOpt(5L)
+
+        command.handle(DefaultCommandContext(event), UserDto(discordId, guildId), 5)
+
+        // Parity branch sends an ephemeral text reply (not embed) and
+        // never reaches the service.
+        verify(exactly = 0) {
+            triggerService.create(any(), any(), any(), any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `add creates trigger and auto-enables PRICE_ALERT DM when opted-out`() {
+        every { event.subcommandName } returns "add"
+        every { event.getOption("price") } returns doubleOpt(80.0)
+        every { event.getOption("side") } returns stringOpt("BUY")
+        every { event.getOption("amount") } returns longOpt(5L)
+        every {
+            prefService.isOptedIn(discordId, guildId, NotificationChannelKind.PRICE_ALERT, Surface.DM)
+        } returns false
+        val created = UserPriceTriggerDto(
+            id = 42L,
+            discordId = discordId, guildId = guildId,
+            thresholdPrice = 80.0, priceAtCreation = 100.0,
+            side = UserPriceTriggerDto.Side.BUY.name, amount = 5L,
+        )
+        every {
+            triggerService.create(discordId, guildId, 80.0, 100.0, UserPriceTriggerDto.Side.BUY, 5L)
+        } returns created
+
+        // Capture the embed sent back so we can assert the direction copy.
+        val embedSlot = slot<MessageEmbed>()
+        every {
+            interactionHook.sendMessageEmbeds(capture(embedSlot))
+        } returns mockk<WebhookMessageCreateAction<net.dv8tion.jda.api.entities.Message>>(relaxed = true)
+
+        command.handle(DefaultCommandContext(event), UserDto(discordId, guildId), 5)
+
+        verify(exactly = 1) {
+            triggerService.create(discordId, guildId, 80.0, 100.0, UserPriceTriggerDto.Side.BUY, 5L)
+        }
+        verify(exactly = 1) {
+            prefService.setPref(
+                discordId, guildId, NotificationChannelKind.PRICE_ALERT, Surface.DM, optIn = true
+            )
+        }
+        val desc = embedSlot.captured.description.orEmpty()
+        assertTrue(desc.contains("drop"), "downward target must read 'drop': $desc")
+        assertTrue(desc.contains("PRICE_ALERT"), "should warn that PRICE_ALERT was enabled: $desc")
+    }
+
+    @Test
+    fun `add does not flip pref when already opted-in`() {
+        every { event.subcommandName } returns "add"
+        every { event.getOption("price") } returns doubleOpt(150.0)
+        every { event.getOption("side") } returns stringOpt("SELL")
+        every { event.getOption("amount") } returns longOpt(3L)
+        every {
+            prefService.isOptedIn(discordId, guildId, NotificationChannelKind.PRICE_ALERT, Surface.DM)
+        } returns true
+        every {
+            triggerService.create(any(), any(), any(), any(), any(), any())
+        } returns UserPriceTriggerDto(id = 1L, discordId = discordId, guildId = guildId)
+
+        command.handle(DefaultCommandContext(event), UserDto(discordId, guildId), 5)
+
+        verify(exactly = 0) {
+            prefService.setPref(any(), any(), any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `remove enforces ownership through the service`() {
+        every { event.subcommandName } returns "remove"
+        every { event.getOption("id") } returns longOpt(99L)
+        every { triggerService.remove(99L, discordId) } returns false
+
+        command.handle(DefaultCommandContext(event), UserDto(discordId, guildId), 5)
+
+        verify(exactly = 1) { triggerService.remove(99L, discordId) }
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/economy/PriceAlertCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/economy/PriceAlertCommandTest.kt
@@ -3,6 +3,7 @@ package bot.toby.command.commands.economy
 import bot.toby.command.CommandTest
 import bot.toby.command.CommandTest.Companion.event
 import bot.toby.command.CommandTest.Companion.interactionHook
+import bot.toby.command.CommandTest.Companion.webhookMessageCreateAction
 import bot.toby.command.DefaultCommandContext
 import common.notification.NotificationChannelKind
 import common.notification.Surface
@@ -17,7 +18,6 @@ import database.service.UserPriceTriggerService
 import io.mockk.*
 import net.dv8tion.jda.api.entities.MessageEmbed
 import net.dv8tion.jda.api.interactions.commands.OptionMapping
-import net.dv8tion.jda.api.requests.restaction.WebhookMessageCreateAction
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -108,14 +108,15 @@ internal class PriceAlertCommandTest : CommandTest {
         } returns created
 
         // Capture the embed sent back so we can assert the direction
-        // copy. JDA's `sendMessageEmbeds(MessageEmbed, MessageEmbed...)`
-        // has a vararg tail; the matcher must spell out `*anyVararg()`
-        // or it falls through to the looser stub in CommandTest which
-        // doesn't capture.
+        // copy. Stub through the chained `event.hook.sendMessageEmbeds`
+        // (matches the working pattern in LevelCommandTest /
+        // JackpotAdminCommandTest); the companion `interactionHook`
+        // reference doesn't get matched by mockk on this codebase even
+        // though `event.hook` is stubbed to return it.
         val embedSlot = slot<MessageEmbed>()
         every {
-            interactionHook.sendMessageEmbeds(capture(embedSlot), *anyVararg())
-        } returns mockk<WebhookMessageCreateAction<net.dv8tion.jda.api.entities.Message>>(relaxed = true)
+            event.hook.sendMessageEmbeds(capture(embedSlot), *anyVararg())
+        } returns webhookMessageCreateAction
 
         command.handle(DefaultCommandContext(event), UserDto(discordId, guildId), 5)
 
@@ -176,7 +177,7 @@ internal class PriceAlertCommandTest : CommandTest {
         // failure branch does the same). We can't easily assert the
         // text content without overriding `sendMessage`, but we can
         // verify that the call hit the service and reached `queue()`.
-        verify(atLeast = 1) { interactionHook.sendMessage(any<String>()) }
+        verify(atLeast = 1) { event.hook.sendMessage(any<String>()) }
     }
 
     @Test
@@ -242,8 +243,13 @@ internal class PriceAlertCommandTest : CommandTest {
 
         command.handle(DefaultCommandContext(event), UserDto(discordId, guildId), 5)
 
+        // Positive assertion through the chained `event.hook` matcher
+        // (matches the working LevelCommandTest pattern). The negative
+        // assertion goes through the leaf `interactionHook` ref so the
+        // chain doesn't also count the `event.hook` getter that the
+        // sendMessage call site rightly invoked.
+        verify(atLeast = 1) { event.hook.sendMessage(any<String>()) }
         verify(exactly = 0) { interactionHook.sendMessageEmbeds(any<MessageEmbed>(), *anyVararg()) }
-        verify(atLeast = 1) { interactionHook.sendMessage(any<String>()) }
     }
 
     @Test
@@ -265,8 +271,8 @@ internal class PriceAlertCommandTest : CommandTest {
         )
         val embedSlot = slot<MessageEmbed>()
         every {
-            interactionHook.sendMessageEmbeds(capture(embedSlot), *anyVararg())
-        } returns mockk<WebhookMessageCreateAction<net.dv8tion.jda.api.entities.Message>>(relaxed = true)
+            event.hook.sendMessageEmbeds(capture(embedSlot), *anyVararg())
+        } returns webhookMessageCreateAction
 
         command.handle(DefaultCommandContext(event), UserDto(discordId, guildId), 5)
 

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/economy/PriceAlertCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/economy/PriceAlertCommandTest.kt
@@ -108,10 +108,14 @@ internal class PriceAlertCommandTest : CommandTest {
             triggerService.create(discordId, guildId, 80.0, 100.0, UserPriceTriggerDto.Side.BUY, 5L)
         } returns created
 
-        // Capture the embed sent back so we can assert the direction copy.
+        // Capture the embed sent back so we can assert the direction
+        // copy. JDA's `sendMessageEmbeds(MessageEmbed, MessageEmbed...)`
+        // has a vararg tail; the matcher must spell out `*anyVararg()`
+        // or it falls through to the looser stub in CommandTest which
+        // doesn't capture.
         val embedSlot = slot<MessageEmbed>()
         every {
-            interactionHook.sendMessageEmbeds(capture(embedSlot))
+            interactionHook.sendMessageEmbeds(capture(embedSlot), *anyVararg())
         } returns mockk<WebhookMessageCreateAction<net.dv8tion.jda.api.entities.Message>>(relaxed = true)
 
         command.handle(DefaultCommandContext(event), UserDto(discordId, guildId), 5)
@@ -158,5 +162,118 @@ internal class PriceAlertCommandTest : CommandTest {
         command.handle(DefaultCommandContext(event), UserDto(discordId, guildId), 5)
 
         verify(exactly = 1) { triggerService.remove(99L, discordId) }
+    }
+
+    @Test
+    fun `remove success path replies with confirmation`() {
+        every { event.subcommandName } returns "remove"
+        every { event.getOption("id") } returns longOpt(42L)
+        every { triggerService.remove(42L, discordId) } returns true
+
+        command.handle(DefaultCommandContext(event), UserDto(discordId, guildId), 5)
+
+        verify(exactly = 1) { triggerService.remove(42L, discordId) }
+        // The success branch sends a non-embed ephemeral reply (the
+        // failure branch does the same). We can't easily assert the
+        // text content without overriding `sendMessage`, but we can
+        // verify that the call hit the service and reached `queue()`.
+        verify(atLeast = 1) { interactionHook.sendMessage(any<String>()) }
+    }
+
+    @Test
+    fun `add handles missing price option`() {
+        every { event.subcommandName } returns "add"
+        every { event.getOption("price") } returns null
+        every { event.getOption("side") } returns stringOpt("BUY")
+        every { event.getOption("amount") } returns longOpt(5L)
+
+        command.handle(DefaultCommandContext(event), UserDto(discordId, guildId), 5)
+
+        verify(exactly = 0) {
+            triggerService.create(any(), any(), any(), any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `add handles missing side option`() {
+        every { event.subcommandName } returns "add"
+        every { event.getOption("price") } returns doubleOpt(80.0)
+        every { event.getOption("side") } returns null
+        every { event.getOption("amount") } returns longOpt(5L)
+
+        command.handle(DefaultCommandContext(event), UserDto(discordId, guildId), 5)
+
+        verify(exactly = 0) {
+            triggerService.create(any(), any(), any(), any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `add handles missing amount option`() {
+        every { event.subcommandName } returns "add"
+        every { event.getOption("price") } returns doubleOpt(80.0)
+        every { event.getOption("side") } returns stringOpt("BUY")
+        every { event.getOption("amount") } returns null
+
+        command.handle(DefaultCommandContext(event), UserDto(discordId, guildId), 5)
+
+        verify(exactly = 0) {
+            triggerService.create(any(), any(), any(), any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `add rejects invalid side string`() {
+        every { event.subcommandName } returns "add"
+        every { event.getOption("price") } returns doubleOpt(80.0)
+        every { event.getOption("side") } returns stringOpt("WOBBLE")
+        every { event.getOption("amount") } returns longOpt(5L)
+
+        command.handle(DefaultCommandContext(event), UserDto(discordId, guildId), 5)
+
+        verify(exactly = 0) {
+            triggerService.create(any(), any(), any(), any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `list with no triggers renders empty-state hint`() {
+        every { event.subcommandName } returns "list"
+        every { triggerService.listForUser(discordId, guildId) } returns emptyList()
+
+        command.handle(DefaultCommandContext(event), UserDto(discordId, guildId), 5)
+
+        verify(exactly = 0) { interactionHook.sendMessageEmbeds(any<MessageEmbed>(), *anyVararg()) }
+        verify(atLeast = 1) { interactionHook.sendMessage(any<String>()) }
+    }
+
+    @Test
+    fun `list with triggers renders one field per row`() {
+        every { event.subcommandName } returns "list"
+        every { triggerService.listForUser(discordId, guildId) } returns listOf(
+            UserPriceTriggerDto(
+                id = 1L, discordId = discordId, guildId = guildId,
+                thresholdPrice = 80.0, priceAtCreation = 100.0,
+                side = UserPriceTriggerDto.Side.BUY.name, amount = 5L,
+                enabled = true,
+            ),
+            UserPriceTriggerDto(
+                id = 2L, discordId = discordId, guildId = guildId,
+                thresholdPrice = 150.0, priceAtCreation = 100.0,
+                side = UserPriceTriggerDto.Side.SELL.name, amount = 3L,
+                enabled = true,
+            ),
+        )
+        val embedSlot = slot<MessageEmbed>()
+        every {
+            interactionHook.sendMessageEmbeds(capture(embedSlot), *anyVararg())
+        } returns mockk<WebhookMessageCreateAction<net.dv8tion.jda.api.entities.Message>>(relaxed = true)
+
+        command.handle(DefaultCommandContext(event), UserDto(discordId, guildId), 5)
+
+        assertEquals(2, embedSlot.captured.fields.size, "two triggers should produce two fields")
+        val text = embedSlot.captured.fields.joinToString(" ") { "${it.name} ${it.value}" }
+        assertTrue(text.contains("↓"), "downward arrow should appear for BUY-below trigger: $text")
+        assertTrue(text.contains("↑"), "upward arrow should appear for SELL-above trigger: $text")
     }
 }

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/economy/PriceAlertCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/economy/PriceAlertCommandTest.kt
@@ -12,6 +12,7 @@ import database.dto.UserPriceTriggerDto
 import database.service.EconomyTradeService
 import database.service.UserNotificationPrefService
 import database.service.UserPriceTriggerService
+import io.mockk.anyVararg
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
@@ -21,6 +22,7 @@ import net.dv8tion.jda.api.entities.MessageEmbed
 import net.dv8tion.jda.api.interactions.commands.OptionMapping
 import net.dv8tion.jda.api.requests.restaction.WebhookMessageCreateAction
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/economy/PriceAlertCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/economy/PriceAlertCommandTest.kt
@@ -12,12 +12,9 @@ import database.dto.UserPriceTriggerDto
 import database.service.EconomyTradeService
 import database.service.UserNotificationPrefService
 import database.service.UserPriceTriggerService
-import io.mockk.anyVararg
-import io.mockk.clearAllMocks
-import io.mockk.every
-import io.mockk.mockk
-import io.mockk.slot
-import io.mockk.verify
+// Wildcard so the `anyVararg()` MockKMatcherScope extension resolves —
+// it's not exposed as a top-level import like `every` / `mockk`.
+import io.mockk.*
 import net.dv8tion.jda.api.entities.MessageEmbed
 import net.dv8tion.jda.api.interactions.commands.OptionMapping
 import net.dv8tion.jda.api.requests.restaction.WebhookMessageCreateAction

--- a/discord-bot/src/test/kotlin/bot/toby/notify/PriceAlertReceiptBuilderTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/notify/PriceAlertReceiptBuilderTest.kt
@@ -1,0 +1,142 @@
+package bot.toby.notify
+
+import database.dto.UserPriceTriggerDto
+import database.service.EconomyTradeService.TradeOutcome
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class PriceAlertReceiptBuilderTest {
+
+    private fun trigger(side: UserPriceTriggerDto.Side, amount: Long = 10) = UserPriceTriggerDto(
+        id = 42,
+        discordId = 1L,
+        guildId = 100L,
+        thresholdPrice = 100.0,
+        priceAtCreation = 120.0,
+        side = side.name,
+        amount = amount,
+        enabled = false,
+    )
+
+    private fun renderedText(dm: net.dv8tion.jda.api.utils.messages.MessageCreateData): String {
+        val embed = dm.embeds.single()
+        val title = embed.title.orEmpty()
+        val desc = embed.description.orEmpty()
+        val fields = embed.fields.joinToString("\n") { "${it.name}: ${it.value}" }
+        return "$title\n$desc\n$fields"
+    }
+
+    @Test
+    fun `BUY receipt shows subtotal, fee, and total with total = subtotal + fee`() {
+        val ok = TradeOutcome.Ok(
+            amount = 10L,
+            transactedCredits = 1023L,
+            newCoins = 145L,
+            newCredits = 8977L,
+            newPrice = 102.34,
+            fee = 11L,
+        )
+        val dm = PriceAlertReceiptBuilder.buildDm(trigger(UserPriceTriggerDto.Side.BUY), ok)
+        val text = renderedText(dm)
+
+        // Subtotal (gross) = transactedCredits - fee = 1012.
+        assertTrue(text.contains("**1012**"), "expected gross 1012 wrapped in bold: $text")
+        assertTrue(text.contains("**11**"), "expected fee 11 wrapped in bold: $text")
+        assertTrue(text.contains("**1023**"), "expected total 1023 wrapped in bold: $text")
+        assertTrue(text.contains("jackpot"), "fee destination must be visible: $text")
+    }
+
+    @Test
+    fun `SELL receipt shows gross, fee, and proceeds with proceeds = gross - fee`() {
+        val ok = TradeOutcome.Ok(
+            amount = 4L,
+            transactedCredits = 396L,
+            newCoins = 0L,
+            newCredits = 396L,
+            newPrice = 99.84,
+            fee = 4L,
+        )
+        val dm = PriceAlertReceiptBuilder.buildDm(trigger(UserPriceTriggerDto.Side.SELL), ok)
+        val text = renderedText(dm)
+
+        // Gross = transactedCredits + fee = 400.
+        assertTrue(text.contains("**400**"), "expected gross 400 wrapped in bold: $text")
+        assertTrue(text.contains("**4**"), "expected fee 4 wrapped in bold: $text")
+        assertTrue(text.contains("**396**"), "expected proceeds 396 wrapped in bold: $text")
+        assertTrue(text.contains("jackpot"), "fee destination must be visible: $text")
+    }
+
+    @Test
+    fun `zero-fee receipt does not render a naked plus 0 fee line`() {
+        val ok = TradeOutcome.Ok(
+            amount = 5L,
+            transactedCredits = 500L,
+            newCoins = 5L,
+            newCredits = 500L,
+            newPrice = 100.0,
+            fee = 0L,
+        )
+        val dm = PriceAlertReceiptBuilder.buildDm(trigger(UserPriceTriggerDto.Side.BUY), ok)
+        val text = renderedText(dm)
+
+        assertTrue(text.contains("500"), "expected total 500 in: $text")
+        assertFalse(text.contains("jackpot"), "zero fee should not mention jackpot: $text")
+        assertFalse(text.contains("+ 0"), "zero fee should not render '+ 0' line: $text")
+        assertFalse(text.contains("− 0"), "zero fee should not render '− 0' line: $text")
+    }
+
+    @Test
+    fun `InsufficientCredits embed surfaces fee-inclusive needed amount as-is`() {
+        val dm = PriceAlertReceiptBuilder.buildDm(
+            trigger(UserPriceTriggerDto.Side.BUY),
+            TradeOutcome.InsufficientCredits(needed = 1023L, have = 800L),
+        )
+        val text = renderedText(dm)
+        assertTrue(text.contains("1023"), "needed credits must render verbatim: $text")
+        assertTrue(text.contains("800"), "have credits must render verbatim: $text")
+    }
+
+    @Test
+    fun `InsufficientCoins embed surfaces needed and held coin counts`() {
+        val dm = PriceAlertReceiptBuilder.buildDm(
+            trigger(UserPriceTriggerDto.Side.SELL),
+            TradeOutcome.InsufficientCoins(needed = 10L, have = 3L),
+        )
+        val text = renderedText(dm)
+        assertTrue(text.contains("10"), "needed coins must render: $text")
+        assertTrue(text.contains("3"), "held coins must render: $text")
+    }
+
+    @Test
+    fun `UnknownUser embed explains the trigger is disabled`() {
+        val dm = PriceAlertReceiptBuilder.buildDm(
+            trigger(UserPriceTriggerDto.Side.BUY),
+            TradeOutcome.UnknownUser,
+        )
+        val text = renderedText(dm)
+        assertTrue(text.contains("wallet"), "embed should reference wallet: $text")
+        assertTrue(text.contains("disabled") || text.contains("Disabled"),
+                "embed should mention disable state: $text")
+    }
+
+    @Test
+    fun `push payload is non-null for every TradeOutcome variant`() {
+        val t = trigger(UserPriceTriggerDto.Side.BUY)
+        val cases = listOf(
+            TradeOutcome.Ok(10L, 1000L, 10L, 9000L, 100.0, 10L),
+            TradeOutcome.InsufficientCredits(needed = 1000L, have = 500L),
+            TradeOutcome.InsufficientCoins(needed = 10L, have = 0L),
+            TradeOutcome.InvalidAmount,
+            TradeOutcome.UnknownUser,
+        )
+        cases.forEach { outcome ->
+            val payload = PriceAlertReceiptBuilder.buildPush(t, outcome)
+            assertNotNull(payload, "push payload must satisfy enforceAllSupportedSurfacesWired: $outcome")
+            assertEquals("TobyCoin price alert", payload.title)
+            assertTrue(payload.body.isNotBlank(), "push body must be non-blank for $outcome")
+        }
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/notify/PriceAlertReceiptBuilderTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/notify/PriceAlertReceiptBuilderTest.kt
@@ -139,4 +139,37 @@ class PriceAlertReceiptBuilderTest {
             assertTrue(payload.body.isNotBlank(), "push body must be non-blank for $outcome")
         }
     }
+
+    @Test
+    fun `InvalidAmount renders a failure embed mentioning the trigger id`() {
+        val dm = PriceAlertReceiptBuilder.buildDm(
+            trigger(UserPriceTriggerDto.Side.BUY),
+            TradeOutcome.InvalidAmount,
+        )
+        val text = renderedText(dm)
+        assertTrue(text.contains("Trigger #42"), "embed should mention trigger id 42: $text")
+        assertTrue(text.contains("invalid") || text.contains("Invalid") || text.contains("failed"),
+                "embed should describe the failure: $text")
+    }
+
+    @Test
+    fun `Ok with amount 0 renders execution price as 0 without dividing by zero`() {
+        // Defensive guard on okEmbed:75 — service rejects amount <= 0,
+        // but the builder should still survive if a bad row slips through.
+        val ok = TradeOutcome.Ok(
+            amount = 0L,
+            transactedCredits = 0L,
+            newCoins = 10L,
+            newCredits = 1000L,
+            newPrice = 100.0,
+            fee = 0L,
+        )
+        val dm = PriceAlertReceiptBuilder.buildDm(trigger(UserPriceTriggerDto.Side.BUY), ok)
+        val text = renderedText(dm)
+        // Either "0.0000" or just "0" appearing inside the Trade line is fine —
+        // the point is we didn't NaN/Infinity-format from a div-by-zero.
+        assertTrue(text.contains("0.0000"), "expected formatted zero price: $text")
+        assertFalse(text.contains("NaN"), "must not render NaN: $text")
+        assertFalse(text.contains("Infinity"), "must not render Infinity: $text")
+    }
 }

--- a/discord-bot/src/test/kotlin/bot/toby/scheduling/TobyCoinPriceTickJobAutoTradeTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/scheduling/TobyCoinPriceTickJobAutoTradeTest.kt
@@ -146,6 +146,126 @@ class TobyCoinPriceTickJobAutoTradeTest {
     }
 
     @Test
+    fun `empty triggered list does not dispatch or mark anything`() {
+        val marketService: TobyCoinMarketService = mockk(relaxed = true)
+        val triggerService: UserPriceTriggerService = mockk(relaxed = true)
+        val tradeService: EconomyTradeService = mockk(relaxed = true)
+        val router: NotificationRouter = mockk(relaxed = true)
+
+        every { marketService.getMarket(guildId) } returns
+                TobyCoinMarketDto(guildId = guildId, price = 110.0, lastTickAt = Instant.now())
+        every { marketService.saveMarket(any()) } answers { firstArg() }
+        every { marketService.appendPricePoint(any()) } answers { firstArg<TobyCoinPricePointDto>() }
+        every { marketService.pruneHistoryOlderThan(any()) } returns 0
+        every { marketService.pruneTradesOlderThan(any()) } returns 0
+        every { triggerService.findTriggered(guildId, any()) } returns emptyList()
+
+        newJob(marketService, triggerService, tradeService, router).tickAllGuilds()
+
+        verify(exactly = 0) { tradeService.buy(any(), any(), any()) }
+        verify(exactly = 0) { tradeService.sell(any(), any(), any()) }
+        verify(exactly = 0) { triggerService.markFired(any(), any()) }
+        verify(exactly = 0) {
+            router.dispatch(any<NotificationChannelKind>(), any<Long>(), any<Long>(), any())
+        }
+    }
+
+    @Test
+    fun `unknown side string disables the row without trading`() {
+        // Refactor R1: a corrupted `side` column should not crash —
+        // the typed accessor's runCatching guard disables the row.
+        val marketService: TobyCoinMarketService = mockk(relaxed = true)
+        val triggerService: UserPriceTriggerService = mockk(relaxed = true)
+        val tradeService: EconomyTradeService = mockk(relaxed = true)
+        val router: NotificationRouter = mockk(relaxed = true)
+
+        every { marketService.getMarket(guildId) } returns
+                TobyCoinMarketDto(guildId = guildId, price = 110.0, lastTickAt = Instant.now())
+        every { marketService.saveMarket(any()) } answers { firstArg() }
+        every { marketService.appendPricePoint(any()) } answers { firstArg<TobyCoinPricePointDto>() }
+        every { marketService.pruneHistoryOlderThan(any()) } returns 0
+        every { marketService.pruneTradesOlderThan(any()) } returns 0
+        val corrupt = armedTrigger().apply { side = "WOBBLE" }
+        every { triggerService.findTriggered(guildId, any()) } returns listOf(corrupt)
+        every { triggerService.markFired(1L, any()) } just Runs
+
+        newJob(marketService, triggerService, tradeService, router).tickAllGuilds()
+
+        verify(exactly = 0) { tradeService.buy(any(), any(), any()) }
+        verify(exactly = 0) { tradeService.sell(any(), any(), any()) }
+        verify(exactly = 1) { triggerService.markFired(1L, any()) }
+    }
+
+    @Test
+    fun `trade service throws — trigger still disabled`() {
+        val marketService: TobyCoinMarketService = mockk(relaxed = true)
+        val triggerService: UserPriceTriggerService = mockk(relaxed = true)
+        val tradeService: EconomyTradeService = mockk(relaxed = true)
+        val router: NotificationRouter = mockk(relaxed = true)
+
+        every { marketService.getMarket(guildId) } returns
+                TobyCoinMarketDto(guildId = guildId, price = 110.0, lastTickAt = Instant.now())
+        every { marketService.saveMarket(any()) } answers { firstArg() }
+        every { marketService.appendPricePoint(any()) } answers { firstArg<TobyCoinPricePointDto>() }
+        every { marketService.pruneHistoryOlderThan(any()) } returns 0
+        every { marketService.pruneTradesOlderThan(any()) } returns 0
+
+        every { triggerService.findTriggered(guildId, any()) } returns listOf(armedTrigger())
+        every { tradeService.buy(discordId, guildId, 10L) } throws RuntimeException("kaboom")
+        every { triggerService.markFired(1L, any()) } just Runs
+
+        // Tick must NOT crash — the outer runCatching swallows.
+        newJob(marketService, triggerService, tradeService, router).tickAllGuilds()
+
+        // Trigger is still disabled by the inner markFired in the
+        // failure branch so it doesn't loop next tick.
+        verify(exactly = 1) { triggerService.markFired(1L, any()) }
+        // No dispatch was issued because the trade itself blew up
+        // before the router was reached.
+        verify(exactly = 0) {
+            router.dispatch(any<NotificationChannelKind>(), any<Long>(), any<Long>(), any())
+        }
+    }
+
+    @Test
+    fun `multiple triggers fire same tick produce one dispatch each`() {
+        val marketService: TobyCoinMarketService = mockk(relaxed = true)
+        val triggerService: UserPriceTriggerService = mockk(relaxed = true)
+        val tradeService: EconomyTradeService = mockk(relaxed = true)
+        val router: NotificationRouter = mockk(relaxed = true)
+
+        every { marketService.getMarket(guildId) } returns
+                TobyCoinMarketDto(guildId = guildId, price = 110.0, lastTickAt = Instant.now())
+        every { marketService.saveMarket(any()) } answers { firstArg() }
+        every { marketService.appendPricePoint(any()) } answers { firstArg<TobyCoinPricePointDto>() }
+        every { marketService.pruneHistoryOlderThan(any()) } returns 0
+        every { marketService.pruneTradesOlderThan(any()) } returns 0
+
+        val a = armedTrigger().apply { id = 1L; discordId = 100L }
+        val b = armedTrigger().apply { id = 2L; discordId = 200L }
+        every { triggerService.findTriggered(guildId, any()) } returns listOf(a, b)
+        every { tradeService.buy(100L, guildId, 10L) } returns TradeOutcome.Ok(
+            amount = 10L, transactedCredits = 1010L, newCoins = 10L,
+            newCredits = 8990L, newPrice = 100.5, fee = 10L,
+        )
+        every { tradeService.buy(200L, guildId, 10L) } returns TradeOutcome.Ok(
+            amount = 10L, transactedCredits = 1010L, newCoins = 10L,
+            newCredits = 8990L, newPrice = 100.5, fee = 10L,
+        )
+        every { triggerService.markFired(any(), any()) } just Runs
+        every {
+            router.dispatch(any<NotificationChannelKind>(), any<Long>(), any<Long>(), any())
+        } just Runs
+
+        newJob(marketService, triggerService, tradeService, router).tickAllGuilds()
+
+        verify(exactly = 1) { router.dispatch(NotificationChannelKind.PRICE_ALERT, 100L, guildId, any()) }
+        verify(exactly = 1) { router.dispatch(NotificationChannelKind.PRICE_ALERT, 200L, guildId, any()) }
+        verify(exactly = 1) { triggerService.markFired(1L, any()) }
+        verify(exactly = 1) { triggerService.markFired(2L, any()) }
+    }
+
+    @Test
     fun `failed trade still disables the trigger`() {
         val marketService: TobyCoinMarketService = mockk(relaxed = true)
         val triggerService: UserPriceTriggerService = mockk(relaxed = true)

--- a/discord-bot/src/test/kotlin/bot/toby/scheduling/TobyCoinPriceTickJobAutoTradeTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/scheduling/TobyCoinPriceTickJobAutoTradeTest.kt
@@ -1,0 +1,177 @@
+package bot.toby.scheduling
+
+import bot.toby.notify.NotificationDispatch
+import bot.toby.notify.NotificationRouter
+import common.notification.NotificationChannelKind
+import database.dto.TobyCoinMarketDto
+import database.dto.TobyCoinPricePointDto
+import database.dto.UserPriceTriggerDto
+import database.service.EconomyTradeService
+import database.service.EconomyTradeService.TradeOutcome
+import database.service.TobyCoinMarketService
+import database.service.UserPriceTriggerService
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import net.dv8tion.jda.api.JDA
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.utils.cache.SnowflakeCacheView
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+/**
+ * Exercises the auto-trade wiring inside [TobyCoinPriceTickJob.tickGuild]:
+ * a tick that crosses a trigger's target must call the trade service
+ * with the trigger's side+amount, dispatch a PRICE_ALERT notification
+ * with BOTH `dm{}` and `push{}` wired (NotificationRouter enforces
+ * this), and mark the row fired.
+ */
+class TobyCoinPriceTickJobAutoTradeTest {
+
+    private val guildId = 7L
+    private val discordId = 99L
+
+    private fun newJob(
+        marketService: TobyCoinMarketService,
+        triggerService: UserPriceTriggerService,
+        tradeService: EconomyTradeService,
+        router: NotificationRouter,
+    ): TobyCoinPriceTickJob {
+        val jda: JDA = mockk(relaxed = true)
+        val guild: Guild = mockk(relaxed = true)
+        every { guild.idLong } returns guildId
+        val cache: SnowflakeCacheView<Guild> = mockk(relaxed = true)
+        every { cache.iterator() } answers { mutableListOf(guild).iterator() }
+        every { jda.guildCache } returns cache
+        return TobyCoinPriceTickJob(jda, marketService, triggerService, tradeService, router)
+    }
+
+    private fun armedTrigger(side: UserPriceTriggerDto.Side = UserPriceTriggerDto.Side.BUY) =
+        UserPriceTriggerDto(
+            id = 1L,
+            discordId = discordId,
+            guildId = guildId,
+            thresholdPrice = 100.0,
+            priceAtCreation = 120.0,
+            side = side.name,
+            amount = 10L,
+            enabled = true,
+        )
+
+    @Test
+    fun `triggered BUY routes through EconomyTradeService and dispatches receipt`() {
+        val marketService: TobyCoinMarketService = mockk(relaxed = true)
+        val triggerService: UserPriceTriggerService = mockk(relaxed = true)
+        val tradeService: EconomyTradeService = mockk(relaxed = true)
+        val router: NotificationRouter = mockk(relaxed = true)
+
+        every { marketService.getMarket(guildId) } returns
+                TobyCoinMarketDto(guildId = guildId, price = 110.0, lastTickAt = Instant.now())
+        every { marketService.saveMarket(any()) } answers { firstArg() }
+        every { marketService.appendPricePoint(any()) } answers { firstArg<TobyCoinPricePointDto>() }
+        every { marketService.pruneHistoryOlderThan(any()) } returns 0
+        every { marketService.pruneTradesOlderThan(any()) } returns 0
+
+        // findTriggered runs after the random walk; force it to return
+        // our row regardless of the actual new price so the test isn't
+        // flaky on the GBM draw.
+        val trigger = armedTrigger()
+        every { triggerService.findTriggered(guildId, any()) } returns listOf(trigger)
+        every { tradeService.buy(discordId, guildId, 10L) } returns TradeOutcome.Ok(
+            amount = 10L,
+            transactedCredits = 1010L,
+            newCoins = 10L,
+            newCredits = 8990L,
+            newPrice = 100.5,
+            fee = 10L,
+        )
+        every { triggerService.markFired(1L, any()) } just Runs
+
+        // Capture the dispatch DSL so we can assert both surfaces were wired.
+        val configure = slot<NotificationDispatch.() -> Unit>()
+        every {
+            router.dispatch(NotificationChannelKind.PRICE_ALERT, discordId, guildId, capture(configure))
+        } just Runs
+
+        newJob(marketService, triggerService, tradeService, router).tickAllGuilds()
+
+        verify(exactly = 1) { tradeService.buy(discordId, guildId, 10L) }
+        verify(exactly = 1) { triggerService.markFired(1L, any()) }
+        verify(exactly = 1) {
+            router.dispatch(NotificationChannelKind.PRICE_ALERT, discordId, guildId, any())
+        }
+
+        // Replay the configure lambda onto a real NotificationDispatch
+        // so we can read the internal builder fields. PRICE_ALERT
+        // declares DM+PUSH; both must be wired or production dispatch
+        // throws via enforceAllSupportedSurfacesWired.
+        val plan = NotificationDispatch(NotificationChannelKind.PRICE_ALERT)
+        configure.captured.invoke(plan)
+        assert(plan.dmBuilder != null) { "PRICE_ALERT dispatch must wire dm{}" }
+        assert(plan.pushBuilder != null) { "PRICE_ALERT dispatch must wire push{}" }
+    }
+
+    @Test
+    fun `triggered SELL calls sell with declared amount`() {
+        val marketService: TobyCoinMarketService = mockk(relaxed = true)
+        val triggerService: UserPriceTriggerService = mockk(relaxed = true)
+        val tradeService: EconomyTradeService = mockk(relaxed = true)
+        val router: NotificationRouter = mockk(relaxed = true)
+
+        every { marketService.getMarket(guildId) } returns
+                TobyCoinMarketDto(guildId = guildId, price = 140.0, lastTickAt = Instant.now())
+        every { marketService.saveMarket(any()) } answers { firstArg() }
+        every { marketService.appendPricePoint(any()) } answers { firstArg<TobyCoinPricePointDto>() }
+        every { marketService.pruneHistoryOlderThan(any()) } returns 0
+        every { marketService.pruneTradesOlderThan(any()) } returns 0
+
+        val sell = armedTrigger(UserPriceTriggerDto.Side.SELL)
+        every { triggerService.findTriggered(guildId, any()) } returns listOf(sell)
+        every { tradeService.sell(discordId, guildId, 10L) } returns TradeOutcome.Ok(
+            amount = 10L, transactedCredits = 990L, newCoins = 0L,
+            newCredits = 11990L, newPrice = 99.5, fee = 10L,
+        )
+        every { triggerService.markFired(1L, any()) } just Runs
+        every {
+            router.dispatch(NotificationChannelKind.PRICE_ALERT, discordId, guildId, any())
+        } just Runs
+
+        newJob(marketService, triggerService, tradeService, router).tickAllGuilds()
+
+        verify(exactly = 1) { tradeService.sell(discordId, guildId, 10L) }
+        verify(exactly = 0) { tradeService.buy(any(), any(), any()) }
+    }
+
+    @Test
+    fun `failed trade still disables the trigger`() {
+        val marketService: TobyCoinMarketService = mockk(relaxed = true)
+        val triggerService: UserPriceTriggerService = mockk(relaxed = true)
+        val tradeService: EconomyTradeService = mockk(relaxed = true)
+        val router: NotificationRouter = mockk(relaxed = true)
+
+        every { marketService.getMarket(guildId) } returns
+                TobyCoinMarketDto(guildId = guildId, price = 110.0, lastTickAt = Instant.now())
+        every { marketService.saveMarket(any()) } answers { firstArg() }
+        every { marketService.appendPricePoint(any()) } answers { firstArg<TobyCoinPricePointDto>() }
+        every { marketService.pruneHistoryOlderThan(any()) } returns 0
+        every { marketService.pruneTradesOlderThan(any()) } returns 0
+
+        every { triggerService.findTriggered(guildId, any()) } returns listOf(armedTrigger())
+        every { tradeService.buy(discordId, guildId, 10L) } returns
+                TradeOutcome.InsufficientCredits(needed = 1010L, have = 50L)
+        every { triggerService.markFired(1L, any()) } just Runs
+        every {
+            router.dispatch(NotificationChannelKind.PRICE_ALERT, discordId, guildId, any())
+        } just Runs
+
+        newJob(marketService, triggerService, tradeService, router).tickAllGuilds()
+
+        verify(exactly = 1) { triggerService.markFired(1L, any()) }
+        verify(exactly = 1) {
+            router.dispatch(NotificationChannelKind.PRICE_ALERT, discordId, guildId, any())
+        }
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/scheduling/TobyCoinPriceTickJobTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/scheduling/TobyCoinPriceTickJobTest.kt
@@ -1,8 +1,11 @@
 package bot.toby.scheduling
 
+import bot.toby.notify.NotificationRouter
 import database.dto.TobyCoinMarketDto
 import database.dto.TobyCoinPricePointDto
+import database.service.EconomyTradeService
 import database.service.TobyCoinMarketService
+import database.service.UserPriceTriggerService
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
@@ -45,7 +48,13 @@ class TobyCoinPriceTickJobTest {
         every { marketService.appendPricePoint(any()) } answers { firstArg<TobyCoinPricePointDto>() }
         every { marketService.pruneHistoryOlderThan(any()) } returns 0
 
-        val job = TobyCoinPriceTickJob(jda, marketService)
+        // Trigger scanning is a no-op when no rows are armed, which is
+        // the case for this regression test — relaxed mocks return an
+        // empty list by default.
+        val triggerService: UserPriceTriggerService = mockk(relaxed = true)
+        val tradeService: EconomyTradeService = mockk(relaxed = true)
+        val router: NotificationRouter = mockk(relaxed = true)
+        val job = TobyCoinPriceTickJob(jda, marketService, triggerService, tradeService, router)
 
         val prices = (1..50).map {
             job.tickAllGuilds()


### PR DESCRIPTION
## Summary

Wires up the `PRICE_ALERT` notification kind, which previously had infrastructure (channel kind, router DM/PUSH surfaces) but no trigger source.

- Adds `/pricealert add|list|remove`. A trigger captures the **current market price** and a **target threshold** plus the user's chosen side (BUY/SELL) and amount.
- On every 5-min tick, `TobyCoinPriceTickJob` scans enabled triggers and fires any whose target was reached **from the side the price was on at creation** — so "buy at 100 when current is 120" fires the first time the price hits 100, without needing a cross-back.
- Fired triggers auto-execute the declared trade via `EconomyTradeService.buy/sell` and DM a receipt via `NotificationRouter.dispatch(PRICE_ALERT, ...)`. Both `dm{}` and `push{}` are wired to satisfy `enforceAllSupportedSurfacesWired`.
- One-shot: row gets `fired_at` stamped and `enabled` flipped false so an oscillation around the threshold can't replay the trade. To re-arm, the user re-runs `/pricealert add`.
- `/pricealert add` auto-enables `PRICE_ALERT` DM in the user's notification prefs so the receipt actually reaches them (warned in the confirmation embed when it flips).
- Receipt embed surfaces the **per-leg jackpot fee** as a separate line: BUY shows `subtotal + fee = total`, SELL shows `gross − fee = proceeds`. Matches the wording in `TobyCoinCommand.describe` so users see the same breakdown they'd get from manual `/tobycoin buy|sell`.

## Files

**New**
- `database/src/main/resources/db/migration/V42__user_price_trigger.sql` — schema, partial index on `(guild_id) WHERE enabled` for the hot-path scan.
- `database/src/main/kotlin/database/dto/UserPriceTriggerDto.kt` — JPA entity with `Side { BUY, SELL }`.
- `database/src/main/kotlin/database/persistence/UserPriceTriggerPersistence.kt` + impl.
- `database/src/main/kotlin/database/service/UserPriceTriggerService.kt` + impl with `findTriggered(guildId, newPrice)` — target-reached check `(priceAtCreation - threshold) * (newPrice - threshold) <= 0`.
- `discord-bot/src/main/kotlin/bot/toby/command/commands/economy/PriceAlertCommand.kt` — slash command. Rejects `threshold ≈ currentPrice` (epsilon 1e-4) to avoid armed-at-parity ambiguity.
- `discord-bot/src/main/kotlin/bot/toby/notify/PriceAlertReceiptBuilder.kt` — DM embed + push payload, fee broken out.

**Modified**
- `discord-bot/src/main/kotlin/bot/toby/scheduling/TobyCoinPriceTickJob.kt` — extends `tickGuild` to call `handleTriggered` after persisting the new price; failed trades still mark the row fired so a broken trigger can't loop.

## Test plan

- [x] `./gradlew :database:test` — all green, including 9 new cases in `UserPriceTriggerTargetReachedTest`.
- [ ] `./gradlew :discord-bot:test` — local sandbox can't fetch `moe.kyokobot.libdave` deps; CI will exercise:
  - `PriceAlertReceiptBuilderTest` — fee accuracy for BUY/SELL/zero-fee + all `TradeOutcome` variants render a non-null push payload.
  - `PriceAlertCommandTest` — parity rejection + auto-enable PRICE_ALERT DM only when previously opted-out.
  - `TobyCoinPriceTickJobAutoTradeTest` — trade-routing for BUY/SELL, dispatch wires both DM and PUSH, failed trade still disables the row.
  - `TobyCoinPriceTickJobTest` — updated for new constructor params (regression guard for the PRNG fix preserved).
- [ ] `./gradlew build` — `enforceAllSupportedSurfacesWired` validates the new dispatch site.
- [ ] Manual end-to-end (dev guild): `/pricealert add price:<below-current> side:BUY amount:5`; force-edit `toby_coin_market.price` so the next tick crosses; confirm DM receipt arrives with no buttons, `/tobycoin balance` reflects the auto-buy, `/pricealert list` shows fired/disabled.

https://claude.ai/code/session_01AyztxwVRr9U9hHRrnbR9nm

---
_Generated by [Claude Code](https://claude.ai/code/session_01AyztxwVRr9U9hHRrnbR9nm)_