### PR TITLE
feat(web): include site footer on every page

### DIFF
--- a/web/src/main/resources/static/css/footer.css
+++ b/web/src/main/resources/static/css/footer.css
@@ -1,0 +1,65 @@
+/* SITE FOOTER
+   Same gradient hairline trick as the top navbar — a 1px gradient strip
+   reads as a designed divider rather than a default border.
+
+   Lives in its own file (not home.css) because the footer fragment is
+   shared across every public page; styles need to load wherever the
+   fragment does, which is why the head fragment links this directly. */
+.site-footer {
+    position: relative;
+    padding: 36px 24px;
+    text-align: center;
+    color: var(--text-dim);
+    font-size: 0.82rem;
+}
+.site-footer::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 1px;
+    background: var(--gradient-accent);
+    opacity: 0.35;
+    pointer-events: none;
+}
+.site-footer-inner {
+    max-width: 800px;
+    margin: 0 auto;
+    display: grid;
+    gap: 8px;
+}
+.site-footer-line { margin: 0; }
+.site-footer a { color: var(--accent-light); text-decoration: none; }
+.site-footer a:hover { text-decoration: underline; }
+.site-footer-source { font-size: 0.85rem; }
+.site-footer-stack {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    align-items: center;
+    gap: 12px;
+    margin-top: 8px;
+    font-size: 0.78rem;
+    color: var(--text-muted);
+}
+.site-footer-stack-label {
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-dim);
+    font-weight: 600;
+}
+.site-footer-stack-item {
+    color: var(--text-muted);
+    position: relative;
+}
+.site-footer-stack-item + .site-footer-stack-item::before {
+    content: "·";
+    color: var(--text-dim);
+    margin-right: 12px;
+    margin-left: -12px;
+}
+
+@media (max-width: 480px) {
+    .site-footer { padding: 24px 16px; }
+}

--- a/web/src/main/resources/static/css/home.css
+++ b/web/src/main/resources/static/css/home.css
@@ -477,64 +477,6 @@
     justify-content: center;
 }
 
