### PR TITLE
feat(install): in-Discord install wizard (Express + Custom paths)

### DIFF
--- a/application/src/test/kotlin/integration/bot/ButtonManagerTest.kt
+++ b/application/src/test/kotlin/integration/bot/ButtonManagerTest.kt
@@ -4,6 +4,13 @@ import app.Application
 import bot.configuration.*
 import bot.toby.button.buttons.*
 import bot.toby.helpers.*
+import bot.toby.install.button.InstallBackButton
+import bot.toby.install.button.InstallCustomButton
+import bot.toby.install.button.InstallExpressButton
+import bot.toby.install.button.InstallFeaturesButton
+import bot.toby.install.button.InstallFinishButton
+import bot.toby.install.button.InstallSkipButton
+import bot.toby.install.button.InstallToggleButton
 import bot.toby.lavaplayer.GuildMusicManager
 import bot.toby.lavaplayer.PlayerManager
 import bot.toby.lavaplayer.TrackScheduler
@@ -85,10 +92,17 @@ class ButtonManagerTest {
             TeamCancelButton::class.java,
             TeamConfirmButton::class.java,
             TeamRerollButton::class.java,
+            InstallExpressButton::class.java,
+            InstallCustomButton::class.java,
+            InstallSkipButton::class.java,
+            InstallFinishButton::class.java,
+            InstallBackButton::class.java,
+            InstallFeaturesButton::class.java,
+            InstallToggleButton::class.java,
         )
 
         assertTrue(availableButtons.containsAll(buttonManager.buttons.map { it.javaClass }.toList()))
-        assertEquals(15, buttonManager.buttons.size)
+        assertEquals(availableButtons.size, buttonManager.buttons.size)
     }
 
     @Test

--- a/application/src/test/kotlin/integration/bot/CommandManagerTest.kt
+++ b/application/src/test/kotlin/integration/bot/CommandManagerTest.kt
@@ -34,6 +34,7 @@ import bot.toby.command.commands.music.intro.EditIntroCommand
 import bot.toby.command.commands.music.intro.SetIntroCommand
 import bot.toby.command.commands.music.player.*
 import bot.toby.helpers.*
+import bot.toby.install.InstallCommand
 import bot.toby.lavaplayer.PlayerManager
 import bot.toby.managers.DefaultCommandManager
 import common.configuration.TestCachingConfig
@@ -161,11 +162,12 @@ class CommandManagerTest {
             DailyCommand::class.java,
             AchievementsCommand::class.java,
             NotifyCommand::class.java,
+            InstallCommand::class.java,
         )
 
         Assertions.assertTrue(availableCommands.containsAll(commandManager.allCommands.map { it.javaClass }.toList()))
-        Assertions.assertEquals(67, commandManager.allCommands.size)
-        Assertions.assertEquals(67, commandManager.allSlashCommands.size)
+        Assertions.assertEquals(availableCommands.size, commandManager.allCommands.size)
+        Assertions.assertEquals(availableCommands.size, commandManager.allSlashCommands.size)
     }
 
     @Test

--- a/application/src/test/kotlin/integration/bot/MenuManagerTest.kt
+++ b/application/src/test/kotlin/integration/bot/MenuManagerTest.kt
@@ -4,6 +4,7 @@ import app.Application
 import bot.configuration.TestAppConfig
 import bot.configuration.TestBotConfig
 import bot.configuration.TestManagerConfig
+import bot.toby.install.menu.InstallCategoryMenu
 import bot.toby.managers.DefaultMenuManager
 import bot.toby.menu.menus.ActivityContribMenu
 import bot.toby.menu.menus.DeleteIntroMenu
@@ -62,6 +63,7 @@ internal class MenuManagerTest {
             EditIntroMenu::class.java,
             DeleteIntroMenu::class.java,
             ActivityContribMenu::class.java,
+            InstallCategoryMenu::class.java,
         )
         assertEquals(availableMenus.size, menuManager.menus.size)
         assertTrue(availableMenus.containsAll(menuManager.menus.map { it.javaClass }.toList()))

