### PR TITLE
fix(web): polish leaderboard LVL + title pill formatting

### DIFF
--- a/web/src/main/resources/static/css/base.css
+++ b/web/src/main/resources/static/css/base.css
@@ -1161,8 +1161,24 @@ td { font-size: 0.95rem; }
 
     .lb-standings-table.mod-table td[data-label="#"] { grid-area: rank; }
     .lb-standings-table.mod-table td[data-label="Member"] { grid-area: member; min-width: 0; }
+    /* Force the inline-flex memberCell to fill its grid track so the
+       username's text-overflow: ellipsis kicks in at the column boundary
+       instead of physically colliding with the prestige cluster. */
+    .lb-standings-table.mod-table td[data-label="Member"] .member-cell-link,
+    .lb-standings-table.mod-table td[data-label="Member"] .member-cell {
+        display: flex;
+        width: 100%;
+        min-width: 0;
+    }
     .lb-standings-table.mod-table td[data-label="Prestige"] { grid-area: title; justify-self: end; min-width: 0; }
-    .lb-standings-table.mod-table td[data-label="Prestige"] .lb-prestige { justify-content: flex-end; }
+    /* Stack LVL above title on mobile so the prestige column is only as
+       wide as the wider pill, freeing horizontal space for long usernames.
+       Each pill keeps its own line, both right-aligned. */
+    .lb-standings-table.mod-table td[data-label="Prestige"] .lb-prestige {
+        flex-direction: column;
+        align-items: flex-end;
+        gap: 4px;
+    }
 
     /* Each metric cell becomes a tight label/value stack — three
        cells across the bottom row, one grid area each. The
@@ -1222,7 +1238,7 @@ td { font-size: 0.95rem; }
     .lb-rank { width: 24px; height: 24px; font-size: 0.8rem; }
     .lb-title-pill { font-size: 0.75rem; padding: 1px 6px; }
     .lb-level-pill { font-size: 0.7rem; padding: 1px 6px; }
-    .lb-prestige { gap: 6px; row-gap: 3px; }
+    .lb-standings-table.mod-table td[data-label="Prestige"] .lb-prestige { gap: 3px; }
 }
 
 /* ---- Searchable user picker (templates/fragments/userPicker.html

--- a/web/src/main/resources/static/css/base.css
+++ b/web/src/main/resources/static/css/base.css
@@ -1011,8 +1011,24 @@ td { font-size: 0.95rem; }
     border-color: var(--medal-bronze);
 }
 
+/* Wrapper around the LVL + title pills inside a single Prestige cell.
+   inline-flex keeps the cell's layout role unchanged on desktop while
+   giving us a real gap between the two pills; flex-wrap lets the title
+   pill drop to a second line at narrow widths instead of overflowing
+   the row. The same wrapper acts as the single grid target on mobile
+   (see the @media block below). */
+.lb-prestige {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+    row-gap: 4px;
+    min-width: 0;
+}
+
 .lb-title-pill {
     display: inline-block;
+    max-width: 100%;
     padding: 2px 8px;
     border: 1px solid var(--border);
     border-radius: 999px;
@@ -1020,6 +1036,9 @@ td { font-size: 0.95rem; }
     background: var(--bg);
     color: var(--text);
     flex-shrink: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 /* Prestige pill — surfaced alongside .lb-title-pill across the
@@ -1142,7 +1161,8 @@ td { font-size: 0.95rem; }
 
     .lb-standings-table.mod-table td[data-label="#"] { grid-area: rank; }
     .lb-standings-table.mod-table td[data-label="Member"] { grid-area: member; min-width: 0; }
-    .lb-standings-table.mod-table td[data-label="Title"] { grid-area: title; justify-self: end; }
+    .lb-standings-table.mod-table td[data-label="Prestige"] { grid-area: title; justify-self: end; min-width: 0; }
+    .lb-standings-table.mod-table td[data-label="Prestige"] .lb-prestige { justify-content: flex-end; }
 
     /* Each metric cell becomes a tight label/value stack — three
        cells across the bottom row, one grid area each. The
@@ -1201,6 +1221,8 @@ td { font-size: 0.95rem; }
     .avatar { width: 24px; height: 24px; }
     .lb-rank { width: 24px; height: 24px; font-size: 0.8rem; }
     .lb-title-pill { font-size: 0.75rem; padding: 1px 6px; }
+    .lb-level-pill { font-size: 0.7rem; padding: 1px 6px; }
+    .lb-prestige { gap: 6px; row-gap: 3px; }
 }
 
 /* ---- Searchable user picker (templates/fragments/userPicker.html

--- a/web/src/main/resources/templates/leaderboard.html
+++ b/web/src/main/resources/templates/leaderboard.html
@@ -217,10 +217,12 @@
                             <div th:replace="~{fragments/memberCell :: cellLink(${row.name}, ${row.avatarUrl}, @{/profile/{g}/{d}(g=${guildId}, d=${row.discordId})})}"></div>
                         </td>
                         <td data-label="Prestige">
-                            <span class="lb-level-pill"
-                                  th:classappend="${'lb-level-tier-' + (row.level >= 50 ? 'diamond' : (row.level >= 25 ? 'gold' : (row.level >= 10 ? 'silver' : 'bronze')))}"
-                                  th:text="'LVL ' + ${row.level}">LVL 0</span>
-                            <span th:if="${row.title != null}" class="lb-title-pill" th:text="${row.title}"></span>
+                            <div class="lb-prestige">
+                                <span class="lb-level-pill"
+                                      th:classappend="${'lb-level-tier-' + (row.level >= 50 ? 'diamond' : (row.level >= 25 ? 'gold' : (row.level >= 10 ? 'silver' : 'bronze')))}"
+                                      th:text="'LVL ' + ${row.level}">LVL 0</span>
+                                <span th:if="${row.title != null}" class="lb-title-pill" th:text="${row.title}"></span>
+                            </div>
                         </td>
                         <td data-label="Credits" class="lb-col-value">
                             <strong class="lb-value lb-value-credits" th:text="${row.socialCredit}">0</strong>
@@ -281,10 +283,12 @@
                             <div th:replace="~{fragments/memberCell :: cellLink(${row.name}, ${row.avatarUrl}, @{/profile/{g}/{d}(g=${guildId}, d=${row.discordId})})}"></div>
                         </td>
                         <td data-label="Prestige">
-                            <span class="lb-level-pill"
-                                  th:classappend="${'lb-level-tier-' + (row.level >= 50 ? 'diamond' : (row.level >= 25 ? 'gold' : (row.level >= 10 ? 'silver' : 'bronze')))}"
-                                  th:text="'LVL ' + ${row.level}">LVL 0</span>
-                            <span th:if="${row.title != null}" class="lb-title-pill" th:text="${row.title}"></span>
+                            <div class="lb-prestige">
+                                <span class="lb-level-pill"
+                                      th:classappend="${'lb-level-tier-' + (row.level >= 50 ? 'diamond' : (row.level >= 25 ? 'gold' : (row.level >= 10 ? 'silver' : 'bronze')))}"
+                                      th:text="'LVL ' + ${row.level}">LVL 0</span>
+                                <span th:if="${row.title != null}" class="lb-title-pill" th:text="${row.title}"></span>
+                            </div>
                         </td>
                         <td data-label="TOBY" class="lb-col-value">
                             <strong class="lb-value lb-value-toby" th:text="${row.coins}">0</strong>


### PR DESCRIPTION
## Summary

The Prestige cell on the leaderboard had three issues visible in the attached screenshot:

1. **No gap between pills.** The `LVL 7` pill and `💎 Diamond Hands` pill rendered as adjacent `inline-block` siblings with no spacing, so they touched each other.
2. **Mobile grid mismatch.** The phone-width grid in `base.css` targeted `td[data-label="Title"]`, but the template emits `data-label="Prestige"` — so on mobile the cell auto-placed into the member column and collided with the truncated username.
3. **No truncation on the title pill.** Long titles would just push the column wider instead of ellipsising.

## Changes

- Wrap the LVL + title pills in a new `.lb-prestige` inline-flex container (with `gap: 8px` and `flex-wrap`) in both the members and TobyCoin standings tables.
- Add `.lb-prestige` styles in `base.css` and extend `.lb-title-pill` with `max-width: 100%`, `overflow: hidden`, `text-overflow: ellipsis`, `white-space: nowrap`.
- Fix the mobile grid selector to target `data-label="Prestige"` so the cluster anchors to the right of the top row, and right-align the flex contents in that cell.
- Shrink `.lb-level-pill` and tighten `.lb-prestige` gap at the `≤480px` breakpoint to match the existing title-pill shrink.

No JS, template-logic, or shared-component changes beyond the one new wrapper class.

## Test plan

- [ ] Run the web app locally and open the leaderboard on desktop (>900px). Confirm the LVL pill and title pill sit on one line with visible breathing room.
- [ ] Resize to ~600px and ~360px (or use devtools iPhone SE preset). Confirm the prestige cluster snaps to the right of the top row, the username ellipsises cleanly, and the title pill wraps below the LVL pill (still right-aligned) if both don't fit on one line.
- [ ] Switch to the TobyCoin tab and confirm the same polish applies.
- [ ] Spot-check the lottery top-holders list to confirm no regression — it shares `.lb-title-pill`/`.lb-level-pill` but not `.lb-prestige`.


---
_Generated by [Claude Code](https://claude.ai/code/session_0197HtKVKbnNQ9fGtENsjLJP)_