### PR TITLE
feat(web): redesign the commands wiki as a searchable catalog

### DIFF
--- a/web/src/main/kotlin/web/controller/CommandWikiController.kt
+++ b/web/src/main/kotlin/web/controller/CommandWikiController.kt
@@ -2,6 +2,9 @@ package web.controller
 
 import core.command.Command
 import core.managers.CommandManager
+import net.dv8tion.jda.api.interactions.commands.OptionType
+import net.dv8tion.jda.api.interactions.commands.build.OptionData
+import net.dv8tion.jda.api.interactions.commands.build.SubcommandData
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.security.oauth2.core.user.OAuth2User
 import org.springframework.stereotype.Controller
@@ -15,6 +18,11 @@ import web.util.displayName
  * `@RestController` while this one renders a Thymeleaf template that uses
  * the shared navbar fragment — keeping the navbar consistent with the rest
  * of the site instead of hand-rolling its own.
+ *
+ * The controller pre-bakes a view model ([CategoryView] / [CommandView] /
+ * [OptionView]) so the template stays declarative: friendly type labels
+ * ("text", "@user") and the per-card search key are computed once here
+ * rather than via Thymeleaf expression gymnastics.
  */
 @Controller
 class CommandWikiController(
@@ -26,25 +34,129 @@ class CommandWikiController(
         @AuthenticationPrincipal user: OAuth2User?,
         model: Model
     ): String {
-        val categories = listOf(
-            CommandCategory("Music", commandManager.musicCommands),
-            CommandCategory("DnD", commandManager.dndCommands),
-            CommandCategory("Moderation", commandManager.moderationCommands),
-            CommandCategory("Economy", commandManager.economyCommands),
-            CommandCategory("Miscellaneous", commandManager.miscCommands),
-            CommandCategory("Fetch", commandManager.fetchCommands)
-        ).filter { it.commands.isNotEmpty() }
-            .map { cat -> cat.copy(commands = cat.commands.sortedBy { it.name }) }
+        val categories = CATEGORY_META.mapNotNull { meta ->
+            val raw = meta.source(commandManager)
+            if (raw.isEmpty()) return@mapNotNull null
+            CategoryView(
+                slug = meta.slug,
+                title = meta.title,
+                icon = meta.icon,
+                blurb = meta.blurb,
+                commands = raw.sortedBy { it.name }.map(::toView)
+            )
+        }
 
         model.addAttribute("categories", categories)
+        model.addAttribute("totalCommandCount", categories.sumOf { it.commands.size })
         // Endpoint is permitAll, so OAuth principal may be null (anon user).
         // Navbar fragment handles the null case (renders Login button).
         if (user != null) model.addAttribute("username", user.displayName())
         return "commands"
     }
 
-    data class CommandCategory(
+    /** Per-category emoji + blurb shown in the category header strip. */
+    private data class CategoryMeta(
+        val slug: String,
         val title: String,
-        val commands: List<Command>
+        val icon: String,
+        val blurb: String,
+        val source: (CommandManager) -> List<Command>
+    )
+
+    private val CATEGORY_META = listOf(
+        CategoryMeta("music", "Music", "🎵",
+            "Play, queue, and control music in your server's voice channels.") { it.musicCommands },
+        CategoryMeta("dnd", "D&D", "🎲",
+            "Roll dice, look up spells, and run tabletop sessions.") { it.dndCommands },
+        CategoryMeta("moderation", "Moderation", "🛡️",
+            "Ban, kick, mute, purge, and manage server permissions.") { it.moderationCommands },
+        CategoryMeta("economy", "Economy", "💰",
+            "Earn, spend, and trade TobyCoin on a live per-server market.") { it.economyCommands },
+        CategoryMeta("misc", "Miscellaneous", "🧰",
+            "Polls, intros, achievements, and assorted small utilities.") { it.miscCommands },
+        CategoryMeta("fetch", "Fetch", "🌐",
+            "Pull memes, news, and quick lookups from the web.") { it.fetchCommands }
+    )
+
+    private fun toView(command: Command): CommandView {
+        val options = command.optionData.map(::toView)
+        val subs = command.subCommands.map(::toView)
+        val searchKey = buildString {
+            append(command.name.lowercase())
+            append(' ')
+            append(command.description.lowercase())
+            options.forEach { append(' ').append(it.name.lowercase()) }
+            subs.forEach { sub ->
+                append(' ').append(sub.name.lowercase())
+                sub.options.forEach { append(' ').append(it.name.lowercase()) }
+            }
+        }
+        return CommandView(
+            name = command.name,
+            description = command.description,
+            options = options,
+            subCommands = subs,
+            searchKey = searchKey
+        )
+    }
+
+    private fun toView(option: OptionData) = OptionView(
+        name = option.name,
+        description = option.description,
+        typeLabel = friendlyTypeLabel(option.type),
+        required = option.isRequired,
+        choices = option.choices.map { it.name }
+    )
+
+    private fun toView(sub: SubcommandData) = SubcommandView(
+        name = sub.name,
+        description = sub.description,
+        options = sub.options.map(::toView)
+    )
+
+    /** JDA enum → label a non-developer can parse at a glance. */
+    private fun friendlyTypeLabel(type: OptionType): String = when (type) {
+        OptionType.STRING -> "text"
+        OptionType.INTEGER -> "number"
+        OptionType.BOOLEAN -> "yes / no"
+        OptionType.USER -> "@user"
+        OptionType.CHANNEL -> "#channel"
+        OptionType.ROLE -> "role"
+        OptionType.MENTIONABLE -> "mention"
+        OptionType.NUMBER -> "decimal"
+        OptionType.ATTACHMENT -> "file"
+        else -> type.name.lowercase().replace('_', ' ')
+    }
+
+    data class CategoryView(
+        val slug: String,
+        val title: String,
+        val icon: String,
+        val blurb: String,
+        val commands: List<CommandView>
+    )
+
+    data class CommandView(
+        val name: String,
+        val description: String,
+        val options: List<OptionView>,
+        val subCommands: List<SubcommandView>,
+        val searchKey: String
+    ) {
+        val hasDetails: Boolean get() = options.isNotEmpty() || subCommands.isNotEmpty()
+    }
+
+    data class OptionView(
+        val name: String,
+        val description: String,
+        val typeLabel: String,
+        val required: Boolean,
+        val choices: List<String>
+    )
+
+    data class SubcommandView(
+        val name: String,
+        val description: String,
+        val options: List<OptionView>
     )
 }

--- a/web/src/main/resources/static/css/commands.css
+++ b/web/src/main/resources/static/css/commands.css
@@ -1,70 +1,492 @@
-/* commands.css — auto-generated slash-command reference page. Tables
-   grouped by category with monospace command names + nested option
-   lists. Pulled out of an inline <style> in commands.html so the page
-   uses the same head fragment + extraCss pattern as the rest of the
-   site. */
+/* commands.css — searchable, scannable catalog of every TobyBot slash
+   command. Hero + sticky search/filter strip + per-category card grid.
+   Reuses base.css design tokens; no new colour variables. */
 
-.commands-page { max-width: 960px; margin: 40px auto; padding: 0 24px 80px; }
-.commands-page h1 { font-size: 1.8rem; color: var(--text); margin-bottom: 8px; }
-.commands-page .subtitle { color: var(--text-muted); margin-bottom: 40px; }
+.commands-page {
+    max-width: 1180px;
+    margin: 0 auto;
+    padding: 40px 24px 80px;
+}
 
-.category { margin-bottom: 48px; }
-.category h2 {
-    font-size: 0.8rem;
+/* ---- Hero ---- */
+.commands-hero {
+    margin-bottom: 28px;
+    max-width: 760px;
+}
+.commands-hero h1 {
+    font-size: 2rem;
+    color: var(--heading);
+    margin: 6px 0 12px;
+    line-height: 1.15;
+}
+.commands-hero .lede {
     color: var(--text-muted);
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
-    margin-bottom: 12px;
-    padding-bottom: 8px;
+    line-height: 1.6;
+    max-width: 60ch;
+    margin-bottom: 18px;
+}
+.commands-hero-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2);
+}
+.meta-chip {
+    display: inline-flex;
+    align-items: center;
+    padding: 4px 12px;
+    border-radius: 999px;
+    background: var(--accent-soft);
+    border: 1px solid rgba(88, 101, 242, 0.35);
+    color: var(--text);
+    font-size: 0.85rem;
+    font-variant-numeric: tabular-nums;
+}
+.meta-chip strong {
+    color: var(--accent-light);
+    margin-right: 4px;
+}
+
+/* ---- Sticky toolbar (search + category chips) ---- */
+.commands-toolbar {
+    position: sticky;
+    top: 0;
+    z-index: 20;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--space-3);
+    padding: 14px 0;
+    margin-bottom: 28px;
+    background: rgba(26, 26, 46, 0.85);
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
     border-bottom: 1px solid var(--border);
 }
 