-/* SITE FOOTER
-   Same gradient hairline trick as the top navbar — a 1px gradient strip
-   reads as a designed divider rather than a default border. */
-.site-footer {
-    position: relative;
-    padding: 36px 24px;
-    text-align: center;
-    color: var(--text-dim);
-    font-size: 0.82rem;
-}
-.site-footer::before {
-    content: "";
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    height: 1px;
-    background: var(--gradient-accent);
-    opacity: 0.35;
-    pointer-events: none;
-}
-.site-footer-inner {
-    max-width: 800px;
-    margin: 0 auto;
-    display: grid;
-    gap: 8px;
-}
-.site-footer-line { margin: 0; }
-.site-footer a { color: var(--accent-light); text-decoration: none; }
-.site-footer a:hover { text-decoration: underline; }
-.site-footer-source { font-size: 0.85rem; }
-.site-footer-stack {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
-    align-items: center;
-    gap: 12px;
-    margin-top: 8px;
-    font-size: 0.78rem;
-    color: var(--text-muted);
-}
-.site-footer-stack-label {
-    text-transform: uppercase;
-    letter-spacing: 0.06em;
-    color: var(--text-dim);
-    font-weight: 600;
-}
-.site-footer-stack-item {
-    color: var(--text-muted);
-    position: relative;
-}
-.site-footer-stack-item + .site-footer-stack-item::before {
-    content: "·";
-    color: var(--text-dim);
-    margin-right: 12px;
-    margin-left: -12px;
-}
-
 /* CHANGELOG TIMELINE */
 .changelog-page {
     max-width: 760px;
@@ -712,7 +654,6 @@
     .howto-strip { gap: 16px; }
     .howto-step { padding: 20px 18px; }
     .final-cta { padding: 48px 16px 64px; }
-    .site-footer { padding: 24px 16px; }
     .login-card { padding: 32px 20px; }
     .login-card h1 { font-size: 1.5rem; }
     .changelog-page { padding: 0 16px 48px; }

--- a/web/src/main/resources/templates/baccarat.html
+++ b/web/src/main/resources/templates/baccarat.html
@@ -99,5 +99,6 @@
 
 <th:block th:replace="~{fragments/casinoMinigame :: scripts}"></th:block>
 <script th:src="@{/js/baccarat.js}"></script>
+<footer th:replace="~{fragments/footer :: footer}"></footer>
 </body>
 </html>

--- a/web/src/main/resources/templates/blackjack-lobby.html
+++ b/web/src/main/resources/templates/blackjack-lobby.html
@@ -77,5 +77,6 @@
 <script th:src="@{/js/casino-jackpot.js}"></script>
 <script th:src="@{/js/casino-balance.js}"></script>
 <script th:src="@{/js/blackjack-lobby.js}"></script>
+<footer th:replace="~{fragments/footer :: footer}"></footer>
 </body>
 </html>

--- a/web/src/main/resources/templates/blackjack-solo.html
+++ b/web/src/main/resources/templates/blackjack-solo.html
@@ -86,5 +86,6 @@
 <script th:src="@{/js/casino-render.js}"></script>
 <script th:src="@{/js/casino-win-settle.js}"></script>
 <script th:src="@{/js/blackjack-solo.js}"></script>
+<footer th:replace="~{fragments/footer :: footer}"></footer>
 </body>
 </html>

--- a/web/src/main/resources/templates/blackjack-table.html
+++ b/web/src/main/resources/templates/blackjack-table.html
@@ -82,5 +82,6 @@
 <script th:src="@{/js/casino-render.js}"></script>
 <script th:src="@{/js/casino-win-settle.js}"></script>
 <script th:src="@{/js/blackjack-table.js}"></script>
+<footer th:replace="~{fragments/footer :: footer}"></footer>
 </body>
 </html>

--- a/web/src/main/resources/templates/casino-guilds.html
+++ b/web/src/main/resources/templates/casino-guilds.html
@@ -81,5 +81,6 @@
         </p>
     </div>
 </main>
+<footer th:replace="~{fragments/footer :: footer}"></footer>
 </body>
 </html>

--- a/web/src/main/resources/templates/casinoholdem-solo.html
+++ b/web/src/main/resources/templates/casinoholdem-solo.html
@@ -97,5 +97,6 @@
 
 <th:block th:replace="~{fragments/casinoMinigame :: scripts}"></th:block>
 <script th:src="@{/js/casinoholdem-solo.js}"></script>
+<footer th:replace="~{fragments/footer :: footer}"></footer>
 </body>
 </html>

--- a/web/src/main/resources/templates/coinflip.html
+++ b/web/src/main/resources/templates/coinflip.html
@@ -71,5 +71,6 @@
 
 <th:block th:replace="~{fragments/casinoMinigame :: scripts}"></th:block>
 <script th:src="@{/js/coinflip.js}"></script>
+<footer th:replace="~{fragments/footer :: footer}"></footer>
 </body>
 </html>

--- a/web/src/main/resources/templates/dice.html
+++ b/web/src/main/resources/templates/dice.html
@@ -68,5 +68,6 @@
 
 <th:block th:replace="~{fragments/casinoMinigame :: scripts}"></th:block>
 <script th:src="@{/js/dice.js}"></script>
+<footer th:replace="~{fragments/footer :: footer}"></footer>
 </body>
 </html>

--- a/web/src/main/resources/templates/dndLookup.html
+++ b/web/src/main/resources/templates/dndLookup.html
@@ -56,5 +56,6 @@
 </main>
 
 <script th:src="@{/js/dndLookup.js}"></script>
+<footer th:replace="~{fragments/footer :: footer}"></footer>
 </body>
 </html>

--- a/web/src/main/resources/templates/duel.html
+++ b/web/src/main/resources/templates/duel.html
@@ -122,5 +122,6 @@
 <script th:src="@{/js/toasts.js}"></script>
 <script th:src="@{/js/userPicker.js}"></script>
 <script th:src="@{/js/duel.js}"></script>
+<footer th:replace="~{fragments/footer :: footer}"></footer>
 </body>
 </html>

--- a/web/src/main/resources/templates/economy-guilds.html
+++ b/web/src/main/resources/templates/economy-guilds.html
@@ -47,5 +47,6 @@
         </p>
     </div>
 </main>
+<footer th:replace="~{fragments/footer :: footer}"></footer>
 </body>
 </html>

--- a/web/src/main/resources/templates/economy.html
+++ b/web/src/main/resources/templates/economy.html
@@ -164,5 +164,6 @@
 <script th:src="@{/js/economy-quote.js}"></script>
 <script th:src="@{/js/economy.js}"></script>
 <script th:src="@{/js/economy-watches.js}"></script>
+<footer th:replace="~{fragments/footer :: footer}"></footer>
 </body>
 </html>

--- a/web/src/main/resources/templates/error.html
+++ b/web/src/main/resources/templates/error.html
@@ -21,5 +21,6 @@
 </main>
 
 <script th:src="@{/js/home.js}"></script>
+<footer th:replace="~{fragments/footer :: footer}"></footer>
 </body>
 </html>

--- a/web/src/main/resources/templates/excuse-guilds.html
+++ b/web/src/main/resources/templates/excuse-guilds.html
@@ -72,5 +72,6 @@
     })();
 </script>
 <script th:src="@{/js/home.js}"></script>
