### PR TITLE
feat(web): public profiles via leaderboard click-through + level pill alongside title

### DIFF
--- a/web/src/main/kotlin/web/controller/ProfileController.kt
+++ b/web/src/main/kotlin/web/controller/ProfileController.kt
@@ -68,6 +68,44 @@ class ProfileController(
 
         model.addAttribute("profile", profile)
         model.addAttribute("username", user.displayName())
+        model.addAttribute("viewerIsOwner", true)
+        model.addAttribute("backLink", "/profile/guilds?pick=true")
+        model.addAttribute("backLabel", "All servers")
+        "profile"
+    }
+
+    // Read-only view of another guild member's profile. Anyone in the guild
+    // can view anyone else's prestige stats (level/streak/achievements/owned
+    // titles) — the same data that's already projected onto the leaderboard.
+    // Owner-only UI (claim button, permissions, title-shop CTA) is gated on
+    // `viewerIsOwner` in the template.
+    @GetMapping("/{guildId}/{targetDiscordId}")
+    fun publicProfile(
+        @PathVariable guildId: Long,
+        @PathVariable targetDiscordId: Long,
+        @AuthenticationPrincipal user: OAuth2User,
+        model: Model,
+        ra: RedirectAttributes
+    ): String = WebGuildAccess.requireForPage(
+        user, guildId, ra, lobbyPath = "/profile/guilds",
+        check = profileWebService::isMember,
+    ) { viewerDiscordId ->
+        // Self-clicks (e.g. from clicking your own row on the leaderboard)
+        // bounce to the owner self-view so the claim/permissions flow is
+        // preserved without duplicating logic here.
+        if (viewerDiscordId == targetDiscordId) {
+            return@requireForPage "redirect:/profile/$guildId"
+        }
+        val profile = profileWebService.getProfile(targetDiscordId, guildId) ?: run {
+            ra.addFlashAttribute("error", "That member isn't in this server.")
+            return@requireForPage "redirect:/leaderboard/$guildId"
+        }
+
+        model.addAttribute("profile", profile)
+        model.addAttribute("username", user.displayName())
+        model.addAttribute("viewerIsOwner", false)
+        model.addAttribute("backLink", "/leaderboard/$guildId")
+        model.addAttribute("backLabel", "Leaderboard")
         "profile"
     }
 }

