### PR TITLE
perf(memory): trim Hikari pool + gate non-core Lavaplayer sources

### DIFF
--- a/application/src/main/resources/application.properties
+++ b/application/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.properties.hibernate.format_sql=false
 spring.jpa.hibernate.ddl-auto=none
 spring.jpa.open-in-view=false
 server.port=8080
@@ -7,6 +7,15 @@ server.forward-headers-strategy=framework
 spring.cache.type=caffeine
 spring.profiles.active=prod
 spring.datasource.driver-class-name=org.postgresql.Driver
+
+# HikariCP — sized for a 512 MB dyno. Tomcat thread max is 10 (below),
+# so a 10-connection pool is oversized; four covers web + scheduled work
+# without queueing. Idle/max-lifetime let the pool shed connections
+# during quiet periods, releasing JDBC driver buffers + statement caches.
+spring.datasource.hikari.maximum-pool-size=4
+spring.datasource.hikari.minimum-idle=1
+spring.datasource.hikari.idle-timeout=60000
+spring.datasource.hikari.max-lifetime=600000
 
 # Discord OAuth2
 spring.security.oauth2.client.registration.discord.client-id=${DISCORD_CLIENT_ID}

--- a/discord-bot/src/main/kotlin/bot/toby/lavaplayer/PlayerManager.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/lavaplayer/PlayerManager.kt
@@ -8,6 +8,7 @@ import com.github.topi314.lavasrc.yandexmusic.YandexMusicSourceManager
 import com.sedmelluq.discord.lavaplayer.player.AudioLoadResultHandler
 import com.sedmelluq.discord.lavaplayer.player.AudioPlayerManager
 import com.sedmelluq.discord.lavaplayer.player.DefaultAudioPlayerManager
+import com.sedmelluq.discord.lavaplayer.source.AudioSourceManager
 import com.sedmelluq.discord.lavaplayer.source.bandcamp.BandcampAudioSourceManager
 import com.sedmelluq.discord.lavaplayer.source.http.HttpAudioSourceManager
 import com.sedmelluq.discord.lavaplayer.source.local.LocalAudioSourceManager
@@ -43,6 +44,12 @@ private const val DEEZER_MASTER_KEY = "DEEZER_MASTER_KEY"
 private const val DEEZER_ARL = "DEEZER_ARL"
 private const val YANDEX_ACCESS_TOKEN = "YANDEX_ACCESS_TOKEN"
 
