### PR TITLE
fix(jda): restore MemberCachePolicy.ALL — offline users broke leaderboards and auth

### DIFF
--- a/discord-bot/src/main/kotlin/bot/configuration/BotConfig.kt
+++ b/discord-bot/src/main/kotlin/bot/configuration/BotConfig.kt
@@ -7,7 +7,6 @@ import moe.kyokobot.libdave.NativeDaveFactory
 import moe.kyokobot.libdave.jda.LDJDADaveSessionFactory
 import net.dv8tion.jda.api.JDA
 import net.dv8tion.jda.api.JDABuilder
-import net.dv8tion.jda.api.OnlineStatus
 import net.dv8tion.jda.api.audio.AudioModuleConfig
 import net.dv8tion.jda.api.requests.GatewayIntent
 import net.dv8tion.jda.api.utils.ChunkingFilter
@@ -43,12 +42,8 @@ class BotConfig {
             GatewayIntent.GUILD_VOICE_STATES,
             GatewayIntent.GUILD_EXPRESSIONS
         )
-            .setMemberCachePolicy(
-                MemberCachePolicy { it.onlineStatus != OnlineStatus.OFFLINE }
-                    .or(MemberCachePolicy.VOICE)
-                    .or(MemberCachePolicy.OWNER)
-            )
-            .setChunkingFilter(ChunkingFilter.NONE)
+            .setMemberCachePolicy(MemberCachePolicy.ALL)
+            .setChunkingFilter(ChunkingFilter.ALL)
             .disableCache(
                 EnumSet.of(
                     CacheFlag.CLIENT_STATUS,


### PR DESCRIPTION
## Summary

The narrowed `MemberCachePolicy` introduced in #525 (`online != OFFLINE`, voice, owner) silently breaks any feature that walks the member list for offline users:

- **Leaderboards** render "Unknown" for every offline player (as @user reported with screenshot).
- **`GuildMembership.isMember(id, guildId)`** returns `false` for an offline user who *is* in the guild — locks them out of pages.
- **`isOwner(...)`** returns `false` for an offline owner — they look like a regular user.
- **`ModerationAuthorizer` / `canModerate` / `togglePermission` / `adjustSocialCredit` / move flows** all guard on `guild.getMemberById(...) ?: return "not in that server"` — offline actors or targets trip false negatives across the board.

Cosmetic-only callers (Economy trades, Music "requested by", Team rosters, Excuse bylines, the monthly Discord leaderboard) all degrade to fallback names too.

Rather than wrap every call site in a `retrieveMemberById` fallback (which would be a much bigger diff and add REST overhead to hot paths), this PR restores the pre-#525 cache shape: `MemberCachePolicy.ALL + ChunkingFilter.ALL`. Every offline user is back in the JDA cache, every existing call site works.

## What survives from #525 / #527

- Per-guild eviction handler (`GuildLeaveCleanupHandler`) — still keeps the cache clean when the bot leaves a guild.
- JVM/Netty/direct-memory caps from #525 (further tuned in #527) — these flatten peaks and aren't affected by this revert.
- JPA `open-in-view=false`, the registry `evictGuild` methods — all stay.

Net memory change vs current main: small bump as offline members return to cache, offset by the JVM caps already in place.

## Test plan
- [x] `./gradlew :discord-bot:test` passes
- [ ] Deploy and confirm leaderboard renders real names for offline users (the original screenshot's repro)
- [ ] Confirm moderation actions work on offline targets again
- [ ] Watch the memory profile — expect a small uptick but should stay near current levels thanks to the JVM caps

https://claude.ai/code/session_01V7LRBy6QhYfTEGfY6Cz3BD

---
_Generated by [Claude Code](https://claude.ai/code/session_01V7LRBy6QhYfTEGfY6Cz3BD)_