### PR TITLE
feat(config): ConfigService.upsertAll — collapse multi-row config writes

### DIFF
--- a/database/src/main/kotlin/database/service/ConfigService.kt
+++ b/database/src/main/kotlin/database/service/ConfigService.kt
@@ -27,6 +27,23 @@ interface ConfigService {
      */
     fun upsertConfig(name: String, value: String, guildId: String): UpsertResult
 
+    /**
+     * Insert-or-update multiple `(name, value)` rows under a single
+     * [guildId] in one transactional batch. Equivalent to calling
+     * [upsertConfig] in a loop, but wrapped in a single `@Transactional`
+     * boundary so all rows commit together (or none do). Returns the
+     * per-row results in the same order as [rows] so callers can
+     * correlate by index — e.g. branch on `Created` vs `Updated` for
+     * first-enable side effects.
+     *
+     * Empty input is a no-op and returns `emptyList()`.
+     *
+     * Replaces hand-rolled loops like
+     * `rows.forEach { (name, value) -> upsertConfig(name, value, guildId) }`
+     * which committed N times instead of once.
+     */
+    fun upsertAll(guildId: String, rows: List<Pair<String, String>>): List<UpsertResult>
+
     sealed interface UpsertResult {
         val dto: ConfigDto
         data class Created(override val dto: ConfigDto) : UpsertResult

--- a/database/src/main/kotlin/database/service/impl/DefaultConfigService.kt
+++ b/database/src/main/kotlin/database/service/impl/DefaultConfigService.kt
@@ -8,6 +8,7 @@ import org.springframework.cache.annotation.CacheEvict
 import org.springframework.cache.annotation.CachePut
 import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 @Service
 class DefaultConfigService : ConfigService {
@@ -50,6 +51,23 @@ class DefaultConfigService : ConfigService {
             createNewConfig(dto)
             ConfigService.UpsertResult.Created(dto)
         }
+    }
+
+    /**
+     * Batched upsert. Class-level transaction-per-method is the default;
+     * marking this `@Transactional` puts every row write in one boundary
+     * so the underlying [ConfigPersistence] (also `@Transactional`)
+     * participates in the outer transaction instead of opening its own
+     * per-call. Per-row `@CachePut` annotations on [createNewConfig] /
+     * [updateConfig] still fire so the cache stays consistent.
+     */
+    @Transactional
+    override fun upsertAll(
+        guildId: String,
+        rows: List<Pair<String, String>>,
+    ): List<ConfigService.UpsertResult> {
+        if (rows.isEmpty()) return emptyList()
+        return rows.map { (name, value) -> upsertConfig(name, value, guildId) }
     }
 
     @CacheEvict(value = ["configs"], allEntries = true)

--- a/database/src/test/kotlin/database/service/AchievementServiceTest.kt
+++ b/database/src/test/kotlin/database/service/AchievementServiceTest.kt
@@ -392,5 +392,10 @@ class AchievementServiceTest {
                 ConfigService.UpsertResult.Updated(rows[key]!!, previousValue = existing.value)
             }
         }
+        override fun upsertAll(
+            guildId: String,
+            entries: List<Pair<String, String>>,
+        ): List<ConfigService.UpsertResult> =
+            entries.map { (name, value) -> upsertConfig(name, value, guildId) }
     }
 }

--- a/database/src/test/kotlin/database/service/LoginStreakServiceTest.kt
+++ b/database/src/test/kotlin/database/service/LoginStreakServiceTest.kt
@@ -288,5 +288,10 @@ class LoginStreakServiceTest {
                 ConfigService.UpsertResult.Updated(rows[key]!!, previousValue = existing.value)
             }
         }
+        override fun upsertAll(
+            guildId: String,
+            entries: List<Pair<String, String>>,
+        ): List<ConfigService.UpsertResult> =
+            entries.map { (name, value) -> upsertConfig(name, value, guildId) }
     }
 }

--- a/database/src/test/kotlin/database/service/SocialCreditAwardServiceTest.kt
+++ b/database/src/test/kotlin/database/service/SocialCreditAwardServiceTest.kt
@@ -232,5 +232,10 @@ class SocialCreditAwardServiceTest {
                 ConfigService.UpsertResult.Updated(rows[key]!!, previousValue = existing.value)
             }
         }
+        override fun upsertAll(
+            guildId: String,
+            entries: List<Pair<String, String>>,
+        ): List<ConfigService.UpsertResult> =
+            entries.map { (name, value) -> upsertConfig(name, value, guildId) }
     }
 }

--- a/database/src/test/kotlin/database/service/XpAwardServiceTest.kt
+++ b/database/src/test/kotlin/database/service/XpAwardServiceTest.kt
@@ -308,5 +308,10 @@ class XpAwardServiceTest {
                 ConfigService.UpsertResult.Updated(rows[key]!!, previousValue = existing.value)
             }
         }
+        override fun upsertAll(
+            guildId: String,
+            entries: List<Pair<String, String>>,
+        ): List<ConfigService.UpsertResult> =
+            entries.map { (name, value) -> upsertConfig(name, value, guildId) }
     }
 }

