### PR TITLE
fix(web): load footer styles on every page, not just home

### DIFF
--- a/web/src/main/resources/static/css/footer.css
+++ b/web/src/main/resources/static/css/footer.css
@@ -1,0 +1,65 @@
+/* SITE FOOTER
+   Same gradient hairline trick as the top navbar — a 1px gradient strip
+   reads as a designed divider rather than a default border.
+
+   Lives in its own file (not home.css) because the footer fragment is
+   shared across every public page; styles need to load wherever the
+   fragment does, which is why the head fragment links this directly. */
+.site-footer {
+    position: relative;
+    padding: 36px 24px;
+    text-align: center;
+    color: var(--text-dim);
+    font-size: 0.82rem;
+}
+.site-footer::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 1px;
+    background: var(--gradient-accent);
+    opacity: 0.35;
+    pointer-events: none;
+}
+.site-footer-inner {
+    max-width: 800px;
+    margin: 0 auto;
+    display: grid;
+    gap: 8px;
+}
+.site-footer-line { margin: 0; }
+.site-footer a { color: var(--accent-light); text-decoration: none; }
+.site-footer a:hover { text-decoration: underline; }
+.site-footer-source { font-size: 0.85rem; }
+.site-footer-stack {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    align-items: center;
+    gap: 12px;
+    margin-top: 8px;
+    font-size: 0.78rem;
+    color: var(--text-muted);
+}
+.site-footer-stack-label {
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-dim);
+    font-weight: 600;
+}
+.site-footer-stack-item {
+    color: var(--text-muted);
+    position: relative;
+}
+.site-footer-stack-item + .site-footer-stack-item::before {
+    content: "·";
+    color: var(--text-dim);
+    margin-right: 12px;
+    margin-left: -12px;
+}
+
+@media (max-width: 480px) {
+    .site-footer { padding: 24px 16px; }
+}

--- a/web/src/main/resources/static/css/home.css
+++ b/web/src/main/resources/static/css/home.css
@@ -477,64 +477,6 @@
     justify-content: center;
 }
 
-/* SITE FOOTER
-   Same gradient hairline trick as the top navbar — a 1px gradient strip
-   reads as a designed divider rather than a default border. */
-.site-footer {
-    position: relative;
-    padding: 36px 24px;
-    text-align: center;
-    color: var(--text-dim);
-    font-size: 0.82rem;
-}
-.site-footer::before {
-    content: "";
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    height: 1px;
-    background: var(--gradient-accent);
-    opacity: 0.35;
-    pointer-events: none;
-}
-.site-footer-inner {
-    max-width: 800px;
-    margin: 0 auto;
-    display: grid;
-    gap: 8px;
-}
-.site-footer-line { margin: 0; }
-.site-footer a { color: var(--accent-light); text-decoration: none; }
-.site-footer a:hover { text-decoration: underline; }
-.site-footer-source { font-size: 0.85rem; }
-.site-footer-stack {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
-    align-items: center;
-    gap: 12px;
-    margin-top: 8px;
-    font-size: 0.78rem;
-    color: var(--text-muted);
-}
-.site-footer-stack-label {
-    text-transform: uppercase;
-    letter-spacing: 0.06em;
-    color: var(--text-dim);
-    font-weight: 600;
-}
-.site-footer-stack-item {
-    color: var(--text-muted);
-    position: relative;
-}
-.site-footer-stack-item + .site-footer-stack-item::before {
-    content: "·";
-    color: var(--text-dim);
-    margin-right: 12px;
-    margin-left: -12px;
-}
-
 /* CHANGELOG TIMELINE */
 .changelog-page {
     max-width: 760px;
@@ -712,7 +654,6 @@
     .howto-strip { gap: 16px; }
     .howto-step { padding: 20px 18px; }
     .final-cta { padding: 48px 16px 64px; }
-    .site-footer { padding: 24px 16px; }
     .login-card { padding: 32px 20px; }
     .login-card h1 { font-size: 1.5rem; }
     .changelog-page { padding: 0 16px 48px; }

--- a/web/src/main/resources/templates/fragments/head.html
+++ b/web/src/main/resources/templates/fragments/head.html
@@ -21,6 +21,7 @@
     <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
     <link rel="stylesheet" th:href="@{/css/base.css}">
     <link rel="stylesheet" th:href="@{/css/nav.css}">
+    <link rel="stylesheet" th:href="@{/css/footer.css}">
     <link rel="stylesheet" th:if="${extraCss != null}" th:href="@{${extraCss}}">
     <!-- Shared motion primitives (count-up + reveal-on-scroll). `defer`
          so it runs after parse but blocks no rendering; reduced-motion is
@@ -48,6 +49,7 @@
     <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
     <link rel="stylesheet" th:href="@{/css/base.css}">
     <link rel="stylesheet" th:href="@{/css/nav.css}">
+    <link rel="stylesheet" th:href="@{/css/footer.css}">
     <link rel="stylesheet" th:if="${extraCss != null}" th:href="@{${extraCss}}">
     <!-- Shared motion primitives (count-up + reveal-on-scroll). `defer`
          so it runs after parse but blocks no rendering; reduced-motion is


### PR DESCRIPTION
## Summary

- The site footer renders flush-left and unstyled on every public page except `/` — visible on `/commands`, `/commands/wiki`, `/changelog`, `/login`, `/terms`, `/privacy`.
- Root cause: `.site-footer*` rules lived in `home.css`, but the footer fragment is included from pages that load their own per-page sheet (`commands.css`, `legal.css`, etc.) and never pull in `home.css`. The shared head fragment only loads `base.css` + `nav.css` + one per-page sheet.
- Fix: extract the footer block into a new `static/css/footer.css` and link it from both head fragments (`head` and `headSeo`) so the styles travel with the shared markup.

## Test plan

- [ ] `./gradlew :web:bootRun`
- [ ] Confirm `/` footer still looks correct (no regression from the extraction)
- [ ] Confirm `/commands`, `/commands/wiki`, `/changelog`, `/login`, `/terms`, `/privacy` now render the footer centered with the gradient hairline divider
- [ ] Resize to <480px width and confirm the responsive padding override still applies

https://claude.ai/code/session_013xtRrLEm77xGRwUMTwMm1i

---
_Generated by [Claude Code](https://claude.ai/code/session_013xtRrLEm77xGRwUMTwMm1i)_