### PR TITLE
feat(setconfig): channel pickers replace typed-ID boxes

### DIFF
--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/moderation/SetConfigCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/moderation/SetConfigCommand.kt
@@ -106,17 +106,17 @@ class SetConfigCommand @Autowired constructor(
             { key -> configService.getConfigByName(key.configValue, guildId)?.value }
 
         val modal = when (sub) {
-            SUB_GENERAL -> general.buildModal(SetConfigGeneralModal.MODAL_NAME, reader)
-            SUB_ACTIVITY -> activity.buildModal(SetConfigActivityModal.MODAL_NAME, reader)
-            SUB_FEES -> fees.buildModal(SetConfigFeesModal.MODAL_NAME, reader)
-            SUB_JACKPOT -> jackpot.buildModal(SetConfigJackpotModal.MODAL_NAME, reader)
-            SUB_JACKPOT_ACTIVITY -> jackpotActivity.buildModal(SetConfigJackpotActivityModal.MODAL_NAME, reader)
-            SUB_POKER_STAKES -> pokerStakes.buildModal(SetConfigPokerStakesModal.MODAL_NAME, reader)
-            SUB_POKER_TABLE -> pokerTable.buildModal(SetConfigPokerTableModal.MODAL_NAME, reader)
-            SUB_BLACKJACK_RULES -> blackjackRules.buildModal(SetConfigBlackjackRulesModal.MODAL_NAME, reader)
-            SUB_BLACKJACK_TABLE -> blackjackTable.buildModal(SetConfigBlackjackTableModal.MODAL_NAME, reader)
-            SUB_LOTTERY_BASICS -> lotteryBasics.buildModal(SetConfigLotteryBasicsModal.MODAL_NAME, reader)
-            SUB_LOTTERY_POOLS -> lotteryPools.buildModal(SetConfigLotteryPoolsModal.MODAL_NAME, reader)
+            SUB_GENERAL -> general.buildModal(SetConfigGeneralModal.MODAL_NAME, guild, reader)
+            SUB_ACTIVITY -> activity.buildModal(SetConfigActivityModal.MODAL_NAME, guild, reader)
+            SUB_FEES -> fees.buildModal(SetConfigFeesModal.MODAL_NAME, guild, reader)
+            SUB_JACKPOT -> jackpot.buildModal(SetConfigJackpotModal.MODAL_NAME, guild, reader)
+            SUB_JACKPOT_ACTIVITY -> jackpotActivity.buildModal(SetConfigJackpotActivityModal.MODAL_NAME, guild, reader)
+            SUB_POKER_STAKES -> pokerStakes.buildModal(SetConfigPokerStakesModal.MODAL_NAME, guild, reader)
+            SUB_POKER_TABLE -> pokerTable.buildModal(SetConfigPokerTableModal.MODAL_NAME, guild, reader)
+            SUB_BLACKJACK_RULES -> blackjackRules.buildModal(SetConfigBlackjackRulesModal.MODAL_NAME, guild, reader)
+            SUB_BLACKJACK_TABLE -> blackjackTable.buildModal(SetConfigBlackjackTableModal.MODAL_NAME, guild, reader)
+            SUB_LOTTERY_BASICS -> lotteryBasics.buildModal(SetConfigLotteryBasicsModal.MODAL_NAME, guild, reader)
+            SUB_LOTTERY_POOLS -> lotteryPools.buildModal(SetConfigLotteryPoolsModal.MODAL_NAME, guild, reader)
             SUB_STAKES -> {
                 val token = event.getOption(OPT_GAME)?.asString
                 val game = token?.let { SetConfigStakesModal.Game.byToken(it) } ?: run {
@@ -124,7 +124,7 @@ class SetConfigCommand @Autowired constructor(
                         .setEphemeral(true).queue()
                     return
                 }
-                stakes.buildModal(SetConfigStakesModal.customIdFor(game), reader)
+                stakes.buildModal(SetConfigStakesModal.customIdFor(game), guild, reader)
             }
             else -> {
                 event.reply("Unknown subcommand `$sub`.").setEphemeral(true).queue()

--- a/discord-bot/src/main/kotlin/bot/toby/install/menu/InstallCategoryMenu.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/menu/InstallCategoryMenu.kt
@@ -24,6 +24,7 @@ import common.logging.DiscordLogger
 import core.menu.Menu
 import core.menu.MenuContext
 import database.service.ConfigService
+import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.components.actionrow.ActionRow
 import net.dv8tion.jda.api.modals.Modal
 import org.springframework.stereotype.Component
@@ -76,7 +77,7 @@ class InstallCategoryMenu(
      *   the menu for a sub-menu) without opening a modal.
      */
     private val categoryActions: Map<String, CategoryAction> = mapOf(
-        QUICK_CHANNELS_TOKEN to CategoryAction.OpenModal { quickChannels.buildModal() },
+        QUICK_CHANNELS_TOKEN to CategoryAction.OpenModal { _, _ -> quickChannels.buildModal() },
         SetConfigCommand.SUB_GENERAL to setconfigModal(general, SetConfigGeneralModal.MODAL_NAME),
         SetConfigCommand.SUB_ACTIVITY to setconfigModal(activity, SetConfigActivityModal.MODAL_NAME),
         SetConfigCommand.SUB_FEES to setconfigModal(fees, SetConfigFeesModal.MODAL_NAME),
@@ -95,7 +96,7 @@ class InstallCategoryMenu(
         modal: bot.toby.modal.modals.setconfig.SetConfigCategoryModal,
         modalName: String,
     ): CategoryAction.OpenModal =
-        CategoryAction.OpenModal { reader -> modal.buildModal(modalName, reader) }
+        CategoryAction.OpenModal { guild, reader -> modal.buildModal(modalName, guild, reader) }
 
     override fun handle(ctx: MenuContext, deleteDelay: Int) {
         val event = ctx.event
@@ -164,7 +165,7 @@ class InstallCategoryMenu(
             return
         }
         when (action) {
-            is CategoryAction.OpenModal -> openModalAndRearm(ctx, section, action.build(reader))
+            is CategoryAction.OpenModal -> openModalAndRearm(ctx, section, action.build(ctx.guild, reader))
             is CategoryAction.Transition -> action.run(ctx)
         }
     }
@@ -182,7 +183,7 @@ class InstallCategoryMenu(
             event.reply("Unknown game `$selectedToken`.").setEphemeral(true).queue()
             return
         }
-        openModalAndRearm(ctx, section, stakes.buildModal(SetConfigStakesModal.customIdFor(game), reader))
+        openModalAndRearm(ctx, section, stakes.buildModal(SetConfigStakesModal.customIdFor(game), ctx.guild, reader))
     }
 
     private fun showStakesGameMenu(ctx: MenuContext) {
@@ -218,7 +219,7 @@ class InstallCategoryMenu(
     }
 
     private sealed interface CategoryAction {
-        class OpenModal(val build: (ConfigReader) -> Modal) : CategoryAction
+        class OpenModal(val build: (Guild, ConfigReader) -> Modal) : CategoryAction
         class Transition(val run: (MenuContext) -> Unit) : CategoryAction
     }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/modal/modals/setconfig/SetConfigCategoryModal.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/modal/modals/setconfig/SetConfigCategoryModal.kt
@@ -7,14 +7,22 @@ import core.modal.ModalContext
 import database.dto.ConfigDto.Configurations
 import database.service.ConfigService
 import net.dv8tion.jda.api.components.label.Label
+import net.dv8tion.jda.api.components.selections.EntitySelectMenu
 import net.dv8tion.jda.api.components.textinput.TextInput
 import net.dv8tion.jda.api.components.textinput.TextInputStyle
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.channel.ChannelType
 import net.dv8tion.jda.api.modals.Modal as JdaModal
 
 /**
  * Base for every `/setconfig <category>` modal. Owns the
  * read-fields → validate-all → write-all-or-error flow so each
  * concrete category just declares its spec map + field-id map.
+ *
+ * Channel-typed fields ([FieldSpec.ChannelByIdStoreName] /
+ * [FieldSpec.ChannelByIdStoreId]) render as Discord native channel
+ * pickers ([EntitySelectMenu]) instead of typed-id [TextInput] fields.
+ * Owners click their channel from a list; no IDs typed.
  *
  * Subclasses override [afterWrites] when they need a side effect
  * keyed off an upsert result (e.g. ACTIVITY_TRACKING's first-enable
@@ -40,8 +48,9 @@ abstract class SetConfigCategoryModal(
     protected abstract fun specsFor(modalId: String): LinkedHashMap<Configurations, FieldSpec>
 
     /**
-     * Discord-side field id (TextInput component id) for each config
-     * key. Must match the lookup keys used by `event.getValue(...)`.
+     * Discord-side field id (TextInput / EntitySelectMenu component
+     * id) for each config key. Must match the lookup keys used by
+     * `event.getValue(...)`.
      */
     protected abstract fun fieldIdsFor(modalId: String): Map<Configurations, String>
 
@@ -62,8 +71,21 @@ abstract class SetConfigCategoryModal(
         val specs = specsFor(modalId)
         val fieldIds = fieldIdsFor(modalId)
 
+        // Channel-picker fields submit their value via `asLongList`;
+        // text fields use `asString`. Branch on the spec so the
+        // validator receives a single uniform String to parse.
+        val readField: (Configurations) -> String? = { key ->
+            val fieldId = fieldIds.getValue(key)
+            when (specs.getValue(key)) {
+                is FieldSpec.ChannelByIdStoreName,
+                is FieldSpec.ChannelByIdStoreId,
+                    -> event.getValue(fieldId)?.asLongList?.firstOrNull()?.toString()
+                else -> event.getValue(fieldId)?.asString
+            }
+        }
+
         val outcome = SetConfigFieldValidator.validateAll(
-            readField = { key -> event.getValue(fieldIds.getValue(key))?.asString },
+            readField = readField,
             specs = specs,
             guild = guild,
         )
@@ -103,26 +125,88 @@ abstract class SetConfigCategoryModal(
      * parameterised modals can vary their fields per-call; for
      * simple modals it's the bare [name].
      *
-     * [currentValues] is read once by the slash command and passed
-     * in as a lookup — the modal handler does no DB reads at open
-     * time.
+     * [guild] is needed to pre-resolve channel-picker default values
+     * — `MOVE` stores a channel name, so we look it up to recover the
+     * channel id for [EntitySelectMenu.Builder.setDefaultValues]. The
+     * other channel-picker fields store the id directly.
+     *
+     * [currentValues] is read once by the caller and passed in as a
+     * lookup — the modal handler does no DB reads at open time.
      */
-    fun buildModal(modalId: String, currentValues: (Configurations) -> String?): JdaModal {
+    fun buildModal(
+        modalId: String,
+        guild: Guild,
+        currentValues: (Configurations) -> String?,
+    ): JdaModal {
         val title = titleFor(modalId)
         val specs = specsFor(modalId)
         val fieldIds = fieldIdsFor(modalId)
         val builder = JdaModal.create(modalId, title)
         for ((key, spec) in specs) {
-            val input = TextInput.create(fieldIds.getValue(key), TextInputStyle.SHORT)
-                .setRequired(false)
-                .apply {
-                    currentValues(key)?.takeIf { it.isNotEmpty() }?.let { setValue(it) }
-                    placeholderFor(spec)?.let { setPlaceholder(it) }
-                }
-                .build()
-            builder.addComponents(Label.of(truncateLabel(spec.label), input))
+            val fieldId = fieldIds.getValue(key)
+            val current = currentValues(key)
+            val component = when (spec) {
+                is FieldSpec.ChannelByIdStoreName ->
+                    buildChannelPicker(fieldId, ChannelType.VOICE, current, guild, storeMode = ChannelStore.BY_NAME)
+                is FieldSpec.ChannelByIdStoreId ->
+                    buildChannelPicker(fieldId, ChannelType.TEXT, current, guild, storeMode = ChannelStore.BY_ID)
+                else -> buildTextInput(fieldId, spec, current)
+            }
+            builder.addComponents(Label.of(truncateLabel(spec.label), component))
         }
         return builder.build()
+    }
+
+    private fun buildTextInput(fieldId: String, spec: FieldSpec, current: String?): TextInput =
+        TextInput.create(fieldId, TextInputStyle.SHORT)
+            .setRequired(false)
+            .apply {
+                current?.takeIf { it.isNotEmpty() }?.let { setValue(it) }
+                placeholderFor(spec)?.let { setPlaceholder(it) }
+            }
+            .build()
+
+    private enum class ChannelStore { BY_NAME, BY_ID }
+
+    /**
+     * Build a channel-picker [EntitySelectMenu] filtered to
+     * [channelType]. Pre-populates the picker's default value from
+     * [current] — interpreting it as a channel name when [storeMode]
+     * is [ChannelStore.BY_NAME], else as a channel id string.
+     *
+     * No selection = skip the write (matches the existing
+     * "blank means don't overwrite" convention on text fields).
+     */
+    private fun buildChannelPicker(
+        fieldId: String,
+        channelType: ChannelType,
+        current: String?,
+        guild: Guild,
+        storeMode: ChannelStore,
+    ): EntitySelectMenu {
+        val builder = EntitySelectMenu.create(fieldId, EntitySelectMenu.SelectTarget.CHANNEL)
+            .setChannelTypes(channelType)
+            .setRequiredRange(0, 1)
+        val resolvedId: Long? = current?.takeIf { it.isNotEmpty() }?.let { value ->
+            when (storeMode) {
+                ChannelStore.BY_NAME -> when (channelType) {
+                    ChannelType.VOICE -> guild.getVoiceChannelsByName(value, true).firstOrNull()?.idLong
+                    ChannelType.TEXT -> guild.getTextChannelsByName(value, true).firstOrNull()?.idLong
+                    else -> null
+                }
+                ChannelStore.BY_ID -> value.toLongOrNull()?.takeIf { guildHasChannel(guild, channelType, it) }
+            }
+        }
+        if (resolvedId != null) {
+            builder.setDefaultValues(EntitySelectMenu.DefaultValue.channel(resolvedId))
+        }
+        return builder.build()
+    }
+
+    private fun guildHasChannel(guild: Guild, channelType: ChannelType, id: Long): Boolean = when (channelType) {
+        ChannelType.TEXT -> guild.getTextChannelById(id) != null
+        ChannelType.VOICE -> guild.getVoiceChannelById(id) != null
+        else -> false
     }
 
     private fun buildSummary(
@@ -142,8 +226,10 @@ abstract class SetConfigCategoryModal(
         is FieldSpec.DoubleRange -> "${spec.range.start}–${spec.range.endInclusive}"
         is FieldSpec.BoolStrict -> "true / false"
         is FieldSpec.EnumChoice -> spec.allowed.joinToString(" / ")
-        is FieldSpec.ChannelByIdStoreName -> "channel id"
-        is FieldSpec.ChannelByIdStoreId -> if (spec.allowClear) "channel id (0 to clear)" else "channel id"
+        // Channel specs render as EntitySelectMenu, not TextInput — no placeholder applies.
+        is FieldSpec.ChannelByIdStoreName,
+        is FieldSpec.ChannelByIdStoreId,
+            -> null
     }
 
     private fun truncateLabel(label: String): String =

--- a/discord-bot/src/main/kotlin/bot/toby/modal/modals/setconfig/SetConfigFieldValidator.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/modal/modals/setconfig/SetConfigFieldValidator.kt
@@ -45,10 +45,12 @@ object SetConfigFieldValidator {
         data class EnumChoice(override val label: String, val allowed: Set<String>) : FieldSpec
 
         /**
-         * Discord channel reference (raw id or `<#id>` mention) resolved
-         * against the guild; the channel's **name** is stored. Used by
-         * `MOVE`, which `MoveCommand` looks up by name — switching to id
-         * would silently break unscoped admins.
+         * Discord channel reference resolved against the guild; the
+         * channel's **name** is stored. Used by `MOVE`, which
+         * `MoveCommand` looks up by name — switching to id would
+         * silently break unscoped admins. Rendered in modals as a
+         * voice [net.dv8tion.jda.api.components.selections.EntitySelectMenu]
+         * channel picker (no IDs typed).
          */
         data class ChannelByIdStoreName(override val label: String) : FieldSpec
 
@@ -56,9 +58,10 @@ object SetConfigFieldValidator {
          * Discord channel reference resolved against the guild; the
          * channel's **id** is stored as a string. Used for
          * LEADERBOARD_CHANNEL, LOTTERY_CHANNEL, CASINO_MODLOG_CHANNEL_ID.
-         * `"0"` clears the override to empty string when [allowClear].
+         * Rendered in modals as a text channel picker; selecting no
+         * channel = skip-write (preserves the existing override).
          */
-        data class ChannelByIdStoreId(override val label: String, val allowClear: Boolean = true) : FieldSpec
+        data class ChannelByIdStoreId(override val label: String) : FieldSpec
     }
 
     sealed interface FieldResult {
@@ -169,7 +172,6 @@ object SetConfigFieldValidator {
     }
 
     private fun resolveChannelId(raw: String, spec: FieldSpec.ChannelByIdStoreId, guild: Guild?): FieldResult {
-        if (spec.allowClear && raw == "0") return FieldResult.Write("")
         if (guild == null) return FieldResult.Error("${spec.label}: no guild context to resolve channel")
         val id = extractChannelId(raw)
             ?: return FieldResult.Error("${spec.label}: must be a channel id or #mention")

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/moderation/SetConfigCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/moderation/SetConfigCommandTest.kt
@@ -139,7 +139,7 @@ internal class SetConfigCommandTest : CommandTest {
         assertOpensModal(
             sub = SetConfigCommand.SUB_GENERAL,
             modalIdExpected = SetConfigGeneralModal.MODAL_NAME,
-            stubReturn = { every { general.buildModal(SetConfigGeneralModal.MODAL_NAME, any()) } returns it },
+            stubReturn = { every { general.buildModal(SetConfigGeneralModal.MODAL_NAME, any(), any()) } returns it },
         )
     }
 
@@ -148,7 +148,7 @@ internal class SetConfigCommandTest : CommandTest {
         assertOpensModal(
             SetConfigCommand.SUB_ACTIVITY,
             SetConfigActivityModal.MODAL_NAME,
-            { every { activity.buildModal(SetConfigActivityModal.MODAL_NAME, any()) } returns it },
+            { every { activity.buildModal(SetConfigActivityModal.MODAL_NAME, any(), any()) } returns it },
         )
     }
 
@@ -157,7 +157,7 @@ internal class SetConfigCommandTest : CommandTest {
         assertOpensModal(
             SetConfigCommand.SUB_FEES,
             SetConfigFeesModal.MODAL_NAME,
-            { every { fees.buildModal(SetConfigFeesModal.MODAL_NAME, any()) } returns it },
+            { every { fees.buildModal(SetConfigFeesModal.MODAL_NAME, any(), any()) } returns it },
         )
     }
 
@@ -166,7 +166,7 @@ internal class SetConfigCommandTest : CommandTest {
         assertOpensModal(
             SetConfigCommand.SUB_JACKPOT,
             SetConfigJackpotModal.MODAL_NAME,
-            { every { jackpot.buildModal(SetConfigJackpotModal.MODAL_NAME, any()) } returns it },
+            { every { jackpot.buildModal(SetConfigJackpotModal.MODAL_NAME, any(), any()) } returns it },
         )
     }
 
@@ -175,7 +175,7 @@ internal class SetConfigCommandTest : CommandTest {
         assertOpensModal(
             SetConfigCommand.SUB_JACKPOT_ACTIVITY,
             SetConfigJackpotActivityModal.MODAL_NAME,
-            { every { jackpotActivity.buildModal(SetConfigJackpotActivityModal.MODAL_NAME, any()) } returns it },
+            { every { jackpotActivity.buildModal(SetConfigJackpotActivityModal.MODAL_NAME, any(), any()) } returns it },
         )
     }
 
@@ -184,7 +184,7 @@ internal class SetConfigCommandTest : CommandTest {
         assertOpensModal(
             SetConfigCommand.SUB_POKER_STAKES,
             SetConfigPokerStakesModal.MODAL_NAME,
-            { every { pokerStakes.buildModal(SetConfigPokerStakesModal.MODAL_NAME, any()) } returns it },
+            { every { pokerStakes.buildModal(SetConfigPokerStakesModal.MODAL_NAME, any(), any()) } returns it },
         )
     }
 
@@ -193,7 +193,7 @@ internal class SetConfigCommandTest : CommandTest {
         assertOpensModal(
             SetConfigCommand.SUB_POKER_TABLE,
             SetConfigPokerTableModal.MODAL_NAME,
-            { every { pokerTable.buildModal(SetConfigPokerTableModal.MODAL_NAME, any()) } returns it },
+            { every { pokerTable.buildModal(SetConfigPokerTableModal.MODAL_NAME, any(), any()) } returns it },
         )
     }
 
@@ -202,7 +202,7 @@ internal class SetConfigCommandTest : CommandTest {
         assertOpensModal(
             SetConfigCommand.SUB_BLACKJACK_RULES,
             SetConfigBlackjackRulesModal.MODAL_NAME,
-            { every { blackjackRules.buildModal(SetConfigBlackjackRulesModal.MODAL_NAME, any()) } returns it },
+            { every { blackjackRules.buildModal(SetConfigBlackjackRulesModal.MODAL_NAME, any(), any()) } returns it },
         )
     }
 
@@ -211,7 +211,7 @@ internal class SetConfigCommandTest : CommandTest {
         assertOpensModal(
             SetConfigCommand.SUB_BLACKJACK_TABLE,
             SetConfigBlackjackTableModal.MODAL_NAME,
-            { every { blackjackTable.buildModal(SetConfigBlackjackTableModal.MODAL_NAME, any()) } returns it },
+            { every { blackjackTable.buildModal(SetConfigBlackjackTableModal.MODAL_NAME, any(), any()) } returns it },
         )
     }
 
@@ -220,7 +220,7 @@ internal class SetConfigCommandTest : CommandTest {
         assertOpensModal(
             SetConfigCommand.SUB_LOTTERY_BASICS,
             SetConfigLotteryBasicsModal.MODAL_NAME,
-            { every { lotteryBasics.buildModal(SetConfigLotteryBasicsModal.MODAL_NAME, any()) } returns it },
+            { every { lotteryBasics.buildModal(SetConfigLotteryBasicsModal.MODAL_NAME, any(), any()) } returns it },
         )
     }
 
@@ -229,7 +229,7 @@ internal class SetConfigCommandTest : CommandTest {
         assertOpensModal(
             SetConfigCommand.SUB_LOTTERY_POOLS,
             SetConfigLotteryPoolsModal.MODAL_NAME,
-            { every { lotteryPools.buildModal(SetConfigLotteryPoolsModal.MODAL_NAME, any()) } returns it },
+            { every { lotteryPools.buildModal(SetConfigLotteryPoolsModal.MODAL_NAME, any(), any()) } returns it },
         )
     }
 
@@ -239,7 +239,7 @@ internal class SetConfigCommandTest : CommandTest {
         assertOpensModal(
             sub = SetConfigCommand.SUB_STAKES,
             modalIdExpected = expectedId,
-            stubReturn = { every { stakes.buildModal(expectedId, any()) } returns it },
+            stubReturn = { every { stakes.buildModal(expectedId, any(), any()) } returns it },
             extraEventStubs = {
                 val opt = mockk<OptionMapping> { every { asString } returns "dice" }
                 every { event.getOption(SetConfigCommand.OPT_GAME) } returns opt
@@ -266,7 +266,7 @@ internal class SetConfigCommandTest : CommandTest {
         val readerSlot = slot<(Configurations) -> String?>()
         every { event.subcommandName } returns SetConfigCommand.SUB_GENERAL
         val builtModal = mockk<Modal>(relaxed = true) { every { id } returns SetConfigGeneralModal.MODAL_NAME }
-        every { general.buildModal(SetConfigGeneralModal.MODAL_NAME, capture(readerSlot)) } returns builtModal
+        every { general.buildModal(SetConfigGeneralModal.MODAL_NAME, any(), capture(readerSlot)) } returns builtModal
         // Use any() because a relaxed-mock ConfigService returns a default
         // ConfigDto (value="") for unstubbed calls — the literal-arg stub
         // matcher fights that default.

--- a/discord-bot/src/test/kotlin/bot/toby/install/menu/InstallCategoryMenuTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/install/menu/InstallCategoryMenuTest.kt
@@ -346,17 +346,17 @@ internal class InstallCategoryMenuTest {
 
         // Stub the modal bean (whichever) to return a known modal id.
         val built = mockk<Modal>(relaxed = true) { every { id } returns expectedModalName }
-        every { general.buildModal(SetConfigGeneralModal.MODAL_NAME, any()) } returns built
-        every { activity.buildModal(SetConfigActivityModal.MODAL_NAME, any()) } returns built
-        every { fees.buildModal(SetConfigFeesModal.MODAL_NAME, any()) } returns built
-        every { jackpot.buildModal(SetConfigJackpotModal.MODAL_NAME, any()) } returns built
-        every { jackpotActivity.buildModal(SetConfigJackpotActivityModal.MODAL_NAME, any()) } returns built
-        every { pokerStakes.buildModal(SetConfigPokerStakesModal.MODAL_NAME, any()) } returns built
-        every { pokerTable.buildModal(SetConfigPokerTableModal.MODAL_NAME, any()) } returns built
-        every { blackjackRules.buildModal(SetConfigBlackjackRulesModal.MODAL_NAME, any()) } returns built
-        every { blackjackTable.buildModal(SetConfigBlackjackTableModal.MODAL_NAME, any()) } returns built
-        every { lotteryBasics.buildModal(SetConfigLotteryBasicsModal.MODAL_NAME, any()) } returns built
-        every { lotteryPools.buildModal(SetConfigLotteryPoolsModal.MODAL_NAME, any()) } returns built
+        every { general.buildModal(SetConfigGeneralModal.MODAL_NAME, any(), any()) } returns built
+        every { activity.buildModal(SetConfigActivityModal.MODAL_NAME, any(), any()) } returns built
+        every { fees.buildModal(SetConfigFeesModal.MODAL_NAME, any(), any()) } returns built
+        every { jackpot.buildModal(SetConfigJackpotModal.MODAL_NAME, any(), any()) } returns built
+        every { jackpotActivity.buildModal(SetConfigJackpotActivityModal.MODAL_NAME, any(), any()) } returns built
+        every { pokerStakes.buildModal(SetConfigPokerStakesModal.MODAL_NAME, any(), any()) } returns built
+        every { pokerTable.buildModal(SetConfigPokerTableModal.MODAL_NAME, any(), any()) } returns built
+        every { blackjackRules.buildModal(SetConfigBlackjackRulesModal.MODAL_NAME, any(), any()) } returns built
+        every { blackjackTable.buildModal(SetConfigBlackjackTableModal.MODAL_NAME, any(), any()) } returns built
+        every { lotteryBasics.buildModal(SetConfigLotteryBasicsModal.MODAL_NAME, any(), any()) } returns built
+        every { lotteryPools.buildModal(SetConfigLotteryPoolsModal.MODAL_NAME, any(), any()) } returns built
 
         // Make the componentId start with a valid section detail prefix.
         every { event.componentId } returns InstallWizard.sectionDetailMenuId(WizardSection.GENERAL.id)
@@ -372,7 +372,7 @@ internal class InstallCategoryMenuTest {
     fun `reader passed to buildModal delegates to configService getConfigByName`() {
         val readerSlot = slot<(Configurations) -> String?>()
         val built = mockk<Modal>(relaxed = true) { every { id } returns SetConfigGeneralModal.MODAL_NAME }
-        every { general.buildModal(SetConfigGeneralModal.MODAL_NAME, capture(readerSlot)) } returns built
+        every { general.buildModal(SetConfigGeneralModal.MODAL_NAME, any(), capture(readerSlot)) } returns built
         every { event.componentId } returns InstallWizard.sectionDetailMenuId(WizardSection.GENERAL.id)
         every { event.selectedOptions } returns listOf(SelectOption.of("x", SetConfigCommand.SUB_GENERAL))
         every {
@@ -475,7 +475,7 @@ internal class InstallCategoryMenuTest {
     fun `game token in stakes sub-menu opens that game's stakes modal`(game: SetConfigStakesModal.Game) {
         val expectedId = SetConfigStakesModal.customIdFor(game)
         val built = mockk<Modal>(relaxed = true) { every { id } returns expectedId }
-        every { stakes.buildModal(expectedId, any()) } returns built
+        every { stakes.buildModal(expectedId, any(), any()) } returns built
         every { event.componentId } returns InstallWizard.MENU_CATEGORY_STAKES
         every { event.selectedOptions } returns listOf(SelectOption.of("x", game.token))
 
@@ -500,7 +500,7 @@ internal class InstallCategoryMenuTest {
         verify(exactly = 1) { event.replyModal(capture(modalSlot)) }
         assertEquals(expectedId, modalSlot.captured.id)
         // Should not have opened any individual game modal.
-        verify(exactly = 0) { stakes.buildModal(any<String>(), any<(Configurations) -> String?>()) }
+        verify(exactly = 0) { stakes.buildModal(any<String>(), any(), any<(Configurations) -> String?>()) }
     }
 
     @Test

--- a/discord-bot/src/test/kotlin/bot/toby/modal/modals/setconfig/SetConfigCategoryModalChannelPickerTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/modal/modals/setconfig/SetConfigCategoryModalChannelPickerTest.kt
@@ -1,0 +1,299 @@
+package bot.toby.modal.modals.setconfig
+
+import database.dto.ConfigDto.Configurations
+import database.service.ConfigService
+import io.mockk.every
+import io.mockk.mockk
+import net.dv8tion.jda.api.components.selections.EntitySelectMenu
+import net.dv8tion.jda.api.components.textinput.TextInput
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.channel.ChannelType
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
+import net.dv8tion.jda.api.entities.channel.concrete.VoiceChannel
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import java.util.stream.Stream
+
+/**
+ * Regression coverage for the channel-picker rendering on
+ * [SetConfigCategoryModal.buildModal].
+ *
+ * The migration replaced typed-id [TextInput]s with native channel
+ * [EntitySelectMenu] pickers for every `ChannelByIdStoreName` /
+ * `ChannelByIdStoreId` spec across the 3 channel-bearing modals
+ * (General, Jackpot, Lottery pools). These tests pin the new
+ * rendering so an accidental drift to TextInput is caught at test
+ * time.
+ *
+ * Pre-selection is validated by tracing the call into
+ * `EntitySelectMenu.Builder.setDefaultValues(...)` via the captured
+ * `defaultValues` on the built menu.
+ */
+class SetConfigCategoryModalChannelPickerTest {
+
+    private lateinit var configService: ConfigService
+    private lateinit var guild: Guild
+    private val guildId = "100"
+
+    @BeforeEach
+    fun setUp() {
+        configService = mockk(relaxed = true)
+        guild = mockk(relaxed = true) {
+            every { id } returns guildId
+        }
+    }
+
+    // ---- 1 & 2: channel specs render as EntitySelectMenu, not TextInput ----
+
+    @Test
+    fun `MOVE renders as a voice EntitySelectMenu, not a TextInput`() {
+        val modal = SetConfigGeneralModal(configService)
+        val built = modal.buildModal(SetConfigGeneralModal.MODAL_NAME, guild) { null }
+
+        val moveChild = findChild(built, SetConfigGeneralModal.FIELD_MOVE)
+        assertNotNull(moveChild, "MOVE field must be present in the modal")
+        assertTrue(
+            moveChild is EntitySelectMenu,
+            "MOVE renders as EntitySelectMenu (got ${moveChild!!::class.simpleName})",
+        )
+        val menu = moveChild as EntitySelectMenu
+        assertTrue(
+            menu.channelTypes.contains(ChannelType.VOICE),
+            "MOVE picker filters to voice channels (got ${menu.channelTypes})",
+        )
+    }
+
+    @Test
+    fun `LEADERBOARD_CHANNEL renders as a text EntitySelectMenu`() {
+        val modal = SetConfigGeneralModal(configService)
+        val built = modal.buildModal(SetConfigGeneralModal.MODAL_NAME, guild) { null }
+
+        val leaderboardChild = findChild(built, SetConfigGeneralModal.FIELD_LEADERBOARD_CHANNEL)
+        assertNotNull(leaderboardChild)
+        assertTrue(leaderboardChild is EntitySelectMenu)
+        val menu = leaderboardChild as EntitySelectMenu
+        assertTrue(menu.channelTypes.contains(ChannelType.TEXT))
+    }
+
+    // ---- 3 & 4: pre-population resolves stored value to a default-selected channel ----
+
+    @Test
+    fun `MOVE pre-selection resolves a stored channel name to a default value`() {
+        val voiceChannel = mockk<VoiceChannel>(relaxed = true) {
+            every { idLong } returns 42L
+            every { id } returns "42"
+        }
+        every { guild.getVoiceChannelsByName("general", true) } returns listOf(voiceChannel)
+        val modal = SetConfigGeneralModal(configService)
+
+        val built = modal.buildModal(SetConfigGeneralModal.MODAL_NAME, guild) { key ->
+            if (key == Configurations.MOVE) "general" else null
+        }
+
+        val menu = findChild(built, SetConfigGeneralModal.FIELD_MOVE) as EntitySelectMenu
+        assertEquals(1, menu.defaultValues.size, "MOVE picker is pre-populated with the resolved channel")
+        assertEquals(42L, menu.defaultValues.first().idLong)
+    }
+
+    @Test
+    fun `LEADERBOARD pre-selection passes the stored id through unchanged`() {
+        val textChannel = mockk<TextChannel>(relaxed = true) {
+            every { idLong } returns 789L
+        }
+        every { guild.getTextChannelById(789L) } returns textChannel
+        val modal = SetConfigGeneralModal(configService)
+
+        val built = modal.buildModal(SetConfigGeneralModal.MODAL_NAME, guild) { key ->
+            if (key == Configurations.LEADERBOARD_CHANNEL) "789" else null
+        }
+
+        val menu = findChild(built, SetConfigGeneralModal.FIELD_LEADERBOARD_CHANNEL) as EntitySelectMenu
+        assertEquals(1, menu.defaultValues.size)
+        assertEquals(789L, menu.defaultValues.first().idLong)
+    }
+
+    @Test
+    fun `MOVE pre-selection is empty when stored name has no matching channel`() {
+        every { guild.getVoiceChannelsByName(any(), any()) } returns emptyList()
+        val modal = SetConfigGeneralModal(configService)
+
+        val built = modal.buildModal(SetConfigGeneralModal.MODAL_NAME, guild) { key ->
+            if (key == Configurations.MOVE) "ghost-channel" else null
+        }
+
+        val menu = findChild(built, SetConfigGeneralModal.FIELD_MOVE) as EntitySelectMenu
+        assertTrue(menu.defaultValues.isEmpty())
+    }
+
+    @Test
+    fun `LEADERBOARD pre-selection is empty when stored id is not a number`() {
+        val modal = SetConfigGeneralModal(configService)
+
+        val built = modal.buildModal(SetConfigGeneralModal.MODAL_NAME, guild) { key ->
+            if (key == Configurations.LEADERBOARD_CHANNEL) "not-an-id" else null
+        }
+
+        val menu = findChild(built, SetConfigGeneralModal.FIELD_LEADERBOARD_CHANNEL) as EntitySelectMenu
+        assertTrue(menu.defaultValues.isEmpty())
+    }
+
+    @Test
+    fun `LEADERBOARD pre-selection is empty when stored id no longer exists in the guild`() {
+        every { guild.getTextChannelById(any<Long>()) } returns null
+        val modal = SetConfigGeneralModal(configService)
+
+        val built = modal.buildModal(SetConfigGeneralModal.MODAL_NAME, guild) { key ->
+            if (key == Configurations.LEADERBOARD_CHANNEL) "999" else null
+        }
+
+        val menu = findChild(built, SetConfigGeneralModal.FIELD_LEADERBOARD_CHANNEL) as EntitySelectMenu
+        assertTrue(menu.defaultValues.isEmpty())
+    }
+
+    // ---- 6: mixing channel pickers with text fields keeps spec order ----
+
+    @Test
+    fun `general modal mixes text inputs and channel pickers in spec order`() {
+        val modal = SetConfigGeneralModal(configService)
+        val built = modal.buildModal(SetConfigGeneralModal.MODAL_NAME, guild) { null }
+        val childIds = collectChildIds(built)
+        // Spec order from SetConfigGeneralModal.fieldIds:
+        // VOLUME, INTRO_VOLUME, DELETE_DELAY, MOVE, LEADERBOARD_CHANNEL.
+        assertEquals(
+            listOf(
+                SetConfigGeneralModal.FIELD_VOLUME,
+                SetConfigGeneralModal.FIELD_INTRO_VOLUME,
+                SetConfigGeneralModal.FIELD_DELETE_DELAY,
+                SetConfigGeneralModal.FIELD_MOVE,
+                SetConfigGeneralModal.FIELD_LEADERBOARD_CHANNEL,
+            ),
+            childIds,
+        )
+    }
+
+    // ---- 7: parametrised across all 4 channel-bearing config keys ----
+
+    companion object {
+        @JvmStatic
+        fun channelBearingFields(): Stream<Arguments> = Stream.of(
+            Arguments.of(
+                "SetConfigGeneralModal.MOVE",
+                Configurations.MOVE,
+                SetConfigGeneralModal.MODAL_NAME,
+                SetConfigGeneralModal.FIELD_MOVE,
+                ChannelType.VOICE,
+            ),
+            Arguments.of(
+                "SetConfigGeneralModal.LEADERBOARD_CHANNEL",
+                Configurations.LEADERBOARD_CHANNEL,
+                SetConfigGeneralModal.MODAL_NAME,
+                SetConfigGeneralModal.FIELD_LEADERBOARD_CHANNEL,
+                ChannelType.TEXT,
+            ),
+            Arguments.of(
+                "SetConfigJackpotModal.CASINO_MODLOG_CHANNEL_ID",
+                Configurations.CASINO_MODLOG_CHANNEL_ID,
+                SetConfigJackpotModal.MODAL_NAME,
+                SetConfigJackpotModal.FIELD_CASINO_MODLOG_CHANNEL_ID,
+                ChannelType.TEXT,
+            ),
+            Arguments.of(
+                "SetConfigLotteryPoolsModal.LOTTERY_CHANNEL",
+                Configurations.LOTTERY_CHANNEL,
+                SetConfigLotteryPoolsModal.MODAL_NAME,
+                SetConfigLotteryPoolsModal.FIELD_CHANNEL,
+                ChannelType.TEXT,
+            ),
+        )
+    }
+
+    @ParameterizedTest(name = "{0} renders a channel picker filtered to {4}")
+    @MethodSource("channelBearingFields")
+    fun `every channel-bearing config key renders as a channel picker`(
+        label: String,
+        key: Configurations,
+        modalName: String,
+        fieldId: String,
+        channelType: ChannelType,
+    ) {
+        val modal: SetConfigCategoryModal = when (modalName) {
+            SetConfigGeneralModal.MODAL_NAME -> SetConfigGeneralModal(configService)
+            SetConfigJackpotModal.MODAL_NAME -> SetConfigJackpotModal(configService)
+            SetConfigLotteryPoolsModal.MODAL_NAME -> SetConfigLotteryPoolsModal(configService)
+            else -> error("Unhandled modal $modalName")
+        }
+        val built = modal.buildModal(modalName, guild) { null }
+        val child = findChild(built, fieldId)
+        assertNotNull(child, "$label: field $fieldId must be present")
+        assertTrue(
+            child is EntitySelectMenu,
+            "$label: rendered as ${child!!::class.simpleName}, expected EntitySelectMenu",
+        )
+        val menu = child as EntitySelectMenu
+        assertTrue(
+            menu.channelTypes.contains(channelType),
+            "$label: filtered to ${menu.channelTypes}, expected to contain $channelType",
+        )
+    }
+
+    // ---- Helpers ----
+
+    /**
+     * Walk the modal's component tree to find the child component with
+     * the given custom id. Modal components are wrapped in `Label`
+     * nodes; we unwrap into either a TextInput or an EntitySelectMenu.
+     */
+    private fun findChild(
+        modal: net.dv8tion.jda.api.modals.Modal,
+        fieldId: String,
+    ): net.dv8tion.jda.api.components.Component? {
+        modal.components.forEach { top ->
+            collectAll(top).firstOrNull {
+                (it is TextInput && it.customId == fieldId) ||
+                    (it is EntitySelectMenu && it.customId == fieldId)
+            }?.let { return it }
+        }
+        return null
+    }
+
+    private fun collectChildIds(modal: net.dv8tion.jda.api.modals.Modal): List<String> =
+        modal.components.flatMap { top ->
+            collectAll(top).mapNotNull { c ->
+                when (c) {
+                    is TextInput -> c.customId
+                    is EntitySelectMenu -> c.customId
+                    else -> null
+                }
+            }
+        }
+
+    private fun collectAll(c: net.dv8tion.jda.api.components.Component): List<net.dv8tion.jda.api.components.Component> {
+        val out = mutableListOf<net.dv8tion.jda.api.components.Component>()
+        fun walk(node: net.dv8tion.jda.api.components.Component) {
+            out += node
+            if (node is net.dv8tion.jda.api.components.label.Label) {
+                walk(node.child)
+            }
+        }
+        walk(c)
+        return out
+    }
+
+    @Suppress("unused")
+    private fun assertChannelTypeFilter(menu: EntitySelectMenu, expected: ChannelType) {
+        assertSame(expected, menu.channelTypes.firstOrNull())
+    }
+
+    @Suppress("unused")
+    private fun assertNullablePreSelection(menu: EntitySelectMenu) {
+        assertNull(menu.defaultValues.firstOrNull())
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/modal/modals/setconfig/SetConfigFieldValidatorTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/modal/modals/setconfig/SetConfigFieldValidatorTest.kt
@@ -158,11 +158,12 @@ internal class SetConfigFieldValidatorTest {
         assertEquals(FieldResult.Write("7"), r)
     }
 
-    @Test
-    fun `ChannelByIdStoreId allows 0 to clear`() {
-        val r = SetConfigFieldValidator.validate("0", FieldSpec.ChannelByIdStoreId("Lottery channel"), guild = null)
-        assertEquals(FieldResult.Write(""), r)
-    }
+    // Note: the `"0" → clear` shortcut was removed when channel fields
+    // switched from typed-id TextInputs to EntitySelectMenu pickers in
+    // the modal. The picker UX surfaces no path that produces "0", and
+    // "clear my channel override" was rarely used in practice. Owners
+    // who need to drop an override can use SQL or, in future, a
+    // dedicated `/setconfig clear-channel` command.
 
     // ----- validateAll() collecting writes vs errors -----
 

--- a/discord-bot/src/test/kotlin/bot/toby/modal/modals/setconfig/SetConfigGeneralModalTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/modal/modals/setconfig/SetConfigGeneralModalTest.kt
@@ -83,8 +83,10 @@ class SetConfigGeneralModalTest {
     }
 
     @Test
-    fun `MOVE resolves the channel name from a numeric id`() {
-        stub(SetConfigGeneralModal.FIELD_MOVE, "42")
+    fun `MOVE picker resolves to the channel name on submit`() {
+        // Channel fields submit via EntitySelectMenu → asLongList rather
+        // than typed-id TextInput → asString.
+        stubChannelPick(SetConfigGeneralModal.FIELD_MOVE, 42L)
         val channel = mockk<TextChannel> { every { name } returns "general" }
         every { guild.getTextChannelById(42L) } returns channel
         val rowsSlot = slot<List<Pair<String, String>>>()
@@ -100,13 +102,14 @@ class SetConfigGeneralModalTest {
     }
 
     @Test
-    fun `MOVE with unknown id fails with an error and writes nothing`() {
-        stub(SetConfigGeneralModal.FIELD_MOVE, "999")
+    fun `MOVE picker with a stale channel id fails with an error and writes nothing`() {
+        stubChannelPick(SetConfigGeneralModal.FIELD_MOVE, 999L)
         every { guild.getTextChannelById(999L) } returns null
         every { guild.getVoiceChannelById(999L) } returns null
 
         modal.handle(ctx, 0)
 
+        verify(exactly = 0) { configService.upsertAll(any(), any()) }
         verify(exactly = 0) { configService.upsertConfig(any(), any(), any()) }
         assertTrue(messageSlot.captured.contains("Couldn't save"))
     }
@@ -128,6 +131,11 @@ class SetConfigGeneralModalTest {
 
     private fun stub(field: String, value: String) {
         val mapping = mockk<ModalMapping> { every { asString } returns value }
+        every { event.getValue(field) } returns mapping
+    }
+
+    private fun stubChannelPick(field: String, channelId: Long) {
+        val mapping = mockk<ModalMapping> { every { asLongList } returns listOf(channelId) }
         every { event.getValue(field) } returns mapping
     }
 }


### PR DESCRIPTION
## Summary

Replaces the typed-channel-ID `TextInput` boxes in `/setconfig` with Discord's native `EntitySelectMenu` channel picker — owners click their channel from a list, no IDs to copy.

Affects four channel fields across three modals:
- `MOVE` (voice, store name) — `SetConfigGeneralModal`
- `LEADERBOARD_CHANNEL` (text, store id) — `SetConfigGeneralModal`
- `CASINO_MODLOG_CHANNEL_ID` (text, store id) — `SetConfigJackpotModal`
- `LOTTERY_CHANNEL` (text, store id) — `SetConfigLotteryPoolsModal`

The install wizard's Custom flow inherits the change automatically — it opens the same modals.

## What changed

- `SetConfigCategoryModal.buildModal` now takes a `Guild` so it can resolve `MOVE`'s stored channel name to a channel id for `EntitySelectMenu.Builder.setDefaultValues(...)` pre-selection. The other channel-id fields store ids directly so pre-selection is straightforward.
- `handle()` reads channel-picker values via `event.getValue(id)?.asLongList?.firstOrNull()?.toString()` for channel specs and passes them through the existing validator (which already accepts a raw numeric id via `extractChannelId`).
- Callers updated: `SetConfigCommand` (slash) and `InstallCategoryMenu` (wizard) both thread their guild into `buildModal`.
- `ChannelByIdStoreId.allowClear` + the `"0" → clear` validator branch are removed — the picker can't produce `"0"`, and the clear gesture was rarely used. Owners who need to drop an override can use SQL or a future dedicated command.

## Tests

**New regression suite** — `SetConfigCategoryModalChannelPickerTest` (12 tests):
- MOVE renders as a voice `EntitySelectMenu`; LEADERBOARD as text.
- MOVE pre-selection resolves a stored channel name → channel id default value.
- LEADERBOARD pre-selection passes the stored id through unchanged.
- Pre-selection is empty when the stored value is unresolvable (missing name, non-numeric id, stale id).
- General modal preserves spec order when mixing text + picker rows.
- Parametrised across all four channel-bearing fields (MOVE, LEADERBOARD_CHANNEL, CASINO_MODLOG_CHANNEL_ID, LOTTERY_CHANNEL) — catches future regressions where one modal's spec drifts back to a non-picker variant.

**Updated existing tests** to match the new shape:
- `SetConfigGeneralModalTest` MOVE tests now stub `asLongList = listOf(channelId)` instead of `asString = "id"`.
- `SetConfigFieldValidatorTest` removes the obsolete "0 clears" test, with a comment explaining why.
- `SetConfigCommandTest` and `InstallCategoryMenuTest` updated for the new `buildModal(modalId, guild, reader)` signature (matchers gained an extra `any()` for guild).

## Test plan

- [x] `./gradlew :discord-bot:test --tests "*SetConfig*"` — all modal + command tests pass
- [x] `./gradlew :discord-bot:test --tests "bot.toby.install.*"` — wizard tests pass
- [x] `./gradlew :web:test` — unaffected, green
- [ ] Manual smoke in a sandbox guild:
  - `/setconfig general` → two channel pickers (voice + text) instead of typed-ID boxes; existing settings pre-populate
  - Pick a different voice channel → submit → DB shows the new channel **name** in `DEFAULT_MOVE_CHANNEL`
  - Submit with no pick → existing values unchanged
  - `/setconfig jackpot` → modlog field is a picker
  - `/setconfig lottery_pools` → announce-channel field is a picker
  - Wizard's Custom → "General settings" → same picker UX (the wizard flows through the same modal)

https://claude.ai/code/session_01NHhBfrbNQEDVrsGovXzyGD

---
_Generated by [Claude Code](https://claude.ai/code/session_01NHhBfrbNQEDVrsGovXzyGD)_