### PR TITLE
feat(install): Quick channels picker for jackpot + lottery sections

### DIFF
--- a/discord-bot/src/main/kotlin/bot/toby/install/WizardSection.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/WizardSection.kt
@@ -2,8 +2,14 @@ package bot.toby.install
 
 import bot.toby.command.commands.moderation.SetConfigCommand
 
-/** Synthetic category token for the EntitySelectMenu-backed quick channels modal. */
+/** Synthetic category token for the General section's Quick channels modal (`InstallQuickChannelsModal`). */
 const val QUICK_CHANNELS_TOKEN = "quick_channels"
+
+/** Synthetic category token for the Jackpot section's Quick channels modal (`InstallJackpotChannelsModal`). */
+const val JACKPOT_QUICK_CHANNELS_TOKEN = "jackpot_quick_channels"
+
+/** Synthetic category token for the Lottery section's Quick channels modal (`InstallLotteryChannelsModal`). */
+const val LOTTERY_QUICK_CHANNELS_TOKEN = "lottery_quick_channels"
 
 /**
  * Groups the 12 setconfig categories into themed sections so the custom
@@ -39,6 +45,7 @@ enum class WizardSection(
         categories = listOf(
             SectionCategory(SetConfigCommand.SUB_FEES, "Fees", "Loss tribute %, jackpot win %, Toby Coin trade fees"),
             SectionCategory(SetConfigCommand.SUB_JACKPOT, "Jackpot", "Stake anchor, cooldown, RTP gate, modlog channel"),
+            SectionCategory(JACKPOT_QUICK_CHANNELS_TOKEN, "Jackpot modlog channel", "Pick the casino modlog channel from a list (no IDs)"),
             SectionCategory(SetConfigCommand.SUB_STAKES, "Per-game stakes", "Min/max stake bounds (apply to all or drill down)"),
         ),
     ),
@@ -80,6 +87,7 @@ enum class WizardSection(
         categories = listOf(
             SectionCategory(SetConfigCommand.SUB_LOTTERY_BASICS, "Lottery basics", "On/off, ticket price, mode, ping"),
             SectionCategory(SetConfigCommand.SUB_LOTTERY_POOLS, "Lottery pools", "Seed/revenue split + announce channel"),
+            SectionCategory(LOTTERY_QUICK_CHANNELS_TOKEN, "Lottery announce channel", "Pick the announce channel from a list (no IDs)"),
         ),
     ),
     ;

--- a/discord-bot/src/main/kotlin/bot/toby/install/menu/InstallCategoryMenu.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/menu/InstallCategoryMenu.kt
@@ -4,9 +4,13 @@ import bot.toby.command.commands.moderation.SetConfigCommand
 import bot.toby.install.ConfigReader
 import bot.toby.install.InstallAuth
 import bot.toby.install.InstallWizard
+import bot.toby.install.JACKPOT_QUICK_CHANNELS_TOKEN
+import bot.toby.install.LOTTERY_QUICK_CHANNELS_TOKEN
 import bot.toby.install.QUICK_CHANNELS_TOKEN
 import bot.toby.install.WizardSection
 import bot.toby.install.modal.InstallAllStakesModal
+import bot.toby.install.modal.InstallJackpotChannelsModal
+import bot.toby.install.modal.InstallLotteryChannelsModal
 import bot.toby.install.modal.InstallQuickChannelsModal
 import bot.toby.modal.modals.setconfig.SetConfigActivityModal
 import bot.toby.modal.modals.setconfig.SetConfigBlackjackRulesModal
@@ -61,6 +65,8 @@ class InstallCategoryMenu(
     private val stakes: SetConfigStakesModal,
     private val allStakes: InstallAllStakesModal,
     quickChannels: InstallQuickChannelsModal,
+    jackpotChannels: InstallJackpotChannelsModal,
+    lotteryChannels: InstallLotteryChannelsModal,
 ) : Menu {
 
     override val name: String = InstallWizard.MENU_SECTION
@@ -78,6 +84,8 @@ class InstallCategoryMenu(
      */
     private val categoryActions: Map<String, CategoryAction> = mapOf(
         QUICK_CHANNELS_TOKEN to CategoryAction.OpenModal { _, _ -> quickChannels.buildModal() },
+        JACKPOT_QUICK_CHANNELS_TOKEN to CategoryAction.OpenModal { _, _ -> jackpotChannels.buildModal() },
+        LOTTERY_QUICK_CHANNELS_TOKEN to CategoryAction.OpenModal { _, _ -> lotteryChannels.buildModal() },
         SetConfigCommand.SUB_GENERAL to setconfigModal(general, SetConfigGeneralModal.MODAL_NAME),
         SetConfigCommand.SUB_ACTIVITY to setconfigModal(activity, SetConfigActivityModal.MODAL_NAME),
         SetConfigCommand.SUB_FEES to setconfigModal(fees, SetConfigFeesModal.MODAL_NAME),

--- a/discord-bot/src/main/kotlin/bot/toby/install/modal/InstallJackpotChannelsModal.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/modal/InstallJackpotChannelsModal.kt
@@ -1,0 +1,73 @@
+package bot.toby.install.modal
+
+import core.modal.Modal
+import core.modal.ModalContext
+import database.dto.ConfigDto.Configurations
+import database.service.ConfigService
+import net.dv8tion.jda.api.components.label.Label
+import net.dv8tion.jda.api.components.selections.EntitySelectMenu
+import net.dv8tion.jda.api.entities.channel.ChannelType
+import org.springframework.stereotype.Component
+import net.dv8tion.jda.api.modals.Modal as JdaModal
+
+/**
+ * Wizard-only single-channel-picker modal for the Jackpot section's
+ * casino modlog channel. Replaces typing a channel id into the bigger
+ * `setconfig_jackpot` modal — owners pick the channel from a list.
+ *
+ * Channel-only modals stay single-component-type
+ * ([EntitySelectMenu] in a [Label]) so Discord accepts the payload;
+ * mixing `TextInput` + `EntitySelectMenu` in one modal triggers
+ * client-side "Interaction failed".
+ *
+ * No selection = skip-write (matches the
+ * "blank means don't overwrite" convention used elsewhere in setconfig).
+ * If the picked channel has been deleted between modal open and submit,
+ * the write is rejected with no DB changes.
+ */
+@Component
+class InstallJackpotChannelsModal(
+    private val configService: ConfigService,
+) : Modal {
+
+    override val name: String = MODAL_NAME
+
+    fun buildModal(): JdaModal {
+        val menu = EntitySelectMenu.create(FIELD_MODLOG, EntitySelectMenu.SelectTarget.CHANNEL)
+            .setChannelTypes(ChannelType.TEXT)
+            .setRequiredRange(0, 1)
+            .build()
+        return JdaModal.create(MODAL_NAME, "Quick jackpot channel setup")
+            .addComponents(Label.of("Casino modlog channel", menu))
+            .build()
+    }
+
+    override fun handle(ctx: ModalContext, deleteDelay: Int) {
+        val event = ctx.event
+        val guild = ctx.guild
+        val guildId = guild.id
+
+        val modlogChannelId = event.getValue(FIELD_MODLOG)?.asLongList?.firstOrNull()
+        if (modlogChannelId == null) {
+            event.reply("No channel picked — nothing changed.").setEphemeral(true).queue()
+            return
+        }
+        val channel = guild.getTextChannelById(modlogChannelId)
+        if (channel == null) {
+            event.reply("Picked text channel no longer exists. No changes were written.")
+                .setEphemeral(true).queue()
+            return
+        }
+        configService.upsertAll(
+            guildId,
+            listOf(Configurations.CASINO_MODLOG_CHANNEL_ID.configValue to modlogChannelId.toString()),
+        )
+        event.reply("Saved:\n• Casino modlog channel → #${channel.name}")
+            .setEphemeral(true).queue()
+    }
+
+    companion object {
+        const val MODAL_NAME = "install_jackpot_channels"
+        const val FIELD_MODLOG = "modlog_channel"
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/install/modal/InstallLotteryChannelsModal.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/modal/InstallLotteryChannelsModal.kt
@@ -1,0 +1,67 @@
+package bot.toby.install.modal
+
+import core.modal.Modal
+import core.modal.ModalContext
+import database.dto.ConfigDto.Configurations
+import database.service.ConfigService
+import net.dv8tion.jda.api.components.label.Label
+import net.dv8tion.jda.api.components.selections.EntitySelectMenu
+import net.dv8tion.jda.api.entities.channel.ChannelType
+import org.springframework.stereotype.Component
+import net.dv8tion.jda.api.modals.Modal as JdaModal
+
+/**
+ * Wizard-only single-channel-picker modal for the Lottery section's
+ * announce channel. Mirrors [InstallJackpotChannelsModal] — owners
+ * pick the channel from a list instead of typing the id into the
+ * bigger `setconfig_lottery_pools` modal.
+ *
+ * See [InstallJackpotChannelsModal] for the design constraint that
+ * keeps these channel-only modals single-component-type.
+ */
+@Component
+class InstallLotteryChannelsModal(
+    private val configService: ConfigService,
+) : Modal {
+
+    override val name: String = MODAL_NAME
+
+    fun buildModal(): JdaModal {
+        val menu = EntitySelectMenu.create(FIELD_ANNOUNCE, EntitySelectMenu.SelectTarget.CHANNEL)
+            .setChannelTypes(ChannelType.TEXT)
+            .setRequiredRange(0, 1)
+            .build()
+        return JdaModal.create(MODAL_NAME, "Quick lottery channel setup")
+            .addComponents(Label.of("Lottery announce channel", menu))
+            .build()
+    }
+
+    override fun handle(ctx: ModalContext, deleteDelay: Int) {
+        val event = ctx.event
+        val guild = ctx.guild
+        val guildId = guild.id
+
+        val announceChannelId = event.getValue(FIELD_ANNOUNCE)?.asLongList?.firstOrNull()
+        if (announceChannelId == null) {
+            event.reply("No channel picked — nothing changed.").setEphemeral(true).queue()
+            return
+        }
+        val channel = guild.getTextChannelById(announceChannelId)
+        if (channel == null) {
+            event.reply("Picked text channel no longer exists. No changes were written.")
+                .setEphemeral(true).queue()
+            return
+        }
+        configService.upsertAll(
+            guildId,
+            listOf(Configurations.LOTTERY_CHANNEL.configValue to announceChannelId.toString()),
+        )
+        event.reply("Saved:\n• Lottery announce channel → #${channel.name}")
+            .setEphemeral(true).queue()
+    }
+
+    companion object {
+        const val MODAL_NAME = "install_lottery_channels"
+        const val FIELD_ANNOUNCE = "announce_channel"
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/install/InstallWizardTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/install/InstallWizardTest.kt
@@ -193,7 +193,11 @@ internal class InstallWizardTest {
             SetConfigCommand.SUB_LOTTERY_BASICS, SetConfigCommand.SUB_LOTTERY_POOLS,
             SetConfigCommand.SUB_STAKES,
         )
-        val wizardInternal = setOf(bot.toby.install.QUICK_CHANNELS_TOKEN)
+        val wizardInternal = setOf(
+            bot.toby.install.QUICK_CHANNELS_TOKEN,
+            bot.toby.install.JACKPOT_QUICK_CHANNELS_TOKEN,
+            bot.toby.install.LOTTERY_QUICK_CHANNELS_TOKEN,
+        )
         WizardSection.entries.flatMap { it.categories }.forEach { cat ->
             assertTrue(
                 knownSubs.contains(cat.token) || wizardInternal.contains(cat.token),

--- a/discord-bot/src/test/kotlin/bot/toby/install/WizardSectionTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/install/WizardSectionTest.kt
@@ -89,6 +89,24 @@ internal class WizardSectionTest {
     }
 
     @Test
+    fun `economy section exposes the jackpot quick-channels entry`() {
+        val tokens = WizardSection.ECONOMY.categories.map { it.token }
+        assertTrue(
+            tokens.contains(JACKPOT_QUICK_CHANNELS_TOKEN),
+            "jackpot_quick_channels missing from Economy section",
+        )
+    }
+
+    @Test
+    fun `lottery section exposes the lottery quick-channels entry`() {
+        val tokens = WizardSection.LOTTERY.categories.map { it.token }
+        assertTrue(
+            tokens.contains(LOTTERY_QUICK_CHANNELS_TOKEN),
+            "lottery_quick_channels missing from Lottery section",
+        )
+    }
+
+    @Test
     fun `general section exposes the quick-channels entry`() {
         val tokens = WizardSection.GENERAL.categories.map { it.token }
         assertTrue(tokens.contains(QUICK_CHANNELS_TOKEN), "quick_channels missing from General section")

--- a/discord-bot/src/test/kotlin/bot/toby/install/menu/InstallCategoryMenuTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/install/menu/InstallCategoryMenuTest.kt
@@ -2,9 +2,13 @@ package bot.toby.install.menu
 
 import bot.toby.command.commands.moderation.SetConfigCommand
 import bot.toby.install.InstallWizard
+import bot.toby.install.JACKPOT_QUICK_CHANNELS_TOKEN
+import bot.toby.install.LOTTERY_QUICK_CHANNELS_TOKEN
 import bot.toby.install.QUICK_CHANNELS_TOKEN
 import bot.toby.install.WizardSection
 import bot.toby.install.modal.InstallAllStakesModal
+import bot.toby.install.modal.InstallJackpotChannelsModal
+import bot.toby.install.modal.InstallLotteryChannelsModal
 import bot.toby.install.modal.InstallQuickChannelsModal
 import bot.toby.modal.modals.setconfig.SetConfigActivityModal
 import bot.toby.modal.modals.setconfig.SetConfigBlackjackRulesModal
@@ -72,6 +76,8 @@ internal class InstallCategoryMenuTest {
     private lateinit var stakes: SetConfigStakesModal
     private lateinit var allStakes: InstallAllStakesModal
     private lateinit var quickChannels: InstallQuickChannelsModal
+    private lateinit var jackpotChannels: InstallJackpotChannelsModal
+    private lateinit var lotteryChannels: InstallLotteryChannelsModal
     private lateinit var menu: InstallCategoryMenu
 
     private lateinit var event: StringSelectInteractionEvent
@@ -99,11 +105,14 @@ internal class InstallCategoryMenuTest {
         stakes = mockk(relaxed = true)
         allStakes = mockk(relaxed = true)
         quickChannels = mockk(relaxed = true)
+        jackpotChannels = mockk(relaxed = true)
+        lotteryChannels = mockk(relaxed = true)
         menu = InstallCategoryMenu(
             configService,
             general, activity, fees, jackpot, jackpotActivity,
             pokerStakes, pokerTable, blackjackRules, blackjackTable,
-            lotteryBasics, lotteryPools, stakes, allStakes, quickChannels,
+            lotteryBasics, lotteryPools, stakes, allStakes,
+            quickChannels, jackpotChannels, lotteryChannels,
         )
 
         event = mockk(relaxed = true)
@@ -527,6 +536,41 @@ internal class InstallCategoryMenuTest {
         val modalSlot = slot<Modal>()
         verify(exactly = 1) { event.replyModal(capture(modalSlot)) }
         assertEquals(expectedId, modalSlot.captured.id)
+    }
+
+    @Test
+    fun `jackpot_quick_channels token opens the jackpot channels modal`() {
+        val expectedId = InstallJackpotChannelsModal.MODAL_NAME
+        val built = mockk<Modal>(relaxed = true) { every { id } returns expectedId }
+        every { jackpotChannels.buildModal() } returns built
+        every { event.componentId } returns InstallWizard.sectionDetailMenuId(WizardSection.ECONOMY.id)
+        every { event.selectedOptions } returns listOf(SelectOption.of("x", JACKPOT_QUICK_CHANNELS_TOKEN))
+
+        menu.handle(ctx, 0)
+
+        val modalSlot = slot<Modal>()
+        verify(exactly = 1) { event.replyModal(capture(modalSlot)) }
+        assertEquals(expectedId, modalSlot.captured.id)
+        // The siblings must not have been opened.
+        verify(exactly = 0) { quickChannels.buildModal() }
+        verify(exactly = 0) { lotteryChannels.buildModal() }
+    }
+
+    @Test
+    fun `lottery_quick_channels token opens the lottery channels modal`() {
+        val expectedId = InstallLotteryChannelsModal.MODAL_NAME
+        val built = mockk<Modal>(relaxed = true) { every { id } returns expectedId }
+        every { lotteryChannels.buildModal() } returns built
+        every { event.componentId } returns InstallWizard.sectionDetailMenuId(WizardSection.LOTTERY.id)
+        every { event.selectedOptions } returns listOf(SelectOption.of("x", LOTTERY_QUICK_CHANNELS_TOKEN))
+
+        menu.handle(ctx, 0)
+
+        val modalSlot = slot<Modal>()
+        verify(exactly = 1) { event.replyModal(capture(modalSlot)) }
+        assertEquals(expectedId, modalSlot.captured.id)
+        verify(exactly = 0) { quickChannels.buildModal() }
+        verify(exactly = 0) { jackpotChannels.buildModal() }
     }
 
     @Test

--- a/discord-bot/src/test/kotlin/bot/toby/install/modal/InstallJackpotChannelsModalTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/install/modal/InstallJackpotChannelsModalTest.kt
@@ -1,0 +1,119 @@
+package bot.toby.install.modal
+
+import core.modal.ModalContext
+import database.dto.ConfigDto.Configurations
+import database.service.ConfigService
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
+import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent
+import net.dv8tion.jda.api.interactions.modals.ModalMapping
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class InstallJackpotChannelsModalTest {
+
+    private lateinit var configService: ConfigService
+    private lateinit var modal: InstallJackpotChannelsModal
+    private lateinit var event: ModalInteractionEvent
+    private lateinit var ctx: ModalContext
+    private lateinit var guild: Guild
+
+    @BeforeEach
+    fun setUp() {
+        configService = mockk(relaxed = true)
+        modal = InstallJackpotChannelsModal(configService)
+        event = mockk(relaxed = true)
+        guild = mockk(relaxed = true) { every { id } returns "g1" }
+        ctx = mockk {
+            every { this@mockk.event } returns this@InstallJackpotChannelsModalTest.event
+            every { this@mockk.guild } returns this@InstallJackpotChannelsModalTest.guild
+        }
+        every { event.reply(any<String>()) } returns mockk(relaxed = true) {
+            every { setEphemeral(any()) } returns this
+            every { queue() } just Runs
+        }
+        every { event.getValue(any<String>()) } returns null
+    }
+
+    private fun stubChannelPick(channelId: Long) {
+        every { event.getValue(InstallJackpotChannelsModal.FIELD_MODLOG) } returns mockk<ModalMapping> {
+            every { asLongList } returns listOf(channelId)
+        }
+    }
+
+    @Test
+    fun `name and modal id constants align`() {
+        assertEquals(InstallJackpotChannelsModal.MODAL_NAME, modal.name)
+        assertEquals("install_jackpot_channels", InstallJackpotChannelsModal.MODAL_NAME)
+    }
+
+    @Test
+    fun `buildModal returns a JDA modal with the right id`() {
+        val built = modal.buildModal()
+        assertEquals(InstallJackpotChannelsModal.MODAL_NAME, built.id)
+        assertNotNull(built.title)
+    }
+
+    @Test
+    fun `no selection replies nothing changed and writes nothing`() {
+        modal.handle(ctx, 0)
+
+        verify(exactly = 1) { event.reply(match<String> { it.contains("nothing changed", ignoreCase = true) }) }
+        verify(exactly = 0) { configService.upsertAll(any(), any()) }
+        verify(exactly = 0) {
+            configService.upsertConfig(any<String>(), any<String>(), any<String>())
+        }
+    }
+
+    @Test
+    fun `picked channel writes CASINO_MODLOG_CHANNEL_ID via batch upsert`() {
+        val textChannel = mockk<TextChannel> { every { name } returns "mod-log" }
+        stubChannelPick(67890L)
+        every { guild.getTextChannelById(67890L) } returns textChannel
+        val rowsSlot = slot<List<Pair<String, String>>>()
+        every { configService.upsertAll("g1", capture(rowsSlot)) } returns emptyList()
+
+        modal.handle(ctx, 0)
+
+        verify(exactly = 1) { configService.upsertAll("g1", any()) }
+        assertEquals(
+            listOf(Configurations.CASINO_MODLOG_CHANNEL_ID.configValue to "67890"),
+            rowsSlot.captured,
+        )
+    }
+
+    @Test
+    fun `picked channel no longer exists rejects without writes`() {
+        stubChannelPick(999L)
+        every { guild.getTextChannelById(999L) } returns null
+
+        modal.handle(ctx, 0)
+
+        verify(exactly = 1) { event.reply(match<String> { it.contains("no longer exists") }) }
+        verify(exactly = 0) { configService.upsertAll(any(), any()) }
+        verify(exactly = 0) {
+            configService.upsertConfig(any<String>(), any<String>(), any<String>())
+        }
+    }
+
+    @Test
+    fun `successful save replies with summary listing the channel name`() {
+        val channel = mockk<TextChannel> { every { name } returns "mod-log" }
+        stubChannelPick(10L)
+        every { guild.getTextChannelById(10L) } returns channel
+
+        modal.handle(ctx, 0)
+
+        verify(exactly = 1) {
+            event.reply(match<String> { it.contains("mod-log") })
+        }
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/install/modal/InstallLotteryChannelsModalTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/install/modal/InstallLotteryChannelsModalTest.kt
@@ -1,0 +1,119 @@
+package bot.toby.install.modal
+
+import core.modal.ModalContext
+import database.dto.ConfigDto.Configurations
+import database.service.ConfigService
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
+import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent
+import net.dv8tion.jda.api.interactions.modals.ModalMapping
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class InstallLotteryChannelsModalTest {
+
+    private lateinit var configService: ConfigService
+    private lateinit var modal: InstallLotteryChannelsModal
+    private lateinit var event: ModalInteractionEvent
+    private lateinit var ctx: ModalContext
+    private lateinit var guild: Guild
+
+    @BeforeEach
+    fun setUp() {
+        configService = mockk(relaxed = true)
+        modal = InstallLotteryChannelsModal(configService)
+        event = mockk(relaxed = true)
+        guild = mockk(relaxed = true) { every { id } returns "g1" }
+        ctx = mockk {
+            every { this@mockk.event } returns this@InstallLotteryChannelsModalTest.event
+            every { this@mockk.guild } returns this@InstallLotteryChannelsModalTest.guild
+        }
+        every { event.reply(any<String>()) } returns mockk(relaxed = true) {
+            every { setEphemeral(any()) } returns this
+            every { queue() } just Runs
+        }
+        every { event.getValue(any<String>()) } returns null
+    }
+
+    private fun stubChannelPick(channelId: Long) {
+        every { event.getValue(InstallLotteryChannelsModal.FIELD_ANNOUNCE) } returns mockk<ModalMapping> {
+            every { asLongList } returns listOf(channelId)
+        }
+    }
+
+    @Test
+    fun `name and modal id constants align`() {
+        assertEquals(InstallLotteryChannelsModal.MODAL_NAME, modal.name)
+        assertEquals("install_lottery_channels", InstallLotteryChannelsModal.MODAL_NAME)
+    }
+
+    @Test
+    fun `buildModal returns a JDA modal with the right id`() {
+        val built = modal.buildModal()
+        assertEquals(InstallLotteryChannelsModal.MODAL_NAME, built.id)
+        assertNotNull(built.title)
+    }
+
+    @Test
+    fun `no selection replies nothing changed and writes nothing`() {
+        modal.handle(ctx, 0)
+
+        verify(exactly = 1) { event.reply(match<String> { it.contains("nothing changed", ignoreCase = true) }) }
+        verify(exactly = 0) { configService.upsertAll(any(), any()) }
+        verify(exactly = 0) {
+            configService.upsertConfig(any<String>(), any<String>(), any<String>())
+        }
+    }
+
+    @Test
+    fun `picked channel writes LOTTERY_CHANNEL via batch upsert`() {
+        val textChannel = mockk<TextChannel> { every { name } returns "lottery-announce" }
+        stubChannelPick(54321L)
+        every { guild.getTextChannelById(54321L) } returns textChannel
+        val rowsSlot = slot<List<Pair<String, String>>>()
+        every { configService.upsertAll("g1", capture(rowsSlot)) } returns emptyList()
+
+        modal.handle(ctx, 0)
+
+        verify(exactly = 1) { configService.upsertAll("g1", any()) }
+        assertEquals(
+            listOf(Configurations.LOTTERY_CHANNEL.configValue to "54321"),
+            rowsSlot.captured,
+        )
+    }
+
+    @Test
+    fun `picked channel no longer exists rejects without writes`() {
+        stubChannelPick(999L)
+        every { guild.getTextChannelById(999L) } returns null
+
+        modal.handle(ctx, 0)
+
+        verify(exactly = 1) { event.reply(match<String> { it.contains("no longer exists") }) }
+        verify(exactly = 0) { configService.upsertAll(any(), any()) }
+        verify(exactly = 0) {
+            configService.upsertConfig(any<String>(), any<String>(), any<String>())
+        }
+    }
+
+    @Test
+    fun `successful save replies with summary listing the channel name`() {
+        val channel = mockk<TextChannel> { every { name } returns "lottery-announce" }
+        stubChannelPick(7L)
+        every { guild.getTextChannelById(7L) } returns channel
+
+        modal.handle(ctx, 0)
+
+        verify(exactly = 1) {
+            event.reply(match<String> { it.contains("lottery-announce") })
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to the revert PR. The General section already has a "Quick channels" entry (Move + Leaderboard channel pickers via `InstallQuickChannelsModal`). This adds the same UX to the Jackpot and Lottery sections so owners never have to type a channel ID anywhere in the wizard.

> **Stacks on top of #542** (the revert). Merge that one first; this PR is independent of its content but its branch was created from #542 to avoid conflicts.

### New modals

| Modal | Section | Writes |
|---|---|---|
| `InstallJackpotChannelsModal` | Economy → "Jackpot modlog channel" | `CASINO_MODLOG_CHANNEL_ID` |
| `InstallLotteryChannelsModal` | Daily lottery → "Lottery announce channel" | `LOTTERY_CHANNEL` |

Both follow the `InstallQuickChannelsModal` pattern: single-component-type (`EntitySelectMenu` in a `Label`), which Discord accepts. Mixing `TextInput` + `EntitySelectMenu` in one modal is what broke the previous attempt; channel-only modals dodge the issue.

Behaviour matches the existing General Quick Channels:
- No selection → "nothing changed" reply, zero writes
- Channel deleted between open and submit → ephemeral rejection, zero writes
- Successful pick → `upsertAll` batches the single row, summary reply

### Tests

- `InstallJackpotChannelsModalTest` + `InstallLotteryChannelsModalTest` — 6 tests each, mirroring `InstallQuickChannelsModalTest` shape (id constants, buildModal id, no-selection, happy path, stale-channel rejection, success summary).
- `InstallCategoryMenuTest` extended:
  - `jackpot_quick_channels` token routes to `InstallJackpotChannelsModal`
  - `lottery_quick_channels` token routes to `InstallLotteryChannelsModal`
  - Each verifies sibling modals are **not** opened (catches a wiring swap).
- `WizardSectionTest` extended: Economy and Lottery sections expose their respective quick-channels entries.
- `InstallWizardTest` "every category token is known" allowlist extended for the two new tokens.

## Test plan

- [x] `./gradlew :discord-bot:test --tests "bot.toby.install.*"` — 169/169 pass
- [x] `./gradlew :discord-bot:test --tests "*SetConfig*"` — pass
- [x] `./gradlew :web:test` — pass
- [ ] Manual smoke in a sandbox guild:
  - `/install` → Custom → **Economy & casino** → "Jackpot modlog channel" → modal opens with a single text-channel picker; pick a channel; submit → DB shows `CASINO_MODLOG_CHANNEL_ID=<id>`
  - `/install` → Custom → **Daily lottery** → "Lottery announce channel" → modal opens with a single text-channel picker; pick; submit → DB shows `LOTTERY_CHANNEL=<id>`
  - Submitting with no pick on either → ephemeral "nothing changed", no DB writes

https://claude.ai/code/session_01NHhBfrbNQEDVrsGovXzyGD

---
_Generated by [Claude Code](https://claude.ai/code/session_01NHhBfrbNQEDVrsGovXzyGD)_