### PR TITLE
fix(install): channel picker modals — min_values=1, plus Activity announce channels

### DIFF
--- a/discord-bot/src/main/kotlin/bot/toby/install/WizardSection.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/WizardSection.kt
@@ -11,6 +11,9 @@ const val JACKPOT_QUICK_CHANNELS_TOKEN = "jackpot_quick_channels"
 /** Synthetic category token for the Lottery section's Quick channels modal (`InstallLotteryChannelsModal`). */
 const val LOTTERY_QUICK_CHANNELS_TOKEN = "lottery_quick_channels"
 
+/** Synthetic category token for the Activity section's Quick channels modal (`InstallActivityChannelsModal`). */
+const val ACTIVITY_QUICK_CHANNELS_TOKEN = "activity_quick_channels"
+
 /**
  * Groups the 12 setconfig categories into themed sections so the custom
  * install flow is two-clicks-to-modal instead of a 13-deep dropdown.
@@ -57,6 +60,7 @@ enum class WizardSection(
         categories = listOf(
             SectionCategory(SetConfigCommand.SUB_ACTIVITY, "Activity config", "UBI, daily credit cap, XP bonus, tracking toggle"),
             SectionCategory(SetConfigCommand.SUB_JACKPOT_ACTIVITY, "Jackpot eligibility", "Activity-day window"),
+            SectionCategory(ACTIVITY_QUICK_CHANNELS_TOKEN, "Announce channels", "Pick level-up + achievement channels from a list (no IDs)"),
         ),
     ),
     POKER(

--- a/discord-bot/src/main/kotlin/bot/toby/install/menu/InstallCategoryMenu.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/menu/InstallCategoryMenu.kt
@@ -4,10 +4,12 @@ import bot.toby.command.commands.moderation.SetConfigCommand
 import bot.toby.install.ConfigReader
 import bot.toby.install.InstallAuth
 import bot.toby.install.InstallWizard
+import bot.toby.install.ACTIVITY_QUICK_CHANNELS_TOKEN
 import bot.toby.install.JACKPOT_QUICK_CHANNELS_TOKEN
 import bot.toby.install.LOTTERY_QUICK_CHANNELS_TOKEN
 import bot.toby.install.QUICK_CHANNELS_TOKEN
 import bot.toby.install.WizardSection
+import bot.toby.install.modal.InstallActivityChannelsModal
 import bot.toby.install.modal.InstallAllStakesModal
 import bot.toby.install.modal.InstallJackpotChannelsModal
 import bot.toby.install.modal.InstallLotteryChannelsModal
@@ -67,6 +69,7 @@ class InstallCategoryMenu(
     quickChannels: InstallQuickChannelsModal,
     jackpotChannels: InstallJackpotChannelsModal,
     lotteryChannels: InstallLotteryChannelsModal,
+    activityChannels: InstallActivityChannelsModal,
 ) : Menu {
 
     override val name: String = InstallWizard.MENU_SECTION
@@ -86,6 +89,7 @@ class InstallCategoryMenu(
         QUICK_CHANNELS_TOKEN to CategoryAction.OpenModal { _, _ -> quickChannels.buildModal() },
         JACKPOT_QUICK_CHANNELS_TOKEN to CategoryAction.OpenModal { _, _ -> jackpotChannels.buildModal() },
         LOTTERY_QUICK_CHANNELS_TOKEN to CategoryAction.OpenModal { _, _ -> lotteryChannels.buildModal() },
+        ACTIVITY_QUICK_CHANNELS_TOKEN to CategoryAction.OpenModal { _, _ -> activityChannels.buildModal() },
         SetConfigCommand.SUB_GENERAL to setconfigModal(general, SetConfigGeneralModal.MODAL_NAME),
         SetConfigCommand.SUB_ACTIVITY to setconfigModal(activity, SetConfigActivityModal.MODAL_NAME),
         SetConfigCommand.SUB_FEES to setconfigModal(fees, SetConfigFeesModal.MODAL_NAME),

--- a/discord-bot/src/main/kotlin/bot/toby/install/menu/InstallCategoryMenu.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/menu/InstallCategoryMenu.kt
@@ -214,20 +214,32 @@ class InstallCategoryMenu(
     }
 
     /**
-     * Open [modal] and, once it's open, rearm the message back to the
-     * [section]'s detail menu so the owner can pick another category in
-     * the same section without re-navigating.
+     * Open [modal] and rearm the message back to the [section]'s detail
+     * menu so the owner can pick another category in the same section
+     * without re-navigating.
+     *
+     * The rearm is queued **before** `replyModal` (not in its callback)
+     * so the rearm PATCH sits next to the manager's disable PATCH
+     * (`DefaultMenuManager.handle:38`) on the same channel-message
+     * rate-limit bucket. JDA serializes the bucket FIFO: disable lands
+     * first, rearm lands second, rearm wins.
+     *
+     * Doing the rearm inside `replyModal.queue { ... }` waits one
+     * interaction-callback RTT before queuing the rearm. On mobile,
+     * dismissing the modal via the phone-back gesture in that window
+     * lets the disable propagate to the client over the gateway before
+     * the rearm does — leaving the dropdown + Back/Finish row visually
+     * locked until the next message refresh.
      */
     private fun openModalAndRearm(ctx: MenuContext, section: WizardSection, modal: Modal) {
         val event = ctx.event
-        event.replyModal(modal).queue {
-            event.message.editMessageEmbeds(InstallWizard.sectionDetailEmbed(section))
-                .setComponents(
-                    ActionRow.of(InstallWizard.sectionDetailMenu(section)),
-                    InstallWizard.backAndFinishRow(),
-                )
-                .queue()
-        }
+        event.message.editMessageEmbeds(InstallWizard.sectionDetailEmbed(section))
+            .setComponents(
+                ActionRow.of(InstallWizard.sectionDetailMenu(section)),
+                InstallWizard.backAndFinishRow(),
+            )
+            .queue()
+        event.replyModal(modal).queue()
     }
 
     private sealed interface CategoryAction {

--- a/discord-bot/src/main/kotlin/bot/toby/install/modal/InstallActivityChannelsModal.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/modal/InstallActivityChannelsModal.kt
@@ -1,0 +1,100 @@
+package bot.toby.install.modal
+
+import core.modal.Modal
+import core.modal.ModalContext
+import database.dto.ConfigDto.Configurations
+import database.service.ConfigService
+import net.dv8tion.jda.api.components.label.Label
+import net.dv8tion.jda.api.components.selections.EntitySelectMenu
+import net.dv8tion.jda.api.entities.channel.ChannelType
+import org.springframework.stereotype.Component
+import net.dv8tion.jda.api.modals.Modal as JdaModal
+
+/**
+ * Wizard-only modal that surfaces the Activity section's two
+ * announcement channels — `LEVEL_UP_CHANNEL` and
+ * `ACHIEVEMENT_ANNOUNCE_CHANNEL` — as native channel pickers. Neither
+ * key has a `setconfig` field today, so this modal is the only way to
+ * set them without SQL.
+ *
+ * Both channels are optional: when unset, the consuming services fall
+ * back gracefully (level-up: message/system channel; achievement:
+ * silent). To clear an override, an owner edits via SQL — the picker
+ * UX is for the 99% case of "set it to this channel".
+ *
+ * See [InstallJackpotChannelsModal] for the design constraint that
+ * keeps these channel-only modals single-component-type, and for the
+ * `setRequiredRange(1, 1)` requirement Discord imposes on
+ * `Label`-wrapped select menus.
+ */
+@Component
+class InstallActivityChannelsModal(
+    private val configService: ConfigService,
+) : Modal {
+
+    override val name: String = MODAL_NAME
+
+    fun buildModal(): JdaModal {
+        val levelUpMenu = EntitySelectMenu.create(FIELD_LEVEL_UP, EntitySelectMenu.SelectTarget.CHANNEL)
+            .setChannelTypes(ChannelType.TEXT)
+            .setRequiredRange(1, 1)
+            .build()
+        val achievementMenu = EntitySelectMenu.create(FIELD_ACHIEVEMENT, EntitySelectMenu.SelectTarget.CHANNEL)
+            .setChannelTypes(ChannelType.TEXT)
+            .setRequiredRange(1, 1)
+            .build()
+        return JdaModal.create(MODAL_NAME, "Quick activity channel setup")
+            .addComponents(
+                Label.of("Level-up announce channel", levelUpMenu),
+                Label.of("Achievement announce channel", achievementMenu),
+            )
+            .build()
+    }
+
+    override fun handle(ctx: ModalContext, deleteDelay: Int) {
+        val event = ctx.event
+        val guild = ctx.guild
+        val guildId = guild.id
+
+        val rows = mutableListOf<Pair<String, String>>()
+        val written = mutableListOf<String>()
+
+        val levelUpId = event.getValue(FIELD_LEVEL_UP)?.asLongList?.firstOrNull()
+        if (levelUpId != null) {
+            val channel = guild.getTextChannelById(levelUpId)
+            if (channel == null) {
+                event.reply("Picked level-up channel no longer exists. No changes were written.")
+                    .setEphemeral(true).queue()
+                return
+            }
+            rows += Configurations.LEVEL_UP_CHANNEL.configValue to levelUpId.toString()
+            written += "Level-up channel → #${channel.name}"
+        }
+
+        val achievementId = event.getValue(FIELD_ACHIEVEMENT)?.asLongList?.firstOrNull()
+        if (achievementId != null) {
+            val channel = guild.getTextChannelById(achievementId)
+            if (channel == null) {
+                event.reply("Picked achievement channel no longer exists. No changes were written.")
+                    .setEphemeral(true).queue()
+                return
+            }
+            rows += Configurations.ACHIEVEMENT_ANNOUNCE_CHANNEL.configValue to achievementId.toString()
+            written += "Achievement channel → #${channel.name}"
+        }
+
+        if (rows.isEmpty()) {
+            event.reply("No channels picked — nothing changed.").setEphemeral(true).queue()
+            return
+        }
+        configService.upsertAll(guildId, rows)
+        event.reply("Saved:\n" + written.joinToString("\n") { "• $it" })
+            .setEphemeral(true).queue()
+    }
+
+    companion object {
+        const val MODAL_NAME = "install_activity_channels"
+        const val FIELD_LEVEL_UP = "level_up_channel"
+        const val FIELD_ACHIEVEMENT = "achievement_channel"
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/install/modal/InstallJackpotChannelsModal.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/modal/InstallJackpotChannelsModal.kt
@@ -20,10 +20,16 @@ import net.dv8tion.jda.api.modals.Modal as JdaModal
  * mixing `TextInput` + `EntitySelectMenu` in one modal triggers
  * client-side "Interaction failed".
  *
- * No selection = skip-write (matches the
- * "blank means don't overwrite" convention used elsewhere in setconfig).
- * If the picked channel has been deleted between modal open and submit,
- * the write is rejected with no DB changes.
+ * The picker uses `setRequiredRange(1, 1)`: Discord rejects a
+ * `Label`-wrapped select menu with `min_values=0` (Label children are
+ * implicitly required, and the API enforces this with
+ * `COMPONENT_REQUIRED_ZERO_MIN_VALUES`). Owners must pick a channel
+ * or cancel the modal (X / Esc) to back out without writing.
+ *
+ * The "no selection" defensive branch in [handle] is unreachable in
+ * normal use but kept as a no-op fallback. If the picked channel has
+ * been deleted between modal open and submit, the write is rejected
+ * with no DB changes.
  */
 @Component
 class InstallJackpotChannelsModal(
@@ -35,7 +41,7 @@ class InstallJackpotChannelsModal(
     fun buildModal(): JdaModal {
         val menu = EntitySelectMenu.create(FIELD_MODLOG, EntitySelectMenu.SelectTarget.CHANNEL)
             .setChannelTypes(ChannelType.TEXT)
-            .setRequiredRange(0, 1)
+            .setRequiredRange(1, 1)
             .build()
         return JdaModal.create(MODAL_NAME, "Quick jackpot channel setup")
             .addComponents(Label.of("Casino modlog channel", menu))

--- a/discord-bot/src/main/kotlin/bot/toby/install/modal/InstallLotteryChannelsModal.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/modal/InstallLotteryChannelsModal.kt
@@ -17,7 +17,9 @@ import net.dv8tion.jda.api.modals.Modal as JdaModal
  * bigger `setconfig_lottery_pools` modal.
  *
  * See [InstallJackpotChannelsModal] for the design constraint that
- * keeps these channel-only modals single-component-type.
+ * keeps these channel-only modals single-component-type and for the
+ * `setRequiredRange(1, 1)` requirement Discord imposes on
+ * `Label`-wrapped select menus.
  */
 @Component
 class InstallLotteryChannelsModal(
@@ -29,7 +31,7 @@ class InstallLotteryChannelsModal(
     fun buildModal(): JdaModal {
         val menu = EntitySelectMenu.create(FIELD_ANNOUNCE, EntitySelectMenu.SelectTarget.CHANNEL)
             .setChannelTypes(ChannelType.TEXT)
-            .setRequiredRange(0, 1)
+            .setRequiredRange(1, 1)
             .build()
         return JdaModal.create(MODAL_NAME, "Quick lottery channel setup")
             .addComponents(Label.of("Lottery announce channel", menu))

--- a/discord-bot/src/main/kotlin/bot/toby/install/modal/InstallQuickChannelsModal.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/install/modal/InstallQuickChannelsModal.kt
@@ -20,6 +20,14 @@ import net.dv8tion.jda.api.modals.Modal as JdaModal
  * Discord modals support select menus inside `Label` since the late
  * 2024 components-v2 API; JDA 6.3 exposes this via `Label.of(name, menu)`.
  *
+ * Discord rejects modal payloads where a `Label`-wrapped select menu
+ * has `min_values=0` (Label children are implicitly required, and
+ * required + min=0 is a contradiction the API enforces with
+ * `COMPONENT_REQUIRED_ZERO_MIN_VALUES`). Both pickers therefore use
+ * `setRequiredRange(1, 1)`: owners must pick a channel for each
+ * picker shown, or cancel the modal (X / Esc) to back out without
+ * writing anything.
+ *
  * On submit:
  * - The voice channel selection's *name* is written to
  *   `DEFAULT_MOVE_CHANNEL` (matches the existing
@@ -27,8 +35,9 @@ import net.dv8tion.jda.api.modals.Modal as JdaModal
  * - The text channel selection's *id* is written to
  *   `LEADERBOARD_CHANNEL` (matches `ChannelByIdStoreId`).
  *
- * Either field can be left empty (no selection); empty selections skip
- * the write.
+ * The "no selection" branches in [handle] are defensive — Discord
+ * shouldn't deliver such a payload given `min=1`, but the bot no-ops
+ * cleanly rather than crashing if one ever arrives.
  */
 @Component
 class InstallQuickChannelsModal(
@@ -40,11 +49,11 @@ class InstallQuickChannelsModal(
     fun buildModal(): JdaModal {
         val moveMenu = EntitySelectMenu.create(FIELD_MOVE, EntitySelectMenu.SelectTarget.CHANNEL)
             .setChannelTypes(ChannelType.VOICE)
-            .setRequiredRange(0, 1)
+            .setRequiredRange(1, 1)
             .build()
         val leaderboardMenu = EntitySelectMenu.create(FIELD_LEADERBOARD, EntitySelectMenu.SelectTarget.CHANNEL)
             .setChannelTypes(ChannelType.TEXT)
-            .setRequiredRange(0, 1)
+            .setRequiredRange(1, 1)
             .build()
         return JdaModal.create(MODAL_NAME, "Quick channel setup")
             .addComponents(

--- a/discord-bot/src/test/kotlin/bot/toby/install/InstallWizardTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/install/InstallWizardTest.kt
@@ -197,6 +197,7 @@ internal class InstallWizardTest {
             bot.toby.install.QUICK_CHANNELS_TOKEN,
             bot.toby.install.JACKPOT_QUICK_CHANNELS_TOKEN,
             bot.toby.install.LOTTERY_QUICK_CHANNELS_TOKEN,
+            bot.toby.install.ACTIVITY_QUICK_CHANNELS_TOKEN,
         )
         WizardSection.entries.flatMap { it.categories }.forEach { cat ->
             assertTrue(

--- a/discord-bot/src/test/kotlin/bot/toby/install/menu/InstallCategoryMenuTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/install/menu/InstallCategoryMenuTest.kt
@@ -605,4 +605,27 @@ internal class InstallCategoryMenuTest {
         verify(exactly = 1) { event.reply(any<String>()) }
         verify(exactly = 0) { event.replyModal(any<Modal>()) }
     }
+
+    @Test
+    fun `category pick rearms the section detail row before queuing replyModal`() {
+        // Regression: on mobile, dismissing the modal via phone-back used to
+        // leave the dropdown + Back/Finish row visually locked. Cause: rearm
+        // was queued inside replyModal.queue { ... }, one interaction-callback
+        // RTT after the manager's disable PATCH (DefaultMenuManager:38). If
+        // the user dismissed the modal in that window, the disable
+        // MESSAGE_UPDATE propagated to their client over the gateway before
+        // the rearm did. Fix: queue the rearm first so both PATCHes ride the
+        // same channel-message rate-limit bucket FIFO — disable, then rearm.
+        every { general.buildModal(SetConfigGeneralModal.MODAL_NAME, any(), any()) } returns
+            mockk<Modal>(relaxed = true) { every { id } returns SetConfigGeneralModal.MODAL_NAME }
+        every { event.componentId } returns InstallWizard.sectionDetailMenuId(WizardSection.GENERAL.id)
+        every { event.selectedOptions } returns listOf(SelectOption.of("x", SetConfigCommand.SUB_GENERAL))
+
+        menu.handle(ctx, 0)
+
+        verifyOrder {
+            message.editMessageEmbeds(any<MessageEmbed>())
+            event.replyModal(any<Modal>())
+        }
+    }
 }

--- a/discord-bot/src/test/kotlin/bot/toby/install/menu/InstallCategoryMenuTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/install/menu/InstallCategoryMenuTest.kt
@@ -1,11 +1,13 @@
 package bot.toby.install.menu
 
 import bot.toby.command.commands.moderation.SetConfigCommand
+import bot.toby.install.ACTIVITY_QUICK_CHANNELS_TOKEN
 import bot.toby.install.InstallWizard
 import bot.toby.install.JACKPOT_QUICK_CHANNELS_TOKEN
 import bot.toby.install.LOTTERY_QUICK_CHANNELS_TOKEN
 import bot.toby.install.QUICK_CHANNELS_TOKEN
 import bot.toby.install.WizardSection
+import bot.toby.install.modal.InstallActivityChannelsModal
 import bot.toby.install.modal.InstallAllStakesModal
 import bot.toby.install.modal.InstallJackpotChannelsModal
 import bot.toby.install.modal.InstallLotteryChannelsModal
@@ -78,6 +80,7 @@ internal class InstallCategoryMenuTest {
     private lateinit var quickChannels: InstallQuickChannelsModal
     private lateinit var jackpotChannels: InstallJackpotChannelsModal
     private lateinit var lotteryChannels: InstallLotteryChannelsModal
+    private lateinit var activityChannels: InstallActivityChannelsModal
     private lateinit var menu: InstallCategoryMenu
 
     private lateinit var event: StringSelectInteractionEvent
@@ -107,12 +110,13 @@ internal class InstallCategoryMenuTest {
         quickChannels = mockk(relaxed = true)
         jackpotChannels = mockk(relaxed = true)
         lotteryChannels = mockk(relaxed = true)
+        activityChannels = mockk(relaxed = true)
         menu = InstallCategoryMenu(
             configService,
             general, activity, fees, jackpot, jackpotActivity,
             pokerStakes, pokerTable, blackjackRules, blackjackTable,
             lotteryBasics, lotteryPools, stakes, allStakes,
-            quickChannels, jackpotChannels, lotteryChannels,
+            quickChannels, jackpotChannels, lotteryChannels, activityChannels,
         )
 
         event = mockk(relaxed = true)
@@ -571,6 +575,24 @@ internal class InstallCategoryMenuTest {
         assertEquals(expectedId, modalSlot.captured.id)
         verify(exactly = 0) { quickChannels.buildModal() }
         verify(exactly = 0) { jackpotChannels.buildModal() }
+    }
+
+    @Test
+    fun `activity_quick_channels token opens the activity channels modal`() {
+        val expectedId = InstallActivityChannelsModal.MODAL_NAME
+        val built = mockk<Modal>(relaxed = true) { every { id } returns expectedId }
+        every { activityChannels.buildModal() } returns built
+        every { event.componentId } returns InstallWizard.sectionDetailMenuId(WizardSection.ACTIVITY.id)
+        every { event.selectedOptions } returns listOf(SelectOption.of("x", ACTIVITY_QUICK_CHANNELS_TOKEN))
+
+        menu.handle(ctx, 0)
+
+        val modalSlot = slot<Modal>()
+        verify(exactly = 1) { event.replyModal(capture(modalSlot)) }
+        assertEquals(expectedId, modalSlot.captured.id)
+        verify(exactly = 0) { quickChannels.buildModal() }
+        verify(exactly = 0) { jackpotChannels.buildModal() }
+        verify(exactly = 0) { lotteryChannels.buildModal() }
     }
 
     @Test

--- a/discord-bot/src/test/kotlin/bot/toby/install/modal/InstallActivityChannelsModalTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/install/modal/InstallActivityChannelsModalTest.kt
@@ -1,0 +1,188 @@
+package bot.toby.install.modal
+
+import core.modal.ModalContext
+import database.dto.ConfigDto.Configurations
+import database.service.ConfigService
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
+import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent
+import net.dv8tion.jda.api.interactions.modals.ModalMapping
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class InstallActivityChannelsModalTest {
+
+    private lateinit var configService: ConfigService
+    private lateinit var modal: InstallActivityChannelsModal
+    private lateinit var event: ModalInteractionEvent
+    private lateinit var ctx: ModalContext
+    private lateinit var guild: Guild
+
+    @BeforeEach
+    fun setUp() {
+        configService = mockk(relaxed = true)
+        modal = InstallActivityChannelsModal(configService)
+        event = mockk(relaxed = true)
+        guild = mockk(relaxed = true) { every { id } returns "g1" }
+        ctx = mockk {
+            every { this@mockk.event } returns this@InstallActivityChannelsModalTest.event
+            every { this@mockk.guild } returns this@InstallActivityChannelsModalTest.guild
+        }
+        every { event.reply(any<String>()) } returns mockk(relaxed = true) {
+            every { setEphemeral(any()) } returns this
+            every { queue() } just Runs
+        }
+        every { event.getValue(any<String>()) } returns null
+    }
+
+    private fun stubLevelUpPick(channelId: Long) {
+        every { event.getValue(InstallActivityChannelsModal.FIELD_LEVEL_UP) } returns mockk<ModalMapping> {
+            every { asLongList } returns listOf(channelId)
+        }
+    }
+
+    private fun stubAchievementPick(channelId: Long) {
+        every { event.getValue(InstallActivityChannelsModal.FIELD_ACHIEVEMENT) } returns mockk<ModalMapping> {
+            every { asLongList } returns listOf(channelId)
+        }
+    }
+
+    @Test
+    fun `name and modal id constants align`() {
+        assertEquals(InstallActivityChannelsModal.MODAL_NAME, modal.name)
+        assertEquals("install_activity_channels", InstallActivityChannelsModal.MODAL_NAME)
+    }
+
+    @Test
+    fun `buildModal returns a JDA modal with the right id`() {
+        val built = modal.buildModal()
+        assertEquals(InstallActivityChannelsModal.MODAL_NAME, built.id)
+        assertNotNull(built.title)
+    }
+
+    @Test
+    fun `no selection replies nothing changed and writes nothing`() {
+        modal.handle(ctx, 0)
+
+        verify(exactly = 1) { event.reply(match<String> { it.contains("nothing changed", ignoreCase = true) }) }
+        verify(exactly = 0) { configService.upsertAll(any(), any()) }
+        verify(exactly = 0) {
+            configService.upsertConfig(any<String>(), any<String>(), any<String>())
+        }
+    }
+
+    @Test
+    fun `level-up pick writes LEVEL_UP_CHANNEL via batch upsert`() {
+        val textChannel = mockk<TextChannel> { every { name } returns "level-ups" }
+        stubLevelUpPick(11L)
+        every { guild.getTextChannelById(11L) } returns textChannel
+        val rowsSlot = slot<List<Pair<String, String>>>()
+        every { configService.upsertAll("g1", capture(rowsSlot)) } returns emptyList()
+
+        modal.handle(ctx, 0)
+
+        verify(exactly = 1) { configService.upsertAll("g1", any()) }
+        assertEquals(
+            listOf(Configurations.LEVEL_UP_CHANNEL.configValue to "11"),
+            rowsSlot.captured,
+        )
+    }
+
+    @Test
+    fun `achievement pick writes ACHIEVEMENT_ANNOUNCE_CHANNEL via batch upsert`() {
+        val textChannel = mockk<TextChannel> { every { name } returns "achievements" }
+        stubAchievementPick(22L)
+        every { guild.getTextChannelById(22L) } returns textChannel
+        val rowsSlot = slot<List<Pair<String, String>>>()
+        every { configService.upsertAll("g1", capture(rowsSlot)) } returns emptyList()
+
+        modal.handle(ctx, 0)
+
+        verify(exactly = 1) { configService.upsertAll("g1", any()) }
+        assertEquals(
+            listOf(Configurations.ACHIEVEMENT_ANNOUNCE_CHANNEL.configValue to "22"),
+            rowsSlot.captured,
+        )
+    }
+
+    @Test
+    fun `both picks write both keys in declaration order`() {
+        val lu = mockk<TextChannel> { every { name } returns "level-ups" }
+        val ach = mockk<TextChannel> { every { name } returns "achievements" }
+        stubLevelUpPick(11L)
+        stubAchievementPick(22L)
+        every { guild.getTextChannelById(11L) } returns lu
+        every { guild.getTextChannelById(22L) } returns ach
+        val rowsSlot = slot<List<Pair<String, String>>>()
+        every { configService.upsertAll("g1", capture(rowsSlot)) } returns emptyList()
+
+        modal.handle(ctx, 0)
+
+        verify(exactly = 1) { configService.upsertAll("g1", any()) }
+        assertEquals(
+            listOf(
+                Configurations.LEVEL_UP_CHANNEL.configValue to "11",
+                Configurations.ACHIEVEMENT_ANNOUNCE_CHANNEL.configValue to "22",
+            ),
+            rowsSlot.captured,
+        )
+    }
+
+    @Test
+    fun `picked level-up channel no longer exists rejects without writes`() {
+        stubLevelUpPick(999L)
+        every { guild.getTextChannelById(999L) } returns null
+
+        modal.handle(ctx, 0)
+
+        verify(exactly = 1) { event.reply(match<String> { it.contains("no longer exists") }) }
+        verify(exactly = 0) { configService.upsertAll(any(), any()) }
+    }
+
+    @Test
+    fun `picked achievement channel no longer exists rejects without writes`() {
+        stubAchievementPick(999L)
+        every { guild.getTextChannelById(999L) } returns null
+
+        modal.handle(ctx, 0)
+
+        verify(exactly = 1) { event.reply(match<String> { it.contains("no longer exists") }) }
+        verify(exactly = 0) { configService.upsertAll(any(), any()) }
+    }
+
+    @Test
+    fun `successful save replies with summary listing both channel names`() {
+        val lu = mockk<TextChannel> { every { name } returns "level-ups" }
+        val ach = mockk<TextChannel> { every { name } returns "achievements" }
+        stubLevelUpPick(11L)
+        stubAchievementPick(22L)
+        every { guild.getTextChannelById(11L) } returns lu
+        every { guild.getTextChannelById(22L) } returns ach
+
+        modal.handle(ctx, 0)
+
+        verify(exactly = 1) {
+            event.reply(match<String> { it.contains("level-ups") && it.contains("achievements") })
+        }
+    }
+
+    @Test
+    fun `both pickers use min_values 1`() {
+        val built = modal.buildModal()
+        val menus = built.components
+            .mapNotNull { it as? net.dv8tion.jda.api.components.label.Label }
+            .map { it.child }
+            .filterIsInstance<net.dv8tion.jda.api.components.selections.EntitySelectMenu>()
+        assertEquals(2, menus.size, "expected two channel pickers")
+        assertTrue(menus.all { it.minValues >= 1 }, "Discord rejects Label-wrapped menus with min_values=0")
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/install/modal/InstallChannelPickerModalsContractTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/install/modal/InstallChannelPickerModalsContractTest.kt
@@ -47,6 +47,10 @@ internal class InstallChannelPickerModalsContractTest {
                     "InstallLotteryChannelsModal",
                     InstallLotteryChannelsModal(configService).buildModal(),
                 ),
+                Arguments.of(
+                    "InstallActivityChannelsModal",
+                    InstallActivityChannelsModal(configService).buildModal(),
+                ),
             )
         }
     }

--- a/discord-bot/src/test/kotlin/bot/toby/install/modal/InstallChannelPickerModalsContractTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/install/modal/InstallChannelPickerModalsContractTest.kt
@@ -1,0 +1,84 @@
+package bot.toby.install.modal
+
+import database.service.ConfigService
+import io.mockk.mockk
+import net.dv8tion.jda.api.components.label.Label
+import net.dv8tion.jda.api.components.selections.EntitySelectMenu
+import net.dv8tion.jda.api.modals.Modal
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import java.util.stream.Stream
+
+/**
+ * Regression guard for every wizard channel-only modal.
+ *
+ * Discord rejects modal payloads where a `Label`-wrapped
+ * [EntitySelectMenu] has `min_values=0`:
+ *
+ * ```
+ * COMPONENT_REQUIRED_ZERO_MIN_VALUES:
+ *   Components marked as required cannot have a min_values of 0
+ * ```
+ *
+ * `Label` children are implicitly required, so every picker built
+ * inside one of these modals must have `minValues >= 1`. This test
+ * iterates every channel-only modal and asserts the constraint on
+ * each menu — adding a fourth such modal automatically gets the
+ * same protection by appending it to [pickerModals].
+ */
+internal class InstallChannelPickerModalsContractTest {
+
+    companion object {
+        @JvmStatic
+        fun pickerModals(): Stream<Arguments> {
+            val configService = mockk<ConfigService>(relaxed = true)
+            return Stream.of(
+                Arguments.of(
+                    "InstallQuickChannelsModal",
+                    InstallQuickChannelsModal(configService).buildModal(),
+                ),
+                Arguments.of(
+                    "InstallJackpotChannelsModal",
+                    InstallJackpotChannelsModal(configService).buildModal(),
+                ),
+                Arguments.of(
+                    "InstallLotteryChannelsModal",
+                    InstallLotteryChannelsModal(configService).buildModal(),
+                ),
+            )
+        }
+    }
+
+    @ParameterizedTest(name = "{0}: every EntitySelectMenu has minValues >= 1")
+    @MethodSource("pickerModals")
+    fun `every channel picker has min_values at least 1`(label: String, built: Modal) {
+        val menus = built.collectSelectMenus()
+        assertTrue(
+            menus.isNotEmpty(),
+            "$label produced no EntitySelectMenu — test setup is wrong, not a real failure",
+        )
+        menus.forEach { menu ->
+            assertTrue(
+                menu.minValues >= 1,
+                "$label's picker '${menu.customId}' has minValues=${menu.minValues}; Discord " +
+                    "rejects Label-wrapped select menus with min_values=0 " +
+                    "(COMPONENT_REQUIRED_ZERO_MIN_VALUES). Required range must start at 1.",
+            )
+        }
+    }
+
+    private fun Modal.collectSelectMenus(): List<EntitySelectMenu> {
+        val out = mutableListOf<EntitySelectMenu>()
+        components.forEach { walk(it, out) }
+        return out
+    }
+
+    private fun walk(node: Any, into: MutableList<EntitySelectMenu>) {
+        when (node) {
+            is EntitySelectMenu -> into += node
+            is Label -> walk(node.child, into)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

**Two changes in one PR — hotfix + small follow-up.**

### 1. Hotfix: `min_values >= 1` on every picker modal

Every wizard channel-picker modal (Quick channels, Jackpot, Lottery)
failed to open with "Interaction failed". Discord rejects modal
payloads where a `Label`-wrapped `EntitySelectMenu` has
`min_values=0` — `Label` children are implicitly required, and
required + min=0 is a contradiction the API enforces:

```
50035 Invalid Form Body
data.components[0].component.min_values
  COMPONENT_REQUIRED_ZERO_MIN_VALUES:
    Components marked as required cannot have a min_values of 0
```

Bump every picker to `setRequiredRange(1, 1)`. Owners must pick a
channel to submit; cancelling the modal (X / Esc) backs out without
writing anything. New parametrised contract test
(`InstallChannelPickerModalsContractTest`) walks every channel-only
modal and asserts `minValues >= 1` — a fourth such modal automatically
gets the guard by appending to the parameter source.

### 2. Activity quick channels picker (`LEVEL_UP_CHANNEL` + `ACHIEVEMENT_ANNOUNCE_CHANNEL`)

Both keys existed in `ConfigDto` but had no UI — owners had to write
SQL to set them. Adds `InstallActivityChannelsModal` (two text-channel
pickers in one shot, same shape as `InstallQuickChannelsModal`) and
wires it into the Activity section detail menu as "Announce channels".
The contract test in part 1 auto-covers it.

## Test plan

- [x] `./gradlew :discord-bot:test --tests "bot.toby.install.*"` — green
- [ ] Manual: `/install` → Custom → General → "Quick channels" — opens
- [ ] Manual: `/install` → Custom → Economy → "Jackpot modlog channel" — opens
- [ ] Manual: `/install` → Custom → Daily lottery → "Lottery announce channel" — opens
- [ ] Manual: `/install` → Custom → Activity tracking → "Announce channels"
      → both pickers visible; pick level-up + achievement channels → submit saves
- [ ] Manual: cancel each modal (X / Esc) → returns to section menu, no DB change

## Out of scope (future follow-up)

- "Unknown Webhook" log noise from `DefaultMenuManager.handle:38` when
  a stale wizard message's interaction webhook expires (downstream of
  the original failure)
- Pre-populating pickers with current channel defaults via
  `setDefaultValues(DefaultValue.channel(currentId))`
- Splitting multi-picker modals into single-picker variants if owners
  want to update just one channel at a time