### PR TITLE
fix(web): un-overlap the commands search icon and placeholder

### DIFF
--- a/web/src/main/resources/static/css/commands.css
+++ b/web/src/main/resources/static/css/commands.css
@@ -78,7 +78,12 @@
     color: var(--text-muted);
     pointer-events: none;
 }
-.commands-search-input {
+/* `input.` prefix bumps specificity to (0,1,1) so this beats the
+   shared `input[type=search] { padding: 10px 12px }` rule in base.css
+   on source order. Without it the input's left padding stays at 12px
+   and the absolutely-positioned search icon at left:14px collides
+   with the first character of the placeholder. */
+input.commands-search-input {
     width: 100%;
     padding: 11px 44px 11px 40px;
     background: var(--bg-input);
@@ -90,8 +95,8 @@
     transition: border-color var(--dur-fast) var(--ease-out),
                 box-shadow var(--dur-fast) var(--ease-out);
 }
-.commands-search-input::placeholder { color: var(--text-muted); }
-.commands-search-input:focus {
+input.commands-search-input::placeholder { color: var(--text-muted); }
+input.commands-search-input:focus {
     outline: none;
     border-color: var(--accent);
     box-shadow: 0 0 0 3px var(--accent-soft);


### PR DESCRIPTION
## Summary

The search SVG on `/commands/wiki` was overlapping the first character of the "Search commands…" placeholder text (visible in user screenshot of the input).

**Cause:** CSS specificity collision with the shared input styling.

- `web/src/main/resources/static/css/commands.css` line 81:
  `.commands-search-input { padding: 11px 44px 11px 40px }` — specificity **(0,1,0)**.
- `web/src/main/resources/static/css/base.css` line 282:
  `input[type=search] { padding: 10px 12px }` — specificity **(0,1,1)**.

Base wins on specificity, source order can't save it. So the input's actual `padding-left` is `12px`, the icon is positioned at `left: 14px`, and the placeholder text starts ~12px from the left — directly under the icon glyph.

**Fix:** bump the selector to `input.commands-search-input` so specificity ties with base at (0,1,1) and commands.css wins on source order (`fragments/headSeo.html` loads base first, commands second). Applied to the sibling `::placeholder` and `:focus` rules too so a future author can't hit the same trap by editing one without the others.

Why no test: `CommandsWikiTemplateRenderTest` (added in #538) is a structural-markup test — the right contract for it. Catching a CSS-specificity regression needs visual snapshot tests, which the project doesn't run in CI (only `npm run test:e2e:build`, no actual Playwright execution). The `input.` prefix + inline comment is its own self-documenting guard.

I should have caught this in #537 — apologies for the noise. The dev env here can't render the page visually so the bug was invisible to me without a screenshot.

## Test plan

- [x] `cd web && npm run lint:css` — clean.
- [ ] After deploy: open `/commands/wiki` on a phone or in DevTools mobile viewport. The placeholder text should start ~40px from the left, with the magnifying-glass icon clearly visible to its left with breathing room — no character overlap.

https://claude.ai/code/session_01SELycDvTHp4oQBZX2odsXB

---
_Generated by [Claude Code](https://claude.ai/code/session_01SELycDvTHp4oQBZX2odsXB)_