-.table-wrap {
+.commands-search {
+    position: relative;
+    flex: 1 1 320px;
+    min-width: 240px;
+}
+.commands-search-icon {
+    position: absolute;
+    left: 14px;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 16px;
+    height: 16px;
+    color: var(--text-muted);
+    pointer-events: none;
+}
+.commands-search-input {
+    width: 100%;
+    padding: 11px 44px 11px 40px;
+    background: var(--bg-input);
+    border: 1px solid var(--border-strong);
+    border-radius: var(--radius-md);
+    color: var(--text);
+    font-size: 0.95rem;
+    font-family: inherit;
+    transition: border-color var(--dur-fast) var(--ease-out),
+                box-shadow var(--dur-fast) var(--ease-out);
+}
+.commands-search-input::placeholder { color: var(--text-muted); }
+.commands-search-input:focus {
+    outline: none;
+    border-color: var(--accent);
+    box-shadow: 0 0 0 3px var(--accent-soft);
+}
+.commands-search-kbd {
+    position: absolute;
+    right: 12px;
+    top: 50%;
+    transform: translateY(-50%);
+    padding: 1px 7px;
+    border: 1px solid var(--border-strong);
+    border-radius: 4px;
+    background: var(--bg);
+    color: var(--text-muted);
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 0.75rem;
+    pointer-events: none;
+}
+.commands-search-input:focus ~ .commands-search-kbd { opacity: 0; }
+
+.commands-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+.cat-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 7px 14px;
+    background: transparent;
+    border: 1px solid var(--border-strong);
+    border-radius: 999px;
+    color: var(--text-muted);
+    font-size: 0.85rem;
+    font-weight: 500;
+    font-family: inherit;
+    cursor: pointer;
+    transition: background var(--dur-fast) var(--ease-out),
+                color var(--dur-fast) var(--ease-out),
+                border-color var(--dur-fast) var(--ease-out);
+}
+.cat-chip:hover {
+    color: var(--text);
+    border-color: var(--accent);
+}
+.cat-chip.is-active {
+    background: var(--accent-soft);
+    border-color: var(--accent);
+    color: var(--on-accent);
+}
+.cat-chip-icon { font-size: 0.95rem; line-height: 1; }
+
+/* ---- Category sections ---- */
+.commands-stream {
+    display: flex;
+    flex-direction: column;
+    gap: 56px;
+}
+.cat-section { scroll-margin-top: 80px; }
+
+/* Category visibility driven by the [data-active-cat] attribute on the
+   page root — JS only flips that one attribute, the CSS does the rest. */
+.commands-page[data-active-cat="all"] .cat-section,
+.commands-page[data-active-cat="music"] .cat-section[data-cat="music"],
+.commands-page[data-active-cat="dnd"] .cat-section[data-cat="dnd"],
+.commands-page[data-active-cat="moderation"] .cat-section[data-cat="moderation"],
+.commands-page[data-active-cat="economy"] .cat-section[data-cat="economy"],
+.commands-page[data-active-cat="misc"] .cat-section[data-cat="misc"],
+.commands-page[data-active-cat="fetch"] .cat-section[data-cat="fetch"] {
+    display: block;
+}
+.commands-page:not([data-active-cat="all"]) .cat-section { display: none; }
+
+.cat-header {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--space-3);
+    padding-bottom: 16px;
+    margin-bottom: 20px;
+    border-bottom: 1px solid var(--border);
+}
+.cat-icon {
+    font-size: 1.7rem;
+    line-height: 1;
+    flex-shrink: 0;
+    margin-top: 2px;
+}
+.cat-heading { flex: 1; min-width: 0; }
+.cat-heading h2 {
+    font-size: 1.25rem;
+    color: var(--heading);
+    margin-bottom: 4px;
+    text-transform: none;
+    letter-spacing: 0;
+}
+.cat-blurb {
+    color: var(--text-muted);
+    font-size: 0.9rem;
+    line-height: 1.5;
+    margin: 0;
+}
+.cat-count {
+    flex-shrink: 0;
+    padding: 4px 10px;
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    background: var(--bg);
+    color: var(--text-muted);
+    font-size: 0.75rem;
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+}
+
+/* ---- Command cards ---- */
+.cmd-grid {
+    display: grid;
+    gap: var(--space-4);
+    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+}
+
+.cmd-card {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: 18px 18px 16px;
     background: var(--bg-elevated);
     border: 1px solid var(--border);
-    border-radius: 10px;
-    overflow: hidden;
+    border-radius: var(--radius-lg);
+    transition: border-color var(--dur-base) var(--ease-out),
+                transform var(--dur-base) var(--ease-out),
+                box-shadow var(--dur-base) var(--ease-out);
 }
