### PR TITLE
fix(memory): bump metaspace cap to stop startup OOM crash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,4 @@ FROM eclipse-temurin:21-jre
 RUN mkdir /app
 COPY --from=build /home/gradle/src/application/build/libs/*.jar /app/toby-bot.jar
 EXPOSE 8080
-ENTRYPOINT ["java", "-Xms128m", "-Xmx256m", "-XX:+UseSerialGC", "-XX:MaxMetaspaceSize=96m", "-XX:ReservedCodeCacheSize=64m", "-XX:MaxDirectMemorySize=48m", "-Dio.netty.maxDirectMemory=0", "-Dio.netty.allocator.numDirectArenas=2", "-Dio.netty.allocator.numHeapArenas=2", "-Xss256k", "-XX:+ExitOnOutOfMemoryError", "-jar", "/app/toby-bot.jar"]
+ENTRYPOINT ["java", "-Xms128m", "-Xmx224m", "-XX:+UseSerialGC", "-XX:MaxMetaspaceSize=192m", "-XX:ReservedCodeCacheSize=48m", "-XX:MaxDirectMemorySize=48m", "-Dio.netty.maxDirectMemory=0", "-Dio.netty.allocator.numDirectArenas=2", "-Dio.netty.allocator.numHeapArenas=2", "-Xss256k", "-XX:+ExitOnOutOfMemoryError", "-jar", "/app/toby-bot.jar"]

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: java -Xms128m -Xmx256m -XX:+UseSerialGC -XX:MaxMetaspaceSize=96m -XX:ReservedCodeCacheSize=64m -XX:MaxDirectMemorySize=48m -Dio.netty.maxDirectMemory=0 -Dio.netty.allocator.numDirectArenas=2 -Dio.netty.allocator.numHeapArenas=2 -Xss256k -XX:+ExitOnOutOfMemoryError -Dserver.port=$PORT -jar application/build/libs/application-7.1-SNAPSHOT.jar
+web: java -Xms128m -Xmx224m -XX:+UseSerialGC -XX:MaxMetaspaceSize=192m -XX:ReservedCodeCacheSize=48m -XX:MaxDirectMemorySize=48m -Dio.netty.maxDirectMemory=0 -Dio.netty.allocator.numDirectArenas=2 -Dio.netty.allocator.numHeapArenas=2 -Xss256k -XX:+ExitOnOutOfMemoryError -Dserver.port=$PORT -jar application/build/libs/application-7.1-SNAPSHOT.jar
 release: ./bin/trigger_publish_wiki.sh  # This runs after deployment


### PR DESCRIPTION
## Summary

Production crashed with:

```
2026-05-20 08:58:42 [main] INFO  o.s.o.jpa.LocalContainerEntityManagerFactoryBean - Initialized JPA EntityManagerFactory for persistence unit 'default'
Terminating due to java.lang.OutOfMemoryError: Metaspace
```

The OOM fired ~500ms after JPA finished initialising — i.e. while Spring was still wiring the remaining beans (JDA listeners, controllers, scheduled jobs). My previous `-XX:MaxMetaspaceSize=96m` cut was too aggressive for Spring Boot + Kotlin reflection + JDA + Hibernate's bytecode generation, and `-XX:+ExitOnOutOfMemoryError` killed the process immediately on the first stumble.

### Fix
- `MaxMetaspaceSize`: **96m → 192m** (the actual cause; doubled to give real headroom)
- `Xmx`: **256m → 224m** (reclaim some heap to absorb the metaspace bump)
- `ReservedCodeCacheSize`: **64m → 48m** (further reclaim; JIT cache rarely fills past ~30m)

Total caps now: 224 (heap) + 192 (metaspace) + 48 (code cache) + 48 (direct) + ~10 (stacks) = ~522m. These are caps, not commits — realistic RSS still targets ~450MB, well inside the 512MB quota.

Keeping `-XX:+ExitOnOutOfMemoryError` so any further OOM cleanly restarts the dyno rather than hanging in an R15 loop.

## Test plan
- [ ] Deploy and confirm the bot reaches steady-state (gets past `EntityManagerFactory initialized` and into normal log output)
- [ ] Watch memory profile for 24h — target avg ≤ 400MB, peak ≤ 460MB

https://claude.ai/code/session_01V7LRBy6QhYfTEGfY6Cz3BD

---
_Generated by [Claude Code](https://claude.ai/code/session_01V7LRBy6QhYfTEGfY6Cz3BD)_