### PR TITLE
perf(memory): tighten JVM/JDA caps and evict per-guild caches on leave

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,4 @@ FROM eclipse-temurin:21-jre
 RUN mkdir /app
 COPY --from=build /home/gradle/src/application/build/libs/*.jar /app/toby-bot.jar
 EXPOSE 8080
-ENTRYPOINT ["java", "-Xms64m", "-Xmx320m", "-XX:+UseSerialGC", "-XX:MaxMetaspaceSize=128m", "-Xss512k", "-jar", "/app/toby-bot.jar"]
+ENTRYPOINT ["java", "-Xms128m", "-Xmx256m", "-XX:+UseSerialGC", "-XX:MaxMetaspaceSize=96m", "-XX:ReservedCodeCacheSize=64m", "-XX:MaxDirectMemorySize=48m", "-Dio.netty.maxDirectMemory=0", "-Dio.netty.allocator.numDirectArenas=2", "-Dio.netty.allocator.numHeapArenas=2", "-Xss256k", "-XX:+ExitOnOutOfMemoryError", "-jar", "/app/toby-bot.jar"]

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: java -Dserver.port=$PORT -jar application/build/libs/application-7.1-SNAPSHOT.jar
+web: java -Xms128m -Xmx256m -XX:+UseSerialGC -XX:MaxMetaspaceSize=96m -XX:ReservedCodeCacheSize=64m -XX:MaxDirectMemorySize=48m -Dio.netty.maxDirectMemory=0 -Dio.netty.allocator.numDirectArenas=2 -Dio.netty.allocator.numHeapArenas=2 -Xss256k -XX:+ExitOnOutOfMemoryError -Dserver.port=$PORT -jar application/build/libs/application-7.1-SNAPSHOT.jar
 release: ./bin/trigger_publish_wiki.sh  # This runs after deployment

--- a/application/src/main/resources/application.properties
+++ b/application/src/main/resources/application.properties
@@ -1,5 +1,6 @@
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.hibernate.ddl-auto=none
+spring.jpa.open-in-view=false
 server.port=8080
 server.servlet.context-path=/
 server.forward-headers-strategy=framework

--- a/core-api/src/main/kotlin/core/managers/CommandManager.kt
+++ b/core-api/src/main/kotlin/core/managers/CommandManager.kt
@@ -23,4 +23,10 @@ interface CommandManager : NamedRegistry<Command> {
     fun getCommand(search: String): Command? = findByName(search)
 
     fun handle(event: SlashCommandInteractionEvent)
+
+    /**
+     * Drop any cached per-guild state for [guildId]. Default no-op so
+     * test doubles and lighter implementations don't have to override.
+     */
+    fun evictGuild(guildId: Long) {}
 }