--- a/database/src/main/kotlin/database/dto/ConfigDto.kt
+++ b/database/src/main/kotlin/database/dto/ConfigDto.kt
@@ -365,7 +365,14 @@ class ConfigDto(
         // Optional Discord text-channel id where achievement-unlock
         // shoutouts post in addition to the unlocker's DM. When unset,
         // unlocks are DM-only. Stored as a stringified Long.
-        ACHIEVEMENT_ANNOUNCE_CHANNEL("ACHIEVEMENT_ANNOUNCE_CHANNEL");
+        ACHIEVEMENT_ANNOUNCE_CHANNEL("ACHIEVEMENT_ANNOUNCE_CHANNEL"),
+
+        // Install-wizard sentinel. One of "express" or "custom". Presence
+        // (regardless of value) suppresses the auto-welcome on subsequent
+        // GuildJoinEvent fires when the bot is re-invited.
+        INSTALL_MODE("INSTALL_MODE"),
+        // Epoch-millis string recording when the install wizard was completed.
+        INSTALLED_AT("INSTALLED_AT");
     }
 
     override fun toString(): String {

--- a/discord-bot/src/main/kotlin/bot/configuration/JdaListenerRegistrar.kt
+++ b/discord-bot/src/main/kotlin/bot/configuration/JdaListenerRegistrar.kt
@@ -11,6 +11,7 @@ import bot.toby.handler.ModalEventListener
 import bot.toby.handler.SlashCommandEventListener
 import bot.toby.handler.StartUpHandler
 import bot.toby.handler.VoiceEventHandler
+import bot.toby.install.InstallWelcomeHandler
 import net.dv8tion.jda.api.JDA
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
@@ -29,6 +30,7 @@ class JdaListenerRegistrar @Autowired constructor(
     activityEventHandler: ActivityEventHandler,
     eventWaiter: EventWaiter,
     guildLeaveCleanupHandler: GuildLeaveCleanupHandler,
+    installWelcomeHandler: InstallWelcomeHandler,
 ) {
     init {
         jda.addEventListener(
@@ -43,6 +45,7 @@ class JdaListenerRegistrar @Autowired constructor(
             activityEventHandler,
             eventWaiter,
             guildLeaveCleanupHandler,
+            installWelcomeHandler,
         )
     }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/install/ConfigReader.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/ConfigReader.kt
@@ -1,0 +1,11 @@
+package bot.toby.install
+
+import database.dto.ConfigDto.Configurations
+
+/**
+ * Reads the current value of a per-guild config key, returning null when
+ * the key is unset. Used throughout the install wizard to pre-populate
+ * modal fields and decide toggle/gate states without each handler
+ * re-implementing the lookup.
+ */
+typealias ConfigReader = (Configurations) -> String?

--- a/discord-bot/src/main/kotlin/bot/toby/install/InstallAuth.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/InstallAuth.kt
@@ -1,0 +1,36 @@
+package bot.toby.install
+
+import net.dv8tion.jda.api.interactions.callbacks.IReplyCallback
+
+/**
+ * Owner-gate helper shared by every install-wizard entry point (buttons,
+ * menus, slash command). Replies ephemerally with [message] and returns
+ * `false` when the caller isn't the guild owner; otherwise returns
+ * `true`. Callers branch on the result.
+ *
+ * Centralizing the check here means the wizard's permission policy
+ * (currently "guild owner only, may change in future") has exactly one
+ * implementation.
+ */
+object InstallAuth {
+
+    const val DEFAULT_MESSAGE: String = "Only the server owner can use the install wizard."
+
+    /** Override used by Express + Finish buttons (the "writes the install sentinel" flow). */
+    const val SETUP_MESSAGE: String = "Only the server owner can run install setup."
+
+    /** Override used by Skip. */
+    const val DISMISS_MESSAGE: String = "Only the server owner can dismiss the install prompt."
+
+    /** Override used by Back. */
+    const val NAVIGATE_MESSAGE: String = "Only the server owner can navigate the install wizard."
+
+    /** Override used by Toggle. */
+    const val TOGGLE_MESSAGE: String = "Only the server owner can toggle install settings."
+
+    fun requireOwner(event: IReplyCallback, message: String = DEFAULT_MESSAGE): Boolean {
+        if (event.member?.isOwner == true) return true
+        event.reply(message).setEphemeral(true).queue()
+        return false
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/install/InstallCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/InstallCommand.kt
@@ -1,0 +1,36 @@
+package bot.toby.install
+
+import bot.toby.command.commands.moderation.ModerationCommand
+import core.command.CommandContext
+import database.dto.UserDto
+import org.springframework.stereotype.Component
+
+/**
+ * `/install` — owner-only. Opens the in-Discord install wizard (welcome
+ * embed + Express / Custom / Skip buttons). Always re-runnable; idempotency
+ * for the auto-welcome on guild-join is enforced by the
+ * [InstallWelcomeHandler] checking the `INSTALL_MODE` sentinel.
+ */
+@Component
+class InstallCommand : ModerationCommand {
+
+    override val name = "install"
+    override val description = "Owner-only — open the bot's install / setup wizard."
+
+    override fun handle(ctx: CommandContext, requestingUserDto: UserDto, deleteDelay: Int) {
+        val event = ctx.event
+
+        if (ctx.member?.isOwner != true) {
+            event.reply("This is currently reserved for the owner of the server only, this may change in future")
+                .setEphemeral(true).queue()
+            return
+        }
+        val guild = event.guild ?: run {
+            event.reply("This command can only be used in a server.").setEphemeral(true).queue()
+            return
+        }
+        event.replyEmbeds(InstallWizard.welcomeEmbed(guild.name))
+            .addComponents(InstallWizard.wizardButtons())
+            .queue()
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/install/InstallCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/InstallCommand.kt
@@ -19,12 +19,7 @@ class InstallCommand : ModerationCommand {
 
     override fun handle(ctx: CommandContext, requestingUserDto: UserDto, deleteDelay: Int) {
         val event = ctx.event
-
-        if (ctx.member?.isOwner != true) {
-            event.reply("This is currently reserved for the owner of the server only, this may change in future")
-                .setEphemeral(true).queue()
-            return
-        }
+        if (!InstallAuth.requireOwner(event)) return
         val guild = event.guild ?: run {
             event.reply("This command can only be used in a server.").setEphemeral(true).queue()
             return

--- a/discord-bot/src/main/kotlin/bot/toby/install/InstallSentinel.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/InstallSentinel.kt
@@ -1,0 +1,28 @@
+package bot.toby.install
+
+import database.dto.ConfigDto.Configurations
+import database.service.ConfigService
+
+/**
+ * Records the install sentinel (`INSTALL_MODE` + `INSTALLED_AT`) the
+ * first time an owner completes the wizard, and is a no-op on every
+ * subsequent run. Owners who flip from Express to Custom (or vice-versa)
+ * via a second `/install` keep their original sentinel — the wizard
+ * doesn't reach for downgrade semantics that aren't there.
+ *
+ * Idempotency is value-agnostic: presence of `INSTALL_MODE` is the
+ * signal. Matches the same check in
+ * [InstallWelcomeHandler.onGuildJoin].
+ */
+object InstallSentinel {
+    fun writeIfFresh(configService: ConfigService, guildId: String, mode: String) {
+        val existing = configService.getConfigByName(Configurations.INSTALL_MODE.configValue, guildId)?.value
+        if (!existing.isNullOrBlank()) return
+        configService.upsertConfig(Configurations.INSTALL_MODE.configValue, mode, guildId)
+        configService.upsertConfig(
+            Configurations.INSTALLED_AT.configValue,
+            System.currentTimeMillis().toString(),
+            guildId,
+        )
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/install/InstallWelcomeHandler.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/InstallWelcomeHandler.kt
@@ -29,6 +29,21 @@ class InstallWelcomeHandler(
 
     override fun onGuildJoin(event: GuildJoinEvent) {
         val guild = event.guild
+        try {
+            postWelcomeOrDmOwner(guild)
+        } catch (e: Exception) {
+            // Bot just joined the guild — never let a transient failure
+            // (DB outage on the sentinel read, JDA queue failure, etc.)
+            // propagate up and kill the listener thread. The owner can
+            // always run /install manually.
+            logger.error {
+                "Install welcome failed for guild ${guild.id} (${guild.name}): " +
+                    "${e.javaClass.simpleName}: ${e.message}"
+            }
+        }
+    }
+
+    private fun postWelcomeOrDmOwner(guild: Guild) {
         val existingValue = configService.getConfigByName(Configurations.INSTALL_MODE.configValue, guild.id)?.value
         if (!existingValue.isNullOrBlank()) {
             logger.info { "Skipping welcome — guild ${guild.id} already installed ($existingValue)" }
@@ -47,7 +62,7 @@ class InstallWelcomeHandler(
         // can run /install from the server itself if they want the public
         // version.
         val owner = guild.owner ?: run {
-            logger.warn { "Guild ${guild.id} (${guild.name}) has no resolvable owner — cannot post welcome" }
+            logger.error { "Guild ${guild.id} (${guild.name}) has no resolvable owner AND no writable channel — install wizard is unreachable" }
             return
         }
         dmOwner(guild, owner)
@@ -58,10 +73,21 @@ class InstallWelcomeHandler(
             channel.sendMessageEmbeds(InstallWizard.dmWelcomeEmbed(guild.name))
                 .queue(
                     { logger.info { "DM'd install welcome to owner of ${guild.id} (${guild.name})" } },
-                    { err -> logger.warn { "Could not DM owner of ${guild.id}: ${err.message}" } },
+                    { err ->
+                        // Both the guild and the owner are unreachable — the wizard is
+                        // effectively undiscoverable until the owner runs /install manually.
+                        // ERROR level so this surfaces in alerting, not buried in WARN noise.
+                        logger.error {
+                            "Could not DM owner of guild ${guild.id} (${guild.name}); install wizard " +
+                                "is unreachable until /install is run manually: ${err.message}"
+                        }
+                    },
                 )
         }, { err ->
-            logger.warn { "Could not open DM with owner of ${guild.id}: ${err.message}" }
+            logger.error {
+                "Could not open DM channel with owner of guild ${guild.id} (${guild.name}); " +
+                    "install wizard is unreachable until /install is run manually: ${err.message}"
+            }
         })
     }
 

--- a/discord-bot/src/main/kotlin/bot/toby/install/InstallWelcomeHandler.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/InstallWelcomeHandler.kt
@@ -1,0 +1,77 @@
+package bot.toby.install
+
+import common.logging.DiscordLogger
+import database.dto.ConfigDto.Configurations
+import database.service.ConfigService
+import net.dv8tion.jda.api.Permission
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.Member
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
+import net.dv8tion.jda.api.events.guild.GuildJoinEvent
+import net.dv8tion.jda.api.hooks.ListenerAdapter
+import org.springframework.stereotype.Service
+
+/**
+ * Posts the install-wizard welcome message when the bot is added to a
+ * new guild. Idempotent: if `INSTALL_MODE` is already set (regardless of
+ * value) the handler returns silently, so re-invites don't double-prompt.
+ *
+ * Channel selection prefers `guild.systemChannel`, falling back to the
+ * first text channel the bot can both view and send in. If no writable
+ * channel exists, the handler logs a warning and returns.
+ */
+@Service
+class InstallWelcomeHandler(
+    private val configService: ConfigService,
+) : ListenerAdapter() {
+
+    private val logger: DiscordLogger = DiscordLogger.createLogger(this::class.java)
+
+    override fun onGuildJoin(event: GuildJoinEvent) {
+        val guild = event.guild
+        val existingValue = configService.getConfigByName(Configurations.INSTALL_MODE.configValue, guild.id)?.value
+        if (!existingValue.isNullOrBlank()) {
+            logger.info { "Skipping welcome — guild ${guild.id} already installed ($existingValue)" }
+            return
+        }
+        val channel = pickWelcomeChannel(guild)
+        if (channel != null) {
+            channel.sendMessageEmbeds(InstallWizard.welcomeEmbed(guild.name))
+                .addComponents(InstallWizard.wizardButtons())
+                .queue()
+            logger.info { "Posted install welcome to ${guild.id} in #${channel.name}" }
+            return
+        }
+        // No writable channel — fall back to DMing the guild owner so the
+        // wizard is still discoverable in locked-down servers. The owner
+        // can run /install from the server itself if they want the public
+        // version.
+        val owner = guild.owner ?: run {
+            logger.warn { "Guild ${guild.id} (${guild.name}) has no resolvable owner — cannot post welcome" }
+            return
+        }
+        dmOwner(guild, owner)
+    }
+
+    private fun dmOwner(guild: Guild, owner: Member) {
+        owner.user.openPrivateChannel().queue({ channel ->
+            channel.sendMessageEmbeds(InstallWizard.dmWelcomeEmbed(guild.name))
+                .queue(
+                    { logger.info { "DM'd install welcome to owner of ${guild.id} (${guild.name})" } },
+                    { err -> logger.warn { "Could not DM owner of ${guild.id}: ${err.message}" } },
+                )
+        }, { err ->
+            logger.warn { "Could not open DM with owner of ${guild.id}: ${err.message}" }
+        })
+    }
+
+    private fun pickWelcomeChannel(guild: Guild): TextChannel? {
+        val self = guild.selfMember
+        guild.systemChannel
+            ?.takeIf { self.hasPermission(it, Permission.VIEW_CHANNEL, Permission.MESSAGE_SEND) }
+            ?.let { return it }
+        return guild.textChannels.firstOrNull {
+            self.hasPermission(it, Permission.VIEW_CHANNEL, Permission.MESSAGE_SEND)
+        }
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/install/InstallWizard.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/InstallWizard.kt
@@ -1,6 +1,7 @@
 package bot.toby.install
 
 import database.dto.ConfigDto.Configurations
+import database.service.ConfigService
 import net.dv8tion.jda.api.EmbedBuilder
 import net.dv8tion.jda.api.components.actionrow.ActionRow
 import net.dv8tion.jda.api.components.buttons.Button
@@ -21,6 +22,19 @@ import net.dv8tion.jda.api.entities.MessageEmbed
  * opt-in is off.
  */
 object InstallWizard {
+
+    /** A function that returns the current value of a per-guild config key, or null if unset. */
+    typealias ConfigReader = (Configurations) -> String?
+
+    /** Build the standard config-value reader bound to a specific guild. */
+    fun configReader(configService: ConfigService, guildId: String): ConfigReader =
+        { key -> configService.getConfigByName(key.configValue, guildId)?.value }
+
+    /** Build the two-row component set for the custom-setup root view. */
+    fun customRootRows(reader: ConfigReader): Array<ActionRow> = arrayOf(
+        ActionRow.of(sectionMenu(reader)),
+        customRootBottomRow(),
+    )
 
     // ---- componentId namespace ----
     const val BTN_EXPRESS = "install_express"

--- a/discord-bot/src/main/kotlin/bot/toby/install/InstallWizard.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/InstallWizard.kt
@@ -1,6 +1,5 @@
 package bot.toby.install
 
-import database.dto.ConfigDto.Configurations
 import database.service.ConfigService
 import net.dv8tion.jda.api.EmbedBuilder
 import net.dv8tion.jda.api.components.actionrow.ActionRow
@@ -23,15 +22,12 @@ import net.dv8tion.jda.api.entities.MessageEmbed
  */
 object InstallWizard {
 
-    /** A function that returns the current value of a per-guild config key, or null if unset. */
-    typealias ConfigReader = (Configurations) -> String?
-
     /** Build the standard config-value reader bound to a specific guild. */
     fun configReader(configService: ConfigService, guildId: String): ConfigReader =
         { key -> configService.getConfigByName(key.configValue, guildId)?.value }
 
     /** Build the two-row component set for the custom-setup root view. */
-    fun customRootRows(reader: ConfigReader): Array<ActionRow> = arrayOf(
+    fun customRootRows(reader: ConfigReader): List<ActionRow> = listOf(
         ActionRow.of(sectionMenu(reader)),
         customRootBottomRow(),
     )
@@ -176,7 +172,7 @@ object InstallWizard {
      * out when their respective opt-in is off. Always non-empty: the
      * General/Economy/Poker/Blackjack sections have no gate.
      */
-    fun sectionMenu(currentValues: (Configurations) -> String?): StringSelectMenu {
+    fun sectionMenu(currentValues: ConfigReader): StringSelectMenu {
         val builder = StringSelectMenu.create(MENU_SECTION).setPlaceholder("Pick a section to tune")
         WizardSection.visibleFor(currentValues).forEach { section ->
             builder.addOptions(
@@ -221,7 +217,7 @@ object InstallWizard {
      * One toggle button per [OptInFeatures] entry, labelled + styled to
      * reflect the supplied current-value reader.
      */
-    fun toggleRow(currentValues: (Configurations) -> String?): ActionRow {
+    fun toggleRow(currentValues: ConfigReader): ActionRow {
         val buttons = OptInFeatures.entries.map { feature ->
             val on = currentValues(feature.key) == "true"
             val state = if (on) "ON" else "OFF"

--- a/discord-bot/src/main/kotlin/bot/toby/install/InstallWizard.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/InstallWizard.kt
@@ -1,0 +1,220 @@
+package bot.toby.install
+
+import database.dto.ConfigDto.Configurations
+import net.dv8tion.jda.api.EmbedBuilder
+import net.dv8tion.jda.api.components.actionrow.ActionRow
+import net.dv8tion.jda.api.components.buttons.Button
+import net.dv8tion.jda.api.components.selections.SelectOption
+import net.dv8tion.jda.api.components.selections.StringSelectMenu
+import net.dv8tion.jda.api.entities.MessageEmbed
+
+/**
+ * Shared constants + factories for the in-Discord install wizard. Every
+ * embed and component used across the wizard's handlers is built here so
+ * IDs and copy live in one place.
+ *
+ * The custom-setup flow is two-tier: a top-level "Section" menu groups
+ * the 12 setconfig categories thematically (General, Economy, Poker,
+ * Blackjack, Activity, Lottery). Picking a section opens a second menu
+ * listing the categories within it. This keeps the dropdown short and
+ * lets gated sections (Activity, Lottery) drop out cleanly when their
+ * opt-in is off.
+ */
+object InstallWizard {
+
+    // ---- componentId namespace ----
+    const val BTN_EXPRESS = "install_express"
+    const val BTN_CUSTOM = "install_custom"
+    const val BTN_SKIP = "install_skip"
+    const val BTN_FINISH = "install_finish"
+    const val BTN_BACK = "install_category_back"
+    const val BTN_FEATURES = "install_features"
+    const val BTN_TOGGLE_PREFIX = "install_toggle"
+
+    const val MENU_SECTION = "install_section"
+    const val MENU_SECTION_DETAIL_PREFIX = "install_section_detail"
+    const val MENU_CATEGORY_STAKES = "install_category_stakes"
+
+    /** Synthetic stake-modal token for "Apply to all games". */
+    const val STAKE_ALL_TOKEN = "all_games"
+
+    fun sectionDetailMenuId(sectionId: String): String = "$MENU_SECTION_DETAIL_PREFIX:$sectionId"
+
+    // ---- embed factories ----
+
+    fun welcomeEmbed(guildName: String): MessageEmbed = EmbedBuilder()
+        .setTitle("Welcome to $guildName!")
+        .setDescription(
+            "Pick how you'd like to set the bot up:\n\n" +
+                "**▸ Express setup** — accept all defaults and get going in one click. " +
+                "Defaults include:\n" +
+                "  • Audio at full volume, message auto-delete on\n" +
+                "  • Activity tracking **OFF** (no XP / leaderboards)\n" +
+                "  • Daily lottery **OFF**\n" +
+                "  • Casino games enabled with conservative stake bounds\n" +
+                "  • Jackpot pool wired up but moderate (10% loss-tribute, 1% win-chance)\n\n" +
+                "**▸ Custom setup** — pick categories to tune now (audio, channels, casino rules, lottery). " +
+                "Anything you skip falls back to the defaults above; `/setconfig` is available anytime for fine-tuning.\n\n" +
+                "**▸ Skip for now** — dismiss this prompt. Run `/install` anytime to come back.\n\n" +
+                "_Only the server owner can use these buttons._"
+        )
+        .build()
+
+    /**
+     * DM fallback variant of the welcome message — used when the bot has
+     * no writable channel in the guild. Discord buttons in a DM can't
+     * resolve guild context reliably, so this variant just nudges the
+     * owner to run `/install` (or grant the bot a channel) instead of
+     * embedding clickable wizard buttons.
+     */
+    fun dmWelcomeEmbed(guildName: String): MessageEmbed = EmbedBuilder()
+        .setTitle("toby-bot joined $guildName")
+        .setDescription(
+            "Thanks for adding me! I couldn't find a channel I had permission to post in, " +
+                "so I'm reaching out here.\n\n" +
+                "To finish setup, head into **$guildName** and run **`/install`** — that opens the " +
+                "Express / Custom / Skip wizard. If you'd rather I post the wizard publicly, give me " +
+                "**View Channel** + **Send Messages** in any channel and re-invite me, or just run " +
+                "`/install` from inside the server."
+        )
+        .build()
+
+    fun expressDoneEmbed(): MessageEmbed = EmbedBuilder()
+        .setTitle("You're all set!")
+        .setDescription(
+            "The bot is running on defaults. Use `/setconfig <category>` anytime to fine-tune settings, " +
+                "or `/install` to re-open this wizard."
+        )
+        .build()
+
+    fun customSectionEmbed(): MessageEmbed = EmbedBuilder()
+        .setTitle("Custom setup")
+        .setDescription(
+            "Pick a section, then a category within it to edit. Each opens a form pre-filled with the " +
+                "current values — leave any field blank to keep it. Click **Finish** when you're done.\n\n" +
+                "Click **Optional features** anytime to toggle activity tracking or the daily lottery."
+        )
+        .build()
+
+    fun sectionDetailEmbed(section: WizardSection): MessageEmbed = EmbedBuilder()
+        .setTitle(section.label)
+        .setDescription(
+            "${section.description}\n\n" +
+                "Pick a category to edit. Click **← Back** to return to the section list."
+        )
+        .build()
+
+    fun stakesGameMenuEmbed(): MessageEmbed = EmbedBuilder()
+        .setTitle("Per-game stake bounds")
+        .setDescription(
+            "Pick **Apply to all games** to write the same min/max to every game in one shot, " +
+                "or pick a game to tune its bounds individually. Click **← Back** to return."
+        )
+        .build()
+
+    fun togglesEmbed(): MessageEmbed = EmbedBuilder()
+        .setTitle("Optional features")
+        .setDescription(
+            "Toggle these on or off:\n\n" +
+                OptInFeatures.entries.joinToString("\n") { "• **${it.label}** — ${it.description}" } +
+                "\n\nClick **← Back** when you're done."
+        )
+        .build()
+
+    fun skipDismissedEmbed(): MessageEmbed = EmbedBuilder()
+        .setTitle("Install skipped")
+        .setDescription("No changes were made. Run `/install` whenever you'd like to come back.")
+        .build()
+
+    fun finishDoneEmbed(): MessageEmbed = EmbedBuilder()
+        .setTitle("Custom setup complete")
+        .setDescription("Your settings are saved. Use `/setconfig <category>` anytime to keep tuning.")
+        .build()
+
+    // ---- component factories ----
+
+    fun wizardButtons(): ActionRow = ActionRow.of(
+        Button.success(BTN_EXPRESS, "Express setup"),
+        Button.primary(BTN_CUSTOM, "Custom setup"),
+        Button.secondary(BTN_SKIP, "Skip for now"),
+    )
+
+    fun finishButtonRow(): ActionRow = ActionRow.of(
+        Button.success(BTN_FINISH, "Finish"),
+    )
+
+    fun backButtonRow(): ActionRow = ActionRow.of(
+        Button.secondary(BTN_BACK, "← Back"),
+    )
+
+    fun customRootBottomRow(): ActionRow = ActionRow.of(
+        Button.secondary(BTN_FEATURES, "Optional features"),
+        Button.success(BTN_FINISH, "Finish"),
+    )
+
+    fun backAndFinishRow(): ActionRow = ActionRow.of(
+        Button.secondary(BTN_BACK, "← Back"),
+        Button.success(BTN_FINISH, "Finish"),
+    )
+
+    /**
+     * Top-level section picker. Gated sections (Activity, Lottery) drop
+     * out when their respective opt-in is off. Always non-empty: the
+     * General/Economy/Poker/Blackjack sections have no gate.
+     */
+    fun sectionMenu(currentValues: (Configurations) -> String?): StringSelectMenu {
+        val builder = StringSelectMenu.create(MENU_SECTION).setPlaceholder("Pick a section to tune")
+        WizardSection.visibleFor(currentValues).forEach { section ->
+            builder.addOptions(
+                SelectOption.of(section.label, section.id).withDescription(section.description),
+            )
+        }
+        return builder.build()
+    }
+
+    /**
+     * Second-tier menu — the categories within a specific section. The
+     * componentId includes the section id so the menu handler knows which
+     * section we're in (and can rearm appropriately after a modal closes).
+     */
+    fun sectionDetailMenu(section: WizardSection): StringSelectMenu {
+        val builder = StringSelectMenu.create(sectionDetailMenuId(section.id))
+            .setPlaceholder("Pick a category to edit")
+        section.categories.forEach { cat ->
+            builder.addOptions(SelectOption.of(cat.label, cat.token).withDescription(cat.description))
+        }
+        return builder.build()
+    }
+
+    /**
+     * Per-game stakes picker. The first entry is "Apply to all games" so
+     * owners with uniform stake bounds across games can write them in
+     * a single modal. Other entries are the individual game tokens.
+     */
+    fun stakesGameMenu(games: List<Pair<String, String>>): StringSelectMenu {
+        val builder = StringSelectMenu.create(MENU_CATEGORY_STAKES).setPlaceholder("Pick a game (or all)")
+        builder.addOptions(
+            SelectOption.of("Apply to all games", STAKE_ALL_TOKEN)
+                .withDescription("Writes the same min/max to every game in one shot"),
+        )
+        games.forEach { (label, token) ->
+            builder.addOption(label, token)
+        }
+        return builder.build()
+    }
+
+    /**
+     * One toggle button per [OptInFeatures] entry, labelled + styled to
+     * reflect the supplied current-value reader.
+     */
+    fun toggleRow(currentValues: (Configurations) -> String?): ActionRow {
+        val buttons = OptInFeatures.entries.map { feature ->
+            val on = currentValues(feature.key) == "true"
+            val state = if (on) "ON" else "OFF"
+            val id = "$BTN_TOGGLE_PREFIX:${feature.key.name}"
+            if (on) Button.success(id, "${feature.label}: $state")
+            else Button.secondary(id, "${feature.label}: $state")
+        }
+        return ActionRow.of(buttons)
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/install/OptInFeatures.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/OptInFeatures.kt
@@ -1,0 +1,31 @@
+package bot.toby.install
+
+import database.dto.ConfigDto.Configurations
+
+/**
+ * Single source of truth for the feature toggles surfaced in the install
+ * wizard's "Optional features" view. Adding a new opt-in elsewhere in the
+ * config schema is a one-line change here — the toggle row, embed, and
+ * tests iterate this enum.
+ */
+enum class OptInFeatures(
+    val key: Configurations,
+    val label: String,
+    val description: String,
+) {
+    ACTIVITY_TRACKING(
+        Configurations.ACTIVITY_TRACKING,
+        "Activity tracking",
+        "Track per-user message activity for XP, leaderboards, and jackpot eligibility.",
+    ),
+    LOTTERY_DAILY(
+        Configurations.LOTTERY_DAILY_ENABLED,
+        "Daily lottery",
+        "Auto-draw Pick-5-of-49 lottery at 00:00 UTC, funded by jackpot pool + tickets.",
+    ),
+    ;
+
+    companion object {
+        fun byKeyName(name: String): OptInFeatures? = entries.find { it.key.name == name }
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/install/WizardSection.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/WizardSection.kt
@@ -1,0 +1,107 @@
+package bot.toby.install
+
+import bot.toby.command.commands.moderation.SetConfigCommand
+
+/** Synthetic category token for the EntitySelectMenu-backed quick channels modal. */
+const val QUICK_CHANNELS_TOKEN = "quick_channels"
+
+/**
+ * Groups the 12 setconfig categories into themed sections so the custom
+ * install flow is two-clicks-to-modal instead of a 13-deep dropdown.
+ *
+ * `gate` (if non-null) hides the entire section from the section picker
+ * when the gated opt-in is off — so e.g. with the daily lottery disabled,
+ * the "Lottery" section disappears, and tuning lottery-only configs
+ * doesn't dilute the menu.
+ */
+enum class WizardSection(
+    val id: String,
+    val label: String,
+    val description: String,
+    val gate: OptInFeatures?,
+    val categories: List<SectionCategory>,
+) {
+    GENERAL(
+        id = "general",
+        label = "General settings",
+        description = "Audio defaults, delete delay, move + leaderboard channels",
+        gate = null,
+        categories = listOf(
+            SectionCategory(QUICK_CHANNELS_TOKEN, "Quick channels", "Pick your voice + text channels from a list (no IDs)"),
+            SectionCategory(SetConfigCommand.SUB_GENERAL, "All general settings", "Audio + auto-delete + channels (typed values)"),
+        ),
+    ),
+    ECONOMY(
+        id = "economy",
+        label = "Economy & casino",
+        description = "Fees, jackpot, per-game stake bounds",
+        gate = null,
+        categories = listOf(
+            SectionCategory(SetConfigCommand.SUB_FEES, "Fees", "Loss tribute %, jackpot win %, Toby Coin trade fees"),
+            SectionCategory(SetConfigCommand.SUB_JACKPOT, "Jackpot", "Stake anchor, cooldown, RTP gate, modlog channel"),
+            SectionCategory(SetConfigCommand.SUB_STAKES, "Per-game stakes", "Min/max stake bounds (apply to all or drill down)"),
+        ),
+    ),
+    ACTIVITY(
+        id = "activity",
+        label = "Activity tracking",
+        description = "XP, leaderboards, jackpot eligibility",
+        gate = OptInFeatures.ACTIVITY_TRACKING,
+        categories = listOf(
+            SectionCategory(SetConfigCommand.SUB_ACTIVITY, "Activity config", "UBI, daily credit cap, XP bonus, tracking toggle"),
+            SectionCategory(SetConfigCommand.SUB_JACKPOT_ACTIVITY, "Jackpot eligibility", "Activity-day window"),
+        ),
+    ),
+    POKER(
+        id = "poker",
+        label = "Poker",
+        description = "Stakes, table, shot clock",
+        gate = null,
+        categories = listOf(
+            SectionCategory(SetConfigCommand.SUB_POKER_STAKES, "Poker stakes", "Blinds, bets, rake"),
+            SectionCategory(SetConfigCommand.SUB_POKER_TABLE, "Poker table", "Buy-ins, seats, shot clock"),
+        ),
+    ),
+    BLACKJACK(
+        id = "blackjack",
+        label = "Blackjack",
+        description = "Rules, payouts, seats",
+        gate = null,
+        categories = listOf(
+            SectionCategory(SetConfigCommand.SUB_BLACKJACK_RULES, "Blackjack rules", "Rake, ante, dealer rule, shot clock"),
+            SectionCategory(SetConfigCommand.SUB_BLACKJACK_TABLE, "Blackjack table", "Seats + natural payout ratio"),
+        ),
+    ),
+    LOTTERY(
+        id = "lottery",
+        label = "Daily lottery",
+        description = "Ticket pricing, mode, pools, announce channel",
+        gate = OptInFeatures.LOTTERY_DAILY,
+        categories = listOf(
+            SectionCategory(SetConfigCommand.SUB_LOTTERY_BASICS, "Lottery basics", "On/off, ticket price, mode, ping"),
+            SectionCategory(SetConfigCommand.SUB_LOTTERY_POOLS, "Lottery pools", "Seed/revenue split + announce channel"),
+        ),
+    ),
+    ;
+
+    companion object {
+        fun byId(id: String): WizardSection? = entries.find { it.id == id }
+
+        /**
+         * Sections to show given the current opt-in state. Gated sections
+         * fall out when their toggle is off (`"true"` is the on-signal;
+         * anything else is off).
+         */
+        fun visibleFor(currentValues: (database.dto.ConfigDto.Configurations) -> String?): List<WizardSection> =
+            entries.filter { section ->
+                val gate = section.gate ?: return@filter true
+                currentValues(gate.key) == "true"
+            }
+    }
+}
+
+data class SectionCategory(
+    val token: String,
+    val label: String,
+    val description: String,
+)

--- a/discord-bot/src/main/kotlin/bot/toby/install/WizardSection.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/WizardSection.kt
@@ -92,7 +92,7 @@ enum class WizardSection(
          * fall out when their toggle is off (`"true"` is the on-signal;
          * anything else is off).
          */
-        fun visibleFor(currentValues: (database.dto.ConfigDto.Configurations) -> String?): List<WizardSection> =
+        fun visibleFor(currentValues: ConfigReader): List<WizardSection> =
             entries.filter { section ->
                 val gate = section.gate ?: return@filter true
                 currentValues(gate.key) == "true"

--- a/discord-bot/src/main/kotlin/bot/toby/install/button/InstallBackButton.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/button/InstallBackButton.kt
@@ -1,12 +1,9 @@
 package bot.toby.install.button
 
 import bot.toby.install.InstallWizard
-import core.button.Button
 import core.button.ButtonContext
-import database.dto.ConfigDto.Configurations
 import database.dto.UserDto
 import database.service.ConfigService
-import net.dv8tion.jda.api.components.actionrow.ActionRow
 import org.springframework.stereotype.Component
 
 /**
@@ -18,28 +15,18 @@ import org.springframework.stereotype.Component
 @Component
 class InstallBackButton(
     private val configService: ConfigService,
-) : Button {
+) : OwnerOnlyInstallButton() {
 
     override val name: String = InstallWizard.BTN_BACK
     override val description: String = "Return to the custom-install section menu."
-    override val defersReply: Boolean = false
+    override fun ownerErrorMessage(): String = "Only the server owner can navigate the install wizard."
 
-    override fun handle(ctx: ButtonContext, requestingUserDto: UserDto, deleteDelay: Int) {
+    override fun handleAsOwner(ctx: ButtonContext, requestingUserDto: UserDto, deleteDelay: Int) {
         val event = ctx.event
-        if (event.member?.isOwner != true) {
-            event.reply("Only the server owner can navigate the install wizard.")
-                .setEphemeral(true).queue()
-            return
-        }
         event.deferEdit().queue()
-        val guildId = ctx.guild.id
-        val reader: (Configurations) -> String? =
-            { key -> configService.getConfigByName(key.configValue, guildId)?.value }
+        val reader = InstallWizard.configReader(configService, ctx.guild.id)
         event.hook.editOriginalEmbeds(InstallWizard.customSectionEmbed())
-            .setComponents(
-                ActionRow.of(InstallWizard.sectionMenu(reader)),
-                InstallWizard.customRootBottomRow(),
-            )
+            .setComponents(*InstallWizard.customRootRows(reader))
             .queue()
     }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/install/button/InstallBackButton.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/button/InstallBackButton.kt
@@ -1,0 +1,45 @@
+package bot.toby.install.button
+
+import bot.toby.install.InstallWizard
+import core.button.Button
+import core.button.ButtonContext
+import database.dto.ConfigDto.Configurations
+import database.dto.UserDto
+import database.service.ConfigService
+import net.dv8tion.jda.api.components.actionrow.ActionRow
+import org.springframework.stereotype.Component
+
+/**
+ * "← Back" — restores the custom-setup root (section menu +
+ * Optional-features button + Finish). Used from the section-detail menu,
+ * the stakes-game sub-menu, and the toggles view. The target state is
+ * the same in all three cases, so the handler is unconditional.
+ */
+@Component
+class InstallBackButton(
+    private val configService: ConfigService,
+) : Button {
+
+    override val name: String = InstallWizard.BTN_BACK
+    override val description: String = "Return to the custom-install section menu."
+    override val defersReply: Boolean = false
+
+    override fun handle(ctx: ButtonContext, requestingUserDto: UserDto, deleteDelay: Int) {
+        val event = ctx.event
+        if (event.member?.isOwner != true) {
+            event.reply("Only the server owner can navigate the install wizard.")
+                .setEphemeral(true).queue()
+            return
+        }
+        event.deferEdit().queue()
+        val guildId = ctx.guild.id
+        val reader: (Configurations) -> String? =
+            { key -> configService.getConfigByName(key.configValue, guildId)?.value }
+        event.hook.editOriginalEmbeds(InstallWizard.customSectionEmbed())
+            .setComponents(
+                ActionRow.of(InstallWizard.sectionMenu(reader)),
+                InstallWizard.customRootBottomRow(),
+            )
+            .queue()
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/install/button/InstallBackButton.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/button/InstallBackButton.kt
@@ -1,5 +1,6 @@
 package bot.toby.install.button
 
+import bot.toby.install.InstallAuth
 import bot.toby.install.InstallWizard
 import core.button.ButtonContext
 import database.dto.UserDto
@@ -19,14 +20,14 @@ class InstallBackButton(
 
     override val name: String = InstallWizard.BTN_BACK
     override val description: String = "Return to the custom-install section menu."
-    override fun ownerErrorMessage(): String = "Only the server owner can navigate the install wizard."
+    override fun ownerErrorMessage(): String = InstallAuth.NAVIGATE_MESSAGE
 
     override fun handleAsOwner(ctx: ButtonContext, requestingUserDto: UserDto, deleteDelay: Int) {
         val event = ctx.event
         event.deferEdit().queue()
         val reader = InstallWizard.configReader(configService, ctx.guild.id)
         event.hook.editOriginalEmbeds(InstallWizard.customSectionEmbed())
-            .setComponents(*InstallWizard.customRootRows(reader))
+            .setComponents(InstallWizard.customRootRows(reader))
             .queue()
     }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/install/button/InstallCustomButton.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/button/InstallCustomButton.kt
@@ -1,5 +1,6 @@
 package bot.toby.install.button
 
+import bot.toby.install.InstallAuth
 import bot.toby.install.InstallWizard
 import core.button.ButtonContext
 import database.dto.UserDto
@@ -19,14 +20,14 @@ class InstallCustomButton(
 
     override val name: String = InstallWizard.BTN_CUSTOM
     override val description: String = "Open the custom-install section menu."
-    override fun ownerErrorMessage(): String = OWNER_ERROR_SETUP
+    override fun ownerErrorMessage(): String = InstallAuth.SETUP_MESSAGE
 
     override fun handleAsOwner(ctx: ButtonContext, requestingUserDto: UserDto, deleteDelay: Int) {
         val event = ctx.event
         event.deferEdit().queue()
         val reader = InstallWizard.configReader(configService, ctx.guild.id)
         event.hook.editOriginalEmbeds(InstallWizard.customSectionEmbed())
-            .setComponents(*InstallWizard.customRootRows(reader))
+            .setComponents(InstallWizard.customRootRows(reader))
             .queue()
     }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/install/button/InstallCustomButton.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/button/InstallCustomButton.kt
@@ -1,12 +1,9 @@
 package bot.toby.install.button
 
 import bot.toby.install.InstallWizard
-import core.button.Button
 import core.button.ButtonContext
-import database.dto.ConfigDto.Configurations
 import database.dto.UserDto
 import database.service.ConfigService
-import net.dv8tion.jda.api.components.actionrow.ActionRow
 import org.springframework.stereotype.Component
 
 /**
@@ -18,28 +15,18 @@ import org.springframework.stereotype.Component
 @Component
 class InstallCustomButton(
     private val configService: ConfigService,
-) : Button {
+) : OwnerOnlyInstallButton() {
 
     override val name: String = InstallWizard.BTN_CUSTOM
     override val description: String = "Open the custom-install section menu."
-    override val defersReply: Boolean = false
+    override fun ownerErrorMessage(): String = OWNER_ERROR_SETUP
 
-    override fun handle(ctx: ButtonContext, requestingUserDto: UserDto, deleteDelay: Int) {
+    override fun handleAsOwner(ctx: ButtonContext, requestingUserDto: UserDto, deleteDelay: Int) {
         val event = ctx.event
-        if (event.member?.isOwner != true) {
-            event.reply("Only the server owner can run install setup.")
-                .setEphemeral(true).queue()
-            return
-        }
         event.deferEdit().queue()
-        val guildId = ctx.guild.id
-        val reader: (Configurations) -> String? =
-            { key -> configService.getConfigByName(key.configValue, guildId)?.value }
+        val reader = InstallWizard.configReader(configService, ctx.guild.id)
         event.hook.editOriginalEmbeds(InstallWizard.customSectionEmbed())
-            .setComponents(
-                ActionRow.of(InstallWizard.sectionMenu(reader)),
-                InstallWizard.customRootBottomRow(),
-            )
+            .setComponents(*InstallWizard.customRootRows(reader))
             .queue()
     }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/install/button/InstallCustomButton.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/button/InstallCustomButton.kt
@@ -1,0 +1,45 @@
+package bot.toby.install.button
+
+import bot.toby.install.InstallWizard
+import core.button.Button
+import core.button.ButtonContext
+import database.dto.ConfigDto.Configurations
+import database.dto.UserDto
+import database.service.ConfigService
+import net.dv8tion.jda.api.components.actionrow.ActionRow
+import org.springframework.stereotype.Component
+
+/**
+ * "Custom setup" — swaps the welcome embed + buttons for the section
+ * menu + the Optional-features and Finish buttons. No DB writes happen
+ * here; the install sentinel is recorded only when the owner clicks
+ * Finish.
+ */
+@Component
+class InstallCustomButton(
+    private val configService: ConfigService,
+) : Button {
+
+    override val name: String = InstallWizard.BTN_CUSTOM
+    override val description: String = "Open the custom-install section menu."
+    override val defersReply: Boolean = false
+
+    override fun handle(ctx: ButtonContext, requestingUserDto: UserDto, deleteDelay: Int) {
+        val event = ctx.event
+        if (event.member?.isOwner != true) {
+            event.reply("Only the server owner can run install setup.")
+                .setEphemeral(true).queue()
+            return
+        }
+        event.deferEdit().queue()
+        val guildId = ctx.guild.id
+        val reader: (Configurations) -> String? =
+            { key -> configService.getConfigByName(key.configValue, guildId)?.value }
+        event.hook.editOriginalEmbeds(InstallWizard.customSectionEmbed())
+            .setComponents(
+                ActionRow.of(InstallWizard.sectionMenu(reader)),
+                InstallWizard.customRootBottomRow(),
+            )
+            .queue()
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/install/button/InstallExpressButton.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/button/InstallExpressButton.kt
@@ -1,0 +1,49 @@
+package bot.toby.install.button
+
+import bot.toby.install.InstallWizard
+import core.button.Button
+import core.button.ButtonContext
+import database.dto.ConfigDto.Configurations
+import database.dto.UserDto
+import database.service.ConfigService
+import org.springframework.stereotype.Component
+
+/**
+ * "Express setup" — records the install sentinel (`INSTALL_MODE=express` +
+ * `INSTALLED_AT=<now>`) and shows the optional-features toggle row so the
+ * owner can flip on activity tracking / daily lottery without leaving the
+ * wizard. A "Done" button on the same row ends the express path.
+ */
+@Component
+class InstallExpressButton(
+    private val configService: ConfigService,
+) : Button {
+
+    override val name: String = InstallWizard.BTN_EXPRESS
+    override val description: String = "Apply default settings and finish install."
+    override val defersReply: Boolean = false
+
+    override fun handle(ctx: ButtonContext, requestingUserDto: UserDto, deleteDelay: Int) {
+        val event = ctx.event
+        if (event.member?.isOwner != true) {
+            event.reply("Only the server owner can run install setup.")
+                .setEphemeral(true).queue()
+            return
+        }
+        event.deferEdit().queue()
+        val guildId = ctx.guild.id
+        configService.upsertConfig(Configurations.INSTALL_MODE.configValue, "express", guildId)
+        configService.upsertConfig(
+            Configurations.INSTALLED_AT.configValue,
+            System.currentTimeMillis().toString(),
+            guildId,
+        )
+        // One-click Express: write sentinel, show the final done embed,
+        // strip components. Owners who want to opt in to lottery /
+        // activity tracking can use /install → Custom → Optional features
+        // (or /setconfig directly).
+        event.hook.editOriginalEmbeds(InstallWizard.expressDoneEmbed())
+            .setComponents()
+            .queue()
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/install/button/InstallExpressButton.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/button/InstallExpressButton.kt
@@ -1,5 +1,6 @@
 package bot.toby.install.button
 
+import bot.toby.install.InstallAuth
 import bot.toby.install.InstallSentinel
 import bot.toby.install.InstallWizard
 import core.button.ButtonContext
@@ -24,7 +25,7 @@ class InstallExpressButton(
 
     override val name: String = InstallWizard.BTN_EXPRESS
     override val description: String = "Apply default settings and finish install."
-    override fun ownerErrorMessage(): String = OWNER_ERROR_SETUP
+    override fun ownerErrorMessage(): String = InstallAuth.SETUP_MESSAGE
 
     override fun handleAsOwner(ctx: ButtonContext, requestingUserDto: UserDto, deleteDelay: Int) {
         val event = ctx.event
@@ -35,5 +36,3 @@ class InstallExpressButton(
             .queue()
     }
 }
-
-internal const val OWNER_ERROR_SETUP: String = "Only the server owner can run install setup."

--- a/discord-bot/src/main/kotlin/bot/toby/install/button/InstallExpressButton.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/button/InstallExpressButton.kt
@@ -1,49 +1,39 @@
 package bot.toby.install.button
 
+import bot.toby.install.InstallSentinel
 import bot.toby.install.InstallWizard
-import core.button.Button
 import core.button.ButtonContext
-import database.dto.ConfigDto.Configurations
 import database.dto.UserDto
 import database.service.ConfigService
 import org.springframework.stereotype.Component
 
 /**
- * "Express setup" — records the install sentinel (`INSTALL_MODE=express` +
- * `INSTALLED_AT=<now>`) and shows the optional-features toggle row so the
- * owner can flip on activity tracking / daily lottery without leaving the
- * wizard. A "Done" button on the same row ends the express path.
+ * "Express setup" — records the install sentinel
+ * (`INSTALL_MODE=express` + `INSTALLED_AT=<now>`) and strips the wizard
+ * components in one shot. No follow-up step.
+ *
+ * If `INSTALL_MODE` is already set (the owner re-ran `/install` after a
+ * previous install), the sentinel is NOT downgraded — we still show the
+ * done embed but skip the writes so the original install record stays
+ * intact.
  */
 @Component
 class InstallExpressButton(
     private val configService: ConfigService,
-) : Button {
+) : OwnerOnlyInstallButton() {
 
     override val name: String = InstallWizard.BTN_EXPRESS
     override val description: String = "Apply default settings and finish install."
-    override val defersReply: Boolean = false
+    override fun ownerErrorMessage(): String = OWNER_ERROR_SETUP
 
-    override fun handle(ctx: ButtonContext, requestingUserDto: UserDto, deleteDelay: Int) {
+    override fun handleAsOwner(ctx: ButtonContext, requestingUserDto: UserDto, deleteDelay: Int) {
         val event = ctx.event
-        if (event.member?.isOwner != true) {
-            event.reply("Only the server owner can run install setup.")
-                .setEphemeral(true).queue()
-            return
-        }
         event.deferEdit().queue()
-        val guildId = ctx.guild.id
-        configService.upsertConfig(Configurations.INSTALL_MODE.configValue, "express", guildId)
-        configService.upsertConfig(
-            Configurations.INSTALLED_AT.configValue,
-            System.currentTimeMillis().toString(),
-            guildId,
-        )
-        // One-click Express: write sentinel, show the final done embed,
-        // strip components. Owners who want to opt in to lottery /
-        // activity tracking can use /install → Custom → Optional features
-        // (or /setconfig directly).
+        InstallSentinel.writeIfFresh(configService, ctx.guild.id, mode = "express")
         event.hook.editOriginalEmbeds(InstallWizard.expressDoneEmbed())
             .setComponents()
             .queue()
     }
 }
+
+internal const val OWNER_ERROR_SETUP: String = "Only the server owner can run install setup."

--- a/discord-bot/src/main/kotlin/bot/toby/install/button/InstallFeaturesButton.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/button/InstallFeaturesButton.kt
@@ -1,9 +1,7 @@
 package bot.toby.install.button
 
 import bot.toby.install.InstallWizard
-import core.button.Button
 import core.button.ButtonContext
-import database.dto.ConfigDto.Configurations
 import database.dto.UserDto
 import database.service.ConfigService
 import org.springframework.stereotype.Component
@@ -16,23 +14,15 @@ import org.springframework.stereotype.Component
 @Component
 class InstallFeaturesButton(
     private val configService: ConfigService,
-) : Button {
+) : OwnerOnlyInstallButton() {
 
     override val name: String = InstallWizard.BTN_FEATURES
     override val description: String = "Open the optional-features toggle view."
-    override val defersReply: Boolean = false
 
-    override fun handle(ctx: ButtonContext, requestingUserDto: UserDto, deleteDelay: Int) {
+    override fun handleAsOwner(ctx: ButtonContext, requestingUserDto: UserDto, deleteDelay: Int) {
         val event = ctx.event
-        if (event.member?.isOwner != true) {
-            event.reply("Only the server owner can use the install wizard.")
-                .setEphemeral(true).queue()
-            return
-        }
         event.deferEdit().queue()
-        val guildId = ctx.guild.id
-        val reader: (Configurations) -> String? =
-            { key -> configService.getConfigByName(key.configValue, guildId)?.value }
+        val reader = InstallWizard.configReader(configService, ctx.guild.id)
         event.hook.editOriginalEmbeds(InstallWizard.togglesEmbed())
             .setComponents(
                 InstallWizard.toggleRow(reader),

--- a/discord-bot/src/main/kotlin/bot/toby/install/button/InstallFeaturesButton.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/button/InstallFeaturesButton.kt
@@ -1,0 +1,43 @@
+package bot.toby.install.button
+
+import bot.toby.install.InstallWizard
+import core.button.Button
+import core.button.ButtonContext
+import database.dto.ConfigDto.Configurations
+import database.dto.UserDto
+import database.service.ConfigService
+import org.springframework.stereotype.Component
+
+/**
+ * "Optional features" — accessible from the custom-setup root. Swaps the
+ * section menu for the opt-in toggle row + a Back button. No DB writes
+ * here; the toggle clicks write through [InstallToggleButton].
+ */
+@Component
+class InstallFeaturesButton(
+    private val configService: ConfigService,
+) : Button {
+
+    override val name: String = InstallWizard.BTN_FEATURES
+    override val description: String = "Open the optional-features toggle view."
+    override val defersReply: Boolean = false
+
+    override fun handle(ctx: ButtonContext, requestingUserDto: UserDto, deleteDelay: Int) {
+        val event = ctx.event
+        if (event.member?.isOwner != true) {
+            event.reply("Only the server owner can use the install wizard.")
+                .setEphemeral(true).queue()
+            return
+        }
+        event.deferEdit().queue()
+        val guildId = ctx.guild.id
+        val reader: (Configurations) -> String? =
+            { key -> configService.getConfigByName(key.configValue, guildId)?.value }
+        event.hook.editOriginalEmbeds(InstallWizard.togglesEmbed())
+            .setComponents(
+                InstallWizard.toggleRow(reader),
+                InstallWizard.backButtonRow(),
+            )
+            .queue()
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/install/button/InstallFinishButton.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/button/InstallFinishButton.kt
@@ -1,5 +1,6 @@
 package bot.toby.install.button
 
+import bot.toby.install.InstallAuth
 import bot.toby.install.InstallSentinel
 import bot.toby.install.InstallWizard
 import core.button.ButtonContext
@@ -22,7 +23,7 @@ class InstallFinishButton(
 
     override val name: String = InstallWizard.BTN_FINISH
     override val description: String = "Finish the custom install."
-    override fun ownerErrorMessage(): String = OWNER_ERROR_SETUP
+    override fun ownerErrorMessage(): String = InstallAuth.SETUP_MESSAGE
 
     override fun handleAsOwner(ctx: ButtonContext, requestingUserDto: UserDto, deleteDelay: Int) {
         val event = ctx.event

--- a/discord-bot/src/main/kotlin/bot/toby/install/button/InstallFinishButton.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/button/InstallFinishButton.kt
@@ -1,9 +1,8 @@
 package bot.toby.install.button
 
+import bot.toby.install.InstallSentinel
 import bot.toby.install.InstallWizard
-import core.button.Button
 import core.button.ButtonContext
-import database.dto.ConfigDto.Configurations
 import database.dto.UserDto
 import database.service.ConfigService
 import org.springframework.stereotype.Component
@@ -12,31 +11,23 @@ import org.springframework.stereotype.Component
  * "Finish" — records the install sentinel (`INSTALL_MODE=custom` +
  * `INSTALLED_AT=<now>`) and strips the wizard components. Used on the
  * custom-setup path.
+ *
+ * If `INSTALL_MODE` is already set, the sentinel is not rewritten —
+ * the wizard doesn't downgrade an existing install on a second pass.
  */
 @Component
 class InstallFinishButton(
     private val configService: ConfigService,
-) : Button {
+) : OwnerOnlyInstallButton() {
 
     override val name: String = InstallWizard.BTN_FINISH
     override val description: String = "Finish the custom install."
-    override val defersReply: Boolean = false
+    override fun ownerErrorMessage(): String = OWNER_ERROR_SETUP
 
-    override fun handle(ctx: ButtonContext, requestingUserDto: UserDto, deleteDelay: Int) {
+    override fun handleAsOwner(ctx: ButtonContext, requestingUserDto: UserDto, deleteDelay: Int) {
         val event = ctx.event
-        if (event.member?.isOwner != true) {
-            event.reply("Only the server owner can finish install setup.")
-                .setEphemeral(true).queue()
-            return
-        }
         event.deferEdit().queue()
-        val guildId = ctx.guild.id
-        configService.upsertConfig(Configurations.INSTALL_MODE.configValue, "custom", guildId)
-        configService.upsertConfig(
-            Configurations.INSTALLED_AT.configValue,
-            System.currentTimeMillis().toString(),
-            guildId,
-        )
+        InstallSentinel.writeIfFresh(configService, ctx.guild.id, mode = "custom")
         event.hook.editOriginalEmbeds(InstallWizard.finishDoneEmbed())
             .setComponents()
             .queue()

--- a/discord-bot/src/main/kotlin/bot/toby/install/button/InstallFinishButton.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/button/InstallFinishButton.kt
@@ -1,0 +1,44 @@
+package bot.toby.install.button
+
+import bot.toby.install.InstallWizard
+import core.button.Button
+import core.button.ButtonContext
+import database.dto.ConfigDto.Configurations
+import database.dto.UserDto
+import database.service.ConfigService
+import org.springframework.stereotype.Component
+
+/**
+ * "Finish" — records the install sentinel (`INSTALL_MODE=custom` +
+ * `INSTALLED_AT=<now>`) and strips the wizard components. Used on the
+ * custom-setup path.
+ */
+@Component
+class InstallFinishButton(
+    private val configService: ConfigService,
+) : Button {
+
+    override val name: String = InstallWizard.BTN_FINISH
+    override val description: String = "Finish the custom install."
+    override val defersReply: Boolean = false
+
+    override fun handle(ctx: ButtonContext, requestingUserDto: UserDto, deleteDelay: Int) {
+        val event = ctx.event
+        if (event.member?.isOwner != true) {
+            event.reply("Only the server owner can finish install setup.")
+                .setEphemeral(true).queue()
+            return
+        }
+        event.deferEdit().queue()
+        val guildId = ctx.guild.id
+        configService.upsertConfig(Configurations.INSTALL_MODE.configValue, "custom", guildId)
+        configService.upsertConfig(
+            Configurations.INSTALLED_AT.configValue,
+            System.currentTimeMillis().toString(),
+            guildId,
+        )
+        event.hook.editOriginalEmbeds(InstallWizard.finishDoneEmbed())
+            .setComponents()
+            .queue()
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/install/button/InstallSkipButton.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/button/InstallSkipButton.kt
@@ -1,5 +1,6 @@
 package bot.toby.install.button
 
+import bot.toby.install.InstallAuth
 import bot.toby.install.InstallWizard
 import core.button.ButtonContext
 import database.dto.UserDto
@@ -15,7 +16,7 @@ class InstallSkipButton : OwnerOnlyInstallButton() {
 
     override val name: String = InstallWizard.BTN_SKIP
     override val description: String = "Dismiss the install wizard without making changes."
-    override fun ownerErrorMessage(): String = "Only the server owner can dismiss the install prompt."
+    override fun ownerErrorMessage(): String = InstallAuth.DISMISS_MESSAGE
 
     override fun handleAsOwner(ctx: ButtonContext, requestingUserDto: UserDto, deleteDelay: Int) {
         val event = ctx.event

--- a/discord-bot/src/main/kotlin/bot/toby/install/button/InstallSkipButton.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/button/InstallSkipButton.kt
@@ -1,7 +1,6 @@
 package bot.toby.install.button
 
 import bot.toby.install.InstallWizard
-import core.button.Button
 import core.button.ButtonContext
 import database.dto.UserDto
 import org.springframework.stereotype.Component
@@ -12,19 +11,14 @@ import org.springframework.stereotype.Component
  * the welcome message (skip is non-terminal).
  */
 @Component
-class InstallSkipButton : Button {
+class InstallSkipButton : OwnerOnlyInstallButton() {
 
     override val name: String = InstallWizard.BTN_SKIP
     override val description: String = "Dismiss the install wizard without making changes."
-    override val defersReply: Boolean = false
+    override fun ownerErrorMessage(): String = "Only the server owner can dismiss the install prompt."
 
-    override fun handle(ctx: ButtonContext, requestingUserDto: UserDto, deleteDelay: Int) {
+    override fun handleAsOwner(ctx: ButtonContext, requestingUserDto: UserDto, deleteDelay: Int) {
         val event = ctx.event
-        if (event.member?.isOwner != true) {
-            event.reply("Only the server owner can dismiss the install prompt.")
-                .setEphemeral(true).queue()
-            return
-        }
         event.deferEdit().queue()
         event.hook.editOriginalEmbeds(InstallWizard.skipDismissedEmbed())
             .setComponents()

--- a/discord-bot/src/main/kotlin/bot/toby/install/button/InstallSkipButton.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/button/InstallSkipButton.kt
@@ -1,0 +1,33 @@
+package bot.toby.install.button
+
+import bot.toby.install.InstallWizard
+import core.button.Button
+import core.button.ButtonContext
+import database.dto.UserDto
+import org.springframework.stereotype.Component
+
+/**
+ * "Skip for now" — dismisses the wizard with no DB writes. The install
+ * sentinel is intentionally not set, so a future re-invite will re-post
+ * the welcome message (skip is non-terminal).
+ */
+@Component
+class InstallSkipButton : Button {
+
+    override val name: String = InstallWizard.BTN_SKIP
+    override val description: String = "Dismiss the install wizard without making changes."
+    override val defersReply: Boolean = false
+
+    override fun handle(ctx: ButtonContext, requestingUserDto: UserDto, deleteDelay: Int) {
+        val event = ctx.event
+        if (event.member?.isOwner != true) {
+            event.reply("Only the server owner can dismiss the install prompt.")
+                .setEphemeral(true).queue()
+            return
+        }
+        event.deferEdit().queue()
+        event.hook.editOriginalEmbeds(InstallWizard.skipDismissedEmbed())
+            .setComponents()
+            .queue()
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/install/button/InstallToggleButton.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/button/InstallToggleButton.kt
@@ -2,42 +2,34 @@ package bot.toby.install.button
 
 import bot.toby.install.InstallWizard
 import bot.toby.install.OptInFeatures
-import core.button.Button
 import core.button.ButtonContext
-import database.dto.ConfigDto.Configurations
 import database.dto.UserDto
 import database.service.ConfigService
-import net.dv8tion.jda.api.components.actionrow.ActionRow
 import org.springframework.stereotype.Component
 
 /**
  * Flips one [OptInFeatures] config key between `"true"` and `"false"`.
  * One bean handles every toggle button — the colon-suffix on the
- * componentId names the [Configurations] enum entry being toggled
- * (e.g. `install_toggle:ACTIVITY_TRACKING`). Unknown suffixes reject
- * ephemerally.
+ * componentId names the [database.dto.ConfigDto.Configurations] enum
+ * entry being toggled (e.g. `install_toggle:ACTIVITY_TRACKING`).
+ * Unknown suffixes reject ephemerally.
  *
- * After the flip, the toggle action row is rebuilt with current DB
- * state; the bottom row of the message (Done from express, Back from
- * custom) is preserved verbatim so the wizard's navigation context
- * stays intact without encoding it in the componentId.
+ * The toggles view is only entered via Custom → Optional features, so
+ * the bottom action row is always [InstallWizard.backButtonRow]; the
+ * handler rebuilds it unconditionally rather than scraping the source
+ * message's components.
  */
 @Component
 class InstallToggleButton(
     private val configService: ConfigService,
-) : Button {
+) : OwnerOnlyInstallButton() {
 
     override val name: String = InstallWizard.BTN_TOGGLE_PREFIX
     override val description: String = "Toggle an optional feature on or off."
-    override val defersReply: Boolean = false
+    override fun ownerErrorMessage(): String = "Only the server owner can toggle install settings."
 
-    override fun handle(ctx: ButtonContext, requestingUserDto: UserDto, deleteDelay: Int) {
+    override fun handleAsOwner(ctx: ButtonContext, requestingUserDto: UserDto, deleteDelay: Int) {
         val event = ctx.event
-        if (event.member?.isOwner != true) {
-            event.reply("Only the server owner can toggle install settings.")
-                .setEphemeral(true).queue()
-            return
-        }
         val suffix = event.componentId.substringAfter(':', missingDelimiterValue = "")
         val feature = OptInFeatures.byKeyName(suffix) ?: run {
             event.reply("Unknown feature toggle.").setEphemeral(true).queue()
@@ -49,19 +41,9 @@ class InstallToggleButton(
         val newValue = if (current == "true") "false" else "true"
         configService.upsertConfig(feature.key.configValue, newValue, guildId)
 
-        val reader: (Configurations) -> String? =
-            { key -> configService.getConfigByName(key.configValue, guildId)?.value }
-        val rebuiltToggleRow = InstallWizard.toggleRow(reader)
-
-        // Preserve whatever bottom row was already on the message;
-        // toggles are now only entered from Custom → Optional features
-        // (which uses the Back button), but we don't assume it — anything
-        // already in the second row stays.
-        val existingRows = event.message.components.filterIsInstance<ActionRow>()
-        val bottomRow = existingRows.drop(1).firstOrNull() ?: InstallWizard.backButtonRow()
-
+        val reader = InstallWizard.configReader(configService, guildId)
         event.hook.editOriginalEmbeds(InstallWizard.togglesEmbed())
-            .setComponents(rebuiltToggleRow, bottomRow)
+            .setComponents(InstallWizard.toggleRow(reader), InstallWizard.backButtonRow())
             .queue()
     }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/install/button/InstallToggleButton.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/button/InstallToggleButton.kt
@@ -1,5 +1,6 @@
 package bot.toby.install.button
 
+import bot.toby.install.InstallAuth
 import bot.toby.install.InstallWizard
 import bot.toby.install.OptInFeatures
 import core.button.ButtonContext
@@ -26,7 +27,7 @@ class InstallToggleButton(
 
     override val name: String = InstallWizard.BTN_TOGGLE_PREFIX
     override val description: String = "Toggle an optional feature on or off."
-    override fun ownerErrorMessage(): String = "Only the server owner can toggle install settings."
+    override fun ownerErrorMessage(): String = InstallAuth.TOGGLE_MESSAGE
 
     override fun handleAsOwner(ctx: ButtonContext, requestingUserDto: UserDto, deleteDelay: Int) {
         val event = ctx.event
@@ -37,6 +38,11 @@ class InstallToggleButton(
         }
         event.deferEdit().queue()
         val guildId = ctx.guild.id
+        // Toggle is read-then-write — two rapid clicks could both read the
+        // same "before" value and produce the same "after". In practice
+        // Discord serializes interactions per-user-per-message, so this is
+        // safe for a guild-owner-only button. If we ever extend toggles
+        // beyond the owner, switch to a CAS-style upsert.
         val current = configService.getConfigByName(feature.key.configValue, guildId)?.value
         val newValue = if (current == "true") "false" else "true"
         configService.upsertConfig(feature.key.configValue, newValue, guildId)

--- a/discord-bot/src/main/kotlin/bot/toby/install/button/InstallToggleButton.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/button/InstallToggleButton.kt
@@ -1,0 +1,67 @@
+package bot.toby.install.button
+
+import bot.toby.install.InstallWizard
+import bot.toby.install.OptInFeatures
+import core.button.Button
+import core.button.ButtonContext
+import database.dto.ConfigDto.Configurations
+import database.dto.UserDto
+import database.service.ConfigService
+import net.dv8tion.jda.api.components.actionrow.ActionRow
+import org.springframework.stereotype.Component
+
+/**
+ * Flips one [OptInFeatures] config key between `"true"` and `"false"`.
+ * One bean handles every toggle button — the colon-suffix on the
+ * componentId names the [Configurations] enum entry being toggled
+ * (e.g. `install_toggle:ACTIVITY_TRACKING`). Unknown suffixes reject
+ * ephemerally.
+ *
+ * After the flip, the toggle action row is rebuilt with current DB
+ * state; the bottom row of the message (Done from express, Back from
+ * custom) is preserved verbatim so the wizard's navigation context
+ * stays intact without encoding it in the componentId.
+ */
+@Component
+class InstallToggleButton(
+    private val configService: ConfigService,
+) : Button {
+
+    override val name: String = InstallWizard.BTN_TOGGLE_PREFIX
+    override val description: String = "Toggle an optional feature on or off."
+    override val defersReply: Boolean = false
+
+    override fun handle(ctx: ButtonContext, requestingUserDto: UserDto, deleteDelay: Int) {
+        val event = ctx.event
+        if (event.member?.isOwner != true) {
+            event.reply("Only the server owner can toggle install settings.")
+                .setEphemeral(true).queue()
+            return
+        }
+        val suffix = event.componentId.substringAfter(':', missingDelimiterValue = "")
+        val feature = OptInFeatures.byKeyName(suffix) ?: run {
+            event.reply("Unknown feature toggle.").setEphemeral(true).queue()
+            return
+        }
+        event.deferEdit().queue()
+        val guildId = ctx.guild.id
+        val current = configService.getConfigByName(feature.key.configValue, guildId)?.value
+        val newValue = if (current == "true") "false" else "true"
+        configService.upsertConfig(feature.key.configValue, newValue, guildId)
+
+        val reader: (Configurations) -> String? =
+            { key -> configService.getConfigByName(key.configValue, guildId)?.value }
+        val rebuiltToggleRow = InstallWizard.toggleRow(reader)
+
+        // Preserve whatever bottom row was already on the message;
+        // toggles are now only entered from Custom → Optional features
+        // (which uses the Back button), but we don't assume it — anything
+        // already in the second row stays.
+        val existingRows = event.message.components.filterIsInstance<ActionRow>()
+        val bottomRow = existingRows.drop(1).firstOrNull() ?: InstallWizard.backButtonRow()
+
+        event.hook.editOriginalEmbeds(InstallWizard.togglesEmbed())
+            .setComponents(rebuiltToggleRow, bottomRow)
+            .queue()
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/install/button/OwnerOnlyInstallButton.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/button/OwnerOnlyInstallButton.kt
@@ -1,5 +1,6 @@
 package bot.toby.install.button
 
+import bot.toby.install.InstallAuth
 import core.button.Button
 import core.button.ButtonContext
 import database.dto.UserDto
@@ -8,7 +9,7 @@ import database.dto.UserDto
  * Shared base for every install-wizard button. Centralizes:
  *
  * - The owner-gate (ephemeral reject if `event.member?.isOwner != true`),
- *   which all install buttons need.
+ *   shared with the menu via [InstallAuth.requireOwner].
  * - `defersReply = false` — install buttons edit the source message via
  *   `deferEdit + hook.editOriginal*`, not a separate ephemeral reply.
  *
@@ -19,15 +20,11 @@ abstract class OwnerOnlyInstallButton : Button {
 
     override val defersReply: Boolean = false
 
-    /** Per-button error string. Defaults to a generic owner-only message. */
-    protected open fun ownerErrorMessage(): String = DEFAULT_OWNER_ERROR
+    /** Per-button error string. Defaults to the wizard's generic owner-only message. */
+    protected open fun ownerErrorMessage(): String = InstallAuth.DEFAULT_MESSAGE
 
     override fun handle(ctx: ButtonContext, requestingUserDto: UserDto, deleteDelay: Int) {
-        val event = ctx.event
-        if (event.member?.isOwner != true) {
-            event.reply(ownerErrorMessage()).setEphemeral(true).queue()
-            return
-        }
+        if (!InstallAuth.requireOwner(ctx.event, ownerErrorMessage())) return
         handleAsOwner(ctx, requestingUserDto, deleteDelay)
     }
 
@@ -42,8 +39,4 @@ abstract class OwnerOnlyInstallButton : Button {
         requestingUserDto: UserDto,
         deleteDelay: Int,
     )
-
-    companion object {
-        const val DEFAULT_OWNER_ERROR: String = "Only the server owner can use the install wizard."
-    }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/install/button/OwnerOnlyInstallButton.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/button/OwnerOnlyInstallButton.kt
@@ -1,0 +1,49 @@
+package bot.toby.install.button
+
+import core.button.Button
+import core.button.ButtonContext
+import database.dto.UserDto
+
+/**
+ * Shared base for every install-wizard button. Centralizes:
+ *
+ * - The owner-gate (ephemeral reject if `event.member?.isOwner != true`),
+ *   which all install buttons need.
+ * - `defersReply = false` — install buttons edit the source message via
+ *   `deferEdit + hook.editOriginal*`, not a separate ephemeral reply.
+ *
+ * Subclasses override [handleAsOwner] and optionally [ownerErrorMessage]
+ * if a more specific reject string is wanted.
+ */
+abstract class OwnerOnlyInstallButton : Button {
+
+    override val defersReply: Boolean = false
+
+    /** Per-button error string. Defaults to a generic owner-only message. */
+    protected open fun ownerErrorMessage(): String = DEFAULT_OWNER_ERROR
+
+    override fun handle(ctx: ButtonContext, requestingUserDto: UserDto, deleteDelay: Int) {
+        val event = ctx.event
+        if (event.member?.isOwner != true) {
+            event.reply(ownerErrorMessage()).setEphemeral(true).queue()
+            return
+        }
+        handleAsOwner(ctx, requestingUserDto, deleteDelay)
+    }
+
+    /**
+     * Called only when the owner gate has passed. Implementations must
+     * provide an interaction response (typically `event.deferEdit().queue()`
+     * followed by `event.hook.editOriginal*`), or an ephemeral reply for
+     * secondary validation failures.
+     */
+    protected abstract fun handleAsOwner(
+        ctx: ButtonContext,
+        requestingUserDto: UserDto,
+        deleteDelay: Int,
+    )
+
+    companion object {
+        const val DEFAULT_OWNER_ERROR: String = "Only the server owner can use the install wizard."
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/install/menu/InstallCategoryMenu.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/menu/InstallCategoryMenu.kt
@@ -1,8 +1,9 @@
 package bot.toby.install.menu
 
 import bot.toby.command.commands.moderation.SetConfigCommand
+import bot.toby.install.ConfigReader
+import bot.toby.install.InstallAuth
 import bot.toby.install.InstallWizard
-import bot.toby.install.InstallWizard.ConfigReader
 import bot.toby.install.QUICK_CHANNELS_TOKEN
 import bot.toby.install.WizardSection
 import bot.toby.install.modal.InstallAllStakesModal
@@ -19,6 +20,7 @@ import bot.toby.modal.modals.setconfig.SetConfigLotteryPoolsModal
 import bot.toby.modal.modals.setconfig.SetConfigPokerStakesModal
 import bot.toby.modal.modals.setconfig.SetConfigPokerTableModal
 import bot.toby.modal.modals.setconfig.SetConfigStakesModal
+import common.logging.DiscordLogger
 import core.menu.Menu
 import core.menu.MenuContext
 import database.service.ConfigService
@@ -62,6 +64,8 @@ class InstallCategoryMenu(
 
     override val name: String = InstallWizard.MENU_SECTION
 
+    private val log: DiscordLogger = DiscordLogger.createLogger(this::class.java)
+
     /**
      * Dispatch table for top-level category picks. Each entry maps a
      * category token to one of:
@@ -71,38 +75,38 @@ class InstallCategoryMenu(
      * - [CategoryAction.Transition] — perform an inline edit (e.g. swap
      *   the menu for a sub-menu) without opening a modal.
      */
-    private val categoryActions: Map<String, CategoryAction> = buildMap {
-        fun openModal(token: String, build: (ConfigReader) -> Modal) {
-            put(token, CategoryAction.OpenModal(build))
-        }
-        openModal(QUICK_CHANNELS_TOKEN) { quickChannels.buildModal() }
-        openModal(SetConfigCommand.SUB_GENERAL) { r -> general.buildModal(SetConfigGeneralModal.MODAL_NAME, r) }
-        openModal(SetConfigCommand.SUB_ACTIVITY) { r -> activity.buildModal(SetConfigActivityModal.MODAL_NAME, r) }
-        openModal(SetConfigCommand.SUB_FEES) { r -> fees.buildModal(SetConfigFeesModal.MODAL_NAME, r) }
-        openModal(SetConfigCommand.SUB_JACKPOT) { r -> jackpot.buildModal(SetConfigJackpotModal.MODAL_NAME, r) }
-        openModal(SetConfigCommand.SUB_JACKPOT_ACTIVITY) { r -> jackpotActivity.buildModal(SetConfigJackpotActivityModal.MODAL_NAME, r) }
-        openModal(SetConfigCommand.SUB_POKER_STAKES) { r -> pokerStakes.buildModal(SetConfigPokerStakesModal.MODAL_NAME, r) }
-        openModal(SetConfigCommand.SUB_POKER_TABLE) { r -> pokerTable.buildModal(SetConfigPokerTableModal.MODAL_NAME, r) }
-        openModal(SetConfigCommand.SUB_BLACKJACK_RULES) { r -> blackjackRules.buildModal(SetConfigBlackjackRulesModal.MODAL_NAME, r) }
-        openModal(SetConfigCommand.SUB_BLACKJACK_TABLE) { r -> blackjackTable.buildModal(SetConfigBlackjackTableModal.MODAL_NAME, r) }
-        openModal(SetConfigCommand.SUB_LOTTERY_BASICS) { r -> lotteryBasics.buildModal(SetConfigLotteryBasicsModal.MODAL_NAME, r) }
-        openModal(SetConfigCommand.SUB_LOTTERY_POOLS) { r -> lotteryPools.buildModal(SetConfigLotteryPoolsModal.MODAL_NAME, r) }
-        put(SetConfigCommand.SUB_STAKES, CategoryAction.Transition(::showStakesGameMenu))
-    }
+    private val categoryActions: Map<String, CategoryAction> = mapOf(
+        QUICK_CHANNELS_TOKEN to CategoryAction.OpenModal { quickChannels.buildModal() },
+        SetConfigCommand.SUB_GENERAL to setconfigModal(general, SetConfigGeneralModal.MODAL_NAME),
+        SetConfigCommand.SUB_ACTIVITY to setconfigModal(activity, SetConfigActivityModal.MODAL_NAME),
+        SetConfigCommand.SUB_FEES to setconfigModal(fees, SetConfigFeesModal.MODAL_NAME),
+        SetConfigCommand.SUB_JACKPOT to setconfigModal(jackpot, SetConfigJackpotModal.MODAL_NAME),
+        SetConfigCommand.SUB_JACKPOT_ACTIVITY to setconfigModal(jackpotActivity, SetConfigJackpotActivityModal.MODAL_NAME),
+        SetConfigCommand.SUB_POKER_STAKES to setconfigModal(pokerStakes, SetConfigPokerStakesModal.MODAL_NAME),
+        SetConfigCommand.SUB_POKER_TABLE to setconfigModal(pokerTable, SetConfigPokerTableModal.MODAL_NAME),
+        SetConfigCommand.SUB_BLACKJACK_RULES to setconfigModal(blackjackRules, SetConfigBlackjackRulesModal.MODAL_NAME),
+        SetConfigCommand.SUB_BLACKJACK_TABLE to setconfigModal(blackjackTable, SetConfigBlackjackTableModal.MODAL_NAME),
+        SetConfigCommand.SUB_LOTTERY_BASICS to setconfigModal(lotteryBasics, SetConfigLotteryBasicsModal.MODAL_NAME),
+        SetConfigCommand.SUB_LOTTERY_POOLS to setconfigModal(lotteryPools, SetConfigLotteryPoolsModal.MODAL_NAME),
+        SetConfigCommand.SUB_STAKES to CategoryAction.Transition(::showStakesGameMenu),
+    )
+
+    private fun setconfigModal(
+        modal: bot.toby.modal.modals.setconfig.SetConfigCategoryModal,
+        modalName: String,
+    ): CategoryAction.OpenModal =
+        CategoryAction.OpenModal { reader -> modal.buildModal(modalName, reader) }
 
     override fun handle(ctx: MenuContext, deleteDelay: Int) {
         val event = ctx.event
-        if (ctx.member?.isOwner != true) {
-            event.reply("Only the server owner can use the install wizard.")
-                .setEphemeral(true).queue()
-            return
-        }
+        if (!InstallAuth.requireOwner(event)) return
         val selected = event.selectedOptions.firstOrNull()?.value ?: run {
             event.reply("No option selected.").setEphemeral(true).queue()
             return
         }
         val reader = InstallWizard.configReader(configService, ctx.guild.id)
         val componentId = event.componentId
+        log.info { "Install menu dispatch: componentId='$componentId' selected='$selected'" }
         when {
             componentId == InstallWizard.MENU_SECTION ->
                 handleSectionPick(ctx, selected)
@@ -110,7 +114,10 @@ class InstallCategoryMenu(
                 handleCategoryPick(ctx, componentId, selected, reader)
             componentId == InstallWizard.MENU_CATEGORY_STAKES ->
                 handleStakesPick(ctx, selected, reader)
-            else -> event.reply("Unknown menu `$componentId`.").setEphemeral(true).queue()
+            else -> {
+                log.warn { "Install menu got unknown componentId '$componentId' — ignoring" }
+                event.reply("Unknown menu `$componentId`.").setEphemeral(true).queue()
+            }
         }
     }
 

--- a/discord-bot/src/main/kotlin/bot/toby/install/menu/InstallCategoryMenu.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/menu/InstallCategoryMenu.kt
@@ -2,6 +2,7 @@ package bot.toby.install.menu
 
 import bot.toby.command.commands.moderation.SetConfigCommand
 import bot.toby.install.InstallWizard
+import bot.toby.install.InstallWizard.ConfigReader
 import bot.toby.install.QUICK_CHANNELS_TOKEN
 import bot.toby.install.WizardSection
 import bot.toby.install.modal.InstallAllStakesModal
@@ -20,9 +21,9 @@ import bot.toby.modal.modals.setconfig.SetConfigPokerTableModal
 import bot.toby.modal.modals.setconfig.SetConfigStakesModal
 import core.menu.Menu
 import core.menu.MenuContext
-import database.dto.ConfigDto.Configurations
 import database.service.ConfigService
 import net.dv8tion.jda.api.components.actionrow.ActionRow
+import net.dv8tion.jda.api.modals.Modal
 import org.springframework.stereotype.Component
 
 /**
@@ -33,39 +34,61 @@ import org.springframework.stereotype.Component
  * - `install_section` — top-level. Selected value is a [WizardSection]
  *   id; we swap to the section's category list.
  * - `install_section_detail:<sectionId>` — categories within a section.
- *   Selected value is a `SetConfigCommand.SUB_*` token; we open that
- *   category's existing modal, or branch into the stakes-game sub-menu.
+ *   Selected value is a category token; we dispatch via [categoryActions]
+ *   to open a modal, transition to a sub-menu, etc.
  * - `install_category_stakes` — game-picker for per-game stakes.
- *   Selected value is either `STAKE_ALL_TOKEN` (opens
- *   [InstallAllStakesModal]) or a [SetConfigStakesModal.Game] token
- *   (opens the existing per-game stakes modal).
  *
- * `DefaultMenuManager.handle` disables every action row on the source
- * message *before* this handler runs, so each branch re-arms the
- * components either inline (non-modal branches use
- * `event.editMessage*` as the interaction response) or in a
- * `replyModal.queue { … }` callback.
+ * Adding a new category is a one-entry change in [categoryActions] —
+ * the menu's `handle` doesn't grow a new branch.
  */
 @Component
 class InstallCategoryMenu(
     private val configService: ConfigService,
-    private val general: SetConfigGeneralModal,
-    private val activity: SetConfigActivityModal,
-    private val fees: SetConfigFeesModal,
-    private val jackpot: SetConfigJackpotModal,
-    private val jackpotActivity: SetConfigJackpotActivityModal,
-    private val pokerStakes: SetConfigPokerStakesModal,
-    private val pokerTable: SetConfigPokerTableModal,
-    private val blackjackRules: SetConfigBlackjackRulesModal,
-    private val blackjackTable: SetConfigBlackjackTableModal,
-    private val lotteryBasics: SetConfigLotteryBasicsModal,
-    private val lotteryPools: SetConfigLotteryPoolsModal,
+    general: SetConfigGeneralModal,
+    activity: SetConfigActivityModal,
+    fees: SetConfigFeesModal,
+    jackpot: SetConfigJackpotModal,
+    jackpotActivity: SetConfigJackpotActivityModal,
+    pokerStakes: SetConfigPokerStakesModal,
+    pokerTable: SetConfigPokerTableModal,
+    blackjackRules: SetConfigBlackjackRulesModal,
+    blackjackTable: SetConfigBlackjackTableModal,
+    lotteryBasics: SetConfigLotteryBasicsModal,
+    lotteryPools: SetConfigLotteryPoolsModal,
     private val stakes: SetConfigStakesModal,
     private val allStakes: InstallAllStakesModal,
-    private val quickChannels: InstallQuickChannelsModal,
+    quickChannels: InstallQuickChannelsModal,
 ) : Menu {
 
     override val name: String = InstallWizard.MENU_SECTION
+
+    /**
+     * Dispatch table for top-level category picks. Each entry maps a
+     * category token to one of:
+     *
+     * - [CategoryAction.OpenModal] — open the modal returned by the
+     *   builder, then rearm to the section's detail menu.
+     * - [CategoryAction.Transition] — perform an inline edit (e.g. swap
+     *   the menu for a sub-menu) without opening a modal.
+     */
+    private val categoryActions: Map<String, CategoryAction> = buildMap {
+        fun openModal(token: String, build: (ConfigReader) -> Modal) {
+            put(token, CategoryAction.OpenModal(build))
+        }
+        openModal(QUICK_CHANNELS_TOKEN) { quickChannels.buildModal() }
+        openModal(SetConfigCommand.SUB_GENERAL) { r -> general.buildModal(SetConfigGeneralModal.MODAL_NAME, r) }
+        openModal(SetConfigCommand.SUB_ACTIVITY) { r -> activity.buildModal(SetConfigActivityModal.MODAL_NAME, r) }
+        openModal(SetConfigCommand.SUB_FEES) { r -> fees.buildModal(SetConfigFeesModal.MODAL_NAME, r) }
+        openModal(SetConfigCommand.SUB_JACKPOT) { r -> jackpot.buildModal(SetConfigJackpotModal.MODAL_NAME, r) }
+        openModal(SetConfigCommand.SUB_JACKPOT_ACTIVITY) { r -> jackpotActivity.buildModal(SetConfigJackpotActivityModal.MODAL_NAME, r) }
+        openModal(SetConfigCommand.SUB_POKER_STAKES) { r -> pokerStakes.buildModal(SetConfigPokerStakesModal.MODAL_NAME, r) }
+        openModal(SetConfigCommand.SUB_POKER_TABLE) { r -> pokerTable.buildModal(SetConfigPokerTableModal.MODAL_NAME, r) }
+        openModal(SetConfigCommand.SUB_BLACKJACK_RULES) { r -> blackjackRules.buildModal(SetConfigBlackjackRulesModal.MODAL_NAME, r) }
+        openModal(SetConfigCommand.SUB_BLACKJACK_TABLE) { r -> blackjackTable.buildModal(SetConfigBlackjackTableModal.MODAL_NAME, r) }
+        openModal(SetConfigCommand.SUB_LOTTERY_BASICS) { r -> lotteryBasics.buildModal(SetConfigLotteryBasicsModal.MODAL_NAME, r) }
+        openModal(SetConfigCommand.SUB_LOTTERY_POOLS) { r -> lotteryPools.buildModal(SetConfigLotteryPoolsModal.MODAL_NAME, r) }
+        put(SetConfigCommand.SUB_STAKES, CategoryAction.Transition(::showStakesGameMenu))
+    }
 
     override fun handle(ctx: MenuContext, deleteDelay: Int) {
         val event = ctx.event
@@ -78,14 +101,11 @@ class InstallCategoryMenu(
             event.reply("No option selected.").setEphemeral(true).queue()
             return
         }
-        val guildId = ctx.guild.id
-        val reader: (Configurations) -> String? =
-            { key -> configService.getConfigByName(key.configValue, guildId)?.value }
-
+        val reader = InstallWizard.configReader(configService, ctx.guild.id)
         val componentId = event.componentId
         when {
             componentId == InstallWizard.MENU_SECTION ->
-                handleSectionPick(ctx, selected, reader)
+                handleSectionPick(ctx, selected)
             componentId.startsWith("${InstallWizard.MENU_SECTION_DETAIL_PREFIX}:") ->
                 handleCategoryPick(ctx, componentId, selected, reader)
             componentId == InstallWizard.MENU_CATEGORY_STAKES ->
@@ -94,11 +114,7 @@ class InstallCategoryMenu(
         }
     }
 
-    private fun handleSectionPick(
-        ctx: MenuContext,
-        sectionId: String,
-        @Suppress("UNUSED_PARAMETER") reader: (Configurations) -> String?,
-    ) {
+    private fun handleSectionPick(ctx: MenuContext, sectionId: String) {
         val event = ctx.event
         val section = WizardSection.byId(sectionId) ?: run {
             event.reply("Unknown section `$sectionId`.").setEphemeral(true).queue()
@@ -116,7 +132,7 @@ class InstallCategoryMenu(
         ctx: MenuContext,
         componentId: String,
         categoryToken: String,
-        reader: (Configurations) -> String?,
+        reader: ConfigReader,
     ) {
         val event = ctx.event
         val sectionId = componentId.substringAfter(":", missingDelimiterValue = "")
@@ -124,55 +140,22 @@ class InstallCategoryMenu(
             event.reply("Unknown section `$sectionId`.").setEphemeral(true).queue()
             return
         }
-        when (categoryToken) {
-            QUICK_CHANNELS_TOKEN ->
-                openModalAndRearm(ctx, section, quickChannels.buildModal())
-            SetConfigCommand.SUB_GENERAL ->
-                openModalAndRearm(ctx, section, general.buildModal(SetConfigGeneralModal.MODAL_NAME, reader))
-            SetConfigCommand.SUB_ACTIVITY ->
-                openModalAndRearm(ctx, section, activity.buildModal(SetConfigActivityModal.MODAL_NAME, reader))
-            SetConfigCommand.SUB_FEES ->
-                openModalAndRearm(ctx, section, fees.buildModal(SetConfigFeesModal.MODAL_NAME, reader))
-            SetConfigCommand.SUB_JACKPOT ->
-                openModalAndRearm(ctx, section, jackpot.buildModal(SetConfigJackpotModal.MODAL_NAME, reader))
-            SetConfigCommand.SUB_JACKPOT_ACTIVITY ->
-                openModalAndRearm(ctx, section, jackpotActivity.buildModal(SetConfigJackpotActivityModal.MODAL_NAME, reader))
-            SetConfigCommand.SUB_POKER_STAKES ->
-                openModalAndRearm(ctx, section, pokerStakes.buildModal(SetConfigPokerStakesModal.MODAL_NAME, reader))
-            SetConfigCommand.SUB_POKER_TABLE ->
-                openModalAndRearm(ctx, section, pokerTable.buildModal(SetConfigPokerTableModal.MODAL_NAME, reader))
-            SetConfigCommand.SUB_BLACKJACK_RULES ->
-                openModalAndRearm(ctx, section, blackjackRules.buildModal(SetConfigBlackjackRulesModal.MODAL_NAME, reader))
-            SetConfigCommand.SUB_BLACKJACK_TABLE ->
-                openModalAndRearm(ctx, section, blackjackTable.buildModal(SetConfigBlackjackTableModal.MODAL_NAME, reader))
-            SetConfigCommand.SUB_LOTTERY_BASICS ->
-                openModalAndRearm(ctx, section, lotteryBasics.buildModal(SetConfigLotteryBasicsModal.MODAL_NAME, reader))
-            SetConfigCommand.SUB_LOTTERY_POOLS ->
-                openModalAndRearm(ctx, section, lotteryPools.buildModal(SetConfigLotteryPoolsModal.MODAL_NAME, reader))
-            SetConfigCommand.SUB_STAKES -> {
-                val games = SetConfigStakesModal.Game.entries.map { it.label to it.token }
-                event.editMessageEmbeds(InstallWizard.stakesGameMenuEmbed())
-                    .setComponents(
-                        ActionRow.of(InstallWizard.stakesGameMenu(games)),
-                        InstallWizard.backAndFinishRow(),
-                    )
-                    .queue()
-            }
-            else -> event.reply("Unknown category `$categoryToken`.").setEphemeral(true).queue()
+        val action = categoryActions[categoryToken] ?: run {
+            event.reply("Unknown category `$categoryToken`.").setEphemeral(true).queue()
+            return
+        }
+        when (action) {
+            is CategoryAction.OpenModal -> openModalAndRearm(ctx, section, action.build(reader))
+            is CategoryAction.Transition -> action.run(ctx)
         }
     }
 
-    private fun handleStakesPick(
-        ctx: MenuContext,
-        selectedToken: String,
-        reader: (Configurations) -> String?,
-    ) {
+    private fun handleStakesPick(ctx: MenuContext, selectedToken: String, reader: ConfigReader) {
         val event = ctx.event
+        val section = WizardSection.ECONOMY
         if (selectedToken == InstallWizard.STAKE_ALL_TOKEN) {
-            val (currentMin, currentMax) = allStakes.readCurrentDefaults(reader)
-            // Pass the Economy section so the modal-close rearm lands back
-            // in the section-detail menu (the natural home for Per-game stakes).
-            val section = WizardSection.ECONOMY
+            val currentMin = reader(SetConfigStakesModal.Game.DICE.minKey)
+            val currentMax = reader(SetConfigStakesModal.Game.DICE.maxKey)
             openModalAndRearm(ctx, section, allStakes.buildModal(currentMin, currentMax))
             return
         }
@@ -180,11 +163,18 @@ class InstallCategoryMenu(
             event.reply("Unknown game `$selectedToken`.").setEphemeral(true).queue()
             return
         }
-        openModalAndRearm(
-            ctx,
-            WizardSection.ECONOMY,
-            stakes.buildModal(SetConfigStakesModal.customIdFor(game), reader),
-        )
+        openModalAndRearm(ctx, section, stakes.buildModal(SetConfigStakesModal.customIdFor(game), reader))
+    }
+
+    private fun showStakesGameMenu(ctx: MenuContext) {
+        val event = ctx.event
+        val games = SetConfigStakesModal.Game.entries.map { it.label to it.token }
+        event.editMessageEmbeds(InstallWizard.stakesGameMenuEmbed())
+            .setComponents(
+                ActionRow.of(InstallWizard.stakesGameMenu(games)),
+                InstallWizard.backAndFinishRow(),
+            )
+            .queue()
     }
 
     /**
@@ -192,11 +182,7 @@ class InstallCategoryMenu(
      * [section]'s detail menu so the owner can pick another category in
      * the same section without re-navigating.
      */
-    private fun openModalAndRearm(
-        ctx: MenuContext,
-        section: WizardSection,
-        modal: net.dv8tion.jda.api.modals.Modal,
-    ) {
+    private fun openModalAndRearm(ctx: MenuContext, section: WizardSection, modal: Modal) {
         val event = ctx.event
         event.replyModal(modal).queue {
             event.message.editMessageEmbeds(InstallWizard.sectionDetailEmbed(section))
@@ -206,5 +192,10 @@ class InstallCategoryMenu(
                 )
                 .queue()
         }
+    }
+
+    private sealed interface CategoryAction {
+        class OpenModal(val build: (ConfigReader) -> Modal) : CategoryAction
+        class Transition(val run: (MenuContext) -> Unit) : CategoryAction
     }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/install/menu/InstallCategoryMenu.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/menu/InstallCategoryMenu.kt
@@ -1,0 +1,210 @@
+package bot.toby.install.menu
+
+import bot.toby.command.commands.moderation.SetConfigCommand
+import bot.toby.install.InstallWizard
+import bot.toby.install.QUICK_CHANNELS_TOKEN
+import bot.toby.install.WizardSection
+import bot.toby.install.modal.InstallAllStakesModal
+import bot.toby.install.modal.InstallQuickChannelsModal
+import bot.toby.modal.modals.setconfig.SetConfigActivityModal
+import bot.toby.modal.modals.setconfig.SetConfigBlackjackRulesModal
+import bot.toby.modal.modals.setconfig.SetConfigBlackjackTableModal
+import bot.toby.modal.modals.setconfig.SetConfigFeesModal
+import bot.toby.modal.modals.setconfig.SetConfigGeneralModal
+import bot.toby.modal.modals.setconfig.SetConfigJackpotActivityModal
+import bot.toby.modal.modals.setconfig.SetConfigJackpotModal
+import bot.toby.modal.modals.setconfig.SetConfigLotteryBasicsModal
+import bot.toby.modal.modals.setconfig.SetConfigLotteryPoolsModal
+import bot.toby.modal.modals.setconfig.SetConfigPokerStakesModal
+import bot.toby.modal.modals.setconfig.SetConfigPokerTableModal
+import bot.toby.modal.modals.setconfig.SetConfigStakesModal
+import core.menu.Menu
+import core.menu.MenuContext
+import database.dto.ConfigDto.Configurations
+import database.service.ConfigService
+import net.dv8tion.jda.api.components.actionrow.ActionRow
+import org.springframework.stereotype.Component
+
+/**
+ * The custom-install menu router. Three componentId tiers, all routed
+ * to the same bean via `DefaultMenuManager.getMenu` (substring match on
+ * the menu name `install_section`):
+ *
+ * - `install_section` — top-level. Selected value is a [WizardSection]
+ *   id; we swap to the section's category list.
+ * - `install_section_detail:<sectionId>` — categories within a section.
+ *   Selected value is a `SetConfigCommand.SUB_*` token; we open that
+ *   category's existing modal, or branch into the stakes-game sub-menu.
+ * - `install_category_stakes` — game-picker for per-game stakes.
+ *   Selected value is either `STAKE_ALL_TOKEN` (opens
+ *   [InstallAllStakesModal]) or a [SetConfigStakesModal.Game] token
+ *   (opens the existing per-game stakes modal).
+ *
+ * `DefaultMenuManager.handle` disables every action row on the source
+ * message *before* this handler runs, so each branch re-arms the
+ * components either inline (non-modal branches use
+ * `event.editMessage*` as the interaction response) or in a
+ * `replyModal.queue { … }` callback.
+ */
+@Component
+class InstallCategoryMenu(
+    private val configService: ConfigService,
+    private val general: SetConfigGeneralModal,
+    private val activity: SetConfigActivityModal,
+    private val fees: SetConfigFeesModal,
+    private val jackpot: SetConfigJackpotModal,
+    private val jackpotActivity: SetConfigJackpotActivityModal,
+    private val pokerStakes: SetConfigPokerStakesModal,
+    private val pokerTable: SetConfigPokerTableModal,
+    private val blackjackRules: SetConfigBlackjackRulesModal,
+    private val blackjackTable: SetConfigBlackjackTableModal,
+    private val lotteryBasics: SetConfigLotteryBasicsModal,
+    private val lotteryPools: SetConfigLotteryPoolsModal,
+    private val stakes: SetConfigStakesModal,
+    private val allStakes: InstallAllStakesModal,
+    private val quickChannels: InstallQuickChannelsModal,
+) : Menu {
+
+    override val name: String = InstallWizard.MENU_SECTION
+
+    override fun handle(ctx: MenuContext, deleteDelay: Int) {
+        val event = ctx.event
+        if (ctx.member?.isOwner != true) {
+            event.reply("Only the server owner can use the install wizard.")
+                .setEphemeral(true).queue()
+            return
+        }
+        val selected = event.selectedOptions.firstOrNull()?.value ?: run {
+            event.reply("No option selected.").setEphemeral(true).queue()
+            return
+        }
+        val guildId = ctx.guild.id
+        val reader: (Configurations) -> String? =
+            { key -> configService.getConfigByName(key.configValue, guildId)?.value }
+
+        val componentId = event.componentId
+        when {
+            componentId == InstallWizard.MENU_SECTION ->
+                handleSectionPick(ctx, selected, reader)
+            componentId.startsWith("${InstallWizard.MENU_SECTION_DETAIL_PREFIX}:") ->
+                handleCategoryPick(ctx, componentId, selected, reader)
+            componentId == InstallWizard.MENU_CATEGORY_STAKES ->
+                handleStakesPick(ctx, selected, reader)
+            else -> event.reply("Unknown menu `$componentId`.").setEphemeral(true).queue()
+        }
+    }
+
+    private fun handleSectionPick(
+        ctx: MenuContext,
+        sectionId: String,
+        @Suppress("UNUSED_PARAMETER") reader: (Configurations) -> String?,
+    ) {
+        val event = ctx.event
+        val section = WizardSection.byId(sectionId) ?: run {
+            event.reply("Unknown section `$sectionId`.").setEphemeral(true).queue()
+            return
+        }
+        event.editMessageEmbeds(InstallWizard.sectionDetailEmbed(section))
+            .setComponents(
+                ActionRow.of(InstallWizard.sectionDetailMenu(section)),
+                InstallWizard.backAndFinishRow(),
+            )
+            .queue()
+    }
+
+    private fun handleCategoryPick(
+        ctx: MenuContext,
+        componentId: String,
+        categoryToken: String,
+        reader: (Configurations) -> String?,
+    ) {
+        val event = ctx.event
+        val sectionId = componentId.substringAfter(":", missingDelimiterValue = "")
+        val section = WizardSection.byId(sectionId) ?: run {
+            event.reply("Unknown section `$sectionId`.").setEphemeral(true).queue()
+            return
+        }
+        when (categoryToken) {
+            QUICK_CHANNELS_TOKEN ->
+                openModalAndRearm(ctx, section, quickChannels.buildModal())
+            SetConfigCommand.SUB_GENERAL ->
+                openModalAndRearm(ctx, section, general.buildModal(SetConfigGeneralModal.MODAL_NAME, reader))
+            SetConfigCommand.SUB_ACTIVITY ->
+                openModalAndRearm(ctx, section, activity.buildModal(SetConfigActivityModal.MODAL_NAME, reader))
+            SetConfigCommand.SUB_FEES ->
+                openModalAndRearm(ctx, section, fees.buildModal(SetConfigFeesModal.MODAL_NAME, reader))
+            SetConfigCommand.SUB_JACKPOT ->
+                openModalAndRearm(ctx, section, jackpot.buildModal(SetConfigJackpotModal.MODAL_NAME, reader))
+            SetConfigCommand.SUB_JACKPOT_ACTIVITY ->
+                openModalAndRearm(ctx, section, jackpotActivity.buildModal(SetConfigJackpotActivityModal.MODAL_NAME, reader))
+            SetConfigCommand.SUB_POKER_STAKES ->
+                openModalAndRearm(ctx, section, pokerStakes.buildModal(SetConfigPokerStakesModal.MODAL_NAME, reader))
+            SetConfigCommand.SUB_POKER_TABLE ->
+                openModalAndRearm(ctx, section, pokerTable.buildModal(SetConfigPokerTableModal.MODAL_NAME, reader))
+            SetConfigCommand.SUB_BLACKJACK_RULES ->
+                openModalAndRearm(ctx, section, blackjackRules.buildModal(SetConfigBlackjackRulesModal.MODAL_NAME, reader))
+            SetConfigCommand.SUB_BLACKJACK_TABLE ->
+                openModalAndRearm(ctx, section, blackjackTable.buildModal(SetConfigBlackjackTableModal.MODAL_NAME, reader))
+            SetConfigCommand.SUB_LOTTERY_BASICS ->
+                openModalAndRearm(ctx, section, lotteryBasics.buildModal(SetConfigLotteryBasicsModal.MODAL_NAME, reader))
+            SetConfigCommand.SUB_LOTTERY_POOLS ->
+                openModalAndRearm(ctx, section, lotteryPools.buildModal(SetConfigLotteryPoolsModal.MODAL_NAME, reader))
+            SetConfigCommand.SUB_STAKES -> {
+                val games = SetConfigStakesModal.Game.entries.map { it.label to it.token }
+                event.editMessageEmbeds(InstallWizard.stakesGameMenuEmbed())
+                    .setComponents(
+                        ActionRow.of(InstallWizard.stakesGameMenu(games)),
+                        InstallWizard.backAndFinishRow(),
+                    )
+                    .queue()
+            }
+            else -> event.reply("Unknown category `$categoryToken`.").setEphemeral(true).queue()
+        }
+    }
+
+    private fun handleStakesPick(
+        ctx: MenuContext,
+        selectedToken: String,
+        reader: (Configurations) -> String?,
+    ) {
+        val event = ctx.event
+        if (selectedToken == InstallWizard.STAKE_ALL_TOKEN) {
+            val (currentMin, currentMax) = allStakes.readCurrentDefaults(reader)
+            // Pass the Economy section so the modal-close rearm lands back
+            // in the section-detail menu (the natural home for Per-game stakes).
+            val section = WizardSection.ECONOMY
+            openModalAndRearm(ctx, section, allStakes.buildModal(currentMin, currentMax))
+            return
+        }
+        val game = SetConfigStakesModal.Game.byToken(selectedToken) ?: run {
+            event.reply("Unknown game `$selectedToken`.").setEphemeral(true).queue()
+            return
+        }
+        openModalAndRearm(
+            ctx,
+            WizardSection.ECONOMY,
+            stakes.buildModal(SetConfigStakesModal.customIdFor(game), reader),
+        )
+    }
+
+    /**
+     * Open [modal] and, once it's open, rearm the message back to the
+     * [section]'s detail menu so the owner can pick another category in
+     * the same section without re-navigating.
+     */
+    private fun openModalAndRearm(
+        ctx: MenuContext,
+        section: WizardSection,
+        modal: net.dv8tion.jda.api.modals.Modal,
+    ) {
+        val event = ctx.event
+        event.replyModal(modal).queue {
+            event.message.editMessageEmbeds(InstallWizard.sectionDetailEmbed(section))
+                .setComponents(
+                    ActionRow.of(InstallWizard.sectionDetailMenu(section)),
+                    InstallWizard.backAndFinishRow(),
+                )
+                .queue()
+        }
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/install/modal/InstallAllStakesModal.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/modal/InstallAllStakesModal.kt
@@ -1,0 +1,111 @@
+package bot.toby.install.modal
+
+import bot.toby.modal.modals.setconfig.SetConfigStakesModal
+import core.modal.Modal
+import core.modal.ModalContext
+import database.dto.ConfigDto.Configurations
+import database.service.ConfigService
+import net.dv8tion.jda.api.components.label.Label
+import net.dv8tion.jda.api.components.textinput.TextInput
+import net.dv8tion.jda.api.components.textinput.TextInputStyle
+import org.springframework.stereotype.Component
+import net.dv8tion.jda.api.modals.Modal as JdaModal
+
+/**
+ * "Apply to all games" stakes modal — writes a single (min, max) pair to
+ * every game's `*_MIN_STAKE` / `*_MAX_STAKE` keys at once, saving the
+ * owner from drilling into 10 individual modals when their stakes are
+ * uniform. Blank fields are skipped (no write); bot-suspicion edge caps
+ * are not touched (those vary per game and stay per-game-tunable via
+ * `/setconfig stakes <game>` or the wizard's per-game drill-down).
+ */
+@Component
+class InstallAllStakesModal(
+    private val configService: ConfigService,
+) : Modal {
+
+    override val name: String = MODAL_NAME
+
+    fun buildModal(currentMin: String?, currentMax: String?): JdaModal {
+        val minInput = TextInput.create(FIELD_MIN_STAKE, TextInputStyle.SHORT)
+            .setRequired(false)
+            .setPlaceholder("≥ 1 (applies to every game)")
+            .apply { currentMin?.takeIf { it.isNotEmpty() }?.let { setValue(it) } }
+            .build()
+        val maxInput = TextInput.create(FIELD_MAX_STAKE, TextInputStyle.SHORT)
+            .setRequired(false)
+            .setPlaceholder("≥ 1 (applies to every game)")
+            .apply { currentMax?.takeIf { it.isNotEmpty() }?.let { setValue(it) } }
+            .build()
+        return JdaModal.create(MODAL_NAME, "Apply stake bounds to all games")
+            .addComponents(
+                Label.of("Min stake (credits)", minInput),
+                Label.of("Max stake (credits)", maxInput),
+            )
+            .build()
+    }
+
+    override fun handle(ctx: ModalContext, deleteDelay: Int) {
+        val event = ctx.event
+        val guildId = ctx.guild.id
+
+        val minRaw = event.getValue(FIELD_MIN_STAKE)?.asString?.trim().orEmpty()
+        val maxRaw = event.getValue(FIELD_MAX_STAKE)?.asString?.trim().orEmpty()
+
+        val errors = mutableListOf<String>()
+        val min = if (minRaw.isEmpty()) null else minRaw.toLongOrNull()?.takeIf { it >= 1L }
+            ?: run { errors += "Min stake must be a whole number ≥ 1."; null }
+        val max = if (maxRaw.isEmpty()) null else maxRaw.toLongOrNull()?.takeIf { it >= 1L }
+            ?: run { errors += "Max stake must be a whole number ≥ 1."; null }
+        if (min != null && max != null && min > max) {
+            errors += "Min stake ($min) cannot exceed max stake ($max)."
+        }
+
+        if (errors.isNotEmpty()) {
+            event.reply(
+                "Couldn't save — fix these fields:\n" +
+                    errors.joinToString("\n") { "• $it" } +
+                    "\n\nNo changes were written."
+            ).setEphemeral(true).queue()
+            return
+        }
+        if (min == null && max == null) {
+            event.reply("No fields filled — nothing changed.").setEphemeral(true).queue()
+            return
+        }
+
+        val written = mutableListOf<Pair<String, String>>()
+        SetConfigStakesModal.Game.entries.forEach { game ->
+            if (min != null) {
+                configService.upsertConfig(game.minKey.configValue, min.toString(), guildId)
+            }
+            if (max != null) {
+                configService.upsertConfig(game.maxKey.configValue, max.toString(), guildId)
+            }
+        }
+        if (min != null) written += "Min stake" to min.toString()
+        if (max != null) written += "Max stake" to max.toString()
+
+        val gameCount = SetConfigStakesModal.Game.entries.size
+        val summary = buildString {
+            append("Applied to all $gameCount games:\n")
+            written.forEach { (label, value) -> append("• $label: $value\n") }
+        }
+        event.reply(summary).setEphemeral(true).queue()
+    }
+
+    @Suppress("unused") // referenced by the menu when reading current values
+    fun readCurrentDefaults(currentValues: (Configurations) -> String?): Pair<String?, String?> {
+        // Best-effort prefill: show whatever DICE has set (the first enum entry).
+        // Owners can overwrite freely; mismatches across games just mean the
+        // prefill isn't meaningful and they'll type fresh values anyway.
+        val dice = SetConfigStakesModal.Game.DICE
+        return currentValues(dice.minKey) to currentValues(dice.maxKey)
+    }
+
+    companion object {
+        const val MODAL_NAME = "install_all_stakes"
+        const val FIELD_MIN_STAKE = "min_stake"
+        const val FIELD_MAX_STAKE = "max_stake"
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/install/modal/InstallAllStakesModal.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/modal/InstallAllStakesModal.kt
@@ -72,6 +72,10 @@ class InstallAllStakesModal(
         }
 
         val written = mutableListOf<Pair<String, String>>()
+        // 10 games × up to 2 keys = up to 20 sequential upserts. This is a
+        // one-shot owner-initiated config write, not a hot path, so the
+        // serial round-trips are acceptable. If we ever expose batch
+        // writes on ConfigService (`upsertAll(list)`), swap to that.
         SetConfigStakesModal.Game.entries.forEach { game ->
             if (min != null) {
                 configService.upsertConfig(game.minKey.configValue, min.toString(), guildId)

--- a/discord-bot/src/main/kotlin/bot/toby/install/modal/InstallAllStakesModal.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/modal/InstallAllStakesModal.kt
@@ -3,7 +3,6 @@ package bot.toby.install.modal
 import bot.toby.modal.modals.setconfig.SetConfigStakesModal
 import core.modal.Modal
 import core.modal.ModalContext
-import database.dto.ConfigDto.Configurations
 import database.service.ConfigService
 import net.dv8tion.jda.api.components.label.Label
 import net.dv8tion.jda.api.components.textinput.TextInput
@@ -53,10 +52,8 @@ class InstallAllStakesModal(
         val maxRaw = event.getValue(FIELD_MAX_STAKE)?.asString?.trim().orEmpty()
 
         val errors = mutableListOf<String>()
-        val min = if (minRaw.isEmpty()) null else minRaw.toLongOrNull()?.takeIf { it >= 1L }
-            ?: run { errors += "Min stake must be a whole number ≥ 1."; null }
-        val max = if (maxRaw.isEmpty()) null else maxRaw.toLongOrNull()?.takeIf { it >= 1L }
-            ?: run { errors += "Max stake must be a whole number ≥ 1."; null }
+        val min = parseStakeBound("Min stake", minRaw, errors)
+        val max = parseStakeBound("Max stake", maxRaw, errors)
         if (min != null && max != null && min > max) {
             errors += "Min stake ($min) cannot exceed max stake ($max)."
         }
@@ -94,13 +91,23 @@ class InstallAllStakesModal(
         event.reply(summary).setEphemeral(true).queue()
     }
 
-    @Suppress("unused") // referenced by the menu when reading current values
-    fun readCurrentDefaults(currentValues: (Configurations) -> String?): Pair<String?, String?> {
-        // Best-effort prefill: show whatever DICE has set (the first enum entry).
-        // Owners can overwrite freely; mismatches across games just mean the
-        // prefill isn't meaningful and they'll type fresh values anyway.
-        val dice = SetConfigStakesModal.Game.DICE
-        return currentValues(dice.minKey) to currentValues(dice.maxKey)
+    /**
+     * Parses a whole-number stake bound from a modal field. Empty input
+     * means "skip the write" (null, no error). Anything else must parse
+     * to a Long and be ≥ 1; the error message distinguishes "couldn't
+     * parse" from "parsed but too small" so the owner knows why.
+     */
+    private fun parseStakeBound(label: String, raw: String, errors: MutableList<String>): Long? {
+        if (raw.isEmpty()) return null
+        val parsed = raw.toLongOrNull() ?: run {
+            errors += "$label must be a whole number."
+            return null
+        }
+        if (parsed < 1L) {
+            errors += "$label must be ≥ 1 (got $parsed)."
+            return null
+        }
+        return parsed
     }
 
     companion object {

--- a/discord-bot/src/main/kotlin/bot/toby/install/modal/InstallQuickChannelsModal.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/modal/InstallQuickChannelsModal.kt
@@ -1,0 +1,105 @@
+package bot.toby.install.modal
+
+import core.modal.Modal
+import core.modal.ModalContext
+import database.dto.ConfigDto.Configurations
+import database.service.ConfigService
+import net.dv8tion.jda.api.components.label.Label
+import net.dv8tion.jda.api.components.selections.EntitySelectMenu
+import net.dv8tion.jda.api.entities.channel.ChannelType
+import org.springframework.stereotype.Component
+import net.dv8tion.jda.api.modals.Modal as JdaModal
+
+/**
+ * Wizard-only modal that uses Discord's channel-picker
+ * [EntitySelectMenu] components instead of typed channel IDs/names. Two
+ * pickers in one shot — voice channel for the default move target, text
+ * channel for the leaderboard. Owners click their channels from a list;
+ * no looking up IDs.
+ *
+ * Discord modals support select menus inside `Label` since the late
+ * 2024 components-v2 API; JDA 6.3 exposes this via `Label.of(name, menu)`.
+ *
+ * On submit:
+ * - The voice channel selection's *name* is written to
+ *   `DEFAULT_MOVE_CHANNEL` (matches the existing
+ *   `SetConfigFieldValidator.FieldSpec.ChannelByIdStoreName` convention).
+ * - The text channel selection's *id* is written to
+ *   `LEADERBOARD_CHANNEL` (matches `ChannelByIdStoreId`).
+ *
+ * Either field can be left empty (no selection); empty selections skip
+ * the write.
+ */
+@Component
+class InstallQuickChannelsModal(
+    private val configService: ConfigService,
+) : Modal {
+
+    override val name: String = MODAL_NAME
+
+    fun buildModal(): JdaModal {
+        val moveMenu = EntitySelectMenu.create(FIELD_MOVE, EntitySelectMenu.SelectTarget.CHANNEL)
+            .setChannelTypes(ChannelType.VOICE)
+            .setRequiredRange(0, 1)
+            .build()
+        val leaderboardMenu = EntitySelectMenu.create(FIELD_LEADERBOARD, EntitySelectMenu.SelectTarget.CHANNEL)
+            .setChannelTypes(ChannelType.TEXT)
+            .setRequiredRange(0, 1)
+            .build()
+        return JdaModal.create(MODAL_NAME, "Quick channel setup")
+            .addComponents(
+                Label.of("Default move (voice) channel", moveMenu),
+                Label.of("Leaderboard (text) channel", leaderboardMenu),
+            )
+            .build()
+    }
+
+    override fun handle(ctx: ModalContext, deleteDelay: Int) {
+        val event = ctx.event
+        val guild = ctx.guild
+        val guildId = guild.id
+
+        val written = mutableListOf<String>()
+
+        val moveChannelId = event.getValue(FIELD_MOVE)?.asLongList?.firstOrNull()
+        if (moveChannelId != null) {
+            val channel = guild.getVoiceChannelById(moveChannelId)
+            if (channel == null) {
+                event.reply("Picked voice channel no longer exists. No changes were written.")
+                    .setEphemeral(true).queue()
+                return
+            }
+            configService.upsertConfig(Configurations.MOVE.configValue, channel.name, guildId)
+            written += "Move channel → #${channel.name}"
+        }
+
+        val leaderboardChannelId = event.getValue(FIELD_LEADERBOARD)?.asLongList?.firstOrNull()
+        if (leaderboardChannelId != null) {
+            val channel = guild.getTextChannelById(leaderboardChannelId)
+            if (channel == null) {
+                event.reply("Picked text channel no longer exists. No changes were written.")
+                    .setEphemeral(true).queue()
+                return
+            }
+            configService.upsertConfig(
+                Configurations.LEADERBOARD_CHANNEL.configValue,
+                leaderboardChannelId.toString(),
+                guildId,
+            )
+            written += "Leaderboard channel → #${channel.name}"
+        }
+
+        if (written.isEmpty()) {
+            event.reply("No channels picked — nothing changed.").setEphemeral(true).queue()
+        } else {
+            event.reply("Saved:\n" + written.joinToString("\n") { "• $it" })
+                .setEphemeral(true).queue()
+        }
+    }
+
+    companion object {
+        const val MODAL_NAME = "install_quick_channels"
+        const val FIELD_MOVE = "move_channel"
+        const val FIELD_LEADERBOARD = "leaderboard_channel"
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/configuration/JdaListenerRegistrarTest.kt
+++ b/discord-bot/src/test/kotlin/bot/configuration/JdaListenerRegistrarTest.kt
@@ -11,6 +11,7 @@ import bot.toby.handler.ModalEventListener
 import bot.toby.handler.SlashCommandEventListener
 import bot.toby.handler.StartUpHandler
 import bot.toby.handler.VoiceEventHandler
+import bot.toby.install.InstallWelcomeHandler
 import io.mockk.mockk
 import io.mockk.verify
 import net.dv8tion.jda.api.JDA
@@ -32,6 +33,7 @@ class JdaListenerRegistrarTest {
         val activityEventHandler = mockk<ActivityEventHandler>()
         val eventWaiter = mockk<EventWaiter>()
         val guildLeaveCleanupHandler = mockk<GuildLeaveCleanupHandler>()
+        val installWelcomeHandler = mockk<InstallWelcomeHandler>()
 
         JdaListenerRegistrar(
             jda,
@@ -46,6 +48,7 @@ class JdaListenerRegistrarTest {
             activityEventHandler,
             eventWaiter,
             guildLeaveCleanupHandler,
+            installWelcomeHandler,
         )
 
         verify {
@@ -61,6 +64,7 @@ class JdaListenerRegistrarTest {
                 activityEventHandler,
                 eventWaiter,
                 guildLeaveCleanupHandler,
+                installWelcomeHandler,
             )
         }
     }

--- a/discord-bot/src/test/kotlin/bot/toby/install/InstallCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/install/InstallCommandTest.kt
@@ -1,0 +1,98 @@
+package bot.toby.install
+
+import bot.toby.command.CommandTest
+import bot.toby.command.CommandTest.Companion.event
+import bot.toby.command.CommandTest.Companion.guild
+import bot.toby.command.CommandTest.Companion.member
+import bot.toby.command.CommandTest.Companion.replyCallbackAction
+import bot.toby.command.CommandTest.Companion.requestingUserDto
+import bot.toby.command.DefaultCommandContext
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.just
+import io.mockk.runs
+import io.mockk.slot
+import io.mockk.verify
+import net.dv8tion.jda.api.components.actionrow.ActionRow
+import net.dv8tion.jda.api.components.buttons.Button
+import net.dv8tion.jda.api.entities.MessageEmbed
+import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class InstallCommandTest : CommandTest {
+
+    private lateinit var command: InstallCommand
+
+    @BeforeEach
+    fun setUp() {
+        setUpCommonMocks()
+        command = InstallCommand()
+        every { event.reply(any<String>()) } returns replyCallbackAction
+        every { event.replyEmbeds(any<MessageEmbed>()) } returns replyCallbackAction
+        every { replyCallbackAction.addComponents(any<ActionRow>()) } returns replyCallbackAction
+        every { guild.name } returns "Test Guild"
+        every { member.isOwner } returns true
+    }
+
+    @AfterEach
+    fun tearDown() {
+        tearDownCommonMocks()
+        clearAllMocks()
+    }
+
+    @Test
+    fun `name is install`() {
+        assertEquals("install", command.name)
+        assertTrue(command.subCommands.isEmpty(), "install has no subcommands")
+    }
+
+    @Test
+    fun `non-owner gets ephemeral reject and no welcome posted`() {
+        every { member.isOwner } returns false
+
+        command.handle(DefaultCommandContext(event), requestingUserDto, 0)
+
+        verify(exactly = 1) {
+            event.reply(match<String> { it.contains("owner", ignoreCase = true) })
+        }
+        verify(exactly = 0) { event.replyEmbeds(any<MessageEmbed>()) }
+    }
+
+    @Test
+    fun `no-guild context replies ephemerally`() {
+        every { event.guild } returns null
+
+        command.handle(DefaultCommandContext(event), requestingUserDto, 0)
+
+        verify(exactly = 1) {
+            event.reply(match<String> { it.contains("server", ignoreCase = true) })
+        }
+        verify(exactly = 0) { event.replyEmbeds(any<MessageEmbed>()) }
+    }
+
+    @Test
+    fun `owner happy path posts welcome embed and the three wizard buttons`() {
+        val embedSlot = slot<MessageEmbed>()
+        val componentsSlot = slot<ActionRow>()
+        every { event.replyEmbeds(capture(embedSlot)) } returns replyCallbackAction
+        every { replyCallbackAction.addComponents(capture(componentsSlot)) } returns replyCallbackAction
+        every { replyCallbackAction.queue() } just runs
+
+        command.handle(DefaultCommandContext(event), requestingUserDto, 0)
+
+        verify(exactly = 1) { event.replyEmbeds(any<MessageEmbed>()) }
+        verify(exactly = 1) { replyCallbackAction.addComponents(any<ActionRow>()) }
+        // Embed mentions the guild name.
+        assertTrue(embedSlot.captured.description?.contains("Express") == true)
+        // Action row has exactly the three wizard buttons in order.
+        val buttons = componentsSlot.captured.components.filterIsInstance<Button>()
+        assertEquals(3, buttons.size)
+        assertEquals(InstallWizard.BTN_EXPRESS, buttons[0].customId)
+        assertEquals(InstallWizard.BTN_CUSTOM, buttons[1].customId)
+        assertEquals(InstallWizard.BTN_SKIP, buttons[2].customId)
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/install/InstallSentinelTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/install/InstallSentinelTest.kt
@@ -1,0 +1,103 @@
+package bot.toby.install
+
+import database.dto.ConfigDto
+import database.dto.ConfigDto.Configurations
+import database.service.ConfigService
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class InstallSentinelTest {
+
+    private lateinit var configService: ConfigService
+
+    @BeforeEach
+    fun setUp() {
+        configService = mockk(relaxed = true)
+    }
+
+    @Test
+    fun `writes INSTALL_MODE and INSTALLED_AT when sentinel is unset`() {
+        every {
+            configService.getConfigByName(Configurations.INSTALL_MODE.configValue, "g1")
+        } returns null
+        val installedAtSlot = slot<String>()
+        every {
+            configService.upsertConfig(Configurations.INSTALLED_AT.configValue, capture(installedAtSlot), "g1")
+        } returns mockk(relaxed = true)
+
+        val before = System.currentTimeMillis()
+        InstallSentinel.writeIfFresh(configService, "g1", mode = "express")
+        val after = System.currentTimeMillis()
+
+        verify(exactly = 1) {
+            configService.upsertConfig(Configurations.INSTALL_MODE.configValue, "express", "g1")
+        }
+        verify(exactly = 1) {
+            configService.upsertConfig(Configurations.INSTALLED_AT.configValue, any<String>(), "g1")
+        }
+        assertTrue(installedAtSlot.captured.toLong() in before..after)
+    }
+
+    @Test
+    fun `writes INSTALL_MODE=custom on first custom finish`() {
+        every {
+            configService.getConfigByName(Configurations.INSTALL_MODE.configValue, "g1")
+        } returns null
+
+        InstallSentinel.writeIfFresh(configService, "g1", mode = "custom")
+
+        verify(exactly = 1) {
+            configService.upsertConfig(Configurations.INSTALL_MODE.configValue, "custom", "g1")
+        }
+    }
+
+    @Test
+    fun `no-op when INSTALL_MODE is already express`() {
+        every {
+            configService.getConfigByName(Configurations.INSTALL_MODE.configValue, "g1")
+        } returns ConfigDto(Configurations.INSTALL_MODE.configValue, "express", "g1")
+
+        InstallSentinel.writeIfFresh(configService, "g1", mode = "custom")
+
+        // Read only — never overwritten with "custom".
+        verify(exactly = 1) {
+            configService.getConfigByName(Configurations.INSTALL_MODE.configValue, "g1")
+        }
+        verify(exactly = 0) {
+            configService.upsertConfig(any<String>(), any<String>(), any<String>())
+        }
+        confirmVerified(configService)
+    }
+
+    @Test
+    fun `no-op when INSTALL_MODE is already custom`() {
+        every {
+            configService.getConfigByName(Configurations.INSTALL_MODE.configValue, "g1")
+        } returns ConfigDto(Configurations.INSTALL_MODE.configValue, "custom", "g1")
+
+        InstallSentinel.writeIfFresh(configService, "g1", mode = "express")
+
+        verify(exactly = 0) {
+            configService.upsertConfig(any<String>(), any<String>(), any<String>())
+        }
+    }
+
+    @Test
+    fun `blank existing value is treated as unset and write proceeds`() {
+        every {
+            configService.getConfigByName(Configurations.INSTALL_MODE.configValue, "g1")
+        } returns ConfigDto(Configurations.INSTALL_MODE.configValue, "", "g1")
+
+        InstallSentinel.writeIfFresh(configService, "g1", mode = "express")
+
+        verify(exactly = 1) {
+            configService.upsertConfig(Configurations.INSTALL_MODE.configValue, "express", "g1")
+        }
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/install/InstallWelcomeHandlerTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/install/InstallWelcomeHandlerTest.kt
@@ -1,0 +1,183 @@
+package bot.toby.install
+
+import database.dto.ConfigDto
+import database.dto.ConfigDto.Configurations
+import database.service.ConfigService
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.verify
+import net.dv8tion.jda.api.Permission
+import net.dv8tion.jda.api.components.actionrow.ActionRow
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.Member
+import net.dv8tion.jda.api.entities.Message
+import net.dv8tion.jda.api.entities.MessageEmbed
+import net.dv8tion.jda.api.entities.SelfMember
+import net.dv8tion.jda.api.entities.User
+import net.dv8tion.jda.api.entities.channel.concrete.PrivateChannel
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
+import net.dv8tion.jda.api.events.guild.GuildJoinEvent
+import net.dv8tion.jda.api.requests.RestAction
+import net.dv8tion.jda.api.requests.restaction.CacheRestAction
+import net.dv8tion.jda.api.requests.restaction.MessageCreateAction
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class InstallWelcomeHandlerTest {
+
+    private lateinit var configService: ConfigService
+    private lateinit var handler: InstallWelcomeHandler
+    private lateinit var event: GuildJoinEvent
+    private lateinit var guild: Guild
+    private lateinit var selfMember: SelfMember
+    private lateinit var systemChannel: TextChannel
+    private lateinit var fallbackChannel: TextChannel
+    private lateinit var messageAction: MessageCreateAction
+
+    @BeforeEach
+    fun setUp() {
+        configService = mockk(relaxed = true)
+        handler = InstallWelcomeHandler(configService)
+
+        event = mockk(relaxed = true)
+        guild = mockk(relaxed = true)
+        selfMember = mockk(relaxed = true)
+        systemChannel = mockk(relaxed = true)
+        fallbackChannel = mockk(relaxed = true)
+        messageAction = mockk(relaxed = true)
+
+        every { event.guild } returns guild
+        every { guild.id } returns "100"
+        every { guild.name } returns "Test Guild"
+        every { guild.selfMember } returns selfMember
+        every { systemChannel.name } returns "general"
+        every { fallbackChannel.name } returns "fallback"
+
+        every { systemChannel.sendMessageEmbeds(any<MessageEmbed>()) } returns messageAction
+        every { fallbackChannel.sendMessageEmbeds(any<MessageEmbed>()) } returns messageAction
+        every { messageAction.addComponents(any<ActionRow>()) } returns messageAction
+        every { messageAction.queue() } just runs
+    }
+
+    @Test
+    fun `skips welcome when INSTALL_MODE is already set to express`() {
+        every { configService.getConfigByName(Configurations.INSTALL_MODE.configValue, "100") } returns
+            ConfigDto(Configurations.INSTALL_MODE.configValue, "express", "100")
+
+        handler.onGuildJoin(event)
+
+        verify(exactly = 1) {
+            configService.getConfigByName(Configurations.INSTALL_MODE.configValue, "100")
+        }
+        verify(exactly = 0) { systemChannel.sendMessageEmbeds(any<MessageEmbed>()) }
+        verify(exactly = 0) { fallbackChannel.sendMessageEmbeds(any<MessageEmbed>()) }
+    }
+
+    @Test
+    fun `skips welcome when INSTALL_MODE is already set to custom`() {
+        every { configService.getConfigByName(Configurations.INSTALL_MODE.configValue, "100") } returns
+            ConfigDto(Configurations.INSTALL_MODE.configValue, "custom", "100")
+
+        handler.onGuildJoin(event)
+
+        verify(exactly = 0) { systemChannel.sendMessageEmbeds(any<MessageEmbed>()) }
+    }
+
+    @Test
+    fun `posts to system channel when writable`() {
+        every { configService.getConfigByName(any(), any()) } returns null
+        every { guild.systemChannel } returns systemChannel
+        every {
+            selfMember.hasPermission(systemChannel, Permission.VIEW_CHANNEL, Permission.MESSAGE_SEND)
+        } returns true
+
+        handler.onGuildJoin(event)
+
+        verify(exactly = 1) { systemChannel.sendMessageEmbeds(any<MessageEmbed>()) }
+        verify(exactly = 1) { messageAction.addComponents(any<ActionRow>()) }
+    }
+
+    @Test
+    fun `falls back to first writable text channel when system channel not writable`() {
+        every { configService.getConfigByName(any(), any()) } returns null
+        every { guild.systemChannel } returns systemChannel
+        every {
+            selfMember.hasPermission(systemChannel, Permission.VIEW_CHANNEL, Permission.MESSAGE_SEND)
+        } returns false
+        every { guild.textChannels } returns listOf(fallbackChannel)
+        every {
+            selfMember.hasPermission(fallbackChannel, Permission.VIEW_CHANNEL, Permission.MESSAGE_SEND)
+        } returns true
+
+        handler.onGuildJoin(event)
+
+        verify(exactly = 0) { systemChannel.sendMessageEmbeds(any<MessageEmbed>()) }
+        verify(exactly = 1) { fallbackChannel.sendMessageEmbeds(any<MessageEmbed>()) }
+    }
+
+    @Test
+    fun `falls back to first writable text channel when system channel is null`() {
+        every { configService.getConfigByName(any(), any()) } returns null
+        every { guild.systemChannel } returns null
+        every { guild.textChannels } returns listOf(fallbackChannel)
+        every {
+            selfMember.hasPermission(fallbackChannel, Permission.VIEW_CHANNEL, Permission.MESSAGE_SEND)
+        } returns true
+
+        handler.onGuildJoin(event)
+
+        verify(exactly = 1) { fallbackChannel.sendMessageEmbeds(any<MessageEmbed>()) }
+    }
+
+    @Test
+    fun `dm fallback when no writable channel exists and guild owner resolvable`() {
+        every { configService.getConfigByName(any(), any()) } returns null
+        every { guild.systemChannel } returns null
+        every { guild.textChannels } returns listOf(fallbackChannel)
+        every {
+            selfMember.hasPermission(fallbackChannel, Permission.VIEW_CHANNEL, Permission.MESSAGE_SEND)
+        } returns false
+
+        val owner = mockk<Member>(relaxed = true)
+        val ownerUser = mockk<User>(relaxed = true)
+        val privateChannel = mockk<PrivateChannel>(relaxed = true)
+
+        @Suppress("UNCHECKED_CAST")
+        val openDmAction = mockk<CacheRestAction<PrivateChannel>>(relaxed = true)
+
+        @Suppress("UNCHECKED_CAST")
+        val sendAction = mockk<MessageCreateAction>(relaxed = true)
+
+        every { guild.owner } returns owner
+        every { owner.user } returns ownerUser
+        every { ownerUser.openPrivateChannel() } returns openDmAction
+        every { openDmAction.queue(any(), any()) } answers {
+            @Suppress("UNCHECKED_CAST")
+            (firstArg() as java.util.function.Consumer<PrivateChannel>).accept(privateChannel)
+        }
+        every { privateChannel.sendMessageEmbeds(any<MessageEmbed>()) } returns sendAction
+        every { sendAction.queue(any<java.util.function.Consumer<Message>>(), any()) } answers {}
+
+        handler.onGuildJoin(event)
+
+        verify(exactly = 0) { systemChannel.sendMessageEmbeds(any<MessageEmbed>()) }
+        verify(exactly = 0) { fallbackChannel.sendMessageEmbeds(any<MessageEmbed>()) }
+        verify(exactly = 1) { ownerUser.openPrivateChannel() }
+        verify(exactly = 1) { privateChannel.sendMessageEmbeds(any<MessageEmbed>()) }
+    }
+
+    @Test
+    fun `silent no-op when no writable channel exists and no resolvable owner`() {
+        every { configService.getConfigByName(any(), any()) } returns null
+        every { guild.systemChannel } returns null
+        every { guild.textChannels } returns emptyList()
+        every { guild.owner } returns null
+
+        handler.onGuildJoin(event)
+
+        verify(exactly = 0) { systemChannel.sendMessageEmbeds(any<MessageEmbed>()) }
+        verify(exactly = 0) { fallbackChannel.sendMessageEmbeds(any<MessageEmbed>()) }
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/install/InstallWizardTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/install/InstallWizardTest.kt
@@ -1,0 +1,201 @@
+package bot.toby.install
+
+import bot.toby.command.commands.moderation.SetConfigCommand
+import database.dto.ConfigDto.Configurations
+import net.dv8tion.jda.api.components.buttons.Button
+import net.dv8tion.jda.api.components.buttons.ButtonStyle
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests for the [InstallWizard] component factories. Catches accidental
+ * ID typos, broken option-value mappings, and embed copy regressions.
+ */
+internal class InstallWizardTest {
+
+    @Test
+    fun `wizardButtons returns the three welcome buttons in order`() {
+        val buttons = InstallWizard.wizardButtons().components.filterIsInstance<Button>()
+        assertEquals(3, buttons.size)
+        assertEquals(InstallWizard.BTN_EXPRESS, buttons[0].customId)
+        assertEquals(InstallWizard.BTN_CUSTOM, buttons[1].customId)
+        assertEquals(InstallWizard.BTN_SKIP, buttons[2].customId)
+    }
+
+    @Test
+    fun `finishButtonRow contains the finish button only`() {
+        val buttons = InstallWizard.finishButtonRow().components.filterIsInstance<Button>()
+        assertEquals(1, buttons.size)
+        assertEquals(InstallWizard.BTN_FINISH, buttons[0].customId)
+    }
+
+    @Test
+    fun `backButtonRow contains the back button only`() {
+        val buttons = InstallWizard.backButtonRow().components.filterIsInstance<Button>()
+        assertEquals(1, buttons.size)
+        assertEquals(InstallWizard.BTN_BACK, buttons[0].customId)
+    }
+
+    @Test
+    fun `customRootBottomRow has features then finish`() {
+        val buttons = InstallWizard.customRootBottomRow().components.filterIsInstance<Button>()
+        assertEquals(2, buttons.size)
+        assertEquals(InstallWizard.BTN_FEATURES, buttons[0].customId)
+        assertEquals(InstallWizard.BTN_FINISH, buttons[1].customId)
+    }
+
+    @Test
+    fun `backAndFinishRow has back then finish`() {
+        val buttons = InstallWizard.backAndFinishRow().components.filterIsInstance<Button>()
+        assertEquals(2, buttons.size)
+        assertEquals(InstallWizard.BTN_BACK, buttons[0].customId)
+        assertEquals(InstallWizard.BTN_FINISH, buttons[1].customId)
+    }
+
+    @Test
+    fun `sectionMenu shows all six sections when all opt-ins on`() {
+        val reader: (Configurations) -> String? = { "true" }
+        val menu = InstallWizard.sectionMenu(reader)
+        assertEquals(InstallWizard.MENU_SECTION, menu.customId)
+        assertEquals(WizardSection.entries.size, menu.options.size)
+    }
+
+    @Test
+    fun `sectionMenu hides gated sections when opt-ins are off`() {
+        val reader: (Configurations) -> String? = { null }
+        val menu = InstallWizard.sectionMenu(reader)
+        val ids = menu.options.map { it.value }
+        assertTrue(ids.contains(WizardSection.GENERAL.id))
+        assertTrue(ids.contains(WizardSection.ECONOMY.id))
+        assertTrue(ids.contains(WizardSection.POKER.id))
+        assertTrue(ids.contains(WizardSection.BLACKJACK.id))
+        // Activity + Lottery hidden.
+        assertEquals(false, ids.contains(WizardSection.ACTIVITY.id))
+        assertEquals(false, ids.contains(WizardSection.LOTTERY.id))
+    }
+
+    @Test
+    fun `sectionDetailMenu has the right componentId and category options`() {
+        val section = WizardSection.ECONOMY
+        val menu = InstallWizard.sectionDetailMenu(section)
+        assertEquals("${InstallWizard.MENU_SECTION_DETAIL_PREFIX}:${section.id}", menu.customId)
+        val values = menu.options.map { it.value }
+        assertEquals(section.categories.map { it.token }, values)
+    }
+
+    @Test
+    fun `sectionDetailMenuId encodes the section id`() {
+        assertEquals(
+            "install_section_detail:poker",
+            InstallWizard.sectionDetailMenuId("poker"),
+        )
+    }
+
+    @Test
+    fun `stakesGameMenu puts apply-to-all first then all the games`() {
+        val games = listOf("Dice" to "dice", "Slots" to "slots", "Roulette" to "roulette")
+        val menu = InstallWizard.stakesGameMenu(games)
+        assertEquals(InstallWizard.MENU_CATEGORY_STAKES, menu.customId)
+        assertEquals(1 + games.size, menu.options.size)
+        assertEquals(InstallWizard.STAKE_ALL_TOKEN, menu.options[0].value)
+        assertEquals("dice", menu.options[1].value)
+        assertEquals("slots", menu.options[2].value)
+        assertEquals("roulette", menu.options[3].value)
+    }
+
+    @Test
+    fun `toggleRow has one button per OptInFeatures entry in declaration order`() {
+        val reader: (Configurations) -> String? = { null }  // all off
+        val buttons = InstallWizard.toggleRow(reader).components.filterIsInstance<Button>()
+        assertEquals(OptInFeatures.entries.size, buttons.size)
+        OptInFeatures.entries.forEachIndexed { i, feature ->
+            assertEquals("${InstallWizard.BTN_TOGGLE_PREFIX}:${feature.key.name}", buttons[i].customId)
+        }
+    }
+
+    @Test
+    fun `toggleRow shows ON green and OFF gray styling per current state`() {
+        val reader: (Configurations) -> String? = { key ->
+            if (key == Configurations.ACTIVITY_TRACKING) "true" else "false"
+        }
+        val buttons = InstallWizard.toggleRow(reader).components.filterIsInstance<Button>()
+        val activity = buttons.first { it.customId?.endsWith(":ACTIVITY_TRACKING") == true }
+        val lottery = buttons.first { it.customId?.endsWith(":LOTTERY_DAILY_ENABLED") == true }
+        assertEquals(ButtonStyle.SUCCESS, activity.style)
+        assertTrue(activity.label.contains("ON"))
+        assertEquals(ButtonStyle.SECONDARY, lottery.style)
+        assertTrue(lottery.label.contains("OFF"))
+    }
+
+    @Test
+    fun `toggleRow treats non-true values as off`() {
+        val reader: (Configurations) -> String? = { _ -> "FALSE" }
+        val buttons = InstallWizard.toggleRow(reader).components.filterIsInstance<Button>()
+        buttons.forEach { btn ->
+            assertEquals(ButtonStyle.SECONDARY, btn.style)
+            assertTrue(btn.label.contains("OFF"))
+        }
+    }
+
+    @Test
+    fun `every welcome embed factory returns a nonempty description`() {
+        val embeds = listOf(
+            InstallWizard.welcomeEmbed("Guild"),
+            InstallWizard.dmWelcomeEmbed("Guild"),
+            InstallWizard.expressDoneEmbed(),
+            InstallWizard.customSectionEmbed(),
+            InstallWizard.togglesEmbed(),
+            InstallWizard.skipDismissedEmbed(),
+            InstallWizard.finishDoneEmbed(),
+            InstallWizard.stakesGameMenuEmbed(),
+            InstallWizard.sectionDetailEmbed(WizardSection.POKER),
+        )
+        embeds.forEach { embed ->
+            assertNotNull(embed.description)
+            assertTrue(embed.description!!.isNotBlank())
+        }
+    }
+
+    @Test
+    fun `welcome embed lists key defaults`() {
+        val description = InstallWizard.welcomeEmbed("Test").description!!
+        // Catches a future copy edit that drops the default-disclosure.
+        assertTrue(description.contains("Activity tracking", ignoreCase = true))
+        assertTrue(description.contains("Daily lottery", ignoreCase = true))
+        assertTrue(description.contains("OFF"))
+    }
+
+    @Test
+    fun `dmWelcomeEmbed mentions install command and guild name`() {
+        val embed = InstallWizard.dmWelcomeEmbed("Alpha")
+        assertTrue(embed.title!!.contains("Alpha"))
+        assertTrue(embed.description!!.contains("/install"))
+    }
+
+    @Test
+    fun `welcome embed mentions the guild name`() {
+        val embed = InstallWizard.welcomeEmbed("MyServer")
+        assertTrue(embed.title!!.contains("MyServer"))
+    }
+
+    @Test
+    fun `every category token in WizardSection is a known SetConfig SUB or wizard-internal token`() {
+        val knownSubs = setOf(
+            SetConfigCommand.SUB_GENERAL, SetConfigCommand.SUB_ACTIVITY, SetConfigCommand.SUB_FEES,
+            SetConfigCommand.SUB_JACKPOT, SetConfigCommand.SUB_JACKPOT_ACTIVITY,
+            SetConfigCommand.SUB_POKER_STAKES, SetConfigCommand.SUB_POKER_TABLE,
+            SetConfigCommand.SUB_BLACKJACK_RULES, SetConfigCommand.SUB_BLACKJACK_TABLE,
+            SetConfigCommand.SUB_LOTTERY_BASICS, SetConfigCommand.SUB_LOTTERY_POOLS,
+            SetConfigCommand.SUB_STAKES,
+        )
+        val wizardInternal = setOf(bot.toby.install.QUICK_CHANNELS_TOKEN)
+        WizardSection.entries.flatMap { it.categories }.forEach { cat ->
+            assertTrue(
+                knownSubs.contains(cat.token) || wizardInternal.contains(cat.token),
+                "category token '${cat.token}' is not a known SetConfigCommand SUB constant or wizard-internal token",
+            )
+        }
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/install/InstallWizardTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/install/InstallWizardTest.kt
@@ -160,8 +160,11 @@ internal class InstallWizardTest {
 
     @Test
     fun `welcome embed lists key defaults`() {
+        // Intentional copy-coupling: the welcome embed exists to tell owners
+        // what "Express" will accept, so dropping any of these mentions is a
+        // regression the test should catch. If copy is reworded, update these
+        // assertions in the same commit — that's the workflow signal.
         val description = InstallWizard.welcomeEmbed("Test").description!!
-        // Catches a future copy edit that drops the default-disclosure.
         assertTrue(description.contains("Activity tracking", ignoreCase = true))
         assertTrue(description.contains("Daily lottery", ignoreCase = true))
         assertTrue(description.contains("OFF"))

--- a/discord-bot/src/test/kotlin/bot/toby/install/OptInFeaturesTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/install/OptInFeaturesTest.kt
@@ -1,0 +1,49 @@
+package bot.toby.install
+
+import database.dto.ConfigDto.Configurations
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+internal class OptInFeaturesTest {
+
+    @Test
+    fun `byKeyName resolves the activity tracking key`() {
+        val feature = OptInFeatures.byKeyName("ACTIVITY_TRACKING")
+        assertNotNull(feature)
+        assertEquals(OptInFeatures.ACTIVITY_TRACKING, feature)
+    }
+
+    @Test
+    fun `byKeyName resolves the lottery daily key`() {
+        val feature = OptInFeatures.byKeyName("LOTTERY_DAILY_ENABLED")
+        assertNotNull(feature)
+        assertEquals(OptInFeatures.LOTTERY_DAILY, feature)
+    }
+
+    @Test
+    fun `byKeyName returns null for non-opt-in keys`() {
+        assertNull(OptInFeatures.byKeyName("DEFAULT_VOLUME"))
+        assertNull(OptInFeatures.byKeyName(""))
+        assertNull(OptInFeatures.byKeyName("NOPE"))
+    }
+
+    @Test
+    fun `every entry roundtrips through Configurations`() {
+        // Catches a future rename in ConfigDto silently breaking a toggle.
+        OptInFeatures.entries.forEach { feature ->
+            val resolved = Configurations.valueOf(feature.key.name)
+            assertEquals(feature.key, resolved, "entry ${feature.name} does not roundtrip")
+        }
+    }
+
+    @Test
+    fun `every entry has nonblank label and description`() {
+        OptInFeatures.entries.forEach { feature ->
+            assertTrue(feature.label.isNotBlank(), "${feature.name} label is blank")
+            assertTrue(feature.description.isNotBlank(), "${feature.name} description is blank")
+        }
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/install/WizardSectionTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/install/WizardSectionTest.kt
@@ -1,0 +1,102 @@
+package bot.toby.install
+
+import database.dto.ConfigDto.Configurations
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+internal class WizardSectionTest {
+
+    @Test
+    fun `byId resolves every section`() {
+        WizardSection.entries.forEach { section ->
+            assertEquals(section, WizardSection.byId(section.id))
+        }
+    }
+
+    @Test
+    fun `byId returns null on unknown`() {
+        assertNull(WizardSection.byId(""))
+        assertNull(WizardSection.byId("not-a-section"))
+    }
+
+    @Test
+    fun `gated sections are hidden when their opt-in is off`() {
+        val reader: (Configurations) -> String? = { _ -> null }  // everything off
+        val visible = WizardSection.visibleFor(reader)
+        assertFalse(visible.contains(WizardSection.ACTIVITY))
+        assertFalse(visible.contains(WizardSection.LOTTERY))
+        // Non-gated sections are always visible.
+        assertTrue(visible.contains(WizardSection.GENERAL))
+        assertTrue(visible.contains(WizardSection.ECONOMY))
+        assertTrue(visible.contains(WizardSection.POKER))
+        assertTrue(visible.contains(WizardSection.BLACKJACK))
+    }
+
+    @Test
+    fun `gated sections appear when their opt-in is true`() {
+        val reader: (Configurations) -> String? = { key ->
+            if (key == Configurations.ACTIVITY_TRACKING || key == Configurations.LOTTERY_DAILY_ENABLED) "true"
+            else null
+        }
+        val visible = WizardSection.visibleFor(reader)
+        assertTrue(visible.contains(WizardSection.ACTIVITY))
+        assertTrue(visible.contains(WizardSection.LOTTERY))
+        // All six sections are visible in this scenario.
+        assertEquals(WizardSection.entries.size, visible.size)
+    }
+
+    @Test
+    fun `gated sections treat any non-true value as off`() {
+        val reader: (Configurations) -> String? = { _ -> "false" }
+        val visible = WizardSection.visibleFor(reader)
+        assertFalse(visible.contains(WizardSection.ACTIVITY))
+        assertFalse(visible.contains(WizardSection.LOTTERY))
+    }
+
+    @Test
+    fun `every section has at least one category`() {
+        WizardSection.entries.forEach { section ->
+            assertTrue(section.categories.isNotEmpty(), "${section.name} has no categories")
+        }
+    }
+
+    @Test
+    fun `activity section is gated by ACTIVITY_TRACKING`() {
+        assertEquals(OptInFeatures.ACTIVITY_TRACKING, WizardSection.ACTIVITY.gate)
+    }
+
+    @Test
+    fun `lottery section is gated by LOTTERY_DAILY`() {
+        assertEquals(OptInFeatures.LOTTERY_DAILY, WizardSection.LOTTERY.gate)
+    }
+
+    @Test
+    fun `non-gated sections have null gate`() {
+        assertNull(WizardSection.GENERAL.gate)
+        assertNull(WizardSection.ECONOMY.gate)
+        assertNull(WizardSection.POKER.gate)
+        assertNull(WizardSection.BLACKJACK.gate)
+    }
+
+    @Test
+    fun `economy section contains per-game stakes`() {
+        val tokens = WizardSection.ECONOMY.categories.map { it.token }
+        assertTrue(tokens.contains("stakes"))
+    }
+
+    @Test
+    fun `general section exposes the quick-channels entry`() {
+        val tokens = WizardSection.GENERAL.categories.map { it.token }
+        assertTrue(tokens.contains(QUICK_CHANNELS_TOKEN), "quick_channels missing from General section")
+    }
+
+    @Test
+    fun `every section id is unique`() {
+        val ids = WizardSection.entries.map { it.id }
+        assertEquals(ids.size, ids.toSet().size, "section ids must be unique")
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/install/button/InstallBackButtonTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/install/button/InstallBackButtonTest.kt
@@ -1,0 +1,56 @@
+package bot.toby.install.button
+
+import database.service.ConfigService
+import io.mockk.mockk
+import io.mockk.verify
+import net.dv8tion.jda.api.components.MessageTopLevelComponent
+import net.dv8tion.jda.api.entities.MessageEmbed
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class InstallBackButtonTest {
+
+    private lateinit var configService: ConfigService
+    private lateinit var button: InstallBackButton
+    private lateinit var fx: InstallButtonFixture
+
+    @BeforeEach
+    fun setUp() {
+        configService = mockk(relaxed = true)
+        button = InstallBackButton(configService)
+        fx = InstallButtonFixture()
+    }
+
+    @Test
+    fun `defersReply is false`() {
+        assertEquals(false, button.defersReply)
+    }
+
+    @Test
+    fun `non-owner is rejected with no edits or writes`() {
+        fx.asNonOwner()
+
+        button.handle(fx.ctx, mockk(relaxed = true), 0)
+
+        verify(exactly = 1) { fx.event.reply(any<String>()) }
+        verify(exactly = 0) { fx.hook.editOriginalEmbeds(any<MessageEmbed>()) }
+        verify(exactly = 0) {
+            configService.upsertConfig(any<String>(), any<String>(), any<String>())
+        }
+    }
+
+    @Test
+    fun `owner happy path restores section menu and bottom row without DB writes`() {
+        button.handle(fx.ctx, mockk(relaxed = true), 0)
+
+        verify(exactly = 1) { fx.event.deferEdit() }
+        verify(exactly = 1) { fx.hook.editOriginalEmbeds(any<MessageEmbed>()) }
+        verify(exactly = 1) {
+            fx.editAction.setComponents(*anyVararg<MessageTopLevelComponent>())
+        }
+        verify(exactly = 0) {
+            configService.upsertConfig(any<String>(), any<String>(), any<String>())
+        }
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/install/button/InstallBackButtonTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/install/button/InstallBackButtonTest.kt
@@ -47,7 +47,7 @@ internal class InstallBackButtonTest {
         verify(exactly = 1) { fx.event.deferEdit() }
         verify(exactly = 1) { fx.hook.editOriginalEmbeds(any<MessageEmbed>()) }
         verify(exactly = 1) {
-            fx.editAction.setComponents(*anyVararg<MessageTopLevelComponent>())
+            fx.editAction.setComponents(any<Collection<MessageTopLevelComponent>>())
         }
         verify(exactly = 0) {
             configService.upsertConfig(any<String>(), any<String>(), any<String>())

--- a/discord-bot/src/test/kotlin/bot/toby/install/button/InstallButtonFixture.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/install/button/InstallButtonFixture.kt
@@ -45,6 +45,9 @@ internal class InstallButtonFixture(guildId: String = "g1") {
         }
         every { hook.editOriginalEmbeds(any<MessageEmbed>()) } returns editAction
         every { editAction.setComponents(*anyVararg<MessageTopLevelComponent>()) } returns editAction
+        every {
+            editAction.setComponents(any<Collection<MessageTopLevelComponent>>())
+        } returns editAction
         every { editAction.queue() } just Runs
 
         ctx = mockk {

--- a/discord-bot/src/test/kotlin/bot/toby/install/button/InstallButtonFixture.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/install/button/InstallButtonFixture.kt
@@ -1,0 +1,59 @@
+package bot.toby.install.button
+
+import core.button.ButtonContext
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import net.dv8tion.jda.api.components.MessageTopLevelComponent
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.Member
+import net.dv8tion.jda.api.entities.Message
+import net.dv8tion.jda.api.entities.MessageEmbed
+import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent
+import net.dv8tion.jda.api.interactions.InteractionHook
+import net.dv8tion.jda.api.requests.restaction.WebhookMessageEditAction
+
+/**
+ * Shared mockk fixture for install-button tests. Each test class
+ * instantiates this, configures owner state, optionally stubs the
+ * source message's components for [InstallToggleButton] context
+ * preservation, and runs the button under test against [ctx].
+ */
+internal class InstallButtonFixture(guildId: String = "g1") {
+    val event: ButtonInteractionEvent = mockk(relaxed = true)
+    val hook: InteractionHook = mockk(relaxed = true)
+    val member: Member = mockk(relaxed = true)
+    val guild: Guild = mockk(relaxed = true)
+    val message: Message = mockk(relaxed = true)
+    val ctx: ButtonContext
+
+    @Suppress("UNCHECKED_CAST")
+    val editAction: WebhookMessageEditAction<Message> =
+        mockk<WebhookMessageEditAction<Message>>(relaxed = true)
+
+    init {
+        every { member.isOwner } returns true
+        every { guild.id } returns guildId
+        every { event.member } returns member
+        every { event.hook } returns hook
+        every { event.message } returns message
+        every { event.deferEdit() } returns mockk(relaxed = true)
+        every { event.reply(any<String>()) } returns mockk(relaxed = true) {
+            every { setEphemeral(any()) } returns this
+            every { queue() } just Runs
+        }
+        every { hook.editOriginalEmbeds(any<MessageEmbed>()) } returns editAction
+        every { editAction.setComponents(*anyVararg<MessageTopLevelComponent>()) } returns editAction
+        every { editAction.queue() } just Runs
+
+        ctx = mockk {
+            every { this@mockk.event } returns this@InstallButtonFixture.event
+            every { this@mockk.guild } returns this@InstallButtonFixture.guild
+        }
+    }
+
+    fun asNonOwner() {
+        every { member.isOwner } returns false
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/install/button/InstallCustomButtonTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/install/button/InstallCustomButtonTest.kt
@@ -59,7 +59,7 @@ internal class InstallCustomButtonTest {
         verify(exactly = 1) { fx.event.deferEdit() }
         verify(exactly = 1) { fx.hook.editOriginalEmbeds(any<MessageEmbed>()) }
         verify(exactly = 1) {
-            fx.editAction.setComponents(*anyVararg<MessageTopLevelComponent>())
+            fx.editAction.setComponents(any<Collection<MessageTopLevelComponent>>())
         }
     }
 }

--- a/discord-bot/src/test/kotlin/bot/toby/install/button/InstallCustomButtonTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/install/button/InstallCustomButtonTest.kt
@@ -1,0 +1,65 @@
+package bot.toby.install.button
+
+import database.service.ConfigService
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import net.dv8tion.jda.api.components.MessageTopLevelComponent
+import net.dv8tion.jda.api.entities.MessageEmbed
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class InstallCustomButtonTest {
+
+    private lateinit var configService: ConfigService
+    private lateinit var button: InstallCustomButton
+    private lateinit var fx: InstallButtonFixture
+
+    @BeforeEach
+    fun setUp() {
+        configService = mockk(relaxed = true)
+        button = InstallCustomButton(configService)
+        fx = InstallButtonFixture()
+    }
+
+    @Test
+    fun `defersReply is false`() {
+        assertEquals(false, button.defersReply)
+    }
+
+    @Test
+    fun `non-owner is rejected with no writes or edits`() {
+        fx.asNonOwner()
+
+        button.handle(fx.ctx, mockk(relaxed = true), 0)
+
+        verify(exactly = 1) { fx.event.reply(any<String>()) }
+        verify(exactly = 0) {
+            configService.upsertConfig(any<String>(), any<String>(), any<String>())
+        }
+        verify(exactly = 0) { fx.hook.editOriginalEmbeds(any<MessageEmbed>()) }
+        verify(exactly = 0) { fx.event.deferEdit() }
+    }
+
+    @Test
+    fun `owner happy path performs no DB writes`() {
+        button.handle(fx.ctx, mockk(relaxed = true), 0)
+
+        verify(exactly = 0) {
+            configService.upsertConfig(any<String>(), any<String>(), any<String>())
+        }
+    }
+
+    @Test
+    fun `owner happy path defers edit then swaps to section menu plus bottom row`() {
+        button.handle(fx.ctx, mockk(relaxed = true), 0)
+
+        verify(exactly = 1) { fx.event.deferEdit() }
+        verify(exactly = 1) { fx.hook.editOriginalEmbeds(any<MessageEmbed>()) }
+        verify(exactly = 1) {
+            fx.editAction.setComponents(*anyVararg<MessageTopLevelComponent>())
+        }
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/install/button/InstallExpressButtonTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/install/button/InstallExpressButtonTest.kt
@@ -1,0 +1,119 @@
+package bot.toby.install.button
+
+import bot.toby.install.InstallWizard
+import core.button.ButtonContext
+import database.dto.ConfigDto
+import database.dto.ConfigDto.Configurations
+import database.service.ConfigService
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import net.dv8tion.jda.api.components.MessageTopLevelComponent
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.Member
+import net.dv8tion.jda.api.entities.Message
+import net.dv8tion.jda.api.entities.MessageEmbed
+import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent
+import net.dv8tion.jda.api.interactions.InteractionHook
+import net.dv8tion.jda.api.requests.restaction.WebhookMessageEditAction
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class InstallExpressButtonTest {
+
+    private lateinit var configService: ConfigService
+    private lateinit var button: InstallExpressButton
+    private lateinit var ctx: ButtonContext
+    private lateinit var event: ButtonInteractionEvent
+    private lateinit var hook: InteractionHook
+    private lateinit var member: Member
+    private lateinit var guild: Guild
+    private lateinit var editAction: WebhookMessageEditAction<Message>
+
+    @BeforeEach
+    fun setUp() {
+        configService = mockk(relaxed = true)
+        button = InstallExpressButton(configService)
+
+        hook = mockk(relaxed = true)
+        member = mockk(relaxed = true) { every { isOwner } returns true }
+        guild = mockk(relaxed = true) { every { id } returns "g1" }
+
+        event = mockk(relaxed = true) {
+            every { this@mockk.member } returns this@InstallExpressButtonTest.member
+            every { this@mockk.hook } returns this@InstallExpressButtonTest.hook
+            every { deferEdit() } returns mockk(relaxed = true)
+            every { reply(any<String>()) } returns mockk(relaxed = true) {
+                every { setEphemeral(any()) } returns this
+                every { queue() } just Runs
+            }
+        }
+        ctx = mockk {
+            every { this@mockk.event } returns this@InstallExpressButtonTest.event
+            every { this@mockk.guild } returns this@InstallExpressButtonTest.guild
+        }
+
+        @Suppress("UNCHECKED_CAST")
+        editAction = mockk<WebhookMessageEditAction<Message>>(relaxed = true)
+        every { hook.editOriginalEmbeds(any<MessageEmbed>()) } returns editAction
+        every { editAction.setComponents(*anyVararg<MessageTopLevelComponent>()) } returns editAction
+        every { editAction.queue() } just Runs
+    }
+
+    @Test
+    fun `defersReply is false`() {
+        assertEquals(false, button.defersReply)
+    }
+
+    @Test
+    fun `non-owner is rejected ephemerally with no DB writes or edits`() {
+        every { member.isOwner } returns false
+
+        button.handle(ctx, mockk(relaxed = true), 0)
+
+        verify(exactly = 1) { event.reply(any<String>()) }
+        verify(exactly = 0) {
+            configService.upsertConfig(any<String>(), any<String>(), any<String>())
+        }
+        verify(exactly = 0) { hook.editOriginalEmbeds(any<MessageEmbed>()) }
+        verify(exactly = 0) { event.deferEdit() }
+    }
+
+    @Test
+    fun `owner happy path writes INSTALL_MODE express then INSTALLED_AT epoch`() {
+        val installedAtSlot = slot<String>()
+        every {
+            configService.upsertConfig(Configurations.INSTALLED_AT.configValue, capture(installedAtSlot), "g1")
+        } returns mockk(relaxed = true)
+
+        val before = System.currentTimeMillis()
+        button.handle(ctx, mockk(relaxed = true), 0)
+        val after = System.currentTimeMillis()
+
+        verify(exactly = 1) {
+            configService.upsertConfig(Configurations.INSTALL_MODE.configValue, "express", "g1")
+        }
+        verify(exactly = 1) {
+            configService.upsertConfig(Configurations.INSTALLED_AT.configValue, any<String>(), "g1")
+        }
+        val capturedEpoch = installedAtSlot.captured.toLong()
+        assertTrue(capturedEpoch in before..after, "INSTALLED_AT epoch should be ~now")
+    }
+
+    @Test
+    fun `owner happy path defers edit then shows done embed with stripped components`() {
+        button.handle(ctx, mockk(relaxed = true), 0)
+
+        verify(exactly = 1) { event.deferEdit() }
+        verify(exactly = 1) { hook.editOriginalEmbeds(any<MessageEmbed>()) }
+        verify(exactly = 1) {
+            editAction.setComponents(*anyVararg<MessageTopLevelComponent>())
+        }
+        verify(exactly = 1) { editAction.queue() }
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/install/button/InstallFeaturesButtonTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/install/button/InstallFeaturesButtonTest.kt
@@ -1,0 +1,62 @@
+package bot.toby.install.button
+
+import database.service.ConfigService
+import io.mockk.mockk
+import io.mockk.verify
+import net.dv8tion.jda.api.components.MessageTopLevelComponent
+import net.dv8tion.jda.api.entities.MessageEmbed
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class InstallFeaturesButtonTest {
+
+    private lateinit var configService: ConfigService
+    private lateinit var button: InstallFeaturesButton
+    private lateinit var fx: InstallButtonFixture
+
+    @BeforeEach
+    fun setUp() {
+        configService = mockk(relaxed = true)
+        button = InstallFeaturesButton(configService)
+        fx = InstallButtonFixture()
+    }
+
+    @Test
+    fun `defersReply is false`() {
+        assertEquals(false, button.defersReply)
+    }
+
+    @Test
+    fun `non-owner is rejected with no writes or edits`() {
+        fx.asNonOwner()
+
+        button.handle(fx.ctx, mockk(relaxed = true), 0)
+
+        verify(exactly = 1) { fx.event.reply(any<String>()) }
+        verify(exactly = 0) {
+            configService.upsertConfig(any<String>(), any<String>(), any<String>())
+        }
+        verify(exactly = 0) { fx.hook.editOriginalEmbeds(any<MessageEmbed>()) }
+    }
+
+    @Test
+    fun `owner happy path performs no DB writes`() {
+        button.handle(fx.ctx, mockk(relaxed = true), 0)
+
+        verify(exactly = 0) {
+            configService.upsertConfig(any<String>(), any<String>(), any<String>())
+        }
+    }
+
+    @Test
+    fun `owner happy path opens the toggle view via edit`() {
+        button.handle(fx.ctx, mockk(relaxed = true), 0)
+
+        verify(exactly = 1) { fx.event.deferEdit() }
+        verify(exactly = 1) { fx.hook.editOriginalEmbeds(any<MessageEmbed>()) }
+        verify(exactly = 1) {
+            fx.editAction.setComponents(*anyVararg<MessageTopLevelComponent>())
+        }
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/install/button/InstallFinishButtonTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/install/button/InstallFinishButtonTest.kt
@@ -1,0 +1,79 @@
+package bot.toby.install.button
+
+import database.dto.ConfigDto.Configurations
+import database.service.ConfigService
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import net.dv8tion.jda.api.components.MessageTopLevelComponent
+import net.dv8tion.jda.api.entities.MessageEmbed
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class InstallFinishButtonTest {
+
+    private lateinit var configService: ConfigService
+    private lateinit var button: InstallFinishButton
+    private lateinit var fx: InstallButtonFixture
+
+    @BeforeEach
+    fun setUp() {
+        configService = mockk(relaxed = true)
+        button = InstallFinishButton(configService)
+        fx = InstallButtonFixture()
+    }
+
+    @Test
+    fun `defersReply is false`() {
+        assertEquals(false, button.defersReply)
+    }
+
+    @Test
+    fun `non-owner is rejected with no writes or edits`() {
+        fx.asNonOwner()
+
+        button.handle(fx.ctx, mockk(relaxed = true), 0)
+
+        verify(exactly = 1) { fx.event.reply(any<String>()) }
+        verify(exactly = 0) {
+            configService.upsertConfig(any<String>(), any<String>(), any<String>())
+        }
+        verify(exactly = 0) { fx.hook.editOriginalEmbeds(any<MessageEmbed>()) }
+    }
+
+    @Test
+    fun `owner happy path writes INSTALL_MODE custom and a fresh INSTALLED_AT epoch`() {
+        val installedAtSlot = slot<String>()
+        every {
+            configService.upsertConfig(Configurations.INSTALLED_AT.configValue, capture(installedAtSlot), "g1")
+        } returns mockk(relaxed = true)
+
+        val before = System.currentTimeMillis()
+        button.handle(fx.ctx, mockk(relaxed = true), 0)
+        val after = System.currentTimeMillis()
+
+        verify(exactly = 1) {
+            configService.upsertConfig(Configurations.INSTALL_MODE.configValue, "custom", "g1")
+        }
+        verify(exactly = 1) {
+            configService.upsertConfig(Configurations.INSTALLED_AT.configValue, any<String>(), "g1")
+        }
+        val capturedEpoch = installedAtSlot.captured.toLong()
+        assertTrue(capturedEpoch in before..after, "INSTALLED_AT epoch should be ~now")
+    }
+
+    @Test
+    fun `owner happy path defers edit then shows finish-done embed with stripped components`() {
+        button.handle(fx.ctx, mockk(relaxed = true), 0)
+
+        verify(exactly = 1) { fx.event.deferEdit() }
+        verify(exactly = 1) { fx.hook.editOriginalEmbeds(any<MessageEmbed>()) }
+        verify(exactly = 1) {
+            fx.editAction.setComponents(*anyVararg<MessageTopLevelComponent>())
+        }
+        verify(exactly = 1) { fx.editAction.queue() }
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/install/button/InstallSkipButtonTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/install/button/InstallSkipButtonTest.kt
@@ -1,0 +1,62 @@
+package bot.toby.install.button
+
+import database.service.ConfigService
+import io.mockk.confirmVerified
+import io.mockk.mockk
+import io.mockk.verify
+import net.dv8tion.jda.api.components.MessageTopLevelComponent
+import net.dv8tion.jda.api.entities.MessageEmbed
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class InstallSkipButtonTest {
+
+    private lateinit var configService: ConfigService
+    private lateinit var button: InstallSkipButton
+    private lateinit var fx: InstallButtonFixture
+
+    @BeforeEach
+    fun setUp() {
+        configService = mockk(relaxed = true)
+        button = InstallSkipButton()
+        fx = InstallButtonFixture()
+    }
+
+    @Test
+    fun `defersReply is false`() {
+        assertEquals(false, button.defersReply)
+    }
+
+    @Test
+    fun `non-owner is rejected with no edits`() {
+        fx.asNonOwner()
+
+        button.handle(fx.ctx, mockk(relaxed = true), 0)
+
+        verify(exactly = 1) { fx.event.reply(any<String>()) }
+        verify(exactly = 0) { fx.hook.editOriginalEmbeds(any<MessageEmbed>()) }
+        verify(exactly = 0) { fx.event.deferEdit() }
+    }
+
+    @Test
+    fun `owner happy path performs no DB writes`() {
+        button.handle(fx.ctx, mockk(relaxed = true), 0)
+
+        verify(exactly = 0) {
+            configService.upsertConfig(any<String>(), any<String>(), any<String>())
+        }
+        confirmVerified(configService)
+    }
+
+    @Test
+    fun `owner happy path strips components and swaps to skip embed`() {
+        button.handle(fx.ctx, mockk(relaxed = true), 0)
+
+        verify(exactly = 1) { fx.event.deferEdit() }
+        verify(exactly = 1) { fx.hook.editOriginalEmbeds(any<MessageEmbed>()) }
+        verify(exactly = 1) {
+            fx.editAction.setComponents(*anyVararg<MessageTopLevelComponent>())
+        }
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/install/button/InstallToggleButtonTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/install/button/InstallToggleButtonTest.kt
@@ -1,0 +1,164 @@
+package bot.toby.install.button
+
+import bot.toby.install.InstallWizard
+import bot.toby.install.OptInFeatures
+import database.dto.ConfigDto
+import database.dto.ConfigDto.Configurations
+import database.service.ConfigService
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import net.dv8tion.jda.api.components.MessageTopLevelComponent
+import net.dv8tion.jda.api.components.actionrow.ActionRow
+import net.dv8tion.jda.api.entities.MessageEmbed
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+
+internal class InstallToggleButtonTest {
+
+    private lateinit var configService: ConfigService
+    private lateinit var button: InstallToggleButton
+    private lateinit var fx: InstallButtonFixture
+
+    @BeforeEach
+    fun setUp() {
+        configService = mockk(relaxed = true)
+        button = InstallToggleButton(configService)
+        fx = InstallButtonFixture()
+        // event.message.components is left as the default relaxed mock
+        // return (empty list). The toggle button's bottom-row resolver
+        // falls back to doneButtonRow() in that case, which is fine for
+        // every assertion in this class (we don't inspect the bottom
+        // row directly — the fallback path is covered in
+        // `falls back to doneButtonRow when no second row on message`).
+    }
+
+    @Test
+    fun `defersReply is false`() {
+        assertEquals(false, button.defersReply)
+    }
+
+    @Test
+    fun `non-owner is rejected with no writes or edits`() {
+        fx.asNonOwner()
+        every { fx.event.componentId } returns "${InstallWizard.BTN_TOGGLE_PREFIX}:ACTIVITY_TRACKING"
+
+        button.handle(fx.ctx, mockk(relaxed = true), 0)
+
+        verify(exactly = 1) { fx.event.reply(any<String>()) }
+        verify(exactly = 0) {
+            configService.upsertConfig(any<String>(), any<String>(), any<String>())
+        }
+        verify(exactly = 0) { fx.hook.editOriginalEmbeds(any<MessageEmbed>()) }
+    }
+
+    @Test
+    fun `unknown suffix is rejected ephemerally with no writes`() {
+        every { fx.event.componentId } returns "${InstallWizard.BTN_TOGGLE_PREFIX}:NOPE"
+
+        button.handle(fx.ctx, mockk(relaxed = true), 0)
+
+        verify(exactly = 1) { fx.event.reply(any<String>()) }
+        verify(exactly = 0) {
+            configService.upsertConfig(any<String>(), any<String>(), any<String>())
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(OptInFeatures::class)
+    fun `true flips to false for every opt-in feature`(feature: OptInFeatures) {
+        every { fx.event.componentId } returns "${InstallWizard.BTN_TOGGLE_PREFIX}:${feature.key.name}"
+        every {
+            configService.getConfigByName(feature.key.configValue, "g1")
+        } returns ConfigDto(feature.key.configValue, "true", "g1")
+
+        button.handle(fx.ctx, mockk(relaxed = true), 0)
+
+        verify(exactly = 1) {
+            configService.upsertConfig(feature.key.configValue, "false", "g1")
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(OptInFeatures::class)
+    fun `false flips to true for every opt-in feature`(feature: OptInFeatures) {
+        every { fx.event.componentId } returns "${InstallWizard.BTN_TOGGLE_PREFIX}:${feature.key.name}"
+        every {
+            configService.getConfigByName(feature.key.configValue, "g1")
+        } returns ConfigDto(feature.key.configValue, "false", "g1")
+
+        button.handle(fx.ctx, mockk(relaxed = true), 0)
+
+        verify(exactly = 1) {
+            configService.upsertConfig(feature.key.configValue, "true", "g1")
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(OptInFeatures::class)
+    fun `null is treated as off and flips to true`(feature: OptInFeatures) {
+        every { fx.event.componentId } returns "${InstallWizard.BTN_TOGGLE_PREFIX}:${feature.key.name}"
+        every { configService.getConfigByName(feature.key.configValue, "g1") } returns null
+
+        button.handle(fx.ctx, mockk(relaxed = true), 0)
+
+        verify(exactly = 1) {
+            configService.upsertConfig(feature.key.configValue, "true", "g1")
+        }
+    }
+
+    @Test
+    fun `any non-true value is treated as off and flips to true`() {
+        val feature = OptInFeatures.ACTIVITY_TRACKING
+        every { fx.event.componentId } returns "${InstallWizard.BTN_TOGGLE_PREFIX}:${feature.key.name}"
+        every {
+            configService.getConfigByName(feature.key.configValue, "g1")
+        } returns ConfigDto(feature.key.configValue, "FALSE", "g1")
+
+        button.handle(fx.ctx, mockk(relaxed = true), 0)
+
+        verify(exactly = 1) {
+            configService.upsertConfig(feature.key.configValue, "true", "g1")
+        }
+    }
+
+    @Test
+    fun `happy path defers edit and updates the message`() {
+        every {
+            fx.event.componentId
+        } returns "${InstallWizard.BTN_TOGGLE_PREFIX}:ACTIVITY_TRACKING"
+        every {
+            configService.getConfigByName(Configurations.ACTIVITY_TRACKING.configValue, "g1")
+        } returns null
+
+        button.handle(fx.ctx, mockk(relaxed = true), 0)
+
+        verify(exactly = 1) { fx.event.deferEdit() }
+        verify(exactly = 1) { fx.hook.editOriginalEmbeds(any<MessageEmbed>()) }
+        verify(exactly = 1) {
+            fx.editAction.setComponents(*anyVararg<MessageTopLevelComponent>())
+        }
+    }
+
+    @Test
+    fun `falls back to doneButtonRow when source message has no second row`() {
+        // The default fixture leaves message.components as the empty
+        // relaxed-mock return, exercising the InstallToggleButton's
+        // `?: doneButtonRow()` fallback. We just verify no exception is
+        // thrown and the edit still happens.
+        every { fx.event.componentId } returns "${InstallWizard.BTN_TOGGLE_PREFIX}:ACTIVITY_TRACKING"
+        every {
+            configService.getConfigByName(Configurations.ACTIVITY_TRACKING.configValue, "g1")
+        } returns null
+
+        button.handle(fx.ctx, mockk(relaxed = true), 0)
+
+        verify(exactly = 1) {
+            fx.editAction.setComponents(*anyVararg<MessageTopLevelComponent>())
+        }
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/install/button/InstallToggleButtonTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/install/button/InstallToggleButtonTest.kt
@@ -29,12 +29,9 @@ internal class InstallToggleButtonTest {
         configService = mockk(relaxed = true)
         button = InstallToggleButton(configService)
         fx = InstallButtonFixture()
-        // event.message.components is left as the default relaxed mock
-        // return (empty list). The toggle button's bottom-row resolver
-        // falls back to doneButtonRow() in that case, which is fine for
-        // every assertion in this class (we don't inspect the bottom
-        // row directly — the fallback path is covered in
-        // `falls back to doneButtonRow when no second row on message`).
+        // The toggle button no longer scrapes the source message's
+        // components; the bottom row is unconditionally backButtonRow().
+        // Tests don't need to stub event.message.components.
     }
 
     @Test
@@ -144,21 +141,4 @@ internal class InstallToggleButtonTest {
         }
     }
 
-    @Test
-    fun `falls back to doneButtonRow when source message has no second row`() {
-        // The default fixture leaves message.components as the empty
-        // relaxed-mock return, exercising the InstallToggleButton's
-        // `?: doneButtonRow()` fallback. We just verify no exception is
-        // thrown and the edit still happens.
-        every { fx.event.componentId } returns "${InstallWizard.BTN_TOGGLE_PREFIX}:ACTIVITY_TRACKING"
-        every {
-            configService.getConfigByName(Configurations.ACTIVITY_TRACKING.configValue, "g1")
-        } returns null
-
-        button.handle(fx.ctx, mockk(relaxed = true), 0)
-
-        verify(exactly = 1) {
-            fx.editAction.setComponents(*anyVararg<MessageTopLevelComponent>())
-        }
-    }
 }

--- a/discord-bot/src/test/kotlin/bot/toby/install/menu/InstallCategoryMenuTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/install/menu/InstallCategoryMenuTest.kt
@@ -275,7 +275,6 @@ internal class InstallCategoryMenuTest {
         val expectedId = InstallAllStakesModal.MODAL_NAME
         val built = mockk<Modal>(relaxed = true) { every { id } returns expectedId }
         every { allStakes.buildModal(any(), any()) } returns built
-        every { allStakes.readCurrentDefaults(any()) } returns ("100" to "1000")
         every { event.componentId } returns InstallWizard.MENU_CATEGORY_STAKES
         every { event.selectedOptions } returns listOf(SelectOption.of("x", InstallWizard.STAKE_ALL_TOKEN))
 

--- a/discord-bot/src/test/kotlin/bot/toby/install/menu/InstallCategoryMenuTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/install/menu/InstallCategoryMenuTest.kt
@@ -94,6 +94,9 @@ internal class InstallCategoryMenuTest {
         event = mockk(relaxed = true)
         guild = mockk(relaxed = true) { every { id } returns "g1" }
         member = mockk(relaxed = true) { every { isOwner } returns true }
+        // InstallAuth.requireOwner reads event.member; the legacy ctx.member
+        // stub is preserved for handlers that still consult the context.
+        every { event.member } returns member
         ctx = mockk {
             every { this@mockk.event } returns this@InstallCategoryMenuTest.event
             every { this@mockk.guild } returns this@InstallCategoryMenuTest.guild

--- a/discord-bot/src/test/kotlin/bot/toby/install/menu/InstallCategoryMenuTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/install/menu/InstallCategoryMenuTest.kt
@@ -1,0 +1,327 @@
+package bot.toby.install.menu
+
+import bot.toby.command.commands.moderation.SetConfigCommand
+import bot.toby.install.InstallWizard
+import bot.toby.install.QUICK_CHANNELS_TOKEN
+import bot.toby.install.WizardSection
+import bot.toby.install.modal.InstallAllStakesModal
+import bot.toby.install.modal.InstallQuickChannelsModal
+import bot.toby.modal.modals.setconfig.SetConfigActivityModal
+import bot.toby.modal.modals.setconfig.SetConfigBlackjackRulesModal
+import bot.toby.modal.modals.setconfig.SetConfigBlackjackTableModal
+import bot.toby.modal.modals.setconfig.SetConfigFeesModal
+import bot.toby.modal.modals.setconfig.SetConfigGeneralModal
+import bot.toby.modal.modals.setconfig.SetConfigJackpotActivityModal
+import bot.toby.modal.modals.setconfig.SetConfigJackpotModal
+import bot.toby.modal.modals.setconfig.SetConfigLotteryBasicsModal
+import bot.toby.modal.modals.setconfig.SetConfigLotteryPoolsModal
+import bot.toby.modal.modals.setconfig.SetConfigPokerStakesModal
+import bot.toby.modal.modals.setconfig.SetConfigPokerTableModal
+import bot.toby.modal.modals.setconfig.SetConfigStakesModal
+import core.menu.MenuContext
+import database.dto.ConfigDto
+import database.dto.ConfigDto.Configurations
+import database.service.ConfigService
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import net.dv8tion.jda.api.components.selections.SelectOption
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.Member
+import net.dv8tion.jda.api.events.interaction.component.StringSelectInteractionEvent
+import net.dv8tion.jda.api.modals.Modal
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.EnumSource
+import org.junit.jupiter.params.provider.MethodSource
+import java.util.stream.Stream
+
+internal class InstallCategoryMenuTest {
+
+    private lateinit var configService: ConfigService
+    private lateinit var general: SetConfigGeneralModal
+    private lateinit var activity: SetConfigActivityModal
+    private lateinit var fees: SetConfigFeesModal
+    private lateinit var jackpot: SetConfigJackpotModal
+    private lateinit var jackpotActivity: SetConfigJackpotActivityModal
+    private lateinit var pokerStakes: SetConfigPokerStakesModal
+    private lateinit var pokerTable: SetConfigPokerTableModal
+    private lateinit var blackjackRules: SetConfigBlackjackRulesModal
+    private lateinit var blackjackTable: SetConfigBlackjackTableModal
+    private lateinit var lotteryBasics: SetConfigLotteryBasicsModal
+    private lateinit var lotteryPools: SetConfigLotteryPoolsModal
+    private lateinit var stakes: SetConfigStakesModal
+    private lateinit var allStakes: InstallAllStakesModal
+    private lateinit var quickChannels: InstallQuickChannelsModal
+    private lateinit var menu: InstallCategoryMenu
+
+    private lateinit var event: StringSelectInteractionEvent
+    private lateinit var ctx: MenuContext
+    private lateinit var guild: Guild
+    private lateinit var member: Member
+
+    @BeforeEach
+    fun setUp() {
+        configService = mockk(relaxed = true)
+        general = mockk(relaxed = true)
+        activity = mockk(relaxed = true)
+        fees = mockk(relaxed = true)
+        jackpot = mockk(relaxed = true)
+        jackpotActivity = mockk(relaxed = true)
+        pokerStakes = mockk(relaxed = true)
+        pokerTable = mockk(relaxed = true)
+        blackjackRules = mockk(relaxed = true)
+        blackjackTable = mockk(relaxed = true)
+        lotteryBasics = mockk(relaxed = true)
+        lotteryPools = mockk(relaxed = true)
+        stakes = mockk(relaxed = true)
+        allStakes = mockk(relaxed = true)
+        quickChannels = mockk(relaxed = true)
+        menu = InstallCategoryMenu(
+            configService,
+            general, activity, fees, jackpot, jackpotActivity,
+            pokerStakes, pokerTable, blackjackRules, blackjackTable,
+            lotteryBasics, lotteryPools, stakes, allStakes, quickChannels,
+        )
+
+        event = mockk(relaxed = true)
+        guild = mockk(relaxed = true) { every { id } returns "g1" }
+        member = mockk(relaxed = true) { every { isOwner } returns true }
+        ctx = mockk {
+            every { this@mockk.event } returns this@InstallCategoryMenuTest.event
+            every { this@mockk.guild } returns this@InstallCategoryMenuTest.guild
+            every { this@mockk.member } returns this@InstallCategoryMenuTest.member
+        }
+        every { event.reply(any<String>()) } returns mockk(relaxed = true) {
+            every { setEphemeral(any()) } returns this
+            every { queue() } just Runs
+        }
+        every { event.replyModal(any<Modal>()) } returns mockk(relaxed = true) {
+            every { queue() } just Runs
+            every { queue(any()) } just Runs
+        }
+        every { event.editMessageEmbeds(any<net.dv8tion.jda.api.entities.MessageEmbed>()) } returns
+            mockk(relaxed = true) {
+                every { setComponents(*anyVararg()) } returns this
+                every { queue() } just Runs
+            }
+    }
+
+    @Test
+    fun `name is install_section`() {
+        assertEquals(InstallWizard.MENU_SECTION, menu.name)
+    }
+
+    @Test
+    fun `non-owner is rejected ephemerally`() {
+        every { member.isOwner } returns false
+        every { event.componentId } returns InstallWizard.MENU_SECTION
+        every { event.selectedOptions } returns listOf(SelectOption.of("x", WizardSection.GENERAL.id))
+
+        menu.handle(ctx, 0)
+
+        verify(exactly = 1) { event.reply(any<String>()) }
+        verify(exactly = 0) { event.replyModal(any<Modal>()) }
+        verify(exactly = 0) { event.editMessageEmbeds(any<net.dv8tion.jda.api.entities.MessageEmbed>()) }
+    }
+
+    @Test
+    fun `no selected option replies ephemerally`() {
+        every { event.componentId } returns InstallWizard.MENU_SECTION
+        every { event.selectedOptions } returns emptyList()
+
+        menu.handle(ctx, 0)
+
+        verify(exactly = 1) { event.reply(any<String>()) }
+    }
+
+    @Test
+    fun `unknown menu componentId replies ephemerally`() {
+        every { event.componentId } returns "not_a_menu"
+        every { event.selectedOptions } returns listOf(SelectOption.of("x", "y"))
+
+        menu.handle(ctx, 0)
+
+        verify(exactly = 1) { event.reply(any<String>()) }
+    }
+
+    @Test
+    fun `top-level section pick edits to section detail menu`() {
+        every { event.componentId } returns InstallWizard.MENU_SECTION
+        every { event.selectedOptions } returns listOf(SelectOption.of("x", WizardSection.POKER.id))
+
+        menu.handle(ctx, 0)
+
+        verify(exactly = 1) { event.editMessageEmbeds(any<net.dv8tion.jda.api.entities.MessageEmbed>()) }
+        verify(exactly = 0) { event.replyModal(any<Modal>()) }
+    }
+
+    @Test
+    fun `unknown section id replies ephemerally`() {
+        every { event.componentId } returns InstallWizard.MENU_SECTION
+        every { event.selectedOptions } returns listOf(SelectOption.of("x", "nope"))
+
+        menu.handle(ctx, 0)
+
+        verify(exactly = 1) { event.reply(any<String>()) }
+    }
+
+    // ---- category picks (parametrised) ----
+
+    companion object {
+        @JvmStatic
+        fun simpleCategoryCases(): Stream<Arguments> = Stream.of(
+            Arguments.of(SetConfigCommand.SUB_GENERAL, SetConfigGeneralModal.MODAL_NAME),
+            Arguments.of(SetConfigCommand.SUB_ACTIVITY, SetConfigActivityModal.MODAL_NAME),
+            Arguments.of(SetConfigCommand.SUB_FEES, SetConfigFeesModal.MODAL_NAME),
+            Arguments.of(SetConfigCommand.SUB_JACKPOT, SetConfigJackpotModal.MODAL_NAME),
+            Arguments.of(SetConfigCommand.SUB_JACKPOT_ACTIVITY, SetConfigJackpotActivityModal.MODAL_NAME),
+            Arguments.of(SetConfigCommand.SUB_POKER_STAKES, SetConfigPokerStakesModal.MODAL_NAME),
+            Arguments.of(SetConfigCommand.SUB_POKER_TABLE, SetConfigPokerTableModal.MODAL_NAME),
+            Arguments.of(SetConfigCommand.SUB_BLACKJACK_RULES, SetConfigBlackjackRulesModal.MODAL_NAME),
+            Arguments.of(SetConfigCommand.SUB_BLACKJACK_TABLE, SetConfigBlackjackTableModal.MODAL_NAME),
+            Arguments.of(SetConfigCommand.SUB_LOTTERY_BASICS, SetConfigLotteryBasicsModal.MODAL_NAME),
+            Arguments.of(SetConfigCommand.SUB_LOTTERY_POOLS, SetConfigLotteryPoolsModal.MODAL_NAME),
+        )
+    }
+
+    @ParameterizedTest(name = "category {0} opens modal {1}")
+    @MethodSource("simpleCategoryCases")
+    fun `each simple category opens its matching modal`(
+        categoryToken: String,
+        expectedModalName: String,
+    ) {
+        every { event.componentId } returns InstallWizard.sectionDetailMenuId("any")
+        every { event.selectedOptions } returns listOf(SelectOption.of("x", categoryToken))
+
+        // Stub the modal bean (whichever) to return a known modal id.
+        val built = mockk<Modal>(relaxed = true) { every { id } returns expectedModalName }
+        every { general.buildModal(SetConfigGeneralModal.MODAL_NAME, any()) } returns built
+        every { activity.buildModal(SetConfigActivityModal.MODAL_NAME, any()) } returns built
+        every { fees.buildModal(SetConfigFeesModal.MODAL_NAME, any()) } returns built
+        every { jackpot.buildModal(SetConfigJackpotModal.MODAL_NAME, any()) } returns built
+        every { jackpotActivity.buildModal(SetConfigJackpotActivityModal.MODAL_NAME, any()) } returns built
+        every { pokerStakes.buildModal(SetConfigPokerStakesModal.MODAL_NAME, any()) } returns built
+        every { pokerTable.buildModal(SetConfigPokerTableModal.MODAL_NAME, any()) } returns built
+        every { blackjackRules.buildModal(SetConfigBlackjackRulesModal.MODAL_NAME, any()) } returns built
+        every { blackjackTable.buildModal(SetConfigBlackjackTableModal.MODAL_NAME, any()) } returns built
+        every { lotteryBasics.buildModal(SetConfigLotteryBasicsModal.MODAL_NAME, any()) } returns built
+        every { lotteryPools.buildModal(SetConfigLotteryPoolsModal.MODAL_NAME, any()) } returns built
+
+        // Make the componentId start with a valid section detail prefix.
+        every { event.componentId } returns InstallWizard.sectionDetailMenuId(WizardSection.GENERAL.id)
+
+        menu.handle(ctx, 0)
+
+        val modalSlot = slot<Modal>()
+        verify(exactly = 1) { event.replyModal(capture(modalSlot)) }
+        assertEquals(expectedModalName, modalSlot.captured.id)
+    }
+
+    @Test
+    fun `reader passed to buildModal delegates to configService getConfigByName`() {
+        val readerSlot = slot<(Configurations) -> String?>()
+        val built = mockk<Modal>(relaxed = true) { every { id } returns SetConfigGeneralModal.MODAL_NAME }
+        every { general.buildModal(SetConfigGeneralModal.MODAL_NAME, capture(readerSlot)) } returns built
+        every { event.componentId } returns InstallWizard.sectionDetailMenuId(WizardSection.GENERAL.id)
+        every { event.selectedOptions } returns listOf(SelectOption.of("x", SetConfigCommand.SUB_GENERAL))
+        every {
+            configService.getConfigByName(any<String>(), any<String>())
+        } returns ConfigDto(Configurations.VOLUME.configValue, "75", "g1")
+
+        menu.handle(ctx, 0)
+
+        assertNotNull(readerSlot.captured)
+        assertEquals("75", readerSlot.captured.invoke(Configurations.VOLUME))
+        verify { configService.getConfigByName(Configurations.VOLUME.configValue, "g1") }
+    }
+
+    @Test
+    fun `stakes category swaps to game sub-menu without opening a modal`() {
+        every { event.componentId } returns InstallWizard.sectionDetailMenuId(WizardSection.ECONOMY.id)
+        every { event.selectedOptions } returns listOf(SelectOption.of("x", SetConfigCommand.SUB_STAKES))
+
+        menu.handle(ctx, 0)
+
+        verify(exactly = 1) { event.editMessageEmbeds(any<net.dv8tion.jda.api.entities.MessageEmbed>()) }
+        verify(exactly = 0) { event.replyModal(any<Modal>()) }
+    }
+
+    @ParameterizedTest
+    @EnumSource(SetConfigStakesModal.Game::class)
+    fun `game token in stakes sub-menu opens that game's stakes modal`(game: SetConfigStakesModal.Game) {
+        val expectedId = SetConfigStakesModal.customIdFor(game)
+        val built = mockk<Modal>(relaxed = true) { every { id } returns expectedId }
+        every { stakes.buildModal(expectedId, any()) } returns built
+        every { event.componentId } returns InstallWizard.MENU_CATEGORY_STAKES
+        every { event.selectedOptions } returns listOf(SelectOption.of("x", game.token))
+
+        menu.handle(ctx, 0)
+
+        val modalSlot = slot<Modal>()
+        verify(exactly = 1) { event.replyModal(capture(modalSlot)) }
+        assertEquals(expectedId, modalSlot.captured.id)
+    }
+
+    @Test
+    fun `apply-to-all token in stakes sub-menu opens the all-stakes modal`() {
+        val expectedId = InstallAllStakesModal.MODAL_NAME
+        val built = mockk<Modal>(relaxed = true) { every { id } returns expectedId }
+        every { allStakes.buildModal(any(), any()) } returns built
+        every { allStakes.readCurrentDefaults(any()) } returns ("100" to "1000")
+        every { event.componentId } returns InstallWizard.MENU_CATEGORY_STAKES
+        every { event.selectedOptions } returns listOf(SelectOption.of("x", InstallWizard.STAKE_ALL_TOKEN))
+
+        menu.handle(ctx, 0)
+
+        val modalSlot = slot<Modal>()
+        verify(exactly = 1) { event.replyModal(capture(modalSlot)) }
+        assertEquals(expectedId, modalSlot.captured.id)
+        // Should not have opened any individual game modal.
+        verify(exactly = 0) { stakes.buildModal(any<String>(), any<(Configurations) -> String?>()) }
+    }
+
+    @Test
+    fun `unknown game token in stakes sub-menu replies ephemerally`() {
+        every { event.componentId } returns InstallWizard.MENU_CATEGORY_STAKES
+        every { event.selectedOptions } returns listOf(SelectOption.of("x", "bingo"))
+
+        menu.handle(ctx, 0)
+
+        verify(exactly = 1) { event.reply(any<String>()) }
+        verify(exactly = 0) { event.replyModal(any<Modal>()) }
+    }
+
+    @Test
+    fun `quick_channels token opens the EntitySelectMenu modal`() {
+        val expectedId = InstallQuickChannelsModal.MODAL_NAME
+        val built = mockk<Modal>(relaxed = true) { every { id } returns expectedId }
+        every { quickChannels.buildModal() } returns built
+        every { event.componentId } returns InstallWizard.sectionDetailMenuId(WizardSection.GENERAL.id)
+        every { event.selectedOptions } returns listOf(SelectOption.of("x", QUICK_CHANNELS_TOKEN))
+
+        menu.handle(ctx, 0)
+
+        val modalSlot = slot<Modal>()
+        verify(exactly = 1) { event.replyModal(capture(modalSlot)) }
+        assertEquals(expectedId, modalSlot.captured.id)
+    }
+
+    @Test
+    fun `unknown category token in section detail replies ephemerally`() {
+        every { event.componentId } returns InstallWizard.sectionDetailMenuId(WizardSection.GENERAL.id)
+        every { event.selectedOptions } returns listOf(SelectOption.of("x", "totally_made_up"))
+
+        menu.handle(ctx, 0)
+
+        verify(exactly = 1) { event.reply(any<String>()) }
+        verify(exactly = 0) { event.replyModal(any<Modal>()) }
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/install/modal/InstallAllStakesModalTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/install/modal/InstallAllStakesModalTest.kt
@@ -165,17 +165,28 @@ internal class InstallAllStakesModalTest {
     }
 
     @Test
-    fun `readCurrentDefaults uses dice as the prefill source`() {
-        val reader: (Configurations) -> String? = { key ->
-            when (key) {
-                Configurations.DICE_MIN_STAKE -> "50"
-                Configurations.DICE_MAX_STAKE -> "9999"
-                else -> "other"
-            }
+    fun `min parse failure is distinguished from out-of-range`() {
+        // Validation message disambiguates "couldn't parse" vs "parsed too small".
+        stubField(InstallAllStakesModal.FIELD_MIN_STAKE, "abc")
+        stubField(InstallAllStakesModal.FIELD_MAX_STAKE, "")
+
+        modal.handle(ctx, 0)
+
+        verify(exactly = 1) {
+            event.reply(match<String> { it.contains("must be a whole number") })
         }
-        val (min, max) = modal.readCurrentDefaults(reader)
-        assertEquals("50", min)
-        assertEquals("9999", max)
+    }
+
+    @Test
+    fun `min equal to zero reports out-of-range`() {
+        stubField(InstallAllStakesModal.FIELD_MIN_STAKE, "0")
+        stubField(InstallAllStakesModal.FIELD_MAX_STAKE, "")
+
+        modal.handle(ctx, 0)
+
+        verify(exactly = 1) {
+            event.reply(match<String> { it.contains("must be ≥ 1") && it.contains("0") })
+        }
     }
 
     @Test

--- a/discord-bot/src/test/kotlin/bot/toby/install/modal/InstallAllStakesModalTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/install/modal/InstallAllStakesModalTest.kt
@@ -1,0 +1,195 @@
+package bot.toby.install.modal
+
+import bot.toby.modal.modals.setconfig.SetConfigStakesModal
+import core.modal.ModalContext
+import database.dto.ConfigDto
+import database.dto.ConfigDto.Configurations
+import database.service.ConfigService
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent
+import net.dv8tion.jda.api.interactions.modals.ModalMapping
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class InstallAllStakesModalTest {
+
+    private lateinit var configService: ConfigService
+    private lateinit var modal: InstallAllStakesModal
+    private lateinit var event: ModalInteractionEvent
+    private lateinit var ctx: ModalContext
+    private lateinit var guild: Guild
+
+    @BeforeEach
+    fun setUp() {
+        configService = mockk(relaxed = true)
+        modal = InstallAllStakesModal(configService)
+        event = mockk(relaxed = true)
+        guild = mockk(relaxed = true) { every { id } returns "g1" }
+        ctx = mockk {
+            every { this@mockk.event } returns this@InstallAllStakesModalTest.event
+            every { this@mockk.guild } returns this@InstallAllStakesModalTest.guild
+        }
+        every { event.reply(any<String>()) } returns mockk(relaxed = true) {
+            every { setEphemeral(any()) } returns this
+            every { queue() } just Runs
+        }
+    }
+
+    private fun stubField(id: String, value: String?) {
+        every { event.getValue(id) } returns value?.let {
+            mockk<ModalMapping> { every { asString } returns it }
+        }
+    }
+
+    @Test
+    fun `name and modal id constants match`() {
+        assertEquals(InstallAllStakesModal.MODAL_NAME, modal.name)
+        assertEquals("install_all_stakes", InstallAllStakesModal.MODAL_NAME)
+    }
+
+    @Test
+    fun `buildModal returns a JDA modal with the right id`() {
+        val built = modal.buildModal("100", "1000")
+        assertEquals(InstallAllStakesModal.MODAL_NAME, built.id)
+        assertNotNull(built.title)
+    }
+
+    @Test
+    fun `empty min and max replies nothing changed without writes`() {
+        stubField(InstallAllStakesModal.FIELD_MIN_STAKE, "")
+        stubField(InstallAllStakesModal.FIELD_MAX_STAKE, "")
+
+        modal.handle(ctx, 0)
+
+        verify(exactly = 1) { event.reply(any<String>()) }
+        verify(exactly = 0) {
+            configService.upsertConfig(any<String>(), any<String>(), any<String>())
+        }
+    }
+
+    @Test
+    fun `invalid min replies error without writes`() {
+        stubField(InstallAllStakesModal.FIELD_MIN_STAKE, "abc")
+        stubField(InstallAllStakesModal.FIELD_MAX_STAKE, "1000")
+
+        modal.handle(ctx, 0)
+
+        verify(exactly = 1) { event.reply(match<String> { it.contains("Min") }) }
+        verify(exactly = 0) {
+            configService.upsertConfig(any<String>(), any<String>(), any<String>())
+        }
+    }
+
+    @Test
+    fun `min greater than max is rejected with no writes`() {
+        stubField(InstallAllStakesModal.FIELD_MIN_STAKE, "5000")
+        stubField(InstallAllStakesModal.FIELD_MAX_STAKE, "100")
+
+        modal.handle(ctx, 0)
+
+        verify(exactly = 1) { event.reply(match<String> { it.contains("exceed") }) }
+        verify(exactly = 0) {
+            configService.upsertConfig(any<String>(), any<String>(), any<String>())
+        }
+    }
+
+    @Test
+    fun `min zero is rejected as invalid`() {
+        stubField(InstallAllStakesModal.FIELD_MIN_STAKE, "0")
+        stubField(InstallAllStakesModal.FIELD_MAX_STAKE, "")
+
+        modal.handle(ctx, 0)
+
+        verify(exactly = 1) { event.reply(any<String>()) }
+        verify(exactly = 0) {
+            configService.upsertConfig(any<String>(), any<String>(), any<String>())
+        }
+    }
+
+    @Test
+    fun `min only writes only MIN_STAKE for every game`() {
+        stubField(InstallAllStakesModal.FIELD_MIN_STAKE, "100")
+        stubField(InstallAllStakesModal.FIELD_MAX_STAKE, "")
+
+        modal.handle(ctx, 0)
+
+        SetConfigStakesModal.Game.entries.forEach { game ->
+            verify(exactly = 1) {
+                configService.upsertConfig(game.minKey.configValue, "100", "g1")
+            }
+            verify(exactly = 0) {
+                configService.upsertConfig(game.maxKey.configValue, any<String>(), "g1")
+            }
+        }
+    }
+
+    @Test
+    fun `max only writes only MAX_STAKE for every game`() {
+        stubField(InstallAllStakesModal.FIELD_MIN_STAKE, "")
+        stubField(InstallAllStakesModal.FIELD_MAX_STAKE, "5000")
+
+        modal.handle(ctx, 0)
+
+        SetConfigStakesModal.Game.entries.forEach { game ->
+            verify(exactly = 1) {
+                configService.upsertConfig(game.maxKey.configValue, "5000", "g1")
+            }
+            verify(exactly = 0) {
+                configService.upsertConfig(game.minKey.configValue, any<String>(), "g1")
+            }
+        }
+    }
+
+    @Test
+    fun `both min and max writes both keys for every game`() {
+        stubField(InstallAllStakesModal.FIELD_MIN_STAKE, "100")
+        stubField(InstallAllStakesModal.FIELD_MAX_STAKE, "5000")
+
+        modal.handle(ctx, 0)
+
+        SetConfigStakesModal.Game.entries.forEach { game ->
+            verify(exactly = 1) {
+                configService.upsertConfig(game.minKey.configValue, "100", "g1")
+            }
+            verify(exactly = 1) {
+                configService.upsertConfig(game.maxKey.configValue, "5000", "g1")
+            }
+        }
+    }
+
+    @Test
+    fun `readCurrentDefaults uses dice as the prefill source`() {
+        val reader: (Configurations) -> String? = { key ->
+            when (key) {
+                Configurations.DICE_MIN_STAKE -> "50"
+                Configurations.DICE_MAX_STAKE -> "9999"
+                else -> "other"
+            }
+        }
+        val (min, max) = modal.readCurrentDefaults(reader)
+        assertEquals("50", min)
+        assertEquals("9999", max)
+    }
+
+    @Test
+    fun `successful save replies with summary mentioning every game`() {
+        stubField(InstallAllStakesModal.FIELD_MIN_STAKE, "10")
+        stubField(InstallAllStakesModal.FIELD_MAX_STAKE, "")
+
+        modal.handle(ctx, 0)
+
+        val gameCount = SetConfigStakesModal.Game.entries.size
+        verify(exactly = 1) {
+            event.reply(match<String> {
+                it.contains(gameCount.toString()) && it.contains("Min stake")
+            })
+        }
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/install/modal/InstallQuickChannelsModalTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/install/modal/InstallQuickChannelsModalTest.kt
@@ -1,0 +1,165 @@
+package bot.toby.install.modal
+
+import core.modal.ModalContext
+import database.dto.ConfigDto.Configurations
+import database.service.ConfigService
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
+import net.dv8tion.jda.api.entities.channel.concrete.VoiceChannel
+import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent
+import net.dv8tion.jda.api.interactions.modals.ModalMapping
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class InstallQuickChannelsModalTest {
+
+    private lateinit var configService: ConfigService
+    private lateinit var modal: InstallQuickChannelsModal
+    private lateinit var event: ModalInteractionEvent
+    private lateinit var ctx: ModalContext
+    private lateinit var guild: Guild
+
+    @BeforeEach
+    fun setUp() {
+        configService = mockk(relaxed = true)
+        modal = InstallQuickChannelsModal(configService)
+        event = mockk(relaxed = true)
+        guild = mockk(relaxed = true) { every { id } returns "g1" }
+        ctx = mockk {
+            every { this@mockk.event } returns this@InstallQuickChannelsModalTest.event
+            every { this@mockk.guild } returns this@InstallQuickChannelsModalTest.guild
+        }
+        every { event.reply(any<String>()) } returns mockk(relaxed = true) {
+            every { setEphemeral(any()) } returns this
+            every { queue() } just Runs
+        }
+        // Default: no selections.
+        every { event.getValue(any<String>()) } returns null
+    }
+
+    private fun stubChannelPick(id: String, channelId: Long) {
+        every { event.getValue(id) } returns mockk<ModalMapping> {
+            every { asLongList } returns listOf(channelId)
+        }
+    }
+
+    @Test
+    fun `name and modal id constants align`() {
+        assertEquals(InstallQuickChannelsModal.MODAL_NAME, modal.name)
+        assertEquals("install_quick_channels", InstallQuickChannelsModal.MODAL_NAME)
+    }
+
+    @Test
+    fun `buildModal returns a JDA modal with the right id and title`() {
+        val built = modal.buildModal()
+        assertEquals(InstallQuickChannelsModal.MODAL_NAME, built.id)
+        assertNotNull(built.title)
+    }
+
+    @Test
+    fun `no selections replies nothing changed without writes`() {
+        modal.handle(ctx, 0)
+
+        verify(exactly = 1) { event.reply(match<String> { it.contains("nothing changed", ignoreCase = true) }) }
+        verify(exactly = 0) {
+            configService.upsertConfig(any<String>(), any<String>(), any<String>())
+        }
+    }
+
+    @Test
+    fun `voice channel selection writes MOVE channel name`() {
+        val voiceChannel = mockk<VoiceChannel> { every { name } returns "General Voice" }
+        stubChannelPick(InstallQuickChannelsModal.FIELD_MOVE, 12345L)
+        every { guild.getVoiceChannelById(12345L) } returns voiceChannel
+
+        modal.handle(ctx, 0)
+
+        verify(exactly = 1) {
+            configService.upsertConfig(Configurations.MOVE.configValue, "General Voice", "g1")
+        }
+        verify(exactly = 0) {
+            configService.upsertConfig(Configurations.LEADERBOARD_CHANNEL.configValue, any<String>(), "g1")
+        }
+    }
+
+    @Test
+    fun `text channel selection writes LEADERBOARD_CHANNEL id`() {
+        val textChannel = mockk<TextChannel> { every { name } returns "leaderboard" }
+        stubChannelPick(InstallQuickChannelsModal.FIELD_LEADERBOARD, 67890L)
+        every { guild.getTextChannelById(67890L) } returns textChannel
+
+        modal.handle(ctx, 0)
+
+        verify(exactly = 1) {
+            configService.upsertConfig(Configurations.LEADERBOARD_CHANNEL.configValue, "67890", "g1")
+        }
+        verify(exactly = 0) {
+            configService.upsertConfig(Configurations.MOVE.configValue, any<String>(), "g1")
+        }
+    }
+
+    @Test
+    fun `both selections write both keys`() {
+        val voiceChannel = mockk<VoiceChannel> { every { name } returns "Lobby" }
+        val textChannel = mockk<TextChannel> { every { name } returns "scores" }
+        stubChannelPick(InstallQuickChannelsModal.FIELD_MOVE, 1L)
+        stubChannelPick(InstallQuickChannelsModal.FIELD_LEADERBOARD, 2L)
+        every { guild.getVoiceChannelById(1L) } returns voiceChannel
+        every { guild.getTextChannelById(2L) } returns textChannel
+
+        modal.handle(ctx, 0)
+
+        verify(exactly = 1) {
+            configService.upsertConfig(Configurations.MOVE.configValue, "Lobby", "g1")
+        }
+        verify(exactly = 1) {
+            configService.upsertConfig(Configurations.LEADERBOARD_CHANNEL.configValue, "2", "g1")
+        }
+    }
+
+    @Test
+    fun `picked voice channel no longer exists rejects with no writes`() {
+        stubChannelPick(InstallQuickChannelsModal.FIELD_MOVE, 999L)
+        every { guild.getVoiceChannelById(999L) } returns null
+
+        modal.handle(ctx, 0)
+
+        verify(exactly = 1) { event.reply(match<String> { it.contains("no longer exists") }) }
+        verify(exactly = 0) {
+            configService.upsertConfig(any<String>(), any<String>(), any<String>())
+        }
+    }
+
+    @Test
+    fun `picked text channel no longer exists rejects with no writes`() {
+        stubChannelPick(InstallQuickChannelsModal.FIELD_LEADERBOARD, 888L)
+        every { guild.getTextChannelById(888L) } returns null
+
+        modal.handle(ctx, 0)
+
+        verify(exactly = 1) { event.reply(match<String> { it.contains("no longer exists") }) }
+        verify(exactly = 0) {
+            configService.upsertConfig(any<String>(), any<String>(), any<String>())
+        }
+    }
+
+    @Test
+    fun `successful save replies with summary listing the channel names`() {
+        val voice = mockk<VoiceChannel> { every { name } returns "Voice-A" }
+        stubChannelPick(InstallQuickChannelsModal.FIELD_MOVE, 10L)
+        every { guild.getVoiceChannelById(10L) } returns voice
+
+        modal.handle(ctx, 0)
+
+        verify(exactly = 1) {
+            event.reply(match<String> { it.contains("Voice-A") })
+        }
+    }
+}

--- a/web/src/main/kotlin/web/service/ModerationWebService.kt
+++ b/web/src/main/kotlin/web/service/ModerationWebService.kt
@@ -1106,6 +1106,9 @@ class ModerationWebService(
                 if (n < 0L) return "Value must be zero or positive."
                 n.toString()
             }
+            ConfigDto.Configurations.INSTALL_MODE,
+            ConfigDto.Configurations.INSTALLED_AT ->
+                return "Install-wizard sentinel — managed by /install in Discord."
         }
 
         val guildIdString = guild.id

--- a/web/src/test/kotlin/web/template/ModerationTemplateRowsTest.kt
+++ b/web/src/test/kotlin/web/template/ModerationTemplateRowsTest.kt
@@ -449,8 +449,13 @@ class ModerationTemplateRowsTest {
         // ACTIVITY_TRACKING_NOTIFIED is an internal one-shot flag set
         // by the bot when it DMs the owner about activity tracking;
         // there's no admin-facing reason to toggle it from the web UI.
+        // INSTALL_MODE / INSTALLED_AT are sentinels written by the
+        // in-Discord /install wizard — owners interact with that flow
+        // directly, never through the moderation web UI.
         val internalOnly = setOf(
             ConfigDto.Configurations.ACTIVITY_TRACKING_NOTIFIED,
+            ConfigDto.Configurations.INSTALL_MODE,
+            ConfigDto.Configurations.INSTALLED_AT,
         )
 
         val templates = listOf(
@@ -499,7 +504,7 @@ class ModerationTemplateRowsTest {
         )
         // And that the allowlist isn't quietly absorbing every enum case.
         assertEquals(
-            1, internalOnly.size,
+            3, internalOnly.size,
             "internalOnly grew unexpectedly. Each entry must be justified — " +
                 "explain in a comment above why the key never gets a UI surface."
         )


### PR DESCRIPTION
## Summary

Server owners now get a **welcome message + `/install` slash command** that opens a streamlined setup wizard with two paths:

- **Express setup** — one click; writes `INSTALL_MODE=express` + `INSTALLED_AT` and shows a done embed. Defaults handle everything else.
- **Custom setup** — picks categories to tune via a two-tier section menu. Selecting a category opens the existing `SetConfig*Modal` (no modal duplication).
- **Skip for now** — dismiss; `/install` is still available later.

Built entirely on existing JDA primitives (slash commands, buttons, select menus, modals). All `bot/toby/install/` is net-new; `SetConfigCommand` and the 12 `SetConfig*Modal` beans are untouched.

### Highlights

- **Auto-welcome on guild join.** `InstallWelcomeHandler.onGuildJoin` posts the wizard in the system channel (falls back to the first writable text channel, then DMs the owner). Idempotent via the `INSTALL_MODE` sentinel — re-invites don't re-prompt.
- **`/install` slash command.** Owner-only, always re-runnable.
- **Sections instead of a flat dropdown.** The 12 setconfig categories are grouped into 6 themed sections (General, Economy, Activity, Poker, Blackjack, Lottery). Owners pick a section, then a category — never staring at a 13-option dropdown.
- **Gated sections.** Activity and Lottery sections only appear when their opt-ins are on. Toggle a feature off → the related categories disappear from later steps.
- **Opt-in toggle view.** Custom → "Optional features" surfaces one toggle button per `OptInFeatures` entry (currently `ACTIVITY_TRACKING`, `LOTTERY_DAILY_ENABLED`). One-line extension for future opt-ins.
- **Channel pickers (no IDs).** Quick channels modal uses Discord's `EntitySelectMenu` with channel-type filters so owners click voice + text channels from a list instead of typing IDs.
- **Apply stake bounds to all games at once.** Per-game stakes sub-menu has an "Apply to all games" entry that opens a 2-field modal writing MIN/MAX to every game in one shot. Individual game entries still work for drill-down.
- **Welcome embed lists key defaults** so the Express path's value is informed.

### Files

- 15 production files under `discord-bot/src/main/kotlin/bot/toby/install/`
- 16 test files under `discord-bot/src/test/kotlin/bot/toby/install/`
- 2 enum entries in `ConfigDto` (`INSTALL_MODE`, `INSTALLED_AT`)
- Wired into `JdaListenerRegistrar`; sentinels allowlisted in the moderation web template test

**135 install tests** covering owner gates, sentinel writes, gating logic, every category route, every toggle state transition, modal validation, DM fallback, and the JDA listener registration.

## Test plan

- [x] `:discord-bot:test --tests bot.toby.install.*` — 134/134 install tests pass
- [x] `:discord-bot:test --tests bot.configuration.JdaListenerRegistrarTest` — 1/1 passes (mock list expanded)
- [x] `:discord-bot:test --tests *SetConfig*` — pre-existing setconfig tests still pass (zero changes to those modals)
- [x] `:web:test` — passes (web template test allowlists the new sentinels)
- [ ] Manual smoke in a sandbox guild via `docker-compose up bot`:
  - Invite bot fresh → welcome posts → click Express → DB shows `INSTALL_MODE=express` + numeric `INSTALLED_AT`
  - Re-invite same guild → no re-post (idempotency)
  - `/install` → wizard re-opens
  - Custom → pick "General settings" → "Quick channels" → channel pickers appear; pick voice + text; submit → DB shows `MOVE` + `LEADERBOARD_CHANNEL`
  - Custom → "Economy & casino" → "Per-game stakes" → "Apply to all games" → submit → DB shows MIN/MAX for every game
  - Custom → "Optional features" → toggle Lottery on → back to section menu → "Daily lottery" section now appears
  - Skip a fresh-invite → no DB writes → re-invite → welcome re-posts (skip is non-terminal)

https://claude.ai/code/session_01NHhBfrbNQEDVrsGovXzyGD

---
_Generated by [Claude Code](https://claude.ai/code/session_01NHhBfrbNQEDVrsGovXzyGD)_