### PR TITLE
fix(web): keep commands toolbar below the nav drawer stacking context

### DIFF
--- a/web/src/main/resources/static/css/commands.css
+++ b/web/src/main/resources/static/css/commands.css
@@ -50,7 +50,11 @@
 .commands-toolbar {
     position: sticky;
     top: 0;
-    z-index: 20;
+    /* Stay below `body > nav { z-index: 10 }` (nav.css) so the sticky
+       toolbar doesn't punch through the open mobile drawer. Same
+       pattern as `.config-search-bar` on the moderation settings page
+       (moderation.css). */
+    z-index: 5;
     display: flex;
     flex-wrap: wrap;
     align-items: center;


### PR DESCRIPTION
## Summary

When the mobile nav drawer is open on `/commands/wiki`, the sticky `.commands-toolbar` (search input + category chips) visibly renders **on top of** the drawer instead of being covered by it.

**Cause:** stacking-context isolation.

- `body > nav` (`nav.css` line 32) sets `position: relative; z-index: 10`, making the entire navbar a stacking context at z=10.
- The drawer panel inside it bumps to `z-index: 1000` (`nav.css` line 360), but that 1000 is only meaningful within the navbar's own context.
- `.commands-toolbar` (`commands.css` line 53) carries `z-index: 20` — its own root-level stacking context above the navbar's 10. So it punches through the drawer.

**Fix:** drop `.commands-toolbar` to `z-index: 5`, matching the precedent already applied to `.config-search-bar` on the moderation settings page (`moderation.css` line 109). Inline comment names the constraint so the next author doesn't bump it back up without checking nav.css.

## Test plan

- [x] `cd web && npm run lint:css` — clean.
- [ ] After deploy on a mobile viewport (~390px):
  - Open `/commands/wiki`, tap the hamburger — the drawer fully covers the page chrome; no search input / chips visible over the nav links.
  - Close the drawer, scroll down — the toolbar still pins to the top of the viewport.

https://claude.ai/code/session_01SELycDvTHp4oQBZX2odsXB

---
_Generated by [Claude Code](https://claude.ai/code/session_01SELycDvTHp4oQBZX2odsXB)_