### PR TITLE
fix(moderation): show role names in autorole errors, unbreak mobile forms

### DIFF
--- a/common/src/main/kotlin/common/discord/AutoRoleValidator.kt
+++ b/common/src/main/kotlin/common/discord/AutoRoleValidator.kt
@@ -31,9 +31,9 @@ object AutoRoleValidator {
         role.isPublicRole ->
             "Cannot auto-assign @everyone."
         role.isManaged ->
-            "${role.asMention} is managed by an integration and can't be assigned by the bot."
+            "${role.name} is managed by an integration and can't be assigned by the bot."
         !selfMember.canInteract(role) ->
-            "${role.asMention} sits above TobyBot's role — move TobyBot's role higher to allow assignment."
+            "${role.name} sits above TobyBot's role — move TobyBot's role higher to allow assignment."
         else -> null
     }
 }

--- a/discord-bot/src/test/kotlin/common/discord/AutoRoleValidatorTest.kt
+++ b/discord-bot/src/test/kotlin/common/discord/AutoRoleValidatorTest.kt
@@ -46,11 +46,11 @@ class AutoRoleValidatorTest {
     }
 
     @Test
-    fun `managed role is rejected with the role mention in the message`() {
+    fun `managed role is rejected with the role name in the message`() {
         every { role.isManaged } returns true
         val msg = AutoRoleValidator.validate(role, selfMember)
         assertEquals(
-            "<@&100> is managed by an integration and can't be assigned by the bot.",
+            "Member is managed by an integration and can't be assigned by the bot.",
             msg,
         )
     }
@@ -60,7 +60,7 @@ class AutoRoleValidatorTest {
         every { selfMember.canInteract(role) } returns false
         val msg = AutoRoleValidator.validate(role, selfMember)
         assertEquals(
-            "<@&100> sits above TobyBot's role — move TobyBot's role higher to allow assignment.",
+            "Member sits above TobyBot's role — move TobyBot's role higher to allow assignment.",
             msg,
         )
     }

--- a/web/src/main/resources/static/css/intros.css
+++ b/web/src/main/resources/static/css/intros.css
@@ -429,7 +429,7 @@
 @media (max-width: 480px) {
     .volume-control input[type=range] { min-width: 0; }
     .volume-inline { min-width: 0; }
-    .slot-select-row select { min-width: 0; flex: 1 1 160px; }
+    .slot-select-row select { min-width: 0; flex: 1 1 100%; }
     .intros-table td.actions { white-space: normal; display: flex; flex-wrap: wrap; gap: 6px; }
     .name-edit-input { max-width: 100%; }
     .empty-hero { padding: 28px 16px; }

--- a/web/src/main/resources/static/css/moderation.css
+++ b/web/src/main/resources/static/css/moderation.css
@@ -393,10 +393,13 @@ details.config-section.is-hidden { display: none; }
     grid-column: 3;
 }
 
-/* Narrow / mobile: stack to label-on-top, input+save-below on left. */
+/* Narrow / mobile: stack to label-on-top, input+save-below.
+   Input takes the full remaining width instead of being capped at the
+   200px desktop column, so long placeholders (e.g. the welcome /
+   goodbye message templates) don't clip on ~360px phones. */
 @media (max-width: 600px) {
     .config-row {
-        grid-template-columns: minmax(0, 200px) auto;
+        grid-template-columns: minmax(0, 1fr) auto;
         column-gap: var(--space-3);
     }
     .config-row label { grid-column: 1 / -1; }
@@ -1005,4 +1008,60 @@ details.config-section.is-hidden { display: none; }
     border: 1px solid var(--border-strong);
     background: var(--bg);
     color: var(--text);
+}
+
+/* ==============================================================
+   Welcome moderation tab — auto-role add form.
+   Mirrors .leveling-reward-add: bottom-aligned label + button on
+   desktop, stacks vertically on phones (see media block below).
+   ============================================================== */
+.welcome-autorole-add {
+    display: flex;
+    gap: var(--space-3);
+    align-items: end;
+    flex-wrap: wrap;
+    margin-top: var(--space-3);
+}
+.welcome-autorole-add label {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    font-size: 0.85rem;
+    color: var(--text-muted);
+    flex: 1 1 200px;
+    min-width: 0;
+}
+.welcome-autorole-add label > span {
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    font-size: 0.72rem;
+}
+.welcome-autorole-add select {
+    width: 100%;
+    min-width: 0;
+    padding: 7px 10px;
+    background: var(--bg);
+    color: var(--text);
+    border: 1px solid var(--border-strong);
+    border-radius: var(--radius-sm);
+    box-sizing: border-box;
+}
+
+/* ==============================================================
+   Phone breakpoint: stack the multi-field add-forms vertically so
+   their hard `min-width` / `flex-basis` columns don't push past a
+   320–400px viewport.
+   ============================================================== */
+@media (max-width: 480px) {
+    .leveling-reward-add label {
+        min-width: 0;
+        width: 100%;
+    }
+    .config-create-channel-field {
+        flex: 1 1 100%;
+    }
+    .welcome-autorole-add label {
+        flex: 1 1 100%;
+    }
 }


### PR DESCRIPTION
## Summary

Reporter (mobile) tried to bind an auto-role on **Welcome → Auto-assigned roles on join** and saw the rejection toast as a raw role mention (`<@&765616866554544130>` sits above TobyBot's role…), plus the **Message template** input above it was clipped to ~200px alongside its Save button so they could only see `{user.name`. Two fixes:

### 1. Autorole error: render role name, not Discord mention

`AutoRoleValidator` interpolated `role.asMention`, which Discord turns into a chip in chat but the web UI prints verbatim. Both the "managed by an integration" and the "sits above TobyBot's role" branches now use `role.name`, matching the precedent already in `ModerationWebService.upsertLevelReward` (web/.../ModerationWebService.kt:414).

Web toast, slash-command ephemeral reply, and join-listener log line all consume the same validator string, so the single edit fixes every surface. The slash command's success replies (`Auto-role added: <@&id>`) still use `.asMention` since they render in a Discord channel where mentions are clickable.

The hierarchy rule itself is correct — Discord enforces role hierarchy even on bots with Administrator — so the message wording stays; only the role identifier changes.

### 2. Mobile forms on the moderation tabs

- **`.config-row`** — the mobile media query capped the input column at `200px`. On a ~360px phone (input + Save button + gaps) the input clips long placeholders like the goodbye template. Mobile rule now uses `minmax(0, 1fr)` so the input fills the row; desktop's 200px cap is untouched.
- **`.welcome-autorole-add`** had no CSS at all, so the role dropdown and "Add auto-role" button used browser defaults. Added a styled block mirroring `.leveling-reward-add` (bottom-aligned row on desktop, stacked on phones).
- New `@media (max-width: 480px)` block stacks `.leveling-reward-add`, `.config-create-channel-form`, and `.welcome-autorole-add` labels to full width so their hardcoded 120–160px column minimums don't overflow on small phones.
- **`intros.css`** — the existing 480px override on `.slot-select-row select` left a `flex: 1 1 160px` basis that still squeezed the row on 320px viewports. Tightened to `flex: 1 1 100%` so the select drops below its label.

Other input pages (`tip`, `lottery`, casino tables, `music-player`, `dnd-lookup`, `excuses`) were audited and already have appropriate `@media (max-width: 600px)` / `480px` rules.

## Test plan

- [x] `./gradlew :discord-bot:test --tests AutoRoleValidatorTest` — updated assertions for the two name-bearing messages; the other three cases unchanged.
- [x] `./gradlew :web:test --tests ModerationWebServiceWelcomeTest` — its rejection test uses `contains("move TobyBot's role higher")`, so the wording shift doesn't affect it.
- [ ] Manual at 360×800 (reporter's viewport): `/moderation/{guildId}/welcome` — Message template input fills the row, Save button to its right, full placeholder visible. Add-auto-role dropdown is full-width with the button below.
- [ ] Manual at 320×568 (iPhone SE): nothing overflows on `/moderation/{guildId}/welcome`, `/moderation/{guildId}/leveling`, `/moderation/{guildId}/settings`, `/intros`.
- [ ] Reproduce the hierarchy-rejection on a real guild: pick a role positioned above TobyBot and confirm the toast reads `<RoleName> sits above TobyBot's role — …`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M4oavWTgwkgusfJfR6oGa7)_