+private const val LAVAPLAYER_ENABLE_SOUNDCLOUD = "LAVAPLAYER_ENABLE_SOUNDCLOUD"
+private const val LAVAPLAYER_ENABLE_BANDCAMP = "LAVAPLAYER_ENABLE_BANDCAMP"
+private const val LAVAPLAYER_ENABLE_VIMEO = "LAVAPLAYER_ENABLE_VIMEO"
+private const val LAVAPLAYER_ENABLE_NICO = "LAVAPLAYER_ENABLE_NICO"
+private const val LAVAPLAYER_ENABLE_TWITCH = "LAVAPLAYER_ENABLE_TWITCH"
+
 private val logger: DiscordLogger = DiscordLogger.createLogger(PlayerManager::class.java)
 
 class PlayerManager(private val audioPlayerManager: AudioPlayerManager) {
@@ -67,11 +74,11 @@ class PlayerManager(private val audioPlayerManager: AudioPlayerManager) {
         }
 
         audioPlayerManager.registerSourceManager(youtubeAudioSourceManager)
-        audioPlayerManager.registerSourceManager(SoundCloudAudioSourceManager.createDefault())
-        audioPlayerManager.registerSourceManager(BandcampAudioSourceManager())
-        audioPlayerManager.registerSourceManager(VimeoAudioSourceManager())
-        audioPlayerManager.registerSourceManager(NicoAudioSourceManager())
-        audioPlayerManager.registerSourceManager(TwitchStreamAudioSourceManager())
+        registerIfEnabled(LAVAPLAYER_ENABLE_SOUNDCLOUD, "SoundCloud") { SoundCloudAudioSourceManager.createDefault() }
+        registerIfEnabled(LAVAPLAYER_ENABLE_BANDCAMP, "Bandcamp") { BandcampAudioSourceManager() }
+        registerIfEnabled(LAVAPLAYER_ENABLE_VIMEO, "Vimeo") { VimeoAudioSourceManager() }
+        registerIfEnabled(LAVAPLAYER_ENABLE_NICO, "Nico") { NicoAudioSourceManager() }
+        registerIfEnabled(LAVAPLAYER_ENABLE_TWITCH, "Twitch") { TwitchStreamAudioSourceManager() }
         audioPlayerManager.registerSourceManager(HttpAudioSourceManager())
         audioPlayerManager.registerSourceManager(LocalAudioSourceManager())
 
@@ -137,6 +144,19 @@ class PlayerManager(private val audioPlayerManager: AudioPlayerManager) {
 
     private fun warnDisabled(sourceName: String, vararg requiredEnv: String) {
         logger.warn { "${requiredEnv.joinToString(" / ")} not set — $sourceName disabled." }
+    }
+
+    // Each Lavaplayer source manager eagerly allocates an Apache HTTP client +
+    // connection pool at construction. On a 512 MB dyno that adds up, so the
+    // non-core sources are opt-in via env flag. Set the flag to "true" to
+    // re-enable.
+    private inline fun registerIfEnabled(envFlag: String, sourceName: String, factory: () -> AudioSourceManager) {
+        if (envOrNull(envFlag)?.equals("true", ignoreCase = true) == true) {
+            audioPlayerManager.registerSourceManager(factory())
+            logger.info { "$sourceName source manager registered ($envFlag=true)." }
+        } else {
+            logger.info { "$sourceName source manager skipped ($envFlag not set to 'true')." }
+        }
     }
 
     // Shared search-provider chain used by sources that can't stream directly


### PR DESCRIPTION
## Summary

Memory dashboard shows the 512 MB dyno sitting pinned at the cap with 102% peaks. Daily reset means this is a **steady-state baseline** problem, not a multi-day leak — so the unbounded-cache fixes I considered first (`IntroHelper.pendingIntros`, `EventWaiter`, `TrackScheduler` overflow, push-row prune) are deferred; they're bounded within a day's runtime and wouldn't move this graph.

Two unaddressed contributors to the per-restart baseline:

- **HikariCP** had no explicit sizing → defaulted to 10 connections. Tomcat thread max is already 10, so 10 connections is oversized; each Postgres JDBC connection costs ~2-5 MB in driver buffers + statement caches. Capped at 4 with idle/max-lifetime so the pool sheds during quiet periods.
- **Lavaplayer** eagerly registered SoundCloud, Bandcamp, Vimeo, Nico and Twitch source managers at startup; each allocates its own Apache HTTP client + connection pool. Now env-flag gated (`LAVAPLAYER_ENABLE_*`) and off by default. YouTube, HTTP, Local and the already-env-gated LavaSrc set (Spotify/Apple/Deezer/Yandex) are unchanged.
- Also flips `spring.jpa.properties.hibernate.format_sql` to `false` in prod.

**JDA caches deliberately left alone.** Dropping `CacheFlag.ACTIVITY` and switching `MemberCachePolicy.ALL` to an LRU are the biggest possible wins, but #529 already showed how narrowing member caching regresses leaderboards/auth. Revisit those separately if this round doesn't free enough headroom.

Expected: ~20-40 MB reduction in steady-state RSS plateau.

## Test plan

- [x] `./gradlew :discord-bot:test` — 1277 pass, 0 fail
- [x] `./gradlew :application:test` — 130 pre-existing failures (Testcontainers integration tests, no Docker in sandbox), identical to baseline on `main`
- [ ] Watch the memory dashboard for one daily cycle after deploy — confirm the plateau drops and 102% peaks are gone
- [ ] If anyone hits a `/play` URL on SoundCloud/Bandcamp/Vimeo/Nico/Twitch, flip the relevant `LAVAPLAYER_ENABLE_*` env var to `true` to restore it

https://claude.ai/code/session_01LfnVvvovFhVmype2dyEhHW

---
_Generated by [Claude Code](https://claude.ai/code/session_01LfnVvvovFhVmype2dyEhHW)_