+<footer th:replace="~{fragments/footer :: footer}"></footer>
 </body>
 </html>

--- a/web/src/main/resources/templates/excuses.html
+++ b/web/src/main/resources/templates/excuses.html
@@ -167,5 +167,6 @@
 <script th:src="@{/js/userPicker.js}"></script>
 <script th:src="@{/js/excuses.js}"></script>
 <script th:src="@{/js/home.js}"></script>
+<footer th:replace="~{fragments/footer :: footer}"></footer>
 </body>
 </html>

--- a/web/src/main/resources/templates/fragments/footer.html
+++ b/web/src/main/resources/templates/fragments/footer.html
@@ -2,14 +2,10 @@
 <html xmlns:th="http://www.thymeleaf.org">
 <body>
 <!--
-    Shared site footer for public marketing pages (home, commands, login,
-    terms, privacy, changelog). Logged-in app pages don't include this —
-    they're working surfaces and the navbar already covers the legal
-    links via OAuth flows.
-
-    Three rows: copyright + legal, source link, tech stack. The
-    tech-stack row doubles as a craft signal for recruiters; the GitHub
-    link points at the same repo referenced from the legal pages.
+    Shared site footer, included from every page. Three rows:
+    copyright + legal, source link, tech stack. The tech-stack row
+    doubles as a craft signal for recruiters; the GitHub link points
+    at the same repo referenced from the legal pages.
 -->
 <footer th:fragment="footer" class="site-footer">
     <div class="site-footer-inner">

--- a/web/src/main/resources/templates/fragments/guildListPage.html
+++ b/web/src/main/resources/templates/fragments/guildListPage.html
@@ -57,6 +57,7 @@
         <p class="mb-5" th:text="${emptyBody}">You need to share a server with TobyBot.</p>
     </div>
 </main>
+<footer th:replace="~{fragments/footer :: footer}"></footer>
 </body>
 </html>
 
@@ -100,5 +101,6 @@
         <p class="mb-5" th:text="${emptyBody}">You need to share a server with TobyBot.</p>
     </div>
 </main>
+<footer th:replace="~{fragments/footer :: footer}"></footer>
 </body>
 </html>

--- a/web/src/main/resources/templates/fragments/head.html
+++ b/web/src/main/resources/templates/fragments/head.html
@@ -21,6 +21,7 @@
     <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
     <link rel="stylesheet" th:href="@{/css/base.css}">
     <link rel="stylesheet" th:href="@{/css/nav.css}">
+    <link rel="stylesheet" th:href="@{/css/footer.css}">
     <link rel="stylesheet" th:if="${extraCss != null}" th:href="@{${extraCss}}">
     <!-- Shared motion primitives (count-up + reveal-on-scroll). `defer`
          so it runs after parse but blocks no rendering; reduced-motion is
@@ -48,6 +49,7 @@
     <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
     <link rel="stylesheet" th:href="@{/css/base.css}">
     <link rel="stylesheet" th:href="@{/css/nav.css}">