-.commands-table { width: 100%; border-collapse: collapse; }
-.commands-table th {
-    text-align: left;
-    padding: 10px 16px;
-    color: var(--text-muted);
-    font-size: 0.78rem;
+.cmd-card::before {
+    content: "";
+    position: absolute;
+    left: 0; top: 12px; bottom: 12px;
+    width: 3px;
+    background: var(--accent);
+    border-radius: 0 2px 2px 0;
+    opacity: 0;
+    transition: opacity var(--dur-base) var(--ease-out);
+}
+.cmd-card:hover {
+    border-color: var(--border-strong);
+    transform: translateY(-1px);
+    box-shadow: var(--shadow-md);
+}
+.cmd-card:hover::before { opacity: 1; }
+.cmd-card:focus-within {
+    border-color: var(--accent);
+}
+
+.cmd-card-top {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    min-width: 0;
+}
+.cmd-pill {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    color: var(--accent-light);
+    background: var(--accent-soft);
+    border: 1px solid rgba(88, 101, 242, 0.35);
+    padding: 3px 10px;
+    border-radius: 6px;
+    font-size: 0.92rem;
     font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    border-bottom: 1px solid var(--border);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 100%;
 }
-.commands-table td {
-    padding: 12px 16px;
-    border-bottom: 1px solid var(--border);
-    font-size: 0.9rem;
-    vertical-align: top;
-}
-.commands-table tr:last-child td { border-bottom: none; }
-.commands-table tr:hover td { background: rgba(88, 101, 242, 0.05); }
-
-.cmd { font-family: monospace; color: var(--accent); font-size: 0.95rem; white-space: nowrap; }
-.desc { color: var(--text); }
-
-.opts { list-style: none; padding: 0; margin: 0; }
-.opt { margin-bottom: 8px; }
-.opt:last-child { margin-bottom: 0; }
-.opt-name { font-family: monospace; color: var(--text); font-size: 0.85rem; }
-.badge {
-    font-size: 0.7rem;
+.cmd-sub-count {
+    font-size: 0.72rem;
     color: var(--text-muted);
-    background: var(--border);
-    padding: 1px 6px;
-    border-radius: 4px;
-    margin-left: 5px;
-    vertical-align: middle;
+    padding: 2px 8px;
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    background: var(--bg);
+    white-space: nowrap;
 }
-.opt-desc { color: var(--text-muted); font-size: 0.82rem; margin-top: 2px; }
+.cmd-copy {
+    margin-left: auto;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    padding: 0;
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: 6px;
+    color: var(--text-muted);
+    cursor: pointer;
+    transition: color var(--dur-fast) var(--ease-out),
+                background var(--dur-fast) var(--ease-out),
+                border-color var(--dur-fast) var(--ease-out);
+}
+.cmd-copy:hover {
+    color: var(--accent-light);
+    background: var(--accent-soft);
+    border-color: rgba(88, 101, 242, 0.35);
+}
+.cmd-copy.is-copied { color: var(--success); border-color: var(--success); }
 
-.choices { list-style: none; margin: 4px 0 0; padding-left: 10px; }
-.choice { font-size: 0.78rem; color: var(--text-muted); font-family: monospace; }
-.choice::before { content: "\2022 "; color: var(--accent); }
+.cmd-desc {
+    color: var(--text);
+    font-size: 0.92rem;
+    line-height: 1.5;
+    margin: 0;
+}
 
-.none { color: var(--text-muted); font-style: italic; font-size: 0.85rem; opacity: 0.6; }
+/* ---- Option / subcommand lists ---- */
+.opt-list, .sub-list {
+    list-style: none;
+    margin: 4px 0 0;
+    padding: 12px 0 0;
+    border-top: 1px dashed var(--border);
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.opt-row { display: flex; flex-direction: column; gap: 3px; }
+.opt-head {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+}
+.opt-name {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    color: var(--text);
+    font-size: 0.84rem;
+    font-weight: 500;
+}
+.opt-type {
+    display: inline-block;
+    font-size: 0.7rem;
+    line-height: 1.4;
+    padding: 1px 8px;
+    border-radius: 999px;
+    background: var(--accent-soft);
+    color: var(--accent-light);
+    font-weight: 500;
+    letter-spacing: 0.01em;
+}
+.opt-req {
+    font-size: 0.65rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--danger);
+    background: var(--danger-bg);
+    border: 1px solid var(--danger-border);
+    padding: 0 6px;
+    border-radius: 3px;
+    font-weight: 600;
+}
+.opt-desc {
+    color: var(--text-muted);
+    font-size: 0.82rem;
+    line-height: 1.45;
+    margin: 0;
+}
+.opt-choices {
+    list-style: none;
+    margin: 4px 0 0;
+    padding: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+}
+.opt-choices li {
+    font-size: 0.72rem;
+    padding: 1px 8px;
+    background: var(--bg-input);
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    color: var(--text-muted);
+}
+
+/* Subcommand rows look like nested mini-cards */
+.sub-row {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    padding: 8px 10px;
+    background: var(--bg-input);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+}
+.sub-pill {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 0.82rem;
+    color: var(--accent-light);
+    font-weight: 500;
+}
+.sub-desc {
+    color: var(--text-muted);
+    font-size: 0.8rem;
+    line-height: 1.45;
+    margin: 0;
+}
+.sub-opts {
+    list-style: none;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    margin: 4px 0 0;
+    padding: 0;
+}
+.sub-opts li {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 0.72rem;
+    color: var(--text-muted);
+}
+.sub-opts .opt-type { font-size: 0.65rem; }
+
+/* ---- Empty state ---- */
+.commands-empty {
+    margin: 0 0 32px;
+}
+.commands-empty[hidden] { display: none; }
+.link-button {
+    background: none;
+    border: none;
+    color: var(--accent);
+    cursor: pointer;
+    padding: 0;
+    font: inherit;
+    text-decoration: underline;
+}
+.link-button:hover { color: var(--accent-hover); }
+
+/* ---- Cards / sections hidden by search filter ----
+   `!important` because the category-show rules above have higher
+   specificity than `[hidden]` alone would, and the [hidden] attribute
+   here is the JS hatch for "this section/card has nothing visible". */
+.cmd-card[hidden],
+.cat-section[hidden] { display: none !important; }
+
+/* ---- Responsive ---- */
+@media (max-width: 768px) {
+    .commands-page { padding: 28px 16px 60px; }
+    .commands-hero h1 { font-size: 1.6rem; }
+    .commands-stream { gap: 44px; }
+}
+
+@media (max-width: 600px) {
+    .commands-page { padding: 20px 14px 60px; }
+    .commands-toolbar {
+        flex-direction: column;
+        align-items: stretch;
+        padding: 12px 0 10px;
+        gap: 10px;
+    }
+    .commands-search { width: 100%; }
+    .commands-chips {
+        flex-wrap: nowrap;
+        overflow-x: auto;
+        padding-bottom: 2px;
+        -webkit-overflow-scrolling: touch;
+        scrollbar-width: none;
+    }
+    .commands-chips::-webkit-scrollbar { display: none; }
+    .cat-chip { flex-shrink: 0; }
+
+    .cmd-grid { grid-template-columns: 1fr; gap: 12px; }
+    .cat-header {
+        flex-wrap: wrap;
+        gap: 10px;
+    }
+    .cat-count { order: 3; }
+    .commands-hero h1 { font-size: 1.45rem; }
+    .commands-search-kbd { display: none; }
+}
+
+@media (max-width: 480px) {
+    .commands-hero h1 { font-size: 1.3rem; }
+    .meta-chip { font-size: 0.8rem; }
+    .cat-icon { font-size: 1.4rem; }
+    .cat-heading h2 { font-size: 1.1rem; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .cmd-card,
+    .cmd-card::before,
+    .cmd-copy,
+    .cat-chip,
+    .commands-search-input {
+        transition: none;
+    }
+    .cmd-card:hover { transform: none; }
+}

--- a/web/src/main/resources/static/js/commands.js
+++ b/web/src/main/resources/static/js/commands.js
@@ -1,0 +1,175 @@
+/* commands.js — search, category filter, copy-to-clipboard, and URL hash
+   sync for the commands page. No framework. The CSS handles the category
+   show/hide via [data-active-cat]; this script only filters cards by
+   search text and toggles per-section visibility when a category empties. */
+(function () {
+    'use strict';
+
+    const page = document.querySelector('.commands-page');
+    if (!page) return;
+
+    const searchInput = document.getElementById('commands-search');
+    const chips = Array.from(document.querySelectorAll('.cat-chip'));
+    const sections = Array.from(document.querySelectorAll('.cat-section'));
+    const cards = Array.from(document.querySelectorAll('.cmd-card'));
+    const emptyState = document.querySelector('[data-empty]');
+    const clearButton = document.querySelector('[data-clear]');
+
+    let activeCat = 'all';
+    let query = '';
+    let rafId = 0;
+
+    function readHash() {
+        const hash = (location.hash || '').replace(/^#/, '');
+        if (!hash) return;
+        const params = new URLSearchParams(hash);
+        const cat = params.get('cat');
+        const q = params.get('q');
+        if (cat) activeCat = cat;
+        if (q) query = q;
+    }
+
+    function writeHash() {
+        const params = new URLSearchParams();
+        if (activeCat && activeCat !== 'all') params.set('cat', activeCat);
+        if (query) params.set('q', query);
+        const next = params.toString();
+        const url = next ? '#' + next : location.pathname + location.search;
+        history.replaceState(null, '', url);
+    }
+
+    function applyChipState() {
+        chips.forEach((chip) => {
+            const isActive = chip.dataset.cat === activeCat;
+            chip.classList.toggle('is-active', isActive);
+            chip.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+        });
+    }
+
+    function applyFilters() {
+        page.dataset.activeCat = activeCat;
+        const needle = query.trim().toLowerCase();
+        let visibleTotal = 0;
+
+        sections.forEach((section) => {
+            const sectionCat = section.dataset.cat;
+            const catMatches = activeCat === 'all' || sectionCat === activeCat;
+            let visibleInSection = 0;
+
+            section.querySelectorAll('.cmd-card').forEach((card) => {
+                const haystack = card.dataset.search || '';
+                const matches = !needle || haystack.indexOf(needle) !== -1;
+                const show = catMatches && matches;
+                card.hidden = !show;
+                if (show) visibleInSection += 1;
+            });
+
+            // Even though CSS already handles category-only hiding, we hide
+            // sections that are empty *because of a search query* (so an
+            // "All" view with a needle doesn't render empty category headers).
+            section.hidden = catMatches && visibleInSection === 0 && needle.length > 0;
+            visibleTotal += visibleInSection;
+        });
+
+        if (emptyState) emptyState.hidden = visibleTotal !== 0;
+    }
+
+    function scheduleApply() {
+        if (rafId) cancelAnimationFrame(rafId);
+        rafId = requestAnimationFrame(() => {
+            rafId = 0;
+            applyFilters();
+            writeHash();
+        });
+    }
+
+    function setCategory(cat) {
+        activeCat = cat || 'all';
+        applyChipState();
+        scheduleApply();
+    }
+
+    function clearAll() {
+        activeCat = 'all';
+        query = '';
+        if (searchInput) searchInput.value = '';
+        applyChipState();
+        scheduleApply();
+        if (searchInput) searchInput.focus();
+    }
+
+    // ---- Wire up listeners ----
+    if (searchInput) {
+        searchInput.addEventListener('input', () => {
+            query = searchInput.value;
+            scheduleApply();
+        });
+        searchInput.addEventListener('keydown', (e) => {
+            if (e.key === 'Escape' && searchInput.value !== '') {
+                e.preventDefault();
+                searchInput.value = '';
+                query = '';
+                scheduleApply();
+            }
+        });
+    }
+
+    chips.forEach((chip) => {
+        chip.addEventListener('click', () => setCategory(chip.dataset.cat));
+    });
+
+    if (clearButton) clearButton.addEventListener('click', clearAll);
+
+    // Copy buttons — copies the slash-command name to the clipboard and
+    // flashes a toast. Uses the shared window.toast helper from toasts.js.
+    document.querySelectorAll('[data-copy]').forEach((btn) => {
+        btn.addEventListener('click', () => {
+            const card = btn.closest('.cmd-card');
+            if (!card) return;
+            const text = '/' + (card.dataset.name || '');
+            const flash = () => {
+                btn.classList.add('is-copied');
+                setTimeout(() => btn.classList.remove('is-copied'), 1200);
+                if (window.toast) window.toast('Copied ' + text, 'success');
+            };
+            const fail = () => {
+                if (window.toast) window.toast('Copy failed', 'error');
+            };
+            if (navigator.clipboard && navigator.clipboard.writeText) {
+                navigator.clipboard.writeText(text).then(flash).catch(fail);
+            } else {
+                // Fallback for older browsers / insecure contexts.
+                const ta = document.createElement('textarea');
+                ta.value = text;
+                ta.setAttribute('readonly', '');
+                ta.style.position = 'absolute';
+                ta.style.left = '-9999px';
+                document.body.appendChild(ta);
+                ta.select();
+                try { document.execCommand('copy'); flash(); }
+                catch (_) { fail(); }
+                finally { document.body.removeChild(ta); }
+            }
+        });
+    });
+
+    // Global "/" shortcut to focus the search — matches GitHub / Discord.
+    document.addEventListener('keydown', (e) => {
+        if (e.key !== '/') return;
+        const t = e.target;
+        if (!t) return;
+        const tag = t.tagName;
+        if (tag === 'INPUT' || tag === 'TEXTAREA' || t.isContentEditable) return;
+        e.preventDefault();
+        if (searchInput) {
+            searchInput.focus();
+            searchInput.select();
+        }
+    });
+
+    // ---- Boot ----
+    readHash();
+    if (query && searchInput) searchInput.value = query;
+    applyChipState();
+    applyFilters();
+})();

--- a/web/src/main/resources/templates/commands.html
+++ b/web/src/main/resources/templates/commands.html
@@ -2,71 +2,86 @@
 <html xmlns:th="http://www.thymeleaf.org" lang="en">
 <head th:replace="~{fragments/headSeo :: headSeo(
         'TobyBot — Commands',
-        'Auto-generated reference for every TobyBot slash command, grouped by category (Music, D&D, Moderation, Economy, Misc, Fetch).',
+        'Searchable catalog of every TobyBot slash command, grouped by category — Music, D&D, Moderation, Economy, Misc, Fetch.',
         null,
         '/css/commands.css')}"></head>
 <body>
 
+<a href="#main" class="skip-link">Skip to content</a>
 <div th:replace="~{fragments/navbar :: navbar}"></div>
 
-<main class="commands-page">
-    <h1>Commands</h1>
-    <p class="subtitle">All available slash commands for TobyBot.</p>
+<main id="main" class="commands-page" data-active-cat="all">
 
-    <section class="category" th:each="category : ${categories}">
-        <h2 th:text="${category.title}">Category</h2>
-        <div class="table-wrap">
-            <table class="commands-table">
-                <thead>
-                <tr>
-                    <th>Command</th>
-                    <th>Description</th>
-                    <th>Options</th>
-                </tr>
-                </thead>
-                <tbody>
-                <tr th:each="command : ${category.commands}">
-                    <td>
-                        <span class="cmd" th:text="'/' + ${command.name}">/cmd</span>
-                    </td>
-                    <td class="desc" th:text="${command.description}">Description</td>
-                    <td>
-                        <!-- Three render modes: top-level options, sub-commands, or nothing. -->
-                        <ul class="opts" th:if="${not #lists.isEmpty(command.optionData)}">
-                            <li class="opt" th:each="option : ${command.optionData}">
-                                <span class="opt-name" th:text="${option.name}">name</span>
-                                <span class="badge" th:text="${option.type.name}">TYPE</span>
-                                <div class="opt-desc" th:text="${option.description}">description</div>
-                                <ul class="choices" th:if="${not #lists.isEmpty(option.choices)}">
-                                    <li class="choice"
-                                        th:each="choice : ${option.choices}"
-                                        th:text="${choice.name}">choice</li>
-                                </ul>
-                            </li>
-                        </ul>
-                        <ul class="opts"
-                            th:if="${#lists.isEmpty(command.optionData) and not #lists.isEmpty(command.subCommands)}">
-                            <li class="opt" th:each="sub : ${command.subCommands}">
-                                <span class="opt-name" th:text="${sub.name}">subname</span>
-                                <div class="opt-desc" th:text="${sub.description}">subdescription</div>
-                                <ul class="choices" th:if="${not #lists.isEmpty(sub.options)}">
-                                    <li class="choice"
-                                        th:each="subopt : ${sub.options}"
-                                        th:text="${subopt.name} + ': ' + ${subopt.description}">subopt</li>
-                                </ul>
-                            </li>
-                        </ul>
-                        <span class="none"
-                              th:if="${#lists.isEmpty(command.optionData) and #lists.isEmpty(command.subCommands)}">&mdash;</span>
-                    </td>
-                </tr>
-                </tbody>
-            </table>
+    <header class="commands-hero">
+        <span class="section-eyebrow">Commands</span>
+        <h1>Everything TobyBot can do</h1>
+        <p class="lede">
+            Every slash command in one place. Search by name, filter by
+            category, and copy the command straight into your Discord
+            client.
+        </p>
+        <div class="commands-hero-meta">
+            <span class="meta-chip"><strong th:text="${totalCommandCount}">0</strong>&nbsp;commands</span>
+            <span class="meta-chip"><strong th:text="${#lists.size(categories)}">0</strong>&nbsp;categories</span>
         </div>
+    </header>
+
+    <div class="commands-toolbar" role="search">
+        <div class="commands-search">
+            <svg class="commands-search-icon" aria-hidden="true" viewBox="0 0 24 24" fill="none"
+                 stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <circle cx="11" cy="11" r="7"></circle>
+                <path d="m21 21-4.3-4.3"></path>
+            </svg>
+            <input type="search" id="commands-search" class="commands-search-input"
+                   placeholder="Search commands… try 'roll' or 'play'"
+                   aria-label="Search commands"
+                   autocomplete="off">
+            <kbd class="commands-search-kbd" aria-hidden="true">/</kbd>
+        </div>
+        <div class="commands-chips" role="tablist" aria-label="Filter by category">
+            <button type="button" class="cat-chip is-active" data-cat="all" aria-pressed="true">
+                All
+            </button>
+            <button type="button" class="cat-chip"
+                    th:each="cat : ${categories}"
+                    th:data-cat="${cat.slug}"
+                    aria-pressed="false">
+                <span class="cat-chip-icon" th:text="${cat.icon}" aria-hidden="true">·</span>
+                <span th:text="${cat.title}">Category</span>
+            </button>
+        </div>
+    </div>
+
+    <section class="commands-empty empty-hero" data-empty hidden aria-live="polite">
+        <span class="emoji" aria-hidden="true">🔍</span>
+        <p>No commands match your search.</p>
+        <p class="muted">Try a different word, or <button type="button" class="link-button" data-clear>clear filters</button>.</p>
     </section>
+
+    <div class="commands-stream">
+        <section class="cat-section"
+                 th:each="cat : ${categories}"
+                 th:data-cat="${cat.slug}">
+            <header class="cat-header">
+                <span class="cat-icon" th:text="${cat.icon}" aria-hidden="true">·</span>
+                <div class="cat-heading">
+                    <h2 th:text="${cat.title}">Category</h2>
+                    <p class="cat-blurb" th:text="${cat.blurb}">Blurb</p>
+                </div>
+                <span class="cat-count" th:text="${#lists.size(cat.commands)} + ' commands'">0 commands</span>
+            </header>
+
+            <div class="cmd-grid">
+                <div th:each="cmd : ${cat.commands}"
+                     th:replace="~{fragments/commandCard :: card(${cmd})}"></div>
+            </div>
+        </section>
+    </div>
 </main>
 
 <footer th:replace="~{fragments/footer :: footer}"></footer>
 
+<script th:src="@{/js/commands.js}" defer></script>
 </body>
 </html>

--- a/web/src/main/resources/templates/fragments/commandCard.html
+++ b/web/src/main/resources/templates/fragments/commandCard.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<body>
+<!--
+    Self-contained "one command" card. Renders the slash-command name as
+    a coloured pill, a copy-to-clipboard button, the human description,
+    and the option / subcommand list with friendly type labels and
+    required-flag chips.
+
+    Takes a single [CommandWikiController.CommandView] argument — the
+    same view model the wiki page populates — so any other surface that
+    wants to render a single command (e.g. a per-command detail page, a
+    moderation audit dialog, a search dropdown preview) can drop:
+
+        <div th:replace="~{fragments/commandCard :: card(${cmd})}"></div>
+
+    Styling lives in `commands.css`. Loading that stylesheet on the
+    consumer page is the consumer's responsibility — the fragment ships
+    semantic markup only.
+
+    The wiki page also relies on `data-search` (lowercased haystack) +
+    `data-name` (raw command name, used by the copy button JS). Both
+    attributes are emitted unconditionally so client code can opt into
+    them without the fragment needing a mode switch.
+-->
+<article th:fragment="card(cmd)"
+         class="cmd-card"
+         th:data-search="${cmd.searchKey}"
+         th:data-name="${cmd.name}">
+    <header class="cmd-card-top">
+        <span class="cmd-pill" th:text="'/' + ${cmd.name}">/cmd</span>
+        <span class="cmd-sub-count"
+              th:if="${not #lists.isEmpty(cmd.subCommands)}"
+              th:text="${#lists.size(cmd.subCommands)} + ' subcommands'">0 subcommands</span>
+        <button type="button" class="cmd-copy" data-copy
+                th:attr="aria-label='Copy /' + ${cmd.name}"
+                title="Copy">
+            <svg viewBox="0 0 24 24" width="14" height="14" aria-hidden="true"
+                 fill="none" stroke="currentColor" stroke-width="2"
+                 stroke-linecap="round" stroke-linejoin="round">
+                <rect x="9" y="9" width="11" height="11" rx="2"></rect>
+                <path d="M5 15V5a2 2 0 0 1 2-2h10"></path>
+            </svg>
+        </button>
+    </header>
+    <p class="cmd-desc" th:text="${cmd.description}">Description</p>
+
+    <ul class="opt-list" th:if="${not #lists.isEmpty(cmd.options)}">
+        <li class="opt-row" th:each="opt : ${cmd.options}">
+            <div class="opt-head">
+                <span class="opt-name" th:text="${opt.name}">name</span>
+                <span class="opt-type" th:text="${opt.typeLabel}">text</span>
+                <span class="opt-req" th:if="${opt.required}" title="Required" aria-label="Required">required</span>
+            </div>
+            <p class="opt-desc" th:text="${opt.description}">desc</p>
+            <ul class="opt-choices" th:if="${not #lists.isEmpty(opt.choices)}">
+                <li th:each="choice : ${opt.choices}" th:text="${choice}">choice</li>
+            </ul>
+        </li>
+    </ul>
+
+    <ul class="sub-list"
+        th:if="${#lists.isEmpty(cmd.options) and not #lists.isEmpty(cmd.subCommands)}">
+        <li class="sub-row" th:each="sub : ${cmd.subCommands}">
+            <span class="sub-pill" th:text="'/' + ${cmd.name} + ' ' + ${sub.name}">/cmd sub</span>
+            <p class="sub-desc" th:text="${sub.description}">desc</p>
+            <ul class="sub-opts" th:if="${not #lists.isEmpty(sub.options)}">
+                <li th:each="subopt : ${sub.options}">
+                    <span class="opt-name" th:text="${subopt.name}">n</span>
+                    <span class="opt-type" th:text="${subopt.typeLabel}">text</span>
+                </li>
+            </ul>
+        </li>
+    </ul>
+</article>
+</body>
+</html>


### PR DESCRIPTION
## Summary

`/commands/wiki` used to render every slash command as raw bordered tables with enum-style type badges (`STRING`, `INTEGER`, `BOOLEAN`…) and nested bullet lists — readable as developer docs but a poor first impression for the two homepage CTAs that point at it. This rebuilds the page as a polished, searchable catalog.

- **Hero** with eyebrow + h1 + lede + live counts (N commands · M categories).
- **Sticky translucent toolbar** with a search input (placeholder hint, `/` to focus, `Escape` clears) and per-category filter chips.
- **Per-category sections** with an emoji icon and a one-line blurb (Music, D&D, Moderation, Economy, Misc, Fetch).
- **Command cards**: monospace pill, copy-to-clipboard button with toast, description, then an option list with **friendly type labels** (`text`, `@user`, `yes / no`, `decimal`, `#channel`, …) and a `required` chip. Subcommand-only commands render their subs inline instead of a `—` dash.
- **Search** filters by name, description, and option names; state syncs to the URL hash (`#cat=music&q=play`) so a filtered view is shareable and the page restores it on load.
- **Empty state** reuses the shared `.empty-hero` primitive.

## Implementation notes

- `CommandWikiController` pre-bakes a view model (`CategoryView` / `CommandView` / `OptionView`) so the template stays declarative and the JDA `OptionType` → friendly label map lives in one place on the server.
- The command card markup lives in `fragments/commandCard.html` so any future surface that wants to render a single command (per-command detail page, search dropdown, audit dialog, …) can `th:replace` it with one line.
- CSS reuses existing tokens from `base.css` (`--accent`, `--bg-elevated`, motion vars, breakpoints, `.section-eyebrow` / `.empty-hero`). Category visibility is driven by a single `[data-active-cat]` attribute on the page root so JS only flips one attribute and CSS does the show/hide.
- `commands.js` debounces with `requestAnimationFrame`, supports the `/` shortcut (matches GitHub / Discord), and falls back to `document.execCommand('copy')` on older browsers.

## Test plan

- [x] `./gradlew :web:compileKotlin` clean
- [x] `./gradlew :web:test` — 20 tasks, all green
- [x] `npm run lint:css` — clean
- [x] `npm test` (jest) — 607 tests pass
- [ ] Hit `/commands/wiki` in a browser, verify: hero count, per-category emojis + blurbs, friendly type labels (not `STRING/INTEGER`), copy-to-clipboard toast.
- [ ] Search: type `roll` → filter works; type nonsense → empty state shows; click a category chip → URL hash updates; reload with `#cat=music&q=play` → state restored; press `/` → search focuses.
- [ ] Resize to mobile width: cards collapse to 1 column, chip strip becomes horizontal-scrolling.
- [ ] BotControllerIT `commands wiki endpoint returns 200 OK` still green in CI (requires Docker for testcontainers, can't run locally in this env).

https://claude.ai/code/session_01SELycDvTHp4oQBZX2odsXB

---
_Generated by [Claude Code](https://claude.ai/code/session_01SELycDvTHp4oQBZX2odsXB)_