### PR TITLE
ci: bump actions/checkout from v2/v3 to v4

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -17,7 +17,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/publish-wiki.yml
+++ b/.github/workflows/publish-wiki.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3  # Check out the code from the repository
+        uses: actions/checkout@v4  # Check out the code from the repository
 
       - name: Fetch Commands Documentation
         env:


### PR DESCRIPTION
## Summary

The build job has been failing on every PR with:

```
fatal: could not read Username for 'https://github.com': terminal prompts disabled
The process '/usr/bin/git' failed with exit code 128
```

`actions/checkout@v2` shipped on Node 12 in 2020. GitHub-hosted runners no longer support that runtime, so the action's pre-step (which installs the git credential helper) never runs, and the subsequent `fetch` hits a credential-less prompt that's been disabled in CI.

## Changes

- `.github/workflows/gradle.yml`: `actions/checkout@v2` → `@v4` (the fix)
- `.github/workflows/publish-wiki.yml`: `actions/checkout@v3` → `@v4` (opportunistic consistency — `v3` still works but the repo now carries one supported pin across all workflows; `label.yml` and `changelog.yml` are already on `@v4`)

Other actions in the affected workflows (`actions/setup-java@v4`, `actions/setup-node@v4`) are already current.

## Test plan

- [ ] CI build job gets past the "Run actions/checkout" step (the failing log line is emitted from inside checkout itself, so any success past step 1 confirms the fix)
- [ ] `publish-wiki.yml` only fires on push to `main` post-merge; spot-check on the next merge

https://claude.ai/code/session_017tRi5q6K3NYHvYeZYzLzBD

---
_Generated by [Claude Code](https://claude.ai/code/session_017tRi5q6K3NYHvYeZYzLzBD)_