### PR TITLE
fix(web): admin tabs no longer paint over the navbar / drawer / dropdowns

### DIFF
--- a/web/src/main/resources/static/css/nav.css
+++ b/web/src/main/resources/static/css/nav.css
@@ -14,7 +14,7 @@
    (body.nav-open).
    ============================================================ */
 
-nav {
+body > nav {
     background: var(--bg-elevated);
     padding: 14px 24px;
     display: flex;
@@ -190,7 +190,7 @@ nav {
    (hamburger). Tighten the inter-link gap so a 7-link nav doesn't
    wrap onto multiple rows or get clipped on iPad-portrait widths. */
 @media (max-width: 768px) {
-    nav { padding: 12px 16px; }
+    body > nav { padding: 12px 16px; }
     .nav-links { gap: var(--space-3); }
 }
 
@@ -289,7 +289,7 @@ nav {
    Mobile drawer (≤ 600px).
    ============================================================ */
 @media (max-width: 600px) {
-    nav {
+    body > nav {
         padding: 12px var(--space-4);
         flex-wrap: nowrap;
         gap: var(--space-2);


### PR DESCRIPTION
## Summary

- The previous attempts (#509 layout, #510 raising the drawer to `z-index: 1000`) didn't fix admin tab overlap because the cause wasn't z-index — it was selector scope.
- `nav { position: relative; z-index: 10 }` in `nav.css` matched **every** `<nav>` on the page, including `<nav class="mod-subnav">` in `moderationHeader.html`. That made the admin tab strip create its own root-level stacking context at the same z-index as the top navbar but later in the DOM, so it painted over the drawer (whose `z-index: 1000` was trapped inside the top navbar's own stacking context) and over desktop nav dropdowns.
- Scoped the three bare `nav { … }` rules in `nav.css` to `body > nav` so they only apply to the page-chrome navbar. Drawer / dropdown z-indices now land in the root stacking context and naturally paint over `.mod-subnav`, which no longer creates a competing context.

## Test plan

- [ ] Open `/moderation/{guildId}/users` on mobile (≤ 600px) → tap hamburger → drawer + backdrop fully cover the admin tab strip.
- [ ] On desktop, hover an Economy / Casino nav dropdown so its menu opens over the tab strip area → menu paints over the tabs, not under.
- [ ] Admin tab strip still looks correct (horizontal scroll on mobile, wraps on ≥ 600px, active tab underlined, no background/padding regressions from losing the leaked `nav` defaults).
- [ ] Non-moderation pages (home, leaderboard, profile) — top navbar visuals unchanged.

https://claude.ai/code/session_01NLtwgP5G9pMgdEWrEpptWZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01NLtwgP5G9pMgdEWrEpptWZ)_