### PR TITLE
feat(web): shared searchable channel picker across moderation pages

### DIFF
--- a/web/src/main/resources/static/css/base.css
+++ b/web/src/main/resources/static/css/base.css
@@ -1241,10 +1241,13 @@ td { font-size: 0.95rem; }
     .lb-standings-table.mod-table td[data-label="Prestige"] .lb-prestige { gap: 3px; }
 }
 
-/* ---- Searchable user picker (templates/fragments/userPicker.html
-   + static/js/userPicker.js). Lives in base.css so every page that
-   includes the fragment gets the styling without an extra <link>. ---- */
+/* ---- Searchable picker styles, shared by userPicker.html/.js and
+   channelPicker.html/.js. The .user-picker__* prefix is historical;
+   these are picker-shape styles, not user-specific. Lives in base.css
+   so every page that includes either fragment gets the styling
+   without an extra <link>. ---- */
 .user-picker { position: relative; }
+.user-picker--disabled { opacity: 0.6; pointer-events: none; }
 .user-picker__native {
     position: absolute;
     left: 0; top: 0;

--- a/web/src/main/resources/static/js/channelPicker.js
+++ b/web/src/main/resources/static/js/channelPicker.js
@@ -1,0 +1,292 @@
+// Searchable channel picker. Finds every <select data-channel-picker>
+// on the page and replaces it with a typeahead combobox, keeping the
+// native <select> hidden in the DOM so the form posts the same field
+// and the page still works with JavaScript disabled.
+//
+// Mirrors static/js/userPicker.js and reuses the same .user-picker__*
+// CSS classes. Differences from userPicker:
+//   - single-select only (no chips, no multi branch)
+//   - no avatar / social credit rendering
+//   - honours `disabled` on the native <select> by locking the wrapper
+//   - keeps the empty-value option visible as a selectable first row,
+//     so users can return to fallback semantics like "— system channel —"
+//     after picking a channel without reloading the page.
+
+'use strict';
+
+function initChannelPicker(select) {
+    if (select.dataset.channelPickerReady === '1') return;
+    select.dataset.channelPickerReady = '1';
+
+    const wrapper = select.closest('.user-picker');
+    if (!wrapper) return;
+    const placeholder = wrapper.dataset.placeholder || 'Search…';
+
+    select.classList.add('user-picker__native');
+    select.setAttribute('aria-hidden', 'true');
+    select.setAttribute('tabindex', '-1');
+
+    const isDisabled = select.disabled;
+    if (isDisabled) wrapper.classList.add('user-picker--disabled');
+
+    const fieldId = select.id || ('channelPicker-' + Math.random().toString(36).slice(2));
+    const listId = fieldId + '-list';
+
+    const field = document.createElement('div');
+    field.className = 'user-picker__field';
+    field.setAttribute('role', 'combobox');
+    field.setAttribute('aria-haspopup', 'listbox');
+    field.setAttribute('aria-expanded', 'false');
+    field.setAttribute('aria-controls', listId);
+    field.tabIndex = isDisabled ? -1 : 0;
+    if (isDisabled) field.setAttribute('aria-disabled', 'true');
+
+    const valueLabel = document.createElement('span');
+    valueLabel.className = 'user-picker__value';
+
+    const caret = document.createElement('span');
+    caret.className = 'user-picker__caret';
+    caret.setAttribute('aria-hidden', 'true');
+    caret.textContent = '▾';
+
+    field.appendChild(valueLabel);
+    field.appendChild(caret);
+
+    const panel = document.createElement('div');
+    panel.className = 'user-picker__panel';
+    panel.hidden = true;
+
+    const input = document.createElement('input');
+    input.type = 'search';
+    input.className = 'user-picker__input';
+    input.placeholder = 'Type to filter…';
+    input.autocomplete = 'off';
+    input.setAttribute('aria-controls', listId);
+
+    const list = document.createElement('ul');
+    list.className = 'user-picker__list';
+    list.id = listId;
+    list.setAttribute('role', 'listbox');
+
+    panel.appendChild(input);
+    panel.appendChild(list);
+    wrapper.appendChild(field);
+    wrapper.appendChild(panel);
+
+    // Cache the picker options. Unlike userPicker we keep the empty-
+    // value option in the list (rendered first, never filtered out) so
+    // users can pick it to return to fallback semantics like
+    // "— system channel —".
+    const options = Array.from(select.options).map((opt, i) => ({
+        el: opt,
+        value: opt.value,
+        label: (opt.textContent || '').trim(),
+        labelLc: (opt.textContent || '').trim().toLowerCase(),
+        isEmpty: opt.value === '',
+        domId: listId + '-opt-' + i
+    }));
+
+    let highlightedIndex = -1;
+
+    function visibleItems() {
+        return Array.from(list.querySelectorAll('.user-picker__option'));
+    }
+
+    function updateHighlight() {
+        const items = visibleItems();
+        items.forEach((li, i) => li.classList.toggle('is-highlighted', i === highlightedIndex));
+        const active = items[highlightedIndex];
+        if (active) {
+            field.setAttribute('aria-activedescendant', active.id);
+            if (typeof active.scrollIntoView === 'function') {
+                active.scrollIntoView({ block: 'nearest' });
+            }
+        } else {
+            field.removeAttribute('aria-activedescendant');
+        }
+    }
+
+    function renderList(query) {
+        const q = (query || '').trim().toLowerCase();
+        list.innerHTML = '';
+        let shown = 0;
+        options.forEach(o => {
+            // Empty-value option is always visible — it represents the
+            // fallback / "none" choice and users should be able to pick
+            // it back without clearing the query first.
+            if (!o.isEmpty && q && !o.labelLc.includes(q)) return;
+            const li = document.createElement('li');
+            li.className = 'user-picker__option';
+            li.setAttribute('role', 'option');
+            li.id = o.domId;
+            li.dataset.value = o.value;
+            const isSelected = select.value === o.value;
+            if (isSelected) {
+                li.classList.add('is-selected');
+                li.setAttribute('aria-selected', 'true');
+            }
+            const text = document.createElement('span');
+            text.className = 'user-picker__option-label';
+            text.textContent = o.label;
+            li.appendChild(text);
+            list.appendChild(li);
+            shown++;
+        });
+        if (shown === 0) {
+            const empty = document.createElement('li');
+            empty.className = 'user-picker__empty';
+            empty.textContent = 'No matches';
+            list.appendChild(empty);
+        }
+        highlightedIndex = -1;
+        updateHighlight();
+    }
+
+    function renderValue() {
+        const sel = select.selectedOptions[0];
+        if (sel && sel.value) {
+            valueLabel.textContent = sel.textContent.trim();
+            valueLabel.classList.remove('user-picker__value--placeholder');
+        } else if (sel && sel.value === '') {
+            // Empty-value option is selected — show its label, not the
+            // placeholder, so users see the active fallback choice.
+            valueLabel.textContent = sel.textContent.trim();
+            valueLabel.classList.add('user-picker__value--placeholder');
+        } else {
+            valueLabel.textContent = placeholder;
+            valueLabel.classList.add('user-picker__value--placeholder');
+        }
+    }
+
+    function sync() {
+        renderValue();
+        select.dispatchEvent(new Event('change', { bubbles: true }));
+    }
+
+    function pick(value) {
+        const opt = Array.from(select.options).find(o => o.value === value);
+        if (!opt) return;
+        select.value = value;
+        sync();
+        close();
+    }
+
+    function open() {
+        if (isDisabled) return;
+        if (!panel.hidden) return;
+        panel.hidden = false;
+        field.setAttribute('aria-expanded', 'true');
+        input.value = '';
+        renderList('');
+        const items = visibleItems();
+        highlightedIndex = items.findIndex(li => li.classList.contains('is-selected'));
+        updateHighlight();
+        requestAnimationFrame(() => input.focus());
+    }
+
+    function close() {
+        if (panel.hidden) return;
+        panel.hidden = true;
+        field.setAttribute('aria-expanded', 'false');
+        input.value = '';
+    }
+
+    field.addEventListener('click', open);
+    field.addEventListener('keydown', e => {
+        if (e.key === 'Enter' || e.key === ' ' || e.key === 'ArrowDown') {
+            e.preventDefault();
+            open();
+        }
+    });
+
+    input.addEventListener('input', () => renderList(input.value));
+    input.addEventListener('keydown', e => {
+        const items = visibleItems();
+        if (e.key === 'ArrowDown') {
+            e.preventDefault();
+            if (items.length === 0) return;
+            highlightedIndex = (highlightedIndex + 1) % items.length;
+            updateHighlight();
+        } else if (e.key === 'ArrowUp') {
+            e.preventDefault();
+            if (items.length === 0) return;
+            highlightedIndex = highlightedIndex <= 0 ? items.length - 1 : highlightedIndex - 1;
+            updateHighlight();
+        } else if (e.key === 'Enter') {
+            e.preventDefault();
+            if (highlightedIndex >= 0 && items[highlightedIndex]) {
+                pick(items[highlightedIndex].dataset.value);
+            } else if (items.length === 1) {
+                pick(items[0].dataset.value);
+            }
+        } else if (e.key === 'Escape') {
+            e.preventDefault();
+            close();
+            field.focus();
+        }
+    });
+
+    list.addEventListener('click', e => {
+        const li = e.target.closest('.user-picker__option');
+        if (li && li.dataset.value != null) pick(li.dataset.value);
+    });
+    list.addEventListener('mousemove', e => {
+        const li = e.target.closest('.user-picker__option');
+        if (!li) return;
+        const items = visibleItems();
+        const i = items.indexOf(li);
+        if (i !== highlightedIndex) {
+            highlightedIndex = i;
+            updateHighlight();
+        }
+    });
+
+    document.addEventListener('click', e => {
+        if (!wrapper.contains(e.target)) close();
+    });
+
+    // Redirect clicks on the associated <label for="…"> to the visible
+    // field. Without this, label clicks focus the hidden native <select>
+    // and nothing on screen reacts.
+    if (select.id) {
+        const escaped = (typeof CSS !== 'undefined' && typeof CSS.escape === 'function')
+            ? CSS.escape(select.id)
+            // JSDOM and some older browsers don't expose CSS.escape.
+            // Escape anything that isn't a CSS identifier char.
+            : select.id.replace(/([^\w-])/g, '\\$1');
+        const ownLabel = document.querySelector('label[for="' + escaped + '"]');
+        if (ownLabel) {
+            ownLabel.addEventListener('click', e => {
+                e.preventDefault();
+                // Without stopPropagation, the document-level
+                // click-outside listener below would fire next and
+                // close the panel we just opened (the label sits
+                // outside the wrapper).
+                e.stopPropagation();
+                open();
+            });
+        }
+    }
+
+    renderValue();
+}
+
+function initAllChannelPickers(root) {
+    (root || document).querySelectorAll('select[data-channel-picker]').forEach(initChannelPicker);
+}
+
+if (typeof document !== 'undefined' && typeof window !== 'undefined') {
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', () => initAllChannelPickers());
+    } else {
+        initAllChannelPickers();
+    }
+    window.ChannelPicker = { init: initAllChannelPickers };
+}
+
+if (typeof module !== 'undefined') {
+    module.exports = {
+        init: initChannelPicker,
+        initAll: initAllChannelPickers
+    };
+}

