### PR TITLE
feat(welcome): per-guild welcome/goodbye announcements + auto-role-on-join

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: java -Xms128m -Xmx224m -XX:+UseSerialGC -XX:MaxMetaspaceSize=192m -XX:ReservedCodeCacheSize=48m -XX:MaxDirectMemorySize=48m -Dio.netty.maxDirectMemory=0 -Dio.netty.allocator.numDirectArenas=2 -Dio.netty.allocator.numHeapArenas=2 -Xss256k -XX:+ExitOnOutOfMemoryError -Dserver.port=$PORT -jar application/build/libs/application-7.1-SNAPSHOT.jar
+web: java -Xms128m -Xmx224m -XX:+UseSerialGC -XX:MaxMetaspaceSize=192m -XX:ReservedCodeCacheSize=48m -XX:MaxDirectMemorySize=48m -Dio.netty.maxDirectMemory=0 -Dio.netty.allocator.numDirectArenas=2 -Dio.netty.allocator.numHeapArenas=2 -Xss256k -XX:+ExitOnOutOfMemoryError -Dserver.port=$PORT -jar application/build/libs/application-7.2-SNAPSHOT.jar
 release: ./bin/trigger_publish_wiki.sh  # This runs after deployment

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Ensure you have the following prerequisites set up before getting started:
 4. Start the bot:
 
    ```shell
-   java -jar application/build/libs/application-7.1-SNAPSHOT.jar -Dspring.profiles.active=prod
+   java -jar application/build/libs/application-7.2-SNAPSHOT.jar -Dspring.profiles.active=prod
    ```
 
 ## Running with Docker

