### PR TITLE
fix(memory): retighten JVM caps below JVM container defaults

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,4 @@ FROM eclipse-temurin:21-jre
 RUN mkdir /app
 COPY --from=build /home/gradle/src/application/build/libs/*.jar /app/toby-bot.jar
 EXPOSE 8080
-ENTRYPOINT ["java", "-Xms128m", "-Xmx224m", "-XX:+UseSerialGC", "-XX:MaxMetaspaceSize=192m", "-XX:ReservedCodeCacheSize=48m", "-XX:MaxDirectMemorySize=48m", "-Dio.netty.maxDirectMemory=0", "-Dio.netty.allocator.numDirectArenas=2", "-Dio.netty.allocator.numHeapArenas=2", "-Xss256k", "-XX:+ExitOnOutOfMemoryError", "-jar", "/app/toby-bot.jar"]
+ENTRYPOINT ["java", "-Xms96m", "-Xmx144m", "-XX:+UseSerialGC", "-XX:MaxMetaspaceSize=144m", "-XX:ReservedCodeCacheSize=40m", "-XX:MaxDirectMemorySize=40m", "-Dio.netty.maxDirectMemory=0", "-Dio.netty.allocator.numDirectArenas=2", "-Dio.netty.allocator.numHeapArenas=2", "-Xss256k", "-XX:+ExitOnOutOfMemoryError", "-jar", "/app/toby-bot.jar"]

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: java -Xms128m -Xmx224m -XX:+UseSerialGC -XX:MaxMetaspaceSize=192m -XX:ReservedCodeCacheSize=48m -XX:MaxDirectMemorySize=48m -Dio.netty.maxDirectMemory=0 -Dio.netty.allocator.numDirectArenas=2 -Dio.netty.allocator.numHeapArenas=2 -Xss256k -XX:+ExitOnOutOfMemoryError -Dserver.port=$PORT -jar application/build/libs/application-7.1-SNAPSHOT.jar
+web: java -Xms96m -Xmx144m -XX:+UseSerialGC -XX:MaxMetaspaceSize=144m -XX:ReservedCodeCacheSize=40m -XX:MaxDirectMemorySize=40m -Dio.netty.maxDirectMemory=0 -Dio.netty.allocator.numDirectArenas=2 -Dio.netty.allocator.numHeapArenas=2 -Xss256k -XX:+ExitOnOutOfMemoryError -Dserver.port=$PORT -jar application/build/libs/application-7.1-SNAPSHOT.jar
 release: ./bin/trigger_publish_wiki.sh  # This runs after deployment


### PR DESCRIPTION
## Summary

Post-merge memory profile got *slightly worse*: avg 489 → 504 MB, swap now active, dyno sits at 100% quota.

### Root cause

The original Procfile passed **no JVM memory flags at all**. JVM 21 with container support defaults to `MaxRAMPercentage=25%` on a 512 MB cgroup → ~128 MB heap implicitly, and metaspace grew organically to whatever Spring/JDA actually needed (typically 100–140 MB).

PR #525/#527 explicitly set:
- `-Xmx224m` → **+96 MB** of heap permission vs the JVM's implicit default
- `-XX:MaxMetaspaceSize=192m` → **+50 MB** of metaspace permission

Spring/JDA happily expanded into the new headroom. The native-memory caps (Netty, direct, code cache) worked correctly — peaks did flatten from 557 → 513 MB — but the steady-state floor rose because heap and metaspace had more room.

### Fix

- `-Xmx`: **224m → 144m** (just above the JVM container default, where the bot historically ran under quota)
- `-XX:MaxMetaspaceSize`: **192m → 144m** (PR #527 proved 96m OOMs at boot, 144m threads the needle)
- `-XX:ReservedCodeCacheSize`: **48m → 40m**
- `-XX:MaxDirectMemorySize`: **48m → 40m**

Total caps now ~378 MB (vs ~520 MB before). Realistic RSS target: **~400 MB**, leaving 100 MB headroom under the 512 MB quota.

The structural changes from #525 (member-cache narrowing, per-guild eviction, OSIV) all stay — they're correct, just dominated by the over-provisioned JVM ceilings.

## Test plan
- [x] `./gradlew :application:bootJar` builds
- [ ] Boot succeeds on Heroku (metaspace doesn't crash — 144m has 50% more than the 96m that died in #527 and ~10 MB above the JVM's natural ceiling for this app)
- [ ] Steady-state RSS ≤ 420 MB over 2 hours
- [ ] Swap returns to 0 MB
- [ ] Music + activity tracking still work

https://claude.ai/code/session_01V7LRBy6QhYfTEGfY6Cz3BD

---
_Generated by [Claude Code](https://claude.ai/code/session_01V7LRBy6QhYfTEGfY6Cz3BD)_