+    <link rel="stylesheet" th:href="@{/css/footer.css}">
     <link rel="stylesheet" th:if="${extraCss != null}" th:href="@{${extraCss}}">
     <!-- Shared motion primitives (count-up + reveal-on-scroll). `defer`
          so it runs after parse but blocks no rendering; reduced-motion is

--- a/web/src/main/resources/templates/guilds.html
+++ b/web/src/main/resources/templates/guilds.html
@@ -155,5 +155,6 @@
     })();
 </script>
 <script th:src="@{/js/home.js}"></script>
+<footer th:replace="~{fragments/footer :: footer}"></footer>
 </body>
 </html>

--- a/web/src/main/resources/templates/highlow.html
+++ b/web/src/main/resources/templates/highlow.html
@@ -87,5 +87,6 @@
 
 <th:block th:replace="~{fragments/casinoMinigame :: scripts}"></th:block>
 <script th:src="@{/js/highlow.js}"></script>
+<footer th:replace="~{fragments/footer :: footer}"></footer>
 </body>
 </html>

--- a/web/src/main/resources/templates/horse-racing.html
+++ b/web/src/main/resources/templates/horse-racing.html
@@ -132,5 +132,6 @@
 
 <th:block th:replace="~{fragments/casinoMinigame :: scripts}"></th:block>
 <script th:src="@{/js/horse-racing.js}"></script>
+<footer th:replace="~{fragments/footer :: footer}"></footer>
 </body>
 </html>

--- a/web/src/main/resources/templates/intros.html
+++ b/web/src/main/resources/templates/intros.html
@@ -337,5 +337,6 @@
 <script th:src="@{/js/modal.js}"></script>
 <script th:src="@{/js/intros.js}"></script>
 <script th:src="@{/js/home.js}"></script>
+<footer th:replace="~{fragments/footer :: footer}"></footer>
 </body>
 </html>

--- a/web/src/main/resources/templates/keno.html
+++ b/web/src/main/resources/templates/keno.html
@@ -129,5 +129,6 @@
 
 <th:block th:replace="~{fragments/casinoMinigame :: scripts}"></th:block>
 <script th:src="@{/js/keno.js}"></script>
+<footer th:replace="~{fragments/footer :: footer}"></footer>
 </body>
 </html>

--- a/web/src/main/resources/templates/leaderboard.html
+++ b/web/src/main/resources/templates/leaderboard.html
@@ -423,5 +423,6 @@
 </main>
 
 <script th:src="@{/js/leaderboard.js}"></script>
+<footer th:replace="~{fragments/footer :: footer}"></footer>
 </body>
 </html>

--- a/web/src/main/resources/templates/leaderboards.html
+++ b/web/src/main/resources/templates/leaderboards.html
@@ -47,5 +47,6 @@
         </p>
     </div>
 </main>
+<footer th:replace="~{fragments/footer :: footer}"></footer>
 </body>
 </html>

--- a/web/src/main/resources/templates/lottery.html
+++ b/web/src/main/resources/templates/lottery.html
@@ -505,5 +505,6 @@
 
 <th:block th:replace="~{fragments/casinoMinigame :: scripts}"></th:block>
 <script th:src="@{/js/lottery.js}"></script>
+<footer th:replace="~{fragments/footer :: footer}"></footer>
 </body>
 </html>

--- a/web/src/main/resources/templates/moderation-guilds.html
+++ b/web/src/main/resources/templates/moderation-guilds.html
@@ -97,5 +97,6 @@
 </main>
 
 <script th:src="@{/js/home.js}"></script>
+<footer th:replace="~{fragments/footer :: footer}"></footer>
 </body>
 </html>

--- a/web/src/main/resources/templates/moderation/actions.html
+++ b/web/src/main/resources/templates/moderation/actions.html
@@ -217,5 +217,6 @@
 <script th:src="@{/js/userPicker.js}"></script>
 <script th:src="@{/js/moderationCommon.js}"></script>
 <script th:src="@{/js/moderation/actions.js}"></script>
+<footer th:replace="~{fragments/footer :: footer}"></footer>
 </body>
 </html>