--- a/application/src/test/kotlin/integration/bot/CommandManagerTest.kt
+++ b/application/src/test/kotlin/integration/bot/CommandManagerTest.kt
@@ -163,6 +163,7 @@ class CommandManagerTest {
             AchievementsCommand::class.java,
             NotifyCommand::class.java,
             InstallCommand::class.java,
+            WelcomeCommand::class.java,
         )
 
         Assertions.assertTrue(availableCommands.containsAll(commandManager.allCommands.map { it.javaClass }.toList()))

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ apply plugin: 'kotlin'
 
 allprojects {
     group = "com.github.ml404"
-    version = "7.1-SNAPSHOT"
+    version = "7.2-SNAPSHOT"
 
     ext['kotlin.version'] = kotlin_version
     // Override Spring Boot 3.3.4's BOM-managed versions with patched releases.

--- a/common/src/main/kotlin/common/discord/AutoRoleValidator.kt
+++ b/common/src/main/kotlin/common/discord/AutoRoleValidator.kt
@@ -1,0 +1,39 @@
+package common.discord
+
+import net.dv8tion.jda.api.entities.Role
+import net.dv8tion.jda.api.entities.SelfMember
+
+/**
+ * Single source of truth for "can TobyBot auto-assign [role] to a
+ * member?" Used by every entry point that touches the `auto_role`
+ * table (slash command write, web write, listener-side assignment) so
+ * the three places can't drift on which roles qualify or on the
+ * user-facing error wording.
+ *
+ * Returns `null` when the role can be assigned; otherwise an admin-
+ * facing reason string. Callers translate that into either a JSON
+ * 4xx body, an ephemeral Discord reply, or a WARN log line.
+ *
+ * The three failure modes:
+ *   - `@everyone` — never auto-assignable; everyone is already in it.
+ *   - managed roles — owned by an integration (Twitch sub, booster,
+ *     bot role, etc.); Discord refuses programmatic assignment.
+ *   - role outranks the bot — JDA's [SelfMember.canInteract] reports
+ *     false; the bot's runtime [Role.addRoleToMember] call would fail.
+ */
+object AutoRoleValidator {
+
+    /**
+     * @return null when [role] is assignable, otherwise a human-readable
+     *         error message safe to surface to admins.
+     */
+    fun validate(role: Role, selfMember: SelfMember): String? = when {
+        role.isPublicRole ->
+            "Cannot auto-assign @everyone."
+        role.isManaged ->
+            "${role.asMention} is managed by an integration and can't be assigned by the bot."
+        !selfMember.canInteract(role) ->
+            "${role.asMention} sits above TobyBot's role — move TobyBot's role higher to allow assignment."
+        else -> null
+    }
+}

--- a/database/src/main/kotlin/database/dto/AutoRoleDto.kt
+++ b/database/src/main/kotlin/database/dto/AutoRoleDto.kt
@@ -1,0 +1,34 @@
+package database.dto
+
+import jakarta.persistence.*
+import org.springframework.transaction.annotation.Transactional
+import java.io.Serializable
+
+@NamedQueries(
+    NamedQuery(
+        name = "AutoRoleDto.getGuildAll",
+        query = "select r from AutoRoleDto r where r.guildId = :guildId order by r.roleId asc"
+    ),
+    NamedQuery(
+        name = "AutoRoleDto.getByGuildAndRole",
+        query = "select r from AutoRoleDto r where r.guildId = :guildId and r.roleId = :roleId"
+    )
+)
+@Entity
+@Table(name = "auto_role", schema = "public")
+@IdClass(AutoRoleId::class)
+@Transactional
+class AutoRoleDto(
+    @Id
+    @Column(name = "guild_id")
+    var guildId: Long = 0,
+
+    @Id
+    @Column(name = "role_id")
+    var roleId: Long = 0
+) : Serializable
+
+data class AutoRoleId(
+    var guildId: Long = 0,
+    var roleId: Long = 0
+) : Serializable

--- a/database/src/main/kotlin/database/dto/ConfigDto.kt
+++ b/database/src/main/kotlin/database/dto/ConfigDto.kt
@@ -372,7 +372,28 @@ class ConfigDto(
         // GuildJoinEvent fires when the bot is re-invited.
         INSTALL_MODE("INSTALL_MODE"),
         // Epoch-millis string recording when the install wizard was completed.
-        INSTALLED_AT("INSTALLED_AT");
+        INSTALLED_AT("INSTALLED_AT"),
+
+        // Per-member welcome announcement on GuildMemberJoin. Three keys:
+        //   WELCOME_ENABLED  — "true"/"false". Default "false" so a fresh
+        //                      install doesn't announce until an admin opts in.
+        //   WELCOME_CHANNEL  — Discord text-channel id (stringified Long)
+        //                      where the announcement posts. Falls back to
+        //                      the guild's system channel when blank or
+        //                      pointing at a non-postable channel.
+        //   WELCOME_MESSAGE  — Free-form announcement text with placeholders
+        //                      `{user}` (mention), `{user.name}` (display
+        //                      name), `{server}`, `{membercount}`. Blank
+        //                      falls back to a built-in default template.
+        // The corresponding GOODBYE_* trio fires on GuildMemberRemove with
+        // the same shape — separate keys so admins can run one without the
+        // other.
+        WELCOME_ENABLED("WELCOME_ENABLED"),
+        WELCOME_CHANNEL("WELCOME_CHANNEL"),
+        WELCOME_MESSAGE("WELCOME_MESSAGE"),
+        GOODBYE_ENABLED("GOODBYE_ENABLED"),
+        GOODBYE_CHANNEL("GOODBYE_CHANNEL"),
+        GOODBYE_MESSAGE("GOODBYE_MESSAGE");
     }
 
     override fun toString(): String {

--- a/database/src/main/kotlin/database/persistence/AutoRolePersistence.kt
+++ b/database/src/main/kotlin/database/persistence/AutoRolePersistence.kt
@@ -1,0 +1,10 @@
+package database.persistence
+
+import database.dto.AutoRoleDto
+
+interface AutoRolePersistence {
+    fun listForGuild(guildId: Long): List<AutoRoleDto>
+    fun exists(guildId: Long, roleId: Long): Boolean
+    fun add(guildId: Long, roleId: Long): AutoRoleDto
+    fun delete(guildId: Long, roleId: Long)
+}

--- a/database/src/main/kotlin/database/persistence/impl/DefaultAutoRolePersistence.kt
+++ b/database/src/main/kotlin/database/persistence/impl/DefaultAutoRolePersistence.kt
@@ -1,0 +1,55 @@
+package database.persistence.impl
+
+import database.dto.AutoRoleDto
+import database.persistence.AutoRolePersistence
+import jakarta.persistence.EntityManager
+import jakarta.persistence.PersistenceContext
+import jakarta.persistence.TypedQuery
+import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
+
+@Repository
+@Transactional
+class DefaultAutoRolePersistence : AutoRolePersistence {
+
+    @PersistenceContext
+    private lateinit var entityManager: EntityManager
+
+    override fun listForGuild(guildId: Long): List<AutoRoleDto> {
+        val q: TypedQuery<AutoRoleDto> = entityManager
+            .createNamedQuery("AutoRoleDto.getGuildAll", AutoRoleDto::class.java)
+        q.setParameter("guildId", guildId)
+        return q.resultList
+    }
+
+    override fun exists(guildId: Long, roleId: Long): Boolean {
+        val q: TypedQuery<AutoRoleDto> = entityManager
+            .createNamedQuery("AutoRoleDto.getByGuildAndRole", AutoRoleDto::class.java)
+        q.setParameter("guildId", guildId)
+        q.setParameter("roleId", roleId)
+        return q.resultList.isNotEmpty()
+    }
+
+    override fun add(guildId: Long, roleId: Long): AutoRoleDto {
+        val existing = findOne(guildId, roleId)
+        if (existing != null) return existing
+        val dto = AutoRoleDto(guildId = guildId, roleId = roleId)
+        entityManager.persist(dto)
+        entityManager.flush()
+        return dto
+    }
+
+    override fun delete(guildId: Long, roleId: Long) {
+        val existing = findOne(guildId, roleId) ?: return
+        entityManager.remove(existing)
+        entityManager.flush()
+    }
+
+    private fun findOne(guildId: Long, roleId: Long): AutoRoleDto? {
+        val q: TypedQuery<AutoRoleDto> = entityManager
+            .createNamedQuery("AutoRoleDto.getByGuildAndRole", AutoRoleDto::class.java)
+        q.setParameter("guildId", guildId)
+        q.setParameter("roleId", roleId)
+        return q.resultList.firstOrNull()
+    }
+}

--- a/database/src/main/kotlin/database/service/AutoRoleService.kt
+++ b/database/src/main/kotlin/database/service/AutoRoleService.kt
@@ -1,0 +1,9 @@
+package database.service
+
+import database.dto.AutoRoleDto
+
+interface AutoRoleService {
+    fun listForGuild(guildId: Long): List<AutoRoleDto>
+    fun add(guildId: Long, roleId: Long): AutoRoleDto
+    fun delete(guildId: Long, roleId: Long)
+}

--- a/database/src/main/kotlin/database/service/impl/DefaultAutoRoleService.kt
+++ b/database/src/main/kotlin/database/service/impl/DefaultAutoRoleService.kt
@@ -1,0 +1,21 @@
+package database.service.impl
+
+import database.dto.AutoRoleDto
+import database.persistence.AutoRolePersistence
+import database.service.AutoRoleService
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Service
+
+@Service
+class DefaultAutoRoleService @Autowired constructor(
+    private val persistence: AutoRolePersistence
+) : AutoRoleService {
+    override fun listForGuild(guildId: Long): List<AutoRoleDto> =
+        persistence.listForGuild(guildId)
+
+    override fun add(guildId: Long, roleId: Long): AutoRoleDto =
+        persistence.add(guildId, roleId)
+
+    override fun delete(guildId: Long, roleId: Long) =
+        persistence.delete(guildId, roleId)
+}

--- a/database/src/main/resources/db/migration/V43__welcome_and_auto_role.sql
+++ b/database/src/main/resources/db/migration/V43__welcome_and_auto_role.sql
@@ -1,0 +1,25 @@
+-- Welcome / goodbye announcements and auto-role-on-join.
+--
+-- Welcome and goodbye are configured through six existing-shape ConfigDto
+-- keys so they ride the established /setconfig modal + moderation config-row
+-- + bidirectional template guard infrastructure. The six keys are:
+--   WELCOME_ENABLED, WELCOME_CHANNEL, WELCOME_MESSAGE,
+--   GOODBYE_ENABLED, GOODBYE_CHANNEL, GOODBYE_MESSAGE
+--
+-- Realistic welcome / goodbye templates with placeholders ("Welcome to
+-- {server}, {user}! You're our {membercount}-th member …") routinely run
+-- over the historical config.value cap of VARCHAR(100). Widen the column
+-- to TEXT so admins aren't forced to abbreviate. Existing rows (all
+-- VARCHAR(100)-sized) migrate without truncation.
+ALTER TABLE config
+    ALTER COLUMN value TYPE TEXT;
+
+-- Roles auto-assigned to every joining member. Composite (guild_id, role_id)
+-- PK lets a guild bind any number of roles without an array column.
+-- Conceptually parallels level_role_reward (added in V34): per-guild rows
+-- of role bindings, applied by an event listener.
+CREATE TABLE auto_role (
+    guild_id BIGINT NOT NULL,
+    role_id  BIGINT NOT NULL,
+    PRIMARY KEY (guild_id, role_id)
+);

--- a/database/src/test/kotlin/database/service/impl/DefaultAutoRoleServiceTest.kt
+++ b/database/src/test/kotlin/database/service/impl/DefaultAutoRoleServiceTest.kt
@@ -1,0 +1,57 @@
+package database.service.impl
+
+import database.dto.AutoRoleDto
+import database.persistence.AutoRolePersistence
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * Thin-delegate sanity tests for [DefaultAutoRoleService]. The service
+ * has no logic beyond forwarding to [AutoRolePersistence]; these
+ * regression tests pin the wiring so a refactor that swaps the
+ * persistence dependency or accidentally drops a method gets caught.
+ */
+class DefaultAutoRoleServiceTest {
+
+    private lateinit var persistence: AutoRolePersistence
+    private lateinit var service: DefaultAutoRoleService
+
+    @BeforeEach
+    fun setUp() {
+        persistence = mockk(relaxed = true)
+        service = DefaultAutoRoleService(persistence)
+    }
+
+    @Test
+    fun `listForGuild delegates to persistence`() {
+        val expected = listOf(AutoRoleDto(guildId = 1L, roleId = 7L))
+        every { persistence.listForGuild(1L) } returns expected
+        assertSame(expected, service.listForGuild(1L))
+        verify(exactly = 1) { persistence.listForGuild(1L) }
+    }
+
+    @Test
+    fun `add delegates to persistence`() {
+        val expected = AutoRoleDto(guildId = 1L, roleId = 7L)
+        every { persistence.add(1L, 7L) } returns expected
+        assertSame(expected, service.add(1L, 7L))
+        verify(exactly = 1) { persistence.add(1L, 7L) }
+    }
+
+    @Test
+    fun `delete delegates to persistence`() {
+        service.delete(1L, 7L)
+        verify(exactly = 1) { persistence.delete(1L, 7L) }
+    }
+
+    @Test
+    fun `listForGuild empty returns empty list without error`() {
+        every { persistence.listForGuild(9999L) } returns emptyList()
+        assertEquals(emptyList<AutoRoleDto>(), service.listForGuild(9999L))
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/configuration/JdaListenerRegistrar.kt
+++ b/discord-bot/src/main/kotlin/bot/configuration/JdaListenerRegistrar.kt
@@ -11,6 +11,7 @@ import bot.toby.handler.ModalEventListener
 import bot.toby.handler.SlashCommandEventListener
 import bot.toby.handler.StartUpHandler
 import bot.toby.handler.VoiceEventHandler
+import bot.toby.handler.WelcomeAndAutoRoleHandler
 import bot.toby.install.InstallWelcomeHandler
 import net.dv8tion.jda.api.JDA
 import org.springframework.beans.factory.annotation.Autowired
@@ -31,6 +32,7 @@ class JdaListenerRegistrar @Autowired constructor(
     eventWaiter: EventWaiter,
     guildLeaveCleanupHandler: GuildLeaveCleanupHandler,
     installWelcomeHandler: InstallWelcomeHandler,
+    welcomeAndAutoRoleHandler: WelcomeAndAutoRoleHandler,
 ) {
     init {
         jda.addEventListener(
@@ -46,6 +48,7 @@ class JdaListenerRegistrar @Autowired constructor(
             eventWaiter,
             guildLeaveCleanupHandler,
             installWelcomeHandler,
+            welcomeAndAutoRoleHandler,
         )
     }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/moderation/WelcomeCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/moderation/WelcomeCommand.kt
@@ -1,0 +1,230 @@
+package bot.toby.command.commands.moderation
+
+import bot.toby.welcome.WelcomeMessageRenderer
+import core.command.CommandContext
+import database.dto.ConfigDto.Configurations
+import database.dto.UserDto
+import database.service.AutoRoleService
+import database.service.ConfigService
+import net.dv8tion.jda.api.EmbedBuilder
+import net.dv8tion.jda.api.entities.Role
+import net.dv8tion.jda.api.entities.channel.ChannelType
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
+import net.dv8tion.jda.api.interactions.commands.OptionType
+import net.dv8tion.jda.api.interactions.commands.build.OptionData
+import net.dv8tion.jda.api.interactions.commands.build.SubcommandData
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+/**
+ * `/welcome <subcommand>` — owner-only configuration for the per-member
+ * welcome / goodbye announcements (six [Configurations] keys) plus the
+ * multi-row `auto_role` table.
+ *
+ * Slash-command options (not modals) are used here for two reasons:
+ *   - the welcome / goodbye message is a free-form string that doesn't
+ *     map cleanly onto the typed [SetConfigFieldValidator] specs used
+ *     by every existing `/setconfig` modal;
+ *   - the auto-role flow is multi-row by nature (one slash invocation
+ *     per role) and modals can't bind multiple roles in one shot.
+ *
+ * Settings are also editable via the web `/moderation/{guildId}/welcome`
+ * tab; both paths write to the same [ConfigService] / [AutoRoleService]
+ * so they stay in sync.
+ */
+@Component
+class WelcomeCommand @Autowired constructor(
+    private val configService: ConfigService,
+    private val autoRoleService: AutoRoleService,
+) : ModerationCommand {
+
+    override val name: String = NAME
+    override val description: String =
+        "Configure the per-member welcome / goodbye announcements and roles assigned on join."
+
+    override val subCommands: List<SubcommandData> = listOf(
+        SubcommandData(SUB_CONFIGURE_WELCOME, "Configure the welcome announcement (owner-only).")
+            .addOptions(
+                OptionData(OptionType.BOOLEAN, OPT_ENABLED, "Toggle welcome announcements on or off.", true),
+                OptionData(OptionType.CHANNEL, OPT_CHANNEL, "Channel to post in (defaults to system channel).", false)
+                    .setChannelTypes(ChannelType.TEXT),
+                OptionData(OptionType.STRING, OPT_MESSAGE, "Message template. Placeholders: {user} {user.name} {server} {membercount}.", false),
+            ),
+        SubcommandData(SUB_CONFIGURE_GOODBYE, "Configure the goodbye announcement (owner-only).")
+            .addOptions(
+                OptionData(OptionType.BOOLEAN, OPT_ENABLED, "Toggle goodbye announcements on or off.", true),
+                OptionData(OptionType.CHANNEL, OPT_CHANNEL, "Channel to post in (defaults to system channel).", false)
+                    .setChannelTypes(ChannelType.TEXT),
+                OptionData(OptionType.STRING, OPT_MESSAGE, "Message template. Placeholders: {user} {user.name} {server} {membercount}.", false),
+            ),
+        SubcommandData(SUB_AUTOROLE_ADD, "Auto-assign a role to every new member (owner-only).")
+            .addOptions(
+                OptionData(OptionType.ROLE, OPT_ROLE, "Role to add to the auto-assign list.", true),
+            ),
+        SubcommandData(SUB_AUTOROLE_REMOVE, "Stop auto-assigning a role on join (owner-only).")
+            .addOptions(
+                OptionData(OptionType.ROLE, OPT_ROLE, "Role to remove from the auto-assign list.", true),
+            ),
+        SubcommandData(SUB_SHOW, "Show current welcome / goodbye / auto-role configuration."),
+    )
+
+    override fun handle(ctx: CommandContext, requestingUserDto: UserDto, deleteDelay: Int) {
+        val event = ctx.event
+        val guild = event.guild ?: run {
+            event.reply("This command can only be used in a server.").setEphemeral(true).queue()
+            return
+        }
+        val sub = event.subcommandName ?: run {
+            event.reply("Pick a subcommand — see `/welcome` autocomplete.").setEphemeral(true).queue()
+            return
+        }
+        if (sub == SUB_SHOW) {
+            handleShow(event, guild.idLong, guild.name)
+            return
+        }
+        if (ctx.member?.isOwner != true) {
+            event.reply("Only the server owner can change welcome / auto-role settings.")
+                .setEphemeral(true).queue()
+            return
+        }
+        when (sub) {
+            SUB_CONFIGURE_WELCOME -> handleConfigure(event, guild.id, isWelcome = true)
+            SUB_CONFIGURE_GOODBYE -> handleConfigure(event, guild.id, isWelcome = false)
+            SUB_AUTOROLE_ADD -> handleAutoRoleAdd(event, guild.idLong)
+            SUB_AUTOROLE_REMOVE -> handleAutoRoleRemove(event, guild.idLong)
+            else -> event.reply("Unknown subcommand `$sub`.").setEphemeral(true).queue()
+        }
+    }
+
+    private fun handleConfigure(
+        event: SlashCommandInteractionEvent,
+        guildId: String,
+        isWelcome: Boolean,
+    ) {
+        val enabled = event.getOption(OPT_ENABLED)?.asBoolean ?: return
+        // `setChannelTypes(ChannelType.TEXT)` on the OptionData guarantees
+        // Discord only allows text channels in this slot, so `asTextChannel()`
+        // is safe — Discord rejects voice/category picks at the client side.
+        val channelOpt = event.getOption(OPT_CHANNEL)?.asChannel?.asTextChannel()
+        val message = event.getOption(OPT_MESSAGE)?.asString
+
+        val keyEnabled = if (isWelcome) Configurations.WELCOME_ENABLED else Configurations.GOODBYE_ENABLED
+        val keyChannel = if (isWelcome) Configurations.WELCOME_CHANNEL else Configurations.GOODBYE_CHANNEL
+        val keyMessage = if (isWelcome) Configurations.WELCOME_MESSAGE else Configurations.GOODBYE_MESSAGE
+
+        val rows = mutableListOf<Pair<String, String>>()
+        rows += keyEnabled.configValue to enabled.toString()
+        if (channelOpt != null) {
+            rows += keyChannel.configValue to channelOpt.id
+        }
+        if (message != null) {
+            rows += keyMessage.configValue to message
+        }
+        configService.upsertAll(guildId, rows)
+
+        val label = if (isWelcome) "Welcome" else "Goodbye"
+        val summary = buildString {
+            append("**$label settings saved**\n")
+            append("• Enabled: ").append(enabled).append('\n')
+            if (channelOpt != null) append("• Channel: ").append(channelOpt.asMention).append('\n')
+            if (message != null) append("• Message: `").append(message).append('`')
+        }
+        event.reply(summary).setEphemeral(true).queue()
+    }
+
+    private fun handleAutoRoleAdd(event: SlashCommandInteractionEvent, guildId: Long) {
+        val role = event.getOption(OPT_ROLE)?.asRole ?: return
+        validateRole(event, role)?.let {
+            event.reply(it).setEphemeral(true).queue()
+            return
+        }
+        autoRoleService.add(guildId, role.idLong)
+        event.reply("Auto-role added: ${role.asMention}. New members will receive this role.")
+            .setEphemeral(true).queue()
+    }
+
+    private fun handleAutoRoleRemove(event: SlashCommandInteractionEvent, guildId: Long) {
+        val role = event.getOption(OPT_ROLE)?.asRole ?: return
+        autoRoleService.delete(guildId, role.idLong)
+        event.reply("Auto-role removed: ${role.asMention}. New members will no longer receive it.")
+            .setEphemeral(true).queue()
+    }
+
+    private fun validateRole(event: SlashCommandInteractionEvent, role: Role): String? {
+        if (role.isPublicRole) return "Cannot auto-assign @everyone."
+        if (role.isManaged) return "${role.asMention} is managed by an integration and can't be assigned by the bot."
+        val self = event.guild?.selfMember
+        if (self != null && !self.canInteract(role)) {
+            return "${role.asMention} sits above TobyBot's role — move TobyBot's role higher to allow assignment."
+        }
+        return null
+    }
+
+    private fun handleShow(event: SlashCommandInteractionEvent, guildId: Long, guildName: String) {
+        val welcomeEnabled = readBool(guildId.toString(), Configurations.WELCOME_ENABLED)
+        val welcomeChannel = readConfig(guildId.toString(), Configurations.WELCOME_CHANNEL)
+        val welcomeMessage = readConfig(guildId.toString(), Configurations.WELCOME_MESSAGE)
+        val goodbyeEnabled = readBool(guildId.toString(), Configurations.GOODBYE_ENABLED)
+        val goodbyeChannel = readConfig(guildId.toString(), Configurations.GOODBYE_CHANNEL)
+        val goodbyeMessage = readConfig(guildId.toString(), Configurations.GOODBYE_MESSAGE)
+        val autoRoles = autoRoleService.listForGuild(guildId)
+
+        val embed = EmbedBuilder()
+            .setTitle("Welcome & Auto-role for $guildName")
+            .addField(
+                "Welcome announcement",
+                buildString {
+                    append("Enabled: ").append(welcomeEnabled).append('\n')
+                    append("Channel: ").append(formatChannel(welcomeChannel)).append('\n')
+                    append("Message: ").append(formatMessage(welcomeMessage, WelcomeMessageRenderer.DEFAULT_WELCOME))
+                },
+                false,
+            )
+            .addField(
+                "Goodbye announcement",
+                buildString {
+                    append("Enabled: ").append(goodbyeEnabled).append('\n')
+                    append("Channel: ").append(formatChannel(goodbyeChannel)).append('\n')
+                    append("Message: ").append(formatMessage(goodbyeMessage, WelcomeMessageRenderer.DEFAULT_GOODBYE))
+                },
+                false,
+            )
+            .addField(
+                "Auto-assigned roles (${autoRoles.size})",
+                if (autoRoles.isEmpty()) "_None_"
+                else autoRoles.joinToString("\n") { "• <@&${it.roleId}>" },
+                false,
+            )
+            .build()
+        event.replyEmbeds(embed).setEphemeral(true).queue()
+    }
+
+    private fun readConfig(guildId: String, key: Configurations): String? =
+        configService.getConfigByName(key.configValue, guildId)?.value
+
+    private fun readBool(guildId: String, key: Configurations): Boolean =
+        readConfig(guildId, key).equals("true", ignoreCase = true)
+
+    private fun formatChannel(raw: String?): String {
+        val id = raw?.takeIf { it.isNotBlank() }?.toLongOrNull() ?: return "_system channel (fallback)_"
+        return "<#$id>"
+    }
+
+    private fun formatMessage(raw: String?, fallback: String): String {
+        val text = raw?.takeIf { it.isNotBlank() } ?: return "_default — `$fallback`_"
+        return "`$text`"
+    }
+
+    companion object {
+        const val NAME = "welcome"
+        const val SUB_CONFIGURE_WELCOME = "configure-welcome"
+        const val SUB_CONFIGURE_GOODBYE = "configure-goodbye"
+        const val SUB_AUTOROLE_ADD = "autorole-add"
+        const val SUB_AUTOROLE_REMOVE = "autorole-remove"
+        const val SUB_SHOW = "show"
+        const val OPT_ENABLED = "enabled"
+        const val OPT_CHANNEL = "channel"
+        const val OPT_MESSAGE = "message"
+        const val OPT_ROLE = "role"
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/moderation/WelcomeCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/moderation/WelcomeCommand.kt
@@ -1,13 +1,13 @@
 package bot.toby.command.commands.moderation
 
-import bot.toby.welcome.WelcomeMessageRenderer
+import bot.toby.welcome.AnnouncementKind
+import common.discord.AutoRoleValidator
 import core.command.CommandContext
 import database.dto.ConfigDto.Configurations
 import database.dto.UserDto
 import database.service.AutoRoleService
 import database.service.ConfigService
 import net.dv8tion.jda.api.EmbedBuilder
-import net.dv8tion.jda.api.entities.Role
 import net.dv8tion.jda.api.entities.channel.ChannelType
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
 import net.dv8tion.jda.api.interactions.commands.OptionType
@@ -88,8 +88,8 @@ class WelcomeCommand @Autowired constructor(
             return
         }
         when (sub) {
-            SUB_CONFIGURE_WELCOME -> handleConfigure(event, guild.id, isWelcome = true)
-            SUB_CONFIGURE_GOODBYE -> handleConfigure(event, guild.id, isWelcome = false)
+            SUB_CONFIGURE_WELCOME -> handleConfigure(event, guild.id, AnnouncementKind.WELCOME)
+            SUB_CONFIGURE_GOODBYE -> handleConfigure(event, guild.id, AnnouncementKind.GOODBYE)
             SUB_AUTOROLE_ADD -> handleAutoRoleAdd(event, guild.idLong)
             SUB_AUTOROLE_REMOVE -> handleAutoRoleRemove(event, guild.idLong)
             else -> event.reply("Unknown subcommand `$sub`.").setEphemeral(true).queue()
@@ -99,7 +99,7 @@ class WelcomeCommand @Autowired constructor(
     private fun handleConfigure(
         event: SlashCommandInteractionEvent,
         guildId: String,
-        isWelcome: Boolean,
+        kind: AnnouncementKind,
     ) {
         val enabled = event.getOption(OPT_ENABLED)?.asBoolean ?: return
         // `setChannelTypes(ChannelType.TEXT)` on the OptionData guarantees
@@ -108,23 +108,18 @@ class WelcomeCommand @Autowired constructor(
         val channelOpt = event.getOption(OPT_CHANNEL)?.asChannel?.asTextChannel()
         val message = event.getOption(OPT_MESSAGE)?.asString
 
-        val keyEnabled = if (isWelcome) Configurations.WELCOME_ENABLED else Configurations.GOODBYE_ENABLED
-        val keyChannel = if (isWelcome) Configurations.WELCOME_CHANNEL else Configurations.GOODBYE_CHANNEL
-        val keyMessage = if (isWelcome) Configurations.WELCOME_MESSAGE else Configurations.GOODBYE_MESSAGE
-
         val rows = mutableListOf<Pair<String, String>>()
-        rows += keyEnabled.configValue to enabled.toString()
+        rows += kind.enabledKey.configValue to enabled.toString()
         if (channelOpt != null) {
-            rows += keyChannel.configValue to channelOpt.id
+            rows += kind.channelKey.configValue to channelOpt.id
         }
         if (message != null) {
-            rows += keyMessage.configValue to message
+            rows += kind.messageKey.configValue to message
         }
         configService.upsertAll(guildId, rows)
 
-        val label = if (isWelcome) "Welcome" else "Goodbye"
         val summary = buildString {
-            append("**$label settings saved**\n")
+            append("**${kind.label} settings saved**\n")
             append("• Enabled: ").append(enabled).append('\n')
             if (channelOpt != null) append("• Channel: ").append(channelOpt.asMention).append('\n')
             if (message != null) append("• Message: `").append(message).append('`')
@@ -134,8 +129,11 @@ class WelcomeCommand @Autowired constructor(
 
     private fun handleAutoRoleAdd(event: SlashCommandInteractionEvent, guildId: Long) {
         val role = event.getOption(OPT_ROLE)?.asRole ?: return
-        validateRole(event, role)?.let {
-            event.reply(it).setEphemeral(true).queue()
+        val self = event.guild?.selfMember
+        val error = if (self == null) "Could not resolve the bot's member entry in this server."
+        else AutoRoleValidator.validate(role, self)
+        if (error != null) {
+            event.reply(error).setEphemeral(true).queue()
             return
         }
         autoRoleService.add(guildId, role.idLong)
@@ -150,45 +148,20 @@ class WelcomeCommand @Autowired constructor(
             .setEphemeral(true).queue()
     }
 
-    private fun validateRole(event: SlashCommandInteractionEvent, role: Role): String? {
-        if (role.isPublicRole) return "Cannot auto-assign @everyone."
-        if (role.isManaged) return "${role.asMention} is managed by an integration and can't be assigned by the bot."
-        val self = event.guild?.selfMember
-        if (self != null && !self.canInteract(role)) {
-            return "${role.asMention} sits above TobyBot's role — move TobyBot's role higher to allow assignment."
-        }
-        return null
-    }
-
     private fun handleShow(event: SlashCommandInteractionEvent, guildId: Long, guildName: String) {
-        val welcomeEnabled = readBool(guildId.toString(), Configurations.WELCOME_ENABLED)
-        val welcomeChannel = readConfig(guildId.toString(), Configurations.WELCOME_CHANNEL)
-        val welcomeMessage = readConfig(guildId.toString(), Configurations.WELCOME_MESSAGE)
-        val goodbyeEnabled = readBool(guildId.toString(), Configurations.GOODBYE_ENABLED)
-        val goodbyeChannel = readConfig(guildId.toString(), Configurations.GOODBYE_CHANNEL)
-        val goodbyeMessage = readConfig(guildId.toString(), Configurations.GOODBYE_MESSAGE)
         val autoRoles = autoRoleService.listForGuild(guildId)
 
         val embed = EmbedBuilder()
             .setTitle("Welcome & Auto-role for $guildName")
-            .addField(
-                "Welcome announcement",
-                buildString {
-                    append("Enabled: ").append(welcomeEnabled).append('\n')
-                    append("Channel: ").append(formatChannel(welcomeChannel)).append('\n')
-                    append("Message: ").append(formatMessage(welcomeMessage, WelcomeMessageRenderer.DEFAULT_WELCOME))
-                },
-                false,
-            )
-            .addField(
-                "Goodbye announcement",
-                buildString {
-                    append("Enabled: ").append(goodbyeEnabled).append('\n')
-                    append("Channel: ").append(formatChannel(goodbyeChannel)).append('\n')
-                    append("Message: ").append(formatMessage(goodbyeMessage, WelcomeMessageRenderer.DEFAULT_GOODBYE))
-                },
-                false,
-            )
+            .also { builder ->
+                for (kind in AnnouncementKind.entries) {
+                    builder.addField(
+                        "${kind.label} announcement",
+                        renderShowSection(guildId.toString(), kind),
+                        false,
+                    )
+                }
+            }
             .addField(
                 "Auto-assigned roles (${autoRoles.size})",
                 if (autoRoles.isEmpty()) "_None_"
@@ -197,6 +170,12 @@ class WelcomeCommand @Autowired constructor(
             )
             .build()
         event.replyEmbeds(embed).setEphemeral(true).queue()
+    }
+
+    private fun renderShowSection(guildId: String, kind: AnnouncementKind): String = buildString {
+        append("Enabled: ").append(readBool(guildId, kind.enabledKey)).append('\n')
+        append("Channel: ").append(formatChannel(readConfig(guildId, kind.channelKey))).append('\n')
+        append("Message: ").append(formatMessage(readConfig(guildId, kind.messageKey), kind.defaultTemplate))
     }
 
     private fun readConfig(guildId: String, key: Configurations): String? =

--- a/discord-bot/src/main/kotlin/bot/toby/handler/WelcomeAndAutoRoleHandler.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/handler/WelcomeAndAutoRoleHandler.kt
@@ -1,0 +1,181 @@
+package bot.toby.handler
+
+import bot.toby.welcome.WelcomeMessageRenderer
+import common.logging.DiscordLogger
+import database.dto.ConfigDto.Configurations
+import database.service.AutoRoleService
+import database.service.ConfigService
+import net.dv8tion.jda.api.EmbedBuilder
+import net.dv8tion.jda.api.Permission
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.Member
+import net.dv8tion.jda.api.entities.MessageEmbed
+import net.dv8tion.jda.api.entities.User
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
+import net.dv8tion.jda.api.events.guild.member.GuildMemberJoinEvent
+import net.dv8tion.jda.api.events.guild.member.GuildMemberRemoveEvent
+import net.dv8tion.jda.api.hooks.ListenerAdapter
+import org.springframework.stereotype.Service
+
+/**
+ * Reacts to guild membership changes:
+ *  - `onGuildMemberJoin` — posts the welcome embed (if `WELCOME_ENABLED`)
+ *    and assigns every role bound for the guild in [AutoRoleService].
+ *  - `onGuildMemberRemove` — posts the goodbye embed (if `GOODBYE_ENABLED`).
+ *
+ * Each side is independently toggled so admins can run one without the
+ * other. Channel resolution prefers the configured `*_CHANNEL`; if that
+ * row is blank, unparseable, missing, or non-postable, falls back to the
+ * guild's system channel. If neither is postable the listener logs and
+ * returns silently — never let a transient JDA-side failure kill the
+ * dispatch thread.
+ */
+@Service
+class WelcomeAndAutoRoleHandler(
+    private val configService: ConfigService,
+    private val autoRoleService: AutoRoleService,
+) : ListenerAdapter() {
+
+    private val logger: DiscordLogger = DiscordLogger.createLogger(this::class.java)
+
+    override fun onGuildMemberJoin(event: GuildMemberJoinEvent) {
+        val guild = event.guild
+        val member = event.member
+        runCatching { assignAutoRoles(guild, member) }
+            .onFailure {
+                logger.error {
+                    "Auto-role assignment failed for guild ${guild.id} member ${member.id}: " +
+                        "${it.javaClass.simpleName}: ${it.message}"
+                }
+            }
+        runCatching { postWelcomeIfEnabled(guild, member) }
+            .onFailure {
+                logger.error {
+                    "Welcome announcement failed for guild ${guild.id} member ${member.id}: " +
+                        "${it.javaClass.simpleName}: ${it.message}"
+                }
+            }
+    }
+
+    override fun onGuildMemberRemove(event: GuildMemberRemoveEvent) {
+        val guild = event.guild
+        val user = event.user
+        runCatching { postGoodbyeIfEnabled(guild, user, event.member) }
+            .onFailure {
+                logger.error {
+                    "Goodbye announcement failed for guild ${guild.id} user ${user.id}: " +
+                        "${it.javaClass.simpleName}: ${it.message}"
+                }
+            }
+    }
+
+    private fun assignAutoRoles(guild: Guild, member: Member) {
+        val rows = autoRoleService.listForGuild(guild.idLong)
+        if (rows.isEmpty()) return
+        val self = guild.selfMember
+        if (!self.hasPermission(Permission.MANAGE_ROLES)) {
+            logger.warn {
+                "Skipping auto-role for guild ${guild.id} — bot lacks MANAGE_ROLES"
+            }
+            return
+        }
+        for (row in rows) {
+            val role = guild.getRoleById(row.roleId)
+            if (role == null) {
+                logger.warn { "Auto-role ${row.roleId} no longer exists in guild ${guild.id}" }
+                continue
+            }
+            if (role.isManaged) {
+                logger.warn { "Skipping managed role ${role.id} (${role.name}) — integration-owned" }
+                continue
+            }
+            if (!self.canInteract(role)) {
+                logger.warn {
+                    "Bot can't assign role ${role.id} (${role.name}) — its role sits above the bot's"
+                }
+                continue
+            }
+            guild.addRoleToMember(member, role).queue(
+                null,
+                { err ->
+                    logger.warn {
+                        "addRoleToMember failed for ${role.id} on ${member.id}: ${err.message}"
+                    }
+                },
+            )
+        }
+    }
+
+    private fun postWelcomeIfEnabled(guild: Guild, member: Member) {
+        if (!isFlagEnabled(guild.id, Configurations.WELCOME_ENABLED)) return
+        val channel = resolveChannel(guild, Configurations.WELCOME_CHANNEL) ?: run {
+            logger.warn { "Welcome enabled for ${guild.id} but no postable channel resolved" }
+            return
+        }
+        val template = readConfig(guild.id, Configurations.WELCOME_MESSAGE)
+        val text = WelcomeMessageRenderer.render(template, guild, member.user, member.effectiveName)
+        channel.sendMessageEmbeds(buildEmbed(member.user, text, isWelcome = true)).queue(
+            { logger.info { "Posted welcome to ${guild.id} #${channel.name}" } },
+            { err ->
+                logger.warn { "Failed to post welcome to ${guild.id} #${channel.name}: ${err.message}" }
+            },
+        )
+    }
+
+    private fun postGoodbyeIfEnabled(guild: Guild, user: User, member: Member?) {
+        if (!isFlagEnabled(guild.id, Configurations.GOODBYE_ENABLED)) return
+        val channel = resolveChannel(guild, Configurations.GOODBYE_CHANNEL) ?: run {
+            logger.warn { "Goodbye enabled for ${guild.id} but no postable channel resolved" }
+            return
+        }
+        val template = readConfig(guild.id, Configurations.GOODBYE_MESSAGE)
+        val text = WelcomeMessageRenderer.renderGoodbye(
+            template,
+            guild,
+            user,
+            member?.effectiveName,
+        )
+        channel.sendMessageEmbeds(buildEmbed(user, text, isWelcome = false)).queue(
+            { logger.info { "Posted goodbye to ${guild.id} #${channel.name}" } },
+            { err ->
+                logger.warn { "Failed to post goodbye to ${guild.id} #${channel.name}: ${err.message}" }
+            },
+        )
+    }
+
+    private fun isFlagEnabled(guildId: String, key: Configurations): Boolean {
+        val value = readConfig(guildId, key) ?: return false
+        return value.equals("true", ignoreCase = true)
+    }
+
+    private fun readConfig(guildId: String, key: Configurations): String? =
+        configService.getConfigByName(key.configValue, guildId)?.value
+
+    private fun resolveChannel(guild: Guild, key: Configurations): TextChannel? {
+        val raw = readConfig(guild.id, key)
+        val configured = raw?.takeIf { it.isNotBlank() }
+            ?.toLongOrNull()
+            ?.let { guild.getTextChannelById(it) }
+            ?.takeIf { canPost(guild, it) }
+        if (configured != null) return configured
+        return guild.systemChannel?.takeIf { canPost(guild, it) }
+    }
+
+    private fun canPost(guild: Guild, channel: TextChannel): Boolean {
+        val self = guild.selfMember
+        return self.hasPermission(channel, Permission.VIEW_CHANNEL, Permission.MESSAGE_SEND, Permission.MESSAGE_EMBED_LINKS)
+    }
+
+    private fun buildEmbed(user: User, text: String, isWelcome: Boolean): MessageEmbed {
+        val builder = EmbedBuilder()
+            .setDescription(text)
+            .setColor(if (isWelcome) WELCOME_COLOR else GOODBYE_COLOR)
+            .setThumbnail(user.effectiveAvatarUrl)
+        return builder.build()
+    }
+
+    companion object {
+        private const val WELCOME_COLOR = 0x57F287 // Discord "green"
+        private const val GOODBYE_COLOR = 0xED4245 // Discord "red"
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/handler/WelcomeAndAutoRoleHandler.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/handler/WelcomeAndAutoRoleHandler.kt
@@ -1,6 +1,8 @@
 package bot.toby.handler
 
+import bot.toby.welcome.AnnouncementKind
 import bot.toby.welcome.WelcomeMessageRenderer
+import common.discord.AutoRoleValidator
 import common.logging.DiscordLogger
 import database.dto.ConfigDto.Configurations
 import database.service.AutoRoleService
@@ -24,8 +26,12 @@ import org.springframework.stereotype.Service
  *  - `onGuildMemberRemove` — posts the goodbye embed (if `GOODBYE_ENABLED`).
  *
  * Each side is independently toggled so admins can run one without the
- * other. Channel resolution prefers the configured `*_CHANNEL`; if that
- * row is blank, unparseable, missing, or non-postable, falls back to the
+ * other. The welcome / goodbye paths are otherwise structurally identical
+ * — both collapse onto [postIfEnabled] with the per-surface knowledge
+ * (config keys, default text, embed accent) carried by [AnnouncementKind].
+ *
+ * Channel resolution prefers the configured `*_CHANNEL`; if that row is
+ * blank, unparseable, missing, or non-postable, falls back to the
  * guild's system channel. If neither is postable the listener logs and
  * returns silently — never let a transient JDA-side failure kill the
  * dispatch thread.
@@ -42,31 +48,16 @@ class WelcomeAndAutoRoleHandler(
         val guild = event.guild
         val member = event.member
         runCatching { assignAutoRoles(guild, member) }
-            .onFailure {
-                logger.error {
-                    "Auto-role assignment failed for guild ${guild.id} member ${member.id}: " +
-                        "${it.javaClass.simpleName}: ${it.message}"
-                }
-            }
-        runCatching { postWelcomeIfEnabled(guild, member) }
-            .onFailure {
-                logger.error {
-                    "Welcome announcement failed for guild ${guild.id} member ${member.id}: " +
-                        "${it.javaClass.simpleName}: ${it.message}"
-                }
-            }
+            .onFailure { logFailure("Auto-role assignment", guild, member.id, it) }
+        runCatching { postIfEnabled(AnnouncementKind.WELCOME, guild, member.user, member.effectiveName) }
+            .onFailure { logFailure("Welcome announcement", guild, member.id, it) }
     }
 
     override fun onGuildMemberRemove(event: GuildMemberRemoveEvent) {
         val guild = event.guild
         val user = event.user
-        runCatching { postGoodbyeIfEnabled(guild, user, event.member) }
-            .onFailure {
-                logger.error {
-                    "Goodbye announcement failed for guild ${guild.id} user ${user.id}: " +
-                        "${it.javaClass.simpleName}: ${it.message}"
-                }
-            }
+        runCatching { postIfEnabled(AnnouncementKind.GOODBYE, guild, user, event.member?.effectiveName) }
+            .onFailure { logFailure("Goodbye announcement", guild, user.id, it) }
     }
 
     private fun assignAutoRoles(guild: Guild, member: Member) {
@@ -74,9 +65,7 @@ class WelcomeAndAutoRoleHandler(
         if (rows.isEmpty()) return
         val self = guild.selfMember
         if (!self.hasPermission(Permission.MANAGE_ROLES)) {
-            logger.warn {
-                "Skipping auto-role for guild ${guild.id} — bot lacks MANAGE_ROLES"
-            }
+            logger.warn { "Skipping auto-role for guild ${guild.id} — bot lacks MANAGE_ROLES" }
             return
         }
         for (row in rows) {
@@ -85,14 +74,9 @@ class WelcomeAndAutoRoleHandler(
                 logger.warn { "Auto-role ${row.roleId} no longer exists in guild ${guild.id}" }
                 continue
             }
-            if (role.isManaged) {
-                logger.warn { "Skipping managed role ${role.id} (${role.name}) — integration-owned" }
-                continue
-            }
-            if (!self.canInteract(role)) {
-                logger.warn {
-                    "Bot can't assign role ${role.id} (${role.name}) — its role sits above the bot's"
-                }
+            val error = AutoRoleValidator.validate(role, self)
+            if (error != null) {
+                logger.warn { "Skipping role ${role.id} (${role.name}) for guild ${guild.id}: $error" }
                 continue
             }
             guild.addRoleToMember(member, role).queue(
@@ -106,39 +90,23 @@ class WelcomeAndAutoRoleHandler(
         }
     }
 
-    private fun postWelcomeIfEnabled(guild: Guild, member: Member) {
-        if (!isFlagEnabled(guild.id, Configurations.WELCOME_ENABLED)) return
-        val channel = resolveChannel(guild, Configurations.WELCOME_CHANNEL) ?: run {
-            logger.warn { "Welcome enabled for ${guild.id} but no postable channel resolved" }
+    private fun postIfEnabled(
+        kind: AnnouncementKind,
+        guild: Guild,
+        user: User,
+        memberDisplayName: String?,
+    ) {
+        if (!isFlagEnabled(guild.id, kind.enabledKey)) return
+        val channel = resolveChannel(guild, kind.channelKey) ?: run {
+            logger.warn { "${kind.label} enabled for ${guild.id} but no postable channel resolved" }
             return
         }
-        val template = readConfig(guild.id, Configurations.WELCOME_MESSAGE)
-        val text = WelcomeMessageRenderer.render(template, guild, member.user, member.effectiveName)
-        channel.sendMessageEmbeds(buildEmbed(member.user, text, isWelcome = true)).queue(
-            { logger.info { "Posted welcome to ${guild.id} #${channel.name}" } },
+        val template = readConfig(guild.id, kind.messageKey)
+        val text = WelcomeMessageRenderer.render(template, kind.defaultTemplate, guild, user, memberDisplayName)
+        channel.sendMessageEmbeds(buildEmbed(user, text, kind.embedColor)).queue(
+            { logger.info { "Posted ${kind.label} to ${guild.id} #${channel.name}" } },
             { err ->
-                logger.warn { "Failed to post welcome to ${guild.id} #${channel.name}: ${err.message}" }
-            },
-        )
-    }
-
-    private fun postGoodbyeIfEnabled(guild: Guild, user: User, member: Member?) {
-        if (!isFlagEnabled(guild.id, Configurations.GOODBYE_ENABLED)) return
-        val channel = resolveChannel(guild, Configurations.GOODBYE_CHANNEL) ?: run {
-            logger.warn { "Goodbye enabled for ${guild.id} but no postable channel resolved" }
-            return
-        }
-        val template = readConfig(guild.id, Configurations.GOODBYE_MESSAGE)
-        val text = WelcomeMessageRenderer.renderGoodbye(
-            template,
-            guild,
-            user,
-            member?.effectiveName,
-        )
-        channel.sendMessageEmbeds(buildEmbed(user, text, isWelcome = false)).queue(
-            { logger.info { "Posted goodbye to ${guild.id} #${channel.name}" } },
-            { err ->
-                logger.warn { "Failed to post goodbye to ${guild.id} #${channel.name}: ${err.message}" }
+                logger.warn { "Failed to post ${kind.label} to ${guild.id} #${channel.name}: ${err.message}" }
             },
         )
     }
@@ -166,16 +134,17 @@ class WelcomeAndAutoRoleHandler(
         return self.hasPermission(channel, Permission.VIEW_CHANNEL, Permission.MESSAGE_SEND, Permission.MESSAGE_EMBED_LINKS)
     }
 
-    private fun buildEmbed(user: User, text: String, isWelcome: Boolean): MessageEmbed {
-        val builder = EmbedBuilder()
+    private fun buildEmbed(user: User, text: String, color: Int): MessageEmbed =
+        EmbedBuilder()
             .setDescription(text)
-            .setColor(if (isWelcome) WELCOME_COLOR else GOODBYE_COLOR)
+            .setColor(color)
             .setThumbnail(user.effectiveAvatarUrl)
-        return builder.build()
-    }
+            .build()
 
-    companion object {
-        private const val WELCOME_COLOR = 0x57F287 // Discord "green"
-        private const val GOODBYE_COLOR = 0xED4245 // Discord "red"
+    private fun logFailure(label: String, guild: Guild, subjectId: String, error: Throwable) {
+        logger.error {
+            "$label failed for guild ${guild.id} subject $subjectId: " +
+                "${error.javaClass.simpleName}: ${error.message}"
+        }
     }
 }

--- a/discord-bot/src/main/kotlin/bot/toby/welcome/AnnouncementKind.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/welcome/AnnouncementKind.kt
@@ -1,0 +1,45 @@
+package bot.toby.welcome
+
+import database.dto.ConfigDto.Configurations
+
+/**
+ * Bundles the three [Configurations] keys + default template + embed
+ * accent colour + display label for one announcement surface (welcome
+ * or goodbye). Adding a third surface in future (e.g. "level-up
+ * shoutout", "ban announcement") is a one-case addition here instead of
+ * a parallel copy-paste across the handler, the slash command, and the
+ * web service.
+ *
+ * The default template constants live on [WelcomeMessageRenderer] —
+ * this enum just references them so there's still one source of truth
+ * for the rendered text shown when a guild hasn't overridden the
+ * message.
+ */
+enum class AnnouncementKind(
+    val enabledKey: Configurations,
+    val channelKey: Configurations,
+    val messageKey: Configurations,
+    val defaultTemplate: String,
+    /** RGB triple for the announcement embed. Welcome = Discord green,
+     *  goodbye = Discord red. Matches the visual language of native
+     *  Discord join / leave system messages. */
+    val embedColor: Int,
+    val label: String,
+) {
+    WELCOME(
+        enabledKey = Configurations.WELCOME_ENABLED,
+        channelKey = Configurations.WELCOME_CHANNEL,
+        messageKey = Configurations.WELCOME_MESSAGE,
+        defaultTemplate = WelcomeMessageRenderer.DEFAULT_WELCOME,
+        embedColor = 0x57F287,
+        label = "Welcome",
+    ),
+    GOODBYE(
+        enabledKey = Configurations.GOODBYE_ENABLED,
+        channelKey = Configurations.GOODBYE_CHANNEL,
+        messageKey = Configurations.GOODBYE_MESSAGE,
+        defaultTemplate = WelcomeMessageRenderer.DEFAULT_GOODBYE,
+        embedColor = 0xED4245,
+        label = "Goodbye",
+    ),
+}

--- a/discord-bot/src/main/kotlin/bot/toby/welcome/WelcomeMessageRenderer.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/welcome/WelcomeMessageRenderer.kt
@@ -1,0 +1,66 @@
+package bot.toby.welcome
+
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.User
+
+/**
+ * Substitutes the four supported placeholders in welcome / goodbye
+ * messages, returning the rendered text. Kept as a pure object (no JDA
+ * action side effects) so the placeholder grammar is unit-testable
+ * without mocking message-send infrastructure.
+ *
+ * Supported placeholders:
+ *   `{user}`        — user mention (`<@123>`); pings the user.
+ *   `{user.name}`   — display name (effective name when the user is in
+ *                     the guild as a [net.dv8tion.jda.api.entities.Member],
+ *                     otherwise the raw user name). Goodbye messages get
+ *                     the raw name fallback because the member has just
+ *                     left.
+ *   `{server}`      — guild display name.
+ *   `{membercount}` — non-bot member count snapshot. Computed at render
+ *                     time so the value matches what admins see in Discord.
+ *
+ * Unknown braces are passed through verbatim — a typo like `{username}`
+ * appears as-is in the announcement, which is a clearer signal to the
+ * admin than silent removal.
+ */
+object WelcomeMessageRenderer {
+
+    const val DEFAULT_WELCOME = "Welcome to {server}, {user}! You're our {membercount}-th member 🎉"
+    const val DEFAULT_GOODBYE = "{user.name} has left {server}. We're now down to {membercount}."
+
+    fun render(
+        template: String?,
+        guild: Guild,
+        user: User,
+        memberDisplayName: String? = null,
+    ): String {
+        val effective = template?.takeIf { it.isNotBlank() } ?: DEFAULT_WELCOME
+        return substitute(effective, guild, user, memberDisplayName)
+    }
+
+    fun renderGoodbye(
+        template: String?,
+        guild: Guild,
+        user: User,
+        memberDisplayName: String? = null,
+    ): String {
+        val effective = template?.takeIf { it.isNotBlank() } ?: DEFAULT_GOODBYE
+        return substitute(effective, guild, user, memberDisplayName)
+    }
+
+    private fun substitute(
+        template: String,
+        guild: Guild,
+        user: User,
+        memberDisplayName: String?,
+    ): String {
+        val displayName = memberDisplayName?.takeIf { it.isNotBlank() } ?: user.name
+        val memberCount = guild.members.count { !it.user.isBot }
+        return template
+            .replace("{user.name}", displayName)
+            .replace("{user}", user.asMention)
+            .replace("{server}", guild.name)
+            .replace("{membercount}", memberCount.toString())
+    }
+}

--- a/discord-bot/src/main/kotlin/bot/toby/welcome/WelcomeMessageRenderer.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/welcome/WelcomeMessageRenderer.kt
@@ -29,35 +29,25 @@ object WelcomeMessageRenderer {
     const val DEFAULT_WELCOME = "Welcome to {server}, {user}! You're our {membercount}-th member 🎉"
     const val DEFAULT_GOODBYE = "{user.name} has left {server}. We're now down to {membercount}."
 
+    /**
+     * Renders [template] (or [default] when [template] is blank/null) by
+     * substituting the four supported placeholders against the live JDA
+     * context. The welcome / goodbye distinction is collapsed into the
+     * caller's choice of [default] so the renderer doesn't need to know
+     * which surface it's serving — see [AnnouncementKind] for the bundle
+     * of (config keys, default template, embed accent) per surface.
+     */
     fun render(
         template: String?,
+        default: String,
         guild: Guild,
         user: User,
         memberDisplayName: String? = null,
     ): String {
-        val effective = template?.takeIf { it.isNotBlank() } ?: DEFAULT_WELCOME
-        return substitute(effective, guild, user, memberDisplayName)
-    }
-
-    fun renderGoodbye(
-        template: String?,
-        guild: Guild,
-        user: User,
-        memberDisplayName: String? = null,
-    ): String {
-        val effective = template?.takeIf { it.isNotBlank() } ?: DEFAULT_GOODBYE
-        return substitute(effective, guild, user, memberDisplayName)
-    }
-
-    private fun substitute(
-        template: String,
-        guild: Guild,
-        user: User,
-        memberDisplayName: String?,
-    ): String {
+        val effective = template?.takeIf { it.isNotBlank() } ?: default
         val displayName = memberDisplayName?.takeIf { it.isNotBlank() } ?: user.name
         val memberCount = guild.members.count { !it.user.isBot }
-        return template
+        return effective
             .replace("{user.name}", displayName)
             .replace("{user}", user.asMention)
             .replace("{server}", guild.name)

--- a/discord-bot/src/test/kotlin/bot/configuration/JdaListenerRegistrarTest.kt
+++ b/discord-bot/src/test/kotlin/bot/configuration/JdaListenerRegistrarTest.kt
@@ -11,6 +11,7 @@ import bot.toby.handler.ModalEventListener
 import bot.toby.handler.SlashCommandEventListener
 import bot.toby.handler.StartUpHandler
 import bot.toby.handler.VoiceEventHandler
+import bot.toby.handler.WelcomeAndAutoRoleHandler
 import bot.toby.install.InstallWelcomeHandler
 import io.mockk.mockk
 import io.mockk.verify
@@ -34,6 +35,7 @@ class JdaListenerRegistrarTest {
         val eventWaiter = mockk<EventWaiter>()
         val guildLeaveCleanupHandler = mockk<GuildLeaveCleanupHandler>()
         val installWelcomeHandler = mockk<InstallWelcomeHandler>()
+        val welcomeAndAutoRoleHandler = mockk<WelcomeAndAutoRoleHandler>()
 
         JdaListenerRegistrar(
             jda,
@@ -49,6 +51,7 @@ class JdaListenerRegistrarTest {
             eventWaiter,
             guildLeaveCleanupHandler,
             installWelcomeHandler,
+            welcomeAndAutoRoleHandler,
         )
 
         verify {
@@ -65,6 +68,7 @@ class JdaListenerRegistrarTest {
                 eventWaiter,
                 guildLeaveCleanupHandler,
                 installWelcomeHandler,
+                welcomeAndAutoRoleHandler,
             )
         }
     }

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/moderation/WelcomeCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/moderation/WelcomeCommandTest.kt
@@ -1,0 +1,314 @@
+package bot.toby.command.commands.moderation
+
+import bot.toby.command.CommandTest
+import bot.toby.command.CommandTest.Companion.botMember
+import bot.toby.command.CommandTest.Companion.event
+import bot.toby.command.CommandTest.Companion.guild
+import bot.toby.command.CommandTest.Companion.member
+import bot.toby.command.CommandTest.Companion.requestingUserDto
+import bot.toby.command.DefaultCommandContext
+import database.dto.AutoRoleDto
+import database.dto.ConfigDto
+import database.dto.ConfigDto.Configurations
+import database.service.AutoRoleService
+import database.service.ConfigService
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.unmockkAll
+import io.mockk.verify
+import net.dv8tion.jda.api.entities.Role
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
+import net.dv8tion.jda.api.entities.channel.unions.GuildChannelUnion
+import net.dv8tion.jda.api.entities.MessageEmbed
+import net.dv8tion.jda.api.interactions.commands.OptionMapping
+import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class WelcomeCommandTest : CommandTest {
+
+    private lateinit var configService: ConfigService
+    private lateinit var autoRoleService: AutoRoleService
+    private lateinit var command: WelcomeCommand
+    private lateinit var ephemeralReply: ReplyCallbackAction
+
+    @BeforeEach
+    fun setUp() {
+        setUpCommonMocks()
+        configService = mockk(relaxed = true)
+        autoRoleService = mockk(relaxed = true)
+        command = WelcomeCommand(configService, autoRoleService)
+        ephemeralReply = mockk(relaxed = true)
+        every { event.reply(any<String>()) } returns ephemeralReply
+        every { event.replyEmbeds(any<net.dv8tion.jda.api.entities.MessageEmbed>()) } returns ephemeralReply
+        every { ephemeralReply.setEphemeral(any()) } returns ephemeralReply
+        every { ephemeralReply.queue() } just runs
+    }
+
+    @AfterEach
+    fun tearDown() {
+        tearDownCommonMocks()
+        unmockkAll()
+    }
+
+    // ---- owner gate ----
+
+    @Test
+    fun `non-owner cannot configure welcome`() {
+        every { member.isOwner } returns false
+        every { event.subcommandName } returns WelcomeCommand.SUB_CONFIGURE_WELCOME
+
+        command.handle(DefaultCommandContext(event), requestingUserDto, 0)
+
+        verify { event.reply(match<String> { it.contains("Only the server owner") }) }
+        verify(exactly = 0) { configService.upsertAll(any(), any()) }
+    }
+
+    @Test
+    fun `non-owner cannot add auto-role`() {
+        every { member.isOwner } returns false
+        every { event.subcommandName } returns WelcomeCommand.SUB_AUTOROLE_ADD
+
+        command.handle(DefaultCommandContext(event), requestingUserDto, 0)
+
+        verify(exactly = 0) { autoRoleService.add(any(), any()) }
+    }
+
+    @Test
+    fun `show is allowed for non-owners`() {
+        every { member.isOwner } returns false
+        every { event.subcommandName } returns WelcomeCommand.SUB_SHOW
+        every { autoRoleService.listForGuild(any()) } returns emptyList()
+        every { configService.getConfigByName(any(), any()) } returns null
+
+        command.handle(DefaultCommandContext(event), requestingUserDto, 0)
+
+        verify(exactly = 1) { event.replyEmbeds(any<net.dv8tion.jda.api.entities.MessageEmbed>()) }
+    }
+
+    // ---- configure-welcome happy path ----
+
+    @Test
+    fun `configure-welcome with enabled+channel+message upserts all three keys`() {
+        every { member.isOwner } returns true
+        every { event.subcommandName } returns WelcomeCommand.SUB_CONFIGURE_WELCOME
+        stubBoolOpt(WelcomeCommand.OPT_ENABLED, true)
+        val channel = stubChannelOpt(WelcomeCommand.OPT_CHANNEL, 555L, "#welcomes")
+        stubStringOpt(WelcomeCommand.OPT_MESSAGE, "hi {user}")
+
+        command.handle(DefaultCommandContext(event), requestingUserDto, 0)
+
+        verify(exactly = 1) {
+            configService.upsertAll(
+                "1",
+                listOf(
+                    Configurations.WELCOME_ENABLED.configValue to "true",
+                    Configurations.WELCOME_CHANNEL.configValue to "555",
+                    Configurations.WELCOME_MESSAGE.configValue to "hi {user}",
+                ),
+            )
+        }
+        // channel mock returned to make the verify above pass; no other
+        // calls expected on it. We don't strictly verify wasNot Called
+        // because mockk's `relaxed = true` would record incidental
+        // interactions (e.g. logging) that aren't behaviourally relevant.
+        @Suppress("UNUSED_VARIABLE") val unused = channel
+    }
+
+    @Test
+    fun `configure-welcome with only enabled omits channel and message rows`() {
+        every { member.isOwner } returns true
+        every { event.subcommandName } returns WelcomeCommand.SUB_CONFIGURE_WELCOME
+        stubBoolOpt(WelcomeCommand.OPT_ENABLED, false)
+        every { event.getOption(WelcomeCommand.OPT_CHANNEL) } returns null
+        every { event.getOption(WelcomeCommand.OPT_MESSAGE) } returns null
+
+        command.handle(DefaultCommandContext(event), requestingUserDto, 0)
+
+        verify(exactly = 1) {
+            configService.upsertAll(
+                "1",
+                listOf(Configurations.WELCOME_ENABLED.configValue to "false"),
+            )
+        }
+    }
+
+    @Test
+    fun `configure-goodbye writes to GOODBYE_* keys not WELCOME_* keys`() {
+        every { member.isOwner } returns true
+        every { event.subcommandName } returns WelcomeCommand.SUB_CONFIGURE_GOODBYE
+        stubBoolOpt(WelcomeCommand.OPT_ENABLED, true)
+        stubChannelOpt(WelcomeCommand.OPT_CHANNEL, 777L, "#farewells")
+        stubStringOpt(WelcomeCommand.OPT_MESSAGE, "bye {user.name}")
+
+        command.handle(DefaultCommandContext(event), requestingUserDto, 0)
+
+        verify(exactly = 1) {
+            configService.upsertAll(
+                "1",
+                listOf(
+                    Configurations.GOODBYE_ENABLED.configValue to "true",
+                    Configurations.GOODBYE_CHANNEL.configValue to "777",
+                    Configurations.GOODBYE_MESSAGE.configValue to "bye {user.name}",
+                ),
+            )
+        }
+    }
+
+    // ---- autorole add ----
+
+    @Test
+    fun `autorole-add adds the role`() {
+        every { member.isOwner } returns true
+        every { event.subcommandName } returns WelcomeCommand.SUB_AUTOROLE_ADD
+        val role = stubRoleOpt(WelcomeCommand.OPT_ROLE, 100L, "Member", managed = false, public = false, canInteract = true)
+
+        command.handle(DefaultCommandContext(event), requestingUserDto, 0)
+
+        verify(exactly = 1) { autoRoleService.add(1L, 100L) }
+    }
+
+    @Test
+    fun `autorole-add rejects everyone role`() {
+        every { member.isOwner } returns true
+        every { event.subcommandName } returns WelcomeCommand.SUB_AUTOROLE_ADD
+        stubRoleOpt(WelcomeCommand.OPT_ROLE, 100L, "@everyone", managed = false, public = true, canInteract = true)
+
+        command.handle(DefaultCommandContext(event), requestingUserDto, 0)
+
+        verify(exactly = 0) { autoRoleService.add(any(), any()) }
+    }
+
+    @Test
+    fun `autorole-add rejects managed role`() {
+        every { member.isOwner } returns true
+        every { event.subcommandName } returns WelcomeCommand.SUB_AUTOROLE_ADD
+        stubRoleOpt(WelcomeCommand.OPT_ROLE, 100L, "Twitch", managed = true, public = false, canInteract = true)
+
+        command.handle(DefaultCommandContext(event), requestingUserDto, 0)
+
+        verify(exactly = 0) { autoRoleService.add(any(), any()) }
+    }
+
+    @Test
+    fun `autorole-add rejects role above the bot`() {
+        every { member.isOwner } returns true
+        every { event.subcommandName } returns WelcomeCommand.SUB_AUTOROLE_ADD
+        stubRoleOpt(WelcomeCommand.OPT_ROLE, 100L, "Admin", managed = false, public = false, canInteract = false)
+
+        command.handle(DefaultCommandContext(event), requestingUserDto, 0)
+
+        verify(exactly = 0) { autoRoleService.add(any(), any()) }
+    }
+
+    // ---- autorole remove ----
+
+    @Test
+    fun `autorole-remove drops the binding`() {
+        every { member.isOwner } returns true
+        every { event.subcommandName } returns WelcomeCommand.SUB_AUTOROLE_REMOVE
+        stubRoleOpt(WelcomeCommand.OPT_ROLE, 100L, "Member", managed = false, public = false, canInteract = true)
+
+        command.handle(DefaultCommandContext(event), requestingUserDto, 0)
+
+        verify(exactly = 1) { autoRoleService.delete(1L, 100L) }
+    }
+
+    // ---- show ----
+
+    @Test
+    fun `show reads every config key and lists auto-roles`() {
+        every { member.isOwner } returns true
+        every { event.subcommandName } returns WelcomeCommand.SUB_SHOW
+        every {
+            configService.getConfigByName(Configurations.WELCOME_ENABLED.configValue, "1")
+        } returns ConfigDto(Configurations.WELCOME_ENABLED.configValue, "true", "1")
+        every {
+            configService.getConfigByName(Configurations.WELCOME_CHANNEL.configValue, "1")
+        } returns ConfigDto(Configurations.WELCOME_CHANNEL.configValue, "555", "1")
+        every {
+            configService.getConfigByName(Configurations.WELCOME_MESSAGE.configValue, "1")
+        } returns ConfigDto(Configurations.WELCOME_MESSAGE.configValue, "hi {user}", "1")
+        every { autoRoleService.listForGuild(1L) } returns listOf(
+            AutoRoleDto(guildId = 1L, roleId = 100L),
+            AutoRoleDto(guildId = 1L, roleId = 200L),
+        )
+
+        command.handle(DefaultCommandContext(event), requestingUserDto, 0)
+
+        verify(exactly = 1) { event.replyEmbeds(any<net.dv8tion.jda.api.entities.MessageEmbed>()) }
+        verify(exactly = 1) { autoRoleService.listForGuild(1L) }
+    }
+
+    // ---- subcommand sanity ----
+
+    @Test
+    fun `subCommands carry the five expected names`() {
+        val names = command.subCommands.map { it.name }.toSet()
+        assert(names == setOf(
+            WelcomeCommand.SUB_CONFIGURE_WELCOME,
+            WelcomeCommand.SUB_CONFIGURE_GOODBYE,
+            WelcomeCommand.SUB_AUTOROLE_ADD,
+            WelcomeCommand.SUB_AUTOROLE_REMOVE,
+            WelcomeCommand.SUB_SHOW,
+        )) { "subcommand names changed: $names" }
+    }
+
+    // ---- helpers ----
+
+    private fun stubBoolOpt(name: String, value: Boolean) {
+        val opt = mockk<OptionMapping>(relaxed = true)
+        every { opt.asBoolean } returns value
+        every { event.getOption(name) } returns opt
+    }
+
+    private fun stubStringOpt(name: String, value: String) {
+        val opt = mockk<OptionMapping>(relaxed = true)
+        every { opt.asString } returns value
+        every { event.getOption(name) } returns opt
+    }
+
+    private fun stubChannelOpt(name: String, id: Long, displayName: String): TextChannel {
+        val opt = mockk<OptionMapping>(relaxed = true)
+        val channel = mockk<TextChannel>(relaxed = true)
+        val union = mockk<GuildChannelUnion>(relaxed = true)
+        every { channel.id } returns id.toString()
+        every { channel.idLong } returns id
+        every { channel.asMention } returns displayName
+        // Production code reaches the channel via
+        // `event.getOption(...).asChannel.asTextChannel()` so the union →
+        // TextChannel resolution is what we mock through; no Kotlin cast
+        // needed in the test setup.
+        every { opt.asChannel } returns union
+        every { union.asTextChannel() } returns channel
+        every { event.getOption(name) } returns opt
+        return channel
+    }
+
+    private fun stubRoleOpt(
+        name: String,
+        id: Long,
+        roleName: String,
+        managed: Boolean,
+        public: Boolean,
+        canInteract: Boolean,
+    ): Role {
+        val opt = mockk<OptionMapping>(relaxed = true)
+        val role = mockk<Role>(relaxed = true)
+        every { role.idLong } returns id
+        every { role.id } returns id.toString()
+        every { role.name } returns roleName
+        every { role.isManaged } returns managed
+        every { role.isPublicRole } returns public
+        every { role.asMention } returns "<@&$id>"
+        every { opt.asRole } returns role
+        every { event.getOption(name) } returns opt
+        // CommandTest wires `guild.selfMember` to return `botMember`
+        // (a mocked SelfMember). Mock the canInteract probe through that.
+        every { botMember.canInteract(role) } returns canInteract
+        return role
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/handler/WelcomeAndAutoRoleHandlerTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/handler/WelcomeAndAutoRoleHandlerTest.kt
@@ -1,0 +1,403 @@
+package bot.toby.handler
+
+import database.dto.AutoRoleDto
+import database.dto.ConfigDto
+import database.dto.ConfigDto.Configurations
+import database.service.AutoRoleService
+import database.service.ConfigService
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.slot
+import io.mockk.verify
+import net.dv8tion.jda.api.Permission
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.Member
+import net.dv8tion.jda.api.entities.MessageEmbed
+import net.dv8tion.jda.api.entities.Role
+import net.dv8tion.jda.api.entities.SelfMember
+import net.dv8tion.jda.api.entities.User
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
+import net.dv8tion.jda.api.events.guild.member.GuildMemberJoinEvent
+import net.dv8tion.jda.api.events.guild.member.GuildMemberRemoveEvent
+import net.dv8tion.jda.api.requests.restaction.AuditableRestAction
+import net.dv8tion.jda.api.requests.restaction.MessageCreateAction
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * Behavioural tests for [WelcomeAndAutoRoleHandler] covering:
+ *   - the four enabled / disabled / channel-set / channel-missing branches
+ *     for both welcome and goodbye paths,
+ *   - the four guard branches in auto-role assignment (missing role,
+ *     managed role, role above bot, bot missing MANAGE_ROLES),
+ *   - the channel fallback to `guild.systemChannel` when the configured
+ *     channel is blank, unparseable, or non-postable.
+ */
+class WelcomeAndAutoRoleHandlerTest {
+
+    private lateinit var configService: ConfigService
+    private lateinit var autoRoleService: AutoRoleService
+    private lateinit var handler: WelcomeAndAutoRoleHandler
+
+    private lateinit var guild: Guild
+    private lateinit var selfMember: SelfMember
+    private lateinit var joinedMember: Member
+    private lateinit var joinedUser: User
+    private lateinit var configuredChannel: TextChannel
+    private lateinit var systemChannel: TextChannel
+    private lateinit var messageAction: MessageCreateAction
+    private lateinit var roleAddAction: AuditableRestAction<Void>
+
+    private val guildId = 1000L
+    private val configuredChannelId = 555L
+
+    @BeforeEach
+    fun setUp() {
+        configService = mockk(relaxed = true)
+        autoRoleService = mockk(relaxed = true)
+        handler = WelcomeAndAutoRoleHandler(configService, autoRoleService)
+
+        guild = mockk(relaxed = true)
+        selfMember = mockk(relaxed = true)
+        joinedMember = mockk(relaxed = true)
+        joinedUser = mockk(relaxed = true)
+        configuredChannel = mockk(relaxed = true)
+        systemChannel = mockk(relaxed = true)
+        messageAction = mockk(relaxed = true)
+        @Suppress("UNCHECKED_CAST")
+        roleAddAction = mockk<AuditableRestAction<Void>>(relaxed = true)
+
+        every { guild.id } returns guildId.toString()
+        every { guild.idLong } returns guildId
+        every { guild.name } returns "Test Guild"
+        every { guild.selfMember } returns selfMember
+        every { guild.members } returns emptyList()
+        every { guild.systemChannel } returns systemChannel
+
+        every { configuredChannel.id } returns configuredChannelId.toString()
+        every { configuredChannel.idLong } returns configuredChannelId
+        every { configuredChannel.name } returns "welcomes"
+        every { systemChannel.id } returns "999"
+        every { systemChannel.name } returns "general"
+
+        every { joinedMember.user } returns joinedUser
+        every { joinedMember.id } returns "42"
+        every { joinedMember.idLong } returns 42L
+        every { joinedMember.effectiveName } returns "Alice"
+        every { joinedUser.id } returns "42"
+        every { joinedUser.idLong } returns 42L
+        every { joinedUser.name } returns "alice"
+        every { joinedUser.asMention } returns "<@42>"
+        every { joinedUser.effectiveAvatarUrl } returns "https://avatar/42.png"
+
+        every { configuredChannel.sendMessageEmbeds(any<MessageEmbed>()) } returns messageAction
+        every { systemChannel.sendMessageEmbeds(any<MessageEmbed>()) } returns messageAction
+        every { messageAction.queue(any(), any()) } just runs
+    }
+
+    // ---- welcome announcement ----
+
+    @Test
+    fun `welcome disabled does not post anything`() {
+        every {
+            configService.getConfigByName(Configurations.WELCOME_ENABLED.configValue, guildId.toString())
+        } returns ConfigDto(Configurations.WELCOME_ENABLED.configValue, "false", guildId.toString())
+        every { autoRoleService.listForGuild(guildId) } returns emptyList()
+
+        val event = mockk<GuildMemberJoinEvent>(relaxed = true)
+        every { event.guild } returns guild
+        every { event.member } returns joinedMember
+
+        handler.onGuildMemberJoin(event)
+
+        verify(exactly = 0) { configuredChannel.sendMessageEmbeds(any<MessageEmbed>()) }
+        verify(exactly = 0) { systemChannel.sendMessageEmbeds(any<MessageEmbed>()) }
+    }
+
+    @Test
+    fun `welcome enabled posts to configured channel`() {
+        stubFlag(Configurations.WELCOME_ENABLED, "true")
+        stubKey(Configurations.WELCOME_CHANNEL, configuredChannelId.toString())
+        stubKey(Configurations.WELCOME_MESSAGE, "hi {user}")
+        every { guild.getTextChannelById(configuredChannelId) } returns configuredChannel
+        every {
+            selfMember.hasPermission(configuredChannel, *anyVararg<Permission>())
+        } returns true
+        every { autoRoleService.listForGuild(guildId) } returns emptyList()
+
+        val event = mockk<GuildMemberJoinEvent>(relaxed = true).also {
+            every { it.guild } returns guild
+            every { it.member } returns joinedMember
+        }
+        handler.onGuildMemberJoin(event)
+
+        verify(exactly = 1) { configuredChannel.sendMessageEmbeds(any<MessageEmbed>()) }
+        verify(exactly = 0) { systemChannel.sendMessageEmbeds(any<MessageEmbed>()) }
+    }
+
+    @Test
+    fun `welcome enabled with blank channel falls back to system channel`() {
+        stubFlag(Configurations.WELCOME_ENABLED, "true")
+        stubKey(Configurations.WELCOME_CHANNEL, "")
+        every {
+            selfMember.hasPermission(systemChannel, *anyVararg<Permission>())
+        } returns true
+        every { autoRoleService.listForGuild(guildId) } returns emptyList()
+
+        val event = mockk<GuildMemberJoinEvent>(relaxed = true).also {
+            every { it.guild } returns guild
+            every { it.member } returns joinedMember
+        }
+        handler.onGuildMemberJoin(event)
+
+        verify(exactly = 1) { systemChannel.sendMessageEmbeds(any<MessageEmbed>()) }
+    }
+
+    @Test
+    fun `welcome enabled with non-postable configured channel falls back to system channel`() {
+        stubFlag(Configurations.WELCOME_ENABLED, "true")
+        stubKey(Configurations.WELCOME_CHANNEL, configuredChannelId.toString())
+        every { guild.getTextChannelById(configuredChannelId) } returns configuredChannel
+        every {
+            selfMember.hasPermission(configuredChannel, *anyVararg<Permission>())
+        } returns false
+        every {
+            selfMember.hasPermission(systemChannel, *anyVararg<Permission>())
+        } returns true
+        every { autoRoleService.listForGuild(guildId) } returns emptyList()
+
+        val event = mockk<GuildMemberJoinEvent>(relaxed = true).also {
+            every { it.guild } returns guild
+            every { it.member } returns joinedMember
+        }
+        handler.onGuildMemberJoin(event)
+
+        verify(exactly = 0) { configuredChannel.sendMessageEmbeds(any<MessageEmbed>()) }
+        verify(exactly = 1) { systemChannel.sendMessageEmbeds(any<MessageEmbed>()) }
+    }
+
+    @Test
+    fun `welcome enabled with no postable channel skips silently`() {
+        stubFlag(Configurations.WELCOME_ENABLED, "true")
+        stubKey(Configurations.WELCOME_CHANNEL, "")
+        every {
+            selfMember.hasPermission(systemChannel, *anyVararg<Permission>())
+        } returns false
+        every { autoRoleService.listForGuild(guildId) } returns emptyList()
+
+        val event = mockk<GuildMemberJoinEvent>(relaxed = true).also {
+            every { it.guild } returns guild
+            every { it.member } returns joinedMember
+        }
+        handler.onGuildMemberJoin(event)
+
+        verify(exactly = 0) { systemChannel.sendMessageEmbeds(any<MessageEmbed>()) }
+        verify(exactly = 0) { configuredChannel.sendMessageEmbeds(any<MessageEmbed>()) }
+    }
+
+    // ---- goodbye announcement ----
+
+    @Test
+    fun `goodbye disabled does not post anything`() {
+        every {
+            configService.getConfigByName(Configurations.GOODBYE_ENABLED.configValue, guildId.toString())
+        } returns ConfigDto(Configurations.GOODBYE_ENABLED.configValue, "false", guildId.toString())
+
+        val event = mockk<GuildMemberRemoveEvent>(relaxed = true).also {
+            every { it.guild } returns guild
+            every { it.user } returns joinedUser
+            every { it.member } returns null
+        }
+        handler.onGuildMemberRemove(event)
+
+        verify(exactly = 0) { systemChannel.sendMessageEmbeds(any<MessageEmbed>()) }
+    }
+
+    @Test
+    fun `goodbye enabled posts to configured channel`() {
+        stubFlag(Configurations.GOODBYE_ENABLED, "true")
+        stubKey(Configurations.GOODBYE_CHANNEL, configuredChannelId.toString())
+        stubKey(Configurations.GOODBYE_MESSAGE, "bye {user.name}")
+        every { guild.getTextChannelById(configuredChannelId) } returns configuredChannel
+        every {
+            selfMember.hasPermission(configuredChannel, *anyVararg<Permission>())
+        } returns true
+
+        val event = mockk<GuildMemberRemoveEvent>(relaxed = true).also {
+            every { it.guild } returns guild
+            every { it.user } returns joinedUser
+            every { it.member } returns joinedMember
+        }
+        handler.onGuildMemberRemove(event)
+
+        verify(exactly = 1) { configuredChannel.sendMessageEmbeds(any<MessageEmbed>()) }
+    }
+
+    // ---- auto-role assignment ----
+
+    @Test
+    fun `auto-role assigns every valid role`() {
+        stubFlag(Configurations.WELCOME_ENABLED, "false")
+        stubFlag(Configurations.GOODBYE_ENABLED, "false")
+        val roleA = stubRole(100L, "Member", managed = false, canInteract = true)
+        val roleB = stubRole(200L, "Verified", managed = false, canInteract = true)
+        every { selfMember.hasPermission(Permission.MANAGE_ROLES) } returns true
+        every { autoRoleService.listForGuild(guildId) } returns listOf(
+            AutoRoleDto(guildId = guildId, roleId = 100L),
+            AutoRoleDto(guildId = guildId, roleId = 200L),
+        )
+        every { guild.addRoleToMember(joinedMember, any<Role>()) } returns roleAddAction
+        every { roleAddAction.queue(any(), any()) } just runs
+
+        val event = mockk<GuildMemberJoinEvent>(relaxed = true).also {
+            every { it.guild } returns guild
+            every { it.member } returns joinedMember
+        }
+        handler.onGuildMemberJoin(event)
+
+        verify(exactly = 1) { guild.addRoleToMember(joinedMember, roleA) }
+        verify(exactly = 1) { guild.addRoleToMember(joinedMember, roleB) }
+    }
+
+    @Test
+    fun `auto-role skips missing role`() {
+        stubFlag(Configurations.WELCOME_ENABLED, "false")
+        every { selfMember.hasPermission(Permission.MANAGE_ROLES) } returns true
+        every { autoRoleService.listForGuild(guildId) } returns listOf(
+            AutoRoleDto(guildId = guildId, roleId = 100L),
+        )
+        every { guild.getRoleById(100L) } returns null
+        every { guild.addRoleToMember(joinedMember, any<Role>()) } returns roleAddAction
+
+        val event = mockk<GuildMemberJoinEvent>(relaxed = true).also {
+            every { it.guild } returns guild
+            every { it.member } returns joinedMember
+        }
+        handler.onGuildMemberJoin(event)
+
+        verify(exactly = 0) { guild.addRoleToMember(joinedMember, any<Role>()) }
+    }
+
+    @Test
+    fun `auto-role skips managed role`() {
+        stubFlag(Configurations.WELCOME_ENABLED, "false")
+        stubRole(100L, "Twitch sub", managed = true, canInteract = true)
+        every { selfMember.hasPermission(Permission.MANAGE_ROLES) } returns true
+        every { autoRoleService.listForGuild(guildId) } returns listOf(
+            AutoRoleDto(guildId = guildId, roleId = 100L),
+        )
+
+        val event = mockk<GuildMemberJoinEvent>(relaxed = true).also {
+            every { it.guild } returns guild
+            every { it.member } returns joinedMember
+        }
+        handler.onGuildMemberJoin(event)
+
+        verify(exactly = 0) { guild.addRoleToMember(joinedMember, any<Role>()) }
+    }
+
+    @Test
+    fun `auto-role skips role bot cannot interact with`() {
+        stubFlag(Configurations.WELCOME_ENABLED, "false")
+        stubRole(100L, "Admin", managed = false, canInteract = false)
+        every { selfMember.hasPermission(Permission.MANAGE_ROLES) } returns true
+        every { autoRoleService.listForGuild(guildId) } returns listOf(
+            AutoRoleDto(guildId = guildId, roleId = 100L),
+        )
+
+        val event = mockk<GuildMemberJoinEvent>(relaxed = true).also {
+            every { it.guild } returns guild
+            every { it.member } returns joinedMember
+        }
+        handler.onGuildMemberJoin(event)
+
+        verify(exactly = 0) { guild.addRoleToMember(joinedMember, any<Role>()) }
+    }
+
+    @Test
+    fun `auto-role bails when bot lacks MANAGE_ROLES`() {
+        stubFlag(Configurations.WELCOME_ENABLED, "false")
+        every { selfMember.hasPermission(Permission.MANAGE_ROLES) } returns false
+        every { autoRoleService.listForGuild(guildId) } returns listOf(
+            AutoRoleDto(guildId = guildId, roleId = 100L),
+        )
+
+        val event = mockk<GuildMemberJoinEvent>(relaxed = true).also {
+            every { it.guild } returns guild
+            every { it.member } returns joinedMember
+        }
+        handler.onGuildMemberJoin(event)
+
+        verify(exactly = 0) { guild.addRoleToMember(joinedMember, any<Role>()) }
+    }
+
+    @Test
+    fun `auto-role no-op when list is empty`() {
+        stubFlag(Configurations.WELCOME_ENABLED, "false")
+        every { selfMember.hasPermission(Permission.MANAGE_ROLES) } returns true
+        every { autoRoleService.listForGuild(guildId) } returns emptyList()
+
+        val event = mockk<GuildMemberJoinEvent>(relaxed = true).also {
+            every { it.guild } returns guild
+            every { it.member } returns joinedMember
+        }
+        handler.onGuildMemberJoin(event)
+
+        verify(exactly = 0) { selfMember.hasPermission(Permission.MANAGE_ROLES) }
+    }
+
+    @Test
+    fun `welcome failure does not block auto-role assignment`() {
+        // If the welcome post throws (or the renderer blows up because the
+        // guild mock is short-stubbed), auto-role assignment must still run.
+        // Each side is wrapped in its own runCatching in the handler so a
+        // bad welcome configuration can never starve role assignment.
+        stubFlag(Configurations.WELCOME_ENABLED, "true")
+        stubKey(Configurations.WELCOME_CHANNEL, configuredChannelId.toString())
+        every { guild.getTextChannelById(configuredChannelId) } throws IllegalStateException("boom")
+
+        stubRole(100L, "Member", managed = false, canInteract = true)
+        every { selfMember.hasPermission(Permission.MANAGE_ROLES) } returns true
+        every { autoRoleService.listForGuild(guildId) } returns listOf(
+            AutoRoleDto(guildId = guildId, roleId = 100L),
+        )
+        every { guild.addRoleToMember(joinedMember, any<Role>()) } returns roleAddAction
+        every { roleAddAction.queue(any(), any()) } just runs
+
+        val event = mockk<GuildMemberJoinEvent>(relaxed = true).also {
+            every { it.guild } returns guild
+            every { it.member } returns joinedMember
+        }
+        handler.onGuildMemberJoin(event)
+
+        verify(exactly = 1) { guild.addRoleToMember(joinedMember, any<Role>()) }
+    }
+
+    // ---- helpers ----
+
+    private fun stubFlag(key: Configurations, value: String) {
+        every {
+            configService.getConfigByName(key.configValue, guildId.toString())
+        } returns ConfigDto(key.configValue, value, guildId.toString())
+    }
+
+    private fun stubKey(key: Configurations, value: String) {
+        every {
+            configService.getConfigByName(key.configValue, guildId.toString())
+        } returns ConfigDto(key.configValue, value, guildId.toString())
+    }
+
+    private fun stubRole(id: Long, name: String, managed: Boolean, canInteract: Boolean): Role {
+        val role = mockk<Role>(relaxed = true).also {
+            every { it.idLong } returns id
+            every { it.id } returns id.toString()
+            every { it.name } returns name
+            every { it.isManaged } returns managed
+        }
+        every { guild.getRoleById(id) } returns role
+        every { selfMember.canInteract(role) } returns canInteract
+        return role
+    }
+}

--- a/discord-bot/src/test/kotlin/bot/toby/welcome/WelcomeMessageRendererTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/welcome/WelcomeMessageRendererTest.kt
@@ -43,12 +43,14 @@ class WelcomeMessageRendererTest {
         every { guild.members } returns listOf(humanMember, humanMember, humanMember, botMember)
     }
 
-    // ---- welcome path ----
+    // ---- substitution ----
 
     @Test
     fun `render substitutes all four placeholders`() {
         val template = "Hi {user} aka {user.name}, welcome to {server} (member #{membercount})"
-        val out = WelcomeMessageRenderer.render(template, guild, user, memberDisplayName = "Alice")
+        val out = WelcomeMessageRenderer.render(
+            template, WelcomeMessageRenderer.DEFAULT_WELCOME, guild, user, memberDisplayName = "Alice",
+        )
         assertEquals("Hi <@123> aka Alice, welcome to My Cool Guild (member #3)", out)
     }
 
@@ -56,6 +58,7 @@ class WelcomeMessageRendererTest {
     fun `render falls back to user name when member display name is blank`() {
         val out = WelcomeMessageRenderer.render(
             template = "Hi {user.name}",
+            default = WelcomeMessageRenderer.DEFAULT_WELCOME,
             guild = guild,
             user = user,
             memberDisplayName = "   ",
@@ -67,6 +70,7 @@ class WelcomeMessageRendererTest {
     fun `render falls back to user name when member display name is null`() {
         val out = WelcomeMessageRenderer.render(
             template = "Hi {user.name}",
+            default = WelcomeMessageRenderer.DEFAULT_WELCOME,
             guild = guild,
             user = user,
             memberDisplayName = null,
@@ -76,7 +80,13 @@ class WelcomeMessageRendererTest {
 
     @Test
     fun `render uses default template when caller supplies blank text`() {
-        val out = WelcomeMessageRenderer.render(template = "", guild = guild, user = user, memberDisplayName = "Alice")
+        val out = WelcomeMessageRenderer.render(
+            template = "",
+            default = WelcomeMessageRenderer.DEFAULT_WELCOME,
+            guild = guild,
+            user = user,
+            memberDisplayName = "Alice",
+        )
         // Default template expands {user}, {server}, {membercount}
         assertTrue(out.contains("<@123>"), "expected user mention in default template: $out")
         assertTrue(out.contains("My Cool Guild"), "expected guild name in default template: $out")
@@ -85,7 +95,12 @@ class WelcomeMessageRendererTest {
 
     @Test
     fun `render uses default template when caller supplies null text`() {
-        val out = WelcomeMessageRenderer.render(template = null, guild = guild, user = user)
+        val out = WelcomeMessageRenderer.render(
+            template = null,
+            default = WelcomeMessageRenderer.DEFAULT_WELCOME,
+            guild = guild,
+            user = user,
+        )
         assertTrue(out.contains("My Cool Guild"), out)
     }
 
@@ -93,6 +108,7 @@ class WelcomeMessageRendererTest {
     fun `render passes unknown placeholders through verbatim`() {
         val out = WelcomeMessageRenderer.render(
             template = "Hi {usernme} (typo) — {user.name}",
+            default = WelcomeMessageRenderer.DEFAULT_WELCOME,
             guild = guild,
             user = user,
             memberDisplayName = "Alice",
@@ -107,6 +123,7 @@ class WelcomeMessageRendererTest {
     fun `render counts only non-bot members`() {
         val out = WelcomeMessageRenderer.render(
             template = "{membercount}",
+            default = WelcomeMessageRenderer.DEFAULT_WELCOME,
             guild = guild,
             user = user,
             memberDisplayName = "Alice",
@@ -122,6 +139,7 @@ class WelcomeMessageRendererTest {
         // consume `{user.name}` and leave a literal `.name` artefact.
         val out = WelcomeMessageRenderer.render(
             template = "{user} {user.name}",
+            default = WelcomeMessageRenderer.DEFAULT_WELCOME,
             guild = guild,
             user = user,
             memberDisplayName = "Alice",
@@ -130,39 +148,29 @@ class WelcomeMessageRendererTest {
         assertFalse(out.contains(".name"), "user_name token must be consumed before user: $out")
     }
 
-    // ---- goodbye path ----
+    // ---- default selection ----
 
     @Test
-    fun `renderGoodbye uses the goodbye default when template is blank`() {
-        val out = WelcomeMessageRenderer.renderGoodbye(
+    fun `render uses the supplied default for goodbye when template is blank`() {
+        val out = WelcomeMessageRenderer.render(
             template = null,
+            default = WelcomeMessageRenderer.DEFAULT_GOODBYE,
             guild = guild,
             user = user,
             memberDisplayName = null,
         )
-        // Default goodbye references {user.name} and {server}
+        // DEFAULT_GOODBYE references {user.name} and {server}
         assertTrue(out.contains("alice"), out)
         assertTrue(out.contains("My Cool Guild"), out)
     }
 
     @Test
-    fun `renderGoodbye substitutes placeholders the same way as render`() {
-        val out = WelcomeMessageRenderer.renderGoodbye(
-            template = "Goodbye {user.name} from {server}",
-            guild = guild,
-            user = user,
-            memberDisplayName = "Alice",
-        )
-        assertEquals("Goodbye Alice from My Cool Guild", out)
-    }
-
-    @Test
-    fun `default templates differ between welcome and goodbye`() {
+    fun `render with goodbye default produces different text than welcome default`() {
         // Same fixture, blank template, but the welcome and goodbye defaults
         // must produce different text — otherwise admins who opt into both
         // get duplicate messages on a quick join-then-leave.
-        val welcome = WelcomeMessageRenderer.render(null, guild, user, "Alice")
-        val goodbye = WelcomeMessageRenderer.renderGoodbye(null, guild, user, "Alice")
+        val welcome = WelcomeMessageRenderer.render(null, WelcomeMessageRenderer.DEFAULT_WELCOME, guild, user, "Alice")
+        val goodbye = WelcomeMessageRenderer.render(null, WelcomeMessageRenderer.DEFAULT_GOODBYE, guild, user, "Alice")
         assertFalse(welcome == goodbye, "welcome and goodbye defaults must differ")
     }
 }

--- a/discord-bot/src/test/kotlin/bot/toby/welcome/WelcomeMessageRendererTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/welcome/WelcomeMessageRendererTest.kt
@@ -1,0 +1,168 @@
+package bot.toby.welcome
+
+import io.mockk.every
+import io.mockk.mockk
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.Member
+import net.dv8tion.jda.api.entities.User
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * Placeholder-substitution unit tests for [WelcomeMessageRenderer].
+ * Pure-function tests — no JDA action side effects, no DB. Together
+ * with [bot.toby.handler.WelcomeAndAutoRoleHandlerTest] (which verifies
+ * the listener calls the renderer, picks the right channel, and posts
+ * an embed) these pin the announcement pipeline end-to-end.
+ */
+class WelcomeMessageRendererTest {
+
+    private lateinit var guild: Guild
+    private lateinit var user: User
+    private lateinit var humanMember: Member
+    private lateinit var botMember: Member
+
+    @BeforeEach
+    fun setup() {
+        guild = mockk(relaxed = true)
+        user = mockk(relaxed = true)
+        every { guild.name } returns "My Cool Guild"
+        every { user.asMention } returns "<@123>"
+        every { user.name } returns "alice"
+
+        humanMember = mockk(relaxed = true)
+        botMember = mockk(relaxed = true)
+        val humanUser = mockk<User>(relaxed = true).also { every { it.isBot } returns false }
+        val botUser = mockk<User>(relaxed = true).also { every { it.isBot } returns true }
+        every { humanMember.user } returns humanUser
+        every { botMember.user } returns botUser
+        // Three humans + one bot — placeholder reads "3"
+        every { guild.members } returns listOf(humanMember, humanMember, humanMember, botMember)
+    }
+
+    // ---- welcome path ----
+
+    @Test
+    fun `render substitutes all four placeholders`() {
+        val template = "Hi {user} aka {user.name}, welcome to {server} (member #{membercount})"
+        val out = WelcomeMessageRenderer.render(template, guild, user, memberDisplayName = "Alice")
+        assertEquals("Hi <@123> aka Alice, welcome to My Cool Guild (member #3)", out)
+    }
+
+    @Test
+    fun `render falls back to user name when member display name is blank`() {
+        val out = WelcomeMessageRenderer.render(
+            template = "Hi {user.name}",
+            guild = guild,
+            user = user,
+            memberDisplayName = "   ",
+        )
+        assertEquals("Hi alice", out)
+    }
+
+    @Test
+    fun `render falls back to user name when member display name is null`() {
+        val out = WelcomeMessageRenderer.render(
+            template = "Hi {user.name}",
+            guild = guild,
+            user = user,
+            memberDisplayName = null,
+        )
+        assertEquals("Hi alice", out)
+    }
+
+    @Test
+    fun `render uses default template when caller supplies blank text`() {
+        val out = WelcomeMessageRenderer.render(template = "", guild = guild, user = user, memberDisplayName = "Alice")
+        // Default template expands {user}, {server}, {membercount}
+        assertTrue(out.contains("<@123>"), "expected user mention in default template: $out")
+        assertTrue(out.contains("My Cool Guild"), "expected guild name in default template: $out")
+        assertTrue(out.contains("3"), "expected member count in default template: $out")
+    }
+
+    @Test
+    fun `render uses default template when caller supplies null text`() {
+        val out = WelcomeMessageRenderer.render(template = null, guild = guild, user = user)
+        assertTrue(out.contains("My Cool Guild"), out)
+    }
+
+    @Test
+    fun `render passes unknown placeholders through verbatim`() {
+        val out = WelcomeMessageRenderer.render(
+            template = "Hi {usernme} (typo) — {user.name}",
+            guild = guild,
+            user = user,
+            memberDisplayName = "Alice",
+        )
+        // `{usernme}` is not a known token — copied through so admins see
+        // the typo instead of silent removal.
+        assertTrue(out.contains("{usernme}"), out)
+        assertTrue(out.contains("Alice"), out)
+    }
+
+    @Test
+    fun `render counts only non-bot members`() {
+        val out = WelcomeMessageRenderer.render(
+            template = "{membercount}",
+            guild = guild,
+            user = user,
+            memberDisplayName = "Alice",
+        )
+        // 3 humans, 1 bot → 3
+        assertEquals("3", out)
+    }
+
+    @Test
+    fun `render substitutes user_name before user so mention wins for plain user token`() {
+        // Substitution order matters: `{user.name}` and `{user}` share a
+        // prefix. If `{user}` were replaced first it would partially
+        // consume `{user.name}` and leave a literal `.name` artefact.
+        val out = WelcomeMessageRenderer.render(
+            template = "{user} {user.name}",
+            guild = guild,
+            user = user,
+            memberDisplayName = "Alice",
+        )
+        assertEquals("<@123> Alice", out)
+        assertFalse(out.contains(".name"), "user_name token must be consumed before user: $out")
+    }
+
+    // ---- goodbye path ----
+
+    @Test
+    fun `renderGoodbye uses the goodbye default when template is blank`() {
+        val out = WelcomeMessageRenderer.renderGoodbye(
+            template = null,
+            guild = guild,
+            user = user,
+            memberDisplayName = null,
+        )
+        // Default goodbye references {user.name} and {server}
+        assertTrue(out.contains("alice"), out)
+        assertTrue(out.contains("My Cool Guild"), out)
+    }
+
+    @Test
+    fun `renderGoodbye substitutes placeholders the same way as render`() {
+        val out = WelcomeMessageRenderer.renderGoodbye(
+            template = "Goodbye {user.name} from {server}",
+            guild = guild,
+            user = user,
+            memberDisplayName = "Alice",
+        )
+        assertEquals("Goodbye Alice from My Cool Guild", out)
+    }
+
+    @Test
+    fun `default templates differ between welcome and goodbye`() {
+        // Same fixture, blank template, but the welcome and goodbye defaults
+        // must produce different text — otherwise admins who opt into both
+        // get duplicate messages on a quick join-then-leave.
+        val welcome = WelcomeMessageRenderer.render(null, guild, user, "Alice")
+        val goodbye = WelcomeMessageRenderer.renderGoodbye(null, guild, user, "Alice")
+        assertFalse(welcome == goodbye, "welcome and goodbye defaults must differ")
+    }
+}

--- a/discord-bot/src/test/kotlin/common/discord/AutoRoleValidatorTest.kt
+++ b/discord-bot/src/test/kotlin/common/discord/AutoRoleValidatorTest.kt
@@ -1,0 +1,77 @@
+package common.discord
+
+import io.mockk.every
+import io.mockk.mockk
+import net.dv8tion.jda.api.entities.Role
+import net.dv8tion.jda.api.entities.SelfMember
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * Unit tests for [AutoRoleValidator]. Pinned independently of the three
+ * consumers (slash command, web service, listener) so a wording change
+ * here forces every consumer's test to acknowledge the new copy.
+ */
+class AutoRoleValidatorTest {
+
+    private lateinit var role: Role
+    private lateinit var selfMember: SelfMember
+
+    @BeforeEach
+    fun setUp() {
+        role = mockk<Role>(relaxed = true).also {
+            every { it.id } returns "100"
+            every { it.idLong } returns 100L
+            every { it.name } returns "Member"
+            every { it.asMention } returns "<@&100>"
+            every { it.isPublicRole } returns false
+            every { it.isManaged } returns false
+        }
+        selfMember = mockk<SelfMember>(relaxed = true).also {
+            every { it.canInteract(role) } returns true
+        }
+    }
+
+    @Test
+    fun `valid role returns null`() {
+        assertNull(AutoRoleValidator.validate(role, selfMember))
+    }
+
+    @Test
+    fun `everyone role is rejected with a specific message`() {
+        every { role.isPublicRole } returns true
+        assertEquals("Cannot auto-assign @everyone.", AutoRoleValidator.validate(role, selfMember))
+    }
+
+    @Test
+    fun `managed role is rejected with the role mention in the message`() {
+        every { role.isManaged } returns true
+        val msg = AutoRoleValidator.validate(role, selfMember)
+        assertEquals(
+            "<@&100> is managed by an integration and can't be assigned by the bot.",
+            msg,
+        )
+    }
+
+    @Test
+    fun `role above the bot is rejected with a position-fix hint`() {
+        every { selfMember.canInteract(role) } returns false
+        val msg = AutoRoleValidator.validate(role, selfMember)
+        assertEquals(
+            "<@&100> sits above TobyBot's role — move TobyBot's role higher to allow assignment.",
+            msg,
+        )
+    }
+
+    @Test
+    fun `everyone is rejected even when also managed`() {
+        // Belt-and-braces: if a role somehow matches multiple failure
+        // modes, the everyone check fires first so admins see the
+        // most-relevant explanation.
+        every { role.isPublicRole } returns true
+        every { role.isManaged } returns true
+        assertEquals("Cannot auto-assign @everyone.", AutoRoleValidator.validate(role, selfMember))
+    }
+}

--- a/web/src/main/kotlin/web/controller/ModerationController.kt
+++ b/web/src/main/kotlin/web/controller/ModerationController.kt
@@ -132,6 +132,33 @@ class ModerationController(
         ra: RedirectAttributes
     ): String = renderSubPage(guildId, user, model, ra, "moderation/lottery")
 
+    @GetMapping("/{guildId}/welcome")
+    fun welcomePage(
+        @PathVariable guildId: Long,
+        @AuthenticationPrincipal user: OAuth2User,
+        model: Model,
+        ra: RedirectAttributes
+    ): String = WebGuildAccess.requireForPage(
+        user, guildId, ra, lobbyPath = "/moderation/guilds",
+        check = moderationWebService::canModerate,
+        deniedMessage = "You are not allowed to moderate that server.",
+    ) { discordId ->
+        val overview = moderationWebService.getGuildOverview(guildId) ?: run {
+            ra.addFlashAttribute("error", "Bot is not in that server.")
+            return@requireForPage "redirect:/moderation/guilds"
+        }
+        val welcome = moderationWebService.getWelcomeOverview(guildId) ?: run {
+            ra.addFlashAttribute("error", "Bot is not in that server.")
+            return@requireForPage "redirect:/moderation/guilds"
+        }
+        model.addAttribute("overview", overview)
+        model.addAttribute("welcome", welcome)
+        model.addAttribute("isOwner", moderationWebService.isOwner(discordId, guildId))
+        model.addAttribute("username", user.displayName())
+        model.addAttribute("actorDiscordId", discordId.toString())
+        "moderation/welcome"
+    }
+
     @GetMapping("/{guildId}/leveling")
     fun levelingPage(
         @PathVariable guildId: Long,
@@ -558,6 +585,44 @@ class ModerationController(
     }
 
     /**
+     * Add a role to the per-guild auto-assign list. Owner-only.
+     * Triggered by the "Add auto-role" form on the welcome moderation tab.
+     */
+    @PostMapping("/{guildId}/auto-role", consumes = ["application/json"])
+    @ResponseBody
+    fun addAutoRole(
+        @PathVariable guildId: Long,
+        @RequestBody body: AutoRoleRequest,
+        @AuthenticationPrincipal user: OAuth2User
+    ): ResponseEntity<ApiResult> = WebGuildAccess.requireSignedInForJson(
+        user, notSignedInApi
+    ) { actor ->
+        val roleId = body.roleId.toLongOrNull()
+            ?: return@requireSignedInForJson ResponseEntity.badRequest().body(ApiResult(false, "Invalid role id."))
+        val error = moderationWebService.addAutoRole(actor, guildId, roleId)
+        if (error != null) ResponseEntity.badRequest().body(ApiResult(false, error))
+        else ResponseEntity.ok(ApiResult(true, null))
+    }
+
+    /**
+     * Drop a `(guildId, roleId)` auto-role binding. Owner-only.
+     * Triggered by the per-row Delete button on the welcome moderation tab.
+     */
+    @DeleteMapping("/{guildId}/auto-role/{roleId}")
+    @ResponseBody
+    fun removeAutoRole(
+        @PathVariable guildId: Long,
+        @PathVariable roleId: Long,
+        @AuthenticationPrincipal user: OAuth2User
+    ): ResponseEntity<ApiResult> = WebGuildAccess.requireSignedInForJson(
+        user, notSignedInApi
+    ) { actor ->
+        val error = moderationWebService.removeAutoRole(actor, guildId, roleId)
+        if (error != null) ResponseEntity.badRequest().body(ApiResult(false, error))
+        else ResponseEntity.ok(ApiResult(true, null))
+    }
+
+    /**
      * Upsert a level → role-reward binding. Owner-only. Triggered by
      * the "Add reward" form on the leveling moderation tab.
      */
@@ -660,6 +725,7 @@ data class MoveRequest(val targetChannelId: String = "", val memberIds: List<Str
 data class PollRequest(val channelId: String = "", val question: String = "", val options: List<String> = emptyList())
 data class LevelRewardRequest(val level: Int = 0, val roleId: String = "")
 data class RequiredLevelRequest(val requiredLevel: Int = 0)
+data class AutoRoleRequest(val roleId: String = "")
 
 data class PurgeResponse(
     val ok: Boolean,

--- a/web/src/main/kotlin/web/service/ModerationWebService.kt
+++ b/web/src/main/kotlin/web/service/ModerationWebService.kt
@@ -5,6 +5,7 @@ import common.logging.DiscordLogger
 import database.dto.ConfigDto
 import database.dto.UserDto
 import database.dto.LevelRoleRewardDto
+import database.service.AutoRoleService
 import database.service.ConfigService
 import database.service.LevelRoleRewardService
 import database.service.LotteryHelper
@@ -44,6 +45,7 @@ class ModerationWebService(
     private val snapshotService: MonthlyCreditSnapshotService,
     private val ubiDailyService: UbiDailyService,
     private val levelRoleRewardService: LevelRoleRewardService,
+    private val autoRoleService: AutoRoleService,
     private val casinoAuditService: CasinoAuditService,
     private val eventPublisher: ApplicationEventPublisher
 ) {
@@ -413,6 +415,67 @@ class ModerationWebService(
         levelRoleRewardService.upsert(
             LevelRoleRewardDto(guildId = guildId, level = level, roleId = roleId)
         )
+        return null
+    }
+
+    /**
+     * Subset of guild data needed to render the welcome moderation tab.
+     * The three welcome config keys + three goodbye config keys ride
+     * through the standard `GuildOverview.config` map (and the existing
+     * POST `/{guildId}/config` save endpoint) so this view only needs to
+     * supply the multi-row auto-role data alongside the role picker.
+     * Returns null if JDA can't see the guild.
+     */
+    fun getWelcomeOverview(guildId: Long): WelcomeOverview? {
+        val guild = jda.getGuildById(guildId) ?: return null
+        val rows = autoRoleService.listForGuild(guildId).map { dto ->
+            val role = guild.getRoleById(dto.roleId)
+            AutoRoleView(
+                roleId = dto.roleId.toString(),
+                roleName = role?.name ?: "(deleted role)",
+                roleColorHex = role?.colorRaw?.takeIf { it != 0 }?.let { String.format("#%06x", it and 0xFFFFFF) },
+                roleMissing = role == null,
+            )
+        }
+        val roles = guild.roles
+            .filter { !it.isManaged && it.idLong != guild.idLong }
+            .sortedByDescending { it.position }
+            .map { RoleInfo(id = it.id, name = it.name) }
+        return WelcomeOverview(
+            guildId = guild.id,
+            guildName = guild.name,
+            autoRoles = rows,
+            roles = roles,
+        )
+    }
+
+    /**
+     * Add a role to the per-guild auto-assign list. Owner-only. Same
+     * "role exists / not managed / bot can interact" guardrails as
+     * [upsertLevelReward] — the join listener applies these too, but
+     * surfacing the failure at config time gives a clearer error than
+     * silently dropping new-member assignments later.
+     */
+    fun addAutoRole(actorDiscordId: Long, guildId: Long, roleId: Long): String? {
+        if (!isOwner(actorDiscordId, guildId)) return "Only the server owner can change guild config."
+        val guild = jda.getGuildById(guildId) ?: return "Bot is not in that server."
+        val role = guild.getRoleById(roleId) ?: return "Role not found in this server."
+        if (role.isPublicRole) return "Cannot auto-assign @everyone."
+        if (role.isManaged) return "That role is managed by an integration and can't be assigned by the bot."
+        if (!guild.selfMember.canInteract(role)) {
+            return "The bot's highest role is below ${role.name} — move TobyBot's role above it to allow assignment."
+        }
+        autoRoleService.add(guildId, roleId)
+        return null
+    }
+
+    /**
+     * Drop an `(guildId, roleId)` auto-role binding. Owner-only. No-op
+     * if no row exists — the UI's per-row delete button is idempotent.
+     */
+    fun removeAutoRole(actorDiscordId: Long, guildId: Long, roleId: Long): String? {
+        if (!isOwner(actorDiscordId, guildId)) return "Only the server owner can change guild config."
+        autoRoleService.delete(guildId, roleId)
         return null
     }
 
@@ -1109,6 +1172,38 @@ class ModerationWebService(
             ConfigDto.Configurations.INSTALL_MODE,
             ConfigDto.Configurations.INSTALLED_AT ->
                 return "Install-wizard sentinel — managed by /install in Discord."
+            // Welcome / goodbye announcement settings. Channel keys store
+            // the Discord text-channel id as a string and validate that
+            // the channel exists; blank clears the override (the listener
+            // falls back to the guild's system channel). Message keys are
+            // free-form and only sanity-checked for length (Discord embed
+            // description cap is 4096; we cap at 2000 for normal messages
+            // with placeholder expansion headroom).
+            ConfigDto.Configurations.WELCOME_ENABLED,
+            ConfigDto.Configurations.GOODBYE_ENABLED -> {
+                val v = rawValue.trim().lowercase()
+                if (v != "true" && v != "false") return "Value must be true or false."
+                v
+            }
+            ConfigDto.Configurations.WELCOME_CHANNEL,
+            ConfigDto.Configurations.GOODBYE_CHANNEL -> {
+                val v = rawValue.trim()
+                if (v.isEmpty()) {
+                    ""
+                } else {
+                    val id = v.toLongOrNull()
+                        ?: return "Channel id must be numeric."
+                    val channel = guild.getTextChannelById(id)
+                        ?: return "No text channel with that id exists in this server."
+                    channel.id
+                }
+            }
+            ConfigDto.Configurations.WELCOME_MESSAGE,
+            ConfigDto.Configurations.GOODBYE_MESSAGE -> {
+                val v = rawValue
+                if (v.length > 2000) return "Message must be 2000 characters or fewer."
+                v
+            }
         }
 
         val guildIdString = guild.id
@@ -1532,6 +1627,29 @@ data class TitleGateView(
     val colorHex: String?,
     val cost: Long,
     val requiredLevel: Int,
+)
+
+/**
+ * Subset of guild data needed to render the welcome moderation tab.
+ * The six welcome / goodbye config keys ride through the standard
+ * [GuildOverview.config] map (and the existing POST `.../config`
+ * endpoint); this struct adds the multi-row auto-role projection plus
+ * the role picker source. Parallels [LevelingOverview]'s shape.
+ */
+data class WelcomeOverview(
+    val guildId: String,
+    val guildName: String,
+    val autoRoles: List<AutoRoleView>,
+    val roles: List<RoleInfo>,
+)
+
+data class AutoRoleView(
+    val roleId: String,
+    val roleName: String,
+    val roleColorHex: String?,
+    /** True if the role id no longer resolves in JDA — surfaced in the
+     *  UI so admins can clean up dangling bindings after a role delete. */
+    val roleMissing: Boolean,
 )
 
 /**

--- a/web/src/main/kotlin/web/service/ModerationWebService.kt
+++ b/web/src/main/kotlin/web/service/ModerationWebService.kt
@@ -1,5 +1,6 @@
 package web.service
 
+import common.discord.AutoRoleValidator
 import common.events.ActivityTrackingEnabled
 import common.logging.DiscordLogger
 import database.dto.ConfigDto
@@ -450,21 +451,16 @@ class ModerationWebService(
     }
 
     /**
-     * Add a role to the per-guild auto-assign list. Owner-only. Same
-     * "role exists / not managed / bot can interact" guardrails as
-     * [upsertLevelReward] — the join listener applies these too, but
-     * surfacing the failure at config time gives a clearer error than
-     * silently dropping new-member assignments later.
+     * Add a role to the per-guild auto-assign list. Owner-only. Defers
+     * to [AutoRoleValidator] for the "role assignable?" check so the
+     * three call sites (slash command, this endpoint, the join listener)
+     * never drift on error wording or the rule set.
      */
     fun addAutoRole(actorDiscordId: Long, guildId: Long, roleId: Long): String? {
         if (!isOwner(actorDiscordId, guildId)) return "Only the server owner can change guild config."
         val guild = jda.getGuildById(guildId) ?: return "Bot is not in that server."
         val role = guild.getRoleById(roleId) ?: return "Role not found in this server."
-        if (role.isPublicRole) return "Cannot auto-assign @everyone."
-        if (role.isManaged) return "That role is managed by an integration and can't be assigned by the bot."
-        if (!guild.selfMember.canInteract(role)) {
-            return "The bot's highest role is below ${role.name} — move TobyBot's role above it to allow assignment."
-        }
+        AutoRoleValidator.validate(role, guild.selfMember)?.let { return it }
         autoRoleService.add(guildId, roleId)
         return null
     }

--- a/web/src/main/resources/static/js/moderation/welcome.js
+++ b/web/src/main/resources/static/js/moderation/welcome.js
@@ -1,0 +1,75 @@
+// Welcome tab: auto-role binding CRUD. Welcome / goodbye scalar
+// settings (enabled / channel / message) use the generic .config-row
+// save handler wired in moderationCommon.js; only the auto-role list
+// needs page-specific code, mirroring leveling.js's role-reward shape.
+(function () {
+    'use strict';
+
+    const ctx = window.ModerationCommon;
+    if (!ctx) return;
+    const { guildId, postJson } = ctx;
+
+    // --- Add auto-role -----------------------------------------------------
+    const addForm = document.getElementById('welcome-autorole-add');
+    if (addForm) {
+        addForm.addEventListener('submit', (e) => {
+            e.preventDefault();
+            const roleSelect = addForm.querySelector('select[name="roleId"]');
+            const submitBtn = addForm.querySelector('button[type="submit"]');
+            const roleId = (roleSelect.value || '').trim();
+            if (!roleId) {
+                toast('Pick a role.', 'error');
+                return;
+            }
+            submitBtn.disabled = true;
+            postJson('/moderation/' + guildId + '/auto-role', { roleId: roleId })
+                .then(r => {
+                    submitBtn.disabled = false;
+                    if (r && r.ok) {
+                        toast('Auto-role added. Reloading…', 'success');
+                        setTimeout(() => window.location.reload(), 600);
+                    } else {
+                        toast(r?.error || 'Could not add auto-role.', 'error');
+                    }
+                })
+                .catch(() => {
+                    submitBtn.disabled = false;
+                    toast('Network error.', 'error');
+                });
+        });
+    }
+
+    // --- Delete auto-role --------------------------------------------------
+    // fetch() is used directly because postJson() only does POSTs; the
+    // delete endpoint is a DELETE for REST symmetry with the add POST.
+    function deleteAutoRole(roleId, btn) {
+        if (!confirm('Stop auto-assigning this role?')) return;
+        btn.disabled = true;
+        fetch('/moderation/' + guildId + '/auto-role/' + roleId, {
+            method: 'DELETE',
+            headers: { 'Accept': 'application/json' },
+            credentials: 'same-origin',
+        }).then(r => r.json().catch(() => ({ ok: false, error: 'Bad response.' })))
+          .then(r => {
+              btn.disabled = false;
+              if (r && r.ok) {
+                  toast('Auto-role removed. Reloading…', 'success');
+                  setTimeout(() => window.location.reload(), 600);
+              } else {
+                  toast(r?.error || 'Could not remove auto-role.', 'error');
+              }
+          })
+          .catch(() => {
+              btn.disabled = false;
+              toast('Network error.', 'error');
+          });
+    }
+
+    document.querySelectorAll('.welcome-autorole-delete').forEach(btn => {
+        btn.addEventListener('click', () => {
+            const roleId = (btn.dataset.roleId || '').trim();
+            if (!roleId) return;
+            deleteAutoRole(roleId, btn);
+        });
+    });
+})();

--- a/web/src/main/resources/templates/fragments/moderationHeader.html
+++ b/web/src/main/resources/templates/fragments/moderationHeader.html
@@ -53,6 +53,10 @@
            class="mod-subnav-link"
            th:classappend="${active == 'leveling'} ? ' active'"
            th:attr="aria-current=${active == 'leveling'} ? 'page'">Leveling</a>
+        <a th:href="@{/moderation/{id}/welcome(id=${overview.guildId})}"
+           class="mod-subnav-link"
+           th:classappend="${active == 'welcome'} ? ' active'"
+           th:attr="aria-current=${active == 'welcome'} ? 'page'">Welcome</a>
     </nav>
 </div>
 </body>

--- a/web/src/main/resources/templates/moderation/welcome.html
+++ b/web/src/main/resources/templates/moderation/welcome.html
@@ -1,0 +1,205 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="en">
+<head th:replace="~{fragments/head :: head('TobyBot - Moderation: Welcome', '/css/moderation.css')}"></head>
+<body>
+<a href="#main" class="skip-link">Skip to content</a>
+<div th:replace="~{fragments/navbar :: navbar}"></div>
+
+<main id="main" class="container"
+      th:attr="data-guild-id=${overview.guildId},
+               data-actor-id=${actorDiscordId},
+               data-is-owner=${isOwner}">
+
+    <div th:replace="~{fragments/moderationHeader :: moderationHeader(${overview}, ${isOwner}, 'welcome')}"></div>
+
+    <!--
+        Welcome / goodbye announcements + auto-role-on-join. Three
+        independently-toggleable announcement systems share the standard
+        .config-row + .save-config wiring picked up by moderationCommon.js;
+        the auto-role list reuses the leveling.js role-binding patterns
+        wired in /js/moderation/welcome.js. Placeholders supported in the
+        message templates: {user}, {user.name}, {server}, {membercount}.
+    -->
+    <section class="mod-panel" data-panel="welcome">
+        <p class="muted mb-4">
+            Greet new members and acknowledge departures with a configurable
+            announcement, and auto-assign roles the moment someone joins.
+            Each announcement is independently toggleable; both fall back
+            to the server's system channel when no channel is set. Placeholders
+            in the message template are expanded at send time:
+            <code>{user}</code> (mention), <code>{user.name}</code> (display name),
+            <code>{server}</code>, <code>{membercount}</code>.
+        </p>
+
+        <div class="mod-card mod-card-wide welcome-admin-card">
+
+            <details class="config-section" open>
+                <summary>Welcome announcement</summary>
+                <div class="config-grid">
+                    <div class="config-row" data-key="WELCOME_ENABLED">
+                        <label>
+                            Enabled
+                            <span class="config-hint">
+                                Whether to post a welcome embed when a member joins.
+                            </span>
+                        </label>
+                        <select th:disabled="${!isOwner}">
+                            <option value="false"
+                                    th:selected="${overview.config['WELCOME_ENABLED'] != 'true'}">Disabled</option>
+                            <option value="true"
+                                    th:selected="${overview.config['WELCOME_ENABLED'] == 'true'}">Enabled</option>
+                        </select>
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
+                    <div class="config-row" data-key="WELCOME_CHANNEL">
+                        <label>
+                            Channel
+                            <span class="config-hint">
+                                Channel to post in. Leave blank to fall back to the server's
+                                system channel.
+                            </span>
+                        </label>
+                        <select th:disabled="${!isOwner}">
+                            <option value="">&mdash; fall back to system channel &mdash;</option>
+                            <option th:each="tc : ${overview.textChannels}"
+                                    th:value="${tc.id}"
+                                    th:text="'#' + ${tc.name}"
+                                    th:selected="${overview.config['WELCOME_CHANNEL'] == tc.id}"></option>
+                        </select>
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
+                    <div class="config-row" data-key="WELCOME_MESSAGE">
+                        <label>
+                            Message template
+                            <span class="config-hint">
+                                Up to 2000 characters. Supports the four placeholders listed above.
+                                Leave blank to use the built-in default.
+                            </span>
+                        </label>
+                        <input type="text" maxlength="2000"
+                               th:value="${overview.config['WELCOME_MESSAGE']}"
+                               placeholder="Welcome to {server}, {user}! You're our {membercount}-th member 🎉"
+                               th:disabled="${!isOwner}">
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
+                </div>
+            </details>
+
+            <details class="config-section" open>
+                <summary>Goodbye announcement</summary>
+                <div class="config-grid">
+                    <div class="config-row" data-key="GOODBYE_ENABLED">
+                        <label>
+                            Enabled
+                            <span class="config-hint">
+                                Whether to post a goodbye embed when a member leaves.
+                            </span>
+                        </label>
+                        <select th:disabled="${!isOwner}">
+                            <option value="false"
+                                    th:selected="${overview.config['GOODBYE_ENABLED'] != 'true'}">Disabled</option>
+                            <option value="true"
+                                    th:selected="${overview.config['GOODBYE_ENABLED'] == 'true'}">Enabled</option>
+                        </select>
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
+                    <div class="config-row" data-key="GOODBYE_CHANNEL">
+                        <label>
+                            Channel
+                            <span class="config-hint">
+                                Channel to post in. Leave blank to fall back to the server's
+                                system channel.
+                            </span>
+                        </label>
+                        <select th:disabled="${!isOwner}">
+                            <option value="">&mdash; fall back to system channel &mdash;</option>
+                            <option th:each="tc : ${overview.textChannels}"
+                                    th:value="${tc.id}"
+                                    th:text="'#' + ${tc.name}"
+                                    th:selected="${overview.config['GOODBYE_CHANNEL'] == tc.id}"></option>
+                        </select>
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
+                    <div class="config-row" data-key="GOODBYE_MESSAGE">
+                        <label>
+                            Message template
+                            <span class="config-hint">
+                                Up to 2000 characters. Supports the four placeholders listed above.
+                                Leave blank to use the built-in default.
+                            </span>
+                        </label>
+                        <input type="text" maxlength="2000"
+                               th:value="${overview.config['GOODBYE_MESSAGE']}"
+                               placeholder="{user.name} has left {server}. We're now down to {membercount}."
+                               th:disabled="${!isOwner}">
+                        <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
+                    </div>
+                </div>
+            </details>
+
+            <details class="config-section" open>
+                <summary>Auto-assigned roles on join</summary>
+                <p class="muted config-section-lead">
+                    Bind one or more Discord roles &mdash; TobyBot assigns them the moment a new
+                    member joins. Common uses: a baseline &ldquo;Member&rdquo; role, a pronoun
+                    placeholder, or a temporary &ldquo;Unverified&rdquo; role.
+                </p>
+                <div class="config-warning">
+                    <strong>Heads up:</strong> TobyBot's role must sit
+                    <em>above</em> any role you bind here in your server's role list, or
+                    the assign will fail at runtime.
+                </div>
+
+                <div class="welcome-autoroles" id="welcome-autoroles-list">
+                    <p class="muted" th:if="${#lists.isEmpty(welcome.autoRoles)}">
+                        No auto-roles bound yet.
+                    </p>
+                    <table class="welcome-autoroles-table" th:if="${not #lists.isEmpty(welcome.autoRoles)}">
+                        <thead>
+                            <tr>
+                                <th>Role</th>
+                                <th></th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr th:each="r : ${welcome.autoRoles}" th:data-role-id="${r.roleId}">
+                                <td>
+                                    <span class="title-pill"
+                                          th:style="${r.roleColorHex != null ? 'color: ' + r.roleColorHex : ''}"
+                                          th:text="${r.roleName}">Role</span>
+                                    <span class="badge off" th:if="${r.roleMissing}">missing</span>
+                                </td>
+                                <td>
+                                    <button type="button" class="btn btn-danger welcome-autorole-delete"
+                                            th:data-role-id="${r.roleId}"
+                                            th:disabled="${!isOwner}">Delete</button>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+
+                <form id="welcome-autorole-add" class="welcome-autorole-add">
+                    <label>
+                        <span>Role</span>
+                        <select name="roleId" th:disabled="${!isOwner}">
+                            <option value="">&mdash; pick a role &mdash;</option>
+                            <option th:each="role : ${welcome.roles}"
+                                    th:value="${role.id}"
+                                    th:text="${role.name}"></option>
+                        </select>
+                    </label>
+                    <button type="submit" class="btn" th:disabled="${!isOwner}">Add auto-role</button>
+                </form>
+            </details>
+        </div>
+    </section>
+</main>
+
+<script th:src="@{/js/api.js}"></script>
+<script th:src="@{/js/toasts.js}"></script>
+<script th:src="@{/js/moderationCommon.js}"></script>
+<script th:src="@{/js/moderation/welcome.js}"></script>
+<footer th:replace="~{fragments/footer :: footer}"></footer>
+</body>
+</html>

--- a/web/src/test/kotlin/web/controller/ModerationControllerWelcomeTest.kt
+++ b/web/src/test/kotlin/web/controller/ModerationControllerWelcomeTest.kt
@@ -1,0 +1,105 @@
+package web.controller
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.security.oauth2.core.user.OAuth2User
+import web.service.ModerationWebService
+
+/**
+ * Welcome-tab slice of [ModerationController] — POST `/auto-role` and
+ * DELETE `/auto-role/{roleId}`. Welcome / goodbye scalar settings ride
+ * the existing `/config` endpoint and are covered by the
+ * `ModerationWebServiceWelcomeTest` validation tests, so no additional
+ * controller test is needed for them.
+ */
+class ModerationControllerWelcomeTest {
+
+    private val guildId = 42L
+    private val actorId = 100L
+    private val roleId = 7L
+
+    private lateinit var moderationWebService: ModerationWebService
+    private lateinit var user: OAuth2User
+    private lateinit var controller: ModerationController
+
+    @BeforeEach
+    fun setup() {
+        moderationWebService = mockk(relaxed = true)
+        user = mockk {
+            every { getAttribute<String>("id") } returns actorId.toString()
+            every { getAttribute<String>("username") } returns "tester"
+        }
+        controller = ModerationController(moderationWebService, "test-client-id")
+    }
+
+    // ---- addAutoRole ----
+
+    @Test
+    fun `addAutoRole returns 400 on non-numeric role id`() {
+        val response = controller.addAutoRole(guildId, AutoRoleRequest(roleId = "abc"), user)
+        assertEquals(400, response.statusCode.value())
+        assertFalse(response.body!!.ok)
+        assertEquals("Invalid role id.", response.body!!.error)
+        verify(exactly = 0) { moderationWebService.addAutoRole(any(), any(), any()) }
+    }
+
+    @Test
+    fun `addAutoRole returns 401 when user is not signed in`() {
+        every { user.getAttribute<String>("id") } returns null
+        val response = controller.addAutoRole(guildId, AutoRoleRequest(roleId = roleId.toString()), user)
+        assertEquals(401, response.statusCode.value())
+        verify(exactly = 0) { moderationWebService.addAutoRole(any(), any(), any()) }
+    }
+
+    @Test
+    fun `addAutoRole dispatches to service and returns ok on success`() {
+        every { moderationWebService.addAutoRole(actorId, guildId, roleId) } returns null
+        val response = controller.addAutoRole(guildId, AutoRoleRequest(roleId = roleId.toString()), user)
+        assertTrue(response.statusCode.is2xxSuccessful)
+        assertTrue(response.body!!.ok)
+        assertNull(response.body!!.error)
+    }
+
+    @Test
+    fun `addAutoRole surfaces service error in 400`() {
+        every { moderationWebService.addAutoRole(actorId, guildId, roleId) } returns "Cannot auto-assign @everyone."
+        val response = controller.addAutoRole(guildId, AutoRoleRequest(roleId = roleId.toString()), user)
+        assertEquals(400, response.statusCode.value())
+        assertFalse(response.body!!.ok)
+        assertEquals("Cannot auto-assign @everyone.", response.body!!.error)
+    }
+
+    // ---- removeAutoRole ----
+
+    @Test
+    fun `removeAutoRole returns 401 when user is not signed in`() {
+        every { user.getAttribute<String>("id") } returns null
+        val response = controller.removeAutoRole(guildId, roleId, user)
+        assertEquals(401, response.statusCode.value())
+        verify(exactly = 0) { moderationWebService.removeAutoRole(any(), any(), any()) }
+    }
+
+    @Test
+    fun `removeAutoRole dispatches to service on success`() {
+        every { moderationWebService.removeAutoRole(actorId, guildId, roleId) } returns null
+        val response = controller.removeAutoRole(guildId, roleId, user)
+        assertTrue(response.statusCode.is2xxSuccessful)
+        assertTrue(response.body!!.ok)
+    }
+
+    @Test
+    fun `removeAutoRole surfaces service error in 400`() {
+        every { moderationWebService.removeAutoRole(actorId, guildId, roleId) } returns "Only the server owner can change guild config."
+        val response = controller.removeAutoRole(guildId, roleId, user)
+        assertEquals(400, response.statusCode.value())
+        assertFalse(response.body!!.ok)
+        assertEquals("Only the server owner can change guild config.", response.body!!.error)
+    }
+}

--- a/web/src/test/kotlin/web/service/ModerationWebServiceTest.kt
+++ b/web/src/test/kotlin/web/service/ModerationWebServiceTest.kt
@@ -42,6 +42,7 @@ class ModerationWebServiceTest {
     private lateinit var snapshotService: MonthlyCreditSnapshotService
     private lateinit var ubiDailyService: UbiDailyService
     private lateinit var levelRoleRewardService: database.service.LevelRoleRewardService
+    private lateinit var autoRoleService: database.service.AutoRoleService
     private lateinit var casinoAuditService: CasinoAuditService
     private lateinit var service: ModerationWebService
 
@@ -66,6 +67,7 @@ class ModerationWebServiceTest {
         snapshotService = mockk(relaxed = true)
         ubiDailyService = mockk(relaxed = true)
         levelRoleRewardService = mockk(relaxed = true)
+        autoRoleService = mockk(relaxed = true)
         casinoAuditService = mockk(relaxed = true)
         eventPublisher = mockk(relaxed = true)
         guild = mockk(relaxed = true)
@@ -79,6 +81,7 @@ class ModerationWebServiceTest {
             snapshotService,
             ubiDailyService,
             levelRoleRewardService,
+            autoRoleService,
             casinoAuditService,
             eventPublisher
         )

--- a/web/src/test/kotlin/web/service/ModerationWebServiceWelcomeTest.kt
+++ b/web/src/test/kotlin/web/service/ModerationWebServiceWelcomeTest.kt
@@ -1,0 +1,330 @@
+package web.service
+
+import database.dto.AutoRoleDto
+import database.dto.ConfigDto
+import database.service.AutoRoleService
+import database.service.ConfigService
+import database.service.LevelRoleRewardService
+import database.service.MonthlyCreditSnapshotService
+import database.service.TitleService
+import database.service.UbiDailyService
+import database.service.UserService
+import database.service.VoiceSessionService
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.unmockkAll
+import io.mockk.verify
+import net.dv8tion.jda.api.JDA
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.Member
+import net.dv8tion.jda.api.entities.Role
+import net.dv8tion.jda.api.entities.SelfMember
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.context.ApplicationEventPublisher
+
+/**
+ * Welcome / goodbye / auto-role slice of the ModerationWebService tests.
+ * Sits beside [ModerationWebServiceTest] so the welcome surface gets a
+ * dedicated test class (parallels the leveling, casino, lottery slice
+ * splits already in place — easier to find and run targeted regressions).
+ */
+class ModerationWebServiceWelcomeTest {
+
+    private lateinit var jda: JDA
+    private lateinit var userService: UserService
+    private lateinit var configService: ConfigService
+    private lateinit var introWebService: IntroWebService
+    private lateinit var voiceSessionService: VoiceSessionService
+    private lateinit var titleService: TitleService
+    private lateinit var snapshotService: MonthlyCreditSnapshotService
+    private lateinit var ubiDailyService: UbiDailyService
+    private lateinit var levelRoleRewardService: LevelRoleRewardService
+    private lateinit var autoRoleService: AutoRoleService
+    private lateinit var casinoAuditService: CasinoAuditService
+    private lateinit var eventPublisher: ApplicationEventPublisher
+    private lateinit var service: ModerationWebService
+    private lateinit var guild: Guild
+
+    private val guildId = 222L
+    private val ownerId = 100L
+    private val nonOwnerId = 101L
+
+    @BeforeEach
+    fun setUp() {
+        jda = mockk(relaxed = true)
+        userService = mockk(relaxed = true)
+        configService = mockk(relaxed = true)
+        introWebService = mockk(relaxed = true)
+        voiceSessionService = mockk(relaxed = true)
+        titleService = mockk(relaxed = true)
+        snapshotService = mockk(relaxed = true)
+        ubiDailyService = mockk(relaxed = true)
+        levelRoleRewardService = mockk(relaxed = true)
+        autoRoleService = mockk(relaxed = true)
+        casinoAuditService = mockk(relaxed = true)
+        eventPublisher = mockk(relaxed = true)
+        guild = mockk(relaxed = true)
+        service = ModerationWebService(
+            jda, userService, configService, introWebService, voiceSessionService,
+            titleService, snapshotService, ubiDailyService, levelRoleRewardService,
+            autoRoleService, casinoAuditService, eventPublisher,
+        )
+
+        every { jda.getGuildById(guildId) } returns guild
+        every { guild.id } returns guildId.toString()
+        every { guild.idLong } returns guildId
+        every { guild.name } returns "Test Guild"
+        // Default config upsert returns Created
+        every { configService.upsertConfig(any(), any(), any()) } answers {
+            ConfigService.UpsertResult.Created(ConfigDto(firstArg(), secondArg(), thirdArg()))
+        }
+
+        val ownerMember = mockk<Member>(relaxed = true).also {
+            every { it.idLong } returns ownerId
+            every { it.isOwner } returns true
+        }
+        every { guild.getMemberById(ownerId) } returns ownerMember
+        val plainMember = mockk<Member>(relaxed = true).also {
+            every { it.idLong } returns nonOwnerId
+            every { it.isOwner } returns false
+        }
+        every { guild.getMemberById(nonOwnerId) } returns plainMember
+    }
+
+    @AfterEach
+    fun tearDown() = unmockkAll()
+
+    // ---- getWelcomeOverview ----
+
+    @Test
+    fun `getWelcomeOverview returns null when bot cannot see guild`() {
+        every { jda.getGuildById(999L) } returns null
+        assertNull(service.getWelcomeOverview(999L))
+    }
+
+    @Test
+    fun `getWelcomeOverview returns rows with role name and color for live roles`() {
+        every { autoRoleService.listForGuild(guildId) } returns listOf(
+            AutoRoleDto(guildId = guildId, roleId = 100L),
+            AutoRoleDto(guildId = guildId, roleId = 200L),
+        )
+        val role100 = mockk<Role>(relaxed = true).also {
+            every { it.id } returns "100"
+            every { it.idLong } returns 100L
+            every { it.name } returns "Member"
+            every { it.colorRaw } returns 0xFF9900
+            every { it.isManaged } returns false
+        }
+        every { guild.getRoleById(100L) } returns role100
+        every { guild.getRoleById(200L) } returns null
+        every { guild.roles } returns listOf(role100)
+
+        val overview = service.getWelcomeOverview(guildId)
+        assertNotNull(overview)
+        assertEquals(2, overview!!.autoRoles.size)
+        val first = overview.autoRoles.first { it.roleId == "100" }
+        val second = overview.autoRoles.first { it.roleId == "200" }
+        assertEquals("Member", first.roleName)
+        assertEquals("#ff9900", first.roleColorHex)
+        assertFalse(first.roleMissing)
+        assertEquals("(deleted role)", second.roleName)
+        assertTrue(second.roleMissing, "row for a role JDA can't resolve must surface as missing")
+    }
+
+    @Test
+    fun `getWelcomeOverview hides everyone and managed roles from the picker source`() {
+        every { autoRoleService.listForGuild(guildId) } returns emptyList()
+        val everyoneRole = mockk<Role>(relaxed = true).also {
+            every { it.id } returns guildId.toString()
+            every { it.idLong } returns guildId
+            every { it.name } returns "@everyone"
+            every { it.isManaged } returns false
+        }
+        val managed = mockk<Role>(relaxed = true).also {
+            every { it.id } returns "1"
+            every { it.idLong } returns 1L
+            every { it.name } returns "Twitch sub"
+            every { it.isManaged } returns true
+        }
+        val ok = mockk<Role>(relaxed = true).also {
+            every { it.id } returns "2"
+            every { it.idLong } returns 2L
+            every { it.name } returns "Member"
+            every { it.isManaged } returns false
+        }
+        every { guild.roles } returns listOf(everyoneRole, managed, ok)
+
+        val overview = service.getWelcomeOverview(guildId)!!
+        val ids = overview.roles.map { it.id }.toSet()
+        assertFalse(ids.contains(guildId.toString()), "@everyone must be hidden from the picker")
+        assertFalse(ids.contains("1"), "managed roles must be hidden from the picker")
+        assertTrue(ids.contains("2"))
+    }
+
+    // ---- addAutoRole ----
+
+    @Test
+    fun `addAutoRole is owner-only`() {
+        val role = stubRole(7L, managed = false, public = false, canInteract = true)
+        val err = service.addAutoRole(nonOwnerId, guildId, role.idLong)
+        assertEquals("Only the server owner can change guild config.", err)
+        verify(exactly = 0) { autoRoleService.add(any(), any()) }
+    }
+
+    @Test
+    fun `addAutoRole reports missing role`() {
+        every { guild.getRoleById(99L) } returns null
+        val err = service.addAutoRole(ownerId, guildId, 99L)
+        assertEquals("Role not found in this server.", err)
+        verify(exactly = 0) { autoRoleService.add(any(), any()) }
+    }
+
+    @Test
+    fun `addAutoRole rejects everyone`() {
+        val role = stubRole(guildId, managed = false, public = true, canInteract = true)
+        val err = service.addAutoRole(ownerId, guildId, role.idLong)
+        assertEquals("Cannot auto-assign @everyone.", err)
+        verify(exactly = 0) { autoRoleService.add(any(), any()) }
+    }
+
+    @Test
+    fun `addAutoRole rejects managed role`() {
+        val role = stubRole(7L, managed = true, public = false, canInteract = true)
+        val err = service.addAutoRole(ownerId, guildId, role.idLong)
+        assertTrue(err!!.contains("managed by an integration"))
+        verify(exactly = 0) { autoRoleService.add(any(), any()) }
+    }
+
+    @Test
+    fun `addAutoRole rejects role above the bot`() {
+        val role = stubRole(7L, managed = false, public = false, canInteract = false)
+        val err = service.addAutoRole(ownerId, guildId, role.idLong)
+        assertTrue(err!!.contains("move TobyBot's role above"))
+        verify(exactly = 0) { autoRoleService.add(any(), any()) }
+    }
+
+    @Test
+    fun `addAutoRole writes through service on happy path`() {
+        val role = stubRole(7L, managed = false, public = false, canInteract = true)
+        val err = service.addAutoRole(ownerId, guildId, role.idLong)
+        assertNull(err)
+        verify(exactly = 1) { autoRoleService.add(guildId, 7L) }
+    }
+
+    @Test
+    fun `addAutoRole reports missing guild`() {
+        every { jda.getGuildById(999L) } returns null
+        val ownerMember = mockk<Member>(relaxed = true).also {
+            every { it.idLong } returns ownerId
+            every { it.isOwner } returns true
+        }
+        val phantomGuild = mockk<Guild>(relaxed = true)
+        every { phantomGuild.getMemberById(ownerId) } returns ownerMember
+        // owner check first goes through isOwner; the test relies on
+        // canModerate/isOwner returning false because the guild is null.
+        val err = service.addAutoRole(ownerId, 999L, 7L)
+        // isOwner returns false for a null guild, so the owner gate fires
+        // before the bot-not-in-server gate.
+        assertEquals("Only the server owner can change guild config.", err)
+    }
+
+    // ---- removeAutoRole ----
+
+    @Test
+    fun `removeAutoRole is owner-only`() {
+        val err = service.removeAutoRole(nonOwnerId, guildId, 7L)
+        assertEquals("Only the server owner can change guild config.", err)
+        verify(exactly = 0) { autoRoleService.delete(any(), any()) }
+    }
+
+    @Test
+    fun `removeAutoRole deletes through service on happy path`() {
+        val err = service.removeAutoRole(ownerId, guildId, 7L)
+        assertNull(err)
+        verify(exactly = 1) { autoRoleService.delete(guildId, 7L) }
+    }
+
+    // ---- updateConfig for welcome / goodbye keys ----
+
+    @Test
+    fun `updateConfig accepts true and false for WELCOME_ENABLED`() {
+        assertNull(service.updateConfig(ownerId, guildId, ConfigDto.Configurations.WELCOME_ENABLED, "true"))
+        assertNull(service.updateConfig(ownerId, guildId, ConfigDto.Configurations.WELCOME_ENABLED, "FALSE"))
+        assertEquals(
+            "Value must be true or false.",
+            service.updateConfig(ownerId, guildId, ConfigDto.Configurations.WELCOME_ENABLED, "maybe"),
+        )
+    }
+
+    @Test
+    fun `updateConfig validates WELCOME_CHANNEL exists`() {
+        every { guild.getTextChannelById(555L) } returns mockk(relaxed = true)
+        assertNull(service.updateConfig(ownerId, guildId, ConfigDto.Configurations.WELCOME_CHANNEL, "555"))
+        every { guild.getTextChannelById(666L) } returns null
+        assertEquals(
+            "No text channel with that id exists in this server.",
+            service.updateConfig(ownerId, guildId, ConfigDto.Configurations.WELCOME_CHANNEL, "666"),
+        )
+        assertEquals(
+            "Channel id must be numeric.",
+            service.updateConfig(ownerId, guildId, ConfigDto.Configurations.WELCOME_CHANNEL, "abc"),
+        )
+    }
+
+    @Test
+    fun `updateConfig clears WELCOME_CHANNEL on blank input`() {
+        // Blank must persist as an empty string so the listener falls back
+        // to the system channel.
+        assertNull(service.updateConfig(ownerId, guildId, ConfigDto.Configurations.WELCOME_CHANNEL, "  "))
+        verify { configService.upsertConfig(ConfigDto.Configurations.WELCOME_CHANNEL.configValue, "", guildId.toString()) }
+    }
+
+    @Test
+    fun `updateConfig caps WELCOME_MESSAGE at 2000 chars`() {
+        val longMessage = "a".repeat(2001)
+        assertEquals(
+            "Message must be 2000 characters or fewer.",
+            service.updateConfig(ownerId, guildId, ConfigDto.Configurations.WELCOME_MESSAGE, longMessage),
+        )
+        verify(exactly = 0) { configService.upsertConfig(eq(ConfigDto.Configurations.WELCOME_MESSAGE.configValue), any(), any()) }
+    }
+
+    @Test
+    fun `updateConfig accepts free-form GOODBYE_MESSAGE under cap`() {
+        val message = "Goodbye {user.name} from {server}!"
+        assertNull(service.updateConfig(ownerId, guildId, ConfigDto.Configurations.GOODBYE_MESSAGE, message))
+        verify(exactly = 1) {
+            configService.upsertConfig(ConfigDto.Configurations.GOODBYE_MESSAGE.configValue, message, guildId.toString())
+        }
+    }
+
+    @Test
+    fun `updateConfig welcome keys are owner-only`() {
+        val err = service.updateConfig(nonOwnerId, guildId, ConfigDto.Configurations.WELCOME_ENABLED, "true")
+        assertEquals("Only the server owner can change guild config.", err)
+    }
+
+    // ---- helpers ----
+
+    private fun stubRole(id: Long, managed: Boolean, public: Boolean, canInteract: Boolean): Role {
+        val role = mockk<Role>(relaxed = true).also {
+            every { it.idLong } returns id
+            every { it.id } returns id.toString()
+            every { it.name } returns "Role-$id"
+            every { it.isManaged } returns managed
+            every { it.isPublicRole } returns public
+        }
+        every { guild.getRoleById(id) } returns role
+        val selfMember = mockk<SelfMember>(relaxed = true)
+        every { guild.selfMember } returns selfMember
+        every { selfMember.canInteract(role) } returns canInteract
+        return role
+    }
+}

--- a/web/src/test/kotlin/web/service/ModerationWebServiceWelcomeTest.kt
+++ b/web/src/test/kotlin/web/service/ModerationWebServiceWelcomeTest.kt
@@ -206,7 +206,7 @@ class ModerationWebServiceWelcomeTest {
     fun `addAutoRole rejects role above the bot`() {
         val role = stubRole(7L, managed = false, public = false, canInteract = false)
         val err = service.addAutoRole(ownerId, guildId, role.idLong)
-        assertTrue(err!!.contains("move TobyBot's role above"))
+        assertTrue(err!!.contains("move TobyBot's role higher"))
         verify(exactly = 0) { autoRoleService.add(any(), any()) }
     }
 

--- a/web/src/test/kotlin/web/template/ModerationTemplateRowsTest.kt
+++ b/web/src/test/kotlin/web/template/ModerationTemplateRowsTest.kt
@@ -466,6 +466,7 @@ class ModerationTemplateRowsTest {
             readTemplate("templates/moderation/casino.html"),
             readTemplate("templates/moderation/lottery.html"),
             readTemplate("templates/moderation/leveling.html"),
+            readTemplate("templates/moderation/welcome.html"),
         )
         val combined = templates.joinToString("\n")
 

--- a/web/src/test/kotlin/web/template/WelcomeTemplateRenderTest.kt
+++ b/web/src/test/kotlin/web/template/WelcomeTemplateRenderTest.kt
@@ -1,0 +1,307 @@
+package web.template
+
+import database.dto.ConfigDto
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.springframework.context.support.GenericApplicationContext
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpServletResponse
+import org.springframework.mock.web.MockServletContext
+import org.thymeleaf.context.WebContext
+import org.thymeleaf.spring6.SpringTemplateEngine
+import org.thymeleaf.spring6.templateresolver.SpringResourceTemplateResolver
+import org.thymeleaf.templatemode.TemplateMode
+import org.thymeleaf.web.servlet.JakartaServletWebApplication
+import web.service.AutoRoleView
+import web.service.CategoryInfo
+import web.service.GuildOverview
+import web.service.RoleInfo
+import web.service.TextChannelInfo
+import web.service.WelcomeOverview
+import web.view.LotteryIncentivesView
+
+/**
+ * End-to-end Thymeleaf render of `templates/moderation/welcome.html`
+ * against a Spring-backed template engine. Exercises:
+ *  - the six welcome / goodbye `data-key` rows (presence + pre-population
+ *    from `overview.config`),
+ *  - the auto-role list rendering (empty state vs populated rows),
+ *  - the role picker source list,
+ *  - `isOwner=false` disabling every save / delete / add button,
+ *  - the moderation header includes the Welcome nav link as active.
+ *
+ * Pure HTML render — no controller wiring. Catches regressions a
+ * controller test cannot, like Thymeleaf expression typos in the
+ * template, missing classes, or fragment misconfiguration.
+ */
+class WelcomeTemplateRenderTest {
+
+    private val servletContext = MockServletContext()
+    private val webApp = JakartaServletWebApplication.buildApplication(servletContext)
+
+    private val engine: SpringTemplateEngine = SpringTemplateEngine().apply {
+        val appCtx = GenericApplicationContext().also { it.refresh() }
+        val resolver = SpringResourceTemplateResolver().apply {
+            setApplicationContext(appCtx)
+            prefix = "classpath:/templates/"
+            suffix = ".html"
+            templateMode = TemplateMode.HTML
+            characterEncoding = "UTF-8"
+            isCacheable = false
+        }
+        setTemplateResolver(resolver)
+    }
+
+    private fun render(
+        welcomeOverview: WelcomeOverview = defaultWelcomeOverview(),
+        guildOverview: GuildOverview = defaultGuildOverview(),
+        isOwner: Boolean = true,
+    ): String {
+        val request = MockHttpServletRequest(servletContext)
+        val response = MockHttpServletResponse()
+        val exchange = webApp.buildExchange(request, response)
+        val ctx = WebContext(exchange).apply {
+            setVariable("overview", guildOverview)
+            setVariable("welcome", welcomeOverview)
+            setVariable("isOwner", isOwner)
+            setVariable("username", "tester")
+            setVariable("actorDiscordId", "1")
+            setVariable("jackpotPool", 0L)
+            setVariable("errorMessage", null)
+        }
+        return engine.process("moderation/welcome", ctx)
+    }
+
+    // ---- presence regressions ----
+
+    @Test
+    fun `every welcome and goodbye config key has a data-key row`() {
+        val html = render()
+        val expectedKeys = listOf(
+            ConfigDto.Configurations.WELCOME_ENABLED,
+            ConfigDto.Configurations.WELCOME_CHANNEL,
+            ConfigDto.Configurations.WELCOME_MESSAGE,
+            ConfigDto.Configurations.GOODBYE_ENABLED,
+            ConfigDto.Configurations.GOODBYE_CHANNEL,
+            ConfigDto.Configurations.GOODBYE_MESSAGE,
+        )
+        for (key in expectedKeys) {
+            assertTrue(
+                html.contains("data-key=\"${key.name}\""),
+                "welcome.html must carry a config-row for ${key.name} so admins can edit it",
+            )
+        }
+    }
+
+    @Test
+    fun `welcome and goodbye sections each appear with details summary`() {
+        val html = render()
+        assertTrue(html.contains("<summary>Welcome announcement</summary>"))
+        assertTrue(html.contains("<summary>Goodbye announcement</summary>"))
+        assertTrue(html.contains("<summary>Auto-assigned roles on join</summary>"))
+    }
+
+    // ---- enabled-flag preselect ----
+
+    @Test
+    fun `WELCOME_ENABLED row preselects Enabled when config value is true`() {
+        val overview = defaultGuildOverview(configOverrides = mapOf("WELCOME_ENABLED" to "true"))
+        val html = render(guildOverview = overview)
+        val row = rowOf(html, "WELCOME_ENABLED")
+        // Thymeleaf renders th:selected="${...}" as a `selected` attribute
+        // on the matching <option>. Pin that the "true" branch wins.
+        val trueOptionIdx = row.indexOf("value=\"true\"")
+        val falseOptionIdx = row.indexOf("value=\"false\"")
+        val selectedIdx = row.indexOf("selected")
+        assertTrue(selectedIdx in trueOptionIdx..(row.length))
+        // sanity: false option shouldn't be selected
+        val sliceUntilSelected = row.substring(falseOptionIdx, selectedIdx.coerceAtLeast(falseOptionIdx))
+        assertFalse(sliceUntilSelected.contains(">selected") || sliceUntilSelected.contains("selected="),
+            "false option must not be selected:\n$sliceUntilSelected")
+    }
+
+    @Test
+    fun `WELCOME_ENABLED row preselects Disabled when config value is absent`() {
+        val html = render()
+        val row = rowOf(html, "WELCOME_ENABLED")
+        val falseIdx = row.indexOf("value=\"false\"")
+        val trueIdx = row.indexOf("value=\"true\"")
+        val between = row.substring(falseIdx, trueIdx)
+        assertTrue(between.contains("selected"),
+            "false option should be selected when WELCOME_ENABLED is absent:\n$row")
+    }
+
+    // ---- message preselect ----
+
+    @Test
+    fun `WELCOME_MESSAGE row carries current value when configured`() {
+        val msg = "Welcome to {server}, {user}!"
+        val overview = defaultGuildOverview(configOverrides = mapOf("WELCOME_MESSAGE" to msg))
+        val html = render(guildOverview = overview)
+        val row = rowOf(html, "WELCOME_MESSAGE")
+        assertTrue(row.contains("value=\"$msg\""), "input should pre-populate with current value:\n$row")
+    }
+
+    @Test
+    fun `WELCOME_MESSAGE input is capped at 2000 chars in markup`() {
+        val html = render()
+        val row = rowOf(html, "WELCOME_MESSAGE")
+        assertTrue(row.contains("maxlength=\"2000\""),
+            "input must mirror the server-side 2000-char cap so browsers refuse longer text early:\n$row")
+    }
+
+    // ---- channel preselect ----
+
+    @Test
+    fun `WELCOME_CHANNEL select preselects the configured channel`() {
+        val overview = defaultGuildOverview(configOverrides = mapOf("WELCOME_CHANNEL" to "555"))
+        val html = render(guildOverview = overview)
+        val row = rowOf(html, "WELCOME_CHANNEL")
+        // Look for the option with id 555 carrying selected.
+        val option555Idx = row.indexOf("value=\"555\"")
+        assertTrue(option555Idx >= 0, "channel option 555 should render:\n$row")
+        val tagEnd = row.indexOf(">", option555Idx)
+        val tagSlice = row.substring(option555Idx, tagEnd)
+        assertTrue(tagSlice.contains("selected"),
+            "the 555 channel option must carry selected:\n$tagSlice")
+    }
+
+    // ---- auto-role list ----
+
+    @Test
+    fun `auto-role table renders one row per binding with role name`() {
+        val welcomeOverview = WelcomeOverview(
+            guildId = "1",
+            guildName = "Test",
+            autoRoles = listOf(
+                AutoRoleView(roleId = "100", roleName = "Member", roleColorHex = "#ff9900", roleMissing = false),
+                AutoRoleView(roleId = "200", roleName = "Verified", roleColorHex = null, roleMissing = false),
+            ),
+            roles = listOf(RoleInfo(id = "100", name = "Member"), RoleInfo(id = "200", name = "Verified")),
+        )
+        val html = render(welcomeOverview = welcomeOverview)
+        assertTrue(html.contains("data-role-id=\"100\""))
+        assertTrue(html.contains("data-role-id=\"200\""))
+        assertTrue(html.contains(">Member<"))
+        assertTrue(html.contains(">Verified<"))
+    }
+
+    @Test
+    fun `auto-role empty state shows the no-bindings message`() {
+        val welcomeOverview = WelcomeOverview(
+            guildId = "1",
+            guildName = "Test",
+            autoRoles = emptyList(),
+            roles = emptyList(),
+        )
+        val html = render(welcomeOverview = welcomeOverview)
+        assertTrue(html.contains("No auto-roles bound yet."),
+            "empty list should render the no-bindings placeholder")
+    }
+
+    @Test
+    fun `missing-role rows surface a missing badge`() {
+        val welcomeOverview = WelcomeOverview(
+            guildId = "1",
+            guildName = "Test",
+            autoRoles = listOf(
+                AutoRoleView(roleId = "999", roleName = "(deleted role)", roleColorHex = null, roleMissing = true),
+            ),
+            roles = emptyList(),
+        )
+        val html = render(welcomeOverview = welcomeOverview)
+        assertTrue(html.contains("missing"),
+            "missing role should carry a `missing` badge so admins can clean up:\n$html")
+    }
+
+    @Test
+    fun `role picker dropdown is populated from welcome roles list`() {
+        val welcomeOverview = WelcomeOverview(
+            guildId = "1",
+            guildName = "Test",
+            autoRoles = emptyList(),
+            roles = listOf(
+                RoleInfo(id = "100", name = "Member"),
+                RoleInfo(id = "200", name = "VIP"),
+            ),
+        )
+        val html = render(welcomeOverview = welcomeOverview)
+        assertTrue(html.contains("value=\"100\""))
+        assertTrue(html.contains(">Member<"))
+        assertTrue(html.contains("value=\"200\""))
+        assertTrue(html.contains(">VIP<"))
+    }
+
+    // ---- non-owner disablement ----
+
+    @Test
+    fun `non-owner sees disabled inputs and buttons`() {
+        val html = render(isOwner = false)
+        // Every save button and form input should carry disabled.
+        // Pin a sample to keep the test resilient to non-functional markup churn.
+        val firstRowEnd = html.indexOf("</button>", html.indexOf("data-key=\"WELCOME_ENABLED\""))
+        val firstRow = html.substring(
+            html.indexOf("data-key=\"WELCOME_ENABLED\""),
+            firstRowEnd,
+        )
+        assertTrue(firstRow.contains("disabled"),
+            "non-owner: save button for WELCOME_ENABLED should be disabled:\n$firstRow")
+    }
+
+    // ---- navigation ----
+
+    @Test
+    fun `welcome tab is marked active in the moderation subnav`() {
+        val html = render()
+        // moderationHeader fragment renders an <a> with class.active when
+        // active == 'welcome'. The Welcome page passes 'welcome' as the
+        // active arg; pin that the active class lands on the welcome link.
+        val anchorIdx = html.indexOf(">Welcome</a>")
+        assertTrue(anchorIdx > 0, "Welcome subnav link must render")
+        val openTagStart = html.lastIndexOf("<a ", anchorIdx)
+        val anchor = html.substring(openTagStart, anchorIdx)
+        assertTrue(anchor.contains("active"),
+            "Welcome subnav link should carry the active class when active=='welcome':\n$anchor")
+    }
+
+    // ---- helpers ----
+
+    private fun defaultWelcomeOverview() = WelcomeOverview(
+        guildId = "1",
+        guildName = "Test Guild",
+        autoRoles = emptyList(),
+        roles = listOf(RoleInfo(id = "100", name = "Member")),
+    )
+
+    private fun defaultGuildOverview(
+        configOverrides: Map<String, String?> = emptyMap(),
+    ): GuildOverview {
+        val baseConfig = ConfigDto.Configurations.entries.associate { it.name to null as String? }
+        val merged = baseConfig + configOverrides
+        return GuildOverview(
+            guildId = "1",
+            guildName = "Test Guild",
+            members = emptyList(),
+            voiceChannels = emptyList(),
+            textChannels = listOf(
+                TextChannelInfo(id = "555", name = "welcomes"),
+                TextChannelInfo(id = "666", name = "general"),
+            ),
+            categories = listOf(CategoryInfo(id = "1", name = "General")),
+            config = merged,
+            lotteryIncentives = LotteryIncentivesView.empty(),
+        )
+    }
+
+    private fun rowOf(html: String, dataKey: String): String {
+        val marker = "data-key=\"$dataKey\""
+        val start = html.indexOf(marker).also {
+            assertTrue(it >= 0, "row for $dataKey not found")
+        }
+        val rowStart = html.lastIndexOf("<div class=\"config-row\"", start)
+        val rowEnd = html.indexOf("</div>", start) + "</div>".length
+        return html.substring(rowStart, rowEnd)
+    }
+}


### PR DESCRIPTION
## Summary

Adds the table-stakes "this bot greets new members" feature that big servers expect from a main bot. Three independently-toggleable surfaces, configurable from both Discord (`/welcome` slash command) and the web dashboard (`/moderation/{guild}/welcome` tab).

This is the first wave from the [feature-recommendations plan](https://claude.ai/code/session_017tRi5q6K3NYHvYeZYzLzBD) — picked as the single biggest unlock for admin appeal.

## What's new

**Discord side**
- `/welcome` slash command (owner-only) with five subcommands:
  - `set-welcome` / `set-goodbye` — toggle enabled, pick channel, edit message template
  - `autorole-add` / `autorole-remove` — bind roles auto-assigned on join
  - `show` — current settings as an ephemeral embed
- New `WelcomeAndAutoRoleHandler` listener fires on `GuildMemberJoin` + `GuildMemberRemove`
- `WelcomeMessageRenderer` supports `{user}`, `{user.name}`, `{server}`, `{membercount}` placeholders with default templates

**Web dashboard**
- New "Welcome" tab in the moderation header (next to Leveling)
- Six `data-key` config rows for the welcome/goodbye scalar settings (ride the existing `.config-row` save infra)
- Auto-role list with per-row delete + role-picker add form (mirrors `leveling.html`)
- Non-owners see disabled controls

**Data model**
- 6 new `ConfigDto.Configurations` enum entries: `WELCOME_ENABLED`, `WELCOME_CHANNEL`, `WELCOME_MESSAGE`, `GOODBYE_ENABLED`, `GOODBYE_CHANNEL`, `GOODBYE_MESSAGE`
- New `auto_role` table (composite-key, parallels `level_role_reward`) + `AutoRoleDto` + persistence + service
- `V43` migration also widens `config.value` from `VARCHAR(100)` to `TEXT` so message templates aren't truncated

## Guardrails

- Welcome / goodbye / auto-role each isolated in `runCatching` — one failure can't starve the others
- Auto-role assignment applies the same managed / canInteract / MANAGE_ROLES checks the leveling role-reward path uses
- Bidirectional `ConfigDto.Configurations` ↔ moderation-template guard test extended to include `welcome.html`, so any future config key without a UI row fails CI

## Test plan
- [x] `WelcomeMessageRendererTest` — 11 tests, placeholder substitution + default fallback + bot/human member count
- [x] `WelcomeAndAutoRoleHandlerTest` — 14 tests, every join/leave branch + auto-role guard table + channel fallback + welcome-failure isolation
- [x] `WelcomeCommandTest` — 13 tests, owner gate + configure-welcome vs goodbye routing + role validators
- [x] `DefaultAutoRoleServiceTest` — 4 tests, service delegation sanity
- [x] `ModerationWebServiceWelcomeTest` — 18 tests, `getWelcomeOverview` + add/removeAutoRole guards + all six welcome/goodbye config validators
- [x] `ModerationControllerWelcomeTest` — 7 tests, JSON POST + DELETE endpoints
- [x] `WelcomeTemplateRenderTest` — 13 tests, full Thymeleaf render: `data-key` presence, preselect, message cap, non-owner disablement, missing-role badge, active-tab nav
- [x] Existing `ModerationWebServiceTest` (136 tests) and `ModerationTemplateRowsTest` (17 tests) still pass

**80 new tests across 7 suites, all green.** The Spring `@SpringBootTest` integration test (`SpringApplicationTest`) was not run in this branch's CI environment because Testcontainers needs Docker — orthogonal to this change.

- [ ] Manual smoke: invite the bot to a test guild, run `/welcome set-welcome enabled:true message:"Hi {user}!"`, have a second user join, confirm the embed renders correctly
- [ ] Manual smoke: open `/moderation/{guildId}/welcome` in the web dashboard, toggle each surface, add an auto-role, refresh and confirm persistence

https://claude.ai/code/session_017tRi5q6K3NYHvYeZYzLzBD

---
_Generated by [Claude Code](https://claude.ai/code/session_017tRi5q6K3NYHvYeZYzLzBD)_