### PR TITLE
feat(achievements): expand catalog with new tiers, counters, consolation, and roadmap stubs

### DIFF
--- a/database/src/main/kotlin/database/achievement/AchievementCatalog.kt
+++ b/database/src/main/kotlin/database/achievement/AchievementCatalog.kt
@@ -81,6 +81,26 @@ object AchievementCatalog {
             creditReward = 1000,
             threshold = 30
         ),
+        AchievementSpec(
+            code = "streak_100",
+            name = "Centurion",
+            description = "Hit a 100-day login streak.",
+            category = "streak",
+            icon = "🏛️",
+            xpReward = 1500,
+            creditReward = 3000,
+            threshold = 100
+        ),
+        AchievementSpec(
+            code = "streak_365",
+            name = "Year of Toby",
+            description = "Hit a 365-day login streak.",
+            category = "streak",
+            icon = "👑",
+            xpReward = 5000,
+            creditReward = 10000,
+            threshold = 365
+        ),
 
         // Level achievements — fired by AchievementEventHandler on LevelUpEvent.
         AchievementSpec(
@@ -113,6 +133,26 @@ object AchievementCatalog {
             creditReward = 750,
             threshold = 50
         ),
+        AchievementSpec(
+            code = "level_75",
+            name = "Elite",
+            description = "Reach level 75.",
+            category = "level",
+            icon = "🏅",
+            xpReward = 1000,
+            creditReward = 1500,
+            threshold = 75
+        ),
+        AchievementSpec(
+            code = "level_100",
+            name = "Legend",
+            description = "Reach level 100.",
+            category = "level",
+            icon = "🌟",
+            xpReward = 2500,
+            creditReward = 5000,
+            threshold = 100
+        ),
 
         // Casino / social achievements — fired by inline calls from
         // DuelService / TipService / IntroHelper resolution paths.
@@ -136,6 +176,36 @@ object AchievementCatalog {
             threshold = 10
         ),
         AchievementSpec(
+            code = "duel_wins_25",
+            name = "Champion",
+            description = "Win 25 duels.",
+            category = "casino",
+            icon = "🛡️",
+            xpReward = 300,
+            creditReward = 400,
+            threshold = 25
+        ),
+        AchievementSpec(
+            code = "duel_wins_50",
+            name = "Warlord",
+            description = "Win 50 duels.",
+            category = "casino",
+            icon = "⚜️",
+            xpReward = 600,
+            creditReward = 800,
+            threshold = 50
+        ),
+        AchievementSpec(
+            code = "duel_wins_100",
+            name = "Undefeated",
+            description = "Win 100 duels.",
+            category = "casino",
+            icon = "💀",
+            xpReward = 1500,
+            creditReward = 2000,
+            threshold = 100
+        ),
+        AchievementSpec(
             code = "tip_giver",
             name = "Generous",
             description = "Tip another user for the first time.",
@@ -143,6 +213,26 @@ object AchievementCatalog {
             icon = "🎁",
             xpReward = 25,
             creditReward = 50
+        ),
+        AchievementSpec(
+            code = "tips_sent_10",
+            name = "Patron",
+            description = "Tip another user 10 times.",
+            category = "social",
+            icon = "💝",
+            xpReward = 150,
+            creditReward = 150,
+            threshold = 10
+        ),
+        AchievementSpec(
+            code = "tips_sent_50",
+            name = "Philanthropist",
+            description = "Tip another user 50 times.",
+            category = "social",
+            icon = "🪙",
+            xpReward = 500,
+            creditReward = 500,
+            threshold = 50
         ),
         AchievementSpec(
             code = "intro_set",
@@ -161,6 +251,36 @@ object AchievementCatalog {
             icon = "🎰",
             xpReward = 100,
             creditReward = 0
+        ),
+        AchievementSpec(
+            code = "lottery_wins_3",
+            name = "Lucky Streak",
+            description = "Win 3 lifetime daily lottery draws.",
+            category = "casino",
+            icon = "🍀",
+            xpReward = 200,
+            creditReward = 0,
+            threshold = 3
+        ),
+        AchievementSpec(
+            code = "lottery_wins_10",
+            name = "Fortune's Favourite",
+            description = "Win 10 lifetime daily lottery draws.",
+            category = "casino",
+            icon = "🎟️",
+            xpReward = 500,
+            creditReward = 0,
+            threshold = 10
+        ),
+        AchievementSpec(
+            code = "lottery_wins_25",
+            name = "Lottomaniac",
+            description = "Win 25 lifetime daily lottery draws.",
+            category = "casino",
+            icon = "💰",
+            xpReward = 1500,
+            creditReward = 0,
+            threshold = 25
         ),
         AchievementSpec(
             code = "voice_10h",
@@ -182,6 +302,36 @@ object AchievementCatalog {
             creditReward = 500,
             threshold = 360000L
         ),
+        AchievementSpec(
+            code = "voice_250h",
+            name = "Voice Devotee",
+            description = "Spend 250 cumulative hours in voice channels.",
+            category = "voice",
+            icon = "🎚️",
+            xpReward = 1000,
+            creditReward = 1000,
+            threshold = 900000L
+        ),
+        AchievementSpec(
+            code = "voice_500h",
+            name = "Voice Legend",
+            description = "Spend 500 cumulative hours in voice channels.",
+            category = "voice",
+            icon = "📡",
+            xpReward = 2000,
+            creditReward = 2000,
+            threshold = 1800000L
+        ),
+        AchievementSpec(
+            code = "voice_1000h",
+            name = "Voice Immortal",
+            description = "Spend 1000 cumulative hours in voice channels.",
+            category = "voice",
+            icon = "🛰️",
+            xpReward = 5000,
+            creditReward = 5000,
+            threshold = 3600000L
+        ),
 
         AchievementSpec(
             code = "blackjack_natural",
@@ -191,6 +341,186 @@ object AchievementCatalog {
             icon = "🃏",
             xpReward = 50,
             creditReward = 50
+        ),
+        AchievementSpec(
+            code = "blackjack_natural_5",
+            name = "Card Counter",
+            description = "Hit 5 lifetime natural blackjacks.",
+            category = "casino",
+            icon = "🂡",
+            xpReward = 200,
+            creditReward = 200,
+            threshold = 5
+        ),
+        AchievementSpec(
+            code = "blackjack_natural_25",
+            name = "Pit Boss",
+            description = "Hit 25 lifetime natural blackjacks.",
+            category = "casino",
+            icon = "🎴",
+            xpReward = 750,
+            creditReward = 750,
+            threshold = 25
+        ),
+
+        // Consolation achievements — fired by AchievementEventHandler on
+        // DuelResolvedEvent against the loser side.
+        AchievementSpec(
+            code = "duel_losses_5",
+            name = "Tough Luck",
+            description = "Lose 5 duels.",
+            category = "consolation",
+            icon = "🩹",
+            xpReward = 50,
+            creditReward = 100,
+            threshold = 5
+        ),
+        AchievementSpec(
+            code = "duel_losses_25",
+            name = "Comeback Kid",
+            description = "Lose 25 duels.",
+            category = "consolation",
+            icon = "💪",
+            xpReward = 250,
+            creditReward = 500,
+            threshold = 25
+        ),
+
+        // Roadmap stubs for casino games that don't yet publish domain
+        // events. Hidden until a future PR adds the corresponding event
+        // and wires up an AchievementEventHandler listener; the codes
+        // are reserved here so the hookup PR doesn't have to invent
+        // them. Each pending entry must stay enumerated in
+        // AchievementCatalogTest.PENDING_HIDDEN_CODES.
+        AchievementSpec(
+            code = "slots_first_jackpot",
+            name = "Jackpot!",
+            description = "Hit the slot machine jackpot.",
+            category = "casino",
+            icon = "🎰",
+            xpReward = 100,
+            creditReward = 100,
+            hidden = true
+        ),
+        AchievementSpec(
+            code = "roulette_first_straight_win",
+            name = "Lucky Number",
+            description = "Win a straight-up roulette bet.",
+            category = "casino",
+            icon = "🎯",
+            xpReward = 100,
+            creditReward = 100,
+            hidden = true
+        ),
+        AchievementSpec(
+            code = "poker_first_royal_flush",
+            name = "Royal Flush",
+            description = "Hit a royal flush in poker.",
+            category = "casino",
+            icon = "♠️",
+            xpReward = 100,
+            creditReward = 100,
+            hidden = true
+        ),
+        AchievementSpec(
+            code = "dice_first_win",
+            name = "Loaded Dice",
+            description = "Win your first dice game.",
+            category = "casino",
+            icon = "🎲",
+            xpReward = 100,
+            creditReward = 100,
+            hidden = true
+        ),
+        AchievementSpec(
+            code = "coinflip_first_win",
+            name = "Heads or Tails",
+            description = "Win your first coinflip.",
+            category = "casino",
+            icon = "🪙",
+            xpReward = 100,
+            creditReward = 100,
+            hidden = true
+        ),
+        AchievementSpec(
+            code = "keno_first_perfect",
+            name = "Perfect Card",
+            description = "Hit every chosen number in keno.",
+            category = "casino",
+            icon = "🔢",
+            xpReward = 100,
+            creditReward = 100,
+            hidden = true
+        ),
+        AchievementSpec(
+            code = "plinko_first_jackpot",
+            name = "The Drop",
+            description = "Land a plinko jackpot.",
+            category = "casino",
+            icon = "🟢",
+            xpReward = 100,
+            creditReward = 100,
+            hidden = true
+        ),
+        AchievementSpec(
+            code = "scratch_first_jackpot",
+            name = "Hit the Strip",
+            description = "Hit the jackpot on a scratch ticket.",
+            category = "casino",
+            icon = "🎫",
+            xpReward = 100,
+            creditReward = 100,
+            hidden = true
+        ),
+        AchievementSpec(
+            code = "wheel_first_jackpot",
+            name = "Spin Doctor",
+            description = "Land the wheel-of-fortune jackpot.",
+            category = "casino",
+            icon = "🎡",
+            xpReward = 100,
+            creditReward = 100,
+            hidden = true
+        ),
+        AchievementSpec(
+            code = "horse_racing_first_win",
+            name = "Photo Finish",
+            description = "Win your first horse race.",
+            category = "casino",
+            icon = "🐎",
+            xpReward = 100,
+            creditReward = 100,
+            hidden = true
+        ),
+        AchievementSpec(
+            code = "baccarat_first_win",
+            name = "Punto Banco",
+            description = "Win your first baccarat hand.",
+            category = "casino",
+            icon = "🎴",
+            xpReward = 100,
+            creditReward = 100,
+            hidden = true
+        ),
+        AchievementSpec(
+            code = "casino_holdem_first_win",
+            name = "All In",
+            description = "Win your first Casino Hold'em hand.",
+            category = "casino",
+            icon = "🂠",
+            xpReward = 100,
+            creditReward = 100,
+            hidden = true
+        ),
+        AchievementSpec(
+            code = "highlow_first_streak",
+            name = "Higher or Lower",
+            description = "Win 5 high-low calls in a row.",
+            category = "casino",
+            icon = "🔼",
+            xpReward = 100,
+            creditReward = 100,
+            hidden = true
         )
     )
 

--- a/database/src/test/kotlin/database/achievement/AchievementCatalogTest.kt
+++ b/database/src/test/kotlin/database/achievement/AchievementCatalogTest.kt
@@ -26,7 +26,7 @@ class AchievementCatalogTest {
 
     @Test
     fun `every catalog entry uses a known category`() {
-        val known = setOf("streak", "level", "casino", "social", "music", "voice")
+        val known = setOf("streak", "level", "casino", "social", "music", "voice", "consolation")
         val unknown = AchievementCatalog.all.filterNot { it.category in known }
         assertTrue(unknown.isEmpty(), "achievements with unknown category: ${unknown.map { it.code to it.category }}")
     }
@@ -54,66 +54,66 @@ class AchievementCatalogTest {
         // If the catalog ships a milestone, the handler must be able to find
         // it — otherwise the unlock call silently no-ops in
         // DefaultAchievementService.unlock.
-        listOf("streak_first", "streak_3", "streak_7", "streak_30").forEach { code ->
+        listOf(
+            "streak_first", "streak_3", "streak_7", "streak_30",
+            "streak_100", "streak_365",
+        ).forEach { code ->
             assertNotNull(AchievementCatalog.byCode(code), "missing streak achievement '$code'")
         }
     }
 
     @Test
     fun `level milestone codes match AchievementEventHandler expectations`() {
-        listOf("level_5", "level_25", "level_50").forEach { code ->
+        listOf("level_5", "level_25", "level_50", "level_75", "level_100").forEach { code ->
             assertNotNull(AchievementCatalog.byCode(code), "missing level achievement '$code'")
         }
     }
 
     @Test
     fun `tip and duel achievement codes match TipSentEvent and DuelResolvedEvent handlers`() {
-        listOf("tip_giver", "first_duel_win", "duel_wins_10").forEach { code ->
+        listOf(
+            "tip_giver", "tips_sent_10", "tips_sent_50",
+            "first_duel_win", "duel_wins_10", "duel_wins_25", "duel_wins_50", "duel_wins_100",
+            "duel_losses_5", "duel_losses_25",
+        ).forEach { code ->
             assertNotNull(AchievementCatalog.byCode(code), "missing achievement '$code'")
         }
     }
 
     /**
      * Locks in which catalog entries are still pending hookup. When you
-     * wire one up (e.g. `blackjack_natural` becomes triggered by the
-     * blackjack hand resolution path), flip `hidden = false` in
-     * AchievementCatalog AND remove it from this list. The intent is
-     * that "hidden" never silently grows — every hidden entry is a
-     * promise to a contributor that finishing the hookup makes it
-     * visible.
+     * wire one up (e.g. give a casino game a domain event and an
+     * AchievementEventHandler listener), flip `hidden = false` in
+     * AchievementCatalog AND remove it from [PENDING_HIDDEN_CODES] below.
+     * The intent is that the hidden set is a known, reviewed roadmap —
+     * never silent growth.
      */
     @Test
-    fun `no achievements are hidden`() {
-        // blackjack_natural was the last hidden entry; this PR wires it
-        // through BlackjackService → BlackjackNaturalEvent →
-        // AchievementEventHandler. Every catalog entry is now reachable.
+    fun `hidden achievements match the documented pending-hookup allowlist`() {
         val actuallyHidden = AchievementCatalog.all.filter { it.hidden }.map { it.code }.toSet()
         assertEquals(
-            emptySet<String>(), actuallyHidden,
-            "Hidden achievements set is non-empty. Either wire up the trigger " +
-                "and flip hidden=false, or document the new pending-hookup code in this test."
+            PENDING_HIDDEN_CODES, actuallyHidden,
+            "Hidden-achievement set drifted from the documented roadmap. Either wire up " +
+                "the trigger and flip hidden=false (and remove it from PENDING_HIDDEN_CODES), " +
+                "or add the new pending-hookup code to PENDING_HIDDEN_CODES."
         )
     }
 
     @Test
     fun `every visible achievement is reachable via a wired event handler`() {
         // The handlers in AchievementEventHandler unlock/progress by
-        // these exact codes:
-        //   streak    → streak_first + streak_{3,7,30}
-        //   level     → level_{5,25,50}
-        //   tip       → tip_giver
-        //   duel      → first_duel_win, duel_wins_10
-        //   lottery   → lottery_winner
-        //   intro     → intro_set
-        //   voice     → voice_10h, voice_100h
-        //   blackjack → blackjack_natural
+        // these exact codes — keep this set in lockstep with the
+        // companion-object tier lists in AchievementEventHandler.
         val wired = setOf(
-            "streak_first", "streak_3", "streak_7", "streak_30",
-            "level_5", "level_25", "level_50",
-            "tip_giver", "first_duel_win", "duel_wins_10",
-            "lottery_winner", "intro_set",
-            "voice_10h", "voice_100h",
-            "blackjack_natural",
+            "streak_first", "streak_3", "streak_7", "streak_30", "streak_100", "streak_365",
+            "level_5", "level_25", "level_50", "level_75", "level_100",
+            "tip_giver", "tips_sent_10", "tips_sent_50",
+            "first_duel_win", "duel_wins_10", "duel_wins_25", "duel_wins_50", "duel_wins_100",
+            "duel_losses_5", "duel_losses_25",
+            "lottery_winner", "lottery_wins_3", "lottery_wins_10", "lottery_wins_25",
+            "intro_set",
+            "voice_10h", "voice_100h", "voice_250h", "voice_500h", "voice_1000h",
+            "blackjack_natural", "blackjack_natural_5", "blackjack_natural_25",
         )
         val visible = AchievementCatalog.all.filterNot { it.hidden }.map { it.code }.toSet()
         val orphaned = visible - wired
@@ -122,6 +122,29 @@ class AchievementCatalogTest {
             "Visible achievements with no event-handler hookup: $orphaned. " +
                 "Either wire them up in AchievementEventHandler, mark them hidden, " +
                 "or add them to the wired allowlist in this test."
+        )
+    }
+
+    companion object {
+        // Casino games that don't yet publish domain events — each row
+        // is a reserved code waiting for a hookup PR. When a game gains
+        // an event + AchievementEventHandler listener, flip
+        // `hidden = false` in AchievementCatalog and remove the code
+        // from this set.
+        private val PENDING_HIDDEN_CODES = setOf(
+            "slots_first_jackpot",
+            "roulette_first_straight_win",
+            "poker_first_royal_flush",
+            "dice_first_win",
+            "coinflip_first_win",
+            "keno_first_perfect",
+            "plinko_first_jackpot",
+            "scratch_first_jackpot",
+            "wheel_first_jackpot",
+            "horse_racing_first_win",
+            "baccarat_first_win",
+            "casino_holdem_first_win",
+            "highlow_first_streak",
         )
     }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/misc/AchievementsCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/misc/AchievementsCommand.kt
@@ -157,7 +157,7 @@ class AchievementsCommand @Autowired constructor(
         private const val FIELD_VALUE_LIMIT = 1024
         private const val TRUNCATE_RESERVE = 24
 
-        private val CATEGORY_ORDER = listOf("streak", "level", "casino", "social", "music", "voice")
+        private val CATEGORY_ORDER = listOf("streak", "level", "casino", "social", "music", "voice", "consolation")
 
         private val CATEGORY_DISPLAY = mapOf(
             "streak" to "🔥 Streaks",
@@ -165,7 +165,8 @@ class AchievementsCommand @Autowired constructor(
             "casino" to "🎰 Casino",
             "social" to "🤝 Social",
             "music" to "🎵 Music",
-            "voice" to "🎙️ Voice"
+            "voice" to "🎙️ Voice",
+            "consolation" to "🩹 Consolation"
         )
     }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/handler/AchievementEventHandler.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/handler/AchievementEventHandler.kt
@@ -89,22 +89,39 @@ class AchievementEventHandler(
             guildId = event.guildId,
             code = "tip_giver"
         )
+        TIP_SENT_TIERS.forEach { tier ->
+            achievementService.progress(
+                discordId = event.senderDiscordId,
+                guildId = event.guildId,
+                code = "tips_sent_$tier",
+                delta = 1L
+            )
+        }
     }
 
     @EventListener
     fun onDuelResolved(event: DuelResolvedEvent) {
-        // Two-shot: the winner's first duel + their tenth.
         achievementService.unlock(
             discordId = event.winnerDiscordId,
             guildId = event.guildId,
             code = "first_duel_win"
         )
-        achievementService.progress(
-            discordId = event.winnerDiscordId,
-            guildId = event.guildId,
-            code = "duel_wins_10",
-            delta = 1L
-        )
+        DUEL_WIN_TIERS.forEach { tier ->
+            achievementService.progress(
+                discordId = event.winnerDiscordId,
+                guildId = event.guildId,
+                code = "duel_wins_$tier",
+                delta = 1L
+            )
+        }
+        DUEL_LOSS_TIERS.forEach { tier ->
+            achievementService.progress(
+                discordId = event.loserDiscordId,
+                guildId = event.guildId,
+                code = "duel_losses_$tier",
+                delta = 1L
+            )
+        }
     }
 
     @EventListener
@@ -114,6 +131,14 @@ class AchievementEventHandler(
             guildId = event.guildId,
             code = "lottery_winner"
         )
+        LOTTERY_WIN_TIERS.forEach { tier ->
+            achievementService.progress(
+                discordId = event.discordId,
+                guildId = event.guildId,
+                code = "lottery_wins_$tier",
+                delta = 1L
+            )
+        }
     }
 
     @EventListener
@@ -136,24 +161,28 @@ class AchievementEventHandler(
             guildId = event.guildId,
             code = "blackjack_natural"
         )
+        BLACKJACK_NATURAL_TIERS.forEach { tier ->
+            achievementService.progress(
+                discordId = event.discordId,
+                guildId = event.guildId,
+                code = "blackjack_natural_$tier",
+                delta = 1L
+            )
+        }
     }
 
     @EventListener
     fun onVoiceSessionLogged(event: VoiceSessionLoggedEvent) {
         // Counter-style: each session's countedSeconds adds to the
         // cumulative hours. progress() unlocks on threshold cross.
-        achievementService.progress(
-            discordId = event.discordId,
-            guildId = event.guildId,
-            code = "voice_10h",
-            delta = event.countedSeconds
-        )
-        achievementService.progress(
-            discordId = event.discordId,
-            guildId = event.guildId,
-            code = "voice_100h",
-            delta = event.countedSeconds
-        )
+        VOICE_TIER_CODES.forEach { code ->
+            achievementService.progress(
+                discordId = event.discordId,
+                guildId = event.guildId,
+                code = code,
+                delta = event.countedSeconds
+            )
+        }
     }
 
     @EventListener
@@ -206,7 +235,15 @@ class AchievementEventHandler(
     }
 
     companion object {
-        private val STREAK_MILESTONES = listOf(3, 7, 30)
-        private val LEVEL_MILESTONES = listOf(5, 25, 50)
+        private val STREAK_MILESTONES = listOf(3, 7, 30, 100, 365)
+        private val LEVEL_MILESTONES = listOf(5, 25, 50, 75, 100)
+        private val DUEL_WIN_TIERS = listOf(10, 25, 50, 100)
+        private val DUEL_LOSS_TIERS = listOf(5, 25)
+        private val LOTTERY_WIN_TIERS = listOf(3, 10, 25)
+        private val BLACKJACK_NATURAL_TIERS = listOf(5, 25)
+        private val TIP_SENT_TIERS = listOf(10, 50)
+        private val VOICE_TIER_CODES = listOf(
+            "voice_10h", "voice_100h", "voice_250h", "voice_500h", "voice_1000h"
+        )
     }
 }

--- a/discord-bot/src/test/kotlin/bot/toby/handler/AchievementEventHandlerTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/handler/AchievementEventHandlerTest.kt
@@ -92,9 +92,11 @@ class AchievementEventHandlerTest {
             StreakClaimedEvent(discordId, guildId, currentStreak = 7, longestStreak = 7, channelId = 99L)
         )
         verify(exactly = 1) { achievementService.unlock(discordId, guildId, "streak_first", 99L) }
-        verify(exactly = 1) { achievementService.setProgress(discordId, guildId, "streak_3", 7L, 99L) }
-        verify(exactly = 1) { achievementService.setProgress(discordId, guildId, "streak_7", 7L, 99L) }
-        verify(exactly = 1) { achievementService.setProgress(discordId, guildId, "streak_30", 7L, 99L) }
+        listOf(3, 7, 30, 100, 365).forEach { milestone ->
+            verify(exactly = 1) {
+                achievementService.setProgress(discordId, guildId, "streak_$milestone", 7L, 99L)
+            }
+        }
         // Old wiring used unlock() for milestones — guard against regression.
         verify(exactly = 0) { achievementService.unlock(discordId, guildId, "streak_3", any()) }
         verify(exactly = 0) { achievementService.unlock(discordId, guildId, "streak_7", any()) }
@@ -107,7 +109,7 @@ class AchievementEventHandlerTest {
             StreakClaimedEvent(discordId, guildId, currentStreak = 30, longestStreak = 30, channelId = null)
         )
         verify(exactly = 1) { achievementService.unlock(discordId, guildId, "streak_first", null) }
-        listOf(3, 7, 30).forEach { milestone ->
+        listOf(3, 7, 30, 100, 365).forEach { milestone ->
             verify(exactly = 1) {
                 achievementService.setProgress(discordId, guildId, "streak_$milestone", 30L, null)
             }
@@ -122,9 +124,11 @@ class AchievementEventHandlerTest {
         handler.onStreakClaimed(
             StreakClaimedEvent(discordId, guildId, currentStreak = 1, longestStreak = 14, channelId = 99L)
         )
-        verify(exactly = 1) { achievementService.setProgress(discordId, guildId, "streak_3", 1L, 99L) }
-        verify(exactly = 1) { achievementService.setProgress(discordId, guildId, "streak_7", 1L, 99L) }
-        verify(exactly = 1) { achievementService.setProgress(discordId, guildId, "streak_30", 1L, 99L) }
+        listOf(3, 7, 30, 100, 365).forEach { milestone ->
+            verify(exactly = 1) {
+                achievementService.setProgress(discordId, guildId, "streak_$milestone", 1L, 99L)
+            }
+        }
     }
 
     // ---- level ----
@@ -135,9 +139,11 @@ class AchievementEventHandlerTest {
             LevelUpEvent(discordId, guildId, oldLevel = 4, newLevel = 26, totalXp = 0L, channelId = 99L)
         )
         // Unconditional — the service short-circuits already-owned milestones.
-        verify(exactly = 1) { achievementService.setProgress(discordId, guildId, "level_5", 26L, 99L) }
-        verify(exactly = 1) { achievementService.setProgress(discordId, guildId, "level_25", 26L, 99L) }
-        verify(exactly = 1) { achievementService.setProgress(discordId, guildId, "level_50", 26L, 99L) }
+        listOf(5, 25, 50, 75, 100).forEach { milestone ->
+            verify(exactly = 1) {
+                achievementService.setProgress(discordId, guildId, "level_$milestone", 26L, 99L)
+            }
+        }
         // Old wiring used unlock() — guard against regression.
         verify(exactly = 0) { achievementService.unlock(any(), any(), match { it.startsWith("level_") }, any()) }
     }
@@ -147,7 +153,7 @@ class AchievementEventHandlerTest {
         handler.onLevelUp(
             LevelUpEvent(discordId, guildId, oldLevel = 0, newLevel = 1, totalXp = 0L, channelId = 12345L)
         )
-        listOf(5, 25, 50).forEach { milestone ->
+        listOf(5, 25, 50, 75, 100).forEach { milestone ->
             verify(exactly = 1) {
                 achievementService.setProgress(discordId, guildId, "level_$milestone", 1L, 12345L)
             }
@@ -162,26 +168,37 @@ class AchievementEventHandlerTest {
         handler.onLevelUp(
             LevelUpEvent(discordId, guildId, oldLevel = 6, newLevel = 7, totalXp = 0L, channelId = 99L)
         )
-        verify(exactly = 1) { achievementService.setProgress(discordId, guildId, "level_5", 7L, 99L) }
-        verify(exactly = 1) { achievementService.setProgress(discordId, guildId, "level_25", 7L, 99L) }
-        verify(exactly = 1) { achievementService.setProgress(discordId, guildId, "level_50", 7L, 99L) }
+        listOf(5, 25, 50, 75, 100).forEach { milestone ->
+            verify(exactly = 1) {
+                achievementService.setProgress(discordId, guildId, "level_$milestone", 7L, 99L)
+            }
+        }
     }
 
     // ---- tip / duel / lottery / intro / blackjack ----
 
     @Test
-    fun `tip sent unlocks tip_giver for the sender`() {
+    fun `tip sent unlocks tip_giver and progresses every tips_sent tier for the sender`() {
         handler.onTipSent(TipSentEvent(senderDiscordId = discordId, recipientDiscordId = otherDiscordId, guildId = guildId, amount = 50L))
         verify(exactly = 1) {
             achievementService.unlock(discordId, guildId, "tip_giver")
         }
+        listOf(10, 50).forEach { tier ->
+            verify(exactly = 1) {
+                achievementService.progress(discordId, guildId, "tips_sent_$tier", 1L)
+            }
+        }
+        // Recipient never gets credit on a tip — sender-only semantics.
         verify(exactly = 0) {
             achievementService.unlock(otherDiscordId, any(), any())
+        }
+        verify(exactly = 0) {
+            achievementService.progress(otherDiscordId, any(), any(), any())
         }
     }
 
     @Test
-    fun `duel resolution unlocks first_duel_win and progresses duel_wins_10 for the winner`() {
+    fun `duel resolution unlocks first_duel_win and progresses every duel_wins tier for the winner`() {
         handler.onDuelResolved(
             DuelResolvedEvent(
                 winnerDiscordId = discordId, loserDiscordId = otherDiscordId,
@@ -191,20 +208,49 @@ class AchievementEventHandlerTest {
         verify(exactly = 1) {
             achievementService.unlock(discordId, guildId, "first_duel_win")
         }
-        verify(exactly = 1) {
-            achievementService.progress(discordId, guildId, "duel_wins_10", 1L)
+        listOf(10, 25, 50, 100).forEach { tier ->
+            verify(exactly = 1) {
+                achievementService.progress(discordId, guildId, "duel_wins_$tier", 1L)
+            }
         }
-        // Loser gets nothing.
+        // Winner doesn't get the consolation prize.
+        verify(exactly = 0) {
+            achievementService.progress(discordId, guildId, match { it.startsWith("duel_losses_") }, any())
+        }
+        // Loser doesn't get the winner achievements.
         verify(exactly = 0) {
             achievementService.unlock(otherDiscordId, any(), any())
+        }
+        verify(exactly = 0) {
+            achievementService.progress(otherDiscordId, guildId, match { it.startsWith("duel_wins_") }, any())
         }
     }
 
     @Test
-    fun `lottery winner unlocks lottery_winner for the recipient`() {
+    fun `duel resolution progresses every duel_losses tier for the loser`() {
+        handler.onDuelResolved(
+            DuelResolvedEvent(
+                winnerDiscordId = discordId, loserDiscordId = otherDiscordId,
+                guildId = guildId, stake = 50L, pot = 100L,
+            )
+        )
+        listOf(5, 25).forEach { tier ->
+            verify(exactly = 1) {
+                achievementService.progress(otherDiscordId, guildId, "duel_losses_$tier", 1L)
+            }
+        }
+    }
+
+    @Test
+    fun `lottery winner unlocks lottery_winner and progresses every lottery_wins tier`() {
         handler.onLotteryWon(LotteryWonEvent(discordId, guildId, amount = 500L))
         verify(exactly = 1) {
             achievementService.unlock(discordId, guildId, "lottery_winner")
+        }
+        listOf(3, 10, 25).forEach { tier ->
+            verify(exactly = 1) {
+                achievementService.progress(discordId, guildId, "lottery_wins_$tier", 1L)
+            }
         }
     }
 
@@ -217,7 +263,7 @@ class AchievementEventHandlerTest {
     }
 
     @Test
-    fun `blackjack natural unlocks blackjack_natural for the player`() {
+    fun `blackjack natural unlocks blackjack_natural and progresses every blackjack_natural tier`() {
         // Regression guard: PR #493 originally shipped without this
         // listener; the event was published but nothing consumed it,
         // so the catalog entry stayed permanently locked even though
@@ -226,20 +272,24 @@ class AchievementEventHandlerTest {
         verify(exactly = 1) {
             achievementService.unlock(discordId, guildId, "blackjack_natural")
         }
+        listOf(5, 25).forEach { tier ->
+            verify(exactly = 1) {
+                achievementService.progress(discordId, guildId, "blackjack_natural_$tier", 1L)
+            }
+        }
     }
 
     // ---- voice ----
 
     @Test
-    fun `voice session logged progresses both 10h and 100h achievements by countedSeconds`() {
+    fun `voice session logged progresses every voice tier achievement by countedSeconds`() {
         handler.onVoiceSessionLogged(
             VoiceSessionLoggedEvent(discordId, guildId, countedSeconds = 3600L)
         )
-        verify(exactly = 1) {
-            achievementService.progress(discordId, guildId, "voice_10h", 3600L)
-        }
-        verify(exactly = 1) {
-            achievementService.progress(discordId, guildId, "voice_100h", 3600L)
+        listOf("voice_10h", "voice_100h", "voice_250h", "voice_500h", "voice_1000h").forEach { code ->
+            verify(exactly = 1) {
+                achievementService.progress(discordId, guildId, code, 3600L)
+            }
         }
     }
 

--- a/web/src/main/kotlin/web/service/ProfileWebService.kt
+++ b/web/src/main/kotlin/web/service/ProfileWebService.kt
@@ -164,7 +164,7 @@ class ProfileWebService(
     }
 
     companion object {
-        private val CATEGORY_ORDER = listOf("streak", "level", "casino", "social", "music", "voice")
+        private val CATEGORY_ORDER = listOf("streak", "level", "casino", "social", "music", "voice", "consolation")
 
         // Pair(label, icon)
         private val CATEGORY_DISPLAY = mapOf(
@@ -174,6 +174,7 @@ class ProfileWebService(
             "social" to ("Social" to "🤝"),
             "music" to ("Music" to "🎵"),
             "voice" to ("Voice" to "🎙️"),
+            "consolation" to ("Consolation" to "🩹"),
         )
     }
 }


### PR DESCRIPTION
## Summary

Expands the achievements catalogue with **19 new visible specs** + **13 hidden roadmap stubs**, riding entirely on event listeners that already exist in `AchievementEventHandler`. No new domain events.

### What's new (visible)

- **Streak ladder**: `streak_100` (Centurion), `streak_365` (Year of Toby)
- **Level ladder**: `level_75` (Elite), `level_100` (Legend)
- **Duel wins ladder**: `duel_wins_25` (Champion), `duel_wins_50` (Warlord), `duel_wins_100` (Undefeated)
- **Voice ladder**: `voice_250h` (Voice Devotee), `voice_500h` (Voice Legend), `voice_1000h` (Voice Immortal)
- **Lottery counter** (sits alongside the existing `lottery_winner` one-shot): `lottery_wins_3`, `lottery_wins_10`, `lottery_wins_25`
- **Blackjack natural counter**: `blackjack_natural_5` (Card Counter), `blackjack_natural_25` (Pit Boss)
- **Tips sent counter**: `tips_sent_10` (Patron), `tips_sent_50` (Philanthropist)
- **Consolation (new category)**: `duel_losses_5` (Tough Luck), `duel_losses_25` (Comeback Kid)

### What's new (hidden roadmap)

One reserved-code stub per casino game that doesn't yet publish a domain event — slots, roulette, poker, dice, coinflip, keno, plinko, scratch, wheel-of-fortune, horse racing, baccarat, casino hold'em, highlow. Flip `hidden = false` when each game gets a hookup PR. Pending set is enumerated in `AchievementCatalogTest.PENDING_HIDDEN_CODES` so it can't silently grow.

### Code shape

The handler refactor pulls every tier ladder into a `companion object` list (`STREAK_MILESTONES`, `LEVEL_MILESTONES`, `DUEL_WIN_TIERS`, `DUEL_LOSS_TIERS`, `LOTTERY_WIN_TIERS`, `BLACKJACK_NATURAL_TIERS`, `TIP_SENT_TIERS`, `VOICE_TIER_CODES`) so each `@EventListener` body is a single `.forEach` over the relevant tier list. Net handler growth: ~25 lines.

The new `consolation` category gets a proper label + icon in both the `/achievements` Discord command and the web profile page.

## Test plan

- [x] `:database:test` — `AchievementCatalogTest` (unique codes, known categories, hidden-allowlist match, every visible code reachable via wired handler)
- [x] `:database:test` — `AchievementSeederTest` (idempotent reseed)
- [x] `:discord-bot:test` — `AchievementEventHandlerTest` (every new tier verified per event, sender-only tip semantics, winner-only duel-wins / loser-only duel-losses split)
- [x] `:discord-bot:test` — `AchievementsCommandTest` (renders unchanged with new categories)
- [x] `:web:test` — `ProfileWebService` category ordering still consistent

End-to-end smoke (post-merge):
- Fire `StreakClaimedEvent(currentStreak=100)` → `streak_100` unlocks, `streak_365` shows progress 100.
- Fire `DuelResolvedEvent` 5× against the same loser → loser unlocks `duel_losses_5`, winner advances on every tier counter.
- Fire `VoiceSessionLoggedEvent(countedSeconds=900000)` → cascades through three voice tiers from a single event.
- Fire `LotteryWonEvent` 3× → `lottery_winner` unlocks once, `lottery_wins_3` unlocks on the third.

https://claude.ai/code/session_01EXSEKQrf9Hztvz9D8TL2TS

---
_Generated by [Claude Code](https://claude.ai/code/session_01EXSEKQrf9Hztvz9D8TL2TS)_