--- a/web/src/main/resources/templates/moderation/casino.html
+++ b/web/src/main/resources/templates/moderation/casino.html
@@ -73,5 +73,6 @@
 <script th:src="@{/js/userPicker.js}"></script>
 <script th:src="@{/js/moderationCommon.js}"></script>
 <script th:src="@{/js/moderation/casino.js}"></script>
+<footer th:replace="~{fragments/footer :: footer}"></footer>
 </body>
 </html>

--- a/web/src/main/resources/templates/moderation/leveling.html
+++ b/web/src/main/resources/templates/moderation/leveling.html
@@ -366,5 +366,6 @@
 <script th:src="@{/js/toasts.js}"></script>
 <script th:src="@{/js/moderationCommon.js}"></script>
 <script th:src="@{/js/moderation/leveling.js}"></script>
+<footer th:replace="~{fragments/footer :: footer}"></footer>
 </body>
 </html>

--- a/web/src/main/resources/templates/moderation/lottery.html
+++ b/web/src/main/resources/templates/moderation/lottery.html
@@ -484,5 +484,6 @@
 <script th:src="@{/js/toasts.js}"></script>
 <script th:src="@{/js/moderationCommon.js}"></script>
 <script th:src="@{/js/moderation/lottery.js}"></script>
+<footer th:replace="~{fragments/footer :: footer}"></footer>
 </body>
 </html>

--- a/web/src/main/resources/templates/moderation/poll.html
+++ b/web/src/main/resources/templates/moderation/poll.html
@@ -45,5 +45,6 @@
 <script th:src="@{/js/toasts.js}"></script>
 <script th:src="@{/js/moderationCommon.js}"></script>
 <script th:src="@{/js/moderation/poll.js}"></script>
+<footer th:replace="~{fragments/footer :: footer}"></footer>
 </body>
 </html>

--- a/web/src/main/resources/templates/moderation/settings.html
+++ b/web/src/main/resources/templates/moderation/settings.html
@@ -911,5 +911,6 @@
 <script th:src="@{/js/moderationCommon.js}"></script>
 <script th:src="@{/js/moderation/settings.js}"></script>
 <script th:src="@{/js/moderation/jackpot-wheel.js}"></script>
+<footer th:replace="~{fragments/footer :: footer}"></footer>
 </body>
 </html>

--- a/web/src/main/resources/templates/moderation/users.html
+++ b/web/src/main/resources/templates/moderation/users.html
@@ -113,5 +113,6 @@
 <script th:src="@{/js/toasts.js}"></script>
 <script th:src="@{/js/moderationCommon.js}"></script>
 <script th:src="@{/js/moderation/users.js}"></script>
+<footer th:replace="~{fragments/footer :: footer}"></footer>
 </body>
 </html>

--- a/web/src/main/resources/templates/moderation/voice.html
+++ b/web/src/main/resources/templates/moderation/voice.html
@@ -50,5 +50,6 @@
 <script th:src="@{/js/userPicker.js}"></script>
 <script th:src="@{/js/moderationCommon.js}"></script>
 <script th:src="@{/js/moderation/voice.js}"></script>
+<footer th:replace="~{fragments/footer :: footer}"></footer>
 </body>
 </html>

--- a/web/src/main/resources/templates/music-guilds.html
+++ b/web/src/main/resources/templates/music-guilds.html
@@ -46,5 +46,6 @@
         <p class="mb-5">You need to share a server with TobyBot to control its music.</p>
     </div>
 </main>
+<footer th:replace="~{fragments/footer :: footer}"></footer>
 </body>
 </html>

--- a/web/src/main/resources/templates/music-player.html
+++ b/web/src/main/resources/templates/music-player.html
@@ -112,5 +112,6 @@
 <script src="/js/api.js" defer></script>
 <script src="/js/music-queue.js" defer></script>
 <script src="/js/music-player.js" defer></script>
+<footer th:replace="~{fragments/footer :: footer}"></footer>
 </body>
 </html>

--- a/web/src/main/resources/templates/plinko.html
+++ b/web/src/main/resources/templates/plinko.html
@@ -148,5 +148,6 @@
 
 <th:block th:replace="~{fragments/casinoMinigame :: scripts}"></th:block>
 <script th:src="@{/js/plinko.js}"></script>
