### PR TITLE
feat(web): surface achievements and notifications on the homepage

### DIFF
--- a/application/src/test/kotlin/web/controller/HomeControllerTest.kt
+++ b/application/src/test/kotlin/web/controller/HomeControllerTest.kt
@@ -31,6 +31,8 @@ class HomeControllerTest {
         minigameCount = 12,
         minigameNames = "slots, dice",
         configKeyCount = 58,
+        achievementCount = 15,
+        notificationKindCount = 8,
     )
 
     @BeforeEach

--- a/web/src/main/kotlin/web/service/HomeStatsService.kt
+++ b/web/src/main/kotlin/web/service/HomeStatsService.kt
@@ -1,6 +1,8 @@
 package web.service
 
+import common.notification.NotificationChannelKind
 import core.managers.CommandManager
+import database.achievement.AchievementCatalog
 import database.dto.ConfigDto
 import net.dv8tion.jda.api.JDA
 import org.springframework.stereotype.Service
@@ -34,6 +36,8 @@ class HomeStatsService(
         val minigameCount: Int,
         val minigameNames: String,
         val configKeyCount: Int,
+        val achievementCount: Int,
+        val notificationKindCount: Int,
     )
 
     private data class Cached(val stats: HomeStats, val expiresAtNanos: Long)