--- a/web/src/main/resources/templates/fragments/channelPicker.html
+++ b/web/src/main/resources/templates/fragments/channelPicker.html
@@ -1,0 +1,50 @@
+<!--
+  Searchable channel picker. Renders a native <select> (so the form
+  still posts the same field with no JS) which channelPicker.js
+  progressively enhances into a typeahead combobox.
+
+  Mirrors templates/fragments/userPicker.html and reuses the same
+  .user-picker__* CSS classes (which are picker-shape styling, not
+  user-specific).
+
+  Params (use named args at the call site):
+    name           form field name (or null for .config-row selects
+                   that have no name attribute).
+    id             DOM id used by <label for="…"> (pass null when
+                   not needed — JS will generate one).
+    channels       iterable of objects exposing .id and .name. Works
+                   with both TextChannelInfo and VoiceChannelInfo.
+    selectedValue  pre-selected value (id or name); pass null for
+                   none.
+    placeholder    text shown when nothing is picked.
+    emptyLabel     label for the empty-string option (e.g. "— system
+                   channel —"). Pass null to omit — required selects
+                   rely on that.
+    required       boolean — forwards to the <select>.
+    valuePrefix    string prepended to display text (typically '#'
+                   for text channels, '' for voice).
+    valueField     'id' or 'name' — which field becomes the option
+                   value. Only the MOVE config uses 'name'; every
+                   other call site uses 'id'.
+    disabled       boolean — applied to the <select> for read-locked
+                   views (e.g. non-owner viewing settings).
+-->
+<div xmlns:th="http://www.thymeleaf.org"
+     th:fragment="channelPicker(name, id, channels, selectedValue, placeholder, emptyLabel, required, valuePrefix, valueField, disabled)"
+     class="user-picker"
+     th:attr="data-placeholder=${placeholder}">
+    <select th:id="${id}"
+            th:name="${name}"
+            th:required="${required}"
+            th:disabled="${disabled}"
+            data-channel-picker>
+        <option th:if="${emptyLabel != null}" value="" th:text="${emptyLabel}"
+                th:selected="${selectedValue == null or selectedValue == ''}"></option>
+        <option th:each="c : ${channels}"
+                th:value="${valueField == 'name' ? c.name : c.id}"
+                th:text="${valuePrefix + c.name}"
+                th:selected="${selectedValue != null
+                              and ((valueField == 'name' and c.name == selectedValue.toString())
+                                   or (valueField != 'name' and c.id == selectedValue.toString()))}"></option>
+    </select>
+</div>