+<footer th:replace="~{fragments/footer :: footer}"></footer>
 </body>
 </html>

--- a/web/src/main/resources/templates/poker-lobby.html
+++ b/web/src/main/resources/templates/poker-lobby.html
@@ -81,5 +81,6 @@
 <script th:src="@{/js/casino-jackpot.js}"></script>
 <script th:src="@{/js/casino-balance.js}"></script>
 <script th:src="@{/js/poker-lobby.js}"></script>
+<footer th:replace="~{fragments/footer :: footer}"></footer>
 </body>
 </html>

--- a/web/src/main/resources/templates/poker-table.html
+++ b/web/src/main/resources/templates/poker-table.html
@@ -88,5 +88,6 @@
 <script th:src="@{/js/casino-render.js}"></script>
 <script th:src="@{/js/poker-pots.js}"></script>
 <script th:src="@{/js/poker-table.js}"></script>
+<footer th:replace="~{fragments/footer :: footer}"></footer>
 </body>
 </html>

--- a/web/src/main/resources/templates/preferences-notifications-picker.html
+++ b/web/src/main/resources/templates/preferences-notifications-picker.html
@@ -29,5 +29,6 @@
         <p>You need to share at least one server with TobyBot.</p>
     </div>
 </main>
+<footer th:replace="~{fragments/footer :: footer}"></footer>
 </body>
 </html>

--- a/web/src/main/resources/templates/preferences-notifications.html
+++ b/web/src/main/resources/templates/preferences-notifications.html
@@ -82,5 +82,6 @@
 <script th:src="@{/js/api.js}"></script>
 <script th:src="@{/js/preferences-notifications.js}"></script>
 <script th:src="@{/js/push-subscribe.js}"></script>
+<footer th:replace="~{fragments/footer :: footer}"></footer>
 </body>
 </html>

--- a/web/src/main/resources/templates/preferences.html
+++ b/web/src/main/resources/templates/preferences.html
@@ -53,5 +53,6 @@
         </p>
     </div>
 </main>
+<footer th:replace="~{fragments/footer :: footer}"></footer>
 </body>
 </html>

--- a/web/src/main/resources/templates/profile-guilds.html
+++ b/web/src/main/resources/templates/profile-guilds.html
@@ -35,5 +35,6 @@
         </p>
     </div>
 </main>
+<footer th:replace="~{fragments/footer :: footer}"></footer>
 </body>
 </html>

--- a/web/src/main/resources/templates/profile.html
+++ b/web/src/main/resources/templates/profile.html
@@ -199,5 +199,6 @@
 </main>
 <script th:src="@{/js/api.js}"></script>
 <script th:src="@{/js/profile.js}"></script>
+<footer th:replace="~{fragments/footer :: footer}"></footer>
 </body>
 </html>

--- a/web/src/main/resources/templates/roulette.html
+++ b/web/src/main/resources/templates/roulette.html
@@ -108,5 +108,6 @@
 
 <th:block th:replace="~{fragments/casinoMinigame :: scripts}"></th:block>
 <script th:src="@{/js/roulette.js}"></script>
+<footer th:replace="~{fragments/footer :: footer}"></footer>
 </body>
 </html>

--- a/web/src/main/resources/templates/scratch.html
+++ b/web/src/main/resources/templates/scratch.html
@@ -87,5 +87,6 @@
 
 <th:block th:replace="~{fragments/casinoMinigame :: scripts}"></th:block>
 <script th:src="@{/js/scratch.js}"></script>
+<footer th:replace="~{fragments/footer :: footer}"></footer>
 </body>
 </html>

--- a/web/src/main/resources/templates/slots.html
+++ b/web/src/main/resources/templates/slots.html
@@ -71,5 +71,6 @@
 
 <th:block th:replace="~{fragments/casinoMinigame :: scripts}"></th:block>
 <script th:src="@{/js/slots.js}"></script>
+<footer th:replace="~{fragments/footer :: footer}"></footer>
 </body>
 </html>

