### PR TITLE
fix(install): unstick custom-setup section pick (deferEdit + bot-webhook)

### DIFF
--- a/discord-bot/src/main/kotlin/bot/toby/install/menu/InstallCategoryMenu.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/menu/InstallCategoryMenu.kt
@@ -127,12 +127,24 @@ class InstallCategoryMenu(
             event.reply("Unknown section `$sectionId`.").setEphemeral(true).queue()
             return
         }
-        event.editMessageEmbeds(InstallWizard.sectionDetailEmbed(section))
-            .setComponents(
-                ActionRow.of(InstallWizard.sectionDetailMenu(section)),
-                InstallWizard.backAndFinishRow(),
-            )
-            .queue()
+        // Ack via deferEdit, then edit the source message via the bot
+        // webhook. The bot-webhook edit goes through the same JDA
+        // rate-limit bucket as DefaultMenuManager's prior
+        // disable-all-rows edit (also a bot webhook), so the two are
+        // serialized in submission order — our rearm always wins.
+        //
+        // The previous form (`event.editMessageEmbeds(...).setComponents(...).queue()`)
+        // sent an interaction-response edit on a *different* token, which
+        // raced against the manager's bot-webhook and could leave the
+        // message stuck with the disabled previous-view components.
+        event.deferEdit().queue {
+            event.message.editMessageEmbeds(InstallWizard.sectionDetailEmbed(section))
+                .setComponents(
+                    ActionRow.of(InstallWizard.sectionDetailMenu(section)),
+                    InstallWizard.backAndFinishRow(),
+                )
+                .queue()
+        }
     }
 
     private fun handleCategoryPick(
@@ -176,12 +188,16 @@ class InstallCategoryMenu(
     private fun showStakesGameMenu(ctx: MenuContext) {
         val event = ctx.event
         val games = SetConfigStakesModal.Game.entries.map { it.label to it.token }
-        event.editMessageEmbeds(InstallWizard.stakesGameMenuEmbed())
-            .setComponents(
-                ActionRow.of(InstallWizard.stakesGameMenu(games)),
-                InstallWizard.backAndFinishRow(),
-            )
-            .queue()
+        // Same defer-then-bot-webhook pattern as `handleSectionPick` — see
+        // the comment there for the race-condition this avoids.
+        event.deferEdit().queue {
+            event.message.editMessageEmbeds(InstallWizard.stakesGameMenuEmbed())
+                .setComponents(
+                    ActionRow.of(InstallWizard.stakesGameMenu(games)),
+                    InstallWizard.backAndFinishRow(),
+                )
+                .queue()
+        }
     }
 
     /**

--- a/discord-bot/src/test/kotlin/bot/toby/install/menu/InstallCategoryMenuTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/install/menu/InstallCategoryMenuTest.kt
@@ -28,19 +28,31 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
+import io.mockk.verifyOrder
+import net.dv8tion.jda.api.components.MessageTopLevelComponent
+import net.dv8tion.jda.api.components.actionrow.ActionRow
+import net.dv8tion.jda.api.components.buttons.Button
 import net.dv8tion.jda.api.components.selections.SelectOption
+import net.dv8tion.jda.api.components.selections.StringSelectMenu
 import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.entities.Member
+import net.dv8tion.jda.api.entities.Message
+import net.dv8tion.jda.api.entities.MessageEmbed
 import net.dv8tion.jda.api.events.interaction.component.StringSelectInteractionEvent
 import net.dv8tion.jda.api.modals.Modal
+import net.dv8tion.jda.api.requests.restaction.MessageEditAction
+import net.dv8tion.jda.api.requests.restaction.interactions.MessageEditCallbackAction
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.EnumSource
 import org.junit.jupiter.params.provider.MethodSource
+import java.util.function.Consumer
 import java.util.stream.Stream
 
 internal class InstallCategoryMenuTest {
@@ -66,6 +78,9 @@ internal class InstallCategoryMenuTest {
     private lateinit var ctx: MenuContext
     private lateinit var guild: Guild
     private lateinit var member: Member
+    private lateinit var message: Message
+    private lateinit var messageEditAction: MessageEditAction
+    private lateinit var deferEditAction: MessageEditCallbackAction
 
     @BeforeEach
     fun setUp() {
@@ -110,11 +125,30 @@ internal class InstallCategoryMenuTest {
             every { queue() } just Runs
             every { queue(any()) } just Runs
         }
-        every { event.editMessageEmbeds(any<net.dv8tion.jda.api.entities.MessageEmbed>()) } returns
-            mockk(relaxed = true) {
-                every { setComponents(*anyVararg()) } returns this
-                every { queue() } just Runs
-            }
+        // Source message that handleSectionPick / showStakesGameMenu edit via
+        // bot webhook after deferEdit acks the interaction.
+        message = mockk(relaxed = true)
+        every { event.message } returns message
+        messageEditAction = mockk(relaxed = true)
+        every { message.editMessageEmbeds(any<MessageEmbed>()) } returns messageEditAction
+        every {
+            messageEditAction.setComponents(*anyVararg<MessageTopLevelComponent>())
+        } returns messageEditAction
+        every {
+            messageEditAction.setComponents(any<Collection<MessageTopLevelComponent>>())
+        } returns messageEditAction
+        every { messageEditAction.queue() } just Runs
+
+        // deferEdit's `.queue { ... }` invokes the callback synchronously so
+        // tests can assert on the chained message-edit deterministically.
+        deferEditAction = mockk(relaxed = true)
+        every { event.deferEdit() } returns deferEditAction
+        every { deferEditAction.queue(any()) } answers {
+            @Suppress("UNCHECKED_CAST")
+            (firstArg() as Consumer<net.dv8tion.jda.api.interactions.InteractionHook?>)
+                .accept(null)
+        }
+        every { deferEditAction.queue() } just Runs
     }
 
     @Test
@@ -132,7 +166,8 @@ internal class InstallCategoryMenuTest {
 
         verify(exactly = 1) { event.reply(any<String>()) }
         verify(exactly = 0) { event.replyModal(any<Modal>()) }
-        verify(exactly = 0) { event.editMessageEmbeds(any<net.dv8tion.jda.api.entities.MessageEmbed>()) }
+        verify(exactly = 0) { event.deferEdit() }
+        verify(exactly = 0) { message.editMessageEmbeds(any<MessageEmbed>()) }
     }
 
     @Test
@@ -156,14 +191,119 @@ internal class InstallCategoryMenuTest {
     }
 
     @Test
-    fun `top-level section pick edits to section detail menu`() {
+    fun `top-level section pick acks via deferEdit then bot-webhook edits the source message`() {
         every { event.componentId } returns InstallWizard.MENU_SECTION
         every { event.selectedOptions } returns listOf(SelectOption.of("x", WizardSection.POKER.id))
 
         menu.handle(ctx, 0)
 
-        verify(exactly = 1) { event.editMessageEmbeds(any<net.dv8tion.jda.api.entities.MessageEmbed>()) }
+        verify(exactly = 1) { event.deferEdit() }
+        verify(exactly = 1) { message.editMessageEmbeds(any<MessageEmbed>()) }
         verify(exactly = 0) { event.replyModal(any<Modal>()) }
+    }
+
+    @Test
+    fun `section pick never uses the racy interaction-response edit form`() {
+        // Regression guard: the previous implementation called
+        // `event.editMessageEmbeds(...)` (interaction-response) which races
+        // against DefaultMenuManager's bot-webhook disable-rows edit and
+        // could leave the message with stale disabled components. The fix
+        // routes through deferEdit + event.message.editMessageEmbeds (both
+        // bot-webhook, same rate-limit bucket → serialized).
+        every { event.componentId } returns InstallWizard.MENU_SECTION
+        every { event.selectedOptions } returns listOf(SelectOption.of("x", WizardSection.POKER.id))
+
+        menu.handle(ctx, 0)
+
+        verify(exactly = 0) { event.editMessageEmbeds(any<MessageEmbed>()) }
+    }
+
+    @Test
+    fun `section pick orders deferEdit before the message edit`() {
+        every { event.componentId } returns InstallWizard.MENU_SECTION
+        every { event.selectedOptions } returns listOf(SelectOption.of("x", WizardSection.POKER.id))
+
+        menu.handle(ctx, 0)
+
+        // Documents the serialization contract: deferEdit fires first to
+        // ack the interaction, the message edit fires from inside its
+        // callback so it lands after the manager's earlier disable-edit.
+        verifyOrder {
+            event.deferEdit()
+            message.editMessageEmbeds(any<MessageEmbed>())
+        }
+    }
+
+    @Test
+    fun `section pick edits the source message instead of replying or opening a modal`() {
+        every { event.componentId } returns InstallWizard.MENU_SECTION
+        every { event.selectedOptions } returns listOf(SelectOption.of("x", WizardSection.POKER.id))
+
+        menu.handle(ctx, 0)
+
+        verify(exactly = 0) { event.reply(any<String>()) }
+        verify(exactly = 0) { event.replyModal(any<Modal>()) }
+    }
+
+    @Test
+    fun `section pick swaps in the section-detail menu, not the section menu`() {
+        // The bug presented exactly as: embed updated, dropdown stayed as
+        // "Pick a section to tune" (section menu) and bottom row stayed as
+        // Optional features + Finish. This test captures the actual
+        // components passed to the bot-webhook edit and asserts the
+        // section-detail menu + Back/Finish row are present.
+        val captured = slot<Array<MessageTopLevelComponent>>()
+        every {
+            messageEditAction.setComponents(*varargAll<MessageTopLevelComponent> { true })
+        } answers {
+            @Suppress("UNCHECKED_CAST")
+            captured.captured = args.firstOrNull() as Array<MessageTopLevelComponent>
+            messageEditAction
+        }
+        every { event.componentId } returns InstallWizard.MENU_SECTION
+        every { event.selectedOptions } returns listOf(SelectOption.of("x", WizardSection.POKER.id))
+
+        menu.handle(ctx, 0)
+
+        val rows = captured.captured.filterIsInstance<ActionRow>()
+        assertEquals(2, rows.size, "section detail view has menu + bottom row")
+        val firstRow = rows[0].components.filterIsInstance<StringSelectMenu>()
+        assertEquals(1, firstRow.size, "first row is a select menu")
+        assertEquals(
+            InstallWizard.sectionDetailMenuId(WizardSection.POKER.id),
+            firstRow[0].customId,
+            "dropdown is the section-detail menu, not the section menu",
+        )
+        val bottomButtons = rows[1].components.filterIsInstance<Button>().map { it.customId }
+        assertTrue(bottomButtons.contains(InstallWizard.BTN_BACK), "bottom row has ← Back")
+        assertTrue(bottomButtons.contains(InstallWizard.BTN_FINISH), "bottom row has Finish")
+    }
+
+    @Test
+    fun `section pick does not leak the previous Optional features button`() {
+        // Specific regression: the stale customRoot bottom row had the
+        // `install_features` button. After the fix, the bottom row is
+        // backAndFinishRow and must not contain that button id.
+        val captured = slot<Array<MessageTopLevelComponent>>()
+        every {
+            messageEditAction.setComponents(*varargAll<MessageTopLevelComponent> { true })
+        } answers {
+            @Suppress("UNCHECKED_CAST")
+            captured.captured = args.firstOrNull() as Array<MessageTopLevelComponent>
+            messageEditAction
+        }
+        every { event.componentId } returns InstallWizard.MENU_SECTION
+        every { event.selectedOptions } returns listOf(SelectOption.of("x", WizardSection.GENERAL.id))
+
+        menu.handle(ctx, 0)
+
+        val allButtonIds = captured.captured.filterIsInstance<ActionRow>()
+            .flatMap { it.components.filterIsInstance<Button>() }
+            .map { it.customId }
+        assertFalse(
+            allButtonIds.contains(InstallWizard.BTN_FEATURES),
+            "Optional features button must not leak into the section-detail view",
+        )
     }
 
     @Test
@@ -253,8 +393,81 @@ internal class InstallCategoryMenuTest {
 
         menu.handle(ctx, 0)
 
-        verify(exactly = 1) { event.editMessageEmbeds(any<net.dv8tion.jda.api.entities.MessageEmbed>()) }
+        verify(exactly = 1) { event.deferEdit() }
+        verify(exactly = 1) { message.editMessageEmbeds(any<MessageEmbed>()) }
         verify(exactly = 0) { event.replyModal(any<Modal>()) }
+    }
+
+    @Test
+    fun `stakes category never uses the racy interaction-response edit form`() {
+        every { event.componentId } returns InstallWizard.sectionDetailMenuId(WizardSection.ECONOMY.id)
+        every { event.selectedOptions } returns listOf(SelectOption.of("x", SetConfigCommand.SUB_STAKES))
+
+        menu.handle(ctx, 0)
+
+        verify(exactly = 0) { event.editMessageEmbeds(any<MessageEmbed>()) }
+    }
+
+    @Test
+    fun `stakes category orders deferEdit before the message edit`() {
+        every { event.componentId } returns InstallWizard.sectionDetailMenuId(WizardSection.ECONOMY.id)
+        every { event.selectedOptions } returns listOf(SelectOption.of("x", SetConfigCommand.SUB_STAKES))
+
+        menu.handle(ctx, 0)
+
+        verifyOrder {
+            event.deferEdit()
+            message.editMessageEmbeds(any<MessageEmbed>())
+        }
+    }
+
+    @Test
+    fun `stakes category swaps to the install_category_stakes menu plus back+finish row`() {
+        val captured = slot<Array<MessageTopLevelComponent>>()
+        every {
+            messageEditAction.setComponents(*varargAll<MessageTopLevelComponent> { true })
+        } answers {
+            @Suppress("UNCHECKED_CAST")
+            captured.captured = args.firstOrNull() as Array<MessageTopLevelComponent>
+            messageEditAction
+        }
+        every { event.componentId } returns InstallWizard.sectionDetailMenuId(WizardSection.ECONOMY.id)
+        every { event.selectedOptions } returns listOf(SelectOption.of("x", SetConfigCommand.SUB_STAKES))
+
+        menu.handle(ctx, 0)
+
+        val rows = captured.captured.filterIsInstance<ActionRow>()
+        assertEquals(2, rows.size)
+        val gameMenu = rows[0].components.filterIsInstance<StringSelectMenu>().single()
+        assertEquals(InstallWizard.MENU_CATEGORY_STAKES, gameMenu.customId)
+        val bottomButtons = rows[1].components.filterIsInstance<Button>().map { it.customId }
+        assertTrue(bottomButtons.contains(InstallWizard.BTN_BACK))
+        assertTrue(bottomButtons.contains(InstallWizard.BTN_FINISH))
+    }
+
+    @ParameterizedTest(name = "section pick {0} lands the right section-detail dropdown")
+    @EnumSource(WizardSection::class)
+    fun `section pick is parametrised across every WizardSection`(section: WizardSection) {
+        val captured = slot<Array<MessageTopLevelComponent>>()
+        every {
+            messageEditAction.setComponents(*varargAll<MessageTopLevelComponent> { true })
+        } answers {
+            @Suppress("UNCHECKED_CAST")
+            captured.captured = args.firstOrNull() as Array<MessageTopLevelComponent>
+            messageEditAction
+        }
+        every { event.componentId } returns InstallWizard.MENU_SECTION
+        every { event.selectedOptions } returns listOf(SelectOption.of("x", section.id))
+
+        menu.handle(ctx, 0)
+
+        val firstRow = captured.captured.filterIsInstance<ActionRow>().first()
+        val dropdown = firstRow.components.filterIsInstance<StringSelectMenu>().single()
+        assertEquals(
+            InstallWizard.sectionDetailMenuId(section.id),
+            dropdown.customId,
+            "picking ${section.name} must land its detail menu",
+        )
     }
 
     @ParameterizedTest


### PR DESCRIPTION
## Summary

Fixes the install wizard hanging after the first section pick in Custom setup. The embed swapped to the section-detail header but the components stayed as the disabled previous view (section menu + Optional features/Finish row) — owner stuck.

### Root cause

Race between `DefaultMenuManager.handle` and `InstallCategoryMenu`'s non-modal branches:

1. **Manager** (bot-webhook): `event.message.editMessageComponents(disabledRows).queue()` queued *before* dispatch.
2. **Handler** (interaction-response): `event.editMessageEmbeds(...).setComponents(...).queue()` to swap to the new view.

The two REST calls use different tokens. JDA can't serialize them. When the manager's bot-webhook edit lands *after* the handler's interaction edit, the disabled previous components overwrite the new ones. The embed survives because nothing else writes to it.

The modal-opening branches don't have this bug — `event.replyModal(...).queue { event.message.editMessageEmbeds(...) }` rides the same bot-webhook bucket as the manager's disable edit, so JDA serializes them.

### Fix

Switch `handleSectionPick` and `showStakesGameMenu` to:

```kotlin
event.deferEdit().queue {
    event.message.editMessageEmbeds(...).setComponents(...).queue()
}
```

`deferEdit` acks the interaction; the message-edit in the callback rides the bot-webhook bucket (same as the manager's disable edit) → JDA serializes → our rearm always wins.

### Tests

47 menu tests now pass (up from 33). New regression coverage:

- **"never uses the racy interaction-response edit form"** — explicit guard against the fix being reverted (section pick + stakes category).
- **"orders deferEdit before the message edit"** — `verifyOrder` documents the serialization contract.
- **"edits the source message instead of replying or opening a modal"** — catches a wrong-response-mode regression.
- **"swaps in the section-detail menu, not the section menu"** — captures components and asserts the dropdown id is `install_section_detail:<id>`, bottom row has ← Back + Finish.
- **"does not leak the previous Optional features button"** — the exact symptom from the screenshot.
- **"swaps to the install_category_stakes menu plus back+finish row"** — stakes-branch equivalent.
- **"section pick is parametrised across every WizardSection"** — one test per section catches a future regression in one branch.

The two existing non-modal-branch tests were updated to expect the new `deferEdit + event.message.editMessageEmbeds` pattern.

## Test plan

- [x] `./gradlew :discord-bot:test --tests "bot.toby.install.menu.InstallCategoryMenuTest"` — 47/47 pass
- [x] `./gradlew :discord-bot:test --tests "bot.toby.install.*"` — 153 total install tests pass
- [ ] Manual smoke in a sandbox guild:
  - `/install` → Custom setup → section menu + Optional-features/Finish row appears
  - Pick "General settings" → embed swaps **and** dropdown becomes "Pick a category to edit", bottom row becomes ← Back + Finish (no more stale Optional features button)
  - Pick a category → modal opens as before
  - Pick "Per-game stakes" → game sub-menu appears (not section menu)
  - ← Back returns to the section list cleanly

https://claude.ai/code/session_01NHhBfrbNQEDVrsGovXzyGD

---
_Generated by [Claude Code](https://claude.ai/code/session_01NHhBfrbNQEDVrsGovXzyGD)_