--- a/database/src/main/kotlin/database/blackjack/BlackjackTableRegistry.kt
+++ b/database/src/main/kotlin/database/blackjack/BlackjackTableRegistry.kt
@@ -154,6 +154,22 @@ class BlackjackTableRegistry(
     }
 
     /**
+     * Force-evict every table belonging to [guildId]. Called when the
+     * bot leaves the guild so seated antes are refunded via the same
+     * [onIdleEvict] path the idle sweeper uses.
+     */
+    fun evictGuild(guildId: Long) {
+        for ((id, table) in tables) {
+            if (table.guildId != guildId) continue
+            synchronized(table) {
+                val evicted = tables.remove(id)
+                cancelShotClock(id)
+                if (evicted != null) runCatching { onIdleEvict?.invoke(evicted) }
+            }
+        }
+    }
+
+    /**
      * Force-evict every table whose `lastActivityAt` is older than
      * [idleTtl]. Public + parameterised so tests can drive it without
      * waiting for the scheduler.

--- a/database/src/main/kotlin/database/poker/CasinoHoldemTableRegistry.kt
+++ b/database/src/main/kotlin/database/poker/CasinoHoldemTableRegistry.kt
@@ -82,6 +82,21 @@ class CasinoHoldemTableRegistry(
     }
 
     /**
+     * Force-evict every table belonging to [guildId]. Called when the
+     * bot leaves the guild so unresolved stakes are refunded via the
+     * same [onIdleEvict] path the idle sweeper uses.
+     */
+    fun evictGuild(guildId: Long) {
+        for ((id, table) in tables) {
+            if (table.guildId != guildId) continue
+            synchronized(table) {
+                val evicted = tables.remove(id)
+                if (evicted != null) runCatching { onIdleEvict?.invoke(evicted) }
+            }
+        }
+    }
+
+    /**
      * Force-evict every table whose `lastActivityAt` is older than
      * [idleTtl]. Public + parameterised so tests can drive it without
      * waiting for the scheduler. Each evicted table is handed to

--- a/database/src/main/kotlin/database/poker/PokerTableRegistry.kt
+++ b/database/src/main/kotlin/database/poker/PokerTableRegistry.kt
@@ -189,6 +189,23 @@ class PokerTableRegistry(
     }
 
     /**
+     * Force-evict every table belonging to [guildId]. Called when the
+     * bot leaves the guild so seated chips are refunded via the same
+     * [onIdleEvict] path the idle sweeper uses, rather than dangling in
+     * memory until the next sweep.
+     */
+    fun evictGuild(guildId: Long) {
+        for ((id, table) in tables) {
+            if (table.guildId != guildId) continue
+            synchronized(table) {
+                val evicted = tables.remove(id)
+                cancelShotClock(id)
+                if (evicted != null) runCatching { onIdleEvict?.invoke(evicted) }
+            }
+        }
+    }
+
+    /**
      * Force-evict every table whose `lastActivityAt` is older than
      * [idleTtl]. Public + parameterised so tests can drive it without
      * waiting for the scheduler.

--- a/database/src/main/kotlin/database/service/CasinoBotSuspicionService.kt
+++ b/database/src/main/kotlin/database/service/CasinoBotSuspicionService.kt
@@ -166,6 +166,15 @@ class CasinoBotSuspicionService(
         return if (nowOpen) matches else 0
     }
 
+    /**
+     * Drop every tracked window for [guildId]. Called when the bot
+     * leaves the guild — the window state is meaningless once the
+     * casino pages can no longer post bets for that guild.
+     */
+    fun evictGuild(guildId: Long) {
+        states.keys.removeIf { it.second == guildId }
+    }
+
     companion object {
         const val EPSILON_PX: Int = 2
 

--- a/discord-bot/src/main/kotlin/bot/configuration/BotConfig.kt
+++ b/discord-bot/src/main/kotlin/bot/configuration/BotConfig.kt
@@ -7,6 +7,7 @@ import moe.kyokobot.libdave.NativeDaveFactory
 import moe.kyokobot.libdave.jda.LDJDADaveSessionFactory
 import net.dv8tion.jda.api.JDA
 import net.dv8tion.jda.api.JDABuilder
+import net.dv8tion.jda.api.OnlineStatus
 import net.dv8tion.jda.api.audio.AudioModuleConfig
 import net.dv8tion.jda.api.requests.GatewayIntent
 import net.dv8tion.jda.api.utils.ChunkingFilter
@@ -42,8 +43,12 @@ class BotConfig {
             GatewayIntent.GUILD_VOICE_STATES,
             GatewayIntent.GUILD_EXPRESSIONS
         )
-            .setMemberCachePolicy(MemberCachePolicy.ALL)
-            .setChunkingFilter(ChunkingFilter.ALL)
+            .setMemberCachePolicy(
+                MemberCachePolicy { it.onlineStatus != OnlineStatus.OFFLINE }
+                    .or(MemberCachePolicy.VOICE)
+                    .or(MemberCachePolicy.OWNER)
+            )
+            .setChunkingFilter(ChunkingFilter.NONE)
             .disableCache(
                 EnumSet.of(
                     CacheFlag.CLIENT_STATUS,

--- a/discord-bot/src/main/kotlin/bot/configuration/JdaListenerRegistrar.kt
+++ b/discord-bot/src/main/kotlin/bot/configuration/JdaListenerRegistrar.kt
@@ -4,6 +4,7 @@ import bot.toby.handler.ActivityEventHandler
 import bot.toby.handler.AutocompleteEventListener
 import bot.toby.handler.ButtonEventListener
 import bot.toby.handler.EventWaiter
+import bot.toby.handler.GuildLeaveCleanupHandler
 import bot.toby.handler.MenuEventListener
 import bot.toby.handler.MessageChatListener
 import bot.toby.handler.ModalEventListener
@@ -27,6 +28,7 @@ class JdaListenerRegistrar @Autowired constructor(
     autocompleteEventListener: AutocompleteEventListener,
     activityEventHandler: ActivityEventHandler,
     eventWaiter: EventWaiter,
+    guildLeaveCleanupHandler: GuildLeaveCleanupHandler,
 ) {
     init {
         jda.addEventListener(
@@ -40,6 +42,7 @@ class JdaListenerRegistrar @Autowired constructor(
             autocompleteEventListener,
             activityEventHandler,
             eventWaiter,
+            guildLeaveCleanupHandler,
         )
     }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/handler/GuildLeaveCleanupHandler.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/handler/GuildLeaveCleanupHandler.kt
@@ -1,0 +1,52 @@
+package bot.toby.handler
+
+import bot.toby.managers.DefaultCommandManager
+import bot.toby.notify.AntiAutoclickNotifier
+import bot.toby.voice.VoiceCompanyTracker
+import common.logging.DiscordLogger
+import database.blackjack.BlackjackTableRegistry
+import database.poker.CasinoHoldemTableRegistry
+import database.poker.PokerTableRegistry
+import database.service.CasinoBotSuspicionService
+import net.dv8tion.jda.api.events.guild.GuildLeaveEvent
+import net.dv8tion.jda.api.hooks.ListenerAdapter
+import org.springframework.stereotype.Service
+import web.service.MusicSseService
+
+/**
+ * Central per-guild cache eviction on guild leave. Each registry/cache
+ * that keys state by guildId exposes an `evictGuild` method; this
+ * listener fans the leave event out to all of them so memory doesn't
+ * drift upward over the bot's lifetime as guilds come and go.
+ *
+ * [VoiceEventHandler.onGuildLeave] already clears the music-side caches
+ * (PlayerManager, NowPlayingManager, last-connected channel) so those
+ * are intentionally not duplicated here.
+ */
+@Service
+class GuildLeaveCleanupHandler(
+    private val commandManager: DefaultCommandManager,
+    private val pokerTableRegistry: PokerTableRegistry,
+    private val blackjackTableRegistry: BlackjackTableRegistry,
+    private val casinoHoldemTableRegistry: CasinoHoldemTableRegistry,
+    private val musicSseService: MusicSseService,
+    private val antiAutoclickNotifier: AntiAutoclickNotifier,
+    private val casinoBotSuspicionService: CasinoBotSuspicionService,
+    private val voiceCompanyTracker: VoiceCompanyTracker,
+) : ListenerAdapter() {
+
+    private val logger: DiscordLogger = DiscordLogger.createLogger(this::class.java)
+
+    override fun onGuildLeave(event: GuildLeaveEvent) {
+        val guildId = event.guild.idLong
+        logger.info { "Guild $guildId left — evicting per-guild caches" }
+        runCatching { commandManager.evictGuild(guildId) }
+        runCatching { pokerTableRegistry.evictGuild(guildId) }
+        runCatching { blackjackTableRegistry.evictGuild(guildId) }
+        runCatching { casinoHoldemTableRegistry.evictGuild(guildId) }
+        runCatching { musicSseService.evictGuild(guildId) }
+        runCatching { antiAutoclickNotifier.evictGuild(guildId) }
+        runCatching { casinoBotSuspicionService.evictGuild(guildId) }
+        runCatching { voiceCompanyTracker.evictGuild(guildId) }
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/handler/GuildLeaveCleanupHandler.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/handler/GuildLeaveCleanupHandler.kt
@@ -1,9 +1,9 @@
 package bot.toby.handler
 
-import bot.toby.managers.DefaultCommandManager
 import bot.toby.notify.AntiAutoclickNotifier
 import bot.toby.voice.VoiceCompanyTracker
 import common.logging.DiscordLogger
+import core.managers.CommandManager
 import database.blackjack.BlackjackTableRegistry
 import database.poker.CasinoHoldemTableRegistry
 import database.poker.PokerTableRegistry
@@ -25,7 +25,7 @@ import web.service.MusicSseService
  */
 @Service
 class GuildLeaveCleanupHandler(
-    private val commandManager: DefaultCommandManager,
+    private val commandManager: CommandManager,
     private val pokerTableRegistry: PokerTableRegistry,
     private val blackjackTableRegistry: BlackjackTableRegistry,
     private val casinoHoldemTableRegistry: CasinoHoldemTableRegistry,

--- a/discord-bot/src/main/kotlin/bot/toby/managers/DefaultCommandManager.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/managers/DefaultCommandManager.kt
@@ -73,7 +73,7 @@ class DefaultCommandManager @Autowired constructor(
      * the associated [CommandContext]) don't pin a stale guild after
      * the bot is gone.
      */
-    fun evictGuild(guildId: Long) {
+    override fun evictGuild(guildId: Long) {
         lastCommands.keys.removeIf { it.idLong == guildId }
     }
 

--- a/discord-bot/src/main/kotlin/bot/toby/managers/DefaultCommandManager.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/managers/DefaultCommandManager.kt
@@ -67,6 +67,16 @@ class DefaultCommandManager @Autowired constructor(
     override val fetchCommands: List<Command> get() = commands.filterIsInstance<FetchCommand>()
     override val economyCommands: List<Command> get() = commands.filterIsInstance<EconomyCommand>()
 
+    /**
+     * Drop the cached last-command entry for [guildId]. Called from
+     * the guild-leave cleanup path so the JDA [Guild] reference (and
+     * the associated [CommandContext]) don't pin a stale guild after
+     * the bot is gone.
+     */
+    fun evictGuild(guildId: Long) {
+        lastCommands.keys.removeIf { it.idLong == guildId }
+    }
+
     override fun handle(event: SlashCommandInteractionEvent) {
         val guildId = event.guild?.id ?: return
         val deleteDelay = configService.getConfigByName(

--- a/discord-bot/src/main/kotlin/bot/toby/notify/AntiAutoclickNotifier.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/notify/AntiAutoclickNotifier.kt
@@ -196,6 +196,22 @@ class AntiAutoclickNotifier(
         guild.selfMember.hasPermission(channel, Permission.MESSAGE_SEND, Permission.MESSAGE_EMBED_LINKS)
 
     /**
+     * Drop every in-flight session for [guildId] and cancel any pending
+     * debounced edit. Called when the bot leaves the guild — there's no
+     * channel to edit against anymore so the message handle and counters
+     * are dead weight.
+     */
+    fun evictGuild(guildId: Long) {
+        val iter = sessions.entries.iterator()
+        while (iter.hasNext()) {
+            val (key, session) = iter.next()
+            if (key.second != guildId) continue
+            iter.remove()
+            session.pendingEdit.getAndSet(null)?.cancel(false)
+        }
+    }
+
+    /**
      * Test-only: force the currently-pending debounced edit to run immediately
      * (and clears the pending future). Returns `true` if there was a pending
      * edit to flush. Production code should never call this; the scheduler

--- a/discord-bot/src/main/kotlin/bot/toby/voice/VoiceCompanyTracker.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/voice/VoiceCompanyTracker.kt
@@ -49,6 +49,14 @@ class VoiceCompanyTracker {
         }
     }
 
+    /**
+     * Drop every tracker for [guildId]. Called when the bot leaves the
+     * guild so per-user session state can't outlive the guild itself.
+     */
+    fun evictGuild(guildId: Long) {
+        trackers.keys.removeIf { it.second == guildId }
+    }
+
     private fun hasCompany(channel: AudioChannel, exceptUserId: Long): Boolean {
         return channel.members.any { other ->
             !other.user.isBot && other.idLong != exceptUserId

--- a/discord-bot/src/test/kotlin/bot/configuration/JdaListenerRegistrarTest.kt
+++ b/discord-bot/src/test/kotlin/bot/configuration/JdaListenerRegistrarTest.kt
@@ -4,6 +4,7 @@ import bot.toby.handler.ActivityEventHandler
 import bot.toby.handler.AutocompleteEventListener
 import bot.toby.handler.ButtonEventListener
 import bot.toby.handler.EventWaiter
+import bot.toby.handler.GuildLeaveCleanupHandler
 import bot.toby.handler.MenuEventListener
 import bot.toby.handler.MessageChatListener
 import bot.toby.handler.ModalEventListener
@@ -30,6 +31,7 @@ class JdaListenerRegistrarTest {
         val autocompleteEventListener = mockk<AutocompleteEventListener>()
         val activityEventHandler = mockk<ActivityEventHandler>()
         val eventWaiter = mockk<EventWaiter>()
+        val guildLeaveCleanupHandler = mockk<GuildLeaveCleanupHandler>()
 
         JdaListenerRegistrar(
             jda,
@@ -43,6 +45,7 @@ class JdaListenerRegistrarTest {
             autocompleteEventListener,
             activityEventHandler,
             eventWaiter,
+            guildLeaveCleanupHandler,
         )
 
         verify {
@@ -57,6 +60,7 @@ class JdaListenerRegistrarTest {
                 autocompleteEventListener,
                 activityEventHandler,
                 eventWaiter,
+                guildLeaveCleanupHandler,
             )
         }
     }

--- a/web/src/main/kotlin/web/service/MusicSseService.kt
+++ b/web/src/main/kotlin/web/service/MusicSseService.kt
@@ -100,6 +100,19 @@ class MusicSseService(
         }
     }
 
+    /**
+     * Drop every emitter for [guildId] and remove the bucket. Called when
+     * the bot leaves the guild — keeping stale browser channels around
+     * holds onto buffers and the `gateway.getState` lookups become moot
+     * once the guild is gone.
+     */
+    fun evictGuild(guildId: Long) {
+        val list = emitters.remove(guildId) ?: return
+        for (emitter in list) {
+            runCatching { emitter.complete() }
+        }
+    }
+
     private fun fanOut(guildId: Long, name: String, payload: Any) {
         val list = emitters[guildId] ?: return
         broadcast(list) { send(SseEmitter.event().name(name).data(payload)) }


### PR DESCRIPTION
## Summary

Dyno memory profile was sitting at **~441 MB avg / 557 MB peak** against the 512 MB quota — R14/R15s on most peaks. Two-pronged fix:

- **Cap JVM + native footprint** so the process can't grow past the dyno quota.
- **Stop per-guild caches from drifting upward** as the bot leaves guilds.

### JVM ceiling (Procfile + Dockerfile)
The Procfile previously passed *no memory flags*, so `-Xmx` defaulted to ~25% of container memory and Netty's direct memory mirrored `Runtime.maxMemory()` — easily another ~256 MB of native on top of the heap. Now:

```
-Xms128m -Xmx256m -XX:MaxMetaspaceSize=96m -XX:ReservedCodeCacheSize=64m
-XX:MaxDirectMemorySize=48m -Dio.netty.maxDirectMemory=0
-Dio.netty.allocator.numDirectArenas=2 -Dio.netty.allocator.numHeapArenas=2
-Xss256k -XX:+ExitOnOutOfMemoryError
```

The Netty flags are the single biggest native-memory win — without them Netty ignores `-XX:MaxDirectMemorySize` and uses its own (much larger) cap.

### JDA member cache (`BotConfig.kt`)
Switched from `MemberCachePolicy.ALL` + `ChunkingFilter.ALL` (which eagerly caches **every member of every guild** at startup) to:

```kotlin
.setMemberCachePolicy(
    MemberCachePolicy { it.onlineStatus != OnlineStatus.OFFLINE }
        .or(MemberCachePolicy.VOICE)
        .or(MemberCachePolicy.OWNER)
)
.setChunkingFilter(ChunkingFilter.NONE)
```

- Online-only keeps `UserUpdateActivitiesEvent` working for `ActivityEventHandler` — you can't be playing a game while offline.
- JDA re-evaluates the policy on presence updates, so offline members are evicted automatically.
- Effective cache size now scales with **concurrent online users**, not total guild membership.

### Per-guild eviction (`GuildLeaveCleanupHandler`)
New listener fans `GuildLeaveEvent` out to `evictGuild(guildId)` on:
- `PokerTableRegistry`, `BlackjackTableRegistry`, `CasinoHoldemTableRegistry` (refunds seated chips via the same `onIdleEvict` callback the idle sweeper uses)
- `MusicSseService` (completes lingering SSE emitters)
- `AntiAutoclickNotifier` (cancels pending debounced edits)
- `CasinoBotSuspicionService`, `VoiceCompanyTracker`
- `DefaultCommandManager.lastCommands` (which keys on the JDA `Guild` object, pinning it forever otherwise)

### JPA
`spring.jpa.open-in-view=false` — small but free; stops the per-request Hibernate session from pinning every entity it touches.

## Test plan
- [x] `./gradlew :application:bootJar` succeeds
- [x] `./gradlew :discord-bot:test :database:test :web:test` passes (with UTF-8 locale; the em-dash test names trip Gradle's HTML report writer on ASCII locales — pre-existing)
- [x] `JdaListenerRegistrarTest` updated to register the new handler
- [ ] Deploy and observe the dyno memory profile over 24h — target ≤ 400 MB avg, ≤ 450 MB peak
- [ ] Verify `/profile`-style lookups still work when the target user is offline (they hit `getMemberById` → null; switch to `retrieveMemberById` if any callers regress)

https://claude.ai/code/session_01V7LRBy6QhYfTEGfY6Cz3BD

---
_Generated by [Claude Code](https://claude.ai/code/session_01V7LRBy6QhYfTEGfY6Cz3BD)_