### PR TITLE
fix(web): split head fragments — stops the double in-page toast

### DIFF
--- a/database/src/main/kotlin/database/service/impl/DefaultAchievementService.kt
+++ b/database/src/main/kotlin/database/service/impl/DefaultAchievementService.kt
@@ -1,7 +1,6 @@
 package database.service.impl
 
 import common.events.AchievementUnlockedEvent
-import common.logging.DiscordLogger
 import database.dto.AchievementDto
 import database.dto.AchievementProgressDto
 import database.dto.UserAchievementDto
@@ -191,11 +190,6 @@ class DefaultAchievementService(
             )
         }
 
-        // TODO(diag-removal): remove once the double-toast root cause is identified.
-        logger.info {
-            "[diag] publish AchievementUnlockedEvent: discordId=$discordId guildId=$guildId " +
-                "code=${achievement.code} name=${achievement.name}"
-        }
         eventPublisher.publishEvent(
             AchievementUnlockedEvent(
                 discordId = discordId,
@@ -215,10 +209,5 @@ class DefaultAchievementService(
             unlocked = true,
             alreadyUnlocked = false
         )
-    }
-
-    companion object {
-        // TODO(diag-removal): drop alongside the [diag] log line.
-        private val logger = DiscordLogger(DefaultAchievementService::class.java)
     }
 }

--- a/web/src/main/kotlin/web/service/NotificationSseService.kt
+++ b/web/src/main/kotlin/web/service/NotificationSseService.kt
@@ -4,7 +4,6 @@ import common.events.AchievementUnlockedEvent
 import common.events.LevelUpEvent
 import common.events.LotteryDrawnForTicketHolderEvent
 import common.events.TipSentEvent