--- a/web/src/main/resources/templates/team-guilds.html
+++ b/web/src/main/resources/templates/team-guilds.html
@@ -68,5 +68,6 @@
     })();
 </script>
 <script th:src="@{/js/home.js}"></script>
+<footer th:replace="~{fragments/footer :: footer}"></footer>
 </body>
 </html>

--- a/web/src/main/resources/templates/teams.html
+++ b/web/src/main/resources/templates/teams.html
@@ -146,5 +146,6 @@
         });
     });
 </script>
+<footer th:replace="~{fragments/footer :: footer}"></footer>
 </body>
 </html>

--- a/web/src/main/resources/templates/tip.html
+++ b/web/src/main/resources/templates/tip.html
@@ -66,5 +66,6 @@
 <script th:src="@{/js/userPicker.js}"></script>
 <script th:src="@{/js/casino-balance.js}"></script>
 <script th:src="@{/js/tip.js}"></script>
+<footer th:replace="~{fragments/footer :: footer}"></footer>
 </body>
 </html>

--- a/web/src/main/resources/templates/titles-guilds.html
+++ b/web/src/main/resources/templates/titles-guilds.html
@@ -43,5 +43,6 @@
         </p>
     </div>
 </main>
+<footer th:replace="~{fragments/footer :: footer}"></footer>
 </body>
 </html>

--- a/web/src/main/resources/templates/titles.html
+++ b/web/src/main/resources/templates/titles.html
@@ -99,5 +99,6 @@
 <script th:src="@{/js/api.js}"></script>
 <script th:src="@{/js/toasts.js}"></script>
 <script th:src="@{/js/titles.js}"></script>
+<footer th:replace="~{fragments/footer :: footer}"></footer>
 </body>
 </html>

--- a/web/src/main/resources/templates/utils.html
+++ b/web/src/main/resources/templates/utils.html
@@ -79,5 +79,6 @@
 <script th:src="@{/js/api.js}"></script>
 <script th:src="@{/js/toasts.js}"></script>
 <script th:src="@{/js/utils.js}"></script>
+<footer th:replace="~{fragments/footer :: footer}"></footer>
 </body>
 </html>

--- a/web/src/main/resources/templates/wheel.html
+++ b/web/src/main/resources/templates/wheel.html
@@ -156,5 +156,6 @@
 
 <th:block th:replace="~{fragments/casinoMinigame :: scripts}"></th:block>
 <script th:src="@{/js/wheel.js}"></script>
+<footer th:replace="~{fragments/footer :: footer}"></footer>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- Adds the site footer fragment to every page template that was missing it: game tables (blackjack, roulette, slots, plinko, …), guild pickers, dashboards, settings, moderation surfaces, public utilities (`utils`, `dndLookup`), the error page, and the previously-orphaned `profile.html` / `excuses.html`.
- Also adds the footer to both fragments inside `fragments/guildListPage.html` (`singleAction` and `dualAction`) so the four pages that delegate their entire body through it — `blackjack-guilds`, `duel-guilds`, `lottery-guilds`, `tip-guilds`, `poker-guilds` — pick it up automatically.
- Drops the now-stale "logged-in pages don't include this" note from the footer fragment's own comment block.

54 templates touched; insertion is a single `<footer th:replace="~{fragments/footer :: footer}"></footer>` line before `</body>` in each.

## Test plan

- [ ] `./gradlew :web:bootRun`
- [ ] Spot-check one of each category to confirm the footer renders correctly:
  - Game table: `/blackjack/{guildId}/solo`
  - Guild picker (own body): `/leaderboards`
  - Guild picker (via fragment): `/blackjack/guilds`
  - Settings: `/preferences`
  - Moderation: `/moderation/{guildId}/settings`
  - Public utility: `/utils`, `/dnd-lookup`
  - Error page: visit `/does-not-exist`
- [ ] Confirm previously-correct pages (`/`, `/commands`, `/terms`, `/privacy`, `/changelog`, `/login`) still look unchanged.

https://claude.ai/code/session_013xtRrLEm77xGRwUMTwMm1i

---
_Generated by [Claude Code](https://claude.ai/code/session_013xtRrLEm77xGRwUMTwMm1i)_