### PR TITLE
chore(diag): temporary INFO logging to isolate the double-toast

### DIFF
--- a/database/src/main/kotlin/database/service/impl/DefaultAchievementService.kt
+++ b/database/src/main/kotlin/database/service/impl/DefaultAchievementService.kt
@@ -1,6 +1,7 @@
 package database.service.impl
 
 import common.events.AchievementUnlockedEvent
+import common.logging.DiscordLogger
 import database.dto.AchievementDto
 import database.dto.AchievementProgressDto
 import database.dto.UserAchievementDto
@@ -190,6 +191,11 @@ class DefaultAchievementService(
             )
         }
 
+        // TODO(diag-removal): remove once the double-toast root cause is identified.
+        logger.info {
+            "[diag] publish AchievementUnlockedEvent: discordId=$discordId guildId=$guildId " +
+                "code=${achievement.code} name=${achievement.name}"
+        }
         eventPublisher.publishEvent(
             AchievementUnlockedEvent(
                 discordId = discordId,
@@ -209,5 +215,10 @@ class DefaultAchievementService(
             unlocked = true,
             alreadyUnlocked = false
         )
+    }
+
+    companion object {
+        // TODO(diag-removal): drop alongside the [diag] log line.
+        private val logger = DiscordLogger(DefaultAchievementService::class.java)
     }
 }

--- a/web/src/main/kotlin/web/service/NotificationSseService.kt
+++ b/web/src/main/kotlin/web/service/NotificationSseService.kt
@@ -4,6 +4,7 @@ import common.events.AchievementUnlockedEvent
 import common.events.LevelUpEvent
 import common.events.LotteryDrawnForTicketHolderEvent
 import common.events.TipSentEvent