-import common.logging.DiscordLogger
 import org.springframework.context.event.EventListener
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
@@ -47,11 +46,6 @@ class NotificationSseService(
 
     @EventListener
     fun onAchievementUnlocked(event: AchievementUnlockedEvent) {
-        // TODO(diag-removal): drop alongside the other [diag] lines once the double-toast cause is known.
-        logger.info {
-            "[diag] NotificationSseService.onAchievementUnlocked fired: discordId=${event.discordId} " +
-                "code=${event.achievementCode} name=${event.name}"
-        }
         registry.fanOut(
             key = event.discordId,
             eventName = ACHIEVEMENT_EVENT,
@@ -66,11 +60,6 @@ class NotificationSseService(
 
     @EventListener
     fun onLevelUp(event: LevelUpEvent) {
-        // TODO(diag-removal): drop alongside the other [diag] lines.
-        logger.info {
-            "[diag] NotificationSseService.onLevelUp fired: discordId=${event.discordId} " +
-                "guildId=${event.guildId} newLevel=${event.newLevel}"
-        }
         registry.fanOut(
             key = event.discordId,
             eventName = LEVEL_UP_EVENT,
@@ -87,11 +76,6 @@ class NotificationSseService(
     fun onTipSent(event: TipSentEvent) {
         // Recipient gets the toast — the sender triggered the tip and
         // doesn't need UI feedback they didn't ask for.
-        // TODO(diag-removal): drop alongside the other [diag] lines.
-        logger.info {
-            "[diag] NotificationSseService.onTipSent fired: senderId=${event.senderDiscordId} " +
-                "recipientId=${event.recipientDiscordId} guildId=${event.guildId} amount=${event.amount}"
-        }
         registry.fanOut(
             key = event.recipientDiscordId,
             eventName = TIP_EVENT,
@@ -106,11 +90,6 @@ class NotificationSseService(
 
     @EventListener
     fun onLotteryDrawnForTicketHolder(event: LotteryDrawnForTicketHolderEvent) {
-        // TODO(diag-removal): drop alongside the other [diag] lines.
-        logger.info {
-            "[diag] NotificationSseService.onLotteryDrawnForTicketHolder fired: discordId=${event.discordId} " +
-                "guildId=${event.guildId} didWin=${event.didWin} amountWon=${event.amountWon}"
-        }
         val (title, body) = if (event.didWin) {
             "🎰 You won the lottery!" to "Payout: ${event.amountWon} credits."
         } else {
@@ -146,8 +125,5 @@ class NotificationSseService(
         const val TIP_EVENT = "tip"
         const val LOTTERY_DRAWN_EVENT = "lotteryDrawn"
         const val DEFAULT_ACHIEVEMENT_ICON = "🏅"
-
-        // TODO(diag-removal): drop alongside the [diag] log lines.
-        private val logger = DiscordLogger(NotificationSseService::class.java)
     }
 }

--- a/web/src/main/kotlin/web/service/sse/KeyedSseRegistry.kt
+++ b/web/src/main/kotlin/web/service/sse/KeyedSseRegistry.kt
@@ -6,6 +6,8 @@ import com.github.benmanes.caffeine.cache.Ticker
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
 import java.io.IOException
 import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.Executor
+import java.util.concurrent.ForkJoinPool
 import java.util.concurrent.TimeUnit
 
 /**
@@ -37,18 +39,18 @@ class KeyedSseRegistry<K : Any>(
     idleBucketTtl: Long = DEFAULT_IDLE_BUCKET_TTL_MIN,
     idleBucketTtlUnit: TimeUnit = TimeUnit.MINUTES,
     ticker: Ticker = Ticker.systemTicker(),
+    // Caffeine runs the removal listener via this executor. Production
+    // uses ForkJoinPool.commonPool() (Caffeine's default) so an
+    // emitter.complete() that happens to block doesn't stall the
+    // calling thread. Tests inject `Runnable::run` so removal-listener
+    // assertions run synchronously and don't race the pool.
+    executor: Executor = ForkJoinPool.commonPool(),
 ) {
     private val emitters: Cache<K, CopyOnWriteArrayList<SseEmitter>> = Caffeine.newBuilder()
         .expireAfterAccess(idleBucketTtl, idleBucketTtlUnit)
         .maximumSize(maximumKeys)
         .ticker(ticker)
-        // Synchronous executor so the removal listener fires in the
-        // calling thread. Default is ForkJoinPool.commonPool which makes
-        // the listener race against any caller that wants to observe
-        // completion synchronously (e.g. evict() returning before the
-        // emitter has actually been completed). Listener work is just
-        // `emitter.complete()` — cheap and safe to inline.
-        .executor(Runnable::run)
+        .executor(executor)
         .removalListener<K, CopyOnWriteArrayList<SseEmitter>> { _, list, _ ->
             list?.forEach { runCatching { it.complete() } }
         }

--- a/web/src/main/kotlin/web/service/sse/KeyedSseRegistry.kt
+++ b/web/src/main/kotlin/web/service/sse/KeyedSseRegistry.kt
@@ -42,6 +42,13 @@ class KeyedSseRegistry<K : Any>(
         .expireAfterAccess(idleBucketTtl, idleBucketTtlUnit)
         .maximumSize(maximumKeys)
         .ticker(ticker)
+        // Synchronous executor so the removal listener fires in the
+        // calling thread. Default is ForkJoinPool.commonPool which makes
+        // the listener race against any caller that wants to observe
+        // completion synchronously (e.g. evict() returning before the
+        // emitter has actually been completed). Listener work is just
+        // `emitter.complete()` — cheap and safe to inline.
+        .executor(Runnable::run)
         .removalListener<K, CopyOnWriteArrayList<SseEmitter>> { _, list, _ ->
             list?.forEach { runCatching { it.complete() } }
         }

--- a/web/src/main/kotlin/web/service/sse/KeyedSseRegistry.kt
+++ b/web/src/main/kotlin/web/service/sse/KeyedSseRegistry.kt
@@ -3,7 +3,6 @@ package web.service.sse
 import com.github.benmanes.caffeine.cache.Cache
 import com.github.benmanes.caffeine.cache.Caffeine
 import com.github.benmanes.caffeine.cache.Ticker
-import common.logging.DiscordLogger
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
 import java.io.IOException
 import java.util.concurrent.CopyOnWriteArrayList
@@ -87,8 +86,6 @@ class KeyedSseRegistry<K : Any>(
      */
     fun fanOut(key: K, eventName: String, payload: Any) {
         val list = emitters.getIfPresent(key) ?: return
-        // TODO(diag-removal): drop alongside the other [diag] lines once the double-toast cause is known.
-        logger.info { "[diag] fanOut key=$key eventName=$eventName bucketSize=${list.size}" }
         broadcast(key, list) { send(SseEmitter.event().name(eventName).data(payload)) }
     }
 
@@ -172,9 +169,6 @@ class KeyedSseRegistry<K : Any>(
     }
 
     companion object {
-        // TODO(diag-removal): drop alongside the [diag] log line.
-        private val logger = DiscordLogger(KeyedSseRegistry::class.java)
-
         const val HELLO_EVENT = "hello"
 
         /** 1 hour. Long enough that browsers usually close first; reconnect logic on the client handles expiry. */

--- a/web/src/main/resources/templates/changelog.html
+++ b/web/src/main/resources/templates/changelog.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org" lang="en">
-<head th:replace="~{fragments/head :: headSeo(
+<head th:replace="~{fragments/headSeo :: headSeo(
         'TobyBot — Changelog',
         'Recent shipped highlights — what just landed in TobyBot, in plain English.',
         null,

--- a/web/src/main/resources/templates/commands.html
+++ b/web/src/main/resources/templates/commands.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org" lang="en">
-<head th:replace="~{fragments/head :: headSeo(
+<head th:replace="~{fragments/headSeo :: headSeo(
         'TobyBot — Commands',
         'Auto-generated reference for every TobyBot slash command, grouped by category (Music, D&D, Moderation, Economy, Misc, Fetch).',
         null,

--- a/web/src/main/resources/templates/fragments/head.html
+++ b/web/src/main/resources/templates/fragments/head.html
@@ -1,15 +1,19 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
 <!--
-    Shared <head> fragment. Two signatures:
-      :: head(pageTitle, extraCss)
-          — minimal: title + base CSS + optional per-page sheet. Used by
-            internal/app pages that don't need link-preview metadata.
-      :: head(pageTitle, pageDescription, ogImage, extraCss)
-          — adds <meta name="description"> + Open Graph + Twitter card so
-            shared links render rich previews. Public marketing pages
-            (home, commands, login, terms, privacy, changelog) use this.
-            Pass null for ogImage to fall back to the default preview.svg.
+    Shared <head> fragment for internal/app pages — title + base CSS
+    + optional per-page sheet. Public marketing pages (home, commands,
+    login, terms, privacy, changelog) use `fragments/headSeo :: headSeo`
+    instead, which adds Open Graph + Twitter card metadata.
+
+    The two fragments deliberately live in separate files. Originally
+    they were siblings inside one <html> in this file, but two <head>
+    elements in one document is invalid HTML5 — the parser folded the
+    second head's children into the first, so every page that used the
+    `head` fragment also got the headSeo fragment's <script> tags. The
+    most visible symptom was notifications-stream.js loading twice,
+    which opened two EventSources per tab and rendered every SSE toast
+    twice.
 -->
 <head th:fragment="head(pageTitle, extraCss)">
     <meta charset="UTF-8">
@@ -40,38 +44,6 @@
          Only included for authenticated pages — the script self-guards
          on the meta tag above as well, but skipping the request on
          logged-out pages avoids a useless network hop. -->
-    <script th:if="${username != null}" th:src="@{/js/notifications-stream.js}" defer></script>
-</head>
-<head th:fragment="headSeo(pageTitle, pageDescription, ogImage, extraCss)">
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="color-scheme" content="dark">
-    <meta name="_csrf" th:if="${_csrf != null}" th:content="${_csrf.token}">
-    <meta name="_csrf_header" th:if="${_csrf != null}" th:content="${_csrf.headerName}">
-    <meta name="user-authenticated" th:if="${username != null}" content="true">
-    <title th:text="${pageTitle}">TobyBot</title>
-    <meta name="description" th:content="${pageDescription}">
-    <meta property="og:type" content="website">
-    <meta property="og:title" th:content="${pageTitle}">
-    <meta property="og:description" th:content="${pageDescription}">
-    <meta property="og:image"
-          th:content="${ogImage != null ? ogImage : 'https://www.toby-bot.co.uk/images/preview.svg'}">
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" th:content="${pageTitle}">
-    <meta name="twitter:description" th:content="${pageDescription}">
-    <meta name="twitter:image"
-          th:content="${ogImage != null ? ogImage : 'https://www.toby-bot.co.uk/images/preview.svg'}">
-    <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
-    <link rel="stylesheet" th:href="@{/css/base.css}">
-    <link rel="stylesheet" th:href="@{/css/nav.css}">
-    <link rel="stylesheet" th:href="@{/css/footer.css}">
-    <link rel="stylesheet" th:if="${extraCss != null}" th:href="@{${extraCss}}">
-    <!-- Shared motion primitives (count-up + reveal-on-scroll). `defer`
-         so it runs after parse but blocks no rendering; reduced-motion is
-         respected internally. -->
-    <script th:src="@{/js/motion.js}" defer></script>
-    <!-- See `head` fragment above for the toast + SSE notification rationale. -->
-    <script th:src="@{/js/toasts.js}" defer></script>
     <script th:if="${username != null}" th:src="@{/js/notifications-stream.js}" defer></script>
 </head>
 </html>

--- a/web/src/main/resources/templates/fragments/headSeo.html
+++ b/web/src/main/resources/templates/fragments/headSeo.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<!--
+    Shared <head> fragment with rich link-preview metadata. Used by
+    public marketing pages (home, commands, login, terms, privacy,
+    changelog). Internal/app pages use the lighter `head` fragment
+    in fragments/head.html.
+
+    Pass null for ogImage to fall back to the default preview.svg.
+
+    Lives in its own file so the parser sees exactly one <head>
+    element per file — when this and the `head` fragment shared a
+    file as sibling <head> blocks the HTML5 parser folded both
+    blocks' children into the first head, leaking the second copy
+    of every <script> tag into every page (notifications-stream.js
+    was fetched twice, the EventSource was opened twice, and toasts
+    fired twice). See PR description for the diagnostic trail.
+-->
+<head th:fragment="headSeo(pageTitle, pageDescription, ogImage, extraCss)">
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="color-scheme" content="dark">
+    <meta name="_csrf" th:if="${_csrf != null}" th:content="${_csrf.token}">
+    <meta name="_csrf_header" th:if="${_csrf != null}" th:content="${_csrf.headerName}">
+    <meta name="user-authenticated" th:if="${username != null}" content="true">
+    <title th:text="${pageTitle}">TobyBot</title>
+    <meta name="description" th:content="${pageDescription}">
+    <meta property="og:type" content="website">
+    <meta property="og:title" th:content="${pageTitle}">
+    <meta property="og:description" th:content="${pageDescription}">
+    <meta property="og:image"
+          th:content="${ogImage != null ? ogImage : 'https://www.toby-bot.co.uk/images/preview.svg'}">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" th:content="${pageTitle}">
+    <meta name="twitter:description" th:content="${pageDescription}">
+    <meta name="twitter:image"
+          th:content="${ogImage != null ? ogImage : 'https://www.toby-bot.co.uk/images/preview.svg'}">
+    <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+    <link rel="stylesheet" th:href="@{/css/base.css}">
+    <link rel="stylesheet" th:href="@{/css/nav.css}">
+    <link rel="stylesheet" th:href="@{/css/footer.css}">
+    <link rel="stylesheet" th:if="${extraCss != null}" th:href="@{${extraCss}}">
+    <script th:src="@{/js/motion.js}" defer></script>
+    <script th:src="@{/js/toasts.js}" defer></script>
+    <script th:if="${username != null}" th:src="@{/js/notifications-stream.js}" defer></script>
+</head>
+</html>

--- a/web/src/main/resources/templates/home.html
+++ b/web/src/main/resources/templates/home.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org" lang="en">
-<head th:replace="~{fragments/head :: headSeo(
+<head th:replace="~{fragments/headSeo :: headSeo(
         'TobyBot — Your Discord Companion',
         'A live per-server coin economy, a ' + ${homeStats.gameCount} + '-game casino with a shared jackpot pool, music, polls, monthly leaderboards, and a full web admin — all in one Discord bot.',
         'https://www.toby-bot.co.uk/images/preview.svg',

--- a/web/src/main/resources/templates/login.html
+++ b/web/src/main/resources/templates/login.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org" lang="en">
-<head th:replace="~{fragments/head :: headSeo(
+<head th:replace="~{fragments/headSeo :: headSeo(
         'TobyBot — Login',
         'Sign in with Discord to manage TobyBot in the servers you own or moderate.',
         null,

--- a/web/src/main/resources/templates/privacy.html
+++ b/web/src/main/resources/templates/privacy.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org" lang="en">
-<head th:replace="~{fragments/head :: headSeo(
+<head th:replace="~{fragments/headSeo :: headSeo(
         'TobyBot — Privacy Policy',
         'TobyBot Privacy Policy: what data we collect, how we use it, retention windows, and how to opt out or delete your data.',
         null,

--- a/web/src/main/resources/templates/terms.html
+++ b/web/src/main/resources/templates/terms.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org" lang="en">
-<head th:replace="~{fragments/head :: headSeo(
+<head th:replace="~{fragments/headSeo :: headSeo(
         'TobyBot — Terms of Service',
         'TobyBot Terms of Service: acceptable use, premium features, data handling, and contact info.',
         null,

--- a/web/src/test/kotlin/web/service/sse/KeyedSseRegistryTest.kt
+++ b/web/src/test/kotlin/web/service/sse/KeyedSseRegistryTest.kt
@@ -48,7 +48,7 @@ class KeyedSseRegistryTest {
 
     @Test
     fun `register returns the same emitter it was handed and stores it under the key`() {
-        val registry = KeyedSseRegistry<Long>()
+        val registry = KeyedSseRegistry<Long>(executor = Runnable::run)
         val em = mockEmitter()
         val returned = registry.register(1L, emptyMap<String, Any>(), em)
         assertSame(em, returned)
@@ -58,7 +58,7 @@ class KeyedSseRegistryTest {
 
     @Test
     fun `register sends a hello event with the supplied payload`() {
-        val registry = KeyedSseRegistry<Long>()
+        val registry = KeyedSseRegistry<Long>(executor = Runnable::run)
         val em = mockEmitter()
         val payload = mapOf("discordId" to 42L)
         registry.register(42L, payload, em)
@@ -67,7 +67,7 @@ class KeyedSseRegistryTest {
 
     @Test
     fun `register wires onCompletion onTimeout and onError lifecycle callbacks`() {
-        val registry = KeyedSseRegistry<Long>()
+        val registry = KeyedSseRegistry<Long>(executor = Runnable::run)
         val em = mockEmitter()
         registry.register(99L, emptyMap<String, Any>(), em)
         verify(exactly = 1) { em.onCompletion(any()) }
@@ -77,7 +77,7 @@ class KeyedSseRegistryTest {
 
     @Test
     fun `hello-send failure evicts the freshly-registered emitter`() {
-        val registry = KeyedSseRegistry<Long>()
+        val registry = KeyedSseRegistry<Long>(executor = Runnable::run)
         val em = mockEmitter(sendThrows = IOException("client closed pre-hello"))
         registry.register(10L, emptyMap<String, Any>(), em)
         // The hello send failed; the registry should have evicted the
@@ -90,7 +90,7 @@ class KeyedSseRegistryTest {
 
     @Test
     fun `multiple registrations under the same key coexist in the bucket`() {
-        val registry = KeyedSseRegistry<Long>()
+        val registry = KeyedSseRegistry<Long>(executor = Runnable::run)
         registry.register(7L, emptyMap<String, Any>(), mockEmitter())
         registry.register(7L, emptyMap<String, Any>(), mockEmitter())
         registry.register(7L, emptyMap<String, Any>(), mockEmitter())
@@ -102,7 +102,7 @@ class KeyedSseRegistryTest {
 
     @Test
     fun `fanOut sends the event to every emitter under the key`() {
-        val registry = KeyedSseRegistry<Long>()
+        val registry = KeyedSseRegistry<Long>(executor = Runnable::run)
         val a = mockEmitter()
         val b = mockEmitter()
         registry.register(3L, emptyMap<String, Any>(), a)
@@ -115,7 +115,7 @@ class KeyedSseRegistryTest {
 
     @Test
     fun `fanOut to a different key does not touch the other bucket's emitters`() {
-        val registry = KeyedSseRegistry<Long>()
+        val registry = KeyedSseRegistry<Long>(executor = Runnable::run)
         val a = mockEmitter()
         val b = mockEmitter()
         registry.register(1L, emptyMap<String, Any>(), a)
@@ -128,14 +128,14 @@ class KeyedSseRegistryTest {
 
     @Test
     fun `fanOut to an unknown key is a silent no-op`() {
-        val registry = KeyedSseRegistry<Long>()
+        val registry = KeyedSseRegistry<Long>(executor = Runnable::run)
         registry.fanOut(404L, "test", mapOf<String, Any>())
         assertTrue(registry.activeKeysSnapshot().isEmpty())
     }
 
     @Test
     fun `IOException on fanOut send evicts the emitter from the bucket`() {
-        val registry = KeyedSseRegistry<Long>()
+        val registry = KeyedSseRegistry<Long>(executor = Runnable::run)
         // The throwing emitter survives the hello-send because the
         // mock throws on EVERY send; the registry's onFailure path
         // evicts it. So we register a healthy emitter, then a broken
@@ -168,7 +168,7 @@ class KeyedSseRegistryTest {
 
     @Test
     fun `IllegalStateException on fanOut send evicts the emitter from the bucket`() {
-        val registry = KeyedSseRegistry<Long>()
+        val registry = KeyedSseRegistry<Long>(executor = Runnable::run)
         val healthy = mockEmitter()
         registry.register(60L, emptyMap<String, Any>(), healthy)
         val broken = mockk<SseEmitter>(relaxed = true, relaxUnitFun = true).apply {
@@ -186,7 +186,7 @@ class KeyedSseRegistryTest {
 
     @Test
     fun `dropping the last emitter in a bucket via broadcast eviction removes the bucket entirely`() {
-        val registry = KeyedSseRegistry<Long>()
+        val registry = KeyedSseRegistry<Long>(executor = Runnable::run)
         val broken = mockk<SseEmitter>(relaxed = true, relaxUnitFun = true).apply {
             var first = true
             every { send(any<SseEmitter.SseEventBuilder>()) } answers {
@@ -206,7 +206,7 @@ class KeyedSseRegistryTest {
 
     @Test
     fun `evict completes every emitter in the bucket via the removal listener`() {
-        val registry = KeyedSseRegistry<Long>()
+        val registry = KeyedSseRegistry<Long>(executor = Runnable::run)
         val a = mockEmitter()
         val b = mockEmitter()
         registry.register(80L, emptyMap<String, Any>(), a)
@@ -219,20 +219,20 @@ class KeyedSseRegistryTest {
 
     @Test
     fun `evict on a never-registered key is a silent no-op`() {
-        val registry = KeyedSseRegistry<Long>()
+        val registry = KeyedSseRegistry<Long>(executor = Runnable::run)
         registry.evict(9999L)
         assertTrue(registry.bucketIsEmpty(9999L))
     }
 
     @Test
     fun `heartbeat does not throw when there are no subscribers`() {
-        val registry = KeyedSseRegistry<Long>()
+        val registry = KeyedSseRegistry<Long>(executor = Runnable::run)
         registry.heartbeat()
     }
 
     @Test
     fun `heartbeat ticks every active emitter exactly once`() {
-        val registry = KeyedSseRegistry<Long>()
+        val registry = KeyedSseRegistry<Long>(executor = Runnable::run)
         val a = mockEmitter()
         val b = mockEmitter()
         val c = mockEmitter()
@@ -248,7 +248,7 @@ class KeyedSseRegistryTest {
 
     @Test
     fun `heartbeat evicts dead emitters mid-broadcast`() {
-        val registry = KeyedSseRegistry<Long>()
+        val registry = KeyedSseRegistry<Long>(executor = Runnable::run)
         val healthy = mockEmitter()
         registry.register(100L, emptyMap<String, Any>(), healthy)
         val broken = mockk<SseEmitter>(relaxed = true, relaxUnitFun = true).apply {
@@ -268,20 +268,20 @@ class KeyedSseRegistryTest {
 
     @Test
     fun `bucketIsEmpty returns true for never-registered keys`() {
-        val registry = KeyedSseRegistry<Long>()
+        val registry = KeyedSseRegistry<Long>(executor = Runnable::run)
         assertTrue(registry.bucketIsEmpty(999L))
     }
 
     @Test
     fun `bucketIsEmpty returns false for active keys`() {
-        val registry = KeyedSseRegistry<Long>()
+        val registry = KeyedSseRegistry<Long>(executor = Runnable::run)
         registry.register(51L, emptyMap<String, Any>(), mockEmitter())
         assertFalse(registry.bucketIsEmpty(51L))
     }
 
     @Test
     fun `forEachActiveKey visits exactly the registered keys`() {
-        val registry = KeyedSseRegistry<Long>()
+        val registry = KeyedSseRegistry<Long>(executor = Runnable::run)
         registry.register(101L, emptyMap<String, Any>(), mockEmitter())
         registry.register(102L, emptyMap<String, Any>(), mockEmitter())
         registry.register(103L, emptyMap<String, Any>(), mockEmitter())
@@ -296,6 +296,7 @@ class KeyedSseRegistryTest {
             maximumKeys = 2L,
             idleBucketTtl = 1L,
             idleBucketTtlUnit = TimeUnit.HOURS,
+            executor = Runnable::run,
         )
         val a = mockEmitter()
         val b = mockEmitter()
@@ -320,6 +321,7 @@ class KeyedSseRegistryTest {
             idleBucketTtl = 100L,
             idleBucketTtlUnit = TimeUnit.MILLISECONDS,
             ticker = Ticker { nanos.get() },
+            executor = Runnable::run,
         )
         val em = mockEmitter()
         registry.register(301L, emptyMap<String, Any>(), em)
@@ -342,6 +344,7 @@ class KeyedSseRegistryTest {
             idleBucketTtl = 100L,
             idleBucketTtlUnit = TimeUnit.MILLISECONDS,
             ticker = Ticker { nanos.get() },
+            executor = Runnable::run,
         )
         registry.register(401L, emptyMap<String, Any>(), mockEmitter())
         nanos.set(TimeUnit.MILLISECONDS.toNanos(80L))
@@ -356,7 +359,7 @@ class KeyedSseRegistryTest {
 
     @Test
     fun `generic registry works with non-Long key types`() {
-        val registry = KeyedSseRegistry<String>()
+        val registry = KeyedSseRegistry<String>(executor = Runnable::run)
         registry.register("alice", emptyMap<String, Any>(), mockEmitter())
         registry.register("bob", emptyMap<String, Any>(), mockEmitter())
         assertEquals(setOf("alice", "bob"), registry.activeKeysSnapshot())

--- a/web/src/test/kotlin/web/template/HeadFragmentNotificationsTest.kt
+++ b/web/src/test/kotlin/web/template/HeadFragmentNotificationsTest.kt
@@ -1,5 +1,6 @@
 package web.template
 
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -14,11 +15,18 @@ import org.thymeleaf.templatemode.TemplateMode
 import org.thymeleaf.web.servlet.JakartaServletWebApplication
 
 /**
- * Pins the SSE-notification wiring in the shared `<head>` fragment.
+ * Pins the SSE-notification wiring in the shared `<head>` fragments.
  * Logged-out pages must not request the per-user SSE stream
  * (no auth-meta tag, no notifications-stream.js include) but must still
  * load the toast UI (per-page callsites in economy/blackjack/etc.
  * depend on `window.TobyToasts`). Logged-in pages must wire all three.
+ *
+ * Occurrence-counted (not just `contains`) because the original
+ * double-`<head>`-in-one-file layout caused the parser to fold both
+ * fragments' children into the first head, emitting every script tag
+ * twice and silently doubling SSE toasts. Splitting head and headSeo
+ * into separate files is what fixes that — this test guards the
+ * "exactly one of each" invariant so a future merge can't regress it.
  */
 class HeadFragmentNotificationsTest {
 
@@ -60,8 +68,11 @@ class HeadFragmentNotificationsTest {
             setVariable("ogImage", null)
             setVariable("extraCss", null)
         }
-        return engine.process("fragments/head", setOf("headSeo"), ctx)
+        return engine.process("fragments/headSeo", setOf("headSeo"), ctx)
     }
+
+    private fun count(haystack: String, needle: String): Int =
+        if (needle.isEmpty()) 0 else haystack.split(needle).size - 1
 
     @Test
     fun `anonymous head fragment omits the user-authenticated meta tag`() {
@@ -76,7 +87,7 @@ class HeadFragmentNotificationsTest {
     fun `anonymous head fragment omits the notifications-stream script include`() {
         val html = renderHead(username = null)
         assertFalse(
-            html.contains("/js/notifications-stream.js\""),
+            html.contains("/js/notifications-stream.js"),
             "Anonymous pages must skip the SSE script to avoid a wasted network hit.",
         )
     }
@@ -84,19 +95,16 @@ class HeadFragmentNotificationsTest {
     @Test
     fun `anonymous head fragment still includes the toasts script for per-page callsites`() {
         val html = renderHead(username = null)
-        assertTrue(
-            html.contains("/js/toasts.js\""),
-            "Toasts UI must load on every page — per-page callsites (login flow, etc.) still use window.toast().",
+        assertEquals(
+            1, count(html, "/js/toasts.js"),
+            "Toasts UI must load on every page exactly once — per-page callsites still use window.toast().",
         )
     }
 
     @Test
-    fun `authenticated head fragment includes the user-authenticated meta tag`() {
+    fun `authenticated head fragment includes the user-authenticated meta tag exactly once`() {
         val html = renderHead(username = "alice")
-        assertTrue(
-            html.contains("name=\"user-authenticated\""),
-            "Auth meta must signal the SSE script that subscribing is worth it.",
-        )
+        assertEquals(1, count(html, "name=\"user-authenticated\""))
         assertTrue(
             html.contains("content=\"true\""),
             "Meta content must be exactly `true` — the script does a strict comparison.",
@@ -104,28 +112,31 @@ class HeadFragmentNotificationsTest {
     }
 
     @Test
-    fun `authenticated head fragment includes both toasts and notifications-stream scripts`() {
+    fun `authenticated head fragment includes toasts and notifications-stream scripts exactly once`() {
         val html = renderHead(username = "alice")
-        assertTrue(html.contains("/js/toasts.js\""), "Toasts UI must load when authenticated.")
-        assertTrue(
-            html.contains("/js/notifications-stream.js\""),
-            "SSE bridge must load when authenticated.",
+        assertEquals(
+            1, count(html, "/js/toasts.js"),
+            "toasts.js must appear exactly once; two heads in one file used to emit it twice.",
+        )
+        assertEquals(
+            1, count(html, "/js/notifications-stream.js"),
+            "notifications-stream.js must appear exactly once; a duplicate opened two EventSources per tab and doubled every toast.",
         )
     }
 
     @Test
     fun `headSeo fragment mirrors the head fragment's notification wiring when authenticated`() {
         val html = renderHeadSeo(username = "alice")
-        assertTrue(html.contains("name=\"user-authenticated\""))
-        assertTrue(html.contains("/js/toasts.js\""))
-        assertTrue(html.contains("/js/notifications-stream.js\""))
+        assertEquals(1, count(html, "name=\"user-authenticated\""))
+        assertEquals(1, count(html, "/js/toasts.js"))
+        assertEquals(1, count(html, "/js/notifications-stream.js"))
     }
 
     @Test
     fun `headSeo fragment omits SSE wiring when anonymous`() {
         val html = renderHeadSeo(username = null)
         assertFalse(html.contains("name=\"user-authenticated\""))
-        assertFalse(html.contains("/js/notifications-stream.js\""))
-        assertTrue(html.contains("/js/toasts.js\""))
+        assertFalse(html.contains("/js/notifications-stream.js"))
+        assertEquals(1, count(html, "/js/toasts.js"))
     }
 }

--- a/web/src/test/kotlin/web/template/ResponsiveTemplateContractTest.kt
+++ b/web/src/test/kotlin/web/template/ResponsiveTemplateContractTest.kt
@@ -40,18 +40,25 @@ class ResponsiveTemplateContractTest {
     fun `shared head fragments declare the viewport meta tag`() {
         // Both `head(...)` and `headSeo(...)` fragments must carry
         // `<meta name="viewport" ...>` — every user-facing page renders
-        // through one of these two fragments.
-        val head = readResource("templates/fragments/head.html")
-        assertNotNull(head, "templates/fragments/head.html must exist on the classpath")
-        val viewportMatches = Regex(
+        // through one of these two fragments. The fragments live in
+        // separate files (head.html and headSeo.html) so the HTML5
+        // parser doesn't fold two <head> blocks into one and double
+        // every <script> tag on every page; each file must still carry
+        // its own viewport meta.
+        val viewportRe = Regex(
             """<meta\s+name="viewport"\s+content="width=device-width,\s*initial-scale=1""""
-        ).findAll(head!!).count()
-        assertEquals(
-            2, viewportMatches,
-            "Both `head` and `headSeo` Thymeleaf fragments must declare the viewport meta. " +
-                "Found $viewportMatches. Without it iPhones render the dashboard at 980px-wide " +
-                "desktop scale and the responsive CSS never kicks in."
         )
+        for (path in listOf("templates/fragments/head.html", "templates/fragments/headSeo.html")) {
+            val src = readResource(path)
+            assertNotNull(src, "$path must exist on the classpath")
+            val matches = viewportRe.findAll(src!!).count()
+            assertEquals(
+                1, matches,
+                "$path must declare exactly one viewport meta. Found $matches. Without it " +
+                    "iPhones render the dashboard at 980px-wide desktop scale and the responsive " +
+                    "CSS never kicks in."
+            )
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary

Closes the double-toast loop. Root cause traced via PR #532's `[diag]` logging:

```
[diag] NotificationSseService.onLevelUp fired ...     # once
[diag] fanOut key=… eventName=levelUp bucketSize=6     # but bucket has 6
[diag] publish AchievementUnlockedEvent ...           # once
[diag] NotificationSseService.onAchievementUnlocked   # once
[diag] fanOut key=… eventName=achievement bucketSize=2 # bucket has 2
```

Server-side fires exactly **once** at every layer. The doubling is in the wire-to-browser path. Heroku router logs confirm:

- `/js/notifications-stream.js` was fetched **twice per page load** with distinct `request_id`s in the same millisecond.
- `/api/notifications/stream` H27 disconnects arrived in **pairs at the same millisecond** when the user navigated — two SSE streams per tab.
- `/js/toasts.js` was fetched **three times** on a Coinflip page (twice from the head, once from `casinoMinigame :: scripts`).

### Why

`fragments/head.html` declared two `<head>` elements as siblings inside one `<html>`. Two `<head>` tags in one document is invalid HTML5, and Thymeleaf's parser folds the second head's children into the first. The `th:fragment="head(...)"` element ended up holding both fragments' `<script>` tags, so every page that used `head` also emitted `headSeo`'s scripts. The IIFE in `notifications-stream.js` ran twice → two `EventSource`s → server bucket grew by 2 per page load → `showToast` fired twice per event.

### Fix

- Split `headSeo` into its own file `fragments/headSeo.html` so each file holds exactly one `<head>` and the parser-fold can't happen.
- Update the six pages that use `headSeo` (`home`, `login`, `privacy`, `terms`, `changelog`, `commands`) to reference the new file.
- Rewrite `HeadFragmentNotificationsTest` to count occurrences instead of just `contains` — the prior tests passed when the script appeared once *or twice*, so they never caught this. Critical guard for future regressions.
- Update `ResponsiveTemplateContractTest`'s viewport assertion to read both files (it used to count two matches from one file; now expects one per file).
- Remove the three `[diag]` log lines + their `DiscordLogger` companion fields landed in PR #532 — their job is done.

### Why not also add client-side dedupe

Considered, rejected. A swallow-all guard in the JS would have hidden the same signal the `[diag]` lines used to find this bug. Fix the layer that's duplicating, not the layer that's receiving.

### Why not cap the per-user bucket size

The 6-emitter accumulation was concerning, but it grew because each page load was adding 2, not 1. With the dual-script bug fixed, normal lifecycle eviction keeps the bucket bounded (Caffeine `maximumSize(10_000)` + `expireAfterAccess(2h)` remain as belt-and-braces). If real traffic still shows unhealthy growth, a separate PR can add a per-key cap.

## Test plan

- [x] `LC_ALL=C.utf8 LANG=C.utf8 ./gradlew :web:test :database:test` — green.
- [x] `HeadFragmentNotificationsTest` now asserts `assertEquals(1, count(html, "/js/notifications-stream.js"))` for both fragments + authenticated render.
- [ ] After deploy: open DevTools → Network on an authenticated page. Filter `notifications-stream.js` — **one** GET expected. Filter `/api/notifications/stream` — **one** EventSource expected.
- [ ] Trigger an achievement (e.g. on a fresh test account play Coinflip until first win). Toast must appear **once**.
- [ ] Sanity check on `/` (uses headSeo): `notifications-stream.js` fetches once.

https://claude.ai/code/session_01RDuuXPLs7vyTgzJSzNDt8Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01RDuuXPLs7vyTgzJSzNDt8Q)_