--- a/database/src/test/kotlin/database/service/impl/DefaultConfigServiceUpsertAllTest.kt
+++ b/database/src/test/kotlin/database/service/impl/DefaultConfigServiceUpsertAllTest.kt
@@ -1,0 +1,204 @@
+package database.service.impl
+
+import database.dto.ConfigDto
+import database.persistence.ConfigPersistence
+import database.service.ConfigService
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import io.mockk.verifyOrder
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * Unit tests for [DefaultConfigService.upsertAll].
+ *
+ * Direct-instantiation tests bypass Spring's `@Transactional` /
+ * `@CachePut` AOP — what we exercise here is the in-method delegation:
+ * does the batch call `upsertConfig` for every row, in input order, and
+ * does it return results that correctly distinguish `Created` from
+ * `Updated`?
+ *
+ * The transactional commit-once semantics are an annotation contract;
+ * a separate assertion verifies the method is annotated.
+ */
+class DefaultConfigServiceUpsertAllTest {
+
+    private lateinit var persistence: ConfigPersistence
+    private lateinit var service: DefaultConfigService
+
+    @BeforeEach
+    fun setUp() {
+        persistence = mockk(relaxed = true)
+        service = DefaultConfigService()
+        // The persistence field is `@Autowired lateinit var configService`;
+        // unit tests don't run Spring AOP so we inject it manually.
+        DefaultConfigService::class.java.getDeclaredField("configService").apply {
+            isAccessible = true
+            set(service, persistence)
+        }
+    }
+
+    @Test
+    fun `empty input returns empty and writes nothing`() {
+        val results = service.upsertAll("g1", emptyList())
+
+        assertEquals(emptyList<ConfigService.UpsertResult>(), results)
+        verify(exactly = 0) { persistence.createNewConfig(any()) }
+        verify(exactly = 0) { persistence.updateConfig(any()) }
+    }
+
+    @Test
+    fun `all-fresh rows yield Created results in input order`() {
+        // No pre-existing rows.
+        every { persistence.getConfigByName(any(), any()) } returns null
+        every { persistence.createNewConfig(any()) } answers { firstArg() }
+
+        val rows = listOf(
+            "VOLUME" to "75",
+            "DELETE_DELAY" to "15",
+            "INTRO_VOLUME" to "50",
+        )
+        val results = service.upsertAll("g1", rows)
+
+        assertEquals(3, results.size)
+        results.forEachIndexed { i, result ->
+            assertInstanceOf(ConfigService.UpsertResult.Created::class.java, result)
+            assertEquals(rows[i].first, result.dto.name)
+            assertEquals(rows[i].second, result.dto.value)
+            assertEquals("g1", result.dto.guildId)
+        }
+        verify(exactly = 3) { persistence.createNewConfig(any()) }
+        verify(exactly = 0) { persistence.updateConfig(any()) }
+    }
+
+    @Test
+    fun `existing rows yield Updated with the right previousValue`() {
+        every {
+            persistence.getConfigByName("VOLUME", "g1")
+        } returns ConfigDto("VOLUME", "100", "g1")
+        every {
+            persistence.getConfigByName("DELETE_DELAY", "g1")
+        } returns ConfigDto("DELETE_DELAY", "30", "g1")
+        every { persistence.updateConfig(any()) } answers { firstArg() }
+
+        val rows = listOf(
+            "VOLUME" to "75",
+            "DELETE_DELAY" to "15",
+        )
+        val results = service.upsertAll("g1", rows)
+
+        assertEquals(2, results.size)
+        val first = results[0] as ConfigService.UpsertResult.Updated
+        assertEquals("VOLUME", first.dto.name)
+        assertEquals("75", first.dto.value)
+        assertEquals("100", first.previousValue)
+
+        val second = results[1] as ConfigService.UpsertResult.Updated
+        assertEquals("DELETE_DELAY", second.dto.name)
+        assertEquals("15", second.dto.value)
+        assertEquals("30", second.previousValue)
+
+        verify(exactly = 2) { persistence.updateConfig(any()) }
+        verify(exactly = 0) { persistence.createNewConfig(any()) }
+    }
+
+    @Test
+    fun `mixed fresh and existing rows interleave Created and Updated correctly`() {
+        // VOLUME exists, INTRO_VOLUME is fresh, MOVE exists.
+        every { persistence.getConfigByName("VOLUME", "g1") } returns ConfigDto("VOLUME", "50", "g1")
+        every { persistence.getConfigByName("INTRO_VOLUME", "g1") } returns null
+        every { persistence.getConfigByName("MOVE", "g1") } returns ConfigDto("MOVE", "Lobby", "g1")
+        every { persistence.updateConfig(any()) } answers { firstArg() }
+        every { persistence.createNewConfig(any()) } answers { firstArg() }
+
+        val results = service.upsertAll(
+            "g1",
+            listOf(
+                "VOLUME" to "75",
+                "INTRO_VOLUME" to "60",
+                "MOVE" to "General",
+            ),
+        )
+
+        assertEquals(3, results.size)
+        assertInstanceOf(ConfigService.UpsertResult.Updated::class.java, results[0])
+        assertInstanceOf(ConfigService.UpsertResult.Created::class.java, results[1])
+        assertInstanceOf(ConfigService.UpsertResult.Updated::class.java, results[2])
+        assertEquals("50", (results[0] as ConfigService.UpsertResult.Updated).previousValue)
+        assertEquals("Lobby", (results[2] as ConfigService.UpsertResult.Updated).previousValue)
+    }
+
+    @Test
+    fun `existing row from a different guild is treated as fresh and creates`() {
+        // Matches the same-guildId guard inside upsertConfig: a row that
+        // happens to share the name but belongs to another guild does not
+        // count as an existing row for this guild's upsert.
+        every {
+            persistence.getConfigByName("VOLUME", "g1")
+        } returns ConfigDto("VOLUME", "200", "OTHER_GUILD")
+        every { persistence.createNewConfig(any()) } answers { firstArg() }
+
+        val results = service.upsertAll("g1", listOf("VOLUME" to "75"))
+
+        assertEquals(1, results.size)
+        assertInstanceOf(ConfigService.UpsertResult.Created::class.java, results[0])
+        verify(exactly = 1) { persistence.createNewConfig(any()) }
+        verify(exactly = 0) { persistence.updateConfig(any()) }
+    }
+
+    @Test
+    fun `rows are processed in input order`() {
+        every { persistence.getConfigByName(any(), any()) } returns null
+        every { persistence.createNewConfig(any()) } answers { firstArg() }
+
+        service.upsertAll(
+            "g1",
+            listOf(
+                "A" to "1",
+                "B" to "2",
+                "C" to "3",
+            ),
+        )
+
+        // Catches a reordering bug — input order must be preserved so
+        // SetConfigCategoryModal's `zip` against outcome.pairs lines up.
+        verifyOrder {
+            persistence.createNewConfig(match { it.name == "A" })
+            persistence.createNewConfig(match { it.name == "B" })
+            persistence.createNewConfig(match { it.name == "C" })
+        }
+    }
+
+    @Test
+    fun `upsertAll is annotated Transactional`() {
+        // Sanity check: if someone removes the @Transactional annotation,
+        // the batch's "one commit" guarantee silently breaks. Catch that
+        // at test time rather than in production.
+        val method = DefaultConfigService::class.java.getDeclaredMethod(
+            "upsertAll",
+            String::class.java,
+            List::class.java,
+        )
+        assertTrue(
+            method.isAnnotationPresent(Transactional::class.java),
+            "DefaultConfigService.upsertAll must be @Transactional so all rows commit together",
+        )
+    }
+
+    @Test
+    fun `non-empty input does not touch deleteAll or deleteConfig`() {
+        every { persistence.getConfigByName(any(), any()) } returns null
+        every { persistence.createNewConfig(any()) } answers { firstArg() }
+
+        service.upsertAll("g1", listOf("X" to "y"))
+
+        verify(exactly = 0) { persistence.deleteAll(any()) }
+        verify(exactly = 0) { persistence.deleteConfig(any(), any()) }
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/install/InstallSentinel.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/InstallSentinel.kt
@@ -18,11 +18,12 @@ object InstallSentinel {
     fun writeIfFresh(configService: ConfigService, guildId: String, mode: String) {
         val existing = configService.getConfigByName(Configurations.INSTALL_MODE.configValue, guildId)?.value
         if (!existing.isNullOrBlank()) return
-        configService.upsertConfig(Configurations.INSTALL_MODE.configValue, mode, guildId)
-        configService.upsertConfig(
-            Configurations.INSTALLED_AT.configValue,
-            System.currentTimeMillis().toString(),
+        configService.upsertAll(
             guildId,
+            listOf(
+                Configurations.INSTALL_MODE.configValue to mode,
+                Configurations.INSTALLED_AT.configValue to System.currentTimeMillis().toString(),
+            ),
         )
     }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/install/modal/InstallAllStakesModal.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/modal/InstallAllStakesModal.kt
@@ -71,21 +71,21 @@ class InstallAllStakesModal(
             return
         }
 
-        val written = mutableListOf<Pair<String, String>>()
-        // 10 games × up to 2 keys = up to 20 sequential upserts. This is a
-        // one-shot owner-initiated config write, not a hot path, so the
-        // serial round-trips are acceptable. If we ever expose batch
-        // writes on ConfigService (`upsertAll(list)`), swap to that.
-        SetConfigStakesModal.Game.entries.forEach { game ->
-            if (min != null) {
-                configService.upsertConfig(game.minKey.configValue, min.toString(), guildId)
-            }
-            if (max != null) {
-                configService.upsertConfig(game.maxKey.configValue, max.toString(), guildId)
+        // Build the (name, value) rows for every game and commit them in a
+        // single transactional batch. 10 games × up to 2 keys = up to 20
+        // rows in one shot — one commit instead of 20.
+        val rows = buildList {
+            SetConfigStakesModal.Game.entries.forEach { game ->
+                if (min != null) add(game.minKey.configValue to min.toString())
+                if (max != null) add(game.maxKey.configValue to max.toString())
             }
         }
-        if (min != null) written += "Min stake" to min.toString()
-        if (max != null) written += "Max stake" to max.toString()
+        configService.upsertAll(guildId, rows)
+
+        val written = buildList<Pair<String, String>> {
+            if (min != null) add("Min stake" to min.toString())
+            if (max != null) add("Max stake" to max.toString())
+        }
 
         val gameCount = SetConfigStakesModal.Game.entries.size
         val summary = buildString {

--- a/discord-bot/src/main/kotlin/bot/toby/install/modal/InstallQuickChannelsModal.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/modal/InstallQuickChannelsModal.kt
@@ -59,6 +59,10 @@ class InstallQuickChannelsModal(
         val guild = ctx.guild
         val guildId = guild.id
 
+        // Validate both picks before writing anything, then commit them in
+        // one batch — partial writes (e.g. move saved but leaderboard
+        // rejected because the channel was deleted mid-flow) are impossible.
+        val rows = mutableListOf<Pair<String, String>>()
         val written = mutableListOf<String>()
 
         val moveChannelId = event.getValue(FIELD_MOVE)?.asLongList?.firstOrNull()
@@ -69,7 +73,7 @@ class InstallQuickChannelsModal(
                     .setEphemeral(true).queue()
                 return
             }
-            configService.upsertConfig(Configurations.MOVE.configValue, channel.name, guildId)
+            rows += Configurations.MOVE.configValue to channel.name
             written += "Move channel → #${channel.name}"
         }
 
@@ -81,20 +85,17 @@ class InstallQuickChannelsModal(
                     .setEphemeral(true).queue()
                 return
             }
-            configService.upsertConfig(
-                Configurations.LEADERBOARD_CHANNEL.configValue,
-                leaderboardChannelId.toString(),
-                guildId,
-            )
+            rows += Configurations.LEADERBOARD_CHANNEL.configValue to leaderboardChannelId.toString()
             written += "Leaderboard channel → #${channel.name}"
         }
 
-        if (written.isEmpty()) {
+        if (rows.isEmpty()) {
             event.reply("No channels picked — nothing changed.").setEphemeral(true).queue()
-        } else {
-            event.reply("Saved:\n" + written.joinToString("\n") { "• $it" })
-                .setEphemeral(true).queue()
+            return
         }
+        configService.upsertAll(guildId, rows)
+        event.reply("Saved:\n" + written.joinToString("\n") { "• $it" })
+            .setEphemeral(true).queue()
     }
 
     companion object {

--- a/discord-bot/src/main/kotlin/bot/toby/modal/modals/setconfig/SetConfigCategoryModal.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/modal/modals/setconfig/SetConfigCategoryModal.kt
@@ -83,9 +83,13 @@ abstract class SetConfigCategoryModal(
                         .setEphemeral(true).queue()
                     return
                 }
-                val results = outcome.pairs.map { (key, value) ->
-                    key to configService.upsertConfig(key.configValue, value, guild.id)
-                }
+                // One transactional batch instead of N sequential commits.
+                // Pair the (key, UpsertResult) results back up by index so
+                // the existing `afterWrites` hook (which keys side-effects
+                // off the Configurations enum) still works.
+                val rows = outcome.pairs.map { (key, value) -> key.configValue to value }
+                val upsertResults = configService.upsertAll(guild.id, rows)
+                val results = outcome.pairs.zip(upsertResults) { (key, _), result -> key to result }
                 event.hook.sendMessage(buildSummary(outcome.pairs, specs))
                     .setEphemeral(true).queue()
                 afterWrites(ctx, results)

--- a/discord-bot/src/test/kotlin/bot/toby/install/InstallSentinelTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/install/InstallSentinelTest.kt
@@ -26,22 +26,21 @@ internal class InstallSentinelTest {
         every {
             configService.getConfigByName(Configurations.INSTALL_MODE.configValue, "g1")
         } returns null
-        val installedAtSlot = slot<String>()
+        val rowsSlot = slot<List<Pair<String, String>>>()
         every {
-            configService.upsertConfig(Configurations.INSTALLED_AT.configValue, capture(installedAtSlot), "g1")
-        } returns mockk(relaxed = true)
+            configService.upsertAll("g1", capture(rowsSlot))
+        } returns emptyList()
 
         val before = System.currentTimeMillis()
         InstallSentinel.writeIfFresh(configService, "g1", mode = "express")
         val after = System.currentTimeMillis()
 
-        verify(exactly = 1) {
-            configService.upsertConfig(Configurations.INSTALL_MODE.configValue, "express", "g1")
-        }
-        verify(exactly = 1) {
-            configService.upsertConfig(Configurations.INSTALLED_AT.configValue, any<String>(), "g1")
-        }
-        assertTrue(installedAtSlot.captured.toLong() in before..after)
+        verify(exactly = 1) { configService.upsertAll("g1", any()) }
+        val rows = rowsSlot.captured
+        assertTrue(rows.size == 2)
+        assertTrue(rows[0] == Configurations.INSTALL_MODE.configValue to "express")
+        assertTrue(rows[1].first == Configurations.INSTALLED_AT.configValue)
+        assertTrue(rows[1].second.toLong() in before..after)
     }
 
     @Test
@@ -49,12 +48,13 @@ internal class InstallSentinelTest {
         every {
             configService.getConfigByName(Configurations.INSTALL_MODE.configValue, "g1")
         } returns null
+        val rowsSlot = slot<List<Pair<String, String>>>()
+        every { configService.upsertAll("g1", capture(rowsSlot)) } returns emptyList()
 
         InstallSentinel.writeIfFresh(configService, "g1", mode = "custom")
 
-        verify(exactly = 1) {
-            configService.upsertConfig(Configurations.INSTALL_MODE.configValue, "custom", "g1")
-        }
+        verify(exactly = 1) { configService.upsertAll("g1", any()) }
+        assertTrue(rowsSlot.captured[0] == Configurations.INSTALL_MODE.configValue to "custom")
     }
 
     @Test
@@ -69,6 +69,7 @@ internal class InstallSentinelTest {
         verify(exactly = 1) {
             configService.getConfigByName(Configurations.INSTALL_MODE.configValue, "g1")
         }
+        verify(exactly = 0) { configService.upsertAll(any(), any()) }
         verify(exactly = 0) {
             configService.upsertConfig(any<String>(), any<String>(), any<String>())
         }
@@ -83,6 +84,7 @@ internal class InstallSentinelTest {
 
         InstallSentinel.writeIfFresh(configService, "g1", mode = "express")
 
+        verify(exactly = 0) { configService.upsertAll(any(), any()) }
         verify(exactly = 0) {
             configService.upsertConfig(any<String>(), any<String>(), any<String>())
         }
@@ -93,11 +95,12 @@ internal class InstallSentinelTest {
         every {
             configService.getConfigByName(Configurations.INSTALL_MODE.configValue, "g1")
         } returns ConfigDto(Configurations.INSTALL_MODE.configValue, "", "g1")
+        val rowsSlot = slot<List<Pair<String, String>>>()
+        every { configService.upsertAll("g1", capture(rowsSlot)) } returns emptyList()
 
         InstallSentinel.writeIfFresh(configService, "g1", mode = "express")
 
-        verify(exactly = 1) {
-            configService.upsertConfig(Configurations.INSTALL_MODE.configValue, "express", "g1")
-        }
+        verify(exactly = 1) { configService.upsertAll("g1", any()) }
+        assertTrue(rowsSlot.captured[0] == Configurations.INSTALL_MODE.configValue to "express")
     }
 }

--- a/discord-bot/src/test/kotlin/bot/toby/install/button/InstallExpressButtonTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/install/button/InstallExpressButtonTest.kt
@@ -77,6 +77,7 @@ internal class InstallExpressButtonTest {
         button.handle(ctx, mockk(relaxed = true), 0)
 
         verify(exactly = 1) { event.reply(any<String>()) }
+        verify(exactly = 0) { configService.upsertAll(any(), any()) }
         verify(exactly = 0) {
             configService.upsertConfig(any<String>(), any<String>(), any<String>())
         }
@@ -85,24 +86,23 @@ internal class InstallExpressButtonTest {
     }
 
     @Test
-    fun `owner happy path writes INSTALL_MODE express then INSTALLED_AT epoch`() {
-        val installedAtSlot = slot<String>()
-        every {
-            configService.upsertConfig(Configurations.INSTALLED_AT.configValue, capture(installedAtSlot), "g1")
-        } returns mockk(relaxed = true)
+    fun `owner happy path writes INSTALL_MODE express and INSTALLED_AT epoch via batch upsert`() {
+        // The sentinel writes flow through InstallSentinel.writeIfFresh,
+        // which now uses upsertAll for transactional cohesion (one commit
+        // instead of two).
+        val rowsSlot = slot<List<Pair<String, String>>>()
+        every { configService.upsertAll("g1", capture(rowsSlot)) } returns emptyList()
 
         val before = System.currentTimeMillis()
         button.handle(ctx, mockk(relaxed = true), 0)
         val after = System.currentTimeMillis()
 
-        verify(exactly = 1) {
-            configService.upsertConfig(Configurations.INSTALL_MODE.configValue, "express", "g1")
-        }
-        verify(exactly = 1) {
-            configService.upsertConfig(Configurations.INSTALLED_AT.configValue, any<String>(), "g1")
-        }
-        val capturedEpoch = installedAtSlot.captured.toLong()
-        assertTrue(capturedEpoch in before..after, "INSTALLED_AT epoch should be ~now")
+        verify(exactly = 1) { configService.upsertAll("g1", any()) }
+        val rows = rowsSlot.captured
+        assertTrue(rows.size == 2)
+        assertTrue(rows[0] == Configurations.INSTALL_MODE.configValue to "express")
+        assertTrue(rows[1].first == Configurations.INSTALLED_AT.configValue)
+        assertTrue(rows[1].second.toLong() in before..after, "INSTALLED_AT epoch should be ~now")
     }
 
     @Test

--- a/discord-bot/src/test/kotlin/bot/toby/install/button/InstallFinishButtonTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/install/button/InstallFinishButtonTest.kt
@@ -38,6 +38,7 @@ internal class InstallFinishButtonTest {
         button.handle(fx.ctx, mockk(relaxed = true), 0)
 
         verify(exactly = 1) { fx.event.reply(any<String>()) }
+        verify(exactly = 0) { configService.upsertAll(any(), any()) }
         verify(exactly = 0) {
             configService.upsertConfig(any<String>(), any<String>(), any<String>())
         }
@@ -45,24 +46,20 @@ internal class InstallFinishButtonTest {
     }
 
     @Test
-    fun `owner happy path writes INSTALL_MODE custom and a fresh INSTALLED_AT epoch`() {
-        val installedAtSlot = slot<String>()
-        every {
-            configService.upsertConfig(Configurations.INSTALLED_AT.configValue, capture(installedAtSlot), "g1")
-        } returns mockk(relaxed = true)
+    fun `owner happy path writes INSTALL_MODE custom and INSTALLED_AT epoch via batch upsert`() {
+        val rowsSlot = slot<List<Pair<String, String>>>()
+        every { configService.upsertAll("g1", capture(rowsSlot)) } returns emptyList()
 
         val before = System.currentTimeMillis()
         button.handle(fx.ctx, mockk(relaxed = true), 0)
         val after = System.currentTimeMillis()
 
-        verify(exactly = 1) {
-            configService.upsertConfig(Configurations.INSTALL_MODE.configValue, "custom", "g1")
-        }
-        verify(exactly = 1) {
-            configService.upsertConfig(Configurations.INSTALLED_AT.configValue, any<String>(), "g1")
-        }
-        val capturedEpoch = installedAtSlot.captured.toLong()
-        assertTrue(capturedEpoch in before..after, "INSTALLED_AT epoch should be ~now")
+        verify(exactly = 1) { configService.upsertAll("g1", any()) }
+        val rows = rowsSlot.captured
+        assertTrue(rows.size == 2)
+        assertTrue(rows[0] == Configurations.INSTALL_MODE.configValue to "custom")
+        assertTrue(rows[1].first == Configurations.INSTALLED_AT.configValue)
+        assertTrue(rows[1].second.toLong() in before..after, "INSTALLED_AT epoch should be ~now")
     }
 
     @Test

--- a/discord-bot/src/test/kotlin/bot/toby/install/modal/InstallAllStakesModalTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/install/modal/InstallAllStakesModalTest.kt
@@ -9,12 +9,15 @@ import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
+import io.mockk.slot
 import io.mockk.verify
 import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent
 import net.dv8tion.jda.api.interactions.modals.ModalMapping
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
@@ -69,6 +72,7 @@ internal class InstallAllStakesModalTest {
         modal.handle(ctx, 0)
 
         verify(exactly = 1) { event.reply(any<String>()) }
+        verify(exactly = 0) { configService.upsertAll(any(), any()) }
         verify(exactly = 0) {
             configService.upsertConfig(any<String>(), any<String>(), any<String>())
         }
@@ -82,6 +86,7 @@ internal class InstallAllStakesModalTest {
         modal.handle(ctx, 0)
 
         verify(exactly = 1) { event.reply(match<String> { it.contains("Min") }) }
+        verify(exactly = 0) { configService.upsertAll(any(), any()) }
         verify(exactly = 0) {
             configService.upsertConfig(any<String>(), any<String>(), any<String>())
         }
@@ -95,6 +100,7 @@ internal class InstallAllStakesModalTest {
         modal.handle(ctx, 0)
 
         verify(exactly = 1) { event.reply(match<String> { it.contains("exceed") }) }
+        verify(exactly = 0) { configService.upsertAll(any(), any()) }
         verify(exactly = 0) {
             configService.upsertConfig(any<String>(), any<String>(), any<String>())
         }
@@ -108,59 +114,63 @@ internal class InstallAllStakesModalTest {
         modal.handle(ctx, 0)
 
         verify(exactly = 1) { event.reply(any<String>()) }
+        verify(exactly = 0) { configService.upsertAll(any(), any()) }
         verify(exactly = 0) {
             configService.upsertConfig(any<String>(), any<String>(), any<String>())
         }
     }
 
     @Test
-    fun `min only writes only MIN_STAKE for every game`() {
+    fun `min only writes one batched upsert containing MIN_STAKE for every game`() {
         stubField(InstallAllStakesModal.FIELD_MIN_STAKE, "100")
         stubField(InstallAllStakesModal.FIELD_MAX_STAKE, "")
+        val rowsSlot = slot<List<Pair<String, String>>>()
+        every { configService.upsertAll("g1", capture(rowsSlot)) } returns emptyList()
 
         modal.handle(ctx, 0)
 
+        verify(exactly = 1) { configService.upsertAll("g1", any()) }
+        val gameCount = SetConfigStakesModal.Game.entries.size
+        assertEquals(gameCount, rowsSlot.captured.size)
         SetConfigStakesModal.Game.entries.forEach { game ->
-            verify(exactly = 1) {
-                configService.upsertConfig(game.minKey.configValue, "100", "g1")
-            }
-            verify(exactly = 0) {
-                configService.upsertConfig(game.maxKey.configValue, any<String>(), "g1")
-            }
+            assertTrue(rowsSlot.captured.contains(game.minKey.configValue to "100"))
+            assertFalse(rowsSlot.captured.any { it.first == game.maxKey.configValue })
         }
     }
 
     @Test
-    fun `max only writes only MAX_STAKE for every game`() {
+    fun `max only writes one batched upsert containing MAX_STAKE for every game`() {
         stubField(InstallAllStakesModal.FIELD_MIN_STAKE, "")
         stubField(InstallAllStakesModal.FIELD_MAX_STAKE, "5000")
+        val rowsSlot = slot<List<Pair<String, String>>>()
+        every { configService.upsertAll("g1", capture(rowsSlot)) } returns emptyList()
 
         modal.handle(ctx, 0)
 
+        verify(exactly = 1) { configService.upsertAll("g1", any()) }
+        val gameCount = SetConfigStakesModal.Game.entries.size
+        assertEquals(gameCount, rowsSlot.captured.size)
         SetConfigStakesModal.Game.entries.forEach { game ->
-            verify(exactly = 1) {
-                configService.upsertConfig(game.maxKey.configValue, "5000", "g1")
-            }
-            verify(exactly = 0) {
-                configService.upsertConfig(game.minKey.configValue, any<String>(), "g1")
-            }
+            assertTrue(rowsSlot.captured.contains(game.maxKey.configValue to "5000"))
+            assertFalse(rowsSlot.captured.any { it.first == game.minKey.configValue })
         }
     }
 
     @Test
-    fun `both min and max writes both keys for every game`() {
+    fun `both min and max writes one batched upsert with both keys for every game`() {
         stubField(InstallAllStakesModal.FIELD_MIN_STAKE, "100")
         stubField(InstallAllStakesModal.FIELD_MAX_STAKE, "5000")
+        val rowsSlot = slot<List<Pair<String, String>>>()
+        every { configService.upsertAll("g1", capture(rowsSlot)) } returns emptyList()
 
         modal.handle(ctx, 0)
 
+        verify(exactly = 1) { configService.upsertAll("g1", any()) }
+        val gameCount = SetConfigStakesModal.Game.entries.size
+        assertEquals(gameCount * 2, rowsSlot.captured.size)
         SetConfigStakesModal.Game.entries.forEach { game ->
-            verify(exactly = 1) {
-                configService.upsertConfig(game.minKey.configValue, "100", "g1")
-            }
-            verify(exactly = 1) {
-                configService.upsertConfig(game.maxKey.configValue, "5000", "g1")
-            }
+            assertTrue(rowsSlot.captured.contains(game.minKey.configValue to "100"))
+            assertTrue(rowsSlot.captured.contains(game.maxKey.configValue to "5000"))
         }
     }
 

--- a/discord-bot/src/test/kotlin/bot/toby/install/modal/InstallQuickChannelsModalTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/install/modal/InstallQuickChannelsModalTest.kt
@@ -7,6 +7,7 @@ import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
+import io.mockk.slot
 import io.mockk.verify
 import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
@@ -68,60 +69,61 @@ internal class InstallQuickChannelsModalTest {
         modal.handle(ctx, 0)
 
         verify(exactly = 1) { event.reply(match<String> { it.contains("nothing changed", ignoreCase = true) }) }
+        verify(exactly = 0) { configService.upsertAll(any(), any()) }
         verify(exactly = 0) {
             configService.upsertConfig(any<String>(), any<String>(), any<String>())
         }
     }
 
     @Test
-    fun `voice channel selection writes MOVE channel name`() {
+    fun `voice channel selection writes MOVE channel name via batch upsert`() {
         val voiceChannel = mockk<VoiceChannel> { every { name } returns "General Voice" }
         stubChannelPick(InstallQuickChannelsModal.FIELD_MOVE, 12345L)
         every { guild.getVoiceChannelById(12345L) } returns voiceChannel
+        val rowsSlot = slot<List<Pair<String, String>>>()
+        every { configService.upsertAll("g1", capture(rowsSlot)) } returns emptyList()
 
         modal.handle(ctx, 0)
 
-        verify(exactly = 1) {
-            configService.upsertConfig(Configurations.MOVE.configValue, "General Voice", "g1")
-        }
-        verify(exactly = 0) {
-            configService.upsertConfig(Configurations.LEADERBOARD_CHANNEL.configValue, any<String>(), "g1")
-        }
+        verify(exactly = 1) { configService.upsertAll("g1", any()) }
+        assertEquals(listOf(Configurations.MOVE.configValue to "General Voice"), rowsSlot.captured)
     }
 
     @Test
-    fun `text channel selection writes LEADERBOARD_CHANNEL id`() {
+    fun `text channel selection writes LEADERBOARD_CHANNEL id via batch upsert`() {
         val textChannel = mockk<TextChannel> { every { name } returns "leaderboard" }
         stubChannelPick(InstallQuickChannelsModal.FIELD_LEADERBOARD, 67890L)
         every { guild.getTextChannelById(67890L) } returns textChannel
+        val rowsSlot = slot<List<Pair<String, String>>>()
+        every { configService.upsertAll("g1", capture(rowsSlot)) } returns emptyList()
 
         modal.handle(ctx, 0)
 
-        verify(exactly = 1) {
-            configService.upsertConfig(Configurations.LEADERBOARD_CHANNEL.configValue, "67890", "g1")
-        }
-        verify(exactly = 0) {
-            configService.upsertConfig(Configurations.MOVE.configValue, any<String>(), "g1")
-        }
+        verify(exactly = 1) { configService.upsertAll("g1", any()) }
+        assertEquals(listOf(Configurations.LEADERBOARD_CHANNEL.configValue to "67890"), rowsSlot.captured)
     }
 
     @Test
-    fun `both selections write both keys`() {
+    fun `both selections write both keys in one batch`() {
         val voiceChannel = mockk<VoiceChannel> { every { name } returns "Lobby" }
         val textChannel = mockk<TextChannel> { every { name } returns "scores" }
         stubChannelPick(InstallQuickChannelsModal.FIELD_MOVE, 1L)
         stubChannelPick(InstallQuickChannelsModal.FIELD_LEADERBOARD, 2L)
         every { guild.getVoiceChannelById(1L) } returns voiceChannel
         every { guild.getTextChannelById(2L) } returns textChannel
+        val rowsSlot = slot<List<Pair<String, String>>>()
+        every { configService.upsertAll("g1", capture(rowsSlot)) } returns emptyList()
 
         modal.handle(ctx, 0)
 
-        verify(exactly = 1) {
-            configService.upsertConfig(Configurations.MOVE.configValue, "Lobby", "g1")
-        }
-        verify(exactly = 1) {
-            configService.upsertConfig(Configurations.LEADERBOARD_CHANNEL.configValue, "2", "g1")
-        }
+        verify(exactly = 1) { configService.upsertAll("g1", any()) }
+        assertEquals(
+            listOf(
+                Configurations.MOVE.configValue to "Lobby",
+                Configurations.LEADERBOARD_CHANNEL.configValue to "2",
+            ),
+            rowsSlot.captured,
+        )
     }
 
     @Test
@@ -132,6 +134,7 @@ internal class InstallQuickChannelsModalTest {
         modal.handle(ctx, 0)
 
         verify(exactly = 1) { event.reply(match<String> { it.contains("no longer exists") }) }
+        verify(exactly = 0) { configService.upsertAll(any(), any()) }
         verify(exactly = 0) {
             configService.upsertConfig(any<String>(), any<String>(), any<String>())
         }
@@ -145,6 +148,7 @@ internal class InstallQuickChannelsModalTest {
         modal.handle(ctx, 0)
 
         verify(exactly = 1) { event.reply(match<String> { it.contains("no longer exists") }) }
+        verify(exactly = 0) { configService.upsertAll(any(), any()) }
         verify(exactly = 0) {
             configService.upsertConfig(any<String>(), any<String>(), any<String>())
         }

--- a/discord-bot/src/test/kotlin/bot/toby/modal/modals/setconfig/SetConfigActivityModalTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/modal/modals/setconfig/SetConfigActivityModalTest.kt
@@ -61,11 +61,11 @@ class SetConfigActivityModalTest {
     @Test
     fun `first-enable from previously-disabled fires the notifier`() {
         stub(SetConfigActivityModal.FIELD_ACTIVITY_TRACKING, "true")
-        every {
-            configService.upsertConfig(Configurations.ACTIVITY_TRACKING.configValue, "true", guildId)
-        } returns ConfigService.UpsertResult.Updated(
-            ConfigDto(Configurations.ACTIVITY_TRACKING.configValue, "true", guildId),
-            previousValue = "false",
+        every { configService.upsertAll(guildId, any()) } returns listOf(
+            ConfigService.UpsertResult.Updated(
+                ConfigDto(Configurations.ACTIVITY_TRACKING.configValue, "true", guildId),
+                previousValue = "false",
+            ),
         )
 
         modal.handle(ctx, 0)
@@ -76,10 +76,10 @@ class SetConfigActivityModalTest {
     @Test
     fun `first-enable from never-set (Created) also fires the notifier`() {
         stub(SetConfigActivityModal.FIELD_ACTIVITY_TRACKING, "true")
-        every {
-            configService.upsertConfig(Configurations.ACTIVITY_TRACKING.configValue, "true", guildId)
-        } returns ConfigService.UpsertResult.Created(
-            ConfigDto(Configurations.ACTIVITY_TRACKING.configValue, "true", guildId),
+        every { configService.upsertAll(guildId, any()) } returns listOf(
+            ConfigService.UpsertResult.Created(
+                ConfigDto(Configurations.ACTIVITY_TRACKING.configValue, "true", guildId),
+            ),
         )
 
         modal.handle(ctx, 0)
@@ -90,11 +90,11 @@ class SetConfigActivityModalTest {
     @Test
     fun `re-enable when previously enabled does NOT re-fire the notifier`() {
         stub(SetConfigActivityModal.FIELD_ACTIVITY_TRACKING, "true")
-        every {
-            configService.upsertConfig(Configurations.ACTIVITY_TRACKING.configValue, "true", guildId)
-        } returns ConfigService.UpsertResult.Updated(
-            ConfigDto(Configurations.ACTIVITY_TRACKING.configValue, "true", guildId),
-            previousValue = "true",
+        every { configService.upsertAll(guildId, any()) } returns listOf(
+            ConfigService.UpsertResult.Updated(
+                ConfigDto(Configurations.ACTIVITY_TRACKING.configValue, "true", guildId),
+                previousValue = "true",
+            ),
         )
 
         modal.handle(ctx, 0)
@@ -105,11 +105,11 @@ class SetConfigActivityModalTest {
     @Test
     fun `disabling never fires the notifier`() {
         stub(SetConfigActivityModal.FIELD_ACTIVITY_TRACKING, "false")
-        every {
-            configService.upsertConfig(Configurations.ACTIVITY_TRACKING.configValue, "false", guildId)
-        } returns ConfigService.UpsertResult.Updated(
-            ConfigDto(Configurations.ACTIVITY_TRACKING.configValue, "false", guildId),
-            previousValue = "true",
+        every { configService.upsertAll(guildId, any()) } returns listOf(
+            ConfigService.UpsertResult.Updated(
+                ConfigDto(Configurations.ACTIVITY_TRACKING.configValue, "false", guildId),
+                previousValue = "true",
+            ),
         )
 
         modal.handle(ctx, 0)
@@ -122,6 +122,7 @@ class SetConfigActivityModalTest {
         // Default: all event.getValue calls return null → Skip outcome
         modal.handle(ctx, 0)
 
+        verify(exactly = 0) { configService.upsertAll(any(), any()) }
         verify(exactly = 0) { configService.upsertConfig(any(), any(), any()) }
         verify(exactly = 0) { notifier.notifyMembersOnFirstEnable(any()) }
         assertTrue(messageSlot.captured.contains("No fields filled"))
@@ -131,21 +132,24 @@ class SetConfigActivityModalTest {
     fun `numeric fields parse and upsert in order`() {
         stub(SetConfigActivityModal.FIELD_UBI_DAILY_AMOUNT, "50")
         stub(SetConfigActivityModal.FIELD_DAILY_CREDIT_CAP, "200")
-        every {
-            configService.upsertConfig(Configurations.UBI_DAILY_AMOUNT.configValue, "50", guildId)
-        } returns ConfigService.UpsertResult.Created(
-            ConfigDto(Configurations.UBI_DAILY_AMOUNT.configValue, "50", guildId),
-        )
-        every {
-            configService.upsertConfig(Configurations.DAILY_CREDIT_CAP.configValue, "200", guildId)
-        } returns ConfigService.UpsertResult.Created(
-            ConfigDto(Configurations.DAILY_CREDIT_CAP.configValue, "200", guildId),
+        val rowsSlot = slot<List<Pair<String, String>>>()
+        every { configService.upsertAll(guildId, capture(rowsSlot)) } returns listOf(
+            ConfigService.UpsertResult.Created(
+                ConfigDto(Configurations.UBI_DAILY_AMOUNT.configValue, "50", guildId),
+            ),
+            ConfigService.UpsertResult.Created(
+                ConfigDto(Configurations.DAILY_CREDIT_CAP.configValue, "200", guildId),
+            ),
         )
 
         modal.handle(ctx, 0)
 
-        verify(exactly = 1) { configService.upsertConfig(Configurations.UBI_DAILY_AMOUNT.configValue, "50", guildId) }
-        verify(exactly = 1) { configService.upsertConfig(Configurations.DAILY_CREDIT_CAP.configValue, "200", guildId) }
+        verify(exactly = 1) { configService.upsertAll(guildId, any()) }
+        // Order matches the modal's spec map iteration; UBI comes before cap.
+        assertTrue(
+            rowsSlot.captured.contains(Configurations.UBI_DAILY_AMOUNT.configValue to "50") &&
+                rowsSlot.captured.contains(Configurations.DAILY_CREDIT_CAP.configValue to "200")
+        )
         verify(exactly = 0) { notifier.notifyMembersOnFirstEnable(any()) }
     }
 
@@ -155,6 +159,7 @@ class SetConfigActivityModalTest {
 
         modal.handle(ctx, 0)
 
+        verify(exactly = 0) { configService.upsertAll(any(), any()) }
         verify(exactly = 0) { configService.upsertConfig(any(), any(), any()) }
         assertTrue(messageSlot.captured.contains("Couldn't save"))
         assertTrue(messageSlot.captured.contains("UBI daily amount"))

--- a/discord-bot/src/test/kotlin/bot/toby/modal/modals/setconfig/SetConfigGeneralModalTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/modal/modals/setconfig/SetConfigGeneralModalTest.kt
@@ -17,6 +17,7 @@ import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent
 import net.dv8tion.jda.api.interactions.InteractionHook
 import net.dv8tion.jda.api.interactions.modals.ModalMapping
 import net.dv8tion.jda.api.requests.restaction.WebhookMessageCreateAction
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -58,17 +59,17 @@ class SetConfigGeneralModalTest {
     fun `happy path writes the filled fields`() {
         stub(SetConfigGeneralModal.FIELD_VOLUME, "120")
         stub(SetConfigGeneralModal.FIELD_DELETE_DELAY, "10")
-        every {
-            configService.upsertConfig(Configurations.VOLUME.configValue, "120", guildId)
-        } returns ConfigService.UpsertResult.Created(ConfigDto(Configurations.VOLUME.configValue, "120", guildId))
-        every {
-            configService.upsertConfig(Configurations.DELETE_DELAY.configValue, "10", guildId)
-        } returns ConfigService.UpsertResult.Created(ConfigDto(Configurations.DELETE_DELAY.configValue, "10", guildId))
+        val rowsSlot = slot<List<Pair<String, String>>>()
+        every { configService.upsertAll(guildId, capture(rowsSlot)) } returns listOf(
+            ConfigService.UpsertResult.Created(ConfigDto(Configurations.VOLUME.configValue, "120", guildId)),
+            ConfigService.UpsertResult.Created(ConfigDto(Configurations.DELETE_DELAY.configValue, "10", guildId)),
+        )
 
         modal.handle(ctx, 0)
 
-        verify { configService.upsertConfig(Configurations.VOLUME.configValue, "120", guildId) }
-        verify { configService.upsertConfig(Configurations.DELETE_DELAY.configValue, "10", guildId) }
+        verify(exactly = 1) { configService.upsertAll(guildId, any()) }
+        assertTrue(rowsSlot.captured.contains(Configurations.VOLUME.configValue to "120"))
+        assertTrue(rowsSlot.captured.contains(Configurations.DELETE_DELAY.configValue to "10"))
         assertTrue(messageSlot.captured.startsWith("Saved 2 settings"))
     }
 
@@ -76,6 +77,7 @@ class SetConfigGeneralModalTest {
     fun `all-blank submission is a no-op with a friendly reply`() {
         modal.handle(ctx, 0)
 
+        verify(exactly = 0) { configService.upsertAll(any(), any()) }
         verify(exactly = 0) { configService.upsertConfig(any(), any(), any()) }
         assertTrue(messageSlot.captured.contains("No fields filled"))
     }
@@ -85,14 +87,16 @@ class SetConfigGeneralModalTest {
         stub(SetConfigGeneralModal.FIELD_MOVE, "42")
         val channel = mockk<TextChannel> { every { name } returns "general" }
         every { guild.getTextChannelById(42L) } returns channel
-        every {
-            configService.upsertConfig(Configurations.MOVE.configValue, "general", guildId)
-        } returns ConfigService.UpsertResult.Created(ConfigDto(Configurations.MOVE.configValue, "general", guildId))
+        val rowsSlot = slot<List<Pair<String, String>>>()
+        every { configService.upsertAll(guildId, capture(rowsSlot)) } returns listOf(
+            ConfigService.UpsertResult.Created(ConfigDto(Configurations.MOVE.configValue, "general", guildId)),
+        )
 
         modal.handle(ctx, 0)
 
         // Must persist the channel NAME (legacy MoveCommand contract), not the id.
-        verify(exactly = 1) { configService.upsertConfig(Configurations.MOVE.configValue, "general", guildId) }
+        verify(exactly = 1) { configService.upsertAll(guildId, any()) }
+        assertEquals(listOf(Configurations.MOVE.configValue to "general"), rowsSlot.captured)
     }
 
     @Test

--- a/discord-bot/src/test/kotlin/bot/toby/modal/modals/setconfig/SetConfigStakesModalTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/modal/modals/setconfig/SetConfigStakesModalTest.kt
@@ -76,15 +76,14 @@ class SetConfigStakesModalTest {
         stub(SetConfigStakesModal.FIELD_MIN_STAKE, "5")
         stub(SetConfigStakesModal.FIELD_MAX_STAKE, "500")
         stub(SetConfigStakesModal.FIELD_BOT_EDGE_PCT, "30")
-        upsertCreated(Configurations.DICE_MIN_STAKE, "5")
-        upsertCreated(Configurations.DICE_MAX_STAKE, "500")
-        upsertCreated(Configurations.DICE_BOT_EDGE_MAX_PCT, "30")
+        val rowsSlot = stubUpsertAllReturningCreated()
 
         modal.handle(ctx, 0)
 
-        verify { configService.upsertConfig(Configurations.DICE_MIN_STAKE.configValue, "5", guildId) }
-        verify { configService.upsertConfig(Configurations.DICE_MAX_STAKE.configValue, "500", guildId) }
-        verify { configService.upsertConfig(Configurations.DICE_BOT_EDGE_MAX_PCT.configValue, "30", guildId) }
+        verify(exactly = 1) { configService.upsertAll(guildId, any()) }
+        assertTrue(rowsSlot.captured.contains(Configurations.DICE_MIN_STAKE.configValue to "5"))
+        assertTrue(rowsSlot.captured.contains(Configurations.DICE_MAX_STAKE.configValue to "500"))
+        assertTrue(rowsSlot.captured.contains(Configurations.DICE_BOT_EDGE_MAX_PCT.configValue to "30"))
     }
 
     @Test
@@ -93,20 +92,16 @@ class SetConfigStakesModalTest {
         stub(SetConfigStakesModal.FIELD_MIN_STAKE, "10")
         stub(SetConfigStakesModal.FIELD_MAX_STAKE, "1000")
         stub(SetConfigStakesModal.FIELD_BOT_EDGE_PCT, "30") // ignored — not in specs
-        upsertCreated(Configurations.DUEL_MIN_STAKE, "10")
-        upsertCreated(Configurations.DUEL_MAX_STAKE, "1000")
+        val rowsSlot = stubUpsertAllReturningCreated()
 
         modal.handle(ctx, 0)
 
-        verify { configService.upsertConfig(Configurations.DUEL_MIN_STAKE.configValue, "10", guildId) }
-        verify { configService.upsertConfig(Configurations.DUEL_MAX_STAKE.configValue, "1000", guildId) }
+        verify(exactly = 1) { configService.upsertAll(guildId, any()) }
+        assertTrue(rowsSlot.captured.contains(Configurations.DUEL_MIN_STAKE.configValue to "10"))
+        assertTrue(rowsSlot.captured.contains(Configurations.DUEL_MAX_STAKE.configValue to "1000"))
         // No bot-edge key exists for DUEL → never written even though the field
         // was submitted. The modal's specs map is the source of truth.
-        verify(exactly = 0) {
-            configService.upsertConfig(
-                match { it.contains("BOT_EDGE") }, any(), any(),
-            )
-        }
+        assertTrue(rowsSlot.captured.none { it.first.contains("BOT_EDGE") })
     }
 
     @Test
@@ -114,12 +109,13 @@ class SetConfigStakesModalTest {
         every { event.modalId } returns SetConfigStakesModal.customIdFor(SetConfigStakesModal.Game.SLOTS)
         // FIELD_MIN_STAKE remains null (blank)
         stub(SetConfigStakesModal.FIELD_MAX_STAKE, "750")
-        upsertCreated(Configurations.SLOTS_MAX_STAKE, "750")
+        val rowsSlot = stubUpsertAllReturningCreated()
 
         modal.handle(ctx, 0)
 
-        verify(exactly = 0) { configService.upsertConfig(Configurations.SLOTS_MIN_STAKE.configValue, any(), any()) }
-        verify(exactly = 1) { configService.upsertConfig(Configurations.SLOTS_MAX_STAKE.configValue, "750", guildId) }
+        verify(exactly = 1) { configService.upsertAll(guildId, any()) }
+        assertTrue(rowsSlot.captured.none { it.first == Configurations.SLOTS_MIN_STAKE.configValue })
+        assertTrue(rowsSlot.captured.contains(Configurations.SLOTS_MAX_STAKE.configValue to "750"))
     }
 
     @Test
@@ -130,6 +126,7 @@ class SetConfigStakesModalTest {
 
         modal.handle(ctx, 0)
 
+        verify(exactly = 0) { configService.upsertAll(any(), any()) }
         verify(exactly = 0) { configService.upsertConfig(any(), any(), any()) }
         assertTrue(messageSlot.captured.contains("Couldn't save"))
     }
@@ -139,9 +136,20 @@ class SetConfigStakesModalTest {
         every { event.getValue(field) } returns mapping
     }
 
-    private fun upsertCreated(key: Configurations, value: String) {
-        every {
-            configService.upsertConfig(key.configValue, value, guildId)
-        } returns ConfigService.UpsertResult.Created(ConfigDto(key.configValue, value, guildId))
+    /**
+     * Stub `upsertAll` to capture the input list and return per-row
+     * `Created` results synthesized from the captured rows. Saves the
+     * test from re-asserting the Created/Updated distinction (covered
+     * by [DefaultConfigServiceUpsertAllTest]) and lets the modal's
+     * `afterWrites` hook see a sensible result.
+     */
+    private fun stubUpsertAllReturningCreated(): io.mockk.CapturingSlot<List<Pair<String, String>>> {
+        val slot = io.mockk.slot<List<Pair<String, String>>>()
+        every { configService.upsertAll(guildId, capture(slot)) } answers {
+            slot.captured.map { (name, value) ->
+                ConfigService.UpsertResult.Created(ConfigDto(name, value, guildId))
+            }
+        }
+        return slot
     }
 }


### PR DESCRIPTION
## Summary

Adds `ConfigService.upsertAll(guildId, rows): List<UpsertResult>` so multi-row config writes land in **one transactional commit** instead of N sequential commits. Migrates every looping / multi-row caller in `discord-bot`.

### Why

`InstallAllStakesModal.handle` writes up to 20 rows in a `forEach` loop, each one its own JPA transaction (the persistence layer is `@Transactional` per-method, the service layer wasn't). The TODO comment on that loop already flagged `upsertAll(list)` as the planned fix. Three other call sites had the same shape.

### New API

```kotlin
fun upsertAll(guildId: String, rows: List<Pair<String, String>>): List<UpsertResult>
```

- `@Transactional` on `DefaultConfigService.upsertAll` so all rows commit together.
- Returns per-row `UpsertResult` in **input order** so `SetConfigCategoryModal.afterWrites` can still branch on `Created` vs `Updated`.
- Empty input is a no-op returning `emptyList()`.
- `upsertConfig` is unchanged — `upsertAll` is purely additive.

### Migrated call sites (backend only)

| Caller | Before | After |
|---|---|---|
| `InstallAllStakesModal` | up to 20 `upsertConfig` calls in a `forEach` | 1 `upsertAll` |
| `SetConfigCategoryModal` | `.map { … upsertConfig … }` over field pairs | 1 `upsertAll` + `zip` to recover `Configurations` keys for `afterWrites` |
| `InstallSentinel` | 2 sequential `upsertConfig` (INSTALL_MODE, INSTALLED_AT) | 1 `upsertAll` (clearer "record install atomically" intent) |
| `InstallQuickChannelsModal` | 2 conditional `upsertConfig` calls | 1 `upsertAll` after validating both picks |

Not migrated:
- `web/ModerationWebService` — both call sites are singles.
- `InstallToggleButton`, `ActivityTrackingNotifier` — single calls.

### Tests

New `DefaultConfigServiceUpsertAllTest` (`database/src/test/`) covers:
- empty input → `emptyList()` + zero persistence calls
- all-fresh rows → all `Created` in input order
- all-existing rows → `Updated` with correct `previousValue`
- mixed Created/Updated interleaving
- different-guild guard (matches single-row `upsertConfig` semantics)
- input-order preservation
- `@Transactional` annotation presence (reflection sanity check)

Updated 8 existing test files to expect a single `upsertAll` call (with capture-and-assert on the row list) instead of N `upsertConfig` calls.

Patched 4 in-memory `ConfigService` fakes (`AchievementServiceTest`, `XpAwardServiceTest`, `SocialCreditAwardServiceTest`, `LoginStreakServiceTest`) to implement the expanded interface.

## Test plan

- [x] `./gradlew :database:test --tests "database.service.impl.DefaultConfigServiceUpsertAllTest"` — 8/8 pass
- [x] `./gradlew :discord-bot:test --tests "bot.toby.install.*" --tests "*SetConfig*Modal*"` — all impacted suites pass
- [x] `./gradlew :web:test` — unaffected, still green
- [x] 165 total tests covering the new API + migrated call sites pass locally
- [ ] Manual smoke (post-deploy): run `/install` Express path; SQL-check that `INSTALL_MODE` and `INSTALLED_AT` rows share the same insert timestamp (single commit).
- [ ] Manual smoke: open `/setconfig general`, fill multiple fields, submit; verify single commit in DB logs.
- [ ] Manual smoke: open per-game stakes "Apply to all games" modal; verify 20 rows land with the same timestamp.

https://claude.ai/code/session_01NHhBfrbNQEDVrsGovXzyGD

---
_Generated by [Claude Code](https://claude.ai/code/session_01NHhBfrbNQEDVrsGovXzyGD)_