+import common.logging.DiscordLogger
 import org.springframework.context.event.EventListener
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
@@ -46,6 +47,11 @@ class NotificationSseService(
 
     @EventListener
     fun onAchievementUnlocked(event: AchievementUnlockedEvent) {
+        // TODO(diag-removal): drop alongside the other [diag] lines once the double-toast cause is known.
+        logger.info {
+            "[diag] NotificationSseService.onAchievementUnlocked fired: discordId=${event.discordId} " +
+                "code=${event.achievementCode} name=${event.name}"
+        }
         registry.fanOut(
             key = event.discordId,
             eventName = ACHIEVEMENT_EVENT,
@@ -60,6 +66,11 @@ class NotificationSseService(
 
     @EventListener
     fun onLevelUp(event: LevelUpEvent) {
+        // TODO(diag-removal): drop alongside the other [diag] lines.
+        logger.info {
+            "[diag] NotificationSseService.onLevelUp fired: discordId=${event.discordId} " +
+                "guildId=${event.guildId} newLevel=${event.newLevel}"
+        }
         registry.fanOut(
             key = event.discordId,
             eventName = LEVEL_UP_EVENT,
@@ -76,6 +87,11 @@ class NotificationSseService(
     fun onTipSent(event: TipSentEvent) {
         // Recipient gets the toast — the sender triggered the tip and
         // doesn't need UI feedback they didn't ask for.
+        // TODO(diag-removal): drop alongside the other [diag] lines.
+        logger.info {
+            "[diag] NotificationSseService.onTipSent fired: senderId=${event.senderDiscordId} " +
+                "recipientId=${event.recipientDiscordId} guildId=${event.guildId} amount=${event.amount}"
+        }
         registry.fanOut(
             key = event.recipientDiscordId,
             eventName = TIP_EVENT,
@@ -90,6 +106,11 @@ class NotificationSseService(
 
     @EventListener
     fun onLotteryDrawnForTicketHolder(event: LotteryDrawnForTicketHolderEvent) {
+        // TODO(diag-removal): drop alongside the other [diag] lines.
+        logger.info {
+            "[diag] NotificationSseService.onLotteryDrawnForTicketHolder fired: discordId=${event.discordId} " +
+                "guildId=${event.guildId} didWin=${event.didWin} amountWon=${event.amountWon}"
+        }
         val (title, body) = if (event.didWin) {
             "🎰 You won the lottery!" to "Payout: ${event.amountWon} credits."
         } else {
@@ -125,5 +146,8 @@ class NotificationSseService(
         const val TIP_EVENT = "tip"
         const val LOTTERY_DRAWN_EVENT = "lotteryDrawn"
         const val DEFAULT_ACHIEVEMENT_ICON = "🏅"
+
+        // TODO(diag-removal): drop alongside the [diag] log lines.
+        private val logger = DiscordLogger(NotificationSseService::class.java)
     }
 }

--- a/web/src/main/kotlin/web/service/sse/KeyedSseRegistry.kt
+++ b/web/src/main/kotlin/web/service/sse/KeyedSseRegistry.kt
@@ -3,6 +3,7 @@ package web.service.sse
 import com.github.benmanes.caffeine.cache.Cache
 import com.github.benmanes.caffeine.cache.Caffeine
 import com.github.benmanes.caffeine.cache.Ticker
+import common.logging.DiscordLogger
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
 import java.io.IOException
 import java.util.concurrent.CopyOnWriteArrayList
@@ -86,6 +87,8 @@ class KeyedSseRegistry<K : Any>(
      */
     fun fanOut(key: K, eventName: String, payload: Any) {
         val list = emitters.getIfPresent(key) ?: return
+        // TODO(diag-removal): drop alongside the other [diag] lines once the double-toast cause is known.
+        logger.info { "[diag] fanOut key=$key eventName=$eventName bucketSize=${list.size}" }
         broadcast(key, list) { send(SseEmitter.event().name(eventName).data(payload)) }
     }
 
@@ -169,6 +172,9 @@ class KeyedSseRegistry<K : Any>(
     }
 
     companion object {
+        // TODO(diag-removal): drop alongside the [diag] log line.
+        private val logger = DiscordLogger(KeyedSseRegistry::class.java)
+
         const val HELLO_EVENT = "hello"
 
         /** 1 hour. Long enough that browsers usually close first; reconnect logic on the client handles expiry. */


### PR DESCRIPTION
## Summary

After PR #531 (in-page toasts + foreground-suppress push) shipped, a real-world repro on mobile produces **two byte-identical in-page toasts** in one tab from one achievement unlock (Casino Hold'em "All In" was the case observed). The Heroku logs we have don't include application-level breadcrumbs at the publish or fan-out sites, so we can't tell whether the duplication originates in:

- the domain layer publishing twice,
- Spring invoking a listener twice for one publish,
- the SSE registry fanning out twice, or
- the client rendering one frame as two toasts.

This PR adds three throwaway `INFO`-level log lines so the next reproduction leaves an unambiguous trail. All lines are tagged with `TODO(diag-removal)` and a follow-up PR will strip them once the answer is in.

## What's logged

- **`DefaultAchievementService.finalizeUnlock`** — logs immediately before `eventPublisher.publishEvent(AchievementUnlockedEvent(...))`. Pins down whether one logical unlock publishes once or twice.
- **`NotificationSseService`** — logs at the top of all four `@EventListener` methods (`onAchievementUnlocked`, `onLevelUp`, `onTipSent`, `onLotteryDrawnForTicketHolder`). Pins down whether Spring is invoking the listener twice for one published event.
- **`KeyedSseRegistry.fanOut`** — logs `key`, `eventName`, and `bucketSize` at fan-out time. `bucketSize > 1` would point at a stale-emitter scenario (eviction is lazy — driven by the next heartbeat write).

All log lines share a `[diag]` prefix so they're trivially grep-able and trivially removed.

## Test plan

- [x] `./gradlew :web:test :database:test` — green (the em-dash test-name encoding hiccup on the Heroku sandbox is pre-existing and unrelated; runs clean under `LC_ALL=C.utf8`).
- [ ] Deploy, trigger an achievement unlock (e.g. play `/casinoholdem-solo` to first win), capture Heroku logs around the trigger, look for the three `[diag]` signatures.
- [ ] Decide where the dupe originates from the log evidence, write the actual fix in a follow-up PR, then strip these log lines.

## Removal tracking

Each line carries a `TODO(diag-removal)` comment. The follow-up PR title will be something like `chore(diag): remove temporary double-toast logging`. Don't merge any other PR that builds on this without first stripping the diag lines.

https://claude.ai/code/session_01RDuuXPLs7vyTgzJSzNDt8Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01RDuuXPLs7vyTgzJSzNDt8Q)_