@@ -63,6 +67,8 @@ class HomeStatsService(
         minigameCount = GameCatalog.minigameCount,
         minigameNames = GameCatalog.minigameNames,
         configKeyCount = ConfigDto.Configurations.values().size,
+        achievementCount = AchievementCatalog.all.count { !it.hidden },
+        notificationKindCount = NotificationChannelKind.entries.size,
     )
 
     companion object {

--- a/web/src/main/resources/templates/home.html
+++ b/web/src/main/resources/templates/home.html
@@ -124,10 +124,10 @@
         <span class="section-eyebrow">Engagement</span>
         <h2 id="engagement-title">Make your server worth showing up to</h2>
         <p class="section-lede">
-            Voice-time and message activity earn XP and credit &mdash; feeding levels,
-            monthly leaderboards, per-user profiles, and personalised intro songs.
-            Configurable daily caps, UBI for non-voice users, and a 30-day rolling
-            activity window.
+            Voice-time and message activity earn XP, credit, and achievements &mdash;
+            feeding levels, monthly leaderboards, per-user profiles, and personalised
+            intro songs. Tune what pings you, where, with per-server notification
+            preferences.
         </p>
     </header>
     <div class="feature-grid">
@@ -150,6 +150,16 @@
             <div class="feature-icon">&#11088;</div>
             <h3>Levels &amp; XP</h3>
             <p>Earn XP from messages, slash commands, voice intros, and voice sessions. Level up to unlock role rewards and gated vanity titles; check your progress with <code>/level</code> or on your profile.</p>
+        </a>
+        <a class="feature-card" href="/profile/guilds" data-reveal>
+            <div class="feature-icon">&#127942;</div>
+            <h3>Achievements</h3>
+            <p>Unlock [[${homeStats.achievementCount}]] achievements across streaks, levels, casino, social, voice and music &mdash; each pays out XP and credit. Track progress on your profile.</p>
+        </a>
+        <a class="feature-card" href="/preferences/notifications" data-reveal>
+            <div class="feature-icon">&#128276;</div>
+            <h3>Notifications</h3>
+            <p>Choose how [[${homeStats.notificationKindCount}]] notification types reach you &mdash; DM, channel post, or web push &mdash; per server, per kind.</p>
         </a>
     </div>
 </section>

--- a/web/src/test/kotlin/web/static/HomeFeatureCardsTemplateTest.kt
+++ b/web/src/test/kotlin/web/static/HomeFeatureCardsTemplateTest.kt
@@ -1,0 +1,106 @@
+package web.static
+
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+/**
+ * Pins the Achievements + Notifications feature-cards on the homepage.
+ *
+ * Both features ship today but are otherwise undiscoverable from the
+ * landing page — Achievements live behind `/profile/{guildId}` and
+ * Notifications behind `/preferences/notifications`. They were added
+ * to the Engagement section so newcomers see they exist before signing
+ * in. This test guards against three regressions:
+ *
+ *  1. A future homepage rewrite quietly drops either card.
+ *  2. Static copy creeps back in place of the live `${homeStats.*Count}`
+ *     interpolation — which would make the homepage lie as the
+ *     catalogues grow (e.g. when a new achievement or notification
+ *     kind is added).
+ *  3. A refactor moves the cards into the Casino or Server Management
+ *     section, away from the user-progression cluster.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class HomeFeatureCardsTemplateTest {
+
+    private lateinit var html: String
+
+    @BeforeAll
+    fun loadTemplate() {
+        html = javaClass.classLoader
+            .getResourceAsStream("templates/home.html")
+            ?.bufferedReader()
+            ?.readText()
+            ?: error("templates/home.html is not on the classpath")
+    }
+
+    @Test
+    fun `achievements card is present on the homepage with a live count`() {
+        assertTrue(
+            html.contains("<h3>Achievements</h3>"),
+            "home.html must include an `<h3>Achievements</h3>` feature-card heading " +
+                "so the achievements system is discoverable from the landing page."
+        )
+        assertTrue(
+            html.contains("href=\"/profile/guilds\""),
+            "the achievements feature-card must link to `/profile/guilds` — the " +
+                "achievements UI lives on the profile page."
+        )
+        assertTrue(
+            html.contains("\${homeStats.achievementCount}"),
+            "the achievements feature-card must interpolate " +
+                "`\${homeStats.achievementCount}` so the count stays in lockstep " +
+                "with AchievementCatalog as it grows. Static copy would silently " +
+                "drift."
+        )
+    }
+
+    @Test
+    fun `notifications card is present on the homepage with a live count`() {
+        assertTrue(
+            html.contains("<h3>Notifications</h3>"),
+            "home.html must include an `<h3>Notifications</h3>` feature-card " +
+                "heading so the per-surface notification system is discoverable " +
+                "from the landing page."
+        )
+        assertTrue(
+            html.contains("href=\"/preferences/notifications\""),
+            "the notifications feature-card must link to `/preferences/notifications`."
+        )
+        assertTrue(
+            html.contains("\${homeStats.notificationKindCount}"),
+            "the notifications feature-card must interpolate " +
+                "`\${homeStats.notificationKindCount}` so the count stays in " +
+                "lockstep with NotificationChannelKind as it grows."
+        )
+    }
+
+    @Test
+    fun `both new cards live in the engagement section, not casino or management`() {
+        val engagementMarker = html.indexOf(">Engagement<")
+        val managementMarker = html.indexOf(">Server Management<")
+        val achievementsMarker = html.indexOf("<h3>Achievements</h3>")
+        val notificationsMarker = html.indexOf("<h3>Notifications</h3>")
+
+        check(engagementMarker >= 0) {
+            "expected an `>Engagement<` section eyebrow on home.html"
+        }
+        check(managementMarker >= 0) {
+            "expected a `>Server Management<` section eyebrow on home.html"
+        }
+
+        assertTrue(
+            achievementsMarker in (engagementMarker + 1) until managementMarker,
+            "the Achievements card must sit between the Engagement and Server " +
+                "Management eyebrows so it groups with the user-progression cluster " +
+                "(Profile, Levels, Leaderboards) rather than casino or moderation."
+        )
+        assertTrue(
+            notificationsMarker in (engagementMarker + 1) until managementMarker,
+            "the Notifications card must sit between the Engagement and Server " +
+                "Management eyebrows."
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- Add two feature-cards to the existing **Engagement** section of `home.html`: **Achievements** (links to `/profile/guilds`) and **Notifications** (links to `/preferences/notifications`). Engagement section grows from 4 to 6 cards, matching the Casino section's 6-card layout — no CSS changes needed.
- Extend `HomeStatsService.HomeStats` with `achievementCount` and `notificationKindCount`, sourced directly from `AchievementCatalog.all.count { !it.hidden }` and `NotificationChannelKind.entries.size`, so card copy stays accurate as the catalogues grow.
- Lightly update the Engagement section lede to mention achievements and per-server notification preferences.
- Add `HomeFeatureCardsTemplateTest` — a static-resource test (same pattern as the existing CSS regression tests) that pins both new cards in place, asserts they use the live `${homeStats.*Count}` interpolations rather than hardcoded numbers, and confirms they live in the Engagement section (not Casino or Server Management).

## Why

Both features shipped a while ago but were undiscoverable from the landing page — Achievements lived behind `/profile/{guildId}` and notification preferences behind a buried settings menu. This makes them first-class headline features for anyone landing on the homepage.

## Test plan

- [ ] `./gradlew :web:test --tests web.static.HomeFeatureCardsTemplateTest` passes (verified locally).
- [ ] `./gradlew :web:test` passes broadly (verified locally — no collateral damage).
- [ ] Visit `/` locally: confirm Engagement section renders 6 cards; counts show `15` and `8`; Achievements card routes to `/profile/guilds`; Notifications card routes to `/preferences/notifications`.
- [ ] Mobile breakpoint: confirm the 6-card grid reflows the same as the Casino section.


---
_Generated by [Claude Code](https://claude.ai/code/session_018YLzp5uQyet6YDMF5ghqE7)_