--- a/web/src/main/resources/templates/moderation/actions.html
+++ b/web/src/main/resources/templates/moderation/actions.html
@@ -142,12 +142,17 @@
         </p>
         <form class="mod-action-form" data-action="purge">
             <label>Channel
-                <select name="channelId" required>
-                    <option value="">&mdash; choose &mdash;</option>
-                    <option th:each="tc : ${overview.textChannels}"
-                            th:value="${tc.id}"
-                            th:text="'#' + ${tc.name}"></option>
-                </select>
+                <div th:replace="~{fragments/channelPicker :: channelPicker(
+                        name='channelId',
+                        id='purge-channel',
+                        channels=${overview.textChannels},
+                        selectedValue=null,
+                        placeholder='— choose —',
+                        emptyLabel=null,
+                        required=true,
+                        valuePrefix='#',
+                        valueField='id',
+                        disabled=false)}"></div>
             </label>
             <label>Count (1-100)
                 <input type="number" name="count" min="1" max="100" value="10" required>
@@ -176,12 +181,17 @@
         </p>
         <form class="mod-action-form" data-action="lock">
             <label>Channel
-                <select name="channelId" required>
-                    <option value="">&mdash; choose &mdash;</option>
-                    <option th:each="tc : ${overview.textChannels}"
-                            th:value="${tc.id}"
-                            th:text="'#' + ${tc.name}"></option>
-                </select>
+                <div th:replace="~{fragments/channelPicker :: channelPicker(
+                        name='channelId',
+                        id='lock-channel',
+                        channels=${overview.textChannels},
+                        selectedValue=null,
+                        placeholder='— choose —',
+                        emptyLabel=null,
+                        required=true,
+                        valuePrefix='#',
+                        valueField='id',
+                        disabled=false)}"></div>
             </label>
             <div class="lock-actions">
                 <button type="button" class="btn-danger" data-lock="true">Lock</button>
@@ -197,12 +207,17 @@
         </p>
         <form class="mod-action-form" data-action="slowmode">
             <label>Channel
-                <select name="channelId" required>
-                    <option value="">&mdash; choose &mdash;</option>
-                    <option th:each="tc : ${overview.textChannels}"
-                            th:value="${tc.id}"
-                            th:text="'#' + ${tc.name}"></option>
-                </select>
+                <div th:replace="~{fragments/channelPicker :: channelPicker(
+                        name='channelId',
+                        id='slowmode-channel',
+                        channels=${overview.textChannels},
+                        selectedValue=null,
+                        placeholder='— choose —',
+                        emptyLabel=null,
+                        required=true,
+                        valuePrefix='#',
+                        valueField='id',
+                        disabled=false)}"></div>
             </label>
             <label>Seconds (0-21600, 0 to disable)
                 <input type="number" name="seconds" min="0" max="21600" value="0" required>
@@ -215,6 +230,7 @@
 <script th:src="@{/js/api.js}"></script>
 <script th:src="@{/js/toasts.js}"></script>
 <script th:src="@{/js/userPicker.js}"></script>
+<script th:src="@{/js/channelPicker.js}"></script>
 <script th:src="@{/js/moderationCommon.js}"></script>
 <script th:src="@{/js/moderation/actions.js}"></script>
 <footer th:replace="~{fragments/footer :: footer}"></footer>

--- a/web/src/main/resources/templates/moderation/leveling.html
+++ b/web/src/main/resources/templates/moderation/leveling.html
@@ -91,13 +91,17 @@
                                 level-ups).
                             </span>
                         </label>
-                        <select th:disabled="${!isOwner}">
-                            <option value="">&mdash; fall back to message/system &mdash;</option>
-                            <option th:each="tc : ${overview.textChannels}"
-                                    th:value="${tc.id}"
-                                    th:text="'#' + ${tc.name}"
-                                    th:selected="${overview.config['LEVEL_UP_CHANNEL'] == tc.id}"></option>
-                        </select>
+                        <div th:replace="~{fragments/channelPicker :: channelPicker(
+                                name=null,
+                                id=null,
+                                channels=${overview.textChannels},
+                                selectedValue=${overview.config['LEVEL_UP_CHANNEL']},
+                                placeholder='— fall back to message/system —',
+                                emptyLabel='— fall back to message/system —',
+                                required=false,
+                                valuePrefix='#',
+                                valueField='id',
+                                disabled=${!isOwner})}"></div>
                         <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
                     </div>
                     <div class="config-create-channel">
@@ -303,13 +307,17 @@
                                 their notification preferences. Leave blank to suppress the public shoutout.
                             </span>
                         </label>
-                        <select th:disabled="${!isOwner}">
-                            <option value="">&mdash; no public shoutout &mdash;</option>
-                            <option th:each="tc : ${overview.textChannels}"
-                                    th:value="${tc.id}"
-                                    th:text="'#' + ${tc.name}"
-                                    th:selected="${overview.config['ACHIEVEMENT_ANNOUNCE_CHANNEL'] == tc.id}"></option>
-                        </select>
+                        <div th:replace="~{fragments/channelPicker :: channelPicker(
+                                name=null,
+                                id=null,
+                                channels=${overview.textChannels},
+                                selectedValue=${overview.config['ACHIEVEMENT_ANNOUNCE_CHANNEL']},
+                                placeholder='— no public shoutout —',
+                                emptyLabel='— no public shoutout —',
+                                required=false,
+                                valuePrefix='#',
+                                valueField='id',
+                                disabled=${!isOwner})}"></div>
                         <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
                     </div>
                 </div>
@@ -364,6 +372,7 @@
 
 <script th:src="@{/js/api.js}"></script>
 <script th:src="@{/js/toasts.js}"></script>
+<script th:src="@{/js/channelPicker.js}"></script>
 <script th:src="@{/js/moderationCommon.js}"></script>
 <script th:src="@{/js/moderation/leveling.js}"></script>
 <footer th:replace="~{fragments/footer :: footer}"></footer>

--- a/web/src/main/resources/templates/moderation/lottery.html
+++ b/web/src/main/resources/templates/moderation/lottery.html
@@ -174,13 +174,17 @@
                                 the guild's system channel.
                             </span>
                         </label>
