### PR TITLE
docs(home): surface install wizard, welcome/auto-role, and /profile on the homepage

### DIFF
--- a/web/src/main/resources/templates/home.html
+++ b/web/src/main/resources/templates/home.html
@@ -57,7 +57,10 @@
         <li class="howto-step" data-reveal>
             <span class="howto-num">1</span>
             <h3>Invite TobyBot</h3>
-            <p>One-click install. Every feature is per-server configurable and starts in a safe default.</p>
+            <p>One-click install. Then run <code>/install</code> in your server &mdash; the
+                wizard walks owners through an Express setup (safe defaults) or a Custom
+                walkthrough that picks announcement channels, casino stakes, and lottery
+                rules. Every feature is per-server configurable and starts in a safe default.</p>
         </li>
         <li class="howto-step" data-reveal>
             <span class="howto-num">2</span>
@@ -139,7 +142,10 @@
         <a class="feature-card" href="/profile/guilds" data-reveal>
             <div class="feature-icon">&#129489;</div>
             <h3>Profile</h3>
-            <p>Per-server view of your social credit, equipped title, owned permissions, and recent activity.</p>
+            <p>Per-server view of your social credit, equipped title, owned permissions, and recent activity &mdash;
+                or run <code>/profile</code> in Discord to render a shareable PNG card with your level, XP bar,
+                balance, title, and three most-recently-unlocked achievements.</p>
+            <span class="feature-card-tag">New</span>
         </a>
         <a class="feature-card" href="/intro/guilds" data-reveal>
             <div class="feature-icon">&#127925;</div>
@@ -199,6 +205,14 @@
         </p>
     </header>
     <div class="feature-grid">
+        <a class="feature-card" href="/moderation/guilds" data-reveal>
+            <div class="feature-icon">&#128075;</div>
+            <h3>Welcome &amp; auto-role</h3>
+            <p>Greet new members with a configurable embed in any channel, auto-assign one or more
+                roles on join, and post a goodbye when someone leaves &mdash; all per-server, all
+                from the moderation web UI or <code>/welcome</code>.</p>
+            <span class="feature-card-tag">New</span>
+        </a>
         <a class="feature-card" href="/moderation/guilds" data-reveal>
             <div class="feature-icon">&#128737;</div>
             <h3>Moderation toolkit</h3>

--- a/web/src/test/kotlin/web/static/HomeFeatureCardsTemplateTest.kt
+++ b/web/src/test/kotlin/web/static/HomeFeatureCardsTemplateTest.kt
@@ -103,4 +103,64 @@ class HomeFeatureCardsTemplateTest {
                 "Management eyebrows."
         )
     }
+
+    @Test
+    fun `welcome and auto-role card is present in the server management section`() {
+        // Pins the welcome / goodbye / auto-role feature (PR #546) on the
+        // homepage. The "Server Management" section is the right home —
+        // admins are the audience, and the card lives next to the
+        // Moderation toolkit / Config / Polls cluster.
+        assertTrue(
+            html.contains("<h3>Welcome &amp; auto-role</h3>"),
+            "home.html must include a `<h3>Welcome &amp; auto-role</h3>` feature-card heading " +
+                "so the welcome / goodbye / auto-role feature is discoverable from the landing page."
+        )
+        val managementMarker = html.indexOf(">Server Management<")
+        val tabletopMarker = html.indexOf(">Tabletop &amp; Tools<")
+        val welcomeMarker = html.indexOf("<h3>Welcome &amp; auto-role</h3>")
+        check(managementMarker >= 0) { "expected a `>Server Management<` section eyebrow on home.html" }
+        check(tabletopMarker >= 0) { "expected a `>Tabletop &amp; Tools<` section eyebrow on home.html" }
+        assertTrue(
+            welcomeMarker in (managementMarker + 1) until tabletopMarker,
+            "the Welcome & auto-role card must sit inside the Server Management section, " +
+                "not engagement / casino / tabletop."
+        )
+    }
+
+    @Test
+    fun `how-it-works step 1 mentions the in-Discord install wizard`() {
+        // PR #534 shipped the /install wizard. The "How it works"
+        // first step used to imply admins set everything via slash
+        // commands; pin that the install wizard is now called out so
+        // owners know there's a guided onboarding path.
+        val howtoMarker = html.indexOf(">How it works<")
+        val casinoMarker = html.indexOf(">Casino &amp; Coin<")
+        check(howtoMarker >= 0) { "expected a `>How it works<` section eyebrow on home.html" }
+        check(casinoMarker >= 0) { "expected a `>Casino &amp; Coin<` section eyebrow on home.html" }
+        val howtoSection = html.substring(howtoMarker, casinoMarker)
+        assertTrue(
+            howtoSection.contains("<code>/install</code>"),
+            "the `How it works` step 1 must reference the `/install` wizard so owners " +
+                "discover the guided setup path, not just the slash-command-only setup."
+        )
+    }
+
+    @Test
+    fun `profile feature card mentions the slash-command PNG render`() {
+        // PR #548 shipped /profile + a PNG card. Pin that the homepage
+        // surfaces the slash-command path, not just the HTML profile
+        // page — otherwise members never discover the shareable PNG.
+        val profileMarker = html.indexOf("<h3>Profile</h3>")
+        check(profileMarker >= 0) { "expected a `<h3>Profile</h3>` feature card on home.html" }
+        // The card's `<p>` body sits immediately after the heading; walk
+        // to the next `</a>` (the card root) to bound the search.
+        val cardEnd = html.indexOf("</a>", profileMarker)
+        check(cardEnd > profileMarker) { "Profile card not terminated" }
+        val card = html.substring(profileMarker, cardEnd)
+        assertTrue(
+            card.contains("<code>/profile</code>"),
+            "the Profile feature card must reference `/profile` so members discover " +
+                "the slash-command PNG render, not just the HTML profile page:\n$card"
+        )
+    }
 }


### PR DESCRIPTION
## Summary

Three surgical homepage edits to call out features from the last ~15 PRs that weren't surfaced on `home.html`:

1. **"How it works" step 1** now mentions `/install` — the wizard from PR #534 walks owners through Express (safe defaults) or Custom (channel + stake + lottery picks) setup. Previously the section implied admins had to discover `/setconfig` themselves.

2. **Engagement section's Profile card** now also calls out `/profile` (PR #548) rendering a shareable PNG with level, XP bar, balance, title, and three most-recently-unlocked achievements. The HTML profile stays the canonical link target.

3. **Server Management section** gains a new "Welcome & auto-role" feature card (PR #546) — greet new members, auto-assign roles on join, post a goodbye when someone leaves. Links into the moderation dashboard alongside the existing Moderation toolkit card.

## Tests

Three new `HomeFeatureCardsTemplateTest` assertions pin each addition so a future homepage refactor that quietly drops one of them fails CI, matching how the existing Achievements / Notifications cards are already pinned.

`./gradlew :web:test --tests "*HomeFeatureCards*"` — 6 tests pass (3 original + 3 new).

## Test plan
- [x] `HomeFeatureCardsTemplateTest` 6/6 green
- [ ] Manual: load the homepage and visually confirm the three changes render

https://claude.ai/code/session_017tRi5q6K3NYHvYeZYzLzBD

---
_Generated by [Claude Code](https://claude.ai/code/session_017tRi5q6K3NYHvYeZYzLzBD)_