### PR TITLE
fix(profile): break Spring cycle by removing JDA from ProfileCardAggregator

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: java -Xms128m -Xmx224m -XX:+UseSerialGC -XX:MaxMetaspaceSize=192m -XX:ReservedCodeCacheSize=48m -XX:MaxDirectMemorySize=48m -Dio.netty.maxDirectMemory=0 -Dio.netty.allocator.numDirectArenas=2 -Dio.netty.allocator.numHeapArenas=2 -Xss256k -XX:+ExitOnOutOfMemoryError -Dserver.port=$PORT -jar application/build/libs/application-7.3-SNAPSHOT.jar
+web: java -Xms128m -Xmx224m -XX:+UseSerialGC -XX:MaxMetaspaceSize=192m -XX:ReservedCodeCacheSize=48m -XX:MaxDirectMemorySize=48m -Dio.netty.maxDirectMemory=0 -Dio.netty.allocator.numDirectArenas=2 -Dio.netty.allocator.numHeapArenas=2 -Xss256k -XX:+ExitOnOutOfMemoryError -Dserver.port=$PORT -jar application/build/libs/application-7.4-SNAPSHOT.jar
 release: ./bin/trigger_publish_wiki.sh  # This runs after deployment

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Ensure you have the following prerequisites set up before getting started:
 4. Start the bot:
 
    ```shell
-   java -jar application/build/libs/application-7.3-SNAPSHOT.jar -Dspring.profiles.active=prod
+   java -jar application/build/libs/application-7.4-SNAPSHOT.jar -Dspring.profiles.active=prod
    ```
 
 ## Running with Docker

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ apply plugin: 'kotlin'
 
 allprojects {
     group = "com.github.ml404"
-    version = "7.3-SNAPSHOT"
+    version = "7.4-SNAPSHOT"
 
     ext['kotlin.version'] = kotlin_version
     // Override Spring Boot 3.3.4's BOM-managed versions with patched releases.

--- a/discord-bot/src/main/kotlin/bot/toby/command/commands/misc/ProfileCommand.kt
+++ b/discord-bot/src/main/kotlin/bot/toby/command/commands/misc/ProfileCommand.kt
@@ -49,12 +49,7 @@ class ProfileCommand @Autowired constructor(
             event.hook.replyEphemeralAndDelete("Could not resolve a member.", deleteDelay)
             return
         }
-        val data = aggregator.build(target.idLong, guild.idLong) ?: run {
-            event.hook.replyEphemeralAndDelete(
-                "No profile data for ${target.effectiveName} in this server yet.", deleteDelay
-            )
-            return
-        }
+        val data = aggregator.build(guild, target)
         val png = runCatching { renderer.renderPng(data) }
             .onFailure {
                 logger.error {

--- a/discord-bot/src/test/kotlin/bot/toby/command/commands/misc/ProfileCommandTest.kt
+++ b/discord-bot/src/test/kotlin/bot/toby/command/commands/misc/ProfileCommandTest.kt
@@ -59,13 +59,13 @@ internal class ProfileCommandTest : CommandTest {
     @Test
     fun `happy path defers and posts an embed with an attached PNG`() {
         every { event.getOption("user") } returns null
-        every { aggregator.build(1L, 100L) } returns sampleData()
+        every { aggregator.build(guild, member) } returns sampleData()
         every { renderer.renderPng(any()) } returns ByteArray(2048)
 
         command.handle(DefaultCommandContext(event), requestingUserDto, 0)
 
         verify(exactly = 1) { event.deferReply() }
-        verify(exactly = 1) { aggregator.build(1L, 100L) }
+        verify(exactly = 1) { aggregator.build(guild, member) }
         verify(exactly = 1) { renderer.renderPng(any()) }
         verify(exactly = 1) { event.hook.sendMessageEmbeds(any<MessageEmbed>()) }
         verify(exactly = 1) { webhookMessageCreateAction.addFiles(any<FileUpload>()) }
@@ -79,34 +79,18 @@ internal class ProfileCommandTest : CommandTest {
         }
         val opt = mockk<OptionMapping>(relaxed = true).also { every { it.asMember } returns targetMember }
         every { event.getOption("user") } returns opt
-        every { aggregator.build(7L, 100L) } returns sampleData()
+        every { aggregator.build(guild, targetMember) } returns sampleData()
         every { renderer.renderPng(any()) } returns ByteArray(2048)
 
         command.handle(DefaultCommandContext(event), requestingUserDto, 0)
 
-        verify(exactly = 1) { aggregator.build(7L, 100L) }
-    }
-
-    @Test
-    fun `replies with no-profile message when aggregator returns null`() {
-        every { event.getOption("user") } returns null
-        every { aggregator.build(1L, 100L) } returns null
-        val reply = captureReply()
-
-        command.handle(DefaultCommandContext(event), requestingUserDto, 0)
-
-        verify(exactly = 0) { renderer.renderPng(any()) }
-        assertTrue(reply.isCaptured, "expected a sendMessage call on the no-profile branch")
-        assertTrue(
-            reply.captured.contains("No profile data"),
-            "reply text should explain the empty-profile case, got: ${reply.captured}",
-        )
+        verify(exactly = 1) { aggregator.build(guild, targetMember) }
     }
 
     @Test
     fun `replies with a render-error message when the renderer throws`() {
         every { event.getOption("user") } returns null
-        every { aggregator.build(1L, 100L) } returns sampleData()
+        every { aggregator.build(guild, member) } returns sampleData()
         every { renderer.renderPng(any()) } throws RuntimeException("boom")
         val reply = captureReply()
 

--- a/web/src/main/kotlin/web/controller/ProfileController.kt
+++ b/web/src/main/kotlin/web/controller/ProfileController.kt
@@ -1,6 +1,7 @@
 package web.controller
 
 import jakarta.servlet.http.HttpServletRequest
+import net.dv8tion.jda.api.JDA
 import org.springframework.http.CacheControl
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
@@ -31,6 +32,7 @@ class ProfileController(
     private val profileWebService: ProfileWebService,
     private val profileCardAggregator: ProfileCardAggregator,
     private val profileCardRenderer: ProfileCardRenderer,
+    private val jda: JDA,
 ) {
 
     @GetMapping("/guilds")
@@ -141,8 +143,15 @@ class ProfileController(
         check = profileWebService::isMember,
         errorBuilder = { status -> ResponseEntity.status(status).build() },
     ) { _ ->
-        val data = profileCardAggregator.build(discordId, guildId)
+        // Resolve guild + member here rather than in the aggregator so
+        // the aggregator stays JDA-free (it's reachable from the Command
+        // dependency graph; injecting JDA there closes a Spring cycle
+        // through JdaListenerRegistrar -> StartUpHandler -> CommandManager).
+        val guild = jda.getGuildById(guildId)
             ?: return@requireForJson ResponseEntity.notFound().build()
+        val member = guild.getMemberById(discordId)
+            ?: return@requireForJson ResponseEntity.notFound().build()
+        val data = profileCardAggregator.build(guild, member)
         val png = profileCardRenderer.renderPng(data)
         ResponseEntity.ok()
             .contentType(MediaType.IMAGE_PNG)

--- a/web/src/main/kotlin/web/service/ProfileCardAggregator.kt
+++ b/web/src/main/kotlin/web/service/ProfileCardAggregator.kt
@@ -4,7 +4,8 @@ import common.leveling.LevelCurve
 import database.service.AchievementService
 import database.service.TitleService
 import database.service.UserService
-import net.dv8tion.jda.api.JDA
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.Member
 import org.springframework.stereotype.Service
 import web.profile.ProfileCardData
 
@@ -14,29 +15,37 @@ import web.profile.ProfileCardData
  *   - `/profile` slash command in the discord-bot module
  *   - `GET /profile/{guildId}/{discordId}/card.png` in [web.controller.ProfileController]
  *
- * Reuses the same JDA / UserService / TitleService / AchievementService
- * stack already aggregated by [ProfileWebService] for the HTML profile
- * page, so the PNG and the existing web view never disagree on a user's
- * numbers. Returns null when the bot can't see the guild or the target
- * user isn't a member — callers translate that into a 404 / ephemeral
- * "no profile" reply.
+ * **Takes [Guild] + [Member] directly rather than ids + a JDA lookup**.
+ * Earlier shape (`build(discordId, guildId)` with an injected `JDA`)
+ * crashed startup with a circular bean dependency:
  *
- * Lives next to [ProfileWebService] rather than in `discord-bot`
- * because every dependency it needs is already wired up here; the
- * discord-bot module pulls this via Spring DI (the
- * `discord-bot -> web` module edge already exists for the existing
- * notifier services).
+ * ```
+ *   JdaListenerRegistrar -> jda -> StartUpHandler -> CommandManager
+ *     -> List<Command> -> ProfileCommand -> ProfileCardAggregator -> jda
+ * ```
+ *
+ * Spring's `CommandManager` injects every `Command` bean, so any
+ * service reachable from a Command that depends on `JDA` re-enters the
+ * graph through the listener-registrar branch. The fix is to keep this
+ * aggregator JDA-free: callers already hold a `Guild` (from
+ * `event.guild` in slash commands, from a guild-scoped controller
+ * route in web) so passing it in is both cheaper and architecturally
+ * cleaner than re-fetching it.
+ *
+ * Returns null when the user has no record in this guild — the user's
+ * row may not exist yet if they've never earned XP or social credit.
+ * `Guild.getMemberById` returning null is already guarded by the
+ * caller before invoking this method.
  */
 @Service
 class ProfileCardAggregator(
-    private val jda: JDA,
     private val userService: UserService,
     private val titleService: TitleService,
     private val achievementService: AchievementService,
 ) {
-    fun build(discordId: Long, guildId: Long): ProfileCardData? {
-        val guild = jda.getGuildById(guildId) ?: return null
-        val member = guild.getMemberById(discordId) ?: return null
+    fun build(guild: Guild, member: Member): ProfileCardData {
+        val discordId = member.idLong
+        val guildId = guild.idLong
         val user = userService.getUserById(discordId, guildId)
 
         val xp = user?.xp ?: 0L

--- a/web/src/test/kotlin/web/controller/ProfileControllerCardPngTest.kt
+++ b/web/src/test/kotlin/web/controller/ProfileControllerCardPngTest.kt
@@ -2,6 +2,9 @@ package web.controller
 
 import io.mockk.every
 import io.mockk.mockk
+import net.dv8tion.jda.api.JDA
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.Member
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -15,11 +18,9 @@ import java.time.Instant
 
 /**
  * Unit-level tests for the `GET /profile/{guildId}/{discordId}/card.png`
- * endpoint. Driven directly through [ProfileController.cardPng] rather
- * than MockMvc since the route's behaviour is entirely determined by
- * the WebGuildAccess gate and the aggregator/renderer mock returns;
- * spinning up a Spring slice context just to verify status codes is
- * overkill for the same coverage we get here.
+ * endpoint. The controller resolves Guild + Member via JDA itself (the
+ * aggregator no longer takes JDA, by design — see [ProfileCardAggregator]),
+ * so these tests also pin the 404 paths for missing-guild / missing-member.
  */
 class ProfileControllerCardPngTest {
 
@@ -30,6 +31,7 @@ class ProfileControllerCardPngTest {
     private lateinit var profileWebService: ProfileWebService
     private lateinit var profileCardAggregator: ProfileCardAggregator
     private lateinit var profileCardRenderer: ProfileCardRenderer
+    private lateinit var jda: JDA
     private lateinit var user: OAuth2User
     private lateinit var controller: ProfileController
 
@@ -38,7 +40,8 @@ class ProfileControllerCardPngTest {
         profileWebService = mockk(relaxed = true)
         profileCardAggregator = mockk(relaxed = true)
         profileCardRenderer = mockk(relaxed = true)
-        controller = ProfileController(profileWebService, profileCardAggregator, profileCardRenderer)
+        jda = mockk(relaxed = true)
+        controller = ProfileController(profileWebService, profileCardAggregator, profileCardRenderer, jda)
         user = mockk {
             every { getAttribute<String>("id") } returns viewerDiscordId.toString()
             every { getAttribute<String>("username") } returns "viewer"
@@ -60,9 +63,19 @@ class ProfileControllerCardPngTest {
     }
 
     @Test
-    fun `returns 404 when the target has no profile data`() {
+    fun `returns 404 when the bot cannot see the guild`() {
         every { profileWebService.isMember(viewerDiscordId, guildId) } returns true
-        every { profileCardAggregator.build(targetDiscordId, guildId) } returns null
+        every { jda.getGuildById(guildId) } returns null
+        val response = controller.cardPng(guildId, targetDiscordId, user)
+        assertTrue(response.statusCode.value() == 404, "expected 404, got ${response.statusCode}")
+    }
+
+    @Test
+    fun `returns 404 when the target user is not in the guild`() {
+        every { profileWebService.isMember(viewerDiscordId, guildId) } returns true
+        val guild = mockk<Guild>(relaxed = true)
+        every { jda.getGuildById(guildId) } returns guild
+        every { guild.getMemberById(targetDiscordId) } returns null
         val response = controller.cardPng(guildId, targetDiscordId, user)
         assertTrue(response.statusCode.value() == 404, "expected 404, got ${response.statusCode}")
     }
@@ -70,15 +83,17 @@ class ProfileControllerCardPngTest {
     @Test
     fun `returns 200 image png with cache-control on the happy path`() {
         every { profileWebService.isMember(viewerDiscordId, guildId) } returns true
-        every { profileCardAggregator.build(targetDiscordId, guildId) } returns sampleData()
+        val guild = mockk<Guild>(relaxed = true)
+        val member = mockk<Member>(relaxed = true)
+        every { jda.getGuildById(guildId) } returns guild
+        every { guild.getMemberById(targetDiscordId) } returns member
+        every { profileCardAggregator.build(guild, member) } returns sampleData()
         val pngStub = byteArrayOf(0x89.toByte(), 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A) + ByteArray(100)
         every { profileCardRenderer.renderPng(any()) } returns pngStub
 
         val response = controller.cardPng(guildId, targetDiscordId, user)
         assertTrue(response.statusCode.is2xxSuccessful, "expected 2xx, got ${response.statusCode}")
         assertTrue(response.body!!.isNotEmpty(), "expected non-empty body")
-        // Content-Type set via @GetMapping(produces=...) is also stamped by the
-        // ResponseEntity.contentType() call — assert the latter.
         assertTrue(
             response.headers.contentType?.toString()?.startsWith("image/png") == true,
             "expected image/png content type, got ${response.headers.contentType}",

--- a/web/src/test/kotlin/web/service/ProfileCardAggregatorTest.kt
+++ b/web/src/test/kotlin/web/service/ProfileCardAggregatorTest.kt
@@ -8,29 +8,31 @@ import database.service.TitleService
 import database.service.UserService
 import io.mockk.every
 import io.mockk.mockk
-import net.dv8tion.jda.api.JDA
 import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.entities.Member
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.Instant
 
 /**
- * Unit tests for [ProfileCardAggregator]. The aggregator is the only
- * place where `UserDto` + leveling + title + achievement data converge
- * into the renderer's input, so this is the contract test that catches
- * mis-wiring (e.g. forgetting to filter unlocked achievements, picking
- * the wrong sort order, swallowing a null user).
+ * Unit tests for [ProfileCardAggregator]. The aggregator combines
+ * `UserDto` + leveling + title + achievement data into the renderer's
+ * input, so this is the contract test that catches mis-wiring (e.g.
+ * forgetting to filter unlocked achievements, picking the wrong sort
+ * order, mishandling a null user record).
+ *
+ * The aggregator takes pre-resolved `Guild` and `Member` parameters —
+ * not ids — so it has no `JDA` dependency. Callers are responsible for
+ * the JDA lookup. See the class doc on [ProfileCardAggregator] for the
+ * Spring-cycle reason.
  */
 class ProfileCardAggregatorTest {
 
     private val guildId = 222L
     private val discordId = 42L
 
-    private lateinit var jda: JDA
     private lateinit var userService: UserService
     private lateinit var titleService: TitleService
     private lateinit var achievementService: AchievementService
@@ -40,31 +42,18 @@ class ProfileCardAggregatorTest {
 
     @BeforeEach
     fun setUp() {
-        jda = mockk(relaxed = true)
         userService = mockk(relaxed = true)
         titleService = mockk(relaxed = true)
         achievementService = mockk(relaxed = true)
-        aggregator = ProfileCardAggregator(jda, userService, titleService, achievementService)
+        aggregator = ProfileCardAggregator(userService, titleService, achievementService)
 
         guild = mockk(relaxed = true)
         member = mockk(relaxed = true)
-        every { jda.getGuildById(guildId) } returns guild
-        every { guild.getMemberById(discordId) } returns member
+        every { guild.idLong } returns guildId
         every { guild.name } returns "Test Guild"
+        every { member.idLong } returns discordId
         every { member.effectiveAvatarUrl } returns "https://avatar/42.png"
         every { member.effectiveName } returns "Alice"
-    }
-
-    @Test
-    fun `build returns null when the guild is unknown`() {
-        every { jda.getGuildById(999L) } returns null
-        assertNull(aggregator.build(discordId, 999L))
-    }
-
-    @Test
-    fun `build returns null when the member is not in the guild`() {
-        every { guild.getMemberById(discordId) } returns null
-        assertNull(aggregator.build(discordId, guildId))
     }
 
     @Test
@@ -72,9 +61,8 @@ class ProfileCardAggregatorTest {
         every { userService.getUserById(discordId, guildId) } returns null
         every { achievementService.listFor(discordId, guildId) } returns emptyList()
 
-        val data = aggregator.build(discordId, guildId)
-        assertNotNull(data)
-        assertEquals(0L, data!!.totalXp)
+        val data = aggregator.build(guild, member)
+        assertEquals(0L, data.totalXp)
         assertEquals(0L, data.socialCredit)
         assertNull(data.equippedTitle)
         assertEquals(emptyList<Any>(), data.recentAchievements)
@@ -87,7 +75,7 @@ class ProfileCardAggregatorTest {
         every { titleService.getById(7L) } returns TitleDto(id = 7L, label = "🌱 Sprout", cost = 200, colorHex = "#57F287")
         every { achievementService.listFor(discordId, guildId) } returns emptyList()
 
-        val data = aggregator.build(discordId, guildId)!!
+        val data = aggregator.build(guild, member)
         assertEquals("🌱 Sprout", data.equippedTitle?.label)
         assertEquals("#57F287", data.equippedTitle?.colorHex)
     }
@@ -97,7 +85,7 @@ class ProfileCardAggregatorTest {
         every { userService.getUserById(discordId, guildId) } returns userDto(activeTitleId = null)
         every { achievementService.listFor(discordId, guildId) } returns emptyList()
 
-        assertNull(aggregator.build(discordId, guildId)!!.equippedTitle)
+        assertNull(aggregator.build(guild, member).equippedTitle)
     }
 
     @Test
@@ -115,7 +103,7 @@ class ProfileCardAggregatorTest {
             view("Eldest", "📜", unlockedAt = olderStill),
         )
 
-        val data = aggregator.build(discordId, guildId)!!
+        val data = aggregator.build(guild, member)
         // Three returned, newest first, locked entries filtered.
         assertEquals(listOf("5-day Streak", "Big Winner", "First Roll"), data.recentAchievements.map { it.name })
         // No locked entries.
@@ -129,7 +117,7 @@ class ProfileCardAggregatorTest {
         every { userService.getUserById(discordId, guildId) } returns userDto()
         every { achievementService.listFor(discordId, guildId) } returns emptyList()
 
-        val data = aggregator.build(discordId, guildId)!!
+        val data = aggregator.build(guild, member)
         assertEquals("https://avatar/42.png", data.avatarUrl)
         assertEquals("Alice", data.displayName)
         assertEquals("Test Guild", data.guildName)
@@ -137,15 +125,13 @@ class ProfileCardAggregatorTest {
 
     @Test
     fun `build derives level math from total XP via LevelCurve`() {
-        // 255 XP is exactly the cumulative XP to reach level 2 (100 + 155),
-        // so progress should report level 2 with 0 XP into the level and
-        // the next-level cost of 210 (5*4 + 100 + 100 + 110 = no, let's just
-        // assert the LevelCurve passthrough surfaces; the curve itself is
-        // covered by its own unit tests).
+        // 255 XP is exactly the cumulative XP to reach level 2 (100 + 155).
+        // The LevelCurve itself is covered by its own unit tests; this
+        // assertion just pins the passthrough.
         every { userService.getUserById(discordId, guildId) } returns userDto(xp = 255L)
         every { achievementService.listFor(discordId, guildId) } returns emptyList()
 
-        val data = aggregator.build(discordId, guildId)!!
+        val data = aggregator.build(guild, member)
         assertEquals(2, data.level)
         assertEquals(255L, data.totalXp)
         assertEquals(0L, data.xpIntoLevel)


### PR DESCRIPTION
## Summary

**Hotfix — production bot crash-looping on main.** Spring fails to start with:

```
APPLICATION FAILED TO START

The dependencies of some of the beans in the application context form a cycle:

  JdaListenerRegistrar
  ┌─────┐
  |  jda
  ↑     ↓
  |  StartUpHandler
  ↑     ↓
  |  CommandManager
  ↑     ↓
  |  HelpCommand
  ↑     ↓
  |  ProfileCommand
  ↑     ↓
  |  ProfileCardAggregator   ← cycle closes here
  └─────┘
```

`CommandManager` and `HelpCommand` both inject `List<Command>` (Spring fills with every `Command` bean), so any service reachable from a `Command` that takes `JDA` re-enters the graph through the listener-registrar branch. My #548 added `JDA` as a constructor dep on `ProfileCardAggregator` — closed the cycle.

## Why CI didn't catch this

`discord-bot/src/test/kotlin/bot/configuration/TestBotConfig.kt` provides a mocked `jda` bean for the `test` profile, bypassing the real `BotConfig.jda()` factory where the cycle actually forms. `SpringApplicationTest` (the slice that would normally catch this) passes against the mocked graph.

## Fix

Removed `JDA` from `ProfileCardAggregator` entirely rather than papering over the cycle with `@Lazy` (which would leave a landmine for the next contributor):

- `ProfileCardAggregator.build` now takes `(Guild, Member)` instead of `(discordId, guildId)`. The slash command already has `event.guild` + the resolved target Member; the web controller resolves them via the `JDA` bean it now injects directly (controllers aren't Command beans, so no cycle).
- The "guild unknown" / "user not in guild" branches move up into the callers, where they belong — controller returns explicit 404; slash command can never hit them since `event.guild` + `event.member` are always present in a guild slash invocation.
- Aggregator no longer returns null — a user with no XP/credit/title rows yields a card with zeros, friendlier than the previous "no profile data" reply.

## Tests

- `ProfileCardAggregatorTest`: dropped the two JDA-lookup-failure cases (no longer the aggregator's concern); the rest pass `(Guild, Member)` mocks.
- `ProfileControllerCardPngTest`: added two 404 cases (guild unknown, member not in guild) now handled at the controller; happy path pins the new `(guild, member)` call shape.
- `ProfileCommandTest`: dropped the no-profile-message test; pins `aggregator.build(guild, targetMember)` call site.

`./gradlew :web:test :discord-bot:test --tests "*Profile*"` — all green locally.

## Version

7.3-SNAPSHOT → 7.4-SNAPSHOT.

## Test plan

- [ ] CI build job passes (pending the unrelated `actions/checkout@v2` issue tracked in #550)
- [ ] On deploy to Heroku, the bot reaches "Started Application in N seconds" — no "APPLICATION FAILED TO START"
- [ ] `/profile` in Discord renders correctly
- [ ] `GET /profile/{guildId}/{discordId}/card.png` returns the PNG

https://claude.ai/code/session_017tRi5q6K3NYHvYeZYzLzBD

---
_Generated by [Claude Code](https://claude.ai/code/session_017tRi5q6K3NYHvYeZYzLzBD)_