-                        <select th:disabled="${!isOwner}">
-                            <option value="">&mdash; fall back to leaderboard / system &mdash;</option>
-                            <option th:each="tc : ${overview.textChannels}"
-                                    th:value="${tc.id}"
-                                    th:text="'#' + ${tc.name}"
-                                    th:selected="${overview.config['LOTTERY_CHANNEL'] == tc.id}"></option>
-                        </select>
+                        <div th:replace="~{fragments/channelPicker :: channelPicker(
+                                name=null,
+                                id=null,
+                                channels=${overview.textChannels},
+                                selectedValue=${overview.config['LOTTERY_CHANNEL']},
+                                placeholder='— fall back to leaderboard / system —',
+                                emptyLabel='— fall back to leaderboard / system —',
+                                required=false,
+                                valuePrefix='#',
+                                valueField='id',
+                                disabled=${!isOwner})}"></div>
                         <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
                     </div>
                     <div class="config-create-channel">
@@ -482,6 +486,7 @@
 
 <script th:src="@{/js/api.js}"></script>
 <script th:src="@{/js/toasts.js}"></script>
+<script th:src="@{/js/channelPicker.js}"></script>
 <script th:src="@{/js/moderationCommon.js}"></script>
 <script th:src="@{/js/moderation/lottery.js}"></script>
 <footer th:replace="~{fragments/footer :: footer}"></footer>

--- a/web/src/main/resources/templates/moderation/poll.html
+++ b/web/src/main/resources/templates/moderation/poll.html
@@ -19,12 +19,17 @@
         <form class="poll-form">
             <label>
                 Channel
-                <select name="channelId" required>
-                    <option value="">&mdash; choose &mdash;</option>
-                    <option th:each="tc : ${overview.textChannels}"
-                            th:value="${tc.id}"
-                            th:text="'#' + ${tc.name}"></option>
-                </select>
+                <div th:replace="~{fragments/channelPicker :: channelPicker(
+                        name='channelId',
+                        id='poll-channel',
+                        channels=${overview.textChannels},
+                        selectedValue=null,
+                        placeholder='— choose —',
+                        emptyLabel=null,
+                        required=true,
+                        valuePrefix='#',
+                        valueField='id',
+                        disabled=false)}"></div>
             </label>
             <label>
                 Question
@@ -43,6 +48,7 @@
 
 <script th:src="@{/js/api.js}"></script>
 <script th:src="@{/js/toasts.js}"></script>
+<script th:src="@{/js/channelPicker.js}"></script>
 <script th:src="@{/js/moderationCommon.js}"></script>
 <script th:src="@{/js/moderation/poll.js}"></script>
 <footer th:replace="~{fragments/footer :: footer}"></footer>

--- a/web/src/main/resources/templates/moderation/settings.html
+++ b/web/src/main/resources/templates/moderation/settings.html
@@ -53,13 +53,17 @@
                 </div>
                 <div class="config-row" data-key="MOVE">
                     <label>Default move channel</label>
-                    <select th:disabled="${!isOwner}">
-                        <option value="">&mdash; none &mdash;</option>
-                        <option th:each="vc : ${overview.voiceChannels}"
-                                th:value="${vc.name}"
-                                th:text="${vc.name}"
-                                th:selected="${overview.config['MOVE'] == vc.name}"></option>
-                    </select>
+                    <div th:replace="~{fragments/channelPicker :: channelPicker(
+                            name=null,
+                            id=null,
+                            channels=${overview.voiceChannels},
+                            selectedValue=${overview.config['MOVE']},
+                            placeholder='— none —',
+                            emptyLabel='— none —',
+                            required=false,
+                            valuePrefix='',
+                            valueField='name',
+                            disabled=${!isOwner})}"></div>
                     <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
                 </div>
                 <!-- Saving "true" here kicks an ActivityTrackingEnabled event that
@@ -95,13 +99,17 @@
                 </div>
                 <div class="config-row" data-key="LEADERBOARD_CHANNEL">
                     <label>Monthly leaderboard channel</label>
-                    <select th:disabled="${!isOwner}">
-                        <option value="">&mdash; system channel &mdash;</option>
-                        <option th:each="tc : ${overview.textChannels}"
-                                th:value="${tc.id}"
-                                th:text="'#' + ${tc.name}"
-                                th:selected="${overview.config['LEADERBOARD_CHANNEL'] == tc.id}"></option>
-                    </select>
+                    <div th:replace="~{fragments/channelPicker :: channelPicker(
+                            name=null,
+                            id=null,
+                            channels=${overview.textChannels},
+                            selectedValue=${overview.config['LEADERBOARD_CHANNEL']},
+                            placeholder='— system channel —',
+                            emptyLabel='— system channel —',
+                            required=false,
+                            valuePrefix='#',
+                            valueField='id',
+                            disabled=${!isOwner})}"></div>
                     <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
                 </div>
                 <div class="config-create-channel">
@@ -423,13 +431,17 @@
                         Casino mod-log channel
                         <span class="config-hint">Where anti-autoclicker session embeds post. Falls back to the system channel.</span>
                     </label>
-                    <select th:disabled="${!isOwner}">
-                        <option value="">&mdash; system channel &mdash;</option>
-                        <option th:each="tc : ${overview.textChannels}"
-                                th:value="${tc.id}"
-                                th:text="'#' + ${tc.name}"
-                                th:selected="${overview.config['CASINO_MODLOG_CHANNEL_ID'] == tc.id}"></option>
-                    </select>
+                    <div th:replace="~{fragments/channelPicker :: channelPicker(
+                            name=null,
+                            id=null,
+                            channels=${overview.textChannels},
+                            selectedValue=${overview.config['CASINO_MODLOG_CHANNEL_ID']},
+                            placeholder='— system channel —',
+                            emptyLabel='— system channel —',
+                            required=false,
+                            valuePrefix='#',
+                            valueField='id',
+                            disabled=${!isOwner})}"></div>
                     <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
                 </div>
                 <div class="config-create-channel">
@@ -908,6 +920,7 @@
 
 <script th:src="@{/js/api.js}"></script>
 <script th:src="@{/js/toasts.js}"></script>
+<script th:src="@{/js/channelPicker.js}"></script>
 <script th:src="@{/js/moderationCommon.js}"></script>
 <script th:src="@{/js/moderation/settings.js}"></script>
 <script th:src="@{/js/moderation/jackpot-wheel.js}"></script>

--- a/web/src/main/resources/templates/moderation/voice.html
+++ b/web/src/main/resources/templates/moderation/voice.html
@@ -22,12 +22,17 @@
         <form class="move-form">
             <label>
                 Destination
-                <select name="targetChannelId" required>
-                    <option value="">&mdash; choose &mdash;</option>
-                    <option th:each="vc : ${overview.voiceChannels}"
-                            th:value="${vc.id}"
-                            th:text="${vc.name}"></option>
-                </select>
+                <div th:replace="~{fragments/channelPicker :: channelPicker(
+                        name='targetChannelId',
+                        id='move-target',
+                        channels=${overview.voiceChannels},
+                        selectedValue=null,
+                        placeholder='— choose —',
+                        emptyLabel=null,
+                        required=true,
+                        valuePrefix='',
+                        valueField='id',
+                        disabled=false)}"></div>
             </label>
             <label for="move-members">Members</label>
             <div th:replace="~{fragments/userPicker :: userPicker(