--- a/web/src/main/kotlin/web/service/LeaderboardWebService.kt
+++ b/web/src/main/kotlin/web/service/LeaderboardWebService.kt
@@ -307,6 +307,7 @@ class LeaderboardWebService(
                     name = member?.effectiveName ?: "Unknown",
                     avatarUrl = member?.effectiveAvatarUrl,
                     title = title,
+                    level = common.leveling.LevelCurve.progress(dto.xp).level,
                     coins = dto.tobyCoins,
                     coinsThisMonth = coinsThisMonth,
                     portfolioCredits = floor(dto.tobyCoins.toDouble() * price).toLong()
@@ -376,6 +377,7 @@ data class TobyCoinLeaderRow(
     val name: String,
     val avatarUrl: String?,
     val title: String?,
+    val level: Int = 0,
     val coins: Long,
     val coinsThisMonth: Long = 0L,
     val portfolioCredits: Long

--- a/web/src/main/kotlin/web/service/ModerationWebService.kt
+++ b/web/src/main/kotlin/web/service/ModerationWebService.kt
@@ -262,6 +262,7 @@ class ModerationWebService(
                     avatarUrl = member?.effectiveAvatarUrl,
                     socialCredit = current,
                     title = title,
+                    level = common.leveling.LevelCurve.progress(dto.xp).level,
                     voiceSecondsLifetime = lifetimeVoice[dto.discordId] ?: 0L,
                     voiceSecondsThisMonth = thisMonthVoice[dto.discordId] ?: 0L,
                     creditsEarnedThisMonth = creditsDelta
@@ -1548,6 +1549,7 @@ data class LeaderboardRow(
     val avatarUrl: String?,
     val socialCredit: Long,
     val title: String? = null,
+    val level: Int = 0,
     val voiceSecondsLifetime: Long = 0,
     val voiceSecondsThisMonth: Long = 0,
     val creditsEarnedThisMonth: Long = 0

--- a/web/src/main/resources/static/css/base.css
+++ b/web/src/main/resources/static/css/base.css
@@ -1022,6 +1022,73 @@ td { font-size: 0.95rem; }
     flex-shrink: 0;
 }
 
+/* Prestige pill — surfaced alongside .lb-title-pill across the
+   leaderboard standings, TobyCoin table, podium cards, and any future
+   page that wants to show level inline. Tier palette mirrors
+   profile.css's .level-tier-* so the bronze/silver/gold/diamond colour
+   language is consistent between the leaderboard and a member's
+   profile page. */
+.lb-level-pill {
+    display: inline-block;
+    padding: 2px 8px;
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    font-size: 0.75rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: #1a1a1a;
+    flex-shrink: 0;
+    font-variant-numeric: tabular-nums;
+}
+.lb-level-pill.lb-level-tier-bronze {
+    background: linear-gradient(135deg, #c9803a 0%, #e6a86b 100%);
+    border-color: #4a3525;
+}
+.lb-level-pill.lb-level-tier-silver {
+    background: linear-gradient(135deg, #9aa3b2 0%, #d3dae6 100%);
+    border-color: #3a3f4a;
+}
+.lb-level-pill.lb-level-tier-gold {
+    background: linear-gradient(135deg, #d4a017 0%, #ffd966 100%);
+    border-color: #4a3a15;
+}
+.lb-level-pill.lb-level-tier-diamond {
+    background: linear-gradient(135deg, #5865f2 0%, #a6b1ff 100%);
+    border-color: #2a3580;
+    color: #f4f6ff;
+}
+
+/* Click-through wrapper for the shared memberCell. Renders the same
+   avatar+name projection but as an inline-flex anchor so rows on the
+   leaderboard, lottery top-holders, duel offers, and top-games
+   contributor tooltips all navigate to /profile/{guildId}/{discordId}.
+   The hover affordance is intentionally subtle — the cell already
+   carries a strong visual signal (avatar + name) so we only need to
+   announce "this is clickable" on hover. */
+.member-cell-link {
+    display: inline-flex;
+    align-items: center;
+    text-decoration: none;
+    color: inherit;
+    min-width: 0;
+    border-radius: 6px;
+    transition: background-color 0.12s ease, transform 0.12s ease;
+}
+.member-cell-link:hover,
+.member-cell-link:focus-visible {
+    background: var(--bg);
+    outline: none;
+}
+.member-cell-link:hover .lb-name,
+.member-cell-link:focus-visible .lb-name {
+    text-decoration: underline;
+    text-underline-offset: 2px;
+}
+.member-cell-link:focus-visible {
+    box-shadow: 0 0 0 2px var(--accent, #5865f2);
+}
+
 /* -- Numeric value accents shared by both standings tables (credits +
    tobycoin) on the leaderboard. Lives here so a future page that wants
    to surface a coloured numeric pill can reuse the same set without

--- a/web/src/main/resources/static/css/leaderboard.css
+++ b/web/src/main/resources/static/css/leaderboard.css
@@ -273,6 +273,33 @@
     color: var(--text);
 }
 .lb-podium-1 .lb-podium-name { font-size: 1.15rem; }
+.lb-podium-name-link {
+    display: inline-block;
+    text-decoration: none;
+    color: inherit;
+    border-radius: 6px;
+    padding: 2px 4px;
+    transition: background-color 0.12s ease;
+}
+.lb-podium-name-link:hover .lb-podium-name,
+.lb-podium-name-link:focus-visible .lb-podium-name {
+    text-decoration: underline;
+    text-underline-offset: 2px;
+}
+.lb-podium-name-link:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 2px var(--accent, #5865f2);
+}
+/* Stack the level pill above the title pill on the podium so each
+   card reads "name → prestige". Centred to match the rest of the card
+   which is column-flex / text-align: center. */
+.lb-podium-pills {
+    display: inline-flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    justify-content: center;
+    align-items: center;
+}
 .lb-podium-credits { color: var(--text); font-size: 0.95rem; }
 .lb-podium-credits strong { color: var(--medal-gold); font-size: 1.1rem; }
 .lb-podium-month {

--- a/web/src/main/resources/templates/duel.html
+++ b/web/src/main/resources/templates/duel.html
@@ -76,7 +76,7 @@
                 <div class="duel-pending-info">
                     <div class="duel-pending-who">
                         <span class="muted">From</span>
-                        <div th:replace="~{fragments/memberCell :: cell(${p.initiatorName}, ${p.initiatorAvatarUrl})}"></div>
+                        <div th:replace="~{fragments/memberCell :: cellLink(${p.initiatorName}, ${p.initiatorAvatarUrl}, @{/profile/{g}/{d}(g=${guildId}, d=${p.initiatorDiscordId})})}"></div>
                     </div>
                     <div class="duel-pending-meta">
                         <span>for <strong th:text="${p.stake}">100</strong> credits</span>
@@ -101,7 +101,7 @@
                 <div class="duel-pending-info">
                     <div class="duel-pending-who">
                         <span class="muted">To</span>
-                        <div th:replace="~{fragments/memberCell :: cell(${p.opponentName}, ${p.opponentAvatarUrl})}"></div>
+                        <div th:replace="~{fragments/memberCell :: cellLink(${p.opponentName}, ${p.opponentAvatarUrl}, @{/profile/{g}/{d}(g=${guildId}, d=${p.opponentDiscordId})})}"></div>
                     </div>
                     <div class="duel-pending-meta">
                         <span>for <strong th:text="${p.stake}">100</strong> credits</span>

--- a/web/src/main/resources/templates/fragments/memberCell.html
+++ b/web/src/main/resources/templates/fragments/memberCell.html
@@ -3,16 +3,37 @@
   standings tables and the lottery top-holders list so the two pages
   render the same Discord-member projection.
 
-  Styling lives in static/css/moderation.css (.member-cell, .avatar)
-  and static/css/leaderboard.css (.lb-name); the fragment is a pure
-  markup refactor.
+  Styling lives in static/css/base.css (.member-cell, .avatar, .lb-name)
+  so every page that loads base.css picks it up uniformly. The link
+  affordance (.member-cell-link) also lives in base.css so the four
+  callers (leaderboard, lottery, duel, profile follow-ups) share it.
 -->
-<div xmlns:th="http://www.thymeleaf.org"
-     th:fragment="cell(name, avatarUrl)"
-     class="member-cell">
+<div xmlns:th="http://www.thymeleaf.org">
+
+<div th:fragment="cell(name, avatarUrl)" class="member-cell">
     <img th:if="${avatarUrl != null}"
          th:src="${avatarUrl}"
          class="avatar"
          alt="">
     <span class="lb-name" th:text="${name}">Name</span>
+</div>
+
+<!--
+  Click-through variant: wraps the cell in an <a> so the row navigates
+  to the public profile (or any other URL). Inline-block so the cell
+  keeps its layout flow inside flex parents (member-cell stays a flex
+  child of the row/table cell).
+-->
+<a th:fragment="cellLink(name, avatarUrl, profileHref)"
+   th:href="${profileHref}"
+   class="member-cell-link">
+    <span class="member-cell">
+        <img th:if="${avatarUrl != null}"
+             th:src="${avatarUrl}"
+             class="avatar"
+             alt="">
+        <span class="lb-name" th:text="${name}">Name</span>
+    </span>
+</a>
+
 </div>

--- a/web/src/main/resources/templates/leaderboard.html
+++ b/web/src/main/resources/templates/leaderboard.html
@@ -44,10 +44,18 @@
                  th:src="${view.podium[1].avatarUrl}"
                  class="lb-podium-avatar"
                  alt="">
-            <div class="lb-podium-name" th:text="${view.podium[1].name}">Name</div>
-            <span th:if="${view.podium[1].title != null}"
-                  class="lb-title-pill"
-                  th:text="${view.podium[1].title}">Title</span>
+            <a class="lb-podium-name-link"
+               th:href="@{/profile/{g}/{d}(g=${guildId}, d=${view.podium[1].discordId})}">
+                <div class="lb-podium-name" th:text="${view.podium[1].name}">Name</div>
+            </a>
+            <div class="lb-podium-pills">
+                <span class="lb-level-pill"
+                      th:classappend="${'lb-level-tier-' + (view.podium[1].level >= 50 ? 'diamond' : (view.podium[1].level >= 25 ? 'gold' : (view.podium[1].level >= 10 ? 'silver' : 'bronze')))}"
+                      th:text="'LVL ' + ${view.podium[1].level}">LVL 0</span>
+                <span th:if="${view.podium[1].title != null}"
+                      class="lb-title-pill"
+                      th:text="${view.podium[1].title}">Title</span>
+            </div>
             <div class="lb-podium-credits">
                 <strong th:if="${isMonth}"
                         th:text="|${view.podium[1].creditsEarnedThisMonth >= 0 ? '+' : ''}${view.podium[1].creditsEarnedThisMonth}|">+0</strong>
@@ -70,10 +78,18 @@
                  th:src="${view.podium[0].avatarUrl}"
                  class="lb-podium-avatar"
                  alt="">
-            <div class="lb-podium-name" th:text="${view.podium[0].name}">Name</div>
-            <span th:if="${view.podium[0].title != null}"
-                  class="lb-title-pill"
-                  th:text="${view.podium[0].title}">Title</span>
+            <a class="lb-podium-name-link"
+               th:href="@{/profile/{g}/{d}(g=${guildId}, d=${view.podium[0].discordId})}">
+                <div class="lb-podium-name" th:text="${view.podium[0].name}">Name</div>
+            </a>
+            <div class="lb-podium-pills">
+                <span class="lb-level-pill"
+                      th:classappend="${'lb-level-tier-' + (view.podium[0].level >= 50 ? 'diamond' : (view.podium[0].level >= 25 ? 'gold' : (view.podium[0].level >= 10 ? 'silver' : 'bronze')))}"
+                      th:text="'LVL ' + ${view.podium[0].level}">LVL 0</span>
+                <span th:if="${view.podium[0].title != null}"
+                      class="lb-title-pill"
+                      th:text="${view.podium[0].title}">Title</span>
+            </div>
             <div class="lb-podium-credits">
                 <strong th:if="${isMonth}"
                         th:text="|${view.podium[0].creditsEarnedThisMonth >= 0 ? '+' : ''}${view.podium[0].creditsEarnedThisMonth}|">+0</strong>
@@ -96,10 +112,18 @@
                  th:src="${view.podium[2].avatarUrl}"
                  class="lb-podium-avatar"
                  alt="">
-            <div class="lb-podium-name" th:text="${view.podium[2].name}">Name</div>
-            <span th:if="${view.podium[2].title != null}"
-                  class="lb-title-pill"
-                  th:text="${view.podium[2].title}">Title</span>
+            <a class="lb-podium-name-link"
+               th:href="@{/profile/{g}/{d}(g=${guildId}, d=${view.podium[2].discordId})}">
+                <div class="lb-podium-name" th:text="${view.podium[2].name}">Name</div>
+            </a>
+            <div class="lb-podium-pills">
+                <span class="lb-level-pill"
+                      th:classappend="${'lb-level-tier-' + (view.podium[2].level >= 50 ? 'diamond' : (view.podium[2].level >= 25 ? 'gold' : (view.podium[2].level >= 10 ? 'silver' : 'bronze')))}"
+                      th:text="'LVL ' + ${view.podium[2].level}">LVL 0</span>
+                <span th:if="${view.podium[2].title != null}"
+                      class="lb-title-pill"
+                      th:text="${view.podium[2].title}">Title</span>
+            </div>
             <div class="lb-podium-credits">
                 <strong th:if="${isMonth}"
                         th:text="|${view.podium[2].creditsEarnedThisMonth >= 0 ? '+' : ''}${view.podium[2].creditsEarnedThisMonth}|">+0</strong>
@@ -171,7 +195,7 @@
                     <tr>
                         <th class="lb-col-rank">#</th>
                         <th>Member</th>
-                        <th>Title</th>
+                        <th>Prestige</th>
                         <th class="lb-col-value"
                             th:attr="aria-sort=${view.sort.name() == 'LIFETIME' ? 'descending' : 'none'}">
                             💰 Credits
@@ -190,11 +214,13 @@
                                   th:text="${row.rank}">4</span>
                         </td>
                         <td data-label="Member">
-                            <div th:replace="~{fragments/memberCell :: cell(${row.name}, ${row.avatarUrl})}"></div>
+                            <div th:replace="~{fragments/memberCell :: cellLink(${row.name}, ${row.avatarUrl}, @{/profile/{g}/{d}(g=${guildId}, d=${row.discordId})})}"></div>
                         </td>
-                        <td data-label="Title">
+                        <td data-label="Prestige">
+                            <span class="lb-level-pill"
+                                  th:classappend="${'lb-level-tier-' + (row.level >= 50 ? 'diamond' : (row.level >= 25 ? 'gold' : (row.level >= 10 ? 'silver' : 'bronze')))}"
+                                  th:text="'LVL ' + ${row.level}">LVL 0</span>
                             <span th:if="${row.title != null}" class="lb-title-pill" th:text="${row.title}"></span>
-                            <span th:unless="${row.title != null}" class="muted">—</span>
                         </td>
                         <td data-label="Credits" class="lb-col-value">
                             <strong class="lb-value lb-value-credits" th:text="${row.socialCredit}">0</strong>
@@ -238,7 +264,7 @@
                     <tr>
                         <th class="lb-col-rank">#</th>
                         <th>Member</th>
-                        <th>Title</th>
+                        <th>Prestige</th>
                         <th class="lb-col-value">🪙 TOBY</th>
                         <th class="lb-col-value">This month</th>
                         <th class="lb-col-value">💰 Portfolio</th>
@@ -252,11 +278,13 @@
                                   th:text="${row.rank}">1</span>
                         </td>
                         <td data-label="Member">
-                            <div th:replace="~{fragments/memberCell :: cell(${row.name}, ${row.avatarUrl})}"></div>
+                            <div th:replace="~{fragments/memberCell :: cellLink(${row.name}, ${row.avatarUrl}, @{/profile/{g}/{d}(g=${guildId}, d=${row.discordId})})}"></div>
                         </td>
-                        <td data-label="Title">
+                        <td data-label="Prestige">
+                            <span class="lb-level-pill"
+                                  th:classappend="${'lb-level-tier-' + (row.level >= 50 ? 'diamond' : (row.level >= 25 ? 'gold' : (row.level >= 10 ? 'silver' : 'bronze')))}"
+                                  th:text="'LVL ' + ${row.level}">LVL 0</span>
                             <span th:if="${row.title != null}" class="lb-title-pill" th:text="${row.title}"></span>
-                            <span th:unless="${row.title != null}" class="muted">—</span>
                         </td>
                         <td data-label="TOBY" class="lb-col-value">
                             <strong class="lb-value lb-value-toby" th:text="${row.coins}">0</strong>
@@ -339,7 +367,7 @@
                                     <div class="lb-tooltip-title">Top contributors</div>
                                     <ul class="lb-tooltip-list">
                                         <li class="lb-tooltip-row" th:each="c : ${row.contributors}">
-                                            <div th:replace="~{fragments/memberCell :: cell(${c.name}, ${c.avatarUrl})}"></div>
+                                            <div th:replace="~{fragments/memberCell :: cellLink(${c.name}, ${c.avatarUrl}, @{/profile/{g}/{d}(g=${guildId}, d=${c.discordId})})}"></div>
                                             <div class="lb-tooltip-meta">
                                                 <span class="lb-tooltip-time" th:text="${c.playtimeDisplay}">0m</span>
                                                 <span class="lb-tooltip-percent muted" th:text="'(' + ${c.percent} + '%)'">(0%)</span>

--- a/web/src/main/resources/templates/lottery.html
+++ b/web/src/main/resources/templates/lottery.html
@@ -299,7 +299,7 @@
                     <span class="lb-rank"
                           th:classappend="${iter.count == 1 ? 'lb-rank-1' : (iter.count == 2 ? 'lb-rank-2' : (iter.count == 3 ? 'lb-rank-3' : ''))}"
                           th:text="${iter.count}">1</span>
-                    <div th:replace="~{fragments/memberCell :: cell(${h.name}, ${h.avatarUrl})}"></div>
+                    <div th:replace="~{fragments/memberCell :: cellLink(${h.name}, ${h.avatarUrl}, @{/profile/{g}/{d}(g=${guildId}, d=${h.discordId})})}"></div>
                     <span th:if="${h.title != null}" class="lb-title-pill" th:text="${h.title}"></span>
                     <span class="lottery-ticket-pill">
                         <strong th:text="${h.bonusTickets > 0}
@@ -418,7 +418,7 @@
                     <span class="lb-rank"
                           th:classappend="${iter.count == 1 ? 'lb-rank-1' : (iter.count == 2 ? 'lb-rank-2' : (iter.count == 3 ? 'lb-rank-3' : ''))}"
                           th:text="${iter.count}">1</span>
-                    <div th:replace="~{fragments/memberCell :: cell(${h.name}, ${h.avatarUrl})}"></div>
+                    <div th:replace="~{fragments/memberCell :: cellLink(${h.name}, ${h.avatarUrl}, @{/profile/{g}/{d}(g=${guildId}, d=${h.discordId})})}"></div>
                     <span th:if="${h.title != null}" class="lb-title-pill" th:text="${h.title}"></span>
                     <span class="lottery-ticket-pill">
                         <strong th:text="${h.bonusTickets > 0}

--- a/web/src/main/resources/templates/profile.html
+++ b/web/src/main/resources/templates/profile.html
@@ -7,7 +7,10 @@
 
 <main id="main" class="container">
     <div class="profile-header">
-        <a class="back-link" th:href="@{/profile/guilds(pick=true)}">&larr; All servers</a>
+        <a class="back-link"
+           th:href="${backLink != null} ? ${backLink} : @{/profile/guilds(pick=true)}">
+            &larr; <span th:text="${backLabel != null} ? ${backLabel} : 'All servers'">All servers</span>
+        </a>
         <h1 th:text="${profile.guildName}">Guild</h1>
     </div>
 
@@ -42,7 +45,7 @@
                       th:text="${profile.equippedTitleLabel}">Title</span>
                 <span th:unless="${profile.equippedTitleLabel != null}" class="muted">—</span>
             </div>
-            <a class="btn profile-action" th:href="@{/titles/{id}(id=${profile.guildId})}">Go to title shop &rarr;</a>
+            <a th:if="${viewerIsOwner}" class="btn profile-action" th:href="@{/titles/{id}(id=${profile.guildId})}">Go to title shop &rarr;</a>
         </section>
 
         <section class="profile-card level-card" th:classappend="'level-tier-' + (${profile.level} >= 50 ? 'diamond' : (${profile.level} >= 25 ? 'gold' : (${profile.level} >= 10 ? 'silver' : 'bronze')))">
@@ -71,7 +74,7 @@
             </div>
         </section>
 
-        <section class="profile-card">
+        <section class="profile-card" th:if="${viewerIsOwner}">
             <h2>Permissions</h2>
             <ul class="profile-perms">
                 <li th:each="p : ${profile.permissions}">
@@ -100,10 +103,14 @@
                th:if="${profile.streak.lastClaimDate != null}"
                th:text="'Last claim: ' + ${profile.streak.lastClaimDate}">Last claim: —</p>
             <p class="muted profile-streak-meta"
-               th:unless="${profile.streak.lastClaimDate != null}">
+               th:if="${viewerIsOwner and profile.streak.lastClaimDate == null}">
                 You haven't claimed yet — `/daily` in Discord or click the button below.
             </p>
-            <button type="button" class="btn profile-streak-claim"
+            <p class="muted profile-streak-meta"
+               th:if="${!viewerIsOwner and profile.streak.lastClaimDate == null}">
+                Hasn't claimed yet.
+            </p>
+            <button th:if="${viewerIsOwner}" type="button" class="btn profile-streak-claim"
                     th:disabled="${profile.streak.claimedToday}"
                     th:text="${profile.streak.claimedToday} ? 'Already claimed today' : 'Claim daily'">
                 Claim daily
@@ -171,9 +178,12 @@
 
         <section class="profile-card profile-card-wide">
             <h2>Owned titles</h2>
-            <div th:if="${#lists.isEmpty(profile.ownedTitles)}" class="muted">
+            <div th:if="${#lists.isEmpty(profile.ownedTitles) and viewerIsOwner}" class="muted">
                 You don't own any titles yet.
                 <a th:href="@{/titles/{id}(id=${profile.guildId})}">Browse the shop &rarr;</a>
+            </div>
+            <div th:if="${#lists.isEmpty(profile.ownedTitles) and !viewerIsOwner}" class="muted">
+                Hasn't unlocked any titles yet.
             </div>
             <ul class="profile-titles" th:if="${not #lists.isEmpty(profile.ownedTitles)}">
                 <li th:each="t : ${profile.ownedTitles}">


### PR DESCRIPTION
## Summary

Turns leaderboard rows into links to a read-only public profile so members can compare their level, streak, and achievements with anyone else in the guild — and surfaces each member's **level next to their title** across the leaderboard for at-a-glance prestige.

- **Public profile route** `GET /profile/{guildId}/{targetDiscordId}` reusing `WebGuildAccess.requireForPage` + `ProfileWebService.getProfile` (already keyed by `(discordId, guildId)`). Self-clicks bounce to the existing `/profile/{guildId}` so the claim/permissions flow stays interactive.
- **Read-only profile mode** in `profile.html`: hides Permissions card, Claim daily button, "Go to title shop" CTA, and the empty-titles shop link when `viewerIsOwner = false`. Identity, balance, level, streak stats, achievements, and owned titles all stay visible (already exposed on the leaderboard — no new privacy surface).
- **Level pill on the leaderboard**: added to standings, TobyCoin table, and all three podium cards. Tier palette (bronze < 10, silver 10–24, gold 25–49, diamond ≥ 50) mirrors `profile.css` `.level-tier-*` so prestige reads consistently between the leaderboard and a member's profile.
- **Shared `cellLink` fragment refactor**: extended `fragments/memberCell.html` with a click-through variant and switched all 7 call-sites (leaderboard ×3 incl. games-tooltip, lottery ×2, duel ×2) so navigation is uniform rather than open-coded per page.
- **CSS lives in `base.css`** alongside the existing `.member-cell` / `.lb-title-pill` rules so every page that loads base.css picks up `.lb-level-pill` and `.member-cell-link` without reimporting leaderboard.css.

## Test plan

- [x] `./gradlew :web:compileKotlin` — passes
- [x] `./gradlew :web:test` — passes
- [ ] On `/leaderboard/{guildId}`: hovering a standings row shows the click affordance; clicking another member lands on `/profile/{guildId}/{theirId}` with no Permissions / Claim button / title-shop CTA. Streak stats, achievements, level, owned titles all render.
- [ ] Clicking own row redirects to `/profile/{guildId}` (owner self-view with claim button).
- [ ] Back link on the public view returns to `/leaderboard/{guildId}`.
- [ ] Level pills render with the right tier colour on standings, TobyCoin, and the three podium cards.
- [ ] Direct visit to `/profile/{guildId}` is unchanged (back link reads "All servers").
- [ ] Logged-in user not in the guild requesting `/profile/{guildId}/{anyId}` is redirected to `/profile/guilds` with the standard 403 flash.
- [ ] Lottery top-holders rows, duel offer rows, and the leaderboard top-games contributor tooltip all click through to the public profile.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SimSuCRyk3h9p9zpWn2K8h)_