@@ -48,6 +53,7 @@
 <script th:src="@{/js/api.js}"></script>
 <script th:src="@{/js/toasts.js}"></script>
 <script th:src="@{/js/userPicker.js}"></script>
+<script th:src="@{/js/channelPicker.js}"></script>
 <script th:src="@{/js/moderationCommon.js}"></script>
 <script th:src="@{/js/moderation/voice.js}"></script>
 <footer th:replace="~{fragments/footer :: footer}"></footer>

--- a/web/src/main/resources/templates/moderation/welcome.html
+++ b/web/src/main/resources/templates/moderation/welcome.html
@@ -59,13 +59,17 @@
                                 system channel.
                             </span>
                         </label>
-                        <select th:disabled="${!isOwner}">
-                            <option value="">&mdash; fall back to system channel &mdash;</option>
-                            <option th:each="tc : ${overview.textChannels}"
-                                    th:value="${tc.id}"
-                                    th:text="'#' + ${tc.name}"
-                                    th:selected="${overview.config['WELCOME_CHANNEL'] == tc.id}"></option>
-                        </select>
+                        <div th:replace="~{fragments/channelPicker :: channelPicker(
+                                name=null,
+                                id=null,
+                                channels=${overview.textChannels},
+                                selectedValue=${overview.config['WELCOME_CHANNEL']},
+                                placeholder='— fall back to system channel —',
+                                emptyLabel='— fall back to system channel —',
+                                required=false,
+                                valuePrefix='#',
+                                valueField='id',
+                                disabled=${!isOwner})}"></div>
                         <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
                     </div>
                     <div class="config-row" data-key="WELCOME_MESSAGE">
@@ -111,13 +115,17 @@
                                 system channel.
                             </span>
                         </label>
-                        <select th:disabled="${!isOwner}">
-                            <option value="">&mdash; fall back to system channel &mdash;</option>
-                            <option th:each="tc : ${overview.textChannels}"
-                                    th:value="${tc.id}"
-                                    th:text="'#' + ${tc.name}"
-                                    th:selected="${overview.config['GOODBYE_CHANNEL'] == tc.id}"></option>
-                        </select>
+                        <div th:replace="~{fragments/channelPicker :: channelPicker(
+                                name=null,
+                                id=null,
+                                channels=${overview.textChannels},
+                                selectedValue=${overview.config['GOODBYE_CHANNEL']},
+                                placeholder='— fall back to system channel —',
+                                emptyLabel='— fall back to system channel —',
+                                required=false,
+                                valuePrefix='#',
+                                valueField='id',
+                                disabled=${!isOwner})}"></div>
                         <button type="button" class="btn save-config" th:disabled="${!isOwner}">Save</button>
                     </div>
                     <div class="config-row" data-key="GOODBYE_MESSAGE">
@@ -198,6 +206,7 @@
 
 <script th:src="@{/js/api.js}"></script>
 <script th:src="@{/js/toasts.js}"></script>
+<script th:src="@{/js/channelPicker.js}"></script>
 <script th:src="@{/js/moderationCommon.js}"></script>
 <script th:src="@{/js/moderation/welcome.js}"></script>
 <footer th:replace="~{fragments/footer :: footer}"></footer>

--- a/web/src/test/js/channelPicker.test.js
+++ b/web/src/test/js/channelPicker.test.js
@@ -1,0 +1,219 @@
+const channelPicker = require('../../main/resources/static/js/channelPicker');
+
+function mount(selectHtml) {
+    document.body.innerHTML = `<div class="user-picker" data-placeholder="Type to filter…">${selectHtml}</div>`;
+    channelPicker.initAll();
+    return document.body.querySelector('.user-picker');
+}
+
+function textOptionsHtml(extraEmpty = false, valuePrefix = '#') {
+    const empty = extraEmpty
+        ? `<option value="">— system channel —</option>`
+        : '';
+    return `
+        ${empty}
+        <option value="1" data-prefix="${valuePrefix}">${valuePrefix}general</option>
+        <option value="2" data-prefix="${valuePrefix}">${valuePrefix}announcements</option>
+        <option value="3" data-prefix="${valuePrefix}">${valuePrefix}gaming</option>
+    `;
+}
+
+function selectHtml({ empty = false, disabled = false, id = '' } = {}) {
+    const dis = disabled ? 'disabled' : '';
+    const idAttr = id ? `id="${id}"` : '';
+    return `<select ${idAttr} data-channel-picker ${dis}>${textOptionsHtml(empty)}</select>`;
+}
+
+function visibleOptionLabels(wrapper) {
+    return Array.from(wrapper.querySelectorAll('.user-picker__option .user-picker__option-label'))
+        .map(el => el.textContent);
+}
+
+function openPanel(wrapper) {
+    wrapper.querySelector('.user-picker__field').click();
+}
+
+beforeEach(() => {
+    document.body.innerHTML = '';
+});
+
+describe('initAll enhancement', () => {
+    test('builds combobox shell and hides native select', () => {
+        const wrapper = mount(selectHtml());
+        const native = wrapper.querySelector('select[data-channel-picker]');
+        expect(wrapper.querySelector('.user-picker__field')).not.toBeNull();
+        expect(wrapper.querySelector('.user-picker__panel')).not.toBeNull();
+        expect(wrapper.querySelector('.user-picker__input')).not.toBeNull();
+        expect(native.classList.contains('user-picker__native')).toBe(true);
+        expect(native.getAttribute('aria-hidden')).toBe('true');
+    });
+
+    test('is idempotent — running initAll twice does not double-build', () => {
+        const wrapper = mount(selectHtml());
+        channelPicker.initAll();
+        expect(wrapper.querySelectorAll('.user-picker__field').length).toBe(1);
+        expect(wrapper.querySelectorAll('.user-picker__panel').length).toBe(1);
+    });
+});
+
+describe('typeahead filtering', () => {
+    test('filters options by case-insensitive substring on the rendered label', () => {
+        const wrapper = mount(selectHtml());
+        openPanel(wrapper);
+        const input = wrapper.querySelector('.user-picker__input');
+        input.value = 'GEN';
+        input.dispatchEvent(new Event('input'));
+        const labels = visibleOptionLabels(wrapper);
+        // "general" matches case-insensitively; "announcements" and
+        // "gaming" do not contain "gen".
+        expect(labels).toContain('#general');
+        expect(labels).not.toContain('#announcements');
+        expect(labels).not.toContain('#gaming');
+    });
+
+    test('the value-prefix is part of the searchable label', () => {
+        const wrapper = mount(selectHtml());
+        openPanel(wrapper);
+        const input = wrapper.querySelector('.user-picker__input');
+        input.value = '#general';
+        input.dispatchEvent(new Event('input'));
+        expect(visibleOptionLabels(wrapper)).toContain('#general');
+    });
+
+    test('shows the "No matches" empty state when query matches nothing', () => {
+        const wrapper = mount(selectHtml());
+        openPanel(wrapper);
+        const input = wrapper.querySelector('.user-picker__input');
+        input.value = 'nope-zzz';
+        input.dispatchEvent(new Event('input'));
+        expect(wrapper.querySelector('.user-picker__empty')).not.toBeNull();
+    });
+});
+
+describe('picking a channel', () => {
+    test('clicking an option sets the native select value and fires a bubbling change event', () => {
+        const wrapper = mount(selectHtml());
+        const native = wrapper.querySelector('select[data-channel-picker]');
+        const onChange = jest.fn();
+        native.addEventListener('change', onChange);
+
+        openPanel(wrapper);
+        const second = wrapper.querySelectorAll('.user-picker__option')[1];
+        second.click();
+
+        expect(native.value).toBe(second.dataset.value);
+        expect(onChange).toHaveBeenCalledTimes(1);
+        expect(onChange.mock.calls[0][0].bubbles).toBe(true);
+    });
+
+    test('after picking, the field shows the chosen label and the panel closes', () => {
+        const wrapper = mount(selectHtml());
+        openPanel(wrapper);
+        const first = wrapper.querySelector('.user-picker__option');
+        const label = first.textContent.trim();
+        first.click();
+
+        expect(wrapper.querySelector('.user-picker__value').textContent).toBe(label);
+        expect(wrapper.querySelector('.user-picker__panel').hidden).toBe(true);
+    });
+});
+
+describe('empty-value option', () => {
+    test('is rendered as a selectable first row in the list', () => {
+        const wrapper = mount(selectHtml({ empty: true }));
+        openPanel(wrapper);
+        const labels = visibleOptionLabels(wrapper);
+        expect(labels[0]).toBe('— system channel —');
+    });
+
+    test('stays visible even when the typed query does not match its label', () => {
+        const wrapper = mount(selectHtml({ empty: true }));
+        openPanel(wrapper);
+        const input = wrapper.querySelector('.user-picker__input');
+        input.value = 'general';
+        input.dispatchEvent(new Event('input'));
+        // Fallback row is the always-on first row; query of "general" should
+        // not hide it even though its label doesn't include "general".
+        expect(visibleOptionLabels(wrapper)).toContain('— system channel —');
+    });
+
+    test('picking the empty row clears the native value and fires change', () => {
+        const wrapper = mount(selectHtml({ empty: true }));
+        const native = wrapper.querySelector('select[data-channel-picker]');
+        // Start from a non-empty selection.
+        native.value = '2';
+
+        const onChange = jest.fn();
+        native.addEventListener('change', onChange);
+
+        openPanel(wrapper);
+        const emptyRow = wrapper.querySelector('.user-picker__option');
+        emptyRow.click();
+
+        expect(native.value).toBe('');
+        expect(onChange).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('disabled state', () => {
+    test('locks the wrapper with --disabled class', () => {
+        const wrapper = mount(selectHtml({ disabled: true }));
+        expect(wrapper.classList.contains('user-picker--disabled')).toBe(true);
+    });
+
+    test('clicking the field does not open the panel', () => {
+        const wrapper = mount(selectHtml({ disabled: true }));
+        openPanel(wrapper);
+        expect(wrapper.querySelector('.user-picker__panel').hidden).toBe(true);
+    });
+
+    test('native select stays disabled', () => {
+        const wrapper = mount(selectHtml({ disabled: true }));
+        expect(wrapper.querySelector('select[data-channel-picker]').disabled).toBe(true);
+    });
+});
+
+describe('keyboard navigation', () => {
+    test('Escape on the search input closes the panel', () => {
+        const wrapper = mount(selectHtml());
+        openPanel(wrapper);
+        const input = wrapper.querySelector('.user-picker__input');
+        input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+        expect(wrapper.querySelector('.user-picker__panel').hidden).toBe(true);
+    });
+
+    test('ArrowDown highlights the next item; Enter picks it', () => {
+        const wrapper = mount(selectHtml());
+        const native = wrapper.querySelector('select[data-channel-picker]');
+        openPanel(wrapper);
+        const input = wrapper.querySelector('.user-picker__input');
+        input.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+        const highlighted = wrapper.querySelector('.user-picker__option.is-highlighted');
+        expect(highlighted).not.toBeNull();
+        const targetValue = highlighted.dataset.value;
+        input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+        expect(native.value).toBe(targetValue);
+    });
+});
+
+describe('label-for redirect', () => {
+    test('clicking the associated label opens the picker panel', () => {
+        document.body.innerHTML = `
+            <label for="ch-test">Channel</label>
+            <div class="user-picker" data-placeholder="Type to filter…">
+                ${selectHtml({ id: 'ch-test' })}
+            </div>
+        `;
+        channelPicker.initAll();
+        // Dispatch a plain click event rather than calling label.click() —
+        // JSDOM's label.click() synthesizes a secondary click on the
+        // associated form control, which fires the document-level
+        // click-outside listener and immediately re-closes the panel.
+        // Real browsers don't show this quirk; dispatching the event
+        // directly tests the listener we care about in isolation.
+        const label = document.querySelector('label[for="ch-test"]');
+        label.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+        const panel = document.body.querySelector('.user-picker__panel');
+        expect(panel.hidden).toBe(false);
+    });
+});

--- a/web/src/test/kotlin/web/template/ChannelPickerTemplateTest.kt
+++ b/web/src/test/kotlin/web/template/ChannelPickerTemplateTest.kt
@@ -1,0 +1,247 @@
+package web.template
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+
+/**
+ * Presence regression for the channelPicker migration. Every channel
+ * `<select>` in the moderation UI now lives behind the shared
+ * `fragments/channelPicker :: channelPicker(...)` fragment, mirroring
+ * the userPicker pattern. This test guards each call site so a future
+ * edit can't accidentally revert one back to a native `<select>`,
+ * which would visibly regress the typeahead UX.
+ *
+ * Reads template files off the classpath; matches what
+ * `ModerationTemplateRowsTest` does. Substring assertions are scoped
+ * to the per-page section that owns each picker so we get pinpointed
+ * failures instead of a single "channelPicker missing somewhere" miss.
+ */
+class ChannelPickerTemplateTest {
+
+    private val settingsHtml: String by lazy { readTemplate("templates/moderation/settings.html") }
+    private val actionsHtml: String by lazy { readTemplate("templates/moderation/actions.html") }
+    private val voiceHtml: String by lazy { readTemplate("templates/moderation/voice.html") }
+    private val pollHtml: String by lazy { readTemplate("templates/moderation/poll.html") }
+    private val lotteryHtml: String by lazy { readTemplate("templates/moderation/lottery.html") }
+    private val levelingHtml: String by lazy { readTemplate("templates/moderation/leveling.html") }
+
+    private fun readTemplate(path: String): String {
+        val url = javaClass.classLoader.getResource(path)
+        assertNotNull(url, "$path must be on the classpath")
+        return url!!.readText()
+    }
+
+    // ------------------------------------------------------------------------
+    // settings.html
+    // ------------------------------------------------------------------------
+
+    @Test
+    fun `settings MOVE row uses channelPicker with name-valued field`() {
+        val block = sectionForDataKey(settingsHtml, "MOVE")
+        assertTrue(
+            block.contains("fragments/channelPicker :: channelPicker"),
+            "MOVE config row should be rendered by channelPicker, not a native <select>"
+        )
+        assertTrue(
+            block.contains("valueField='name'"),
+            "MOVE config stores channel name (not id) in DB, so picker must use valueField='name'"
+        )
+    }
+
+    @Test
+    fun `settings LEADERBOARD_CHANNEL row uses channelPicker with id and # prefix`() {
+        val block = sectionForDataKey(settingsHtml, "LEADERBOARD_CHANNEL")
+        assertTrue(block.contains("fragments/channelPicker :: channelPicker"))
+        assertTrue(block.contains("valueField='id'"))
+        assertTrue(block.contains("valuePrefix='#'"))
+    }
+
+    @Test
+    fun `settings CASINO_MODLOG_CHANNEL_ID row uses channelPicker`() {
+        val block = sectionForDataKey(settingsHtml, "CASINO_MODLOG_CHANNEL_ID")
+        assertTrue(block.contains("fragments/channelPicker :: channelPicker"))
+        assertTrue(block.contains("valueField='id'"))
+        assertTrue(block.contains("valuePrefix='#'"))
+    }
+
+    // ------------------------------------------------------------------------
+    // actions.html — purge / lock / slowmode all use name='channelId'
+    // ------------------------------------------------------------------------
+
+    @Test
+    fun `actions form pickers all use channelPicker with required=true`() {
+        val callers = channelPickerCalls(actionsHtml)
+        assertEquals(
+            3, callers.size,
+            "actions.html should have three channelPicker calls (purge, lock, slowmode); found $callers"
+        )
+        for (call in callers) {
+            assertTrue(call.contains("name='channelId'"), "actions caller missing name='channelId': $call")
+            assertTrue(call.contains("required=true"), "actions caller missing required=true: $call")
+        }
+    }
+
+    // ------------------------------------------------------------------------
+    // voice.html — move target is a voice channel, no '#' prefix
+    // ------------------------------------------------------------------------
+
+    @Test
+    fun `voice move form uses channelPicker on voice channels with no prefix`() {
+        val callers = channelPickerCalls(voiceHtml)
+        assertEquals(1, callers.size, "voice.html should have exactly one channelPicker call")
+        val call = callers[0]
+        assertTrue(call.contains("name='targetChannelId'"))
+        assertTrue(call.contains("\${overview.voiceChannels}"))
+        assertTrue(call.contains("valuePrefix=''"))
+        assertTrue(call.contains("required=true"))
+    }
+
+    // ------------------------------------------------------------------------
+    // poll.html
+    // ------------------------------------------------------------------------
+
+    @Test
+    fun `poll form uses channelPicker with required=true`() {
+        val callers = channelPickerCalls(pollHtml)
+        assertEquals(1, callers.size)
+        val call = callers[0]
+        assertTrue(call.contains("name='channelId'"))
+        assertTrue(call.contains("required=true"))
+    }
+
+    // ------------------------------------------------------------------------
+    // lottery.html / leveling.html — config-row channels with fallback empty
+    // ------------------------------------------------------------------------
+
+    @Test
+    fun `lottery LOTTERY_CHANNEL row uses channelPicker`() {
+        val block = sectionForDataKey(lotteryHtml, "LOTTERY_CHANNEL")
+        assertTrue(block.contains("fragments/channelPicker :: channelPicker"))
+        assertTrue(block.contains("valueField='id'"))
+    }
+
+    @Test
+    fun `leveling LEVEL_UP_CHANNEL row uses channelPicker`() {
+        val block = sectionForDataKey(levelingHtml, "LEVEL_UP_CHANNEL")
+        assertTrue(block.contains("fragments/channelPicker :: channelPicker"))
+        assertTrue(block.contains("valueField='id'"))
+    }
+
+    @Test
+    fun `leveling ACHIEVEMENT_ANNOUNCE_CHANNEL row uses channelPicker`() {
+        val block = sectionForDataKey(levelingHtml, "ACHIEVEMENT_ANNOUNCE_CHANNEL")
+        assertTrue(block.contains("fragments/channelPicker :: channelPicker"))
+        assertTrue(block.contains("valueField='id'"))
+    }
+
+    // ------------------------------------------------------------------------
+    // Cross-template regression guard
+    // ------------------------------------------------------------------------
+
+    @Test
+    fun `no moderation template renders a raw channel select via th-each over text or voice channels`() {
+        // Walk every .html under templates/moderation/ and assert the
+        // signature pattern of the old native select is gone. A future
+        // edit that adds `<option th:each="tc : ${overview.textChannels}">`
+        // back will trip this guard.
+        val templatesRoot = Paths.get("src/main/resources/templates/moderation")
+            .takeIf { Files.exists(it) }
+            ?: Paths.get("web/src/main/resources/templates/moderation")
+        val problems = mutableListOf<String>()
+        Files.walk(templatesRoot).use { stream ->
+            stream
+                .filter { Files.isRegularFile(it) && it.toString().endsWith(".html") }
+                .forEach { path ->
+                    val text = Files.readString(path)
+                    if (text.contains("th:each=\"tc : \${overview.textChannels}\"")
+                        || text.contains("th:each=\"vc : \${overview.voiceChannels}\"")) {
+                        problems += templatesRoot.relativize(path).toString()
+                    }
+                }
+        }
+        assertTrue(
+            problems.isEmpty(),
+            "Native channel <select> regression in: $problems — should use fragments/channelPicker instead"
+        )
+    }
+
+    @Test
+    fun `every migrated moderation page includes the channelPicker script tag`() {
+        val pages = listOf(
+            "settings" to settingsHtml,
+            "actions" to actionsHtml,
+            "voice" to voiceHtml,
+            "poll" to pollHtml,
+            "lottery" to lotteryHtml,
+            "leveling" to levelingHtml,
+        )
+        for ((name, html) in pages) {
+            assertTrue(
+                html.contains("channelPicker.js"),
+                "$name.html must <script src=channelPicker.js> so the picker enhancement runs"
+            )
+        }
+    }
+
+    // ------------------------------------------------------------------------
+    // helpers
+    // ------------------------------------------------------------------------
+
+    /**
+     * Returns the substring of [html] that belongs to the `.config-row`
+     * with the given `data-key`. Scoping assertions to a single row
+     * gives precise failure messages.
+     */
+    private fun sectionForDataKey(html: String, dataKey: String): String {
+        val marker = "data-key=\"$dataKey\""
+        val start = html.indexOf(marker)
+        assertTrue(start >= 0, "expected data-key=\"$dataKey\" somewhere in the template")
+        // The config-row div is the parent; look back for the opening tag,
+        // forward for the closing </div> at the same depth. Cheap: scan
+        // forward through ~2KB of HTML, which always overshoots the row.
+        val end = (start + 4096).coerceAtMost(html.length)
+        return html.substring(start, end)
+    }
+
+    /**
+     * Returns every `~{fragments/channelPicker :: channelPicker(...)}`
+     * invocation in [html], each captured as a single flattened string
+     * (newlines collapsed to spaces) so substring assertions don't need
+     * to care about formatting.
+     */
+    private fun channelPickerCalls(html: String): List<String> {
+        val out = mutableListOf<String>()
+        val anchor = "fragments/channelPicker :: channelPicker("
+        var i = 0
+        while (true) {
+            val start = html.indexOf(anchor, i)
+            if (start < 0) break
+            val openParen = start + anchor.length - 1
+            val end = matchingCloseParen(html, openParen) ?: break
+            out += html.substring(start, end + 1).replace(Regex("\\s+"), " ")
+            i = end + 1
+        }
+        return out
+    }
+
+    private fun matchingCloseParen(text: String, openIdx: Int): Int? {
+        var depth = 1
+        var i = openIdx + 1
+        while (i < text.length) {
+            when (text[i]) {
+                '(' -> depth++
+                ')' -> {
+                    depth--
+                    if (depth == 0) return i
+                }
+            }
+            i++
+        }
+        return null
+    }
+}

--- a/web/src/test/kotlin/web/template/ChannelPickerTemplateTest.kt
+++ b/web/src/test/kotlin/web/template/ChannelPickerTemplateTest.kt
@@ -29,6 +29,7 @@ class ChannelPickerTemplateTest {
     private val pollHtml: String by lazy { readTemplate("templates/moderation/poll.html") }
     private val lotteryHtml: String by lazy { readTemplate("templates/moderation/lottery.html") }
     private val levelingHtml: String by lazy { readTemplate("templates/moderation/leveling.html") }
+    private val welcomeHtml: String by lazy { readTemplate("templates/moderation/welcome.html") }
 
     private fun readTemplate(path: String): String {
         val url = javaClass.classLoader.getResource(path)
@@ -139,6 +140,22 @@ class ChannelPickerTemplateTest {
         assertTrue(block.contains("valueField='id'"))
     }
 
+    @Test
+    fun `welcome WELCOME_CHANNEL row uses channelPicker`() {
+        val block = sectionForDataKey(welcomeHtml, "WELCOME_CHANNEL")
+        assertTrue(block.contains("fragments/channelPicker :: channelPicker"))
+        assertTrue(block.contains("valueField='id'"))
+        assertTrue(block.contains("valuePrefix='#'"))
+    }
+
+    @Test
+    fun `welcome GOODBYE_CHANNEL row uses channelPicker`() {
+        val block = sectionForDataKey(welcomeHtml, "GOODBYE_CHANNEL")
+        assertTrue(block.contains("fragments/channelPicker :: channelPicker"))
+        assertTrue(block.contains("valueField='id'"))
+        assertTrue(block.contains("valuePrefix='#'"))
+    }
+
     // ------------------------------------------------------------------------
     // Cross-template regression guard
     // ------------------------------------------------------------------------
@@ -179,6 +196,7 @@ class ChannelPickerTemplateTest {
             "poll" to pollHtml,
             "lottery" to lotteryHtml,
             "leveling" to levelingHtml,
+            "welcome" to welcomeHtml,
         )
         for ((name, html) in pages) {
             assertTrue(


### PR DESCRIPTION
## Summary

Every channel `<select>` dropdown in the moderation UI now uses a searchable typeahead combobox that mirrors the existing `userPicker` UX (filter-as-you-type, keyboard nav, accessible combobox roles). The new `channelPicker` fragment + JS module progressively enhances a native `<select>`, so the form-save handlers in `moderationCommon.js`, `actions.js`, `poll.js`, `voice.js`, `lottery.js`, and `leveling.js` keep reading `.value` unchanged.

Eleven sites migrated across:
- `settings.html` — MOVE (voice, name-valued), LEADERBOARD_CHANNEL, CASINO_MODLOG_CHANNEL_ID
- `actions.html` — purge, lock, slowmode
- `voice.html` — move destination
- `poll.html` — poll channel
- `lottery.html` — LOTTERY_CHANNEL
- `leveling.html` — LEVEL_UP_CHANNEL, ACHIEVEMENT_ANNOUNCE_CHANNEL

Two enhancements on top of the userPicker pattern:
- honours `disabled` on the underlying `<select>` so non-owner views of `settings.html` stay visually locked (no equivalent on userPicker today)
- renders the empty-value option as a selectable first row, so users can return to fallback semantics like `— system channel —` or `— fall back —` without a page reload

The MOVE config stores channel **name** rather than id (historical quirk) — supported via a `valueField='name'` fragment param. Every other site uses `valueField='id'`.

Reuses the existing `.user-picker__*` CSS classes verbatim; the `.user-picker` prefix is now historical (shared by both pickers). Added a one-line `.user-picker--disabled` rule for the lock state.

## Test plan

- [x] `npx jest` — 623/623 pass; new `channelPicker.test.js` has 16 cases covering init, filtering, keyboard nav, change-event dispatch, disabled lock, empty-row selection, label-for redirect
- [x] `./gradlew :web:test` — new `ChannelPickerTemplateTest` (11 cases) passes, plus existing `FragmentSignatureTest` and `ModerationTemplateRowsTest` still green
- [x] `npm run lint:css` — clean
- [ ] Local bot smoke test: each picker opens, filters, picks by mouse and keyboard; config rows save correctly and the empty-value row restores fallback semantics
- [ ] MOVE-specific: pick a voice channel → Save → `/setconfig get MOVE` returns the channel **name** string
- [ ] Non-owner view of `settings.html`: every `.config-row` picker is visually locked and does not open on click


---
_Generated by [Claude Code](https://claude.ai/code/session_012pgeP4VHvb9Z5HPbbL8zoK)_